### PR TITLE
feat: add .apmrc configuration file support

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -70,6 +70,7 @@ export default defineConfig({
 						{ label: 'Private Packages', slug: 'guides/private-packages' },
 						{ label: 'Org-Wide Packages', slug: 'guides/org-packages' },
 						{ label: 'Marketplaces', slug: 'guides/marketplaces' },
+						{ label: 'Configuration (.apmrc)', slug: 'guides/configuration' },
 						{ label: 'CI Policy Enforcement', slug: 'guides/ci-policy-setup' },
 						{ label: 'Agent Workflows (Experimental)', slug: 'guides/agent-workflows' },
 					],

--- a/docs/examples/.apmrc
+++ b/docs/examples/.apmrc
@@ -1,0 +1,57 @@
+# .apmrc — Agent Package Manager configuration
+# https://github.com/microsoft/apm/docs/apmrc.md
+#
+# This file uses a flat key=value format (no section headers).
+# Lines starting with # or ; are comments.
+#
+# Environment variable substitution is supported:
+#   ${VAR}          — use env var value; leave '${VAR}' as-is if unset
+#   ${VAR?}         — use env var value; empty string if unset
+#   ${VAR:-default} — use env var value; fall back to 'default' if unset/empty
+#   ${VAR:+word}    — use 'word' only if VAR is set and non-empty
+#
+# Configuration hierarchy (lowest → highest precedence):
+#   ~/.apmrc  →  ~/.apm/.apmrc  →  $XDG_CONFIG_HOME/apm/.apmrc
+#   →  <project>/.apmrc  →  environment variables  →  CLI flags
+#
+# Recommended practice:
+#   Commit .apmrc with ${VAR} references (no secrets).
+#   Store actual tokens in ~/.apm/.apmrc or shell env vars.
+
+# =============================================================================
+# Registry
+# =============================================================================
+
+# Default registry URL for all package lookups.
+# The env var APM_REGISTRY takes precedence over this value.
+# registry=https://api.mcp.github.com
+
+# Route packages in the @myorg scope to a private registry.
+# @myorg:registry=https://myorg.pkg.github.com
+
+# =============================================================================
+# Authentication
+# =============================================================================
+
+# GitHub personal access token for private packages.
+# The env vars GITHUB_APM_PAT, GITHUB_TOKEN, and GH_TOKEN are checked first.
+# github-token=${GITHUB_APM_PAT}
+
+# Per-host auth token for a scoped registry (mirrors .npmrc convention).
+# //myorg.pkg.github.com/:_authToken=${MYORG_REGISTRY_TOKEN}
+
+# =============================================================================
+# Behavior
+# =============================================================================
+
+# Default AI client target when none is specified on the CLI.
+# Accepted values: vscode, claude, cursor, copilot, codex, opencode
+# default-client=claude
+
+# Automatically integrate installed packages into the client config.
+# Default: true
+# auto-integrate=true
+
+# Suppress interactive prompts and enforce strict mode in CI.
+# Uses ${CI:+true} so it only activates when the CI env var is set.
+# ci-mode=${CI:+true}

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -1,0 +1,192 @@
+---
+title: Configuration (.apmrc)
+description: Configure APM behavior, registries, and authentication with .apmrc files.
+---
+
+APM reads configuration from `.apmrc` files using a flat `key=value` format inspired by npm's `.npmrc`. This lets you configure registries, authentication tokens, and behavior flags per-project or globally.
+
+## Quick Start
+
+Scaffold a new `.apmrc` in your project:
+
+```bash
+apm config init-rc
+```
+
+Or set a value directly:
+
+```bash
+apm config set registry https://your-registry.example.com
+apm config set auto-integrate false
+```
+
+## File Format
+
+`.apmrc` is a flat INI-style file. Each line is a `key=value` pair, a comment (`#` or `;`), or blank.
+
+```ini
+# Default registry
+registry=https://api.mcp.github.com
+
+# Auth token (use env var reference — never commit real tokens)
+github-token=${GITHUB_APM_PAT}
+
+# Scoped registry for an organization
+@myorg:registry=https://myorg.pkg.github.com
+//myorg.pkg.github.com/:_authToken=${MYORG_TOKEN}
+
+# Behavior
+default-client=claude
+auto-integrate=true
+ci-mode=${CI:+true}
+```
+
+## Configuration Hierarchy
+
+APM loads `.apmrc` from multiple locations. Later sources override earlier ones:
+
+| Priority | Source | Location |
+|----------|--------|----------|
+| 1 (lowest) | Global home | `~/.apmrc` |
+| 2 | Global APM dir | `~/.apm/.apmrc` |
+| 3 | XDG config | `$XDG_CONFIG_HOME/apm/.apmrc` (Linux/macOS) |
+| 4 | Project | `.apmrc` in project root (walked up from cwd) |
+| 5 | Env vars | `APM_CONFIG_*` environment variables |
+| 6 (highest) | CLI flags | Command-line arguments |
+
+Use `apm config which-rc` to see which files are loaded:
+
+```bash
+$ apm config which-rc
+  1. [global] /home/user/.apm/.apmrc
+  2. [project] /home/user/myproject/.apmrc
+```
+
+## Environment Variable Substitution
+
+Values can reference environment variables. This lets you commit `.apmrc` to version control without exposing secrets:
+
+| Syntax | Behavior |
+|--------|----------|
+| `${VAR}` | Substitute value; leave `${VAR}` as-is if unset |
+| `${VAR?}` | Substitute value; empty string if unset |
+| `${VAR:-default}` | Substitute value; use `default` if unset or empty |
+| `${VAR:+word}` | Use `word` if VAR is set and non-empty; else empty |
+| `\${VAR}` | Literal `${VAR}` (backslash escaping) |
+
+Example:
+
+```ini
+# Token from env var — safe to commit
+github-token=${GITHUB_APM_PAT}
+
+# Conditional CI mode — only active when CI env var is set
+ci-mode=${CI:+true}
+
+# Registry with fallback
+registry=${APM_REGISTRY:-https://api.mcp.github.com}
+```
+
+## `APM_CONFIG_*` Environment Variables
+
+Any environment variable starting with `APM_CONFIG_` is mapped to a config key, mirroring npm's `npm_config_*` convention. Underscores become hyphens:
+
+```bash
+# These are equivalent:
+export APM_CONFIG_REGISTRY=https://custom.io    # → registry=https://custom.io
+export APM_CONFIG_DEFAULT_CLIENT=claude          # → default-client=claude
+export APM_CONFIG_AUTO_INTEGRATE=false           # → auto-integrate=false
+```
+
+`APM_CONFIG_*` variables take precedence over all `.apmrc` files, making them ideal for CI/CD overrides.
+
+## Supported Keys
+
+### Registry
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `registry` | Default registry URL for package lookups | `https://api.mcp.github.com` |
+| `@scope:registry` | Override registry for packages under `@scope` | Falls back to `registry` |
+
+### Authentication
+
+| Key | Description |
+|-----|-------------|
+| `github-token` | GitHub personal access token for private packages |
+| `//host/:_authToken` | Per-host bearer token (follows `.npmrc` convention) |
+
+Token resolution priority: `GITHUB_APM_PAT` env → `GITHUB_TOKEN` env → `GH_TOKEN` env → `.apmrc github-token` → git credential helper.
+
+### Behavior
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `default-client` | AI client target (`vscode`, `claude`, `cursor`, `copilot`, `codex`) | `vscode` |
+| `auto-integrate` | Auto-integrate packages into client config | `true` |
+| `ci-mode` | Suppress interactive prompts in CI | `false` |
+
+## Scoped Registries
+
+Route packages under a scope to a different registry, with separate auth:
+
+```ini
+# Packages under @myorg use a private registry
+@myorg:registry=https://myorg.pkg.github.com
+
+# Auth token for that registry
+//myorg.pkg.github.com/:_authToken=${MYORG_TOKEN}
+```
+
+When APM resolves `@myorg/some-package`, it uses `https://myorg.pkg.github.com` instead of the default registry, and sends the configured bearer token.
+
+## CLI Commands
+
+| Command | Description |
+|---------|-------------|
+| `apm config show-rc` | Show all merged `.apmrc` values (tokens masked) |
+| `apm config show-rc --json` | Same, as JSON |
+| `apm config which-rc` | List loaded `.apmrc` files with precedence |
+| `apm config get <key>` | Get a specific config value |
+| `apm config set <key> <value>` | Set a value in `.apmrc` |
+| `apm config set <key> <value> --global` | Set in `~/.apm/.apmrc` |
+| `apm config delete <key>` | Remove a key from `.apmrc` |
+| `apm config init-rc` | Scaffold a new `.apmrc` with commented defaults |
+| `apm config init-rc --global` | Scaffold global `~/.apm/.apmrc` |
+| `apm config edit` | Open `.apmrc` in `$EDITOR` |
+
+## Security
+
+- **Never commit real tokens.** Use `${VAR}` references and set the actual values via environment variables or `~/.apm/.apmrc`.
+- **File permissions:** `.apmrc` files are created with mode `0600` (owner-only). APM warns if it finds a world-readable `.apmrc`.
+- **Sensitive keys are protected.** `apm config get github-token` is blocked — use `apm config show-rc` to see masked values.
+- **Symlinks rejected.** File write operations refuse to follow symlinks to prevent write-redirection attacks.
+
+## Best Practices
+
+1. **Project `.apmrc`** — Commit to version control with `${VAR}` references only. This documents what configuration your project needs without exposing secrets.
+
+2. **Global `~/.apm/.apmrc`** — Store actual tokens here. This file is never committed and is protected with `0600` permissions.
+
+3. **CI/CD** — Use `APM_CONFIG_*` environment variables to override settings in automated pipelines:
+   ```yaml
+   env:
+     APM_CONFIG_REGISTRY: https://internal-registry.example.com
+     APM_CONFIG_GITHUB_TOKEN: ${{ secrets.APM_TOKEN }}
+   ```
+
+## For npm Users
+
+If you're familiar with `.npmrc`, `.apmrc` works similarly:
+
+| `.npmrc` | `.apmrc` | Notes |
+|----------|----------|-------|
+| `registry=url` | `registry=url` | Same |
+| `@scope:registry=url` | `@scope:registry=url` | Same |
+| `//host/:_authToken=tok` | `//host/:_authToken=tok` | Same |
+| `${VAR}` | `${VAR}` | Same |
+| `\${VAR}` | `\${VAR}` | Same (backslash escaping) |
+| `npm_config_*` env vars | `APM_CONFIG_*` env vars | Same convention |
+| `~/.npmrc` | `~/.apm/.apmrc` | Different path |
+
+APM additionally supports `${VAR:-default}`, `${VAR?}`, and `${VAR:+word}` substitution forms that `.npmrc` does not.

--- a/docs/src/content/docs/reference/cli-commands.md
+++ b/docs/src/content/docs/reference/cli-commands.md
@@ -1232,7 +1232,7 @@ APM integrates seamlessly with [Spec-kit](https://github.com/github/spec-kit) fo
 
 ### `apm config` - Configure APM CLI
 
-Manage APM CLI configuration settings. Running `apm config` without subcommands displays the current configuration.
+Manage APM CLI configuration settings. Configuration is stored in `.apmrc` files (flat `key=value` format with `${ENV_VAR}` substitution). See the [Configuration Guide](/guides/configuration/) for full details.
 
 ```bash
 apm config [COMMAND]
@@ -1246,79 +1246,86 @@ Display current APM CLI configuration and project settings.
 apm config
 ```
 
-**What's displayed:**
-- Project configuration from `apm.yml` (if in an APM project)
-  - Project name, version, entrypoint
-  - Number of MCP dependencies
-  - Compilation settings (output, chatmode, resolve_links)
-- Global configuration
-  - APM CLI version
-  - `auto-integrate` setting
-
-**Examples:**
-```bash
-# Show current configuration
-apm config
-```
-
 #### `apm config get` - Get a configuration value
-
-Get a specific configuration value or display all configuration values.
 
 ```bash
 apm config get [KEY]
 ```
 
 **Arguments:**
-- `KEY` (optional) - Configuration key to retrieve. Supported keys:
-  - `auto-integrate` - Whether to automatically integrate `.prompt.md` files into AGENTS.md
+- `KEY` (optional) - Any `.apmrc` key: `registry`, `default-client`, `auto-integrate`, `@scope:registry`, etc.
 
-If `KEY` is omitted, displays all configuration values.
+If `KEY` is omitted, displays all configuration values. Sensitive keys (`github-token`, `*:_authToken`) are blocked — use `show-rc` instead.
 
 **Examples:**
 ```bash
-# Get auto-integrate setting
+apm config get registry
 apm config get auto-integrate
-
-# Show all configuration
-apm config get
+apm config get                  # show all
 ```
 
 #### `apm config set` - Set a configuration value
 
-Set a configuration value globally for APM CLI.
+Write a key-value pair to an `.apmrc` file.
 
 ```bash
-apm config set KEY VALUE
+apm config set KEY VALUE [--global]
 ```
 
-**Arguments:**
-- `KEY` - Configuration key to set. Supported keys:
-  - `auto-integrate` - Enable/disable automatic integration of `.prompt.md` files
-- `VALUE` - Value to set. For boolean keys, use: `true`, `false`, `yes`, `no`, `1`, `0`
-
-**Configuration Keys:**
-
-**`auto-integrate`** - Control automatic prompt integration
-- **Type:** Boolean
-- **Default:** `true`
-- **Description:** When enabled, APM automatically discovers and integrates `.prompt.md` files from `.github/prompts/` and `.apm/prompts/` directories into the compiled AGENTS.md file. This ensures all prompts are available to coding agents without manual compilation.
-- **Use Cases:**
-  - Set to `false` if you want to manually manage which prompts are compiled
-  - Set to `true` to ensure all prompts are always included in the context
+**Options:**
+- `--global` - Write to `~/.apm/.apmrc` instead of the project file.
 
 **Examples:**
 ```bash
-# Enable auto-integration (default)
-apm config set auto-integrate true
-
-# Disable auto-integration
+apm config set registry https://custom-registry.example.com
 apm config set auto-integrate false
-
-# Using alternative boolean values
-apm config set auto-integrate yes
-apm config set auto-integrate 1
+apm config set github-token ghp_xxxx --global
+apm config set @myorg:registry https://myorg.pkg.github.com
 ```
+
+#### `apm config delete` - Delete a configuration key
+
+```bash
+apm config delete KEY [--global]
+```
+
+**Examples:**
+```bash
+apm config delete registry
+apm config delete github-token --global
+```
+
+#### `apm config show-rc` - Show merged .apmrc values
+
+Display all `.apmrc` configuration values from all loaded files. Tokens are masked as `***`.
+
+```bash
+apm config show-rc [--json]
+```
+
+#### `apm config which-rc` - Show loaded .apmrc files
+
+List which `.apmrc` files are active and their precedence order.
+
+```bash
+apm config which-rc
+```
+
+#### `apm config init-rc` - Scaffold a new .apmrc
+
+Create a new `.apmrc` file with commented-out defaults. File is created with `0600` permissions.
+
+```bash
+apm config init-rc [--global] [--force]
+```
+
+#### `apm config edit` - Open .apmrc in editor
+
+```bash
+apm config edit [--global]
+```
+
+Opens the project or global `.apmrc` in `$EDITOR`.
 
 ## Runtime Management (Experimental)
 

--- a/src/apm_cli/apmrc.py
+++ b/src/apm_cli/apmrc.py
@@ -1,0 +1,661 @@
+"""
+Parser and loader for .apmrc configuration files.
+
+File format: flat INI-style key=value pairs with ${ENV_VAR} substitution.
+Supports scoped registries (@scope:registry=url) and per-host auth tokens
+(//hostname/:_authToken=value), following .npmrc conventions.
+
+Env var substitution forms:
+  ${VAR}          - substitute; leave ${VAR} as-is if unset
+  ${VAR?}         - substitute; empty string if unset
+  ${VAR:-default} - substitute; use 'default' if unset or empty
+  ${VAR:+word}    - use 'word' if VAR is set and non-empty; else empty string
+"""
+
+from __future__ import annotations
+
+import configparser
+import logging
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+APMRC_FILENAME = ".apmrc"
+
+_SYNTHETIC_SECTION = "__apmrc__"
+
+DEFAULT_REGISTRY = "https://api.mcp.github.com"
+
+# Canonical key name for each recognised alias (hyphen-normalised form).
+_KEY_ALIASES: dict[str, str] = {
+    "registry": "registry",
+    "github-token": "github-token",
+    "github_token": "github-token",
+    "default-client": "default-client",
+    "default_client": "default-client",
+    "auto-integrate": "auto-integrate",
+    "auto_integrate": "auto-integrate",
+    "ci-mode": "ci-mode",
+    "ci_mode": "ci-mode",
+}
+
+# ---------------------------------------------------------------------------
+# Env-var substitution (compiled once at import time)
+# ---------------------------------------------------------------------------
+
+# Order matters: :-/  :+ must be matched before plain ${VAR} to avoid
+# partial matches on the colon.
+_RE_COND = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*):([+\-])([^}]*)\}")
+_RE_OPT = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\?\}")
+_RE_PLAIN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+# Sentinel used to protect backslash-escaped \${ sequences during expansion.
+_ESC_SENTINEL = "\x00APMRC_LITERAL_DOLLAR_BRACE\x00"
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ApmrcConfig:
+    """Parsed, env-expanded contents of a single .apmrc file."""
+
+    registry: Optional[str] = None
+    github_token: Optional[str] = None
+    default_client: Optional[str] = None
+    auto_integrate: Optional[bool] = None
+    ci_mode: Optional[bool] = None
+    scoped_registries: dict[str, str] = field(default_factory=dict)
+    auth_tokens: dict[str, str] = field(default_factory=dict)
+    # Unrecognised keys are stored here for forward compatibility.
+    raw: dict[str, str] = field(default_factory=dict)
+    source_file: Optional[Path] = None
+
+
+@dataclass
+class MergedApmrcConfig:
+    """Result of merging the full .apmrc file hierarchy."""
+
+    registry: str = DEFAULT_REGISTRY
+    github_token: Optional[str] = None
+    default_client: Optional[str] = None
+    auto_integrate: Optional[bool] = None
+    ci_mode: bool = False
+    scoped_registries: dict[str, str] = field(default_factory=dict)
+    auth_tokens: dict[str, str] = field(default_factory=dict)
+    # Paths of all .apmrc files that contributed to this config, in load order.
+    sources: list[Path] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Exception
+# ---------------------------------------------------------------------------
+
+
+class ApmrcParseError(ValueError):
+    """Raised when a .apmrc file cannot be parsed."""
+
+    def __init__(self, path: Path, reason: str) -> None:
+        super().__init__(f"Failed to parse {path}: {reason}")
+        self.path = path
+        self.reason = reason
+
+
+# ---------------------------------------------------------------------------
+# Env-var expansion
+# ---------------------------------------------------------------------------
+
+
+def expand_env_vars(value: str, env: Optional[dict[str, str]] = None) -> str:
+    """
+    Expand environment variable references in *value*.
+
+    Supported forms::
+
+        ${VAR}          substitute value of VAR; leave '${VAR}' as-is if unset
+        ${VAR?}         substitute value of VAR; empty string if unset
+        ${VAR:-default} substitute value of VAR; use 'default' if unset or empty
+        ${VAR:+word}    use 'word' if VAR is set and non-empty; else empty string
+
+    Args:
+        value: Raw string that may contain substitution tokens.
+        env:   Environment mapping to use; defaults to :data:`os.environ`.
+
+    Returns:
+        String with all recognised substitution tokens replaced.
+    """
+    if env is None:
+        env = os.environ  # type: ignore[assignment]
+
+    def _replace_cond(m: re.Match[str]) -> str:
+        name, operator, word = m.group(1), m.group(2), m.group(3)
+        var_value = env.get(name)  # type: ignore[arg-type]
+        if operator == "-":
+            # ${VAR:-default} — use default if unset or empty
+            return var_value if var_value else word
+        else:
+            # ${VAR:+word} — use word only if set and non-empty
+            return word if var_value else ""
+
+    def _replace_opt(m: re.Match[str]) -> str:
+        # ${VAR?} — empty string if unset
+        return env.get(m.group(1), "")  # type: ignore[arg-type]
+
+    def _replace_plain(m: re.Match[str]) -> str:
+        # ${VAR} — leave as-is if unset
+        name = m.group(1)
+        return env.get(name, m.group(0))  # type: ignore[arg-type]
+
+    # Protect backslash-escaped \${ sequences (npm convention).
+    value = value.replace("\\${", _ESC_SENTINEL)
+    # Apply substitutions in precedence order.
+    value = _RE_COND.sub(_replace_cond, value)
+    value = _RE_OPT.sub(_replace_opt, value)
+    value = _RE_PLAIN.sub(_replace_plain, value)
+    # Restore escaped sequences to literal ${.
+    value = value.replace(_ESC_SENTINEL, "${")
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_raw_pairs(text: str, path: Path) -> dict[str, str]:
+    """Parse flat INI text into a raw key→value dict.
+
+    A synthetic section header is prepended so that configparser accepts the
+    sectionless format.  The ``=`` character is the only delimiter, which
+    preserves colons inside keys (needed for ``@scope:registry`` and
+    ``//host/:_authToken``).
+    """
+    wrapped = f"[{_SYNTHETIC_SECTION}]\n" + text
+    parser = configparser.RawConfigParser(
+        delimiters=("=",),
+        comment_prefixes=("#", ";"),
+        strict=False,  # last duplicate key wins, matching .npmrc
+        allow_no_value=True,
+    )
+    parser.optionxform = str  # type: ignore[method-assign]  # preserve case
+    try:
+        parser.read_string(wrapped)
+    except configparser.Error as exc:
+        raise ApmrcParseError(path, str(exc)) from exc
+
+    return dict(parser.items(_SYNTHETIC_SECTION))
+
+
+def _to_bool(value: str) -> bool:
+    """Convert a string to bool using the same mapping as configparser."""
+    _BOOL_STATES = {
+        "true": True,
+        "1": True,
+        "yes": True,
+        "on": True,
+        "false": False,
+        "0": False,
+        "no": False,
+        "off": False,
+    }
+    lowered = value.strip().lower()
+    if lowered not in _BOOL_STATES:
+        raise ValueError(f"Not a boolean value: {value!r}")
+    return _BOOL_STATES[lowered]
+
+
+_RE_SCOPED_REGISTRY = re.compile(r"^@[^:]+:registry$")
+_RE_AUTH_TOKEN = re.compile(r"^//[^/].*/:_authToken$")
+
+
+def _classify_raw_pairs(
+    raw: dict[str, str],
+    path: Path,
+) -> ApmrcConfig:
+    """Route each raw key→value pair into the right ApmrcConfig field."""
+    cfg = ApmrcConfig(source_file=path)
+
+    for key, value in raw.items():
+        if value is None:
+            # allow_no_value keys — skip silently
+            continue
+
+        canonical = _KEY_ALIASES.get(key)
+        if canonical is not None:
+            if canonical == "registry":
+                cfg.registry = value
+            elif canonical == "github-token":
+                cfg.github_token = value
+            elif canonical == "default-client":
+                cfg.default_client = value
+            elif canonical == "auto-integrate":
+                try:
+                    cfg.auto_integrate = _to_bool(value)
+                except ValueError:
+                    logger.warning(
+                        "Ignoring invalid boolean for %r in %s: %r",
+                        canonical,
+                        path,
+                        value,
+                    )
+            elif canonical == "ci-mode":
+                try:
+                    cfg.ci_mode = _to_bool(value)
+                except ValueError:
+                    logger.warning(
+                        "Ignoring invalid boolean for %r in %s: %r",
+                        canonical,
+                        path,
+                        value,
+                    )
+        elif _RE_SCOPED_REGISTRY.match(key):
+            # Strip trailing ':registry' to get the bare scope.
+            scope = key[: key.rfind(":registry")]
+            cfg.scoped_registries[scope] = value
+        elif _RE_AUTH_TOKEN.match(key):
+            cfg.auth_tokens[key] = value
+        else:
+            logger.warning("Unknown key %r in %s (stored but unused)", key, path)
+            cfg.raw[key] = value
+
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Public API: file-level
+# ---------------------------------------------------------------------------
+
+
+def parse_file(
+    path: Path,
+    env: Optional[dict[str, str]] = None,
+) -> ApmrcConfig:
+    """Read and parse a single .apmrc file.
+
+    Args:
+        path: Path to the .apmrc file to read.
+        env:  Environment mapping for variable expansion; defaults to
+              :data:`os.environ`.
+
+    Returns:
+        :class:`ApmrcConfig` populated from the file.
+
+    Raises:
+        FileNotFoundError: If *path* does not exist.
+        ApmrcParseError:   If the file is malformed.
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"No such file: {path}")
+
+    # Warn about overly permissive file modes (tokens may be exposed).
+    if sys.platform != "win32":
+        try:
+            mode = path.stat().st_mode
+            if mode & 0o077:
+                logger.warning(
+                    "%s has overly permissive mode %04o. "
+                    "Consider running: chmod 600 %s",
+                    path,
+                    mode & 0o777,
+                    path,
+                )
+        except OSError:
+            pass
+
+    text = path.read_text(encoding="utf-8-sig")  # utf-8-sig strips BOM
+    raw = _parse_raw_pairs(text, path)
+
+    # Expand env vars in all values before classification.
+    expanded = {k: expand_env_vars(v, env) for k, v in raw.items() if v is not None}
+    # Restore None values for allow_no_value keys.
+    for k, v in raw.items():
+        if v is None:
+            expanded[k] = None  # type: ignore[assignment]
+
+    return _classify_raw_pairs(expanded, path)
+
+
+# ---------------------------------------------------------------------------
+# Public API: discovery
+# ---------------------------------------------------------------------------
+
+
+def find_global_apmrc_paths() -> list[Path]:
+    """Return candidate global .apmrc paths in ascending precedence order.
+
+    Checks the following locations, returning only those that exist:
+
+    1. ``~/.apmrc``
+    2. ``~/.apm/.apmrc``
+    3. ``$XDG_CONFIG_HOME/apm/.apmrc``  (skipped on Windows)
+
+    Returns:
+        List of existing :class:`~pathlib.Path` objects, lowest precedence first.
+    """
+    home = Path.home()
+    candidates: list[Path] = [
+        home / APMRC_FILENAME,
+        home / ".apm" / APMRC_FILENAME,
+    ]
+
+    if sys.platform != "win32":
+        xdg = os.environ.get("XDG_CONFIG_HOME", "")
+        if xdg:
+            candidates.append(Path(xdg) / "apm" / APMRC_FILENAME)
+        else:
+            candidates.append(home / ".config" / "apm" / APMRC_FILENAME)
+
+    return [p for p in candidates if p.exists()]
+
+
+def find_project_apmrc(start: Optional[Path] = None) -> Optional[Path]:
+    """Walk upward from *start* to find a project-level .apmrc.
+
+    The walk stops at the first directory that contains ``apm.yml``,
+    ``apm.yaml``, or ``.git``.  If an ``.apmrc`` is found at or before that
+    boundary it is returned; otherwise ``None`` is returned.
+
+    This prevents a global ``~/.apmrc`` from leaking into unrelated
+    directories when ``apm`` is run outside a project.
+
+    Args:
+        start: Starting directory; defaults to :func:`pathlib.Path.cwd`.
+
+    Returns:
+        Path to the ``.apmrc`` file, or ``None`` if not found.
+    """
+    current = (start or Path.cwd()).resolve()
+    _ROOT_MARKERS = {"apm.yml", "apm.yaml", ".git"}
+
+    while True:
+        apmrc = current / APMRC_FILENAME
+        if apmrc.exists():
+            return apmrc
+
+        # Stop if this directory is a project root (contains a root marker).
+        if any((current / marker).exists() for marker in _ROOT_MARKERS):
+            return None
+
+        parent = current.parent
+        if parent == current:
+            # Reached the filesystem root.
+            return None
+        current = parent
+
+
+# ---------------------------------------------------------------------------
+# Public API: hierarchy merge
+# ---------------------------------------------------------------------------
+
+
+def _merge_into(base: MergedApmrcConfig, layer: ApmrcConfig) -> None:
+    """Apply non-None fields from *layer* onto *base* in-place."""
+    if layer.registry is not None:
+        base.registry = layer.registry
+    if layer.github_token is not None:
+        base.github_token = layer.github_token
+    if layer.default_client is not None:
+        base.default_client = layer.default_client
+    if layer.auto_integrate is not None:
+        base.auto_integrate = layer.auto_integrate
+    if layer.ci_mode is not None:
+        base.ci_mode = layer.ci_mode
+    # Dicts are merged; later layers override earlier ones for the same key.
+    base.scoped_registries.update(layer.scoped_registries)
+    base.auth_tokens.update(layer.auth_tokens)
+    if layer.source_file is not None:
+        base.sources.append(layer.source_file)
+
+
+def _load_env_overrides(
+    env: Optional[dict[str, str]] = None,
+) -> ApmrcConfig:
+    """Build an ApmrcConfig from ``APM_CONFIG_*`` environment variables.
+
+    Maps ``APM_CONFIG_REGISTRY=url`` to ``registry=url``, mirroring npm's
+    ``npm_config_*`` convention.  Underscores in the suffix become hyphens.
+    """
+    if env is None:
+        env = os.environ  # type: ignore[assignment]
+    prefix = "APM_CONFIG_"
+    raw: dict[str, str] = {}
+    for key, value in env.items():  # type: ignore[union-attr]
+        if key.startswith(prefix) and len(key) > len(prefix):
+            config_key = key[len(prefix) :].lower().replace("_", "-")
+            raw[config_key] = value
+    return _classify_raw_pairs(raw, Path("<env>"))
+
+
+def load_merged_config(
+    cwd: Optional[Path] = None,
+    env: Optional[dict[str, str]] = None,
+) -> MergedApmrcConfig:
+    """Load and merge the full .apmrc hierarchy into one config object.
+
+    Merge order (later sources override earlier ones):
+
+    1. Global paths from :func:`find_global_apmrc_paths` (lowest precedence)
+    2. Project .apmrc from :func:`find_project_apmrc`
+    3. ``APM_CONFIG_*`` environment variables (highest precedence)
+
+    Args:
+        cwd: Working directory for project .apmrc discovery; defaults to
+             :func:`pathlib.Path.cwd`.
+        env: Environment mapping for variable expansion; defaults to
+             :data:`os.environ`.
+
+    Returns:
+        :class:`MergedApmrcConfig` with all layers merged.
+    """
+    merged = MergedApmrcConfig()
+
+    all_paths: list[Path] = list(find_global_apmrc_paths())
+    project = find_project_apmrc(cwd)
+    if project is not None and project not in all_paths:
+        all_paths.append(project)
+
+    for path in all_paths:
+        try:
+            layer = parse_file(path, env=env)
+        except (ApmrcParseError, OSError):
+            # Skip unreadable/malformed files gracefully.
+            continue
+        _merge_into(merged, layer)
+
+    # APM_CONFIG_* env vars override all file-based config.
+    env_layer = _load_env_overrides(env)
+    if (
+        env_layer.registry is not None
+        or env_layer.github_token is not None
+        or env_layer.default_client is not None
+        or env_layer.auto_integrate is not None
+        or env_layer.ci_mode is not None
+        or env_layer.scoped_registries
+        or env_layer.auth_tokens
+    ):
+        _merge_into(merged, env_layer)
+
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# Public API: convenience accessors
+# ---------------------------------------------------------------------------
+
+
+def get_registry_for_scope(scope: str, config: MergedApmrcConfig) -> str:
+    """Return the registry URL for *scope*, falling back to the default.
+
+    Args:
+        scope:  Scope string, e.g. ``'@myorg'`` or ``'myorg'``.
+        config: Merged config.
+
+    Returns:
+        Registry URL string.
+    """
+    key = scope if scope.startswith("@") else f"@{scope}"
+    return config.scoped_registries.get(key, config.registry)
+
+
+def get_auth_token_for_host(host: str, config: MergedApmrcConfig) -> Optional[str]:
+    """Return the ``_authToken`` for a registry host, or ``None``.
+
+    Looks up the ``//host/:_authToken`` key in :attr:`MergedApmrcConfig.auth_tokens`.
+
+    Args:
+        host:   Hostname, e.g. ``'myorg.pkg.github.com'``.
+        config: Merged config.
+
+    Returns:
+        Auth token string, or ``None`` if not configured.
+    """
+    key = f"//{host}/:_authToken"
+    return config.auth_tokens.get(key)
+
+
+# ---------------------------------------------------------------------------
+# Public API: file mutation helpers
+# ---------------------------------------------------------------------------
+
+
+def _safe_write(path: Path, content: str) -> None:
+    """Write *content* to *path* with restrictive permissions from the start.
+
+    On Unix the file is opened with mode ``0o600`` so there is no window
+    where its contents are world-readable.  Symlinks are rejected to
+    prevent write-redirection attacks.
+    """
+    resolved = path.resolve()
+    if path.exists() and not path.is_file():
+        raise OSError(f"Refusing to write to non-regular file: {path}")
+    if path.is_symlink():
+        raise OSError(f"Refusing to write through symlink: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if sys.platform != "win32":
+        fd = os.open(str(resolved), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.write(fd, content.encode("utf-8"))
+        finally:
+            os.close(fd)
+    else:
+        path.write_text(content, encoding="utf-8")
+
+
+def set_value_in_file(path: Path, key: str, value: str) -> None:
+    """Set or update a *key=value* pair in an .apmrc file.
+
+    If *key* already exists, its line is replaced in-place.  Otherwise the
+    pair is appended.  The file is created with mode ``0o600`` to prevent
+    token exposure.  Symlinks are rejected.
+
+    Args:
+        path:  Path to the .apmrc file (created if it does not exist).
+        key:   Configuration key (e.g. ``'registry'``, ``'@scope:registry'``).
+        value: Value to set.
+
+    Raises:
+        OSError: If *path* is a symlink or non-regular file.
+    """
+    lines: list[str] = []
+    found = False
+    if path.exists() and path.is_file() and not path.is_symlink():
+        lines = path.read_text(encoding="utf-8-sig").splitlines(keepends=True)
+        for i, line in enumerate(lines):
+            stripped = line.lstrip()
+            if (
+                stripped.startswith("#")
+                or stripped.startswith(";")
+                or "=" not in stripped
+            ):
+                continue
+            line_key = stripped.split("=", 1)[0].strip()
+            if line_key == key:
+                lines[i] = f"{key}={value}\n"
+                found = True
+                break
+    if not found:
+        lines.append(f"{key}={value}\n")
+    _safe_write(path, "".join(lines))
+
+
+def delete_value_from_file(path: Path, key: str) -> bool:
+    """Remove *key* from an .apmrc file.
+
+    Args:
+        path: Path to the .apmrc file.
+        key:  Configuration key to remove.
+
+    Returns:
+        ``True`` if the key was found and removed, ``False`` otherwise.
+
+    Raises:
+        OSError: If *path* is a symlink.
+    """
+    if not path.exists():
+        return False
+    if path.is_symlink():
+        raise OSError(f"Refusing to modify symlink: {path}")
+    lines = path.read_text(encoding="utf-8-sig").splitlines(keepends=True)
+    new_lines: list[str] = []
+    found = False
+    for line in lines:
+        stripped = line.lstrip()
+        if (
+            not stripped.startswith("#")
+            and not stripped.startswith(";")
+            and "=" in stripped
+        ):
+            line_key = stripped.split("=", 1)[0].strip()
+            if line_key == key:
+                found = True
+                continue
+        new_lines.append(line)
+    if found:
+        _safe_write(path, "".join(new_lines))
+    return found
+
+
+def get_value_from_merged(key: str, config: MergedApmrcConfig) -> Optional[str]:
+    """Look up any key from a :class:`MergedApmrcConfig`.
+
+    Handles plain keys, scoped registries (``@scope:registry``), and
+    auth token keys (``//host/:_authToken``).
+
+    Args:
+        key:    Configuration key to look up.
+        config: Merged configuration object.
+
+    Returns:
+        String representation of the value, or ``None`` if not set.
+    """
+    # Scoped registry
+    if _RE_SCOPED_REGISTRY.match(key):
+        scope = key[: key.rfind(":registry")]
+        return config.scoped_registries.get(scope)
+    # Auth token
+    if _RE_AUTH_TOKEN.match(key):
+        return config.auth_tokens.get(key)
+    # Plain key — map through aliases
+    canonical = _KEY_ALIASES.get(key, key)
+    _FIELD_MAP: dict[str, str] = {
+        "registry": "registry",
+        "github-token": "github_token",
+        "default-client": "default_client",
+        "auto-integrate": "auto_integrate",
+        "ci-mode": "ci_mode",
+    }
+    attr = _FIELD_MAP.get(canonical)
+    if attr:
+        val = getattr(config, attr, None)
+        return str(val) if val is not None else None
+    return None

--- a/src/apm_cli/commands/config.py
+++ b/src/apm_cli/commands/config.py
@@ -106,68 +106,310 @@ def config(ctx):
             click.echo(f"  APM CLI Version: {get_version()}")
 
 
+_SENSITIVE_KEY_PATTERNS = {"github-token", "github_token"}
+_SENSITIVE_KEY_SUFFIXES = (":_authToken", ":_password", ":_auth")
+
+
+def _is_sensitive_key(key: str) -> bool:
+    """Return True if *key* contains auth credentials."""
+    if key in _SENSITIVE_KEY_PATTERNS:
+        return True
+    return any(key.endswith(s) for s in _SENSITIVE_KEY_SUFFIXES)
+
+
+def _resolve_apmrc_path(is_global: bool) -> Path:
+    """Return the target .apmrc path for set/delete operations."""
+    if is_global:
+        target = Path.home() / ".apm" / ".apmrc"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        return target
+    from ..apmrc import find_project_apmrc
+
+    return find_project_apmrc() or Path.cwd() / ".apmrc"
+
+
 @config.command(help="Set a configuration value")
 @click.argument("key")
 @click.argument("value")
-def set(key, value):
-    """Set a configuration value.
+@click.option(
+    "--global",
+    "is_global",
+    is_flag=True,
+    help="Write to global ~/.apm/.apmrc instead of the project file.",
+)
+def set(key, value, is_global):
+    """Set a configuration value in .apmrc.
 
     Examples:
+        apm config set registry https://custom.registry.io
         apm config set auto-integrate false
-        apm config set auto-integrate true
+        apm config set github-token ghp_xxxx --global
     """
-    from ..config import set_auto_integrate
+    import re
+
+    from ..apmrc import set_value_in_file
+    from ..config import _invalidate_config_cache, set_auto_integrate
 
     logger = CommandLogger("config set")
-    if key == "auto-integrate":
-        if value.lower() in ["true", "1", "yes"]:
-            set_auto_integrate(True)
-            logger.success("Auto-integration enabled")
-        elif value.lower() in ["false", "0", "no"]:
-            set_auto_integrate(False)
-            logger.success("Auto-integration disabled")
-        else:
-            logger.error(f"Invalid value '{value}'. Use 'true' or 'false'.")
-            sys.exit(1)
-    else:
-        logger.error(f"Unknown configuration key: '{key}'")
-        logger.progress("Valid keys: auto-integrate")
-        logger.progress(
-            "This error may indicate a bug in command routing. Please report this issue."
-        )
+
+    # Validate key format to prevent injection via crafted key names.
+    if not re.match(r"^[@a-zA-Z0-9/_][a-zA-Z0-9_./:_-]*$", key):
+        logger.error(f"Invalid key format: '{key}'")
         sys.exit(1)
+
+    target = _resolve_apmrc_path(is_global)
+    set_value_in_file(target, key, value)
+    _invalidate_config_cache()
+
+    # Backward compat: also write auto-integrate to config.json.
+    if key == "auto-integrate":
+        if value.lower() in ("true", "1", "yes"):
+            set_auto_integrate(True)
+        elif value.lower() in ("false", "0", "no"):
+            set_auto_integrate(False)
+
+    logger.success(f"Set {key} in {target}")
 
 
 @config.command(help="Get a configuration value")
 @click.argument("key", required=False)
 def get(key):
-    """Get a configuration value or show all configuration.
+    """Get a configuration value from the merged .apmrc hierarchy.
 
     Examples:
+        apm config get registry
         apm config get auto-integrate
-        apm config get
+        apm config get               # show all
     """
-    from ..config import get_config, get_auto_integrate
+    from ..apmrc import get_value_from_merged, load_merged_config
+    from ..config import get_config
 
     logger = CommandLogger("config get")
+    merged = load_merged_config()
     if key:
-        if key == "auto-integrate":
-            value = get_auto_integrate()
-            click.echo(f"auto-integrate: {value}")
-        else:
-            logger.error(f"Unknown configuration key: '{key}'")
-            logger.progress("Valid keys: auto-integrate")
-            logger.progress(
-                "This error may indicate a bug in command routing. Please report this issue."
+        if _is_sensitive_key(key):
+            logger.error(
+                f"Key '{key}' is protected. "
+                "Use 'apm config show-rc' to see masked values."
             )
             sys.exit(1)
+        value = get_value_from_merged(key, merged)
+        if value is not None:
+            click.echo(f"{key}={value}")
+        else:
+            # Fall back to config.json for backward compat.
+            config_data = get_config()
+            json_key = key.replace("-", "_")
+            if json_key in config_data:
+                click.echo(f"{key}={config_data[json_key]}")
+            else:
+                logger.error(f"Key '{key}' is not set")
+                sys.exit(1)
     else:
-        # Show all config
+        # Show all config from both sources.
         config_data = get_config()
         logger.progress("APM Configuration:")
         for k, v in config_data.items():
-            # Map internal keys to user-friendly names
-            if k == "auto_integrate":
-                click.echo(f"  auto-integrate: {v}")
-            else:
-                click.echo(f"  {k}: {v}")
+            display_key = k.replace("_", "-")
+            click.echo(f"  {display_key}={v}")
+
+
+@config.command(help="Delete a configuration key from .apmrc")
+@click.argument("key")
+@click.option(
+    "--global",
+    "is_global",
+    is_flag=True,
+    help="Delete from global ~/.apm/.apmrc instead of the project file.",
+)
+def delete(key, is_global):
+    """Remove a key from an .apmrc file.
+
+    Examples:
+        apm config delete registry
+        apm config delete github-token --global
+    """
+    from ..apmrc import delete_value_from_file
+    from ..config import _invalidate_config_cache
+
+    logger = CommandLogger("config delete")
+    target = _resolve_apmrc_path(is_global)
+    if delete_value_from_file(target, key):
+        _invalidate_config_cache()
+        logger.success(f"Deleted {key} from {target}")
+    else:
+        logger.error(f"Key '{key}' not found in {target}")
+        sys.exit(1)
+
+
+@config.command("show-rc", help="Print all .apmrc configuration values")
+@click.option("--json", "as_json", is_flag=True, help="Output as JSON.")
+def show_rc(as_json):
+    """Print all .apmrc configuration values across all loaded files."""
+    import json as _json
+
+    from ..apmrc import load_merged_config
+
+    merged = load_merged_config()
+
+    def _mask(value):
+        return "***" if value else None
+
+    if as_json:
+        data = {
+            "registry": merged.registry,
+            "github_token": _mask(merged.github_token),
+            "default_client": merged.default_client,
+            "auto_integrate": merged.auto_integrate,
+            "ci_mode": merged.ci_mode,
+            "scoped_registries": merged.scoped_registries,
+            "auth_tokens": {k: "***" for k in merged.auth_tokens},
+            "sources": [str(s) for s in merged.sources],
+        }
+        click.echo(_json.dumps(data, indent=2))
+        return
+
+    try:
+        from rich.console import Console
+        from rich.table import Table
+
+        console = Console()
+        table = Table(
+            title=".apmrc configuration", show_header=True, header_style="bold cyan"
+        )
+        table.add_column("Key", style="cyan", no_wrap=True)
+        table.add_column("Value", style="green")
+
+        rows = [
+            ("registry", merged.registry),
+            ("github-token", _mask(merged.github_token)),
+            ("default-client", merged.default_client),
+            (
+                "auto-integrate",
+                (
+                    str(merged.auto_integrate)
+                    if merged.auto_integrate is not None
+                    else None
+                ),
+            ),
+            ("ci-mode", str(merged.ci_mode) if merged.ci_mode else None),
+        ]
+        for k, v in rows:
+            if v is not None:
+                table.add_row(k, v)
+        for scope, url in merged.scoped_registries.items():
+            table.add_row(f"{scope}:registry", url)
+        for host_key in merged.auth_tokens:
+            table.add_row(host_key, "***")
+
+        console.print(table)
+        if merged.sources:
+            console.print()
+            console.print("[dim]Loaded from (lowest → highest precedence):[/dim]")
+            for src in merged.sources:
+                console.print(f"  [dim]{src}[/dim]")
+    except ImportError:
+        for key, value in [
+            ("registry", merged.registry),
+            ("github-token", _mask(merged.github_token)),
+            ("default-client", merged.default_client),
+        ]:
+            if value is not None:
+                click.echo(f"{key}={value}")
+        for scope, url in merged.scoped_registries.items():
+            click.echo(f"{scope}:registry={url}")
+        for host_key in merged.auth_tokens:
+            click.echo(f"{host_key}=***")
+
+
+@config.command(
+    "which-rc", help="Show which .apmrc files are loaded and their precedence"
+)
+def which_rc():
+    """Show which .apmrc files are loaded and their precedence order."""
+    from ..apmrc import find_global_apmrc_paths, find_project_apmrc
+
+    global_paths = find_global_apmrc_paths()
+    project_path = find_project_apmrc()
+    all_paths = list(global_paths)
+    if project_path is not None and project_path not in all_paths:
+        all_paths.append(project_path)
+
+    if not all_paths:
+        click.echo("No .apmrc files found.")
+        return
+
+    for i, p in enumerate(all_paths, 1):
+        label = "project" if p == project_path else "global"
+        click.echo(f"  {i}. [{label}] {p}")
+
+
+_INIT_RC_TEMPLATE = """\
+# .apmrc — Agent Package Manager configuration
+# https://github.com/microsoft/apm/docs/apmrc.md
+#
+# Environment variable substitution:
+#   ${VAR}          — use env var; leave '${VAR}' as-is if unset
+#   ${VAR?}         — use env var; empty string if unset
+#   ${VAR:-default} — use env var; fall back to 'default' if unset/empty
+#   ${VAR:+word}    — use 'word' only if VAR is set and non-empty
+#
+# See docs/examples/.apmrc for a fully-annotated example.
+
+# registry=https://api.mcp.github.com
+# github-token=${GITHUB_APM_PAT}
+# @myorg:registry=https://myorg.pkg.github.com
+# //myorg.pkg.github.com/:_authToken=${MYORG_REGISTRY_TOKEN}
+# default-client=claude
+# auto-integrate=true
+# ci-mode=${CI:+true}
+"""
+
+
+@config.command("init-rc", help="Scaffold a .apmrc file with commented-out defaults")
+@click.option(
+    "--global",
+    "is_global",
+    is_flag=True,
+    help="Write to ~/.apm/.apmrc instead of the current directory.",
+)
+@click.option("--force", is_flag=True, help="Overwrite an existing file.")
+def init_rc(is_global, force):
+    """Scaffold a .apmrc file with commented-out defaults."""
+    if is_global:
+        target = Path.home() / ".apm" / ".apmrc"
+        target.parent.mkdir(parents=True, exist_ok=True)
+    else:
+        target = Path.cwd() / ".apmrc"
+
+    if target.exists() and not force:
+        click.echo(f"{target} already exists. Use --force to overwrite.", err=True)
+        sys.exit(1)
+
+    from ..apmrc import _safe_write
+
+    _safe_write(target, _INIT_RC_TEMPLATE)
+    click.echo(f"Created {target}")
+
+
+@config.command("edit", help="Open .apmrc in your editor")
+@click.option(
+    "--global",
+    "is_global",
+    is_flag=True,
+    help="Edit global ~/.apm/.apmrc instead of the project file.",
+)
+def edit(is_global):
+    """Open .apmrc in $EDITOR or $VISUAL."""
+    import os as _os
+    import subprocess
+
+    from ..apmrc import find_project_apmrc
+
+    editor = _os.environ.get("EDITOR", _os.environ.get("VISUAL", "vi"))
+    if is_global:
+        target = Path.home() / ".apm" / ".apmrc"
+        target.parent.mkdir(parents=True, exist_ok=True)
+    else:
+        target = find_project_apmrc() or Path.cwd() / ".apmrc"
+    subprocess.run([editor, str(target)])

--- a/src/apm_cli/config.py
+++ b/src/apm_cli/config.py
@@ -4,6 +4,13 @@ import json
 import os
 from typing import Optional
 
+from apm_cli.apmrc import (
+    DEFAULT_REGISTRY,
+    MergedApmrcConfig,
+    get_registry_for_scope,
+    load_merged_config,
+)
+
 CONFIG_DIR = os.path.expanduser("~/.apm")
 CONFIG_FILE = os.path.join(CONFIG_DIR, "config.json")
 
@@ -38,9 +45,10 @@ def get_config():
 
 
 def _invalidate_config_cache():
-    """Invalidate the config cache (called after writes)."""
-    global _config_cache
+    """Invalidate both config caches (called after writes)."""
+    global _config_cache, _apmrc_cache
     _config_cache = None
+    _apmrc_cache = None
 
 
 def update_config(updates):
@@ -92,3 +100,68 @@ def set_auto_integrate(enabled: bool) -> None:
         enabled: Whether to enable auto-integration.
     """
     update_config({"auto_integrate": enabled})
+
+
+# ---------------------------------------------------------------------------
+# .apmrc integration
+# ---------------------------------------------------------------------------
+
+_apmrc_cache: Optional[MergedApmrcConfig] = None
+
+
+def get_apmrc_config(refresh: bool = False) -> MergedApmrcConfig:
+    """Return the merged .apmrc config (cached after first call).
+
+    Args:
+        refresh: If True, reload from disk and discard the cached value.
+
+    Returns:
+        MergedApmrcConfig with all layers merged.
+    """
+    global _apmrc_cache
+    if _apmrc_cache is None or refresh:
+        _apmrc_cache = load_merged_config()
+    return _apmrc_cache
+
+
+def get_effective_registry(scope: Optional[str] = None) -> str:
+    """Return the registry URL respecting the full config hierarchy.
+
+    Priority (highest first):
+      1. ``MCP_REGISTRY_URL`` environment variable
+      2. Scoped registry from .apmrc (when *scope* is given)
+      3. Default registry from .apmrc
+      4. Built-in default
+
+    Args:
+        scope: Optional scope string, e.g. ``'@myorg'``.
+
+    Returns:
+        Registry URL string.
+    """
+    env_url = os.environ.get("MCP_REGISTRY_URL")
+    if env_url:
+        return env_url
+    rc = get_apmrc_config()
+    if scope:
+        return get_registry_for_scope(scope, rc)
+    return rc.registry or DEFAULT_REGISTRY
+
+
+def get_effective_token() -> Optional[str]:
+    """Return the best available GitHub auth token.
+
+    Priority (highest first):
+      1. ``GITHUB_APM_PAT`` environment variable
+      2. ``GITHUB_TOKEN`` environment variable
+      3. ``GH_TOKEN`` environment variable
+      4. ``github-token`` from .apmrc
+
+    Returns:
+        Token string, or None if no token is configured.
+    """
+    for env_key in ("GITHUB_APM_PAT", "GITHUB_TOKEN", "GH_TOKEN"):
+        val = os.environ.get(env_key)
+        if val:
+            return val
+    return get_apmrc_config().github_token

--- a/src/apm_cli/core/token_manager.py
+++ b/src/apm_cli/core/token_manager.py
@@ -26,36 +26,45 @@ from typing import Dict, Optional, Tuple
 
 class GitHubTokenManager:
     """Manages GitHub token environment setup for different AI runtimes."""
-    
+
     # Define token precedence for different use cases
     TOKEN_PRECEDENCE = {
-        'copilot': ['GITHUB_COPILOT_PAT', 'GITHUB_TOKEN', 'GITHUB_APM_PAT'],
-        'models': ['GITHUB_TOKEN', 'GITHUB_APM_PAT'],  # GitHub Models prefers user-scoped PAT, falls back to APM PAT
-        'modules': ['GITHUB_APM_PAT', 'GITHUB_TOKEN', 'GH_TOKEN'],  # APM module access (GitHub)
-        'ado_modules': ['ADO_APM_PAT'],  # APM module access (Azure DevOps)
-        'artifactory_modules': ['ARTIFACTORY_APM_TOKEN'],  # APM module access (JFrog Artifactory)
+        "copilot": ["GITHUB_COPILOT_PAT", "GITHUB_TOKEN", "GITHUB_APM_PAT"],
+        "models": [
+            "GITHUB_TOKEN",
+            "GITHUB_APM_PAT",
+        ],  # GitHub Models prefers user-scoped PAT, falls back to APM PAT
+        "modules": [
+            "GITHUB_APM_PAT",
+            "GITHUB_TOKEN",
+            "GH_TOKEN",
+        ],  # APM module access (GitHub)
+        "ado_modules": ["ADO_APM_PAT"],  # APM module access (Azure DevOps)
+        "artifactory_modules": [
+            "ARTIFACTORY_APM_TOKEN"
+        ],  # APM module access (JFrog Artifactory)
     }
-    
+
     # Runtime-specific environment variable mappings
     RUNTIME_ENV_VARS = {
-        'copilot': ['GH_TOKEN', 'GITHUB_PERSONAL_ACCESS_TOKEN'],
-        'codex': ['GITHUB_TOKEN'],  # Uses GITHUB_TOKEN directly
-        'llm': ['GITHUB_MODELS_KEY'],  # LLM-specific variable for GitHub Models
+        "copilot": ["GH_TOKEN", "GITHUB_PERSONAL_ACCESS_TOKEN"],
+        "codex": ["GITHUB_TOKEN"],  # Uses GITHUB_TOKEN directly
+        "llm": ["GITHUB_MODELS_KEY"],  # LLM-specific variable for GitHub Models
     }
-    
+
     def __init__(self, preserve_existing: bool = True):
         """Initialize token manager.
-        
+
         Args:
             preserve_existing: If True, never overwrite existing environment variables
         """
         self.preserve_existing = preserve_existing
         self._credential_cache: Dict[str, Optional[str]] = {}
-    
+
     @staticmethod
     def _is_valid_credential_token(token: str) -> bool:
         """Validate that a credential-fill token looks like a real credential.
-        
+
         Rejects garbage values that can appear when GIT_ASKPASS or credential
         helpers return prompt text instead of actual tokens.
         """
@@ -63,9 +72,14 @@ class GitHubTokenManager:
             return False
         if len(token) > 1024:
             return False
-        if any(c in token for c in (' ', '\t', '\n', '\r')):
+        if any(c in token for c in (" ", "\t", "\n", "\r")):
             return False
-        prompt_fragments = ('Password for', 'Username for', 'password for', 'username for')
+        prompt_fragments = (
+            "Password for",
+            "Username for",
+            "password for",
+            "username for",
+        )
         if any(fragment in token for fragment in prompt_fragments):
             return False
         return True
@@ -94,128 +108,144 @@ class GitHubTokenManager:
     @staticmethod
     def resolve_credential_from_git(host: str) -> Optional[str]:
         """Resolve a credential from the git credential store.
-        
+
         Uses `git credential fill` to query the user's configured credential
         helpers (macOS Keychain, Windows Credential Manager, gh CLI, etc.).
         This is the same mechanism git clone uses internally.
-        
+
         Args:
             host: The git host to resolve credentials for (e.g., "github.com")
-            
+
         Returns:
             The password/token from the credential store, or None if unavailable
         """
         try:
             result = subprocess.run(
-                ['git', 'credential', 'fill'],
+                ["git", "credential", "fill"],
                 input=f"protocol=https\nhost={host}\n\n",
                 capture_output=True,
                 text=True,
                 timeout=GitHubTokenManager._get_credential_timeout(),
-                env={**os.environ, 'GIT_TERMINAL_PROMPT': '0',
-                     'GIT_ASKPASS': '' if sys.platform != 'win32' else 'echo'},
+                env={
+                    **os.environ,
+                    "GIT_TERMINAL_PROMPT": "0",
+                    "GIT_ASKPASS": "" if sys.platform != "win32" else "echo",
+                },
             )
             if result.returncode != 0:
                 return None
-            
+
             for line in result.stdout.splitlines():
-                if line.startswith('password='):
-                    token = line[len('password='):]
+                if line.startswith("password="):
+                    token = line[len("password=") :]
                     if token and GitHubTokenManager._is_valid_credential_token(token):
                         return token
                     return None
             return None
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
             return None
-        
+
     def setup_environment(self, env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
         """Set up complete token environment for all runtimes.
-        
+
         Args:
             env: Environment dictionary to modify (defaults to os.environ.copy())
-            
+
         Returns:
             Updated environment dictionary with all required tokens set
         """
         if env is None:
             env = os.environ.copy()
-        
+
         # Get available tokens
         available_tokens = self._get_available_tokens(env)
-        
+
         # Set up tokens for each runtime without overwriting existing values
         self._setup_copilot_tokens(env, available_tokens)
         self._setup_codex_tokens(env, available_tokens)
         self._setup_llm_tokens(env, available_tokens)
-        
+
         return env
-    
-    def get_token_for_purpose(self, purpose: str, env: Optional[Dict[str, str]] = None) -> Optional[str]:
+
+    def get_token_for_purpose(
+        self, purpose: str, env: Optional[Dict[str, str]] = None
+    ) -> Optional[str]:
         """Get the best available token for a specific purpose.
-        
+
         Args:
             purpose: Token purpose ('copilot', 'models', 'modules')
             env: Environment to check (defaults to os.environ)
-            
+
         Returns:
             Best available token for the purpose, or None if not available
         """
         if env is None:
             env = os.environ
-            
+
         if purpose not in self.TOKEN_PRECEDENCE:
             raise ValueError(f"Unknown purpose: {purpose}")
-            
+
         for token_var in self.TOKEN_PRECEDENCE[purpose]:
             token = env.get(token_var)
             if token:
                 return token
         return None
-    
-    def get_token_with_credential_fallback(self, purpose: str, host: str, env: Optional[Dict[str, str]] = None) -> Optional[str]:
+
+    def get_token_with_credential_fallback(
+        self, purpose: str, host: str, env: Optional[Dict[str, str]] = None
+    ) -> Optional[str]:
         """Get token for a purpose, falling back to git credential helpers.
-        
+
         Tries environment variables first (via get_token_for_purpose), then
         queries the git credential store as a last resort. Results are cached
         per host to avoid repeated subprocess calls.
-        
+
         Args:
             purpose: Token purpose ('modules', etc.)
             host: Git host to resolve credentials for (e.g., "github.com")
             env: Environment to check (defaults to os.environ)
-            
+
         Returns:
             Best available token, or None if not available from any source
         """
         token = self.get_token_for_purpose(purpose, env)
         if token:
             return token
-        
+
+        # Check .apmrc github-token before the git credential helper.
+        # Only applies to the 'modules' purpose (package downloads).
+        if purpose == "modules":
+            from apm_cli.config import get_effective_token
+
+            apmrc_token = get_effective_token()
+            if apmrc_token:
+                return apmrc_token
+
         if host in self._credential_cache:
             return self._credential_cache[host]
-        
+
         credential = self.resolve_credential_from_git(host)
         self._credential_cache[host] = credential
         return credential
-    
+
     def validate_tokens(self, env: Optional[Dict[str, str]] = None) -> Tuple[bool, str]:
         """Validate that required tokens are available.
-        
+
         Args:
             env: Environment to check (defaults to os.environ)
-            
+
         Returns:
             Tuple of (is_valid, error_message)
         """
         if env is None:
             env = os.environ
-            
+
         # Check for at least one valid token
         has_any_token = any(
-            self.get_token_for_purpose(purpose, env) 
-            for purpose in ['copilot', 'models', 'modules']
+            self.get_token_for_purpose(purpose, env)
+            for purpose in ["copilot", "models", "modules"]
         )
-        
+
         if not has_any_token:
             return False, (
                 "No tokens found. Set one of:\n"
@@ -223,19 +253,19 @@ class GitHubTokenManager:
                 "- GITHUB_APM_PAT (fine-grained PAT for APM modules on GitHub)\n"
                 "- ADO_APM_PAT (PAT for APM modules on Azure DevOps)"
             )
-        
+
         # Warn about GitHub Models access if only fine-grained PAT is available
-        models_token = self.get_token_for_purpose('models', env)
+        models_token = self.get_token_for_purpose("models", env)
         if not models_token:
-            has_fine_grained = env.get('GITHUB_APM_PAT')
+            has_fine_grained = env.get("GITHUB_APM_PAT")
             if has_fine_grained:
                 return True, (
                     "Warning: Only fine-grained PAT available. "
                     "GitHub Models requires GITHUB_TOKEN (user-scoped PAT)"
                 )
-        
+
         return True, "Token validation passed"
-    
+
     def _get_available_tokens(self, env: Dict[str, str]) -> Dict[str, str]:
         """Get all available GitHub tokens from environment."""
         tokens = {}
@@ -244,42 +274,46 @@ class GitHubTokenManager:
                 if token_var in env and env[token_var]:
                     tokens[token_var] = env[token_var]
         return tokens
-    
-    def _setup_copilot_tokens(self, env: Dict[str, str], available_tokens: Dict[str, str]):
+
+    def _setup_copilot_tokens(
+        self, env: Dict[str, str], available_tokens: Dict[str, str]
+    ):
         """Set up tokens for Copilot."""
-        copilot_token = self.get_token_for_purpose('copilot', available_tokens)
+        copilot_token = self.get_token_for_purpose("copilot", available_tokens)
         if not copilot_token:
             return
-            
-        for env_var in self.RUNTIME_ENV_VARS['copilot']:
+
+        for env_var in self.RUNTIME_ENV_VARS["copilot"]:
             if self.preserve_existing and env_var in env:
                 continue
             env[env_var] = copilot_token
-    
-    def _setup_codex_tokens(self, env: Dict[str, str], available_tokens: Dict[str, str]):
+
+    def _setup_codex_tokens(
+        self, env: Dict[str, str], available_tokens: Dict[str, str]
+    ):
         """Set up tokens for Codex CLI (preserve existing tokens)."""
         # Codex script checks for both GITHUB_TOKEN and GITHUB_APM_PAT
         # Set up GITHUB_TOKEN if not present
-        if not (self.preserve_existing and 'GITHUB_TOKEN' in env):
-            models_token = self.get_token_for_purpose('models', available_tokens)
-            if models_token and 'GITHUB_TOKEN' not in env:
-                env['GITHUB_TOKEN'] = models_token
-        
+        if not (self.preserve_existing and "GITHUB_TOKEN" in env):
+            models_token = self.get_token_for_purpose("models", available_tokens)
+            if models_token and "GITHUB_TOKEN" not in env:
+                env["GITHUB_TOKEN"] = models_token
+
         # Ensure GITHUB_APM_PAT is available if we have it
-        if not (self.preserve_existing and 'GITHUB_APM_PAT' in env):
-            apm_token = available_tokens.get('GITHUB_APM_PAT')
-            if apm_token and 'GITHUB_APM_PAT' not in env:
-                env['GITHUB_APM_PAT'] = apm_token
-    
+        if not (self.preserve_existing and "GITHUB_APM_PAT" in env):
+            apm_token = available_tokens.get("GITHUB_APM_PAT")
+            if apm_token and "GITHUB_APM_PAT" not in env:
+                env["GITHUB_APM_PAT"] = apm_token
+
     def _setup_llm_tokens(self, env: Dict[str, str], available_tokens: Dict[str, str]):
         """Set up tokens for LLM CLI."""
         # LLM uses GITHUB_MODELS_KEY, prefer GITHUB_TOKEN if available
-        if self.preserve_existing and 'GITHUB_MODELS_KEY' in env:
+        if self.preserve_existing and "GITHUB_MODELS_KEY" in env:
             return
-            
-        models_token = self.get_token_for_purpose('models', available_tokens)
+
+        models_token = self.get_token_for_purpose("models", available_tokens)
         if models_token:
-            env['GITHUB_MODELS_KEY'] = models_token
+            env["GITHUB_MODELS_KEY"] = models_token
 
 
 # Convenience functions for common use cases
@@ -295,19 +329,21 @@ def validate_github_tokens(env: Optional[Dict[str, str]] = None) -> Tuple[bool, 
     return manager.validate_tokens(env)
 
 
-def get_github_token_for_runtime(runtime: str, env: Optional[Dict[str, str]] = None) -> Optional[str]:
+def get_github_token_for_runtime(
+    runtime: str, env: Optional[Dict[str, str]] = None
+) -> Optional[str]:
     """Get the appropriate GitHub token for a specific runtime."""
     manager = GitHubTokenManager()
-    
+
     # Map runtime names to purposes
     runtime_to_purpose = {
-        'copilot': 'copilot',
-        'codex': 'models',
-        'llm': 'models',
+        "copilot": "copilot",
+        "codex": "models",
+        "llm": "models",
     }
-    
+
     purpose = runtime_to_purpose.get(runtime)
     if not purpose:
         raise ValueError(f"Unknown runtime: {runtime}")
-        
+
     return manager.get_token_for_purpose(purpose, env)

--- a/src/apm_cli/registry/client.py
+++ b/src/apm_cli/registry/client.py
@@ -1,8 +1,9 @@
 """Simple MCP Registry client for server discovery."""
 
 import os
+from typing import Any, Dict, List, Optional, Tuple
+
 import requests
-from typing import Dict, List, Optional, Any, Tuple
 
 
 class SimpleRegistryClient:
@@ -13,15 +14,38 @@ class SimpleRegistryClient:
 
         Args:
             registry_url (str, optional): URL of the MCP registry.
-                If not provided, uses the MCP_REGISTRY_URL environment variable
-                or falls back to the default demo registry.
+                If not provided, resolution order is:
+                1. ``MCP_REGISTRY_URL`` environment variable
+                2. ``registry`` key in .apmrc
+                3. Built-in default (``https://api.mcp.github.com``)
         """
-        self.registry_url = registry_url or os.environ.get(
-            "MCP_REGISTRY_URL", "https://api.mcp.github.com"
-        )
-        self.session = requests.Session()
+        if registry_url:
+            self.registry_url = registry_url
+        else:
+            from apm_cli.config import get_effective_registry
 
-    def list_servers(self, limit: int = 100, cursor: Optional[str] = None) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+            self.registry_url = get_effective_registry()
+        self.session = requests.Session()
+        self.session.headers.update(self._get_auth_headers())
+
+    def _get_auth_headers(self) -> Dict[str, str]:
+        """Return auth headers for the current registry host, if configured."""
+        from urllib.parse import urlparse
+
+        from apm_cli.apmrc import get_auth_token_for_host
+        from apm_cli.config import get_apmrc_config
+
+        host = urlparse(self.registry_url).hostname or ""
+        if not host:
+            return {}
+        token = get_auth_token_for_host(host, get_apmrc_config())
+        if token:
+            return {"Authorization": f"Bearer {token}"}
+        return {}
+
+    def list_servers(
+        self, limit: int = 100, cursor: Optional[str] = None
+    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
         """List all available servers in the registry.
 
         Args:
@@ -30,22 +54,22 @@ class SimpleRegistryClient:
 
         Returns:
             Tuple[List[Dict[str, Any]], Optional[str]]: List of server metadata dictionaries and the next cursor if available.
-        
+
         Raises:
             requests.RequestException: If the request fails.
         """
         url = f"{self.registry_url}/v0/servers"
         params = {}
-        
+
         if limit is not None:
-            params['limit'] = limit
+            params["limit"] = limit
         if cursor is not None:
-            params['cursor'] = cursor
-            
+            params["cursor"] = cursor
+
         response = self.session.get(url, params=params)
         response.raise_for_status()
         data = response.json()
-        
+
         # Extract servers - they're nested under "server" key in each item
         raw_servers = data.get("servers", [])
         servers = []
@@ -54,10 +78,10 @@ class SimpleRegistryClient:
                 servers.append(item["server"])
             else:
                 servers.append(item)  # Fallback for different structure
-                
+
         metadata = data.get("metadata", {})
         next_cursor = metadata.get("next_cursor")
-        
+
         return servers, next_cursor
 
     def search_servers(self, query: str) -> List[Dict[str, Any]]:
@@ -68,7 +92,7 @@ class SimpleRegistryClient:
 
         Returns:
             List[Dict[str, Any]]: List of matching server metadata dictionaries.
-        
+
         Raises:
             requests.RequestException: If the request fails.
         """
@@ -76,14 +100,14 @@ class SimpleRegistryClient:
         # If the query looks like a full identifier (e.g., "io.github.github/github-mcp-server"),
         # extract the repository name for the search
         search_query = self._extract_repository_name(query)
-        
+
         url = f"{self.registry_url}/v0/servers/search"
-        params = {'q': search_query}
-        
+        params = {"q": search_query}
+
         response = self.session.get(url, params=params)
         response.raise_for_status()
         data = response.json()
-        
+
         # Extract servers - they're nested under "server" key in each item
         raw_servers = data.get("servers", [])
         servers = []
@@ -92,7 +116,7 @@ class SimpleRegistryClient:
                 servers.append(item["server"])
             else:
                 servers.append(item)  # Fallback for different structure
-                
+
         return servers
 
     def get_server_info(self, server_id: str) -> Dict[str, Any]:
@@ -103,7 +127,7 @@ class SimpleRegistryClient:
 
         Returns:
             Dict[str, Any]: Server metadata dictionary.
-        
+
         Raises:
             requests.RequestException: If the request fails.
             ValueError: If the server is not found.
@@ -112,7 +136,7 @@ class SimpleRegistryClient:
         response = self.session.get(url)
         response.raise_for_status()
         data = response.json()
-        
+
         # Return the complete response including x-github and other metadata
         # but ensure the main server info is accessible at the top level
         if "server" in data:
@@ -121,16 +145,16 @@ class SimpleRegistryClient:
             for key, value in data.items():
                 if key != "server":
                     result[key] = value
-            
+
             if not result:
                 raise ValueError(f"Server '{server_id}' not found in registry")
-                
+
             return result
         else:
             if not data:
                 raise ValueError(f"Server '{server_id}' not found in registry")
             return data
-        
+
     def get_server_by_name(self, name: str) -> Optional[Dict[str, Any]]:
         """Find a server by its name using the search API.
 
@@ -139,13 +163,13 @@ class SimpleRegistryClient:
 
         Returns:
             Optional[Dict[str, Any]]: Server metadata dictionary or None if not found.
-        
+
         Raises:
             requests.RequestException: If the registry API request fails.
         """
         # Use search API to find by name - more efficient than listing all servers
         search_results = self.search_servers(name)
-        
+
         # Look for an exact match in search results
         for server in search_results:
             if server.get("name") == name:
@@ -153,11 +177,9 @@ class SimpleRegistryClient:
                     return self.get_server_info(server["id"])
                 except ValueError:
                     continue
-                    
-        return None
-    
 
-    
+        return None
+
     def find_server_by_reference(self, reference: str) -> Optional[Dict[str, Any]]:
         """Find a server by exact name match or server ID.
 
@@ -170,22 +192,22 @@ class SimpleRegistryClient:
 
         Returns:
             Optional[Dict[str, Any]]: Server metadata dictionary or None if not found.
-        
+
         Raises:
             requests.RequestException: If the registry API request fails.
         """
         # Strategy 1: Try as server ID first (direct lookup)
         try:
             # Check if it looks like a UUID (contains hyphens and is 36 chars)
-            if len(reference) == 36 and reference.count('-') == 4:
+            if len(reference) == 36 and reference.count("-") == 4:
                 return self.get_server_info(reference)
         except ValueError:
             pass
-        
+
         # Strategy 2: Use search API to find by name
         # search_servers now handles extracting repository names internally
         search_results = self.search_servers(reference)
-        
+
         # Pass 1: exact full-name match (prevents slug collisions)
         for server in search_results:
             server_name = server.get("name", "")
@@ -194,7 +216,7 @@ class SimpleRegistryClient:
                     return self.get_server_info(server["id"])
                 except ValueError:
                     continue
-        
+
         # Pass 2: fuzzy slug match (only when reference has no namespace)
         for server in search_results:
             server_name = server.get("name", "")
@@ -203,26 +225,26 @@ class SimpleRegistryClient:
                     return self.get_server_info(server["id"])
                 except ValueError:
                     continue
-                    
+
         # If not found by ID or exact name, server is not in registry
         return None
-    
+
     def _extract_repository_name(self, reference: str) -> str:
         """Extract the repository name from various identifier formats.
-        
+
         This method handles various naming patterns by extracting the part after
         the last slash, which typically represents the actual server/repository name.
-        
+
         Examples:
         - "io.github.github/github-mcp-server" -> "github-mcp-server"
         - "abc.dllde.io/some-server" -> "some-server"
         - "adb.ok/another-server" -> "another-server"
         - "github/github-mcp-server" -> "github-mcp-server"
         - "github-mcp-server" -> "github-mcp-server"
-        
+
         Args:
             reference (str): Server reference in various formats.
-            
+
         Returns:
             str: Repository name suitable for API search.
         """
@@ -230,13 +252,13 @@ class SimpleRegistryClient:
         # This works for any pattern like domain.tld/server, owner/repo, etc.
         if "/" in reference:
             return reference.split("/")[-1]
-        
+
         # Already a simple repo name
         return reference
-    
+
     def _is_server_match(self, reference: str, server_name: str) -> bool:
         """Check if a reference matches a server name using common patterns.
-        
+
         Matching rules:
         1. Exact string match always wins.
         2. Qualified references (contain '/') match if the server name ends
@@ -246,19 +268,19 @@ class SimpleRegistryClient:
            prevent slug collisions like 'microsoftdocs/mcp' matching
            'com.supabase/mcp'.
         3. Unqualified references fall back to slug (last segment) comparison.
-        
+
         Args:
             reference (str): Original reference from user.
             server_name (str): Server name from registry.
-            
+
         Returns:
             bool: True if they represent the same server.
         """
         # Direct match
         if reference == server_name:
             return True
-        
-        if '/' in reference:
+
+        if "/" in reference:
             # Qualified reference: allow suffix match at a namespace boundary.
             # e.g. "github/github-mcp-server" matches "io.github.github/github-mcp-server"
             # but "microsoftdocs/mcp" must NOT match "com.supabase/mcp".
@@ -268,9 +290,9 @@ class SimpleRegistryClient:
                 if prefix == "" or prefix.endswith("."):
                     return True
             return False
-            
+
         # Unqualified reference: fall back to slug comparison
         ref_repo = self._extract_repository_name(reference)
         server_repo = self._extract_repository_name(server_name)
-        
+
         return ref_repo == server_repo

--- a/tests/test_apmrc.py
+++ b/tests/test_apmrc.py
@@ -1,0 +1,1555 @@
+"""Tests for src/apm_cli/apmrc.py"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Allow running from the repo root without installing the package.
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from apm_cli.apmrc import (
+    APMRC_FILENAME,
+    ApmrcConfig,
+    ApmrcParseError,
+    MergedApmrcConfig,
+    expand_env_vars,
+    find_project_apmrc,
+    get_auth_token_for_host,
+    get_registry_for_scope,
+    load_merged_config,
+    parse_file,
+)
+
+# ===========================================================================
+# TestExpandEnvVars
+# ===========================================================================
+
+
+class TestExpandEnvVars:
+    ENV: dict[str, str] = {"FOO": "bar", "EMPTY": "", "CI": "1"}
+
+    def test_plain_var_defined(self) -> None:
+        assert expand_env_vars("${FOO}", self.ENV) == "bar"
+
+    def test_plain_var_undefined_left_as_is(self) -> None:
+        assert expand_env_vars("${UNDEF}", self.ENV) == "${UNDEF}"
+
+    def test_optional_var_undefined_gives_empty(self) -> None:
+        assert expand_env_vars("${UNDEF?}", self.ENV) == ""
+
+    def test_optional_var_defined_gives_value(self) -> None:
+        assert expand_env_vars("${FOO?}", self.ENV) == "bar"
+
+    def test_default_form_undefined(self) -> None:
+        assert expand_env_vars("${UNDEF:-fallback}", self.ENV) == "fallback"
+
+    def test_default_form_defined(self) -> None:
+        assert expand_env_vars("${FOO:-fallback}", self.ENV) == "bar"
+
+    def test_default_form_empty_uses_default(self) -> None:
+        assert expand_env_vars("${EMPTY:-fallback}", self.ENV) == "fallback"
+
+    def test_conditional_form_set(self) -> None:
+        assert expand_env_vars("${CI:+running}", self.ENV) == "running"
+
+    def test_conditional_form_unset(self) -> None:
+        assert expand_env_vars("${UNDEF:+running}", self.ENV) == ""
+
+    def test_conditional_form_empty_gives_empty(self) -> None:
+        # EMPTY is defined but empty — :+ should return empty string.
+        assert expand_env_vars("${EMPTY:+word}", self.ENV) == ""
+
+    def test_no_substitution_tokens(self) -> None:
+        assert expand_env_vars("plain_value", self.ENV) == "plain_value"
+
+    def test_multiple_tokens_in_one_value(self) -> None:
+        result = expand_env_vars("${FOO}:${CI}", self.ENV)
+        assert result == "bar:1"
+
+    def test_token_embedded_in_longer_string(self) -> None:
+        result = expand_env_vars("prefix-${FOO}-suffix", self.ENV)
+        assert result == "prefix-bar-suffix"
+
+    def test_defaults_to_os_environ(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("_APM_TEST_VAR", "hello")
+        assert expand_env_vars("${_APM_TEST_VAR}") == "hello"
+
+
+# ===========================================================================
+# TestParseFile
+# ===========================================================================
+
+
+class TestParseFile:
+    def test_parse_plain_registry(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("registry=https://example.com\n")
+        cfg = parse_file(f, env={})
+        assert cfg.registry == "https://example.com"
+
+    def test_parse_scoped_registry(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("@myorg:registry=https://custom.example.io\n")
+        cfg = parse_file(f, env={})
+        assert cfg.scoped_registries["@myorg"] == "https://custom.example.io"
+
+    def test_parse_auth_token_key(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("//custom.example.io/:_authToken=tok123\n")
+        cfg = parse_file(f, env={})
+        assert cfg.auth_tokens["//custom.example.io/:_authToken"] == "tok123"
+
+    def test_env_var_expanded_in_token(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("github-token=${TEST_TOKEN}\n")
+        cfg = parse_file(f, env={"TEST_TOKEN": "ghp_abc"})
+        assert cfg.github_token == "ghp_abc"
+
+    def test_env_var_undefined_left_as_is(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("github-token=${UNSET_TOKEN}\n")
+        cfg = parse_file(f, env={})
+        assert cfg.github_token == "${UNSET_TOKEN}"
+
+    def test_comment_hash_ignored(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("# comment\nregistry=https://x.io\n")
+        cfg = parse_file(f, env={})
+        assert cfg.registry == "https://x.io"
+
+    def test_comment_semicolon_ignored(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("; comment\nregistry=https://x.io\n")
+        cfg = parse_file(f, env={})
+        assert cfg.registry == "https://x.io"
+
+    def test_blank_lines_ignored(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("\n\nregistry=https://x.io\n\n")
+        cfg = parse_file(f, env={})
+        assert cfg.registry == "https://x.io"
+
+    def test_unknown_keys_stored_in_raw(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("future-key=some-value\n")
+        cfg = parse_file(f, env={})
+        assert cfg.raw.get("future-key") == "some-value"
+        assert cfg.registry is None
+
+    def test_boolean_auto_integrate_true(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("auto-integrate=true\n")
+        cfg = parse_file(f, env={})
+        assert cfg.auto_integrate is True
+
+    def test_boolean_auto_integrate_false(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("auto-integrate=false\n")
+        cfg = parse_file(f, env={})
+        assert cfg.auto_integrate is False
+
+    def test_boolean_yes_no(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("auto-integrate=yes\n")
+        cfg = parse_file(f, env={})
+        assert cfg.auto_integrate is True
+
+    def test_boolean_numeric(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("auto-integrate=1\n")
+        cfg = parse_file(f, env={})
+        assert cfg.auto_integrate is True
+
+    def test_boolean_case_insensitive(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("auto-integrate=True\n")
+        cfg = parse_file(f, env={})
+        assert cfg.auto_integrate is True
+
+    def test_hyphen_and_underscore_aliases(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("default_client=claude\n")
+        cfg = parse_file(f, env={})
+        assert cfg.default_client == "claude"
+
+    def test_source_file_set(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("registry=https://x.io\n")
+        cfg = parse_file(f, env={})
+        assert cfg.source_file == f
+
+    def test_file_not_found_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            parse_file(tmp_path / "nonexistent.apmrc", env={})
+
+    def test_utf8_bom_handled(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        # Write with BOM
+        f.write_bytes(b"\xef\xbb\xbfregistry=https://bom.io\n")
+        cfg = parse_file(f, env={})
+        assert cfg.registry == "https://bom.io"
+
+    def test_crlf_line_endings(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_bytes(b"registry=https://crlf.io\r\n")
+        cfg = parse_file(f, env={})
+        assert cfg.registry == "https://crlf.io"
+
+    def test_ci_mode_conditional(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("ci-mode=${CI:+true}\n")
+        cfg_ci = parse_file(f, env={"CI": "1"})
+        assert cfg_ci.ci_mode is True
+        cfg_no_ci = parse_file(f, env={})
+        # Empty string after substitution — not a valid bool, stored as None.
+        assert cfg_no_ci.ci_mode is None
+
+    def test_multiple_keys_parsed(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text(
+            "registry=https://r.io\n" "default-client=claude\n" "auto-integrate=false\n"
+        )
+        cfg = parse_file(f, env={})
+        assert cfg.registry == "https://r.io"
+        assert cfg.default_client == "claude"
+        assert cfg.auto_integrate is False
+
+
+# ===========================================================================
+# TestFindProjectApmrc
+# ===========================================================================
+
+
+class TestFindProjectApmrc:
+    def test_finds_apmrc_in_cwd(self, tmp_path: Path) -> None:
+        (tmp_path / ".apmrc").write_text("registry=https://x.io\n")
+        assert find_project_apmrc(tmp_path) == tmp_path / ".apmrc"
+
+    def test_finds_apmrc_in_parent(self, tmp_path: Path) -> None:
+        subdir = tmp_path / "subdir"
+        subdir.mkdir()
+        (tmp_path / ".apmrc").write_text("registry=https://x.io\n")
+        assert find_project_apmrc(subdir) == tmp_path / ".apmrc"
+
+    def test_finds_apmrc_in_grandparent(self, tmp_path: Path) -> None:
+        nested = tmp_path / "a" / "b"
+        nested.mkdir(parents=True)
+        (tmp_path / ".apmrc").write_text("registry=https://x.io\n")
+        assert find_project_apmrc(nested) == tmp_path / ".apmrc"
+
+    def test_stops_at_apm_yml_without_apmrc(self, tmp_path: Path) -> None:
+        (tmp_path / "apm.yml").write_text("name: test\n")
+        subdir = tmp_path / "subdir"
+        subdir.mkdir()
+        assert find_project_apmrc(subdir) is None
+
+    def test_finds_apmrc_at_apm_yml_root(self, tmp_path: Path) -> None:
+        (tmp_path / "apm.yml").write_text("name: test\n")
+        (tmp_path / ".apmrc").write_text("registry=https://x.io\n")
+        subdir = tmp_path / "subdir"
+        subdir.mkdir()
+        assert find_project_apmrc(subdir) == tmp_path / ".apmrc"
+
+    def test_stops_at_dot_git(self, tmp_path: Path) -> None:
+        (tmp_path / ".git").mkdir()
+        subdir = tmp_path / "subdir"
+        subdir.mkdir()
+        assert find_project_apmrc(subdir) is None
+
+    def test_finds_apmrc_at_dot_git_root(self, tmp_path: Path) -> None:
+        (tmp_path / ".git").mkdir()
+        (tmp_path / ".apmrc").write_text("registry=https://x.io\n")
+        subdir = tmp_path / "subdir"
+        subdir.mkdir()
+        assert find_project_apmrc(subdir) == tmp_path / ".apmrc"
+
+    def test_returns_none_when_no_markers_and_no_apmrc(self, tmp_path: Path) -> None:
+        # tmp_path is isolated; no .apmrc or root markers above it in tmp.
+        assert find_project_apmrc(tmp_path) is None
+
+    def test_apm_yaml_also_stops_walk(self, tmp_path: Path) -> None:
+        (tmp_path / "apm.yaml").write_text("name: test\n")
+        subdir = tmp_path / "subdir"
+        subdir.mkdir()
+        assert find_project_apmrc(subdir) is None
+
+
+# ===========================================================================
+# TestLoadMergedConfig
+# ===========================================================================
+
+
+class TestLoadMergedConfig:
+    def _write(self, path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+
+    def test_project_overrides_global(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home_dir = tmp_path / "home"
+        self._write(
+            home_dir / ".apm" / ".apmrc",
+            "registry=https://global.example.io\n",
+        )
+        project_dir = tmp_path / "project"
+        self._write(project_dir / "apm.yml", "name: test\n")
+        self._write(
+            project_dir / ".apmrc",
+            "registry=https://project.example.io\n",
+        )
+        monkeypatch.setenv("HOME", str(home_dir))
+        merged = load_merged_config(cwd=project_dir, env={})
+        assert merged.registry == "https://project.example.io"
+
+    def test_global_used_when_no_project_apmrc(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home_dir = tmp_path / "home"
+        self._write(
+            home_dir / ".apm" / ".apmrc",
+            "registry=https://global.example.io\n",
+        )
+        project_dir = tmp_path / "project"
+        self._write(project_dir / "apm.yml", "name: test\n")
+        monkeypatch.setenv("HOME", str(home_dir))
+        merged = load_merged_config(cwd=project_dir, env={})
+        assert merged.registry == "https://global.example.io"
+
+    def test_scoped_registries_merged_from_all_layers(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home_dir = tmp_path / "home"
+        self._write(
+            home_dir / ".apm" / ".apmrc",
+            "@globalorg:registry=https://global.io\n",
+        )
+        project_dir = tmp_path / "project"
+        self._write(project_dir / "apm.yml", "name: test\n")
+        self._write(
+            project_dir / ".apmrc",
+            "@projectorg:registry=https://project.io\n",
+        )
+        monkeypatch.setenv("HOME", str(home_dir))
+        merged = load_merged_config(cwd=project_dir, env={})
+        assert merged.scoped_registries.get("@globalorg") == "https://global.io"
+        assert merged.scoped_registries.get("@projectorg") == "https://project.io"
+
+    def test_sources_list_populated(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home_dir = tmp_path / "empty_home"
+        home_dir.mkdir(parents=True)
+        project_dir = tmp_path / "project"
+        self._write(project_dir / ".apmrc", "registry=https://x.io\n")
+        monkeypatch.setenv("HOME", str(home_dir))
+        merged = load_merged_config(cwd=project_dir, env={})
+        assert project_dir / ".apmrc" in merged.sources
+
+    def test_defaults_when_no_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home_dir = tmp_path / "empty_home"
+        home_dir.mkdir(parents=True)
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        monkeypatch.setenv("HOME", str(home_dir))
+        merged = load_merged_config(cwd=project_dir, env={})
+        assert merged.registry == "https://api.mcp.github.com"
+        assert merged.github_token is None
+        assert merged.sources == []
+
+    def test_auth_tokens_merged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home_dir = tmp_path / "home"
+        self._write(
+            home_dir / ".apm" / ".apmrc",
+            "//global.io/:_authToken=global_tok\n",
+        )
+        project_dir = tmp_path / "project"
+        self._write(project_dir / "apm.yml", "name: test\n")
+        self._write(
+            project_dir / ".apmrc",
+            "//project.io/:_authToken=project_tok\n",
+        )
+        monkeypatch.setenv("HOME", str(home_dir))
+        merged = load_merged_config(cwd=project_dir, env={})
+        assert merged.auth_tokens.get("//global.io/:_authToken") == "global_tok"
+        assert merged.auth_tokens.get("//project.io/:_authToken") == "project_tok"
+
+    def test_project_auth_token_overrides_global(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home_dir = tmp_path / "home"
+        self._write(
+            home_dir / ".apm" / ".apmrc",
+            "//shared.io/:_authToken=global_tok\n",
+        )
+        project_dir = tmp_path / "project"
+        self._write(project_dir / "apm.yml", "name: test\n")
+        self._write(
+            project_dir / ".apmrc",
+            "//shared.io/:_authToken=project_tok\n",
+        )
+        monkeypatch.setenv("HOME", str(home_dir))
+        merged = load_merged_config(cwd=project_dir, env={})
+        assert merged.auth_tokens["//shared.io/:_authToken"] == "project_tok"
+
+    def test_env_var_expanded_during_load(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home_dir = tmp_path / "empty_home"
+        home_dir.mkdir(parents=True)
+        project_dir = tmp_path / "project"
+        self._write(
+            project_dir / ".apmrc",
+            "github-token=${MY_TOKEN}\n",
+        )
+        monkeypatch.setenv("HOME", str(home_dir))
+        merged = load_merged_config(cwd=project_dir, env={"MY_TOKEN": "ghp_xyz"})
+        assert merged.github_token == "ghp_xyz"
+
+
+# ===========================================================================
+# TestScopeAndAuthHelpers
+# ===========================================================================
+
+
+class TestScopeAndAuthHelpers:
+    def _cfg(self, **kwargs: object) -> MergedApmrcConfig:
+        return MergedApmrcConfig(**kwargs)  # type: ignore[arg-type]
+
+    def test_scoped_registry_lookup(self) -> None:
+        cfg = self._cfg(scoped_registries={"@myorg": "https://myorg.io"})
+        assert get_registry_for_scope("@myorg", cfg) == "https://myorg.io"
+
+    def test_scope_without_at_prefix_normalised(self) -> None:
+        cfg = self._cfg(scoped_registries={"@myorg": "https://myorg.io"})
+        assert get_registry_for_scope("myorg", cfg) == "https://myorg.io"
+
+    def test_scoped_registry_falls_back_to_default(self) -> None:
+        cfg = self._cfg(registry="https://default.io")
+        assert get_registry_for_scope("@unknown", cfg) == "https://default.io"
+
+    def test_auth_token_for_host(self) -> None:
+        cfg = self._cfg(auth_tokens={"//myorg.pkg.github.com/:_authToken": "tok123"})
+        assert get_auth_token_for_host("myorg.pkg.github.com", cfg) == "tok123"
+
+    def test_auth_token_missing_returns_none(self) -> None:
+        cfg = self._cfg()
+        assert get_auth_token_for_host("unknown.host", cfg) is None
+
+    def test_auth_token_exact_host_match(self) -> None:
+        cfg = self._cfg(
+            auth_tokens={
+                "//a.example.com/:_authToken": "tok_a",
+                "//b.example.com/:_authToken": "tok_b",
+            }
+        )
+        assert get_auth_token_for_host("a.example.com", cfg) == "tok_a"
+        assert get_auth_token_for_host("b.example.com", cfg) == "tok_b"
+
+
+# ===========================================================================
+# TestFindGlobalApmrcPaths — XDG_CONFIG_HOME and global discovery
+# ===========================================================================
+
+
+class TestFindGlobalApmrcPaths:
+    from apm_cli.apmrc import find_global_apmrc_paths
+
+    def test_xdg_config_home_used_on_non_windows(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import sys
+
+        if sys.platform == "win32":
+            pytest.skip("XDG not applicable on Windows")
+
+        xdg = tmp_path / "xdg"
+        apmrc = xdg / "apm" / APMRC_FILENAME
+        apmrc.parent.mkdir(parents=True)
+        apmrc.write_text("registry=https://xdg.io\n")
+
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        monkeypatch.setenv("HOME", str(home_dir))
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+
+        from apm_cli.apmrc import find_global_apmrc_paths
+
+        paths = find_global_apmrc_paths()
+        assert apmrc in paths
+
+    def test_fallback_to_dot_config_without_xdg_var(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import sys
+
+        if sys.platform == "win32":
+            pytest.skip("XDG not applicable on Windows")
+
+        home_dir = tmp_path / "home"
+        dot_config_apmrc = home_dir / ".config" / "apm" / APMRC_FILENAME
+        dot_config_apmrc.parent.mkdir(parents=True)
+        dot_config_apmrc.write_text("registry=https://dotconfig.io\n")
+
+        monkeypatch.setenv("HOME", str(home_dir))
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+        from apm_cli.apmrc import find_global_apmrc_paths
+
+        paths = find_global_apmrc_paths()
+        assert dot_config_apmrc in paths
+
+    def test_nonexistent_paths_not_returned(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home_dir = tmp_path / "empty_home"
+        home_dir.mkdir()
+        monkeypatch.setenv("HOME", str(home_dir))
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+        from apm_cli.apmrc import find_global_apmrc_paths
+
+        paths = find_global_apmrc_paths()
+        assert paths == []
+
+
+# ===========================================================================
+# TestConfigIntegration — config.py additions
+# ===========================================================================
+
+
+class TestConfigIntegration:
+    def test_get_effective_registry_respects_env_var(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("MCP_REGISTRY_URL", "https://env-registry.io")
+        # Force cache refresh after monkeypatching
+        from apm_cli import config as cfg_module
+
+        cfg_module._apmrc_cache = None
+        from apm_cli.config import get_effective_registry
+
+        assert get_effective_registry() == "https://env-registry.io"
+        monkeypatch.delenv("MCP_REGISTRY_URL")
+        cfg_module._apmrc_cache = None
+
+    def test_get_effective_registry_falls_back_to_apmrc(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("MCP_REGISTRY_URL", raising=False)
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        (project_dir / "apm.yml").write_text("name: test\n")
+        (project_dir / ".apmrc").write_text("registry=https://apmrc-registry.io\n")
+
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        monkeypatch.setenv("HOME", str(home_dir))
+        monkeypatch.chdir(project_dir)
+
+        from apm_cli import config as cfg_module
+
+        cfg_module._apmrc_cache = None
+        from apm_cli.config import get_effective_registry
+
+        assert get_effective_registry() == "https://apmrc-registry.io"
+        cfg_module._apmrc_cache = None
+
+    def test_get_effective_token_env_var_takes_priority(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GITHUB_APM_PAT", "env_token_123")
+
+        from apm_cli import config as cfg_module
+
+        cfg_module._apmrc_cache = None
+        from apm_cli.config import get_effective_token
+
+        assert get_effective_token() == "env_token_123"
+        monkeypatch.delenv("GITHUB_APM_PAT")
+        cfg_module._apmrc_cache = None
+
+    def test_get_effective_token_skips_empty_env_var(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GITHUB_APM_PAT", "")
+        monkeypatch.setenv("GITHUB_TOKEN", "fallback_token")
+
+        from apm_cli import config as cfg_module
+
+        cfg_module._apmrc_cache = None
+        from apm_cli.config import get_effective_token
+
+        assert get_effective_token() == "fallback_token"
+        monkeypatch.delenv("GITHUB_APM_PAT")
+        monkeypatch.delenv("GITHUB_TOKEN")
+        cfg_module._apmrc_cache = None
+
+    def test_get_apmrc_config_cache_refresh(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        monkeypatch.setenv("HOME", str(home_dir))
+
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        monkeypatch.chdir(project_dir)
+
+        from apm_cli import config as cfg_module
+
+        cfg_module._apmrc_cache = None
+        from apm_cli.config import get_apmrc_config
+
+        first = get_apmrc_config()
+        second = get_apmrc_config()
+        assert first is second  # cached
+
+        third = get_apmrc_config(refresh=True)
+        assert third is not first  # fresh load
+
+        cfg_module._apmrc_cache = None
+
+
+# ===========================================================================
+# TestInitRcTemplate — verifies the scaffolded .apmrc template content
+# ===========================================================================
+
+
+class TestInitRcTemplate:
+    def test_template_uses_single_braces(self) -> None:
+        from apm_cli.commands.config import _INIT_RC_TEMPLATE
+
+        # Must not contain double-brace artifacts from non-f-string formatting.
+        assert "{{" not in _INIT_RC_TEMPLATE
+        assert "}}" not in _INIT_RC_TEMPLATE
+
+    def test_template_contains_expected_keys(self) -> None:
+        from apm_cli.commands.config import _INIT_RC_TEMPLATE
+
+        for expected in (
+            "registry=",
+            "github-token=",
+            "default-client=",
+            "auto-integrate=",
+            "ci-mode=",
+        ):
+            assert expected in _INIT_RC_TEMPLATE, f"Missing key: {expected}"
+
+    def test_template_env_vars_use_correct_syntax(self) -> None:
+        # Each env var reference should look like ${VAR_NAME}
+        import re
+
+        from apm_cli.commands.config import _INIT_RC_TEMPLATE
+
+        refs = re.findall(r"\$\{[^}]+\}", _INIT_RC_TEMPLATE)
+        assert len(refs) >= 2  # at least github-token and ci-mode
+        for ref in refs:
+            assert ref.startswith("${") and ref.endswith("}")
+
+
+# ===========================================================================
+# TestExpandEnvVarsEdgeCases — additional edge cases
+# ===========================================================================
+
+
+class TestExpandEnvVarsEdgeCases:
+    def test_invalid_var_name_left_as_is(self) -> None:
+        # Variable names starting with digits are invalid per the regex.
+        assert expand_env_vars("${123}", {}) == "${123}"
+
+    def test_nested_dollar_brace_not_expanded(self) -> None:
+        # No recursive expansion: inner ${FOO} is literal.
+        assert expand_env_vars("${${FOO}}", {"FOO": "bar"}) == "${bar}"
+
+    def test_empty_string_value(self) -> None:
+        assert expand_env_vars("", {"FOO": "bar"}) == ""
+
+    def test_dollar_sign_without_brace_untouched(self) -> None:
+        assert expand_env_vars("$FOO", {"FOO": "bar"}) == "$FOO"
+
+    def test_default_with_empty_default_value(self) -> None:
+        # ${VAR:-} means empty string as default.
+        assert expand_env_vars("${UNDEF:-}", {}) == ""
+
+    def test_conditional_with_empty_word(self) -> None:
+        # ${VAR:+} means replace with empty string when set.
+        assert expand_env_vars("${FOO:+}", {"FOO": "bar"}) == ""
+
+    def test_mixed_forms_in_one_string(self) -> None:
+        env = {"A": "1", "C": "3"}
+        result = expand_env_vars("${A}-${B?}-${C:-default}-${D:+word}", env)
+        assert result == "1--3-"
+
+
+# ===========================================================================
+# TestParseFileEdgeCases — additional parse_file edge cases
+# ===========================================================================
+
+
+class TestParseFileEdgeCases:
+    def test_empty_file(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("")
+        cfg = parse_file(f, env={})
+        assert cfg.registry is None
+        assert cfg.scoped_registries == {}
+        assert cfg.auth_tokens == {}
+        assert cfg.raw == {}
+
+    def test_only_comments_file(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("# comment\n; another\n")
+        cfg = parse_file(f, env={})
+        assert cfg.registry is None
+
+    def test_duplicate_keys_last_wins(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("registry=https://first.io\nregistry=https://second.io\n")
+        cfg = parse_file(f, env={})
+        assert cfg.registry == "https://second.io"
+
+    def test_value_containing_equals(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("github-token=abc=def=ghi\n")
+        cfg = parse_file(f, env={})
+        assert cfg.github_token == "abc=def=ghi"
+
+    def test_spaces_around_equals(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("registry = https://spaced.io\n")
+        cfg = parse_file(f, env={})
+        assert cfg.registry == "https://spaced.io"
+
+    def test_malformed_boolean_stays_none(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("auto-integrate=garbage\n")
+        cfg = parse_file(f, env={})
+        assert cfg.auto_integrate is None
+
+    def test_invalid_auth_token_format_goes_to_raw(self, tmp_path: Path) -> None:
+        # Missing trailing /:_authToken pattern — should be stored in raw.
+        f = tmp_path / ".apmrc"
+        f.write_text("//hostname:_authToken=tok\n")
+        cfg = parse_file(f, env={})
+        assert cfg.auth_tokens == {}
+        assert "//hostname:_authToken" in cfg.raw
+
+    def test_multiple_scoped_registries(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text(
+            "@org1:registry=https://org1.io\n"
+            "@org2:registry=https://org2.io\n"
+            "@org3:registry=https://org3.io\n"
+        )
+        cfg = parse_file(f, env={})
+        assert len(cfg.scoped_registries) == 3
+        assert cfg.scoped_registries["@org1"] == "https://org1.io"
+        assert cfg.scoped_registries["@org3"] == "https://org3.io"
+
+    def test_env_var_in_scoped_registry(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("@myorg:registry=${ORG_REGISTRY}\n")
+        cfg = parse_file(f, env={"ORG_REGISTRY": "https://env.io"})
+        assert cfg.scoped_registries["@myorg"] == "https://env.io"
+
+    def test_env_var_with_default_in_auth_token(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("//example.io/:_authToken=${TOK:-default_tok}\n")
+        cfg = parse_file(f, env={})
+        assert cfg.auth_tokens["//example.io/:_authToken"] == "default_tok"
+
+    def test_all_key_aliases(self, tmp_path: Path) -> None:
+        # Verify every alias in _KEY_ALIASES resolves correctly.
+        f = tmp_path / ".apmrc"
+        f.write_text(
+            "github_token=tok1\n"
+            "default_client=cursor\n"
+            "auto_integrate=no\n"
+            "ci_mode=true\n"
+        )
+        cfg = parse_file(f, env={})
+        assert cfg.github_token == "tok1"
+        assert cfg.default_client == "cursor"
+        assert cfg.auto_integrate is False
+        assert cfg.ci_mode is True
+
+
+# ===========================================================================
+# TestApmrcParseError
+# ===========================================================================
+
+
+class TestApmrcParseError:
+    def test_error_attributes(self) -> None:
+        err = ApmrcParseError(Path("/foo/.apmrc"), "bad syntax")
+        assert err.path == Path("/foo/.apmrc")
+        assert err.reason == "bad syntax"
+        assert "/foo/.apmrc" in str(err)
+        assert "bad syntax" in str(err)
+
+
+# ===========================================================================
+# TestMergeInto — verify _merge_into semantics
+# ===========================================================================
+
+
+class TestMergeInto:
+    from apm_cli.apmrc import _merge_into
+
+    def test_none_fields_do_not_override(self) -> None:
+        from apm_cli.apmrc import _merge_into
+
+        base = MergedApmrcConfig(registry="https://base.io", github_token="base_tok")
+        layer = ApmrcConfig()  # all None
+        _merge_into(base, layer)
+        assert base.registry == "https://base.io"
+        assert base.github_token == "base_tok"
+
+    def test_non_none_fields_override(self) -> None:
+        from apm_cli.apmrc import _merge_into
+
+        base = MergedApmrcConfig(registry="https://base.io")
+        layer = ApmrcConfig(registry="https://layer.io", default_client="claude")
+        _merge_into(base, layer)
+        assert base.registry == "https://layer.io"
+        assert base.default_client == "claude"
+
+    def test_scoped_registries_merge_not_replace(self) -> None:
+        from apm_cli.apmrc import _merge_into
+
+        base = MergedApmrcConfig(scoped_registries={"@org1": "https://org1.io"})
+        layer = ApmrcConfig(scoped_registries={"@org2": "https://org2.io"})
+        _merge_into(base, layer)
+        assert base.scoped_registries == {
+            "@org1": "https://org1.io",
+            "@org2": "https://org2.io",
+        }
+
+    def test_same_scope_overridden(self) -> None:
+        from apm_cli.apmrc import _merge_into
+
+        base = MergedApmrcConfig(scoped_registries={"@org1": "https://old.io"})
+        layer = ApmrcConfig(scoped_registries={"@org1": "https://new.io"})
+        _merge_into(base, layer)
+        assert base.scoped_registries["@org1"] == "https://new.io"
+
+
+# ===========================================================================
+# TestLoadMergedConfigEdgeCases
+# ===========================================================================
+
+
+class TestLoadMergedConfigEdgeCases:
+    def _write(self, path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+
+    def test_malformed_file_skipped_gracefully(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home_dir = tmp_path / "home"
+        # Write a binary/unreadable file that will cause a parse error.
+        bad_file = home_dir / ".apm" / ".apmrc"
+        bad_file.parent.mkdir(parents=True)
+        bad_file.write_bytes(b"\x00\x01\x02\x03")
+
+        project_dir = tmp_path / "project"
+        self._write(project_dir / ".apmrc", "registry=https://good.io\n")
+
+        monkeypatch.setenv("HOME", str(home_dir))
+        merged = load_merged_config(cwd=project_dir, env={})
+        # The malformed global file should be skipped; project one works.
+        assert merged.registry == "https://good.io"
+
+    def test_home_apmrc_and_apm_dir_both_loaded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home_dir = tmp_path / "home"
+        self._write(home_dir / ".apmrc", "default-client=vscode\n")
+        self._write(
+            home_dir / ".apm" / ".apmrc",
+            "registry=https://apm-dir.io\n",
+        )
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+
+        monkeypatch.setenv("HOME", str(home_dir))
+        merged = load_merged_config(cwd=project_dir, env={})
+        # Both global files should be loaded.
+        assert merged.default_client == "vscode"
+        assert merged.registry == "https://apm-dir.io"
+        assert len(merged.sources) == 2
+
+
+# ===========================================================================
+# TestClickCommands — test show-rc, which-rc, init-rc via CliRunner
+# ===========================================================================
+
+
+class TestClickCommands:
+    def test_show_rc_json(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import json as _json
+
+        from click.testing import CliRunner
+
+        from apm_cli.commands.config import config
+
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        monkeypatch.setenv("HOME", str(home_dir))
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".apmrc").write_text("registry=https://test.io\n")
+
+        # Clear the cache.
+        from apm_cli import config as cfg_module
+
+        cfg_module._apmrc_cache = None
+
+        runner = CliRunner()
+        result = runner.invoke(config, ["show-rc", "--json"])
+        assert result.exit_code == 0
+        data = _json.loads(result.output)
+        assert data["registry"] == "https://test.io"
+
+        cfg_module._apmrc_cache = None
+
+    def test_show_rc_masks_token(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import json as _json
+
+        from click.testing import CliRunner
+
+        from apm_cli.commands.config import config
+
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        monkeypatch.setenv("HOME", str(home_dir))
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".apmrc").write_text("github-token=super_secret\n")
+
+        from apm_cli import config as cfg_module
+
+        cfg_module._apmrc_cache = None
+
+        runner = CliRunner()
+        result = runner.invoke(config, ["show-rc", "--json"])
+        assert result.exit_code == 0
+        data = _json.loads(result.output)
+        assert data["github_token"] == "***"
+        assert "super_secret" not in result.output
+
+        cfg_module._apmrc_cache = None
+
+    def test_which_rc_no_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from click.testing import CliRunner
+
+        from apm_cli.commands.config import config
+
+        home_dir = tmp_path / "empty_home"
+        home_dir.mkdir()
+        monkeypatch.setenv("HOME", str(home_dir))
+        monkeypatch.chdir(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(config, ["which-rc"])
+        assert result.exit_code == 0
+        assert "No .apmrc files found" in result.output
+
+    def test_which_rc_lists_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from click.testing import CliRunner
+
+        from apm_cli.commands.config import config
+
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        monkeypatch.setenv("HOME", str(home_dir))
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".apmrc").write_text("registry=https://x.io\n")
+
+        runner = CliRunner()
+        result = runner.invoke(config, ["which-rc"])
+        assert result.exit_code == 0
+        assert "[project]" in result.output
+
+    def test_init_rc_creates_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from click.testing import CliRunner
+
+        from apm_cli.commands.config import config
+
+        monkeypatch.chdir(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(config, ["init-rc"])
+        assert result.exit_code == 0
+        assert "Created" in result.output
+
+        created = tmp_path / ".apmrc"
+        assert created.exists()
+        content = created.read_text()
+        assert "${GITHUB_APM_PAT}" in content
+        assert "{{" not in content
+
+    def test_init_rc_refuses_overwrite(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from click.testing import CliRunner
+
+        from apm_cli.commands.config import config
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".apmrc").write_text("existing\n")
+
+        runner = CliRunner()
+        result = runner.invoke(config, ["init-rc"])
+        assert result.exit_code != 0
+        assert "already exists" in result.output
+
+    def test_init_rc_force_overwrites(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from click.testing import CliRunner
+
+        from apm_cli.commands.config import config
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".apmrc").write_text("old content\n")
+
+        runner = CliRunner()
+        result = runner.invoke(config, ["init-rc", "--force"])
+        assert result.exit_code == 0
+        content = (tmp_path / ".apmrc").read_text()
+        assert "old content" not in content
+        assert "github-token" in content
+
+    def test_init_rc_global(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from click.testing import CliRunner
+
+        from apm_cli.commands.config import config
+
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.chdir(tmp_path)
+
+        runner = CliRunner()
+        result = runner.invoke(config, ["init-rc", "--global"])
+        assert result.exit_code == 0
+        assert (tmp_path / ".apm" / ".apmrc").exists()
+
+
+# ===========================================================================
+# TestRegistryClientIntegration
+# ===========================================================================
+
+
+class TestRegistryClientIntegration:
+    def test_client_uses_effective_registry(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        monkeypatch.setenv("HOME", str(home_dir))
+        monkeypatch.delenv("MCP_REGISTRY_URL", raising=False)
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".apmrc").write_text("registry=https://custom.registry.io\n")
+
+        from apm_cli import config as cfg_module
+
+        cfg_module._apmrc_cache = None
+
+        from apm_cli.registry.client import SimpleRegistryClient
+
+        client = SimpleRegistryClient()
+        assert client.registry_url == "https://custom.registry.io"
+
+        cfg_module._apmrc_cache = None
+
+    def test_client_explicit_url_takes_priority(self) -> None:
+        from apm_cli.registry.client import SimpleRegistryClient
+
+        client = SimpleRegistryClient(registry_url="https://explicit.io")
+        assert client.registry_url == "https://explicit.io"
+
+
+# ===========================================================================
+# TestTokenManagerIntegration
+# ===========================================================================
+
+
+class TestTokenManagerIntegration:
+    def test_credential_fallback_uses_apmrc_for_modules(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        monkeypatch.setenv("HOME", str(home_dir))
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".apmrc").write_text("github-token=apmrc_tok_123\n")
+
+        # Clear env vars so they don't interfere.
+        for k in ("GITHUB_APM_PAT", "GITHUB_TOKEN", "GH_TOKEN"):
+            monkeypatch.delenv(k, raising=False)
+
+        from apm_cli import config as cfg_module
+
+        cfg_module._apmrc_cache = None
+
+        from apm_cli.core.token_manager import GitHubTokenManager
+
+        mgr = GitHubTokenManager()
+        token = mgr.get_token_with_credential_fallback("modules", "github.com")
+        assert token == "apmrc_tok_123"
+
+        cfg_module._apmrc_cache = None
+
+    def test_credential_fallback_env_beats_apmrc(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        monkeypatch.setenv("HOME", str(home_dir))
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".apmrc").write_text("github-token=apmrc_tok\n")
+        monkeypatch.setenv("GITHUB_APM_PAT", "env_tok")
+
+        from apm_cli import config as cfg_module
+
+        cfg_module._apmrc_cache = None
+
+        from apm_cli.core.token_manager import GitHubTokenManager
+
+        mgr = GitHubTokenManager()
+        token = mgr.get_token_with_credential_fallback("modules", "github.com")
+        assert token == "env_tok"
+
+        monkeypatch.delenv("GITHUB_APM_PAT")
+        cfg_module._apmrc_cache = None
+
+    def test_credential_fallback_skips_apmrc_for_non_modules(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        monkeypatch.setenv("HOME", str(home_dir))
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".apmrc").write_text("github-token=apmrc_tok\n")
+
+        for k in ("GITHUB_COPILOT_PAT", "GITHUB_TOKEN", "GITHUB_APM_PAT", "GH_TOKEN"):
+            monkeypatch.delenv(k, raising=False)
+
+        from apm_cli import config as cfg_module
+
+        cfg_module._apmrc_cache = None
+
+        from apm_cli.core.token_manager import GitHubTokenManager
+
+        mgr = GitHubTokenManager()
+        # For 'copilot' purpose, .apmrc is NOT checked.
+        token = mgr.get_token_for_purpose("copilot")
+        assert token is None
+
+        cfg_module._apmrc_cache = None
+
+
+# ===========================================================================
+# TestBackslashEscaping — Step 1a
+# ===========================================================================
+
+
+class TestBackslashEscaping:
+    def test_escaped_var_produces_literal(self) -> None:
+        assert expand_env_vars("\\${FOO}", {"FOO": "bar"}) == "${FOO}"
+
+    def test_escaped_mixed_with_real_var(self) -> None:
+        result = expand_env_vars("\\${FOO}-${FOO}", {"FOO": "bar"})
+        assert result == "${FOO}-bar"
+
+    def test_escaped_in_default_form(self) -> None:
+        result = expand_env_vars("\\${FOO:-fallback}", {"FOO": "bar"})
+        assert result == "${FOO:-fallback}"
+
+    def test_escaped_in_optional_form(self) -> None:
+        result = expand_env_vars("\\${FOO?}", {"FOO": "bar"})
+        assert result == "${FOO?}"
+
+    def test_no_double_unescape(self) -> None:
+        # A single backslash escape should not be consumed twice.
+        result = expand_env_vars("\\${A}\\${B}", {"A": "1", "B": "2"})
+        assert result == "${A}${B}"
+
+    def test_backslash_in_file(self, tmp_path: Path) -> None:
+        f = tmp_path / ".apmrc"
+        f.write_text("registry=\\${NOT_EXPANDED}\n")
+        cfg = parse_file(f, env={"NOT_EXPANDED": "should_not_appear"})
+        assert cfg.registry == "${NOT_EXPANDED}"
+
+
+# ===========================================================================
+# TestBooleanWarning — Step 1b
+# ===========================================================================
+
+
+class TestBooleanWarning:
+    def test_malformed_boolean_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        f = tmp_path / ".apmrc"
+        f.write_text("auto-integrate=truee\n")
+        with caplog.at_level(logging.WARNING, logger="apm_cli.apmrc"):
+            cfg = parse_file(f, env={})
+        assert cfg.auto_integrate is None
+        assert "invalid boolean" in caplog.text.lower()
+
+    def test_valid_boolean_no_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        f = tmp_path / ".apmrc"
+        f.write_text("auto-integrate=true\n")
+        with caplog.at_level(logging.WARNING, logger="apm_cli.apmrc"):
+            cfg = parse_file(f, env={})
+        assert cfg.auto_integrate is True
+        assert "invalid boolean" not in caplog.text.lower()
+
+
+# ===========================================================================
+# TestCacheInvalidation — Step 1c
+# ===========================================================================
+
+
+class TestCacheInvalidation:
+    def test_invalidate_clears_both_caches(self) -> None:
+        from apm_cli import config as cfg_module
+        from apm_cli.config import _invalidate_config_cache
+
+        cfg_module._config_cache = {"dummy": True}
+        cfg_module._apmrc_cache = MergedApmrcConfig()
+        _invalidate_config_cache()
+        assert cfg_module._config_cache is None
+        assert cfg_module._apmrc_cache is None
+
+
+# ===========================================================================
+# TestRegistryAuthHeaders — Step 2
+# ===========================================================================
+
+
+class TestRegistryAuthHeaders:
+    def test_auth_token_applied_from_apmrc(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        monkeypatch.setenv("HOME", str(home_dir))
+        monkeypatch.delenv("MCP_REGISTRY_URL", raising=False)
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".apmrc").write_text(
+            "registry=https://registry.example.com\n"
+            "//registry.example.com/:_authToken=test_bearer_tok\n"
+        )
+
+        from apm_cli import config as cfg_module
+
+        cfg_module._apmrc_cache = None
+
+        from apm_cli.registry.client import SimpleRegistryClient
+
+        client = SimpleRegistryClient()
+        assert client.session.headers.get("Authorization") == "Bearer test_bearer_tok"
+
+        cfg_module._apmrc_cache = None
+
+    def test_no_auth_when_no_token(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        monkeypatch.setenv("HOME", str(home_dir))
+        monkeypatch.delenv("MCP_REGISTRY_URL", raising=False)
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".apmrc").write_text("registry=https://no-token.io\n")
+
+        from apm_cli import config as cfg_module
+
+        cfg_module._apmrc_cache = None
+
+        from apm_cli.registry.client import SimpleRegistryClient
+
+        client = SimpleRegistryClient()
+        assert "Authorization" not in client.session.headers
+
+        cfg_module._apmrc_cache = None
+
+
+# ===========================================================================
+# TestEnvOverrides — Step 3
+# ===========================================================================
+
+
+class TestEnvOverrides:
+    def test_apm_config_registry(self) -> None:
+        merged = load_merged_config(
+            cwd=Path("/nonexistent"),
+            env={"APM_CONFIG_REGISTRY": "https://env.io"},
+        )
+        assert merged.registry == "https://env.io"
+
+    def test_apm_config_underscore_to_hyphen(self) -> None:
+        merged = load_merged_config(
+            cwd=Path("/nonexistent"),
+            env={"APM_CONFIG_DEFAULT_CLIENT": "claude"},
+        )
+        assert merged.default_client == "claude"
+
+    def test_apm_config_github_token(self) -> None:
+        merged = load_merged_config(
+            cwd=Path("/nonexistent"),
+            env={"APM_CONFIG_GITHUB_TOKEN": "ghp_test"},
+        )
+        assert merged.github_token == "ghp_test"
+
+    def test_apm_config_auto_integrate(self) -> None:
+        merged = load_merged_config(
+            cwd=Path("/nonexistent"),
+            env={"APM_CONFIG_AUTO_INTEGRATE": "false"},
+        )
+        assert merged.auto_integrate is False
+
+    def test_env_overrides_project_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        monkeypatch.setenv("HOME", str(home_dir))
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / ".apmrc").write_text("registry=https://file.io\n")
+
+        merged = load_merged_config(
+            cwd=project,
+            env={"APM_CONFIG_REGISTRY": "https://env-wins.io"},
+        )
+        assert merged.registry == "https://env-wins.io"
+
+    def test_no_apm_config_vars_no_sources_added(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        monkeypatch.setenv("HOME", str(home_dir))
+        merged = load_merged_config(cwd=tmp_path, env={})
+        # No Path("<env>") in sources when no APM_CONFIG_* vars are set.
+        assert Path("<env>") not in merged.sources
+
+    def test_apm_config_prefix_only_ignored(self) -> None:
+        # "APM_CONFIG_" alone (no key) should not be parsed.
+        merged = load_merged_config(
+            cwd=Path("/nonexistent"),
+            env={"APM_CONFIG_": "bad"},
+        )
+        assert merged.registry == "https://api.mcp.github.com"
+
+
+# ===========================================================================
+# TestConfigSetGetDelete — Step 4
+# ===========================================================================
+
+
+class TestConfigSetGetDelete:
+    def _setup(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        home_dir = tmp_path / "home"
+        home_dir.mkdir()
+        monkeypatch.setenv("HOME", str(home_dir))
+        monkeypatch.chdir(tmp_path)
+
+        from apm_cli import config as cfg_module
+
+        cfg_module._apmrc_cache = None
+        cfg_module._config_cache = None
+
+    def test_config_set_creates_apmrc(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._setup(tmp_path, monkeypatch)
+        from click.testing import CliRunner
+
+        from apm_cli.commands.config import config
+
+        runner = CliRunner()
+        result = runner.invoke(config, ["set", "registry", "https://new.io"])
+        assert result.exit_code == 0
+
+        content = (tmp_path / ".apmrc").read_text()
+        assert "registry=https://new.io" in content
+
+    def test_config_get_reads_value(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._setup(tmp_path, monkeypatch)
+        (tmp_path / ".apmrc").write_text("registry=https://test.io\n")
+
+        from click.testing import CliRunner
+
+        from apm_cli.commands.config import config
+
+        runner = CliRunner()
+        result = runner.invoke(config, ["get", "registry"])
+        assert result.exit_code == 0
+        assert "https://test.io" in result.output
+
+    def test_config_delete_removes_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._setup(tmp_path, monkeypatch)
+        (tmp_path / ".apmrc").write_text(
+            "registry=https://test.io\ndefault-client=claude\n"
+        )
+
+        from click.testing import CliRunner
+
+        from apm_cli.commands.config import config
+
+        runner = CliRunner()
+        result = runner.invoke(config, ["delete", "registry"])
+        assert result.exit_code == 0
+        content = (tmp_path / ".apmrc").read_text()
+        assert "registry" not in content
+        assert "default-client=claude" in content
+
+    def test_config_delete_nonexistent_key_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._setup(tmp_path, monkeypatch)
+        (tmp_path / ".apmrc").write_text("registry=https://test.io\n")
+
+        from click.testing import CliRunner
+
+        from apm_cli.commands.config import config
+
+        runner = CliRunner()
+        result = runner.invoke(config, ["delete", "nonexistent"])
+        assert result.exit_code != 0
+
+    def test_config_set_updates_existing_key(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._setup(tmp_path, monkeypatch)
+        (tmp_path / ".apmrc").write_text("registry=https://old.io\n")
+
+        from click.testing import CliRunner
+
+        from apm_cli.commands.config import config
+
+        runner = CliRunner()
+        result = runner.invoke(config, ["set", "registry", "https://new.io"])
+        assert result.exit_code == 0
+        content = (tmp_path / ".apmrc").read_text()
+        assert "https://new.io" in content
+        assert "https://old.io" not in content
+
+
+# ===========================================================================
+# TestFilePermissionWarning — Step 5a
+# ===========================================================================
+
+
+class TestFilePermissionWarning:
+    def test_world_readable_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+        import sys
+
+        if sys.platform == "win32":
+            pytest.skip("Permission checks not applicable on Windows")
+
+        f = tmp_path / ".apmrc"
+        f.write_text("registry=https://x.io\n")
+        f.chmod(0o644)
+        with caplog.at_level(logging.WARNING, logger="apm_cli.apmrc"):
+            parse_file(f, env={})
+        assert "permissive" in caplog.text.lower()
+
+    def test_restricted_no_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+        import sys
+
+        if sys.platform == "win32":
+            pytest.skip("Permission checks not applicable on Windows")
+
+        f = tmp_path / ".apmrc"
+        f.write_text("registry=https://x.io\n")
+        f.chmod(0o600)
+        with caplog.at_level(logging.WARNING, logger="apm_cli.apmrc"):
+            parse_file(f, env={})
+        assert "permissive" not in caplog.text.lower()
+
+    def test_init_rc_creates_restricted_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import sys
+
+        if sys.platform == "win32":
+            pytest.skip("Permission checks not applicable on Windows")
+
+        from click.testing import CliRunner
+
+        from apm_cli.commands.config import config
+
+        monkeypatch.chdir(tmp_path)
+        runner = CliRunner()
+        runner.invoke(config, ["init-rc"])
+        mode = (tmp_path / ".apmrc").stat().st_mode & 0o777
+        assert mode == 0o600
+
+
+# ===========================================================================
+# TestUnknownKeyWarning — Step 5c
+# ===========================================================================
+
+
+class TestUnknownKeyWarning:
+    def test_unknown_key_warns(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        f = tmp_path / ".apmrc"
+        f.write_text("registy=https://typo.io\n")
+        with caplog.at_level(logging.WARNING, logger="apm_cli.apmrc"):
+            cfg = parse_file(f, env={})
+        assert cfg.raw.get("registy") == "https://typo.io"
+        assert "unknown key" in caplog.text.lower()
+
+    def test_known_key_no_warning(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        f = tmp_path / ".apmrc"
+        f.write_text("registry=https://x.io\n")
+        with caplog.at_level(logging.WARNING, logger="apm_cli.apmrc"):
+            parse_file(f, env={})
+        assert "unknown key" not in caplog.text.lower()

--- a/tests/unit/test_config_command.py
+++ b/tests/unit/test_config_command.py
@@ -65,7 +65,9 @@ class TestConfigShow:
             os.chdir(tmp_dir)
             try:
                 apm_yml = Path(tmp_dir) / "apm.yml"
-                apm_yml.write_text("name: myproject\ncompilation:\n  output: AGENTS.md\n")
+                apm_yml.write_text(
+                    "name: myproject\ncompilation:\n  output: AGENTS.md\n"
+                )
                 apm_config = {
                     "name": "myproject",
                     "version": "0.1",
@@ -79,7 +81,8 @@ class TestConfigShow:
                 with (
                     patch("apm_cli.commands.config.get_version", return_value="1.2.3"),
                     patch(
-                        "apm_cli.commands.config._load_apm_config", return_value=apm_config
+                        "apm_cli.commands.config._load_apm_config",
+                        return_value=apm_config,
                     ),
                 ):
                     result = self.runner.invoke(config, [])
@@ -97,7 +100,9 @@ class TestConfigShow:
             try:
                 with (
                     patch("apm_cli.commands.config.get_version", return_value="0.9.0"),
-                    patch.object(rich.table, "Table", side_effect=ImportError("no rich")),
+                    patch.object(
+                        rich.table, "Table", side_effect=ImportError("no rich")
+                    ),
                 ):
                     result = self.runner.invoke(config, [])
             finally:
@@ -122,9 +127,12 @@ class TestConfigShow:
                 with (
                     patch("apm_cli.commands.config.get_version", return_value="0.9.0"),
                     patch(
-                        "apm_cli.commands.config._load_apm_config", return_value=apm_config
+                        "apm_cli.commands.config._load_apm_config",
+                        return_value=apm_config,
                     ),
-                    patch.object(rich.table, "Table", side_effect=ImportError("no rich")),
+                    patch.object(
+                        rich.table, "Table", side_effect=ImportError("no rich")
+                    ),
                 ):
                     result = self.runner.invoke(config, [])
             finally:
@@ -137,63 +145,121 @@ class TestConfigSet:
 
     def setup_method(self):
         self.runner = CliRunner()
+        self.original_dir = os.getcwd()
+
+    def teardown_method(self):
+        try:
+            os.chdir(self.original_dir)
+        except (FileNotFoundError, OSError):
+            pass
+
+    def _run_in_tmpdir(self, args):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.chdir(tmp_dir)
+            try:
+                return self.runner.invoke(config, args)
+            finally:
+                os.chdir(self.original_dir)
 
     def test_set_auto_integrate_true(self):
         """Enable auto-integration."""
-        with patch("apm_cli.config.set_auto_integrate") as mock_set:
-            result = self.runner.invoke(config, ["set", "auto-integrate", "true"])
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.chdir(tmp_dir)
+            try:
+                with patch("apm_cli.config.set_auto_integrate") as mock_set:
+                    result = self.runner.invoke(
+                        config, ["set", "auto-integrate", "true"]
+                    )
+            finally:
+                os.chdir(self.original_dir)
         assert result.exit_code == 0
         mock_set.assert_called_once_with(True)
 
     def test_set_auto_integrate_yes(self):
         """Enable auto-integration with 'yes' alias."""
-        with patch("apm_cli.config.set_auto_integrate") as mock_set:
-            result = self.runner.invoke(config, ["set", "auto-integrate", "yes"])
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.chdir(tmp_dir)
+            try:
+                with patch("apm_cli.config.set_auto_integrate") as mock_set:
+                    result = self.runner.invoke(
+                        config, ["set", "auto-integrate", "yes"]
+                    )
+            finally:
+                os.chdir(self.original_dir)
         assert result.exit_code == 0
         mock_set.assert_called_once_with(True)
 
     def test_set_auto_integrate_one(self):
         """Enable auto-integration with '1' alias."""
-        with patch("apm_cli.config.set_auto_integrate") as mock_set:
-            result = self.runner.invoke(config, ["set", "auto-integrate", "1"])
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.chdir(tmp_dir)
+            try:
+                with patch("apm_cli.config.set_auto_integrate") as mock_set:
+                    result = self.runner.invoke(config, ["set", "auto-integrate", "1"])
+            finally:
+                os.chdir(self.original_dir)
         assert result.exit_code == 0
         mock_set.assert_called_once_with(True)
 
     def test_set_auto_integrate_false(self):
         """Disable auto-integration."""
-        with patch("apm_cli.config.set_auto_integrate") as mock_set:
-            result = self.runner.invoke(config, ["set", "auto-integrate", "false"])
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.chdir(tmp_dir)
+            try:
+                with patch("apm_cli.config.set_auto_integrate") as mock_set:
+                    result = self.runner.invoke(
+                        config, ["set", "auto-integrate", "false"]
+                    )
+            finally:
+                os.chdir(self.original_dir)
         assert result.exit_code == 0
         mock_set.assert_called_once_with(False)
 
     def test_set_auto_integrate_no(self):
         """Disable auto-integration with 'no' alias."""
-        with patch("apm_cli.config.set_auto_integrate") as mock_set:
-            result = self.runner.invoke(config, ["set", "auto-integrate", "no"])
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.chdir(tmp_dir)
+            try:
+                with patch("apm_cli.config.set_auto_integrate") as mock_set:
+                    result = self.runner.invoke(config, ["set", "auto-integrate", "no"])
+            finally:
+                os.chdir(self.original_dir)
         assert result.exit_code == 0
         mock_set.assert_called_once_with(False)
 
     def test_set_auto_integrate_zero(self):
         """Disable auto-integration with '0' alias."""
-        with patch("apm_cli.config.set_auto_integrate") as mock_set:
-            result = self.runner.invoke(config, ["set", "auto-integrate", "0"])
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.chdir(tmp_dir)
+            try:
+                with patch("apm_cli.config.set_auto_integrate") as mock_set:
+                    result = self.runner.invoke(config, ["set", "auto-integrate", "0"])
+            finally:
+                os.chdir(self.original_dir)
         assert result.exit_code == 0
         mock_set.assert_called_once_with(False)
 
     def test_set_auto_integrate_invalid_value(self):
-        """Reject an invalid value for auto-integrate."""
-        result = self.runner.invoke(config, ["set", "auto-integrate", "maybe"])
-        assert result.exit_code == 1
+        """Any value is accepted by the generalized set command."""
+        result = self._run_in_tmpdir(["set", "auto-integrate", "maybe"])
+        assert result.exit_code == 0
 
     def test_set_unknown_key(self):
-        """Reject an unknown configuration key."""
-        result = self.runner.invoke(config, ["set", "nonexistent", "value"])
-        assert result.exit_code == 1
+        """Any key is accepted (written to .apmrc)."""
+        result = self._run_in_tmpdir(["set", "nonexistent", "value"])
+        assert result.exit_code == 0
 
     def test_set_auto_integrate_case_insensitive(self):
         """Value comparison is case-insensitive."""
-        with patch("apm_cli.config.set_auto_integrate") as mock_set:
-            result = self.runner.invoke(config, ["set", "auto-integrate", "TRUE"])
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.chdir(tmp_dir)
+            try:
+                with patch("apm_cli.config.set_auto_integrate") as mock_set:
+                    result = self.runner.invoke(
+                        config, ["set", "auto-integrate", "TRUE"]
+                    )
+            finally:
+                os.chdir(self.original_dir)
         assert result.exit_code == 0
         mock_set.assert_called_once_with(True)
 
@@ -203,24 +269,53 @@ class TestConfigGet:
 
     def setup_method(self):
         self.runner = CliRunner()
+        self.original_dir = os.getcwd()
+
+    def teardown_method(self):
+        try:
+            os.chdir(self.original_dir)
+        except (FileNotFoundError, OSError):
+            pass
 
     def test_get_auto_integrate(self):
-        """Get the auto-integrate setting."""
-        with patch("apm_cli.config.get_auto_integrate", return_value=True):
-            result = self.runner.invoke(config, ["get", "auto-integrate"])
+        """Get the auto-integrate setting from config.json."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.chdir(tmp_dir)
+            try:
+                with patch(
+                    "apm_cli.config.get_config",
+                    return_value={"auto_integrate": True},
+                ):
+                    result = self.runner.invoke(config, ["get", "auto-integrate"])
+            finally:
+                os.chdir(self.original_dir)
         assert result.exit_code == 0
-        assert "auto-integrate: True" in result.output
+        assert "True" in result.output
 
     def test_get_auto_integrate_disabled(self):
         """Get auto-integrate when disabled."""
-        with patch("apm_cli.config.get_auto_integrate", return_value=False):
-            result = self.runner.invoke(config, ["get", "auto-integrate"])
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.chdir(tmp_dir)
+            try:
+                with patch(
+                    "apm_cli.config.get_config",
+                    return_value={"auto_integrate": False},
+                ):
+                    result = self.runner.invoke(config, ["get", "auto-integrate"])
+            finally:
+                os.chdir(self.original_dir)
         assert result.exit_code == 0
-        assert "auto-integrate: False" in result.output
+        assert "False" in result.output
 
     def test_get_unknown_key(self):
-        """Reject an unknown key."""
-        result = self.runner.invoke(config, ["get", "nonexistent"])
+        """Reject an unknown key not in .apmrc or config.json."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.chdir(tmp_dir)
+            try:
+                with patch("apm_cli.config.get_config", return_value={}):
+                    result = self.runner.invoke(config, ["get", "nonexistent"])
+            finally:
+                os.chdir(self.original_dir)
         assert result.exit_code == 1
 
     def test_get_all_config(self):
@@ -229,7 +324,7 @@ class TestConfigGet:
         with patch("apm_cli.config.get_config", return_value=fake_config):
             result = self.runner.invoke(config, ["get"])
         assert result.exit_code == 0
-        assert "auto-integrate: True" in result.output
+        assert "auto-integrate=True" in result.output
 
     def test_get_all_config_unknown_key_passthrough(self):
         """Unknown config keys are shown as-is."""
@@ -237,7 +332,7 @@ class TestConfigGet:
         with patch("apm_cli.config.get_config", return_value=fake_config):
             result = self.runner.invoke(config, ["get"])
         assert result.exit_code == 0
-        assert "some_other_key: value" in result.output
+        assert "some-other-key=value" in result.output
 
 
 class TestAutoIntegrateFunctions:


### PR DESCRIPTION
## Description

Add `.npmrc`-style configuration file support for APM. Users can now configure registries, authentication tokens, and behavior flags via `.apmrc` files with environment variable substitution — matching the conventions npm users already know.

**Motivation:** APM currently requires environment variables or manual JSON editing for configuration. This is cumbersome in CI/CD pipelines and multi-registry setups. `.apmrc` provides a familiar, file-based configuration that can be committed to repos (with `${VAR}` references) while keeping secrets in global config or env vars.

### Key features

- **File format:** Flat INI `key=value` with `${VAR}` substitution (4 forms: `${VAR}`, `${VAR?}`, `${VAR:-default}`, `${VAR:+word}`, plus `\${VAR}` escaping)
- **Three-tier hierarchy:** `~/.apm/.apmrc` → project `.apmrc` → `APM_CONFIG_*` env vars
- **Scoped registries:** `@scope:registry=url` with per-host auth tokens (`//host/:_authToken=tok`)
- **`APM_CONFIG_*` env var mapping** — mirrors npm's `npm_config_*` convention for CI/CD
- **CLI commands:** `set`, `get`, `delete`, `show-rc`, `which-rc`, `init-rc`, `edit`
- **Security hardening:**
  - Files created with `0600` permissions (no world-readable window)
  - Symlink rejection on all write operations
  - Sensitive keys (`github-token`, `*:_authToken`) blocked from `config get` output
  - File permission warnings on overly permissive `.apmrc` files
  - Unknown key warnings to catch typos
- **Registry auth integration:** `SimpleRegistryClient` now sends per-host Bearer tokens from `.apmrc`
- **Token manager integration:** `.apmrc github-token` used as fallback for module downloads

### Files

| File | Change |
|---|---|
| `src/apm_cli/apmrc.py` | **New** — core parser (650 lines) |
| `src/apm_cli/config.py` | `get_apmrc_config`, `get_effective_registry`, `get_effective_token` |
| `src/apm_cli/commands/config.py` | 8 CLI subcommands, sensitive key protection |
| `src/apm_cli/core/token_manager.py` | `.apmrc` fallback in `get_token_with_credential_fallback` |
| `src/apm_cli/registry/client.py` | Per-host auth headers via `_get_auth_headers()` |
| `tests/test_apmrc.py` | **New** — 135 tests |
| `tests/unit/test_config_command.py` | Updated for generalized `set`/`get`/`delete` |
| `docs/src/content/docs/guides/configuration.md` | **New** — user guide |
| `docs/examples/.apmrc` | **New** — annotated example |
| `docs/astro.config.mjs` | Sidebar entry |
| `docs/.../reference/cli-commands.md` | Updated config command reference |

## Type of change

- [x] New feature

## Testing

- [x] Tested locally
- [x] All existing tests pass (3699 passed, 2 pre-existing upstream failures unrelated)
- [x] Added tests for new functionality (135 new tests covering parser, hierarchy merge, CLI commands, security, integration)