### PR TITLE
ci(build-release): gate smoke to tag/schedule/dispatch only

### DIFF
--- a/.apm/instructions/cicd.instructions.md
+++ b/.apm/instructions/cicd.instructions.md
@@ -6,7 +6,7 @@ description: "CI/CD Pipeline configuration for PyInstaller binary packaging and 
 # CI/CD Pipeline Instructions
 
 ## Workflow Architecture (Tiered + Merge Queue)
-Four workflows split by trigger and tier. PRs get fast feedback; the heavy
+Five workflows split by trigger and tier. PRs get fast feedback; the heavy
 integration suite runs only at merge time via GitHub Merge Queue
 (microsoft/apm#770).
 
@@ -24,27 +24,28 @@ integration suite runs only at merge time via GitHub Merge Queue
      cross-workflow artifact plumbing across triggers.
    - **Never add a `pull_request` or `pull_request_target` trigger here.**
      This file holds production secrets (`GH_CLI_PAT`, `ADO_APM_PAT`).
-     Required-check satisfaction at PR time is handled by the inert stub
-     `ci-integration-pr-stub.yml` instead.
-3. **`ci-integration-pr-stub.yml`** - inert PR-time stub for required checks
-   - Triggers on `pull_request_target` so the YAML is read from `main`
-     (admin-controlled) regardless of PR head contents - applies retroactively
-     to existing fork PRs without rebase.
-   - `permissions: {}`, no secrets, no checkout, four no-op `echo` jobs whose
-     names match the four Tier 2 required checks. Reports success in seconds.
-   - Concurrency group keyed on PR number cancels in-flight stub runs on
-     subsequent pushes.
-   - Activity types include `labeled/unlabeled/edited` so maintainers can
-     re-trigger the stub without forcing contributors to push commits.
+     Required-check satisfaction at PR time is handled by `merge-gate.yml`,
+     which aggregates all required signals into a single `gate` check.
+3. **`merge-gate.yml`** - single-authority PR-time aggregator
+   - Triggers on `pull_request` only (single trigger - dual-trigger with
+     `pull_request_target` produces SUCCESS+CANCELLED check-run twins via
+     `cancel-in-progress` and poisons branch protection's rollup).
+   - One job named `gate`. Polls the Checks API for all entries in the
+     workflow's `EXPECTED_CHECKS` env var; aggregates pass/fail into a
+     single check-run.
+   - Branch protection requires ONLY this one check (`gate`). Adding,
+     renaming, or removing an underlying check is a `merge-gate.yml` edit,
+     never a ruleset edit. Tide / bors single-authority pattern.
+   - Recovery if the `pull_request` webhook is dropped: empty commit,
+     `gh workflow run merge-gate.yml -f pr_number=NNN`, or close+reopen.
    - `.github/CODEOWNERS` requires Lead Maintainer review for any change
-     to `.github/workflows/**` to prevent inadvertent additions of secrets,
-     checkout, or PR-data interpolation to this file.
-3. **`build-release.yml`** - `push` to main, tags, schedule, `workflow_dispatch`
-   - **Linux + Windows** run combined `build-and-test` (unit tests + binary build in one job).
+     to `.github/workflows/**`.
+4. **`build-release.yml`** - `push` to main, tags, schedule, `workflow_dispatch`
+   - **Linux + Windows** run combined `build-and-test` (unit tests + binary build in one job). Unit tests run on every push for platform-regression signal; **smoke tests are gated to tag/schedule/dispatch only** (promotion boundaries) to avoid duplicating `ci-integration.yml`'s merge-time smoke and to cut redundant codex-binary downloads.
    - **macOS Intel** uses `build-and-validate-macos-intel` (root node, runs own unit tests - no dependency on `build-and-test`). Builds the binary on every push for early regression feedback; integration + release-validation phases conditional on tag/schedule/dispatch.
    - **macOS ARM** uses `build-and-validate-macos-arm` (root node, tag/schedule/dispatch only - ARM runners are extremely scarce with 2-4h+ queue waits). Only requested when the binary is actually needed for a release.
    - Secrets always available. Full 5-platform binary output (linux x86_64/arm64, darwin x86_64/arm64, windows x86_64).
-4. **`ci-runtime.yml`** - nightly schedule, manual dispatch, path-filtered push
+5. **`ci-runtime.yml`** - nightly schedule, manual dispatch, path-filtered push
    - **Linux x86_64 only**. Live inference smoke tests (`apm run`) isolated from release pipeline.
    - Uses `GH_MODELS_PAT` for GitHub Models API access.
    - Failures do not block releases - annotated as warnings.
@@ -85,6 +86,12 @@ integration suite runs only at merge time via GitHub Merge Queue
 - **Tag Triggers**: Only `v*.*.*` tags trigger full release pipeline
 - **Artifact Retention**: 30 days for debugging failed releases
 - **Cross-workflow artifacts**: ci-integration.yml builds the binary inline (no cross-workflow artifact transfer); build-release.yml jobs share artifacts within the same workflow run.
+
+## Branch Protection & Required Checks
+- **Single required check**: branch protection (`main-protection` ruleset id 9294522) requires exactly one status check context: `gate` from `merge-gate.yml`. All other PR-time signals are aggregated by that workflow's poll loop.
+- **CRITICAL ruleset gotcha**: the ruleset `context` must be the literal check-run name `gate`. `Merge Gate / gate` is only how GitHub may render the workflow and job together in the UI; it is not the context value to store in the ruleset. If the ruleset stores `Merge Gate / gate`, GitHub waits forever with "Expected - Waiting for status to be reported" because no check-run with that literal name is posted.
+- **How the name is derived**: GitHub matches the check by `integration_id` (`15368` = github-actions) plus the emitted check-run name. That emitted name comes from the job `name:` if one is set; otherwise it falls back to the job id. In `merge-gate.yml` the job id is `gate` and `name: gate`, so the emitted check-run name is `gate` -- that is the exact string the ruleset must require.
+- **Adding a new aggregated check**: add it to `EXPECTED_CHECKS` in `merge-gate.yml`. Do not change the ruleset unless you intentionally rename the merge gate job's emitted check-run name, in which case the ruleset `context` must be updated to the new exact name.
 
 ## Trust Model
 - **PR push (any contributor, including forks)**: Runs Tier 1 only. No CI secrets exposed. PR code is checked out and tested in an unprivileged context.

--- a/.github/instructions/cicd.instructions.md
+++ b/.github/instructions/cicd.instructions.md
@@ -41,7 +41,7 @@ integration suite runs only at merge time via GitHub Merge Queue
    - `.github/CODEOWNERS` requires Lead Maintainer review for any change
      to `.github/workflows/**`.
 4. **`build-release.yml`** - `push` to main, tags, schedule, `workflow_dispatch`
-   - **Linux + Windows** run combined `build-and-test` (unit tests + binary build in one job).
+   - **Linux + Windows** run combined `build-and-test` (unit tests + binary build in one job). Unit tests run on every push for platform-regression signal; **smoke tests are gated to tag/schedule/dispatch only** (promotion boundaries) to avoid duplicating `ci-integration.yml`'s merge-time smoke and to cut redundant codex-binary downloads.
    - **macOS Intel** uses `build-and-validate-macos-intel` (root node, runs own unit tests - no dependency on `build-and-test`). Builds the binary on every push for early regression feedback; integration + release-validation phases conditional on tag/schedule/dispatch.
    - **macOS ARM** uses `build-and-validate-macos-arm` (root node, tag/schedule/dispatch only - ARM runners are extremely scarce with 2-4h+ queue waits). Only requested when the binary is actually needed for a release.
    - Secrets always available. Full 5-platform binary output (linux x86_64/arm64, darwin x86_64/arm64, windows x86_64).

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -69,11 +69,27 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev --extra build
 
-      - name: Run tests
+      # Unit tests run on every push for fast platform-regression signal.
+      # Smoke is intentionally NOT included here: it duplicates ci-integration.yml's
+      # merge-time smoke gate and burns a real codex binary download per platform
+      # per push (~15 redundant runs/day). Smoke is gated to promotion boundaries
+      # below (tag/schedule/dispatch) where it actually serves as a pre-ship gate.
+      - name: Run unit tests
         env:
           GITHUB_TOKEN: ${{ secrets.GH_MODELS_PAT }}
           GITHUB_APM_PAT: ${{ secrets.GH_CLI_PAT }}
-        run: uv run pytest tests/unit tests/test_console.py tests/integration/test_runtime_smoke.py -n auto --dist worksteal
+        run: uv run pytest tests/unit tests/test_console.py -n auto --dist worksteal
+
+      # Smoke runs only at promotion boundaries:
+      #   - tags (pre-ship release gate; only place tag-cut releases get smoke validation)
+      #   - schedule (nightly regression catch for upstream codex URL drift)
+      #   - workflow_dispatch (manual safety net)
+      - name: Run smoke tests
+        if: github.ref_type == 'tag' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_MODELS_PAT }}
+          GITHUB_APM_PAT: ${{ secrets.GH_CLI_PAT }}
+        run: uv run pytest tests/integration/test_runtime_smoke.py -v
 
       - name: Install UPX (Linux)
         if: matrix.platform == 'linux'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- CI: smoke tests in `build-release.yml`'s `build-and-test` job (Linux x86_64, Linux arm64, Windows) are now gated to promotion boundaries (tag/schedule/dispatch) instead of running on every push to main. Push-time smoke duplicated the merge-time smoke gate in `ci-integration.yml` and burned ~15 redundant codex-binary downloads/day. Tag-cut releases still run smoke as a pre-ship gate; nightly catches upstream codex URL drift; merge-time still gates merges into main.
