### PR TITLE
fix(ci): replace curl-based uv install with astral-sh/setup-uv action

### DIFF
--- a/.github/workflows/auth-acceptance.yml
+++ b/.github/workflows/auth-acceptance.yml
@@ -57,7 +57,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v6
 
       - name: Install dependencies
         run: uv sync

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -61,18 +61,8 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     
-    - name: Install uv (Unix)
-      if: matrix.platform != 'windows'
-      run: |
-        curl -LsSf https://astral.sh/uv/install.sh | sh
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-    - name: Install uv (Windows)
-      if: matrix.platform == 'windows'
-      shell: pwsh
-      run: |
-        irm https://astral.sh/uv/install.ps1 | iex
-        echo "$env:USERPROFILE\.local\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
     
     - name: Cache uv environments
       uses: actions/cache@v3
@@ -136,18 +126,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y upx-ucl
       
-      - name: Install uv (Unix)
-        if: matrix.platform != 'windows'
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-      - name: Install uv (Windows)
-        if: matrix.platform == 'windows'
-        shell: pwsh
-        run: |
-          irm https://astral.sh/uv/install.ps1 | iex
-          echo "$env:USERPROFILE\.local\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
       
       - name: Install Python dependencies
         run: |
@@ -217,9 +197,7 @@ jobs:
         run: brew install upx
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        uses: astral-sh/setup-uv@v6
 
       - name: Install dependencies
         run: uv sync --extra dev --extra build
@@ -318,9 +296,7 @@ jobs:
         run: brew install upx
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        uses: astral-sh/setup-uv@v6
 
       - name: Install dependencies
         run: uv sync --extra dev --extra build
@@ -433,18 +409,8 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       
-      - name: Install uv (Unix)
-        if: matrix.platform != 'windows'
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-      - name: Install uv (Windows)
-        if: matrix.platform == 'windows'
-        shell: pwsh
-        run: |
-          irm https://astral.sh/uv/install.ps1 | iex
-          echo "$env:USERPROFILE\.local\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
       
       - name: Install test dependencies
         run: uv sync --extra dev

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -69,9 +69,7 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Install uv
-      run: |
-        curl -LsSf https://astral.sh/uv/install.sh | sh
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      uses: astral-sh/setup-uv@v6
 
     - name: Cache uv environments
       uses: actions/cache@v3
@@ -127,9 +125,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        uses: astral-sh/setup-uv@v6
 
       - name: Install test dependencies
         run: uv sync --extra dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,7 @@ jobs:
         python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Install uv
-      run: |
-        curl -LsSf https://astral.sh/uv/install.sh | sh
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      uses: astral-sh/setup-uv@v6
 
     - name: Cache uv environments
       uses: actions/cache@v3
@@ -78,9 +76,7 @@ jobs:
           sudo apt-get install -y upx-ucl
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        uses: astral-sh/setup-uv@v6
 
       - name: Install Python dependencies
         run: |

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -36,7 +36,7 @@ jobs:
           python-version: '3.12'
       
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v6
       
       - name: Sync dependencies with uv
         run: uv sync


### PR DESCRIPTION
## Problem

The `astral.sh/uv/install.sh` URL intermittently returns **HTTP 404**, breaking macOS builds (and potentially other platforms). This caused the v0.8.4 release pipeline to fail on both macOS jobs.

## Fix

Replace all `curl -LsSf https://astral.sh/uv/install.sh | sh` (and the Windows PowerShell equivalent) with the official `astral-sh/setup-uv@v6` GitHub Action across all CI/CD workflows:

- `ci.yml` (2 instances)
- `ci-integration.yml` (2 instances)
- `build-release.yml` (5 instances)
- `auth-acceptance.yml` (bumped v4 → v6)
- `copilot-setup-steps.yml` (bumped v4 → v6)

The `setup-uv` action:
- Downloads directly from GitHub releases (no astral.sh CDN dependency)
- Handles PATH setup automatically (no manual `GITHUB_PATH` manipulation)
- Works reliably across Linux, macOS, and Windows
- **Net result: -56 lines, +14 lines**

## Context

This blocked the v0.8.4 release. After merging, we need to re-trigger the release pipeline for the v0.8.4 tag.