### PR TITLE
[docs] Update MCP client documentation for global scope and missing runtimes

### DIFF
--- a/docs/src/content/docs/integrations/ide-tool-integration.md
+++ b/docs/src/content/docs/integrations/ide-tool-integration.md
@@ -464,11 +464,15 @@ apm install --trust-transitive-mcp
 
 APM configures MCP servers in the native config format for each supported client:
 
-| Client | Config Location | Format |
-|--------|----------------|--------|
-| VS Code | `.vscode/mcp.json` | JSON `servers` object |
-| GitHub Copilot CLI | `~/.copilot/mcp-config.json` | JSON `mcpServers` object |
-| Codex CLI | `~/.codex/config.toml` | TOML `mcp_servers` section |
+| Client | Config Location | Format | Global (`-g`) |
+|--------|----------------|--------|---------------|
+| VS Code | `.vscode/mcp.json` | JSON `servers` object | No (workspace only) |
+| Cursor | `.cursor/mcp.json` | JSON `mcpServers` object | No (workspace only) |
+| OpenCode | `opencode.json` | JSON `mcp` key | No (workspace only) |
+| GitHub Copilot CLI | `~/.copilot/mcp-config.json` | JSON `mcpServers` object | Yes |
+| Codex CLI | `~/.codex/config.toml` | TOML `mcp_servers` section | Yes |
+
+When using `apm install --global` (`-g`), MCP servers are installed only to runtimes with a user-level config path (Copilot CLI, Codex CLI). Workspace-only runtimes (VS Code, Cursor, OpenCode) are skipped because their config files are project-scoped.
 
 **Runtime targeting**: APM detects which runtimes are installed and configures MCP servers for all of them. Use `--runtime <name>` or `--exclude <name>` to control which clients receive configuration.
 
@@ -505,14 +509,14 @@ The MCP registry API may return empty `registry_name` fields for packages. APM i
 
 When installing registry MCP servers, APM selects the best available package for each runtime:
 
-| Package Registry | VS Code | Copilot CLI | Codex CLI |
-|-----------------|---------|-------------|-----------|
-| npm | Yes (npx) | Yes (npx) | Yes (npx) |
-| pypi | Yes (uvx/python3) | Yes (uvx) | Yes (uvx) |
-| docker | Yes | Yes | Yes |
-| homebrew | -- | Yes | Yes |
-| Other (with runtime_hint) | Yes (generic) | Yes (generic) | Yes (generic) |
-| HTTP/SSE remotes | Yes | Yes | Yes |
+| Package Registry | VS Code | Cursor | OpenCode | Copilot CLI | Codex CLI |
+|-----------------|---------|--------|----------|-------------|-----------|
+| npm | Yes (npx) | Yes (npx) | Yes (npx) | Yes (npx) | Yes (npx) |
+| pypi | Yes (uvx/python3) | Yes (uvx) | Yes (uvx) | Yes (uvx) | Yes (uvx) |
+| docker | Yes | Yes | Yes | Yes | Yes |
+| homebrew | -- | -- | -- | Yes | Yes |
+| Other (with runtime_hint) | Yes (generic) | Yes (generic) | Yes (generic) | Yes (generic) | Yes (generic) |
+| HTTP/SSE remotes | Yes | Yes | Yes | Yes | Yes |
 
 ### MCP Server Declaration
 


### PR DESCRIPTION
## Documentation Updates - 2026-04-21

This PR updates the documentation based on features merged in the last 24 hours.

### Features Documented

- `apm install --global` MCP scope filtering (from #638): Copilot CLI and Codex CLI support global scope; VS Code, Cursor, and OpenCode are workspace-only
- Missing Cursor and OpenCode entries in the MCP Client Configuration and Supported Package Types tables

### Changes Made

- Updated `docs/src/content/docs/integrations/ide-tool-integration.md`:
  - Added **Cursor** (`.cursor/mcp.json`) and **OpenCode** (`opencode.json`) as workspace-only MCP runtimes to the Client Configuration table (both were missing)
  - Added a **"Global (`-g`)"** column to the Client Configuration table clarifying which runtimes support `apm install --global` for MCP deployment
  - Added an explanatory paragraph noting why workspace-only runtimes are skipped at user scope
  - Expanded the Supported Package Types table to include Cursor and OpenCode columns

### Merged PRs Referenced

- #638 - Fix `apm install --global` skipping MCP server installation (added `supports_user_scope` attribute per adapter; CHANGELOG and `cli-commands.md`/`guides/dependencies.md` already updated in that PR)

### Notes

The behavioral changes from #638 were already reflected in:
- `CHANGELOG.md` (Unreleased section)
- `docs/src/content/docs/reference/cli-commands.md:98`
- `docs/src/content/docs/guides/dependencies.md:336`

This PR fills the remaining gap in `ide-tool-integration.md` where the MCP client table was incomplete (missing Cursor, OpenCode) and lacked the global scope indicator column.




> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/24702946750) · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+is%3Apr+%22gh-aw-workflow-id%3A+daily-doc-updater%22+in%3Abody)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-04-23T03:53:59.749Z --> on Apr 23, 2026, 3:53 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, id: 24702946750, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/24702946750 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->