### PR TITLE
test(windows): make path assertions and chmod tests OS-aware

### DIFF
--- a/tests/unit/integration/test_hook_integrator.py
+++ b/tests/unit/integration/test_hook_integrator.py
@@ -490,9 +490,9 @@ class TestClaudeIntegration:
         sidecar = json.loads(sidecar_path.read_text())
         assert sidecar["PreToolUse"][0]["_apm_source"] == "hookify"
 
-        # Verify rewritten paths
+        # Verify rewritten paths (normalize separators for cross-platform compare)
         cmd = settings["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
-        assert ".claude/hooks/hookify/hooks/pretooluse.py" in cmd
+        assert ".claude/hooks/hookify/hooks/pretooluse.py" in cmd.replace("\\", "/")
 
     def test_integrate_learning_output_style_claude(self, temp_project):
         """Test Claude integration of learning-output-style plugin."""
@@ -844,8 +844,8 @@ class TestClaudeIntegration:
         # Verify rewritten command in settings.json
         settings = json.loads((temp_project / ".claude" / "settings.json").read_text())
         cmd = settings["hooks"]["PostToolUse"][0]["hooks"][0]["command"]
-        assert ".claude/hooks/lint-hooks/scripts/lint.sh" in cmd
-        assert "./" not in cmd
+        assert ".claude/hooks/lint-hooks/scripts/lint.sh" in cmd.replace("\\", "/")
+        assert "./" not in cmd.replace("\\", "/")
 
         # Verify script was copied to Claude target location
         copied_script = temp_project / ".claude" / "hooks" / "lint-hooks" / "scripts" / "lint.sh"
@@ -1177,9 +1177,9 @@ class TestCursorIntegration:
         # Check APM source marker for cleanup
         assert config["hooks"]["PreToolUse"][0]["_apm_source"] == "hookify"
 
-        # Verify rewritten paths point to .cursor/hooks/
+        # Verify rewritten paths point to .cursor/hooks/ (normalize separators)
         cmd = config["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
-        assert ".cursor/hooks/hookify/hooks/pretooluse.py" in cmd
+        assert ".cursor/hooks/hookify/hooks/pretooluse.py" in cmd.replace("\\", "/")
 
     def test_skips_when_no_cursor_dir(self, temp_project):
         """Test that Cursor integration is skipped when .cursor/ doesn't exist."""
@@ -3293,7 +3293,7 @@ class TestIssue1007Fixes:
         assert cmd.startswith(str(deploy_root.resolve())), (
             f"Command must be absolute path under deploy_root; got {cmd}"
         )
-        assert cmd.endswith(".claude/hooks/my-pkg/hooks/run.sh"), (
+        assert cmd.replace("\\", "/").endswith(".claude/hooks/my-pkg/hooks/run.sh"), (
             f"Command must end with .claude/hooks/my-pkg/hooks/run.sh; got {cmd}"
         )
 

--- a/tests/unit/runtime/test_runtime_utils.py
+++ b/tests/unit/runtime/test_runtime_utils.py
@@ -63,6 +63,11 @@ class TestFindRuntimeBinary:
 
         assert result is None
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Windows does not honor POSIX execute bits; os.access(X_OK) returns True "
+        "for any readable file, so the non-executable fallback path is unreachable.",
+    )
     def test_skips_non_executable_apm_binary(self, fake_home):
         """Non-executable APM binary should be skipped in favor of PATH.
 
@@ -168,6 +173,11 @@ class TestFindRuntimeBinary:
 
         assert result == str(node_binary)
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason="Windows does not honor POSIX execute bits; os.access(X_OK) returns True "
+        "for any readable file, so the non-executable fallback path is unreachable.",
+    )
     def test_apm_binary_without_execute_permission_falls_back(self, fake_home):
         """An APM binary without execute permission should trigger fallback.
 


### PR DESCRIPTION
## Problem

Windows CI on `main` is red ([run 26061585552](https://github.com/microsoft/apm/actions/runs/26061585552/job/76622845261)). Linux and macOS pass — only the Windows job fails, with six unit-test failures that all encode POSIX-only assumptions:

```
FAILED tests/unit/runtime/test_runtime_utils.py::TestFindRuntimeBinary::test_skips_non_executable_apm_binary
FAILED tests/unit/runtime/test_runtime_utils.py::TestFindRuntimeBinary::test_apm_binary_without_execute_permission_falls_back
FAILED tests/unit/integration/test_hook_integrator.py::TestClaudeIntegration::test_integrate_hookify_claude
FAILED tests/unit/integration/test_hook_integrator.py::TestClaudeIntegration::test_integrate_hooks_with_scripts_in_hooks_subdir_claude
FAILED tests/unit/integration/test_hook_integrator.py::TestCursorIntegration::test_integrate_hookify_cursor
FAILED tests/unit/integration/test_hook_integrator.py::TestIssue1007Fixes::test_rewrite_command_deploy_root_produces_absolute_path
```

Both groups are test-only defects; production code behaves correctly on Windows.

## Root cause

**Runtime tests (2)** — both call `chmod(0o644)` / `chmod(0o600)` on the APM-managed binary expecting `find_runtime_binary()` to fall back to `shutil.which()` because the file is "not executable". Windows ignores POSIX execute bits: `os.access(path, os.X_OK)` returns `True` for any readable file, so the fallback branch is unreachable and the test asserts the wrong path.

**Hook integrator tests (4)** — all assert forward-slash substrings such as `".claude/hooks/hookify/hooks/pretooluse.py" in cmd`. When `deploy_root` is set, `_rewrite_command_for_target()` emits absolute paths via `Path.resolve()`, which uses native separators (backslash on Windows). This is the correct production behaviour — Claude Code / Cursor on Windows expect Windows paths — so the fix is on the assertion side.

## Fix

- Skip the two `chmod`-based runtime tests on `win32` with a reason documenting the platform limitation. Other tests in the same class already use `@pytest.mark.skipif(sys.platform != "win32", ...)` for the inverse case, so the pattern is established.
- Normalise backslashes to forward slashes (`cmd.replace("\\", "/")`) before the substring / `endswith` check in the four hook-integrator tests. The production rewriter is untouched.

No `src/` changes — six test-only edits, 17 lines added / 7 removed.

## Validation

Locally:

```
$ uv run --extra dev pytest tests/unit/runtime/test_runtime_utils.py tests/unit/integration/test_hook_integrator.py -q
154 passed, 1 skipped in 2.17s
$ uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/
All checks passed!
786 files already formatted
```

Both CI-mirror lint commands are silent per `.apm/instructions/linting.instructions.md`. Windows CI on this branch will confirm the six previously-failing tests now pass / skip cleanly.