### PR TITLE
feat(codex): add project-scoped MCP and user target support

### DIFF
--- a/docs/src/content/docs/integrations/ide-tool-integration.md
+++ b/docs/src/content/docs/integrations/ide-tool-integration.md
@@ -468,9 +468,9 @@ APM configures MCP servers in the native config format for each supported client
 |--------|----------------|--------|
 | VS Code | `.vscode/mcp.json` | JSON `servers` object |
 | GitHub Copilot CLI | `~/.copilot/mcp-config.json` | JSON `mcpServers` object |
-| Codex CLI | `~/.codex/config.toml` | TOML `mcp_servers` section |
+| Codex CLI | Project: `.codex/config.toml`  User scope: `~/.codex/config.toml` | TOML `mcp_servers` section |
 
-**Runtime targeting**: APM detects which runtimes are installed and configures MCP servers for all of them. Use `--runtime <name>` or `--exclude <name>` to control which clients receive configuration.
+**Runtime targeting**: APM detects which runtimes are installed and configures MCP servers for all of them. Codex MCP is project-scoped during project installs, so it is written to `.codex/config.toml` only when Codex is an active project target. Use `--runtime <name>` or `--exclude <name>` to control which clients receive configuration.
 
 > **VS Code detection**: APM considers VS Code available when either the `code` CLI command is on PATH **or** a `.vscode/` directory exists in the current working directory. This means VS Code MCP configuration works even when `code` is not on PATH — common on macOS and Linux when "Install 'code' command in PATH" has not been run from the VS Code command palette, or when VS Code was installed via a method that doesn't register the CLI (e.g. `.tar.gz`, Flatpak, or a non-standard macOS install location).
 

--- a/docs/src/content/docs/reference/cli-commands.md
+++ b/docs/src/content/docs/reference/cli-commands.md
@@ -1553,7 +1553,7 @@ apm runtime setup llm
 **Default Behavior:**
 - Installs runtime binary from official sources
 - Configures with GitHub Models (free) as APM default
-- Creates configuration file at `~/.codex/config.toml` or similar
+- Creates Codex runtime configuration (global `~/.codex/config.toml`; project MCP config is managed separately in `.codex/config.toml`)
 - Provides clear logging about what's being configured
 
 **Vanilla Behavior (`--vanilla` flag):**

--- a/src/apm_cli/adapters/client/base.py
+++ b/src/apm_cli/adapters/client/base.py
@@ -1,6 +1,8 @@
 """Base adapter interface for MCP clients."""
 
+import os
 import re
+from pathlib import Path
 from abc import ABC, abstractmethod
 
 _INPUT_VAR_RE = re.compile(r"\$\{input:([^}]+)\}")
@@ -14,6 +16,18 @@ class MCPClientAdapter(ABC):
     # Adapters that target a global path should override this to ``True``
     # so that ``apm install --global`` can install MCP servers to them.
     supports_user_scope: bool = False
+
+    def __init__(self, project_root=None, user_scope=False):
+        """Initialize the adapter with optional scope-aware path context."""
+        self._project_root = Path(project_root) if project_root is not None else None
+        self.user_scope = user_scope
+
+    @property
+    def project_root(self) -> Path:
+        """Return the explicit project root or the current working directory."""
+        if self._project_root is not None:
+            return self._project_root
+        return Path(os.getcwd())
 
     @abstractmethod
     def get_config_path(self):
@@ -123,3 +137,13 @@ class MCPClientAdapter(ABC):
                     f"'{server_name}' will not be resolved \u2014 "
                     f"{runtime_label} does not support input variable prompts"
                 )
+
+    def normalize_project_arg(self, value):
+        """Normalize workspace placeholders for project-local runtimes."""
+        if (
+            not self.user_scope
+            and isinstance(value, str)
+            and value in {"${workspaceFolder}", "${projectRoot}"}
+        ):
+            return "."
+        return value

--- a/src/apm_cli/adapters/client/codex.py
+++ b/src/apm_cli/adapters/client/codex.py
@@ -1,9 +1,4 @@
-"""OpenAI Codex CLI implementation of MCP client adapter.
-
-This adapter implements the Codex CLI-specific handling of MCP server configuration,
-targeting the global ~/.codex/config.toml file as specified in the MCP installation
-architecture specification.
-"""
+"""OpenAI Codex CLI implementation of MCP client adapter."""
 
 import os
 import toml
@@ -17,13 +12,12 @@ class CodexClientAdapter(MCPClientAdapter):
     """Codex CLI implementation of MCP client adapter.
     
     This adapter handles Codex CLI-specific configuration for MCP servers using
-    a global ~/.codex/config.toml file, following the TOML format for
-    MCP server configuration.
+    a scope-resolved config.toml file, following the TOML format for MCP
+    server configuration.
     """
-
     supports_user_scope: bool = True
 
-    def __init__(self, registry_url=None):
+    def __init__(self, registry_url=None, project_root=None, user_scope=False):
         """Initialize the Codex CLI client adapter.
         
         Args:
@@ -31,17 +25,23 @@ class CodexClientAdapter(MCPClientAdapter):
                 If not provided, uses the MCP_REGISTRY_URL environment variable
                 or falls back to the default GitHub registry.
         """
+        super().__init__(project_root=project_root, user_scope=user_scope)
         self.registry_client = SimpleRegistryClient(registry_url)
         self.registry_integration = RegistryIntegration(registry_url)
