### PR TITLE
[Test Improver] test: add error-handling and display-variation tests for view command

### DIFF
--- a/tests/unit/test_view_command.py
+++ b/tests/unit/test_view_command.py
@@ -690,3 +690,190 @@ class TestViewMarketplaceNoField(_InfoCmdBase):
 
         assert result.exit_code == 0
         assert "1.0.0" in result.output
+
+
+# ------------------------------------------------------------------
+# _display_marketplace_plugin error and display variation tests
+# ------------------------------------------------------------------
+
+
+class TestDisplayMarketplacePluginErrors(_InfoCmdBase):
+    """Error handling and display variations for _display_marketplace_plugin."""
+
+    def _invoke_marketplace(self, plugin_name="my-plugin", marketplace="acme-tools"):
+        return self.runner.invoke(cli, ["view", f"{plugin_name}@{marketplace}"])
+
+    def test_marketplace_not_found_exits_1(self):
+        """Exits 1 when get_marketplace_by_name raises an exception."""
+        with patch(
+            "apm_cli.marketplace.registry.get_marketplace_by_name",
+            side_effect=ValueError("unknown marketplace: acme-tools"),
+        ):
+            result = self._invoke_marketplace()
+        assert result.exit_code == 1
+        assert "unknown marketplace" in result.output.lower()
+
+    def test_marketplace_fetch_error_exits_1(self):
+        """Exits 1 when fetch_or_cache raises MarketplaceFetchError."""
+        from apm_cli.marketplace.errors import MarketplaceFetchError
+        from apm_cli.marketplace.models import MarketplaceSource
+
+        source = MarketplaceSource(name="acme-tools", owner="acme", repo="marketplace")
+        with (
+            patch(
+                "apm_cli.marketplace.registry.get_marketplace_by_name",
+                return_value=source,
+            ),
+            patch(
+                "apm_cli.marketplace.client.fetch_or_cache",
+                side_effect=MarketplaceFetchError("network failure"),
+            ),
+        ):
+            result = self._invoke_marketplace()
+        assert result.exit_code == 1
+        assert "network failure" in result.output
+
+    def test_plugin_not_found_exits_1(self):
+        """Exits 1 when the plugin is absent from the marketplace manifest."""
+        from apm_cli.marketplace.models import (
+            MarketplaceManifest,
+            MarketplaceSource,
+        )
+
+        manifest = MarketplaceManifest(name="acme-tools", plugins=())
+        source = MarketplaceSource(name="acme-tools", owner="acme", repo="marketplace")
+        with (
+            patch(
+                "apm_cli.marketplace.registry.get_marketplace_by_name",
+                return_value=source,
+            ),
+            patch(
+                "apm_cli.marketplace.client.fetch_or_cache",
+                return_value=manifest,
+            ),
+        ):
+            result = self._invoke_marketplace(plugin_name="missing-plugin")
+        assert result.exit_code == 1
+        assert "missing-plugin" in result.output
+
+    def test_plugin_with_str_source_displays(self):
+        """Plugin with a plain string source renders the source value."""
+        from apm_cli.marketplace.models import (
+            MarketplaceManifest,
+            MarketplacePlugin,
+            MarketplaceSource,
+        )
+
+        plugin = MarketplacePlugin(
+            name="str-plugin",
+            source="github.com/acme/str-plugin",
+            version="0.1.0",
+        )
+        manifest = MarketplaceManifest(name="acme-tools", plugins=(plugin,))
+        source = MarketplaceSource(name="acme-tools", owner="acme", repo="marketplace")
+
+        with (
+            patch(
+                "apm_cli.marketplace.registry.get_marketplace_by_name",
+                return_value=source,
+            ),
+            patch(
+                "apm_cli.marketplace.client.fetch_or_cache",
+                return_value=manifest,
+            ),
+            _force_rich_fallback(),
+        ):
+            result = self.runner.invoke(cli, ["view", "str-plugin@acme-tools"])
+
+        assert result.exit_code == 0
+        assert "github.com/acme/str-plugin" in result.output
+
+    def test_plugin_with_tags_displays(self):
+        """Plugin tags are shown in the output."""
+        from apm_cli.marketplace.models import (
+            MarketplaceManifest,
+            MarketplacePlugin,
+            MarketplaceSource,
+        )
+
+        plugin = MarketplacePlugin(
+            name="tagged-plugin",
+            source={"type": "github", "repo": "acme/tagged", "ref": "main"},
+            version="1.0.0",
+            tags=["ai", "testing"],
+        )
+        manifest = MarketplaceManifest(name="acme-tools", plugins=(plugin,))
+        source = MarketplaceSource(name="acme-tools", owner="acme", repo="marketplace")
+
+        with (
+            patch(
+                "apm_cli.marketplace.registry.get_marketplace_by_name",
+                return_value=source,
+            ),
+            patch(
+                "apm_cli.marketplace.client.fetch_or_cache",
+                return_value=manifest,
+            ),
+            _force_rich_fallback(),
+        ):
+            result = self.runner.invoke(cli, ["view", "tagged-plugin@acme-tools"])
+
+        assert result.exit_code == 0
+        assert "ai" in result.output
+        assert "testing" in result.output
+
+    def test_plugin_without_version_or_description(self):
+        """Plugin with no version/description renders without those lines."""
+        from apm_cli.marketplace.models import (
+            MarketplaceManifest,
+            MarketplacePlugin,
+            MarketplaceSource,
+        )
+
+        plugin = MarketplacePlugin(
+            name="bare-plugin",
+            source={"type": "github", "repo": "acme/bare"},
+        )
+        manifest = MarketplaceManifest(name="acme-tools", plugins=(plugin,))
+        source = MarketplaceSource(name="acme-tools", owner="acme", repo="marketplace")
+
+        with (
+            patch(
+                "apm_cli.marketplace.registry.get_marketplace_by_name",
+                return_value=source,
+            ),
+            patch(
+                "apm_cli.marketplace.client.fetch_or_cache",
+                return_value=manifest,
+            ),
+            _force_rich_fallback(),
+        ):
+            result = self.runner.invoke(cli, ["view", "bare-plugin@acme-tools"])
+
+        assert result.exit_code == 0
+        assert "bare-plugin" in result.output
+        assert "Install: apm install bare-plugin@acme-tools" in result.output
+
+
+# ------------------------------------------------------------------
+# display_package_info exception handling
+# ------------------------------------------------------------------
+
+
+class TestDisplayPackageInfoErrors(_InfoCmdBase):
+    """Verify display_package_info handles unexpected exceptions gracefully."""
+
+    def test_package_info_read_failure_exits_1(self):
+        """Exits 1 and shows error message when _get_detailed_package_info raises."""
+        with self._chdir_tmp() as tmp:
+            self._make_package(tmp, "eorg", "erepo")
+            import os
+
+            os.chdir(tmp)
+            with patch(
+                "apm_cli.commands.view._get_detailed_package_info",
+                side_effect=OSError("permission denied"),
+            ):
+                result = self.runner.invoke(cli, ["view", "eorg/erepo"])
+        assert result.exit_code == 1
+        assert "error" in result.output.lower()


