### PR TITLE
ci: adopt GitHub Merge Queue with tiered CI (#770)

### DIFF
--- a/.github/instructions/cicd.instructions.md
+++ b/.github/instructions/cicd.instructions.md
@@ -5,19 +5,23 @@ description: "CI/CD Pipeline configuration for PyInstaller binary packaging and 
 
 # CI/CD Pipeline Instructions
 
-## Workflow Architecture (Fork-safe)
-Four workflows split by trigger and secret requirements:
+## Workflow Architecture (Tiered + Merge Queue)
+Four workflows split by trigger and tier. PRs get fast feedback; the heavy
+integration suite runs only at merge time via GitHub Merge Queue
+(microsoft/apm#770).
 
-1. **`ci.yml`** — `pull_request` trigger (all PRs, including forks)
+1. **`ci.yml`** — Tier 1, runs on `pull_request` AND `merge_group`
    - **Linux-only** (ubuntu-24.04). Combined `build-and-test` job: unit tests + binary build in a single runner. No secrets needed.
    - Uploads Linux x86_64 binary artifact for downstream integration testing.
-2. **`ci-integration.yml`** — `workflow_run` trigger (after CI completes, environment-gated)
-   - **Linux-only**. Smoke tests, integration tests, release validation. Requires `integration-tests` environment approval.
-   - Security: uses `workflow_run` (not `pull_request_target`) — PR code is NEVER checked out.
-   - Downloads Linux binary artifact from ci.yml, runs test scripts from default branch (main).
-   - Reports results back to PR via commit status API.
-   - Detects CI circular dependency (upstream failure → reports `pending` instead of blocking).
-   - Annotates originating PR URL for traceability.
+   - Runs in both PR context (fast feedback for contributors) and merge_group
+     context (against the tentative merge commit before queue auto-merges).
+2. **`ci-integration.yml`** — Tier 2, `merge_group` trigger only
+   - **Linux-only**. Builds binary inline, then runs smoke + integration +
+     release-validation against the tentative merge commit.
+   - Trust boundary is the write-access grant (only users with write can
+     enqueue a PR). No environment approval gate.
+   - Inlines the binary build instead of fetching from `ci.yml` to avoid
+     cross-workflow artifact plumbing across triggers.
 3. **`build-release.yml`** — `push` to main, tags, schedule, `workflow_dispatch`
    - **Linux + Windows** run combined `build-and-test` (unit tests + binary build in one job).
    - **macOS Intel** uses `build-and-validate-macos-intel` (root node, runs own unit tests — no dependency on `build-and-test`). Builds the binary on every push for early regression feedback; integration + release-validation phases conditional on tag/schedule/dispatch.
@@ -52,24 +56,24 @@ Four workflows split by trigger and secret requirements:
 ## Inference Testing (Decoupled)
 - Live inference tests (`apm run`) are **isolated** in `ci-runtime.yml` — they do NOT gate releases
 - `APM_RUN_INFERENCE_TESTS=1` env var enables inference in test scripts; absent = skipped
-- `GH_MODELS_PAT` is only used in `ci-runtime.yml` and smoke-test jobs — NOT in integration-tests or release-validation
+- `GH_MODELS_PAT` is only used in `ci-runtime.yml` and Tier 2 smoke-test job — NOT in integration-tests or release-validation
 - Rationale: 8 inference executions × 2% failure rate = 14.9% false-negative per release; APM core UVPs require zero live inference
 
 ## Release Flow Dependencies
-- **PR workflow**: ci.yml (build-and-test, Linux-only) then ci-integration.yml via workflow_run (approve → smoke-test → integration-tests → release-validation → report-status, all Linux-only)
+- **PR workflow**: Tier 1 only — ci.yml (build-and-test, Linux-only) provides fast feedback. Tier 2 does not run until enqueued.
+- **Merge queue workflow**: ci.yml (Tier 1 against tentative merge ref) + ci-integration.yml (Tier 2: build → smoke-test → integration-tests → release-validation). Queue auto-merges on success; ejects on failure.
 - **Push/Release workflow (Linux + Windows)**: build-and-test → integration-tests → release-validation → create-release → publish-pypi → update-homebrew (gh-aw-compat runs in parallel, informational)
 - **Push/Release workflow (macOS Intel)**: build-and-validate-macos-intel (root node: unit tests + build always + conditional integration/release-validation) → create-release
 - **Push/Release workflow (macOS ARM)**: build-and-validate-macos-arm (root node, tag/schedule/dispatch only; all phases run) → create-release
 - **Tag Triggers**: Only `v*.*.*` tags trigger full release pipeline
 - **Artifact Retention**: 30 days for debugging failed releases
-- **Cross-workflow artifacts**: ci-integration.yml downloads artifacts from ci.yml using `run-id` and `github-token`
+- **Cross-workflow artifacts**: ci-integration.yml builds the binary inline (no cross-workflow artifact transfer); build-release.yml jobs share artifacts within the same workflow run.
 
-## Fork PR Security Model
-- Fork PRs get unit tests + build via `ci.yml` (no secrets, runs PR code safely)
-- `ci-integration.yml` triggers via `workflow_run` after CI completes — NEVER checks out PR code
-- Binary artifacts from ci.yml are tested using test scripts from the default branch (main)
-- Environment approval gate (`integration-tests`) ensures maintainer reviews PR before integration tests run
-- Commit status is reported back to the PR SHA so results appear on the PR
+## Trust Model
+- **PR push (any contributor, including forks)**: Runs Tier 1 only. No CI secrets exposed. PR code is checked out and tested in an unprivileged context.
+- **merge_group (write access required)**: Runs Tier 1 + Tier 2. Tier 2 sees secrets. The `gh-readonly-queue/main/*` ref is created by GitHub from the PR merged into main; only users with write access can trigger this by enqueueing a PR.
+- **Trust boundary = write-access grant**, managed in repo Settings -> Collaborators. Write access is granted only to vetted contributors.
+- **No environment approval gate** is required because the act of enqueueing IS the trust assertion. This replaces the previous `integration-tests` environment approval flow.
 
 ## Key Environment Variables
 - `PYTHON_VERSION: '3.12'` - Standardized across all jobs
@@ -83,6 +87,7 @@ Four workflows split by trigger and secret requirements:
 - **Targeted setup-node usage**: Node.js is only installed in `ci-runtime.yml`, macOS consolidated jobs, and integration-tests/release-validation phases (for `apm runtime setup copilot` → npm install).
 - **macOS runner consolidation**: Each macOS arch has a single consolidated job (build + integration + release-validation). Intel (`build-and-validate-macos-intel`) runs on every push since Intel runners are plentiful. ARM (`build-and-validate-macos-arm`) is gated to tag/schedule/dispatch only since ARM runners are extremely scarce (2-4h+ queue waits). This avoids serial re-queuing of runners across multiple jobs.
 - **Unit tests skip macOS**: Python unit tests are platform-agnostic; Linux + Windows coverage is sufficient. macOS-specific validation (binary build, integration tests, release validation) still runs via the consolidated job.
+- **Tier 2 runs once per merged PR**, not per WIP push, since it triggers on `merge_group` only. Saves the bulk of integration minutes that the previous per-push flow burned.
 - UPX compression when available (reduces binary size ~50%)
 - Python optimization level 2 in PyInstaller
 - Aggressive module exclusions (tkinter, matplotlib, etc.)

--- a/.github/instructions/cicd.instructions.md
+++ b/.github/instructions/cicd.instructions.md
@@ -10,32 +10,32 @@ Four workflows split by trigger and tier. PRs get fast feedback; the heavy
 integration suite runs only at merge time via GitHub Merge Queue
 (microsoft/apm#770).
 
-1. **`ci.yml`** — Tier 1, runs on `pull_request` AND `merge_group`
+1. **`ci.yml`** - Tier 1, runs on `pull_request` AND `merge_group`
    - **Linux-only** (ubuntu-24.04). Combined `build-and-test` job: unit tests + binary build in a single runner. No secrets needed.
    - Uploads Linux x86_64 binary artifact for downstream integration testing.
    - Runs in both PR context (fast feedback for contributors) and merge_group
      context (against the tentative merge commit before queue auto-merges).
-2. **`ci-integration.yml`** — Tier 2, `merge_group` trigger only
+2. **`ci-integration.yml`** - Tier 2, `merge_group` trigger only
    - **Linux-only**. Builds binary inline, then runs smoke + integration +
      release-validation against the tentative merge commit.
    - Trust boundary is the write-access grant (only users with write can
      enqueue a PR). No environment approval gate.
    - Inlines the binary build instead of fetching from `ci.yml` to avoid
      cross-workflow artifact plumbing across triggers.
-3. **`build-release.yml`** — `push` to main, tags, schedule, `workflow_dispatch`
+3. **`build-release.yml`** - `push` to main, tags, schedule, `workflow_dispatch`
    - **Linux + Windows** run combined `build-and-test` (unit tests + binary build in one job).
-   - **macOS Intel** uses `build-and-validate-macos-intel` (root node, runs own unit tests — no dependency on `build-and-test`). Builds the binary on every push for early regression feedback; integration + release-validation phases conditional on tag/schedule/dispatch.
-   - **macOS ARM** uses `build-and-validate-macos-arm` (root node, tag/schedule/dispatch only — ARM runners are extremely scarce with 2-4h+ queue waits). Only requested when the binary is actually needed for a release.
+   - **macOS Intel** uses `build-and-validate-macos-intel` (root node, runs own unit tests - no dependency on `build-and-test`). Builds the binary on every push for early regression feedback; integration + release-validation phases conditional on tag/schedule/dispatch.
+   - **macOS ARM** uses `build-and-validate-macos-arm` (root node, tag/schedule/dispatch only - ARM runners are extremely scarce with 2-4h+ queue waits). Only requested when the binary is actually needed for a release.
    - Secrets always available. Full 5-platform binary output (linux x86_64/arm64, darwin x86_64/arm64, windows x86_64).
-4. **`ci-runtime.yml`** — nightly schedule, manual dispatch, path-filtered push
+4. **`ci-runtime.yml`** - nightly schedule, manual dispatch, path-filtered push
    - **Linux x86_64 only**. Live inference smoke tests (`apm run`) isolated from release pipeline.
    - Uses `GH_MODELS_PAT` for GitHub Models API access.
-   - Failures do not block releases — annotated as warnings.
+   - Failures do not block releases - annotated as warnings.
 
 ## Platform Testing Strategy
 - **PR time**: Linux-only combined build-and-test in `ci.yml`. Catches logic bugs and dependency issues before merge. Windows + macOS are tested post-merge (platform-specific issues are rare and the full matrix runs on every push to main).
 - **Post-merge**: Full 5-platform matrix (linux x86_64/arm64, darwin x86_64/arm64, windows x86_64) catches remaining platform-specific issues on main.
-- **Rationale**: ci.yml has always been Linux-only — Windows and macOS are covered by `build-release.yml` on every push to main. This keeps PR feedback fast while still catching platform issues before release.
+- **Rationale**: ci.yml has always been Linux-only - Windows and macOS are covered by `build-release.yml` on every push to main. This keeps PR feedback fast while still catching platform issues before release.
 
 ## PyInstaller Binary Packaging
 - **CRITICAL**: Uses `--onedir` mode (NOT `--onefile`) for faster CLI startup performance
@@ -54,17 +54,17 @@ integration suite runs only at merge time via GitHub Merge Queue
 3. **Path Resolution**: Use symlinks and PATH manipulation for isolated binary testing
 
 ## Inference Testing (Decoupled)
-- Live inference tests (`apm run`) are **isolated** in `ci-runtime.yml` — they do NOT gate releases
+- Live inference tests (`apm run`) are **isolated** in `ci-runtime.yml` - they do NOT gate releases
 - `APM_RUN_INFERENCE_TESTS=1` env var enables inference in test scripts; absent = skipped
-- `GH_MODELS_PAT` is only used in `ci-runtime.yml` and Tier 2 smoke-test job — NOT in integration-tests or release-validation
-- Rationale: 8 inference executions × 2% failure rate = 14.9% false-negative per release; APM core UVPs require zero live inference
+- `GH_MODELS_PAT` is only used in `ci-runtime.yml` and Tier 2 smoke-test job - NOT in integration-tests or release-validation
+- Rationale: 8 inference executions x 2% failure rate = 14.9% false-negative per release; APM core UVPs require zero live inference
 
 ## Release Flow Dependencies
-- **PR workflow**: Tier 1 only — ci.yml (build-and-test, Linux-only) provides fast feedback. Tier 2 does not run until enqueued.
-- **Merge queue workflow**: ci.yml (Tier 1 against tentative merge ref) + ci-integration.yml (Tier 2: build → smoke-test → integration-tests → release-validation). Queue auto-merges on success; ejects on failure.
-- **Push/Release workflow (Linux + Windows)**: build-and-test → integration-tests → release-validation → create-release → publish-pypi → update-homebrew (gh-aw-compat runs in parallel, informational)
-- **Push/Release workflow (macOS Intel)**: build-and-validate-macos-intel (root node: unit tests + build always + conditional integration/release-validation) → create-release
-- **Push/Release workflow (macOS ARM)**: build-and-validate-macos-arm (root node, tag/schedule/dispatch only; all phases run) → create-release
+- **PR workflow**: Tier 1 only - ci.yml (build-and-test, Linux-only) provides fast feedback. Tier 2 does not run until enqueued.
+- **Merge queue workflow**: ci.yml (Tier 1 against tentative merge ref) + ci-integration.yml (Tier 2: build -> smoke-test -> integration-tests -> release-validation). Queue auto-merges on success; ejects on failure.
+- **Push/Release workflow (Linux + Windows)**: build-and-test -> integration-tests -> release-validation -> create-release -> publish-pypi -> update-homebrew (gh-aw-compat runs in parallel, informational)
+- **Push/Release workflow (macOS Intel)**: build-and-validate-macos-intel (root node: unit tests + build always + conditional integration/release-validation) -> create-release
+- **Push/Release workflow (macOS ARM)**: build-and-validate-macos-arm (root node, tag/schedule/dispatch only; all phases run) -> create-release
 - **Tag Triggers**: Only `v*.*.*` tags trigger full release pipeline
 - **Artifact Retention**: 30 days for debugging failed releases
 - **Cross-workflow artifacts**: ci-integration.yml builds the binary inline (no cross-workflow artifact transfer); build-release.yml jobs share artifacts within the same workflow run.
@@ -82,9 +82,9 @@ integration suite runs only at merge time via GitHub Merge Queue
 
 ## Performance Considerations
 - **Combined build-and-test**: Eliminates ~1.5m runner re-provisioning overhead by running unit tests and binary build in the same job.
-- **macOS as root nodes**: macOS consolidated jobs run their own unit tests and start immediately — no dependency on Linux/Windows test completion.
+- **macOS as root nodes**: macOS consolidated jobs run their own unit tests and start immediately - no dependency on Linux/Windows test completion.
 - **Native uv caching**: `setup-uv` action with `enable-cache: true` replaces manual `actions/cache@v3` blocks.
-- **Targeted setup-node usage**: Node.js is only installed in `ci-runtime.yml`, macOS consolidated jobs, and integration-tests/release-validation phases (for `apm runtime setup copilot` → npm install).
+- **Targeted setup-node usage**: Node.js is only installed in `ci-runtime.yml`, macOS consolidated jobs, and integration-tests/release-validation phases (for `apm runtime setup copilot` -> npm install).
 - **macOS runner consolidation**: Each macOS arch has a single consolidated job (build + integration + release-validation). Intel (`build-and-validate-macos-intel`) runs on every push since Intel runners are plentiful. ARM (`build-and-validate-macos-arm`) is gated to tag/schedule/dispatch only since ARM runners are extremely scarce (2-4h+ queue waits). This avoids serial re-queuing of runners across multiple jobs.
 - **Unit tests skip macOS**: Python unit tests are platform-agnostic; Linux + Windows coverage is sufficient. macOS-specific validation (binary build, integration tests, release validation) still runs via the consolidated job.
 - **Tier 2 runs once per merged PR**, not per WIP push, since it triggers on `merge_group` only. Saves the bulk of integration minutes that the previous per-push flow burned.

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -1,114 +1,114 @@
-# Integration tests for PRs (including forks).
-# Uses workflow_run to safely access secrets without checking out untrusted PR code.
-# Security model:
-#   - ci.yml builds the PR's code in an unprivileged context and uploads binary artifacts
-#   - This workflow downloads those artifacts and runs tests from the DEFAULT BRANCH (main)
-#   - PR code is never checked out in a privileged context
-#   - Fork PRs require manual environment approval before tests run (security gate)
-#   - Internal PRs (same repo) skip the approval gate — contributors already have write access
-name: Integration Tests (PR)
+# Tier 2 integration suite — runs only when a PR is added to the merge queue.
+#
+# Design (microsoft/apm#770):
+#   - Tier 1 (ci.yml) runs unit tests + binary build on every PR push and on
+#     every merge_group event. No secrets needed there.
+#   - Tier 2 (this workflow) runs smoke + integration + release-validation
+#     against the tentative merge commit that the merge queue creates.
+#
+# Trust model:
+#   - merge_group only fires when a user with write access enqueues a PR.
+#   - The gh-readonly-queue/main/* ref contains the PR's code merged into
+#     main and is created by GitHub, not by the contributor.
+#   - Trust boundary = write-access grant, managed in repo settings.
+#     Write access is granted only to vetted contributors.
+#   - Fork PRs without write access never reach this workflow and never see
+#     CI secrets.
+#
+# Binary is built inline rather than downloaded from ci.yml so this workflow
+# tests exactly the merge-queue tentative merge SHA without cross-workflow
+# artifact plumbing.
+name: Integration Tests
 
 env:
   PYTHON_VERSION: '3.12'
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
+  merge_group:
+    branches: [ main ]
 
 permissions:
   contents: read
-  actions: read
-  statuses: write
 
 jobs:
-  # Fork PRs: require manual approval via environment protection rules.
-  # A maintainer must review the fork's code before secrets are exposed to its artifacts.
-  approve-fork:
-    if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.head_repository.full_name != github.repository
-    runs-on: ubuntu-latest
-    environment: integration-tests
-    steps:
-      - run: echo "Fork PR approved for ${{ github.event.workflow_run.head_branch }} from ${{ github.event.workflow_run.head_repository.full_name }}"
-
-  # Internal PRs: skip approval gate — contributors already have write access to the repo.
-  approve-internal:
-    if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.head_repository.full_name == github.repository
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Internal PR auto-approved for ${{ github.event.workflow_run.head_branch }}"
-
-  # Linux smoke test
-  smoke-test:
-    needs: [approve-fork, approve-internal]
-    # Run if either approval job succeeded (the other will be skipped)
-    if: always() && (needs.approve-fork.result == 'success' || needs.approve-internal.result == 'success')
+  build:
+    name: Build (Linux)
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      actions: read
-
     steps:
-    # Checkout default branch (main) — never PR code
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    # O8: PR traceability — annotate with originating PR URL
-    - name: Annotate originating PR
-      run: |
-        PR_NUMBER=$(echo '${{ toJSON(github.event.workflow_run.pull_requests) }}' | jq -r '.[0].number // empty')
-        if [ -n "$PR_NUMBER" ]; then
-          echo "::notice::🔗 Originating PR: https://github.com/${{ github.repository }}/pull/${PR_NUMBER}"
-        else
-          echo "::notice::Triggered by push to ${{ github.event.workflow_run.head_branch }}"
-        fi
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ env.PYTHON_VERSION }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v6
-      with:
-        enable-cache: true
+      - name: Install dependencies
+        run: uv sync --extra dev --extra build
 
-    - name: Install dependencies
-      run: uv sync --extra dev
+      - name: Install UPX
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y upx-ucl
 
-    - name: Run smoke tests
-      env:
-        GITHUB_TOKEN: ${{ secrets.GH_MODELS_PAT }}
-        GITHUB_APM_PAT: ${{ secrets.GH_CLI_PAT }}
-      run: uv run pytest tests/integration/test_runtime_smoke.py -v
+      - name: Build binary
+        run: |
+          chmod +x scripts/build-binary.sh
+          uv run ./scripts/build-binary.sh
 
-  # Linux integration tests — downloads the Linux binary artifact from ci.yml.
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: apm-mq-linux-x86_64
+          path: |
+            ./dist/apm-linux-x86_64
+            ./dist/apm-linux-x86_64.sha256
+          include-hidden-files: true
+          retention-days: 7
+          if-no-files-found: error
+
+  smoke-test:
+    name: Smoke Test (Linux)
+    needs: [build]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run smoke tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_MODELS_PAT }}
+          GITHUB_APM_PAT: ${{ secrets.GH_CLI_PAT }}
+        run: uv run pytest tests/integration/test_runtime_smoke.py -v
+
   integration-tests:
     name: Integration Tests (Linux)