+
+    def _get_codex_dir(self):
+        """Return the root directory used for Codex config in the current scope."""
+        if self.user_scope:
+            return Path.home() / ".codex"
+        return self.project_root / ".codex"
     
     def get_config_path(self):
         """Get the path to the Codex CLI MCP configuration file.
         
         Returns:
-            str: Path to ~/.codex/config.toml
+            str: Path to the scope-resolved Codex config.toml
         """
-        codex_dir = Path.home() / ".codex"
-        return str(codex_dir / "config.toml")
+        return str(self._get_codex_dir() / "config.toml")
     
     def update_config(self, config_updates):
         """Update the Codex CLI MCP configuration.
@@ -180,7 +180,7 @@ class CodexClientAdapter(MCPClientAdapter):
         raw = server_info.get("_raw_stdio")
         if raw:
             config["command"] = raw["command"]
-            config["args"] = raw["args"]
+            config["args"] = [self.normalize_project_arg(arg) for arg in raw["args"]]
             if raw.get("env"):
                 config["env"] = raw["env"]
                 self._warn_input_variables(raw["env"], server_info.get("name", ""), "Codex CLI")
@@ -555,4 +555,3 @@ class CodexClientAdapter(MCPClientAdapter):
         
         # If no priority package found, return the first one
         return packages[0] if packages else None
-

--- a/src/apm_cli/adapters/client/copilot.py
+++ b/src/apm_cli/adapters/client/copilot.py
@@ -23,10 +23,9 @@ class CopilotClientAdapter(MCPClientAdapter):
     a global ~/.copilot/mcp-config.json file, following the JSON format for
     MCP server configuration.
     """
-
     supports_user_scope: bool = True
 
-    def __init__(self, registry_url=None):
+    def __init__(self, registry_url=None, project_root=None, user_scope=False):
         """Initialize the Copilot CLI client adapter.
         
         Args:
@@ -34,6 +33,7 @@ class CopilotClientAdapter(MCPClientAdapter):
                 If not provided, uses the MCP_REGISTRY_URL environment variable
                 or falls back to the default GitHub registry.
         """
+        super().__init__(project_root=project_root, user_scope=user_scope)
         self.registry_client = SimpleRegistryClient(registry_url)
         self.registry_integration = RegistryIntegration(registry_url)
     

--- a/src/apm_cli/adapters/client/cursor.py
+++ b/src/apm_cli/adapters/client/cursor.py
@@ -38,7 +38,7 @@ class CursorClientAdapter(CopilotClientAdapter):
         ``.cursor/`` directory is *not* created automatically — APM only
         writes here when the directory already exists.
         """
-        cursor_dir = Path(os.getcwd()) / ".cursor"
+        cursor_dir = self.project_root / ".cursor"
         return str(cursor_dir / "mcp.json")
 
     # ------------------------------------------------------------------ #
@@ -102,7 +102,7 @@ class CursorClientAdapter(CopilotClientAdapter):
             return False
 
         # Opt-in: skip silently when .cursor/ does not exist
-        cursor_dir = Path(os.getcwd()) / ".cursor"
+        cursor_dir = self.project_root / ".cursor"
         if not cursor_dir.exists():
             return True  # nothing to do, not an error
 

--- a/src/apm_cli/adapters/client/opencode.py
+++ b/src/apm_cli/adapters/client/opencode.py
@@ -44,7 +44,7 @@ class OpenCodeClientAdapter(CopilotClientAdapter):
 
     def get_config_path(self):
         """Return the path to ``opencode.json`` in the repository root."""
-        return str(Path(os.getcwd()) / "opencode.json")
+        return str(self.project_root / "opencode.json")
 
     def update_config(self, config_updates, enabled=True):
         """Merge *config_updates* into the ``mcp`` section of ``opencode.json``.
@@ -55,7 +55,7 @@ class OpenCodeClientAdapter(CopilotClientAdapter):
         Translates Copilot-format entries (``command``/``args``/``env``) into
         OpenCode format (``command`` array / ``environment``).
         """
-        opencode_dir = Path(os.getcwd()) / ".opencode"
+        opencode_dir = self.project_root / ".opencode"
         if not opencode_dir.is_dir():
             return
 

--- a/src/apm_cli/adapters/client/vscode.py
+++ b/src/apm_cli/adapters/client/vscode.py
@@ -21,7 +21,7 @@ class VSCodeClientAdapter(MCPClientAdapter):
     in the VSCode documentation.
     """
     
-    def __init__(self, registry_url=None):
+    def __init__(self, registry_url=None, project_root=None, user_scope=False):
         """Initialize the VSCode client adapter.
         
         Args:
@@ -29,6 +29,7 @@ class VSCodeClientAdapter(MCPClientAdapter):
                 If not provided, uses the MCP_REGISTRY_URL environment variable
                 or falls back to the default demo registry.
         """
+        super().__init__(project_root=project_root, user_scope=user_scope)
         self.registry_client = SimpleRegistryClient(registry_url)
         self.registry_integration = RegistryIntegration(registry_url)
     
