### PR TITLE
[Test Improver] test: add collection_parser unit tests (0%→100%) and fix ANSI test failure

### DIFF
--- a/tests/unit/test_collection_parser.py
+++ b/tests/unit/test_collection_parser.py
@@ -1,0 +1,323 @@
+"""Unit tests for apm_cli.deps.collection_parser."""
+
+import pytest
+import yaml
+
+from apm_cli.deps.collection_parser import (
+    CollectionItem,
+    CollectionManifest,
+    parse_collection_yml,
+)
+
+
+class TestCollectionItem:
+    """Tests for CollectionItem dataclass."""
+
+    def test_subdirectory_prompt(self):
+        item = CollectionItem(path="p.prompt.md", kind="prompt")
+        assert item.subdirectory == "prompts"
+
+    def test_subdirectory_instruction(self):
+        item = CollectionItem(path="i.instructions.md", kind="instruction")
+        assert item.subdirectory == "instructions"
+
+    def test_subdirectory_chat_mode_hyphenated(self):
+        item = CollectionItem(path="c.chatmode.md", kind="chat-mode")
+        assert item.subdirectory == "chatmodes"
+
+    def test_subdirectory_chatmode_no_hyphen(self):
+        item = CollectionItem(path="c.chatmode.md", kind="chatmode")
+        assert item.subdirectory == "chatmodes"
+
+    def test_subdirectory_agent(self):
+        item = CollectionItem(path="a.agent.md", kind="agent")
+        assert item.subdirectory == "agents"
+
+    def test_subdirectory_context(self):
+        item = CollectionItem(path="c.context.md", kind="context")
+        assert item.subdirectory == "contexts"
+
+    def test_subdirectory_unknown_defaults_to_prompts(self):
+        item = CollectionItem(path="x.md", kind="unknown_kind")
+        assert item.subdirectory == "prompts"
+
+    def test_subdirectory_case_insensitive(self):
+        item = CollectionItem(path="p.md", kind="PROMPT")
+        assert item.subdirectory == "prompts"
+
+    def test_subdirectory_instruction_uppercase(self):
+        item = CollectionItem(path="i.md", kind="INSTRUCTION")
+        assert item.subdirectory == "instructions"
+
+
+class TestCollectionManifest:
+    """Tests for CollectionManifest dataclass."""
+
+    def _make_manifest(self, items=None):
+        if items is None:
+            items = [CollectionItem(path="p.md", kind="prompt")]
+        return CollectionManifest(
+            id="test-id",
+            name="Test",
+            description="Desc",
+            items=items,
+        )
+
+    def test_item_count_single(self):
+        manifest = self._make_manifest()
+        assert manifest.item_count == 1
+
+    def test_item_count_multiple(self):
+        items = [
+            CollectionItem(path="a.md", kind="prompt"),
+            CollectionItem(path="b.md", kind="instruction"),
+            CollectionItem(path="c.md", kind="agent"),
+        ]
+        manifest = self._make_manifest(items)
+        assert manifest.item_count == 3
+
+    def test_item_count_empty(self):
+        manifest = CollectionManifest(id="x", name="X", description="X", items=[])
+        assert manifest.item_count == 0
+
+    def test_get_items_by_kind_match(self):
+        items = [
+            CollectionItem(path="a.md", kind="prompt"),
+            CollectionItem(path="b.md", kind="instruction"),
+            CollectionItem(path="c.md", kind="prompt"),
+        ]
+        manifest = self._make_manifest(items)
+        result = manifest.get_items_by_kind("prompt")
+        assert len(result) == 2
+        assert all(i.kind == "prompt" for i in result)
+
+    def test_get_items_by_kind_no_match(self):
+        manifest = self._make_manifest()
+        result = manifest.get_items_by_kind("agent")
+        assert result == []
+
+    def test_get_items_by_kind_case_insensitive(self):
+        items = [CollectionItem(path="p.md", kind="Prompt")]
+        manifest = self._make_manifest(items)
+        result = manifest.get_items_by_kind("PROMPT")
+        assert len(result) == 1
+
+    def test_optional_tags_none_by_default(self):
+        manifest = self._make_manifest()
+        assert manifest.tags is None
+
+    def test_optional_display_none_by_default(self):
+        manifest = self._make_manifest()
+        assert manifest.display is None
+
+
+class TestParseCollectionYml:
+    """Tests for parse_collection_yml function."""
+
+    VALID_YAML = b"""
+id: my-collection
+name: My Collection
+description: A wonderful collection
+items:
+  - path: prompts/hello.prompt.md
+    kind: prompt
+  - path: instructions/setup.instructions.md
+    kind: instruction
+tags:
+  - ai
+  - tools
+display:
+  ordering: alpha
+"""
+
+    def test_parse_valid_full_manifest(self):
+        manifest = parse_collection_yml(self.VALID_YAML)
+        assert manifest.id == "my-collection"
+        assert manifest.name == "My Collection"
+        assert manifest.description == "A wonderful collection"
+        assert manifest.tags == ["ai", "tools"]
+        assert manifest.display == {"ordering": "alpha"}
+
+    def test_parse_valid_items(self):
+        manifest = parse_collection_yml(self.VALID_YAML)
+        assert len(manifest.items) == 2
+        assert manifest.items[0].path == "prompts/hello.prompt.md"
+        assert manifest.items[0].kind == "prompt"
+        assert manifest.items[1].path == "instructions/setup.instructions.md"
+        assert manifest.items[1].kind == "instruction"
+
+    def test_parse_minimal_manifest_no_optional_fields(self):
+        content = b"""
+id: minimal
+name: Minimal
+description: Minimal collection
+items:
+  - path: p.md
+    kind: prompt
+"""
+        manifest = parse_collection_yml(content)
+        assert manifest.id == "minimal"
+        assert manifest.tags is None
+        assert manifest.display is None
+        assert manifest.item_count == 1
+
+    def test_missing_id_raises_value_error(self):
+        content = b"""
+name: Test
+description: Desc
+items:
+  - path: p.md
+    kind: prompt
+"""
+        with pytest.raises(ValueError, match="missing required fields"):
+            parse_collection_yml(content)
+
+    def test_missing_name_raises_value_error(self):
+        content = b"""
+id: test
+description: Desc
+items:
+  - path: p.md
+    kind: prompt
+"""
+        with pytest.raises(ValueError, match="missing required fields"):
+            parse_collection_yml(content)
+
+    def test_missing_description_raises_value_error(self):
+        content = b"""
+id: test
+name: Test
+items:
+  - path: p.md
+    kind: prompt
+"""
+        with pytest.raises(ValueError, match="missing required fields"):
+            parse_collection_yml(content)
+
+    def test_missing_items_raises_value_error(self):
+        content = b"""
+id: test
+name: Test
+description: Desc
+"""
+        with pytest.raises(ValueError, match="missing required fields"):
+            parse_collection_yml(content)
+
+    def test_multiple_missing_fields_error_lists_all(self):
+        content = b"""
+name: Test
+"""
+        with pytest.raises(ValueError, match="missing required fields"):
+            parse_collection_yml(content)
+
+    def test_empty_items_list_raises_value_error(self):
+        content = b"""
+id: test
+name: Test
+description: Desc
+items: []
+"""
+        with pytest.raises(ValueError, match="at least one item"):
+            parse_collection_yml(content)
+
+    def test_items_not_a_list_raises_value_error(self):
+        content = b"""
+id: test
+name: Test
+description: Desc
+items: not-a-list
+"""
+        with pytest.raises(ValueError, match="'items' must be a list"):
+            parse_collection_yml(content)
+
+    def test_item_not_a_dict_raises_value_error(self):
+        content = b"""
+id: test
+name: Test
+description: Desc
+items:
+  - just-a-string
+"""
+        with pytest.raises(ValueError, match="item 0 must be a dictionary"):
+            parse_collection_yml(content)
+
+    def test_item_missing_path_raises_value_error(self):
+        content = b"""
+id: test
+name: Test
+description: Desc
+items:
+  - kind: prompt
+"""
+        with pytest.raises(ValueError, match="item 0 missing required field 'path'"):
+            parse_collection_yml(content)
+
+    def test_item_missing_kind_raises_value_error(self):
+        content = b"""
+id: test
+name: Test
+description: Desc
+items:
+  - path: p.md
+"""
+        with pytest.raises(ValueError, match="item 0 missing required field 'kind'"):
+            parse_collection_yml(content)
+
+    def test_invalid_yaml_raises_value_error(self):
+        content = b"key: : invalid: yaml: content:"
+        with pytest.raises(ValueError, match="Invalid YAML format"):
+            parse_collection_yml(content)
+
+    def test_non_dict_yaml_raises_value_error(self):
+        content = b"- just\n- a\n- list"
+        with pytest.raises(ValueError, match="must be a dictionary"):
+            parse_collection_yml(content)
+
+    def test_null_yaml_raises_value_error(self):
+        content = b"null"
+        with pytest.raises(ValueError, match="must be a dictionary"):
+            parse_collection_yml(content)
+
+    def test_second_item_missing_kind_raises_value_error(self):
+        """Verify error message includes correct item index."""
+        content = b"""
+id: test
+name: Test
+description: Desc
+items:
+  - path: p0.md
+    kind: prompt
+  - path: p1.md
+"""
+        with pytest.raises(ValueError, match="item 1 missing required field 'kind'"):
+            parse_collection_yml(content)
+
+    def test_all_kind_subdirectories(self):
+        """Verify all supported kind mappings via parse."""
+        kinds = [
+            ("prompt", "prompts"),
+            ("instruction", "instructions"),
+            ("chat-mode", "chatmodes"),
+            ("chatmode", "chatmodes"),
+            ("agent", "agents"),
+            ("context", "contexts"),
+        ]
+        for kind, expected_subdir in kinds:
+            content = f"""
+id: test
+name: Test
+description: Desc
+items:
+  - path: file.md
+    kind: {kind}
+""".encode()
+            manifest = parse_collection_yml(content)
+            assert (
+                manifest.items[0].subdirectory == expected_subdir
+            ), f"kind={kind!r} should map to {expected_subdir!r}"
+
+    def test_get_items_by_kind_after_parse(self):
+        manifest = parse_collection_yml(self.VALID_YAML)
+        prompts = manifest.get_items_by_kind("prompt")
+        assert len(prompts) == 1
+        assert prompts[0].path == "prompts/hello.prompt.md"

