### PR TITLE
chore(release): cut 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,41 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-04-27
+
 ### Added
 
-- [Experimental] `apm marketplace package add/set`: mutable git refs (`HEAD`, branch names) are now auto-resolved to concrete SHAs for supply-chain safety. When no `--ref` is provided, the current HEAD SHA is pinned automatically. (#790)
-- [Experimental] `apm marketplace init` subcommand to scaffold a richly-commented `marketplace.yml` in the current directory, with an optional `.gitignore` staleness check (#790)
-- [Experimental] `apm marketplace build` subcommand to compile `marketplace.yml` into an Anthropic-compliant `marketplace.json` with `--dry-run`, `--offline`, and `--include-prerelease` flags; APM-only build options are stripped and `metadata:` is passed through verbatim (#790)
-- [Experimental] `apm marketplace outdated` subcommand to report upgradable package versions, distinguishing "latest in range" from "latest overall" so maintainers know when a manual range bump is required (#790)
-- [Experimental] `apm marketplace check` subcommand to validate `marketplace.yml` and verify every package entry resolves (`--offline` for schema + cached-ref checks) (#790)
-- [Experimental] `apm marketplace doctor` subcommand for environment diagnostics (git, network, auth, `gh` CLI, and `marketplace.yml` readiness) (#790)
-- [Experimental] `apm marketplace publish` subcommand to open PRs across consumer repositories from a `consumer-targets.yml`, with `--dry-run`, `--no-pr`, `--draft`, `--allow-downgrade`, `--allow-ref-change`, `--parallel N`, and a `.apm/publish-state.json` run history (#790)
-- [Experimental] `apm marketplace package add|set|remove` subcommands for programmatic management of marketplace.yml entries (#790)
+- **Microsoft 365 Copilot Cowork** target works end-to-end: `apm install --target cowork --global` deploys skills to OneDrive (behind `apm experimental enable cowork`). (#926)
+- **[Experimental] `apm marketplace` authoring CLI**: maintainers can scaffold, build, validate, and publish Anthropic-compliant marketplaces from the CLI (`init` -> `package add` -> `build` -> `publish`). (#790)
+- README "Coming from `npx skills add`?" 30-second migration table for users arriving from the agentskills.io ecosystem. (#980)
 
 ### Changed
 
-- [Experimental] Renamed `apm marketplace plugin` subgroup to `apm marketplace package` for npm/pip/cargo familiarity (#722)
-- [Experimental] Grouped `apm marketplace --help` output into "Consumer commands" and "Authoring commands" sections (#722)
-- [Experimental] `apm marketplace init` now accepts `--name` and `--owner` flags for non-interactive scaffolding (#722)
+- [Experimental] `apm marketplace plugin` renamed to `apm marketplace package` (npm/pip/cargo familiarity); `--help` grouped into Consumer / Authoring sections. (#722)
 
 ### Fixed
 
-- Docs site auto-deploys again after bot-cut releases by correctly detecting tag-push context in `docs.yml`. (#953)
-- [Experimental] Hidden unimplemented `--check-refs` flag on `validate` command (#722)
-- [Experimental] Fixed `includePrerelease` camelCase typo in init template comment (#722)
-- [Experimental] `apm marketplace doctor` now uses `AuthResolver` for GitHub token detection instead of raw env-var lookup (#790)
-- [Experimental] `apm marketplace doctor` checks `gh` CLI availability as an informational diagnostic (#790)
-- [Experimental] `apm marketplace outdated` summary line simplified; exit code 1 when upgradable packages exist (#790)
-- [Experimental] `Builder.resolve()` returns a `ResolveResult` dataclass instead of smuggling errors via instance state (#790)
-- [Experimental] `ConsumerTarget` validates repo format, branch safety, and path traversal at construction time (shift-left) (#790)
-- [Experimental] `apm marketplace` confirmation prompts now fail loudly in non-interactive/CI mode without `--yes` (#790)
-- [Experimental] `apm marketplace` exception handlers log verbose tracebacks via `logger.debug(exc_info=True)` and three handlers narrowed from bare `Exception` (#790)
-- [Experimental] Replaced 15 bare `click.echo()` calls and 3 Rich markup literals with `CommandLogger` methods (#790)
-- [Experimental] `version_pins.load_ref_pins()` warns when an expected pin file is missing instead of silently returning empty (#790)
+- Docs site auto-deploys again after bot-cut releases (now triggered on tag push). (#981)
 
 ### Maintainer tooling
 
-- `pr-description-skill` mermaid guidance hardened: new asset `assets/mermaid-conventions.md` defines diagram-type-by-intent (sequenceDiagram for execution flow with `rect rgb(...)` boxing, flowchart for pipelines/architecture with `classDef new`, stateDiagram-v2 for state machines) and captures GitHub-renderer gotchas that `mmdc` does not always catch (notably: square brackets in flowchart edge labels MUST be quoted -- `|"[label]"|` not `|[label]|`).
+- `pr-description-skill` ships an evals suite so PR-description quality regressions are caught in CI without an LLM API key. (#985)
+- `pr-description-skill` mermaid guidance hardened with `assets/mermaid-conventions.md` (diagram-type-by-intent + GitHub-renderer gotchas `mmdc` misses). (#984)
+- Cowork tests mock `sys.platform` so the macOS auto-detection paths don't false-fail on Windows CI. (#989)
 
 ## [0.9.4] - 2026-04-27
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apm-cli"
-version = "0.9.4"
+version = "0.10.0"
 description = "MCP configuration tool"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## TL;DR

Cuts **v0.10.0**. Five PRs ship since v0.9.4: one user-facing docs add, one CI fix that finally lands the post-release docs deploy, and three maintainer-tooling pieces (`pr-description-skill` evals + mermaid hardening + Windows CI hotfix). Milestone `0.9.5` was renamed to `0.10.0` and the 40 open items moved to a fresh `0.10.1` bucket.

## Changes

- `pyproject.toml`: `0.9.4` -> `0.10.0`
- `CHANGELOG.md`: `[Unreleased]` promoted to `[0.10.0] - 2026-04-27`. Each entry is one line answering "so what" for users:
  - **Added** `#980` README conversion block for `npx skills add` traffic
  - **Fixed** `#981` docs auto-deploy on tag push (the real fix; `#953` had landed an unreachable `workflow_call` branch)
  - **Maintainer tooling** `#985` evals suite for `pr-description-skill` (genesis-driven; deterministic, no API key)
  - **Maintainer tooling** `#984` mermaid hardening (diagram-type-by-intent + GH-renderer gotchas)
  - **Maintainer tooling** `#979` Windows CI hotfix (UTF-8 fixture read)

## Audit notes

PRs merged since v0.9.4: #985, #984, #981, #980, #979. PR #982 (multi-app shared/apm.md) is intentionally excluded -- still OPEN, blocked on upstream `microsoft/apm-action` `bundles-file:` input.

The previous `[Unreleased]` line crediting `#953` for the docs-deploy fix was incorrect (that was the v0.9.4 attempt that left `workflow_call` unreachable). Re-attributed to `#981` and the 0.9.4 entry left as-is.

## Milestones

- Renamed milestone `0.9.5` -> `0.10.0` (was the next-up bucket).
- Created milestone `0.10.1`.
- Moved 40 open items from `0.10.0` -> `0.10.1`. Closed items (3, including #913 cowork) stay in `0.10.0`.

## How to ship

Merge -> tag `v0.10.0` push triggers `build-release.yml` -> bot cuts release -> `docs.yml` (now correctly tag-triggered per #981) deploys docs.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
