### PR TITLE
fix(tests): make cache-lockfile-parity test resilient to leftover deploy artifacts and timestamp drift

### DIFF
--- a/tests/integration/test_cache_lockfile_parity.py
+++ b/tests/integration/test_cache_lockfile_parity.py
@@ -1,16 +1,16 @@
 """Lockfile-determinism integration test under the persistent cache.
 
 Regression-trap for the worst silent failure the cache layer could
-introduce: byte-level lockfile drift between cached and non-cached
-runs. If ``apm install`` produces a different ``apm.lock.yaml`` when
-``APM_NO_CACHE=1`` is set vs. when the cache is hot, a CI run that
-ships with a stale cache would commit a lockfile that disagrees with
-the reproducible-from-scratch baseline -- and downstream installs
-would diverge.
+introduce: lockfile drift between cached and non-cached runs. If
+``apm install`` produces a different ``apm.lock.yaml`` (modulo the
+``generated_at`` write-timestamp) when ``APM_NO_CACHE=1`` is set vs.
+when the cache is hot, a CI run that ships with a stale cache would
+commit a lockfile that disagrees with the reproducible-from-scratch
+baseline -- and downstream installs would diverge.
 
 The contract: ``apm install`` from the same ``apm.yml`` MUST produce
-a byte-identical lockfile regardless of cache state. This test
-asserts it across three regimes:
+a content-identical lockfile (excluding ``generated_at``) regardless
+of cache state. This test asserts it across three regimes:
 
   Run A: cold cache (cache empty)
   Run B: cache hot (warm reuse, no network for unchanged deps)
@@ -83,18 +83,36 @@ def _run_install(apm: str, project: Path, *, env_overrides: dict[str, str]) -> N
 
 
 def _lockfile_sha(project: Path) -> str:
+    """Hash the lockfile excluding the `generated_at` line.
+
+    `generated_at` is a wall-clock timestamp captured at write time, so it
+    necessarily differs between independent runs. The parity invariant is
+    about resolution outcome (resolved_commit, content_hash, deployed_files,
+    package_type, ...), not the write timestamp.
+    """
     lock = project / "apm.lock.yaml"
     assert lock.is_file(), "apm.lock.yaml not produced by install"
-    return hashlib.sha256(lock.read_bytes()).hexdigest()
+    canonical = "\n".join(
+        line
+        for line in lock.read_text(encoding="utf-8").splitlines()
+        if not line.startswith("generated_at:")
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
-def _reset_install_state(project: Path) -> None:
-    """Remove install artifacts but keep apm.yml so the next run is identical input."""
-    for child in (project / "apm_modules", project / "apm.lock.yaml"):
-        if child.is_dir():
-            shutil.rmtree(child, ignore_errors=True)
-        elif child.is_file():
-            child.unlink()
+def _clone_project(template: Path, dest: Path) -> Path:
+    """Clone *template* into *dest* so each regime runs against pristine state.
+
+    Reusing the same project dir across regimes would leave previously-deployed
+    integration outputs (`.github/agents/`, `.agents/skills/`, ...) on disk.
+    With the lockfile deleted between runs, those orphaned files look like
+    user-authored collisions to the integrators (`check_collision()` returns
+    True), so they are skipped and never recorded in the new lockfile's
+    `deployed_files`. That is a fixture artifact, not a cache-layer drift, so
+    we sidestep it by giving each regime its own copy of the project tree.
+    """
+    shutil.copytree(template, dest)
+    return dest
 
 
 def test_lockfile_byte_identical_across_cache_regimes(
@@ -102,7 +120,7 @@ def test_lockfile_byte_identical_across_cache_regimes(
     project_with_apm: Path,
     tmp_path: Path,
 ) -> None:
-    """A, B, C must produce byte-identical apm.lock.yaml.
+    """A, B, C must produce content-identical apm.lock.yaml (modulo `generated_at`).
 
     A: cold cache (fresh APM_CACHE_DIR pointing at empty dir)
     B: warm cache (same dir, second run reuses entries)
@@ -112,30 +130,31 @@ def test_lockfile_byte_identical_across_cache_regimes(
     cache_dir.mkdir()
 
     # Run A: cold cache
+    project_a = _clone_project(project_with_apm, tmp_path / "run-a")
     _run_install(
         apm_command,
-        project_with_apm,
+        project_a,
         env_overrides={"APM_CACHE_DIR": str(cache_dir), "CI": "1"},
     )
-    sha_a = _lockfile_sha(project_with_apm)
+    sha_a = _lockfile_sha(project_a)
 
-    # Run B: warm cache (same APM_CACHE_DIR retained)
-    _reset_install_state(project_with_apm)
+    # Run B: warm cache (same APM_CACHE_DIR retained, fresh project tree)
+    project_b = _clone_project(project_with_apm, tmp_path / "run-b")
     _run_install(
         apm_command,
-        project_with_apm,
+        project_b,
         env_overrides={"APM_CACHE_DIR": str(cache_dir), "CI": "1"},
     )
-    sha_b = _lockfile_sha(project_with_apm)
+    sha_b = _lockfile_sha(project_b)
 
-    # Run C: cache disabled
-    _reset_install_state(project_with_apm)
+    # Run C: cache disabled (fresh project tree)
+    project_c = _clone_project(project_with_apm, tmp_path / "run-c")
     _run_install(
         apm_command,
-        project_with_apm,
+        project_c,
         env_overrides={"APM_NO_CACHE": "1", "CI": "1"},
     )
-    sha_c = _lockfile_sha(project_with_apm)
+    sha_c = _lockfile_sha(project_c)
 
     assert sha_a == sha_b, (
         "Lockfile drifted between cold-cache and warm-cache runs -- "


### PR DESCRIPTION
## TL;DR

Fixes the `tests/integration/test_cache_lockfile_parity.py` regression-trap added in #1116, which has been failing on `main` since merge (run [25287779252](https://github.com/microsoft/apm/actions/runs/25287779252) blocks v0.12.1 release CI on macOS arm64 build-validate and integration tests across ubuntu/windows/arm64).

Test-only change. No product code touched -- the cache layer was always deterministic; the fixture was wrong.

## Root cause

Two fixture-level bugs caused false positives:

### 1. Stale deployed-files state leaked between regimes

`_reset_install_state` removed `apm_modules/` + `apm.lock.yaml` between runs but left the prior run's integration outputs (`.github/agents/`, `.agents/skills/`, ...) on disk.

With the lockfile gone, the integrate phase had an empty `managed_files` set; the leftover files looked like user-authored collisions to [`BaseIntegrator.check_collision()`](https://github.com/microsoft/apm/blob/main/src/apm_cli/integration/base_integrator.py#L60-L99); they were skipped and never appended to `target_paths` -- so the new lockfile recorded only the single freshly-written file, not the package's full `deployed_files` list.

Cold-cache (run A, fresh disk) recorded 5 files. Warm-cache (B) and no-cache (C) recorded 1. Hence the drift.

### 2. `generated_at` drifts between independent runs

The lockfile's `generated_at` field is captured at write time. With no existing lockfile to dedupe against (each fresh project starts empty), every run produces a different timestamp. The byte-identical sha256 assertion was unsatisfiable by construction.

## Fix

1. **Clone the project tree per regime** via `_clone_project()` instead of trying to surgically reset state. Each run starts from pristine filesystem state, which is what "same input, same output" actually means for the parity invariant. No hand-rolled cleanup list to keep in sync with future target deploy roots (`.cursor/`, `.claude/`, `.github/hooks/`, `.agents/`, etc).

2. **Hash the lockfile excluding `generated_at`** in `_lockfile_sha`. The parity contract is about resolution outcome (`resolved_commit`, `content_hash`, `deployed_files`, `package_type`, ...) -- not the wall-clock write timestamp. The assertion message and intent are unchanged.

Updated docstring + test docstring to reflect "content-identical (modulo `generated_at`)" rather than "byte-identical".

## Validation

Locally on macOS arm64:

```
$ GITHUB_TOKEN=$(gh auth token) uv run --extra dev pytest tests/integration/test_cache_lockfile_parity.py -x -v
...
tests/integration/test_cache_lockfile_parity.py::test_lockfile_byte_identical_across_cache_regimes PASSED [100%]
============================== 1 passed in 12.73s ==============================
```

Lint contract:
```
$ uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/
All checks passed!
668 files already formatted
```

## How to verify the root cause

Before this PR, running the test on a fresh checkout produces:
```
AssertionError: Lockfile drifted between cold-cache and warm-cache runs --
the cache layer is mutating resolution results.
```

`diff` of the two lockfiles before the fix showed run A had 5 entries under `deployed_files` (`.agents/skills/style-checker` + 4 `.github/{agents,instructions,prompts}/*` paths) while runs B and C had only `.agents/skills/style-checker`. After the project-isolation fix, the only remaining difference was `generated_at` -- which the second part of the fix handles.

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;