### PR TITLE
fix(tests): force UTF-8 in non-ASCII SKILL.md fixture (Windows CI hotfix)

### DIFF
--- a/tests/unit/test_skill_bundle.py
+++ b/tests/unit/test_skill_bundle.py
@@ -226,7 +226,8 @@ class TestSkillBundleValidation:
         sd = skills_dir / "unicode-skill"
         sd.mkdir()
         (sd / "SKILL.md").write_text(
-            "---\nname: unicode-skill\ndescription: Ünïcödé description\n---\n# x\n"
+            "---\nname: unicode-skill\ndescription: Ünïcödé description\n---\n# x\n",
+            encoding="utf-8",
         )
         result = validate_apm_package(tmp_path)
         assert result.is_valid  # warnings don't fail validation


### PR DESCRIPTION
## Problem
`tests/unit/test_skill_bundle.py::TestSkillBundleValidation::test_non_ascii_frontmatter_warning` fails on Windows runners on the v0.9.4 release branch (job 73133340014).

`Path.write_text()` defaults to the system locale encoding. On `windows-latest` that is **cp1252**, so the non-ASCII description bytes are written incorrectly. The validator then fails to decode the file as UTF-8 and surfaces a hard parse error:

```
'utf-8' codec can't decode byte ... position 39: invalid continuation byte
```

The test asserts `is_valid == True` and a "non-ASCII" *warning* — i.e. the validator's tolerant code path for valid UTF-8 with non-ASCII bytes. The fixture has to actually be valid UTF-8 for that path to fire.

## Fix
Pin `encoding="utf-8"` on the one `write_text` call that contains non-ASCII content. The other 24 `write_text` calls in the file are ASCII-only and are unaffected.

## Verification
```
uv run pytest tests/unit/test_skill_bundle.py -x
============================== 31 passed in 0.62s ==============================
```

## Scope
- One-line test fix, no production code touched.
- Should be cherry-picked to `v0.9.4` to unblock the release.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>