### PR TITLE
fix(triage-panel): use search_issues with -label:status/triaged for sweep

### DIFF
--- a/.github/workflows/triage-panel.md
+++ b/.github/workflows/triage-panel.md
@@ -272,49 +272,36 @@ fetch the full body again -- the cap is the cap.
 
 Find up to 10 untriaged open issues, **oldest first**, excluding
 bots. The candidate list lives in the GitHub MCP server -- shell `gh`
-is not authenticated, so use the MCP `list_issues` tool. The MCP
-`labels` filter only does positive matches (it cannot exclude
-`status/triaged`), so paginate oldest-first and filter in your
-reasoning step:
+is not authenticated, so use the MCP `search_issues` tool with a
+server-side filter that excludes already-triaged issues:
 
 ```
-list_issues(
-  owner: "microsoft",
-  repo:  "apm",
-  state: "OPEN",
-  orderBy:   "CREATED_AT",
-  direction: "ASC",
-  perPage:   30,
+search_issues(
+  query: "repo:microsoft/apm is:open is:issue -label:status/triaged sort:created-asc",
+  perPage: 30,
 )
 ```
 
-**Pagination is mandatory.** A single page of 30 will commonly be
-mostly already-triaged issues. Keep calling `list_issues` with
-`after: <endCursor>` from the previous response's `pageInfo` until
-**either**:
+**Why `search_issues` and not `list_issues`:** GitHub Search supports
+the `-label:status/triaged` negation, so the response contains ONLY
+the candidates we care about. With `list_issues` we'd have to
+paginate the entire open-issue queue and filter the triaged label
+client-side -- and the MCP gateway's DIFC integrity filter silently
+drops responses from non-collaborator authors mid-page, which makes
+"is the next page worth fetching?" reasoning unreliable. The search
+API sidesteps both problems.
 
-- you have collected at least **10 eligible candidates** after
-  applying the filters below, **or**
-- the API reports `hasNextPage: false` (queue exhausted), **or**
-- you have fetched **5 pages** (150 issues) without finding 10
-  eligibles -- a healthy sweep is allowed to be small.
+The `sort:created-asc` qualifier returns oldest first, so the first
+30 results are the oldest untriaged issues -- exactly the queue we
+want to drain. **One page is enough.** If `total_count` is greater
+than 30 the extras roll to tomorrow's sweep; do not paginate.
 
-Do NOT stop after the first page just because the first page
-contains few eligibles -- the oldest untriaged issues are exactly
-the ones we most want to drain. If you cannot read a single page's
-JSON in one tool response, request a smaller `perPage` (e.g. 15) and
-keep paginating.
-
-In your reasoning step (no shell required), filter each fetched page:
+In your reasoning step (no shell required), filter the response:
 
 - Drop any issue where `author.is_bot` is true or `author.login`
   matches common bot patterns (`*[bot]`, `dependabot*`,
   `github-actions*`, `renovate*`).
 - Drop any issue where `locked` is true.
-- Drop any issue whose `labels` contains `status/triaged`. That label
-  is the explicit "this issue has been through agentic triage" signal.
-  A maintainer can re-trigger triage by removing it (sweep re-picks)
-  or by applying `status/needs-triage` (fast path).
 - Drop any issue with an empty or template-only body.
 - **Spam-shape filter** (drop AND do NOT mark `status/triaged` -- they
   stay in queue for human review):
@@ -329,8 +316,14 @@ In your reasoning step (no shell required), filter each fetched page:
   log (no comment, no labels, no triage); a maintainer who reviews the
   issue can manually apply `status/needs-triage` to force a panel run.
 
