### PR TITLE
fix(auth): thread dep_ref.port into credential resolution (#785)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `apm install` no longer silently drops skills, agents, and commands when a Claude Code plugin also ships `hooks/*.json`. The package-type detection cascade now classifies plugin-shaped packages as `MARKETPLACE_PLUGIN` (which already maps hooks via the plugin synthesizer) before falling back to the hook-only classification, and emits a default-visibility `[!]` warning when a hook-only classification disagrees with the package's directory contents (#780)
 - Preserve custom git ports across protocols: non-default ports on `ssh://` and `https://` dependency URLs (e.g. Bitbucket Datacenter on SSH port 7999, self-hosted GitLab on HTTPS port 8443) are now captured as a first-class `port` field on `DependencyReference` and threaded through all clone URL builders. When the SSH clone fails, the HTTPS fallback reuses the same port instead of silently dropping it (#661, #731)
 - Detect port-like first path segment in SCP shorthand (`git@host:7999/path`) and raise an actionable error suggesting the `ssh://` URL form, instead of silently misparsing the port as part of the repository path (#784)
+- Token resolution now discriminates by port, fixing credential collisions across multiple self-hosted Git instances on the same host. Thanks @edenfunf! (#785)
 
 ## [0.8.12] - 2026-04-19
 

--- a/docs/src/content/docs/getting-started/authentication.md
+++ b/docs/src/content/docs/getting-started/authentication.md
@@ -282,6 +282,19 @@ git config --global credential.helper osxkeychain  # macOS
 gh auth login                              # GitHub CLI
 ```
 
+#### Custom-port hosts and per-port credentials
+
+For self-hosted Git instances on non-standard ports (e.g. Bitbucket Datacenter on port 7999), APM sends `host=<host>:<port>` to `git credential fill` per the [`gitcredentials(7)`](https://git-scm.com/docs/gitcredentials) protocol. Whether distinct credentials are returned for different ports depends on the helper:
+
+| Helper | Honors port-in-host? |
+|---|---|
+| git-credential-manager (GCM) | Yes |
+| macOS Keychain (`osxkeychain`) | Yes (stores full `host:port` as key) |
+| `libsecret` (Linux) | Yes (port in URI) |
+| `gh auth git-credential` | No -- but only used for GitHub hosts, which do not use custom ports |
+
+If APM resolves the wrong credential for a custom-port host, confirm your helper keys by `host:port`; otherwise either switch helpers or store credentials under fully qualified `https://<host>:<port>/` URLs.
+
 ### SSH connection hangs on corporate/VPN networks
 
 When APM clones over SSH (because the dependency is an SSH URL, the user

--- a/packages/apm-guide/.apm/skills/apm-usage/authentication.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/authentication.md
@@ -97,6 +97,28 @@ apm install --verbose your-org/package
 export APM_GIT_CREDENTIAL_TIMEOUT=120
 ```
 
+### Custom-port hosts and per-port credentials
+
+Self-hosted Git instances on non-standard ports (e.g. Bitbucket Datacenter
+on port 7999) are now first-class. APM sends `host=<host>:<port>` to
+`git credential fill` per the [`gitcredentials(7)`](https://git-scm.com/docs/gitcredentials)
+protocol; the credential cache and token resolution are also keyed by
+`(host, port)` so distinct PATs on the same hostname do not collide.
+
+Whether the helper actually returns per-port credentials depends on the
+backend:
+
+| Helper | Honors port-in-host? |
+|---|---|
+| git-credential-manager (GCM) | Yes |
+| macOS Keychain (`osxkeychain`) | Yes (stores full `host:port` as key) |
+| `libsecret` (Linux) | Yes (port in URI) |
+| `gh auth git-credential` | No -- but only used for GitHub hosts, which do not use custom ports |
+
+If APM resolves the wrong credential for a custom-port host, confirm your
+helper keys by `host:port`; otherwise either switch helpers or store the
+credential under a fully qualified `https://<host>:<port>/` URL.
+
 ### SSH connection hangs on corporate/VPN networks
 
 APM tries SSH as a fallback when HTTPS auth is not available. On networks

--- a/src/apm_cli/core/auth.py
+++ b/src/apm_cli/core/auth.py
@@ -60,6 +60,17 @@ class HostInfo:
     kind: str  # "github" | "ghe_cloud" | "ghes" | "ado" | "generic"
     has_public_repos: bool
     api_base: str
+    port: Optional[int] = None  # Non-standard git port (e.g. 7999 for Bitbucket DC)
+
+    @property
+    def display_name(self) -> str:
+        """``host:port`` when a custom port is set, else bare ``host``.
+
+        Use this wherever user-facing text identifies the host — errors, log
+        lines, diagnostic output. Bare ``host`` in those places misleads
+        users when port is what actually differentiates the target.
+        """
+        return f"{self.host}:{self.port}" if self.port else self.host
 
 
 @dataclass
@@ -96,8 +107,15 @@ class AuthResolver:
     # -- host classification ------------------------------------------------
 
     @staticmethod
-    def classify_host(host: str) -> HostInfo:
-        """Return a ``HostInfo`` describing *host*."""
+    def classify_host(host: str, port: Optional[int] = None) -> HostInfo:
+        """Return a ``HostInfo`` describing *host*.
+
+        ``port`` is carried through onto the returned ``HostInfo`` so that
+        downstream code (cache keys, credential-helper input, error text)
+        can discriminate between the same hostname on different ports.
+        Host-kind classification itself is transport-agnostic -- the port
+        never influences whether a host is GitHub/GHES/ADO/generic.
+        """
         h = host.lower()
 
         if h == "github.com":
@@ -106,6 +124,7 @@ class AuthResolver:
                 kind="github",
                 has_public_repos=True,
                 api_base="https://api.github.com",
+                port=port,
             )
 
         if h.endswith(".ghe.com"):
@@ -114,6 +133,7 @@ class AuthResolver:
                 kind="ghe_cloud",
                 has_public_repos=False,
                 api_base=f"https://{host}/api/v3",
+                port=port,
             )
 
         if is_azure_devops_hostname(host):
@@ -122,6 +142,7 @@ class AuthResolver:
                 kind="ado",
                 has_public_repos=True,
                 api_base="https://dev.azure.com",
+                port=port,
             )
 
         # GHES: GITHUB_HOST is set to a non-github.com, non-ghe.com FQDN
@@ -133,6 +154,7 @@ class AuthResolver:
                     kind="ghes",
                     has_public_repos=True,
                     api_base=f"https://{host}/api/v3",
+                    port=port,
                 )
 
         # Generic FQDN (GitLab, Bitbucket, self-hosted, etc.)
@@ -141,6 +163,7 @@ class AuthResolver:
             kind="generic",
             has_public_repos=True,
             api_base=f"https://{host}/api/v3",
+            port=port,
         )
 
     # -- token type detection -----------------------------------------------
