### PR TITLE
[docs] Update documentation for features from 2026-05-01

### DIFF
--- a/docs/src/content/docs/guides/compilation.md
+++ b/docs/src/content/docs/guides/compilation.md
@@ -20,7 +20,7 @@ When you run `apm compile` without specifying a target, APM automatically detect
 
 | Project Structure | Target | What Gets Generated |
 |-------------------|--------|---------------------|
-| `.github/` folder only | `copilot` | AGENTS.md (instructions only) |
+| `.github/` folder only | `copilot` | AGENTS.md + `.github/copilot-instructions.md` (global instructions) |
 | `.claude/` folder only | `claude` | CLAUDE.md (instructions only) |
 | `.codex/` folder exists | `codex` | AGENTS.md (instructions only) |
 | `.gemini/` folder exists | `gemini` | GEMINI.md (instructions only) |
@@ -53,7 +53,7 @@ target: [claude, copilot]  # multiple targets -- only these are compiled
 
 | Target | Files Generated | Consumers |
 |--------|-----------------|-----------|
-| `copilot` | `AGENTS.md` | GitHub Copilot, Cursor, OpenCode |
+| `copilot` | `AGENTS.md` + `.github/copilot-instructions.md` | GitHub Copilot, Cursor, OpenCode |
 | `claude` | `CLAUDE.md` | Claude Code, Claude Desktop |
 | `gemini` | `GEMINI.md` | Gemini CLI |
 | `codex` | `AGENTS.md` | Codex CLI |
@@ -61,6 +61,8 @@ target: [claude, copilot]  # multiple targets -- only these are compiled
 | `minimal` | `AGENTS.md` only | Works everywhere, no folder integration |
 
 > **Aliases**: `vscode` and `agents` are accepted as aliases for `copilot`.
+
+> **Note**: For the `copilot` target, instructions without an `applyTo` pattern (global instructions) are also synthesized into `.github/copilot-instructions.md`. Instructions with `applyTo` patterns continue to flow into per-pattern `.github/instructions/*.instructions.md` files. The generated `.github/copilot-instructions.md` carries a build-id marker so `apm compile` can cleanly remove it when switching to a non-Copilot target -- manually-authored files at the same path are preserved.
 
 > **Note**: `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md` contain **only instructions** (grouped by `applyTo` patterns). Prompts, agents, commands, hooks, and skills are integrated by `apm install`, not `apm compile`. See the [Integrations Guide](../../integrations/ide-tool-integration/) for details on how `apm install` populates `.github/prompts/`, `.github/agents/`, `.github/skills/`, `.claude/commands/`, `.cursor/rules/`, `.cursor/agents/`, `.opencode/agents/`, `.opencode/commands/`, `.codex/agents/`, `.gemini/commands/`, and `.agents/skills/`.
 
@@ -73,11 +75,13 @@ target: [claude, copilot]  # multiple targets -- only these are compiled
 
 ### Example Output
 
-**After `apm compile`:**
+**After `apm compile` (copilot target):**
 ```
 my-project/
-├── AGENTS.md              # Instructions only (for Copilot, Cursor, etc.)
-└── CLAUDE.md              # Instructions only (for Claude)
+├── AGENTS.md                          # Instructions (for Copilot, Cursor, etc.)
+├── CLAUDE.md                          # Instructions (for Claude)
+└── .github/
+    └── copilot-instructions.md        # Global instructions synthesized from .apm/instructions/ (no applyTo)
 ```
 
 **After `apm install` (folder integration):**
