### PR TITLE
fix(ci): prevent skip-propagation in integration test pipeline

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -96,7 +96,7 @@ jobs:
   integration-tests:
     name: Integration Tests
     needs: [smoke-test]
-    if: needs.smoke-test.result == 'success'
+    if: always() && needs.smoke-test.result == 'success'
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -149,7 +149,7 @@ jobs:
   release-validation:
     name: Release Validation
     needs: [integration-tests]
-    if: needs.integration-tests.result == 'success'
+    if: always() && needs.integration-tests.result == 'success'
     runs-on: ubuntu-24.04
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

In [run #22402036846](https://github.com/microsoft/apm/actions/runs/22402036846), `integration-tests` and `release-validation` were **skipped** even though `smoke-test` succeeded.

**Root cause:** When `approve-fork` is skipped (internal PRs), GitHub Actions propagates the skip through the **entire dependency chain** — not just direct dependents. Without `always()`, the `if` conditions on downstream jobs are never even evaluated; the jobs are skipped before the condition check happens.

From the [docs](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idneeds):
> *"If a job fails or is skipped, all jobs that need it are skipped unless the jobs use a conditional expression that causes the job to continue."*

## Fix

Add `always()` to `integration-tests` and `release-validation` so skip-propagation is overridden and the `if` condition is actually evaluated:

```yaml
if: always() && needs.smoke-test.result == 'success'
```

The `result == 'success'` check still ensures each job only runs when its direct dependency genuinely passed.