### PR TITLE
fix(workflows): gate pr-review-panel on panel-review label at pre-activation

### DIFF
--- a/.github/workflows/pr-review-panel.lock.yml
+++ b/.github/workflows/pr-review-panel.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"7d07172bee3f1898f2e45a8bd63bdcb115a1ad4cee0285f6ec7df4b9b7c2da95","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"a8730b9c31fe50d5a50ee9d99212bc6da387fc069501aa0a425bdd8951ba9541","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_PLUGINS_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"},{"repo":"microsoft/apm-action","sha":"9fe9337ef58b5e620e0113071ceb47a6a8a232f7","version":"v1.4.2"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -61,6 +61,23 @@ name: "PR Review Panel"
   # - admin # Roles processed as role check in pre-activation job
   # - maintainer # Roles processed as role check in pre-activation job
   # - write # Roles processed as role check in pre-activation job
+  # steps: # Steps injected into pre-activation job
+  # - env:
+      # EVENT_NAME: ${{ github.event_name }}
+      # LABEL_NAME: ${{ github.event.label.name }}
+    # id: label_check
+    # name: Filter on panel-review label
+    # run: |
+      # if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+        # echo "Manual workflow_dispatch -- proceeding."
+        # exit 0
+      # fi
+      # if [ "$LABEL_NAME" = "panel-review" ]; then
+        # echo "Triggering label is 'panel-review' -- proceeding."
+        # exit 0
+      # fi
+      # echo "Triggering label is '$LABEL_NAME' (not 'panel-review'); skipping."
+      # exit 1
   workflow_dispatch:
     inputs:
       aw_context:
@@ -188,7 +205,6 @@ jobs:
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
           GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
-          GH_AW_GITHUB_EVENT_NAME: ${{ github.event_name }}
           GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
@@ -197,14 +213,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_9b70ff9898f5f7d2_EOF'
+          cat << 'GH_AW_PROMPT_daad15abf8de7f2c_EOF'
           <system>
-          GH_AW_PROMPT_9b70ff9898f5f7d2_EOF
+          GH_AW_PROMPT_daad15abf8de7f2c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9b70ff9898f5f7d2_EOF'
+          cat << 'GH_AW_PROMPT_daad15abf8de7f2c_EOF'
           <safe-output-tools>
           Tools: add_comment(max:7), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -236,22 +252,21 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_9b70ff9898f5f7d2_EOF
