### PR TITLE
[fix] use target.root_dir for copilot hook deployment at user scope (#565)

### DIFF
--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -152,6 +152,7 @@ class HookIntegrator(BaseIntegrator):
         package_name: str,
         target: str,
         hook_file_dir: Optional[Path] = None,
+        hook_root: str = ".github",
     ) -> Tuple[str, List[Tuple[Path, str]]]:
         """Rewrite a hook command to use installed script paths.
 
@@ -165,6 +166,8 @@ class HookIntegrator(BaseIntegrator):
             package_name: Name used for the scripts subdirectory
             target: "vscode" or "claude"
             hook_file_dir: Directory containing the hook JSON file (for ./path resolution)
+            hook_root: Root directory for the vscode/copilot target (e.g. ".github" or
+                ".copilot" at user scope).  Ignored for non-vscode targets.
 
         Returns:
             Tuple of (rewritten_command, list of (source_file, relative_target_path))
@@ -173,7 +176,7 @@ class HookIntegrator(BaseIntegrator):
         new_command = command
 
         if target == "vscode":
-            scripts_base = f".github/hooks/scripts/{package_name}"
+            scripts_base = f"{hook_root}/hooks/scripts/{package_name}"
         elif target == "cursor":
             scripts_base = f".cursor/hooks/{package_name}"
         elif target == "codex":
@@ -223,6 +226,7 @@ class HookIntegrator(BaseIntegrator):
         package_name: str,
         target: str,
         hook_file_dir: Optional[Path] = None,
+        hook_root: str = ".github",
     ) -> Tuple[Dict, List[Tuple[Path, str]]]:
         """Rewrite all command paths in a hooks JSON structure.
 
@@ -234,6 +238,9 @@ class HookIntegrator(BaseIntegrator):
             package_name: Name for scripts subdirectory
             target: "vscode" or "claude"
             hook_file_dir: Directory containing the hook JSON file (for ./path resolution)
+            hook_root: Root directory for the vscode/copilot target (e.g. ".github" or
+                ".copilot" at user scope).  Forwarded to
+                ``_rewrite_command_for_target``; ignored for non-vscode targets.
 
         Returns:
             Tuple of (rewritten_data_copy, list of (source_file, target_rel_path))
