### PR TITLE
[docs] Update documentation for features from 2026-04-14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pin codex setup to `rust-v0.118.0` for security and reproducibility; update config to `wire_api = "responses"` (#663)
 - Propagate headers and environment variables through OpenCode MCP adapter with defensive copies to prevent mutation (#622)
 - Fix `apm install` hanging indefinitely when corporate firewalls silently drop SSH packets by setting `GIT_SSH_COMMAND` with `ConnectTimeout=30` (#652)
+- Fix `apm install` falling back to HTTPS after SSH times out so installs complete on networks that block port 22 (#653)
 - Fix `apm compile --target claude` silently skipping dependency instructions stored in `.github/instructions/` (#631)
 
 ### Changed

--- a/docs/src/content/docs/getting-started/installation.md
+++ b/docs/src/content/docs/getting-started/installation.md
@@ -149,6 +149,24 @@ mkdir -p ~/bin
 
 See [Authentication -- Troubleshooting](../authentication/#troubleshooting) for token setup, SSO authorization, and diagnosing auth failures.
 
+### `apm install` hangs or times out on corporate networks (SSH blocked)
+
+Some corporate firewalls silently drop SSH packets, causing `apm install` to stall indefinitely when APM tries to clone a dependency over SSH.
+
+APM automatically sets a 30-second SSH connection timeout (`GIT_SSH_COMMAND` with `-o ConnectTimeout=30`) and falls back to HTTPS when the SSH attempt fails. If installs are still slow, you can force HTTPS clones by prepending the dependency URL with `https://`:
+
+```yaml
+# apm.yml
+dependencies:
+  - https://github.com/org/repo
+```
+
+If the problem persists, set `APM_DEBUG=1` for detailed clone diagnostics:
+
+```bash
+APM_DEBUG=1 apm install
+```
+
 ### File access errors on Windows (antivirus / endpoint protection)
 
 If `apm install` fails with `The process cannot access the file because it is being used by another process`, your antivirus or endpoint protection software is likely scanning temp files during installation.

--- a/packages/apm-guide/.apm/skills/apm-usage/troubleshooting.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/troubleshooting.md
@@ -2,6 +2,7 @@
 
 | Problem | Fix |
 |---------|-----|
+| `apm install` hangs or stalls (SSH blocked by firewall) | APM now times out SSH after 30 seconds and retries over HTTPS automatically. To force HTTPS always, prefix the dependency URL with `https://` in `apm.yml`. Use `APM_DEBUG=1` for clone diagnostics. |
 | `apm: command not found` | Install APM: `curl -sSL https://aka.ms/apm-unix \| sh` (macOS/Linux) or `irm https://aka.ms/apm-windows \| iex` (Windows). Ensure `/usr/local/bin` is in `$PATH`. |
 | Authentication errors (401/403) | Set the correct token. Run `apm install --verbose` to see which token source is used. See [Authentication](./authentication.md). |
 | File collision on install | A local file conflicts with a dependency file. Use `--force` to overwrite, or rename the local file. |


### PR DESCRIPTION
## Documentation Updates - 2026-04-14

This PR updates the documentation based on features merged in the last 24 hours.

### Features Documented

- SSH timeout + automatic HTTPS fallback for `apm install` on networks that block port 22 (from #653)

### Changes Made

- Updated `CHANGELOG.md` to add an entry for PR #653 (HTTPS fallback after SSH connection timeout)
- Added troubleshooting section `apm install hangs or times out on corporate networks (SSH blocked)` in `docs/src/content/docs/getting-started/installation.md` explaining the automatic SSH-to-HTTPS fallback and how to force HTTPS via the dependency URL prefix
- Added a new row to `packages/apm-guide/.apm/skills/apm-usage/troubleshooting.md` covering the SSH firewall scenario

### Merged PRs Referenced

- #653 - Enable SSH timeout to fallback to HTTP (`fix-apm-install`)
- #652 - Fix `apm install` hanging indefinitely when corporate firewalls silently drop SSH packets (set `GIT_SSH_COMMAND` `ConnectTimeout=30`; already documented, referenced for context)

### Notes

The CHANGELOG already contained the PR #652 entry. PR #653 builds directly on top of it by ensuring that after the SSH connection times out (in 30 s), `_clone_with_fallback` continues to Method 3 (standard HTTPS) rather than surfacing the SSH error immediately. The new documentation covers both behaviors together from a user perspective.




> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/24379856166) · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+is%3Apr+%22gh-aw-workflow-id%3A+daily-doc-updater%22+in%3Abody)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-04-16T03:57:30.592Z --> on Apr 16, 2026, 3:57 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, id: 24379856166, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/24379856166 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->