### PR TITLE
fix(tests): repair 2 integration tests that surfaced post-#1257

### DIFF
--- a/tests/integration/test_deployed_files_e2e.py
+++ b/tests/integration/test_deployed_files_e2e.py
@@ -162,8 +162,16 @@ class TestDeployedFilesInLockfile:
             full_path = temp_project / rel_path
             assert full_path.exists(), f"Deployed file {rel_path} does not exist on disk"
 
-    def test_deployed_files_are_under_github_or_claude(self, temp_project, apm_command):
-        """deployed_files should only be under .github/ or .claude/ directories."""
+    def test_deployed_files_are_under_known_target_roots(self, temp_project, apm_command):
+        """deployed_files must land under one of the known target roots.
+
+        Plugin-style packages whose primitives include skills also deploy a
+        copy under the AGENTS family root (``.agents/``) -- AGENTS.md is
+        the cross-tool common skills format used by Codex / Cursor /
+        OpenCode. The post-#1257 lockfile correctly records those paths,
+        so the assertion must allow ``.agents/`` alongside ``.github/``
+        and ``.claude/``.
+        """
         result = _run_apm(apm_command, ["install", "microsoft/apm-sample-package"], temp_project)
         assert result.returncode == 0, f"Install failed: {result.stderr}\n{result.stdout}"
 
@@ -171,9 +179,10 @@ class TestDeployedFilesInLockfile:
         dep = _get_locked_dep(lockfile, "microsoft/apm-sample-package")
         assert dep is not None
 
+        allowed_roots = (".github/", ".claude/", ".agents/")
         for rel_path in dep["deployed_files"]:
-            assert rel_path.startswith(".github/") or rel_path.startswith(".claude/"), (
-                f"Deployed file {rel_path} is not under .github/ or .claude/"
+            assert rel_path.startswith(allowed_roots), (
+                f"Deployed file {rel_path} is not under any of {allowed_roots}"
             )
 
     def test_deployed_files_have_clean_names_in_lockfile(self, temp_project, apm_command):

--- a/tests/integration/test_pack_unpack_e2e.py
+++ b/tests/integration/test_pack_unpack_e2e.py
@@ -1,6 +1,6 @@
 """End-to-end integration tests for ``apm pack`` and ``apm unpack``.
 
-Round-trip tests: install → pack → unpack → verify files match.
+Round-trip tests: install -> pack -> install bundle -> verify files match.
 
 Requires network access and GITHUB_TOKEN/GITHUB_APM_PAT for GitHub API.
 """
@@ -60,7 +60,14 @@ def _run_apm(apm_command, args, cwd, timeout=120):
 
 class TestPackUnpackE2E:
     def test_full_round_trip(self, apm_command, temp_project, tmp_path):
-        """Install → pack --archive → unpack in fresh dir → files match."""
+        """Install -> pack --archive -> install <bundle> in fresh dir -> files match.
+
+        Note: ``apm unpack`` was deprecated in favor of ``apm install <bundle-path>``
+        and its bundle verification step does not understand the plugin-format
+        layout (it compared lockfile ``.github/...`` paths against on-disk
+        ``agents/``, ``commands/``, ... paths and always failed). The
+        round-trip uses the supported ``apm install <archive>`` flow instead.
+        """
         # 1. Install
         result = _run_apm(apm_command, ["install"], cwd=temp_project)
         assert result.returncode == 0, f"install failed: {result.stderr}"
@@ -74,16 +81,21 @@ class TestPackUnpackE2E:
         archives = list(build_dir.glob("*.tar.gz"))
         assert len(archives) == 1, f"Expected 1 archive, found {archives}"
 
-        # 3. Unpack in a clean directory
+        # 3. Install the bundle in a clean directory. Seed the copilot
+        # detection signal so target resolution succeeds in the consumer.
         consumer = tmp_path / "consumer"
         consumer.mkdir()
+        (consumer / ".github").mkdir()
+        (consumer / ".github" / "copilot-instructions.md").write_text("# test\n")
         archive = archives[0]
 
-        result = _run_apm(apm_command, ["unpack", str(archive)], cwd=consumer)
-        assert result.returncode == 0, f"unpack failed: {result.stderr}"
+        result = _run_apm(apm_command, ["install", str(archive)], cwd=consumer)
+        assert result.returncode == 0, (
+            f"bundle install failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+        )
 
         # 4. Verify .github/ files are present
-        assert (consumer / ".github").exists(), ".github/ missing after unpack"
+        assert (consumer / ".github").exists(), ".github/ missing after bundle install"
 
     def test_pack_dry_run_no_side_effects(self, apm_command, temp_project):
         """Dry run should not create any files."""


### PR DESCRIPTION
## Summary

Two integration tests were green in the merge queue (because the suite was not yet wired in) and surfaced as failures only after #1257 enabled the runner -- see [run #25640445147](https://github.com/microsoft/apm/actions/runs/25640445147/job/75259927602).

| Test | Root cause | Fix |
|---|---|---|
| `test_deployed_files_e2e::test_deployed_files_are_under_github_or_claude` | Stale assumption: lockfile correctly records `.agents/skills/<name>` for skill primitives (AGENTS.md is the cross-tool common skills format used by Codex / Cursor / OpenCode), but the assertion forbade `.agents/`. | Renamed to `..._under_known_target_roots` and widened the allowlist to `('.github/', '.claude/', '.agents/')`. |
| `test_pack_unpack_e2e::test_full_round_trip` | `apm unpack` is deprecated (the CLI prints the migration to `apm install <bundle-path>`) and its bundle verification compares lockfile `.github/...` paths against on-disk plugin-bundle `agents/` / `commands/` / `instructions/` paths -- always fails on the supported plugin format. | Switched the round-trip to `apm install <archive>`, the documented replacement, and seeded a copilot signal in the consumer dir. |

## Validation

```
$ uv run --extra dev pytest tests/integration/test_deployed_files_e2e.py tests/integration/test_pack_unpack_e2e.py -q
................                                                         [100%]
16 passed in 41.40s
```

Both reproduced before the fix and verified green after. `ruff check` + `ruff format --check` are silent.