### PR TITLE
fix(deps): honor SSH user from dependency URL (closes #1383)

### DIFF
--- a/src/apm_cli/deps/host_backends.py
+++ b/src/apm_cli/deps/host_backends.py
@@ -192,6 +192,7 @@ class _GitHubFamilyBase:
             self._url_host(dep_ref),
             dep_ref.repo_url,
             port=getattr(dep_ref, "port", None),
+            user=getattr(dep_ref, "ssh_user", None) or "git",
         )
 
     def build_clone_http_url(self, dep_ref: DependencyReference) -> str:
@@ -391,7 +392,12 @@ class GitLabBackend:
 
     def build_clone_ssh_url(self, dep_ref: DependencyReference) -> str:
         host = getattr(dep_ref, "host", None) or self.host_info.host
-        return build_ssh_url(host, dep_ref.repo_url, port=getattr(dep_ref, "port", None))
+        return build_ssh_url(
+            host,
+            dep_ref.repo_url,
+            port=getattr(dep_ref, "port", None),
+            user=getattr(dep_ref, "ssh_user", None) or "git",
+        )
 
     def build_clone_http_url(self, dep_ref: DependencyReference) -> str:
         port = getattr(dep_ref, "port", None)
@@ -469,7 +475,12 @@ class GenericGitBackend:
 
     def build_clone_ssh_url(self, dep_ref: DependencyReference) -> str:
         host = getattr(dep_ref, "host", None) or self.host_info.host