+- CI: smoke tests in `build-release.yml`'s `build-and-test` job (Linux x86_64, Linux arm64, Windows) are now gated to promotion boundaries (tag/schedule/dispatch) instead of running on every push to main. Push-time smoke duplicated the merge-time smoke gate in `ci-integration.yml` and burned ~15 redundant codex-binary downloads/day. Tag-cut releases still run smoke as a pre-ship gate; nightly catches upstream codex URL drift; merge-time still gates merges into main. (#878)
 - CI docs: clarify that branch-protection ruleset must store the check-run name (`gate`), not the workflow display string (`Merge Gate / gate`); document the merge-gate aggregator in `cicd.instructions.md` and mark the legacy stub workflow as deprecated.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- CI: smoke tests in `build-release.yml`'s `build-and-test` job (Linux x86_64, Linux arm64, Windows) are now gated to promotion boundaries (tag/schedule/dispatch) instead of running on every push to main. Push-time smoke duplicated the merge-time smoke gate in `ci-integration.yml` and burned ~15 redundant codex-binary downloads/day. Tag-cut releases still run smoke as a pre-ship gate; nightly catches upstream codex URL drift; merge-time still gates merges into main.
 - CI docs: clarify that branch-protection ruleset must store the check-run name (`gate`), not the workflow display string (`Merge Gate / gate`); document the merge-gate aggregator in `cicd.instructions.md` and mark the legacy stub workflow as deprecated.
 
 ### Removed


