### PR TITLE
fix(ci): deploy docs after bot-cut releases via workflow_call

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -627,6 +627,24 @@ jobs:
             ./dist/apm-windows-x86_64.zip
             ./dist/apm-windows-x86_64.zip.sha256
 
+  # Deploy the docs site after the release is published.
+  # Invoked here (rather than via the docs workflow's `release: published`
+  # trigger) because release events created by GITHUB_TOKEN do not fire
+  # downstream workflow runs -- a documented Actions safeguard against
+  # recursion. Calling docs.yml directly preserves the standard release ->
+  # docs deploy chain without needing a PAT or GitHub App token.
+  deploy-docs:
+    name: Deploy Docs
+    needs: [create-release]
+    if: github.ref_type == 'tag' && needs.create-release.outputs.is_prerelease != 'true'
+    uses: ./.github/workflows/docs.yml
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    with:
+      is_prerelease: false
+
   # GH-AW Compatibility — validates the released binary works in the
   # exact flow GitHub Agentic Workflows uses (isolated install + pack, no token).
   # Informational: runs as continue-on-error because it depends on external services

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,8 +3,19 @@ name: Deploy Docs
 on:
   # Deploy docs only when a new APM version is released, so the published
   # site always matches the latest released binary (see microsoft/apm#641).
-  # PR runs build (no deploy) to catch breakage before merge. Manual
-  # workflow_dispatch is supported for re-publishing the current docs.
+  # Primary entrypoint is workflow_call from the CI/CD Pipeline release job
+  # (release: published does not fire when the release is created by
+  # GITHUB_TOKEN -- a documented Actions safeguard against recursion).
+  # The release: published trigger is kept as a safety net for human-cut
+  # releases. PR runs build (no deploy) to catch breakage before merge.
+  # Manual workflow_dispatch is supported for re-publishing the current docs.
+  workflow_call:
+    inputs:
+      is_prerelease:
+        description: 'Skip deploy when true (build-only). Defaults to false (deploy).'
+        required: false
+        type: boolean
+        default: false
   release:
     types: [published]
   pull_request:
@@ -45,7 +56,8 @@ jobs:
       - name: Upload build artifacts
         if: |
           github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'release' && github.event.release.prerelease == false)
+          (github.event_name == 'release' && github.event.release.prerelease == false) ||
+          (github.event_name == 'workflow_call' && inputs.is_prerelease == false)
         uses: actions/upload-pages-artifact@v3
         with:
           path: docs/dist
@@ -56,7 +68,8 @@ jobs:
     # so prerelease tags (vX.Y.Z-rc1, etc.) don't clobber published docs.
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'release' && github.event.release.prerelease == false)
+      (github.event_name == 'release' && github.event.release.prerelease == false) ||
+      (github.event_name == 'workflow_call' && inputs.is_prerelease == false)
     runs-on: ubuntu-latest
     permissions:
       pages: write


### PR DESCRIPTION
## TL;DR

The `Deploy Docs` workflow listens for `release: published`, but that event **never fires** when the release is created by `GITHUB_TOKEN` — a documented Actions safeguard against recursion. The CI/CD Pipeline cuts releases as `github-actions[bot]`, so docs haven't auto-deployed since v0.9.3 (and won't going forward). This PR fixes it by converting `docs.yml` into a reusable workflow and invoking it directly from the release job.

## Problem (WHY)

