### PR TITLE
[Test Improver] fix(tests): strip ANSI escape codes in test_policy_status._ascii_only

### DIFF
--- a/tests/unit/commands/test_policy_status.py
+++ b/tests/unit/commands/test_policy_status.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import textwrap
 import unicodedata
 from pathlib import Path
@@ -14,12 +15,11 @@ from click.testing import CliRunner
 from apm_cli.commands.policy import (
     _count_rules,
     _format_age,
-    policy as policy_group,
 )
+from apm_cli.commands.policy import policy as policy_group
 from apm_cli.policy.discovery import PolicyFetchResult
 from apm_cli.policy.parser import load_policy
 from apm_cli.policy.schema import ApmPolicy
-
 
 # -- Fixtures -------------------------------------------------------
 
@@ -36,9 +36,7 @@ def _make_policy(yaml_str: str) -> ApmPolicy:
 
 def _rich_policy() -> ApmPolicy:
     """A policy with a non-trivial set of rules across sections."""
-    return _make_policy(
-        textwrap.dedent(
-            """\
+    return _make_policy(textwrap.dedent("""\
             name: test-policy
             version: '1.0'
             enforcement: block
@@ -62,13 +60,24 @@ def _rich_policy() -> ApmPolicy:
               required_fields: [name, version]
             unmanaged_files:
               directories: [.legacy, .scratch]
-            """
-        )
-    )
+            """))
+
+
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI/VT100 CSI escape sequences from *text*."""
+    return _ANSI_RE.sub("", text)
 
 
 def _ascii_only(text: str) -> bool:
-    """Return True iff every codepoint is printable ASCII (U+0020-U+007E)."""
+    """Return True iff every codepoint is printable ASCII (U+0020-U+007E).
+
+    ANSI escape sequences emitted by Rich are stripped first; they are an
+    artefact of the terminal renderer, not source-authored text.
+    """
+    text = _strip_ansi(text)
     for ch in text:
         if ch in ("\n", "\r", "\t"):
             continue
@@ -84,9 +93,23 @@ def _ascii_only(text: str) -> bool:
             # text we control.
             if 0x2500 <= cp <= 0x257F:
                 continue
-            if cp in (0x2501, 0x2503, 0x250F, 0x2513, 0x2517, 0x251B, 0x2523,
-                     0x252B, 0x2533, 0x253B, 0x254B, 0x2578, 0x2579,
-                     0x257A, 0x257B):
+            if cp in (
+                0x2501,
+                0x2503,
+                0x250F,
+                0x2513,
+                0x2517,
+                0x251B,
+                0x2523,
+                0x252B,
+                0x2533,
+                0x253B,
+                0x254B,
+                0x2578,
+                0x2579,
+                0x257A,
+                0x257B,
+            ):
                 continue
             return False
     return True
@@ -266,12 +289,13 @@ class TestStatusNoCache:
             source="org:contoso/.github",
             outcome="absent",
         )
-        with patch(
-            "apm_cli.commands.policy.discover_policy",
-            return_value=result_obj,
-        ) as mock_disc, patch(
-            "apm_cli.commands.policy.discover_policy_with_chain"
-        ) as mock_chain:
+        with (
+            patch(
+                "apm_cli.commands.policy.discover_policy",
+                return_value=result_obj,
+            ) as mock_disc,
+            patch("apm_cli.commands.policy.discover_policy_with_chain") as mock_chain,
+        ):
             result = runner.invoke(policy_group, ["status", "--no-cache"])
         assert result.exit_code == 0, result.output
         # --no-cache must bypass the chain helper and call discover_policy
@@ -306,12 +330,13 @@ class TestStatusPolicySourceOverride:
             source="url:https://example.com/p.yml",
             outcome="found",
         )
-        with patch(
-            "apm_cli.commands.policy.discover_policy",
-            return_value=result_obj,
-        ) as mock_disc, patch(
-            "apm_cli.commands.policy.discover_policy_with_chain"
-        ) as mock_chain:
+        with (
+            patch(
+                "apm_cli.commands.policy.discover_policy",
+                return_value=result_obj,
+            ) as mock_disc,
+            patch("apm_cli.commands.policy.discover_policy_with_chain") as mock_chain,
+        ):
             result = runner.invoke(
                 policy_group,
                 ["status", "--policy-source", "https://example.com/p.yml"],
@@ -386,7 +411,9 @@ class TestStatusAsciiOnly:
     )
     def test_renderings_are_ascii_safe(self, runner, outcome, policy_obj, extras):
         result_obj = PolicyFetchResult(
-            outcome=outcome, policy=policy_obj, source="org:contoso/.github",
+            outcome=outcome,
+            policy=policy_obj,
+            source="org:contoso/.github",
             **extras,
         )
         with patch(
@@ -395,12 +422,12 @@ class TestStatusAsciiOnly:
         ):
             table_result = runner.invoke(policy_group, ["status"])
             json_result = runner.invoke(policy_group, ["status", "--json"])
-        assert _ascii_only(table_result.output), (
-            f"non-ASCII output for outcome={outcome}: {table_result.output!r}"
-        )
-        assert _ascii_only(json_result.output), (
-            f"non-ASCII JSON for outcome={outcome}: {json_result.output!r}"
-        )
+        assert _ascii_only(
+            table_result.output
+        ), f"non-ASCII output for outcome={outcome}: {table_result.output!r}"
+        assert _ascii_only(
+            json_result.output
+        ), f"non-ASCII JSON for outcome={outcome}: {json_result.output!r}"
 
 
 class TestStatusCheckFlag:
@@ -457,9 +484,7 @@ class TestStatusCheckFlag:
             "apm_cli.commands.policy.discover_policy_with_chain",
             return_value=result_obj,
         ):
-            result = runner.invoke(
-                policy_group, ["status", "--check", "--json"]
-            )
+            result = runner.invoke(policy_group, ["status", "--check", "--json"])
         assert result.exit_code == 1
         payload = json.loads(result.output)
         assert payload["outcome"] == "absent"


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant*

## Problem

`test_policy_status.py` had 7 consistently failing tests. The `_ascii_only()` helper was returning `False` because Rich outputs ANSI CSI escape sequences (`\x1b[3m` italic, `\x1b[1m` bold, `\x1b[0m` reset) even inside Click's `CliRunner`, which does not set a pseudo-TTY. The ESC byte (`\x1b`, codepoint 0x1B) is categorised as `Cc` (control character) by `unicodedata`, so the existing guard correctly rejects it — but incorrectly flags Rich's styling codes as a violation.

Failures:
````
FAILED test_policy_status.py::TestStatusFoundOutcome::test_renders_found_outcome
FAILED test_policy_status.py::TestStatusAbsentOutcome::test_renders_absent_cleanly
FAILED test_policy_status.py::TestStatusCachedStaleOutcome::test_renders_stale_with_refresh_error
FAILED test_policy_status.py::TestStatusAsciiOnly::test_renderings_are_ascii_safe[found-...]
FAILED test_policy_status.py::TestStatusAsciiOnly::test_renderings_are_ascii_safe[absent-...]
FAILED test_policy_status.py::TestStatusAsciiOnly::test_renderings_are_ascii_safe[cached_stale-...]
FAILED test_policy_status.py::TestStatusAsciiOnly::test_renderings_are_ascii_safe[disabled-...]
```

## Approach

- Add `_strip_ansi()` helper using `re.sub(r"\x1b\[[0-9;]*[A-Za-z]", "", text)` — strips CSI escape sequences only, leaving actual text intact.
- Call `_strip_ansi()` at the top of `_ascii_only()` before iteration.
- The intent of `_ascii_only` is to catch non-ASCII *authored* strings (emojis, smart quotes) in CLI output — Rich's ANSI styling is not authored text and should be excluded from the check.

## Test Status

| Suite | Before | After |
|---|---|---|
| `tests/unit/commands/test_policy_status.py` | 7 failed, 33 passed | **40 passed** |
| Full unit suite | blocked at first failure | **6564 passed** |

```
uv run pytest tests/unit/commands/test_policy_status.py -q
# 40 passed in 0.34s

uv run pytest tests/unit tests/test_console.py -q
# 6564 passed, 1 warning, 26 subtests passed in 24.27s
````

## Trade-offs

- Minimal change: one import (`re`), one compiled regex, one helper function.
- The regex `\x1b\[[0-9;]*[A-Za-z]` covers standard CSI sequences; OSC/DCS sequences are not stripped but don't appear in Rich table output.




> Generated by [Daily Test Improver](https://github.com/microsoft/apm/actions/runs/25032452046/agentic_workflow) · ● 1.9M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+%22gh-aw-workflow-id%3A+daily-test-improver%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/blob/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-test-improver.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-test-improver.md@b87234850bf9664d198f28a02df0f937d0447295
> ```

<!-- gh-aw-agentic-workflow: Daily Test Improver, engine: copilot, model: auto, id: 25032452046, workflow_id: daily-test-improver, run: https://github.com/microsoft/apm/actions/runs/25032452046 -->

<!-- gh-aw-workflow-id: daily-test-improver -->