### PR TITLE
fix(test): handle Windows file locking in integration test teardown

### DIFF
--- a/tests/integration/test_ado_e2e.py
+++ b/tests/integration/test_ado_e2e.py
@@ -10,6 +10,7 @@ Skip these tests if ADO_APM_PAT is not available.
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -31,7 +32,10 @@ def run_apm_command(cmd: str, cwd: Path, timeout: int = 60) -> subprocess.Comple
         apm_path = apm_on_path
     else:
         # Fallback to local dev venv
-        apm_path = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
+        if sys.platform == "win32":
+            apm_path = Path(__file__).parent.parent.parent / ".venv" / "Scripts" / "apm.exe"
+        else:
+            apm_path = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
     
     full_cmd = f"{apm_path} {cmd}"
     result = subprocess.run(

--- a/tests/integration/test_auto_install_e2e.py
+++ b/tests/integration/test_auto_install_e2e.py
@@ -69,7 +69,10 @@ author: test
         """Clean up test environment."""
         os.chdir(self.original_dir)
         if os.path.exists(self.test_dir):
-            shutil.rmtree(self.test_dir)
+            # ignore_errors=True: on Windows, recently-terminated subprocesses
+            # may still hold file locks on the temp directory (WinError 32).
+            # CI temp dirs are ephemeral — safe to leave behind if needed.
+            shutil.rmtree(self.test_dir, ignore_errors=True)
     
     def test_auto_install_virtual_prompt_first_run(self, temp_e2e_home):
         """Test auto-install on first run with virtual package reference.
@@ -126,8 +129,9 @@ author: test
                     break
             
             # Wait for graceful shutdown
+            process.stdout.close()
             try:
-                process.wait(timeout=5)
+                process.wait(timeout=10)
             except subprocess.TimeoutExpired:
                 process.kill()
                 process.wait()
@@ -185,7 +189,8 @@ author: test
                 if "Package installed and ready to run" in line:
                     process.terminate()
                     break
-            process.wait(timeout=5)
+            process.stdout.close()
+            process.wait(timeout=10)
         except:
             process.kill()
             process.wait()
@@ -218,7 +223,8 @@ author: test
                 if "Executing" in line or "Package installed and ready to run" in line:
                     process.terminate()
                     break
-            process.wait(timeout=5)
+            process.stdout.close()
+            process.wait(timeout=10)
         except:
             process.kill()
             process.wait()
@@ -265,7 +271,8 @@ author: test
                 if "Package installed and ready to run" in line:
                     process.terminate()
                     break
-            process.wait(timeout=5)
+            process.stdout.close()
+            process.wait(timeout=10)
         except:
             process.kill()
             process.wait()
@@ -294,7 +301,8 @@ author: test
                 if "Executing" in line or "Auto-discovered" in line:
                     process.terminate()
                     break
-            process.wait(timeout=5)
+            process.stdout.close()
+            process.wait(timeout=10)
         except:
             process.kill()
             process.wait()
@@ -340,7 +348,8 @@ author: test
                 if "Package installed and ready to run" in line:
                     process.terminate()
                     break
-            process.wait(timeout=5)
+            process.stdout.close()
+            process.wait(timeout=10)
         except:
             process.kill()
             process.wait()


### PR DESCRIPTION
## Summary

Fixes the Windows integration test teardown failure that blocks the v0.7.9 release pipeline.

### Root Cause

`test_auto_install_e2e.py::teardown_method` calls `shutil.rmtree(self.test_dir)` which fails on Windows with `PermissionError: [WinError 32]` — the recently-terminated `apm` subprocess still holds file locks on the temp directory.

All 4 tests **PASS**, but the teardown error causes pytest to exit non-zero, failing the entire integration test job and blocking the release.

### Changes

**`tests/integration/test_auto_install_e2e.py`**:
- Use `shutil.rmtree(ignore_errors=True)` in `teardown_method` — CI temp dirs are ephemeral
- Close `process.stdout` pipes before `process.wait()` to release file handles on Windows
- Increase wait timeout from 5s to 10s for graceful subprocess shutdown

**`tests/integration/test_ado_e2e.py`**:
- Fix venv path fallback: `.venv/Scripts/apm.exe` on Windows vs `.venv/bin/apm` on Unix

### Evidence

Same error reproduced consistently across multiple pipeline runs:
- Scheduled run: https://github.com/microsoft/apm/actions/runs/23080491292
- v0.7.9 tag run: https://github.com/microsoft/apm/actions/runs/23072938506

### Notes

- Test-only changes — no production code modified
- Partially addresses #185
- This is the first-ever Windows binary release — subsequent test suites (guardrailing, MCP registry, etc.) will also run on Windows for the first time after this fix unblocks the pipeline