### PR TITLE
chore: bump to v0.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,23 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Windows antivirus file-lock errors (`WinError 32`) during `apm install`: new `file_ops` retry utility with exponential backoff for `rmtree`/`copytree`/`copy2` operations (#453)
-- `install.sh` now falls back to pip when binary fails in devcontainers with older glibc (#456)
-- Skills now deploy to all active targets (`.opencode/`, `.cursor/`) instead of only `.github/` (#456)
-- `apm install` no longer rewrites `apm.lock.yaml` when dependencies are unchanged, eliminating `generated_at` churn in version control (#456)
-- `.github/` is no longer auto-created when other target dirs (`.claude/`, `.cursor/`, `.opencode/`) already exist; copilot is only the fallback for greenfield projects (#456)
-- Linux binary no longer bundles `libssl.so.3`/`libcrypto.so.3`, preventing OpenSSL ABI conflicts on distros where system `libcurl` requires a newer OpenSSL than the build machine (e.g. Fedora 43) (#466)
-- SSH-style Git URLs (`git@host:owner/../evil`) now reject path traversal sequences, closing a bypass of the HTTPS validation added in #437 -- by @thakoreh (#458)
-
-### Changed
-
-- Consolidated path-segment traversal checks in `DependencyReference` into a single `validate_path_segments()` utility in `path_security.py`, eliminating behavioral drift (backslash normalisation now applied uniformly across all parse paths)
+## [0.8.6] - 2026-03-27
 
 ### Added
 
 - `apm install --target` flag to force deployment to a specific target (copilot, claude, cursor, opencode, all) (#456)
+
+### Fixed
+
+- Windows antivirus file-lock errors (`WinError 32`) during `apm install` with `file_ops` retry utility (#440)
+- Installer fallback to pip in devcontainers, target registry, and lockfile idempotency fixes (#456)
+- Reject path traversal sequences in SSH-style Git URLs — by @thakoreh (#458)
+- Exclude bundled OpenSSL libs from Linux binary to prevent ABI conflicts (#466)
+- Allow spaces in ADO repository names when parsing URLs (#437)
+- Gate `.claude/commands/` deployment behind `integrate_claude` flag (#443)
+- Sort instruction discovery order for deterministic Build IDs across platforms (#468)
+- Share `AuthResolver` across install to prevent duplicate auth popups (#424)
+
+### Changed
+
+- Consolidated path-segment traversal checks into `validate_path_segments()` in `path_security.py` (#458)
 
 ## [0.8.5] - 2026-03-24
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apm-cli"
-version = "0.8.5"
+version = "0.8.6"
 description = "MCP configuration tool"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Version bump to 0.8.6

- **pyproject.toml**: `0.8.5` → `0.8.6`
- **CHANGELOG.md**: Promoted `[Unreleased]` → `[0.8.6] - 2026-03-27` with 1-line-per-PR entries

### PRs included since v0.8.5

| PR | Description |
|----|-------------|
| #456 | `apm install --target` flag + installer fallback, target registry, lockfile idempotency |
| #440 | Windows antivirus file-lock errors (`WinError 32`) during `apm install` |
| #458 | Reject path traversal in SSH-style Git URLs |
| #466 | Exclude bundled OpenSSL libs from Linux binary |
| #437 | Allow spaces in ADO repository names |
| #443 | Gate `.claude/commands/` deployment behind `integrate_claude` flag |
| #468 | Sort instruction discovery order for deterministic Build IDs |
| #424 | Share `AuthResolver` across install to prevent duplicate auth popups |
