### PR TITLE
fix: Windows test failures in config command and agents compiler

### DIFF
--- a/src/apm_cli/compilation/agents_compiler.py
+++ b/src/apm_cli/compilation/agents_compiler.py
@@ -838,9 +838,9 @@ class AgentsCompiler:
         
         for placement in distributed_result.placements:
             try:
-                rel_path = placement.agents_path.relative_to(self.base_dir.resolve())
+                rel_path = placement.agents_path.relative_to(self.base_dir.resolve()).as_posix()
             except ValueError:
-                rel_path = placement.agents_path
+                rel_path = str(placement.agents_path)
             lines.append(f"{rel_path}")
             lines.append(f"   Instructions: {len(placement.instructions)}")
             lines.append(f"   Patterns: {', '.join(sorted(placement.coverage_patterns))}")
@@ -868,9 +868,9 @@ class AgentsCompiler:
         
         for placement in distributed_result.placements:
             try:
-                rel_path = placement.agents_path.relative_to(self.base_dir.resolve())
+                rel_path = placement.agents_path.relative_to(self.base_dir.resolve()).as_posix()
             except ValueError:
-                rel_path = placement.agents_path
+                rel_path = str(placement.agents_path)
             lines.append(f"- {rel_path} ({len(placement.instructions)} instructions)")
         
         lines.extend([

--- a/tests/unit/test_config_command.py
+++ b/tests/unit/test_config_command.py
@@ -29,53 +29,62 @@ class TestConfigShow:
         """Show config when not in an APM project directory."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             os.chdir(tmp_dir)
-            with patch("apm_cli.commands.config.get_version", return_value="1.2.3"):
-                result = self.runner.invoke(config, [])
+            try:
+                with patch("apm_cli.commands.config.get_version", return_value="1.2.3"):
+                    result = self.runner.invoke(config, [])
+            finally:
+                os.chdir(self.original_dir)
         assert result.exit_code == 0
 
     def test_config_show_inside_project(self):
         """Show config when apm.yml is present."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             os.chdir(tmp_dir)
-            apm_yml = Path(tmp_dir) / "apm.yml"
-            apm_yml.write_text("name: myproject\nversion: '0.1'\n")
-            with (
-                patch("apm_cli.commands.config.get_version", return_value="1.2.3"),
-                patch(
-                    "apm_cli.commands.config._load_apm_config",
-                    return_value={
-                        "name": "myproject",
-                        "version": "0.1",
-                        "entrypoint": "main.md",
-                    },
-                ),
-            ):
-                result = self.runner.invoke(config, [])
+            try:
+                apm_yml = Path(tmp_dir) / "apm.yml"
+                apm_yml.write_text("name: myproject\nversion: '0.1'\n")
+                with (
+                    patch("apm_cli.commands.config.get_version", return_value="1.2.3"),
+                    patch(
+                        "apm_cli.commands.config._load_apm_config",
+                        return_value={
+                            "name": "myproject",
+                            "version": "0.1",
+                            "entrypoint": "main.md",
+                        },
+                    ),
+                ):
+                    result = self.runner.invoke(config, [])
+            finally:
+                os.chdir(self.original_dir)
         assert result.exit_code == 0
 
     def test_config_show_inside_project_with_compilation(self):
         """Show config when apm.yml has compilation settings."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             os.chdir(tmp_dir)
-            apm_yml = Path(tmp_dir) / "apm.yml"
-            apm_yml.write_text("name: myproject\ncompilation:\n  output: AGENTS.md\n")
-            apm_config = {
-                "name": "myproject",
-                "version": "0.1",
-                "compilation": {
-                    "output": "AGENTS.md",
-                    "chatmode": "copilot",
-                    "resolve_links": False,
-                },
-                "dependencies": {"mcp": ["server1", "server2"]},
-            }
-            with (
-                patch("apm_cli.commands.config.get_version", return_value="1.2.3"),
-                patch(
-                    "apm_cli.commands.config._load_apm_config", return_value=apm_config
-                ),
-            ):
-                result = self.runner.invoke(config, [])
+            try:
+                apm_yml = Path(tmp_dir) / "apm.yml"
+                apm_yml.write_text("name: myproject\ncompilation:\n  output: AGENTS.md\n")
+                apm_config = {
+                    "name": "myproject",
+                    "version": "0.1",
+                    "compilation": {
+                        "output": "AGENTS.md",
+                        "chatmode": "copilot",
+                        "resolve_links": False,
+                    },
+                    "dependencies": {"mcp": ["server1", "server2"]},
+                }
+                with (
+                    patch("apm_cli.commands.config.get_version", return_value="1.2.3"),
+                    patch(
+                        "apm_cli.commands.config._load_apm_config", return_value=apm_config
+                    ),
+                ):
+                    result = self.runner.invoke(config, [])
+            finally:
+                os.chdir(self.original_dir)
         assert result.exit_code == 0
 
     def test_config_show_rich_import_error_fallback(self):
@@ -85,11 +94,14 @@ class TestConfigShow:
         mock_table_cls = MagicMock(side_effect=ImportError("no rich"))
         with tempfile.TemporaryDirectory() as tmp_dir:
             os.chdir(tmp_dir)
-            with (
-                patch("apm_cli.commands.config.get_version", return_value="0.9.0"),
-                patch.object(rich.table, "Table", side_effect=ImportError("no rich")),
-            ):
-                result = self.runner.invoke(config, [])
+            try:
+                with (
+                    patch("apm_cli.commands.config.get_version", return_value="0.9.0"),
+                    patch.object(rich.table, "Table", side_effect=ImportError("no rich")),
+                ):
+                    result = self.runner.invoke(config, [])
+            finally:
+                os.chdir(self.original_dir)
         assert result.exit_code == 0
 
     def test_config_show_fallback_inside_project(self):
@@ -98,22 +110,25 @@ class TestConfigShow:
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             os.chdir(tmp_dir)
-            apm_yml = Path(tmp_dir) / "apm.yml"
-            apm_yml.write_text("name: proj\n")
-            apm_config = {
-                "name": "proj",
-                "version": "1.0",
-                "entrypoint": None,
-                "dependencies": {"mcp": []},
-            }
-            with (
-                patch("apm_cli.commands.config.get_version", return_value="0.9.0"),
-                patch(
-                    "apm_cli.commands.config._load_apm_config", return_value=apm_config
-                ),
-                patch.object(rich.table, "Table", side_effect=ImportError("no rich")),
-            ):
-                result = self.runner.invoke(config, [])
+            try:
+                apm_yml = Path(tmp_dir) / "apm.yml"
+                apm_yml.write_text("name: proj\n")
+                apm_config = {
+                    "name": "proj",
+                    "version": "1.0",
+                    "entrypoint": None,
+                    "dependencies": {"mcp": []},
+                }
+                with (
+                    patch("apm_cli.commands.config.get_version", return_value="0.9.0"),
+                    patch(
+                        "apm_cli.commands.config._load_apm_config", return_value=apm_config
+                    ),
+                    patch.object(rich.table, "Table", side_effect=ImportError("no rich")),
+                ):
+                    result = self.runner.invoke(config, [])
+            finally:
+                os.chdir(self.original_dir)
         assert result.exit_code == 0
 
 


### PR DESCRIPTION
## Summary

Fixes 7 pre-existing Windows CI test failures (unrelated to #407).

### Config command tests (5 failures)
**Root cause**: `PermissionError [WinError 32]` — `os.chdir(tmp_dir)` inside `TemporaryDirectory()` context. On Windows, the OS holds a handle on the CWD, preventing `__exit__` from deleting the directory.

**Fix**: Wrap test body in `try/finally` to `os.chdir(self.original_dir)` before the `TemporaryDirectory` context exits.

### Agents compiler summary tests (2 failures)  
**Root cause**: `Path.relative_to()` returns OS-native separators (`sub\AGENTS.md` on Windows). Assertions check for forward-slash paths.

**Fix**: Use `.as_posix()` in production code (`_generate_placement_summary` and `_generate_distributed_summary`) for consistent cross-platform output.

### Changes
- `src/apm_cli/compilation/agents_compiler.py` — `.as_posix()` on relative paths in summary generation
- `tests/unit/test_config_command.py` — `try/finally` to restore CWD before temp dir cleanup

### Testing
- All 2594 unit tests pass locally
- Both fixes target Windows-specific issues (path separators, file locking)