### PR TITLE
fix(init): reframe Next Steps panel around install workflows (#603)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `apm mcp search`, `apm mcp list`, and `apm mcp show` now honour the `MCP_REGISTRY_URL` environment variable (previously hardcoded to the public registry), bringing them in line with `apm install --mcp`. When the variable is set, the discovery commands print a one-line `Registry: <url>` diagnostic and surface the configured URL in network-error messages so misconfigured enterprise registries are obvious (#813)
 - `apm install --mcp ... --dry-run` now validates the would-be entry through the same chokepoint the real install uses, so dry-run never previews "success" for an entry `apm install` would reject (empty / whitespace-only / over-128-char / embedded `..` names, invalid transport-conflict combinations) (#810)
 - `SimpleRegistryClient` now applies a `(connect=10s, read=30s)` timeout on every registry HTTP call, removing the unbounded-hang failure mode when a registry is slow or unreachable. Operators can tune via `MCP_REGISTRY_CONNECT_TIMEOUT` / `MCP_REGISTRY_READ_TIMEOUT` env vars; invalid values silently fall back to defaults (#810)
+- `apm init` Next Steps panel now shows install/marketplace/plugin workflows instead of the dead-end `apm run start` reference; no extra files are created besides `apm.yml` (#649)
 
 ### Security
 

--- a/docs/src/content/docs/getting-started/first-package.md
+++ b/docs/src/content/docs/getting-started/first-package.md
@@ -26,7 +26,7 @@ my-coding-standards/
 └── apm.yml              # Package manifest
 ```
 
-> **Note:** `apm init` creates only `apm.yml`. The directory structure below is what you build manually in the following steps.
+> **Note:** By default, `apm init` creates only `apm.yml`. The directory structure below is what you build manually in the following steps.
 
 ## 2. Add an Instruction
 

--- a/docs/src/content/docs/getting-started/first-package.md
+++ b/docs/src/content/docs/getting-started/first-package.md
@@ -23,14 +23,10 @@ This creates:
 
 ```
 my-coding-standards/
-├── apm.yml              # Package manifest
-└── .apm/
-    ├── instructions/    # Coding standards (.instructions.md)
-    ├── prompts/         # Slash commands (.prompt.md)
-    ├── skills/          # Agent skills (SKILL.md)
-    ├── agents/          # Personas (.agent.md)
-    └── hooks/           # Event handlers (.json)
+└── apm.yml              # Package manifest
 ```
+
+> **Note:** `apm init` creates only `apm.yml`. The directory structure below is what you build manually in the following steps.
 
 ## 2. Add an Instruction
 

--- a/docs/src/content/docs/introduction/key-concepts.md
+++ b/docs/src/content/docs/introduction/key-concepts.md
@@ -23,7 +23,7 @@ my-project/
 └── apm.yml              # Project configuration and dependency manifest
 ```
 
-> **Note:** `apm init` creates only `apm.yml`. Add primitives manually or install them with `apm install`. See [Your First Package](../../getting-started/first-package/) for a step-by-step guide.
+> **Note:** By default, `apm init` creates only `apm.yml`. Add primitives manually or install them with `apm install`. See [Your First Package](../../getting-started/first-package/) for a step-by-step guide.
 
 ### Intelligent Compilation
 

--- a/docs/src/content/docs/introduction/key-concepts.md
+++ b/docs/src/content/docs/introduction/key-concepts.md
@@ -10,29 +10,20 @@ Context components are the configurable tools that deploy proven prompt engineer
 
 APM implements Context - the configurable tools that deploy prompt engineering and context engineering techniques to transform unreliable AI interactions into engineered systems.
 
-### Initialize a project with AI-Native structure
+### Initialize a project
 
 ```bash
-apm init my-project  # Creates complete Context scaffolding + apm.yml
+apm init my-project  # Creates apm.yml -- the only file apm init produces
 ```
 
 ### Generated Project Structure
 
 ```yaml
 my-project/
-├── apm.yml              # Project configuration and script definitions
-├── SKILL.md             # Package meta-guide for AI discovery
-└── .apm/
-    ├── agents/          # Role-based AI expertise with tool boundaries
-    │   ├── backend-dev.agent.md        # API development specialist
-    │   └── frontend-dev.agent.md       # UI development specialist
-    ├── instructions/    # Targeted guidance by file type and domain  
-    │   ├── security.instructions.md    # applyTo: "auth/**"
-    │   └── testing.instructions.md     # applyTo: "**/*test*"
-    └── prompts/         # Reusable agent workflows
-        ├── code-review.prompt.md       # Systematic review process
-        └── feature-spec.prompt.md      # Spec-first development
+└── apm.yml              # Project configuration and dependency manifest
 ```
+
+> **Note:** `apm init` creates only `apm.yml`. Add primitives manually or install them with `apm install`. See [Your First Package](../../getting-started/first-package/) for a step-by-step guide.
 
 ### Intelligent Compilation
 

--- a/src/apm_cli/commands/init.py
+++ b/src/apm_cli/commands/init.py
@@ -126,7 +126,7 @@ def init(ctx, project_name, yes, plugin, verbose):
                 start_prompt_path.write_text(START_PROMPT_TEMPLATE, encoding="utf-8")
                 start_prompt_created = True
             else:
-                logger.progress("start.prompt.md already exists, skipping")
+                logger.progress(f"{START_PROMPT_FILENAME} already exists, skipping")
 
         # Create plugin.json for plugin mode
         if plugin:
@@ -151,7 +151,7 @@ def init(ctx, project_name, yes, plugin, verbose):
             logger.progress("Created:")
             click.echo("  * apm.yml - Project configuration")
             if start_prompt_created:
-                click.echo("  * start.prompt.md - Starter prompt")
+                click.echo(f"  * {START_PROMPT_FILENAME} - Starter prompt")
             if plugin:
                 click.echo("  * plugin.json - Plugin metadata")
 
@@ -167,7 +167,7 @@ def init(ctx, project_name, yes, plugin, verbose):
             next_steps = [
                 "Install a runtime:       apm runtime setup copilot",
                 "Add APM dependencies:    apm install <owner>/<repo>",
-                "Edit your prompt:        start.prompt.md",
+                "Edit your prompt:        start.prompt.md (or .apm/prompts/start.prompt.md)",
                 "Run your first workflow: apm run start",
             ]
 

--- a/src/apm_cli/commands/init.py
+++ b/src/apm_cli/commands/init.py
@@ -24,6 +24,17 @@ from ._helpers import (
     _validate_project_name,
 )
 
+START_PROMPT_FILENAME = "start.prompt.md"
+
+START_PROMPT_TEMPLATE = """\
+---
+name: start
+---
+You are a helpful assistant working on this project.
+
+Help me understand the codebase and suggest improvements.
+"""
+
 
 @click.command(help="Initialize a new APM project")
 @click.argument("project_name", required=False)
@@ -107,6 +118,16 @@ def init(ctx, project_name, yes, plugin, verbose):
         # Create apm.yml (with devDependencies for plugin mode)
         _create_minimal_apm_yml(config, plugin=plugin)
 
+        # Create start.prompt.md for regular projects (not plugin mode)
+        start_prompt_created = False
+        if not plugin:
+            start_prompt_path = Path(START_PROMPT_FILENAME)
+            if not start_prompt_path.exists():
+                start_prompt_path.write_text(START_PROMPT_TEMPLATE, encoding="utf-8")
+                start_prompt_created = True
+            else:
+                logger.progress("start.prompt.md already exists, skipping")
+
         # Create plugin.json for plugin mode
         if plugin:
             _create_plugin_json(config)
@@ -120,6 +141,8 @@ def init(ctx, project_name, yes, plugin, verbose):
                 files_data = [
                     ("*", APM_YML_FILENAME, "Project configuration"),
                 ]
+                if start_prompt_created:
+                    files_data.append(("*", START_PROMPT_FILENAME, "Starter prompt"))
                 if plugin:
                     files_data.append(("*", "plugin.json", "Plugin metadata"))
                 table = _create_files_table(files_data, title="Created Files")
@@ -127,6 +150,8 @@ def init(ctx, project_name, yes, plugin, verbose):
         except (ImportError, NameError):
             logger.progress("Created:")
             click.echo("  * apm.yml - Project configuration")
+            if start_prompt_created:
+                click.echo("  * start.prompt.md - Starter prompt")
             if plugin:
                 click.echo("  * plugin.json - Plugin metadata")
 
@@ -142,7 +167,7 @@ def init(ctx, project_name, yes, plugin, verbose):
             next_steps = [
                 "Install a runtime:       apm runtime setup copilot",
                 "Add APM dependencies:    apm install <owner>/<repo>",
-                "Compile agent context:   apm compile",
+                "Edit your prompt:        start.prompt.md",
                 "Run your first workflow: apm run start",
             ]
 

--- a/src/apm_cli/commands/init.py
+++ b/src/apm_cli/commands/init.py
@@ -24,18 +24,6 @@ from ._helpers import (
     _validate_project_name,
 )
 
-START_PROMPT_FILENAME = "start.prompt.md"
-
-START_PROMPT_TEMPLATE = """\
----
-name: start
----
-You are a helpful assistant working on this project.
-
-Help me understand the codebase and suggest improvements.
-"""
-
-
 @click.command(help="Initialize a new APM project")
 @click.argument("project_name", required=False)
 @click.option(
@@ -118,16 +106,6 @@ def init(ctx, project_name, yes, plugin, verbose):
         # Create apm.yml (with devDependencies for plugin mode)
         _create_minimal_apm_yml(config, plugin=plugin)
 
-        # Create start.prompt.md for regular projects (not plugin mode)
-        start_prompt_created = False
-        if not plugin:
-            start_prompt_path = Path(START_PROMPT_FILENAME)
-            if not start_prompt_path.exists():
-                start_prompt_path.write_text(START_PROMPT_TEMPLATE, encoding="utf-8")
-                start_prompt_created = True
-            else:
-                logger.progress(f"{START_PROMPT_FILENAME} already exists, skipping")
-
         # Create plugin.json for plugin mode
         if plugin:
             _create_plugin_json(config)
@@ -141,8 +119,6 @@ def init(ctx, project_name, yes, plugin, verbose):
                 files_data = [
                     ("*", APM_YML_FILENAME, "Project configuration"),
                 ]
-                if start_prompt_created:
-                    files_data.append(("*", START_PROMPT_FILENAME, "Starter prompt"))
                 if plugin:
                     files_data.append(("*", "plugin.json", "Plugin metadata"))
                 table = _create_files_table(files_data, title="Created Files")
@@ -150,8 +126,6 @@ def init(ctx, project_name, yes, plugin, verbose):
         except (ImportError, NameError):
             logger.progress("Created:")
             click.echo("  * apm.yml - Project configuration")
-            if start_prompt_created:
-                click.echo(f"  * {START_PROMPT_FILENAME} - Starter prompt")
             if plugin:
                 click.echo("  * plugin.json - Plugin metadata")
 
@@ -165,10 +139,10 @@ def init(ctx, project_name, yes, plugin, verbose):
             ]
         else:
             next_steps = [
-                "Install a runtime:       apm runtime setup copilot",
-                "Add APM dependencies:    apm install <owner>/<repo>",
-                "Edit your prompt:        start.prompt.md (or .apm/prompts/start.prompt.md)",
-                "Run your first workflow: apm run start",
+                "Install a skill:                apm install github/awesome-copilot/skills/documentation-writer",
+                "Install a marketplace plugin:   apm install frontend-web-dev@awesome-copilot",
+                "Install a versioned package:    apm install microsoft/apm-sample-package#v1.0.0",
+                "Author your own plugin:         apm pack --format plugin",
             ]
 
         try:
@@ -181,6 +155,26 @@ def init(ctx, project_name, yes, plugin, verbose):
             logger.progress("Next steps:")
             for step in next_steps:
                 click.echo(f"  * {step}")
+
+        # Footer with links
+        try:
+            console = _get_console()
+            if console:
+                console.print(
+                    "  Docs: https://microsoft.github.io/apm  |  "
+                    "Star: https://github.com/microsoft/apm",
+                    style="dim",
+                )
+            else:
+                click.echo(
+                    "  Docs: https://microsoft.github.io/apm  |  "
+                    "Star: https://github.com/microsoft/apm"
+                )
+        except (ImportError, NameError):
+            click.echo(
+                "  Docs: https://microsoft.github.io/apm  |  "
+                "Star: https://github.com/microsoft/apm"
+            )
 
     except Exception as e:
         logger.error(f"Error initializing project: {e}")

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -46,7 +46,7 @@ class TestInitCommand:
                 assert result.exit_code == 0
                 assert "APM project initialized successfully!" in result.output
                 assert Path("apm.yml").exists()
-                assert Path("start.prompt.md").exists()
+                assert not Path("start.prompt.md").exists()
                 # No extra template files created
                 assert not Path("hello-world.prompt.md").exists()
                 assert not Path("README.md").exists()
@@ -65,7 +65,7 @@ class TestInitCommand:
                 assert result.exit_code == 0
                 assert "APM project initialized successfully!" in result.output
                 assert Path("apm.yml").exists()
-                assert Path("start.prompt.md").exists()
+                assert not Path("start.prompt.md").exists()
                 # No extra template files created
                 assert not Path("hello-world.prompt.md").exists()
             finally:
@@ -86,7 +86,7 @@ class TestInitCommand:
                 assert project_path.exists()
                 assert project_path.is_dir()
                 assert (project_path / "apm.yml").exists()
-                assert (project_path / "start.prompt.md").exists()
+                assert not (project_path / "start.prompt.md").exists()
                 # No extra template files created
                 assert not (project_path / "hello-world.prompt.md").exists()
                 assert not (project_path / "README.md").exists()
@@ -291,8 +291,8 @@ class TestInitCommand:
                     assert "scripts" in config
                     assert config["scripts"] == {}
 
-                # start.prompt.md created
-                assert (project_path / "start.prompt.md").exists()
+                # start.prompt.md NOT created (apm init creates only apm.yml)
+                assert not (project_path / "start.prompt.md").exists()
                 # No extra template files created
                 assert not (project_path / "hello-world.prompt.md").exists()
                 assert not (project_path / "README.md").exists()
@@ -346,68 +346,35 @@ class TestInitCommand:
             finally:
                 os.chdir(self.original_dir)  # restore CWD before TemporaryDirectory cleanup
 
-    def test_init_creates_start_prompt_md(self):
-        """Test that init creates start.prompt.md with correct content."""
+    def test_init_next_steps_panel_content(self):
+        """Test that next steps show install workflows, not apm run start."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             os.chdir(tmp_dir)
             try:
                 result = self.runner.invoke(cli, ["init", "--yes"])
 
                 assert result.exit_code == 0
-                prompt_path = Path("start.prompt.md")
-                assert prompt_path.exists()
-
-                content = prompt_path.read_text(encoding="utf-8")
-                assert "---" in content
-                assert "name: start" in content
-                assert "You are a helpful assistant" in content
-            finally:
-                os.chdir(self.original_dir)
-
-    def test_init_does_not_overwrite_existing_start_prompt(self):
-        """Test that init preserves existing start.prompt.md (brownfield)."""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            os.chdir(tmp_dir)
-            try:
-                # Create existing start.prompt.md with custom content
-                Path("start.prompt.md").write_text(
-                    "---\nname: start\n---\nMy custom prompt\n", encoding="utf-8"
-                )
-
-                result = self.runner.invoke(cli, ["init", "--yes"])
-
-                assert result.exit_code == 0
-                content = Path("start.prompt.md").read_text(encoding="utf-8")
-                assert "My custom prompt" in content
-                assert "start.prompt.md already exists" in result.output
-            finally:
-                os.chdir(self.original_dir)
-
-    def test_init_next_steps_no_compile(self):
-        """Test that next steps do not reference apm compile."""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            os.chdir(tmp_dir)
-            try:
-                result = self.runner.invoke(cli, ["init", "--yes"])
-
-                assert result.exit_code == 0
+                # New v5 panel content
+                assert "apm install" in result.output
+                assert "apm pack" in result.output
+                assert "https://microsoft.github.io/apm" in result.output
+                # Old dead-end content must be gone
                 assert "apm compile" not in result.output
-                assert "Edit your prompt" in result.output
-                assert "start.prompt.md" in result.output
-                assert "apm run start" in result.output
+                assert "apm run start" not in result.output
+                assert "start.prompt.md" not in result.output
             finally:
                 os.chdir(self.original_dir)
 
-    def test_init_created_files_table_includes_start_prompt(self):
-        """Test that Created Files table lists start.prompt.md."""
+    def test_init_created_files_table_no_start_prompt(self):
+        """Test that Created Files table does NOT list start.prompt.md."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             os.chdir(tmp_dir)
             try:
                 result = self.runner.invoke(cli, ["init", "--yes"])
 
                 assert result.exit_code == 0
-                # start.prompt.md appears in the Created Files table
-                assert "start.prompt.md" in result.output
+                assert "apm.yml" in result.output
+                assert "start.prompt.md" not in result.output
             finally:
                 os.chdir(self.original_dir)
 

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -36,7 +36,7 @@ class TestInitCommand:
             os.chdir(str(repo_root))
 
     def test_init_current_directory(self):
-        """Test initialization in current directory (minimal mode)."""
+        """Test initialization in current directory."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             os.chdir(tmp_dir)
             try:
@@ -46,7 +46,8 @@ class TestInitCommand:
                 assert result.exit_code == 0
                 assert "APM project initialized successfully!" in result.output
                 assert Path("apm.yml").exists()
-                # Minimal mode: no template files created
+                assert Path("start.prompt.md").exists()
+                # No extra template files created
                 assert not Path("hello-world.prompt.md").exists()
                 assert not Path("README.md").exists()
                 assert not Path(".apm").exists()
@@ -54,7 +55,7 @@ class TestInitCommand:
                 os.chdir(self.original_dir)  # restore CWD before TemporaryDirectory cleanup
 
     def test_init_explicit_current_directory(self):
-        """Test initialization with explicit '.' argument (minimal mode)."""
+        """Test initialization with explicit '.' argument."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             os.chdir(tmp_dir)
             try:
@@ -64,13 +65,14 @@ class TestInitCommand:
                 assert result.exit_code == 0
                 assert "APM project initialized successfully!" in result.output
                 assert Path("apm.yml").exists()
-                # Minimal mode: no template files created
+                assert Path("start.prompt.md").exists()
+                # No extra template files created
                 assert not Path("hello-world.prompt.md").exists()
             finally:
                 os.chdir(self.original_dir)  # restore CWD before TemporaryDirectory cleanup
 
     def test_init_new_directory(self):
-        """Test initialization in new directory (minimal mode)."""
+        """Test initialization in new directory."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             os.chdir(tmp_dir)
             try:
@@ -84,7 +86,8 @@ class TestInitCommand:
                 assert project_path.exists()
                 assert project_path.is_dir()
                 assert (project_path / "apm.yml").exists()
-                # Minimal mode: no template files created
+                assert (project_path / "start.prompt.md").exists()
+                # No extra template files created
                 assert not (project_path / "hello-world.prompt.md").exists()
                 assert not (project_path / "README.md").exists()
                 assert not (project_path / ".apm").exists()
@@ -266,7 +269,7 @@ class TestInitCommand:
                 os.chdir(self.original_dir)  # restore CWD before TemporaryDirectory cleanup
 
     def test_init_validates_project_structure(self):
-        """Test that init creates minimal project structure."""
+        """Test that init creates expected project structure."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             os.chdir(tmp_dir)
             try:
@@ -288,7 +291,9 @@ class TestInitCommand:
                     assert "scripts" in config
                     assert config["scripts"] == {}
 
-                # Minimal mode: no template files created
+                # start.prompt.md created
+                assert (project_path / "start.prompt.md").exists()
+                # No extra template files created
                 assert not (project_path / "hello-world.prompt.md").exists()
                 assert not (project_path / "README.md").exists()
                 assert not (project_path / ".apm").exists()
@@ -340,6 +345,71 @@ class TestInitCommand:
                 assert not Path("SKILL.md").exists()
             finally:
                 os.chdir(self.original_dir)  # restore CWD before TemporaryDirectory cleanup
+
+    def test_init_creates_start_prompt_md(self):
+        """Test that init creates start.prompt.md with correct content."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.chdir(tmp_dir)
+            try:
+                result = self.runner.invoke(cli, ["init", "--yes"])
+
+                assert result.exit_code == 0
+                prompt_path = Path("start.prompt.md")
+                assert prompt_path.exists()
+
+                content = prompt_path.read_text(encoding="utf-8")
+                assert "---" in content
+                assert "name: start" in content
+                assert "You are a helpful assistant" in content
+            finally:
+                os.chdir(self.original_dir)
+
+    def test_init_does_not_overwrite_existing_start_prompt(self):
+        """Test that init preserves existing start.prompt.md (brownfield)."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.chdir(tmp_dir)
+            try:
+                # Create existing start.prompt.md with custom content
+                Path("start.prompt.md").write_text(
+                    "---\nname: start\n---\nMy custom prompt\n", encoding="utf-8"
+                )
+
+                result = self.runner.invoke(cli, ["init", "--yes"])
+
+                assert result.exit_code == 0
+                content = Path("start.prompt.md").read_text(encoding="utf-8")
+                assert "My custom prompt" in content
+                assert "start.prompt.md already exists" in result.output
+            finally:
+                os.chdir(self.original_dir)
+
+    def test_init_next_steps_no_compile(self):
+        """Test that next steps do not reference apm compile."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.chdir(tmp_dir)
+            try:
+                result = self.runner.invoke(cli, ["init", "--yes"])
+
+                assert result.exit_code == 0
+                assert "apm compile" not in result.output
+                assert "Edit your prompt" in result.output
+                assert "start.prompt.md" in result.output
+                assert "apm run start" in result.output
+            finally:
+                os.chdir(self.original_dir)
+
+    def test_init_created_files_table_includes_start_prompt(self):
+        """Test that Created Files table lists start.prompt.md."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.chdir(tmp_dir)
+            try:
+                result = self.runner.invoke(cli, ["init", "--yes"])
+
+                assert result.exit_code == 0
+                # start.prompt.md appears in the Created Files table
+                assert "start.prompt.md" in result.output
+            finally:
+                os.chdir(self.original_dir)
 
 
 

--- a/tests/unit/test_init_plugin.py
+++ b/tests/unit/test_init_plugin.py
@@ -284,6 +284,19 @@ class TestInitPlugin:
             finally:
                 os.chdir(self.original_dir)
 
+    def test_plugin_does_not_create_start_prompt(self):
+        """start.prompt.md is NOT created in plugin mode."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            project_dir = Path(tmp_dir) / "my-plugin"
+            project_dir.mkdir()
+            os.chdir(project_dir)
+            try:
+                result = self.runner.invoke(cli, ["init", "--plugin", "--yes"])
+                assert result.exit_code == 0, result.output
+                assert not Path("start.prompt.md").exists()
+            finally:
+                os.chdir(self.original_dir)
+
     def test_plugin_apm_yml_has_dependencies(self):
         """apm.yml created with --plugin still has regular dependencies section."""
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary

Fixes the broken `apm init` Next Steps panel that referenced `apm compile` and `apm run start` — workflows that don't match where APM's value lands today.

### Changes

- **Removed `start.prompt.md` creation** — honours the PR #18 contract that `apm init` is brownfield-clean and creates only `apm.yml`
- **Replaced Next Steps panel** with the v5 install-focused shape (skill install, marketplace plugin, versioned package, plugin authoring)
- **Dropped `apm run start`** from the panel entirely — that was the source of the dead-end
- **Fixed doc drift** in `key-concepts.md` and `first-package.md` — removed stale `.apm/` scaffold trees that haven't existed since PR #18
- **Updated tests** — assertions match new panel content, stale tests deleted
- **Updated CHANGELOG** entry

Closes #603