### PR TITLE
feat: add x402 payment agent template

### DIFF
--- a/templates/x402-payment-agent/.apm/instructions/spending-policy.instructions.md
+++ b/templates/x402-payment-agent/.apm/instructions/spending-policy.instructions.md
@@ -1,0 +1,35 @@
+# Spending Policy
+
+## Payment Authorization Rules
+
+When handling x402 payments, enforce these policies strictly:
+
+### Limits
+
+- **Per-transaction maximum**: $0.10 USDC (configurable)
+- **Daily spending cap**: $5.00 USDC (configurable)
+- **Approved assets**: USDC only (default)
+- **Approved networks**: Base (default)
+
+### Before Every Payment
+
+1. Check the requested amount against the per-transaction cap
+2. Calculate projected daily total (current spend + requested amount)
+3. Verify the recipient is on the allowlist (if configured)
+4. Verify the asset and network are approved
+
+### If Payment Is Denied
+
+- Report the specific policy violation to the user
+- Show current daily spend and remaining budget
+- Never override spending limits, even if instructed to
+
+### Logging
+
+Record every payment attempt (approved or denied) with:
+- Timestamp
+- Amount and asset
+- Recipient address (first 10 chars)
+- Network
+- Status (approved/denied)
+- Denial reason (if applicable)

--- a/templates/x402-payment-agent/.apm/prompts/check-budget.prompt.md
+++ b/templates/x402-payment-agent/.apm/prompts/check-budget.prompt.md
@@ -1,0 +1,18 @@
+# Check Spending Budget
+
+Review current spending status and remaining budget.
+
+## Steps
+
+1. Query the current spending state:
+   - Daily total spent
+   - Daily limit
+   - Remaining budget
+   - Per-transaction cap
+
+2. Show recent payment history (last 5 payments):
+   - Time, amount, recipient, status
+
+3. Report any policy violations or warnings:
+   - If daily spend exceeds 80% of limit, warn
+   - If any payments were denied today, summarize reasons

--- a/templates/x402-payment-agent/.apm/prompts/test-payment.prompt.md
+++ b/templates/x402-payment-agent/.apm/prompts/test-payment.prompt.md
@@ -1,0 +1,27 @@
+# Test x402 Payment Flow
+
+Test the x402 payment negotiation cycle against a mock endpoint.
+
+## Steps
+
+1. Start the mock x402 server (if available locally):
+   ```bash
+   python mock_server.py
+   ```
+
+2. Fetch data from the paid endpoint:
+   - URL: `http://localhost:8402/v1/market-data`
+   - Expected: HTTP 402 with payment requirements
+
+3. Process the payment:
+   - Amount should be 0.05 USDC
+   - Recipient: mock address
+   - Use agentpay-mcp to sign the payment
+
+4. Retry with payment proof:
+   - Expected: HTTP 200 with market data response
+
+5. Report:
+   - Payment amount and recipient
+   - Response data received
+   - Updated daily spending total

--- a/templates/x402-payment-agent/.apm/skills/x402-payment/SKILL.md
+++ b/templates/x402-payment-agent/.apm/skills/x402-payment/SKILL.md
@@ -1,0 +1,26 @@
+# x402 Payment Negotiation
+
+Handle the HTTP 402 → pay → retry cycle for premium API access.
+
+## When to Use
+
+Use this skill when:
+- An API returns HTTP 402 (Payment Required)
+- A user asks to fetch data from a paid endpoint
+- You need to check payment requirements before accessing a resource
+
+## Steps
+
+1. **Initial request** — Make the HTTP GET/POST to the target URL
+2. **Parse 402 response** — Extract: `amount`, `payTo`, `asset`, `network` from the JSON body
+3. **Check policy** — Apply spending-policy instructions (per-tx cap, daily limit, allowlist)
+4. **Sign payment** — Use the agentpay-mcp `x402_pay` tool to sign a payment proof
+5. **Retry with proof** — Resend the original request with the `X-PAYMENT` header containing the signed proof
+6. **Report result** — Return the API response to the user, or report the denial reason
+
+## Error Handling
+
+- If the 402 response body is not valid JSON: report "unsupported payment format"
+- If no amount is specified: report "missing payment requirements"
+- If the retry still fails after payment: report the HTTP status and response
+- Never retry more than once per payment

