### PR TITLE
fix: CI test assertions for Rich line-wrapping and scope output

### DIFF
--- a/scripts/test-dependency-integration.sh
+++ b/scripts/test-dependency-integration.sh
@@ -64,10 +64,10 @@ EOF
     echo "--- OUTPUT START ---"
     echo "$deps_output"
     echo "--- OUTPUT END ---"
-    if echo "$deps_output" | grep -q "No APM dependencies installed yet"; then
+    if echo "$deps_output" | grep -q "No APM dependencies installed"; then
         log_success "Correctly shows no dependencies installed"
     else
-        log_error "Expected 'No APM dependencies installed yet' message"
+        log_error "Expected 'No APM dependencies installed' message"
         log_error "Got: $deps_output"
         return 1
     fi
@@ -256,7 +256,7 @@ test_dependency_cleanup() {
     echo "--- OUTPUT START ---"
     echo "$deps_output_after_cleanup"
     echo "--- OUTPUT END ---"
-    if echo "$deps_output_after_cleanup" | grep -q "No APM dependencies installed yet"; then
+    if echo "$deps_output_after_cleanup" | grep -q "No APM dependencies installed"; then
         log_success "Correctly shows no dependencies after cleanup"
     else
         log_error "Expected no dependencies after cleanup"

--- a/scripts/windows/test-dependency-integration.ps1
+++ b/scripts/windows/test-dependency-integration.ps1
@@ -60,10 +60,10 @@ scripts:
         Write-Host "--- OUTPUT START ---"
         Write-Host $depsOutput
         Write-Host "--- OUTPUT END ---"
-        if ($depsOutput -match "No APM dependencies installed yet") {
+        if ($depsOutput -match "No APM dependencies installed") {
             Write-DepSuccess "Correctly shows no dependencies installed"
         } else {
-            Write-DepError "Expected 'No APM dependencies installed yet' message"
+            Write-DepError "Expected 'No APM dependencies installed' message"
             Write-DepError "Got: $depsOutput"
             return $false
         }
@@ -282,7 +282,7 @@ function Test-DependencyCleanup {
         Write-Host "--- OUTPUT START ---"
         Write-Host $depsOutput
         Write-Host "--- OUTPUT END ---"
-        if ($depsOutput -match "No APM dependencies installed yet") {
+        if ($depsOutput -match "No APM dependencies installed") {
             Write-DepSuccess "Correctly shows no dependencies after cleanup"
         } else {
             Write-DepError "Expected no dependencies after cleanup"

--- a/tests/unit/test_install_command.py
+++ b/tests/unit/test_install_command.py
@@ -818,7 +818,9 @@ class TestInstallGlobalFlag:
                     )
 
                 # Should fail with clear message about local packages
-                assert "local packages are not supported at user scope" in result.output
+                # Use shorter substring to tolerate Rich word-wrapping on
+                # platforms with long temp paths (Windows).
+                assert "not supported at user scope" in result.output
                 # Should suggest using remote reference
                 assert "owner/repo" in result.output
             finally:
@@ -840,7 +842,7 @@ class TestInstallGlobalFlag:
                         cli, ["install", "--global", str(local_pkg)]
                     )
 
-                assert "local packages are not supported at user scope" in result.output
+                assert "not supported at user scope" in result.output
             finally:
                 os.chdir(self.original_dir)
 
@@ -857,6 +859,6 @@ class TestInstallGlobalFlag:
                         cli, ["install", "--global", "~/some-pkg"]
                     )
 
-                assert "local packages are not supported at user scope" in result.output
+                assert "not supported at user scope" in result.output
             finally:
                 os.chdir(self.original_dir)


### PR DESCRIPTION
## Hotfix: CI test assertions broken by v0.8.8 changes

Two CI failures on the v0.8.8 release pipeline need urgent fixes:

### Root Cause Analysis

**1. Windows unit test failure** (`test_global_rejects_absolute_local_path`)
- Rich `Console()` defaults to 80-char width when no TTY is detected (CI runners)
- Windows temp paths are much longer than Linux/macOS (~60+ chars vs ~25)
- The validation error message `[x] D:\a\...\abs-pkg -- local packages are not supported at user scope` exceeds 80 chars, causing Rich to insert a word-wrap `\n` between "local" and "packages"
- The assertion `"local packages are not supported at user scope" in result.output` fails because the substring is split across lines
- **Fix**: Shorten assertion to `"not supported at user scope"` which won't be split by wrapping

**2. macOS ARM release validation failure** (`test-dependency-integration.sh`)
- PR #452 changed `apm deps list` output from `"No APM dependencies installed yet"` to `"No APM dependencies installed (Project scope)"`
- Release validation scripts (bash + PowerShell) still grep for the old `"yet"` suffix
- **Fix**: Match `"No APM dependencies installed"` (common prefix) in all 4 script locations

### Changes
- `tests/unit/test_install_command.py` — 3 assertions shortened to tolerate Rich wrapping
- `scripts/test-dependency-integration.sh` — 2 grep patterns updated
- `scripts/windows/test-dependency-integration.ps1` — 2 match patterns updated