+          GH_AW_PROMPT_daad15abf8de7f2c_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_9b70ff9898f5f7d2_EOF'
+          cat << 'GH_AW_PROMPT_daad15abf8de7f2c_EOF'
           </system>
           
           
           
           {{#runtime-import .github/workflows/pr-review-panel.md}}
-          GH_AW_PROMPT_9b70ff9898f5f7d2_EOF
+          GH_AW_PROMPT_daad15abf8de7f2c_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         env:
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_EXPR_A0E5D436: ${{ github.event.pull_request.number || inputs.pr_number }}
-          GH_AW_GITHUB_EVENT_NAME: ${{ github.event_name }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
         with:
           script: |
@@ -268,7 +283,6 @@ jobs:
           GH_AW_GITHUB_EVENT_COMMENT_ID: ${{ github.event.comment.id }}
           GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
           GH_AW_GITHUB_EVENT_ISSUE_NUMBER: ${{ github.event.issue.number }}
-          GH_AW_GITHUB_EVENT_NAME: ${{ github.event_name }}
           GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
           GH_AW_GITHUB_REPOSITORY: ${{ github.repository }}
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
@@ -290,7 +304,6 @@ jobs:
                 GH_AW_GITHUB_EVENT_COMMENT_ID: process.env.GH_AW_GITHUB_EVENT_COMMENT_ID,
                 GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER: process.env.GH_AW_GITHUB_EVENT_DISCUSSION_NUMBER,
                 GH_AW_GITHUB_EVENT_ISSUE_NUMBER: process.env.GH_AW_GITHUB_EVENT_ISSUE_NUMBER,
-                GH_AW_GITHUB_EVENT_NAME: process.env.GH_AW_GITHUB_EVENT_NAME,
                 GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER: process.env.GH_AW_GITHUB_EVENT_PULL_REQUEST_NUMBER,
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
@@ -437,9 +450,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_f819ea2bf38c25a8_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_f053aa54733793da_EOF'
           {"add_comment":{"max":7},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_f819ea2bf38c25a8_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_f053aa54733793da_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -623,7 +636,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_2b3d00b802971123_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_f34a70f444ade5b1_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -664,7 +677,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_2b3d00b802971123_EOF
+          GH_AW_MCP_CONFIG_f34a70f444ade5b1_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1197,6 +1210,7 @@ jobs:
     runs-on: ubuntu-slim
     outputs:
       activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
+      label_check_result: ${{ steps.label_check.outcome }}
       matched_command: ''
       setup-trace-id: ${{ steps.setup.outputs.trace-id }}
     steps:
@@ -1218,6 +1232,22 @@ jobs:
             setupGlobals(core, github, context, exec, io, getOctokit);
             const { main } = require('${{ runner.temp }}/gh-aw/actions/check_membership.cjs');
             await main();
+      - name: Filter on panel-review label
+        id: label_check
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "Manual workflow_dispatch -- proceeding."
+            exit 0
+          fi
+          if [ "$LABEL_NAME" = "panel-review" ]; then
+            echo "Triggering label is 'panel-review' -- proceeding."
+            exit 0
+          fi
+          echo "Triggering label is '$LABEL_NAME' (not 'panel-review'); skipping."
+          exit 1
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          LABEL_NAME: ${{ github.event.label.name }}
 
   safe_outputs:
     needs:

--- a/.github/workflows/pr-review-panel.md
+++ b/.github/workflows/pr-review-panel.md
@@ -6,9 +6,17 @@ description: Multi-persona expert panel review of labelled PRs, posting a single
 #
 # 1. pull_request_target: fires when a label is applied. We use _target
 #    (not plain pull_request) so that fork PRs run in the BASE repo
-#    context with full secrets (COPILOT_GITHUB_TOKEN etc.). The label
-#    name is filtered inside the prompt (Step 0) -- gh-aw does not
-#    expose `names:` on pull_request_target.
+#    context with full secrets (COPILOT_GITHUB_TOKEN etc.). gh-aw does
+#    not expose `names:` on `pull_request_target`, so the label-name
+#    filter is enforced via `on.steps:` -- a pre-activation step that
+#    exits non-zero for any label other than `panel-review`. This kills
+#    the entire downstream pipeline (activation, apm bundle restore,
+#    agent container) at the cheapest possible point. Previously the
+#    label check lived inside the agent prompt, which (a) cost a full
+#    runner cold-start + agent spin-up per label change on every PR in
+#    the repo, and (b) relied on the LLM honoring an "exit 0" prompt
+#    instruction -- not always reliable. The pre-activation step is a
+#    deterministic gate.
 #
 #    Why pull_request_target is safe here despite the well-known
 #    "pwn-request" pattern:
@@ -41,6 +49,23 @@ on:
         description: "Pull request number to review (works for fork PRs)"
         required: true
         type: string
+  steps:
+    - name: Filter on panel-review label
+      id: label_check
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        LABEL_NAME: ${{ github.event.label.name }}
+      run: |
+        if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+          echo "Manual workflow_dispatch -- proceeding."
+          exit 0
+        fi
+        if [ "$LABEL_NAME" = "panel-review" ]; then
+          echo "Triggering label is 'panel-review' -- proceeding."
+          exit 0
+        fi
+        echo "Triggering label is '$LABEL_NAME' (not 'panel-review'); skipping."
+        exit 1
   roles: [admin, maintainer, write]
 
 # Agent job runs READ-ONLY. Safe-output jobs are auto-granted scoped write.
@@ -85,20 +110,9 @@ timeout-minutes: 30
 You are orchestrating the **apm-review-panel** skill against pull request
 **#${{ github.event.pull_request.number || inputs.pr_number }}** in `${{ github.repository }}`.
 
-## Step 0: Label-name guard (skip when irrelevant)
-
-`pull_request_target: types: [labeled]` fires for ANY label change. Bail
-immediately unless the triggering label is `panel-review` (or this is a
-manual `workflow_dispatch`):
-
-```bash
-EVENT="${{ github.event_name }}"
-LABEL="$(jq -r '.label.name // ""' "$GITHUB_EVENT_PATH")"
-if [ "$EVENT" = "pull_request_target" ] && [ "$LABEL" != "panel-review" ]; then
-  echo "Triggering label is '$LABEL' (not 'panel-review'); exiting cleanly."
-  exit 0
-fi
-```
+> The label-name guard runs at the workflow level (`on.steps:` pre-activation
+> step `label_check`). If you are reading this prompt, the triggering label
+> is `panel-review` or this is a manual `workflow_dispatch` -- proceed.
 
 ## Step 1: Gather PR context (read-only)
 


### PR DESCRIPTION
## Problem

The `pr-review-panel` workflow was firing on **every label change to every PR**, not just when the `panel-review` label was applied.

The label-name guard lived inside the agent prompt as Step 0 ("exit 0 if label != panel-review"), which had two failure modes:

1. **Wasted CI on irrelevant labels.** Every label add ran `pre_activation` + `activation` + APM bundle restore + agent container spin-up (~50s) before the LLM was even prompted. Then it asked the LLM to please exit early.
2. **Prompt-level instruction is non-deterministic.** "Exit 0 if X" is a request the LLM can ignore. Observed: PR #943 was labelled `automation`/`testing` (never `panel-review`); the agent ran for **5 min 12 s** before stopping. That's a paid LLM call plus full container lifecycle for nothing.

## Fix

Move the guard to gh-aw's `on.steps:` (pre-activation hook). The new `label_check` step:

```yaml
on:
  steps:
    - id: label_check
      name: Filter on panel-review label
      run: |
        if [ "$EVENT_NAME" = "workflow_dispatch" ]; then exit 0; fi
        if [ "$LABEL_NAME" = "panel-review" ]; then exit 0; fi
        echo "Triggering label is '$LABEL_NAME' (not 'panel-review'); skipping."
        exit 1
      env:
        EVENT_NAME: ${{ github.event_name }}
        LABEL_NAME: ${{ github.event.label.name }}
```

When the triggering label is not `panel-review`, the step exits 1 -> the `pre_activation` job fails -> all downstream jobs (`activation`, `apm`, `agent`, `safe_outputs`, etc.) skip. **Total cost when filtered out: one ubuntu-slim runner for ~10s. No LLM, no bundle restore, no agent container.**

The redundant Step 0 is removed from the prompt body and replaced with a short note pointing at the workflow-level guard.

## Why not `names:`?

gh-aw's `names:` filter is documented to apply only to `pull_request`, `issues`, `discussion`, and `label_command` triggers. Adding `names: [panel-review]` to `pull_request_target` fails compilation:

> Unknown property: names. \`names\` belongs under \`on/label_command\`, \`on/pull_request\`, or \`on/issues\`

We need `pull_request_target` to retain secret access on fork PRs (so the agent can post the verdict comment). `label_command:` would auto-remove the label after activation, but it generates `pull_request` (not `pull_request_target`) -- same fork-secret problem. `on.steps:` is the documented escape hatch.

## Validation

- `gh aw compile pr-review-panel` succeeds with 0 errors / 0 warnings.
- Lock file regenerated; `label_check` step present in `pre_activation` job.
- Existing safety posture preserved: read-only permissions, pinned imports to `microsoft/apm#main`, `roles: [admin, maintainer, write]`, no checkout of PR head.

## Test plan after merge

1. Open any PR with a label other than `panel-review` -> workflow should run `pre_activation` only (~10s) and then skip everything else.
2. Apply `panel-review` label to a PR -> full panel runs as before.
3. `workflow_dispatch` with a `pr_number` input -> still works (manual override path).

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>