### PR TITLE
[docs] Update documentation for features from 2026-05-12

### DIFF
--- a/docs/src/content/docs/consumer/install-mcp-servers.md
+++ b/docs/src/content/docs/consumer/install-mcp-servers.md
@@ -80,7 +80,7 @@ writes a runtime-specific MCP config file. The schemas differ; the
 | GitHub Copilot CLI | `~/.copilot/mcp-config.json` | global | JSON `mcpServers` |
 | VS Code (Copilot) | `.vscode/mcp.json` | project | JSON `servers` |
 | Claude Code | `.mcp.json` (project) or `~/.claude.json` (`-g`) | both | JSON `mcpServers` |
-| Cursor | `.cursor/mcp.json` | project (only if `.cursor/` exists) | JSON `mcpServers` |
+| Cursor | `.cursor/mcp.json` | project (only if `.cursor/` exists) | JSON `mcpServers` (Cursor-native schema: `type: stdio` / `type: http`) |
 | Codex CLI | `~/.codex/config.toml` | global | TOML `[mcp_servers.*]` |
 | Gemini CLI | `.gemini/settings.json` | project (only if `.gemini/` exists) | JSON `mcpServers` |
 | OpenCode | `opencode.json` | project (only if `.opencode/` exists) | JSON `mcp` |

--- a/docs/src/content/docs/enterprise/policy-reference.md
+++ b/docs/src/content/docs/enterprise/policy-reference.md
@@ -293,6 +293,8 @@ manifest:
 
 Detect files in governance directories that are not tracked by APM.
 
+A file is "tracked by APM" only if it was produced by an installed plugin. Pre-existing files that APM did not deploy are counted as unmanaged even if they reside in a governed directory.
+
 ### `action`
 
 | Value | Behavior |
@@ -422,7 +424,7 @@ A child policy can only tighten constraints — never relax them:
 | `max_depth` | `min(parent, child)` |
 | `mcp.self_defined` | Escalates: `allow` < `warn` < `deny` |
 | `manifest.scripts` | Escalates: `allow` < `deny` |
-| `unmanaged_files.action` | Escalates: `ignore` < `warn` < `deny` |
+| `unmanaged_files.action` | Escalates: `ignore` < `warn` < `deny`. Omitting `unmanaged_files` in the child is treated as "no opinion" -- the parent value is preserved unchanged. |
 | `source_attribution` | `parent OR child` — either enables it |
 | `trust_transitive` | `parent AND child` — both must allow it |
 

--- a/docs/src/content/docs/getting-started/authentication.md
+++ b/docs/src/content/docs/getting-started/authentication.md
@@ -184,14 +184,16 @@ export ADO_APM_PAT=your_ado_pat
 apm install dev.azure.com/myorg/myproject/myrepo
 ```
 
-ADO is always auth-required. Uses 3-segment paths (`org/project/repo`). No `ADO_HOST` equivalent - always use FQDN syntax:
+ADO is always auth-required. Uses 3-segment paths (`org/project/repo`). No `ADO_HOST` equivalent - always use FQDN syntax. Both the shorthand (`dev.azure.com/...`) and full HTTPS URL (`https://dev.azure.com/...`) forms are accepted:
 
 ```bash
 apm install dev.azure.com/myorg/myproject/myrepo#main
+apm install https://dev.azure.com/myorg/myproject/_git/myrepo  # full URL also accepted
 apm install mycompany.visualstudio.com/org/project/repo  # legacy URL
 
 # Sub-path inside an ADO repo, pinned to a tag (use the _git form for sub-paths):
 apm install dev.azure.com/myorg/myproject/_git/myrepo/instructions/security#v2.0
+apm install https://dev.azure.com/myorg/myproject/_git/myrepo/instructions/security#v2.0
 ```
 
 If your ADO project or repository name contains spaces, URL-encode them as `%20`:


### PR DESCRIPTION
## Documentation Updates - 2026-05-12

This PR updates documentation based on fixes merged in the last 24 hours.

### Features Documented

- Full `https://` ADO URL support (from #1254)
- Policy inheritance: omitting `unmanaged_files` preserves parent value (from #1253)
- `apm install` file provenance: only APM-produced files are tracked as managed (from #1256)
- Cursor-native MCP schema (`type: stdio` / `type: http`) (from #1240)

### Changes Made

- Updated `docs/src/content/docs/getting-started/authentication.md` to document that full `(dev.azure.com/redacted) URLs are accepted in addition to the shorthand form, with examples for both standard and sub-path installs.
- Updated `docs/src/content/docs/enterprise/policy-reference.md`:
  - Clarified that a file is "tracked by APM" only if it was produced by an installed plugin (pre-existing files count as unmanaged).
  - Clarified `unmanaged_files.action` inheritance: omitting the block in a child policy is "no opinion" and preserves the parent value unchanged.
- Updated `docs/src/content/docs/consumer/install-mcp-servers.md` to note that Cursor's MCP config uses Cursor-native schema (`type: stdio` / `type: http`).

### Merged PRs Referenced

- #1254 - fix: accept full ADO https:// URLs with sub-paths
- #1253 - fix: policy inheritance preserves parent unmanaged_files when child omits block
- #1256 - fix: apm install no longer adopts files not produced by installed plugins
- #1240 - fix: emit Cursor-native MCP schema (type: stdio) instead of Copilot schema




> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/25716113058/agentic_workflow) · ● 1.3M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+%22gh-aw-workflow-id%3A+daily-doc-updater%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/blob/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-05-14T05:55:50.709Z --> on May 14, 2026, 5:55 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 25716113058, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/25716113058 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->