### PR TITLE
fix: source integrity for all integrators + README restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,125 +5,118 @@
 [![Downloads](https://img.shields.io/pypi/dm/apm-cli.svg)](https://pypi.org/project/apm-cli/)
 [![GitHub stars](https://img.shields.io/github/stars/danielmeppiel/apm.svg?style=social&label=Star)](https://github.com/danielmeppiel/apm/stargazers)
 
-**npm for AI coding agents.** The package manager for [AGENTS.md](https://agents.md), [Agent Skills](https://agentskills.io), and MCP servers.
+**The dependency manager for AI agents.** `apm.yml` declares the skills, prompts, instructions, and tools your project needs — so every developer gets the same agent setup. Packages can depend on packages, and APM resolves the full tree.
+
+Think `package.json`, `requirements.txt`, or `Cargo.toml` — but for AI agent configuration.
 
 GitHub Copilot · Cursor · Claude · Codex · Gemini
 
-> 📐 **Built on open standards:** APM generates [AGENTS.md](https://agents.md) instructions, installs [Agent Skills](https://agentskills.io) natively, and manages [MCP](https://modelcontextprotocol.io) servers.
+## Why APM
 
-## Install
+AI coding agents need context to be useful: what standards to follow, what prompts to use, what skills to leverage. Today this is manual — each developer installs things one by one, writes instructions from scratch, copies files around. None of it is portable. There's no manifest for it.
+
+**APM fixes this.** You declare your project's agentic dependencies once, and every developer who clones your repo gets a fully configured agent setup in seconds. Packages can depend on other packages — APM resolves transitive dependencies automatically, just like npm or pip.
+
+## See It in Action
+
+```yaml
+# apm.yml — ships with your project, like package.json
+name: corporate-website
+dependencies:
+  apm:
+    - danielmeppiel/form-builder       # Skills: React Hook Form + Zod
+    - danielmeppiel/compliance-rules   # Guardrails: GDPR, security audits
+    - danielmeppiel/design-guidelines  # Standards: UI consistency, a11y
+```
+
+New developer joins the team:
+
+```bash
+git clone your-org/corporate-website
+cd corporate-website
+apm install && apm compile
+```
+
+**That's it.** Copilot, Claude, Cursor — every agent is configured with the right skills, prompts, and coding standards. No wiki. No "ask Sarah which skills to install." It just works.
+
+→ [View the full example project](https://github.com/danielmeppiel/corporate-website)
+
+## Not Just Skills
+
+Skill registries install skills. APM manages **every primitive** your AI agents need:
+
+| Primitive | What it does | Example |
+|-----------|-------------|---------|
+| **Instructions** | Coding standards, guardrails | "Use type hints in all Python files" |
+| **Skills** | AI capabilities, workflows | Form builder, code reviewer |
+| **Prompts** | Reusable slash commands | `/security-audit`, `/design-review` |
+| **Agents** | Specialized personas | Accessibility auditor, API designer |
+| **MCP Servers** | Tool integrations | Database access, API connectors |
+
+All declared in one manifest. All installed with one command — including transitive dependencies:
+
+**`apm install`** → integrates prompts, agents, and skills into `.github/` and `.claude/`
+**`apm compile`** → compiles instructions into `AGENTS.md` (Copilot, Cursor, Codex) and `CLAUDE.md` (Claude)
+
+## Get Started
+
+**1. Install APM**
 
 ```bash
 curl -sSL https://raw.githubusercontent.com/danielmeppiel/apm/main/install.sh | sh
 ```
 
-## Quick Start
-
-**One package. Every AI agent. Native format for each.**
+<details>
+<summary>Homebrew or pip</summary>
 
 ```bash
-# Install a skill — give your agent new capabilities
-apm install danielmeppiel/form-builder
+brew tap danielmeppiel/apm-cli && brew install apm-cli
+# or
+pip install apm-cli
+```
+</details>
 
-# Install guardrails — keep your agent compliant
+**2. Add packages to your project**
+
+```bash
 apm install danielmeppiel/compliance-rules
+```
 
-# Compile for your AI tools
+> No `apm.yml` yet? APM creates one automatically on first install.
+
+**3. Compile your instructions**
+
+```bash
 apm compile
 ```
 
-**Done.** Type `/gdpr-assessment` or `/code-review` in Copilot or Claude. It just works.
-
-## What APM Does
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│  APM Packages (from GitHub, Azure DevOps)                       │
-│  ├── Instructions → Coding standards, guardrails (AGENTS.md)    │
-│  ├── Skills       → AI capabilities, workflows (agentskills.io) │
-│  ├── Prompts      → Reusable commands and templates             │
-│  └── MCP Servers  → Tool integrations                           │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                    apm install && apm compile
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│  Universal Output (auto-detected from .github/ and .claude/)    │
-│  ├── AGENTS.md      → Instructions for Copilot, Cursor, Codex   │
-│  ├── CLAUDE.md      → Instructions for Claude Code              │
-│  ├── .github/       → VSCode native prompts & agents            │
-│  └── .claude/       → Claude commands & skills                  │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-**One package. Every AI agent. Native format for each.**
-
-## Real Example: corporate-website
-
-A production project using APM with skills and layered guardrails:
-
-```yaml
-# apm.yml
-name: corporate-website
-dependencies:
-  apm:
-    - danielmeppiel/form-builder      # Build forms with React Hook Form + Zod
-    - danielmeppiel/compliance-rules  # GDPR, security
-    - danielmeppiel/design-guidelines # UI standards
-```
-
-```bash
-apm install && apm compile
-```
-
-→ [View the full example](https://github.com/danielmeppiel/corporate-website)
-
-## Commands
-
-| Command | What it does |
-|---------|--------------|
-| `apm install <pkg>` | Add package to project |
-| `apm compile` | Generate agent context files |
-| `apm init` | Create new APM project |
-| `apm run <prompt>` | Execute a workflow |
-| `apm deps list` | Show installed packages |
+**Done.** Your instructions are compiled into AGENTS.md and CLAUDE.md — open your project in VS Code or Claude and your agents are ready.
 
 ## Install From Anywhere
 
 ```bash
-# For packages hosted on GitHub 
-apm install owner/repo
-
-# Paths or Single file are also OK (Virtual Package)
-apm install github/awesome-copilot/prompts/code-review.prompt.md
-
-# For packages in GitHub Enterprise with Data Residency 
-apm install ghe.company.com/owner/repo
-
-# For packages Azure DevOps
-apm install dev.azure.com/org/project/repo
+apm install owner/repo                                              # GitHub
+apm install github/awesome-copilot/prompts/code-review.prompt.md   # Single file
+apm install ghe.company.com/owner/repo                             # GitHub Enterprise
+apm install dev.azure.com/org/project/repo                         # Azure DevOps
 ```
 
-## Create Your Own Package
+## Create & Share Packages
 
 ```bash
 apm init my-standards && cd my-standards
 ```
 
-This creates:
-
 ```
 my-standards/
 ├── apm.yml              # Package manifest
-├── SKILL.md             # Package meta-guide for AI discovery
 └── .apm/
     ├── instructions/    # Guardrails (.instructions.md)
-    ├── prompts/         # Workflows (.prompt.md)  
+    ├── prompts/         # Slash commands (.prompt.md)
     └── agents/          # Personas (.agent.md)
 ```
 
-Example guardrail:
+Add a guardrail and publish:
 
 ```bash
 cat > .apm/instructions/python.instructions.md << 'EOF'
@@ -135,42 +128,28 @@ applyTo: "**/*.py"
 - Follow PEP 8 style guidelines
 EOF
 
-# Push and share
 git add . && git commit -m "Initial standards" && git push
 ```
 
-Anyone can now run: `apm install you/my-standards`
+Anyone can now `apm install you/my-standards`.
 
-## Installation Options
+## All Commands
 
-```bash
-# Quick install (recommended)
-curl -sSL https://raw.githubusercontent.com/danielmeppiel/apm/main/install.sh | sh
+| Command | What it does |
+|---------|--------------|
+| `apm install <pkg>` | Add a package and integrate its primitives |
+| `apm compile` | Compile instructions into AGENTS.md / CLAUDE.md |
+| `apm init [name]` | Scaffold a new APM project or package |
+| `apm run <prompt>` | Execute a prompt workflow via AI runtime |
+| `apm deps list` | Show installed packages and versions |
+| `apm compile --target` | Target a specific agent (`vscode`, `claude`, `all`) |
 
-# Homebrew
-brew tap danielmeppiel/apm-cli && brew install apm-cli
+## Configuration
 
-# pip
-pip install apm-cli
-```
+For private repos or Azure DevOps, set a token:
 
-## Target Specific Agents
-
-```bash
-apm compile                    # Auto-detects from .github/ and .claude/ folders
-apm compile --target vscode    # AGENTS.md + .github/ only
-apm compile --target claude    # CLAUDE.md + .claude/ only
-apm compile --target all       # Force all formats
-```
-
-> **Note:** `apm compile` generates instruction files (AGENTS.md, CLAUDE.md). Prompts, agents, and skills are integrated by `apm install` into `.github/` and `.claude/` folders.
-
-## Advanced Configuration
-
-For private packages, Azure DevOps, or running prompts via AI runtimes:
-
-| Token | Purpose |
-|-------|---------|
+| Token | When you need it |
+|-------|-----------------|
 | `GITHUB_APM_PAT` | Private GitHub packages |
 | `ADO_APM_PAT` | Azure DevOps packages |
 | `GITHUB_COPILOT_PAT` | Running prompts via `apm run` |
@@ -181,44 +160,30 @@ For private packages, Azure DevOps, or running prompts via AI runtimes:
 
 ## Community Packages
 
-[![Install with APM](https://img.shields.io/badge/📦_Install_with-APM-blue?style=flat-square)](https://github.com/danielmeppiel/apm#community-packages)
+APM installs from any GitHub or Azure DevOps repo — no special packaging required. Point at a prompt file, a skill, or a full package. These are some curated packages to get you started:
 
 | Package | What you get |
 |---------|-------------|
-| [danielmeppiel/compliance-rules](https://github.com/danielmeppiel/compliance-rules) | `/gdpr-assessment`, `/security-audit` + compliance rules |
+| [danielmeppiel/compliance-rules](https://github.com/danielmeppiel/compliance-rules) | `/gdpr-assessment`, `/security-audit` + compliance guardrails |
 | [danielmeppiel/design-guidelines](https://github.com/danielmeppiel/design-guidelines) | `/accessibility-audit`, `/design-review` + UI standards |
 | [DevExpGbb/platform-mode](https://github.com/DevExpGbb/platform-mode) | Platform engineering prompts & agents |
+| [github/awesome-copilot](https://github.com/github/awesome-copilot) | Community prompts, agents & instructions for Copilot |
+| [anthropics/courses](https://github.com/anthropics/courses) | Anthropic's official skills & prompt library |
 | [Add yours →](https://github.com/danielmeppiel/apm/discussions/new) | |
 
 ---
 
 ## Documentation
 
-### Getting Started
-| Guide | Description |
-|-------|-------------|
-| [Quick Start](docs/getting-started.md) | Complete setup, tokens, first project |
-| [Core Concepts](docs/concepts.md) | How APM works, the primitives model |
-| [Examples](docs/examples.md) | Real-world patterns and use cases |
-
-### Reference
-| Guide | Description |
-|-------|-------------|
-| [CLI Reference](docs/cli-reference.md) | All commands and options |
-| [Compilation Engine](docs/compilation.md) | Context optimization algorithm |
-| [Skills](docs/skills.md) | Native [agentskills.io](https://agentskills.io) support |
-| [Integrations](docs/integrations.md) | VSCode, Spec-kit, MCP servers |
-
-### Advanced
-| Guide | Description |
-|-------|-------------|
-| [Dependencies](docs/dependencies.md) | Package management deep-dive |
-| [Primitives](docs/primitives.md) | Building advanced workflows |
-| [Contributing](CONTRIBUTING.md) | Join the ecosystem |
+| | |
+|---|---|
+| **Get Started** | [Quick Start](docs/getting-started.md) · [Core Concepts](docs/concepts.md) · [Examples](docs/examples.md) |
+| **Reference** | [CLI Reference](docs/cli-reference.md) · [Compilation Engine](docs/compilation.md) · [Skills](docs/skills.md) · [Integrations](docs/integrations.md) |
+| **Advanced** | [Dependencies](docs/dependencies.md) · [Primitives](docs/primitives.md) · [Contributing](CONTRIBUTING.md) |
 
 ---
 
-**Open Standards:** [AGENTS.md](https://agents.md) · [Agent Skills](https://agentskills.io) · [MCP](https://modelcontextprotocol.io)
+**Built on open standards:** [AGENTS.md](https://agents.md) · [Agent Skills](https://agentskills.io) · [MCP](https://modelcontextprotocol.io)
 
-**Learn AI-Native Development** → [Awesome AI Native](https://danielmeppiel.github.io/awesome-ai-native)  
+**Learn AI-Native Development** → [Awesome AI Native](https://danielmeppiel.github.io/awesome-ai-native)
 A practical learning path for AI-Native Development, leveraging APM along the way.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -97,7 +97,6 @@ apm init my-project --yes
 
 **Creates:**
 - `apm.yml` - Minimal project configuration with empty dependencies and scripts sections
-- `SKILL.md` - Package meta-guide for AI discovery (describes what the package does)
 
 **Auto-detected fields:**
 - `name` - From project directory name

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -148,19 +148,18 @@ APM automatically integrates prompts and agents from installed packages into VSC
 apm install danielmeppiel/design-guidelines
 
 # Prompts are automatically integrated to:
-# .github/prompts/*-apm.prompt.md (with package metadata header)
+# .github/prompts/*-apm.prompt.md (verbatim copy with -apm suffix)
 
 # Agents are automatically integrated to:
-# .github/agents/*-apm.agent.md (with package metadata header)
+# .github/agents/*-apm.agent.md (verbatim copy)
 ```
 
 **How Auto-Integration Works**:
 - **Zero-Config**: Always enabled, works automatically with no configuration needed
 - **Auto-Cleanup**: Removes integrated prompts when you uninstall packages
-- **Smart Updates**: Tracks package version/commit; updates only when package changes
-- **Metadata Headers**: Integrated prompts include source, version, and commit information
+- **Always Overwrite**: Prompt and agent files are always copied fresh — no version comparison
 - **GitIgnore Protection**: Automatically adds pattern to `.gitignore` for integrated prompts
-- **User-Safe**: Preserves any custom `*-apm.prompt.md` files without APM metadata headers
+- **Link Resolution**: Context links are resolved during integration
 
 **Integration Flow**:
 1. Run `apm install` to fetch APM packages
@@ -168,10 +167,9 @@ apm install danielmeppiel/design-guidelines
 3. Discovers `.prompt.md` and `.agent.md` files in each package
 4. Copies prompts to `.github/prompts/` with `-apm` suffix (e.g., `accessibility-audit-apm.prompt.md`)
 5. Copies agents to `.github/agents/` with `-apm` suffix (e.g., `security-apm.agent.md`)
-6. Adds metadata headers for version tracking
-7. Updates `.gitignore` to exclude integrated prompts and agents
-8. VSCode automatically loads all prompts and agents for your coding agents
-9. Run `apm uninstall` to automatically remove integrated prompts and agents
+6. Updates `.gitignore` to exclude integrated prompts and agents
+7. VSCode automatically loads all prompts and agents for your coding agents
+8. Run `apm uninstall` to automatically remove integrated prompts and agents
 
 **Intent-First Discovery**:
 The `-apm` suffix pattern enables natural autocomplete in VSCode:
@@ -244,7 +242,7 @@ apm install danielmeppiel/design-guidelines
 **How it works:**
 1. `apm install` detects `.prompt.md` files in the package
 2. Converts each to Claude command format in `.claude/commands/`
-3. Adds `-apm` suffix and metadata header for tracking
+3. Adds `-apm` suffix for tracking
 4. Updates `.gitignore` to exclude generated commands
 5. `apm uninstall` automatically removes the package's commands
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -141,7 +141,7 @@ my-skill/
 
 ### Quick Start with apm init
 
-`apm init` automatically creates a SKILL.md at root:
+`apm init` creates a minimal project:
 
 ```bash
 apm init my-skill && cd my-skill
@@ -151,9 +151,10 @@ This creates:
 ```
 my-skill/
 ├── apm.yml       # Package manifest
-├── SKILL.md      # Package meta-guide (edit this!)
 └── .apm/         # Primitives folder
 ```
+
+Add a `SKILL.md` at root to make it a publishable skill (see below).
 
 ### Option 1: Standalone Skill
 

--- a/src/apm_cli/integration/prompt_integrator.py
+++ b/src/apm_cli/integration/prompt_integrator.py
@@ -3,12 +3,8 @@
 from pathlib import Path
 from typing import List, Dict
 from dataclasses import dataclass
-import hashlib
 import re
-from datetime import datetime
-import frontmatter
 
-from .utils import normalize_repo_url
 from apm_cli.compilation.link_resolver import UnifiedLinkResolver
 from apm_cli.primitives.discovery import discover_primitives
 
@@ -17,8 +13,8 @@ from apm_cli.primitives.discovery import discover_primitives
 class IntegrationResult:
     """Result of prompt integration operation."""
     files_integrated: int
-    files_updated: int  # Updated due to version/commit change
-    files_skipped: int  # Unchanged (same version/commit)
+    files_updated: int  # Kept for CLI compatibility, always 0
+    files_skipped: int  # Kept for CLI compatibility, always 0
     target_paths: List[Path]
     gitignore_updated: bool
     links_resolved: int = 0  # Number of context links resolved
@@ -68,182 +64,36 @@ class PromptIntegrator:
         
         return prompt_files
     
-    def _parse_header_metadata(self, file_path: Path) -> dict:
-        """Parse metadata from frontmatter or legacy header comment in an integrated prompt file.
+    def copy_prompt(self, source: Path, target: Path) -> int:
+        """Copy prompt file verbatim with link resolution.
         
-        Args:
-            file_path: Path to the integrated prompt file
-            
-        Returns:
-            dict: Metadata extracted from frontmatter/header (version, commit, source, etc.)
-                  Empty dict if no valid metadata found or parsing fails
-        """
-        try:
-            # Try parsing frontmatter first (new format)
-            post = frontmatter.load(file_path)
-            
-            # Check for nested apm metadata (new format)
-            apm_data = post.metadata.get('apm', {})
-            if apm_data:
-                metadata = {
-                    'Version': apm_data.get('version', ''),
-                    'Commit': apm_data.get('commit', ''),
-                    'Source': f"{apm_data.get('source', '')} ({apm_data.get('source_repo', '')})",
-                    'SourceDependency': apm_data.get('source_dependency', ''),  # Full dependency string
-                    'ContentHash': apm_data.get('content_hash', '')
-                }
-                return metadata
-            
-            # Fallback: Try legacy HTML comment format
-            content = file_path.read_text(encoding='utf-8')
-            
-            # Check if file starts with comment block
-            if not content.startswith('<!--'):
-                return {}
-            
-            # Extract comment block (everything before the closing -->)
-            end_marker = content.find('-->')
-            if end_marker == -1:
-                return {}
-            
-            header_text = content[4:end_marker].strip()
-            
-            # Parse key-value pairs from header
-            metadata = {}
-            for line in header_text.split('\n'):
-                line = line.strip()
-                if ':' in line:
-                    key, value = line.split(':', 1)
-                    metadata[key.strip()] = value.strip()
-            
-            return metadata
-        except Exception:
-            # If any error occurs during parsing, return empty dict
-            return {}
-    
-    def _calculate_content_hash(self, file_path: Path) -> str:
-        """Calculate SHA256 hash of file content (excluding frontmatter).
-        
-        Args:
-            file_path: Path to the file
-            
-        Returns:
-            str: Hexadecimal hash of the content
-        """
-        try:
-            post = frontmatter.load(file_path)
-            # Hash only the content, not the frontmatter
-            return hashlib.sha256(post.content.encode()).hexdigest()
-        except Exception:
-            return ""
-    
-    def _should_update_prompt(self, existing_header: dict, package_info, existing_file: Path = None) -> tuple[bool, bool]:
-        """Determine if an existing prompt file should be updated.
-        
-        Args:
-            existing_header: Metadata from existing file's header
-            package_info: PackageInfo object with new package metadata
-            existing_file: Path to existing file for content hash verification
-            
-        Returns:
-            tuple[bool, bool]: (should_update, was_modified)
-                - should_update: True if file should be updated
-                - was_modified: True if content was modified by user
-        """
-        # If no valid header exists, update the file
-        if not existing_header:
-            return (True, False)
-        
-        # Get new version and commit
-        new_version = package_info.package.version
-        new_commit = (
-            package_info.resolved_reference.resolved_commit
-            if package_info.resolved_reference
-            else "unknown"
-        )
-        
-        # Get existing version and commit from header
-        existing_version = existing_header.get('Version', '')
-        existing_commit = existing_header.get('Commit', '')
-        
-        # Check for content modifications if we have the file path
-        was_modified = False
-        if existing_file and existing_file.exists():
-            stored_hash = existing_header.get('ContentHash', '')
-            if stored_hash:
-                current_hash = self._calculate_content_hash(existing_file)
-                was_modified = (current_hash != stored_hash and current_hash != "")
-        
-        # Update if version or commit has changed
-        should_update = (existing_version != new_version or existing_commit != new_commit)
-        return (should_update, was_modified)
-    
-    def copy_prompt_with_metadata(self, source: Path, target: Path, package_info, original_path: Path) -> int:
-        """Copy prompt file with metadata embedded in frontmatter.
-        
-        If source has frontmatter, adds nested apm: metadata.
-        If source has no frontmatter, creates frontmatter with apm: metadata only.
-        Resolves context links before writing.
+        Copies file content as-is, only resolving context links.
+        No metadata injection.
         
         Args:
             source: Source file path
             target: Target file path
-            package_info: PackageInfo object with package metadata
-            original_path: Original path to the prompt file (for metadata)
         
         Returns:
             int: Number of links resolved
         """
-        # Parse source file
-        post = frontmatter.load(source)
-        
-        # Resolve context links in content
+        content = source.read_text(encoding='utf-8')
         links_resolved = 0
+        
         if self.link_resolver:
-            original_content = post.content
             resolved_content = self.link_resolver.resolve_links_for_installation(
-                content=post.content,
+                content=content,
                 source_file=source,
                 target_file=target
             )
-            post.content = resolved_content
-            # Count how many links changed by comparing actual link content
-            if resolved_content != original_content:
-                import re
-                # Extract all links from both versions
+            if resolved_content != content:
                 link_pattern = re.compile(r'\]\(([^)]+)\)')
-                original_links = set(link_pattern.findall(original_content))
+                original_links = set(link_pattern.findall(content))
                 resolved_links = set(link_pattern.findall(resolved_content))
-                # Count links that were changed
                 links_resolved = len(original_links - resolved_links)
+                content = resolved_content
         
-        # Calculate content hash for modification detection (after link resolution)
-        content_hash = hashlib.sha256(post.content.encode()).hexdigest()
-        
-        # Add nested apm metadata
-        post.metadata['apm'] = {
-            'source': package_info.package.name,
-            'source_repo': package_info.package.source or "unknown",
-            'source_dependency': package_info.get_canonical_dependency_string(),  # Full dependency string for orphan detection
-            'version': package_info.package.version,
-            'commit': (
-                package_info.resolved_reference.resolved_commit
-                if package_info.resolved_reference
-                else "unknown"
-            ),
-            'original_path': (
-                str(original_path.relative_to(package_info.install_path))
-                if original_path.is_relative_to(package_info.install_path)
-                else original_path.name
-            ),
-            'installed_at': package_info.installed_at or datetime.now().isoformat(),
-            'content_hash': content_hash
-        }
-        
-        # Write to target with updated frontmatter
-        with open(target, 'w', encoding='utf-8') as f:
-            f.write(frontmatter.dumps(post))
-        
+        target.write_text(content, encoding='utf-8')
         return links_resolved
     
     def get_target_filename(self, source_file: Path, package_name: str) -> str:
@@ -266,12 +116,7 @@ class PromptIntegrator:
     def integrate_package_prompts(self, package_info, project_root: Path) -> IntegrationResult:
         """Integrate all prompts from a package into .github/prompts/.
         
-        Implements smart update logic:
-        - First install: Copy with header and @ prefix
-        - Subsequent installs:
-          - Compare version/commit with existing file
-          - Update if different (re-copy with new header)
-          - Skip if unchanged (preserve file timestamps)
+        Always overwrites existing files (it's cheap).
         Resolves context links during integration.
         
         Args:
@@ -306,142 +151,49 @@ class PromptIntegrator:
         prompts_dir = project_root / ".github" / "prompts"
         prompts_dir.mkdir(parents=True, exist_ok=True)
         
-        # Process each prompt file
+        # Process each prompt file - always overwrite
         files_integrated = 0
-        files_updated = 0
-        files_skipped = 0
         target_paths = []
         total_links_resolved = 0
         
         for source_file in prompt_files:
-            # Generate target filename
             target_filename = self.get_target_filename(source_file, package_info.package.name)
             target_path = prompts_dir / target_filename
             
-            # Check if target already exists
-            if target_path.exists():
-                # Parse existing file's metadata
-                existing_header = self._parse_header_metadata(target_path)
-                
-                # Check if update is needed and if content was modified
-                should_update, was_modified = self._should_update_prompt(
-                    existing_header, package_info, target_path
-                )
-                
-                if should_update:
-                    # Warn if user modified the content
-                    if was_modified:
-                        from apm_cli.cli import _rich_warning
-                        _rich_warning(
-                            f"⚠ Restoring modified file: {target_path.name} "
-                            f"(your changes will be overwritten)"
-                        )
-                    # Version or commit changed - update the file
-                    links_resolved = self.copy_prompt_with_metadata(source_file, target_path, package_info, source_file)
-                    total_links_resolved += links_resolved
-                    files_updated += 1
-                    target_paths.append(target_path)
-                else:
-                    # No change - skip to preserve file timestamp
-                    files_skipped += 1
-            else:
-                # New file - integrate it
-                links_resolved = self.copy_prompt_with_metadata(source_file, target_path, package_info, source_file)
-                total_links_resolved += links_resolved
-                files_integrated += 1
-                target_paths.append(target_path)
+            links_resolved = self.copy_prompt(source_file, target_path)
+            total_links_resolved += links_resolved
+            files_integrated += 1
+            target_paths.append(target_path)
         
         return IntegrationResult(
             files_integrated=files_integrated,
-            files_updated=files_updated,
-            files_skipped=files_skipped,
+            files_updated=0,
+            files_skipped=0,
             target_paths=target_paths,
             gitignore_updated=False,
             links_resolved=total_links_resolved
         )
     
     def sync_integration(self, apm_package, project_root: Path) -> Dict[str, int]:
-        """Sync .github/prompts/ with currently installed packages.
+        """Remove all APM-managed prompt files for clean regeneration.
         
-        - Removes prompts from uninstalled packages (orphans)
-        - Updates prompts from updated packages
-        - Adds prompts from new packages
-        
-        Idempotent: safe to call anytime. Reuses existing smart update logic.
-        
-        Args:
-            apm_package: APMPackage with current dependencies
-            project_root: Root directory of the project
-            
-        Returns:
-            Dict with 'files_removed' and 'errors' counts
+        Uses nuke-and-regenerate approach: removes all *-apm.prompt.md files.
+        The caller re-integrates from currently installed packages.
         """
+        stats = {'files_removed': 0, 'errors': 0}
+        
         prompts_dir = project_root / ".github" / "prompts"
         if not prompts_dir.exists():
-            return {'files_removed': 0, 'errors': 0}
+            return stats
         
-        # Build set of canonical dependency strings for comparison
-        # For virtual packages: owner/repo/path/to/file or owner/repo/collections/name
-        # For regular packages: owner/repo
-        installed_deps = set()
-        installed_repo_urls = set()  # Fallback for old metadata format
-        for dep in apm_package.get_apm_dependencies():
-            installed_deps.add(dep.get_canonical_dependency_string())
-            installed_repo_urls.add(dep.repo_url)
-        
-        # Track cleanup statistics
-        files_removed = 0
-        errors = 0
-        
-        # Remove orphaned prompts (from uninstalled packages)
         for prompt_file in prompts_dir.glob("*-apm.prompt.md"):
-            metadata = self._parse_header_metadata(prompt_file)
-            
-            # Skip files without valid metadata - they might be user's custom files
-            if not metadata:
-                continue
-            
-            # Try new format first: source_dependency contains full dependency string
-            source_dependency = metadata.get('SourceDependency', '')
-            
-            if source_dependency and source_dependency != 'unknown':
-                # New format: compare full dependency strings directly
-                # Both source_dependency and installed_deps are in canonical form
-                package_match = source_dependency in installed_deps
-            else:
-                # Fallback: old format using repo URL from Source field
-                source = metadata.get('Source', '')
-                if not source:
-                    continue
-                
-                # Extract package repo URL from source
-                # Format: "package-name (owner/repo)" or "package-name (host.com/owner/repo)"
-                package_repo_url = None
-                if '(' in source and ')' in source:
-                    package_repo_url = source.split('(')[1].split(')')[0].strip()
-                
-                if not package_repo_url:
-                    continue
-                
-                # Normalize the repo URL for comparison
-                normalized_package_url = normalize_repo_url(package_repo_url)
-                
-                # Check if source package is still installed (using repo_url for backwards compat)
-                package_match = any(
-                    pkg == normalized_package_url or 
-                    (pkg + '.git') == normalized_package_url or
-                    pkg == package_repo_url
-                    for pkg in installed_repo_urls
-                )
-            
-            if not package_match:
-                try:
-                    prompt_file.unlink()  # Orphaned - remove it
-                    files_removed += 1
-                except Exception:
-                    errors += 1
+            try:
+                prompt_file.unlink()
+                stats['files_removed'] += 1
+            except Exception:
+                stats['errors'] += 1
         
-        return {'files_removed': files_removed, 'errors': errors}
+        return stats
     
     def update_gitignore_for_integrated_prompts(self, project_root: Path) -> bool:
         """Update .gitignore with pattern for integrated prompts.

--- a/tests/unit/integration/test_sync_integration_url_normalization.py
+++ b/tests/unit/integration/test_sync_integration_url_normalization.py
@@ -1,18 +1,7 @@
-"""Tests for sync_integration URL normalization fix.
+"""Tests for sync_integration nuke-and-regenerate behavior.
 
-This test file specifically covers the critical bug fix where sync_integration
-was incorrectly removing ALL integrated files instead of only orphaned ones.
-
-The bug was caused by URL format mismatch:
-- Metadata stored: https://github.com/owner/repo (full URL)
-- Dependency list: owner/repo (short form)
-- Comparison failed, causing all files to be seen as orphans
-
-These tests ensure the URL normalization logic works correctly across:
-- GitHub repositories
-- Virtual packages
-- Multiple packages installed simultaneously
-- Different URL formats (with/without .git suffix)
+These tests verify that sync_integration correctly removes all APM-managed
+files (identified by the -apm suffix) for clean regeneration from the lockfile.
 """
 
 import tempfile
@@ -20,7 +9,6 @@ from pathlib import Path
 from unittest.mock import Mock
 
 from apm_cli.integration import PromptIntegrator, AgentIntegrator
-from apm_cli.models.apm_package import DependencyReference
 
 
 class TestSyncIntegrationURLNormalization:
@@ -38,301 +26,107 @@ class TestSyncIntegrationURLNormalization:
         import shutil
         shutil.rmtree(self.temp_dir, ignore_errors=True)
     
-    def test_sync_removes_only_uninstalled_package_prompts(self):
-        """Test that uninstalling one package only removes its prompts, not others."""
+    def test_sync_removes_all_apm_prompt_files(self):
+        """Test that sync removes all *-apm.prompt.md files (nuke approach)."""
         github_prompts = self.project_root / ".github" / "prompts"
         github_prompts.mkdir(parents=True)
         
-        # Create integrated prompts from multiple packages with YAML frontmatter
-        compliance_prompt = """---
-apm:
-  source: compliance-rules
-  source_repo: https://github.com/danielmeppiel/compliance-rules
-  version: 1.0.0
-  commit: abc123
-  original_path: compliance-audit.prompt.md
-  installed_at: '2024-11-13T10:00:00'
-  content_hash: hash1
----
-
-# Compliance Audit"""
+        # Create integrated prompts from multiple packages
+        (github_prompts / "compliance-audit-apm.prompt.md").write_text("# Compliance Audit")
+        (github_prompts / "design-review-apm.prompt.md").write_text("# Design Review")
+        (github_prompts / "breakdown-plan-apm.prompt.md").write_text("# Breakdown Plan")
         
-        design_prompt = """---
-apm:
-  source: design-guidelines
-  source_repo: https://github.com/danielmeppiel/design-guidelines
-  version: 1.0.0
-  commit: def456
-  original_path: design-review.prompt.md
-  installed_at: '2024-11-13T10:00:00'
-  content_hash: hash2
----
-
-# Design Review"""
-        
-        virtual_prompt = """---
-apm:
-  source: awesome-copilot-breakdown-plan
-  source_repo: https://github.com/github/awesome-copilot
-  version: 1.0.0
-  commit: unknown
-  original_path: .apm/prompts/breakdown-plan.prompt.md
-  installed_at: '2024-11-13T10:00:00'
-  content_hash: hash3
----
-
-# Breakdown Plan"""
-        
-        (github_prompts / "compliance-audit-apm.prompt.md").write_text(compliance_prompt)
-        (github_prompts / "design-review-apm.prompt.md").write_text(design_prompt)
-        (github_prompts / "breakdown-plan-apm.prompt.md").write_text(virtual_prompt)
-        
-        # Simulate uninstalling design-guidelines (keeping compliance-rules and virtual package)
         apm_package = Mock()
-        apm_package.get_apm_dependencies.return_value = [
-            DependencyReference(
-                repo_url="danielmeppiel/compliance-rules",
-                reference="main"
-            ),
-            DependencyReference(
-                repo_url="github/awesome-copilot",
-                reference="main"
-            )
-        ]
         
-        # Run sync
+        # Run sync - nuke approach removes all
         result = self.prompt_integrator.sync_integration(apm_package, self.project_root)
         
-        # Verify only design-guidelines prompt was removed
-        assert not (github_prompts / "design-review-apm.prompt.md").exists(), "design-guidelines prompt should be removed"
-        assert (github_prompts / "compliance-audit-apm.prompt.md").exists(), "compliance-rules prompt should remain"
-        assert (github_prompts / "breakdown-plan-apm.prompt.md").exists(), "virtual package prompt should remain"
-        assert result['files_removed'] == 1, "Should remove exactly 1 file"
-        assert result['errors'] == 0, "Should have no errors"
+        assert not (github_prompts / "design-review-apm.prompt.md").exists()
+        assert not (github_prompts / "compliance-audit-apm.prompt.md").exists()
+        assert not (github_prompts / "breakdown-plan-apm.prompt.md").exists()
+        assert result['files_removed'] == 3
+        assert result['errors'] == 0
     
-    def test_sync_handles_github_url_formats(self):
-        """Test that sync correctly normalizes different GitHub URL formats."""
+    def test_sync_preserves_non_apm_prompt_files(self):
+        """Test that sync only removes *-apm.prompt.md files, not other files."""
         github_prompts = self.project_root / ".github" / "prompts"
         github_prompts.mkdir(parents=True)
         
-        # Test various URL formats in metadata
-        test_cases = [
-            ("https://github.com/owner/repo", "owner/repo"),
-            ("https://github.com/owner/repo.git", "owner/repo"),
-            ("https://gitlab.com/owner/repo", "owner/repo"),
-            ("https://git.company.com/owner/repo", "owner/repo"),
-        ]
+        # APM files (should be removed)
+        (github_prompts / "test-apm.prompt.md").write_text("# APM prompt")
         
-        for idx, (source_repo_url, expected_match) in enumerate(test_cases):
-            prompt_content = f"""---
-apm:
-  source: test-package-{idx}
-  source_repo: {source_repo_url}
-  version: 1.0.0
-  commit: abc123
-  original_path: test.prompt.md
-  installed_at: '2024-11-13T10:00:00'
-  content_hash: hash{idx}
----
-
-# Test Prompt {idx}"""
-            
-            (github_prompts / f"test-{idx}-apm.prompt.md").write_text(prompt_content)
+        # Non-APM files (should be preserved)
+        (github_prompts / "my-custom.prompt.md").write_text("# Custom prompt")
+        (github_prompts / "readme.md").write_text("# Readme")
         
-        # Simulate package still installed (short form)
         apm_package = Mock()
-        apm_package.get_apm_dependencies.return_value = [
-            DependencyReference(repo_url="owner/repo", reference="main")
-        ]
         
-        # Run sync
         result = self.prompt_integrator.sync_integration(apm_package, self.project_root)
         
-        # All prompts should remain (they all normalize to owner/repo)
-        assert result['files_removed'] == 0, "No files should be removed - all should match"
-        for idx in range(len(test_cases)):
-            assert (github_prompts / f"test-{idx}-apm.prompt.md").exists(), f"Prompt {idx} should still exist"
+        assert result['files_removed'] == 1
+        assert not (github_prompts / "test-apm.prompt.md").exists()
+        assert (github_prompts / "my-custom.prompt.md").exists()
+        assert (github_prompts / "readme.md").exists()
     
-    def test_sync_removes_only_uninstalled_package_agents(self):
-        """Test that uninstalling one package only removes its agents, not others."""
+    def test_sync_nuke_removes_all_agent_files(self):
+        """Test that sync removes ALL *-apm.agent.md files (nuke-and-regenerate)."""
         github_agents = self.project_root / ".github" / "agents"
         github_agents.mkdir(parents=True)
         
-        # Create integrated agents from multiple packages with YAML frontmatter
-        compliance_agent = """---
-apm:
-  source: compliance-rules
-  source_repo: https://github.com/danielmeppiel/compliance-rules
-  version: 1.0.0
-  commit: abc123
-  original_path: compliance-agent.agent.md
-  installed_at: '2024-11-13T10:00:00'
-  content_hash: hash1
----
-
-# Compliance Agent"""
+        # Create integrated agents from multiple packages
+        (github_agents / "compliance-agent-apm.agent.md").write_text("# Compliance Agent")
+        (github_agents / "design-agent-apm.agent.md").write_text("# Design Agent")
+        # Non-APM file should survive
+        (github_agents / "my-custom.agent.md").write_text("# My Custom Agent")
         
-        design_agent = """---
-apm:
-  source: design-guidelines
-  source_repo: https://github.com/danielmeppiel/design-guidelines
-  version: 1.0.0
-  commit: def456
-  original_path: design-agent.agent.md
-  installed_at: '2024-11-13T10:00:00'
-  content_hash: hash2
----
-
-# Design Agent"""
-        
-        (github_agents / "compliance-agent-apm.agent.md").write_text(compliance_agent)
-        (github_agents / "design-agent-apm.agent.md").write_text(design_agent)
-        
-        # Simulate uninstalling design-guidelines (keeping compliance-rules)
-        apm_package = Mock()
-        apm_package.get_apm_dependencies.return_value = [
-            DependencyReference(
-                repo_url="danielmeppiel/compliance-rules",
-                reference="main"
-            )
-        ]
-        
-        # Run sync
-        result = self.agent_integrator.sync_integration(apm_package, self.project_root)
-        
-        # Verify only design-guidelines agent was removed
-        assert not (github_agents / "design-agent-apm.agent.md").exists(), "design-guidelines agent should be removed"
-        assert (github_agents / "compliance-agent-apm.agent.md").exists(), "compliance-rules agent should remain"
-        assert result['files_removed'] == 1, "Should remove exactly 1 file"
-        assert result['errors'] == 0, "Should have no errors"
-    
-    def test_sync_with_three_packages_removes_one(self):
-        """Test realistic scenario: 3 packages installed, uninstall 1, verify 2 remain."""
-        github_prompts = self.project_root / ".github" / "prompts"
-        github_prompts.mkdir(parents=True)
-        
-        # Create prompts from 3 packages
-        packages = [
-            ("pkg-a", "https://github.com/owner/pkg-a"),
-            ("pkg-b", "https://github.com/owner/pkg-b"),
-            ("pkg-c", "https://github.com/owner/pkg-c"),
-        ]
-        
-        for pkg_name, repo_url in packages:
-            prompt = f"""---
-apm:
-  source: {pkg_name}
-  source_repo: {repo_url}
-  version: 1.0.0
-  commit: abc123
-  original_path: test.prompt.md
-  installed_at: '2024-11-13T10:00:00'
-  content_hash: hash
----
-
-# Prompt from {pkg_name}"""
-            (github_prompts / f"{pkg_name}-apm.prompt.md").write_text(prompt)
-        
-        # Uninstall pkg-b (keep pkg-a and pkg-c)
-        apm_package = Mock()
-        apm_package.get_apm_dependencies.return_value = [
-            DependencyReference(repo_url="owner/pkg-a", reference="main"),
-            DependencyReference(repo_url="owner/pkg-c", reference="main")
-        ]
-        
-        # Run sync
-        result = self.prompt_integrator.sync_integration(apm_package, self.project_root)
-        
-        # Verify correct removal
-        assert (github_prompts / "pkg-a-apm.prompt.md").exists(), "pkg-a should remain"
-        assert not (github_prompts / "pkg-b-apm.prompt.md").exists(), "pkg-b should be removed"
-        assert (github_prompts / "pkg-c-apm.prompt.md").exists(), "pkg-c should remain"
-        assert result['files_removed'] == 1, "Should remove exactly pkg-b"
-    
-    def test_sync_preserves_files_without_metadata(self):
-        """Test that sync doesn't remove user's custom files without APM metadata."""
-        github_prompts = self.project_root / ".github" / "prompts"
-        github_prompts.mkdir(parents=True)
-        
-        # Create a user's custom prompt without APM metadata
-        custom_prompt = """# Custom User Prompt
-
-This is a custom prompt without APM metadata."""
-        (github_prompts / "my-custom-apm.prompt.md").write_text(custom_prompt)
-        
-        # Create an APM-integrated prompt
-        apm_prompt = """---
-apm:
-  source: test-package
-  source_repo: https://github.com/owner/test-package
-  version: 1.0.0
-  commit: abc123
-  original_path: test.prompt.md
-  installed_at: '2024-11-13T10:00:00'
-  content_hash: hash
----
-
-# APM Prompt"""
-        (github_prompts / "test-apm.prompt.md").write_text(apm_prompt)
-        
-        # Uninstall the package (no packages remain)
         apm_package = Mock()
         apm_package.get_apm_dependencies.return_value = []
         
         # Run sync
-        result = self.prompt_integrator.sync_integration(apm_package, self.project_root)
+        result = self.agent_integrator.sync_integration(apm_package, self.project_root)
         
-        # User's custom file should remain, APM file should be removed
-        assert (github_prompts / "my-custom-apm.prompt.md").exists(), "Custom file should remain"
-        assert not (github_prompts / "test-apm.prompt.md").exists(), "APM file should be removed"
-        assert result['files_removed'] == 1, "Should only remove the APM file"
+        # All -apm files removed
+        assert not (github_agents / "compliance-agent-apm.agent.md").exists()
+        assert not (github_agents / "design-agent-apm.agent.md").exists()
+        # Non-APM file preserved
+        assert (github_agents / "my-custom.agent.md").exists()
+        assert result['files_removed'] == 2
+        assert result['errors'] == 0
     
-    def test_sync_handles_virtual_packages_correctly(self):
-        """Test that virtual packages (single file imports) are handled correctly."""
+    def test_sync_nuke_removes_all_prompt_files(self):
+        """Test that sync removes all *-apm.prompt.md files regardless of packages."""
         github_prompts = self.project_root / ".github" / "prompts"
         github_prompts.mkdir(parents=True)
         
-        # Virtual package: github/awesome-copilot/prompts/breakdown-plan.prompt.md
-        # The source_repo will be the repo root, not the file path
-        virtual_prompt = """---
-apm:
-  source: awesome-copilot-breakdown-plan
-  source_repo: https://github.com/github/awesome-copilot
-  version: 1.0.0
-  commit: unknown
-  original_path: .apm/prompts/breakdown-plan.prompt.md
-  installed_at: '2024-11-13T10:00:00'
-  content_hash: hash
----
-
-# Breakdown Plan"""
-        (github_prompts / "breakdown-plan-apm.prompt.md").write_text(virtual_prompt)
+        # Create prompts from 3 packages
+        packages = ["pkg-a", "pkg-b", "pkg-c"]
+        for pkg_name in packages:
+            (github_prompts / f"{pkg_name}-apm.prompt.md").write_text(f"# Prompt from {pkg_name}")
         
-        # Regular package
-        regular_prompt = """---
-apm:
-  source: test-package
-  source_repo: https://github.com/owner/test-package
-  version: 1.0.0
-  commit: abc123
-  original_path: test.prompt.md
-  installed_at: '2024-11-13T10:00:00'
-  content_hash: hash
----
-
-# Regular Prompt"""
-        (github_prompts / "test-apm.prompt.md").write_text(regular_prompt)
-        
-        # Keep only the virtual package
         apm_package = Mock()
-        apm_package.get_apm_dependencies.return_value = [
-            DependencyReference(repo_url="github/awesome-copilot", reference="main")
-        ]
         
-        # Run sync
         result = self.prompt_integrator.sync_integration(apm_package, self.project_root)
         
-        # Virtual package should remain, regular should be removed
-        assert (github_prompts / "breakdown-plan-apm.prompt.md").exists(), "Virtual package prompt should remain"
-        assert not (github_prompts / "test-apm.prompt.md").exists(), "Regular package prompt should be removed"
-        assert result['files_removed'] == 1, "Should remove only the regular package"
+        # All APM files removed (nuke approach)
+        for pkg_name in packages:
+            assert not (github_prompts / f"{pkg_name}-apm.prompt.md").exists()
+        assert result['files_removed'] == 3
+    
+    def test_sync_nuke_preserves_non_apm_files(self):
+        """Test that nuke approach doesn't remove non-APM files."""
+        github_prompts = self.project_root / ".github" / "prompts"
+        github_prompts.mkdir(parents=True)
+        
+        # User's custom prompt (no -apm suffix)
+        (github_prompts / "my-custom.prompt.md").write_text("# Custom prompt")
+        
+        # APM-integrated prompt
+        (github_prompts / "test-apm.prompt.md").write_text("# APM Prompt")
+        
+        apm_package = Mock()
+        
+        result = self.prompt_integrator.sync_integration(apm_package, self.project_root)
+        
+        assert (github_prompts / "my-custom.prompt.md").exists(), "Custom file should remain"
+        assert not (github_prompts / "test-apm.prompt.md").exists(), "APM file should be removed"
+        assert result['files_removed'] == 1

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -248,88 +248,13 @@ class TestInitCommand:
                 # Should auto-detect description
                 assert "APM project" in config["description"]
 
-    def test_init_creates_skill_md(self):
-        """Test that init creates SKILL.md alongside apm.yml."""
+    def test_init_does_not_create_skill_md(self):
+        """Test that init does not create SKILL.md (only apm.yml)."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             os.chdir(tmp_dir)
 
             result = self.runner.invoke(cli, ["init", "--yes"])
 
             assert result.exit_code == 0
-            assert Path("SKILL.md").exists()
-
-    def test_init_skill_md_contains_frontmatter(self):
-        """Test that SKILL.md contains proper YAML frontmatter."""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            os.chdir(tmp_dir)
-
-            result = self.runner.invoke(cli, ["init", "--yes"])
-
-            assert result.exit_code == 0
-            
-            skill_content = Path("SKILL.md").read_text()
-            # Check frontmatter structure
-            assert skill_content.startswith("---")
-            assert "name:" in skill_content
-            assert "description:" in skill_content
-            # Frontmatter should be closed
-            assert skill_content.count("---") >= 2
-
-    def test_init_skill_md_reflects_project_name(self):
-        """Test that SKILL.md reflects the project name and description."""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            os.chdir(tmp_dir)
-
-            result = self.runner.invoke(cli, ["init", "my-awesome-package", "--yes"])
-
-            assert result.exit_code == 0
-            
-            project_path = Path(tmp_dir) / "my-awesome-package"
-            skill_content = (project_path / "SKILL.md").read_text()
-            
-            # Check project name appears in frontmatter and title
-            assert "name: my-awesome-package" in skill_content
-            assert "# my-awesome-package" in skill_content
-            # Check install command uses project name
-            assert "apm install your-org/my-awesome-package" in skill_content
-
-    def test_init_skill_md_has_expected_sections(self):
-        """Test that SKILL.md contains expected content sections."""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            os.chdir(tmp_dir)
-
-            result = self.runner.invoke(cli, ["init", "--yes"])
-
-            assert result.exit_code == 0
-            
-            skill_content = Path("SKILL.md").read_text()
-            
-            # Check for expected sections
-            assert "## What This Package Does" in skill_content
-            assert "## Getting Started" in skill_content
-            assert "## Available Primitives" in skill_content
-            # Check primitive types are listed
-            assert "Instructions" in skill_content
-            assert "Prompts" in skill_content
-            assert "Agents" in skill_content
-
-    def test_init_interactive_creates_skill_md_with_custom_values(self):
-        """Test that interactive mode creates SKILL.md with user-provided values."""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            os.chdir(tmp_dir)
-
-            # Simulate user input
-            user_input = "custom-project\n1.0.0\nMy custom description\nTest Author\ny\n"
-
-            result = self.runner.invoke(cli, ["init"], input=user_input)
-
-            assert result.exit_code == 0
-            assert Path("SKILL.md").exists()
-            
-            skill_content = Path("SKILL.md").read_text()
-            
-            # Check custom values appear
-            assert "name: custom-project" in skill_content
-            assert "description: My custom description" in skill_content
-            assert "# custom-project" in skill_content
-            assert "My custom description" in skill_content
+            assert Path("apm.yml").exists()
+            assert not Path("SKILL.md").exists()

--- a/tests/unit/test_uninstall_reintegration.py
+++ b/tests/unit/test_uninstall_reintegration.py
@@ -1,0 +1,327 @@
+"""Tests for the uninstall nuke-and-regenerate flow.
+
+When a package is uninstalled, all -apm suffixed integrated files are nuked,
+then remaining packages are re-integrated from apm_modules/.
+"""
+
+import pytest
+from pathlib import Path
+from datetime import datetime
+
+from apm_cli.integration import PromptIntegrator, AgentIntegrator
+from apm_cli.integration.skill_integrator import SkillIntegrator
+from apm_cli.integration.command_integrator import CommandIntegrator
+from apm_cli.models.apm_package import (
+    PackageInfo,
+    APMPackage,
+    ResolvedReference,
+    GitReferenceType,
+    PackageType,
+    PackageContentType,
+)
+
+
+def _make_package(
+    tmp_path: Path,
+    owner: str,
+    name: str,
+    *,
+    prompts: dict[str, str] | None = None,
+    agents: dict[str, str] | None = None,
+    skill_md: str | None = None,
+    pkg_type: PackageContentType | None = None,
+) -> PackageInfo:
+    """Create a minimal package under apm_modules/<owner>/<name>."""
+    pkg_path = tmp_path / "apm_modules" / owner / name
+    pkg_path.mkdir(parents=True, exist_ok=True)
+
+    type_line = f"\ntype: {pkg_type.value}" if pkg_type else ""
+    (pkg_path / "apm.yml").write_text(
+        f"name: {name}\nversion: 1.0.0{type_line}\n"
+    )
+
+    if prompts:
+        prompts_dir = pkg_path / ".apm" / "prompts"
+        prompts_dir.mkdir(parents=True, exist_ok=True)
+        for fname, content in prompts.items():
+            (prompts_dir / fname).write_text(content)
+
+    if agents:
+        agents_dir = pkg_path / ".apm" / "agents"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        for fname, content in agents.items():
+            (agents_dir / fname).write_text(content)
+
+    if skill_md is not None:
+        (pkg_path / "SKILL.md").write_text(skill_md)
+
+    pkg = APMPackage(
+        name=name,
+        version="1.0.0",
+        package_path=pkg_path,
+        type=pkg_type,
+    )
+    resolved_ref = ResolvedReference(
+        original_ref="main",
+        ref_type=GitReferenceType.BRANCH,
+        resolved_commit="abc123",
+        ref_name="main",
+    )
+    package_type = PackageType.CLAUDE_SKILL if skill_md else PackageType.APM_PACKAGE
+    if skill_md and (prompts or agents):
+        package_type = PackageType.HYBRID
+
+    return PackageInfo(
+        package=pkg,
+        install_path=pkg_path,
+        resolved_reference=resolved_ref,
+        installed_at=datetime.now().isoformat(),
+        package_type=package_type,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Prompt nuke-and-regenerate
+# ---------------------------------------------------------------------------
+
+
+class TestUninstallPreservesOtherPackagePrompts:
+    """Nuke all *-apm.prompt.md, re-integrate remaining → only remaining survives."""
+
+    def test_uninstall_preserves_other_package_prompts(self, tmp_path: Path):
+        project_root = tmp_path
+        (project_root / ".github").mkdir()
+
+        # Two packages, each with a prompt
+        pkg_a = _make_package(
+            tmp_path, "owner", "pkg-a",
+            prompts={"review.prompt.md": "---\nname: review\n---\n# Review A"},
+        )
+        pkg_b = _make_package(
+            tmp_path, "owner", "pkg-b",
+            prompts={"lint.prompt.md": "---\nname: lint\n---\n# Lint B"},
+        )
+
+        prompt_int = PromptIntegrator()
+
+        # Integrate both
+        prompt_int.integrate_package_prompts(pkg_a, project_root)
+        prompt_int.integrate_package_prompts(pkg_b, project_root)
+
+        prompts_dir = project_root / ".github" / "prompts"
+        assert (prompts_dir / "review-apm.prompt.md").exists()
+        assert (prompts_dir / "lint-apm.prompt.md").exists()
+
+        # --- Simulate uninstall of pkg-a ---
+        # Phase 1: nuke all -apm prompt files
+        dummy_pkg = APMPackage(name="root", version="0.0.0")
+        prompt_int.sync_integration(dummy_pkg, project_root)
+
+        # Everything nuked
+        assert not (prompts_dir / "review-apm.prompt.md").exists()
+        assert not (prompts_dir / "lint-apm.prompt.md").exists()
+
+        # Phase 2: re-integrate only pkg-b
+        prompt_int.integrate_package_prompts(pkg_b, project_root)
+
+        assert not (prompts_dir / "review-apm.prompt.md").exists()
+        assert (prompts_dir / "lint-apm.prompt.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Agent nuke-and-regenerate
+# ---------------------------------------------------------------------------
+
+
+class TestUninstallPreservesOtherPackageAgents:
+    """Nuke all *-apm.agent.md, re-integrate remaining → only remaining survives."""
+
+    def test_uninstall_preserves_other_package_agents(self, tmp_path: Path):
+        project_root = tmp_path
+        (project_root / ".github").mkdir()
+
+        pkg_a = _make_package(
+            tmp_path, "owner", "pkg-a",
+            agents={"security.agent.md": "---\nname: security\n---\n# Security A"},
+        )
+        pkg_b = _make_package(
+            tmp_path, "owner", "pkg-b",
+            agents={"planner.agent.md": "---\nname: planner\n---\n# Planner B"},
+        )
+
+        agent_int = AgentIntegrator()
+
+        agent_int.integrate_package_agents(pkg_a, project_root)
+        agent_int.integrate_package_agents(pkg_b, project_root)
+
+        agents_dir = project_root / ".github" / "agents"
+        assert (agents_dir / "security-apm.agent.md").exists()
+        assert (agents_dir / "planner-apm.agent.md").exists()
+
+        # Phase 1: nuke
+        dummy_pkg = APMPackage(name="root", version="0.0.0")
+        agent_int.sync_integration(dummy_pkg, project_root)
+
+        assert not (agents_dir / "security-apm.agent.md").exists()
+        assert not (agents_dir / "planner-apm.agent.md").exists()
+
+        # Phase 2: re-integrate only pkg-b
+        agent_int.integrate_package_agents(pkg_b, project_root)
+
+        assert not (agents_dir / "security-apm.agent.md").exists()
+        assert (agents_dir / "planner-apm.agent.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Skill name-based cleanup
+# ---------------------------------------------------------------------------
+
+
+class TestUninstallPreservesOtherPackageSkills:
+    """Skills use name-based matching: only the uninstalled skill dir is removed."""
+
+    def test_uninstall_preserves_other_package_skills(self, tmp_path: Path):
+        project_root = tmp_path
+        (project_root / ".github").mkdir()
+
+        pkg_a = _make_package(
+            tmp_path, "owner", "skill-a",
+            skill_md="---\nname: skill-a\ndescription: test A\n---\n# Skill A",
+            pkg_type=PackageContentType.SKILL,
+        )
+        pkg_b = _make_package(
+            tmp_path, "owner", "skill-b",
+            skill_md="---\nname: skill-b\ndescription: test B\n---\n# Skill B",
+            pkg_type=PackageContentType.SKILL,
+        )
+
+        skill_int = SkillIntegrator()
+
+        skill_int.integrate_package_skill(pkg_a, project_root)
+        skill_int.integrate_package_skill(pkg_b, project_root)
+
+        skills_dir = project_root / ".github" / "skills"
+        assert (skills_dir / "skill-a").is_dir()
+        assert (skills_dir / "skill-b").is_dir()
+
+        # Build an APMPackage that only lists skill-b as a remaining dependency.
+        # sync_integration derives expected names from get_apm_dependencies().
+        # We use a real APMPackage loaded from a manifest that references skill-b only.
+        remaining_manifest = tmp_path / "remaining_apm.yml"
+        remaining_manifest.write_text(
+            "name: root\nversion: 0.0.0\n"
+            "dependencies:\n"
+            "  apm:\n"
+            "    - owner/skill-b\n"
+        )
+        root_pkg = APMPackage.from_apm_yml(remaining_manifest)
+
+        skill_int.sync_integration(root_pkg, project_root)
+
+        # skill-a removed, skill-b preserved
+        assert not (skills_dir / "skill-a").exists()
+        assert (skills_dir / "skill-b").is_dir()
+
+
+# ---------------------------------------------------------------------------
+# User files not touched
+# ---------------------------------------------------------------------------
+
+
+class TestUninstallPreservesUserFiles:
+    """Nuke only touches *-apm.* files; user-created files survive."""
+
+    def test_uninstall_preserves_user_files(self, tmp_path: Path):
+        project_root = tmp_path
+        (project_root / ".github").mkdir()
+
+        # User-created prompt (no -apm suffix)
+        prompts_dir = project_root / ".github" / "prompts"
+        prompts_dir.mkdir(parents=True)
+        user_file = prompts_dir / "my-review.prompt.md"
+        user_file.write_text("# My custom review prompt")
+
+        # User-created agent
+        agents_dir = project_root / ".github" / "agents"
+        agents_dir.mkdir(parents=True)
+        user_agent = agents_dir / "my-agent.agent.md"
+        user_agent.write_text("# My custom agent")
+
+        # User-created command
+        commands_dir = project_root / ".claude" / "commands"
+        commands_dir.mkdir(parents=True)
+        user_cmd = commands_dir / "my-command.md"
+        user_cmd.write_text("# My custom command")
+
+        # Also add an APM-managed file to confirm it gets nuked
+        (prompts_dir / "pkg-review-apm.prompt.md").write_text("# APM managed")
+        (agents_dir / "pkg-agent-apm.agent.md").write_text("# APM managed")
+        (commands_dir / "pkg-cmd-apm.md").write_text("# APM managed")
+
+        dummy_pkg = APMPackage(name="root", version="0.0.0")
+
+        PromptIntegrator().sync_integration(dummy_pkg, project_root)
+        AgentIntegrator().sync_integration(dummy_pkg, project_root)
+        CommandIntegrator().sync_integration(dummy_pkg, project_root)
+
+        # APM files gone
+        assert not (prompts_dir / "pkg-review-apm.prompt.md").exists()
+        assert not (agents_dir / "pkg-agent-apm.agent.md").exists()
+        assert not (commands_dir / "pkg-cmd-apm.md").exists()
+
+        # User files untouched
+        assert user_file.exists()
+        assert user_file.read_text() == "# My custom review prompt"
+        assert user_agent.exists()
+        assert user_agent.read_text() == "# My custom agent"
+        assert user_cmd.exists()
+        assert user_cmd.read_text() == "# My custom command"
+
+
+# ---------------------------------------------------------------------------
+# Last package uninstall → clean state
+# ---------------------------------------------------------------------------
+
+
+class TestUninstallLastPackageLeavesCleanDirs:
+    """Installing one package and uninstalling it removes all -apm artifacts."""
+
+    def test_uninstall_last_package_leaves_clean_dirs(self, tmp_path: Path):
+        project_root = tmp_path
+        (project_root / ".github").mkdir()
+
+        pkg = _make_package(
+            tmp_path, "owner", "only-pkg",
+            prompts={"guide.prompt.md": "---\nname: guide\n---\n# Guide"},
+            agents={"helper.agent.md": "---\nname: helper\n---\n# Helper"},
+        )
+
+        prompt_int = PromptIntegrator()
+        agent_int = AgentIntegrator()
+        cmd_int = CommandIntegrator()
+
+        prompt_int.integrate_package_prompts(pkg, project_root)
+        agent_int.integrate_package_agents(pkg, project_root)
+        cmd_int.integrate_package_commands(pkg, project_root)
+
+        prompts_dir = project_root / ".github" / "prompts"
+        agents_dir = project_root / ".github" / "agents"
+        commands_dir = project_root / ".claude" / "commands"
+
+        # Verify files were created
+        apm_prompts = list(prompts_dir.glob("*-apm.prompt.md"))
+        apm_agents = list(agents_dir.glob("*-apm.agent.md"))
+        apm_commands = list(commands_dir.glob("*-apm.md"))
+        assert len(apm_prompts) > 0
+        assert len(apm_agents) > 0
+        assert len(apm_commands) > 0
+
+        # Nuke everything (no re-integration — last package removed)
+        dummy_pkg = APMPackage(name="root", version="0.0.0")
+        prompt_int.sync_integration(dummy_pkg, project_root)
+        agent_int.sync_integration(dummy_pkg, project_root)
+        cmd_int.sync_integration(dummy_pkg, project_root)
+
+        assert list(prompts_dir.glob("*-apm.prompt.md")) == []
+        assert list(agents_dir.glob("*-apm.agent.md")) == []
+        assert list(commands_dir.glob("*-apm.md")) == []

--- a/uv.lock
+++ b/uv.lock
@@ -166,7 +166,7 @@ wheels = [
 
 [[package]]
 name = "apm-cli"
-version = "0.7.1"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
Closes #73

## Source Integrity (npm-style approach)

- **Remove metadata injection** from all integrators (skills, prompts, agents, commands)
- Integrated files are now **pure build artifacts** — verbatim copies from `apm_modules/`
- `apm.lock` is the single source of truth (no more frontmatter metadata)
- Nuke-and-regenerate sync for prompts/agents/commands
- Name-based orphan detection for skills (like `node_modules/`)
- Fix uninstall to re-integrate remaining packages after nuke

## Init Cleanup

- Remove `SKILL.md` from `apm init` (not needed for consumer projects)

## README Restructure

- Lead with **dependency manifest** value prop — not standards
- Add transitive dependency story (packages depend on packages)
- Reframe as "Not Just Skills" — all primitives, not just skills
- Fix compile messaging (compiles instructions, not agents)
- Add community sources (github/awesome-copilot, anthropics/courses)

## Tests

- **796 unit tests passing** (+5 new uninstall re-integration tests)
- Net: **-1,762 lines** across 18 files