-    needs: [smoke-test]
-    if: always() && needs.smoke-test.result == 'success'
+    needs: [build, smoke-test]
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      actions: read
-
     steps:
-      # Checkout default branch (main) for test scripts — never PR code
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      # Download binary artifact built from PR code by ci.yml
-      - name: Download APM binary from CI workflow
+      - name: Download binary
         uses: actions/download-artifact@v4
         with:
-          name: apm-linux-x86_64
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          name: apm-mq-linux-x86_64
+          path: ./dist/apm-linux-x86_64/
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -138,18 +138,11 @@ jobs:
           uv run ./scripts/test-integration.sh
         timeout-minutes: 20
 
-  # Linux release validation — validates the Linux binary in isolation.
   release-validation:
     name: Release Validation (Linux)
-    needs: [integration-tests]
-    if: always() && needs.integration-tests.result == 'success'
+    needs: [build, integration-tests]
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      actions: read
-
     steps:
-      # Checkout default branch for test scripts — never PR code
       - name: Checkout test scripts
         uses: actions/checkout@v4
         with:
@@ -166,23 +159,15 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      # Download binary artifact to isolated test directory
-      - name: Download APM binary from CI workflow
+      - name: Download binary
         uses: actions/download-artifact@v4
         with:
-          name: apm-linux-x86_64
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: /tmp/apm-isolated-test/
+          name: apm-mq-linux-x86_64
+          path: /tmp/apm-isolated-test/dist/apm-linux-x86_64/
 
