### PR TITLE
fix: hide experimental cowork config key and fix verbose target log

### DIFF
--- a/src/apm_cli/commands/config.py
+++ b/src/apm_cli/commands/config.py
@@ -53,7 +53,12 @@ def _get_config_getters():
 
 def _valid_config_keys() -> str:
     """Return valid config keys for messages."""
-    return ", ".join(["auto-integrate", "temp-dir", "copilot-cowork-skills-dir"])
+    from ..core.experimental import is_enabled
+
+    keys = ["auto-integrate", "temp-dir"]
+    if is_enabled("copilot_cowork"):
+        keys.append("copilot-cowork-skills-dir")
+    return ", ".join(keys)
 
 
 @click.group(help="Configure APM CLI", invoke_without_command=True)

--- a/src/apm_cli/install/phases/targets.py
+++ b/src/apm_cli/install/phases/targets.py
@@ -305,7 +305,13 @@ def run(ctx: InstallContext) -> None:
         # User-scope: legacy target directory creation and logging.
         if ctx.logger:
             if _targets:
-                _target_names = ", ".join(f"{t.name} (~/{t.root_dir}/)" for t in _targets)
+
+                def _fmt_target(t):
+                    if t.resolved_deploy_root is not None:
+                        return f"{t.name} ({t.resolved_deploy_root})"
+                    return f"{t.name} (~/{t.root_dir}/)"
+
+                _target_names = ", ".join(_fmt_target(t) for t in _targets)
                 ctx.logger.verbose_detail(f"Active global targets: {_target_names}")
                 from apm_cli.deps.lockfile import get_lockfile_path
 

--- a/tests/integration/test_config_valid_keys_e2e.py
+++ b/tests/integration/test_config_valid_keys_e2e.py
@@ -1,0 +1,61 @@
+"""End-to-end tests for config valid-keys gating (Issue #923).
+
+Verifies that ``apm config set <unknown-key> <value>`` only mentions
+``copilot-cowork-skills-dir`` in the valid-keys hint when the
+``copilot_cowork`` experimental flag is enabled.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from apm_cli.cli import cli
+
+
+@pytest.fixture
+def isolated_config(tmp_path, monkeypatch):
+    """Redirect CONFIG_FILE to a temp dir so tests never touch ~/.apm."""
+    import apm_cli.config as _conf
+
+    _conf._invalidate_config_cache()
+    config_dir = tmp_path / ".apm"
+    config_file = config_dir / "config.json"
+    monkeypatch.setattr(_conf, "CONFIG_DIR", str(config_dir))
+    monkeypatch.setattr(_conf, "CONFIG_FILE", str(config_file))
+    yield config_file
+    _conf._invalidate_config_cache()
+
+
+class TestConfigValidKeysE2E:
+    """Full CLI pipeline tests for valid-keys gating in config set."""
+
+    def test_config_set_unknown_key_omits_cowork_when_flag_off(self, isolated_config):
+        """When copilot_cowork is disabled, cowork key must not appear."""
+        runner = CliRunner()
+        with patch("apm_cli.core.experimental.is_enabled", return_value=False):
+            result = runner.invoke(
+                cli,
+                ["config", "set", "unknown-key", "value"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code != 0, f"Expected non-zero exit code, got {result.exit_code}"
+        assert "copilot-cowork-skills-dir" not in result.output
+        assert "auto-integrate" in result.output
+
+    def test_config_set_unknown_key_includes_cowork_when_flag_on(self, isolated_config):
+        """When copilot_cowork is enabled, cowork key must appear."""
+        runner = CliRunner()
+        with patch("apm_cli.core.experimental.is_enabled", return_value=True):
+            result = runner.invoke(
+                cli,
+                ["config", "set", "unknown-key", "value"],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code != 0, f"Expected non-zero exit code, got {result.exit_code}"
+        assert "copilot-cowork-skills-dir" in result.output
+        assert "auto-integrate" in result.output

--- a/tests/unit/test_config_command.py
+++ b/tests/unit/test_config_command.py
@@ -886,3 +886,29 @@ class TestFlagGatingRegression:
         with patch("apm_cli.core.experimental.is_enabled", return_value=False):
             result = self.runner.invoke(config, ["set", "copilot-cowork-skills-dir", "/some/path"])
         assert result.exit_code == 1
+
+
+class TestValidConfigKeys:
+    """Tests for _valid_config_keys() feature-flag gating."""
+
+    def test_valid_config_keys_excludes_cowork_when_flag_off(self):
+        """copilot-cowork-skills-dir is hidden when the copilot_cowork flag is off."""
+        from apm_cli.commands.config import _valid_config_keys
+
+        with patch("apm_cli.core.experimental.is_enabled", return_value=False):
+            result = _valid_config_keys()
+
+        assert "auto-integrate" in result
+        assert "temp-dir" in result
+        assert "copilot-cowork-skills-dir" not in result
+
+    def test_valid_config_keys_includes_cowork_when_flag_on(self):
+        """copilot-cowork-skills-dir is listed when the copilot_cowork flag is on."""
+        from apm_cli.commands.config import _valid_config_keys
+
+        with patch("apm_cli.core.experimental.is_enabled", return_value=True):
+            result = _valid_config_keys()
+
+        assert "auto-integrate" in result
+        assert "temp-dir" in result
+        assert "copilot-cowork-skills-dir" in result


### PR DESCRIPTION
# Description

Two cosmetic/diagnostic polish items from the cowork feature review (#913):

1. **`_valid_config_keys()` leaks `cowork-skills-dir`** when the `cowork` experimental flag is off — users see it in error suggestions, leaking experimental surface awareness. Fix: gate on `experimental.is_enabled("cowork")`.

2. **Verbose target log prints placeholder** `~/cowork/` instead of the resolved OneDrive path. Fix: prefer `target.resolved_deploy_root` over `target.root_dir` when logging.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [ ] Unit tests for config-key gating (flag on/off)
- [ ] Verbose log prints resolved path
- [ ] All existing tests pass

Closes #923
