### PR TITLE
fix: use yaml.safe_dump for virtual package apm.yml generation

### DIFF
--- a/src/apm_cli/deps/github_downloader.py
+++ b/src/apm_cli/deps/github_downloader.py
@@ -1515,11 +1515,14 @@ class GitHubPackageDownloader:
             # If frontmatter parsing fails, use default description
             pass
 
-        apm_yml_content = f"""name: {package_name}
-version: 1.0.0
-description: {description}
-author: {dep_ref.repo_url.split('/')[0]}
-"""
+        from ..utils.yaml_io import yaml_to_str
+        apm_yml_data = {
+            "name": package_name,
+            "version": "1.0.0",
+            "description": description,
+            "author": dep_ref.repo_url.split('/')[0],
+        }
+        apm_yml_content = yaml_to_str(apm_yml_data)
 
         apm_yml_path = target_path / "apm.yml"
         apm_yml_path.write_text(apm_yml_content, encoding='utf-8')
@@ -1655,17 +1658,16 @@ author: {dep_ref.repo_url.split('/')[0]}
         # Generate apm.yml with collection metadata
         package_name = dep_ref.get_virtual_package_name()
 
-        apm_yml_content = f"""name: {package_name}
-version: 1.0.0
-description: {manifest.description}
-author: {dep_ref.repo_url.split('/')[0]}
-"""
-
-        # Add tags if present
+        from ..utils.yaml_io import yaml_to_str
+        apm_yml_data = {
+            "name": package_name,
+            "version": "1.0.0",
+            "description": manifest.description,
+            "author": dep_ref.repo_url.split('/')[0],
+        }
         if manifest.tags:
-            apm_yml_content += f"\ntags:\n"
-            for tag in manifest.tags:
-                apm_yml_content += f"  - {tag}\n"
+            apm_yml_data["tags"] = list(manifest.tags)
+        apm_yml_content = yaml_to_str(apm_yml_data)
 
         apm_yml_path = target_path / "apm.yml"
         apm_yml_path.write_text(apm_yml_content, encoding='utf-8')

--- a/src/apm_cli/deps/github_downloader.py
+++ b/src/apm_cli/deps/github_downloader.py
@@ -42,6 +42,7 @@ from ..utils.github_host import (
     is_azure_devops_hostname,
     is_github_hostname
 )
+from ..utils.yaml_io import yaml_to_str
 
 
 def normalize_collection_path(virtual_path: str) -> str:
@@ -1515,7 +1516,6 @@ class GitHubPackageDownloader:
             # If frontmatter parsing fails, use default description
             pass
 