@@ -39,7 +40,7 @@ class VSCodeClientAdapter(MCPClientAdapter):
             str: Path to the .vscode/mcp.json file.
         """
         # Use the current working directory as the repository root
-        repo_root = Path(os.getcwd())
+        repo_root = self.project_root
         
         # Path to .vscode/mcp.json in the repository
         vscode_dir = repo_root / ".vscode"

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -663,10 +663,20 @@ def install(ctx, packages, runtime, exclude, only, update, dry_run, force, verbo
         # Continue with MCP installation (existing logic)
         mcp_count = 0
         new_mcp_servers: builtins.set = builtins.set()
+        project_root = Path.cwd()
+        explicit_target = target
+        mcp_apm_config = {
+            "target": apm_package.target,
+            "scripts": apm_package.scripts or {},
+        }
         if should_install_mcp and mcp_deps:
             mcp_count = MCPIntegrator.install(
                 mcp_deps, runtime, exclude, verbose,
                 stored_mcp_configs=old_mcp_configs,
+                apm_config=mcp_apm_config,
+                project_root=project_root,
+                user_scope=(scope is InstallScope.USER),
+                explicit_target=explicit_target,
                 diagnostics=apm_diagnostics,
                 scope=scope,
             )
@@ -676,14 +686,28 @@ def install(ctx, packages, runtime, exclude, only, update, dry_run, force, verbo
             # Remove stale MCP servers that are no longer needed
             stale_servers = old_mcp_servers - new_mcp_servers
             if stale_servers:
-                MCPIntegrator.remove_stale(stale_servers, runtime, exclude, scope=scope)
+                MCPIntegrator.remove_stale(
+                    stale_servers,
+                    runtime,
+                    exclude,
+                    project_root=project_root,
+                    user_scope=(scope is InstallScope.USER),
+                    scope=scope,
+                )
 
             # Persist the new MCP server set and configs in the lockfile
             MCPIntegrator.update_lockfile(new_mcp_servers, mcp_configs=new_mcp_configs)
         elif should_install_mcp and not mcp_deps:
             # No MCP deps at all -- remove any old APM-managed servers
             if old_mcp_servers:
-                MCPIntegrator.remove_stale(old_mcp_servers, runtime, exclude, scope=scope)
+                MCPIntegrator.remove_stale(
+                    old_mcp_servers,
+                    runtime,
+                    exclude,
+                    project_root=project_root,
+                    user_scope=(scope is InstallScope.USER),
+                    scope=scope,
+                )
                 MCPIntegrator.update_lockfile(builtins.set(), mcp_configs={})
             logger.verbose_detail("No MCP dependencies found in apm.yml")
         elif not should_install_mcp and old_mcp_servers:
@@ -802,7 +826,4 @@ def _install_apm_dependencies(
         allow_protocol_fallback=allow_protocol_fallback,
     )
     return InstallService().run(request)
-
-
-
 

--- a/src/apm_cli/commands/uninstall/cli.py
+++ b/src/apm_cli/commands/uninstall/cli.py
@@ -194,8 +194,16 @@ def uninstall(ctx, packages, dry_run, verbose, global_):
         # Step 10: MCP cleanup
         try:
             apm_package = APMPackage.from_apm_yml(manifest_path)
-            _cleanup_stale_mcp(apm_package, lockfile, lockfile_path, _pre_uninstall_mcp_servers,
-                               modules_dir=get_modules_dir(scope), scope=scope)
+            _cleanup_stale_mcp(
+                apm_package,
+                lockfile,
+                lockfile_path,
+                _pre_uninstall_mcp_servers,
+                modules_dir=get_modules_dir(scope),
+                project_root=deploy_root,
+                user_scope=scope is InstallScope.USER,
+                scope=scope,
+            )
         except Exception:
             logger.warning("MCP cleanup during uninstall failed")
 

--- a/src/apm_cli/commands/uninstall/engine.py
+++ b/src/apm_cli/commands/uninstall/engine.py
@@ -354,7 +354,16 @@ def _sync_integrations_after_uninstall(apm_package, project_root, all_deployed_f
     return counts
 
 
-def _cleanup_stale_mcp(apm_package, lockfile, lockfile_path, old_mcp_servers, modules_dir=None, scope=None):
+def _cleanup_stale_mcp(
+    apm_package,
+    lockfile,
+    lockfile_path,
+    old_mcp_servers,
+    modules_dir=None,
+    project_root=None,
+    user_scope: bool = False,
+    scope=None,
+):
     """Remove MCP servers that are no longer needed after uninstall."""
     if not old_mcp_servers:
         return
@@ -368,5 +377,10 @@ def _cleanup_stale_mcp(apm_package, lockfile, lockfile_path, old_mcp_servers, mo
     new_mcp_servers = MCPIntegrator.get_server_names(all_remaining_mcp)
     stale_servers = old_mcp_servers - new_mcp_servers
     if stale_servers:
-        MCPIntegrator.remove_stale(stale_servers, scope=scope)
+        MCPIntegrator.remove_stale(
+            stale_servers,
+            project_root=project_root,
+            user_scope=user_scope,
+            scope=scope,
+        )
     MCPIntegrator.update_lockfile(new_mcp_servers, lockfile_path)

--- a/src/apm_cli/core/operations.py
+++ b/src/apm_cli/core/operations.py
@@ -4,7 +4,7 @@ from ..factory import ClientFactory, PackageManagerFactory
 from .safe_installer import SafeMCPInstaller
 
 
-def configure_client(client_type, config_updates):
+def configure_client(client_type, config_updates, project_root=None, user_scope=False):
     """Configure an MCP client.
     
     Args:
@@ -15,7 +15,11 @@ def configure_client(client_type, config_updates):
         bool: True if successful, False otherwise.
     """
     try:
-        client = ClientFactory.create_client(client_type)
+        client = ClientFactory.create_client(
+            client_type,
+            project_root=project_root,
+            user_scope=user_scope,
+        )
         client.update_config(config_updates)
         return True
     except Exception as e:
@@ -23,7 +27,7 @@ def configure_client(client_type, config_updates):
         return False
 
 
-def install_package(client_type, package_name, version=None, shared_env_vars=None, server_info_cache=None, shared_runtime_vars=None):
+def install_package(client_type, package_name, version=None, shared_env_vars=None, server_info_cache=None, shared_runtime_vars=None, project_root=None, user_scope=False):
     """Install an MCP package for a specific client type.
     
     Args:
@@ -39,7 +43,11 @@ def install_package(client_type, package_name, version=None, shared_env_vars=Non
     """
     try:
         # Use safe installer with conflict detection
-        safe_installer = SafeMCPInstaller(client_type)
+        safe_installer = SafeMCPInstaller(
+            client_type,
+            project_root=project_root,
+            user_scope=user_scope,
+        )
         
         # Pass shared environment and runtime variables and server info cache if available
         if shared_env_vars is not None or server_info_cache is not None or shared_runtime_vars is not None:
@@ -69,7 +77,7 @@ def install_package(client_type, package_name, version=None, shared_env_vars=Non
         }
 
 
-def uninstall_package(client_type, package_name):
+def uninstall_package(client_type, package_name, project_root=None, user_scope=False):
     """Uninstall an MCP package.
     
     Args:
@@ -80,7 +88,11 @@ def uninstall_package(client_type, package_name):
         bool: True if successful, False otherwise.
     """
     try:
-        client = ClientFactory.create_client(client_type)
+        client = ClientFactory.create_client(
+            client_type,
+            project_root=project_root,
+            user_scope=user_scope,
+        )
         package_manager = PackageManagerFactory.create_package_manager()
         
         # Uninstall the package

--- a/src/apm_cli/core/safe_installer.py
+++ b/src/apm_cli/core/safe_installer.py
@@ -58,15 +58,21 @@ class InstallationSummary:
 class SafeMCPInstaller:
     """Safe MCP server installation with conflict detection."""
     
-    def __init__(self, runtime: str, logger=None):
+    def __init__(self, runtime: str, logger=None, project_root=None, user_scope=False):
         """Initialize the safe installer.
         
         Args:
             runtime: Target runtime (copilot, codex, vscode).
             logger: Optional CommandLogger for structured output.
+            project_root: Optional project root for repo-local runtime configs.
+            user_scope: Whether runtime config should resolve in user scope.
         """
         self.runtime = runtime
-        self.adapter = ClientFactory.create_client(runtime)
+        self.adapter = ClientFactory.create_client(
+            runtime,
+            project_root=project_root,
+            user_scope=user_scope,
+        )
         self.conflict_detector = MCPConflictDetector(self.adapter)
         self.logger = logger
     

--- a/src/apm_cli/factory.py
+++ b/src/apm_cli/factory.py
@@ -12,11 +12,13 @@ class ClientFactory:
     """Factory for creating MCP client adapters."""
     
     @staticmethod
-    def create_client(client_type):
+    def create_client(client_type, project_root=None, user_scope=False):
         """Create a client adapter based on the specified type.
         
         Args:
             client_type (str): Type of client adapter to create.
+            project_root: Optional project root for repo-local configs.
+            user_scope: Whether the adapter should use user-scope paths.
         
         Returns:
             MCPClientAdapter: An instance of the specified client adapter.
@@ -36,7 +38,10 @@ class ClientFactory:
         if client_type.lower() not in clients:
             raise ValueError(f"Unsupported client type: {client_type}")
             
-        return clients[client_type.lower()]()
+        return clients[client_type.lower()](
+            project_root=project_root,
+            user_scope=user_scope,
+        )
 
 
 class PackageManagerFactory:

--- a/src/apm_cli/integration/mcp_integrator.py
+++ b/src/apm_cli/integration/mcp_integrator.py
@@ -399,6 +399,8 @@ class MCPIntegrator:
     def _check_self_defined_servers_needing_installation(
         dep_names: list,
         target_runtimes: list,
+        project_root=None,
+        user_scope: bool = False,
     ) -> list:
         """Return self-defined MCP servers missing from at least one runtime.
 
@@ -416,7 +418,11 @@ class MCPIntegrator:
         runtime_failures = []
         for runtime in target_runtimes:
             try:
-                client = ClientFactory.create_client(runtime)
+                client = ClientFactory.create_client(
+                    runtime,
+                    project_root=project_root,
+                    user_scope=user_scope,
+                )
                 detector = MCPConflictDetector(client)
                 runtime_existing[runtime] = detector.get_existing_server_configs()
             except Exception:
@@ -443,6 +449,8 @@ class MCPIntegrator:
         stale_names: builtins.set,
         runtime: str = None,
         exclude: str = None,
+        project_root=None,
+        user_scope: bool = False,
         logger=None,
         scope=None,
     ) -> None:
@@ -550,9 +558,17 @@ class MCPIntegrator:
                         exc_info=True,
                     )
 
-        # Clean ~/.codex/config.toml (mcp_servers section)
+        # Clean the scope-resolved Codex config.toml (mcp_servers section)
         if "codex" in target_runtimes:
-            codex_cfg = Path.home() / ".codex" / "config.toml"
+            from apm_cli.factory import ClientFactory
+
+            codex_cfg = Path(
+                ClientFactory.create_client(
+                    "codex",
+                    project_root=project_root,
+                    user_scope=user_scope,
+                ).get_config_path()
+            )
             if codex_cfg.exists():
                 try:
                     import toml as _toml
@@ -722,7 +738,9 @@ class MCPIntegrator:
 
         except ImportError:
             mcp_compatible = [
-                rt for rt in detected_runtimes if rt in ["vscode", "copilot", "cursor", "opencode"]
+                rt
+                for rt in detected_runtimes
+                if rt in ["vscode", "copilot", "codex", "cursor", "opencode"]
             ]
             return [rt for rt in mcp_compatible if shutil.which(rt)]
 
@@ -737,6 +755,8 @@ class MCPIntegrator:
         shared_env_vars: dict = None,
         server_info_cache: dict = None,
         shared_runtime_vars: dict = None,
+        project_root=None,
+        user_scope: bool = False,
         logger=None,
     ) -> bool:
         """Install MCP dependencies for a specific runtime.
@@ -745,10 +765,6 @@ class MCPIntegrator:
         """
         try:
             from apm_cli.core.operations import install_package
-            from apm_cli.factory import ClientFactory
-
-            # Get the appropriate client for the runtime
-            client = ClientFactory.create_client(runtime)
 
             all_ok = True
             for dep in mcp_deps:
@@ -763,6 +779,8 @@ class MCPIntegrator:
                         shared_env_vars=shared_env_vars,
                         server_info_cache=server_info_cache,
                         shared_runtime_vars=shared_runtime_vars,
+                        project_root=project_root,
+                        user_scope=user_scope,
                     )
                     if result["failed"]:
                         if logger:
@@ -822,6 +840,9 @@ class MCPIntegrator:
         verbose: bool = False,
         apm_config: dict = None,
         stored_mcp_configs: dict = None,
+        project_root=None,
+        user_scope: bool = False,
+        explicit_target: str = None,
         logger=None,
         diagnostics=None,
         scope=None,
@@ -839,7 +860,10 @@ class MCPIntegrator:
             stored_mcp_configs: Previously stored MCP configs from lockfile
                 for diff-aware installation.  When provided, servers whose
                 manifest config has changed are re-applied automatically.
-            scope: InstallScope (PROJECT or USER).  When USER, only
+            project_root: Project root for repo-local runtime configs.
+            user_scope: Whether runtime configuration is being resolved at user scope.
+            explicit_target: Explicit target selected by CLI or manifest.
+            scope: InstallScope (PROJECT or USER). When USER, only
                 runtimes whose adapter declares ``supports_user_scope``
                 are targeted; workspace-only runtimes are skipped.
 
@@ -1058,6 +1082,20 @@ class MCPIntegrator:
             if exclude:
                 target_runtimes = [r for r in target_runtimes if r != exclude]
 
+            # Codex MCP is project-scoped: only configure it when Codex is an
+            # active project target, mirroring Cursor/OpenCode opt-in behavior.
+            if not user_scope and "codex" in target_runtimes:
+                from apm_cli.integration.targets import active_targets
+
+                root = project_root or Path.cwd()
+                config_target = (
+                    explicit_target
+                    or (apm_config.get("target") if apm_config else None)
+                )
+                active = {t.name for t in active_targets(root, config_target)}
+                if "codex" not in active:
+                    target_runtimes = [r for r in target_runtimes if r != "codex"]
+
             # All runtimes excluded  -- nothing to configure
             if not target_runtimes and installed_runtimes:
                 if logger:
@@ -1168,7 +1206,10 @@ class MCPIntegrator:
                 if valid_servers:
                     servers_to_install = (
                         operations.check_servers_needing_installation(
-                            target_runtimes, valid_servers
+                            target_runtimes,
+                            valid_servers,
+                            project_root=project_root,
+                            user_scope=user_scope,
                         )
                     )
                     already_configured_candidates = [
@@ -1292,6 +1333,8 @@ class MCPIntegrator:
                                     shared_env_vars,
                                     server_info_cache,
                                     shared_runtime_vars,
+                                    project_root=project_root,
+                                    user_scope=user_scope,
                                     logger=logger,
                                 ):
                                     any_ok = True
@@ -1335,6 +1378,8 @@ class MCPIntegrator:
                 MCPIntegrator._check_self_defined_servers_needing_installation(
                     self_defined_names,
                     target_runtimes,
+                    project_root=project_root,
+                    user_scope=user_scope,
                 )
             )
             already_configured_candidates_sd = [
@@ -1414,6 +1459,8 @@ class MCPIntegrator:
                         [dep.name],
                         self_defined_env,
                         self_defined_cache,
+                        project_root=project_root,
+                        user_scope=user_scope,
                         logger=logger,
                     ):
                         any_ok = True

--- a/src/apm_cli/integration/targets.py
+++ b/src/apm_cli/integration/targets.py
@@ -280,6 +280,7 @@ KNOWN_TARGETS: Dict[str, TargetProfile] = {
         },
         auto_create=False,
         detect_by_dir=True,
+        user_supported="partial",
     ),
 }
 

--- a/src/apm_cli/registry/operations.py
+++ b/src/apm_cli/registry/operations.py
@@ -24,7 +24,7 @@ class MCPServerOperations:
         """
         self.registry_client = SimpleRegistryClient(registry_url)
     
-    def check_servers_needing_installation(self, target_runtimes: List[str], server_references: List[str]) -> List[str]:
+    def check_servers_needing_installation(self, target_runtimes: List[str], server_references: List[str], project_root=None, user_scope: bool = False) -> List[str]:
         """Check which MCP servers actually need installation across target runtimes.
         
         This method checks the actual MCP configuration files to see which servers
@@ -60,7 +60,11 @@ class MCPServerOperations:
                 # Check if this server needs installation in ANY of the target runtimes
                 needs_installation = False
                 for runtime in target_runtimes:
-                    runtime_installed_ids = self._get_installed_server_ids([runtime])
+                    runtime_installed_ids = self._get_installed_server_ids(
+                        [runtime],
+                        project_root=project_root,
+                        user_scope=user_scope,
+                    )
                     if server_id not in runtime_installed_ids:
                         needs_installation = True
                         break
@@ -74,7 +78,7 @@ class MCPServerOperations:
         
         return list(servers_needing_installation)
     
-    def _get_installed_server_ids(self, target_runtimes: List[str]) -> Set[str]:
+    def _get_installed_server_ids(self, target_runtimes: List[str], project_root=None, user_scope: bool = False) -> Set[str]:
         """Get all installed server IDs across target runtimes.
         
         Args:
@@ -93,7 +97,11 @@ class MCPServerOperations:
         
         for runtime in target_runtimes:
             try:
-                client = ClientFactory.create_client(runtime)
+                client = ClientFactory.create_client(
+                    runtime,
+                    project_root=project_root,
+                    user_scope=user_scope,
+                )
                 config = client.get_current_config()
                 
                 if isinstance(config, dict):

--- a/tests/unit/integration/test_data_driven_dispatch.py
+++ b/tests/unit/integration/test_data_driven_dispatch.py
@@ -669,12 +669,14 @@ class TestForScope:
         copilot = KNOWN_TARGETS["copilot"]
         assert copilot.for_scope(user_scope=False) is copilot
 
-    def test_unsupported_target_returns_none(self):
-        """for_scope returns None for targets that don't support user scope."""
+    def test_codex_is_supported_at_user_scope(self):
+        """Codex resolves cleanly at user scope."""
         from apm_cli.integration.targets import KNOWN_TARGETS
         codex = KNOWN_TARGETS["codex"]
-        assert codex.user_supported is False
-        assert codex.for_scope(user_scope=True) is None
+        assert codex.user_supported == "partial"
+        resolved = codex.for_scope(user_scope=True)
+        assert resolved is not None
+        assert resolved.root_dir == ".codex"
 
     def test_resolves_root_dir_to_user_root(self):
         """for_scope replaces root_dir with user_root_dir."""
@@ -746,13 +748,12 @@ class TestForScope:
             assert targets[0].root_dir == ".github"
 
     def test_resolve_targets_filters_unsupported(self):
-        """resolve_targets at user scope excludes unsupported targets."""
+        """resolve_targets at user scope includes all user-capable targets."""
         from apm_cli.integration.targets import resolve_targets, KNOWN_TARGETS
         from pathlib import Path
         targets = resolve_targets(Path.home(), user_scope=True, explicit_target="all")
         target_names = {t.name for t in targets}
-        # Codex doesn't support user scope
-        assert "codex" not in target_names
+        assert "codex" in target_names
 
 
 # ===================================================================

--- a/tests/unit/integration/test_hook_integrator.py
+++ b/tests/unit/integration/test_hook_integrator.py
@@ -2160,6 +2160,20 @@ class TestScopeResolvedHookDeployment:
         assert result.files_integrated > 0
         assert (self.root / ".claude" / "settings.json").exists()
 
+    def test_codex_hooks_use_scope_resolved_root_dir(self):
+        """Codex hooks at user scope merge into .codex/hooks.json."""
+        codex_target = self._make_target("codex", ".codex")
+        (self.root / ".codex").mkdir()
+        pi = _make_package_info(self.pkg_dir, "scope-pkg")
+        integrator = HookIntegrator()
+
+        result = integrator.integrate_hooks_for_target(
+            codex_target, pi, self.root,
+        )
+
+        assert result.files_integrated > 0
+        assert (self.root / ".codex" / "hooks.json").exists()
+
     def test_script_paths_rewritten_with_scope_root(self):
         """Script paths in hook commands use the scope-resolved root_dir."""
         # Create a hook with a script reference

--- a/tests/unit/integration/test_scope_install_uninstall.py
+++ b/tests/unit/integration/test_scope_install_uninstall.py
@@ -693,10 +693,29 @@ class TestCodexInstallUninstallCycle:
         for p in deployed:
             assert not (self.project_root / p).exists()
 
-    def test_user_scope_returns_none(self):
-        """Codex does not support user scope -- for_scope returns None."""
-        result = KNOWN_TARGETS["codex"].for_scope(user_scope=True)
-        assert result is None
+    def test_user_scope(self):
+        """Codex agents deploy to .codex/agents/ at user scope as well."""
+        target = KNOWN_TARGETS["codex"].for_scope(user_scope=True)
+        assert target is not None
+        (self.project_root / ".codex").mkdir()
+
+        pkg_info = _make_pkg(
+            self.project_root,
+            instructions=False,
+            agents=True,
+            commands=False,
+        )
+
+        agent_integrator = AgentIntegrator()
+        agent_result = agent_integrator.integrate_agents_for_target(
+            target, pkg_info, self.project_root
+        )
+
+        assert agent_result.files_integrated >= 1
+
+        deployed = _posix_relpaths(self.project_root, agent_result.target_paths)
+        assert any(p.startswith(".codex/agents/") for p in deployed)
+        assert any(p.endswith(".toml") for p in deployed)
 
 
 # ---------------------------------------------------------------------------
@@ -878,6 +897,29 @@ class TestSkillInstallUninstallCycle:
         assert sync["files_removed"] >= 1
         for p in deployed:
             assert not (self.project_root / p).exists()
+
+    def test_codex_user_scope(self):
+        """Codex skills keep using .agents/skills/ at user scope."""
+        target = KNOWN_TARGETS["codex"].for_scope(user_scope=True)
+        assert target is not None
+        (self.project_root / ".codex").mkdir()
+
+        pkg_info = _make_pkg(
+            self.project_root,
+            name="test-skill",
+            instructions=False,
+            agents=False,
+            skills=True,
+        )
+
+        integrator = SkillIntegrator()
+        result = integrator.integrate_package_skill(
+            pkg_info, self.project_root, targets=[target]
+        )
+
+        assert result.skill_created or result.skill_updated
+        deployed = _posix_relpaths(self.project_root, result.target_paths)
+        assert any(p.startswith(".agents/skills/") for p in deployed)
 
     def test_claude_project_scope(self):
         """Skill deploys to .claude/skills/ at project scope."""

--- a/tests/unit/integration/test_scope_integration.py
+++ b/tests/unit/integration/test_scope_integration.py
@@ -196,23 +196,28 @@ class TestOpenCodeScopeResolution:
         ).exists()
 
 
