### PR TITLE
fix(install): restore static-target deploy path; tighten test fixtures for #1154 strict harness detection

### DIFF
--- a/scripts/test-dependency-integration.sh
+++ b/scripts/test-dependency-integration.sh
@@ -48,6 +48,7 @@ name: dependency-test-project
 version: 1.0.0
 description: Test project for dependency integration testing
 author: CI Test
+target: copilot
 
 dependencies:
   apm:
@@ -149,6 +150,7 @@ name: multi-dependency-test
 version: 1.0.0
 description: Test project for multi-dependency scenario
 author: CI Test
+target: copilot
 
 dependencies:
   apm:

--- a/scripts/test-release-validation.sh
+++ b/scripts/test-release-validation.sh
@@ -377,6 +377,7 @@ test_ghaw_compat() {
         cat > apm.yml <<'APMYML'
 name: ghaw-compat-test
 version: 1.0.0
+target: copilot
 dependencies:
   apm:
     - microsoft/apm-sample-package

--- a/scripts/windows/test-dependency-integration.ps1
+++ b/scripts/windows/test-dependency-integration.ps1
@@ -44,6 +44,7 @@ name: dependency-test-project
 version: 1.0.0
 description: Test project for dependency integration testing
 author: CI Test
+target: copilot
 
 dependencies:
   apm:
@@ -156,6 +157,7 @@ name: multi-dependency-test
 version: 1.0.0
 description: Test project for multi-dependency scenario
 author: CI Test
+target: copilot
 
 dependencies:
   apm:

--- a/src/apm_cli/install/phases/targets.py
+++ b/src/apm_cli/install/phases/targets.py
@@ -49,7 +49,6 @@ def run(ctx: InstallContext) -> None:
 
     On return ``ctx.targets`` and ``ctx.integrators`` are populated.
     """
-    from dataclasses import replace as _replace
 
     from apm_cli.core.scope import InstallScope
     from apm_cli.core.target_detection import (
@@ -282,7 +281,13 @@ def run(ctx: InstallContext) -> None:
                         raise SystemExit(1) from None
                     if ctx.logger:
                         ctx.logger.verbose_detail(f"Created {_profile.root_dir}/ ({_tname} target)")
-                _profile = _replace(_profile, resolved_deploy_root=_target_dir)
+                # NOTE: do NOT set resolved_deploy_root on static targets.
+                # That field is reserved for dynamic-root targets (cowork)
+                # and is treated as the final deploy destination by
+                # skill_integrator and base_integrator. Static targets must
+                # follow the standard primitive-mapping path so that
+                # ``deploy_root`` (e.g. .agents) and ``subdir`` (e.g. skills)
+                # are honored.
                 _v2_targets.append(_profile)
 
             # Replace legacy targets with v2 targets for project-scope.
@@ -379,7 +384,6 @@ def run_targets_phase(ctx) -> None:
     This is the three-guard collapse: every resolved target always materializes
     its deploy directory (auto_create=True unconditionally post-resolution).
     """
-    from dataclasses import replace
     from pathlib import Path
 
     from apm_cli.core.target_detection import resolve_targets
@@ -420,8 +424,12 @@ def run_targets_phase(ctx) -> None:
         if not target_dir.exists():
             target_dir.mkdir(parents=True, exist_ok=True)
 
-        # Set resolved_deploy_root so downstream code knows the exact path
-        profile = replace(profile, resolved_deploy_root=target_dir)
+        # NOTE: do NOT set resolved_deploy_root on static targets.
+        # That field is reserved for dynamic-root targets (cowork) and is
+        # treated as the final deploy destination by downstream integrators.
+        # Static targets must follow the standard primitive-mapping path so
+        # that ``deploy_root`` (e.g. .agents) and ``subdir`` (e.g. skills)
+        # are honored.
         profiles.append(profile)
 
     ctx.targets = profiles

--- a/tests/integration/test_apm_dependencies.py
+++ b/tests/integration/test_apm_dependencies.py
@@ -525,8 +525,11 @@ class TestAPMDependenciesCI:
             "Downloader should have a GitHub token for modules access"
         )
         assert downloader.github_token is not None, "GitHub token should be available"
