### PR TITLE
fix: resolve both sides of relative_to() for Windows 8.3 path compat

### DIFF
--- a/src/apm_cli/compilation/agents_compiler.py
+++ b/src/apm_cli/compilation/agents_compiler.py
@@ -838,7 +838,7 @@ class AgentsCompiler:
         
         for placement in distributed_result.placements:
             try:
-                rel_path = placement.agents_path.relative_to(self.base_dir.resolve()).as_posix()
+                rel_path = placement.agents_path.resolve().relative_to(self.base_dir.resolve()).as_posix()
             except ValueError:
                 rel_path = str(placement.agents_path)
             lines.append(f"{rel_path}")
@@ -868,7 +868,7 @@ class AgentsCompiler:
         
         for placement in distributed_result.placements:
             try:
-                rel_path = placement.agents_path.relative_to(self.base_dir.resolve()).as_posix()
+                rel_path = placement.agents_path.resolve().relative_to(self.base_dir.resolve()).as_posix()
             except ValueError:
                 rel_path = str(placement.agents_path)
             lines.append(f"- {rel_path} ({len(placement.instructions)} instructions)")


### PR DESCRIPTION
## Summary

Follow-up to #410 — the `.as_posix()` fix addressed the separator issue but `relative_to()` still fails on Windows CI runners due to 8.3 short name mismatch.

**Root cause**: `Path.resolve()` expands Windows 8.3 short names (`RUNNER~1` → `runneradmin`). PR #410 resolved `self.base_dir` but not `placement.agents_path`, so `relative_to()` raises `ValueError` and falls back to the absolute path.

**Fix**: Call `.resolve()` on both sides of `relative_to()` in `_generate_placement_summary` and `_generate_distributed_summary`.

### Changes
- `src/apm_cli/compilation/agents_compiler.py` — `placement.agents_path.resolve().relative_to(self.base_dir.resolve())`