### PR TITLE
[docs] Update documentation for features from 2026-05-14

### DIFF
--- a/docs/src/content/docs/troubleshooting/install-failures.md
+++ b/docs/src/content/docs/troubleshooting/install-failures.md
@@ -166,7 +166,24 @@ apm audit --check drift
 
 A non-zero exit means the working tree has diverged from `apm.lock.yaml` -- either re-run `apm install` to restore parity, or commit the new lockfile if the drift was intentional.
 
-For the full flag list see [`apm install`](../reference/cli/install/).
+### Policy blocked after lockfile wipe
+
+If `apm install` fails with `Policy violation: required-packages-deployed` right after a lockfile wipe, hand-edit, or partial-install crash, the lockfile has an empty `deployed_files` list for a required package even though the files are on disk.
+
+Re-run `apm install` -- APM now auto-adopts byte-identical existing files and repopulates `deployed_files`, which lets the policy gate pass:
+
+```bash
+apm install
+```
+
+On APM versions older than v0.14, use `--no-policy` once to break the loop:
+
+```bash
+apm install --no-policy   # one-time: repopulates deployed_files
+apm install               # policy now passes
+```
+
+For full diagnosis of policy failures, see [Debugging policy failures](./policy-debugging/).
 
 ## 4. Cache problems
 

--- a/docs/src/content/docs/troubleshooting/policy-debugging.md
+++ b/docs/src/content/docs/troubleshooting/policy-debugging.md
@@ -87,6 +87,9 @@ Common surprises:
 - A child sets `mcp.transport.allow: [stdio, http]` but the parent
   pinned `[http]` -- the child's broader list is ignored.
 - Severity can only be raised by a child, never lowered.
+- `dependencies.require` and `dependencies.deny` from an org floor are
+  correctly inherited when a repo policy uses `extends: org`. An absent
+  repo-level block no longer silently drops the org requirement.
 
 The full merge semantics live in
 [Policy schema -> Merge rules (tighten-only)](../reference/policy-schema/#merge-rules-tighten-only).
@@ -170,6 +173,23 @@ shortest path to green.
 - **Fix:** Edit `apm.yml` and add the listed field. Org policy
   defines the required set; check
   [Policy schema](../reference/policy-schema/).
+
+### `required-packages-deployed`
+
+- **Symptom:** `Policy violation: required-packages-deployed -- 1 required package(s) not deployed: <org>/<repo>/...` even though the package files appear to be on disk.
+- **Cause:** The lockfile (`apm.lock.yaml`) has an empty `deployed_files` list for the required package. This can happen after a lockfile wipe, a hand-edit, a partial-install crash, or an older APM build that did not record the entry. The policy gate runs before `apm install` deploys files, so it fires on the stale (empty) lockfile state.
+- **Fix (v0.14+):** Re-run `apm install`. APM now auto-adopts byte-identical existing files, which repopulates `deployed_files` without overwriting your content. The next `apm install` will then pass the policy gate.
+
+  ```bash
+  apm install          # repopulates deployed_files; policy passes on this run
+  ```
+
+- **Fix (older versions):** Use `--no-policy` once to break the loop, then run normally:
+
+  ```bash
+  apm install --no-policy   # one-time: repopulates deployed_files
+  apm install               # policy now passes
+  ```
 
 ### `unmanaged_files.action: deny`
 


### PR DESCRIPTION
## Documentation Updates - 2026-05-14

This PR updates the documentation based on features and fixes merged in the last 24 hours.

### Features Documented

- `required-packages-deployed` policy block after lockfile wipe (from #1313)
- `dependencies.require` / `dependencies.deny` inheritance through `extends: org` (from #1290)

### Changes Made

- Updated `docs/src/content/docs/troubleshooting/install-failures.md` to add a "Policy blocked after lockfile wipe" section describing the `required-packages-deployed` catch-22, the v0.14 self-healing behavior, and the older-version workaround
- Updated `docs/src/content/docs/troubleshooting/policy-debugging.md` to add `required-packages-deployed` as a named common block scenario with fix instructions, and to note that `dependencies.require`/`deny` now layer correctly through `extends: org`

### Merged PRs Referenced

- #1313 - fix: apm install no longer permanently blocked by policy after lockfile wipe (required-packages-deployed catch-22)
- #1290 - fix(policy): layer dependencies.require through extends: org

### Notes

- #1324 (feat: filter-driven CLI, map-based manifest, JSON output for `apm pack`) -- documentation was already included in that PR (`pack.md` and `publish-to-a-marketplace.md` fully updated)
- #1289 (fix: audit drift check skip-with-info on cache miss) -- documentation was already included in that PR (`baseline-checks.md` and `drift-detection.md` updated)
- #1320 (chore: pylint guardrail) -- internal tooling, no user-facing docs needed
- #1291 (fix(ci): audit-only pattern) -- internal CI fix, no user-facing docs needed
- #1255 (fix: warn when apm.yml missing) -- behavioral improvement; no dedicated doc section required as the warning is self-explanatory




> [!NOTE]
> <details>
> <summary>🔒 Integrity filter blocked 9 items</summary>
>
> The following items were blocked because they don't meet the GitHub integrity level.
>
> - [#1319](https://github.com/microsoft/apm/pull/1319) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1312](https://github.com/microsoft/apm/pull/1312) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1307](https://github.com/microsoft/apm/pull/1307) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1306](https://github.com/microsoft/apm/pull/1306) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1281](https://github.com/microsoft/apm/pull/1281) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1248](https://github.com/microsoft/apm/pull/1248) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1246](https://github.com/microsoft/apm/pull/1246) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1245](https://github.com/microsoft/apm/pull/1245) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1224](https://github.com/microsoft/apm/pull/1224) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/25903035908/agentic_workflow) · ● 1.7M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+%22gh-aw-workflow-id%3A+daily-doc-updater%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/blob/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-05-17T06:10:07.845Z --> on May 17, 2026, 6:10 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 25903035908, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/25903035908 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->