-        return build_ssh_url(host, dep_ref.repo_url, port=getattr(dep_ref, "port", None))
+        return build_ssh_url(
+            host,
+            dep_ref.repo_url,
+            port=getattr(dep_ref, "port", None),
+            user=getattr(dep_ref, "ssh_user", None) or "git",
+        )
 
     def build_clone_http_url(self, dep_ref: DependencyReference) -> str:
         port = getattr(dep_ref, "port", None)

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -17,6 +17,7 @@ from ...utils.github_host import (
     maybe_raise_bare_fqdn_github_gitlab_conflict,
     parse_artifactory_path,
     unsupported_host_error,
+    validate_ssh_user,
 )
 from ...utils.path_security import (
     PathTraversalError,
@@ -87,6 +88,14 @@ class DependencyReference:
 
     # SKILL_BUNDLE subset selection (persisted in apm.yml `skills:` field)
     skill_subset: list[str] | None = None  # Sorted skill names, or None = all
+
+    # SSH username for SCP-shorthand or ``ssh://`` dependencies. ``None`` for
+    # non-SSH inputs. Defaults to ``"git"`` whenever an SSH form was parsed
+    # without an explicit user. Carried as auth/transport context, NOT
+    # baked into ``to_canonical()`` / ``get_identity()`` so dependency
+    # identity stays user-agnostic (lockfile pinning + dedup work the same
+    # whether a project uses ``git@`` or an EMU/custom SSH account).
+    ssh_user: str | None = None
 
     # Supported file extensions for virtual packages
     VIRTUAL_FILE_EXTENSIONS = (
@@ -424,11 +433,26 @@ class DependencyReference:
             ssh://git@host/owner/repo.git@alias
 
         Returns:
-            ``(host, port, repo_url, reference, alias)`` or ``None`` if the
-            input is not an ``ssh://`` URL.
+            ``(host, port, repo_url, reference, alias, user)`` or ``None`` if
+            the input is not an ``ssh://`` URL. ``user`` defaults to ``"git"``
+            when no userinfo is present.
         """
         if not url.startswith("ssh://"):
             return None
+
+        # SECURITY: reject percent-encoded userinfo BEFORE urlparse decodes it.
+        # ``urlparse('ssh://%2DoProxyCommand=evil@host/repo').username`` returns
+        # ``-oProxyCommand=evil`` which would smuggle SSH options past the
+        # allowlist in validate_ssh_user. We inspect the raw substring between
+        # ``ssh://`` and the first ``@`` (which terminates the userinfo per
+        # RFC 3986) and reject any ``%`` there. There is no legitimate need for
+        # percent-encoding in a real SSH username.
+        userinfo_match = re.match(r"^ssh://([^@/?#]+)@", url)
+        if userinfo_match and "%" in userinfo_match.group(1):
+            raise ValueError(
+                "Percent-encoded characters are not allowed in SSH userinfo. "
+                "Use the literal username (e.g. 'ssh://myuser@host/...')."
+            )
 
         parsed = urllib.parse.urlparse(url)
         host = parsed.hostname or ""
@@ -438,6 +462,12 @@ class DependencyReference:
             port = None
         path = parsed.path.lstrip("/")
         fragment = parsed.fragment
+
+        # Userinfo: validate or default to "git". urlparse exposes ``username``
+        # already percent-decoded; the pre-check above guarantees no decoding
+        # actually happened, so what we see equals what was on the wire.
+        raw_user = parsed.username
+        ssh_user = validate_ssh_user(raw_user) if raw_user else "git"
 
         reference: str | None = None
         alias: str | None = None
@@ -464,7 +494,7 @@ class DependencyReference:
         # Security: reject traversal sequences in SSH repo paths
         validate_path_segments(repo_url, context="SSH repository path", reject_empty=True)
 
-        return host, port, repo_url, reference, alias
+        return host, port, repo_url, reference, alias, ssh_user
 
     @staticmethod
     def _normalize_parent_repo_decl_path(raw: str) -> str:
@@ -972,7 +1002,8 @@ class DependencyReference:
         # Security: reject traversal sequences in SSH repo paths
         validate_path_segments(repo_url, context="SSH repository path", reject_empty=True)
 
-        return host, None, repo_url, reference, alias
+        ssh_user = validate_ssh_user(user)
+        return host, None, repo_url, reference, alias, ssh_user
 
     @classmethod
     def _resolve_virtual_shorthand_repo(cls, repo_url, validated_host, virtual_path=None):
@@ -1435,14 +1466,15 @@ class DependencyReference:
         # Phase 2: parse SSH (ssh:// URL first -- it preserves port; then SCP
         # shorthand), otherwise fall back to HTTPS/shorthand parsing.
         explicit_scheme: str | None = None
+        ssh_user: str | None = None
         ssh_proto_result = cls._parse_ssh_protocol_url(dependency_str)
         if ssh_proto_result:
-            host, port, repo_url, reference, alias = ssh_proto_result
+            host, port, repo_url, reference, alias, ssh_user = ssh_proto_result
             explicit_scheme = "ssh"
         else:
             scp_result = cls._parse_ssh_url(dependency_str)
             if scp_result:
-                host, port, repo_url, reference, alias = scp_result
+                host, port, repo_url, reference, alias, ssh_user = scp_result
                 explicit_scheme = "ssh"
             else:
                 host, port, repo_url, reference, alias, is_virtual_package, virtual_path = (
@@ -1484,6 +1516,7 @@ class DependencyReference:
             ado_repo=ado_repo,
             artifactory_prefix=artifactory_prefix,
             is_insecure=urllib.parse.urlparse(dependency_str).scheme.lower() == "http",
+            ssh_user=ssh_user,
         )
 
     def to_apm_yml_entry(self):

--- a/src/apm_cli/utils/github_host.py
+++ b/src/apm_cli/utils/github_host.py
@@ -278,17 +278,67 @@ def build_raw_content_url(owner: str, repo: str, ref: str, file_path: str) -> st
     return f"https://raw.githubusercontent.com/{owner}/{repo}/{encoded_ref}/{file_path}"
 
 
-def build_ssh_url(host: str, repo_ref: str, port: int | None = None) -> str:
+_SSH_USER_RE = re.compile(r"^[a-zA-Z0-9_][a-zA-Z0-9_.+-]*$")
+_SSH_USER_MAX_LEN = 64
+
+
+def validate_ssh_user(user: str) -> str:
+    """Validate an SSH username; return it unchanged or raise ``ValueError``.
+
+    Allowlist policy (deliberately strict):
+
+    - First character must be alphanumeric or underscore. This blocks
+      SSH option injection vectors like ``-oProxyCommand=...`` from ever
+      reaching ``git clone`` argv as a userinfo segment.
+    - Remaining characters are letters, digits, ``.``, ``+``, ``-``, ``_``.
+      This forbids ``/`` (path escape), ``@`` (double-userinfo confusion
+      in ``ssh://user@host``), ``:`` (port confusion), and any whitespace
+      or control character (log/ANSI injection).
+    - Maximum length 64 bytes: long enough for any legitimate username
+      and short enough to bound log size and reject buffer-abuse payloads.
+
+    The shape matches the ``user`` group in ``SCP_LIKE_RE``
+    (``cache/url_normalize.py``) so SCP-shorthand inputs that parsed
+    successfully never fail this validation, while ``ssh://`` URLs (whose
+    userinfo is percent-decoded by ``urllib.parse``) are still gated.
+    """
+    if not user:
+        raise ValueError("SSH user must be a non-empty string")
+    if len(user) > _SSH_USER_MAX_LEN:
+        raise ValueError(f"SSH user is too long ({len(user)} > {_SSH_USER_MAX_LEN} chars)")
+    if not _SSH_USER_RE.match(user):
+        # Do NOT echo the raw user value -- a hostile apm.yml could embed
+        # control characters that survive log emission. Show only the length.
+        raise ValueError(
+            f"Invalid SSH user (length {len(user)}). "
+            "Allowed: alphanumerics, '.', '+', '-', '_'; "
+            "must not start with '-'."
+        )
+    return user
+
+
+def build_ssh_url(
+    host: str,
+    repo_ref: str,
+    port: int | None = None,
+    user: str = "git",
+) -> str:
     """Build an SSH clone URL for the given host and repo_ref (owner/repo).
 
     When ``port`` is set, emit the explicit ``ssh://`` form because SCP
     shorthand (``git@host:path``) cannot carry a port — the ``:`` is the path
     separator. Without a port, keep the compact SCP shorthand (no behavioural
     change for the common case).
+
+    ``user`` defaults to ``"git"`` for backward compatibility with public
+    GitHub / GitLab / Bitbucket which all expect that fixed account name.
+    Non-default usernames (EMU SSH accounts, self-hosted servers with a
+    different bot user) are passed through after ``validate_ssh_user``.
     """
+    safe_user = validate_ssh_user(user)
     if port:
-        return f"ssh://git@{host}:{port}/{repo_ref}.git"
-    return f"git@{host}:{repo_ref}.git"
+        return f"ssh://{safe_user}@{host}:{port}/{repo_ref}.git"
+    return f"{safe_user}@{host}:{repo_ref}.git"
 
 
 def build_https_clone_url(

--- a/tests/acceptance/test_logging_acceptance.py
+++ b/tests/acceptance/test_logging_acceptance.py
@@ -454,7 +454,7 @@ class TestLoggingRules(_InstallAcceptanceBase):
 
     def test_status_symbols_are_ascii_brackets(self):
         """All STATUS_SYMBOLS must be ASCII bracket format [x]."""
-        bracket_pattern = {"[*]", "[>]", "[i]", "[!]", "[x]", "[+]", "[#]"}
+        bracket_pattern = {"[*]", "[>]", "[i]", "[!]", "[x]", "[+]", "[#]", "[~]", "[-]", "[=]"}
         for key, sym in STATUS_SYMBOLS.items():
             assert sym in bracket_pattern, (
                 f"STATUS_SYMBOLS['{key}'] = '{sym}' is not a valid bracket symbol"

--- a/tests/integration/test_dep_url_parsing_e2e.py
+++ b/tests/integration/test_dep_url_parsing_e2e.py
@@ -226,3 +226,105 @@ class TestDependencyReferenceParsesEMUAndAdoSsh:
         dep = deps[0]
         assert dep.host == "github.com"
         assert dep.repo_url == "contoso/my-pkg"
+
+
+class TestSshUserThreadedThroughCloneUrl:
+    """Defends issue #1383 end-to-end.
+
+    Pre-fix: writing ``myuser@github.com:org/repo`` in apm.yml resulted in
+    ``apm install`` cloning ``git@github.com:org/repo.git`` (wrong user). The
+    custom user was parsed by regex but discarded; the host backend always
+    asked ``build_ssh_url`` for the hardcoded ``git`` user.
+
+    Post-fix: the SSH user is captured at parse time, validated against the
+    supply-chain allowlist, and threaded through to the clone URL.
+
+    These tests parse through the real ``APMPackage.from_apm_yml`` entry
+    point AND then invoke the real ``GitHubBackend.build_clone_ssh_url`` so
+    a regression in either layer surfaces here.
+    """
+
+    def test_custom_scp_user_survives_through_clone_url(self, tmp_path):
+        from apm_cli.core.auth import HostInfo
+        from apm_cli.deps.host_backends import GitHubBackend
+
+        apm_yml = _write_minimal_apm_yml(tmp_path, deps=["myuser@github.com:contoso/my-pkg"])
+        pkg = APMPackage.from_apm_yml(apm_yml)
+        deps = pkg.get_apm_dependencies()
+        assert len(deps) == 1
+        dep = deps[0]
+        assert dep.ssh_user == "myuser"
+
+        host_info = HostInfo(
+            host="github.com",
+            kind="github",
+            has_public_repos=True,
+            api_base="https://api.github.com",
+        )
+        backend = GitHubBackend(host_info)
+        clone_url = backend.build_clone_ssh_url(dep)
+        assert clone_url == "myuser@github.com:contoso/my-pkg.git"
+
+    def test_custom_ssh_protocol_user_with_port_survives_through_clone_url(self, tmp_path):
+        from apm_cli.core.auth import HostInfo
+        from apm_cli.deps.host_backends import GenericGitBackend
+
+        apm_yml = _write_minimal_apm_yml(
+            tmp_path, deps=["ssh://buildbot@git.corp.com:7999/team/my-pkg.git"]
+        )
+        pkg = APMPackage.from_apm_yml(apm_yml)
+        deps = pkg.get_apm_dependencies()
+        assert len(deps) == 1
+        dep = deps[0]
+        assert dep.ssh_user == "buildbot"
+        assert dep.port == 7999
+
+        host_info = HostInfo(
+            host="git.corp.com",
+            kind="generic",
+            has_public_repos=False,
+            api_base="https://git.corp.com",
+        )
+        backend = GenericGitBackend(host_info)
+        clone_url = backend.build_clone_ssh_url(dep)
+        assert clone_url == "ssh://buildbot@git.corp.com:7999/team/my-pkg.git"
+
+    def test_legacy_git_user_clone_url_unchanged_for_backward_compat(self, tmp_path):
+        """Regression guard: the default ``git@`` SSH user MUST stay the
+        default for any dep written without an explicit user. This is what
+        every existing apm.yml in the wild relies on."""
+        from apm_cli.core.auth import HostInfo
+        from apm_cli.deps.host_backends import GitHubBackend
+
+        apm_yml = _write_minimal_apm_yml(tmp_path, deps=["git@github.com:contoso/my-pkg"])
+        pkg = APMPackage.from_apm_yml(apm_yml)
+        deps = pkg.get_apm_dependencies()
+        host_info = HostInfo(
+            host="github.com",
+            kind="github",
+            has_public_repos=True,
+            api_base="https://api.github.com",
+        )
+        backend = GitHubBackend(host_info)
+        clone_url = backend.build_clone_ssh_url(deps[0])
+        assert clone_url == "git@github.com:contoso/my-pkg.git"
+
+    def test_option_injection_user_in_apm_yml_is_rejected(self, tmp_path):
+        """A malicious or typo'd apm.yml that starts the SSH user with ``-``
+        (which OpenSSH would interpret as an option flag like
+        ``-oProxyCommand=...``) MUST fail at parse time, not silently flow
+        into ``git clone`` argv."""
+        apm_yml = _write_minimal_apm_yml(tmp_path, deps=["-oProxy@github.com:contoso/my-pkg"])
+        with pytest.raises(ValueError):
+            APMPackage.from_apm_yml(apm_yml).get_apm_dependencies()
+
+    def test_percent_encoded_ssh_user_is_rejected(self, tmp_path):
+        """``urlparse('ssh://%2DoProxyCommand@host/repo').username`` returns
+        ``-oProxyCommand`` — the percent-decode would smuggle option injection
+        past the allowlist. The parser must reject percent-encoded userinfo
+        BEFORE urlparse decodes it."""
+        apm_yml = _write_minimal_apm_yml(
+            tmp_path, deps=["ssh://%2DoProxyCommand@github.com/contoso/my-pkg.git"]
+        )
+        with pytest.raises(ValueError):
+            APMPackage.from_apm_yml(apm_yml).get_apm_dependencies()

--- a/tests/unit/test_generic_git_urls.py
+++ b/tests/unit/test_generic_git_urls.py
@@ -393,6 +393,41 @@ class TestCloneURLBuilding:
         url = build_https_clone_url("bitbucket.domain.ext", "team/repo", port=8443)
         assert url == "https://bitbucket.domain.ext:8443/team/repo"
 
+    def test_ssh_clone_url_with_custom_user(self):
+        """Custom SSH usernames (e.g. EMU accounts) are preserved in the SCP shorthand."""
+        url = build_ssh_url("github.com", "acme/repo", user="myuser")
+        assert url == "myuser@github.com:acme/repo.git"
+
+    def test_ssh_clone_url_with_custom_user_and_port(self):
+        """Custom SSH user + port emits the explicit ssh:// form."""
+        url = build_ssh_url("bitbucket.domain.ext", "team/repo", port=7999, user="myuser")
+        assert url == "ssh://myuser@bitbucket.domain.ext:7999/team/repo.git"
+
+    def test_ssh_clone_url_default_user_unchanged(self):
+        """Omitting the user keeps the historical ``git@`` default."""
+        url = build_ssh_url("github.com", "acme/repo")
+        assert url == "git@github.com:acme/repo.git"
+
+    def test_ssh_clone_url_rejects_option_injection_user(self):
+        """A leading ``-`` would be interpreted as an SSH option flag by OpenSSH; reject it."""
+        import pytest
+
+        with pytest.raises(ValueError, match="Invalid SSH user"):
+            build_ssh_url("github.com", "acme/repo", user="-oProxyCommand=evil")
+
+    def test_ssh_clone_url_rejects_user_with_at_sign(self):
+        """A ``@`` in the user would split the userinfo and shift the host."""
+        import pytest
+
+        with pytest.raises(ValueError, match="Invalid SSH user"):
+            build_ssh_url("github.com", "acme/repo", user="user@other-host")
+
+    def test_ssh_clone_url_rejects_empty_user(self):
+        import pytest
+
+        with pytest.raises(ValueError, match="non-empty"):
+            build_ssh_url("github.com", "acme/repo", user="")
+
     def test_https_clone_url_with_token_and_port(self):
         url = build_https_clone_url("bitbucket.domain.ext", "team/repo", token="pat-xxx", port=8443)
         assert url == "https://x-access-token:pat-xxx@bitbucket.domain.ext:8443/team/repo.git"

--- a/tests/unit/test_ssh_user_threading.py
+++ b/tests/unit/test_ssh_user_threading.py
@@ -1,0 +1,212 @@
+"""Regression tests for issue #1383 — hardcoded ``git@`` SSH username.
+
+Bug: ``apm install`` always cloned dependencies as ``git@host:...`` even when
+the user wrote ``myuser@host:org/repo`` in apm.yml. ``_parse_ssh_url`` captured
+the user via regex but discarded it; ``_parse_ssh_protocol_url`` never read
+``urlparse().username``; ``build_ssh_url`` hardcoded ``git``.
+
+Fix: thread a validated ``ssh_user`` field from both SSH parsers through
+``parse_dependency`` to ``build_ssh_url``. These tests pin:
+
+1. End-to-end parse correctly populates ``ssh_user`` for SCP and ssh:// forms.
+2. The supply-chain ``validate_ssh_user`` allowlist rejects option-injection
+   payloads (leading ``-``, ``@``, ``/``, ``:``, whitespace, length > 64).
+3. Percent-encoded userinfo in ``ssh://`` form is rejected BEFORE urlparse
+   decodes it — otherwise ``ssh://%2DoProxyCommand@host/repo`` would smuggle
+   ``-oProxyCommand`` past the allowlist.
+4. Dependency identity (canonical form, dedup key) stays user-agnostic so a
+   project that switches from ``git@`` to a custom user does NOT invalidate
+   the lockfile or duplicate cached clones by identity.
+5. URL-cache shard key DIFFERS across users so two checkouts with different
+   auth contexts never collide on disk.
+"""
+
+import pytest
+
+from apm_cli.cache.url_normalize import cache_shard_key
+from apm_cli.models.dependency.reference import DependencyReference
+from apm_cli.utils.github_host import build_ssh_url, validate_ssh_user
+
+
+class TestValidateSshUser:
+    @pytest.mark.parametrize(
+        "user",
+        [
+            "git",
+            "myuser",
+            "enterprise-user",
+            "user_name",
+            "u",
+            "abc.def",
+            "abc+def",
+            "user-123",
+            "a" * 64,
+        ],
+    )
+    def test_allows_legitimate_users(self, user: str):
+        assert validate_ssh_user(user) == user
+
+    @pytest.mark.parametrize(
+        "user",
+        [
+            "-oProxyCommand=evil",  # leading dash = SSH option flag
+            "-l",
+            ".hidden",  # leading dot is unusual; only alnum/_ allowed at start
+            "user@other",  # @ would shift host parsing
+            "user/path",  # path traversal-ish
+            "user:passwd",  # colon would be parsed as port
+            "user name",  # whitespace
+            "user\nname",  # CR/LF log/ANSI injection
+            "user;rm -rf /",
+            "",  # empty
+            "a" * 65,  # over length cap
+        ],
+    )
+    def test_rejects_dangerous_users(self, user: str):
+        with pytest.raises(ValueError):
+            validate_ssh_user(user)
+
+    def test_error_does_not_leak_user_value(self):
+        """The error message must not echo the (potentially hostile) user string."""
+        with pytest.raises(ValueError) as exc:
+            validate_ssh_user("-oProxyCommand=evil")
+        # The dangerous string itself must not appear in the message
+        # (length disclosure is fine).
+        assert "ProxyCommand" not in str(exc.value)
+        assert "evil" not in str(exc.value)
+
+
+class TestParseDependencyPopulatesSshUser:
+    def test_scp_shorthand_with_default_git_user(self):
+        dep = DependencyReference.parse("git@github.com:acme/repo")
+        assert dep.ssh_user == "git"
+
+    def test_scp_shorthand_with_custom_user(self):
+        """The reported bug from issue #1383 — myuser must be preserved."""
+        dep = DependencyReference.parse("myuser@github.com:acme/repo")
+        assert dep.ssh_user == "myuser"
+
+    def test_scp_shorthand_with_emu_user(self):
+        dep = DependencyReference.parse("enterprise-user@ghe.corp.com:org/repo")
+        assert dep.ssh_user == "enterprise-user"
+
+    def test_ssh_protocol_url_with_default_git_user(self):
+        dep = DependencyReference.parse("ssh://git@github.com/acme/repo.git")
+        assert dep.ssh_user == "git"
+
+    def test_ssh_protocol_url_with_custom_user(self):
+        dep = DependencyReference.parse("ssh://otheruser@github.com/acme/repo.git")
+        assert dep.ssh_user == "otheruser"
+
+    def test_ssh_protocol_url_with_user_and_port(self):
+        dep = DependencyReference.parse("ssh://buildbot@git.corp.com:7999/team/repo.git")
+        assert dep.ssh_user == "buildbot"
+        assert dep.port == 7999
+
+    def test_ssh_protocol_url_without_userinfo_defaults_to_git(self):
+        dep = DependencyReference.parse("ssh://github.com/acme/repo.git")
+        assert dep.ssh_user == "git"
+
+    def test_https_dependency_has_no_ssh_user(self):
+        dep = DependencyReference.parse("https://github.com/acme/repo")
+        assert dep.ssh_user is None
+
+    def test_shorthand_dependency_has_no_ssh_user(self):
+        dep = DependencyReference.parse("acme/repo")
+        assert dep.ssh_user is None
+
+
+class TestSshUserRejectsInjection:
+    def test_scp_rejects_leading_dash_user(self):
+        """SCP-shorthand: SCP_LIKE_RE already requires alnum/_ at start, but
+        validate_ssh_user is the canonical gate; assert end-to-end rejection."""
+        with pytest.raises(ValueError):
+            DependencyReference.parse("-oProxy@github.com:acme/repo")
+
+    def test_ssh_protocol_rejects_percent_encoded_userinfo(self):
+        """CRITICAL: percent-encoded userinfo must NOT smuggle SSH options past
+        the allowlist. Two layers of defence:
+
+        1. ``parse()`` calls ``urllib.parse.unquote`` early, so ``%2D`` becomes
+           literal ``-`` and then ``validate_ssh_user`` rejects the leading
+           dash. End-to-end: any ``ValueError`` is fine.
+        2. ``_parse_ssh_protocol_url`` (called directly, bypassing parse()'s
+           unquote) ALSO rejects ``%`` in raw userinfo as defence-in-depth --
+           see the dedicated direct-call test below.
+        """
+        with pytest.raises(ValueError):
+            DependencyReference.parse("ssh://%2DoProxyCommand@github.com/acme/repo.git")
+
+    def test_ssh_protocol_rejects_percent_encoded_userinfo_lowercase(self):
+        with pytest.raises(ValueError):
+            DependencyReference.parse("ssh://%2doProxyCommand@github.com/acme/repo.git")
+
+    def test_parse_ssh_protocol_url_direct_rejects_percent_encoding(self):
+        """Defence-in-depth: even if ``parse()``'s early unquote were removed
+        or bypassed, ``_parse_ssh_protocol_url`` itself rejects percent-encoded
+        userinfo before urlparse can decode it."""
+        with pytest.raises(ValueError, match="Percent-encoded"):
+            DependencyReference._parse_ssh_protocol_url(
+                "ssh://%2DoProxyCommand@github.com/acme/repo.git"
+            )
+
+    def test_ssh_protocol_rejects_overlong_user(self):
+        long_user = "a" * 65
+        with pytest.raises(ValueError):
+            DependencyReference.parse(f"ssh://{long_user}@github.com/acme/repo.git")
+
+
+class TestSshUserDoesNotAffectIdentity:
+    """Dependency identity must stay user-agnostic. The user is auth context,
+    not part of what package is being installed. Otherwise:
+
+    - Switching from ``git@`` to ``myuser@`` would silently dedupe to a new
+      lockfile entry (looks like a different package).
+    - Two devs on the same project with different SSH usernames would write
+      conflicting lockfiles.
+    """
+
+    def test_to_canonical_identical_across_users(self):
+        a = DependencyReference.parse("git@github.com:acme/repo")
+        b = DependencyReference.parse("myuser@github.com:acme/repo")
+        assert a.to_canonical() == b.to_canonical()
+
+    def test_get_identity_identical_across_users(self):
+        a = DependencyReference.parse("git@github.com:acme/repo")
+        b = DependencyReference.parse("myuser@github.com:acme/repo")
+        assert a.get_identity() == b.get_identity()
+
+    def test_to_canonical_identical_for_ssh_protocol_users(self):
+        a = DependencyReference.parse("ssh://git@github.com/acme/repo.git")
+        b = DependencyReference.parse("ssh://other@github.com/acme/repo.git")
+        assert a.to_canonical() == b.to_canonical()
+
+
+class TestSshUserDifferentiatesCacheShard:
+    """Cache shard key MUST differ across users -- different auth context can
+    resolve to different refs (e.g. private fork accessible only to one user)
+    so checkouts must not share an on-disk directory."""
+
+    def test_cache_shard_key_differs_across_users(self):
+        key_git = cache_shard_key("git@github.com:acme/repo")
+        key_user = cache_shard_key("myuser@github.com:acme/repo")
+        assert key_git != key_user
+
+    def test_cache_shard_key_stable_for_same_user(self):
+        key1 = cache_shard_key("myuser@github.com:acme/repo")
+        key2 = cache_shard_key("myuser@github.com:acme/repo")
+        assert key1 == key2
+
+
+class TestBuildSshUrlDispatchesUser:
+    """Round-trip: parsed dep -> backend -> SSH URL with the right user."""
+
+    def test_round_trip_custom_user_scp(self):
+        dep = DependencyReference.parse("myuser@github.com:acme/repo")
+        url = build_ssh_url(dep.host, dep.repo_url, port=dep.port, user=dep.ssh_user or "git")
+        assert url == "myuser@github.com:acme/repo.git"
+
+    def test_round_trip_custom_user_with_port(self):
+        dep = DependencyReference.parse("ssh://buildbot@git.corp.com:7999/team/repo.git")
+        url = build_ssh_url(dep.host, dep.repo_url, port=dep.port, user=dep.ssh_user or "git")
+        assert url == "ssh://buildbot@git.corp.com:7999/team/repo.git"


### PR DESCRIPTION
Closes #1383

## Problem

`build_ssh_url()` unconditionally prepended `git@` even when the user explicitly specified a non-`git` SSH user in the dependency URL (e.g. EMU accounts like `meppiel-microsoft` or `ado-username@org`). The user portion of `ssh://`, scp-shorthand, and parsed dependency URLs was silently dropped, leaving clone attempts authenticated as the wrong identity.

## Fix

Thread `ssh_user` from the parsed `DependencyReference` through to per-host backend `build_clone_ssh_url` callers, validated against a strict allowlist before composing the URL.

### Source changes

- **`utils/github_host.py`** — `validate_ssh_user()` with `^[a-zA-Z0-9_][a-zA-Z0-9_.+-]*$` regex, 64-char cap, error messages that hide the user value (only the length is leaked). `build_ssh_url(user="git")` validates before composing.
- **`models/dependency/reference.py`** — `ssh_user: str | None` field on `DependencyReference`; parsed from `ssh://` and scp shorthand; percent-encoded userinfo rejected at the pre-`urlparse` layer (defence in depth). Kept **out of** `to_canonical`/`get_identity` so it cannot perturb the install-plan identity invariant.
- **`deps/host_backends.py`** — three non-ADO backends pass `user=getattr(dep_ref, "ssh_user", None) or "git"`. ADO is left untouched (literal `git@` is required by the service).

## Supply-chain review

Reviewed by the `apm-review-panel` supply-chain expert (verdict: APPROVE-WITH-CHANGES, all changes applied):

- Strict allowlist with leading-dash rejection blocks SSH argument injection (`-oProxyCommand=…`).
- Length cap prevents pathological inputs.
- Error message hides the raw user value to avoid leaking secrets if a token is mistakenly pasted into a URL.
- Identity invariant preserved: `ssh_user` is presentation-only, never part of canonical identity.

## Tests

- **`tests/unit/test_ssh_user_threading.py`** (new) — allowlist boundaries, length cap, percent rejection, error-message-hides-value, parser threading, identity-invariant preservation.
- **`tests/integration/test_dep_url_parsing_e2e.py`** — end-to-end thread from URL string to `backend.build_clone_ssh_url`.
- **`tests/acceptance/test_logging_acceptance.py`** — drive-by baseline fix: extend bracket pattern to cover the `[~]`, `[-]`, `[=]` plan-diff symbols (was failing on `main`).

All 226 SSH-related tests pass; lint clean (`ruff check` + `ruff format --check` both silent).

## Deferred follow-ups

- **Lockfile `ssh_user` storage** — `apm.yml` is re-parsed on each install, so URL-encoded users round-trip correctly today. Persisting `ssh_user` in `apm.lock.yaml` is a separate enhancement and left for a follow-up issue.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>