### PR TITLE
[fix] include dependency instructions in claude compile (#631)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pin codex setup to `rust-v0.118.0` for security and reproducibility; update config to `wire_api = "responses"` (#663)
 - Propagate headers and environment variables through OpenCode MCP adapter with defensive copies to prevent mutation (#622)
+- Fix `apm compile --target claude` silently skipping dependency instructions stored in `.github/instructions/` (#631)
 ### Changed
 
 - `apm marketplace browse/search/add/update` now route through the registry proxy when `PROXY_REGISTRY_URL` is set; `PROXY_REGISTRY_ONLY=1` blocks direct GitHub API calls (#506)

--- a/src/apm_cli/primitives/discovery.py
+++ b/src/apm_cli/primitives/discovery.py
@@ -311,6 +311,27 @@ def get_dependency_declaration_order(base_dir: str) -> List[str]:
         return []
 
 
+def _scan_patterns(base_dir: Path, patterns: Dict[str, List[str]], collection: PrimitiveCollection, source: str) -> None:
+    """Glob-scan-parse loop for one base directory and one patterns dict.
+
+    Args:
+        base_dir (Path): Directory to scan (e.g., dep/.apm or dep/.github).
+        patterns (Dict[str, List[str]]): Primitive-type → glob-pattern mapping.
+        collection (PrimitiveCollection): Collection to add primitives to.
+        source (str): Source identifier for discovered primitives.
+    """
+    for _primitive_type, type_patterns in patterns.items():
+        for pattern in type_patterns:
+            for file_path_str in glob.glob(str(base_dir / pattern), recursive=True):
+                file_path = Path(file_path_str)
+                if file_path.is_file() and _is_readable(file_path):
+                    try:
+                        primitive = parse_primitive_file(file_path, source=source)
+                        collection.add_primitive(primitive)
+                    except Exception as e:
+                        print(f"Warning: Failed to parse dependency primitive {file_path}: {e}")
+
+
 def scan_directory_with_source(directory: Path, collection: PrimitiveCollection, source: str) -> None:
     """Scan a directory for primitives with a specific source tag.
 
@@ -322,38 +343,14 @@ def scan_directory_with_source(directory: Path, collection: PrimitiveCollection,
     # Scan .apm directory within the dependency
     apm_dir = directory / ".apm"
     if apm_dir.exists():
-        for primitive_type, patterns in DEPENDENCY_PRIMITIVE_PATTERNS.items():
-            for pattern in patterns:
-                full_pattern = str(apm_dir / pattern)
-                matching_files = glob.glob(full_pattern, recursive=True)
-
-                for file_path_str in matching_files:
-                    file_path = Path(file_path_str)
-                    if file_path.is_file() and _is_readable(file_path):
-                        try:
-                            primitive = parse_primitive_file(file_path, source=source)
-                            collection.add_primitive(primitive)
-                        except Exception as e:
-                            print(f"Warning: Failed to parse dependency primitive {file_path}: {e}")
+        _scan_patterns(apm_dir, DEPENDENCY_PRIMITIVE_PATTERNS, collection, source)
 
     # Also scan .github directory — some packages store primitives there instead of (or
     # in addition to) .apm/.  Without this, dependency instructions in .github/instructions/
     # are silently skipped in the normal compile path (issue #631).
     github_dir = directory / ".github"
     if github_dir.exists():
-        for primitive_type, patterns in DEPENDENCY_GITHUB_PRIMITIVE_PATTERNS.items():
-            for pattern in patterns:
-                full_pattern = str(github_dir / pattern)
-                matching_files = glob.glob(full_pattern, recursive=True)
-
-                for file_path_str in matching_files:
-                    file_path = Path(file_path_str)
-                    if file_path.is_file() and _is_readable(file_path):
-                        try:
-                            primitive = parse_primitive_file(file_path, source=source)
-                            collection.add_primitive(primitive)
-                        except Exception as e:
-                            print(f"Warning: Failed to parse dependency primitive {file_path}: {e}")
+        _scan_patterns(github_dir, DEPENDENCY_GITHUB_PRIMITIVE_PATTERNS, collection, source)
 
     # Check for SKILL.md in the dependency root
     _discover_skill_in_directory(directory, collection, source)

--- a/src/apm_cli/primitives/discovery.py
+++ b/src/apm_cli/primitives/discovery.py
@@ -55,6 +55,20 @@ DEPENDENCY_PRIMITIVE_PATTERNS: Dict[str, List[str]] = {
     ]
 }
 
+# Dependency primitive patterns for .github directory within dependencies.
+# Some packages store primitives in .github/ instead of (or in addition to) .apm/.
+DEPENDENCY_GITHUB_PRIMITIVE_PATTERNS: Dict[str, List[str]] = {
+    'chatmode': [
+        "agents/*.agent.md",
+        "chatmodes/*.chatmode.md",
+    ],
+    'instruction': ["instructions/*.instructions.md"],
+    'context': [
+        "context/*.context.md",
+        "memory/*.memory.md",
+    ]
+}
+
 
 def discover_primitives(
     base_dir: str = ".",
@@ -299,35 +313,49 @@ def get_dependency_declaration_order(base_dir: str) -> List[str]:
 
 def scan_directory_with_source(directory: Path, collection: PrimitiveCollection, source: str) -> None:
     """Scan a directory for primitives with a specific source tag.
-    
+
     Args:
         directory (Path): Directory to scan (e.g., apm_modules/package_name).
         collection (PrimitiveCollection): Collection to add primitives to.
         source (str): Source identifier for discovered primitives.
     """
-    # Look for .apm directory within the dependency
+    # Scan .apm directory within the dependency
     apm_dir = directory / ".apm"
-    if not apm_dir.exists():
-        # Even without .apm, check for SKILL.md (Claude Skills support)
-        _discover_skill_in_directory(directory, collection, source)
-        return
-    
-    # Find and parse files for each primitive type
-    for primitive_type, patterns in DEPENDENCY_PRIMITIVE_PATTERNS.items():
-        for pattern in patterns:
-            full_pattern = str(apm_dir / pattern)
-            matching_files = glob.glob(full_pattern, recursive=True)
-            
-            for file_path_str in matching_files:
-                file_path = Path(file_path_str)
-                if file_path.is_file() and _is_readable(file_path):
-                    try:
-                        primitive = parse_primitive_file(file_path, source=source)
-                        collection.add_primitive(primitive)
-                    except Exception as e:
-                        print(f"Warning: Failed to parse dependency primitive {file_path}: {e}")
-    
-    # Also check for SKILL.md in the dependency root
+    if apm_dir.exists():
+        for primitive_type, patterns in DEPENDENCY_PRIMITIVE_PATTERNS.items():
+            for pattern in patterns:
+                full_pattern = str(apm_dir / pattern)
+                matching_files = glob.glob(full_pattern, recursive=True)
+
+                for file_path_str in matching_files:
+                    file_path = Path(file_path_str)
+                    if file_path.is_file() and _is_readable(file_path):
+                        try:
+                            primitive = parse_primitive_file(file_path, source=source)
+                            collection.add_primitive(primitive)
+                        except Exception as e:
+                            print(f"Warning: Failed to parse dependency primitive {file_path}: {e}")
+
+    # Also scan .github directory — some packages store primitives there instead of (or
+    # in addition to) .apm/.  Without this, dependency instructions in .github/instructions/
+    # are silently skipped in the normal compile path (issue #631).
+    github_dir = directory / ".github"
+    if github_dir.exists():
+        for primitive_type, patterns in DEPENDENCY_GITHUB_PRIMITIVE_PATTERNS.items():
+            for pattern in patterns:
+                full_pattern = str(github_dir / pattern)
+                matching_files = glob.glob(full_pattern, recursive=True)
+
+                for file_path_str in matching_files:
+                    file_path = Path(file_path_str)
+                    if file_path.is_file() and _is_readable(file_path):
+                        try:
+                            primitive = parse_primitive_file(file_path, source=source)
+                            collection.add_primitive(primitive)
+                        except Exception as e:
+                            print(f"Warning: Failed to parse dependency primitive {file_path}: {e}")
+
+    # Check for SKILL.md in the dependency root
     _discover_skill_in_directory(directory, collection, source)
 
 

--- a/tests/unit/primitives/test_discovery_parser.py
+++ b/tests/unit/primitives/test_discovery_parser.py
@@ -331,6 +331,46 @@ class TestScanDirectoryWithSource(unittest.TestCase):
             self.assertIn("Warning", buf.getvalue())
         self.assertEqual(collection.count(), 0)
 
+    def test_github_instructions_discovered_when_no_apm_dir(self):
+        """Regression test for issue #631.
+
+        Dependency instructions stored in .github/instructions/ must be
+        included in compile --target claude without --local-only.
+        """
+        dep_dir = Path(self.tmp) / "chkp-roniz" / "cc-rubber-duck"
+        _write(
+            dep_dir / ".github" / "instructions" / "rubber-duck.instructions.md",
+            INSTRUCTION_CONTENT,
+        )
+        collection = PrimitiveCollection()
+        scan_directory_with_source(
+            dep_dir, collection, source="dependency:chkp-roniz/cc-rubber-duck"
+        )
+        self.assertEqual(len(collection.instructions), 1)
+        self.assertEqual(
+            collection.instructions[0].source,
+            "dependency:chkp-roniz/cc-rubber-duck",
+        )
+
+    def test_github_instructions_discovered_alongside_apm_dir(self):
+        """Regression test for issue #631.
+
+        When a dependency has both .apm/instructions/ and .github/instructions/,
+        primitives from both directories must be discovered.
+        """
+        dep_dir = Path(self.tmp) / "owner" / "mixed-pkg"
+        _write(
+            dep_dir / ".apm" / "instructions" / "from-apm.instructions.md",
+            INSTRUCTION_CONTENT,
+        )
+        _write(
+            dep_dir / ".github" / "instructions" / "from-github.instructions.md",
+            INSTRUCTION_CONTENT,
+        )
+        collection = PrimitiveCollection()
+        scan_directory_with_source(dep_dir, collection, source="dependency:owner/mixed-pkg")
+        self.assertEqual(len(collection.instructions), 2)
+
 
 class TestGetDependencyDeclarationOrder(unittest.TestCase):
     """Tests for get_dependency_declaration_order."""


### PR DESCRIPTION
## What
Fix compile path that silently skipped dependency instructions stored in
`.github/instructions/` when running `apm compile --target claude` without
`--local-only`.

## Why
Issue #631: `scan_directory_with_source` only scanned `{dep}/.apm/` for
primitives. Packages that store instructions in `.github/instructions/`
(instead of `.apm/instructions/`) were completely invisible to
`discover_primitives_with_dependencies`. The `--local-only` and `--validate`
paths used `LOCAL_PRIMITIVE_PATTERNS` (which includes `**/.github/instructions/`)
so they worked, but the normal distributed compile path did not.

Symptoms:
- `apm compile --target claude --verbose` showed `Instruction Processing: 0.0ms`
- No `CLAUDE.md` was generated
- `apm compile --target claude --local-only` worked correctly
- `apm compile --validate` could find the instructions

## How
Add `DEPENDENCY_GITHUB_PRIMITIVE_PATTERNS` (mirroring `DEPENDENCY_PRIMITIVE_PATTERNS`
for the `.github/` directory layout) and scan `{dep}/.github/` in
`scan_directory_with_source` alongside the existing `.apm/` scan.

The original early-return guard `if not apm_dir.exists(): return` is replaced
by independent `if apm_dir.exists():` / `if github_dir.exists():` checks so
both directories are always considered regardless of which one is present.

No CLI interface changes. No architecture changes. Existing `.apm/`-based
packages are unaffected.

## Test
- Reproduced issue #631: `.github/`-only dependency → 0 instructions before fix
- Verified fix: `.github/`-only dependency → instruction found and `CLAUDE.md` generated
- `--local-only` still works correctly
- `--target copilot` unaffected
- `--validate` unaffected
- Regression tests added to `TestScanDirectoryWithSource`:
  - `test_github_instructions_discovered_when_no_apm_dir`
  - `test_github_instructions_discovered_alongside_apm_dir`
- All 348 existing unit tests pass