### PR TITLE
[docs] Update documentation for features from 2026-04-23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New `enterprise/governance-guide.md` documentation page: flagship governance reference for CISO / VPE / Platform Tech Lead audiences, covering enforcement points, bypass contract, failure semantics, air-gapped operation, rollout playbook, and known gaps. Trims duplicated content in `governance.md`, `apm-policy.md`, and `integrations/github-rulesets.md`. Adds `templates/apm-policy-starter.yml`. (#851)
 
+### Fixed
+
+- Generic host clone and `ls-remote` error messages now include the custom port (`host:port`) so users on Bitbucket Datacenter or other self-hosted servers running on non-default ports see the exact address they need to verify against their git credential helper. Closes #798 (#804)
+
 ## [0.9.1] - 2026-04-22
 
 ### Added


### PR DESCRIPTION
## Documentation Updates - 2026-04-23

This PR updates the documentation based on features merged in the last 24 hours.

### Features Documented

- Generic host `host:port` surfacing in clone / `ls-remote` error messages (from #804)

### Changes Made

- Added missing `### Fixed` entry in `CHANGELOG.md` under `[Unreleased]` for the generic host port fix

### Merged PRs Referenced

- #804 - `fix(install): surface custom port in generic host clone/ls-remote error` (closes #798)

### Notes

PR #804's commit message explicitly stated it added a CHANGELOG entry under `[Unreleased]`, but the entry was absent from the merged state. This PR adds the missing entry:

> Generic host clone and `ls-remote` error messages now include the custom port (`host:port`) so users on Bitbucket Datacenter or other self-hosted servers running on non-default ports see the exact address they need to verify against their git credential helper.

No other documentation files required changes — the existing `docs/src/content/docs/guides/private-packages.md` already documents custom port syntax for self-hosted servers, and this fix is an error-message quality improvement rather than a feature or API change.




> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/24815619526) · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+is%3Apr+%22gh-aw-workflow-id%3A+daily-doc-updater%22+in%3Abody)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-04-25T03:57:11.612Z --> on Apr 25, 2026, 3:57 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, id: 24815619526, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/24815619526 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->