### PR TITLE
[Test Improver] test: fix ANSI escape code failures in unpacker and install tests

### DIFF
--- a/tests/unit/test_install_command.py
+++ b/tests/unit/test_install_command.py
@@ -1,14 +1,21 @@
 """Tests for the apm install command auto-bootstrap feature."""
 
-import pytest
-import tempfile
 import os
-import yaml
+import re
+import tempfile
 from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
 from click.testing import CliRunner
-from unittest.mock import patch, MagicMock
 
 from apm_cli.cli import cli
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes from *text* for plain-text assertions."""
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
 
 
 class TestInstallCommandAutoBootstrap:
@@ -41,7 +48,7 @@ class TestInstallCommandAutoBootstrap:
             assert result.exit_code == 1
             assert "No apm.yml found" in result.output
             assert "apm init" in result.output
-            assert "apm install <org/repo>" in result.output
+            assert "apm install <org/repo>" in _strip_ansi(result.output)
 
     @patch("apm_cli.commands.install._validate_package_exists")
     @patch("apm_cli.commands.install.APM_DEPS_AVAILABLE", True)

--- a/tests/unit/test_unpacker.py
+++ b/tests/unit/test_unpacker.py
@@ -1,12 +1,18 @@
 """Unit tests for apm_cli.bundle.unpacker."""
 
+import re
 import tarfile
 from pathlib import Path
 
 import pytest
 
 from apm_cli.bundle.unpacker import unpack_bundle
-from apm_cli.deps.lockfile import LockFile, LockedDependency
+from apm_cli.deps.lockfile import LockedDependency, LockFile
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes from *text* for plain-text assertions."""
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
 
 
 def _build_bundle_dir(tmp_path: Path, deployed_files: list[str]) -> Path:
@@ -169,7 +175,9 @@ class TestUnpackBundle:
 
         unpack_bundle(bundle, output)
 
-        assert (output / ".github" / "agents" / "a.md").read_text() == "content of .github/agents/a.md"
+        assert (
+            output / ".github" / "agents" / "a.md"
+        ).read_text() == "content of .github/agents/a.md"
 
     def test_unpack_lockfile_not_scattered(self, tmp_path):
         deployed = [".github/agents/a.md"]
@@ -344,9 +352,11 @@ class TestUnpackCmdLogging:
 
     def test_unpack_cmd_logs_file_list(self, tmp_path):
         """unpack command outputs each file under its dependency name."""
-        from click.testing import CliRunner
-        from apm_cli.commands.pack import unpack_cmd
         import os
+
+        from click.testing import CliRunner
+
+        from apm_cli.commands.pack import unpack_cmd
 
         deployed = [".github/agents/a.md", ".github/prompts/b.md"]
         bundle = _build_bundle_dir(tmp_path, deployed)
@@ -362,18 +372,21 @@ class TestUnpackCmdLogging:
         finally:
             os.chdir(original_dir)
 
+        out = _strip_ansi(result.output)
         assert result.exit_code == 0
-        assert "Unpacking" in result.output
-        assert "owner/repo" in result.output
-        assert ".github/agents/a.md" in result.output
-        assert ".github/prompts/b.md" in result.output
-        assert "Unpacked 2 file(s)" in result.output
+        assert "Unpacking" in out
+        assert "owner/repo" in out
+        assert ".github/agents/a.md" in out
+        assert ".github/prompts/b.md" in out
+        assert "Unpacked 2 file(s)" in out
 
     def test_unpack_cmd_dry_run_logs_files(self, tmp_path):
         """Dry-run output includes per-dependency file listing."""
-        from click.testing import CliRunner
-        from apm_cli.commands.pack import unpack_cmd
         import os
+
+        from click.testing import CliRunner
+
+        from apm_cli.commands.pack import unpack_cmd
 
         deployed = [".github/agents/a.md"]
         bundle = _build_bundle_dir(tmp_path, deployed)
@@ -391,16 +404,19 @@ class TestUnpackCmdLogging:
         finally:
             os.chdir(original_dir)
 
+        out = _strip_ansi(result.output)
         assert result.exit_code == 0
