### PR TITLE
fix(tests): hermetic HOME for unit tests on Windows runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Pin `Path.home()` under unit tests via a session-scoped autouse conftest fixture, fixing 56 Windows runner failures on the new `windows-2025-vs2026` GitHub-hosted image where `USERPROFILE`/`HOMEDRIVE`+`HOMEPATH` are not seeded for pytest workers; also patch the `_check_and_notify_updates` import binding in the disabled-self-update test so it no longer races on the version-check cache. (#1270)
+
 ## [0.13.0] - 2026-05-11
 
 ### Breaking Changes

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,63 @@
+"""Unit-test conftest: hermetic HOME isolation.
+
+The session-scoped autouse fixture below pins ``Path.home()`` to a tmp
+directory for the entire unit-test session. Two reasons:
+
+1. Hermeticity. Unit tests must not read or write the contributor's real
+   ``~`` (config files, runtimes, caches). Tests that call
+   ``RuntimeManager()`` or ``Path.home()`` directly previously inherited
+   whatever HOME the runner had.
+2. Windows runner robustness. On the ``windows-2025-vs2026`` GitHub
+   Actions image the ``USERPROFILE`` / ``HOMEDRIVE`` + ``HOMEPATH``
+   triplet is not set under the pytest worker subprocess, so
+   ``Path.home()`` raises ``RuntimeError: Could not determine home
+   directory.`` This fixture sets the platform-correct trio so
+   ``Path.home()`` always resolves to ``<tmp>`` regardless of runner
+   image.
+
+Per-test fixtures that need a different HOME (e.g. tests/unit/integration
+that exercise scope resolution) keep using ``monkeypatch.setenv`` and
+override this baseline; the function-scoped monkeypatch wins over the
+session-scoped baseline for the duration of the test.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+def _set_home_env(home: Path) -> None:
+    """Set ``HOME`` and the Windows-equivalent vars to ``home``.
+
+    ``Path.home()`` consults ``HOME`` on POSIX but ``USERPROFILE``
+    (with ``HOMEDRIVE`` + ``HOMEPATH`` fallback) on Windows.
+    """
+    home_str = str(home)
+    os.environ["HOME"] = home_str
+    if os.name == "nt":
+        os.environ["USERPROFILE"] = home_str
+        drive, _, tail = home_str.partition(":")
+        if tail:
+            os.environ["HOMEDRIVE"] = f"{drive}:"
+            os.environ["HOMEPATH"] = tail
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _hermetic_home(tmp_path_factory: pytest.TempPathFactory) -> None:
+    """Pin ``Path.home()`` to a per-session tmp dir for all unit tests."""
+    home = tmp_path_factory.mktemp("apm-unit-home")
+    previous = {
+        key: os.environ.get(key) for key in ("HOME", "USERPROFILE", "HOMEDRIVE", "HOMEPATH")
+    }
+    _set_home_env(home)
+    try:
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value

--- a/tests/unit/test_update_command.py
+++ b/tests/unit/test_update_command.py
@@ -40,6 +40,7 @@ class TestUpdateCommand(unittest.TestCase):
         self.assertIn("powershell", command.lower())
 
     @patch("apm_cli.commands.self_update.is_self_update_enabled", return_value=False)
+    @patch("apm_cli.commands._helpers.is_self_update_enabled", return_value=False)
     @patch(
         "apm_cli.commands.self_update.get_self_update_disabled_message",
         return_value="Update with: pixi update apm-cli",
@@ -51,6 +52,7 @@ class TestUpdateCommand(unittest.TestCase):
         mock_get,
         mock_run,
         mock_message,
+        mock_enabled_helpers,
         mock_enabled,
     ):
         """Disabled self-update policy should print guidance and skip installer."""


### PR DESCRIPTION
## TL;DR

The post-tag CI/CD Pipeline run on `v0.13.0` ([25660187642](https://github.com/microsoft/apm/actions/runs/25660187642)) failed Windows unit tests with **57 failures**:

- **56**: `RuntimeError: Could not determine home directory` from `Path.home()` in `tests/unit/test_runtime_manager.py` and `tests/unit/test_runtime_detection.py`.
- **1**: `test_update_command_respects_disabled_policy` -- `requests.get` called once when it should not have been.

Both were latent test-infra issues exposed by GitHub redirecting `windows-latest` from `windows-2025` to `windows-2025-vs2026`. No product code change.

## Problem

### 1. Path.home() on the new Windows image

`Path.home()` on Windows reads `USERPROFILE` first, then `HOMEDRIVE`+`HOMEPATH`. The `windows-2025-vs2026` image does not seed any of these for pytest worker subprocesses. Any unit test that touches `Path.home()` (directly or via `get_user_runtime_dir()` etc.) raises.

### 2. Missed mock in disabled-self-update test

`apm_cli/commands/_helpers.py` does `from ..update_policy import ... is_self_update_enabled`, rebinding the symbol locally. `_check_and_notify_updates()` runs on every `cli()` invocation. The test only patched `apm_cli.commands.self_update.is_self_update_enabled`, leaving the `_helpers` reference live. On Linux xdist workers an earlier test primed `~/.cache/apm/last_version_check` so `should_check_for_updates()` skipped the network call; Windows workers were cold, so `requests.get` fired.

## Fix

1. **`tests/unit/conftest.py`** (new) -- session-scoped autouse `_hermetic_home` fixture pins `Path.home()` to a tmp dir via `tmp_path_factory.mktemp`. Sets `HOME` on POSIX and `USERPROFILE`/`HOMEDRIVE`/`HOMEPATH` on Windows. Restores prior values on teardown. Per-test `monkeypatch.setenv` fixtures (`_set_home` etc.) keep working for their scope.
2. **`tests/unit/test_update_command.py`** -- stack a second `@patch("apm_cli.commands._helpers.is_self_update_enabled", return_value=False)` on `test_update_command_respects_disabled_policy` and add the matching mock arg.

## Validation

Ran locally on macOS:

```
uv run --extra dev pytest tests/unit tests/test_console.py -n auto --dist worksteal -q
# 8281 passed, 29 subtests passed in 70.94s
```

Lint mirror clean:

```
uv run --extra dev ruff check src/ tests/    # All checks passed!
uv run --extra dev ruff format --check src/ tests/   # 746 files already formatted
```

Cannot reproduce the `USERPROFILE` drift on macOS, but the conftest fix unifies behaviour with the existing per-test `_set_home` helper at `tests/unit/integration/test_scope_integration.py:25-40`, so the Windows runner will now see a stable `Path.home()` for every unit test.

## How to test

Triggered on push to `fix/windows-home-runner`; the merge will re-trigger the `CI/CD Pipeline` job on Windows after we re-tag `v0.13.0`.