### PR TITLE
fix(triage-panel): dispatch project-sync per themed issue

### DIFF
--- a/.github/workflows/triage-panel.lock.yml
+++ b/.github/workflows/triage-panel.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"58cf861a6fb353acdf2c9a7a3e26d177ea0027877fde9e7e2cb05027164ae38e","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"1477b4d463ca800dfc0e5e0dee19d03097a122660a33fb4deb2d0e70c129871b","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_PLUGINS_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"},{"repo":"microsoft/apm-action","sha":"9fe9337ef58b5e620e0113071ceb47a6a8a232f7","version":"v1.4.2"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -232,16 +232,16 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_73d31ff43cf90af6_EOF'
+          cat << 'GH_AW_PROMPT_f05680ef0c5f9228_EOF'
           <system>
-          GH_AW_PROMPT_73d31ff43cf90af6_EOF
+          GH_AW_PROMPT_f05680ef0c5f9228_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_73d31ff43cf90af6_EOF'
+          cat << 'GH_AW_PROMPT_f05680ef0c5f9228_EOF'
           <safe-output-tools>
-          Tools: add_comment(max:12), add_labels(max:70), remove_labels(max:12), assign_milestone(max:12), missing_tool, missing_data, noop
+          Tools: add_comment(max:12), add_labels(max:70), remove_labels(max:12), assign_milestone(max:12), dispatch_workflow(max:10), missing_tool, missing_data, noop
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -271,15 +271,15 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_73d31ff43cf90af6_EOF
+          GH_AW_PROMPT_f05680ef0c5f9228_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_73d31ff43cf90af6_EOF'
+          cat << 'GH_AW_PROMPT_f05680ef0c5f9228_EOF'
           </system>
           
           
           
           {{#runtime-import .github/workflows/triage-panel.md}}
-          GH_AW_PROMPT_73d31ff43cf90af6_EOF
+          GH_AW_PROMPT_f05680ef0c5f9228_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -473,9 +473,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_dc8d9d06e140a655_EOF'
-          {"add_comment":{"max":12},"add_labels":{"allowed":["theme/governance","theme/portability","theme/security","area/audit-policy","area/ci-cd","area/cli","area/content-security","area/distribution","area/docs-site","area/enterprise","area/lockfile","area/marketplace","area/mcp-config","area/mcp-trust","area/multi-target","area/package-authoring","area/testing","type/architecture","type/automation","type/bug","type/docs","type/feature","type/performance","type/refactor","type/release","priority/high","priority/low","status/accepted","status/blocked","status/in-flight","status/needs-design","status/triaged","good first issue","help wanted","test/triage-validation"],"max":70,"target":"*"},"assign_milestone":{"max":12},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"remove_labels":{"allowed":["status/needs-triage"],"max":12,"target":"*"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_dc8d9d06e140a655_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_c65ae9b8fafa62c0_EOF'
+          {"add_comment":{"max":12},"add_labels":{"allowed":["theme/governance","theme/portability","theme/security","area/audit-policy","area/ci-cd","area/cli","area/content-security","area/distribution","area/docs-site","area/enterprise","area/lockfile","area/marketplace","area/mcp-config","area/mcp-trust","area/multi-target","area/package-authoring","area/testing","type/architecture","type/automation","type/bug","type/docs","type/feature","type/performance","type/refactor","type/release","priority/high","priority/low","status/accepted","status/blocked","status/in-flight","status/needs-design","status/triaged","good first issue","help wanted","test/triage-validation"],"max":70,"target":"*"},"assign_milestone":{"max":12},"create_report_incomplete_issue":{},"dispatch_workflow":{"max":10,"workflow_files":{"project-sync":".yml"},"workflows":["project-sync"]},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"remove_labels":{"allowed":["status/needs-triage"],"max":12,"target":"*"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_c65ae9b8fafa62c0_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -487,7 +487,26 @@ jobs:
                 "remove_labels": " CONSTRAINTS: Maximum 12 label(s) can be removed. Only these labels can be removed: [status/needs-triage]. Target: *."
               },
               "repo_params": {},
-              "dynamic_tools": []
+              "dynamic_tools": [
+                {
+                  "_workflow_name": "project-sync",
+                  "description": "Dispatch the 'project-sync' workflow with workflow_dispatch trigger. This workflow must support workflow_dispatch and be in .github/workflows/ directory in the same repository.",
+                  "inputSchema": {
+                    "additionalProperties": false,
+                    "properties": {
+                      "content_id": {
+                        "description": "Issue or PR GraphQL node ID (e.g. I_kwDO... / PR_kwDO...). Obtain via: gh api graphql -f query='query{repository(owner:\"microsoft\",name:\"apm\"){issue(number:N){id}}}'",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "content_id"
+                    ],
+                    "type": "object"
+                  },
+                  "name": "project_sync"
+                }
+              ]
             }
           GH_AW_VALIDATION_JSON: |
             {
@@ -716,7 +735,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_a6964120872e648d_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_2534aeb6d7216bb0_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -757,7 +776,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_a6964120872e648d_EOF
+          GH_AW_MCP_CONFIG_2534aeb6d7216bb0_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1004,6 +1023,7 @@ jobs:
       needs.activation.outputs.stale_lock_file_failed == 'true')
     runs-on: ubuntu-slim
     permissions:
+      actions: write
       contents: read
       discussions: write
       issues: write
@@ -1352,6 +1372,7 @@ jobs:
     if: (!cancelled()) && needs.agent.result != 'skipped' && needs.detection.result == 'success'
     runs-on: ubuntu-slim
     permissions:
+      actions: write
       contents: read
       discussions: write
       issues: write
@@ -1415,7 +1436,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,docs.github.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":12},\"add_labels\":{\"allowed\":[\"theme/governance\",\"theme/portability\",\"theme/security\",\"area/audit-policy\",\"area/ci-cd\",\"area/cli\",\"area/content-security\",\"area/distribution\",\"area/docs-site\",\"area/enterprise\",\"area/lockfile\",\"area/marketplace\",\"area/mcp-config\",\"area/mcp-trust\",\"area/multi-target\",\"area/package-authoring\",\"area/testing\",\"type/architecture\",\"type/automation\",\"type/bug\",\"type/docs\",\"type/feature\",\"type/performance\",\"type/refactor\",\"type/release\",\"priority/high\",\"priority/low\",\"status/accepted\",\"status/blocked\",\"status/in-flight\",\"status/needs-design\",\"status/triaged\",\"good first issue\",\"help wanted\",\"test/triage-validation\"],\"max\":70,\"target\":\"*\"},\"assign_milestone\":{\"max\":12},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"remove_labels\":{\"allowed\":[\"status/needs-triage\"],\"max\":12,\"target\":\"*\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"add_comment\":{\"max\":12},\"add_labels\":{\"allowed\":[\"theme/governance\",\"theme/portability\",\"theme/security\",\"area/audit-policy\",\"area/ci-cd\",\"area/cli\",\"area/content-security\",\"area/distribution\",\"area/docs-site\",\"area/enterprise\",\"area/lockfile\",\"area/marketplace\",\"area/mcp-config\",\"area/mcp-trust\",\"area/multi-target\",\"area/package-authoring\",\"area/testing\",\"type/architecture\",\"type/automation\",\"type/bug\",\"type/docs\",\"type/feature\",\"type/performance\",\"type/refactor\",\"type/release\",\"priority/high\",\"priority/low\",\"status/accepted\",\"status/blocked\",\"status/in-flight\",\"status/needs-design\",\"status/triaged\",\"good first issue\",\"help wanted\",\"test/triage-validation\"],\"max\":70,\"target\":\"*\"},\"assign_milestone\":{\"max\":12},\"create_report_incomplete_issue\":{},\"dispatch_workflow\":{\"max\":10,\"workflow_files\":{\"project-sync\":\".yml\"},\"workflows\":[\"project-sync\"]},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"remove_labels\":{\"allowed\":[\"status/needs-triage\"],\"max\":12,\"target\":\"*\"},\"report_incomplete\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/triage-panel.md
+++ b/.github/workflows/triage-panel.md
@@ -135,6 +135,14 @@ network:
 #     humans apply, only humans remove.
 #   - assign-milestone: lets the panel set the milestone when the
 #     issue has none. The prompt forbids overwriting an existing one.
+#   - dispatch-workflow `project-sync`: triggers the PGS project board
+#     sync per themed issue. Required because gh-aw safe-output label
+#     writes run under GITHUB_TOKEN, and GitHub does NOT fan out
+#     downstream workflow events from GITHUB_TOKEN-driven label changes.
+#     Without this dispatch, themed issues silently miss the project
+#     board (Theme/Area/Kind/Priority columns stay blank). max:10 mirrors
+#     the SCHEDULED_SWEEP issue cap; gh-aw enforces a 5s delay between
+#     dispatches so the worst-case latency add is ~50s per sweep.
 safe-outputs:
   add-comment:
     max: 12
@@ -193,6 +201,16 @@ safe-outputs:
     target: "*"
   assign-milestone:
     max: 12
+  # Same-repo only; compile-time validated (project-sync.yml must exist
+  # and declare workflow_dispatch). The agent passes `content_id` (the
+  # issue's GraphQL node ID, e.g. I_kwDO...) as the dispatch input.
+  # max:10 matches SCHEDULED_SWEEP issue ceiling (one dispatch per
+  # themed issue, worst case). gh-aw enforces a 5s delay between
+  # consecutive dispatches.
+  dispatch-workflow:
+    workflows:
+      - project-sync
+    max: 10
 
 timeout-minutes: 30
 ---
@@ -269,7 +287,7 @@ gh issue list \
   --repo "${{ github.repository }}" \
   --state open \
   --limit 200 \
-  --json number,title,author,labels,locked,createdAt,body
+  --json number,title,author,labels,locked,createdAt,body,id
 ```
 
 In your reasoning step (no shell required), filter the result:
@@ -320,7 +338,7 @@ The triggering issue is `#${{ github.event.issue.number }}`. Read it:
 ```bash
 gh issue view "${{ github.event.issue.number }}" \
   --repo "${{ github.repository }}" \
-  --json number,title,author,labels,locked,state,body,milestone,createdAt
+  --json number,title,author,labels,locked,state,body,milestone,createdAt,id
 gh issue view "${{ github.event.issue.number }}" \
   --repo "${{ github.repository }}" --comments
 ```
@@ -438,6 +456,22 @@ safe-output tools. Required label-set hygiene per issue:
   MUST emit a corresponding `assign_milestone` call -- the verdict
   text and the applied state must agree.** Only skip emission if you
   explicitly omitted milestone from the verdict.
+- **`dispatch_workflow` (project-sync)**: For every issue where you
+  added at least one `theme/*` label in this run, you MUST also call
+  `dispatch_workflow` with `workflow_name: "project-sync"` and inputs
+  `{"content_id": "<issue node id>"}` -- where `<issue node id>` is
+  the `id` field returned by `gh issue list --json id` / `gh issue
+  view --json id` (it looks like `I_kwDO...`, NOT the integer issue
+  number). This triggers the PGS project board sync for that issue.
+  It is required because gh-aw applies `add-labels` under
+  `GITHUB_TOKEN`, and GitHub does NOT fire downstream workflow events
+  from `GITHUB_TOKEN`-driven label changes -- so without this dispatch
+  the issue gets the right labels but never lands on the project
+  board. If you did NOT add any `theme/*` label (for example a
+  re-triage that only touches `status/*`), do NOT dispatch -- the
+  project-sync workflow only acts on themed items, so the dispatch
+  would be a no-op. Cap is 10 dispatches per run (matches sweep
+  ceiling); gh-aw enforces a 5s delay between consecutive dispatches.
 
 If the panel decides on a label that does not exist in APM's
 taxonomy (the `add-labels` allow-list, which is enumerated literally

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed TLS validation failure behind corporate TLS-intercepting proxies and firewalls: `install/validation.py` now uses `requests` (honouring `REQUESTS_CA_BUNDLE`) instead of stdlib `urllib`, and surfaces a single CA-trust hint at default verbosity instead of a misleading auth error. (#911)
+- Triage Panel themed issues now reach the PGS project board: the workflow dispatches `project-sync` per themed issue via the new `safe-outputs.dispatch-workflow` channel, working around GitHub's rule that `GITHUB_TOKEN`-driven label changes never fire downstream `issues: labeled` workflows. Without this, sweeps applied `theme/*` labels but the project-sync trigger silently no-op'd, leaving the board empty.
 
 ## [0.9.3] - 2026-04-26
 


### PR DESCRIPTION
## TL;DR

The Triage Panel applies `theme/*` labels but the PGS project board never gets the issues: GitHub does not fire downstream `issues: labeled` workflows when the label change was written under `GITHUB_TOKEN`, which is exactly what `safe-outputs.add-labels` does. We had to manually backfill 46 issues into project [#2304](https://github.com/orgs/microsoft/projects/2304) after the first 7 sweeps. This PR wires the panel through gh-aw's `safe-outputs.dispatch-workflow` channel so it dispatches `project-sync.yml` per themed issue, restoring the trigger fan-out without introducing new secrets.

## Problem (WHY)

- **Symptom observed in production.** After the 7-sweep manual drain on 2026-04-26 (66 issues triaged in 1h55m), zero `issues`-event runs of `project-sync.yml` fired in the sweep window — confirmed via `gh run list --workflow=project-sync.yml`. Project board stayed empty for newly-themed issues.
- **Root cause is a documented GitHub Actions rule.** ["When you use the repository's `GITHUB_TOKEN` to perform tasks, events triggered by the `GITHUB_TOKEN` will not create a new workflow run."](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) gh-aw's `safe-outputs.add-labels` writes labels via `GITHUB_TOKEN` by default, so `project-sync.yml`'s `on: issues: labeled` filter sees nothing.
- **Affects every event-driven downstream workflow we add later.** Any future automation listening for label/milestone/comment changes the panel produces would silently no-op the same way.
- **Backfill is not a fix.** Running `gh workflow run project-sync.yml -f content_id=...` once per themed issue is a manual rescue that has to happen after every sweep, indefinitely.

## Approach (WHAT)

Use gh-aw v0.68.3's [`safe-outputs.dispatch-workflow`](https://github.github.com/gh-aw/reference/safe-outputs/#workflow-dispatch-dispatch-workflow) — same security model as `add-labels` (same-repo only, allowlisted workflow names, compile-time validated):

| Decision | Choice | Rejected alternatives |
|---|---|---|
| How to trigger project-sync | gh-aw `dispatch-workflow` from inside the panel | PAT-routed `add-labels` (broadens PAT blast radius); `update-project` safe-output (duplicates the label→field mapping that already lives in `sync_item.py`); independent daily sweep workflow (extra moving piece) |
| When to dispatch | Only when at least one `theme/*` label was applied this run | Always (creates a no-op project-sync run on `status/*`-only re-triages); never (the bug stays) |
| Cap | `max: 10` | `max: 1` (default — too low for sweep mode); `max: 50` (gh-aw ceiling — wasteful, signals nothing) |
| Lock-file recompile | `gh aw compile triage-panel` and ship `.lock.yml` in the same commit | Leave stale (CI's regeneration-drift gate would reject) |

The panel knows the GraphQL node ID for every issue it processes — `gh issue list --json id` already returns it in the form `I_kwDO...`, so the only data-flow change is adding `id` to the existing `--json` field set.

## Implementation (HOW)

| File | Change |
|---|---|
| `.github/workflows/triage-panel.md` | Added `dispatch-workflow: { workflows: [project-sync], max: 10 }` to `safe-outputs`; extended both `gh issue list --json` (SCHEDULED_SWEEP) and `gh issue view --json` (OPT_IN_RETRIAGE / MANUAL_DISPATCH) with the `id` field; added a new `dispatch_workflow` bullet to the **Output safety rails** section that explains *when* to dispatch (only when ≥1 `theme/*` was applied), *what* node ID format to use, and *why* the dispatch is required. |
| `.github/workflows/triage-panel.lock.yml` | Regenerated by `gh aw compile triage-panel`. Confirmed `dispatch_workflow(max:10, workflows: [project-sync])` appears in the tool list and handler config. |
| `CHANGELOG.md` | Added one `### Fixed` bullet under `[Unreleased]` describing the symptom and the fan-out fix. |

No changes to `project-sync.yml` — it already supports `workflow_dispatch` with a `content_id` input, which is exactly what we used during the manual backfill.

### Sequence (what changes at runtime)

```mermaid
sequenceDiagram
  autonumber
  participant Sched as Cron 12:49 UTC
  participant Panel as Triage Panel<br/>(agent)
  participant SO as gh-aw safe-outputs<br/>handler
  participant Issues as Issues API
  participant Sync as project-sync.yml
  participant Board as PGS Project 2304
  Sched->>Panel: schedule fire
  Panel->>Issues: gh issue list --json ...,id
  Issues-->>Panel: 10 candidates incl. node IDs
  Panel-->>SO: add_labels theme/*, area/*, ...
  Panel-->>SO: dispatch_workflow project-sync<br/>{ content_id: I_kwDO... }
  SO->>Issues: PATCH labels (under GITHUB_TOKEN)
  Note over Issues,Sync: GITHUB_TOKEN label event<br/>does NOT fan out
  SO->>Sync: workflow_dispatch (under GITHUB_TOKEN)<br/>5s rate-limit between dispatches
  Sync->>Board: sync_item.py --content-id ...
  Board-->>Sync: Theme/Area/Kind/Priority/Tier set
```

> [!NOTE]
> Step 7 (`workflow_dispatch`) IS the fix. The `workflow_dispatch` event type is one of the few events GitHub fans out even when triggered by `GITHUB_TOKEN` — that's why `dispatch-workflow` works where letting the natural `issues: labeled` event do the work does not.

## Trade-offs

- **Coupling.** The panel prompt now names `project-sync` explicitly. Acceptable: both workflows are repo-internal, both ship in this repo, and gh-aw compile-time validation rejects the workflow if `project-sync.yml` ever moves or loses its `workflow_dispatch` trigger.
- **Latency.** gh-aw enforces a 5s delay between consecutive dispatches. Worst case 10 themed issues × 5s = 50s added to a sweep. Sweeps already take 16-20 min, so this is in the noise.
- **Agent-discipline dependency.** The agent has to remember to dispatch when it labelled. Mitigated by the same pattern we use for milestone-consistency: an explicit `MUST` in the **Output safety rails** section, paired with a `MUST NOT` for the case where no `theme/*` was applied.
- **Per-author quota interaction.** Per-author cap is 2 issues/sweep × max 10 issues × 1 dispatch each = 10 dispatches max, exactly equal to `max: 10`. No headroom is wasted.

## Benefits

1. Project board reflects panel triage automatically — eliminates the manual `gh workflow run` backfill after every sweep.
2. Pattern reusable for any future event-driven automation we add (e.g., a milestone-changed listener) — they just wire `dispatch-workflow` the same way.
3. No new secrets. No PAT scope expansion. Same security posture as the existing safe-outputs.
4. `project-sync.yml` remains the sole project writer — one source of truth for the label→field mapping in `scripts/project/sync_item.py`.

## Validation

```
$ gh aw compile triage-panel
✓ .github/workflows/triage-panel.md (74.9 KB)
✓ Compiled 1 workflow(s): 0 error(s), 0 warning(s)

$ grep "dispatch_workflow" .github/workflows/triage-panel.lock.yml | head -2
... Tools: ..., assign_milestone(max:12), dispatch_workflow(max:10), ...
... "dispatch_workflow":{"max":10,"workflow_files":{"project-sync":".yml"},"workflows":["project-sync"]} ...
```

The compiler cross-checks that `project-sync.yml` exists and declares `workflow_dispatch` — both true in `main`.

<details><summary>Manual backfill evidence (the bug this fixes)</summary>

After the 7-sweep manual drain on 2026-04-26, 46 themed issues were missing from project 2304. Running `gh workflow run project-sync.yml -f content_id=<node_id>` once per issue produced 47 successful runs, all of which set Theme/Area/Kind/Priority/Tier as expected. Sample log for issue [#944](https://github.com/microsoft/apm/issues/944) confirmed full field population. This PR removes the need for that manual step.

</details>

## How to test

1. Merge this PR.
2. Apply `status/needs-triage` to any open issue that lacks a `theme/*` label (fast-path trigger).
3. Watch the [Triage Panel](https://github.com/microsoft/apm/actions/workflows/triage-panel.lock.yml) run; expect a verdict comment with at least one `theme/*` label applied.
4. Within ~10s of the panel finishing, expect a new [PGS project sync](https://github.com/microsoft/apm/actions/workflows/project-sync.yml) run triggered by `workflow_dispatch` (event column will read `workflow_dispatch`, not `issues`).
5. Verify the issue appears in [project 2304](https://github.com/orgs/microsoft/projects/2304) with Theme/Area/Kind/Priority filled.

> [!TIP]
> If you want to test the SCHEDULED_SWEEP path before the next 12:49 UTC fire, run `gh workflow run triage-panel.lock.yml` (no inputs). It will pick up to 10 untriaged issues and dispatch project-sync for each themed one.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
