### PR TITLE
feat: add package variables (${var:...}) for deployed primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [Unreleased]
 
 ### Added
 
+- Package variables (`${var:...}`) for deployed primitives -- package authors declare variables in `apm.yml`, consumers override values, and placeholders are substituted at install time in `.agent.md`, `.instructions.md`, `SKILL.md`, and other text files
 - `apm install` now automatically discovers and deploys local `.apm/` primitives (skills, instructions, agents, prompts, hooks, commands) to target directories, with local content taking priority over dependencies on collision (#626, #644)
 
 ### Fixed
@@ -426,7 +426,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added missing `version` field in the apm.yml README example (#108)
 - Slim PR pipelines to Linux-only, auto-approve integration tests, added agentic workflows for maintenance (#98, #103, #104, #119)
 
-
 ## [0.7.3] - 2025-02-15
 
 ### Added
@@ -520,9 +519,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Neither folder → generates `AGENTS.md` only (universal format)
 
 - **`target` field in apm.yml**: Persistent target configuration
+
   ```yaml
-  target: vscode  # or claude, or all
+  target: vscode # or claude, or all
   ```
+
   Applies to both `apm compile` and `apm install`
 
 - **`--target` flag**: Override auto-detection
@@ -585,6 +586,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.5] - 2025-11-17
 
 ### Added
+
 - **Context Link Resolution**: Automatic markdown link resolution for `.context.md` files across installation and compilation
   - Links in prompts/agents automatically resolve to actual source locations (`apm_modules/` or `.apm/context/`)
   - Works everywhere: IDE, GitHub, all coding agents supporting AGENTS.md
@@ -593,9 +595,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.4] - 2025-11-17
 
 ### Added
+
 - **Agent Integration**: Automatic sync of `.agent.md` files to `.github/agents/` with `-apm` suffix (same pattern as prompt integration)
 
 ### Fixed
+
 - `sync_integration` URL normalization bug that caused ALL integrated files to be removed during uninstall instead of only the uninstalled package's files
   - Root cause: Metadata stored full URLs (`https://github.com/owner/repo`) while dependency list used short form (`owner/repo`)
   - Impact: Uninstalling one package would incorrectly remove prompts/agents from ALL other packages
@@ -606,38 +610,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.3] - 2025-11-16
 
 ### Changed
+
 - **Prompt Naming Pattern**: Migrated from `@` prefix to `-apm` suffix for integrated prompts
 - **GitIgnore Pattern**: Updated from `.github/prompts/@*.prompt.md` to `.github/prompts/*-apm.prompt.md`
 
 ### Migration Notes
+
 - **Existing Users**: Old `@`-prefixed files will not be automatically removed
 - **Action Required**: Manually delete old `@*.prompt.md` files from `.github/prompts/` after upgrading
 
 ## [0.5.2] - 2025-11-14
 
 ### Added
+
 - **Prompt Integration with GitHub** - Automatically sync downloaded prompts to `.github/prompts/` for GitHub Copilot
 
 ### Changed
+
 - Improved installer UX and console output
 
 ## [0.5.1] - 2025-11-09
 
 ### Added
