### PR TITLE
fix(shared/apm): drop stale STATUS banner; recompile lock files to v1.5.0

### DIFF
--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -1,5 +1,10 @@
 {
   "entries": {
+    "actions/create-github-app-token@v3.1.1": {
+      "repo": "actions/create-github-app-token",
+      "version": "v3.1.1",
+      "sha": "1b10c78c7865c340bc4f6099eb2f838309f1e8c3"
+    },
     "actions/download-artifact@v8.0.1": {
       "repo": "actions/download-artifact",
       "version": "v8.0.1",
@@ -20,6 +25,11 @@
       "version": "v7",
       "sha": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
     },
+    "github/gh-aw-actions/setup-cli@v0.68.3": {
+      "repo": "github/gh-aw-actions/setup-cli",
+      "version": "v0.68.3",
+      "sha": "ba90f2186d7ad780ec640f364005fa24e797b360"
+    },
     "github/gh-aw-actions/setup@v0.68.3": {
       "repo": "github/gh-aw-actions/setup",
       "version": "v0.68.3",
@@ -39,6 +49,11 @@
       "repo": "microsoft/apm-action",
       "version": "v1.4.2",
       "sha": "9fe9337ef58b5e620e0113071ceb47a6a8a232f7"
+    },
+    "microsoft/apm-action@v1.5.0": {
+      "repo": "microsoft/apm-action",
+      "version": "v1.5.0",
+      "sha": "454b8a1d279376a47df8bb8d525ec076ca0fcef7"
     }
   }
 }

--- a/.github/workflows/agentics-maintenance.yml
+++ b/.github/workflows/agentics-maintenance.yml
@@ -171,7 +171,7 @@ jobs:
             await main();
 
       - name: Install gh-aw
-        uses: github/gh-aw-actions/setup-cli@v0.68.3
+        uses: github/gh-aw-actions/setup-cli@ba90f2186d7ad780ec640f364005fa24e797b360 # v0.68.3
         with:
           version: v0.68.3
 
@@ -272,7 +272,7 @@ jobs:
             await main();
 
       - name: Install gh-aw
-        uses: github/gh-aw-actions/setup-cli@v0.68.3
+        uses: github/gh-aw-actions/setup-cli@ba90f2186d7ad780ec640f364005fa24e797b360 # v0.68.3
         with:
           version: v0.68.3
 
@@ -316,7 +316,7 @@ jobs:
             await main();
 
       - name: Install gh-aw
-        uses: github/gh-aw-actions/setup-cli@v0.68.3
+        uses: github/gh-aw-actions/setup-cli@ba90f2186d7ad780ec640f364005fa24e797b360 # v0.68.3
         with:
           version: v0.68.3
 

--- a/.github/workflows/pr-review-panel.lock.yml
+++ b/.github/workflows/pr-review-panel.lock.yml
@@ -1,5 +1,5 @@
 # gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b815b0974637d563cb04400baa74bf4b2d661724ea984b770276ef17e827ae8a","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_PLUGINS_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"},{"repo":"microsoft/apm-action","sha":"9fe9337ef58b5e620e0113071ceb47a6a8a232f7","version":"v1.4.2"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_PLUGINS_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"},{"repo":"microsoft/apm-action","sha":"454b8a1d279376a47df8bb8d525ec076ca0fcef7","version":"v1.5.0"},{"repo":"ruby/setup-ruby","sha":"4c56a21280b36d862b5fc31348f463d60bdc55d5","version":"v1.301.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -37,12 +37,14 @@
 #
 # Custom actions used:
 #   - actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#   - actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
 #   - github/gh-aw-actions/setup@ba90f2186d7ad780ec640f364005fa24e797b360 # v0.68.3
-#   - microsoft/apm-action@9fe9337ef58b5e620e0113071ceb47a6a8a232f7 # v1.4.2
+#   - microsoft/apm-action@454b8a1d279376a47df8bb8d525ec076ca0fcef7 # v1.5.0
+#   - ruby/setup-ruby@4c56a21280b36d862b5fc31348f463d60bdc55d5 # v1.301.0
 #
 # Container images used:
 #   - ghcr.io/github/gh-aw-firewall/agent:0.25.20