-        assert downloader.github_token.startswith("github_pat_"), (
-            "Token should be a valid GitHub PAT"
+        # Accept any valid GitHub token prefix: github_pat_ (fine-grained PAT),
+        # ghp_ (classic PAT), gho_ (OAuth via gh CLI), ghs_/ghu_ (app tokens).
+        valid_prefixes = ("github_pat_", "ghp_", "gho_", "ghs_", "ghu_")
+        assert downloader.github_token.startswith(valid_prefixes), (
+            f"Token should be a valid GitHub token (one of {valid_prefixes})"
         )
 
         # Verify that environment variables are properly set for Git operations
@@ -542,8 +545,8 @@ class TestAPMDependenciesCI:
         assert token_for_modules is not None, (
             "Token manager should provide a token for modules access"
         )
-        assert token_for_modules.startswith("github_pat_"), (
-            "Modules token should be a valid GitHub PAT"
+        assert token_for_modules.startswith(valid_prefixes), (
+            f"Modules token should be a valid GitHub token (one of {valid_prefixes})"
         )
 
         # This validates the authentication setup works with real tokens

--- a/tests/integration/test_cache_lockfile_parity.py
+++ b/tests/integration/test_cache_lockfile_parity.py
@@ -56,6 +56,7 @@ def project_with_apm(tmp_path: Path) -> Path:
         """\
 name: parity-test
 version: 0.1.0
+target: copilot
 dependencies:
   apm:
     - microsoft/apm-sample-package

--- a/tests/integration/test_deps_update_e2e.py
+++ b/tests/integration/test_deps_update_e2e.py
@@ -92,6 +92,7 @@ def _write_apm_yml(target_dir, packages):
     config = {
         "name": "deps-update-test",
         "version": "1.0.0",
+        "target": "copilot",
         "dependencies": {"apm": packages, "mcp": []},
     }
     (target_dir / "apm.yml").write_text(
@@ -244,6 +245,7 @@ def test_deps_update_global_user_scope(tmp_path, fake_home, apm_command):
                 {
                     "name": "global-deps-update-test",
                     "version": "1.0.0",
+                    "target": "copilot",
                     "dependencies": {
                         "apm": [{"git": SAMPLE_GIT_URL, "ref": ref}],
                         "mcp": [],

--- a/tests/integration/test_drift_check.py
+++ b/tests/integration/test_drift_check.py
@@ -55,7 +55,7 @@ def _make_apm_project(
     *,
     name: str = "drift-fixture",
     version: str = "1.0.0",
-    target: str | None = None,
+    target: str | None = "copilot",
     files: Mapping[str, bytes] | None = None,
 ) -> Path:
     """Create a minimal APM project rooted under ``tmp_path``.

--- a/tests/integration/test_drift_check_e2e.py
+++ b/tests/integration/test_drift_check_e2e.py
@@ -40,7 +40,9 @@ _INSTRUCTION_BYTES = b'---\napplyTo: "**"\n---\n# Rules\n\nE2E fixture content.\
 def _make_project(tmp_path: Path, name: str = "drift-e2e") -> Path:
     project = tmp_path / name
     project.mkdir()
-    (project / "apm.yml").write_bytes(yaml.safe_dump({"name": name, "version": "1.0.0"}).encode())
+    (project / "apm.yml").write_bytes(
+        yaml.safe_dump({"name": name, "version": "1.0.0", "target": "copilot"}).encode()
+    )
     inst_dir = project / ".apm" / "instructions"
     inst_dir.mkdir(parents=True)
     (inst_dir / "rules.instructions.md").write_bytes(_INSTRUCTION_BYTES)

--- a/tests/integration/test_link_rewrite_e2e.py
+++ b/tests/integration/test_link_rewrite_e2e.py
@@ -74,9 +74,14 @@ def _make_consumer(root: Path, *, targets: list[str] | None = None) -> Path:
     consumer = root / "consumer"
     consumer.mkdir()
     (consumer / ".github").mkdir()
-    yml: dict = {"name": "consumer", "version": "1.0.0", "dependencies": {"apm": []}}
+    yml: dict = {
+        "name": "consumer",
+        "version": "1.0.0",
+        "target": "copilot",
+        "dependencies": {"apm": []},
+    }
     if targets:
-        yml["targets"] = targets
+        yml["target"] = ",".join(targets) if len(targets) > 1 else targets[0]
     _write_yaml(consumer / "apm.yml", yml)
     return consumer
 
@@ -375,7 +380,7 @@ class TestMultiTargetLinkRewriting:
             producer / ".apm" / "instructions" / "multi.instructions.md",
             '---\napplyTo: "**/*.py"\n---\n# Multi\n\nSee [style](../../standards/style.md).\n',
         )
-        consumer = _make_consumer(ws)
+        consumer = _make_consumer(ws, targets=["copilot", "claude"])
         # Auto-detect needs both target dirs present.  Copilot
         # instructions deploy to .github/instructions/; Claude
         # instructions deploy to .claude/rules/.

--- a/tests/integration/test_mixed_deps.py
+++ b/tests/integration/test_mixed_deps.py
@@ -31,6 +31,7 @@ def temp_project(tmp_path):
     apm_yml.write_text("""name: mixed-deps-project
 version: 1.0.0
 description: Test project with mixed dependencies
+target: copilot
 dependencies:
   apm: []
   mcp: []

--- a/tests/integration/test_skill_install.py
+++ b/tests/integration/test_skill_install.py
@@ -31,6 +31,7 @@ def temp_project(tmp_path):
     apm_yml.write_text("""name: test-skill-project
 version: 1.0.0
 description: Test project for skill installation
+target: copilot
 dependencies:
   apm: []
   mcp: []
@@ -270,6 +271,7 @@ class TestSkillInstallWithoutVSCodeTarget:
         apm_yml = project_dir / "apm.yml"
         apm_yml.write_text("""name: no-vscode-project
 version: 1.0.0
+target: copilot
 dependencies:
   apm: []
 """)

--- a/tests/integration/test_skill_integration.py
+++ b/tests/integration/test_skill_integration.py
@@ -32,6 +32,7 @@ def temp_project(tmp_path):
     apm_yml.write_text("""name: skill-compile-project
 version: 1.0.0
 description: Test project for skill compilation
+target: copilot
 dependencies:
   apm: []
   mcp: []

--- a/tests/integration/test_transitive_chain_e2e.py
+++ b/tests/integration/test_transitive_chain_e2e.py
@@ -56,6 +56,7 @@ def chain_workspace(tmp_path):
             {
                 "name": "consumer-project",
                 "version": "1.0.0",
+                "target": "copilot",
                 "dependencies": {"apm": []},
             }
         )
@@ -203,6 +204,7 @@ def test_asymmetric_layout_anchors_on_declaring_pkg(tmp_path, apm_command):
             {
                 "name": "consumer",
                 "version": "1.0.0",
+                "target": "copilot",
                 "dependencies": {"apm": ["./packages/specialized"]},
             }
         )

--- a/tests/unit/install/phases/test_targets_phase_v2.py
+++ b/tests/unit/install/phases/test_targets_phase_v2.py
@@ -46,13 +46,22 @@ def _make_ctx(
     return ctx
 
 
-def _resolved_dirs(ctx) -> list[Path]:
-    """Collect resolved_deploy_root from every TargetProfile on ctx.targets."""
+def _target_root_dirs(ctx, project_root: Path) -> list[Path]:
+    """Collect on-disk deploy directories for every TargetProfile in ctx.targets.
+
+    Static targets resolve to ``project_root / target.root_dir`` (e.g.
+    ``.claude``). Dynamic targets (cowork) carry an explicit
+    ``resolved_deploy_root`` -- if present, prefer it.
+    """
     out: list[Path] = []
     for t in ctx.targets:
         root = getattr(t, "resolved_deploy_root", None)
         if root is not None:
             out.append(Path(root))
+            continue
+        root_dir = getattr(t, "root_dir", None)
+        if root_dir:
+            out.append(project_root / root_dir)
     return out
 
 
@@ -68,7 +77,7 @@ def test_three_guard_collapse_no_skip(tmp_path):
     run_targets_phase(ctx)
 
     assert ctx.targets, "run_targets_phase produced no targets"
-    dirs = _resolved_dirs(ctx)
+    dirs = _target_root_dirs(ctx, project)
     assert any(d.name == ".claude" for d in dirs), f"No .claude/ deploy dir resolved; got {dirs}"
 
 


### PR DESCRIPTION
## TL;DR

Two CI failures on the v0.12.3 retag exposed (1) a real source regression where skills deployed to the wrong path, and (2) a fleet of integration/release tests that hadn't been updated for the post-#1154 strict harness-detection regime. This PR fixes both so the full integration AND release-validation suites are green locally end-to-end.

## Problem (WHY)

After cutting v0.12.3 (#1170, #1171, #1173) the integration job kept failing. Investigation surfaced two distinct issues:

1. **Source regression in PR #1165**: `phases/targets.py` started setting `resolved_deploy_root = project_root / target.root_dir` on EVERY v2-resolved static target. But that field was originally set only by cowork's dynamic-root `for_scope(user_scope=True)`, and downstream readers (`skill_integrator.py:751-753, 887-889, 985-986`, `base_integrator.py:237-242`) treat `resolved_deploy_root != None` as "this is a dynamic-root cowork target where the resolved path is the FINAL deploy destination". Result: skills landed at `<root_dir>/<skill_name>/` (e.g. `.github/brand-guidelines/SKILL.md`) instead of `<deploy_root>/<subdir>/<skill_name>/` (e.g. `.agents/skills/brand-guidelines/SKILL.md`). Reproduced manually:

   ```text
   |-- Skill integrated -> .agents/skills/    # what the log claims
   ./.github/brand-guidelines/SKILL.md         # what actually happens (pre-fix)
   ./.agents/skills/brand-guidelines/SKILL.md  # post-fix
   ```

2. **Test/script fixtures lacking `target:`**: After #1154, `apm install` exits 2 with "No harness detected" when the project has neither a harness signal nor `target:` in `apm.yml` nor `--target` on the CLI. A wide swath of integration tests, release-validation scripts, and even the gh-aw compat fixture (`test-release-validation.sh`) were still relying on the old "default to copilot" behavior.

## Approach (WHAT)

**Source fix** (smallest possible surface): stop setting `resolved_deploy_root` on static targets. Static targets fall back to the standard primitive-mapping path (`deploy_root` override + `subdir`), which is the correct logic. `resolved_deploy_root` remains reserved for true dynamic-root targets (cowork via `for_scope`).

**Fixture fixes**: add `target: copilot` to every test/script `apm.yml` literal that drives `apm install` without a harness signal. For tests that intentionally exercise multi-target behavior (`link_rewrite_e2e::TestMultiTargetLinkRewriting`), pass an explicit list.

**Unit-test alignment**: `test_targets_phase_v2.py::test_three_guard_collapse_no_skip` was added in #1165 and used `resolved_deploy_root` as a proxy for "target was resolved". Updated the helper to accept either `resolved_deploy_root` (cowork) or `root_dir` (static), preserving the semantic intent of the test ("target is in `ctx.targets` with a real on-disk dir") without leaking the proxy detail.

## Implementation (HOW)

| File | Change |
|---|---|
| `src/apm_cli/install/phases/targets.py` | Remove two `resolved_deploy_root=_target_dir` assignments (lines ~285, ~424). Drop now-unused `dataclasses.replace` imports. |
| `tests/unit/install/phases/test_targets_phase_v2.py` | `_resolved_dirs` -> `_target_root_dirs(ctx, project_root)` that falls back to `root_dir` for static targets. |
| `tests/integration/test_drift_check.py` | Default `target` arg on `_make_apm_project` flipped from `None` -> `"copilot"`. |
| `tests/integration/test_drift_check_e2e.py` | `_make_project` adds `target: copilot`. |
| `tests/integration/test_link_rewrite_e2e.py` | `_make_consumer` defaults to `target: copilot`; `MultiTargetLinkRewriting` now passes `targets=["copilot","claude"]`; switch from plural `targets:` to canonical singular `target:` (CSV when multiple). |
| `tests/integration/test_transitive_chain_e2e.py` | Two consumer apm.yml literals add `target: copilot`. |
| `scripts/test-release-validation.sh` | gh-aw compat fixture (apm-action's generateManifest format) adds `target: copilot`. |
| `scripts/test-dependency-integration.sh` + Windows `.ps1` mirror | Both real-dep and multi-dep apm.yml fixtures add `target: copilot`. |

Other test-fixture target-additions and one token-prefix relaxation (`test_apm_dependencies.py` accepts `gho_` from gh CLI OAuth in addition to `github_pat_*`) carried over from earlier work in this batch.

## Validation

```bash
$ bash scripts/test-integration.sh --use-existing-binary
... Integration validation complete - COMPREHENSIVE TESTING ... ✅ Ready for release validation!

$ bash scripts/test-release-validation.sh /Users/.../.venv/bin/apm
... Results: 6/6 tests passed ✅ RELEASE VALIDATION PASSED!

$ uv run pytest tests/unit -q
7779 passed, 1 warning, 30 subtests passed in 90.39s

$ uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/
All checks passed! ; 705 files already formatted
```

## Trade-offs

- **Source fix is surgical** (remove 2 lines + 2 unused imports) instead of guarding every reader with `target.user_root_resolver is not None`. Both restore the same invariant; the surgical version preserves the cowork-only contract that downstream code already encodes.
- The gh-aw compat scenario change in the script makes a soft assumption that apm-action's `generateManifest()` will be updated to include `target:` once it consumes >= v0.12.3. Until then, gh-aw users on older apm-action will hit the same exit-2; this is the expected new contract from #1154 and not introduced by this PR.

## How to test

```bash
# repro skill deploy regression on main pre-fix
git checkout main
mkdir /tmp/skill-test && cd /tmp/skill-test
printf 'name: t\nversion: 1.0.0\ntarget: copilot\n' > apm.yml && mkdir .github
apm install anthropics/skills/skills/brand-guidelines
find . -name 'SKILL.md'   # outside apm_modules: was .github/brand-guidelines/, now .agents/skills/brand-guidelines/

# verify suites
bash scripts/test-integration.sh --use-existing-binary
bash scripts/test-release-validation.sh
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>