### PR TITLE
fix(marketplace): `add` honors manifest.name for Claude Code parity

### DIFF
--- a/src/apm_cli/commands/marketplace.py
+++ b/src/apm_cli/commands/marketplace.py
@@ -7,6 +7,7 @@ Click group pattern as ``mcp.py``.
 import builtins
 import json
 import os
+import re
 import subprocess
 import sys
 import traceback
@@ -42,6 +43,16 @@ from ..marketplace.yml_schema import load_marketplace_yml
 from ..utils.path_security import PathTraversalError, validate_path_segments
 from ..utils.console import _rich_info, _rich_warning
 from ._helpers import _get_console, _is_interactive
+
+
+# Marketplace alias must satisfy this pattern so it can appear on the right of
+# ``@`` in ``apm install <plugin>@<marketplace>`` syntax.
+_ALIAS_PATTERN = re.compile(r"^[a-zA-Z0-9._-]+$")
+
+
+def _is_valid_alias(value: str) -> bool:
+    """Return True when ``value`` is a legal marketplace alias."""
+    return bool(value) and _ALIAS_PATTERN.match(value) is not None
 
 
 # ---------------------------------------------------------------------------
@@ -336,28 +347,22 @@ def add(repo, name, branch, host, verbose):
             resolved_host = normalized_host
         else:
             resolved_host = default_host()
-        display_name = name or repo_name
 
-        # Validate name is identifier-compatible for NAME@MARKETPLACE syntax
-        import re
-
-        if not re.match(r"^[a-zA-Z0-9._-]+$", display_name):
+        # Hard-fail if the user-supplied --name flag is malformed; the
+        # manifest's name is validated softly below (publisher mistakes
+        # shouldn't break a successful add).
+        if name is not None and not _is_valid_alias(name):
             logger.error(
-                f"Invalid marketplace name: '{display_name}'. "
+                f"Invalid marketplace name: '{name}'. "
                 f"Names must only contain letters, digits, '.', '_', and '-' "
                 f"(required for 'apm install plugin@marketplace' syntax)."
             )
             sys.exit(1)
 
-        logger.start(f"Registering marketplace '{display_name}'...", symbol="gear")
-        logger.verbose_detail(f"    Repository: {owner}/{repo_name}")
-        logger.verbose_detail(f"    Branch: {branch}")
-        if resolved_host != "github.com":
-            logger.verbose_detail(f"    Host: {resolved_host}")
-
-        # Auto-detect marketplace.json location
+        # Probe for the marketplace.json location. The probe source's name
+        # is a placeholder -- _auto_detect_path only consults host/owner/repo.
         probe_source = MarketplaceSource(
-            name=display_name,
+            name=name or repo_name,
             owner=owner,
             repo=repo_name,
             branch=branch,
@@ -373,9 +378,56 @@ def add(repo, name, branch, host, verbose):
             )
             sys.exit(1)
 
-        logger.verbose_detail(f"    Detected path: {detected_path}")
+        # Fetch and validate the manifest before logging start, so that the
+        # success/start lines display the *final* alias the user must use.
+        fetch_source = MarketplaceSource(
+            name=name or repo_name,
+            owner=owner,
+            repo=repo_name,
+            branch=branch,
+            host=resolved_host,
+            path=detected_path,
+        )
+        manifest = fetch_marketplace(fetch_source, force_refresh=True)
+        plugin_count = len(manifest.plugins)
 
