### PR TITLE
feat(targets): add codebuddy as alias of claude

### DIFF
--- a/src/apm_cli/compilation/agents_compiler.py
+++ b/src/apm_cli/compilation/agents_compiler.py
@@ -41,6 +41,7 @@ _VSCODE_TARGET_ALIASES = ("copilot", "agents")
 _KNOWN_TARGETS = (  # noqa: RUF005
     "vscode",
     "claude",
+    "codebuddy",  # TNV downstream: Tencent CodeBuddy (claude family, .codebuddy/ deploy)
     "cursor",
     "opencode",
     "codex",

--- a/src/apm_cli/core/apm_yml.py
+++ b/src/apm_cli/core/apm_yml.py
@@ -32,6 +32,7 @@ CANONICAL_TARGETS: frozenset[str] = frozenset(
         "gemini",
         "windsurf",
         "agent-skills",
+        "codebuddy",  # TNV downstream: Tencent CodeBuddy (Claude-compatible IDE)
     }
 )
 

--- a/src/apm_cli/core/target_detection.py
+++ b/src/apm_cli/core/target_detection.py
@@ -53,6 +53,7 @@ def agents_alias_was_detected() -> bool:
 TargetType = Literal[
     "vscode",
     "claude",
+    "codebuddy",  # TNV downstream: Tencent CodeBuddy (Claude-compatible)
     "cursor",
     "opencode",
     "codex",
@@ -92,6 +93,7 @@ UserTargetType = Literal[
     "vscode",
     "agents",
     "claude",
+    "codebuddy",  # TNV downstream: Tencent CodeBuddy (Claude-compatible)
     "cursor",
     "opencode",
     "codex",
@@ -126,6 +128,8 @@ def detect_target(  # noqa: PLR0911
             return "vscode", "explicit --target flag"
         elif explicit_target == "claude":
             return "claude", "explicit --target flag"
+        elif explicit_target == "codebuddy":  # TNV downstream
+            return "codebuddy", "explicit --target flag"
         elif explicit_target == "cursor":
             return "cursor", "explicit --target flag"
         elif explicit_target == "opencode":
@@ -147,6 +151,8 @@ def detect_target(  # noqa: PLR0911
             return "vscode", "apm.yml target"
         elif config_target == "claude":
             return "claude", "apm.yml target"
+        elif config_target == "codebuddy":  # TNV downstream
+            return "codebuddy", "apm.yml target"
         elif config_target == "cursor":
             return "cursor", "apm.yml target"
         elif config_target == "opencode":
@@ -236,7 +242,8 @@ def should_compile_claude_md(target: CompileTargetType) -> bool:
     """
     if isinstance(target, frozenset):
         return "claude" in target
-    return target in ("claude", "all")
+    # codebuddy shares the claude compile family (TNV downstream)
+    return target in ("claude", "codebuddy", "all")
 
 
 def should_compile_gemini_md(target: CompileTargetType) -> bool:
@@ -294,6 +301,7 @@ def get_target_description(target: UserTargetType) -> str:
     descriptions = {
         "vscode": "AGENTS.md + .github/copilot-instructions.md + .github/prompts/ + .github/agents/",
         "claude": "CLAUDE.md + .claude/commands/ + .claude/agents/ + .claude/skills/",
+        "codebuddy": "CLAUDE.md + .codebuddy/commands/ + .codebuddy/agents/ + .codebuddy/skills/ (Claude-compatible)",
         "cursor": ".cursor/agents/ + .cursor/skills/ + .cursor/rules/",
         "opencode": "AGENTS.md + .opencode/agents/ + .opencode/commands/ + .opencode/skills/",
         "codex": "AGENTS.md + .agents/skills/ + .codex/agents/ + .codex/hooks.json",
@@ -313,7 +321,7 @@ def get_target_description(target: UserTargetType) -> str:
 #: The complete set of real (non-pseudo) canonical targets.
 #: "minimal" is intentionally excluded -- it is a fallback pseudo-target.
 ALL_CANONICAL_TARGETS = frozenset(
-    {"vscode", "claude", "cursor", "opencode", "codex", "gemini", "windsurf"}
+    {"vscode", "claude", "codebuddy", "cursor", "opencode", "codex", "gemini", "windsurf"}
 )
 
 #: Targets that the parser must accept but that are gated at runtime by
@@ -620,6 +628,7 @@ class ResolvedTargets:
 SIGNAL_WHITELIST: list[tuple[str, str, str]] = [
     ("claude", "dir", ".claude"),
     ("claude", "file", "CLAUDE.md"),
+    ("codebuddy", "dir", ".codebuddy"),  # TNV downstream
     ("cursor", "dir", ".cursor"),
     ("cursor", "file", ".cursorrules"),  # legacy; .cursor/ is canonical
     ("copilot", "file", ".github/copilot-instructions.md"),
@@ -633,6 +642,7 @@ SIGNAL_WHITELIST: list[tuple[str, str, str]] = [
 # Ordered list of targets for display (excludes agent-skills meta-target).
 CANONICAL_TARGETS_ORDERED: list[str] = [
     "claude",
+    "codebuddy",  # TNV downstream
     "copilot",
     "cursor",
     "codex",
@@ -644,6 +654,7 @@ CANONICAL_TARGETS_ORDERED: list[str] = [
 # Canonical deploy directories for each target.
 CANONICAL_DEPLOY_DIRS: dict[str, str] = {
     "claude": ".claude/",
+    "codebuddy": ".codebuddy/",  # TNV downstream
     "copilot": ".github/",
     "cursor": ".cursor/",
     "codex": ".codex/",
@@ -656,6 +667,7 @@ CANONICAL_DEPLOY_DIRS: dict[str, str] = {
 # "needs <path>" display for inactive targets.
 CANONICAL_SIGNAL: dict[str, str] = {
     "claude": "CLAUDE.md",
+    "codebuddy": ".codebuddy/",  # TNV downstream
     "copilot": ".github/copilot-instructions.md",
     "cursor": ".cursor/",
     "codex": ".codex/",

--- a/src/apm_cli/integration/targets.py
+++ b/src/apm_cli/integration/targets.py
@@ -373,6 +373,27 @@ KNOWN_TARGETS: dict[str, TargetProfile] = {
         compile_family="claude",
         hooks_config_display=".claude/settings.json",
     ),
+    # CodeBuddy (Tencent) -- Claude-Code-compatible AI coding IDE. Reads
+    # CLAUDE.md at project root and uses .claude/-style settings.json for
+    # hooks. Reuses claude_* primitive formatters but deploys to .codebuddy/
+    # so multi-IDE projects (.claude/ + .codebuddy/) don't collide.
+    # Ref: https://copilot.tencent.com/codebuddy
+    "codebuddy": TargetProfile(
+        name="codebuddy",
+        root_dir=".codebuddy",
+        primitives={
+            "instructions": PrimitiveMapping("rules", ".md", "claude_rules"),
+            "agents": PrimitiveMapping("agents", ".md", "claude_agent"),
+            "commands": PrimitiveMapping("commands", ".md", "claude_command"),
+            "skills": PrimitiveMapping("skills", "/SKILL.md", "skill_standard"),
+            "hooks": PrimitiveMapping("hooks", ".json", "claude_hooks"),
+        },
+        auto_create=False,
+        detect_by_dir=True,
+        user_supported=True,
+        compile_family="claude",
+        hooks_config_display=".codebuddy/settings.json",
+    ),
     # Cursor -- at user scope, ~/.cursor/ supports skills, agents, hooks,
     # and MCP.  Rules/instructions are managed via Cursor Settings UI only
     # (not file-based), so "instructions" is excluded from user scope.


### PR DESCRIPTION
## Summary

Registers Tencent CodeBuddy IDE as a **first-class target** with its own deploy directory `.codebuddy/`. CodeBuddy is a Claude-Code-compatible AI coding assistant — it reads `CLAUDE.md` from the project root and uses `.claude/`-style `settings.json` for hook configuration. Reuses the existing `claude_*` primitive formatters but deploys to `.codebuddy/` so projects using both Claude Code and CodeBuddy can co-exist without directory collision.

CodeBuddy CLI: https://copilot.tencent.com/codebuddy

## Patch surface (4 files, +37 net)

- `src/apm_cli/integration/targets.py` — new `KNOWN_TARGETS["codebuddy"]` `TargetProfile` (root_dir=".codebuddy", compile_family="claude", primitives reuse `claude_rules` / `claude_agent` / `claude_command` / `skill_standard` / `claude_hooks`, `hooks_config_display=".codebuddy/settings.json"`)
- `src/apm_cli/core/target_detection.py` — `TargetType` / `UserTargetType` Literals + `ALL_CANONICAL_TARGETS` + `CANONICAL_TARGETS_ORDERED` + `CANONICAL_DEPLOY_DIRS` + `CANONICAL_SIGNAL` + `SIGNAL_WHITELIST` all add codebuddy; `detect_target()` `--target` / `apm.yml` elif chains return `"codebuddy"`; `should_compile_claude_md()` accepts `codebuddy` (so root `CLAUDE.md` is still generated); `get_target_description()` describes codebuddy output
- `src/apm_cli/core/apm_yml.py` — `CANONICAL_TARGETS` frozenset gains `"codebuddy"`
- `src/apm_cli/compilation/agents_compiler.py` — `_KNOWN_TARGETS` tuple gains `"codebuddy"` so the compiler's local validation accepts `config.target == "codebuddy"`

## Verified locally against `upstream/main` (219af91)

```
$ apm targets
  TARGET       STATUS     SOURCE                         DEPLOY DIR
  claude       inactive   needs CLAUDE.md                .claude/
  codebuddy    inactive   needs .codebuddy/              .codebuddy/
  ...

$ apm install --target codebuddy
Installed 17 APM dependencies in 15.2s

$ apm compile -t codebuddy
[+] Compilation completed successfully!
[i] Targets: codebuddy  (source: --target flag)
[i] Compiling for CLAUDE.md + .codebuddy/commands/ + .codebuddy/agents/ + .codebuddy/skills/ (Claude-compatible)
```

End-to-end on a real project — fresh git repo + `apm install --target codebuddy`:
- `.codebuddy/agents/` populated with agent files
- `.codebuddy/commands/` populated with command files
- `.codebuddy/skills/` populated with skills
- `.codebuddy/settings.json` written (hook config)
- Root `CLAUDE.md` generated by `apm compile -t codebuddy`

Multi-IDE (`.claude/` + `.codebuddy/` in the same project) deploys primitives to both directories in parallel with no overlap.

## Design choices

- **`compile_family="claude"`** so root `CLAUDE.md` is still generated. CodeBuddy reads Claude Code's format verbatim — adding a new `compile_family="codebuddy"` would have required a new template and output writer with no functional benefit. Happy to revisit if maintainers prefer a dedicated `CODEBUDDY.md` marker.
- **Reuse `claude_*` primitive formatters**. Same justification — CodeBuddy's parser is Claude-Code compatible.
- **Add `_KNOWN_TARGETS` entry in `agents_compiler.py`**. Because `detect_target()` now returns `"codebuddy"` (not `"claude"`), the compiler's `config.target` is `"codebuddy"` when codebuddy is the active target; the existing `_KNOWN_TARGETS` validation rejects it unless we register it explicitly.
- **Add `SIGNAL_WHITELIST` entry** for `.codebuddy/` so `apm install` without `--target` auto-detects codebuddy alongside other harnesses.

## Why this changed shape vs the earlier revision

An earlier version of this PR (47 lines) registered codebuddy as a **pure alias** of `claude` in `TARGET_ALIASES`. That's the smallest possible patch and makes `apm compile -t codebuddy` work without errors — but the deploy lands in `.claude/`, so codebuddy-only projects end up with a `.claude/` directory and no `.codebuddy/` content beyond what the caller manually places. The first-class registration here is what we ship downstream (Tinnove TAC bundles a patched wheel for our internal users) and produces a coherent `.codebuddy/` deploy parallel to other native targets.

## Tests

Local smoke (Python REPL against the patched checkout): `TARGET_ALIASES` does not contain codebuddy (intentional — first-class now, not an alias); `CANONICAL_TARGETS / ALL_CANONICAL_TARGETS / CANONICAL_DEPLOY_DIRS / CANONICAL_SIGNAL / SIGNAL_WHITELIST / CANONICAL_TARGETS_ORDERED` all contain codebuddy; `KNOWN_TARGETS["codebuddy"].root_dir == ".codebuddy"` and `.compile_family == "claude"`; `detect_target(explicit_target="codebuddy")` returns `("codebuddy", "explicit --target flag")`. Two unrelated `tests/unit/marketplace/test_schema_conformance.py` / `tests/unit/test_plugin_exporter_schema.py` collection errors from missing optional `jsonschema` dep on my machine; not affected by this patch.

Happy to add a dedicated `tests/test_codebuddy_target.py` if maintainers want unit coverage parallel to the existing target tests.