### PR TITLE
[docs] Update CI policy docs for drift detection default-on (v0.12.2)

### DIFF
--- a/docs/src/content/docs/guides/ci-policy-setup.md
+++ b/docs/src/content/docs/guides/ci-policy-setup.md
@@ -50,7 +50,7 @@ Commit this to the default branch of `your-org/.github`.
 
 ## Step 2: Add baseline CI checks
 
-Add `apm audit --ci` to your CI pipeline. This runs 6 lockfile consistency checks — no policy file needed:
+Add `apm audit --ci` to your CI pipeline. This runs 7 baseline lockfile checks plus integration drift detection — no policy file needed:
 
 ```yaml
 # .github/workflows/apm-policy.yml
@@ -80,7 +80,7 @@ jobs:
         run: apm audit --ci
 ```
 
-This catches lockfile/manifest drift, missing files, and hidden Unicode — without any policy configuration.
+This catches lockfile/manifest drift, missing files, hidden Unicode, and integration drift (forgot to re-run `apm install`, hand-edits to deployed files, orphaned files) — without any policy configuration. See the [Drift Detection guide](../drift-detection/) for details.
 
 ## Step 3: Enable policy enforcement
 


### PR DESCRIPTION
## Documentation Updates - 2026-05-05

This PR updates `docs/src/content/docs/guides/ci-policy-setup.md` based on features merged in the last 24 hours.

### Features Documented

- Default-on integration drift detection in `apm audit --ci` (from #1137)

### Changes Made

- Updated `docs/src/content/docs/guides/ci-policy-setup.md`:
  - Corrected "6 lockfile consistency checks" -> "7 baseline lockfile checks" (the seventh is the `lockfile-exists` check added earlier)
  - Added mention of integration drift detection as default-on behavior in `apm audit --ci`
  - Expanded the summary line to list the three drift failure modes it catches
  - Added link to the Drift Detection guide

### Merged PRs Referenced

- #1137 - feat(audit): default-on integration drift detection
- #1142 - fix(install): exclude .apm-pin marker from package content hash (unblocks v0.12.2)
- #1135 - fix(deps): subdir-agnostic bare cache fixes parallel sparse-checkout race

### Notes

The `drift-detection.md` guide, `commands.md` in `packages/apm-guide`, the CHANGELOG, and the `ci-cd.md` integration doc were all already up to date from PR #1137. Only `ci-policy-setup.md` had stale copy (wrong check count, missing drift mention).




> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/25377669591/agentic_workflow) · ● 787K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+%22gh-aw-workflow-id%3A+daily-doc-updater%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/blob/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-05-07T13:01:42.873Z --> on May 7, 2026, 1:01 PM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, version: 1.0.36, model: claude-sonnet-4.6, id: 25377669591, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/25377669591 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->