### PR TITLE
fix(init): remove triple confirm prompt on Windows CP950 terminals (#602)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `apm install --global` now installs MCP servers to global-capable runtimes (Copilot CLI, Codex CLI) instead of blanket-skipping all MCP installation at user scope. Note: lockfile-path behavior at `--global` tracked in #794 (#638)
 - `--trust-transitive-mcp` no longer silently ignored when combined with `--global` (#638)
 - Token resolution now discriminates by port, fixing credential collisions across multiple self-hosted Git instances on the same host. Thanks @edenfunf! (#785)
+- Fix `apm init` showing overwrite confirmation prompt three times on Windows CP950 terminals (#602)
 
 ## [0.8.12] - 2026-04-19
 

--- a/src/apm_cli/commands/init.py
+++ b/src/apm_cli/commands/init.py
@@ -19,7 +19,6 @@ from ._helpers import (
     _create_plugin_json,
     _get_console,
     _get_default_config,
-    _lazy_confirm,
     _rich_blank_line,
     _validate_plugin_name,
     _validate_project_name,
@@ -84,14 +83,7 @@ def init(ctx, project_name, yes, plugin, verbose):
             logger.warning("apm.yml already exists")
 
             if not yes:
-                Confirm = _lazy_confirm()
-                if Confirm:
-                    try:
-                        confirm = Confirm.ask("Continue and overwrite?")
-                    except Exception:
-                        confirm = click.confirm("Continue and overwrite?")
-                else:
-                    confirm = click.confirm("Continue and overwrite?")
+                confirm = click.confirm("Continue and overwrite?")
 
                 if not confirm:
                     logger.progress("Initialization cancelled.")

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -220,6 +220,51 @@ class TestInitCommand:
             finally:
                 os.chdir(self.original_dir)  # restore CWD before TemporaryDirectory cleanup
 
+    def test_init_existing_project_confirm_prompt_shown_once(self):
+        """Test that overwrite confirmation prompt appears exactly once (#602).
+
+        On Windows CP950 terminals, Rich Confirm.ask() could fail on encoding,
+        retry internally, then fall back to click.confirm(), showing the prompt
+        three times. After the fix, only click.confirm() is used.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.chdir(tmp_dir)
+            try:
+
+                # Create existing apm.yml
+                Path("apm.yml").write_text("name: existing-project\nversion: 0.1.0\n")
+
+                # Say yes to overwrite, then provide interactive setup input
+                user_input = "y\nmy-project\n1.0.0\nA description\nAuthor\ny\n"
+                result = self.runner.invoke(cli, ["init"], input=user_input)
+
+                assert result.exit_code == 0
+                # The overwrite prompt must appear exactly once
+                assert result.output.count("Continue and overwrite?") == 1
+            finally:
+                os.chdir(self.original_dir)  # restore CWD before TemporaryDirectory cleanup
+
+    def test_init_existing_project_confirm_uses_click(self):
+        """Test that overwrite confirmation uses click.confirm, not Rich (#602)."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.chdir(tmp_dir)
+            try:
+
+                # Create existing apm.yml
+                Path("apm.yml").write_text("name: existing-project\nversion: 0.1.0\n")
+
+                with patch("apm_cli.commands.init.click.confirm", return_value=True) as mock_confirm:
+                    result = self.runner.invoke(cli, ["init", "--yes"])
+                    # --yes skips the prompt entirely, so confirm should NOT be called
+                    mock_confirm.assert_not_called()
+
+                with patch("apm_cli.commands.init.click.confirm", return_value=False) as mock_confirm:
+                    result = self.runner.invoke(cli, ["init"])
+                    mock_confirm.assert_called_once_with("Continue and overwrite?")
+                    assert "Initialization cancelled" in result.output
+            finally:
+                os.chdir(self.original_dir)  # restore CWD before TemporaryDirectory cleanup
+
     def test_init_validates_project_structure(self):
         """Test that init creates minimal project structure."""
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary

Fixes #602 — On Windows systems with non-UTF-8 console encoding (CP950, CP936, CP932), `apm init` in an existing project showed the overwrite confirmation prompt **three times**.

## Root Cause

Rich `Confirm.ask()` would:
1. Prompt once
2. Fail to decode input on CP950, retry internally (prompt #2)
3. Raise an exception — the `except` block called `click.confirm()` again (prompt #3)

## Fix

Simplified the overwrite confirmation to always use `click.confirm()` directly. This is a simple y/n prompt where cross-platform reliability matters more than Rich styling. The interactive setup section retains its own Rich/click fallback pattern.

## Changes

- `src/apm_cli/commands/init.py` — Replace Rich Confirm.ask fallback with direct `click.confirm()` (-9 lines, +1 line)
- `tests/unit/test_init_command.py` — Add 2 regression tests
- `CHANGELOG.md` — Add fix entry

## Testing

All 17 init tests pass. Two new regression tests verify:
- The prompt appears exactly once
- `click.confirm` is the function called (not Rich)