### PR TITLE
fix(panel-workflow): use pull_request_target so labelled fork PRs run

### DIFF
--- a/.github/workflows/pr-review-panel.lock.yml
+++ b/.github/workflows/pr-review-panel.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c0cf1bea4db4b0fba452d99a1e787653db96316d27fb8740050cc5d25d5c6860","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"568ddeef22451814cb5a691b0845f2c8ba599c72796186d9ad82b54ce1546571","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_PLUGINS_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"},{"repo":"microsoft/apm-action","sha":"a190b0b1a91031057144dc136acf9757a59c9e4d","version":"v1.4.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -54,13 +54,13 @@
 
 name: "PR Review Panel"
 "on":
-  pull_request:
-    # forks: # Fork filtering applied via job conditions
-    # - "*" # Fork filtering applied via job conditions
-    # names: # Label filtering applied via job conditions
-    # - panel-review # Label filtering applied via job conditions
+  pull_request_target:
     types:
     - labeled
+  # roles: # Roles processed as role check in pre-activation job
+  # - admin # Roles processed as role check in pre-activation job
+  # - maintainer # Roles processed as role check in pre-activation job
+  # - write # Roles processed as role check in pre-activation job
   workflow_dispatch:
     inputs:
       aw_context:
@@ -84,9 +84,7 @@ run-name: "PR Review Panel"
 jobs:
   activation:
     needs: pre_activation
-    if: >
-      needs.pre_activation.outputs.activated == 'true' && (github.event_name != 'pull_request' || github.event.action != 'labeled' ||
-      github.event.label.name == 'panel-review')
+    if: needs.pre_activation.outputs.activated == 'true'
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -190,6 +188,7 @@ jobs:
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
           GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GH_AW_GITHUB_EVENT_NAME: ${{ github.event_name }}
           GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
@@ -198,14 +197,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_02c6fb391cf3c3fe_EOF'
+          cat << 'GH_AW_PROMPT_e279ddc7abe758c5_EOF'
           <system>
-          GH_AW_PROMPT_02c6fb391cf3c3fe_EOF
+          GH_AW_PROMPT_e279ddc7abe758c5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_02c6fb391cf3c3fe_EOF'
+          cat << 'GH_AW_PROMPT_e279ddc7abe758c5_EOF'
           <safe-output-tools>
           Tools: add_comment, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -237,21 +236,22 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_02c6fb391cf3c3fe_EOF
+          GH_AW_PROMPT_e279ddc7abe758c5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_02c6fb391cf3c3fe_EOF'
+          cat << 'GH_AW_PROMPT_e279ddc7abe758c5_EOF'
           </system>
           
           
           
           {{#runtime-import .github/workflows/pr-review-panel.md}}
-          GH_AW_PROMPT_02c6fb391cf3c3fe_EOF
+          GH_AW_PROMPT_e279ddc7abe758c5_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_EXPR_A0E5D436: ${{ github.event.pull_request.number || inputs.pr_number }}
+          GH_AW_GITHUB_EVENT_NAME: ${{ github.event_name }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
         with:
           script: |
@@ -268,6 +268,7 @@ jobs:
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
           GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GH_AW_GITHUB_EVENT_NAME: ${{ github.event_name }}
           GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
@@ -289,6 +290,7 @@ jobs:
                 GH_AW_GITHUB_EVENT_COMMENT_ID: process.env.GH_AW_GITHUB_EVENT_COMMENT_ID,
                 GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: process.env.GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER,
                 GH_AW_GITHUB_EVENT_ISSUE_NUMBER: process.env.GH_AW_GITHUB_EVENT_ISSUE_NUMBER,
+                GH_AW_GITHUB_EVENT_NAME: process.env.GH_AW_GITHUB_EVENT_NAME,
                 GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: process.env.GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER,
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
@@ -435,9 +437,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_007d270780981e10_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_3e3c0744a2d8ea00_EOF'
           {"add_comment":{"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_007d270780981e10_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_3e3c0744a2d8ea00_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -621,7 +623,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_0b06780a37e35684_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_9953eb7975809a34_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -662,7 +664,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_0b06780a37e35684_EOF
+          GH_AW_MCP_CONFIG_9953eb7975809a34_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1192,7 +1194,6 @@ jobs:
             await main();
 
   pre_activation:
-    if: github.event_name != 'pull_request' || github.event.action != 'labeled' || github.event.label.name == 'panel-review'
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}

--- a/.github/workflows/pr-review-panel.md
+++ b/.github/workflows/pr-review-panel.md
@@ -4,34 +4,42 @@ description: Multi-persona expert panel review of labelled PRs, posting a single
 
 # Triggers (cost-gated, fork-safe, GHES-compatible):
 #
-# 1. pull_request: only when a maintainer applies the `panel-review` label.
-#    We deliberately do NOT subscribe to `synchronize` -- previous behaviour
-#    re-ran the panel on every push to a labelled PR, which is wasteful and
-#    indistinguishable from a DoS on agent quota. Re-apply the label
-#    (remove + add) to re-run after addressing findings.
+# 1. pull_request_target: fires when a label is applied. We use _target
+#    (not plain pull_request) so that fork PRs run in the BASE repo
+#    context with full secrets (COPILOT_GITHUB_TOKEN etc.). The label
+#    name is filtered inside the prompt (Step 0) -- gh-aw does not
+#    expose `names:` on pull_request_target.
 #
-# 2. workflow_dispatch: manual trigger taking a PR number. This is the
-#    only path that works for fork PRs on GitHub.com and GHES, because
-#    `pull_request` from forks does NOT pass repository secrets
-#    (COPILOT_GITHUB_TOKEN etc.), and gh-aw blocks `pull_request_target`
-#    on public repos. workflow_dispatch always runs in the base/trusted
-#    context with full secrets, regardless of where the PR head lives.
+#    Why pull_request_target is safe here despite the well-known
+#    "pwn-request" pattern:
+#      - permissions are read-only (no write to contents / actions)
+#      - we never `actions/checkout` the PR head; only `gh pr view` /
+#        `gh pr diff` which return inert text
+#      - imports are pinned to microsoft/apm#main (panel skill +
+#        persona definitions are trusted, not from the PR)
+#      - the only write surface is safe-outputs.add-comment (max 1)
+#      - `roles: [admin, maintainer, write]` ensures only repo
+#        maintainers can trigger -- matches the trust model that
+#        applying the `panel-review` label requires write access.
 #
-# `forks: ["*"]` is retained so the label path also works against fork
-# PRs in private/enterprise repos where secrets DO pass to fork PRs
-# (per-org setting). On microsoft/apm public, the dispatch path is the
-# reliable fork route.
+#    `synchronize` is intentionally NOT subscribed: previous behaviour
+#    re-ran the panel on every push to a labelled PR, which burned
+#    agent quota. Re-apply the label (remove + add) to re-run after
+#    addressing findings.
+#
+# 2. workflow_dispatch: manual fallback. Reads YAML from the dispatched
+#    ref (default main) and accepts any PR number. Useful if a
+#    maintainer needs to re-run without touching labels.
 on:
-  pull_request:
+  pull_request_target:
     types: [labeled]
-    names: [panel-review]
-    forks: ["*"]
   workflow_dispatch:
     inputs:
       pr_number:
         description: "Pull request number to review (works for fork PRs)"
         required: true
         type: string
+  roles: [admin, maintainer, write]
 
 # Agent job runs READ-ONLY. Safe-output jobs are auto-granted scoped write.
 permissions:
@@ -74,6 +82,21 @@ timeout-minutes: 30
 
 You are orchestrating the **apm-review-panel** skill against pull request
 **#${{ github.event.pull_request.number || inputs.pr_number }}** in `${{ github.repository }}`.
+
+## Step 0: Label-name guard (skip when irrelevant)
+
+`pull_request_target: types: [labeled]` fires for ANY label change. Bail
+immediately unless the triggering label is `panel-review` (or this is a
+manual `workflow_dispatch`):
+
+```bash
+EVENT="${{ github.event_name }}"
+LABEL="$(jq -r '.label.name // ""' "$GITHUB_EVENT_PATH")"
+if [ "$EVENT" = "pull_request_target" ] && [ "$LABEL" != "panel-review" ]; then
+  echo "Triggering label is '$LABEL' (not 'panel-review'); exiting cleanly."
+  exit 0
+fi
+```
 
 ## Step 1: Load the panel skill
 


### PR DESCRIPTION
## What

Switch the panel-review workflow trigger from `pull_request` to `pull_request_target` so labelled fork PRs (like #815) actually run instead of silently failing at secret validation.

## Why PR #836 was incomplete

#836 dropped `synchronize` and added `workflow_dispatch`, but kept `pull_request:` as the label-driven trigger. Forks PRs do not receive secrets under `pull_request`, so labelling them produced a failed run with empty `COPILOT_GITHUB_TOKEN`. See run https://github.com/microsoft/apm/actions/runs/24769454293.

## Trust model

Maintainer applies `panel-review` label -> workflow runs in **base repo context** with full secrets, regardless of fork origin.

| Gate | Mechanism |
|---|---|
| Trigger | `pull_request_target: types: [labeled]` |
| Actor | gh-aw `roles: [admin, maintainer, write]` -- only repo maintainers can fire it |
| Label name | Bash guard in Step 0 of prompt body (gh-aw doesn't expose `names:` on `pull_request_target`) |
| Code execution surface | None -- no `actions/checkout` of PR head; only `gh pr view` / `gh pr diff` (inert text) |
| Trusted definitions | Imports pinned to `microsoft/apm#main` (panel skill + persona files always come from main, not the PR) |
| Permissions | `contents/pull-requests/issues: read` only |
| Write surface | `safe-outputs.add-comment: max 1` (single comment via gh-aw's permission-isolated downstream job) |

This is why the standard "pwn-request" exploit does NOT apply: there is no path from PR-controlled code to a write operation. The only attacker-controlled input is text we feed to the agent as inert prompt context.

## Why label-as-trust-gate is sufficient

The `panel-review` label can only be applied by users with repo write access. Combined with gh-aw's `roles` check, the workflow only ever runs when a maintainer explicitly opts in. This is the same model GitHub recommends for ChatOps via `issue_comment` (see actions/runner#163 discussion). Gated environments with manual approval would be a strictly worse UX for the same threat model.

## How to verify

After merge, label PR #815 (or any other fork PR) with `panel-review`. Workflow should fire and post a verdict comment.

## Files

- `.github/workflows/pr-review-panel.md` -- trigger + Step 0 guard + updated rationale
- `.github/workflows/pr-review-panel.lock.yml` -- regenerated by `gh aw compile`

Follow-up to #836.