### PR TITLE
[docs] Update documentation for features from 2026-05-04

### DIFF
--- a/docs/src/content/docs/reference/cli-commands.md
+++ b/docs/src/content/docs/reference/cli-commands.md
@@ -164,6 +164,17 @@ Exceptions:
 - APM packages whose ref/version changed in `apm.yml` are re-downloaded automatically (no `--update` needed)
 - `--force` remains available for full overwrite/reset scenarios
 
+**Performance and Progress UI:**
+
+`apm install` uses parallel dependency resolution and download for fast installs:
+
+- **Parallel BFS resolution**: Dependencies are resolved level-by-level in parallel batches.
+- **Persistent two-tier cache**: Git repos and HTTP packages are cached on disk; cache hits are validated with `rev-parse HEAD` (git) or ETag revalidation (HTTP), so repeated installs skip redundant network fetches.
+- **In-run dedup**: Multiple subdirectory deps from the same repo share one clone per install.
+- **Live progress**: An ASCII progress bar shows resolution and download progress in real time.
+- **Elapsed time**: Total elapsed time is shown on every exit path (including errors).
+- **Per-phase timing** (`--verbose`): Each phase (resolve, download, integrate) reports its individual duration.
+
 **Stale-file cleanup:**
 
 `apm install` removes files that a still-present package previously deployed but no longer produces -- for example after a package renames or drops a primitive. This keeps the workspace consistent with the manifest without any manual `apm prune`/`uninstall` step. Behaviour:
@@ -291,7 +302,7 @@ APM automatically detects which integrations to enable based on your project str
 
 - **VSCode integration**: Enabled when `.github/` directory exists
 - **Claude integration**: Enabled when `.claude/` directory exists
-- **Cursor integration**: Enabled when `.cursor/` directory exists
+- **Cursor integration**: Enabled when `.cursor/` directory exists. Cursor slash command support (Cursor 1.6+): `.prompt.md` files are deployed to `.cursor/commands/*.md`
 - **OpenCode integration**: Enabled when `.opencode/` directory exists
 - **Codex integration**: Enabled when `.codex/` directory exists
 - **Gemini integration**: Enabled when `.gemini/` directory exists
@@ -316,7 +327,7 @@ When you run `apm install`, APM automatically integrates primitives from install
 After installation completes, APM prints a grouped diagnostic summary instead of inline warnings. Categories include collisions (skipped files), cross-package skill replacements, warnings, and errors.
 
 - **Normal mode**: Shows counts and actionable tips (e.g., "9 files skipped -- use `apm install --force` to overwrite")
-- **Verbose mode** (`--verbose`): Additionally lists individual file paths grouped by package, full error details, and **the resolved auth source per remote host** (e.g., `[i] dev.azure.com -- using bearer from az cli (source: AAD_BEARER_AZ_CLI)` or `[i] github.com -- token from GITHUB_APM_PAT`). Useful for diagnosing PAT vs. Entra-ID-bearer behaviour against Azure DevOps. For subdirectory packages with an explicit `#ref` (e.g. `owner/repo/sub#v1.2.0`), `--verbose` also shows each validation probe attempt -- marker-file lookups, the Contents API directory probe, and the `git ls-remote` fallback -- including which auth step (token, credential-helper, SSH) resolved the ref.
+- **Verbose mode** (`--verbose`): Additionally lists individual file paths grouped by package, full error details, **per-phase timing** (resolve / download / integrate durations), and **the resolved auth source per remote host** (e.g., `[i] dev.azure.com -- using bearer from az cli (source: AAD_BEARER_AZ_CLI)` or `[i] github.com -- token from GITHUB_APM_PAT`). Useful for diagnosing PAT vs. Entra-ID-bearer behaviour against Azure DevOps. For subdirectory packages with an explicit `#ref` (e.g. `owner/repo/sub#v1.2.0`), `--verbose` also shows each validation probe attempt -- marker-file lookups, the Contents API directory probe, and the `git ls-remote` fallback -- including which auth step (token, credential-helper, SSH) resolved the ref.
 
 ```bash
 # See exactly which files were skipped or had issues, and which auth source was used
@@ -333,10 +344,11 @@ APM also integrates with Claude Code when `.claude/` directory exists:
 
 **Skill Integration:**
 
-Skills are copied directly to target directories:
+Skills are copied to the converged cross-client directory by default:
 
-- **Primary**: `.github/skills/{skill-name}/` — Entire skill folder copied
-- **Compatibility**: `.claude/skills/{skill-name}/` — Also copied if `.claude/` folder exists
+- **Primary (converged)**: `.agents/skills/{skill-name}/` — Shared by Copilot, Cursor, OpenCode, Codex, and Gemini
+- **Claude**: `.claude/skills/{skill-name}/` — Claude retains its own per-client path
+- Pass `--legacy-skill-paths` (or set `APM_LEGACY_SKILL_PATHS=1`) to restore the old per-client layout (`.github/skills/`, `.cursor/skills/`, etc.)
 
 **Example Integration Output**:
 ```
