### PR TITLE
[docs] Update documentation for features from 2026-03-11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Refactor `cli.py` and `apm_package.py` into focused modules — `cli.py` is now a thin 80-line wiring layer; all command logic lives in `apm_cli.commands.*` modules (#224)
+
 ## [0.7.7] - 2026-03-10
 
 ### Added

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -345,7 +345,7 @@ apm pack [OPTIONS]
 
 **Options:**
 - `-o, --output TEXT` - Output directory (default: `./build/`)
-- `-t, --target [vscode|claude|all]` - Filter files by target. Auto-detects from `apm.yml` if not specified
+- `-t, --target [copilot|vscode|claude|all]` - Filter files by target. `vscode` is an alias for `copilot`. Auto-detects from `apm.yml` if not specified
 - `--archive` - Produce a `.tar.gz` archive instead of a directory
 - `--dry-run` - List files that would be packed without writing anything
 - `--format [apm|plugin]` - Bundle format (default: `apm`)
@@ -358,8 +358,8 @@ apm pack
 # Pack as a .tar.gz archive
 apm pack --archive
 
-# Pack only VS Code / Copilot files
-apm pack --target vscode
+# Pack only GitHub Copilot / VS Code files
+apm pack --target copilot
 
 # Preview what would be packed
 apm pack --dry-run
@@ -375,11 +375,12 @@ apm pack -o dist/
 
 **Target filtering:**
 
-| Target | Includes paths starting with |
-|--------|------------------------------|
-| `vscode` | `.github/` |
-| `claude` | `.claude/` |
-| `all` | both |
+| Target | Includes paths starting with | Notes |
+|--------|------------------------------|-------|
+| `copilot` | `.github/` | Primary name for GitHub Copilot / Cursor / Codex / Gemini |
+| `vscode` | `.github/` | Alias for `copilot` |
+| `claude` | `.claude/` | |
+| `all` | both | |
 
 **Enriched lockfile example:**
 ```yaml

--- a/docs/runtime-integration.md
+++ b/docs/runtime-integration.md
@@ -226,7 +226,7 @@ APM's runtime system consists of three main components:
 1. **Create Runtime Adapter** - Extend `RuntimeAdapter` in `src/apm_cli/runtime/your_runtime.py`
 2. **Create Setup Script** - Add installation script in `scripts/runtime/setup-your-runtime.sh`
 3. **Register Runtime** - Add entry to `supported_runtimes` in `RuntimeManager`
-4. **Update CLI** - Add runtime to command choices in `cli.py`
+4. **Update CLI** - Add runtime to command choices in `src/apm_cli/commands/runtime.py`
 5. **Update Factory** - Add runtime to `RuntimeFactory`
 
 ### Best Practices


### PR DESCRIPTION
## Documentation Updates - 2026-03-11

This PR updates the documentation based on features merged in the last 24 hours.

### Features Documented

- CLI refactoring: `cli.py` and `apm_package.py` split into focused modules (from #224)
- `copilot` as primary target name for `apm pack`, with `vscode` as alias (from #228)
- Fixed stale `cli.py` reference in runtime integration contributor guide (from #224)

### Changes Made

- Updated `CHANGELOG.md` to add `[Unreleased]` entry for the cli.py / apm_package.py refactoring (PR #224, issue #172)
- Updated `docs/cli-reference.md`:
  - `apm pack --target` option now documents `[copilot|vscode|claude|all]` with `vscode` noted as alias
  - Updated example from `--target vscode` to `--target copilot`
  - Expanded target filtering table to list `copilot` as primary and `vscode` as alias
- Updated `docs/runtime-integration.md`:
  - Step 4 of "Adding a New Runtime" now references `src/apm_cli/commands/runtime.py` instead of the now-thin `cli.py` wiring layer

### Merged PRs Referenced

- #224 - Refactor `cli.py` and `apm_package.py` into focused command modules
- #228 - Add `copilot` as primary target name (vscode/agents remain as aliases)

### Notes

The `compile` command's `--target` option still uses `[vscode|agents|claude|all]` without `copilot` — this was intentional per the current source (only `apm pack` received the `copilot` target name in #228). If `copilot` should also be added to `compile`, that would be a separate follow-up.




> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/22935256187) · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+is%3Apr+%22gh-aw-workflow-id%3A+daily-doc-updater%22+in%3Abody)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-03-13T03:37:16.973Z --> on Mar 13, 2026, 3:37 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, id: 22935256187, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/22935256187 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->