### PR TITLE
chore: add pylint R0801 duplicate code guardrail (Phase 0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,14 @@ jobs:
           exit 1
         fi
 
+    - name: Code duplication guardrail (pylint R0801)
+      run: |
+        uv run --extra dev python -m pylint \
+          --disable=all --enable=R0801 \
+          --min-similarity-lines=50 \
+          --fail-on=R0801 \
+          src/apm_cli/
+
     - name: Lint - auth-protocol boundary (#1212 anti-regression)
       run: bash scripts/lint-auth-signals.sh
 

--- a/plan.md
+++ b/plan.md
@@ -1,243 +1,78 @@
-# Implementation Plan — PR #700 Architectural Fixes
+# Duplicate Code Reduction Plan
 
-## Overview
+CI guardrail + 4-phase strangling fig to progressively eliminate
+duplicated code blocks in `src/apm_cli/`.
 
-Three targeted refactors requested by review, all scoped inside a single PR.
-They share no mutual data-flow dependency, so they can be implemented as three
-independent commits, but must be **ordered** to minimise merge-conflict surface.
+## Tool
 
----
+**pylint R0801** (cross-file similarity detection).
 
-## Change 1: `LockedDependency.to_dependency_ref()` — Eliminate 3 Duplicate Reconstructions
+Ruff has no duplicate-code rule. pylint is Python-native, supports
+`--min-similarity-lines` as a tuneable lever, and integrates with the
+existing `uv run --extra dev` workflow.
 
-### Problem
+## Strangling Fig Phases
 
-Three call sites manually reconstruct a `DependencyReference` from a
-`LockedDependency` using an identical 8-field constructor call.  The field
-mapping is non-trivial (`registry_prefix` → `artifactory_prefix`;
-`source == "local"` → `is_local`), creating a maintenance hazard.
+| Phase | Threshold | Violations | Status |
+|-------|-----------|-----------|--------|
+| 0 | 50 | 0 | This PR -- guardrail only |
+| 1 | 25 | 2 | Separate PR |
+| 2 | 15 | 6 | Separate PR |
+| 3 | 10 | 19 | Separate PR |
 
-| # | File | Function | Lines |
-|---|------|----------|-------|
-| 1 | `src/apm_cli/deps/lockfile.py` | `LockFile.get_installed_paths()` | 375-385 |
-| 2 | `src/apm_cli/commands/_helpers.py` | `_build_expected_install_paths()` | 138-148 |
-| 3 | `src/apm_cli/bundle/plugin_exporter.py` | `_dep_install_path()` | 399-409 |
+Each phase: lower the `--min-similarity-lines` threshold, fix the
+violations that surface, then update CI to enforce zero violations
+at the new level.
 
-### Design
+## Phase 0 (this PR)
 
-Add a new method on `LockedDependency`:
+Add pylint R0801 to CI with `--min-similarity-lines=50`. Zero
+violations exist at this threshold, so no code changes are needed.
+This prevents new large duplicated blocks from being introduced.
 
-```python
-def to_dependency_ref(self) -> "DependencyReference":
-    """Reconstruct the DependencyReference needed for path computation."""
-    from ..models.apm_package import DependencyReference
-    return DependencyReference(
-        repo_url=self.repo_url,
-        host=self.host,
-        virtual_path=self.virtual_path,
-        is_virtual=self.is_virtual,
-        artifactory_prefix=self.registry_prefix,
-        is_local=(self.source == "local"),
-        local_path=self.local_path,
-        is_insecure=self.is_insecure,
-        allow_insecure=self.allow_insecure,
-    )
-```
+## Phase 1 -- threshold 25 (2 violations)
 
-Lazy import inside the method body avoids circular dependency
-(`lockfile.py` → `reference.py`; `reference.py` does NOT import lockfile).
+1. `copilot.py:617-696 <-> cursor.py:200-261` -- registry package
+   config (npm/docker/pypi/homebrew/generic dispatch). ~51 lines.
+2. `codex.py:419-476 <-> copilot.py:813-882` -- environment variable
+   resolution + prompting logic. ~57 lines.
 
-### Files Changed (4)
+Fix: extract `_build_package_config()` and
+`_resolve_environment_variables()` into `MCPClientAdapter` base class.
 
-| File | Change |
-|------|--------|
-| `src/apm_cli/deps/lockfile.py` | Add `to_dependency_ref()` to `LockedDependency`; refactor `get_installed_paths()` to call it |
-| `src/apm_cli/commands/_helpers.py` | Replace 10-line constructor with `dep.to_dependency_ref()` |
-| `src/apm_cli/bundle/plugin_exporter.py` | Replace 10-line constructor with `dep.to_dependency_ref()` |
-| `tests/test_lockfile.py` | Add unit test for `to_dependency_ref()` round-trip fidelity |
+## Phase 2 -- threshold 15 (4 additional violations)
 
-### Risks
+3. `copilot.py:568-591 <-> cursor.py:158-180` -- MCP auth/header
+   injection. ~23 lines.
+4. `codex.py:300-325 <-> copilot.py:670-696` -- pypi/homebrew/generic
+   config subset. ~26 lines (subset of V1).
+5. `copilot.py:617-646 <-> cursor.py:200-223` -- package extraction
+   preamble. ~29 lines.
+6. `claude_formatter.py:281-308 <-> distributed_compiler.py:542-565`
+   -- instruction rendering + footer. ~24 lines.
 
-- **Low**: Pure refactor — no behaviour change.  Existing tests for
-  `get_installed_paths`, `_build_expected_install_paths`, and
-  `_dep_install_path` serve as regression coverage.
-- **Field drift**: If a future field is added to the reconstruction,
-  only ONE site needs updating.  This is the whole point.
+Fix: extract auth injection and instruction rendering into shared
+helpers. V4-V5 are subsets of V1 and resolve when V1 is fixed.
 
----
+## Phase 3 -- threshold 10 (13 additional violations)
 
-## Change 2: Scheme-Blind Identity / Drift Handling
+7-19. Smaller clones across adapter clients, integrators, deps,
+marketplace, policy, and runtime modules. See the full impact report
+in the PR description for per-violation details.
 
-### Problem
+Fix: lift shared logic to base classes, remove deprecated shims,
+consolidate utility helpers.
 
-`get_unique_key()` (both on `DependencyReference` and `LockedDependency`)
-returns `repo_url`, which is scheme-blind: `owner/repo` is the same key
-whether the dependency is HTTP or HTTPS.  This means:
+## Tests
 
-1. **Identity collision** — an `http://` dep and an `https://` dep to the same
-   `owner/repo` silently overwrite each other in the lockfile dict (keyed by
-   `get_unique_key()`).
-2. **Drift not detected** — `detect_ref_change()` in `drift.py` compares
-   `dep_ref.reference != locked_dep.resolved_ref` but never checks whether
-   the *scheme* changed.  The docstring at `drift.py:41-46` explicitly
-   documents this as a known non-goal ("Source/host/scheme changes — *not*
-   detected").
-3. **Silent lockfile corruption on scheme switch** — if a user edits
-   `apm.yml` from `http://host/owner/repo` to `https://host/owner/repo`
-   (fixing a security issue), the lockfile entry retains `is_insecure: true`
-   from the old lock, and `build_download_ref()` (drift.py:253) restores
-   `is_insecure=True` to the download ref, defeating the upgrade.
+Tests (`tests/`) have 4.64% duplication. This is expected for test
+fixtures and parametrised setups. Test deduplication is deferred to
+a separate effort after `src/` stabilises. Tests can later be added
+to the pylint scope with a higher threshold.
 
-### Design
+## Hotspot
 
-This is a **policy decision** with two possible depths:
-
-**Option A — Minimal (recommended for this PR):** Make scheme change trigger
-re-download by adding a scheme check in `build_download_ref()`:
-
-```python
-# In build_download_ref(), after the lockfile lookup:
-if locked_dep.is_insecure != dep_ref.is_insecure:
-    return dep_ref  # scheme changed → re-download from manifest
-```
-
-This ensures that an HTTP→HTTPS (or HTTPS→HTTP) change in `apm.yml` is not
-masked by the lockfile replay.  The unique key stays scheme-blind (same
-filesystem path), but the *download* respects the manifest's scheme.
-
-**Option B — Full (consider for follow-up):** Include scheme in
-`get_unique_key()` so that HTTP and HTTPS versions of the same repo are
-truly distinct entries.  This has much wider blast radius (lockfile format,
-orphan detection, filesystem layout).
-
-### Files Changed (Option A — 3 files)
-
-| File | Change |
-|------|--------|
-| `src/apm_cli/drift.py` | Add scheme-change guard in `build_download_ref()`; update module docstring to remove the "not detected" caveat |
-| `tests/unit/test_install_update.py` | Add test: HTTP→HTTPS scheme change triggers re-download; add test: HTTPS→HTTP without `allow_insecure` is rejected |
-| `tests/unit/test_install_update.py` | Verify existing `test_http_lockfile_restores_insecure_scheme` still passes (no change to it, just run) |
-
-### Risks
-
-- **Medium — lockfile replay**: If an existing lockfile has `is_insecure: true`
-  and the user switches to HTTPS in `apm.yml`, the dep will be re-downloaded
-  on next install.  This is *correct* but is a behavioural change for users
-  who previously edited scheme without re-downloading.
-- **Low — identity stability**: `get_unique_key()` is unchanged, so lockfile
-  keying, orphan detection, and filesystem layout are unaffected.
-- **None — `get_identity()`**: Already scheme-blind by design (it serves
-  duplicate detection, not lockfile keying).  No change needed.
-
----
-
-## Change 3: Move Insecure Policy Logic to Install Module
-
-### Problem
-
-10 insecure-policy functions and 1 dataclass live in
-`src/apm_cli/commands/install.py` (lines 111-306).  The resolve phase
-(`install/phases/resolve.py:300-305`) imports them back:
-
-```python
-from apm_cli.commands.install import (
-    _check_insecure_dependencies,
-    _collect_insecure_dependency_infos,
-    _guard_transitive_insecure_dependencies,
-    _warn_insecure_dependencies,
-)
-```
-
-This creates a **circular dependency smell** (`commands/ → install/` and
-`install/ → commands/`) and places pure-domain logic inside a Click CLI module.
-
-### Design
-
-Create `src/apm_cli/install/insecure_policy.py` containing:
-
-- `_InsecureDependencyInfo` (dataclass)
-- `_collect_insecure_dependency_infos()`
-- `_format_insecure_dependency_warning()`
-- `_warn_insecure_dependencies()`
-- `_normalize_allow_insecure_host()`
-- `_allow_insecure_host_callback()` (Click callback — needs `click` import)
-- `_get_insecure_dependency_host()`
-- `_get_allowed_transitive_insecure_hosts()`
-- `_guard_transitive_insecure_dependencies()`
-- `_check_insecure_dependencies()`
-
-In `commands/install.py`, add re-exports to preserve the existing test import
-contract:
-
-```python
-from apm_cli.install.insecure_policy import (
-    _InsecureDependencyInfo,
-    _check_insecure_dependencies,
-    _collect_insecure_dependency_infos,
-    _format_insecure_dependency_warning,
-    _guard_transitive_insecure_dependencies,
-    _warn_insecure_dependencies,
-    _allow_insecure_host_callback,
-    _normalize_allow_insecure_host,
-    _get_insecure_dependency_host,
-    _get_allowed_transitive_insecure_hosts,
-)
-```
-
-The resolve phase import changes to the canonical location:
-
-```python
-from apm_cli.install.insecure_policy import (
-    _check_insecure_dependencies,
-    _collect_insecure_dependency_infos,
-    _guard_transitive_insecure_dependencies,
-    _warn_insecure_dependencies,
-)
-```
-
-### Files Changed (4 + 1 new)
-
-| File | Change |
-|------|--------|
-| `src/apm_cli/install/insecure_policy.py` | **NEW** — all 10 functions + dataclass moved here |
-| `src/apm_cli/commands/install.py` | Delete function bodies (lines 111-306); add re-export block |
-| `src/apm_cli/install/phases/resolve.py` | Update import from `apm_cli.install.insecure_policy` |
-| `tests/unit/test_install_command.py` | No change needed if re-exports preserved.  Optionally add a parallel import path test. |
-| `tests/unit/install/test_insecure_policy.py` | **NEW** (optional) — dedicated tests for the new module, migrated from test_install_command.py |
-
-### Risks
-
-- **Low — import compat**: Re-exports from `commands/install.py` keep all 17
-  existing test patches (e.g. `@patch("apm_cli.commands.install._check_insecure_dependencies")`)
-  working.  This follows the precedent already set in `install.py` lines 34-70
-  for `_hash_deployed`, `_validate_package_exists`, `_pre_deploy_security_scan`, etc.
-- **Low — Click dependency**: `_allow_insecure_host_callback` needs `click`;
-  the install package already imports click transitively (via context/request).
-  Keep the import local to that one function.
-- **None — runtime**: Pure file-move.  No logic change.
-
----
-
-## Recommended Commit Order
-
-| Order | Change | Rationale |
-|-------|--------|-----------|
-| **1** | `to_dependency_ref()` | Smallest blast radius (4 files). Self-contained refactor. No test import changes. Easiest to review. |
-| **2** | Scheme-blind drift fix | Builds on stable lockfile model from (1). Adds a single guard in `drift.py`. Small, focused. |
-| **3** | Move insecure policy | Largest file-move. Touches the most test-adjacent surface. Doing it last means reviewers already understand the insecure plumbing from (2). |
-
-Each commit should be independently green (all tests pass). This ordering
-minimises rebase conflicts if any commit needs rework.
-
----
-
-## Test Strategy
-
-| Commit | New Tests | Existing Coverage |
-|--------|-----------|-------------------|
-| 1 | 1 unit test for `to_dependency_ref()` round-trip | `test_lockfile.py` (44 tests), `test_transitive_deps.py` |
-| 2 | 2 tests for scheme-change detection | `test_install_update.py` (existing HTTP lockfile test) |
-| 3 | Import-path smoke test (optional) | All 17 tests in `TestAllowInsecureFlag`, `TestInsecureDependencyWarnings`, `TestTransitiveInsecureDependencyGuard` pass unchanged via re-exports |
-
-Total new test count: ~3-4 tests.
-Total files touched: 8 (+ 1-2 new).
+70% of duplication (13/19 violations) is in `adapters/client/`.
+The root cause: `codex.py` extends `MCPClientAdapter` directly
+instead of `CopilotClientAdapter`, duplicating env resolution,
+package config, and argument processing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "ruff>=0.11.0",
     "mypy>=1.0.0",
     "jsonschema>=4.0.0",
+    "pylint>=3.0.0",
 ]
 build = [
     "pyinstaller>=6.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,11 @@
 version = 1
 revision = 3
 requires-python = ">=3.10"
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version == '3.11.*'",
+    "python_full_version < '3.11'",
+]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -206,6 +211,7 @@ build = [
 dev = [
     { name = "jsonschema" },
     { name = "mypy" },
+    { name = "pylint" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-split" },
@@ -224,6 +230,7 @@ requires-dist = [
     { name = "llm-github-models", specifier = ">=0.1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pyinstaller", marker = "extra == 'build'", specifier = ">=6.0.0" },
+    { name = "pylint", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pytest-split", marker = "extra == 'dev'", specifier = ">=0.9.0" },
@@ -240,6 +247,18 @@ requires-dist = [
     { name = "watchdog", specifier = ">=3.0.0" },
 ]
 provides-extras = ["dev", "build"]
+
+[[package]]
+name = "astroid"
+version = "4.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/63/0adf26577da5eff6eb7a177876c1cfa213856be9926a000f65c4add9692b/astroid-4.0.4.tar.gz", hash = "sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0", size = 406358, upload-time = "2026-02-07T23:35:07.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl", hash = "sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753", size = 276445, upload-time = "2026-02-07T23:35:05.344Z" },
+]
 
 [[package]]
 name = "async-timeout"
@@ -492,6 +511,15 @@ toml = [
 ]
 
 [[package]]
+name = "dill"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -505,7 +533,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -713,6 +741,15 @@ wheels = [
 ]
 
 [[package]]
+name = "isort"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
+]
+
+[[package]]
 name = "jiter"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -873,6 +910,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
 ]
 
 [[package]]
@@ -1093,6 +1139,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/73/7e/d2b04004e1068ad4fdfa2f227b839b5d03e602e47cdbbf49de71137c9546/pip-26.1.tar.gz", hash = "sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3", size = 1840316, upload-time = "2026-04-26T21:00:05.406Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl", hash = "sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1", size = 1812804, upload-time = "2026-04-26T21:00:03.194Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
 ]
 
 [[package]]
@@ -1352,6 +1407,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/71/d6/e5b378b7d4add8c879295c531309b0320e9c07a70458665d091760ffdc87/pyinstaller_hooks_contrib-2025.8.tar.gz", hash = "sha256:3402ad41dfe9b5110af134422e37fc5d421ba342c6cb980bd67cb30b7415641c", size = 164214, upload-time = "2025-07-27T16:37:31.943Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/34/1d973d0dae849683e53fbcda84443ce016f315e6f4dc7605ede4f56a28c3/pyinstaller_hooks_contrib-2025.8-py3-none-any.whl", hash = "sha256:8d0b8cfa0cb689a619294ae200497374234bd4e3994b3ace2a4442274c899064", size = 442346, upload-time = "2025-07-27T16:37:30.268Z" },
+]
+
+[[package]]
+name = "pylint"
+version = "4.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "astroid" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "dill" },
+    { name = "isort" },
+    { name = "mccabe" },
+    { name = "platformdirs" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomlkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/b6/74d9a8a68b8067efce8d07707fe6a236324ee1e7808d2eb3646ec8517c7d/pylint-4.0.5.tar.gz", hash = "sha256:8cd6a618df75deb013bd7eb98327a95f02a6fb839205a6bbf5456ef96afb317c", size = 1572474, upload-time = "2026-02-20T09:07:33.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/6f/9ac2548e290764781f9e7e2aaf0685b086379dabfb29ca38536985471eaf/pylint-4.0.5-py3-none-any.whl", hash = "sha256:00f51c9b14a3b3ae08cff6b2cdd43f28165c78b165b628692e428fb1f8dc2cf2", size = 536694, upload-time = "2026-02-20T09:07:31.028Z" },
 ]
 
 [[package]]
@@ -1847,6 +1921,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/b9/1ed31d167be802da0fc95020d04cd27b7d7065cc6fbefdd2f9186f60d7bd/tomli-2.2.1-cp313-cp313-win32.whl", hash = "sha256:d3f5614314d758649ab2ab3a62d4f2004c825922f9e370b29416484086b264ec", size = 98724, upload-time = "2024-11-27T22:38:32.837Z" },
     { url = "https://files.pythonhosted.org/packages/c7/32/b0963458706accd9afcfeb867c0f9175a741bf7b19cd424230714d722198/tomli-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a38aa0308e754b0e3c67e344754dff64999ff9b513e691d0e786265c93583c69", size = 109383, upload-time = "2024-11-27T22:38:34.455Z" },
     { url = "https://files.pythonhosted.org/packages/6e/c2/61d3e0f47e2b74ef40a68b9e6ad5984f6241a942f7cd3bbfbdbd03861ea9/tomli-2.2.1-py3-none-any.whl", hash = "sha256:cb55c73c5f4408779d0cf3eef9f762b9c9f147a77de7b258bef0a5628adc85cc", size = 14257, upload-time = "2024-11-27T22:38:35.385Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Duplicate Code Guardrail -- Phase 0

## TL;DR

Adds a **pylint R0801** CI step to detect cross-file code duplication in `src/apm_cli/`. Threshold starts at `--min-similarity-lines=50` (0 violations today), establishing the guardrail without requiring any code changes. Future PRs will progressively lower the threshold via a 4-phase strangling fig strategy.

## Problem (WHY)

The `src/apm_cli/` codebase contains **19 duplicate code blocks** (at threshold 10), totalling ~490 lines of copy-pasted logic across 24 files. The worst offenders are in `adapters/client/` where `copilot.py` (8 clones), `cursor.py` (6), and `codex.py` (5) share duplicated env resolution, package config, and argument processing. This duplication inflates the testing surface and makes bug fixes error-prone (fix in one place, miss the copy).

Ruff has no duplicate-code detection rule. pylint R0801 is the standard Python-native solution.

## Approach (WHAT)

**Phase 0 only** -- guardrail setup, zero code changes:

1. Add `pylint>=3.0.0` to dev dependencies
2. Add a CI lint step: `pylint --disable=all --enable=R0801 --min-similarity-lines=50 --fail-on=R0801 src/apm_cli/`
3. Document the 4-phase strangling fig in `plan.md`

The strangling fig mechanism uses `--min-similarity-lines` as the lever:

| Phase | Threshold | Violations | Status |
|-------|-----------|------------|--------|
| 0 | 50 | 0 | **This PR** |
| 1 | 25 | 2 | Separate PR |
| 2 | 15 | 6 | Separate PR |
| 3 | 10 | 19 | Separate PR |

Each future phase: lower threshold -> violations appear -> fix them -> CI enforces 0 at new level.

## Implementation (HOW)

### Files changed

| File | Change |
|------|--------|
| `pyproject.toml` | Added `\"pylint>=3.0.0\"` to `[project.optional-dependencies] dev` |
| `uv.lock` | Updated with pylint v4.0.5 + transitive deps (isort, mccabe, platformdirs, tomlkit) |
| `.github/workflows/ci.yml` | New \"Code duplication guardrail (pylint R0801)\" step in Lint job |
| `plan.md` | Replaced old PR #700 plan with duplicate code reduction roadmap |

### CI step detail

```yaml
- name: Code duplication guardrail (pylint R0801)
  run: |
    uv run --extra dev python -m pylint \\
      --disable=all --enable=R0801 \\
      --min-similarity-lines=50 \\
      --fail-on=R0801 \\
      src/apm_cli/
```

- `--disable=all --enable=R0801`: only runs the similarity checker, no other pylint rules
- `--fail-on=R0801`: exit code 0 when clean, non-zero when duplicates found
- Runtime: ~19s locally

### Supply chain

New dev dependency `pylint>=3.0.0` (locked to v4.0.5). Transitive deps are all well-established packages already common in the Python ecosystem: `isort`, `mccabe`, `platformdirs`, `tomlkit`.

## Trade-offs

| Decision | Rationale |
|----------|-----------|
| pylint over jscpd | Python-native, no npm dependency, integrates with existing `uv run --extra dev` workflow |
| Threshold 50 (not 10) | Start conservative -- prevents new large clones without blocking existing code |
| Dev-only dependency | pylint is never shipped to users, only runs in CI and local dev |
| plan.md documents future phases | Phases 1-3 are separate PRs; plan.md serves as the roadmap |

## Validation

- [x] `uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=50 --fail-on=R0801 src/apm_cli/` -- exits 0 (0 violations)
- [x] `uv run --extra dev ruff check src/ tests/` -- passes
- [x] `uv run --extra dev ruff format --check src/ tests/` -- passes

## How to test

```bash
# Verify guardrail passes at threshold 50
uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=50 --fail-on=R0801 src/apm_cli/

# See what Phase 1 will surface (threshold 25)
uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=25 --fail-on=R0801 src/apm_cli/

# See the full duplication landscape (threshold 10)
uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/
```