### PR TITLE
fix(run): add explicit UTF-8 encoding to prompt file operations (#604)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Add explicit UTF-8 encoding to prompt file read/write operations to prevent `UnicodeDecodeError` on non-UTF-8 default locales (e.g., Windows CP950) (#604)
 - Propagate headers and environment variables through OpenCode MCP adapter with defensive copies to prevent mutation (#622)
 ### Changed
 

--- a/src/apm_cli/core/script_runner.py
+++ b/src/apm_cli/core/script_runner.py
@@ -256,7 +256,7 @@ class ScriptRunner:
             compiled_prompt_files.append(prompt_file)
 
             # Read the compiled content
-            with open(compiled_path, "r") as f:
+            with open(compiled_path, "r", encoding="utf-8") as f:
                 compiled_content = f.read().strip()
 
             # Check if this is a runtime command (copilot, codex, llm) before transformation
@@ -916,7 +916,7 @@ class PromptCompiler:
         # Now ensure compiled directory exists
         self.compiled_dir.mkdir(parents=True, exist_ok=True)
 
-        with open(prompt_path, "r") as f:
+        with open(prompt_path, "r", encoding="utf-8") as f:
             content = f.read()
 
         # Parse frontmatter and content
@@ -939,7 +939,7 @@ class PromptCompiler:
         output_path = self.compiled_dir / output_name
 
         # Write compiled content
-        with open(output_path, "w") as f:
+        with open(output_path, "w", encoding="utf-8") as f:
             f.write(compiled_content)
 
         return str(output_path)

--- a/tests/unit/test_script_runner.py
+++ b/tests/unit/test_script_runner.py
@@ -325,6 +325,61 @@ Hello ${input:name}!"""
         with pytest.raises(FileNotFoundError, match="Prompt file 'nonexistent.prompt.md' not found"):
             self.compiler.compile("nonexistent.prompt.md", {})
 
+    def test_compile_utf8_content_with_cjk_characters(self):
+        """Test that prompt files with non-ASCII characters compile correctly.
+
+        Regression test for #604: UnicodeDecodeError on Windows CP950
+        when .prompt.md contains CJK or other non-ASCII characters.
+        """
+        tmp_dir = tempfile.mkdtemp()
+        try:
+            prompt_dir = Path(tmp_dir)
+            prompt_path = prompt_dir / "i18n.prompt.md"
+            cjk_content = (
+                "---\n"
+                "description: 国際化テスト\n"
+                "---\n"
+                "\n"
+                "你好世界！こんにちは ${input:name}！\n"
+                "Ünïcödé résumé naïve café"
+            )
+            prompt_path.write_text(cjk_content, encoding="utf-8")
+
+            compiler = PromptCompiler()
+            compiler.compiled_dir = prompt_dir / ".compiled"
+
+            result_path = compiler.compile(
+                str(prompt_path), {"name": "ユーザー"}
+            )
+
+            compiled = Path(result_path).read_text(encoding="utf-8")
+            assert "你好世界！こんにちは ユーザー！" in compiled
+            assert "Ünïcödé résumé naïve café" in compiled
+            # Frontmatter must be stripped
+            assert "---" not in compiled
+        finally:
+            shutil.rmtree(tmp_dir)
+
+    def test_compile_utf8_content_without_frontmatter(self):
+        """Test non-ASCII prompt without frontmatter compiles correctly."""
+        tmp_dir = tempfile.mkdtemp()
+        try:
+            prompt_dir = Path(tmp_dir)
+            prompt_path = prompt_dir / "simple_cjk.prompt.md"
+            prompt_path.write_text(
+                "Привет ${input:who}! 🚀", encoding="utf-8"
+            )
+
+            compiler = PromptCompiler()
+            compiler.compiled_dir = prompt_dir / ".compiled"
+
+            result_path = compiler.compile(str(prompt_path), {"who": "мир"})
+
+            compiled = Path(result_path).read_text(encoding="utf-8")
+            assert compiled == "Привет мир! 🚀"
+        finally:
+            shutil.rmtree(tmp_dir)
+
 
 class TestPromptCompilerDependencyDiscovery:
     """Test PromptCompiler dependency discovery functionality."""


### PR DESCRIPTION
## Summary\n\nFixes #604 — `apm run start` crashes with `UnicodeDecodeError` when `.prompt.md` contains non-ASCII characters on Windows systems with non-UTF-8 locale encoding (CP950, CP936, CP932).\n\n## Root Cause\n\nThree `open()` calls in `script_runner.py` did not pass an explicit `encoding` parameter:\n- `PromptCompiler.compile()` — reads the source `.prompt.md`\n- `PromptCompiler.compile()` — writes the compiled output file\n- `ScriptRunner._execute_script()` — reads the compiled file\n\nWithout `encoding=\"utf-8\"`, Python uses the platform default (CP950 on affected systems), which cannot decode UTF-8 multi-byte sequences.\n\n## Fix\n\nAdded `encoding=\"utf-8\"` to all three `open()` calls. Full audit of the codebase confirmed no other prompt-related `open()` calls are affected.\n\n## Changes\n\n- `src/apm_cli/core/script_runner.py` — Add `encoding=\"utf-8\"` to 3 `open()` calls\n- `tests/unit/test_script_runner.py` — Add 2 tests for CJK and Cyrillic content in prompt compilation\n- `CHANGELOG.md` — Add fix entry\n\n## Testing\n\nAll 3792 tests pass. New tests verify:\n- CJK characters with frontmatter and parameter substitution\n- Cyrillic + emoji content without frontmatter\n