### PR TITLE
[docs] Update documentation for features from 2026-03-24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Virtual package types (files, collections, subdirectories) now respect `ARTIFACTORY_ONLY=1`, matching the primary zip-archive proxy-only behavior (#418)
-- `apm pack --target claude` no longer produces an empty bundle when skills/agents are installed under `.github/` -- cross-target path mapping remaps `skills/` and `agents/` to the pack target prefix (#420)
+- `apm pack --target claude` no longer produces an empty bundle when skills/agents are installed under `.github/` -- cross-target path mapping remaps `skills/` and `agents/` to the pack target prefix (#426)
 
 ### Added
 
+- `apm unpack` now shows bundle target, dependency count, and file count; warns when the bundle target differs from the project's detected target (#426)
+- Cursor target support: `apm pack --target cursor`, `apm compile --target cursor`, and auto-detection from `.cursor/` folder in `detect_target()` (#426)
 - `ci-runtime.yml` workflow for nightly + manual runtime inference tests, decoupled from release pipeline (#371)
 - `APM_RUN_INFERENCE_TESTS` env var to gate live inference (`apm run`) in test scripts (#371)
 - PR traceability `::notice` annotation in `ci-integration.yml` smoke-test job (#371)

--- a/docs/src/content/docs/guides/compilation.md
+++ b/docs/src/content/docs/guides/compilation.md
@@ -22,20 +22,22 @@ When you run `apm compile` without specifying a target, APM automatically detect
 |-------------------|--------|---------------------|
 | `.github/` folder only | `copilot` | AGENTS.md (instructions only) |
 | `.claude/` folder only | `claude` | CLAUDE.md (instructions only) |
-| Both folders exist | `all` | Both AGENTS.md and CLAUDE.md |
-| Neither folder exists | `minimal` | AGENTS.md only (universal format) |
+| `.cursor/` folder only | `cursor` | AGENTS.md (instructions only) |
+| Multiple folders exist | `all` | All applicable output files |
+| No recognized folder | `minimal` | AGENTS.md only (universal format) |
 
 ```bash
 apm compile                    # Auto-detects target from project structure
 apm compile --target copilot   # Force GitHub Copilot, Cursor, Codex, Gemini
 apm compile --target claude    # Force Claude Code, Claude Desktop
+apm compile --target cursor    # Force Cursor IDE
 ```
 
 You can set a persistent target in `apm.yml`:
 ```yaml
 name: my-project
 version: 1.0.0
-target: copilot  # or vscode, claude, or all
+target: copilot  # or claude, cursor, or all
 ```
 
 ### Output Files

--- a/docs/src/content/docs/reference/cli-commands.md
+++ b/docs/src/content/docs/reference/cli-commands.md
@@ -429,7 +429,7 @@ apm pack
 apm pack --archive
 
 # Pack only VS Code / Copilot files
-apm pack --target vscode
+apm pack --target copilot
 
 # Export as a standalone plugin directory
 apm pack --format plugin
@@ -452,7 +452,8 @@ apm pack -o dist/
 
 | Target | Includes paths starting with |
 |--------|------------------------------|
-| `vscode` | `.github/` |
+| `copilot` | `.github/` |
+| `vscode` | Deprecated alias for `copilot` |
 | `claude` | `.claude/` |
 | `cursor` | `.cursor/` |
 | `opencode` | `.opencode/` |
@@ -462,7 +463,7 @@ apm pack -o dist/
 ```yaml
 pack:
   format: apm
-  target: vscode
+  target: copilot
   packed_at: '2026-03-09T12:00:00+00:00'
 lockfile_version: '1'
 generated_at: ...
@@ -509,6 +510,7 @@ apm unpack bundle.tar.gz --force
 **Behavior:**
 - **Additive-only**: only writes files listed in the bundle's `apm.lock.yaml`; never deletes existing files
 - If a local file has the same path as a bundle file, the bundle file wins (overwrite)
+- **Bundle metadata**: displays the bundle target, dependency count, and file count on unpack; warns if the bundle target differs from the project's detected target (informational only -- files still extract)
 - **Security scanning**: Bundle contents are scanned before deployment. Critical findings block deployment unless `--force` is used (exit code 1)
 - Verification checks that all `deployed_files` from the bundle lockfile are present in the bundle
 - The bundle's `apm.lock.yaml` is metadata only — it is **not** copied to the output directory
@@ -879,7 +881,7 @@ apm compile [OPTIONS]
 
 **Options:**
 - `-o, --output TEXT` - Output file path (for single-file mode)
-- `-t, --target [vscode|agents|claude|opencode|all]` - Target agent format. `agents` is an alias for `vscode`. Auto-detects if not specified.
+- `-t, --target [copilot|vscode|agents|claude|cursor|opencode|all]` - Target agent format. `vscode` and `agents` are deprecated aliases for `copilot`. Auto-detects if not specified.
 - `--chatmode TEXT` - Chatmode to prepend to the AGENTS.md file
 - `--dry-run` - Preview compilation without writing files (shows placement decisions)
 - `--no-links` - Skip markdown link resolution
@@ -897,24 +899,26 @@ When `--target` is not specified, APM auto-detects based on existing project str
 
 | Condition | Target | Output |
 |-----------|--------|--------|
-| `.github/` exists only | `vscode` | AGENTS.md + .github/ |
+| `.github/` exists only | `copilot` | AGENTS.md + .github/ |
 | `.claude/` exists only | `claude` | CLAUDE.md + .claude/ |
-| Both folders exist | `all` | All outputs |
-| Neither folder exists | `minimal` | AGENTS.md only |
+| `.cursor/` exists only | `cursor` | AGENTS.md + .cursor/ |
+| Multiple folders exist | `all` | All applicable outputs |
+| No recognized folder | `minimal` | AGENTS.md only |
 
 You can also set a persistent target in `apm.yml`:
 ```yaml
 name: my-project
 version: 1.0.0
-target: vscode  # or claude, opencode, or all
+target: copilot  # or claude, cursor, opencode, or all
 ```
 
 **Target Formats (explicit):**
 
 | Target | Output Files | Best For |
 |--------|--------------|----------|
-| `vscode` | AGENTS.md, .github/prompts/, .github/agents/, .github/skills/ | GitHub Copilot, Cursor, Codex, Gemini |
+| `copilot` | AGENTS.md, .github/prompts/, .github/agents/, .github/skills/ | GitHub Copilot, Cursor, Codex, Gemini |
 | `claude` | CLAUDE.md, .claude/commands/, SKILL.md | Claude Code, Claude Desktop |
+| `cursor` | AGENTS.md, .cursor/rules/, .cursor/agents/, .cursor/skills/ | Cursor IDE |
 | `opencode` | AGENTS.md, .opencode/agents/, .opencode/commands/, .opencode/skills/ | OpenCode |
 | `all` | All of the above | Universal compatibility |
 
@@ -942,8 +946,9 @@ apm compile --watch
 apm compile --watch --dry-run
 
 # Target specific agent formats
-apm compile --target vscode    # AGENTS.md + .github/ only
+apm compile --target copilot   # AGENTS.md + .github/ only
 apm compile --target claude    # CLAUDE.md + .claude/ only
+apm compile --target cursor    # AGENTS.md + .cursor/ only
 apm compile --target opencode  # AGENTS.md + .opencode/ only
 apm compile --target all       # All formats (default)
 


### PR DESCRIPTION
## Documentation Updates - 2026-03-24

This PR updates the documentation based on features merged in the last 24 hours.

### Features Documented

- Cross-target path mapping for `apm pack` (from #426)
- `apm unpack` bundle metadata display and target mismatch warning (from #426)
- Cursor target support in `detect_target()`, `apm compile --target`, and `apm pack --target` (from #426)
- `copilot` as primary target name, `vscode` as deprecated alias (from #426)

### Changes Made

- Updated `CHANGELOG.md`: corrected PR reference (#420 -> #426) for cross-target mapping; added entries for `apm unpack` bundle metadata and cursor target support
- Updated `docs/src/content/docs/guides/compilation.md`: added `.cursor/` folder to target auto-detection table; added `cursor` target to CLI examples and persistent config example
- Updated `docs/src/content/docs/reference/cli-commands.md`: updated `apm compile --target` options to include `cursor` and mark `vscode`/`agents` as deprecated aliases; updated auto-detection table with cursor; updated target formats table with cursor row; updated `apm pack` example to use `copilot` (not `vscode`); updated target filtering table to label `vscode` as deprecated; added bundle metadata behavior note to `apm unpack` section

### Merged PRs Referenced

- #426 - fix: cross-target path mapping for skills/agents in `apm pack` (also includes cursor target support, unpack bundle metadata, and copilot/vscode rename)




> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/23471701992) · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+is%3Apr+%22gh-aw-workflow-id%3A+daily-doc-updater%22+in%3Abody)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-03-26T03:36:31.162Z --> on Mar 26, 2026, 3:36 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, id: 23471701992, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/23471701992 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->