### PR TITLE
fix(init): create start.prompt.md on init and fix next-steps guidance

### DIFF
--- a/src/apm_cli/commands/_helpers.py
+++ b/src/apm_cli/commands/_helpers.py
@@ -21,8 +21,8 @@ from ..constants import (
     GITIGNORE_FILENAME,
 )
 from ..utils.console import _rich_echo, _rich_info, _rich_warning
-from ..version import get_build_sha, get_version
 from ..utils.version_checker import check_for_updates
+from ..version import get_build_sha, get_version
 
 # CRITICAL: Shadow Click commands at module level to prevent namespace collision
 # When Click commands like 'config set' are defined, calling set() can invoke the command
@@ -114,7 +114,10 @@ def _lazy_confirm():
 # Shared orphan-detection helpers
 # ------------------------------------------------------------------
 
-def _build_expected_install_paths(declared_deps, lockfile, apm_modules_dir: Path) -> set:
+
+def _build_expected_install_paths(
+    declared_deps, lockfile, apm_modules_dir: Path
+) -> set:
     """Build expected package paths under *apm_modules_dir*.
 
     Combines direct deps (from ``apm.yml``) with transitive deps
@@ -165,7 +168,9 @@ def _scan_installed_packages(apm_modules_dir: Path) -> list:
     for candidate in apm_modules_dir.rglob("*"):
         if not candidate.is_dir() or candidate.name.startswith("."):
             continue
-        if not ((candidate / APM_YML_FILENAME).exists() or (candidate / APM_DIR).exists()):
+        if not (
+            (candidate / APM_YML_FILENAME).exists() or (candidate / APM_DIR).exists()
+        ):
             continue
         rel_parts = candidate.relative_to(apm_modules_dir).parts
         if len(rel_parts) >= 2:
@@ -192,13 +197,15 @@ def _check_orphaned_packages():
             return []
 
         try:
-            from ..models.apm_package import APMPackage
             from ..deps.lockfile import LockFile, get_lockfile_path
+            from ..models.apm_package import APMPackage
 
             apm_package = APMPackage.from_apm_yml(Path(APM_YML_FILENAME))
             declared_deps = apm_package.get_apm_dependencies()
             lockfile = LockFile.read(get_lockfile_path(Path.cwd()))
-            expected = _build_expected_install_paths(declared_deps, lockfile, apm_modules_dir)
+            expected = _build_expected_install_paths(
+                declared_deps, lockfile, apm_modules_dir
+            )
         except Exception:
             return []
 
@@ -329,10 +336,12 @@ def _update_gitignore_for_apm_modules(logger=None):
 # Script / config helpers (shared by run, list, config commands)
 # ------------------------------------------------------------------
 
+
 def _load_apm_config():
     """Load configuration from apm.yml."""
     if Path(APM_YML_FILENAME).exists():
         from ..utils.yaml_io import load_yaml
+
         return load_yaml(APM_YML_FILENAME)
     return None
 
@@ -357,13 +366,18 @@ def _list_available_scripts():
 # Init helpers (shared by init and install commands)
 # ------------------------------------------------------------------
 
+
 def _auto_detect_author():
     """Auto-detect author from git config."""
     import subprocess
 
     try:
         result = subprocess.run(
-            ["git", "config", "user.name"], capture_output=True, text=True, encoding="utf-8", timeout=5
+            ["git", "config", "user.name"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=5,
         )
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip()
@@ -458,5 +472,22 @@ def _create_minimal_apm_yml(config, plugin=False, target_path=None):
 
     # Write apm.yml
     from ..utils.yaml_io import dump_yaml
+
     out_path = target_path or APM_YML_FILENAME
     dump_yaml(apm_yml_data, out_path)
+
+    if not plugin:
+        prompt_path = (
+            Path(out_path).parent / "start.prompt.md"
+            if target_path
+            else Path("start.prompt.md")
+        )
+        if not prompt_path.exists():
+            prompt_path.write_text(
+                "# Start\n\n"
+                "Write your agent instructions here.\n\n"
+                "## Parameters\n\n"
+                "You can pass parameters with `${input:param_name}` syntax.\n"
+                "Example: Hello, ${input:name}!\n",
+                encoding="utf-8",
+            )

--- a/src/apm_cli/commands/init.py
+++ b/src/apm_cli/commands/init.py
@@ -19,7 +19,6 @@ from ._helpers import (
     _create_plugin_json,
     _get_console,
     _get_default_config,
-    _lazy_confirm,
     _rich_blank_line,
     _validate_plugin_name,
 )
@@ -28,10 +27,15 @@ from ._helpers import (
 @click.command(help="Initialize a new APM project")
 @click.argument("project_name", required=False)
 @click.option(
-    "--yes", "-y", is_flag=True, help="Skip interactive prompts and use auto-detected defaults"
+    "--yes",
+    "-y",
+    is_flag=True,
+    help="Skip interactive prompts and use auto-detected defaults",
 )
 @click.option(
-    "--plugin", is_flag=True, help="Initialize as plugin author (creates plugin.json + apm.yml)"
+    "--plugin",
+    is_flag=True,
+    help="Initialize as plugin author (creates plugin.json + apm.yml)",
 )
 @click.option("--verbose", "-v", is_flag=True, help="Show detailed output")
 @click.pass_context
@@ -52,7 +56,9 @@ def init(ctx, project_name, yes, plugin, verbose):
             project_dir = Path(project_name)
             project_dir.mkdir(exist_ok=True)
             os.chdir(project_dir)
-            logger.progress(f"Created project directory: {project_name}", symbol="folder")
+            logger.progress(
+                f"Created project directory: {project_name}", symbol="folder"
+            )
             final_project_name = project_name
         else:
             project_dir = Path.cwd()
@@ -75,16 +81,7 @@ def init(ctx, project_name, yes, plugin, verbose):
             logger.warning("apm.yml already exists")
 
             if not yes:
-                Confirm = _lazy_confirm()
-                if Confirm:
-                    try:
-                        confirm = Confirm.ask("Continue and overwrite?")
-                    except Exception:
-                        confirm = click.confirm("Continue and overwrite?")
-                else:
-                    confirm = click.confirm("Continue and overwrite?")
-
-                if not confirm:
+                if not click.confirm("Continue and overwrite?"):
                     logger.progress("Initialization cancelled.")
                     return
             else:
@@ -121,6 +118,14 @@ def init(ctx, project_name, yes, plugin, verbose):
                 ]
                 if plugin:
                     files_data.append(("*", "plugin.json", "Plugin metadata"))
+                else:
+                    files_data.append(
+                        (
+                            "*",
+                            "start.prompt.md",
+                            "Starter prompt -- edit with your instructions",
+                        )
+                    )
                 table = _create_files_table(files_data, title="Created Files")
                 console.print(table)
         except (ImportError, NameError):
@@ -128,6 +133,10 @@ def init(ctx, project_name, yes, plugin, verbose):
             click.echo("  * apm.yml - Project configuration")
             if plugin:
                 click.echo("  * plugin.json - Plugin metadata")
+            else:
+                click.echo(
+                    "  * start.prompt.md - Starter prompt -- edit with your instructions"
+                )
 
         _rich_blank_line()
 
@@ -140,8 +149,7 @@ def init(ctx, project_name, yes, plugin, verbose):
         else:
             next_steps = [
                 "Install a runtime:       apm runtime setup copilot",
-                "Add APM dependencies:    apm install <owner>/<repo>",
-                "Compile agent context:   apm compile",
+                "Edit your prompt:        open start.prompt.md and write your instructions",
                 "Run your first workflow: apm run start",
             ]
 

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -1,13 +1,14 @@
 """Tests for the apm init command."""
 
 import json
-import pytest
-import tempfile
 import os
-import yaml
+import tempfile
 from pathlib import Path
-from click.testing import CliRunner
 from unittest.mock import patch
+
+import pytest
+import yaml
+from click.testing import CliRunner
 
 from apm_cli.cli import cli
 
@@ -36,7 +37,7 @@ class TestInitCommand:
             os.chdir(str(repo_root))
 
     def test_init_current_directory(self):
-        """Test initialization in current directory (minimal mode)."""
+        """Test initialization in current directory."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             os.chdir(tmp_dir)
             try:
@@ -46,15 +47,18 @@ class TestInitCommand:
                 assert result.exit_code == 0
                 assert "APM project initialized successfully!" in result.output
                 assert Path("apm.yml").exists()
-                # Minimal mode: no template files created
+                # starter prompt created so users can immediately run `apm run start`
+                assert Path("start.prompt.md").exists()
                 assert not Path("hello-world.prompt.md").exists()
                 assert not Path("README.md").exists()
                 assert not Path(".apm").exists()
             finally:
-                os.chdir(self.original_dir)  # restore CWD before TemporaryDirectory cleanup
+                os.chdir(
+                    self.original_dir
+                )  # restore CWD before TemporaryDirectory cleanup
 
     def test_init_explicit_current_directory(self):
-        """Test initialization with explicit '.' argument (minimal mode)."""
+        """Test initialization with explicit '.' argument."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             os.chdir(tmp_dir)
             try:
@@ -64,13 +68,15 @@ class TestInitCommand:
                 assert result.exit_code == 0
                 assert "APM project initialized successfully!" in result.output
                 assert Path("apm.yml").exists()
-                # Minimal mode: no template files created
+                assert Path("start.prompt.md").exists()
                 assert not Path("hello-world.prompt.md").exists()
             finally:
-                os.chdir(self.original_dir)  # restore CWD before TemporaryDirectory cleanup
+                os.chdir(
+                    self.original_dir
+                )  # restore CWD before TemporaryDirectory cleanup
 
     def test_init_new_directory(self):
-        """Test initialization in new directory (minimal mode)."""
+        """Test initialization in new directory."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             os.chdir(tmp_dir)
             try:
