### PR TITLE
test(marketplace): isolate test_auto_detect_through_proxy from real network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix `apm marketplace add` silently failing for private repos by using credentials when probing `marketplace.json` (#701)
+- Stop `test_auto_detect_through_proxy` from making real `api.github.com` calls by passing a mock `auth_resolver`, fixing flaky macOS CI rate-limit failures
 - Pin codex setup to `rust-v0.118.0` for security and reproducibility; update config to `wire_api = "responses"` (#663)
 - Propagate headers and environment variables through OpenCode MCP adapter with defensive copies to prevent mutation (#622)
 - Fix `apm install` hanging indefinitely when corporate firewalls silently drop SSH packets by setting `GIT_SSH_COMMAND` with `ConnectTimeout=30` (#652)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix `apm marketplace add` silently failing for private repos by using credentials when probing `marketplace.json` (#701)
-- Stop `test_auto_detect_through_proxy` from making real `api.github.com` calls by passing a mock `auth_resolver`, fixing flaky macOS CI rate-limit failures
+- Stop `test_auto_detect_through_proxy` from making real `api.github.com` calls by passing a mock `auth_resolver`, fixing flaky macOS CI rate-limit failures (#759)
 - Pin codex setup to `rust-v0.118.0` for security and reproducibility; update config to `wire_api = "responses"` (#663)
 - Propagate headers and environment variables through OpenCode MCP adapter with defensive copies to prevent mutation (#622)
 - Fix `apm install` hanging indefinitely when corporate firewalls silently drop SSH packets by setting `GIT_SSH_COMMAND` with `ConnectTimeout=30` (#652)

--- a/tests/unit/marketplace/test_marketplace_client.py
+++ b/tests/unit/marketplace/test_marketplace_client.py
@@ -295,9 +295,12 @@ class TestProxyAwareFetch:
                 return None  # first candidate not found
             return json.dumps(self._MARKETPLACE_JSON).encode()
 
+        mock_resolver = MagicMock()
+        mock_resolver.try_with_fallback.return_value = None
+        mock_resolver.classify_host.return_value = MagicMock(api_base="https://api.github.com")
         with patch("apm_cli.deps.registry_proxy.RegistryConfig.from_env", return_value=cfg), \
              patch("apm_cli.deps.artifactory_entry.fetch_entry_from_archive", side_effect=mock_entry):
-            path = client_mod._auto_detect_path(source)
+            path = client_mod._auto_detect_path(source, auth_resolver=mock_resolver)
 
         assert path == ".github/plugin/marketplace.json"
 

--- a/tests/unit/marketplace/test_marketplace_client.py
+++ b/tests/unit/marketplace/test_marketplace_client.py
@@ -297,7 +297,6 @@ class TestProxyAwareFetch:
 
         mock_resolver = MagicMock()
         mock_resolver.try_with_fallback.return_value = None
-        mock_resolver.classify_host.return_value = MagicMock(api_base="https://api.github.com")
         with patch("apm_cli.deps.registry_proxy.RegistryConfig.from_env", return_value=cfg), \
              patch("apm_cli.deps.artifactory_entry.fetch_entry_from_archive", side_effect=mock_entry):
             path = client_mod._auto_detect_path(source, auth_resolver=mock_resolver)


### PR DESCRIPTION
## Problem

The macOS x86_64 unit-test job has been failing intermittently with:

```
FAILED tests/unit/marketplace/test_marketplace_client.py::TestProxyAwareFetch::test_auto_detect_through_proxy
  apm_cli.marketplace.errors.MarketplaceFetchError: Failed to fetch marketplace 'acme':
  403 Client Error: rate limit exceeded for url:
  https://api.github.com/repos/acme-org/plugins/contents/marketplace.json?ref=main
```

Example failure: https://github.com/microsoft/apm/actions/runs/24597356401/job/71929864401

## Root cause

`test_auto_detect_through_proxy` mocked the proxy fetch but did **not** pass an `auth_resolver` to `_auto_detect_path`. When the proxy mock returns `None` for the first candidate path (`marketplace.json`), `_fetch_file` falls through to the GitHub Contents API path. Because no resolver was provided, a real `AuthResolver` was instantiated and made a live HTTP request to `api.github.com` — hitting the anonymous rate limit on shared macOS runners.

This is the kind of network call we want confined to authenticated integration tests, not unit CI.

## Fix

Pass a mock `auth_resolver` whose `try_with_fallback` returns `None` (simulates "file not found via GitHub fallback"). Probing then advances to the next candidate, which the proxy mock satisfies — verifying the auto-detect probing logic without any real network I/O.

## Validation

`uv run pytest tests/unit/marketplace/test_marketplace_client.py` -> 26 passed.