### PR TITLE
fix(workflows): allow fork PRs in pr-review-panel

### DIFF
--- a/.github/workflows/pr-review-panel.lock.yml
+++ b/.github/workflows/pr-review-panel.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"95ff9bc25005fd01f6bd115e1e7d7ec0cab4d8cb67a36b15c244973199c5db95","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6fe1e7f6f93daec1a2ef1015ee002d094bdfd536b8505e9d7a00dbe5c9f7887e","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_PLUGINS_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"},{"repo":"microsoft/apm-action","sha":"a190b0b1a91031057144dc136acf9757a59c9e4d","version":"v1.4.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -55,6 +55,8 @@
 name: "PR Review Panel"
 "on":
   pull_request:
+    # forks: # Fork filtering applied via job conditions
+    # - "*" # Fork filtering applied via job conditions
     # names: # Label filtering applied via job conditions
     # - panel-review # Label filtering applied via job conditions
     types:
@@ -73,8 +75,8 @@ jobs:
   activation:
     needs: pre_activation
     if: >
-      needs.pre_activation.outputs.activated == 'true' && ((github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id) &&
-      (github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'panel-review'))
+      needs.pre_activation.outputs.activated == 'true' && (github.event_name != 'pull_request' || github.event.action != 'labeled' ||
+      github.event.label.name == 'panel-review')
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -185,14 +187,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_97ef67420b3d24cc_EOF'
+          cat << 'GH_AW_PROMPT_b76e8934c9ad4413_EOF'
           <system>
-          GH_AW_PROMPT_97ef67420b3d24cc_EOF
+          GH_AW_PROMPT_b76e8934c9ad4413_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_97ef67420b3d24cc_EOF'
+          cat << 'GH_AW_PROMPT_b76e8934c9ad4413_EOF'
           <safe-output-tools>
           Tools: add_comment, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -224,15 +226,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_97ef67420b3d24cc_EOF
+          GH_AW_PROMPT_b76e8934c9ad4413_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_97ef67420b3d24cc_EOF'
+          cat << 'GH_AW_PROMPT_b76e8934c9ad4413_EOF'
           </system>
           
           
           
           {{#runtime-import .github/workflows/pr-review-panel.md}}
-          GH_AW_PROMPT_97ef67420b3d24cc_EOF
+          GH_AW_PROMPT_b76e8934c9ad4413_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -420,9 +422,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_c8b7039cf46d088c_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_6f198687644f2362_EOF'
           {"add_comment":{"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_c8b7039cf46d088c_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_6f198687644f2362_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -606,7 +608,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_5d8a3547447f65de_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_607efd5a8ba1e3e9_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -647,7 +649,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_5d8a3547447f65de_EOF
+          GH_AW_MCP_CONFIG_607efd5a8ba1e3e9_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1177,9 +1179,7 @@ jobs:
             await main();
 
   pre_activation:
-    if: >
-      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.id == github.repository_id) &&
-      (github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'panel-review')
+    if: github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'panel-review'
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}

--- a/.github/workflows/pr-review-panel.md
+++ b/.github/workflows/pr-review-panel.md
@@ -5,11 +5,13 @@ description: Multi-persona expert panel review of labelled PRs, posting a single
 # Trigger: pull_request (NOT pull_request_target -- gh-aw blocks the latter on
 # public repos). Cost-gate: only runs when a maintainer applies `panel-review`.
 # `synchronize` re-runs on new pushes once the PR carries the label.
-# Default fork policy (no `forks:` field) restricts to same-repo PRs only.
+# `forks: ["*"]` allows fork PRs to be reviewed; the trust gate is the label
+# itself, which only write-access maintainers can apply.
 on:
   pull_request:
     types: [labeled, synchronize]
     names: [panel-review]
+    forks: ["*"]
 
 # Agent job runs READ-ONLY. Safe-output jobs are auto-granted scoped write.
 permissions:


### PR DESCRIPTION
## Problem

PR #815 (from `edenfunf/apm` fork) had the `panel-review` label applied but every job skipped: https://github.com/microsoft/apm/actions/runs/24751987642

Root cause: gh-aw's default fork policy on `pull_request` injects a fork-blocking gate (`github.event.pull_request.head.repo.id == github.repository_id`) on every job, so fork-originated runs skip entirely.

## Fix

Add `forks: ["*"]` to the `pull_request` trigger in `.github/workflows/pr-review-panel.md`. Recompiled with `gh aw compile --strict`.

## Trust model

The `panel-review` label is the trust gate: only write-access maintainers can apply labels, so a malicious fork PR cannot self-trigger the workflow. gh-aw's safe-outputs isolation handles the fork-token problem -- the write-scoped publisher job runs in base-repo context, separate from the read-only agent job.

## Test plan

After merge, re-apply (or remove + re-apply) `panel-review` to PR #815 and confirm the panel runs and posts a verdict comment.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>