@@ -391,7 +403,7 @@ apm uninstall -g microsoft/apm-sample-package
 | Integrated agents | `.github/agents/*.agent.md` |
 | Integrated chatmodes | `.github/agents/*.agent.md` |
 | Claude commands | `.claude/commands/*.md` |
-| Skill folders | `.github/skills/{folder-name}/` |
+| Skill folders | `.agents/skills/{folder-name}/` (converged); `.claude/skills/` for Claude |
 | Integrated hooks | `.github/hooks/*.json` |
 | Claude hook settings | `.claude/settings.json` (hooks key cleaned) |
 | Cursor rules | `.cursor/rules/*.mdc` |


### PR DESCRIPTION
## Documentation Updates - 2026-05-04

This PR updates `docs/src/content/docs/reference/cli-commands.md` based on features merged in the last 24 hours.

### Features Documented

- `apm install` performance + UX overhaul: parallel BFS, persistent two-tier cache, live progress bar, elapsed time, per-phase `--verbose` timing (from #1116)
- Cursor slash command support (Cursor 1.6+): `.prompt.md` -> `.cursor/commands/*.md` (from #1046, shipped in v0.12.1)
- Skill routing convergence: primary skill target is now `.agents/skills/` for Copilot, Cursor, OpenCode, Codex, Gemini (from #737, shipped in v0.12.0)

### Changes Made

- Updated `docs/src/content/docs/reference/cli-commands.md`:
  - **Skill Integration section**: corrected primary path from `.github/skills/` to `.agents/skills/`; added `--legacy-skill-paths` escape hatch note
  - **Uninstall table**: corrected skill folder row from `.github/skills/` to `.agents/skills/`
  - **Cursor auto-detection note**: added mention of Cursor 1.6+ slash command deployment (`.cursor/commands/*.md`)
  - **New "Performance and Progress UI" section**: documents parallel BFS resolution, persistent two-tier cache with ETag/rev-parse revalidation, live ASCII progress bar, elapsed time, in-run clone dedup
  - **Verbose mode description**: added mention of per-phase timing output

### Merged PRs Referenced

- #1116 - perf+ux: comprehensive overhaul of apm install (cache, parallel BFS, UX)
- #1046 - Cursor slash command support (Cursor 1.6+)
- #737 - skill routing convergence to `.agents/skills/`

### Notes

PRs #1127 and #1129 were documentation-only PRs that already updated their respective docs pages. PRs #1121, #1124, #1125 were CI/test fixes with no user-facing documentation impact. PR #1112 was the 0.12.0 release cut.




> [!NOTE]
> <details>
> <summary>🔒 Integrity filter blocked 2 items</summary>
>
> The following items were blocked because they don't meet the GitHub integrity level.
>
> - [#1046](https://github.com/microsoft/apm/pull/1046) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - microsoft/apm#1116 `pull_request_read`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/25320650099/agentic_workflow) · ● 1.8M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+%22gh-aw-workflow-id%3A+daily-doc-updater%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/blob/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-05-06T13:11:47.908Z --> on May 6, 2026, 1:11 PM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, version: 1.0.36, model: claude-sonnet-4.6, id: 25320650099, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/25320650099 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->