- `v0.9.3` published at `2026-04-26T12:04:31Z` ([release](https://github.com/microsoft/apm/releases/tag/v0.9.3))
- API check: `repos/microsoft/apm/actions/runs?event=release` returns **0 runs** in the last 30 days, across the entire repo
- Last actual `Deploy Docs` deploy was a manual `workflow_dispatch` on **2026-04-23** (3 days before v0.9.3)
- Root cause: release was authored by `github-actions[bot]` (confirmed via API). [GitHub Actions documents](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow): _"events triggered by the GITHUB_TOKEN [...] will not create a new workflow run"_

So the published site at https://microsoft.github.io/apm still serves pre-0.9.3 content despite a successful release.

## Approach (WHAT)

Convert `docs.yml` into a **reusable workflow** (`workflow_call`) and have the CI/CD Pipeline's `create-release` job invoke it directly via a new `deploy-docs` job. No new credentials; no event-loss risk.

### Why this over the alternatives

| Approach | New creds? | Coupling | Failure modes |
|---|---|---|---|
| **`workflow_call` from release job** (this PR) | None | Explicit, intentional | Direct invocation — no event-loss risk |
| `workflow_run` event chain | None | Implicit, name-based ("CI/CD Pipeline") | Always runs the default-branch workflow file (cut-at-tag pinning gotcha); fires on every CI/CD completion → must filter conclusion + branch + detect "was a release cut" |
| Fine-grained PAT in release step | PAT secret | Loose (release event) | Tied to a user; expires (max 1y); Microsoft PAT policies still apply; rotation burden |
| GitHub App token | App install | Loose (release event) | App install on a Microsoft-org repo requires security review |
| Fold docs into CI/CD Pipeline | None | Maximally tight | Loses PR-time docs build; can't deploy docs without re-running CI |

The `workflow_call` approach is the right level of coupling for this case: the docs site is part of the release artifact, not an independent observer, so the release pipeline declaring "publishing a release includes deploying its docs" is correct domain modeling.

## Implementation (HOW)

**`docs.yml`** — add `workflow_call` trigger with an `is_prerelease` input, extend the existing gating conditions on `build` and `deploy` jobs to honor it. Keep `release: published`, `pull_request`, and `workflow_dispatch` triggers as-is for backward compatibility (human-cut releases, PR builds, manual re-publish all continue to work).

**`build-release.yml`** — add a `deploy-docs` job that `needs: [create-release]`, gated to stable tags only (`is_prerelease != 'true'`), and `uses: ./.github/workflows/docs.yml` with `is_prerelease: false`. Job declares its own `permissions:` (`contents: read`, `pages: write`, `id-token: write`) — these bound what the called workflow can request.

```yaml
deploy-docs:
  name: Deploy Docs
  needs: [create-release]
  if: github.ref_type == 'tag' && needs.create-release.outputs.is_prerelease != 'true'
  uses: ./.github/workflows/docs.yml
  permissions:
    contents: read
    pages: write
    id-token: write
  with:
    is_prerelease: false
```

### Trade-offs

- **Trades event-driven loose coupling for explicit pipeline composition.** For a single repo where the release pipeline owns end-to-end shipping (artifacts + docs + downstream packages), composition is the right call. If APM later grows to N independent post-release consumers maintained by different teams, revisit (App-token + `release: published` becomes more attractive at that scale).
- **`release: published` trigger retained.** Slightly more surface area in the trigger list, but it's a safety net — human-cut releases (rare but possible) still deploy docs without further work.

## Validation evidence

- `actionlint` clean for the changes (only pre-existing SC2086 shellcheck infos elsewhere in `build-release.yml`)
- YAML loads cleanly via `yaml.safe_load`; both jobs lists parse as expected:
  - `docs.yml` jobs: `build`, `deploy`
  - `build-release.yml` jobs: `..., create-release, deploy-docs, gh-aw-compat, ...`
- ASCII-only (verified: 0 non-ASCII bytes added in `docs.yml`)
- All existing trigger paths preserved (PR-time build, manual `workflow_dispatch`, human-cut `release: published`)

## How to test

1. **Backfill v0.9.3**: trigger `Deploy Docs` via `workflow_dispatch` on `main` to republish the v0.9.3 docs site immediately (no merge needed).
2. **End-to-end on next release**: cut the next tag (`v0.9.4` or later); confirm a `Deploy Docs` job now appears as a child of the `CI/CD Pipeline` run, and https://microsoft.github.io/apm reflects the new version within minutes.
3. **PR build still works**: this PR itself should trigger a `Deploy Docs` build-only run if it touches `docs/**` (it doesn't, so no run expected — matches current behavior).
4. **Prerelease gating**: cut any prerelease tag (`vX.Y.Z-rc1`); confirm `deploy-docs` job is skipped (`if:` evaluates false).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
