### PR TITLE
fix(compile): deduplicate Claude Code instructions (#1138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Copilot, Codex, Cursor, Claude, Windsurf, OpenCode, and Gemini adapters handle MCP v0.1 `runtimeArguments`/`packageArguments` with `variables` (no `type` key), matching the VS Code fix from #1444. (#1461, closes #1452, thanks @sergio-sisternes-epam)
+- **Deduplicate Claude Code instructions.** `apm compile --target claude` now omits the "Project Standards" section from `CLAUDE.md` when instructions are already deployed to `.claude/rules/` by `apm install`, avoiding duplicate content in Claude Code's context window. `CLAUDE.md` is still generated for constitution and dependency imports. (#1138)
 
 ## [0.14.2] - 2026-05-22
 

--- a/docs/src/content/docs/integrations/ide-tool-integration.md
+++ b/docs/src/content/docs/integrations/ide-tool-integration.md
@@ -64,6 +64,8 @@ mcp: in apm.yml      ->   per target: .mcp.json / settings.json / equivalent
 
 Not every target supports every primitive type. When a primitive can't land on a target, APM emits a warning at install time. Skim [Targets matrix](../reference/targets-matrix/) to set expectations before adding a primitive.
 
+> **Deduplication**: When `.claude/rules/` already contains `.md` files (deployed by `apm install`), `apm compile --target claude` omits the instructions section from `CLAUDE.md` to avoid duplicate context. `CLAUDE.md` is still generated if it carries a constitution or dependency imports.
+
 ## Common workflows
 
 ### Add a target to an existing project

--- a/docs/src/content/docs/producer/compile.md
+++ b/docs/src/content/docs/producer/compile.md
@@ -115,7 +115,7 @@ Per target, with the rules shape on disk after compile:
 | Target | Root context file | Per-rule output | Compile required? |
 |---|---|---|---|
 | `copilot` | `AGENTS.md` | `.github/instructions/<name>.instructions.md` (preserves `applyTo`) | No -- Copilot reads the per-rule files natively |
-| `claude` | `CLAUDE.md` | `.claude/rules/<name>.md` | Yes -- `CLAUDE.md` is the entry point (omitted when `.claude/rules/` already has instructions; see [deduplication note](#claude-code-deduplication) below) |
+| `claude` | `CLAUDE.md` | `.claude/rules/<name>.md` | Conditional -- needed for constitution/dependency imports; skipped when `.claude/rules/` already has instructions (see [deduplication note](#claude-code-deduplication)) |
 | `cursor` | -- | `.cursor/rules/<name>.mdc` | Yes -- `.mdc` is Cursor's rules format |
 | `codex` | `AGENTS.md` (folded) | none -- compile-only, no per-file deploy | Yes -- folded into `AGENTS.md` |
 | `gemini` | `GEMINI.md` (folded) | none -- compile-only, no per-file deploy | Yes -- folded into `GEMINI.md` |

--- a/docs/src/content/docs/producer/compile.md
+++ b/docs/src/content/docs/producer/compile.md
@@ -115,7 +115,7 @@ Per target, with the rules shape on disk after compile:
 | Target | Root context file | Per-rule output | Compile required? |
 |---|---|---|---|
 | `copilot` | `AGENTS.md` | `.github/instructions/<name>.instructions.md` (preserves `applyTo`) | No -- Copilot reads the per-rule files natively |
-| `claude` | `CLAUDE.md` | `.claude/rules/<name>.md` | Yes -- `CLAUDE.md` is the entry point |
+| `claude` | `CLAUDE.md` | `.claude/rules/<name>.md` | Yes -- `CLAUDE.md` is the entry point (omitted when `.claude/rules/` already has instructions; see [deduplication note](#claude-code-deduplication) below) |
 | `cursor` | -- | `.cursor/rules/<name>.mdc` | Yes -- `.mdc` is Cursor's rules format |
 | `codex` | `AGENTS.md` (folded) | none -- compile-only, no per-file deploy | Yes -- folded into `AGENTS.md` |
 | `gemini` | `GEMINI.md` (folded) | none -- compile-only, no per-file deploy | Yes -- folded into `GEMINI.md` |

--- a/docs/src/content/docs/producer/compile.md
+++ b/docs/src/content/docs/producer/compile.md
@@ -115,7 +115,7 @@ Per target, with the rules shape on disk after compile:
 | Target | Root context file | Per-rule output | Compile required? |
 |---|---|---|---|
 | `copilot` | `AGENTS.md` | `.github/instructions/<name>.instructions.md` (preserves `applyTo`) | No -- Copilot reads the per-rule files natively |
-| `claude` | `CLAUDE.md` | `.claude/rules/<name>.md` | Conditional -- needed for constitution/dependency imports; skipped when `.claude/rules/` already has instructions (see [deduplication note](#claude-code-deduplication)) |
+| `claude` | `CLAUDE.md` | `.claude/rules/<name>.md` | Yes -- deduplicates with `.claude/rules/` (see [below](#claude-code-deduplication)) |
 | `cursor` | -- | `.cursor/rules/<name>.mdc` | Yes -- `.mdc` is Cursor's rules format |
 | `codex` | `AGENTS.md` (folded) | none -- compile-only, no per-file deploy | Yes -- folded into `AGENTS.md` |
 | `gemini` | `GEMINI.md` (folded) | none -- compile-only, no per-file deploy | Yes -- folded into `GEMINI.md` |

--- a/docs/src/content/docs/producer/compile.md
+++ b/docs/src/content/docs/producer/compile.md
@@ -140,13 +140,17 @@ correct AGENTS.md / CLAUDE.md / GEMINI.md output. Reach for
 do not want install's side effects.
 
 :::note[Claude Code deduplication]
-When `apm install` has already deployed instructions to
-`.claude/rules/`, `apm compile --target claude` automatically omits
-the instructions section from `CLAUDE.md` to avoid duplicate content
-in Claude Code's context window. `CLAUDE.md` is still generated when
-it carries a constitution or dependency `@import` paths. If
-`.claude/rules/` is later removed, re-running `apm compile` restores
-the instructions section to `CLAUDE.md`.
+<a id="claude-code-deduplication"></a>
+When `.claude/rules/` is already populated with instructions,
+`apm compile --target claude` automatically omits the instructions
+section from `CLAUDE.md` to avoid duplicate content in Claude Code's
+context window. The directory can be populated by either
+`apm install --target claude` or by an earlier `apm compile --target claude`
+run -- both write per-file instruction rules into `.claude/rules/`.
+`CLAUDE.md` is still generated when it carries a constitution or
+dependency `@import` paths. If `.claude/rules/` is later removed,
+re-running `apm compile` restores the instructions section to
+`CLAUDE.md`.
 :::
 
 ## Pitfalls

--- a/docs/src/content/docs/producer/compile.md
+++ b/docs/src/content/docs/producer/compile.md
@@ -139,6 +139,16 @@ correct AGENTS.md / CLAUDE.md / GEMINI.md output. Reach for
 `apm compile` directly when you are iterating on instructions and
 do not want install's side effects.
 
+:::note[Claude Code deduplication]
+When `apm install` has already deployed instructions to
+`.claude/rules/`, `apm compile --target claude` automatically omits
+the instructions section from `CLAUDE.md` to avoid duplicate content
+in Claude Code's context window. `CLAUDE.md` is still generated when
+it carries a constitution or dependency `@import` paths. If
+`.claude/rules/` is later removed, re-running `apm compile` restores
+the instructions section to `CLAUDE.md`.
+:::
+
 ## Pitfalls
 
 - **Confusing compile's scope.** Compile only handles **instructions**

--- a/docs/src/content/docs/producer/compile.md
+++ b/docs/src/content/docs/producer/compile.md
@@ -122,6 +122,8 @@ Per target, with the rules shape on disk after compile:
 | `opencode` | `AGENTS.md` (folded) | none -- compile-only, no per-file deploy | Yes -- folded into `AGENTS.md` |
 | `windsurf` | -- | `.windsurf/rules/<name>.md` | Yes -- compiled to Windsurf rules |
 
+> **Claude deduplication**: When `apm install` has already deployed instructions to `.claude/rules/`, `apm compile --target claude` omits the instructions section from `CLAUDE.md` to avoid duplicate content in Claude Code's context window. `CLAUDE.md` is still generated if it carries a constitution or dependency `@import` paths.
+
 ## compile vs install
 
 | You want to... | Run |

--- a/src/apm_cli/compilation/agents_compiler.py
+++ b/src/apm_cli/compilation/agents_compiler.py
@@ -670,13 +670,15 @@ class AgentsCompiler:
 
         # Display CLAUDE.md compilation output using standard formatter
         # Get proper compilation results from distributed compiler (has optimization decisions)
+        # Skip formatter output when deduplication filtered out all placements to
+        # avoid contradicting the "not generated" log message above.
         from ..output.formatters import CompilationFormatter
         from ..output.models import CompilationResults
 
         compilation_results = distributed_compiler.get_compilation_results_for_display(
             is_dry_run=config.dry_run
         )
-        if compilation_results:
+        if compilation_results and not (skip_instructions and files_written == 0):
             # Update target name for CLAUDE.md output
             formatter_results = CompilationResults(
                 project_analysis=compilation_results.project_analysis,

--- a/src/apm_cli/compilation/agents_compiler.py
+++ b/src/apm_cli/compilation/agents_compiler.py
@@ -563,9 +563,8 @@ class AgentsCompiler:
                 ensure_path_within(claude_rules_dir, self.base_dir)
             except PathTraversalError:
                 self._log(
-                    "progress",
+                    "warning",
                     ".claude/rules/ is a symlink outside the project root -- ignoring",
-                    symbol="warning",
                 )
             else:
                 if any(claude_rules_dir.glob("*.md")):

--- a/src/apm_cli/compilation/agents_compiler.py
+++ b/src/apm_cli/compilation/agents_compiler.py
@@ -556,18 +556,20 @@ class AgentsCompiler:
         # .claude/rules/ by `apm install` (avoids duplicate context in Claude Code).
         claude_rules_dir = self.base_dir / ".claude" / "rules"
         skip_instructions = False
-        if claude_rules_dir.is_dir() and any(claude_rules_dir.glob("*.md")):
+        if claude_rules_dir.is_dir():
             from ..utils.path_security import PathTraversalError, ensure_path_within
 
             try:
                 ensure_path_within(claude_rules_dir, self.base_dir)
-                skip_instructions = True
             except PathTraversalError:
                 self._log(
                     "progress",
                     ".claude/rules/ is a symlink outside the project root -- ignoring",
                     symbol="warning",
                 )
+            else:
+                if any(claude_rules_dir.glob("*.md")):
+                    skip_instructions = True
 
         if skip_instructions:
             self._log(

--- a/src/apm_cli/compilation/agents_compiler.py
+++ b/src/apm_cli/compilation/agents_compiler.py
@@ -574,7 +574,8 @@ class AgentsCompiler:
         if skip_instructions:
             self._log(
                 "progress",
-                "Instructions already in .claude/rules/ -- skipping from CLAUDE.md",
+                "Instructions already in .claude/rules/ -- omitting from CLAUDE.md"
+                " to avoid duplicate context",
                 symbol="info",
             )
 
@@ -662,8 +663,8 @@ class AgentsCompiler:
         if files_written == 0 and skip_instructions:
             self._log(
                 "progress",
-                "CLAUDE.md not generated (instructions in .claude/rules/, "
-                "no constitution or dependencies to emit)",
+                "CLAUDE.md not generated -- Claude Code reads .claude/rules/ directly,"
+                " no further action needed",
                 symbol="info",
             )
 

--- a/src/apm_cli/compilation/agents_compiler.py
+++ b/src/apm_cli/compilation/agents_compiler.py
@@ -643,6 +643,14 @@ class AgentsCompiler:
         stats = claude_result.stats.copy()
         stats["claude_files_written"] = files_written
 
+        if files_written == 0 and skip_instructions:
+            self._log(
+                "progress",
+                "CLAUDE.md not generated (instructions in .claude/rules/, "
+                "no constitution or dependencies to emit)",
+                symbol="info",
+            )
+
         # Display CLAUDE.md compilation output using standard formatter
         # Get proper compilation results from distributed compiler (has optimization decisions)
         from ..output.formatters import CompilationFormatter

--- a/src/apm_cli/compilation/agents_compiler.py
+++ b/src/apm_cli/compilation/agents_compiler.py
@@ -555,7 +555,20 @@ class AgentsCompiler:
         # Skip instructions in CLAUDE.md when they are already deployed to
         # .claude/rules/ by `apm install` (avoids duplicate context in Claude Code).
         claude_rules_dir = self.base_dir / ".claude" / "rules"
-        skip_instructions = claude_rules_dir.is_dir() and any(claude_rules_dir.glob("*.md"))
+        skip_instructions = False
+        if claude_rules_dir.is_dir() and any(claude_rules_dir.glob("*.md")):
+            from ..utils.path_security import PathTraversalError, ensure_path_within
+
+            try:
+                ensure_path_within(claude_rules_dir, self.base_dir)
+                skip_instructions = True
+            except PathTraversalError:
+                self._log(
+                    "progress",
+                    ".claude/rules/ is a symlink outside the project root -- ignoring",
+                    symbol="warning",
+                )
+
         if skip_instructions:
             self._log(
                 "progress",

--- a/src/apm_cli/compilation/agents_compiler.py
+++ b/src/apm_cli/compilation/agents_compiler.py
@@ -552,8 +552,23 @@ class AgentsCompiler:
             debug=config.debug,
         )
 
+        # Skip instructions in CLAUDE.md when they are already deployed to
+        # .claude/rules/ by `apm install` (avoids duplicate context in Claude Code).
+        claude_rules_dir = self.base_dir / ".claude" / "rules"
+        skip_instructions = claude_rules_dir.is_dir() and any(claude_rules_dir.glob("*.md"))
+        if skip_instructions:
+            self._log(
+                "progress",
+                "Instructions already in .claude/rules/ -- skipping from CLAUDE.md",
+                symbol="info",
+            )
+
         # Format CLAUDE.md files
-        claude_config = {"source_attribution": config.source_attribution, "debug": config.debug}
+        claude_config = {
+            "source_attribution": config.source_attribution,
+            "debug": config.debug,
+            "skip_instructions": skip_instructions,
+        }
         claude_result = claude_formatter.format_distributed(
             primitives, placement_map, claude_config
         )

--- a/src/apm_cli/compilation/agents_compiler.py
+++ b/src/apm_cli/compilation/agents_compiler.py
@@ -603,6 +603,16 @@ class AgentsCompiler:
             preview_lines = [
                 f"CLAUDE.md Preview: Would generate {count} {'file' if count == 1 else 'files'}"
             ]
+            # Surface the deduplication skip so dry-run is self-explanatory
+            # for scripted consumers (otherwise "Would generate 0 files"
+            # looks like a no-op or a bug). The same skip appears in the
+            # non-dry-run path via the dedicated INFO log line.
+            if skip_instructions:
+                preview_lines.append(
+                    "  (instructions section skipped: .claude/rules/ already "
+                    "populated -- avoids duplicate content in Claude Code's "
+                    "context window)"
+                )
             for claude_path in claude_result.content_map.keys():  # noqa: SIM118
                 rel_path = portable_relpath(claude_path, self.base_dir)
                 preview_lines.append(f"  {rel_path}")

--- a/src/apm_cli/compilation/agents_compiler.py
+++ b/src/apm_cli/compilation/agents_compiler.py
@@ -598,8 +598,9 @@ class AgentsCompiler:
         # Handle dry-run mode
         if config.dry_run:
             # Generate preview summary
+            count = len(claude_result.placements)
             preview_lines = [
-                f"CLAUDE.md Preview: Would generate {len(claude_result.placements)} files"
+                f"CLAUDE.md Preview: Would generate {count} {'file' if count == 1 else 'files'}"
             ]
             for claude_path in claude_result.content_map.keys():  # noqa: SIM118
                 rel_path = portable_relpath(claude_path, self.base_dir)

--- a/src/apm_cli/compilation/claude_formatter.py
+++ b/src/apm_cli/compilation/claude_formatter.py
@@ -115,7 +115,7 @@ class ClaudeFormatter:
                     try:
                         is_root = placement.claude_path.parent.resolve() == self.base_dir
                     except OSError:
-                        is_root = placement.claude_path.parent == self.base_dir
+                        is_root = placement.claude_path.parent.absolute() == self.base_dir
                     if not is_root:
                         continue
                     has_constitution = bool(read_constitution(self.base_dir))

--- a/src/apm_cli/compilation/claude_formatter.py
+++ b/src/apm_cli/compilation/claude_formatter.py
@@ -74,6 +74,7 @@ class ClaudeFormatter:
 
         self.warnings: builtins.list[str] = []
         self.errors: builtins.list[str] = []
+        self._skip_instructions: bool = False
 
     def format_distributed(
         self,
@@ -306,9 +307,7 @@ class ClaudeFormatter:
                 )
             )
 
-        # Note: CLAUDE.md only contains instructions (Project Standards).
-        # Agents/workflows are NOT included - they go to .github/agents/ as separate files.
-        # This matches AGENTS.md behavior which also only contains instructions.
+        # Agents/workflows go to .github/agents/ as separate files, not here.
 
         # Footer
         sections.append("---")

--- a/src/apm_cli/compilation/claude_formatter.py
+++ b/src/apm_cli/compilation/claude_formatter.py
@@ -36,6 +36,7 @@ class ClaudePlacement:
     dependencies: builtins.list[str] = field(default_factory=list)  # @import paths
     coverage_patterns: builtins.set[str] = field(default_factory=set)
     source_attribution: builtins.dict[str, str] = field(default_factory=dict)
+    is_root: bool = False
 
 
 @dataclass
@@ -74,7 +75,6 @@ class ClaudeFormatter:
 
         self.warnings: builtins.list[str] = []
         self.errors: builtins.list[str] = []
-        self._skip_instructions: bool = False
 
     def format_distributed(
         self,
@@ -98,7 +98,7 @@ class ClaudeFormatter:
         try:
             config = config or {}
             source_attribution = config.get("source_attribution", True)
-            self._skip_instructions = config.get("skip_instructions", False)
+            skip_instructions = config.get("skip_instructions", False)
 
             # Generate Claude placements from the placement map
             placements = self._generate_placements(
@@ -109,19 +109,17 @@ class ClaudeFormatter:
             # When instructions are skipped (already in .claude/rules/), only
             # emit root CLAUDE.md if it has other content (constitution or
             # dependencies); subdirectory placements are omitted entirely.
+            has_constitution = bool(read_constitution(self.base_dir))
             content_map = {}
             for placement in placements:
-                if self._skip_instructions:
-                    try:
-                        is_root = placement.claude_path.parent.resolve() == self.base_dir
-                    except OSError:
-                        is_root = placement.claude_path.parent.absolute() == self.base_dir
-                    if not is_root:
+                if skip_instructions:
+                    if not placement.is_root:
                         continue
-                    has_constitution = bool(read_constitution(self.base_dir))
                     if not placement.dependencies and not has_constitution:
                         continue
-                content = self._generate_claude_content(placement, primitives)
+                content = self._generate_claude_content(
+                    placement, primitives, skip_instructions=skip_instructions
+                )
                 content_map[placement.claude_path] = content
 
             # Filter placements to only those that produced content so stats
@@ -182,6 +180,7 @@ class ClaudeFormatter:
                     dependencies=self._collect_dependencies(),
                     coverage_patterns=set(),
                     source_attribution={},
+                    is_root=True,
                 )
                 placements.append(placement)
         else:
@@ -215,6 +214,7 @@ class ClaudeFormatter:
                     dependencies=self._collect_dependencies() if is_root else [],
                     coverage_patterns=patterns,
                     source_attribution=source_map,
+                    is_root=is_root,
                 )
 
                 placements.append(placement)
@@ -254,13 +254,18 @@ class ClaudeFormatter:
         return sorted(dependencies)
 
     def _generate_claude_content(
-        self, placement: ClaudePlacement, primitives: PrimitiveCollection
+        self,
+        placement: ClaudePlacement,
+        primitives: PrimitiveCollection,
+        *,
+        skip_instructions: bool = False,
     ) -> str:
         """Generate CLAUDE.md content for a specific placement.
 
         Args:
             placement (ClaudePlacement): Placement result with instructions.
             primitives (PrimitiveCollection): Full primitive collection.
+            skip_instructions (bool): If True, omit the Project Standards section.
 
         Returns:
             str: Generated CLAUDE.md content.
@@ -282,8 +287,7 @@ class ClaudeFormatter:
             sections.append("")
 
         # Constitution section (only for root CLAUDE.md)
-        is_root = placement.claude_path.parent == self.base_dir
-        if is_root:
+        if placement.is_root:
             constitution = read_constitution(self.base_dir)
             if constitution:
                 sections.append("# Constitution")
@@ -295,7 +299,7 @@ class ClaudeFormatter:
         # Skipped when instructions are already deployed to .claude/rules/ by
         # `apm install`, since Claude Code reads both locations and would see
         # duplicate content.
-        if placement.instructions and not self._skip_instructions:
+        if placement.instructions and not skip_instructions:
             sections.append("# Project Standards")
             sections.append("")
 

--- a/src/apm_cli/compilation/claude_formatter.py
+++ b/src/apm_cli/compilation/claude_formatter.py
@@ -97,15 +97,29 @@ class ClaudeFormatter:
         try:
             config = config or {}
             source_attribution = config.get("source_attribution", True)
+            self._skip_instructions = config.get("skip_instructions", False)
 
             # Generate Claude placements from the placement map
             placements = self._generate_placements(
                 placement_map, primitives, source_attribution=source_attribution
             )
 
-            # Generate content for each placement
+            # Generate content for each placement.
+            # When instructions are skipped (already in .claude/rules/), only
+            # emit root CLAUDE.md if it has other content (constitution or
+            # dependencies); subdirectory placements are omitted entirely.
             content_map = {}
             for placement in placements:
+                if self._skip_instructions:
+                    try:
+                        is_root = placement.claude_path.parent.resolve() == self.base_dir
+                    except OSError:
+                        is_root = placement.claude_path.parent == self.base_dir
+                    if not is_root:
+                        continue
+                    has_constitution = bool(read_constitution(self.base_dir))
+                    if not placement.dependencies and not has_constitution:
+                        continue
                 content = self._generate_claude_content(placement, primitives)
                 content_map[placement.claude_path] = content
 
@@ -272,8 +286,11 @@ class ClaudeFormatter:
                 sections.append(constitution.strip())
                 sections.append("")
 
-        # Project Standards section (grouped by pattern)
-        if placement.instructions:
+        # Project Standards section (grouped by pattern).
+        # Skipped when instructions are already deployed to .claude/rules/ by
+        # `apm install`, since Claude Code reads both locations and would see
+        # duplicate content.
+        if placement.instructions and not self._skip_instructions:
             sections.append("# Project Standards")
             sections.append("")
 

--- a/src/apm_cli/compilation/claude_formatter.py
+++ b/src/apm_cli/compilation/claude_formatter.py
@@ -123,12 +123,16 @@ class ClaudeFormatter:
                 content = self._generate_claude_content(placement, primitives)
                 content_map[placement.claude_path] = content
 
+            # Filter placements to only those that produced content so stats
+            # and downstream consumers see an accurate picture.
+            emitted_placements = [p for p in placements if p.claude_path in content_map]
+
             # Compile statistics
-            stats = self._compile_stats(placements, primitives)
+            stats = self._compile_stats(emitted_placements, primitives)
 
             return ClaudeCompilationResult(
                 success=len(self.errors) == 0,
-                placements=placements,
+                placements=emitted_placements,
                 content_map=content_map,
                 warnings=self.warnings.copy(),
                 errors=self.errors.copy(),

--- a/src/apm_cli/compilation/claude_formatter.py
+++ b/src/apm_cli/compilation/claude_formatter.py
@@ -167,17 +167,17 @@ class ClaudeFormatter:
         """
         placements = []
 
-        # Handle empty placement map with constitution
+        # Handle empty placement map with constitution or dependencies
         if not placement_map:
             constitution = read_constitution(self.base_dir)
-            if constitution:
-                # Create root placement for constitution-only projects
+            dependencies = self._collect_dependencies()
+            if constitution or dependencies:
                 root_path = self.base_dir / "CLAUDE.md"
                 placement = ClaudePlacement(
                     claude_path=root_path,
                     instructions=[],
                     agents=list(primitives.chatmodes),
-                    dependencies=self._collect_dependencies(),
+                    dependencies=dependencies,
                     coverage_patterns=set(),
                     source_attribution={},
                     is_root=True,

--- a/tests/integration/test_install_compile_claude_dedup_e2e.py
+++ b/tests/integration/test_install_compile_claude_dedup_e2e.py
@@ -1,0 +1,134 @@
+"""Integration: install -> compile deduplication for Claude Code (PR #1146).
+
+Pins the user-visible promise across the install and compile boundaries:
+after ``apm install --target claude`` populates ``.claude/rules/`` with
+per-instruction files, a subsequent ``apm compile --target claude`` must
+omit the instructions section from ``CLAUDE.md`` so Claude Code does not
+load duplicate content into its context window.
+
+This is the cross-module guard requested by the review panel on PR #1146
+(test-coverage-expert: outcome=missing). The unit suite covers the
+formatter and compiler in isolation; this regression trap fires if a
+future refactor of ``apm install``'s write path silently breaks the
+filesystem contract that ``apm compile`` reads (any ``.md`` file under
+``.claude/rules/`` triggers the skip).
+
+Both stages run through the real CLI as subprocesses to exercise the
+full code path, not just the formatter unit.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+CLI = [sys.executable, "-m", "apm_cli.cli"]
+
+APM_YML = """name: test-dedup
+version: 1.0.0
+description: Install->compile dedup regression trap
+author: Test
+targets:
+  - claude
+"""
+
+INSTRUCTION_BODY = (
+    "---\n"
+    "description: Style rule for the dedup test\n"
+    "applyTo: '**/*.py'\n"
+    "---\n"
+    "# Style rule\n"
+    "Use type hints everywhere.\n"
+)
+
+
+def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        CLI + list(args),
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.fixture
+def project_with_instruction():
+    with tempfile.TemporaryDirectory(prefix="apm-dedup-e2e-") as tmp:
+        proj = Path(tmp).resolve()
+        (proj / "apm.yml").write_text(APM_YML, encoding="utf-8")
+        instr_dir = proj / ".apm" / "instructions"
+        instr_dir.mkdir(parents=True)
+        (instr_dir / "style.instructions.md").write_text(INSTRUCTION_BODY, encoding="utf-8")
+        yield proj
+
+
+def test_install_then_compile_skips_duplicated_instructions(project_with_instruction):
+    """After install populates .claude/rules/, compile must drop the
+    instructions section from CLAUDE.md. Pre-PR-#1146 the section was
+    duplicated into both files on every compile.
+    """
+    proj = project_with_instruction
+
+    install_res = _run(proj, "install", "--target", "claude")
+    assert install_res.returncode == 0, (
+        f"install stdout:\n{install_res.stdout}\ninstall stderr:\n{install_res.stderr}"
+    )
+    rules_dir = proj / ".claude" / "rules"
+    assert rules_dir.exists(), (
+        "install --target claude must populate .claude/rules/ "
+        "(this is the precondition the dedup logic reads)"
+    )
+    rule_files = sorted(rules_dir.glob("*.md"))
+    assert rule_files, "install must emit at least one *.md rule file"
+
+    compile_res = _run(proj, "compile", "--target", "claude")
+    assert compile_res.returncode == 0, (
+        f"compile stdout:\n{compile_res.stdout}\ncompile stderr:\n{compile_res.stderr}"
+    )
+
+    claude_md = proj / "CLAUDE.md"
+    if claude_md.exists():
+        body = claude_md.read_text(encoding="utf-8")
+        # The PR's contract: when .claude/rules/ is populated, the
+        # "Project Standards" instructions section is omitted from
+        # CLAUDE.md to keep Claude's context window lean.
+        assert "# Project Standards" not in body, (
+            "CLAUDE.md must NOT carry the duplicated instructions "
+            "section after install populated .claude/rules/. "
+            "Body was:\n" + body
+        )
+
+
+def test_compile_alone_then_compile_again_skips_on_second_run(project_with_instruction):
+    """`apm compile` itself also writes per-file rules into
+    ``.claude/rules/``; running it twice must trigger the dedup on the
+    second pass even if `apm install` was never invoked. Locks in the
+    docs claim that either install or compile can populate the dir.
+    """
+    proj = project_with_instruction
+
+    first = _run(proj, "compile", "--target", "claude")
+    assert first.returncode == 0, first.stderr
+
+    rules_dir = proj / ".claude" / "rules"
+    if not rules_dir.exists() or not list(rules_dir.glob("*.md")):
+        pytest.skip(
+            "compile alone does not populate .claude/rules/ on this "
+            "build; install->compile path is covered by the sibling test"
+        )
+
+    second = _run(proj, "compile", "--target", "claude")
+    assert second.returncode == 0, second.stderr
+
+    claude_md = proj / "CLAUDE.md"
+    if claude_md.exists():
+        body = claude_md.read_text(encoding="utf-8")
+        assert "# Project Standards" not in body, (
+            "Second compile must dedup against its own previously-emitted "
+            ".claude/rules/ files. Body was:\n" + body
+        )

--- a/tests/integration/test_install_compile_claude_dedup_e2e.py
+++ b/tests/integration/test_install_compile_claude_dedup_e2e.py
@@ -67,6 +67,7 @@ def project_with_instruction():
         yield proj
 
 
+@pytest.mark.integration
 def test_install_then_compile_skips_duplicated_instructions(project_with_instruction):
     """After install populates .claude/rules/, compile must drop the
     instructions section from CLAUDE.md. Pre-PR-#1146 the section was
@@ -104,6 +105,7 @@ def test_install_then_compile_skips_duplicated_instructions(project_with_instruc
         )
 
 
+@pytest.mark.integration
 def test_compile_alone_then_compile_again_skips_on_second_run(project_with_instruction):
     """`apm compile` itself also writes per-file rules into
     ``.claude/rules/``; running it twice must trigger the dedup on the

--- a/tests/unit/compilation/test_agents_compiler_coverage.py
+++ b/tests/unit/compilation/test_agents_compiler_coverage.py
@@ -719,11 +719,9 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         result = compiler.compile(config)
         assert result.success
 
-        # Check that the generated CLAUDE.md does not contain instructions
+        # No constitution or dependencies, so CLAUDE.md should not be generated
         claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
-        if claude_md.exists():
-            content = claude_md.read_text()
-            assert "# Project Standards" not in content
+        assert not claude_md.exists()
 
     def test_instructions_not_skipped_with_empty_rules_dir(self):
         """An empty .claude/rules/ does not trigger instruction skipping."""
@@ -739,6 +737,56 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         assert claude_md.exists()
         content = claude_md.read_text()
         assert "# Project Standards" in content
+
+    def test_instructions_not_skipped_with_non_md_files_in_rules_dir(self):
+        """Non-.md files in .claude/rules/ do not trigger instruction skipping."""
+        rules_dir = Path(self.tmp_resolved) / ".claude" / "rules"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / ".gitkeep").write_text("")
+        (rules_dir / "notes.txt").write_text("some notes")
+
+        compiler = AgentsCompiler(self.tmp_resolved)
+        config = CompilationConfig(target="claude", dry_run=False)
+        result = compiler.compile(config)
+        assert result.success
+
+        claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
+        assert claude_md.exists()
+        content = claude_md.read_text()
+        assert "# Project Standards" in content
+
+    def test_skip_instructions_dry_run(self):
+        """Dry-run respects skip_instructions when .claude/rules/ is populated."""
+        rules_dir = Path(self.tmp_resolved) / ".claude" / "rules"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "style.md").write_text("---\npaths:\n  - '**/*.py'\n---\nUse type hints.\n")
+
+        compiler = AgentsCompiler(self.tmp_resolved)
+        config = CompilationConfig(target="claude", dry_run=True)
+        result = compiler.compile(config)
+        assert result.success
+        assert "Project Standards" not in result.content
+
+    def test_skip_instructions_emits_log_messages(self):
+        """When instructions are skipped, informational log messages are emitted."""
+        rules_dir = Path(self.tmp_resolved) / ".claude" / "rules"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "style.md").write_text("---\npaths:\n  - '**/*.py'\n---\nUse type hints.\n")
+
+        compiler = AgentsCompiler(self.tmp_resolved)
+        config = CompilationConfig(target="claude", dry_run=False)
+
+        mock_logger = MagicMock()
+        result = compiler.compile(config, logger=mock_logger)
+        assert result.success
+
+        # Collect all progress messages
+        progress_calls = [
+            str(call) for call in mock_logger.progress.call_args_list
+        ]
+        joined = " ".join(progress_calls)
+        assert "Instructions already in .claude/rules/" in joined
+        assert "CLAUDE.md not generated" in joined
 
 
 if __name__ == "__main__":

--- a/tests/unit/compilation/test_agents_compiler_coverage.py
+++ b/tests/unit/compilation/test_agents_compiler_coverage.py
@@ -768,6 +768,16 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         result = compiler.compile(config)
         assert result.success
         assert result.stats.get("claude_files_generated", 0) == 0
+        assert "Would generate 0 files" in result.content
+
+    def test_dry_run_reports_file_without_skip(self):
+        """Dry-run without .claude/rules/ reports CLAUDE.md would be generated."""
+        compiler = AgentsCompiler(self.tmp_resolved)
+        config = CompilationConfig(target="claude", dry_run=True)
+        result = compiler.compile(config)
+        assert result.success
+        assert "Would generate 1 files" in result.content
+        assert "CLAUDE.md" in result.content
 
     def test_skip_instructions_stats_reflect_emitted_files(self):
         """Stats report zero files generated when all placements are skipped."""

--- a/tests/unit/compilation/test_agents_compiler_coverage.py
+++ b/tests/unit/compilation/test_agents_compiler_coverage.py
@@ -826,7 +826,10 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         claude_dir = Path(self.tmp_resolved) / ".claude"
         claude_dir.mkdir(parents=True, exist_ok=True)
         rules_link = claude_dir / "rules"
-        rules_link.symlink_to(external_dir)
+        try:
+            rules_link.symlink_to(external_dir)
+        except OSError:
+            self.skipTest("symlinks not supported on this platform")
 
         compiler = AgentsCompiler(self.tmp_resolved)
         config = CompilationConfig(target="claude", dry_run=False)

--- a/tests/unit/compilation/test_agents_compiler_coverage.py
+++ b/tests/unit/compilation/test_agents_compiler_coverage.py
@@ -767,7 +767,7 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         config = CompilationConfig(target="claude", dry_run=True)
         result = compiler.compile(config)
         assert result.success
-        assert "Project Standards" not in result.content
+        assert result.stats.get("claude_files_generated", 0) == 0
 
     def test_skip_instructions_stats_reflect_emitted_files(self):
         """Stats report zero files generated when all placements are skipped."""

--- a/tests/unit/compilation/test_agents_compiler_coverage.py
+++ b/tests/unit/compilation/test_agents_compiler_coverage.py
@@ -817,32 +817,33 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         """A .claude/rules/ symlinked outside the project does not trigger skip."""
         import shutil
 
-        # Create a rules directory outside the project
-        external_dir = Path(self.tmp_resolved).parent / "external_rules"
-        external_dir.mkdir(parents=True, exist_ok=True)
-        (external_dir / "style.md").write_text("---\npaths:\n  - '**/*.py'\n---\nHacked.\n")
-
-        # Symlink .claude/rules/ to the external directory
-        claude_dir = Path(self.tmp_resolved) / ".claude"
-        claude_dir.mkdir(parents=True, exist_ok=True)
-        rules_link = claude_dir / "rules"
+        # Create a rules directory in a separate unique temp directory
+        external_dir = Path(tempfile.mkdtemp())
         try:
-            rules_link.symlink_to(external_dir)
-        except OSError:
-            self.skipTest("symlinks not supported on this platform")
+            (external_dir / "style.md").write_text(
+                "---\npaths:\n  - '**/*.py'\n---\nHacked.\n"
+            )
 
-        compiler = AgentsCompiler(self.tmp_resolved)
-        config = CompilationConfig(target="claude", dry_run=False)
-        result = compiler.compile(config)
-        assert result.success
+            # Symlink .claude/rules/ to the external directory
+            claude_dir = Path(self.tmp_resolved) / ".claude"
+            claude_dir.mkdir(parents=True, exist_ok=True)
+            rules_link = claude_dir / "rules"
+            try:
+                rules_link.symlink_to(external_dir)
+            except OSError:
+                self.skipTest("symlinks not supported on this platform")
 
-        # Instructions should NOT be skipped (symlink escapes project root)
-        claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
-        assert claude_md.exists()
-        assert "# Project Standards" in claude_md.read_text()
+            compiler = AgentsCompiler(self.tmp_resolved)
+            config = CompilationConfig(target="claude", dry_run=False)
+            result = compiler.compile(config)
+            assert result.success
 
-        # Cleanup external dir
-        shutil.rmtree(external_dir, ignore_errors=True)
+            # Instructions should NOT be skipped (symlink escapes project root)
+            claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
+            assert claude_md.exists()
+            assert "# Project Standards" in claude_md.read_text()
+        finally:
+            shutil.rmtree(external_dir, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/tests/unit/compilation/test_agents_compiler_coverage.py
+++ b/tests/unit/compilation/test_agents_compiler_coverage.py
@@ -813,5 +813,34 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         assert "CLAUDE.md not generated" in joined
 
 
+    def test_skip_instructions_ignores_symlink_outside_project(self):
+        """A .claude/rules/ symlinked outside the project does not trigger skip."""
+        import shutil
+
+        # Create a rules directory outside the project
+        external_dir = Path(self.tmp_resolved).parent / "external_rules"
+        external_dir.mkdir(parents=True, exist_ok=True)
+        (external_dir / "style.md").write_text("---\npaths:\n  - '**/*.py'\n---\nHacked.\n")
+
+        # Symlink .claude/rules/ to the external directory
+        claude_dir = Path(self.tmp_resolved) / ".claude"
+        claude_dir.mkdir(parents=True, exist_ok=True)
+        rules_link = claude_dir / "rules"
+        rules_link.symlink_to(external_dir)
+
+        compiler = AgentsCompiler(self.tmp_resolved)
+        config = CompilationConfig(target="claude", dry_run=False)
+        result = compiler.compile(config)
+        assert result.success
+
+        # Instructions should NOT be skipped (symlink escapes project root)
+        claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
+        assert claude_md.exists()
+        assert "# Project Standards" in claude_md.read_text()
+
+        # Cleanup external dir
+        shutil.rmtree(external_dir, ignore_errors=True)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/compilation/test_agents_compiler_coverage.py
+++ b/tests/unit/compilation/test_agents_compiler_coverage.py
@@ -671,5 +671,75 @@ class TestCompileClaudeMdConstitutionInjectionFailure(unittest.TestCase):
         )
 
 
+# ---------------------------------------------------------------------------
+# AgentsCompiler._compile_claude_md() -- skip_instructions when .claude/rules/ populated
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeCompileSkipInstructions(unittest.TestCase):
+    """Test that _compile_claude_md skips instructions when .claude/rules/ has files."""
+
+    def setUp(self):
+        self.original_dir = os.getcwd()
+        self.tmp = tempfile.mkdtemp()
+        self.tmp_resolved = str(Path(self.tmp).resolve())
+        os.chdir(self.tmp_resolved)
+        # Minimal apm.yml so discovery works
+        with open("apm.yml", "w") as f:
+            yaml.dump({"name": "test-project", "version": "1.0.0"}, f)
+        # Create .apm/instructions with a sample instruction
+        instr_dir = Path(self.tmp_resolved) / ".apm" / "instructions"
+        instr_dir.mkdir(parents=True)
+        (instr_dir / "style.instructions.md").write_text(
+            "---\ndescription: Style guide\napplyTo: '**/*.py'\n---\nUse type hints.\n"
+        )
+
+    def tearDown(self):
+        os.chdir(self.original_dir)
+        import shutil
+
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_instructions_included_without_rules_dir(self):
+        """Without .claude/rules/, instructions appear in CLAUDE.md."""
+        compiler = AgentsCompiler(self.tmp_resolved)
+        config = CompilationConfig(target="claude", dry_run=True)
+        result = compiler.compile(config)
+        assert result.success
+        assert "Project Standards" in result.content or "1" in str(result.stats)
+
+    def test_instructions_skipped_with_populated_rules_dir(self):
+        """With .claude/rules/ containing .md files, instructions are skipped."""
+        rules_dir = Path(self.tmp_resolved) / ".claude" / "rules"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "style.md").write_text("---\npaths:\n  - '**/*.py'\n---\nUse type hints.\n")
+
+        compiler = AgentsCompiler(self.tmp_resolved)
+        config = CompilationConfig(target="claude", dry_run=False)
+        result = compiler.compile(config)
+        assert result.success
+
+        # Check that the generated CLAUDE.md does not contain instructions
+        claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
+        if claude_md.exists():
+            content = claude_md.read_text()
+            assert "# Project Standards" not in content
+
+    def test_instructions_not_skipped_with_empty_rules_dir(self):
+        """An empty .claude/rules/ does not trigger instruction skipping."""
+        rules_dir = Path(self.tmp_resolved) / ".claude" / "rules"
+        rules_dir.mkdir(parents=True)
+
+        compiler = AgentsCompiler(self.tmp_resolved)
+        config = CompilationConfig(target="claude", dry_run=False)
+        result = compiler.compile(config)
+        assert result.success
+
+        claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
+        assert claude_md.exists()
+        content = claude_md.read_text()
+        assert "# Project Standards" in content
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/compilation/test_agents_compiler_coverage.py
+++ b/tests/unit/compilation/test_agents_compiler_coverage.py
@@ -705,10 +705,10 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         compiler = AgentsCompiler(self.tmp_resolved)
         config = CompilationConfig(target="claude", dry_run=False)
         result = compiler.compile(config)
-        assert result.success
+        self.assertTrue(result.success)
         claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
-        assert claude_md.exists()
-        assert "# Project Standards" in claude_md.read_text()
+        self.assertTrue(claude_md.exists())
+        self.assertIn("# Project Standards", claude_md.read_text())
 
     def test_instructions_skipped_with_populated_rules_dir(self):
         """With .claude/rules/ containing .md files, instructions are skipped."""
@@ -719,11 +719,11 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         compiler = AgentsCompiler(self.tmp_resolved)
         config = CompilationConfig(target="claude", dry_run=False)
         result = compiler.compile(config)
-        assert result.success
+        self.assertTrue(result.success)
 
         # No constitution or dependencies, so CLAUDE.md should not be generated
         claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
-        assert not claude_md.exists()
+        self.assertFalse(claude_md.exists())
 
     def test_instructions_not_skipped_with_empty_rules_dir(self):
         """An empty .claude/rules/ does not trigger instruction skipping."""
@@ -733,12 +733,12 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         compiler = AgentsCompiler(self.tmp_resolved)
         config = CompilationConfig(target="claude", dry_run=False)
         result = compiler.compile(config)
-        assert result.success
+        self.assertTrue(result.success)
 
         claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
-        assert claude_md.exists()
+        self.assertTrue(claude_md.exists())
         content = claude_md.read_text()
-        assert "# Project Standards" in content
+        self.assertIn("# Project Standards", content)
 
     def test_instructions_not_skipped_with_non_md_files_in_rules_dir(self):
         """Non-.md files in .claude/rules/ do not trigger instruction skipping."""
@@ -750,12 +750,12 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         compiler = AgentsCompiler(self.tmp_resolved)
         config = CompilationConfig(target="claude", dry_run=False)
         result = compiler.compile(config)
-        assert result.success
+        self.assertTrue(result.success)
 
         claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
-        assert claude_md.exists()
+        self.assertTrue(claude_md.exists())
         content = claude_md.read_text()
-        assert "# Project Standards" in content
+        self.assertIn("# Project Standards", content)
 
     def test_skip_instructions_dry_run(self):
         """Dry-run respects skip_instructions when .claude/rules/ is populated."""
@@ -766,18 +766,18 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         compiler = AgentsCompiler(self.tmp_resolved)
         config = CompilationConfig(target="claude", dry_run=True)
         result = compiler.compile(config)
-        assert result.success
-        assert result.stats.get("claude_files_generated", 0) == 0
-        assert "Would generate 0 files" in result.content
+        self.assertTrue(result.success)
+        self.assertEqual(result.stats.get("claude_files_generated", 0), 0)
+        self.assertIn("Would generate 0 files", result.content)
 
     def test_dry_run_reports_file_without_skip(self):
         """Dry-run without .claude/rules/ reports CLAUDE.md would be generated."""
         compiler = AgentsCompiler(self.tmp_resolved)
         config = CompilationConfig(target="claude", dry_run=True)
         result = compiler.compile(config)
-        assert result.success
-        assert "Would generate 1 file" in result.content
-        assert "CLAUDE.md" in result.content
+        self.assertTrue(result.success)
+        self.assertIn("Would generate 1 file", result.content)
+        self.assertIn("CLAUDE.md", result.content)
 
     def test_skip_instructions_stats_reflect_emitted_files(self):
         """Stats report zero files generated when all placements are skipped."""
@@ -788,8 +788,8 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         compiler = AgentsCompiler(self.tmp_resolved)
         config = CompilationConfig(target="claude", dry_run=True)
         result = compiler.compile(config)
-        assert result.success
-        assert result.stats.get("claude_files_generated", 0) == 0
+        self.assertTrue(result.success)
+        self.assertEqual(result.stats.get("claude_files_generated", 0), 0)
 
     def test_skip_instructions_emits_log_messages(self):
         """When instructions are skipped, informational log messages are emitted."""
@@ -802,15 +802,15 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
 
         mock_logger = MagicMock()
         result = compiler.compile(config, logger=mock_logger)
-        assert result.success
+        self.assertTrue(result.success)
 
         # Collect all progress messages
         progress_calls = [
             str(call) for call in mock_logger.progress.call_args_list
         ]
         joined = " ".join(progress_calls)
-        assert "Instructions already in .claude/rules/" in joined
-        assert "CLAUDE.md not generated" in joined
+        self.assertIn("Instructions already in .claude/rules/", joined)
+        self.assertIn("CLAUDE.md not generated", joined)
 
 
     def test_skip_instructions_ignores_symlink_outside_project(self):
@@ -836,12 +836,12 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
             compiler = AgentsCompiler(self.tmp_resolved)
             config = CompilationConfig(target="claude", dry_run=False)
             result = compiler.compile(config)
-            assert result.success
+            self.assertTrue(result.success)
 
             # Instructions should NOT be skipped (symlink escapes project root)
             claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
-            assert claude_md.exists()
-            assert "# Project Standards" in claude_md.read_text()
+            self.assertTrue(claude_md.exists())
+            self.assertIn("# Project Standards", claude_md.read_text())
         finally:
             shutil.rmtree(external_dir, ignore_errors=True)
 

--- a/tests/unit/compilation/test_agents_compiler_coverage.py
+++ b/tests/unit/compilation/test_agents_compiler_coverage.py
@@ -776,7 +776,7 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         config = CompilationConfig(target="claude", dry_run=True)
         result = compiler.compile(config)
         assert result.success
-        assert "Would generate 1 files" in result.content
+        assert "Would generate 1 file" in result.content
         assert "CLAUDE.md" in result.content
 
     def test_skip_instructions_stats_reflect_emitted_files(self):

--- a/tests/unit/compilation/test_agents_compiler_coverage.py
+++ b/tests/unit/compilation/test_agents_compiler_coverage.py
@@ -769,6 +769,10 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         self.assertTrue(result.success)
         self.assertEqual(result.stats.get("claude_files_generated", 0), 0)
         self.assertIn("Would generate 0 files", result.content)
+        # Dry-run UX (panel follow-up #4): "0 files" must be accompanied
+        # by a why so scripted consumers do not read it as a no-op.
+        self.assertIn("instructions section skipped", result.content)
+        self.assertIn(".claude/rules/", result.content)
 
     def test_dry_run_reports_file_without_skip(self):
         """Dry-run without .claude/rules/ reports CLAUDE.md would be generated."""
@@ -805,13 +809,10 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         self.assertTrue(result.success)
 
         # Collect all progress messages
-        progress_calls = [
-            str(call) for call in mock_logger.progress.call_args_list
-        ]
+        progress_calls = [str(call) for call in mock_logger.progress.call_args_list]
         joined = " ".join(progress_calls)
         self.assertIn("Instructions already in .claude/rules/", joined)
         self.assertIn("CLAUDE.md not generated", joined)
-
 
     def test_skip_instructions_ignores_symlink_outside_project(self):
         """A .claude/rules/ symlinked outside the project does not trigger skip."""
@@ -820,9 +821,7 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         # Create a rules directory in a separate unique temp directory
         external_dir = Path(tempfile.mkdtemp())
         try:
-            (external_dir / "style.md").write_text(
-                "---\npaths:\n  - '**/*.py'\n---\nHacked.\n"
-            )
+            (external_dir / "style.md").write_text("---\npaths:\n  - '**/*.py'\n---\nHacked.\n")
 
             # Symlink .claude/rules/ to the external directory
             claude_dir = Path(self.tmp_resolved) / ".claude"

--- a/tests/unit/compilation/test_agents_compiler_coverage.py
+++ b/tests/unit/compilation/test_agents_compiler_coverage.py
@@ -703,10 +703,12 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
     def test_instructions_included_without_rules_dir(self):
         """Without .claude/rules/, instructions appear in CLAUDE.md."""
         compiler = AgentsCompiler(self.tmp_resolved)
-        config = CompilationConfig(target="claude", dry_run=True)
+        config = CompilationConfig(target="claude", dry_run=False)
         result = compiler.compile(config)
         assert result.success
-        assert "Project Standards" in result.content or "1" in str(result.stats)
+        claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
+        assert claude_md.exists()
+        assert "# Project Standards" in claude_md.read_text()
 
     def test_instructions_skipped_with_populated_rules_dir(self):
         """With .claude/rules/ containing .md files, instructions are skipped."""
@@ -766,6 +768,18 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         result = compiler.compile(config)
         assert result.success
         assert "Project Standards" not in result.content
+
+    def test_skip_instructions_stats_reflect_emitted_files(self):
+        """Stats report zero files generated when all placements are skipped."""
+        rules_dir = Path(self.tmp_resolved) / ".claude" / "rules"
+        rules_dir.mkdir(parents=True)
+        (rules_dir / "style.md").write_text("---\npaths:\n  - '**/*.py'\n---\nUse type hints.\n")
+
+        compiler = AgentsCompiler(self.tmp_resolved)
+        config = CompilationConfig(target="claude", dry_run=True)
+        result = compiler.compile(config)
+        assert result.success
+        assert result.stats.get("claude_files_generated", 0) == 0
 
     def test_skip_instructions_emits_log_messages(self):
         """When instructions are skipped, informational log messages are emitted."""

--- a/tests/unit/compilation/test_claude_formatter.py
+++ b/tests/unit/compilation/test_claude_formatter.py
@@ -609,9 +609,7 @@ class TestSkipInstructions:
         assert result.success
         assert len(result.content_map) == 0
 
-    def test_no_skip_instructions_includes_project_standards(
-        self, temp_project, sample_primitives
-    ):
+    def test_no_skip_instructions_includes_project_standards(self, temp_project, sample_primitives):
         """When skip_instructions is False (default), instructions are included."""
         formatter = ClaudeFormatter(str(temp_project))
         placement_map = {temp_project: list(sample_primitives.instructions)}

--- a/tests/unit/compilation/test_claude_formatter.py
+++ b/tests/unit/compilation/test_claude_formatter.py
@@ -628,31 +628,45 @@ class TestSkipInstructions:
     def test_skip_instructions_oserror_fallback_identifies_root(
         self, temp_project, sample_primitives
     ):
-        """When Path.resolve() raises OSError, fallback still identifies root placement."""
-        from unittest.mock import patch
-
+        """When Path.resolve() raises OSError, the .absolute() fallback correctly
+        identifies root vs non-root placements."""
         formatter = ClaudeFormatter(str(temp_project))
-        placement_map = {temp_project: list(sample_primitives.instructions)}
 
         # Create a dependency so root CLAUDE.md is emitted even with skip
         dep_dir = temp_project / "apm_modules" / "owner" / "package"
         dep_dir.mkdir(parents=True)
         (dep_dir / "CLAUDE.md").write_text("# dep")
 
+        placement_map = {temp_project: list(sample_primitives.instructions)}
         config = {"skip_instructions": True}
 
-        original_resolve = Path.resolve
+        # Exercise the .absolute() fallback branch directly by replicating the
+        # placement loop logic with the fallback comparison.
+        def format_with_oserror_fallback(primitives, pm, cfg):
+            # Call the real method but patch the is_root check to use fallback
+            formatter._skip_instructions = cfg.get("skip_instructions", False)
+            placements = formatter._generate_placements(
+                pm, primitives, source_attribution=cfg.get("source_attribution", True)
+            )
+            content_map = {}
+            for placement in placements:
+                if formatter._skip_instructions:
+                    # Exercise the fallback branch directly
+                    is_root = placement.claude_path.parent.absolute() == formatter.base_dir
+                    if not is_root:
+                        continue
+                    from apm_cli.compilation.constitution import read_constitution
 
-        def raising_resolve(self_path, *args, **kwargs):
-            if "CLAUDE.md" in str(self_path):
-                raise OSError("simulated resolve failure")
-            return original_resolve(self_path, *args, **kwargs)
+                    has_constitution = bool(read_constitution(formatter.base_dir))
+                    if not placement.dependencies and not has_constitution:
+                        continue
+                content = formatter._generate_claude_content(placement, primitives)
+                content_map[placement.claude_path] = content
+            return content_map
 
-        with patch.object(Path, "resolve", raising_resolve):
-            result = formatter.format_distributed(sample_primitives, placement_map, config)
+        content_map = format_with_oserror_fallback(sample_primitives, placement_map, config)
 
-        assert result.success
-        assert len(result.content_map) == 1
-        content = result.content_map[temp_project / "CLAUDE.md"]
+        assert len(content_map) == 1
+        content = content_map[temp_project / "CLAUDE.md"]
         assert "# Dependencies" in content
         assert "# Project Standards" not in content

--- a/tests/unit/compilation/test_claude_formatter.py
+++ b/tests/unit/compilation/test_claude_formatter.py
@@ -496,3 +496,128 @@ class TestErrorHandling:
         result = formatter.format_distributed(primitives, {temp_project: [instruction]})
 
         assert isinstance(result, ClaudeCompilationResult)
+
+
+class TestSkipInstructions:
+    """Tests for skip_instructions behavior when .claude/rules/ is populated."""
+
+    @pytest.fixture
+    def temp_project(self):
+        """Create a temporary project directory."""
+        temp_dir = tempfile.mkdtemp()
+        resolved = Path(temp_dir).resolve()
+        yield resolved
+        shutil.rmtree(resolved, ignore_errors=True)
+
+    @pytest.fixture
+    def sample_primitives(self, temp_project):
+        """Create sample primitives for testing."""
+        primitives = PrimitiveCollection()
+        instruction = Instruction(
+            name="python-style",
+            file_path=temp_project / ".apm/instructions/python.instructions.md",
+            description="Python coding standards",
+            apply_to="**/*.py",
+            content="Use type hints and follow PEP 8.",
+            author="test",
+            source="local",
+        )
+        primitives.add_primitive(instruction)
+        return primitives
+
+    def test_skip_instructions_omits_project_standards(self, temp_project, sample_primitives):
+        """When skip_instructions is True, Project Standards section is omitted."""
+        formatter = ClaudeFormatter(str(temp_project))
+        placement_map = {temp_project: list(sample_primitives.instructions)}
+
+        config = {"skip_instructions": True}
+        result = formatter.format_distributed(sample_primitives, placement_map, config)
+
+        # No files generated (no constitution or dependencies either)
+        assert result.success
+        assert len(result.content_map) == 0
+
+    def test_skip_instructions_preserves_constitution(self, temp_project, sample_primitives):
+        """When skip_instructions is True, constitution is still included."""
+        from apm_cli.compilation.constitution import clear_constitution_cache
+
+        # Create a constitution file at the expected path
+        memory_dir = temp_project / ".specify" / "memory"
+        memory_dir.mkdir(parents=True)
+        (memory_dir / "constitution.md").write_text("Always be helpful.")
+
+        clear_constitution_cache()
+        formatter = ClaudeFormatter(str(temp_project))
+        placement_map = {temp_project: list(sample_primitives.instructions)}
+
+        config = {"skip_instructions": True}
+        result = formatter.format_distributed(sample_primitives, placement_map, config)
+
+        assert result.success
+        assert len(result.content_map) == 1
+        content = result.content_map[temp_project / "CLAUDE.md"]
+        assert "# Constitution" in content
+        assert "Always be helpful." in content
+        assert "# Project Standards" not in content
+
+    def test_skip_instructions_preserves_dependencies(self, temp_project, sample_primitives):
+        """When skip_instructions is True, dependencies are still included."""
+        # Create a dependency with CLAUDE.md
+        dep_dir = temp_project / "apm_modules" / "owner" / "package"
+        dep_dir.mkdir(parents=True)
+        (dep_dir / "CLAUDE.md").write_text("# dep")
+
+        formatter = ClaudeFormatter(str(temp_project))
+        placement_map = {temp_project: list(sample_primitives.instructions)}
+
+        config = {"skip_instructions": True}
+        result = formatter.format_distributed(sample_primitives, placement_map, config)
+
+        assert result.success
+        assert len(result.content_map) == 1
+        content = result.content_map[temp_project / "CLAUDE.md"]
+        assert "# Dependencies" in content
+        assert "@apm_modules/owner/package/CLAUDE.md" in content
+        assert "# Project Standards" not in content
+
+    def test_skip_instructions_omits_subdirectory_files(self, temp_project, sample_primitives):
+        """When skip_instructions is True, subdirectory CLAUDE.md files are not generated."""
+        subdir = temp_project / "src"
+        subdir.mkdir()
+
+        primitives = PrimitiveCollection()
+        instruction = Instruction(
+            name="src-style",
+            file_path=temp_project / ".apm/instructions/src.instructions.md",
+            description="Source standards",
+            apply_to="src/**/*.py",
+            content="Source-specific rules.",
+            author="test",
+            source="local",
+        )
+        primitives.add_primitive(instruction)
+
+        placement_map = {subdir: list(primitives.instructions)}
+
+        config = {"skip_instructions": True}
+        formatter = ClaudeFormatter(str(temp_project))
+        result = formatter.format_distributed(primitives, placement_map, config)
+
+        assert result.success
+        assert len(result.content_map) == 0
+
+    def test_no_skip_instructions_includes_project_standards(
+        self, temp_project, sample_primitives
+    ):
+        """When skip_instructions is False (default), instructions are included."""
+        formatter = ClaudeFormatter(str(temp_project))
+        placement_map = {temp_project: list(sample_primitives.instructions)}
+
+        config = {"skip_instructions": False}
+        result = formatter.format_distributed(sample_primitives, placement_map, config)
+
+        assert result.success
+        assert len(result.content_map) == 1
+        content = result.content_map[temp_project / "CLAUDE.md"]
+        assert "# Project Standards" in content
+        assert "Use type hints and follow PEP 8." in content

--- a/tests/unit/compilation/test_claude_formatter.py
+++ b/tests/unit/compilation/test_claude_formatter.py
@@ -630,6 +630,8 @@ class TestSkipInstructions:
     ):
         """When Path.resolve() raises OSError, the .absolute() fallback correctly
         identifies root vs non-root placements."""
+        from unittest.mock import patch
+
         formatter = ClaudeFormatter(str(temp_project))
 
         # Create a dependency so root CLAUDE.md is emitted even with skip
@@ -640,33 +642,50 @@ class TestSkipInstructions:
         placement_map = {temp_project: list(sample_primitives.instructions)}
         config = {"skip_instructions": True}
 
-        # Exercise the .absolute() fallback branch directly by replicating the
-        # placement loop logic with the fallback comparison.
-        def format_with_oserror_fallback(primitives, pm, cfg):
-            # Call the real method but patch the is_root check to use fallback
-            formatter._skip_instructions = cfg.get("skip_instructions", False)
-            placements = formatter._generate_placements(
-                pm, primitives, source_attribution=cfg.get("source_attribution", True)
-            )
-            content_map = {}
-            for placement in placements:
-                if formatter._skip_instructions:
-                    # Exercise the fallback branch directly
-                    is_root = placement.claude_path.parent.absolute() == formatter.base_dir
-                    if not is_root:
-                        continue
-                    from apm_cli.compilation.constitution import read_constitution
+        # Build a placement with a mock parent that raises on resolve()
+        # but returns the correct base_dir on absolute().
+        class RaisingParent:
+            """Mimics a Path parent that fails resolve() but works with absolute()."""
 
-                    has_constitution = bool(read_constitution(formatter.base_dir))
-                    if not placement.dependencies and not has_constitution:
-                        continue
-                content = formatter._generate_claude_content(placement, primitives)
-                content_map[placement.claude_path] = content
-            return content_map
+            def resolve(self):
+                raise OSError("simulated resolve failure")
 
-        content_map = format_with_oserror_fallback(sample_primitives, placement_map, config)
+            def absolute(self):
+                return formatter.base_dir
 
-        assert len(content_map) == 1
-        content = content_map[temp_project / "CLAUDE.md"]
+            def __eq__(self, other):
+                return other == formatter.base_dir
+
+            def __hash__(self):
+                return hash(formatter.base_dir)
+
+        class MockClaudePath:
+            """A path-like object whose .parent raises on resolve()."""
+
+            def __init__(self, real_path):
+                self._real_path = real_path
+                self.parent = RaisingParent()
+
+            def __hash__(self):
+                return hash(self._real_path)
+
+            def __eq__(self, other):
+                return self._real_path == other
+
+        # Patch _generate_placements to inject our mock path
+        real_placements_fn = formatter._generate_placements
+
+        def patched_generate(*args, **kwargs):
+            placements = real_placements_fn(*args, **kwargs)
+            for p in placements:
+                p.claude_path = MockClaudePath(p.claude_path)
+            return placements
+
+        with patch.object(formatter, "_generate_placements", patched_generate):
+            result = formatter.format_distributed(sample_primitives, placement_map, config)
+
+        assert result.success
+        assert len(result.content_map) == 1
+        content = next(iter(result.content_map.values()))
         assert "# Dependencies" in content
         assert "# Project Standards" not in content

--- a/tests/unit/compilation/test_claude_formatter.py
+++ b/tests/unit/compilation/test_claude_formatter.py
@@ -625,67 +625,24 @@ class TestSkipInstructions:
         assert "# Project Standards" in content
         assert "Use type hints and follow PEP 8." in content
 
-    def test_skip_instructions_oserror_fallback_identifies_root(
-        self, temp_project, sample_primitives
-    ):
-        """When Path.resolve() raises OSError, the .absolute() fallback correctly
-        identifies root vs non-root placements."""
-        from unittest.mock import patch
-
-        formatter = ClaudeFormatter(str(temp_project))
-
+    def test_is_root_flag_used_for_skip_filtering(self, temp_project, sample_primitives):
+        """The is_root flag on ClaudePlacement drives skip filtering, not path comparison."""
         # Create a dependency so root CLAUDE.md is emitted even with skip
         dep_dir = temp_project / "apm_modules" / "owner" / "package"
         dep_dir.mkdir(parents=True)
         (dep_dir / "CLAUDE.md").write_text("# dep")
 
+        formatter = ClaudeFormatter(str(temp_project))
         placement_map = {temp_project: list(sample_primitives.instructions)}
         config = {"skip_instructions": True}
 
-        # Build a placement with a mock parent that raises on resolve()
-        # but returns the correct base_dir on absolute().
-        class RaisingParent:
-            """Mimics a Path parent that fails resolve() but works with absolute()."""
-
-            def resolve(self):
-                raise OSError("simulated resolve failure")
-
-            def absolute(self):
-                return formatter.base_dir
-
-            def __eq__(self, other):
-                return other == formatter.base_dir
-
-            def __hash__(self):
-                return hash(formatter.base_dir)
-
-        class MockClaudePath:
-            """A path-like object whose .parent raises on resolve()."""
-
-            def __init__(self, real_path):
-                self._real_path = real_path
-                self.parent = RaisingParent()
-
-            def __hash__(self):
-                return hash(self._real_path)
-
-            def __eq__(self, other):
-                return self._real_path == other
-
-        # Patch _generate_placements to inject our mock path
-        real_placements_fn = formatter._generate_placements
-
-        def patched_generate(*args, **kwargs):
-            placements = real_placements_fn(*args, **kwargs)
-            for p in placements:
-                p.claude_path = MockClaudePath(p.claude_path)
-            return placements
-
-        with patch.object(formatter, "_generate_placements", patched_generate):
-            result = formatter.format_distributed(sample_primitives, placement_map, config)
+        result = formatter.format_distributed(sample_primitives, placement_map, config)
 
         assert result.success
         assert len(result.content_map) == 1
+        # Root placement was emitted (has dependencies)
+        assert len(result.placements) == 1
+        assert result.placements[0].is_root is True
         content = next(iter(result.content_map.values()))
         assert "# Dependencies" in content
         assert "# Project Standards" not in content

--- a/tests/unit/compilation/test_claude_formatter.py
+++ b/tests/unit/compilation/test_claude_formatter.py
@@ -1,8 +1,10 @@
 """Unit tests for ClaudeFormatter - CLAUDE.md generation."""
 
+import pathlib
 import shutil
 import tempfile
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -37,6 +39,23 @@ class TestClaudeFormatterInit:
         """Test initialization with relative path."""
         formatter = ClaudeFormatter(".")
         assert formatter.base_dir.is_absolute()
+
+    def test_init_falls_back_to_absolute_on_oserror(self):
+        """When Path.resolve() raises OSError, __init__ uses absolute() as fallback."""
+        with patch.object(pathlib.Path, "resolve", side_effect=OSError("resolve failed")):
+            formatter = ClaudeFormatter(".")
+        # base_dir must be absolute regardless of which code path was taken
+        assert formatter.base_dir.is_absolute()
+        assert formatter.warnings == []
+        assert formatter.errors == []
+
+    def test_init_falls_back_to_absolute_on_filenotfounderror(self):
+        """When Path.resolve() raises FileNotFoundError, __init__ uses absolute() as fallback."""
+        with patch.object(pathlib.Path, "resolve", side_effect=FileNotFoundError("not found")):
+            formatter = ClaudeFormatter(".")
+        assert formatter.base_dir.is_absolute()
+        assert formatter.warnings == []
+        assert formatter.errors == []
 
 
 class TestFormatDistributed:

--- a/tests/unit/compilation/test_claude_formatter.py
+++ b/tests/unit/compilation/test_claude_formatter.py
@@ -624,3 +624,35 @@ class TestSkipInstructions:
         content = result.content_map[temp_project / "CLAUDE.md"]
         assert "# Project Standards" in content
         assert "Use type hints and follow PEP 8." in content
+
+    def test_skip_instructions_oserror_fallback_identifies_root(
+        self, temp_project, sample_primitives
+    ):
+        """When Path.resolve() raises OSError, fallback still identifies root placement."""
+        from unittest.mock import patch
+
+        formatter = ClaudeFormatter(str(temp_project))
+        placement_map = {temp_project: list(sample_primitives.instructions)}
+
+        # Create a dependency so root CLAUDE.md is emitted even with skip
+        dep_dir = temp_project / "apm_modules" / "owner" / "package"
+        dep_dir.mkdir(parents=True)
+        (dep_dir / "CLAUDE.md").write_text("# dep")
+
+        config = {"skip_instructions": True}
+
+        original_resolve = Path.resolve
+
+        def raising_resolve(self_path, *args, **kwargs):
+            if "CLAUDE.md" in str(self_path):
+                raise OSError("simulated resolve failure")
+            return original_resolve(self_path, *args, **kwargs)
+
+        with patch.object(Path, "resolve", raising_resolve):
+            result = formatter.format_distributed(sample_primitives, placement_map, config)
+
+        assert result.success
+        assert len(result.content_map) == 1
+        content = result.content_map[temp_project / "CLAUDE.md"]
+        assert "# Dependencies" in content
+        assert "# Project Standards" not in content

--- a/tests/unit/compilation/test_claude_formatter.py
+++ b/tests/unit/compilation/test_claude_formatter.py
@@ -536,6 +536,9 @@ class TestSkipInstructions:
         # No files generated (no constitution or dependencies either)
         assert result.success
         assert len(result.content_map) == 0
+        # Stats reflect zero emitted files, not the original placement count
+        assert result.stats["claude_files_generated"] == 0
+        assert result.placements == []
 
     def test_skip_instructions_preserves_constitution(self, temp_project, sample_primitives):
         """When skip_instructions is True, constitution is still included."""


### PR DESCRIPTION
## Summary

- When both `apm install` (deploys to `.claude/rules/`) and `apm compile --target claude` (generates `CLAUDE.md`) have been run, Claude Code sees every instruction twice. This PR detects when `.claude/rules/` already contains `.md` files and omits the "Project Standards" section from `CLAUDE.md`, eliminating the duplication.
- `CLAUDE.md` is still generated when it carries a constitution block or `@import` dependency paths — only the instructions section is suppressed.
- Adds an informational log message when zero CLAUDE.md files are generated (all content already deployed via rules).

## Details

Detection heuristic: `claude_rules_dir.is_dir() and any(claude_rules_dir.glob("*.md"))`. This is intentionally simple — if the directory exists and has markdown files, we assume `apm install` put them there. A future enhancement could cross-check against `apm.lock.yaml` deployed-file provenance for more precision.

**Files changed:**
- `src/apm_cli/compilation/agents_compiler.py` — detection logic + log messages
- `src/apm_cli/compilation/claude_formatter.py` — `skip_instructions` config plumbing; `is_root` field on `ClaudePlacement`; skips subdirectory placements and the Project Standards section when active
- `tests/unit/compilation/test_agents_compiler_coverage.py` — 9 tests (`TestClaudeCompileSkipInstructions`)
- `tests/unit/compilation/test_claude_formatter.py` — 6 tests (`TestSkipInstructions`)
- `docs/src/content/docs/producer/compile.md` — deduplication note + updated "Where instructions land" table
- `CHANGELOG.md` — entry under Unreleased/Fixed

## Possible follow-up

Lockfile-provenance detection: instead of globbing `.claude/rules/*.md`, cross-check against `deployed_files` in `apm.lock.yaml` to distinguish APM-managed rules from hand-authored ones. Deferred to keep this PR focused.

## Test plan

- [x] All 359 compilation unit tests pass
- [x] Full unit suite passes (8,310 tests)
- [x] Linter passes on all modified files
- [x] Verify `apm compile --target claude` with `.claude/rules/` present → no Project Standards in CLAUDE.md
- [x] Verify `apm compile --target claude` without `.claude/rules/` → CLAUDE.md includes Project Standards as before
- [x] Verify constitution + dependencies still appear in CLAUDE.md when instructions are skipped

Closes #1138