### PR TITLE
[docs] Update documentation for features from 2026-05-09

### DIFF
--- a/docs/src/content/docs/getting-started/authentication.md
+++ b/docs/src/content/docs/getting-started/authentication.md
@@ -186,6 +186,16 @@ apm install dev.azure.com/myorg/myproject/myrepo
 [!]     Consider unsetting the stale variable.
 ```
 
+This fallback applies to all ADO operations including `apm install --update`. If you have a stale `ADO_APM_PAT` but an active `az login` session, `apm install --update` will succeed transparently via the bearer retry.
+
+If both `ADO_APM_PAT` and the `az` bearer fail, APM emits:
+
+```
+[x] AAD bearer fallback also failed for dev.azure.com.
+```
+
+This confirms both paths were attempted and neither succeeded, so the fix is either to refresh your PAT or run `az login`.
+
 **Verbose output** (`--verbose`) shows which source was used per host:
 
 ```


### PR DESCRIPTION
## Documentation Updates - 2026-05-09

This PR updates the documentation based on features merged in the last 24 hours.

### Features Documented

- ADO `--update` bearer fallback now documented (from #1214)
- New "AAD bearer fallback also failed" dual-fail diagnostic documented (from #1214)

### Changes Made

- Updated `docs/src/content/docs/getting-started/authentication.md`:
  - Clarified the stale-PAT fallback applies to `apm install --update` (not just plain `apm install`)
  - Added documentation for the new "AAD bearer fallback also failed" error message shown when both PAT and `az` bearer are rejected
  - Both paragraphs give users clear remediation guidance (refresh PAT or run `az login`)

### Merged PRs Referenced

- #1214 - fix(install): wire ADO --update preflight through PAT->bearer fallback
- #1215 - fix(errors): hide agent-skills meta-target from unknown-target suggestions (no doc change needed -- behavior already consistent with existing docs for `apm targets`)
- #1216 - fix(cli): add missing help text to `outdated` command (no doc change needed -- command already documented)

### Notes

PRs #1215 and #1216 are internal consistency fixes that do not require new user-facing documentation. The agent-skills meta-target exclusion from error suggestions is consistent with what is already documented for `apm targets`. The `outdated` CLI help text fix is cosmetic and the command is already documented in `cli-commands.md`.




> [!NOTE]
> <details>
> <summary>🔒 Integrity filter blocked 1 item</summary>
>
> The following item was blocked because it doesn't meet the GitHub integrity level.
>
> - [#587](https://github.com/microsoft/apm/pull/587) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/25593091396/agentic_workflow) · ● 779.3K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+%22gh-aw-workflow-id%3A+daily-doc-updater%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/blob/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-05-11T05:42:17.030Z --> on May 11, 2026, 5:42 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 25593091396, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/25593091396 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->