### PR TITLE
fix(panel-review): orchestrator self-arbitrates and emits in skill contract

### DIFF
--- a/.apm/skills/apm-review-panel/SKILL.md
+++ b/.apm/skills/apm-review-panel/SKILL.md
@@ -184,12 +184,16 @@ the final step.
    - No persona return is missing or empty.
    If any check fails, re-invoke the missing persona and repeat the
    gate. Do not proceed to step 5 until the gate passes.
-5. Run the CEO arbitration pass over the collected findings. CEO
-   arbitration may run only after the completeness gate has passed.
+5. Run the CEO arbitration pass over the collected findings **as
+   yourself** (the orchestrator). Do NOT dispatch a separate sub-agent
+   for arbitration -- you are the arbiter. CEO arbitration may run
+   only after the completeness gate has passed.
 6. Now (and only now) load `assets/verdict-template.md` and fill it
    in with the collected findings + arbitration.
 7. Emit the filled template as exactly ONE comment via the workflow's
-   `safe-outputs.add-comment` channel.
+   `safe-outputs.add-comment` channel. You (the orchestrator) write
+   the comment; never delegate emission to a sub-agent and never call
+   the GitHub API directly.
 
 ### Dispatch contract
 
@@ -217,8 +221,9 @@ panel review that lands as one cohesive verdict and one that fragments
 into per-persona noise.
 
 - Produce **exactly one** comment per panel run. The
-  `safe-outputs.add-comment.max: 1` cap in the workflow is a backstop;
-  the discipline lives here.
+  `safe-outputs.add-comment.max` cap in the workflow is a fail-soft
+  ceiling (currently 7, one per persona slot); the one-comment
+  discipline lives here.
 - Use `assets/verdict-template.md` as the comment body. Keep its
   section headings exactly as written. Adapt the body of each section
   to the PR. Do not invent new top-level sections or drop existing

--- a/.github/skills/apm-review-panel/SKILL.md
+++ b/.github/skills/apm-review-panel/SKILL.md
@@ -184,12 +184,16 @@ the final step.
    - No persona return is missing or empty.
    If any check fails, re-invoke the missing persona and repeat the
    gate. Do not proceed to step 5 until the gate passes.
-5. Run the CEO arbitration pass over the collected findings. CEO
-   arbitration may run only after the completeness gate has passed.
+5. Run the CEO arbitration pass over the collected findings **as
+   yourself** (the orchestrator). Do NOT dispatch a separate sub-agent
+   for arbitration -- you are the arbiter. CEO arbitration may run
+   only after the completeness gate has passed.
 6. Now (and only now) load `assets/verdict-template.md` and fill it
    in with the collected findings + arbitration.
 7. Emit the filled template as exactly ONE comment via the workflow's
-   `safe-outputs.add-comment` channel.
+   `safe-outputs.add-comment` channel. You (the orchestrator) write
+   the comment; never delegate emission to a sub-agent and never call
+   the GitHub API directly.
 
 ### Dispatch contract
 
@@ -217,8 +221,9 @@ panel review that lands as one cohesive verdict and one that fragments
 into per-persona noise.
 
 - Produce **exactly one** comment per panel run. The
-  `safe-outputs.add-comment.max: 1` cap in the workflow is a backstop;
-  the discipline lives here.
+  `safe-outputs.add-comment.max` cap in the workflow is a fail-soft
+  ceiling (currently 7, one per persona slot); the one-comment
+  discipline lives here.
 - Use `assets/verdict-template.md` as the comment body. Keep its
   section headings exactly as written. Adapt the body of each section
   to the PR. Do not invent new top-level sections or drop existing

--- a/.github/workflows/pr-review-panel.md
+++ b/.github/workflows/pr-review-panel.md
@@ -117,29 +117,6 @@ gh pr diff "$PR"
 Load the **apm-review-panel** skill and follow its execution checklist
 and output contract exactly. The skill owns reviewer routing, persona
 dispatch, the Auth Expert conditional rule, the pre-arbitration
-completeness gate, template loading, and verdict shape.
-
-Auth Expert is the only conditional panelist. The skill decides
-activation from the already-fetched PR title/body/files/diff using a
-fast-path file list plus a fallback self-check. Do not invent a
-separate scope-analysis sub-agent for this. If the skill marks Auth
-Expert inactive, do not dispatch it; keep the Auth Expert heading in
-the final verdict and fill it with `Not activated -- <reason>`.
-
-## Step 3: Output contract
-
-- You may post **exactly one** comment for this entire panel run, and it
-  **must** be the final synthesized verdict from the **CEO** (after
-  arbitration). Sub-agent personas (Python Architect, CLI Logging
-  Expert, DevX UX Expert, Supply Chain Security Expert, OSS Growth
-  Hacker, Auth Expert when active) **do not** post comments — they
-  return their findings to the CEO, who synthesizes the single verdict.
-  When dispatching each sub-agent, instruct it explicitly: "do not post
-  any comment; return your findings to the orchestrator."
-- Do not call the GitHub API directly. Write the comment via the
-  provided output channel; a downstream publisher posts it.
-
-## Step 4: Emit the verdict
-
-Write the CEO's final verdict comment body to the agent output channel.
-The downstream publisher will post it to PR #$PR.
+completeness gate, CEO arbitration, template loading, verdict shape,
+and the one-comment emission contract -- including writing the final
+comment to `safe-outputs.add-comment` rather than the GitHub API.


### PR DESCRIPTION
## Problem

PR #905 broke the panel: agent posts zero comments. Issue #906 captures the failure on run [24897368527](https://github.com/microsoft/apm/actions/runs/24897368527).

## Root cause

Inspected the agent artifact (`agent_output.json={"items":[]}`, full stdio transcript). Two coupled issues with #905:

1. **The 'do not post any comment; return to orchestrator' instruction is a no-op.** Sub-agents launched via the `task` tool do not have safe-outputs MCP access -- only the orchestrator session does.

2. **Real bug**: phrasing the contract as 'CEO synthesizes the single verdict' framed CEO as a separate emitter. The orchestrator dispatched 5 personas, got 4 results, was waiting on a slow one, **never dispatched apm-ceo**, and the session ended at 6m without ever reaching synthesis.

## Fix lives in the skill, not the workflow

The user's architectural point: `.apm/skills/apm-review-panel/SKILL.md` is the authoritative source for routing, dispatch, arbitration, emission. The workflow .md should be a thin shell.

This PR:

- **SKILL.md step 5**: orchestrator runs CEO arbitration **as itself**, never delegates to a sub-agent.
- **SKILL.md step 7**: orchestrator writes the comment via `safe-outputs.add-comment`, never the GitHub API.
- **SKILL.md output contract**: `max` cap reference updated to fail-soft ceiling of 7 (matches workflow frontmatter).
- **Workflow .md**: removed Steps 3 and 4. They were duplicating skill territory. Step 2 now expanded slightly to point at all the skill responsibilities (including emission contract).

## Stats

`3 files changed, 23 insertions(+), 36 deletions(-)` -- net simpler, single source of truth.

## Verification

Will be verified live by re-triggering the panel on PR #889 after merge.

Closes #906.