### PR TITLE
[docs] Update documentation for features from 2026-04-16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix hook install losing entries from earlier hook files when a package contributes multiple hook files to the same event (#709)
 - Fix `apm marketplace add` silently failing for private repos by using credentials when probing `marketplace.json` (#701)
 - Pin codex setup to `rust-v0.118.0` for security and reproducibility; update config to `wire_api = "responses"` (#663)
 - Propagate headers and environment variables through OpenCode MCP adapter with defensive copies to prevent mutation (#622)


### PR DESCRIPTION
## Documentation Updates - 2026-04-16

This PR updates the documentation based on changes merged in the last 24 hours.

### Features Documented

- Bug fix: hook install losing entries from earlier hook files when a package contributes multiple hook files to the same event (from #709)

### Changes Made

- Updated `CHANGELOG.md` to add the missing `Fixed` entry for the hook integration bug fix merged in commit `40bdf98`.

### Merged PRs Referenced

- #709 - Fix hook install: only strip prior-owned entries once per event per run

### Notes

The fix addresses a regression in hook merging logic: when a package contributed multiple hook files all targeting the same event (e.g., `Stop`), the per-hook-file loop was re-filtering already-appended entries on each iteration, causing earlier files' hook entries to be discarded. The fix tracks which events have already been cleared and skips re-filtering on subsequent iterations.




> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/24490982525) · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+is%3Apr+%22gh-aw-workflow-id%3A+daily-doc-updater%22+in%3Abody)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-04-18T03:52:57.229Z --> on Apr 18, 2026, 3:52 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, id: 24490982525, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/24490982525 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->