### PR TITLE
test(command-integrator): write _make_package fixtures as utf-8 bytes for Windows

### DIFF
--- a/tests/unit/integration/test_command_integrator.py
+++ b/tests/unit/integration/test_command_integrator.py
@@ -34,7 +34,7 @@ def _make_package(project_root, prompts):
     prompts_dir = pkg_dir / ".apm" / "prompts"
     prompts_dir.mkdir(parents=True)
     for name, content in prompts.items():
-        (prompts_dir / name).write_text(content)
+        (prompts_dir / name).write_bytes(content.encode("utf-8"))
 
     mock_info = MagicMock()
     mock_info.install_path = pkg_dir


### PR DESCRIPTION
## TL;DR

Fix Windows-only test failure introduced when `_make_package` (shared helper at `tests/unit/integration/test_command_integrator.py:25`) writes fixture content via `Path.write_text(content)`. On Windows the default codec is `cp1252`, which raises `UnicodeEncodeError` for the `U+E041` tag character that `test_critical_security_finding_blocks_write` deliberately injects. Switch to `write_bytes(content.encode("utf-8"))`.

## Failing run

https://github.com/microsoft/apm/actions/runs/25286532040/job/74131700555 (Build & Test, windows-latest, x86_64).

```
FAILED tests/unit/integration/test_command_integrator.py::TestCursorCommandPanelFindings::test_critical_security_finding_blocks_write
- UnicodeEncodeError: 'charmap' codec can't encode character '\U000e0041' in position 39
  C:\hostedtoolcache\windows\Python\3.12.10\x64\Lib\encodings\cp1252.py:19
  tests\unit\integration\test_command_integrator.py:37
      (prompts_dir / name).write_text(content)
```

7366 passed, 1 failed.

## Why this is the right fix

The test purposefully injects `U+E041` to exercise the post-transform critical-finding gate (the production code is supposed to *block* this character on the way in, not encode it for storage). The fixture only needs to write the literal bytes to disk for the gate to read back -- so we should NOT round-trip via the platform default text codec.

This matches the canonical fixture pattern already used in this repo whenever bytes-on-disk must equal bytes-in-test (e.g. sha256 integrity helpers in `tests/unit/install/test_install_local_bundle.py:68`, `tests/integration/test_install_local_bundle_e2e.py:64`, and `tests/unit/bundle/test_local_bundle.py:82` -- the last one fixed in PR #1103). It also sidesteps `write_text`'s Windows `\n` -> `\r\n` translation, which the failing trace shows happening in the input string.

## Validation

- Local: `uv run --extra dev pytest tests/unit/integration/test_command_integrator.py::TestCursorCommandPanelFindings -x` -- 8 passed.
- Lint: `ruff check` and `ruff format --check` on the touched file -- silent.
- 1-line surgical change in a shared test helper; all other `write_text` calls in the same file are pure ASCII and remain unchanged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>