### PR TITLE
feat: add pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -17,13 +17,13 @@
       apm\.yml|
       apm\.lock\.yaml|
       apm-policy\.yml|
-      .claude/.*|
-      .cursor/.*|
-      .github/agents/.*|
-      .github/instructions/.*|
-      .github/hooks/.*|
-      .opencode/.*|
-      .agents/.*
+      \.claude/.*|
+      \.cursor/.*|
+      \.github/agents/.*|
+      \.github/instructions/.*|
+      \.github/hooks/.*|
+      \.opencode/.*|
+      \.agents/.*
     )$
   language: system
   pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,29 @@
+---
+- id: apm_audit
+  name: apm_audit
+  description: |
+    Check that apm dependencies are in sync and policy compliant.
+
+    Note: `args` can have `--policy {apm-policy.yml}` passed to run further checks - that file can live in an org's `org/.github` repository for centralizing compliance. For that, use `--policy org`.
+
+    Note: `files` should include:
+
+    - apm*yml configuration files (and schema).
+    - toolchain manager configuration files (to trigger this when apm changes versions).
+    - agent configuration directories - to cause audit to detect if apm-delivered assets become modified.
+  entry: apm audit --ci
+  files: |-
+    (?x)^(
+      apm.yml|
+      apm.lock.yaml|
+      apm-policy\.yml|
+      .claude/.*|
+      .cursor/.*|
+      .github/agents/.*|
+      .github/instructions/.*|
+      .github/hooks/.*|
+      .opencode/.*|
+      .agents/.*
+    )$
+  language: system
+  pass_filenames: false

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -14,8 +14,8 @@
   entry: apm audit --ci
   files: |-
     (?x)^(
-      apm.yml|
-      apm.lock.yaml|
+      apm\.yml|
+      apm\.lock\.yaml|
       apm-policy\.yml|
       .claude/.*|
       .cursor/.*|

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,6 +4,8 @@
   description: |
     Check that apm dependencies are in sync and policy compliant.
 
+    Note: `apm` must be installed and present on `PATH`.
+
     Note: `args` can have `--policy {apm-policy.yml}` passed to run further checks - that file can live in an org's `org/.github` repository for centralizing compliance. For that, use `--policy org`.
 
     Note: `files` should include:
@@ -17,13 +19,15 @@
       apm\.yml|
       apm\.lock\.yaml|
       apm-policy\.yml|
+      \.agents/.*|
       \.claude/.*|
+      \.codex/.*|
       \.cursor/.*|
       \.github/agents/.*|
       \.github/instructions/.*|
       \.github/hooks/.*|
-      \.opencode/.*|
-      \.agents/.*
+      \.github/skills/.*|
+      \.opencode/.*
     )$
   language: system
   pass_filenames: false


### PR DESCRIPTION
## Description

... for shifting-left `apm audit` runs to developers who use [pre-commit](https://pre-commit.com/) or [prek](https://prek.j178.dev/).

Please note prose in the `description` attribute. My choices with the files multiline regex may need extension to every `target` apm supports.

Users can use the hook by pasting:

```yaml
repos:
...
  - repo: https://github.com/microsoft/apm
    rev: {some tag or sha}
    hooks:
      id: apm_audit
```

... into their `.pre-commit-config.yaml`. They can override any attribute in `-hooks` within their user-side config, which is how come I'm not overly concerned by the files regex being incomplete w.r.t. each supported `target`.

I turned `pass_filenames` off because the command does not receive filenames as positional args (pre-commit will, as standard, pass a list of files to every hook; that list may be filtered to only contain the files changed in a given diff, to optimise runtime).

Background docs: https://pre-commit.com/#new-hooks

(I also noticed that `apm audit --help` suggests the command is just for finding hidden Unicode characters; that sounds stale given what else the command seems to do)

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally

<details><summary>`prek run apm_audit --all-files` - entry fires correctly and hook failed where my tree's apm deps was unclean</summary>

```console
(.venv)$ prek run apm_audit --all-files
warning: The following repos have mutable `rev` fields (moving tag / branch):
https://github.com/petemounce/apm: pete/pre-commit-hook
Mutable references are never updated after first install and are not supported.
See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details.
hint: `prek auto-update` often fixes this",

apm_audit................................................................Failed
- hook id: apm_audit
- exit code: 1

                             [>] APM Policy Compliance
  ┏━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
  ┃ Status   ┃ Check                  ┃ Message                                  ┃
  ┡━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
  │ [+]      │ lockfile-exists        │ Lockfile present                         │
  │ [+]      │ ref-consistency        │ All dependency refs match lockfile       │
  │          │ deployed-files-present │ 45 deployed file(s) missing -- run 'apm  │
  │          │                        │ install' to restore                      │
  └──────────┴────────────────────────┴──────────────────────────────────────────┘

    deployed-files-present details:
      - .claude/skills/br
      - .github/skills/br
      - .opencode/skills/br
      - .claude/skills/caveman
```

</details>

<details><summary>hook fires when a change to `apm.yml` (`files` regex match) is staged</summary>

```console
(.venv)$ prek run apm_audit
warning: The following repos have mutable `rev` fields (moving tag / branch):
https://github.com/petemounce/apm: pete/pre-commit-hook
Mutable references are never updated after first install and are not supported.
See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details.
hint: `prek auto-update` often fixes this",

Unstaged changes detected, stashing unstaged changes to `/Users/pmounce/.cache/prek/patches/1776939861127-2938.patch`
apm_audit................................................................Passed
```

</details>

- [ ] All existing tests pass

    n/a - no code changes
- [ ] Added tests for new functionality (if applicable)

    n/a - no code changes