### PR TITLE
chore: release v0.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.8] - 2026-03-13
+
 ### Added
 
 - Diff-aware `apm install` — manifest as source of truth: removed packages, ref/version changes, and MCP config drift in `apm.yml` all self-correct on the next `apm install` without `--update` or `--force`; introduces `drift.py` with pure helper functions (#260)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apm-cli"
-version = "0.7.7"
+version = "0.7.8"
 description = "MCP configuration tool"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Release v0.7.8

Prepares the v0.7.8 release:

- Bumps version in `pyproject.toml` to `0.7.8`
- Moves Unreleased changelog entries into `[0.7.8] - 2026-03-13` section
- Adds empty Unreleased placeholder
- Adds `changelog.instructions.md` for LLM-guided changelog formatting
- Documents all 14 PRs merged since v0.7.7

After merge, tag with `v0.7.8` to trigger the release pipeline.