### PR TITLE
chore: prepare v0.8.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+## [0.8.2] - 2026-03-18
+
+### Fixed
+
+- Credential fill returning garbage token in tokenless CI environments — broke `apm install` for public repos in GitHub Actions (#356)
+
+### Added
+
+- GH-AW compatibility gate in release pipeline — `gh-aw-compat` job tests tokenless install + pack before publishing (#356)
+- Release validation now includes `test_ghaw_compat` scenario (#356)
+
+
 ## [0.8.1] - 2026-03-17
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apm-cli"
-version = "0.8.1"
+version = "0.8.2"
 description = "MCP configuration tool"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Hotfix release for gh-aw regression.

### Changes
- Version bump: 0.8.1 → 0.8.2
- CHANGELOG.md entry for v0.8.2

### Context
- Fix PR: #356 (already merged)
- This is a version-bump-only PR to enable the tagged release