### PR TITLE
[docs] Update documentation for features from 2026-05-06

### DIFF
--- a/docs/src/content/docs/guides/dependencies.md
+++ b/docs/src/content/docs/guides/dependencies.md
@@ -806,7 +806,8 @@ The `mcp_servers` field records the MCP dependency references (e.g. `io.github.g
 
 1. **First install**: APM resolves dependencies, downloads packages, and writes `apm.lock.yaml`
 2. **Subsequent installs**: APM reads `apm.lock.yaml` and uses locked commits for exact reproducibility. If the local checkout already matches the locked commit SHA, the download is skipped entirely.
-3. **Updating**: Use `--update` to re-resolve dependencies and generate a fresh lockfile. This re-resolves all dependencies, including transitive ones, so stale locked SHAs are never reused.
+3. **Mutable branch refs**: When a dependency uses `ref: <branch>` (e.g. `ref: main`), `apm install` always resolves the current remote HEAD for that branch and re-downloads if it has advanced past the lockfile-recorded SHA. The lockfile is updated to reflect the new commit. This means plain `apm install` keeps branch-pinned deps up to date without `--update`.
+4. **Updating**: Use `--update` to re-resolve dependencies and generate a fresh lockfile. This re-resolves all dependencies, including transitive ones, so stale locked SHAs are never reused.
 
 ### Version Control
 


### PR DESCRIPTION
## Documentation Updates - 2026-05-06

This PR updates the documentation based on features and fixes merged in the last 24 hours.

### Features Documented

- Branch-ref drift behavior clarification (from #1158)

### Changes Made

- Updated `docs/src/content/docs/guides/dependencies.md` to clarify that mutable branch refs (`ref: main`) always re-check remote HEAD on plain `apm install` and re-download when upstream has advanced. Added as step 3 in the "How It Works" section of the lockfile documentation.

### Merged PRs Referenced

- #1158 - fix(install): branch-ref drift no longer ships 3-way-inconsistent lockfile
- #1160 - fix(install): rewrite in-package relative links to apm_modules/ paths (#1147) -- already documented in `guides/package-relative-links.md`
- #1137 - feat(audit): default-on integration drift detection -- already documented in `guides/drift-detection.md`

### Notes

PRs #1160 and #1137 were already fully documented in the existing guide pages (`package-relative-links.md` and `drift-detection.md` respectively). Only the branch-ref behavior from #1158 needed a documentation gap filled.




> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/25437158630/agentic_workflow) · ● 819.4K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+%22gh-aw-workflow-id%3A+daily-doc-updater%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/blob/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-05-08T13:12:19.774Z --> on May 8, 2026, 1:12 PM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, version: 1.0.36, model: claude-sonnet-4.6, id: 25437158630, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/25437158630 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->