### PR TITLE
fix(shared/apm): repair gh-aw `[a b]` import-input serialization that breaks apm-prep

### DIFF
--- a/.github/workflows/pr-review-panel.lock.yml
+++ b/.github/workflows/pr-review-panel.lock.yml
@@ -1019,6 +1019,26 @@ jobs:
           apps_json=${AW_APM_APPS:-null}
           legacy_id=${AW_APM_LEGACY_APP_ID:-}
 
+          # gh-aw substitutes `["microsoft/apm#main"]` at
+          # compile time using Go's default slice formatter, which emits
+          # `[a b c]` (space-separated, no quotes) instead of valid JSON.
+          # That breaks `jq --argjson` below. Repair string-array inputs
+          # in place; leave already-valid JSON untouched. apps[] (objects)
+          # is not repairable this way -- consumers must use the legacy
+          # single-app inputs until upstream gh-aw exposes a JSON-encoding
+          # helper for import-inputs.
+          repair_string_array() {
+            local raw="$1"
+            if [ -z "$raw" ] || [ "$raw" = "null" ]; then
+              echo "$raw"; return
+            fi
+            if printf '%s' "$raw" | jq -e 'type=="array"' >/dev/null 2>&1; then
+              echo "$raw"; return
+            fi
+            python3 -c 'import json, re, sys; s=sys.argv[1].strip(); s=s[1:-1] if s.startswith("[") and s.endswith("]") else s; print(json.dumps([t for t in re.split(r"[\s,]+", s) if t]))' "$raw"
+          }
+          packages_json=$(repair_string_array "$packages_json")
+
           groups=$(jq -nc \
             --argjson packages "$packages_json" \
             --argjson apps "$apps_json" \

--- a/.github/workflows/shared/apm.md
+++ b/.github/workflows/shared/apm.md
@@ -158,6 +158,26 @@ jobs:
           apps_json=${AW_APM_APPS:-null}
           legacy_id=${AW_APM_LEGACY_APP_ID:-}
 
+          # gh-aw substitutes `${{ github.aw.import-inputs.packages }}` at
+          # compile time using Go's default slice formatter, which emits
+          # `[a b c]` (space-separated, no quotes) instead of valid JSON.
+          # That breaks `jq --argjson` below. Repair string-array inputs
+          # in place; leave already-valid JSON untouched. apps[] (objects)
+          # is not repairable this way -- consumers must use the legacy
+          # single-app inputs until upstream gh-aw exposes a JSON-encoding
+          # helper for import-inputs.
+          repair_string_array() {
+            local raw="$1"
+            if [ -z "$raw" ] || [ "$raw" = "null" ]; then
+              echo "$raw"; return
+            fi
+            if printf '%s' "$raw" | jq -e 'type=="array"' >/dev/null 2>&1; then
+              echo "$raw"; return
+            fi
+            python3 -c 'import json, re, sys; s=sys.argv[1].strip(); s=s[1:-1] if s.startswith("[") and s.endswith("]") else s; print(json.dumps([t for t in re.split(r"[\s,]+", s) if t]))' "$raw"
+          }
+          packages_json=$(repair_string_array "$packages_json")
+
           groups=$(jq -nc \
             --argjson packages "$packages_json" \
             --argjson apps "$apps_json" \

--- a/.github/workflows/triage-panel.lock.yml
+++ b/.github/workflows/triage-panel.lock.yml
@@ -1067,6 +1067,26 @@ jobs:
           apps_json=${AW_APM_APPS:-null}
           legacy_id=${AW_APM_LEGACY_APP_ID:-}
 
+          # gh-aw substitutes `["microsoft/apm#main"]` at
+          # compile time using Go's default slice formatter, which emits
+          # `[a b c]` (space-separated, no quotes) instead of valid JSON.
+          # That breaks `jq --argjson` below. Repair string-array inputs
+          # in place; leave already-valid JSON untouched. apps[] (objects)
+          # is not repairable this way -- consumers must use the legacy
+          # single-app inputs until upstream gh-aw exposes a JSON-encoding
+          # helper for import-inputs.
+          repair_string_array() {
+            local raw="$1"
+            if [ -z "$raw" ] || [ "$raw" = "null" ]; then
+              echo "$raw"; return
+            fi
+            if printf '%s' "$raw" | jq -e 'type=="array"' >/dev/null 2>&1; then
+              echo "$raw"; return
+            fi
+            python3 -c 'import json, re, sys; s=sys.argv[1].strip(); s=s[1:-1] if s.startswith("[") and s.endswith("]") else s; print(json.dumps([t for t in re.split(r"[\s,]+", s) if t]))' "$raw"
+          }
+          packages_json=$(repair_string_array "$packages_json")
+
           groups=$(jq -nc \
             --argjson packages "$packages_json" \
             --argjson apps "$apps_json" \


### PR DESCRIPTION
## TL;DR

PR #982's new `Compute APM credential-group matrix` step in `shared/apm.md` feeds `${{ github.aw.import-inputs.packages }}` to `jq --argjson`. gh-aw substitutes that template at compile time using Go's default slice formatter, which emits `[microsoft/apm#main]` (space-separated, no quotes) instead of valid JSON. `jq` rejects it and `apm-prep` crashes, blocking every `pr-review-panel` and `triage-panel` run since lock files were last regenerated.

This PR adds a small repair shim in `shared/apm.md` and recompiles both lock files. Upstream paper-cut filed at github/gh-aw#29076.

## How we got here

| Date | PR | What happened |
|---|---|---|
| 2026-04-28 | #982 | Added `apm-prep` step using `--argjson`; locks **not** regenerated, bug latent |
| 2026-04-28 | #1026 | Recompiled locks to v1.5.0; surfaced bug -- locks now contain `AW_APM_PACKAGES: "[microsoft/apm#main]"` |
| 2026-04-29 | (today) | First failing run observed on PR #1031: `jq: invalid JSON text passed to --argjson` |

Pinning gh-aw doesn't help: same compiler version (v0.68.3) produced both shapes -- the difference was that #982 introduced the new compute step that started routing the substituted value through `--argjson`. The bug is in our `shared/apm.md`, not in the gh-aw binary -- though the upstream serializer choice is what makes the bug possible (hence github/gh-aw#29076).

## What changed

```
.github/workflows/shared/apm.md            | 20 ++++++++++++++++++++
.github/workflows/pr-review-panel.lock.yml | 20 ++++++++++++++++++++
.github/workflows/triage-panel.lock.yml    | 20 ++++++++++++++++++++
```

`shared/apm.md` gains a tiny `repair_string_array` Bash+Python helper that:

- passes `null` and empty values through untouched,
- passes already-valid JSON (`jq -e 'type=="array"'`) through untouched,
- otherwise strips outer brackets, splits on whitespace/commas, and re-emits as JSON.

The two consumer lock files are regenerated with `gh aw compile pr-review-panel triage-panel`. No source change to either `pr-review-panel.md` or `triage-panel.md`.

`apps[]` (object arrays) is **not** repairable this way -- the Go-slice format for objects is `[map[k:v] map[k:v]]` and is non-trivially round-trippable. No current workflow uses `apps[]` via import-inputs (only the legacy single-app inputs are exercised), so this PR leaves apps alone with a comment pointing at the upstream issue.

## Verification

End-to-end simulation against the live `shared/apm.md` run-block:

| Input `AW_APM_PACKAGES` | Resulting `matrix.group.packages` |
|---|---|
| `[microsoft/apm#main]` | `["microsoft/apm#main"]` |
| `[microsoft/apm#main github/awesome-copilot/skills/foo]` | `["microsoft/apm#main","github/awesome-copilot/skills/foo"]` |
| `["already","json"]` | `["already","json"]` |
| `null` | (no group emitted -- existing 'no packages' error path, unchanged) |

## Audit of other gh-aw workflows

Only `pr-review-panel.md` and `triage-panel.md` import `shared/apm.md`; `cli-consistency-checker.md`, `daily-doc-updater.md`, and `daily-test-improver.md` do not have any `imports:` block and are unaffected.

## Risk

Low. The repair is fully gated behind an `is-this-already-valid-JSON` check, so well-formed inputs (today and after upstream fix) are untouched. No changes to schema, no breaking change for vendored copies of `shared/apm.md` -- the `Source of truth`/`apm-action pin` header lines stay byte-identical.

## Follow-ups

- github/gh-aw#29076 -- request that import-input arrays be substituted as JSON (or that a compile-time JSON helper be exposed). Once shipped, the `repair_string_array` shim becomes a no-op and can be deleted.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>