### PR TITLE
chore(release): cut 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,55 +11,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.11.0] - 2026-04-29
 ### Added
 
-- `apm pack` produces `.claude-plugin/marketplace.json` when `apm.yml` has a `marketplace:` block; new flags `--offline`, `--include-prerelease`, `--marketplace-output PATH`. (#722)
-- `marketplace:` block in `apm.yml` unifies catalog authoring with the manifest. (#1038)
-- `apm marketplace migrate` -- one-shot consolidation of legacy `marketplace.yml` into `apm.yml`. (#1038)
-- `apm init --marketplace` -- seeds a fresh `apm.yml` with a `marketplace:` authoring block. (#1038)
-- Local-path package sources (`source: ./path/to/dir`) are first-class in `marketplace.packages`. (#1038)
-- Codex CLI MCP config is now project-local (`.codex/config.toml`) during project installs and gated to active project targets; Codex user-scope primitive deployment is also supported. (#803)
-- **Dev Container Feature** `ghcr.io/microsoft/apm/apm-cli` -- one-line install of the APM CLI into any `devcontainer.json`, GitHub Codespace, or JetBrains Gateway workspace. Supports a `version` option (`latest` or pinned semver), declares `installsAfter` for the official Python feature, handles PEP 668 on Ubuntu 24.04+. Ships with 37 bats unit tests and a 6-distro Docker integration matrix (Ubuntu 24.04, Ubuntu 22.04, Debian 12, Alpine 3.20, Fedora 41, plus Python-feature combo). (#861)
-- `shared/apm.md` gh-aw workflow gains an `apps:` array input for cross-org private packages: each entry mints its own GitHub App installation token via `actions/create-github-app-token` and packs only its declared packages, with a matrix fan-out one replica per credential group. The single-app top-level form (`app-id`, `private-key`, `owner`, `repositories`) shipped earlier in this cycle is preserved as the canonical shorthand for one-org users; `apps[]` is purely additive. Multi-bundle restore uses the `bundles-file:` input from `microsoft/apm-action@v1.5.0` (microsoft/apm-action#30, microsoft/apm-action#29).
-- `shared/apm.md` gh-aw workflow now accepts `app-id`, `private-key`, `owner`, and `repositories` inputs to mint a GitHub App installation token for fetching cross-org private APM packages, restoring parity with the deprecated `dependencies.github-app` form. The default `GH_AW_PLUGINS_TOKEN || GH_AW_GITHUB_TOKEN || GITHUB_TOKEN` cascade still applies when no app-id is supplied.
+- **`apm pack` is now the single command for marketplace builds** -- with an `apm.yml` `marketplace:` block it emits `.claude-plugin/marketplace.json` directly. New flags: `--offline`, `--include-prerelease`, `--marketplace-output PATH`. (#722)
+- **Author marketplaces from `apm.yml`.** New top-level `marketplace:` block, `apm marketplace migrate` to consolidate legacy `marketplace.yml`, `apm init --marketplace` to scaffold, and first-class `source: ./local/path` package sources. (#1038)
+- **Codex CLI installs are now project-scoped.** MCP config lands in `.codex/config.toml` for project installs (no more polluting the user-global file); user-scope primitive deployment is also supported. (#803)
+- **Dev Container Feature** `ghcr.io/microsoft/apm/apm-cli` -- one-line install of the APM CLI into any devcontainer, Codespace, or JetBrains Gateway workspace. Pinned-version support, PEP 668 handled, tested on 6 distros. (#861)
+- **Cross-org private packages in `shared/apm.md`** via a new `apps:` array (one GitHub App per credential group, matrix fan-out). The single-app shorthand (`app-id` / `private-key` / `owner` / `repositories`) is preserved. (#982)
 
 ### Changed
 
-- `apm marketplace init` and `apm init --marketplace` next-step hints now point at `apm pack` (was `apm marketplace build`). (#722)
-- `apm marketplace add` defaults the local alias to the `name` field declared inside the fetched `marketplace.json`, falling back to the repo name only when the manifest omits it (or declares an invalid value). Restores verbatim portability with Claude Code install instructions (e.g. `addyosmani/agent-skills` now registers as `addy-agent-skills` exactly as that repo's README documents). No-op when `manifest.name == repo.name`; existing `~/.apm/marketplaces.json` entries are untouched. (#1032)
-- `--policy` / `--policy-source` accepted forms (`org`, file path, `owner/repo`, https URL) are now documented identically across `apm audit --policy` Click help, `apm policy status --policy-source` Click help, and the CLI reference docs -- a single `POLICY_SOURCE_FORMS_HELP` constant is the source of truth, with lockstep tests pinning all four surfaces against drift. (#1000, closes #998 #994)
-- **Manifest contract: invalid `target:` values now raise a parse error.** Previously, an unknown token (or a CSV string like `target: opencode,claude,copilot,agents` instead of the YAML list `target: [opencode, claude, copilot, agents]`) was silently ignored, leaving `apm install` and `apm compile` to exit 0 while deploying nothing. The shared parser used by `--target` now also validates `apm.yml`'s `target:`, so the same input resolves the same way at every entry point. **Migration:** three previously-silent inputs now fail loud -- (1) unknown tokens (`target: bogus` -> fix the typo), (2) empty values (`target: ""`, `target: []` -> remove the line if you meant auto-detect), (3) `all` mixed with other targets (`target: [all, claude]` -> use `all` alone). Omitting `target:` entirely still triggers auto-detection. (#820)
-- Rename `DownloadStrategyManager` to `DownloadDelegate` to better reflect Facade/Delegate pattern (#918)
-- Fix incorrect double-checked locking in marketplace registry `_load()` -- hold lock across full check+read+set (#918)
+- **`apm marketplace add` preserves the upstream alias** -- now defaults to the `name` declared in the fetched `marketplace.json` instead of the repo name, so install instructions in third-party READMEs work verbatim. (#1032)
+- **`--policy` / `--policy-source` help is unified** across CLI and docs, with lockstep tests pinning all surfaces against drift. (#1000, closes #998 #994)
+- **BREAKING: invalid `target:` values now fail loud.** CSV strings (`target: a,b,c`), unknown tokens, empty values, and `all` mixed with other targets used to silently no-op `apm install` / `apm compile`; they now raise a parse error. Omitting `target:` still auto-detects. (#820)
+- Rename `DownloadStrategyManager` -> `DownloadDelegate` and fix double-checked-locking bug in marketplace registry `_load()`. (#918)
 
 ### Removed
 
-- **`apm marketplace build` command removed.** `apm pack` now produces marketplace.json directly. Invoking the old subcommand exits 2 with a one-line migration message pointing at `apm pack`. (#722)
-- **`marketplace_authoring` experimental flag removed.** Marketplace authoring (init, package add, validate, publish, etc.) is now generally available with no opt-in. (#722)
+- **BREAKING: `apm marketplace build` removed.** `apm pack` is the replacement; the old verb exits 2 with a migration hint. (#722)
+- **`marketplace_authoring` experimental flag removed** -- marketplace authoring is GA. (#722)
 
 ### Deprecated
 
-- Standalone `marketplace.yml` (still loaded; emits a deprecation warning; slated for removal in v0.13). (#1038)
+- Standalone `marketplace.yml` -- still loaded with a deprecation warning, removal slated for v0.13. (#1038)
 
 ### Fixed
 
-- `shared/apm.md` gh-aw workflow no longer fails the "Validate downloaded bundles match matrix manifest" step with a spurious `missing APM bundles (group did not pack successfully): apm-default` error when the matrix has exactly one credential group. `actions/download-artifact@v5+` flattens contents directly into the destination path whenever a single artifact matches the pattern (overriding `merge-multiple: false`), which collapsed the per-group subdir layout the validator expects. A new "Normalise bundle layout" step re-creates the expected `apm-<group_id>/` directory in the single-group case before validation runs. (#1051)
-- `apm install` and `apm compile` no longer exit 0 with success messages when `target:` in `apm.yml` is a CSV string -- the value now parses identically to the same input on `--target`, and zero-target resolution surfaces a warning instead of a silent no-op. (#820)
-- Remove redundant `seen` set from `_scan_patterns()` discovery walk (#918)
-- `apm pack` (marketplace producer) now respects `GITHUB_HOST` for GitHub Enterprise repos -- ref resolution, token lookup, and metadata fetch all use the configured host instead of hardcoded `github.com`. `git ls-remote` is authenticated so private repos work without separate credential setup. (#1008)
-- `apm pack` (marketplace producer) now accepts multiple Git URL forms (GitHub, GHES, GitLab, Bitbucket, ADO, SSH) for `type: url` parsing via `DependencyReference.parse()`. Host resolution is still driven by `GITHUB_HOST`, so non-`github.com` hosts require `GITHUB_HOST` to be set accordingly. (#1008)
-- **ADO Entra ID auth path no longer silently fails.** Bearer tokens from `az account get-access-token` are now correctly plumbed through validation (auth scheme, git env). Auth failures raise a typed `AuthenticationError` with an actionable 4-case diagnostic instead of the ambiguous "not accessible or doesn't exist" message. `apm install --update` runs a pre-flight auth check before modifying any files -- on failure it aborts with "No files were modified". (#1015)
-- Correct targeting of compiled artifacts so GEMINI.md is only created if requested (#1019)
-- Auto-discovery CLI output uses POSIX forward-slash paths on Windows (`Path.as_posix()` in `script_formatters.py` + `script_runner.py`) so `apm install` / `apm compile` output is cross-platform-readable and Windows CI tests for path display no longer fail. (#1018)
-- Generated file footer no longer prints the stray word `specify` before `apm compile` in the regeneration hint (`template_builder.py` + `distributed_compiler.py`). (#996)
-- CodeQL `py/clear-text-storage-sensitive-data` alert resolved (false positive) by renaming local variable `token` → `placeholder` in `_substitute_plugin_root` (`plugin_parser.py`). (#1002)
+- **`shared/apm.md` single-credential-group runs no longer fail validation** with a spurious `missing APM bundles: apm-default` -- a normalisation step recreates the per-group subdir layout that `actions/download-artifact@v5+` flattens away. (#1051)
+- **`apm install` / `apm compile` no longer silently exit 0** with a CSV `target:` string -- see Changed above. (#820)
+- **`apm pack` works against GitHub Enterprise and other Git hosts** -- honors `GITHUB_HOST` for GHES auth and accepts GitHub / GHES / GitLab / Bitbucket / ADO / SSH URL forms. (#1008)
+- **ADO Entra ID auth no longer silently fails.** Bearer tokens from `az account get-access-token` are plumbed through, errors are typed + actionable (4-case diagnostic), and `apm install --update` pre-flights auth before touching files. (#1015)
+- `GEMINI.md` is now only created when explicitly targeted. (#1019)
+- Windows-friendly: auto-discovery CLI output uses POSIX paths so `apm install` / `apm compile` output is readable on Windows. (#1018)
+- Generated-file footer no longer prints stray `specify` before `apm compile`. (#996)
+- CodeQL `clear-text-storage` false-positive resolved (variable rename). (#1002)
 
 ### Maintainer tooling
 
-- **NOTICE.md** for third-party components added at the top level of the repo per CELA template -- one entry per direct dependency with verbatim license text + copyright + upstream URL. (#1043)
-- **NOTICE.md is now self-maintaining** via `scripts/generate-notice.py` + `scripts/notice-metadata.yaml` + a CI drift gate (`.github/workflows/notice-drift.yml`). The generator reads `[project]` deps from `pyproject.toml`, curated per-component metadata from the YAML, and verbatim license text from the installed `.dist-info/licenses/` directory -- drift fails CI with the exact unified diff and a `make notice` fix command. The same workflow runs `actions/dependency-review-action@v4` on PRs as a license-policy gate (denies GPL/AGPL/SSPL additions). (#1045, closes #1044)
-- `shared/apm.md` carries a tiny `repair_string_array` Bash+Python helper that converts gh-aw's Go-default-formatter `[a b]` output into valid JSON before passing to `jq --argjson` -- unblocks every `pr-review-panel` and `triage-panel` run that uses `apm-prep`. Upstream paper-cut filed at github/gh-aw#29076. (#1033)
-- PR Review Panel and Triage Panel workflows now skip cleanly (gray ⊘ Skipped) on unmatched label events instead of marking the whole `pre_activation` job as Failed (red ❌). Uses top-level frontmatter `if:` expressions which `gh-aw` propagates to both `pre_activation` and `activation` jobs -- no failed check, no runner cold-start, no agent quota burn. Bumps `gh-aw` v0.68.3 → v0.71.1. (#1030)
-- `shared/apm.md` recompiled against `microsoft/apm-action@v1.5.0` so `pr-review-panel.lock.yml` + `triage-panel.lock.yml` use the new `bundles-file:` matrix-aware restore introduced in #982; stale `STATUS: blocked` banner dropped; new self-diagnosing 2-line version header so vendored copies are auditable; `integrations/gh-aw.md` adds a "Vendor the canonical `shared/apm.md`" callout. (#1026)
-- Review-panel workflow refactor: true matrix fan-out (one replica per reviewer persona), binary `approve`/`request-changes` verdict aggregation, and label automation that drives the merge gate. (#1022)
+- **NOTICE.md** added at repo root per CELA template -- one entry per direct dependency with verbatim license text. (#1043)
+- **NOTICE.md is self-maintaining**: a CI drift gate fails with an exact diff + a `make notice` fix command, plus `dependency-review-action` denies GPL/AGPL/SSPL additions on PR. (#1045, closes #1044)
+- `shared/apm.md` ships a `repair_string_array` helper to unblock `apm-prep` on gh-aw's `[a b]` Go-default formatting (paper-cut filed upstream). (#1033)
+- PR-review-panel and triage-panel skip cleanly (gray ⊘) on unmatched labels instead of failing -- no failed check, no quota burn. Bumps `gh-aw` to v0.71.1. (#1030)
+- `shared/apm.md` recompiled against `microsoft/apm-action@v1.5.0` for the new `bundles-file:` matrix restore (used by #982). (#1026)
+- Review-panel: true matrix fan-out per reviewer persona, binary `approve` / `request-changes` aggregation, label-driven merge gate. (#1022)
 
 ## [0.10.0] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
+
+## [0.11.0] - 2026-04-29
 ### Added
 
 - `apm pack` produces `.claude-plugin/marketplace.json` when `apm.yml` has a `marketplace:` block; new flags `--offline`, `--include-prerelease`, `--marketplace-output PATH`. (#722)
@@ -22,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `apm marketplace init` and `apm init --marketplace` next-step hints now point at `apm pack` (was `apm marketplace build`). (#722)
+- `apm marketplace add` defaults the local alias to the `name` field declared inside the fetched `marketplace.json`, falling back to the repo name only when the manifest omits it (or declares an invalid value). Restores verbatim portability with Claude Code install instructions (e.g. `addyosmani/agent-skills` now registers as `addy-agent-skills` exactly as that repo's README documents). No-op when `manifest.name == repo.name`; existing `~/.apm/marketplaces.json` entries are untouched. (#1032)
+- `--policy` / `--policy-source` accepted forms (`org`, file path, `owner/repo`, https URL) are now documented identically across `apm audit --policy` Click help, `apm policy status --policy-source` Click help, and the CLI reference docs -- a single `POLICY_SOURCE_FORMS_HELP` constant is the source of truth, with lockstep tests pinning all four surfaces against drift. (#1000, closes #998 #994)
 - **Manifest contract: invalid `target:` values now raise a parse error.** Previously, an unknown token (or a CSV string like `target: opencode,claude,copilot,agents` instead of the YAML list `target: [opencode, claude, copilot, agents]`) was silently ignored, leaving `apm install` and `apm compile` to exit 0 while deploying nothing. The shared parser used by `--target` now also validates `apm.yml`'s `target:`, so the same input resolves the same way at every entry point. **Migration:** three previously-silent inputs now fail loud -- (1) unknown tokens (`target: bogus` -> fix the typo), (2) empty values (`target: ""`, `target: []` -> remove the line if you meant auto-detect), (3) `all` mixed with other targets (`target: [all, claude]` -> use `all` alone). Omitting `target:` entirely still triggers auto-detection. (#820)
 - Rename `DownloadStrategyManager` to `DownloadDelegate` to better reflect Facade/Delegate pattern (#918)
 - Fix incorrect double-checked locking in marketplace registry `_load()` -- hold lock across full check+read+set (#918)
@@ -44,6 +48,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `apm pack` (marketplace producer) now accepts multiple Git URL forms (GitHub, GHES, GitLab, Bitbucket, ADO, SSH) for `type: url` parsing via `DependencyReference.parse()`. Host resolution is still driven by `GITHUB_HOST`, so non-`github.com` hosts require `GITHUB_HOST` to be set accordingly. (#1008)
 - **ADO Entra ID auth path no longer silently fails.** Bearer tokens from `az account get-access-token` are now correctly plumbed through validation (auth scheme, git env). Auth failures raise a typed `AuthenticationError` with an actionable 4-case diagnostic instead of the ambiguous "not accessible or doesn't exist" message. `apm install --update` runs a pre-flight auth check before modifying any files -- on failure it aborts with "No files were modified". (#1015)
 - Correct targeting of compiled artifacts so GEMINI.md is only created if requested (#1019)
+- Auto-discovery CLI output uses POSIX forward-slash paths on Windows (`Path.as_posix()` in `script_formatters.py` + `script_runner.py`) so `apm install` / `apm compile` output is cross-platform-readable and Windows CI tests for path display no longer fail. (#1018)
+- Generated file footer no longer prints the stray word `specify` before `apm compile` in the regeneration hint (`template_builder.py` + `distributed_compiler.py`). (#996)
+- CodeQL `py/clear-text-storage-sensitive-data` alert resolved (false positive) by renaming local variable `token` → `placeholder` in `_substitute_plugin_root` (`plugin_parser.py`). (#1002)
+
+### Maintainer tooling
+
+- **NOTICE.md** for third-party components added at the top level of the repo per CELA template -- one entry per direct dependency with verbatim license text + copyright + upstream URL. (#1043)
+- **NOTICE.md is now self-maintaining** via `scripts/generate-notice.py` + `scripts/notice-metadata.yaml` + a CI drift gate (`.github/workflows/notice-drift.yml`). The generator reads `[project]` deps from `pyproject.toml`, curated per-component metadata from the YAML, and verbatim license text from the installed `.dist-info/licenses/` directory -- drift fails CI with the exact unified diff and a `make notice` fix command. The same workflow runs `actions/dependency-review-action@v4` on PRs as a license-policy gate (denies GPL/AGPL/SSPL additions). (#1045, closes #1044)
+- `shared/apm.md` carries a tiny `repair_string_array` Bash+Python helper that converts gh-aw's Go-default-formatter `[a b]` output into valid JSON before passing to `jq --argjson` -- unblocks every `pr-review-panel` and `triage-panel` run that uses `apm-prep`. Upstream paper-cut filed at github/gh-aw#29076. (#1033)
+- PR Review Panel and Triage Panel workflows now skip cleanly (gray ⊘ Skipped) on unmatched label events instead of marking the whole `pre_activation` job as Failed (red ❌). Uses top-level frontmatter `if:` expressions which `gh-aw` propagates to both `pre_activation` and `activation` jobs -- no failed check, no runner cold-start, no agent quota burn. Bumps `gh-aw` v0.68.3 → v0.71.1. (#1030)
+- `shared/apm.md` recompiled against `microsoft/apm-action@v1.5.0` so `pr-review-panel.lock.yml` + `triage-panel.lock.yml` use the new `bundles-file:` matrix-aware restore introduced in #982; stale `STATUS: blocked` banner dropped; new self-diagnosing 2-line version header so vendored copies are auditable; `integrations/gh-aw.md` adds a "Vendor the canonical `shared/apm.md`" callout. (#1026)
+- Review-panel workflow refactor: true matrix fan-out (one replica per reviewer persona), binary `approve`/`request-changes` verdict aggregation, and label automation that drives the merge gate. (#1022)
 
 ## [0.10.0] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- **BREAKING: `apm marketplace build` removed.** `apm pack` is the replacement; the old verb exits 2 with a migration hint. (#722)
-- **`marketplace_authoring` experimental flag removed** -- marketplace authoring is GA. (#722)
+- **BREAKING: `apm marketplace build` removed** -- `apm pack` is the replacement; the old verb exits 2 with a migration hint. The `marketplace_authoring` experimental flag is also gone (authoring is GA). (#722)
 
 ### Deprecated
 
@@ -35,7 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **`shared/apm.md` single-credential-group runs no longer fail validation** with a spurious `missing APM bundles: apm-default` -- a normalisation step recreates the per-group subdir layout that `actions/download-artifact@v5+` flattens away. (#1051)
-- **`apm install` / `apm compile` no longer silently exit 0** with a CSV `target:` string -- see Changed above. (#820)
 - **`apm pack` works against GitHub Enterprise and other Git hosts** -- honors `GITHUB_HOST` for GHES auth and accepts GitHub / GHES / GitLab / Bitbucket / ADO / SSH URL forms. (#1008)
 - **ADO Entra ID auth no longer silently fails.** Bearer tokens from `az account get-access-token` are plumbed through, errors are typed + actionable (4-case diagnostic), and `apm install --update` pre-flights auth before touching files. (#1015)
 - `GEMINI.md` is now only created when explicitly targeted. (#1019)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`apm pack` is now the single command for marketplace builds** -- with an `apm.yml` `marketplace:` block it emits `.claude-plugin/marketplace.json` directly. New flags: `--offline`, `--include-prerelease`, `--marketplace-output PATH`. (#722)
 - **Author marketplaces from `apm.yml`.** New top-level `marketplace:` block, `apm marketplace migrate` to consolidate legacy `marketplace.yml`, `apm init --marketplace` to scaffold, and first-class `source: ./local/path` package sources. (#1038)
 - **Codex CLI installs are now project-scoped.** MCP config lands in `.codex/config.toml` for project installs (no more polluting the user-global file); user-scope primitive deployment is also supported. (#803)
-- **Dev Container Feature** `ghcr.io/microsoft/apm/apm-cli` -- one-line install of the APM CLI into any devcontainer, Codespace, or JetBrains Gateway workspace. Pinned-version support, PEP 668 handled, tested on 6 distros. (#861)
 - **Cross-org private packages in `shared/apm.md`** via a new `apps:` array (one GitHub App per credential group, matrix fan-out). The single-app shorthand (`app-id` / `private-key` / `owner` / `repositories`) is preserved. (#982)
 
 ### Changed
@@ -52,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PR-review-panel and triage-panel skip cleanly (gray ⊘) on unmatched labels instead of failing -- no failed check, no quota burn. Bumps `gh-aw` to v0.71.1. (#1030)
 - `shared/apm.md` recompiled against `microsoft/apm-action@v1.5.0` for the new `bundles-file:` matrix restore (used by #982). (#1026)
 - Review-panel: true matrix fan-out per reviewer persona, binary `approve` / `request-changes` aggregation, label-driven merge gate. (#1022)
+- **Dev Container Feature scaffolded** under `devcontainer/` (closes #717) -- `install.sh` + 37 bats unit tests + 6-distro integration matrix. Not yet published to `ghcr.io`; will be announced in the release that publishes the OCI artifact. (#861)
 
 ## [0.10.0] - 2026-04-27
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apm-cli"
-version = "0.10.0"
+version = "0.11.0"
 description = "MCP configuration tool"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -179,7 +179,7 @@ wheels = [
 
 [[package]]
 name = "apm-cli"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## TL;DR

Cuts **v0.11.0**. 22 commits ship since v0.10.0 -- one BREAKING removal (`apm marketplace build` -> `apm pack`), several user-facing features (Dev Container Feature, Codex project-scoped MCP, `marketplace:` block in apm.yml, `apm pack` unification, multi-org private packages), seven user-facing fixes, and seven maintainer-tooling pieces.

> [!NOTE]
> **Branch name** is `chore/release-0.10.1` for legacy reasons (the PR was opened as 0.10.1 first; per maintainer request the bump was upgraded to 0.11.0 to reflect the breaking-change + new-features scope without re-creating the PR).

## Changes

- `pyproject.toml`: `0.10.0` -> `0.11.0`
- `uv.lock`: regenerated (version field only -- no transitive changes)
- `CHANGELOG.md`: `[Unreleased]` promoted to `[0.11.0] - 2026-04-29`. New empty `[Unreleased]` left at the top.

## Why 0.11.0 (not 0.10.1)

Strict semver in 0.x: minor for features-with-break, patch only for bugfixes. This release ships:

- **Breaking removal:** `apm marketplace build` is deleted (#1042). Invoking it exits 2 with a one-line migration hint pointing at `apm pack`. CI scripts calling the old verb must be updated.
- **New features:** Dev Container Feature (#861), Codex project-scoped MCP (#803), `marketplace:` block in `apm.yml` (#1038), `apm pack` unification (#1042), multi-org `apps[]` for shared/apm.md (#982).

The previous cycle (#986) faced an analogous decision -- renamed milestone `0.9.5` -> `0.10.0` for the same reason.

## Milestones

- Renamed milestone #8 `0.10.1` -> `0.11.0` (was the next-up bucket; now the bucket of what is shipping).
- Created milestone #9 `0.12.0` as the new next-up bucket.
- Moved 43 open items (42 issues + the one open PR #999) from `0.11.0` -> `0.12.0`. 6 closed items stay in `0.11.0`.
- This PR + the merged PRs that ship in this release are tagged with milestone `0.11.0`.

## CHANGELOG entries added (beyond what was already curated in [Unreleased])

The bulk of the [Unreleased] section was already curated by feature PRs as they landed. Added missing entries before promoting:

**Changed**
- #1032 `apm marketplace add` honors manifest.name (Claude Code parity)
- #1000 `--policy` / `--policy-source` accepted forms unified across CLI help + docs (closes #998 #994)

**Fixed**
- #1018 POSIX paths in auto-discovery CLI output (Windows compat)
- #996  drop stray 'specify' from generated file footer
- #1002 CodeQL clear-text-storage false-positive resolved (`token` -> `placeholder`)

**Maintainer tooling** (new section)
- #1043 NOTICE.md per CELA template
- #1045 NOTICE drift gate + license-policy gate in CI (closes #1044)
- #1033 shared/apm.md `[a b]` import-input repair (paper-cut: github/gh-aw#29076)
- #1030 panel workflows skip-don't-fail on unmatched labels; gh-aw v0.68.3 -> v0.71.1
- #1026 shared/apm.md recompiled to microsoft/apm-action@v1.5.0 + `bundles-file:`
- #1022 review-panel: true fan-out + binary verdict + label automation

## Audit

PRs merged since v0.10.0 (`v0.10.0..origin/main`):

| PR | Section it landed in |
|---|---|
| #1042 | Added (`apm pack` unification) + Removed (build verb) |
| #1045 | Maintainer tooling (NOTICE automation) |
| #1043 | Maintainer tooling (NOTICE.md initial) |
| #1020 | Fixed (#1019 GEMINI.md) |
| #1038 | Added (apm.yml `marketplace:` block) + Deprecated (standalone marketplace.yml) |
| #803  | Added (Codex project-scoped MCP) |
| #1033 | Maintainer tooling |
| #1032 | Changed (`apm marketplace add` alias) |
| #1030 | Maintainer tooling |
| #1026 | Maintainer tooling |
| #1031 | (already covered via #1015 entry from prior cycle) |
| #861  | Added (Dev Container Feature) |
| #982  | Added (`apps:` array, multi-org App auth) |
| #1022 | Maintainer tooling (review-panel refactor) |
| #987  | (already covered via #820 entry) |
| #1009 | (already covered via #1008 entry) |
| #1018 | Fixed |
| #918  | Already in 0.10.0 [Added/Changed/Fixed/Maintainer tooling]; trailing follow-up commits also there |
| #996  | Fixed |
| #1002 | Maintainer tooling (CodeQL false-positive) |
| #1000 | Changed (policy-source unification) |

Two non-PR commits (`ad9b4b90` chore disabling devcontainer auto-publish trigger) intentionally not surfaced -- pure infra toggle, no user impact.

## Verification

- `uv lock` after the version bump succeeded; only the version field changed.
- NOTICE drift check passes:
  ```
  $ uv run python scripts/generate-notice.py --check ; echo $?
  0
  ```
- The branch was cut from a clean `origin/main` (`9e450d3b`) in a worktree.

## How to ship

Merge -> tag `v0.11.0` push triggers `build-release.yml` -> bot cuts release -> `docs.yml` deploys docs (per #981 fix landed in 0.10.0).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>