### PR TITLE
docs(python-architect): document mermaid classDiagram :::cssClass GitHub-render trap

### DIFF
--- a/.apm/agents/python-architect.agent.md
+++ b/.apm/agents/python-architect.agent.md
@@ -143,6 +143,16 @@ classDiagram
 Read the PR's diff and surrounding code, then draw the actual
 problem-space classes.)
 
+**Mermaid `classDiagram` GitHub-render gotcha**: the `:::cssClass`
+shorthand is ONLY valid as a standalone `class Name:::cssClass`
+declaration (or inside a `class Name:::cssClass { ... }` block).
+GitHub's mermaid parser rejects `:::cssClass` appended to a
+relationship line (`A *-- B:::touched`) with `Expecting 'NEWLINE',
+'EOF', 'LABEL', got 'STYLE_SEPARATOR'`. Always declare the styled
+classes on their own lines BEFORE the `classDef` block. This trap
+does not apply to `flowchart` diagrams, where the inline form is
+valid.
+
 If the PR is purely procedural (no class changes anywhere in scope),
 state that explicitly and substitute a `classDiagram` showing the
 module boundaries and the function entry points -- still annotated

--- a/.github/agents/python-architect.agent.md
+++ b/.github/agents/python-architect.agent.md
@@ -143,6 +143,16 @@ classDiagram
 Read the PR's diff and surrounding code, then draw the actual
 problem-space classes.)
 
+**Mermaid `classDiagram` GitHub-render gotcha**: the `:::cssClass`
+shorthand is ONLY valid as a standalone `class Name:::cssClass`
+declaration (or inside a `class Name:::cssClass { ... }` block).
+GitHub's mermaid parser rejects `:::cssClass` appended to a
+relationship line (`A *-- B:::touched`) with `Expecting 'NEWLINE',
+'EOF', 'LABEL', got 'STYLE_SEPARATOR'`. Always declare the styled
+classes on their own lines BEFORE the `classDef` block. This trap
+does not apply to `flowchart` diagrams, where the inline form is
+valid.
+
 If the PR is purely procedural (no class changes anywhere in scope),
 state that explicitly and substitute a `classDiagram` showing the
 module boundaries and the function entry points -- still annotated

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -41,7 +41,7 @@ local_deployed_file_hashes:
   .github/agents/doc-analyser.agent.md: sha256:47b1d0204904b786c19d4fe84343e86cdab6f92f862f676ba741ffe6e1385679
   .github/agents/doc-writer.agent.md: sha256:328a5b9ea079869b8ccd914a6e2135c204225a5eedb42f59a1ec73058f7f0b47
   .github/agents/oss-growth-hacker.agent.md: sha256:8d18f5be46913c40ad3aa66fb984575a88988cfac402d39353cdfb09f7e582c5
-  .github/agents/python-architect.agent.md: sha256:32ed3390cb0e41fea28b3fd95b00124cd097ea0db51f992d2349e6837742723c
+  .github/agents/python-architect.agent.md: sha256:a70b1be6cd877a85414a65a1db8117be7dbecc3865d98045f46ed14462fda099
   .github/agents/supply-chain-security-expert.agent.md: sha256:9a4e731b12e7658f71d54c22e90f80ce0c45e3eacbb069b8505ed96ec9e79ba5
   .github/instructions/changelog.instructions.md: sha256:1e51ec4c74e847967962bd279dc4c6e582c5d3578490b3c28d5f3acd3e05f73e
   .github/instructions/cicd.instructions.md: sha256:9c0fafc74f743aa97e5adba2168d66c9e3a327b135065e3b804bdbb5f04cda5d


### PR DESCRIPTION
## Why

While running the apm-review-panel skill on Epic #898, the Python Architect's "After" class diagram failed to render on GitHub with:

```
Parse error on line 50: ...*-- LockedDependency:::touched
Expecting 'NEWLINE', 'EOF', 'LABEL', got 'STYLE_SEPARATOR'
```

The cause: GitHub's mermaid parser only accepts the `:::cssClass` shorthand as a **standalone** `class Name:::cssClass` declaration in `classDiagram`. Appending it after a relationship arrow (`A *-- B:::touched`) parses fine in flowchart but not in classDiagram. The persona's existing example was already correct, but the rule was implicit -- the next reviewer drifted from it and silently shipped a broken diagram.

Verdict comment that hit the trap: https://github.com/microsoft/apm/issues/898#issuecomment-4315966500 (since patched to standalone form).

## What

Adds one explicit Gotcha block under the OO / class diagram section. No code changes, no behavior changes -- this is persona-contract documentation that protects every future panel review's mermaid output.

## Files

- `.apm/agents/python-architect.agent.md` -- the authored source
- `.github/agents/python-architect.agent.md` -- regenerated via `apm install --target copilot` per repo convention
- `apm.lock.yaml` -- hash bump for the regenerated mirror

## Test

The block reads as plain documentation; no executable contract changes. Verified by re-rendering the patched Epic #898 diagram on GitHub (now renders correctly with standalone `class X:::touched` declarations).

Independent of and orthogonal to PR #897 (visual-communicator persona).