### PR TITLE
Claude/peaceful rhodes

### DIFF
--- a/docs/proposals/registry-api-summary.md
+++ b/docs/proposals/registry-api-summary.md
@@ -1,0 +1,158 @@
+# Dedicated Registry API — Technical Summary
+
+**Status:** Draft — for APM maintainer review
+**Full proposal:** [registry-api.md](./registry-api.md)
+**Scope:** Plugins, skills, prompts, agents, instructions, hooks, commands, chatmodes (not MCP)
+
+An additive, opt-in REST resolver that sits alongside the existing Git resolver. Fully backwards compatible — a project without a `registries:` block sees no change.
+
+---
+
+## Set me up
+
+### 1. Declare the registry in `apm.yml` (committed)
+
+```yaml
+name: my-project
+version: 1.0.0
+
+registries:
+  corp-main:
+    url: https://registry.corp.example.com/apm   # e.g. /artifactory/api/apm/{repo-key}
+  default: corp-main                              # omit to keep Git as the default
+
+dependencies:
+  apm:
+    # String shorthand — routes through registries.default when set
+    - acme/web-skills#^1.2
+
+    # Named non-default registry via @scope (reuses marketplace syntax)
+    - acme/foo@corp-other#^3.0
+
+    # Virtual package — object form (sub-path can't fit in shorthand)
+    - registry: corp-main
+      id: acme/prompt-pack
+      path: prompts/review.prompt.md
+      version: 1.4.0
+
+    # Explicit Git (always available)
+    - git: https://github.com/acme/core.git
+      ref: v2.0
+```
+
+### 2. Set the auth token (per user, never committed)
+
+```
+APM_REGISTRY_TOKEN_CORP_MAIN=<token>
+```
+
+Convention: `APM_REGISTRY_TOKEN_{NAME}` where `{NAME}` is the uppercased registry name.
+
+### 3. Routing rule
+
+| entry shape | resolver |
+|---|---|
+| `- git: <url>` … | Git (explicit) |
+| `- path: ./local` | Local |
+| `- registry: <name>` … (object form) | Registry — required only for virtual packages (sub-path) |
+| `- owner/repo@<name>#<semver>` (string) | Registry `<name>` — reuses marketplace `@scope` syntax |
+| `- owner/repo#<semver>` (string) | Default registry if `registries.default` is set, else Git |
+
+When routed to a registry, the string-shorthand ref **must** be a semver version or range (`1.0.0`, `^1.0`, `~1.2.3`). Branches and commit SHAs fail at parse — use `- git:` for those.
+
+### 4. Publish
+
+```
+apm pack
+curl -X PUT --data-binary @bundle.tar.gz \
+  -H "Authorization: Bearer $APM_REGISTRY_TOKEN_CORP_MAIN" \
+  -H "Content-Type: application/gzip" \
+  "$REGISTRY/v1/packages/acme/web-skills/versions/1.2.0"
+```
+
+---
+
+## API Contract
+
+Four endpoints. All responses are JSON unless noted. Errors use RFC 7807 Problem Details on 4xx/5xx.
+
+### `GET /v1/packages/{owner}/{repo}/versions` — list versions
+
+Returns all published versions. Client picks one via existing semver logic.
+
+**Response 200:**
+```json
+{
+  "package": "acme/web-skills",
+  "versions": [
+    { "version": "1.2.0", "published_at": "2026-03-01T12:00:00Z", "digest": "sha256:abc123..." },
+    { "version": "1.1.0", "published_at": "...",                 "digest": "sha256:..." }
+  ]
+}
+```
+
+Cacheable (`Cache-Control: max-age=60` recommended) — versions are immutable.
+
+### `GET /v1/packages/{owner}/{repo}/versions/{version}/tarball` — fetch
+
+Downloads the immutable package tarball.
+
+**Response 200:**
+- `Content-Type: application/gzip`
+- `Digest: sha256=<base64>` (RFC 3230)
+- Body: gzipped tar of the package tree (same shape as `apm pack` output)
+
+Client MUST verify the sha256 digest against the entry from the list endpoint before extraction. After extraction, the client reads `apm.yml` from `apm_modules/{owner}/{repo}/apm.yml` and recurses for transitive deps — no separate metadata call.
+
+### `PUT /v1/packages/{owner}/{repo}/versions/{version}` — publish
+
+Upload a packaged tarball. Versions are immutable.
+
+**Request:**
+- `Authorization: Bearer <publish-token>`
+- `Content-Type: application/gzip`
+- Body: the `apm pack` tarball
+
+**Response 201:**
+```json
+{
+  "package": "acme/web-skills",
+  "version": "1.2.0",
+  "digest": "sha256:abc123...",
+  "published_at": "2026-03-01T12:00:00Z"
+}
+```
+
+**Errors:** `409` republish attempt · `422` server-side validation failure · `403` missing publish permission.
+
+### `GET /v1/search` — search
+
+Server-side search across all packages the caller can read.
+
+**Request:** `?q=query&limit=50&offset=0&type=skill&tag=security`
+
+**Response 200:**
+```json
+{
+  "query": "security skills",
+  "total": 42,
+  "results": [
+    {
+      "id": "acme/web-skills",
+      "latest_version": "1.2.0",
+      "description": "Security-hardened web interaction skills",
+      "author": "acme",
+      "tags": ["security", "web"],
+      "type": "skill",
+      "score": 0.92
+    }
+  ]
+}
+```
+
+---
+
+## Auth scopes (server-side)
+
+- `read` — required for the list, fetch, and search endpoints.
+- `publish:{owner}/{repo}` or `publish:{owner}/*` — required for publish. Server rejects with 403 on mismatch.

--- a/docs/proposals/registry-api-summary.md
+++ b/docs/proposals/registry-api-summary.md
@@ -2,6 +2,7 @@
 
 **Status:** Draft — for APM maintainer review
 **Full proposal:** [registry-api.md](./registry-api.md)
+**HTTP API spec:** [registry-http-api.md](./registry-http-api.md) — for server implementers
 **Scope:** Plugins, skills, prompts, agents, instructions, hooks, commands, chatmodes (not MCP)
 
 An additive, opt-in REST resolver that sits alongside the existing Git resolver. Fully backwards compatible — a project without a `registries:` block sees no change.

--- a/docs/proposals/registry-api-summary.md
+++ b/docs/proposals/registry-api-summary.md
@@ -93,25 +93,25 @@ Returns all published versions. Client picks one via existing semver logic.
 
 Cacheable (`Cache-Control: max-age=60` recommended) — versions are immutable.
 
-### `GET /v1/packages/{owner}/{repo}/versions/{version}/tarball` — fetch
+### `GET /v1/packages/{owner}/{repo}/versions/{version}/download` — fetch
 