-        # Create source with detected path
+        # Resolve final alias: --name flag > manifest.name (if valid) > repo name.
+        # Track which tier won so we can report it in verbose mode and emit a
+        # warning when a publisher-declared name had to be rejected.
+        manifest_name = (manifest.name or "").strip()
+        if name is not None:
+            display_name = name
+            alias_source = "--name flag"
+        elif manifest_name and _is_valid_alias(manifest_name):
+            display_name = manifest_name
+            alias_source = f"manifest.name ('{manifest_name}')"
+        else:
+            display_name = repo_name
+            if manifest_name and not _is_valid_alias(manifest_name):
+                logger.warning(
+                    f"Manifest declares name '{manifest_name}' which is not a "
+                    f"valid alias (must match [a-zA-Z0-9._-]+). "
+                    f"Falling back to repo name."
+                )
+                alias_source = f"repo name (manifest.name '{manifest_name}' invalid)"
+            else:
+                alias_source = "repo name (manifest.name missing)"
+
+        # Defense-in-depth: repo names from GitHub already satisfy the alias
+        # regex, so this invariant should always hold by the time we register.
+        assert _is_valid_alias(display_name), (
+            f"Resolved marketplace alias '{display_name}' failed validation"
+        )
+
+        logger.start(f"Registering marketplace '{display_name}'...", symbol="gear")
+        logger.verbose_detail(f"    Repository: {owner}/{repo_name}")
+        logger.verbose_detail(f"    Branch: {branch}")
+        if resolved_host != "github.com":
+            logger.verbose_detail(f"    Host: {resolved_host}")
+        logger.verbose_detail(f"    Detected path: {detected_path}")
+        logger.verbose_detail(f"    Alias source: {alias_source}")
+
+        # Persist with the final alias.
         source = MarketplaceSource(
             name=display_name,
             owner=owner,
@@ -384,12 +436,6 @@ def add(repo, name, branch, host, verbose):
             host=resolved_host,
             path=detected_path,
         )
-
-        # Fetch and validate
-        manifest = fetch_marketplace(source, force_refresh=True)
-        plugin_count = len(manifest.plugins)
-
-        # Register
         add_marketplace(source)
 
         logger.success(
@@ -398,6 +444,14 @@ def add(repo, name, branch, host, verbose):
         )
         if manifest.description:
             logger.verbose_detail(f"    {manifest.description}")
+
+        # Surface the install syntax only when the alias is something the user
+        # could not have predicted from OWNER/REPO. Silence is fine otherwise.
+        if name is None and display_name != repo_name:
+            logger.progress(
+                f"Install plugins with: apm install <plugin>@{display_name}",
+                symbol="info",
+            )
 
     except Exception as e:  # noqa: BLE001 -- top-level command catch-all
         logger.error(f"Failed to register marketplace: {e}")

--- a/tests/unit/marketplace/test_marketplace_commands.py
+++ b/tests/unit/marketplace/test_marketplace_commands.py
@@ -38,6 +38,154 @@ class TestMarketplaceAdd:
         assert result.exit_code != 0
         assert "OWNER/REPO" in result.output
 