-        from ..utils.yaml_io import yaml_to_str
         apm_yml_data = {
             "name": package_name,
             "version": "1.0.0",
@@ -1658,7 +1658,6 @@ class GitHubPackageDownloader:
         # Generate apm.yml with collection metadata
         package_name = dep_ref.get_virtual_package_name()
 
-        from ..utils.yaml_io import yaml_to_str
         apm_yml_data = {
             "name": package_name,
             "version": "1.0.0",

--- a/tests/test_github_downloader.py
+++ b/tests/test_github_downloader.py
@@ -1656,5 +1656,103 @@ class TestRawContentCDNDownload:
             assert result == b'hello world'
 
 
+class TestVirtualFilePackageYamlGeneration:
+    """Tests that apm.yml for virtual packages is always valid YAML."""
+
+    def setup_method(self):
+        self.downloader = GitHubPackageDownloader()
+        self.temp_dir = Path(tempfile.mkdtemp())
+
+    def teardown_method(self):
+        if self.temp_dir.exists():
+            shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _make_dep_ref(self, virtual_path):
+        """Helper: build a minimal DependencyReference for a virtual file."""
+        from apm_cli.models.apm_package import DependencyReference
+        dep_ref = Mock(spec=DependencyReference)
+        dep_ref.is_virtual = True
+        dep_ref.virtual_path = virtual_path
+        dep_ref.reference = "main"
+        dep_ref.repo_url = "github/awesome-copilot"
+        dep_ref.get_virtual_package_name.return_value = "awesome-copilot-swe-subagent"
+        dep_ref.to_github_url.return_value = f"https://github.com/github/awesome-copilot/blob/main/{virtual_path}"
+        dep_ref.is_virtual_file.return_value = True
+        dep_ref.VIRTUAL_FILE_EXTENSIONS = [".prompt.md", ".instructions.md", ".chatmode.md", ".agent.md"]
+        return dep_ref
+
+    def test_yaml_with_colon_in_description(self):
+        """apm.yml must be valid when the agent description contains a colon."""
+        import yaml
+
+        agent_content = (
+            b"---\n"
+            b"name: 'SWE'\n"
+            b"description: 'Senior software engineer subagent for implementation tasks:"
+            b" feature development, debugging, refactoring, and testing.'\n"
+            b"tools: ['vscode']\n"
+            b"---\n\n## Body\n"
+        )
+
+        dep_ref = self._make_dep_ref("agents/swe-subagent.agent.md")
+        target_path = self.temp_dir / "pkg"
+
+        with patch.dict(os.environ, {}, clear=True), _CRED_FILL_PATCH:
+            with patch.object(self.downloader, "download_raw_file", return_value=agent_content):
+                pkg_info = self.downloader.download_virtual_file_package(dep_ref, target_path)
+
+        apm_yml_path = target_path / "apm.yml"
+        assert apm_yml_path.exists(), "apm.yml was not created"
+
+        content = apm_yml_path.read_text(encoding="utf-8")
+        parsed = yaml.safe_load(content)   # must not raise
+
+        expected = (
+            "Senior software engineer subagent for implementation tasks:"
+            " feature development, debugging, refactoring, and testing."
+        )
+        assert parsed["description"] == expected
+
+    def test_yaml_with_colon_in_name(self):
+        """apm.yml must be valid even when the package name contains a colon."""
+        import yaml
+
+        dep_ref = self._make_dep_ref("agents/my-agent.agent.md")
+        dep_ref.get_virtual_package_name.return_value = "org-name: special"
+
+        agent_content = b"---\nname: 'plain'\ndescription: 'plain'\n---\n"
+        target_path = self.temp_dir / "pkg2"
+
+        with patch.dict(os.environ, {}, clear=True), _CRED_FILL_PATCH:
+            with patch.object(self.downloader, "download_raw_file", return_value=agent_content):
+                self.downloader.download_virtual_file_package(dep_ref, target_path)
+
+        content = (target_path / "apm.yml").read_text(encoding="utf-8")
+        parsed = yaml.safe_load(content)
+        assert parsed["name"] == "org-name: special"
+
+    def test_yaml_without_special_characters_still_valid(self):
+        """apm.yml generation must still work for ordinary descriptions."""
+        import yaml
+
+        agent_content = (
+            b"---\n"
+            b"name: 'Simple Agent'\n"
+            b"description: 'A simple agent without special chars'\n"
+            b"---\n"
+        )
+
+        dep_ref = self._make_dep_ref("agents/simple.agent.md")
+        target_path = self.temp_dir / "pkg3"
+
+        with patch.dict(os.environ, {}, clear=True), _CRED_FILL_PATCH:
+            with patch.object(self.downloader, "download_raw_file", return_value=agent_content):
+                self.downloader.download_virtual_file_package(dep_ref, target_path)
+
+        content = (target_path / "apm.yml").read_text(encoding="utf-8")
+        parsed = yaml.safe_load(content)
+        assert parsed["description"] == "A simple agent without special chars"
+
+
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/tests/test_github_downloader.py
+++ b/tests/test_github_downloader.py
@@ -1659,14 +1659,6 @@ class TestRawContentCDNDownload:
 class TestVirtualFilePackageYamlGeneration:
     """Tests that apm.yml for virtual packages is always valid YAML."""
 
-    def setup_method(self):
-        self.downloader = GitHubPackageDownloader()
-        self.temp_dir = Path(tempfile.mkdtemp())
-
-    def teardown_method(self):
-        if self.temp_dir.exists():
-            shutil.rmtree(self.temp_dir, ignore_errors=True)
-
     def _make_dep_ref(self, virtual_path):
         """Helper: build a minimal DependencyReference for a virtual file."""
         from apm_cli.models.apm_package import DependencyReference
@@ -1681,7 +1673,20 @@ class TestVirtualFilePackageYamlGeneration:
         dep_ref.VIRTUAL_FILE_EXTENSIONS = [".prompt.md", ".instructions.md", ".chatmode.md", ".agent.md"]
         return dep_ref
 
-    def test_yaml_with_colon_in_description(self):
+    def _make_collection_dep_ref(self, virtual_path):
+        """Helper: build a minimal DependencyReference for a virtual collection."""
+        from apm_cli.models.apm_package import DependencyReference
+        dep_ref = Mock(spec=DependencyReference)
+        dep_ref.is_virtual = True
+        dep_ref.virtual_path = virtual_path
+        dep_ref.reference = "main"
+        dep_ref.repo_url = "github/my-org"
+        dep_ref.get_virtual_package_name.return_value = "my-org-my-collection"
+        dep_ref.to_github_url.return_value = f"https://github.com/github/my-org/blob/main/{virtual_path}"
+        dep_ref.is_virtual_collection.return_value = True
+        return dep_ref
+
+    def test_yaml_with_colon_in_description(self, tmp_path):
         """apm.yml must be valid when the agent description contains a colon."""
         import yaml
 
@@ -1695,11 +1700,12 @@ class TestVirtualFilePackageYamlGeneration:
         )
 
         dep_ref = self._make_dep_ref("agents/swe-subagent.agent.md")
-        target_path = self.temp_dir / "pkg"
+        target_path = tmp_path / "pkg"
 
+        downloader = GitHubPackageDownloader()
         with patch.dict(os.environ, {}, clear=True), _CRED_FILL_PATCH:
-            with patch.object(self.downloader, "download_raw_file", return_value=agent_content):
-                pkg_info = self.downloader.download_virtual_file_package(dep_ref, target_path)
+            with patch.object(downloader, "download_raw_file", return_value=agent_content):
+                downloader.download_virtual_file_package(dep_ref, target_path)
 
         apm_yml_path = target_path / "apm.yml"
         assert apm_yml_path.exists(), "apm.yml was not created"
@@ -1713,7 +1719,7 @@ class TestVirtualFilePackageYamlGeneration:
         )
         assert parsed["description"] == expected
 
