### PR TITLE
docs(compile): clarify target routing docstring

### DIFF
--- a/src/apm_cli/commands/compile/cli.py
+++ b/src/apm_cli/commands/compile/cli.py
@@ -164,10 +164,14 @@ def _get_validation_suggestion(error_msg):
 
 
 def _resolve_compile_target(target):
-    """Map CLI target input to compiler-understood target string.
+    """Map CLI target input to a compiler/detection target string.
 
-    The compiler only understands ``"vscode"``, ``"claude"``, and ``"all"``.
-    Multi-target lists are mapped to the narrowest equivalent.
+    Single targets are passed through unchanged. Multi-target lists are mapped
+    to the narrowest equivalent routing target:
+
+    - any AGENTS-family target only -> ``"vscode"``
+    - ``"claude"`` only -> ``"claude"``
+    - AGENTS-family target(s) plus ``"claude"`` -> ``"all"``
 
     Args:
         target: A single target string, a list of target strings, or ``None``.


### PR DESCRIPTION
This follow-up docs fix clarifies `_resolve_compile_target()` to match the current target-routing behavior.

## What changed
- removed the outdated statement that the compiler only understands `"vscode"`, `"claude"`, and `"all"`
- documented how single targets pass through unchanged
- documented how multi-target lists collapse to `"vscode"`, `"claude"`, or `"all"`

## Validation
- `PYTHONPATH=src uv run pytest tests/unit/compilation/test_compile_target_flag.py -x`