+    @patch("apm_cli.marketplace.registry.add_marketplace")
+    @patch("apm_cli.marketplace.client.fetch_marketplace")
+    @patch("apm_cli.marketplace.client._auto_detect_path")
+    def test_add_uses_manifest_name_when_available(
+        self, mock_detect, mock_fetch, mock_add, runner
+    ):
+        """Manifest's `name` field becomes the registered alias."""
+        from apm_cli.commands.marketplace import marketplace
+
+        mock_detect.return_value = ".claude-plugin/marketplace.json"
+        mock_fetch.return_value = MarketplaceManifest(
+            name="addy-agent-skills",
+            plugins=(MarketplacePlugin(name="agent-skills"),),
+        )
+
+        result = runner.invoke(marketplace, ["add", "addyosmani/agent-skills"])
+        assert result.exit_code == 0
+        # Registered source carries the manifest's name, not the repo name.
+        registered_source = mock_add.call_args[0][0]
+        assert registered_source.name == "addy-agent-skills"
+        assert registered_source.repo == "agent-skills"
+        # Install hint surfaces the alias the user must use next.
+        assert "apm install <plugin>@addy-agent-skills" in result.output
+
+    @patch("apm_cli.marketplace.registry.add_marketplace")
+    @patch("apm_cli.marketplace.client.fetch_marketplace")
+    @patch("apm_cli.marketplace.client._auto_detect_path")
+    def test_add_cli_name_overrides_manifest(
+        self, mock_detect, mock_fetch, mock_add, runner
+    ):
+        """An explicit --name flag wins over the manifest's name."""
+        from apm_cli.commands.marketplace import marketplace
+
+        mock_detect.return_value = "marketplace.json"
+        mock_fetch.return_value = MarketplaceManifest(
+            name="manifest-alias",
+            plugins=(MarketplacePlugin(name="p1"),),
+        )
+
+        result = runner.invoke(
+            marketplace, ["add", "acme/plugins", "--name", "custom-alias"]
+        )
+        assert result.exit_code == 0
+        registered_source = mock_add.call_args[0][0]
+        assert registered_source.name == "custom-alias"
+        # No install hint when the user explicitly chose the alias.
+        assert "Install plugins with" not in result.output
+
+    @patch("apm_cli.marketplace.registry.add_marketplace")
+    @patch("apm_cli.marketplace.client.fetch_marketplace")
+    @patch("apm_cli.marketplace.client._auto_detect_path")
+    def test_add_falls_back_when_manifest_name_invalid(
+        self, mock_detect, mock_fetch, mock_add, runner
+    ):
+        """Invalid manifest.name triggers a soft fallback to the repo name."""
+        from apm_cli.commands.marketplace import marketplace
+
+        mock_detect.return_value = "marketplace.json"
+        mock_fetch.return_value = MarketplaceManifest(
+            name="has spaces!",
+            plugins=(MarketplacePlugin(name="p1"),),
+        )
+
+        result = runner.invoke(marketplace, ["add", "acme/plugins"])
+        # Soft fallback: the command still succeeds.
+        assert result.exit_code == 0
+        registered_source = mock_add.call_args[0][0]
+        assert registered_source.name == "plugins"
+        # User sees a warning quoting the offending value.
+        assert "has spaces!" in result.output
+        assert "Falling back to repo name" in result.output
+
+    @patch("apm_cli.marketplace.registry.add_marketplace")
+    @patch("apm_cli.marketplace.client.fetch_marketplace")
+    @patch("apm_cli.marketplace.client._auto_detect_path")
+    def test_add_falls_back_when_manifest_name_missing(
+        self, mock_detect, mock_fetch, mock_add, runner
+    ):
+        """Empty manifest.name silently falls back to the repo name."""
+        from apm_cli.commands.marketplace import marketplace
+
+        mock_detect.return_value = "marketplace.json"
+        mock_fetch.return_value = MarketplaceManifest(
+            name="",
+            plugins=(MarketplacePlugin(name="p1"),),
+        )
+
+        result = runner.invoke(marketplace, ["add", "acme/plugins"])
+        assert result.exit_code == 0
+        registered_source = mock_add.call_args[0][0]
+        assert registered_source.name == "plugins"
+        # No warning when the publisher simply omitted the field.
+        assert "Falling back" not in result.output
+        # No install hint either: alias matches the repo name -- predictable.
+        assert "Install plugins with" not in result.output
+
+    def test_add_rejects_invalid_cli_name(self, runner):
+        """An invalid --name flag is a user error and hard-fails."""
+        from apm_cli.commands.marketplace import marketplace
+
+        result = runner.invoke(
+            marketplace, ["add", "acme/plugins", "--name", "bad name"]
+        )
+        assert result.exit_code != 0
+        assert "Invalid marketplace name" in result.output
+
+    @patch("apm_cli.marketplace.registry.add_marketplace")
+    @patch("apm_cli.marketplace.client.fetch_marketplace")
+    @patch("apm_cli.marketplace.client._auto_detect_path")
+    def test_add_awesome_copilot_pattern_unchanged(
+        self, mock_detect, mock_fetch, mock_add, runner
+    ):
+        """Regression: github/awesome-copilot manifest name == repo name -> no behaviour change."""
+        from apm_cli.commands.marketplace import marketplace
+
+        mock_detect.return_value = ".github/plugin/marketplace.json"
+        mock_fetch.return_value = MarketplaceManifest(
+            name="awesome-copilot",
+            plugins=(MarketplacePlugin(name="azure-cloud-development"),),
+        )
+
+        result = runner.invoke(marketplace, ["add", "github/awesome-copilot"])
+        assert result.exit_code == 0
+        registered_source = mock_add.call_args[0][0]
+        assert registered_source.name == "awesome-copilot"
+        # Alias matches the repo name, so the install hint is suppressed.
+        assert "Install plugins with" not in result.output
+
+    @patch("apm_cli.marketplace.client.fetch_marketplace")
+    @patch("apm_cli.marketplace.client._auto_detect_path")
+    def test_add_verbose_shows_alias_source(
+        self, mock_detect, mock_fetch, runner
+    ):
+        """Verbose mode reports which precedence tier picked the alias."""
+        from apm_cli.commands.marketplace import marketplace
+
+        mock_detect.return_value = "marketplace.json"
+        mock_fetch.return_value = MarketplaceManifest(
+            name="acme-tools",
+            plugins=(MarketplacePlugin(name="p1"),),
+        )
+
+        result = runner.invoke(
+            marketplace, ["add", "acme/plugins", "--verbose"]
+        )
+        assert result.exit_code == 0
+        assert "Alias source: manifest.name" in result.output
+
     @patch("apm_cli.marketplace.client.fetch_marketplace")
     @patch("apm_cli.marketplace.client._auto_detect_path")
     def test_successful_add(self, mock_detect, mock_fetch, runner):


