### PR TITLE
docs: revamp README as storefront for docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Think `package.json`, `requirements.txt`, or `Cargo.toml` — but for AI agent c
 
 GitHub Copilot · Claude Code
 
-**[Documentation](https://microsoft.github.io/apm/)** · **[Quick Start](https://microsoft.github.io/apm/getting-started/quick-start/)** · **[CLI Reference](https://microsoft.github.io/apm/reference/cli/)**
+**[Documentation](https://microsoft.github.io/apm/)** · **[Quick Start](https://microsoft.github.io/apm/getting-started/quick-start/)** · **[CLI Reference](https://microsoft.github.io/apm/reference/cli-commands/)**
 
 ## Why APM
 


### PR DESCRIPTION
## Summary

Now that the docs site is live at [microsoft.github.io/apm/](https://microsoft.github.io/apm/), the README no longer needs to serve as both landing page AND reference manual.

This PR revamps the README following the **uv pattern** (benchmarked against uv, ruff, deno, bun) — enough content to convey the value proposition without clicking away, but funneling to the docs site for everything else.

## What changed

| Section | Before | After |
|---------|--------|-------|
| **Badges** | 4 shield badges | Removed |
| **Tagline** | Compliance line + expanded description | Compliance line preserved (standalone) |
| **Agent list** | Copilot · Cursor · Claude · Codex · Gemini | Copilot · Claude Code (currently supported) |
| **Doc links** | Bottom table with relative `docs/` paths | Prominent top bar linking to docs site |
| **Why APM** | 2 paragraphs | Condensed to 1 paragraph |
| **apm.yml example** | 10 deps with verbose comments | 4 deps, cleaner |
| **Primitives table** | 7-row feature matrix | Replaced by single "Highlights" bullet list |
| **Install** | 2-step numbered + separate "Install From Anywhere" section | Single curl + collapsible alternatives |
| **Create & Share** | Full scaffold + heredoc example | Removed (covered in docs) |
| **Key Commands** | 7-row command table | Removed (covered in CLI Reference doc) |
| **Configuration** | Token table + link | Removed (covered in docs) |
| **APM Packages** | Description + 3-row popular sources table | Removed (covered in docs) |
| **Documentation table** | 3-row link matrix | Removed (replaced by top bar links) |
| **Community** | Scattered links | Consolidated section |
| **Open standards** | Kept | Kept |
| **Trademarks** | Kept | Kept |

**250 lines → ~80 lines**

## Constraints respected
- `**An open-source, community-driven dependency manager for AI agents.**` kept verbatim (Microsoft compliance)
- All deep content lives in the docs site, not lost