### PR TITLE
fix(test): patch sys.platform in cowork tests for Windows CI

### DIFF
--- a/src/apm_cli/config.py
+++ b/src/apm_cli/config.py
@@ -169,7 +169,7 @@ def set_copilot_cowork_skills_dir(path: str) -> None:
     """
     if not path or not path.strip():
         raise ValueError("Path cannot be empty")
-    expanded = os.path.expanduser(path)
+    expanded = os.path.normpath(os.path.expanduser(path))
     if not os.path.isabs(expanded):
         raise ValueError(f"Path must be absolute: {expanded}")
     update_config({"copilot_cowork_skills_dir": expanded})

--- a/tests/unit/integration/test_copilot_cowork_paths.py
+++ b/tests/unit/integration/test_copilot_cowork_paths.py
@@ -72,9 +72,12 @@ class TestResolveCoworkSkillsDir:
         cloud_dir = tmp_path / "Library" / "CloudStorage"
         tenant_dir = cloud_dir / "OneDrive - Tenant"
         tenant_dir.mkdir(parents=True)
-        with patch(
-            "apm_cli.integration.copilot_cowork_paths.Path.home",
-            return_value=tmp_path,
+        with (
+            patch("apm_cli.integration.copilot_cowork_paths.sys.platform", "darwin"),
+            patch(
+                "apm_cli.integration.copilot_cowork_paths.Path.home",
+                return_value=tmp_path,
+            ),
         ):
             result = resolve_copilot_cowork_skills_dir()
         expected = tenant_dir / "Documents" / "Cowork" / "skills"
@@ -87,9 +90,12 @@ class TestResolveCoworkSkillsDir:
         cloud_dir = tmp_path / "Library" / "CloudStorage"
         cloud_dir.mkdir(parents=True)
         # No OneDrive dirs
-        with patch(
-            "apm_cli.integration.copilot_cowork_paths.Path.home",
-            return_value=tmp_path,
+        with (
+            patch("apm_cli.integration.copilot_cowork_paths.sys.platform", "darwin"),
+            patch(
+                "apm_cli.integration.copilot_cowork_paths.Path.home",
+                return_value=tmp_path,
+            ),
         ):
             result = resolve_copilot_cowork_skills_dir()
         assert result is None
@@ -99,9 +105,12 @@ class TestResolveCoworkSkillsDir:
     ) -> None:
         monkeypatch.delenv("APM_COPILOT_COWORK_SKILLS_DIR", raising=False)
         # No Library/CloudStorage at all
-        with patch(
-            "apm_cli.integration.copilot_cowork_paths.Path.home",
-            return_value=tmp_path,
+        with (
+            patch("apm_cli.integration.copilot_cowork_paths.sys.platform", "darwin"),
+            patch(
+                "apm_cli.integration.copilot_cowork_paths.Path.home",
+                return_value=tmp_path,
+            ),
         ):
             result = resolve_copilot_cowork_skills_dir()
         assert result is None
@@ -113,9 +122,12 @@ class TestResolveCoworkSkillsDir:
         cloud_dir = tmp_path / "Library" / "CloudStorage"
         (cloud_dir / "OneDrive - TenantA").mkdir(parents=True)
         (cloud_dir / "OneDrive - TenantB").mkdir(parents=True)
-        with patch(
-            "apm_cli.integration.copilot_cowork_paths.Path.home",
-            return_value=tmp_path,
+        with (
+            patch("apm_cli.integration.copilot_cowork_paths.sys.platform", "darwin"),
+            patch(
+                "apm_cli.integration.copilot_cowork_paths.Path.home",
+                return_value=tmp_path,
+            ),
         ):
             with pytest.raises(CoworkResolutionError):
                 resolve_copilot_cowork_skills_dir()
@@ -127,9 +139,12 @@ class TestResolveCoworkSkillsDir:
         cloud_dir = tmp_path / "Library" / "CloudStorage"
         (cloud_dir / "OneDrive - TenantA").mkdir(parents=True)
         (cloud_dir / "OneDrive - TenantB").mkdir(parents=True)
-        with patch(
-            "apm_cli.integration.copilot_cowork_paths.Path.home",
-            return_value=tmp_path,
+        with (
+            patch("apm_cli.integration.copilot_cowork_paths.sys.platform", "darwin"),
+            patch(
+                "apm_cli.integration.copilot_cowork_paths.Path.home",
+                return_value=tmp_path,
+            ),
         ):
             with pytest.raises(CoworkResolutionError) as exc_info:
                 resolve_copilot_cowork_skills_dir()
@@ -144,9 +159,12 @@ class TestResolveCoworkSkillsDir:
         cloud_dir = tmp_path / "Library" / "CloudStorage"
         (cloud_dir / "OneDrive - TenantA").mkdir(parents=True)
         (cloud_dir / "OneDrive - TenantB").mkdir(parents=True)
-        with patch(
-            "apm_cli.integration.copilot_cowork_paths.Path.home",
-            return_value=tmp_path,
+        with (
+            patch("apm_cli.integration.copilot_cowork_paths.sys.platform", "darwin"),
+            patch(
+                "apm_cli.integration.copilot_cowork_paths.Path.home",
+                return_value=tmp_path,
+            ),
         ):
             with pytest.raises(CoworkResolutionError) as exc_info:
                 resolve_copilot_cowork_skills_dir()
@@ -165,9 +183,12 @@ class TestResolveCoworkSkillsDir:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.delenv("APM_COPILOT_COWORK_SKILLS_DIR", raising=False)
-        with patch(
-            "apm_cli.integration.copilot_cowork_paths.Path.home",
-            return_value=tmp_path,
+        with (
+            patch("apm_cli.integration.copilot_cowork_paths.sys.platform", "linux"),
+            patch(
+                "apm_cli.integration.copilot_cowork_paths.Path.home",
+                return_value=tmp_path,
+            ),
         ):
             result = resolve_copilot_cowork_skills_dir()
         assert result is None
@@ -186,6 +207,7 @@ class TestResolveCoworkSkillsDir:
         (cloud / "OneDrive - Tenant").mkdir(parents=True)
         with (
             patch("apm_cli.config.get_copilot_cowork_skills_dir", return_value="/config/skills"),
+            patch("apm_cli.integration.copilot_cowork_paths.sys.platform", "darwin"),
             patch(
                 "apm_cli.integration.copilot_cowork_paths.Path.home",
                 return_value=tmp_path,
@@ -215,6 +237,7 @@ class TestResolveCoworkSkillsDir:
         tenant.mkdir(parents=True)
         with (
             patch("apm_cli.config.get_copilot_cowork_skills_dir", return_value=None),
+            patch("apm_cli.integration.copilot_cowork_paths.sys.platform", "darwin"),
             patch(
                 "apm_cli.integration.copilot_cowork_paths.Path.home",
                 return_value=tmp_path,
@@ -243,6 +266,7 @@ class TestResolveCoworkSkillsDir:
         # No CloudStorage directory -- auto-detect returns None.
         with (
             patch("apm_cli.config.get_copilot_cowork_skills_dir", return_value=None),
+            patch("apm_cli.integration.copilot_cowork_paths.sys.platform", "darwin"),
             patch(
                 "apm_cli.integration.copilot_cowork_paths.Path.home",
                 return_value=tmp_path,


### PR DESCRIPTION
## Summary

Fixes the 6 test failures introduced by #926 on Windows CI ([run](https://github.com/microsoft/apm/actions/runs/24988484842/job/73167738332)).

## Root cause

**5 tests in `test_copilot_cowork_paths.py`** -- macOS auto-detection tests did not mock `sys.platform`. On Windows CI the code enters the `win32` branch first and returns `None` without ever reaching the `~/Library/CloudStorage` glob logic. Two additional tests (`zero_tenant`, `no_cloud_storage`) passed for the wrong reason (the Windows short-circuit happened to return `None`, matching the expected result).

**1 test in `test_config_command.py`** -- `os.path.expanduser("~/myskills")` on Windows produces `C:\Users\...\myskills` with a forward slash after the home directory, while `os.path.join(home, "myskills")` uses the native backslash. The assertion failed because the strings differed.

## Fix

1. Every platform-specific test now patches `apm_cli.integration.copilot_cowork_paths.sys.platform` to the intended OS (`"darwin"` for macOS, `"linux"` for Linux).
2. `set_copilot_cowork_skills_dir` now normalises the expanded path with `os.path.normpath` to avoid mixed separators on Windows.

## Validation

5752 tests pass locally (macOS). The platform patches ensure the same code paths are exercised on all CI runners.