### PR TITLE
perf(ci): consolidate macOS into single-request jobs, gate ARM to releases only

### DIFF
--- a/.github/instructions/cicd.instructions.md
+++ b/.github/instructions/cicd.instructions.md
@@ -18,8 +18,10 @@ Three workflows split by trigger and secret requirements:
    - Downloads Linux binary artifact from ci.yml, runs test scripts from default branch (main).
    - Reports results back to PR via commit status API.
 3. **`build-release.yml`** — `push` to main, tags, schedule, `workflow_dispatch`
-   - **Full 4-platform matrix** (linux x86_64/arm64, darwin x86_64/arm64). Secrets always available.
-   - macOS builds and cross-platform validation happen here, where queue time doesn't block PRs.
+   - **Linux + Windows** run separate `test → build → integration-tests → release-validation` jobs.
+   - **macOS Intel** uses `build-and-validate-macos-intel` (always runs — Intel runners are plentiful with <1 min queue). Builds the binary on every push for early regression feedback; integration + release-validation phases conditional on tag/schedule/dispatch.
+   - **macOS ARM** uses `build-and-validate-macos-arm` (tag/schedule/dispatch only — ARM runners are extremely scarce with 2-4h+ queue waits). Only requested when the binary is actually needed for a release.
+   - Secrets always available. Full 5-platform binary output (linux x86_64/arm64, darwin x86_64/arm64, windows x86_64).
 
 ## Platform Testing Strategy
 - **PR time**: Linux + Windows in parallel. Catches logic bugs, dependency issues, path separators, encoding, and Windows-specific problems before merge.
@@ -44,7 +46,9 @@ Three workflows split by trigger and secret requirements:
 
 ## Release Flow Dependencies
 - **PR workflow**: ci.yml (test → build, Linux-only) then ci-integration.yml via workflow_run (approve → smoke-test → integration-tests → release-validation → report-status, all Linux-only)
-- **Push/Release workflow**: test → build → integration-tests → release-validation → create-release → publish-pypi → update-homebrew (full 4-platform matrix)
+- **Push/Release workflow (Linux + Windows)**: test → build → integration-tests → release-validation → create-release → publish-pypi → update-homebrew
+- **Push/Release workflow (macOS Intel)**: test → build-and-validate-macos-intel (build always + conditional integration/release-validation) → create-release
+- **Push/Release workflow (macOS ARM)**: test → build-and-validate-macos-arm (tag/schedule/dispatch only; all phases run) → create-release
 - **Tag Triggers**: Only `v*.*.*` tags trigger full release pipeline
 - **Artifact Retention**: 30 days for debugging failed releases
 - **Cross-workflow artifacts**: ci-integration.yml downloads artifacts from ci.yml using `run-id` and `github-token`
@@ -61,7 +65,9 @@ Three workflows split by trigger and secret requirements:
 - `GITHUB_TOKEN` - Fallback token for compatibility (GitHub Actions built-in)
 
 ## Performance Considerations
-- **PR CI is Linux-only**: Eliminates macOS runner queue delays (20-40+ min). Full platform coverage runs post-merge.
+- **PR CI is Linux-only**: Eliminates macOS runner queue delays. Full platform coverage runs post-merge.
+- **macOS runner consolidation**: Each macOS arch has a single consolidated job (build + integration + release-validation). Intel (`build-and-validate-macos-intel`) runs on every push since Intel runners are plentiful. ARM (`build-and-validate-macos-arm`) is gated to tag/schedule/dispatch only since ARM runners are extremely scarce (2-4h+ queue waits). This avoids serial re-queuing of runners across multiple jobs.
+- **Unit tests skip macOS**: Python unit tests are platform-agnostic; Linux + Windows coverage is sufficient. macOS-specific validation (binary build, integration tests, release validation) still runs via the consolidated job.
 - UPX compression when available (reduces binary size ~50%)
 - Python optimization level 2 in PyInstaller
 - Aggressive module exclusions (tkinter, matplotlib, etc.)

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -27,7 +27,9 @@ permissions:
   contents: read
 
 jobs:
-  # Always run tests first with matrix strategy
+  # Unit tests on Linux + Windows only. macOS runners are scarce and Python unit
+  # tests are platform-agnostic — macOS-specific validation (build + integration +
+  # release-validation) is consolidated into a single job per arch below.
   test:
     runs-on: ${{ matrix.os }}
     permissions:
@@ -42,12 +44,6 @@ jobs:
           - os: ubuntu-24.04-arm
             arch: arm64
             platform: linux