--- a/tests/unit/test_install_command.py
+++ b/tests/unit/test_install_command.py
@@ -1,14 +1,18 @@
 """Tests for the apm install command auto-bootstrap feature."""
 
-import pytest
-import tempfile
 import os
-import yaml
+import re
+import tempfile
 from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
 from click.testing import CliRunner
-from unittest.mock import patch, MagicMock
 
 from apm_cli.cli import cli
+
+_ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
 
 
 class TestInstallCommandAutoBootstrap:
@@ -41,7 +45,8 @@ class TestInstallCommandAutoBootstrap:
             assert result.exit_code == 1
             assert "No apm.yml found" in result.output
             assert "apm init" in result.output
-            assert "apm install <org/repo>" in result.output
+            clean_output = _ANSI_ESCAPE.sub("", result.output)
+            assert "apm install <org/repo>" in clean_output
 
     @patch("apm_cli.cli._validate_package_exists")
     @patch("apm_cli.cli.APM_DEPS_AVAILABLE", True)
@@ -66,7 +71,11 @@ class TestInstallCommandAutoBootstrap:
             mock_apm_package.from_apm_yml.return_value = mock_pkg_instance
 
             # Mock the install function to avoid actual installation
-            mock_install_apm.return_value = (0, 0, 0)  # Return tuple (installed_count, prompts_integrated, agents_integrated)
+            mock_install_apm.return_value = (
+                0,
+                0,
+                0,
+            )  # Return tuple (installed_count, prompts_integrated, agents_integrated)
 
             result = self.runner.invoke(cli, ["install", "test/package"])
 
