### PR TITLE
fix(triage-panel): paginate scheduled sweep oldest-first via MCP

### DIFF
--- a/.github/workflows/triage-panel.md
+++ b/.github/workflows/triage-panel.md
@@ -270,17 +270,42 @@ fetch the full body again -- the cap is the cap.
 
 ### SCHEDULED_SWEEP
 
-Find up to 10 untriaged open issues, oldest first, excluding bots:
+Find up to 10 untriaged open issues, **oldest first**, excluding
+bots. The candidate list lives in the GitHub MCP server -- shell `gh`
+is not authenticated, so use the MCP `list_issues` tool. The MCP
+`labels` filter only does positive matches (it cannot exclude
+`status/triaged`), so paginate oldest-first and filter in your
+reasoning step:
 
-```bash
-gh issue list \
-  --repo "${{ github.repository }}" \
-  --state open \
-  --limit 200 \
-  --json number,title,author,labels,locked,createdAt,body,id
+```
+list_issues(
+  owner: "microsoft",
+  repo:  "apm",
+  state: "OPEN",
+  orderBy:   "CREATED_AT",
+  direction: "ASC",
+  perPage:   30,
+)
 ```
 
-In your reasoning step (no shell required), filter the result:
+**Pagination is mandatory.** A single page of 30 will commonly be
+mostly already-triaged issues. Keep calling `list_issues` with
+`after: <endCursor>` from the previous response's `pageInfo` until
+**either**:
+
+- you have collected at least **10 eligible candidates** after
+  applying the filters below, **or**
+- the API reports `hasNextPage: false` (queue exhausted), **or**
+- you have fetched **5 pages** (150 issues) without finding 10
+  eligibles -- a healthy sweep is allowed to be small.
+
+Do NOT stop after the first page just because the first page
+contains few eligibles -- the oldest untriaged issues are exactly
+the ones we most want to drain. If you cannot read a single page's
+JSON in one tool response, request a smaller `perPage` (e.g. 15) and
+keep paginating.
+
+In your reasoning step (no shell required), filter each fetched page:
 
 - Drop any issue where `author.is_bot` is true or `author.login`
   matches common bot patterns (`*[bot]`, `dependabot*`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `shared/apm.md` no longer wraps the `target` input in a `|| 'all'` fallback. The defensive expression broke gh-aw's bare-expression substitution regex, causing consumer-supplied `target:` values to be silently dropped; the `import-schema` default already covers the omitted-input case. (#1185)
 - `apm install --target all` no longer enumerates the experimental `copilot-cowork` target, which was crashing project-scope installs with a "requires --global" error and made `gh aw` workflows that pin `target: all` unusable. (#1191)
 - Stabilized `test_install_over_defer_threshold_starts_live_once` on slow CI runners by joining the deferred-start timer thread instead of relying on a 100ms grace window. (#1191)
+- `triage-panel` scheduled sweep now paginates the candidate query oldest-first via the GitHub MCP `list_issues` tool instead of a single 200-issue page, so daily runs actually drain the untriaged backlog rather than processing one issue per cron tick.
 
 ## [0.12.4] - 2026-05-07
 


### PR DESCRIPTION
## TL;DR

The `triage-panel` scheduled sweep has been processing **one issue per daily cron run** instead of the documented `MAX_ISSUES_PER_RUN=10`, silently letting the untriaged backlog grow. Root cause is a prompt bug in `triage-panel.md`, not anything in the engine. Fix is a `.md`-only edit (lockfile imports the prompt at runtime).

## Problem (WHY)

Maintainer flagged: "I have not seen [the panel] labelling issues lately."

Investigation:

- 13 currently-open, human-authored, untriaged issues: #1120, #1122, #1130, #1138, #1144, #1151, #1156, #1157, #1166, #1168, #1177, #1187, #1188.
- Last successful sweep (2026-05-06, [run 25437842915](https://github.com/microsoft/apm/actions/runs/25437842915)) labelled **exactly one** issue (#1161) and exited with:

  > Sweep complete. One untriaged issue found and processed... All other open issues were already `status/triaged` or authored by bots (skipped).

  -- which is false.

- Today's scheduled run [25496929817](https://github.com/microsoft/apm/actions/runs/25496929817) crashed on the `cowork-in-all` bug (already fixed by #1192).

From the agent stdio trace of the 2026-05-06 run:

```
list_issues (MCP: github) · owner: "microsoft", repo: "apm", state: "OPEN",
  perPage: 100, orderBy...
  Output too large to read at once (140.7 KB). Saved to: /tmp/...
```

Then:

> Now I have all context to run the triage panel. **BATCH_ALLOW_LIST = [1161]**.

So the agent:

1. Made one MCP `list_issues` call (~140 KB response).
2. Couldn't read the response in one tool turn.
3. Picked `BATCH_ALLOW_LIST = [1161]` from the head of whatever slice it did see.
4. Never paginated. Never adjusted `perPage`. Never re-ordered oldest-first.

Why the agent went off-script: the SCHEDULED_SWEEP prompt example showed `gh issue list --limit 200`, but `shared/apm.md` tells the agent that shell `gh` is unauthenticated and to use the GitHub MCP `list_issues` tool. The MCP tool defaults to newest-first and lacks "exclude label" semantics, neither of which the prompt addresses.

## Approach (WHAT)

Rewrite the SCHEDULED_SWEEP "Step 1: Gather candidates" subsection in `.github/workflows/triage-panel.md` to:

- Drop the misleading `gh issue list` example.
- Specify the actual MCP call: `list_issues` with `orderBy: CREATED_AT, direction: ASC, perPage: 30`.
- Mandate pagination via `after: <endCursor>` until **either** 10 eligibles found, **or** `hasNextPage: false`, **or** 5 pages scanned (a healthy sweep is allowed to be small).
- Tell the agent to drop `perPage` to 15 if a single page can't be read in one tool response.

The lockfile uses `{{#runtime-import .github/workflows/triage-panel.md}}` to pull the prompt at runtime, so `gh aw compile` produces zero lockfile diff. Verified locally.

## Validation

- `gh aw compile triage-panel` -> 0 errors, 0 warnings, 0 lockfile diff.
- Diff is contained to `.github/workflows/triage-panel.md` + a CHANGELOG line.
- Manually dispatched the panel ([run 25514565839](https://github.com/microsoft/apm/actions/runs/25514565839)) **without** this fix to validate #1192 in isolation. Next scheduled cron + this PR will validate the throughput fix end-to-end.

## Trade-offs

- The 5-page (150-issue) cap is a defensive ceiling against runaway pagination if the queue is huge. With a real backlog around 13, this is comfortably above what's needed.
- We could have added a hard "exit non-zero if BATCH_ALLOW_LIST has fewer than `min(N_eligibles, 10)` entries" check, but that would risk noisy CI failures from edge cases. Prompt clarity is the cheaper fix.
- This does not change the cost ceiling: the cron cap is still 10 runs/day, and `safe-output-tools` still cap at `add_labels(max:70)`, which is ~10 issues at 7 labels each.

## How to test

After merge, watch the next daily scheduled run of `.github/workflows/triage-panel.lock.yml`. Expected: the agent processes up to 10 untriaged issues (oldest first) in a single sweep, draining the current 13-issue queue across two cron ticks.

