### PR TITLE
[docs] Update documentation for OpenCode remote MCP server headers (2026-04-10)

### DIFF
--- a/docs/src/content/docs/integrations/ide-tool-integration.md
+++ b/docs/src/content/docs/integrations/ide-tool-integration.md
@@ -196,7 +196,8 @@ APM natively integrates with OpenCode when a `.opencode/` directory exists in yo
 | Agents (`.agent.md`) | `.opencode/agents/*.md` | Markdown with YAML frontmatter |
 | Prompts (`.prompt.md`) | `.opencode/commands/*.md` | Converted to command format |
 | Skills (`SKILL.md`) | `.opencode/skills/{name}/SKILL.md` | Identical (agentskills.io standard) |
-| MCP servers | `opencode.json` | `mcp` key with `command` array, `environment` |
+| MCP servers (local) | `opencode.json` | `mcp` key with `command` array, `environment` |
+| MCP servers (remote) | `opencode.json` | `mcp` key with `url`, `headers`, `environment` |
 | Instructions | Via `AGENTS.md` | Read natively by OpenCode |
 
 **Setup**: Create a `.opencode/` directory in your project root, then run `apm install`. APM detects the directory and deploys automatically. OpenCode reads `AGENTS.md` natively for instructions.
@@ -579,6 +580,7 @@ dependencies:
 | VS Code | ✅ Prompts user at runtime |
 | Copilot CLI | ❌ Use environment variables instead |
 | Codex | ❌ Use environment variables instead |
+| OpenCode | ❌ Use environment variables instead |
 
 ## Roadmap
 


### PR DESCRIPTION
## Documentation Updates - 2026-04-10

This PR updates the documentation based on features merged in the last 24 hours.

### Features Documented

- OpenCode remote MCP server support with `headers` field propagation (from #622)

### Changes Made

- Updated `docs/src/content/docs/integrations/ide-tool-integration.md`:
  - Split the single "MCP servers" row in the OpenCode primitives table into two rows: **local** (stdio, `command` array + `environment`) and **remote** (HTTP/SSE, `url` + `headers` + `environment`) to reflect that both server types are fully supported and that `headers` are correctly propagated
  - Added **OpenCode** row to the `\$\{input:...}` variable support table, clarifying that OpenCode does not support VS Code-style runtime prompts (use environment variables instead)

### Merged PRs Referenced

- #622 - fix: propagate headers through OpenCode MCP adapter (defensive copies prevent mutation of the source config)

### Notes

The fix in #622 was a bug correction: remote MCP servers defined with `url` + `headers` in `apm.yml` were silently dropping the `headers` field when writing to `opencode.json`. The fix ensures `headers` are now included in the output. The docs previously did not document remote server support for OpenCode at all, so this update fills that gap.




> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/24225247143) · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+is%3Apr+%22gh-aw-workflow-id%3A+daily-doc-updater%22+in%3Abody)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-04-12T03:50:06.548Z --> on Apr 12, 2026, 3:50 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, id: 24225247143, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/24225247143 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->