@@ -106,7 +115,11 @@ class TestInstallCommandAutoBootstrap:
             mock_pkg_instance.get_mcp_dependencies.return_value = []
             mock_apm_package.from_apm_yml.return_value = mock_pkg_instance
 
-            mock_install_apm.return_value = (0, 0, 0)  # Return tuple (installed_count, prompts_integrated, agents_integrated)
+            mock_install_apm.return_value = (
+                0,
+                0,
+                0,
+            )  # Return tuple (installed_count, prompts_integrated, agents_integrated)
 
             result = self.runner.invoke(cli, ["install", "org1/pkg1", "org2/pkg2"])
 
@@ -148,7 +161,11 @@ class TestInstallCommandAutoBootstrap:
             mock_pkg_instance.get_mcp_dependencies.return_value = []
             mock_apm_package.from_apm_yml.return_value = mock_pkg_instance
 
-            mock_install_apm.return_value = (0, 0, 0)  # Return tuple (installed_count, prompts_integrated, agents_integrated)
+            mock_install_apm.return_value = (
+                0,
+                0,
+                0,
+            )  # Return tuple (installed_count, prompts_integrated, agents_integrated)
 
             result = self.runner.invoke(cli, ["install"])
 
@@ -186,7 +203,11 @@ class TestInstallCommandAutoBootstrap:
             mock_pkg_instance.get_mcp_dependencies.return_value = []
             mock_apm_package.from_apm_yml.return_value = mock_pkg_instance
 