@@ -256,6 +263,7 @@ class HookIntegrator(BaseIntegrator):
                         new_cmd, scripts = self._rewrite_command_for_target(
                             matcher[key], package_path, package_name, target,
                             hook_file_dir=hook_file_dir,
+                            hook_root=hook_root,
                         )
                         if scripts:
                             _log.debug(
@@ -275,6 +283,7 @@ class HookIntegrator(BaseIntegrator):
                             new_cmd, scripts = self._rewrite_command_for_target(
                                 hook[key], package_path, package_name, target,
                                 hook_file_dir=hook_file_dir,
+                                hook_root=hook_root,
                             )
                             if scripts:
                                 _log.debug(
@@ -308,17 +317,25 @@ class HookIntegrator(BaseIntegrator):
     def integrate_package_hooks(self, package_info, project_root: Path,
                                  force: bool = False,
                                  managed_files: set = None,
-                                 diagnostics=None) -> HookIntegrationResult:
-        """Integrate hooks from a package into .github/hooks/ (VSCode target).
+                                 diagnostics=None,
+                                 target=None) -> HookIntegrationResult:
+        """Integrate hooks from a package into the copilot hooks directory.
 
         Deploys hook JSON files with clean filenames and copies referenced
         script files. Skips user-authored files unless force=True.
+
+        At project scope this is ``.github/hooks/``; at user scope it is
+        ``.copilot/hooks/`` (driven by ``target.root_dir`` when *target* is
+        provided).
 
         Args:
             package_info: PackageInfo with package metadata and install path
             project_root: Root directory of the project
             force: If True, overwrite user-authored files on collision
             managed_files: Set of relative paths known to be APM-managed
+            target: Scope-resolved TargetProfile for the copilot target.
+                When provided, ``target.root_dir`` is used as the root
+                directory instead of the default ``".github"``.
 
         Returns:
             HookIntegrationResult: Results of the integration operation
@@ -331,7 +348,8 @@ class HookIntegrator(BaseIntegrator):
                 scripts_copied=0,
             )
 
-        hooks_dir = project_root / ".github" / "hooks"
+        hook_root = target.root_dir if target is not None else ".github"
+        hooks_dir = project_root / hook_root / "hooks"
         hooks_dir.mkdir(parents=True, exist_ok=True)
 
         package_name = self._get_package_name(package_info)
@@ -344,10 +362,11 @@ class HookIntegrator(BaseIntegrator):
             if data is None:
                 continue
 
-            # Rewrite script paths for VSCode target
+            # Rewrite script paths for VSCode/Copilot target
             rewritten, scripts = self._rewrite_hooks_data(
                 data, package_info.install_path, package_name, "vscode",
                 hook_file_dir=hook_file.parent,
+                hook_root=hook_root,
             )
 
             # Generate target filename (clean, no -apm suffix)
@@ -693,6 +712,7 @@ class HookIntegrator(BaseIntegrator):
                 package_info, project_root,
                 force=force, managed_files=managed_files,
                 diagnostics=diagnostics,
+                target=target,
             )
         if target.name == "claude":
             return self.integrate_package_hooks_claude(

--- a/tests/unit/integration/test_hook_integrator.py
+++ b/tests/unit/integration/test_hook_integrator.py
@@ -438,6 +438,41 @@ class TestVSCodeIntegration:
         result = integrator.integrate_package_hooks(pkg_info, temp_project)
         assert (temp_project / ".github" / "hooks").exists()
 
+    def test_integrate_package_hooks_user_scope_uses_copilot_root(self, temp_project):
+        """Hooks land in .copilot/hooks/ when target.root_dir is '.copilot' (user scope)."""
+        pkg_dir = temp_project / "apm_modules" / "anthropics" / "hookify"
+        hooks_dir = pkg_dir / "hooks"
+        hooks_dir.mkdir(parents=True)
+        (hooks_dir / "hooks.json").write_text(json.dumps(HOOKIFY_HOOKS_JSON, indent=2))
+        for script in ["pretooluse.py", "posttooluse.py", "stop.py", "userpromptsubmit.py"]:
+            (hooks_dir / script).write_text(f"#!/usr/bin/env python3\n# {script}")
+
+        pkg_info = _make_package_info(pkg_dir, "hookify")
+        integrator = HookIntegrator()
+
+        # Simulate a scope-resolved Copilot target at user scope (root_dir=".copilot")
+        mock_target = MagicMock()
+        mock_target.root_dir = ".copilot"
+
+        result = integrator.integrate_package_hooks(pkg_info, temp_project, target=mock_target)
+
+        assert result.hooks_integrated == 1
+        assert result.scripts_copied == 4
+
+        # Hook JSON must be in .copilot/hooks/, NOT .github/hooks/
+        assert (temp_project / ".copilot" / "hooks" / "hookify-hooks.json").exists()
+        assert not (temp_project / ".github" / "hooks" / "hookify-hooks.json").exists()
+
+        # Script paths inside the hook JSON must reference .copilot/, not .github/
+        data = json.loads((temp_project / ".copilot" / "hooks" / "hookify-hooks.json").read_text())
+        cmd = data["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+        assert ".copilot/hooks/scripts/hookify/" in cmd
+        assert ".github" not in cmd
+
+        # Scripts must be copied under .copilot/hooks/scripts/
+        scripts_dir = temp_project / ".copilot" / "hooks" / "scripts" / "hookify" / "hooks"
+        assert (scripts_dir / "pretooluse.py").exists()
+
 
 # ─── Claude integration tests ────────────────────────────────────────────────
 


### PR DESCRIPTION
## What

`integrate_package_hooks` hardcoded `".github"` as the hooks root directory, ignoring the scope-resolved `target.root_dir`. At user scope the Copilot target resolves to `root_dir=".copilot"` (via `TargetProfile.for_scope()`), but hooks always landed in `~/.github/hooks/` instead of `~/.copilot/hooks/`. The same bug applied to the script paths written *inside* the deployed hook JSON files.

Fixes #565.

## Why

`TargetProfile.for_scope(user_scope=True)` returns a copy of the profile with `root_dir` already overridden to `user_root_dir` (`".copilot"` for Copilot). All other integrators (`InstructionIntegrator`, `AgentIntegrator`, etc.) read `target.root_dir` directly after scope resolution. `HookIntegrator.integrate_package_hooks` was the only one that ignored it.

## How

- Added `target=None` parameter to `integrate_package_hooks`. When provided, `target.root_dir` is used as `hook_root`; otherwise falls back to `".github"` (backward-compatible, all existing call sites without `target` continue to work).
- Threaded `hook_root` through `_rewrite_hooks_data` → `_rewrite_command_for_target` so that script paths embedded in the deployed JSON also reference the correct root.
- `integrate_hooks_for_target` now passes `target=target` to `integrate_package_hooks` for the `"copilot"` branch, matching the pattern used by every other `integrate_*_for_target` dispatcher.

No changes outside `hook_integrator.py`. No new abstractions.

## Test

Added `test_integrate_package_hooks_user_scope_uses_copilot_root` to `TestVSCodeIntegration`:

- Constructs a mock target with `root_dir=".copilot"` (mirrors what `for_scope(user_scope=True)` returns for Copilot)
- Asserts hook JSON lands in `.copilot/hooks/`, not `.github/hooks/`
- Asserts script paths inside the deployed JSON reference `.copilot/`, not `.github/`
- Asserts scripts are copied under `.copilot/hooks/scripts/`

All 71 existing tests continue to pass.