### PR TITLE
docs(ci): improve Branch Protection section per review feedback

### DIFF
--- a/.github/instructions/cicd.instructions.md
+++ b/.github/instructions/cicd.instructions.md
@@ -88,9 +88,10 @@ integration suite runs only at merge time via GitHub Merge Queue
 - **Cross-workflow artifacts**: ci-integration.yml builds the binary inline (no cross-workflow artifact transfer); build-release.yml jobs share artifacts within the same workflow run.
 
 ## Branch Protection & Required Checks
-- **Single required check**: branch protection (`main-protection` ruleset id 9294522) requires only one status check: `gate` from `merge-gate.yml`. All other PR-time signals are aggregated by that workflow's poll loop.
-- **CRITICAL ruleset gotcha**: the `context` field stored in the ruleset must match the **check-run name** (the job key, e.g. `gate`), NOT the GitHub UI's display string (`Merge Gate / gate`). Storing the display string causes permanent "Expected - Waiting for status to be reported" because no check-run with that literal name ever posts. The integration_id (`15368` = github-actions) plus the check-run name is what GitHub matches.
-- **Adding a new required check**: add it to `EXPECTED_CHECKS` in `merge-gate.yml`. Do NOT touch the ruleset.
+- **Single required check**: branch protection (`main-protection` ruleset id 9294522) requires exactly one status check context: `gate` from `merge-gate.yml`. All other PR-time signals are aggregated by that workflow's poll loop.
+- **CRITICAL ruleset gotcha**: the ruleset `context` must be the literal check-run name `gate`. `Merge Gate / gate` is only how GitHub may render the workflow and job together in the UI; it is not the context value to store in the ruleset. If the ruleset stores `Merge Gate / gate`, GitHub waits forever with "Expected - Waiting for status to be reported" because no check-run with that literal name is posted.
+- **How the name is derived**: GitHub matches the check by `integration_id` (`15368` = github-actions) plus the emitted check-run name. That emitted name comes from the job `name:` if one is set; otherwise it falls back to the job id. In `merge-gate.yml` the job id is `gate` and `name: gate`, so the emitted check-run name is `gate` -- that is the exact string the ruleset must require.
+- **Adding a new aggregated check**: add it to `EXPECTED_CHECKS` in `merge-gate.yml`. Do not change the ruleset unless you intentionally rename the merge gate job's emitted check-run name, in which case the ruleset `context` must be updated to the new exact name.
 
 ## Trust Model
 - **PR push (any contributor, including forks)**: Runs Tier 1 only. No CI secrets exposed. PR code is checked out and tested in an unprivileged context.


### PR DESCRIPTION
## What changed

Most of the original PR #874 content was absorbed when stacked-PR #875 was merged (workflow renumbering, merge-gate.yml entry, original Branch Protection section, CHANGELOG bump all landed via #875).

This PR is now scoped down to **just the reviewer-suggested wording improvements** for the Branch Protection section in `.github/instructions/cicd.instructions.md`.

## Why

The version that landed via #875 is correct but terse. The reviewer (Copilot reviewer on the original #874) suggested a 4-bullet structure with a new "How the name is derived" bullet that documents the job `name:` vs job-id fallback rule. This makes the diagnostic process explicit for any future contributor who hits the same "Expected - Waiting for status to be reported" symptom we hit on PR #860 today.

Also tightens the gotcha bullet: previous wording said the context must "match" the check-run name (room for ambiguity). New wording says it must BE the literal check-run name and explicitly calls out that `Merge Gate / gate` is a UI rendering, not a value to store.

## Diff

One file, 4 insertions / 3 deletions in `cicd.instructions.md`.