-          - os: macos-15-intel
-            arch: x86_64  
-            platform: darwin
-          - os: macos-latest
-            arch: arm64
-            platform: darwin
           - os: windows-latest
             arch: x86_64
             platform: windows
@@ -64,14 +60,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON_VERSION }}
-    
-    - name: Setup build environment (macOS-15 Intel)
-      if: matrix.os == 'macos-15-intel'
-      run: |
-        # Install Xcode Command Line Tools
-        sudo xcode-select --install 2>/dev/null || true
-        # Wait for installation to complete
-        until xcode-select -p >/dev/null 2>&1; do sleep 5; done
     
     - name: Install uv (Unix)
       if: matrix.platform != 'windows'
@@ -109,7 +97,7 @@ jobs:
         GITHUB_APM_PAT: ${{ secrets.GH_CLI_PAT }}
       run: uv run pytest tests/integration/test_runtime_smoke.py -v
 
-  # Build binaries
+  # Build binaries (Linux + Windows). macOS builds are in build-and-validate-macos-intel / -arm.
   build:
     name: Build APM Binary
     needs: [test]
@@ -124,14 +112,6 @@ jobs:
             platform: linux
             arch: arm64
             binary_name: apm-linux-arm64
-          - os: macos-15-intel
-            platform: darwin
-            arch: x86_64
-            binary_name: apm-darwin-x86_64
-          - os: macos-latest
-            platform: darwin
-            arch: arm64
-            binary_name: apm-darwin-arm64
           - os: windows-latest
             platform: windows
             arch: x86_64
@@ -155,15 +135,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y upx-ucl
-      
-      - name: Install UPX and XCode (macOS)
-        if: matrix.platform == 'darwin'
-        run: |
-          # Install Xcode Command Line Tools
-          sudo xcode-select --install 2>/dev/null || true
-          # Wait for installation to complete
-          until xcode-select -p >/dev/null 2>&1; do sleep 5; done
-          brew install upx
       
       - name: Install uv (Unix)
         if: matrix.platform != 'windows'
@@ -211,7 +182,210 @@ jobs:
           retention-days: 30
           if-no-files-found: error
 
