### PR TITLE
fix(shared/apm.md): drop || 'all' fallback so gh-aw substitutes target (#1185)

### DIFF
--- a/.github/workflows/pr-review-panel.lock.yml
+++ b/.github/workflows/pr-review-panel.lock.yml
@@ -1018,7 +1018,7 @@ jobs:
           dependencies: ${{ steps.list.outputs.deps }}
           isolated: "true"
           pack: "true"
-          target: ${{ github.aw.import-inputs.target || 'all' }}
+          target: all
           working-directory: /tmp/gh-aw/apm-workspace
       - name: Upload APM bundle artifact
         if: success()

--- a/.github/workflows/shared/apm.md
+++ b/.github/workflows/shared/apm.md
@@ -287,7 +287,7 @@ jobs:
           isolated: 'true'
           pack: 'true'
           archive: 'true'
-          target: ${{ github.aw.import-inputs.target || 'all' }}
+          target: ${{ github.aw.import-inputs.target }}
           working-directory: /tmp/gh-aw/apm-workspace
       - name: Upload APM bundle artifact
         if: success()

--- a/.github/workflows/triage-panel.lock.yml
+++ b/.github/workflows/triage-panel.lock.yml
@@ -1086,7 +1086,7 @@ jobs:
           dependencies: ${{ steps.list.outputs.deps }}
           isolated: "true"
           pack: "true"
-          target: ${{ github.aw.import-inputs.target || 'all' }}
+          target: all
           working-directory: /tmp/gh-aw/apm-workspace
       - name: Upload APM bundle artifact
         if: success()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `shared/apm.md` gh-aw shared workflow exposes a `target:` import input (default `all`) so consumer workflows can ship slim, single-harness bundles instead of always packing every layout. (#1184)
 
+### Fixed
+
+- `shared/apm.md` no longer wraps the `target` input in a `|| 'all'` fallback. The defensive expression broke gh-aw's bare-expression substitution regex, causing consumer-supplied `target:` values to be silently dropped; the `import-schema` default already covers the omitted-input case. (#1185)
+
 ## [0.12.4] - 2026-05-07
 
 ### Fixed


### PR DESCRIPTION
Closes #1185.

## Problem

#1184 introduced a defensive `|| 'all'` fallback on the `target` import:

```yaml
target: ${{ github.aw.import-inputs.target || 'all' }}
```

That broke gh-aw's substitution. The `importInputsExprRegex` in `pkg/parser/import_field_extractor.go` only matches **bare** `${{ github.aw.import-inputs.X }}`. Anything inside the brackets (like `|| 'all'`) makes the regex skip substitution entirely, so the unresolved expression was emitted verbatim into the consuming lock workflow. At runtime `with.target` was empty, which `apm-action` then interpreted as `all` -- silently ignoring whatever the consumer passed via `with: target: copilot`.

## Fix

Drop the fallback. The schema default `default: all` declared on the `target` input is already applied by gh-aw's `applyImportSchemaDefaultsFromFrontmatter` **before** substitution, so omitted-input behaviour is preserved without the belt-and-suspenders.

```yaml
target: ${{ github.aw.import-inputs.target }}
```

## Validation

Recompiled with `gh aw compile` pinned to v0.71.5 (matching the `compiler_version` stamped in current lock metadata). Diff is exactly 3 files / 3 lines:

- `shared/apm.md` -- 1 line, drops the fallback
- `pr-review-panel.lock.yml` -- gh-aw substituted the schema default in place; line now reads literal `target: all`
- `triage-panel.lock.yml` -- same

Consumers who pass `with: target: copilot` will now get `target: copilot` substituted into their lock workflow.

## Follow-up (not in this PR)

It would be nice for `gh-aw` upstream to make `importInputsExprRegex` tolerant of GHA-idiom `||` fallbacks, since this is a footgun. Worth filing in `githubnext/gh-aw`.