### PR TITLE
[docs] Update documentation for features from 2026-04-04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Standardized `--target` choices, replaced Unicode with ASCII for cp1252 compatibility, and documented missing CLI flags (#519)
 - `apm install -g` now correctly deploys to user-scope directories, skips unsupported primitives, and cleans up on uninstall -- including multi-level paths like `~/.config/opencode/` (#542)
 - `apm deps update` now correctly re-resolves transitive dependencies instead of reusing stale locked SHAs (#548)
+- `apm install` now warns when two packages deploy a native skill with the same name, identifying both the incoming and previous owner so users know which dependency to remove (#545)
 
 ### Added
 

--- a/docs/src/content/docs/guides/skills.md
+++ b/docs/src/content/docs/guides/skills.md
@@ -376,6 +376,21 @@ If you see a skill name validation warning:
 1. **Check naming:** Names must be lowercase, 1-64 chars, hyphens only (no underscores)
 2. **Auto-normalization:** APM automatically normalizes invalid names when possible
 
+### Skill Name Collision Warning
+
+If you see a warning like:
+
+```
+[!] Skill 'humanizer': replaced 'org/other-package' -- remove one package to avoid this
+```
+
+Two of your installed packages deploy a native skill with the same name. The second install
+overwrote the first. To resolve:
+
+1. **Identify the conflict**: The warning names both the incoming package and the previous owner.
+2. **Remove one**: Uninstall the package you no longer need with `apm uninstall owner/repo`.
+3. **Reinstall**: Run `apm install` again to restore a clean state.
+
 ### Metadata Missing
 
 If skill lacks APM metadata:


### PR DESCRIPTION
## Documentation Updates - 2026-04-04

This PR updates the documentation based on features merged in the last 24 hours.

### Features Documented

- Native skill name collision warning (from #545)

### Changes Made

- Updated `CHANGELOG.md` to add a `Fixed` entry under `[Unreleased]` for the cross-package native skill collision detection introduced in #545.
- Added a **"Skill Name Collision Warning"** troubleshooting section to `docs/src/content/docs/guides/skills.md` explaining the new warning message and how users can resolve the conflict.

### Merged PRs Referenced

- #545 - `[fix] warn when two packages deploy a native skill with the same name` -- when two installed packages deploy a native skill with the same leaf directory name, APM now emits a warning identifying both the incoming package and the previous owner, and tells the user to remove one to resolve the conflict. Previously the second install silently overwrote the first.

### Notes

No other PRs were merged in the last 24 hours. The CHANGELOG entry and troubleshooting note cover all user-facing aspects of #545.




> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/23970374009) · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+is%3Apr+%22gh-aw-workflow-id%3A+daily-doc-updater%22+in%3Abody)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-04-06T03:32:58.578Z --> on Apr 6, 2026, 3:32 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, id: 23970374009, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/23970374009 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->