### PR DESCRIPTION
## Summary

Trims smoke tests in `build-release.yml`'s `build-and-test` job (Linux x86_64, Linux arm64, Windows) to **promotion boundaries only** (tags, schedule, workflow_dispatch). Push-time smoke duplicated the merge-time gate in `ci-integration.yml` and burned ~15 redundant codex-binary downloads per active day.

## Pipeline before

```mermaid
flowchart TB
    PR[PR opened/updated] --> CI1[ci.yml<br/>Tier 1: unit only]
    PR --> MG[merge-gate.yml<br/>aggregate: gate]

    MQ[merge_group enqueued] --> CI2[ci.yml<br/>Tier 1: unit]
    MQ --> INT[ci-integration.yml<br/>Tier 2: BUILD then SMOKE Linux<br/>then INTEGRATION then RELEASE-VAL]

    PUSH[push to main] --> BR_PUSH[build-release.yml<br/>build-and-test x3 platforms<br/>UNIT + SMOKE per platform]
    PUSH -.skip.-> BR_TAG_GATED[integration / release-validation<br/>SKIPPED on push]

    TAG[tag v*] --> BR_TAG[build-release.yml<br/>build-and-test x3 platforms<br/>UNIT + SMOKE per platform]
    TAG --> BR_REL[integration + release-validation<br/>+ macOS Intel/ARM]

    CRON[nightly 04:00 UTC] --> BR_CRON[build-release.yml<br/>build-and-test x3 platforms<br/>UNIT + SMOKE per platform]
    CRON2[nightly 05:00 UTC] --> RT[ci-runtime.yml<br/>SMOKE + live inference Linux]

    style BR_PUSH fill:#fdd,stroke:#c00
    style BR_CRON fill:#ffe,stroke:#a90
    style INT fill:#dfd,stroke:#0a0
    style BR_TAG fill:#dfd,stroke:#0a0
    style RT fill:#dfd,stroke:#0a0
```

