### PR TITLE
[docs] Update documentation for features from 2026-03-27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Instruction discovery order is now sorted alphabetically in `_get_all_files()` and all three compilation paths (`template_builder`, `distributed_compiler`, `claude_formatter`), making Build IDs deterministic across platforms (macOS APFS vs Linux ext4 had different `os.walk()` ordering); `apm compile` is now safe to use in pre-commit hooks (#468)
 - Windows antivirus file-lock errors (`WinError 32`) during `apm install`: new `file_ops` retry utility with exponential backoff for `rmtree`/`copytree`/`copy2` operations (#453)
 - `install.sh` now falls back to pip when binary fails in devcontainers with older glibc (#456)
 - Skills now deploy to all active targets (`.opencode/`, `.cursor/`) instead of only `.github/` (#456)

--- a/docs/src/content/docs/guides/compilation.md
+++ b/docs/src/content/docs/guides/compilation.md
@@ -353,10 +353,16 @@ self._glob_cache: Dict[str, List[str]] = {}
 ### Deterministic Output
 
 Compilation is completely reproducible:
-- Sorted iteration order prevents randomness
+- Sorted iteration order prevents filesystem-native ordering differences (APFS on macOS, ext4 on Linux)
 - Stable optimization algorithm
-- Consistent Build IDs across machines
+- Consistent Build IDs across machines and platforms
 - Cache-friendly for CI/CD systems
+- Safe to use in pre-commit hooks -- the same inputs always produce the same Build ID
+
+```bash
+# Example: pre-commit hook to keep AGENTS.md in sync
+apm compile --dry-run   # verify no drift before committing
+```
 
 ### Constitution Injection
 


### PR DESCRIPTION
## Documentation Updates - 2026-03-27

This PR updates the documentation based on features merged in the last 24 hours.

### Features Documented

- Deterministic Build IDs across platforms (from #468)

### Changes Made

- Updated `CHANGELOG.md` to add a `Fixed` entry for the sorted instruction discovery order fix
- Updated `docs/src/content/docs/guides/compilation.md` (`Deterministic Output` section) to:
  - Clarify that sorted iteration order prevents filesystem-native ordering differences between platforms (APFS on macOS, ext4 on Linux)
  - Update "Consistent Build IDs across machines" to reflect cross-platform correctness
  - Add a note that `apm compile` is now safe to use in pre-commit hooks
  - Include a brief pre-commit hook example using `--dry-run`

### Merged PRs Referenced

- #468 - fix: sort instruction discovery order for deterministic Build IDs across platforms

### Notes

The fix in #468 sorted `os.walk()` results in `_get_all_files()` and `pattern_instructions` lists in `template_builder`, `distributed_compiler`, and `claude_formatter`. The documentation already claimed "Consistent Build IDs across machines" but that claim was not accurate until this fix landed. The updated docs now accurately reflect the behavior and highlight the pre-commit hook use case that was unblocked by the fix.




> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/23629981299) · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+is%3Apr+%22gh-aw-workflow-id%3A+daily-doc-updater%22+in%3Abody)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-03-29T03:45:24.919Z --> on Mar 29, 2026, 3:45 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, id: 23629981299, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/23629981299 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->