### PR TITLE
fix: handle multiple brace groups in applyTo glob patterns

### DIFF
--- a/src/apm_cli/compilation/context_optimizer.py
+++ b/src/apm_cli/compilation/context_optimizer.py
@@ -738,22 +738,28 @@ class ContextOptimizer:
         return None
     
     def _expand_glob_pattern(self, pattern: str) -> List[str]:
-        """Expand glob pattern with brace expansion.
+        """Expand glob pattern with brace expansion, supporting multiple brace groups.
         
         Args:
-            pattern (str): Pattern like '**/*.{css,scss}'
+            pattern (str): Pattern like '**/*.{css,scss}' or '**/*.{test,spec}.{ts,js}'
         
         Returns:
             List[str]: Expanded patterns like ['**/*.css', '**/*.scss']
+                       or ['**/*.test.ts', '**/*.test.js', '**/*.spec.ts', '**/*.spec.js']
         """
         import re
         
         # Handle brace expansion like {css,scss}
         brace_match = re.search(r'\{([^}]+)\}', pattern)
         if brace_match:
-            extensions = brace_match.group(1).split(',')
-            base_pattern = pattern[:brace_match.start()] + '{}' + pattern[brace_match.end():]
-            return [base_pattern.format(ext) for ext in extensions]
+            alternatives = brace_match.group(1).split(',')
+            prefix = pattern[:brace_match.start()]
+            suffix = pattern[brace_match.end():]
+            # Recursively expand remaining brace groups in each result
+            expanded = []
+            for alt in alternatives:
+                expanded.extend(self._expand_glob_pattern(prefix + alt + suffix))
+            return expanded
         
         return [pattern]
     

--- a/tests/unit/compilation/test_context_optimizer.py
+++ b/tests/unit/compilation/test_context_optimizer.py
@@ -677,5 +677,37 @@ class TestDirectoryExclusion:
             assert base_path / "custom_exclude" not in cached_dirs  # Custom exclusion
 
 
+class TestExpandGlobPattern:
+    """Test _expand_glob_pattern brace expansion."""
+
+    def test_single_brace_group(self):
+        """Test expansion of a single brace group."""
+        optimizer = ContextOptimizer(base_dir="/tmp")
+        result = optimizer._expand_glob_pattern("**/*.{css,scss}")
+        assert sorted(result) == sorted(["**/*.css", "**/*.scss"])
+
+    def test_multiple_brace_groups(self):
+        """Test expansion of multiple brace groups (Fixes #153)."""
+        optimizer = ContextOptimizer(base_dir="/tmp")
+        result = optimizer._expand_glob_pattern("**/*.{test,spec}.{ts,js,mts,mjs}")
+        expected = [
+            "**/*.test.ts", "**/*.test.js", "**/*.test.mts", "**/*.test.mjs",
+            "**/*.spec.ts", "**/*.spec.js", "**/*.spec.mts", "**/*.spec.mjs",
+        ]
+        assert sorted(result) == sorted(expected)
+
+    def test_no_brace_group(self):
+        """Test pattern without braces is returned as-is."""
+        optimizer = ContextOptimizer(base_dir="/tmp")
+        result = optimizer._expand_glob_pattern("**/*.py")
+        assert result == ["**/*.py"]
+
+    def test_single_item_brace_group(self):
+        """Test brace group with a single item."""
+        optimizer = ContextOptimizer(base_dir="/tmp")
+        result = optimizer._expand_glob_pattern("**/*.{ts}")
+        assert result == ["**/*.ts"]
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## Description

`_expand_glob_pattern()` in `context_optimizer.py` used `str.format()` to expand brace alternatives in `applyTo` patterns. When a pattern contained multiple brace groups (e.g., `**/*.{test,spec}.{ts,js,mts,mjs}`), `str.format()` treated the second group as a Python format placeholder, raising a `KeyError` and failing compilation.

Replaced with a recursive brace expansion that finds the first `{...}` group, expands it into one variant per alternative, and recursively processes remaining brace groups. This correctly handles any number of brace groups.

Fixes #153

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

Added 4 test cases in `TestExpandGlobPattern`:
- `test_single_brace_group` — single `{a,b}` expansion
- `test_multiple_brace_groups` — two brace groups (the failing case from #153)
- `test_no_brace_group` — passthrough for patterns without braces
- `test_single_item_brace_group` — `{a}` expands to just `a`

All 37 tests pass (33 existing + 4 new). Also validated end-to-end: `apm compile --verbose` on a project using `applyTo: "**/*.{test,spec}.{ts,js,mts,mjs}"` completes successfully, correctly matching 3 directories.