### PR TITLE
chore: prepare v0.8.3 release (supersedes v0.8.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
-## [0.8.2] - 2026-03-18
+## [0.8.3] - 2026-03-18
 
 ### Fixed
 
 - Credential fill returning garbage token in tokenless CI environments — broke `apm install` for public repos in GitHub Actions (#356)
+- Release validation `test_ghaw_compat` using correct `apm install` syntax (#360)
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apm-cli"
-version = "0.8.2"
+version = "0.8.3"
 description = "MCP configuration tool"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Hotfix release for gh-aw regression. Supersedes v0.8.2 which had a broken test script (tag is protected, cannot be moved).

### Changes
- Version bump: 0.8.2 → 0.8.3
- CHANGELOG.md updated to include #360 test fix

### PRs included in this release
- #356 — fix: credential fill garbage token
- #360 — fix: gh-aw compat test syntax