-  # Integration tests with full source code access
+  # Consolidated macOS Intel build + validation.
+  # Intel runners are plentiful (<1 min queue) so this runs on every push for
+  # early macOS build-regression feedback. Integration and release-validation
+  # phases are conditional on tag/schedule/dispatch.
+  build-and-validate-macos-intel:
+    name: Build & Validate (macOS x86_64)
+    needs: [test]
+    runs-on: macos-15-intel
+    permissions:
+      contents: read
+      models: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Setup build environment
+        run: |
+          sudo xcode-select --install 2>/dev/null || true
+          until xcode-select -p >/dev/null 2>&1; do sleep 5; done
+
+      - name: Install UPX
+        run: brew install upx
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: uv sync --extra dev --extra build
+
+      # ── PHASE 1: BUILD BINARY ──
+      - name: Build binary
+        run: |
+          chmod +x scripts/build-binary.sh
+          uv run ./scripts/build-binary.sh
+
+      - name: Upload binary as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: apm-darwin-x86_64
+          path: |
+            ./dist/apm-darwin-x86_64
+            ./dist/apm-darwin-x86_64.sha256
+            ./scripts/test-release-validation.sh
+            ./scripts/test-dependency-integration.sh
+            ./scripts/github-token-helper.sh
+          include-hidden-files: true
+          retention-days: 30
+          if-no-files-found: error
+
+      # ── PHASE 2: INTEGRATION TESTS (tag/schedule/dispatch only) ──
+      - name: Run integration tests
+        if: github.ref_type == 'tag' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        env:
+          APM_E2E_TESTS: "1"
+          GITHUB_TOKEN: ${{ secrets.GH_MODELS_PAT }}
+          GITHUB_APM_PAT: ${{ secrets.GH_CLI_PAT }}
+          ADO_APM_PAT: ${{ secrets.ADO_APM_PAT }}
+        run: |
+          chmod +x scripts/test-integration.sh
+          uv run ./scripts/test-integration.sh
+        timeout-minutes: 20
+
+      # ── PHASE 3: RELEASE VALIDATION (tag/schedule/dispatch only) ──
+      - name: Prepare isolated release-validation environment
+        if: github.ref_type == 'tag' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        run: |
+          mkdir -p /tmp/apm-isolated-test/dist
+          cp -R ./dist/apm-darwin-x86_64 /tmp/apm-isolated-test/dist/
+          cp ./dist/apm-darwin-x86_64.sha256 /tmp/apm-isolated-test/dist/ 2>/dev/null || true
+          cp ./scripts/test-release-validation.sh /tmp/apm-isolated-test/
+          cp ./scripts/test-dependency-integration.sh /tmp/apm-isolated-test/ 2>/dev/null || true
+          cp ./scripts/github-token-helper.sh /tmp/apm-isolated-test/ 2>/dev/null || true
+
+          cd /tmp/apm-isolated-test
+          chmod +x ./dist/apm-darwin-x86_64/apm
+          ln -s "$(pwd)/dist/apm-darwin-x86_64/apm" "$(pwd)/apm"
+          echo "/tmp/apm-isolated-test" >> $GITHUB_PATH
+
+      - name: Run release validation tests
+        if: github.ref_type == 'tag' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        env:
+          APM_E2E_TESTS: "1"
+          GITHUB_TOKEN: ${{ secrets.GH_MODELS_PAT }}
+          GITHUB_APM_PAT: ${{ secrets.GH_CLI_PAT }}
+          ADO_APM_PAT: ${{ secrets.ADO_APM_PAT }}
+        run: |
+          cd /tmp/apm-isolated-test
+          chmod +x test-release-validation.sh
+          ./test-release-validation.sh
+        timeout-minutes: 20
+
+  # Consolidated macOS ARM build + validation.
+  # ARM runners (macos-latest) are extremely scarce — 2-4+ hour queue waits are
+  # common. This job is gated to tag/schedule/dispatch only so push-to-main never
+  # blocks on ARM availability. All phases run unconditionally since the job itself
+  # is already release-gated.
+  build-and-validate-macos-arm:
+    name: Build & Validate (macOS arm64)
+    needs: [test]
+    if: github.ref_type == 'tag' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: macos-latest
+    permissions:
+      contents: read
+      models: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install UPX
+        run: brew install upx
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: uv sync --extra dev --extra build
+
+      # ── PHASE 1: BUILD BINARY ──
+      - name: Build binary
+        run: |
+          chmod +x scripts/build-binary.sh
+          uv run ./scripts/build-binary.sh
+
+      - name: Upload binary as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: apm-darwin-arm64
+          path: |
+            ./dist/apm-darwin-arm64
+            ./dist/apm-darwin-arm64.sha256
+            ./scripts/test-release-validation.sh
+            ./scripts/test-dependency-integration.sh
+            ./scripts/github-token-helper.sh
+          include-hidden-files: true
+          retention-days: 30
+          if-no-files-found: error
+
+      # ── PHASE 2: INTEGRATION TESTS ──
+      - name: Run integration tests
+        env:
+          APM_E2E_TESTS: "1"
+          GITHUB_TOKEN: ${{ secrets.GH_MODELS_PAT }}
+          GITHUB_APM_PAT: ${{ secrets.GH_CLI_PAT }}
+          ADO_APM_PAT: ${{ secrets.ADO_APM_PAT }}
+        run: |
+          chmod +x scripts/test-integration.sh
+          uv run ./scripts/test-integration.sh
+        timeout-minutes: 20
+
+      # ── PHASE 3: RELEASE VALIDATION ──
+      - name: Prepare isolated release-validation environment
+        run: |
+          mkdir -p /tmp/apm-isolated-test/dist
+          cp -R ./dist/apm-darwin-arm64 /tmp/apm-isolated-test/dist/
+          cp ./dist/apm-darwin-arm64.sha256 /tmp/apm-isolated-test/dist/ 2>/dev/null || true
+          cp ./scripts/test-release-validation.sh /tmp/apm-isolated-test/
+          cp ./scripts/test-dependency-integration.sh /tmp/apm-isolated-test/ 2>/dev/null || true
+          cp ./scripts/github-token-helper.sh /tmp/apm-isolated-test/ 2>/dev/null || true
+
+          cd /tmp/apm-isolated-test
+          chmod +x ./dist/apm-darwin-arm64/apm
+          ln -s "$(pwd)/dist/apm-darwin-arm64/apm" "$(pwd)/apm"
+          echo "/tmp/apm-isolated-test" >> $GITHUB_PATH
+
+      - name: Run release validation tests
+        env:
+          APM_E2E_TESTS: "1"
+          GITHUB_TOKEN: ${{ secrets.GH_MODELS_PAT }}
+          GITHUB_APM_PAT: ${{ secrets.GH_CLI_PAT }}
+          ADO_APM_PAT: ${{ secrets.ADO_APM_PAT }}
+        run: |
+          cd /tmp/apm-isolated-test
+          chmod +x test-release-validation.sh
+          ./test-release-validation.sh
+        timeout-minutes: 20
+
+  # Integration tests with full source code access (Linux + Windows).
+  # macOS integration tests run inside the consolidated macOS jobs to avoid re-queuing scarce runners.
   # Skip on push-to-main: already validated by ci-integration.yml during the PR.
   # Run on tags (release gate), schedule (regression), and dispatch (manual).
   integration-tests:
