### PR TITLE
harden(plugin): enforce plugin-root containment for manifest paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix `apm marketplace add` silently failing for private repos by using credentials when probing `marketplace.json` (#701)
+- Harden marketplace plugin normalization to enforce that manifest-declared `agents`/`skills`/`commands`/`hooks` paths resolve inside the plugin root
 - Pin codex setup to `rust-v0.118.0` for security and reproducibility; update config to `wire_api = "responses"` (#663)
 - Propagate headers and environment variables through OpenCode MCP adapter with defensive copies to prevent mutation (#622)
 - Fix `apm install` hanging indefinitely when corporate firewalls silently drop SSH packets by setting `GIT_SSH_COMMAND` with `ConnectTimeout=30` (#652)

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -24,7 +24,7 @@ from ..utils.path_security import ensure_path_within, PathTraversalError
 _logger = logging.getLogger(__name__)
 
 
-def _is_within_plugin(candidate: Path, plugin_root: Path, *, component: str, raw: str) -> bool:
+def _is_within_plugin(candidate: Path, plugin_root: Path, *, component: str) -> bool:
     """Return True iff *candidate* resolves inside *plugin_root*.
 
     Logs a warning and returns False when the path escapes the plugin
@@ -32,19 +32,18 @@ def _is_within_plugin(candidate: Path, plugin_root: Path, *, component: str, raw
     Used to enforce the trust boundary on attacker-controlled manifest
     fields (agents/skills/commands/hooks) during plugin normalization.
 
-    The rejected path string is intentionally kept out of the warning
-    record (logged at debug level only) because manifest values are
-    externally controlled and may carry data flagged as sensitive by
-    static-analysis tooling.
+    The rejected path string and resolved exception are deliberately
+    omitted from log output: manifest values are externally controlled
+    and static-analysis tooling treats them as tainted/sensitive. The
+    component name alone is sufficient to identify which manifest field
+    was rejected; operators that need the full value can reproduce
+    locally with a clean checkout.
     """
     try:
         ensure_path_within(candidate, plugin_root)
-    except PathTraversalError as exc:
+    except PathTraversalError:
         _logger.warning(
             "Skipping %s entry: path escapes plugin root", component,
-        )
-        _logger.debug(
-            "Rejected %s entry %r: %s", component, raw, exc,
         )
         return False
     return True
@@ -382,7 +381,7 @@ def _map_plugin_artifacts(plugin_path: Path, apm_dir: Path, manifest: Optional[D
                 if (
                     src.exists()
                     and not src.is_symlink()
-                    and _is_within_plugin(src, plugin_path, component=component, raw=raw)
+                    and _is_within_plugin(src, plugin_path, component=component)
                 ):
                     paths.append(src)
             return paths
@@ -391,7 +390,7 @@ def _map_plugin_artifacts(plugin_path: Path, apm_dir: Path, manifest: Optional[D
             if (
                 src.exists()
                 and not src.is_symlink()
-                and _is_within_plugin(src, plugin_path, component=component, raw=custom)
+                and _is_within_plugin(src, plugin_path, component=component)
             ):
                 return [src]
             return []
@@ -400,7 +399,7 @@ def _map_plugin_artifacts(plugin_path: Path, apm_dir: Path, manifest: Optional[D
             default.exists()
             and not default.is_symlink()
             and default.is_dir()
-            and _is_within_plugin(default, plugin_path, component=component, raw=default_dir)
+            and _is_within_plugin(default, plugin_path, component=component)
         ):
             return [default]
         return []
@@ -493,7 +492,7 @@ def _map_plugin_artifacts(plugin_path: Path, apm_dir: Path, manifest: Optional[D
         # Config file path (e.g. "hooks": "hooks.json")
         src_file = plugin_path / hooks_value
         if src_file.is_symlink() or not _is_within_plugin(
-            src_file, plugin_path, component="hooks", raw=hooks_value
+            src_file, plugin_path, component="hooks"
         ):
             pass
         else:

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -31,13 +31,20 @@ def _is_within_plugin(candidate: Path, plugin_root: Path, *, component: str, raw
     root (absolute path, ``..`` traversal, or symlink pointing outside).
     Used to enforce the trust boundary on attacker-controlled manifest
     fields (agents/skills/commands/hooks) during plugin normalization.
+
+    The rejected path string is intentionally kept out of the warning
+    record (logged at debug level only) because manifest values are
+    externally controlled and may carry data flagged as sensitive by
+    static-analysis tooling.
     """
     try:
         ensure_path_within(candidate, plugin_root)
     except PathTraversalError as exc:
         _logger.warning(
-            "Skipping %s entry %r: path escapes plugin root (%s)",
-            component, raw, exc,
+            "Skipping %s entry: path escapes plugin root", component,
+        )
+        _logger.debug(
+            "Rejected %s entry %r: %s", component, raw, exc,
         )
         return False
     return True
@@ -389,7 +396,14 @@ def _map_plugin_artifacts(plugin_path: Path, apm_dir: Path, manifest: Optional[D
                 return [src]
             return []
         default = plugin_path / default_dir
-        return [default] if default.exists() and default.is_dir() else []
+        if (
+            default.exists()
+            and not default.is_symlink()
+            and default.is_dir()
+            and _is_within_plugin(default, plugin_path, component=component, raw=default_dir)
+        ):
+            return [default]
+        return []
 
     # Map agents/
     # Unlike skills (which are named directories containing SKILL.md), agents

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -18,6 +18,30 @@ from pathlib import Path
 from typing import Dict, Any, List, Optional
 import yaml
 
+from ..utils.path_security import ensure_path_within, PathTraversalError
+
+
+_logger = logging.getLogger(__name__)
+
+
+def _is_within_plugin(candidate: Path, plugin_root: Path, *, component: str, raw: str) -> bool:
+    """Return True iff *candidate* resolves inside *plugin_root*.
+
+    Logs a warning and returns False when the path escapes the plugin
+    root (absolute path, ``..`` traversal, or symlink pointing outside).
+    Used to enforce the trust boundary on attacker-controlled manifest
+    fields (agents/skills/commands/hooks) during plugin normalization.
+    """
+    try:
+        ensure_path_within(candidate, plugin_root)
+    except PathTraversalError as exc:
+        _logger.warning(
+            "Skipping %s entry %r: path escapes plugin root (%s)",
+            component, raw, exc,
+        )
+        return False
+    return True
+
 
 def parse_plugin_manifest(plugin_json_path: Path) -> Dict[str, Any]:
     """Parse a plugin.json manifest file.
@@ -333,19 +357,37 @@ def _map_plugin_artifacts(plugin_path: Path, apm_dir: Path, manifest: Optional[D
 
     # Resolve source paths  -- use manifest arrays if present, else defaults.
     # Custom paths may be directories OR individual files.
+    #
+    # Security: every manifest-controlled path is verified to resolve
+    # inside *plugin_path* before it is copied.  Without this guard, a
+    # malicious plugin could set ``"commands": "/etc/passwd"`` or
+    # ``"agents": ["../../host"]`` and trick ``apm install`` into copying
+    # arbitrary host files into the project's ``.apm/`` tree (and from
+    # there into ``.github/prompts/`` via auto-integration).
     def _resolve_sources(component: str, default_dir: str):
         """Return list of existing source paths (dirs or files) for a component."""
         custom = manifest.get(component)
         if isinstance(custom, list):
             paths = []
             for p in custom:
-                src = plugin_path / str(p)
-                if src.exists() and not src.is_symlink():
+                raw = str(p)
+                src = plugin_path / raw
+                if (
+                    src.exists()
+                    and not src.is_symlink()
+                    and _is_within_plugin(src, plugin_path, component=component, raw=raw)
+                ):
                     paths.append(src)
             return paths
         elif isinstance(custom, str):
             src = plugin_path / custom
-            return [src] if src.exists() and not src.is_symlink() else []
+            if (
+                src.exists()
+                and not src.is_symlink()
+                and _is_within_plugin(src, plugin_path, component=component, raw=custom)
+            ):
+                return [src]
+            return []
         default = plugin_path / default_dir
         return [default] if default.exists() and default.is_dir() else []
 
@@ -435,10 +477,14 @@ def _map_plugin_artifacts(plugin_path: Path, apm_dir: Path, manifest: Optional[D
         )
     elif isinstance(hooks_value, str) and (plugin_path / hooks_value).is_file():
         # Config file path (e.g. "hooks": "hooks.json")
-        target_hooks = apm_dir / "hooks"
-        target_hooks.mkdir(parents=True, exist_ok=True)
         src_file = plugin_path / hooks_value
-        if not src_file.is_symlink():
+        if src_file.is_symlink() or not _is_within_plugin(
+            src_file, plugin_path, component="hooks", raw=hooks_value
+        ):
+            pass
+        else:
+            target_hooks = apm_dir / "hooks"
+            target_hooks.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src_file, target_hooks / "hooks.json")
     else:
         # Directory path(s)  -- standard flow

--- a/tests/unit/test_plugin_parser.py
+++ b/tests/unit/test_plugin_parser.py
@@ -838,3 +838,95 @@ class TestSynthesizeMCPIntegration:
         assert len(mcp_deps) == 1
         assert mcp_deps[0]["name"] == "web-srv"
         assert mcp_deps[0]["transport"] == "http"
+
+
+class TestPathTraversalProtection:
+    """Regression tests for GHSA path-traversal advisory.
+
+    A malicious plugin must not be able to use absolute paths or ``..``
+    traversal in manifest fields (agents/skills/commands/hooks) to copy
+    arbitrary host files into ``.apm/``.
+    """
+
+    def _make_outside_secret(self, tmp_path: Path) -> Path:
+        outside = tmp_path / "outside" / "secret.md"
+        outside.parent.mkdir(parents=True, exist_ok=True)
+        outside.write_text("# STOLEN VIA APM INSTALL\n")
+        return outside
+
+    def _make_plugin(self, tmp_path: Path) -> tuple[Path, Path]:
+        plugin = tmp_path / "evil-plugin"
+        plugin.mkdir()
+        apm_dir = tmp_path / "victim" / ".apm"
+        apm_dir.mkdir(parents=True)
+        return plugin, apm_dir
+
+    def test_commands_absolute_path_rejected(self, tmp_path):
+        secret = self._make_outside_secret(tmp_path)
+        plugin, apm_dir = self._make_plugin(tmp_path)
+        manifest = {"name": "evil", "commands": str(secret)}
+
+        _map_plugin_artifacts(plugin, apm_dir, manifest)
+
+        prompts_dir = apm_dir / "prompts"
+        assert not prompts_dir.exists() or not list(prompts_dir.iterdir()), (
+            "Absolute commands path must not produce any prompts files"
+        )
+
+    def test_commands_traversal_path_rejected(self, tmp_path):
+        self._make_outside_secret(tmp_path)
+        plugin, apm_dir = self._make_plugin(tmp_path)
+        manifest = {"name": "evil", "commands": "../outside/secret.md"}
+
+        _map_plugin_artifacts(plugin, apm_dir, manifest)
+
+        prompts_dir = apm_dir / "prompts"
+        assert not prompts_dir.exists() or not list(prompts_dir.iterdir())
+
+    def test_agents_traversal_in_list_rejected(self, tmp_path):
+        outside_dir = tmp_path / "outside_agents"
+        outside_dir.mkdir()
+        (outside_dir / "evil.md").write_text("# evil")
+        plugin, apm_dir = self._make_plugin(tmp_path)
+        manifest = {"name": "evil", "agents": ["../outside_agents"]}
+
+        _map_plugin_artifacts(plugin, apm_dir, manifest)
+
+        agents_dir = apm_dir / "agents"
+        assert not agents_dir.exists() or not list(agents_dir.iterdir())
+
+    def test_skills_absolute_path_in_list_rejected(self, tmp_path):
+        outside_skill = tmp_path / "outside_skills" / "leak"
+        outside_skill.mkdir(parents=True)
+        (outside_skill / "SKILL.md").write_text("# leak")
+        plugin, apm_dir = self._make_plugin(tmp_path)
+        manifest = {"name": "evil", "skills": [str(outside_skill)]}
+
+        _map_plugin_artifacts(plugin, apm_dir, manifest)
+
+        skills_dir = apm_dir / "skills"
+        assert not skills_dir.exists() or not list(skills_dir.iterdir())
+
+    def test_hooks_string_traversal_rejected(self, tmp_path):
+        outside_hook = tmp_path / "outside" / "hooks.json"
+        outside_hook.parent.mkdir(parents=True, exist_ok=True)
+        outside_hook.write_text('{"hooks": {}}')
+        plugin, apm_dir = self._make_plugin(tmp_path)
+        manifest = {"name": "evil", "hooks": "../outside/hooks.json"}
+
+        _map_plugin_artifacts(plugin, apm_dir, manifest)
+
+        hooks_dir = apm_dir / "hooks"
+        assert not hooks_dir.exists() or not list(hooks_dir.iterdir())
+
+    def test_in_root_paths_still_accepted(self, tmp_path):
+        """Sanity check: legitimate manifest paths must still work."""
+        plugin, apm_dir = self._make_plugin(tmp_path)
+        custom = plugin / "custom_cmds"
+        custom.mkdir()
+        (custom / "hello.md").write_text("# hello")
+        manifest = {"name": "good", "commands": "custom_cmds"}
+
+        _map_plugin_artifacts(plugin, apm_dir, manifest)
+
+        assert (apm_dir / "prompts" / "hello.prompt.md").read_text() == "# hello"

--- a/tests/unit/test_plugin_parser.py
+++ b/tests/unit/test_plugin_parser.py
@@ -930,3 +930,20 @@ class TestPathTraversalProtection:
         _map_plugin_artifacts(plugin, apm_dir, manifest)
 
         assert (apm_dir / "prompts" / "hello.prompt.md").read_text() == "# hello"
+
+    def test_default_component_dir_as_symlink_rejected(self, tmp_path):
+        """Default 'agents'/'skills'/etc dirs must be rejected if they're symlinks
+        pointing outside the plugin root (no manifest override needed)."""
+        outside = tmp_path / "outside_target"
+        outside.mkdir()
+        (outside / "leak.md").write_text("# leak")
+        plugin, apm_dir = self._make_plugin(tmp_path)
+        (plugin / "agents").symlink_to(outside, target_is_directory=True)
+        manifest = {"name": "evil"}  # no custom paths -> default branch is taken
+
+        _map_plugin_artifacts(plugin, apm_dir, manifest)
+
+        agents_dir = apm_dir / "agents"
+        assert not agents_dir.exists() or not list(agents_dir.iterdir()), (
+            "Symlinked default component dir must not be copied"
+        )


### PR DESCRIPTION
## Summary

Tightens `_map_plugin_artifacts` so every manifest-controlled component path (`agents`, `skills`, `commands`, `hooks`) is verified to resolve inside the plugin root before it's copied into `.apm/`. Today the helper only checks `exists()` / `is_symlink()`; if a custom path points outside the plugin directory it gets copied anyway, which is inconsistent with the trust boundary we already enforce for MCP config files (`_read_mcp_file`) and with the rest of the codebase's use of `ensure_path_within`.

## Changes

- `src/apm_cli/deps/plugin_parser.py`: introduce `_is_within_plugin` helper that wraps `ensure_path_within` with a warning-and-skip behaviour, and apply it inside `_resolve_sources` (list + string forms) and the `hooks` string-config branch.
- `tests/unit/test_plugin_parser.py`: new `TestPathTraversalProtection` class covering absolute paths, `..` traversal, and the hooks string-config branch, plus a positive case to confirm legitimate in-root paths still work.
- `CHANGELOG.md`: hardening note under `Fixed`.

## Validation

- `uv run pytest tests/unit/test_plugin_parser.py` -> 67 passed (61 existing + 6 new)
- `uv run pytest tests/unit tests/test_console.py` -> 3939 passed

## Notes

Behaviour change is conservative: only paths escaping the plugin root are dropped, and a warning is logged identifying the offending component. No public API changes.