### PR TITLE
fix(tests): use urlparse for host assertions (CodeQL #88-#91)

### DIFF
--- a/tests/unit/marketplace/test_marketplace_client.py
+++ b/tests/unit/marketplace/test_marketplace_client.py
@@ -1,14 +1,32 @@
 """Tests for marketplace client -- HTTP mock, caching, TTL, auth, auto-detection, proxy."""
 
 import json
+import re
 import time
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
 
 import pytest
 
 from apm_cli.marketplace import client as client_mod
 from apm_cli.marketplace.errors import MarketplaceFetchError
 from apm_cli.marketplace.models import MarketplaceSource
+
+
+def _quoted_hosts(text: str) -> set[str]:
+    """Extract host tokens from `Host '<host>'` patterns in error text.
+
+    Each token is normalised through ``urllib.parse.urlparse`` so callers
+    compare on parsed hostnames (set equality), not raw substrings -- which
+    is what CodeQL's ``py/incomplete-url-substring-sanitization`` rule
+    requires (see ``.github/instructions/tests.instructions.md``).
+    """
+    hosts: set[str] = set()
+    for m in re.finditer(r"Host '([^']+)'", text, re.IGNORECASE):
+        parsed = urlparse(f"https://{m.group(1)}")
+        if parsed.hostname:
+            hosts.add(parsed.hostname)
+    return hosts
 
 
 @pytest.fixture(autouse=True)
@@ -494,7 +512,7 @@ class TestFetchFileHostKindGuard:
 
         # No HTTP request should have been issued (no credential leakage).
         mock_get.assert_not_called()
-        assert "gitlab.com" in str(excinfo.value)
+        assert _quoted_hosts(str(excinfo.value)) == {"gitlab.com"}
         assert "not a supported marketplace source" in str(excinfo.value)
 
     def test_github_host_passes_guard(self):

--- a/tests/unit/marketplace/test_marketplace_commands.py
+++ b/tests/unit/marketplace/test_marketplace_commands.py
@@ -1,7 +1,9 @@
 """Tests for marketplace CLI commands using CliRunner."""
 
 import json  # noqa: F401
+import re
 from unittest.mock import MagicMock, patch  # noqa: F401
+from urllib.parse import urlparse
 
 import pytest
 from click.testing import CliRunner
@@ -11,6 +13,22 @@ from apm_cli.marketplace.models import (
     MarketplacePlugin,
     MarketplaceSource,
 )
+
+
+def _quoted_hosts(text: str) -> set[str]:
+    """Extract host tokens from `Host '<host>'` patterns in error text.
+
+    Each token is normalised through ``urllib.parse.urlparse`` so callers
+    compare on parsed hostnames (set equality), not raw substrings -- which
+    is what CodeQL's ``py/incomplete-url-substring-sanitization`` rule
+    requires (see ``.github/instructions/tests.instructions.md``).
+    """
+    hosts: set[str] = set()
+    for m in re.finditer(r"Host '([^']+)'", text, re.IGNORECASE):
+        parsed = urlparse(f"https://{m.group(1)}")
+        if parsed.hostname:
+            hosts.add(parsed.hostname)
+    return hosts
 
 
 @pytest.fixture
@@ -297,7 +315,7 @@ class TestMarketplaceAdd:
             marketplace, ["add", "https://gitlab.com/acme/team/plugin-marketplace"]
         )
         assert result.exit_code != 0
-        assert "gitlab.com" in result.output
+        assert _quoted_hosts(result.output) == {"gitlab.com"}
         assert "not supported" in result.output.lower()
 
     def test_add_rejects_non_github_host_shorthand(self, runner):
@@ -305,7 +323,7 @@ class TestMarketplaceAdd:
 
         result = runner.invoke(marketplace, ["add", "gitlab.com/acme/team/plugin-marketplace"])
         assert result.exit_code != 0