@@ -84,12 +90,14 @@ class TestInitCommand:
                 assert project_path.exists()
                 assert project_path.is_dir()
                 assert (project_path / "apm.yml").exists()
-                # Minimal mode: no template files created
+                assert (project_path / "start.prompt.md").exists()
                 assert not (project_path / "hello-world.prompt.md").exists()
                 assert not (project_path / "README.md").exists()
                 assert not (project_path / ".apm").exists()
             finally:
-                os.chdir(self.original_dir)  # restore CWD before TemporaryDirectory cleanup
+                os.chdir(
+                    self.original_dir
+                )  # restore CWD before TemporaryDirectory cleanup
 
     def test_init_existing_project_without_force(self):
         """Test initialization over existing apm.yml without --force (removed flag)."""
@@ -107,7 +115,9 @@ class TestInitCommand:
                 assert "apm.yml already exists" in result.output
                 assert "--yes specified, overwriting apm.yml..." in result.output
             finally:
-                os.chdir(self.original_dir)  # restore CWD before TemporaryDirectory cleanup
+                os.chdir(
+                    self.original_dir
+                )  # restore CWD before TemporaryDirectory cleanup
 
     def test_init_existing_project_with_force(self):
         """Test initialization over existing apm.yml (--force flag removed, behavior same as --yes)."""
@@ -131,7 +141,9 @@ class TestInitCommand:
                     assert "scripts" in config
                     assert config["scripts"] == {}
             finally:
-                os.chdir(self.original_dir)  # restore CWD before TemporaryDirectory cleanup
+                os.chdir(
+                    self.original_dir
+                )  # restore CWD before TemporaryDirectory cleanup
 
     def test_init_preserves_existing_config(self):
         """Test that init with --yes overwrites existing apm.yml (no merge in minimal mode)."""
@@ -155,7 +167,9 @@ class TestInitCommand:
                 # Minimal mode: overwrites with auto-detected values
                 assert "apm.yml already exists" in result.output
             finally:
