### PR TITLE
Fix Scoop bucket URL for apm installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pip install apm-cli
 
 ```powershell
 # Scoop
-scoop bucket add apm https://github.com/microsoft/scoop-apm
+scoop bucket add apm https://github.com/microsoft/apm
 scoop install apm
 # pip
 pip install apm-cli


### PR DESCRIPTION
## Description

The current scoop url points to `https://github.com/microsoft/scoop-apm` and gives a 404.
Fixed the url.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Maintenance / refactor