-# -- Codex exclusion at user scope -------------------------------------------
+# -- Codex user-scope behavior ----------------------------------------------
 
 
-class TestCodexScopeExclusion:
-    """Verify Codex is excluded at user scope."""
+class TestCodexUserScope:
+    """Verify Codex participates in user-scope target resolution."""
 
-    def test_for_scope_returns_none(self):
+    def test_for_scope_returns_profile(self):
         codex = KNOWN_TARGETS["codex"]
-        assert codex.user_supported is False
-        assert codex.for_scope(user_scope=True) is None
+        assert codex.user_supported == "partial"
+        resolved = codex.for_scope(user_scope=True)
+        assert resolved is not None
+        assert resolved.root_dir == ".codex"
+        assert "agents" in resolved.primitives
+        assert "skills" in resolved.primitives
+        assert "hooks" in resolved.primitives
 
-    def test_resolve_targets_excludes_codex_at_user_scope(self):
+    def test_resolve_targets_includes_codex_at_user_scope(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             targets = resolve_targets(root, user_scope=True, explicit_target="all")
             names = {t.name for t in targets}
-            assert "codex" not in names
+            assert "codex" in names
 
 
 # -- Claude same-root behavior -----------------------------------------------
@@ -248,8 +253,8 @@ class TestResolveTargetsConsistency:
                 Path(tmp), user_scope=True, explicit_target="all"
             )
             root_map = {t.name: t.root_dir for t in targets}
