### PR TITLE
fix(deps): align _count_package_files to use .apm/context/ (singular) dir

### DIFF
--- a/src/apm_cli/commands/deps/_utils.py
+++ b/src/apm_cli/commands/deps/_utils.py
@@ -100,7 +100,7 @@ def _count_package_files(package_path: Path) -> tuple[int, int]:
         return 0, workflow_count
     
     context_count = 0
-    context_dirs = ['instructions', 'chatmodes', 'contexts']
+    context_dirs = ['instructions', 'chatmodes', 'context']
     
     for context_dir in context_dirs:
         context_path = apm_dir / context_dir

--- a/tests/unit/test_deps_utils.py
+++ b/tests/unit/test_deps_utils.py
@@ -3,9 +3,7 @@
 Covers the pure helpers that scan, count, and describe installed packages.
 """
 
-import tempfile
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -233,10 +231,10 @@ class TestCountPackageFiles:
         assert ctx == 1
 
     def test_contexts_dir_counted(self, tmp_path):
-        """Files in .apm/contexts/ are counted as context."""
+        """Files in .apm/context/ (singular) are counted as context."""
         apm = _make_apm_dir(tmp_path)
-        (apm / "contexts").mkdir()
-        (apm / "contexts" / "c.md").write_text("# c")
+        (apm / "context").mkdir()
+        (apm / "context" / "c.md").write_text("# c")
         ctx, _ = _count_package_files(tmp_path)
         assert ctx == 1
 


### PR DESCRIPTION
## What

`_count_package_files()` in `src/apm_cli/commands/deps/_utils.py` scanned `.apm/contexts/` (plural) for context files, but the canonical directory is `.apm/context/` (singular). This caused `apm deps list` to always report **0 context files** for every package, while `apm view` showed the correct count — a silent, persistent inconsistency.

**Before:**
```python
context_dirs = ['instructions', 'chatmodes', 'contexts']
```

**After:**
```python
context_dirs = ["instructions", "chatmodes", "context"]
```

---

## Why

`.apm/context/` (singular) is the established convention across the codebase:

- `_get_detailed_context_counts()` in the same file already maps correctly, with an explicit comment:
  ```python
  'contexts': 'context'  # Note: directory is 'context', not 'contexts'
  ```
- Primitive discovery in `primitives/discovery.py` uses `"**/.apm/context/*.context.md"`.

`_count_package_files()` was the only function using the wrong plural form, so it always traversed a directory that doesn't exist and returned 0.

---

## How

One-character change: `'contexts'` → `'context'` in `_count_package_files()`, aligning it with `_get_detailed_context_counts()` at `src/apm_cli/commands/deps/_utils.py:149`.

No public CLI interface is affected — `apm --help` output is unchanged.

---

## Tests

```
pytest tests/unit/test_deps_utils.py    43/43   pass  (Python 3.13, Windows 11)
pytest tests/unit/                    3908/3908  pass  (no regression)
```

The test suite covers all public helpers in `_utils.py` across 8 test classes, adapted from the structure proposed in #682. One test was corrected in the process: `test_contexts_dir_counted` in #682 created `.apm/contexts/` (plural) and expected a non-zero count, which validated the buggy behavior. This PR changes it to use `.apm/context/` (singular), so it now correctly documents and pins the fix.

Fixes #704
