### PR TITLE
fix(install,test): exclude cowork from --target all + stabilize defer-start timer test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `shared/apm.md` no longer wraps the `target` input in a `|| 'all'` fallback. The defensive expression broke gh-aw's bare-expression substitution regex, causing consumer-supplied `target:` values to be silently dropped; the `import-schema` default already covers the omitted-input case. (#1185)
-- `apm install --target all` no longer enumerates the experimental `copilot-cowork` target, which was crashing project-scope installs with a "requires --global" error and made `gh aw` workflows that pin `target: all` unusable. (#PR_NUMBER)
-- Stabilized `test_install_over_defer_threshold_starts_live_once` on slow CI runners by joining the deferred-start timer thread instead of relying on a 100ms grace window. (#PR_NUMBER)
+- `apm install --target all` no longer enumerates the experimental `copilot-cowork` target, which was crashing project-scope installs with a "requires --global" error and made `gh aw` workflows that pin `target: all` unusable. (#1191)
+- Stabilized `test_install_over_defer_threshold_starts_live_once` on slow CI runners by joining the deferred-start timer thread instead of relying on a 100ms grace window. (#1191)
 
 ## [0.12.4] - 2026-05-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `shared/apm.md` no longer wraps the `target` input in a `|| 'all'` fallback. The defensive expression broke gh-aw's bare-expression substitution regex, causing consumer-supplied `target:` values to be silently dropped; the `import-schema` default already covers the omitted-input case. (#1185)
+- `apm install --target all` no longer enumerates the experimental `copilot-cowork` target, which was crashing project-scope installs with a "requires --global" error and made `gh aw` workflows that pin `target: all` unusable. (#PR_NUMBER)
+- Stabilized `test_install_over_defer_threshold_starts_live_once` on slow CI runners by joining the deferred-start timer thread instead of relying on a 100ms grace window. (#PR_NUMBER)
 
 ## [0.12.4] - 2026-05-07
 

--- a/src/apm_cli/integration/targets.py
+++ b/src/apm_cli/integration/targets.py
@@ -775,14 +775,24 @@ def active_targets(
         for t in raw:
             canonical = "copilot" if t in ("copilot", "vscode", "agents") else t
             if canonical == "all":
-                # Return all targets regardless of flag gating.
                 # Exclude explicit-only targets (agent-skills) -- they must
                 # be requested individually.
-                # The project-scope gate in phases/targets.py and
-                # for_scope() handle user-observable blocking.
-                from apm_cli.core.target_detection import EXPLICIT_ONLY_TARGETS
+                # Exclude experimental targets (copilot-cowork) -- they must
+                # be opted into explicitly via `--target copilot-cowork`,
+                # matching the documented contract on EXPERIMENTAL_TARGETS in
+                # core/target_detection.py. Including cowork in `all` for
+                # project scope hits the unconditional project-scope gate in
+                # phases/targets.py and aborts the entire install (#1185 b).
+                from apm_cli.core.target_detection import (
+                    EXPERIMENTAL_TARGETS,
+                    EXPLICIT_ONLY_TARGETS,
+                )
 
-                return [p for p in KNOWN_TARGETS.values() if p.name not in EXPLICIT_ONLY_TARGETS]
+                return [
+                    p
+                    for p in KNOWN_TARGETS.values()
+                    if p.name not in EXPLICIT_ONLY_TARGETS and p.name not in EXPERIMENTAL_TARGETS
+                ]
             profile = KNOWN_TARGETS.get(canonical)
             if profile and _flag_gated(profile) and profile.name not in seen:
                 seen.add(profile.name)

--- a/tests/unit/integration/test_copilot_cowork_target.py
+++ b/tests/unit/integration/test_copilot_cowork_target.py
@@ -160,17 +160,29 @@ class TestActiveTargetsGating:
         assert results == []
 
     def test_cowork_absent_from_all_when_flag_off(self, tmp_path: Path, inject_config: Any) -> None:
+        """`--target all` (project scope) must NOT include cowork.
+
+        cowork is in EXPERIMENTAL_TARGETS; per the documented contract in
+        core/target_detection.py it is opt-in only -- explicit
+        ``--target copilot-cowork`` -- and never resolved via ``all``.
+        Including it in the project-scope ``all`` set hits the
+        project-scope gate in phases/targets.py and aborts the install.
+        """
         inject_config({"experimental": {"copilot_cowork": False}})
         results = active_targets(tmp_path, explicit_target="all")
         names = [t.name for t in results]
-        # "all" returns all targets regardless of flag gating
-        # but explicit_target="copilot-cowork" with flag off returns []
-        # The "all" path returns list(KNOWN_TARGETS.values()) which
-        # includes cowork. This is documented: "all" bypasses flag gate.
-        # So cowork IS in the "all" set even when flag is off.
-        # This matches the implementation comment:
-        # "Return all targets regardless of flag gating."
-        assert "copilot-cowork" in names
+        assert "copilot-cowork" not in names
+
+    def test_cowork_absent_from_all_when_flag_on(self, tmp_path: Path, inject_config: Any) -> None:
+        """`--target all` (project scope) excludes cowork even when the
+        experimental flag is enabled. cowork is user-scope only and the
+        project-scope gate would error otherwise; ``all`` honors the
+        documented EXPERIMENTAL_TARGETS exclusion regardless of flag.
+        """
+        inject_config({"experimental": {"copilot_cowork": True}})
+        results = active_targets(tmp_path, explicit_target="all")
+        names = [t.name for t in results]
+        assert "copilot-cowork" not in names
 
     def test_cowork_absent_when_flag_on_resolver_returns_none(
         self, tmp_path: Path, inject_config: Any

--- a/tests/unit/integration/test_targets.py
+++ b/tests/unit/integration/test_targets.py
@@ -76,10 +76,17 @@ class TestActiveTargets:
         assert [t.name for t in targets] == ["claude"]
 
     def test_explicit_all_returns_every_known_target(self):
-        from apm_cli.core.target_detection import EXPLICIT_ONLY_TARGETS
+        from apm_cli.core.target_detection import (
+            EXPERIMENTAL_TARGETS,
+            EXPLICIT_ONLY_TARGETS,
+        )
 
         targets = active_targets(self.root, explicit_target="all")
-        assert len(targets) == len(KNOWN_TARGETS) - len(EXPLICIT_ONLY_TARGETS)
+        expected = len(KNOWN_TARGETS) - len(EXPLICIT_ONLY_TARGETS) - len(EXPERIMENTAL_TARGETS)
+        assert len(targets) == expected
+        names = [t.name for t in targets]
+        assert "copilot-cowork" not in names
+        assert "agent-skills" not in names
 
     def test_explicit_vscode_alias(self):
         targets = active_targets(self.root, explicit_target="vscode")
@@ -193,17 +200,25 @@ class TestActiveTargets:
         assert [t.name for t in targets] == ["copilot"]
 
     def test_explicit_list_with_all_returns_every_known_target(self):
-        from apm_cli.core.target_detection import EXPLICIT_ONLY_TARGETS
+        from apm_cli.core.target_detection import (
+            EXPERIMENTAL_TARGETS,
+            EXPLICIT_ONLY_TARGETS,
+        )
 
         targets = active_targets(self.root, explicit_target=["all"])
-        assert len(targets) == len(KNOWN_TARGETS) - len(EXPLICIT_ONLY_TARGETS)
+        expected = len(KNOWN_TARGETS) - len(EXPLICIT_ONLY_TARGETS) - len(EXPERIMENTAL_TARGETS)
+        assert len(targets) == expected
 
     def test_explicit_list_all_mixed_returns_every_known_target(self):
         """'all' anywhere in the list wins."""
-        from apm_cli.core.target_detection import EXPLICIT_ONLY_TARGETS
+        from apm_cli.core.target_detection import (
+            EXPERIMENTAL_TARGETS,
+            EXPLICIT_ONLY_TARGETS,
+        )
 
         targets = active_targets(self.root, explicit_target=["claude", "all"])
-        assert len(targets) == len(KNOWN_TARGETS) - len(EXPLICIT_ONLY_TARGETS)
+        expected = len(KNOWN_TARGETS) - len(EXPLICIT_ONLY_TARGETS) - len(EXPERIMENTAL_TARGETS)
+        assert len(targets) == expected
 
     def test_explicit_list_all_unknown_returns_empty(self):
         """When the parser is bypassed and all tokens are unknown, the

--- a/tests/unit/test_install_tui.py
+++ b/tests/unit/test_install_tui.py
@@ -132,12 +132,16 @@ class TestDeferredStart:
             with patch.object(InstallTui, "_defer_start", autospec=True) as mock_defer:
                 with tui:
                     # Sleep slightly longer than the defer window so the
-                    # timer fires before __exit__ cancels it.
+                    # timer fires before __exit__ cancels it, then join the
+                    # Timer thread to deterministically wait for the
+                    # callback to complete. Without the join this test is
+                    # flaky on busy CI runners where threading.Timer
+                    # scheduling can slip past a fixed grace window.
                     time.sleep(_DEFER_SHOW_S + 0.10)
-                # Either the timer fired (preferred) or it was cancelled.
-                # We assert at most one call -- never multiple.
-                assert mock_defer.call_count <= 1
-                # In the typical case the timer fires; assert it did.
+                    if tui._timer is not None:
+                        tui._timer.join(timeout=2.0)
+                # The timer must have fired exactly once (deterministic
+                # via the join above).
                 assert mock_defer.call_count == 1
 
 


### PR DESCRIPTION
## TL;DR

Two unrelated CI failures, one PR (per request):

1. **gh-aw apm self-check** ([run 25511043293](https://github.com/microsoft/apm/actions/runs/25511043293/job/74869773153)) -- `apm install --target all` exited 1 with `[x] The 'copilot-cowork' target requires --global (user scope)`. Project-scope `all` was leaking the experimental cowork target.
2. **macOS x86_64 unit build** ([run 25496089562](https://github.com/microsoft/apm/actions/runs/25496089562/job/74705413425)) -- `test_install_over_defer_threshold_starts_live_once` flaked under pytest-xdist with `assert mock_defer.call_count == 1` failing on `0 == 1`.

## Problem (WHY)

### Failure A -- cowork-in-all

`active_targets()` for `explicit_target == "all"` (project scope) returned `KNOWN_TARGETS minus EXPLICIT_ONLY_TARGETS`. That still includes `copilot-cowork`, which lives in `EXPERIMENTAL_TARGETS`, not `EXPLICIT_ONLY_TARGETS`. The downstream project-scope gate in `phases/targets.py` then unconditionally `raise SystemExit(1)` because cowork is user-scope-only.

This contradicts the documented contract on `EXPERIMENTAL_TARGETS` in `core/target_detection.py:319-322`:

> They are NOT included in the `parse_target_arg("all")` expansion -- explicit opt-in only.

Net effect: any consumer of `shared/apm.md` that left `target:` at its default `all` (which includes the apm self-check workflow) crashed at install time. This was the root cause of the gh-aw self-check red after merging #1186.

A pre-existing test, `test_cowork_absent_from_all_when_flag_off`, was *named* like a contract-asserting test but its body asserted `"copilot-cowork" in names` with a comment claiming "all bypasses flag gate". That comment was wrong and contradicted the documented exclusion.

### Failure B -- flaky defer test

`test_install_over_defer_threshold_starts_live_once` patches `InstallTui._defer_start`, enters `with tui:`, sleeps `_DEFER_SHOW_S + 0.10s` (350ms), exits, then asserts the mock fired exactly once. Under parallel pytest-xdist on macOS x86_64, `threading.Timer` callback scheduling can slip past the 100ms grace before `__exit__` cancels the timer.

## Approach (WHAT)

1. **Filter `EXPERIMENTAL_TARGETS` out of `active_targets()` `all` expansion** -- match the documented contract; cowork remains opt-in via `--target copilot-cowork --global`.
2. **Flip the misleading test** to assert the correct behaviour, and add a parallel `flag_on` case proving project-scope `all` still excludes cowork even when the experimental flag is enabled (cowork is structurally user-scope only).
3. **Update three counting tests in `test_targets.py`** to subtract `EXPERIMENTAL_TARGETS` from the expected `all` cardinality.
4. **Make the defer test deterministic** by joining `tui._timer` with a 2s timeout before the `with` block exits. The callback is now guaranteed complete before the assertion runs.

## Implementation (HOW)

- `src/apm_cli/integration/targets.py` -- `active_targets()` "all" branch now excludes both `EXPLICIT_ONLY_TARGETS` and `EXPERIMENTAL_TARGETS`. The user-scope sibling (`active_targets_user_scope`) was already correct via `_flag_gated`; not touched.
- `tests/unit/integration/test_copilot_cowork_target.py` -- flipped `test_cowork_absent_from_all_when_flag_off` (and added flag-on case); both now assert `"copilot-cowork" not in names`.
- `tests/unit/integration/test_targets.py` -- three `len(KNOWN_TARGETS) - len(EXPLICIT_ONLY_TARGETS)` assertions now also subtract `len(EXPERIMENTAL_TARGETS)`; added explicit `not in` checks.
- `tests/unit/test_install_tui.py` -- added `tui._timer.join(timeout=2.0)` after the sleep, before the implicit `__exit__`.
- `CHANGELOG.md` -- two `### Fixed` lines under `[Unreleased]`.

## Validation

```
uv run --extra dev pytest tests/unit/test_install_tui.py tests/unit/integration/test_copilot_cowork_target.py tests/unit/integration/test_targets.py -x
=> 107 passed in 3.47s

uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/
=> All checks passed!  705 files already formatted
```

`gh aw compile` produced no diff against `origin/main` -- this PR ships no workflow churn.

## Trade-offs

- Cowork users who relied on `--target all` resolving cowork at project scope are unaffected: that path was always broken (it crashed the install). The supported path (`--target copilot-cowork --global`) is unchanged.
- The `Timer.join(timeout=2.0)` adds at most ~0ms in the fast path (callback already done) and at most 2s if the runner is wedged. The pre-existing `assert mock_defer.call_count == 1` semantic is preserved.

Closes #1185 (b -- the gh-aw self-check half).