### PR TITLE
fix: write UTF-8 characters in apm.yml instead of escaped `\xNN` sequences

### DIFF
--- a/src/apm_cli/commands/_helpers.py
+++ b/src/apm_cli/commands/_helpers.py
@@ -457,5 +457,5 @@ def _create_minimal_apm_yml(config, plugin=False):
     apm_yml_data["scripts"] = {}
 
     # Write apm.yml
-    with open(APM_YML_FILENAME, "w") as f:
-        yaml.safe_dump(apm_yml_data, f, default_flow_style=False, sort_keys=False)
+    with open(APM_YML_FILENAME, "w", encoding="utf-8") as f:
+        yaml.safe_dump(apm_yml_data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -200,8 +200,8 @@ def _validate_and_add_packages_to_apm_yml(packages, dry_run=False, dev=False, lo
 
     # Write back to apm.yml
     try:
-        with open(apm_yml_path, "w") as f:
-            yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
+        with open(apm_yml_path, "w", encoding="utf-8") as f:
+            yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
         if logger:
             logger.success(f"Updated {APM_YML_FILENAME} with {len(validated_packages)} new package(s)")
     except Exception as e:
@@ -2102,7 +2102,3 @@ def _install_apm_dependencies(
 
     except Exception as e:
         raise RuntimeError(f"Failed to resolve APM dependencies: {e}")
-
-
-
-

--- a/src/apm_cli/commands/uninstall/cli.py
+++ b/src/apm_cli/commands/uninstall/cli.py
@@ -88,8 +88,8 @@ def uninstall(ctx, packages, dry_run, verbose):
             logger.progress(f"Removed {package} from apm.yml")
         data["dependencies"]["apm"] = current_deps
         try:
-            with open(apm_yml_path, "w") as f:
-                yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
+            with open(apm_yml_path, "w", encoding="utf-8") as f:
+                yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
             logger.success(f"Updated {APM_YML_FILENAME} (removed {len(packages_to_remove)} package(s))")
         except Exception as e:
             logger.error(f"Failed to write {APM_YML_FILENAME}: {e}")

--- a/src/apm_cli/core/script_runner.py
+++ b/src/apm_cli/core/script_runner.py
@@ -822,8 +822,8 @@ class ScriptRunner:
             config["dependencies"]["apm"].append(package_ref)
 
             # Write back to file
-            with open(config_path, "w") as f:
-                yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+            with open(config_path, "w", encoding="utf-8") as f:
+                yaml.dump(config, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
 
             print(f"  [i]  Added {package_ref} to apm.yml dependencies")
 
@@ -838,8 +838,8 @@ class ScriptRunner:
             "description": "Auto-generated for zero-config virtual package execution",
         }
 
-        with open("apm.yml", "w") as f:
-            yaml.dump(minimal_config, f, default_flow_style=False, sort_keys=False)
+        with open("apm.yml", "w", encoding="utf-8") as f:
+            yaml.dump(minimal_config, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
 
         print(f"  [i]  Created minimal apm.yml for zero-config execution")
 

--- a/src/apm_cli/deps/github_downloader.py
+++ b/src/apm_cli/deps/github_downloader.py
@@ -1238,7 +1238,7 @@ class GitHubPackageDownloader:
         
         # Create target directory structure
         target_path.mkdir(parents=True, exist_ok=True)
-        
+
         # Determine the subdirectory based on file extension
         subdirs = {
             '.prompt.md': 'prompts',
@@ -1683,7 +1683,7 @@ author: {dep_ref.repo_url.split('/')[0]}
                     _data = _yaml.safe_load(_f) or {}
                 _data["version"] = short_sha
                 with open(apm_yml_path, "w", encoding="utf-8") as _f:
-                    _yaml.dump(_data, _f, default_flow_style=False, sort_keys=False)
+                    _yaml.dump(_data, _f, default_flow_style=False, sort_keys=False, allow_unicode=True)
         
         # Update progress - complete
         if progress_obj and progress_task_id is not None:
@@ -1991,7 +1991,7 @@ author: {dep_ref.repo_url.split('/')[0]}
                     _data = _yaml.safe_load(_f) or {}
                 _data["version"] = short_sha
                 with open(apm_yml_path, "w", encoding="utf-8") as _f:
-                    _yaml.dump(_data, _f, default_flow_style=False, sort_keys=False)
+                    _yaml.dump(_data, _f, default_flow_style=False, sort_keys=False, allow_unicode=True)
         
         # Create and return PackageInfo
         return PackageInfo(

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -282,6 +282,38 @@ class TestInitCommand:
             finally:
                 os.chdir(self.original_dir)  # restore CWD before TemporaryDirectory cleanup
 
+
+    def test_init_unicode_author(self):
+        """Test that non-ASCII author names are written as UTF-8, not escaped."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.chdir(tmp_dir)
+            try:
+
+                import subprocess
+
+                subprocess.run(["git", "init"], capture_output=True, check=True)
+                subprocess.run(
+                    ["git", "config", "user.name", "Pepe Rodríguez"],
+                    capture_output=True,
+                    check=True,
+                )
+
+                result = self.runner.invoke(cli, ["init", "--yes"])
+
+                assert result.exit_code == 0
+
+                # Verify parsed value
+                with open("apm.yml", encoding="utf-8") as f:
+                    config = yaml.safe_load(f)
+                    assert config["author"] == "Pepe Rodríguez"
+
+                # Verify raw file contains actual UTF-8, not escaped sequences
+                raw = Path("apm.yml").read_text(encoding="utf-8")
+                assert "Rodríguez" in raw
+                assert "\\x" not in raw
+            finally:
+                os.chdir(self.original_dir)  # restore CWD before TemporaryDirectory cleanup
+
     def test_init_does_not_create_skill_md(self):
         """Test that init does not create SKILL.md (only apm.yml)."""
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/unit/test_install_command.py
+++ b/tests/unit/test_install_command.py
@@ -489,3 +489,53 @@ class TestTransitiveDepParentChain:
         assert ">" in chain, (
             f"Expected '>' separator in chain, got: '{chain}'"
         )
+
+    @patch("apm_cli.commands.install._validate_package_exists")
+    @patch("apm_cli.commands.install.APM_DEPS_AVAILABLE", True)
+    @patch("apm_cli.commands.install.APMPackage")
+    @patch("apm_cli.commands.install._install_apm_dependencies")
+    def test_install_preserves_unicode_author_on_rewrite(
+        self, mock_install_apm, mock_apm_package, mock_validate
+    ):
+        """Test that install round-trip preserves non-ASCII author as UTF-8."""
+        with self._chdir_tmp():
+            # Create apm.yml with non-ASCII author
+            initial_config = {
+                "name": "test-project",
+                "version": "0.1.0",
+                "author": "Alejandro López Sánchez",
+                "dependencies": {"apm": []},
+            }
+            with open("apm.yml", "w", encoding="utf-8") as f:
+                yaml.safe_dump(
+                    initial_config, f, default_flow_style=False,
+                    sort_keys=False, allow_unicode=True,
+                )
+
+            mock_validate.return_value = True
+
+            mock_pkg_instance = MagicMock()
+            mock_pkg_instance.get_apm_dependencies.return_value = [
+                MagicMock(repo_url="test/package", reference="main")
+            ]
+            mock_pkg_instance.get_mcp_dependencies.return_value = []
+            mock_apm_package.from_apm_yml.return_value = mock_pkg_instance
+
+            mock_install_apm.return_value = InstallResult(
+                diagnostics=MagicMock(
+                    has_diagnostics=False, has_critical_security=False
+                )
+            )
+
+            result = self.runner.invoke(cli, ["install", "test/package"])
+            assert result.exit_code == 0
+
+            # Verify parsed value preserves Unicode
+            with open("apm.yml", encoding="utf-8") as f:
+                config = yaml.safe_load(f)
+                assert config["author"] == "Alejandro López Sánchez"
+
+            # Verify raw file contains actual UTF-8, not escaped sequences
+            raw = Path("apm.yml").read_text(encoding="utf-8")
+            assert "López" in raw
+            assert "\\x" not in raw


### PR DESCRIPTION
## Description

PyYAML defaults to `allow_unicode=False`, which escapes non-ASCII characters (e.g. "López" → "L\xF3pez") regardless of file encoding. Add `allow_unicode=True` to all yaml.dump/safe_dump calls that write apm.yml files.

Fixes #387 387

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)