-            mock_install_apm.return_value = (0, 0, 0)  # Return tuple (installed_count, prompts_integrated, agents_integrated)
+            mock_install_apm.return_value = (
+                0,
+                0,
+                0,
+            )  # Return tuple (installed_count, prompts_integrated, agents_integrated)
 
             result = self.runner.invoke(cli, ["install", "test/package"])
 


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant*

## What

- **32 new unit tests** for `deps/collection_parser.py` (was at 0% coverage)
- **Fix pre-existing test failure** in `test_install_command.py` — ANSI escape codes added by Rich around `(org/repo)` caused an assertion to fail

## Why it matters

`collection_parser.py` is the entry point for all collection manifest parsing (`.collection.yml` files). It was completely untested by unit tests — only a few integration tests touched it. The 0% unit coverage meant any regression (wrong field validation, kind→subdirectory mapping bug) would only be caught by integration tests.

The ANSI test failure has been a silent pre-existing flake: `1 failed` was visible in every test run but silently ignored.

## Approach

**collection_parser.py (0% → 100%):**
- `CollectionItem.subdirectory` — all 6 kind mappings + unknown-defaults-to-prompts + case-insensitivity
- `CollectionManifest.item_count` and `get_items_by_kind` — filtering, case-insensitivity, empty results
- `parse_collection_yml` — valid full manifest, minimal manifest, all 4 missing-required-field combos, empty items, non-list items, non-dict item, missing path/kind on nth item (verifying correct index in message), invalid YAML, non-dict YAML, null YAML, all 6 kind→subdirectory mappings end-to-end

**ANSI fix (test_install_command.py):**
Strip ANSI escape sequences before asserting on the `apm install (org/repo)` substring — Rich adds `\x1b[1m` bold markers around `<` and `>`.

## Coverage impact

| File | Before | After |
|------|--------|-------|
| `deps/collection_parser.py` | 0% | 100% |
| Total missed lines | 5703 | 5653 |
| Test suite result | 1 failed, 1270 passed | **0 failed, 1307 passed** |

## Reproducibility

```bash
uv sync --extra dev
uv run pytest tests/unit/test_collection_parser.py tests/unit/test_install_command.py -v
uv run pytest tests/unit/ -q  # full suite
```

## Test Status

✅ All 1307 unit tests pass (0 failures, up from 1270 passing + 1 failing).




> Generated by [Daily Test Improver](https://github.com/microsoft/apm/actions/runs/22788483882) · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+is%3Apr+%22gh-aw-workflow-id%3A+daily-test-improver%22+in%3Abody)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-test-improver.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-test-improver.md@b87234850bf9664d198f28a02df0f937d0447295
> ```

<!-- gh-aw-agentic-workflow: Daily Test Improver, engine: copilot, id: 22788483882, workflow_id: daily-test-improver, run: https://github.com/microsoft/apm/actions/runs/22788483882 -->

<!-- gh-aw-workflow-id: daily-test-improver -->