### PR TITLE
[docs] Update compilation guide — add opencode target, fix vscode alias

### DIFF
--- a/docs/src/content/docs/guides/compilation.md
+++ b/docs/src/content/docs/guides/compilation.md
@@ -20,34 +20,37 @@ When you run `apm compile` without specifying a target, APM automatically detect
 
 | Project Structure | Target | What Gets Generated |
 |-------------------|--------|---------------------|
-| `.github/` folder only | `copilot` | AGENTS.md (instructions only) |
-| `.claude/` folder only | `claude` | CLAUDE.md (instructions only) |
-| Both folders exist | `all` | Both AGENTS.md and CLAUDE.md |
-| Neither folder exists | `minimal` | AGENTS.md only (universal format) |
+| `.github/` folder only | `vscode` | AGENTS.md + .github/ |
+| `.claude/` folder only | `claude` | CLAUDE.md + .claude/ |
+| `.opencode/` folder only | `opencode` | AGENTS.md + .opencode/ |
+| Multiple target folders | `all` | All outputs |
+| No target folders | `minimal` | AGENTS.md only (universal format) |
 
 ```bash
 apm compile                    # Auto-detects target from project structure
-apm compile --target copilot   # Force GitHub Copilot, Cursor, Codex, Gemini
+apm compile --target vscode    # Force GitHub Copilot, Cursor, Codex, Gemini
 apm compile --target claude    # Force Claude Code, Claude Desktop
+apm compile --target opencode  # Force OpenCode
 ```
 
 You can set a persistent target in `apm.yml`:
 ```yaml
 name: my-project
 version: 1.0.0
-target: copilot  # or vscode, claude, or all
+target: vscode  # or claude, opencode, or all
 ```
 
 ### Output Files
 
 | Target | Files Generated | Consumers |
 |--------|-----------------|-----------|
-| `copilot` | `AGENTS.md` | GitHub Copilot, Cursor, OpenCode, Codex, Gemini |
-| `claude` | `CLAUDE.md` | Claude Code, Claude Desktop |
-| `all` | Both `AGENTS.md` and `CLAUDE.md` | Universal compatibility |
+| `vscode` | `AGENTS.md` + `.github/` | GitHub Copilot, Cursor, Codex, Gemini |
+| `claude` | `CLAUDE.md` + `.claude/` | Claude Code, Claude Desktop |
+| `opencode` | `AGENTS.md` + `.opencode/` | OpenCode |
+| `all` | `AGENTS.md` + `CLAUDE.md` + all folders | Universal compatibility |
 | `minimal` | `AGENTS.md` only | Works everywhere, no folder integration |
 
-> **Aliases**: `vscode` and `agents` are accepted as aliases for `copilot`.
+> **Aliases**: `agents` is accepted as an alias for `vscode`. `copilot` is also accepted in `apm.yml` but is not a valid `--target` flag value.
 
 > **Note**: `AGENTS.md` and `CLAUDE.md` contain **only instructions** (grouped by `applyTo` patterns). Prompts, agents, commands, hooks, and skills are integrated by `apm install`, not `apm compile`. See the [Integrations Guide](../../integrations/ide-tool-integration/) for details on how `apm install` populates `.github/prompts/`, `.github/agents/`, `.github/skills/`, `.claude/commands/`, `.cursor/rules/`, `.cursor/agents/`, `.opencode/agents/`, and `.opencode/commands/`.
 


### PR DESCRIPTION
## Documentation Updates - 2026-03-20

This PR updates the compilation guide based on recent code changes merged in the last 24 hours (#231/#232 refactoring, with CHANGELOG [Unreleased] noting the docs gap for #366).

### Features Documented

- `apm compile --target opencode` option (from #306 OpenCode integration, gap noted in [Unreleased] #366)
- Correct `--target vscode` flag name (replacing incorrect `copilot` alias which is only valid in `apm.yml`, not as a CLI flag)

### Changes Made

Updated `docs/src/content/docs/guides/compilation.md`:

1. **Auto-detection table** — replaced `copilot` target label with `vscode`, added `.opencode/` folder row, updated "both folders" to "multiple target folders" to be inclusive
2. **Quick-start examples** — changed `--target copilot` to `--target vscode`, added `--target opencode` example
3. **`apm.yml` example** — changed `target: copilot` to `target: vscode` for consistency with CLI flag values
4. **Output files table** — replaced `copilot` row with `vscode`, added `opencode` row with its generated files
5. **Aliases note** — corrected to: "`agents` is an alias for `vscode`; `copilot` is accepted in `apm.yml` but not as a `--target` flag value"

### Root Cause

The compilation guide was written using `copilot` as the target name, but the CLI's `click.Choice` only accepts `["vscode", "agents", "claude", "opencode", "all"]`. `copilot` is handled internally by `target_detection.py` for `apm.yml` config but was never a valid `--target` flag. The OpenCode target was also not shown in the guide.

### Merged PRs Referenced

- #231/#232 — Internal refactoring that introduced this codebase snapshot
- The gap for `--target opencode` documentation was tracked in CHANGELOG [Unreleased] for #366

### Notes

The `apm audit --dry-run` wording and `apm audit --drift` planned-feature notice in `enterprise/governance.md` were already correctly documented and required no changes.




> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/23327796101) · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+is%3Apr+%22gh-aw-workflow-id%3A+daily-doc-updater%22+in%3Abody)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-03-22T03:38:36.780Z --> on Mar 22, 2026, 3:38 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, id: 23327796101, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/23327796101 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->