-      - name: Make binary executable and verify isolation
+      - name: Make binary executable
         run: |
           cd /tmp/apm-isolated-test
-
-          echo "Downloaded structure:"
-          find . -name "apm" -type f
-          ls -la ./dist/
-
           chmod +x ./dist/apm-linux-x86_64/apm
 
       - name: Create APM symlink for testing
@@ -191,9 +176,8 @@ jobs:
           ln -s "$(pwd)/dist/apm-linux-x86_64/apm" "$(pwd)/apm"
           echo "/tmp/apm-isolated-test" >> $GITHUB_PATH
 
-      - name: Prepare test scripts from default branch
+      - name: Prepare test scripts
         run: |
-          # Copy test scripts from main branch checkout into isolated test dir
           cp -r repo/scripts /tmp/apm-isolated-test/scripts
 
       - name: Run release validation tests
@@ -206,51 +190,3 @@ jobs:
           chmod +x scripts/test-release-validation.sh
           ./scripts/test-release-validation.sh
         timeout-minutes: 20
-
-  # Report integration test results back to the PR as a commit status
-  report-status:
-    needs: [smoke-test, integration-tests, release-validation]
-    if: always()
-    runs-on: ubuntu-latest
-    permissions:
-      statuses: write
-    steps:
-      - name: Report status to PR
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const ciConclusion = '${{ github.event.workflow_run.conclusion }}';
-            const smokeResult = '${{ needs.smoke-test.result }}';
-            const integResult = '${{ needs.integration-tests.result }}';
-            const relvalResult = '${{ needs.release-validation.result }}';
-
-            // O7: Detect CI circular dependency — when ci.yml fails, all approval
-            // jobs are skipped (their `if: conclusion == 'success'` fails), which
-            // cascades to skip smoke-test → integration-tests → release-validation.
-            // Without this check, we'd report 'failure' and block the CI-fixing PR.
-            const allSkipped = smokeResult === 'skipped' && integResult === 'skipped' && relvalResult === 'skipped';
-
-            let state, description;
-            if (allSkipped && ciConclusion !== 'success') {
-              // Upstream CI failed — all jobs were skipped via approval guards, not due to test failures
-              state = 'pending';
-              description = `CI workflow ${ciConclusion} — integration tests skipped (not blocking)`;
-              core.notice(`CI workflow concluded with '${ciConclusion}' — integration tests were skipped. This is expected when ci.yml itself has an error.`);
-            } else {
-              const success = relvalResult === 'success'
-                && integResult === 'success'
-                && smokeResult === 'success';
-              state = success ? 'success' : 'failure';
-              description = success ? 'All integration tests passed' : 'Integration tests failed';
-            }
-
-            await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.payload.workflow_run.head_sha,
-              state,
-              target_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              context: 'Integration Tests (PR)',
-              description
-            });
-

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -1,4 +1,4 @@
-# Tier 2 integration suite — runs only when a PR is added to the merge queue.
+# Tier 2 integration suite - runs only when a PR is added to the merge queue.
 #
 # Design (microsoft/apm#770):
 #   - Tier 1 (ci.yml) runs unit tests + binary build on every PR push and on

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -26,6 +26,7 @@ env:
 on:
   merge_group:
     branches: [ main ]
