### PR TITLE
fix(panel-workflow): only fire on label, add dispatch path for fork PRs

### DIFF
--- a/.github/workflows/pr-review-panel.lock.yml
+++ b/.github/workflows/pr-review-panel.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6fe1e7f6f93daec1a2ef1015ee002d094bdfd536b8505e9d7a00dbe5c9f7887e","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c0cf1bea4db4b0fba452d99a1e787653db96316d27fb8740050cc5d25d5c6860","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_PLUGINS_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"},{"repo":"microsoft/apm-action","sha":"a190b0b1a91031057144dc136acf9757a59c9e4d","version":"v1.4.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -61,7 +61,17 @@ name: "PR Review Panel"
     # - panel-review # Label filtering applied via job conditions
     types:
     - labeled
-    - synchronize
+  workflow_dispatch:
+    inputs:
+      aw_context:
+        default: ""
+        description: Agent caller context (used internally by Agentic Workflows).
+        required: false
+        type: string
+      pr_number:
+        description: Pull request number to review (works for fork PRs)
+        required: true
+        type: string
 
 permissions: {}
 
@@ -175,6 +185,7 @@ jobs:
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_SAFE_OUTPUTS: ${{ runner.temp }}/gh-aw/safeoutputs/outputs.jsonl
+          GH_AW_EXPR_A0E5D436: ${{ github.event.pull_request.number || inputs.pr_number }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
@@ -187,14 +198,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_b76e8934c9ad4413_EOF'
+          cat << 'GH_AW_PROMPT_02c6fb391cf3c3fe_EOF'
           <system>
-          GH_AW_PROMPT_b76e8934c9ad4413_EOF
+          GH_AW_PROMPT_02c6fb391cf3c3fe_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b76e8934c9ad4413_EOF'
+          cat << 'GH_AW_PROMPT_02c6fb391cf3c3fe_EOF'
           <safe-output-tools>
           Tools: add_comment, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -226,21 +237,21 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_b76e8934c9ad4413_EOF
+          GH_AW_PROMPT_02c6fb391cf3c3fe_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_b76e8934c9ad4413_EOF'
+          cat << 'GH_AW_PROMPT_02c6fb391cf3c3fe_EOF'
           </system>
           
           
           
           {{#runtime-import .github/workflows/pr-review-panel.md}}
-          GH_AW_PROMPT_b76e8934c9ad4413_EOF
+          GH_AW_PROMPT_02c6fb391cf3c3fe_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
-          GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+          GH_AW_EXPR_A0E5D436: ${{ github.event.pull_request.number || inputs.pr_number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
         with:
           script: |
@@ -252,6 +263,7 @@ jobs:
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
+          GH_AW_EXPR_A0E5D436: ${{ github.event.pull_request.number || inputs.pr_number }}
           GH_AW_GITHUB_ACTOR: ${{ github.actor }}
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
@@ -272,6 +284,7 @@ jobs:
             return await substitutePlaceholders({
               file: process.env.GH_AW_PROMPT,
               substitutions: {
+                GH_AW_EXPR_A0E5D436: process.env.GH_AW_EXPR_A0E5D436,
                 GH_AW_GITHUB_ACTOR: process.env.GH_AW_GITHUB_ACTOR,
                 GH_AW_GITHUB_EVENT_COMMENT_ID: process.env.GH_AW_GITHUB_EVENT_COMMENT_ID,
                 GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: process.env.GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER,
@@ -422,9 +435,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_6f198687644f2362_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_007d270780981e10_EOF'
           {"add_comment":{"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_6f198687644f2362_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_007d270780981e10_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -608,7 +621,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_607efd5a8ba1e3e9_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_0b06780a37e35684_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -649,7 +662,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_607efd5a8ba1e3e9_EOF
+          GH_AW_MCP_CONFIG_0b06780a37e35684_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/pr-review-panel.md
+++ b/.github/workflows/pr-review-panel.md
@@ -2,16 +2,36 @@
 name: PR Review Panel
 description: Multi-persona expert panel review of labelled PRs, posting a single synthesized verdict comment.
 
-# Trigger: pull_request (NOT pull_request_target -- gh-aw blocks the latter on
-# public repos). Cost-gate: only runs when a maintainer applies `panel-review`.
-# `synchronize` re-runs on new pushes once the PR carries the label.
-# `forks: ["*"]` allows fork PRs to be reviewed; the trust gate is the label
-# itself, which only write-access maintainers can apply.
+# Triggers (cost-gated, fork-safe, GHES-compatible):
+#
+# 1. pull_request: only when a maintainer applies the `panel-review` label.
+#    We deliberately do NOT subscribe to `synchronize` -- previous behaviour
+#    re-ran the panel on every push to a labelled PR, which is wasteful and
+#    indistinguishable from a DoS on agent quota. Re-apply the label
+#    (remove + add) to re-run after addressing findings.
+#
+# 2. workflow_dispatch: manual trigger taking a PR number. This is the
+#    only path that works for fork PRs on GitHub.com and GHES, because
+#    `pull_request` from forks does NOT pass repository secrets
+#    (COPILOT_GITHUB_TOKEN etc.), and gh-aw blocks `pull_request_target`
+#    on public repos. workflow_dispatch always runs in the base/trusted
+#    context with full secrets, regardless of where the PR head lives.
+#
+# `forks: ["*"]` is retained so the label path also works against fork
+# PRs in private/enterprise repos where secrets DO pass to fork PRs
+# (per-org setting). On microsoft/apm public, the dispatch path is the
+# reliable fork route.
 on:
   pull_request:
-    types: [labeled, synchronize]
+    types: [labeled]
     names: [panel-review]
     forks: ["*"]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to review (works for fork PRs)"
+        required: true
+        type: string
 
 # Agent job runs READ-ONLY. Safe-output jobs are auto-granted scoped write.
 permissions:
@@ -53,7 +73,7 @@ timeout-minutes: 30
 # PR Review Panel
 
 You are orchestrating the **apm-review-panel** skill against pull request
-**#${{ github.event.pull_request.number }}** in `${{ github.repository }}`.
+**#${{ github.event.pull_request.number || inputs.pr_number }}** in `${{ github.repository }}`.
 
 ## Step 1: Load the panel skill
 
@@ -79,7 +99,7 @@ repo context with read-only permissions; the PR diff is the only untrusted
 input we touch, and `gh` returns it as inert data.
 
 ```bash
-PR=${{ github.event.pull_request.number }}
+PR=${{ github.event.pull_request.number || inputs.pr_number }}
 gh pr view "$PR" --json title,body,author,additions,deletions,changedFiles,files,labels
 gh pr diff "$PR"
 ```


### PR DESCRIPTION
## Problems

### 1. Triggers on every push (cost / spam)
The panel review workflow re-runs on every push to a labelled PR. Reproduced repeatedly on PR #832 -- each push burned a full panel run.

Root cause: the activation gate only enforces the label check on the `labeled` action. `synchronize` bypasses it.

```yaml
# pr-review-panel.lock.yml (current)
if: needs.pre_activation.outputs.activated == 'true' && (
      github.event_name != 'pull_request'
      || github.event.action != 'labeled'
      || github.event.label.name == 'panel-review'
    )
```

For `action = 'synchronize'`, the second clause is true -> gate passes regardless of label. Bug, not by design.

### 2. Fork PRs fail (no secrets)
[Run on PR #815](https://github.com/microsoft/apm/actions/runs/24752294360/job/72418786181?pr=815) failed because `pull_request` from a fork does not pass repository secrets (`COPILOT_GITHUB_TOKEN` etc.). gh-aw correctly blocks `pull_request_target` on public repos -- that pattern executes the PR's code with full write tokens.

There is no `pull_request`-based path that gives fork PRs full secrets on a public repo. The portable, GHES-compatible answer is `workflow_dispatch` (always runs in the base/trusted context, full secrets, regardless of where the PR head lives).

## Fix

Two surgical changes to `.github/workflows/pr-review-panel.md` (lock recompiled with `gh aw compile`):

1. **Drop `synchronize`** from `pull_request` types -- the panel runs once when the maintainer applies `panel-review`. To re-run after addressing findings: **remove + re-apply** the label.
2. **Add `workflow_dispatch`** with a required `pr_number` input. Maintainers trigger the review manually for fork PRs from the Actions tab (or via `gh workflow run pr-review-panel.lock.yml -f pr_number=NNN`).
3. Wire `${{ inputs.pr_number }}` as fallback for `github.event.pull_request.number` throughout the prompt body so both paths target the same PR.

## Trust model (unchanged, and strictly safer than `pull_request_target` for forks)

`workflow_dispatch` runs from the **dispatched ref (default `main`)**, NOT the PR head. For this workflow that is the desired property:

| Concern | What dispatch gives us |
|---|---|
| Workflow YAML that executes | The one on `main` -- trusted, already-merged |
| Skill / persona definitions | Already pinned to `microsoft/apm#main` via `imports:` |
| Where the PR diff comes from | `gh pr view` + `gh pr diff` -- API calls returning inert text |
| Whether PR code is executed | **No.** No `actions/checkout` of the PR head; the prompt explicitly forbids `git checkout` of PR head. The panel reviews the diff as data, never runs it (no tests, no build, no scripts) |
| Secrets | Full repo secrets available (base/trusted context) |

This is strictly safer than the `pull_request_target` pattern, which can be coerced into running PR-controlled code with write tokens. Here, a malicious PR can put anything in its diff and the worst it can do is mislead the review prose -- it cannot escalate to code execution or token exfiltration.

Other invariants unchanged:
- Both paths require write access (label gate / dispatch gate).
- Imports still pinned to `microsoft/apm#main`.
- Same READ-only `permissions:` block; `safe-outputs.add-comment` mediates the only write surface.

## Verification

- `gh aw compile .github/workflows/pr-review-panel.md` -> 0 errors, 0 warnings.
- Lock diff: `types: [labeled, synchronize]` -> `types: [labeled]`; `workflow_dispatch` block added with `pr_number` input; expression substitution `${{ github.event.pull_request.number || inputs.pr_number }}` resolved correctly across 3 use sites.
- Activation gate (line ~88 of lock.yml) is correct for the reduced trigger set: `workflow_dispatch` -> first clause true; `labeled` with `panel-review` -> third clause true; `labeled` with other labels -> all false (skipped).

## Operator notes

To trigger the panel on a fork PR after this lands:

```bash
gh workflow run pr-review-panel.lock.yml -R microsoft/apm -f pr_number=815
```

Or from the Actions tab: "PR Review Panel" -> "Run workflow" -> enter PR number.

Note: when dispatching, leave the "Use workflow from" branch as `main` (the default). Dispatching from a feature branch would run that branch's workflow definition against the PR -- not what you want.