### PR TITLE
[Test Improver] test: add unit tests for uninstall engine helpers

### DIFF
--- a/tests/unit/commands/test_uninstall_engine.py
+++ b/tests/unit/commands/test_uninstall_engine.py
@@ -1,0 +1,224 @@
+"""Unit tests for apm_cli.commands.uninstall.engine helper functions.
+
+Focuses on the pure/near-pure helpers that are currently untested:
+  - _build_children_index
+  - _parse_dependency_entry
+  - _validate_uninstall_packages
+  - _remove_packages_from_disk (filesystem interaction)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apm_cli.commands.uninstall.engine import (
+    _build_children_index,
+    _parse_dependency_entry,
+    _remove_packages_from_disk,
+    _validate_uninstall_packages,
+)
+from apm_cli.deps.lockfile import LockedDependency, LockFile
+from apm_cli.models.dependency.reference import DependencyReference
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_locked_dep(repo_url: str, resolved_by: str | None = None) -> LockedDependency:
+    return LockedDependency(
+        repo_url=repo_url,
+        resolved_commit="abc123",
+        depth=0 if resolved_by is None else 1,
+        resolved_by=resolved_by,
+    )
+
+
+def _make_lockfile(*deps: LockedDependency) -> LockFile:
+    lf = LockFile()
+    for dep in deps:
+        lf.add_dependency(dep)
+    return lf
+
+
+def _make_logger() -> MagicMock:
+    logger = MagicMock()
+    logger.error = MagicMock()
+    logger.warning = MagicMock()
+    logger.progress = MagicMock()
+    return logger
+
+
+# ---------------------------------------------------------------------------
+# _build_children_index
+# ---------------------------------------------------------------------------
+
+
+class TestBuildChildrenIndex:
+    def test_empty_lockfile_returns_empty_dict(self):
+        lf = _make_lockfile()
+        assert _build_children_index(lf) == {}
+
+    def test_direct_deps_with_no_parent_not_indexed(self):
+        lf = _make_lockfile(_make_locked_dep("owner/direct"))
+        assert _build_children_index(lf) == {}
+
+    def test_transitive_dep_indexed_under_parent(self):
+        parent = _make_locked_dep("owner/parent")
+        child = _make_locked_dep("owner/child", resolved_by="owner/parent")
+        lf = _make_lockfile(parent, child)
+        index = _build_children_index(lf)
+        assert "owner/parent" in index
+        assert len(index["owner/parent"]) == 1
+        assert index["owner/parent"][0].repo_url == "owner/child"
+
+    def test_multiple_children_under_same_parent(self):
+        parent = _make_locked_dep("org/a")
+        child1 = _make_locked_dep("org/b", resolved_by="org/a")
+        child2 = _make_locked_dep("org/c", resolved_by="org/a")
+        lf = _make_lockfile(parent, child1, child2)
+        index = _build_children_index(lf)
+        assert len(index["org/a"]) == 2
+        child_urls = {d.repo_url for d in index["org/a"]}
+        assert child_urls == {"org/b", "org/c"}
+
+    def test_chained_deps_each_parent_indexed(self):
+        a = _make_locked_dep("org/a")
+        b = _make_locked_dep("org/b", resolved_by="org/a")
+        c = _make_locked_dep("org/c", resolved_by="org/b")
+        lf = _make_lockfile(a, b, c)
+        index = _build_children_index(lf)
+        assert "org/a" in index
+        assert "org/b" in index
+        assert "org/c" not in index
+
+
+# ---------------------------------------------------------------------------
+# _parse_dependency_entry
+# ---------------------------------------------------------------------------
+
+
+class TestParseDependencyEntry:
+    def test_string_input_returns_dependency_reference(self):
+        result = _parse_dependency_entry("owner/repo")
+        assert isinstance(result, DependencyReference)
+        assert result.repo_url == "owner/repo"
+
+    def test_dependency_reference_passthrough(self):
+        ref = DependencyReference.parse("owner/repo2")
+        result = _parse_dependency_entry(ref)
+        assert result is ref
+
+    def test_dict_input_parsed(self):
+        entry = {"git": "https://github.com/owner/repo3"}
+        result = _parse_dependency_entry(entry)
+        assert isinstance(result, DependencyReference)
+        assert "owner/repo3" in result.repo_url
+
+    def test_unsupported_type_raises_value_error(self):
+        with pytest.raises(ValueError, match="Unsupported dependency entry type"):
+            _parse_dependency_entry(42)
+
+    def test_none_raises_value_error(self):
+        with pytest.raises((ValueError, TypeError, AttributeError)):
+            _parse_dependency_entry(None)
+
+
+# ---------------------------------------------------------------------------
+# _validate_uninstall_packages
+# ---------------------------------------------------------------------------
+
+
+class TestValidateUninstallPackages:
+    def test_matching_package_moved_to_remove_list(self):
+        deps = ["owner/pkg"]
+        logger = _make_logger()
+        to_remove, not_found = _validate_uninstall_packages(["owner/pkg"], deps, logger)
+        assert "owner/pkg" in to_remove
+        assert not_found == []
+
+    def test_missing_package_moved_to_not_found(self):
+        deps = ["owner/other"]
+        logger = _make_logger()
+        to_remove, not_found = _validate_uninstall_packages(
+            ["owner/missing"], deps, logger
+        )
+        assert to_remove == []
+        assert "owner/missing" in not_found
+
+    def test_invalid_format_no_slash_logs_error(self):
+        logger = _make_logger()
+        to_remove, not_found = _validate_uninstall_packages(["noslash"], [], logger)
+        assert to_remove == []
+        assert not_found == []
+        logger.error.assert_called_once()
+
+    def test_multiple_packages_mixed_results(self):
+        deps = ["owner/a", "owner/b"]
+        logger = _make_logger()
+        to_remove, not_found = _validate_uninstall_packages(
+            ["owner/a", "owner/missing"], deps, logger
+        )
+        assert "owner/a" in to_remove
+        assert "owner/missing" in not_found
+
+    def test_empty_packages_list_returns_empty(self):
+        logger = _make_logger()
+        to_remove, not_found = _validate_uninstall_packages([], ["owner/pkg"], logger)
+        assert to_remove == []
+        assert not_found == []
+
+    def test_empty_deps_means_all_not_found(self):
+        logger = _make_logger()
+        to_remove, not_found = _validate_uninstall_packages(["owner/x"], [], logger)
+        assert to_remove == []
+        assert "owner/x" in not_found
+
+    def test_dependency_reference_object_in_deps_matches(self):
+        ref = DependencyReference.parse("owner/repox")
+        logger = _make_logger()
+        to_remove, not_found = _validate_uninstall_packages(
+            ["owner/repox"], [ref], logger
+        )
+        assert ref in to_remove
+        assert not_found == []
+
+
+# ---------------------------------------------------------------------------
+# _remove_packages_from_disk
+# ---------------------------------------------------------------------------
+
+
+class TestRemovePackagesFromDisk:
+    def test_nonexistent_modules_dir_returns_zero(self, tmp_path):
+        logger = _make_logger()
+        absent_dir = tmp_path / "no_such_dir"
+        result = _remove_packages_from_disk(["owner/pkg"], absent_dir, logger)
+        assert result == 0
+
+    def test_package_on_disk_is_removed(self, tmp_path):
+        logger = _make_logger()
+        pkg_dir = tmp_path / "owner" / "pkg"
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / "file.txt").write_text("hi")
+
+        result = _remove_packages_from_disk(["owner/pkg"], tmp_path, logger)
+        assert result == 1
+        assert not pkg_dir.exists()
+
+    def test_package_not_on_disk_counts_as_zero(self, tmp_path):
+        logger = _make_logger()
+        result = _remove_packages_from_disk(["owner/missing"], tmp_path, logger)
+        assert result == 0
+        logger.warning.assert_called_once()
+
+    def test_path_traversal_in_dep_is_rejected(self, tmp_path):
+        """A dep_entry whose string fallback path has no slash is safely skipped."""
+        logger = _make_logger()
+        # "noslash" has no "/" so _parse_dependency_entry raises; the fallback
+        # constructs a path that does not exist, so removal is skipped.
+        result = _remove_packages_from_disk(["noslash"], tmp_path, logger)
+        assert result == 0


### PR DESCRIPTION
🤖 *Test Improver — automated AI assistant*

## Goal

`src/apm_cli/commands/uninstall/engine.py` had no dedicated unit tests. This PR adds 21 tests for four focused helper functions that implement the core uninstall logic.

## What is tested

| Helper | Tests | Why it matters |
|--------|-------|----------------|
| `_build_children_index` | 5 | Orphan-detection depends on correct parent→children mapping |
| `_parse_dependency_entry` | 5 | Entry point for all dep parsing; wrong dispatch causes silent skips |
| `_validate_uninstall_packages` | 7 | Determines which packages are removed — false negatives are user-visible bugs |
| `_remove_packages_from_disk` | 4 | Filesystem writes; missing path and no-module-dir edge cases |

## Coverage impact

| Metric | Before | After |
|--------|--------|-------|
| Tests passing | 6708 | 6729 |
| New tests | — | **+21** |

(Pre-existing failures in `test_audit_report.py` and `test_deps_update_command.py` are unrelated and unchanged.)

## How to test

```bash
uv run pytest tests/unit/commands/test_uninstall_engine.py -v
# 21 passed
```

## Test status

All 21 new tests pass. Full suite: `6708 passed + 21 new = 6729 passed`.

> Generated by [Daily Test Improver](https://github.com/microsoft/apm/actions/runs/25145989383)




> Generated by [Daily Test Improver](https://github.com/microsoft/apm/actions/runs/25145989383/agentic_workflow) · ● 2.6M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+%22gh-aw-workflow-id%3A+daily-test-improver%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/blob/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-test-improver.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-test-improver.md@b87234850bf9664d198f28a02df0f937d0447295
> ```

<!-- gh-aw-agentic-workflow: Daily Test Improver, engine: copilot, version: 1.0.36, model: claude-sonnet-4.6, id: 25145989383, workflow_id: daily-test-improver, run: https://github.com/microsoft/apm/actions/runs/25145989383 -->

<!-- gh-aw-workflow-id: daily-test-improver -->