@@ -445,7 +449,7 @@ Different AI tools get different levels of support from `apm install` vs `apm co
 
 | AI Tool | What `apm install` deploys | What `apm compile` adds | Support level |
 |---------|--------------------------|------------------------|---------------|
-| GitHub Copilot | `.github/instructions/`, `.github/prompts/`, agents, hooks, plugins, MCP | `AGENTS.md` (optional) | **Full** |
+| GitHub Copilot | `.github/instructions/`, `.github/prompts/`, agents, hooks, plugins, MCP | `AGENTS.md` + `.github/copilot-instructions.md` (global instructions) | **Full** |
 | Claude | `.claude/` commands, skills, MCP | `CLAUDE.md` | **Full** |
 | Cursor | `.cursor/rules/`, `.cursor/agents/`, `.cursor/skills/`, `.cursor/hooks.json`, `.cursor/mcp.json` | `AGENTS.md` (optional) | **Full** |
 | OpenCode | `.opencode/agents/`, `.opencode/commands/`, `.opencode/skills/`, `opencode.json` (MCP) | Via `AGENTS.md` | **Full** |


### PR DESCRIPTION
## Documentation Updates - 2026-05-01

This PR updates the documentation based on features merged in the last 24 hours.

### Features Documented

- `apm compile -t copilot` now emits `.github/copilot-instructions.md` from global instructions (from #1067)

### Changes Made

- Updated `docs/src/content/docs/guides/compilation.md`:
  - Target auto-detection table: `copilot` row now shows both `AGENTS.md` and `.github/copilot-instructions.md`
  - Output Files table: updated `copilot` entry to include `.github/copilot-instructions.md`
  - Added explanatory note: global instructions (no `applyTo`) go to `.github/copilot-instructions.md`; per-pattern instructions continue to flow into `.github/instructions/*.instructions.md`; generated files carry a build-id marker for safe cleanup
  - Example Output: updated the example directory tree to show the new file
  - Tool Compatibility table: updated GitHub Copilot row to reflect new compile output

### Merged PRs Referenced

- #1067 - fix(compile): emit and clean up copilot root instructions
- #1063 - feat(marketplace): harden apm pack output (marketplace-authoring.md was already up to date)
- #1086 - test(windows): fix CLAUDE_CONFIG_DIR scope tests on Windows (test-only, no doc change needed)
- #1083 - fix: remove Codex-only user-visible hint on opt-in miss (internal behavior, no doc change needed)
- #1090 - docs(authors): show maintainer affiliations and link contributor graph (AUTHORS file, no guide doc change needed)
- #1073 - docs(notice): rename NOTICE.md -> NOTICE; add CLA third-party section (legal file, no guide doc change needed)
- #1068 - fix: extend explicit UTF-8 encoding to 5 remaining open() call sites (bug fix for Windows, no doc change needed)

### Notes

The marketplace-authoring.md guide was already up to date with the new fields added in #1063 (`author`, `license`, `repository`, `keywords`, pluginRoot subtraction, curator-wins override semantics). No changes were needed there.




> [!NOTE]
> <details>
> <summary>🔒 Integrity filter blocked 13 items</summary>
>
> The following items were blocked because they don't meet the GitHub integrity level.
>
> - [#1084](https://github.com/microsoft/apm/pull/1084) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1055](https://github.com/microsoft/apm/pull/1055) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1052](https://github.com/microsoft/apm/pull/1052) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1048](https://github.com/microsoft/apm/pull/1048) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1034](https://github.com/microsoft/apm/pull/1034) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1024](https://github.com/microsoft/apm/pull/1024) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#991](https://github.com/microsoft/apm/pull/991) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#959](https://github.com/microsoft/apm/pull/959) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#951](https://github.com/microsoft/apm/pull/951) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#947](https://github.com/microsoft/apm/pull/947) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#941](https://github.com/microsoft/apm/pull/941) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#937](https://github.com/microsoft/apm/pull/937) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#871](https://github.com/microsoft/apm/pull/871) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/25214893447/agentic_workflow) · ● 1.4M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+%22gh-aw-workflow-id%3A+daily-doc-updater%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/blob/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-05-03T12:56:56.372Z --> on May 3, 2026, 12:56 PM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, version: 1.0.36, model: claude-sonnet-4.6, id: 25214893447, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/25214893447 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->