### PR TITLE
[docs] Update CHANGELOG for generic git URL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Generic git URL support**: APM now accepts any valid FQDN as a git host, enabling installation of packages from GitLab, Bitbucket, self-hosted Gitea, and any other git-accessible server (#150)
+  - HTTPS URLs: `https://gitlab.com/acme/rules.git`, `https://bitbucket.org/team/standards.git`
+  - SSH URLs: `git@gitlab.com:acme/rules.git`, `git@bitbucket.org:team/standards.git`
+  - FQDN shorthand: `gitlab.com/acme/rules`, `gitlab.com/group/subgroup/repo`
+  - Object format with `git:` key supports `path`, `ref`, and `alias` on any git URL
+  - Authentication delegates to git credentials / SSH keys for non-GitHub hosts
+
 ## [0.7.4] - 2025-03-03
 
 ### Added


### PR DESCRIPTION
## Documentation Updates - 2026-03-06

This PR updates `CHANGELOG.md` based on features merged in the last 24 hours.

### Features Documented

- Generic git URL support for GitLab, Bitbucket, and any self-hosted git server (from #150)

### Changes Made

- Updated `CHANGELOG.md` to populate the empty `[Unreleased]` section with the generic git URL support feature

### Merged PRs Referenced

- #150 - feat: Generic git URL support (GitLab, Bitbucket, any host)

### Notes

The user-facing documentation in `docs/dependencies.md` and `docs/getting-started.md` already comprehensively covers this feature (it was included in the same PR #150). The only gap was the empty `[Unreleased]` changelog entry, which this PR addresses.




> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/22747684834) · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+is%3Apr+%22gh-aw-workflow-id%3A+daily-doc-updater%22+in%3Abody)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-03-08T03:31:59.995Z --> on Mar 8, 2026, 3:31 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, id: 22747684834, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/22747684834 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->