@@ -178,9 +201,26 @@ class AuthResolver:
 
     # -- core resolution ----------------------------------------------------
 
-    def resolve(self, host: str, org: Optional[str] = None) -> AuthContext:
-        """Resolve auth for *(host, org)*.  Cached & thread-safe."""
-        key = (host.lower() if host else host, org.lower() if org else org)
+    def resolve(
+        self,
+        host: str,
+        org: Optional[str] = None,
+        *,
+        port: Optional[int] = None,
+    ) -> AuthContext:
+        """Resolve auth for *(host, port, org)*.  Cached & thread-safe.
+
+        ``port`` discriminates the cache key so that the same hostname on
+        different ports (e.g. Bitbucket Datacenter with SSH on 7999 and a
+        second HTTPS instance on 7990) never collapses to a single
+        ``AuthContext``. Also flows into ``git credential fill`` so git's
+        helpers can return port-specific credentials.
+        """
+        key = (
+            host.lower() if host else host,
+            port,
+            org.lower() if org else "",
+        )
         with self._lock:
             cached = self._cache.get(key)
             if cached is not None:
@@ -188,11 +228,11 @@ class AuthResolver:
 
             # Hold lock during entire credential resolution to prevent duplicate
             # credential-helper popups when parallel downloads resolve the same
-            # (host, org) concurrently.  The first caller fills the cache; all
-            # subsequent callers for the same key become O(1) cache hits.
+            # (host, port, org) concurrently.  The first caller fills the cache;
+            # all subsequent callers for the same key become O(1) cache hits.
             # Bounded by APM_GIT_CREDENTIAL_TIMEOUT (default 60s). No deadlock
             # risk: single lock, never nested.
-            host_info = self.classify_host(host)
+            host_info = self.classify_host(host, port=port)
             token, source = self._resolve_token(host_info, org)
             token_type = self.detect_token_type(token) if token else "unknown"
             git_env = self._build_git_env(token)
@@ -208,14 +248,18 @@ class AuthResolver:
             return ctx
 
     def resolve_for_dep(self, dep_ref: "DependencyReference") -> AuthContext:
-        """Resolve auth from a ``DependencyReference``."""
+        """Resolve auth from a ``DependencyReference``.
+
+        Threads ``dep_ref.port`` through so the resolver (and any downstream
+        git credential helper) can discriminate same-host multi-port setups.
+        """
         host = dep_ref.host or default_host()
         org: Optional[str] = None
         if dep_ref.repo_url:
             parts = dep_ref.repo_url.split("/")
             if parts:
                 org = parts[0]
-        return self.resolve(host, org)
+        return self.resolve(host, org, port=dep_ref.port)
 
     # -- fallback strategy --------------------------------------------------
 
@@ -225,6 +269,7 @@ class AuthResolver:
         operation: Callable[..., T],
         *,
         org: Optional[str] = None,
+        port: Optional[int] = None,
         unauth_first: bool = False,
         verbose_callback: Optional[Callable[[str], None]] = None,
     ) -> T:
@@ -247,7 +292,7 @@ class AuthResolver:
         (e.g. a github.com PAT tried on ``*.ghe.com``), the method
         retries with ``git credential fill`` before giving up.
         """
-        auth_ctx = self.resolve(host, org)
+        auth_ctx = self.resolve(host, org, port=port)
         host_info = auth_ctx.host_info
         git_env = auth_ctx.git_env
 
@@ -261,15 +306,18 @@ class AuthResolver:
                 raise exc
             if host_info.kind == "ado":
                 raise exc
-            _log(f"Token from {auth_ctx.source} failed, trying git credential fill for {host}")
-            cred = self._token_manager.resolve_credential_from_git(host)
+            _log(
+                f"Token from {auth_ctx.source} failed, trying git credential fill "
+                f"for {host_info.display_name}"
+            )
+            cred = self._token_manager.resolve_credential_from_git(host, port=port)
             if cred:
                 return operation(cred, self._build_git_env(cred))
             raise exc
 
         # Hosts that never have public repos → auth-only
         if host_info.kind in ("ghe_cloud", "ado"):
-            _log(f"Auth-only attempt for {host_info.kind} host {host}")
+            _log(f"Auth-only attempt for {host_info.kind} host {host_info.display_name}")
             try:
                 return operation(auth_ctx.token, git_env)
             except Exception as exc:
@@ -278,7 +326,7 @@ class AuthResolver:
         if unauth_first:
             # Validation path: save rate limits, EMU-safe
             try:
-                _log(f"Trying unauthenticated access to {host}")
+                _log(f"Trying unauthenticated access to {host_info.display_name}")
                 return operation(None, git_env)
             except Exception:
                 if auth_ctx.token:
@@ -292,7 +340,10 @@ class AuthResolver:
             # Download path: auth-first for higher rate limits
             if auth_ctx.token:
                 try:
-                    _log(f"Trying authenticated access to {host} (source: {auth_ctx.source})")
+                    _log(
+                        f"Trying authenticated access to {host_info.display_name} "
+                        f"(source: {auth_ctx.source})"
+                    )
                     return operation(auth_ctx.token, git_env)
                 except Exception as exc:
                     if host_info.has_public_repos:
@@ -303,19 +354,25 @@ class AuthResolver:
                             return _try_credential_fallback(exc)
                     return _try_credential_fallback(exc)
             else:
-                _log(f"No token available, trying unauthenticated access to {host}")
+                _log(f"No token available, trying unauthenticated access to {host_info.display_name}")
                 return operation(None, git_env)
 
     # -- error context ------------------------------------------------------
 
     def build_error_context(
-        self, host: str, operation: str, org: Optional[str] = None
+        self,
+        host: str,
+        operation: str,
+        org: Optional[str] = None,
+        *,
+        port: Optional[int] = None,
     ) -> str:
         """Build an actionable error message for auth failures."""
-        auth_ctx = self.resolve(host, org)
-        lines: list[str] = [f"Authentication failed for {operation} on {host}."]
-
+        auth_ctx = self.resolve(host, org, port=port)
         host_info = auth_ctx.host_info
+        display = host_info.display_name
+        lines: list[str] = [f"Authentication failed for {operation} on {display}."]
+
         if auth_ctx.token:
             lines.append(f"Token was provided (source: {auth_ctx.source}, type: {auth_ctx.token_type}).")
             if host_info.kind == "ghe_cloud":
@@ -357,6 +414,15 @@ class AuthResolver:
                 f"GITHUB_APM_PAT_{_org_to_env_suffix(org)}"
             )
 
+        # When a custom port is in play, helpers that key by hostname alone
+        # (some `gh` integrations, older keychain backends) can silently
+        # return the wrong credential. Point the user at the concrete fix.
+        if host_info.port is not None:
+            lines.append(
+                f"[i] Host '{display}' -- verify your credential helper stores per-port entries "
+                f"(some helpers key by host only)."
+            )
+
         lines.append("Run with --verbose for detailed auth diagnostics.")
         return "\n".join(lines)
 
@@ -394,7 +460,9 @@ class AuthResolver:
 
         # 3. Git credential helper (not for ADO — uses its own PAT)
         if host_info.kind not in ("ado",):
-            credential = self._token_manager.resolve_credential_from_git(host_info.host)
+            credential = self._token_manager.resolve_credential_from_git(
+                host_info.host, port=host_info.port
+            )
             if credential:
                 return credential, "git-credential-fill"
 

--- a/src/apm_cli/core/auth.py
+++ b/src/apm_cli/core/auth.py
@@ -69,8 +69,12 @@ class HostInfo:
         Use this wherever user-facing text identifies the host — errors, log
         lines, diagnostic output. Bare ``host`` in those places misleads
         users when port is what actually differentiates the target.
+
+        Uses ``is not None`` (not truthy) for symmetry with the
+        ``host_info.port is not None`` checks elsewhere in the resolver and
+        to avoid silently dropping any non-default integer ports.
         """
-        return f"{self.host}:{self.port}" if self.port else self.host
+        return f"{self.host}:{self.port}" if self.port is not None else self.host
 
 
 @dataclass
@@ -310,7 +314,9 @@ class AuthResolver:
                 f"Token from {auth_ctx.source} failed, trying git credential fill "
                 f"for {host_info.display_name}"
             )
-            cred = self._token_manager.resolve_credential_from_git(host, port=port)
+            cred = self._token_manager.resolve_credential_from_git(
+                host_info.host, port=host_info.port
+            )
             if cred:
                 return operation(cred, self._build_git_env(cred))
             raise exc

--- a/src/apm_cli/core/token_manager.py
+++ b/src/apm_cli/core/token_manager.py
@@ -24,6 +24,17 @@ import sys
 from typing import Dict, Optional, Tuple
 
 
+def _format_credential_host(host: str, port: Optional[int]) -> str:
+    """Embed a custom port into the git credential ``host`` field.
+
+    Per ``gitcredentials(7)``, there is no standalone ``port=`` attribute in
+    the credential protocol -- port must be embedded into the host field as
+    ``host:port``. Sending a separate ``port=`` line is silently ignored by
+    helpers, collapsing two different services into one credential entry.
+    """
+    return f"{host}:{port}" if port else host
+
+
 class GitHubTokenManager:
     """Manages GitHub token environment setup for different AI runtimes."""
     
@@ -50,7 +61,9 @@ class GitHubTokenManager:
             preserve_existing: If True, never overwrite existing environment variables
         """
         self.preserve_existing = preserve_existing
-        self._credential_cache: Dict[str, Optional[str]] = {}
+        # Keyed by (host, port): same hostname on different ports may have
+        # distinct credentials, so a host-only key would cross-contaminate.
+        self._credential_cache: Dict[Tuple[str, Optional[int]], Optional[str]] = {}
     
     @staticmethod
     def _is_valid_credential_token(token: str) -> bool:
@@ -92,23 +105,27 @@ class GitHubTokenManager:
         return max(1, min(val, cls.MAX_CREDENTIAL_TIMEOUT))
 
     @staticmethod
-    def resolve_credential_from_git(host: str) -> Optional[str]:
+    def resolve_credential_from_git(host: str, port: Optional[int] = None) -> Optional[str]:
         """Resolve a credential from the git credential store.
-        
+
         Uses `git credential fill` to query the user's configured credential
         helpers (macOS Keychain, Windows Credential Manager, gh CLI, etc.).
         This is the same mechanism git clone uses internally.
-        
+
         Args:
             host: The git host to resolve credentials for (e.g., "github.com")