### PR DESCRIPTION
## TL;DR

`apm marketplace add` now defaults the local alias to the `name` field declared inside the fetched `marketplace.json`, falling back to the repo name only when the manifest omits it (or declares something invalid). This restores verbatim portability with Claude Code install instructions — `addyosmani/agent-skills` now registers as `addy-agent-skills`, exactly as that repo's README documents — and is a no-op for `github/awesome-copilot` (manifest name == repo name).

## Problem (WHY)

The marketplace.json spec, originated by Claude Code, treats the manifest's top-level `name` as **the** canonical alias. APM was the only consumer that ignored it.

- **Reproducer.** `addyosmani/agent-skills` ships `.claude-plugin/marketplace.json` with `"name": "addy-agent-skills"`. Claude Code's `/plugin install agent-skills@addy-agent-skills` works; APM forced `agent-skills@agent-skills` (repo name). Addy's published install command was therefore broken under APM.
- **Code path.** `add` in `src/apm_cli/commands/marketplace.py` computed `display_name = name or repo_name` *before* fetching the manifest, then fetched and discarded `manifest.name`.
- **Spec alignment.** The Claude Code marketplace format documents `name` as a required, identifying field of the marketplace itself ([source: marketplace.json reference](https://docs.anthropic.com/en/docs/claude-code/plugin-marketplaces)).
- **Surface area.** `MarketplaceManifest` already parses `name` from JSON; the data is there, just unused.
- **Blast radius.** Every Claude-Code-authored marketplace whose `name` differs from its repo name produces a different alias under APM than under any other tool. Users hit this immediately, on the very next command (`apm install <plugin>@<alias>`).

> [!NOTE]
> This only affects newly-added marketplaces. Existing entries in `~/.apm/marketplaces.json` are untouched; users who already added a marketplace keep their alias.

## Approach (WHAT)

| Tier | Source of alias | Behaviour on invalid value |
|---|---|---|
| 1 | `--name` flag | Hard-fail with the existing error |
| 2 | `manifest.name` (after fetch) | Soft-fallback to tier 3 + yellow warning |
| 3 | Repo name | (Always valid by GitHub naming rules) |

Restructured `add` so that `fetch_marketplace` runs *before* the alias is finalized and before `logger.start` prints the headline. The probe source for `_auto_detect_path` keeps a placeholder name (it only consults host/owner/repo).

## Implementation (HOW)

| File | Change |
|---|---|
| `src/apm_cli/commands/marketplace.py` | New `_is_valid_alias` helper (single regex, single call site). `add`: hard-validate `--name` early; build probe source with placeholder name; fetch manifest; resolve `display_name` via 3-tier precedence; print headline + verbose `Alias source:` line; emit install hint only when alias differs from repo name *and* user did not pass `--name`. |
| `tests/unit/marketplace/test_marketplace_commands.py` | 7 new tests covering each precedence tier, the awesome-copilot regression case, the verbose `Alias source` trace, and `--name` rejection. |

> [!TIP]
> The `_is_valid_alias` helper stays inlined in `marketplace.py` rather than promoted to `utils/`. Per the python-architect persona's "abstract when 3+ call sites" rule, single call site = no extraction.

## Diagram

Resolution flow for `display_name` after the fix:

```mermaid
flowchart TD
  A["apm marketplace add OWNER/REPO [--name X]"] --> B{--name passed?}
  B -- yes --> C{_is_valid_alias?}
  C -- no --> Z1[hard-fail: invalid CLI name]
  C -- yes --> D[display_name = X]
  B -- no --> E[fetch_marketplace]
  E --> F{manifest.name set?}
  F -- no --> G[display_name = repo_name]
  F -- yes --> H{_is_valid_alias?}
  H -- yes --> I["display_name = manifest.name"]
  H -- no --> J["warn + display_name = repo_name"]
  D --> K[register + verbose 'Alias source' line]
  G --> K
  I --> K
  J --> K
  K --> L{alias != repo_name AND --name not used?}
  L -- yes --> M["info hint: apm install <plugin>@<alias>"]
  L -- no --> N[done]
```

## Trade-offs

- **Soft-fail vs hard-fail on invalid `manifest.name`.** Chose soft-fail because the user typed a valid `OWNER/REPO`; punishing them for a publisher mistake would block the install entirely. The yellow warning quotes the offending value so the publisher (often the same person reading) can fix it.
- **Behaviour change for unpinned scripts.** Any automation that re-runs `apm marketplace add X/Y` and assumed the alias would be `Y` will pick up a different alias if `Y`'s manifest declares one. Mitigation: `--name` is the explicit escape hatch; documented in the commit body.
- **Help text on `--name` left as `(defaults to repo name)`.** Strictly the default is now `manifest.name or repo_name`. Updating help text was deferred to keep the patch minimal and to avoid relitigating the option's docstring; the verbose `Alias source:` line surfaces the actual resolution.
- **Single extra `MarketplaceSource` construction** (frozen dataclass, cheap) preferred over plumbing a mutable name through the probe path.

## Validation

Live smoke test against the two real-world marketplaces — Addy's repo (different manifest name) and awesome-copilot (same manifest name as repo):

<details><summary>Default mode</summary>

```
$ apm marketplace add addyosmani/agent-skills
[*] Registering marketplace 'addy-agent-skills'...
[+] Marketplace 'addy-agent-skills' registered (1 plugins)
[i] Install plugins with: apm install <plugin>@addy-agent-skills

$ apm marketplace add github/awesome-copilot
[*] Registering marketplace 'awesome-copilot'...
[+] Marketplace 'awesome-copilot' registered (73 plugins)
```
</details>

<details><summary>Verbose mode (Addy's repo)</summary>

```
[*] Registering marketplace 'addy-agent-skills'...
    Repository: addyosmani/agent-skills
    Branch: main
    Detected path: .claude-plugin/marketplace.json
    Alias source: manifest.name ('addy-agent-skills')
[+] Marketplace 'addy-agent-skills' registered (1 plugins)
[i] Install plugins with: apm install <plugin>@addy-agent-skills
```
</details>

<details><summary>Browse confirms parity with Claude Code install syntax</summary>

```
$ apm marketplace browse addy-agent-skills
...
| agent-skills | ... | -- | agent-skills@addy-agent-skills |
[i] Install a plugin: apm install <plugin-name>@addy-agent-skills
```
</details>

Test suite — full marketplace surface, 0 regressions, 7 new tests:

```
$ pytest tests/unit/marketplace/ tests/unit/commands/test_marketplace_plugin.py \
         tests/integration/test_marketplace_e2e.py -q
827 passed, 1 skipped in 10.35s
```

## How to test

- [ ] `apm marketplace add addyosmani/agent-skills` — registers as `addy-agent-skills`; hint shows the new alias.
- [ ] `apm marketplace add github/awesome-copilot` — registers as `awesome-copilot`; no hint (alias == repo name).
- [ ] `apm marketplace add OWNER/REPO --name foo` — registers as `foo`; no hint regardless of manifest.
- [ ] `apm marketplace add OWNER/REPO --name "bad name"` — hard-fails with the existing `Invalid marketplace name` error.
- [ ] `apm marketplace add addyosmani/agent-skills -v` — verbose output includes `Alias source: manifest.name ('addy-agent-skills')`.
- [ ] After (1), `apm install agent-skills@addy-agent-skills` succeeds — verbatim copy of Addy's README install command.
