### PR TITLE
fix: normalise default-scheme ports (443/80/22) on DependencyReference / HostInfo

### DIFF
--- a/src/apm_cli/core/auth.py
+++ b/src/apm_cli/core/auth.py
@@ -66,17 +66,19 @@ class HostInfo:
 
     @property
     def display_name(self) -> str:
-        """``host:port`` when a custom port is set, else bare ``host``.
+        """``host:port`` when a non-default port is set, else bare ``host``.
 
-        Use this wherever user-facing text identifies the host — errors, log
-        lines, diagnostic output. Bare ``host`` in those places misleads
-        users when port is what actually differentiates the target.
+        Well-known default ports (443, 80, 22) are suppressed even if
+        stored explicitly, as defence-in-depth against callers that
+        construct a ``HostInfo`` without prior normalisation.
 
-        Uses ``is not None`` (not truthy) for symmetry with the
-        ``host_info.port is not None`` checks elsewhere in the resolver and
-        to avoid silently dropping any non-default integer ports.
+        Use this wherever user-facing text identifies the host -- errors, log
+        lines, diagnostic output.
         """
-        return f"{self.host}:{self.port}" if self.port is not None else self.host
+        _well_known_default_ports = {443, 80, 22}
+        if self.port is not None and self.port not in _well_known_default_ports:
+            return f"{self.host}:{self.port}"
+        return self.host
 
 
 @dataclass

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -24,6 +24,12 @@ from ...utils.path_security import (
 from ..validation import InvalidVirtualPackageExtensionError
 from .types import VirtualPackageType
 
+# Default ports per URI scheme -- used to normalise away redundant
+# explicit ports (e.g. https://host:443/...) so that lockfile keys
+# and error messages stay consistent regardless of how the user
+# spelled the URL.
+_DEFAULT_SCHEME_PORTS: dict[str, int] = {"https": 443, "http": 80, "ssh": 22}
+
 
 @dataclass
 class DependencyReference:
@@ -403,6 +409,9 @@ class DependencyReference:
         parsed = urllib.parse.urlparse(url)
         host = parsed.hostname or ""
         port = parsed.port  # int or None
+        # Normalise default SSH port so ssh://host:22/... matches ssh://host/...
+        if port == _DEFAULT_SCHEME_PORTS.get("ssh"):
+            port = None
         path = parsed.path.lstrip("/")
         fragment = parsed.fragment
 
@@ -957,6 +966,11 @@ class DependencyReference:
             parsed_url = urllib.parse.urlparse(repo_url)
             host = parsed_url.hostname or ""
             port = parsed_url.port  # capture :PORT from https://host:8443/...
+            # Normalise default-scheme ports (443 for HTTPS, 80 for HTTP)
+            # so lockfile keys are consistent regardless of URL spelling.
+            scheme = (parsed_url.scheme or "").lower()
+            if port == _DEFAULT_SCHEME_PORTS.get(scheme):
+                port = None
         else:
             parsed_url, host = cls._resolve_shorthand_to_parsed_url(repo_url, host)
 

--- a/tests/integration/test_default_port_normalisation_e2e.py
+++ b/tests/integration/test_default_port_normalisation_e2e.py
@@ -1,0 +1,196 @@
+"""End-to-end tests for #797 default-port normalisation.
+
+Verifies that well-known default ports (443 for HTTPS, 80 for HTTP,
+22 for SSH) are normalised away through the full dependency lifecycle:
+
+    apm.yml  ->  DependencyReference.parse  ->  LockedDependency  ->  lockfile YAML
+
+The contract: a URL with an explicit default port (e.g.
+``https://github.com:443/owner/repo``) and the same URL without the
+port MUST produce identical lockfile entries -- different spellings of
+the same target must not create distinct lockfile keys.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from apm_cli.deps.lockfile import LockedDependency, LockFile
+from apm_cli.models.apm_package import APMPackage, clear_apm_yml_cache
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    clear_apm_yml_cache()
+    yield
+    clear_apm_yml_cache()
+
+
+def _write_apm_yml(project: Path, deps: list[str]) -> Path:
+    """Write a minimal apm.yml with the given string dependencies."""
+    apm_yml = project / "apm.yml"
+    config = {
+        "name": "port-normalisation-test",
+        "version": "1.0.0",
+        "dependencies": {"apm": deps},
+    }
+    apm_yml.write_text(yaml.dump(config), encoding="utf-8")
+    return apm_yml
+
+
+def _parse_single_dep(project: Path, dep_str: str):
+    """Write apm.yml with one dep, parse it, return the DependencyReference."""
+    apm_yml = _write_apm_yml(project, [dep_str])
+    pkg = APMPackage.from_apm_yml(apm_yml)
+    deps = pkg.get_apm_dependencies()
+    assert len(deps) == 1, f"Expected 1 dep, got {len(deps)}"
+    return deps[0]
+
+
+def _make_locked_dep(dep_ref) -> LockedDependency:
+    """Create a LockedDependency from a DependencyReference with dummy resolution."""
+    return LockedDependency.from_dependency_ref(
+        dep_ref,
+        resolved_commit="abc123def456",
+        depth=1,
+        resolved_by=None,
+    )
+
+
+class TestDefaultPortNormalisationE2E:
+    """Issue #797: default ports normalised through the full dep lifecycle."""
+
+    def test_https_443_normalised_through_apm_yml_parse(self, tmp_path):
+        """https://github.com:443/owner/repo parsed via apm.yml drops port."""
+        dep = _parse_single_dep(tmp_path, "https://github.com:443/owner/repo")
+        assert dep.port is None
+        assert dep.host == "github.com"
+        assert dep.repo_url == "owner/repo"
+
+    def test_ssh_22_normalised_through_apm_yml_parse(self, tmp_path):
+        """ssh://git@gitlab.com:22/owner/repo.git parsed via apm.yml drops port."""
+        dep = _parse_single_dep(tmp_path, "ssh://git@gitlab.com:22/owner/repo.git")
+        assert dep.port is None
+        assert dep.host == "gitlab.com"
+        assert dep.repo_url == "owner/repo"
+
+    def test_non_default_port_preserved_through_apm_yml_parse(self, tmp_path):
+        """Non-default port survives the full apm.yml parse path."""
+        dep = _parse_single_dep(tmp_path, "https://bitbucket.corp.com:7990/team/repo")
+        assert dep.port == 7990
+
+    def test_lockfile_entry_omits_default_port(self, tmp_path):
+        """LockedDependency created from a :443 URL has no port in its dict."""
+        dep = _parse_single_dep(tmp_path, "https://github.com:443/owner/repo")
+        locked = _make_locked_dep(dep)
+        serialised = locked.to_dict()
+        assert "port" not in serialised
+        assert serialised["repo_url"] == "owner/repo"
+
+    def test_lockfile_entry_preserves_non_default_port(self, tmp_path):
+        """LockedDependency from a non-default port includes port in its dict."""
+        dep = _parse_single_dep(tmp_path, "https://bitbucket.corp.com:7990/team/repo")
+        locked = _make_locked_dep(dep)
+        serialised = locked.to_dict()
+        assert serialised["port"] == 7990
+
+    def test_lockfile_key_identity_with_and_without_default_port(self, tmp_path):
+        """Explicit :443 and bare URL produce the same lockfile key.
+
+        This is the supply-chain correctness invariant: two spellings
+        of the same target MUST NOT create separate lockfile entries.
+        """
+        project_a = tmp_path / "proj-a"
+        project_a.mkdir()
+        project_b = tmp_path / "proj-b"
+        project_b.mkdir()
+
+        dep_with_port = _parse_single_dep(project_a, "https://github.com:443/owner/repo")
+        dep_bare = _parse_single_dep(project_b, "https://github.com/owner/repo")
+
+        locked_with_port = _make_locked_dep(dep_with_port)
+        locked_bare = _make_locked_dep(dep_bare)
+
+        assert locked_with_port.get_unique_key() == locked_bare.get_unique_key()
+
+    def test_lockfile_yaml_roundtrip_no_default_port(self, tmp_path):
+        """Write lockfile with a :443 dep, read it back -- no port leaks.
+
+        Exercises the full LockFile serialisation pipeline:
+        parse -> LockedDependency -> LockFile.write -> LockFile.read.
+        """
+        dep = _parse_single_dep(tmp_path, "https://github.com:443/owner/repo")
+        locked = _make_locked_dep(dep)
+
+        lockfile = LockFile()
+        lockfile.add_dependency(locked)
+
+        lock_path = tmp_path / "apm.lock.yaml"
+        lockfile.write(lock_path)
+
+        # Read the raw YAML and verify no port key
+        raw_yaml = lock_path.read_text(encoding="utf-8")
+        assert "port:" not in raw_yaml
+        assert ":443" not in raw_yaml
+
+        # Roundtrip through LockFile.read
+        loaded = LockFile.read(lock_path)
+        assert loaded is not None
+        reloaded_dep = loaded.dependencies.get("owner/repo")
+        assert reloaded_dep is not None
+        assert reloaded_dep.port is None
+
+    def test_lockfile_yaml_roundtrip_preserves_non_default_port(self, tmp_path):
+        """Non-default port survives the full lockfile write/read roundtrip."""
+        dep = _parse_single_dep(tmp_path, "https://bitbucket.corp.com:7990/team/repo")
+        locked = _make_locked_dep(dep)
+
+        lockfile = LockFile()
+        lockfile.add_dependency(locked)
+
+        lock_path = tmp_path / "apm.lock.yaml"
+        lockfile.write(lock_path)
+
+        raw_yaml = lock_path.read_text(encoding="utf-8")
+        assert "port: 7990" in raw_yaml
+
+        loaded = LockFile.read(lock_path)
+        assert loaded is not None
+        reloaded_dep = loaded.dependencies.get("team/repo")
+        assert reloaded_dep is not None
+        assert reloaded_dep.port == 7990
+
+    def test_canonical_string_identity_across_port_spellings(self, tmp_path):
+        """to_canonical() output is identical for :443 and bare spellings."""
+        project_a = tmp_path / "proj-c"
+        project_a.mkdir()
+        project_b = tmp_path / "proj-d"
+        project_b.mkdir()
+
+        dep_with_port = _parse_single_dep(project_a, "https://gitlab.com:443/acme/tools")
+        dep_bare = _parse_single_dep(project_b, "https://gitlab.com/acme/tools")
+
+        assert dep_with_port.to_canonical() == dep_bare.to_canonical()
+        assert ":443" not in dep_with_port.to_canonical()
+
+    def test_ssh_default_port_lockfile_roundtrip(self, tmp_path):
+        """SSH with :22 produces a clean lockfile entry with no port."""
+        dep = _parse_single_dep(tmp_path, "ssh://git@gitlab.com:22/acme/tools.git")
+        locked = _make_locked_dep(dep)
+
+        lockfile = LockFile()
+        lockfile.add_dependency(locked)
+
+        lock_path = tmp_path / "apm.lock.yaml"
+        lockfile.write(lock_path)
+
+        raw_yaml = lock_path.read_text(encoding="utf-8")
+        assert "port:" not in raw_yaml
+
+        loaded = LockFile.read(lock_path)
+        reloaded = loaded.dependencies.get("acme/tools")
+        assert reloaded is not None
+        assert reloaded.port is None

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -887,6 +887,37 @@ class TestHostInfoPort:
         assert hi.kind == "github"
         assert hi.port == 8443
 
+    def test_display_name_suppresses_default_port_443(self):
+        """Defence-in-depth: display_name never renders well-known default ports."""
+        hi = HostInfo(
+            host="github.com",
+            kind="github",
+            has_public_repos=True,
+            api_base="x",
+            port=443,
+        )
+        assert hi.display_name == "github.com"
+
+    def test_display_name_suppresses_default_port_22(self):
+        hi = HostInfo(
+            host="gitlab.com",
+            kind="generic",
+            has_public_repos=True,
+            api_base="x",
+            port=22,
+        )
+        assert hi.display_name == "gitlab.com"
+
+    def test_display_name_suppresses_default_port_80(self):
+        hi = HostInfo(
+            host="internal.git",
+            kind="generic",
+            has_public_repos=True,
+            api_base="x",
+            port=80,
+        )
+        assert hi.display_name == "internal.git"
+
 
 # ---------------------------------------------------------------------------
 # TestResolvePortDiscrimination -- same host, different ports must not

--- a/tests/unit/test_generic_git_urls.py
+++ b/tests/unit/test_generic_git_urls.py
@@ -963,3 +963,46 @@ class TestGiteaVirtualPackageDetection:
         assert dep.repo_url == "owner/repo"
         assert dep.virtual_path == "prompts/review.prompt.md"
         assert dep.is_virtual is True
+
+
+class TestDefaultPortNormalisation:
+    """Issue #797: default-scheme ports are normalised to None at parse time."""
+
+    def test_default_https_port_normalised_to_none(self):
+        dep = DependencyReference.parse("https://github.com:443/owner/repo")
+        assert dep.port is None
+        assert dep.host == "github.com"
+        assert dep.repo_url == "owner/repo"
+
+    def test_default_ssh_port_normalised_to_none(self):
+        dep = DependencyReference.parse("ssh://git@gitlab.com:22/owner/repo.git")
+        assert dep.port is None
+        assert dep.host == "gitlab.com"
+        assert dep.repo_url == "owner/repo"
+
+    def test_default_http_port_normalised_to_none(self):
+        dep = DependencyReference.parse("http://internal.git:80/team/repo")
+        assert dep.port is None
+        assert dep.host == "internal.git"
+        assert dep.repo_url == "team/repo"
+
+    def test_non_default_port_preserved(self):
+        dep = DependencyReference.parse("https://bitbucket.corp.com:7990/team/repo")
+        assert dep.port == 7990
+
+    def test_non_default_ssh_port_preserved(self):
+        dep = DependencyReference.parse("ssh://git@bitbucket.corp.com:7999/team/repo.git")
+        assert dep.port == 7999
+
+    def test_canonical_string_omits_normalised_default_port(self):
+        dep = DependencyReference.parse("https://gitlab.com:443/owner/repo")
+        canonical = dep.to_canonical()
+        assert ":443" not in canonical
+        assert "gitlab.com/owner/repo" in canonical
+
+    def test_https_url_with_port_443_matches_bare_url(self):
+        """Lockfile consistency: explicit :443 and bare URL produce the same key."""
+        dep_with_port = DependencyReference.parse("https://github.com:443/owner/repo")
+        dep_bare = DependencyReference.parse("https://github.com/owner/repo")
+        assert dep_with_port.port == dep_bare.port
+        assert dep_with_port.to_canonical() == dep_bare.to_canonical()


### PR DESCRIPTION
## Description

Normalise default-scheme ports (443 for HTTPS, 80 for HTTP, 22 for SSH) to `None` at parse time in `DependencyReference.parse()`, so that `https://github.com:443/owner/repo` and `https://github.com/owner/repo` produce identical `HostInfo` and lockfile keys.

Also updates `HostInfo.display_name` to never render a default port in the `[i]` hint.

Fixes #797

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [ ] Tested locally
- [ ] All existing tests pass
- [ ] Added tests for new functionality (if applicable)
