### PR TITLE
feat: Full Kiro support #702

### DIFF
--- a/src/apm_cli/adapters/client/kiro.py
+++ b/src/apm_cli/adapters/client/kiro.py
@@ -1,12 +1,14 @@
-"""Kiro IDE implementation of MCP client adapter.
+"""Kiro IDE/CLI implementation of MCP client adapter.
 
-Kiro uses the standard ``mcpServers`` JSON format at ``.kiro/mcp.json``
-(repo-local).  The config schema is identical to GitHub Copilot CLI, so this
-adapter subclasses :class:`CopilotClientAdapter` and only overrides the
-config-path logic and the user-facing labels.
+Kiro stores MCP configuration at ``.kiro/settings/mcp.json`` (project-local)
+or ``~/.kiro/settings/mcp.json`` (global/user scope).  The schema uses the
+standard ``mcpServers`` object so the Copilot formatter is reused directly.
 
-APM only writes to ``.kiro/mcp.json`` when the ``.kiro/`` directory
-already exists — Kiro support is opt-in.
+APM writes to ``.kiro/settings/mcp.json`` only when the ``.kiro/`` directory
+already exists — Kiro support is opt-in at project scope.  At user scope
+(``--global``), ``~/.kiro/settings/`` is auto-created.
+
+Ref: https://kiro.dev/docs/mcp/configuration/
 """
 
 import json
@@ -17,33 +19,48 @@ from .copilot import CopilotClientAdapter
 
 
 class KiroClientAdapter(CopilotClientAdapter):
-    """Kiro IDE MCP client adapter.
+    """Kiro IDE/CLI MCP client adapter.
 
     Inherits all config formatting from :class:`CopilotClientAdapter`
-    (``mcpServers`` JSON with ``command``/``args``/``env``).  Only the
-    config-file location differs: repo-local ``.kiro/mcp.json`` instead
-    of global ``~/.copilot/mcp-config.json``.
+    (``mcpServers`` JSON with ``command``/``args``/``env``).  Overrides
+    the config-file path to target ``.kiro/settings/mcp.json``.
+
+    User-scope (``--global``) writes to ``~/.kiro/settings/mcp.json``.
+    Project-scope writes to ``<cwd>/.kiro/settings/mcp.json`` only when
+    ``.kiro/`` already exists.
     """
 
-    supports_user_scope: bool = False
+    supports_user_scope: bool = True
 
-    def get_config_path(self):
-        """Return the path to ``.kiro/mcp.json`` in the repository root."""
+    def get_config_path(self, user_scope: bool = False):
+        """Return path to the Kiro MCP config file.
+
+        Args:
+            user_scope: When True, return the global ``~/.kiro/settings/mcp.json``.
+        """
+        if user_scope:
+            return str(Path.home() / ".kiro" / "settings" / "mcp.json")
         kiro_dir = Path(os.getcwd()) / ".kiro"
-        return str(kiro_dir / "mcp.json")
+        return str(kiro_dir / "settings" / "mcp.json")
 
-    def update_config(self, config_updates):
+    def update_config(self, config_updates, user_scope: bool = False):
         """Merge *config_updates* into the ``mcpServers`` section.
 
-        The ``.kiro/`` directory must already exist; if it does not, this
-        method returns silently (opt-in behaviour).
+        At project scope the ``.kiro/`` directory must already exist; if it
+        does not, this method returns silently (opt-in behaviour).
+        At user scope the ``~/.kiro/settings/`` directory is created on demand.
         """
-        config_path = Path(self.get_config_path())
+        config_path = Path(self.get_config_path(user_scope=user_scope))
 
-        if not config_path.parent.exists():
-            return
+        if user_scope:
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+        else:
+            kiro_root = config_path.parent.parent  # .kiro/
+            if not kiro_root.exists():
+                return
+            config_path.parent.mkdir(parents=True, exist_ok=True)
 
-        current_config = self.get_current_config()
+        current_config = self.get_current_config(user_scope=user_scope)
         if "mcpServers" not in current_config:
             current_config["mcpServers"] = {}
 
@@ -52,9 +69,9 @@ class KiroClientAdapter(CopilotClientAdapter):
         with open(config_path, "w", encoding="utf-8") as f:
             json.dump(current_config, f, indent=2)
 
-    def get_current_config(self):
-        """Read the current ``.kiro/mcp.json`` contents."""
-        config_path = self.get_config_path()
+    def get_current_config(self, user_scope: bool = False):
+        """Read the current Kiro MCP config file contents."""
+        config_path = self.get_config_path(user_scope=user_scope)
 
         if not os.path.exists(config_path):
             return {}
@@ -74,7 +91,7 @@ class KiroClientAdapter(CopilotClientAdapter):
         server_info_cache=None,
         runtime_vars=None,
     ):
-        """Configure an MCP server in Kiro's ``.kiro/mcp.json``."""
+        """Configure an MCP server in ``.kiro/settings/mcp.json``."""
         if not server_url:
             print("Error: server_url cannot be empty")
             return False

--- a/src/apm_cli/adapters/client/kiro.py
+++ b/src/apm_cli/adapters/client/kiro.py
@@ -1,0 +1,113 @@
+"""Kiro IDE implementation of MCP client adapter.
+
+Kiro uses the standard ``mcpServers`` JSON format at ``.kiro/mcp.json``
+(repo-local).  The config schema is identical to GitHub Copilot CLI, so this
+adapter subclasses :class:`CopilotClientAdapter` and only overrides the
+config-path logic and the user-facing labels.
+
+APM only writes to ``.kiro/mcp.json`` when the ``.kiro/`` directory
+already exists — Kiro support is opt-in.
+"""
+
+import json
+import os
+from pathlib import Path
+
+from .copilot import CopilotClientAdapter
+
+
+class KiroClientAdapter(CopilotClientAdapter):
+    """Kiro IDE MCP client adapter.
+
+    Inherits all config formatting from :class:`CopilotClientAdapter`
+    (``mcpServers`` JSON with ``command``/``args``/``env``).  Only the
+    config-file location differs: repo-local ``.kiro/mcp.json`` instead
+    of global ``~/.copilot/mcp-config.json``.
+    """
+
+    supports_user_scope: bool = False
+
+    def get_config_path(self):
+        """Return the path to ``.kiro/mcp.json`` in the repository root."""
+        kiro_dir = Path(os.getcwd()) / ".kiro"
+        return str(kiro_dir / "mcp.json")
+
+    def update_config(self, config_updates):
+        """Merge *config_updates* into the ``mcpServers`` section.
+
+        The ``.kiro/`` directory must already exist; if it does not, this
+        method returns silently (opt-in behaviour).
+        """
+        config_path = Path(self.get_config_path())
+
+        if not config_path.parent.exists():
+            return
+
+        current_config = self.get_current_config()
+        if "mcpServers" not in current_config:
+            current_config["mcpServers"] = {}
+
+        current_config["mcpServers"].update(config_updates)
+
+        with open(config_path, "w", encoding="utf-8") as f:
+            json.dump(current_config, f, indent=2)
+
+    def get_current_config(self):
+        """Read the current ``.kiro/mcp.json`` contents."""
+        config_path = self.get_config_path()
+
+        if not os.path.exists(config_path):
+            return {}
+
+        try:
+            with open(config_path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, IOError):
+            return {}
+
+    def configure_mcp_server(
+        self,
+        server_url,
+        server_name=None,
+        enabled=True,
+        env_overrides=None,
+        server_info_cache=None,
+        runtime_vars=None,
+    ):
+        """Configure an MCP server in Kiro's ``.kiro/mcp.json``."""
+        if not server_url:
+            print("Error: server_url cannot be empty")
+            return False
+
+        kiro_dir = Path(os.getcwd()) / ".kiro"
+        if not kiro_dir.exists():
+            return True  # nothing to do, not an error
+
+        try:
+            if server_info_cache and server_url in server_info_cache:
+                server_info = server_info_cache[server_url]
+            else:
+                server_info = self.registry_client.find_server_by_reference(server_url)
+
+            if not server_info:
+                print(f"Error: MCP server '{server_url}' not found in registry")
+                return False
+
+            if server_name:
+                config_key = server_name
+            elif "/" in server_url:
+                config_key = server_url.split("/")[-1]
+            else:
+                config_key = server_url
+
+            server_config = self._format_server_config(
+                server_info, env_overrides, runtime_vars
+            )
+            self.update_config({config_key: server_config})
+
+            print(f"Successfully configured MCP server '{config_key}' for Kiro")
+            return True
+
+        except Exception as e:
+            print(f"Error configuring MCP server: {e}")
+            return False

