### PR TITLE
[docs] Update documentation for features from 2026-04-27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Renamed the experimental Cowork target and all user-facing surfaces from `cowork` to `copilot-cowork` for futureproofing (e.g. `apm experimental enable copilot-cowork`, `--target copilot-cowork`, `apm config set copilot-cowork-skills-dir`, `APM_COPILOT_COWORK_SKILLS_DIR`). No behaviour change; the `[0.9.3]` release shipped as `cowork` and this rename landed immediately after. (#926)
+
 ### Fixed
 
 - Docs site auto-deploys again after bot-cut releases by correctly detecting tag-push context in `docs.yml`. (#953)


### PR DESCRIPTION
## Documentation Updates - 2026-04-27

This PR documents the `cowork` → `copilot-cowork` rename that landed in PR #926, which was not reflected in `CHANGELOG.md`.

### Features Documented

- Rename of experimental Cowork target from `cowork` to `copilot-cowork` (from #926)

### Changes Made

- Updated `CHANGELOG.md` `[Unreleased]` section with a `Changed` entry for #926 explaining the rename, so users upgrading from v0.9.3 know the correct flag/target/config key names.

### Merged PRs Referenced

- #926 - `feat(cowork)`: experimental support for Microsoft 365 Copilot Cowork custom skills, with rename from `cowork` to `copilot-cowork` for futureproofing

### Notes

- `docs/src/content/docs/integrations/copilot-cowork.md` — already uses correct `copilot-cowork` naming (included in #926).
- `docs/src/content/docs/reference/experimental.md` — already lists `copilot-cowork` flag correctly.
- `docs/src/content/docs/reference/cli-commands.md` — already documents `copilot-cowork` target and `copilot-cowork-skills-dir` config key.
- `packages/apm-guide/.apm/skills/apm-usage/commands.md` — already references `copilot-cowork` naming.
- Only the CHANGELOG was missing the rename entry.




> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/24996665052/agentic_workflow) · ● 798.6K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+%22gh-aw-workflow-id%3A+daily-doc-updater%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/blob/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-04-29T13:09:10.734Z --> on Apr 29, 2026, 1:09 PM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, model: auto, id: 24996665052, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/24996665052 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->