### PR TITLE
[Test Improver] fix(tests): strip ANSI codes before plain-text assertions in 3 test files

### DIFF
--- a/tests/unit/test_install_command.py
+++ b/tests/unit/test_install_command.py
@@ -1,6 +1,7 @@
 """Tests for the apm install command auto-bootstrap feature."""
 
 import contextlib
+import re
 import pytest
 import tempfile
 import os
@@ -10,6 +11,11 @@ from click.testing import CliRunner
 from unittest.mock import patch, MagicMock
 
 from apm_cli.cli import cli
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes for plain-text assertions."""
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
 
 
 class TestInstallCommandAutoBootstrap:
@@ -55,7 +61,7 @@ class TestInstallCommandAutoBootstrap:
             assert result.exit_code == 1
             assert "No apm.yml found" in result.output
             assert "apm init" in result.output
-            assert "apm install <org/repo>" in result.output
+            assert "apm install <org/repo>" in _strip_ansi(result.output)
 
     @patch("apm_cli.commands.install._validate_package_exists")
     @patch("apm_cli.commands.install.APM_DEPS_AVAILABLE", True)

--- a/tests/unit/test_unpacker.py
+++ b/tests/unit/test_unpacker.py
@@ -1,7 +1,13 @@
 """Unit tests for apm_cli.bundle.unpacker."""
 
+import re
 import tarfile
 from pathlib import Path
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes from text for plain-text assertions."""
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
 
 import pytest
 
@@ -388,11 +394,12 @@ class TestUnpackCmdLogging:
             os.chdir(original_dir)
 
         assert result.exit_code == 0
-        assert "Unpacking" in result.output
-        assert "owner/repo" in result.output
-        assert ".github/agents/a.md" in result.output
-        assert ".github/prompts/b.md" in result.output
-        assert "Unpacked 2 file(s)" in result.output
+        out = _strip_ansi(result.output)
+        assert "Unpacking" in out
+        assert "owner/repo" in out
+        assert ".github/agents/a.md" in out
+        assert ".github/prompts/b.md" in out
+        assert "Unpacked 2 file(s)" in out
 
     def test_unpack_cmd_dry_run_logs_files(self, tmp_path):
         """Dry-run output includes per-dependency file listing."""
@@ -417,9 +424,10 @@ class TestUnpackCmdLogging:
             os.chdir(original_dir)
 
         assert result.exit_code == 0
-        assert "Dry run" in result.output
-        assert "Would unpack 1 file(s)" in result.output
-        assert ".github/agents/a.md" in result.output
+        out = _strip_ansi(result.output)
+        assert "Dry run" in out
+        assert "Would unpack 1 file(s)" in out
+        assert ".github/agents/a.md" in out
 
     def test_unpack_cmd_logs_skipped_files(self, tmp_path):
         """Skipped files warning appears when skip_verify allows missing files."""
@@ -455,7 +463,7 @@ class TestUnpackCmdLogging:
             os.chdir(original_dir)
 
         assert result.exit_code == 0
-        assert "1 file(s) skipped" in result.output
+        assert "1 file(s) skipped" in _strip_ansi(result.output)
 
     def test_unpack_cmd_multi_dep_logging(self, tmp_path):
         """Multiple dependencies are each logged with their file lists."""
@@ -495,8 +503,9 @@ class TestUnpackCmdLogging:
             os.chdir(original_dir)
 
         assert result.exit_code == 0
-        assert "org/repo-a" in result.output
-        assert "org/repo-b" in result.output
-        assert ".github/agents/a.md" in result.output
-        assert ".github/prompts/b.md" in result.output
-        assert "Unpacked 2 file(s)" in result.output
+        out = _strip_ansi(result.output)
+        assert "org/repo-a" in out
+        assert "org/repo-b" in out
+        assert ".github/agents/a.md" in out
+        assert ".github/prompts/b.md" in out
+        assert "Unpacked 2 file(s)" in out

--- a/tests/unit/test_update_command.py
+++ b/tests/unit/test_update_command.py
@@ -1,5 +1,6 @@
 """Tests for the platform-aware update command."""
 
+import re
 import unittest
 from unittest.mock import Mock, patch
 
@@ -8,6 +9,10 @@ from click.testing import CliRunner
 import apm_cli.commands.update as update_module
 from apm_cli.cli import cli
 
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes for plain-text assertions."""
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
 
 class TestUpdateCommand(unittest.TestCase):
     """Verify update command behavior across supported installer platforms."""
@@ -49,7 +54,7 @@ class TestUpdateCommand(unittest.TestCase):
             result = self.runner.invoke(cli, ["update"])
 
         self.assertEqual(result.exit_code, 0)
-        self.assertIn("Successfully updated to version 0.7.0", result.output)
+        self.assertIn("Successfully updated to version 0.7.0", _strip_ansi(result.output))
         mock_get.assert_called_once()
         self.assertTrue(mock_get.call_args.args[0].endswith("install.ps1"))
         mock_run.assert_called_once()
@@ -83,7 +88,7 @@ class TestUpdateCommand(unittest.TestCase):
             result = self.runner.invoke(cli, ["update"])
 
         self.assertEqual(result.exit_code, 0)
-        self.assertIn("Successfully updated to version 0.7.0", result.output)
+        self.assertIn("Successfully updated to version 0.7.0", _strip_ansi(result.output))
         mock_get.assert_called_once()
         self.assertTrue(mock_get.call_args.args[0].endswith("install.sh"))
         mock_run.assert_called_once()


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant*

## Goal

Fix 7 failing unit tests caused by Rich library injecting ANSI escape codes into CLI output captured by Click's `CliRunner`.

## Root Cause

Rich outputs bold/italic ANSI codes (e.g. `\x1b[1m2\x1b[0m`) even when output is captured by `CliRunner`. Tests that assert plain-text substrings like `"Unpacked 2 file(s)"` or `"Successfully updated to version 0.7.0"` fail because the actual output contains these codes between characters.

## Changes

Added a `_strip_ansi()` helper to 3 test files and applied it before plain-text substring assertions:

| File | Tests Fixed |
|------|------------|
| `tests/unit/test_unpacker.py` | 4 tests in `TestUnpackCmdLogging` |
| `tests/unit/test_update_command.py` | 2 tests in `TestUpdateCommand` |
| `tests/unit/test_install_command.py` | 1 test in `TestInstallCommandAutoBootstrap` |

The helper is a one-liner:
````python
def _strip_ansi(text: str) -> str:
    return re.sub(r"\x1b\[[0-9;]*m", "", text)
```

## Test Status

✅ All 1683 unit tests pass (was 1676 passing + 7 failing before this fix):

```
1683 passed in 12.87s
````

## Reproducibility

```bash
uv sync --extra dev
uv run pytest tests/unit/ -q
```




> Generated by [Daily Test Improver](https://github.com/microsoft/apm/actions/runs/23076812413) · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+is%3Apr+%22gh-aw-workflow-id%3A+daily-test-improver%22+in%3Abody)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-test-improver.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-test-improver.md@b87234850bf9664d198f28a02df0f937d0447295
> ```

<!-- gh-aw-agentic-workflow: Daily Test Improver, engine: copilot, id: 23076812413, workflow_id: daily-test-improver, run: https://github.com/microsoft/apm/actions/runs/23076812413 -->

<!-- gh-aw-workflow-id: daily-test-improver -->