### PR TITLE
[Test Improver] tests(cache): add unit tests for cache.integrity SHA verification

### DIFF
--- a/tests/unit/cache/test_cache_integrity.py
+++ b/tests/unit/cache/test_cache_integrity.py
@@ -1,0 +1,176 @@
+"""Unit tests for cache.integrity module.
+
+Covers _read_head_sha and verify_checkout_sha across all .git layouts:
+- .git directory with ref HEAD
+- .git directory with detached HEAD
+- .git directory with packed-refs fallback
+- .git file (worktree gitdir indirection)
+- missing / malformed layouts
+"""
+
+from apm_cli.cache.integrity import _read_head_sha, verify_checkout_sha
+
+_SHA = "a" * 40
+_SHA2 = "b" * 40
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_git_dir(tmp_path, sha=_SHA):
+    """Create a standard .git directory with detached HEAD."""
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    (git_dir / "HEAD").write_text(sha + "\n")
+    return tmp_path
+
+
+def _make_git_dir_with_ref(tmp_path, sha=_SHA, branch="refs/heads/main"):
+    """Create a standard .git directory with a symbolic ref HEAD."""
+    git_dir = tmp_path / ".git"
+    git_dir.mkdir()
+    (git_dir / "HEAD").write_text(f"ref: {branch}\n")
+    ref_path = git_dir / branch
+    ref_path.parent.mkdir(parents=True, exist_ok=True)
+    ref_path.write_text(sha + "\n")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# _read_head_sha: .git is a directory, detached HEAD
+# ---------------------------------------------------------------------------
+
+
+class TestReadHeadShaDetachedHead:
+    def test_returns_sha_for_detached_head(self, tmp_path):
+        checkout = _make_git_dir(tmp_path, sha=_SHA)
+        assert _read_head_sha(checkout) == _SHA
+
+    def test_normalises_uppercase_sha(self, tmp_path):
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "HEAD").write_text(_SHA.upper() + "\n")
+        assert _read_head_sha(tmp_path) == _SHA.lower()
+
+    def test_returns_none_for_non_sha_detached(self, tmp_path):
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "HEAD").write_text("not-a-sha\n")
+        assert _read_head_sha(tmp_path) is None
+
+    def test_returns_none_when_head_missing(self, tmp_path):
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        assert _read_head_sha(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# _read_head_sha: .git is a directory, symbolic ref HEAD
+# ---------------------------------------------------------------------------
+
+
+class TestReadHeadShaSymbolicRef:
+    def test_follows_symbolic_ref(self, tmp_path):
+        checkout = _make_git_dir_with_ref(tmp_path, sha=_SHA)
+        assert _read_head_sha(checkout) == _SHA
+
+    def test_returns_none_when_ref_file_missing_and_no_packed_refs(self, tmp_path):
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "HEAD").write_text("ref: refs/heads/missing\n")
+        assert _read_head_sha(tmp_path) is None
+
+    def test_falls_back_to_packed_refs(self, tmp_path):
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "HEAD").write_text("ref: refs/heads/main\n")
+        packed = git_dir / "packed-refs"
+        packed.write_text(f"# pack-refs with: peeled fully-peeled sorted\n{_SHA} refs/heads/main\n")
+        assert _read_head_sha(tmp_path) == _SHA
+
+    def test_packed_refs_ignores_peeled_lines(self, tmp_path):
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "HEAD").write_text("ref: refs/heads/main\n")
+        packed = git_dir / "packed-refs"
+        packed.write_text(f"{_SHA} refs/heads/main\n^{_SHA2}\n{_SHA2} refs/heads/other\n")
+        assert _read_head_sha(tmp_path) == _SHA
+
+    def test_packed_refs_no_match_returns_none(self, tmp_path):
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+        (git_dir / "HEAD").write_text("ref: refs/heads/main\n")
+        packed = git_dir / "packed-refs"
+        packed.write_text(f"{_SHA} refs/heads/other\n")
+        assert _read_head_sha(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# _read_head_sha: .git is a file (worktree)
+# ---------------------------------------------------------------------------
+
+
+class TestReadHeadShaWorktree:
+    def test_follows_gitdir_indirection(self, tmp_path):
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        real_git = tmp_path / "real_git"
+        real_git.mkdir()
+        (real_git / "HEAD").write_text(_SHA + "\n")
+        (worktree / ".git").write_text(f"gitdir: {real_git}\n")
+        assert _read_head_sha(worktree) == _SHA
+
+    def test_gitdir_file_without_gitdir_prefix_returns_none(self, tmp_path):
+        checkout = tmp_path / "checkout"
+        checkout.mkdir()
+        (checkout / ".git").write_text("some random content\n")
+        assert _read_head_sha(checkout) is None
+
+
+# ---------------------------------------------------------------------------
+# _read_head_sha: missing or empty .git
+# ---------------------------------------------------------------------------
+
+
+class TestReadHeadShaMissing:
+    def test_returns_none_when_no_git_dir_or_file(self, tmp_path):
+        assert _read_head_sha(tmp_path) is None
+
+    def test_returns_none_for_nonexistent_checkout(self, tmp_path):
+        assert _read_head_sha(tmp_path / "does_not_exist") is None
+
+
+# ---------------------------------------------------------------------------
+# verify_checkout_sha
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyCheckoutSha:
+    def test_returns_true_when_sha_matches(self, tmp_path):
+        checkout = _make_git_dir(tmp_path, sha=_SHA)
+        assert verify_checkout_sha(checkout, _SHA) is True
+
+    def test_returns_false_when_sha_mismatches(self, tmp_path):
+        checkout = _make_git_dir(tmp_path, sha=_SHA)
+        assert verify_checkout_sha(checkout, _SHA2) is False
+
+    def test_returns_false_when_checkout_dir_missing(self, tmp_path):
+        assert verify_checkout_sha(tmp_path / "missing", _SHA) is False
+
+    def test_returns_false_when_head_unreadable(self, tmp_path):
+        # Directory exists but has no .git at all
+        assert verify_checkout_sha(tmp_path, _SHA) is False
+
+    def test_accepts_uppercase_expected_sha(self, tmp_path):
+        checkout = _make_git_dir(tmp_path, sha=_SHA)
+        assert verify_checkout_sha(checkout, _SHA.upper()) is True
+
+    def test_accepts_sha_with_trailing_whitespace(self, tmp_path):
+        checkout = _make_git_dir(tmp_path, sha=_SHA)
+        assert verify_checkout_sha(checkout, f"  {_SHA}  ") is True
+
+    def test_returns_true_via_symbolic_ref(self, tmp_path):
+        checkout = _make_git_dir_with_ref(tmp_path, sha=_SHA)
+        assert verify_checkout_sha(checkout, _SHA) is True


### PR DESCRIPTION
🤖 *Test Improver - automated AI assistant for test improvements.*

## Goal and Rationale

`src/apm_cli/cache/integrity.py` is a security-critical module that defends against poisoned cache content. On every cache HIT, `verify_checkout_sha` confirms the checkout's HEAD matches the expected SHA - a mismatch triggers eviction and a fresh fetch.

Despite being a critical defence layer, it had zero dedicated unit tests. The logic is non-trivial: it handles three distinct `.git` layouts (directory, worktree file, packed-refs) with multiple fallback paths.

## Approach

New file `tests/unit/cache/test_cache_integrity.py` with 20 unit tests across 6 test classes. Uses `tmp_path` fixtures to create realistic git layout fragments on disk - no subprocess or actual git needed.

Branches covered:
- `.git` directory + detached HEAD (raw SHA)
- `.git` directory + symbolic `ref:` HEAD following the ref file
- `.git` directory + symbolic ref with no ref file, falling back to `packed-refs`
- `packed-refs` ignoring peeled (`^`) lines and non-matching entries
- `.git` file (worktree `gitdir:` indirection) - follows pointer to real git dir
- `.git` file without `gitdir:` prefix - returns `None`
- Missing `.git` entirely - returns `None`
- `verify_checkout_sha`: match, mismatch, missing dir, unreadable HEAD, uppercase SHA, whitespace padding

## Coverage Impact

| Module | Before | After |
|--------|--------|-------|
| `cache/integrity.py` | 0 dedicated tests | 20 tests, all branches covered |

## Trade-offs

- Pure filesystem tests using `tmp_path`; fast (~0.35s for all 20)
- Tests `_read_head_sha` directly (private, but it carries the bulk of the logic)
- No real git process - constructs minimal file layout manually

## Reproducibility

```bash
# Run just these tests
.venv/bin/pytest tests/unit/cache/test_cache_integrity.py -v

# Full unit suite
.venv/bin/pytest tests/unit/ -q
```

## Test Status

- **New tests**: 20 passing, 0 failing
- **Lint**: clean (ruff check + ruff format --check both silent)
- Pre-existing failures: 7 `test_policy_status.py` ANSI tests (unrelated, unchanged)




> [!NOTE]
> <details>
> <summary>🔒 Integrity filter blocked 18 items</summary>
>
> The following items were blocked because they don't meet the GitHub integrity level.
>
> - [#1301](https://github.com/microsoft/apm/pull/1301) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1292](https://github.com/microsoft/apm/pull/1292) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1288](https://github.com/microsoft/apm/pull/1288) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1281](https://github.com/microsoft/apm/pull/1281) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1277](https://github.com/microsoft/apm/pull/1277) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1262](https://github.com/microsoft/apm/pull/1262) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1248](https://github.com/microsoft/apm/pull/1248) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1246](https://github.com/microsoft/apm/pull/1246) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1245](https://github.com/microsoft/apm/pull/1245) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1234](https://github.com/microsoft/apm/pull/1234) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1227](https://github.com/microsoft/apm/pull/1227) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1224](https://github.com/microsoft/apm/pull/1224) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1146](https://github.com/microsoft/apm/pull/1146) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1117](https://github.com/microsoft/apm/pull/1117) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1113](https://github.com/microsoft/apm/pull/1113) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1028](https://github.com/microsoft/apm/pull/1028) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - ... and 2 more items
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [Daily Test Improver](https://github.com/microsoft/apm/actions/runs/25783278624/agentic_workflow) · ● 2.1M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+%22gh-aw-workflow-id%3A+daily-test-improver%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/blob/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-test-improver.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-test-improver.md@b87234850bf9664d198f28a02df0f937d0447295
> ```

<!-- gh-aw-agentic-workflow: Daily Test Improver, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 25783278624, workflow_id: daily-test-improver, run: https://github.com/microsoft/apm/actions/runs/25783278624 -->

<!-- gh-aw-workflow-id: daily-test-improver -->