-After dropping bots/locked/triaged/template/spam, sort the remainder
-by `createdAt` ascending.
+Note: `status/triaged` exclusion is already done by the search query
+above, so you don't need to re-check that label. A maintainer can
+re-trigger triage by removing the label (sweep re-picks the issue) or
+by applying `status/needs-triage` (which fires the fast path).
+
+After dropping bots/locked/template/spam, the remainder is already
+sorted oldest-first by the `sort:created-asc` qualifier in the search
+query.
 
 - **Per-author quota**: when picking the final batch, take at most
   **2 issues per distinct author** per sweep. If author X has 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `shared/apm.md` no longer wraps the `target` input in a `|| 'all'` fallback. The defensive expression broke gh-aw's bare-expression substitution regex, causing consumer-supplied `target:` values to be silently dropped; the `import-schema` default already covers the omitted-input case. (#1185)
 - `apm install --target all` no longer enumerates the experimental `copilot-cowork` target, which was crashing project-scope installs with a "requires --global" error and made `gh aw` workflows that pin `target: all` unusable. (#1191)
 - Stabilized `test_install_over_defer_threshold_starts_live_once` on slow CI runners by joining the deferred-start timer thread instead of relying on a 100ms grace window. (#1191)
-- `triage-panel` scheduled sweep now paginates the candidate query oldest-first via the GitHub MCP `list_issues` tool instead of a single 200-issue page, so daily runs actually drain the untriaged backlog rather than processing one issue per cron tick.
+- `triage-panel` scheduled sweep now paginates the candidate query oldest-first via the GitHub MCP `list_issues` tool instead of a single 200-issue page, so daily runs actually drain the untriaged backlog rather than processing one issue per cron tick. (#1193)
+- `triage-panel` scheduled sweep switches the candidate query from `list_issues`+prose-driven pagination to `search_issues` with `-label:status/triaged sort:created-asc`, so untriaged candidates are filtered server-side; the previous approach silently noop'd because the MCP gateway DIFC filter dropped non-collaborator issues mid-page and the agent inferred a false `hasNextPage:false`.
 
 ## [0.12.4] - 2026-05-07
 


### PR DESCRIPTION
## TL;DR

`#1193` (paginate `list_issues` oldest-first) **did not fix the throughput problem**. The first dispatch on the fixed `main` (run [25514877383](https://github.com/microsoft/apm/actions/runs/25514877383)) noop'd the sweep — 0 issues triaged — while 11 untriaged issues sat in the queue. This PR replaces the prose-driven pagination loop with a server-side `search_issues` query that returns only untriaged candidates.

## Why #1193 failed (RCA from MCP logs)

Two compounding effects sabotaged the pagination approach:

**1. MCP gateway DIFC filter silently drops non-collaborator issues mid-page.**
`/tmp/fixed-agent/mcp-logs/rpc-messages.jsonl` shows 17 of 30 returned issues were filtered with messages like:

> `Resource 'issue:microsoft/apm#20' has lower integrity than agent requires. The agent cannot read data with integrity below "approved".`

The agent saw 13 of 30 items even though the underlying API returned 30. This breaks any "did I get a full page?" heuristic.

**2. The LLM hallucinated `hasNextPage: false`.**
The actual MCP response (75 KB into the payload) clearly contained:

> `pageInfo: {"hasNextPage":true, "hasPreviousPage":false, "startCursor":"...", "endCursor":"..."}`

But the agent's final output said:

> "Zero untriaged candidates found across the full open-issue queue (single page, **hasNextPage implicitly false with 13 of 30 requested**)."

It ignored the explicit field and invented an inference from the short count. Prose pagination instructions cannot recover from this — the LLM is unreliable at multi-page loops driven by deeply-nested JSON fields.

## Fix

Replace `list_issues`-with-prose-pagination with **`search_issues`** using a server-side filter:

```
search_issues(
  query: "repo:microsoft/apm is:open is:issue -label:status/triaged sort:created-asc",
  perPage: 30,
)
```

GitHub Search supports `-label:` negation, so the response contains **only** the candidates we want. One page = one tool call = no LLM reasoning about pagination. `sort:created-asc` returns oldest-first; the first 30 results are the correct batch.

## What changed

- `.github/workflows/triage-panel.md` SCHEDULED_SWEEP gather step rewritten to use `search_issues` and explain why (~33 lines deleted, ~28 added).
- The status/triaged-label-exclusion bullet in the in-reasoning filter list is removed (now redundant — the search query already excluded those issues).
- The "After dropping ... sort by createdAt ascending" line is removed (redundant — query already sorts).
- Spam-shape, bot, locked, template, and per-author-quota filters all unchanged.
- CHANGELOG.md updated under [Unreleased] / Fixed.

## Lockfile

`triage-panel.lock.yml` uses `{{#runtime-import .github/workflows/triage-panel.md}}` (line 280), so `.md` edits take effect on the next workflow run with no recompile needed.

## Validation

- `uv run --extra dev ruff check src/ tests/` → All checks passed
- `uv run --extra dev ruff format --check src/ tests/` → 705 files already formatted

Manual validation will be on the next scheduled cron tick (or a manual dispatch). Expected behavior: `search_issues` returns 11 untriaged candidates oldest-first; the agent triages up to 10 of them and rolls 1 to tomorrow.

## Why this is robust

- **Server-side filter** = no client reasoning about which issues to skip.
- **No pagination loop** = no `hasNextPage` inference for the LLM to get wrong.
- **DIFC-resilient** = even if some search results are integrity-filtered client-side, the agent's only decision is "process whichever survive" rather than "should I fetch more?" — short page = small sweep, not a noop.

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;