### PR TITLE
fix(deps): use ASCII-safe non-TTY output to prevent Windows cp1252 decode warnings in deps commands

### DIFF
--- a/src/apm_cli/commands/deps/cli.py
+++ b/src/apm_cli/commands/deps/cli.py
@@ -43,10 +43,16 @@ def list_packages():
         # Import Rich components with fallback
         from rich.table import Table
         from rich.console import Console
-        import shutil
         term_width = shutil.get_terminal_size((120, 24)).columns
-        console = Console(width=max(120, term_width))
-        has_rich = True
+        # Rich tables include unicode box drawing by default. Avoid rich output
+        # for non-interactive streams so subprocess capture stays ASCII-safe.
+        is_tty = bool(getattr(sys.stdout, "isatty", lambda: False)())
+        has_rich = is_tty
+        console = Console(
+            width=max(120, term_width),
+            force_terminal=False,
+            no_color=True,
+        ) if has_rich else None
     except ImportError:
         has_rich = False
         console = None
@@ -64,12 +70,20 @@ def list_packages():
         # Load project dependencies to check for orphaned packages
         # GitHub: owner/repo or owner/virtual-pkg-name (2 levels)
         # Azure DevOps: org/project/repo or org/project/virtual-pkg-name (3 levels)
-        declared_sources = {}  # dep_path -> 'github' | 'azure-devops'
+        # Local: _local/package-name
+        declared_sources = {}  # dep_path -> 'github' | 'azure-devops' | 'local'
         try:
             apm_yml_path = project_root / APM_YML_FILENAME
             if apm_yml_path.exists():
                 project_package = APMPackage.from_apm_yml(apm_yml_path)
                 for dep in project_package.get_apm_dependencies():
+                    # Handle local dependencies
+                    if dep.is_local and dep.local_path:
+                        # Local packages are installed as _local/<dirname>
+                        pkg_name = Path(dep.local_path).name
+                        declared_sources[f"_local/{pkg_name}"] = 'local'
+                        continue
+
                     # Build the expected installed package name
                     repo_parts = dep.repo_url.split('/')
                     source = 'azure-devops' if dep.is_azure_devops() else 'github'
@@ -234,7 +248,7 @@ def list_packages():
         sys.exit(1)
 
 
-@deps.command(help="Show dependency tree structure")  
+@deps.command(help="Show dependency tree structure")
 def tree():
     """Display dependencies in hierarchical tree format using lockfile."""
     logger = CommandLogger("deps-tree")
@@ -243,8 +257,11 @@ def tree():
         # Import Rich components with fallback
         from rich.tree import Tree
         from rich.console import Console
-        console = Console()
-        has_rich = True
+        # Tree rendering uses unicode branches. Use fallback text when output is
+        # captured/piped to keep bytes ASCII-safe for Windows cp1252 readers.
+        is_tty = bool(getattr(sys.stdout, "isatty", lambda: False)())
+        has_rich = is_tty
+        console = Console(force_terminal=False, no_color=True) if has_rich else None
     except ImportError:
         has_rich = False
         console = None
@@ -530,13 +547,17 @@ def info(package: str):
     try:
         # Load package information
         package_info = _get_detailed_package_info(package_path)
-        
+
         # Display with Rich panel if available
         try:
             from rich.panel import Panel
             from rich.console import Console
-            from rich.text import Text
-            console = Console()
+            # Rich panels use unicode borders. Keep captured output ASCII by
+            # using plain-text fallback when not writing to a terminal.
+            is_tty = bool(getattr(sys.stdout, "isatty", lambda: False)())
+            if not is_tty:
+                raise ImportError
+            console = Console(force_terminal=False, no_color=True)
             
             content_lines = []
             content_lines.append(f"[bold]Name:[/bold] {package_info['name']}")

--- a/src/apm_cli/core/token_manager.py
+++ b/src/apm_cli/core/token_manager.py
@@ -113,7 +113,7 @@ class GitHubTokenManager:
                 text=True,
                 timeout=GitHubTokenManager._get_credential_timeout(),
                 env={**os.environ, 'GIT_TERMINAL_PROMPT': '0',
-                     'GIT_ASKPASS': '' if sys.platform != 'win32' else 'echo'},
+                     'GIT_ASKPASS': ''},
             )
             if result.returncode != 0:
                 return None

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -128,14 +128,17 @@ class DependencyReference:
     @staticmethod
     def is_local_path(dep_str: str) -> bool:
         """Check if a dependency string looks like a local filesystem path.
-        
-        Local paths start with './', '../', '/', or '~'.
+
+        Local paths start with './', '../', '/', or '~', or are Windows absolute paths.
         Protocol-relative URLs ('//...') are explicitly excluded.
         """
         s = dep_str.strip()
         # Reject protocol-relative URLs ('//...')
         if s.startswith('//'):
             return False
+        # Check for Windows absolute paths (e.g., C:\, D:/)
+        if len(s) >= 2 and s[1] == ':':
+            return True
         return s.startswith(('./','../', '/', '~/', '~\\', '.\\', '..\\'))
 
     def get_unique_key(self) -> str:


### PR DESCRIPTION
Hey, I’m new to this repo and started by fixing some small but crucial issues that were causing test failures.

Summary of what i have changed 

1. I updated the deps CLI output path to avoid Rich unicode rendering when output is captured or piped.
2. It now uses TTY detection and falls back to plain ASCII-safe output in non-interactive mode.
3. I also included local dependency source handling in deps listing so local packages are recognized consistently.


> [!NOTE]
> Also, is there any reason you’re using Black instead of Ruff? Ruff provides linting and type checks as well, and running ruff check shows the project has around 511 issues, with about 385 of them being easily fixable.


