### PR TITLE
test(release-validation): pass --target copilot to apm init on Windows

### DIFF
--- a/scripts/windows/test-release-validation.ps1
+++ b/scripts/windows/test-release-validation.ps1
@@ -258,9 +258,9 @@ function Test-HeroGuardrailing {
     Write-TestHeader "HERO SCENARIO 2: 2-Minute Guardrailing (README lines 46-60)"
 
     # Step 1: apm init my-project
-    Write-Host "Running: $script:BINARY_PATH init my-project --yes"
+    Write-Host "Running: $script:BINARY_PATH init my-project --yes --target copilot"
     Write-Host "--- Command Output Start ---"
-    $result = & $script:BINARY_PATH init my-project --yes 2>&1
+    $result = & $script:BINARY_PATH init my-project --yes --target copilot 2>&1
     $exitCode = $LASTEXITCODE
     $result | Out-Host
     Write-Host "--- Command Output End ---"


### PR DESCRIPTION
## TL;DR

Hero scenario 2 of release validation fails only on Windows ([run 25484129617](https://github.com/microsoft/apm/actions/runs/25484129617/job/74776387255)) because the `.ps1` mirror of `test-release-validation.sh` was missed when #1171 added `--target copilot` to `apm init --yes`.

## Why only Windows

| Script | `apm init` invocation |
|---|---|
| `scripts/test-release-validation.sh:224` | `apm init my-project --yes --target copilot` |
| `scripts/windows/test-release-validation.ps1:263` (before this PR) | `apm init my-project --yes` (missing) |

Without `--target copilot` the resulting `apm.yml` has no target, the fresh `my-project/` has no `.github/` signal, and the next step `apm install microsoft/apm-sample-package` exits 2 under post-#1154 strict harness detection.

## Fix

One-line addition: pass `--target copilot` to `apm init` in the Windows release-validation script, matching the `.sh` mirror.

## Follow-up

After merge, retag `v0.12.3` to the new merge SHA so the release pipeline reruns.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>