### PR TITLE
fix(install): harden stale-file cleanup with per-file content-hash provenance (#666 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Harden `apm install` stale-file cleanup (#666 follow-up): refuse to delete directory entries from the lockfile (closes a poisoned-lockfile vector); skip files the user has edited since APM deployed them via per-file SHA-256 provenance recorded in `apm.lock.yaml`; preview package-level orphan cleanup in `--dry-run`; reclassify recoverable cleanup failures as warnings (retried on next install) instead of errors; surface stale-file removals at default verbosity through a new `InstallLogger.stale_cleanup` / `orphan_cleanup` path; extract a shared `apm_cli.integration.cleanup.remove_stale_deployed_files` helper to dedupe the remote- and local-package cleanup blocks in `install.py`
+- Harden `apm install` stale-file cleanup to prevent unsafe lockfile deletions, preserve user-edited files via per-file SHA-256 provenance, and improve cleanup reporting during install and `--dry-run` (#666, #762)
 - Fix `apm marketplace add` silently failing for private repos by using credentials when probing `marketplace.json` (#701)
 - Harden marketplace plugin normalization to enforce that manifest-declared `agents`/`skills`/`commands`/`hooks` paths resolve inside the plugin root (#760)
 - Stop `test_auto_detect_through_proxy` from making real `api.github.com` calls by passing a mock `auth_resolver`, fixing flaky macOS CI rate-limit failures (#759)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Harden `apm install` stale-file cleanup (#666 follow-up): refuse to delete directory entries from the lockfile (closes a poisoned-lockfile vector); skip files the user has edited since APM deployed them via per-file SHA-256 provenance recorded in `apm.lock.yaml`; preview package-level orphan cleanup in `--dry-run`; reclassify recoverable cleanup failures as warnings (retried on next install) instead of errors; surface stale-file removals at default verbosity through a new `InstallLogger.stale_cleanup` / `orphan_cleanup` path; extract a shared `apm_cli.integration.cleanup.remove_stale_deployed_files` helper to dedupe the remote- and local-package cleanup blocks in `install.py`
 - Fix `apm marketplace add` silently failing for private repos by using credentials when probing `marketplace.json` (#701)
 - Harden marketplace plugin normalization to enforce that manifest-declared `agents`/`skills`/`commands`/`hooks` paths resolve inside the plugin root (#760)
 - Stop `test_auto_detect_through_proxy` from making real `api.github.com` calls by passing a mock `auth_resolver`, fixing flaky macOS CI rate-limit failures (#759)

--- a/docs/src/content/docs/reference/cli-commands.md
+++ b/docs/src/content/docs/reference/cli-commands.md
@@ -115,8 +115,19 @@ Exceptions:
 - MCP servers already configured but with changed manifest config are re-applied automatically (`updated`)
 - APM packages removed from `apm.yml` have their deployed files cleaned up on the next full `apm install`
 - APM packages whose ref/version changed in `apm.yml` are re-downloaded automatically (no `--update` needed)
-- Files previously deployed by a still-present package that are no longer produced (e.g. the package renamed or removed a primitive) are removed from disk and from `apm.lock.yaml` `deployed_files` on the next `apm install`
 - `--force` remains available for full overwrite/reset scenarios
+
+**Stale-file cleanup:**
+
+`apm install` removes files that a still-present package previously deployed but no longer produces -- for example after a package renames or drops a primitive. This keeps the workspace consistent with the manifest without any manual `apm prune`/`uninstall` step. Behaviour:
+
+- Scope: only files recorded under that package's `deployed_files` in `apm.lock.yaml` are eligible
+- Safety gate: paths that escape the project root or fall outside known integration prefixes are refused
+- Directory entries are refused outright -- APM only deletes individual files
+- Per-file provenance: APM records a content hash for each deployed file; if the on-disk content has changed since deploy time the file is treated as user-edited and kept (with a warning explaining how to remove it manually)
+- Skipped when integration reports an error for the package (avoids deleting a file that just failed to redeploy)
+- Files that fail to delete are kept in `deployed_files` and retried on the next `apm install`
+- Use `apm install --dry-run` to preview package-level orphan cleanup; intra-package stale cleanup is not previewed because it requires running integration
 
 **Examples:**
 ```bash

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -2700,11 +2700,16 @@ def _install_apm_dependencies(
         # ------------------------------------------------------------------
         if existing_lockfile and not only_packages:
             from ..integration.cleanup import remove_stale_deployed_files as _rmstale
-            _intended_keys = builtins.set(package_deployed_files.keys())
+            # Use intended_dep_keys (manifest intent, computed at ~line 1707) --
+            # NOT package_deployed_files.keys() (integration outcome). A transient
+            # integration failure for a still-declared package would leave its key
+            # absent from package_deployed_files; deriving orphans from the outcome
+            # set would then misclassify it as removed and delete its previously
+            # deployed files even though it is still in apm.yml.
             _orphan_total_deleted = 0
             _orphan_deleted_targets: builtins.list = []
             for _orphan_key, _orphan_dep in existing_lockfile.dependencies.items():
-                if _orphan_key in _intended_keys:
+                if _orphan_key in intended_dep_keys:
                     continue  # still in manifest -- handled by stale-cleanup below
                 if not _orphan_dep.deployed_files:
                     continue

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -809,6 +809,40 @@ def install(ctx, packages, runtime, exclude, only, update, dry_run, force, verbo
             if not apm_deps and not dev_apm_deps and not mcp_deps:
                 logger.progress("No dependencies found in apm.yml")
 
+            # Orphan preview: lockfile + manifest difference -- no integration
+            # required, accurate to compute.
+            try:
+                _dryrun_lock = LockFile.read(get_lockfile_path(apm_dir))
+            except Exception:
+                _dryrun_lock = None
+            if _dryrun_lock:
+                _intended_keys = builtins.set()
+                for _dep in (apm_deps or []) + (dev_apm_deps or []):
+                    try:
+                        _intended_keys.add(_dep.get_unique_key())
+                    except Exception:
+                        pass
+                _orphan_preview = detect_orphans(
+                    _dryrun_lock, _intended_keys, only_packages=only_packages,
+                )
+                if _orphan_preview:
+                    logger.progress(
+                        f"Files that would be removed (packages no longer in apm.yml): "
+                        f"{len(_orphan_preview)}"
+                    )
+                    for _orphan in sorted(_orphan_preview)[:10]:
+                        logger.progress(f"  - {_orphan}")
+                    if len(_orphan_preview) > 10:
+                        logger.progress(
+                            f"  ... and {len(_orphan_preview) - 10} more"
+                        )
+
+            logger.dry_run_notice(
+                "Per-package stale-file cleanup (renames within a package) is "
+                "not previewed -- it requires running integration. Run without "
+                "--dry-run to apply."
+            )
+
             logger.success("Dry run complete - no changes made")
             return
 
@@ -1012,56 +1046,44 @@ def install(ctx, packages, runtime, exclude, only, update, dry_run, force, verbo
                     # integration that are no longer produced.  Only run when
                     # integration completed without errors to avoid deleting
                     # files that failed to re-deploy.
-                    _errors_before = (
-                        _local_diagnostics.error_count
-                        if _local_diagnostics else 0
-                    )
                     _local_had_errors = (
                         _local_diagnostics is not None
                         and _local_diagnostics.error_count > _errors_before_local
                     )
                     if old_local_deployed and not _local_had_errors:
-                        _prev_local = builtins.set(old_local_deployed)
-                        _curr_local = builtins.set(_local_deployed)
-                        _stale = _prev_local - _curr_local
+                        from ..integration.cleanup import remove_stale_deployed_files as _rmstale
+                        _stale = builtins.set(old_local_deployed) - builtins.set(_local_deployed)
                         if _stale:
-                            import shutil as _local_shutil
-                            _stale_removed = 0
-                            _stale_deleted_paths = []
-                            _stale_failed = []
-                            for _stale_path in sorted(_stale):
-                                if BaseIntegrator.validate_deploy_path(
-                                    _stale_path, project_root, targets=_local_targets
-                                ):
-                                    _stale_target = project_root / _stale_path
-                                    if _stale_target.exists():
-                                        try:
-                                            if _stale_target.is_dir():
-                                                _local_shutil.rmtree(_stale_target)
-                                            else:
-                                                _stale_target.unlink()
-                                            _stale_deleted_paths.append(_stale_target)
-                                            _stale_removed += 1
-                                        except Exception:
-                                            _stale_failed.append(_stale_path)
-                                            logger.verbose_detail(
-                                                f"Failed to remove stale file: {_stale_path}"
-                                            )
-                            # Keep failed paths in local_deployed so they
-                            # are retried on the next install.
-                            _local_deployed.extend(_stale_failed)
-                            if _stale_deleted_paths:
+                            _local_prev_hashes = {}
+                            _prev_local_lf = _LocalLF.read(_local_lock_path)
+                            if _prev_local_lf:
+                                _local_prev_hashes = dict(
+                                    _prev_local_lf.local_deployed_file_hashes
+                                )
+                            _cleanup_result = _rmstale(
+                                _stale, project_root,
+                                dep_key="<local .apm/>",
+                                targets=_local_targets,
+                                diagnostics=_local_diagnostics,
+                                logger=logger,
+                                recorded_hashes=_local_prev_hashes,
+                            )
+                            # Failed paths stay in lockfile so we retry next time.
+                            _local_deployed.extend(_cleanup_result.failed)
+                            if _cleanup_result.deleted_targets:
                                 BaseIntegrator.cleanup_empty_parents(
-                                    _stale_deleted_paths, project_root
+                                    _cleanup_result.deleted_targets, project_root
                                 )
-                            if _stale_removed > 0:
-                                logger.verbose_detail(
-                                    f"Removed {_stale_removed} stale local file(s)"
-                                )
+                            logger.stale_cleanup(
+                                "<local .apm/>", len(_cleanup_result.deleted)
+                            )
 
-                    # Persist local_deployed_files in the lockfile
+                    # Persist local_deployed_files (and hashes) in the lockfile
                     _persist_lock = _LocalLF.read(_local_lock_path) or _LocalLF()
                     _persist_lock.local_deployed_files = sorted(_local_deployed)
+                    _persist_lock.local_deployed_file_hashes = _hash_deployed(
+                        _local_deployed
+                    )
                     # Only write if changed
                     _existing_for_cmp = _LocalLF.read(_local_lock_path)
                     if not _existing_for_cmp or not _persist_lock.is_semantically_equivalent(_existing_for_cmp):
@@ -1088,7 +1110,12 @@ def install(ctx, packages, runtime, exclude, only, update, dry_run, force, verbo
                 error_count = int(apm_diagnostics.error_count)
             except (TypeError, ValueError):
                 error_count = 0
-        logger.install_summary(apm_count=apm_count, mcp_count=mcp_count, errors=error_count)
+        logger.install_summary(
+            apm_count=apm_count,
+            mcp_count=mcp_count,
+            errors=error_count,
+            stale_cleaned=logger.stale_cleaned_total,
+        )
 
         # Hard-fail when critical security findings blocked any package.
         # Consistent with apm unpack which also hard-fails on critical.
@@ -1767,11 +1794,24 @@ def _install_apm_dependencies(
         from apm_cli.deps.lockfile import LockFile, LockedDependency, get_lockfile_path
         from apm_cli.deps.installed_package import InstalledPackage
         from apm_cli.deps.registry_proxy import RegistryConfig
-        from ..utils.content_hash import compute_package_hash as _compute_hash
+        from ..utils.content_hash import compute_package_hash as _compute_hash, compute_file_hash as _compute_file_hash
         installed_packages: List[InstalledPackage] = []
         package_deployed_files: builtins.dict = {}  # dep_key → list of relative deployed paths
+        package_deployed_file_hashes: builtins.dict = {}  # dep_key → {rel_path: "sha256:hex"}
         package_types: builtins.dict = {}  # dep_key → package type string
         _package_hashes: builtins.dict = {}  # dep_key → sha256 hash (captured at download/verify time)
+
+        def _hash_deployed(rel_paths):
+            """Hash currently-on-disk deployed files for provenance."""
+            out: builtins.dict = {}
+            for _rel in rel_paths or ():
+                _full = project_root / _rel
+                if _full.is_file() and not _full.is_symlink():
+                    try:
+                        out[_rel] = _compute_file_hash(_full)
+                    except Exception:
+                        pass
+            return out
 
         # Resolve registry proxy configuration once for this install session.
         registry_config = RegistryConfig.from_env()
@@ -2111,6 +2151,7 @@ def _install_apm_dependencies(
                         )
 
                     package_deployed_files[dep_key] = dep_deployed_files
+                    package_deployed_file_hashes[dep_key] = _hash_deployed(dep_deployed_files)
 
                     # In verbose mode, show inline skip/error count for this package
                     if logger and logger.verbose:
@@ -2369,6 +2410,7 @@ def _install_apm_dependencies(
                         total_links_resolved += int_result["links_resolved"]
                         dep_deployed = int_result["deployed_files"]
                         package_deployed_files[dep_key] = dep_deployed
+                        package_deployed_file_hashes[dep_key] = _hash_deployed(dep_deployed)
                     except Exception as e:
                         diagnostics.error(
                             f"Failed to integrate primitives from cached package: {e}",
@@ -2564,6 +2606,7 @@ def _install_apm_dependencies(
                             total_links_resolved += int_result["links_resolved"]
                             dep_deployed_fresh = int_result["deployed_files"]
                             package_deployed_files[dep_ref.get_unique_key()] = dep_deployed_fresh
+                            package_deployed_file_hashes[dep_ref.get_unique_key()] = _hash_deployed(dep_deployed_fresh)
                         except Exception as e:
                             # Don't fail installation if integration fails
                             diagnostics.error(
@@ -2659,49 +2702,52 @@ def _install_apm_dependencies(
         # Orphan cleanup: remove deployed files for packages that were
         # removed from the manifest.  This happens on every full install
         # (no only_packages), making apm install idempotent with the manifest.
-        # Handles both regular files and directory entries (e.g., legacy skills).
         # ------------------------------------------------------------------
         if orphaned_deployed_files:
             import shutil as _shutil
             _removed_orphan_count = 0
-            _failed_orphan_count = 0
             _deleted_orphan_paths: builtins.list = []
-            # Build validation targets that cover both default KNOWN_TARGETS
-            # and scope-resolved targets so legacy project-scope orphan paths
-            # (e.g., ".github/...") are also cleaned up at user scope.
-            _validation_targets = _targets or {}
-            _default_targets = getattr(BaseIntegrator, "KNOWN_TARGETS", None)
-            if _default_targets:
-                _validation_targets = {**_default_targets, **_validation_targets}
             for _orphan_path in sorted(orphaned_deployed_files):
                 # validate_deploy_path() is the safety gate: it rejects path-traversal,
                 # requires a known integration prefix, and checks the resolved path
-                # stays within project_root -- so rmtree is safe here.
-                if BaseIntegrator.validate_deploy_path(_orphan_path, project_root, targets=_validation_targets):
-                    _target = project_root / _orphan_path
-                    if _target.exists():
-                        try:
-                            if _target.is_dir():
-                                _shutil.rmtree(_target)
-                            else:
-                                _target.unlink()
-                            _deleted_orphan_paths.append(_target)
-                            _removed_orphan_count += 1
-                        except Exception as _orphan_err:
-                            _orphan_msg = f"Could not remove orphaned path {_orphan_path}: {_orphan_err}"
-                            diagnostics.error(_orphan_msg)
-                            if logger:
-                                logger.verbose_detail(f"  {_orphan_msg}")
-                            _failed_orphan_count += 1
+                # stays within project_root.
+                if not BaseIntegrator.validate_deploy_path(
+                    _orphan_path, project_root, targets=_targets or None,
+                ):
+                    continue
+                _target = project_root / _orphan_path
+                if not _target.exists():
+                    continue
+                # Refuse directory entries -- a directory under an integration
+                # prefix is almost certainly a poisoned lockfile entry.  APM
+                # only deploys (and so should only delete) individual files.
+                if _target.is_dir() and not _target.is_symlink():
+                    diagnostics.warn(
+                        (
+                            f"Refused to remove directory entry {_orphan_path}: "
+                            "APM only deletes individual files. Remove it "
+                            "manually from apm.lock.yaml if it was added by "
+                            "a malicious or corrupt lockfile."
+                        ),
+                    )
+                    continue
+                try:
+                    _target.unlink()
+                    _deleted_orphan_paths.append(_target)
+                    _removed_orphan_count += 1
+                except Exception as _orphan_err:
+                    diagnostics.warn(
+                        (
+                            f"Could not remove orphaned file {_orphan_path}: "
+                            f"{_orphan_err}. Path retained in lockfile; will "
+                            "retry on next 'apm install'."
+                        ),
+                    )
             # Clean up empty parent directories left after file removal
             if _deleted_orphan_paths:
                 BaseIntegrator.cleanup_empty_parents(_deleted_orphan_paths, project_root)
-            if _removed_orphan_count > 0:
-                if logger:
-                    logger.verbose_detail(
-                        f"Removed {_removed_orphan_count} file(s) from packages "
-                        "no longer in apm.yml"
-                    )
+            if logger:
+                logger.orphan_cleanup(_removed_orphan_count)
 
         # ------------------------------------------------------------------
         # Stale-file cleanup: within each package still present in the
@@ -2712,12 +2758,7 @@ def _install_apm_dependencies(
         # packages that left the manifest entirely.
         # ------------------------------------------------------------------
         if existing_lockfile and package_deployed_files:
-            import shutil as _shutil
-            _validation_targets = _targets or {}
-            _default_targets = getattr(BaseIntegrator, "KNOWN_TARGETS", None)
-            if _default_targets:
-                _validation_targets = {**_default_targets, **_validation_targets}
-
+            from ..integration.cleanup import remove_stale_deployed_files as _rmstale
             for dep_key, new_deployed in package_deployed_files.items():
                 # Skip packages whose integration reported errors this run --
                 # a file that failed to re-deploy would look stale and get
@@ -2728,52 +2769,27 @@ def _install_apm_dependencies(
                 prev_dep = existing_lockfile.get_dependency(dep_key)
                 if not prev_dep:
                     continue  # new package this install -- nothing stale yet
-                old_deployed = builtins.list(prev_dep.deployed_files)
-
-                stale = detect_stale_files(old_deployed, new_deployed)
+                stale = detect_stale_files(prev_dep.deployed_files, new_deployed)
                 if not stale:
                     continue
 
-                _stale_failed: builtins.list = []
-                _stale_deleted_paths: builtins.list = []
-                for stale_path in sorted(stale):
-                    # validate_deploy_path is the safety gate: no traversal,
-                    # must start with a known integration prefix, must resolve
-                    # inside project_root.
-                    if not BaseIntegrator.validate_deploy_path(
-                        stale_path, project_root, targets=_validation_targets
-                    ):
-                        continue
-                    stale_target = project_root / stale_path
-                    if not stale_target.exists():
-                        continue
-                    try:
-                        if stale_target.is_dir():
-                            _shutil.rmtree(stale_target)
-                        else:
-                            stale_target.unlink()
-                        _stale_deleted_paths.append(stale_target)
-                    except Exception as stale_err:
-                        _stale_failed.append(stale_path)
-                        stale_msg = f"Could not remove stale path {stale_path}: {stale_err}"
-                        diagnostics.error(stale_msg, package=dep_key)
-                        if logger:
-                            logger.verbose_detail(f"  {stale_msg}")
-
+                cleanup_result = _rmstale(
+                    stale, project_root,
+                    dep_key=dep_key,
+                    targets=_targets or None,
+                    diagnostics=diagnostics,
+                    logger=logger,
+                    recorded_hashes=dict(prev_dep.deployed_file_hashes),
+                )
                 # Re-insert failed paths so the lockfile retains them for
-                # retry on the next install (matches the local-package
-                # stale-cleanup pattern in install.py:1025).
-                new_deployed.extend(_stale_failed)
-
-                if _stale_deleted_paths:
+                # retry on the next install.
+                new_deployed.extend(cleanup_result.failed)
+                if cleanup_result.deleted_targets:
                     BaseIntegrator.cleanup_empty_parents(
-                        _stale_deleted_paths, project_root
+                        cleanup_result.deleted_targets, project_root
                     )
-                _removed = len(_stale_deleted_paths)
-                if _removed > 0 and logger:
-                    logger.verbose_detail(
-                        f"Removed {_removed} stale file(s) from {dep_key}"
-                    )
+                if logger:
+                    logger.stale_cleanup(dep_key, len(cleanup_result.deleted))
 
         # Generate apm.lock for reproducible installs (T4: lockfile generation)
         if installed_packages:
@@ -2783,6 +2799,13 @@ def _install_apm_dependencies(
                 for dep_key, dep_files in package_deployed_files.items():
                     if dep_key in lockfile.dependencies:
                         lockfile.dependencies[dep_key].deployed_files = dep_files
+                        # Hash the files as they exist on disk AFTER stale
+                        # cleanup so the recorded hashes match what is now
+                        # deployed (provenance for the next install's stale
+                        # cleanup).
+                        lockfile.dependencies[dep_key].deployed_file_hashes = (
+                            _hash_deployed(dep_files)
+                        )
                 for dep_key, pkg_type in package_types.items():
                     if dep_key in lockfile.dependencies:
                         lockfile.dependencies[dep_key].package_type = pkg_type

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -25,7 +25,29 @@ from ..drift import (
 from ..models.results import InstallResult
 from ..core.command_logger import InstallLogger, _ValidationOutcome
 from ..utils.console import _rich_echo, _rich_error, _rich_info, _rich_success
+from ..utils.content_hash import compute_file_hash as _compute_file_hash_for_provenance
 from ..utils.diagnostics import DiagnosticCollector
+
+
+def _hash_deployed(rel_paths, project_root: Path) -> dict:
+    """Hash currently-on-disk deployed files for provenance.
+
+    Module-level so both the local-package persist site (in
+    ``_integrate_local_content``) and the remote-package lockfile-build
+    site (in ``_install_apm_dependencies``) share one implementation.
+    Returns ``{rel_path: "sha256:<hex>"}`` for files that exist as regular
+    files; symlinks and unreadable paths are silently omitted (they cannot
+    contribute meaningful provenance).
+    """
+    out: dict = {}
+    for _rel in rel_paths or ():
+        _full = project_root / _rel
+        if _full.is_file() and not _full.is_symlink():
+            try:
+                out[_rel] = _compute_file_hash_for_provenance(_full)
+            except Exception:
+                pass
+    return out
 from ..utils.github_host import default_host, is_valid_fqdn
 from ..utils.path_security import safe_rmtree
 from ._helpers import (
@@ -1086,7 +1108,7 @@ def install(ctx, packages, runtime, exclude, only, update, dry_run, force, verbo
                     _persist_lock = _LocalLF.read(_local_lock_path) or _LocalLF()
                     _persist_lock.local_deployed_files = sorted(_local_deployed)
                     _persist_lock.local_deployed_file_hashes = _hash_deployed(
-                        _local_deployed
+                        _local_deployed, project_root
                     )
                     # Only write if changed
                     _existing_for_cmp = _LocalLF.read(_local_lock_path)
@@ -1798,23 +1820,11 @@ def _install_apm_dependencies(
         from apm_cli.deps.lockfile import LockFile, LockedDependency, get_lockfile_path
         from apm_cli.deps.installed_package import InstalledPackage
         from apm_cli.deps.registry_proxy import RegistryConfig
-        from ..utils.content_hash import compute_package_hash as _compute_hash, compute_file_hash as _compute_file_hash
+        from ..utils.content_hash import compute_package_hash as _compute_hash
         installed_packages: List[InstalledPackage] = []
         package_deployed_files: builtins.dict = {}  # dep_key → list of relative deployed paths
         package_types: builtins.dict = {}  # dep_key → package type string
         _package_hashes: builtins.dict = {}  # dep_key → sha256 hash (captured at download/verify time)
-
-        def _hash_deployed(rel_paths):
-            """Hash currently-on-disk deployed files for provenance."""
-            out: builtins.dict = {}
-            for _rel in rel_paths or ():
-                _full = project_root / _rel
-                if _full.is_file() and not _full.is_symlink():
-                    try:
-                        out[_rel] = _compute_file_hash(_full)
-                    except Exception:
-                        pass
-            return out
 
         # Resolve registry proxy configuration once for this install session.
         registry_config = RegistryConfig.from_env()
@@ -2717,7 +2727,15 @@ def _install_apm_dependencies(
                     _orphan_dep.deployed_files,
                     project_root,
                     dep_key=_orphan_key,
-                    targets=_targets or None,
+                    # targets=None -> validate against all KNOWN_TARGETS, not
+                    # just the active install's targets. An orphan can have
+                    # files under a target the user is not currently running
+                    # (e.g. switched runtime since the dep was installed,
+                    # or scope mismatch). Restricting to _targets here would
+                    # leave those files behind. Pre-PR code handled this by
+                    # explicitly merging KNOWN_TARGETS; targets=None is the
+                    # cleaner equivalent.
+                    targets=None,
                     diagnostics=diagnostics,
                     recorded_hashes=dict(_orphan_dep.deployed_file_hashes),
                     failed_path_retained=False,
@@ -2787,7 +2805,7 @@ def _install_apm_dependencies(
                         # deployed (provenance for the next install's stale
                         # cleanup).
                         lockfile.dependencies[dep_key].deployed_file_hashes = (
-                            _hash_deployed(dep_files)
+                            _hash_deployed(dep_files, project_root)
                         )
                 for dep_key, pkg_type in package_types.items():
                     if dep_key in lockfile.dependencies:

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -837,11 +837,12 @@ def install(ctx, packages, runtime, exclude, only, update, dry_run, force, verbo
                             f"  ... and {len(_orphan_preview) - 10} more"
                         )
 
-            logger.dry_run_notice(
-                "Per-package stale-file cleanup (renames within a package) is "
-                "not previewed -- it requires running integration. Run without "
-                "--dry-run to apply."
-            )
+            if (apm_deps or dev_apm_deps):
+                logger.dry_run_notice(
+                    "Per-package stale-file cleanup (renames within a package) is "
+                    "not previewed -- it requires running integration. Run without "
+                    "--dry-run to apply."
+                )
 
             logger.success("Dry run complete - no changes made")
             return
@@ -1065,7 +1066,6 @@ def install(ctx, packages, runtime, exclude, only, update, dry_run, force, verbo
                                 dep_key="<local .apm/>",
                                 targets=_local_targets,
                                 diagnostics=_local_diagnostics,
-                                logger=logger,
                                 recorded_hashes=_local_prev_hashes,
                             )
                             # Failed paths stay in lockfile so we retry next time.
@@ -1073,6 +1073,10 @@ def install(ctx, packages, runtime, exclude, only, update, dry_run, force, verbo
                             if _cleanup_result.deleted_targets:
                                 BaseIntegrator.cleanup_empty_parents(
                                     _cleanup_result.deleted_targets, project_root
+                                )
+                            for _skipped in _cleanup_result.skipped_user_edit:
+                                logger.cleanup_skipped_user_edit(
+                                    _skipped, "<local .apm/>"
                                 )
                             logger.stale_cleanup(
                                 "<local .apm/>", len(_cleanup_result.deleted)
@@ -1797,7 +1801,6 @@ def _install_apm_dependencies(
         from ..utils.content_hash import compute_package_hash as _compute_hash, compute_file_hash as _compute_file_hash
         installed_packages: List[InstalledPackage] = []
         package_deployed_files: builtins.dict = {}  # dep_key → list of relative deployed paths
-        package_deployed_file_hashes: builtins.dict = {}  # dep_key → {rel_path: "sha256:hex"}
         package_types: builtins.dict = {}  # dep_key → package type string
         _package_hashes: builtins.dict = {}  # dep_key → sha256 hash (captured at download/verify time)
 
@@ -1872,14 +1875,6 @@ def _install_apm_dependencies(
         # Normalize path separators once for O(1) lookups in check_collision
         from apm_cli.integration.base_integrator import BaseIntegrator
         managed_files = BaseIntegrator.normalize_managed_files(managed_files)
-
-        # Collect deployed file paths for packages that are no longer in the manifest.
-        # detect_orphans() returns an empty set for partial installs automatically.
-        orphaned_deployed_files = detect_orphans(
-            existing_lockfile,
-            intended_dep_keys,
-            only_packages=only_packages,
-        )
 
         # Install each dependency with Rich progress display
         from rich.progress import (
@@ -2151,7 +2146,6 @@ def _install_apm_dependencies(
                         )
 
                     package_deployed_files[dep_key] = dep_deployed_files
-                    package_deployed_file_hashes[dep_key] = _hash_deployed(dep_deployed_files)
 
                     # In verbose mode, show inline skip/error count for this package
                     if logger and logger.verbose:
@@ -2410,7 +2404,6 @@ def _install_apm_dependencies(
                         total_links_resolved += int_result["links_resolved"]
                         dep_deployed = int_result["deployed_files"]
                         package_deployed_files[dep_key] = dep_deployed
-                        package_deployed_file_hashes[dep_key] = _hash_deployed(dep_deployed)
                     except Exception as e:
                         diagnostics.error(
                             f"Failed to integrate primitives from cached package: {e}",
@@ -2606,7 +2599,6 @@ def _install_apm_dependencies(
                             total_links_resolved += int_result["links_resolved"]
                             dep_deployed_fresh = int_result["deployed_files"]
                             package_deployed_files[dep_ref.get_unique_key()] = dep_deployed_fresh
-                            package_deployed_file_hashes[dep_ref.get_unique_key()] = _hash_deployed(dep_deployed_fresh)
                         except Exception as e:
                             # Don't fail installation if integration fails
                             diagnostics.error(
@@ -2700,54 +2692,40 @@ def _install_apm_dependencies(
 
         # ------------------------------------------------------------------
         # Orphan cleanup: remove deployed files for packages that were
-        # removed from the manifest.  This happens on every full install
+        # removed from the manifest. This happens on every full install
         # (no only_packages), making apm install idempotent with the manifest.
+        # Routed through remove_stale_deployed_files() so the same safety
+        # gates -- including per-file content-hash provenance -- apply
+        # uniformly with the intra-package stale path below.
         # ------------------------------------------------------------------
-        if orphaned_deployed_files:
-            import shutil as _shutil
-            _removed_orphan_count = 0
-            _deleted_orphan_paths: builtins.list = []
-            for _orphan_path in sorted(orphaned_deployed_files):
-                # validate_deploy_path() is the safety gate: it rejects path-traversal,
-                # requires a known integration prefix, and checks the resolved path
-                # stays within project_root.
-                if not BaseIntegrator.validate_deploy_path(
-                    _orphan_path, project_root, targets=_targets or None,
-                ):
+        if existing_lockfile and not only_packages:
+            from ..integration.cleanup import remove_stale_deployed_files as _rmstale
+            _intended_keys = builtins.set(package_deployed_files.keys())
+            _orphan_total_deleted = 0
+            _orphan_deleted_targets: builtins.list = []
+            for _orphan_key, _orphan_dep in existing_lockfile.dependencies.items():
+                if _orphan_key in _intended_keys:
+                    continue  # still in manifest -- handled by stale-cleanup below
+                if not _orphan_dep.deployed_files:
                     continue
-                _target = project_root / _orphan_path
-                if not _target.exists():
-                    continue
-                # Refuse directory entries -- a directory under an integration
-                # prefix is almost certainly a poisoned lockfile entry.  APM
-                # only deploys (and so should only delete) individual files.
-                if _target.is_dir() and not _target.is_symlink():
-                    diagnostics.warn(
-                        (
-                            f"Refused to remove directory entry {_orphan_path}: "
-                            "APM only deletes individual files. Remove it "
-                            "manually from apm.lock.yaml if it was added by "
-                            "a malicious or corrupt lockfile."
-                        ),
-                    )
-                    continue
-                try:
-                    _target.unlink()
-                    _deleted_orphan_paths.append(_target)
-                    _removed_orphan_count += 1
-                except Exception as _orphan_err:
-                    diagnostics.warn(
-                        (
-                            f"Could not remove orphaned file {_orphan_path}: "
-                            f"{_orphan_err}. Path retained in lockfile; will "
-                            "retry on next 'apm install'."
-                        ),
-                    )
-            # Clean up empty parent directories left after file removal
-            if _deleted_orphan_paths:
-                BaseIntegrator.cleanup_empty_parents(_deleted_orphan_paths, project_root)
-            if logger:
-                logger.orphan_cleanup(_removed_orphan_count)
+                _orphan_result = _rmstale(
+                    _orphan_dep.deployed_files,
+                    project_root,
+                    dep_key=_orphan_key,
+                    targets=_targets or None,
+                    diagnostics=diagnostics,
+                    recorded_hashes=dict(_orphan_dep.deployed_file_hashes),
+                    failed_path_retained=False,
+                )
+                _orphan_total_deleted += len(_orphan_result.deleted)
+                _orphan_deleted_targets.extend(_orphan_result.deleted_targets)
+                for _skipped in _orphan_result.skipped_user_edit:
+                    logger.cleanup_skipped_user_edit(_skipped, _orphan_key)
+            if _orphan_deleted_targets:
+                BaseIntegrator.cleanup_empty_parents(
+                    _orphan_deleted_targets, project_root
+                )
+            logger.orphan_cleanup(_orphan_total_deleted)
 
         # ------------------------------------------------------------------
         # Stale-file cleanup: within each package still present in the
@@ -2778,7 +2756,6 @@ def _install_apm_dependencies(
                     dep_key=dep_key,
                     targets=_targets or None,
                     diagnostics=diagnostics,
-                    logger=logger,
                     recorded_hashes=dict(prev_dep.deployed_file_hashes),
                 )
                 # Re-insert failed paths so the lockfile retains them for
@@ -2788,8 +2765,9 @@ def _install_apm_dependencies(
                     BaseIntegrator.cleanup_empty_parents(
                         cleanup_result.deleted_targets, project_root
                     )
-                if logger:
-                    logger.stale_cleanup(dep_key, len(cleanup_result.deleted))
+                for _skipped in cleanup_result.skipped_user_edit:
+                    logger.cleanup_skipped_user_edit(_skipped, dep_key)
+                logger.stale_cleanup(dep_key, len(cleanup_result.deleted))
 
         # Generate apm.lock for reproducible installs (T4: lockfile generation)
         if installed_packages:

--- a/src/apm_cli/core/command_logger.py
+++ b/src/apm_cli/core/command_logger.py
@@ -322,7 +322,7 @@ class InstallLogger(CommandLogger):
             return
         self._stale_cleaned_total += count
         noun = "file" if count == 1 else "files"
-        _rich_info(f"Cleaned {count} stale {noun} from {dep_key}", symbol="gear")
+        _rich_info(f"Cleaned {count} stale {noun} from {dep_key}", symbol="info")
 
     def orphan_cleanup(self, count: int):
         """Log post-install orphan-file cleanup outcome at default verbosity.
@@ -336,7 +336,7 @@ class InstallLogger(CommandLogger):
         noun = "file" if count == 1 else "files"
         _rich_info(
             f"Cleaned {count} {noun} from packages no longer in apm.yml",
-            symbol="gear",
+            symbol="info",
         )
 
     @property
@@ -393,12 +393,12 @@ class InstallLogger(CommandLogger):
             summary = " and ".join(parts)
             if errors > 0:
                 _rich_warning(
-                    f"Installed {summary} with {errors} error(s).{cleanup_suffix}",
+                    f"Installed {summary}{cleanup_suffix} with {errors} error(s).",
                     symbol="warning",
                 )
             else:
                 _rich_success(
-                    f"Installed {summary}.{cleanup_suffix}", symbol="sparkles"
+                    f"Installed {summary}{cleanup_suffix}.", symbol="sparkles"
                 )
         elif errors > 0:
             _rich_error(

--- a/src/apm_cli/core/command_logger.py
+++ b/src/apm_cli/core/command_logger.py
@@ -170,6 +170,7 @@ class InstallLogger(CommandLogger):
     ):
         super().__init__("install", verbose=verbose, dry_run=dry_run)
         self.partial = partial  # True when specific packages are passed to `apm install`
+        self._stale_cleaned_total = 0  # Accumulated by stale_cleanup / orphan_cleanup
 
     # --- Validation phase ---
 
@@ -305,10 +306,76 @@ class InstallLogger(CommandLogger):
             return
         _rich_echo(f"    Package type: {type_label}", color="dim")
 
+    # --- Cleanup phase (stale and orphan file removal) ---
+
+    def stale_cleanup(self, dep_key: str, count: int):
+        """Log per-package stale-file cleanup outcome at default verbosity.
+
+        Stale-file deletion is a destructive operation in the user's
+        tracked workspace (unlike npm's ``node_modules``); it must be
+        visible without ``--verbose``. Rendered as an info line so it
+        groups visually with other phase messages, not as a tree item
+        (the originating package line was emitted earlier in the install
+        sequence and is no longer adjacent).
+        """
+        if count <= 0:
+            return
+        self._stale_cleaned_total += count
+        noun = "file" if count == 1 else "files"
+        _rich_info(f"Cleaned {count} stale {noun} from {dep_key}", symbol="gear")
+
+    def orphan_cleanup(self, count: int):
+        """Log post-install orphan-file cleanup outcome at default verbosity.
+
+        Same visibility rationale as :meth:`stale_cleanup`: file deletion
+        in the user's workspace must be visible by default.
+        """
+        if count <= 0:
+            return
+        self._stale_cleaned_total += count
+        noun = "file" if count == 1 else "files"
+        _rich_info(
+            f"Cleaned {count} {noun} from packages no longer in apm.yml",
+            symbol="gear",
+        )
+
+    @property
+    def stale_cleaned_total(self) -> int:
+        """Total files removed by stale + orphan cleanup during this install."""
+        return self._stale_cleaned_total
+
+    def cleanup_skipped_user_edit(self, rel_path: str, dep_key: str):
+        """Log a stale-file deletion that was skipped because the user
+        edited the file after APM deployed it.
+
+        Yellow inline at default verbosity -- the user needs to know APM
+        kept the file and a manual decision is pending.
+        """
+        _rich_warning(
+            f"  Kept user-edited file {rel_path} (from {dep_key}); "
+            "delete manually if no longer needed",
+            symbol="warning",
+        )
+
     # --- Install summary ---
 
-    def install_summary(self, apm_count: int, mcp_count: int, errors: int = 0):
-        """Log final install summary."""
+    def install_summary(
+        self,
+        apm_count: int,
+        mcp_count: int,
+        errors: int = 0,
+        stale_cleaned: int = 0,
+    ):
+        """Log final install summary.
+
+        Args:
+            apm_count: Number of APM dependencies installed.
+            mcp_count: Number of MCP servers installed.
+            errors: Number of errors collected during install.
+            stale_cleaned: Total stale + orphan files removed during
+                this install. Reported as a parenthetical so existing
+                callers and assertion patterns continue to work.
+        """
         parts = []
         if apm_count > 0:
             noun = "dependency" if apm_count == 1 else "dependencies"
@@ -317,14 +384,22 @@ class InstallLogger(CommandLogger):
             noun = "server" if mcp_count == 1 else "servers"
             parts.append(f"{mcp_count} MCP {noun}")
 
+        cleanup_suffix = ""
+        if stale_cleaned > 0:
+            file_noun = "file" if stale_cleaned == 1 else "files"
+            cleanup_suffix = f" ({stale_cleaned} stale {file_noun} cleaned)"
+
         if parts:
             summary = " and ".join(parts)
             if errors > 0:
                 _rich_warning(
-                    f"Installed {summary} with {errors} error(s).", symbol="warning"
+                    f"Installed {summary} with {errors} error(s).{cleanup_suffix}",
+                    symbol="warning",
                 )
             else:
-                _rich_success(f"Installed {summary}.", symbol="sparkles")
+                _rich_success(
+                    f"Installed {summary}.{cleanup_suffix}", symbol="sparkles"
+                )
         elif errors > 0:
             _rich_error(
                 f"Installation failed with {errors} error(s).", symbol="error"

--- a/src/apm_cli/deps/lockfile.py
+++ b/src/apm_cli/deps/lockfile.py
@@ -32,6 +32,7 @@ class LockedDependency:
     resolved_by: Optional[str] = None
     package_type: Optional[str] = None
     deployed_files: List[str] = field(default_factory=list)
+    deployed_file_hashes: Dict[str, str] = field(default_factory=dict)
     source: Optional[str] = None  # "local" for local deps, None/absent for remote
     local_path: Optional[str] = None  # Original local path (relative to project root)
     content_hash: Optional[str] = None  # SHA-256 of package file tree
@@ -72,6 +73,10 @@ class LockedDependency:
             result["package_type"] = self.package_type
         if self.deployed_files:
             result["deployed_files"] = sorted(self.deployed_files)
+        if self.deployed_file_hashes:
+            result["deployed_file_hashes"] = dict(
+                sorted(self.deployed_file_hashes.items())
+            )
         if self.source:
             result["source"] = self.source
         if self.local_path:
@@ -116,6 +121,7 @@ class LockedDependency:
             resolved_by=data.get("resolved_by"),
             package_type=data.get("package_type"),
             deployed_files=deployed_files,
+            deployed_file_hashes=dict(data.get("deployed_file_hashes") or {}),
             source=data.get("source"),
             local_path=data.get("local_path"),
             content_hash=data.get("content_hash"),
@@ -183,6 +189,7 @@ class LockFile:
     mcp_servers: List[str] = field(default_factory=list)
     mcp_configs: Dict[str, dict] = field(default_factory=dict)
     local_deployed_files: List[str] = field(default_factory=list)
+    local_deployed_file_hashes: Dict[str, str] = field(default_factory=dict)
 
     def add_dependency(self, dep: LockedDependency) -> None:
         """Add a dependency to the lock file."""
@@ -217,6 +224,10 @@ class LockFile:
             data["mcp_configs"] = dict(sorted(self.mcp_configs.items()))
         if self.local_deployed_files:
             data["local_deployed_files"] = sorted(self.local_deployed_files)
+        if self.local_deployed_file_hashes:
+            data["local_deployed_file_hashes"] = dict(
+                sorted(self.local_deployed_file_hashes.items())
+            )
         from ..utils.yaml_io import yaml_to_str
         return yaml_to_str(data)
 
@@ -238,6 +249,9 @@ class LockFile:
         lock.mcp_servers = list(data.get("mcp_servers", []))
         lock.mcp_configs = dict(data.get("mcp_configs") or {})
         lock.local_deployed_files = list(data.get("local_deployed_files", []))
+        lock.local_deployed_file_hashes = dict(
+            data.get("local_deployed_file_hashes") or {}
+        )
         return lock
 
     def write(self, path: Path) -> None:

--- a/src/apm_cli/integration/cleanup.py
+++ b/src/apm_cli/integration/cleanup.py
@@ -29,7 +29,6 @@ or progress lines through *logger*.
 
 from __future__ import annotations
 
-import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional
@@ -68,37 +67,48 @@ def remove_stale_deployed_files(
     dep_key: str,
     targets,
     diagnostics,
-    logger,
     recorded_hashes: Optional[Dict[str, str]] = None,
+    failed_path_retained: bool = True,
 ) -> CleanupResult:
     """Remove APM-deployed files that are no longer produced by *dep_key*.
 
     Args:
         stale_paths: Workspace-relative paths flagged as stale by
-            :func:`apm_cli.drift.detect_stale_files`.
+            :func:`apm_cli.drift.detect_stale_files` (intra-package
+            renames/removals) or :func:`apm_cli.drift.detect_orphans`
+            (whole package removed from the manifest).
         project_root: Project root the deletion is scoped within.
         dep_key: Unique key of the package these paths belong to (used
-            for diagnostic attribution and verbose output).
+            for diagnostic attribution).
         targets: Resolved target profiles for this install (passed
             through to :meth:`BaseIntegrator.validate_deploy_path`).
         diagnostics: ``DiagnosticCollector`` -- recoverable warnings
             (user-edit skip, unlink failure, refused directory entry)
             are pushed here.
-        logger: ``CommandLogger`` (or subclass) for inline verbose
-            output. May be ``None`` only in tests; production callers
-            always pass an instance.
         recorded_hashes: Mapping from rel-path to ``"sha256:<hex>"`` as
             stored on the previous ``LockedDependency``. ``None`` (or
             empty) disables the per-file provenance check entirely --
             preserved for backward compat with pre-hash lockfiles.
+        failed_path_retained: When ``True`` (default, intra-package
+            stale cleanup) the failure diagnostic tells the user APM
+            will retry on the next install -- the caller is expected
+            to re-insert ``result.failed`` into the new
+            ``deployed_files``. When ``False`` (orphan cleanup) the
+            owning package is being removed from the lockfile so a
+            failed path cannot be retained; the diagnostic instructs
+            the user to remove the file manually instead.
 
     Returns:
         :class:`CleanupResult` describing what happened. The caller is
         responsible for any post-deletion bookkeeping (extending the
         new ``deployed_files`` list with ``failed`` so they are retried,
         invoking :meth:`BaseIntegrator.cleanup_empty_parents` on
-        ``deleted_targets``, and reporting ``deleted`` count to the user
-        via the appropriate logger method).
+        ``deleted_targets``, calling
+        :meth:`InstallLogger.cleanup_skipped_user_edit` for each entry
+        in ``skipped_user_edit`` so the inline yellow warning renders,
+        and reporting ``deleted`` count to the user via
+        :meth:`InstallLogger.stale_cleanup` /
+        :meth:`InstallLogger.orphan_cleanup`).
     """
     result = CleanupResult()
     recorded_hashes = recorded_hashes or {}
@@ -165,13 +175,23 @@ def remove_stale_deployed_files(
             result.deleted_targets.append(stale_target)
         except Exception as exc:
             result.failed.append(stale_path)
-            diagnostics.warn(
-                (
-                    f"Could not remove stale file {stale_path}: {exc}. "
-                    "Path retained in lockfile; will retry on next "
-                    "'apm install'."
-                ),
-                package=dep_key,
-            )
+            if failed_path_retained:
+                diagnostics.warn(
+                    (
+                        f"Could not remove stale file {stale_path}: {exc}. "
+                        "Path retained in lockfile; will retry on next "
+                        "'apm install'."
+                    ),
+                    package=dep_key,
+                )
+            else:
+                diagnostics.warn(
+                    (
+                        f"Could not remove orphaned file {stale_path}: {exc}. "
+                        "The owning package is no longer in apm.yml -- "
+                        "delete the file manually."
+                    ),
+                    package=dep_key,
+                )
 
     return result

--- a/src/apm_cli/integration/cleanup.py
+++ b/src/apm_cli/integration/cleanup.py
@@ -1,0 +1,177 @@
+"""Shared cleanup helper for stale deployed files.
+
+Used by the post-install cleanup blocks in :mod:`apm_cli.commands.install`
+to remove files previously deployed for a still-present package that the
+current install no longer produces (e.g. after a rename or removal inside
+the package). Centralises the safety gates so both the local-package and
+remote-package cleanup paths apply the same rules.
+
+Safety gates, in order:
+
+1. **Path validation** -- :meth:`BaseIntegrator.validate_deploy_path` rejects
+   path traversal and any path not under a known integration prefix.
+2. **Directory rejection** -- APM-managed primitives are file-keyed
+   (``SKILL.md`` for skills, individual ``.prompt.md`` / ``.instructions.md``
+   files elsewhere). A ``deployed_files`` entry that resolves to a directory
+   on disk is treated as untrusted (likely a poisoned lockfile entry under a
+   broad prefix like ``.github/instructions/``) and refused.
+3. **Provenance check** -- when the previous lockfile recorded a content
+   hash for the file, the on-disk content must still match. If the user
+   edited the file after APM deployed it the hash will differ and the
+   deletion is skipped with a warning. Files without a recorded hash
+   (legacy lockfiles) fall through and are deleted, preserving prior
+   behaviour.
+
+The helper does not own diagnostics-vs-logger output formatting policy;
+it pushes warnings to *diagnostics* (collect-then-render) and informational
+or progress lines through *logger*.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from .base_integrator import BaseIntegrator
+
+
+@dataclass
+class CleanupResult:
+    """Outcome of a stale-file cleanup pass for a single package."""
+
+    deleted: List[str] = field(default_factory=list)
+    """Workspace-relative paths actually removed from disk."""
+
+    failed: List[str] = field(default_factory=list)
+    """Paths that raised during ``unlink``/``rmtree`` and should be
+    retained in ``deployed_files`` for retry on the next install."""
+
+    skipped_user_edit: List[str] = field(default_factory=list)
+    """Paths skipped because the on-disk content no longer matches the
+    hash APM recorded at deploy time -- treated as user-edited."""
+
+    skipped_unmanaged: List[str] = field(default_factory=list)
+    """Paths refused by the safety gates (validation failure, directory
+    entry, etc.). Not retained in ``deployed_files``."""
+
+    deleted_targets: List[Path] = field(default_factory=list)
+    """Absolute paths of deleted entries -- input to
+    :meth:`BaseIntegrator.cleanup_empty_parents`."""
+
+
+def remove_stale_deployed_files(
+    stale_paths: Iterable[str],
+    project_root: Path,
+    *,
+    dep_key: str,
+    targets,
+    diagnostics,
+    logger,
+    recorded_hashes: Optional[Dict[str, str]] = None,
+) -> CleanupResult:
+    """Remove APM-deployed files that are no longer produced by *dep_key*.
+
+    Args:
+        stale_paths: Workspace-relative paths flagged as stale by
+            :func:`apm_cli.drift.detect_stale_files`.
+        project_root: Project root the deletion is scoped within.
+        dep_key: Unique key of the package these paths belong to (used
+            for diagnostic attribution and verbose output).
+        targets: Resolved target profiles for this install (passed
+            through to :meth:`BaseIntegrator.validate_deploy_path`).
+        diagnostics: ``DiagnosticCollector`` -- recoverable warnings
+            (user-edit skip, unlink failure, refused directory entry)
+            are pushed here.
+        logger: ``CommandLogger`` (or subclass) for inline verbose
+            output. May be ``None`` only in tests; production callers
+            always pass an instance.
+        recorded_hashes: Mapping from rel-path to ``"sha256:<hex>"`` as
+            stored on the previous ``LockedDependency``. ``None`` (or
+            empty) disables the per-file provenance check entirely --
+            preserved for backward compat with pre-hash lockfiles.
+
+    Returns:
+        :class:`CleanupResult` describing what happened. The caller is
+        responsible for any post-deletion bookkeeping (extending the
+        new ``deployed_files`` list with ``failed`` so they are retried,
+        invoking :meth:`BaseIntegrator.cleanup_empty_parents` on
+        ``deleted_targets``, and reporting ``deleted`` count to the user
+        via the appropriate logger method).
+    """
+    result = CleanupResult()
+    recorded_hashes = recorded_hashes or {}
+
+    for stale_path in sorted(stale_paths):
+        # Gate 1: path validation (traversal, allowed prefix, in-tree).
+        if not BaseIntegrator.validate_deploy_path(
+            stale_path, project_root, targets=targets
+        ):
+            result.skipped_unmanaged.append(stale_path)
+            continue
+
+        stale_target = project_root / stale_path
+        if not stale_target.exists():
+            # File already gone -- treat as cleaned (no-op success).
+            continue
+
+        # Gate 2: directory rejection. APM-managed primitives are
+        # file-keyed; a directory entry under an integration prefix is
+        # almost certainly a poisoned lockfile entry that would rmtree
+        # an entire user-managed subtree.
+        if stale_target.is_dir() and not stale_target.is_symlink():
+            result.skipped_unmanaged.append(stale_path)
+            diagnostics.warn(
+                (
+                    f"Refused to remove directory entry {stale_path}: APM "
+                    "only deletes individual files. If this entry was added "
+                    "by a malicious or corrupt lockfile, remove it manually "
+                    "from apm.lock.yaml."
+                ),
+                package=dep_key,
+            )
+            continue
+
+        # Gate 3: provenance check. If APM recorded a content hash for
+        # this file at deploy time and it no longer matches, the user
+        # has edited the file -- skip deletion and warn so they can
+        # decide what to do.
+        expected_hash = recorded_hashes.get(stale_path)
+        if expected_hash:
+            try:
+                from ..utils.content_hash import compute_file_hash
+
+                actual_hash = compute_file_hash(stale_target)
+            except Exception:
+                actual_hash = None
+            if actual_hash and actual_hash != expected_hash:
+                result.skipped_user_edit.append(stale_path)
+                diagnostics.warn(
+                    (
+                        f"Skipped removing {stale_path}: file has been "
+                        "edited since APM deployed it. Delete it manually "
+                        "if you no longer need it, or ignore this warning "
+                        "to keep your changes."
+                    ),
+                    package=dep_key,
+                )
+                continue
+
+        # All gates passed -- safe to delete.
+        try:
+            stale_target.unlink()
+            result.deleted.append(stale_path)
+            result.deleted_targets.append(stale_target)
+        except Exception as exc:
+            result.failed.append(stale_path)
+            diagnostics.warn(
+                (
+                    f"Could not remove stale file {stale_path}: {exc}. "
+                    "Path retained in lockfile; will retry on next "
+                    "'apm install'."
+                ),
+                package=dep_key,
+            )
+
+    return result

--- a/src/apm_cli/integration/cleanup.py
+++ b/src/apm_cli/integration/cleanup.py
@@ -22,9 +22,11 @@ Safety gates, in order:
    (legacy lockfiles) fall through and are deleted, preserving prior
    behaviour.
 
-The helper does not own diagnostics-vs-logger output formatting policy;
-it pushes warnings to *diagnostics* (collect-then-render) and informational
-or progress lines through *logger*.
+The helper records cleanup diagnostics via *diagnostics* (collect-then-
+render) and returns a :class:`CleanupResult` summarizing deleted, failed,
+and skipped paths. Callers remain responsible for any informational,
+progress, or warning logging based on that result -- the helper itself
+takes no logger.
 """
 
 from __future__ import annotations
@@ -146,16 +148,28 @@ def remove_stale_deployed_files(
         # Gate 3: provenance check. If APM recorded a content hash for
         # this file at deploy time and it no longer matches, the user
         # has edited the file -- skip deletion and warn so they can
-        # decide what to do.
+        # decide what to do. Fails CLOSED on hash-read errors: if APM
+        # cannot prove the file is unmodified (PermissionError, race,
+        # etc.) we keep it rather than risk destroying user work.
         expected_hash = recorded_hashes.get(stale_path)
         if expected_hash:
             try:
                 from ..utils.content_hash import compute_file_hash
 
                 actual_hash = compute_file_hash(stale_target)
-            except Exception:
-                actual_hash = None
-            if actual_hash and actual_hash != expected_hash:
+            except Exception as _hash_exc:
+                result.skipped_user_edit.append(stale_path)
+                diagnostics.warn(
+                    (
+                        f"Skipped removing {stale_path}: could not verify "
+                        f"file content ({_hash_exc.__class__.__name__}). "
+                        "Inspect the file and delete it manually if no "
+                        "longer needed."
+                    ),
+                    package=dep_key,
+                )
+                continue
+            if actual_hash != expected_hash:
                 result.skipped_user_edit.append(stale_path)
                 diagnostics.warn(
                     (

--- a/src/apm_cli/utils/content_hash.py
+++ b/src/apm_cli/utils/content_hash.py
@@ -58,6 +58,29 @@ def compute_package_hash(package_path: Path) -> str:
     return f"sha256:{hasher.hexdigest()}"
 
 
+def compute_file_hash(file_path: Path) -> str:
+    """Compute SHA-256 of a single file's contents.
+
+    Used for per-deployed-file provenance checks before APM deletes a
+    file recorded in ``deployed_files``. The path itself is not mixed
+    in (unlike :func:`compute_package_hash`) because deployed files may
+    be renamed by integrators (e.g. ``.md`` -> ``.mdc`` for Cursor).
+
+    Args:
+        file_path: File to hash.
+
+    Returns:
+        Hash string in format ``"sha256:<hex_digest>"``. Returns the
+        empty-content hash when the path does not exist or is not a
+        regular file.
+    """
+    if not file_path.is_file() or file_path.is_symlink():
+        return _EMPTY_HASH
+    hasher = hashlib.sha256()
+    hasher.update(file_path.read_bytes())
+    return f"sha256:{hasher.hexdigest()}"
+
+
 def verify_package_hash(package_path: Path, expected_hash: str) -> bool:
     """Verify a package's content matches the expected hash.
 

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -37,6 +37,29 @@ class TestLockedDependency:
         assert locked.repo_url == "owner/repo"
         assert locked.resolved_commit == "abc123"
 
+    def test_deployed_file_hashes_round_trip(self):
+        dep = LockedDependency(
+            repo_url="owner/repo",
+            deployed_files=["a.md", "b.md"],
+            deployed_file_hashes={"b.md": "sha256:dead", "a.md": "sha256:beef"},
+        )
+        d = dep.to_dict()
+        # Serialised deterministically (sorted by key).
+        assert list(d["deployed_file_hashes"].keys()) == ["a.md", "b.md"]
+        assert (
+            LockedDependency.from_dict(d).deployed_file_hashes
+            == dep.deployed_file_hashes
+        )
+
+    def test_deployed_file_hashes_omitted_when_empty(self):
+        """Backward compat: legacy dicts without the field stay clean."""
+        dep = LockedDependency(repo_url="owner/repo")
+        assert "deployed_file_hashes" not in dep.to_dict()
+
+    def test_from_dict_missing_hashes_defaults_empty(self):
+        loaded = LockedDependency.from_dict({"repo_url": "owner/repo"})
+        assert loaded.deployed_file_hashes == {}
+
 
 class TestLockFile:
     def test_add_and_get_dependency(self):
@@ -77,7 +100,6 @@ class TestLockFile:
         lock.add_dependency(LockedDependency(repo_url="owner/repo"))
         lock_path = tmp_path / "apm.lock"
         lock.write(lock_path)
-
         loaded = LockFile.read(lock_path)
         assert loaded is not None
         assert loaded.mcp_servers == ["acme-kb", "atlassian", "github"]  # sorted
@@ -87,6 +109,24 @@ class TestLockFile:
         assert lock.mcp_servers == []
         yaml_str = lock.to_yaml()
         assert "mcp_servers" not in yaml_str  # omitted when empty
+
+    def test_local_deployed_file_hashes_round_trip(self, tmp_path):
+        """local_deployed_file_hashes must survive a write -> read cycle."""
+        lock = LockFile()
+        lock.local_deployed_files = ["a.md", "b.md"]
+        lock.local_deployed_file_hashes = {"a.md": "sha256:1", "b.md": "sha256:2"}
+        path = tmp_path / "apm.lock"
+        lock.write(path)
+        loaded = LockFile.read(path)
+        assert loaded is not None
+        assert loaded.local_deployed_file_hashes == {
+            "a.md": "sha256:1",
+            "b.md": "sha256:2",
+        }
+
+    def test_local_deployed_file_hashes_omitted_when_empty(self):
+        lock = LockFile()
+        assert "local_deployed_file_hashes" not in lock.to_yaml()
 
     def test_mcp_servers_from_yaml(self):
         yaml_str = (

--- a/tests/unit/integration/test_cleanup_helper.py
+++ b/tests/unit/integration/test_cleanup_helper.py
@@ -168,6 +168,43 @@ def test_no_recorded_hashes_falls_through_to_delete(project_root, diagnostics, l
     assert not target.exists()
 
 
+def test_hash_read_failure_fails_closed(project_root, diagnostics, logger, monkeypatch):
+    """Provenance gate must fail CLOSED on hash-read errors.
+
+    Regression test for PR #762 review feedback: previously a
+    ``compute_file_hash`` exception (e.g. ``PermissionError``) was
+    swallowed and ``actual_hash`` became ``None``, allowing the file
+    to be deleted even though a hash was recorded. With a hash
+    recorded but unreadable the helper cannot prove the file is
+    unmodified, so it must skip deletion.
+    """
+    rel = ".github/prompts/unreadable.prompt.md"
+    target = _make_managed_file(project_root, rel, "could be edited, can't tell\n")
+    recorded = {rel: "sha256:" + "1" * 64}
+
+    def _boom(_path):
+        raise PermissionError("simulated EACCES")
+
+    # The helper imports compute_file_hash lazily inside the gate, so
+    # patch the source module.
+    monkeypatch.setattr(
+        "apm_cli.utils.content_hash.compute_file_hash", _boom
+    )
+    result = remove_stale_deployed_files(
+        [rel], project_root,
+        dep_key="pkg", targets=None,
+        diagnostics=diagnostics,
+        recorded_hashes=recorded,
+    )
+    assert result.deleted == []
+    assert result.skipped_user_edit == [rel]
+    assert target.exists()
+    msgs = [d.message for d in diagnostics._diagnostics]
+    assert any("could not verify" in m.lower() for m in msgs), (
+        "Expected fail-closed warning mentioning the verification failure."
+    )
+
+
 def test_unlink_failure_is_retained_for_retry(project_root, diagnostics, logger, monkeypatch):
     rel = ".github/prompts/cant-delete.prompt.md"
     _make_managed_file(project_root, rel)
@@ -281,6 +318,34 @@ def test_orphan_loop_uses_manifest_intent_not_integration_outcome():
         "Orphan loop must not derive membership from package_deployed_files.keys() -- "
         "see test_orphan_loop_uses_manifest_intent_not_integration_outcome docstring."
     )
+
+
+def test_hash_deployed_is_module_level_and_works(tmp_path):
+    """Regression test for PR #762 review feedback.
+
+    Previously ``_hash_deployed`` was an inner closure of
+    ``_install_apm_dependencies`` but was *referenced* from
+    ``_integrate_local_content`` (a sibling module-level function),
+    which would raise ``NameError`` at runtime whenever the local
+    ``.apm/`` persist path executed. Promoted to module scope so both
+    call sites share one implementation. This test pins:
+
+    1. The helper is module-importable (no NameError at import time).
+    2. It accepts the new ``(rel_paths, project_root)`` signature.
+    3. It returns ``{rel: "sha256:<hex>"}`` for regular files and
+       silently omits symlinks / missing paths.
+    """
+    from apm_cli.commands.install import _hash_deployed
+
+    (tmp_path / "a.txt").write_text("hello\n", encoding="utf-8")
+    (tmp_path / "missing.txt")  # never created
+    out = _hash_deployed(["a.txt", "missing.txt"], tmp_path)
+    assert "a.txt" in out
+    assert out["a.txt"].startswith("sha256:")
+    assert "missing.txt" not in out
+    # Empty input is safe.
+    assert _hash_deployed([], tmp_path) == {}
+    assert _hash_deployed(None, tmp_path) == {}
 
 
 def test_result_dataclass_defaults():

--- a/tests/unit/integration/test_cleanup_helper.py
+++ b/tests/unit/integration/test_cleanup_helper.py
@@ -50,7 +50,7 @@ def test_happy_path_deletes_under_known_prefix(project_root, diagnostics, logger
     result = remove_stale_deployed_files(
         [".github/prompts/old.prompt.md"], project_root,
         dep_key="pkg", targets=None,
-        diagnostics=diagnostics, logger=logger,
+        diagnostics=diagnostics,
     )
     assert result.deleted == [".github/prompts/old.prompt.md"]
     assert not result.failed
@@ -63,7 +63,7 @@ def test_path_traversal_rejected(project_root, diagnostics, logger):
     result = remove_stale_deployed_files(
         ["../escape.md"], project_root,
         dep_key="pkg", targets=None,
-        diagnostics=diagnostics, logger=logger,
+        diagnostics=diagnostics,
     )
     assert result.deleted == []
     assert result.skipped_unmanaged == ["../escape.md"]
@@ -76,7 +76,7 @@ def test_unmanaged_prefix_rejected(project_root, diagnostics, logger):
     result = remove_stale_deployed_files(
         [rel], project_root,
         dep_key="pkg", targets=None,
-        diagnostics=diagnostics, logger=logger,
+        diagnostics=diagnostics,
     )
     assert result.deleted == []
     assert rel in result.skipped_unmanaged
@@ -99,7 +99,7 @@ def test_directory_entry_refused(project_root, diagnostics, logger):
     result = remove_stale_deployed_files(
         [".github/instructions"], project_root,
         dep_key="pkg", targets=None,
-        diagnostics=diagnostics, logger=logger,
+        diagnostics=diagnostics,
     )
     assert result.deleted == []
     assert ".github/instructions" in result.skipped_unmanaged
@@ -114,7 +114,7 @@ def test_missing_file_treated_as_already_clean(project_root, diagnostics, logger
     result = remove_stale_deployed_files(
         [".github/prompts/gone.prompt.md"], project_root,
         dep_key="pkg", targets=None,
-        diagnostics=diagnostics, logger=logger,
+        diagnostics=diagnostics,
     )
     assert result.deleted == []
     assert result.failed == []
@@ -130,7 +130,7 @@ def test_hash_mismatch_skips_user_edited_file(project_root, diagnostics, logger)
     result = remove_stale_deployed_files(
         [rel], project_root,
         dep_key="pkg", targets=None,
-        diagnostics=diagnostics, logger=logger,
+        diagnostics=diagnostics,
         recorded_hashes=fake_recorded,
     )
     assert result.deleted == []
@@ -147,7 +147,7 @@ def test_hash_match_deletes_file(project_root, diagnostics, logger):
     result = remove_stale_deployed_files(
         [rel], project_root,
         dep_key="pkg", targets=None,
-        diagnostics=diagnostics, logger=logger,
+        diagnostics=diagnostics,
         recorded_hashes=recorded,
     )
     assert result.deleted == [rel]
@@ -161,7 +161,7 @@ def test_no_recorded_hashes_falls_through_to_delete(project_root, diagnostics, l
     result = remove_stale_deployed_files(
         [rel], project_root,
         dep_key="pkg", targets=None,
-        diagnostics=diagnostics, logger=logger,
+        diagnostics=diagnostics,
         recorded_hashes=None,
     )
     assert result.deleted == [rel]
@@ -179,12 +179,69 @@ def test_unlink_failure_is_retained_for_retry(project_root, diagnostics, logger,
     result = remove_stale_deployed_files(
         [rel], project_root,
         dep_key="pkg", targets=None,
-        diagnostics=diagnostics, logger=logger,
+        diagnostics=diagnostics,
     )
     assert result.deleted == []
     assert result.failed == [rel]
     msgs = [d.message for d in diagnostics._diagnostics]
     assert any("retry on next" in m.lower() for m in msgs)
+
+
+def test_orphan_failure_message_does_not_promise_retry(
+    project_root, diagnostics, logger, monkeypatch
+):
+    """failed_path_retained=False rewords the failure diagnostic.
+
+    Orphan cleanup runs against a package that is no longer in the
+    manifest, so the lockfile entry is being dropped entirely and a
+    failed deletion can't be retried by APM. The user must remove the
+    file manually -- the diagnostic must say so instead of promising
+    a retry that will never happen.
+    """
+    rel = ".github/prompts/orphan-cant-delete.prompt.md"
+    _make_managed_file(project_root, rel)
+    monkeypatch.setattr(Path, "unlink", lambda *_a, **_kw: (_ for _ in ()).throw(PermissionError("nope")))
+    result = remove_stale_deployed_files(
+        [rel], project_root,
+        dep_key="some/orphan-pkg", targets=None,
+        diagnostics=diagnostics,
+        failed_path_retained=False,
+    )
+    assert result.failed == [rel]
+    msgs = [d.message for d in diagnostics._diagnostics]
+    assert not any("will retry" in m.lower() for m in msgs)
+    assert any("delete the file manually" in m.lower() for m in msgs)
+
+
+def test_orphan_path_honours_hash_gate(project_root, diagnostics, logger):
+    """Orphan cleanup must skip user-edited files just like stale cleanup.
+
+    Regression guard for the security review of the #666 follow-up:
+    earlier the orphan path bypassed the helper entirely and would have
+    silently deleted a file the user edited after APM deployed it.
+    """
+    rel = ".github/prompts/edited-orphan.prompt.md"
+    target = _make_managed_file(project_root, rel, "user has edited this\n")
+    fake_recorded = {rel: "sha256:" + "0" * 64}
+    result = remove_stale_deployed_files(
+        [rel], project_root,
+        dep_key="orphan-pkg", targets=None,
+        diagnostics=diagnostics,
+        recorded_hashes=fake_recorded,
+        failed_path_retained=False,
+    )
+    assert result.deleted == []
+    assert result.skipped_user_edit == [rel]
+    assert target.exists()
+
+
+def test_helper_signature_does_not_accept_logger():
+    """Logger kwarg was dropped -- helper output goes through diagnostics
+    plus caller-side InstallLogger methods (cleanup_skipped_user_edit /
+    stale_cleanup / orphan_cleanup). Pin the SoC."""
+    import inspect
+    sig = inspect.signature(remove_stale_deployed_files)
+    assert "logger" not in sig.parameters
 
 
 def test_result_dataclass_defaults():

--- a/tests/unit/integration/test_cleanup_helper.py
+++ b/tests/unit/integration/test_cleanup_helper.py
@@ -1,0 +1,196 @@
+"""Unit tests for ``apm_cli.integration.cleanup.remove_stale_deployed_files``.
+
+The helper is the single safety gate guarding APM's intra-package and
+local-package stale-file deletion. These tests pin its invariants:
+
+* path validation rejects unmanaged prefixes
+* directory entries are refused (defeats poisoned-lockfile rmtree)
+* recorded-hash mismatch skips deletion (treats as user-edited)
+* missing recorded hash falls through (back-compat with legacy lockfiles)
+* unlink failures are retained for retry on next install
+"""
+
+from pathlib import Path
+
+import pytest
+
+from apm_cli.integration.cleanup import (
+    CleanupResult,
+    remove_stale_deployed_files,
+)
+from apm_cli.utils.content_hash import compute_file_hash
+from apm_cli.utils.diagnostics import DiagnosticCollector
+from apm_cli.core.command_logger import CommandLogger
+
+
+@pytest.fixture
+def project_root(tmp_path):
+    return tmp_path
+
+
+@pytest.fixture
+def diagnostics():
+    return DiagnosticCollector(verbose=False)
+
+
+@pytest.fixture
+def logger():
+    return CommandLogger("install", verbose=False)
+
+
+def _make_managed_file(project_root: Path, rel: str, content: str = "hi\n") -> Path:
+    p = project_root / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def test_happy_path_deletes_under_known_prefix(project_root, diagnostics, logger):
+    target = _make_managed_file(project_root, ".github/prompts/old.prompt.md")
+    result = remove_stale_deployed_files(
+        [".github/prompts/old.prompt.md"], project_root,
+        dep_key="pkg", targets=None,
+        diagnostics=diagnostics, logger=logger,
+    )
+    assert result.deleted == [".github/prompts/old.prompt.md"]
+    assert not result.failed
+    assert not result.skipped_unmanaged
+    assert not target.exists()
+
+
+def test_path_traversal_rejected(project_root, diagnostics, logger):
+    """validate_deploy_path rejects '..' segments."""
+    result = remove_stale_deployed_files(
+        ["../escape.md"], project_root,
+        dep_key="pkg", targets=None,
+        diagnostics=diagnostics, logger=logger,
+    )
+    assert result.deleted == []
+    assert result.skipped_unmanaged == ["../escape.md"]
+
+
+def test_unmanaged_prefix_rejected(project_root, diagnostics, logger):
+    """A file outside any integration prefix is refused."""
+    rel = "src/main.py"
+    _make_managed_file(project_root, rel)
+    result = remove_stale_deployed_files(
+        [rel], project_root,
+        dep_key="pkg", targets=None,
+        diagnostics=diagnostics, logger=logger,
+    )
+    assert result.deleted == []
+    assert rel in result.skipped_unmanaged
+    assert (project_root / rel).exists()
+
+
+def test_directory_entry_refused(project_root, diagnostics, logger):
+    """A lockfile entry that resolves to a directory is refused outright.
+
+    This is the lockfile-poisoning blocker: an attacker writes
+    '.github/instructions/' (a directory under a known prefix) into the
+    lockfile and expects the next install to rmtree the user's whole
+    instructions folder. APM only deploys individual files, so it must
+    only delete individual files.
+    """
+    (project_root / ".github" / "instructions").mkdir(parents=True)
+    (project_root / ".github" / "instructions" / "user.md").write_text(
+        "user-authored", encoding="utf-8",
+    )
+    result = remove_stale_deployed_files(
+        [".github/instructions"], project_root,
+        dep_key="pkg", targets=None,
+        diagnostics=diagnostics, logger=logger,
+    )
+    assert result.deleted == []
+    assert ".github/instructions" in result.skipped_unmanaged
+    # Subtree intact.
+    assert (project_root / ".github" / "instructions" / "user.md").exists()
+    # Diagnostic recorded so user knows.
+    msgs = [d.message for d in diagnostics._diagnostics]
+    assert any("Refused to remove directory entry" in m for m in msgs)
+
+
+def test_missing_file_treated_as_already_clean(project_root, diagnostics, logger):
+    result = remove_stale_deployed_files(
+        [".github/prompts/gone.prompt.md"], project_root,
+        dep_key="pkg", targets=None,
+        diagnostics=diagnostics, logger=logger,
+    )
+    assert result.deleted == []
+    assert result.failed == []
+    assert result.skipped_unmanaged == []  # missing != unmanaged
+
+
+def test_hash_mismatch_skips_user_edited_file(project_root, diagnostics, logger):
+    rel = ".github/prompts/edited.prompt.md"
+    _make_managed_file(project_root, rel, "user has edited this\n")
+    # Pretend APM recorded a different hash at deploy time (i.e. user
+    # has since edited the file).
+    fake_recorded = {rel: "sha256:" + "0" * 64}
+    result = remove_stale_deployed_files(
+        [rel], project_root,
+        dep_key="pkg", targets=None,
+        diagnostics=diagnostics, logger=logger,
+        recorded_hashes=fake_recorded,
+    )
+    assert result.deleted == []
+    assert result.skipped_user_edit == [rel]
+    assert (project_root / rel).exists()
+    msgs = [d.message for d in diagnostics._diagnostics]
+    assert any("edited" in m.lower() for m in msgs)
+
+
+def test_hash_match_deletes_file(project_root, diagnostics, logger):
+    rel = ".github/prompts/match.prompt.md"
+    target = _make_managed_file(project_root, rel, "untouched\n")
+    recorded = {rel: compute_file_hash(target)}
+    result = remove_stale_deployed_files(
+        [rel], project_root,
+        dep_key="pkg", targets=None,
+        diagnostics=diagnostics, logger=logger,
+        recorded_hashes=recorded,
+    )
+    assert result.deleted == [rel]
+    assert not target.exists()
+
+
+def test_no_recorded_hashes_falls_through_to_delete(project_root, diagnostics, logger):
+    """Backward compat with legacy lockfiles -- no hash means delete."""
+    rel = ".github/prompts/legacy.prompt.md"
+    target = _make_managed_file(project_root, rel)
+    result = remove_stale_deployed_files(
+        [rel], project_root,
+        dep_key="pkg", targets=None,
+        diagnostics=diagnostics, logger=logger,
+        recorded_hashes=None,
+    )
+    assert result.deleted == [rel]
+    assert not target.exists()
+
+
+def test_unlink_failure_is_retained_for_retry(project_root, diagnostics, logger, monkeypatch):
+    rel = ".github/prompts/cant-delete.prompt.md"
+    _make_managed_file(project_root, rel)
+
+    def _raise(*_a, **_kw):
+        raise PermissionError("simulated")
+
+    monkeypatch.setattr(Path, "unlink", _raise)
+    result = remove_stale_deployed_files(
+        [rel], project_root,
+        dep_key="pkg", targets=None,
+        diagnostics=diagnostics, logger=logger,
+    )
+    assert result.deleted == []
+    assert result.failed == [rel]
+    msgs = [d.message for d in diagnostics._diagnostics]
+    assert any("retry on next" in m.lower() for m in msgs)
+
+
+def test_result_dataclass_defaults():
+    r = CleanupResult()
+    assert r.deleted == []
+    assert r.failed == []
+    assert r.skipped_user_edit == []
+    assert r.skipped_unmanaged == []
+    assert r.deleted_targets == []

--- a/tests/unit/integration/test_cleanup_helper.py
+++ b/tests/unit/integration/test_cleanup_helper.py
@@ -244,6 +244,45 @@ def test_helper_signature_does_not_accept_logger():
     assert "logger" not in sig.parameters
 
 
+def test_orphan_loop_uses_manifest_intent_not_integration_outcome():
+    """Regression guard: the orphan-cleanup loop in install.py must derive
+    'still-declared' from intended_dep_keys (manifest intent), NOT from
+    package_deployed_files (integration outcome).
+
+    Bug reproduced if the membership test reads package_deployed_files: a
+    transient integration failure for a still-declared package leaves its
+    key absent from package_deployed_files; the orphan loop then deletes
+    that package's previously deployed files even though the package is
+    still in apm.yml. Detected by the security re-review on commit 4b64c27.
+    """
+    import inspect
+    from apm_cli.commands import install as install_mod
+    src = inspect.getsource(install_mod)
+    orphan_marker = "# Orphan cleanup: remove deployed files for packages that were"
+    assert orphan_marker in src, "Orphan cleanup block not found -- update marker."
+    block_start = src.index(orphan_marker)
+    block_end = src.index("# Stale-file cleanup:", block_start)
+    orphan_block = src[block_start:block_end]
+    # Strip comments so the banned-phrase check doesn't trip on the
+    # cautionary comment that explains the bug we're guarding against.
+    code_only_lines = [
+        ln for ln in orphan_block.splitlines()
+        if not ln.lstrip().startswith("#")
+    ]
+    code_only = "\n".join(code_only_lines)
+    # Must consult manifest intent.
+    assert "intended_dep_keys" in code_only, (
+        "Orphan loop must use intended_dep_keys (manifest intent). "
+        "Using package_deployed_files.keys() (integration outcome) re-introduces "
+        "silent deletion of files for still-declared packages on transient errors."
+    )
+    # Must NOT regress to the outcome set.
+    assert "package_deployed_files.keys()" not in code_only, (
+        "Orphan loop must not derive membership from package_deployed_files.keys() -- "
+        "see test_orphan_loop_uses_manifest_intent_not_integration_outcome docstring."
+    )
+
+
 def test_result_dataclass_defaults():
     r = CleanupResult()
     assert r.deleted == []

--- a/tests/unit/test_command_logger.py
+++ b/tests/unit/test_command_logger.py
@@ -329,6 +329,9 @@ class TestInstallLogger:
         logger.install_summary(apm_count=3, mcp_count=0, stale_cleaned=5)
         msg = mock_success.call_args[0][0]
         assert "5 stale files cleaned" in msg
+        # Period belongs at the end of the sentence, after the parenthetical.
+        assert msg.endswith("cleaned).")
+        assert ". (" not in msg
 
     @patch("apm_cli.core.command_logger._rich_success")
     def test_install_summary_no_stale_no_suffix(self, mock_success):

--- a/tests/unit/test_command_logger.py
+++ b/tests/unit/test_command_logger.py
@@ -284,6 +284,70 @@ class TestInstallLogger:
         logger.install_summary(apm_count=0, mcp_count=0, errors=3)
         assert "3 error" in mock_error.call_args[0][0]
 
+    @patch("apm_cli.core.command_logger._rich_info")
+    def test_stale_cleanup_visible_at_default_verbosity(self, mock_info):
+        logger = InstallLogger(verbose=False)
+        logger.stale_cleanup("pkg/repo", 3)
+        assert mock_info.called
+        msg = mock_info.call_args[0][0]
+        assert "3 stale files" in msg
+        assert "pkg/repo" in msg
+        assert logger.stale_cleaned_total == 3
+
+    @patch("apm_cli.core.command_logger._rich_info")
+    def test_stale_cleanup_singular_noun(self, mock_info):
+        logger = InstallLogger()
+        logger.stale_cleanup("pkg", 1)
+        assert "1 stale file " in mock_info.call_args[0][0]
+
+    @patch("apm_cli.core.command_logger._rich_info")
+    def test_stale_cleanup_zero_count_silent(self, mock_info):
+        logger = InstallLogger()
+        logger.stale_cleanup("pkg", 0)
+        assert not mock_info.called
+        assert logger.stale_cleaned_total == 0
+
+    @patch("apm_cli.core.command_logger._rich_info")
+    def test_orphan_cleanup_visible_at_default_verbosity(self, mock_info):
+        logger = InstallLogger(verbose=False)
+        logger.orphan_cleanup(2)
+        assert mock_info.called
+        assert "no longer in apm.yml" in mock_info.call_args[0][0]
+        assert logger.stale_cleaned_total == 2
+
+    @patch("apm_cli.core.command_logger._rich_info")
+    def test_stale_and_orphan_totals_accumulate(self, _info):
+        logger = InstallLogger()
+        logger.stale_cleanup("pkg-a", 2)
+        logger.orphan_cleanup(3)
+        logger.stale_cleanup("pkg-b", 1)
+        assert logger.stale_cleaned_total == 6
+
+    @patch("apm_cli.core.command_logger._rich_success")
+    def test_install_summary_reports_stale_cleaned(self, mock_success):
+        logger = InstallLogger()
+        logger.install_summary(apm_count=3, mcp_count=0, stale_cleaned=5)
+        msg = mock_success.call_args[0][0]
+        assert "5 stale files cleaned" in msg
+
+    @patch("apm_cli.core.command_logger._rich_success")
+    def test_install_summary_no_stale_no_suffix(self, mock_success):
+        logger = InstallLogger()
+        logger.install_summary(apm_count=3, mcp_count=0, stale_cleaned=0)
+        msg = mock_success.call_args[0][0]
+        assert "stale" not in msg
+
+    @patch("apm_cli.core.command_logger._rich_warning")
+    def test_cleanup_skipped_user_edit_actionable(self, mock_warning):
+        logger = InstallLogger()
+        logger.cleanup_skipped_user_edit(".github/prompts/x.prompt.md", "pkg")
+        msg = mock_warning.call_args[0][0]
+        # Passes the "So What?" test: tells user what file, where it came
+        # from, and what they can do.
+        assert "x.prompt.md" in msg
+        assert "pkg" in msg
+        assert "delete manually" in msg.lower()
+
     @patch("apm_cli.core.command_logger._rich_error")
     def test_download_failed(self, mock_error):
         logger = InstallLogger()


### PR DESCRIPTION
## Summary

Hardening follow-up to #750 (issue #666). Three commits, addressing every blocker and reasonable polish surfaced by an internal review team (security expert, Python architect, CLI logging UX expert) across three iteration rounds.

## What this PR does

### 1. Per-file content-hash provenance for stale-file deletion

`#750` cleans up files that left a package between installs. This PR makes that cleanup **safe under user edits**:

- `LockedDependency.deployed_file_hashes: Dict[str, str]` records `sha256:<hex>` for every file APM deploys.
- On the next install, before deleting a "stale" file, APM compares the current on-disk hash to the recorded hash. **Mismatch -> file kept**, treated as a user edit, attributed in diagnostics.
- Missing recorded hash (legacy lockfiles) falls through to delete (back-compat).

### 2. Single safety chokepoint: `apm_cli/integration/cleanup.py`

New `remove_stale_deployed_files(...)` helper is the **only** path that deletes lockfile-tracked files on install. Three gates, in order:

1. `BaseIntegrator.validate_deploy_path()` -- rejects unmanaged prefixes.
2. Directory rejection -- defeats poisoned-lockfile rmtree.
3. Recorded-hash comparison -- defeats user-edit clobber.

The orphan-cleanup path (packages removed from `apm.yml` entirely) and the intra-package stale path both route through this helper. Pinned by `test_helper_signature_does_not_accept_logger` (SoC: helper pushes to `DiagnosticCollector`, never logs directly).

### 3. Logger surface for cleanup

Three new `CommandLogger` methods:
- `stale_cleanup(n, package=)` / `orphan_cleanup(n)` -- `[i]` symbol (informational, not progress; cleanup is not a success in itself).
- `cleanup_skipped_user_edit(path, package)` -- yellow inline warning per skipped file (verbose mode).
- `install_summary(stale_cleaned=)` -- final summary appends `(N stale files cleaned).` inside the sentence.

### 4. Orphan-cleanup correctness regression fix (commit 3)

The first refactor introduced a subtle bug caught by security re-review: the orphan loop derived its "still-declared" set from `package_deployed_files.keys()` (integration outcome). A transient integration error for a still-declared package would leave its key absent from that dict, and the loop would silently delete the package's files. **Fix:** derive from `intended_dep_keys` (manifest intent). Pinned by `test_orphan_loop_uses_manifest_intent_not_integration_outcome` (source-level guard that strips comments before checking).

## Review iteration

| Round | Security | Architecture | UX |
|-------|----------|--------------|-----|
| 1 | REQUEST-CHANGES (orphan path bypassed hash gate) | APPROVE-WITH-SUGGESTIONS (5 polish items) | APPROVE-WITH-SUGGESTIONS (1 wiring blocker + 6 polish) |
| 2 | REQUEST-CHANGES (orphan loop misclassification on integration failure) | APPROVE | APPROVE |
| 3 | APPROVE | -- (no code in scope) | -- (no code in scope) |

Deferred suggestions (tracked, non-blocking):
- Validate `sha256:<hex>` format on recorded hashes (fail-safe today).
- Plan a deprecation path for legacy lockfiles missing hashes.
- Apply safety gates to dry-run preview (preview-vs-actual divergence is UX, not security).

## Tests

- New: 14 unit tests in `tests/unit/integration/test_cleanup_helper.py` (gates, orphan path, SoC pin, regression guard).
- New: 9 unit tests in `tests/unit/test_command_logger.py` (cleanup methods + summary punctuation).
- New: 4 unit tests in `tests/test_lockfile.py` (`deployed_file_hashes` round-trip).
- Full suite: **3968 unit + 87 install/orphan integration tests pass.**

## Files changed

- New: `src/apm_cli/integration/cleanup.py`, `src/apm_cli/utils/content_hash.py`
- Modified: `src/apm_cli/commands/install.py`, `src/apm_cli/deps/lockfile.py`, `src/apm_cli/core/command_logger.py`
- Tests: `tests/unit/integration/test_cleanup_helper.py` (new), `tests/unit/test_command_logger.py`, `tests/test_lockfile.py`
- Docs: `docs/src/content/docs/reference/cli-commands.md` (stale-cleanup section + safety contract), `CHANGELOG.md` ([Unreleased] -> Fixed)
