### PR TITLE
fix(test): set PYTHONUTF8=1 for Windows integration tests

### DIFF
--- a/scripts/windows/test-integration.ps1
+++ b/scripts/windows/test-integration.ps1
@@ -164,6 +164,7 @@ function Invoke-IntegrationTests {
     Write-Info "  - APM Dependencies with real repositories"
 
     $env:APM_E2E_TESTS = "1"
+    $env:PYTHONUTF8 = "1"
 
     Write-Info "Environment:"
     Write-Host "  APM_E2E_TESTS: $env:APM_E2E_TESTS"


### PR DESCRIPTION
## Problem

After fixing Unicode in print statements (PR #296), the Windows integration tests still fail because `Path.read_text()` defaults to cp1252, which can't decode UTF-8 content in generated files like AGENTS.md:

```
agents_content = agents_md.read_text()
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 3179
```

There are dozens of `.read_text()` calls across integration tests — fixing each individually is whack-a-mole.

## Fix

Set `PYTHONUTF8=1` in the Windows test runner (`scripts/windows/test-integration.ps1`). This is Python's official mechanism to force UTF-8 for all I/O on Windows, matching Linux/macOS behavior.

Covers: `print()`, `Path.read_text()`, `subprocess.run(text=True)`, and any other implicit encoding.

## Files changed

- `scripts/windows/test-integration.ps1` — one line: `$env:PYTHONUTF8 = "1"`

Builds on PR #296 (ASCII print replacements + subprocess encoding, kept as defense-in-depth).