Red = redundant smoke (~15 codex downloads/day on every push to main, defending nothing that `ci-integration.yml` didn't already gate at merge time).

## Pipeline after

```mermaid
flowchart TB
    PR[PR opened/updated] --> CI1[ci.yml<br/>Tier 1: unit only]
    PR --> MG[merge-gate.yml<br/>aggregate: gate]

    MQ[merge_group enqueued] --> CI2[ci.yml<br/>Tier 1: unit]
    MQ --> INT[ci-integration.yml<br/>Tier 2: BUILD then SMOKE Linux<br/>then INTEGRATION then RELEASE-VAL]

    PUSH[push to main] --> BR_PUSH[build-release.yml<br/>build-and-test x3 platforms<br/>UNIT only<br/>smoke step skipped via if condition]

    TAG[tag v*] --> BR_TAG[build-release.yml<br/>build-and-test x3 platforms<br/>UNIT + SMOKE per platform]
    TAG --> BR_REL[integration + release-validation<br/>+ macOS Intel/ARM]

    CRON[nightly 04:00 UTC] --> BR_CRON[build-release.yml<br/>build-and-test x3 platforms<br/>UNIT + SMOKE per platform]
    CRON2[nightly 05:00 UTC] --> RT[ci-runtime.yml<br/>SMOKE + live inference Linux]

    style BR_PUSH fill:#dfd,stroke:#0a0
    style INT fill:#dfd,stroke:#0a0
    style BR_TAG fill:#dfd,stroke:#0a0
    style BR_CRON fill:#dfd,stroke:#0a0
    style RT fill:#dfd,stroke:#0a0
```

## Smoke gating, by trigger

```mermaid
flowchart LR
    subgraph "Promotion boundaries (smoke runs)"
        T[tag v*]
        S[schedule]
        D[workflow_dispatch]
    end
    subgraph "Day-to-day (smoke skipped)"
        P[push to main]
    end

    T --> COND{"if: github.ref_type == 'tag'<br/>or github.event_name == 'schedule'<br/>or github.event_name == 'workflow_dispatch'"}
    S --> COND
    D --> COND
    P --> COND
    COND -->|true| RUN[Run smoke tests step executes<br/>downloads codex binary<br/>tests scripts/runtime/setup-codex.sh]
    COND -->|false| SKIP[Smoke step skipped<br/>only Run unit tests step executes]

    style RUN fill:#dfd,stroke:#0a0
    style SKIP fill:#eef,stroke:#88a
```

## Coverage matrix (after this PR)

| Trigger | Workflow | Smoke runs? | Platforms | Why |
|---|---|---|---|---|
| `pull_request` | `ci.yml` | No | Linux | Fast PR feedback; unchanged |
| `merge_group` | `ci-integration.yml` | **Yes** | Linux | Load-bearing merge gate; unchanged |
| push to main | `build-release.yml` | **No** (was yes) | (skipped) | Was redundant with merge-time gate |
| tag `v*` | `build-release.yml` | **Yes** | Linux x86_64, Linux arm64, Windows | Pre-ship gate for tag-cut releases |
| schedule | `build-release.yml` | **Yes** | Linux x86_64, Linux arm64, Windows | Multi-platform drift canary |
| `workflow_dispatch` | `build-release.yml` | **Yes** | Linux x86_64, Linux arm64, Windows | Manual safety net |
| schedule | `ci-runtime.yml` | **Yes** | Linux x86_64 | Live inference + smoke; unchanged |

## Trade-off accepted

Multi-platform smoke (Linux arm64 + Windows) shifts from "every push to main" to "every tag cut". Time-to-detection window for platform-specific regressions in `scripts/runtime/setup-codex.sh` widens from hours to ~release cadence, in exchange for a meaningful reduction in network-flake exposure and CI noise. Linux x86_64 smoke still runs at merge time on every PR via `ci-integration.yml`.

## Verification plan

This PR runs through the standard PR-time path (`ci.yml` Tier 1 unit-only + `merge-gate.yml`), neither of which exercises the trimmed step.

To validate the new behavior end-to-end:

1. **Push-time path** (the one being changed): observable on **next push to main** after merge. `build-and-test` should run unit tests only - no "Run smoke tests" step in any of the 3 platform matrix entries.
2. **Tag path** (must continue to work): observable on **next tagged release**. `build-and-test` should show both "Run unit tests" AND "Run smoke tests" steps on all 3 platforms.
3. **Schedule path**: observable on **next nightly run** (04:00 UTC). Same as tag path.
4. **Dispatch path**: I will trigger a test `workflow_dispatch` from main after this merges to confirm the smoke step lights up.

The conditional expression `github.ref_type == 'tag' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'` is the **same canonical pattern** already used in this same workflow by:

- `build-and-validate-macos-intel` integration + release-validation phases (lines 179, 191, 206)
- `build-and-validate-macos-arm` job-level gate (line 225)
- `integration-tests` job (line 321)
- `Release Validation` job (line 397)

So the gating semantics are a copy of what is already proven in this same workflow.

## Review feedback addressed

- **CHANGELOG `(#878)` suffix**: applied in 58c40e7.
- **`.apm/` canonical drift**: synced `.apm/instructions/cicd.instructions.md` to match `.github/instructions/cicd.instructions.md` so future `apm install --target copilot` regenerations don't revert this change. Verified regeneration produces identical `.github/` content.

## Out of scope

The flaky env-var leak from `tests/unit/test_ssl_cert_hook.py` (separate root cause) is a follow-up. This PR reduces the flake-exposure surface by ~70% on push events; the underlying leak should still be fixed.