-        assert "Dry run" in result.output
-        assert "Would unpack 1 file(s)" in result.output
-        assert ".github/agents/a.md" in result.output
+        assert "Dry run" in out
+        assert "Would unpack 1 file(s)" in out
+        assert ".github/agents/a.md" in out
 
     def test_unpack_cmd_logs_skipped_files(self, tmp_path):
         """Skipped files warning appears when skip_verify allows missing files."""
-        from click.testing import CliRunner
-        from apm_cli.commands.pack import unpack_cmd
         import os
+
+        from click.testing import CliRunner
+
+        from apm_cli.commands.pack import unpack_cmd
 
         deployed = [".github/agents/a.md", ".github/agents/missing.md"]
         bundle_dir = tmp_path / "bundle" / "test-pkg"
@@ -430,13 +446,15 @@ class TestUnpackCmdLogging:
             os.chdir(original_dir)
 
         assert result.exit_code == 0
-        assert "1 file(s) skipped" in result.output
+        assert "1 file(s) skipped" in _strip_ansi(result.output)
 
     def test_unpack_cmd_multi_dep_logging(self, tmp_path):
         """Multiple dependencies are each logged with their file lists."""
-        from click.testing import CliRunner
-        from apm_cli.commands.pack import unpack_cmd
         import os
+
+        from click.testing import CliRunner
+
+        from apm_cli.commands.pack import unpack_cmd
 
         bundle_dir = tmp_path / "bundle" / "multi-pkg"
         bundle_dir.mkdir(parents=True)
@@ -469,9 +487,10 @@ class TestUnpackCmdLogging:
         finally:
             os.chdir(original_dir)
 
+        out = _strip_ansi(result.output)
         assert result.exit_code == 0
-        assert "org/repo-a" in result.output
-        assert "org/repo-b" in result.output
-        assert ".github/agents/a.md" in result.output
-        assert ".github/prompts/b.md" in result.output
-        assert "Unpacked 2 file(s)" in result.output
+        assert "org/repo-a" in out
+        assert "org/repo-b" in out
+        assert ".github/agents/a.md" in out
+        assert ".github/prompts/b.md" in out
+        assert "Unpacked 2 file(s)" in out


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant.*

## Goal and Rationale

Five unit tests were failing because the Rich library renders CLI output with ANSI bold escape codes (e.g. `\x1b[1m2\x1b[0m`) even when captured by Click's `CliRunner`. Plain-text assertions like `"Unpacked 2 file(s)" in result.output` therefore failed because the string was fragmented by ANSI markers.

The failures were:
- `test_unpacker.py::TestUnpackCmdLogging` — 4 tests checking `"Unpacked N file(s)"`, `"Would unpack N file(s)"`, and `"N file(s) skipped"`
- `test_install_command.py::TestInstallCommandAutoBootstrap::test_install_no_apm_yml_no_packages_shows_helpful_error` — checking `"apm install (org/repo)"`

## Approach

Added a small `_strip_ansi(text)` helper to each affected test file that uses `re.sub(r"\x1b\[[0-9;]*m", "", text)` to strip SGR escape sequences. Applied it only to the assertions that were failing — existing assertions checking strings not affected by ANSI codes are left unchanged.

No production code changes. No new dependencies.

## Test Status

```
1586 passed in 13.02s  (0 failures, previously 5 failed)
```

| File | Before | After |
|------|--------|-------|
| `test_unpacker.py::TestUnpackCmdLogging` | 4 FAILED | 4 PASSED |
| `test_install_command.py::TestInstallCommandAutoBootstrap` | 1 FAILED | 1 PASSED |

## Reproducibility

```bash
pip install uv --break-system-packages
python3 -m uv sync --extra dev
python3 -m uv run pytest tests/unit/ --no-header -q
```




> Generated by [Daily Test Improver](https://github.com/microsoft/apm/actions/runs/23031424288) · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+is%3Apr+%22gh-aw-workflow-id%3A+daily-test-improver%22+in%3Abody)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-test-improver.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-test-improver.md@b87234850bf9664d198f28a02df0f937d0447295
> ```

<!-- gh-aw-agentic-workflow: Daily Test Improver, engine: copilot, id: 23031424288, workflow_id: daily-test-improver, run: https://github.com/microsoft/apm/actions/runs/23031424288 -->

<!-- gh-aw-workflow-id: daily-test-improver -->