-    def test_yaml_with_colon_in_name(self):
+    def test_yaml_with_colon_in_name(self, tmp_path):
         """apm.yml must be valid even when the package name contains a colon."""
         import yaml
 
@@ -1721,17 +1727,18 @@ class TestVirtualFilePackageYamlGeneration:
         dep_ref.get_virtual_package_name.return_value = "org-name: special"
 
         agent_content = b"---\nname: 'plain'\ndescription: 'plain'\n---\n"
-        target_path = self.temp_dir / "pkg2"
+        target_path = tmp_path / "pkg"
 
+        downloader = GitHubPackageDownloader()
         with patch.dict(os.environ, {}, clear=True), _CRED_FILL_PATCH:
-            with patch.object(self.downloader, "download_raw_file", return_value=agent_content):
-                self.downloader.download_virtual_file_package(dep_ref, target_path)
+            with patch.object(downloader, "download_raw_file", return_value=agent_content):
+                downloader.download_virtual_file_package(dep_ref, target_path)
 
         content = (target_path / "apm.yml").read_text(encoding="utf-8")
         parsed = yaml.safe_load(content)
         assert parsed["name"] == "org-name: special"
 
-    def test_yaml_without_special_characters_still_valid(self):
+    def test_yaml_without_special_characters_still_valid(self, tmp_path):
         """apm.yml generation must still work for ordinary descriptions."""
         import yaml
 
@@ -1743,15 +1750,86 @@ class TestVirtualFilePackageYamlGeneration:
         )
 
         dep_ref = self._make_dep_ref("agents/simple.agent.md")
-        target_path = self.temp_dir / "pkg3"
+        target_path = tmp_path / "pkg"
 
+        downloader = GitHubPackageDownloader()
         with patch.dict(os.environ, {}, clear=True), _CRED_FILL_PATCH:
-            with patch.object(self.downloader, "download_raw_file", return_value=agent_content):
-                self.downloader.download_virtual_file_package(dep_ref, target_path)
+            with patch.object(downloader, "download_raw_file", return_value=agent_content):
+                downloader.download_virtual_file_package(dep_ref, target_path)
 
         content = (target_path / "apm.yml").read_text(encoding="utf-8")
         parsed = yaml.safe_load(content)
         assert parsed["description"] == "A simple agent without special chars"
