### PR TITLE
fix: marketplace add fails to authenticate for private repos

### DIFF
--- a/src/apm_cli/marketplace/client.py
+++ b/src/apm_cli/marketplace/client.py
@@ -229,6 +229,11 @@ def _fetch_file(
             headers["Authorization"] = f"token {token}"
         resp = requests.get(url, headers=headers, timeout=30)
         if resp.status_code == 404:
+            if not token:
+                # Unauthenticated 404 may mean "private repo" (GitHub
+                # returns 404 instead of 403 to avoid leaking existence).
+                # Raise so try_with_fallback retries with credentials.
+                resp.raise_for_status()
             return None
         resp.raise_for_status()
         return resp.json()

--- a/tests/unit/marketplace/test_marketplace_client.py
+++ b/tests/unit/marketplace/test_marketplace_client.py
@@ -5,6 +5,7 @@ import time
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 
 from apm_cli.marketplace.errors import MarketplaceFetchError
 from apm_cli.marketplace.models import MarketplaceSource
@@ -313,6 +314,81 @@ class TestProxyAwareFetch:
         assert manifest.name == "Test"
         assert len(manifest.plugins) == 1
         assert manifest.plugins[0].name == "p1"
+
+
+class TestPrivateRepoAuthFallback:
+    """Regression test for #669: private repos return 404 without auth."""
+
+    def test_unauthenticated_404_triggers_auth_retry(self, tmp_path):
+        """An unauthenticated 404 should raise so try_with_fallback retries with a token."""
+        source = _make_source()
+        raw_data = {"name": "Private", "plugins": []}
+
+        mock_resolver = MagicMock()
+        mock_resolver.classify_host.return_value = MagicMock(api_base="https://api.github.com")
+
+        call_tokens = []
+
+        def mock_fallback(host, op, org=None, unauth_first=False):
+            # Simulate try_with_fallback: try unauth first, then auth on exception
+            assert unauth_first is True
+            try:
+                result = op(None, {})
+                call_tokens.append(None)
+                return result
+            except Exception:
+                call_tokens.append("real-token")
+                return op("real-token", {})
+
+        mock_resp_404 = MagicMock()
+        mock_resp_404.status_code = 404
+        mock_resp_404.raise_for_status.side_effect = requests.exceptions.HTTPError(response=mock_resp_404)
+
+        mock_resp_ok = MagicMock()
+        mock_resp_ok.status_code = 200
+        mock_resp_ok.json.return_value = raw_data
+
+        call_count = [0]
+
+        def mock_get(url, headers=None, timeout=None):
+            call_count[0] += 1
+            if headers and headers.get("Authorization"):
+                return mock_resp_ok
+            return mock_resp_404
+
+        mock_resolver.try_with_fallback.side_effect = mock_fallback
+
+        with patch("apm_cli.deps.registry_proxy.RegistryConfig.from_env", return_value=None), \
+             patch("requests.get", side_effect=mock_get):
+            result = client_mod._fetch_file(source, "marketplace.json", auth_resolver=mock_resolver)
+
+        assert result == raw_data
+        assert "real-token" in call_tokens  # auth fallback was triggered
+
+    def test_authenticated_404_returns_none(self, tmp_path):
+        """A 404 with a valid token means the file genuinely doesn't exist."""
+        source = _make_source()
+
+        mock_resolver = MagicMock()
+        mock_resolver.classify_host.return_value = MagicMock(api_base="https://api.github.com")
+
+        def mock_fallback(host, op, org=None, unauth_first=False):
+            # Simulate auth-first (skipping unauth)
+            return op("real-token", {})
+
+        mock_resp_404 = MagicMock()
+        mock_resp_404.status_code = 404
+
+        def mock_get(url, headers=None, timeout=None):
+            return mock_resp_404
+
+        mock_resolver.try_with_fallback.side_effect = mock_fallback
+
+        with patch("apm_cli.deps.registry_proxy.RegistryConfig.from_env", return_value=None), \
+             patch("requests.get", side_effect=mock_get):
+            result = client_mod._fetch_file(source, "marketplace.json", auth_resolver=mock_resolver)
+
+        assert result is None  # file genuinely not found
 
 
 class TestCacheKey:


### PR DESCRIPTION
## Summary

Fixes #669

- `apm marketplace add` fails with "No marketplace.json found" for private GitHub repos because `_do_fetch()` returns `None` on HTTP 404, preventing `try_with_fallback()` from retrying with credentials
- GitHub returns 404 (not 403) for private repos on unauthenticated requests to avoid leaking repo existence
- Fix: when `_do_fetch` receives a 404 **without a token**, raise via `raise_for_status()` so the auth fallback triggers. Authenticated 404s still return `None` (file genuinely not found)

## Changes

**`src/apm_cli/marketplace/client.py`** (5 lines added):
- In `_do_fetch`, distinguish unauthenticated 404 (raise to trigger fallback) from authenticated 404 (return None)

**`tests/unit/marketplace/test_marketplace_client.py`** (76 lines added):
- `test_unauthenticated_404_triggers_auth_retry`: verifies the auth fallback fires on unauth 404
- `test_authenticated_404_returns_none`: verifies genuine 404 with token returns None

## Test plan

- [x] All 3824 existing unit tests pass
- [x] New regression tests cover both code paths (unauth 404 → retry, auth 404 → None)
- [ ] Manual test with a private repo: `GITHUB_TOKEN=... apm marketplace add OWNER/PRIVATE_REPO`