### PR TITLE
fix: use POSIX paths in auto-discovery CLI output for Windows compat

### DIFF
--- a/src/apm_cli/core/script_runner.py
+++ b/src/apm_cli/core/script_runner.py
@@ -73,7 +73,7 @@ class ScriptRunner:
         if discovered_prompt:
             # Print discovery message early to allow E2E tests to validate
             # This message appears before runtime detection, which may fail in test environments
-            print(f"[i] Auto-discovered: {discovered_prompt}")
+            print(f"[i] Auto-discovered: {discovered_prompt.as_posix()}")
 
             # Detect runtime and generate command
             runtime = self._detect_installed_runtime()

--- a/src/apm_cli/output/script_formatters.py
+++ b/src/apm_cli/output/script_formatters.py
@@ -321,7 +321,7 @@ class ScriptExecutionFormatter:
             try:
                 text = Text()
                 text.append("[i] Auto-discovered: ", style="cyan")
-                text.append(str(prompt_file), style="bold white")
+                text.append(prompt_file.as_posix(), style="bold white")
                 text.append(f" (runtime: {runtime})", style="dim")
                 
                 with self.console.capture() as capture:
@@ -329,9 +329,9 @@ class ScriptExecutionFormatter:
                 return capture.get().rstrip('\n')
             except Exception:
                 # Fallback to simple formatting
-                return f"[i] Auto-discovered: {prompt_file} (runtime: {runtime})"
+                return f"[i] Auto-discovered: {prompt_file.as_posix()} (runtime: {runtime})"
         else:
-            return f"[i] Auto-discovered: {prompt_file} (runtime: {runtime})"
+            return f"[i] Auto-discovered: {prompt_file.as_posix()} (runtime: {runtime})"
     
     def _styled(self, text: str, style: str) -> str:
         """Apply styling to text with rich fallback."""


### PR DESCRIPTION
## Problem

The CI/CD Pipeline is broken on Windows ([run 25036652822](https://github.com/microsoft/apm/actions/runs/25036652822)). Two unit tests in `test_script_formatters.py` fail because `Path.__str__()` uses backslash separators on Windows:

```
FAILED test_format_auto_discovery_message_rich_fallback
  AssertionError: 'prompts/hello.md' not found in '[i] Auto-discovered: prompts\hello.md (runtime: copilot)'

FAILED test_format_auto_discovery_message_success
  AssertionError: 'scripts/deploy.prompt.md' not found in '[i] Auto-discovered: scripts\deploy.prompt.md (runtime: codex)'
```

## Fix

Use `Path.as_posix()` instead of `str(path)` / `f"{path}"` in three sites within `script_formatters.py` and one in `script_runner.py`. This ensures consistent forward-slash output regardless of platform.

## Files changed

- `src/apm_cli/output/script_formatters.py` -- 3 interpolation sites in `format_auto_discovery_message`
- `src/apm_cli/core/script_runner.py` -- 1 print statement in `execute`

## Validation

6,627 unit tests pass locally (macOS). The fix is a minimal, surgical change with no behavioural impact beyond normalising path display.