### PR TITLE
[Test Improver] tests(compile): add unit tests for compile() command early-exit paths

### DIFF
--- a/tests/unit/compilation/test_compile_command_early_exits.py
+++ b/tests/unit/compilation/test_compile_command_early_exits.py
@@ -1,0 +1,194 @@
+"""Tests for compile() command early-exit paths.
+
+Covers branches in cli.py::compile() that exit before reaching the compiler:
+- Missing apm.yml
+- --all with --target conflict
+- --target all deprecation warning
+- No APM content found (no .apm/, no modules, no constitution)
+- Empty .apm directory
+- --validate mode: discover failure, validation errors, success
+"""
+
+import os
+
+import pytest
+from click.testing import CliRunner
+
+from apm_cli.cli import cli
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def empty_project(tmp_path):
+    """Project directory with only apm.yml, no .apm content."""
+    (tmp_path / "apm.yml").write_text("name: test-project\nversion: 0.1.0\n")
+    return tmp_path
+
+
+@pytest.fixture
+def minimal_project(tmp_path):
+    """Project directory with apm.yml and one instruction file."""
+    (tmp_path / "apm.yml").write_text("name: test-project\nversion: 0.1.0\n")
+    apm_dir = tmp_path / ".apm" / "instructions"
+    apm_dir.mkdir(parents=True)
+    (apm_dir / "test.instructions.md").write_text(
+        '---\napplyTo: "**"\n---\nFollow best practices.\n'
+    )
+    return tmp_path
+
+
+class TestNoApmYml:
+    """compile() exits with error when apm.yml is absent."""
+
+    def test_missing_apm_yml_exits_with_error(self, runner, tmp_path):
+        original = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            result = runner.invoke(cli, ["compile"])
+            assert result.exit_code != 0
+            assert "apm.yml" in result.output.lower() or "Not an APM project" in result.output
+        finally:
+            os.chdir(original)
+
+    def test_missing_apm_yml_suggests_init(self, runner, tmp_path):
+        original = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            result = runner.invoke(cli, ["compile"])
+            assert "apm init" in result.output
+        finally:
+            os.chdir(original)
+
+
+class TestAllAndTargetConflict:
+    """--all and --target together must exit with code 2."""
+
+    def test_all_with_target_exits_nonzero(self, runner, minimal_project):
+        original = os.getcwd()
+        try:
+            os.chdir(minimal_project)
+            result = runner.invoke(cli, ["compile", "--all", "--target", "vscode"])
+            assert result.exit_code != 0
+        finally:
+            os.chdir(original)
+
+    def test_all_with_target_shows_error_message(self, runner, minimal_project):
+        original = os.getcwd()
+        try:
+            os.chdir(minimal_project)
+            result = runner.invoke(cli, ["compile", "--all", "--target", "vscode"])
+            assert "--all" in result.output or "--target" in result.output
+        finally:
+            os.chdir(original)
+
+
+class TestTargetAllDeprecation:
+    """--target all emits a deprecation warning."""
+
+    def test_target_all_emits_deprecation_warning(self, runner, minimal_project):
+        original = os.getcwd()
+        try:
+            os.chdir(minimal_project)
+            result = runner.invoke(cli, ["compile", "--target", "all", "--dry-run"])
+            # Should warn about deprecation of --target all
+            assert "deprecated" in result.output.lower()
+        finally:
+            os.chdir(original)
+
+    def test_target_all_still_runs(self, runner, minimal_project):
+        original = os.getcwd()
+        try:
+            os.chdir(minimal_project)
+            result = runner.invoke(cli, ["compile", "--target", "all", "--dry-run"])
+            # Should not exit with code 2 (reserved for --all + --target conflict)
+            assert result.exit_code != 2
+        finally:
+            os.chdir(original)
+
+
+class TestNoApmContent:
+    """compile() exits with helpful errors when there is nothing to compile."""
+
+    def test_no_content_exits_nonzero(self, runner, empty_project):
+        original = os.getcwd()
+        try:
+            os.chdir(empty_project)
+            result = runner.invoke(cli, ["compile"])
+            assert result.exit_code != 0
+        finally:
+            os.chdir(original)
+
+    def test_no_content_suggests_install_or_create(self, runner, empty_project):
+        original = os.getcwd()
+        try:
+            os.chdir(empty_project)
+            result = runner.invoke(cli, ["compile"])
+            # Should mention installing or creating content
+            assert "install" in result.output.lower() or "create" in result.output.lower()
+        finally:
+            os.chdir(original)
+
+    def test_empty_apm_dir_gives_specific_error(self, runner, tmp_path):
+        """When .apm/ exists but has no instruction files, show targeted error."""
+        (tmp_path / "apm.yml").write_text("name: test-project\nversion: 0.1.0\n")
+        (tmp_path / ".apm").mkdir()  # exists but empty
+        original = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            result = runner.invoke(cli, ["compile"])
+            assert result.exit_code != 0
+            # Should mention .apm/ directory or instruction files
+            assert ".apm/" in result.output or "instruction" in result.output.lower()
+        finally:
+            os.chdir(original)
+
+    def test_no_content_dry_run_does_not_exit(self, runner, empty_project):
+        """--dry-run should skip the sys.exit(1) for missing content."""
+        original = os.getcwd()
+        try:
+            os.chdir(empty_project)
+            result = runner.invoke(cli, ["compile", "--dry-run"])
+            # dry-run is allowed to continue even with no content (line 421-422)
+            assert result.exit_code in (0, 1)
+        finally:
+            os.chdir(original)
+
+
+class TestValidateMode:
+    """--validate flag exercises the validation-only code path."""
+
+    def test_validate_succeeds_with_valid_project(self, runner, minimal_project):
+        original = os.getcwd()
+        try:
+            os.chdir(minimal_project)
+            result = runner.invoke(cli, ["compile", "--validate"])
+            # Should succeed and mention validated
+            assert result.exit_code == 0
+            assert "validat" in result.output.lower()
+        finally:
+            os.chdir(original)
+
+    def test_validate_reports_primitive_counts(self, runner, minimal_project):
+        original = os.getcwd()
+        try:
+            os.chdir(minimal_project)
+            result = runner.invoke(cli, ["compile", "--validate"])
+            assert result.exit_code == 0
+            # Should show primitive counts
+            assert "instruction" in result.output.lower() or "primitive" in result.output.lower()
+        finally:
+            os.chdir(original)
+
+    def test_validate_without_apm_yml_exits_nonzero(self, runner, tmp_path):
+        """--validate on a non-APM project still hits the apm.yml guard first."""
+        original = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            result = runner.invoke(cli, ["compile", "--validate"])
+            assert result.exit_code != 0
+        finally:
+            os.chdir(original)


