### PR TITLE
fix: strip 'skills/' prefix in _collect_bare_skill to prevent double nesting

### DIFF
--- a/src/apm_cli/bundle/plugin_exporter.py
+++ b/src/apm_cli/bundle/plugin_exporter.py
@@ -133,6 +133,9 @@ def _collect_bare_skill(
     slug = (getattr(dep, "virtual_path", "") or "").strip("/")
     if not slug:
         slug = dep.repo_url.rsplit("/", 1)[-1] if dep.repo_url else "skill"
+    # Strip "skills/" prefix to avoid double nesting like "skills/skills/..."
+    if slug.startswith("skills/"):
+        slug = slug[len("skills/"):]
     for f in sorted(install_path.iterdir()):
         if f.is_file() and not f.is_symlink() and f.name not in (
             "apm.yml", "apm.lock.yaml", "plugin.json",

--- a/tests/unit/test_plugin_exporter.py
+++ b/tests/unit/test_plugin_exporter.py
@@ -310,6 +310,25 @@ class TestCollectBareSkill:
         _collect_bare_skill(tmp_path, dep, out)
         assert any(r.startswith("skills/frontend-design/") for _, r in out)
 
+    def test_virtual_path_with_skills_prefix_no_double_nesting(self, tmp_path):
+        """virtual_path prefixed with 'skills/' does not produce 'skills/skills/...'."""
+        from apm_cli.bundle.plugin_exporter import _collect_bare_skill
+
+        (tmp_path / "SKILL.md").write_text("# Jest Typescript")
+        dep = LockedDependency(
+            repo_url="github/awesome-copilot",
+            resolved_commit="abc123",
+            depth=1,
+            virtual_path="skills/javascript-typescript-jest",
+            is_virtual=True,
+        )
+        out: list = []
+        _collect_bare_skill(tmp_path, dep, out)
+        rel_paths = [r for _, r in out]
+        # Must be skills/javascript-typescript-jest/SKILL.md, NOT skills/skills/javascript-typescript-jest/SKILL.md
+        assert "skills/javascript-typescript-jest/SKILL.md" in rel_paths
+        assert not any(r.startswith("skills/skills/") for r in rel_paths)
+
     def test_skips_when_no_skill_md(self, tmp_path):
         """No SKILL.md at root means nothing collected."""
         from apm_cli.bundle.plugin_exporter import _collect_bare_skill


### PR DESCRIPTION
## Summary

When a dependency has `virtual_path='skills/javascript-typescript-jest'`, the bare skill collector in `_collect_bare_skill` was producing output paths like `skills/skills/javascript-typescript-jest/SKILL.md` instead of `skills/javascript-typescript-jest/SKILL.md`.

This happens because the slug (derived from `virtual_path`) already contains the `skills/` prefix, and the code unconditionally prepends another `skills/` to the output path.

## Fix

Strip the `skills/` prefix from the slug before prepending `skills/` in the output path:

```python
# Strip "skills/" prefix to avoid double nesting like "skills/skills/..."
if slug.startswith("skills/"):
    slug = slug[len("skills/"):]
```

## Test added

`test_virtual_path_with_skills_prefix_no_double_nesting` in `tests/unit/test_plugin_exporter.py` covers this exact bug scenario.

Fixes #719.