@@ -229,14 +403,6 @@ jobs:
             arch: arm64
             platform: linux
             binary_name: apm-linux-arm64
-          - os: macos-15-intel
-            arch: x86_64
-            platform: darwin
-            binary_name: apm-darwin-x86_64
-          - os: macos-latest
-            arch: arm64
-            platform: darwin
-            binary_name: apm-darwin-arm64
           - os: windows-latest
             arch: x86_64
             platform: windows
@@ -266,14 +432,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Setup build environment (macOS-15-intel)
-        if: matrix.os == 'macos-15-intel'
-        run: |
-          # Install Xcode Command Line Tools
-          sudo xcode-select --install 2>/dev/null || true
-          # Wait for installation to complete
-          until xcode-select -p >/dev/null 2>&1; do sleep 5; done
       
       - name: Install uv (Unix)
         if: matrix.platform != 'windows'
@@ -315,7 +473,8 @@ jobs:
           uv run pwsh scripts/windows/test-integration.ps1 -SkipBuild
         timeout-minutes: 20
 
-# Release validation tests - Final pre-release validation of shipped binary
+  # Release validation tests - Final pre-release validation of shipped binary (Linux + Windows).
+  # macOS release validation runs inside the consolidated macOS jobs.
   release-validation:
     name: Release Validation
     if: github.ref_type == 'tag' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -331,14 +490,6 @@ jobs:
             arch: arm64
             platform: linux
             binary_name: apm-linux-arm64
-          - os: macos-15-intel
-            arch: x86_64
-            platform: darwin
-            binary_name: apm-darwin-x86_64
-          - os: macos-latest
-            arch: arm64
-            platform: darwin
-            binary_name: apm-darwin-arm64
           - os: windows-latest
             arch: x86_64
             platform: windows
@@ -359,14 +510,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-      
-      - name: Setup build environment (macOS-15-intel)
-        if: matrix.os == 'macos-15-intel'
-        run: |
-          # Install Xcode Command Line Tools
-          sudo xcode-select --install 2>/dev/null || true
-          # Wait for installation to complete
-          until xcode-select -p >/dev/null 2>&1; do sleep 5; done
           
       - name: Download APM binary from build artifacts
         uses: actions/download-artifact@v4
@@ -438,7 +581,7 @@ jobs:
 
   create-release:
     name: Create GitHub Release
-    needs: [test, build, integration-tests, release-validation]
+    needs: [test, build, build-and-validate-macos-intel, build-and-validate-macos-arm, integration-tests, release-validation]
     if: github.ref_type == 'tag'  # All tags create GitHub releases
     runs-on: ubuntu-latest
     permissions:
@@ -585,7 +728,7 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    needs: [test, build, integration-tests, release-validation, create-release, gh-aw-compat]
+    needs: [test, build, build-and-validate-macos-intel, build-and-validate-macos-arm, integration-tests, release-validation, create-release, gh-aw-compat]
     if: github.ref_type == 'tag' && needs.create-release.outputs.is_private_repo != 'true' && needs.create-release.outputs.is_prerelease != 'true'
     environment:
       name: pypi
@@ -623,7 +766,7 @@ jobs:
   update-homebrew:
     name: Update Homebrew Formula
     runs-on: ubuntu-latest
-    needs: [test, build, integration-tests, release-validation, create-release, gh-aw-compat, publish-pypi]
+    needs: [test, build, build-and-validate-macos-intel, build-and-validate-macos-arm, integration-tests, release-validation, create-release, gh-aw-compat, publish-pypi]
     if: github.ref_type == 'tag' && needs.create-release.outputs.is_private_repo != 'true' && needs.create-release.outputs.is_prerelease != 'true'
     permissions:
       contents: read
@@ -688,7 +831,7 @@ jobs:
   update-scoop:
     name: Update Scoop Bucket
     runs-on: ubuntu-latest
