### PR TITLE
fix: use _rmtree for Windows-safe directory cleanup in downloader

### DIFF
--- a/src/apm_cli/deps/github_downloader.py
+++ b/src/apm_cli/deps/github_downloader.py
@@ -1280,7 +1280,7 @@ author: {dep_ref.repo_url.split('/')[0]}
 
             # If target exists and has content, remove it
             if target_path.exists() and any(target_path.iterdir()):
-                shutil.rmtree(target_path)
+                _rmtree(target_path)
                 target_path.mkdir(parents=True, exist_ok=True)
 
             # Copy subdirectory contents to target
@@ -1409,7 +1409,7 @@ author: {dep_ref.repo_url.split('/')[0]}
         
         # If directory already exists and has content, remove it
         if target_path.exists() and any(target_path.iterdir()):
-            shutil.rmtree(target_path)
+            _rmtree(target_path)
             target_path.mkdir(parents=True, exist_ok=True)
         
         # Store progress reporter so we can disable it after clone


### PR DESCRIPTION
Replace bare `shutil.rmtree()` with existing `_rmtree()` helper that handles read-only git pack files and Windows file locks. Two code paths in `download_package` and `download_subdirectory_package` were using the raw call instead of the helper that was already defined for this exact purpose.

Fixes `PermissionError: [WinError 5] Access is denied` on `.git/objects/pack/*.idx` files during dependency update on Windows.