### PR TITLE
chore: bump shared/apm.md to microsoft/apm-action@v1.4.2

### DIFF
--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -35,10 +35,10 @@
       "version": "v0.52.1",
       "sha": "a86e657586e4ac5f549a790628971ec02f6a4a8f"
     },
-    "microsoft/apm-action@v1.4.1": {
+    "microsoft/apm-action@v1.4.2": {
       "repo": "microsoft/apm-action",
-      "version": "v1.4.1",
-      "sha": "a190b0b1a91031057144dc136acf9757a59c9e4d"
+      "version": "v1.4.2",
+      "sha": "9fe9337ef58b5e620e0113071ceb47a6a8a232f7"
     }
   }
 }

--- a/.github/workflows/pr-review-panel.lock.yml
+++ b/.github/workflows/pr-review-panel.lock.yml
@@ -1,5 +1,5 @@
 # gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"568ddeef22451814cb5a691b0845f2c8ba599c72796186d9ad82b54ce1546571","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_PLUGINS_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"},{"repo":"microsoft/apm-action","sha":"a190b0b1a91031057144dc136acf9757a59c9e4d","version":"v1.4.1"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_PLUGINS_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"},{"repo":"microsoft/apm-action","sha":"9fe9337ef58b5e620e0113071ceb47a6a8a232f7","version":"v1.4.2"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -42,7 +42,7 @@
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
 #   - github/gh-aw-actions/setup@ba90f2186d7ad780ec640f364005fa24e797b360 # v0.68.3
-#   - microsoft/apm-action@a190b0b1a91031057144dc136acf9757a59c9e4d # v1.4.1
+#   - microsoft/apm-action@9fe9337ef58b5e620e0113071ceb47a6a8a232f7 # v1.4.2
 #
 # Container images used:
 #   - ghcr.io/github/gh-aw-firewall/agent:0.25.20
@@ -383,7 +383,7 @@ jobs:
         name: Find APM bundle path
         run: echo "path=$(find /tmp/gh-aw/apm-bundle -name '*.tar.gz' | head -1)" >> "$GITHUB_OUTPUT"
       - name: Restore APM packages
-        uses: microsoft/apm-action@a190b0b1a91031057144dc136acf9757a59c9e4d # v1.4.1
+        uses: microsoft/apm-action@9fe9337ef58b5e620e0113071ceb47a6a8a232f7 # v1.4.2
         with:
           bundle: ${{ steps.apm_bundle.outputs.path }}
 
@@ -881,7 +881,7 @@ jobs:
           AW_APM_PACKAGES: "[\"microsoft/apm#main\"]"
       - name: Pack APM packages
         id: apm_pack
-        uses: microsoft/apm-action@a190b0b1a91031057144dc136acf9757a59c9e4d # v1.4.1
+        uses: microsoft/apm-action@9fe9337ef58b5e620e0113071ceb47a6a8a232f7 # v1.4.2
         env:
           GITHUB_TOKEN: ${{ secrets.GH_AW_PLUGINS_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/shared/apm.md
+++ b/.github/workflows/shared/apm.md
@@ -46,7 +46,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
       - name: Pack APM packages
         id: apm_pack
-        uses: microsoft/apm-action@v1.4.1
+        uses: microsoft/apm-action@v1.4.2
         env:
           GITHUB_TOKEN: ${{ secrets.GH_AW_PLUGINS_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         with:
@@ -74,7 +74,7 @@ steps:
     id: apm_bundle
     run: echo "path=$(find /tmp/gh-aw/apm-bundle -name '*.tar.gz' | head -1)" >> "$GITHUB_OUTPUT"
   - name: Restore APM packages
-    uses: microsoft/apm-action@v1.4.1
+    uses: microsoft/apm-action@v1.4.2
     with:
       bundle: ${{ steps.apm_bundle.outputs.path }}
 ---


### PR DESCRIPTION
## Summary

Bumps `microsoft/apm-action` from `v1.4.1` to `v1.4.2` in our shared agentic-workflow `shared/apm.md`.

v1.4.2 fixes the restore-mode workspace pollution that caused #901 and the CI failure surfaced in #889. With v1.4.2, restore mode installs APM and uses `apm unpack` to extract bundles, writing only files declared in the lockfile's `deployed_files` instead of overwriting tracked `apm.lock.yaml` / `apm.yml` / `apm_modules` in the caller's git workspace.

Closes #902.

## Changes

- `.github/workflows/shared/apm.md` — bump both pack and restore steps to `@v1.4.2` (lines 49 and 77).
- `.github/workflows/pr-review-panel.lock.yml` — regenerated via `gh aw compile` (SHA pin updated to `9fe9337…`).
- `.github/aw/actions-lock.json` — SHA pin updated.

No other workflow files needed regeneration; only `pr-review-panel` consumes `shared/apm.md`.

## Verification

- `gh aw compile` ran cleanly (4 workflows, 0 errors).
- Drift unrelated to this change in other lockfiles (`cli-consistency-checker`, `daily-doc-updater`, `daily-test-improver`, `agentics-maintenance`) was reverted to keep this PR minimal.
- Upstream release: https://github.com/microsoft/apm-action/releases/tag/v1.4.2
- Upstream PR: https://github.com/microsoft/apm-action/pull/27 (with live integration test `test-restore-clean-workspace` reproducing the #889 scenario end-to-end).

## Why pin a patch version, not `@v1`

Supply-chain hygiene: immutable patch pins survive a tag rewrite. The `v1` floating tag has already been retagged to `v1.4.2`, so consumers pinned to `@v1` are also on the fix.