-                os.chdir(self.original_dir)  # restore CWD before TemporaryDirectory cleanup
+                os.chdir(
+                    self.original_dir
+                )  # restore CWD before TemporaryDirectory cleanup
 
     def test_init_interactive_mode(self):
         """Test interactive mode with user input."""
@@ -164,7 +178,9 @@ class TestInitCommand:
             try:
 
                 # Simulate user input
-                user_input = "my-test-project\n1.5.0\nTest description\nTest Author\ny\n"
+                user_input = (
+                    "my-test-project\n1.5.0\nTest description\nTest Author\ny\n"
+                )
 
                 result = self.runner.invoke(cli, ["init"], input=user_input)
 
@@ -183,7 +199,9 @@ class TestInitCommand:
                     assert config["description"] == "Test description"
                     assert config["author"] == "Test Author"
             finally:
-                os.chdir(self.original_dir)  # restore CWD before TemporaryDirectory cleanup
+                os.chdir(
+                    self.original_dir
+                )  # restore CWD before TemporaryDirectory cleanup
 
     def test_init_interactive_mode_abort(self):
         """Test aborting interactive mode."""
@@ -192,7 +210,9 @@ class TestInitCommand:
             try:
 
                 # Simulate user input with 'no' to confirmation
-                user_input = "my-test-project\n1.5.0\nTest description\nTest Author\nn\n"
+                user_input = (
+                    "my-test-project\n1.5.0\nTest description\nTest Author\nn\n"
+                )
 
                 result = self.runner.invoke(cli, ["init"], input=user_input)
 
@@ -200,7 +220,9 @@ class TestInitCommand:
                 assert "Aborted" in result.output
                 assert not Path("apm.yml").exists()
             finally:
-                os.chdir(self.original_dir)  # restore CWD before TemporaryDirectory cleanup
+                os.chdir(
+                    self.original_dir
+                )  # restore CWD before TemporaryDirectory cleanup
 
     def test_init_existing_project_interactive_cancel(self):
         """Test cancelling when existing apm.yml detected in interactive mode."""
@@ -218,10 +240,12 @@ class TestInitCommand:
                 assert "apm.yml already exists" in result.output
                 assert "Initialization cancelled" in result.output
             finally:
-                os.chdir(self.original_dir)  # restore CWD before TemporaryDirectory cleanup
+                os.chdir(
+                    self.original_dir
+                )  # restore CWD before TemporaryDirectory cleanup
 
     def test_init_validates_project_structure(self):
-        """Test that init creates minimal project structure."""
+        """Test that init creates expected project structure."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             os.chdir(tmp_dir)
             try:
@@ -233,7 +257,7 @@ class TestInitCommand:
                 # Use absolute path for checking files
                 project_path = Path(tmp_dir) / "test-project"
 
-                # Verify apm.yml minimal structure
+                # Verify apm.yml structure
                 with open(project_path / "apm.yml", encoding="utf-8") as f:
                     config = yaml.safe_load(f)
                     assert config["name"] == "test-project"
@@ -243,12 +267,15 @@ class TestInitCommand:
                     assert "scripts" in config
                     assert config["scripts"] == {}
 
-                # Minimal mode: no template files created
+                # starter prompt created for immediate use
+                assert (project_path / "start.prompt.md").exists()
                 assert not (project_path / "hello-world.prompt.md").exists()
                 assert not (project_path / "README.md").exists()
                 assert not (project_path / ".apm").exists()
             finally:
-                os.chdir(self.original_dir)  # restore CWD before TemporaryDirectory cleanup
+                os.chdir(
+                    self.original_dir
+                )  # restore CWD before TemporaryDirectory cleanup
 
     def test_init_auto_detection(self):
         """Test auto-detection of project metadata."""
@@ -280,10 +307,12 @@ class TestInitCommand:
                     # Should auto-detect description
                     assert "APM project" in config["description"]
             finally:
-                os.chdir(self.original_dir)  # restore CWD before TemporaryDirectory cleanup
+                os.chdir(
+                    self.original_dir
+                )  # restore CWD before TemporaryDirectory cleanup
 
     def test_init_does_not_create_skill_md(self):
-        """Test that init does not create SKILL.md (only apm.yml)."""
+        """Test that init does not create SKILL.md."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             os.chdir(tmp_dir)
             try:
@@ -292,10 +321,38 @@ class TestInitCommand:
 
                 assert result.exit_code == 0
                 assert Path("apm.yml").exists()
+                assert Path("start.prompt.md").exists()
                 assert not Path("SKILL.md").exists()
             finally:
-                os.chdir(self.original_dir)  # restore CWD before TemporaryDirectory cleanup
+                os.chdir(
+                    self.original_dir
+                )  # restore CWD before TemporaryDirectory cleanup
 
+    def test_init_starter_prompt_not_overwritten(self):
+        """Test that re-running init does not overwrite an existing start.prompt.md."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.chdir(tmp_dir)
+            try:
+                result = self.runner.invoke(cli, ["init", "--yes"])
+                assert result.exit_code == 0
+                assert Path("start.prompt.md").exists()
+
+                # Write custom content to the starter prompt
+                Path("start.prompt.md").write_text(
+                    "# My custom instructions\n", encoding="utf-8"
+                )
+
+                # Re-run init (overwriting apm.yml)
+                result = self.runner.invoke(cli, ["init", "--yes"])
+                assert result.exit_code == 0
+
+                # Custom content should be preserved
+                assert (
+                    Path("start.prompt.md").read_text(encoding="utf-8")
+                    == "# My custom instructions\n"
+                )
+            finally:
+                os.chdir(self.original_dir)
 
 
 class TestPluginNameValidation:


### PR DESCRIPTION
Closes #747

## What

**Before:** `apm init` created only `apm.yml`. Running `apm run start` immediately after would fail with _prompt file not found_. The "Next Steps" panel also listed `apm install` and `apm compile`, neither of which is required for a basic first run.

**After:** `apm init` creates `start.prompt.md` alongside `apm.yml`. Next Steps now shows the three essential steps: install a runtime, edit the prompt, run.

```diff
- next_steps = [
-     "Install a runtime:       apm runtime setup copilot",
-     "Add APM dependencies:    apm install <owner>/<repo>",
-     "Compile agent context:   apm compile",
-     "Run your first workflow: apm run start",
- ]
+ next_steps = [
+     "Install a runtime:       apm runtime setup copilot",
+     "Edit your prompt:        open start.prompt.md and write your instructions",
+     "Run your first workflow: apm run start",
+ ]
```

## Why

The root problem is that `apm run start` looks for `start.prompt.md` to exist, so `apm init` leaving it absent breaks the advertised end-to-end flow. `apm install` and `apm compile` are listed as if required but a fresh project with a single prompt file needs neither.

The overwrite-confirm path used `_lazy_confirm()` with a bare `except Exception` fallback; replacing it with `click.confirm()` (consistent with the rest of the fallback paths in the same file) avoids swallowing unexpected exceptions.

## How

- `_helpers._create_minimal_apm_yml()`: after writing `apm.yml`, write `start.prompt.md` with a template if it does not yet exist. Skipped for `--plugin` mode (matches the existing pattern where plugin projects don't receive a starter prompt). Pattern mirrors the `_create_plugin_json()` neighbour: create once, never overwrite.
- `init.py`: add `start.prompt.md` to the "Created Files" table (both rich and plain-text paths). Fix next-steps list. Replace `_lazy_confirm()` block with `click.confirm()`.

Reference: `src/apm_cli/commands/_helpers.py` — `_create_plugin_json()` uses the same "create if not exists" pattern for `plugin.json`.

## Test

```
pytest tests/unit/test_init_command.py    15/15  pass  (Python 3.13, Windows 11)
pytest tests/unit/                       3865/3865  pass  (no regression)
```

New test `test_init_starter_prompt_not_overwritten` verifies that re-running `apm init --yes` on an existing project does not clobber a customised `start.prompt.md`.