### PR TITLE
feat(shared/apm.md): expose target input for slim per-harness bundles

### DIFF
--- a/.github/workflows/pr-review-panel.lock.yml
+++ b/.github/workflows/pr-review-panel.lock.yml
@@ -1018,7 +1018,7 @@ jobs:
           dependencies: ${{ steps.list.outputs.deps }}
           isolated: "true"
           pack: "true"
-          target: all
+          target: ${{ github.aw.import-inputs.target || 'all' }}
           working-directory: /tmp/gh-aw/apm-workspace
       - name: Upload APM bundle artifact
         if: success()

--- a/.github/workflows/shared/apm.md
+++ b/.github/workflows/shared/apm.md
@@ -56,6 +56,16 @@
 #              owner: beta-org
 #              packages:
 #                - beta-org/beta-pkg
+#
+# 4. Slim bundle for a single harness (recommended when the workflow
+#    targets one engine -- avoids packing every harness layout):
+#
+#    imports:
+#      - uses: shared/apm.md
+#        with:
+#          target: copilot
+#          packages:
+#            - microsoft/apm-sample-package
 
 import-schema:
   packages:
@@ -132,6 +142,21 @@ import-schema:
           items:
             type: string
           required: true
+
+  # APM compilation target (which agent harness layouts to deploy)
+  target:
+    type: string
+    required: false
+    default: all
+    description: >
+      Target harness(es) for APM compilation. Controls which agent config
+      directories are generated in the bundle. Single token or comma-separated
+      list. Valid tokens: copilot, claude, cursor, codex, opencode, gemini,
+      windsurf, agent-skills, all. Default: all (every supported harness).
+      Set this to match the engine your gh-aw workflow targets for smaller,
+      faster bundles. The shared workflow runs apm-action in isolated mode,
+      so any apm.yml in the consumer repo is intentionally ignored -- this
+      input is the sole target signal.
 
 jobs:
   apm-prep:
@@ -262,7 +287,7 @@ jobs:
           isolated: 'true'
           pack: 'true'
           archive: 'true'
-          target: all
+          target: ${{ github.aw.import-inputs.target || 'all' }}
           working-directory: /tmp/gh-aw/apm-workspace
       - name: Upload APM bundle artifact
         if: success()

--- a/.github/workflows/triage-panel.lock.yml
+++ b/.github/workflows/triage-panel.lock.yml
@@ -1086,7 +1086,7 @@ jobs:
           dependencies: ${{ steps.list.outputs.deps }}
           isolated: "true"
           pack: "true"