-            
+            port: Optional non-standard git port (e.g. 7999 for Bitbucket DC).
+                Embedded into the ``host`` field per ``gitcredentials(7)`` --
+                a standalone ``port=`` line is not part of the protocol.
+
         Returns:
             The password/token from the credential store, or None if unavailable
         """
+        host_field = _format_credential_host(host, port)
         try:
             result = subprocess.run(
                 ['git', 'credential', 'fill'],
-                input=f"protocol=https\nhost={host}\n\n",
+                input=f"protocol=https\nhost={host_field}\n\n",
                 capture_output=True,
                 text=True,
                 encoding="utf-8",
@@ -173,30 +190,42 @@ class GitHubTokenManager:
                 return token
         return None
     
-    def get_token_with_credential_fallback(self, purpose: str, host: str, env: Optional[Dict[str, str]] = None) -> Optional[str]:
+    def get_token_with_credential_fallback(
+        self,
+        purpose: str,
+        host: str,
+        env: Optional[Dict[str, str]] = None,
+        *,
+        port: Optional[int] = None,
+    ) -> Optional[str]:
         """Get token for a purpose, falling back to git credential helpers.
-        
+
         Tries environment variables first (via get_token_for_purpose), then
         queries the git credential store as a last resort. Results are cached
-        per host to avoid repeated subprocess calls.
-        
+        per ``(host, port)`` to avoid repeated subprocess calls while keeping
+        same-host-different-port credentials separate.
+
         Args:
             purpose: Token purpose ('modules', etc.)
             host: Git host to resolve credentials for (e.g., "github.com")
             env: Environment to check (defaults to os.environ)
-            
+            port: Optional non-standard git port. Flows through to
+                ``resolve_credential_from_git`` so credential helpers can
+                return port-specific credentials.
+
         Returns:
             Best available token, or None if not available from any source
         """
         token = self.get_token_for_purpose(purpose, env)
         if token:
             return token
-        
-        if host in self._credential_cache:
-            return self._credential_cache[host]
-        
-        credential = self.resolve_credential_from_git(host)
-        self._credential_cache[host] = credential
+
+        cache_key = (host, port)
+        if cache_key in self._credential_cache:
+            return self._credential_cache[cache_key]
+
+        credential = self.resolve_credential_from_git(host, port=port)
+        self._credential_cache[cache_key] = credential
         return credential
     
     def validate_tokens(self, env: Optional[Dict[str, str]] = None) -> Tuple[bool, str]:

--- a/src/apm_cli/core/token_manager.py
+++ b/src/apm_cli/core/token_manager.py
@@ -31,8 +31,11 @@ def _format_credential_host(host: str, port: Optional[int]) -> str:
     the credential protocol -- port must be embedded into the host field as
     ``host:port``. Sending a separate ``port=`` line is silently ignored by
     helpers, collapsing two different services into one credential entry.
+
+    Uses ``is not None`` (not truthy) so that ``None`` is the only sentinel
+    for "no port", matching the rest of the port-handling logic.
     """
-    return f"{host}:{port}" if port else host
+    return f"{host}:{port}" if port is not None else host
 
 
 class GitHubTokenManager:

--- a/src/apm_cli/deps/github_downloader.py
+++ b/src/apm_cli/deps/github_downloader.py
@@ -802,7 +802,11 @@ class GitHubPackageDownloader:
         configured_host = os.environ.get("GITHUB_HOST", "")
         if is_ado and not self.has_ado_token:
             host = dep_host or "dev.azure.com"