-        assert "gitlab.com" in result.output
+        assert _quoted_hosts(result.output) == {"gitlab.com"}
         assert "not supported" in result.output.lower()
 
     def test_add_rejects_http_url(self, runner):
@@ -399,7 +417,7 @@ class TestMarketplaceAdd:
         # leak", etc.) must NOT appear in the default error path.
         first_line = next((line for line in result.output.splitlines() if line.strip()), "").lower()
         assert "not supported" in first_line
-        assert "gitlab.com" in first_line
+        assert _quoted_hosts(first_line) == {"gitlab.com"}
         assert "credential" not in result.output.lower()
         assert "leak" not in result.output.lower()
 


### PR DESCRIPTION
## TL;DR

Resolves four high-severity CodeQL `py/incomplete-url-substring-sanitization` alerts (#88, #89, #90, #91) by switching four substring `assert "gitlab.com" in <text>` checks in the marketplace test suite to set-equality on `urllib.parse`-normalised host tokens, per the canonical pattern in `.github/instructions/tests.instructions.md`.

## Problem (WHY)

CodeQL flagged four assertions in `tests/unit/marketplace/test_marketplace_commands.py` (lines 300, 308, 402) and `tests/unit/marketplace/test_marketplace_client.py` (line 497):

```python
assert "gitlab.com" in result.output
```

The rule fires because substring-checking a host name inside a URL-bearing string is the same code shape as a security-critical sanitiser (e.g. `evil-gitlab.com` would also pass `"gitlab.com" in url`). The static analyser cannot tell test assertions and production sanitisers apart, so the rule is intentionally conservative.

The repo's canonical lint contract for tests (`.github/instructions/tests.instructions.md`) explicitly forbids this pattern even in "obviously safe" tests:

> Substring assertions like `assert "host.example.com" in msg` are flagged by CodeQL as `py/incomplete-url-substring-sanitization` (high severity, "the string may be at an arbitrary position in the URL") and **will fail CI**.

## Approach (WHAT)

Add a small `_quoted_hosts(text: str) -> set[str]` helper to each affected test file. The helper:

2. Normalises each token through `urllib.parse.urlparse` so the assertion compares on parsed hostnames, not raw substrings.
3. Returns a `set[str]`, so call sites assert with **set equality** (`==`), not membership (`in`) -- equality avoids the residual `string in set` shape that the canonical instructions note CodeQL still flags.

Call sites change from:

```python
assert "gitlab.com" in result.output
```

to:

```python
assert _quoted_hosts(result.output) == {"gitlab.com"}
```

This mirrors the canonical `_printed_urls` helper in `tests/unit/test_mcp_command.py` (referenced by the tests-instructions file) but specialised for the `Host '...'` error pattern these marketplace tests assert against.

## Behaviour preserved

- Each test still verifies the rejected host name is named in the user-facing error.
- `"not supported"` / `"not a supported marketplace source"` phrase checks unchanged (plain English, not URL substrings, not flagged by the rule).
- `"credential"` / `"leak"` negative assertions in `test_untrusted_host_error_has_action_in_first_sentence` unchanged.

## Validation

- `uv run --extra dev pytest -k "test_add_rejects_non_github_host_with_actionable_error or test_add_rejects_non_github_host_shorthand or test_untrusted_host_error_has_action_in_first_sentence or test_generic_host_rejected_before_request"` -- 4 passed.
- `uv run --extra dev pytest tests/unit/marketplace/` -- 905 passed.
- `uv run --extra dev ruff check src/ tests/` -- silent.
- `uv run --extra dev ruff format --check src/ tests/` -- 626 files already formatted.

## How to test

```bash
uv run --extra dev pytest tests/unit/marketplace/ -x
uv run --extra dev ruff check src/ tests/
uv run --extra dev ruff format --check src/ tests/
```

After merge, the four CodeQL alerts (#88, #89, #90, #91) close on the next `codeql` workflow run against `main`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>