-            # Codex should be excluded
-            assert "codex" not in root_map
+            # Codex keeps .codex at user scope
+            assert root_map["codex"] == ".codex"
             # Copilot should use .copilot
             if "copilot" in root_map:
                 assert root_map["copilot"] == ".copilot"

--- a/tests/unit/test_mcp_client_factory.py
+++ b/tests/unit/test_mcp_client_factory.py
@@ -78,8 +78,15 @@ class TestCodexClientAdapter(unittest.TestCase):
         self.temp_dir.cleanup()
     
     def test_get_config_path_default(self):
-        """Test default config path for Codex CLI."""
-        adapter = CodexClientAdapter()
+        """Test project-scope config path for Codex CLI."""
+        project_root = Path(self.temp_dir.name) / "workspace"
+        adapter = CodexClientAdapter(project_root=project_root)
+        expected_path = str(project_root / ".codex" / "config.toml")
+        self.assertEqual(adapter.get_config_path(), expected_path)
+
+    def test_get_config_path_user_scope(self):
+        """Test user-scope config path for Codex CLI."""
+        adapter = CodexClientAdapter(user_scope=True)
         expected_path = str(Path.home() / ".codex" / "config.toml")
         self.assertEqual(adapter.get_config_path(), expected_path)
     
@@ -211,6 +218,31 @@ class TestCodexClientAdapter(unittest.TestCase):
         self.assertIn("mcp_servers", config)
         self.assertIn("azure-devops-mcp", config["mcp_servers"])  # Should extract name after slash
         self.assertNotIn("microsoft/azure-devops-mcp", config["mcp_servers"])  # Should NOT use full path
