### PR TITLE
fix: pass env dict to setup_runtime_environment to preserve CI tokens

### DIFF
--- a/src/apm_cli/runtime/manager.py
+++ b/src/apm_cli/runtime/manager.py
@@ -131,7 +131,7 @@ class RuntimeManager:
                 # - GITHUB_TOKEN: User authentication for GitHub Models (Codex CLI)
                 
                 # Setup GitHub tokens using centralized manager
-                env = setup_runtime_environment()  # General token setup for scripts
+                env = setup_runtime_environment(env)  # Pass env to preserve CI tokens
                 
                 result = subprocess.run(
                     cmd,


### PR DESCRIPTION
The runtime manager was calling setup_runtime_environment() without passing the env dict, which caused it to create a new os.environ.copy() and lose any tokens set in the CI environment.

This fixes integration test failures where GITHUB_TOKEN and other secrets configured in GitHub Actions weren't reaching the runtime setup scripts, causing unauthenticated API requests and rate limiting.

Fixes integration test failures in PR #8 and similar CI environments.
