### PR TITLE
[docs] Update documentation for features from 2026-05-18

### DIFF
--- a/docs/src/content/docs/reference/cli/pack.md
+++ b/docs/src/content/docs/reference/cli/pack.md
@@ -37,7 +37,9 @@ Bundles are target-agnostic. The consumer's project decides where files land at 
 | `--include-prerelease` | off | Marketplace: allow pre-release tags to satisfy version ranges. |
 | `-m`, `--marketplace FORMATS` | all configured | Comma-separated list of marketplace formats to build. Sentinels: `all` (every configured format), `none` (skip marketplace entirely). |
 | `--marketplace-path FORMAT=PATH` | manifest default | Override the output path for a specific format. Repeatable. Example: `--marketplace-path codex=./dist/codex.json`. |
-| `--json` | off | Emit machine-readable JSON to stdout. All logs move to stderr. Shape: `{ok, dry_run, warnings, errors, marketplace: {outputs: [...]}}`. |
+| `--json` | off | Emit machine-readable JSON to stdout. All logs move to stderr. Shape: `{ok, dry_run, warnings, errors, marketplace: {outputs: [...]}, version_alignment, drift}`. The `version_alignment` and `drift` keys are always present; they are `null` when the corresponding gate flag was not passed. |
+| `--check-versions` | off | Validate per-package versions against the `marketplace.versioning.strategy` declared in `apm.yml` (`lockstep`, `tag_pattern`, or `per_package`). On misalignment, prints a table of per-package status and exits `3`. Skips with an info note when `apm.yml` has no `marketplace:` block. Composes with `--dry-run` and `--json`. |
+| `--check-clean` | off | Regenerate `marketplace.json` into a temp directory and diff it against the committed copy. Exits `4` when any format has drifted. Never writes to the working tree. Composes with `--dry-run` and `--json`. |
 | `--marketplace-output PATH` | _(hidden)_ | **Deprecated.** Translates to `--marketplace-path claude=PATH` with a stderr warning. Will be removed in v0.15 (see #1318). |
 | `--legacy-skill-paths` | off | Bundle skills under per-client paths (e.g. `.cursor/skills/`) instead of the converged `.agents/skills/`. Compatibility flag. |
 | `--target`, `-t VALUE` | auto-detect | **Deprecated.** Recorded as informational `pack.target` metadata only; ignored by `apm install`. Will be removed in a future release. |
@@ -92,6 +94,29 @@ apm pack --dry-run
 apm pack --archive --dry-run -v
 ```
 
+### Release gates (CI)
+
+```bash
+# Validate version alignment against declared strategy (exits 3 on mismatch):
+apm pack --check-versions --dry-run
+
+# Confirm committed marketplace.json is not stale (exits 4 on drift):
+apm pack --check-clean
+
+# Run both gates together; structured output for CI step summary:
+apm pack --check-versions --check-clean --json
+```
+
+Configure the versioning strategy in `apm.yml`:
+
+```yaml
+marketplace:
+  versioning:
+    strategy: lockstep   # all packages must share the same version
+```
+
+Strategies: `lockstep` (default) -- all package versions match the top-level `version`; `tag_pattern` -- versions are checked against the `build.tagPattern`; `per_package` -- no cross-package version constraint (gate never fails).
+
 ## Output format
 
 ### Plugin bundle (`--format plugin`, default)
@@ -145,6 +170,8 @@ Configure marketplace artifact paths in `apm.yml`: `marketplace.claude.output` c
 | `0` | Success. Requested artifacts written (or, with `--dry-run`, planned). |
 | `1` | Build or runtime error: network failure, ref not found, no tag matches a marketplace range, lockfile read error, or unhandled packer exception. |
 | `2` | `apm.yml` schema validation error. |
+| `3` | `--check-versions` gate failed: at least one package version does not satisfy the declared `marketplace.versioning.strategy`. When both `--check-versions` and `--check-clean` fail, exit `3` takes precedence over `4`. |
+| `4` | `--check-clean` gate failed: the committed `marketplace.json` differs from what `apm pack` would generate now. Re-run `apm pack` and commit the updated artifact. |
 
 ## Related
 

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -573,6 +573,7 @@ Overrides exist for the rare case where the published marketplace identity diffe
 | `output` | `string` | OPTIONAL | `.claude-plugin/marketplace.json` | Output path for the generated marketplace JSON. |
 | `metadata` | `object` | OPTIONAL | `{}` | Free-form metadata forwarded verbatim to `marketplace.json` (e.g. `homepage`, `support`). |
 | `build` | `Build` | OPTIONAL | `tagPattern: "v{version}"` | Build configuration for resolving package refs. See Section 7.4. |
+| `versioning` | `MarketplaceVersioning` | OPTIONAL | `{strategy: lockstep}` | Release-gate strategy for `apm pack --check-versions`. See Section 7.7. |
 | `packages` | `list<Package>` | OPTIONAL | `[]` | Packages exposed in the marketplace. See Section 7.5. |
 
 Unknown keys inside `marketplace:` are rejected at parse time.
@@ -657,6 +658,37 @@ marketplace:
 ```
 
 The legacy standalone `marketplace.yml` (top-level keys, no `marketplace:` wrapper) is still loadable but deprecated; new repositories SHOULD use the in-`apm.yml` form scaffolded by `apm marketplace init`.
+
+### 7.7. `marketplace.versioning`
+
+The OPTIONAL `versioning` block configures the release-gate strategy enforced by `apm pack --check-versions`. When omitted, the strategy defaults to `lockstep` when `--check-versions` is invoked.
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `strategy` | `enum` | REQUIRED | `lockstep` | One of `lockstep`, `tag_pattern`, or `per_package`. |
+
+Unknown keys are rejected at parse time.
+
+**Strategies:**
+
+| Strategy | Behaviour |
+|---|---|
+| `lockstep` | All packages listed under `marketplace.packages` MUST share the same `version` value as the top-level `version` field. The most common convention for monorepo marketplaces. |
+| `tag_pattern` | Versions are derived from the `build.tagPattern` template; cross-package version equality is not enforced. Suitable for semantic-release workflows where each package tags independently. |
+| `per_package` | No cross-package version constraint. The `--check-versions` gate always passes; the field documents intent without enforcement. |
+
+```yaml
+marketplace:
+  versioning:
+    strategy: lockstep
+  packages:
+    - name: auth
+      source: contoso/auth
+      version: "1.2.0"
+    - name: billing
+      source: contoso/billing
+      version: "1.2.0"   # must match for lockstep to pass
+```
 
 ---
 


### PR DESCRIPTION
## Documentation Updates - 2026-05-18

This PR updates the documentation based on features merged in the last 24 hours.

### Features Documented

- `apm pack --check-versions` and `--check-clean` release gates (from #1365)
- `marketplace.versioning` schema field (from #1365)

### Changes Made

- Updated `docs/src/content/docs/reference/cli/pack.md`:
  - Added `--check-versions` flag: validates per-package versions against `marketplace.versioning.strategy`
  - Added `--check-clean` flag: regenerates `marketplace.json` into a temp dir and diffs against the committed copy
  - Updated `--json` envelope description to mention new `version_alignment` and `drift` keys
  - Added exit codes `3` (version misalignment) and `4` (marketplace.json drift)
  - Added "Release gates (CI)" examples section with usage and `marketplace.versioning` config snippet

- Updated `docs/src/content/docs/reference/manifest-schema.md`:
  - Added `versioning` row to the `marketplace:` block fields table (Section 7.2)
  - Added new Section 7.7: `marketplace.versioning` -- covers `lockstep`, `tag_pattern`, and `per_package` strategies with a full YAML example

### Merged PRs Referenced

- #1365 - `feat(pack): add --check-versions and --check-clean release gates`
- #1370 - `feat(cli): introduce apm plugin init noun-verb surface` (docs shipped in the PR itself)
- #1362 - `feat(pack,doctor,init): vendor-neutral producer first-run UX` (docs shipped in the PR itself)
- #1358 - `fix: add --target flag to apm update command` (already reflected in update.md)
- #1325 - `feat: support marketplace notation in apm uninstall` (already reflected in uninstall.md)

### Notes

The following merged PRs were reviewed but required no documentation changes (either already documented by the PR author or internal/infrastructure changes):

- #1378 - Windows CI test fixes (internal test-only change)
- #1377 - Tilde in Bitbucket DC paths (internal fix, no user-facing behavior change)
- #1376 - Tiered git ref resolver (performance optimization, no new flags or behavior)
- #1373 - Shared apm.md secret-stripping fix (CI infra)
- #1372 - Cut 0.14.0 release (CHANGELOG only)
- #1360 - Eliminate duplicate code blocks (refactor)
- #1359 - Stop writing _apm_source into Claude settings.json (bug fix, no new interface)
- #1357 - Skip GitHub API validation with PROXY_REGISTRY_ONLY (internal behavior)
- #1356 - Prefer APM-managed runtimes (bug fix, behavior change documented in PR description but no separate doc page needed)
- #1355 - Fix target forwarding in CompilationConfig (internal bug fix)
- #1354 - Resolve hook paths to absolute (internal bug fix)
- #1349 - Forward target to watch-mode recompile (internal bug fix)




> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/26079462923/agentic_workflow) · ● 1.4M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+%22gh-aw-workflow-id%3A+daily-doc-updater%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/blob/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-05-21T06:13:48.972Z --> on May 21, 2026, 6:13 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 26079462923, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/26079462923 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->