### PR TITLE
chore: changelog and version bump for v0.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.6] - 2026-03-10
+
+### Added
+
+- `apm pack` and `apm unpack` commands for portable bundle creation and extraction with target filtering, archive support, and verification (#218)
+- Plugin MCP Server installation — extract, convert, and deploy MCP servers defined in plugin packages (#217)
+
+### Fixed
+
+- Plugin agents not deployed due to directory nesting in custom agent paths (#214)
+- Skip already-configured self-defined MCP servers on re-install (#191)
+- CLI consistency: remove emojis from help strings, fix `apm config` bare invocation, update descriptions (#212)
+
+### Changed
+
+- Extract `MCPIntegrator` from `cli.py` — move MCP lifecycle orchestration (~760 lines) into standalone module with hardened error handling (#215)
+
 ## [0.7.5] - 2026-03-09
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apm-cli"
-version = "0.7.5"
+version = "0.7.6"
 description = "MCP configuration tool"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Changelog entry and version bump for v0.7.6.

### PRs included since v0.7.5

#### Added
- `apm pack` and `apm unpack` commands (#218)
- Plugin MCP Server installation support (#217)

#### Fixed
- Plugin agents directory nesting bug (#214)
- Skip already-configured self-defined MCP servers (#191)
- CLI consistency: emojis, `apm config`, descriptions (#212)

#### Changed
- Extract `MCPIntegrator` from `cli.py` (#215)

### Files changed
- `CHANGELOG.md` — new v0.7.6 section
- `pyproject.toml` — version `0.7.5` → `0.7.6`