### PR TITLE
test(integration): pass --target copilot to apm init --yes

### DIFF
--- a/scripts/test-release-validation.sh
+++ b/scripts/test-release-validation.sh
@@ -219,9 +219,9 @@ test_hero_guardrailing() {
     log_test "HERO SCENARIO 2: 2-Minute Guardrailing (README lines 46-60)"
     
     # Step 1: apm init my-project
-    echo "Running: $BINARY_PATH init my-project --yes"
+    echo "Running: $BINARY_PATH init my-project --yes --target copilot"
     echo "--- Command Output Start ---"
-    "$BINARY_PATH" init my-project --yes 2>&1
+    "$BINARY_PATH" init my-project --yes --target copilot 2>&1
     local exit_code=$?
     echo "--- Command Output End ---"
     echo "Exit code: $exit_code"

--- a/tests/integration/test_golden_scenario_e2e.py
+++ b/tests/integration/test_golden_scenario_e2e.py
@@ -223,7 +223,7 @@ class TestGoldenScenarioE2E:
 
             print("\n=== Step 3: Transform your project with AI-Native structure ===")
             result = run_command(
-                f"{apm_binary} init my-ai-native-project --yes",
+                f"{apm_binary} init my-ai-native-project --yes --target copilot",
                 cwd=project_workspace,
                 show_output=True,
             )
@@ -442,7 +442,8 @@ Basic instructions for E2E testing.
 
             print("\n=== Initializing Codex test project ===")
             result = run_command(
-                f"{apm_binary} init my-ai-native-project-codex --yes", cwd=project_workspace
+                f"{apm_binary} init my-ai-native-project-codex --yes --target copilot",
+                cwd=project_workspace,
             )
             assert result.returncode == 0, f"Project init failed: {result.stderr}"
 
@@ -592,7 +593,8 @@ Instructions for Codex E2E testing.
 
             print("\\n=== Initializing LLM test project ===")
             result = run_command(
-                f"{apm_binary} init my-ai-native-project-llm --yes", cwd=project_workspace
+                f"{apm_binary} init my-ai-native-project-llm --yes --target copilot",
+                cwd=project_workspace,
             )
             assert result.returncode == 0, f"Project init failed: {result.stderr}"
 
@@ -748,7 +750,8 @@ Instructions for LLM E2E testing.
 
             print("\n=== Initializing Gemini test project ===")
             result = run_command(
-                f"{apm_binary} init my-ai-native-project-gemini --yes", cwd=project_workspace
+                f"{apm_binary} init my-ai-native-project-gemini --yes --target copilot",
+                cwd=project_workspace,
             )
             assert result.returncode == 0, f"Project init failed: {result.stderr}"
 
@@ -908,7 +911,9 @@ Instructions for Gemini CLI E2E testing.
 
             # Test apm init
             result = run_command(
-                f"{apm_binary} init template-test-project --yes", cwd=workspace, show_output=True
+                f"{apm_binary} init template-test-project --yes --target copilot",
+                cwd=workspace,
+                show_output=True,
             )
             assert result.returncode == 0, f"APM init failed: {result.stderr}"
 

--- a/tests/integration/test_guardrailing_hero_e2e.py
+++ b/tests/integration/test_guardrailing_hero_e2e.py
@@ -127,7 +127,9 @@ class TestGuardrailingHeroScenario:
             # Step 1: apm init my-project
             print("\n=== Step 1: apm init my-project ===")
             result = run_command(
-                f"{apm_binary} init my-project --yes", cwd=workspace, show_output=True
+                f"{apm_binary} init my-project --yes --target copilot",
+                cwd=workspace,
+                show_output=True,
             )
             assert result.returncode == 0, f"Project init failed: {result.stderr}"
 

--- a/tests/integration/test_mcp_registry_e2e.py
+++ b/tests/integration/test_mcp_registry_e2e.py
@@ -202,7 +202,8 @@ class TestMCPRegistryE2E:
 
             print("Creating project with MCP dependencies...")
             result = run_command(
-                f"{apm_binary} init registry-test-project --yes", cwd=project_workspace
+                f"{apm_binary} init registry-test-project --yes --target copilot",
+                cwd=project_workspace,
             )
             assert result.returncode == 0, f"Project init failed: {result.stderr}"
 
@@ -331,7 +332,7 @@ class TestMCPRegistryE2E:
             project_dir = Path(project_workspace) / "empty-string-test"
 
             result = run_command(
-                f"{apm_binary} init empty-string-test --yes", cwd=project_workspace
+                f"{apm_binary} init empty-string-test --yes --target copilot", cwd=project_workspace
             )
             assert result.returncode == 0, f"Project init failed: {result.stderr}"
 
@@ -446,7 +447,7 @@ class TestMCPRegistryE2E:
             project_dir = Path(project_workspace) / "empty-string-test"
 
             result = run_command(
-                f"{apm_binary} init empty-string-test --yes", cwd=project_workspace
+                f"{apm_binary} init empty-string-test --yes --target copilot", cwd=project_workspace
             )
             assert result.returncode == 0, f"Project init failed: {result.stderr}"
 
@@ -514,7 +515,9 @@ class TestMCPRegistryE2E:
         with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as project_workspace:
             project_dir = Path(project_workspace) / "consistency-test"
 
-            result = run_command(f"{apm_binary} init consistency-test --yes", cwd=project_workspace)
+            result = run_command(
+                f"{apm_binary} init consistency-test --yes --target copilot", cwd=project_workspace
+            )
             assert result.returncode == 0, f"Project init failed: {result.stderr}"
 
             # Create apm.yml with Codex script
@@ -579,7 +582,9 @@ class TestMCPRegistryE2E:
         with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as project_workspace:
             project_dir = Path(project_workspace) / "duplication-test"
 
-            result = run_command(f"{apm_binary} init duplication-test --yes", cwd=project_workspace)
+            result = run_command(
+                f"{apm_binary} init duplication-test --yes --target copilot", cwd=project_workspace
+            )
             assert result.returncode == 0, f"Project init failed: {result.stderr}"
 
             # Create apm.yml


### PR DESCRIPTION
## TL;DR

Fix integration test regression introduced by #1165 (explicit-target resolution). Pass `--target copilot` to all `apm init --yes` calls in E2E tests and the release validation script so generated `apm.yml` declares a harness; downstream `apm install` / `apm compile` no longer exit 2 with `[x] No harness detected`.

## Why

Release pipeline run [25461756411](https://github.com/microsoft/apm/actions/runs/25461756411/job/74705413425) failed on `tests/integration/test_guardrailing_hero_e2e.py::test_2_minute_guardrailing_flow`. Root cause:

- `apm init <name> --yes` in an empty dir auto-detects targets, finds no signal, and writes `apm.yml` with `targets:` commented out.
- After #1165, `apm install <pkg>` on a project with no harness signal AND no `apm.yml` target now fails closed (exit 2) instead of silently defaulting to `copilot`.
- The hero test (and several siblings) ran exactly that flow.

The new fail-closed contract is intentional. Tests must adapt by declaring a target on init.

## Changes

- `tests/integration/test_guardrailing_hero_e2e.py` -- 1 init call
- `tests/integration/test_golden_scenario_e2e.py` -- 5 init calls (codex/llm/gemini scenarios + template test)
- `tests/integration/test_mcp_registry_e2e.py` -- 5 init calls
- `scripts/test-release-validation.sh` -- 1 init call (post-binary smoke test)

All updated with `--target copilot` (matches the implicit pre-#1165 default).

## Validation

- `APM_E2E_TESTS=1 pytest tests/integration/test_guardrailing_hero_e2e.py` -- PASSED locally on macOS arm64 with `apm` v0.12.3.
- Lint contract green: `ruff check src/ tests/` + `ruff format --check src/ tests/` both silent.
