### PR TITLE
refactor(tests): marker-driven integration discovery (PR1 of #1166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `apm marketplace browse/search/add/update` route through the registry proxy when `PROXY_REGISTRY_URL` is set; `PROXY_REGISTRY_ONLY=1` blocks direct GitHub and GitLab host API fallbacks. (#1149)
 - Registry proxy now warns when `PROXY_REGISTRY_TOKEN` is set and `PROXY_REGISTRY_URL` uses `http://`, since the bearer token would be transmitted in plaintext; set `PROXY_REGISTRY_ALLOW_HTTP=1` to silence the warning for trusted internal proxies. (#1149)
+- Integration tests now use marker-driven discovery: 21 `pytestmark = pytest.mark.skipif(...)` chains across `tests/integration/` are replaced with declarative `requires_*` markers, with precondition logic centralized in `tests/integration/conftest.py` and auto-skipping at collection time. PR1 of #1166. (#1167)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `apm marketplace browse/search/add/update` route through the registry proxy when `PROXY_REGISTRY_URL` is set; `PROXY_REGISTRY_ONLY=1` blocks direct GitHub and GitLab host API fallbacks. (#1149)
 - Registry proxy now warns when `PROXY_REGISTRY_TOKEN` is set and `PROXY_REGISTRY_URL` uses `http://`, since the bearer token would be transmitted in plaintext; set `PROXY_REGISTRY_ALLOW_HTTP=1` to silence the warning for trusted internal proxies. (#1149)
 - Integration tests now use marker-driven discovery: 21 `pytestmark = pytest.mark.skipif(...)` chains across `tests/integration/` are replaced with declarative `requires_*` markers, with precondition logic centralized in `tests/integration/conftest.py` and auto-skipping at collection time. PR1 of #1166. (#1167)
+- Integration test apm-binary resolution now prefers the local build (`./dist/apm-<os>-<arch>/apm`) over a system-wide `apm` on `PATH`, so contributors validating the binary under test are not silently shadowed by a global install; the bearer-token marker (`requires_ado_bearer`) discards the captured JWT immediately and persists only the boolean outcome. (#1167)
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,6 +214,35 @@ pip install -e .[dev]
 pytest tests/unit tests/test_console.py -x
 ```
 
+### Running integration tests
+
+Integration tests under `tests/integration/` use a marker-driven
+discovery system: each test declares the precondition it needs
+(token, runtime, opt-in flag, ...) as a `pytest.mark.requires_*`
+marker, and `tests/integration/conftest.py` auto-skips at collection
+time when the precondition is missing. Without any setup,
+`uv run pytest tests/integration` is silent rather than red -- every
+test reports as `SKIPPED` with a one-line reason, so you can see
+exactly what is missing.
+
+The full marker reference (one row per `_MARKER_CHECKS` entry, with
+the env-var or `apm runtime setup` command that satisfies it) lives
+in
+[Integration Testing](docs/src/content/docs/contributing/integration-testing.md#the-marker-registry).
+A typical local run looks like:
+
+```bash
+# Run only what your current env satisfies
+uv run pytest tests/integration -v
+
+# Run only one marker family (e.g. tests that need a GitHub token)
+uv run pytest tests/integration -m requires_github_token -v
+```
+
+When adding a new precondition, add an entry to `_MARKER_CHECKS` and
+declare the marker in `pyproject.toml`; that is the only place the
+precondition needs to live.
+
 ## Coding Style
 
 This project follows:

--- a/docs/src/content/docs/contributing/integration-testing.md
+++ b/docs/src/content/docs/contributing/integration-testing.md
@@ -35,54 +35,77 @@ APM uses a tiered approach to integration testing:
 
 ## Running Tests Locally
 
-### Smoke Tests
-```bash
-# Run all smoke tests
-pytest tests/integration/test_runtime_smoke.py -v
+Integration tests live under `tests/integration/` and run via `pytest`
+directly. Each test module declares the preconditions it needs as
+standard pytest markers; the registry in
+`tests/integration/conftest.py` (`_MARKER_CHECKS`) automatically skips
+tests whose precondition is not met, so you only have to install/set
+what the test family you want actually requires.
 
-# Run specific test
-pytest tests/integration/test_runtime_smoke.py::TestRuntimeSmoke::test_codex_runtime_setup -v
+### The marker registry
+
+| Marker | Precondition | How to satisfy it |
+| --- | --- | --- |
+| `requires_e2e_mode` | Opt-in for the heavyweight golden-scenario suite | `export APM_E2E_TESTS=1` |
+| `requires_network_integration` | Opt-in for tests that hit live registries | `export APM_RUN_INTEGRATION_TESTS=1` |
+| `requires_inference` | Opt-in for tests that call inference APIs | `export APM_RUN_INFERENCE_TESTS=1` |
+| `requires_github_token` | A token usable against `github.com` / GitHub Models | `export GITHUB_APM_PAT=...` (or `GITHUB_TOKEN`) |
+| `requires_ado_pat` | Azure DevOps PAT for ADO host tests | `export ADO_APM_PAT=...` |
+| `requires_ado_bearer` | Azure CLI signed in + opt-in flag | `az login` and `export APM_TEST_ADO_BEARER=1` |
+| `requires_apm_binary` | A built `apm` binary on disk or `PATH` | `scripts/build-binary.sh` (or set `APM_BINARY_PATH`) |
+| `requires_runtime_codex` | The `codex` runtime installed under `~/.apm/runtimes/` | `apm runtime setup codex` |
+| `requires_runtime_copilot` | The GitHub Copilot CLI runtime installed under `~/.apm/runtimes/` | `apm runtime setup copilot` |
+| `requires_runtime_llm` | The `llm` runtime installed under `~/.apm/runtimes/` | `apm runtime setup llm` |
+
+Without any of those env vars or runtimes a `pytest tests/integration`
+invocation is silent rather than red: every test is collected and
+reported as `SKIPPED` with a one-line reason, so you can see exactly
+what is missing and why.
+
+### Common invocations
+
+```bash
+# Run everything you currently have the prerequisites for
+uv run pytest tests/integration -v
+
+# Run a single suite (the marker registry still applies)
+uv run pytest tests/integration/test_golden_scenario_e2e.py -v
+
+# Run only a marker family
+uv run pytest tests/integration -m requires_github_token -v
 ```
 
-### E2E Tests
+### Apm binary resolution
 
-#### Option 1: Complete CI Process Simulation (Recommended)
-```bash
-export GITHUB_TOKEN=your_token_here
-./scripts/test-integration.sh
-```
+Tests that need to shell out to a real `apm` binary use the
+`apm_binary_path` fixture and the `requires_apm_binary` marker. The
+binary is resolved in this order, so a local build is preferred over a
+system install:
 
-This script (`scripts/test-integration.sh`) is a unified script that automatically adapts to your environment:
+1. `APM_BINARY_PATH` env var
+2. `./dist/apm-<os>-<arch>/apm` (the layout produced by `scripts/build-binary.sh`)
+3. `shutil.which("apm")`
 
-**Local mode** (no existing binary):
-1. **Builds binary** with PyInstaller (like CI build job)
-2. **Sets up symlink and PATH** (like CI artifacts download)
-3. **Installs runtimes** (codex/llm setup)
-4. **Installs test dependencies** (like CI test setup)
-5. **Runs integration tests** with the built binary (like CI integration-tests job)
+### Adding an integration test that needs a precondition
 
-**CI mode** (binary exists in `./dist/`):
-1. **Uses existing binary** from CI build artifacts
-2. **Sets up symlink and PATH** (standard CI process)
-3. **Installs runtimes** (codex/llm setup)
-4. **Installs test dependencies** (like CI test setup)  
-5. **Runs E2E tests** with pre-built binary
+1. Apply the marker at module or test level:
+   ```python
+   import pytest
+   pytestmark = pytest.mark.requires_github_token
+   ```
+2. If you need a brand-new precondition, add an entry to
+   `_MARKER_CHECKS` in `tests/integration/conftest.py` (predicate +
+   skip reason) and declare the marker in `pyproject.toml`. That is
+   the only place the precondition needs to live.
 
-#### Option 2: Direct pytest execution
-```bash
-# Set up environment
-export APM_E2E_TESTS=1
-export GITHUB_TOKEN=your_github_token_here
-export GITHUB_MODELS_KEY=your_github_token_here  # LLM runtime expects this specific env var
+### Legacy: `scripts/test-integration.sh`
 
-# Run E2E tests
-pytest tests/integration/test_golden_scenario_e2e.py -v -s
-
-# Run specific E2E test
-pytest tests/integration/test_golden_scenario_e2e.py::TestGoldenScenarioE2E::test_complete_golden_scenario_codex -v -s
-```
-
-**Note**: Both `GITHUB_TOKEN` and `GITHUB_MODELS_KEY` should contain the same GitHub token value, but different runtimes expect different environment variable names.
+`scripts/test-integration.sh` is the legacy wrapper that built a
+binary, set up runtimes, and shelled out to pytest. It is being
+retired (see `microsoft/apm#1166`); prefer the direct `pytest`
+invocations above. The script is still wired into CI for the moment
+and continues to work, but new test plumbing belongs in the marker
+registry, not in the bash script.
 
 ## CI/CD Integration
 
@@ -207,14 +230,24 @@ All integration tests run on:
 ## Adding New Tests
 
 ### For New Runtime Support:
-1. Add smoke test for runtime setup
-2. Add E2E test for golden scenario with new runtime
-3. Update CI matrix if new platform support
+1. Add a smoke test for runtime setup, marked
+   `@pytest.mark.requires_runtime_<name>` (and add the marker entry to
+   `_MARKER_CHECKS` in `tests/integration/conftest.py` if the runtime
+   is brand new).
+2. Add an E2E test for the golden scenario with the new runtime,
+   marked `@pytest.mark.requires_e2e_mode` and any token markers it
+   needs.
+3. Update the CI matrix if the runtime introduces new platform
+   support.
 
 ### For New Features:
-1. Add smoke test for compilation/validation
-2. Add E2E test if feature requires API calls
-3. Keep tests focused and fast
+1. Add a smoke test for compilation/validation.
+2. Add an E2E test if the feature requires API calls -- pick the
+   smallest set of markers that captures its real preconditions
+   (`requires_github_token`, `requires_network_integration`, etc.)
+   so contributors without those credentials still get a clean
+   `SKIPPED` rather than a hard failure.
+3. Keep tests focused and fast.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,5 +134,15 @@ markers = [
     "live: marks tests that hit real GitHub repos (requires network + optional GITHUB_TOKEN)",
     "slow: marks tests as slow running tests",
     "benchmark: marks performance benchmark tests (deselected by default, run with -m benchmark)",
+    "requires_e2e_mode: requires APM_E2E_TESTS=1",
+    "requires_github_token: requires GITHUB_APM_PAT or GITHUB_TOKEN",
+    "requires_ado_pat: requires ADO_APM_PAT",
+    "requires_ado_bearer: requires az CLI logged in + APM_TEST_ADO_BEARER=1",
+    "requires_network_integration: requires APM_RUN_INTEGRATION_TESTS=1",
+    "requires_apm_binary: requires built apm binary on PATH (or APM_BINARY_PATH)",
+    "requires_runtime_codex: requires codex runtime installed",
+    "requires_runtime_copilot: requires GitHub Copilot CLI runtime installed",
+    "requires_runtime_llm: requires llm runtime installed",
+    "requires_inference: requires APM_RUN_INFERENCE_TESTS=1 + model API access",
 ]
 

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 # Integration testing script for both CI and local environments
+#
+# DEPRECATED (PR2 of #1166): This script is being retired in favour of
+# direct ``pytest tests/integration/`` invocations gated by the
+# marker-driven discovery system introduced in PR1
+# (microsoft/apm#1167). Once PR2 lands the canonical commands will be
+# documented in CONTRIBUTING.md and
+# docs/src/content/docs/contributing/integration-testing.md. Avoid
+# adding new logic here -- new test plumbing belongs in
+# ``tests/integration/conftest.py`` ``_MARKER_CHECKS``.
+#
 # Tests comprehensive runtime scenarios and edge cases:
 #   - Both Codex AND LLM runtime setup and interoperability
 #   - Complex pytest-based scenarios with error handling

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,9 +16,11 @@ See microsoft/apm#1166 for the design rationale.
 from __future__ import annotations
 
 import os
+import platform as _platform
 import shutil
 import subprocess
 from collections.abc import Callable
+from functools import lru_cache
 from pathlib import Path
 
 import pytest
@@ -77,9 +79,64 @@ def _has_ado_bearer() -> bool:
             timeout=30,
             check=False,
         )
-        return result.returncode == 0 and result.stdout.startswith("eyJ")
+        # Discard the bearer token immediately; persist only the boolean
+        # outcome. Keeping the JWT in `result.stdout` would let it survive
+        # in a fixture/closure (or surface in pytest capture on failure).
+        ok = result.returncode == 0 and result.stdout.strip().startswith("eyJ")
+        del result
+        return ok
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return False
+
+
+def _local_dist_apm_binary() -> Path | None:
+    """Return ``./dist/apm-<os>-<arch>/apm`` if it exists, else None.
+
+    Encapsulates the local-build naming convention used by
+    ``scripts/build-binary.sh`` so both the marker predicate and the
+    session fixture share one source of truth.
+    """
+    os_name = _platform.system().lower()
+    arch = _platform.machine().lower()
+    arch_map = {
+        "x86_64": "x86_64",
+        "amd64": "x86_64",
+        "arm64": "arm64",
+        "aarch64": "arm64",
+    }
+    binary_name = f"apm-{os_name}-{arch_map.get(arch, arch)}"
+    candidate = Path("dist") / binary_name / "apm"
+    return candidate if candidate.is_file() else None
+
+
+@lru_cache(maxsize=1)
+def _resolve_apm_binary() -> Path | None:
+    """Resolve the apm binary used by integration tests.
+
+    Resolution order (prefers the build under test over a system install):
+      1. ``APM_BINARY_PATH`` env var (CI sets this after the build step).
+      2. ``./dist/<platform>/apm`` (local build convention).
+      3. ``shutil.which("apm")`` lookup on ``PATH``.
+
+    The order intentionally pushes ``PATH`` last so that a globally
+    installed ``apm`` does not silently shadow the local build a
+    contributor is trying to validate.
+    """
+    env_path = os.environ.get("APM_BINARY_PATH")
+    if env_path:
+        candidate = Path(env_path)
+        if candidate.is_file():
+            return candidate.resolve()
+
+    local = _local_dist_apm_binary()
+    if local is not None:
+        return local.resolve()
+
+    on_path = shutil.which("apm")
+    if on_path:
+        return Path(on_path).resolve()
+
+    return None
 
 
 def _is_e2e_mode() -> bool:
@@ -95,9 +152,7 @@ def _is_inference_mode() -> bool:
 
 
 def _has_apm_binary() -> bool:
-    if os.environ.get("APM_BINARY_PATH"):
-        return Path(os.environ["APM_BINARY_PATH"]).is_file()
-    return shutil.which("apm") is not None
+    return _resolve_apm_binary() is not None
 
 
 def _has_runtime(name: str) -> bool:
@@ -162,38 +217,14 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
 def apm_binary_path() -> Path:
     """Resolve the apm binary path for tests that need to shell out to it.
 
-    Resolution order:
-      1. ``APM_BINARY_PATH`` env var (CI sets this after the build step).
-      2. ``shutil.which("apm")`` lookup on ``PATH``.
-      3. ``./dist/<platform>/apm`` (local build convention).
-
-    Skips the test if no binary is found, with a message pointing at the
-    build script.
+    Delegates to :func:`_resolve_apm_binary` so the marker predicate
+    (collection-time skip decision) and the fixture (test-time path
+    handed to subprocess) cannot drift. See the helper docstring for
+    the full resolution order.
     """
-    env_path = os.environ.get("APM_BINARY_PATH")
-    if env_path:
-        candidate = Path(env_path)
-        if candidate.is_file():
-            return candidate.resolve()
-
-    on_path = shutil.which("apm")
-    if on_path:
-        return Path(on_path).resolve()
-
-    import platform as plat
-
-    os_name = plat.system().lower()
-    arch = plat.machine().lower()
-    arch_map = {
-        "x86_64": "x86_64",
-        "amd64": "x86_64",
-        "arm64": "arm64",
-        "aarch64": "arm64",
-    }
-    binary_name = f"apm-{os_name}-{arch_map.get(arch, arch)}"
-    local_path = Path("dist") / binary_name / "apm"
-    if local_path.is_file():
-        return local_path.resolve()
+    resolved = _resolve_apm_binary()
+    if resolved is not None:
+        return resolved
 
     pytest.skip("No apm binary found (set APM_BINARY_PATH or build via scripts/build-binary.sh)")
     raise RuntimeError("unreachable")  # for type-checker

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,14 +1,27 @@
-"""Shared fixtures and helpers for integration tests.
+"""Integration test configuration: marker-driven skip + shared fixtures.
 
-Migrating tests should call ``make_copilot_project`` instead of the
-legacy ``(project / ".github").mkdir()`` pattern. Under #1154 the bare
-``.github/`` directory is no longer a copilot signal -- the file
+This conftest replaces the manual per-file ``pytest.mark.skipif`` boilerplate
+with declarative markers that auto-skip when the required precondition is
+absent. Tests apply markers via module-level ``pytestmark`` or per-test
+decorators; the precondition logic lives here, exactly once.
+
+It also exposes ``make_copilot_project`` for tests that need a project
+directory whose target auto-detection resolves to ``copilot``. Under #1154
+the bare ``.github/`` directory is no longer a copilot signal -- the file
 ``.github/copilot-instructions.md`` is required.
+
+See microsoft/apm#1166 for the design rationale.
 """
 
 from __future__ import annotations
 
+import os
+import shutil
+import subprocess
+from collections.abc import Callable
 from pathlib import Path
+
+import pytest
 
 
 def make_copilot_project(tmp_path: Path, name: str = "test-project") -> Path:
@@ -30,3 +43,157 @@ def make_copilot_project(tmp_path: Path, name: str = "test-project") -> Path:
     github_dir.mkdir()
     (github_dir / "copilot-instructions.md").write_bytes(b"# Copilot instructions\n")
     return project
+
+
+def _has_github_token() -> bool:
+    return bool(os.environ.get("GITHUB_APM_PAT") or os.environ.get("GITHUB_TOKEN"))
+
+
+def _has_ado_pat() -> bool:
+    return bool(os.environ.get("ADO_APM_PAT"))
+
+
+def _has_ado_bearer() -> bool:
+    if os.getenv("APM_TEST_ADO_BEARER") != "1":
+        return False
+    az_bin = shutil.which("az")
+    if az_bin is None:
+        return False
+    try:
+        result = subprocess.run(
+            [
+                az_bin,
+                "account",
+                "get-access-token",
+                "--resource",
+                "499b84ac-1321-427f-aa17-267ca6975798",
+                "--query",
+                "accessToken",
+                "-o",
+                "tsv",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        return result.returncode == 0 and result.stdout.startswith("eyJ")
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def _is_e2e_mode() -> bool:
+    return os.environ.get("APM_E2E_TESTS", "").lower() in ("1", "true", "yes")
+
+
+def _is_network_integration() -> bool:
+    return os.environ.get("APM_RUN_INTEGRATION_TESTS") == "1"
+
+
+def _is_inference_mode() -> bool:
+    return os.environ.get("APM_RUN_INFERENCE_TESTS") == "1"
+
+
+def _has_apm_binary() -> bool:
+    if os.environ.get("APM_BINARY_PATH"):
+        return Path(os.environ["APM_BINARY_PATH"]).is_file()
+    return shutil.which("apm") is not None
+
+
+def _has_runtime(name: str) -> bool:
+    if shutil.which(name):
+        return True
+    runtime_path = Path.home() / ".apm" / "runtimes" / name
+    return runtime_path.is_file() and os.access(runtime_path, os.X_OK)
+
+
+_MARKER_CHECKS: dict[str, tuple[Callable[[], bool], str]] = {
+    "requires_e2e_mode": (_is_e2e_mode, "APM_E2E_TESTS=1 not set"),
+    "requires_github_token": (
+        _has_github_token,
+        "GITHUB_APM_PAT or GITHUB_TOKEN not set",
+    ),
+    "requires_ado_pat": (_has_ado_pat, "ADO_APM_PAT not set"),
+    "requires_ado_bearer": (
+        _has_ado_bearer,
+        "az CLI + APM_TEST_ADO_BEARER=1 required",
+    ),
+    "requires_network_integration": (
+        _is_network_integration,
+        "APM_RUN_INTEGRATION_TESTS=1 not set",
+    ),
+    "requires_apm_binary": (
+        _has_apm_binary,
+        "apm binary not found on PATH (set APM_BINARY_PATH or build via scripts/build-binary.sh)",
+    ),
+    "requires_runtime_codex": (
+        lambda: _has_runtime("codex"),
+        "codex runtime not available (run apm runtime setup codex)",
+    ),
+    "requires_runtime_copilot": (
+        lambda: _has_runtime("copilot"),
+        "GitHub Copilot CLI runtime not available (run apm runtime setup copilot)",
+    ),
+    "requires_runtime_llm": (
+        lambda: _has_runtime("llm"),
+        "llm runtime not available (run apm runtime setup llm)",
+    ),
+    "requires_inference": (
+        _is_inference_mode,
+        "APM_RUN_INFERENCE_TESTS=1 not set",
+    ),
+}
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Auto-skip items whose marker precondition is not met.
+
+    The skip decision is made once at collection time, so ``-v`` output shows
+    the test as ``SKIPPED`` with a clear reason, exactly mirroring the prior
+    ``pytestmark = pytest.mark.skipif(...)`` behavior.
+    """
+    for item in items:
+        for marker_name, (check_fn, reason) in _MARKER_CHECKS.items():
+            if item.get_closest_marker(marker_name) and not check_fn():
+                item.add_marker(pytest.mark.skip(reason=reason))
+
+
+@pytest.fixture(scope="session")
+def apm_binary_path() -> Path:
+    """Resolve the apm binary path for tests that need to shell out to it.
+
+    Resolution order:
+      1. ``APM_BINARY_PATH`` env var (CI sets this after the build step).
+      2. ``shutil.which("apm")`` lookup on ``PATH``.
+      3. ``./dist/<platform>/apm`` (local build convention).
+
+    Skips the test if no binary is found, with a message pointing at the
+    build script.
+    """
+    env_path = os.environ.get("APM_BINARY_PATH")
+    if env_path:
+        candidate = Path(env_path)
+        if candidate.is_file():
+            return candidate.resolve()
+
+    on_path = shutil.which("apm")
+    if on_path:
+        return Path(on_path).resolve()
+
+    import platform as plat
+
+    os_name = plat.system().lower()
+    arch = plat.machine().lower()
+    arch_map = {
+        "x86_64": "x86_64",
+        "amd64": "x86_64",
+        "arm64": "arm64",
+        "aarch64": "arm64",
+    }
+    binary_name = f"apm-{os_name}-{arch_map.get(arch, arch)}"
+    local_path = Path("dist") / binary_name / "apm"
+    if local_path.is_file():
+        return local_path.resolve()
+
+    pytest.skip("No apm binary found (set APM_BINARY_PATH or build via scripts/build-binary.sh)")
+    raise RuntimeError("unreachable")  # for type-checker

--- a/tests/integration/test_ado_bearer_e2e.py
+++ b/tests/integration/test_ado_bearer_e2e.py
@@ -63,10 +63,7 @@ if _AZ_AVAILABLE and os.getenv("APM_TEST_ADO_BEARER") == "1":
     except Exception:
         _BEARER_REACHABLE = False
 
-pytestmark = pytest.mark.skipif(
-    not (_AZ_AVAILABLE and _BEARER_REACHABLE and os.getenv("APM_TEST_ADO_BEARER") == "1"),
-    reason="Requires az CLI logged in + APM_TEST_ADO_BEARER=1",
-)
+pytestmark = pytest.mark.requires_ado_bearer
 
 
 def run_apm(

--- a/tests/integration/test_ado_e2e.py
+++ b/tests/integration/test_ado_e2e.py
@@ -18,9 +18,7 @@ import pytest
 import yaml
 
 # Skip all tests in this module if ADO_APM_PAT is not set
-pytestmark = pytest.mark.skipif(
-    not os.getenv("ADO_APM_PAT"), reason="ADO_APM_PAT environment variable not set"
-)
+pytestmark = pytest.mark.requires_ado_pat
 
 
 def run_apm_command(cmd: str, cwd: Path, timeout: int = 60) -> subprocess.CompletedProcess:

--- a/tests/integration/test_auth_resolver.py
+++ b/tests/integration/test_auth_resolver.py
@@ -25,7 +25,7 @@ E2E_MODE = os.environ.get("APM_E2E_TESTS", "").lower() in ("1", "true", "yes")
 
 pytestmark = [
     pytest.mark.integration,
-    pytest.mark.skipif(not E2E_MODE, reason="Integration tests require APM_E2E_TESTS=1"),
+    pytest.mark.requires_e2e_mode,
 ]
 
 # Shared helper: suppress git-credential-fill so env vars are the only source.

--- a/tests/integration/test_auto_install_e2e.py
+++ b/tests/integration/test_auto_install_e2e.py
@@ -23,9 +23,7 @@ import pytest
 # Skip all tests in this module if not in E2E mode
 E2E_MODE = os.environ.get("APM_E2E_TESTS", "").lower() in ("1", "true", "yes")
 
-pytestmark = pytest.mark.skipif(
-    not E2E_MODE, reason="E2E tests only run when APM_E2E_TESTS=1 is set"
-)
+pytestmark = pytest.mark.requires_e2e_mode
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_cache_lockfile_parity.py
+++ b/tests/integration/test_cache_lockfile_parity.py
@@ -29,10 +29,7 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("GITHUB_APM_PAT") and not os.environ.get("GITHUB_TOKEN"),
-    reason="GITHUB_APM_PAT or GITHUB_TOKEN required for GitHub API access",
-)
+pytestmark = pytest.mark.requires_github_token
 
 
 @pytest.fixture

--- a/tests/integration/test_deployed_files_e2e.py
+++ b/tests/integration/test_deployed_files_e2e.py
@@ -13,7 +13,6 @@ Requires network access and GITHUB_TOKEN/GITHUB_APM_PAT for GitHub API.
 """
 
 import json  # noqa: F401
-import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -22,10 +21,7 @@ import pytest
 import yaml
 
 # Skip all tests if no GitHub token is available
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("GITHUB_APM_PAT") and not os.environ.get("GITHUB_TOKEN"),
-    reason="GITHUB_APM_PAT or GITHUB_TOKEN required for GitHub API access",
-)
+pytestmark = pytest.mark.requires_github_token
 
 
 @pytest.fixture

--- a/tests/integration/test_deps_update_e2e.py
+++ b/tests/integration/test_deps_update_e2e.py
@@ -22,10 +22,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("GITHUB_APM_PAT") and not os.environ.get("GITHUB_TOKEN"),
-    reason="GITHUB_APM_PAT or GITHUB_TOKEN required for GitHub API access",
-)
+pytestmark = pytest.mark.requires_github_token
 
 
 SAMPLE_REPO_URL = "microsoft/apm-sample-package"

--- a/tests/integration/test_diff_aware_install_e2e.py
+++ b/tests/integration/test_diff_aware_install_e2e.py
@@ -11,7 +11,6 @@ Uses real packages from GitHub:
   - microsoft/apm-sample-package (deployed prompts, agents, etc.)
 """
 
-import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -20,10 +19,7 @@ import pytest
 import yaml
 
 # Skip all tests if no GitHub token is available
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("GITHUB_APM_PAT") and not os.environ.get("GITHUB_TOKEN"),
-    reason="GITHUB_APM_PAT or GITHUB_TOKEN required for GitHub API access",
-)
+pytestmark = pytest.mark.requires_github_token
 
 
 @pytest.fixture

--- a/tests/integration/test_global_install_e2e.py
+++ b/tests/integration/test_global_install_e2e.py
@@ -21,10 +21,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("GITHUB_APM_PAT") and not os.environ.get("GITHUB_TOKEN"),
-    reason="GITHUB_APM_PAT or GITHUB_TOKEN required for GitHub API access",
-)
+pytestmark = pytest.mark.requires_github_token
 
 
 SAMPLE_PKG = "microsoft/apm-sample-package"

--- a/tests/integration/test_golden_scenario_e2e.py
+++ b/tests/integration/test_golden_scenario_e2e.py
@@ -46,9 +46,7 @@ GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
 # Primary token for requirement checking only (integration script handles actual usage)
 PRIMARY_TOKEN = GITHUB_APM_PAT or GITHUB_TOKEN
 
-pytestmark = pytest.mark.skipif(
-    not E2E_MODE, reason="E2E tests only run when APM_E2E_TESTS=1 is set"
-)
+pytestmark = pytest.mark.requires_e2e_mode
 
 
 def run_command(

--- a/tests/integration/test_guardrailing_hero_e2e.py
+++ b/tests/integration/test_guardrailing_hero_e2e.py
@@ -29,9 +29,7 @@ GITHUB_APM_PAT = os.environ.get("GITHUB_APM_PAT")
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
 PRIMARY_TOKEN = GITHUB_APM_PAT or GITHUB_TOKEN
 
-pytestmark = pytest.mark.skipif(
-    not E2E_MODE, reason="E2E tests only run when APM_E2E_TESTS=1 is set"
-)
+pytestmark = pytest.mark.requires_e2e_mode
 
 
 def run_command(

--- a/tests/integration/test_install_dry_run_e2e.py
+++ b/tests/integration/test_install_dry_run_e2e.py
@@ -9,7 +9,6 @@ Uses the real `microsoft/apm-sample-package` from GitHub. Requires
 GITHUB_APM_PAT or GITHUB_TOKEN for API access.
 """
 
-import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -17,10 +16,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("GITHUB_APM_PAT") and not os.environ.get("GITHUB_TOKEN"),
-    reason="GITHUB_APM_PAT or GITHUB_TOKEN required for GitHub API access",
-)
+pytestmark = pytest.mark.requires_github_token
 
 
 @pytest.fixture

--- a/tests/integration/test_mcp_registry_e2e.py
+++ b/tests/integration/test_mcp_registry_e2e.py
@@ -62,9 +62,7 @@ def _is_registry_healthy() -> bool:
 E2E_MODE = os.environ.get("APM_E2E_TESTS", "").lower() in ("1", "true", "yes")
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
 
-pytestmark = pytest.mark.skipif(
-    not E2E_MODE, reason="MCP registry E2E tests only run when APM_E2E_TESTS=1 is set"
-)
+pytestmark = pytest.mark.requires_e2e_mode
 
 
 def run_command(cmd, check=True, capture_output=True, timeout=180, cwd=None, input_text=None):

--- a/tests/integration/test_mixed_deps.py
+++ b/tests/integration/test_mixed_deps.py
@@ -6,7 +6,6 @@ as dependencies, and that both types work correctly together.
 These tests require network access to GitHub.
 """
 
-import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -14,10 +13,7 @@ from pathlib import Path
 import pytest
 
 # Skip all tests if GITHUB_APM_PAT is not set
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("GITHUB_APM_PAT") and not os.environ.get("GITHUB_TOKEN"),
-    reason="GITHUB_APM_PAT or GITHUB_TOKEN required for GitHub API access",
-)
+pytestmark = pytest.mark.requires_github_token
 
 
 @pytest.fixture

--- a/tests/integration/test_pack_unpack_e2e.py
+++ b/tests/integration/test_pack_unpack_e2e.py
@@ -5,17 +5,13 @@ Round-trip tests: install → pack → unpack → verify files match.
 Requires network access and GITHUB_TOKEN/GITHUB_APM_PAT for GitHub API.
 """
 
-import os
 import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("GITHUB_APM_PAT") and not os.environ.get("GITHUB_TOKEN"),
-    reason="GITHUB_APM_PAT or GITHUB_TOKEN required for GitHub API access",
-)
+pytestmark = pytest.mark.requires_github_token
 
 
 @pytest.fixture

--- a/tests/integration/test_plugin_e2e.py
+++ b/tests/integration/test_plugin_e2e.py
@@ -371,10 +371,7 @@ class TestPluginHeroScenarios:
 # Class 2 — NETWORK E2E tests (real CLI, requires GitHub token)
 # ===========================================================================
 
-pytestmark_network = pytest.mark.skipif(
-    not os.environ.get("GITHUB_APM_PAT") and not os.environ.get("GITHUB_TOKEN"),
-    reason="GITHUB_APM_PAT or GITHUB_TOKEN required for GitHub API access",
-)
+pytestmark_network = pytest.mark.requires_github_token
 
 
 @pytest.fixture

--- a/tests/integration/test_skill_install.py
+++ b/tests/integration/test_skill_install.py
@@ -6,7 +6,6 @@ including simple skills and skills with bundled resources.
 These tests require network access to GitHub.
 """
 
-import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -14,10 +13,7 @@ from pathlib import Path
 import pytest
 
 # Skip all tests if GITHUB_APM_PAT is not set
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("GITHUB_APM_PAT") and not os.environ.get("GITHUB_TOKEN"),
-    reason="GITHUB_APM_PAT or GITHUB_TOKEN required for GitHub API access",
-)
+pytestmark = pytest.mark.requires_github_token
 
 
 @pytest.fixture

--- a/tests/integration/test_skill_integration.py
+++ b/tests/integration/test_skill_integration.py
@@ -7,7 +7,6 @@ and that compile does not modify skill files.
 These tests require network access to GitHub.
 """
 
-import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -15,10 +14,7 @@ from pathlib import Path
 import pytest
 
 # Skip all tests if GITHUB_APM_PAT is not set
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("GITHUB_APM_PAT") and not os.environ.get("GITHUB_TOKEN"),
-    reason="GITHUB_APM_PAT or GITHUB_TOKEN required for GitHub API access",
-)
+pytestmark = pytest.mark.requires_github_token
 
 
 @pytest.fixture

--- a/tests/integration/test_transport_selection_integration.py
+++ b/tests/integration/test_transport_selection_integration.py
@@ -18,7 +18,6 @@ Network-dependent. Skipped unless ``APM_RUN_INTEGRATION_TESTS=1``.
 
 from __future__ import annotations
 
-import os
 import shutil
 import subprocess
 import tempfile
@@ -36,10 +35,7 @@ from apm_cli.deps.transport_selection import (
 )
 from apm_cli.models.apm_package import DependencyReference
 
-pytestmark = pytest.mark.skipif(
-    os.environ.get("APM_RUN_INTEGRATION_TESTS") != "1",
-    reason="Set APM_RUN_INTEGRATION_TESTS=1 to run network-dependent tests",
-)
+pytestmark = pytest.mark.requires_network_integration
 
 
 _OWNER = "github"

--- a/tests/integration/test_uninstall_dry_run_e2e.py
+++ b/tests/integration/test_uninstall_dry_run_e2e.py
@@ -7,7 +7,6 @@ Requires network access and GITHUB_TOKEN/GITHUB_APM_PAT for GitHub API.
 Uses the real microsoft/apm-sample-package.
 """
 
-import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -15,10 +14,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("GITHUB_APM_PAT") and not os.environ.get("GITHUB_TOKEN"),
-    reason="GITHUB_APM_PAT or GITHUB_TOKEN required for GitHub API access",
-)
+pytestmark = pytest.mark.requires_github_token
 
 
 @pytest.fixture

