### PR TITLE
fix(tests): mock search_servers fallback in registry-client UUID-not-found test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `test_find_server_by_reference_uuid_not_found` no longer leaks a live HTTP call to `api.mcp.github.com` (fixing Windows CI failures from `socket.gaierror`); the `search_servers` fallback is now mocked. (#1264)
 - ADO full HTTPS URLs with sub-path virtual packages (e.g. `https://dev.azure.com/org/proj/_git/repo/sub/path`) are now parsed correctly instead of being rejected. (#1254)
 - Fixed `apm install` crash (exit code 128) when a mono-repo package depends on a sibling pinned to a non-HEAD commit; installs now resolve with a single in-place fetch, and multiple SHA-pinned references to the same repository share a single cached clone. (#1258)
 - MCP server token injection now requires both an allowlisted server name and a verified HTTPS GitHub hostname, preventing PAT exfiltration via poisoned registry entries. (#1239)

--- a/tests/unit/test_registry_client.py
+++ b/tests/unit/test_registry_client.py
@@ -210,11 +210,22 @@ class TestSimpleRegistryClient(unittest.TestCase):
         self.assertEqual(result, server_data)
         mock_get_server_info.assert_called_once_with("123e4567-e89b-12d3-a456-426614174000")
 
+    @mock.patch("apm_cli.registry.client.SimpleRegistryClient.search_servers")
     @mock.patch("apm_cli.registry.client.SimpleRegistryClient.get_server_info")
-    def test_find_server_by_reference_uuid_not_found(self, mock_get_server_info):
-        """Test finding a server by UUID that doesn't exist."""
-        # Mock get_server_info to raise ValueError
+    def test_find_server_by_reference_uuid_not_found(
+        self, mock_get_server_info, mock_search_servers
+    ):
+        """Test finding a server by UUID that doesn't exist.
+
+        When the UUID lookup raises ValueError, ``find_server_by_reference`` falls
+        through to ``search_servers``; that fallback must be mocked so the test
+        never hits the real registry (the Windows CI runner cannot resolve
+        ``api.mcp.github.com`` and the call would raise ``socket.gaierror``).
+        """
+        # Mock get_server_info to raise ValueError so the UUID branch fails.
         mock_get_server_info.side_effect = ValueError("Server not found")
+        # Mock the fallback search to return no hits (the "not found" case).
+        mock_search_servers.return_value = []
 
         # Call the method with UUID
         result = self.client.find_server_by_reference("123e4567-e89b-12d3-a456-426614174000")
@@ -222,6 +233,7 @@ class TestSimpleRegistryClient(unittest.TestCase):
         # Should return None when server not found
         self.assertIsNone(result)
         mock_get_server_info.assert_called_once_with("123e4567-e89b-12d3-a456-426614174000")
+        mock_search_servers.assert_called_once_with("123e4567-e89b-12d3-a456-426614174000")
 
     @mock.patch("apm_cli.registry.client.SimpleRegistryClient.get_server_info")
     @mock.patch("apm_cli.registry.client.SimpleRegistryClient.search_servers")


### PR DESCRIPTION
## TL;DR

`test_find_server_by_reference_uuid_not_found` made a real HTTPS call to `api.mcp.github.com` because only `get_server_info` was mocked. The Windows runner in `build-release.yml` can't resolve that hostname and raised `socket.gaierror [Errno 11001] getaddrinfo failed`, failing the unit-test step. Linux/macOS runners happened to resolve the host so the PR gate (`ci.yml`, Linux-only) stayed green.

Failing run: https://github.com/microsoft/apm/actions/runs/25651666245

## Root cause

`find_server_by_reference(reference)` in `src/apm_cli/registry/client.py:349`:

1. If `reference` is UUID-shaped, calls `self.get_server_info(reference)`.
2. If that raises `ValueError`, it **catches and falls through** to `self.search_servers(reference)` (the name-search fallback).

The test mocked step (1) to raise `ValueError` but left step (2) unmocked. `search_servers` builds a `requests` call to the live registry — on a runner that can't resolve the host, you get a DNS error instead of a `ValueError`, propagating out of the test as a hard fail.

## Fix

Mock `search_servers` to return `[]` so the not-found path completes hermetically. Test now exercises both branches of the UUID-not-found path and never touches the network — consistent with the existing `.github/instructions/tests.instructions.md` rule ("Tests must never hit a real HTTP endpoint").

## Why this didn't surface earlier

The Linux PR gate (`ci.yml`) is Linux-only by design; Windows is covered post-merge by `build-release.yml`. So this latent network leak only manifested on the Windows post-merge runner.

## Validation

```
uv run --extra dev ruff check src/ tests/        # silent
uv run --extra dev ruff format --check src/ tests/  # silent
uv run pytest tests/unit/test_registry_client.py -x -q
# 31 passed, 5 subtests passed in 2.80s
```