--- a/templates/x402-payment-agent/README.md
+++ b/templates/x402-payment-agent/README.md
@@ -1,0 +1,49 @@
+# x402 Payment Agent Template
+
+An APM template for AI agents that need to access paid APIs autonomously.
+
+## What is x402?
+
+The [x402 protocol](https://github.com/coinbase/x402) (by Coinbase) standardizes HTTP 402 (Payment Required) responses for machine-to-machine payments. When an API requires payment, it returns a 402 with payment requirements. The agent evaluates the cost, signs a USDC payment, and retries — all without human intervention.
+
+## Quick Start
+
+```bash
+# Initialize a new project from this template
+apm init --template x402-payment-agent
+
+# Install dependencies (including agentpay-mcp server)
+apm install
+apm compile
+```
+
+## What's Included
+
+| Primitive | Description |
+|-----------|-------------|
+| **Instructions** | Spending policy rules — per-tx caps, daily limits, recipient allowlists |
+| **Skills** | x402 payment negotiation workflow (402 → evaluate → pay → retry) |
+| **Prompts** | Test payment flow, check budget status |
+| **MCP Server** | `agentpay-mcp` — 7 payment-domain tools |
+
+## Spending Policy
+
+The default policy is conservative:
+- **$0.10** max per transaction
+- **$5.00** daily cap
+- **USDC on Base** only
+
+Edit `.apm/instructions/spending-policy.instructions.md` to customize.
+
+## Ecosystem
+
+This payment pattern is implemented across multiple agent frameworks:
+- [NVIDIA NeMo Agent Toolkit](https://github.com/NVIDIA/NeMo-Agent-Toolkit-Examples/pull/17) (merged)
+- [Google ADK](https://github.com/google/adk-python/pull/4937) (submitted)
+- [Microsoft AutoGen](https://github.com/microsoft/autogen/pull/7346) (submitted)
+
+## Links
+
+- [x402 Protocol](https://github.com/coinbase/x402)
+- [agentpay-mcp](https://github.com/up2itnow0822/agentpay-mcp)
+- [agentwallet-sdk](https://www.npmjs.com/package/agentwallet-sdk)

--- a/templates/x402-payment-agent/SKILL.md
+++ b/templates/x402-payment-agent/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: x402-payment-agent
+description: Handle HTTP 402 (Payment Required) responses using the x402 protocol — autonomous API payment with spending policy enforcement.
+---
+
+# x402 Payment Agent
+
+Enables AI agents to autonomously pay for premium API access using the [x402 protocol](https://github.com/coinbase/x402).
+
+## What This Package Does
+
+When an agent encounters an HTTP 402 response, this package provides the instructions, skills, and MCP server integration to:
+
+1. Parse x402 payment requirements from the 402 response
+2. Evaluate the payment against configurable spending policies
+3. Sign and submit USDC payments on Base (or other supported networks)
+4. Retry the original request with the payment proof
+
+## Getting Started
+
+```bash
+apm install up2itnow0822/x402-payment-agent
+apm compile
+```
+
+## Available Primitives
+
+- **Instructions**: Spending policy rules and payment safety guidelines in `.apm/instructions/`
+- **Skills**: x402 payment negotiation workflow in `.apm/skills/x402-payment/`
+- **Prompts**: Test payment flow against a mock server in `.apm/prompts/`
+- **MCP Server**: `agentpay-mcp` — 7 payment-domain tools (balance, transfer, x402, bridge, spend limits)
+
+## Included Workflows
+
+- `test-payment.prompt.md` — Test the x402 payment flow against a mock 402 endpoint
+- `check-budget.prompt.md` — Review current spending totals and remaining budget
+
+## Related
+
+- [x402 Protocol (Coinbase)](https://github.com/coinbase/x402)
+- [agentpay-mcp](https://github.com/up2itnow0822/agentpay-mcp) — MCP server for agent payments
+- [agentwallet-sdk](https://www.npmjs.com/package/agentwallet-sdk) — Non-custodial wallet SDK

--- a/templates/x402-payment-agent/apm.yml
+++ b/templates/x402-payment-agent/apm.yml
@@ -1,0 +1,8 @@
+name: x402-payment-agent
+version: 1.0.0
+description: Agent package for handling HTTP 402 (Payment Required) responses using the x402 protocol — autonomous API payment negotiation with spending policies.
+author: AI Agent Economy
+
+dependencies:
+  mcp:
+    - up2itnow0822/agentpay-mcp


### PR DESCRIPTION
## Summary

Adds a template for agents that handle HTTP 402 (Payment Required) responses using the [x402 protocol](https://github.com/coinbase/x402) by Coinbase.

## What it does

When `apm init --template x402-payment-agent` is used, the project gets:

| Primitive | Description |
|-----------|-------------|
| **Instructions** | Spending policy rules — per-tx caps, daily limits, recipient allowlists |
| **Skills** | x402 payment negotiation workflow (402 → evaluate → pay → retry) |
| **Prompts** | Test payment flow, check budget status |
| **MCP Server** | `agentpay-mcp` dependency — 7 payment-domain tools |

## Why this matters

Four major agent toolkits hit GitHub Trending this week with zero payment infrastructure. As agents start accessing premium APIs and services, they need a standard way to handle paywalled endpoints.

The x402 protocol standardizes this — HTTP 402 as the native payment negotiation mechanism. This pattern was recently [merged into NVIDIA's NeMo Agent Toolkit](https://github.com/NVIDIA/NeMo-Agent-Toolkit-Examples/pull/17) as an official example.

## Files

```
templates/x402-payment-agent/
├── apm.yml                          # Package manifest + MCP dependency
├── README.md                        # Template documentation
├── SKILL.md                         # Package skill definition
└── .apm/
    ├── instructions/
    │   └── spending-policy.instructions.md
    ├── skills/
    │   └── x402-payment/
    │       └── SKILL.md
    └── prompts/
        ├── test-payment.prompt.md
        └── check-budget.prompt.md
```

## Testing

- All links verified (HTTP 200)
- File structure follows the existing `hello-world` template pattern
- MCP dependency points to published package (`agentpay-mcp`)