### PR DESCRIPTION
🤖 *Test Improver - automated AI assistant*

## Goal

Cover 7 previously untested code paths in `src/apm_cli/commands/view.py` that handle error conditions and display variations in `_display_marketplace_plugin` and `display_package_info`.

## Approach

Added tests to `tests/unit/test_view_command.py` in two new test classes:

**`TestDisplayMarketplacePluginErrors`** (6 tests):
- `test_marketplace_not_found_exits_1` - `get_marketplace_by_name` raises `ValueError` -> exit 1
- `test_marketplace_fetch_error_exits_1` - `fetch_or_cache` raises `MarketplaceFetchError` -> exit 1
- `test_plugin_not_found_exits_1` - plugin absent from manifest -> exit 1
- `test_plugin_with_str_source_displays` - `source` is a plain string, renders correctly
- `test_plugin_with_tags_displays` - plugin `tags` list appears in output
- `test_plugin_without_version_or_description` - minimal plugin renders without optional fields

**`TestDisplayPackageInfoErrors`** (1 test):
- `test_package_info_read_failure_exits_1` - `_get_detailed_package_info` raises `OSError` -> exit 1 + error message shown

## Coverage Impact

| Metric | Before | After |
|--------|--------|-------|
| Tests in file | 34 | 41 |
| New tests | - | +7 |

These are error-handling and conditional-display paths that previously had zero test coverage. The error paths are particularly valuable because they verify that bad marketplace configs fail fast with clear messages instead of crashing silently.

## Trade-offs

- All tests are fully mocked - no network calls or filesystem side-effects beyond existing patterns in the file.
- Tests follow the same helper pattern (`_force_rich_fallback`, `_chdir_tmp`) already used in the file.

## Test Status

```
41 passed in 1.70s
```

Lint: `ruff check` and `ruff format --check` both pass clean.

## Reproducibility

```bash
.venv/bin/pytest tests/unit/test_view_command.py -v
```




> [!NOTE]
> <details>
> <summary>🔒 Integrity filter blocked 17 items</summary>
>
> The following items were blocked because they don't meet the GitHub integrity level.
>
> - [#1097](https://github.com/microsoft/apm/pull/1097) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1088](https://github.com/microsoft/apm/pull/1088) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1085](https://github.com/microsoft/apm/pull/1085) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1069](https://github.com/microsoft/apm/pull/1069) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1066](https://github.com/microsoft/apm/pull/1066) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1046](https://github.com/microsoft/apm/pull/1046) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1028](https://github.com/microsoft/apm/pull/1028) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1017](https://github.com/microsoft/apm/pull/1017) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#940](https://github.com/microsoft/apm/pull/940) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#928](https://github.com/microsoft/apm/pull/928) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#900](https://github.com/microsoft/apm/pull/900) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#881](https://github.com/microsoft/apm/pull/881) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#869](https://github.com/microsoft/apm/pull/869) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#691](https://github.com/microsoft/apm/pull/691) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#655](https://github.com/microsoft/apm/pull/655) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#630](https://github.com/microsoft/apm/pull/630) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - ... and 1 more item
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [Daily Test Improver](https://github.com/microsoft/apm/actions/runs/25242820159/agentic_workflow) · ● 4.1M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+%22gh-aw-workflow-id%3A+daily-test-improver%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/blob/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-test-improver.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-test-improver.md@b87234850bf9664d198f28a02df0f937d0447295
> ```

<!-- gh-aw-agentic-workflow: Daily Test Improver, engine: copilot, version: 1.0.36, model: claude-sonnet-4.6, id: 25242820159, workflow_id: daily-test-improver, run: https://github.com/microsoft/apm/actions/runs/25242820159 -->

<!-- gh-aw-workflow-id: daily-test-improver -->