### PR TITLE
fix(marketplace): resolve source.repo vs source.repository key mismatch (#1105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`apm install <pkg>@<marketplace>` no longer fails for all marketplace packages** due to a `source.repo` vs `source.repository` key-name mismatch in the install resolver. The resolver now accepts both key names with a backward-compatible fallback. ([#1105](https://github.com/microsoft/apm/issues/1105))
+- **`apm install <pkg>@<marketplace>` no longer fails for all marketplace packages** due to a `source.repo` vs `source.repository` key-name mismatch in the install resolver. The resolver now accepts both key names with a backward-compatible fallback. (#1106, closes #1105)
 - **`apm install --update` no longer fails for GHES/generic hosts** that rely on git credential helpers (e.g., `git-credential-manager`) for authentication. The preflight auth probe was blocking credential helpers by setting `GIT_CONFIG_GLOBAL=/dev/null`; it now uses the same relaxed environment as the clone fallback path for non-GitHub/non-ADO hosts. (#1082)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`apm install <pkg>@<marketplace>` no longer fails for all marketplace packages** due to a `source.repo` vs `source.repository` key-name mismatch in the install resolver. The resolver now accepts both key names with a backward-compatible fallback. ([#1105](https://github.com/microsoft/apm/issues/1105))
 - **`apm install --update` no longer fails for GHES/generic hosts** that rely on git credential helpers (e.g., `git-credential-manager`) for authentication. The preflight auth probe was blocking credential helpers by setting `GIT_CONFIG_GLOBAL=/dev/null`; it now uses the same relaxed environment as the clone fallback path for non-GitHub/non-ADO hosts. (#1082)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`apm install <pkg>@<marketplace>` no longer fails for all marketplace packages** due to a `source.repo` vs `source.repository` key-name mismatch in the install resolver. The resolver now accepts both key names with a backward-compatible fallback. (#1106, closes #1105)
+- **`apm install <pkg>@<marketplace>` no longer fails for all marketplace packages.** The install resolver now accepts both legacy and current marketplace key names: `repository`/`repo` for github sources, `url`/`repo` for git-subdir sources, and `type`/`source` as the source-type discriminator. A scheme guard rejects full URLs passed through the `url` fallback. (#1106, closes #1105)
 - **`apm install --update` no longer fails for GHES/generic hosts** that rely on git credential helpers (e.g., `git-credential-manager`) for authentication. The preflight auth probe was blocking credential helpers by setting `GIT_CONFIG_GLOBAL=/dev/null`; it now uses the same relaxed environment as the clone fallback path for non-GitHub/non-ADO hosts. (#1082)
 
 ### Added

--- a/docs/src/content/docs/guides/marketplaces.md
+++ b/docs/src/content/docs/guides/marketplaces.md
@@ -48,6 +48,19 @@ Both Copilot CLI and Claude Code `marketplace.json` formats are supported. Copil
 
 npm sources are not supported. Copilot CLI format uses `"repository"` and optional `"ref"` fields instead of `"source"`.
 
+### Source key aliases
+
+The install resolver accepts both legacy (Copilot CLI) and current (Claude Code) key names in `marketplace.json` source objects:
+
+| Current key | Legacy alias | Notes |
+|---|---|---|
+| `source` (discriminator) | `type` | Values: `github`, `git-subdir`, `url` |
+| `repo` | `repository` | Must be `owner/repo` format |
+| `sha` | `commit` | Resolved commit SHA |
+| `repo` (git-subdir) | `url` | Must be `owner/repo`, not a full URL |
+
+Marketplace authors should use the current keys (emitted by `apm pack`). Legacy aliases are accepted for backward compatibility with older manifests.
+
 ### Plugin root directory
 
 Marketplaces can declare a `metadata.pluginRoot` field to specify the base directory for bare-name sources:

--- a/src/apm_cli/marketplace/resolver.py
+++ b/src/apm_cli/marketplace/resolver.py
@@ -76,7 +76,9 @@ def _resolve_github_source(source: dict) -> str:
     ref = source.get("ref", "")
     path = source.get("path", "").strip("/")
     if not repo or "/" not in repo:
-        raise ValueError(f"Invalid github source: 'repo' field must be 'owner/repo', got '{repo}'")
+        raise ValueError(
+            f"Invalid github source: 'repo' (or 'repository') field must be 'owner/repo', got '{repo}'"
+        )
     if path:
         try:
             validate_path_segments(path, context="github source path")
@@ -116,10 +118,18 @@ def _resolve_url_source(source: dict) -> str:
 def _resolve_git_subdir_source(source: dict) -> str:
     """Resolve a ``git-subdir`` source type to ``owner/repo[/subdir][#ref]``."""
     repo = source.get("repo", "") or source.get("url", "")
+    # Reject full URLs -- the url fallback accepts owner/repo strings only
+    if "://" in repo:
+        raise ValueError(
+            f"Invalid git-subdir source: expected 'owner/repo' but got a URL '{repo}'. "
+            f"Use source type 'url' for full URL references."
+        )
     ref = source.get("ref", "")
     subdir = (source.get("subdir", "") or source.get("path", "")).strip("/")
     if not repo or "/" not in repo:
-        raise ValueError(f"Invalid git-subdir source: 'repo' must be 'owner/repo', got '{repo}'")
+        raise ValueError(
+            f"Invalid git-subdir source: 'repo' (or 'url') must be 'owner/repo', got '{repo}'"
+        )
     if subdir:
         try:
             validate_path_segments(subdir, context="git-subdir source path")

--- a/src/apm_cli/marketplace/resolver.py
+++ b/src/apm_cli/marketplace/resolver.py
@@ -72,7 +72,7 @@ def _resolve_github_source(source: dict) -> str:
 
     Accepts ``path`` field (Copilot CLI format) as a virtual subdirectory.
     """
-    repo = source.get("repo", "")
+    repo = source.get("repo", "") or source.get("repository", "")
     ref = source.get("ref", "")
     path = source.get("path", "").strip("/")
     if not repo or "/" not in repo:
@@ -115,7 +115,7 @@ def _resolve_url_source(source: dict) -> str:
 
 def _resolve_git_subdir_source(source: dict) -> str:
     """Resolve a ``git-subdir`` source type to ``owner/repo[/subdir][#ref]``."""
-    repo = source.get("repo", "")
+    repo = source.get("repo", "") or source.get("url", "")
     ref = source.get("ref", "")
     subdir = (source.get("subdir", "") or source.get("path", "")).strip("/")
     if not repo or "/" not in repo:
@@ -207,7 +207,7 @@ def resolve_plugin_source(
             f"Plugin '{plugin.name}' has unrecognized source format: {type(source).__name__}"
         )
 
-    source_type = source.get("type", "")
+    source_type = source.get("type", "") or source.get("source", "")
 
     if source_type == "github":
         return _resolve_github_source(source)

--- a/tests/fixtures/marketplace/golden.json
+++ b/tests/fixtures/marketplace/golden.json
@@ -14,15 +14,16 @@
   "plugins": [
     {
       "name": "code-reviewer",
+      "description": "Automated code review assistant",
       "tags": [
         "review",
         "quality"
       ],
       "source": {
-        "type": "github",
-        "repository": "acme/code-reviewer",
+        "source": "github",
+        "repo": "acme/code-reviewer",
         "ref": "v2.1.0",
-        "commit": "abcd234567890abcdef1234567890abcdef12345"
+        "sha": "abcd234567890abcdef1234567890abcdef12345"
       }
     },
     {
@@ -31,11 +32,11 @@
         "testing"
       ],
       "source": {
-        "type": "github",
-        "repository": "acme/test-generator",
+        "source": "git-subdir",
+        "url": "acme/test-generator",
         "path": "src/plugin",
         "ref": "v1.0.3",
-        "commit": "def4567890abcdef1234567890abcdef12345678"
+        "sha": "def4567890abcdef1234567890abcdef12345678"
       }
     }
   ]

--- a/tests/integration/marketplace/test_build_integration.py
+++ b/tests/integration/marketplace/test_build_integration.py
@@ -100,16 +100,16 @@ class TestBuildGoldenFile:
             assert keys[-1] == "source"
 
     def test_source_key_order(self, tmp_path: Path, mock_ref_resolver_golden):
-        """Each source block must follow: type, repository, (path), ref, commit."""
+        """Each source block must follow: source, repo/url, (path), ref, sha."""
         _write_yml(tmp_path, GOLDEN_YML)
         builder = MarketplaceBuilder(tmp_path / "marketplace.yml")
         builder.build()
 
         data = _read_json(tmp_path)
-        # test-generator has subdir -> path must appear between repository and ref
+        # test-generator has subdir -> path must appear between url and ref
         tg = next(p for p in data["plugins"] if p["name"] == "test-generator")
         src_keys = list(tg["source"].keys())
-        assert src_keys == ["type", "repository", "path", "ref", "commit"]
+        assert src_keys == ["source", "url", "path", "ref", "sha"]
 
     def test_no_apm_only_keys_in_output(self, tmp_path: Path, mock_ref_resolver_golden):
         """APM-only fields must not appear in marketplace.json."""
@@ -158,7 +158,7 @@ class TestBuildHappyPath:
 
         data = _read_json(tmp_path)
         for plugin in data["plugins"]:
-            sha = plugin["source"]["commit"]
+            sha = plugin["source"]["sha"]
             assert len(sha) == 40, f"Expected 40-char SHA, got {sha!r}"
             assert all(c in "0123456789abcdef" for c in sha)
 

--- a/tests/unit/marketplace/test_builder.py
+++ b/tests/unit/marketplace/test_builder.py
@@ -979,10 +979,10 @@ class TestGoldenFile:
             assert "tags" in plugin
             assert "source" in plugin
             src = plugin["source"]
-            assert src["type"] == "github"
-            assert "repository" in src
+            assert src.get("source") in ("github", "git-subdir")
+            assert "repo" in src or "url" in src
             assert "ref" in src
-            assert "commit" in src
+            assert "sha" in src
 
     def test_golden_file_no_apm_keys(self) -> None:
         data = json.loads(_GOLDEN_PATH.read_text("utf-8"))

--- a/tests/unit/marketplace/test_marketplace_resolver.py
+++ b/tests/unit/marketplace/test_marketplace_resolver.py
@@ -409,3 +409,49 @@ class TestResolvePluginSource:
         p = MarketplacePlugin(name="test", source=None)
         with pytest.raises(ValueError, match="no source defined"):
             resolve_plugin_source(p)
+
+
+class TestOldFormatIntegration:
+    """Integration tests verifying old-format marketplace entries resolve correctly."""
+
+    def test_old_github_format_full_pipeline(self) -> None:
+        """Old format with type/repository/commit resolves via resolve_plugin_source."""
+        plugin = MarketplacePlugin(
+            name="legacy-plugin",
+            source={
+                "type": "github",
+                "repository": "acme/legacy-tool",
+                "ref": "main",
+                "commit": "abc123",
+            },
+        )
+        result = resolve_plugin_source(plugin, "org", "marketplace", plugin_root="")
+        assert result == "acme/legacy-tool#main"
+
+    def test_old_git_subdir_format_full_pipeline(self) -> None:
+        """Old format with type/url/path resolves via resolve_plugin_source."""
+        plugin = MarketplacePlugin(
+            name="legacy-subdir",
+            source={
+                "type": "git-subdir",
+                "url": "acme/monorepo",
+                "path": "tools/helper",
+                "ref": "v2.0",
+            },
+        )
+        result = resolve_plugin_source(plugin, "org", "marketplace", plugin_root="")
+        assert result == "acme/monorepo/tools/helper#v2.0"
+
+    def test_old_format_url_with_scheme_rejected(self) -> None:
+        """A full URL in the url field is rejected by the scheme guard."""
+        plugin = MarketplacePlugin(
+            name="bad-url",
+            source={
+                "type": "git-subdir",
+                "url": "https://evil.example.com/payload",
+                "path": "x",
+                "ref": "main",
+            },
+        )
+        with pytest.raises(ValueError, match=r"expected 'owner/repo' but got a URL"):
+            resolve_plugin_source(plugin, "org", "marketplace", plugin_root="")

--- a/tests/unit/marketplace/test_marketplace_resolver.py
+++ b/tests/unit/marketplace/test_marketplace_resolver.py
@@ -131,6 +131,19 @@ class TestResolveGithubSource:
         with pytest.raises(ValueError, match="owner/repo"):
             _resolve_github_source({"repo": "just-a-name"})
 
+    def test_repository_key_fallback(self):
+        """Old marketplace format uses 'repository' instead of 'repo'."""
+        assert (
+            _resolve_github_source({"repository": "owner/repo", "ref": "v1.0"}) == "owner/repo#v1.0"
+        )
+
+    def test_repo_key_takes_precedence(self):
+        """When both 'repo' and 'repository' are present, 'repo' wins."""
+        result = _resolve_github_source(
+            {"repo": "owner/new-repo", "repository": "owner/old-repo", "ref": "v1.0"}
+        )
+        assert result == "owner/new-repo#v1.0"
+
 
 class TestResolveUrlSource:
     """Resolve url source type."""
@@ -216,6 +229,18 @@ class TestResolveGitSubdirSource:
     def test_path_traversal_rejected(self):
         with pytest.raises(ValueError, match="traversal sequence"):
             _resolve_git_subdir_source({"repo": "owner/mono", "subdir": "../escape"})
+
+    def test_url_key_fallback(self):
+        """Builder emits 'url' instead of 'repo' for git-subdir sources."""
+        result = _resolve_git_subdir_source({"url": "owner/mono", "path": "pkg", "ref": "v1.0"})
+        assert result == "owner/mono/pkg#v1.0"
+
+    def test_repo_key_takes_precedence_over_url(self):
+        """When both 'repo' and 'url' are present, 'repo' wins."""
+        result = _resolve_git_subdir_source(
+            {"repo": "owner/primary", "url": "owner/fallback", "subdir": "pkg"}
+        )
+        assert result == "owner/primary/pkg"
 
 
 class TestResolveRelativeSource:
@@ -347,6 +372,30 @@ class TestResolvePluginSource:
         )
         with pytest.raises(ValueError, match="npm source type"):
             resolve_plugin_source(p)
+
+    def test_source_discriminator_key(self):
+        """New builder format uses 'source' as discriminator instead of 'type'."""
+        p = MarketplacePlugin(
+            name="test",
+            source={"source": "github", "repo": "owner/repo", "ref": "v1.0"},
+        )
+        assert resolve_plugin_source(p) == "owner/repo#v1.0"
+
+    def test_source_discriminator_git_subdir(self):
+        """New builder format for git-subdir uses 'source' key and 'url' field."""
+        p = MarketplacePlugin(
+            name="test",
+            source={"source": "git-subdir", "url": "owner/mono", "path": "pkg/a", "ref": "main"},
+        )
+        assert resolve_plugin_source(p) == "owner/mono/pkg/a#main"
+
+    def test_old_format_repository_key(self):
+        """Old marketplace format uses 'type' and 'repository' keys."""
+        p = MarketplacePlugin(
+            name="test",
+            source={"type": "github", "repository": "owner/repo", "ref": "v1.0"},
+        )
+        assert resolve_plugin_source(p) == "owner/repo#v1.0"
 
     def test_unknown_source_type_rejected(self):
         p = MarketplacePlugin(


### PR DESCRIPTION
## Description

Fix key mismatch between `apm pack` output and `apm install` resolver that caused **all** marketplace installs to fail with:
```
Invalid github source: 'repo' field must be 'owner/repo', got ''
```

The resolver only read the `"repo"` key, but:
- Old marketplaces and Copilot CLI use `"repository"`
- The builder emits `"url"` for git-subdir sources
- The builder uses `"source"` as discriminator, not `"type"`

The fix adds backward-compatible fallbacks so both old and new formats are accepted.

Fixes #1105

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

**7 new unit tests** covering:
- `"repository"` fallback for github sources
- `"url"` fallback for git-subdir sources
- `"source"` discriminator key fallback
- Precedence when both old and new keys are present
- End-to-end old-format resolution via `resolve_plugin_source`