### PR TITLE
docs(producer): add zava-agent-config as live golden-path reference

### DIFF
--- a/docs/src/content/docs/producer/releasing-from-any-ci.md
+++ b/docs/src/content/docs/producer/releasing-from-any-ci.md
@@ -66,7 +66,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: microsoft/apm-action@v1
         with:
           mode: release
@@ -81,6 +81,14 @@ sequence above. It installs the CLI, runs `apm pack
 calls `gh release create` against the pushed tag. Use it when you
 want one less script to maintain; use the raw `run:` form below when
 you need to customise any step.
+
+> **Reference deployment.** [`DevExpGbb/zava-agent-config`](https://github.com/DevExpGbb/zava-agent-config)
+> runs this exact pipeline. The
+> [v6.1.2 release](https://github.com/DevExpGbb/zava-agent-config/releases/tag/v6.1.2)
+> attaches 7 per-plugin tarballs + their `.sha256` companions +
+> `marketplace-6.1.2.json` (15 assets total) via the workflow in
+> [`.github/workflows/release.yml`](https://github.com/DevExpGbb/zava-agent-config/blob/main/.github/workflows/release.yml).
+> Apm `0.14.0` and apm-action `v1.9.1` or newer required.
 
 ```yaml
       - uses: actions/setup-python@v5

--- a/docs/src/content/docs/producer/repo-shapes.md
+++ b/docs/src/content/docs/producer/repo-shapes.md
@@ -102,7 +102,7 @@ is no `dependencies:` block.
 
 ## Monorepo-hybrid
 
-> **Advanced.** Most first-time authors should start with single-plugin or aggregator. Reach for hybrid when you're shipping your own plugin *and* curating others (e.g., `zava-agent-configs`).
+> **Advanced.** Most first-time authors should start with single-plugin or aggregator. Reach for hybrid when you're shipping your own plugin *and* curating others. [`DevExpGbb/zava-agent-config`](https://github.com/DevExpGbb/zava-agent-config) is the live reference: 7 plugins under `plugins/`, one root `apm.yml`, releases via [microsoft/apm-action@v1](https://github.com/microsoft/apm-action) `mode: release`.
 
 One repo, many plugins under `packages/`, one marketplace at the root
 that lists them as local-path entries. Each plugin gets its own

--- a/docs/src/content/docs/producer/versioning-strategies.md
+++ b/docs/src/content/docs/producer/versioning-strategies.md
@@ -47,6 +47,12 @@ Use lockstep when:
 - Consumers expect a single coherent version across the bundle.
 - You run a small monorepo where independent versions add no value.
 
+Worked example: [`DevExpGbb/zava-agent-config`](https://github.com/DevExpGbb/zava-agent-config)
+ships 7 plugins on lockstep. Its [`apm.yml`](https://github.com/DevExpGbb/zava-agent-config/blob/main/apm.yml)
+omits `versioning.strategy:` (lockstep is the default), declares one
+top-level `version:`, and uses `build.tagPattern: "v{version}"` so a
+single repo-wide tag (`v6.1.2`) cuts all 7 tarballs together.
+
 ## tag_pattern
 
 Each rendered tag must be unique across local packages, and every


### PR DESCRIPTION
## TL;DR

Polish pass on the producer docs corpus to point cold readers at the live attested deployment ([DevExpGbb/zava-agent-config](https://github.com/DevExpGbb/zava-agent-config) @ v6.1.2) that exercises the canonical `apm pack` + `apm-action mode: release` pipeline end-to-end. Three in-place edits, no TOC or schema changes.

## Why

Two open discussions (#1322 monorepo layout, #1332 versioning strategies) asked for guidance that we have already shipped and attested, but the docs corpus did not direct readers to the live example:

- `releasing-from-any-ci.md` (strongest producer page) had no reference deployment link.
- `repo-shapes.md` Monorepo-hybrid callout had a typo (`zava-agent-configs` plural) and no link.
- `versioning-strategies.md` lockstep section had no worked example.

Result: producers reading the docs cold could not trace from concept ('hybrid monorepo with lockstep') to evidence ('here are 7 plugins shipping today on a single `v6.1.2` tag with 15 release assets').

## What

| File | Edit |
|---|---|
| `docs/src/content/docs/producer/releasing-from-any-ci.md` | Add 'Reference deployment' callout after the apm-action wrapper paragraph naming zava and linking the [v6.1.2 release](https://github.com/DevExpGbb/zava-agent-config/releases/tag/v6.1.2) (15 assets) + its [`release.yml`](https://github.com/DevExpGbb/zava-agent-config/blob/main/.github/workflows/release.yml). Note version floor (apm 0.14.0 + apm-action v1.9.1). Bump `checkout@v4 -> v5` in the snippet for Node 20 deprecation alignment. |
| `docs/src/content/docs/producer/repo-shapes.md` | Fix `zava-agent-configs` -> `zava-agent-config` typo + replace parenthetical with live link, noting 7 plugins under `plugins/` and apm-action `mode: release`. |
| `docs/src/content/docs/producer/versioning-strategies.md` | Append worked-example pointer to lockstep section: zava omits `versioning.strategy:` (default), declares one top-level `version:`, uses `build.tagPattern: "v{version}"` for a single repo-wide tag. |

## How (verification)

Every code-truth claim verified with real commands before drafting (S7 deterministic tool bridge per the [docs-sync skill](.apm/skills/docs-sync/SKILL.md)):

| Claim | Evidence |
|---|---|
| apm-action v1.9.1 published with per-package tarball isolation | `gh release view v1.9.1 --repo microsoft/apm-action` -> body: 'fix(release): isolate per-package tarball in shared distDir (v1.9.1)' |
| zava release run green on v6.1.2 | `gh run list --repo DevExpGbb/zava-agent-config` run 26081432583 -> `success` |
| zava strategy = lockstep | `gh api repos/DevExpGbb/zava-agent-config/contents/apm.yml?ref=v6.1.2` -> no `versioning:` key, single `version: 6.1.2`, `build.tagPattern: "v{version}"` (lockstep default) |
| zava plugin count = 7 | `gh api contents/plugins?ref=v6.1.2 --jq '. \| length'` -> 7 |
| zava release asset count = 15 | `gh release view v6.1.2 --json assets` -> 7 tarballs + 7 sha256 + marketplace-6.1.2.json |

## Trade-offs

- **In-place edits only.** No new pages, no TOC change. Keeps the polish pass scoped and reversible.
- **Single reference example.** Zava is the only deployment we've end-to-end attested on apm 0.14.0 + apm-action v1.9.1. When a second producer ships at this version floor, we can fan out.
- **Lockstep section gets the worked example, not tag_pattern.** Verified zava actually uses lockstep (S7 catch -- a prior draft assumed tag_pattern). The tag_pattern and per_package sections remain example-less until a real producer ships on those strategies.

## How to test

1. `cd docs && npm install && npm run dev` -> visit `/producer/releasing-from-any-ci/`, `/producer/repo-shapes/`, `/producer/versioning-strategies/`.
2. Click every new outbound link -> confirm all resolve to live GitHub URLs (release tag, release.yml, apm.yml, plugins directory).
3. `npm run build` -> Starlight build succeeds (no broken internal links).

## Follow-ups (post-merge)

- Post a follow-up comment on [#1322](https://github.com/microsoft/apm/discussions/1322) and [#1332](https://github.com/microsoft/apm/discussions/1332) linking these refreshed pages.
- File any new producer-feedback drift here.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>