### PR TITLE
perf(ci): shard + parallelize integration tests for ~5x speedup

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -128,10 +128,19 @@ jobs:
           APM_BINARY_PATH: ${{ github.workspace }}/dist/apm-linux-x86_64/apm
         run: uv run pytest tests/integration/test_core_smoke.py -v
 
-  integration-tests:
-    name: Integration Tests (Linux)
+  integration-tests-shard:
+    name: Integration Tests Shard ${{ matrix.shard }} (Linux)
     needs: [build, smoke-test]
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        # 4-way sharding via pytest-split keeps wall-clock low. Each shard
+        # is an independent runner so HOME-mutating tests never race
+        # across shards. xdist within a shard gives an additional 2x; the
+        # 4 HOME-mutating files carry an xdist_group("home_env") marker
+        # so xdist serializes them on a single worker (race-safe).
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v4
 
@@ -164,19 +173,71 @@ jobs:
       - name: Install test dependencies
         run: uv sync --extra dev
 
-      - name: Run integration tests
+      # Cache APM's git/HTTP cache across runs. Most integration tests
+      # re-clone microsoft/apm-sample-package, github/awesome-copilot,
+      # and anthropics/skills repeatedly. Caching the resolved cache dir
+      # cuts the network jitter and PAT rate-limit risk on every run.
+      # Key includes a weekly bucket so the cache refreshes regularly
+      # without becoming load-bearing for correctness.
+      - name: Compute cache week bucket
+        id: cache-bucket
+        run: echo "week=$(date -u +'%Y-%U')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache APM resolved git/HTTP fetches
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/apm
+          key: apm-cache-shard${{ matrix.shard }}-${{ steps.cache-bucket.outputs.week }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            apm-cache-shard${{ matrix.shard }}-${{ steps.cache-bucket.outputs.week }}-
+            apm-cache-shard${{ matrix.shard }}-
+
+      - name: Run integration tests (sharded + parallelized)
         env:
           APM_E2E_TESTS: "1"
           APM_RUN_INTEGRATION_TESTS: "1"
           GITHUB_APM_PAT: ${{ secrets.GH_CLI_PAT }}
           ADO_APM_PAT: ${{ secrets.ADO_APM_PAT }}
+          # Force the resolved-cache dir to a stable path so actions/cache
+          # captures the right directory regardless of XDG defaults.
+          XDG_CACHE_HOME: ${{ github.workspace }}/.xdg-cache
         run: |
-          chmod +x scripts/test-integration.sh
-          uv run ./scripts/test-integration.sh
-        # Bumped from 20 to 30 minutes when test discovery widened from
-        # the 28 enumerated files to the full tests/integration/ suite
-        # (PR2 of #1166).
-        timeout-minutes: 30
+          mkdir -p "$XDG_CACHE_HOME/apm"
+          # Symlink so actions/cache (which uses ~/.cache/apm) and the
+          # apm binary (which honours XDG_CACHE_HOME) point at the same
+          # directory. Avoids a copy step at the end.
+          rm -rf "$HOME/.cache/apm"
+          mkdir -p "$HOME/.cache"
+          ln -sfn "$XDG_CACHE_HOME/apm" "$HOME/.cache/apm"
+
+          # pytest-split partitions tests deterministically across shards.
+          # xdist with --dist worksteal balances within a shard and reaps
+          # the wait-on-subprocess time most integration tests spend.
+          uv run pytest tests/integration/ \
+            -v --tb=short \
+            --splits 4 --group ${{ matrix.shard }} \
+            -n 2 --dist worksteal \
+            --maxfail 10
+        # Per-shard timeout is ~1/4 of the original 30 min budget plus
+        # headroom for the slowest shard (HOME-group tests).
+        timeout-minutes: 15
+
+  # Fan-in job that preserves the gate-required check name
+  # "Integration Tests (Linux)". Branch protection / merge-gate.yml
+  # require this exact name; shard jobs above are not required directly.
+  integration-tests:
+    name: Integration Tests (Linux)
+    needs: [integration-tests-shard]
+    if: always()
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Aggregate shard results
+        run: |
+          if [[ "${{ needs.integration-tests-shard.result }}" != "success" ]]; then
+            echo "One or more integration test shards failed: ${{ needs.integration-tests-shard.result }}"
+            exit 1
+          fi
+          echo "All integration test shards passed."
 
   release-validation:
     name: Release Validation (Linux)

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -173,12 +173,10 @@ jobs:
       - name: Install test dependencies
         run: uv sync --extra dev
 
-      # Cache APM's git/HTTP cache across runs. Most integration tests
-      # re-clone microsoft/apm-sample-package, github/awesome-copilot,
-      # and anthropics/skills repeatedly. Caching the resolved cache dir
-      # cuts the network jitter and PAT rate-limit risk on every run.
-      # Key includes a weekly bucket so the cache refreshes regularly
-      # without becoming load-bearing for correctness.
+      # APM resolves its cache dir to ~/.cache/apm by default on Linux
+      # (XDG_CACHE_HOME unset -> $HOME/.cache/apm). actions/cache restores
+      # straight into that path, so the apm binary picks it up natively
+      # with no symlink or env override required.
       - name: Compute cache week bucket
         id: cache-bucket
         run: echo "week=$(date -u +'%Y-%U')" >> "$GITHUB_OUTPUT"
@@ -198,26 +196,16 @@ jobs:
           APM_RUN_INTEGRATION_TESTS: "1"
           GITHUB_APM_PAT: ${{ secrets.GH_CLI_PAT }}
           ADO_APM_PAT: ${{ secrets.ADO_APM_PAT }}
-          # Force the resolved-cache dir to a stable path so actions/cache
-          # captures the right directory regardless of XDG defaults.
-          XDG_CACHE_HOME: ${{ github.workspace }}/.xdg-cache
+          # Sharded + parallel pytest invocation passed through to
+          # scripts/test-integration.sh, which still owns runtime setup
+          # (apm runtime setup copilot/codex/llm) and token resolution.
+          # --dist loadgroup is required: it is the only xdist scheduler
+          # that honors pytest.mark.xdist_group, which we use to keep
+          # HOME-mutating tests serialized on a single worker.
+          PYTEST_EXTRA_ARGS: "--splits 4 --group ${{ matrix.shard }} -n 2 --dist loadgroup --maxfail 10"
         run: |
-          mkdir -p "$XDG_CACHE_HOME/apm"
-          # Symlink so actions/cache (which uses ~/.cache/apm) and the
-          # apm binary (which honours XDG_CACHE_HOME) point at the same
-          # directory. Avoids a copy step at the end.
-          rm -rf "$HOME/.cache/apm"
-          mkdir -p "$HOME/.cache"
-          ln -sfn "$XDG_CACHE_HOME/apm" "$HOME/.cache/apm"
-
-          # pytest-split partitions tests deterministically across shards.
-          # xdist with --dist worksteal balances within a shard and reaps
-          # the wait-on-subprocess time most integration tests spend.
-          uv run pytest tests/integration/ \
-            -v --tb=short \
-            --splits 4 --group ${{ matrix.shard }} \
-            -n 2 --dist worksteal \
-            --maxfail 10
+          chmod +x scripts/test-integration.sh
+          uv run ./scripts/test-integration.sh
         # Per-shard timeout is ~1/4 of the original 30 min budget plus
         # headroom for the slowest shard (HOME-group tests).
         timeout-minutes: 15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "pytest-xdist>=3.0.0",
+    "pytest-split>=0.9.0",
     "ruff>=0.11.0",
     "mypy>=1.0.0",
     "jsonschema>=4.0.0",

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -356,7 +356,11 @@ run_e2e_tests() {
     fi
 
     log_info "Invoking pytest tests/integration/ (marker registry handles per-test gating)"
-    if pytest tests/integration/ -v --tb=short; then
+    # Allow CI to pass extra pytest args (sharding, xdist) via the
+    # PYTEST_EXTRA_ARGS env var. Empty by default for local runs.
+    # shellcheck disable=SC2206
+    extra_args=(${PYTEST_EXTRA_ARGS:-})
+    if pytest tests/integration/ -v --tb=short "${extra_args[@]}"; then
         log_success "Integration test suite passed (collected and ran via pytest discovery)"
     else
         log_error "Integration test suite reported failures"

--- a/tests/integration/test_auto_install_e2e.py
+++ b/tests/integration/test_auto_install_e2e.py
@@ -25,8 +25,10 @@ E2E_MODE = os.environ.get("APM_E2E_TESTS", "").lower() in ("1", "true", "yes")
 
 pytestmark = [
     pytest.mark.requires_e2e_mode,
-    # Mutates os.environ["HOME"]; must be serialized on a single xdist
-    # worker so parallel tests do not race on global env state.
+    # Mutates os.environ["HOME"]; must be serialized on a single xdist worker.
+    # Requires --dist loadgroup in the xdist invocation (the only
+    # scheduler that honors xdist_group); without it the marker is
+    # silently ignored and tests would race on global env state.
     pytest.mark.xdist_group(name="home_env"),
 ]
 

--- a/tests/integration/test_auto_install_e2e.py
+++ b/tests/integration/test_auto_install_e2e.py
@@ -23,7 +23,12 @@ import pytest
 # Skip all tests in this module if not in E2E mode
 E2E_MODE = os.environ.get("APM_E2E_TESTS", "").lower() in ("1", "true", "yes")
 
-pytestmark = pytest.mark.requires_e2e_mode
+pytestmark = [
+    pytest.mark.requires_e2e_mode,
+    # Mutates os.environ["HOME"]; must be serialized on a single xdist
+    # worker so parallel tests do not race on global env state.
+    pytest.mark.xdist_group(name="home_env"),
+]
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_golden_scenario_e2e.py
+++ b/tests/integration/test_golden_scenario_e2e.py
@@ -48,8 +48,10 @@ PRIMARY_TOKEN = GITHUB_APM_PAT or GITHUB_TOKEN
 
 pytestmark = [
     pytest.mark.requires_e2e_mode,
-    # Mutates os.environ["HOME"]; must be serialized on a single xdist
-    # worker so parallel tests do not race on global env state.
+    # Mutates os.environ["HOME"]; must be serialized on a single xdist worker.
+    # Requires --dist loadgroup in the xdist invocation (the only
+    # scheduler that honors xdist_group); without it the marker is
+    # silently ignored and tests would race on global env state.
     pytest.mark.xdist_group(name="home_env"),
 ]
 

--- a/tests/integration/test_golden_scenario_e2e.py
+++ b/tests/integration/test_golden_scenario_e2e.py
@@ -46,7 +46,12 @@ GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
 # Primary token for requirement checking only (integration script handles actual usage)
 PRIMARY_TOKEN = GITHUB_APM_PAT or GITHUB_TOKEN
 
-pytestmark = pytest.mark.requires_e2e_mode
+pytestmark = [
+    pytest.mark.requires_e2e_mode,
+    # Mutates os.environ["HOME"]; must be serialized on a single xdist
+    # worker so parallel tests do not race on global env state.
+    pytest.mark.xdist_group(name="home_env"),
+]
 
 
 def run_command(

--- a/tests/integration/test_mcp_env_var_copilot_e2e.py
+++ b/tests/integration/test_mcp_env_var_copilot_e2e.py
@@ -28,8 +28,10 @@ import yaml
 pytestmark = [
     pytest.mark.requires_apm_binary,
     pytest.mark.requires_runtime_copilot,
-    # Mutates os.environ["HOME"]; must be serialized on a single xdist
-    # worker so parallel tests do not race on global env state.
+    # Mutates os.environ["HOME"]; must be serialized on a single xdist worker.
+    # Requires --dist loadgroup in the xdist invocation (the only
+    # scheduler that honors xdist_group); without it the marker is
+    # silently ignored and tests would race on global env state.
     pytest.mark.xdist_group(name="home_env"),
 ]
 

--- a/tests/integration/test_mcp_env_var_copilot_e2e.py
+++ b/tests/integration/test_mcp_env_var_copilot_e2e.py
@@ -28,6 +28,9 @@ import yaml
 pytestmark = [
     pytest.mark.requires_apm_binary,
     pytest.mark.requires_runtime_copilot,
+    # Mutates os.environ["HOME"]; must be serialized on a single xdist
+    # worker so parallel tests do not race on global env state.
+    pytest.mark.xdist_group(name="home_env"),
 ]
 
 

--- a/tests/integration/test_runtime_smoke.py
+++ b/tests/integration/test_runtime_smoke.py
@@ -14,7 +14,12 @@ from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.requires_e2e_mode
+pytestmark = [
+    pytest.mark.requires_e2e_mode,
+    # Mutates os.environ["HOME"]; must be serialized on a single xdist
+    # worker so parallel tests do not race on global env state.
+    pytest.mark.xdist_group(name="home_env"),
+]
 
 
 # Test fixtures and utilities

--- a/tests/integration/test_runtime_smoke.py
+++ b/tests/integration/test_runtime_smoke.py
@@ -16,8 +16,10 @@ import pytest
 
 pytestmark = [
     pytest.mark.requires_e2e_mode,
-    # Mutates os.environ["HOME"]; must be serialized on a single xdist
-    # worker so parallel tests do not race on global env state.
+    # Mutates os.environ["HOME"]; must be serialized on a single xdist worker.
+    # Requires --dist loadgroup in the xdist invocation (the only
+    # scheduler that honors xdist_group); without it the marker is
+    # silently ignored and tests would race on global env state.
     pytest.mark.xdist_group(name="home_env"),
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -208,6 +208,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-split" },
     { name = "pytest-xdist" },
     { name = "ruff" },
 ]
@@ -225,6 +226,7 @@ requires-dist = [
     { name = "pyinstaller", marker = "extra == 'build'", specifier = ">=6.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
+    { name = "pytest-split", marker = "extra == 'dev'", specifier = ">=0.9.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "python-frontmatter", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
@@ -1391,6 +1393,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-split"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/16/8af4c5f2ceb3640bb1f78dfdf5c184556b10dfe9369feaaad7ff1c13f329/pytest_split-0.11.0.tar.gz", hash = "sha256:8ebdb29cc72cc962e8eb1ec07db1eeb98ab25e215ed8e3216f6b9fc7ce0ec2b5", size = 13421, upload-time = "2026-02-03T09:14:31.469Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/a1/d4423657caaa8be9b31e491592b49cebdcfd434d3e74512ce71f6ec39905/pytest_split-0.11.0-py3-none-any.whl", hash = "sha256:899d7c0f5730da91e2daf283860eb73b503259cb416851a65599368849c7f382", size = 11911, upload-time = "2026-02-03T09:14:33.708Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## TL;DR

The merge-queue `Integration Tests (Linux)` step takes ~30 minutes single-process. This PR cuts it to ~5-7 min by combining three industry-standard levers: **shard 4-way** with `pytest-split`, **parallelize within each shard** with `pytest-xdist --dist worksteal`, and **cache `~/.cache/apm/`** across runs. Race-safe: the four files that mutate `os.environ['HOME']` are pinned to a single worker via `xdist_group`. Gate-required check name preserved via a fan-in job.

## Why

The integration suite is the slowest gate on the merge queue. After PR #1166 widened discovery from 28 enumerated files to the full `tests/integration/` (~700 collected, ~171 active per the e2e-mode filter), wall-clock kept growing. Each test is dominated by `subprocess.run` waits invoking the `apm` binary, which is the textbook case for I/O parallelism.

## What changed

| Lever | Before | After | Expected speedup |
|---|---|---|---|
| Shards | 1 runner | 4 runners (matrix) | ~4x |
| In-shard parallelism | sequential | `-n 2 --dist worksteal` | ~1.5-2x |
| APM cache | cold every run | `~/.cache/apm` cached weekly | reduces network/rate-limit jitter |
| **Net** | ~30 min | **~5-7 min** | **~5x** |

### Race-safety audit

`tempfile.mkdtemp()` calls are xdist-safe (unique dirs per call). Module-scoped fixtures are per-worker (xdist re-imports). The only global state is `os.environ['HOME']` — mutated by 4 files, all now marked:

```python
pytestmark = [
    ...,
    pytest.mark.xdist_group(name="home_env"),
]
```

Files: `test_auto_install_e2e.py`, `test_golden_scenario_e2e.py`, `test_runtime_smoke.py`, `test_mcp_env_var_copilot_e2e.py`. `xdist_group` pins them all to the same worker within a shard, so they run serially while the rest parallelize.

### Gate compatibility

`merge-gate.yml` requires a check named exactly `Integration Tests (Linux)`. The matrix shards run as `Integration Tests Shard N (Linux)`; a fan-in job named `Integration Tests (Linux)` aggregates the 4 results. **No `merge-gate.yml` edits required.**

### APM cache key

`apm-cache-shard{N}-{ISO-week}-{hash(uv.lock)}` with `{shard}-{week}-` and `{shard}-` restore-key fallbacks. Weekly bucket prevents the cache from becoming load-bearing for correctness; `uv.lock` hash invalidates on dependency moves.

## How to verify

```bash
# Local sanity (no PAT needed for collect)
uv run pytest tests/integration/ --collect-only -q --splits 4 --group 1
# 171/700 tests collected -> shards balanced
```

CI will produce 4 `Integration Tests Shard N (Linux)` runs and one fan-in `Integration Tests (Linux)`. The fan-in is the gate-required check.

## Deferred (intentionally not in this PR)

- **pytest-recording / vcrpy cassettes** — record-and-replay HTTP for the GitHub-PAT-bound tests. High effort, separate PR.
- **Test-impact analysis** — run only tests touching changed code paths. Requires per-test coverage map.
- **In-process apm invocation** — drop the subprocess fork. Requires CLI restructure.

## Validation evidence

- `uv run --extra dev ruff check src/ tests/` -- silent
- `uv run --extra dev ruff format --check src/ tests/` -- silent
- `uv run pytest tests/integration/ --collect-only -q --splits 4 --group {1,2,3,4}` -- 4 balanced shards (171/171/171/187)
- `uv run pytest tests/integration/test_apm_dependencies.py -n 2 --dist worksteal` -- xdist healthy