+
+    def test_self_defined_stdio_normalizes_project_placeholders(self):
+        """Project-local Codex configs normalize VS Code placeholders to '.'."""
+        adapter = CodexClientAdapter(project_root=Path(self.temp_dir.name))
+        server_info = {
+            "id": "stdio-id",
+            "name": "local-filesystem",
+            "_raw_stdio": {
+                "command": "npx",
+                "args": [
+                    "-y",
+                    "@modelcontextprotocol/server-filesystem",
+                    "${workspaceFolder}",
+                    "${projectRoot}",
+                ],
+                "env": {},
+            },
+        }
+
+        config = adapter._format_server_config(server_info)
+
+        self.assertEqual(
+            config["args"],
+            ["-y", "@modelcontextprotocol/server-filesystem", ".", "."],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_transitive_mcp.py
+++ b/tests/unit/test_transitive_mcp.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import toml
 import yaml
 
 from apm_cli.integration.mcp_integrator import MCPIntegrator
@@ -976,3 +977,112 @@ class TestDiffAwareSelfDefinedInstall:
         mock_install_runtime.assert_not_called()
         mock_rich_success.assert_called_once()
         assert "already configured" in mock_rich_success.call_args.args[0]
+
+
+class TestCodexProjectScopedMCP:
+    """Tests for project-local Codex MCP activation and cleanup."""
+
+    @patch("apm_cli.integration.mcp_integrator._get_console", return_value=None)
+    @patch("apm_cli.integration.mcp_integrator._is_vscode_available", return_value=False)
+    @patch("apm_cli.integration.mcp_integrator.MCPIntegrator._install_for_runtime")
+    @patch("apm_cli.registry.operations.MCPServerOperations")
+    @patch("apm_cli.factory.ClientFactory.create_client")
+    @patch("apm_cli.runtime.manager.RuntimeManager")
+    def test_codex_skipped_when_not_active_project_target(
+        self,
+        mock_manager_cls,
+        mock_create_client,
+        mock_ops_cls,
+        mock_install_runtime,
+        _vscode,
+        _console,
+        tmp_path,
+    ):
+        """Installed Codex should not receive MCP config unless the project targets Codex."""
+        mock_manager = mock_manager_cls.return_value
+        mock_manager.is_runtime_available.side_effect = lambda runtime: runtime == "codex"
+        mock_create_client.return_value = MagicMock()
+
+        mock_ops = mock_ops_cls.return_value
+        mock_ops.validate_servers_exist.return_value = (["ghcr.io/org/new"], [])
+        mock_ops.check_servers_needing_installation.return_value = ["ghcr.io/org/new"]
+        mock_ops.batch_fetch_server_info.return_value = {"ghcr.io/org/new": {}}
+        mock_ops.collect_environment_variables.return_value = {}
+        mock_ops.collect_runtime_variables.return_value = {}
+
+        count = MCPIntegrator.install(
+            ["ghcr.io/org/new"],
+            project_root=tmp_path,
+            apm_config={},
+        )
+
+        assert count == 0
+        mock_install_runtime.assert_not_called()
+
+    @patch("apm_cli.integration.mcp_integrator._get_console", return_value=None)
+    @patch("apm_cli.integration.mcp_integrator._is_vscode_available", return_value=False)
+    @patch("apm_cli.integration.mcp_integrator.MCPIntegrator._install_for_runtime")
+    @patch("apm_cli.registry.operations.MCPServerOperations")
+    @patch("apm_cli.factory.ClientFactory.create_client")
+    @patch("apm_cli.runtime.manager.RuntimeManager")
+    def test_codex_installed_when_explicit_project_target(
+        self,
+        mock_manager_cls,
+        mock_create_client,
+        mock_ops_cls,
+        mock_install_runtime,
+        _vscode,
+        _console,
+        tmp_path,
+    ):
+        """Explicit Codex targeting should install MCP config into the project scope."""
+        mock_manager = mock_manager_cls.return_value
+        mock_manager.is_runtime_available.side_effect = lambda runtime: runtime == "codex"
+        mock_create_client.return_value = MagicMock()
+        mock_install_runtime.return_value = True
+
+        mock_ops = mock_ops_cls.return_value
+        mock_ops.validate_servers_exist.return_value = (["ghcr.io/org/new"], [])
+        mock_ops.check_servers_needing_installation.return_value = ["ghcr.io/org/new"]
+        mock_ops.batch_fetch_server_info.return_value = {"ghcr.io/org/new": {}}
+        mock_ops.collect_environment_variables.return_value = {}
+        mock_ops.collect_runtime_variables.return_value = {}
+
+        count = MCPIntegrator.install(
+            ["ghcr.io/org/new"],
+            project_root=tmp_path,
+            apm_config={"target": "codex"},
+            explicit_target="codex",
+        )
+
+        assert count == 1
+        mock_install_runtime.assert_called_once()
+        assert mock_install_runtime.call_args.kwargs["project_root"] == tmp_path
+        assert mock_install_runtime.call_args.kwargs["user_scope"] is False
+
+    def test_remove_stale_codex_uses_project_config(self, tmp_path):
+        """Stale cleanup should edit the project .codex/config.toml."""
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        config_path = codex_dir / "config.toml"
+        config_path.write_text(
+            toml.dumps(
+                {
+                    "mcp_servers": {
+                        "keep": {"command": "npx"},
+                        "stale": {"command": "npx"},
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        MCPIntegrator.remove_stale(
+            {"stale"},
+            runtime="codex",
+            project_root=tmp_path,
+        )
+
+        data = toml.loads(config_path.read_text(encoding="utf-8"))
+        assert "keep" in data["mcp_servers"]
+        assert "stale" not in data["mcp_servers"]


### PR DESCRIPTION
## Description

Make Codex MCP config project-scoped for repo installs by writing to `.codex/config.toml` instead of `~/.codex/config.toml`, and only configure Codex MCP when Codex is an active project target.

Also add Codex user-scope support for installed primitives so agents, hooks, and skills follow the existing target and scope model used by the other supported tools.

Fixes #502

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Documentation
- [x] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)
