### PR TITLE
fix(errors): hide agent-skills meta-target from unknown-target suggestions (#1208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `triage-panel` scheduled sweep switches the candidate query from `list_issues`+prose-driven pagination to `search_issues` with `-label:status/triaged sort:created-asc`, so untriaged candidates are filtered server-side; the previous approach silently noop'd because the MCP gateway DIFC filter dropped non-collaborator issues mid-page and the agent inferred a false `hasNextPage:false`.
 - `apm install` now accepts the YAML list form under `target:` (e.g. `target: [copilot, claude]`); previously crashed with a garbled `Unknown target` error. (#1197)
 - `apm install --update` now falls back from a stale `ADO_APM_PAT` to an `az login` AAD bearer in the preflight auth probe, matching the behavior of `apm install` and every other ADO call site. Previously the preflight raised `AuthenticationError` on 401/403 even when `az login` would have succeeded. The bearer env also pops any pre-existing `GIT_TOKEN` so the JWT flows only via `GIT_CONFIG_VALUE_0`, and the per-host stale-PAT warning dedup is lock-guarded so parallel installs against the same ADO host emit one warning instead of one-per-thread. (#1212)
+- `Unknown target` error suggestions no longer advertise the `agent-skills` meta-target, which `apm targets` intentionally omits from its table. The canonical set still accepts `agent-skills` via `--target` and `apm.yml`, but the recovery path printed on errors now matches what the discovery command actually lists. (#1215)
 
 ## [0.12.4] - 2026-05-07
 

--- a/src/apm_cli/commands/outdated.py
+++ b/src/apm_cli/commands/outdated.py
@@ -262,7 +262,7 @@ def _check_one_dep(dep, downloader, verbose):
             )
 
 
-@click.command(name="outdated", help="Check for outdated locked dependencies")
+@click.command(name="outdated", help="Show outdated locked dependencies")
 @click.option(
     "--global",
     "-g",

--- a/src/apm_cli/core/errors.py
+++ b/src/apm_cli/core/errors.py
@@ -126,18 +126,23 @@ def render_unknown_target_error(value: str, valid: list[str]) -> str:
     # continue to work; we just don't advertise it here.
     visible = [t for t in valid if t != "agent-skills"]
     visible_sorted = sorted(visible)
-    valid_csv = ", ".join(visible_sorted)
+    suggestion = (
+        "copilot"
+        if "copilot" in visible_sorted
+        else (visible_sorted[0] if visible_sorted else "claude")
+    )
+    # When the caller passes only the hidden meta-target (or an empty
+    # list), fall back to the safety-net suggestion so the "Valid
+    # targets:" line never renders as a bare colon. In practice all
+    # production call sites pass the full canonical set, so this is a
+    # defense-in-depth path for tests and future callers.
+    valid_csv = ", ".join(visible_sorted) if visible_sorted else suggestion
     # Strip bracket/quote noise that can leak in from misparsed tokens
     # (e.g. "['copilot'"). Defense-in-depth: callers should pass clean
     # values, but this keeps the headline readable if they don't. Fall
     # back to the raw value (or "<empty>") if stripping consumes
     # everything, so the headline remains actionable.
     display_value = value.strip("[]'\" ") or value or "<empty>"
-    suggestion = (
-        "copilot"
-        if "copilot" in visible_sorted
-        else (visible_sorted[0] if visible_sorted else "claude")
-    )
     return (
         f"[x] Unknown target '{display_value}'\n"
         "\n"

--- a/src/apm_cli/core/errors.py
+++ b/src/apm_cli/core/errors.py
@@ -116,8 +116,17 @@ def render_ambiguous_error(project_root: Path | None, detected: list[str]) -> st
 
 def render_unknown_target_error(value: str, valid: list[str]) -> str:
     """Render the 3-section error for unknown target token."""
-    valid_sorted = sorted(valid)
-    valid_csv = ", ".join(valid_sorted)
+    # Hide ``agent-skills`` from the user-facing suggestion surface (#1208).
+    # ``agent-skills`` is a meta-target (multi-harness fan-out to
+    # ``.agents/skills/``) and is intentionally excluded from the
+    # ``apm targets`` table -- it has no single ``deploy_dir`` and is not
+    # what a beginner who mistyped a harness name should be steered toward.
+    # The canonical set still accepts it so power users who pass it
+    # explicitly via ``--target agent-skills`` (or list it in apm.yml)
+    # continue to work; we just don't advertise it here.
+    visible = [t for t in valid if t != "agent-skills"]
+    visible_sorted = sorted(visible)
+    valid_csv = ", ".join(visible_sorted)
     # Strip bracket/quote noise that can leak in from misparsed tokens
     # (e.g. "['copilot'"). Defense-in-depth: callers should pass clean
     # values, but this keeps the headline readable if they don't. Fall
@@ -125,7 +134,9 @@ def render_unknown_target_error(value: str, valid: list[str]) -> str:
     # everything, so the headline remains actionable.
     display_value = value.strip("[]'\" ") or value or "<empty>"
     suggestion = (
-        "copilot" if "copilot" in valid_sorted else (valid_sorted[0] if valid_sorted else "claude")
+        "copilot"
+        if "copilot" in visible_sorted
+        else (visible_sorted[0] if visible_sorted else "claude")
     )
     return (
         f"[x] Unknown target '{display_value}'\n"

--- a/tests/unit/core/test_error_renderer.py
+++ b/tests/unit/core/test_error_renderer.py
@@ -124,13 +124,17 @@ def test_unknown_target_error_hides_agent_skills_meta_target():
 
 def test_unknown_target_error_falls_back_when_only_meta_target_visible():
     """If the caller filters to only agent-skills, the renderer must
-    not crash and must emit a sane default suggestion (claude)."""
+    not crash and must emit a sane default suggestion (claude) -- and
+    the 'Valid targets:' line must not render as a bare colon."""
     text = render_unknown_target_error("foo", ["agent-skills"])
     # No agent-skills in suggestions...
     assert "--target agent-skills" not in text
     assert "    - agent-skills" not in text
     # ...and the safety-net default 'claude' surfaces instead.
     assert "--target claude" in text
+    # The 'Valid targets:' line must have non-empty content (#1215 review).
+    assert "Valid targets: \n" not in text
+    assert "Valid targets: claude" in text
 
 
 def test_conflicting_schema_error_has_three_parts():

--- a/tests/unit/core/test_error_renderer.py
+++ b/tests/unit/core/test_error_renderer.py
@@ -102,6 +102,37 @@ def test_unknown_target_error_falls_back_when_strip_empties_value():
     assert "Unknown target '" in headline
 
 
+def test_unknown_target_error_hides_agent_skills_meta_target():
+    """agent-skills is a meta-target; do not advertise it as a recovery
+    path here when ``apm targets`` won't list it (#1208).
+
+    The canonical set still ACCEPTS ``agent-skills`` via --target or
+    apm.yml; this test only pins that the unknown-target error message
+    does not steer users to it. Discoverability lives in
+    ``apm targets --json --all``.
+    """
+    valid = ["agent-skills", "claude", "copilot", "cursor"]
+    text = render_unknown_target_error("foo", valid)
+    # 'agent-skills' must not appear in the rendered "Valid targets:" CSV
+    # nor in any of the three suggested commands or the apm.yml snippet.
+    assert "agent-skills" not in text, (
+        f"agent-skills meta-target leaked into unknown-target suggestions:\n{text}"
+    )
+    # Sanity: the surviving harness targets are still listed.
+    assert "claude" in text and "copilot" in text and "cursor" in text
+
+
+def test_unknown_target_error_falls_back_when_only_meta_target_visible():
+    """If the caller filters to only agent-skills, the renderer must
+    not crash and must emit a sane default suggestion (claude)."""
+    text = render_unknown_target_error("foo", ["agent-skills"])
+    # No agent-skills in suggestions...
+    assert "--target agent-skills" not in text
+    assert "    - agent-skills" not in text
+    # ...and the safety-net default 'claude' surfaces instead.
+    assert "--target claude" in text
+
+
 def test_conflicting_schema_error_has_three_parts():
     text = render_conflicting_schema_error()
     _assert_three_sections(text, ["cannot use both", "conflicting"])


### PR DESCRIPTION
# TL;DR

Drop `agent-skills` from the recovery suggestions printed by `apm install` /
`apm.yml` validation when the user supplies an unknown target. The canonical
set still ACCEPTS `agent-skills` (it's a meta-target for multi-harness
fan-out); we just stop steering users toward it from an error message whose
companion "discoverability" command (`apm targets`) refuses to list it.

Closes #1208 (paired with #1197 which fixed the parser crash that produced
the original headline).

# Problem (WHY)

Issue #1208 is the user-visible tip of two coupled problems:

1. **Parser crash** -- on `0.12.4`, supplying `target: [copilot, claude]`
   (singular key, YAML list) crashed install with a garbled headline
   `Unknown target '['agent-skills''`. **This is already fixed on `main` by
   PR #1197.**
2. **Discoverability gap** -- the error renderer
   (`render_unknown_target_error`) advertises EVERY canonical target,
   including the meta-target `agent-skills`, in both the "Valid targets:"
   CSV and as a "Fix with" suggestion. But `apm targets` intentionally
   omits `agent-skills` from its table -- it is a multi-harness fan-out
   target with no single `deploy_dir`, surfaced only via
   `apm targets --json --all` for power users (`commands/targets.py:61-63`).

   The result is an APM-authored contradiction:

   ```
   [x] Unknown target 'foo'
   Valid targets: agent-skills, claude, copilot, ...
   Fix with one of:
     apm targets                            # see all supported harnesses
   ```

   The user runs `apm targets`, doesn't see `agent-skills`, and is left
   wondering whether APM is broken or whether they're broken.

# Approach (WHAT)

Single-point change inside `render_unknown_target_error`:

- Filter `agent-skills` out of the rendered "Valid targets:" CSV.
- Filter `agent-skills` out of the suggestion fallback chain so we never
  print `--target agent-skills` or `- agent-skills` in the apm.yml snippet
  as a recovery path.

What does NOT change:

- `agent-skills` remains in `CANONICAL_TARGETS`. Validation still accepts
  `--target agent-skills` and `target: agent-skills` / `targets: [agent-skills]`
  in `apm.yml`. Power users who already know about the meta-target keep
  working.
- The three call sites still pass the full `sorted(CANONICAL_TARGETS)`;
  the filter lives inside the renderer so call sites stay coupling-free.
- `apm targets --json --all` continues to be the discoverability surface
  for the meta-target.

# Implementation (HOW)

`src/apm_cli/core/errors.py` -- replace the unfiltered `valid_sorted`
with a `visible_sorted` that drops `agent-skills` before formatting the
CSV and computing the fallback suggestion. Comment cites #1208 so the
next contributor understands why this filter exists.

`tests/unit/core/test_error_renderer.py` -- two new tests:

- `test_unknown_target_error_hides_agent_skills_meta_target` -- given
  the full canonical-style list, the rendered text contains no occurrence
  of `agent-skills` (covers CSV, suggestion command, and apm.yml snippet)
  while surviving harnesses still appear.
- `test_unknown_target_error_falls_back_when_only_meta_target_visible` --
  if the caller pathologically passes `["agent-skills"]`, the renderer
  must NOT print `--target agent-skills`; it falls back to `claude`.

The existing test
`test_unknown_target_error_suggests_copilot_not_first_alphabetical`
already asserts `"--target agent-skills" not in text`, but only because
`copilot` wins the fallback ranking; that test does not pin the CSV.
The new tests pin the CSV and the empty-tail fallback.

# Trade-offs

- **Why not show `agent-skills` in `apm targets`?** Considered. It would
  require either a new column or a special-case row, and the meta-target
  has no per-harness signal to defend its presence in a "what does APM
  detect for me?" table. Smaller, less-disruptive fix is to align the
  error message with the existing table contract.
- **Why filter inside the renderer instead of at the three call sites?**
  Single point of change. All three callers pass the full canonical set
  by design; pushing the filter to call sites would duplicate the rule
  three times and invite drift.
- **Could a future canonical-target addition need similar suppression?**
  Possibly. If/when that happens, generalize the filter to read a
  `HIDDEN_FROM_SUGGESTIONS` constant. For one entry, an inline literal is
  clearer.

# Validation

- `uv run --extra dev ruff check src/ tests/` -- silent.
- `uv run --extra dev ruff format --check src/ tests/` -- silent.
- `uv run --extra dev pytest tests/unit/core/test_error_renderer.py -q`
  -- 14 passed (includes the two new tests).
- `uv run --extra dev pytest tests/unit/core tests/unit/install tests/unit/commands -q`
  -- 1187 passed (broader sweep over the surfaces that import the
  renderer).

# How to test

```bash
git fetch origin fix/agent-skills-targets-discoverability-1208
git checkout fix/agent-skills-targets-discoverability-1208
uv run --extra dev pytest tests/unit/core/test_error_renderer.py -q
```

Manual: in any apm.yml-bearing repo, set `target: foo` and run
`apm install --dry-run`. The "Valid targets:" line and the suggestion
must NOT contain `agent-skills`. The "Fix with" hint should still
include `apm targets` (its contract is now consistent with what that
command actually prints).