@@ -337,6 +339,7 @@ jobs:
     needs:
       - activation
       - apm
+      - apm-prep
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -381,24 +384,34 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@4c56a21280b36d862b5fc31348f463d60bdc55d5 # v1.301.0
+        with:
+          ruby-version: '3.3'
       - name: Create gh-aw temp directory
         run: bash "${RUNNER_TEMP}/gh-aw/actions/create_gh_aw_tmp_dir.sh"
       - name: Configure gh CLI for GitHub Enterprise
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
-      - name: Download APM bundle artifact
+      - name: Download APM bundle artifacts (all groups)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ needs.activation.outputs.artifact_prefix }}apm
-          path: /tmp/gh-aw/apm-bundle
-      - id: apm_bundle
-        name: Find APM bundle path
-        run: echo "path=$(find /tmp/gh-aw/apm-bundle -name '*.tar.gz' | head -1)" >> "$GITHUB_OUTPUT"
-      - name: Restore APM packages
-        uses: microsoft/apm-action@9fe9337ef58b5e620e0113071ceb47a6a8a232f7 # v1.4.2
+          merge-multiple: false
+          path: /tmp/gh-aw/apm-bundles
+          pattern: ${{ needs.activation.outputs.artifact_prefix }}apm-*
+      - env:
+          ARTIFACT_PREFIX: ${{ needs.activation.outputs.artifact_prefix }}
+          EXPECTED_MATRIX: ${{ needs.apm-prep.outputs.matrix }}
+        name: Validate downloaded bundles match matrix manifest
+        run: "set -euo pipefail\nexpected=$(echo \"$EXPECTED_MATRIX\" | jq -r --arg prefix \"$ARTIFACT_PREFIX\" '.group | map($prefix + \"apm-\" + .id) | sort | .[]')\nactual=$(ls /tmp/gh-aw/apm-bundles | sort)\nmissing=$(comm -23 <(echo \"$expected\") <(echo \"$actual\") || true)\nunexpected=$(comm -13 <(echo \"$expected\") <(echo \"$actual\") || true)\nif [ -n \"$missing\" ]; then\n  echo \"::error::missing APM bundles (group did not pack successfully): $missing\"\n  exit 1\nfi\nif [ -n \"$unexpected\" ]; then\n  echo \"::error::unexpected artifact in apm bundle download (collision attack?): $unexpected\"\n  exit 1\nfi\n"
+      - id: bundles
+        name: Build bundle list
+        run: "set -euo pipefail\nmapfile -t list < <(find /tmp/gh-aw/apm-bundles -name '*.tar.gz' | sort)\n[ ${#list[@]} -gt 0 ] || { echo '::error::no apm bundles found'; exit 1; }\nprintf '%s\\n' \"${list[@]}\" > /tmp/gh-aw/apm-bundle-list.txt\n"
+      - name: Restore APM packages (all bundles)
+        uses: microsoft/apm-action@454b8a1d279376a47df8bb8d525ec076ca0fcef7 # v1.5.0
         with:
-          bundle: ${{ steps.apm_bundle.outputs.path }}
+          bundles-file: /tmp/gh-aw/apm-bundle-list.txt
 
       - name: Configure Git credentials
         env:
@@ -906,8 +919,13 @@ jobs:
           if-no-files-found: ignore
 
   apm:
-    needs: activation
+    needs:
+      - activation
+      - apm-prep
     runs-on: ubuntu-slim
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.apm-prep.outputs.matrix) }}
     permissions:
       {}
 
@@ -921,25 +939,34 @@ jobs:
           GH_HOST="${GITHUB_SERVER_URL#https://}"
           GH_HOST="${GH_HOST#http://}"
           echo "GH_HOST=${GH_HOST}" >> "$GITHUB_ENV"