+    types: [ checks_requested ]
 
 permissions:
   contents: read
@@ -104,11 +105,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Artifact root is ./dist/ (least common ancestor of the uploaded paths in
+      # the build job), so download to ./dist/ to preserve dist/apm-linux-x86_64/apm.
       - name: Download binary
         uses: actions/download-artifact@v4
         with:
           name: apm-mq-linux-x86_64
-          path: ./dist/apm-linux-x86_64/
+          path: ./dist/
+
+      - name: Make binary executable
+        run: chmod +x ./dist/apm-linux-x86_64/apm
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -159,16 +165,15 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
+      # See note in integration-tests: download to dist/ to preserve layout.
       - name: Download binary
         uses: actions/download-artifact@v4
         with:
           name: apm-mq-linux-x86_64
-          path: /tmp/apm-isolated-test/dist/apm-linux-x86_64/
+          path: /tmp/apm-isolated-test/dist/
 
       - name: Make binary executable
-        run: |
-          cd /tmp/apm-isolated-test
-          chmod +x ./dist/apm-linux-x86_64/apm
+        run: chmod +x /tmp/apm-isolated-test/dist/apm-linux-x86_64/apm
 
       - name: Create APM symlink for testing
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
   # microsoft/apm#770 for the design.
   merge_group:
     branches: [ main ]
+    types: [ checks_requested ]
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
       - 'docs/**'
       - '.gitignore'
       - 'LICENSE'
+  # Tier 1 also runs in merge queue context so the same unit + build checks
+  # execute against the tentative merge commit that the queue creates. See
+  # microsoft/apm#770 for the design.
+  merge_group:
+    branches: [ main ]
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `apm install` now automatically discovers and deploys local `.apm/` primitives (skills, instructions, agents, prompts, hooks, commands) to target directories, with local content taking priority over dependencies on collision (#626, #644)
 - Add `temp-dir` configuration key (`apm config set temp-dir PATH`) to override the system temporary directory, resolving `[WinError 5] Access is denied` in corporate Windows environments (#629)
 
+### Changed
+
+- CI: adopt GitHub Merge Queue with tiered CI. `ci.yml` (Tier 1: unit tests + binary build) now runs on `pull_request` and `merge_group`. The integration + release-validation suite (Tier 2) moves to `merge_group`-only, replacing the previous `workflow_run` + environment-approval flow. PR branches no longer need manual updates against `main`, and the heavy integration suite runs once at merge time instead of on every PR push (#770)
+
 ### Fixed
 
 - Harden `apm install` stale-file cleanup to prevent unsafe lockfile deletions, preserve user-edited files via per-file SHA-256 provenance, and improve cleanup reporting during install and `--dry-run` (#666, #762)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,26 @@ Enhancement suggestions are welcome! Please:
 4. Update documentation if needed.
 5. PRs must pass all CI checks before they can be merged.
 
+### How merging works
+
+This repo uses GitHub's native **merge queue**. Once your PR is approved, a
+maintainer adds it to the queue. The queue then:
+
+1. Builds a tentative merge of your PR against the latest `main` — no manual
+   "Update branch" needed.
+2. Runs the integration suite against that tentative merge.
+3. Auto-merges if checks pass; ejects from the queue if they fail.
+
+What this means for contributors:
+
+- You don't need to keep your branch up to date with `main` manually.
+- The fast unit + build checks (Tier 1) run on every push to your PR.
+- The full integration suite (Tier 2) only runs once your PR is in the queue,
+  not on every WIP push.
+
+If your PR is ejected from the queue because of a real failure, push a fix and
+ask a maintainer to re-queue.
+
 ### Issue Triage
 
 Every new issue is automatically labeled `needs-triage`. Maintainers review incoming issues and:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Enhancement suggestions are welcome! Please:
 
 ### Pull Request Process
 
-1. Fill out the PR template — describe what changed, why, and link the issue.
+1. Fill out the PR template - describe what changed, why, and link the issue.
 2. Ensure your PR addresses only one concern (one feature, one bug fix).
 3. Include tests for new functionality.
 4. Update documentation if needed.
@@ -54,7 +54,7 @@ Enhancement suggestions are welcome! Please:
 This repo uses GitHub's native **merge queue**. Once your PR is approved, a
 maintainer adds it to the queue. The queue then:
 
-1. Builds a tentative merge of your PR against the latest `main` — no manual
+1. Builds a tentative merge of your PR against the latest `main` - no manual
    "Update branch" needed.
 2. Runs the integration suite against that tentative merge.
 3. Auto-merges if checks pass; ejects from the queue if they fail.
@@ -73,9 +73,9 @@ ask a maintainer to re-queue.
 
 Every new issue is automatically labeled `needs-triage`. Maintainers review incoming issues and:
 
-1. **Accept** — remove `needs-triage`, add `accepted`, and assign a milestone.
-2. **Prioritize** — optionally add `priority/high` or `priority/low`.
-3. **Close** — if it's a duplicate (`duplicate`) or out of scope, close with a comment explaining why.
+1. **Accept** - remove `needs-triage`, add `accepted`, and assign a milestone.
+2. **Prioritize** - optionally add `priority/high` or `priority/low`.
+3. **Close** - if it's a duplicate (`duplicate`) or out of scope, close with a comment explaining why.
 
 Labels used for triage: `needs-triage`, `accepted`, `needs-design`, `priority/high`, `priority/low`.
 
@@ -97,7 +97,7 @@ uv sync --extra dev
 We use pytest for testing with `pytest-xdist` for parallel execution. After completing the setup above:
 
 ```bash
-# Run the unit test suite (recommended — matches CI, fast)
+# Run the unit test suite (recommended - matches CI, fast)
 uv run pytest tests/unit tests/test_console.py -x
 
 # Run a specific test file (fastest, use during development)


### PR DESCRIPTION
Implements #770.

## Summary

Restructure CI into two tiers gated by GitHub native Merge Queue:

- **Tier 1 (`ci.yml`)** — unit tests + binary build. Runs on every PR push and on `merge_group` events. No secrets, fork-safe, fast feedback (~2-4 min).
- **Tier 2 (`ci-integration.yml`)** — smoke + integration + release-validation. Runs **only** on `merge_group` events against the queue's tentative merge commit. Heavy suite no longer fires on every WIP push.

## What this fixes

1. **Manual "Update branch" clicks** — merge queue tests the tentative merge commit, so PRs are always validated against current `main`. No more rebase loops.
2. **Per-PR-push approval bottleneck** — Tier 2 was previously gated by the `integration-tests` environment requiring manual approval on every push. With merge queue, the trust boundary becomes the write-access grant: only users with write can enqueue, and only enqueued runs see CI secrets. Fork PRs without write access run only Tier 1.

## Files changed

- `.github/workflows/ci.yml` — added `merge_group` trigger.
- `.github/workflows/ci-integration.yml` — rewritten as `merge_group`-only; inlines the binary build so the suite tests exactly the tentative merge SHA without cross-workflow artifact plumbing; drops `workflow_run`, `approve-fork`, `approve-internal`, `report-status` jobs.
- `CONTRIBUTING.md` — added "How merging works" section.
- `.github/instructions/cicd.instructions.md` — rewrote workflow architecture, trust model, release flow, and performance sections.
- `CHANGELOG.md` — Unreleased > Changed entry.

## Required follow-up (repo Settings, cannot be done in YAML)

After this PR merges, a maintainer must:

1. **Enable merge queue on `main`** in branch protection (Settings -> Branches -> `main`).
2. **Update required status checks** to the names produced by the first `merge_group` run. Expected:
   - From `ci.yml` (PR + merge_group): `Build & Test (Linux)`
   - From `ci-integration.yml` (merge_group only): `Build (Linux)`, `Smoke Test (Linux)`, `Integration Tests (Linux)`, `Release Validation (Linux)`
3. **Disable** "Require branches to be up to date before merging" — the queue handles that.
4. **Retire the `integration-tests` environment** (Settings -> Environments) — no longer used.

## Risks

The `ci-integration.yml` rewrite is the riskiest piece — losing the `workflow_run` machinery means any bug ships at merge time. The first few merges should be watched closely. If the queue stalls, disabling merge queue in branch protection takes one click and reverts to the previous PR-merge model without any YAML changes.

## Out of scope

- Mergify/Kodiak — GitHub native merge queue removes the need.
- Required reviews policy — orthogonal.
- Test parallelization / sharding — separate optimization.

Closes part of #770.
