### PR TITLE
[docs] Update documentation for Artifactory archive entry download (2026-04-05)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unified integration dispatch table in `dispatch.py` -- both install and uninstall import from one source of truth (#562)
 - Hook merge logic deduplicated: three copy-pasted JSON-merge methods replaced with `_integrate_merged_hooks()` + config dict (#562)
 
+### Added
+
+- Artifactory Archive Entry Download for virtual file packages: single-file primitives (`.prompt.md`, `.agent.md`, etc.) are now fetched via the `!/{path}` entry API instead of a full archive download, with transparent fallback on unsupported Artifactory versions (#525)
+
 ### Fixed
 
 - `apm deps update -g` now correctly passes scope, preventing user-scope updates from silently using project-scope paths (#562)

--- a/docs/src/content/docs/getting-started/authentication.md
+++ b/docs/src/content/docs/getting-started/authentication.md
@@ -199,6 +199,18 @@ With `PROXY_REGISTRY_ONLY=1`, APM will:
 2. Skip the download cache for entries that have no `registry_prefix` (forcing a fresh proxy download)
 3. Raise an error for any package reference that does not route through the configured proxy
 
+### Archive Entry Download (virtual file packages)
+
+When downloading virtual file packages (`.prompt.md`, `.agent.md`, and similar single-file primitives) through an Artifactory proxy, APM uses the **Archive Entry Download API** to fetch only the specific file instead of the full archive.
+
+The entry URL follows the Artifactory pattern:
+
+```
+GET {archive_url}!/{repo}-{ref}/{file_path}
+```
+
+This avoids downloading a multi-MB archive just to extract a single small file. If the entry API returns a 404, a connection error, or is unsupported by the Artifactory version in use, APM falls back to the standard full-archive download transparently -- no configuration required.
+
 ### Deprecated Artifactory env vars
 
 The following env vars still work but emit a `DeprecationWarning`. Migrate to the `PROXY_REGISTRY_*` equivalents:


### PR DESCRIPTION
## Documentation Updates - 2026-04-05

This PR updates documentation based on the feature merged in the last 24 hours.

### Features Documented

- Artifactory Archive Entry Download for virtual file packages (from #525)

### Changes Made

- Updated `docs/src/content/docs/getting-started/authentication.md` to add a new **Archive Entry Download** subsection under the "Registry proxy (Artifactory)" section, explaining the single-file fetch optimization and transparent fallback behaviour.
- Updated `CHANGELOG.md` to add the `Added` entry under `[Unreleased]` for this feature.

### Merged PRs Referenced

- #525 — feat: Artifactory archive entry download for virtual file packages

### Summary of the feature

Virtual file packages (`.prompt.md`, `.agent.md`, etc.) downloaded through an Artifactory proxy now use the Archive Entry Download API (`!/{repo}-{ref}/{path}`) to fetch only the specific file, avoiding a full multi-MB archive download. If the entry API is unavailable (404, connection error, or unsupported Artifactory version), APM falls back to the standard full-archive download transparently — no configuration required.




> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/23993593936) · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+is%3Apr+%22gh-aw-workflow-id%3A+daily-doc-updater%22+in%3Abody)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-04-07T03:47:18.034Z --> on Apr 7, 2026, 3:47 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, id: 23993593936, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/23993593936 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->