### PR TITLE
test(windows): fix CLAUDE_CONFIG_DIR scope tests on Windows

### DIFF
--- a/tests/unit/integration/test_scope_install_uninstall.py
+++ b/tests/unit/integration/test_scope_install_uninstall.py
@@ -7,6 +7,7 @@ For each target x scope combination, verifies:
 - Files at wrong-scope paths are never created
 """
 
+import os
 import shutil
 import tempfile
 from datetime import datetime
@@ -22,6 +23,23 @@ from apm_cli.integration.targets import KNOWN_TARGETS
 from apm_cli.models.apm_package import APMPackage, PackageInfo
 from apm_cli.models.dependency.types import GitReferenceType, ResolvedReference
 from apm_cli.models.validation import PackageType
+
+
+def _set_home(monkeypatch, home: Path) -> None:
+    """Portably set the user's home directory for ``Path.home()``.
+
+    On Windows, ``Path.home()`` ignores ``HOME`` and uses ``USERPROFILE``
+    (or ``HOMEDRIVE`` + ``HOMEPATH``).
+    """
+    home_str = str(home)
+    monkeypatch.setenv("HOME", home_str)
+    if os.name == "nt":
+        monkeypatch.setenv("USERPROFILE", home_str)
+        drive, _, tail = home_str.partition(":")
+        if tail:
+            monkeypatch.setenv("HOMEDRIVE", f"{drive}:")
+            monkeypatch.setenv("HOMEPATH", tail)
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -380,7 +398,7 @@ class TestClaudeInstallUninstallCycle:
 
     def test_user_scope_with_claude_config_dir(self, monkeypatch):
         """CLAUDE_CONFIG_DIR override: deploy lands at custom root and uninstall cleans it."""
-        monkeypatch.setenv("HOME", str(self.project_root))
+        _set_home(monkeypatch, self.project_root)
         custom = self.project_root / ".config" / "test-claude"
         monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(custom))
         custom.mkdir(parents=True)

--- a/tests/unit/integration/test_scope_integration.py
+++ b/tests/unit/integration/test_scope_integration.py
@@ -266,8 +266,8 @@ class TestClaudeScopeResolution:
         monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(outside))
         scoped = KNOWN_TARGETS["claude"].for_scope(user_scope=True)
         assert scoped is not None
-        # Paths outside $HOME are not normalized; preserve the absolute string.
-        assert scoped.root_dir == str(outside.resolve())
+        # Paths outside $HOME remain absolute and are resolved/normalized.
+        assert scoped.root_dir == str(outside.resolve(strict=False))
 
     def test_user_scope_collapses_dotdot_segments(self, tmp_path, monkeypatch):
         # ``..`` must be resolved before relative_to(home) so traversal

--- a/tests/unit/integration/test_scope_integration.py
+++ b/tests/unit/integration/test_scope_integration.py
@@ -5,6 +5,7 @@ correct paths at both project and user scope, across all targets.
 Uses real integrators against temp directories -- no mocks.
 """
 
+import os
 import shutil
 import tempfile
 from datetime import datetime
@@ -19,6 +20,24 @@ from apm_cli.integration.targets import KNOWN_TARGETS, resolve_targets
 from apm_cli.models.apm_package import APMPackage, PackageInfo
 from apm_cli.models.dependency.types import GitReferenceType, ResolvedReference
 from apm_cli.models.validation import PackageType
+
+
+def _set_home(monkeypatch, home: Path) -> None:
+    """Set the user's home directory portably across POSIX and Windows.
+
+    ``Path.home()`` consults ``HOME`` on POSIX but ``USERPROFILE`` (with
+    ``HOMEDRIVE`` + ``HOMEPATH`` fallback) on Windows. Setting only ``HOME``
+    is a no-op on Windows and causes ``relative_to(Path.home())`` checks in
+    code under test to compare against the real user's profile.
+    """
+    home_str = str(home)
+    monkeypatch.setenv("HOME", home_str)
+    if os.name == "nt":
+        monkeypatch.setenv("USERPROFILE", home_str)
+        drive, _, tail = home_str.partition(":")
+        if tail:
+            monkeypatch.setenv("HOMEDRIVE", f"{drive}:")
+            monkeypatch.setenv("HOMEPATH", tail)
 
 
 def _make_package_info(install_path, name="test-pkg"):
