### PR TITLE
[docs] Update dependencies guide for apm outdated and apm view versions (from #613)

### DIFF
--- a/docs/src/content/docs/guides/dependencies.md
+++ b/docs/src/content/docs/guides/dependencies.md
@@ -608,6 +608,38 @@ dependencies:
     - company/internal-standards#abc123        # Specific commit
 ```
 
+### Checking for Outdated Dependencies
+
+Use `apm outdated` to compare locked dependency SHAs and tags against the latest remote refs before deciding whether to update:
+
+```bash
+# Check project dependencies for staleness
+apm outdated
+
+# Check user-scope dependencies
+apm outdated --global
+
+# Show available tags for outdated packages
+apm outdated --verbose
+
+# Use up to 8 parallel remote checks for large dependency sets
+apm outdated -j 8
+```
+
+Output columns:
+- **Package** - dependency identifier from the lockfile
+- **Current** - the ref or tag recorded in `apm.lock.yaml`
+- **Latest** - the newest remote tag or branch-tip SHA
+- **Status** - `up-to-date`, `outdated`, or `unknown`
+
+Tag-pinned deps use semver comparison; branch-pinned deps compare commit SHAs. Local and Artifactory dependencies are skipped.
+
+To inspect all available tags and branches for a specific package before updating:
+
+```bash
+apm view owner/repo-name versions
+```
+
 ### Updating Dependencies
 
 ```bash


### PR DESCRIPTION
## Documentation Updates - 2026-04-09

This PR updates the dependencies guide based on features merged in the last 24 hours.

### Features Documented

- `apm outdated` command (from #613) - added to the dependencies workflow guide
- `apm view (package) versions` field (from #613) - referenced as a complement to `apm outdated`

### Changes Made

- Updated `docs/src/content/docs/guides/dependencies.md` to add a new **"Checking for Outdated Dependencies"** subsection just before the existing "Updating Dependencies" section.

The new subsection documents:
- `apm outdated` usage with all options (`--global`, `--verbose`, `-j N`)
- Output column meanings (`Package`, `Current`, `Latest`, `Status`)
- Comparison logic (semver for tags, SHA for branches)
- `apm view owner/repo-name versions` as a complement for inspecting available refs before updating

### Merged PRs Referenced

- #613 - feat: add apm info, apm outdated, and list_remote_refs

### Notes

The CLI reference (`docs/src/content/docs/reference/cli-commands.md`) and the skill guide (`packages/apm-guide/.apm/skills/apm-usage/commands.md`) already documented both commands. The CHANGELOG for `[0.8.11]` also covered the changes. The only gap was the user-facing **dependencies guide**, which described the update workflow but gave no visibility into staleness detection before updating.




> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/24171014575) · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+is%3Apr+%22gh-aw-workflow-id%3A+daily-doc-updater%22+in%3Abody)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-04-11T03:44:29.896Z --> on Apr 11, 2026, 3:44 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, id: 24171014575, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/24171014575 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->