### PR TITLE
[docs] Update documentation for features from 2026-05-02

### DIFF
--- a/docs/src/content/docs/guides/pack-distribute.md
+++ b/docs/src/content/docs/guides/pack-distribute.md
@@ -26,10 +26,10 @@ Common motivations:
 The pack/distribute workflow fits between install and consumption:
 
 ```
-apm install  ->  apm pack  ->  upload artifact  ->  download  ->  apm unpack (or tar xzf)
+apm install  ->  apm pack  ->  upload artifact  ->  download  ->  apm install <bundle>
 ```
 
-The left side (install, pack) runs where APM is available. The right side (download, unpack) runs anywhere — a CI job, a dev container, a colleague's laptop. The bundle is the boundary.
+The left side (install, pack) runs where APM is available. The right side (download, install) runs anywhere — a CI job, a dev container, a colleague's laptop. The bundle is the boundary.
 
 ## `apm pack`
 
@@ -126,7 +126,7 @@ This is informational -- the files still extract. The warning helps users unders
 |---|---|---|
 | Output layout | Claude Code plugin directory with `plugin.json` at the root and convention dirs (`agents/`, `skills/`, `commands/`, `instructions/`, `hooks/`) | Mirrors `apm install` deploy paths (`.github/`, `.claude/`, `.cursor/`, `.opencode/`) plus an enriched `apm.lock.yaml` |
 | `plugin.json` | Synthesized (or updated from existing) and validates against the [official Claude Code plugin manifest schema](https://json.schemastore.org/claude-code-plugin.json) | Not emitted |
-| `apm.lock.yaml` inside output | Not emitted (no APM-specific files) | Enriched copy with a `pack:` metadata section |
+| `apm.lock.yaml` inside output | Embedded at bundle root with a `pack.bundle_files` sha256 manifest (SBOM). Consumed by `apm install <bundle>` for integrity verification. | Enriched copy with a `pack:` metadata section |
 | Drop-in for | Any Claude Code plugin consumer (Copilot CLI, Claude Code, Cursor, ...) | `microsoft/apm-action`'s restore mode and bundle-aware tooling |
 | `devDependencies` | Excluded | Included (full install layout) |
 
@@ -278,11 +278,35 @@ dependencies:
       - .github/agents/architect.md
 ```
 
-The `pack:` section records the bundle `format`, the effective `target` filter, and a `packed_at` UTC timestamp. Plugin-format output has no `apm.lock.yaml` -- consumers verify by re-running the upstream pack instead.
+The `pack:` section records the bundle `format`, the effective `target` filter, and a `packed_at` UTC timestamp. Plugin-format output includes an `apm.lock.yaml` with a `pack.bundle_files` sha256 manifest at the bundle root — this is the SBOM that `apm install <bundle>` uses for integrity verification.
 
-## `apm unpack`
+## `apm install <bundle>` (restore)
 
-Extracts an APM bundle (produced with `--format apm`) into a project directory. Accepts both `.tar.gz` archives and unpacked bundle directories. Plugin-format output is consumed directly by Claude Code and other plugin hosts and does not need `apm unpack`.
+Restores a packed plugin bundle (directory or `.tar.gz`) produced by `apm pack`. This is the single restore primitive — matching the `pip install ./wheel` / `cargo install --path` mental model.
+
+```bash
+# Install from a bundle directory
+apm install ./build/my-plugin-1.0.0/
+
+# Install from a .tar.gz archive
+apm install ./build/my-plugin-1.0.0.tar.gz
+
+# Override the log/display label
+apm install ./build/my-plugin-1.0.0.tar.gz --as my-plugin
+
+# Preview without writing
+apm install ./build/my-plugin-1.0.0.tar.gz --dry-run
+```
+
+`apm install <bundle>` verifies the sha256 manifest embedded in the bundle's `apm.lock.yaml` before writing any files. Path-traversal entries are rejected at the install boundary. Installed paths are recorded in the project lockfile under `local_deployed_files` — `apm.yml` is never mutated.
+
+> **Air-gapped installs**: local bundle installs do zero network I/O. The bundle is self-contained and self-describing.
+
+## `apm unpack` (deprecated)
+
+Extracts an APM bundle (produced with `--format apm`) into a project directory. Accepts both `.tar.gz` archives and unpacked bundle directories. Plugin-format output should be restored with `apm install <bundle>`, not `apm unpack`.
+
+> **Deprecated**: `apm unpack` is deprecated as of v0.12. Use `apm install <bundle>` instead — it is the unified restore primitive for both plugin-format and APM-format bundles. `apm unpack` will be removed in v0.13.
 
 ```bash
 # Extract and verify

--- a/docs/src/content/docs/reference/cli-commands.md
+++ b/docs/src/content/docs/reference/cli-commands.md
@@ -130,6 +130,7 @@ See [Dependencies: Transport selection](../../guides/dependencies/#transport-sel
 **Behavior:**
 - `apm install` (no args): Installs **all** packages from `apm.yml` and deploys the project's own `.apm/` content
 - `apm install <package>`: Installs **only** the specified package (adds to `apm.yml` if not present)
+- `apm install <local-bundle>`: Restores a packed plugin bundle (directory or `.tar.gz`) produced by `apm pack`. Verifies the sha256 manifest embedded in the bundle's `apm.lock.yaml`, then deploys files to the target directory. Does not mutate `apm.yml`. Records deployed paths under `local_deployed_files` in the project lockfile. Rejected flags: `--resolver`, `--registry`, `--mcp`, `--policy`/`--no-policy`, `--skill`, `--dev`, `--update`, `--trust-transitive-mcp`, `--allow-insecure`. See [Pack & Distribute](../../guides/pack-distribute/#apm-install-bundle-restore) for the full workflow.
 - Each `http://` dependency is warned at install time before any fetch begins
 - Transitive `http://` dependencies are allowed automatically when they use the same host as a direct insecure dependency you approved with `--allow-insecure`; other transitive hosts require `--allow-insecure-host HOSTNAME`
 


### PR DESCRIPTION
## Documentation Updates - 2026-05-02

This PR updates the documentation based on features merged in the last 24 hours.

### Features Documented

- `apm install <local-bundle>` unified restore primitive (from #1099)
- Plugin-format bundles now embed `apm.lock.yaml` with sha256 SBOM (from #1099)
- `apm unpack` deprecated in v0.12, removal in v0.13 (from #1099)

### Changes Made

- Updated `docs/src/content/docs/guides/pack-distribute.md`:
  - Pipeline diagram updated: `apm unpack` -> `apm install <bundle>`
  - Corrected plugin-format table row: `apm.lock.yaml` is now embedded in plugin bundles with `pack.bundle_files` sha256 manifest
  - Corrected the lockfile enrichment section prose (previously incorrectly stated plugin format has no `apm.lock.yaml`)
  - Added new `apm install <bundle> (restore)` section documenting the unified restore primitive, integrity verification, air-gapped behavior, and `--as ALIAS` flag
  - Added deprecation notice to `apm unpack` section
- Updated `docs/src/content/docs/reference/cli-commands.md`:
  - Added `apm install <local-bundle>` behavior entry to the Behavior list, linking to the pack-distribute guide

### Merged PRs Referenced

- #1099 - feat(install): `apm install <local-bundle>` + lockfile-embedded plugin packs
- #1083 - fix: remove Codex-only user-visible hint on opt-in miss (vendor-neutrality) -- internal fix, no documentation change needed

### Notes

PR #1090 (docs: show maintainer affiliations) and PRs #1093/#1102 (refactor: apm-review-panel) are internal changes that do not require user-facing documentation updates.




> [!NOTE]
> <details>
> <summary>🔒 Integrity filter blocked 2 items</summary>
>
> The following items were blocked because they don't meet the GitHub integrity level.
>
> - [#1097](https://github.com/microsoft/apm/pull/1097) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1084](https://github.com/microsoft/apm/pull/1084) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/25252294553/agentic_workflow) · ● 1.1M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+%22gh-aw-workflow-id%3A+daily-doc-updater%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/blob/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-05-04T12:56:44.242Z --> on May 4, 2026, 12:56 PM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, version: 1.0.36, model: claude-sonnet-4.6, id: 25252294553, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/25252294553 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->