### PR TITLE
[docs] Update documentation for v0.8.12 features

### DIFF
--- a/docs/src/content/docs/getting-started/authentication.md
+++ b/docs/src/content/docs/getting-started/authentication.md
@@ -175,7 +175,7 @@ export PROXY_REGISTRY_ONLY=1    # optional -- enforces proxy-only mode
 apm install
 ```
 
-When `PROXY_REGISTRY_URL` is set, APM rewrites download URLs to go through the proxy and sends `PROXY_REGISTRY_TOKEN` as the `Authorization: Bearer` header instead of the GitHub PAT.
+When `PROXY_REGISTRY_URL` is set, APM rewrites download URLs to go through the proxy and sends `PROXY_REGISTRY_TOKEN` as the `Authorization: Bearer` header instead of the GitHub PAT. This includes both GitHub API archive downloads and `codeload.github.com`-style tarball URLs, so JFrog Artifactory proxies configured against `codeload.github.com` work correctly in proxy-only mode.
 
 ### Lockfile and reproducibility
 
@@ -281,6 +281,17 @@ git config credential.helper              # check current helper
 git config --global credential.helper osxkeychain  # macOS
 gh auth login                              # GitHub CLI
 ```
+
+### Azure DevOps authentication errors
+
+If `apm install` fails with an ADO-specific error (e.g., `Authentication failed for dev.azure.com`), ensure `ADO_APM_PAT` is set and has **Code (Read)** permission for the target organisation. ADO does not fall back to unauthenticated access -- all ADO installs require an explicit PAT:
+
+```bash
+export ADO_APM_PAT=your_ado_pat
+apm install dev.azure.com/myorg/myproject/myrepo
+```
+
+See [Azure DevOps](#azure-devops) above for PAT creation steps.
 
 ### SSH connection hangs on corporate/VPN networks
 

--- a/docs/src/content/docs/guides/compilation.md
+++ b/docs/src/content/docs/guides/compilation.md
@@ -31,6 +31,7 @@ apm compile                    # Auto-detects target from project structure
 apm compile --target copilot   # Force GitHub Copilot, Cursor, Gemini
 apm compile --target codex     # Force Codex CLI
 apm compile --target claude    # Force Claude Code, Claude Desktop
+apm compile --target minimal   # AGENTS.md only, no folder integration
 ```
 
 You can set a persistent target in `apm.yml`:

--- a/docs/src/content/docs/reference/cli-commands.md
+++ b/docs/src/content/docs/reference/cli-commands.md
@@ -229,7 +229,7 @@ apm install --dry-run
 APM automatically detects which integrations to enable based on your project structure:
 
 - **VSCode integration**: Enabled when `.github/` directory exists
-- **Claude integration**: Enabled when `.claude/` directory exists
+- **Claude integration**: Enabled when `.claude/` directory exists (using `--target claude` explicitly creates `.claude/` even if it does not exist yet)
 - **Cursor integration**: Enabled when `.cursor/` directory exists
 - **OpenCode integration**: Enabled when `.opencode/` directory exists
 - All integrations can coexist in the same project
@@ -1187,7 +1187,7 @@ apm compile [OPTIONS]
 
 **Options:**
 - `-o, --output TEXT` - Output file path (for single-file mode)
-- `-t, --target [vscode|agents|claude|codex|opencode|all]` - Target agent format. `agents` is an alias for `vscode`. Auto-detects if not specified.
+- `-t, --target [vscode|agents|claude|codex|opencode|minimal|all]` - Target agent format. `agents` is an alias for `vscode`. `minimal` generates `AGENTS.md` only with no folder integration. Auto-detects if not specified.
 - `--chatmode TEXT` - Chatmode to prepend to the AGENTS.md file
 - `--dry-run` - Preview compilation without writing files (shows placement decisions)
 - `--no-links` - Skip markdown link resolution


### PR DESCRIPTION
## Documentation Updates - 2026-04-20

This PR updates the documentation based on features shipped in v0.8.12 (released 2026-04-19, #774).

### Features Documented

- `--target claude` now creates `.claude/` on first run, even when the directory does not already exist (#763)
- `apm compile --target minimal` added as an explicit, discoverable CLI invocation (#766)
- ADO-specific authentication error troubleshooting entry (#742)
- `codeload.github.com` archive URL proxy rewriting clarified in registry proxy docs (#712)

### Changes Made

- Updated `docs/src/content/docs/reference/cli-commands.md`:
  - Auto-detection note for Claude integration now clarifies that `--target claude` creates `.claude/` even when absent (previously the wording implied the directory must pre-exist, actively misleading users bootstrapping a new Claude setup)
  - Added `minimal` to the `--target` flag value list for `apm compile` (it was missing, making `--target minimal` undiscoverable)
- Updated `docs/src/content/docs/guides/compilation.md`:
  - Added `apm compile --target minimal` to the example code block
- Updated `docs/src/content/docs/getting-started/authentication.md`:
  - Added "Azure DevOps authentication errors" troubleshooting subsection pointing users to `ADO_APM_PAT` setup (#742 added an actionable ADO-specific error message but there was no backing docs entry)
  - Extended the registry proxy description to mention `codeload.github.com`-style archive URLs are also rewritten (#712), which is critical for air-gapped/proxy-only environments

### Merged PRs Referenced

- #763 - Fix `--target claude` not creating `.claude/` when absent
- #766 - Fix `apm compile --target codex/opencode/minimal` silent no-op
- #742 - ADO-specific authentication error message
- #712 - Support `codeload.github.com` archive URLs in Artifactory proxy
- #774 - Prepare v0.8.12 release (trigger for this docs update)

### Notes

The only commit in the last 24 hours was the v0.8.12 release preparation (#774). All gaps identified are from features included in that release that were not yet reflected in the docs site.




> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/24647539866) · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+is%3Apr+%22gh-aw-workflow-id%3A+daily-doc-updater%22+in%3Abody)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-04-22T03:59:31.275Z --> on Apr 22, 2026, 3:59 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, id: 24647539866, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/24647539866 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->