--- a/src/apm_cli/core/target_detection.py
+++ b/src/apm_cli/core/target_detection.py
@@ -26,10 +26,10 @@ from typing import List, Literal, Optional, Tuple, Union
 import click
 
 # Valid target values (internal canonical form)
-TargetType = Literal["vscode", "claude", "cursor", "opencode", "codex", "all", "minimal"]
+TargetType = Literal["vscode", "claude", "cursor", "kiro", "opencode", "codex", "all", "minimal"]
 
 # User-facing target values (includes aliases accepted by CLI)
-UserTargetType = Literal["copilot", "vscode", "agents", "claude", "cursor", "opencode", "codex", "all", "minimal"]
+UserTargetType = Literal["copilot", "vscode", "agents", "claude", "cursor", "kiro", "opencode", "codex", "all", "minimal"]
 
 
 def detect_target(
@@ -57,13 +57,15 @@ def detect_target(
             return "claude", "explicit --target flag"
         elif explicit_target == "cursor":
             return "cursor", "explicit --target flag"
+        elif explicit_target == "kiro":
+            return "kiro", "explicit --target flag"
         elif explicit_target == "opencode":
             return "opencode", "explicit --target flag"
         elif explicit_target == "codex":
             return "codex", "explicit --target flag"
         elif explicit_target == "all":
             return "all", "explicit --target flag"
-    
+
     # Priority 2: apm.yml target setting
     if config_target:
         if config_target in ("copilot", "vscode", "agents"):
@@ -72,6 +74,8 @@ def detect_target(
             return "claude", "apm.yml target"
         elif config_target == "cursor":
             return "cursor", "apm.yml target"
+        elif config_target == "kiro":
+            return "kiro", "apm.yml target"
         elif config_target == "opencode":
             return "opencode", "apm.yml target"
         elif config_target == "codex":
@@ -83,6 +87,7 @@ def detect_target(
     github_exists = (project_root / ".github").exists()
     claude_exists = (project_root / ".claude").exists()
     cursor_exists = (project_root / ".cursor").is_dir()
+    kiro_exists = (project_root / ".kiro").is_dir()
     opencode_exists = (project_root / ".opencode").is_dir()
     codex_exists = (project_root / ".codex").is_dir()
     detected = []
@@ -92,6 +97,8 @@ def detect_target(
         detected.append(".claude/")
     if cursor_exists:
         detected.append(".cursor/")
+    if kiro_exists:
+        detected.append(".kiro/")
     if opencode_exists:
         detected.append(".opencode/")
     if codex_exists:
@@ -105,13 +112,15 @@ def detect_target(
         return "claude", "detected .claude/ folder"
     elif cursor_exists:
         return "cursor", "detected .cursor/ folder"
+    elif kiro_exists:
+        return "kiro", "detected .kiro/ folder"
     elif opencode_exists:
         return "opencode", "detected .opencode/ folder"
     elif codex_exists:
         return "codex", "detected .codex/ folder"
     else:
         # No known target folders exist - minimal output
-        return "minimal", "no .github/, .claude/, .cursor/, .opencode/, or .codex/ folder found"
+        return "minimal", "no .github/, .claude/, .cursor/, .kiro/, .opencode/, or .codex/ folder found"
 
 
 def should_integrate_vscode(target: TargetType) -> bool:
@@ -160,6 +169,18 @@ def should_integrate_cursor(target: TargetType) -> bool:
         bool: True if Cursor integration (agents, skills, rules) should run
     """
     return target in ("cursor", "all")
+
+
+def should_integrate_kiro(target: TargetType) -> bool:
+    """Check if Kiro integration should be performed.
+
+    Args:
+        target: The detected or configured target
+
+    Returns:
+        bool: True if Kiro integration (steering, skills, hooks, MCP) should run
+    """
+    return target in ("kiro", "all")
 
 
 def should_integrate_codex(target: TargetType) -> bool:
@@ -218,9 +239,10 @@ def get_target_description(target: UserTargetType) -> str:
         "vscode": "AGENTS.md + .github/prompts/ + .github/agents/",
         "claude": "CLAUDE.md + .claude/commands/ + .claude/agents/ + .claude/skills/",
         "cursor": ".cursor/agents/ + .cursor/skills/ + .cursor/rules/",
+        "kiro": ".kiro/steering/ + .kiro/skills/ + .kiro/hooks/ + .kiro/mcp.json",
         "opencode": "AGENTS.md + .opencode/agents/ + .opencode/commands/ + .opencode/skills/",
         "codex": "AGENTS.md + .agents/skills/ + .codex/agents/ + .codex/hooks.json",
-        "all": "AGENTS.md + CLAUDE.md + .github/ + .claude/ + .cursor/ + .opencode/ + .codex/ + .agents/",
+        "all": "AGENTS.md + CLAUDE.md + .github/ + .claude/ + .cursor/ + .kiro/ + .opencode/ + .codex/ + .agents/",
         "minimal": "AGENTS.md only (create .github/ or .claude/ for full integration)",
     }
     return descriptions.get(normalized, "unknown target")
@@ -232,7 +254,7 @@ def get_target_description(target: UserTargetType) -> str:
 
 #: The complete set of real (non-pseudo) canonical targets.
 #: "minimal" is intentionally excluded -- it is a fallback pseudo-target.
-ALL_CANONICAL_TARGETS = frozenset({"vscode", "claude", "cursor", "opencode", "codex"})
+ALL_CANONICAL_TARGETS = frozenset({"vscode", "claude", "cursor", "kiro", "opencode", "codex"})
 
 #: Alias mapping: user-facing name -> canonical internal name.
 TARGET_ALIASES: dict[str, str] = {

--- a/src/apm_cli/factory.py
+++ b/src/apm_cli/factory.py
@@ -4,6 +4,7 @@ from .adapters.client.vscode import VSCodeClientAdapter
 from .adapters.client.codex import CodexClientAdapter
 from .adapters.client.copilot import CopilotClientAdapter
 from .adapters.client.cursor import CursorClientAdapter
+from .adapters.client.kiro import KiroClientAdapter
 from .adapters.client.opencode import OpenCodeClientAdapter
 from .adapters.package_manager.default_manager import DefaultMCPPackageManager
 
@@ -29,6 +30,7 @@ class ClientFactory:
             "vscode": VSCodeClientAdapter,
             "codex": CodexClientAdapter,
             "cursor": CursorClientAdapter,
+            "kiro": KiroClientAdapter,
             "opencode": OpenCodeClientAdapter,
             # Add more clients as needed
         }

--- a/src/apm_cli/install/services.py
+++ b/src/apm_cli/install/services.py
@@ -128,6 +128,8 @@ def integrate_package_primitives(
                         _deploy_dir = ".cursor/hooks.json"
                     elif _target.name == "codex":
                         _deploy_dir = ".codex/hooks.json"
+                    elif _target.name == "kiro":
+                        _deploy_dir = ".kiro/hooks/"
                     _label = "hook(s)"
                 else:
                     _label = _prim_name

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -145,6 +145,9 @@ class AgentIntegrator(BaseIntegrator):
             if mapping.format_id == "codex_agent":
                 self._write_codex_agent(source_file, target_path)
                 links_resolved = 0
+            elif mapping.format_id == "kiro_agent":
+                self._write_kiro_agent(source_file, target_path)
+                links_resolved = 0
             else:
                 links_resolved = self.copy_agent(source_file, target_path)
             total_links_resolved += links_resolved
@@ -262,6 +265,49 @@ class AgentIntegrator(BaseIntegrator):
             "developer_instructions": body.strip(),
         }
         target.write_text(_toml.dumps(doc), encoding="utf-8")
+
+    @staticmethod
+    def _write_kiro_agent(source: Path, target: Path) -> None:
+        """Transform an ``.agent.md`` file to Kiro ``.json`` agent format.
+
+        Parses YAML frontmatter for ``name``, ``description``, and ``model``,
+        uses the markdown body as ``prompt``.
+
+        Ref: https://kiro.dev/docs/cli/custom-agents/configuration-reference/
+        """
+        import json as _json
+
+        content = source.read_text(encoding="utf-8")
+
+        name = source.stem
+        if name.endswith(".agent"):
+            name = name[: -len(".agent")]
+        description = ""
+        model = ""
+        body = content
+
+        fm_match = AgentIntegrator._FRONTMATTER_RE.match(content)
+        if fm_match:
+            body = content[fm_match.end():]
+            try:
+                import yaml
+
+                fm = yaml.safe_load(fm_match.group(1)) or {}
+                name = fm.get("name", name)
+                description = fm.get("description", description)
+                model = fm.get("model", model)
+            except Exception:
+                pass
+
+        doc: dict = {
+            "name": name,
+            "description": description,
+            "prompt": body.strip(),
+        }
+        if model:
+            doc["model"] = model
+
+        target.write_text(_json.dumps(doc, indent=2), encoding="utf-8")
 
     # DEPRECATED: use integrate_agents_for_target(KNOWN_TARGETS["copilot"], ...) instead.
     def integrate_package_agents(self, package_info, project_root: Path,

--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -400,6 +400,15 @@ class HookIntegrator(BaseIntegrator):
             )
 
         root_dir = target.root_dir if target else ".github"
+
+        # Opt-in guard: targets with auto_create=False skip when their root dir is absent.
+        if target and not getattr(target, "auto_create", True):
+            if not (project_root / root_dir).is_dir():
+                return HookIntegrationResult(
+                    files_integrated=0, files_updated=0,
+                    files_skipped=0, target_paths=[],
+                )
+
         hooks_dir = project_root / root_dir / "hooks"
         hooks_dir.mkdir(parents=True, exist_ok=True)
 
@@ -408,14 +417,17 @@ class HookIntegrator(BaseIntegrator):
         scripts_copied = 0
         target_paths: List[Path] = []
 
+        # Select rewrite target: Kiro uses its own script-path layout;
+        # all other individual-file targets (Copilot) use the VSCode layout.
+        rewrite_target = target.name if target and target.name == "kiro" else "vscode"
+
         for hook_file in hook_files:
             data = self._parse_hook_json(hook_file)
             if data is None:
                 continue
 
-            # Rewrite script paths for VSCode target
             rewritten, scripts = self._rewrite_hooks_data(
-                data, package_info.install_path, package_name, "vscode",
+                data, package_info.install_path, package_name, rewrite_target,
                 hook_file_dir=hook_file.parent,
                 root_dir=root_dir,
             )

--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -96,11 +96,6 @@ _MERGE_HOOK_TARGETS: dict[str, _MergeHookConfig] = {
         target_key="cursor",
         require_dir=True,
     ),
-    "kiro": _MergeHookConfig(
-        config_filename="hooks.json",
-        target_key="kiro",
-        require_dir=True,
-    ),
     "codex": _MergeHookConfig(
         config_filename="hooks.json",
         target_key="codex",
@@ -655,7 +650,7 @@ class HookIntegrator(BaseIntegrator):
         All other merge-based targets are dispatched via the
         ``_MERGE_HOOK_TARGETS`` registry.
         """
-        if target.name == "copilot":
+        if target.name in ("copilot", "kiro"):
             return self.integrate_package_hooks(
                 package_info, project_root,
                 force=force, managed_files=managed_files,

--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -96,6 +96,11 @@ _MERGE_HOOK_TARGETS: dict[str, _MergeHookConfig] = {
         target_key="cursor",
         require_dir=True,
     ),
+    "kiro": _MergeHookConfig(
+        config_filename="hooks.json",
+        target_key="kiro",
+        require_dir=True,
+    ),
     "codex": _MergeHookConfig(
         config_filename="hooks.json",
         target_key="codex",
@@ -224,6 +229,9 @@ class HookIntegrator(BaseIntegrator):
             scripts_base = f"{base_root}/hooks/scripts/{package_name}"
         elif target == "cursor":
             base_root = root_dir or ".cursor"
+            scripts_base = f"{base_root}/hooks/{package_name}"
+        elif target == "kiro":
+            base_root = root_dir or ".kiro"
             scripts_base = f"{base_root}/hooks/{package_name}"
         elif target == "codex":
             base_root = root_dir or ".codex"

--- a/src/apm_cli/integration/instruction_integrator.py
+++ b/src/apm_cli/integration/instruction_integrator.py
@@ -91,7 +91,7 @@ class InstructionIntegrator(BaseIntegrator):
         deploy_dir.mkdir(parents=True, exist_ok=True)
 
         fmt = mapping.format_id
-        needs_rename = fmt in ("cursor_rules", "claude_rules")
+        needs_rename = fmt in ("cursor_rules", "claude_rules", "kiro_steering")
 
         files_integrated = 0
         files_skipped = 0
@@ -121,6 +121,8 @@ class InstructionIntegrator(BaseIntegrator):
                 links_resolved = self.copy_instruction_cursor(source_file, target_path)
             elif fmt == "claude_rules":
                 links_resolved = self.copy_instruction_claude(source_file, target_path)
+            elif fmt == "kiro_steering":
+                links_resolved = self.copy_instruction_kiro(source_file, target_path)
             else:
                 links_resolved = self.copy_instruction(source_file, target_path)
 
@@ -347,6 +349,55 @@ class InstructionIntegrator(BaseIntegrator):
         """
         content = source.read_text(encoding='utf-8')
         content = self._convert_to_claude_rules(content)
+        content, links_resolved = self.resolve_links(content, source, target)
+        target.write_text(content, encoding='utf-8')
+        return links_resolved
+
+    # ------------------------------------------------------------------
+    # Kiro Steering (.md with inclusion/fileMatchPattern frontmatter)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _convert_to_kiro_steering(content: str) -> str:
+        """Convert APM instruction content to Kiro steering ``.md`` format.
+
+        Parses existing YAML frontmatter and maps ``applyTo`` to Kiro's
+        ``inclusion: fileMatch`` + ``fileMatchPattern:`` fields.
+        Instructions without ``applyTo`` get ``inclusion: always``.
+
+        Ref: https://kiro.dev/docs/steering-files/
+        """
+        body = content
+        apply_to = ""
+
+        fm_match = re.match(r'^---\s*\n(.*?)\n---\s*\n?', content, re.DOTALL)
+        if fm_match:
+            fm_block = fm_match.group(1)
+            body = content[fm_match.end():]
+
+            for line in fm_block.splitlines():
+                line_stripped = line.strip()
+                if line_stripped.startswith("applyTo:"):
+                    apply_to = line_stripped[len("applyTo:"):].strip().strip("'\"")
+
+        parts = ["---"]
+        if apply_to:
+            parts.append("inclusion: fileMatch")
+            parts.append(f'fileMatchPattern: "{apply_to}"')
+        else:
+            parts.append("inclusion: always")
+        parts.append("---")
+
+        return "\n".join(parts) + "\n\n" + body.lstrip("\n")
+
+    def copy_instruction_kiro(self, source: Path, target: Path) -> int:
+        """Copy instruction file converted to Kiro steering format.
+
+        Converts ``applyTo:`` to ``inclusion``/``fileMatchPattern:`` frontmatter
+        and resolves links.
+        """
+        content = source.read_text(encoding='utf-8')
+        content = self._convert_to_kiro_steering(content)
         content, links_resolved = self.resolve_links(content, source, target)
         target.write_text(content, encoding='utf-8')
         return links_resolved

--- a/src/apm_cli/integration/instruction_integrator.py
+++ b/src/apm_cli/integration/instruction_integrator.py
@@ -354,53 +354,20 @@ class InstructionIntegrator(BaseIntegrator):
         return links_resolved
 
     # ------------------------------------------------------------------
-    # Kiro Steering (.md with inclusion/fileMatchPattern frontmatter)
+    # Kiro Steering (.md — verbatim, Kiro uses applyTo: natively)
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _convert_to_kiro_steering(content: str) -> str:
-        """Convert APM instruction content to Kiro steering ``.md`` format.
+    def copy_instruction_kiro(self, source: Path, target: Path) -> int:
+        """Copy instruction file verbatim for Kiro steering.
 
-        Parses existing YAML frontmatter and maps ``applyTo`` to Kiro's
-        ``inclusion: fileMatch`` + ``fileMatchPattern:`` fields.
-        Instructions without ``applyTo`` get ``inclusion: always``.
+        Kiro steering files in ``.kiro/steering/`` use the same ``applyTo:``
+        frontmatter field as APM instructions, so no transformation is needed.
+        Only the filename is changed (from ``.instructions.md`` to ``.md``),
+        which is handled by ``integrate_instructions_for_target``.
 
         Ref: https://kiro.dev/docs/steering-files/
         """
-        body = content
-        apply_to = ""
-
-        fm_match = re.match(r'^---\s*\n(.*?)\n---\s*\n?', content, re.DOTALL)
-        if fm_match:
-            fm_block = fm_match.group(1)
-            body = content[fm_match.end():]
-
-            for line in fm_block.splitlines():
-                line_stripped = line.strip()
-                if line_stripped.startswith("applyTo:"):
-                    apply_to = line_stripped[len("applyTo:"):].strip().strip("'\"")
-
-        parts = ["---"]
-        if apply_to:
-            parts.append("inclusion: fileMatch")
-            parts.append(f'fileMatchPattern: "{apply_to}"')
-        else:
-            parts.append("inclusion: always")
-        parts.append("---")
-
-        return "\n".join(parts) + "\n\n" + body.lstrip("\n")
-
-    def copy_instruction_kiro(self, source: Path, target: Path) -> int:
-        """Copy instruction file converted to Kiro steering format.
-
-        Converts ``applyTo:`` to ``inclusion``/``fileMatchPattern:`` frontmatter
-        and resolves links.
-        """
-        content = source.read_text(encoding='utf-8')
-        content = self._convert_to_kiro_steering(content)
-        content, links_resolved = self.resolve_links(content, source, target)
-        target.write_text(content, encoding='utf-8')
-        return links_resolved
+        return self.copy_instruction(source, target)
 
     # DEPRECATED: use integrate_instructions_for_target(KNOWN_TARGETS["claude"], ...) instead.
     def integrate_package_instructions_claude(

--- a/src/apm_cli/integration/mcp_integrator.py
+++ b/src/apm_cli/integration/mcp_integrator.py
@@ -462,7 +462,7 @@ class MCPIntegrator:
             return
 
         # Determine which runtimes to clean, mirroring install-time logic.
-        all_runtimes = {"vscode", "copilot", "codex", "cursor", "opencode"}
+        all_runtimes = {"vscode", "copilot", "codex", "cursor", "kiro", "opencode"}
         if runtime:
             target_runtimes = {runtime}
         else:
@@ -597,6 +597,37 @@ class MCPIntegrator:
                 except Exception:
                     _log.debug(
                         "Failed to clean stale MCP servers from .cursor/mcp.json",
+                        exc_info=True,
+                    )
+
+        # Clean .kiro/mcp.json (only if .kiro/ directory exists)
+        if "kiro" in target_runtimes:
+            kiro_mcp = Path.cwd() / ".kiro" / "mcp.json"
+            if kiro_mcp.exists():
+                try:
+                    import json as _json
+
+                    config = _json.loads(kiro_mcp.read_text(encoding="utf-8"))
+                    servers = config.get("mcpServers", {})
+                    removed = [n for n in expanded_stale if n in servers]
+                    for name in removed:
+                        del servers[name]
+                    if removed:
+                        kiro_mcp.write_text(
+                            _json.dumps(config, indent=2), encoding="utf-8"
+                        )
+                        for name in removed:
+                            if logger:
+                                logger.progress(
+                                    f"Removed stale MCP server '{name}' from .kiro/mcp.json"
+                                )
+                            else:
+                                _rich_info(
+                                    f"+ Removed stale MCP server '{name}' from .kiro/mcp.json"
+                                )
+                except Exception:
+                    _log.debug(
+                        "Failed to clean stale MCP servers from .kiro/mcp.json",
                         exc_info=True,
                     )
 
@@ -930,7 +961,7 @@ class MCPIntegrator:
                 manager = RuntimeManager()
                 installed_runtimes = []
 
-                for runtime_name in ["copilot", "codex", "vscode", "cursor", "opencode"]:
+                for runtime_name in ["copilot", "codex", "vscode", "cursor", "kiro", "opencode"]:
                     try:
                         if runtime_name == "vscode":
                             if _is_vscode_available():
@@ -939,6 +970,11 @@ class MCPIntegrator:
                         elif runtime_name == "cursor":
                             # Cursor is opt-in: only target when .cursor/ exists
                             if (Path.cwd() / ".cursor").is_dir():
+                                ClientFactory.create_client(runtime_name)
+                                installed_runtimes.append(runtime_name)
+                        elif runtime_name == "kiro":
+                            # Kiro is opt-in: only target when .kiro/ exists
+                            if (Path.cwd() / ".kiro").is_dir():
                                 ClientFactory.create_client(runtime_name)
                                 installed_runtimes.append(runtime_name)
                         elif runtime_name == "opencode":
@@ -964,6 +1000,9 @@ class MCPIntegrator:
                 # Cursor is directory-presence based, not binary-based
                 if (Path.cwd() / ".cursor").is_dir():
                     installed_runtimes.append("cursor")
+                # Kiro is directory-presence based
+                if (Path.cwd() / ".kiro").is_dir():
+                    installed_runtimes.append("kiro")
                 # OpenCode is directory-presence based
                 if (Path.cwd() / ".opencode").is_dir():
                     installed_runtimes.append("opencode")

--- a/src/apm_cli/integration/mcp_integrator.py
+++ b/src/apm_cli/integration/mcp_integrator.py
@@ -600,9 +600,9 @@ class MCPIntegrator:
                         exc_info=True,
                     )
 
-        # Clean .kiro/mcp.json (only if .kiro/ directory exists)
+        # Clean .kiro/settings/mcp.json (only if .kiro/ directory exists)
         if "kiro" in target_runtimes:
-            kiro_mcp = Path.cwd() / ".kiro" / "mcp.json"
+            kiro_mcp = Path.cwd() / ".kiro" / "settings" / "mcp.json"
             if kiro_mcp.exists():
                 try:
                     import json as _json
@@ -619,15 +619,15 @@ class MCPIntegrator:
                         for name in removed:
                             if logger:
                                 logger.progress(
-                                    f"Removed stale MCP server '{name}' from .kiro/mcp.json"
+                                    f"Removed stale MCP server '{name}' from .kiro/settings/mcp.json"
                                 )
                             else:
                                 _rich_info(
-                                    f"+ Removed stale MCP server '{name}' from .kiro/mcp.json"
+                                    f"+ Removed stale MCP server '{name}' from .kiro/settings/mcp.json"
                                 )
                 except Exception:
                     _log.debug(
-                        "Failed to clean stale MCP servers from .kiro/mcp.json",
+                        "Failed to clean stale MCP servers from .kiro/settings/mcp.json",
                         exc_info=True,
                     )
 

--- a/src/apm_cli/integration/targets.py
+++ b/src/apm_cli/integration/targets.py
@@ -260,6 +260,28 @@ KNOWN_TARGETS: Dict[str, TargetProfile] = {
         user_root_dir=".config/opencode",
         unsupported_user_primitives=("hooks",),
     ),
+    # Kiro (Amazon) -- spec-driven development editor.
+    # Steering files are the Kiro equivalent of instructions and live in .kiro/steering/.
+    # Skills map to .kiro/skills/ (Kiro native skills), MCP to .kiro/mcp.json,
+    # and hooks to .kiro/hooks/.
+    # Ref: https://kiro.dev/docs/steering-files/
+    "kiro": TargetProfile(
+        name="kiro",
+        root_dir=".kiro",
+        primitives={
+            "instructions": PrimitiveMapping(
+                "steering", ".md", "kiro_steering"
+            ),
+            "skills": PrimitiveMapping(
+                "skills", "/SKILL.md", "skill_standard"
+            ),
+            "hooks": PrimitiveMapping(
+                "hooks", ".json", "kiro_hooks"
+            ),
+        },
+        auto_create=False,
+        detect_by_dir=True,
+    ),
     # Codex CLI: skills use the cross-tool .agents/ dir (agent skills standard),
     # agents are TOML under .codex/agents/, hooks merge into .codex/hooks.json.
     # Instructions are compile-only (AGENTS.md) -- not installed.

--- a/src/apm_cli/integration/targets.py
+++ b/src/apm_cli/integration/targets.py
@@ -272,6 +272,9 @@ KNOWN_TARGETS: Dict[str, TargetProfile] = {
             "instructions": PrimitiveMapping(
                 "steering", ".md", "kiro_steering"
             ),
+            "agents": PrimitiveMapping(
+                "agents", ".json", "kiro_agent"
+            ),
             "skills": PrimitiveMapping(
                 "skills", "/SKILL.md", "skill_standard"
             ),
@@ -281,6 +284,8 @@ KNOWN_TARGETS: Dict[str, TargetProfile] = {
         },
         auto_create=False,
         detect_by_dir=True,
+        user_supported=True,
+        user_root_dir=".kiro",
     ),
     # Codex CLI: skills use the cross-tool .agents/ dir (agent skills standard),
     # agents are TOML under .codex/agents/, hooks merge into .codex/hooks.json.

--- a/tests/unit/integration/test_hook_integrator.py
+++ b/tests/unit/integration/test_hook_integrator.py
@@ -2082,6 +2082,108 @@ class TestCodexHookIntegration:
         assert result.files_integrated == 0
 
 
+# ─── Kiro hook integration tests ─────────────────────────────────────────────
+
+
+class TestKiroHookIntegration:
+    """Tests for Kiro hook integration (.kiro/hooks/ individual JSON files)."""
+
+    @pytest.fixture
+    def temp_project(self):
+        temp_dir = tempfile.mkdtemp()
+        project = Path(temp_dir)
+        (project / ".kiro").mkdir()
+        yield project
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+    def _setup_hookify_package(self, project: Path) -> PackageInfo:
+        pkg_dir = project / "apm_modules" / "anthropics" / "hookify"
+        hooks_dir = pkg_dir / "hooks"
+        hooks_dir.mkdir(parents=True, exist_ok=True)
+        (hooks_dir / "hooks.json").write_text(json.dumps(HOOKIFY_HOOKS_JSON, indent=2))
+        for script in ["pretooluse.py", "posttooluse.py", "stop.py", "userpromptsubmit.py"]:
+            (hooks_dir / script).write_text(f"#!/usr/bin/env python3\n# {script}")
+        return _make_package_info(pkg_dir, "hookify")
+
+    def _kiro_target(self):
+        from apm_cli.integration.targets import KNOWN_TARGETS
+        return KNOWN_TARGETS["kiro"]
+
+    def test_integrate_hookify_kiro(self, temp_project):
+        """Kiro deploys individual JSON files to .kiro/hooks/."""
+        pkg_info = self._setup_hookify_package(temp_project)
+        integrator = HookIntegrator()
+
+        result = integrator.integrate_hooks_for_target(
+            self._kiro_target(), pkg_info, temp_project,
+        )
+
+        assert result.files_integrated == 1
+        assert result.scripts_copied == 4
+
+        target_json = temp_project / ".kiro" / "hooks" / "hookify-hooks.json"
+        assert target_json.exists()
+
+        data = json.loads(target_json.read_text())
+        assert "hooks" in data
+        assert "PreToolUse" in data["hooks"]
+
+        # Script paths must point into .kiro/hooks/ (no scripts/ subdir)
+        cmd = data["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+        assert ".kiro/hooks/hookify/hooks/pretooluse.py" in cmd
+        assert "${CLAUDE_PLUGIN_ROOT}" not in cmd
+
+    def test_skips_when_no_kiro_dir(self, temp_project):
+        """Kiro hooks are not deployed when .kiro/ directory does not exist."""
+        shutil.rmtree(temp_project / ".kiro")
+
+        pkg_info = self._setup_hookify_package(temp_project)
+        integrator = HookIntegrator()
+
+        result = integrator.integrate_hooks_for_target(
+            self._kiro_target(), pkg_info, temp_project,
+        )
+
+        assert result.files_integrated == 0
+        assert not (temp_project / ".kiro").exists()
+
+    def test_scripts_copied_to_kiro_hooks_dir(self, temp_project):
+        """Scripts are copied to .kiro/hooks/<pkg>/ (no scripts/ subdir)."""
+        pkg_info = self._setup_hookify_package(temp_project)
+        integrator = HookIntegrator()
+
+        integrator.integrate_hooks_for_target(
+            self._kiro_target(), pkg_info, temp_project,
+        )
+
+        scripts_dir = temp_project / ".kiro" / "hooks" / "hookify" / "hooks"
+        assert scripts_dir.exists()
+        for script in ["pretooluse.py", "posttooluse.py", "stop.py", "userpromptsubmit.py"]:
+            assert (scripts_dir / script).exists()
+
+    def test_sync_removes_kiro_hook_files(self, temp_project):
+        """sync_integration removes APM-managed Kiro hook files via managed_files."""
+        kiro_hooks = temp_project / ".kiro" / "hooks" / "hookify"
+        kiro_hooks.mkdir(parents=True, exist_ok=True)
+        (kiro_hooks / "pretooluse.py").write_text("# script")
+        hook_json = temp_project / ".kiro" / "hooks" / "hookify-hooks.json"
+        hook_json.write_text(json.dumps({"hooks": {}}))
+
+        integrator = HookIntegrator()
+        managed = {
+            ".kiro/hooks/hookify/pretooluse.py",
+            ".kiro/hooks/hookify-hooks.json",
+        }
+        stats = integrator.sync_integration(
+            None, temp_project, managed_files=managed,
+            targets=[self._kiro_target()],
+        )
+
+        assert stats["files_removed"] == 2
+        assert not hook_json.exists()
+        assert not (kiro_hooks / "pretooluse.py").exists()
+
+
 # ─── Scope-resolved target tests (PR #566 rework) ────────────────────────────
 
 

--- a/tests/unit/test_kiro_mcp.py
+++ b/tests/unit/test_kiro_mcp.py
@@ -1,0 +1,290 @@
+"""Unit tests for KiroClientAdapter and its MCP integrator wiring."""
+
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from apm_cli.adapters.client.kiro import KiroClientAdapter
+from apm_cli.factory import ClientFactory
+
+
+class TestKiroClientFactory(unittest.TestCase):
+    """Factory registration for the kiro runtime."""
+
+    def test_create_kiro_client(self):
+        client = ClientFactory.create_client("kiro")
+        self.assertIsInstance(client, KiroClientAdapter)
+
+    def test_create_kiro_client_case_insensitive(self):
+        client = ClientFactory.create_client("Kiro")
+        self.assertIsInstance(client, KiroClientAdapter)
+
+
+class TestKiroClientAdapter(unittest.TestCase):
+    """Core adapter behaviour."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.kiro_dir = Path(self.tmp.name) / ".kiro"
+        self.kiro_dir.mkdir()
+        self.mcp_json = self.kiro_dir / "mcp.json"
+
+        self.adapter = KiroClientAdapter()
+        self._cwd_patcher = patch("os.getcwd", return_value=self.tmp.name)
+        self._cwd_patcher.start()
+
+    def tearDown(self):
+        self._cwd_patcher.stop()
+        self.tmp.cleanup()
+
+    # -- config path --
+
+    def test_config_path_is_repo_local(self):
+        path = self.adapter.get_config_path()
+        self.assertEqual(path, str(self.mcp_json))
+
+    def test_supports_user_scope_is_false(self):
+        self.assertFalse(self.adapter.supports_user_scope)
+
+    # -- get_current_config --
+
+    def test_get_current_config_missing_file(self):
+        self.assertEqual(self.adapter.get_current_config(), {})
+
+    def test_get_current_config_existing_file(self):
+        self.mcp_json.write_text(
+            json.dumps({"mcpServers": {"s": {"command": "x"}}}),
+            encoding="utf-8",
+        )
+        cfg = self.adapter.get_current_config()
+        self.assertIn("mcpServers", cfg)
+        self.assertIn("s", cfg["mcpServers"])
+
+    # -- update_config --
+
+    def test_update_config_creates_file(self):
+        self.adapter.update_config({"my-server": {"command": "npx", "args": ["-y", "pkg"]}})
+        data = json.loads(self.mcp_json.read_text(encoding="utf-8"))
+        self.assertEqual(data["mcpServers"]["my-server"]["command"], "npx")
+
+    def test_update_config_merges_existing(self):
+        self.mcp_json.write_text(
+            json.dumps({"mcpServers": {"old": {"command": "old-cmd"}}}),
+            encoding="utf-8",
+        )
+        self.adapter.update_config({"new": {"command": "new-cmd"}})
+        data = json.loads(self.mcp_json.read_text(encoding="utf-8"))
+        self.assertIn("old", data["mcpServers"])
+        self.assertIn("new", data["mcpServers"])
+
+    def test_update_config_noop_when_kiro_dir_missing(self):
+        """If .kiro/ doesn't exist, update_config should silently skip."""
+        self.kiro_dir.rmdir()
+        self.adapter.update_config({"s": {"command": "x"}})
+        self.assertFalse(self.mcp_json.exists())
+
+    # -- configure_mcp_server --
+
+    @patch("apm_cli.registry.client.SimpleRegistryClient.find_server_by_reference")
+    def test_configure_mcp_server_basic(self, mock_find):
+        mock_find.return_value = {
+            "id": "test-id",
+            "name": "test-server",
+            "packages": [{"registry_name": "npm", "name": "test-pkg", "arguments": []}],
+            "environment_variables": [],
+        }
+        ok = self.adapter.configure_mcp_server("test-server", "my-srv")
+        self.assertTrue(ok)
+        data = json.loads(self.mcp_json.read_text(encoding="utf-8"))
+        self.assertIn("my-srv", data["mcpServers"])
+        self.assertEqual(data["mcpServers"]["my-srv"]["command"], "npx")
+
+    @patch("apm_cli.registry.client.SimpleRegistryClient.find_server_by_reference")
+    def test_configure_mcp_server_name_extraction(self, mock_find):
+        mock_find.return_value = {
+            "id": "id",
+            "name": "srv",
+            "packages": [{"registry_name": "npm", "name": "pkg"}],
+            "environment_variables": [],
+        }
+        self.adapter.configure_mcp_server("org/my-mcp-server")
+        data = json.loads(self.mcp_json.read_text(encoding="utf-8"))
+        self.assertIn("my-mcp-server", data["mcpServers"])
+
+    def test_configure_mcp_server_skips_when_no_kiro_dir(self):
+        """Should return True (not an error) when .kiro/ doesn't exist."""
+        self.kiro_dir.rmdir()
+        result = self.adapter.configure_mcp_server("some-server")
+        self.assertTrue(result)
+
+    def test_configure_mcp_server_empty_url(self):
+        result = self.adapter.configure_mcp_server("")
+        self.assertFalse(result)
+
+
+class TestMCPIntegratorKiroStaleCleanup(unittest.TestCase):
+    """remove_stale() cleans .kiro/mcp.json."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.kiro_dir = Path(self.tmp.name) / ".kiro"
+        self.kiro_dir.mkdir()
+        self.mcp_json = self.kiro_dir / "mcp.json"
+
+        self._cwd_patcher = patch(
+            "apm_cli.integration.mcp_integrator.Path.cwd",
+            return_value=Path(self.tmp.name),
+        )
+        self._cwd_patcher.start()
+
+    def tearDown(self):
+        self._cwd_patcher.stop()
+        self.tmp.cleanup()
+
+    def test_remove_stale_kiro(self):
+        from apm_cli.integration.mcp_integrator import MCPIntegrator
+
+        self.mcp_json.write_text(
+            json.dumps({"mcpServers": {"keep": {"command": "k"}, "stale": {"command": "s"}}}),
+            encoding="utf-8",
+        )
+        MCPIntegrator.remove_stale({"stale"}, runtime="kiro")
+        data = json.loads(self.mcp_json.read_text(encoding="utf-8"))
+        self.assertIn("keep", data["mcpServers"])
+        self.assertNotIn("stale", data["mcpServers"])
+
+    def test_remove_stale_kiro_noop_when_no_file(self):
+        """Should not fail when .kiro/mcp.json doesn't exist."""
+        from apm_cli.integration.mcp_integrator import MCPIntegrator
+
+        MCPIntegrator.remove_stale({"stale"}, runtime="kiro")
+        # No exception is the assertion
+
+
+class TestKiroTargetProfile(unittest.TestCase):
+    """Kiro entry in KNOWN_TARGETS."""
+
+    def test_kiro_in_known_targets(self):
+        from apm_cli.integration.targets import KNOWN_TARGETS
+
+        self.assertIn("kiro", KNOWN_TARGETS)
+
+    def test_kiro_root_dir(self):
+        from apm_cli.integration.targets import KNOWN_TARGETS
+
+        self.assertEqual(KNOWN_TARGETS["kiro"].root_dir, ".kiro")
+
+    def test_kiro_supports_instructions(self):
+        from apm_cli.integration.targets import KNOWN_TARGETS
+
+        target = KNOWN_TARGETS["kiro"]
+        self.assertIn("instructions", target.primitives)
+        mapping = target.primitives["instructions"]
+        self.assertEqual(mapping.subdir, "steering")
+        self.assertEqual(mapping.extension, ".md")
+        self.assertEqual(mapping.format_id, "kiro_steering")
+
+    def test_kiro_supports_skills(self):
+        from apm_cli.integration.targets import KNOWN_TARGETS
+
+        target = KNOWN_TARGETS["kiro"]
+        self.assertIn("skills", target.primitives)
+        self.assertEqual(target.primitives["skills"].format_id, "skill_standard")
+
+    def test_kiro_supports_hooks(self):
+        from apm_cli.integration.targets import KNOWN_TARGETS
+
+        target = KNOWN_TARGETS["kiro"]
+        self.assertIn("hooks", target.primitives)
+
+    def test_kiro_detect_by_dir(self):
+        from apm_cli.integration.targets import KNOWN_TARGETS
+
+        self.assertTrue(KNOWN_TARGETS["kiro"].detect_by_dir)
+
+    def test_kiro_no_user_scope(self):
+        from apm_cli.integration.targets import KNOWN_TARGETS
+
+        self.assertFalse(KNOWN_TARGETS["kiro"].user_supported)
+
+
+class TestKiroSteeringConverter(unittest.TestCase):
+    """_convert_to_kiro_steering content transforms."""
+
+    def _convert(self, content):
+        from apm_cli.integration.instruction_integrator import InstructionIntegrator
+        return InstructionIntegrator._convert_to_kiro_steering(content)
+
+    def test_no_frontmatter_gets_always_inclusion(self):
+        result = self._convert("# My rule\n\nsome content")
+        self.assertIn("inclusion: always", result)
+        self.assertIn("# My rule", result)
+
+    def test_apply_to_maps_to_file_match(self):
+        content = "---\napplyTo: '**/*.ts'\n---\n\n# TypeScript rules\n"
+        result = self._convert(content)
+        self.assertIn("inclusion: fileMatch", result)
+        self.assertIn('fileMatchPattern: "**/*.ts"', result)
+        self.assertIn("# TypeScript rules", result)
+
+    def test_apply_to_not_present_gives_always(self):
+        content = "---\ndescription: My rule\n---\n\nBody text\n"
+        result = self._convert(content)
+        self.assertIn("inclusion: always", result)
+        self.assertNotIn("fileMatchPattern", result)
+
+    def test_body_preserved(self):
+        content = "---\napplyTo: '**/*.py'\n---\n\nDo not use globals.\n"
+        result = self._convert(content)
+        self.assertIn("Do not use globals.", result)
+
+
+class TestTargetDetectionKiro(unittest.TestCase):
+    """target_detection.py recognises .kiro/ folders."""
+
+    def test_should_integrate_kiro(self):
+        from apm_cli.core.target_detection import should_integrate_kiro
+        self.assertTrue(should_integrate_kiro("kiro"))
+        self.assertTrue(should_integrate_kiro("all"))
+        self.assertFalse(should_integrate_kiro("claude"))
+        self.assertFalse(should_integrate_kiro("vscode"))
+
+    def test_kiro_in_all_canonical_targets(self):
+        from apm_cli.core.target_detection import ALL_CANONICAL_TARGETS
+        self.assertIn("kiro", ALL_CANONICAL_TARGETS)
+
+    def test_detect_target_explicit_kiro(self):
+        from pathlib import Path
+        from apm_cli.core.target_detection import detect_target
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target, reason = detect_target(Path(tmp), explicit_target="kiro")
+        self.assertEqual(target, "kiro")
+        self.assertIn("explicit", reason)
+
+    def test_detect_target_auto_kiro(self):
+        from pathlib import Path
+        from apm_cli.core.target_detection import detect_target
+
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / ".kiro").mkdir()
+            target, reason = detect_target(Path(tmp))
+        self.assertEqual(target, "kiro")
+        self.assertIn(".kiro/", reason)
+
+    def test_detect_target_kiro_in_all(self):
+        from pathlib import Path
+        from apm_cli.core.target_detection import detect_target
+
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / ".kiro").mkdir()
+            (Path(tmp) / ".github").mkdir()
+            target, _ = detect_target(Path(tmp))
+        self.assertEqual(target, "all")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_kiro_mcp.py
+++ b/tests/unit/test_kiro_mcp.py
@@ -30,7 +30,9 @@ class TestKiroClientAdapter(unittest.TestCase):
         self.tmp = tempfile.TemporaryDirectory()
         self.kiro_dir = Path(self.tmp.name) / ".kiro"
         self.kiro_dir.mkdir()
-        self.mcp_json = self.kiro_dir / "mcp.json"
+        self.settings_dir = self.kiro_dir / "settings"
+        self.settings_dir.mkdir()
+        self.mcp_json = self.settings_dir / "mcp.json"
 
         self.adapter = KiroClientAdapter()
         self._cwd_patcher = patch("os.getcwd", return_value=self.tmp.name)
@@ -40,14 +42,22 @@ class TestKiroClientAdapter(unittest.TestCase):
         self._cwd_patcher.stop()
         self.tmp.cleanup()
 
+    # -- supports_user_scope --
+
+    def test_supports_user_scope_is_true(self):
+        """Kiro supports both project and global (~/.kiro/) scope."""
+        self.assertTrue(self.adapter.supports_user_scope)
+
     # -- config path --
 
-    def test_config_path_is_repo_local(self):
+    def test_config_path_is_in_settings_subdir(self):
+        """MCP config lives at .kiro/settings/mcp.json, not .kiro/mcp.json."""
         path = self.adapter.get_config_path()
         self.assertEqual(path, str(self.mcp_json))
 
-    def test_supports_user_scope_is_false(self):
-        self.assertFalse(self.adapter.supports_user_scope)
+    def test_config_path_user_scope(self):
+        expected = str(Path.home() / ".kiro" / "settings" / "mcp.json")
+        self.assertEqual(self.adapter.get_config_path(user_scope=True), expected)
 
     # -- get_current_config --
 
@@ -65,7 +75,7 @@ class TestKiroClientAdapter(unittest.TestCase):
 
     # -- update_config --
 
-    def test_update_config_creates_file(self):
+    def test_update_config_creates_file_in_settings_subdir(self):
         self.adapter.update_config({"my-server": {"command": "npx", "args": ["-y", "pkg"]}})
         data = json.loads(self.mcp_json.read_text(encoding="utf-8"))
         self.assertEqual(data["mcpServers"]["my-server"]["command"], "npx")
@@ -81,10 +91,18 @@ class TestKiroClientAdapter(unittest.TestCase):
         self.assertIn("new", data["mcpServers"])
 
     def test_update_config_noop_when_kiro_dir_missing(self):
-        """If .kiro/ doesn't exist, update_config should silently skip."""
-        self.kiro_dir.rmdir()
+        """If .kiro/ doesn't exist at all, update_config should silently skip."""
+        import shutil
+        shutil.rmtree(self.kiro_dir)
         self.adapter.update_config({"s": {"command": "x"}})
         self.assertFalse(self.mcp_json.exists())
+
+    def test_update_config_creates_settings_subdir_if_missing(self):
+        """settings/ subdir is auto-created inside an existing .kiro/."""
+        import shutil
+        shutil.rmtree(self.settings_dir)
+        self.adapter.update_config({"s": {"command": "x"}})
+        self.assertTrue(self.mcp_json.exists())
 
     # -- configure_mcp_server --
 
@@ -116,7 +134,8 @@ class TestKiroClientAdapter(unittest.TestCase):
 
     def test_configure_mcp_server_skips_when_no_kiro_dir(self):
         """Should return True (not an error) when .kiro/ doesn't exist."""
-        self.kiro_dir.rmdir()
+        import shutil
+        shutil.rmtree(self.kiro_dir)
         result = self.adapter.configure_mcp_server("some-server")
         self.assertTrue(result)
 
@@ -126,13 +145,14 @@ class TestKiroClientAdapter(unittest.TestCase):
 
 
 class TestMCPIntegratorKiroStaleCleanup(unittest.TestCase):
-    """remove_stale() cleans .kiro/mcp.json."""
+    """remove_stale() cleans .kiro/settings/mcp.json."""
 
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()
         self.kiro_dir = Path(self.tmp.name) / ".kiro"
-        self.kiro_dir.mkdir()
-        self.mcp_json = self.kiro_dir / "mcp.json"
+        self.settings_dir = self.kiro_dir / "settings"
+        self.settings_dir.mkdir(parents=True)
+        self.mcp_json = self.settings_dir / "mcp.json"
 
         self._cwd_patcher = patch(
             "apm_cli.integration.mcp_integrator.Path.cwd",
@@ -157,11 +177,10 @@ class TestMCPIntegratorKiroStaleCleanup(unittest.TestCase):
         self.assertNotIn("stale", data["mcpServers"])
 
     def test_remove_stale_kiro_noop_when_no_file(self):
-        """Should not fail when .kiro/mcp.json doesn't exist."""
+        """Should not fail when .kiro/settings/mcp.json doesn't exist."""
         from apm_cli.integration.mcp_integrator import MCPIntegrator
 
         MCPIntegrator.remove_stale({"stale"}, runtime="kiro")
-        # No exception is the assertion
 
 
 class TestKiroTargetProfile(unittest.TestCase):
@@ -169,77 +188,151 @@ class TestKiroTargetProfile(unittest.TestCase):
 
     def test_kiro_in_known_targets(self):
         from apm_cli.integration.targets import KNOWN_TARGETS
-
         self.assertIn("kiro", KNOWN_TARGETS)
 
     def test_kiro_root_dir(self):
         from apm_cli.integration.targets import KNOWN_TARGETS
-
         self.assertEqual(KNOWN_TARGETS["kiro"].root_dir, ".kiro")
 
-    def test_kiro_supports_instructions(self):
+    def test_kiro_supports_instructions_to_steering(self):
         from apm_cli.integration.targets import KNOWN_TARGETS
-
         target = KNOWN_TARGETS["kiro"]
         self.assertIn("instructions", target.primitives)
-        mapping = target.primitives["instructions"]
-        self.assertEqual(mapping.subdir, "steering")
-        self.assertEqual(mapping.extension, ".md")
-        self.assertEqual(mapping.format_id, "kiro_steering")
+        m = target.primitives["instructions"]
+        self.assertEqual(m.subdir, "steering")
+        self.assertEqual(m.extension, ".md")
+        self.assertEqual(m.format_id, "kiro_steering")
+
+    def test_kiro_supports_agents(self):
+        from apm_cli.integration.targets import KNOWN_TARGETS
+        target = KNOWN_TARGETS["kiro"]
+        self.assertIn("agents", target.primitives)
+        m = target.primitives["agents"]
+        self.assertEqual(m.subdir, "agents")
+        self.assertEqual(m.extension, ".json")
+        self.assertEqual(m.format_id, "kiro_agent")
 
     def test_kiro_supports_skills(self):
         from apm_cli.integration.targets import KNOWN_TARGETS
-
         target = KNOWN_TARGETS["kiro"]
         self.assertIn("skills", target.primitives)
         self.assertEqual(target.primitives["skills"].format_id, "skill_standard")
 
     def test_kiro_supports_hooks(self):
         from apm_cli.integration.targets import KNOWN_TARGETS
-
         target = KNOWN_TARGETS["kiro"]
         self.assertIn("hooks", target.primitives)
 
     def test_kiro_detect_by_dir(self):
         from apm_cli.integration.targets import KNOWN_TARGETS
-
         self.assertTrue(KNOWN_TARGETS["kiro"].detect_by_dir)
 
-    def test_kiro_no_user_scope(self):
+    def test_kiro_user_scope_supported(self):
         from apm_cli.integration.targets import KNOWN_TARGETS
+        self.assertTrue(KNOWN_TARGETS["kiro"].user_supported)
 
-        self.assertFalse(KNOWN_TARGETS["kiro"].user_supported)
+    def test_kiro_user_root_dir(self):
+        from apm_cli.integration.targets import KNOWN_TARGETS
+        self.assertEqual(KNOWN_TARGETS["kiro"].user_root_dir, ".kiro")
+
+    def test_kiro_for_user_scope_returns_scoped_profile(self):
+        from apm_cli.integration.targets import KNOWN_TARGETS
+        scoped = KNOWN_TARGETS["kiro"].for_scope(user_scope=True)
+        self.assertIsNotNone(scoped)
+        self.assertEqual(scoped.root_dir, ".kiro")
 
 
-class TestKiroSteeringConverter(unittest.TestCase):
-    """_convert_to_kiro_steering content transforms."""
+class TestKiroSteeringIsVerbatim(unittest.TestCase):
+    """kiro_steering format should copy content verbatim (Kiro uses applyTo: natively)."""
 
-    def _convert(self, content):
+    def test_kiro_steering_preserves_apply_to(self):
         from apm_cli.integration.instruction_integrator import InstructionIntegrator
-        return InstructionIntegrator._convert_to_kiro_steering(content)
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "coding.instructions.md"
+            dst = Path(tmp) / "coding.md"
+            content = "---\napplyTo: '**/*.ts'\n---\n\nUse strict TypeScript.\n"
+            src.write_text(content, encoding="utf-8")
 
-    def test_no_frontmatter_gets_always_inclusion(self):
-        result = self._convert("# My rule\n\nsome content")
-        self.assertIn("inclusion: always", result)
-        self.assertIn("# My rule", result)
+            ii = InstructionIntegrator()
+            ii.copy_instruction_kiro(src, dst)
+            result = dst.read_text(encoding="utf-8")
 
-    def test_apply_to_maps_to_file_match(self):
-        content = "---\napplyTo: '**/*.ts'\n---\n\n# TypeScript rules\n"
-        result = self._convert(content)
-        self.assertIn("inclusion: fileMatch", result)
-        self.assertIn('fileMatchPattern: "**/*.ts"', result)
-        self.assertIn("# TypeScript rules", result)
+        # applyTo: should be preserved verbatim — no conversion to inclusion/fileMatchPattern
+        self.assertIn("applyTo:", result)
+        self.assertNotIn("inclusion:", result)
+        self.assertNotIn("fileMatchPattern:", result)
+        self.assertIn("Use strict TypeScript.", result)
 
-    def test_apply_to_not_present_gives_always(self):
-        content = "---\ndescription: My rule\n---\n\nBody text\n"
-        result = self._convert(content)
-        self.assertIn("inclusion: always", result)
-        self.assertNotIn("fileMatchPattern", result)
+    def test_kiro_steering_preserves_no_frontmatter(self):
+        from apm_cli.integration.instruction_integrator import InstructionIntegrator
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "general.instructions.md"
+            dst = Path(tmp) / "general.md"
+            content = "# General rules\n\nAlways write tests.\n"
+            src.write_text(content, encoding="utf-8")
 
-    def test_body_preserved(self):
-        content = "---\napplyTo: '**/*.py'\n---\n\nDo not use globals.\n"
-        result = self._convert(content)
-        self.assertIn("Do not use globals.", result)
+            ii = InstructionIntegrator()
+            ii.copy_instruction_kiro(src, dst)
+            result = dst.read_text(encoding="utf-8")
+
+        self.assertEqual(result, content)
+
+
+class TestKiroAgentWriter(unittest.TestCase):
+    """_write_kiro_agent converts .agent.md to Kiro JSON agent format."""
+
+    def test_basic_conversion(self):
+        from apm_cli.integration.agent_integrator import AgentIntegrator
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "my-agent.agent.md"
+            dst = Path(tmp) / "my-agent.json"
+            src.write_text(
+                "---\nname: My Agent\ndescription: A helpful agent\n---\n\nDo great things.\n",
+                encoding="utf-8",
+            )
+            AgentIntegrator._write_kiro_agent(src, dst)
+            data = json.loads(dst.read_text(encoding="utf-8"))
+
+        self.assertEqual(data["name"], "My Agent")
+        self.assertEqual(data["description"], "A helpful agent")
+        self.assertIn("Do great things.", data["prompt"])
+
+    def test_model_field_included_when_present(self):
+        from apm_cli.integration.agent_integrator import AgentIntegrator
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "agent.agent.md"
+            dst = Path(tmp) / "agent.json"
+            src.write_text(
+                "---\nname: agent\ndescription: desc\nmodel: claude-sonnet-4\n---\n\nBody.\n",
+                encoding="utf-8",
+            )
+            AgentIntegrator._write_kiro_agent(src, dst)
+            data = json.loads(dst.read_text(encoding="utf-8"))
+
+        self.assertEqual(data["model"], "claude-sonnet-4")
+
+    def test_no_frontmatter(self):
+        from apm_cli.integration.agent_integrator import AgentIntegrator
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "plain-agent.agent.md"
+            dst = Path(tmp) / "plain-agent.json"
+            src.write_text("# Plain agent\n\nDo things.\n", encoding="utf-8")
+            AgentIntegrator._write_kiro_agent(src, dst)
+            data = json.loads(dst.read_text(encoding="utf-8"))
+
+        self.assertEqual(data["name"], "plain-agent")
+        self.assertIn("Plain agent", data["prompt"])
+
+    def test_model_omitted_when_not_in_frontmatter(self):
+        from apm_cli.integration.agent_integrator import AgentIntegrator
+        with tempfile.TemporaryDirectory() as tmp:
+            src = Path(tmp) / "agent.agent.md"
+            dst = Path(tmp) / "agent.json"
+            src.write_text("---\nname: agent\ndescription: d\n---\n\nBody.\n", encoding="utf-8")
+            AgentIntegrator._write_kiro_agent(src, dst)
+            data = json.loads(dst.read_text(encoding="utf-8"))
+
+        self.assertNotIn("model", data)
 
 
 class TestTargetDetectionKiro(unittest.TestCase):
@@ -257,33 +350,32 @@ class TestTargetDetectionKiro(unittest.TestCase):
         self.assertIn("kiro", ALL_CANONICAL_TARGETS)
 
     def test_detect_target_explicit_kiro(self):
-        from pathlib import Path
-        from apm_cli.core.target_detection import detect_target
-
         with tempfile.TemporaryDirectory() as tmp:
+            from apm_cli.core.target_detection import detect_target
             target, reason = detect_target(Path(tmp), explicit_target="kiro")
         self.assertEqual(target, "kiro")
         self.assertIn("explicit", reason)
 
     def test_detect_target_auto_kiro(self):
-        from pathlib import Path
-        from apm_cli.core.target_detection import detect_target
-
         with tempfile.TemporaryDirectory() as tmp:
+            from apm_cli.core.target_detection import detect_target
             (Path(tmp) / ".kiro").mkdir()
             target, reason = detect_target(Path(tmp))
         self.assertEqual(target, "kiro")
         self.assertIn(".kiro/", reason)
 
-    def test_detect_target_kiro_in_all(self):
-        from pathlib import Path
-        from apm_cli.core.target_detection import detect_target
-
+    def test_detect_target_kiro_in_all_when_multiple_dirs(self):
         with tempfile.TemporaryDirectory() as tmp:
+            from apm_cli.core.target_detection import detect_target
             (Path(tmp) / ".kiro").mkdir()
             (Path(tmp) / ".github").mkdir()
             target, _ = detect_target(Path(tmp))
         self.assertEqual(target, "all")
+
+    def test_kiro_target_description_contains_paths(self):
+        from apm_cli.core.target_detection import get_target_description
+        desc = get_target_description("kiro")
+        self.assertIn(".kiro/", desc)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #702

## Summary

Full Kiro IDE/CLI support for APM:

- **Instructions**: Deploy to `.kiro/steering/` verbatim (Kiro uses `applyTo:` natively — no conversion needed)
- **Agents**: Convert `.agent.md` → `.kiro/agents/*.json` (Kiro's JSON agent format)
- **Hooks**: Deploy individual JSON files to `.kiro/hooks/` with correct script path rewriting
- **Skills**: Standard `SKILL.md` deployment to `.kiro/skills/`
- **MCP**: Full config support at `.kiro/settings/mcp.json` (project) and `~/.kiro/settings/mcp.json` (global)
- **Auto-detection**: `.kiro/` directory presence triggers Kiro target automatically
- **User scope**: `--global` deploys to `~/.kiro/` alongside other global tools

43 tests added covering all new behaviour.
