### PR TITLE
docs(authors): show maintainer affiliations and link contributor graph

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,14 +1,20 @@
 # Authors
 
-## Project Maintainers
+## Maintainers
 
-* Daniel Meppiel (@danielmeppiel) - Creator and Lead Maintainer
-* Sergio Sisternes (@sergio-sisternes-epam) - Maintainer
+* Daniel Meppiel (@danielmeppiel) — Microsoft
+* Sergio Sisternes (@sergio-sisternes-epam) — EPAM Systems
+
+Maintainers' work on APM is supported by their employers. Project
+decisions are made in the interest of APM and its users, independent
+of any single employer's commercial priorities. Maintainers disclose
+conflicts of interest when they arise.
 
 ## Contributors
 
-Thank you to all our contributors! 
+APM is built by contributors from many organizations and independent
+developers. See the full list:
 
-[This space will be updated as contributors join the project]
+https://github.com/microsoft/apm/graphs/contributors
 
-Want to contribute? Check out our [Contributing Guidelines](CONTRIBUTING.md).
+Want to contribute? See [Contributing Guidelines](CONTRIBUTING.md).


### PR DESCRIPTION
## Why

Two issues with the current `AUTHORS`:

1. **Vendor-neutrality signal is missing.** Both maintainers are listed with no affiliation. APM is hosted under `microsoft/` and reads as a single-vendor project, even though Sergio is at EPAM Systems and the contributor base spans Red Hat, Inditex, Wolters Kluwer, Mirego, Check Point, Linde, Microsoft, EPAM, plus ~30 independents. The cross-organization reality is invisible.

2. **The contributor section is stale.** It still says `[This space will be updated as contributors join the project]` while the project already has 40+ contributors per `git shortlog`.

## What

Aligns `AUTHORS` with how foundation-grade OSS projects (CNCF, Linux Foundation, OpenTelemetry, Envoy, Kubernetes) frame employer-sponsored maintainership:

- **Both maintainers listed with explicit affiliations** (Microsoft, EPAM Systems). This is the highest-leverage neutrality signal available without changing governance.
- **Drop the `Creator and Lead Maintainer` / `Maintainer` hierarchy.** Flat list. Lead-vs-not framing implies single-vendor control. Effective ownership is unchanged (CODEOWNERS still reflects current responsibilities).
- **Replace the volunteer-OSS `personal capacity` convention** (dishonest for paid maintainers) with the CNCF-pattern commitment: project decisions are made in the project's interest, independent of any employer's commercial priorities, with COI disclosure when relevant.
- **Link to the GitHub contributors graph** instead of a placeholder. Stays current automatically.

## What this does NOT do

- Does **not** add a maintainer-onboarding process or `GOVERNANCE.md` (deliberately scoped small).
- Does **not** change CODEOWNERS, decision-making, or release process.
- Does **not** open the project to new maintainers — it just describes the existing two more honestly.

A future `GOVERNANCE.md` (decision model, how to become a maintainer, dispute resolution) is the natural next step when the project is ready to formalize.

## Reference

CNCF Project Governance Guidelines: https://contribute.cncf.io/maintainers/governance/