--- a/tests/integration/test_uninstall_multi_e2e.py
+++ b/tests/integration/test_uninstall_multi_e2e.py
@@ -10,7 +10,6 @@ Uses two real public APM packages from GitHub:
   - github/awesome-copilot/skills/aspire
 """
 
-import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -18,10 +17,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("GITHUB_APM_PAT") and not os.environ.get("GITHUB_TOKEN"),
-    reason="GITHUB_APM_PAT or GITHUB_TOKEN required for GitHub API access",
-)
+pytestmark = pytest.mark.requires_github_token
 
 
 PKG_A = "microsoft/apm-sample-package"


### PR DESCRIPTION
## TL;DR

Foundation PR for #1166. Replaces 21 per-file `pytestmark = pytest.mark.skipif(...)` chains across `tests/integration/` with declarative `requires_*` markers. Precondition logic now lives once in `tests/integration/conftest.py` and auto-skips at collection time. **No behavior change** — same files run, same skip semantics, same exit codes. Unblocks PR2 (replacing the 665-line `scripts/test-integration.sh` with a single `pytest tests/integration/` invocation).

## Why (the bug we just hit)

PR #1153 added `tests/integration/test_skill_install.py` but did NOT wire it into `scripts/test-integration.sh`. Result: 8 integration tests silently never ran in CI. Caught manually via review; would have shipped silently otherwise.

The root cause is a 665-line bash script that re-implements pytest's discovery/reporting/exit-code in `if pytest <file>; then log_success; else log_error; exit 1; fi` blocks. Every new integration file requires a manual edit to the script. Files that aren't wired up are silently never executed.

This PR fixes the **discovery** half of that problem. PR2 fixes the **execution** half (script swap).

## What changed

### Added (`tests/integration/conftest.py`, new file)

- `_MARKER_CHECKS` dict: maps each `requires_*` marker to a `(precondition_callable, skip_reason)` pair.
- `pytest_collection_modifyitems` hook: at collection time, for every item, scans its closest marker against the registry; if precondition unmet, applies `pytest.mark.skip(reason=...)`. Same `SKIPPED [reason]` output as the current `skipif` decorator -- just centralized.
- `apm_binary_path` session fixture: resolves the apm binary via `APM_BINARY_PATH` env > `shutil.which("apm")` > `./dist/<platform>/apm`. Used in PR2 when the bash script's binary-build orchestration is preserved but per-test enumeration is dropped.

### Added (`pyproject.toml`)

10 markers under `[tool.pytest.ini_options]` `markers`:
- `requires_e2e_mode` — `APM_E2E_TESTS=1`
- `requires_github_token` — `GITHUB_APM_PAT` or `GITHUB_TOKEN`
- `requires_ado_pat` — `ADO_APM_PAT`
- `requires_ado_bearer` — az CLI logged in + `APM_TEST_ADO_BEARER=1` (matches the existing JWT-prefix probe in `test_ado_bearer_e2e.py` for parity)
- `requires_network_integration` — `APM_RUN_INTEGRATION_TESTS=1`
- `requires_apm_binary` — built binary on PATH or via `APM_BINARY_PATH`
- `requires_runtime_codex` / `_copilot` / `_llm` — runtime installed via `apm runtime setup`
- `requires_inference` — `APM_RUN_INFERENCE_TESTS=1`

### Migrated (~20 test files)

Each existing `pytestmark = pytest.mark.skipif(...)` was replaced with `pytestmark = pytest.mark.requires_X` (or list-form for files like `test_auth_resolver.py` that combine `integration` + `skipif`). `ruff --fix` removed the now-unused `os` and `E2E_MODE` imports.

Mapping (from issue #1166 design):

| File | Old skipif | New marker |
|---|---|---|
| test_skill_install.py + 9 others | `not GITHUB_APM_PAT and not GITHUB_TOKEN` | `requires_github_token` |
| test_auto_install_e2e.py + 3 others | `not E2E_MODE` | `requires_e2e_mode` |
| test_ado_e2e.py | `not ADO_APM_PAT` | `requires_ado_pat` |
| test_ado_bearer_e2e.py | az CLI + bearer probe | `requires_ado_bearer` |
| test_transport_selection_integration.py | `APM_RUN_INTEGRATION_TESTS != 1` | `requires_network_integration` |
| test_auth_resolver.py | `[integration, skipif(not E2E_MODE)]` | `[integration, requires_e2e_mode]` |
| test_plugin_e2e.py | per-class `pytestmark_network = skipif(...)` | per-class `pytestmark_network = requires_github_token` |

## Validation evidence

All commands run in this worktree on Darwin/arm64 (Python 3.12.9):

| Check | Command | Result |
|---|---|---|
| Lint mirror | `uv run --extra dev ruff check src/ tests/ && ruff format --check src/ tests/` | All checks passed (silent) |
| Collection parity | `APM_E2E_TESTS=1 APM_RUN_INTEGRATION_TESTS=1 pytest --collect-only -q tests/integration/ --ignore=tests/integration/marketplace` | **524 collected** before AND after (identical) |
| Marker auto-skip works | unset `GITHUB_APM_PAT` + `pytest test_skill_install.py -v` | 7 SKIPPED with reason "GITHUB_APM_PAT or GITHUB_TOKEN not set" |
| Marker run works | `GITHUB_APM_PAT=$(gh auth token) pytest test_skill_install.py -v` | 7 PASSED in 19.28s |
| Full unit suite | `pytest tests/unit -q` | 7701 passed in 109s |

## What this PR does NOT change (deferred to PR2)

- `scripts/test-integration.sh` is **untouched** (still 665 lines, still works) — the markers are silent semantic equivalents to the old `skipif` chains, so the existing per-file enumeration keeps working
- CI workflow files untouched
- `marketplace/` subdirectory tests untouched (separate conftest)
- Windows `scripts/windows/test-integration.ps1` untouched (follow-up)

## Risk

- **Risk: collection regression** — Mitigated by the 524 == 524 parity check above
- **Risk: marker check fires differently than skipif** — `_has_ado_bearer()` matches the old test's `_BEARER_REACHABLE` logic (returncode + JWT prefix); other checks are direct env-var lookups
- **Risk: previously-uncalled files get auto-skip surprises** — The 38 files not wired into the bash script have no `pytestmark` (already collected unconditionally if you ran `pytest tests/integration/` directly); this PR doesn't change their behavior

Closes the discovery half of #1166. PR2 (script swap + CI wiring) will follow.

---

Built on commits from #1153 (the symptom that motivated this).