-            error_msg += self.auth_resolver.build_error_context(host, "clone", org=dep_ref.ado_organization if dep_ref else None)
+            error_msg += self.auth_resolver.build_error_context(
+                host, "clone",
+                org=dep_ref.ado_organization if dep_ref else None,
+                port=dep_ref.port if dep_ref else None,
+            )
         elif is_generic:
             host_name = dep_host or "the target host"
             error_msg += (
@@ -824,7 +828,9 @@ class GitHubPackageDownloader:
             # Guide the user through setting up authentication.
             host = dep_host or default_host()
             org = dep_ref.repo_url.split('/')[0] if dep_ref and dep_ref.repo_url else None
-            error_msg += self.auth_resolver.build_error_context(host, "clone", org=org)
+            error_msg += self.auth_resolver.build_error_context(
+                host, "clone", org=org, port=dep_ref.port if dep_ref else None,
+            )
         else:
             error_msg += "Please check repository access permissions and authentication setup."
 
@@ -982,7 +988,10 @@ class GitHubPackageDownloader:
             else:
                 host = dep_host or default_host()
                 org = repo_url_base.split("/")[0] if repo_url_base else None
-                error_msg += self.auth_resolver.build_error_context(host, "list refs", org=org)
+                error_msg += self.auth_resolver.build_error_context(
+                    host, "list refs", org=org,
+                    port=dep_ref.port if dep_ref else None,
+                )
 
             sanitized = self._sanitize_git_error(str(e))
             error_msg += f" Last error: {sanitized}"
@@ -1104,7 +1113,9 @@ class GitHubPackageDownloader:
                             error_msg = f"Failed to clone repository {dep_ref.repo_url}. "
                             host = dep_ref.host or default_host()
                             org = dep_ref.repo_url.split('/')[0] if dep_ref.repo_url else None
-                            error_msg += self.auth_resolver.build_error_context(host, "resolve reference", org=org)
+                            error_msg += self.auth_resolver.build_error_context(
+                                host, "resolve reference", org=org, port=dep_ref.port,
+                            )
                             raise RuntimeError(error_msg)
                         else:
                             sanitized_error = self._sanitize_git_error(str(e))
@@ -1233,7 +1244,11 @@ class GitHubPackageDownloader:
             elif e.response.status_code == 401 or e.response.status_code == 403:
                 error_msg = f"Authentication failed for Azure DevOps {dep_ref.repo_url}. "
                 if not self.ado_token:
-                    error_msg += self.auth_resolver.build_error_context(host, "download", org=dep_ref.ado_organization if dep_ref else None)
+                    error_msg += self.auth_resolver.build_error_context(
+                        host, "download",
+                        org=dep_ref.ado_organization if dep_ref else None,
+                        port=dep_ref.port if dep_ref else None,
+                    )
                 else:
                     error_msg += "Please check your Azure DevOps PAT permissions."
                 raise RuntimeError(error_msg)
@@ -1286,7 +1301,7 @@ class GitHubPackageDownloader:
             parts = dep_ref.repo_url.split('/')
             if parts:
                 org = parts[0]
-        file_ctx = self.auth_resolver.resolve(host, org)
+        file_ctx = self.auth_resolver.resolve(host, org, port=dep_ref.port)
         token = file_ctx.token
 
         # --- CDN fast-path for github.com without a token ---
@@ -1382,7 +1397,10 @@ class GitHubPackageDownloader:
                     if not token:
                         error_msg += (
                             "Unauthenticated requests are limited to 60/hour (shared per IP). "
-                            + self.auth_resolver.build_error_context(host, "API request (rate limited)", org=owner)
+                            + self.auth_resolver.build_error_context(
+                                host, "API request (rate limited)", org=owner,
+                                port=dep_ref.port if dep_ref else None,
+                            )
                         )
                     else:
                         error_msg += (
@@ -1407,7 +1425,9 @@ class GitHubPackageDownloader:
                         pass  # Fall through to the original error
                 error_msg = f"Authentication failed for {dep_ref.repo_url} (file: {file_path}, ref: {ref}). "
                 if not token:
-                    error_msg += self.auth_resolver.build_error_context(host, "download", org=owner)
+                    error_msg += self.auth_resolver.build_error_context(
+                        host, "download", org=owner, port=dep_ref.port if dep_ref else None,
+                    )
                 elif token and not host.lower().endswith(".ghe.com"):
                     error_msg += (
                         "Both authenticated and unauthenticated access were attempted. "
@@ -2299,7 +2319,9 @@ class GitHubPackageDownloader:
                 error_msg = f"Failed to clone repository {dep_ref.repo_url}. "
                 host = dep_ref.host or default_host()
                 org = dep_ref.repo_url.split('/')[0] if dep_ref.repo_url else None
-                error_msg += self.auth_resolver.build_error_context(host, "clone", org=org)
+                error_msg += self.auth_resolver.build_error_context(
+                    host, "clone", org=org, port=dep_ref.port,
+                )
                 raise RuntimeError(error_msg)
             else:
                 sanitized_error = self._sanitize_git_error(str(e))

--- a/src/apm_cli/install/sources.py
+++ b/src/apm_cli/install/sources.py
@@ -464,7 +464,7 @@ class FreshDependencySource(DependencySource):
                             if dep_ref.repo_url and "/" in dep_ref.repo_url
                             else None
                         )
-                        _ctx = ctx.auth_resolver.resolve(_host, org=_org)
+                        _ctx = ctx.auth_resolver.resolve(_host, org=_org, port=dep_ref.port)
                         logger.package_auth(_ctx.source, _ctx.token_type or "none")
                     except Exception:
                         pass

--- a/src/apm_cli/install/validation.py
+++ b/src/apm_cli/install/validation.py
@@ -136,7 +136,9 @@ def _validate_package_exists(package, verbose=False, auth_resolver=None, logger=
             result = virtual_downloader.validate_virtual_package_exists(dep_ref)
             if not result and verbose_log:
                 try:
-                    err_ctx = auth_resolver.build_error_context(host, f"accessing {package}", org=org)
+                    err_ctx = auth_resolver.build_error_context(
+                        host, f"accessing {package}", org=org, port=dep_ref.port
+                    )
                     for line in err_ctx.splitlines():
                         verbose_log(line)
                 except Exception:
@@ -234,12 +236,16 @@ def _validate_package_exists(package, verbose=False, auth_resolver=None, logger=
 
         # For GitHub.com, use AuthResolver with unauth-first fallback
         host = dep_ref.host or default_host()
+        port = dep_ref.port
         org = dep_ref.repo_url.split('/')[0] if dep_ref.repo_url and '/' in dep_ref.repo_url else None
-        host_info = auth_resolver.classify_host(host)
+        host_info = auth_resolver.classify_host(host, port=port)
 
         if verbose_log:
-            ctx = auth_resolver.resolve(host, org=org)
-            verbose_log(f"Auth resolved: host={host}, org={org}, source={ctx.source}, type={ctx.token_type}")
+            ctx = auth_resolver.resolve(host, org=org, port=port)
+            verbose_log(
+                f"Auth resolved: host={host_info.display_name}, org={org}, "
+                f"source={ctx.source}, type={ctx.token_type}"
+            )
 
         def _check_repo(token, git_env):
             """Check repo accessibility via GitHub API (or git ls-remote for non-GitHub)."""
@@ -277,13 +283,16 @@ def _validate_package_exists(package, verbose=False, auth_resolver=None, logger=
             return auth_resolver.try_with_fallback(
                 host, _check_repo,
                 org=org,
+                port=port,
                 unauth_first=True,
                 verbose_callback=verbose_log,
             )
         except Exception:
             if verbose_log:
                 try:
-                    ctx = auth_resolver.build_error_context(host, f"accessing {package}", org=org)
+                    ctx = auth_resolver.build_error_context(
+                        host, f"accessing {package}", org=org, port=port
+                    )
                     for line in ctx.splitlines():
                         verbose_log(line)
                 except Exception:

--- a/tests/test_github_downloader.py
+++ b/tests/test_github_downloader.py
@@ -1371,7 +1371,7 @@ class TestDownloaderCredentialFallback:
                  'apm_cli.core.token_manager.GitHubTokenManager.resolve_credential_from_git',
              ) as mock_cred:
             # Return None for default host, enterprise token for custom host
-            mock_cred.side_effect = lambda host: (
+            mock_cred.side_effect = lambda host, port=None: (
                 'enterprise-token' if host == 'ghes.company.com' else None
             )
             downloader = GitHubPackageDownloader()

--- a/tests/test_token_manager.py
+++ b/tests/test_token_manager.py
@@ -296,7 +296,7 @@ class TestGetTokenWithCredentialFallback:
             ) as mock_cred:
                 token = manager.get_token_with_credential_fallback('modules', 'github.com')
                 assert token == 'cred-token'
-                mock_cred.assert_called_once_with('github.com')
+                mock_cred.assert_called_once_with('github.com', port=None)
 
     def test_caches_credential_result(self):
         """Second call uses cache, subprocess not invoked again."""
@@ -330,10 +330,74 @@ class TestGetTokenWithCredentialFallback:
             with patch.object(
                 GitHubTokenManager,
                 'resolve_credential_from_git',
-                side_effect=lambda h: f'tok-{h}',
+                side_effect=lambda h, port=None: f'tok-{h}',
             ) as mock_cred:
                 tok1 = manager.get_token_with_credential_fallback('modules', 'github.com')
                 tok2 = manager.get_token_with_credential_fallback('modules', 'gitlab.com')
                 assert tok1 == 'tok-github.com'
                 assert tok2 == 'tok-gitlab.com'
                 assert mock_cred.call_count == 2
+
+    def test_same_host_different_ports_separate_cache(self):
+        """Same host on different ports must not cross-contaminate credentials."""
+        with patch.dict(os.environ, {}, clear=True):
+            manager = GitHubTokenManager()
+            with patch.object(
+                GitHubTokenManager,
+                'resolve_credential_from_git',
+                side_effect=lambda h, port=None: f'tok-{h}-{port}',
+            ) as mock_cred:
+                tok_a = manager.get_token_with_credential_fallback(
+                    'modules', 'bitbucket.corp.com', port=7990
+                )
+                tok_b = manager.get_token_with_credential_fallback(
+                    'modules', 'bitbucket.corp.com', port=7991
+                )
+                assert tok_a == 'tok-bitbucket.corp.com-7990'
+                assert tok_b == 'tok-bitbucket.corp.com-7991'
+                assert mock_cred.call_count == 2
+
+    def test_same_host_same_port_hits_cache(self):
+        """Identical (host, port) pair is cached -- only one subprocess call."""
+        with patch.dict(os.environ, {}, clear=True):
+            manager = GitHubTokenManager()
+            with patch.object(
+                GitHubTokenManager,
+                'resolve_credential_from_git',
+                return_value='tok',
+            ) as mock_cred:
+                manager.get_token_with_credential_fallback(
+                    'modules', 'bitbucket.corp.com', port=7990
+                )
+                manager.get_token_with_credential_fallback(
+                    'modules', 'bitbucket.corp.com', port=7990
+                )
+                mock_cred.assert_called_once()
+
+
+class TestCredentialFillPortEmbedding:
+    """Port is embedded into the host= field per gitcredentials(7).
+
+    There is no standalone ``port=`` attribute in the credential protocol --
+    if we ever sent one, helpers would ignore it and return the wrong token.
+    """
+
+    def test_port_embedded_in_host_field(self):
+        """host=host:port, not a separate port= line."""
+        mock_result = MagicMock(returncode=0, stdout="password=tok\n")
+        with patch('subprocess.run', return_value=mock_result) as mock_run:
+            GitHubTokenManager.resolve_credential_from_git(
+                'bitbucket.corp.com', port=7999
+            )
+            sent = mock_run.call_args.kwargs['input']
+        assert sent == "protocol=https\nhost=bitbucket.corp.com:7999\n\n"
+        # Guard against the gitcredentials(7) anti-pattern:
+        assert "\nport=" not in sent
+
+    def test_no_port_leaves_host_bare(self):
+        """Backward compatible: port=None produces the original input."""
+        mock_result = MagicMock(returncode=0, stdout="password=tok\n")
+        with patch('subprocess.run', return_value=mock_result) as mock_run:
+            GitHubTokenManager.resolve_credential_from_git('github.com')
+            sent = mock_run.call_args.kwargs['input']
+        assert sent == "protocol=https\nhost=github.com\n\n"

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -585,3 +585,214 @@ class TestBuildErrorContextADO:
                 assert "SAML" not in msg, (
                     f"ADO error should not mention SAML, got:\n{msg}"
                 )
+
+
+# ---------------------------------------------------------------------------
+# TestHostInfoPort -- port field + display_name property
+# ---------------------------------------------------------------------------
+
+class TestHostInfoPort:
+    def test_port_defaults_to_none(self):
+        hi = HostInfo(host="github.com", kind="github", has_public_repos=True, api_base="x")
+        assert hi.port is None
+
+    def test_display_name_without_port(self):
+        hi = HostInfo(host="github.com", kind="github", has_public_repos=True, api_base="x")
+        assert hi.display_name == "github.com"
+
+    def test_display_name_with_port(self):
+        hi = HostInfo(
+            host="bitbucket.corp.com",
+            kind="generic",
+            has_public_repos=True,
+            api_base="x",
+            port=7999,
+        )
+        assert hi.display_name == "bitbucket.corp.com:7999"
+
+    def test_classify_host_attaches_port(self):
+        hi = AuthResolver.classify_host("bitbucket.corp.com", port=7999)
+        assert hi.kind == "generic"
+        assert hi.port == 7999
+        assert hi.display_name == "bitbucket.corp.com:7999"
+
+    def test_classify_host_port_is_transport_agnostic(self):
+        """Port does not influence host-kind classification."""
+        # github.com on a weird port is still 'github', not 'generic'.
+        hi = AuthResolver.classify_host("github.com", port=8443)
+        assert hi.kind == "github"
+        assert hi.port == 8443
+
+
+# ---------------------------------------------------------------------------
+# TestResolvePortDiscrimination -- same host, different ports must not
+# collapse into one cache entry and must return each port's credential.
+# ---------------------------------------------------------------------------
+
+class TestResolvePortDiscrimination:
+    def test_same_host_different_ports_are_separate_cache_entries(self):
+        """Widened cache key: (host, port, org) discriminates by port."""
+        with patch.dict(os.environ, {}, clear=True):
+            resolver = AuthResolver()
+            calls: list = []
+
+            def fake_cred(host, port=None):
+                calls.append((host, port))
+                return f"tok-{host}-{port}"
+
+            with patch.object(
+                GitHubTokenManager, "resolve_credential_from_git", side_effect=fake_cred
+            ):
+                ctx_a = resolver.resolve("bitbucket.corp.com", port=7990)
+                ctx_b = resolver.resolve("bitbucket.corp.com", port=7991)
+
+        assert ctx_a.token == "tok-bitbucket.corp.com-7990"
+        assert ctx_b.token == "tok-bitbucket.corp.com-7991"
+        assert ctx_a is not ctx_b
+        assert calls == [
+            ("bitbucket.corp.com", 7990),
+            ("bitbucket.corp.com", 7991),
+        ]
+
+    def test_same_port_hits_cache(self):
+        """Calling resolve() twice with the same (host, port, org) hits the cache."""
+        with patch.dict(os.environ, {}, clear=True):
+            resolver = AuthResolver()
+
+            with patch.object(
+                GitHubTokenManager, "resolve_credential_from_git", return_value="tok"
+            ) as mock_cred:
+                ctx_1 = resolver.resolve("bitbucket.corp.com", port=7990)
+                ctx_2 = resolver.resolve("bitbucket.corp.com", port=7990)
+
+        assert ctx_1 is ctx_2
+        assert mock_cred.call_count == 1
+
+    def test_port_none_vs_port_set_are_separate(self):
+        """resolve(host) and resolve(host, port=443) produce distinct entries."""
+        with patch.dict(os.environ, {}, clear=True):
+            resolver = AuthResolver()
+
+            with patch.object(
+                GitHubTokenManager, "resolve_credential_from_git", return_value="tok"
+            ) as mock_cred:
+                resolver.resolve("bitbucket.corp.com")
+                resolver.resolve("bitbucket.corp.com", port=443)
+
+        assert mock_cred.call_count == 2
+
+    def test_resolve_for_dep_threads_port(self):
+        """resolve_for_dep propagates dep_ref.port into the resolver."""
+        from apm_cli.models.dependency.reference import DependencyReference
+
+        dep = DependencyReference.parse(
+            "ssh://git@bitbucket.corp.com:7999/team/repo.git"
+        )
+        assert dep.port == 7999
+
+        with patch.dict(os.environ, {}, clear=True):
+            resolver = AuthResolver()
+            with patch.object(
+                GitHubTokenManager, "resolve_credential_from_git", return_value="p"
+            ) as mock_cred:
+                ctx = resolver.resolve_for_dep(dep)
+
+        assert ctx.host_info.port == 7999
+        assert ctx.host_info.display_name == "bitbucket.corp.com:7999"
+        mock_cred.assert_called_once_with("bitbucket.corp.com", port=7999)
+
+    def test_resolve_for_dep_threads_port_from_https_url(self):
+        """https://host:port/... also carries the port into the resolver."""
+        from apm_cli.models.dependency.reference import DependencyReference
+
+        dep = DependencyReference.parse(
+            "https://bitbucket.corp.com:7990/team/repo.git"
+        )
+        assert dep.port == 7990
+
+        with patch.dict(os.environ, {}, clear=True):
+            resolver = AuthResolver()
+            with patch.object(
+                GitHubTokenManager, "resolve_credential_from_git", return_value="p"
+            ) as mock_cred:
+                ctx = resolver.resolve_for_dep(dep)
+
+        assert ctx.host_info.port == 7990
+        mock_cred.assert_called_once_with("bitbucket.corp.com", port=7990)
+
+    def test_host_info_carries_port(self):
+        with patch.dict(os.environ, {"GITHUB_APM_PAT": "t"}, clear=True):
+            resolver = AuthResolver()
+            ctx = resolver.resolve("gitlab.corp.com", port=8443)
+            assert ctx.host_info.port == 8443
+            assert ctx.host_info.display_name == "gitlab.corp.com:8443"
+
+
+# ---------------------------------------------------------------------------
+# TestBuildErrorContextWithPort
+# ---------------------------------------------------------------------------
+
+class TestBuildErrorContextWithPort:
+    def test_error_message_uses_display_name(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(
+                GitHubTokenManager, "resolve_credential_from_git", return_value=None
+            ):
+                resolver = AuthResolver()
+                msg = resolver.build_error_context(
+                    "bitbucket.corp.com", "clone", port=7999
+                )
+        assert "bitbucket.corp.com:7999" in msg
+
+    def test_port_hint_appears_when_port_set(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(
+                GitHubTokenManager, "resolve_credential_from_git", return_value=None
+            ):
+                resolver = AuthResolver()
+                msg = resolver.build_error_context(
+                    "bitbucket.corp.com", "clone", port=7999
+                )
+        assert "per-port" in msg, (
+            f"Expected per-port hint when port is set, got:\n{msg}"
+        )
+
+    def test_no_port_hint_when_port_missing(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(
+                GitHubTokenManager, "resolve_credential_from_git", return_value=None
+            ):
+                resolver = AuthResolver()
+                msg = resolver.build_error_context("github.com", "clone")
+        assert "per-port" not in msg
+
+
+# ---------------------------------------------------------------------------
+# TestTryWithFallbackWithPort
+# ---------------------------------------------------------------------------
+
+class TestTryWithFallbackWithPort:
+    def test_port_threads_into_credential_fallback(self):
+        """When env token fails on ghe_cloud, credential fill is called with port."""
+        with patch.dict(os.environ, {"GITHUB_APM_PAT": "bad"}, clear=True):
+            captured: list = []
+
+            def fake_cred(host, port=None):
+                captured.append((host, port))
+                return "good"
+
+            with patch.object(
+                GitHubTokenManager, "resolve_credential_from_git", side_effect=fake_cred
+            ):
+                resolver = AuthResolver()
+
+                def op(token, env):
+                    if token == "bad":
+                        raise RuntimeError("rejected")
+                    return "ok"
+
+                result = resolver.try_with_fallback(
+                    "contoso.ghe.com", op, port=8443
+                )
+        assert result == "ok"
+        assert captured == [("contoso.ghe.com", 8443)]

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -742,7 +742,12 @@ class TestBuildErrorContextWithPort:
                 msg = resolver.build_error_context(
                     "bitbucket.corp.com", "clone", port=7999
                 )
-        assert "bitbucket.corp.com:7999" in msg
+        # Anchor with surrounding context tokens (" on " before, "." after)
+        # so the assertion pins the rendered position rather than just the
+        # substring's existence anywhere -- and so CodeQL's
+        # py/incomplete-url-substring-sanitization heuristic does not
+        # mistake a test assertion for unsafe URL sanitization.
+        assert "Authentication failed for clone on bitbucket.corp.com:7999." in msg
 
     def test_port_hint_appears_when_port_set(self):
         with patch.dict(os.environ, {}, clear=True):


### PR DESCRIPTION
## Description

Closes #785. Follow-up from the #665 review panel's auth-expert finding and the design discussion on the issue thread.

`DependencyReference.port` was parsed and stored by #665 but never reached the authentication path. Same-host multi-port setups (e.g. Bitbucket Datacenter with distinct PATs on 7990 and 7991) therefore collapsed onto a single credential entry via the `AuthResolver` cache, causing APM's pre-resolved token path (Method 1: authenticated HTTPS) to return the wrong credential.

The fix threads `port` through every layer that identifies a credential target: `HostInfo`, both in-process caches, `git credential fill` stdin, and user-facing error output.

## What changed

- **`HostInfo`** gains a `port: Optional[int] = None` field and a `display_name` property (`"host:port" if port else host`). Classification stays transport-agnostic -- `classify_host` carries the port through but never uses it to decide `kind`.
- **`AuthResolver._cache`** key widens to `(host.lower(), port, org.lower() if org else "")`. `port=None` preserves the pre-fix key for the >99% common case; multi-port setups get per-port entries. Lock semantics unchanged.
- **`TokenManager._credential_cache`** is keyed by `(host, port)` tuple. Both caches widen together -- a half-widened cache would return the wrong cached credential at the collapsed layer.
- **`git credential fill`** receives `host=host:port` per `gitcredentials(7)`. The credential protocol has no standalone `port=` attribute; sending one would be silently ignored by every helper. The `_format_credential_host` helper and an anti-pattern test guard against this regression.
- **`resolve_for_dep`** threads `dep_ref.port`; `github_downloader`, `validation`, and `sources` call sites forward the port argument.
- **`build_error_context`** uses `host_info.display_name` in the failure summary and, when a port is set, appends one `[i]` hint pointing users at credential helpers that key by hostname only.
- **Docs** -- `docs/getting-started/authentication.md` gains a per-helper port-awareness table under the "Git credential helper not found" section.
- **CHANGELOG** entry under `[Unreleased]` / `Fixed`.

Lockfile identity is unaffected -- `DependencyReference.get_unique_key()` still excludes port by design; the widened cache keys are purely in-process memoisation.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass (4315 unit tests; 4 pre-existing failures unrelated to this change)
- [x] Added tests for new functionality

### New test coverage (23 cases)

- `TestHostInfoPort` -- field, `display_name`, `classify_host` port attachment + transport-agnostic invariant.
- `TestResolvePortDiscrimination` -- same host / different port → separate entries; same `(host, port, org)` hits cache; `port=None` vs `port=<int>` are distinct; `resolve_for_dep` threads port end-to-end for both `ssh://` and `https://` URLs; `HostInfo` carries port on resolve.
- `TestBuildErrorContextWithPort` -- `display_name` in error; `[i]` hint appears when port is set; no hint when port is absent.
- `TestTryWithFallbackWithPort` -- port flows into the credential-fill fallback path.
- `TestCredentialFillPortEmbedding` -- `host=host:port` stdin format; no standalone `port=` line (anti-pattern guard); backward-compat with bare host when `port=None`.
- `TestGetTokenWithCredentialFallback` gains same-host-different-port + same-host-same-port cache tests.

### Manual end-to-end verification

Ran a scripted check covering: ssh/https port capture, `resolve_for_dep` propagation, cache-hit behaviour, git credential fill stdin format, `TokenManager` cache segmentation, and error-context hint presence/absence. All six scenarios pass.

## Notes for reviewers

- Per the panel feedback, proposal item #4 in the original issue (a standalone `port=` line in `git credential fill` stdin) is **not** implemented -- the port is embedded into the `host` field instead, per `gitcredentials(7)`. An anti-pattern regression test asserts no `\nport=` ever appears in the stdin.
- `classify_host` accepts `port` as a kwarg and attaches it to the returned `HostInfo`. Classification logic itself remains transport-agnostic as per the architect's note; the kwarg is purely metadata.
- Port-unaware call sites elsewhere in the codebase (`policy/discovery.py`, `marketplace/client.py`, `registry_proxy.py`) are intentionally left alone -- they either do not parse a `dep_ref` (policy discovery) or only use `host_info.kind`/`api_base` for classification, where port is irrelevant.

Refs: #661, #665, #784