+
+    def test_collection_yaml_with_colon_in_description(self, tmp_path):
+        """apm.yml for collection packages must be valid when description contains a colon."""
+        import yaml
+
+        # A minimal .collection.yml whose description contains ":"
+        collection_manifest = (
+            b"id: my-collection\n"
+            b"name: My Collection\n"
+            b"description: 'A collection for tasks: feature development, debugging.'\n"
+            b"items:\n"
+            b"  - path: agents/my-agent.agent.md\n"
+            b"    kind: agent\n"
+        )
+        agent_file = b"---\nname: My Agent\n---\n## Body\n"
+
+        dep_ref = self._make_collection_dep_ref("collections/my-collection")
+        target_path = tmp_path / "pkg"
+
+        downloader = GitHubPackageDownloader()
+
+        def _fake_download(dep_ref_arg, path, ref):
+            if "collection" in path:
+                return collection_manifest
+            return agent_file
+
+        with patch.dict(os.environ, {}, clear=True), _CRED_FILL_PATCH:
+            with patch.object(downloader, "download_raw_file", side_effect=_fake_download):
+                downloader.download_collection_package(dep_ref, target_path)
+
+        content = (target_path / "apm.yml").read_text(encoding="utf-8")
+        parsed = yaml.safe_load(content)   # must not raise
+
+        assert parsed["description"] == "A collection for tasks: feature development, debugging."
+
+    def test_collection_yaml_with_colon_in_tags(self, tmp_path):
+        """apm.yml for collection packages must be valid when tags contain a colon."""
+        import yaml
+
+        collection_manifest = (
+            b"id: tagged-collection\n"
+            b"name: Tagged\n"
+            b"description: Normal description\n"
+            b"tags:\n"
+            b"  - 'scope: engineering'\n"
+            b"  - plain-tag\n"
+            b"items:\n"
+            b"  - path: agents/my-agent.agent.md\n"
+            b"    kind: agent\n"
+        )
+        agent_file = b"---\nname: My Agent\n---\n## Body\n"
+
+        dep_ref = self._make_collection_dep_ref("collections/tagged-collection")
+        target_path = tmp_path / "pkg"
+
+        downloader = GitHubPackageDownloader()
+
+        def _fake_download(dep_ref_arg, path, ref):
+            if "collection" in path:
+                return collection_manifest
+            return agent_file
+
+        with patch.dict(os.environ, {}, clear=True), _CRED_FILL_PATCH:
+            with patch.object(downloader, "download_raw_file", side_effect=_fake_download):
+                downloader.download_collection_package(dep_ref, target_path)
+
+        content = (target_path / "apm.yml").read_text(encoding="utf-8")
+        parsed = yaml.safe_load(content)
+
+        assert parsed["tags"] == ["scope: engineering", "plain-tag"]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem

When a virtual file or collection dependency (e.g. a single `.agent.md`) has a `:` in its `description` field, `apm install` fails with:

```
Invalid YAML format in .../apm.yml: mapping values are not allowed here
  in "...apm.yml", line 3, column 72
```

Root cause: `download_virtual_file_package` and `download_collection_package` in `github_downloader.py` generated `apm.yml` by **string interpolation** (`f"""name: {name}\ndescription: {description}\n"""`). Any `:` in a value produces syntactically invalid YAML.

Concrete example from the issue — swe-subagent frontmatter:
```
description: 'Senior software engineer subagent for implementation tasks: feature development, debugging, refactoring, and testing.'
```
After stripping the surrounding quotes and dropping into the f-string, the `:` after "tasks" is parsed as a YAML mapping separator, causing the error.

## Fix

Replace both f-string blocks with `yaml_to_str()` (backed by `yaml.safe_dump`), which correctly quotes strings that contain `:`, `#`, `[`, or other YAML special characters.

```python
# Before
apm_yml_content = f"""name: {package_name}
version: 1.0.0
description: {description}
author: {dep_ref.repo_url.split('/')[0]}
"""

# After
apm_yml_data = {
    "name": package_name,
    "version": "1.0.0",
    "description": description,
    "author": dep_ref.repo_url.split('/')[0],
}
apm_yml_content = yaml_to_str(apm_yml_data)
```

`yaml_to_str` already exists in `apm_cli/utils/yaml_io.py` and is the established helper for this purpose throughout the codebase.

## Tests

Three new unit tests in `TestVirtualFilePackageYamlGeneration`:

| Test | What it checks |
|------|---------------|
| `test_yaml_with_colon_in_description` | Reproduces the exact swe-subagent failure from #703 |
| `test_yaml_with_colon_in_name` | Colon in the package name field |
| `test_yaml_without_special_characters_still_valid` | Ordinary descriptions still work (regression guard) |

## Checklist

- [x] Bug reproduced locally before fix
- [x] Fix verified: `yaml.safe_load` on generated `apm.yml` succeeds after change
- [x] Both affected code paths fixed (`download_virtual_file_package` and `download_collection_package`)
- [x] New tests added and passing
- [x] Existing test suite passes (79 pass, 1 pre-existing unrelated failure)

Closes #703