### PR TITLE
Fix duplicated skills/ directory nesting in plugin pack

### DIFF
--- a/src/apm_cli/bundle/plugin_exporter.py
+++ b/src/apm_cli/bundle/plugin_exporter.py
@@ -131,6 +131,10 @@ def _collect_bare_skill(
     # Derive a slug: prefer virtual_path (e.g. "frontend-design"), else last
     # segment of repo_url (e.g. "my-skill" from "owner/my-skill")
     slug = (getattr(dep, "virtual_path", "") or "").strip("/")
+    # Strip leading "skills/" to avoid double nesting (skills/skills/…)
+    # when virtual_path already contains the skills/ prefix.
+    if slug.startswith("skills/"):
+        slug = slug[len("skills/"):]
     if not slug:
         slug = dep.repo_url.rsplit("/", 1)[-1] if dep.repo_url else "skill"
     for f in sorted(install_path.iterdir()):

--- a/src/apm_cli/bundle/plugin_exporter.py
+++ b/src/apm_cli/bundle/plugin_exporter.py
@@ -133,8 +133,9 @@ def _collect_bare_skill(
     slug = (getattr(dep, "virtual_path", "") or "").strip("/")
     # Strip leading "skills/" to avoid double nesting (skills/skills/…)
     # when virtual_path already contains the skills/ prefix.
+    # Also strip any extra leading slashes (e.g. "skills//foo" → "foo").
     if slug.startswith("skills/"):
-        slug = slug[len("skills/"):]
+        slug = slug[len("skills/"):].lstrip("/")
     if not slug:
         slug = dep.repo_url.rsplit("/", 1)[-1] if dep.repo_url else "skill"
     for f in sorted(install_path.iterdir()):

--- a/tests/unit/test_plugin_exporter.py
+++ b/tests/unit/test_plugin_exporter.py
@@ -308,7 +308,8 @@ class TestCollectBareSkill:
         )
         out: list = []
         _collect_bare_skill(tmp_path, dep, out)
-        assert any(r.startswith("skills/frontend-design/") for _, r in out)
+        rel_paths = [r for _, r in out]
+        assert rel_paths == ["skills/frontend-design/SKILL.md"]
 
     def test_virtual_path_with_skills_prefix_no_double_nesting(self, tmp_path):
         """virtual_path starting with skills/ should not produce skills/skills/."""
@@ -326,8 +327,25 @@ class TestCollectBareSkill:
         _collect_bare_skill(tmp_path, dep, out)
         rel_paths = [r for _, r in out]
         # Should be skills/javascript-typescript-jest/SKILL.md, NOT skills/skills/...
-        assert any(r.startswith("skills/javascript-typescript-jest/") for r in rel_paths)
-        assert not any("skills/skills/" in r for r in rel_paths)
+        assert rel_paths == ["skills/javascript-typescript-jest/SKILL.md"]
+
+    def test_virtual_path_with_skills_double_slash_no_leading_slash(self, tmp_path):
+        """virtual_path like 'skills//foo' should produce skills/foo/..., not skills//foo/..."""
+        from apm_cli.bundle.plugin_exporter import _collect_bare_skill
+
+        (tmp_path / "SKILL.md").write_text("# Foo")
+        dep = LockedDependency(
+            repo_url="github/awesome-copilot",
+            resolved_commit="abc123",
+            depth=1,
+            virtual_path="skills//foo",
+            is_virtual=True,
+        )
+        out: list = []
+        _collect_bare_skill(tmp_path, dep, out)
+        rel_paths = [r for _, r in out]
+        assert rel_paths == ["skills/foo/SKILL.md"]
+        assert not any("//" in r for r in rel_paths)
 
     def test_skips_when_no_skill_md(self, tmp_path):
         """No SKILL.md at root means nothing collected."""

--- a/tests/unit/test_plugin_exporter.py
+++ b/tests/unit/test_plugin_exporter.py
@@ -310,6 +310,25 @@ class TestCollectBareSkill:
         _collect_bare_skill(tmp_path, dep, out)
         assert any(r.startswith("skills/frontend-design/") for _, r in out)
 
+    def test_virtual_path_with_skills_prefix_no_double_nesting(self, tmp_path):
+        """virtual_path starting with skills/ should not produce skills/skills/."""
+        from apm_cli.bundle.plugin_exporter import _collect_bare_skill
+
+        (tmp_path / "SKILL.md").write_text("# JS/TS Jest")
+        dep = LockedDependency(
+            repo_url="github/awesome-copilot",
+            resolved_commit="abc123",
+            depth=1,
+            virtual_path="skills/javascript-typescript-jest",
+            is_virtual=True,
+        )
+        out: list = []
+        _collect_bare_skill(tmp_path, dep, out)
+        rel_paths = [r for _, r in out]
+        # Should be skills/javascript-typescript-jest/SKILL.md, NOT skills/skills/...
+        assert any(r.startswith("skills/javascript-typescript-jest/") for r in rel_paths)
+        assert not any("skills/skills/" in r for r in rel_paths)
+
     def test_skips_when_no_skill_md(self, tmp_path):
         """No SKILL.md at root means nothing collected."""
         from apm_cli.bundle.plugin_exporter import _collect_bare_skill


### PR DESCRIPTION
## Description

When running `apm pack --format plugin` with a dependency whose `virtual_path` starts with `skills/` (e.g. `github/awesome-copilot/skills/javascript-typescript-jest`), the bare skill collector (`_collect_bare_skill`) used the full `virtual_path` as the slug. Since the function already prepends `skills/` to the output path, this produced `skills/skills/javascript-typescript-jest/SKILL.md` instead of the expected `skills/javascript-typescript-jest/SKILL.md`.

I ran into this while testing a plugin that depends on `github/awesome-copilot/skills/javascript-typescript-jest` — the packed output had the skill files nested one level too deep, which meant the plugin host couldn't discover them.

The fix strips the leading `skills/` prefix from `virtual_path` before using it as the directory slug, preventing the double nesting. Added a regression test that verifies virtual paths with a `skills/` prefix produce the correct flat structure.

Fixes #719

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass (65/65 in test_plugin_exporter.py)
- [x] Added tests for new functionality (if applicable)