@@ -228,7 +247,7 @@ class TestClaudeScopeResolution:
         assert "agents" in resolved.primitives
 
     def test_user_scope_expands_tilde(self, tmp_path, monkeypatch):
-        monkeypatch.setenv("HOME", str(tmp_path))
+        _set_home(monkeypatch, tmp_path)
         monkeypatch.setenv("CLAUDE_CONFIG_DIR", "~/.config/claude")
         scoped = KNOWN_TARGETS["claude"].for_scope(user_scope=True)
         assert scoped is not None
@@ -243,19 +262,19 @@ class TestClaudeScopeResolution:
     def test_user_scope_outside_home_keeps_absolute(self, tmp_path, monkeypatch):
         home = tmp_path / "home"
         outside = tmp_path / "elsewhere"
-        monkeypatch.setenv("HOME", str(home))
+        _set_home(monkeypatch, home)
         monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(outside))
         scoped = KNOWN_TARGETS["claude"].for_scope(user_scope=True)
         assert scoped is not None
         # Paths outside $HOME are not normalized; preserve the absolute string.
-        assert scoped.root_dir == str(outside)
+        assert scoped.root_dir == str(outside.resolve())
 
     def test_user_scope_collapses_dotdot_segments(self, tmp_path, monkeypatch):
         # ``..`` must be resolved before relative_to(home) so traversal
         # cannot leak into root_dir and later escape project_root / root_dir.
         home = tmp_path / "home"
         home.mkdir()
-        monkeypatch.setenv("HOME", str(home))
+        _set_home(monkeypatch, home)
         monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(home / ".." / "outside"))
         scoped = KNOWN_TARGETS["claude"].for_scope(user_scope=True)
         assert scoped is not None


### PR DESCRIPTION
## Problem

Three Windows unit tests added in #1055 fail on `windows-latest` (CI run [25190857376](https://github.com/microsoft/apm/actions/runs/25190857376/job/73860213927)):

- `test_user_scope_with_claude_config_dir`
- `test_user_scope_outside_home_keeps_absolute`
- `test_user_scope_collapses_dotdot_segments`

All three patch `HOME` via `monkeypatch` and then exercise code that calls `Path.home()`. On Windows, `Path.home()` ignores `HOME` and reads `USERPROFILE` (with `HOMEDRIVE`+`HOMEPATH` as fallback). So `Path.home()` returned the real runner profile (`C:\Users\runneradmin`), `relative_to(home)` succeeded against `tmp_path` (which lives under `AppData\Local\Temp\...`), and the assertions on `root_dir` failed:

```
AssertionError: assert 'AppData/Loca...g/test-claude' == '.config/test-claude'
AssertionError: assert 'AppData/Loca..._k0/elsewhere' == 'C:\\Users\\r...k0\\elsewhere'
AssertionError: assert 'AppData/Loca...dotd0/outside' == 'C:\\Users\\r...otd0\\elsewhere'
```

## Fix

Add a small `_set_home()` helper in both scope test modules that, on Windows, also patches `USERPROFILE` / `HOMEDRIVE` / `HOMEPATH` so `Path.home()` returns the fake home. Use it in the three failing tests plus `test_user_scope_expands_tilde` for consistency.

Also call `.resolve()` on the expected `outside` path in `test_user_scope_outside_home_keeps_absolute` to match the source's `Path(env).expanduser().resolve(strict=False)` output (covers macOS `/var` -> `/private/var` and Windows 8.3 short-name expansion).

Test-only change. No production code touched.

## Validation

```
uv run --extra dev ruff check tests/unit/integration/test_scope_integration.py tests/unit/integration/test_scope_install_uninstall.py
uv run --extra dev ruff format --check tests/unit/integration/test_scope_integration.py tests/unit/integration/test_scope_install_uninstall.py
uv run --extra dev pytest tests/unit/integration/test_scope_integration.py tests/unit/integration/test_scope_install_uninstall.py
# 38 passed
```