### PR TITLE
[docs] Update documentation for features from 2026-04-15

### DIFF
--- a/docs/src/content/docs/guides/marketplaces.md
+++ b/docs/src/content/docs/guides/marketplaces.md
@@ -161,6 +161,21 @@ apm marketplace update acme-plugins
 apm marketplace update
 ```
 
+## Private marketplace repositories
+
+Private marketplace repositories work without extra configuration. APM uses the same credential resolution as `apm install`: `GITHUB_APM_PAT`, per-org `GITHUB_APM_PAT_{ORG}` env vars, and git credential helpers are all tried automatically before falling back to unauthenticated access.
+
+```bash
+export GITHUB_APM_PAT=github_pat_your_token
+
+# Registers a private marketplace — credentials applied automatically
+apm marketplace add your-org/private-marketplace
+```
+
+Previously, `apm marketplace add` would silently fail for private repos because the credential check happened after the initial probe. The fix ensures credentials are used from the first request, so 404s from auth failures are no longer confused with missing `marketplace.json` files.
+
+See [Authentication](../../getting-started/authentication/) for the full credential priority order.
+
 ## Registry proxy support
 
 When `PROXY_REGISTRY_URL` is set, marketplace commands (`add`, `browse`, `search`, `update`) fetch `marketplace.json` through the registry proxy (Artifactory Archive Entry Download) before falling back to the GitHub Contents API. When `PROXY_REGISTRY_ONLY=1` is also set, the GitHub API fallback is blocked entirely, enabling fully air-gapped marketplace discovery.


### PR DESCRIPTION
## Documentation Updates - 2026-04-15

This PR updates the documentation based on features merged in the last 24 hours.

### Features Documented

- Private marketplace repository support (`apm marketplace add` with private repos) — from #701

### Changes Made

- Updated `docs/src/content/docs/guides/marketplaces.md` to add a "Private marketplace repositories" section explaining:
  - Private repos work without extra configuration
  - The same credential resolution as `apm install` is used (`GITHUB_APM_PAT`, per-org env vars, git credential helpers)
  - Context on why the fix matters (previously silent failures due to auth probe ordering)
  - Link to the Authentication guide

### Merged PRs Referenced

- #701 — Fix: `apm marketplace add` silently fails for private repos (uses `AuthResolver.try_with_fallback(unauth_first=False)` so credentials are applied from the first probe request)

### Notes

The CHANGELOG already contains the entry for #701 under `[Unreleased]`. No other source changes from this commit window required documentation updates — the other unreleased items (SSH timeout fix, compile target fix, OpenCode headers fix, Codex pin) are internal fixes without user-facing documentation gaps.




> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/24435268323) · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+is%3Apr+%22gh-aw-workflow-id%3A+daily-doc-updater%22+in%3Abody)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-04-17T04:52:24.023Z --> on Apr 17, 2026, 4:52 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, id: 24435268323, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/24435268323 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->