### PR TITLE
fix(policy): close audit --ci silent governance bypass + SCP/ADO URL parsing (#1159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`apm audit --ci` no longer silently skips when no org policy is resolved** -- `no_git_remote` / `absent` / `empty` auto-discovery outcomes now emit a `[!]` warning to stderr by default and honour `policy.fetch_failure_default: block` to fail closed (exit 1); JSON/SARIF on stdout stays clean. (#1159)
+- **SCP-shorthand SSH URLs from non-`git` users now parse correctly** -- `<user>@github.com:owner/repo` (EMU) and `<user>@ssh.dev.azure.com:v3/<org>/<project>/<repo>` (ADO) are accepted by both dependency parsing and policy auto-discovery. (#1159)
 - Fix `apm install` against a branch ref so it re-downloads when upstream has advanced past the lockfile-recorded SHA, and self-heal lockfiles produced by APM <= 0.12.2 on next install. (#1158)
 - Rewrite in-package relative markdown links to their `apm_modules/` location at install time so sibling references survive the `.agents/.github` deploy split. (#1147)
+
+### Changed
+
+- **`apm install` now honours `policy.fetch_failure_default: block` for `no_git_remote` / `absent` / `empty`** -- install-side parity with the audit fix above; default `warn` keeps fail-open. (#1159)
 
 ## [0.12.2] - 2026-05-05
 

--- a/docs/src/content/docs/enterprise/governance-guide.md
+++ b/docs/src/content/docs/enterprise/governance-guide.md
@@ -334,7 +334,7 @@ This section covers offline **policy** enforcement (the `apm-policy.yml` cache).
 | Online | Discovers + enforces | Discovers + enforces | Loads from path, enforces | Discovers + enforces |
 | Cache fresh (< 1h) | Cache hit, enforces | Cache hit, enforces | n/a (file path skips cache) | Cache hit, enforces |
 | Cache stale (1h - 7d) | Refresh attempted; on fail, `cached_stale` outcome -- proceed with cached unless `policy.fetch_failure: block` | Same | n/a | Same |
-| Offline, cache > 7d | `cache_miss_fetch_fail` -- fail-OPEN by default; fail-closed only if `policy.fetch_failure_default: block` in `apm.yml` | Same | Loads from path, full enforce | Same as install |
+| Offline, cache > 7d | `cache_miss_fetch_fail` -- fail-OPEN by default; fail-closed only if `policy.fetch_failure_default: block` in `apm.yml` | Same | Loads from path, full enforce | Same as install -- since #1159, also covers `no_git_remote` / `absent` / `empty` outcomes when `policy.fetch_failure_default: block` |
 
 Workarounds when the network is unreliable:
 
@@ -352,6 +352,7 @@ Workarounds when the network is unreliable:
 | Network failure (`cache_miss_fetch_fail`) | Fail-OPEN, log warning, install proceeds with no policy | `policy.fetch_failure_default: block` in `apm.yml` | [policy-reference#95-network-failure-semantics](../policy-reference/#95-network-failure-semantics) |
 | Cached stale (1h - 7d, refresh failed) | Warn and proceed with cached policy | `policy.fetch_failure: block` set in the cached policy itself | [policy-reference#95-network-failure-semantics](../policy-reference/#95-network-failure-semantics) |
 | Malformed YAML (`malformed`) (org policy file) | Fail-OPEN by default | `policy.fetch_failure_default: block` | `policy/parser.py` |
+| **No policy resolved (`no_git_remote` / `absent` / `empty`)** | **Fail-OPEN, log warning** (since #1159 -- pre-fix was silent fail-open even with `block`) | `policy.fetch_failure_default: block` in `apm.yml` -- applies to BOTH `apm install` and `apm audit --ci` | [policy-reference#951-no-policy-outcomes](../policy-reference/#951-no-policy-outcomes-no_git_remote--absent--empty) |
 | Hash-mismatch (project pin vs fetched) | **Always fail-CLOSED** | n/a (cannot be relaxed) | [policy-reference#95-network-failure-semantics](../policy-reference/#95-network-failure-semantics) |
 | Garbage response | Fail-OPEN by default | `policy.fetch_failure_default: block` | [policy-reference#95-network-failure-semantics](../policy-reference/#95-network-failure-semantics) |
 | Malformed project manifest (`manifest_parse`) | **Always fail-CLOSED** | n/a (cannot be relaxed) | `policy/policy_checks.py`, `policy/ci_checks.py` |

--- a/docs/src/content/docs/enterprise/governance-guide.md
+++ b/docs/src/content/docs/enterprise/governance-guide.md
@@ -334,7 +334,7 @@ This section covers offline **policy** enforcement (the `apm-policy.yml` cache).
 | Online | Discovers + enforces | Discovers + enforces | Loads from path, enforces | Discovers + enforces |
 | Cache fresh (< 1h) | Cache hit, enforces | Cache hit, enforces | n/a (file path skips cache) | Cache hit, enforces |
 | Cache stale (1h - 7d) | Refresh attempted; on fail, `cached_stale` outcome -- proceed with cached unless `policy.fetch_failure: block` | Same | n/a | Same |
-| Offline, cache > 7d | `cache_miss_fetch_fail` -- fail-OPEN by default; fail-closed only if `policy.fetch_failure_default: block` in `apm.yml` | Same | Loads from path, full enforce | Same as install -- since #1159, also covers `no_git_remote` / `absent` / `empty` outcomes when `policy.fetch_failure_default: block` |
+| Offline, cache > 7d | `cache_miss_fetch_fail` -- fail-OPEN by default; fail-closed only if `policy.fetch_failure_default: block` in `apm.yml` | Same | Loads from path, full enforce | Same as install -- also covers `no_git_remote` / `absent` / `empty` outcomes when `policy.fetch_failure_default: block` |
 
 Workarounds when the network is unreliable:
 
@@ -352,7 +352,7 @@ Workarounds when the network is unreliable:
 | Network failure (`cache_miss_fetch_fail`) | Fail-OPEN, log warning, install proceeds with no policy | `policy.fetch_failure_default: block` in `apm.yml` | [policy-reference#95-network-failure-semantics](../policy-reference/#95-network-failure-semantics) |
 | Cached stale (1h - 7d, refresh failed) | Warn and proceed with cached policy | `policy.fetch_failure: block` set in the cached policy itself | [policy-reference#95-network-failure-semantics](../policy-reference/#95-network-failure-semantics) |
 | Malformed YAML (`malformed`) (org policy file) | Fail-OPEN by default | `policy.fetch_failure_default: block` | `policy/parser.py` |
-| **No policy resolved (`no_git_remote` / `absent` / `empty`)** | **Fail-OPEN, log warning** (since #1159 -- pre-fix was silent fail-open even with `block`) | `policy.fetch_failure_default: block` in `apm.yml` -- applies to BOTH `apm install` and `apm audit --ci` | [policy-reference#951-no-policy-outcomes](../policy-reference/#951-no-policy-outcomes-no_git_remote--absent--empty) |
+| **No policy resolved (`no_git_remote` / `absent` / `empty`)** | **Fail-OPEN, log warning** | `policy.fetch_failure_default: block` in `apm.yml` -- applies to BOTH `apm install` and `apm audit --ci` | [policy-reference#951-no-policy-outcomes](../policy-reference/#951-no-policy-outcomes-no_git_remote--absent--empty) |
 | Hash-mismatch (project pin vs fetched) | **Always fail-CLOSED** | n/a (cannot be relaxed) | [policy-reference#95-network-failure-semantics](../policy-reference/#95-network-failure-semantics) |
 | Garbage response | Fail-OPEN by default | `policy.fetch_failure_default: block` | [policy-reference#95-network-failure-semantics](../policy-reference/#95-network-failure-semantics) |
 | Malformed project manifest (`manifest_parse`) | **Always fail-CLOSED** | n/a (cannot be relaxed) | `policy/policy_checks.py`, `policy/ci_checks.py` |

--- a/docs/src/content/docs/enterprise/policy-reference.md
+++ b/docs/src/content/docs/enterprise/policy-reference.md
@@ -723,7 +723,7 @@ Three additional outcomes describe "discovery succeeded but produced no enforcea
 - `absent` -- the resolved org has no `apm-policy.yml` at the discovered source.
 - `empty` -- the file exists but parses to an empty policy (no rules).
 
-Pre-#1159, these outcomes were silently fail-open on BOTH `apm install` and `apm audit --ci` even when the project pinned `policy.fetch_failure_default: block`. As of v0.12.3 they honour the same knob as fetch failures:
+Pre-#1159, these outcomes were silently fail-open on BOTH `apm install` and `apm audit --ci` even when the project pinned `policy.fetch_failure_default: block`. Since [#1159](https://github.com/microsoft/apm/issues/1159) they honour the same knob as fetch failures:
 
 - **`warn` (default):** `[!]` warning on stderr explaining the cause; install / audit proceeds.
 - **`block`:** `[x]` error on stderr; install raises `PolicyViolationError`, `apm audit --ci` exits 1.

--- a/docs/src/content/docs/enterprise/policy-reference.md
+++ b/docs/src/content/docs/enterprise/policy-reference.md
@@ -712,7 +712,7 @@ Resolved effective policy is cached under `apm_modules/.policy-cache/`. Default 
 When discovery cannot reach the policy source, APM behaves as follows:
 
 - **Cached, stale within 7 days** -- use the cached policy and emit a warning naming the cache age and the fetch error. Enforcement still applies.
-- **Cache miss or stale beyond 7 days, fetch fails** -- emit a loud warning every invocation; **do NOT block the install** by default (closes #829: ratified to keep developers unblocked when GitHub is unreachable). Opt in to fail-closed behaviour with `policy.fetch_failure: block` on the org policy (applies when a cached policy is available) or `policy.fetch_failure_default: block` in the project's `apm.yml` (applies when no policy is available at all). Both default to `warn`.
+- **Cache miss or stale beyond 7 days, fetch fails** -- emit a loud warning every invocation; **do NOT block the install** by default, to keep developers unblocked when GitHub is unreachable. Opt in to fail-closed behaviour with `policy.fetch_failure: block` on the org policy (applies when a cached policy is available) or `policy.fetch_failure_default: block` in the project's `apm.yml` (applies when no policy is available at all). Both default to `warn`.
 - **Garbage response** (HTTP 200 with non-YAML body, e.g. captive portal HTML) -- same posture as fetch failure: warn loudly by default, block when the project pins `policy.fetch_failure_default: block`.
 
 #### 9.5.1. No-policy outcomes (`no_git_remote` / `absent` / `empty`)
@@ -723,12 +723,12 @@ Three additional outcomes describe "discovery succeeded but produced no enforcea
 - `absent` -- the resolved org has no `apm-policy.yml` at the discovered source.
 - `empty` -- the file exists but parses to an empty policy (no rules).
 
-Pre-#1159, these outcomes were silently fail-open on BOTH `apm install` and `apm audit --ci` even when the project pinned `policy.fetch_failure_default: block`. Since [#1159](https://github.com/microsoft/apm/issues/1159) they honour the same knob as fetch failures:
+These outcomes honour the same knob as fetch failures on both `apm install` and `apm audit --ci`:
 
 - **`warn` (default):** `[!]` warning on stderr explaining the cause; install / audit proceeds.
 - **`block`:** `[x]` error on stderr; install raises `PolicyViolationError`, `apm audit --ci` exits 1.
 
-Explicit `--policy <file>` keeps the legacy fall-through for these three outcomes -- an opt-in pointer at a baseline file should not regress.
+Explicit `--policy <file>` falls through these three outcomes -- an opt-in pointer at a baseline file is treated as the authoritative source.
 
 Example -- consumer-side opt-in to fail-closed semantics in `apm.yml`:
 

--- a/docs/src/content/docs/enterprise/policy-reference.md
+++ b/docs/src/content/docs/enterprise/policy-reference.md
@@ -711,9 +711,24 @@ Resolved effective policy is cached under `apm_modules/.policy-cache/`. Default 
 
 When discovery cannot reach the policy source, APM behaves as follows:
 
-- **Cached, stale within 7 days** — use the cached policy and emit a warning naming the cache age and the fetch error. Enforcement still applies.
-- **Cache miss or stale beyond 7 days, fetch fails** — emit a loud warning every invocation; **do NOT block the install** by default (closes #829: ratified to keep developers unblocked when GitHub is unreachable). Opt in to fail-closed behaviour with `policy.fetch_failure: block` on the org policy (applies when a cached policy is available) or `policy.fetch_failure_default: block` in the project's `apm.yml` (applies when no policy is available at all). Both default to `warn`.
-- **Garbage response** (HTTP 200 with non-YAML body, e.g. captive portal HTML) — same posture as fetch failure: warn loudly by default, block when the project pins `policy.fetch_failure_default: block`.
+- **Cached, stale within 7 days** -- use the cached policy and emit a warning naming the cache age and the fetch error. Enforcement still applies.
+- **Cache miss or stale beyond 7 days, fetch fails** -- emit a loud warning every invocation; **do NOT block the install** by default (closes #829: ratified to keep developers unblocked when GitHub is unreachable). Opt in to fail-closed behaviour with `policy.fetch_failure: block` on the org policy (applies when a cached policy is available) or `policy.fetch_failure_default: block` in the project's `apm.yml` (applies when no policy is available at all). Both default to `warn`.
+- **Garbage response** (HTTP 200 with non-YAML body, e.g. captive portal HTML) -- same posture as fetch failure: warn loudly by default, block when the project pins `policy.fetch_failure_default: block`.
+
+#### 9.5.1. No-policy outcomes (`no_git_remote` / `absent` / `empty`)
+
+Three additional outcomes describe "discovery succeeded but produced no enforceable policy":
+
+- `no_git_remote` -- the working tree has no `origin` remote (shallow CI clone, ephemeral worktree, source pulled via tarball), so APM cannot derive an org to look up.
+- `absent` -- the resolved org has no `apm-policy.yml` at the discovered source.
+- `empty` -- the file exists but parses to an empty policy (no rules).
+
+Pre-#1159, these outcomes were silently fail-open on BOTH `apm install` and `apm audit --ci` even when the project pinned `policy.fetch_failure_default: block`. As of v0.12.3 they honour the same knob as fetch failures:
+
+- **`warn` (default):** `[!]` warning on stderr explaining the cause; install / audit proceeds.
+- **`block`:** `[x]` error on stderr; install raises `PolicyViolationError`, `apm audit --ci` exits 1.
+
+Explicit `--policy <file>` keeps the legacy fall-through for these three outcomes -- an opt-in pointer at a baseline file should not regress.
 
 Example -- consumer-side opt-in to fail-closed semantics in `apm.yml`:
 

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -219,7 +219,7 @@ policy:
 
 | Sub-key | Type | Default | Allowed values | Semantic |
 |---|---|---|---|---|
-| `fetch_failure_default` | `string` | `warn` | `warn`, `block` | Posture when no policy is reachable AND none is cached. `warn` keeps installs unblocked when GitHub is unreachable; `block` opts into fail-closed semantics. See [Network failure semantics](../../enterprise/policy-reference/#95-network-failure-semantics). |
+| `fetch_failure_default` | `string` | `warn` | `warn`, `block` | Posture when no enforceable policy is available -- covers fetch failures (`malformed`, `cache_miss_fetch_fail`, `garbage_response`) AND no-policy outcomes (`no_git_remote`, `absent`, `empty`). `warn` keeps installs unblocked when GitHub is unreachable or no org policy is published; `block` opts into fail-closed semantics for both `apm install` and `apm audit --ci`. See [Network failure semantics](../../enterprise/policy-reference/#95-network-failure-semantics). |
 | `hash` | `string` | unset | `<algo>:<hex-digest>` (e.g. `sha256:6a8c...e2f1`) | Pin on the raw bytes of the fetched leaf org policy. Verified before YAML parsing; mismatch is always fail-closed regardless of `fetch_failure_default`. See [Hash pin: `policy.hash`](../../enterprise/policy-reference/#96-hash-pin-policyhash-consumer-side-verification). |
 | `hash_algorithm` | `string` | `sha256` | `sha256`, `sha384`, `sha512` | Digest algorithm for `policy.hash`. Inferred from the `<algo>:` prefix when present; this field is the explicit override. MD5 and SHA-1 are rejected at parse time. |
 

--- a/packages/apm-guide/.apm/skills/apm-usage/governance.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/governance.md
@@ -304,11 +304,16 @@ atomic (temp file + rename).
   invocation; **do NOT block the install** by default (closes #829).
 - **Garbage response** (HTTP 200 with non-YAML body, e.g. captive portal):
   same posture as fetch failure -- warn loudly, cache fallback if present.
+- **No policy resolved (`no_git_remote` / `absent` / `empty`):** since
+  #1159, these emit a `[!]` warning to stderr and honour
+  `policy.fetch_failure_default: block` for parity with fetch failures.
+  Pre-fix they were silently fail-open even with `block` set.
 
 Opt in to fail-closed semantics with the `policy.fetch_failure: warn|block`
 knob on `apm-policy.yml` (applies when a cached policy is available) or
 `policy.fetch_failure_default: warn|block` in the project's `apm.yml`
-(applies when no policy is available at all). Both default to `warn`.
+(applies for fetch failures AND no-policy outcomes when no policy is
+available at all). Both default to `warn`.
 
 ### 9.6. Hash pin (`policy.hash`)
 
@@ -340,6 +345,14 @@ so it is safe for CI / SIEM ingestion. Supports `--policy-source` and
 When `--policy` (alias `--policy-source`) is omitted, `apm audit --ci`
 auto-discovers the org policy from the git remote, mirroring the install
 path. Use `--no-policy` to skip discovery for a single invocation.
+
+Since #1159, the no-policy outcomes (`no_git_remote`, `absent`, `empty`)
+emit a `[!]` warning to stderr by default and exit 1 with `[x]` when
+the project sets `policy.fetch_failure_default: block` -- pre-fix they
+silently exited 0, leaving CI green with no enforcement applied. JSON
+and SARIF output on stdout stays clean (all diagnostics on stderr).
+Explicit `--policy <file>` keeps the legacy fall-through (no warning)
+so opt-in pointers at minimal baseline files do not regress.
 
 ### 10. Errors and exit codes
 

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -596,6 +596,54 @@ run_e2e_tests() {
         exit 1
     fi
 
+    # Run #1159 audit silent-skip E2E -- offline, no tokens needed
+    # Defends the audit --ci CI gate against silent fall-through when
+    # auto-discovery hits no_git_remote / absent / empty / disabled
+    # outcomes. Real `git init`, real CliRunner. Covers exit codes,
+    # stderr cleanliness for both JSON and SARIF formats, and the
+    # policy.fetch_failure_default=block enforcement contract.
+    log_info "Running #1159 audit silent-skip E2E..."
+    echo "Command: pytest tests/integration/test_audit_silent_skip_e2e.py -v -s --tb=short"
+
+    if pytest tests/integration/test_audit_silent_skip_e2e.py -v -s --tb=short; then
+        log_success "#1159 audit silent-skip E2E passed!"
+    else
+        log_error "#1159 audit silent-skip E2E failed!"
+        exit 1
+    fi
+
+    # Run #1159 install silent-skip parity E2E -- offline, no tokens
+    # Defends the install pipeline parity for #1159: real `git init`
+    # with no remote configured + project policy.fetch_failure_default=block
+    # must raise PolicyViolationError through the policy_gate phase.
+    # Mirrors the audit-side block contract on the install codepath.
+    log_info "Running #1159 install silent-skip parity E2E..."
+    echo "Command: pytest tests/integration/test_install_silent_skip_e2e.py -v -s --tb=short"
+
+    if pytest tests/integration/test_install_silent_skip_e2e.py -v -s --tb=short; then
+        log_success "#1159 install silent-skip parity E2E passed!"
+    else
+        log_error "#1159 install silent-skip parity E2E failed!"
+        exit 1
+    fi
+
+    # Run #1159 SCP/EMU + ADO v3 SSH URL parsing E2E -- offline
+    # Defends the shared SCP_LIKE_RE regex against regressions on its
+    # three consumers: cache.url_normalize, policy.discovery, and
+    # models.dependency.reference. Real `git init` + real `git remote
+    # add origin` for EMU (enterprise-user@), GHE custom hosts, and
+    # ADO v3 SSH (git@ssh.dev.azure.com:v3/<org>/...). Also exercises
+    # APMPackage.from_apm_yml on the same URL forms.
+    log_info "Running #1159 dep URL parsing E2E..."
+    echo "Command: pytest tests/integration/test_dep_url_parsing_e2e.py -v -s --tb=short"
+
+    if pytest tests/integration/test_dep_url_parsing_e2e.py -v -s --tb=short; then
+        log_success "#1159 dep URL parsing E2E passed!"
+    else
+        log_error "#1159 dep URL parsing E2E failed!"
+        exit 1
+    fi
+
     log_success "All integration test suites completed successfully!"
     
 

--- a/src/apm_cli/cache/url_normalize.py
+++ b/src/apm_cli/cache/url_normalize.py
@@ -23,8 +23,11 @@ import hashlib
 import re
 import urllib.parse
 
-# SCP-like pattern: git@host:path (no scheme, colon separates host:path)
-_SCP_LIKE_RE = re.compile(
+# SCP-like pattern: <user>@host:path (no scheme, colon separates host:path).
+# Public symbol -- shared by `policy.discovery` and `models.dependency.reference`
+# so dependency parsing and remote-URL introspection can never drift on what
+# counts as an SCP-shorthand SSH URL (e.g. EMU users, Azure DevOps users).
+SCP_LIKE_RE = re.compile(
     r"^(?P<user>[a-zA-Z0-9_][a-zA-Z0-9_.+-]*)@"
     r"(?P<host>[^:/]+)"
     r":(?P<path>.+)$"
@@ -60,7 +63,7 @@ def normalize_repo_url(url: str) -> str:
     url = url.strip()
 
     # Step 2: Convert SCP-like to ssh:// form
-    scp_match = _SCP_LIKE_RE.match(url)
+    scp_match = SCP_LIKE_RE.match(url)
     if scp_match:
         user = scp_match.group("user")
         host = scp_match.group("host")

--- a/src/apm_cli/commands/audit.py
+++ b/src/apm_cli/commands/audit.py
@@ -492,8 +492,10 @@ def _audit_ci_gate(
                 err=True,
             )
             fetch_result = None
-        elif fetch_result.outcome in fetch_failure_outcomes or fetch_result.error or (
-            auto_discovered and fetch_result.outcome in no_policy_outcomes
+        elif (
+            fetch_result.outcome in fetch_failure_outcomes
+            or fetch_result.error
+            or (auto_discovered and fetch_result.outcome in no_policy_outcomes)
         ):
             project_default = read_project_fetch_failure_default(cfg.project_root)
             source = fetch_result.source

--- a/src/apm_cli/commands/audit.py
+++ b/src/apm_cli/commands/audit.py
@@ -53,6 +53,28 @@ class _AuditConfig:
 # -- Helpers --------------------------------------------------------
 
 
+def _audit_outcome_cause(outcome: str, source: str | None, err_text: str | None) -> str:
+    """Render a per-outcome `cause` line for audit --ci policy-discovery messages.
+
+    Used by both the ``warn`` (`[!]`) and ``block`` (`[x]`) branches so the
+    wording is identical; only the prefix and suffix change. Closes #1159
+    by replacing the prior silent-skip with explicit, actionable causes
+    for ``no_git_remote`` / ``absent`` / ``empty`` outcomes (and matching
+    the existing wording for fetch failures).
+    """
+    src = source or "unknown"
+    if outcome == "no_git_remote":
+        return "Could not determine org from git remote; org-policy enforcement skipped"
+    if outcome == "absent":
+        return f"No org policy found at {src}"
+    if outcome == "empty":
+        return f"Org policy at {src} is present but empty"
+    # malformed / cache_miss_fetch_fail / garbage_response (and any
+    # `error` set on the result): preserve the legacy wording so existing
+    # consumers parsing the line keep working.
+    return f"Policy fetch failed: {err_text or outcome}"
+
+
 def _scan_single_file(file_path: Path, logger) -> tuple[dict[str, list[ScanFinding]], int]:
     """Scan a single arbitrary file.
 
@@ -425,6 +447,7 @@ def _audit_ci_gate(
     )
 
     fetch_result = None
+    auto_discovered = False
     if policy_source and (not fail_fast or ci_result.passed):
         fetch_result = discover_policy(
             cfg.project_root,
@@ -434,29 +457,59 @@ def _audit_ci_gate(
     elif not policy_source and not no_policy and (not fail_fast or ci_result.passed):
         # Auto-discovery (mirror install path)
         fetch_result = discover_policy_with_chain(cfg.project_root)
-        # Treat outcomes that mean "no policy to enforce" as a no-op.
-        if fetch_result.outcome in ("absent", "no_git_remote", "empty", "disabled"):
-            fetch_result = None
+        auto_discovered = True
 
     if fetch_result is not None:
-        # Honour project-side fetch_failure_default when the org policy
-        # could not be fetched / parsed (closes #829). Default "warn"
-        # downgrades the previous unconditional sys.exit(1) into a log.
-        if fetch_result.error or (
-            fetch_result.outcome in ("malformed", "cache_miss_fetch_fail", "garbage_response")
+        # Honour project-side fetch_failure_default for outcomes that
+        # mean "no enforcement applied".  Pre-#1159, auto-discovery
+        # silently swallowed `absent` / `no_git_remote` / `empty` /
+        # `disabled` -- a fail-open governance bypass.  Now those
+        # outcomes are surfaced explicitly:
+        #
+        #   * malformed / cache_miss_fetch_fail / garbage_response
+        #     -> existing fetch-failure handling (warn unless block);
+        #     applies to BOTH explicit --policy and auto-discovery.
+        #   * absent / no_git_remote / empty   (auto-discovery only)
+        #     -> were silently dropped pre-#1159; now surfaced as
+        #        explicit warnings, and honour `block` for parity with
+        #        install.  Explicit --policy keeps the legacy fall-
+        #        through so an opt-in pointer at a baseline file does
+        #        not regress.
+        #   * disabled   (auto-discovery only)
+        #     -> emit a forensic `[i]` breadcrumb in --ci mode so
+        #        audit logs explain WHY no policy ran.
+        fetch_failure_outcomes = (
+            "malformed",
+            "cache_miss_fetch_fail",
+            "garbage_response",
+        )
+        no_policy_outcomes = ("absent", "no_git_remote", "empty")
+
+        if auto_discovered and fetch_result.outcome == "disabled":
+            click.echo(
+                "[i] Org-policy auto-discovery disabled by project apm.yml "
+                "(policy.discovery_enabled=false); no enforcement applied",
+                err=True,
+            )
+            fetch_result = None
+        elif fetch_result.outcome in fetch_failure_outcomes or fetch_result.error or (
+            auto_discovered and fetch_result.outcome in no_policy_outcomes
         ):
             project_default = read_project_fetch_failure_default(cfg.project_root)
+            source = fetch_result.source
             err_text = fetch_result.error or fetch_result.fetch_error or fetch_result.outcome
+            cause = _audit_outcome_cause(fetch_result.outcome, source, err_text)
             if project_default == "block":
-                logger.error(
-                    f"Policy fetch failed: {err_text} (policy.fetch_failure_default=block)"
+                click.echo(
+                    f"[x] {cause} (policy.fetch_failure_default=block)",
+                    err=True,
                 )
                 sys.exit(1)
             else:
-                logger.warning(
-                    f"Policy fetch failed: {err_text}; "
-                    "proceeding without policy checks "
-                    "(set policy.fetch_failure_default=block in apm.yml to fail closed)"
+                click.echo(
+                    f"[!] {cause}; enforcement skipped "
+                    "(set policy.fetch_failure_default=block in apm.yml to fail closed)",
+                    err=True,
                 )
                 fetch_result = None
 

--- a/src/apm_cli/commands/audit.py
+++ b/src/apm_cli/commands/audit.py
@@ -64,7 +64,7 @@ def _audit_outcome_cause(outcome: str, source: str | None, err_text: str | None)
     """
     src = source or "unknown"
     if outcome == "no_git_remote":
-        return "Could not determine org from git remote; org-policy enforcement skipped"
+        return "Could not determine org from git remote"
     if outcome == "absent":
         return f"No org policy found at {src}"
     if outcome == "empty":

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional  # noqa: F401, UP035
 
+from ...cache.url_normalize import SCP_LIKE_RE
 from ...utils.github_host import (
     default_host,
     is_artifactory_path,
@@ -675,10 +676,7 @@ class DependencyReference:
         Returns:
             ``(host, port, repo_url, reference, alias)`` or *None* if not an SCP URL.
         """
-        ssh_match = re.match(
-            r"^(?P<user>[a-zA-Z0-9_][a-zA-Z0-9_.+-]*)@(?P<host>[^:/]+):(?P<path>.+)$",
-            dependency_str,
-        )
+        ssh_match = SCP_LIKE_RE.match(dependency_str)
         if not ssh_match:
             return None
 

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -663,21 +663,28 @@ class DependencyReference:
 
     @staticmethod
     def _parse_ssh_url(dependency_str: str):
-        """Parse an SCP-shorthand SSH URL (``git@host:owner/repo``).
+        """Parse an SCP-shorthand SSH URL (``<user>@host:owner/repo``).
 
-        SCP shorthand cannot carry a port (``:`` is the path separator), so the
-        returned port is always ``None``. For custom SSH ports, use the
-        ``ssh://`` URL form which is handled by ``_parse_ssh_protocol_url``.
+        Accepts any SSH username (not just ``git``), so EMU and custom GHE
+        SSH accounts (e.g. ``enterprise-user@ghe.corp.com:org/repo``) parse
+        correctly. SCP shorthand cannot carry a port (``:`` is the path
+        separator), so the returned port is always ``None``. For custom SSH
+        ports, use the ``ssh://`` URL form which is handled by
+        ``_parse_ssh_protocol_url``.
 
         Returns:
             ``(host, port, repo_url, reference, alias)`` or *None* if not an SCP URL.
         """
-        ssh_match = re.match(r"^git@([^:]+):(.+)$", dependency_str)
+        ssh_match = re.match(
+            r"^(?P<user>[a-zA-Z0-9_][a-zA-Z0-9_.+-]*)@(?P<host>[^:/]+):(?P<path>.+)$",
+            dependency_str,
+        )
         if not ssh_match:
             return None
 
-        host = ssh_match.group(1)
-        ssh_repo_part = ssh_match.group(2)
+        user = ssh_match.group("user")
+        host = ssh_match.group("host")
+        ssh_repo_part = ssh_match.group("path")
 
         reference = None
         alias = None
@@ -712,19 +719,19 @@ class DependencyReference:
                     git_suffix = ".git" if had_git_suffix else ""
                     ref_suffix = f"#{reference}" if reference else ""
                     alias_suffix = f"@{alias}" if alias else ""
-                    suggested = f"ssh://git@{host}:{port_candidate}/{remaining_path}{git_suffix}{ref_suffix}{alias_suffix}"
+                    suggested = f"ssh://{user}@{host}:{port_candidate}/{remaining_path}{git_suffix}{ref_suffix}{alias_suffix}"
                     raise ValueError(
-                        f"It looks like '{first_segment}' in 'git@{host}:{repo_url}' "
-                        f"is a port number, but SCP-style URLs (git@host:path) cannot "
+                        f"It looks like '{first_segment}' in '{user}@{host}:{repo_url}' "
+                        f"is a port number, but SCP-style URLs (<user>@host:path) cannot "
                         f"carry a port. Use the ssh:// URL form instead:\n"
                         f"  {suggested}"
                     )
                 else:
                     raise ValueError(
-                        f"It looks like '{first_segment}' in 'git@{host}:{first_segment}' "
+                        f"It looks like '{first_segment}' in '{user}@{host}:{first_segment}' "
                         f"is a port number, but no repository path follows it. "
-                        f"SCP-style URLs (git@host:path) cannot carry a port. "
-                        f"Use the ssh:// URL form: ssh://git@{host}:{port_candidate}/<owner>/<repo>.git"
+                        f"SCP-style URLs (<user>@host:path) cannot carry a port. "
+                        f"Use the ssh:// URL form: ssh://{user}@{host}:{port_candidate}/<owner>/<repo>.git"
                     )
 
         # Security: reject traversal sequences in SSH repo paths

--- a/src/apm_cli/policy/discovery.py
+++ b/src/apm_cli/policy/discovery.py
@@ -33,6 +33,7 @@ from urllib.parse import urlparse
 import requests
 import yaml
 
+from ..cache.url_normalize import _SCP_LIKE_RE
 from ..utils.path_security import PathTraversalError, ensure_path_within
 from .parser import PolicyValidationError, load_policy
 from .project_config import (
@@ -663,22 +664,35 @@ def _extract_org_from_git_remote(
 def _parse_remote_url(url: str) -> tuple[str, str] | None:
     """Parse a git remote URL into (org, host).
 
+    Accepts SCP-style SSH URLs with any username (not just ``git@``), so
+    EMU/GHE deployments that use a non-``git`` SSH user
+    (e.g. ``enterprise-user@ghe.corp.com:org/repo.git``) parse correctly.
+    Also handles Azure DevOps SSH URLs which carry an extra ``v3/``
+    path prefix (``git@ssh.dev.azure.com:v3/<org>/<project>/<repo>``).
+
     Returns None if URL can't be parsed.
     """
     if not url:
         return None
 
-    # SSH: git@github.com:owner/repo.git
-    if url.startswith("git@"):
+    # SCP-like SSH: <user>@<host>:<path> -- any user, not just `git`.
+    # Closes #1159 for non-`git` SSH users (EMU, custom GHE accounts).
+    scp_match = _SCP_LIKE_RE.match(url)
+    if scp_match:
+        host = scp_match.group("host")
+        path_part = scp_match.group("path")
         try:
-            host_part, path_part = url.split(":", 1)
-            host = host_part.replace("git@", "")
             parts = path_part.rstrip("/").removesuffix(".git").split("/")
-            if parts and parts[0]:
-                return (parts[0], host)
+            parts = [p for p in parts if p]
+            if not parts:
+                return None
+            # Azure DevOps SSH carries a leading 'v3/' segment that is
+            # NOT the org. The org is the second segment.
+            if host == "ssh.dev.azure.com" and parts[0] == "v3" and len(parts) >= 2:
+                return (parts[1], host)
+            return (parts[0], host)
         except (ValueError, IndexError):
             return None
-        return None
 
     # HTTPS: https://github.com/owner/repo.git
     # ADO:   https://dev.azure.com/org/project/_git/repo

--- a/src/apm_cli/policy/discovery.py
+++ b/src/apm_cli/policy/discovery.py
@@ -33,7 +33,7 @@ from urllib.parse import urlparse
 import requests
 import yaml
 
-from ..cache.url_normalize import _SCP_LIKE_RE
+from ..cache.url_normalize import SCP_LIKE_RE
 from ..utils.path_security import PathTraversalError, ensure_path_within
 from .parser import PolicyValidationError, load_policy
 from .project_config import (
@@ -677,7 +677,7 @@ def _parse_remote_url(url: str) -> tuple[str, str] | None:
 
     # SCP-like SSH: <user>@<host>:<path> -- any user, not just `git`.
     # Closes #1159 for non-`git` SSH users (EMU, custom GHE accounts).
-    scp_match = _SCP_LIKE_RE.match(url)
+    scp_match = SCP_LIKE_RE.match(url)
     if scp_match:
         host = scp_match.group("host")
         path_part = scp_match.group("path")

--- a/src/apm_cli/policy/outcome_routing.py
+++ b/src/apm_cli/policy/outcome_routing.py
@@ -33,14 +33,21 @@ if TYPE_CHECKING:  # pragma: no cover - type-checking only
     from apm_cli.policy.schema import ApmPolicy
 
 
-# Fetch-failure outcomes that honour the project-side
-# ``policy.fetch_failure_default`` knob.  ``absent`` / ``no_git_remote``
-# / ``empty`` are NOT failures -- they mean "no org policy" and are
-# always fail-open.
+# Outcomes that honour the project-side ``policy.fetch_failure_default``
+# knob.  Pre-#1159, ``absent`` / ``no_git_remote`` / ``empty`` were
+# excluded here -- they meant "no org policy" and were always fail-open
+# even when the project explicitly opted in to ``block``.  That was an
+# install-path silent-skip (governance bypass) symmetrical to the audit
+# bug fixed in the same PR.  They now route through the ``block``
+# branch so a project that asserts "no policy = no install" gets that
+# guarantee on BOTH install and audit paths.
 _FETCH_FAILURE_OUTCOMES = (
     "malformed",
     "cache_miss_fetch_fail",
     "garbage_response",
+    "no_git_remote",
+    "absent",
+    "empty",
 )
 
 
@@ -134,7 +141,7 @@ def route_discovery_outcome(
             and fetch_failure_default == "block"
         ):
             raise PolicyViolationError(
-                "Install blocked: org policy could not be fetched / parsed "
+                "Install blocked: no enforceable org policy was resolved "
                 f"(outcome={outcome}) and project apm.yml has "
                 "policy.fetch_failure_default=block "
                 f"(source={source or 'unknown'})",

--- a/src/apm_cli/policy/outcome_routing.py
+++ b/src/apm_cli/policy/outcome_routing.py
@@ -34,14 +34,16 @@ if TYPE_CHECKING:  # pragma: no cover - type-checking only
 
 
 # Outcomes that honour the project-side ``policy.fetch_failure_default``
-# knob.  Pre-#1159, ``absent`` / ``no_git_remote`` / ``empty`` were
-# excluded here -- they meant "no org policy" and were always fail-open
+# knob.  Despite the historical name "fetch failure", this set ALSO
+# includes the no-policy outcomes ``no_git_remote`` / ``absent`` /
+# ``empty`` -- pre-#1159 those were excluded and were always fail-open
 # even when the project explicitly opted in to ``block``.  That was an
 # install-path silent-skip (governance bypass) symmetrical to the audit
-# bug fixed in the same PR.  They now route through the ``block``
-# branch so a project that asserts "no policy = no install" gets that
-# guarantee on BOTH install and audit paths.
-_FETCH_FAILURE_OUTCOMES = (
+# bug fixed in the same PR.  Membership rule: an outcome belongs here
+# iff a project that asserts ``policy.fetch_failure_default: block``
+# expects "no enforceable policy" to fail closed for that outcome on
+# BOTH install and audit paths.
+_OUTCOMES_HONORING_FETCH_FAILURE_DEFAULT = (
     "malformed",
     "cache_miss_fetch_fail",
     "garbage_response",
@@ -81,7 +83,7 @@ def route_discovery_outcome(
     fetch_failure_default:
         Project-side ``policy.fetch_failure_default``; one of
         ``"warn"`` (default) or ``"block"``.  Only consulted for
-        outcomes in :data:`_FETCH_FAILURE_OUTCOMES`.
+        outcomes in :data:`_OUTCOMES_HONORING_FETCH_FAILURE_DEFAULT`.
     raise_blocking_errors:
         When ``True`` (default), raise :class:`PolicyViolationError` for
         outcomes that demand fail-closed behaviour (hash mismatch,
@@ -137,7 +139,7 @@ def route_discovery_outcome(
             )
         if (
             raise_blocking_errors
-            and outcome in _FETCH_FAILURE_OUTCOMES
+            and outcome in _OUTCOMES_HONORING_FETCH_FAILURE_DEFAULT
             and fetch_failure_default == "block"
         ):
             raise PolicyViolationError(

--- a/tests/integration/test_audit_silent_skip_e2e.py
+++ b/tests/integration/test_audit_silent_skip_e2e.py
@@ -146,3 +146,54 @@ class TestAuditCiNoGitDirE2E:
         assert result.exit_code == 0
         assert "[!]" in result.stderr
         assert "Could not determine org from git remote" in result.stderr
+
+
+class TestAuditCiNoGitRemoteSarifE2E:
+    """SARIF stdout cleanliness on no_git_remote -- TC-2 from #1164 review.
+
+    Mirrors the JSON cleanliness probe in
+    ``TestAuditCiNoGitRemoteE2E.test_default_warn_emits_stderr_and_exits_zero``
+    but with ``-f sarif``.  The new ``[!]`` warning MUST land on stderr
+    so the SARIF document on stdout stays valid for GitHub Code Scanning
+    upload (``codeql/upload-sarif``).
+    """
+
+    def test_warn_emits_clean_sarif_on_stdout(self, runner, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        _git_init(tmp_path)
+        _setup_clean_project(tmp_path)
+
+        result = runner.invoke(
+            audit,
+            ["--ci", "--no-drift", "-f", "sarif"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        assert "[!]" in result.stderr
+        assert "Could not determine org from git remote" in result.stderr
+        # SARIF on stdout must be parseable end-to-end.
+        sarif = json.loads(result.stdout)
+        assert sarif.get("$schema", "").endswith("sarif-schema-2.1.0.json") or (
+            sarif.get("version") == "2.1.0"
+        )
+        assert "runs" in sarif
+        assert isinstance(sarif["runs"], list)
+
+    def test_block_emits_clean_stderr_on_sarif_format(self, runner, tmp_path, monkeypatch):
+        """Block path with -f sarif: [x] on stderr, exit 1, no stdout pollution."""
+        monkeypatch.chdir(tmp_path)
+        _git_init(tmp_path)
+        _setup_clean_project(tmp_path, fetch_failure_default="block")
+
+        result = runner.invoke(
+            audit,
+            ["--ci", "--no-drift", "-f", "sarif"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 1
+        assert "[x]" in result.stderr
+        assert "policy.fetch_failure_default=block" in result.stderr
+        # Block path exits before SARIF is rendered, so stdout must be empty.
+        assert result.stdout.strip() == ""

--- a/tests/integration/test_audit_silent_skip_e2e.py
+++ b/tests/integration/test_audit_silent_skip_e2e.py
@@ -1,0 +1,148 @@
+"""End-to-end tests for #1159 audit silent-skip fix using real ``git init``.
+
+Unit tests in ``tests/unit/test_audit_ci_auto_discovery.py`` mock
+``discover_policy_with_chain``. These tests exercise the real
+discovery path with a real git working tree, so the wiring between
+``git remote`` introspection, ``discover_policy_with_chain`` and the
+audit CLI is end-to-end verified (no mocks on the discovery layer).
+
+The "no_git_remote" outcome is the canonical CI scenario for #1159:
+``apm audit --ci`` running in a checkout that does not expose an
+``origin`` remote (e.g. shallow CI clones, ephemeral worktrees, or
+projects pulled via tarball) silently passed pre-fix even when the
+project apm.yml asked for fail-closed.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from apm_cli.commands.audit import audit
+from apm_cli.models.apm_package import clear_apm_yml_cache
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_apm_yml_cache()
+    yield
+    clear_apm_yml_cache()
+
+
+def _git_init(path: Path) -> None:
+    """Initialise a real git repo with no remote configured."""
+    subprocess.run(
+        ["git", "init", "--quiet"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _setup_clean_project(project: Path, *, fetch_failure_default: str | None = None) -> None:
+    apm_yml_lines = [
+        "name: test-project",
+        "version: '1.0.0'",
+        "dependencies:",
+        "  apm:",
+        "    - owner/repo#v1.0.0",
+    ]
+    if fetch_failure_default is not None:
+        apm_yml_lines += [
+            "policy:",
+            f"  fetch_failure_default: {fetch_failure_default}",
+        ]
+    (project / "apm.yml").write_text("\n".join(apm_yml_lines) + "\n", encoding="utf-8")
+    lockfile = textwrap.dedent("""\
+        lockfile_version: '1'
+        generated_at: '2025-01-01T00:00:00Z'
+        dependencies:
+          - repo_url: owner/repo
+            resolved_ref: v1.0.0
+            deployed_files:
+              - .github/prompts/test.md
+    """)
+    (project / "apm.lock.yaml").write_text(lockfile, encoding="utf-8")
+    prompts_dir = project / ".github" / "prompts"
+    prompts_dir.mkdir(parents=True)
+    (prompts_dir / "test.md").write_text("Clean content\n", encoding="utf-8")
+
+
+class TestAuditCiNoGitRemoteE2E:
+    """Real ``git init`` without a remote -> outcome=no_git_remote."""
+
+    def test_default_warn_emits_stderr_and_exits_zero(self, runner, tmp_path, monkeypatch):
+        """Default warn: [!] on stderr; clean JSON on stdout; exit 0."""
+        monkeypatch.chdir(tmp_path)
+        _git_init(tmp_path)
+        _setup_clean_project(tmp_path)
+
+        result = runner.invoke(
+            audit,
+            ["--ci", "--no-drift", "-f", "json"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        assert "[!]" in result.stderr
+        assert "Could not determine org from git remote" in result.stderr
+        # JSON on stdout must remain parseable end-to-end.
+        data = json.loads(result.stdout)
+        assert "summary" in data
+
+    def test_block_fails_closed_with_exit_one(self, runner, tmp_path, monkeypatch):
+        """policy.fetch_failure_default=block: [x] + exit 1."""
+        monkeypatch.chdir(tmp_path)
+        _git_init(tmp_path)
+        _setup_clean_project(tmp_path, fetch_failure_default="block")
+
+        result = runner.invoke(
+            audit,
+            ["--ci", "--no-drift", "-f", "json"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 1
+        assert "[x]" in result.stderr
+        assert "policy.fetch_failure_default=block" in result.stderr
+
+
+class TestAuditCiNoGitDirE2E:
+    """No git directory at all -> outcome=no_git_remote (same surface)."""
+
+    def test_warn_when_not_a_git_repo(self, runner, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        # No git init -- bare directory.
+        _setup_clean_project(tmp_path)
+
+        result = runner.invoke(
+            audit,
+            ["--ci", "--no-drift", "-f", "json"],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        assert "[!]" in result.stderr
+        assert "Could not determine org from git remote" in result.stderr

--- a/tests/integration/test_dep_url_parsing_e2e.py
+++ b/tests/integration/test_dep_url_parsing_e2e.py
@@ -1,0 +1,228 @@
+"""End-to-end tests for #1159 SCP/EMU + ADO v3 SSH URL parsing.
+
+The shared regex ``SCP_LIKE_RE`` (``cache/url_normalize.py``) is
+consumed by THREE call sites in the codebase:
+
+  1. ``cache/url_normalize.py`` itself (lockfile normalization)
+  2. ``policy/discovery.py::_parse_remote_url`` (audit / install
+     auto-discovery)
+  3. ``models/dependency/reference.py::DependencyReference._parse_ssh_url``
+     (dependency parsing in apm.yml)
+
+Unit tests (``tests/unit/cache/test_url_normalize.py``,
+``tests/unit/policy/test_discovery.py``,
+``tests/unit/test_canonicalization.py``) verify each consumer
+independently, but no end-to-end test exercises the regex through the
+full ``apm audit`` / ``apm install`` codepath with a real ``git
+remote`` configured to an EMU or ADO v3 SSH URL.
+
+These tests close that gap: they stand up a real git working tree,
+configure a real ``origin`` remote with the URL form being defended,
+and run the auto-discovery codepath end-to-end (mocking only the
+network fetch so the test is hermetic).  A regression that bypasses
+``SCP_LIKE_RE`` on any of the three consumers would surface as the
+pre-#1159 silent fall-through (``no_git_remote`` outcome) instead of
+the expected ``(org, host)`` extraction.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from apm_cli.models.apm_package import APMPackage, clear_apm_yml_cache
+from apm_cli.policy.discovery import (
+    PolicyFetchResult,
+    _extract_org_from_git_remote,
+    discover_policy_with_chain,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_apm_yml_cache()
+    yield
+    clear_apm_yml_cache()
+
+
+def _git_init_with_remote(path: Path, remote_url: str) -> None:
+    """Initialise a real git repo with a configured origin remote."""
+    subprocess.run(
+        ["git", "init", "--quiet"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "remote", "add", "origin", remote_url],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _write_minimal_apm_yml(project: Path, deps: list[str] | None = None) -> Path:
+    apm_yml = project / "apm.yml"
+    body = "name: test-project\nversion: '1.0.0'\n"
+    if deps:
+        body += "dependencies:\n  apm:\n" + "".join(f"    - {d}\n" for d in deps)
+    apm_yml.write_text(body, encoding="utf-8")
+    return apm_yml
+
+
+class TestExtractOrgFromRealGitRemote:
+    """Auto-discovery org extraction across SCP/EMU + ADO v3 SSH forms.
+
+    Pre-#1159: any SSH URL with a non-``git`` user (EMU,
+    ``enterprise-user@ghe.corp.com:org/repo``) silently failed the
+    SCP regex and returned ``None`` from
+    ``_extract_org_from_git_remote``, which then surfaced as the
+    silent ``no_git_remote`` fall-through.
+
+    This test runs the REAL ``git remote get-url origin`` codepath
+    against a REAL git working tree to prove the shared
+    ``SCP_LIKE_RE`` is reachable end-to-end.
+    """
+
+    def test_emu_ssh_user_extracts_org(self, tmp_path):
+        _git_init_with_remote(tmp_path, "enterprise-user@github.com:contoso/my-project.git")
+        result = _extract_org_from_git_remote(tmp_path)
+        assert result == ("contoso", "github.com")
+
+    def test_emu_on_ghe_host_extracts_org_and_host(self, tmp_path):
+        _git_init_with_remote(tmp_path, "enterprise-user@ghe.corp.com:contoso/my-project.git")
+        result = _extract_org_from_git_remote(tmp_path)
+        assert result == ("contoso", "ghe.corp.com")
+
+    def test_legacy_git_user_still_extracts_org(self, tmp_path):
+        """Regression guard: the SCP regex change must not break ``git@``."""
+        _git_init_with_remote(tmp_path, "git@github.com:contoso/my-project.git")
+        result = _extract_org_from_git_remote(tmp_path)
+        assert result == ("contoso", "github.com")
+
+    def test_ado_v3_ssh_extracts_org_not_v3(self, tmp_path):
+        """ADO SSH form: the ``v3`` segment MUST NOT be parsed as the org."""
+        _git_init_with_remote(
+            tmp_path,
+            "git@ssh.dev.azure.com:v3/myorg/myproject/myrepo",
+        )
+        result = _extract_org_from_git_remote(tmp_path)
+        # Pre-fix returned ("v3", "ssh.dev.azure.com") -- silent
+        # mis-attribution. Post-fix returns the real org.
+        assert result == ("myorg", "ssh.dev.azure.com")
+
+
+class TestDiscoverPolicyWithChainEMUEndToEnd:
+    """Full auto-discovery pipeline with EMU SSH remote.
+
+    Mocks only the inner ``_fetch_from_repo`` so the test is
+    hermetic, but exercises the real ``git remote`` introspection
+    + URL parse + repo-ref construction. A regression in any of the
+    three SCP-regex consumers would cause discovery to short-circuit
+    before reaching the fetch.
+    """
+
+    def test_emu_ssh_remote_routes_to_correct_org_policy_repo(self, tmp_path):
+        _git_init_with_remote(tmp_path, "enterprise-user@github.com:contoso/some-app.git")
+        _write_minimal_apm_yml(tmp_path)
+
+        sentinel = PolicyFetchResult(outcome="absent", source="org:contoso/.github")
+
+        with patch(
+            "apm_cli.policy.discovery._fetch_from_repo", return_value=sentinel
+        ) as mock_fetch:
+            result = discover_policy_with_chain(tmp_path)
+
+        # Discovery reached _fetch_from_repo (proves SCP_LIKE_RE
+        # matched and org was extracted) and routed to contoso/.github.
+        assert mock_fetch.call_count >= 1
+        first_call_repo_ref = mock_fetch.call_args_list[0].args[0]
+        assert first_call_repo_ref == "contoso/.github"
+        assert result is sentinel
+
+    def test_ado_v3_ssh_remote_routes_to_correct_org_policy_repo(self, tmp_path):
+        _git_init_with_remote(
+            tmp_path,
+            "git@ssh.dev.azure.com:v3/realorg/myproject/myrepo",
+        )
+        _write_minimal_apm_yml(tmp_path)
+
+        sentinel = PolicyFetchResult(outcome="absent")
+
+        with patch(
+            "apm_cli.policy.discovery._fetch_from_repo", return_value=sentinel
+        ) as mock_fetch:
+            result = discover_policy_with_chain(tmp_path)
+
+        # Pre-fix the repo_ref would have been constructed from
+        # org="v3" -- a silent mis-routing.  Post-fix the real org
+        # ``realorg`` is used.
+        assert mock_fetch.call_count >= 1
+        first_call_repo_ref = mock_fetch.call_args_list[0].args[0]
+        # ADO host attaches a host prefix when host != github.com.
+        assert "realorg/.github" in first_call_repo_ref
+        assert "v3/.github" not in first_call_repo_ref
+        assert result is sentinel
+
+
+class TestDependencyReferenceParsesEMUAndAdoSsh:
+    """Defends the SCP regex on the dependency-parse codepath
+    (``DependencyReference._parse_ssh_url``).
+
+    Pre-#1159 the inline regex in ``models/dependency/reference.py``
+    accepted only ``git@`` users.  Post-fix it uses the shared
+    ``SCP_LIKE_RE`` from ``cache/url_normalize.py``.
+
+    These tests parse through the real ``APMPackage.from_apm_yml``
+    entry point (the same codepath ``apm install`` follows) to
+    catch any future regression that bypasses the shared regex.
+    """
+
+    def test_emu_user_in_apm_yml_parses_through_real_package_loader(self, tmp_path):
+        apm_yml = _write_minimal_apm_yml(
+            tmp_path, deps=["enterprise-user@github.com:contoso/my-pkg"]
+        )
+        pkg = APMPackage.from_apm_yml(apm_yml)
+        deps = pkg.get_apm_dependencies()
+        assert len(deps) == 1
+        dep = deps[0]
+        # Pre-fix this dep would have been rejected by _parse_ssh_url
+        # and fallen through to the string fallback path.
+        assert dep.host == "github.com"
+        assert dep.repo_url == "contoso/my-pkg"
+
+    def test_ghe_emu_user_in_apm_yml_parses_through_real_package_loader(self, tmp_path):
+        apm_yml = _write_minimal_apm_yml(
+            tmp_path, deps=["enterprise-user@ghe.corp.com:contoso/my-pkg"]
+        )
+        pkg = APMPackage.from_apm_yml(apm_yml)
+        deps = pkg.get_apm_dependencies()
+        assert len(deps) == 1
+        dep = deps[0]
+        assert dep.host == "ghe.corp.com"
+        assert dep.repo_url == "contoso/my-pkg"
+
+    def test_legacy_git_user_in_apm_yml_still_parses(self, tmp_path):
+        """Regression guard: ``git@`` SCP form must still parse cleanly."""
+        apm_yml = _write_minimal_apm_yml(tmp_path, deps=["git@github.com:contoso/my-pkg"])
+        pkg = APMPackage.from_apm_yml(apm_yml)
+        deps = pkg.get_apm_dependencies()
+        assert len(deps) == 1
+        dep = deps[0]
+        assert dep.host == "github.com"
+        assert dep.repo_url == "contoso/my-pkg"

--- a/tests/integration/test_install_silent_skip_e2e.py
+++ b/tests/integration/test_install_silent_skip_e2e.py
@@ -1,0 +1,179 @@
+"""End-to-end tests for #1159 install-side silent-skip fix.
+
+The audit-side counterpart lives in ``test_audit_silent_skip_e2e.py``;
+this file defends the install pipeline parity.  The previous
+integration coverage in ``test_policy_install_e2e.py::TestI17NoGitRemote``
+mocks ``discover_policy_with_chain`` at both
+``policy.discovery`` and ``policy.install_preflight`` import sites.
+That mocking proves the routing constant but does NOT exercise the
+real ``git remote get-url origin`` -> ``no_git_remote`` outcome wiring
+that #1159 fixes.  These tests run a real ``git init`` (no remote
+configured) so:
+
+  * the ``git remote`` introspection in ``_extract_org_from_git_remote``
+    runs for real,
+  * ``discover_policy_with_chain`` returns
+    ``PolicyFetchResult(outcome="no_git_remote")`` end-to-end, and
+  * the ``policy.fetch_failure_default=block`` knob in the project
+    ``apm.yml`` raises ``PolicyViolationError`` through the
+    ``policy_gate`` pipeline phase (the install-side mirror of the
+    audit ``[x] ... policy.fetch_failure_default=block`` contract).
+
+Note on pipeline ordering: in ``apm install`` the resolve phase
+(which constructs the downloader and downloads packages) runs BEFORE
+``policy_gate``. The block contract is therefore "non-zero exit with
+the verbatim ``policy.fetch_failure_default=block`` message," not
+"downloader was never called". The audit-side test asserts the
+stronger pre-fetch contract because audit's order is reversed
+(discovery -> gate -> render).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import textwrap
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from apm_cli.models.apm_package import clear_apm_yml_cache
+
+# Mock targets -- bypass network/registry but let policy discovery run real.
+_PATCH_UPDATES = "apm_cli.commands._helpers.check_for_updates"
+_PATCH_VALIDATE_PKG = "apm_cli.commands.install._validate_package_exists"
+_PATCH_DOWNLOADER = "apm_cli.deps.github_downloader.GitHubPackageDownloader"
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_apm_yml_cache()
+    yield
+    clear_apm_yml_cache()
+
+
+def _git_init_no_remote(path: Path) -> None:
+    """Initialise a real git repo with no remote configured."""
+    subprocess.run(
+        ["git", "init", "--quiet"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=path,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _write_block_project(project: Path) -> None:
+    """Write apm.yml with a fetch_failure_default=block knob."""
+    (project / "apm.yml").write_text(
+        textwrap.dedent("""\
+            name: test-project
+            version: '1.0.0'
+            dependencies:
+              apm:
+                - owner/repo#v1.0.0
+            policy:
+              fetch_failure_default: block
+        """),
+        encoding="utf-8",
+    )
+    (project / ".github").mkdir(exist_ok=True)
+
+
+class TestInstallNoGitRemoteBlockE2E:
+    """Real ``git init`` (no remote) + fetch_failure_default=block.
+
+    Pre-#1159 this combination silently proceeded with no enforcement.
+    Post-fix it must raise ``PolicyViolationError`` and exit non-zero
+    BEFORE any download attempt -- proving the routing reaches both
+    the install_preflight and the policy_gate codepaths.
+    """
+
+    def test_block_raises_after_discovery_with_no_remote(self, runner, tmp_path, monkeypatch):
+        """Real ``git init`` (no remote) + project ``fetch_failure_default=block``
+        must raise ``PolicyViolationError`` from the policy_gate phase
+        and exit non-zero. The error message contract is the verbatim
+        ``policy.fetch_failure_default=block`` token.
+        """
+        from apm_cli.cli import cli
+
+        monkeypatch.chdir(tmp_path)
+        _git_init_no_remote(tmp_path)
+        _write_block_project(tmp_path)
+
+        with (
+            patch(_PATCH_UPDATES, return_value=None),
+            patch(_PATCH_VALIDATE_PKG, return_value=True),
+            patch(_PATCH_DOWNLOADER) as mock_dl,
+        ):
+            # Make the downloader a no-op success so resolve phase
+            # completes and we reach policy_gate.  The contract under
+            # test is the policy_gate behaviour, not download timing.
+            mock_dl.return_value.download_package.return_value = None
+            result = runner.invoke(cli, ["install"], catch_exceptions=False)
+
+        assert result.exit_code != 0, (
+            f"Expected non-zero exit; got 0.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        combined = (result.stdout or "") + (result.stderr or "")
+        assert "policy.fetch_failure_default=block" in combined, (
+            f"Expected fetch-failure block message in output:\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+    def test_default_warn_proceeds_without_remote(self, runner, tmp_path, monkeypatch):
+        """No fetch_failure_default knob -> warn-and-proceed (legacy default)."""
+        from apm_cli.cli import cli
+
+        monkeypatch.chdir(tmp_path)
+        _git_init_no_remote(tmp_path)
+        # Same project but WITHOUT the block knob -- exercises the warn
+        # default for symmetry with the block test above.
+        (tmp_path / "apm.yml").write_text(
+            textwrap.dedent("""\
+                name: test-project
+                version: '1.0.0'
+                dependencies:
+                  apm:
+                    - owner/repo#v1.0.0
+            """),
+            encoding="utf-8",
+        )
+        (tmp_path / ".github").mkdir(exist_ok=True)
+
+        with (
+            patch(_PATCH_UPDATES, return_value=None),
+            patch(_PATCH_VALIDATE_PKG, return_value=True),
+            patch(_PATCH_DOWNLOADER) as mock_dl,
+        ):
+            # Make download a no-op success so we exit cleanly past the
+            # policy gate.
+            mock_dl.return_value.download_package.side_effect = Exception("downloader bypass")
+            result = runner.invoke(cli, ["install"], catch_exceptions=False)
+
+        # Warn path: install MAY fail at download time (we forced an
+        # exception on the mocked downloader), but the failure must NOT
+        # be a fetch_failure_default=block PolicyViolationError --
+        # discovery must proceed past the no_git_remote outcome.
+        combined = (result.stdout or "") + (result.stderr or "")
+        assert "policy.fetch_failure_default=block" not in combined, (
+            f"Default warn must not raise the block error:\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )

--- a/tests/unit/policy/test_discovery.py
+++ b/tests/unit/policy/test_discovery.py
@@ -94,6 +94,36 @@ class TestParseRemoteUrl(unittest.TestCase):
         result = _parse_remote_url("https://github.com/")
         self.assertIsNone(result)
 
+    # --- Regression: #1159 SCP non-`git` user (EMU / GHE) ---
+
+    def test_scp_emu_enterprise_user(self):
+        """SCP-like SSH with non-`git` user (EMU/GHE) must parse, not return None."""
+        result = _parse_remote_url("enterprise-user@ghe.corp.com:contoso/my-project.git")
+        self.assertEqual(result, ("contoso", "ghe.corp.com"))
+
+    def test_scp_custom_user(self):
+        """SCP-like SSH with arbitrary username parses correctly."""
+        result = _parse_remote_url("alice@github.example.com:org/repo.git")
+        self.assertEqual(result, ("org", "github.example.com"))
+
+    def test_scp_user_with_dot_dash(self):
+        """SCP usernames may include `.` `-` `_` `+` -- still parse."""
+        result = _parse_remote_url("first.last-1@github.com:contoso/repo.git")
+        self.assertEqual(result, ("contoso", "github.com"))
+
+    def test_ado_ssh_v3_prefix(self):
+        """Azure DevOps SSH URLs carry a `v3/` segment that is NOT the org."""
+        result = _parse_remote_url(
+            "git@ssh.dev.azure.com:v3/myorg/myproject/myrepo"
+        )
+        self.assertEqual(result, ("myorg", "ssh.dev.azure.com"))
+
+    def test_ado_ssh_v3_prefix_with_git_suffix(self):
+        result = _parse_remote_url(
+            "git@ssh.dev.azure.com:v3/myorg/myproject/myrepo.git"
+        )
+        self.assertEqual(result, ("myorg", "ssh.dev.azure.com"))
+
 
 class TestExtractOrgFromGitRemote(unittest.TestCase):
     """Test _extract_org_from_git_remote with mocked subprocess."""

--- a/tests/unit/policy/test_discovery.py
+++ b/tests/unit/policy/test_discovery.py
@@ -113,15 +113,11 @@ class TestParseRemoteUrl(unittest.TestCase):
 
     def test_ado_ssh_v3_prefix(self):
         """Azure DevOps SSH URLs carry a `v3/` segment that is NOT the org."""
-        result = _parse_remote_url(
-            "git@ssh.dev.azure.com:v3/myorg/myproject/myrepo"
-        )
+        result = _parse_remote_url("git@ssh.dev.azure.com:v3/myorg/myproject/myrepo")
         self.assertEqual(result, ("myorg", "ssh.dev.azure.com"))
 
     def test_ado_ssh_v3_prefix_with_git_suffix(self):
-        result = _parse_remote_url(
-            "git@ssh.dev.azure.com:v3/myorg/myproject/myrepo.git"
-        )
+        result = _parse_remote_url("git@ssh.dev.azure.com:v3/myorg/myproject/myrepo.git")
         self.assertEqual(result, ("myorg", "ssh.dev.azure.com"))
 
 

--- a/tests/unit/policy/test_fetch_failure_knob.py
+++ b/tests/unit/policy/test_fetch_failure_knob.py
@@ -195,22 +195,49 @@ class TestPolicyGateFailClosed:
         ctx.logger.policy_discovery_miss.assert_called_once()
 
     @patch(_PATCH_DISCOVER)
-    def test_absent_block_does_not_raise(self, mock_discover):
-        """absent / no_git_remote / empty are NOT fetch failures."""
+    def test_absent_block_raises(self, mock_discover):
+        """#1159 install parity: absent/no_git_remote/empty now honour block."""
         mock_discover.return_value = _fetch("absent", source="org:foo/.github")
         ctx = _FakeCtx(
             logger=MagicMock(),
             policy_fetch_failure_default="block",
         )
-        run(ctx)  # Must not raise
-        assert ctx.policy_enforcement_active is False
+        with pytest.raises(PolicyViolationError) as excinfo:
+            run(ctx)
+        assert "no enforceable org policy" in str(excinfo.value)
+        assert "outcome=absent" in str(excinfo.value)
 
     @patch(_PATCH_DISCOVER)
-    def test_no_git_remote_block_does_not_raise(self, mock_discover):
+    def test_no_git_remote_block_raises(self, mock_discover):
+        """#1159 install parity: no_git_remote now honours block."""
         mock_discover.return_value = _fetch("no_git_remote", source="")
         ctx = _FakeCtx(
             logger=MagicMock(),
             policy_fetch_failure_default="block",
+        )
+        with pytest.raises(PolicyViolationError) as excinfo:
+            run(ctx)
+        assert "outcome=no_git_remote" in str(excinfo.value)
+
+    @patch(_PATCH_DISCOVER)
+    def test_empty_block_raises(self, mock_discover):
+        """#1159 install parity: empty now honours block."""
+        mock_discover.return_value = _fetch("empty", source="org:foo/.github")
+        ctx = _FakeCtx(
+            logger=MagicMock(),
+            policy_fetch_failure_default="block",
+        )
+        with pytest.raises(PolicyViolationError) as excinfo:
+            run(ctx)
+        assert "outcome=empty" in str(excinfo.value)
+
+    @patch(_PATCH_DISCOVER)
+    def test_absent_warn_does_not_raise(self, mock_discover):
+        """Default warn keeps fail-open for no-policy outcomes."""
+        mock_discover.return_value = _fetch("absent", source="org:foo/.github")
+        ctx = _FakeCtx(
+            logger=MagicMock(),
+            policy_fetch_failure_default="warn",
         )
         run(ctx)
         assert ctx.policy_enforcement_active is False

--- a/tests/unit/test_audit_ci_auto_discovery.py
+++ b/tests/unit/test_audit_ci_auto_discovery.py
@@ -186,3 +186,93 @@ class TestAutoDiscoveryFetchFailure:
             result = runner.invoke(audit, ["--ci", "--no-drift"])
 
         assert result.exit_code == 1, result.output
+
+
+# -- #1159: silent-skip fix for no-policy outcomes -------------------
+#
+# Pre-#1159, ``--ci`` auto-discovery silently swallowed
+# ``no_git_remote`` / ``absent`` / ``empty`` / ``disabled`` (set
+# ``fetch_result = None`` with no log line). The fix surfaces those
+# outcomes via stderr warnings and honors ``policy.fetch_failure_default``
+# for parity with the install path.
+
+
+def _make_no_policy_outcome(outcome: str) -> PolicyFetchResult:
+    return PolicyFetchResult(
+        policy=None,
+        source="https://example.invalid",
+        outcome=outcome,
+    )
+
+
+class TestNoPolicyOutcomesWarn:
+    """Auto-discovery returns no-policy outcome; default warn -> stderr line, exit 0."""
+
+    @pytest.mark.parametrize(
+        ("outcome", "needle"),
+        [
+            ("no_git_remote", "Could not determine org from git remote"),
+            ("absent", "No org policy found at"),
+            ("empty", "is present but empty"),
+        ],
+    )
+    @patch("apm_cli.policy.discovery.discover_policy_with_chain")
+    def test_warn_to_stderr_and_proceeds(
+        self, mock_discover, runner, tmp_path, outcome, needle
+    ):
+        _setup_project_with_unmanaged_file(tmp_path)
+        mock_discover.return_value = _make_no_policy_outcome(outcome)
+
+        with patch("apm_cli.commands.audit.Path.cwd", return_value=tmp_path):
+            result = runner.invoke(
+                audit, ["--ci", "--no-drift", "-f", "json"]
+            )
+
+        assert result.exit_code == 0, result.output
+        assert needle in result.stderr
+        assert "[!]" in result.stderr
+        assert "fetch_failure_default=block" in result.stderr
+        # JSON on stdout must remain parseable.
+        import json as _json
+
+        _json.loads(result.stdout)
+
+
+class TestNoPolicyOutcomesBlock:
+    """policy.fetch_failure_default=block -> [x] + exit 1 for no-policy outcomes."""
+
+    @pytest.mark.parametrize(
+        "outcome", ["no_git_remote", "absent", "empty"]
+    )
+    @patch("apm_cli.policy.discovery.discover_policy_with_chain")
+    def test_block_exits_one(self, mock_discover, runner, tmp_path, outcome):
+        _setup_project_with_unmanaged_file(tmp_path)
+        # Opt-in to fail closed.
+        apm_yml = (tmp_path / "apm.yml").read_text() + (
+            "policy:\n  fetch_failure_default: block\n"
+        )
+        (tmp_path / "apm.yml").write_text(apm_yml, encoding="utf-8")
+        mock_discover.return_value = _make_no_policy_outcome(outcome)
+
+        with patch("apm_cli.commands.audit.Path.cwd", return_value=tmp_path):
+            result = runner.invoke(audit, ["--ci", "--no-drift"])
+
+        assert result.exit_code == 1, result.output
+        assert "[x]" in result.stderr
+        assert "policy.fetch_failure_default=block" in result.stderr
+
+
+class TestDisabledOutcome:
+    """outcome=disabled emits forensic [i] breadcrumb on stderr; exit 0."""
+
+    @patch("apm_cli.policy.discovery.discover_policy_with_chain")
+    def test_disabled_emits_info(self, mock_discover, runner, tmp_path):
+        _setup_project_with_unmanaged_file(tmp_path)
+        mock_discover.return_value = _make_no_policy_outcome("disabled")
+
+        with patch("apm_cli.commands.audit.Path.cwd", return_value=tmp_path):
+            result = runner.invoke(audit, ["--ci", "--no-drift"])
+
+        assert result.exit_code == 0, result.output
+        assert "[i]" in result.stderr
+        assert "auto-discovery disabled" in result.stderr

--- a/tests/unit/test_audit_ci_auto_discovery.py
+++ b/tests/unit/test_audit_ci_auto_discovery.py
@@ -217,16 +217,12 @@ class TestNoPolicyOutcomesWarn:
         ],
     )
     @patch("apm_cli.policy.discovery.discover_policy_with_chain")
-    def test_warn_to_stderr_and_proceeds(
-        self, mock_discover, runner, tmp_path, outcome, needle
-    ):
+    def test_warn_to_stderr_and_proceeds(self, mock_discover, runner, tmp_path, outcome, needle):
         _setup_project_with_unmanaged_file(tmp_path)
         mock_discover.return_value = _make_no_policy_outcome(outcome)
 
         with patch("apm_cli.commands.audit.Path.cwd", return_value=tmp_path):
-            result = runner.invoke(
-                audit, ["--ci", "--no-drift", "-f", "json"]
-            )
+            result = runner.invoke(audit, ["--ci", "--no-drift", "-f", "json"])
 
         assert result.exit_code == 0, result.output
         assert needle in result.stderr
@@ -241,16 +237,12 @@ class TestNoPolicyOutcomesWarn:
 class TestNoPolicyOutcomesBlock:
     """policy.fetch_failure_default=block -> [x] + exit 1 for no-policy outcomes."""
 
-    @pytest.mark.parametrize(
-        "outcome", ["no_git_remote", "absent", "empty"]
-    )
+    @pytest.mark.parametrize("outcome", ["no_git_remote", "absent", "empty"])
     @patch("apm_cli.policy.discovery.discover_policy_with_chain")
     def test_block_exits_one(self, mock_discover, runner, tmp_path, outcome):
         _setup_project_with_unmanaged_file(tmp_path)
         # Opt-in to fail closed.
-        apm_yml = (tmp_path / "apm.yml").read_text() + (
-            "policy:\n  fetch_failure_default: block\n"
-        )
+        apm_yml = (tmp_path / "apm.yml").read_text() + ("policy:\n  fetch_failure_default: block\n")
         (tmp_path / "apm.yml").write_text(apm_yml, encoding="utf-8")
         mock_discover.return_value = _make_no_policy_outcome(outcome)
 

--- a/tests/unit/test_audit_ci_command.py
+++ b/tests/unit/test_audit_ci_command.py
@@ -136,7 +136,7 @@ class TestCIOutputFormats:
         with patch("apm_cli.commands.audit.Path.cwd", return_value=tmp_path):
             result = runner.invoke(audit, ["--ci", "--no-drift", "-f", "json"])
         assert result.exit_code == 0
-        data = json.loads(result.output)
+        data = json.loads(result.stdout)
         assert "passed" in data
         assert "checks" in data
         assert "summary" in data
@@ -147,7 +147,7 @@ class TestCIOutputFormats:
         with patch("apm_cli.commands.audit.Path.cwd", return_value=tmp_path):
             result = runner.invoke(audit, ["--ci", "--no-drift", "-f", "sarif"])
         assert result.exit_code == 0
-        data = json.loads(result.output)
+        data = json.loads(result.stdout)
         assert data["version"] == "2.1.0"
         assert "runs" in data
 

--- a/tests/unit/test_audit_policy_command.py
+++ b/tests/unit/test_audit_policy_command.py
@@ -240,6 +240,9 @@ class TestCiWithoutPolicy:
             catch_exceptions=False,
         )
         assert result.exit_code == 0
-        data = json.loads(result.output)
+        # Auto-discovery emits a [!] warning to stderr when no git remote is
+        # found; JSON is on stdout. Read stdout explicitly so the warning does
+        # not corrupt JSON parsing.
+        data = json.loads(result.stdout)
         # Only baseline checks (max 8 incl. skill-subset + includes-consent)
         assert data["summary"]["total"] <= 8

--- a/tests/unit/test_generic_git_urls.py
+++ b/tests/unit/test_generic_git_urls.py
@@ -131,6 +131,24 @@ class TestGitLabSSH:
         assert dep.host == "gitlab.company.internal"
         assert dep.repo_url == "team/rules"
 
+    # --- Regression: #1159 -- SCP shorthand must accept any user, not just `git` ---
+
+    def test_scp_emu_enterprise_user(self):
+        """EMU/GHE SSH URLs use a non-`git` user (e.g. enterprise-user@)."""
+        dep = DependencyReference.parse(
+            "enterprise-user@ghe.corp.com:contoso/rules.git"
+        )
+        assert dep.host == "ghe.corp.com"
+        assert dep.repo_url == "contoso/rules"
+
+    def test_scp_custom_user_with_ref(self):
+        dep = DependencyReference.parse(
+            "alice@gitlab.company.internal:team/rules.git#main"
+        )
+        assert dep.host == "gitlab.company.internal"
+        assert dep.repo_url == "team/rules"
+        assert dep.reference == "main"
+
     def test_self_hosted_ssh_protocol(self):
         dep = DependencyReference.parse("ssh://git@gitlab.company.internal/team/rules.git")
         assert dep.host == "gitlab.company.internal"

--- a/tests/unit/test_generic_git_urls.py
+++ b/tests/unit/test_generic_git_urls.py
@@ -135,16 +135,12 @@ class TestGitLabSSH:
 
     def test_scp_emu_enterprise_user(self):
         """EMU/GHE SSH URLs use a non-`git` user (e.g. enterprise-user@)."""
-        dep = DependencyReference.parse(
-            "enterprise-user@ghe.corp.com:contoso/rules.git"
-        )
+        dep = DependencyReference.parse("enterprise-user@ghe.corp.com:contoso/rules.git")
         assert dep.host == "ghe.corp.com"
         assert dep.repo_url == "contoso/rules"
 
     def test_scp_custom_user_with_ref(self):
-        dep = DependencyReference.parse(
-            "alice@gitlab.company.internal:team/rules.git#main"
-        )
+        dep = DependencyReference.parse("alice@gitlab.company.internal:team/rules.git#main")
         assert dep.host == "gitlab.company.internal"
         assert dep.repo_url == "team/rules"
         assert dep.reference == "main"


### PR DESCRIPTION
## TL;DR

Closes #1159. Fixes a silent governance bypass in `apm audit --ci` plus a sibling SCP/ADO SSH URL parsing bug that produced the same class of failure on the install path. Adds install-path parity so `policy.fetch_failure_default: block` actually fails closed for the three no-policy outcomes (`no_git_remote`, `absent`, `empty`) on BOTH install and audit. Documents the new contract on five doc surfaces.

## Problem (WHY)

#1159 reports two interlocking bugs:

1. **`apm audit --ci` silently passed (exit 0, no log line) when auto-discovery resolved no enforceable policy** -- specifically the `no_git_remote` (no `origin`), `absent` (no `apm-policy.yml` at the org), and `empty` (file present but empty) outcomes. CI stayed green even when no enforcement ran. `policy.fetch_failure_default: block` did NOT block these on the install path either -- only `malformed` / `cache_miss_fetch_fail` / `garbage_response` honoured the knob.
2. **SCP-shorthand SSH URLs from non-`git` users failed to parse**, dropping `<user>@github.com:owner/repo` (EMU) and `<user>@ssh.dev.azure.com:v3/<org>/<project>/<repo>` (Azure DevOps) on the floor. Auto-discovery then fell through to `no_git_remote` -- which (per #1) was silent. So an enterprise / ADO user got NO policy enforcement and NO warning.

The two together meant: an EMU/ADO project with `policy.fetch_failure_default: block` set, expecting fail-closed CI gating, would ship green with zero enforcement. That is the silent-bypass class the issue calls out.

## Approach (WHAT)

Five phases, each its own commit:

1. **Fix SCP / ADO URL parsing at the source.** Share one `_SCP_LIKE_RE` between `models/dependency/reference.py` and `policy/discovery.py` so EMU and ADO patterns parse on both code paths. Unwrap ADO `v3/<org>` to the real org.
2. **Stop silent-skip in `apm audit --ci`.** For the three no-policy outcomes (`no_git_remote`, `absent`, `empty`) emit a `[!]` warning to stderr by default; honour `policy.fetch_failure_default: block` to fail closed (`[x]` + exit 1). Emit a forensic `[i]` line for `disabled` (auto-discovery turned off) so it's visible in CI logs. All diagnostics on stderr -- JSON / SARIF on stdout stays clean.
3. **Install-path parity.** Extend `_FETCH_FAILURE_OUTCOMES` in `policy/outcome_routing.py` from 3 to 6 outcomes. `policy.fetch_failure_default: block` now means what it says on BOTH `apm install` and `apm audit --ci`. Reword `PolicyViolationError` to "no enforceable org policy was resolved" (honest about scope -- covers both fetch failure and absent/empty).
4. **e2e integration tests with real `git init`.** No mocks on the discovery layer -- spawns a temp dir, runs `git init`, asserts on real CLI behavior.
5. **Documentation.** Five surfaces: manifest schema, policy reference (new section 9.5.1), governance guide (failure-semantics table + offline matrix), apm-guide skill, CHANGELOG.

## Implementation (HOW)

| Layer | Change |
|---|---|
| `src/apm_cli/policy/discovery.py` | `_parse_remote_url` uses shared `_SCP_LIKE_RE`; ADO `v3/<org>` unwrapped |
| `src/apm_cli/models/dependency/reference.py` | `_parse_ssh_url` uses shared `_SCP_LIKE_RE`; error messages cite captured user |
| `src/apm_cli/commands/audit.py` | `_audit_outcome_cause()` helper; `auto_discovered` flag; per-outcome `click.echo(..., err=True)` (NOT logger -- logger routes to stdout via Rich Console and corrupts JSON) |
| `src/apm_cli/policy/outcome_routing.py` | `_FETCH_FAILURE_OUTCOMES` extended `(malformed, cache_miss_fetch_fail, garbage_response, no_git_remote, absent, empty)`; consumed by both `install/phases/policy_gate.py` and `policy/install_preflight.py` via single dispatch |

**Explicit `--policy <file>` opt-out:** the new no-policy warnings only fire when `auto_discovered=True`. An explicit pointer at a minimal/empty baseline file does not regress.

**ASCII-only:** `[!]` warn, `[x]` error, `[i]` info -- per the repo's encoding contract.

**Click 8.2.1 stderr/stdout split:** `result.stdout` / `result.stderr` are now distinct (`mix_stderr` removed). Tests parsing JSON updated from `result.output` to `result.stdout` to avoid stderr contamination.

## Trade-offs

- **install-parity is in this PR, not a follow-up.** Per CEO arbitration on the apm-review-panel pass: the audit-only fix would have left the install half of the "block means block" promise broken, which was the original silent bypass. Bundling them is the smallest correct change.
- **Legacy fetch-failure paths in audit still use `logger` (which routes to stdout).** Latent JSON-corruption bug for `malformed`/`cache_miss_fetch_fail`/`garbage_response`. Out of scope here -- confined fix to the new code paths to limit blast radius. Tracked as a follow-up.
- **No `--require-policy` flag yet** (noted in the issue). Deferred to a follow-up so this PR stays focused on the bypass.

## Validation evidence

- Lint (CI mirror): `uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/` -- silent.
- Targeted: 61 tests across `test_audit_silent_skip_e2e.py` (3 new e2e), `test_audit_ci_auto_discovery.py` (13: 6 pre-existing + 7 new), `test_audit_ci_command.py`, `test_audit_policy_command.py`, `test_fetch_failure_knob.py` (4 -- 2 flipped from regression-trap, 2 new). All pass.
- Full unit sweep (7699 tests) ran clean during phase 3.

## How to test manually

```bash
# Bug repro: no remote, fetch_failure_default=block, expect FAIL CLOSED
mkdir /tmp/apm-1159 && cd /tmp/apm-1159
git init
cat > apm.yml <<YAML
name: test
version: '1.0'
policy:
  fetch_failure_default: block
YAML
apm audit --ci
# Pre-fix: exit 0, no output  -- silent bypass
# Post-fix: [x] on stderr, exit 1
```

Refs #1159
