### PR TITLE
fix(runtime): pin codex setup to rust-v0.118.0 for security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Pin codex setup to `rust-v0.118.0` for security and reproducibility; update config to `wire_api = "responses"` (#662)
 - Propagate headers and environment variables through OpenCode MCP adapter with defensive copies to prevent mutation (#622)
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Pin codex setup to `rust-v0.118.0` for security and reproducibility; update config to `wire_api = "responses"` (#662)
+- Pin codex setup to `rust-v0.118.0` for security and reproducibility; update config to `wire_api = "responses"` (#663)
 - Propagate headers and environment variables through OpenCode MCP adapter with defensive copies to prevent mutation (#622)
 ### Changed
 

--- a/docs/src/content/docs/integrations/runtime-compatibility.md
+++ b/docs/src/content/docs/integrations/runtime-compatibility.md
@@ -83,7 +83,7 @@ apm runtime setup codex
 ```
 
 This automatically:
-- Downloads the latest Codex binary for your platform
+- Downloads Codex binary `rust-v0.118.0` for your platform (override with `--version`)
 - Installs to `~/.apm/runtimes/codex`
 - Creates configuration for GitHub Models (`github/gpt-4o`)
 - Updates your PATH

--- a/scripts/runtime/setup-codex.ps1
+++ b/scripts/runtime/setup-codex.ps1
@@ -2,7 +2,7 @@
 # Downloads Codex binary from GitHub releases and configures with GitHub Models
 
 # Pin to a known stable release for security and reproducibility (#662).
-# Users can override with: apm runtime setup codex -Version <version> (e.g. 'latest')
+# Users can override with: apm runtime setup codex --version <version> (e.g. 'latest')
 param(
     [switch]$Vanilla,
     [string]$Version = "rust-v0.118.0"
@@ -167,8 +167,8 @@ wire_api = "responses"
 "@ | Set-Content -Path $codexConfig -Encoding UTF8
 
         Write-Success "Codex configuration created at $codexConfig"
-        Write-Info "Codex is pinned to $Version for reproducibility."
-        Write-Info "To use a different version, run: apm runtime setup codex -Version <version> (e.g. 'latest')"
+        Write-Info "Using Codex $Version."
+        Write-Info "Override with: apm runtime setup codex --version <version> (e.g. 'latest')"
     } else {
         Write-Info "Vanilla mode: Skipping APM configuration"
     }

--- a/scripts/runtime/setup-codex.ps1
+++ b/scripts/runtime/setup-codex.ps1
@@ -1,9 +1,11 @@
 # Setup script for Codex runtime (Windows)
 # Downloads Codex binary from GitHub releases and configures with GitHub Models
 
+# Pin to a known stable release for security and reproducibility (#662).
+# Users can override with: apm runtime setup codex -Version <version> (e.g. 'latest')
 param(
     [switch]$Vanilla,
-    [string]$Version = "latest"
+    [string]$Version = "rust-v0.118.0"
 )
 
 $ErrorActionPreference = "Stop"
@@ -161,10 +163,12 @@ model = "openai/gpt-4o"
 name = "GitHub Models"
 base_url = "https://models.github.ai/inference/"
 env_key = "$githubTokenVar"
-wire_api = "chat"
+wire_api = "responses"
 "@ | Set-Content -Path $codexConfig -Encoding UTF8
 
         Write-Success "Codex configuration created at $codexConfig"
+        Write-Info "Codex is pinned to $Version for reproducibility."
+        Write-Info "To use a different version, run: apm runtime setup codex -Version <version> (e.g. 'latest')"
     } else {
         Write-Info "Vanilla mode: Skipping APM configuration"
     }

--- a/scripts/runtime/setup-codex.sh
+++ b/scripts/runtime/setup-codex.sh
@@ -24,7 +24,7 @@ source "$SCRIPT_DIR/setup-common.sh"
 # Configuration
 CODEX_REPO="openai/codex"
 # Pin to a known stable release for security and reproducibility (#662).
-# Users can override with: apm runtime setup codex <version> (e.g. 'latest')
+# Users can override with: apm runtime setup codex --version <version> (e.g. 'latest')
 CODEX_VERSION="rust-v0.118.0"
 VANILLA_MODE=false
 
@@ -210,8 +210,8 @@ wire_api = "responses"
 EOF
         
         log_success "Codex configuration created at $codex_config"
-        log_info "Codex is pinned to $CODEX_VERSION for reproducibility."
-        log_info "To use a different version, run: apm runtime setup codex <version> (e.g. 'latest')"
+        log_info "Using Codex $CODEX_VERSION."
+        log_info "Override with: apm runtime setup codex --version <version> (e.g. 'latest')"
         log_info "APM configured Codex with GitHub Models as default provider"
         log_info "Use 'apm install' to configure MCP servers for your projects"
     else

--- a/scripts/runtime/setup-codex.sh
+++ b/scripts/runtime/setup-codex.sh
@@ -23,7 +23,9 @@ source "$SCRIPT_DIR/setup-common.sh"
 
 # Configuration
 CODEX_REPO="openai/codex"
-CODEX_VERSION="latest"  # Default version
+# Pin to a known stable release for security and reproducibility (#662).
+# Users can override with: apm runtime setup codex <version> (e.g. 'latest')
+CODEX_VERSION="rust-v0.118.0"
 VANILLA_MODE=false
 
 # Parse command line arguments
@@ -204,10 +206,12 @@ model = "openai/gpt-4o"
 name = "GitHub Models"
 base_url = "https://models.github.ai/inference/"
 env_key = "$github_token_var"
-wire_api = "chat"
+wire_api = "responses"
 EOF
         
         log_success "Codex configuration created at $codex_config"
+        log_info "Codex is pinned to $CODEX_VERSION for reproducibility."
+        log_info "To use a different version, run: apm runtime setup codex <version> (e.g. 'latest')"
         log_info "APM configured Codex with GitHub Models as default provider"
         log_info "Use 'apm install' to configure MCP servers for your projects"
     else


### PR DESCRIPTION
## Summary

Pin codex runtime setup scripts to `rust-v0.118.0` instead of `"latest"` to prevent supply-chain attacks and ensure reproducible installs. Also updates the generated config from `wire_api = "chat"` to `wire_api = "responses"` — the only protocol supported by current Codex releases.

Closes #662

## Problem

Using `CODEX_VERSION="latest"` means APM downloads whichever codex binary happens to be the newest release. This is a supply-chain risk — a compromised upstream release would be automatically pulled by every `apm runtime setup codex` invocation.

Additionally, the generated Codex config used `wire_api = "chat"`, which has been removed from the Codex config schema entirely. All current releases only support `wire_api = "responses"`.

## Changes

- **`scripts/runtime/setup-codex.sh`**: Pin `CODEX_VERSION="rust-v0.118.0"`, update `wire_api` to `"responses"`, add pin rationale messaging
- **`scripts/runtime/setup-codex.ps1`**: Same changes for Windows
- **`CHANGELOG.md`**: Add entry under Fixed

## Context

Discovered during CI investigation of PR #651 — an earlier attempt to pin to `0.1.2025051600` (a deleted tag) caused integration test failures. See [root cause analysis](https://github.com/microsoft/apm/pull/651#issuecomment-4222882048).

## Testing

- Verified `rust-v0.118.0` assets exist and are downloadable (HTTP 302) for all platforms
- Archive structure (`codex-{platform}` binary inside tar.gz) is compatible with existing extraction logic
- Users can still override with `apm runtime setup codex latest` or any specific version