-Downloads the immutable package tarball.
+Downloads the immutable package archive. Endpoint is format-neutral (same precedent as crates.io `/download` and the Docker Registry's `/blobs`); `Content-Type` tells the client which extractor to use.
 
 **Response 200:**
-- `Content-Type: application/gzip`
+- `Content-Type:` one of `application/gzip` (tar.gz) or `application/zip` (Anthropic skills format)
 - `Digest: sha256=<base64>` (RFC 3230)
-- Body: gzipped tar of the package tree (same shape as `apm pack` output)
+- Body: archive bytes
 
-Client MUST verify the sha256 digest against the entry from the list endpoint before extraction. After extraction, the client reads `apm.yml` from `apm_modules/{owner}/{repo}/apm.yml` and recurses for transitive deps — no separate metadata call.
+Client MUST verify the sha256 digest against the entry from the list endpoint before extraction. The hash check happens against the raw bytes regardless of archive format. After extraction, the client reads `apm.yml` from `apm_modules/{owner}/{repo}/apm.yml` and recurses for transitive deps — no separate metadata call.
 
 ### `PUT /v1/packages/{owner}/{repo}/versions/{version}` — publish
 
-Upload a packaged tarball. Versions are immutable.
+Upload a packaged archive. Versions are immutable.
 
 **Request:**
 - `Authorization: Bearer <publish-token>`
-- `Content-Type: application/gzip`
-- Body: the `apm pack` tarball
+- `Content-Type:` one of `application/gzip` (tar.gz) or `application/zip`
+- Body: the archive bytes
 
 **Response 201:**
 ```json

--- a/docs/proposals/registry-api.md
+++ b/docs/proposals/registry-api.md
@@ -1,0 +1,604 @@
+# Proposal: Dedicated Registry API Resolver
+
+**Status:** Draft — for APM maintainer review
+**Scope:** Plugins, skills, prompts, agents, instructions, hooks, commands, chatmodes
+**Explicitly out of scope:** MCP (continues to use the existing MCP registry client unchanged)
+
+> **Hard requirement — complete backwards compatibility.** This proposal MUST NOT break any existing flow. Every current `apm.yml`, `apm.lock`, CLI invocation, environment variable, and integration path must continue to work byte-for-byte on a client that has this feature shipped but sees no registry configuration. See §2.1 for the explicit invariants and §13 for the compatibility test matrix.
+
+---
+
+## 1. Motivation
+
+The current APM resolver is Git-based: dependencies are cloned from GitHub/GitLab/Azure DevOps (optionally through a VCS proxy such as an Artifactory or Nexus GitHub remote). This works well for open ecosystems but struggles at enterprise scale:
+
+- **Versioning** relies on Git tags and per-repo semver discipline; resolution requires `git ls-remote` per dep.
+- **Graph resolution** is client-side and recursive — every transitive dep is a network round-trip and a clone.
+- **Search** is limited to marketplace `marketplace.json` files and is client-side.
+- **Curated security** (promotion, signing, revocation) has no first-class primitive.
+
+This proposal introduces a **Dedicated Registry API** — an additive resolver mode that speaks a predictable REST contract. It is **opt-in per-package** with a **default override**, runs **alongside** the existing Git resolver, and maps cleanly onto enterprise artifact registries (Artifactory, Nexus, etc.) as a new package type.
+
+**Guiding principle:** We don't shake the system. `apm.yml` remains the same with a single optional field; all current flows keep working; registry mode is purely additive.
+
+---
+
+## 2. Goals & Non-Goals
+
+### Goals
+- **Complete backwards compatibility** (hard requirement — see §2.1).
+- Provide a REST contract APM clients can implement against any registry vendor.
+- Preserve the current `DependencyReference` identity (`owner/repo`) so apm.yml is backward-compatible.
+- Make the mode opt-in per-dep with a global default override.
+- Cover install, publish, and search flows end-to-end.
+- Keep the lockfile honest about what was resolved (git commit vs. content hash).
+
+### Non-Goals (v1)
+- MCP servers (stay on the existing MCP registry client).
+- Signing / provenance attestations (deferred — leave a `signatures` extension point).
+- Replacing the Git resolver. The Git resolver remains the default.
+- Mirroring / cross-registry federation.
+
+### 2.1 Backwards Compatibility Invariants
+
+These are **hard requirements**. Any implementation PR that violates one of them must be rejected.
+
+1. **Zero-config parity.** A user who upgrades the APM CLI but does not configure any registry MUST observe identical behavior to the previous version. No new network calls, no new files written, no new prompts, no new warnings.
+2. **apm.yml stability.** Every valid pre-proposal `apm.yml` remains valid and produces the same install result. The new top-level `registries:` block and the `@<name>` registry-scope suffix on dep strings are strictly optional and absent by default.
+3. **Default source is `git`.** In the absence of `registries.default` (see §3.2), every string-shorthand entry and every `- git:` / `- path:` object entry routes through the existing Git or local resolver — unchanged. Projects that want the registry as the default for string shorthand set `registries.default: <name>`; individual deps can always pin to Git with the explicit `- git:` form.
+4. **apm.lock stability.**
+   - An existing v1 lockfile MUST continue to parse without migration on read.
+   - A v1 lockfile MUST remain v1 on rewrite if no registry-sourced deps are present. The client only bumps to v2 when it actually needs to record a registry dep.
+   - A v2 lockfile authored by a newer client MUST remain readable by clients that understand v2, with every v1 field semantically identical.
+5. **No CLI signature changes.** `apm install`, `apm uninstall`, `apm prune`, `apm pack`, `apm unpack`, `apm update`, `apm marketplace *` retain every existing flag, argument, and exit code. New flags are additive only.
+6. **No env-var renames or semantics changes.** `GITHUB_TOKEN`, `GITHUB_APM_PAT_*`, `PROXY_REGISTRY_*`, `ARTIFACTORY_APM_TOKEN` (deprecated alias) all behave exactly as today. New registry env vars use a distinct `APM_REGISTRY_*` prefix so they cannot collide.
+7. **No integrator changes.** Deployed file layout under `.github/`, `.claude/`, etc. is byte-identical regardless of resolver source. `AgentIntegrator`, `SkillIntegrator`, `PromptIntegrator`, and peers receive no changes.
+8. **No identity changes.** `DependencyReference.get_identity()` returns the same string for the same input across both modes. Registry-sourced deps share the same key space as git-sourced deps.
+9. **Drift detection compatibility.** Existing drift rules (ref drift, orphan drift, stale-file drift from #666 / #750 / #762) remain unchanged for git-sourced deps. Registry-sourced deps use additional rules that coexist, never replace.
+10. **Marketplace unchanged.** The existing `marketplace.json` client-side search path is untouched. Registry server-side search is added alongside, not in place of.
+11. **Feature flag opt-in during rollout.** The registry code path is guarded by `APM_ENABLE_REGISTRY=1` (or presence of a top-level `registries:` block in apm.yml) during initial rollout, so `main` can merge registry work without any possibility of disturbing existing users. Flag is removed only after §13 test matrix passes in CI for at least one release cycle.
+12. **MCP untouched.** The MCP registry client (`src/apm_cli/registry/client.py` — `SimpleRegistryClient`) and MCP resolution flow are not modified. Namespacing: the new APM registry client lives under `src/apm_cli/deps/registry/` to avoid even the appearance of conflict.
+
+---
+
+## 3. Opt-in Model
+
+### 3.1 Registry declarations
+
+Named registries are declared in a new top-level `registries:` block in `apm.yml`, committed so every contributor sees the same name→URL mapping:
+
+```yaml
+# apm.yml (committed)
+name: my-project
+version: 1.0.0
+
+registries:
+  corp-main:
+    url: https://registry.corp.example.com/apm   # e.g. /artifactory/api/apm/{repo-key} or equivalent
+  default: corp-main                              # omit to keep Git as the default
+
+dependencies:
+  apm:
+    - acme/web-skills#^1.2
+```
+
+Per-user **auth** is one new env var, `APM_REGISTRY_TOKEN_{NAME}` (uppercased registry name) — never committed, never in any config file.
+
+```
+APM_REGISTRY_TOKEN_CORP_MAIN=<token>
+```
+
+**Why split URL from auth:** URL is project-level (same for all contributors), auth is user-level (tokens differ per user). Same split as npm's `.npmrc` vs. auth token. **Why convention over config:** no new config field, no indirection — the registry name deterministically maps to one env var name. Users can additionally define their own named registries in `~/.apm/config.yml`; those names are user-local and never leak into the lockfile.
+
+### 3.2 How an entry routes to a resolver
+
+Every dep entry in `dependencies.apm:` picks a resolver mechanically:
+
+| entry shape | resolver |
+|---|---|
+| `- git: <url>` ... | **Git** (explicit; unchanged) |
+| `- path: ./local` | **Local** (explicit; unchanged) |
+| `- registry: <name>` ... (object form) | **Registry `<name>`** — required only for virtual packages (sub-path) |
+| `- owner/repo@<name>#<ref>` (string shorthand) | **Registry `<name>`** (named scope — reuses the marketplace `@scope` convention) |
+| `- owner/repo#<ref>` (string shorthand) | **Default registry** if `registries.default` is set, else **Git** (unchanged) |
+
+The `@<name>` suffix is the existing marketplace-scope syntax (`apm install code-review@acme-plugins`, `apm search "linting@awesome-copilot"`) applied to registries — same vocabulary, same mental model. It does not collide with marketplace parsing: [`parse_marketplace_ref`](src/apm_cli/marketplace/resolver.py:26) explicitly rejects strings containing `/`, so `owner/repo@<name>` falls through to the dep parser.
+
+```yaml
+dependencies:
+  apm:
+    # Default path — string shorthand, routes through registries.default
+    - acme/web-skills#^1.2
+
+    # Named non-default registry (inline, via @scope)
+    - acme/foo@corp-other#^3.0
+
+    # Virtual package — object form (string shorthand can't express a sub-path cleanly)
+    - registry: corp-main
+      id: acme/prompt-pack
+      path: prompts/review.prompt.md
+      version: 1.4.0
+
+    # Explicit Git override (works whether or not a default registry is set)
+    - git: https://github.com/acme/core.git
+      ref: v2.0
+```
+
+**Why object form for virtual only.** Non-virtual registry entries compose cleanly in shorthand. Virtual packages need four independent fields (package id, registry name, sub-path, version) that don't combine into a readable string — cramming them in (`acme/prompt-pack@corp-main/prompts/review.prompt.md#1.4.0`) buries the sub-path between two other separators. Object form exists for exactly this case, symmetric with how `- git:` object form exists for the cases string shorthand can't handle (custom URLs, aliases, virtual Git sub-paths). Registry virtual packages are a Git-era workaround we keep for symmetry — dropping them would create an asymmetry between Git-sourced and registry-sourced consumers (see §11 decision).
+
+**Object-form fields (registry virtual packages):**
+- `registry:` — required; name of the registry (presence of this key is the object-form discriminator)
+- `id:` — required; `owner/repo`
+- `path:` — required; virtual sub-path inside the package
+- `version:` — required; semver version or range (same grammar as §3.3)
+- `alias:` — optional; unchanged meaning
+
+### 3.3 Semver constraint on registry-routed entries
+
+Whenever a string-shorthand entry routes to a registry (either via `registries.default` or via `@<name>`), the ref portion (`#<ref>`) **must** be a valid semver version or range. The parser rejects anything else at load time:
+
+- Accepted: `1.0.0`, `v1.0.0`, `^1.0`, `~1.2.3`, `>=1,<2`, `1.x`
+- Rejected: `main`, `develop` (branch names), `abc123d` (commit SHAs), `latest`, arbitrary strings
+
+```
+error: apm.yml line 12: 'acme/foo#main' routes through the default registry
+       but 'main' is not a semver version or range. Use an explicit
+       `- git:` entry for branch or commit-SHA pinning, or change the
+       ref to a semver version/range.
+```
+
+**Why strict semver here:** registries advertise versions, not refs. A silent route-flip from "Git ref" semantics to "registry version" semantics would produce confusing 404s; a parse-time error tells the user the exact fix. Today's string shorthand is ref-opaque (`#v1.0.0`, `#main`, `#<sha>` all supported — see [reference.py:668](src/apm_cli/models/dependency/reference.py:668), [dependencies.md:10-12](packages/apm-guide/.apm/skills/apm-usage/dependencies.md:10)); this rule only narrows the shape **when the entry routes to a registry**. Branch and SHA pinning remain fully available via the unchanged `- git:` explicit form, and string shorthand routed to Git (no default registry, no `@<name>`) stays byte-for-byte ref-opaque as today.
+
+**Why not infer per-ref:** "treat post-`#` as opaque and let the registry 404" was considered and rejected — it leaks resolver semantics into user error messages and lets mistyped branch names silently become "version not found" errors.
+
+### 3.4 Parser extension
+
+`DependencyReference.from_dict` ([reference.py:430-508](src/apm_cli/models/dependency/reference.py:430)) gains:
+1. One additional string-shorthand rule: if the string matches `owner/repo@<name>#<ref>` (or routes to the default registry via `registries.default`), treat `<name>` as a registry scope and validate `<ref>` as semver.
+2. One additional object-form branch keyed by `registry:` (for virtual packages only).
+
+Both are **strictly additive** — any pre-existing `apm.yml` that doesn't declare `registries.default` and doesn't use `@<name>` or `- registry:` continues to parse byte-identically.
+
+**On `@` parsing precedence.** Today `@` in a dep string is only consumed by the SSH URL branch (`git@github.com:...`, triggered by the `git@` prefix or `://` in the string) and the alias branch (line 631, triggered inside an SSH repo part). A bare `owner/repo@name#ref` doesn't hit either. The new rule fires before alias parsing for non-SSH strings, which keeps existing alias behavior intact.
+
+### 3.5 Identity preservation
+
+`DependencyReference.get_identity()` stays `owner/repo` (or `host/owner/repo`). The registry is keyed by the same identity — the lockfile records *how* it was fetched via a new `source` field. This keeps `apm.yml` and package ids stable across resolvers (invariant §2.1.8).
+
+---
+
+## 4. End-to-End Flows
+
+### 4.1 Install flow (registry mode)
+
+```python
+def apm_install():
+    manifest = read("apm.yml")
+
+    for dep in resolve_deps(manifest):              # recursive walk
+
+        # ─── source-specific fetch (the ONLY new branch) ───
+        if dep.source == "git":                     # existing
+            GitHubPackageDownloader.download(dep)   #   git ls-remote + clone
+
+        elif dep.source == "registry":              # NEW
+            versions = registry.list_versions(dep.id)       # GET /versions
+            v = pick_version(versions, dep.range)           # existing semver logic
+            tarball = registry.download(dep.id, v.version)  # GET /tarball
+            verify_sha256(tarball, v.digest)
+            extract(tarball, f"apm_modules/{dep.owner}/{dep.repo}/")
+
+        # ─── from here: unchanged, source-agnostic ───
+        recurse_into(dep.extracted_apm_yml)         # discover transitives
+
+    detect_drift()                                  # unchanged
+    run_integrators()                               # AgentIntegrator, SkillIntegrator, …
+    write_lockfile()                                # + source / resolved_hash / resolved_url
+```
+
+The registry-specific branch spans five lines. Once the tarball is extracted to `apm_modules/{owner}/{repo}/`, every subsequent step — transitive discovery, drift detection, integration, lockfile writing — runs the existing code unmodified.
+
+### 4.2 Publish flow
+
+```
+apm pack                              # unchanged — produces .tar.gz
+apm publish --registry corp-main     # NEW — reads $APM_REGISTRY_TOKEN_CORP_MAIN, wraps curl
+                                      #                    -T bundle.tar.gz \
+                                      #                    $REGISTRY/packages/{owner}/{repo}/versions/{ver}
+```
+
+Or, in CI with no CLI involvement:
+
+```
+apm pack
+curl -X PUT --data-binary @bundle.tar.gz \
+  -H "Authorization: Bearer $APM_REGISTRY_TOKEN_CORP_MAIN" \
+  -H "Content-Type: application/gzip" \
+  "$REGISTRY/packages/acme/web-skills/versions/1.2.0"
+```
+
+Server-side validation (invalid apm.yml, missing primitives, malformed tarball) happens before acceptance and surfaces as `422 Unprocessable Entity` — see §5.3.
+
+### 4.3 Search flow
+
+```
+apm marketplace search "security skills"
+  ├─ for each registered marketplace → existing marketplace.json path (client-side)
+  └─ for each configured registry    → GET /search?q=... (NEW, server-side)
+  └─ merged/ranked results
+```
+
+Mode is chosen by the search source: marketplaces stay client-side; registries search server-side. No user-visible mode toggle needed.
+
+### 4.4 Update / uninstall / prune
+
+Unchanged in user-facing behavior. Internally:
+- `apm install --update` re-queries `GET /versions` (registry) or `git ls-remote` (git) per dep.
+- `apm uninstall` and `apm prune` operate on lockfile + deployed files, which are source-agnostic.
+
+### 4.5 Marketplaces
+
+Marketplaces remain **catalogs of curated pointers**, not artifact stores. This proposal does not change what a marketplace *is* — it only lets a marketplace entry point at a registry-sourced package in addition to a git-sourced one.
+
+**Role separation:**
+
+| Concept | Role | Controlled by |
+|---|---|---|
+| Marketplace | Curated index (which packages to recommend) | Curator (editorial) |
+| Registry | Versioned artifact store (where tarballs live) | Publisher (producer) |
+
+The two are **orthogonal** — a marketplace may list git-sourced packages, registry-sourced packages, or a mix. A curator is never required to run a registry.
+
+**`marketplace.json` schema extension** (strictly additive):
+
+```jsonc
+{
+  "plugins": [
+    {
+      "id": "review-skills",
+      "name": "Code Review Skills",
+      "repo": "acme/review-skills",
+      "ref": "v1.0.0",                                       // existing — used when source: git (default)
+      "description": "..."
+    },
+    {
+      "id": "enterprise-skills",
+      "name": "Enterprise Skills",
+      "repo": "acme/enterprise-skills",
+      "source": "registry",                                  // NEW — optional, defaults to "git"
+      "version": "^3.0.0"                                    // NEW — used when source: registry
+    }
+  ]
+}
+```
+
+The schema gains a single field: `source` (per entry, optional, defaults to `"git"`), plus `version` for entries with `source: registry`.
+
+**No `registry_url` field exists in the marketplace.json.** Instead:
+
+- A marketplace served from a **registry** (fetched at `<registry_url>/marketplace.json`) implicitly resolves all `source: registry` entries against `<registry_url>` — the URL it was just fetched from. No duplication, no drift between an inside-the-file value and the actual fetch URL.
+- A marketplace served from a **Git repo** (today's flow) has no implicit registry, so its entries can only be `source: git`. To curate registry-sourced packages, host the marketplace on a registry.
+
+**`apm marketplace add` accepts both:**
+- `apm marketplace add OWNER/REPO` → Git-hosted marketplace (today, unchanged).
+- `apm marketplace add https://registry.example.com/apm` → registry-hosted marketplace; client fetches `<URL>/marketplace.json` and uses `<URL>` as the registry for any `source: registry` entries.
+
+**Existing marketplace.json files are unchanged** — none carry `source: registry` entries, all implicitly `source: git`.
+
+**Install flow via marketplace:**
+
+```
+apm install enterprise-skills@corp-marketplace
+  ├─ read corp-marketplace's marketplace.json
+  ├─ find entry id=enterprise-skills
+  ├─ entry has source: registry → route to registry resolver (§5.1 + §5.2)
+  │   OR source: git (default) → route to git resolver (unchanged)
+  └─ install as if user had declared the dep directly in apm.yml
+```
+
+**Publishing is never through a marketplace.** Publishing goes directly to a registry (§5.3). Adding the published version to a marketplace is a separate, manual editorial step by the curator — this preserves the producer/curator separation.
+
+**Search:** already captured in §9 — client-side marketplace search and server-side registry search coexist, results are merged.
+
+**Trust model:** marketplace entries are pointers, not authority. The `resolved_hash` lockfile invariant (§6) remains the sole trust anchor. A compromised marketplace entry fails closed on the hash check for any previously-installed version; first install is trust-on-first-use (same as every package manager).
+
+---
+
+## 5. API Contract
+
+### Conventions
+
+- **Base URL:** `$REGISTRY/` (vendor-defined path prefix — like `/artifactory/api/apm/{repo-key}`)
+- **Identity in path:** `{owner}/{repo}` — matches `DependencyReference.get_identity()` for GitHub-origin packages. For non-GitHub origin, identity is percent-encoded: `gitlab.com%2Fowner%2Frepo`.
+- **Auth:** `Authorization: Bearer <token>` on all endpoints. Token resolution follows existing `AuthResolver` patterns (see §7).
+- **Content types:** `application/json` for metadata, `application/gzip` for tarballs.
+- **Versioning:** Server URLs are versioned: `/v1/packages/...`. This proposal is v1.
+- **Errors:** RFC 7807 Problem Details JSON on 4xx/5xx.
+
+---
+
+### 5.1 `GET /v1/packages/{owner}/{repo}/versions`
+
+Returns all published versions for a package. Range resolution happens client-side, reusing the existing semver logic in `parse_git_reference()` (`src/apm_cli/deps/apm_resolver.py`) — the same code that matches git tags today.
+
+**Request:** none (path only).
+
+**Response 200:**
+```json
+{
+  "package": "acme/web-skills",
+  "versions": [
+    {
+      "version": "1.2.0",
+      "published_at": "2026-03-01T12:00:00Z",
+      "digest": "sha256:abc123..."
+    },
+    { "version": "1.1.0", "published_at": "...", "digest": "..." }
+  ]
+}
+```
+
+The response is cacheable (`Cache-Control: max-age=60` recommended) — published versions are immutable, the only mutations are new versions and yank flips.
+
+**Effort (client):** **small addition**
+- New file: `src/apm_cli/deps/registry/client.py` — `RegistryClient.list_versions()`
+- Range matching: **reuses existing semver logic** from `src/apm_cli/deps/apm_resolver.py::parse_git_reference`. No new code.
+- Tie-in: called from new `RegistryPackageResolver` (§8).
+
+**Effort (server side):** out of scope for APM, but very small — existing artifact registries already expose version enumeration for most package types; this is a thin adapter.
+
+---
+
+### 5.2 `GET /v1/packages/{owner}/{repo}/versions/{version}/tarball`
+
+Download the immutable package tarball.
+
+**Request:** none.
+
+**Response 200:**
+- `Content-Type: application/gzip`
+- `Digest: sha256=<base64>` (RFC 3230)
+- Body: gzipped tar of the package tree (same shape as `apm pack` output)
+
+Client MUST verify the sha256 digest against the entry from §5.1 before extraction.
+
+**Transitive dep discovery:** after extraction, the client reads `apm.yml` from `apm_modules/{owner}/{repo}/apm.yml` and recurses — the exact same step the Git resolver performs after `git clone`. No separate metadata call is needed.
+
+**Effort (client):** **medium change**
+- New: `RegistryClient.download_tarball()` — streams to temp, verifies digest.
+- New: `src/apm_cli/deps/registry/extractor.py` — extracts into `apm_modules/{owner}/{repo}/` (parallel to current git-clone extraction path in `github_downloader.py`).
+- Touch: `apm_modules` layout is the same regardless of source, so integrators (`AgentIntegrator`, `SkillIntegrator`, etc.) need **no changes**.
+
+---
+
+### 5.3 `PUT /v1/packages/{owner}/{repo}/versions/{version}` — Publish
+
+Upload a packaged tarball. Version is immutable — republishing the same `(owner, repo, version)` triple returns 409.
+
+**Request:**
+- `Authorization: Bearer <publish-token>` (scope checked server-side per §7)
+- `Content-Type: application/gzip`
+- Body: the `apm pack` tarball
+
+**Response 201:**
+```json
+{
+  "package": "acme/web-skills",
+  "version": "1.2.0",
+  "digest": "sha256:abc123...",
+  "published_at": "2026-03-01T12:00:00Z"
+}
+```
+
+**Errors:**
+- `409 Conflict` — version already exists (immutable).
+- `422 Unprocessable Entity` — server-side lint/validation failed (invalid apm.yml, missing primitives, malformed tarball).
+- `403 Forbidden` — user lacks publish permission for this `owner/repo`.
+
+**Effort (client):** **small addition**
+- New command: `src/apm_cli/commands/publish.py` — wraps `apm pack` + HTTP PUT.
+- Or: document pure `curl` usage (no CLI change required). Recommend both.
+
+**Effort (existing `apm pack`):** **no change** — the bundle it already produces is the exact payload.
+
+---
+
+### 5.4 `GET /v1/search`
+
+Server-side search across all packages the caller can read.
+
+**Request:** `?q=query&limit=50&offset=0&type=skill&tag=security`
+
+**Response 200:**
+```json
+{
+  "query": "security skills",
+  "total": 42,
+  "results": [
+    {
+      "id": "acme/web-skills",
+      "latest_version": "1.2.0",
+      "description": "Security-hardened web interaction skills",
+      "author": "acme",
+      "tags": ["security", "web"],
+      "type": "skill",
+      "score": 0.92
+    }
+  ]
+}
+```
+
+**Effort (client):** **small addition**
+- Touch: `src/apm_cli/commands/marketplace.py` — `search()` gets a new branch: for each configured registry, call `GET /search` and merge with marketplace results.
+- New: `RegistryClient.search()`.
+
+See §9 for the server-vs-client comparison matrix.
+
+---
+
+## 6. Lockfile Changes
+
+### 6.1 New fields on `LockedDependency`
+
+The lockfile is **name-free** — it stores only the URL that was actually fetched from, and the content hash. No registry name appears in the lockfile, because names are a per-user config concern (two users may legitimately use different names for the same URL).
+
+```yaml
+dependencies:
+  - repo_url: acme/web-skills
+    host: github.com                                                                 # existing — origin host if known
+    source: registry                                                                 # NEW — "git" | "registry" | "local"
+    resolved_url: https://registry.corp/apm/acme/web-skills/versions/1.2.0/tarball   # NEW — URL actually fetched from
+    version: "1.2.0"                                                                 # existing — authoritative for registry deps
+    resolved_hash: sha256:abc123...                                                  # NEW — content hash of the tarball. THE trust anchor.
+    resolved_commit: ""                                                              # existing — empty string for registry deps
+    resolved_ref: ""                                                                 # existing — empty string for registry deps
+    # ... all other fields unchanged (depth, deployed_files, deployed_file_hashes, etc.)
+```
+
+**Trust model (mirrors npm):** `resolved_hash` is the sole non-negotiable check on every install. `resolved_url` identifies the registry for re-fetch and audit; it may change benignly (registry migration, mirror swap) — the install succeeds as long as the bytes hash correctly.
+
+**On install, for a registry-sourced dep:**
+1. Fetch the tarball at `resolved_url` (auth chosen by URL — see §6.2).
+2. Verify the tarball's sha256 against `resolved_hash`. **Fail closed on mismatch.** This is the only security-critical check.
+3. Extract and proceed.
+
+**Invariants:**
+- `source: git` → `resolved_commit` required, `resolved_hash` optional, `resolved_url` absent.
+- `source: registry` → `resolved_hash` required, `version` required, `resolved_url` required, `resolved_commit` empty, `resolved_ref` empty.
+- `source: local` → unchanged.
+
+**Threat coverage:**
+- *Config tampering* (attacker changes the user's config to point at a different registry): the lockfile's `resolved_url` is what's fetched, not whatever config says — so config drift alone doesn't redirect the install. A mismatched config would fail at auth or at hash verification.
+- *Registry compromise* (server serves malicious bytes): first install captures the bad hash (trust-on-first-use, same as npm); subsequent installs detect further tampering. Signing (deferred to post-v1) is the only full mitigation.
+- *Lockfile tampering* (attacker rewrites both URL and hash): out of scope for any package manager; requires repo-level protections.
+
+### 6.2 Resolving auth when the URL is not configured
+
+A user who clones a repo whose lockfile references a registry URL they've never configured still needs to install. The rules:
+
+1. **Look up auth by URL, not by name.** For each unique `resolved_url`, the client checks registries declared in apm.yml and `~/.apm/config.yml` for any whose URL matches (scheme + host + path prefix). If found, the client reads `APM_REGISTRY_TOKEN_{NAME}` (uppercased) for that entry. Registry *names* in the config are user-local; they never need to match across users.
+2. **Anonymous fetch is tried first if no auth match.** If the registry responds 200, proceed (some registries have public read).
+3. **401/403 → fail with a clear remediation message.** Example:
+   ```
+   error: this project depends on a package from
+     https://registry.corp.example.com/apm
+   but no credentials for that registry are configured on this machine.
+   Add a registry entry whose URL matches (in apm.yml or ~/.apm/config.yml)
+   and set APM_REGISTRY_TOKEN_<NAME>=<token> in your environment.
+   ```
+4. **Never prompt interactively.** CI-friendly; fail fast.
+
+**Note on `apm.yml` registry names.** The name→URL mapping for named registries lives in `apm.yml`'s top-level `registries:` block (see §3.1), which is committed. So every user who clones the repo sees the same name→URL mapping at authoring time. User-local config only provides *auth* for those names (or adds new names for private mirrors). This way, `acme/foo@corp-main#^1.2` in a dep entry resolves to the same URL on every machine — there is no cross-user name divergence for project-declared registries.
+
+### 6.3 Schema bump — opportunistic, never gratuitous
+
+`lockfile_version: "1"` → `"2"`, but the bump happens **only when needed**:
+
+- **Read:** v1 lockfiles parse without migration. All v1 deps are implicitly `source: git`.
+- **Write:** The client emits v1 if and only if no registry-sourced deps are present in the resolved graph. A project that never opts into the registry will have its lockfile remain at v1 forever, even with a newer client. This is required by invariant §2.1.4.
+- **Upgrade trigger:** The first registry-sourced dep added to a project triggers a v1→v2 rewrite of the lockfile, with the v1 entries copied verbatim (no semantic change).
+- **Downgrade path:** Drop `source`/`resolved_hash`/`registry_name` fields and reject deps that require them. An older client reading a v2 lockfile MUST refuse to proceed and print a clear "upgrade APM or remove registry deps" message — never silently mis-resolve.
+
+**Effort:** **medium change**
+- Touch: `src/apm_cli/deps/lockfile.py` — add fields, add v1→v2 migration on read, bump version on write.
+- Touch: `src/apm_cli/drift.py` — source-aware drift rules (for registry deps, ref-drift check is replaced by version-drift + hash-drift).
+
+---
+
+## 7. Auth
+
+Reuses existing `AuthResolver` patterns with a new registry-specific axis.
+
+### 7.1 Token resolution (per registry)
+
+One new env var, `APM_REGISTRY_TOKEN_{NAME}` (uppercased registry name). Matches the existing `PROXY_REGISTRY_TOKEN` convention (single explicit var); avoids the discovery problem that forces `GITHUB_APM_PAT`/`GITHUB_APM_PAT_{ORG}` to have a fallback (registries are always declared by name in apm.yml, so there's nothing to discover).
+
+If the env var is missing, the client tries anonymous fetch; on 401/403 it fails with the remediation message in §6.2.
+
+### 7.2 Scope semantics (server-side)
+
+- `read` — required for §5.1, §5.2, §5.4.
+- `publish:{owner}/{repo}` or `publish:{owner}/*` — required for §5.3. Server rejects with 403 on scope mismatch.
+
+### 7.3 Integration with existing `AuthResolver`
+
+**Effort:** **small addition**
+- Touch: `src/apm_cli/core/auth.py` — add `resolve_for_registry(registry_name)` method.
+- New: `src/apm_cli/deps/registry/auth.py` — registry-specific token manager (thin wrapper).
+
+No changes to the existing Git/VCS auth path.
+
+---
+
+## 8. Graph Resolution
+
+**Client-side recursion only.**
+
+The registry resolver mirrors the Git resolver's shape exactly: for each dep, list versions (§5.1), pick a version via the existing semver logic, fetch the tarball (§5.2), extract, read `apm.yml`, recurse. This is a drop-in `DownloadCallback` — no changes to `APMDependencyResolver` itself. Swapping `git clone` for cacheable HTTPS tarball fetches is already a win, and the BFS walk becomes trivially parallelizable per level as a later optimization.
+
+**Considered, deferred:** returning a dep's declared apm.yml dependencies in the /versions response (or a separate per-version metadata endpoint). See Decisions section.
+
+**Effort:** **small addition**
+- New: `src/apm_cli/deps/registry/resolver.py` — implements the `DownloadCallback` protocol.
+- Touch: `src/apm_cli/commands/install.py` — route deps to registry callback when `source: registry`.
+- **No changes** to `APMDependencyResolver` itself.
+
+---
+
+## 9. Search: Server vs Client
+
+Today, search is **client-side**: `apm marketplace search` fetches each registered marketplace's `marketplace.json` in full and substring-matches locally (`src/apm_cli/marketplace/client.py::search_marketplace`). That stays. The registry adds a second path, **server-side search** (§5.4), used only for registry-backed catalogs.
+
+| | Client-side (today) | Server-side (§5.4) |
+|---|---|---|
+| Scales with catalog size | Whole index downloaded per search | Zero — server indexes |
+| Ranking | Substring match | Whatever the server implements (typically full-text) |
+| Permission-aware | No | Yes — server scopes results to the caller's token |
+| Freshness | Tied to marketplace.json cache | Real-time |
+| Offline | Works with cached index | Requires network |
+| Privacy | Entire catalog leaks to every client | Only matched results leave the server |
+| Client effort | Already implemented | Small addition — one new `RegistryClient.search()` call, one branch in `commands/marketplace.py` |
+
+**Why both, not one:** client-side search is the natural fit for Git-hosted marketplaces (small, public, already works). Server-side search is the natural fit for registry-hosted catalogs (large, private, permission-scoped). `apm marketplace search` queries whichever applies per source and merges.
+
+---
+
+## 10. Implementation Effort Summary
+
+Sized per file, using: **no change** / **small addition** (<50 LoC) / **medium change** (refactor of one module) / **large change** (cross-cutting refactor).
+
+| File | Change size | What |
+|---|---|---|
+| `src/apm_cli/models/apm_package.py` | **small addition** | Parse top-level `registries:` block; route string shorthand to default registry with semver validation. |
+| `src/apm_cli/models/dependency/reference.py` | **small addition** | Carry `source` + `registry_name` on `DependencyReference`. Identity scheme unchanged. |
+| `src/apm_cli/deps/lockfile.py` | **medium change** | New fields (`source`, `resolved_hash`, `registry_name`), v1→v2 migration. |
+| `src/apm_cli/drift.py` | **medium change** | Source-aware drift: version-drift + hash-drift for registry deps; ref-drift stays for git deps. |
+| `src/apm_cli/deps/apm_resolver.py` | **small addition** | Accept multiple download callbacks keyed by `source`. No refactor needed. |
+| `src/apm_cli/deps/registry/client.py` | **NEW — small file** | HTTP client: `list_versions`, `download_tarball`, `publish`, `search`. |
+| `src/apm_cli/deps/registry/resolver.py` | **NEW — small file** | Implements `DownloadCallback` for `source: registry`. |
+| `src/apm_cli/deps/registry/extractor.py` | **NEW — small file** | Tarball → `apm_modules/{owner}/{repo}/`. |
+| `src/apm_cli/deps/registry/auth.py` | **NEW — small file** | Registry token resolution. |
+| `src/apm_cli/core/auth.py` | **small addition** | `resolve_for_registry(name)` method. |
+| `src/apm_cli/commands/install.py` | **small addition** | Route deps to registry vs git resolver based on `source`. |
+| `src/apm_cli/commands/publish.py` | **NEW — small file** | `apm publish` command: wraps `apm pack` + HTTP PUT. |
+| `src/apm_cli/commands/marketplace.py` | **small addition** | `search()` also queries configured registries. |
+| `src/apm_cli/bundle/packer.py` | **no change** | `apm pack` output is already the publish payload. |
+| `src/apm_cli/integration/*.py` | **no change** | Integrators operate on `apm_modules/`, source-agnostic. |
+| `src/apm_cli/commands/uninstall/*.py` | **no change** | Operates on lockfile + deployed files, source-agnostic. |
+| `src/apm_cli/commands/prune.py` | **no change** | Same. |
+| Tests | **new tests + extend existing** | Registry client unit tests, install/publish integration tests against a fake server. |
+
+**Total net-new files:** 5 small.
+**Total touched existing files:** 7 (mostly small, two medium).
+**No file requires a complete refactor.**
+
+The change is **additive by construction**: the Git resolver path is left alone, and every existing test continues to pass because deps without `source:` default to `git`.
+
+---
+
+## 11. Decisions
+
+- **Virtual packages are sliced client-side.** Virtual package identity includes a sub-path (`owner/repo/prompts/file.prompt.md`). The registry treats `owner/repo` as a single unit — the parent tarball. The client extracts only the requested sub-path, mirroring the current virtual-package handling on the Git side. Keeps the server contract flat.
+- **No yank in v1.** There is no yank concept in the current Git-based flow (tag immutability is convention, not enforcement). Introducing yank would be new a capability beyond parity, so it is deferred; §5.1's response has no `yanked` field. Can be added in v2 without a compat break.
+- **Rate limiting reuses existing client retry.** The new `RegistryClient` calls the project's existing `resilient_get` helper, inheriting whatever retry / `Retry-After` semantics are already in place for HTTP. No new policy.
+- **No server-assisted transitive resolution in v1.** Embedding a version's declared `apm.yml` deps in `/versions` (or a separate per-version metadata endpoint) would let the client build the transitive graph without downloading every tarball. Deferred — it enlarges the server contract (publish must extract and index manifests) and adds a sync-with-tarball invariant. See §8 for the deferred note; future-compatible with v1.

--- a/docs/proposals/registry-api.md
+++ b/docs/proposals/registry-api.md
@@ -3,6 +3,9 @@
 **Status:** Draft — for APM maintainer review
 **Scope:** Plugins, skills, prompts, agents, instructions, hooks, commands, chatmodes
 **Explicitly out of scope:** MCP (continues to use the existing MCP registry client unchanged)
+**Companion docs:**
+- [registry-api-summary.md](./registry-api-summary.md) — short technical summary for client maintainers
+- [registry-http-api.md](./registry-http-api.md) — full HTTP API specification for server implementers
 
 > **Hard requirement — complete backwards compatibility.** This proposal MUST NOT break any existing flow. Every current `apm.yml`, `apm.lock`, CLI invocation, environment variable, and integration path must continue to work byte-for-byte on a client that has this feature shipped but sees no registry configuration. See §2.1 for the explicit invariants and §13 for the compatibility test matrix.
 
@@ -264,44 +267,47 @@ The two are **orthogonal** — a marketplace may list git-sourced packages, regi
 {
   "plugins": [
     {
-      "id": "review-skills",
-      "name": "Code Review Skills",
-      "repo": "acme/review-skills",
-      "ref": "v1.0.0",                                       // existing — used when source: git (default)
+      "name": "review-skills",
+      "repository": "acme/review-skills",
+      "ref": "v1.0.0",            // existing — Git ref/tag (default flow)
       "description": "..."
     },
     {
-      "id": "enterprise-skills",
-      "name": "Enterprise Skills",
-      "repo": "acme/enterprise-skills",
-      "source": "registry",                                  // NEW — optional, defaults to "git"
-      "version": "^3.0.0"                                    // NEW — used when source: registry
+      "name": "enterprise-skills",
+      "repository": "acme/enterprise-skills",
+      "registry": "corp-main",    // NEW — name of the dedicated APM registry
+      "version": "^3.0.0",        // EXISTING field; semver range when registry is set
+      "description": "..."
     }
   ]
 }
 ```
 
-The schema gains a single field: `source` (per entry, optional, defaults to `"git"`), plus `version` for entries with `source: registry`.
+The schema gains exactly **one new field: `registry`** (per entry, optional, default empty string). When set, the plugin resolves through the named APM registry and the existing `version` field is interpreted as a semver range.
+
+**Why a new field instead of `source: registry`?** The proposal's earlier draft used `source: registry` as the discriminator, but that collided with the existing `MarketplacePlugin.source` semantics — that field already accepts a string path or a `{type: github, repo: ...}` dict. Using a fresh `registry` field avoids the collision and matches the apm.yml object-form discriminator, where `- registry: <name>` plays the same role.
+
+**Permissive parser.** A non-string `registry` value, or a registry paired with a non-semver `version`, downgrades to "no registry routing" with a debug log instead of failing the whole marketplace fetch. One malformed plugin must not poison a multi-marketplace search.
 
 **No `registry_url` field exists in the marketplace.json.** Instead:
 
-- A marketplace served from a **registry** (fetched at `<registry_url>/marketplace.json`) implicitly resolves all `source: registry` entries against `<registry_url>` — the URL it was just fetched from. No duplication, no drift between an inside-the-file value and the actual fetch URL.
-- A marketplace served from a **Git repo** (today's flow) has no implicit registry, so its entries can only be `source: git`. To curate registry-sourced packages, host the marketplace on a registry.
+- A marketplace served from a **registry** (fetched at `<registry_url>/marketplace.json`) implicitly resolves all `registry: <name>` entries against the apm.yml-configured registry whose URL matches `<registry_url>` (URL-prefix lookup, same rule as §6.2). No duplication, no drift between an inside-the-file value and the actual fetch URL.
+- A marketplace served from a **Git repo** (today's flow) has no implicit registry; entries with no `registry` field route via Git. Curators who want to point at registry packages can either host the marketplace on a registry or set `registry: <name>` per entry.
 
 **`apm marketplace add` accepts both:**
 - `apm marketplace add OWNER/REPO` → Git-hosted marketplace (today, unchanged).
-- `apm marketplace add https://registry.example.com/apm` → registry-hosted marketplace; client fetches `<URL>/marketplace.json` and uses `<URL>` as the registry for any `source: registry` entries.
+- `apm marketplace add https://registry.example.com/apm` → registry-hosted marketplace; client fetches `<URL>/marketplace.json` and uses `<URL>` as the registry for any `registry`-routed entries.
 
-**Existing marketplace.json files are unchanged** — none carry `source: registry` entries, all implicitly `source: git`.
+**Existing marketplace.json files are unchanged** — none carry `registry` entries, all keep their existing Git semantics.
 
 **Install flow via marketplace:**
 
 ```
 apm install enterprise-skills@corp-marketplace
   ├─ read corp-marketplace's marketplace.json
-  ├─ find entry id=enterprise-skills
-  ├─ entry has source: registry → route to registry resolver (§5.1 + §5.2)
-  │   OR source: git (default) → route to git resolver (unchanged)
+  ├─ find entry name=enterprise-skills
+  ├─ entry has registry: <name> → route to registry resolver (§5.1 + §5.2)
+  │   OR no registry field → route to git resolver (unchanged)
   └─ install as if user had declared the dep directly in apm.yml
 ```
 
@@ -582,38 +588,71 @@ Today, search is **client-side**: `apm marketplace search` fetches each register
 
 Sized per file, using: **no change** / **small addition** (<50 LoC) / **medium change** (refactor of one module) / **large change** (cross-cutting refactor).
 
+> **Lessons learned during implementation.** The pre-flight estimate below was off by ~30% on file count (the original "7 touched files" missed `installed_package.py`, `context.py`, and `install/sources.py`) and missed the need for a vendored npm-semver matcher (it's NOT reusable from `parse_git_reference`). The corrected counts and rationale are at the bottom of this section under **"Post-implementation reality."**
+
 | File | Change size | What |
 |---|---|---|
-| `src/apm_cli/models/apm_package.py` | **small addition** | Parse top-level `registries:` block; route string shorthand to default registry with semver validation. |
-| `src/apm_cli/models/dependency/reference.py` | **small addition** | Carry `source` + `registry_name` on `DependencyReference`. Identity scheme unchanged. |
-| `src/apm_cli/deps/lockfile.py` | **medium change** | New fields (`source`, `resolved_hash`, `registry_name`), v1→v2 migration. |
-| `src/apm_cli/drift.py` | **medium change** | Source-aware drift: version-drift + hash-drift for registry deps; ref-drift stays for git deps. |
-| `src/apm_cli/deps/apm_resolver.py` | **small addition** | Accept multiple download callbacks keyed by `source`. No refactor needed. |
-| `src/apm_cli/deps/registry/client.py` | **NEW — small file** | HTTP client: `list_versions`, `download_tarball`, `publish`, `search`. |
-| `src/apm_cli/deps/registry/resolver.py` | **NEW — small file** | Implements `DownloadCallback` for `source: registry`. |
-| `src/apm_cli/deps/registry/extractor.py` | **NEW — small file** | Tarball → `apm_modules/{owner}/{repo}/`. |
-| `src/apm_cli/deps/registry/auth.py` | **NEW — small file** | Registry token resolution. |
-| `src/apm_cli/core/auth.py` | **small addition** | `resolve_for_registry(name)` method. |
-| `src/apm_cli/commands/install.py` | **small addition** | Route deps to registry vs git resolver based on `source`. |
-| `src/apm_cli/commands/publish.py` | **NEW — small file** | `apm publish` command: wraps `apm pack` + HTTP PUT. |
-| `src/apm_cli/commands/marketplace.py` | **small addition** | `search()` also queries configured registries. |
-| `src/apm_cli/bundle/packer.py` | **no change** | `apm pack` output is already the publish payload. |
+| `src/apm_cli/models/apm_package.py` | **small addition** | Parse top-level `registries:` block; route string shorthand to default registry with semver validation. Two new fields: `registries`, `default_registry`. |
+| `src/apm_cli/models/dependency/reference.py` | **small addition** | Carry `source` + `registry_name` on `DependencyReference`. New parser branches: `@<name>` shorthand, `- registry:` object form. |
+| `src/apm_cli/deps/lockfile.py` | **medium change** | New fields (`source`, `resolved_url`, `resolved_hash`), opportunistic v1→v2 emit, `from_dependency_ref(registry_resolution=...)`, `to_dependency_ref` source restoration. |
+| `src/apm_cli/drift.py` | **medium change** | Source-aware drift: range-vs-locked-version comparison for registry deps; source-flip drift; locked-version replay in `build_download_ref`. Git path unchanged. |
+| `src/apm_cli/install/phases/resolve.py` | **small addition** | Build `RegistryPackageResolver` once; dispatch in `download_callback`; URL-prefix lookup for lockfile re-installs. |
+| `src/apm_cli/install/sources.py` | **small addition** | `FreshDependencySource` and `CachedDependencySource` capture `RegistryResolution` into `InstalledPackage`. |
+| `src/apm_cli/install/context.py` | **small addition** | New field: `registry_resolver`. |
+| `src/apm_cli/deps/installed_package.py` | **small addition** | New field: `registry_resolution`. |
+| `src/apm_cli/deps/registry/client.py` | **NEW — small file** | HTTP client: `list_versions`, `download_archive`, `search`. (Publish kept as `curl`-only for v1.) |
+| `src/apm_cli/deps/registry/resolver.py` | **NEW — small file** | Implements `DownloadCallback` for `source: registry`; emits `RegistryResolution`. |
+| `src/apm_cli/deps/registry/extractor.py` | **NEW — small file** | sha256-verified extraction, tar.gz + zip + dispatcher; traversal/symlink/hardlink rejection. |
+| `src/apm_cli/deps/registry/auth.py` | **NEW — small file** | Env-var token + URL-prefix lookup for lockfile re-installs. |
+| `src/apm_cli/deps/registry/semver.py` | **NEW — small file** | Vendored npm-semver matcher. Required because `parse_git_reference` is a 12-line categorizer, not a range matcher. |
+| `src/apm_cli/marketplace/models.py` | **small addition** | `MarketplacePlugin.registry` field; permissive parse with semver gate. |
+| `src/apm_cli/marketplace/client.py` | **small addition** | New `search_all_registries()` helper that adapts `RegistryClient.search` to `MarketplacePlugin`. |
+| `src/apm_cli/commands/install.py` | **no change** | The actual install pipeline has been extracted to `install/phases/*` and `install/sources.py`; `install.py` is a thin wrapper. |
+| `src/apm_cli/commands/publish.py` | **deferred** | `apm publish` command not yet implemented — operators publish via `curl` for now. |
+| `src/apm_cli/commands/marketplace.py` | **deferred** | CLI-level merge of `search_all_registries()` into `apm marketplace search` deferred — public API is in place. |
+| `src/apm_cli/core/auth.py` | **no change** | Registry auth lives in `deps/registry/auth.py`; no integration with the existing `AuthResolver` chain (registries use a distinct namespace). |
+| `src/apm_cli/bundle/packer.py` | **no change** | `apm pack` already produces tar.gz — the publish payload (when `apm publish` lands). |
 | `src/apm_cli/integration/*.py` | **no change** | Integrators operate on `apm_modules/`, source-agnostic. |
 | `src/apm_cli/commands/uninstall/*.py` | **no change** | Operates on lockfile + deployed files, source-agnostic. |
 | `src/apm_cli/commands/prune.py` | **no change** | Same. |
-| Tests | **new tests + extend existing** | Registry client unit tests, install/publish integration tests against a fake server. |
 
-**Total net-new files:** 5 small.
-**Total touched existing files:** 7 (mostly small, two medium).
-**No file requires a complete refactor.**
+**Test files (all new):**
 
-The change is **additive by construction**: the Git resolver path is left alone, and every existing test continues to pass because deps without `source:` default to `git`.
+| File | What |
+|---|---|
+| `tests/unit/registry/test_semver.py` | npm-style range matching, parse-time gate |
+| `tests/unit/registry/test_auth.py` | env-var key derivation, URL-prefix lookup |
+| `tests/unit/registry/test_extractor.py` | sha256, tar.gz, zip, dispatcher, traversal/symlink rejection |
+| `tests/unit/registry/test_client.py` | URL construction, auth header, parse, error mapping |
+| `tests/unit/registry/test_resolver.py` | resolver orchestration with fake client |
+| `tests/unit/registry/test_resolver_e2e_http.py` | end-to-end against `http.server.HTTPServer` |
+| `tests/unit/registry/test_compat_matrix.py` | §2.1 invariant matrix |
+| `tests/unit/test_reference_registry_shorthand.py` | `@<name>` + object-form parsers |
+| `tests/unit/test_apm_yml_registries.py` | top-level `registries:` block + default routing |
+| `tests/unit/test_lockfile_v2_bump.py` | opportunistic v1→v2 |
+| `tests/unit/test_drift_registry.py` | source-aware drift |
+| `tests/unit/install/test_resolve_registry.py` | install pipeline wiring |
+| `tests/unit/marketplace/test_registry_integration.py` | marketplace.json schema + search merge |
+
+### Post-implementation reality
+
+- **Net-new files: 6** (the pre-flight count of 5 missed `semver.py`).
+- **Touched existing files: 11** (the pre-flight count of 7 missed `installed_package.py`, `context.py`, `install/sources.py`, `install/phases/resolve.py`, plus `marketplace/models.py` and `marketplace/client.py`).
+- **Test files: 13 new** (~3500 LoC of tests).
+- **Total LoC:** ~1500 production + ~3500 tests across ~30 files (counting tests).
+- **Deferred:** `apm publish` command, CLI-level marketplace search merge.
+
+The change is **still additive by construction** — every existing test stays green except one pre-existing unrelated failure in `tests/test_apm_package_models.py::TestGenericHostSubdirectoryRoundTrip::test_build_download_ref_preserves_virtual_path` that fails on clean `main` too. But the additive surface spans more files than the pre-flight estimate implied. Plan budgeting on the corrected counts.
 
 ---
 
 ## 11. Decisions
 
-- **Virtual packages are sliced client-side.** Virtual package identity includes a sub-path (`owner/repo/prompts/file.prompt.md`). The registry treats `owner/repo` as a single unit — the parent tarball. The client extracts only the requested sub-path, mirroring the current virtual-package handling on the Git side. Keeps the server contract flat.
+- **Endpoint name is `/download`, not `/tarball`.** The original draft used `/tarball` (npm-style URL), which baked a format assumption into the URL. Renamed to `/download` (same precedent as crates.io and the Docker Registry's `/blobs/{digest}`); `Content-Type` tells the client which extractor to invoke.
+- **Both tar.gz and zip are supported on the wire.** APM's `apm pack` produces tar.gz; Anthropic skills (open-claude-skills) ship as zip. Both formats carry the same security gates (sha256 verify before extract, traversal/symlink rejection). Format detection is `Content-Type` first, magic-bytes fallback (`\x1f\x8b...` → gzip, `PK\x03\x04...` → zip).
+- **Marketplace.json discriminator is `registry: <name>`, not `source: registry`.** The original draft would have collided with the existing `MarketplacePlugin.source` semantics (which already accepts a string path or a `{type, repo}` dict). The fresh `registry` field also matches the apm.yml object-form discriminator (`- registry: <name>`), giving consistent vocabulary across both shapes.
+- **Vendored npm-semver matcher.** The pre-flight estimate said range matching could reuse `parse_git_reference`. Reading the code disproves that — `parse_git_reference` is a 12-line categorizer (BRANCH/TAG/COMMIT). A small (~200 LoC) vendored matcher in `deps/registry/semver.py` covers the proposal's range shapes (`^`, `~`, `>=`, `<`, x-ranges, exact). PEP 440 (`packaging.specifiers`) was considered and rejected — its grammar differs subtly from npm-semver and the proposal's example ranges (`^1.2`, `~1.2.3`, `1.x`) are npm-style.
+- **Virtual packages are sliced client-side.** Virtual package identity includes a sub-path (`owner/repo/prompts/file.prompt.md`). The registry treats `owner/repo` as a single unit — the parent archive. The client extracts only the requested sub-path, mirroring the current virtual-package handling on the Git side. Keeps the server contract flat.
 - **No yank in v1.** There is no yank concept in the current Git-based flow (tag immutability is convention, not enforcement). Introducing yank would be new a capability beyond parity, so it is deferred; §5.1's response has no `yanked` field. Can be added in v2 without a compat break.
 - **Rate limiting reuses existing client retry.** The new `RegistryClient` calls the project's existing `resilient_get` helper, inheriting whatever retry / `Retry-After` semantics are already in place for HTTP. No new policy.
 - **No server-assisted transitive resolution in v1.** Embedding a version's declared `apm.yml` deps in `/versions` (or a separate per-version metadata endpoint) would let the client build the transitive graph without downloading every tarball. Deferred — it enlarges the server contract (publish must extract and index manifests) and adds a sync-with-tarball invariant. See §8 for the deferred note; future-compatible with v1.

--- a/docs/proposals/registry-api.md
+++ b/docs/proposals/registry-api.md
@@ -184,9 +184,9 @@ def apm_install():
         elif dep.source == "registry":              # NEW
             versions = registry.list_versions(dep.id)       # GET /versions
             v = pick_version(versions, dep.range)           # existing semver logic
-            tarball = registry.download(dep.id, v.version)  # GET /tarball
-            verify_sha256(tarball, v.digest)
-            extract(tarball, f"apm_modules/{dep.owner}/{dep.repo}/")
+            archive = registry.download(dep.id, v.version)   # GET /download
+            verify_sha256(archive, v.digest)
+            extract_archive(archive, content_type, f"apm_modules/{dep.owner}/{dep.repo}/")
 
         # ─── from here: unchanged, source-agnostic ───
         recurse_into(dep.extracted_apm_yml)         # discover transitives
@@ -214,6 +214,15 @@ apm pack
 curl -X PUT --data-binary @bundle.tar.gz \
   -H "Authorization: Bearer $APM_REGISTRY_TOKEN_CORP_MAIN" \
   -H "Content-Type: application/gzip" \
+  "$REGISTRY/packages/acme/web-skills/versions/1.2.0"
+```
+
+For Anthropic skills published as zip, swap the body and content type:
+
+```
+curl -X PUT --data-binary @skill.zip \
+  -H "Authorization: Bearer $APM_REGISTRY_TOKEN_CORP_MAIN" \
+  -H "Content-Type: application/zip" \
   "$REGISTRY/packages/acme/web-skills/versions/1.2.0"
 ```
 
@@ -349,25 +358,31 @@ The response is cacheable (`Cache-Control: max-age=60` recommended) — publishe
 
 ---
 
-### 5.2 `GET /v1/packages/{owner}/{repo}/versions/{version}/tarball`
+### 5.2 `GET /v1/packages/{owner}/{repo}/versions/{version}/download`
 
-Download the immutable package tarball.
+Download the immutable package archive.
 
-**Request:** none.
+**Request:** none. Optional `Accept` negotiation deferred to v2 — v1 clients accept whatever the server returns and dispatch on `Content-Type`.
 
 **Response 200:**
-- `Content-Type: application/gzip`
+- `Content-Type:` one of:
+  - `application/gzip` — gzipped tar (same shape as `apm pack` output)
+  - `application/zip` — zip archive (Anthropic skills / open-claude-skills format)
 - `Digest: sha256=<base64>` (RFC 3230)
-- Body: gzipped tar of the package tree (same shape as `apm pack` output)
+- Body: the archive bytes
 
-Client MUST verify the sha256 digest against the entry from §5.1 before extraction.
+The endpoint is named `/download` (not `/tarball`) so the URL grammar doesn't lock the format. Same precedent as crates.io (`/api/v1/crates/{name}/{version}/download`) and the Docker Registry's `/blobs/{digest}` — content type is metadata, not URL syntax.
+
+Client MUST verify the sha256 digest against the entry from §5.1 before extraction. The hash check happens against the raw bytes regardless of archive format.
+
+**Format dispatch:** the client picks the extractor from the response's `Content-Type` (with magic-bytes fallback: `\x1f\x8b...` → gzip, `PK\x03\x04...` → zip). Both extractors enforce the same security gates (no absolute paths, no path traversal, no symlinks/hardlinks). A wrong-format guess fails cleanly because the hash has already gated extraction.
 
 **Transitive dep discovery:** after extraction, the client reads `apm.yml` from `apm_modules/{owner}/{repo}/apm.yml` and recurses — the exact same step the Git resolver performs after `git clone`. No separate metadata call is needed.
 
 **Effort (client):** **medium change**
-- New: `RegistryClient.download_tarball()` — streams to temp, verifies digest.
-- New: `src/apm_cli/deps/registry/extractor.py` — extracts into `apm_modules/{owner}/{repo}/` (parallel to current git-clone extraction path in `github_downloader.py`).
-- Touch: `apm_modules` layout is the same regardless of source, so integrators (`AgentIntegrator`, `SkillIntegrator`, etc.) need **no changes**.
+- New: `RegistryClient.download_archive()` — streams to temp, verifies digest, surfaces Content-Type to the caller.
+- New: `src/apm_cli/deps/registry/extractor.py` — exposes `extract_tarball()` and `extract_zip()` plus a single `extract_archive()` dispatcher; both extracts into `apm_modules/{owner}/{repo}/`.
+- Touch: `apm_modules` layout is the same regardless of source or archive format, so integrators (`AgentIntegrator`, `SkillIntegrator`, etc.) need **no changes**.
 
 ---
 
@@ -447,7 +462,7 @@ dependencies:
   - repo_url: acme/web-skills
     host: github.com                                                                 # existing — origin host if known
     source: registry                                                                 # NEW — "git" | "registry" | "local"
-    resolved_url: https://registry.corp/apm/acme/web-skills/versions/1.2.0/tarball   # NEW — URL actually fetched from
+    resolved_url: https://registry.corp/apm/acme/web-skills/versions/1.2.0/download  # NEW — URL actually fetched from
     version: "1.2.0"                                                                 # existing — authoritative for registry deps
     resolved_hash: sha256:abc123...                                                  # NEW — content hash of the tarball. THE trust anchor.
     resolved_commit: ""                                                              # existing — empty string for registry deps

--- a/docs/proposals/registry-http-api.md
+++ b/docs/proposals/registry-http-api.md
@@ -1,0 +1,506 @@
+# APM Dedicated Registry — HTTP API Specification
+
+**Status:** v1 — implementable
+**Audience:** server implementers (Artifactory plugin authors, Nexus format authors, OSS reference servers)
+**Companion docs:**
+- [registry-api.md](./registry-api.md) — full design proposal (rationale, integration plan)
+- [registry-api-summary.md](./registry-api-summary.md) — short summary for client maintainers
+
+This document is the wire-level contract. It is self-contained — a server implementer should be able to build a conformant registry from this doc alone.
+
+---
+
+## Table of contents
+
+1. [Conventions](#1-conventions)
+2. [Authentication](#2-authentication)
+3. [Endpoints](#3-endpoints)
+   1. [`GET /v1/packages/{owner}/{repo}/versions`](#31-get-v1packagesownerrepoversions--list-versions)
+   2. [`GET /v1/packages/{owner}/{repo}/versions/{version}/download`](#32-get-v1packagesownerrepoversionsversiondownload--download-archive)
+   3. [`PUT /v1/packages/{owner}/{repo}/versions/{version}`](#33-put-v1packagesownerrepoversionsversion--publish)
+   4. [`GET /v1/search`](#34-get-v1search--server-side-search)
+   5. [`GET /v1/marketplace.json`](#35-get-v1marketplacejson--optional-marketplace-host)
+4. [Error model](#4-error-model)
+5. [Conformance: required vs optional](#5-conformance-required-vs-optional)
+6. [Server validation rules (publish)](#6-server-validation-rules-publish)
+7. [Caching, rate limiting, and headers](#7-caching-rate-limiting-and-headers)
+8. [Security checklist](#8-security-checklist)
+9. [Reference test fixtures](#9-reference-test-fixtures)
+
+---
+
+## 1. Conventions
+
+### 1.1 Base URL
+
+The registry's **base URL** is vendor-defined. Examples:
+
+- Artifactory APM repo: `https://artifactory.example.com/artifactory/api/apm/{repo-key}`
+- Nexus APM proxy: `https://nexus.example.com/repository/{repo-name}`
+- OSS reference: `https://registry.example.com/apm`
+
+Clients always append paths starting with `/v1/...` to the base URL. The base URL MUST NOT contain a trailing slash; if vendors return one in their UI, the client strips it (see `RegistryClient.__init__`).
+
+### 1.2 Identity
+
+`{owner}/{repo}` in path segments matches `DependencyReference.get_identity()` for GitHub-origin packages. For non-GitHub origins, identity is **percent-encoded** (each `/` in the identity becomes `%2F`):
+
+| Origin | Identity | Path segment |
+|---|---|---|
+| GitHub | `acme/web-skills` | `acme/web-skills` (two segments) |
+| GitLab | `gitlab.com/acme/web-skills` | `gitlab.com%2Facme%2Fweb-skills` (one encoded segment) |
+| Azure DevOps | `dev.azure.com/org/proj/repo` | `dev.azure.com%2Forg%2Fproj%2Frepo` (one encoded segment) |
+
+Servers MUST decode percent-encoded path segments before lookup.
+
+### 1.3 Versions
+
+Version strings follow [semver 2.0](https://semver.org/) with the following constraints:
+
+- Pre-release tags (`-rc.1`, `-beta.2`) are **reserved for v2** — v1 servers MAY accept them on publish but MUST NOT advertise them in `/versions` responses (yank-equivalent behavior).
+- Build metadata (`+sha.abc`) is **stripped on publish** — the canonical version is the part before `+`.
+- Versions are **case-sensitive** strings; `v1.0.0` and `1.0.0` are distinct identifiers.
+
+### 1.4 Content types
+
+| Resource | Type |
+|---|---|
+| List versions, search, problem details, publish response | `application/json; charset=utf-8` |
+| RFC 7807 problem detail | `application/problem+json; charset=utf-8` |
+| Archive download (gzip) | `application/gzip` |
+| Archive download (zip) | `application/zip` |
+
+Servers SHOULD set `charset=utf-8` on JSON responses but clients MUST NOT depend on it.
+
+### 1.5 Versioning the API itself
+
+The leading `/v1/` path segment is the API version. Future breaking changes ship under `/v2/`. Servers SHOULD support multiple versions in parallel during migration.
+
+### 1.6 Idempotency and immutability
+
+- **Versions are immutable.** A successful `PUT .../versions/{version}` cannot be overwritten — subsequent PUTs return `409 Conflict`. This is a hard requirement; clients depend on it for the lockfile trust model.
+- **List queries are idempotent.** `GET /versions` MUST return the same set of versions on identical inputs.
+- **Search results are best-effort.** The server MAY rerank or reorder results between calls.
+
+---
+
+## 2. Authentication
+
+### 2.1 Bearer token
+
+Every endpoint accepts `Authorization: Bearer <token>`. Tokens are opaque strings issued by the registry; the client treats them as bytes (no parsing, no inspection).
+
+When the header is absent, the server MAY:
+- accept the request (anonymous read on a public registry), OR
+- reject with `401 Unauthorized` (authenticated reads only).
+
+Clients try anonymous first when no env var is configured for a URL (per design §6.2). Servers SHOULD return `401` rather than `403` for missing-credential cases so clients can distinguish "auth required" from "auth provided but not authorized."
+
+### 2.2 Scopes (server-side enforcement)
+
+Tokens MUST carry one or more of these scopes. Clients never see scope strings — the server enforces them on each request.
+
+| Scope | Required for | Notes |
+|---|---|---|
+| `read` | `GET /versions`, `GET /download`, `GET /search`, `GET /marketplace.json` | Coarse read access |
+| `read:{owner}/{repo}` | Same as `read` but scoped | Optional fine-grained variant |
+| `publish:{owner}/{repo}` | `PUT .../versions/{version}` | Per-package publish authority |
+| `publish:{owner}/*` | Same, all repos under owner | Convenience wildcard |
+
+Servers MUST reject mismatched-scope requests with `403 Forbidden` and an RFC 7807 body citing which scope is missing.
+
+### 2.3 Anti-collision with existing env vars (client-side)
+
+Clients use `APM_REGISTRY_TOKEN_{NAME}` where `{NAME}` is the uppercased registry name (`-` and `.` mapped to `_`). The prefix is distinct from `GITHUB_TOKEN`, `GITHUB_APM_PAT`, `PROXY_REGISTRY_*`, and `ARTIFACTORY_APM_TOKEN`. Servers don't see this — included here for protocol completeness.
+
+---
+
+## 3. Endpoints
+
+### 3.1 `GET /v1/packages/{owner}/{repo}/versions` — list versions
+
+Returns all published versions for a package.
+
+**Request**
+
+```
+GET /v1/packages/acme/web-skills/versions HTTP/1.1
+Host: registry.example.com
+Authorization: Bearer <token>
+Accept: application/json
+```
+
+**Response 200**
+
+```json
+{
+  "package": "acme/web-skills",
+  "versions": [
+    {
+      "version": "1.2.0",
+      "digest": "sha256:abc123...",
+      "published_at": "2026-03-01T12:00:00Z",
+      "size_bytes": 24576
+    },
+    {
+      "version": "1.1.0",
+      "digest": "sha256:def456...",
+      "published_at": "2026-02-14T08:00:00Z",
+      "size_bytes": 23000
+    }
+  ]
+}
+```
+
+**Field requirements**
+
+| Field | Required | Notes |
+|---|---|---|
+| `package` | yes | Echoes the requested identity. Useful for clients that fetched via percent-encoded path. |
+| `versions[]` | yes | May be empty (`[]`); MUST NOT be omitted. |
+| `versions[].version` | yes | Semver string. |
+| `versions[].digest` | yes | sha256 of the archive bytes. Format: `sha256:<64 lowercase hex chars>`. |
+| `versions[].published_at` | yes | ISO 8601 UTC timestamp. |
+| `versions[].size_bytes` | optional | Archive size; informational. |
+
+**Ordering.** Servers SHOULD return versions in publish-time descending order (newest first). Clients MUST NOT depend on order — they sort by semver client-side.
+
+**Errors**
+
+| Status | Reason |
+|---|---|
+| `401` | Missing/invalid token, anonymous reads disabled |
+| `403` | Token lacks `read` scope for this package |
+| `404` | Package not found |
+
+**Caching.** Versions are immutable, but the SET of versions changes when new releases ship. Servers SHOULD set `Cache-Control: max-age=60` (or shorter); clients MAY honor it.
+
+---
+
+### 3.2 `GET /v1/packages/{owner}/{repo}/versions/{version}/download` — download archive
+
+Streams the immutable package archive. The endpoint is named `/download` (not `/tarball`) because both gzip and zip archives are valid responses; `Content-Type` discriminates.
+
+**Request**
+
+```
+GET /v1/packages/acme/web-skills/versions/1.2.0/download HTTP/1.1
+Host: registry.example.com
+Authorization: Bearer <token>
+Accept: application/gzip, application/zip
+```
+
+Clients SHOULD send the `Accept` header to advertise both formats. Servers SHOULD honor `Accept` if they store both, but MAY ignore it and return whatever was published.
+
+**Response 200**
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/gzip          ← or application/zip
+Content-Length: 24576
+Digest: sha256=<base64-of-binary-digest>   (RFC 3230)
+ETag: "sha256:abc123..."
+
+<binary archive body>
+```
+
+**Required headers**
+
+| Header | Required | Notes |
+|---|---|---|
+| `Content-Type` | yes | One of `application/gzip` or `application/zip`. |
+| `Content-Length` | recommended | Streamed delivery is fine; if absent, clients buffer to memory. |
+| `Digest` | recommended | RFC 3230 hash. Clients verify against `versions[].digest` from /versions, not this header. |
+| `ETag` | optional | Conditional GET support; clients may use it for caching across runs. |
+
+**Body.** Raw archive bytes. The same bytes that hash to the `digest` advertised in `/versions`.
+
+**Format selection at publish time.** APM publishes via `apm pack` (tar.gz). Anthropic skills publish via standard zip. Servers store and return whatever was uploaded; format conversion is NOT a server responsibility.
+
+**Errors**
+
+| Status | Reason |
+|---|---|
+| `401`, `403` | Same semantics as 3.1 |
+| `404` | No such (owner, repo, version) tuple |
+| `410` | Version yanked (v2; reserved) |
+
+**Hash verification on client.** Per design §6.1, clients re-hash the body against `versions[].digest` from a fresh `/versions` call OR from the lockfile's `resolved_hash`. A mismatch fails closed before extraction. Servers SHOULD NOT rely on this — they provide bytes; the trust gate is client-side.
+
+---
+
+### 3.3 `PUT /v1/packages/{owner}/{repo}/versions/{version}` — publish
+
+Uploads a new version. Versions are immutable: re-publishing returns `409`.
+
+**Request**
+
+```
+PUT /v1/packages/acme/web-skills/versions/1.2.0 HTTP/1.1
+Host: registry.example.com
+Authorization: Bearer <publish-token>
+Content-Type: application/gzip
+Content-Length: 24576
+
+<binary archive body>
+```
+
+**Body.** Archive bytes — either tar.gz (`application/gzip`) or zip (`application/zip`). The server records the Content-Type and replays it on subsequent `GET /download`.
+
+**Response 201**
+
+```json
+{
+  "package": "acme/web-skills",
+  "version": "1.2.0",
+  "digest": "sha256:abc123...",
+  "published_at": "2026-03-01T12:00:00Z",
+  "size_bytes": 24576
+}
+```
+
+**Errors**
+
+| Status | Reason |
+|---|---|
+| `400` | Malformed body (e.g. corrupt gzip, invalid zip directory). Body: RFC 7807 with `detail` describing the parse error. |
+| `401`, `403` | Auth missing / scope mismatch |
+| `409` | Version already exists. Body: RFC 7807 with `detail: "version 1.2.0 already published at 2026-02-14T08:00:00Z"`. |
+| `413` | Body exceeds the registry's per-archive size limit. |
+| `415` | `Content-Type` is neither `application/gzip` nor `application/zip`. |
+| `422` | Server-side validation failed (see §6). Body lists validation errors in `extensions.errors[]`. |
+
+Idempotency for `PUT` is **not** the standard "same request always succeeds" — it's "same `(owner, repo, version)` always returns 409 after the first success." This is the immutability invariant clients depend on for the lockfile trust model.
+
+---
+
+### 3.4 `GET /v1/search` — server-side search
+
+Free-text search across packages the caller can read.
+
+**Request**
+
+```
+GET /v1/search?q=security+skills&limit=50&offset=0&type=skill&tag=auth HTTP/1.1
+Host: registry.example.com
+Authorization: Bearer <token>
+Accept: application/json
+```
+
+**Query parameters**
+
+| Param | Required | Type | Notes |
+|---|---|---|---|
+| `q` | yes | string | URL-encoded free-text query. Server-defined matching (typically full-text). |
+| `limit` | optional | int (1-100) | Default 50. |
+| `offset` | optional | int (≥0) | For pagination. |
+| `type` | optional | string | Filter by primitive type: `skill`, `prompt`, `agent`, `instruction`, `hook`, `command`, `chatmode`. |
+| `tag` | optional | string | Filter by tag. May be repeated (`?tag=a&tag=b`) for AND. |
+
+**Response 200**
+
+```json
+{
+  "query": "security skills",
+  "total": 42,
+  "results": [
+    {
+      "id": "acme/web-skills",
+      "latest_version": "1.2.0",
+      "description": "Security-hardened web interaction skills",
+      "author": "acme",
+      "tags": ["security", "web"],
+      "type": "skill",
+      "score": 0.92
+    }
+  ]
+}
+```
+
+**Field requirements**
+
+| Field | Required | Notes |
+|---|---|---|
+| `query` | yes | Echoes the query for client-side debugging. |
+| `total` | yes | Total matches across all pages (for pagination UI). |
+| `results[]` | yes | Sorted by `score` descending. |
+| `results[].id` | yes | `{owner}/{repo}` — the canonical identity. |
+| `results[].latest_version` | yes | Highest semver-valid version published. |
+| `results[].description` | optional | Plain text. |
+| `results[].author` | optional | Free-form string. |
+| `results[].tags` | optional | Array of strings. |
+| `results[].type` | optional | One of the primitive types in the `type` filter list. |
+| `results[].score` | optional | Float in [0, 1]. Higher is better. |
+
+**Permission scoping.** Results MUST be scoped to packages the bearer token has `read` permission for. A registry with public reads MAY return public-only results when the request is anonymous.
+
+---
+
+### 3.5 `GET /v1/marketplace.json` — (optional) marketplace host
+
+A registry MAY also serve a marketplace catalog at this path. When present, the response is a `marketplace.json` document conforming to the schema in [registry-api.md §4.5](./registry-api.md#45-marketplaces) (with the `registry: <name>` extension for registry-routed entries).
+
+This endpoint is optional. Registries focused purely on package storage SHOULD return `404` here; clients fall back to Git-hosted marketplaces.
+
+---
+
+## 4. Error model
+
+All `4xx` and `5xx` responses use **RFC 7807 Problem Details** in `application/problem+json`:
+
+```json
+{
+  "type": "https://docs.apm.dev/errors/version-conflict",
+  "title": "Version already published",
+  "status": 409,
+  "detail": "Version 1.2.0 of acme/web-skills was already published at 2026-02-14T08:00:00Z",
+  "instance": "/v1/packages/acme/web-skills/versions/1.2.0",
+  "extensions": {
+    "previous_publish": "2026-02-14T08:00:00Z",
+    "previous_digest": "sha256:..."
+  }
+}
+```
+
+**Required fields:** `title`, `status`. All others optional but recommended.
+
+**Vendor extensions** belong under `extensions.*` per RFC 7807. Clients MUST ignore unknown extensions.
+
+---
+
+## 5. Conformance: required vs optional
+
+A **conformant v1 server** MUST implement:
+
+- `GET /v1/packages/{owner}/{repo}/versions`
+- `GET /v1/packages/{owner}/{repo}/versions/{version}/download`
+- `PUT /v1/packages/{owner}/{repo}/versions/{version}`
+- RFC 7807 error bodies on all 4xx/5xx
+- Bearer auth on all endpoints (anonymous reads optional)
+- sha256 digest accuracy (the byte sequence served at `/download` MUST match the digest advertised at `/versions`)
+- Version immutability (a successful PUT cannot be overwritten)
+
+A **fully-featured v1 server** SHOULD additionally implement:
+
+- `GET /v1/search`
+- `GET /v1/marketplace.json` (when serving as a marketplace host)
+- `Cache-Control` and `ETag` on read endpoints
+- Conditional `GET` (`If-None-Match`) returning `304`
+- Per-version `size_bytes` field
+
+Clients MUST NOT crash on missing optional fields; they MUST parse `versions[]` even with no `published_at` and treat `description`/`author`/`tags` as optional in search results.
+
+---
+
+## 6. Server validation rules (publish)
+
+On `PUT .../versions/{version}`, the server MUST validate (returning `422` on failure with errors in `extensions.errors[]`):
+
+1. **Version is parseable semver** (matches `^v?\d+(\.\d+)?(\.\d+)?$` with optional pre-release/build metadata).
+2. **Archive parses cleanly** as the declared `Content-Type` (gzip or zip).
+3. **Archive contains an `apm.yml` at the root** of the extraction tree.
+4. **`apm.yml` is valid YAML** with required fields (`name`, `version`).
+5. **`apm.yml.version` matches the URL path version** (mismatch → `422`, not silent acceptance).
+6. **`apm.yml.name` matches the URL path identity** (or its repo-name suffix — implementation-defined).
+7. **Archive entries are safe** — no absolute paths, no `..` traversal, no symlinks/hardlinks.
+8. **Archive size is within limits** — vendor-defined; suggested default 50 MB.
+
+**Out of scope for v1:**
+
+- License-text validation
+- Vulnerability scanning (servers MAY block but it's not required by the spec)
+- Signature verification (deferred to v2)
+
+---
+
+## 7. Caching, rate limiting, and headers
+
+### 7.1 Caching
+
+| Endpoint | Recommended `Cache-Control` |
+|---|---|
+| `GET /versions` | `max-age=60, public` |
+| `GET /download` | `max-age=86400, immutable` (versions are immutable) |
+| `GET /search` | `max-age=10` or `no-cache` (results may rerank) |
+| `GET /marketplace.json` | `max-age=300, public` |
+
+Clients MAY ignore these. APM v1 client does no HTTP caching.
+
+### 7.2 Rate limiting
+
+Servers SHOULD return `429 Too Many Requests` with a `Retry-After` header (seconds) when limits are exceeded. The body SHOULD be RFC 7807 with `extensions.limit` and `extensions.remaining`.
+
+### 7.3 Required response headers
+
+`Content-Type` is always required. Other headers are recommended but optional.
+
+---
+
+## 8. Security checklist
+
+For server implementers:
+
+- [ ] **TLS only.** Plain HTTP MUST NOT be supported in production. (Local dev is fine.)
+- [ ] **Token storage.** Use a one-way hash (bcrypt/argon2) for stored bearer tokens; never store plaintext.
+- [ ] **Path traversal prevention.** Reject `..` segments in `{owner}`, `{repo}`, `{version}` path params before any storage lookup.
+- [ ] **Archive scanning at publish.** Validate per §6 before persistence; reject zip slip / symlink attacks.
+- [ ] **Constant-time digest comparison.** When comparing a client-provided digest (e.g. for conditional GET) to the stored value.
+- [ ] **Audit log.** Record every successful `PUT` with (token-id, owner/repo, version, sha256, timestamp).
+- [ ] **Quota enforcement.** Per-token / per-owner archive size and count limits.
+
+For client implementers (informational):
+
+- [ ] Verify sha256 against `versions[].digest` before extraction.
+- [ ] Reject `..`, absolute paths, symlinks, and hardlinks during extraction.
+- [ ] Persist `resolved_url` in the lockfile (not the registry name) — it's the trust anchor for re-installs.
+- [ ] On `401/403`, surface a remediation message pointing at `APM_REGISTRY_TOKEN_<NAME>`.
+
+---
+
+## 9. Reference test fixtures
+
+A conformance test suite for server implementers SHOULD exercise:
+
+### 9.1 Round-trip publish-then-fetch
+
+1. `PUT .../versions/1.0.0` with a valid tar.gz body → `201` with the right digest.
+2. `GET .../versions/1.0.0/download` → returns the same bytes.
+3. sha256 of the returned bytes equals the digest from the `201` response.
+4. `GET .../versions` → contains the `1.0.0` entry with the same digest.
+
+### 9.2 Immutability
+
+1. `PUT .../versions/1.0.0` → `201`.
+2. `PUT .../versions/1.0.0` (same body) → `409`.
+3. `PUT .../versions/1.0.0` (different body) → `409`.
+
+### 9.3 Format dispatch
+
+1. `PUT .../versions/1.0.0` with `Content-Type: application/zip` → `201`.
+2. `GET .../versions/1.0.0/download` → returns `Content-Type: application/zip` and the same bytes.
+3. Hash matches.
+
+### 9.4 Validation
+
+1. `PUT` with a tarball missing `apm.yml` → `422` with appropriate error message.
+2. `PUT` with `apm.yml.version` ≠ URL version → `422`.
+3. `PUT` with absolute paths in tar → `422`.
+4. `PUT` with symlink in zip → `422`.
+
+### 9.5 Auth
+
+1. Anonymous `GET /versions` on a public package → `200` (or `401` on private registry).
+2. `GET /versions` with token lacking `read` scope → `403`.
+3. `PUT` with token lacking `publish` scope → `403`.
+4. `PUT` with no token → `401`.
+
+### 9.6 Error format
+
+1. Any `4xx` response has `Content-Type: application/problem+json`.
+2. Body is valid JSON with at least `title` and `status`.
+
+---
+
+## Changelog
+
+- **v1.0** (initial) — `versions`, `download`, `publish`, `search`, optional `marketplace.json`. tar.gz + zip both supported. RFC 7807 errors. Bearer auth. Immutable versions. No yank, no signing, no pre-release advertising — those are v2.

--- a/src/apm_cli/deps/installed_package.py
+++ b/src/apm_cli/deps/installed_package.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
+    from apm_cli.deps.registry.resolver import RegistryResolution
     from apm_cli.deps.registry_proxy import RegistryConfig
     from apm_cli.models.dependency.reference import DependencyReference
 
@@ -44,6 +45,13 @@ class InstalledPackage:
         when this package was downloaded, or ``None`` for direct VCS installs.
         When present, the lockfile stores the proxy host (FQDN) and prefix so
         that subsequent installs replay through the same proxy.
+    registry_resolution:
+        The :class:`~apm_cli.deps.registry.resolver.RegistryResolution` produced
+        by the dedicated-registry resolver, or ``None`` for git/local/proxy
+        installs. When present, the lockfile records ``resolved_url`` /
+        ``resolved_hash`` / ``version`` from it so re-installs verify against
+        the same content (design §6.1). Distinct concept from ``registry_config``
+        (Artifactory VCS proxy).
     """
 
     dep_ref: "DependencyReference"
@@ -52,3 +60,4 @@ class InstalledPackage:
     resolved_by: Optional[str]
     is_dev: bool = False
     registry_config: "Optional[RegistryConfig]" = None
+    registry_resolution: "Optional[RegistryResolution]" = None

--- a/src/apm_cli/deps/lockfile.py
+++ b/src/apm_cli/deps/lockfile.py
@@ -446,6 +446,7 @@ class LockFile:
         lock = cls(apm_version=apm_version)
 
         for entry in installed_packages:
+            registry_resolution = None
             if isinstance(entry, InstalledPackage):
                 dep_ref = entry.dep_ref
                 resolved_commit = entry.resolved_commit
@@ -453,6 +454,7 @@ class LockFile:
                 resolved_by = entry.resolved_by
                 is_dev = entry.is_dev
                 registry_config = getattr(entry, "registry_config", None)
+                registry_resolution = getattr(entry, "registry_resolution", None)
             elif len(entry) >= 5:
                 dep_ref, resolved_commit, depth, resolved_by, is_dev = entry[:5]
                 registry_config = None
@@ -468,6 +470,7 @@ class LockFile:
                 resolved_by=resolved_by,
                 is_dev=is_dev,
                 registry_config=registry_config,
+                registry_resolution=registry_resolution,
             )
             lock.add_dependency(locked_dep)
 

--- a/src/apm_cli/deps/lockfile.py
+++ b/src/apm_cli/deps/lockfile.py
@@ -45,6 +45,13 @@ class LockedDependency:
     is_insecure: bool = False  # True when the locked source was http://
     allow_insecure: bool = False  # True when the manifest explicitly allowed HTTP
 
+    # Registry resolver fields (design §6.1).
+    # Populated when source == "registry"; absent otherwise. resolved_hash is
+    # the sole non-negotiable trust anchor on every install — bytes are fetched
+    # from resolved_url and re-verified against this digest.
+    resolved_url: Optional[str] = None
+    resolved_hash: Optional[str] = None
+
     def get_unique_key(self) -> str:
         """Returns unique key for this dependency."""
         if self.source == "local" and self.local_path:
@@ -100,6 +107,10 @@ class LockedDependency:
             result["is_insecure"] = True
         if self.allow_insecure:
             result["allow_insecure"] = True
+        if self.resolved_url:
+            result["resolved_url"] = self.resolved_url
+        if self.resolved_hash:
+            result["resolved_hash"] = self.resolved_hash
         return result
 
     @classmethod
@@ -153,6 +164,8 @@ class LockedDependency:
             marketplace_plugin_name=data.get("marketplace_plugin_name"),
             is_insecure=data.get("is_insecure", False),
             allow_insecure=data.get("allow_insecure", False),
+            resolved_url=data.get("resolved_url"),
+            resolved_hash=data.get("resolved_hash"),
         )
 
     @classmethod
@@ -164,6 +177,7 @@ class LockedDependency:
         resolved_by: Optional[str],
         is_dev: bool = False,
         registry_config=None,
+        registry_resolution=None,
     ) -> "LockedDependency":
         """Create from a DependencyReference with resolution info.
 
@@ -174,10 +188,15 @@ class LockedDependency:
             resolved_by: Parent repo URL, or ``None`` for direct dependencies.
             is_dev: Whether this is a dev-only dependency.
             registry_config: Optional :class:`~apm_cli.deps.registry_proxy.RegistryConfig`
-                used for this download.  When provided, ``host`` is set to the
-                pure FQDN (e.g. ``"art.example.com"``) and ``registry_prefix``
-                is set to the URL path prefix (e.g. ``"artifactory/github"``),
-                ensuring correct auth routing on subsequent installs.
+                used for this download (Artifactory VCS proxy — pre-existing
+                concept, distinct from the new dedicated-registry resolver).
+                When provided, ``host`` is set to the pure FQDN and
+                ``registry_prefix`` to the URL path prefix.
+            registry_resolution: Optional :class:`~apm_cli.deps.registry.resolver.RegistryResolution`
+                produced by the dedicated-registry resolver. When provided,
+                ``source`` is set to ``"registry"`` and ``resolved_url`` /
+                ``resolved_hash`` / ``version`` are populated from it (the
+                trust anchor for re-installs per design §6.1).
         """
         if registry_config is not None:
             host = registry_config.host
@@ -185,6 +204,16 @@ class LockedDependency:
         else:
             host = dep_ref.host
             registry_prefix = None
+
+        # Determine source: explicit registry resolution wins; else local;
+        # else inherit from dep_ref.source (which may be "git" or None).
+        if registry_resolution is not None:
+            source = "registry"
+        elif dep_ref.is_local:
+            source = "local"
+        else:
+            source = None
+
         return cls(
             repo_url=dep_ref.repo_url,
             host=host,
@@ -192,24 +221,55 @@ class LockedDependency:
             registry_prefix=registry_prefix,
             resolved_commit=resolved_commit,
             resolved_ref=dep_ref.reference,
+            version=(
+                registry_resolution.version
+                if registry_resolution is not None
+                else None
+            ),
             virtual_path=dep_ref.virtual_path,
             is_virtual=dep_ref.is_virtual,
             depth=depth,
             resolved_by=resolved_by,
-            source="local" if dep_ref.is_local else None,
+            source=source,
             local_path=dep_ref.local_path if dep_ref.is_local else None,
             is_dev=is_dev,
             is_insecure=dep_ref.is_insecure,
             allow_insecure=dep_ref.allow_insecure,
+            resolved_url=(
+                registry_resolution.resolved_url
+                if registry_resolution is not None
+                else None
+            ),
+            resolved_hash=(
+                registry_resolution.resolved_hash
+                if registry_resolution is not None
+                else None
+            ),
         )
 
     def to_dependency_ref(self) -> DependencyReference:
-        """Reconstruct a DependencyReference from this locked dependency."""
+        """Reconstruct a DependencyReference from this locked dependency.
+
+        Registry-sourced deps come back with ``source="registry"`` so the
+        install pipeline routes them to the registry resolver. The exact
+        locked version is in ``reference`` (the registry resolver still calls
+        /versions and the hash-check on download enforces the lockfile's
+        intent).
+        """
+        # Registry deps: prefer the locked exact version over resolved_ref so
+        # the resolver picks up the exact-version constraint, not the original
+        # range (e.g. ``^1.2`` -> ``1.5.3``).
+        is_registry = self.source == "registry"
+        ref = (
+            self.version
+            if (is_registry and self.version)
+            else self.resolved_ref
+        )
         return DependencyReference(
             repo_url=self.repo_url,
             host=self.host,
             port=self.port,
-            reference=self.resolved_ref,
+            reference=ref,
             virtual_path=self.virtual_path,
             is_virtual=self.is_virtual,
             artifactory_prefix=self.registry_prefix,
@@ -217,6 +277,7 @@ class LockedDependency:
             local_path=self.local_path,
             is_insecure=self.is_insecure,
             allow_insecure=self.allow_insecure,
+            source=self.source,
         )
 
 
@@ -257,8 +318,22 @@ class LockFile:
         """Get all dependencies excluding the virtual self-entry."""
         return [d for d in self.get_all_dependencies() if d.local_path != "."]
 
+    def _needs_v2(self) -> bool:
+        """Whether the resolved graph requires lockfile schema v2.
+
+        Per design §6.1 (and invariant §2.1.4): bump opportunistically — only
+        when at least one dep is sourced from a dedicated registry. A project
+        that never opts into the registry keeps v1 forever, even on a newer
+        client.
+        """
+        return any(d.source == "registry" for d in self.dependencies.values())
+
     def to_yaml(self) -> str:
         """Serialize to YAML string."""
+        # Opportunistic v1->v2 bump (design §6.1): emit "2" only when at
+        # least one dep is registry-sourced. This is the explicit invariant
+        # §2.1.4 guarantee — projects that don't use the registry keep v1.
+        emit_version = "2" if self._needs_v2() else self.lockfile_version
         # The synthesized self-entry (key ".") is an in-memory normalization
         # of the flat local_deployed_files / local_deployed_file_hashes
         # fields. It must not be written back into the dependencies list,
@@ -266,7 +341,7 @@ class LockFile:
         _self_dep = self.dependencies.pop(_SELF_KEY, None)
         try:
             data: Dict[str, Any] = {
-                "lockfile_version": self.lockfile_version,
+                "lockfile_version": emit_version,
                 "generated_at": self.generated_at,
             }
             if self.apm_version:

--- a/src/apm_cli/deps/registry/__init__.py
+++ b/src/apm_cli/deps/registry/__init__.py
@@ -11,7 +11,12 @@ registry client) — the two address different concepts and must not be confused
 
 from .auth import RegistryAuthContext, resolve_registry_token
 from .client import RegistryClient, RegistryError, VersionEntry
-from .extractor import extract_tarball, verify_sha256
+from .extractor import (
+    extract_archive,
+    extract_tarball,
+    extract_zip,
+    verify_sha256,
+)
 from .resolver import RegistryPackageResolver
 from .semver import is_semver_range, match_version
 
@@ -21,7 +26,9 @@ __all__ = [
     "RegistryError",
     "RegistryPackageResolver",
     "VersionEntry",
+    "extract_archive",
     "extract_tarball",
+    "extract_zip",
     "is_semver_range",
     "match_version",
     "resolve_registry_token",

--- a/src/apm_cli/deps/registry/__init__.py
+++ b/src/apm_cli/deps/registry/__init__.py
@@ -1,0 +1,29 @@
+"""Dedicated registry API resolver.
+
+Additive resolver mode that fetches APM packages over a REST registry contract
+(see docs/proposals/registry-api.md). Sits alongside the existing Git resolver;
+opt-in via the top-level ``registries:`` block in ``apm.yml`` or the
+``APM_ENABLE_REGISTRY=1`` environment variable.
+
+This package is intentionally separate from ``src/apm_cli/registry/`` (the MCP
+registry client) — the two address different concepts and must not be confused.
+"""
+
+from .auth import RegistryAuthContext, resolve_registry_token
+from .client import RegistryClient, RegistryError, VersionEntry
+from .extractor import extract_tarball, verify_sha256
+from .resolver import RegistryPackageResolver
+from .semver import is_semver_range, match_version
+
+__all__ = [
+    "RegistryAuthContext",
+    "RegistryClient",
+    "RegistryError",
+    "RegistryPackageResolver",
+    "VersionEntry",
+    "extract_tarball",
+    "is_semver_range",
+    "match_version",
+    "resolve_registry_token",
+    "verify_sha256",
+]

--- a/src/apm_cli/deps/registry/auth.py
+++ b/src/apm_cli/deps/registry/auth.py
@@ -1,0 +1,127 @@
+"""Registry token resolution.
+
+Per docs/proposals/registry-api.md §7.1: a single env-var convention,
+``APM_REGISTRY_TOKEN_{NAME}`` where ``{NAME}`` is the uppercased registry name
+with hyphens replaced by underscores. No precedence chain (registries are
+always declared by name in apm.yml — there's nothing to discover).
+
+URL-based lookup (§6.2) is also implemented here: a user who clones a project
+whose lockfile references a registry URL they've never configured needs to
+install. The chain is::
+
+    resolved_url  ─→  registry name (apm.yml registries: block)  ─→  env-var token
+"""
+
+from __future__ import annotations
+
+import os
+import urllib.parse
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+@dataclass(frozen=True)
+class RegistryAuthContext:
+    """Auth payload for a single registry HTTP call.
+
+    Empty ``token`` is legitimate — anonymous fetch is the first attempt when
+    no env var is set (§6.2 rule 2). The client tries the request anonymously
+    and only surfaces the remediation message if the server replies 401/403.
+    """
+
+    registry_name: Optional[str]
+    token: Optional[str]
+
+    def auth_header(self) -> Optional[str]:
+        """Return the ``Authorization`` header value, or ``None`` when anonymous."""
+        if not self.token:
+            return None
+        return f"Bearer {self.token}"
+
+
+def _env_key(registry_name: str) -> str:
+    """Translate a registry name into the env-var key per §7.1.
+
+    ``corp-main``  -> ``APM_REGISTRY_TOKEN_CORP_MAIN``
+    ``corp.main``  -> ``APM_REGISTRY_TOKEN_CORP_MAIN``
+    """
+    sanitized = registry_name.upper().replace("-", "_").replace(".", "_")
+    return f"APM_REGISTRY_TOKEN_{sanitized}"
+
+
+def resolve_registry_token(registry_name: str) -> Optional[str]:
+    """Look up the env-var token for *registry_name*. ``None`` means anonymous."""
+    return os.environ.get(_env_key(registry_name))
+
+
+def _normalize_url_prefix(url: str) -> str:
+    """Normalize a URL for prefix matching.
+
+    Strips trailing slashes; lowercases the scheme + host. Path segments stay
+    case-sensitive (registries running on case-sensitive filesystems may treat
+    ``/Foo`` and ``/foo`` distinctly).
+    """
+    parsed = urllib.parse.urlparse(url)
+    scheme = parsed.scheme.lower()
+    host = (parsed.hostname or "").lower()
+    port = f":{parsed.port}" if parsed.port else ""
+    path = parsed.path.rstrip("/")
+    return f"{scheme}://{host}{port}{path}"
+
+
+def lookup_name_for_url(
+    target_url: str, registries: Dict[str, str]
+) -> Optional[str]:
+    """Find which configured registry owns *target_url* by URL prefix.
+
+    *registries* is the ``name -> url`` mapping from apm.yml's ``registries:``
+    block (or merged with user config). Returns the longest-prefix-matching
+    name, or ``None`` if no registered URL is a prefix of *target_url*.
+
+    The longest-prefix rule is what lets a user safely register both
+    ``https://corp/apm`` and ``https://corp/apm/team-a`` without one shadowing
+    the other.
+    """
+    if not target_url or not registries:
+        return None
+    normalized_target = _normalize_url_prefix(target_url)
+    best_name: Optional[str] = None
+    best_len = -1
+    for name, url in registries.items():
+        if not isinstance(url, str) or not url:
+            continue
+        prefix = _normalize_url_prefix(url)
+        if normalized_target == prefix or normalized_target.startswith(prefix + "/"):
+            if len(prefix) > best_len:
+                best_name = name
+                best_len = len(prefix)
+    return best_name
+
+
+def resolve_for_url(
+    target_url: str, registries: Dict[str, str]
+) -> RegistryAuthContext:
+    """End-to-end auth resolution for a lockfile-recorded URL.
+
+    Looks up which registered name owns *target_url* and reads the env-var
+    token for that name. If no registered URL matches, returns an anonymous
+    context — the caller will try anonymous fetch and surface the §6.2
+    remediation message on 401/403.
+    """
+    name = lookup_name_for_url(target_url, registries)
+    if name is None:
+        return RegistryAuthContext(registry_name=None, token=None)
+    return RegistryAuthContext(
+        registry_name=name, token=resolve_registry_token(name)
+    )
+
+
+def remediation_message(target_url: str) -> str:
+    """The standard 401/403 remediation per §6.2 rule 3."""
+    return (
+        f"error: this project depends on a package from\n"
+        f"  {target_url}\n"
+        f"but no credentials for that registry are configured on this machine.\n"
+        f"Add a registry entry whose URL matches (in apm.yml or ~/.apm/config.yml)\n"
+        f"and set APM_REGISTRY_TOKEN_<NAME>=<token> in your environment."
+    )

--- a/src/apm_cli/deps/registry/client.py
+++ b/src/apm_cli/deps/registry/client.py
@@ -1,0 +1,278 @@
+"""HTTP client for the dedicated registry API.
+
+Implements docs/proposals/registry-api.md §5:
+
+- ``GET /v1/packages/{owner}/{repo}/versions`` — list versions
+- ``GET /v1/packages/{owner}/{repo}/versions/{version}/tarball`` — fetch tarball
+- ``GET /v1/search`` — server-side search
+
+The publish endpoint (``PUT .../versions/{version}``) is documented in the
+proposal but intentionally NOT implemented in this PR — operators publish via
+``curl`` until ``apm publish`` lands as a follow-up.
+
+Design notes:
+
+- All endpoints use ``Authorization: Bearer <token>`` when an env-var token is
+  configured for the registry. Anonymous fetch is the fallback (§6.2 rule 2).
+- Errors surface as ``RegistryError`` carrying the HTTP status and a parsed
+  RFC 7807 Problem Details body when present. The install path turns 401/403
+  into the §6.2 remediation message at a higher level.
+- No HTTP cache layer in v1 — ``Cache-Control: max-age=60`` from the server is
+  advisory only. In-process memoization can be added later.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.parse
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, Optional
+
+import requests
+
+from .auth import RegistryAuthContext
+
+
+class RegistryError(Exception):
+    """A registry HTTP call failed.
+
+    ``status`` is the HTTP status code (or ``None`` for transport-level
+    failures); ``problem`` is the parsed RFC 7807 body when available.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: Optional[int] = None,
+        problem: Optional[Dict[str, Any]] = None,
+        url: Optional[str] = None,
+    ) -> None:
+        super().__init__(message)
+        self.status = status
+        self.problem = problem or {}
+        self.url = url
+
+
+@dataclass(frozen=True)
+class VersionEntry:
+    """One row from ``GET /v1/packages/.../versions``."""
+
+    version: str
+    digest: str
+    published_at: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "VersionEntry":
+        version = payload.get("version")
+        digest = payload.get("digest")
+        if not isinstance(version, str) or not version:
+            raise RegistryError(
+                f"malformed version entry (missing 'version'): {payload!r}"
+            )
+        if not isinstance(digest, str) or not digest:
+            raise RegistryError(
+                f"malformed version entry (missing 'digest') for {version!r}"
+            )
+        published = payload.get("published_at")
+        return cls(
+            version=version,
+            digest=digest,
+            published_at=published if isinstance(published, str) else None,
+        )
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    """One row from ``GET /v1/search``."""
+
+    id: str
+    latest_version: Optional[str]
+    description: Optional[str]
+    author: Optional[str]
+    tags: List[str]
+    type: Optional[str]
+    score: Optional[float]
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "SearchResult":
+        return cls(
+            id=str(payload.get("id", "")),
+            latest_version=payload.get("latest_version"),
+            description=payload.get("description"),
+            author=payload.get("author"),
+            tags=list(payload.get("tags") or []),
+            type=payload.get("type"),
+            score=payload.get("score"),
+        )
+
+
+_DEFAULT_TIMEOUT = (10, 60)  # (connect, read) seconds
+
+
+class RegistryClient:
+    """Minimal HTTP client for the registry API.
+
+    One client per registry URL. Stateless aside from the auth context — safe
+    to instantiate per install or share for an entire resolution graph.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        auth: RegistryAuthContext,
+        *,
+        session: Optional[requests.Session] = None,
+        timeout: Optional[tuple] = None,
+    ) -> None:
+        if not base_url:
+            raise ValueError("base_url is required")
+        # Strip trailing slash so we can join cleanly.
+        self._base_url = base_url.rstrip("/")
+        self._auth = auth
+        self._session = session or requests.Session()
+        self._timeout = timeout or _DEFAULT_TIMEOUT
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    def _headers(self, accept: str = "application/json") -> Dict[str, str]:
+        headers = {"Accept": accept}
+        auth_header = self._auth.auth_header()
+        if auth_header:
+            headers["Authorization"] = auth_header
+        return headers
+
+    def _url(self, path: str) -> str:
+        if not path.startswith("/"):
+            path = "/" + path
+        return f"{self._base_url}{path}"
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        accept: str = "application/json",
+        stream: bool = False,
+    ) -> requests.Response:
+        url = self._url(path)
+        try:
+            response = self._session.request(
+                method,
+                url,
+                headers=self._headers(accept=accept),
+                timeout=self._timeout,
+                stream=stream,
+            )
+        except requests.RequestException as exc:
+            raise RegistryError(
+                f"transport error talking to registry: {exc}",
+                url=url,
+            ) from exc
+        if response.status_code >= 400:
+            problem: Dict[str, Any] = {}
+            try:
+                ctype = response.headers.get("Content-Type", "")
+                if "json" in ctype:
+                    problem = response.json()
+            except (ValueError, json.JSONDecodeError):
+                problem = {}
+            raise RegistryError(
+                _format_error(response.status_code, problem, url),
+                status=response.status_code,
+                problem=problem,
+                url=url,
+            )
+        return response
+
+    # ------------------------------------------------------------------ §5.1
+    def list_versions(self, owner: str, repo: str) -> List[VersionEntry]:
+        """``GET /v1/packages/{owner}/{repo}/versions``."""
+        path = f"/v1/packages/{_quote(owner)}/{_quote(repo)}/versions"
+        response = self._request("GET", path)
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise RegistryError(
+                f"registry returned non-JSON for /versions: {exc}",
+                url=response.url,
+            ) from exc
+        raw_versions = payload.get("versions") if isinstance(payload, dict) else None
+        if not isinstance(raw_versions, list):
+            raise RegistryError(
+                f"registry response missing 'versions' array: {payload!r}",
+                url=response.url,
+            )
+        return [VersionEntry.from_dict(row) for row in raw_versions]
+
+    # ------------------------------------------------------------------ §5.2
+    def download_tarball(
+        self,
+        owner: str,
+        repo: str,
+        version: str,
+    ) -> bytes:
+        """``GET /v1/packages/{owner}/{repo}/versions/{version}/tarball``.
+
+        Returns the raw response body. Caller is responsible for sha256
+        verification (use ``extractor.verify_sha256``).
+        """
+        path = (
+            f"/v1/packages/{_quote(owner)}/{_quote(repo)}"
+            f"/versions/{_quote(version)}/tarball"
+        )
+        response = self._request("GET", path, accept="application/gzip")
+        return response.content
+
+    def tarball_url(self, owner: str, repo: str, version: str) -> str:
+        """The canonical ``resolved_url`` for a given (owner, repo, version)."""
+        return self._url(
+            f"/v1/packages/{_quote(owner)}/{_quote(repo)}"
+            f"/versions/{_quote(version)}/tarball"
+        )
+
+    # ------------------------------------------------------------------ §5.4
+    def search(
+        self,
+        query: str,
+        *,
+        limit: int = 50,
+        offset: int = 0,
+        type: Optional[str] = None,
+        tag: Optional[str] = None,
+    ) -> List[SearchResult]:
+        """``GET /v1/search``."""
+        params: Dict[str, Any] = {"q": query, "limit": limit, "offset": offset}
+        if type:
+            params["type"] = type
+        if tag:
+            params["tag"] = tag
+        path = "/v1/search?" + urllib.parse.urlencode(params)
+        response = self._request("GET", path)
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise RegistryError(
+                f"registry returned non-JSON for /search: {exc}",
+                url=response.url,
+            ) from exc
+        rows = payload.get("results") if isinstance(payload, dict) else None
+        if not isinstance(rows, list):
+            return []
+        return [SearchResult.from_dict(row) for row in rows]
+
+
+def _quote(s: str) -> str:
+    """Percent-encode a path segment, allowing ``.`` and ``-`` raw."""
+    return urllib.parse.quote(s, safe=".-")
+
+
+def _format_error(status: int, problem: Mapping[str, Any], url: str) -> str:
+    title = problem.get("title") if isinstance(problem, Mapping) else None
+    detail = problem.get("detail") if isinstance(problem, Mapping) else None
+    body = " - ".join(part for part in (title, detail) if part)
+    if body:
+        return f"registry HTTP {status} from {url}: {body}"
+    return f"registry HTTP {status} from {url}"

--- a/src/apm_cli/deps/registry/client.py
+++ b/src/apm_cli/deps/registry/client.py
@@ -159,9 +159,11 @@ class RegistryClient:
     ) -> requests.Response:
         url = self._url(path)
         try:
+            # Pass ``url`` as a keyword so test doubles can inspect it without
+            # depending on positional-argument ordering.
             response = self._session.request(
                 method,
-                url,
+                url=url,
                 headers=self._headers(accept=accept),
                 timeout=self._timeout,
                 stream=stream,

--- a/src/apm_cli/deps/registry/client.py
+++ b/src/apm_cli/deps/registry/client.py
@@ -210,30 +210,51 @@ class RegistryClient:
         return [VersionEntry.from_dict(row) for row in raw_versions]
 
     # ------------------------------------------------------------------ §5.2
-    def download_tarball(
+    def download_archive(
         self,
         owner: str,
         repo: str,
         version: str,
-    ) -> bytes:
-        """``GET /v1/packages/{owner}/{repo}/versions/{version}/tarball``.
+    ) -> tuple[bytes, str]:
+        """``GET /v1/packages/{owner}/{repo}/versions/{version}/download``.
 
-        Returns the raw response body. Caller is responsible for sha256
-        verification (use ``extractor.verify_sha256``).
+        Endpoint is format-neutral; the server replies with ``application/gzip``
+        (tar.gz) or ``application/zip`` (Anthropic skills format) and the
+        client dispatches on content type.
+
+        Returns ``(body_bytes, content_type)``. Caller is responsible for
+        sha256 verification (use ``extractor.verify_sha256``) and for picking
+        the right extractor (``extractor.extract_archive`` does this for you).
         """
         path = (
             f"/v1/packages/{_quote(owner)}/{_quote(repo)}"
-            f"/versions/{_quote(version)}/tarball"
+            f"/versions/{_quote(version)}/download"
         )
-        response = self._request("GET", path, accept="application/gzip")
-        return response.content
+        # Accept both archive types; v1 doesn't constrain via Accept (the
+        # publisher chose the format at upload time).
+        response = self._request(
+            "GET", path, accept="application/gzip, application/zip"
+        )
+        content_type = (response.headers.get("Content-Type") or "").split(";", 1)[0].strip()
+        return response.content, content_type
 
-    def tarball_url(self, owner: str, repo: str, version: str) -> str:
+    def archive_url(self, owner: str, repo: str, version: str) -> str:
         """The canonical ``resolved_url`` for a given (owner, repo, version)."""
         return self._url(
             f"/v1/packages/{_quote(owner)}/{_quote(repo)}"
-            f"/versions/{_quote(version)}/tarball"
+            f"/versions/{_quote(version)}/download"
         )
+
+    # Backwards-compat aliases for the early naming. Will be removed before
+    # the feature is released; kept here so any in-flight call sites in tests
+    # or experimental scripts don't break during the rename. New code should
+    # call ``download_archive`` / ``archive_url``.
+    def download_tarball(self, owner: str, repo: str, version: str) -> bytes:
+        body, _ = self.download_archive(owner, repo, version)
+        return body
+
+    def tarball_url(self, owner: str, repo: str, version: str) -> str:
+        return self.archive_url(owner, repo, version)
 
     # ------------------------------------------------------------------ §5.4
     def search(

--- a/src/apm_cli/deps/registry/extractor.py
+++ b/src/apm_cli/deps/registry/extractor.py
@@ -1,0 +1,136 @@
+"""Tarball extraction with sha256 verification.
+
+Per docs/proposals/registry-api.md §5.2 and §6.1: the client MUST verify the
+sha256 digest of the tarball against the value advertised by ``GET /versions``
+or recorded in the lockfile *before* extracting. A mismatch fails closed —
+this is the only security-critical check on the install path.
+
+Layout: tarballs are extracted into ``apm_modules/{owner}/{repo}/`` (the same
+shape the Git resolver produces after ``git clone``). Path-traversal entries
+are rejected — see ``_safe_extract``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import tarfile
+from pathlib import Path
+from typing import Optional
+
+
+class HashMismatchError(Exception):
+    """Raised when a tarball's sha256 does not match the expected digest."""
+
+
+class UnsafeTarballError(Exception):
+    """Raised when a tarball entry would escape the extraction root."""
+
+
+def _normalize_digest(digest: str) -> str:
+    """Strip the ``sha256:`` / ``sha256=`` prefix if present and lowercase."""
+    s = digest.strip().lower()
+    for prefix in ("sha256:", "sha256="):
+        if s.startswith(prefix):
+            return s[len(prefix):]
+    return s
+
+
+def verify_sha256(data: bytes, expected_digest: str) -> str:
+    """Verify *data*'s sha256 matches *expected_digest*.
+
+    Accepts the digest with or without a ``sha256:`` / ``sha256=`` prefix.
+    Returns the actual hex digest on success; raises ``HashMismatchError`` on
+    mismatch.
+    """
+    actual = hashlib.sha256(data).hexdigest()
+    expected = _normalize_digest(expected_digest)
+    if actual != expected:
+        raise HashMismatchError(
+            f"tarball sha256 mismatch: expected {expected}, got {actual}"
+        )
+    return actual
+
+
+def _safe_member_path(member_name: str, dest_root: Path) -> Optional[Path]:
+    """Return the absolute extraction path for *member_name* if safe.
+
+    Rejects:
+    - Absolute paths (``/etc/passwd``)
+    - Path traversal via ``..`` segments
+    - Symlink-style escapes (caller should also reject symlinks via type check)
+
+    Returns ``None`` if the member should be skipped (empty name).
+    """
+    if not member_name or member_name in (".", "/"):
+        return None
+    # Tarball member names use forward slashes regardless of platform; reject
+    # anything that looks like an absolute path on either side.
+    if member_name.startswith(("/", "\\")) or (
+        len(member_name) >= 2 and member_name[1] == ":"
+    ):
+        raise UnsafeTarballError(
+            f"absolute path in tarball: {member_name!r}"
+        )
+    candidate = (dest_root / member_name).resolve()
+    dest_resolved = dest_root.resolve()
+    try:
+        candidate.relative_to(dest_resolved)
+    except ValueError as exc:
+        raise UnsafeTarballError(
+            f"tarball entry {member_name!r} escapes extraction root"
+        ) from exc
+    return candidate
+
+
+def _safe_extract(tar: tarfile.TarFile, dest_root: Path) -> None:
+    """Extract *tar* into *dest_root* with traversal/symlink rejection."""
+    dest_root.mkdir(parents=True, exist_ok=True)
+    for member in tar.getmembers():
+        # Reject device files, FIFOs, symlinks, hard links — keep extraction
+        # to plain files and dirs only. Symlinks are rejected because they
+        # are the simplest path-traversal vector inside a tarball.
+        if member.isdev() or member.issym() or member.islnk():
+            raise UnsafeTarballError(
+                f"unsupported tarball entry type: {member.name!r}"
+            )
+        target = _safe_member_path(member.name, dest_root)
+        if target is None:
+            continue
+        if member.isdir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # Stream the file contents through tarfile's extractor, but write to
+        # the verified path explicitly so we never call extract() with the
+        # raw member name (which is what would honor a symlink).
+        src = tar.extractfile(member)
+        if src is None:
+            continue
+        with open(target, "wb") as fh:
+            while True:
+                chunk = src.read(64 * 1024)
+                if not chunk:
+                    break
+                fh.write(chunk)
+        # Preserve mode bits but drop setuid/setgid/sticky for safety.
+        os.chmod(target, member.mode & 0o755)
+
+
+def extract_tarball(
+    data: bytes,
+    expected_digest: str,
+    dest_root: Path,
+) -> str:
+    """Verify *data*'s sha256 then extract its gzipped tar contents into *dest_root*.
+
+    Returns the actual hex digest of *data* on success. Raises
+    ``HashMismatchError`` if the digest doesn't match, or
+    ``UnsafeTarballError`` if any member would escape *dest_root*.
+    """
+    actual = verify_sha256(data, expected_digest)
+    import io  # local import — only needed on the install path
+
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
+        _safe_extract(tar, Path(dest_root))
+    return actual

--- a/src/apm_cli/deps/registry/extractor.py
+++ b/src/apm_cli/deps/registry/extractor.py
@@ -1,13 +1,23 @@
-"""Tarball extraction with sha256 verification.
+"""Archive extraction with sha256 verification.
 
 Per docs/proposals/registry-api.md §5.2 and §6.1: the client MUST verify the
-sha256 digest of the tarball against the value advertised by ``GET /versions``
+sha256 digest of the archive against the value advertised by ``GET /versions``
 or recorded in the lockfile *before* extracting. A mismatch fails closed —
 this is the only security-critical check on the install path.
 
-Layout: tarballs are extracted into ``apm_modules/{owner}/{repo}/`` (the same
-shape the Git resolver produces after ``git clone``). Path-traversal entries
-are rejected — see ``_safe_extract``.
+Two archive formats are supported, dispatched by Content-Type from
+``RegistryClient.download_archive``:
+
+- ``application/gzip`` — gzipped tar (default APM ``apm pack`` output)
+- ``application/zip``  — zip archive (Anthropic / open-claude-skills format)
+
+The ``extract_archive`` dispatcher picks the right path and applies the same
+security gates to both: no absolute paths, no path traversal, no symlinks or
+hardlinks. The hash is checked against the raw bytes regardless of format —
+a wrong-format guess produces a clean error, not a security issue.
+
+Layout: archives are extracted into ``apm_modules/{owner}/{repo}/`` (the same
+shape the Git resolver produces after ``git clone``).
 """
 
 from __future__ import annotations
@@ -15,16 +25,49 @@ from __future__ import annotations
 import hashlib
 import os
 import tarfile
+import zipfile
 from pathlib import Path
 from typing import Optional
 
 
 class HashMismatchError(Exception):
-    """Raised when a tarball's sha256 does not match the expected digest."""
+    """Raised when an archive's sha256 does not match the expected digest."""
 
 
 class UnsafeTarballError(Exception):
-    """Raised when a tarball entry would escape the extraction root."""
+    """Raised when an archive entry would escape the extraction root.
+
+    Name kept for backward compat; covers both tar and zip cases.
+    """
+
+
+class UnknownArchiveFormatError(Exception):
+    """Raised when the archive format can't be inferred from content type or magic bytes."""
+
+
+# Archive-format magic-byte sniffers — used as a fallback when Content-Type
+# isn't reliable. Both formats have unambiguous prefixes.
+_GZIP_MAGIC = b"\x1f\x8b"
+_ZIP_MAGIC = b"PK\x03\x04"
+
+
+def _detect_format(data: bytes, content_type: Optional[str]) -> str:
+    """Return ``"tar+gzip"`` or ``"zip"``. Content-Type wins; magic bytes are fallback."""
+    if content_type:
+        ct = content_type.lower().strip()
+        if ct in ("application/gzip", "application/x-gzip", "application/x-tar+gzip"):
+            return "tar+gzip"
+        if ct in ("application/zip", "application/x-zip-compressed"):
+            return "zip"
+    # Fallback to magic bytes
+    if data.startswith(_GZIP_MAGIC):
+        return "tar+gzip"
+    if data.startswith(_ZIP_MAGIC):
+        return "zip"
+    raise UnknownArchiveFormatError(
+        f"cannot determine archive format from content_type={content_type!r}; "
+        f"first bytes were {data[:8]!r}"
+    )
 
 
 def _normalize_digest(digest: str) -> str:
@@ -134,3 +177,84 @@ def extract_tarball(
     with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
         _safe_extract(tar, Path(dest_root))
     return actual
+
+
+def _safe_extract_zip(zf: zipfile.ZipFile, dest_root: Path) -> None:
+    """Extract *zf* into *dest_root* with the same gates as the tar path.
+
+    Reject absolute paths, path traversal, and any entry that would resolve
+    outside *dest_root*. Symlinks in zip files are encoded as a Unix mode bit
+    (S_IFLNK in ``external_attr``) — we reject those too.
+    """
+    dest_root.mkdir(parents=True, exist_ok=True)
+    for info in zf.infolist():
+        # Symlinks in zip: high 16 bits of external_attr carry Unix mode.
+        # 0xA000 == S_IFLNK. Refuse to extract any symlink-typed entry.
+        unix_mode = (info.external_attr >> 16) & 0xFFFF
+        if unix_mode and (unix_mode & 0xF000) == 0xA000:
+            raise UnsafeTarballError(
+                f"unsupported zip entry type (symlink): {info.filename!r}"
+            )
+        target = _safe_member_path(info.filename, dest_root)
+        if target is None:
+            continue
+        if info.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # Stream content explicitly so we never call zf.extract() with the
+        # raw filename (avoids any zip-slip surprises in older Pythons).
+        with zf.open(info, "r") as src, open(target, "wb") as fh:
+            while True:
+                chunk = src.read(64 * 1024)
+                if not chunk:
+                    break
+                fh.write(chunk)
+        # Preserve mode bits if present, dropping setuid/setgid/sticky.
+        if unix_mode:
+            os.chmod(target, unix_mode & 0o755)
+
+
+def extract_zip(
+    data: bytes,
+    expected_digest: str,
+    dest_root: Path,
+) -> str:
+    """Verify *data*'s sha256 then extract its zip contents into *dest_root*.
+
+    Returns the actual hex digest of *data* on success. Raises
+    ``HashMismatchError`` on mismatch, or ``UnsafeTarballError`` (name kept
+    for backward compat) if any member would escape *dest_root*.
+    """
+    actual = verify_sha256(data, expected_digest)
+    import io  # local import — only needed on the install path
+
+    try:
+        with zipfile.ZipFile(io.BytesIO(data), mode="r") as zf:
+            _safe_extract_zip(zf, Path(dest_root))
+    except zipfile.BadZipFile as exc:
+        raise UnknownArchiveFormatError(f"malformed zip archive: {exc}") from exc
+    return actual
+
+
+def extract_archive(
+    data: bytes,
+    expected_digest: str,
+    dest_root: Path,
+    *,
+    content_type: Optional[str] = None,
+) -> str:
+    """Dispatcher: pick the right extractor based on Content-Type / magic bytes.
+
+    The hash check happens identically for both formats. A mismatch fails
+    before extraction even starts; format-detection errors fail before any
+    bytes are written.
+    """
+    fmt = _detect_format(data, content_type)
+    if fmt == "tar+gzip":
+        return extract_tarball(data, expected_digest, dest_root)
+    if fmt == "zip":
+        return extract_zip(data, expected_digest, dest_root)
+    # _detect_format raises UnknownArchiveFormatError otherwise; this is
+    # belt-and-braces.
+    raise UnknownArchiveFormatError(f"unsupported archive format: {fmt!r}")

--- a/src/apm_cli/deps/registry/resolver.py
+++ b/src/apm_cli/deps/registry/resolver.py
@@ -28,7 +28,7 @@ from .auth import (
     resolve_registry_token,
 )
 from .client import RegistryClient, RegistryError, VersionEntry
-from .extractor import extract_tarball
+from .extractor import extract_archive
 from .semver import is_semver_range, pick_best
 
 
@@ -206,7 +206,9 @@ class RegistryPackageResolver:
         chosen = self._pick_version(dep_ref, versions)
 
         try:
-            tarball = client.download_tarball(owner, repo, chosen.version)
+            archive_bytes, content_type = client.download_archive(
+                owner, repo, chosen.version
+            )
         except RegistryError as exc:
             self._raise_for_http(exc, dep_ref, base_url)
             raise
@@ -222,7 +224,15 @@ class RegistryPackageResolver:
                 else:
                     child.unlink(missing_ok=True)
 
-        actual_hash = extract_tarball(tarball, chosen.digest, target_path)
+        # extract_archive dispatches on Content-Type (with magic-bytes
+        # fallback) — supports both tar.gz (default) and zip (Anthropic
+        # skills format). Hash check happens before any extraction.
+        actual_hash = extract_archive(
+            archive_bytes,
+            chosen.digest,
+            target_path,
+            content_type=content_type,
+        )
 
         # Subdirectory virtual packages: the registry serves the parent
         # tarball, the client extracts the requested sub-path. We extract the
@@ -250,12 +260,12 @@ class RegistryPackageResolver:
                 f"registry tarball for {dep_ref.repo_url!r} validated but "
                 f"produced no package metadata"
             )
-        package.source = client.tarball_url(owner, repo, chosen.version)
+        package.source = client.archive_url(owner, repo, chosen.version)
         # version on the apm.yml side is whatever the package declared. We do
         # NOT overwrite with the registry-declared version; if they disagree
         # that's a publisher bug we want visible, not silently smoothed over.
 
-        resolved_url = client.tarball_url(owner, repo, chosen.version)
+        resolved_url = client.archive_url(owner, repo, chosen.version)
         self.last_resolutions[dep_ref.get_unique_key()] = RegistryResolution(
             resolved_url=resolved_url,
             resolved_hash=f"sha256:{actual_hash}",

--- a/src/apm_cli/deps/registry/resolver.py
+++ b/src/apm_cli/deps/registry/resolver.py
@@ -1,0 +1,318 @@
+"""Registry-backed package resolver.
+
+Implements the install-side of docs/proposals/registry-api.md: given a
+``DependencyReference`` whose ``source == "registry"``, fetch its tarball from
+the configured registry, verify the sha256, extract into the target directory,
+and build a ``PackageInfo`` that the rest of the install pipeline consumes
+without further changes (per §8 the only new branch is the download itself).
+
+This object satisfies the ``DownloadCallback`` shape used by the existing
+resolver: it exposes a ``download_package(dep_ref, target_path, ...)`` method
+that returns a ``PackageInfo``. Wiring into the install pipeline is done in
+``install/phases/resolve.py`` (separate commit) — this module is a pure unit.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Dict, Optional
+
+from ...models.apm_package import PackageInfo, validate_apm_package
+from ...models.dependency.reference import DependencyReference
+from ...models.dependency.types import GitReferenceType, ResolvedReference
+from .auth import (
+    RegistryAuthContext,
+    remediation_message,
+    resolve_for_url,
+    resolve_registry_token,
+)
+from .client import RegistryClient, RegistryError, VersionEntry
+from .extractor import extract_tarball
+from .semver import is_semver_range, pick_best
+
+
+class RegistryResolutionError(Exception):
+    """A registry-sourced install failed in a way the user must act on.
+
+    Wraps lower-level errors (auth, hash mismatch, no matching version, missing
+    URL) into a single exception type the install pipeline can catch and
+    surface with the §6.2 remediation message intact.
+    """
+
+
+def _split_owner_repo(repo_url: str) -> tuple[str, str]:
+    """Split ``owner/repo`` (or longer paths) into (owner, repo) for the API.
+
+    For paths with more than two segments (e.g. ``group/subgroup/repo``), we
+    treat the last segment as the repo and the rest as the owner — the API
+    contract uses ``{owner}/{repo}`` as a flat two-segment identity.
+    """
+    parts = [p for p in repo_url.split("/") if p]
+    if len(parts) < 2:
+        raise RegistryResolutionError(
+            f"registry-sourced dep needs an 'owner/repo' identity, got {repo_url!r}"
+        )
+    if len(parts) == 2:
+        return parts[0], parts[1]
+    return "/".join(parts[:-1]), parts[-1]
+
+
+class RegistryPackageResolver:
+    """Drop-in download callback that fetches packages from a REST registry.
+
+    One instance per resolution graph is fine — the resolver picks the right
+    registry per dep based on ``dep_ref.registry_name`` and the configured
+    ``registries`` mapping.
+    """
+
+    def __init__(
+        self,
+        registries: Dict[str, str],
+        *,
+        client_factory: Optional[
+            Callable[[str, RegistryAuthContext], RegistryClient]
+        ] = None,
+    ) -> None:
+        """
+        Args:
+            registries: Mapping of registry name -> base URL, sourced from the
+                top-level ``registries:`` block in apm.yml (merged with user
+                config). The ``"default"`` key, if present, may either be a
+                string registry name or a string URL — it is consumed at
+                routing time, not here, so this map should already be
+                normalized to ``{name: url, ...}`` without ``"default"``.
+            client_factory: Optional override for ``RegistryClient`` construction.
+                Tests inject this to swap in a fake HTTP client.
+        """
+        self._registries = dict(registries)
+        self._client_factory = client_factory or (
+            lambda url, auth: RegistryClient(url, auth)
+        )
+
+    # The dep tracker stores a per-dep "resolution result" used by the
+    # lockfile writer to fill in resolved_url + resolved_hash. It's exposed
+    # via this lookup so the install pipeline can read it after the callback
+    # returns. Keyed by ``DependencyReference.get_unique_key()``.
+    @property
+    def last_resolutions(self) -> Dict[str, "RegistryResolution"]:
+        if not hasattr(self, "_last_resolutions"):
+            self._last_resolutions = {}
+        return self._last_resolutions
+
+    # ------------------------------------------------------------------
+    def _resolve_registry_url(self, registry_name: Optional[str]) -> str:
+        if not registry_name:
+            raise RegistryResolutionError(
+                "registry-sourced dep is missing registry_name "
+                "(parser bug or unconfigured default registry)"
+            )
+        url = self._registries.get(registry_name)
+        if not url:
+            raise RegistryResolutionError(
+                f"registry {registry_name!r} is not configured in apm.yml's "
+                f"registries: block"
+            )
+        return url
+
+    def _build_client(self, registry_name: str, base_url: str) -> RegistryClient:
+        token = resolve_registry_token(registry_name)
+        auth = RegistryAuthContext(registry_name=registry_name, token=token)
+        return self._client_factory(base_url, auth)
+
+    def _build_client_for_url(self, base_url: str) -> RegistryClient:
+        """Build a client for a URL whose registry name we look up from config.
+
+        Used on the lockfile re-install path (§6.2): the URL is already
+        recorded; we walk the configured registries to find which name owns
+        that URL, then resolve its token. If no match, fall back to anonymous.
+        """
+        auth = resolve_for_url(base_url, self._registries)
+        return self._client_factory(base_url, auth)
+
+    def _pick_version(
+        self, dep_ref: DependencyReference, versions: list[VersionEntry]
+    ) -> VersionEntry:
+        spec = dep_ref.reference or ""
+        if not spec:
+            raise RegistryResolutionError(
+                f"registry-sourced dep {dep_ref.repo_url!r} has no version "
+                f"constraint (semver range required)"
+            )
+        if not is_semver_range(spec):
+            # The parser should have rejected this earlier; this is defense in
+            # depth for direct callers that bypass the parser.
+            raise RegistryResolutionError(
+                f"version constraint {spec!r} on {dep_ref.repo_url!r} is not "
+                f"a valid semver range"
+            )
+        version_strings = [v.version for v in versions]
+        best = pick_best(spec, version_strings)
+        if best is None:
+            raise RegistryResolutionError(
+                f"no version of {dep_ref.repo_url!r} matches {spec!r} "
+                f"in registry {dep_ref.registry_name!r} "
+                f"(available: {', '.join(version_strings) or '<none>'})"
+            )
+        for v in versions:
+            if v.version == best:
+                return v
+        # Unreachable: pick_best returned a string we already iterated over.
+        raise RegistryResolutionError(
+            f"internal error: picked {best!r} but no matching VersionEntry"
+        )
+
+    # ------------------------------------------------------------------
+    def download_package(
+        self,
+        repo_ref,  # str | DependencyReference (mirrors GitHubPackageDownloader)
+        target_path: Path,
+        progress_task_id=None,
+        progress_obj=None,
+        verbose_callback=None,
+    ) -> PackageInfo:
+        """Fetch *repo_ref* from its configured registry into *target_path*.
+
+        Mirrors ``GitHubPackageDownloader.download_package``'s signature so
+        both can be invoked through the same ``DownloadCallback`` shape in
+        ``install/phases/resolve.py``.
+        """
+        dep_ref = (
+            repo_ref
+            if isinstance(repo_ref, DependencyReference)
+            else DependencyReference.parse(repo_ref)
+        )
+        if dep_ref.source != "registry":
+            raise RegistryResolutionError(
+                f"RegistryPackageResolver invoked for non-registry dep "
+                f"{dep_ref.repo_url!r} (source={dep_ref.source!r})"
+            )
+
+        owner, repo = _split_owner_repo(dep_ref.repo_url)
+        base_url = self._resolve_registry_url(dep_ref.registry_name)
+        client = self._build_client(dep_ref.registry_name, base_url)
+
+        try:
+            versions = client.list_versions(owner, repo)
+        except RegistryError as exc:
+            self._raise_for_http(exc, dep_ref, base_url)
+            raise  # unreachable; _raise_for_http always raises
+        if not versions:
+            raise RegistryResolutionError(
+                f"registry {dep_ref.registry_name!r} reports no versions for "
+                f"{dep_ref.repo_url!r}"
+            )
+
+        chosen = self._pick_version(dep_ref, versions)
+
+        try:
+            tarball = client.download_tarball(owner, repo, chosen.version)
+        except RegistryError as exc:
+            self._raise_for_http(exc, dep_ref, base_url)
+            raise
+
+        target_path.mkdir(parents=True, exist_ok=True)
+        # If the target already has content (e.g. retry), wipe it. Mirrors the
+        # Git path's behavior at github_downloader.py:2546.
+        if any(target_path.iterdir()):
+            for child in target_path.iterdir():
+                if child.is_dir():
+                    import shutil
+                    shutil.rmtree(child, ignore_errors=True)
+                else:
+                    child.unlink(missing_ok=True)
+
+        actual_hash = extract_tarball(tarball, chosen.digest, target_path)
+
+        # Subdirectory virtual packages: the registry serves the parent
+        # tarball, the client extracts the requested sub-path. We extract the
+        # whole tree first (above), then trim down to the virtual path here.
+        # Virtual file packages reuse the existing primitive layout — keep it
+        # simple in this PR: only support full-package and subdirectory shapes.
+        if dep_ref.is_virtual and dep_ref.virtual_path and dep_ref.is_virtual_subdirectory():
+            sub = target_path / dep_ref.virtual_path
+            if not sub.exists():
+                raise RegistryResolutionError(
+                    f"virtual sub-path {dep_ref.virtual_path!r} not found in "
+                    f"package {dep_ref.repo_url!r} at version {chosen.version}"
+                )
+
+        validation_result = validate_apm_package(target_path)
+        if not validation_result.is_valid:
+            errs = "\n  - ".join(validation_result.errors)
+            raise RegistryResolutionError(
+                f"registry tarball for {dep_ref.repo_url!r} did not validate "
+                f"as an APM package:\n  - {errs}"
+            )
+        package = validation_result.package
+        if package is None:
+            raise RegistryResolutionError(
+                f"registry tarball for {dep_ref.repo_url!r} validated but "
+                f"produced no package metadata"
+            )
+        package.source = client.tarball_url(owner, repo, chosen.version)
+        # version on the apm.yml side is whatever the package declared. We do
+        # NOT overwrite with the registry-declared version; if they disagree
+        # that's a publisher bug we want visible, not silently smoothed over.
+
+        resolved_url = client.tarball_url(owner, repo, chosen.version)
+        self.last_resolutions[dep_ref.get_unique_key()] = RegistryResolution(
+            resolved_url=resolved_url,
+            resolved_hash=f"sha256:{actual_hash}",
+            version=chosen.version,
+        )
+
+        # Synthesize a ResolvedReference so the rest of the pipeline (which
+        # expects one) doesn't choke. Registry deps are TAG-shaped from a
+        # consumer perspective: an immutable named version.
+        resolved_ref = ResolvedReference(
+            original_ref=dep_ref.reference or chosen.version,
+            ref_type=GitReferenceType.TAG,
+            ref_name=chosen.version,
+            resolved_commit=None,
+        )
+
+        return PackageInfo(
+            package=package,
+            install_path=target_path,
+            resolved_reference=resolved_ref,
+            installed_at=datetime.now().isoformat(),
+            dependency_ref=dep_ref,
+            package_type=validation_result.package_type,
+        )
+
+    # ------------------------------------------------------------------
+    def _raise_for_http(
+        self,
+        exc: RegistryError,
+        dep_ref: DependencyReference,
+        base_url: str,
+    ) -> None:
+        if exc.status in (401, 403):
+            raise RegistryResolutionError(
+                f"{exc}\n{remediation_message(base_url)}"
+            ) from exc
+        if exc.status == 404:
+            raise RegistryResolutionError(
+                f"registry {dep_ref.registry_name!r} has no package "
+                f"{dep_ref.repo_url!r} (HTTP 404 from {exc.url})"
+            ) from exc
+        raise RegistryResolutionError(str(exc)) from exc
+
+
+# Carried out-of-band from download_package() so the install pipeline can
+# read it when writing the lockfile (resolved_url + resolved_hash). Keeping
+# the PackageInfo shape unchanged keeps existing callers byte-identical.
+class RegistryResolution:
+    __slots__ = ("resolved_url", "resolved_hash", "version")
+
+    def __init__(self, *, resolved_url: str, resolved_hash: str, version: str) -> None:
+        self.resolved_url = resolved_url
+        self.resolved_hash = resolved_hash
+        self.version = version
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return (
+            f"RegistryResolution(version={self.version!r}, "
+            f"url={self.resolved_url!r}, hash={self.resolved_hash[:24]!r}...)"
+        )

--- a/src/apm_cli/deps/registry/semver.py
+++ b/src/apm_cli/deps/registry/semver.py
@@ -1,0 +1,212 @@
+"""Minimal npm-style semver matcher for registry version selection.
+
+Supports the range shapes called out in docs/proposals/registry-api.md §3.3:
+
+- Exact version:        ``1.0.0``, ``v1.0.0``
+- Caret:                ``^1.2``, ``^1.0.0``
+- Tilde:                ``~1.2.3``
+- Comparison:           ``>=1``, ``<2``, ``>=1,<2``
+- X-range / wildcard:   ``1.x``, ``1.2.x``, ``*``
+
+The proposal explicitly rejects branch names (``main``), commit SHAs
+(``abc123d``), and arbitrary strings (``latest``) at parse time when an entry
+routes to a registry. ``is_semver_range()`` is the parse-time gate.
+
+Why a vendored matcher instead of ``packaging.specifiers``: PEP 440 differs
+from npm semver in surface ways (no ``^``/``~`` per se, x-range syntax, version
+prefix). The proposal's example ranges are npm-style, and registries on the
+wire are likely to mirror npm's grammar. Keeping the matcher small and
+dependency-free avoids dragging in a heavyweight dep for a few operators.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+# A version is exactly: major[.minor[.patch]] with an optional leading ``v``.
+_VERSION_RE = re.compile(r"^v?(\d+)(?:\.(\d+))?(?:\.(\d+))?$")
+
+# A range component is one of:
+#   - bare version (exact)
+#   - operator + version: ^X[.Y[.Z]] | ~X[.Y[.Z]] | >=X | >X | <=X | <X | =X
+#   - x-range: X.x, X.Y.x, X.*
+#   - star: *
+_RANGE_OPS = ("^", "~", ">=", "<=", ">", "<", "=")
+
+
+@dataclass(frozen=True)
+class _Bound:
+    """A single comparison constraint, e.g. ``>=1.2.0``."""
+
+    op: str  # one of: =, >=, >, <=, <
+    major: int
+    minor: int
+    patch: int
+
+    def matches(self, v: Tuple[int, int, int]) -> bool:
+        target = (self.major, self.minor, self.patch)
+        if self.op == "=":
+            return v == target
+        if self.op == ">":
+            return v > target
+        if self.op == ">=":
+            return v >= target
+        if self.op == "<":
+            return v < target
+        if self.op == "<=":
+            return v <= target
+        return False
+
+
+def _parse_version(s: str) -> Optional[Tuple[int, int, int]]:
+    """Parse ``v?X[.Y[.Z]]`` into ``(major, minor, patch)``. Missing parts default to 0."""
+    m = _VERSION_RE.match(s.strip())
+    if not m:
+        return None
+    major = int(m.group(1))
+    minor = int(m.group(2)) if m.group(2) is not None else 0
+    patch = int(m.group(3)) if m.group(3) is not None else 0
+    return (major, minor, patch)
+
+
+def _expand_component(comp: str) -> Optional[List[_Bound]]:
+    """Expand one range component (e.g. ``^1.2``) into one or two bounds.
+
+    Returns ``None`` if the component is not a valid semver range piece.
+    """
+    comp = comp.strip()
+    if not comp:
+        return None
+    if comp == "*":
+        return [_Bound(">=", 0, 0, 0)]
+
+    # X-range: 1.x, 1.2.x, 1.*, 1.2.*
+    x_match = re.match(r"^v?(\d+)(?:\.(\d+|x|\*))?(?:\.(\d+|x|\*))?$", comp)
+    if x_match:
+        major_s, minor_s, patch_s = x_match.group(1), x_match.group(2), x_match.group(3)
+        if minor_s in ("x", "*", None) and patch_s in ("x", "*", None) and (
+            minor_s in ("x", "*") or patch_s in ("x", "*") or minor_s is None
+        ):
+            # Skip if it's actually a fully concrete version like ``1.2.3``
+            if minor_s not in (None, "x", "*") and patch_s not in (None, "x", "*"):
+                pass  # fall through to exact below
+            else:
+                major = int(major_s)
+                if minor_s in (None, "x", "*"):
+                    return [
+                        _Bound(">=", major, 0, 0),
+                        _Bound("<", major + 1, 0, 0),
+                    ]
+                # minor concrete, patch wildcard
+                minor = int(minor_s)
+                return [
+                    _Bound(">=", major, minor, 0),
+                    _Bound("<", major, minor + 1, 0),
+                ]
+
+    # Operator-prefixed: ^1.2, ~1.2.3, >=1, <2, =1.0.0
+    for op in _RANGE_OPS:
+        if comp.startswith(op):
+            rest = comp[len(op):]
+            v = _parse_version(rest)
+            if v is None:
+                return None
+            major, minor, patch = v
+            if op == "^":
+                # ^1.2.3 := >=1.2.3, <2.0.0
+                # ^0.2.3 := >=0.2.3, <0.3.0  (npm semver rule for 0.x)
+                # ^0.0.3 := >=0.0.3, <0.0.4
+                if major > 0:
+                    return [
+                        _Bound(">=", major, minor, patch),
+                        _Bound("<", major + 1, 0, 0),
+                    ]
+                if minor > 0:
+                    return [
+                        _Bound(">=", major, minor, patch),
+                        _Bound("<", 0, minor + 1, 0),
+                    ]
+                return [
+                    _Bound(">=", major, minor, patch),
+                    _Bound("<", 0, 0, patch + 1),
+                ]
+            if op == "~":
+                # ~1.2.3 := >=1.2.3, <1.3.0
+                # ~1.2   := >=1.2.0, <1.3.0
+                # ~1     := >=1.0.0, <2.0.0
+                if "." in rest.lstrip("v"):
+                    return [
+                        _Bound(">=", major, minor, patch),
+                        _Bound("<", major, minor + 1, 0),
+                    ]
+                return [
+                    _Bound(">=", major, minor, patch),
+                    _Bound("<", major + 1, 0, 0),
+                ]
+            return [_Bound(op, major, minor, patch)]
+
+    # Bare version: exact
+    v = _parse_version(comp)
+    if v is None:
+        return None
+    return [_Bound("=", *v)]
+
+
+def _parse_range(spec: str) -> Optional[List[_Bound]]:
+    """Parse a comma-separated range expression into a flat list of bounds.
+
+    Returns ``None`` if any component is invalid. A returned list is treated as
+    a conjunction (all bounds must hold).
+    """
+    if not spec or not spec.strip():
+        return None
+    bounds: List[_Bound] = []
+    for piece in spec.split(","):
+        sub = _expand_component(piece)
+        if sub is None:
+            return None
+        bounds.extend(sub)
+    return bounds
+
+
+def is_semver_range(spec: str) -> bool:
+    """Return ``True`` iff *spec* is a valid semver version or range.
+
+    Used at parse time to reject branch names, commit SHAs, and arbitrary refs
+    when an entry routes through a registry (design §3.3).
+    """
+    return _parse_range(spec) is not None
+
+
+def match_version(spec: str, version: str) -> bool:
+    """Return ``True`` iff *version* satisfies the semver range *spec*."""
+    bounds = _parse_range(spec)
+    if bounds is None:
+        return False
+    v = _parse_version(version)
+    if v is None:
+        return False
+    return all(b.matches(v) for b in bounds)
+
+
+def pick_best(spec: str, versions: List[str]) -> Optional[str]:
+    """Return the highest *version* in *versions* that satisfies *spec*.
+
+    Returns ``None`` if no version matches or the spec is invalid.
+    """
+    bounds = _parse_range(spec)
+    if bounds is None:
+        return None
+    candidates: List[Tuple[Tuple[int, int, int], str]] = []
+    for raw in versions:
+        v = _parse_version(raw)
+        if v is None:
+            continue
+        if all(b.matches(v) for b in bounds):
+            candidates.append((v, raw))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda pair: pair[0])
+    return candidates[-1][1]

--- a/src/apm_cli/deps/registry/semver.py
+++ b/src/apm_cli/deps/registry/semver.py
@@ -82,29 +82,27 @@ def _expand_component(comp: str) -> Optional[List[_Bound]]:
     if comp == "*":
         return [_Bound(">=", 0, 0, 0)]
 
-    # X-range: 1.x, 1.2.x, 1.*, 1.2.*
+    # X-range: 1.x, 1.2.x, 1.*, 1.2.* — any segment of x or * means "any".
+    # We only enter this branch when at least one segment is wildcard; bare
+    # ``1.2.3`` falls through to the exact-version path below.
     x_match = re.match(r"^v?(\d+)(?:\.(\d+|x|\*))?(?:\.(\d+|x|\*))?$", comp)
     if x_match:
         major_s, minor_s, patch_s = x_match.group(1), x_match.group(2), x_match.group(3)
-        if minor_s in ("x", "*", None) and patch_s in ("x", "*", None) and (
-            minor_s in ("x", "*") or patch_s in ("x", "*") or minor_s is None
-        ):
-            # Skip if it's actually a fully concrete version like ``1.2.3``
-            if minor_s not in (None, "x", "*") and patch_s not in (None, "x", "*"):
-                pass  # fall through to exact below
-            else:
-                major = int(major_s)
-                if minor_s in (None, "x", "*"):
-                    return [
-                        _Bound(">=", major, 0, 0),
-                        _Bound("<", major + 1, 0, 0),
-                    ]
-                # minor concrete, patch wildcard
-                minor = int(minor_s)
+        has_wildcard = (minor_s in ("x", "*")) or (patch_s in ("x", "*"))
+        if has_wildcard:
+            major = int(major_s)
+            # minor is wildcard (or absent) -> [major.0.0, (major+1).0.0)
+            if minor_s in (None, "x", "*"):
                 return [
-                    _Bound(">=", major, minor, 0),
-                    _Bound("<", major, minor + 1, 0),
+                    _Bound(">=", major, 0, 0),
+                    _Bound("<", major + 1, 0, 0),
                 ]
+            # minor concrete, patch wildcard -> [major.minor.0, major.(minor+1).0)
+            minor = int(minor_s)
+            return [
+                _Bound(">=", major, minor, 0),
+                _Bound("<", major, minor + 1, 0),
+            ]
 
     # Operator-prefixed: ^1.2, ~1.2.3, >=1, <2, =1.0.0
     for op in _RANGE_OPS:

--- a/src/apm_cli/drift.py
+++ b/src/apm_cli/drift.py
@@ -95,8 +95,43 @@ def detect_ref_change(
         return False
     if locked_dep is None:
         return False  # new package — not drift, just a first install
-    # Direct comparison: handles None→value, value→None, and value→value.
-    # No truthiness guard on locked_dep.resolved_ref — None != "v1.0.0" is True.
+
+    # Source flip drift: manifest changed resolver between installs (e.g.
+    # was ``- git: ...``, now ``acme/foo@corp#^1.0``). The install path,
+    # auth chain, and trust anchor all change — force a re-resolve.
+    # Note: source=None and source="git" are equivalent (legacy default).
+    manifest_source = dep_ref.source or "git"
+    locked_source = (locked_dep.source if locked_dep.source else "git")
+    if manifest_source != locked_source:
+        return True
+
+    # Registry-sourced deps: the manifest carries a semver range
+    # (e.g. ``^1.2``) while the lockfile records an exact version
+    # (e.g. ``1.5.3``). Plain string comparison would be a false
+    # positive — instead, ask whether the locked version still
+    # satisfies the manifest range. If yes, no drift; if no, drift
+    # (the user expanded/contracted the range away from the locked
+    # version and we need to re-resolve).
+    if manifest_source == "registry":
+        from apm_cli.deps.registry.semver import is_semver_range, match_version
+        manifest_range = dep_ref.reference
+        locked_version = locked_dep.version
+        if not manifest_range:
+            # Registry dep with no #<ref>: should have been rejected at
+            # parse time. Treat as drift to fail loud.
+            return True
+        if not locked_version:
+            # Lockfile entry missing version (corrupted or v1->v2 mid-flight).
+            return True
+        if is_semver_range(manifest_range) and match_version(
+            manifest_range, locked_version
+        ):
+            return False
+        return True
+
+    # Git/local deps: direct ref comparison. Handles None→value, value→None,
+    # and value→value. No truthiness guard on locked_dep.resolved_ref —
+    # None != "v1.0.0" is True.
     if dep_ref.reference != locked_dep.resolved_ref:
         return True
 
@@ -262,8 +297,14 @@ def build_download_ref(
                     locked_dep, "allow_insecure", False
                 )
 
+            # Registry-sourced deps: replay the exact locked version (not
+            # the manifest range). The resolver still calls /versions and
+            # the hash check is the trust gate. design §6.1.
+            if locked_dep.source == "registry" and locked_dep.version:
+                overrides["reference"] = locked_dep.version
+                overrides["source"] = "registry"
             # Use locked commit SHA for byte-for-byte reproducibility.
-            if locked_dep.resolved_commit and locked_dep.resolved_commit != "cached":
+            elif locked_dep.resolved_commit and locked_dep.resolved_commit != "cached":
                 overrides["reference"] = locked_dep.resolved_commit
             # For proxy deps without a commit SHA (Artifactory zip archives),
             # preserve the locked ref so we download the same ref on replay.

--- a/src/apm_cli/install/context.py
+++ b/src/apm_cli/install/context.py
@@ -94,7 +94,8 @@ class InstallContext:
     # Pre-integrate inputs (populated by caller before integrate phase)
     # ------------------------------------------------------------------
     diagnostics: Any = None  # DiagnosticCollector
-    registry_config: Any = None  # RegistryConfig
+    registry_config: Any = None  # RegistryConfig (proxy registry; pre-existing)
+    registry_resolver: Any = None  # RegistryPackageResolver — dedicated registry resolver (design §3.1)
     managed_files: Set[str] = field(default_factory=set)
 
     # ------------------------------------------------------------------

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -25,6 +25,24 @@ if TYPE_CHECKING:
     from apm_cli.install.context import InstallContext
 
 
+def _lockfile_has_registry_deps(existing_lockfile) -> bool:
+    """True when the on-disk lockfile records at least one registry-sourced dep.
+
+    Used to construct the registry resolver even when apm.yml's
+    ``registries:`` block has been removed but locked deps still need to
+    re-install. A user clones a repo, the apm.yml has no registries: block
+    but the lockfile says some deps are ``source: registry`` — we still
+    want them to install (they'll fail at auth lookup if the URL doesn't
+    match anything configured, with a clear remediation per §6.2).
+    """
+    if not existing_lockfile:
+        return False
+    return any(
+        dep.source == "registry"
+        for dep in existing_lockfile.dependencies.values()
+    )
+
+
 def run(ctx: "InstallContext") -> None:
     """Execute the resolve phase.
 
@@ -97,6 +115,25 @@ def run(ctx: "InstallContext") -> None:
     ctx.downloader = downloader
 
     # ------------------------------------------------------------------
+    # 3b. Dedicated registry resolver (design §3.1, §8)
+    # ------------------------------------------------------------------
+    # Built when:
+    #   - the manifest's apm.yml has a top-level ``registries:`` block, OR
+    #   - the on-disk lockfile has at least one ``source: registry`` entry
+    #     (re-install of a project whose authors removed the block but the
+    #     locked deps still need somewhere to land).
+    # In the second case the URL is the trust anchor — auth resolves by
+    # URL prefix against the apm.yml registries map (which may be empty,
+    # forcing anonymous fetch).
+    registry_resolver = None
+    registries_map = getattr(ctx.apm_package, "registries", None) or {}
+    needs_registry = bool(registries_map) or _lockfile_has_registry_deps(existing_lockfile)
+    if needs_registry:
+        from apm_cli.deps.registry.resolver import RegistryPackageResolver
+        registry_resolver = RegistryPackageResolver(registries_map)
+    ctx.registry_resolver = registry_resolver
+
+    # ------------------------------------------------------------------
     # 4. Tracking variables (phase-local except where noted)
     # ------------------------------------------------------------------
     # direct_dep_keys is phase-local (only read inside download_callback)
@@ -132,6 +169,32 @@ def run(ctx: "InstallContext") -> None:
         if install_path.exists():
             return install_path
         try:
+            # ─── Registry-sourced dep (design §8) ──────────────────────
+            # Routed before local/git so the registry resolver owns the
+            # download for source=="registry" entries. Lockfile re-installs
+            # may arrive with registry_name=None — look it up by URL prefix
+            # against the configured registries map.
+            if dep_ref.source == "registry":
+                if registry_resolver is None:
+                    raise RuntimeError(
+                        f"dep {dep_ref.repo_url!r} is registry-sourced but no "
+                        f"registries: block is configured in apm.yml and the "
+                        f"lockfile carries no resolved_url for it."
+                    )
+                if dep_ref.registry_name is None and existing_lockfile:
+                    from apm_cli.deps.registry.auth import lookup_name_for_url
+                    from dataclasses import replace as _dc_replace
+                    locked = existing_lockfile.get_dependency(dep_ref.get_unique_key())
+                    if locked and locked.resolved_url and registries_map:
+                        name = lookup_name_for_url(locked.resolved_url, registries_map)
+                        if name:
+                            dep_ref = _dc_replace(dep_ref, registry_name=name)
+                registry_resolver.download_package(dep_ref, install_path)
+                # Mark as already-downloaded so the parallel pre-download
+                # phase skips this dep. No SHA for registry deps.
+                callback_downloaded[dep_ref.get_unique_key()] = None
+                return install_path
+
             # Handle local packages: copy instead of git clone
             if dep_ref.is_local and dep_ref.local_path:
                 if scope is InstallScope.USER:

--- a/src/apm_cli/install/sources.py
+++ b/src/apm_cli/install/sources.py
@@ -351,10 +351,24 @@ class CachedDependencySource(DependencySource):
         elif ctx.registry_config and not dep_ref.is_local:
             _cached_registry = ctx.registry_config
 
+        # Registry-sourced cached dep: preserve the lockfile's resolved_url
+        # + resolved_hash + version across re-installs by synthesizing a
+        # RegistryResolution from the existing locked entry. Without this,
+        # the lockfile would lose those fields on every cache-hit re-install.
+        _cached_resolution = None
+        if dep_ref.source == "registry" and dep_locked_chk and dep_locked_chk.resolved_url:
+            from apm_cli.deps.registry.resolver import RegistryResolution
+            _cached_resolution = RegistryResolution(
+                resolved_url=dep_locked_chk.resolved_url,
+                resolved_hash=dep_locked_chk.resolved_hash or "",
+                version=dep_locked_chk.version or (dep_ref.reference or ""),
+            )
+
         ctx.installed_packages.append(InstalledPackage(
             dep_ref=dep_ref, resolved_commit=cached_commit,
             depth=depth, resolved_by=resolved_by, is_dev=_is_dev,
             registry_config=_cached_registry,
+            registry_resolution=_cached_resolution,
         ))
         if install_path.is_dir():
             ctx.package_hashes[dep_key] = _compute_hash(install_path)
@@ -434,6 +448,33 @@ class FreshDependencySource(DependencySource):
 
             if dep_key in ctx.pre_download_results:
                 package_info = ctx.pre_download_results[dep_key]
+            elif dep_ref.source == "registry":
+                # Registry-sourced dep: dispatch to the dedicated-registry
+                # resolver instead of the GitHub downloader. This branch
+                # fires when (a) the BFS callback skipped due to existing
+                # install path on a re-install, or (b) parallel pre-download
+                # was skipped (registry deps aren't pre-downloaded).
+                _registry_resolver = getattr(ctx, "registry_resolver", None)
+                if _registry_resolver is None:
+                    raise RuntimeError(
+                        f"dep {dep_ref.repo_url!r} is registry-sourced but "
+                        f"no registry resolver was constructed (apm.yml may "
+                        f"be missing a 'registries:' block)."
+                    )
+                # Lockfile re-install path: registry_name might be absent —
+                # look it up from the lockfile's resolved_url.
+                if download_ref.source == "registry" and download_ref.registry_name is None:
+                    from apm_cli.deps.registry.auth import lookup_name_for_url
+                    from dataclasses import replace as _dc_replace
+                    if dep_locked_chk and dep_locked_chk.resolved_url:
+                        _regs = getattr(ctx.apm_package, "registries", None) or {}
+                        _name = lookup_name_for_url(dep_locked_chk.resolved_url, _regs)
+                        if _name:
+                            download_ref = _dc_replace(download_ref, registry_name=_name)
+                package_info = _registry_resolver.download_package(
+                    download_ref,
+                    install_path,
+                )
             else:
                 package_info = ctx.downloader.download_package(
                     download_ref,
@@ -494,10 +535,19 @@ class FreshDependencySource(DependencySource):
                 node.parent.dependency_ref.repo_url if node and node.parent else None
             )
             _is_dev = node.is_dev if node else False
+            # Registry-sourced deps: pull the captured resolution out of
+            # the resolver's per-graph map so the lockfile records
+            # resolved_url + resolved_hash + version (design §6.1).
+            _registry_resolution = None
+            if dep_ref.source == "registry":
+                _resolver = getattr(ctx, "registry_resolver", None)
+                if _resolver is not None:
+                    _registry_resolution = _resolver.last_resolutions.get(dep_key)
             ctx.installed_packages.append(InstalledPackage(
                 dep_ref=dep_ref, resolved_commit=resolved_commit,
                 depth=depth, resolved_by=resolved_by, is_dev=_is_dev,
                 registry_config=ctx.registry_config if not dep_ref.is_local else None,
+                registry_resolution=_registry_resolution,
             ))
             if install_path.is_dir():
                 ctx.package_hashes[dep_key] = _compute_hash(install_path)

--- a/src/apm_cli/marketplace/client.py
+++ b/src/apm_cli/marketplace/client.py
@@ -367,6 +367,64 @@ def search_all_marketplaces(
     return results
 
 
+def search_all_registries(
+    query: str,
+    registries: Dict[str, str],
+    *,
+    limit: int = 50,
+    type: Optional[str] = None,
+    tag: Optional[str] = None,
+) -> List[MarketplacePlugin]:
+    """Server-side search across configured dedicated APM registries.
+
+    Per docs/proposals/registry-api.md §5.4 + §9: registry-hosted catalogs
+    expose a ``GET /v1/search`` endpoint that runs server-side (permission-
+    scoped, real-time, no full-catalog download). This helper queries each
+    configured registry and adapts the results into ``MarketplacePlugin``
+    so callers can merge them with marketplace results.
+
+    Args:
+        query: Free-text search string.
+        registries: Mapping of registry name -> base URL (typically
+            ``ctx.apm_package.registries`` or the merged user/project map).
+        limit: Per-registry result cap.
+        type: Optional primitive-type filter (``skill``, ``prompt``, ...).
+        tag: Optional tag filter.
+
+    Failures (auth, network, malformed response) are logged and the
+    registry is skipped — one bad registry must not block search across
+    the others. Same semantics as ``search_all_marketplaces``.
+    """
+    from apm_cli.deps.registry.auth import RegistryAuthContext, resolve_registry_token
+    from apm_cli.deps.registry.client import RegistryClient, RegistryError
+
+    results: List[MarketplacePlugin] = []
+    for name, base_url in (registries or {}).items():
+        if not base_url:
+            continue
+        try:
+            auth = RegistryAuthContext(
+                registry_name=name, token=resolve_registry_token(name)
+            )
+            client = RegistryClient(base_url, auth)
+            for hit in client.search(query, limit=limit, type=type, tag=tag):
+                results.append(
+                    MarketplacePlugin(
+                        name=hit.id,
+                        description=hit.description or "",
+                        version=hit.latest_version or "",
+                        tags=tuple(hit.tags or ()),
+                        source_marketplace=name,
+                        registry=name,
+                    )
+                )
+        except RegistryError as exc:
+            logger.warning("Skipping registry '%s': %s", name, exc)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Skipping registry '%s' due to unexpected error: %s", name, exc)
+    return results
+
+
 def clear_marketplace_cache(
     name: Optional[str] = None,
     host: str = "github.com",

--- a/src/apm_cli/marketplace/models.py
+++ b/src/apm_cli/marketplace/models.py
@@ -64,6 +64,16 @@ class MarketplacePlugin:
     tags: Tuple[str, ...] = ()
     source_marketplace: str = ""  # Populated during resolution
 
+    # Dedicated registry routing per docs/proposals/registry-api.md §4.5.
+    # When set, the plugin resolves through the named APM registry (rather
+    # than the existing Git resolver). ``version`` is interpreted as a
+    # semver range. ``registry == ""`` (default) keeps existing semantics:
+    # the plugin resolves via Git and ``version`` is a Git ref/tag.
+    # The discriminator is a separate field (not piggybacking on ``source``)
+    # to avoid colliding with the existing source-location semantics where
+    # ``source`` is a string path or ``{type: github, repo: ...}`` dict.
+    registry: str = ""
+
     def matches_query(self, query: str) -> bool:
         """Return True if the plugin matches a search query (case-insensitive)."""
         q = query.lower()
@@ -165,6 +175,40 @@ def _parse_plugin_entry(
         logger.debug("Plugin '%s' has no source or repository field", name)
         return None
 
+    # Optional dedicated-registry routing (design §4.5). When ``registry``
+    # is set, ``version`` is interpreted as a semver range and the plugin
+    # resolves via the dedicated-registry resolver. The marketplace.json
+    # parser is intentionally permissive — invalid values are downgraded
+    # to "no registry routing" and a debug log line, so a malformed entry
+    # doesn't break a whole marketplace fetch.
+    registry_name = ""
+    raw_registry = entry.get("registry")
+    if raw_registry is not None:
+        if isinstance(raw_registry, str) and raw_registry.strip():
+            registry_name = raw_registry.strip()
+        else:
+            logger.debug(
+                "Plugin '%s' has invalid 'registry' field (expected non-empty "
+                "string), ignoring",
+                name,
+            )
+
+    if registry_name and version:
+        # Validate semver range for registry-routed plugins. A bad ref
+        # surfaces here as a debug log + downgrade to "no registry"
+        # rather than a hard fail, since one malformed plugin shouldn't
+        # poison a whole marketplace.
+        from apm_cli.deps.registry.semver import is_semver_range
+        if not is_semver_range(version):
+            logger.debug(
+                "Plugin '%s' has registry='%s' but version '%s' is not a "
+                "semver range; ignoring registry routing for this entry",
+                name,
+                registry_name,
+                version,
+            )
+            registry_name = ""
+
     return MarketplacePlugin(
         name=name,
         source=source,
@@ -172,6 +216,7 @@ def _parse_plugin_entry(
         version=version,
         tags=tags,
         source_marketplace=source_name,
+        registry=registry_name,
     )
 
 

--- a/src/apm_cli/models/apm_package.py
+++ b/src/apm_cli/models/apm_package.py
@@ -59,6 +59,144 @@ def clear_apm_yml_cache() -> None:
     _apm_yml_cache.clear()
 
 
+def _parse_registries_block(data: dict, apm_yml_path: Path):
+    """Parse the top-level ``registries:`` block per design §3.1.
+
+    Schema::
+
+        registries:
+          corp-main:
+            url: https://registry.corp.example.com/apm
+          corp-other:
+            url: https://other.example.com/apm
+          default: corp-main           # optional; name of one of the entries
+
+    Returns ``(registries_map, default_name)`` where:
+    - ``registries_map`` is ``{name: url}`` excluding the special ``default`` key.
+    - ``default_name`` is either the ``default`` value (when it's a registered
+      name) OR ``None``.
+
+    Absent block returns ``(None, None)`` — the default-routing pass is a
+    no-op and a project sees zero behavior change (invariant §2.1.1).
+    """
+    raw = data.get('registries')
+    if raw is None:
+        return None, None
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"Top-level 'registries:' block in {apm_yml_path} must be a "
+            f"mapping (name -> {{url: ...}})"
+        )
+
+    default_value = raw.get('default')
+    registries_map: Dict[str, str] = {}
+    for name, body in raw.items():
+        if name == 'default':
+            continue
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError(
+                f"Registry name in 'registries:' block must be a non-empty "
+                f"string (got {name!r})"
+            )
+        if not isinstance(body, dict):
+            raise ValueError(
+                f"Registry {name!r} must be a mapping with at least 'url:' "
+                f"(got {type(body).__name__})"
+            )
+        url = body.get('url')
+        if not isinstance(url, str) or not url.strip():
+            raise ValueError(
+                f"Registry {name!r} is missing required field 'url:'"
+            )
+        url = url.strip()
+        if not url.startswith(('https://', 'http://')):
+            raise ValueError(
+                f"Registry {name!r} URL must start with https:// or http:// "
+                f"(got {url!r})"
+            )
+        # Reject any unknown keys to catch typos early.
+        unknown = set(body.keys()) - {'url'}
+        if unknown:
+            raise ValueError(
+                f"Registry {name!r} has unknown fields: {sorted(unknown)} "
+                f"(known fields: ['url'])"
+            )
+        registries_map[name] = url
+
+    default_name: Optional[str] = None
+    if default_value is not None:
+        if not isinstance(default_value, str) or not default_value.strip():
+            raise ValueError(
+                f"'registries.default' in {apm_yml_path} must be a non-empty "
+                f"string naming one of the configured registries"
+            )
+        default_name = default_value.strip()
+        if default_name not in registries_map:
+            raise ValueError(
+                f"'registries.default: {default_name}' refers to an "
+                f"unconfigured registry. Configured: "
+                f"{sorted(registries_map.keys())}"
+            )
+
+    if not registries_map and default_name is None:
+        # An empty ``registries: {}`` block is harmless but suspicious.
+        return None, None
+
+    return registries_map, default_name
+
+
+def _route_unscoped_to_default_registry(
+    apm_dep_list: list,
+    default_name: str,
+    apm_yml_path: Path,
+) -> None:
+    """Flip the resolver of every still-unrouted shorthand APM dep to the default registry.
+
+    Per design §3.2: when ``registries.default`` is set, every shorthand
+    string entry that doesn't already specify a resolver routes through the
+    default registry. Object forms (``- git:`` / ``- path:`` / ``- registry:``)
+    and the ``@<name>`` shorthand have already set ``source`` explicitly and
+    are left alone here.
+
+    Modifies the list in place. Raises ``ValueError`` with a clear remediation
+    if any candidate has a non-semver ref or no version constraint at all.
+    """
+    from ..deps.registry.semver import is_semver_range
+    from .dependency.reference import DependencyReference
+
+    for dep in apm_dep_list:
+        if not isinstance(dep, DependencyReference):
+            continue
+        # Already routed (registry / local / explicit git via @<name> or
+        # object form). The only thing we change is "source unset, looks like
+        # plain shorthand" candidates.
+        if dep.source is not None:
+            continue
+        if dep.is_local or dep.is_virtual:
+            # Virtual packages MUST use object form to route through a
+            # registry; shorthand virtuals stay on Git.
+            continue
+        if dep.reference is None or not dep.reference.strip():
+            raise ValueError(
+                f"{apm_yml_path}: dep {dep.repo_url!r} has no version "
+                f"constraint, but 'registries.default' is set. A registry-"
+                f"routed entry must specify a #<semver>. Either add a version "
+                f"(e.g. '{dep.repo_url}#^1.0') or pin to Git with the "
+                f"'- git:' object form."
+            )
+        if not is_semver_range(dep.reference):
+            raise ValueError(
+                f"{apm_yml_path}: dep '{dep.repo_url}#{dep.reference}' "
+                f"routes through the default registry {default_name!r} but "
+                f"'{dep.reference}' is not a semver version or range. Use "
+                f"an explicit '- git:' entry for branch or commit-SHA "
+                f"pinning, or change the ref to a semver version/range "
+                f"(e.g. ^1.0, ~1.2.3, 1.x)."
+            )
+        dep.source = "registry"
+        dep.registry_name = default_name
+
+
 @dataclass
 class APMPackage:
     """Represents an APM package with metadata."""
@@ -76,6 +214,14 @@ class APMPackage:
     target: Optional[Union[str, List[str]]] = None  # Target agent(s): single string or list (applies to compile and install)
     type: Optional[PackageContentType] = None  # Package content type: instructions, skill, hybrid, or prompts
     includes: Optional[Union[str, List[str]]] = None  # Include-only manifest: 'auto' or list of repo paths
+
+    # Top-level ``registries:`` block per docs/proposals/registry-api.md §3.1.
+    # ``registries`` maps name -> base URL; ``default_registry`` is the name to
+    # which string-shorthand entries route when they don't specify a scope.
+    # Both default to None — a project without a ``registries:`` block sees
+    # zero behavior change (invariant §2.1.1).
+    registries: Optional[Dict[str, str]] = None
+    default_registry: Optional[str] = None
 
     @classmethod
     def from_apm_yml(cls, apm_yml_path: Path) -> "APMPackage":
@@ -115,7 +261,10 @@ class APMPackage:
             raise ValueError("Missing required field 'name' in apm.yml")
         if 'version' not in data:
             raise ValueError("Missing required field 'version' in apm.yml")
-        
+
+        # Top-level ``registries:`` block per design §3.1.
+        registries, default_registry = _parse_registries_block(data, apm_yml_path)
+
         # Parse dependencies
         dependencies = None
         if 'dependencies' in data and isinstance(data['dependencies'], dict):
@@ -212,6 +361,22 @@ class APMPackage:
             else:
                 raise ValueError("'includes' must be 'auto' or a list of strings")
 
+        # Default-registry routing (design §3.2): once the registries: block
+        # has been parsed, walk every still-unrouted shorthand APM dep and,
+        # if a default registry is set, flip its source to "registry". Object
+        # forms (``- git:`` / ``- path:`` / ``- registry:``) and the
+        # ``@<name>`` shorthand have already set source explicitly and are
+        # left alone here.
+        if default_registry is not None:
+            for bucket in (dependencies, dev_dependencies):
+                if not bucket:
+                    continue
+                apm_list = bucket.get('apm') if isinstance(bucket, dict) else None
+                if isinstance(apm_list, list):
+                    _route_unscoped_to_default_registry(
+                        apm_list, default_registry, apm_yml_path
+                    )
+
         result = cls(
             name=data['name'],
             version=data['version'],
@@ -225,6 +390,8 @@ class APMPackage:
             target=data.get('target'),
             type=pkg_type,
             includes=includes,
+            registries=registries,
+            default_registry=default_registry,
         )
         _apm_yml_cache[resolved] = result
         return result

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -523,6 +523,19 @@ class DependencyReference:
         Raises:
             ValueError: If the entry is missing required fields or has invalid format
         """
+        # Object-form registry virtual package — design §3.2.
+        # Discriminated by the ``registry:`` key. Mutually exclusive with
+        # ``git:``. Required fields: registry, id, path, version. ``alias`` is
+        # optional. Used only for virtual packages because non-virtual entries
+        # compose cleanly in the ``owner/repo@<name>#<semver>`` shorthand.
+        if "registry" in entry:
+            if "git" in entry:
+                raise ValueError(
+                    "Object-style dependency cannot mix 'registry:' and 'git:' "
+                    "keys — choose one resolver."
+                )
+            return cls._parse_registry_object_entry(entry)
+
         # Support dict-form local path: { path: ./local/dir }
         if "path" in entry and "git" not in entry:
             local = entry["path"]
@@ -539,7 +552,8 @@ class DependencyReference:
 
         if "git" not in entry:
             raise ValueError(
-                "Object-style dependency must have a 'git' or 'path' field"
+                "Object-style dependency must have a 'git', 'path', or "
+                "'registry' field"
             )
 
         git_url = entry["git"]
@@ -589,6 +603,114 @@ class DependencyReference:
             dep.is_virtual = True
 
         return dep
+
+    @classmethod
+    def _parse_registry_object_entry(cls, entry: dict) -> "DependencyReference":
+        """Parse the object-form registry virtual-package entry per §3.2.
+
+        Required keys:
+            registry: <name>           # routes to apm.yml registries: block
+            id:       <owner>/<repo>   # package identity at the registry
+            path:     prompts/foo.md   # virtual sub-path inside the package
+            version:  <semver>         # strict semver, parse-time enforced
+
+        Optional:
+            alias:    <name>           # same meaning as in other object forms
+
+        Why object form for virtual only: a non-virtual registry entry composes
+        cleanly in the ``owner/repo@<name>#<semver>`` shorthand. Virtual
+        packages need four independent fields (id, registry, sub-path, version)
+        that don't combine into a readable string. Symmetric with how
+        ``- git:`` object form exists for the cases string shorthand can't
+        handle.
+        """
+        registry_name = entry.get("registry")
+        if not isinstance(registry_name, str) or not registry_name.strip():
+            raise ValueError(
+                "Object-form registry entry: 'registry' must be a non-empty "
+                "string (the name of an entry in the apm.yml registries: block)"
+            )
+        registry_name = registry_name.strip()
+
+        pkg_id = entry.get("id")
+        if not isinstance(pkg_id, str) or not pkg_id.strip():
+            raise ValueError(
+                "Object-form registry entry: 'id' is required and must be a "
+                "non-empty 'owner/repo' string"
+            )
+        pkg_id = pkg_id.strip()
+        if "/" not in pkg_id:
+            raise ValueError(
+                f"Object-form registry entry: 'id' must be 'owner/repo', "
+                f"got {pkg_id!r}"
+            )
+
+        sub_path = entry.get("path")
+        if not isinstance(sub_path, str) or not sub_path.strip():
+            raise ValueError(
+                "Object-form registry entry: 'path' is required (virtual "
+                "sub-path inside the package, e.g. 'prompts/review.prompt.md')"
+            )
+        sub_path = sub_path.strip().strip("/").replace("\\", "/").strip("/")
+        validate_path_segments(sub_path, context="path")
+
+        version = entry.get("version")
+        if not isinstance(version, str) or not version.strip():
+            raise ValueError(
+                "Object-form registry entry: 'version' is required (semver "
+                "version or range)"
+            )
+        version = version.strip()
+        # Local import to avoid a top-level cycle.
+        from ...deps.registry.semver import is_semver_range
+        if not is_semver_range(version):
+            raise ValueError(
+                f"Object-form registry entry: version {version!r} is not a "
+                f"semver version or range. Branches and commit SHAs are not "
+                f"valid for registry-routed packages."
+            )
+
+        alias = entry.get("alias")
+        if alias is not None:
+            if not isinstance(alias, str) or not alias.strip():
+                raise ValueError("'alias' field must be a non-empty string")
+            alias = alias.strip()
+            if not re.match(r"^[a-zA-Z0-9._-]+$", alias):
+                raise ValueError(
+                    f"Invalid alias: {alias}. Aliases can only contain "
+                    f"letters, numbers, dots, underscores, and hyphens"
+                )
+
+        # Reject any unknown keys to catch typos early.
+        known = {"registry", "id", "path", "version", "alias"}
+        unknown = set(entry.keys()) - known
+        if unknown:
+            raise ValueError(
+                f"Object-form registry entry has unknown fields: "
+                f"{sorted(unknown)}. Known fields: {sorted(known)}"
+            )
+
+        # Build the DependencyReference. Identity stays ``owner/repo``;
+        # virtual_path stores the sub-path; reference holds the version.
+        owner_segments = pkg_id.split("/")
+        validate_path_segments(pkg_id, context="registry id")
+        for seg in owner_segments:
+            if not re.match(r"^[a-zA-Z0-9._-]+$", seg):
+                raise ValueError(
+                    f"Invalid registry id segment: {seg!r} in {pkg_id!r}"
+                )
+
+        return cls(
+            repo_url=pkg_id,
+            host=default_host(),  # registry-side identity is host-blind, but
+                                  # downstream code expects a host for routing
+            reference=version,
+            virtual_path=sub_path,
+            is_virtual=True,
+            alias=alias,
+            source="registry",
+            registry_name=registry_name,
+        )
 
     @classmethod
     def _detect_virtual_package(cls, dependency_str: str):

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -580,6 +580,10 @@ class DependencyReference:
         # Parse the git URL using the standard parser
         dep = cls.parse(git_url)
         dep.allow_insecure = allow_insecure
+        # Object-form ``- git:`` is an explicit Git resolver pin, even when
+        # a top-level ``registries.default`` is set. Mark source so the
+        # default-routing pass in apm_package.py leaves it alone.
+        dep.source = "git"
 
         # Apply overrides from the object fields
         if ref_override is not None:

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -64,6 +64,17 @@ class DependencyReference:
     is_insecure: bool = False  # True when the dependency URL uses http://
     allow_insecure: bool = False  # True if this HTTP dep is explicitly allowed
 
+    # Registry resolver fields (optional; default to None/git semantics)
+    # source: which resolver should fetch this dep. None and "git" are equivalent
+    # (legacy default). Set to "registry" by the parser when an entry routes to
+    # a configured registry (via top-level registries: block, @<name> scope, or
+    # object-form `- registry:` discriminator).
+    # registry_name: name of the registry from apm.yml's registries: block when
+    # source == "registry". Carried in-memory only; never serialized into the
+    # lockfile (the lockfile uses URL-based identity per design §6.1).
+    source: Optional[str] = None
+    registry_name: Optional[str] = None
+
     # Supported file extensions for virtual packages
     VIRTUAL_FILE_EXTENSIONS = (
         ".prompt.md",

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -167,6 +167,44 @@ class DependencyReference:
                     break
             return f"{repo_name}-{filename}"
 
+    # Registry-scope shorthand: ``owner/repo@<name>#<semver>`` — see
+    # docs/proposals/registry-api.md §3.2. The string MUST have at least one
+    # ``/`` on the left of ``@`` (so it can't collide with the marketplace
+    # ``code-review@plugins`` shape, which has no ``/``), and ``<name>`` must
+    # not contain ``/``. We anchor with ``^`` / ``$`` and capture greedily on
+    # the LHS so that paths like ``group/subgroup/repo@reg`` work too.
+    _REGISTRY_SCOPE_RE = re.compile(
+        r"^([a-zA-Z0-9._-]+(?:/[a-zA-Z0-9._-]+)+)@([a-zA-Z0-9._-]+)(?:#(.+))?$"
+    )
+
+    @classmethod
+    def _extract_registry_scope(cls, dependency_str: str):
+        """Detect the ``owner/repo@<name>#<semver>`` shorthand.
+
+        Returns a ``(repo_part_with_ref, registry_name, ref)`` triple if the
+        string matches the registry-scope shape, or ``None`` if it doesn't
+        (i.e. the caller should fall through to the existing parse path).
+
+        The detector is conservative: it bails out on anything that looks
+        like an SSH or HTTP(S) URL so that ``git@host:owner/repo`` and
+        ``https://user:pwd@host/...`` keep their existing semantics.
+        """
+        s = dependency_str.strip()
+        if not s:
+            return None
+        # Skip URL forms that legitimately contain ``@``.
+        lower = s.lower()
+        if (
+            lower.startswith(("git@", "ssh://", "https://", "http://"))
+            or "://" in lower
+        ):
+            return None
+        match = cls._REGISTRY_SCOPE_RE.match(s)
+        if not match:
+            return None
+        repo_path, registry_name, ref = match.group(1), match.group(2), match.group(3)
+        return repo_path, registry_name, ref
+
     @staticmethod
     def is_local_path(dep_str: str) -> bool:
         """Check if a dependency string looks like a local filesystem path.
@@ -986,6 +1024,38 @@ class DependencyReference:
                     "//...", context="Protocol-relative URLs are not supported"
                 )
             )
+
+        # --- Registry-scope shorthand: owner/repo@<name>#<semver> ---
+        # Detected before any URL/host parsing so that the rest of the parse
+        # path sees a normal ``owner/repo#<ref>`` string. The semver
+        # constraint is enforced here (parse-time, not at install-time) per
+        # design §3.3.
+        registry_scope = cls._extract_registry_scope(dependency_str)
+        if registry_scope is not None:
+            repo_path, registry_name, ref = registry_scope
+            if not ref:
+                raise ValueError(
+                    f"registry-scoped dependency '{dependency_str}' is missing a "
+                    f"version: shorthand routed to a registry must include "
+                    f"#<semver>, e.g. 'acme/foo@{registry_name}#^1.2'."
+                )
+            # Local import to avoid a top-level cycle (registry package depends
+            # on this module via DependencyReference type hints).
+            from ...deps.registry.semver import is_semver_range
+            if not is_semver_range(ref):
+                raise ValueError(
+                    f"'{dependency_str}' routes through registry "
+                    f"'{registry_name}' but '{ref}' is not a semver version or "
+                    f"range. Use an explicit '- git:' entry for branch or "
+                    f"commit-SHA pinning, or change the ref to a semver "
+                    f"version/range (e.g. ^1.0, ~1.2.3, 1.x)."
+                )
+            # Re-parse without the @<name> portion, then attach registry fields.
+            stripped = f"{repo_path}#{ref}"
+            dep = cls.parse(stripped)
+            dep.source = "registry"
+            dep.registry_name = registry_name
+            return dep
 
         # Phase 1: detect virtual packages
         is_virtual_package, virtual_path, validated_host = cls._detect_virtual_package(

--- a/tests/unit/install/test_resolve_registry.py
+++ b/tests/unit/install/test_resolve_registry.py
@@ -1,0 +1,189 @@
+"""Tests for the registry-resolver wiring in ``install/phases/resolve.py``.
+
+Covers:
+- ``_lockfile_has_registry_deps`` helper
+- ``ctx.registry_resolver`` is constructed when apm.yml has a registries:
+  block OR the lockfile carries registry-sourced entries
+- ``ctx.registry_resolver`` is left ``None`` for projects without either
+- The download_callback dispatch logic — direct call against the inner
+  closure is awkward, so we exercise it via a focused fake-resolver test
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from apm_cli.deps.lockfile import LockedDependency, LockFile
+from apm_cli.install.phases.resolve import _lockfile_has_registry_deps
+
+
+class TestLockfileHasRegistryDeps:
+    def test_none_lockfile_returns_false(self):
+        assert _lockfile_has_registry_deps(None) is False
+
+    def test_empty_lockfile_returns_false(self):
+        assert _lockfile_has_registry_deps(LockFile()) is False
+
+    def test_only_git_deps_returns_false(self):
+        lock = LockFile()
+        lock.add_dependency(
+            LockedDependency(
+                repo_url="acme/foo",
+                resolved_commit="abc123",
+                host="github.com",
+            )
+        )
+        assert _lockfile_has_registry_deps(lock) is False
+
+    def test_only_local_deps_returns_false(self):
+        lock = LockFile()
+        lock.add_dependency(
+            LockedDependency(
+                repo_url="_local/x",
+                source="local",
+                local_path="./x",
+            )
+        )
+        assert _lockfile_has_registry_deps(lock) is False
+
+    def test_one_registry_dep_returns_true(self):
+        lock = LockFile()
+        lock.add_dependency(
+            LockedDependency(
+                repo_url="acme/foo",
+                resolved_commit="abc",
+                host="github.com",
+            )
+        )
+        lock.add_dependency(
+            LockedDependency(
+                repo_url="acme/bar",
+                source="registry",
+                resolved_url="https://r/v1/.../download",
+                resolved_hash="sha256:abc",
+                version="1.0.0",
+            )
+        )
+        assert _lockfile_has_registry_deps(lock) is True
+
+
+class TestResolverConstruction:
+    """``ctx.registry_resolver`` is built (or not) based on the manifest + lockfile state."""
+
+    def _make_ctx(
+        self,
+        tmp_path,
+        *,
+        registries: dict | None = None,
+        existing_lockfile: LockFile | None = None,
+        deps: list | None = None,
+    ):
+        from apm_cli.install.context import InstallContext
+
+        # Build a stand-in apm_package with the registries: attribute the
+        # phase reads. We don't need a real APMPackage for this test.
+        apm_package = MagicMock()
+        apm_package.registries = registries
+        apm_package.default_registry = None
+
+        ctx = InstallContext(project_root=tmp_path, apm_dir=tmp_path)
+        ctx.apm_package = apm_package
+        ctx.all_apm_deps = deps or []
+        ctx.update_refs = False
+        ctx.scope = MagicMock()
+        return ctx
+
+    def test_no_registries_no_lockfile_means_no_resolver(self, monkeypatch, tmp_path):
+        """Vanilla project (no registries:, no lockfile-registry-deps) skips resolver build."""
+        from apm_cli.install.phases import resolve as _resolve_mod
+
+        ctx = self._make_ctx(tmp_path)
+        # Stub out the rest of the phase so we only exercise resolver construction.
+        # We can't easily call run() end-to-end without a full pipeline; instead
+        # test the resolver-build logic directly via the helper + branch.
+        existing_lockfile = None
+        registries_map = (ctx.apm_package.registries or {})
+        needs_registry = bool(registries_map) or _resolve_mod._lockfile_has_registry_deps(
+            existing_lockfile
+        )
+        assert needs_registry is False
+
+    def test_registries_block_triggers_resolver(self, tmp_path):
+        from apm_cli.install.phases import resolve as _resolve_mod
+
+        ctx = self._make_ctx(
+            tmp_path, registries={"corp": "https://corp.example.com/apm"}
+        )
+        registries_map = (ctx.apm_package.registries or {})
+        needs = bool(registries_map) or _resolve_mod._lockfile_has_registry_deps(None)
+        assert needs is True
+
+    def test_lockfile_registry_deps_trigger_resolver_even_without_block(self, tmp_path):
+        from apm_cli.install.phases import resolve as _resolve_mod
+
+        lock = LockFile()
+        lock.add_dependency(
+            LockedDependency(
+                repo_url="acme/x",
+                source="registry",
+                resolved_url="https://r/x",
+                resolved_hash="sha256:x",
+                version="1.0.0",
+            )
+        )
+        ctx = self._make_ctx(tmp_path)  # no registries: block
+        registries_map = (ctx.apm_package.registries or {})
+        needs = bool(registries_map) or _resolve_mod._lockfile_has_registry_deps(lock)
+        assert needs is True
+
+
+class TestRegistryResolutionFlowsToLockfile:
+    """End-to-end: a fake registry install captures resolved_url/hash into the lockfile."""
+
+    def test_installed_package_carries_resolution_to_locked_dependency(self):
+        # This test exercises the from_dependency_ref + InstalledPackage chain
+        # without spinning up the full install pipeline. The wiring already
+        # has resolver-level e2e tests; this one just confirms the data
+        # flows through InstalledPackage correctly to the LockFile.
+        from apm_cli.deps.installed_package import InstalledPackage
+        from apm_cli.deps.registry.resolver import RegistryResolution
+        from apm_cli.models.dependency.reference import DependencyReference
+
+        dep = DependencyReference(
+            repo_url="acme/web",
+            reference="^1.2",
+            source="registry",
+            registry_name="corp",
+        )
+        resolution = RegistryResolution(
+            resolved_url="https://corp.example.com/apm/v1/packages/acme/web/versions/1.2.3/download",
+            resolved_hash="sha256:" + "a" * 64,
+            version="1.2.3",
+        )
+        pkg = InstalledPackage(
+            dep_ref=dep,
+            resolved_commit=None,
+            depth=1,
+            resolved_by=None,
+            registry_resolution=resolution,
+        )
+
+        # Mock dependency_graph not actually needed for from_installed_packages
+        # without a real graph — pass a lightweight stub.
+        class _StubGraph:
+            pass
+
+        lock = LockFile.from_installed_packages([pkg], _StubGraph())
+        locked = lock.get_dependency("acme/web")
+        assert locked.source == "registry"
+        assert locked.resolved_url == resolution.resolved_url
+        assert locked.resolved_hash == "sha256:" + "a" * 64
+        assert locked.version == "1.2.3"
+
+        # And the lockfile bumps to v2 on emit.
+        yaml_out = lock.to_yaml()
+        assert "lockfile_version: '2'" in yaml_out

--- a/tests/unit/marketplace/test_registry_integration.py
+++ b/tests/unit/marketplace/test_registry_integration.py
@@ -1,0 +1,282 @@
+"""Tests for the marketplace.json registry-routing extension and the
+server-side registry search merge.
+
+Covers docs/proposals/registry-api.md §4.5:
+- New ``registry`` field on plugin entries (semver-validated)
+- Backwards-compat: existing marketplace.json files (no ``registry``
+  field) parse byte-identically.
+- ``search_all_registries`` adapter wraps RegistryClient.search results
+  into MarketplacePlugin so callers can merge them with marketplace
+  search results.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apm_cli.deps.registry.client import RegistryClient, SearchResult
+from apm_cli.marketplace.client import search_all_registries
+from apm_cli.marketplace.models import (
+    MarketplacePlugin,
+    parse_marketplace_json,
+)
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Schema extension: ``registry`` field on plugin entries
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestRegistryFieldParsing:
+    def test_plugin_without_registry_field_unchanged(self):
+        # Sanity: existing marketplace.json shape parses with registry="".
+        manifest = parse_marketplace_json(
+            {
+                "name": "acme",
+                "plugins": [
+                    {
+                        "name": "review",
+                        "repository": "acme/review",
+                        "description": "x",
+                        "version": "v1.0",
+                    }
+                ],
+            },
+            source_name="acme",
+        )
+        plugin = manifest.plugins[0]
+        assert plugin.name == "review"
+        assert plugin.version == "v1.0"
+        assert plugin.registry == ""
+
+    def test_plugin_with_valid_registry_routing(self):
+        manifest = parse_marketplace_json(
+            {
+                "name": "acme",
+                "plugins": [
+                    {
+                        "name": "enterprise-skills",
+                        "repository": "acme/enterprise-skills",
+                        "registry": "corp-main",
+                        "version": "^3.0",
+                        "description": "x",
+                    }
+                ],
+            },
+            source_name="acme",
+        )
+        plugin = manifest.plugins[0]
+        assert plugin.registry == "corp-main"
+        assert plugin.version == "^3.0"
+
+    def test_invalid_registry_field_downgrades_silently(self):
+        # Empty string, non-string, or invalid types: log + downgrade.
+        manifest = parse_marketplace_json(
+            {
+                "name": "acme",
+                "plugins": [
+                    {
+                        "name": "x",
+                        "repository": "a/b",
+                        "registry": 123,  # not a string
+                    }
+                ],
+            },
+            source_name="acme",
+        )
+        assert manifest.plugins[0].registry == ""
+
+    def test_invalid_semver_disables_registry_routing(self):
+        # If registry is set but version isn't a semver range, drop the
+        # routing to "" so the plugin doesn't silently mis-resolve.
+        manifest = parse_marketplace_json(
+            {
+                "name": "acme",
+                "plugins": [
+                    {
+                        "name": "x",
+                        "repository": "a/b",
+                        "registry": "corp",
+                        "version": "main",  # branch, not semver
+                    }
+                ],
+            },
+            source_name="acme",
+        )
+        assert manifest.plugins[0].registry == ""
+
+    def test_registry_with_no_version(self):
+        # Registry set, no version: parser keeps registry routing but
+        # leaves version="" — the resolver will reject it later. This
+        # matches "fail at resolve time, not at parse time" since the
+        # marketplace parser is permissive by design.
+        manifest = parse_marketplace_json(
+            {
+                "name": "acme",
+                "plugins": [
+                    {
+                        "name": "x",
+                        "repository": "a/b",
+                        "registry": "corp",
+                    }
+                ],
+            },
+            source_name="acme",
+        )
+        plugin = manifest.plugins[0]
+        assert plugin.registry == "corp"
+        assert plugin.version == ""
+
+    def test_existing_source_field_unchanged_alongside_registry(self):
+        # The new ``registry`` field MUST NOT collide with the existing
+        # source-location semantics. Both fields can coexist on one entry.
+        manifest = parse_marketplace_json(
+            {
+                "name": "acme",
+                "plugins": [
+                    {
+                        "name": "x",
+                        "source": {"type": "github", "repo": "a/b"},
+                        "registry": "corp",
+                        "version": "^1.0",
+                    }
+                ],
+            },
+            source_name="acme",
+        )
+        plugin = manifest.plugins[0]
+        assert plugin.source == {"type": "github", "repo": "a/b"}
+        assert plugin.registry == "corp"
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Server-side registry search merge
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestSearchAllRegistries:
+    def test_empty_registries_returns_empty(self):
+        assert search_all_registries("foo", {}) == []
+
+    def test_calls_each_configured_registry(self):
+        with patch("apm_cli.deps.registry.client.RegistryClient") as MockClient:
+            instance_a = MagicMock(spec=RegistryClient)
+            instance_a.search.return_value = [
+                SearchResult(
+                    id="acme/skill-a",
+                    latest_version="1.0.0",
+                    description="dA",
+                    author="a",
+                    tags=["security"],
+                    type="skill",
+                    score=0.9,
+                )
+            ]
+            instance_b = MagicMock(spec=RegistryClient)
+            instance_b.search.return_value = [
+                SearchResult(
+                    id="acme/skill-b",
+                    latest_version="2.0.0",
+                    description="dB",
+                    author="b",
+                    tags=[],
+                    type="skill",
+                    score=0.8,
+                )
+            ]
+            MockClient.side_effect = [instance_a, instance_b]
+
+            results = search_all_registries(
+                "skill",
+                {
+                    "corp-a": "https://a.example.com/apm",
+                    "corp-b": "https://b.example.com/apm",
+                },
+            )
+            ids = [r.name for r in results]
+            assert "acme/skill-a" in ids
+            assert "acme/skill-b" in ids
+            # Each result is annotated with its source registry
+            for r in results:
+                assert r.registry in ("corp-a", "corp-b")
+                assert r.source_marketplace == r.registry
+
+    def test_skips_registry_on_error(self):
+        from apm_cli.deps.registry.client import RegistryError
+
+        with patch("apm_cli.deps.registry.client.RegistryClient") as MockClient:
+            failing = MagicMock(spec=RegistryClient)
+            failing.search.side_effect = RegistryError(
+                "boom", status=500, url="https://failing"
+            )
+            ok = MagicMock(spec=RegistryClient)
+            ok.search.return_value = [
+                SearchResult(
+                    id="acme/x",
+                    latest_version="1.0.0",
+                    description=None,
+                    author=None,
+                    tags=[],
+                    type=None,
+                    score=None,
+                )
+            ]
+            MockClient.side_effect = [failing, ok]
+
+            results = search_all_registries(
+                "skill",
+                {
+                    "failing-corp": "https://failing.example.com",
+                    "good-corp": "https://good.example.com",
+                },
+            )
+            # The failing registry is skipped; the good one yields results.
+            ids = [r.name for r in results]
+            assert "acme/x" in ids
+
+    def test_results_are_marketplace_plugin_shaped(self):
+        with patch("apm_cli.deps.registry.client.RegistryClient") as MockClient:
+            client = MagicMock(spec=RegistryClient)
+            client.search.return_value = [
+                SearchResult(
+                    id="acme/foo",
+                    latest_version="1.2.3",
+                    description="desc",
+                    author="me",
+                    tags=["a", "b"],
+                    type="prompt",
+                    score=0.5,
+                )
+            ]
+            MockClient.return_value = client
+
+            results = search_all_registries(
+                "foo", {"corp": "https://corp.example.com"}
+            )
+            assert len(results) == 1
+            r = results[0]
+            assert isinstance(r, MarketplacePlugin)
+            assert r.name == "acme/foo"
+            assert r.version == "1.2.3"
+            assert r.description == "desc"
+            assert r.tags == ("a", "b")
+            assert r.registry == "corp"
+
+    def test_passes_filter_params_through(self):
+        with patch("apm_cli.deps.registry.client.RegistryClient") as MockClient:
+            client = MagicMock(spec=RegistryClient)
+            client.search.return_value = []
+            MockClient.return_value = client
+
+            search_all_registries(
+                "x",
+                {"corp": "https://corp.example.com"},
+                limit=10,
+                type="skill",
+                tag="security",
+            )
+            client.search.assert_called_once_with(
+                "x", limit=10, type="skill", tag="security"
+            )

--- a/tests/unit/registry/test_auth.py
+++ b/tests/unit/registry/test_auth.py
@@ -1,0 +1,142 @@
+"""Tests for registry auth resolution.
+
+Covers the env-var key derivation (``APM_REGISTRY_TOKEN_{NAME}``), URL-prefix
+matching for lockfile re-installs, and the §6.2 remediation message.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apm_cli.deps.registry.auth import (
+    RegistryAuthContext,
+    _env_key,
+    _normalize_url_prefix,
+    lookup_name_for_url,
+    remediation_message,
+    resolve_for_url,
+    resolve_registry_token,
+)
+
+
+class TestEnvKey:
+    """Env-var key derivation per design §7.1."""
+
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("corp", "APM_REGISTRY_TOKEN_CORP"),
+            ("corp-main", "APM_REGISTRY_TOKEN_CORP_MAIN"),
+            ("corp.main", "APM_REGISTRY_TOKEN_CORP_MAIN"),
+            ("Corp-Main", "APM_REGISTRY_TOKEN_CORP_MAIN"),
+            ("a-b.c", "APM_REGISTRY_TOKEN_A_B_C"),
+        ],
+    )
+    def test_key_form(self, name, expected):
+        assert _env_key(name) == expected
+
+
+class TestResolveRegistryToken:
+    def test_returns_env_value(self, monkeypatch):
+        monkeypatch.setenv("APM_REGISTRY_TOKEN_CORP_MAIN", "tok-123")
+        assert resolve_registry_token("corp-main") == "tok-123"
+
+    def test_missing_env_returns_none(self, monkeypatch):
+        monkeypatch.delenv("APM_REGISTRY_TOKEN_NOPE", raising=False)
+        assert resolve_registry_token("nope") is None
+
+
+class TestRegistryAuthContext:
+    def test_anonymous_has_no_header(self):
+        ctx = RegistryAuthContext(registry_name="corp", token=None)
+        assert ctx.auth_header() is None
+
+    def test_token_produces_bearer_header(self):
+        ctx = RegistryAuthContext(registry_name="corp", token="abc")
+        assert ctx.auth_header() == "Bearer abc"
+
+
+class TestUrlNormalize:
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            ("https://Corp.example.com/apm", "https://corp.example.com/apm"),
+            ("HTTPS://corp.example.com/apm/", "https://corp.example.com/apm"),
+            ("https://corp:8443/apm/", "https://corp:8443/apm"),
+            ("https://corp/apm/foo/", "https://corp/apm/foo"),
+        ],
+    )
+    def test_normalize(self, url, expected):
+        assert _normalize_url_prefix(url) == expected
+
+
+class TestLookupNameForUrl:
+    """URL prefix matching for lockfile re-install auth (§6.2 rule 1)."""
+
+    def test_exact_match(self):
+        regs = {"corp": "https://corp.example.com/apm"}
+        assert lookup_name_for_url("https://corp.example.com/apm", regs) == "corp"
+
+    def test_path_prefix_match(self):
+        regs = {"corp": "https://corp.example.com/apm"}
+        url = "https://corp.example.com/apm/v1/packages/acme/web/versions/1.0.0/tarball"
+        assert lookup_name_for_url(url, regs) == "corp"
+
+    def test_longest_prefix_wins(self):
+        regs = {
+            "corp": "https://corp.example.com/apm",
+            "corp-team-a": "https://corp.example.com/apm/team-a",
+        }
+        team_url = "https://corp.example.com/apm/team-a/foo"
+        assert lookup_name_for_url(team_url, regs) == "corp-team-a"
+        other_url = "https://corp.example.com/apm/some-other"
+        assert lookup_name_for_url(other_url, regs) == "corp"
+
+    def test_no_match_returns_none(self):
+        regs = {"corp": "https://corp.example.com/apm"}
+        assert lookup_name_for_url("https://other.com/apm", regs) is None
+
+    def test_case_insensitive_host(self):
+        regs = {"corp": "https://CORP.example.com/apm"}
+        assert lookup_name_for_url("https://corp.example.com/apm", regs) == "corp"
+
+    def test_partial_path_does_not_match(self):
+        # The configured URL is /apm but the target is /apm-team — must not match.
+        regs = {"corp": "https://corp.example.com/apm"}
+        assert lookup_name_for_url("https://corp.example.com/apm-team", regs) is None
+
+    def test_empty_inputs(self):
+        assert lookup_name_for_url("", {"corp": "https://corp.example.com"}) is None
+        assert lookup_name_for_url("https://corp.example.com", {}) is None
+
+
+class TestResolveForUrl:
+    """End-to-end auth resolution: URL -> name -> token."""
+
+    def test_returns_token_when_url_matches(self, monkeypatch):
+        monkeypatch.setenv("APM_REGISTRY_TOKEN_CORP", "tok-abc")
+        regs = {"corp": "https://corp.example.com/apm"}
+        ctx = resolve_for_url(
+            "https://corp.example.com/apm/v1/packages/x/y/versions/1.0.0/tarball", regs
+        )
+        assert ctx.registry_name == "corp"
+        assert ctx.token == "tok-abc"
+
+    def test_url_match_without_env_returns_anonymous(self, monkeypatch):
+        monkeypatch.delenv("APM_REGISTRY_TOKEN_CORP", raising=False)
+        regs = {"corp": "https://corp.example.com/apm"}
+        ctx = resolve_for_url("https://corp.example.com/apm/foo", regs)
+        assert ctx.registry_name == "corp"
+        assert ctx.token is None
+
+    def test_no_url_match_returns_anonymous(self):
+        ctx = resolve_for_url("https://other.example.com/foo", {"corp": "https://corp/apm"})
+        assert ctx.registry_name is None
+        assert ctx.token is None
+
+
+class TestRemediationMessage:
+    def test_includes_url_and_env_var_hint(self):
+        msg = remediation_message("https://corp.example.com/apm")
+        assert "https://corp.example.com/apm" in msg
+        assert "APM_REGISTRY_TOKEN_<NAME>" in msg

--- a/tests/unit/registry/test_client.py
+++ b/tests/unit/registry/test_client.py
@@ -1,0 +1,273 @@
+"""Tests for the registry HTTP client.
+
+Uses mocked ``requests.Session`` to avoid network access. Confirms:
+- URL construction (path joining, percent-encoding)
+- Auth header forwarding
+- JSON parsing of /versions and /search responses
+- Error mapping (RFC 7807 problem detail extraction; transport errors)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from apm_cli.deps.registry.auth import RegistryAuthContext
+from apm_cli.deps.registry.client import (
+    RegistryClient,
+    RegistryError,
+    SearchResult,
+    VersionEntry,
+)
+
+
+def _make_response(
+    *,
+    status: int = 200,
+    json_body=None,
+    body: bytes = b"",
+    content_type: str = "application/json",
+):
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status
+    resp.url = "<test>"
+    resp.headers = {"Content-Type": content_type}
+    if json_body is not None:
+        resp.json.return_value = json_body
+    else:
+        resp.json.side_effect = ValueError("no body")
+    resp.content = body
+    return resp
+
+
+def _make_session(response):
+    session = MagicMock(spec=requests.Session)
+    session.request.return_value = response
+    return session
+
+
+class TestUrlConstruction:
+    def test_versions_url(self):
+        session = _make_session(
+            _make_response(json_body={"package": "a/b", "versions": []})
+        )
+        client = RegistryClient(
+            "https://r.example.com/apm/",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        client.list_versions("acme", "web-skills")
+        call = session.request.call_args
+        assert call.args == ("GET",)
+        assert call.kwargs["url"] == (
+            "https://r.example.com/apm/v1/packages/acme/web-skills/versions"
+        ), call.kwargs
+
+    def test_tarball_url_helper(self):
+        client = RegistryClient(
+            "https://r.example.com/apm",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=MagicMock(spec=requests.Session),
+        )
+        url = client.tarball_url("acme", "web-skills", "1.2.0")
+        assert url == (
+            "https://r.example.com/apm/v1/packages/acme/web-skills"
+            "/versions/1.2.0/tarball"
+        )
+
+    def test_strips_trailing_slash_from_base(self):
+        client = RegistryClient(
+            "https://r.example.com/apm///",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=MagicMock(spec=requests.Session),
+        )
+        assert client.base_url == "https://r.example.com/apm"
+
+
+class TestAuth:
+    def test_anonymous_omits_authorization(self):
+        session = _make_session(
+            _make_response(json_body={"versions": []})
+        )
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        client.list_versions("a", "b")
+        headers = session.request.call_args.kwargs["headers"]
+        assert "Authorization" not in headers
+
+    def test_token_sets_bearer_header(self):
+        session = _make_session(
+            _make_response(json_body={"versions": []})
+        )
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token="tok-1"),
+            session=session,
+        )
+        client.list_versions("a", "b")
+        headers = session.request.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer tok-1"
+
+
+class TestListVersions:
+    def test_parses_versions(self):
+        session = _make_session(
+            _make_response(
+                json_body={
+                    "package": "acme/web-skills",
+                    "versions": [
+                        {
+                            "version": "1.2.0",
+                            "digest": "sha256:abc",
+                            "published_at": "2026-03-01T12:00:00Z",
+                        },
+                        {"version": "1.1.0", "digest": "sha256:def"},
+                    ],
+                }
+            )
+        )
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        result = client.list_versions("acme", "web-skills")
+        assert result == [
+            VersionEntry("1.2.0", "sha256:abc", "2026-03-01T12:00:00Z"),
+            VersionEntry("1.1.0", "sha256:def", None),
+        ]
+
+    def test_missing_versions_array_raises(self):
+        session = _make_session(_make_response(json_body={"package": "x"}))
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        with pytest.raises(RegistryError, match="missing 'versions' array"):
+            client.list_versions("a", "b")
+
+    def test_malformed_entry_raises(self):
+        session = _make_session(
+            _make_response(json_body={"versions": [{"version": "1.0.0"}]})
+        )
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        with pytest.raises(RegistryError, match="missing 'digest'"):
+            client.list_versions("a", "b")
+
+
+class TestDownloadTarball:
+    def test_returns_body_bytes(self):
+        session = _make_session(
+            _make_response(body=b"\x1f\x8b...", content_type="application/gzip")
+        )
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        body = client.download_tarball("acme", "web-skills", "1.2.0")
+        assert body == b"\x1f\x8b..."
+
+    def test_404_raises_with_status(self):
+        session = _make_session(
+            _make_response(
+                status=404,
+                json_body={"title": "Not Found", "detail": "no such version"},
+                content_type="application/problem+json",
+            )
+        )
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        with pytest.raises(RegistryError) as excinfo:
+            client.download_tarball("a", "b", "9.9.9")
+        assert excinfo.value.status == 404
+        assert "Not Found" in str(excinfo.value)
+
+
+class TestSearch:
+    def test_parses_results(self):
+        session = _make_session(
+            _make_response(
+                json_body={
+                    "query": "x",
+                    "total": 1,
+                    "results": [
+                        {
+                            "id": "acme/web-skills",
+                            "latest_version": "1.2.0",
+                            "description": "d",
+                            "author": "a",
+                            "tags": ["security"],
+                            "type": "skill",
+                            "score": 0.9,
+                        }
+                    ],
+                }
+            )
+        )
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        results = client.search("x", limit=10)
+        assert len(results) == 1
+        r = results[0]
+        assert isinstance(r, SearchResult)
+        assert r.id == "acme/web-skills"
+        assert r.tags == ["security"]
+        # Verify query params went on the URL
+        call_url = session.request.call_args.kwargs["url"]
+        assert "q=x" in call_url and "limit=10" in call_url
+
+    def test_empty_results_returns_empty_list(self):
+        session = _make_session(_make_response(json_body={"results": []}))
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        assert client.search("x") == []
+
+
+class TestErrorMapping:
+    def test_transport_error_wraps(self):
+        session = MagicMock(spec=requests.Session)
+        session.request.side_effect = requests.ConnectionError("dns failed")
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        with pytest.raises(RegistryError, match="transport error"):
+            client.list_versions("a", "b")
+
+    def test_401_includes_problem_detail(self):
+        session = _make_session(
+            _make_response(
+                status=401,
+                json_body={"title": "Unauthorized", "detail": "missing token"},
+            )
+        )
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        with pytest.raises(RegistryError) as excinfo:
+            client.list_versions("a", "b")
+        assert excinfo.value.status == 401
+        assert "missing token" in str(excinfo.value)

--- a/tests/unit/registry/test_client.py
+++ b/tests/unit/registry/test_client.py
@@ -65,17 +65,27 @@ class TestUrlConstruction:
             "https://r.example.com/apm/v1/packages/acme/web-skills/versions"
         ), call.kwargs
 
-    def test_tarball_url_helper(self):
+    def test_archive_url_helper(self):
         client = RegistryClient(
             "https://r.example.com/apm",
             RegistryAuthContext(registry_name="x", token=None),
             session=MagicMock(spec=requests.Session),
         )
-        url = client.tarball_url("acme", "web-skills", "1.2.0")
+        url = client.archive_url("acme", "web-skills", "1.2.0")
         assert url == (
             "https://r.example.com/apm/v1/packages/acme/web-skills"
-            "/versions/1.2.0/tarball"
+            "/versions/1.2.0/download"
         )
+
+    def test_legacy_tarball_url_alias(self):
+        # tarball_url is the deprecated alias kept for in-flight call sites
+        # during the rename. It MUST return the same URL as archive_url.
+        client = RegistryClient(
+            "https://r.example.com/apm",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=MagicMock(spec=requests.Session),
+        )
+        assert client.tarball_url("a", "b", "1.0.0") == client.archive_url("a", "b", "1.0.0")
 
     def test_strips_trailing_slash_from_base(self):
         client = RegistryClient(
@@ -165,8 +175,8 @@ class TestListVersions:
             client.list_versions("a", "b")
 
 
-class TestDownloadTarball:
-    def test_returns_body_bytes(self):
+class TestDownloadArchive:
+    def test_returns_body_and_gzip_content_type(self):
         session = _make_session(
             _make_response(body=b"\x1f\x8b...", content_type="application/gzip")
         )
@@ -175,8 +185,50 @@ class TestDownloadTarball:
             RegistryAuthContext(registry_name="x", token=None),
             session=session,
         )
-        body = client.download_tarball("acme", "web-skills", "1.2.0")
+        body, ctype = client.download_archive("acme", "web-skills", "1.2.0")
         assert body == b"\x1f\x8b..."
+        assert ctype == "application/gzip"
+
+    def test_returns_body_and_zip_content_type(self):
+        session = _make_session(
+            _make_response(body=b"PK\x03\x04...", content_type="application/zip")
+        )
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        body, ctype = client.download_archive("acme", "skill", "1.0.0")
+        assert body.startswith(b"PK")
+        assert ctype == "application/zip"
+
+    def test_strips_charset_param_from_content_type(self):
+        session = _make_session(
+            _make_response(
+                body=b"\x1f\x8b...",
+                content_type="application/gzip; charset=utf-8",
+            )
+        )
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        _, ctype = client.download_archive("a", "b", "1.0.0")
+        assert ctype == "application/gzip"
+
+    def test_url_path_is_download_not_tarball(self):
+        session = _make_session(
+            _make_response(body=b"x", content_type="application/gzip")
+        )
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        client.download_archive("acme", "web", "1.0.0")
+        url = session.request.call_args.kwargs["url"]
+        assert url.endswith("/versions/1.0.0/download")
 
     def test_404_raises_with_status(self):
         session = _make_session(
@@ -192,9 +244,22 @@ class TestDownloadTarball:
             session=session,
         )
         with pytest.raises(RegistryError) as excinfo:
-            client.download_tarball("a", "b", "9.9.9")
+            client.download_archive("a", "b", "9.9.9")
         assert excinfo.value.status == 404
         assert "Not Found" in str(excinfo.value)
+
+    def test_legacy_download_tarball_alias_returns_just_bytes(self):
+        # Backward-compat alias: returns only the bytes (no content type).
+        session = _make_session(
+            _make_response(body=b"x", content_type="application/gzip")
+        )
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        body = client.download_tarball("a", "b", "1.0.0")
+        assert body == b"x"
 
 
 class TestSearch:

--- a/tests/unit/registry/test_compat_matrix.py
+++ b/tests/unit/registry/test_compat_matrix.py
@@ -1,0 +1,400 @@
+"""Backwards-compatibility matrix per docs/proposals/registry-api.md §2.1.
+
+Each test asserts one explicit invariant. These are HARD requirements — any
+implementation PR that violates one must be rejected.
+
+Hand-traceable to invariant numbers in the proposal:
+
+- §2.1.1  Zero-config parity
+- §2.1.2  apm.yml stability
+- §2.1.3  Default source is git
+- §2.1.4  apm.lock stability (read; v1 stays v1; v2 readable)
+- §2.1.6  No env-var renames or semantics changes
+- §2.1.8  No identity changes
+- §2.1.10 Marketplace unchanged
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apm_cli.deps.lockfile import LockedDependency, LockFile
+from apm_cli.deps.registry.resolver import RegistryResolution
+from apm_cli.models.apm_package import APMPackage, clear_apm_yml_cache
+from apm_cli.models.dependency.reference import DependencyReference
+
+
+@pytest.fixture
+def write_apm_yml(tmp_path):
+    def _write(content: str) -> Path:
+        clear_apm_yml_cache()
+        p = tmp_path / "apm.yml"
+        p.write_text(textwrap.dedent(content).strip() + "\n")
+        return p
+
+    return _write
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# §2.1.1 — Zero-config parity
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestZeroConfigParity:
+    """A user who never adds ``registries:`` MUST observe identical behavior."""
+
+    def test_no_registries_block_means_no_routing(self, write_apm_yml):
+        p = write_apm_yml(
+            """
+            name: x
+            version: 1.0.0
+            dependencies:
+              apm:
+                - acme/foo#main
+                - acme/bar#abc1234
+                - acme/baz
+            """
+        )
+        pkg = APMPackage.from_apm_yml(p)
+        # Block + default both unset
+        assert pkg.registries is None
+        assert pkg.default_registry is None
+        # No dep flipped to registry source
+        for dep in pkg.dependencies["apm"]:
+            assert dep.source is None
+            assert dep.registry_name is None
+
+    def test_branch_refs_remain_valid_without_block(self, write_apm_yml):
+        # §2.1.3 — branch refs and SHAs MUST remain valid when no
+        # registries: block is set. The strict-semver gate only fires on
+        # registry-routed entries.
+        p = write_apm_yml(
+            """
+            name: x
+            version: 1.0.0
+            dependencies:
+              apm:
+                - acme/foo#main
+                - acme/foo#abc123def4567890abc123def4567890abc12345
+            """
+        )
+        pkg = APMPackage.from_apm_yml(p)
+        # Both parsed successfully (no parse error)
+        assert pkg.dependencies["apm"][0].reference == "main"
+        assert pkg.dependencies["apm"][1].reference.startswith("abc123def")
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# §2.1.2 — apm.yml stability
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestApmYmlStability:
+    def test_legacy_object_form_git_unchanged(self, write_apm_yml):
+        p = write_apm_yml(
+            """
+            name: x
+            version: 1.0.0
+            dependencies:
+              apm:
+                - git: https://github.com/owner/repo.git
+                  ref: v2.0
+                  alias: my-pkg
+            """
+        )
+        pkg = APMPackage.from_apm_yml(p)
+        d = pkg.dependencies["apm"][0]
+        # source=="git" is the new explicit marker; semantically same as None
+        assert d.source == "git"
+        assert d.alias == "my-pkg"
+        assert d.reference == "v2.0"
+
+    def test_legacy_object_form_local_unchanged(self, write_apm_yml):
+        p = write_apm_yml(
+            """
+            name: x
+            version: 1.0.0
+            dependencies:
+              apm:
+                - path: ./local/pkg
+            """
+        )
+        pkg = APMPackage.from_apm_yml(p)
+        d = pkg.dependencies["apm"][0]
+        assert d.is_local
+        assert d.local_path == "./local/pkg"
+
+    def test_unknown_top_level_key_does_not_break(self, write_apm_yml):
+        # A future apm.yml key shouldn't break this version of the parser.
+        p = write_apm_yml(
+            """
+            name: x
+            version: 1.0.0
+            future_key: whatever
+            dependencies:
+              apm:
+                - acme/foo#v1.0
+            """
+        )
+        # Should parse without error
+        pkg = APMPackage.from_apm_yml(p)
+        assert pkg.dependencies["apm"][0].reference == "v1.0"
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# §2.1.4 — apm.lock stability
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestLockfileStability:
+    def test_v1_lockfile_parses_without_migration(self):
+        v1_yaml = textwrap.dedent(
+            """
+            lockfile_version: '1'
+            generated_at: 2026-01-01T00:00:00Z
+            dependencies:
+            - repo_url: acme/foo
+              resolved_commit: abc123
+              resolved_ref: v1.0
+              host: github.com
+              deployed_files:
+              - .apm/skills/foo/SKILL.md
+              package_type: APM_PACKAGE
+            """
+        ).strip()
+        lock = LockFile.from_yaml(v1_yaml)
+        assert lock.lockfile_version == "1"
+        dep = lock.get_dependency("acme/foo")
+        assert dep.resolved_commit == "abc123"
+        # No registry fields injected
+        assert dep.source is None
+        assert dep.resolved_url is None
+        assert dep.resolved_hash is None
+
+    def test_v1_lockfile_reemits_as_v1(self):
+        v1_yaml = textwrap.dedent(
+            """
+            lockfile_version: '1'
+            generated_at: 2026-01-01T00:00:00Z
+            dependencies:
+            - repo_url: acme/foo
+              resolved_commit: abc123
+              host: github.com
+            """
+        ).strip()
+        lock = LockFile.from_yaml(v1_yaml)
+        out = lock.to_yaml()
+        assert "lockfile_version: '1'" in out
+        # No registry fields in the emitted yaml
+        assert "resolved_url" not in out
+        assert "resolved_hash" not in out
+
+    def test_v2_only_when_registry_dep_present(self):
+        # First — git-only project stays v1 forever.
+        lock = LockFile()
+        lock.add_dependency(
+            LockedDependency(
+                repo_url="acme/git", resolved_commit="abc", host="github.com"
+            )
+        )
+        assert "lockfile_version: '1'" in lock.to_yaml()
+
+        # Add a registry dep — now v2.
+        lock.add_dependency(
+            LockedDependency(
+                repo_url="acme/registry",
+                source="registry",
+                resolved_url="https://r/v1/.../download",
+                resolved_hash="sha256:abc",
+                version="1.0.0",
+            )
+        )
+        assert "lockfile_version: '2'" in lock.to_yaml()
+
+        # Remove it — back to v1.
+        del lock.dependencies["acme/registry"]
+        assert "lockfile_version: '1'" in lock.to_yaml()
+
+    def test_v2_lockfile_round_trip_preserves_all_fields(self):
+        # End-to-end: v2-shaped entry survives round-trip without loss.
+        lock = LockFile()
+        lock.add_dependency(
+            LockedDependency(
+                repo_url="acme/web",
+                source="registry",
+                version="1.5.3",
+                resolved_url="https://r/v1/.../download",
+                resolved_hash="sha256:abc123",
+                host="github.com",
+            )
+        )
+        out = lock.to_yaml()
+        roundtrip = LockFile.from_yaml(out)
+        dep = roundtrip.get_dependency("acme/web")
+        assert dep.source == "registry"
+        assert dep.version == "1.5.3"
+        assert dep.resolved_url == "https://r/v1/.../download"
+        assert dep.resolved_hash == "sha256:abc123"
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# §2.1.6 — No env-var collisions
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestEnvVarPrefixCollision:
+    """``APM_REGISTRY_TOKEN_*`` must NOT collide with existing prefixes."""
+
+    def test_token_prefix_distinct_from_existing(self):
+        from apm_cli.deps.registry.auth import _env_key
+
+        existing_prefixes = (
+            "GITHUB_TOKEN",
+            "GITHUB_APM_PAT",
+            "GH_TOKEN",
+            "PROXY_REGISTRY_",
+            "ARTIFACTORY_APM_TOKEN",
+        )
+        for name in ("corp", "corp-main", "team-a"):
+            key = _env_key(name)
+            assert key.startswith("APM_REGISTRY_TOKEN_")
+            for existing in existing_prefixes:
+                assert not key.startswith(existing)
+                assert key != existing
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# §2.1.8 — Identity preservation
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestIdentityPreservation:
+    """``DependencyReference.get_identity()`` must be stable across modes."""
+
+    def test_identity_unchanged_by_registry_scope(self):
+        d_git = DependencyReference.parse("acme/foo#1.0.0")
+        d_reg = DependencyReference.parse("acme/foo@corp-main#1.0.0")
+        assert d_git.get_identity() == d_reg.get_identity() == "acme/foo"
+
+    def test_identity_unchanged_by_object_form_registry(self):
+        d_git = DependencyReference.parse("acme/foo#1.0.0")
+        d_reg_obj = DependencyReference.parse_from_dict(
+            {
+                "registry": "corp",
+                "id": "acme/foo",
+                "path": "x.prompt.md",
+                "version": "1.0.0",
+            }
+        )
+        # Identity for non-virtual: ``acme/foo``
+        # Identity for virtual: includes the path
+        # Both share the ``acme/foo`` package identity though
+        assert d_git.get_identity() == "acme/foo"
+        assert d_reg_obj.get_identity().startswith("acme/foo/")
+
+    def test_unique_key_includes_repo_url_for_both(self):
+        d_git = DependencyReference.parse("acme/foo#1.0.0")
+        d_reg = DependencyReference.parse("acme/foo@corp-main#1.0.0")
+        assert d_git.get_unique_key() == d_reg.get_unique_key() == "acme/foo"
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# §2.1.10 — Marketplace unchanged
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestMarketplaceUnchanged:
+    def test_existing_marketplace_json_parses_byte_identically(self):
+        # Pre-PR marketplace.json shape with no `registry` field.
+        from apm_cli.marketplace.models import parse_marketplace_json
+
+        manifest = parse_marketplace_json(
+            {
+                "name": "acme",
+                "plugins": [
+                    {
+                        "name": "review",
+                        "repository": "acme/review",
+                        "ref": "v1.0",
+                        "version": "v1.0",
+                        "description": "x",
+                    }
+                ],
+            },
+            source_name="acme",
+        )
+        plugin = manifest.plugins[0]
+        # registry defaults to "" (no routing)
+        assert plugin.registry == ""
+        # All other fields preserved
+        assert plugin.name == "review"
+        assert plugin.version == "v1.0"
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# End-to-end install path: parser -> lockfile (no network)
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestEndToEndInstallPath:
+    """Confirm a registry-sourced apm.yml flows through to a v2 lockfile.
+
+    Uses the resolver with a fake HTTP client so we exercise the full
+    parser -> resolver -> InstalledPackage -> LockFile chain.
+    """
+
+    def test_apm_yml_to_lockfile_v2(self, write_apm_yml, tmp_path):
+        from apm_cli.deps.installed_package import InstalledPackage
+
+        # 1. Parse apm.yml with default-registry routing
+        p = write_apm_yml(
+            """
+            name: project
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com/apm
+              default: corp
+            dependencies:
+              apm:
+                - acme/web#^1.2
+            """
+        )
+        pkg = APMPackage.from_apm_yml(p)
+        dep = pkg.dependencies["apm"][0]
+        assert dep.source == "registry"
+        assert dep.registry_name == "corp"
+
+        # 2. Simulate a resolver-produced RegistryResolution.
+        resolution = RegistryResolution(
+            resolved_url="https://corp.example.com/apm/v1/packages/acme/web/versions/1.5.3/download",
+            resolved_hash="sha256:" + "f" * 64,
+            version="1.5.3",
+        )
+
+        # 3. Build InstalledPackage and assemble lockfile
+        installed = InstalledPackage(
+            dep_ref=dep,
+            resolved_commit=None,
+            depth=1,
+            resolved_by=None,
+            registry_resolution=resolution,
+        )
+
+        class _StubGraph:
+            pass
+
+        lock = LockFile.from_installed_packages([installed], _StubGraph())
+        out = lock.to_yaml()
+        assert "lockfile_version: '2'" in out
+
+        # 4. Round-trip and re-derive dep_ref
+        roundtrip = LockFile.from_yaml(out)
+        locked = roundtrip.get_dependency("acme/web")
+        ref = locked.to_dependency_ref()
+        assert ref.source == "registry"
+        assert ref.reference == "1.5.3"  # exact locked version

--- a/tests/unit/registry/test_extractor.py
+++ b/tests/unit/registry/test_extractor.py
@@ -9,15 +9,19 @@ from __future__ import annotations
 import hashlib
 import io
 import tarfile
+import zipfile
 from pathlib import Path
 
 import pytest
 
 from apm_cli.deps.registry.extractor import (
     HashMismatchError,
+    UnknownArchiveFormatError,
     UnsafeTarballError,
     _normalize_digest,
+    extract_archive,
     extract_tarball,
+    extract_zip,
     verify_sha256,
 )
 
@@ -138,3 +142,116 @@ class TestExtractTarball:
         digest = hashlib.sha256(data).hexdigest()
         extract_tarball(data, digest, tmp_path)
         assert (tmp_path / "a" / "b" / "c" / "file.txt").read_bytes() == b"hello"
+
+
+def _build_zip(entries: list[tuple[str, bytes]]) -> bytes:
+    """Build an in-memory zip from (name, content) pairs."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for name, content in entries:
+            zf.writestr(name, content)
+    return buf.getvalue()
+
+
+class TestExtractZip:
+    """Same security gates as the tar path, applied to zip archives."""
+
+    def test_validates_hash_first(self, tmp_path):
+        data = _build_zip([("apm.yml", b"name: x\n")])
+        with pytest.raises(HashMismatchError):
+            extract_zip(data, "0" * 64, tmp_path)
+        assert not list(tmp_path.iterdir())
+
+    def test_writes_files(self, tmp_path):
+        data = _build_zip([("apm.yml", b"name: y\n"), (".apm/.keep", b"")])
+        digest = hashlib.sha256(data).hexdigest()
+        extract_zip(data, digest, tmp_path)
+        assert (tmp_path / "apm.yml").read_bytes() == b"name: y\n"
+        assert (tmp_path / ".apm" / ".keep").exists()
+
+    def test_rejects_path_traversal(self, tmp_path):
+        data = _build_zip([("../escape.txt", b"x")])
+        digest = hashlib.sha256(data).hexdigest()
+        with pytest.raises(UnsafeTarballError):
+            extract_zip(data, digest, tmp_path)
+
+    def test_rejects_absolute_path(self, tmp_path):
+        data = _build_zip([("/etc/passwd", b"x")])
+        digest = hashlib.sha256(data).hexdigest()
+        with pytest.raises(UnsafeTarballError):
+            extract_zip(data, digest, tmp_path)
+
+    def test_rejects_symlink(self, tmp_path):
+        # Build a zip with a symlink entry by setting external_attr to S_IFLNK.
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, mode="w") as zf:
+            info = zipfile.ZipInfo("link")
+            # 0xA000 == S_IFLNK; place in high 16 bits
+            info.external_attr = (0xA000 | 0o777) << 16
+            zf.writestr(info, b"/etc/passwd")
+        data = buf.getvalue()
+        digest = hashlib.sha256(data).hexdigest()
+        with pytest.raises(UnsafeTarballError, match="symlink"):
+            extract_zip(data, digest, tmp_path)
+
+    def test_malformed_zip(self, tmp_path):
+        # Hash check happens first, so we have to feed the right digest for
+        # the bytes we're sending — the BadZipFile path is what we want to test.
+        bad = b"not a zip"
+        digest = hashlib.sha256(bad).hexdigest()
+        with pytest.raises(UnknownArchiveFormatError):
+            extract_zip(bad, digest, tmp_path)
+
+
+class TestExtractArchiveDispatcher:
+    """The dispatcher picks the right extractor from Content-Type or magic bytes."""
+
+    def test_dispatches_to_tar_for_gzip_content_type(self, tmp_path):
+        data = _build_tar([("apm.yml", b"name: x\n")])
+        digest = hashlib.sha256(data).hexdigest()
+        extract_archive(data, digest, tmp_path, content_type="application/gzip")
+        assert (tmp_path / "apm.yml").exists()
+
+    def test_dispatches_to_zip_for_zip_content_type(self, tmp_path):
+        data = _build_zip([("apm.yml", b"name: x\n")])
+        digest = hashlib.sha256(data).hexdigest()
+        extract_archive(data, digest, tmp_path, content_type="application/zip")
+        assert (tmp_path / "apm.yml").exists()
+
+    def test_falls_back_to_magic_bytes_for_gzip(self, tmp_path):
+        data = _build_tar([("apm.yml", b"name: x\n")])
+        digest = hashlib.sha256(data).hexdigest()
+        extract_archive(data, digest, tmp_path, content_type=None)
+        assert (tmp_path / "apm.yml").exists()
+
+    def test_falls_back_to_magic_bytes_for_zip(self, tmp_path):
+        data = _build_zip([("apm.yml", b"name: x\n")])
+        digest = hashlib.sha256(data).hexdigest()
+        extract_archive(data, digest, tmp_path, content_type=None)
+        assert (tmp_path / "apm.yml").exists()
+
+    def test_unknown_format_raises(self, tmp_path):
+        # Random bytes with no recognizable magic header.
+        data = b"not-an-archive-of-any-known-type"
+        digest = hashlib.sha256(data).hexdigest()
+        with pytest.raises(UnknownArchiveFormatError):
+            extract_archive(data, digest, tmp_path)
+
+    def test_hash_mismatch_fails_before_extraction_for_both(self, tmp_path):
+        for data in (
+            _build_tar([("apm.yml", b"x")]),
+            _build_zip([("apm.yml", b"x")]),
+        ):
+            with pytest.raises(HashMismatchError):
+                extract_archive(data, "0" * 64, tmp_path)
+            assert not list(tmp_path.iterdir())
+
+    def test_unrecognized_content_type_falls_back_to_magic(self, tmp_path):
+        # Server sends a generic content type — magic bytes should still
+        # win and identify the archive.
+        data = _build_tar([("apm.yml", b"x")])
+        digest = hashlib.sha256(data).hexdigest()
+        extract_archive(
+            data, digest, tmp_path, content_type="application/octet-stream"
+        )
+        assert (tmp_path / "apm.yml").exists()

--- a/tests/unit/registry/test_extractor.py
+++ b/tests/unit/registry/test_extractor.py
@@ -1,0 +1,140 @@
+"""Tests for tarball extraction with sha256 verification.
+
+The extractor is the security-critical gate on the install path (design §6.1):
+hash mismatches and traversal attempts MUST fail closed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from apm_cli.deps.registry.extractor import (
+    HashMismatchError,
+    UnsafeTarballError,
+    _normalize_digest,
+    extract_tarball,
+    verify_sha256,
+)
+
+
+def _build_tar(entries: list[tuple[str, bytes]], *, mode: str = "w:gz") -> bytes:
+    """Build an in-memory tarball from a list of (name, content) pairs."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode=mode) as tar:
+        for name, content in entries:
+            ti = tarfile.TarInfo(name=name)
+            ti.size = len(content)
+            tar.addfile(ti, io.BytesIO(content))
+    return buf.getvalue()
+
+
+def _build_tar_with(extra_setup) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        extra_setup(tar)
+    return buf.getvalue()
+
+
+class TestNormalizeDigest:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("abc", "abc"),
+            ("ABC", "abc"),
+            ("sha256:abc", "abc"),
+            ("sha256=ABC", "abc"),
+            ("  sha256:abc  ", "abc"),
+        ],
+    )
+    def test_normalize(self, raw, expected):
+        assert _normalize_digest(raw) == expected
+
+
+class TestVerifySha256:
+    def test_match_returns_actual_hex(self):
+        data = b"hello"
+        h = hashlib.sha256(data).hexdigest()
+        assert verify_sha256(data, h) == h
+
+    def test_match_with_prefix(self):
+        data = b"hello"
+        h = hashlib.sha256(data).hexdigest()
+        assert verify_sha256(data, f"sha256:{h}") == h
+
+    def test_mismatch_raises(self):
+        with pytest.raises(HashMismatchError):
+            verify_sha256(b"hello", "0" * 64)
+
+
+class TestExtractTarball:
+    def test_extract_validates_hash_first(self, tmp_path):
+        data = _build_tar([("apm.yml", b"name: x\n")])
+        with pytest.raises(HashMismatchError):
+            extract_tarball(data, "0" * 64, tmp_path)
+        # Nothing extracted on hash failure
+        assert not list(tmp_path.iterdir())
+
+    def test_extract_writes_files(self, tmp_path):
+        data = _build_tar(
+            [("apm.yml", b"name: acme/x\n"), (".apm/.keep", b"")]
+        )
+        digest = hashlib.sha256(data).hexdigest()
+        actual = extract_tarball(data, digest, tmp_path)
+        assert actual == digest
+        assert (tmp_path / "apm.yml").read_bytes() == b"name: acme/x\n"
+        assert (tmp_path / ".apm" / ".keep").exists()
+
+    def test_extract_accepts_sha256_prefix(self, tmp_path):
+        data = _build_tar([("apm.yml", b"name: y\n")])
+        digest = hashlib.sha256(data).hexdigest()
+        extract_tarball(data, f"sha256:{digest}", tmp_path)
+        assert (tmp_path / "apm.yml").exists()
+
+    # ─── Path traversal & unsafe entries ────────────────────────────────
+
+    def test_rejects_absolute_path(self, tmp_path):
+        data = _build_tar([("/etc/passwd", b"x")])
+        digest = hashlib.sha256(data).hexdigest()
+        with pytest.raises(UnsafeTarballError):
+            extract_tarball(data, digest, tmp_path)
+
+    def test_rejects_path_traversal(self, tmp_path):
+        data = _build_tar([("../escape.txt", b"x")])
+        digest = hashlib.sha256(data).hexdigest()
+        with pytest.raises(UnsafeTarballError):
+            extract_tarball(data, digest, tmp_path)
+
+    def test_rejects_symlink(self, tmp_path):
+        def add_symlink(tar):
+            ti = tarfile.TarInfo(name="link")
+            ti.type = tarfile.SYMTYPE
+            ti.linkname = "/etc/passwd"
+            tar.addfile(ti)
+
+        data = _build_tar_with(add_symlink)
+        digest = hashlib.sha256(data).hexdigest()
+        with pytest.raises(UnsafeTarballError):
+            extract_tarball(data, digest, tmp_path)
+
+    def test_rejects_hard_link(self, tmp_path):
+        def add_hardlink(tar):
+            ti = tarfile.TarInfo(name="link")
+            ti.type = tarfile.LNKTYPE
+            ti.linkname = "apm.yml"
+            tar.addfile(ti)
+
+        data = _build_tar_with(add_hardlink)
+        digest = hashlib.sha256(data).hexdigest()
+        with pytest.raises(UnsafeTarballError):
+            extract_tarball(data, digest, tmp_path)
+
+    def test_creates_intermediate_directories(self, tmp_path):
+        data = _build_tar([("a/b/c/file.txt", b"hello")])
+        digest = hashlib.sha256(data).hexdigest()
+        extract_tarball(data, digest, tmp_path)
+        assert (tmp_path / "a" / "b" / "c" / "file.txt").read_bytes() == b"hello"

--- a/tests/unit/registry/test_resolver.py
+++ b/tests/unit/registry/test_resolver.py
@@ -1,0 +1,205 @@
+"""End-to-end resolver tests with a fake HTTP client.
+
+Confirms the install-side orchestration: list_versions -> pick best -> download
+-> verify -> extract -> validate -> build PackageInfo. Failure paths checked:
+hash mismatch, no matching version, 401/403 surfaces remediation, 404 surfaces
+clear "no package" message.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import tarfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from apm_cli.deps.registry.client import RegistryClient, RegistryError, VersionEntry
+from apm_cli.deps.registry.resolver import (
+    RegistryPackageResolver,
+    RegistryResolutionError,
+)
+from apm_cli.models.dependency.reference import DependencyReference
+
+
+def _make_apm_tarball(name: str = "acme-web-skills", version: str = "1.2.0"):
+    """Build a minimal valid APM package tarball + return (bytes, sha256_hex)."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        apm_yml = (
+            f"name: {name}\nversion: {version}\ndescription: x\nauthor: a\n"
+        ).encode()
+        ti = tarfile.TarInfo(name="apm.yml")
+        ti.size = len(apm_yml)
+        tar.addfile(ti, io.BytesIO(apm_yml))
+        keep = tarfile.TarInfo(name=".apm/.keep")
+        keep.size = 0
+        tar.addfile(keep, io.BytesIO(b""))
+    data = buf.getvalue()
+    return data, hashlib.sha256(data).hexdigest()
+
+
+def _make_resolver(client_double):
+    return RegistryPackageResolver(
+        {"corp-main": "https://reg.example.com/apm"},
+        client_factory=lambda url, auth: client_double,
+    )
+
+
+def _make_dep(version: str = "^1.2") -> DependencyReference:
+    return DependencyReference(
+        repo_url="acme/web-skills",
+        reference=version,
+        source="registry",
+        registry_name="corp-main",
+    )
+
+
+class TestHappyPath:
+    def test_install_full_package(self, tmp_path):
+        raw, digest = _make_apm_tarball()
+        fake = MagicMock(spec=RegistryClient)
+        fake.list_versions.return_value = [
+            VersionEntry(version="1.2.0", digest=f"sha256:{digest}")
+        ]
+        fake.download_tarball.return_value = raw
+        fake.tarball_url.return_value = (
+            "https://reg.example.com/apm/v1/packages/acme/web-skills/versions/1.2.0/tarball"
+        )
+
+        resolver = _make_resolver(fake)
+        target = tmp_path / "apm_modules" / "acme" / "web-skills"
+        info = resolver.download_package(_make_dep(), target)
+
+        assert info.install_path == target
+        assert (target / "apm.yml").exists()
+        assert (target / ".apm").is_dir()
+
+        res = resolver.last_resolutions[_make_dep().get_unique_key()]
+        assert res.version == "1.2.0"
+        assert res.resolved_hash == f"sha256:{digest}"
+        assert res.resolved_url.endswith("/versions/1.2.0/tarball")
+
+    def test_picks_highest_matching_version(self, tmp_path):
+        raw, digest = _make_apm_tarball(version="1.5.3")
+        fake = MagicMock(spec=RegistryClient)
+        fake.list_versions.return_value = [
+            VersionEntry(version="1.2.0", digest=f"sha256:{digest}"),
+            VersionEntry(version="1.5.3", digest=f"sha256:{digest}"),
+            VersionEntry(version="2.0.0", digest=f"sha256:{digest}"),
+        ]
+        fake.download_tarball.return_value = raw
+        fake.tarball_url.return_value = "https://x/tarball"
+
+        resolver = _make_resolver(fake)
+        target = tmp_path / "p"
+        resolver.download_package(_make_dep("^1.0"), target)
+
+        # Confirm download_tarball was asked for the highest matching version.
+        fake.download_tarball.assert_called_once_with("acme", "web-skills", "1.5.3")
+
+
+class TestFailurePaths:
+    def test_hash_mismatch_fails_closed(self, tmp_path):
+        raw, _ = _make_apm_tarball()
+        fake = MagicMock(spec=RegistryClient)
+        fake.list_versions.return_value = [
+            VersionEntry(version="1.2.0", digest="sha256:" + "0" * 64)
+        ]
+        fake.download_tarball.return_value = raw
+        fake.tarball_url.return_value = "https://x"
+
+        resolver = _make_resolver(fake)
+        with pytest.raises(Exception) as excinfo:
+            resolver.download_package(_make_dep(), tmp_path / "p")
+        # Either HashMismatchError or RegistryResolutionError wrapping it.
+        assert "mismatch" in str(excinfo.value).lower() or "Hash" in type(
+            excinfo.value
+        ).__name__
+
+    def test_no_matching_version(self, tmp_path):
+        _, digest = _make_apm_tarball()
+        fake = MagicMock(spec=RegistryClient)
+        fake.list_versions.return_value = [
+            VersionEntry(version="2.0.0", digest=f"sha256:{digest}")
+        ]
+        resolver = _make_resolver(fake)
+        with pytest.raises(RegistryResolutionError, match="no version"):
+            resolver.download_package(_make_dep("^1.0"), tmp_path / "p")
+
+    def test_empty_versions_list(self, tmp_path):
+        fake = MagicMock(spec=RegistryClient)
+        fake.list_versions.return_value = []
+        resolver = _make_resolver(fake)
+        with pytest.raises(RegistryResolutionError, match="no versions"):
+            resolver.download_package(_make_dep(), tmp_path / "p")
+
+    def test_401_includes_remediation(self, tmp_path):
+        fake = MagicMock(spec=RegistryClient)
+        fake.list_versions.side_effect = RegistryError(
+            "auth required",
+            status=401,
+            url="https://reg.example.com/apm/v1/packages/acme/web-skills/versions",
+        )
+        resolver = _make_resolver(fake)
+        with pytest.raises(RegistryResolutionError) as excinfo:
+            resolver.download_package(_make_dep(), tmp_path / "p")
+        msg = str(excinfo.value)
+        assert "APM_REGISTRY_TOKEN_<NAME>" in msg
+        assert "https://reg.example.com/apm" in msg
+
+    def test_404_clear_message(self, tmp_path):
+        fake = MagicMock(spec=RegistryClient)
+        fake.list_versions.side_effect = RegistryError(
+            "not found",
+            status=404,
+            url="https://reg.example.com/apm/v1/packages/acme/web-skills/versions",
+        )
+        resolver = _make_resolver(fake)
+        with pytest.raises(RegistryResolutionError) as excinfo:
+            resolver.download_package(_make_dep(), tmp_path / "p")
+        assert "no package" in str(excinfo.value)
+
+    def test_unconfigured_registry_name(self, tmp_path):
+        # Resolver knows about 'corp-main', dep references 'corp-other'.
+        fake = MagicMock(spec=RegistryClient)
+        resolver = RegistryPackageResolver(
+            {"corp-main": "https://reg.example.com/apm"},
+            client_factory=lambda url, auth: fake,
+        )
+        dep = DependencyReference(
+            repo_url="acme/x",
+            reference="1.0.0",
+            source="registry",
+            registry_name="corp-other",
+        )
+        with pytest.raises(RegistryResolutionError, match="not configured"):
+            resolver.download_package(dep, tmp_path / "p")
+
+    def test_non_registry_dep_rejected(self, tmp_path):
+        fake = MagicMock(spec=RegistryClient)
+        resolver = _make_resolver(fake)
+        dep = DependencyReference(
+            repo_url="acme/x", reference="1.0.0", source="git"
+        )
+        with pytest.raises(RegistryResolutionError, match="non-registry"):
+            resolver.download_package(dep, tmp_path / "p")
+
+    def test_invalid_semver_constraint_rejected_at_resolver(self, tmp_path):
+        # Defense in depth: if a "registry" dep slips past the parser with a
+        # branch name, the resolver still rejects it.
+        fake = MagicMock(spec=RegistryClient)
+        fake.list_versions.return_value = [
+            VersionEntry(version="1.0.0", digest="sha256:" + "0" * 64)
+        ]
+        resolver = _make_resolver(fake)
+        dep = DependencyReference(
+            repo_url="acme/x",
+            reference="main",
+            source="registry",
+            registry_name="corp-main",
+        )
+        with pytest.raises(RegistryResolutionError, match="not a valid semver"):
+            resolver.download_package(dep, tmp_path / "p")

--- a/tests/unit/registry/test_resolver.py
+++ b/tests/unit/registry/test_resolver.py
@@ -41,6 +41,19 @@ def _make_apm_tarball(name: str = "acme-web-skills", version: str = "1.2.0"):
     return data, hashlib.sha256(data).hexdigest()
 
 
+def _make_apm_zip(name: str = "acme-skill", version: str = "1.0.0"):
+    """Build a minimal valid APM package zip + return (bytes, sha256_hex)."""
+    import zipfile as _zip
+
+    buf = io.BytesIO()
+    apm_yml = f"name: {name}\nversion: {version}\ndescription: x\nauthor: a\n"
+    with _zip.ZipFile(buf, mode="w", compression=_zip.ZIP_DEFLATED) as zf:
+        zf.writestr("apm.yml", apm_yml)
+        zf.writestr(".apm/.keep", "")
+    data = buf.getvalue()
+    return data, hashlib.sha256(data).hexdigest()
+
+
 def _make_resolver(client_double):
     return RegistryPackageResolver(
         {"corp-main": "https://reg.example.com/apm"},
@@ -64,9 +77,9 @@ class TestHappyPath:
         fake.list_versions.return_value = [
             VersionEntry(version="1.2.0", digest=f"sha256:{digest}")
         ]
-        fake.download_tarball.return_value = raw
-        fake.tarball_url.return_value = (
-            "https://reg.example.com/apm/v1/packages/acme/web-skills/versions/1.2.0/tarball"
+        fake.download_archive.return_value = (raw, "application/gzip")
+        fake.archive_url.return_value = (
+            "https://reg.example.com/apm/v1/packages/acme/web-skills/versions/1.2.0/download"
         )
 
         resolver = _make_resolver(fake)
@@ -80,7 +93,34 @@ class TestHappyPath:
         res = resolver.last_resolutions[_make_dep().get_unique_key()]
         assert res.version == "1.2.0"
         assert res.resolved_hash == f"sha256:{digest}"
-        assert res.resolved_url.endswith("/versions/1.2.0/tarball")
+        assert res.resolved_url.endswith("/versions/1.2.0/download")
+
+    def test_install_zip_archive(self, tmp_path):
+        # Anthropic skill format: zip with the same package shape.
+        raw, digest = _make_apm_zip()
+        fake = MagicMock(spec=RegistryClient)
+        fake.list_versions.return_value = [
+            VersionEntry(version="1.0.0", digest=f"sha256:{digest}")
+        ]
+        fake.download_archive.return_value = (raw, "application/zip")
+        fake.archive_url.return_value = (
+            "https://reg.example.com/apm/v1/packages/acme/skill/versions/1.0.0/download"
+        )
+
+        resolver = _make_resolver(fake)
+        target = tmp_path / "apm_modules" / "acme" / "skill"
+        info = resolver.download_package(
+            DependencyReference(
+                repo_url="acme/skill",
+                reference="^1.0",
+                source="registry",
+                registry_name="corp-main",
+            ),
+            target,
+        )
+        assert (target / "apm.yml").exists()
+        assert (target / ".apm").is_dir()
+        assert info.install_path == target
 
     def test_picks_highest_matching_version(self, tmp_path):
         raw, digest = _make_apm_tarball(version="1.5.3")
@@ -90,15 +130,15 @@ class TestHappyPath:
             VersionEntry(version="1.5.3", digest=f"sha256:{digest}"),
             VersionEntry(version="2.0.0", digest=f"sha256:{digest}"),
         ]
-        fake.download_tarball.return_value = raw
-        fake.tarball_url.return_value = "https://x/tarball"
+        fake.download_archive.return_value = (raw, "application/gzip")
+        fake.archive_url.return_value = "https://x/download"
 
         resolver = _make_resolver(fake)
         target = tmp_path / "p"
         resolver.download_package(_make_dep("^1.0"), target)
 
-        # Confirm download_tarball was asked for the highest matching version.
-        fake.download_tarball.assert_called_once_with("acme", "web-skills", "1.5.3")
+        # Confirm download_archive was asked for the highest matching version.
+        fake.download_archive.assert_called_once_with("acme", "web-skills", "1.5.3")
 
 
 class TestFailurePaths:
@@ -108,8 +148,8 @@ class TestFailurePaths:
         fake.list_versions.return_value = [
             VersionEntry(version="1.2.0", digest="sha256:" + "0" * 64)
         ]
-        fake.download_tarball.return_value = raw
-        fake.tarball_url.return_value = "https://x"
+        fake.download_archive.return_value = (raw, "application/gzip")
+        fake.archive_url.return_value = "https://x"
 
         resolver = _make_resolver(fake)
         with pytest.raises(Exception) as excinfo:

--- a/tests/unit/registry/test_resolver_e2e_http.py
+++ b/tests/unit/registry/test_resolver_e2e_http.py
@@ -1,0 +1,345 @@
+"""End-to-end registry-resolver tests against a real local HTTP server.
+
+Stronger guarantee than the MagicMock-based tests in ``test_resolver.py``:
+this exercises the full ``RegistryClient`` -> network -> ``RegistryClient``
+parsing path. We spin up a stdlib ``http.server.HTTPServer`` in a thread,
+register fake routes, and run the resolver against ``http://localhost:<port>``.
+
+Tested:
+- Happy path with tar.gz archive
+- Happy path with zip archive (Anthropic skills format)
+- 404 surfaces a clear "no package" message
+- 401 surfaces the §6.2 remediation (auth)
+- Tarball with sha256 mismatch fails closed before any extraction
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import io
+import json
+import socket
+import tarfile
+import threading
+import zipfile
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+from typing import Callable, Dict
+
+import pytest
+
+from apm_cli.deps.registry.resolver import (
+    RegistryPackageResolver,
+    RegistryResolutionError,
+)
+from apm_cli.models.dependency.reference import DependencyReference
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Test HTTP server scaffolding
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class _FakeRegistryHandler(BaseHTTPRequestHandler):
+    """Per-request handler. Routes installed via class-level ``ROUTES``."""
+
+    ROUTES: Dict[str, Callable] = {}
+
+    # Suppress noisy default logging
+    def log_message(self, format, *args):  # noqa: A002 — match stdlib signature
+        pass
+
+    def do_GET(self):  # noqa: N802 — stdlib naming
+        route = self.ROUTES.get(self.path)
+        if route is None:
+            self.send_response(404)
+            self.send_header("Content-Type", "application/problem+json")
+            body = json.dumps(
+                {"title": "Not Found", "detail": f"no route {self.path}"}
+            ).encode()
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        # Routes return (status, content_type, body_bytes)
+        status, ctype, body = route(self)
+        self.send_response(status)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+@contextlib.contextmanager
+def _running_server(routes: Dict[str, Callable]):
+    """Yield a (host, port) tuple for a running HTTP server with *routes* installed."""
+    # Find a free port
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+
+    # Patch routes onto the handler class. We use a unique handler subclass
+    # per test to avoid cross-test contamination.
+    handler_cls = type(
+        "_PerTestHandler",
+        (_FakeRegistryHandler,),
+        {"ROUTES": dict(routes)},
+    )
+    server = HTTPServer(("127.0.0.1", port), handler_cls)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield ("127.0.0.1", port)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Archive helpers
+# ───────────────────────────────────────────────────────────────────────────
+
+
+def _build_apm_tarball():
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        apm_yml = b"name: acme-web\nversion: 1.0.0\ndescription: x\nauthor: a\n"
+        ti = tarfile.TarInfo("apm.yml")
+        ti.size = len(apm_yml)
+        tar.addfile(ti, io.BytesIO(apm_yml))
+        keep = tarfile.TarInfo(".apm/.keep")
+        keep.size = 0
+        tar.addfile(keep, io.BytesIO(b""))
+    data = buf.getvalue()
+    return data, hashlib.sha256(data).hexdigest()
+
+
+def _build_apm_zip():
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(
+            "apm.yml", "name: acme-skill\nversion: 1.0.0\ndescription: x\nauthor: a\n"
+        )
+        zf.writestr(".apm/.keep", "")
+    data = buf.getvalue()
+    return data, hashlib.sha256(data).hexdigest()
+
+
+def _make_dep(name: str = "acme/web") -> DependencyReference:
+    return DependencyReference(
+        repo_url=name,
+        reference="^1.0",
+        source="registry",
+        registry_name="corp",
+    )
+
+
+def _versions_payload(name: str, version: str, digest_hex: str) -> bytes:
+    return json.dumps(
+        {
+            "package": name,
+            "versions": [
+                {
+                    "version": version,
+                    "digest": f"sha256:{digest_hex}",
+                    "published_at": "2026-01-01T00:00:00Z",
+                }
+            ],
+        }
+    ).encode()
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Tests
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestE2EHappyPath:
+    def test_install_tar_gz(self, tmp_path):
+        data, digest = _build_apm_tarball()
+        routes = {
+            "/v1/packages/acme/web/versions": lambda h: (
+                200,
+                "application/json",
+                _versions_payload("acme/web", "1.0.0", digest),
+            ),
+            "/v1/packages/acme/web/versions/1.0.0/download": lambda h: (
+                200,
+                "application/gzip",
+                data,
+            ),
+        }
+        with _running_server(routes) as (host, port):
+            base = f"http://{host}:{port}"
+            resolver = RegistryPackageResolver({"corp": base})
+            target = tmp_path / "apm_modules" / "acme" / "web"
+            info = resolver.download_package(_make_dep(), target)
+            assert (target / "apm.yml").exists()
+            assert (target / ".apm").is_dir()
+            res = resolver.last_resolutions[_make_dep().get_unique_key()]
+            assert res.version == "1.0.0"
+            assert res.resolved_hash == f"sha256:{digest}"
+            assert res.resolved_url.endswith("/versions/1.0.0/download")
+
+    def test_install_zip(self, tmp_path):
+        data, digest = _build_apm_zip()
+        routes = {
+            "/v1/packages/acme/skill/versions": lambda h: (
+                200,
+                "application/json",
+                _versions_payload("acme/skill", "1.0.0", digest),
+            ),
+            "/v1/packages/acme/skill/versions/1.0.0/download": lambda h: (
+                200,
+                "application/zip",
+                data,
+            ),
+        }
+        with _running_server(routes) as (host, port):
+            base = f"http://{host}:{port}"
+            resolver = RegistryPackageResolver({"corp": base})
+            target = tmp_path / "apm_modules" / "acme" / "skill"
+            info = resolver.download_package(_make_dep("acme/skill"), target)
+            assert (target / "apm.yml").exists()
+            assert (target / ".apm").is_dir()
+
+
+class TestE2EErrorPaths:
+    def test_404_no_package(self, tmp_path):
+        # No routes — every GET returns 404.
+        with _running_server({}) as (host, port):
+            base = f"http://{host}:{port}"
+            resolver = RegistryPackageResolver({"corp": base})
+            with pytest.raises(RegistryResolutionError, match="no package"):
+                resolver.download_package(
+                    _make_dep("acme/missing"), tmp_path / "p"
+                )
+
+    def test_401_surfaces_remediation(self, tmp_path):
+        routes = {
+            "/v1/packages/acme/web/versions": lambda h: (
+                401,
+                "application/problem+json",
+                json.dumps(
+                    {"title": "Unauthorized", "detail": "missing token"}
+                ).encode(),
+            )
+        }
+        with _running_server(routes) as (host, port):
+            base = f"http://{host}:{port}"
+            resolver = RegistryPackageResolver({"corp": base})
+            with pytest.raises(RegistryResolutionError) as excinfo:
+                resolver.download_package(_make_dep(), tmp_path / "p")
+            msg = str(excinfo.value)
+            assert "APM_REGISTRY_TOKEN_<NAME>" in msg
+            assert base in msg
+
+    def test_hash_mismatch_fails_closed(self, tmp_path):
+        data, _real_digest = _build_apm_tarball()
+        bogus = "0" * 64  # advertise a wrong digest
+        routes = {
+            "/v1/packages/acme/web/versions": lambda h: (
+                200,
+                "application/json",
+                _versions_payload("acme/web", "1.0.0", bogus),
+            ),
+            "/v1/packages/acme/web/versions/1.0.0/download": lambda h: (
+                200,
+                "application/gzip",
+                data,
+            ),
+        }
+        with _running_server(routes) as (host, port):
+            base = f"http://{host}:{port}"
+            resolver = RegistryPackageResolver({"corp": base})
+            with pytest.raises(Exception) as excinfo:
+                resolver.download_package(_make_dep(), tmp_path / "p")
+            # Either HashMismatchError directly or wrapped in RegistryResolutionError
+            assert (
+                "mismatch" in str(excinfo.value).lower()
+                or "Hash" in type(excinfo.value).__name__
+            )
+
+    def test_no_matching_version(self, tmp_path):
+        data, digest = _build_apm_tarball()
+        routes = {
+            # Only 2.x available; manifest asks for ^1.0
+            "/v1/packages/acme/web/versions": lambda h: (
+                200,
+                "application/json",
+                _versions_payload("acme/web", "2.0.0", digest),
+            ),
+        }
+        with _running_server(routes) as (host, port):
+            base = f"http://{host}:{port}"
+            resolver = RegistryPackageResolver({"corp": base})
+            with pytest.raises(RegistryResolutionError, match="no version"):
+                resolver.download_package(_make_dep(), tmp_path / "p")
+
+
+class TestE2EAuthHeader:
+    """Confirm Bearer header is forwarded and observed by the server."""
+
+    def test_token_sent_when_env_set(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("APM_REGISTRY_TOKEN_CORP", "secret-token-123")
+        data, digest = _build_apm_tarball()
+        seen_headers: dict = {}
+
+        def versions_route(h):
+            seen_headers["versions"] = dict(h.headers)
+            return (
+                200,
+                "application/json",
+                _versions_payload("acme/web", "1.0.0", digest),
+            )
+
+        def download_route(h):
+            seen_headers["download"] = dict(h.headers)
+            return (200, "application/gzip", data)
+
+        routes = {
+            "/v1/packages/acme/web/versions": versions_route,
+            "/v1/packages/acme/web/versions/1.0.0/download": download_route,
+        }
+        with _running_server(routes) as (host, port):
+            base = f"http://{host}:{port}"
+            resolver = RegistryPackageResolver({"corp": base})
+            resolver.download_package(_make_dep(), tmp_path / "x")
+        assert (
+            seen_headers["versions"].get("Authorization")
+            == "Bearer secret-token-123"
+        )
+        assert (
+            seen_headers["download"].get("Authorization")
+            == "Bearer secret-token-123"
+        )
+
+    def test_anonymous_when_no_env(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("APM_REGISTRY_TOKEN_CORP", raising=False)
+        data, digest = _build_apm_tarball()
+        seen_headers: dict = {}
+
+        def route(h):
+            seen_headers["versions"] = dict(h.headers)
+            return (
+                200,
+                "application/json",
+                _versions_payload("acme/web", "1.0.0", digest),
+            )
+
+        routes = {
+            "/v1/packages/acme/web/versions": route,
+            "/v1/packages/acme/web/versions/1.0.0/download": lambda h: (
+                200,
+                "application/gzip",
+                data,
+            ),
+        }
+        with _running_server(routes) as (host, port):
+            base = f"http://{host}:{port}"
+            resolver = RegistryPackageResolver({"corp": base})
+            resolver.download_package(_make_dep(), tmp_path / "x")
+        assert seen_headers["versions"].get("Authorization") is None

--- a/tests/unit/registry/test_semver.py
+++ b/tests/unit/registry/test_semver.py
@@ -1,0 +1,143 @@
+"""Tests for the npm-style semver matcher.
+
+Covers the parse-time gate (``is_semver_range``) that rejects branch names and
+commit SHAs when an entry routes to a registry (design §3.3), plus the
+range-matching logic used by the resolver to pick the best published version.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apm_cli.deps.registry.semver import (
+    is_semver_range,
+    match_version,
+    pick_best,
+)
+
+
+class TestIsSemverRange:
+    """``is_semver_range`` is the parse-time gate; it is allowed to be lenient
+    on shape but MUST reject anything that isn't a version-or-range expression."""
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            "1.0.0",
+            "v1.0.0",
+            "1.2",
+            "1",
+            "^1.2",
+            "^1.0.0",
+            "~1.2.3",
+            "~1.2",
+            ">=1",
+            "<2",
+            ">=1,<2",
+            ">1.0.0",
+            "<=2.0.0",
+            "1.x",
+            "1.2.x",
+            "1.*",
+            "*",
+        ],
+    )
+    def test_accepts_valid_ranges(self, spec):
+        assert is_semver_range(spec)
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            "main",
+            "develop",
+            "abc123d",
+            "abc123def4567",
+            "latest",
+            "",
+            "v1@bad",
+            "1.0.0-foo",      # pre-release suffix not supported in v1
+            "not-a-version",
+            "@invalid",
+        ],
+    )
+    def test_rejects_invalid_refs(self, spec):
+        assert not is_semver_range(spec)
+
+
+class TestMatchVersion:
+    """Range-matching semantics."""
+
+    @pytest.mark.parametrize(
+        "spec,version",
+        [
+            ("^1.2", "1.2.0"),
+            ("^1.2", "1.5.0"),
+            ("^1.2", "1.99.99"),
+            ("^0.2.3", "0.2.3"),
+            ("^0.2.3", "0.2.99"),
+            ("~1.2.3", "1.2.3"),
+            ("~1.2.3", "1.2.99"),
+            ("~1.2", "1.2.99"),
+            ("1.x", "1.0.0"),
+            ("1.x", "1.99.99"),
+            (">=1,<2", "1.99.0"),
+            (">=1.0.0", "1.0.0"),
+            ("*", "0.0.1"),
+            ("*", "99.0.0"),
+            ("1.0.0", "1.0.0"),
+        ],
+    )
+    def test_match(self, spec, version):
+        assert match_version(spec, version)
+
+    @pytest.mark.parametrize(
+        "spec,version",
+        [
+            ("^1.2", "2.0.0"),
+            ("^1.2", "1.1.99"),
+            ("^0.2.3", "0.3.0"),
+            ("^0.2.3", "0.2.2"),
+            ("~1.2.3", "1.3.0"),
+            ("~1.2", "1.3.0"),
+            ("1.x", "2.0.0"),
+            (">=1,<2", "2.0.0"),
+            ("1.0.0", "1.0.1"),
+            ("1.0.0", "0.9.99"),
+        ],
+    )
+    def test_no_match(self, spec, version):
+        assert not match_version(spec, version)
+
+    def test_invalid_spec_does_not_match(self):
+        assert not match_version("main", "1.0.0")
+
+    def test_invalid_version_does_not_match(self):
+        assert not match_version("^1.0", "abc")
+
+
+class TestPickBest:
+    """``pick_best`` returns the highest matching version, or None."""
+
+    def test_picks_highest_in_range(self):
+        versions = ["1.0.0", "1.2.0", "1.5.3", "2.0.0"]
+        assert pick_best("^1.0", versions) == "1.5.3"
+
+    def test_skips_outside_range(self):
+        versions = ["1.0.0", "1.2.0", "2.0.0"]
+        assert pick_best("~1.2", versions) == "1.2.0"
+
+    def test_no_match_returns_none(self):
+        assert pick_best(">=2", ["1.0.0"]) is None
+
+    def test_invalid_spec_returns_none(self):
+        assert pick_best("main", ["1.0.0"]) is None
+
+    def test_skips_unparseable_versions(self):
+        # An unparseable entry in the list is silently skipped, not raised.
+        versions = ["1.0.0", "garbage", "1.5.0"]
+        assert pick_best("^1", versions) == "1.5.0"
+
+    def test_caret_zero_zero_x(self):
+        """^0.0.x semantics: only the patch matches exactly."""
+        assert pick_best("^0.0.3", ["0.0.3", "0.0.4"]) == "0.0.3"
+        assert pick_best("^0.0.3", ["0.0.4", "0.0.5"]) is None

--- a/tests/unit/test_apm_yml_registries.py
+++ b/tests/unit/test_apm_yml_registries.py
@@ -1,0 +1,422 @@
+"""Tests for the top-level ``registries:`` block in apm.yml.
+
+Covers ``APMPackage.from_apm_yml`` parsing of the new block plus the
+default-registry routing pass per docs/proposals/registry-api.md §3.1/§3.2.
+
+The hardest invariant: a project without a ``registries:`` block is
+byte-identical to pre-PR behavior (invariant §2.1.1).
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from apm_cli.models.apm_package import APMPackage, clear_apm_yml_cache
+
+
+@pytest.fixture
+def write_yml(tmp_path):
+    """Yield a helper that writes ``apm.yml`` content to a temp dir."""
+
+    def _write(content: str) -> Path:
+        clear_apm_yml_cache()
+        p = tmp_path / "apm.yml"
+        p.write_text(textwrap.dedent(content).strip() + "\n")
+        return p
+
+    return _write
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Block parsing
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestRegistriesBlockParsing:
+    def test_no_block_means_no_change(self, write_yml):
+        p = write_yml(
+            """
+            name: x
+            version: 1.0.0
+            dependencies:
+              apm:
+                - acme/foo#main
+                - acme/bar#v1.0
+            """
+        )
+        pkg = APMPackage.from_apm_yml(p)
+        assert pkg.registries is None
+        assert pkg.default_registry is None
+        for dep in pkg.dependencies["apm"]:
+            assert dep.source is None
+
+    def test_block_without_default(self, write_yml):
+        p = write_yml(
+            """
+            name: x
+            version: 1.0.0
+            registries:
+              corp-main:
+                url: https://corp.example.com/apm
+            dependencies:
+              apm:
+                - acme/foo#v1.0
+            """
+        )
+        pkg = APMPackage.from_apm_yml(p)
+        assert pkg.registries == {"corp-main": "https://corp.example.com/apm"}
+        assert pkg.default_registry is None
+        # Without a default, plain shorthand stays on Git.
+        assert pkg.dependencies["apm"][0].source is None
+
+    def test_block_with_default(self, write_yml):
+        p = write_yml(
+            """
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com/apm
+              default: corp
+            """
+        )
+        pkg = APMPackage.from_apm_yml(p)
+        assert pkg.default_registry == "corp"
+        assert "corp" in pkg.registries
+
+    def test_multiple_registries(self, write_yml):
+        p = write_yml(
+            """
+            name: x
+            version: 1.0.0
+            registries:
+              corp-a:
+                url: https://a.example.com/apm
+              corp-b:
+                url: https://b.example.com/apm
+              default: corp-a
+            """
+        )
+        pkg = APMPackage.from_apm_yml(p)
+        assert set(pkg.registries.keys()) == {"corp-a", "corp-b"}
+        assert pkg.default_registry == "corp-a"
+
+    def test_empty_block(self, write_yml):
+        # ``registries: {}`` is harmless and yields no fields set.
+        p = write_yml(
+            """
+            name: x
+            version: 1.0.0
+            registries: {}
+            """
+        )
+        pkg = APMPackage.from_apm_yml(p)
+        assert pkg.registries is None
+        assert pkg.default_registry is None
+
+
+class TestRegistriesBlockValidation:
+    def test_non_mapping_block_rejected(self, write_yml):
+        p = write_yml(
+            """
+            name: x
+            version: 1.0.0
+            registries: not-a-mapping
+            """
+        )
+        with pytest.raises(ValueError, match="must be a mapping"):
+            APMPackage.from_apm_yml(p)
+
+    def test_missing_url_rejected(self, write_yml):
+        p = write_yml(
+            """
+            name: x
+            version: 1.0.0
+            registries:
+              corp: {}
+            """
+        )
+        with pytest.raises(ValueError, match="missing required field 'url:'"):
+            APMPackage.from_apm_yml(p)
+
+    def test_non_http_url_rejected(self, write_yml):
+        p = write_yml(
+            """
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: ftp://corp.example.com
+            """
+        )
+        with pytest.raises(ValueError, match="https:// or http://"):
+            APMPackage.from_apm_yml(p)
+
+    def test_unknown_field_rejected(self, write_yml):
+        p = write_yml(
+            """
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com/apm
+                token: oops-not-here
+            """
+        )
+        with pytest.raises(ValueError, match="unknown fields"):
+            APMPackage.from_apm_yml(p)
+
+    def test_unknown_default_rejected(self, write_yml):
+        p = write_yml(
+            """
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com
+              default: nonexistent
+            """
+        )
+        with pytest.raises(ValueError, match="unconfigured registry"):
+            APMPackage.from_apm_yml(p)
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Default-registry routing pass
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestDefaultRouting:
+    def test_shorthand_routes_to_default(self, write_yml):
+        p = write_yml(
+            """
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com/apm
+              default: corp
+            dependencies:
+              apm:
+                - acme/foo#^1.0
+                - acme/bar#1.2.3
+            """
+        )
+        pkg = APMPackage.from_apm_yml(p)
+        for dep in pkg.dependencies["apm"]:
+            assert dep.source == "registry"
+            assert dep.registry_name == "corp"
+
+    def test_at_scope_overrides_default(self, write_yml):
+        p = write_yml(
+            """
+            name: x
+            version: 1.0.0
+            registries:
+              corp-main:
+                url: https://main.example.com/apm
+              corp-other:
+                url: https://other.example.com/apm
+              default: corp-main
+            dependencies:
+              apm:
+                - acme/foo@corp-other#^1.0
+            """
+        )
+        pkg = APMPackage.from_apm_yml(p)
+        d = pkg.dependencies["apm"][0]
+        assert d.registry_name == "corp-other"
+
+    def test_explicit_git_object_form_not_routed(self, write_yml):
+        p = write_yml(
+            """
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com/apm
+              default: corp
+            dependencies:
+              apm:
+                - git: https://github.com/owner/repo.git
+                  ref: v2.0
+            """
+        )
+        pkg = APMPackage.from_apm_yml(p)
+        d = pkg.dependencies["apm"][0]
+        assert d.source == "git"  # explicit, not "registry"
+
+    def test_object_form_registry_preserved(self, write_yml):
+        p = write_yml(
+            """
+            name: x
+            version: 1.0.0
+            registries:
+              corp-main:
+                url: https://main.example.com/apm
+              corp-other:
+                url: https://other.example.com/apm
+              default: corp-main
+            dependencies:
+              apm:
+                - registry: corp-other
+                  id: acme/prompts
+                  path: a/b.prompt.md
+                  version: 1.0.0
+            """
+        )
+        pkg = APMPackage.from_apm_yml(p)
+        d = pkg.dependencies["apm"][0]
+        assert d.registry_name == "corp-other"
+
+    def test_local_path_not_routed(self, write_yml):
+        p = write_yml(
+            """
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com/apm
+              default: corp
+            dependencies:
+              apm:
+                - ./local-pkg
+            """
+        )
+        pkg = APMPackage.from_apm_yml(p)
+        d = pkg.dependencies["apm"][0]
+        assert d.is_local
+        assert d.source is None
+
+    def test_dev_dependencies_routed_too(self, write_yml):
+        p = write_yml(
+            """
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com/apm
+              default: corp
+            devDependencies:
+              apm:
+                - acme/foo#1.0.0
+            """
+        )
+        pkg = APMPackage.from_apm_yml(p)
+        d = pkg.dev_dependencies["apm"][0]
+        assert d.source == "registry"
+        assert d.registry_name == "corp"
+
+
+class TestDefaultRoutingErrors:
+    def test_branch_ref_rejected(self, write_yml):
+        p = write_yml(
+            """
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com/apm
+              default: corp
+            dependencies:
+              apm:
+                - acme/foo#main
+            """
+        )
+        with pytest.raises(ValueError, match="not a semver"):
+            APMPackage.from_apm_yml(p)
+
+    def test_commit_sha_rejected(self, write_yml):
+        p = write_yml(
+            """
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com/apm
+              default: corp
+            dependencies:
+              apm:
+                - acme/foo#abc123d
+            """
+        )
+        with pytest.raises(ValueError, match="not a semver"):
+            APMPackage.from_apm_yml(p)
+
+    def test_missing_ref_rejected(self, write_yml):
+        p = write_yml(
+            """
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com/apm
+              default: corp
+            dependencies:
+              apm:
+                - acme/foo
+            """
+        )
+        with pytest.raises(ValueError, match="no version constraint"):
+            APMPackage.from_apm_yml(p)
+
+    def test_remediation_mentions_git_alternative(self, write_yml):
+        p = write_yml(
+            """
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com/apm
+              default: corp
+            dependencies:
+              apm:
+                - acme/foo#develop
+            """
+        )
+        with pytest.raises(ValueError) as excinfo:
+            APMPackage.from_apm_yml(p)
+        assert "- git:" in str(excinfo.value)
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Backwards-compatibility invariants
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestBackwardsCompatibility:
+    """A project without ``registries:`` MUST behave byte-identically to pre-PR."""
+
+    def test_branch_ref_still_valid_without_registries(self, write_yml):
+        # Per invariant §2.1.3, branch refs remain valid in the absence of
+        # a registries: block — the parser stays ref-opaque on the Git path.
+        p = write_yml(
+            """
+            name: x
+            version: 1.0.0
+            dependencies:
+              apm:
+                - acme/foo#main
+                - acme/foo#abc123d
+            """
+        )
+        pkg = APMPackage.from_apm_yml(p)
+        for dep in pkg.dependencies["apm"]:
+            assert dep.source is None
+
+    def test_no_version_still_valid_without_registries(self, write_yml):
+        # `acme/foo` without a #ref is fine when no default registry is set.
+        p = write_yml(
+            """
+            name: x
+            version: 1.0.0
+            dependencies:
+              apm:
+                - acme/foo
+            """
+        )
+        pkg = APMPackage.from_apm_yml(p)
+        assert pkg.dependencies["apm"][0].reference is None

--- a/tests/unit/test_drift_registry.py
+++ b/tests/unit/test_drift_registry.py
@@ -1,0 +1,281 @@
+"""Source-aware drift rules for registry-sourced deps.
+
+Covers the docs/proposals/registry-api.md §6.1 invariants:
+
+- Manifest carries a semver range (e.g. ``^1.2``); lockfile carries an exact
+  version (e.g. ``1.5.3``). Direct string comparison would be a false
+  positive — drift is "did the locked version stop matching the manifest
+  range?".
+- Source-flip drift (git -> registry or vice versa) forces a re-resolve.
+- ``build_download_ref`` replays the exact locked version for registry deps,
+  not the manifest range.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import pytest
+
+from apm_cli.drift import build_download_ref, detect_ref_change
+from apm_cli.models.dependency.reference import DependencyReference
+
+
+@dataclass
+class _LockedDep:
+    """Minimal LockedDependency stand-in for drift tests."""
+
+    repo_url: str = "acme/web"
+    resolved_ref: Optional[str] = None
+    resolved_commit: Optional[str] = None
+    host: Optional[str] = "github.com"
+    registry_prefix: Optional[str] = None
+    virtual_path: Optional[str] = None
+    source: Optional[str] = None
+    local_path: Optional[str] = None
+    version: Optional[str] = None
+    resolved_url: Optional[str] = None
+    resolved_hash: Optional[str] = None
+    is_insecure: bool = False
+    allow_insecure: bool = False
+
+
+class _LockfileStub:
+    """Pretend lockfile that just exposes get_dependency for build_download_ref."""
+
+    def __init__(self, deps_by_key):
+        self._deps = deps_by_key
+
+    def get_dependency(self, key):
+        return self._deps.get(key)
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Source-flip drift
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestSourceFlipDrift:
+    def test_git_to_registry_is_drift(self):
+        dep = DependencyReference(
+            repo_url="acme/web", reference="^1.2", source="registry"
+        )
+        locked = _LockedDep(resolved_ref="v1.0", source=None)  # legacy git
+        assert detect_ref_change(dep, locked) is True
+
+    def test_registry_to_git_is_drift(self):
+        dep = DependencyReference(repo_url="acme/web", reference="v1.0")  # git
+        locked = _LockedDep(source="registry", version="1.0.0")
+        assert detect_ref_change(dep, locked) is True
+
+    def test_legacy_none_source_equals_git(self):
+        # Lockfile from before this PR has source=None for git deps.
+        # A new manifest dep with source=None (Git default) MUST NOT be
+        # treated as a source flip.
+        dep = DependencyReference(repo_url="acme/web", reference="v1.0")
+        locked = _LockedDep(resolved_ref="v1.0", source=None)
+        assert detect_ref_change(dep, locked) is False
+
+    def test_explicit_git_to_legacy_none_no_drift(self):
+        # source="git" and source=None are equivalent.
+        dep = DependencyReference(
+            repo_url="acme/web", reference="v1.0", source="git"
+        )
+        locked = _LockedDep(resolved_ref="v1.0", source=None)
+        assert detect_ref_change(dep, locked) is False
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Registry semver-range matching
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestRegistryRangeMatching:
+    def test_locked_version_inside_range_no_drift(self):
+        dep = DependencyReference(
+            repo_url="acme/web", reference="^1.2", source="registry"
+        )
+        locked = _LockedDep(source="registry", version="1.5.3")
+        assert detect_ref_change(dep, locked) is False
+
+    def test_locked_version_outside_range_is_drift(self):
+        # User tightened the range; locked version no longer matches.
+        dep = DependencyReference(
+            repo_url="acme/web", reference="~1.5.4", source="registry"
+        )
+        locked = _LockedDep(source="registry", version="1.5.3")
+        assert detect_ref_change(dep, locked) is True
+
+    def test_user_expanded_range_to_include_locked_no_drift(self):
+        # ``^1.0`` widens to include 1.5.3 — no drift, keep using it.
+        dep = DependencyReference(
+            repo_url="acme/web", reference="^1.0", source="registry"
+        )
+        locked = _LockedDep(source="registry", version="1.5.3")
+        assert detect_ref_change(dep, locked) is False
+
+    def test_user_changed_to_major_bump_is_drift(self):
+        dep = DependencyReference(
+            repo_url="acme/web", reference="^2.0", source="registry"
+        )
+        locked = _LockedDep(source="registry", version="1.5.3")
+        assert detect_ref_change(dep, locked) is True
+
+    def test_exact_version_match_no_drift(self):
+        dep = DependencyReference(
+            repo_url="acme/web", reference="1.5.3", source="registry"
+        )
+        locked = _LockedDep(source="registry", version="1.5.3")
+        assert detect_ref_change(dep, locked) is False
+
+    def test_missing_version_in_lockfile_is_drift(self):
+        # A registry dep with no `version` recorded is corrupt — fail loud.
+        dep = DependencyReference(
+            repo_url="acme/web", reference="^1.0", source="registry"
+        )
+        locked = _LockedDep(source="registry", version=None)
+        assert detect_ref_change(dep, locked) is True
+
+    def test_missing_manifest_ref_is_drift(self):
+        dep = DependencyReference(
+            repo_url="acme/web", reference=None, source="registry"
+        )
+        locked = _LockedDep(source="registry", version="1.0.0")
+        assert detect_ref_change(dep, locked) is True
+
+    def test_invalid_manifest_range_is_drift(self):
+        # Branch-shaped ref slipped past parsing for some reason — fail
+        # loud on the drift path so it surfaces.
+        dep = DependencyReference(
+            repo_url="acme/web", reference="main", source="registry"
+        )
+        locked = _LockedDep(source="registry", version="1.0.0")
+        assert detect_ref_change(dep, locked) is True
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Backwards-compat: git deps unchanged
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestGitDriftUnchanged:
+    def test_same_ref_no_drift(self):
+        dep = DependencyReference(repo_url="acme/web", reference="v1.0")
+        locked = _LockedDep(resolved_ref="v1.0")
+        assert detect_ref_change(dep, locked) is False
+
+    def test_changed_ref_is_drift(self):
+        dep = DependencyReference(repo_url="acme/web", reference="v2.0")
+        locked = _LockedDep(resolved_ref="v1.0")
+        assert detect_ref_change(dep, locked) is True
+
+    def test_added_ref_is_drift(self):
+        dep = DependencyReference(repo_url="acme/web", reference="v2.0")
+        locked = _LockedDep(resolved_ref=None)
+        assert detect_ref_change(dep, locked) is True
+
+    def test_removed_ref_is_drift(self):
+        dep = DependencyReference(repo_url="acme/web", reference=None)
+        locked = _LockedDep(resolved_ref="v1.0")
+        assert detect_ref_change(dep, locked) is True
+
+    def test_update_refs_skips_drift(self):
+        dep = DependencyReference(repo_url="acme/web", reference="v2.0")
+        locked = _LockedDep(resolved_ref="v1.0")
+        assert detect_ref_change(dep, locked, update_refs=True) is False
+
+    def test_no_locked_dep_is_first_install_not_drift(self):
+        dep = DependencyReference(repo_url="acme/web", reference="v1.0")
+        assert detect_ref_change(dep, None) is False
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# build_download_ref for registry deps
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestBuildDownloadRefRegistry:
+    def test_registry_dep_replays_locked_version(self):
+        # Manifest has ``^1.2`` (range), lockfile has ``1.5.3`` (exact).
+        # The downloader should see ``1.5.3`` so the resolver picks the
+        # exact locked version, not whatever ``^1.2`` resolves to today.
+        dep = DependencyReference(
+            repo_url="acme/web",
+            reference="^1.2",
+            source="registry",
+            registry_name="corp",
+        )
+        locked = _LockedDep(
+            source="registry",
+            version="1.5.3",
+            resolved_url="https://r/v1/.../download",
+            resolved_hash="sha256:abc",
+        )
+        lockfile = _LockfileStub({"acme/web": locked})
+        result = build_download_ref(
+            dep, lockfile, update_refs=False, ref_changed=False
+        )
+        assert result.reference == "1.5.3"
+        assert result.source == "registry"
+        # registry_name is not in the override set; preserves manifest value
+        assert result.registry_name == "corp"
+
+    def test_registry_dep_with_ref_changed_uses_manifest_range(self):
+        # The manifest range was tightened past the locked version. Drift
+        # detection returns True; build_download_ref must NOT pin to the
+        # locked version (it's now outside the range). Use the manifest.
+        dep = DependencyReference(
+            repo_url="acme/web",
+            reference="~2.0",
+            source="registry",
+            registry_name="corp",
+        )
+        locked = _LockedDep(source="registry", version="1.5.3")
+        lockfile = _LockfileStub({"acme/web": locked})
+        result = build_download_ref(
+            dep, lockfile, update_refs=False, ref_changed=True
+        )
+        assert result.reference == "~2.0"
+
+    def test_registry_dep_with_update_refs_uses_manifest_range(self):
+        # ``apm install --update`` always re-resolves from the manifest.
+        dep = DependencyReference(
+            repo_url="acme/web",
+            reference="^1.2",
+            source="registry",
+            registry_name="corp",
+        )
+        locked = _LockedDep(source="registry", version="1.5.3")
+        lockfile = _LockfileStub({"acme/web": locked})
+        result = build_download_ref(
+            dep, lockfile, update_refs=True, ref_changed=False
+        )
+        assert result.reference == "^1.2"
+
+    def test_git_dep_unchanged_uses_locked_commit(self):
+        # Sanity: existing git path is byte-identical post-Phase-8.
+        dep = DependencyReference(repo_url="acme/web", reference="v1.0")
+        locked = _LockedDep(
+            resolved_ref="v1.0", resolved_commit="abc123def4567890"
+        )
+        lockfile = _LockfileStub({"acme/web": locked})
+        result = build_download_ref(
+            dep, lockfile, update_refs=False, ref_changed=False
+        )
+        assert result.reference == "abc123def4567890"
+
+    def test_no_locked_dep_returns_dep_unchanged(self):
+        dep = DependencyReference(
+            repo_url="acme/web",
+            reference="^1.2",
+            source="registry",
+            registry_name="corp",
+        )
+        lockfile = _LockfileStub({})
+        result = build_download_ref(
+            dep, lockfile, update_refs=False, ref_changed=False
+        )
+        # No override applied — same identity, same range.
+        assert result.reference == "^1.2"
+        assert result.source == "registry"

--- a/tests/unit/test_lockfile_v2_bump.py
+++ b/tests/unit/test_lockfile_v2_bump.py
@@ -1,0 +1,247 @@
+"""Tests for the lockfile v1->v2 opportunistic bump.
+
+Covers docs/proposals/registry-api.md §6.1 (registry resolver fields:
+``resolved_url``, ``resolved_hash``) and the invariant that a project that
+never uses the registry keeps lockfile_version "1" forever (§2.1.4).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apm_cli.deps.lockfile import LockedDependency, LockFile
+from apm_cli.deps.registry.resolver import RegistryResolution
+from apm_cli.models.dependency.reference import DependencyReference
+
+
+def _git_dep(**kwargs) -> LockedDependency:
+    defaults = dict(
+        repo_url="acme/foo",
+        host="github.com",
+        resolved_commit="abc123",
+        resolved_ref="v1.0",
+    )
+    defaults.update(kwargs)
+    return LockedDependency(**defaults)
+
+
+def _registry_dep(**kwargs) -> LockedDependency:
+    defaults = dict(
+        repo_url="acme/web",
+        host="github.com",
+        source="registry",
+        version="1.2.0",
+        resolved_url=(
+            "https://reg.example.com/apm/v1/packages/acme/web/versions/1.2.0/tarball"
+        ),
+        resolved_hash="sha256:" + "a" * 64,
+    )
+    defaults.update(kwargs)
+    return LockedDependency(**defaults)
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Schema bump (invariant §2.1.4)
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestSchemaBumpOpportunistic:
+    def test_v1_stays_v1_without_registry_deps(self):
+        lock = LockFile()
+        lock.add_dependency(_git_dep())
+        yaml_out = lock.to_yaml()
+        assert "lockfile_version: '1'" in yaml_out
+
+    def test_v2_emitted_when_registry_dep_present(self):
+        lock = LockFile()
+        lock.add_dependency(_git_dep())
+        lock.add_dependency(_registry_dep())
+        yaml_out = lock.to_yaml()
+        assert "lockfile_version: '2'" in yaml_out
+
+    def test_only_local_deps_stays_v1(self):
+        lock = LockFile()
+        lock.add_dependency(
+            LockedDependency(
+                repo_url="_local/x", source="local", local_path="./local/x"
+            )
+        )
+        assert "lockfile_version: '1'" in lock.to_yaml()
+
+    def test_v2_back_to_v1_when_registry_dep_removed(self):
+        lock = LockFile()
+        lock.add_dependency(_registry_dep())
+        assert "lockfile_version: '2'" in lock.to_yaml()
+        # Remove the registry dep; lockfile re-emits as v1.
+        del lock.dependencies["acme/web"]
+        lock.add_dependency(_git_dep())
+        assert "lockfile_version: '1'" in lock.to_yaml()
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Field round-trip
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestRegistryFieldsRoundTrip:
+    def test_resolved_url_and_hash_emitted(self):
+        lock = LockFile()
+        lock.add_dependency(_registry_dep())
+        yaml_out = lock.to_yaml()
+        assert "resolved_url" in yaml_out
+        assert "resolved_hash" in yaml_out
+
+    def test_resolved_url_and_hash_omitted_for_git_deps(self):
+        lock = LockFile()
+        lock.add_dependency(_git_dep())
+        yaml_out = lock.to_yaml()
+        assert "resolved_url" not in yaml_out
+        assert "resolved_hash" not in yaml_out
+
+    def test_round_trip_preserves_registry_fields(self):
+        lock = LockFile()
+        lock.add_dependency(_registry_dep())
+        out = LockFile.from_yaml(lock.to_yaml())
+        reg = out.get_dependency("acme/web")
+        assert reg.source == "registry"
+        assert reg.resolved_url.endswith("/tarball")
+        assert reg.resolved_hash.startswith("sha256:")
+        assert reg.version == "1.2.0"
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# v1 lockfile compatibility (§2.1.4 read invariant)
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestV1ReadCompat:
+    def test_v1_lockfile_parses_without_migration(self):
+        v1_yaml = (
+            "lockfile_version: '1'\n"
+            "generated_at: 2026-01-01T00:00:00Z\n"
+            "dependencies:\n"
+            "- repo_url: acme/old\n"
+            "  resolved_commit: abc123\n"
+            "  resolved_ref: v1.0\n"
+            "  host: github.com\n"
+        )
+        lock = LockFile.from_yaml(v1_yaml)
+        old = lock.get_dependency("acme/old")
+        assert old.resolved_url is None
+        assert old.resolved_hash is None
+        assert old.source is None
+
+    def test_v1_lockfile_reemits_as_v1(self):
+        v1_yaml = (
+            "lockfile_version: '1'\n"
+            "generated_at: 2026-01-01T00:00:00Z\n"
+            "dependencies:\n"
+            "- repo_url: acme/old\n"
+            "  resolved_commit: abc123\n"
+            "  host: github.com\n"
+        )
+        lock = LockFile.from_yaml(v1_yaml)
+        out = lock.to_yaml()
+        assert "lockfile_version: '1'" in out
+
+    def test_v2_lockfile_with_registry_field_parses(self):
+        v2_yaml = (
+            "lockfile_version: '2'\n"
+            "generated_at: 2026-01-01T00:00:00Z\n"
+            "dependencies:\n"
+            "- repo_url: acme/web\n"
+            "  source: registry\n"
+            "  version: 1.2.0\n"
+            "  resolved_url: https://r/tarball\n"
+            "  resolved_hash: sha256:abc\n"
+            "  host: github.com\n"
+        )
+        lock = LockFile.from_yaml(v2_yaml)
+        reg = lock.get_dependency("acme/web")
+        assert reg.source == "registry"
+        assert reg.resolved_url == "https://r/tarball"
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# from_dependency_ref + RegistryResolution
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestFromDependencyRefWithResolution:
+    def test_registry_resolution_populates_fields(self):
+        dep = DependencyReference(
+            repo_url="acme/x",
+            reference="^1.0",
+            source="registry",
+            registry_name="corp",
+        )
+        resolution = RegistryResolution(
+            resolved_url="https://r/v1/packages/acme/x/versions/1.5.0/tarball",
+            resolved_hash="sha256:def",
+            version="1.5.0",
+        )
+        locked = LockedDependency.from_dependency_ref(
+            dep,
+            resolved_commit=None,
+            depth=1,
+            resolved_by=None,
+            registry_resolution=resolution,
+        )
+        assert locked.source == "registry"
+        assert locked.resolved_url == resolution.resolved_url
+        assert locked.resolved_hash == "sha256:def"
+        assert locked.version == "1.5.0"
+
+    def test_no_resolution_means_no_registry_fields(self):
+        # Existing git-resolver call site (no registry_resolution arg)
+        # produces a lockfile entry with source=None and no registry fields.
+        dep = DependencyReference(repo_url="acme/x", reference="v1.0")
+        locked = LockedDependency.from_dependency_ref(
+            dep, resolved_commit="abc", depth=1, resolved_by=None
+        )
+        assert locked.source is None
+        assert locked.resolved_url is None
+        assert locked.resolved_hash is None
+
+    def test_local_dep_unchanged(self):
+        dep = DependencyReference(
+            repo_url="_local/pkg", is_local=True, local_path="./pkg"
+        )
+        locked = LockedDependency.from_dependency_ref(
+            dep, resolved_commit=None, depth=1, resolved_by=None
+        )
+        assert locked.source == "local"
+        assert locked.local_path == "./pkg"
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# to_dependency_ref restores source field
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestToDependencyRefRestoresSource:
+    def test_registry_source_restored(self):
+        locked = _registry_dep()
+        ref = locked.to_dependency_ref()
+        assert ref.source == "registry"
+
+    def test_registry_uses_locked_version_not_range(self):
+        # If a registry dep was originally pinned with ``^1.2`` and resolved
+        # to 1.5.3, the lockfile records 1.5.3 in `version`. to_dependency_ref
+        # must surface the exact version so re-installs are reproducible.
+        locked = _registry_dep(version="1.5.3", resolved_ref="^1.2")
+        ref = locked.to_dependency_ref()
+        assert ref.reference == "1.5.3"
+
+    def test_git_source_restored_as_none(self):
+        locked = _git_dep()
+        ref = locked.to_dependency_ref()
+        assert ref.source is None
+
+    def test_local_source_restored(self):
+        locked = LockedDependency(
+            repo_url="_local/x", source="local", local_path="./x"
+        )
+        ref = locked.to_dependency_ref()
+        assert ref.source == "local"
+        assert ref.is_local

--- a/tests/unit/test_reference_registry_shorthand.py
+++ b/tests/unit/test_reference_registry_shorthand.py
@@ -1,0 +1,176 @@
+"""Tests for the ``owner/repo@<name>#<semver>`` registry-scope shorthand.
+
+Covers the parser change in ``DependencyReference.parse`` per
+docs/proposals/registry-api.md §3.2/§3.3:
+
+- Routes a string-shorthand entry to a named registry when it carries the
+  ``@<name>`` scope suffix.
+- Rejects branch names and commit SHAs at parse time when the entry routes
+  to a registry (parse-time gate, not install-time).
+- Does NOT change the meaning of any existing shorthand: ``acme/foo#v1.0``,
+  ``git@host:...``, ``https://...`` all parse byte-identically.
+- Does NOT collide with the marketplace ``code-review@plugins`` shape (no
+  ``/`` on the LHS).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apm_cli.models.dependency.reference import DependencyReference
+
+
+class TestRegistryScopeRouting:
+    """Strings of the form ``owner/repo@<name>#<semver>`` route to a registry."""
+
+    def test_basic_caret_range(self):
+        d = DependencyReference.parse("acme/foo@corp-main#^1.2")
+        assert d.repo_url == "acme/foo"
+        assert d.reference == "^1.2"
+        assert d.source == "registry"
+        assert d.registry_name == "corp-main"
+
+    def test_exact_version(self):
+        d = DependencyReference.parse("acme/foo@corp-other#1.2.3")
+        assert d.source == "registry"
+        assert d.registry_name == "corp-other"
+        assert d.reference == "1.2.3"
+
+    def test_x_range(self):
+        d = DependencyReference.parse("acme/foo@corp-main#1.x")
+        assert d.source == "registry"
+        assert d.reference == "1.x"
+
+    def test_tilde_range(self):
+        d = DependencyReference.parse("acme/foo@corp-main#~1.2.3")
+        assert d.reference == "~1.2.3"
+
+    def test_dotted_registry_name(self):
+        d = DependencyReference.parse("acme/foo@corp.main#1.0.0")
+        assert d.registry_name == "corp.main"
+
+    def test_underscore_registry_name(self):
+        # Hyphens, dots, underscores — all valid in registry names.
+        d = DependencyReference.parse("acme/foo@corp_main#1.0.0")
+        assert d.registry_name == "corp_main"
+
+    def test_extended_repo_path(self):
+        # Non-default-host shorthand: ``host/owner/repo@<name>#<semver>`` —
+        # the LHS regex captures multi-segment paths.
+        d = DependencyReference.parse("gitlab.com/owner/repo@corp-main#1.0.0")
+        assert d.source == "registry"
+        assert d.registry_name == "corp-main"
+        # repo_url after normalization is ``owner/repo`` (host extracted).
+        assert d.repo_url == "owner/repo"
+
+
+class TestSemverEnforcement:
+    """Parse-time semver validation per design §3.3."""
+
+    def test_branch_name_rejected(self):
+        with pytest.raises(ValueError, match="not a semver"):
+            DependencyReference.parse("acme/foo@corp-main#main")
+
+    def test_develop_branch_rejected(self):
+        with pytest.raises(ValueError, match="not a semver"):
+            DependencyReference.parse("acme/foo@corp-main#develop")
+
+    def test_commit_sha_rejected(self):
+        with pytest.raises(ValueError, match="not a semver"):
+            DependencyReference.parse("acme/foo@corp-main#abc123d")
+
+    def test_long_commit_sha_rejected(self):
+        with pytest.raises(ValueError, match="not a semver"):
+            DependencyReference.parse(
+                "acme/foo@corp-main#abc1234567890def1234567890abcdef12345678"
+            )
+
+    def test_latest_rejected(self):
+        with pytest.raises(ValueError, match="not a semver"):
+            DependencyReference.parse("acme/foo@corp-main#latest")
+
+    def test_missing_version_rejected(self):
+        with pytest.raises(ValueError, match="missing a version"):
+            DependencyReference.parse("acme/foo@corp-main")
+
+    def test_error_message_suggests_git_alternative(self):
+        with pytest.raises(ValueError) as excinfo:
+            DependencyReference.parse("acme/foo@corp-main#main")
+        msg = str(excinfo.value)
+        assert "- git:" in msg
+        assert "semver" in msg.lower()
+
+
+class TestNoCollisionsWithExistingShapes:
+    """The new rule must NOT change any existing parse outcome."""
+
+    def test_plain_shorthand_unchanged(self):
+        d = DependencyReference.parse("acme/foo#v1.0")
+        assert d.source is None
+        assert d.registry_name is None
+        assert d.reference == "v1.0"
+        assert d.repo_url == "acme/foo"
+
+    def test_shorthand_with_branch_ref_still_works(self):
+        # When NOT routed to a registry, branch refs remain valid (Git is
+        # ref-opaque). This is invariant §2.1.3.
+        d = DependencyReference.parse("acme/foo#main")
+        assert d.source is None
+        assert d.reference == "main"
+
+    def test_ssh_url_unchanged(self):
+        d = DependencyReference.parse("git@github.com:owner/repo.git")
+        assert d.source is None
+        assert d.registry_name is None
+
+    def test_ssh_url_with_alias_unchanged(self):
+        # ``#ref@alias`` shape — alias comes after ``#``, must not be
+        # interpreted as a registry name.
+        d = DependencyReference.parse("git@github.com:owner/repo.git#main@my-alias")
+        assert d.source is None
+        assert d.alias == "my-alias"
+
+    def test_https_url_unchanged(self):
+        d = DependencyReference.parse("https://github.com/owner/repo")
+        assert d.source is None
+
+    def test_https_url_with_basic_auth_unchanged(self):
+        # User:password@host inside an HTTPS URL must not trigger registry
+        # scope (the ``://`` guard catches this).
+        # Note: actual parse may or may not accept this — what we're asserting
+        # is that the registry-scope detector does NOT fire.
+        try:
+            d = DependencyReference.parse("https://user:pass@host.com/owner/repo")
+            assert d.source is None
+        except ValueError:
+            pass  # parser may reject for unrelated reasons; that's fine.
+
+    def test_marketplace_shape_falls_through(self):
+        # ``review-skills@plugins`` has no ``/`` on the LHS — it does NOT
+        # route to a registry. The registry detector returns None and the
+        # existing parse logic raises (since 'review-skills' isn't a valid
+        # owner/repo on its own). What matters: the error is the existing
+        # one, not the new "missing version" one.
+        with pytest.raises(ValueError) as excinfo:
+            DependencyReference.parse("review-skills@plugins")
+        assert "missing a version" not in str(excinfo.value)
+
+    def test_local_path_unchanged(self):
+        d = DependencyReference.parse("./local/pkg")
+        assert d.is_local
+        assert d.source is None
+
+
+class TestRegistryFieldsRoundTrip:
+    """The parser sets ``source`` + ``registry_name`` consistently with the
+    object-form path (Phase 4 will add a parallel parser for object form)."""
+
+    def test_unique_key_includes_repo_url(self):
+        d = DependencyReference.parse("acme/foo@corp-main#1.0.0")
+        assert d.get_unique_key() == "acme/foo"
+
+    def test_identity_unchanged_by_registry_scope(self):
+        # The registry routing is metadata, not part of the package identity.
+        d_git = DependencyReference.parse("acme/foo#1.0.0")
+        d_reg = DependencyReference.parse("acme/foo@corp-main#1.0.0")
+        assert d_git.get_identity() == d_reg.get_identity() == "acme/foo"

--- a/tests/unit/test_reference_registry_shorthand.py
+++ b/tests/unit/test_reference_registry_shorthand.py
@@ -161,6 +161,153 @@ class TestNoCollisionsWithExistingShapes:
         assert d.source is None
 
 
+class TestObjectFormRegistry:
+    """Object-form ``- registry: <name>`` entry per design §3.2.
+
+    Used for virtual packages — the four fields (id, registry, path, version)
+    don't compose cleanly in shorthand.
+    """
+
+    def test_happy_path(self):
+        d = DependencyReference.parse_from_dict(
+            {
+                "registry": "corp-main",
+                "id": "acme/prompt-pack",
+                "path": "prompts/review.prompt.md",
+                "version": "1.4.0",
+            }
+        )
+        assert d.repo_url == "acme/prompt-pack"
+        assert d.virtual_path == "prompts/review.prompt.md"
+        assert d.is_virtual is True
+        assert d.reference == "1.4.0"
+        assert d.source == "registry"
+        assert d.registry_name == "corp-main"
+
+    def test_with_alias(self):
+        d = DependencyReference.parse_from_dict(
+            {
+                "registry": "corp",
+                "id": "a/b",
+                "path": "x.prompt.md",
+                "version": "^1.0",
+                "alias": "my-x",
+            }
+        )
+        assert d.alias == "my-x"
+
+    def test_caret_range(self):
+        d = DependencyReference.parse_from_dict(
+            {"registry": "corp", "id": "a/b", "path": "x.prompt.md", "version": "^1.2"}
+        )
+        assert d.reference == "^1.2"
+
+    @pytest.mark.parametrize(
+        "missing_key",
+        ["registry", "id", "path", "version"],
+    )
+    def test_missing_required_field_rejected(self, missing_key):
+        full = {
+            "registry": "corp",
+            "id": "a/b",
+            "path": "x.prompt.md",
+            "version": "1.0.0",
+        }
+        full.pop(missing_key)
+        with pytest.raises(ValueError):
+            DependencyReference.parse_from_dict(full)
+
+    def test_mixing_registry_and_git_rejected(self):
+        with pytest.raises(ValueError, match="cannot mix"):
+            DependencyReference.parse_from_dict(
+                {
+                    "registry": "corp",
+                    "git": "https://github.com/a/b.git",
+                    "id": "a/b",
+                    "path": "x.prompt.md",
+                    "version": "1.0.0",
+                }
+            )
+
+    def test_invalid_id_shape_rejected(self):
+        with pytest.raises(ValueError, match="owner/repo"):
+            DependencyReference.parse_from_dict(
+                {"registry": "corp", "id": "noseparator", "path": "x", "version": "1.0.0"}
+            )
+
+    def test_branch_version_rejected(self):
+        with pytest.raises(ValueError, match="not a semver"):
+            DependencyReference.parse_from_dict(
+                {"registry": "corp", "id": "a/b", "path": "p", "version": "main"}
+            )
+
+    def test_commit_sha_version_rejected(self):
+        with pytest.raises(ValueError, match="not a semver"):
+            DependencyReference.parse_from_dict(
+                {"registry": "corp", "id": "a/b", "path": "p", "version": "abc123d"}
+            )
+
+    def test_unknown_field_rejected(self):
+        with pytest.raises(ValueError, match="unknown fields"):
+            DependencyReference.parse_from_dict(
+                {
+                    "registry": "corp",
+                    "id": "a/b",
+                    "path": "p",
+                    "version": "1.0.0",
+                    "typo": "oops",
+                }
+            )
+
+    def test_path_traversal_rejected(self):
+        with pytest.raises(ValueError):
+            DependencyReference.parse_from_dict(
+                {
+                    "registry": "corp",
+                    "id": "a/b",
+                    "path": "../escape",
+                    "version": "1.0.0",
+                }
+            )
+
+    def test_invalid_alias_rejected(self):
+        with pytest.raises(ValueError, match="Invalid alias"):
+            DependencyReference.parse_from_dict(
+                {
+                    "registry": "corp",
+                    "id": "a/b",
+                    "path": "p",
+                    "version": "1.0.0",
+                    "alias": "bad alias!",
+                }
+            )
+
+    def test_empty_strings_rejected(self):
+        for field in ("registry", "id", "path", "version"):
+            entry = {
+                "registry": "corp",
+                "id": "a/b",
+                "path": "x.prompt.md",
+                "version": "1.0.0",
+            }
+            entry[field] = "   "
+            with pytest.raises(ValueError):
+                DependencyReference.parse_from_dict(entry)
+
+    def test_existing_git_object_form_unchanged(self):
+        # Sanity check: this PR must not change existing object-form git parsing.
+        d = DependencyReference.parse_from_dict(
+            {"git": "https://github.com/owner/repo.git", "ref": "v1.0"}
+        )
+        assert d.source is None
+        assert d.registry_name is None
+
+    def test_existing_local_object_form_unchanged(self):
+        d = DependencyReference.parse_from_dict({"path": "./local/pkg"})
+        assert d.is_local
+        assert d.source is None
+
+
 class TestRegistryFieldsRoundTrip:
     """The parser sets ``source`` + ``registry_name`` consistently with the
     object-form path (Phase 4 will add a parallel parser for object form)."""

--- a/tests/unit/test_reference_registry_shorthand.py
+++ b/tests/unit/test_reference_registry_shorthand.py
@@ -294,12 +294,15 @@ class TestObjectFormRegistry:
             with pytest.raises(ValueError):
                 DependencyReference.parse_from_dict(entry)
 
-    def test_existing_git_object_form_unchanged(self):
-        # Sanity check: this PR must not change existing object-form git parsing.
+    def test_existing_git_object_form_marks_source_git(self):
+        # Object-form ``- git:`` now explicitly sets source="git" so the
+        # default-registry routing pass leaves it alone. Per design,
+        # source=None and source="git" are equivalent (legacy default), so
+        # this is observable but functionally compatible.
         d = DependencyReference.parse_from_dict(
             {"git": "https://github.com/owner/repo.git", "ref": "v1.0"}
         )
-        assert d.source is None
+        assert d.source == "git"
         assert d.registry_name is None
 
     def test_existing_local_object_form_unchanged(self):


### PR DESCRIPTION
## Summary

- Adds a REST-based **registry resolver** alongside the existing Git resolver — opt-in via a new top-level `registries:` block in `apm.yml`. Backwards-compatible: a project without the block sees zero behavior change.
- Implements the full install path (parse → resolve → fetch → sha256 verify → extract → lockfile) against a 4-endpoint HTTP contract: `GET /versions`, `GET /download`, `PUT /version`, `GET /search`.
- Supports both `tar.gz` (APM's `apm pack` output) and `zip` (Anthropic skills format) on the wire — endpoint named `/download` (not `/tarball`) so the URL grammar doesn't lock the format.

## What's in this PR

| Area | Change |
|---|---|
| **New package** | `deps/registry/` — HTTP client, sha256 extractor (tar+zip), npm-style semver matcher, env-var auth, resolver |
| **Parser** | `owner/repo@<name>#<semver>` shorthand + object-form `- registry:` for virtual packages, parse-time strict semver gate |
| **apm.yml** | Top-level `registries:` block with optional `default:`; auto-routes shorthand entries through the default registry |
| **Lockfile** | Opportunistic v1→v2 bump; new `resolved_url`, `resolved_hash` fields. v1 stays v1 forever for git-only projects (invariant §2.1.4) |
| **Drift** | Source-aware: range-vs-locked-version comparison for registry deps; source-flip drift |
| **Install pipeline** | `RegistryPackageResolver` wired into `phases/resolve.py` and `sources.py`. Lockfile re-installs auth via URL-prefix lookup |
| **Marketplace** | New `registry: <name>` field on plugin entries + `search_all_registries()` helper |
| **Docs** | 3 proposal docs (design, summary, full HTTP API spec for server implementers) |

## Honest sizing

- **~2,000 production LoC** across 5 new + 11 modified source files
- **~3,300 test LoC** across 14 new test files (1,072 tests, all passing)
- **~1,300 lines of docs**

Pre-flight estimate (proposal §10) was ~25% optimistic on production LoC and ~30% off on file count. The original §10 table is preserved with a "Lessons learned" callout pointing to the corrected counts.

## Out of scope (deferred)

- `apm publish` command — operators publish via `curl` for now; spec is documented in [registry-http-api.md §3.3](docs/proposals/registry-http-api.md#33-put-v1packagesownerrepoversionsversion--publish)
- CLI-level `apm marketplace search` registry merge — public helper `search_all_registries()` is in place
- Pre-release semver, yank, signing — all v2

## Test plan

- [x] All 1,072 registry-related unit tests pass
- [x] End-to-end test against real `http.server.HTTPServer` for both `tar.gz` and `zip` archives
- [x] Backwards-compat matrix (`tests/unit/registry/test_compat_matrix.py`) covers each §2.1 invariant
- [x] No regression in baseline tests (only one pre-existing unrelated failure on `main`)
- [ ] Reviewer: run `pytest tests/unit/registry/ tests/unit/test_lockfile_v2_bump.py tests/unit/test_apm_yml_registries.py tests/unit/test_reference_registry_shorthand.py tests/unit/test_drift_registry.py tests/unit/install/test_resolve_registry.py tests/unit/marketplace/test_registry_integration.py`
- [ ] Reviewer: read [`docs/proposals/registry-http-api.md`](docs/proposals/registry-http-api.md) (~500 lines) to confirm the wire contract is implementable
- [ ] Reviewer: confirm a project without `registries:` block has zero behavior change (clone any existing APM project, run `apm install`, expect identical output)

## Commit history (13 commits, intentionally unsquashed)