### PR TITLE
fix: apm deps update was a no-op -- delegate to install engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `apm deps update` was a no-op -- rewrote to delegate to the install engine (`apm install --update --only=apm`) so the lockfile, deployed files, and integration state are all refreshed correctly
+
 ## [0.8.6] - 2026-03-27
 
 ### Added

--- a/src/apm_cli/commands/deps/cli.py
+++ b/src/apm_cli/commands/deps/cli.py
@@ -11,10 +11,6 @@ from ...constants import APM_DIR, APM_MODULES_DIR, APM_YML_FILENAME, SKILL_MD_FI
 from ...models.apm_package import APMPackage, ValidationResult, validate_apm_package
 from ...core.command_logger import CommandLogger
 
-# Import APM dependency system components (with fallback)
-from ...deps.github_downloader import GitHubPackageDownloader
-from ...deps.apm_resolver import APMDependencyResolver
-
 from ._utils import (
     _is_nested_under_package,
     _count_primitives,
@@ -23,8 +19,6 @@ from ._utils import (
     _get_detailed_context_counts,
     _get_package_display_info,
     _get_detailed_package_info,
-    _update_single_package,
-    _update_all_packages,
 )
 
 
@@ -444,42 +438,35 @@ def clean(dry_run: bool, yes: bool):
 
 
 @deps.command(help="Update APM dependencies")
+@click.option("--verbose", "-v", is_flag=True, help="Show detailed update information")
+@click.option("--force", is_flag=True, help="Overwrite locally-authored files on collision")
 @click.argument('package', required=False)
-def update(package: Optional[str]):
-    """Update specific package or all if no package specified."""
-    logger = CommandLogger("deps-update")
+@click.pass_context
+def update(ctx, package: Optional[str], verbose: bool, force: bool):
+    """Update specific package or all if no package specified.
 
-    project_root = Path(".")
-    apm_modules_path = project_root / APM_MODULES_DIR
-    
-    if not apm_modules_path.exists():
-        logger.progress("No apm_modules/ directory found - no packages to update")
-        return
-    
-    # Get project dependencies to validate updates
-    try:
-        apm_yml_path = project_root / APM_YML_FILENAME
-        if not apm_yml_path.exists():
-            logger.error(f"No {APM_YML_FILENAME} found in current directory")
-            return
-            
-        project_package = APMPackage.from_apm_yml(apm_yml_path)
-        project_deps = project_package.get_apm_dependencies()
-        
-        if not project_deps:
-            logger.progress("No APM dependencies defined in apm.yml")
-            return
-            
-    except Exception as e:
-        logger.error(f"Error reading {APM_YML_FILENAME}: {e}")
-        return
-    
-    if package:
-        # Update specific package
-        _update_single_package(package, project_deps, apm_modules_path, logger=logger)
-    else:
-        # Update all packages
-        _update_all_packages(project_deps, apm_modules_path, logger=logger)
+    Delegates to the install engine with --update to ensure the lockfile,
+    deployed files, and integration state are all refreshed correctly.
+    """
+    from ..install import install as install_cmd
+
+    # Build the install invocation: --update --only=apm (skip MCP)
+    invoke_kwargs = {
+        "packages": (package,) if package else (),
+        "runtime": None,
+        "exclude": None,
+        "only": "apm",
+        "update": True,
+        "dry_run": False,
+        "force": force,
+        "verbose": verbose,
+        "trust_transitive_mcp": False,
+        "parallel_downloads": 4,
+        "dev": False,
+        "target": None,
+    }
+
+    ctx.invoke(install_cmd, **invoke_kwargs)
 
 
 @deps.command(help="Show detailed package information")

--- a/tests/unit/test_deps_update_command.py
+++ b/tests/unit/test_deps_update_command.py
@@ -1,0 +1,119 @@
+"""Tests for apm deps update command delegation to install engine.
+
+Verifies that `apm deps update` delegates to `apm install --update --only=apm`
+instead of using a broken standalone update path that silently fails to update
+the lockfile, deployed files, and integration state.
+
+Bug: _update_all_packages() and _update_single_package() called
+download_package() but never regenerated the lockfile or re-integrated
+primitives — making `apm deps update` a no-op that lied about success.
+"""
+
+import inspect
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from apm_cli.cli import cli
+
+
+class TestDepsUpdateDelegatesToInstall:
+    """Verify deps update invokes the install engine with --update."""
+
+    @pytest.fixture()
+    def runner(self):
+        return CliRunner()
+
+    @pytest.fixture()
+    def apm_yml(self, tmp_path):
+        """Create a minimal apm.yml with one dependency."""
+        yml = tmp_path / "apm.yml"
+        yml.write_text(
+            "name: test-project\n"
+            "version: 1.0.0\n"
+            "dependencies:\n"
+            "  apm:\n"
+            "    - microsoft/apm-sample-package\n"
+        )
+        return yml
+
+    def test_deps_update_all_runs_without_crash(self, runner, apm_yml):
+        """apm deps update (no args) should not crash."""
+        with runner.isolated_filesystem(temp_dir=apm_yml.parent):
+            Path("apm.yml").write_text(apm_yml.read_text())
+
+            result = runner.invoke(cli, ["deps", "update"])
+
+            # The command should run (possibly fail due to network) but not crash
+            assert result.exit_code in (0, 1), (
+                f"Unexpected exit code {result.exit_code}:\n{result.output}"
+            )
+
+
+class TestDepsUpdateHelp:
+    """Verify deps update --help advertises --verbose, --force, PACKAGE."""
+
+    @pytest.fixture()
+    def runner(self):
+        return CliRunner()
+
+    def test_help_shows_verbose(self, runner):
+        """apm deps update --help should show --verbose."""
+        result = runner.invoke(cli, ["deps", "update", "--help"])
+        assert "--verbose" in result.output
+
+    def test_help_shows_force(self, runner):
+        """apm deps update --help should show --force."""
+        result = runner.invoke(cli, ["deps", "update", "--help"])
+        assert "--force" in result.output
+
+    def test_help_shows_package_arg(self, runner):
+        """apm deps update --help should show PACKAGE argument."""
+        result = runner.invoke(cli, ["deps", "update", "--help"])
+        assert "PACKAGE" in result.output.upper()
+
+
+class TestDepsUpdateNoLongerUsesStaleUtils:
+    """Verify the old broken _update_all_packages path is no longer used."""
+
+    def _get_update_source(self):
+        """Read the source of the deps update command from disk."""
+        src = Path(__file__).resolve().parents[2] / "src" / "apm_cli" / "commands" / "deps" / "cli.py"
+        return src.read_text()
+
+    def test_update_command_does_not_import_broken_utils(self):
+        """The deps update command source should not call _update_all_packages."""
+        source = self._get_update_source()
+        # Find the update function body
+        idx = source.find("def update(")
+        assert idx != -1, "update function not found in cli.py"
+        # Grab text from the function definition to the next top-level def/class
+        rest = source[idx:]
+        lines = rest.split("\n")
+        body_lines = []
+        for i, line in enumerate(lines):
+            if i > 0 and (line.startswith("def ") or line.startswith("class ") or line.startswith("@")):
+                break
+            body_lines.append(line)
+        body = "\n".join(body_lines)
+
+        assert "_update_all_packages" not in body
+        assert "_update_single_package" not in body
+
+    def test_update_command_delegates_to_install(self):
+        """The deps update command should use ctx.invoke to call install."""
+        source = self._get_update_source()
+        idx = source.find("def update(")
+        assert idx != -1
+        rest = source[idx:]
+        lines = rest.split("\n")
+        body_lines = []
+        for i, line in enumerate(lines):
+            if i > 0 and (line.startswith("def ") or line.startswith("class ") or line.startswith("@")):
+                break
+            body_lines.append(line)
+        body = "\n".join(body_lines)
+
+        assert "ctx.invoke" in body
+        assert "install" in body.lower()


### PR DESCRIPTION
The update command in `_utils.py` called `download_package()` but never regenerated the lockfile, re-integrated deployed primitives, or used correct install paths for subdirectory/virtual packages. This made `apm deps update` silently report success while doing nothing.

Rewrite the command to delegate to the install engine via `ctx.invoke(install_cmd, update=True, only='apm')`. This ensures the lockfile, deployed files, and integration state are all refreshed.

## Description

`apm deps update` was silently a no-op. The `_update_all_packages()` and `_update_single_package()` functions in `_utils.py` had three critical issues:

1. Used wrong install paths for subdirectory/virtual packages (`repo_url.split('/')[:2]` ignores `virtual_path`)
2. Never regenerated the lockfile after downloading
3. Never re-integrated deployed primitives (instructions, agents, skills, hooks)

Rewrote the `deps update` command to delegate to the install engine via `ctx.invoke(install_cmd, update=True, only="apm")`, reusing the battle-tested install pipeline that correctly handles BFS resolution, parallel downloads, lockfile regeneration, file integration, and collision detection.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

6 new tests in `tests/unit/test_deps_update_command.py` covering help output, source code inspection, and crash-free invocation. 2260 existing unit tests pass with no regressions.