### PR TITLE
[Test Improver] fix: suppress ANSI escape codes in non-TTY contexts

### DIFF
--- a/src/apm_cli/utils/console.py
+++ b/src/apm_cli/utils/console.py
@@ -56,10 +56,17 @@ STATUS_SYMBOLS = {
 
 
 def _get_console() -> Optional[Any]:
-    """Get Rich console instance if available."""
+    """Get Rich console instance if available.
+
+    Passes ``force_terminal=False`` when stdout is not a TTY so that Rich
+    does not emit ANSI escape sequences (bold, italic, colour) to non-terminal
+    outputs such as pipes, files, or test runners.  Box-drawing characters
+    used in Rich tables are still emitted; those are acceptable Unicode output.
+    """
     if RICH_AVAILABLE:
         try:
-            return Console()
+            is_tty = getattr(sys.stdout, "isatty", lambda: False)()
+            return Console(force_terminal=is_tty)
         except Exception:
             pass
     return None


### PR DESCRIPTION
🤖 *This is an automated change from Test Improver, an AI assistant.*

## Summary

`_get_console()` in `src/apm_cli/utils/console.py` created `Console()` with no arguments. Rich's auto-detection uses `sys.__stdout__.isatty()` (the original stdout), not the stream it actually writes to. This caused ANSI escape sequences (bold `\x1b[1m`, italic `\x1b[3m`, reset `\x1b[0m`) to be emitted even when writing to pipes, files, or test-runner capture buffers.

This broke 7 tests in `tests/unit/commands/test_policy_status.py` that were added in the most recent commit to enforce the repo's ASCII-only encoding rule.

## Root cause

```python
# Before: Console() uses sys.__stdout__.isatty() for detection,
# ignoring the actual write target (which may be a non-TTY buffer).
return Console()
```

## Fix

````python
# After: explicitly set force_terminal based on sys.stdout.isatty(),
# which IS replaced by CliRunner/pytest capture, so detection is accurate.
is_tty = getattr(sys.stdout, "isatty", lambda: False)()
return Console(force_terminal=is_tty)
```

**Behaviour change:**
- In a real terminal (`isatty()` → True): ANSI codes emitted as before — no visible change for users
- In non-TTY contexts (pipes, files, test runners): ANSI codes suppressed
- Box-drawing characters (Rich table borders) still emitted in both modes — `_ascii_only()` explicitly permits these

## Test Status

| Suite | Before | After |
|---|---|---|
| `tests/unit/commands/test_policy_status.py` | 7 failed, 33 passed | **40 passed** |
| Full unit suite (`tests/unit tests/test_console.py`) | 5262 passed | **5302 passed** |

```
uv run pytest tests/unit tests/test_console.py -x -q
# 5302 passed, 1 warning, 26 subtests passed
````

## Scope

Only `src/apm_cli/utils/console.py` is modified (9 lines — 7 added, 2 changed). No test files changed, no new dependencies.




> Generated by [Daily Test Improver](https://github.com/microsoft/apm/actions/runs/24867069418) · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+is%3Apr+%22gh-aw-workflow-id%3A+daily-test-improver%22+in%3Abody)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/tree/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-test-improver.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-test-improver.md@b87234850bf9664d198f28a02df0f937d0447295
> ```

<!-- gh-aw-agentic-workflow: Daily Test Improver, engine: copilot, id: 24867069418, workflow_id: daily-test-improver, run: https://github.com/microsoft/apm/actions/runs/24867069418 -->

<!-- gh-aw-workflow-id: daily-test-improver -->