### PR TITLE
docs: add Marketplaces guide to sidebar navigation

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -69,6 +69,7 @@ export default defineConfig({
 						{ label: 'Pack & Distribute', slug: 'guides/pack-distribute' },
 						{ label: 'Private Packages', slug: 'guides/private-packages' },
 						{ label: 'Org-Wide Packages', slug: 'guides/org-packages' },
+						{ label: 'Marketplaces', slug: 'guides/marketplaces' },
 						{ label: 'CI Policy Enforcement', slug: 'guides/ci-policy-setup' },
 						{ label: 'Agent Workflows (Experimental)', slug: 'guides/agent-workflows' },
 					],


### PR DESCRIPTION
## Summary

The `guides/marketplaces.md` page exists and is deployed at https://microsoft.github.io/apm/guides/marketplaces/ but was never added to the Starlight sidebar configuration in `astro.config.mjs`. This makes it unreachable via sidebar navigation -- users can only find it through direct URL or search.

## Changes

- Added `{ label: 'Marketplaces', slug: 'guides/marketplaces' }` to the Guides section in `docs/astro.config.mjs`, placed after "Org-Wide Packages" and before "CI Policy Enforcement".

## Verification

- Docs build succeeds with all internal links valid.
- Marketplace page now appears in the sidebar under Guides.