### PR TITLE
chore(release): v0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.2] - 2026-05-05
+
 ### Added
 
 - **`apm audit` now catches forgotten installs and hand-edits by default.** No more shipping stale `.github/instructions/` because someone forgot to re-run `apm install`, no more silent hand-edits to regenerated content. Opt out with `--no-drift`. See the [Drift Detection guide](https://danielmeppiel.github.io/awd-cli/guides/drift-detection/). (#1137, closes #1071, supersedes scope of #898)
 
 ### Fixed
 
-- **Parallel subdir install race.** `apm install` no longer intermittently fails with `RuntimeError: Subdirectory '<path>' not found in repository` when multiple dependencies resolve to different subdirectories of the same `repo@ref`. The shared clone cache now stores subdir-agnostic bare clones and each consumer materializes its own working tree (mirrors the WS3 `GitCache` pattern). (#1135, fixes #1126)
+- **Parallel subdir install race.** `apm install` no longer intermittently fails with `RuntimeError: Subdirectory '<path>' not found in repository` when multiple dependencies (including ADO sub-path deps) resolve to different subdirectories of the same `repo@ref`. The shared clone cache now stores subdir-agnostic bare clones and each consumer materializes its own working tree (mirrors the WS3 `GitCache` pattern). (#1135, fixes #1126, fixes #1140)
+
+### Changed
+
+- **Docs: `first-package` guide accuracy.** Clarifies how `includes: auto` actually behaves and corrects the skill deployment paths so a newcomer's first package matches what `apm install` writes to disk. (#1129)
+- **Docs: APM's role for skills, plugins-as-packages, ADO sub-paths.** Six user-surfaced doc gaps closed in one pass -- unifies the "plugin == package" framing, adds ADO sub-path install examples, and states the current stability posture so users stop guessing from release notes. (#1127)
 
 ## [0.12.1] - 2026-05-03
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apm-cli"
-version = "0.12.1"
+version = "0.12.2"
 description = "MCP configuration tool"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -179,7 +179,7 @@ wheels = [
 
 [[package]]
 name = "apm-cli"
-version = "0.12.1"
+version = "0.12.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## TL;DR

Cut **v0.12.2** -- a small patch release that ships the four PRs merged since v0.12.1, headlined by the parallel sub-path install race fix that was being re-reported by users on ADO (#1140).

## What's in it

| PR | Type | One-liner |
|----|------|-----------|
| #1137 | Added | `apm audit` now catches forgotten installs and hand-edits by default (`--no-drift` to opt out) |
| #1135 | Fixed | Parallel sub-path installs from the same `repo@ref` no longer race -- subdir-agnostic bare cache + per-consumer materialization. Fixes #1126 and the duplicate ADO report #1140 |
| #1129 | Changed | Docs: `first-package` guide -- corrects `includes: auto` behavior and skill deployment paths |
| #1127 | Changed | Docs: clarifies APM's role for skills, unifies "plugin == package", adds ADO sub-path examples, states stability posture |

Each PR gets exactly one "so what" line in `CHANGELOG.md` per the [changelog contract](.github/instructions/changelog.instructions.md).

## Mechanics

- `pyproject.toml`: `0.12.1` -> `0.12.2`
- `uv.lock`: re-locked (only the `apm-cli` package version changes)
- `CHANGELOG.md`: `[Unreleased]` block converted to `## [0.12.2] - 2026-05-05`; #1140 added to the #1135 fix line; two new docs entries under `### Changed`

## Why now

#1140 lands the second user-visible report of the #1126 race in two days, both with the same `Subdirectory '...' not found` symptom and the same "run install twice" workaround. The fix has been on `main` since #1135 merged; getting it tagged unblocks ADO sub-path users without asking them to build from source.

## Validation

- Lint: `uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/` (no source changes in this PR; only `pyproject.toml`, `uv.lock`, `CHANGELOG.md`)
- Tag/release pipeline kicks off automatically when `v0.12.2` is pushed after merge (per `.github/instructions/cicd.instructions.md`: only `v*.*.*` tags trigger the full release pipeline).

## Post-merge

1. Tag `v0.12.2` on `main` and push -- triggers build-release workflow.
2. Verify PyPI + GitHub release artifacts, then update Homebrew tap.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>