### PR DESCRIPTION
🤖 *Test Improver - automated AI assistant for test improvements.*

## Goal and Rationale

The `compile()` Click command in `src/apm_cli/commands/compile/cli.py` had extensive helper-function coverage (PR #1206) but the main command body's early-exit branches were untested. These guards protect users from confusing states:

- No `apm.yml` in cwd → clear error + `apm init` suggestion
- `--all` + `--target` conflict → error exit code 2
- `--target all` (deprecated form) → deprecation warning
- No APM content found → helpful error with suggestions
- Empty `.apm/` directory → targeted error mentioning instruction files
- `--dry-run` bypasses the no-content exit (by design, line 421-422)
- `--validate` mode: guard on missing `apm.yml`, success path, primitive count output

These paths are user-facing contract surfaces -- if they break silently, users get confusing output or misleading exit codes.

## Approach

New test file `tests/unit/compilation/test_compile_command_early_exits.py` with 13 tests across 5 test classes. Uses `CliRunner` + `tmp_path` fixtures to set up minimal project states and invoke `apm compile` in isolated directories.

No mocking of internals -- tests exercise real code paths against minimal real-directory layouts, which makes them robust against refactors that preserve behaviour.

## Coverage Impact

| Before | After |
|--------|-------|
| compile() main body early exits: untested | 13 new passing tests pin these branches |

These are behaviour-contract tests: they would catch regressions in error messages, exit codes, and guard ordering.

## Trade-offs

- Uses `os.chdir` inside tests (isolated per-test with `try/finally`) -- same pattern as `test_compile_target_flag.py`
- No complex mocking; tests run fast (~0.4s for all 13)
- Does not attempt to test the full compilation path (too many external dependencies for minimal additional value)

## Reproducibility

```bash
# Run just these tests
.venv/bin/pytest tests/unit/compilation/test_compile_command_early_exits.py -v

# Full compilation suite
.venv/bin/pytest tests/unit/compilation/ -q

# Full unit suite
.venv/bin/pytest tests/unit/ -q
```

## Test Status

- **New tests**: 13 passing, 0 failing
- **Full unit suite**: 7978 passing, 11 failing (all pre-existing: 7 policy_status ANSI + 4 runtime_factory LLM -- unrelated to this PR)
- **Lint**: clean

> Generated by [Daily Test Improver](https://github.com/microsoft/apm/actions/runs/25622096654/agentic_workflow) - automated AI assistant




> [!NOTE]
> <details>
> <summary>🔒 Integrity filter blocked 17 items</summary>
>
> The following items were blocked because they don't meet the GitHub integrity level.
>
> - [#1230](https://github.com/microsoft/apm/pull/1230) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1227](https://github.com/microsoft/apm/pull/1227) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1224](https://github.com/microsoft/apm/pull/1224) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1149](https://github.com/microsoft/apm/pull/1149) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1146](https://github.com/microsoft/apm/pull/1146) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1117](https://github.com/microsoft/apm/pull/1117) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1113](https://github.com/microsoft/apm/pull/1113) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1028](https://github.com/microsoft/apm/pull/1028) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1017](https://github.com/microsoft/apm/pull/1017) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#928](https://github.com/microsoft/apm/pull/928) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#900](https://github.com/microsoft/apm/pull/900) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#881](https://github.com/microsoft/apm/pull/881) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#869](https://github.com/microsoft/apm/pull/869) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#691](https://github.com/microsoft/apm/pull/691) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#409](https://github.com/microsoft/apm/pull/409) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#7](https://github.com/microsoft/apm/pull/7) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - ... and 1 more item
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [Daily Test Improver](https://github.com/microsoft/apm/actions/runs/25622096654/agentic_workflow) · ● 3M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+%22gh-aw-workflow-id%3A+daily-test-improver%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/blob/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-test-improver.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-test-improver.md@b87234850bf9664d198f28a02df0f937d0447295
> ```

<!-- gh-aw-agentic-workflow: Daily Test Improver, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 25622096654, workflow_id: daily-test-improver, run: https://github.com/microsoft/apm/actions/runs/25622096654 -->

<!-- gh-aw-workflow-id: daily-test-improver -->