### PR TITLE
fix(policy): unify --policy / --policy-source forms across CLI help and docs

### DIFF
--- a/docs/src/content/docs/reference/cli-commands.md
+++ b/docs/src/content/docs/reference/cli-commands.md
@@ -432,7 +432,7 @@ apm audit [PACKAGE] [OPTIONS]
 - `-f, --format [text|json|sarif|markdown]` - Output format: `text` (default), `json` (machine-readable), `sarif` (GitHub Code Scanning), `markdown` (step summaries). Cannot be combined with `--strip` or `--dry-run`.
 - `-o, --output PATH` - Write report to file. Auto-detects format from extension (`.sarif`, `.sarif.json` → SARIF; `.json` → JSON; `.md` → Markdown) when `--format` is not specified.
 - `--ci` - Run lockfile consistency checks for CI/CD gates. Exit 0 if clean, 1 if violations found. Auto-discovers org policy from the org `.github` repo unless `--no-policy` is set. Runs the 7 baseline checks: lockfile presence, ref consistency, deployed files present, no orphaned packages, MCP config consistency, content integrity (Unicode + hash drift on every deployed file including local content), includes consent (advisory).
-- `--policy SOURCE` - *(Experimental)* Override discovery: `org` (auto-discover from org), file path, or URL. Without this flag, `--ci` auto-discovers.
+- `--policy SOURCE` - *(Experimental)* Policy source. Accepts: `org` (auto-discover from your project's git remote), `owner/repo` (defaults to github.com), an `https://` URL, or a local file path. Used with `--ci` for policy checks. Without this flag, `--ci` auto-discovers.
 - `--no-policy` - Skip policy discovery and enforcement entirely. Equivalent to `APM_POLICY_DISABLE=1`.
 - `--no-cache` - Force fresh policy fetch (skip cache). Only relevant with policy discovery active.
 - `--no-fail-fast` - Run all checks even after a failure. By default, CI mode stops at the first failing check to save time.
@@ -520,7 +520,7 @@ apm policy status [OPTIONS]
 ```
 
 **Options:**
-- `--policy-source SOURCE` - Override discovery: `org`, file path, or URL. Same shape as `apm install --policy`.
+- `--policy-source SOURCE` - Override discovery. Accepts: `org` (auto-discover from your project's git remote), `owner/repo` (defaults to github.com), an `https://` URL, or a local file path.
 - `--no-cache` - Force fresh fetch (skip cache).
 - `--json` / `-o json` - Machine-readable output for SIEM ingestion or CI inspection.
 - `--check` - Exit non-zero (1) when no usable policy is found. Default is always 0; use `--check` for CI pre-checks.

--- a/src/apm_cli/commands/audit.py
+++ b/src/apm_cli/commands/audit.py
@@ -17,10 +17,11 @@ from typing import Dict, List, Optional, Tuple
 
 import click
 
+from ..core.command_logger import CommandLogger
 from ..deps.lockfile import LockFile, get_lockfile_path
+from ..policy._help_text import POLICY_SOURCE_FORMS_HELP
 from ..security.content_scanner import ContentScanner, ScanFinding
 from ..security.file_scanner import scan_lockfile_packages
-from ..core.command_logger import CommandLogger
 from ..utils.console import (
     _get_console,
     _rich_echo,
@@ -437,7 +438,7 @@ def _render_ci_results(ci_result: "CIAuditResult") -> None:
     "policy_source",
     default=None,
     help=(
-        "Policy source: 'org' (auto-discover), file path, or URL. "
+        f"Policy source. {POLICY_SOURCE_FORMS_HELP} "
         "Used with --ci for policy checks. [experimental]"
     ),
 )

--- a/src/apm_cli/commands/policy.py
+++ b/src/apm_cli/commands/policy.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Optional
 import click
 
 from ..core.command_logger import CommandLogger
+from ..policy._help_text import POLICY_SOURCE_FORMS_HELP
 from ..policy.discovery import (
     DEFAULT_CACHE_TTL,
     MAX_STALE_TTL,
@@ -284,10 +285,7 @@ def policy():
     "--policy-source",
     "policy_source",
     default=None,
-    help=(
-        "Override discovery: 'org', a local file path, owner/repo, "
-        "or an https URL."
-    ),
+    help=f"Override discovery. {POLICY_SOURCE_FORMS_HELP}",
 )
 @click.option(
     "--no-cache",

--- a/src/apm_cli/policy/_help_text.py
+++ b/src/apm_cli/policy/_help_text.py
@@ -1,0 +1,18 @@
+"""Shared help text fragments for policy-related CLI commands.
+
+The canonical contract for what ``--policy`` / ``--policy-source`` accept
+is enforced by ``discover_policy`` in ``discovery.py``. This module is the
+single source of truth for the user-facing rendering of that contract,
+shared by ``apm audit``, ``apm policy status``, and the consistency tests
+that pin them together.
+
+Adding or removing a form here without a matching change in
+``discover_policy`` (and an updated regression test in
+``tests/unit/policy/test_help_consistency.py``) will fail CI.
+"""
+
+POLICY_SOURCE_FORMS_HELP = (
+    "Accepts: 'org' (auto-discover from your project's git remote), "
+    "'owner/repo' (defaults to github.com), an https:// URL, or a "
+    "local file path."
+)

--- a/src/apm_cli/policy/discovery.py
+++ b/src/apm_cli/policy/discovery.py
@@ -542,9 +542,17 @@ def discover_policy(
 
     Resolution order:
     1. If policy_override is a local file path -> load from file
-    2. If policy_override is a URL -> fetch from URL
-    3. If policy_override is "org" -> auto-discover from org
-    4. If policy_override is None -> auto-discover from org
+    2. If policy_override is an https:// URL -> fetch from URL
+       (http:// is rejected for security)
+    3. If policy_override is "org" -> auto-discover from project's git remote
+    4. If policy_override is "owner/repo" (or "host/owner/repo")
+       -> fetch from that repo via GitHub Contents API
+    5. If policy_override is None -> auto-discover from project's git remote
+
+    The user-facing forms are documented in
+    ``apm_cli.policy._help_text.POLICY_SOURCE_FORMS_HELP``; that constant
+    is the single source of truth shared by ``apm audit --policy`` and
+    ``apm policy status --policy-source``.
 
     The optional ``expected_hash`` (``"<algo>:<hex>"``) pins the leaf
     policy bytes; mismatches return ``outcome="hash_mismatch"`` and

--- a/tests/unit/policy/test_help_consistency.py
+++ b/tests/unit/policy/test_help_consistency.py
@@ -1,0 +1,155 @@
+"""Lockstep tests pinning the documented forms of ``--policy`` / ``--policy-source``.
+
+The forms accepted by ``discover_policy`` (the ground-truth parser in
+``apm_cli.policy.discovery``) are mirrored in:
+
+- ``apm_cli.policy._help_text.POLICY_SOURCE_FORMS_HELP`` (Python constant)
+- ``apm audit --policy`` Click help (uses the constant)
+- ``apm policy status --policy-source`` Click help (uses the constant)
+- ``docs/src/content/docs/reference/cli-commands.md`` (manual prose)
+
+If any of these drift, the tests below fail. See #998 for the underlying
+incident that motivated this lockstep.
+"""
+
+import re
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from apm_cli.policy._help_text import POLICY_SOURCE_FORMS_HELP
+
+# Canonical user-facing forms accepted by ``--policy`` / ``--policy-source``.
+# Tokens chosen to be robust against Click's help-text reflow (no internal
+# whitespace) and to uniquely identify each form.
+EXPECTED_FORM_TOKENS = ("'org'", "owner/repo", "https://", "file path")
+
+# Same set of forms, written with the markdown backtick convention used in
+# the docs (the docs render Click-style single quotes as inline code).
+DOCS_FORM_TOKENS = ("`org`", "`owner/repo`", "`https://`", "file path")
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DOCS_PATH = (
+    REPO_ROOT
+    / "docs"
+    / "src"
+    / "content"
+    / "docs"
+    / "reference"
+    / "cli-commands.md"
+)
+
+
+def _normalize_help_output(text: str) -> str:
+    """Collapse all whitespace runs to single spaces.
+
+    Click reflows long help strings across terminal width; the constant
+    can land on word boundaries that get a newline + indent inserted.
+    Collapsing whitespace lets us search for canonical phrases without
+    having to anticipate every wrap point.
+    """
+    return re.sub(r"\s+", " ", text)
+
+
+def test_canonical_constant_lists_all_supported_forms():
+    """The constant text mentions every form ``discover_policy`` accepts."""
+    for token in EXPECTED_FORM_TOKENS:
+        assert token in POLICY_SOURCE_FORMS_HELP, (
+            f"POLICY_SOURCE_FORMS_HELP missing canonical form: {token!r}. "
+            "If discover_policy stopped accepting this form, the change "
+            "is intentional and this test should be updated. Otherwise "
+            "the constant has drifted from the parser."
+        )
+
+
+def test_audit_policy_help_uses_canonical_constant():
+    """``apm audit --help`` includes the canonical forms list."""
+    from apm_cli.commands.audit import audit
+
+    runner = CliRunner()
+    result = runner.invoke(audit, ["--help"])
+    assert result.exit_code == 0, result.output
+
+    output = _normalize_help_output(result.output)
+    for token in EXPECTED_FORM_TOKENS:
+        assert token in output, (
+            f"`apm audit --help` missing canonical form: {token!r}. The "
+            "Click decorator may have stopped using "
+            "POLICY_SOURCE_FORMS_HELP."
+        )
+
+
+def test_policy_status_help_uses_canonical_constant():
+    """``apm policy status --help`` includes the canonical forms list."""
+    from apm_cli.commands.policy import policy
+
+    runner = CliRunner()
+    result = runner.invoke(policy, ["status", "--help"])
+    assert result.exit_code == 0, result.output
+
+    output = _normalize_help_output(result.output)
+    for token in EXPECTED_FORM_TOKENS:
+        assert token in output, (
+            f"`apm policy status --help` missing canonical form: {token!r}. "
+            "The Click decorator may have stopped using "
+            "POLICY_SOURCE_FORMS_HELP."
+        )
+
+
+def _bullet_starting_with(text: str, marker: str) -> str:
+    """Return the bullet line that begins with ``marker`` (up to next newline).
+
+    Used to scope assertions to a specific flag's documentation bullet
+    instead of the whole docs file -- a form keyword may appear elsewhere
+    in cli-commands.md (e.g. unrelated marketplace examples), so a global
+    count is not strict enough to catch a removal from the bullet we
+    actually care about.
+    """
+    idx = text.find(marker)
+    if idx < 0:
+        raise AssertionError(
+            f"Could not find bullet starting with {marker!r} in {DOCS_PATH.name}"
+        )
+    end = text.find("\n", idx)
+    return text[idx:end] if end >= 0 else text[idx:]
+
+
+def test_docs_audit_policy_bullet_lists_all_forms():
+    """The ``apm audit --policy SOURCE`` doc bullet lists every canonical form."""
+    text = DOCS_PATH.read_text(encoding="utf-8")
+    bullet = _bullet_starting_with(text, "- `--policy SOURCE`")
+    for token in DOCS_FORM_TOKENS:
+        assert token in bullet, (
+            f"`apm audit --policy SOURCE` doc bullet missing form: {token!r}.\n"
+            f"Bullet text:\n  {bullet}"
+        )
+
+
+def test_docs_policy_status_bullet_lists_all_forms():
+    """The ``apm policy status --policy-source SOURCE`` bullet lists every canonical form."""
+    text = DOCS_PATH.read_text(encoding="utf-8")
+    bullet = _bullet_starting_with(text, "- `--policy-source SOURCE`")
+    for token in DOCS_FORM_TOKENS:
+        assert token in bullet, (
+            f"`apm policy status --policy-source SOURCE` doc bullet missing form: {token!r}.\n"
+            f"Bullet text:\n  {bullet}"
+        )
+
+
+def test_no_broken_install_policy_cross_reference_anywhere_in_docs():
+    """Regression guard for #994: no doc page may reference ``apm install --policy``.
+
+    ``apm install`` has no ``--policy`` flag (only ``--no-policy``). Any
+    cross-reference to ``apm install --policy`` is a broken pointer.
+    Scoped to the entire ``docs/`` tree (not just cli-commands.md) so a
+    future copy-paste into another docs page is also caught.
+    """
+    docs_root = REPO_ROOT / "docs"
+    offenders = []
+    for md_path in docs_root.rglob("*.md"):
+        if "apm install --policy" in md_path.read_text(encoding="utf-8"):
+            offenders.append(md_path.relative_to(REPO_ROOT))
+    assert not offenders, (
+        "Found broken reference to `apm install --policy` (no such flag) "
+        f"in: {[str(p) for p in offenders]}. See #994."
+    )


### PR DESCRIPTION
## TL;DR

The "policy source" format accepted by `apm audit --policy` and `apm policy status --policy-source` is documented inconsistently across four locations — two Click help texts and two docs sections, with the parser supporting `owner/repo` shorthand that is missing from three of the four. This PR establishes a single Python constant as the source of truth, threads it through both Click decorators, aligns the docs, and adds six lockstep regression tests so future drift fails CI rather than going unnoticed for months.

> [!NOTE]
> Closes #998 and #994. #994 reported a broken cross-reference (`Same shape as 'apm install --policy'` — a flag that does not exist); investigation revealed #998, the underlying drift. Both are fixed in one PR because they touch the same line of code; splitting would force the same line to be rewritten twice with no benefit.

## Problem (WHY)

- [x] **Drift across four surfaces.** [`policy.py:288`](https://github.com/microsoft/apm/blob/2023e8c/src/apm_cli/commands/policy.py#L288) lists 4 forms (`'org'`, file path, `owner/repo`, https URL); [`audit.py:440`](https://github.com/microsoft/apm/blob/2023e8c/src/apm_cli/commands/audit.py#L440) lists 3; [`cli-commands.md:435`](https://github.com/microsoft/apm/blob/2023e8c/docs/src/content/docs/reference/cli-commands.md#L435) lists 3; [`cli-commands.md:523`](https://github.com/microsoft/apm/blob/2023e8c/docs/src/content/docs/reference/cli-commands.md#L523) lists 3 and points at a non-existent flag.
- [x] **Docs miss `owner/repo`.** Users reading the CLI reference cannot discover that `apm policy status --policy-source contoso/.github` is valid input, even though the parser accepts it (proven by [`test_override_owner_repo`](https://github.com/microsoft/apm/blob/2023e8c/tests/unit/policy/test_discovery.py#L524-L535)).
- [x] **Broken cross-reference (#994).** `cli-commands.md:523` says `Same shape as \`apm install --policy\``, but `apm install` has no `--policy` flag (only `--no-policy`).
- [!] **No structural barrier to drift.** Each surface is hand-maintained. The parser docstring at [`discovery.py:543-547`](https://github.com/microsoft/apm/blob/2023e8c/src/apm_cli/policy/discovery.py#L543-L547) itself omits the `owner/repo` case, so even the in-code spec drifted.

Why these matter: the per-flag accepted-forms list is a contract the CLI advertises and the parser enforces; today they describe the same contract differently in four places, which violates the discoverability guarantee the docs imply.

## Approach (WHAT)

| # | Change |
|---|--------|
| 1 | Define `POLICY_SOURCE_FORMS_HELP` in a new lightweight module (`apm_cli/policy/_help_text.py`) co-located with the parser. |
| 2 | Both `apm audit --policy` and `apm policy status --policy-source` Click decorators import and embed the constant via f-string. |
| 3 | The two `cli-commands.md` bullets are rewritten to the same canonical wording — this also subsumes #994, since the broken cross-reference is rewritten away rather than redirected to another command. |
| 4 | The parser docstring in `discovery.py` is corrected to list all five resolution branches (it was missing `owner/repo`) and points readers to the constant as the user-facing rendering. |
| 5 | Six lockstep tests (`tests/unit/policy/test_help_consistency.py`) pin the constant, both Click helps, both docs bullets, and the absence of `apm install --policy` references docs-tree-wide. |

## Implementation (HOW)

- **`src/apm_cli/policy/_help_text.py` (new)** — holds `POLICY_SOURCE_FORMS_HELP`. Tiny, zero imports, lives next to the parser so a parser-behavior change forces a help-text update in the same diff.
- **`src/apm_cli/commands/audit.py`** — imports the constant, uses f-string interpolation in the `--policy` Click help so the command-specific suffix (`Used with --ci ... [experimental]`) is preserved.
- **`src/apm_cli/commands/policy.py`** — imports the constant, replaces the previous (already-most-accurate) help string with `f"Override discovery. {POLICY_SOURCE_FORMS_HELP}"`.
- **`src/apm_cli/policy/discovery.py`** — expands the `discover_policy()` docstring from 4 cases to 5 (the previous text omitted `owner/repo`) and cross-references the constant.
- **`docs/src/content/docs/reference/cli-commands.md`** — the two affected bullets (lines 435 and 523) are rewritten to canonical wording mirroring the constant, using markdown backticks for inline forms.
- **`tests/unit/policy/test_help_consistency.py` (new)** — six lockstep tests; mutation-tested to confirm each catches a distinct drift mode.

## Trade-offs

- **Did not document the 3-segment `host/owner/repo` form.** The parser supports it via `_fetch_from_repo` but no user-facing surface advertises it today. Promoting an internal capability to public API is a product decision, not a docs fix. Conservative call: keep the user-facing list at four forms; readers needing explicit-host can use the `https://` URL form.
- **Did not change `enterprise/policy-reference.md`.** That page already lists 4 forms correctly (different wording, same information). Pursuing byte-identical SSOT across audience-distinct docs would expand scope and trade reader-friendly prose for build-system parity.
- **Did not refactor `discover_policy()`.** Behavior is unchanged; only the docstring was corrected and a cross-reference to the constant added. The 507 unit tests in `tests/unit/policy/` pass unchanged.

## Benefits

1. **Drift becomes a CI failure**, not a months-later bug report. Mutation testing during review confirmed each lockstep test catches a distinct drift mode (constant edit, decorator bypass, docs deletion, broken cross-reference reintroduction).
2. **Discoverability of `owner/repo` shorthand.** `--policy` and `--policy-source` users can now find this form from any single doc page or `--help` invocation.
3. **#994 closed without an intermediate state.** The offending line is touched once and lands at the canonical wording — no "fixed cross-ref but still incomplete" middle stage.
4. **One-line maintenance.** Future help-text changes for these flags require updating one Python constant, not four hand-maintained surfaces.

## Validation

`apm audit --help` (relevant fragment):

```
  --policy TEXT                   Policy source. Accepts: 'org' (auto-discover
                                  from your project's git remote),
                                  'owner/repo' (defaults to github.com), an
                                  https:// URL, or a local file path. Used
                                  with --ci for policy checks. [experimental]
```

`apm policy status --help` (relevant fragment):

```
  --policy-source TEXT       Override discovery. Accepts: 'org' (auto-discover
                             from your project's git remote), 'owner/repo'
                             (defaults to github.com), an https:// URL, or a
                             local file path.
```

Lockstep regression tests:

```
$ pytest tests/unit/policy/test_help_consistency.py -v
test_canonical_constant_lists_all_supported_forms              PASSED
test_audit_policy_help_uses_canonical_constant                 PASSED
test_policy_status_help_uses_canonical_constant                PASSED
test_docs_audit_policy_bullet_lists_all_forms                  PASSED
test_docs_policy_status_bullet_lists_all_forms                 PASSED
test_no_broken_install_policy_cross_reference_anywhere_in_docs PASSED
============================== 6 passed in 0.45s ==============================
```

<details><summary>Aggregate regression on all touched code (563 tests)</summary>

```
$ pytest tests/unit/policy tests/unit/test_audit_policy_command.py \
    tests/unit/test_audit_ci_auto_discovery.py \
    tests/unit/commands/test_policy_status.py
============================= 563 passed in 2.33s =============================
```

The 26 failures observed in `tests/unit/` outside this set are pre-existing on `main` (marketplace / install / cowork / config — none touched by this PR), confirmed by stashing the changes and rerunning the same selection on the parent commit.

</details>

<details><summary>Mutation testing performed during review</summary>

Each mutation was applied locally, the relevant test was run, then the mutation was reverted.

| Mutation | Tests caught it | Result |
|----------|----------------|--------|
| Delete `'owner/repo'` from `POLICY_SOURCE_FORMS_HELP` | 3 (constant + audit help + policy status help) | Caught |
| Replace `audit.py` help with hand-written string (bypass constant) | 1 (audit help test) | Caught |
| Reintroduce `apm install --policy` reference in `governance-guide.md` (a different docs page) | 1 (docs-wide test, with file path in error) | Caught |
| Delete `owner/repo` from `cli-commands.md:523` bullet | 1 (policy status doc bullet test, with bullet text in error) | Caught |

</details>

## How to test

- [ ] `pytest tests/unit/policy/test_help_consistency.py -v` — expect 6 passes.
- [ ] `apm audit --help` — expect the `--policy` line to mention `owner/repo`, `https://`, and `local file path`.
- [ ] `apm policy status --help` — expect the `--policy-source` line to mention all four canonical forms.
- [ ] `grep -r "apm install --policy" docs/` — expect no matches (closes #994).
- [ ] Try `apm policy status --policy-source contoso/.github` — expect the parser to attempt fetch (not a parse-level rejection), confirming the newly-documented `owner/repo` form actually works.
