### PR TITLE
ci: dogfood apm audit --ci and integration-drift gate (closes #883)

### DIFF
--- a/.apm/agents/auth-expert.agent.md
+++ b/.apm/agents/auth-expert.agent.md
@@ -23,8 +23,8 @@ If a code change contradicts the mermaid diagram, the diagram (and matching doc 
 
 ## Core Knowledge
 
-- **Token prefixes**: Fine-grained PATs (`github_pat_`), classic PATs (`ghp_`), OAuth user-to-server (`ghu_` — e.g. `gh auth login`), OAuth app (`gho_`), GitHub App install (`ghs_`), GitHub App refresh (`ghr_`)
-- **EMU (Enterprise Managed Users)**: Use standard PAT prefixes (`ghp_`, `github_pat_`). There is NO special prefix for EMU — it's a property of the account, not the token. EMU tokens are enterprise-scoped and cannot access public github.com repos. EMU orgs can exist on github.com or *.ghe.com.
+- **Token prefixes**: Fine-grained PATs (`github_pat_`), classic PATs (`ghp_`), OAuth user-to-server (`ghu_` -- e.g. `gh auth login`), OAuth app (`gho_`), GitHub App install (`ghs_`), GitHub App refresh (`ghr_`)
+- **EMU (Enterprise Managed Users)**: Use standard PAT prefixes (`ghp_`, `github_pat_`). There is NO special prefix for EMU -- it's a property of the account, not the token. EMU tokens are enterprise-scoped and cannot access public github.com repos. EMU orgs can exist on github.com or *.ghe.com.
 - **Host classification**: github.com (public), *.ghe.com (no public repos), GHES (`GITHUB_HOST`), ADO
 - **Git credential helpers**: macOS Keychain, Windows Credential Manager, `gh auth`, `git credential fill`
 - **Rate limiting**: 60/hr unauthenticated, 5000/hr authenticated, primary (403) vs secondary (429)
@@ -32,7 +32,7 @@ If a code change contradicts the mermaid diagram, the diagram (and matching doc 
 ## APM Architecture
 
 - **AuthResolver** (`src/apm_cli/core/auth.py`): Single source of truth. Per-(host, org) resolution. Frozen `AuthContext` for thread safety.
-- **Token precedence**: `GITHUB_APM_PAT_{ORG}` → `GITHUB_APM_PAT` → `GITHUB_TOKEN` → `GH_TOKEN` → `git credential fill`
+- **Token precedence**: `GITHUB_APM_PAT_{ORG}` -> `GITHUB_APM_PAT` -> `GITHUB_TOKEN` -> `GH_TOKEN` -> `git credential fill`
 - **Fallback chains**: unauth-first for validation (save rate limits), auth-first for download
 - **GitHubTokenManager** (`src/apm_cli/core/token_manager.py`): Low-level token lookup, wrapped by AuthResolver
 
@@ -40,18 +40,18 @@ If a code change contradicts the mermaid diagram, the diagram (and matching doc 
 
 When reviewing or writing auth code:
 
-1. **Every remote operation** must go through AuthResolver — no direct `os.getenv()` for tokens
+1. **Every remote operation** must go through AuthResolver -- no direct `os.getenv()` for tokens
 2. **Per-dep resolution**: Use `resolve_for_dep(dep_ref)`, never `self.github_token` instance vars
 3. **Host awareness**: Global env vars are checked for all hosts (no host-gating). `try_with_fallback()` retries with `git credential fill` if the token is rejected. HTTPS is the transport security boundary. *.ghe.com and ADO always require auth (no unauthenticated fallback).
-4. **Error messages**: Always use `build_error_context()` — never hardcode env var names
+4. **Error messages**: Always use `build_error_context()` -- never hardcode env var names
 5. **Thread safety**: AuthContext is resolved before `executor.submit()`, passed per-worker
 
 ## Common Pitfalls
 
-- EMU PATs on public github.com repos → will fail silently (you cannot detect EMU from prefix)
+- EMU PATs on public github.com repos -> will fail silently (you cannot detect EMU from prefix)
 - `git credential fill` only resolves per-host, not per-org
 - `_build_repo_url` must accept token param, not use instance var
 - Windows: `GIT_ASKPASS` must be `'echo'` not empty string
-- Classic PATs (`ghp_`) work cross-org but are being deprecated — prefer fine-grained
-- ADO uses Basic auth with base64-encoded `:PAT` — different from GitHub bearer token flow
+- Classic PATs (`ghp_`) work cross-org but are being deprecated -- prefer fine-grained
+- ADO uses Basic auth with base64-encoded `:PAT` -- different from GitHub bearer token flow
 - ADO also supports AAD bearer tokens via `az account get-access-token` (resource `499b84ac-1321-427f-aa17-267ca6975798`); precedence is `ADO_APM_PAT` -> az bearer -> fail. Stale PATs (401) silently fall back to the bearer with a `[!]` warning. See the auth skill for the four diagnostic cases.

--- a/.apm/skills/auth/SKILL.md
+++ b/.apm/skills/auth/SKILL.md
@@ -3,7 +3,7 @@ name: auth
 description: >
   Activate when code touches token management, credential resolution, git auth
   flows, GITHUB_APM_PAT, ADO_APM_PAT, AuthResolver, HostInfo, AuthContext, or
-  any remote host authentication — even if 'auth' isn't mentioned explicitly.
+  any remote host authentication -- even if 'auth' isn't mentioned explicitly.
 ---
 
 # Auth Skill
@@ -35,7 +35,7 @@ ADO hosts (`dev.azure.com`, `*.visualstudio.com`) resolve auth in this order:
 2. AAD bearer via `az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798` if `az` is installed and `az account show` succeeds
 3. Otherwise: auth-failed error from `build_error_context`
 
-Token source constants live in `src/apm_cli/core/token_manager.py`: `ADO_APM_PAT = "ADO_APM_PAT"`, `ADO_BEARER_SOURCE = "AAD_BEARER_AZ_CLI"`.
+`ADO_APM_PAT` is the env var name used by the auth flow. The AAD bearer source constant lives in `src/apm_cli/core/token_manager.py` as `GitHubTokenManager.ADO_BEARER_SOURCE = "AAD_BEARER_AZ_CLI"`.
 
 **Stale-PAT silent fallback:** if `ADO_APM_PAT` is rejected with HTTP 401, APM retries with the az bearer and emits:
 

--- a/.github/agents/auth-expert.agent.md
+++ b/.github/agents/auth-expert.agent.md
@@ -23,8 +23,8 @@ If a code change contradicts the mermaid diagram, the diagram (and matching doc 
 
 ## Core Knowledge
 
-- **Token prefixes**: Fine-grained PATs (`github_pat_`), classic PATs (`ghp_`), OAuth user-to-server (`ghu_` — e.g. `gh auth login`), OAuth app (`gho_`), GitHub App install (`ghs_`), GitHub App refresh (`ghr_`)
-- **EMU (Enterprise Managed Users)**: Use standard PAT prefixes (`ghp_`, `github_pat_`). There is NO special prefix for EMU — it's a property of the account, not the token. EMU tokens are enterprise-scoped and cannot access public github.com repos. EMU orgs can exist on github.com or *.ghe.com.
+- **Token prefixes**: Fine-grained PATs (`github_pat_`), classic PATs (`ghp_`), OAuth user-to-server (`ghu_` -- e.g. `gh auth login`), OAuth app (`gho_`), GitHub App install (`ghs_`), GitHub App refresh (`ghr_`)
+- **EMU (Enterprise Managed Users)**: Use standard PAT prefixes (`ghp_`, `github_pat_`). There is NO special prefix for EMU -- it's a property of the account, not the token. EMU tokens are enterprise-scoped and cannot access public github.com repos. EMU orgs can exist on github.com or *.ghe.com.
 - **Host classification**: github.com (public), *.ghe.com (no public repos), GHES (`GITHUB_HOST`), ADO
 - **Git credential helpers**: macOS Keychain, Windows Credential Manager, `gh auth`, `git credential fill`
 - **Rate limiting**: 60/hr unauthenticated, 5000/hr authenticated, primary (403) vs secondary (429)
@@ -32,7 +32,7 @@ If a code change contradicts the mermaid diagram, the diagram (and matching doc 
 ## APM Architecture
 
 - **AuthResolver** (`src/apm_cli/core/auth.py`): Single source of truth. Per-(host, org) resolution. Frozen `AuthContext` for thread safety.
-- **Token precedence**: `GITHUB_APM_PAT_{ORG}` → `GITHUB_APM_PAT` → `GITHUB_TOKEN` → `GH_TOKEN` → `git credential fill`
+- **Token precedence**: `GITHUB_APM_PAT_{ORG}` -> `GITHUB_APM_PAT` -> `GITHUB_TOKEN` -> `GH_TOKEN` -> `git credential fill`
 - **Fallback chains**: unauth-first for validation (save rate limits), auth-first for download
 - **GitHubTokenManager** (`src/apm_cli/core/token_manager.py`): Low-level token lookup, wrapped by AuthResolver
 
@@ -40,18 +40,18 @@ If a code change contradicts the mermaid diagram, the diagram (and matching doc 
 
 When reviewing or writing auth code:
 
-1. **Every remote operation** must go through AuthResolver — no direct `os.getenv()` for tokens
+1. **Every remote operation** must go through AuthResolver -- no direct `os.getenv()` for tokens
 2. **Per-dep resolution**: Use `resolve_for_dep(dep_ref)`, never `self.github_token` instance vars
 3. **Host awareness**: Global env vars are checked for all hosts (no host-gating). `try_with_fallback()` retries with `git credential fill` if the token is rejected. HTTPS is the transport security boundary. *.ghe.com and ADO always require auth (no unauthenticated fallback).
-4. **Error messages**: Always use `build_error_context()` — never hardcode env var names
+4. **Error messages**: Always use `build_error_context()` -- never hardcode env var names
 5. **Thread safety**: AuthContext is resolved before `executor.submit()`, passed per-worker
 
 ## Common Pitfalls
 
-- EMU PATs on public github.com repos → will fail silently (you cannot detect EMU from prefix)
+- EMU PATs on public github.com repos -> will fail silently (you cannot detect EMU from prefix)
 - `git credential fill` only resolves per-host, not per-org
 - `_build_repo_url` must accept token param, not use instance var
 - Windows: `GIT_ASKPASS` must be `'echo'` not empty string
-- Classic PATs (`ghp_`) work cross-org but are being deprecated — prefer fine-grained
-- ADO uses Basic auth with base64-encoded `:PAT` — different from GitHub bearer token flow
+- Classic PATs (`ghp_`) work cross-org but are being deprecated -- prefer fine-grained
+- ADO uses Basic auth with base64-encoded `:PAT` -- different from GitHub bearer token flow
 - ADO also supports AAD bearer tokens via `az account get-access-token` (resource `499b84ac-1321-427f-aa17-267ca6975798`); precedence is `ADO_APM_PAT` -> az bearer -> fail. Stale PATs (401) silently fall back to the bearer with a `[!]` warning. See the auth skill for the four diagnostic cases.

--- a/.github/agents/auth-expert.agent.md
+++ b/.github/agents/auth-expert.agent.md
@@ -54,3 +54,4 @@ When reviewing or writing auth code:
 - Windows: `GIT_ASKPASS` must be `'echo'` not empty string
 - Classic PATs (`ghp_`) work cross-org but are being deprecated — prefer fine-grained
 - ADO uses Basic auth with base64-encoded `:PAT` — different from GitHub bearer token flow
+- ADO also supports AAD bearer tokens via `az account get-access-token` (resource `499b84ac-1321-427f-aa17-267ca6975798`); precedence is `ADO_APM_PAT` -> az bearer -> fail. Stale PATs (401) silently fall back to the bearer with a `[!]` warning. See the auth skill for the four diagnostic cases.

--- a/.github/skills/auth/SKILL.md
+++ b/.github/skills/auth/SKILL.md
@@ -3,7 +3,7 @@ name: auth
 description: >
   Activate when code touches token management, credential resolution, git auth
   flows, GITHUB_APM_PAT, ADO_APM_PAT, AuthResolver, HostInfo, AuthContext, or
-  any remote host authentication — even if 'auth' isn't mentioned explicitly.
+  any remote host authentication -- even if 'auth' isn't mentioned explicitly.
 ---
 
 # Auth Skill
@@ -35,7 +35,7 @@ ADO hosts (`dev.azure.com`, `*.visualstudio.com`) resolve auth in this order:
 2. AAD bearer via `az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798` if `az` is installed and `az account show` succeeds
 3. Otherwise: auth-failed error from `build_error_context`
 
-Token source constants live in `src/apm_cli/core/token_manager.py`: `ADO_APM_PAT = "ADO_APM_PAT"`, `ADO_BEARER_SOURCE = "AAD_BEARER_AZ_CLI"`.
+`ADO_APM_PAT` is the env var name used by the auth flow. The AAD bearer source constant lives in `src/apm_cli/core/token_manager.py` as `GitHubTokenManager.ADO_BEARER_SOURCE = "AAD_BEARER_AZ_CLI"`.
 
 **Stale-PAT silent fallback:** if `ADO_APM_PAT` is rejected with HTTP 401, APM retries with the az bearer and emits:
 

--- a/.github/skills/auth/SKILL.md
+++ b/.github/skills/auth/SKILL.md
@@ -26,3 +26,34 @@ All auth flows MUST go through `AuthResolver`. No direct `os.getenv()` for token
 ## Canonical reference
 
 The full per-org -> global -> credential-fill -> fallback resolution flow is in [`docs/src/content/docs/getting-started/authentication.md`](../../../docs/src/content/docs/getting-started/authentication.md) (mermaid flowchart). Treat it as the single source of truth; if behavior diverges, fix the diagram in the same PR.
+
+## Bearer-token authentication for ADO
+
+ADO hosts (`dev.azure.com`, `*.visualstudio.com`) resolve auth in this order:
+
+1. `ADO_APM_PAT` env var if set
+2. AAD bearer via `az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798` if `az` is installed and `az account show` succeeds
+3. Otherwise: auth-failed error from `build_error_context`
+
+Token source constants live in `src/apm_cli/core/token_manager.py`: `ADO_APM_PAT = "ADO_APM_PAT"`, `ADO_BEARER_SOURCE = "AAD_BEARER_AZ_CLI"`.
+
+**Stale-PAT silent fallback:** if `ADO_APM_PAT` is rejected with HTTP 401, APM retries with the az bearer and emits:
+
+```
+[!] ADO_APM_PAT was rejected for {host} (HTTP 401); fell back to az cli bearer.
+[!]     Consider unsetting the stale variable.
+```
+
+**Verbose source line** (one per host, emitted under `--verbose`):
+
+```
+[i] dev.azure.com -- using bearer from az cli (source: AAD_BEARER_AZ_CLI)
+[i] dev.azure.com -- token from ADO_APM_PAT
+```
+
+**Diagnostic cases** (`_emit_stale_pat_diagnostic` + `build_error_context` in `src/apm_cli/core/auth.py`):
+
+1. No PAT, no `az`: `No ADO_APM_PAT was set and az CLI is not installed.` -> install `az`, run `az login --tenant <tenant>`, or set `ADO_APM_PAT`.
+2. No PAT, `az` not signed in: `az CLI is installed but no active session was found.` -> run `az login --tenant <tenant>` against the tenant that owns the org, or set `ADO_APM_PAT`.
+3. No PAT, wrong tenant: `az CLI returned a token but the org does not accept it (likely a tenant mismatch).` -> run `az login --tenant <correct-tenant>`, or set `ADO_APM_PAT`.
+4. PAT 401, no `az` fallback: `ADO_APM_PAT was rejected (HTTP 401) and no az cli fallback was available.` -> rotate the PAT, or install `az` and run `az login --tenant <tenant>`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,3 +96,45 @@ jobs:
         include-hidden-files: true
         retention-days: 30
         if-no-files-found: error
+
+  # Dogfood the two CI gates we ship and document to users:
+  #   - Gate A (consumer-side): `apm audit --ci` -- lockfile / install fidelity.
+  #   - Gate B (producer-side): regeneration drift -- did someone hand-edit
+  #     a regenerated file under .github/ without updating canonical .apm/?
+  # See microsoft/apm#883 for context. Tier 1 (no secrets needed).
+  apm-self-check:
+    name: APM Self-Check
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      # Installs the APM CLI (latest stable) and runs `apm install` against
+      # this repo's apm.yml. Auto-detects target from the existing .github/
+      # directory and re-integrates local .apm/ content, regenerating
+      # .github/instructions/, .github/agents/, .github/skills/, etc.
+      # Adds `apm` to PATH for subsequent steps.
+      - uses: microsoft/apm-action@v1
+
+      # Gate A: lockfile / install fidelity (consumer-side).
+      # Verifies every file in lockfile.deployed_files exists, ref consistency
+      # between apm.yml and apm.lock.yaml, no orphan packages, and
+      # content-integrity (hidden Unicode) on deployed package content.
+      # Does NOT verify deployed-file content vs lockfile (see #684).
+      - name: apm audit --ci
+        run: apm audit --ci
+
+      # Gate B: regeneration drift (producer-side).
+      # The action's `apm install` step re-integrated local .apm/ into
+      # .github/ via target auto-detection. If anything in the governed
+      # integration directories changed, someone edited the regenerated
+      # output without updating the canonical .apm/ source.
+      - name: Check APM integration drift
+        run: |
+          if [ -n "$(git status --porcelain -- .github/ .claude/ .cursor/ .opencode/)" ]; then
+            echo "::error::APM integration files are out of date."
+            echo "Run 'apm install' locally (with .github/ present) and commit the result."
+            git --no-pager diff -- .github/ .claude/ .cursor/ .opencode/
+            exit 1
+          fi

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -90,11 +90,11 @@ jobs:
           SHA: ${{ steps.sha.outputs.sha }}
           # All PR-time checks the gate aggregates. Keep this in sync with
           # the underlying workflows. Currently only ci.yml emits PR-time
-          # checks ('Build & Test (Linux)'); ci-integration.yml is
-          # merge_group-only and is NOT polled here.
+          # checks ('Build & Test (Linux)', 'APM Self-Check');
+          # ci-integration.yml is merge_group-only and is NOT polled here.
           # NOTE: 'gate' (this job) MUST NOT appear here -- it would
           # deadlock waiting for itself.
-          EXPECTED_CHECKS: 'Build & Test (Linux)'
+          EXPECTED_CHECKS: 'Build & Test (Linux),APM Self-Check'
           TIMEOUT_MIN: '30'
           POLL_SEC: '30'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- CI: new `APM Self-Check` job in `ci.yml` dogfoods the two CI gates we ship to users via `microsoft/apm-action@v1` -- `apm audit --ci` (consumer-side install fidelity) plus a `git status --porcelain` regeneration-drift check (producer-side, catches hand-edits to `.github/` that bypass canonical `.apm/`). Wired into `merge-gate.yml`'s `EXPECTED_CHECKS`. Includes the precursor regen of `.github/agents/auth-expert.agent.md` and `.github/skills/auth/SKILL.md` so the gate is green on first run. Closes #883.
+- CI: add `APM Self-Check` to `ci.yml` for `apm audit --ci`, regeneration-drift validation, and `merge-gate.yml` `EXPECTED_CHECKS` coverage. (#885)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- CI: new `APM Self-Check` job in `ci.yml` dogfoods the two CI gates we ship to users via `microsoft/apm-action@v1` -- `apm audit --ci` (consumer-side install fidelity) plus a `git status --porcelain` regeneration-drift check (producer-side, catches hand-edits to `.github/` that bypass canonical `.apm/`). Wired into `merge-gate.yml`'s `EXPECTED_CHECKS`. Includes the precursor regen of `.github/agents/auth-expert.agent.md` and `.github/skills/auth/SKILL.md` so the gate is green on first run. Closes #883.
+
 ### Changed
 
 - CI: smoke tests in `build-release.yml`'s `build-and-test` job (Linux x86_64, Linux arm64, Windows) are now gated to promotion boundaries (tag/schedule/dispatch) instead of running on every push to main. Push-time smoke duplicated the merge-time smoke gate in `ci-integration.yml` and burned ~15 redundant codex-binary downloads/day. Tag-cut releases still run smoke as a pre-ship gate; nightly catches upstream codex URL drift; merge-time still gates merges into main. (#878)

--- a/docs/src/content/docs/integrations/ci-cd.md
+++ b/docs/src/content/docs/integrations/ci-cd.md
@@ -74,6 +74,10 @@ To ensure `.github/`, `.claude/`, `.cursor/`, and `.opencode/` integration files
 
 This catches cases where a developer updates `apm.yml` but forgets to re-run `apm install`.
 
+:::tip[We dogfood this]
+APM's own repo runs both gates on every PR via the `APM Self-Check` job in [`microsoft/apm`'s `ci.yml`](https://github.com/microsoft/apm/blob/main/.github/workflows/ci.yml). It's the same `microsoft/apm-action@v1` + `apm audit --ci` + `git status --porcelain` pattern shown above -- copy it as a reference implementation.
+:::
+
 ## Azure Pipelines
 
 ```yaml

--- a/docs/src/content/docs/integrations/ci-cd.md
+++ b/docs/src/content/docs/integrations/ci-cd.md
@@ -75,7 +75,7 @@ To ensure `.github/`, `.claude/`, `.cursor/`, and `.opencode/` integration files
 This catches cases where a developer updates `apm.yml` but forgets to re-run `apm install`.
 
 :::tip[We dogfood this]
-APM's own repo runs both gates on every PR via the `APM Self-Check` job in [`microsoft/apm`'s `ci.yml`](https://github.com/microsoft/apm/blob/main/.github/workflows/ci.yml). It's the same `microsoft/apm-action@v1` + `apm audit --ci` + `git status --porcelain` pattern shown above -- copy it as a reference implementation.
+APM's own repo uses the `APM Self-Check` job in [`microsoft/apm`'s `ci.yml`](https://github.com/microsoft/apm/blob/main/.github/workflows/ci.yml) as a reference implementation for installing APM, running CI validation commands such as `apm audit --ci`, and checking for drift with `git status --porcelain`. Use it as a practical example when wiring these checks into your own workflow.
 :::
 
 ## Azure Pipelines


### PR DESCRIPTION
# ci: dogfood `apm audit --ci` and integration-drift gate

## TL;DR

`microsoft/apm` ships two CI gates as features and documents them publicly, but never ran them on its own pipeline — the embarrassment that PRs #874, #875, and #878 made unavoidable. This PR adds an `APM Self-Check` job to `ci.yml` that runs both via `microsoft/apm-action@v1`, wires it into `merge-gate.yml`'s `EXPECTED_CHECKS`, and bundles the precursor regeneration the gate would otherwise have flagged on first run. Closes #883.

> [!NOTE]
> The bundled regen is exactly the drift inventory #883 called out: `.github/agents/auth-expert.agent.md` and `.github/skills/auth/SKILL.md`, both stale vs `.apm/` since #856's ADO bearer-token work. The third drift item (`pr-description-skill`) is owned by PR #884 and intentionally untouched here.

## Problem (WHY)

- [x] We document `apm audit --ci` and the integration-drift recipe at [`integrations/ci-cd.md` "Verify Deployed Primitives"](https://microsoft.github.io/apm/integrations/ci-cd/#verify-deployed-primitives) and run neither on this repo. Self-inflicted credibility hole for a project whose value prop is "treat governance as code".
- [x] The producer-side drift mode caught us three times in a row: PRs #874, #875, and the initial commit of #878 each silently desynced `.apm/instructions/cicd.instructions.md` from `.github/instructions/cicd.instructions.md` because the maintainer edited the regenerated output. The next `apm install` would have **overwritten** the new content with the stale source.
- [!] Live drift on `main` today: `.github/agents/auth-expert.agent.md` and `.github/skills/auth/SKILL.md` are stale vs canonical `.apm/` (provenance: #856 updated `.apm/` only). Any honest first run of the gate fails on these — which is precisely why the issue called for a precursor PR.

Why these matter: shipping a CI gate we don't run ourselves violates ["agents pattern-match well against concrete structures"](https://agentskills.io/skill-creation/best-practices) — when the canonical reference repo doesn't match what we tell users to do, the recommendation stops being credible. And accepting silent producer-side drift violates ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) — `apm install` is the deterministic step; bypassing it makes the regenerated tree probabilistic relative to source.

## Approach (WHAT)

| # | Fix | Principle | Source |
|---|-----|-----------|--------|
| 1 | Single PR-time job runs both gates via `microsoft/apm-action@v1` (no secrets needed → fits Tier 1). | ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) | PROSE |
| 2 | Bundle the precursor `.github/` regen into this PR rather than ship a separate sequencing PR first. | ["Add what the agent lacks, omit what it knows"](https://agentskills.io/skill-creation/best-practices) — a separate PR adds nothing the bundled commit doesn't already prove. | Agent Skills |
| 3 | Add `APM Self-Check` to `merge-gate.yml`'s `EXPECTED_CHECKS` so the single-authority gate aggregator waits on it. | Reuses the existing aggregator pattern documented in the file header. | `merge-gate.yml:7-11` |
| 4 | Add a "We dogfood this" callout in `integrations/ci-cd.md` pointing at our own `ci.yml`. | Dogfooding becomes evidence, not just intent. | issue #883 acceptance criteria |

## Implementation (HOW)

- **`.github/workflows/ci.yml`** — new top-level `apm-self-check` job mirroring the issue's spec verbatim. Uses `microsoft/apm-action@v1` (auto-detects target from existing `.github/`), then runs `apm audit --ci` (Gate A) and a `git status --porcelain -- .github/ .claude/ .cursor/ .opencode/` check (Gate B). Permissions scoped to `contents: read`. Comments preserved from the issue spec to keep the rationale on-disk for future readers.
- **`.github/workflows/merge-gate.yml`** — append `APM Self-Check` to the comma-separated `EXPECTED_CHECKS` env var (now `'Build & Test (Linux),APM Self-Check'`); update the inline comment to list both checks. Branch protection requires only `gate`, so no ruleset edit is needed.
- **`.github/agents/auth-expert.agent.md`**, **`.github/skills/auth/SKILL.md`** — pure regenerated output of `apm install` against current canonical `.apm/`. Not hand-edited. Diff is exactly the ADO bearer-token content from #856 propagating into the deployed tree.
- **`docs/src/content/docs/integrations/ci-cd.md`** — three-line `:::tip[We dogfood this]` callout right after the existing "Verify Deployed Primitives" snippet, pointing at `microsoft/apm`'s own `ci.yml`.
- **`CHANGELOG.md`** — single Unreleased entry under `### Added` summarising the gate + bundled regen and citing #883.

## Diagrams

Legend: the dogfooding loop — canonical authoring lives in `.apm/`, `apm install` regenerates the integration tree, and the self-check job re-runs install in CI to detect any hand-edit that bypassed the canonical source.

```mermaid
flowchart LR
    A[".apm/ canonical source"] -->|"author edits here"| B["apm install (local)"]
    B -->|"regenerates"| C[".github/ integration tree"]
    C -->|"committed to PR"| D["PR opened"]
    D --> E["APM Self-Check (CI)"]
    E -->|"microsoft/apm-action@v1<br/>re-runs apm install"| F{"git status --porcelain<br/>.github/ .claude/ .cursor/ .opencode/"}
    F -->|"clean"| G["Gate B passes"]
    F -->|"dirty"| H["Gate B fails:<br/>'Run apm install and commit'"]
    E --> I["apm audit --ci"]
    I -->|"6/6 baseline checks"| J["Gate A passes"]
    I -->|"any check fails"| K["Gate A fails"]
```

Legend: producer-side vs consumer-side gates catch different failure modes; both are needed because they have disjoint blast radii.

```mermaid
flowchart TB
    subgraph CONSUMER["Gate A — apm audit --ci (consumer-side)"]
        A1["lockfile-exists"]
        A2["ref-consistency"]
        A3["deployed-files-present"]
        A4["no-orphaned-packages"]
        A5["config-consistency"]
        A6["content-integrity (Unicode)"]
    end
    subgraph PRODUCER["Gate B — regeneration drift (producer-side)"]
        B1["Run apm install"]
        B2["git status --porcelain<br/>on integration dirs"]
        B1 --> B2
    end
    X1["Edited apm.yml<br/>without re-install"] --> A2
    X2["Deleted a deployed file"] --> A3
    X3["Hidden Unicode in package"] --> A6
    Y1["Hand-edit to .github/<br/>without updating .apm/"] --> B2
    Y2["Stale .github/ from older<br/>upstream update"] --> B2
```

## Trade-offs

- **Bundled precursor regen vs separate precursor PR.** Issue #883 originally proposed shipping the regen as a precursor PR, then wiring the gate in a follow-up. Chose to bundle: a separate PR would add a merge cycle, leave the gate self-DOSing in the gap (CI on the precursor PR runs against pre-gate `main` so the gate isn't enforced; opening the gate-wiring PR right after is the first time it fires, and it has nothing to assert against beyond what we already manually verified). Bundling keeps the change atomic and verifiable from a single diff. Risk: the regen diff is reviewed alongside CI plumbing instead of in isolation — mitigated by the diff being two files, both pure mechanical regen output.
- **`microsoft/apm-action@v1` unpinned vs SHA-pinned.** Chose the floating major. Per the issue spec: ["`apm-version` is intentionally unpinned. If a future change requires a specific CLI behavior, pin then; for now we want to catch breakage on latest stable as part of release readiness."](https://github.com/microsoft/apm/issues/883). Trade: a malicious tag retag on `microsoft/apm-action` would execute in CI; mitigated because the action is in our own org and Tier 1 has no secrets to exfiltrate.
- **Job name `APM Self-Check` (with space) vs `apm-self-check` (kebab).** Chose the spaced display name to match the existing convention in `EXPECTED_CHECKS` (`'Build & Test (Linux)'` already uses spaces and capitals). Branch protection matches on the rendered check-run name, not the job key, so this is consistent with the documented pattern in `merge-gate.yml`'s header comment. The kebab form survives as the YAML job key (`apm-self-check`).
- **Tier 1 (PR-time, no secrets) vs Tier 2 (merge-queue only).** Both gates are pure-public — they need no `GH_CLI_PAT`, `ADO_APM_PAT`, or `GH_MODELS_PAT` — so Tier 1 is the right home. Catching producer-side drift at PR-time is also where the signal is highest; surfacing it only in the merge queue would let drift accumulate on open PRs.

## Benefits

1. **Three known prior incidents would have been caught at PR-time.** PRs #874, #875, and the initial commit of #878 all desynced `.apm/` and `.github/` for the same file; Gate B fails any of them on first push.
2. **`apm audit --ci` runs on every PR**, exercising the documented 6/6 baseline (`lockfile-exists`, `ref-consistency`, `deployed-files-present`, `no-orphaned-packages`, `config-consistency`, `content-integrity`).
3. **Reference implementation users can copy verbatim.** The dogfood callout makes our own `ci.yml` the canonical example for `microsoft/apm-action@v1` consumers — no separate template to maintain.
4. **Atomic commit:** the precursor drift fix and the gate that would have caught it ship together; reviewer can verify "yes this was the right fix" by reading both changes in one pass.
5. **No new secrets, no new runners.** Tier 1 ubuntu-24.04, no `permissions:` escalation beyond `contents: read`.

## Validation

`apm audit --ci` (run locally on the branch — this is the gate validating itself):

```
                                [>] APM Policy Compliance
+----------+------------------------+---------------------------------------------------+
| Status   | Check                  | Message                                           |
+----------+------------------------+---------------------------------------------------+
| [+]      | lockfile-exists        | No dependencies declared -- lockfile not required |
| [+]      | ref-consistency        | All dependency refs match lockfile                |
| [+]      | deployed-files-present | All deployed files present on disk                |
| [+]      | no-orphaned-packages   | No orphaned packages in lockfile                  |
| [+]      | config-consistency     | No MCP configs to check                           |
| [+]      | content-integrity      | No critical hidden Unicode characters detected    |
+----------+------------------------+---------------------------------------------------+

[*] All 6 check(s) passed
```

`apm install` (verifies Gate B is clean post-regen):

```
[>] Installing dependencies from apm.yml...
  [+] <project root> (local)
  |-- 8 instruction(s) integrated -> .github/instructions/
  |-- 10 agents integrated -> .github/agents/
  |-- 8 skill(s) integrated -> .github/skills/
[*] Installed 1 APM dependency.
```

After install: `git status --porcelain -- .github/ .claude/ .cursor/ .opencode/` returns empty (gate-green).

<details><summary>Full diff stat against origin/main</summary>

```
.github/agents/auth-expert.agent.md         |  1 +
.github/skills/auth/SKILL.md                | 31 +++++++++++++++++++++++++++++++
.github/workflows/ci.yml                    | 42 ++++++++++++++++++++++++++++++++++++++++++
.github/workflows/merge-gate.yml            |  6 +++---
docs/src/content/docs/integrations/ci-cd.md |  4 ++++
CHANGELOG.md                                |  6 +++++-
6 files changed, 89 insertions(+), 4 deletions(-)
```

</details>

## How to test

- [ ] Open this PR and observe `APM Self-Check` reports green alongside `Build & Test (Linux)`.
- [ ] Confirm `merge-gate.yml`'s `gate` job waits on `APM Self-Check` (poll log line `[merge-gate]` mentions both checks).
- [ ] **Negative test (Gate B):** push a commit that edits only `.github/instructions/cicd.instructions.md` without touching `.apm/`. `APM Self-Check` should fail with the diff visible in the log and the message `APM integration files are out of date.`
- [ ] **Negative test (Gate A):** bump a version in `apm.yml` without running `apm install`. `APM Self-Check` should fail with a `ref-consistency` violation from `apm audit --ci`.
- [ ] Render `docs/src/content/docs/integrations/ci-cd.md` locally; the new `:::tip[We dogfood this]` callout appears under "Verify Deployed Primitives" linking to `microsoft/apm`'s `ci.yml`.

## References

- Closes #883
- Drift incidents this gate would have caught at PR-time: #874, #875, #878
- Provenance of the bundled regen: #856 (ADO AAD bearer-token auth)
- Documented "Verify Deployed Primitives" pattern: [integrations/ci-cd.md](https://microsoft.github.io/apm/integrations/ci-cd/#verify-deployed-primitives)
- Related future work: #684 (per-deployed-file content drift; out of scope here)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
