### PR TITLE
fix(install,tests): repair 63 integration tests in merge queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Unknown target` error suggestions no longer advertise the `agent-skills` meta-target, which `apm targets` intentionally omits from its table. The canonical set still accepts `agent-skills` via `--target` and `apm.yml`, but the recovery path printed on errors now matches what the discovery command actually lists. (#1215)
 - `apm pack` no longer hardcodes `pack.target` into bundles; bundles are target-agnostic and `apm install <bundle>` resolves the consumer target from project context and wires bundle `.mcp.json` servers per target via `MCPIntegrator`. (#1217)
 - Multi-account Git Credential Manager users: APM now selects the right GitHub account automatically per repository (no account-picker prompt) when `credential.useHttpPath = true` is set. Existing single-account setups are unaffected. (#1226)
+- `apm install --global <abs-local-path>` no longer rejects absolute local paths at user scope (regression introduced by #1149); restores the post-#937 contract that only relative local paths are ambiguous at user scope. (#1247)
+- Realigned the failing integration suite with current product contracts: copilot-target detection requires `.github/copilot-instructions.md` (post-#1154), `apm marketplace build` is removed in favor of `apm pack`, ADO virtual collections use the SUBDIRECTORY layout (post-#1094), and the `repo:` apm.yml key is replaced by `git:`. (#1247)
 
 ## [0.12.4] - 2026-05-07
 

--- a/src/apm_cli/install/package_resolution.py
+++ b/src/apm_cli/install/package_resolution.py
@@ -86,7 +86,10 @@ def user_scope_rejection_reason(dep_ref: Any, scope: Any) -> str | None:
 
     if dep_ref.is_local and scope is InstallScope.USER:
         local_path = dep_ref.local_path or ""
-        if not Path(local_path).is_absolute():
+        # Match the rest of the install pipeline (sources.py, phases/resolve.py)
+        # which expanduser()s local paths before consuming them: `~/pkg` is
+        # absolute after expansion and must NOT be rejected here.
+        if not Path(local_path).expanduser().is_absolute():
             return (
                 "relative local paths are not supported at user scope (--global). "
                 "Use an absolute path or a remote reference (owner/repo) instead"

--- a/src/apm_cli/install/package_resolution.py
+++ b/src/apm_cli/install/package_resolution.py
@@ -72,16 +72,25 @@ def resolve_parsed_dependency_reference(
 
 
 def user_scope_rejection_reason(dep_ref: Any, scope: Any) -> str | None:
-    """Return a validation-fail reason if *dep_ref* is invalid at user scope."""
+    """Return a validation-fail reason if *dep_ref* is invalid at user scope.
+
+    Per #937, only relative local paths are rejected at user scope -- absolute
+    local paths are unambiguous and flow through the same _copy_local_package
+    code path as project scope.
+    """
     if scope is None:
         return None
+    from pathlib import Path
+
     from apm_cli.core.scope import InstallScope
 
     if dep_ref.is_local and scope is InstallScope.USER:
-        return (
-            "local packages are not supported at user scope (--global). "
-            "Use a remote reference (owner/repo) instead"
-        )
+        local_path = dep_ref.local_path or ""
+        if not Path(local_path).is_absolute():
+            return (
+                "relative local paths are not supported at user scope (--global). "
+                "Use an absolute path or a remote reference (owner/repo) instead"
+            )
     if dep_ref.is_parent_repo_inheritance and scope is InstallScope.USER:
         return GIT_PARENT_USER_SCOPE_ERROR
     return None

--- a/tests/fixtures/azure-skills/.claude-plugin/marketplace.json
+++ b/tests/fixtures/azure-skills/.claude-plugin/marketplace.json
@@ -8,8 +8,8 @@
     {
       "name": "azure",
       "description": "Microsoft Azure MCP integration for cloud resource management, deployments, and Azure services. Manage your Azure infrastructure, monitor applications, and deploy resources directly from Claude Code.",
-      "source": "./.github/plugins/azure-skills",
-      "homepage": "https://github.com/microsoft/azure-skills"
+      "homepage": "https://github.com/microsoft/azure-skills",
+      "source": "./.github/plugins/azure-skills"
     }
   ]
 }

--- a/tests/integration/marketplace/test_build_integration.py
+++ b/tests/integration/marketplace/test_build_integration.py
@@ -256,11 +256,13 @@ class TestBuildCLI:
     """Tests that invoke `apm marketplace build` via subprocess."""
 
     def test_missing_yml_exits_1(self, tmp_path: Path):
-        """Missing marketplace.yml must exit 1."""
+        """`apm marketplace build` was removed; the stub exits 2 with a
+        deprecation message that points users at `apm pack`."""
         result = run_cli(["marketplace", "build"], cwd=tmp_path)
-        assert result.returncode == 1
+        assert result.returncode == 2
         combined = result.stdout + result.stderr
-        assert "marketplace.yml" in combined
+        assert "removed" in combined.lower()
+        assert "apm pack" in combined
 
     def test_schema_error_exits_2(self, tmp_path: Path):
         """Malformed marketplace.yml must exit 2."""
@@ -269,10 +271,12 @@ class TestBuildCLI:
         assert result.returncode == 2
 
     def test_dry_run_flag_present(self, tmp_path: Path, mock_ref_resolver):
-        """--dry-run must be accepted by the CLI (no crash)."""
+        """The removed `apm marketplace build` accepts --dry-run without
+        crashing on unknown args; exit is the deprecation code (2) and
+        there is no Python traceback."""
         _write_yml(tmp_path, MINIMAL_YML)
         result = run_cli(["marketplace", "build", "--dry-run"], cwd=tmp_path)
-        # Without real network, build will fail resolving refs; exit != 0 is OK.
-        # Key check: exit code is not 2 (schema error) and no Python traceback.
-        assert result.returncode != 2
+        assert result.returncode == 2
         assert "Traceback" not in result.stderr
+        combined = result.stdout + result.stderr
+        assert "removed" in combined.lower()

--- a/tests/integration/test_azure_skills_marketplace.py
+++ b/tests/integration/test_azure_skills_marketplace.py
@@ -20,7 +20,7 @@ from click.testing import CliRunner
 from apm_cli.commands.pack import pack_cmd
 
 FIXTURES = Path(__file__).parent.parent / "fixtures" / "azure-skills"
-EXPECTED_SHA256 = "02f76bfc0e5bbf7fdf1de1dda1f84c4da6e986913b6647973c0ffe39c1d5003b"
+EXPECTED_SHA256 = "583399dd0eff5e4ed275c9c1e7bcd79b55c088c6468749a226311e6f1dddc4c2"
 
 
 @pytest.mark.integration

--- a/tests/integration/test_deployed_files_e2e.py
+++ b/tests/integration/test_deployed_files_e2e.py
@@ -52,8 +52,10 @@ def temp_project(tmp_path):
         "  mcp: []\n"
     )
 
-    # Create .github folder so VSCode target is detected
+    # Create .github/copilot-instructions.md so the copilot target is
+    # detected (post-#1154 the bare directory is no longer a signal).
     (project_dir / ".github").mkdir()
+    (project_dir / ".github" / "copilot-instructions.md").write_text("# test\n")
 
     return project_dir
 

--- a/tests/integration/test_global_install_e2e.py
+++ b/tests/integration/test_global_install_e2e.py
@@ -216,6 +216,7 @@ class TestGlobalInstallDeploysRealPackage:
         project_dir = tmp_path / "project"
         project_dir.mkdir()
         (project_dir / ".github").mkdir()
+        (project_dir / ".github" / "copilot-instructions.md").write_text("# test\n")
         (project_dir / "apm.yml").write_text(
             yaml.dump(
                 {

--- a/tests/integration/test_global_scope_e2e.py
+++ b/tests/integration/test_global_scope_e2e.py
@@ -51,6 +51,10 @@ def fake_home(tmp_path):
     """
     home_dir = tmp_path / "fakehome"
     home_dir.mkdir()
+    # Mark the home dir as a copilot harness so install --global passes
+    # target detection (post-#1154 the bare directory is no longer a signal).
+    (home_dir / ".github").mkdir()
+    (home_dir / ".github" / "copilot-instructions.md").write_text("# test\n")
     return home_dir
 
 

--- a/tests/integration/test_install_dry_run_e2e.py
+++ b/tests/integration/test_install_dry_run_e2e.py
@@ -33,11 +33,12 @@ def apm_command():
 
 @pytest.fixture
 def temp_project(tmp_path):
-    """Temp APM project with .github/ for VSCode target detection."""
+    """Temp APM project. Target is set explicitly in apm.yml so that target
+    detection does not depend on .github/copilot-instructions.md existing
+    (whose absence is asserted by _assert_no_install_artifacts after the
+    dry-run)."""
     project_dir = tmp_path / "dry-run-test"
     project_dir.mkdir()
-    (project_dir / ".github").mkdir()
-    (project_dir / ".github" / "copilot-instructions.md").write_text("# test\n")
     return project_dir
 
 
@@ -55,6 +56,7 @@ def _write_apm_yml(project_dir, apm_packages, mcp_packages=None):
     config = {
         "name": "dry-run-test",
         "version": "1.0.0",
+        "targets": ["copilot"],
         "dependencies": {
             "apm": apm_packages,
             "mcp": mcp_packages or [],

--- a/tests/integration/test_install_dry_run_e2e.py
+++ b/tests/integration/test_install_dry_run_e2e.py
@@ -37,6 +37,7 @@ def temp_project(tmp_path):
     project_dir = tmp_path / "dry-run-test"
     project_dir.mkdir()
     (project_dir / ".github").mkdir()
+    (project_dir / ".github" / "copilot-instructions.md").write_text("# test\n")
     return project_dir
 
 

--- a/tests/integration/test_install_invalid_deps_format_e2e.py
+++ b/tests/integration/test_install_invalid_deps_format_e2e.py
@@ -48,6 +48,7 @@ class TestInstallInvalidDepsFormatE2E:
             encoding="utf-8",
         )
         (tmp_path / ".github").mkdir()
+        (tmp_path / ".github" / "copilot-instructions.md").write_text("# test\n")
 
         with patch(_PATCH_UPDATES, return_value=None):
             result = runner.invoke(cli, ["install"], catch_exceptions=False)
@@ -55,7 +56,7 @@ class TestInstallInvalidDepsFormatE2E:
         assert result.exit_code != 0, (
             f"Expected non-zero exit for flat-list deps; got 0.\nstdout:\n{result.stdout}"
         )
-        combined = (result.output or "") + (result.stderr or "")
+        combined = " ".join(((result.output or "") + (result.stderr or "")).split())
         assert "expected a mapping" in combined, (
             f"Expected 'expected a mapping' in output:\n{combined}"
         )
@@ -74,6 +75,7 @@ class TestInstallInvalidDepsFormatE2E:
             encoding="utf-8",
         )
         (tmp_path / ".github").mkdir()
+        (tmp_path / ".github" / "copilot-instructions.md").write_text("# test\n")
 
         with patch(_PATCH_UPDATES, return_value=None):
             result = runner.invoke(cli, ["install"], catch_exceptions=False)
@@ -81,7 +83,7 @@ class TestInstallInvalidDepsFormatE2E:
         assert result.exit_code != 0, (
             f"Expected non-zero exit for string deps; got 0.\nstdout:\n{result.stdout}"
         )
-        combined = (result.output or "") + (result.stderr or "")
+        combined = " ".join(((result.output or "") + (result.stderr or "")).split())
         assert "expected a mapping" in combined, (
             f"Expected 'expected a mapping' in output:\n{combined}"
         )
@@ -103,6 +105,7 @@ class TestInstallInvalidDepsFormatE2E:
             encoding="utf-8",
         )
         (tmp_path / ".github").mkdir()
+        (tmp_path / ".github" / "copilot-instructions.md").write_text("# test\n")
 
         with patch(_PATCH_UPDATES, return_value=None):
             result = runner.invoke(cli, ["install"], catch_exceptions=False)

--- a/tests/integration/test_intra_package_cleanup.py
+++ b/tests/integration/test_intra_package_cleanup.py
@@ -36,6 +36,7 @@ def temp_project(tmp_path):
     project_dir = tmp_path / "intra-package-cleanup-test"
     project_dir.mkdir()
     (project_dir / ".github").mkdir()
+    (project_dir / ".github" / "copilot-instructions.md").write_text("# test\n")
     return project_dir
 
 

--- a/tests/integration/test_local_content_audit.py
+++ b/tests/integration/test_local_content_audit.py
@@ -64,8 +64,9 @@ def _seed_local_content(project: Path) -> None:
     instr_dir.mkdir(parents=True)
     (instr_dir / "bar.instructions.md").write_text("---\napplyTo: '**'\n---\n# Bar\nbody\n")
 
-    # .github/ already-exists triggers copilot target detection (and the
-    # default fallback is also copilot, so this is belt-and-suspenders).
+    # Post-#1154, the copilot target-detection signal is the
+    # .github/copilot-instructions.md file (a bare .github/ directory is no
+    # longer sufficient). Seed the marker so target detection succeeds.
     (project / ".github").mkdir()
     (project / ".github" / "copilot-instructions.md").write_text("# test\n")
 

--- a/tests/integration/test_local_content_audit.py
+++ b/tests/integration/test_local_content_audit.py
@@ -67,6 +67,7 @@ def _seed_local_content(project: Path) -> None:
     # .github/ already-exists triggers copilot target detection (and the
     # default fallback is also copilot, so this is belt-and-suspenders).
     (project / ".github").mkdir()
+    (project / ".github" / "copilot-instructions.md").write_text("# test\n")
 
 
 def _make_project(tmp_path: Path, *, includes=None) -> Path:

--- a/tests/integration/test_local_install.py
+++ b/tests/integration/test_local_install.py
@@ -70,6 +70,7 @@ def temp_workspace(tmp_path):
     )
     # Create .github directory for instructions deployment
     (consumer / ".github").mkdir()
+    (consumer / ".github" / "copilot-instructions.md").write_text("# test\n")
 
     # Local skills package
     skills_pkg = workspace / "packages" / "local-skills"

--- a/tests/integration/test_pack_unpack_e2e.py
+++ b/tests/integration/test_pack_unpack_e2e.py
@@ -43,6 +43,7 @@ def temp_project(tmp_path):
     )
 
     (project_dir / ".github").mkdir()
+    (project_dir / ".github" / "copilot-instructions.md").write_text("# test\n")
     return project_dir
 
 

--- a/tests/integration/test_plugin_e2e.py
+++ b/tests/integration/test_plugin_e2e.py
@@ -400,6 +400,7 @@ def temp_project(tmp_path):
         "  apm: []\n"
     )
     (project_dir / ".github").mkdir()
+    (project_dir / ".github" / "copilot-instructions.md").write_text("# test\n")
     return project_dir
 
 

--- a/tests/integration/test_policy_install_e2e.py
+++ b/tests/integration/test_policy_install_e2e.py
@@ -218,6 +218,7 @@ def project(tmp_path):
     project_dir = tmp_path / "policy-e2e"
     project_dir.mkdir()
     (project_dir / ".github").mkdir()
+    (project_dir / ".github" / "copilot-instructions.md").write_text("# test\n")
     os.chdir(project_dir)
     yield project_dir, CliRunner()
     os.chdir(orig_cwd)

--- a/tests/integration/test_selective_install_mcp.py
+++ b/tests/integration/test_selective_install_mcp.py
@@ -56,6 +56,17 @@ def _make_pkg(
     )
 
 
+def _mark_copilot(project_root: Path) -> None:
+    """Mark *project_root* as a copilot harness so target detection passes.
+
+    Post-#1154 the bare ``.github/`` directory is no longer a signal --
+    ``.github/copilot-instructions.md`` is the canonical marker file.
+    """
+    github = project_root / ".github"
+    github.mkdir(exist_ok=True)
+    (github / "copilot-instructions.md").write_text("# test\n")
+
+
 def _seed_lockfile(path: Path, locked_deps: list, mcp_servers: list = None):  # noqa: RUF013
     """Write a lockfile pre-populated with given dependencies."""
     lf = LockFile()
@@ -90,6 +101,9 @@ def cli_env(tmp_path):
 
     # Root project declares squad-alpha as a dep
     _write_apm_yml(tmp_path / "apm.yml", deps=["acme/squad-alpha"])
+
+    # Mark project as a copilot harness so target detection succeeds
+    _mark_copilot(tmp_path)
 
     # squad-alpha has no MCP, depends on infra-cloud
     _make_pkg(apm_modules, "acme/squad-alpha", apm_deps=["acme/infra-cloud"])
@@ -214,6 +228,7 @@ class TestDeepChainIntegration:
             apm_modules = tmp_path / "apm_modules"
 
             _write_apm_yml(tmp_path / "apm.yml", deps=["acme/pkg-a"])
+            _mark_copilot(tmp_path)
             _make_pkg(apm_modules, "acme/pkg-a", apm_deps=["acme/pkg-b"])
             _make_pkg(apm_modules, "acme/pkg-b", apm_deps=["acme/pkg-c"])
             _make_pkg(apm_modules, "acme/pkg-c", apm_deps=["acme/pkg-d"])
@@ -286,6 +301,7 @@ class TestDiamondDependencyIntegration:
             apm_modules = tmp_path / "apm_modules"
 
             _write_apm_yml(tmp_path / "apm.yml", deps=["acme/pkg-a"])
+            _mark_copilot(tmp_path)
             _make_pkg(apm_modules, "acme/pkg-a", apm_deps=["acme/pkg-b", "acme/pkg-c"])
             _make_pkg(apm_modules, "acme/pkg-b", apm_deps=["acme/pkg-d"])
             _make_pkg(apm_modules, "acme/pkg-c", apm_deps=["acme/pkg-d"])
@@ -365,6 +381,7 @@ class TestMultiPackageSelectiveInstallIntegration:
             apm_modules = tmp_path / "apm_modules"
 
             _write_apm_yml(tmp_path / "apm.yml", deps=["acme/pkg-x", "acme/pkg-y"])
+            _mark_copilot(tmp_path)
 
             # pkg-x → dep-x (has mcp-x)
             _make_pkg(apm_modules, "acme/pkg-x", apm_deps=["acme/dep-x"])
@@ -464,6 +481,7 @@ class TestStaleRemovalAfterUpdate:
 
             # Root depends on infra-cloud
             _write_apm_yml(tmp_path / "apm.yml", deps=["acme/infra-cloud"])
+            _mark_copilot(tmp_path)
 
             # infra-cloud NOW declares only mcp-beta (dropped mcp-alpha)
             _make_pkg(

--- a/tests/integration/test_uninstall_dry_run_e2e.py
+++ b/tests/integration/test_uninstall_dry_run_e2e.py
@@ -36,6 +36,7 @@ def temp_project(tmp_path):
     project_dir = tmp_path / "uninstall-dry-run-test"
     project_dir.mkdir()
     (project_dir / ".github").mkdir()
+    (project_dir / ".github" / "copilot-instructions.md").write_text("# test\n")
     return project_dir
 
 

--- a/tests/integration/test_uninstall_multi_e2e.py
+++ b/tests/integration/test_uninstall_multi_e2e.py
@@ -43,6 +43,7 @@ def temp_project(tmp_path):
     project_dir = tmp_path / "uninstall-multi-test"
     project_dir.mkdir()
     (project_dir / ".github").mkdir()
+    (project_dir / ".github" / "copilot-instructions.md").write_text("# test\n")
     return project_dir
 
 

--- a/tests/integration/test_update_e2e.py
+++ b/tests/integration/test_update_e2e.py
@@ -228,7 +228,7 @@ def _write_apm_yml_with_ref(project_dir: Path, package: str, *, ref: str) -> Non
         "name": "update-test",
         "version": "1.0.0",
         "dependencies": {
-            "apm": [{"repo": package, "ref": ref}],
+            "apm": [{"git": package, "ref": ref}],
             "mcp": [],
         },
     }

--- a/tests/integration/test_virtual_package_orphan_detection.py
+++ b/tests/integration/test_virtual_package_orphan_detection.py
@@ -340,14 +340,18 @@ def test_azure_devops_virtual_collection_not_flagged_as_orphan(tmp_path):
     with open(project_dir / "apm.yml", "w") as f:
         yaml.dump(apm_yml_content, f)
 
-    # Simulate installed ADO virtual collection package
-    # ADO 3-level structure: apm_modules/org/project/virtual-pkg-name
+    # Simulate installed ADO virtual collection package.
+    # Per #1094, virtual collection packages now use the SUBDIRECTORY layout,
+    # so the on-disk structure preserves the natural path:
+    #   apm_modules/org/project/repo/collections/<name>
     collection_dir = (
         project_dir
         / "apm_modules"
         / "company"
         / "my-azurecollection"
-        / "copilot-instructions-csharp-ddd-cleanarchitecture"
+        / "copilot-instructions"
+        / "collections"
+        / "csharp-ddd-cleanarchitecture"
     )
     collection_dir.mkdir(parents=True)
 
@@ -375,9 +379,9 @@ def test_azure_devops_virtual_collection_not_flagged_as_orphan(tmp_path):
         f"ADO virtual collection should not be flagged as orphaned. Found: {orphaned_packages}. Expected: {expected_installed}"
     )
 
-    # Verify the expected path is correct for ADO 3-level structure
+    # Verify the expected path is correct for ADO virtual subdirectory layout
     assert (
-        "company/my-azurecollection/copilot-instructions-csharp-ddd-cleanarchitecture"
+        "company/my-azurecollection/copilot-instructions/collections/csharp-ddd-cleanarchitecture"
         in expected_installed
     )
 
@@ -452,11 +456,13 @@ def test_get_dependency_declaration_order_ado_virtual(tmp_path):
     # Get dependency order
     dep_order = get_dependency_declaration_order(str(project_dir))
 
-    # Should return the correct installed path for ADO virtual collection
+    # Should return the correct installed path for ADO virtual collection.
+    # Per #1094, virtual collection packages use the SUBDIRECTORY layout
+    # (natural slash path), not the flattened name.
     assert len(dep_order) == 1
     assert (
         dep_order[0]
-        == "company/my-azurecollection/copilot-instructions-csharp-ddd-cleanarchitecture"
+        == "company/my-azurecollection/copilot-instructions/collections/csharp-ddd-cleanarchitecture"
     )
 
 
@@ -495,8 +501,8 @@ def test_get_dependency_declaration_order_mixed_github_and_ado(tmp_path):
     )  # GitHub virtual subdirectory: owner/repo/subdir
     assert dep_order[2] == "company/project/repo"  # ADO regular: org/project/repo
     assert (
-        dep_order[3] == "company/my-azurecollection/copilot-instructions-csharp-ddd"
-    )  # ADO virtual: org/project/virtual-pkg-name
+        dep_order[3] == "company/my-azurecollection/copilot-instructions/collections/csharp-ddd"
+    )  # ADO virtual subdirectory: org/project/repo/collections/<name>
 
 
 @pytest.mark.integration

--- a/tests/unit/install/test_user_scope_rejection_reason.py
+++ b/tests/unit/install/test_user_scope_rejection_reason.py
@@ -1,0 +1,166 @@
+"""Regression-trap tests for ``user_scope_rejection_reason``.
+
+This module pins the post-#937 / post-#1149 contract:
+
+  * Project scope            -> NEVER reject (manifest gates ambiguity).
+  * User scope, remote ref   -> NEVER reject (the happy path).
+  * User scope, local *abs*  -> NEVER reject (an absolute path is unambiguous;
+                                see PR #937 commit message).
+  * User scope, local *rel*  -> ALWAYS reject (relative-to-cwd is ambiguous
+                                outside a project; ``$HOME`` is not a project
+                                root).
+  * User scope, ``git: parent`` inheritance -> ALWAYS reject (no monorepo
+                                root at user scope).
+
+A regression here previously shipped to release because the only coverage
+was a single slow E2E (``test_auto_bootstrap_creates_user_manifest``) that
+was not wired into CI -- the #1149 GitLab refactor regressed the absolute-
+path branch and went undetected for an entire release window.
+
+Keeping these as fast unit tests means the next refactor that touches the
+predicate fails one assertion in <10ms instead of one slow E2E in 14s.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from apm_cli.core.scope import InstallScope
+from apm_cli.install.package_resolution import (
+    GIT_PARENT_USER_SCOPE_ERROR,
+    user_scope_rejection_reason,
+)
+from apm_cli.models.dependency.reference import DependencyReference
+
+
+def _local_ref(path: str) -> DependencyReference:
+    """Build a minimal local DependencyReference."""
+    return DependencyReference(
+        repo_url="local",
+        is_local=True,
+        local_path=path,
+    )
+
+
+def _remote_ref() -> DependencyReference:
+    return DependencyReference(repo_url="acme/widgets")
+
+
+def _parent_ref() -> DependencyReference:
+    return DependencyReference(
+        repo_url="acme/monorepo",
+        is_parent_repo_inheritance=True,
+        virtual_path="packages/widgets",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Scope handling
+# ---------------------------------------------------------------------------
+
+
+def test_scope_none_never_rejects():
+    """A None scope short-circuits to None (no scope, no policy)."""
+    assert user_scope_rejection_reason(_local_ref("./pkg"), scope=None) is None
+    assert user_scope_rejection_reason(_remote_ref(), scope=None) is None
+
+
+def test_project_scope_accepts_relative_local_path():
+    """Project scope must never reject local paths (only USER scope is policed)."""
+    assert user_scope_rejection_reason(_local_ref("./pkg"), scope=InstallScope.PROJECT) is None
+
+
+def test_project_scope_accepts_absolute_local_path(tmp_path):
+    """Symmetry check: project scope is also fine with absolute local paths."""
+    assert (
+        user_scope_rejection_reason(_local_ref(str(tmp_path)), scope=InstallScope.PROJECT) is None
+    )
+
+
+def test_project_scope_accepts_parent_inheritance():
+    """``git: parent`` is a project-scope construct; project scope must accept it."""
+    assert user_scope_rejection_reason(_parent_ref(), scope=InstallScope.PROJECT) is None
+
+
+# ---------------------------------------------------------------------------
+# User-scope local-path policy (the regression hot-spot)
+# ---------------------------------------------------------------------------
+
+
+def test_user_scope_rejects_relative_local_path():
+    """Relative local paths are ambiguous at user scope -- must be rejected."""
+    reason = user_scope_rejection_reason(_local_ref("./pkg"), scope=InstallScope.USER)
+    assert reason is not None
+    assert "relative" in reason.lower()
+    assert "user scope" in reason or "--global" in reason
+
+
+def test_user_scope_rejects_dotted_relative_local_path():
+    """``../sibling`` is also relative -- must be rejected at user scope."""
+    reason = user_scope_rejection_reason(_local_ref("../sibling-pkg"), scope=InstallScope.USER)
+    assert reason is not None
+    assert "relative" in reason.lower()
+
+
+def test_user_scope_rejects_bare_directory_local_path():
+    """A bare directory name (no ``./``) is still relative -- must be rejected."""
+    reason = user_scope_rejection_reason(_local_ref("local-pkg"), scope=InstallScope.USER)
+    assert reason is not None
+    assert "relative" in reason.lower()
+
+
+def test_user_scope_accepts_absolute_local_path(tmp_path):
+    """Absolute local paths are unambiguous -- post-#937 contract.
+
+    This is the assertion that catches the #1149 regression: an
+    unconditional ``dep_ref.is_local`` check would fail this test.
+    """
+    abs_path = str(tmp_path / "local-pkg")
+    assert os.path.isabs(abs_path), "test setup invariant: tmp_path is absolute"
+    assert user_scope_rejection_reason(_local_ref(abs_path), scope=InstallScope.USER) is None
+
+
+def test_user_scope_handles_empty_local_path_defensively():
+    """A malformed ref with empty local_path is treated as relative (rejected).
+
+    ``Path("").is_absolute()`` is False, so the predicate must classify
+    an empty path as relative -- *not* crash and *not* silently accept.
+    """
+    ref = DependencyReference(repo_url="local", is_local=True, local_path=None)
+    reason = user_scope_rejection_reason(ref, scope=InstallScope.USER)
+    assert reason is not None
+    assert "relative" in reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# User-scope remote / parent-inheritance handling
+# ---------------------------------------------------------------------------
+
+
+def test_user_scope_accepts_remote_reference():
+    """Remote references are the canonical user-scope happy path."""
+    assert user_scope_rejection_reason(_remote_ref(), scope=InstallScope.USER) is None
+
+
+def test_user_scope_rejects_parent_repo_inheritance():
+    """``git: parent`` cannot resolve at user scope -- there is no parent repo."""
+    reason = user_scope_rejection_reason(_parent_ref(), scope=InstallScope.USER)
+    assert reason == GIT_PARENT_USER_SCOPE_ERROR
+
+
+# ---------------------------------------------------------------------------
+# Error wording sanity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("rel_path", ["./pkg", "../sibling", "pkg", "sub/dir/pkg"])
+def test_user_scope_relative_rejection_mentions_recovery(rel_path):
+    """Every relative-rejection message must steer the user toward a fix."""
+    reason = user_scope_rejection_reason(_local_ref(rel_path), scope=InstallScope.USER)
+    assert reason is not None
+    lowered = reason.lower()
+    # Should mention either "absolute" or "remote reference" so the user
+    # knows what to type next instead of just being told "no".
+    assert "absolute" in lowered or "remote reference" in lowered

--- a/tests/unit/install/test_user_scope_rejection_reason.py
+++ b/tests/unit/install/test_user_scope_rejection_reason.py
@@ -122,6 +122,19 @@ def test_user_scope_accepts_absolute_local_path(tmp_path):
     assert user_scope_rejection_reason(_local_ref(abs_path), scope=InstallScope.USER) is None
 
 
+@pytest.mark.parametrize("tilde_path", ["~/pkg", "~/sub/pkg"])
+def test_user_scope_accepts_tilde_local_path(tilde_path):
+    """`~/pkg` is absolute after expanduser() and must NOT be rejected.
+
+    The rest of the install pipeline (sources.py, phases/resolve.py)
+    expanduser()s local paths before consuming them, so a `~`-prefixed
+    path reaches `_copy_local_package` as an absolute path. The
+    rejection predicate must mirror that contract -- without it, every
+    `apm install --global ~/pkg` invocation is incorrectly rejected.
+    """
+    assert user_scope_rejection_reason(_local_ref(tilde_path), scope=InstallScope.USER) is None
+
+
 def test_user_scope_handles_empty_local_path_defensively():
     """A malformed ref with empty local_path is treated as relative (rejected).
 

--- a/tests/unit/test_install_path_declaration_invariant.py
+++ b/tests/unit/test_install_path_declaration_invariant.py
@@ -1,0 +1,155 @@
+"""Invariant: ``get_install_path`` and ``get_dependency_declaration_order``
+must produce paths that agree, for every flavor of dependency reference.
+
+Why this test exists
+--------------------
+``DependencyReference.get_install_path()`` and
+``primitives.discovery.get_dependency_declaration_order()`` are two
+independently-written code paths that both compute "where does this
+package live in ``apm_modules/``?" -- one returns an absolute ``Path``,
+the other returns a relative POSIX-style string used by orphan-detection
+and primitive discovery. If they disagree, the orphan detector flags
+correctly-installed packages as orphans and the primitive scanner misses
+real packages.
+
+The cluster-6 failure in the merge-queue run for #1238 was exactly this
+class of drift: PR #1094 changed ``collections/<name>`` from the deleted
+``COLLECTION`` virtual type to ``SUBDIRECTORY``, which made
+``get_install_path()`` and ``get_dependency_declaration_order()`` start
+using slash-form paths; tests caught it because they hard-coded the old
+flattened name -- but no invariant test asserted the two functions agree.
+
+Pinning the agreement directly catches future drift in either function
+(or in ``is_virtual_subdirectory()`` / ``get_virtual_package_name()``)
+in <10ms instead of waiting for a slow E2E to misbehave.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from apm_cli.models.dependency.reference import DependencyReference
+from apm_cli.primitives.discovery import get_dependency_declaration_order
+
+
+def _project_with_deps(tmp_path: Path, deps: list[str]) -> Path:
+    """Write a minimal ``apm.yml`` declaring *deps* and return its dir."""
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / "apm.yml").write_text(
+        yaml.dump(
+            {
+                "name": "harness",
+                "version": "1.0.0",
+                "dependencies": {"apm": deps},
+            }
+        )
+    )
+    return proj
+
+
+def _install_path_str(dep_str: str, apm_modules: Path) -> str:
+    """Compute install path for *dep_str* and return it relative to apm_modules."""
+    ref = DependencyReference.parse(dep_str)
+    abs_path = ref.get_install_path(apm_modules)
+    rel = abs_path.relative_to(apm_modules)
+    return rel.as_posix()
+
+
+# ---------------------------------------------------------------------------
+# The invariant matrix: one case per dependency flavor.
+# ---------------------------------------------------------------------------
+
+# Each row: (dep_string, expected_relative_path).
+# Expected paths are the post-#1094 contract: virtual *subdirectory* packages
+# (Claude Skills, ADO ``collections/<name>``) keep their natural slash path;
+# virtual *file* packages flatten via ``get_virtual_package_name()``.
+INVARIANT_MATRIX: list[tuple[str, str]] = [
+    # Regular GitHub package
+    ("acme/widgets", "acme/widgets"),
+    # Regular ADO package -- 3-level org/project/repo
+    (
+        "dev.azure.com/contoso/platform/widgets",
+        "contoso/platform/widgets",
+    ),
+    # Virtual subdirectory on GitHub (Claude Skills pattern)
+    (
+        "github/awesome-copilot/skills/review-and-refactor",
+        "github/awesome-copilot/skills/review-and-refactor",
+    ),
+    # Virtual subdirectory on ADO -- post-#1094 collections layout
+    (
+        "dev.azure.com/contoso/platform/instructions/collections/csharp-ddd",
+        "contoso/platform/instructions/collections/csharp-ddd",
+    ),
+]
+
+
+@pytest.mark.parametrize("dep_str,expected_rel", INVARIANT_MATRIX)
+def test_install_path_matches_declaration_order(tmp_path: Path, dep_str: str, expected_rel: str):
+    """``get_install_path`` and ``get_dependency_declaration_order`` agree.
+
+    For every supported reference flavor, the relative path produced by
+    ``DependencyReference.get_install_path()`` must equal the path emitted
+    by ``get_dependency_declaration_order()`` for the same ``apm.yml``.
+    """
+    proj = _project_with_deps(tmp_path, [dep_str])
+    apm_modules = proj / "apm_modules"
+
+    install_rel = _install_path_str(dep_str, apm_modules)
+    declared = get_dependency_declaration_order(str(proj))
+
+    assert install_rel == expected_rel, (
+        f"get_install_path produced {install_rel!r}, expected {expected_rel!r}"
+    )
+    assert declared == [expected_rel], (
+        "get_dependency_declaration_order disagrees with get_install_path: "
+        f"declaration={declared!r} vs install={install_rel!r}"
+    )
+
+
+def test_ado_virtual_collection_uses_subdirectory_layout(tmp_path: Path):
+    """Regression trap for cluster-6: ADO ``collections/<name>`` MUST be a
+    virtual *subdirectory*, not a flattened virtual package.
+
+    Pre-#1094, ADO ``collections/<name>`` was a dedicated COLLECTION virtual
+    type that flattened to ``org/project/repo-<name>``. PR #1094 deleted that
+    type so ``collections/<name>`` is now indistinguishable from any other
+    virtual subdirectory and must keep its natural slash path everywhere.
+    """
+    dep_str = "dev.azure.com/contoso/platform/instructions/collections/csharp-ddd"
+    ref = DependencyReference.parse(dep_str)
+
+    assert ref.is_virtual, "ADO collections/<name> must be a virtual package"
+    assert ref.is_virtual_subdirectory(), (
+        "ADO collections/<name> must be classified as a virtual SUBDIRECTORY "
+        "post-#1094 (the COLLECTION virtual type was deleted)"
+    )
+
+    rel = _install_path_str(dep_str, tmp_path / "apm_modules")
+    # Must NOT be the flattened legacy form ``contoso/platform/instructions-csharp-ddd``.
+    assert "instructions-csharp-ddd" not in rel, (
+        "Install path regressed to the deleted COLLECTION flattened form"
+    )
+    assert rel == "contoso/platform/instructions/collections/csharp-ddd"
+
+
+def test_declaration_order_preserves_apm_yml_order(tmp_path: Path):
+    """Declaration order must be stable across mixed-flavor manifests.
+
+    Catches regressions where dependency reordering (e.g. virtual deps moved
+    after regular deps for resolver convenience) breaks downstream consumers
+    that rely on apm.yml ordering for primitive precedence.
+    """
+    deps = [dep for dep, _ in INVARIANT_MATRIX]
+    expected = [exp for _, exp in INVARIANT_MATRIX]
+
+    proj = _project_with_deps(tmp_path, deps)
+    declared = get_dependency_declaration_order(str(proj))
+
+    assert declared == expected, (
+        "get_dependency_declaration_order changed the order of apm.yml deps"
+    )


### PR DESCRIPTION
## TL;DR

The merge-queue `Integration Tests` job for #1238 surfaced **63 failing tests** that had accumulated in the suite since several integration tests were finally wired into CI. This PR fixes all of them, plus one real regression discovered along the way.

Verified locally with `APM_RUN_INTEGRATION_TESTS=1 uv run --extra dev pytest tests/integration/`: **473 passed, 209 skipped, 16 deselected, 2 xfailed** (0 failures). Lint silent.

## Failure clusters

| # | Cluster | Root cause | Fix kind |
|---|---|---|---|
| 1 | ~53 tests | Post-#1154 the bare `.github/` directory is no longer a copilot harness signal -- `.github/copilot-instructions.md` is. | tests |
| 2 | 2 tests | `apm marketplace build` was removed in favor of `apm pack` (exit 2 + recovery message). | tests |
| 3 | 1 test | `tests/fixtures/azure-skills/.claude-plugin/marketplace.json` snapshot drift (key ordering, semantically identical). | snapshot |
| 4 | 1 test | Rich line-wraps the `dependencies` literal echo on narrow terminals; substring assertion was brittle. | tests |
| 5 | 1 test | Used the removed top-level `repo:` key instead of `git:`. | tests |
| 6 | 3 tests | ADO virtual collections (`collections/<name>`) now use the SUBDIRECTORY layout per #1094; install-path and orphan-detection use the natural slash path, not the old flattened name. | tests |
| 7 | 1 test | **Real regression** introduced by #1149: `user_scope_rejection_reason()` rejected ALL local paths at user scope, contradicting the post-#937 contract that only relative local paths are ambiguous. | **product** |

## Cluster 7 in detail (the real bug)

PR #937 (Apr 2026, "allow local packages at --global scope") explicitly removed the rejection of absolute local paths at user scope. PR #1149 ("GitLab marketplace host support") refactored validation into `src/apm_cli/install/package_resolution.py:user_scope_rejection_reason()` and re-introduced the unconditional `dep_ref.is_local` check, regressing the contract. This PR restores absolute-vs-relative gating and updates the error message accordingly.

## Pre-existing failures (NOT fixed here)

Two unit tests fail on `origin/main` without these changes (network-mocking flakes), out of scope:

- `tests/unit/install/test_mcp_registry_module.py::TestRegistryClientTimeout::test_session_get_called_with_timeout`
- `tests/unit/test_registry_client.py::TestSimpleRegistryClient::test_list_servers`

## How to test

```
APM_RUN_INTEGRATION_TESTS=1 uv run --extra dev pytest tests/integration/
uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/
```