### PR TITLE
fix(cli): add missing help text to `outdated` command

### DIFF
--- a/src/apm_cli/commands/outdated.py
+++ b/src/apm_cli/commands/outdated.py
@@ -262,7 +262,7 @@ def _check_one_dep(dep, downloader, verbose):
             )
 
 
-@click.command(name="outdated")
+@click.command(name="outdated", help="Check for outdated locked dependencies")
 @click.option(
     "--global",
     "-g",


### PR DESCRIPTION
## Summary

Adds the missing `help=` parameter to the `outdated` command's `@click.command()` decorator so it displays a description in `apm --help` output.

## Problem

Running `apm --help` shows the `outdated` command with no help text, unlike all other commands which have descriptions. This was reported in #1204.

## Fix

Added `help="Check for outdated locked dependencies"` to the `@click.command(name="outdated")` decorator in `src/apm_cli/commands/outdated.py`.

Fixes #1204