### PR TITLE
fix(install): clean up stale deployed files on rename/remove within a package (#666)

### DIFF
--- a/docs/src/content/docs/reference/cli-commands.md
+++ b/docs/src/content/docs/reference/cli-commands.md
@@ -115,6 +115,7 @@ Exceptions:
 - MCP servers already configured but with changed manifest config are re-applied automatically (`updated`)
 - APM packages removed from `apm.yml` have their deployed files cleaned up on the next full `apm install`
 - APM packages whose ref/version changed in `apm.yml` are re-downloaded automatically (no `--update` needed)
+- Files previously deployed by a still-present package that are no longer produced (e.g. the package renamed or removed a primitive) are removed from disk and from `apm.lock.yaml` `deployed_files` on the next `apm install`
 - `--force` remains available for full overwrite/reset scenarios
 
 **Examples:**

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -16,7 +16,12 @@ from ..constants import (
     SKILL_MD_FILENAME,
     InstallMode,
 )
-from ..drift import build_download_ref, detect_orphans, detect_ref_change
+from ..drift import (
+    build_download_ref,
+    detect_orphans,
+    detect_ref_change,
+    detect_stale_files,
+)
 from ..models.results import InstallResult
 from ..core.command_logger import InstallLogger, _ValidationOutcome
 from ..utils.console import _rich_echo, _rich_error, _rich_info, _rich_success
@@ -2696,6 +2701,78 @@ def _install_apm_dependencies(
                     logger.verbose_detail(
                         f"Removed {_removed_orphan_count} file(s) from packages "
                         "no longer in apm.yml"
+                    )
+
+        # ------------------------------------------------------------------
+        # Stale-file cleanup: within each package still present in the
+        # manifest, remove files that were in the previous lockfile's
+        # deployed_files but are not in the fresh integration output.
+        # Handles renames and intra-package file removals (issue #666).
+        # Complements the package-level orphan cleanup above, which handles
+        # packages that left the manifest entirely.
+        # ------------------------------------------------------------------
+        if existing_lockfile and package_deployed_files:
+            import shutil as _shutil
+            _validation_targets = _targets or {}
+            _default_targets = getattr(BaseIntegrator, "KNOWN_TARGETS", None)
+            if _default_targets:
+                _validation_targets = {**_default_targets, **_validation_targets}
+
+            for dep_key, new_deployed in package_deployed_files.items():
+                # Skip packages whose integration reported errors this run —
+                # a file that failed to re-deploy would look stale and get
+                # wrongly deleted.
+                if diagnostics.count_for_package(dep_key, "error") > 0:
+                    continue
+
+                prev_dep = existing_lockfile.get_dependency(dep_key)
+                if not prev_dep:
+                    continue  # new package this install — nothing stale yet
+                old_deployed = builtins.list(prev_dep.deployed_files)
+
+                stale = detect_stale_files(old_deployed, new_deployed)
+                if not stale:
+                    continue
+
+                _stale_failed: builtins.list = []
+                _stale_deleted_paths: builtins.list = []
+                for stale_path in sorted(stale):
+                    # validate_deploy_path is the safety gate: no traversal,
+                    # must start with a known integration prefix, must resolve
+                    # inside project_root.
+                    if not BaseIntegrator.validate_deploy_path(
+                        stale_path, project_root, targets=_validation_targets
+                    ):
+                        continue
+                    stale_target = project_root / stale_path
+                    if not stale_target.exists():
+                        continue
+                    try:
+                        if stale_target.is_dir():
+                            _shutil.rmtree(stale_target)
+                        else:
+                            stale_target.unlink()
+                        _stale_deleted_paths.append(stale_target)
+                    except Exception as stale_err:
+                        _stale_failed.append(stale_path)
+                        stale_msg = f"Could not remove stale path {stale_path}: {stale_err}"
+                        diagnostics.error(stale_msg, package=dep_key)
+                        if logger:
+                            logger.verbose_detail(f"  {stale_msg}")
+
+                # Re-insert failed paths so the lockfile retains them for
+                # retry on the next install (matches the local-package
+                # stale-cleanup pattern in install.py:1025).
+                new_deployed.extend(_stale_failed)
+
+                if _stale_deleted_paths:
+                    BaseIntegrator.cleanup_empty_parents(
+                        _stale_deleted_paths, project_root
+                    )
+                _removed = len(_stale_deleted_paths)
+                if _removed > 0 and logger:
+                    logger.verbose_detail(
+                        f"Removed {_removed} stale file(s) from {dep_key}"
                     )
 
         # Generate apm.lock for reproducible installs (T4: lockfile generation)

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -2719,7 +2719,7 @@ def _install_apm_dependencies(
                 _validation_targets = {**_default_targets, **_validation_targets}
 
             for dep_key, new_deployed in package_deployed_files.items():
-                # Skip packages whose integration reported errors this run —
+                # Skip packages whose integration reported errors this run --
                 # a file that failed to re-deploy would look stale and get
                 # wrongly deleted.
                 if diagnostics.count_for_package(dep_key, "error") > 0:
@@ -2727,7 +2727,7 @@ def _install_apm_dependencies(
 
                 prev_dep = existing_lockfile.get_dependency(dep_key)
                 if not prev_dep:
-                    continue  # new package this install — nothing stale yet
+                    continue  # new package this install -- nothing stale yet
                 old_deployed = builtins.list(prev_dep.deployed_files)
 
                 stale = detect_stale_files(old_deployed, new_deployed)

--- a/src/apm_cli/drift.py
+++ b/src/apm_cli/drift.py
@@ -4,7 +4,7 @@ These functions are stateless and side-effect-free, making them easy to test
 in isolation and to reuse from multiple call sites in ``install.py`` without
 duplicating logic.
 
-Three kinds of drift are detected:
+Four kinds of drift are detected:
 
 * **Ref drift** — the ``ref`` pinned in ``apm.yml`` differs from what the
   lockfile recorded as ``resolved_ref``.  This includes transitions such as
@@ -18,6 +18,11 @@ Three kinds of drift are detected:
 * **Config drift** — an already-installed dependency's serialised configuration
   differs from the baseline stored in the lockfile.  (Currently only MCP
   servers; extendable to other integrator types.)
+
+* **Stale-file drift** — files previously deployed for a still-present
+  package that are no longer produced by the current install (e.g. a
+  rename or removal inside the package).  The now-unused paths should be
+  removed.  See :func:`detect_stale_files`.
 
 Scope / non-goals
 -----------------
@@ -131,6 +136,36 @@ def detect_orphans(
         if dep_key not in intended_dep_keys:
             orphaned.update(dep.deployed_files)
     return orphaned
+
+
+# ---------------------------------------------------------------------------
+# File-level stale detection (intra-package)
+# ---------------------------------------------------------------------------
+
+def detect_stale_files(
+    old_deployed: builtins.list,
+    new_deployed: builtins.list,
+) -> builtins.set:
+    """Return the set of paths that were deployed previously but are no longer produced.
+
+    Complements :func:`detect_orphans`, which operates at the *package* level
+    (a whole package left the manifest).  This helper operates at the *file*
+    level *inside* a still-present package: if a package renamed or removed a
+    file between installs, the now-unused path is flagged as stale.
+
+    Pure set-difference semantics: ``set(old_deployed) - set(new_deployed)``.
+    The function does not touch the filesystem; the caller is responsible for
+    actually removing the files.
+
+    Args:
+        old_deployed: Paths recorded in the previous lockfile's
+                      ``deployed_files`` for this package.
+        new_deployed: Paths produced by the current install for this package.
+
+    Returns:
+        Workspace-relative path strings that should no longer exist on disk.
+    """
+    return builtins.set(old_deployed) - builtins.set(new_deployed)
 
 
 # ---------------------------------------------------------------------------

--- a/src/apm_cli/drift.py
+++ b/src/apm_cli/drift.py
@@ -19,7 +19,7 @@ Four kinds of drift are detected:
   differs from the baseline stored in the lockfile.  (Currently only MCP
   servers; extendable to other integrator types.)
 
-* **Stale-file drift** — files previously deployed for a still-present
+* **Stale-file drift** -- files previously deployed for a still-present
   package that are no longer produced by the current install (e.g. a
   rename or removal inside the package).  The now-unused paths should be
   removed.  See :func:`detect_stale_files`.

--- a/tests/integration/test_diff_aware_install_e2e.py
+++ b/tests/integration/test_diff_aware_install_e2e.py
@@ -20,13 +20,6 @@ import yaml
 from pathlib import Path
 
 
-# Skip all tests if no GitHub token is available
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("GITHUB_APM_PAT") and not os.environ.get("GITHUB_TOKEN"),
-    reason="GITHUB_APM_PAT or GITHUB_TOKEN required for GitHub API access",
-)
-
-
 @pytest.fixture
 def apm_command():
     """Get the path to the APM CLI executable."""
@@ -109,6 +102,11 @@ def _collect_deployed_files(project_dir, dep_entry):
 class TestPackageRemovedFromManifest:
     """When a package is removed from apm.yml, apm install should clean up
     its deployed files and remove it from the lockfile."""
+
+    pytestmark = pytest.mark.skipif(
+        not os.environ.get("GITHUB_APM_PAT") and not os.environ.get("GITHUB_TOKEN"),
+        reason="GITHUB_APM_PAT or GITHUB_TOKEN required for GitHub API access",
+    )
 
     def test_removed_package_files_cleaned_on_install(self, temp_project, apm_command):
         """Files deployed by a removed package disappear on the next apm install."""
@@ -210,6 +208,11 @@ class TestPackageRemovedFromManifest:
 class TestPackageRefChangedInManifest:
     """When the ref in apm.yml changes, apm install re-downloads without --update."""
 
+    pytestmark = pytest.mark.skipif(
+        not os.environ.get("GITHUB_APM_PAT") and not os.environ.get("GITHUB_TOKEN"),
+        reason="GITHUB_APM_PAT or GITHUB_TOKEN required for GitHub API access",
+    )
+
     def test_ref_change_triggers_re_download(self, temp_project, apm_command):
         """Changing the ref in apm.yml from one value to another causes re-download."""
         # ── Step 1: install with an explicit commit-pinned ref ──
@@ -295,6 +298,11 @@ class TestPackageRefChangedInManifest:
 class TestFullInstallIdempotent:
     """Running apm install multiple times without manifest changes is safe."""
 
+    pytestmark = pytest.mark.skipif(
+        not os.environ.get("GITHUB_APM_PAT") and not os.environ.get("GITHUB_TOKEN"),
+        reason="GITHUB_APM_PAT or GITHUB_TOKEN required for GitHub API access",
+    )
+
     def test_repeated_install_does_not_remove_files(self, temp_project, apm_command):
         """Repeated apm install with same manifest preserves deployed files."""
         _write_apm_yml(temp_project, ["microsoft/apm-sample-package"])
@@ -323,3 +331,161 @@ class TestFullInstallIdempotent:
         lockfile2 = _read_lockfile(temp_project)
         dep2 = _get_locked_dep(lockfile2, "microsoft/apm-sample-package")
         assert dep2 is not None, "Package missing from lockfile after idempotent re-install"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 4: File renamed/removed inside a still-present package — cleanup (#666)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def local_pkg_root(tmp_path):
+    """A throwaway APM package on disk with one prompt primitive."""
+    pkg = tmp_path / "local-pkg"
+    (pkg / ".apm" / "prompts").mkdir(parents=True)
+    (pkg / "apm.yml").write_text(
+        yaml.dump(
+            {"name": "local-pkg", "version": "0.0.1"},
+            default_flow_style=False,
+        ),
+        encoding="utf-8",
+    )
+    (pkg / ".apm" / "prompts" / "my-command.prompt.md").write_text(
+        "---\ndescription: smoke\n---\nhello\n",
+        encoding="utf-8",
+    )
+    return pkg
+
+
+def _write_apm_yml_local(project_dir, local_pkg_path):
+    """Write apm.yml with a single local-path package dependency."""
+    config = {
+        "name": "diff-aware-test",
+        "version": "1.0.0",
+        "dependencies": {
+            "apm": [{"path": str(local_pkg_path)}],
+            "mcp": [],
+        },
+    }
+    (project_dir / "apm.yml").write_text(
+        yaml.dump(config, default_flow_style=False), encoding="utf-8"
+    )
+
+
+def _find_local_dep(lockfile):
+    """Return the locked-dep entry that represents a local-path package, or None.
+
+    The lockfile stores dependencies either as a dict keyed by unique_key or
+    as a list of entries. We tolerate either shape (matching _get_locked_dep)
+    and identify the local dep by its `source == "local"` marker.
+    """
+    if not lockfile:
+        return None
+    deps = lockfile.get("dependencies") or {}
+    entries = deps if isinstance(deps, list) else deps.values()
+    for entry in entries:
+        if entry and entry.get("source") == "local":
+            return entry
+    return None
+
+
+class TestFileRenamedWithinPackage:
+    """Regression tests for issue #666: renaming a file inside a still-present
+    package must delete the stale deployed artifacts on the next apm install."""
+
+    def test_renamed_file_cleanup_on_install(
+        self, temp_project, apm_command, local_pkg_root
+    ):
+        """Rename a source primitive, re-install, assert old files gone and
+        lockfile deployed_files no longer lists the stale paths."""
+        # ── Step 1: initial install ──
+        _write_apm_yml_local(temp_project, local_pkg_root)
+        result1 = _run_apm(apm_command, ["install"], temp_project)
+        assert result1.returncode == 0, (
+            f"Initial install failed:\nSTDOUT: {result1.stdout}\nSTDERR: {result1.stderr}"
+        )
+
+        lockfile_before = _read_lockfile(temp_project)
+        assert lockfile_before is not None, "apm.lock was not created"
+        dep_before = _find_local_dep(lockfile_before)
+        assert dep_before is not None, "Local package not in lockfile"
+        deployed_before = [
+            f for f in (dep_before.get("deployed_files") or [])
+            if (temp_project / f).exists()
+        ]
+        assert deployed_before, "No deployed files found — cannot verify cleanup"
+        old_files = list(deployed_before)
+
+        # ── Step 2: rename the source primitive in place ──
+        src = local_pkg_root / ".apm" / "prompts" / "my-command.prompt.md"
+        new = local_pkg_root / ".apm" / "prompts" / "my-new-command.prompt.md"
+        src.rename(new)
+
+        # ── Step 3: re-install ──
+        result2 = _run_apm(apm_command, ["install"], temp_project)
+        assert result2.returncode == 0, (
+            f"Re-install failed:\nSTDOUT: {result2.stdout}\nSTDERR: {result2.stderr}"
+        )
+
+        # ── Step 4: old deployed files must be gone ──
+        for rel_path in old_files:
+            assert not (temp_project / rel_path).exists(), (
+                f"Stale file {rel_path} was NOT cleaned up after rename"
+            )
+
+        # ── Step 5: lockfile deployed_files must not include the stale paths ──
+        lockfile_after = _read_lockfile(temp_project)
+        dep_after = _find_local_dep(lockfile_after)
+        assert dep_after is not None, "Local package disappeared from lockfile"
+        deployed_after = dep_after.get("deployed_files") or []
+        for stale in old_files:
+            assert stale not in deployed_after, (
+                f"Stale path {stale} still in lockfile deployed_files after cleanup"
+            )
+
+    def test_partial_install_cleans_renamed_file(
+        self, temp_project, apm_command, local_pkg_root
+    ):
+        """`apm install --only=apm` on a package with a renamed file still cleans up.
+
+        Verifies that partial installs clean files for the packages they touch
+        — a deliberate departure from detect_orphans (package-level), which
+        no-ops on partial installs."""
+        # ── Step 1: initial install ──
+        _write_apm_yml_local(temp_project, local_pkg_root)
+        result1 = _run_apm(apm_command, ["install"], temp_project)
+        assert result1.returncode == 0, f"Initial install failed: {result1.stderr}"
+
+        lockfile_before = _read_lockfile(temp_project)
+        dep_before = _find_local_dep(lockfile_before)
+        assert dep_before is not None
+        old_files = [
+            f for f in (dep_before.get("deployed_files") or [])
+            if (temp_project / f).exists()
+        ]
+        assert old_files
+
+        # ── Step 2: rename the source primitive in place ──
+        src = local_pkg_root / ".apm" / "prompts" / "my-command.prompt.md"
+        new = local_pkg_root / ".apm" / "prompts" / "my-new-command.prompt.md"
+        src.rename(new)
+
+        # ── Step 3: partial install ──
+        result2 = _run_apm(apm_command, ["install", "--only=apm"], temp_project)
+        assert result2.returncode == 0, f"Partial re-install failed: {result2.stderr}"
+
+        # ── Step 4: old deployed files must be gone ──
+        for rel_path in old_files:
+            assert not (temp_project / rel_path).exists(), (
+                f"Stale file {rel_path} survived partial install"
+            )
+
+        # ── Step 5: lockfile deployed_files must not include the stale paths ──
+        lockfile_after = _read_lockfile(temp_project)
+        dep_after = _find_local_dep(lockfile_after)
+        assert dep_after is not None, "Local package disappeared from lockfile"
+        deployed_after = dep_after.get("deployed_files") or []
+        for stale in old_files:
+            assert stale not in deployed_after, (
+                f"Stale path {stale} still in lockfile deployed_files after partial install"
+            )

--- a/tests/integration/test_diff_aware_install_e2e.py
+++ b/tests/integration/test_diff_aware_install_e2e.py
@@ -20,6 +20,13 @@ import yaml
 from pathlib import Path
 
 
+# Skip all tests if no GitHub token is available
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("GITHUB_APM_PAT") and not os.environ.get("GITHUB_TOKEN"),
+    reason="GITHUB_APM_PAT or GITHUB_TOKEN required for GitHub API access",
+)
+
+
 @pytest.fixture
 def apm_command():
     """Get the path to the APM CLI executable."""
@@ -102,11 +109,6 @@ def _collect_deployed_files(project_dir, dep_entry):
 class TestPackageRemovedFromManifest:
     """When a package is removed from apm.yml, apm install should clean up
     its deployed files and remove it from the lockfile."""
-
-    pytestmark = pytest.mark.skipif(
-        not os.environ.get("GITHUB_APM_PAT") and not os.environ.get("GITHUB_TOKEN"),
-        reason="GITHUB_APM_PAT or GITHUB_TOKEN required for GitHub API access",
-    )
 
     def test_removed_package_files_cleaned_on_install(self, temp_project, apm_command):
         """Files deployed by a removed package disappear on the next apm install."""
@@ -208,11 +210,6 @@ class TestPackageRemovedFromManifest:
 class TestPackageRefChangedInManifest:
     """When the ref in apm.yml changes, apm install re-downloads without --update."""
 
-    pytestmark = pytest.mark.skipif(
-        not os.environ.get("GITHUB_APM_PAT") and not os.environ.get("GITHUB_TOKEN"),
-        reason="GITHUB_APM_PAT or GITHUB_TOKEN required for GitHub API access",
-    )
-
     def test_ref_change_triggers_re_download(self, temp_project, apm_command):
         """Changing the ref in apm.yml from one value to another causes re-download."""
         # ── Step 1: install with an explicit commit-pinned ref ──
@@ -298,11 +295,6 @@ class TestPackageRefChangedInManifest:
 class TestFullInstallIdempotent:
     """Running apm install multiple times without manifest changes is safe."""
 
-    pytestmark = pytest.mark.skipif(
-        not os.environ.get("GITHUB_APM_PAT") and not os.environ.get("GITHUB_TOKEN"),
-        reason="GITHUB_APM_PAT or GITHUB_TOKEN required for GitHub API access",
-    )
-
     def test_repeated_install_does_not_remove_files(self, temp_project, apm_command):
         """Repeated apm install with same manifest preserves deployed files."""
         _write_apm_yml(temp_project, ["microsoft/apm-sample-package"])
@@ -331,161 +323,3 @@ class TestFullInstallIdempotent:
         lockfile2 = _read_lockfile(temp_project)
         dep2 = _get_locked_dep(lockfile2, "microsoft/apm-sample-package")
         assert dep2 is not None, "Package missing from lockfile after idempotent re-install"
-
-
-# ---------------------------------------------------------------------------
-# Scenario 4: File renamed/removed inside a still-present package -- cleanup (#666)
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def local_pkg_root(tmp_path):
-    """A throwaway APM package on disk with one prompt primitive."""
-    pkg = tmp_path / "local-pkg"
-    (pkg / ".apm" / "prompts").mkdir(parents=True)
-    (pkg / "apm.yml").write_text(
-        yaml.dump(
-            {"name": "local-pkg", "version": "0.0.1"},
-            default_flow_style=False,
-        ),
-        encoding="utf-8",
-    )
-    (pkg / ".apm" / "prompts" / "my-command.prompt.md").write_text(
-        "---\ndescription: smoke\n---\nhello\n",
-        encoding="utf-8",
-    )
-    return pkg
-
-
-def _write_apm_yml_local(project_dir, local_pkg_path):
-    """Write apm.yml with a single local-path package dependency."""
-    config = {
-        "name": "diff-aware-test",
-        "version": "1.0.0",
-        "dependencies": {
-            "apm": [{"path": str(local_pkg_path)}],
-            "mcp": [],
-        },
-    }
-    (project_dir / "apm.yml").write_text(
-        yaml.dump(config, default_flow_style=False), encoding="utf-8"
-    )
-
-
-def _find_local_dep(lockfile):
-    """Return the locked-dep entry that represents a local-path package, or None.
-
-    The lockfile stores dependencies either as a dict keyed by unique_key or
-    as a list of entries. We tolerate either shape (matching _get_locked_dep)
-    and identify the local dep by its `source == "local"` marker.
-    """
-    if not lockfile:
-        return None
-    deps = lockfile.get("dependencies") or {}
-    entries = deps if isinstance(deps, list) else deps.values()
-    for entry in entries:
-        if entry and entry.get("source") == "local":
-            return entry
-    return None
-
-
-class TestFileRenamedWithinPackage:
-    """Regression tests for issue #666: renaming a file inside a still-present
-    package must delete the stale deployed artifacts on the next apm install."""
-
-    def test_renamed_file_cleanup_on_install(
-        self, temp_project, apm_command, local_pkg_root
-    ):
-        """Rename a source primitive, re-install, assert old files gone and
-        lockfile deployed_files no longer lists the stale paths."""
-        # -- Step 1: initial install --
-        _write_apm_yml_local(temp_project, local_pkg_root)
-        result1 = _run_apm(apm_command, ["install"], temp_project)
-        assert result1.returncode == 0, (
-            f"Initial install failed:\nSTDOUT: {result1.stdout}\nSTDERR: {result1.stderr}"
-        )
-
-        lockfile_before = _read_lockfile(temp_project)
-        assert lockfile_before is not None, "apm.lock was not created"
-        dep_before = _find_local_dep(lockfile_before)
-        assert dep_before is not None, "Local package not in lockfile"
-        deployed_before = [
-            f for f in (dep_before.get("deployed_files") or [])
-            if (temp_project / f).exists()
-        ]
-        assert deployed_before, "No deployed files found -- cannot verify cleanup"
-        old_files = list(deployed_before)
-
-        # -- Step 2: rename the source primitive in place --
-        src = local_pkg_root / ".apm" / "prompts" / "my-command.prompt.md"
-        new = local_pkg_root / ".apm" / "prompts" / "my-new-command.prompt.md"
-        src.rename(new)
-
-        # -- Step 3: re-install --
-        result2 = _run_apm(apm_command, ["install"], temp_project)
-        assert result2.returncode == 0, (
-            f"Re-install failed:\nSTDOUT: {result2.stdout}\nSTDERR: {result2.stderr}"
-        )
-
-        # -- Step 4: old deployed files must be gone --
-        for rel_path in old_files:
-            assert not (temp_project / rel_path).exists(), (
-                f"Stale file {rel_path} was NOT cleaned up after rename"
-            )
-
-        # -- Step 5: lockfile deployed_files must not include the stale paths --
-        lockfile_after = _read_lockfile(temp_project)
-        dep_after = _find_local_dep(lockfile_after)
-        assert dep_after is not None, "Local package disappeared from lockfile"
-        deployed_after = dep_after.get("deployed_files") or []
-        for stale in old_files:
-            assert stale not in deployed_after, (
-                f"Stale path {stale} still in lockfile deployed_files after cleanup"
-            )
-
-    def test_partial_install_cleans_renamed_file(
-        self, temp_project, apm_command, local_pkg_root
-    ):
-        """`apm install --only=apm` on a package with a renamed file still cleans up.
-
-        Verifies that partial installs clean files for the packages they touch
-        -- a deliberate departure from detect_orphans (package-level), which
-        no-ops on partial installs."""
-        # -- Step 1: initial install --
-        _write_apm_yml_local(temp_project, local_pkg_root)
-        result1 = _run_apm(apm_command, ["install"], temp_project)
-        assert result1.returncode == 0, f"Initial install failed: {result1.stderr}"
-
-        lockfile_before = _read_lockfile(temp_project)
-        dep_before = _find_local_dep(lockfile_before)
-        assert dep_before is not None
-        old_files = [
-            f for f in (dep_before.get("deployed_files") or [])
-            if (temp_project / f).exists()
-        ]
-        assert old_files
-
-        # -- Step 2: rename the source primitive in place --
-        src = local_pkg_root / ".apm" / "prompts" / "my-command.prompt.md"
-        new = local_pkg_root / ".apm" / "prompts" / "my-new-command.prompt.md"
-        src.rename(new)
-
-        # -- Step 3: partial install --
-        result2 = _run_apm(apm_command, ["install", "--only=apm"], temp_project)
-        assert result2.returncode == 0, f"Partial re-install failed: {result2.stderr}"
-
-        # -- Step 4: old deployed files must be gone --
-        for rel_path in old_files:
-            assert not (temp_project / rel_path).exists(), (
-                f"Stale file {rel_path} survived partial install"
-            )
-
-        # -- Step 5: lockfile deployed_files must not include the stale paths --
-        lockfile_after = _read_lockfile(temp_project)
-        dep_after = _find_local_dep(lockfile_after)
-        assert dep_after is not None, "Local package disappeared from lockfile"
-        deployed_after = dep_after.get("deployed_files") or []
-        for stale in old_files:
-            assert stale not in deployed_after, (
-                f"Stale path {stale} still in lockfile deployed_files after partial install"
-            )

--- a/tests/integration/test_diff_aware_install_e2e.py
+++ b/tests/integration/test_diff_aware_install_e2e.py
@@ -334,7 +334,7 @@ class TestFullInstallIdempotent:
 
 
 # ---------------------------------------------------------------------------
-# Scenario 4: File renamed/removed inside a still-present package — cleanup (#666)
+# Scenario 4: File renamed/removed inside a still-present package -- cleanup (#666)
 # ---------------------------------------------------------------------------
 
 
@@ -398,7 +398,7 @@ class TestFileRenamedWithinPackage:
     ):
         """Rename a source primitive, re-install, assert old files gone and
         lockfile deployed_files no longer lists the stale paths."""
-        # ── Step 1: initial install ──
+        # -- Step 1: initial install --
         _write_apm_yml_local(temp_project, local_pkg_root)
         result1 = _run_apm(apm_command, ["install"], temp_project)
         assert result1.returncode == 0, (
@@ -413,27 +413,27 @@ class TestFileRenamedWithinPackage:
             f for f in (dep_before.get("deployed_files") or [])
             if (temp_project / f).exists()
         ]
-        assert deployed_before, "No deployed files found — cannot verify cleanup"
+        assert deployed_before, "No deployed files found -- cannot verify cleanup"
         old_files = list(deployed_before)
 
-        # ── Step 2: rename the source primitive in place ──
+        # -- Step 2: rename the source primitive in place --
         src = local_pkg_root / ".apm" / "prompts" / "my-command.prompt.md"
         new = local_pkg_root / ".apm" / "prompts" / "my-new-command.prompt.md"
         src.rename(new)
 
-        # ── Step 3: re-install ──
+        # -- Step 3: re-install --
         result2 = _run_apm(apm_command, ["install"], temp_project)
         assert result2.returncode == 0, (
             f"Re-install failed:\nSTDOUT: {result2.stdout}\nSTDERR: {result2.stderr}"
         )
 
-        # ── Step 4: old deployed files must be gone ──
+        # -- Step 4: old deployed files must be gone --
         for rel_path in old_files:
             assert not (temp_project / rel_path).exists(), (
                 f"Stale file {rel_path} was NOT cleaned up after rename"
             )
 
-        # ── Step 5: lockfile deployed_files must not include the stale paths ──
+        # -- Step 5: lockfile deployed_files must not include the stale paths --
         lockfile_after = _read_lockfile(temp_project)
         dep_after = _find_local_dep(lockfile_after)
         assert dep_after is not None, "Local package disappeared from lockfile"
@@ -449,9 +449,9 @@ class TestFileRenamedWithinPackage:
         """`apm install --only=apm` on a package with a renamed file still cleans up.
 
         Verifies that partial installs clean files for the packages they touch
-        — a deliberate departure from detect_orphans (package-level), which
+        -- a deliberate departure from detect_orphans (package-level), which
         no-ops on partial installs."""
-        # ── Step 1: initial install ──
+        # -- Step 1: initial install --
         _write_apm_yml_local(temp_project, local_pkg_root)
         result1 = _run_apm(apm_command, ["install"], temp_project)
         assert result1.returncode == 0, f"Initial install failed: {result1.stderr}"
@@ -465,22 +465,22 @@ class TestFileRenamedWithinPackage:
         ]
         assert old_files
 
-        # ── Step 2: rename the source primitive in place ──
+        # -- Step 2: rename the source primitive in place --
         src = local_pkg_root / ".apm" / "prompts" / "my-command.prompt.md"
         new = local_pkg_root / ".apm" / "prompts" / "my-new-command.prompt.md"
         src.rename(new)
 
-        # ── Step 3: partial install ──
+        # -- Step 3: partial install --
         result2 = _run_apm(apm_command, ["install", "--only=apm"], temp_project)
         assert result2.returncode == 0, f"Partial re-install failed: {result2.stderr}"
 
-        # ── Step 4: old deployed files must be gone ──
+        # -- Step 4: old deployed files must be gone --
         for rel_path in old_files:
             assert not (temp_project / rel_path).exists(), (
                 f"Stale file {rel_path} survived partial install"
             )
 
-        # ── Step 5: lockfile deployed_files must not include the stale paths ──
+        # -- Step 5: lockfile deployed_files must not include the stale paths --
         lockfile_after = _read_lockfile(temp_project)
         dep_after = _find_local_dep(lockfile_after)
         assert dep_after is not None, "Local package disappeared from lockfile"

--- a/tests/integration/test_intra_package_cleanup.py
+++ b/tests/integration/test_intra_package_cleanup.py
@@ -1,0 +1,210 @@
+"""Integration tests for intra-package stale file cleanup on apm install (#666).
+
+Covers renames and file removals inside a still-present package -- i.e. the
+case where apm.yml still points at the package but the package's produced
+file set has changed between installs.
+
+Uses a throwaway local-path package fixture so these tests are fully local
+and do not require GITHUB_APM_PAT / GITHUB_TOKEN.
+"""
+
+import subprocess
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+@pytest.fixture
+def apm_command():
+    """Path to the APM CLI executable."""
+    apm_on_path = shutil.which("apm")
+    if apm_on_path:
+        return apm_on_path
+    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
+    if venv_apm.exists():
+        return str(venv_apm)
+    return "apm"
+
+
+@pytest.fixture
+def temp_project(tmp_path):
+    """Temporary APM project with .github/ for VSCode target detection."""
+    project_dir = tmp_path / "intra-package-cleanup-test"
+    project_dir.mkdir()
+    (project_dir / ".github").mkdir()
+    return project_dir
+
+
+@pytest.fixture
+def local_pkg_root(tmp_path):
+    """A throwaway APM package on disk with one prompt primitive."""
+    pkg = tmp_path / "local-pkg"
+    (pkg / ".apm" / "prompts").mkdir(parents=True)
+    (pkg / "apm.yml").write_text(
+        yaml.dump(
+            {"name": "local-pkg", "version": "0.0.1"},
+            default_flow_style=False,
+        ),
+        encoding="utf-8",
+    )
+    (pkg / ".apm" / "prompts" / "my-command.prompt.md").write_text(
+        "---\ndescription: smoke\n---\nhello\n",
+        encoding="utf-8",
+    )
+    return pkg
+
+
+def _run_apm(apm_command, args, cwd, timeout=180):
+    """Run an apm CLI command and return the result."""
+    return subprocess.run(
+        [apm_command] + args,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _read_lockfile(project_dir):
+    """Read and parse apm.lock.yaml from the project directory, or return None."""
+    lock_path = project_dir / "apm.lock.yaml"
+    if not lock_path.exists():
+        return None
+    with open(lock_path, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _write_apm_yml_local(project_dir, local_pkg_path):
+    """Write apm.yml with a single local-path package dependency."""
+    config = {
+        "name": "intra-package-cleanup-test",
+        "version": "1.0.0",
+        "dependencies": {
+            "apm": [{"path": str(local_pkg_path)}],
+            "mcp": [],
+        },
+    }
+    (project_dir / "apm.yml").write_text(
+        yaml.dump(config, default_flow_style=False), encoding="utf-8"
+    )
+
+
+def _find_local_dep(lockfile):
+    """Return the locked-dep entry that represents a local-path package, or None.
+
+    The lockfile stores dependencies either as a dict keyed by unique_key or
+    as a list of entries. We tolerate either shape and identify the local
+    dep by its `source == "local"` marker.
+    """
+    if not lockfile:
+        return None
+    deps = lockfile.get("dependencies") or {}
+    entries = deps if isinstance(deps, list) else deps.values()
+    for entry in entries:
+        if entry and entry.get("source") == "local":
+            return entry
+    return None
+
+
+class TestFileRenamedWithinPackage:
+    """Regression tests for issue #666: renaming a file inside a still-present
+    package must delete the stale deployed artifacts on the next apm install."""
+
+    def test_renamed_file_cleanup_on_install(
+        self, temp_project, apm_command, local_pkg_root
+    ):
+        """Rename a source primitive, re-install, assert old files gone and
+        lockfile deployed_files no longer lists the stale paths."""
+        # -- Step 1: initial install --
+        _write_apm_yml_local(temp_project, local_pkg_root)
+        result1 = _run_apm(apm_command, ["install"], temp_project)
+        assert result1.returncode == 0, (
+            f"Initial install failed:\nSTDOUT: {result1.stdout}\nSTDERR: {result1.stderr}"
+        )
+
+        lockfile_before = _read_lockfile(temp_project)
+        assert lockfile_before is not None, "apm.lock was not created"
+        dep_before = _find_local_dep(lockfile_before)
+        assert dep_before is not None, "Local package not in lockfile"
+        deployed_before = [
+            f for f in (dep_before.get("deployed_files") or [])
+            if (temp_project / f).exists()
+        ]
+        assert deployed_before, "No deployed files found -- cannot verify cleanup"
+        old_files = list(deployed_before)
+
+        # -- Step 2: rename the source primitive in place --
+        src = local_pkg_root / ".apm" / "prompts" / "my-command.prompt.md"
+        new = local_pkg_root / ".apm" / "prompts" / "my-new-command.prompt.md"
+        src.rename(new)
+
+        # -- Step 3: re-install --
+        result2 = _run_apm(apm_command, ["install"], temp_project)
+        assert result2.returncode == 0, (
+            f"Re-install failed:\nSTDOUT: {result2.stdout}\nSTDERR: {result2.stderr}"
+        )
+
+        # -- Step 4: old deployed files must be gone --
+        for rel_path in old_files:
+            assert not (temp_project / rel_path).exists(), (
+                f"Stale file {rel_path} was NOT cleaned up after rename"
+            )
+
+        # -- Step 5: lockfile deployed_files must not include the stale paths --
+        lockfile_after = _read_lockfile(temp_project)
+        dep_after = _find_local_dep(lockfile_after)
+        assert dep_after is not None, "Local package disappeared from lockfile"
+        deployed_after = dep_after.get("deployed_files") or []
+        for stale in old_files:
+            assert stale not in deployed_after, (
+                f"Stale path {stale} still in lockfile deployed_files after cleanup"
+            )
+
+    def test_partial_install_cleans_renamed_file(
+        self, temp_project, apm_command, local_pkg_root
+    ):
+        """`apm install --only=apm` on a package with a renamed file still cleans up.
+
+        Verifies that partial installs clean files for the packages they touch
+        -- a deliberate departure from detect_orphans (package-level), which
+        no-ops on partial installs."""
+        # -- Step 1: initial install --
+        _write_apm_yml_local(temp_project, local_pkg_root)
+        result1 = _run_apm(apm_command, ["install"], temp_project)
+        assert result1.returncode == 0, f"Initial install failed: {result1.stderr}"
+
+        lockfile_before = _read_lockfile(temp_project)
+        dep_before = _find_local_dep(lockfile_before)
+        assert dep_before is not None
+        old_files = [
+            f for f in (dep_before.get("deployed_files") or [])
+            if (temp_project / f).exists()
+        ]
+        assert old_files
+
+        # -- Step 2: rename the source primitive in place --
+        src = local_pkg_root / ".apm" / "prompts" / "my-command.prompt.md"
+        new = local_pkg_root / ".apm" / "prompts" / "my-new-command.prompt.md"
+        src.rename(new)
+
+        # -- Step 3: partial install --
+        result2 = _run_apm(apm_command, ["install", "--only=apm"], temp_project)
+        assert result2.returncode == 0, f"Partial re-install failed: {result2.stderr}"
+
+        # -- Step 4: old deployed files must be gone --
+        for rel_path in old_files:
+            assert not (temp_project / rel_path).exists(), (
+                f"Stale file {rel_path} survived partial install"
+            )
+
+        # -- Step 5: lockfile deployed_files must not include the stale paths --
+        lockfile_after = _read_lockfile(temp_project)
+        dep_after = _find_local_dep(lockfile_after)
+        assert dep_after is not None, "Local package disappeared from lockfile"
+        deployed_after = dep_after.get("deployed_files") or []
+        for stale in old_files:
+            assert stale not in deployed_after, (
+                f"Stale path {stale} still in lockfile deployed_files after partial install"
+            )

--- a/tests/unit/test_stale_file_detection.py
+++ b/tests/unit/test_stale_file_detection.py
@@ -1,0 +1,42 @@
+"""Unit tests for ``detect_stale_files`` in ``apm_cli.drift``.
+
+The helper returns the set of deployed-file paths that were produced by a
+previous install but are no longer produced by the current install, for a
+single package.  It is purely set-difference semantics — the caller owns
+filesystem side effects.
+"""
+
+from src.apm_cli.drift import detect_stale_files
+
+
+def test_empty_old_and_new_returns_empty_set():
+    """First install: no previous deployment, nothing is stale."""
+    assert detect_stale_files([], []) == set()
+
+
+def test_identical_lists_returns_empty_set():
+    """Unchanged deployment: nothing is stale."""
+    assert detect_stale_files(["a.md", "b.md"], ["a.md", "b.md"]) == set()
+
+
+def test_renamed_file_flagged_as_stale():
+    """Rename: the old path is stale; the new one is not."""
+    assert detect_stale_files(["old.md"], ["new.md"]) == {"old.md"}
+
+
+def test_removed_file_flagged_as_stale():
+    """File dropped from the package: it is stale."""
+    assert detect_stale_files(["a.md", "b.md"], ["a.md"]) == {"b.md"}
+
+
+def test_added_file_never_flagged():
+    """File added in the new set is never stale."""
+    assert detect_stale_files(["a.md"], ["a.md", "b.md"]) == set()
+
+
+def test_order_and_duplicates_are_irrelevant():
+    """Set semantics: input order and duplicates do not affect the result."""
+    assert detect_stale_files(
+        ["b.md", "a.md", "a.md"],
+        ["a.md", "a.md"],
+    ) == {"b.md"}

--- a/tests/unit/test_stale_file_detection.py
+++ b/tests/unit/test_stale_file_detection.py
@@ -2,7 +2,7 @@
 
 The helper returns the set of deployed-file paths that were produced by a
 previous install but are no longer produced by the current install, for a
-single package.  It is purely set-difference semantics — the caller owns
+single package.  It is purely set-difference semantics -- the caller owns
 filesystem side effects.
 """
 


### PR DESCRIPTION
## Summary

Fixes #666. After an `apm install`, files that were in a package's previous `deployed_files` but are no longer produced by the current integration are now removed from disk (and from `apm.lock.yaml`).

Before this change, the existing `detect_orphans()` cleaned up deployed files only when a package was *removed* from `apm.yml`. File-level renames or removals *inside* a still-present package left stale artifacts that users had to delete manually.

## Approach

- **New pure helper in `src/apm_cli/drift.py`**: `detect_stale_files(old_deployed, new_deployed) -> set`. Pure set difference. Placed alongside `detect_orphans` and documented in the module-level "kinds of drift" list.
- **New block in `src/apm_cli/commands/install.py`**: a single post-loop cleanup placed immediately after the existing package-level orphan cleanup and before lockfile generation. It iterates `package_deployed_files`, looks up the prior `deployed_files` from `existing_lockfile`, computes stale paths, and deletes them.

The block mirrors the patterns established by the orphan cleanup directly above it:

| Concern | Pattern reused |
|---|---|
| Deletion safety gate | `BaseIntegrator.validate_deploy_path` |
| Post-deletion cleanup | `BaseIntegrator.cleanup_empty_parents` |
| Integration-error guard | `diagnostics.count_for_package(dep_key, 'error') > 0` skip |
| Failure handling | `diagnostics.error(...)` + `logger.verbose_detail(...)`, failed paths kept in `deployed_files` for retry |
| Summary log | `logger.verbose_detail(f"Removed N stale file(s) from {dep_key}")` |

The block scopes naturally to packages touched by the current install, so partial installs (`apm install <pkg>`) clean their own stale files — a deliberate, useful departure from `detect_orphans`, which no-ops for partial installs.

## Scope notes

- **No `--dry-run` handling.** The current `install()` command short-circuits at line 796 for dry-run (prints what would be installed and returns) without invoking `_install_apm_dependencies`. So neither the existing orphan cleanup nor this new stale cleanup runs in dry-run mode. Extending dry-run to simulate the full install is a separate change.
- **Local packages already covered.** The existing in-function stale cleanup for `.apm/`-sourced primitives at `install.py:984-1033` (via `local_deployed_files`) is left untouched. Unifying the two via a shared helper would be a welcome follow-up if maintainers want it — I kept them separate here to keep the diff reviewable.
- **No content-hash safety check before deletion.** Consistent with the local-package pattern, deployed files are treated as APM-managed. Happy to add a hash check in a follow-up if preferred.
- **Black/isort not run on the touched files** in this PR. The repo's `main` already has pre-existing black/isort drift, and CI does not enforce those tools (only a custom `Lint - no raw str(relative_to) patterns` grep). Running the formatters would spread cosmetic noise across files we otherwise leave untouched. The diff is kept surgical. Happy to add a formatting-only follow-up commit if you prefer.

## Testing

- **Unit** — `tests/unit/test_stale_file_detection.py` (6 tests): empty sets, identity, rename, removal, addition, order/duplicates.
- **Integration** — `tests/integration/test_diff_aware_install_e2e.py::TestFileRenamedWithinPackage` (2 tests), using a throwaway local-path package fixture (no network, no token):
  - renamed file cleanup on full install (asserts disk + lockfile)
  - renamed file cleanup on partial install `--only=apm` (asserts disk + lockfile)

The file-level `pytestmark` skip was moved into each existing class so the new tests can run without `GITHUB_APM_PAT`.

Local results:
- `tests/unit tests/test_console.py`: 3881 passed
- `TestFileRenamedWithinPackage`: 2 passed
- `detect_stale_files`: 6 passed
- Manual end-to-end smoke test on a local package with rename: passes cleanly; verbose output shows "Removed 1 stale file(s) from <dep_key>".

Closes #666