### PR TITLE
fix(templates): use canonical taxonomy labels in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: '[BUG] '
-labels: bug, needs-triage
+labels: type/bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: '[FEATURE] '
-labels: enhancement, needs-triage
+labels: type/feature
 assignees: ''
 
 ---


### PR DESCRIPTION
## TL;DR

Drop the deprecated labels pre-applied by issue templates and switch to the canonical APM taxonomy. Net effect for end users: opening a Bug or Feature template no longer applies orphaned/wrong labels; the daily Triage Panel sweep handles classification from there.

## Problem (WHY)

Both issue templates pre-applied labels that were both **deprecated** and **wrong for the current automation**:

- `needs-triage` is deprecated (slated for removal in 0.10.0) and does NOT trigger the Triage Panel fast-path — the workflow only fires on `status/needs-triage`. Triaged issues ended up carrying both `needs-triage` and `status/triaged` because the panel never removes the legacy label.
- `bug` and `enhancement` are also deprecated; the canonical types in the panel's `add-labels` allow-list are `type/bug` and `type/feature`.

Templates are the most-used path to file an issue, so this drift was producing inconsistent label state on most new issues.

## Approach (WHAT)

| Template | Before | After |
|---|---|---|
| `bug_report.md` | `bug, needs-triage` | `type/bug` |
| `feature_request.md` | `enhancement, needs-triage` | `type/feature` |

`needs-triage` is dropped entirely — new issues are picked up by the daily Triage Panel sweep, which is the design we explicitly shipped in #954 (cost-bounded, exploit-resistant). Maintainers who want immediate triage on a specific issue still have the one-click fast-path: apply `status/needs-triage` manually.

## Implementation (HOW)

Two-line frontmatter edits in `.github/ISSUE_TEMPLATE/{bug_report,feature_request}.md`. No workflow or skill changes.

## Trade-offs

- **No more `needs-triage` auto-apply.** New issues sit unlabeled (beyond `type/*`) for up to ~24h until the daily sweep. Acceptable given the architecture decision in #954 — auto-fast-path on every new issue reintroduces the unbounded-cost / open-close exploit surface.
- **Existing 20 open issues still carry the legacy `needs-triage` label.** Out of scope for this PR; they'll either be cleaned up when 0.10.0 removes the deprecated label, or via a one-shot manual sweep.

## Validation

- `git diff` confirms only frontmatter `labels:` lines changed; template body untouched.
- Verified `type/bug` and `type/feature` are in the live `add-labels.allowed` list at `.github/workflows/triage-panel.md` (so the panel respects user-applied type labels rather than dropping them).

## How to test

1. After merge, click "New issue" in the GitHub UI and pick "Bug report" — confirm only `type/bug` is pre-applied.
2. Same for "Feature request" — confirm only `type/feature`.
3. Wait for the next daily sweep (or apply `status/needs-triage` for the fast-path) and confirm the panel applies the rest of the taxonomy plus `status/triaged`.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
