### PR TITLE
fix: script runner misidentifies 'codex' in model names as the codex runtime binary

### DIFF
--- a/src/apm_cli/core/script_runner.py
+++ b/src/apm_cli/core/script_runner.py
@@ -343,7 +343,7 @@ class ScriptRunner:
         # Handle individual runtime patterns without environment variables
 
         # Handle "codex [args] file.prompt.md [more_args]" -> "codex exec [args] [more_args]"
-        if re.search(r"codex\s+.*" + re.escape(prompt_file), command):
+        if re.search(r"(^|\s)codex\s+.*" + re.escape(prompt_file), command):
             match = re.search(
                 r"codex\s+(.*?)(" + re.escape(prompt_file) + r")(.*?)$", command
             )

--- a/tests/unit/test_script_runner.py
+++ b/tests/unit/test_script_runner.py
@@ -114,7 +114,15 @@ class TestScriptRunner:
             original, "hello-world.prompt.md", self.compiled_content, self.compiled_path
         )
         assert result == "copilot --log-level all"
-    
+
+    def test_transform_runtime_command_copilot_with_codex_in_model_name(self):
+        """Test copilot command with --model flag containing 'codex' substring is not misidentified."""
+        original = "copilot --allow-all-tools --model gpt-5.3-codex -p hello-world.prompt.md"
+        result = self.script_runner._transform_runtime_command(
+            original, "hello-world.prompt.md", self.compiled_content, self.compiled_path
+        )
+        assert result == "copilot --allow-all-tools --model gpt-5.3-codex"
+
     def test_detect_runtime_copilot(self):
         """Test runtime detection for copilot commands."""
         assert self.script_runner._detect_runtime("copilot --log-level all") == "copilot"


### PR DESCRIPTION
Closes #396

## Summary

- Anchors the `codex` regex in `_transform_runtime_command` with `(^|\s)` so it only matches `codex` as a standalone command token, not as a substring of flag values like `--model gpt-5.3-codex`
- Adds a regression test covering the exact scenario from the issue: `copilot --allow-all-tools --model gpt-5.3-codex -p fix-issue.prompt.md`

## Test plan

- [ ] New unit test `test_transform_runtime_command_copilot_with_codex_in_model_name` passes
- [ ] Existing unit tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)