-      - name: Prepare APM package list
-        id: apm_prep
+      - name: Mint installation token
+        id: token
+        if: ${{ matrix.group.app-id != '' }}
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ matrix.group.app-id }}
+          owner: ${{ matrix.group.owner != '' && matrix.group.owner || github.repository_owner }}
+          private-key: ${{ matrix.group.private-key }}
+          repositories: ${{ matrix.group.repositories }}
+      - name: Render package list
+        id: list
         run: |
-          DEPS=$(echo "$AW_APM_PACKAGES" | jq -r '.[] | "- " + .')
+          DEPS=$(echo "$AW_PKG" | jq -r '.[] | "- " + .')
           {
             echo "deps<<APMDEPS"
             printf '%s\n' "$DEPS"
             echo "APMDEPS"
           } >> "$GITHUB_OUTPUT"
         env:
-          AW_APM_PACKAGES: "[\"microsoft/apm#main\"]"
+          AW_PKG: ${{ toJSON(matrix.group.packages) }}
       - name: Pack APM packages
-        id: apm_pack
-        uses: microsoft/apm-action@9fe9337ef58b5e620e0113071ceb47a6a8a232f7 # v1.4.2
+        id: pack
+        uses: microsoft/apm-action@454b8a1d279376a47df8bb8d525ec076ca0fcef7 # v1.5.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_AW_PLUGINS_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.token.outputs.token || secrets.GH_AW_PLUGINS_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         with:
           archive: "true"
-          dependencies: ${{ steps.apm_prep.outputs.deps }}
+          dependencies: ${{ steps.list.outputs.deps }}
           isolated: "true"
           pack: "true"
           target: all
@@ -948,15 +975,95 @@ jobs:
         if: success()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ${{ needs.activation.outputs.artifact_prefix }}apm
-          path: ${{ steps.apm_pack.outputs.bundle-path }}
+          name: ${{ needs.activation.outputs.artifact_prefix }}apm-${{ matrix.group.id }}
+          path: ${{ steps.pack.outputs.bundle-path }}
           retention-days: "1"
