### PR TITLE
fix: align direct install HTTPS validation with manifest-driven credential handling

### DIFF
--- a/src/apm_cli/install/validation.py
+++ b/src/apm_cli/install/validation.py
@@ -278,7 +278,6 @@ def _validate_package_exists(package, verbose=False, auth_resolver=None, logger=
 
             explicit_scheme = (getattr(dep_ref, "explicit_scheme", None) or "").lower() or None
             is_insecure = bool(getattr(dep_ref, "is_insecure", False))
-            prefer_web_probe_first = explicit_scheme in ("http", "https") or is_insecure
 
             # Strict-by-default cross-protocol policy (issue microsoft/apm#992):
             # an explicit ``http://`` / ``https://`` / ``ssh://`` URL is honored
@@ -295,11 +294,16 @@ def _validate_package_exists(package, verbose=False, auth_resolver=None, logger=
             allow_fallback_env = is_fallback_allowed()
 
             # For generic hosts (not GitHub, not ADO), relax the env so native
-            # credential helpers (SSH keys, macOS Keychain, etc.) can work.
-            # This mirrors _clone_with_fallback() which does the same relaxation.
+            # credential helpers (macOS Keychain, credential-store,
+            # manager-core, SSH agent, etc.) can work.  Config isolation
+            # (GIT_CONFIG_GLOBAL=/dev/null, GIT_CONFIG_NOSYSTEM=1) is only
+            # enforced for insecure plaintext HTTP connections where
+            # credential leakage is a real risk; HTTPS connections need
+            # access to user-configured helpers in ~/.gitconfig.  This
+            # matches _clone_with_fallback() and git_reference_resolver.
             if is_generic:
                 validate_env = ado_downloader._build_noninteractive_git_env(
-                    preserve_config_isolation=prefer_web_probe_first,
+                    preserve_config_isolation=is_insecure,
                     suppress_credential_helpers=is_insecure,
                 )
             else:

--- a/tests/integration/test_generic_https_credential_env_e2e.py
+++ b/tests/integration/test_generic_https_credential_env_e2e.py
@@ -1,0 +1,310 @@
+"""Hermetic integration tests for issue #1013: credential-env contract.
+
+These tests exercise the full validation code path with real
+:class:`AuthResolver`, :class:`DependencyReference`, and
+:class:`GitHubPackageDownloader` instances.  Only ``subprocess.run``
+(the ``git ls-remote`` call) is mocked to avoid network dependency.
+
+A true end-to-end test against a real private Bitbucket server is
+infeasible in CI (no private instance available).  The tests verify the
+**credential-env contract** instead: the env dict passed to
+``git ls-remote`` must not contain config-isolation keys that block
+credential helpers for HTTPS connections.
+
+The parity test confirms the direct ``apm install`` validation path and
+the manifest-driven ``_build_validation_attempts`` path produce
+equivalent credential environments for the same generic HTTPS URL.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from apm_cli.core.auth import AuthResolver
+from apm_cli.core.token_manager import GitHubTokenManager
+from apm_cli.deps.github_downloader import GitHubPackageDownloader
+from apm_cli.deps.github_downloader_validation import _build_validation_attempts
+from apm_cli.install import validation
+from apm_cli.models.apm_package import DependencyReference
+
+pytestmark = [pytest.mark.integration]
+
+# ── Shared constants ──────────────────────────────────────────────────
+
+_HTTPS_URL = "https://bitbucket.example.internal/scm/team/repo.git"
+_HTTP_URL = "http://bitbucket.example.internal/scm/team/repo.git"
+
+# Env vars to scrub so the resolver finds no pre-existing tokens.
+_TOKEN_VARS = ("GITHUB_APM_PAT", "GITHUB_TOKEN", "GH_TOKEN", "ADO_APM_PAT")
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _ok_completed_process(*args, **kwargs):
+    """Fake ``subprocess.run`` result simulating a successful ``git ls-remote``."""
+    return subprocess.CompletedProcess(
+        args=args[0] if args else [],
+        returncode=0,
+        stdout="abc123\trefs/heads/main\n",
+        stderr="",
+    )
+
+
+def _clean_env() -> dict[str, str]:
+    """Return a copy of ``os.environ`` with token vars removed."""
+    return {k: v for k, v in os.environ.items() if k not in _TOKEN_VARS}
+
+
+def _make_resolver() -> AuthResolver:
+    """Build a real ``AuthResolver`` (no mocks on the resolver itself)."""
+    return AuthResolver()
+
+
+# ── Context managers ──────────────────────────────────────────────────
+# Reusable patches shared across multiple tests.
+
+_NO_GIT_CRED = lambda: patch.object(  # noqa: E731
+    GitHubTokenManager, "resolve_credential_from_git", return_value=None
+)
+_NO_GH_CLI = lambda: patch.object(  # noqa: E731
+    GitHubTokenManager, "resolve_credential_from_gh_cli", return_value=None
+)
+
+
+# =====================================================================
+# 1. Full-flow: HTTPS generic host
+# =====================================================================
+
+
+class TestHttpsGenericHostEnv:
+    """Validate that the env for a generic HTTPS host allows credential
+    helpers to operate (no config isolation, no GIT_ASKPASS)."""
+
+    def test_https_env_allows_credential_helpers(self):
+        """Direct ``apm install <https-url>`` must not block credential
+        helpers for a generic HTTPS host."""
+        captured_env: dict[str, str] = {}
+
+        def _capture_run(*args, **kwargs):
+            env = kwargs.get("env") or {}
+            captured_env.update(env)
+            return _ok_completed_process(*args, **kwargs)
+
+        with (
+            patch.dict(os.environ, _clean_env(), clear=True),
+            _NO_GIT_CRED(),
+            _NO_GH_CLI(),
+            patch("subprocess.run", side_effect=_capture_run),
+        ):
+            resolver = _make_resolver()
+            validation._validate_package_exists(
+                _HTTPS_URL,
+                verbose=False,
+                auth_resolver=resolver,
+            )
+
+        # Credential helpers must be reachable.
+        assert captured_env.get("GIT_CONFIG_GLOBAL") != "/dev/null", (
+            "GIT_CONFIG_GLOBAL=/dev/null blocks credential helpers"
+        )
+        assert captured_env.get("GIT_CONFIG_NOSYSTEM") != "1", (
+            "GIT_CONFIG_NOSYSTEM=1 blocks system credential helpers"
+        )
+        # Interactive prompts are still suppressed.
+        assert captured_env.get("GIT_TERMINAL_PROMPT") == "0", (
+            "GIT_TERMINAL_PROMPT must be 0 to prevent interactive prompts"
+        )
+        # GIT_ASKPASS must NOT be present (popped by noninteractive_env).
+        assert "GIT_ASKPASS" not in captured_env, (
+            "GIT_ASKPASS should be absent so credential helpers can work"
+        )
+
+
+# =====================================================================
+# 2. Full-flow: HTTP insecure generic host
+# =====================================================================
+
+
+class TestHttpInsecureGenericHostEnv:
+    """Validate that the env for a plain HTTP host enforces full config
+    isolation and credential-helper suppression."""
+
+    def test_http_env_enforces_config_isolation(self):
+        """Direct ``apm install <http-url>`` must lock down credential
+        helpers for insecure plaintext transport."""
+        captured_env: dict[str, str] = {}
+
+        def _capture_run(*args, **kwargs):
+            env = kwargs.get("env") or {}
+            captured_env.update(env)
+            return _ok_completed_process(*args, **kwargs)
+
+        with (
+            patch.dict(os.environ, _clean_env(), clear=True),
+            _NO_GIT_CRED(),
+            _NO_GH_CLI(),
+            patch("subprocess.run", side_effect=_capture_run),
+        ):
+            resolver = _make_resolver()
+            validation._validate_package_exists(
+                _HTTP_URL,
+                verbose=False,
+                auth_resolver=resolver,
+            )
+
+        # Config isolation must be active.
+        assert captured_env.get("GIT_CONFIG_NOSYSTEM") == "1", (
+            "GIT_CONFIG_NOSYSTEM must be 1 for insecure HTTP"
+        )
+        # GIT_ASKPASS must be set to suppress credential helpers.
+        assert captured_env.get("GIT_ASKPASS") == "echo", (
+            "GIT_ASKPASS must be 'echo' for insecure HTTP"
+        )
+        # credential.helper override via GIT_CONFIG_COUNT.
+        assert captured_env.get("GIT_CONFIG_COUNT") == "1"
+        assert captured_env.get("GIT_CONFIG_KEY_0") == "credential.helper"
+        assert captured_env.get("GIT_CONFIG_VALUE_0") == ""
+
+
+# =====================================================================
+# 3. Parity: direct install vs manifest _build_validation_attempts
+# =====================================================================
+
+
+class TestCredentialEnvParity:
+    """The env produced by the direct install validation path must match
+    the env from ``_build_validation_attempts`` for the same generic
+    HTTPS URL."""
+
+    def test_direct_and_manifest_env_are_equivalent(self):
+        """Both paths must produce an env that does NOT isolate config
+        and does NOT suppress credential helpers for generic HTTPS."""
+        # ── Path A: direct install validation ──
+        captured_direct_env: dict[str, str] = {}
+
+        def _capture_run(*args, **kwargs):
+            env = kwargs.get("env") or {}
+            captured_direct_env.update(env)
+            return _ok_completed_process(*args, **kwargs)
+
+        with (
+            patch.dict(os.environ, _clean_env(), clear=True),
+            _NO_GIT_CRED(),
+            _NO_GH_CLI(),
+            patch("subprocess.run", side_effect=_capture_run),
+        ):
+            resolver = _make_resolver()
+            validation._validate_package_exists(
+                _HTTPS_URL,
+                verbose=False,
+                auth_resolver=resolver,
+            )
+
+        # ── Path B: _build_validation_attempts ──
+        with (
+            patch.dict(os.environ, _clean_env(), clear=True),
+            _NO_GIT_CRED(),
+            _NO_GH_CLI(),
+        ):
+            resolver_b = _make_resolver()
+            dep_ref = DependencyReference.parse(_HTTPS_URL)
+            downloader = GitHubPackageDownloader(auth_resolver=resolver_b)
+            if dep_ref.host:
+                downloader.github_host = dep_ref.host
+
+            attempts = _build_validation_attempts(downloader, dep_ref, log=lambda msg: None)
+
+        # For a generic host with no token, only the "plain HTTPS w/
+        # credential helper" attempt should be present.
+        plain_attempts = [a for a in attempts if "credential helper" in a.label.lower()]
+        assert len(plain_attempts) == 1, (
+            f"Expected exactly one credential-helper attempt, got {len(plain_attempts)}: "
+            f"{[a.label for a in attempts]}"
+        )
+        manifest_env = plain_attempts[0].env
+
+        # ── Compare credential-relevant keys ──
+        keys_of_interest = (
+            "GIT_CONFIG_GLOBAL",
+            "GIT_CONFIG_NOSYSTEM",
+            "GIT_ASKPASS",
+            "GIT_TERMINAL_PROMPT",
+        )
+
+        for key in keys_of_interest:
+            direct_val = captured_direct_env.get(key)
+            manifest_val = manifest_env.get(key)
+            assert direct_val == manifest_val, (
+                f"Env key {key} differs: direct={direct_val!r}, manifest={manifest_val!r}"
+            )
+
+        # Explicit contract assertions.
+        assert captured_direct_env.get("GIT_CONFIG_GLOBAL") != "/dev/null"
+        assert manifest_env.get("GIT_CONFIG_GLOBAL") != "/dev/null"
+        assert captured_direct_env.get("GIT_CONFIG_NOSYSTEM") != "1"
+        assert manifest_env.get("GIT_CONFIG_NOSYSTEM") != "1"
+        assert "GIT_ASKPASS" not in captured_direct_env
+        assert "GIT_ASKPASS" not in manifest_env
+        assert captured_direct_env.get("GIT_TERMINAL_PROMPT") == "0"
+        assert manifest_env.get("GIT_TERMINAL_PROMPT") == "0"
+
+
+# =====================================================================
+# 4. Credential helper simulation
+# =====================================================================
+
+
+class TestCredentialHelperSimulation:
+    """Even when ``git credential fill`` returns a token for the host,
+    the validation env for a generic host must still allow native
+    credential helpers (no config isolation).
+
+    For generic hosts ``_resolve_dep_token`` returns ``None`` regardless
+    of what the ``AuthResolver`` discovers, because generic hosts rely
+    on git's own credential helpers rather than APM-managed tokens.
+    The subprocess env must therefore remain non-isolated so those
+    helpers can inject credentials into ``git ls-remote``."""
+
+    def test_credential_fill_does_not_trigger_config_isolation(self):
+        captured_env: dict[str, str] = {}
+
+        def _capture_run(*args, **kwargs):
+            env = kwargs.get("env") or {}
+            captured_env.update(env)
+            return _ok_completed_process(*args, **kwargs)
+
+        with (
+            patch.dict(os.environ, _clean_env(), clear=True),
+            patch.object(
+                GitHubTokenManager,
+                "resolve_credential_from_git",
+                return_value="fake-credential-token-abc123",
+            ),
+            _NO_GH_CLI(),
+            patch("subprocess.run", side_effect=_capture_run),
+        ):
+            resolver = _make_resolver()
+            validation._validate_package_exists(
+                _HTTPS_URL,
+                verbose=False,
+                auth_resolver=resolver,
+            )
+
+        # Even with a credential-fill token, the generic-host branch
+        # does NOT use it directly; it delegates to native git helpers.
+        # The env must therefore remain non-isolated.
+        assert captured_env.get("GIT_CONFIG_GLOBAL") != "/dev/null", (
+            "GIT_CONFIG_GLOBAL=/dev/null blocks credential helpers"
+        )
+        assert captured_env.get("GIT_CONFIG_NOSYSTEM") != "1", (
+            "GIT_CONFIG_NOSYSTEM=1 blocks system credential helpers"
+        )
+        assert captured_env.get("GIT_TERMINAL_PROMPT") == "0", "GIT_TERMINAL_PROMPT must be 0"
+        assert "GIT_ASKPASS" not in captured_env, (
+            "GIT_ASKPASS should be absent so credential helpers can work"
+        )

--- a/tests/unit/install/test_validation_credential_env.py
+++ b/tests/unit/install/test_validation_credential_env.py
@@ -1,0 +1,173 @@
+"""Tests for generic-host credential-helper env in install.validation.
+
+Regression: ``apm install https://corp-bitbucket.example/...`` on a generic
+(non-GitHub, non-ADO) host set ``preserve_config_isolation=True`` because the
+flag was wired to ``prefer_web_probe_first`` instead of ``is_insecure``.  This
+kept ``GIT_CONFIG_GLOBAL=/dev/null`` and ``GIT_CONFIG_NOSYSTEM=1`` in the
+subprocess env, preventing git from reading user-configured credential helpers
+(e.g. osxkeychain, credential-store, manager-core) from ``~/.gitconfig``.
+
+After the fix, ``preserve_config_isolation`` uses ``is_insecure`` (matching
+every other call site), so config isolation is only enforced for plaintext
+HTTP connections where credential leakage is a real risk.  (issue #1013)
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from apm_cli.deps.github_downloader import GitHubPackageDownloader
+from apm_cli.install import validation
+
+
+def _make_resolver():
+    """Resolver mock sufficient for the generic-host validation branch."""
+    resolver = MagicMock()
+    host_info = MagicMock()
+    host_info.api_base = "https://bitbucket.example.internal"
+    host_info.display_name = "bitbucket.example.internal"
+    host_info.kind = "generic"
+    host_info.has_public_repos = False
+    resolver.classify_host.return_value = host_info
+    ctx = MagicMock(source="env", token_type="pat", token=None)
+    resolver.resolve.return_value = ctx
+    resolver.resolve_for_dep.return_value = ctx
+    return resolver
+
+
+def _ok_run(*args, **kwargs):
+    return subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout="abc123\trefs/heads/main\n",
+        stderr="",
+    )
+
+
+class TestGenericHostCredentialEnv:
+    """Validate that _build_noninteractive_git_env receives the correct
+    ``preserve_config_isolation`` and ``suppress_credential_helpers`` flags
+    for generic hosts, depending on whether the URL is HTTPS or HTTP."""
+
+    def test_https_generic_host_does_not_preserve_config_isolation(self, monkeypatch):
+        """HTTPS generic host: preserve_config_isolation=False so that
+        user-configured credential helpers in ~/.gitconfig can work."""
+        monkeypatch.delenv("APM_ALLOW_PROTOCOL_FALLBACK", raising=False)
+        resolver = _make_resolver()
+
+        original_build = GitHubPackageDownloader._build_noninteractive_git_env
+        captured_calls: list[dict] = []
+
+        def _spy(self, *, preserve_config_isolation=False, suppress_credential_helpers=False):
+            captured_calls.append(
+                {
+                    "preserve_config_isolation": preserve_config_isolation,
+                    "suppress_credential_helpers": suppress_credential_helpers,
+                }
+            )
+            return original_build(
+                self,
+                preserve_config_isolation=preserve_config_isolation,
+                suppress_credential_helpers=suppress_credential_helpers,
+            )
+
+        with (
+            patch.object(
+                GitHubPackageDownloader,
+                "_build_noninteractive_git_env",
+                _spy,
+            ),
+            patch("subprocess.run", side_effect=_ok_run),
+        ):
+            validation._validate_package_exists(
+                "https://bitbucket.example.internal/scm/team/repo.git",
+                verbose=False,
+                auth_resolver=resolver,
+            )
+
+        assert len(captured_calls) == 1, f"expected exactly one call, got {len(captured_calls)}"
+        assert captured_calls[0]["preserve_config_isolation"] is False
+        assert captured_calls[0]["suppress_credential_helpers"] is False
+
+    def test_http_generic_host_preserves_config_isolation(self, monkeypatch):
+        """HTTP (insecure) generic host: preserve_config_isolation=True
+        and suppress_credential_helpers=True to prevent credential leakage."""
+        monkeypatch.delenv("APM_ALLOW_PROTOCOL_FALLBACK", raising=False)
+        resolver = _make_resolver()
+
+        original_build = GitHubPackageDownloader._build_noninteractive_git_env
+        captured_calls: list[dict] = []
+
+        def _spy(self, *, preserve_config_isolation=False, suppress_credential_helpers=False):
+            captured_calls.append(
+                {
+                    "preserve_config_isolation": preserve_config_isolation,
+                    "suppress_credential_helpers": suppress_credential_helpers,
+                }
+            )
+            return original_build(
+                self,
+                preserve_config_isolation=preserve_config_isolation,
+                suppress_credential_helpers=suppress_credential_helpers,
+            )
+
+        with (
+            patch.object(
+                GitHubPackageDownloader,
+                "_build_noninteractive_git_env",
+                _spy,
+            ),
+            patch("subprocess.run", side_effect=_ok_run),
+        ):
+            validation._validate_package_exists(
+                "http://bitbucket.example.internal/scm/team/repo.git",
+                verbose=False,
+                auth_resolver=resolver,
+            )
+
+        assert len(captured_calls) == 1, f"expected exactly one call, got {len(captured_calls)}"
+        assert captured_calls[0]["preserve_config_isolation"] is True
+        assert captured_calls[0]["suppress_credential_helpers"] is True
+
+
+class TestGenericHttpsEnvContents:
+    """Concrete environment check: for a generic HTTPS host the resulting
+    validate_env must NOT contain the config-isolation keys that block
+    credential helpers."""
+
+    def test_https_env_allows_credential_helpers(self, monkeypatch):
+        """The env produced for a generic HTTPS URL must not contain
+        GIT_CONFIG_GLOBAL=/dev/null or GIT_CONFIG_NOSYSTEM=1, because
+        these prevent git from reading credential helpers from
+        ~/.gitconfig."""
+        monkeypatch.delenv("APM_ALLOW_PROTOCOL_FALLBACK", raising=False)
+        resolver = _make_resolver()
+
+        captured_env: dict[str, str] = {}
+
+        def _capture_env_run(*args, **kwargs):
+            env = kwargs.get("env") or {}
+            captured_env.update(env)
+            return subprocess.CompletedProcess(
+                args=args[0] if args else [],
+                returncode=0,
+                stdout="abc123\trefs/heads/main\n",
+                stderr="",
+            )
+
+        with patch("subprocess.run", side_effect=_capture_env_run):
+            validation._validate_package_exists(
+                "https://bitbucket.example.internal/scm/team/repo.git",
+                verbose=False,
+                auth_resolver=resolver,
+            )
+
+        # The env passed to subprocess.run for the ls-remote probe
+        # must not contain config-isolation keys.
+        assert captured_env.get("GIT_CONFIG_GLOBAL") != "/dev/null", (
+            "GIT_CONFIG_GLOBAL=/dev/null blocks credential helpers"
+        )
+        assert captured_env.get("GIT_CONFIG_NOSYSTEM") != "1", (
+            "GIT_CONFIG_NOSYSTEM=1 blocks system credential helpers"
+        )


### PR DESCRIPTION
# Description

`apm install <https-url>` fails with `terminalprompts disabled` on private repos that work fine with `git clone` and with manifest-driven `apm install --update`. The direct install validation path (`git ls-remote`) does not honour the configured Git credential mechanism.

**Root cause**: The direct `apm install <url>` validation code path does not use `git-credential-fill` to inject credentials into the `git ls-remote` environment, while the manifest-driven install path does.

**Fix**: Align the direct install validation path with the manifest-driven credential handling so that `git ls-remote` receives the same credential environment as `git clone`.

Follow-up to #992.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [ ] Unit test: HTTPS validation with credential helper
- [ ] All existing tests pass

Closes #1013
