### PR TITLE
fix: show auth diagnostics in --verbose for virtual package validation

### DIFF
--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -247,10 +247,10 @@ def _validate_package_exists(package, verbose=False):
 
         # For virtual packages, use the downloader's validation method
         if dep_ref.is_virtual:
+            ctx = auth_resolver.resolve_for_dep(dep_ref)
             host = dep_ref.host or default_host()
             org = dep_ref.repo_url.split('/')[0] if dep_ref.repo_url and '/' in dep_ref.repo_url else None
             if verbose_log:
-                ctx = auth_resolver.resolve(host, org=org)
                 verbose_log(f"Auth resolved: host={host}, org={org}, source={ctx.source}, type={ctx.token_type}")
             downloader = GitHubPackageDownloader(auth_resolver=auth_resolver)
             result = downloader.validate_virtual_package_exists(dep_ref)

--- a/tests/unit/test_install_command.py
+++ b/tests/unit/test_install_command.py
@@ -323,15 +323,16 @@ class TestValidationFailureReasonMessages:
             return_value=False,
         ), patch.object(
             __import__("apm_cli.core.auth", fromlist=["AuthResolver"]).AuthResolver,
-            "resolve",
+            "resolve_for_dep",
             return_value=MagicMock(source="none", token_type="none", token=None),
-        ), patch.object(
+        ) as mock_resolve, patch.object(
             __import__("apm_cli.core.auth", fromlist=["AuthResolver"]).AuthResolver,
             "build_error_context",
             return_value="Authentication failed for accessing owner/repo/skills/my-skill on github.com.\nNo token available.",
         ) as mock_build_ctx:
             result = _validate_package_exists("owner/repo/skills/my-skill", verbose=True)
             assert result is False
+            mock_resolve.assert_called_once()
             mock_build_ctx.assert_called_once()
             call_args = mock_build_ctx.call_args
             assert call_args[0][0] == "github.com"  # host


### PR DESCRIPTION
## Problem

When virtual package validation fails (subdirectory skills, virtual files, collections), running with `--verbose` produced **no additional auth diagnostics** — despite the hint message suggesting it would. This made it impossible for users to debug authentication issues with private repos when using subdirectory paths like `owner/repo/skills/my-skill`.

Reported in #413 — the reporter's private repo was inaccessible but the error gave no clue about auth being the issue.

## Fix

- Add auth resolution logging (`Auth resolved: host=..., org=..., source=..., type=...`) to the virtual package validation path, matching the existing behavior for non-virtual packages
- On failure, call `build_error_context()` to show actionable suggestions (SSO, per-org tokens, etc.)
- Reuse the existing `AuthResolver` instance instead of creating a bare `GitHubPackageDownloader()`, ensuring consistent auth state

### Before (`--verbose`)
```
[x] owner/repo/skills/my-skill -- not accessible or doesn't exist
```

### After (`--verbose`)
```
  Auth resolved: host=github.com, org=owner, source=git-credential-fill, type=oauth
  Authentication failed for accessing owner/repo/skills/my-skill on github.com.
  Token was provided (source: git-credential-fill, type: oauth).
  If your organization uses SAML SSO or is an EMU org, ensure your PAT is authorized...
  If packages span multiple organizations, set per-org tokens: GITHUB_APM_PAT_OWNER
[x] owner/repo/skills/my-skill -- not accessible or doesn't exist
```

## Tests

- `test_verbose_virtual_package_validation_shows_auth_diagnostics` — verifies `build_error_context` is called on virtual package failure in verbose mode
- `test_virtual_package_validation_reuses_auth_resolver` — verifies the downloader receives the shared AuthResolver

Closes #413