### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @danielmeppiel


### PR DESCRIPTION
Adds a CODEOWNERS file so that the org-level `microsoft-production-ruleset` (which already has `require_code_owner_review: true`) can enforce lead maintainer approval on all PRs to `main`.