+
+  apm-prep:
+    needs: activation
+    runs-on: ubuntu-slim
+    permissions:
+      {}
+
+    outputs:
+      matrix: ${{ steps.compute.outputs.matrix }}
+    steps:
+      - name: Configure GH_HOST for enterprise compatibility
+        id: ghes-host-config
+        shell: bash
+        run: |
+          # Derive GH_HOST from GITHUB_SERVER_URL so the gh CLI targets the correct
+          # GitHub instance (GHES/GHEC). On github.com this is a harmless no-op.
+          GH_HOST="${GITHUB_SERVER_URL#https://}"
+          GH_HOST="${GH_HOST#http://}"
+          echo "GH_HOST=${GH_HOST}" >> "$GITHUB_ENV"
+      - name: Compute APM credential-group matrix
+        id: compute
+        run: |
+          set -euo pipefail
+          packages_json=${AW_APM_PACKAGES:-null}
+          apps_json=${AW_APM_APPS:-null}
+          legacy_id=${AW_APM_LEGACY_APP_ID:-}
+
+          groups=$(jq -nc \
+            --argjson packages "$packages_json" \
+            --argjson apps "$apps_json" \
+            --arg legacy_id "$legacy_id" \
+            --arg legacy_pk "${AW_APM_LEGACY_PRIVATE_KEY:-}" \
+            --arg legacy_owner "${AW_APM_LEGACY_OWNER:-}" \
+            --arg legacy_repos "${AW_APM_LEGACY_REPOS:-}" \
+            'def slug(s): s | gsub("[^a-zA-Z0-9-]"; "-") | ascii_downcase | .[0:32];
+             def with_id(g):
+               g + (if (g.id // "") == "" then {id: ("auto-" + slug(g.owner // "default"))} else {} end);
+             [
+               (if (($packages // []) | length) > 0 and $legacy_id == ""
+                  then [{id:"default",("app-id"):"",("private-key"):"",owner:"",repositories:"",packages:$packages}]
+                  else [] end),
+               (if $legacy_id != ""
+                  then [with_id({id:"legacy",("app-id"):$legacy_id,("private-key"):$legacy_pk,owner:$legacy_owner,repositories:$legacy_repos,packages:($packages // [])})]
+                  else [] end),
+               (($apps // []) | map(with_id(.)))
+             ] | add // []')
+
+          count=$(echo "$groups" | jq 'length')
+          if [ "$count" = "0" ]; then
+            echo "::error::shared/apm.md import provided no packages. Add packages: <list>, single-app inputs (app-id + private-key), or apps: <list> in the with: block."
+            exit 1
+          fi
+
+          dups=$(echo "$groups" | jq -r '[.[].id] | group_by(.) | map(select(length > 1) | first) | join(", ")')
+          if [ -n "$dups" ]; then
+            echo "::error::duplicate apm group ids after auto-derivation: $dups. Set apps[].id explicitly when two entries share the same owner."
+            exit 1
+          fi
+
+          while IFS= read -r id; do
+            if ! echo "$id" | grep -Eq '^[a-z0-9-]{1,32}$'; then
+              echo "::error::invalid apm group id: '$id' (lowercase alphanumeric and dashes, 1-32 chars). Set apps[].id explicitly."
+              exit 1
+            fi
+          done < <(echo "$groups" | jq -r '.[].id')
+
+          # SAFE: emit only id + package-count to logs. Never $groups in full.
+          {
+            echo "matrix={\"group\":$groups}"
+          } >> "$GITHUB_OUTPUT"
+          printf "::notice::APM matrix: %d credential group(s)\n" "$count"
+          echo "$groups" | jq -r '.[] | "  - " + .id + " (" + (.packages | length | tostring) + " package(s))"'
+        env:
+          AW_APM_APPS: ${{ github.aw.import-inputs.apps }}
+          AW_APM_LEGACY_APP_ID: ${{ github.aw.import-inputs.app-id }}
+          AW_APM_LEGACY_OWNER: ${{ github.aw.import-inputs.owner }}
+          AW_APM_LEGACY_PRIVATE_KEY: ${{ github.aw.import-inputs.private-key }}
+          AW_APM_LEGACY_REPOS: ${{ github.aw.import-inputs.repositories }}
+          AW_APM_PACKAGES: "[microsoft/apm#main]"
 
   conclusion:
     needs:
       - activation
       - agent
       - apm
+      - apm-prep
       - detection
       - safe_outputs
     if: >

--- a/.github/workflows/shared/apm.md
+++ b/.github/workflows/shared/apm.md
@@ -9,12 +9,11 @@
 # declared packages with microsoft/apm-action, and uploads a uniquely-named artifact.
 # Pre-agent-steps then download all bundles and restore them in one apm-action call.
 #
-# STATUS: blocked on upstream microsoft/apm-action gaining a `bundles-file:` input.
-# The matrix restore block in `steps:` below is intentionally commented out until
-# that input ships -- see TODO marker. Until then this workflow does not produce
-# a working agent run; the diff is for design review only.
+# Source of truth: https://github.com/microsoft/apm/blob/main/.github/workflows/shared/apm.md
+# apm-action pin:  microsoft/apm-action@v1.5.0
+# To check whether a vendored copy is current, compare these two lines.
 #
-# Documentation: https://github.com/microsoft/APM
+# Documentation: https://microsoft.github.io/apm/integrations/gh-aw/
 #
 # Three user-facing forms (all valid, additive):
 #

--- a/.github/workflows/triage-panel.lock.yml
+++ b/.github/workflows/triage-panel.lock.yml
@@ -1,5 +1,5 @@
 # gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"1477b4d463ca800dfc0e5e0dee19d03097a122660a33fb4deb2d0e70c129871b","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_PLUGINS_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"},{"repo":"microsoft/apm-action","sha":"9fe9337ef58b5e620e0113071ceb47a6a8a232f7","version":"v1.4.2"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_PLUGINS_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"},{"repo":"microsoft/apm-action","sha":"454b8a1d279376a47df8bb8d525ec076ca0fcef7","version":"v1.5.0"},{"repo":"ruby/setup-ruby","sha":"4c56a21280b36d862b5fc31348f463d60bdc55d5","version":"v1.301.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -37,12 +37,14 @@
 #
 # Custom actions used:
 #   - actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+#   - actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
 #   - github/gh-aw-actions/setup@ba90f2186d7ad780ec640f364005fa24e797b360 # v0.68.3
-#   - microsoft/apm-action@9fe9337ef58b5e620e0113071ceb47a6a8a232f7 # v1.4.2
+#   - microsoft/apm-action@454b8a1d279376a47df8bb8d525ec076ca0fcef7 # v1.5.0
+#   - ruby/setup-ruby@4c56a21280b36d862b5fc31348f463d60bdc55d5 # v1.301.0
 #
 # Container images used:
 #   - ghcr.io/github/gh-aw-firewall/agent:0.25.20
@@ -360,6 +362,7 @@ jobs:
     needs:
       - activation
       - apm
+      - apm-prep
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -404,24 +407,34 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@4c56a21280b36d862b5fc31348f463d60bdc55d5 # v1.301.0
+        with:
+          ruby-version: '3.3'
       - name: Create gh-aw temp directory
         run: bash "${RUNNER_TEMP}/gh-aw/actions/create_gh_aw_tmp_dir.sh"
       - name: Configure gh CLI for GitHub Enterprise
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
-      - name: Download APM bundle artifact
+      - name: Download APM bundle artifacts (all groups)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: ${{ needs.activation.outputs.artifact_prefix }}apm
-          path: /tmp/gh-aw/apm-bundle
-      - id: apm_bundle
-        name: Find APM bundle path
-        run: echo "path=$(find /tmp/gh-aw/apm-bundle -name '*.tar.gz' | head -1)" >> "$GITHUB_OUTPUT"
-      - name: Restore APM packages
-        uses: microsoft/apm-action@9fe9337ef58b5e620e0113071ceb47a6a8a232f7 # v1.4.2
+          merge-multiple: false
+          path: /tmp/gh-aw/apm-bundles
+          pattern: ${{ needs.activation.outputs.artifact_prefix }}apm-*
+      - env:
+          ARTIFACT_PREFIX: ${{ needs.activation.outputs.artifact_prefix }}
+          EXPECTED_MATRIX: ${{ needs.apm-prep.outputs.matrix }}
+        name: Validate downloaded bundles match matrix manifest
+        run: "set -euo pipefail\nexpected=$(echo \"$EXPECTED_MATRIX\" | jq -r --arg prefix \"$ARTIFACT_PREFIX\" '.group | map($prefix + \"apm-\" + .id) | sort | .[]')\nactual=$(ls /tmp/gh-aw/apm-bundles | sort)\nmissing=$(comm -23 <(echo \"$expected\") <(echo \"$actual\") || true)\nunexpected=$(comm -13 <(echo \"$expected\") <(echo \"$actual\") || true)\nif [ -n \"$missing\" ]; then\n  echo \"::error::missing APM bundles (group did not pack successfully): $missing\"\n  exit 1\nfi\nif [ -n \"$unexpected\" ]; then\n  echo \"::error::unexpected artifact in apm bundle download (collision attack?): $unexpected\"\n  exit 1\nfi\n"
+      - id: bundles
+        name: Build bundle list
+        run: "set -euo pipefail\nmapfile -t list < <(find /tmp/gh-aw/apm-bundles -name '*.tar.gz' | sort)\n[ ${#list[@]} -gt 0 ] || { echo '::error::no apm bundles found'; exit 1; }\nprintf '%s\\n' \"${list[@]}\" > /tmp/gh-aw/apm-bundle-list.txt\n"
+      - name: Restore APM packages (all bundles)
+        uses: microsoft/apm-action@454b8a1d279376a47df8bb8d525ec076ca0fcef7 # v1.5.0
         with:
-          bundle: ${{ steps.apm_bundle.outputs.path }}
+          bundles-file: /tmp/gh-aw/apm-bundle-list.txt
 
       - name: Configure Git credentials
         env:
@@ -965,8 +978,13 @@ jobs:
           if-no-files-found: ignore
 
   apm:
-    needs: activation
+    needs:
+      - activation
+      - apm-prep
     runs-on: ubuntu-slim
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.apm-prep.outputs.matrix) }}
     permissions:
       {}
 
@@ -980,25 +998,34 @@ jobs:
           GH_HOST="${GITHUB_SERVER_URL#https://}"
           GH_HOST="${GH_HOST#http://}"
           echo "GH_HOST=${GH_HOST}" >> "$GITHUB_ENV"
-      - name: Prepare APM package list
-        id: apm_prep
+      - name: Mint installation token
+        id: token
+        if: ${{ matrix.group.app-id != '' }}
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ matrix.group.app-id }}
+          owner: ${{ matrix.group.owner != '' && matrix.group.owner || github.repository_owner }}
+          private-key: ${{ matrix.group.private-key }}
+          repositories: ${{ matrix.group.repositories }}
+      - name: Render package list
+        id: list
         run: |
-          DEPS=$(echo "$AW_APM_PACKAGES" | jq -r '.[] | "- " + .')
+          DEPS=$(echo "$AW_PKG" | jq -r '.[] | "- " + .')
           {
             echo "deps<<APMDEPS"
             printf '%s\n' "$DEPS"
             echo "APMDEPS"
           } >> "$GITHUB_OUTPUT"
         env:
-          AW_APM_PACKAGES: "[\"microsoft/apm#main\"]"
+          AW_PKG: ${{ toJSON(matrix.group.packages) }}
       - name: Pack APM packages
-        id: apm_pack
-        uses: microsoft/apm-action@9fe9337ef58b5e620e0113071ceb47a6a8a232f7 # v1.4.2
+        id: pack
+        uses: microsoft/apm-action@454b8a1d279376a47df8bb8d525ec076ca0fcef7 # v1.5.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_AW_PLUGINS_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.token.outputs.token || secrets.GH_AW_PLUGINS_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         with:
           archive: "true"
-          dependencies: ${{ steps.apm_prep.outputs.deps }}
+          dependencies: ${{ steps.list.outputs.deps }}
           isolated: "true"
           pack: "true"
           target: all
@@ -1007,15 +1034,95 @@ jobs:
         if: success()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ${{ needs.activation.outputs.artifact_prefix }}apm
-          path: ${{ steps.apm_pack.outputs.bundle-path }}
+          name: ${{ needs.activation.outputs.artifact_prefix }}apm-${{ matrix.group.id }}
+          path: ${{ steps.pack.outputs.bundle-path }}
           retention-days: "1"
+
+  apm-prep:
+    needs: activation
+    runs-on: ubuntu-slim
+    permissions:
+      {}
+
+    outputs:
+      matrix: ${{ steps.compute.outputs.matrix }}
+    steps:
+      - name: Configure GH_HOST for enterprise compatibility
+        id: ghes-host-config
+        shell: bash
+        run: |
+          # Derive GH_HOST from GITHUB_SERVER_URL so the gh CLI targets the correct
+          # GitHub instance (GHES/GHEC). On github.com this is a harmless no-op.
+          GH_HOST="${GITHUB_SERVER_URL#https://}"
+          GH_HOST="${GH_HOST#http://}"
+          echo "GH_HOST=${GH_HOST}" >> "$GITHUB_ENV"
+      - name: Compute APM credential-group matrix
+        id: compute
+        run: |
+          set -euo pipefail
+          packages_json=${AW_APM_PACKAGES:-null}
+          apps_json=${AW_APM_APPS:-null}
+          legacy_id=${AW_APM_LEGACY_APP_ID:-}
+
+          groups=$(jq -nc \
+            --argjson packages "$packages_json" \
+            --argjson apps "$apps_json" \
+            --arg legacy_id "$legacy_id" \
+            --arg legacy_pk "${AW_APM_LEGACY_PRIVATE_KEY:-}" \
+            --arg legacy_owner "${AW_APM_LEGACY_OWNER:-}" \
+            --arg legacy_repos "${AW_APM_LEGACY_REPOS:-}" \
+            'def slug(s): s | gsub("[^a-zA-Z0-9-]"; "-") | ascii_downcase | .[0:32];
+             def with_id(g):
+               g + (if (g.id // "") == "" then {id: ("auto-" + slug(g.owner // "default"))} else {} end);
+             [
+               (if (($packages // []) | length) > 0 and $legacy_id == ""
+                  then [{id:"default",("app-id"):"",("private-key"):"",owner:"",repositories:"",packages:$packages}]
+                  else [] end),
+               (if $legacy_id != ""
+                  then [with_id({id:"legacy",("app-id"):$legacy_id,("private-key"):$legacy_pk,owner:$legacy_owner,repositories:$legacy_repos,packages:($packages // [])})]
+                  else [] end),
+               (($apps // []) | map(with_id(.)))
+             ] | add // []')
+
+          count=$(echo "$groups" | jq 'length')
+          if [ "$count" = "0" ]; then
+            echo "::error::shared/apm.md import provided no packages. Add packages: <list>, single-app inputs (app-id + private-key), or apps: <list> in the with: block."
+            exit 1
+          fi
+
+          dups=$(echo "$groups" | jq -r '[.[].id] | group_by(.) | map(select(length > 1) | first) | join(", ")')
+          if [ -n "$dups" ]; then
+            echo "::error::duplicate apm group ids after auto-derivation: $dups. Set apps[].id explicitly when two entries share the same owner."
+            exit 1
+          fi
+
+          while IFS= read -r id; do
+            if ! echo "$id" | grep -Eq '^[a-z0-9-]{1,32}$'; then
+              echo "::error::invalid apm group id: '$id' (lowercase alphanumeric and dashes, 1-32 chars). Set apps[].id explicitly."
+              exit 1
+            fi
+          done < <(echo "$groups" | jq -r '.[].id')
+
+          # SAFE: emit only id + package-count to logs. Never $groups in full.
+          {
+            echo "matrix={\"group\":$groups}"
+          } >> "$GITHUB_OUTPUT"
+          printf "::notice::APM matrix: %d credential group(s)\n" "$count"
+          echo "$groups" | jq -r '.[] | "  - " + .id + " (" + (.packages | length | tostring) + " package(s))"'
+        env:
+          AW_APM_APPS: ${{ github.aw.import-inputs.apps }}
+          AW_APM_LEGACY_APP_ID: ${{ github.aw.import-inputs.app-id }}
+          AW_APM_LEGACY_OWNER: ${{ github.aw.import-inputs.owner }}
+          AW_APM_LEGACY_PRIVATE_KEY: ${{ github.aw.import-inputs.private-key }}
+          AW_APM_LEGACY_REPOS: ${{ github.aw.import-inputs.repositories }}
+          AW_APM_PACKAGES: "[microsoft/apm#main]"
 
   conclusion:
     needs:
       - activation
       - agent
       - apm
+      - apm-prep
       - detection
       - safe_outputs
     if: >

--- a/docs/src/content/docs/integrations/gh-aw.md
+++ b/docs/src/content/docs/integrations/gh-aw.md
@@ -71,6 +71,20 @@ Packages are fetched using gh-aw's cascading token fallback: `GH_AW_PLUGINS_TOKE
 Earlier gh-aw versions accepted a top-level `dependencies:` field on the workflow. That form is deprecated and no longer supported -- migrate to the `imports: - uses: shared/apm.md` pattern shown above.
 :::
 
+:::tip[Vendor the canonical `shared/apm.md`]
+`shared/apm.md` is a **local file** that gh-aw resolves at `.github/workflows/shared/apm.md` in your repository -- not a remote import. Two copies exist in the wild: one in [microsoft/apm](https://github.com/microsoft/apm/blob/main/.github/workflows/shared/apm.md) (canonical, current) and one in [github/gh-aw](https://github.com/github/gh-aw/blob/main/.github/workflows/shared/apm.md) (vendored, may lag).
+
+To get the canonical version with multi-org GitHub App auth (`apps:`) and multi-bundle restore:
+
+```bash
+mkdir -p .github/workflows/shared
+curl -sSL https://raw.githubusercontent.com/microsoft/apm/main/.github/workflows/shared/apm.md \
+  > .github/workflows/shared/apm.md
+```
+
+Check whether your vendored copy is current by comparing the `Source of truth:` and `apm-action pin:` lines near the top of the file with the canonical copy linked above.
+:::
+
 ### apm-action Pre-Step
 
 For more control over the installation process, use [`microsoft/apm-action@v1`](https://github.com/microsoft/apm-action) as an explicit workflow step. This approach runs `apm install` directly, giving you access to the full APM CLI. To also compile, add `compile: true` to the action configuration.


### PR DESCRIPTION
## Why

apm-action v1.5.0 shipped (#984 → microsoft/apm-action#30) with the `bundles-file:` input that #982's matrix fan-out depends on. PR #982 merged correctly in source but left two artifacts stale:

1. `shared/apm.md` carried a `STATUS: blocked` docstring saying "this workflow does not produce a working agent run; the diff is for design review only." The body has since been wired to v1.5.0 + `bundles-file:` for real, but the banner was never updated. Anyone reading `head -20 shared/apm.md` today gets misleading info.
2. `pr-review-panel.lock.yml` + `triage-panel.lock.yml` were not regenerated, so they still SHA-pin `microsoft/apm-action@v1.4.2` with the old single-`bundle:` restore. Runtime executes v1.4.2 logic against a workflow source that says v1.5.0. This is a real drift, not cosmetic.

## What this PR does

- **Drops the stale STATUS banner** in `shared/apm.md`.
- **Adds a 2-line version header** so vendored copies are self-diagnosing:
  ```
  # Source of truth: https://github.com/microsoft/apm/blob/main/.github/workflows/shared/apm.md
  # apm-action pin:  microsoft/apm-action@v1.5.0
  ```
  Anyone who `head -3`s the file now knows whether their copy is current.
- **Recompiles the lock files** via `gh aw compile`. Both `pr-review-panel.lock.yml` and `triage-panel.lock.yml` now pin `apm-action@454b8a1d` (v1.5.0) and use the new matrix-aware restore (apm-prep job, multi-bundle download, bundles-file build, validation against expected matrix). `agentics-maintenance.yml` got SHA pin tightening only — no behavior change.
- **Adds a docs callout** to `integrations/gh-aw.md` ("Vendor the canonical `shared/apm.md`") explaining `shared/apm.md` is a local file with two competing copies in the wild, with a `curl` command to fetch the canonical microsoft/apm version. This is the user-facing surface we own regardless of what gh-aw does upstream.

## Why now

The next gh-aw panel run on a labelled PR/issue would have used the v1.4.2 SHA (because that's what the lock file pinned), masking the v1.5.0 capabilities #982 was supposed to enable. Catching this BEFORE we tell the world about v1.5.0 / before any external user finds the apparent contradiction.

## Validation

- `gh aw compile` clean (1 unrelated warning about `push-to-pull-request-branch` target).
- Both lock files now reference `microsoft/apm-action@454b8a1d279376a47df8bb8d525ec076ca0fcef7 # v1.5.0`.
- The `Restore APM packages (all bundles)` step in both lock files now uses `bundles-file: /tmp/gh-aw/apm-bundle-list.txt` instead of the old single `bundle:` parameter.
- Smoke test will land when this PR's own checks invoke `pr-review-panel.lock.yml` against itself (eats own dogfood).

## Out of scope

- gh-aw upstream coordination (their copy at `github/gh-aw/.github/workflows/shared/apm.md` is still pinned to v1.4.2 with the deprecated `dependencies:` shape). Tracking separately — talk-first, then issue.

