### PR TITLE
fix(install): exclude .apm-pin marker from package content hash (unblocks v0.12.2 release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Parallel subdir install race.** `apm install` no longer intermittently fails with `RuntimeError: Subdirectory '<path>' not found in repository` when multiple dependencies (including ADO sub-path deps) resolve to different subdirectories of the same `repo@ref`. The shared clone cache now stores subdir-agnostic bare clones and each consumer materializes its own working tree (mirrors the WS3 `GitCache` pattern). (#1135, fixes #1126, fixes #1140)
+- **Re-installing the same package no longer rmtree's it.** `compute_package_hash` now excludes the `.apm-pin` cache marker (introduced by #1137) so the supply-chain content-hash check sees a stable hash across installs instead of falsely tripping and deleting `apm_modules/<owner>/<pkg>/`. (#1142, regression from #1137)
 
 ### Changed
 

--- a/src/apm_cli/utils/content_hash.py
+++ b/src/apm_cli/utils/content_hash.py
@@ -7,6 +7,13 @@ from typing import Optional  # noqa: F401
 # Directories excluded from hashing (not relevant to package content)
 _EXCLUDED_DIRS = {".git", "__pycache__"}
 
+# Files excluded from hashing. ``.apm-pin`` is the cache-pin marker
+# (see :mod:`apm_cli.install.cache_pin`) written AFTER hash recording
+# during install; including it would make the on-disk hash diverge
+# from the lockfile-recorded hash on every subsequent install,
+# falsely tripping the supply-chain content-hash mismatch check.
+_EXCLUDED_FILES = {".apm-pin"}
+
 # Well-known hash for empty/missing packages
 _EMPTY_HASH = "sha256:" + hashlib.sha256(b"").hexdigest()
 
@@ -41,6 +48,8 @@ def compute_package_hash(package_path: Path) -> str:
         if any(part in _EXCLUDED_DIRS for part in rel.parts):
             continue
         if item.is_file():
+            if rel.name in _EXCLUDED_FILES:
+                continue
             regular_files.append(rel)
 
     # Sort lexicographically by POSIX path for determinism

--- a/src/apm_cli/utils/content_hash.py
+++ b/src/apm_cli/utils/content_hash.py
@@ -7,12 +7,14 @@ from typing import Optional  # noqa: F401
 # Directories excluded from hashing (not relevant to package content)
 _EXCLUDED_DIRS = {".git", "__pycache__"}
 
-# Files excluded from hashing. ``.apm-pin`` is the cache-pin marker
-# (see :mod:`apm_cli.install.cache_pin`) written AFTER hash recording
-# during install; including it would make the on-disk hash diverge
-# from the lockfile-recorded hash on every subsequent install,
-# falsely tripping the supply-chain content-hash mismatch check.
-_EXCLUDED_FILES = {".apm-pin"}
+# Files at the package root excluded from hashing. ``.apm-pin`` is the
+# cache-pin marker (see :mod:`apm_cli.install.cache_pin`) written AFTER
+# hash recording during install; including it would make the on-disk
+# hash diverge from the lockfile-recorded hash on every subsequent
+# install, falsely tripping the supply-chain content-hash mismatch
+# check. Scoped to root paths only so a package cannot slip a
+# ``subdir/.apm-pin`` past the integrity hash.
+_EXCLUDED_ROOT_FILES = {".apm-pin"}
 
 # Well-known hash for empty/missing packages
 _EMPTY_HASH = "sha256:" + hashlib.sha256(b"").hexdigest()
@@ -48,7 +50,7 @@ def compute_package_hash(package_path: Path) -> str:
         if any(part in _EXCLUDED_DIRS for part in rel.parts):
             continue
         if item.is_file():
-            if rel.name in _EXCLUDED_FILES:
+            if len(rel.parts) == 1 and rel.name in _EXCLUDED_ROOT_FILES:
                 continue
             regular_files.append(rel)
 

--- a/tests/unit/test_content_hash.py
+++ b/tests/unit/test_content_hash.py
@@ -72,6 +72,27 @@ class TestComputePackageHash:
 
         assert hash_before == hash_after
 
+    def test_skips_apm_pin_marker(self, tmp_path):
+        """``.apm-pin`` cache-pin marker is excluded from hashing.
+
+        Regression test for the v0.12.2 release-blocking bug: the
+        ``.apm-pin`` marker (introduced in PR #1137 for drift-replay
+        cache verification) is written to the package root AFTER the
+        install-time hash is recorded in the lockfile. Including it in
+        :func:`compute_package_hash` made every subsequent ``apm
+        install`` of the same package observe a hash mismatch against
+        the lockfile, falsely tripping the supply-chain content-hash
+        check in ``FreshDependencySource.acquire`` and
+        ``safe_rmtree``-ing the package directory.
+        """
+        (tmp_path / "apm.yml").write_text("name: x\n")
+        hash_before = compute_package_hash(tmp_path)
+
+        (tmp_path / ".apm-pin").write_text('{"schema_version": 1, "resolved_commit": "deadbeef"}')
+        hash_after = compute_package_hash(tmp_path)
+
+        assert hash_before == hash_after
+
     def test_empty_directory(self, tmp_path):
         """Empty directory returns a well-known hash."""
         empty = tmp_path / "empty"

--- a/tests/unit/test_content_hash.py
+++ b/tests/unit/test_content_hash.py
@@ -84,6 +84,12 @@ class TestComputePackageHash:
         the lockfile, falsely tripping the supply-chain content-hash
         check in ``FreshDependencySource.acquire`` and
         ``safe_rmtree``-ing the package directory.
+
+        Exclusion is scoped to the package root: a nested
+        ``subdir/.apm-pin`` (which the install pipeline never writes)
+        MUST still be hashed so a malicious package cannot smuggle
+        bytes past the integrity check by burying them under that
+        name.
         """
         (tmp_path / "apm.yml").write_text("name: x\n")
         hash_before = compute_package_hash(tmp_path)
@@ -92,6 +98,16 @@ class TestComputePackageHash:
         hash_after = compute_package_hash(tmp_path)
 
         assert hash_before == hash_after
+
+        # A nested .apm-pin (never written by the install pipeline) is
+        # NOT excluded -- defense against using the marker name as a
+        # blind spot in the integrity hash.
+        nested = tmp_path / "subdir"
+        nested.mkdir()
+        (nested / ".apm-pin").write_text("smuggled bytes")
+        hash_with_nested = compute_package_hash(tmp_path)
+
+        assert hash_with_nested != hash_after
 
     def test_empty_directory(self, tmp_path):
         """Empty directory returns a well-known hash."""


### PR DESCRIPTION
## TL;DR

The v0.12.2 release tag (deleted) failed integration tests on every platform because re-installing any APM-managed package triggered a false supply-chain hash mismatch and `rmtree`'d the package directory. Root cause: the `.apm-pin` cache marker added by #1137 was being included in `compute_package_hash` despite being written AFTER hash recording. Fix: exclude `.apm-pin` from package hashing.

## Problem (WHY)

After PR #1137 introduced the `.apm-pin` drift-replay cache marker, every second `apm install` of an already-installed package observed:

```
Content hash mismatch for github/awesome-copilot/instructions/code-review-generic.instructions.md:
expected sha256:31212689..., got sha256:4361e707...
```

…then `safe_rmtree`'d `apm_modules/<owner>/<pkg>/` and `sys.exit(1)`.

This blocked the **v0.12.2 release** -- `tests/integration/test_guardrailing_hero_e2e.py::test_2_minute_guardrailing_flow` failed on macOS-x86, macOS-arm, and Linux-arm in [run 25369501023](https://github.com/microsoft/apm/actions/runs/25369501023). The test calls `run_command(show_output=True)` which runs each `apm install` twice (once for display, once for capture) -- triggering the bug deterministically.

## Approach (WHAT)

`compute_package_hash` already excluded `.git/` and `__pycache__/` directories. Add a parallel `_EXCLUDED_FILES = {".apm-pin"}` and skip matching files in the regular-files collection loop.

## Implementation (HOW)

```python
# src/apm_cli/utils/content_hash.py
_EXCLUDED_FILES = {".apm-pin"}
...
if item.is_file():
    if rel.name in _EXCLUDED_FILES:
        continue
    regular_files.append(rel)
```

Why `.apm-pin` is correct to exclude: it is install-process metadata (pin marker for drift replay), not package content. The marker is written by `LockfileBuilder._sync_cache_pin_markers` AFTER `_compute_hash` runs in `FreshDependencySource.acquire`, so including it can only make the on-disk hash diverge from the lockfile-recorded hash. Excluding it makes the hash stable across installs.

## Validation

- New regression test `test_skips_apm_pin_marker` in `tests/unit/test_content_hash.py`.
- All 23 unit tests in `test_content_hash.py` pass locally.
- **Attestation against PyInstaller binary**: rebuilt `dist/apm-darwin-arm64/apm` from this branch; `pytest tests/integration/test_auto_install_e2e.py tests/integration/test_guardrailing_hero_e2e.py` -- **5 passed in 134s**, including the previously-failing `test_2_minute_guardrailing_flow`.
- Lint mirror: `uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/` -- silent.

## Follow-ups (out of scope)

- Integration tests should run on PRs that touch `src/apm_cli/install/` or `src/apm_cli/deps/`, not just on tag push -- this regression would have been caught at PR #1137 time.
- `FreshDependencySource.acquire` swallows exceptions at `sources.py:632` and exits 0; worth surfacing as a non-zero exit. (Separate issue.)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>