+
 - Package FQDN support - install from any Git host using fully qualified domain names (thanks @richgo for PR #25)
 
 ### Fixed
+
 - **Security**: CWE-20 URL validation vulnerability - proper hostname validation using `urllib.parse` prevents malicious URL bypass attacks
 - Package validation HTTPS URL construction for git ls-remote checks
 - Virtual package orphan detection in `apm deps list` command
 
 ### Changed
+
 - GitHub Enterprise support via `GITHUB_HOST` environment variable (thanks @richgo for PR #25)
 - Build pipeline updates for macOS compatibility
 
 ## [0.5.0] - 2025-10-30
 
 ### Added - Virtual Packages
+
 - **Virtual Package Support**: Install individual files directly from any repository without requiring full APM package structure
   - Individual file packages: `apm install owner/repo/path/to/file.prompt.md`
 - **Collection Support**: Install curated collections of primitives from [Awesome Copilot](https://github.com/github/awesome-copilot): `apm install github/awesome-copilot/collections/collection-name`
@@ -646,6 +658,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Integration with github/awesome-copilot collections
 
 ### Added - Runnable Prompts
+
 - **Auto-Discovery of Prompts**: Run installed prompts without manual script configuration
   - `apm run <prompt-name>` automatically discovers and executes prompts without having to wire a script in `apm.yml`
   - Search priority: local root → .apm/prompts → .github/prompts → dependencies
@@ -656,12 +669,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Zero-Configuration Execution**: Install and run prompts immediately without apm.yml scripts section
 
 ### Changed
+
 - Enhanced dependency resolution to support virtual package unique keys
 - Improved GitHub downloader with virtual file and collection package support
 - Extended `DependencyReference.parse()` to detect and validate virtual packages (3+ path segments)
 - Script runner now falls back to prompt discovery when script not found in apm.yml
 
 ### Developer Experience
+
 - Streamlined workflow: `apm install <file>` → `apm run <name>` works immediately
 - No manual script configuration needed for simple use cases
 - Power users retain full control via explicit scripts in apm.yml
@@ -670,15 +685,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.3] - 2025-10-29
 
 ### Added
+
 - Auto-bootstrap `apm.yml` when running `apm install <package>` without existing config
 - GitHub Enterprise Server and Data Residency Cloud support via `GITHUB_HOST` environment variable
 - ARM64 Linux support
 
 ### Changed
+
 - Refactored `apm init` to initialize projects minimally without templated prompts and instructions
 - Improved next steps formatting in project initialization output
 
 ### Fixed
+
 - GitHub token fallback handling for Codex runtime setup
 - Environment variable passing to subprocess in smoke tests and runtime setup
 
@@ -689,6 +707,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.4.1] - 2025-09-18
 
 ### Fixed
+
 - Fix prompt file resolution for dependencies in org/repo directory structure
 - APM dependency prompt files now correctly resolve from `apm_modules/org/repo/` paths
 - `apm run` commands can now find and execute prompt files from installed dependencies

--- a/docs/src/content/docs/guides/dependencies.md
+++ b/docs/src/content/docs/guides/dependencies.md
@@ -21,16 +21,16 @@ APM supports any git-accessible host — GitHub, GitLab, Bitbucket, self-hosted 
 
 APM supports multiple dependency types:
 
-| Type | Detection | Example |
-|------|-----------|---------|
-| **APM Package** | Has `apm.yml` | `microsoft/apm-sample-package` |
-| **Marketplace Plugin** | Has `plugin.json` (no `apm.yml`) | `github/awesome-copilot/plugins/context-engineering` |
-| **Claude Skill** | Has `SKILL.md` (no `apm.yml`) | `ComposioHQ/awesome-claude-skills/brand-guidelines` |
-| **Hook Package** | Has `hooks/*.json` (no `apm.yml` or `SKILL.md`) | `anthropics/claude-plugins-official/plugins/hookify` |
-| **Virtual Subdirectory Package** | Folder path in monorepo | `ComposioHQ/awesome-claude-skills/mcp-builder` |
-| **Virtual Subdirectory Package** | Folder path in repo | `github/awesome-copilot/skills/review-and-refactor` |
-| **Local Path Package** | Path starts with `./`, `../`, or `/` | `./packages/my-shared-skills` |
-| **ADO Package** | Azure DevOps repo | `dev.azure.com/org/project/_git/repo` or `dev.azure.com/org/My%20Project/_git/My%20Repo` |
+| Type                             | Detection                                       | Example                                                                                  |
+| -------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| **APM Package**                  | Has `apm.yml`                                   | `microsoft/apm-sample-package`                                                           |
+| **Marketplace Plugin**           | Has `plugin.json` (no `apm.yml`)                | `github/awesome-copilot/plugins/context-engineering`                                     |
+| **Claude Skill**                 | Has `SKILL.md` (no `apm.yml`)                   | `ComposioHQ/awesome-claude-skills/brand-guidelines`                                      |
+| **Hook Package**                 | Has `hooks/*.json` (no `apm.yml` or `SKILL.md`) | `anthropics/claude-plugins-official/plugins/hookify`                                     |
+| **Virtual Subdirectory Package** | Folder path in monorepo                         | `ComposioHQ/awesome-claude-skills/mcp-builder`                                           |
+| **Virtual Subdirectory Package** | Folder path in repo                             | `github/awesome-copilot/skills/review-and-refactor`                                      |
+| **Local Path Package**           | Path starts with `./`, `../`, or `/`            | `./packages/my-shared-skills`                                                            |
+| **ADO Package**                  | Azure DevOps repo                               | `dev.azure.com/org/project/_git/repo` or `dev.azure.com/org/My%20Project/_git/My%20Repo` |
 
 **Virtual Subdirectory Packages** are skill folders from monorepos - they download an entire folder and may contain a SKILL.md plus resources.
 
@@ -52,10 +52,10 @@ apm install ComposioHQ/awesome-claude-skills/brand-guidelines
 
 Skills are integrated to `.github/skills/`:
 
-| Source | Result |
-|--------|--------|
-| Package with `SKILL.md` | Skill folder copied to `.github/skills/{folder-name}/` |
-| Package without `SKILL.md` | No skill folder created |
+| Source                     | Result                                                 |
+| -------------------------- | ------------------------------------------------------ |
+| Package with `SKILL.md`    | Skill folder copied to `.github/skills/{folder-name}/` |
+| Package without `SKILL.md` | No skill folder created                                |
 
 #### Skill Folder Naming
 
@@ -96,19 +96,19 @@ dependencies:
     - gitlab.com/acme/repo/prompts/code-review.prompt.md
 
     # Local path (for development / monorepo workflows)
-    - ./packages/my-shared-skills          # relative to project root
-    - /home/user/repos/my-ai-package       # absolute path
+    - ./packages/my-shared-skills # relative to project root
+    - /home/user/repos/my-ai-package # absolute path
 
     # Object format: git URL + sub-path / ref / alias
     - git: https://gitlab.com/acme/coding-standards.git
       path: instructions/security
       ref: v2.0
   mcp:
-    - io.github.github/github-mcp-server          # Registry reference (string)
-    - name: io.github.github/github-mcp-server      # Registry with overlays
+    - io.github.github/github-mcp-server # Registry reference (string)
+    - name: io.github.github/github-mcp-server # Registry with overlays
       transport: stdio
       tools: ["repos", "issues"]
-    - name: internal-knowledge-base                  # Self-defined (private server)
+    - name: internal-knowledge-base # Self-defined (private server)
       registry: false
       transport: http
       url: "${KNOWLEDGE_BASE_URL}"
@@ -119,6 +119,7 @@ dependencies:
 APM accepts dependencies in two forms:
 
 **String format** (simple cases):
+
 - **Shorthand** (`owner/repo`) — defaults to GitHub
 - **HTTPS URL** (`https://host/owner/repo.git`) — any git host, whole repo
 - **SSH URL** (`git@host:owner/repo.git`) — any git host, whole repo
@@ -134,11 +135,11 @@ APM accepts dependencies in two forms:
 dependencies:
   apm:
     - git: https://gitlab.com/acme/coding-standards.git
-      path: instructions/security        # virtual sub-path inside the repo
-      ref: v2.0                          # pin to a tag, branch, or commit
+      path: instructions/security # virtual sub-path inside the repo
+      ref: v2.0 # pin to a tag, branch, or commit
     - git: git@bitbucket.org:team/rules.git
       path: prompts/review.prompt.md
-      alias: review                      # local alias (controls install directory name)
+      alias: review # local alias (controls install directory name)
 ```
 
 Fields: `git` (required), `path`, `ref`, `alias` (all optional). The `git` value is any HTTPS or SSH clone URL.
@@ -162,27 +163,28 @@ APM normalizes every dependency entry on write — no matter how you specify a p
 - **GitHub** is the default registry. The `github.com` host is stripped, leaving just `owner/repo`.
 - **Non-default hosts** (GitLab, Bitbucket, self-hosted) keep their FQDN: `gitlab.com/owner/repo`.
 
-| You type | Stored in apm.yml |
-|----------|-------------------|
-| `microsoft/apm-sample-package` | `microsoft/apm-sample-package` |
-| `https://github.com/microsoft/apm-sample-package.git` | `microsoft/apm-sample-package` |
-| `git@github.com:microsoft/apm-sample-package.git` | `microsoft/apm-sample-package` |
-| `github.com/microsoft/apm-sample-package` | `microsoft/apm-sample-package` |
-| `https://gitlab.com/acme/rules.git` | `gitlab.com/acme/rules` |
-| `gitlab.com/group/subgroup/repo` | `gitlab.com/group/subgroup/repo` |
-| `git@gitlab.com:group/subgroup/repo.git` | `gitlab.com/group/subgroup/repo` |
-| `git@bitbucket.org:team/standards.git` | `bitbucket.org/team/standards` |
-| `./packages/my-skills` | `./packages/my-skills` |
-| `/home/user/repos/my-pkg` | `/home/user/repos/my-pkg` |
+| You type                                              | Stored in apm.yml                |
+| ----------------------------------------------------- | -------------------------------- |
+| `microsoft/apm-sample-package`                        | `microsoft/apm-sample-package`   |
+| `https://github.com/microsoft/apm-sample-package.git` | `microsoft/apm-sample-package`   |
+| `git@github.com:microsoft/apm-sample-package.git`     | `microsoft/apm-sample-package`   |
+| `github.com/microsoft/apm-sample-package`             | `microsoft/apm-sample-package`   |
+| `https://gitlab.com/acme/rules.git`                   | `gitlab.com/acme/rules`          |
+| `gitlab.com/group/subgroup/repo`                      | `gitlab.com/group/subgroup/repo` |
+| `git@gitlab.com:group/subgroup/repo.git`              | `gitlab.com/group/subgroup/repo` |
+| `git@bitbucket.org:team/standards.git`                | `bitbucket.org/team/standards`   |
+| `./packages/my-skills`                                | `./packages/my-skills`           |
+| `/home/user/repos/my-pkg`                             | `/home/user/repos/my-pkg`        |
 
 Virtual paths and refs are preserved:
 
-| You type | Stored in apm.yml |
-|----------|-------------------|
-| `github.com/org/repo/skills/review#v2` | `org/repo/skills/review#v2` |
+| You type                                                      | Stored in apm.yml                |
+| ------------------------------------------------------------- | -------------------------------- |
+| `github.com/org/repo/skills/review#v2`                        | `org/repo/skills/review#v2`      |
 | `https://gitlab.com/acme/repo.git` + path `docs` + ref `main` | `gitlab.com/acme/repo/docs#main` |
 
 This normalization means:
+
 - **Duplicate detection works** across input forms — you can't accidentally install the same package twice using different URL formats.
 - **`apm uninstall` accepts any form** — shorthand, HTTPS URL, or SSH URL all resolve to the same canonical identity.
 - **`apm.yml` stays clean** and readable regardless of how packages were added.
@@ -264,12 +266,13 @@ Or declare them in `apm.yml`:
 ```yaml
 dependencies:
   apm:
-    - ./packages/my-shared-skills          # relative to project root
-    - /home/user/repos/my-ai-package       # absolute path
-    - microsoft/apm-sample-package         # remote (can be mixed)
+    - ./packages/my-shared-skills # relative to project root
+    - /home/user/repos/my-ai-package # absolute path
+    - microsoft/apm-sample-package # remote (can be mixed)
 ```
 
 **How it works:**
+
 - Files are **copied** (not symlinked) to `apm_modules/_local/<package-name>/`
 - Local packages are validated the same as remote packages (must have `apm.yml` or `SKILL.md`)
 - `apm compile` works identically regardless of dependency source
@@ -298,35 +301,35 @@ apm deps list -g       # user-scope packages only
 apm deps list --all    # project + user-scope packages
 ```
 
-| Item | Project scope (default) | User scope (`-g`) |
-|------|------------------------|-------------------|
-| Manifest | `./apm.yml` | `~/.apm/apm.yml` |
-| Modules | `./apm_modules/` | `~/.apm/apm_modules/` |
-| Lockfile | `./apm.lock.yaml` | `~/.apm/apm.lock.yaml` |
+| Item                | Project scope (default)         | User scope (`-g`)                                                |
+| ------------------- | ------------------------------- | ---------------------------------------------------------------- |
+| Manifest            | `./apm.yml`                     | `~/.apm/apm.yml`                                                 |
+| Modules             | `./apm_modules/`                | `~/.apm/apm_modules/`                                            |
+| Lockfile            | `./apm.lock.yaml`               | `~/.apm/apm.lock.yaml`                                           |
 | Deployed primitives | `./.github/`, `./.claude/`, ... | `~/.copilot/`, `~/.claude/`, `~/.cursor/`, `~/.config/opencode/` |
 
 ### Per-target support
 
 Coverage varies by target and primitive type:
 
-| Target | Status | User-level dir | Primitives | Not supported |
-|--------|--------|---------------|------------|---------------|
-| Claude Code | Supported | `~/.claude/` | Skills, agents, commands, hooks, instructions | -- |
-| Copilot CLI | Partial | `~/.copilot/` | Skills, agents, hooks | Prompts, instructions |
-| Cursor | Partial | `~/.cursor/` | Skills, agents, hooks | Rules |
-| OpenCode | Partial | `~/.config/opencode/` | Skills, agents, commands | Hooks |
+| Target      | Status    | User-level dir        | Primitives                                    | Not supported         |
+| ----------- | --------- | --------------------- | --------------------------------------------- | --------------------- |
+| Claude Code | Supported | `~/.claude/`          | Skills, agents, commands, hooks, instructions | --                    |
+| Copilot CLI | Partial   | `~/.copilot/`         | Skills, agents, hooks                         | Prompts, instructions |
+| Cursor      | Partial   | `~/.cursor/`          | Skills, agents, hooks                         | Rules                 |
+| OpenCode    | Partial   | `~/.config/opencode/` | Skills, agents, commands                      | Hooks                 |
 
 Target detection mirrors project scope: APM auto-detects by `~/.<target>/` directory presence,
 falling back to Copilot. Security scanning runs for global installs.
 
 ### When to use each scope
 
-| Use case | Scope |
-|----------|-------|
+| Use case                             | Scope                   |
+| ------------------------------------ | ----------------------- |
 | Team-shared instructions and prompts | Project (`apm install`) |
 | Personal commands, agents, or skills | User (`apm install -g`) |
-| CI/CD reproducible setup | Project |
-| Cross-project coding standards | User |
+| CI/CD reproducible setup             | Project                 |
+| Cross-project coding standards       | User                    |
 
 :::note
 MCP servers are not supported at user scope. Each target uses a different MCP configuration format; user-scope MCP support is planned for a future release.
@@ -356,25 +359,25 @@ Customize a registry-resolved server with project-specific preferences:
 ```yaml
 mcp:
   - name: io.github.github/github-mcp-server
-    transport: stdio          # Prefer stdio over remote
-    env:                      # Pre-populate environment variables
+    transport: stdio # Prefer stdio over remote
+    env: # Pre-populate environment variables
       GITHUB_TOKEN: "${MY_TOKEN}"
-    tools: ["repos", "issues"]  # Restrict exposed tools
-    headers:                  # Custom HTTP headers (remote transports)
+    tools: ["repos", "issues"] # Restrict exposed tools
+    headers: # Custom HTTP headers (remote transports)
       X-Custom: "value"
-    package: npm              # Select package type (npm, pypi, oci)
+    package: npm # Select package type (npm, pypi, oci)
 ```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `name` | string | Server reference (required) |
-| `transport` | string | `stdio`, `sse`, `http`, or `streamable-http` |
-| `env` | dict | Environment variable overrides |
-| `args` | list or dict | Runtime argument overrides |
-| `version` | string | Pin server version |
-| `package` | string | Select package type (`npm`, `pypi`, `oci`) |
-| `headers` | dict | HTTP headers for remote transports |
-| `tools` | list | Restrict exposed tool names |
+| Field       | Type         | Description                                  |
+| ----------- | ------------ | -------------------------------------------- |
+| `name`      | string       | Server reference (required)                  |
+| `transport` | string       | `stdio`, `sse`, `http`, or `streamable-http` |
+| `env`       | dict         | Environment variable overrides               |
+| `args`      | list or dict | Runtime argument overrides                   |
+| `version`   | string       | Pin server version                           |
+| `package`   | string       | Select package type (`npm`, `pypi`, `oci`)   |
+| `headers`   | dict         | HTTP headers for remote transports           |
+| `tools`     | list         | Restrict exposed tool names                  |
 
 Overlay fields are merged on top of registry metadata — they augment, never replace, the registry-first model.
 
@@ -408,6 +411,7 @@ mcp:
 ```
 
 **Required fields when `registry: false`:**
+
 - `transport` — always required
 - `url` — required for `http`, `sse`, `streamable-http` transports
 - `command` — required for `stdio` transport
@@ -431,7 +435,7 @@ For GitHub and GitHub Enterprise repositories, set up a personal access token:
 Create a fine-grained personal access token at [github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new):
 
 - **Repository access**: Select specific repositories or "All repositories"
-- **Permissions**: 
+- **Permissions**:
   - Contents: Read (to access repository files)
   - Metadata: Read (to access basic repository information)
 
@@ -493,7 +497,7 @@ dependencies:
         KB_TOKEN: "${KB_TOKEN}"
 
 scripts:
-  # Design workflows  
+  # Design workflows
   design-review: "codex --skip-git-repo-check design-review.prompt.md"
   accessibility: "codex --skip-git-repo-check accessibility-audit.prompt.md"
 ```
@@ -503,17 +507,20 @@ scripts:
 The combined packages provide comprehensive coverage:
 
 **[apm-sample-package](https://github.com/microsoft/apm-sample-package) contributes:**
+
 - **Agent Workflows**: `.apm/prompts/design-review.prompt.md`, `.apm/prompts/accessibility-audit.prompt.md`
 - **Instructions**: `.apm/instructions/design-standards.instructions.md` - Design guidelines
 - **Agents**: `.apm/agents/design-reviewer.agent.md` - Design review persona
 - **Skills**: `.apm/skills/style-checker/SKILL.md` - Style checking capability
 
 **[github/awesome-copilot](https://github.com/github/awesome-copilot) virtual packages contribute:**
+
 - **Prompts**: Individual prompt files installed via virtual package references
 
 ### Compounding Benefits
 
 When both packages are installed, your project gains:
+
 - **Accessibility audit** capabilities for web components
 - **Design system enforcement** with automated style checking
 - **Code review** workflows from community prompts
@@ -555,6 +562,7 @@ my-project/
 ```
 
 During compilation, APM merges instruction content by `applyTo` patterns:
+
 1. **Pattern-Based Grouping**: Instructions are grouped by their `applyTo` patterns, not by filename
 2. **Content Merging**: All instructions matching the same pattern are concatenated in the final AGENTS.md
 3. **Source Attribution**: Each instruction includes source file attribution when compiled
@@ -603,9 +611,9 @@ Specify specific branches, tags, or commits for dependency versions:
 ```yaml
 dependencies:
   apm:
-    - github/awesome-copilot/skills/review-and-refactor#v2.1.0    # Specific tag
-    - microsoft/apm-sample-package#main     # Specific branch  
-    - company/internal-standards#abc123        # Specific commit
+    - github/awesome-copilot/skills/review-and-refactor#v2.1.0 # Specific tag
+    - microsoft/apm-sample-package#main # Specific branch
+    - company/internal-standards#abc123 # Specific commit
 ```
 
 ### Updating Dependencies
@@ -701,6 +709,7 @@ apm install contoso/package-a
 ```
 
 Result:
+
 - Downloads A, B, and C
 - Records all three in `apm.lock.yaml` with depth information
 - `depth: 1` = direct dependency
@@ -726,6 +735,59 @@ apm deps clean
 # Use with caution - requires reinstallation
 ```
 
+## Package Variables
+
+Package authors can declare variables in `apm.yml` that consumers override to customize deployed content. Variables use `${var:name}` syntax and are resolved at install time.
+
+### Declaring variables (package author)
+
+```yaml
+# Package's apm.yml
+name: tdd-development
+version: 0.5.0
+
+variables:
+  stack-profile:
+    description: "Stack profile skill for test framework and conventions"
+    default: stack-react-featureapp
+```
+
+Reference variables in primitive files:
+
+```markdown
+<!-- .apm/agents/tdd-orchestrator.agent.md -->
+
+Skills:
+
+- Invoke skill: `${var:stack-profile}`
+```
+
+### Overriding variables (consumer)
+
+```yaml
+# Consumer's apm.yml
+name: my-ios-app
+version: 1.0.0
+
+dependencies:
+  apm:
+    - acme/tdd-development#v0.5.0
+
+variables:
+  tdd-development:
+    stack-profile: stack-ios-swift
+```
+
+After `apm install`, the deployed agent file contains `stack-ios-swift` instead of the default.
+
+### Resolution order
+
+1. Consumer override (`variables.<package-name>.<var-name>`)
+2. Package default (`variables.<var-name>.default`)
+3. Unresolved -- `${var:...}` left as-is with a warning
+
+See the [manifest schema reference](../../reference/manifest-schema/#4-variables) for the full specification.
+
 ## Best Practices
 
 ### Package Structure
@@ -736,7 +798,7 @@ Create well-structured APM packages for maximum reusability:
 your-package/
 ├── .apm/
 │   ├── instructions/        # Context for AI behavior
-│   ├── contexts/           # Domain knowledge and facts  
+│   ├── contexts/           # Domain knowledge and facts
 │   ├── chatmodes/          # Interactive chat configurations
 │   └── prompts/            # Agent workflows
 ├── apm.yml                 # Package metadata
@@ -766,9 +828,11 @@ your-package/
 
 ### Common Issues
 
-#### "Authentication failed" 
+#### "Authentication failed"
+
 **Problem**: GitHub token is missing or invalid
-**Solution**: 
+**Solution**:
+
 ```bash
 # Verify token is set
 echo $GITHUB_CLI_PAT
@@ -778,24 +842,30 @@ curl -H "Authorization: token $GITHUB_CLI_PAT" https://api.github.com/user
 ```
 
 #### "Package validation failed"
+
 **Problem**: Repository doesn't have valid APM package structure
-**Solution**: 
+**Solution**:
+
 - Ensure target repository has `.apm/` directory
 - Check that `apm.yml` exists and is valid
 - Verify repository is accessible with your token
 
 #### "Circular dependency detected"
+
 **Problem**: Packages depend on each other in a loop
 **Solution**:
+
 - Review your dependency chain
 - Remove circular references
 - Consider merging closely related packages
 
 #### "File conflicts during installation"
+
 **Problem**: Local files collide with package files during `apm install`
 **Resolution**: APM skips files that exist locally and aren't managed by APM. The diagnostic summary at the end of install shows how many files were skipped. Use `--verbose` to see which files, or `--force` to overwrite.
 
 #### "File conflicts during compilation"
+
 **Problem**: Multiple packages or local files have same names
 **Resolution**: Local files automatically override dependency files with same names
 

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -40,21 +40,22 @@ A conforming manifest MUST be a YAML mapping at the top level with the following
 
 ```yaml
 # apm.yml
-name:          <string>                  # REQUIRED
-version:       <string>                  # REQUIRED
-description:   <string>
-author:        <string>
-license:       <string>
-target:        <enum>
-type:          <enum>
-scripts:       <map<string, string>>
+name: <string> # REQUIRED
+version: <string> # REQUIRED
+description: <string>
+author: <string>
+license: <string>
+target: <enum>
+type: <enum>
+scripts: <map<string, string>>
+variables: <map<string, Variable>>
 dependencies:
-  apm:         <list<ApmDependency>>
-  mcp:         <list<McpDependency>>
+  apm: <list<ApmDependency>>
+  mcp: <list<McpDependency>>
 devDependencies:
-  apm:         <list<ApmDependency>>
-  mcp:         <list<McpDependency>>
-compilation:   <CompilationConfig>
+  apm: <list<ApmDependency>>
+  mcp: <list<McpDependency>>
+compilation: <CompilationConfig>
 ```
 
 ---
@@ -63,101 +64,165 @@ compilation:   <CompilationConfig>
 
 ### 3.1. `name`
 
-| | |
-|---|---|
-| **Type** | `string` |
-| **Required** | MUST be present |
+|                 |                                                                                                                                 |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| **Type**        | `string`                                                                                                                        |
+| **Required**    | MUST be present                                                                                                                 |
 | **Description** | Package identifier. Free-form string (no pattern enforced at parse time). Convention: alphanumeric, dots, hyphens, underscores. |
 
 ### 3.2. `version`
 
-| | |
-|---|---|
-| **Type** | `string` |
-| **Required** | MUST be present |
-| **Pattern** | `^\d+\.\d+\.\d+` (semver; pre-release/build suffixes allowed) |
+|                 |                                                                                                               |
+| --------------- | ------------------------------------------------------------------------------------------------------------- |
+| **Type**        | `string`                                                                                                      |
+| **Required**    | MUST be present                                                                                               |
+| **Pattern**     | `^\d+\.\d+\.\d+` (semver; pre-release/build suffixes allowed)                                                 |
 | **Description** | Semantic version. A value that does not match the pattern SHOULD produce a validation warning (non-blocking). |
 
 ### 3.3. `description`
 
-| | |
-|---|---|
-| **Type** | `string` |
-| **Required** | OPTIONAL |
+|                 |                                   |
+| --------------- | --------------------------------- |
+| **Type**        | `string`                          |
+| **Required**    | OPTIONAL                          |
 | **Description** | Brief human-readable description. |
 
 ### 3.4. `author`
 
-| | |
-|---|---|
-| **Type** | `string` |
-| **Required** | OPTIONAL |
+|                 |                                 |
+| --------------- | ------------------------------- |
+| **Type**        | `string`                        |
+| **Required**    | OPTIONAL                        |
 | **Description** | Package author or organization. |
 
 ### 3.5. `license`
 
-| | |
-|---|---|
-| **Type** | `string` |
-| **Required** | OPTIONAL |
+|                 |                                                     |
+| --------------- | --------------------------------------------------- |
+| **Type**        | `string`                                            |
+| **Required**    | OPTIONAL                                            |
 | **Description** | SPDX license identifier (e.g. `MIT`, `Apache-2.0`). |
 
 ### 3.6. `target`
 
-| | |
-|---|---|
-| **Type** | `enum<string>` |
-| **Required** | OPTIONAL |
-| **Default** | Auto-detect: `vscode` if `.github/` exists, `claude` if `.claude/` exists, `codex` if `.codex/` exists, `all` if both `.github/` and `.claude/`, `minimal` if neither |
-| **Allowed values** | `vscode` · `agents` · `claude` · `codex` · `all` |
+|                    |                                                                                                                                                                       |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Type**           | `enum<string>`                                                                                                                                                        |
+| **Required**       | OPTIONAL                                                                                                                                                              |
+| **Default**        | Auto-detect: `vscode` if `.github/` exists, `claude` if `.claude/` exists, `codex` if `.codex/` exists, `all` if both `.github/` and `.claude/`, `minimal` if neither |
+| **Allowed values** | `vscode` · `agents` · `claude` · `codex` · `all`                                                                                                                      |
 
 Controls which output targets are generated during compilation. When unset, a conforming resolver SHOULD auto-detect based on `.github/`, `.claude/`, and `.codex/` folder presence. Unknown values MUST be silently ignored (auto-detection takes over).
 
-| Value | Effect |
-|---|---|
-| `vscode` | Emits `AGENTS.md` at the project root (and per-directory files in distributed mode) |
-| `agents` | Alias for `vscode` |
-| `claude` | Emits `CLAUDE.md` at the project root |
-| `codex` | Emits `AGENTS.md` and deploys skills to `.agents/skills/`, agents to `.codex/agents/` |
-| `all` | Both `vscode` and `claude` targets |
+| Value     | Effect                                                                                                                                                                                       |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `vscode`  | Emits `AGENTS.md` at the project root (and per-directory files in distributed mode)                                                                                                          |
+| `agents`  | Alias for `vscode`                                                                                                                                                                           |
+| `claude`  | Emits `CLAUDE.md` at the project root                                                                                                                                                        |
+| `codex`   | Emits `AGENTS.md` and deploys skills to `.agents/skills/`, agents to `.codex/agents/`                                                                                                        |
+| `all`     | Both `vscode` and `claude` targets                                                                                                                                                           |
 | `minimal` | AGENTS.md only at project root. **Auto-detected only** — this value MUST NOT be set explicitly in manifests; it is an internal fallback when no `.github/` or `.claude/` folder is detected. |
 
 ### 3.7. `type`
 
-| | |
-|---|---|
-| **Type** | `enum<string>` |
-| **Required** | OPTIONAL |
-| **Default** | None (behaviour driven by package content; synthesized plugin manifests use `hybrid`) |
-| **Allowed values** | `instructions` · `skill` · `hybrid` · `prompts` |
+|                    |                                                                                       |
+| ------------------ | ------------------------------------------------------------------------------------- |
+| **Type**           | `enum<string>`                                                                        |
+| **Required**       | OPTIONAL                                                                              |
+| **Default**        | None (behaviour driven by package content; synthesized plugin manifests use `hybrid`) |
+| **Allowed values** | `instructions` · `skill` · `hybrid` · `prompts`                                       |
 
 Declares how the package's content is processed during install and compile. Currently behaviour is driven by package content (presence of `SKILL.md`, component directories, etc.); this field is reserved for future explicit overrides.
 
-| Value | Behaviour |
-|---|---|
+| Value          | Behaviour                                                 |
+| -------------- | --------------------------------------------------------- |
 | `instructions` | Compiled into AGENTS.md only. No skill directory created. |
-| `skill` | Installed as a native skill only. No AGENTS.md output. |
-| `hybrid` | Both AGENTS.md compilation and skill installation. |
-| `prompts` | Commands/prompts only. No instructions or skills. |
+| `skill`        | Installed as a native skill only. No AGENTS.md output.    |
+| `hybrid`       | Both AGENTS.md compilation and skill installation.        |
+| `prompts`      | Commands/prompts only. No instructions or skills.         |
 
 ### 3.8. `scripts`
 
-| | |
-|---|---|
-| **Type** | `map<string, string>` |
-| **Required** | OPTIONAL |
-| **Key pattern** | Script name (free-form string) |
-| **Value** | Shell command string |
+|                 |                                                                                              |
+| --------------- | -------------------------------------------------------------------------------------------- |
+| **Type**        | `map<string, string>`                                                                        |
+| **Required**    | OPTIONAL                                                                                     |
+| **Key pattern** | Script name (free-form string)                                                               |
+| **Value**       | Shell command string                                                                         |
 | **Description** | Named commands executed via `apm run <name>`. MUST support `--param key=value` substitution. |
 
 ---
 
-## 4. Dependencies
+## 4. Variables
 
-| | |
-|---|---|
-| **Type** | `object` |
-| **Required** | OPTIONAL |
+|                 |                                                                                                         |
+| --------------- | ------------------------------------------------------------------------------------------------------- |
+| **Type**        | `map<string, Variable>`                                                                                 |
+| **Required**    | OPTIONAL                                                                                                |
+| **Description** | Declares install-time variables substituted in deployed primitive files via `${var:name}` placeholders. |
+
+Variables let package authors create parameterized templates. Consumers override values in their own `apm.yml` to customize deployed content without editing package files.
+
+### 4.1. Package author syntax
+
+Each key is a variable name (`[a-zA-Z0-9_-]+`). The value is either a string shorthand (treated as the default) or an object:
+
+```yaml
+variables:
+  stack-profile: stack-react-featureapp # shorthand: default value only
+
+  test-runner: # full form
+    description: "Test runner command"
+    default: "pytest"
+
+  api-key: # required, no default
+    description: "API key for the service"
+    required: true
+```
+
+| Field         | Type      | Required    | Description                                                                                                      |
+| ------------- | --------- | ----------- | ---------------------------------------------------------------------------------------------------------------- |
+| `description` | `string`  | OPTIONAL    | Human-readable purpose of the variable.                                                                          |
+| `default`     | `string`  | Conditional | Default value. MUST be present if `required` is false or omitted.                                                |
+| `required`    | `boolean` | OPTIONAL    | When `true` and no `default` is set, consumers MUST provide a value or `apm install` fails. Defaults to `false`. |
+
+### 4.2. Consumer override syntax
+
+Consumers override package variables keyed by package name:
+
+```yaml
+# Consumer's apm.yml
+variables:
+  tdd-development:
+    stack-profile: stack-ios-swift
+```
+
+### 4.3. Resolution order
+
+1. Consumer's `variables.<package-name>.<var-name>` (highest priority)
+2. Package's `variables.<var-name>.default`
+3. Unresolved -- placeholder left as-is with a warning
+
+### 4.4. Substitution syntax
+
+Placeholders use `${var:name}` in any deployed text file (`.md`, `.yml`, `.yaml`, `.json`, `.toml`, `.txt`):
+
+```markdown
+Skills:
+
+- Invoke skill: `${var:stack-profile}`
+```
+
+The `var:` namespace is distinct from `${input:...}` (runtime prompts). `${var:...}` is resolved at install time; `${input:...}` is resolved at runtime by the IDE.
+
+---
+
+## 5. Dependencies
+
+|                |              |
+| -------------- | ------------ |
+| **Type**       | `object`     |
+| **Required**   | OPTIONAL     |
 | **Known keys** | `apm`, `mcp` |
 
 Contains two OPTIONAL lists: `apm` for agent primitive packages and `mcp` for MCP servers. Each list entry is either a string shorthand or a typed object. Additional keys MAY be present for future dependency types; conforming resolvers MUST ignore unknown keys for resolution but MUST preserve them when reading and rewriting manifests, to allow forward compatibility.
@@ -179,12 +244,12 @@ shorthand_form = [host "/"] owner "/" repo ["/" virtual_path] ["#" ref]
 local_path_form = ("./" / "../" / "/" / "~/" / ".\\" / "..\\" / "~\\") path
 ```
 
-| Segment | Required | Pattern | Description |
-|---|---|---|---|
-| `host` | OPTIONAL | FQDN (e.g. `gitlab.com`) | Git host. Defaults to `github.com`. |
-| `owner/repo` | REQUIRED | 2+ path segments of `[a-zA-Z0-9._-]+` | Repository path. GitHub uses exactly 2 segments (`owner/repo`). Non-GitHub hosts MAY use nested groups (e.g. `gitlab.com/group/sub/repo`). |
-| `virtual_path` | OPTIONAL | Path segments after repo | Subdirectory, file, or collection within the repo. See §4.1.3. |
-| `ref` | OPTIONAL | Branch, tag, or commit SHA | Git reference. Commit SHAs matched by `^[a-f0-9]{7,40}$`. Semver tags matched by `^v?\d+\.\d+\.\d+`. |
+| Segment        | Required | Pattern                               | Description                                                                                                                                |
+| -------------- | -------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `host`         | OPTIONAL | FQDN (e.g. `gitlab.com`)              | Git host. Defaults to `github.com`.                                                                                                        |
+| `owner/repo`   | REQUIRED | 2+ path segments of `[a-zA-Z0-9._-]+` | Repository path. GitHub uses exactly 2 segments (`owner/repo`). Non-GitHub hosts MAY use nested groups (e.g. `gitlab.com/group/sub/repo`). |
+| `virtual_path` | OPTIONAL | Path segments after repo              | Subdirectory, file, or collection within the repo. See §4.1.3.                                                                             |
+| `ref`          | OPTIONAL | Branch, tag, or commit SHA            | Git reference. Commit SHAs matched by `^[a-f0-9]{7,40}$`. Semver tags matched by `^v?\d+\.\d+\.\d+`.                                       |
 
 **Examples:**
 
@@ -192,9 +257,9 @@ local_path_form = ("./" / "../" / "/" / "~/" / ".\\" / "..\\" / "~\\") path
 dependencies:
   apm:
     # GitHub shorthand (default host) — each line shows a syntax variant
-    - microsoft/apm-sample-package                # latest (lockfile pins commit SHA)
-    - microsoft/apm-sample-package#v1.0.0         # pinned to tag (immutable)
-    - microsoft/apm-sample-package#main           # branch ref (may change over time)
+    - microsoft/apm-sample-package # latest (lockfile pins commit SHA)
+    - microsoft/apm-sample-package#v1.0.0 # pinned to tag (immutable)
+    - microsoft/apm-sample-package#main # branch ref (may change over time)
 
     # Non-GitHub hosts (FQDN preserved)
     - gitlab.com/acme/coding-standards
@@ -207,27 +272,27 @@ dependencies:
     - ssh://git@github.com/microsoft/apm-sample-package.git
 
     # Virtual packages
-    - ComposioHQ/awesome-claude-skills/brand-guidelines   # subdirectory
-    - contoso/prompts/review.prompt.md                    # single file
+    - ComposioHQ/awesome-claude-skills/brand-guidelines # subdirectory
+    - contoso/prompts/review.prompt.md # single file
 
     # Azure DevOps
     - dev.azure.com/org/project/_git/repo
 
     # Local path (development only)
-    - ./packages/my-shared-skills          # relative to project root
-    - ../sibling-repo/my-package           # parent directory
+    - ./packages/my-shared-skills # relative to project root
+    - ../sibling-repo/my-package # parent directory
 ```
 
 #### 4.1.2. Object Form
 
 REQUIRED when the shorthand is ambiguous (e.g. nested-group repos with virtual paths).
 
-| Field | Type | Required | Pattern / Constraint | Description |
-|---|---|---|---|---|
-| `git` | `string` | REQUIRED (remote) | HTTPS URL, SSH URL, or FQDN shorthand | Clone URL of the repository. Required for remote dependencies. |
-| `path` | `string` | OPTIONAL / REQUIRED (local) | Relative path within the repo, or local filesystem path | When `git` is present: subdirectory, file, or collection (virtual package). When `git` is absent: local filesystem path (must start with `./`, `../`, `/`, or `~/`). |
-| `ref` | `string` | OPTIONAL | Branch, tag, or commit SHA | Git reference to checkout. |
-| `alias` | `string` | OPTIONAL | `^[a-zA-Z0-9._-]+$` | Local alias. |
+| Field   | Type     | Required                    | Pattern / Constraint                                    | Description                                                                                                                                                          |
+| ------- | -------- | --------------------------- | ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `git`   | `string` | REQUIRED (remote)           | HTTPS URL, SSH URL, or FQDN shorthand                   | Clone URL of the repository. Required for remote dependencies.                                                                                                       |
+| `path`  | `string` | OPTIONAL / REQUIRED (local) | Relative path within the repo, or local filesystem path | When `git` is present: subdirectory, file, or collection (virtual package). When `git` is absent: local filesystem path (must start with `./`, `../`, `/`, or `~/`). |
+| `ref`   | `string` | OPTIONAL                    | Branch, tag, or commit SHA                              | Git reference to checkout.                                                                                                                                           |
+| `alias` | `string` | OPTIONAL                    | `^[a-zA-Z0-9._-]+$`                                     | Local alias.                                                                                                                                                         |
 
 Remote dependency (git URL + sub-path):
 
@@ -248,22 +313,22 @@ Local path dependency (development only):
 
 A dependency MAY target a subdirectory, file, or collection within a repository rather than the whole repo. Conforming resolvers MUST classify virtual packages using the following rules, evaluated in order:
 
-| Kind | Detection rule | Example |
-|---|---|---|
-| **File** | `virtual_path` ends in `.prompt.md`, `.instructions.md`, `.agent.md`, or `.chatmode.md` | `owner/repo/prompts/review.prompt.md` |
-| **Collection (dir)** | `virtual_path` contains `/collections/` (no collection extension) | `owner/repo/collections/security` |
+| Kind                      | Detection rule                                                                                | Example                                          |
+| ------------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| **File**                  | `virtual_path` ends in `.prompt.md`, `.instructions.md`, `.agent.md`, or `.chatmode.md`       | `owner/repo/prompts/review.prompt.md`            |
+| **Collection (dir)**      | `virtual_path` contains `/collections/` (no collection extension)                             | `owner/repo/collections/security`                |
 | **Collection (manifest)** | `virtual_path` contains `/collections/` and ends with `.collection.yml` or `.collection.yaml` | `owner/repo/collections/security.collection.yml` |
-| **Subdirectory** | `virtual_path` does not match any file, collection, or extension rule above | `owner/repo/skills/security` |
+| **Subdirectory**          | `virtual_path` does not match any file, collection, or extension rule above                   | `owner/repo/skills/security`                     |
 
 #### 4.1.4. Canonical Normalisation
 
 Conforming writers MUST normalise entries to canonical form on write. `github.com` is the default host and MUST be stripped; all other hosts MUST be preserved as FQDN.
 
-| Input | Canonical form |
-|---|---|
+| Input                                                 | Canonical form                 |
+| ----------------------------------------------------- | ------------------------------ |
 | `https://github.com/microsoft/apm-sample-package.git` | `microsoft/apm-sample-package` |
-| `git@github.com:microsoft/apm-sample-package.git` | `microsoft/apm-sample-package` |
-| `gitlab.com/acme/repo` | `gitlab.com/acme/repo` |
+| `git@github.com:microsoft/apm-sample-package.git`     | `microsoft/apm-sample-package` |
+| `gitlab.com/acme/repo`                                | `gitlab.com/acme/repo`         |
 
 ---
 
@@ -277,19 +342,19 @@ A plain registry reference: `io.github.github/github-mcp-server`
 
 #### 4.2.2. Object Form
 
-| Field | Type | Required | Constraint | Description |
-|---|---|---|---|---|
-| `name` | `string` | REQUIRED | Non-empty | Server identifier (registry name or custom name). |
-| `transport` | `enum<string>` | Conditional | `stdio` · `sse` · `http` · `streamable-http` | Transport protocol. REQUIRED when `registry: false`. |
-| `env` | `map<string, string>` | OPTIONAL | | Environment variable overrides. Values may contain `${input:<id>}` references (VS Code only — see §4.2.4). |
-| `args` | `dict` or `list` | OPTIONAL | | Dict for overlay variable overrides (registry), list for positional args (self-defined). |
-| `version` | `string` | OPTIONAL | | Pin to a specific server version. |
-| `registry` | `bool` or `string` | OPTIONAL | Default: `true` (public registry) | `false` = self-defined (private) server. String = custom registry URL. |
-| `package` | `enum<string>` | OPTIONAL | `npm` · `pypi` · `oci` | Package manager type hint. |
-| `headers` | `map<string, string>` | OPTIONAL | | Custom HTTP headers for remote endpoints. Values may contain `${input:<id>}` references (VS Code only — see §4.2.4). |
-| `tools` | `list<string>` | OPTIONAL | Default: `["*"]` | Restrict which tools are exposed. |
-| `url` | `string` | Conditional | | Endpoint URL. REQUIRED when `registry: false` and `transport` is `http`, `sse`, or `streamable-http`. |
-| `command` | `string` | Conditional | | Binary path. REQUIRED when `registry: false` and `transport` is `stdio`. |
+| Field       | Type                  | Required    | Constraint                                   | Description                                                                                                          |
+| ----------- | --------------------- | ----------- | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `name`      | `string`              | REQUIRED    | Non-empty                                    | Server identifier (registry name or custom name).                                                                    |
+| `transport` | `enum<string>`        | Conditional | `stdio` · `sse` · `http` · `streamable-http` | Transport protocol. REQUIRED when `registry: false`.                                                                 |
+| `env`       | `map<string, string>` | OPTIONAL    |                                              | Environment variable overrides. Values may contain `${input:<id>}` references (VS Code only — see §4.2.4).           |
+| `args`      | `dict` or `list`      | OPTIONAL    |                                              | Dict for overlay variable overrides (registry), list for positional args (self-defined).                             |
+| `version`   | `string`              | OPTIONAL    |                                              | Pin to a specific server version.                                                                                    |
+| `registry`  | `bool` or `string`    | OPTIONAL    | Default: `true` (public registry)            | `false` = self-defined (private) server. String = custom registry URL.                                               |
+| `package`   | `enum<string>`        | OPTIONAL    | `npm` · `pypi` · `oci`                       | Package manager type hint.                                                                                           |
+| `headers`   | `map<string, string>` | OPTIONAL    |                                              | Custom HTTP headers for remote endpoints. Values may contain `${input:<id>}` references (VS Code only — see §4.2.4). |
+| `tools`     | `list<string>`        | OPTIONAL    | Default: `["*"]`                             | Restrict which tools are exposed.                                                                                    |
+| `url`       | `string`              | Conditional |                                              | Endpoint URL. REQUIRED when `registry: false` and `transport` is `http`, `sse`, or `streamable-http`.                |
+| `command`   | `string`              | Conditional |                                              | Binary path. REQUIRED when `registry: false` and `transport` is `stdio`.                                             |
 
 #### 4.2.3. Validation Rules for Self-Defined Servers
 
@@ -340,20 +405,20 @@ dependencies:
         X-Project: "${input:my-server-project}"
 ```
 
-| Runtime | `${input:...}` support |
-|---------|----------------------|
-| VS Code | Yes — prompts user at runtime |
+| Runtime     | `${input:...}` support         |
+| ----------- | ------------------------------ |
+| VS Code     | Yes — prompts user at runtime  |
 | Copilot CLI | No — use environment variables |
-| Codex | No — use environment variables |
+| Codex       | No — use environment variables |
 
 ---
 
-## 5. devDependencies
+## 6. devDependencies
 
-| | |
-|---|---|
-| **Type** | `object` |
-| **Required** | OPTIONAL |
+|                |              |
+| -------------- | ------------ |
+| **Type**       | `object`     |
+| **Required**   | OPTIONAL     |
 | **Known keys** | `apm`, `mcp` |
 
 Development-only dependencies installed locally but excluded from plugin bundles (`apm pack --format plugin`). Uses the same structure as [`dependencies`](#4-dependencies).
@@ -373,27 +438,27 @@ apm install --dev owner/test-helpers
 
 ---
 
-## 6. Compilation
+## 7. Compilation
 
 The `compilation` key is OPTIONAL. It controls `apm compile` behaviour. All fields have sensible defaults; omitting the entire section is valid.
 
-| Field | Type | Default | Constraint | Description |
-|---|---|---|---|---|
-| `target` | `enum<string>` | `all` | `vscode` · `agents` · `claude` · `codex` · `all` | Output target (same values as §3.6). Defaults to `all` when set explicitly in compilation config. |
-| `strategy` | `enum<string>` | `distributed` | `distributed` · `single-file` | `distributed` generates per-directory AGENTS.md files. `single-file` generates one monolithic file. |
-| `single_file` | `bool` | `false` | | Legacy alias. When `true`, overrides `strategy` to `single-file`. |
-| `output` | `string` | `AGENTS.md` | File path | Custom output path for the compiled file. |
-| `chatmode` | `string` | — | | Chatmode filter for compilation. |
-| `resolve_links` | `bool` | `true` | | Resolve relative Markdown links in primitives. |
-| `source_attribution` | `bool` | `true` | | Include source-file origin comments in compiled output. |
-| `exclude` | `list<string>` or `string` | `[]` | Glob patterns | Directories to skip during compilation (e.g. `apm_modules/**`). |
-| `placement` | `object` | — | | Placement tuning. See §6.1. |
+| Field                | Type                       | Default       | Constraint                                       | Description                                                                                         |
+| -------------------- | -------------------------- | ------------- | ------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `target`             | `enum<string>`             | `all`         | `vscode` · `agents` · `claude` · `codex` · `all` | Output target (same values as §3.6). Defaults to `all` when set explicitly in compilation config.   |
+| `strategy`           | `enum<string>`             | `distributed` | `distributed` · `single-file`                    | `distributed` generates per-directory AGENTS.md files. `single-file` generates one monolithic file. |
+| `single_file`        | `bool`                     | `false`       |                                                  | Legacy alias. When `true`, overrides `strategy` to `single-file`.                                   |
+| `output`             | `string`                   | `AGENTS.md`   | File path                                        | Custom output path for the compiled file.                                                           |
+| `chatmode`           | `string`                   | —             |                                                  | Chatmode filter for compilation.                                                                    |
+| `resolve_links`      | `bool`                     | `true`        |                                                  | Resolve relative Markdown links in primitives.                                                      |
+| `source_attribution` | `bool`                     | `true`        |                                                  | Include source-file origin comments in compiled output.                                             |
+| `exclude`            | `list<string>` or `string` | `[]`          | Glob patterns                                    | Directories to skip during compilation (e.g. `apm_modules/**`).                                     |
+| `placement`          | `object`                   | —             |                                                  | Placement tuning. See §6.1.                                                                         |
 
 ### 6.1. `compilation.placement`
 
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `min_instructions_per_file` | `int` | `1` | Minimum instruction count to warrant a separate AGENTS.md file. |
+| Field                       | Type  | Default | Description                                                     |
+| --------------------------- | ----- | ------- | --------------------------------------------------------------- |
+| `min_instructions_per_file` | `int` | `1`     | Minimum instruction count to warrant a separate AGENTS.md file. |
 
 ```yaml
 compilation:
@@ -409,34 +474,35 @@ compilation:
 
 ---
 
-## 7. Lockfile (`apm.lock.yaml`)
+## 8. Lockfile (`apm.lock.yaml`)
 
 After successful dependency resolution, a conforming resolver MUST write a lockfile capturing the exact resolved state. The lockfile MUST be a YAML file named `apm.lock.yaml` at the project root. It SHOULD be committed to version control.
 
-### 7.1. Structure
+### 8.1. Structure
 
 ```yaml
 lockfile_version: "1"
-generated_at:     <ISO 8601 timestamp>
-apm_version:      <string>
-dependencies:                              # YAML list (not a map)
-  - repo_url:        <string>              # Resolved clone URL
-    host:            <string>              # Git host (OPTIONAL, e.g. "gitlab.com")
-    resolved_commit: <string>              # Full commit SHA
-    resolved_ref:    <string>              # Branch/tag that was resolved
-    version:         <string>              # Package version from its apm.yml
-    virtual_path:    <string>              # Virtual package path (if applicable)
-    is_virtual:      <bool>                # True for virtual (file/subdirectory) packages
-    depth:           <int>                 # 1 = direct, 2+ = transitive
-    resolved_by:     <string>              # Parent dependency (transitive only)
-    package_type:    <string>              # Package type (e.g. "apm_package", "marketplace_plugin")
-    content_hash:    <string>              # SHA-256 of package file tree (e.g. "sha256:a1b2c3...")
-    is_dev:          <bool>                # True for devDependencies
-    deployed_files:  <list<string>>        # Workspace-relative paths of installed files
-mcp_servers:       <list<string>>          # MCP dependency references managed by APM (OPTIONAL, e.g. "io.github.github/github-mcp-server")
+generated_at: <ISO 8601 timestamp>
+apm_version: <string>
+dependencies: # YAML list (not a map)
+  - repo_url: <string> # Resolved clone URL
+    host: <string> # Git host (OPTIONAL, e.g. "gitlab.com")
+    resolved_commit: <string> # Full commit SHA
+    resolved_ref: <string> # Branch/tag that was resolved
+    version: <string> # Package version from its apm.yml
+    virtual_path: <string> # Virtual package path (if applicable)
+    is_virtual: <bool> # True for virtual (file/subdirectory) packages
+    depth: <int> # 1 = direct, 2+ = transitive
+    resolved_by: <string> # Parent dependency (transitive only)
+    package_type: <string> # Package type (e.g. "apm_package", "marketplace_plugin")
+    content_hash: <string> # SHA-256 of package file tree (e.g. "sha256:a1b2c3...")
+    is_dev: <bool> # True for devDependencies
+    deployed_files: <list<string>> # Workspace-relative paths of installed files
+    resolved_variables: <map<string,string>> # Resolved ${var:...} values (OPTIONAL)
+mcp_servers: <list<string>> # MCP dependency references managed by APM (OPTIONAL, e.g. "io.github.github/github-mcp-server")
 ```
 
-### 7.2. Resolver Behaviour
+### 8.2. Resolver Behaviour
 
 1. **First install** — Resolve all dependencies, write `apm.lock.yaml`.
 2. **Subsequent installs** — Read `apm.lock.yaml`, use locked commit SHAs. A resolver SHOULD skip download if local checkout already matches.
@@ -444,7 +510,7 @@ mcp_servers:       <list<string>>          # MCP dependency references managed b
 
 ---
 
-## 8. Integrator Contract
+## 9. Integrator Contract
 
 Any runtime adopting this format (e.g. GitHub Agentic Workflows, CI systems, IDEs) MUST implement these steps:
 
@@ -465,11 +531,11 @@ description: AI-native web application
 author: Contoso
 license: MIT
 target: all
-type: hybrid              # instructions | skill | hybrid | prompts
+type: hybrid # instructions | skill | hybrid | prompts
 
 scripts:
   review: "copilot -p 'code-review.prompt.md'"
-  impl:   "copilot -p 'implement-feature.prompt.md'"
+  impl: "copilot -p 'implement-feature.prompt.md'"
 
 dependencies:
   apm:
@@ -504,6 +570,6 @@ compilation:
 
 ## Appendix B. Revision History
 
-| Version | Date | Changes |
-|---|---|---|
-| 0.1 | 2026-03-06 | Initial Working Draft. |
+| Version | Date       | Changes                |
+| ------- | ---------- | ---------------------- |
+| 0.1     | 2026-03-06 | Initial Working Draft. |

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -150,3 +150,23 @@ dependencies:
 This ensures consistent instructions, agents, and policies across the org.
 Local `.apm/` primitives in each repo can extend or override the shared ones
 (local always takes priority over dependencies).
+
+## Package variables
+
+Declare variables in `apm.yml` so consumers can customize deployed content:
+
+```yaml
+# Package apm.yml
+variables:
+  stack-profile:
+    description: "Stack profile skill"
+    default: stack-react-featureapp
+```
+
+Use `${var:name}` in any primitive file. Consumers override in their `apm.yml`:
+
+```yaml
+variables:
+  my-package:
+    stack-profile: stack-ios-swift
+```

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -1123,6 +1123,7 @@ def _integrate_package_primitives(
     package_name="",
     logger=None,
     scope=None,
+    variables=None,
 ):
     """Run the full integration pipeline for a single package.
 
@@ -1139,6 +1140,15 @@ def _integrate_package_primitives(
     from apm_cli.integration.dispatch import get_dispatch_table
 
     _dispatch = get_dispatch_table()
+
+    # Set package variables on all integrators for ${var:...} substitution
+    _all_integrators = [
+        prompt_integrator, agent_integrator, skill_integrator,
+        instruction_integrator, command_integrator, hook_integrator,
+    ]
+    for _integ in _all_integrators:
+        _integ.set_variables(variables or {})
+
     result = {
         "prompts": 0,
         "agents": 0,
@@ -1361,6 +1371,62 @@ def _copy_local_package(dep_ref, install_path, project_root):
 
     shutil.copytree(local, install_path, dirs_exist_ok=False, symlinks=True)
     return install_path
+
+
+def _resolve_variables_for_package(
+    package_info, consumer_apm_package, diagnostics=None, logger=None,
+):
+    """Resolve ${var:...} variables for a single package.
+
+    Reads the package's own apm.yml for variable definitions, then merges
+    with consumer overrides from the top-level apm.yml.
+
+    Returns:
+        dict mapping variable name to resolved value (may be empty).
+    """
+    from apm_cli.utils.variables import (
+        parse_package_variables,
+        parse_consumer_overrides,
+        resolve_package_variables,
+    )
+
+    # Read the package's own apm.yml for variable definitions
+    pkg_apm_yml = package_info.install_path / "apm.yml"
+    pkg_variables_raw = None
+    if pkg_apm_yml.exists():
+        try:
+            pkg = package_info.package
+            pkg_variables_raw = pkg.variables
+        except Exception:
+            pass
+
+    package_vars = parse_package_variables(pkg_variables_raw)
+    if not package_vars and not (consumer_apm_package.variables or {}):
+        return {}
+
+    consumer_overrides = parse_consumer_overrides(consumer_apm_package.variables)
+    pkg_name = package_info.package.name
+
+    resolved, warnings, errors = resolve_package_variables(
+        pkg_name, package_vars, consumer_overrides,
+    )
+
+    for warn_msg in warnings:
+        if diagnostics:
+            diagnostics.warn(warn_msg, package=pkg_name)
+        elif logger:
+            logger.verbose_detail(f"  [!] {warn_msg}")
+
+    for err_msg in errors:
+        if diagnostics:
+            diagnostics.error(err_msg, package=pkg_name)
+        elif logger:
+            logger.error(err_msg)
+
+    if errors:
+        return {}
+
+    return resolved
 
 
 def _install_apm_dependencies(
@@ -1724,6 +1790,7 @@ def _install_apm_dependencies(
         package_deployed_files: builtins.dict = {}  # dep_key → list of relative deployed paths
         package_types: builtins.dict = {}  # dep_key → package type string
         _package_hashes: builtins.dict = {}  # dep_key → sha256 hash (captured at download/verify time)
+        _package_resolved_vars: builtins.dict = {}  # dep_key → resolved variables dict
 
         # Resolve registry proxy configuration once for this install session.
         registry_config = RegistryConfig.from_env()
@@ -2031,6 +2098,14 @@ def _install_apm_dependencies(
                             package_deployed_files[dep_key] = []
                             continue
 
+                        # Resolve ${var:...} variables for this package
+                        _pkg_vars = _resolve_variables_for_package(
+                            package_info, apm_package,
+                            diagnostics=diagnostics, logger=logger,
+                        )
+                        if _pkg_vars:
+                            _package_resolved_vars[dep_key] = _pkg_vars
+
                         int_result = _integrate_package_primitives(
                             package_info, project_root,
                             targets=_targets,
@@ -2046,6 +2121,7 @@ def _install_apm_dependencies(
                             package_name=dep_key,
                             logger=logger,
                             scope=scope,
+                            variables=_pkg_vars,
                         )
                         total_prompts_integrated += int_result["prompts"]
                         total_agents_integrated += int_result["agents"]
@@ -2295,6 +2371,14 @@ def _install_apm_dependencies(
                             package_deployed_files[dep_key] = []
                             continue
 
+                        # Resolve ${var:...} variables for this package
+                        _cached_pkg_vars = _resolve_variables_for_package(
+                            cached_package_info, apm_package,
+                            diagnostics=diagnostics, logger=logger,
+                        )
+                        if _cached_pkg_vars:
+                            _package_resolved_vars[dep_key] = _cached_pkg_vars
+
                         int_result = _integrate_package_primitives(
                             cached_package_info, project_root,
                             targets=_targets,
@@ -2310,6 +2394,7 @@ def _install_apm_dependencies(
                             package_name=dep_key,
                             logger=logger,
                             scope=scope,
+                            variables=_cached_pkg_vars,
                         )
                         total_prompts_integrated += int_result["prompts"]
                         total_agents_integrated += int_result["agents"]
@@ -2490,6 +2575,14 @@ def _install_apm_dependencies(
 
                     if _targets:
                         try:
+                            # Resolve ${var:...} variables for this package
+                            _fresh_pkg_vars = _resolve_variables_for_package(
+                                package_info, apm_package,
+                                diagnostics=diagnostics, logger=logger,
+                            )
+                            if _fresh_pkg_vars:
+                                _package_resolved_vars[dep_ref.get_unique_key()] = _fresh_pkg_vars
+
                             int_result = _integrate_package_primitives(
                                 package_info, project_root,
                                 targets=_targets,
@@ -2505,6 +2598,7 @@ def _install_apm_dependencies(
                                 package_name=dep_ref.get_unique_key(),
                                 logger=logger,
                                 scope=scope,
+                                variables=_fresh_pkg_vars,
                             )
                             total_prompts_integrated += int_result["prompts"]
                             total_agents_integrated += int_result["agents"]
@@ -2615,6 +2709,10 @@ def _install_apm_dependencies(
                 for dep_key, locked_dep in lockfile.dependencies.items():
                     if dep_key in _package_hashes:
                         locked_dep.content_hash = _package_hashes[dep_key]
+                # Attach resolved ${var:...} variables for reproducible installs
+                for dep_key, resolved_vars in _package_resolved_vars.items():
+                    if dep_key in lockfile.dependencies:
+                        lockfile.dependencies[dep_key].resolved_variables = resolved_vars
                 # Attach marketplace provenance if available
                 if marketplace_provenance:
                     for dep_key, prov in marketplace_provenance.items():

--- a/src/apm_cli/deps/lockfile.py
+++ b/src/apm_cli/deps/lockfile.py
@@ -38,6 +38,7 @@ class LockedDependency:
     is_dev: bool = False  # True for devDependencies
     discovered_via: Optional[str] = None  # Marketplace name (provenance)
     marketplace_plugin_name: Optional[str] = None  # Plugin name in marketplace
+    resolved_variables: Optional[Dict[str, str]] = None  # Resolved ${var:...} variables
 
     def get_unique_key(self) -> str:
         """Returns unique key for this dependency."""
@@ -84,6 +85,8 @@ class LockedDependency:
             result["discovered_via"] = self.discovered_via
         if self.marketplace_plugin_name:
             result["marketplace_plugin_name"] = self.marketplace_plugin_name
+        if self.resolved_variables:
+            result["resolved_variables"] = dict(sorted(self.resolved_variables.items()))
         return result
 
     @classmethod
@@ -122,6 +125,7 @@ class LockedDependency:
             is_dev=data.get("is_dev", False),
             discovered_via=data.get("discovered_via"),
             marketplace_plugin_name=data.get("marketplace_plugin_name"),
+            resolved_variables=data.get("resolved_variables"),
         )
 
     @classmethod

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -143,7 +143,7 @@ class AgentIntegrator(BaseIntegrator):
                 continue
 
             if mapping.format_id == "codex_agent":
-                self._write_codex_agent(source_file, target_path)
+                self._write_codex_agent(source_file, target_path, variables=self._variables)
                 links_resolved = 0
             else:
                 links_resolved = self.copy_agent(source_file, target_path)
@@ -215,6 +215,7 @@ class AgentIntegrator(BaseIntegrator):
         """
         content = source.read_text(encoding='utf-8')
         content, links_resolved = self.resolve_links(content, source, target)
+        content = self.apply_variable_substitution(content)
         target.write_text(content, encoding='utf-8')
         return links_resolved
 
@@ -228,7 +229,7 @@ class AgentIntegrator(BaseIntegrator):
     )
 
     @staticmethod
-    def _write_codex_agent(source: Path, target: Path) -> None:
+    def _write_codex_agent(source: Path, target: Path, variables: Dict[str, str] = None) -> None:
         """Transform an ``.agent.md`` file to Codex ``.toml`` format.
 
         Parses YAML frontmatter for ``name`` and ``description``, uses
@@ -237,6 +238,10 @@ class AgentIntegrator(BaseIntegrator):
         import toml as _toml
 
         content = source.read_text(encoding="utf-8")
+
+        if variables:
+            from apm_cli.utils.variables import substitute_variables
+            content = substitute_variables(content, variables)
 
         name = source.stem
         if name.endswith(".agent"):

--- a/src/apm_cli/integration/base_integrator.py
+++ b/src/apm_cli/integration/base_integrator.py
@@ -45,6 +45,21 @@ class BaseIntegrator:
 
     def __init__(self):
         self.link_resolver: Optional[UnifiedLinkResolver] = None
+        self._variables: Dict[str, str] = {}
+
+    def set_variables(self, variables: Dict[str, str]) -> None:
+        """Set package variables for ``${var:...}`` substitution.
+
+        Called before integration runs for each package.
+        """
+        self._variables = variables or {}
+
+    def apply_variable_substitution(self, content: str) -> str:
+        """Apply ``${var:...}`` substitution using the current variable set."""
+        if not self._variables:
+            return content
+        from apm_cli.utils.variables import substitute_variables
+        return substitute_variables(content, self._variables)
 
     # ------------------------------------------------------------------
     # Common behaviour  -- subclasses inherit directly

--- a/src/apm_cli/integration/command_integrator.py
+++ b/src/apm_cli/integration/command_integrator.py
@@ -97,6 +97,9 @@ class CommandIntegrator(BaseIntegrator):
         # Resolve context links in content
         post.content, links_resolved = self.resolve_links(post.content, source, target)
         
+        # Apply variable substitution
+        post.content = self.apply_variable_substitution(post.content)
+        
         # Ensure target directory exists
         target.parent.mkdir(parents=True, exist_ok=True)
         

--- a/src/apm_cli/integration/instruction_integrator.py
+++ b/src/apm_cli/integration/instruction_integrator.py
@@ -48,6 +48,7 @@ class InstructionIntegrator(BaseIntegrator):
         """
         content = source.read_text(encoding='utf-8')
         content, links_resolved = self.resolve_links(content, source, target)
+        content = self.apply_variable_substitution(content)
         target.write_text(content, encoding='utf-8')
         return links_resolved
 
@@ -265,6 +266,7 @@ class InstructionIntegrator(BaseIntegrator):
         content = source.read_text(encoding='utf-8')
         content = self._convert_to_cursor_rules(content)
         content, links_resolved = self.resolve_links(content, source, target)
+        content = self.apply_variable_substitution(content)
         target.write_text(content, encoding='utf-8')
         return links_resolved
 
@@ -348,6 +350,7 @@ class InstructionIntegrator(BaseIntegrator):
         content = source.read_text(encoding='utf-8')
         content = self._convert_to_claude_rules(content)
         content, links_resolved = self.resolve_links(content, source, target)
+        content = self.apply_variable_substitution(content)
         target.write_text(content, encoding='utf-8')
         return links_resolved
 

--- a/src/apm_cli/integration/prompt_integrator.py
+++ b/src/apm_cli/integration/prompt_integrator.py
@@ -53,6 +53,7 @@ class PromptIntegrator(BaseIntegrator):
         """
         content = source.read_text(encoding='utf-8')
         content, links_resolved = self.resolve_links(content, source, target)
+        content = self.apply_variable_substitution(content)
         target.write_text(content, encoding='utf-8')
         return links_resolved
     

--- a/src/apm_cli/integration/skill_integrator.py
+++ b/src/apm_cli/integration/skill_integrator.py
@@ -253,6 +253,7 @@ def copy_skill_to_target(
     source_path: Path,
     target_base: Path,
     targets=None,
+    variables: dict[str, str] | None = None,
 ) -> list[Path]:
     """Copy skill directory to all active target skills/ directories.
     
@@ -328,6 +329,10 @@ def copy_skill_to_target(
         if skill_dir.exists():
             shutil.rmtree(skill_dir)
         shutil.copytree(source_path, skill_dir)
+        # Apply ${var:...} substitution to copied text files
+        if variables:
+            from apm_cli.utils.variables import substitute_variables_in_directory
+            substitute_variables_in_directory(skill_dir, variables)
         deployed.append(skill_dir)
     
     return deployed
@@ -344,6 +349,7 @@ class SkillIntegrator(BaseIntegrator):
     """
 
     def __init__(self) -> None:
+        super().__init__()
         # In-memory map of skill_name -> dep.get_unique_key() updated as each native
         # skill is deployed in the current install run.  Complements the lockfile-based
         # map so that same-manifest collisions are detected before the lockfile is written.
@@ -466,7 +472,7 @@ class SkillIntegrator(BaseIntegrator):
         return True
 
     @staticmethod
-    def _promote_sub_skills(sub_skills_dir: Path, target_skills_root: Path, parent_name: str, *, warn: bool = True, owned_by: dict[str, str] | None = None, diagnostics=None, managed_files=None, force: bool = False, project_root: Path | None = None, logger=None) -> tuple[int, list[Path]]:
+    def _promote_sub_skills(sub_skills_dir: Path, target_skills_root: Path, parent_name: str, *, warn: bool = True, owned_by: dict[str, str] | None = None, diagnostics=None, managed_files=None, force: bool = False, project_root: Path | None = None, logger=None, variables: dict[str, str] | None = None) -> tuple[int, list[Path]]:
         """Promote sub-skills from .apm/skills/ to top-level skill entries.
 
         Args:
@@ -566,6 +572,10 @@ class SkillIntegrator(BaseIntegrator):
                 shutil.rmtree(target)
             target.mkdir(parents=True, exist_ok=True)
             shutil.copytree(sub_skill_path, target, dirs_exist_ok=True)
+            # Apply ${var:...} substitution to copied text files
+            if variables:
+                from apm_cli.utils.variables import substitute_variables_in_directory
+                substitute_variables_in_directory(target, variables)
             promoted += 1
             deployed.append(target)
         return promoted, deployed
@@ -672,6 +682,7 @@ class SkillIntegrator(BaseIntegrator):
                 managed_files=managed_files if is_primary else None,
                 force=force,
                 project_root=project_root,
+                variables=self._variables or None,
             )
             if is_primary:
                 count = n
@@ -817,6 +828,10 @@ class SkillIntegrator(BaseIntegrator):
             target_skill_dir.parent.mkdir(parents=True, exist_ok=True)
             shutil.copytree(package_path, target_skill_dir,
                             ignore=shutil.ignore_patterns('.apm'))
+            # Apply ${var:...} substitution to copied text files
+            if self._variables:
+                from apm_cli.utils.variables import substitute_variables_in_directory
+                substitute_variables_in_directory(target_skill_dir, self._variables)
             all_target_paths.append(target_skill_dir)
 
             if is_primary:
@@ -833,6 +848,7 @@ class SkillIntegrator(BaseIntegrator):
                 force=force,
                 project_root=project_root,
                 logger=logger if is_primary else None,
+                variables=self._variables or None,
             )
             all_target_paths.extend(sub_deployed)
 

--- a/src/apm_cli/models/apm_package.py
+++ b/src/apm_cli/models/apm_package.py
@@ -9,7 +9,7 @@ compatibility.
 import yaml
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, List, Dict, Union
+from typing import Any, Optional, List, Dict, Union
 
 from .dependency import (
     DependencyReference,
@@ -75,6 +75,7 @@ class APMPackage:
     package_path: Optional[Path] = None  # Local path to package
     target: Optional[str] = None  # Target agent: vscode, claude, or all (applies to compile and install)
     type: Optional[PackageContentType] = None  # Package content type: instructions, skill, hybrid, or prompts
+    variables: Optional[Dict[str, Any]] = None  # Package variables (${var:...} substitution)
     
     @classmethod
     def from_apm_yml(cls, apm_yml_path: Path) -> "APMPackage":
@@ -208,6 +209,7 @@ class APMPackage:
             package_path=apm_yml_path.parent,
             target=data.get('target'),
             type=pkg_type,
+            variables=data.get('variables'),
         )
         _apm_yml_cache[resolved] = result
         return result

--- a/src/apm_cli/utils/variables.py
+++ b/src/apm_cli/utils/variables.py
@@ -1,0 +1,196 @@
+"""Package variable substitution for deployed primitives.
+
+Resolves ``${var:name}`` placeholders in primitive files at install time.
+Variables are declared in a package's ``apm.yml`` and can be overridden
+by the consuming project's ``apm.yml``.
+
+Resolution order (highest priority first):
+1. Consumer's ``apm.yml`` ``variables.<package-name>.<var-name>``
+2. Package's ``apm.yml`` ``variables.<var-name>.default``
+3. Leave ``${var:...}`` as-is (with a warning)
+"""
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Pattern matches ${var:name} where name is alphanumeric with hyphens/underscores
+VAR_PATTERN = re.compile(r'\$\{var:([a-zA-Z0-9_-]+)\}')
+
+# File extensions eligible for variable substitution
+_TEXT_EXTENSIONS = frozenset({
+    ".md", ".yml", ".yaml", ".json", ".toml", ".txt",
+})
+
+
+@dataclass
+class PackageVariable:
+    """Definition of a package variable declared in apm.yml."""
+
+    description: Optional[str] = None
+    default: Optional[str] = None
+    required: bool = False
+
+
+def parse_package_variables(
+    raw: Optional[Dict[str, Any]],
+) -> Dict[str, PackageVariable]:
+    """Parse the ``variables`` section from a package's own ``apm.yml``.
+
+    Accepts both shorthand (string value = default) and full object form.
+
+    Returns:
+        Mapping of variable name to PackageVariable.
+    """
+    if not raw:
+        return {}
+    result: Dict[str, PackageVariable] = {}
+    for name, value in raw.items():
+        if isinstance(value, str):
+            result[name] = PackageVariable(default=value)
+        elif isinstance(value, dict):
+            result[name] = PackageVariable(
+                description=value.get("description"),
+                default=value.get("default"),
+                required=bool(value.get("required", False)),
+            )
+        else:
+            logger.warning("Ignoring variable '%s': unsupported type %s", name, type(value).__name__)
+    return result
+
+
+def parse_consumer_overrides(
+    raw: Optional[Dict[str, Any]],
+) -> Dict[str, Dict[str, str]]:
+    """Parse the ``variables`` section from a consumer's ``apm.yml``.
+
+    The consumer format is keyed by package name::
+
+        variables:
+          tdd-development:
+            stack-profile: stack-ios-swift
+
+    Returns:
+        Mapping of package-name to variable-name -> override-value.
+    """
+    if not raw:
+        return {}
+    result: Dict[str, Dict[str, str]] = {}
+    for pkg_name, overrides in raw.items():
+        if isinstance(overrides, dict):
+            result[pkg_name] = {
+                k: str(v) for k, v in overrides.items() if isinstance(v, (str, int, float, bool))
+            }
+    return result
+
+
+def resolve_package_variables(
+    package_name: str,
+    package_variables: Dict[str, PackageVariable],
+    consumer_overrides: Dict[str, Dict[str, str]],
+) -> tuple:
+    """Resolve variables for a single package.
+
+    Args:
+        package_name: Name of the package being installed.
+        package_variables: Variable definitions from the package's apm.yml.
+        consumer_overrides: All consumer overrides (keyed by package name).
+
+    Returns:
+        Tuple of (resolved_dict, warnings, errors) where:
+        - resolved_dict maps variable name to resolved value
+        - warnings is a list of warning messages
+        - errors is a list of error messages (required variables missing)
+    """
+    resolved: Dict[str, str] = {}
+    warnings: List[str] = []
+    errors: List[str] = []
+
+    pkg_overrides = consumer_overrides.get(package_name, {})
+
+    for var_name, var_def in package_variables.items():
+        if var_name in pkg_overrides:
+            resolved[var_name] = pkg_overrides[var_name]
+        elif var_def.default is not None:
+            resolved[var_name] = var_def.default
+        elif var_def.required:
+            errors.append(
+                f"Required variable '{var_name}' for package '{package_name}' "
+                f"has no default and no consumer override. "
+                f"Add to your apm.yml: variables.{package_name}.{var_name}"
+            )
+        else:
+            warnings.append(
+                f"Variable '{var_name}' for package '{package_name}' is unresolved "
+                f"-- ${{{var_name}}} placeholders will be left as-is"
+            )
+
+    # Consumer may also provide overrides for variables NOT declared by the
+    # package.  Accept them silently -- they'll simply have no effect unless
+    # the file content uses a matching placeholder.
+    for var_name, value in pkg_overrides.items():
+        if var_name not in resolved:
+            resolved[var_name] = value
+
+    return resolved, warnings, errors
+
+
+def substitute_variables(content: str, variables: Dict[str, str]) -> str:
+    """Replace ``${var:name}`` placeholders with resolved values.
+
+    Unresolved placeholders are left as-is.
+    """
+    if not variables:
+        return content
+
+    def _replace(match: re.Match) -> str:
+        var_name = match.group(1)
+        if var_name in variables:
+            return variables[var_name]
+        return match.group(0)
+
+    return VAR_PATTERN.sub(_replace, content)
+
+
+def find_unresolved_variables(content: str) -> List[str]:
+    """Return a list of ``${var:...}`` placeholders still present in *content*."""
+    return VAR_PATTERN.findall(content)
+
+
+def is_substitutable_file(path: Path) -> bool:
+    """Return True if *path* is a text file eligible for variable substitution."""
+    return path.suffix.lower() in _TEXT_EXTENSIONS
+
+
+def substitute_variables_in_directory(
+    directory: Path,
+    variables: Dict[str, str],
+) -> int:
+    """Apply variable substitution to all eligible text files in *directory*.
+
+    Used for skill directories that are bulk-copied via ``shutil.copytree``.
+
+    Returns:
+        Number of files modified.
+    """
+    if not variables:
+        return 0
+    modified = 0
+    for file_path in directory.rglob("*"):
+        if not file_path.is_file():
+            continue
+        if not is_substitutable_file(file_path):
+            continue
+        try:
+            content = file_path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        new_content = substitute_variables(content, variables)
+        if new_content != content:
+            file_path.write_text(new_content, encoding="utf-8")
+            modified += 1
+    return modified

--- a/tests/unit/test_package_variables.py
+++ b/tests/unit/test_package_variables.py
@@ -1,0 +1,425 @@
+"""Tests for package variable substitution (${var:...})."""
+
+import pytest
+from pathlib import Path
+
+from apm_cli.utils.variables import (
+    PackageVariable,
+    parse_package_variables,
+    parse_consumer_overrides,
+    resolve_package_variables,
+    substitute_variables,
+    find_unresolved_variables,
+    is_substitutable_file,
+    substitute_variables_in_directory,
+    VAR_PATTERN,
+)
+
+
+# ---------------------------------------------------------------------------
+# VAR_PATTERN regex
+# ---------------------------------------------------------------------------
+
+class TestVarPattern:
+    def test_matches_simple_name(self):
+        assert VAR_PATTERN.search("${var:stack-profile}")
+
+    def test_matches_underscore(self):
+        assert VAR_PATTERN.search("${var:my_var}")
+
+    def test_matches_digits(self):
+        assert VAR_PATTERN.search("${var:var123}")
+
+    def test_no_match_input_namespace(self):
+        assert not VAR_PATTERN.search("${input:prompt}")
+
+    def test_no_match_empty_name(self):
+        assert not VAR_PATTERN.search("${var:}")
+
+    def test_no_match_spaces(self):
+        assert not VAR_PATTERN.search("${var:has space}")
+
+
+# ---------------------------------------------------------------------------
+# parse_package_variables
+# ---------------------------------------------------------------------------
+
+class TestParsePackageVariables:
+    def test_none_input(self):
+        assert parse_package_variables(None) == {}
+
+    def test_empty_dict(self):
+        assert parse_package_variables({}) == {}
+
+    def test_shorthand_string(self):
+        result = parse_package_variables({"stack": "react"})
+        assert result["stack"].default == "react"
+        assert result["stack"].required is False
+
+    def test_full_object(self):
+        result = parse_package_variables({
+            "stack": {
+                "description": "Stack profile",
+                "default": "react",
+                "required": False,
+            }
+        })
+        assert result["stack"].description == "Stack profile"
+        assert result["stack"].default == "react"
+        assert result["stack"].required is False
+
+    def test_required_no_default(self):
+        result = parse_package_variables({
+            "stack": {
+                "description": "Stack profile",
+                "required": True,
+            }
+        })
+        assert result["stack"].required is True
+        assert result["stack"].default is None
+
+    def test_mixed_formats(self):
+        result = parse_package_variables({
+            "simple": "value",
+            "complex": {"default": "other", "description": "desc"},
+        })
+        assert len(result) == 2
+        assert result["simple"].default == "value"
+        assert result["complex"].default == "other"
+
+    def test_ignores_invalid_types(self):
+        result = parse_package_variables({"bad": 42})
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# parse_consumer_overrides
+# ---------------------------------------------------------------------------
+
+class TestParseConsumerOverrides:
+    def test_none_input(self):
+        assert parse_consumer_overrides(None) == {}
+
+    def test_empty_dict(self):
+        assert parse_consumer_overrides({}) == {}
+
+    def test_single_package_override(self):
+        result = parse_consumer_overrides({
+            "tdd-development": {"stack-profile": "stack-ios-swift"}
+        })
+        assert result["tdd-development"]["stack-profile"] == "stack-ios-swift"
+
+    def test_multiple_packages(self):
+        result = parse_consumer_overrides({
+            "pkg-a": {"var1": "val1"},
+            "pkg-b": {"var2": "val2"},
+        })
+        assert len(result) == 2
+        assert result["pkg-a"]["var1"] == "val1"
+        assert result["pkg-b"]["var2"] == "val2"
+
+    def test_coerces_non_string_values(self):
+        result = parse_consumer_overrides({
+            "pkg": {"num": 42, "flag": True}
+        })
+        assert result["pkg"]["num"] == "42"
+        assert result["pkg"]["flag"] == "True"
+
+    def test_ignores_non_dict_package_overrides(self):
+        result = parse_consumer_overrides({"pkg": "not-a-dict"})
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# resolve_package_variables
+# ---------------------------------------------------------------------------
+
+class TestResolvePackageVariables:
+    def test_consumer_override_wins(self):
+        pkg_vars = {"stack": PackageVariable(default="react")}
+        consumer = {"my-pkg": {"stack": "ios-swift"}}
+        resolved, warnings, errors = resolve_package_variables("my-pkg", pkg_vars, consumer)
+        assert resolved["stack"] == "ios-swift"
+        assert not warnings
+        assert not errors
+
+    def test_default_used_when_no_override(self):
+        pkg_vars = {"stack": PackageVariable(default="react")}
+        resolved, warnings, errors = resolve_package_variables("my-pkg", pkg_vars, {})
+        assert resolved["stack"] == "react"
+        assert not warnings
+        assert not errors
+
+    def test_required_no_default_no_override_errors(self):
+        pkg_vars = {"stack": PackageVariable(required=True)}
+        resolved, warnings, errors = resolve_package_variables("my-pkg", pkg_vars, {})
+        assert "stack" not in resolved
+        assert len(errors) == 1
+        assert "Required variable" in errors[0]
+
+    def test_no_default_not_required_warns(self):
+        pkg_vars = {"stack": PackageVariable()}
+        resolved, warnings, errors = resolve_package_variables("my-pkg", pkg_vars, {})
+        assert "stack" not in resolved
+        assert len(warnings) == 1
+        assert "unresolved" in warnings[0]
+        assert not errors
+
+    def test_consumer_override_for_undeclared_variable(self):
+        pkg_vars = {}
+        consumer = {"my-pkg": {"extra-var": "value"}}
+        resolved, _, _ = resolve_package_variables("my-pkg", pkg_vars, consumer)
+        assert resolved["extra-var"] == "value"
+
+    def test_scoped_by_package_name(self):
+        pkg_vars = {"stack": PackageVariable(default="react")}
+        consumer = {"other-pkg": {"stack": "ios"}}
+        resolved, _, _ = resolve_package_variables("my-pkg", pkg_vars, consumer)
+        assert resolved["stack"] == "react"  # other-pkg override does not apply
+
+    def test_multiple_variables(self):
+        pkg_vars = {
+            "stack": PackageVariable(default="react"),
+            "lang": PackageVariable(default="typescript"),
+        }
+        consumer = {"pkg": {"stack": "ios-swift"}}
+        resolved, _, _ = resolve_package_variables("pkg", pkg_vars, consumer)
+        assert resolved["stack"] == "ios-swift"
+        assert resolved["lang"] == "typescript"
+
+
+# ---------------------------------------------------------------------------
+# substitute_variables
+# ---------------------------------------------------------------------------
+
+class TestSubstituteVariables:
+    def test_single_substitution(self):
+        content = "Invoke skill: `${var:stack-profile}`"
+        result = substitute_variables(content, {"stack-profile": "ios-swift"})
+        assert result == "Invoke skill: `ios-swift`"
+
+    def test_multiple_substitutions(self):
+        content = "${var:a} and ${var:b}"
+        result = substitute_variables(content, {"a": "X", "b": "Y"})
+        assert result == "X and Y"
+
+    def test_unresolved_left_as_is(self):
+        content = "${var:missing}"
+        result = substitute_variables(content, {"other": "value"})
+        assert result == "${var:missing}"
+
+    def test_empty_variables_dict(self):
+        content = "${var:name}"
+        result = substitute_variables(content, {})
+        assert result == "${var:name}"
+
+    def test_no_variables_in_content(self):
+        content = "Plain text with no variables"
+        result = substitute_variables(content, {"key": "value"})
+        assert result == content
+
+    def test_variable_in_yaml_frontmatter(self):
+        content = "---\nskills:\n  - ${var:stack-profile}\n---\nBody text"
+        result = substitute_variables(content, {"stack-profile": "react-app"})
+        assert "react-app" in result
+        assert "${var:stack-profile}" not in result
+
+    def test_same_variable_multiple_times(self):
+        content = "${var:name} is ${var:name}"
+        result = substitute_variables(content, {"name": "foo"})
+        assert result == "foo is foo"
+
+    def test_does_not_substitute_input_vars(self):
+        content = "${input:prompt} ${var:name}"
+        result = substitute_variables(content, {"name": "X", "prompt": "Y"})
+        assert result == "${input:prompt} X"
+
+    def test_hyphen_in_variable_name(self):
+        content = "${var:my-var}"
+        result = substitute_variables(content, {"my-var": "value"})
+        assert result == "value"
+
+    def test_underscore_in_variable_name(self):
+        content = "${var:my_var}"
+        result = substitute_variables(content, {"my_var": "value"})
+        assert result == "value"
+
+
+# ---------------------------------------------------------------------------
+# find_unresolved_variables
+# ---------------------------------------------------------------------------
+
+class TestFindUnresolvedVariables:
+    def test_no_variables(self):
+        assert find_unresolved_variables("plain text") == []
+
+    def test_finds_variables(self):
+        content = "${var:a} text ${var:b}"
+        result = find_unresolved_variables(content)
+        assert set(result) == {"a", "b"}
+
+    def test_finds_single(self):
+        assert find_unresolved_variables("${var:name}") == ["name"]
+
+
+# ---------------------------------------------------------------------------
+# is_substitutable_file
+# ---------------------------------------------------------------------------
+
+class TestIsSubstitutableFile:
+    @pytest.mark.parametrize("suffix", [".md", ".yml", ".yaml", ".json", ".toml", ".txt"])
+    def test_text_files(self, suffix):
+        assert is_substitutable_file(Path(f"file{suffix}"))
+
+    @pytest.mark.parametrize("suffix", [".py", ".png", ".exe", ".bin", ".zip"])
+    def test_non_text_files(self, suffix):
+        assert not is_substitutable_file(Path(f"file{suffix}"))
+
+    def test_case_insensitive(self):
+        assert is_substitutable_file(Path("FILE.MD"))
+
+
+# ---------------------------------------------------------------------------
+# substitute_variables_in_directory
+# ---------------------------------------------------------------------------
+
+class TestSubstituteVariablesInDirectory:
+    def test_substitutes_in_md_files(self, tmp_path):
+        (tmp_path / "SKILL.md").write_text("Skill: ${var:name}", encoding="utf-8")
+        modified = substitute_variables_in_directory(tmp_path, {"name": "react"})
+        assert modified == 1
+        assert (tmp_path / "SKILL.md").read_text(encoding="utf-8") == "Skill: react"
+
+    def test_skips_non_text_files(self, tmp_path):
+        (tmp_path / "script.py").write_text("${var:name}", encoding="utf-8")
+        modified = substitute_variables_in_directory(tmp_path, {"name": "react"})
+        assert modified == 0
+        assert "${var:name}" in (tmp_path / "script.py").read_text(encoding="utf-8")
+
+    def test_no_variables_returns_zero(self, tmp_path):
+        (tmp_path / "SKILL.md").write_text("No variables here", encoding="utf-8")
+        modified = substitute_variables_in_directory(tmp_path, {"name": "react"})
+        assert modified == 0
+
+    def test_empty_variables_returns_zero(self, tmp_path):
+        (tmp_path / "SKILL.md").write_text("${var:name}", encoding="utf-8")
+        modified = substitute_variables_in_directory(tmp_path, {})
+        assert modified == 0
+
+    def test_recursive_subdirectories(self, tmp_path):
+        sub = tmp_path / "refs"
+        sub.mkdir()
+        (sub / "ref.md").write_text("Use ${var:tool}", encoding="utf-8")
+        modified = substitute_variables_in_directory(tmp_path, {"tool": "pytest"})
+        assert modified == 1
+        assert "pytest" in (sub / "ref.md").read_text(encoding="utf-8")
+
+    def test_multiple_files(self, tmp_path):
+        (tmp_path / "a.md").write_text("${var:x}", encoding="utf-8")
+        (tmp_path / "b.yml").write_text("key: ${var:x}", encoding="utf-8")
+        (tmp_path / "c.py").write_text("${var:x}", encoding="utf-8")
+        modified = substitute_variables_in_directory(tmp_path, {"x": "val"})
+        assert modified == 2  # .md and .yml, not .py
+
+
+# ---------------------------------------------------------------------------
+# APMPackage.variables field
+# ---------------------------------------------------------------------------
+
+class TestAPMPackageVariables:
+    def test_variables_parsed_from_yml(self, tmp_path):
+        apm_yml = tmp_path / "apm.yml"
+        apm_yml.write_text(
+            "name: test-pkg\n"
+            "version: 1.0.0\n"
+            "variables:\n"
+            "  stack-profile:\n"
+            "    description: Stack profile\n"
+            "    default: react\n",
+            encoding="utf-8",
+        )
+        from apm_cli.models.apm_package import APMPackage, clear_apm_yml_cache
+        clear_apm_yml_cache()
+        pkg = APMPackage.from_apm_yml(apm_yml)
+        assert pkg.variables is not None
+        assert "stack-profile" in pkg.variables
+        assert pkg.variables["stack-profile"]["default"] == "react"
+
+    def test_variables_none_when_absent(self, tmp_path):
+        apm_yml = tmp_path / "apm.yml"
+        apm_yml.write_text("name: test-pkg\nversion: 1.0.0\n", encoding="utf-8")
+        from apm_cli.models.apm_package import APMPackage, clear_apm_yml_cache
+        clear_apm_yml_cache()
+        pkg = APMPackage.from_apm_yml(apm_yml)
+        assert pkg.variables is None
+
+    def test_consumer_variables_parsed(self, tmp_path):
+        apm_yml = tmp_path / "apm.yml"
+        apm_yml.write_text(
+            "name: my-app\n"
+            "version: 1.0.0\n"
+            "variables:\n"
+            "  tdd-development:\n"
+            "    stack-profile: ios-swift\n",
+            encoding="utf-8",
+        )
+        from apm_cli.models.apm_package import APMPackage, clear_apm_yml_cache
+        clear_apm_yml_cache()
+        pkg = APMPackage.from_apm_yml(apm_yml)
+        assert pkg.variables["tdd-development"]["stack-profile"] == "ios-swift"
+
+
+# ---------------------------------------------------------------------------
+# LockedDependency.resolved_variables
+# ---------------------------------------------------------------------------
+
+class TestLockedDependencyVariables:
+    def test_serialization_round_trip(self):
+        from apm_cli.deps.lockfile import LockedDependency
+        dep = LockedDependency(
+            repo_url="owner/repo",
+            resolved_variables={"stack": "ios-swift", "lang": "swift"},
+        )
+        d = dep.to_dict()
+        assert d["resolved_variables"] == {"lang": "swift", "stack": "ios-swift"}
+
+        restored = LockedDependency.from_dict(d)
+        assert restored.resolved_variables == {"lang": "swift", "stack": "ios-swift"}
+
+    def test_no_variables_omitted_from_dict(self):
+        from apm_cli.deps.lockfile import LockedDependency
+        dep = LockedDependency(repo_url="owner/repo")
+        d = dep.to_dict()
+        assert "resolved_variables" not in d
+
+    def test_empty_variables_omitted_from_dict(self):
+        from apm_cli.deps.lockfile import LockedDependency
+        dep = LockedDependency(repo_url="owner/repo", resolved_variables={})
+        d = dep.to_dict()
+        assert "resolved_variables" not in d
+
+
+# ---------------------------------------------------------------------------
+# BaseIntegrator variable substitution
+# ---------------------------------------------------------------------------
+
+class TestBaseIntegratorVariables:
+    def test_set_and_apply_variables(self):
+        from apm_cli.integration.base_integrator import BaseIntegrator
+        integrator = BaseIntegrator()
+        integrator.set_variables({"name": "react"})
+        result = integrator.apply_variable_substitution("Use ${var:name}")
+        assert result == "Use react"
+
+    def test_no_variables_set(self):
+        from apm_cli.integration.base_integrator import BaseIntegrator
+        integrator = BaseIntegrator()
+        result = integrator.apply_variable_substitution("Use ${var:name}")
+        assert result == "Use ${var:name}"
+
+    def test_set_empty_variables(self):
+        from apm_cli.integration.base_integrator import BaseIntegrator
+        integrator = BaseIntegrator()
+        integrator.set_variables({})
+        result = integrator.apply_variable_substitution("Use ${var:name}")
+        assert result == "Use ${var:name}"


### PR DESCRIPTION
Hello! APM team. This a feature I think would be super helpful to make apm a little more modular for abstractions of agents for installing. Please let me know what you think would be happy to make some changes.

## Summary

Adds support for declaring and resolving variables in APM packages. Package authors can define `${var:name}` placeholders in their primitive files, declare variables with defaults in `apm.yml`, and consumers can override values per-dependency. Variables are resolved at install time and substituted into all deployed text-based primitives.

## Motivation

Packages often need to be customizable without requiring consumers to fork or manually edit files after install. Variables provide a first-class mechanism for parameterization -- things like model names, API endpoints, project-specific paths, or behavioral toggles can be exposed as named variables with sensible defaults.

## How it works

1. **Declaration** -- Package authors add a `variables` section to `apm.yml` with names, defaults, and optional descriptions.
2. **Usage** -- Authors place `${var:name}` placeholders anywhere in their primitive text files (instructions, prompts, agents, skills, commands).
3. **Override** -- Consumers specify per-package variable values in their own `apm.yml` under `dependencies[].variables`.
4. **Resolution** -- At install time, APM resolves each variable (consumer override > package default) and substitutes placeholders in all deployed files.
5. **Lockfile** -- Resolved values are recorded in `apm-lock.yml` for reproducibility.

## Changes

- New `src/apm_cli/utils/variables.py` -- substitution engine (pattern matching, resolution, file walking)
- `models/apm_package.py` -- `variables` field on `APMPackage`
- `deps/lockfile.py` -- `resolved_variables` on `LockedDependency`
- `integration/base_integrator.py` -- `set_variables()` / `apply_variable_substitution()` on base class
- All integrators (agent, instruction, prompt, command, skill) -- apply substitution during deploy
- `commands/install.py` -- resolve variables per-package and thread through integration
- 66 new unit tests in `tests/unit/test_package_variables.py`
- Documentation: manifest schema reference, dependencies guide, package authoring skill, CHANGELOG