-          target: all
+          target: ${{ github.aw.import-inputs.target || 'all' }}
           working-directory: /tmp/gh-aw/apm-workspace
       - name: Upload APM bundle artifact
         if: success()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `shared/apm.md` gh-aw shared workflow exposes a `target:` import input (default `all`) so consumer workflows can ship slim, single-harness bundles instead of always packing every layout. (#TBD)
+
 ## [0.12.4] - 2026-05-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `shared/apm.md` gh-aw shared workflow exposes a `target:` import input (default `all`) so consumer workflows can ship slim, single-harness bundles instead of always packing every layout. (#TBD)
+- `shared/apm.md` gh-aw shared workflow exposes a `target:` import input (default `all`) so consumer workflows can ship slim, single-harness bundles instead of always packing every layout. (#1184)
 
 ## [0.12.4] - 2026-05-07
 

--- a/uv.lock
+++ b/uv.lock
@@ -179,7 +179,7 @@ wheels = [
 
 [[package]]
 name = "apm-cli"
-version = "0.12.3"
+version = "0.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## TL;DR

`shared/apm.md` (the gh-aw shared workflow) hardcoded `target: all` on its `apm-action` call, forcing every consumer bundle to ship all 8 harness layouts (`.github/`, `.claude/`, `.cursor/`, `.opencode/`, `.codex/`, `.gemini/`, `.windsurf/`, `.agents/`) regardless of which engine actually consumed it. This PR exposes `target` as an `import-schema` input (default `all`) so consumers can opt into slim, single-harness bundles. Zero behavior change for any existing import.

## Problem (WHY)

The shared workflow runs `apm-action` with `isolated: 'true'` and `target: all` baked into the Pack step (`.github/workflows/shared/apm.md` was at line 265). Two consequences:

1. **Bundle bloat.** Every workflow that imports `shared/apm.md` packs every harness's deploy tree into the artifact, even when the agent step downstream only consumes one. For a single-engine gh-aw workflow this is roughly 8x more files than necessary.
2. **No consumer knob.** Even consumers who knew exactly which harness they wanted had no way to express it through `shared/apm.md`'s `import-schema` -- they would have had to fork the file.

The natural follow-up question -- "why not honor the consumer repo's `apm.yml target:`?" -- doesn't apply: `isolated: 'true'` makes `apm-action` ignore any consumer apm.yml entirely (it generates a synthetic one from the inline `dependencies:` input, working in `/tmp/gh-aw/apm-workspace`). There is no apm.yml to honor in this code path. The shared workflow is the sole signal, so it needs an input.

## Approach (WHAT)

Add a single optional `target` input to `import-schema`, default `all`, and thread it into the Pack step via `${{ github.aw.import-inputs.target || 'all' }}`.

- **Name:** `target` (singular) -- matches the `apm.yml` key, the `apm-action` input, and the `--target` CLI flag.
- **Type:** `string` (CSV when multiple targets are needed) -- matches `apm-action`'s native format. Avoids forcing a YAML-array-to-CSV conversion in the workflow.
- **Default:** `all` -- byte-for-byte back-compat with the previous hardcoded value. No existing import changes behavior.
- **Fallback expression:** the `|| 'all'` belt-and-suspenders covers gh-aw versions that emit empty strings rather than honoring `default:` in the schema. Keeps the contract deterministic regardless of which gh-aw version compiles the workflow.

### Rejected alternatives

| Option | Rejected because |
|---|---|
| Default to empty + fail loudly | Breaks every existing import. Bad DevX. |
| Auto-derive target by scanning the consumer checkout | The `apm` job runs with `permissions: {}` and no checkout; adding one costs ~15s for a heuristic the consumer can replace with one line. |
| Auto-derive from a `engine:` sibling input | Requires a gh-aw contract change (engine isn't currently passed through). Phase 2, separate issue in microsoft/gh-aw. |
| Per-app-group `target:` in the `apps[]` schema | No user has asked. A single workflow-level target is sufficient. |
| Pre-validation step in shared/apm.md | Duplicates CLI logic, will drift. The CLI is the single validator and produces a clear error on bad tokens. |

## Implementation (HOW)

Three surgical edits to `.github/workflows/shared/apm.md`:

1. **Add usage example #4** to the header comment block illustrating slim-bundle opt-in.
2. **Add `target` to `import-schema`** with description text enumerating valid tokens (`copilot`, `claude`, `cursor`, `codex`, `opencode`, `gemini`, `windsurf`, `agent-skills`, `all`) and noting the isolated-mode contract (apm.yml is intentionally ignored).
3. **Replace `target: all`** in the Pack step with `target: ${{ github.aw.import-inputs.target || 'all' }}`.

Recompile via `gh aw compile` regenerates the two consuming lock workflows (`pr-review-panel.lock.yml`, `triage-panel.lock.yml`) so the new expression ships in CI. CHANGELOG entry added under `[Unreleased]`.

## Trade-offs

- **Default `all` keeps the bundle-bloat default.** This is intentional for back-compat. Slim bundles are now an opt-in. Phase 2 (gh-aw side) makes them zero-config for single-engine workflows.
- **No checkout for auto-detect.** The shared workflow stays cheap. Consumers who want auto-detection can write `target: copilot` (or whichever) explicitly -- one line.
- **The `default: all` in import-schema is documentation-grade.** The expression-level `|| 'all'` is what actually guarantees the runtime behavior. We accept the small redundancy because gh-aw's import-input default substitution semantics vary across versions.

## Validation

- `uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/` -- silent.
- `gh aw compile` -- 5 workflows recompiled, 0 errors. The two lock files that import `shared/apm.md` now contain `target: ${{ github.aw.import-inputs.target || 'all' }}`. At runtime, undefined `github.aw.import-inputs.target` evaluates to empty in `${{ }}` expressions, so the `||` fallback yields `'all'` -- preserving the previous behavior exactly.

## How to test

1. **Existing consumer (back-compat):** the `pr-review-panel.lock.yml` / `triage-panel.lock.yml` workflows that import `shared/apm.md` without setting `target:` continue to receive `target: all`. No change in CI behavior expected.
2. **New consumer (opt-in):** add `target: copilot` to a `with:` block and recompile -- the `target:` value flows through to `apm-action` and the resulting bundle should contain only `.github/` (not the other 7 harness trees).

## Follow-up

Open a sibling issue in `microsoft/gh-aw`: *"Pass workflow engine as `target` to shared/apm.md"* -- gh-aw's compile step knows the engine declared in the workflow front-matter and could inject `target: <engine>` automatically when the consumer omits the field. Makes slim bundles zero-config for single-engine workflows.
