### PR TITLE
fix: route --target codex/opencode through AGENTS.md compiler (#766)

### DIFF
--- a/src/apm_cli/commands/compile/cli.py
+++ b/src/apm_cli/commands/compile/cli.py
@@ -380,23 +380,20 @@ def compile(
 
         # Handle distributed vs single-file compilation
         if config.strategy == "distributed" and not single_agents:
-            # Show target-aware message with detection reason
+            # Show target-aware message with detection reason. Use
+            # get_target_description() so any future target added to
+            # target_detection shows up here automatically.
             if detected_target == "minimal":
                 logger.progress(f"Compiling for AGENTS.md only ({detection_reason})")
                 logger.progress(
-                    " Create .github/ or .claude/ folder for full integration",
+                    " Create .github/, .claude/, .codex/, .opencode/ or .cursor/ folder for full integration",
                     symbol="light_bulb",
                 )
-            elif detected_target == "vscode" or detected_target == "agents":
+            else:
+                description = get_target_description(detected_target)
                 logger.progress(
-                    f"Compiling for AGENTS.md (VSCode/Copilot) - {detection_reason}"
+                    f"Compiling for {description} - {detection_reason}"
                 )
-            elif detected_target == "claude":
-                logger.progress(
-                    f"Compiling for CLAUDE.md (Claude Code) - {detection_reason}"
-                )
-            else:  # "all"
-                logger.progress(f"Compiling for AGENTS.md + CLAUDE.md - {detection_reason}")
 
             if dry_run:
                 logger.dry_run_notice(

--- a/src/apm_cli/compilation/agents_compiler.py
+++ b/src/apm_cli/compilation/agents_compiler.py
@@ -20,6 +20,15 @@ from .template_builder import (
 )
 from .link_resolver import resolve_markdown_links, validate_link_targets
 from ..utils.paths import portable_relpath
+from ..core.target_detection import should_compile_agents_md, should_compile_claude_md
+
+
+# User-facing target aliases that map to the canonical "vscode" target.
+# Kept in sync with target_detection.detect_target().
+_VSCODE_TARGET_ALIASES = ("copilot", "agents")
+_KNOWN_TARGETS = (
+    "vscode", "claude", "cursor", "opencode", "codex", "all", "minimal",
+) + _VSCODE_TARGET_ALIASES
 
 
 @dataclass
@@ -199,17 +208,52 @@ class AgentsCompiler:
                         exclude_patterns=config.exclude,
                     )
             
-            # Route to targets based on config.target
+            # Route to targets based on config.target.
+            # Use target_detection helpers as the single source of truth so
+            # new targets (codex, opencode, cursor, minimal, ...) route
+            # correctly without touching this method again.
+            routing_target = (
+                "vscode" if config.target in _VSCODE_TARGET_ALIASES else config.target
+            )
+
+            if routing_target not in _KNOWN_TARGETS and config.target not in _KNOWN_TARGETS:
+                self.errors.append(
+                    f"Unknown compilation target: {config.target!r}. "
+                    f"Expected one of: {', '.join(sorted(set(_KNOWN_TARGETS)))}"
+                )
+                return CompilationResult(
+                    success=False,
+                    output_path="",
+                    content="",
+                    warnings=self.warnings.copy(),
+                    errors=self.errors.copy(),
+                    stats={},
+                )
+
             results: List[CompilationResult] = []
-            
-            # AGENTS.md target (vscode/agents)
-            if config.target in ("vscode", "agents", "all"):
+
+            if should_compile_agents_md(routing_target):
                 results.append(self._compile_agents_md(config, primitives))
-            
-            # CLAUDE.md target
-            if config.target in ("claude", "all"):
+
+            if should_compile_claude_md(routing_target):
                 results.append(self._compile_claude_md(config, primitives))
-            
+
+            # Defensive: should never happen for a known target, but guards
+            # against future target_detection drift silently producing no-ops.
+            if not results:
+                self.errors.append(
+                    f"Target {config.target!r} did not route to any compiler. "
+                    "This is an internal bug in target routing."
+                )
+                return CompilationResult(
+                    success=False,
+                    output_path="",
+                    content="",
+                    warnings=self.warnings.copy(),
+                    errors=self.errors.copy(),
+                    stats={},
+                )
+
             # Merge results from all targets
             return self._merge_results(results)
                 

--- a/tests/unit/compilation/test_compile_target_flag.py
+++ b/tests/unit/compilation/test_compile_target_flag.py
@@ -166,13 +166,70 @@ Use type hints in Python code.
             dry_run=True,
             single_agents=True  # Use single-file for AGENTS.md
         )
-        
+
         compiler = AgentsCompiler(str(temp_project))
         result = compiler.compile(config, sample_primitives)
-        
+
         assert result.success
         # Output path should mention both targets
         assert "AGENTS.md" in result.output_path or "CLAUDE" in result.output_path
+
+    def test_target_codex_generates_agents_md(self, temp_project, sample_primitives):
+        """Regression for issue #766: --target codex must produce AGENTS.md, not a silent no-op."""
+        config = CompilationConfig(
+            target="codex",
+            dry_run=True,
+            single_agents=True,
+        )
+
+        compiler = AgentsCompiler(str(temp_project))
+        result = compiler.compile(config, sample_primitives)
+
+        assert result.success
+        assert result.output_path, "codex target must route to a compiler, not return empty"
+        assert "AGENTS.md" in result.output_path
+
+    def test_target_opencode_generates_agents_md(self, temp_project, sample_primitives):
+        """target='opencode' must route to AGENTS.md (same universal format as codex)."""
+        config = CompilationConfig(
+            target="opencode",
+            dry_run=True,
+            single_agents=True,
+        )
+
+        compiler = AgentsCompiler(str(temp_project))
+        result = compiler.compile(config, sample_primitives)
+
+        assert result.success
+        assert "AGENTS.md" in result.output_path
+
+    def test_target_minimal_generates_agents_md(self, temp_project, sample_primitives):
+        """target='minimal' must route to AGENTS.md-only."""
+        config = CompilationConfig(
+            target="minimal",
+            dry_run=True,
+            single_agents=True,
+        )
+
+        compiler = AgentsCompiler(str(temp_project))
+        result = compiler.compile(config, sample_primitives)
+
+        assert result.success
+        assert "AGENTS.md" in result.output_path
+
+    def test_unknown_target_returns_failure(self, temp_project, sample_primitives):
+        """Unknown target must fail explicitly instead of silently succeeding."""
+        config = CompilationConfig(
+            target="not-a-real-target",
+            dry_run=True,
+            single_agents=True,
+        )
+
+        compiler = AgentsCompiler(str(temp_project))
+        result = compiler.compile(config, sample_primitives)
+
+        assert result.success is False
+        assert any("Unknown compilation target" in e for e in result.errors)
 
 
 class TestMergeResults:


### PR DESCRIPTION
## Description

`apm compile --target codex` was a silent no-op. `AgentsCompiler.compile()` only routed for `("vscode", "agents", "all")` and `("claude", "all")`, so `apm compile --target codex` (and `opencode`, `minimal`) fell through both branches and `_merge_results([])` returned a successful empty result — leaving any existing `AGENTS.md` stale. This made distributed Codex compile look like it silently dropped a dependency instruction.

- Route via `should_compile_agents_md()` / `should_compile_claude_md()` so `target_detection.py` is the single source of truth
- Normalize `copilot`/`agents` aliases locally before routing
- Fail loud on unknown targets instead of silently succeeding
- CLI progress message uses `get_target_description()` so the banner matches the actual work performed for every target

Fixes #766

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

Manual repro from the issue: created the minimal `codex-compile-repro` project, ran `apm compile --target codex` — `AGENTS.md` is now generated with both `pkg-a` and `pkg-b` rules (previously the file was not created at all). Added 4 new unit tests in `tests/unit/compilation/test_compile_target_flag.py` covering `codex`, `opencode`, `minimal`, and unknown-target failure paths. All 379 tests in `tests/unit/compilation/`, `tests/unit/core/`, and `tests/unit/test_install_scanning.py` pass.