### PR TITLE
[docs] Update documentation for features from 2026-05-16

### DIFF
--- a/docs/src/content/docs/troubleshooting/common-errors.md
+++ b/docs/src/content/docs/troubleshooting/common-errors.md
@@ -147,11 +147,11 @@ See also: [./compile-zero-output-warning/](./compile-zero-output-warning/), [../
 [x] No harness detected
 ```
 
-Cause: the project has no harness markers (`.github/copilot/`, `.claude/`, `.cursor/`, ...) and no `targets:` block in `apm.yml`. APM no longer defaults to copilot.
+Cause: the project has no harness markers (`.github/copilot/`, `.claude/`, `.cursor/`, ...) and no `targets:` block in `apm.yml`. APM fails closed rather than defaulting to copilot. This applies to both `apm compile` and `apm install --mcp` (MCP install now uses the same fail-closed behavior as `apm install` for any other dependency type).
 
 Fix: pass `--target <harness>` on the command, or declare `targets:` in `apm.yml`. Run `apm targets` to list supported harnesses.
 
-See also: [../reference/cli/targets/](../reference/cli/targets/), [../reference/targets-matrix/](../reference/targets-matrix/)
+See also: [../reference/cli/targets/](../reference/cli/targets/), [../reference/targets-matrix/](../reference/targets-matrix/), [../../consumer/install-mcp-servers/](../../consumer/install-mcp-servers/)
 
 ### `[x] Multiple harnesses detected: <a>, <b>`
 
@@ -224,6 +224,25 @@ Fix: run `apm --help` for the current command list. Upgrade APM if the command w
 See also: [../reference/cli/](../reference/cli/), [./migration/](./migration/)
 
 ## Auth and network
+
+### `Server '<name>' not found in registry <url>`
+
+```
+[x] Server '<name>' not found in registry https://...
+    If this is a self-hosted registry, verify it implements the
+    MCP Registry v0.1 API (apm uses /v0.1/servers/...).
+```
+
+Cause: APM received a 404 from the registry when looking up the named MCP server. Two common causes: (1) the server name is wrong or not published, (2) a self-hosted registry still serves only the legacy `/v0/` paths instead of the required `/v0.1/` paths.
+
+Fix:
+
+- Confirm the name with `apm mcp search <term>`.
+- For self-hosted registries, upgrade the registry software to serve the [MCP Registry v0.1 spec](https://github.com/modelcontextprotocol/registry). The public registries (`api.mcp.github.com` and `registry.modelcontextprotocol.io`) already serve v0.1.
+- To point at a different registry for a single invocation: `apm install --mcp NAME --registry https://my-registry.example.com`.
+- To switch the default registry: `export MCP_REGISTRY_URL=https://my-registry.example.com`.
+
+See also: [../reference/cli/mcp/](../reference/cli/mcp/)
 
 ### `Authentication failed for <host>`
 


### PR DESCRIPTION
## Documentation Updates - 2026-05-16

This PR updates the documentation based on features merged in the last 24 hours.

### Features Documented

- MCP Registry v0.1 hard cut-over: `ServerNotFoundError` with v0.1 hint for self-hosted registries (from #1337)
- `apm install --mcp` now fails closed on greenfield projects, matching `apm install` behavior (from #1336)

### Changes Made

- Updated `docs/src/content/docs/troubleshooting/common-errors.md`:
  - Extended the `[x] No harness detected` entry to clarify that `apm install --mcp` now fails closed with the same `NoHarnessError` as `apm install` (PR #1336 parity fix)
  - Added a new `Server '<name>' not found in registry <url>` entry documenting the typed `ServerNotFoundError` with actionable v0.1 migration guidance for self-hosted registry operators (PR #1337)

### Merged PRs Referenced

- #1337 - fix(registry): migrate SimpleRegistryClient to MCP Registry v0.1 spec -- breaking change for self-hosted registries on legacy `/v0/` paths; new `ServerNotFoundError` carries a one-sentence v0.1 hint
- #1336 - fix: respect `targets:` whitelist for all runtimes during MCP install -- greenfield projects now fail closed with `NoHarnessError` instead of silently writing to `~/.copilot/mcp-config.json`

### Notes

PRs #1337 and #1336 already updated their primary docs (`reference/cli/mcp.md`, `consumer/install-mcp-servers.md`, `reference/targets-matrix.md`). This PR fills the remaining gap in the troubleshooting catalog so operators encountering the new error messages can find them with a quick page search.




> [!NOTE]
> <details>
> <summary>🔒 Integrity filter blocked 1 item</summary>
>
> The following item was blocked because it doesn't meet the GitHub integrity level.
>
> - [#1306](https://github.com/microsoft/apm/pull/1306) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/25954129228/agentic_workflow) · ● 1.3M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+%22gh-aw-workflow-id%3A+daily-doc-updater%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/blob/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-05-18T05:49:02.423Z --> on May 18, 2026, 5:49 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 25954129228, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/25954129228 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->