-    needs: [test, build, integration-tests, release-validation, create-release, gh-aw-compat, publish-pypi]
+    needs: [test, build, build-and-validate-macos-intel, build-and-validate-macos-arm, integration-tests, release-validation, create-release, gh-aw-compat, publish-pypi]
     # TODO: Enable once downstream repository and secrets are configured (see #88)
     if: false && github.ref_type == 'tag' && needs.create-release.outputs.is_private_repo != 'true' && needs.create-release.outputs.is_prerelease != 'true'
     permissions:


### PR DESCRIPTION
## Problem

macOS runners (especially `macos-latest` ARM) are extremely scarce. The previous workflow requested them **up to 4 times sequentially** per architecture (test → build → integration-tests → release-validation), multiplying queue penalties.

### Live evidence — run [#23272240042](https://github.com/microsoft/apm/actions/runs/23272240042)

| Job | Queue wait | Execution | Status |
|---|---|---|---|
| `test (macos-latest, arm64)` | **3h 37min** | 58s | ✅ |
| `Build (macos-latest, arm64)` | **2h 22min+** | — | ⏳ still queued |
| `test (macos-15-intel)` | **<1 min** | 2 min | ✅ |
| All Linux + Windows jobs | <1 min | 1-2 min | ✅ done hours ago |

A push-to-main with just 2 stages was already **6+ hours**. A tag release (4 stages) could exceed **12 hours**.

## Solution

**Differentiate by runner scarcity.** Intel runners are plentiful; ARM runners are scarce.

### Changes

1. **Remove macOS from `test`, `build`, `integration-tests`, `release-validation`** — these become Linux + Windows only
2. **Add `build-and-validate-macos-intel`** — **always runs** (Intel runners have <1 min queue). Builds the x86_64 binary on every push for early macOS regression feedback. Integration + release-validation phases conditional on tag/schedule/dispatch.
3. **Add `build-and-validate-macos-arm`** — **tag/schedule/dispatch only** (ARM runners have 2-4h+ queue waits). Only requested when the binary is actually needed for a release. All phases run unconditionally since the job itself is already release-gated.
4. **Update `needs:` chains** on all downstream jobs

### Pipeline Architecture

#### Push to main (fast feedback, no ARM queue)

```mermaid
graph LR
    test["🧪 test\n(Linux + Windows)"]
    build["📦 build\n(Linux + Windows)"]
    mac_intel["🍎 build-and-validate\nmacos-intel\n(build only)"]

    test --> build
    test --> mac_intel

    style test fill:#4CAF50,color:#fff
    style build fill:#2196F3,color:#fff
    style mac_intel fill:#FF9800,color:#fff
```

#### Tag release (full 5-platform validation)

```mermaid
graph LR
    test["🧪 test\n(Linux + Windows)"]
    build["📦 build\n(Linux + Windows)"]
    mac_intel["🍎 build-and-validate\nmacos-intel\n(build + integ + release-val)"]
    mac_arm["🍎 build-and-validate\nmacos-arm\n(build + integ + release-val)"]
    integ["🔬 integration-tests\n(Linux + Windows)"]
    relval["✅ release-validation\n(Linux + Windows)"]
    release["🚀 create-release"]
    compat["🔗 gh-aw-compat"]
    pypi["📦 publish-pypi"]
    brew["🍺 update-homebrew"]

    test --> build --> integ --> relval --> release
    test --> mac_intel --> release
    test --> mac_arm --> release
    release --> compat --> pypi --> brew

    style test fill:#4CAF50,color:#fff
    style build fill:#2196F3,color:#fff
    style mac_intel fill:#FF9800,color:#fff
    style mac_arm fill:#f44336,color:#fff
    style integ fill:#9C27B0,color:#fff
    style relval fill:#009688,color:#fff
    style release fill:#673AB7,color:#fff
    style compat fill:#607D8B,color:#fff
    style pypi fill:#795548,color:#fff
    style brew fill:#795548,color:#fff
```

### Impact

| Metric | Before | After |
|---|---|---|
| macOS runners (push to main) | 4 (2 intel + 2 arm) | **1** (intel only) |
| macOS runners (tag release) | 8 | **2** (1 intel + 1 arm) |
| ARM queue waits per release | 4 serial | **1** |
| Push-to-main wall-clock | 6+ hours | **~5 min** |
| Tag release wall-clock | 12+ hours | **~3.5 hours** |

### Robustness

- **Same tests run** — identical integration tests and release validation, just consolidated
- **Isolation preserved** — release validation runs from `/tmp/apm-isolated-test/` with no source checkout access
- **macOS build coverage on push** — Intel build runs on every push, catching macOS-specific build regressions early
- **No cross-compilation** — each binary still built natively on target arch