### PR TITLE
fix: add required name field to ghaw compat test apm.yml

### DIFF
--- a/scripts/test-release-validation.sh
+++ b/scripts/test-release-validation.sh
@@ -362,6 +362,7 @@ test_ghaw_compat() {
         
         # Create a minimal apm.yml like apm-action does in isolated mode
         cat > apm.yml <<'APMYML'
+name: ghaw-compat-test
 dependencies:
   - microsoft/apm-sample-package
 APMYML


### PR DESCRIPTION
One-liner: `apm.yml` requires a `name` field. The `test_ghaw_compat` test was missing it, causing release validation to fail.