### PR TITLE
fix(ci): wire coverage observability into CI pipelines (Phase 1)

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -202,7 +202,7 @@ jobs:
           # --dist loadgroup is required: it is the only xdist scheduler
           # that honors pytest.mark.xdist_group, which we use to keep
           # HOME-mutating tests serialized on a single worker.
-          PYTEST_EXTRA_ARGS: "--splits 4 --group ${{ matrix.shard }} -n 2 --dist loadgroup --maxfail 10 --cov --cov-report=json:coverage.json"
+          PYTEST_EXTRA_ARGS: "--splits 4 --group ${{ matrix.shard }} -n 2 --dist loadgroup --maxfail 10 --cov"
         run: |
           chmod +x scripts/test-integration.sh
           uv run ./scripts/test-integration.sh
@@ -210,12 +210,20 @@ jobs:
         # headroom for the slowest shard (HOME-group tests).
         timeout-minutes: 15
 
+      - name: Rename coverage data for shard
+        if: always()
+        run: |
+          if [ -f .coverage ]; then
+            mv .coverage .coverage.shard-${{ matrix.shard }}
+          fi
+
       - name: Upload coverage data
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: integration-coverage-shard-${{ matrix.shard }}
-          path: coverage.json
+          path: .coverage.shard-${{ matrix.shard }}
+          include-hidden-files: true
           retention-days: 7
           if-no-files-found: ignore
 
@@ -228,6 +236,40 @@ jobs:
     if: always()
     runs-on: ubuntu-24.04
     steps:
+      # Coverage summary runs first (with if: always()) so we get
+      # observability even when some shards fail. The shard-result
+      # gate runs last so it can still fail the job.
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install coverage
+        run: pip install "coverage[toml]"
+
+      - name: Download shard coverage
+        if: always()
+        uses: actions/download-artifact@v4
+        with:
+          pattern: integration-coverage-shard-*
+          path: coverage-shards/
+          merge-multiple: true
+        continue-on-error: true
+
+      - name: Combine and summarise coverage
+        if: always()
+        run: |
+          if find coverage-shards -type f -name '.coverage*' 2>/dev/null | grep -q .; then
+            coverage combine coverage-shards/
+            coverage json -o coverage.json
+            python3 scripts/coverage-summary.py coverage.json --title "Integration Test Coverage"
+          else
+            echo "No coverage shard files found; skipping integration coverage summary."
+          fi
+        continue-on-error: true
+
       - name: Aggregate shard results
         run: |
           if [[ "${{ needs.integration-tests-shard.result }}" != "success" ]]; then
@@ -235,54 +277,6 @@ jobs:
             exit 1
           fi
           echo "All integration test shards passed."
-
-      - name: Download shard coverage
-        if: success()
-        uses: actions/download-artifact@v4
-        with:
-          pattern: integration-coverage-shard-*
-          path: coverage-shards/
-
-      - name: Integration coverage summary
-        if: success()
-        shell: bash
-        run: |
-          python3 - coverage-shards "$GITHUB_STEP_SUMMARY" << 'PYEOF'
-          import json, pathlib, os, sys
-          shards_dir = pathlib.Path(sys.argv[1])
-          summary_path = sys.argv[2] if len(sys.argv) > 2 else ""
-          if not shards_dir.exists():
-              print("No coverage data found"); raise SystemExit(0)
-          shard_files = sorted(shards_dir.rglob("coverage.json"))
-          if not shard_files:
-              print("No coverage.json found"); raise SystemExit(0)
-          total_stmts = total_miss = 0
-          for sf in shard_files:
-              data = json.loads(sf.read_text())
-              t = data.get("totals", {})
-              total_stmts += t.get("num_statements", 0)
-              total_miss += t.get("missing_lines", 0)
-          covered = total_stmts - total_miss
-          pct = round(covered / total_stmts * 100, 1) if total_stmts else 0
-          md = [
-              "## Integration Test Coverage",
-              f"*{len(shard_files)} shards aggregated*",
-              "",
-              f"**Overall: {pct}%** ({covered:,}/{total_stmts:,} statements)",
-              "",
-              "| Metric | Value |",
-              "|--------|-------|",
-              f"| Statements | {total_stmts:,} |",
-              f"| Covered | {covered:,} |",
-              f"| Missed | {total_miss:,} |",
-              f"| Coverage | {pct}% |",
-          ]
-          out = "\n".join(md) + "\n"
-          print(out)
-          if summary_path:
-              with open(summary_path, "a") as f:
-                  f.write(out)
-          PYEOF
 
   release-validation:
     name: Release Validation (Linux)

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -202,13 +202,22 @@ jobs:
           # --dist loadgroup is required: it is the only xdist scheduler
           # that honors pytest.mark.xdist_group, which we use to keep
           # HOME-mutating tests serialized on a single worker.
-          PYTEST_EXTRA_ARGS: "--splits 4 --group ${{ matrix.shard }} -n 2 --dist loadgroup --maxfail 10"
+          PYTEST_EXTRA_ARGS: "--splits 4 --group ${{ matrix.shard }} -n 2 --dist loadgroup --maxfail 10 --cov --cov-report=json:coverage.json"
         run: |
           chmod +x scripts/test-integration.sh
           uv run ./scripts/test-integration.sh
         # Per-shard timeout is ~1/4 of the original 30 min budget plus
         # headroom for the slowest shard (HOME-group tests).
         timeout-minutes: 15
+
+      - name: Upload coverage data
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-coverage-shard-${{ matrix.shard }}
+          path: coverage.json
+          retention-days: 7
+          if-no-files-found: ignore
 
   # Fan-in job that preserves the gate-required check name
   # "Integration Tests (Linux)". Branch protection / merge-gate.yml
@@ -226,6 +235,54 @@ jobs:
             exit 1
           fi
           echo "All integration test shards passed."
+
+      - name: Download shard coverage
+        if: success()
+        uses: actions/download-artifact@v4
+        with:
+          pattern: integration-coverage-shard-*
+          path: coverage-shards/
+
+      - name: Integration coverage summary
+        if: success()
+        shell: bash
+        run: |
+          python3 - coverage-shards "$GITHUB_STEP_SUMMARY" << 'PYEOF'
+          import json, pathlib, os, sys
+          shards_dir = pathlib.Path(sys.argv[1])
+          summary_path = sys.argv[2] if len(sys.argv) > 2 else ""
+          if not shards_dir.exists():
+              print("No coverage data found"); raise SystemExit(0)
+          shard_files = sorted(shards_dir.rglob("coverage.json"))
+          if not shard_files:
+              print("No coverage.json found"); raise SystemExit(0)
+          total_stmts = total_miss = 0
+          for sf in shard_files:
+              data = json.loads(sf.read_text())
+              t = data.get("totals", {})
+              total_stmts += t.get("num_statements", 0)
+              total_miss += t.get("missing_lines", 0)
+          covered = total_stmts - total_miss
+          pct = round(covered / total_stmts * 100, 1) if total_stmts else 0
+          md = [
+              "## Integration Test Coverage",
+              f"*{len(shard_files)} shards aggregated*",
+              "",
+              f"**Overall: {pct}%** ({covered:,}/{total_stmts:,} statements)",
+              "",
+              "| Metric | Value |",
+              "|--------|-------|",
+              f"| Statements | {total_stmts:,} |",
+              f"| Covered | {covered:,} |",
+              f"| Missed | {total_miss:,} |",
+              f"| Coverage | {pct}% |",
+          ]
+          out = "\n".join(md) + "\n"
+          print(out)
+          if summary_path:
+              with open(summary_path, "a") as f:
+                  f.write(out)
+          PYEOF
 
   release-validation:
     name: Release Validation (Linux)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,69 @@ jobs:
     - name: Install dependencies
       run: uv sync --extra dev --extra build
 
-    - name: Run tests
-      run: uv run pytest tests/unit tests/test_console.py -n auto --dist worksteal
+    - name: Run tests with coverage
+      run: uv run pytest tests/unit tests/test_console.py -n auto --dist worksteal --cov --cov-report=term-missing:skip-covered --cov-report=json:coverage.json
+
+    - name: Coverage summary
+      if: always()
+      run: |
+        if [ -f coverage.json ]; then
+          python3 << 'PYEOF'
+import json, pathlib
+
+data = json.loads(pathlib.Path("coverage.json").read_text())
+totals = data.get("totals", {})
+pct = totals.get("percent_covered_display", "N/A")
+stmts = totals.get("num_statements", 0)
+miss = totals.get("missing_lines", 0)
+covered = stmts - miss
+
+lines = []
+lines.append("## Code Coverage Report")
+lines.append("")
+lines.append(f"**Overall: {pct}%** ({covered:,}/{stmts:,} statements)")
+lines.append("")
+lines.append("| Metric | Value |")
+lines.append("|--------|-------|")
+lines.append(f"| Statements | {stmts:,} |")
+lines.append(f"| Covered | {covered:,} |")
+lines.append(f"| Missed | {miss:,} |")
+lines.append(f"| Coverage | {pct}% |")
+lines.append("")
+
+files = data.get("files", {})
+ranked = sorted(
+    files.items(),
+    key=lambda kv: kv[1].get("summary", {}).get("percent_covered", 100),
+)
+bottom = [
+    (f, d)
+    for f, d in ranked
+    if d.get("summary", {}).get("percent_covered", 100) < 80
+][:10]
+if bottom:
+    lines.append("<details><summary>Lowest-coverage files (below 80%)</summary>")
+    lines.append("")
+    lines.append("| File | Stmts | Miss | Cover |")
+    lines.append("|------|-------|------|-------|")
+    for fpath, fdata in bottom:
+        s = fdata.get("summary", {})
+        short = fpath.replace("src/apm_cli/", "")
+        fp = s.get("percent_covered_display", "?")
+        lines.append(
+            f"| `{short}` | {s.get('num_statements',0)}"
+            f" | {s.get('missing_lines',0)} | {fp}% |"
+        )
+    lines.append("")
+    lines.append("</details>")
+
+pathlib.Path("coverage-summary.md").write_text("\n".join(lines) + "\n")
+print("\n".join(lines))
+PYEOF
+          if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+            cat coverage-summary.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+        fi
 
     - name: Install UPX
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,61 +113,7 @@ jobs:
       if: always()
       run: |
         if [ -f coverage.json ]; then
-          python3 << 'PYEOF'
-import json, pathlib
-
-data = json.loads(pathlib.Path("coverage.json").read_text())
-totals = data.get("totals", {})
-pct = totals.get("percent_covered_display", "N/A")
-stmts = totals.get("num_statements", 0)
-miss = totals.get("missing_lines", 0)
-covered = stmts - miss
-
-lines = []
-lines.append("## Code Coverage Report")
-lines.append("")
-lines.append(f"**Overall: {pct}%** ({covered:,}/{stmts:,} statements)")
-lines.append("")
-lines.append("| Metric | Value |")
-lines.append("|--------|-------|")
-lines.append(f"| Statements | {stmts:,} |")
-lines.append(f"| Covered | {covered:,} |")
-lines.append(f"| Missed | {miss:,} |")
-lines.append(f"| Coverage | {pct}% |")
-lines.append("")
-
-files = data.get("files", {})
-ranked = sorted(
-    files.items(),
-    key=lambda kv: kv[1].get("summary", {}).get("percent_covered", 100),
-)
-bottom = [
-    (f, d)
-    for f, d in ranked
-    if d.get("summary", {}).get("percent_covered", 100) < 80
-][:10]
-if bottom:
-    lines.append("<details><summary>Lowest-coverage files (below 80%)</summary>")
-    lines.append("")
-    lines.append("| File | Stmts | Miss | Cover |")
-    lines.append("|------|-------|------|-------|")
-    for fpath, fdata in bottom:
-        s = fdata.get("summary", {})
-        short = fpath.replace("src/apm_cli/", "")
-        fp = s.get("percent_covered_display", "?")
-        lines.append(
-            f"| `{short}` | {s.get('num_statements',0)}"
-            f" | {s.get('missing_lines',0)} | {fp}% |"
-        )
-    lines.append("")
-    lines.append("</details>")
-
-pathlib.Path("coverage-summary.md").write_text("\n".join(lines) + "\n")
-print("\n".join(lines))
-PYEOF
-          if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
-            cat coverage-summary.md >> "$GITHUB_STEP_SUMMARY"
-          fi
+          python3 scripts/coverage-summary.py coverage.json --title "Unit Test Coverage"
         fi
 
     - name: Install UPX

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,23 @@ python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 
+[tool.coverage.run]
+source = ["src/apm_cli"]
+branch = true
+parallel = true
+
+[tool.coverage.report]
+show_missing = true
+skip_empty = true
+# Exclude lines that are not meant to be covered
+exclude_lines = [
+    "pragma: no cover",
+    "if __name__ == .__main__.",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+    "@overload",
+]
+
 [tool.pytest.ini_options]
 addopts = "-m 'not benchmark and not live'"
 markers = [

--- a/scripts/coverage-summary.py
+++ b/scripts/coverage-summary.py
@@ -41,7 +41,7 @@ def _build_markdown(data: dict, title: str) -> str:
     pct = totals.get("percent_covered_display", "N/A")
     stmts = totals.get("num_statements", 0)
     miss = totals.get("missing_lines", 0)
-    covered = stmts - miss
+    covered = totals.get("covered_lines", stmts - miss)
 
     lines: list[str] = []
     lines.append(f"## {title}")

--- a/scripts/coverage-summary.py
+++ b/scripts/coverage-summary.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Render a coverage.json file as a Markdown summary.
+
+Usage:
+    python3 scripts/coverage-summary.py coverage.json [--title "My Title"]
+
+Writes Markdown to stdout and, if GITHUB_STEP_SUMMARY is set, appends to
+that file so the summary appears in the GitHub Actions job summary panel.
+
+Exit codes:
+    0  Always -- missing coverage.json is treated as a soft warning, not
+       an error, so CI steps that set ``if: always()`` never fail here.
+"""
+
+import argparse
+import json
+import os
+import pathlib
+import sys
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Render a coverage.json file as a Markdown summary."
+    )
+    parser.add_argument(
+        "coverage_json",
+        metavar="COVERAGE_JSON",
+        help="Path to coverage.json produced by `coverage json`.",
+    )
+    parser.add_argument(
+        "--title",
+        default="Code Coverage Report",
+        help="Heading text for the summary (default: 'Code Coverage Report').",
+    )
+    return parser.parse_args()
+
+
+def _build_markdown(data: dict, title: str) -> str:
+    totals = data.get("totals", {})
+    pct = totals.get("percent_covered_display", "N/A")
+    stmts = totals.get("num_statements", 0)
+    miss = totals.get("missing_lines", 0)
+    covered = stmts - miss
+
+    lines: list[str] = []
+    lines.append(f"## {title}")
+    lines.append("")
+    lines.append(f"**Overall: {pct}%** ({covered:,}/{stmts:,} statements)")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("|--------|-------|")
+    lines.append(f"| Statements | {stmts:,} |")
+    lines.append(f"| Covered | {covered:,} |")
+    lines.append(f"| Missed | {miss:,} |")
+    lines.append(f"| Coverage | {pct}% |")
+    lines.append("")
+
+    files = data.get("files", {})
+    ranked = sorted(
+        files.items(),
+        key=lambda kv: kv[1].get("summary", {}).get("percent_covered", 100.0),
+    )
+    # Always show bottom-10 files so the section appears even when
+    # overall coverage is high (acceptance criteria: "collapsible
+    # lowest-coverage files" in every summary).
+    bottom = ranked[:10]
+
+    if bottom:
+        lines.append("<details>")
+        lines.append("<summary>Lowest-coverage files</summary>")
+        lines.append("")
+        lines.append("| File | Stmts | Miss | Cover |")
+        lines.append("|------|-------|------|-------|")
+        for fpath, fdata in bottom:
+            s = fdata.get("summary", {})
+            # Strip common prefix to keep the table narrow.
+            short = fpath.replace("src/apm_cli/", "")
+            fp = s.get("percent_covered_display", "?")
+            lines.append(
+                f"| `{short}` | {s.get('num_statements', 0)}"
+                f" | {s.get('missing_lines', 0)} | {fp}% |"
+            )
+        lines.append("")
+        lines.append("</details>")
+        lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def main() -> None:
+    args = _parse_args()
+    coverage_path = pathlib.Path(args.coverage_json)
+
+    if not coverage_path.exists():
+        print(
+            f"[!] coverage-summary: {coverage_path} not found -- skipping summary.",
+            file=sys.stderr,
+        )
+        sys.exit(0)
+
+    try:
+        data = json.loads(coverage_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        print(
+            f"[x] coverage-summary: failed to read {coverage_path}: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(0)
+
+    md = _build_markdown(data, args.title)
+    print(md, end="")
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "")
+    if summary_path:
+        try:
+            with open(summary_path, "a", encoding="utf-8") as fh:
+                fh.write(md)
+        except OSError as exc:
+            print(
+                f"[!] coverage-summary: could not write to GITHUB_STEP_SUMMARY: {exc}",
+                file=sys.stderr,
+            )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## TL;DR

Adds test coverage reporting to both CI pipelines (unit and integration) as Phase 1 of the progressive coverage ratchet (#1398). Coverage summaries appear in GitHub Actions job summaries as markdown tables — no PR is blocked.

> [!NOTE]
> Phase 1 is observability only — no `fail_under` gates. Phases 2–4 (#1401, #1402, #1400) will progressively tighten thresholds.

## Problem (WHY)

- [x] CI has no coverage measurement today. Contributors cannot see the coverage impact of their changes, and regressions land silently (#1398).
- [!] Without coverage visibility, there is no baseline to gate against in future phases.

## Approach (WHAT)

| # | Fix |
|---|-----|
| 1 | Add `[tool.coverage.run]` and `[tool.coverage.report]` to `pyproject.toml` with `branch = true`, `parallel = true`, and standard exclusion patterns |
| 2 | Wire `--cov` + JSON report into `ci.yml` unit test step; add coverage summary step |
| 3 | Wire `--cov` into integration shard `PYTEST_EXTRA_ARGS`; upload `.coverage` data files per shard with `include-hidden-files: true` |
| 4 | Fan-in job: `coverage combine` → `coverage json` → shared summary script for correct multi-shard merge |
| 5 | Create `scripts/coverage-summary.py` — stdlib-only shared renderer used by both pipelines |
| 6 | All coverage steps use `continue-on-error: true` / `if: always()` so coverage never blocks the required check |

## Implementation (HOW)

- **`pyproject.toml`** — Adds `[tool.coverage.run]` (source, branch, parallel) and `[tool.coverage.report]` (exclusions for `pragma: no cover`, `TYPE_CHECKING`, `NotImplementedError`, `@overload`).
- **`scripts/coverage-summary.py`** — New file. Reads `coverage.json`, renders a markdown summary (overall %, metrics table, collapsible lowest-coverage files). Writes to stdout and `$GITHUB_STEP_SUMMARY`. Exits 0 on missing input (soft-fail). Stdlib only, ASCII source.
- **`.github/workflows/ci.yml`** — Adds `--cov --cov-report=term-missing:skip-covered --cov-report=json:coverage.json` to the pytest invocation. Calls the shared summary script.
- **`.github/workflows/ci-integration.yml`** — Each shard produces a `.coverage` binary data file, renamed per-shard and uploaded with `include-hidden-files: true`. Fan-in job: checkout → Python → `pip install coverage[toml]` → download with `merge-multiple: true` → `coverage combine` → `coverage json` → summary script. Coverage summary runs before shard-result gate so observability is preserved even when shards fail.

## Diagrams

Legend: Integration coverage data flow from shards to fan-in. The yellow region highlights the `coverage combine` merge path.

```mermaid
sequenceDiagram
    participant S as Shard Job 1..4
    participant A as Upload Artifact
    participant F as Fan-in Job

    S->>S: pytest --cov
    S->>S: mv .coverage .coverage.shard-N
    S->>A: upload .coverage.shard-N
    rect rgb(255, 247, 200)
        Note over F: NEW: proper coverage combine
        A-->>F: download all shards
        F->>F: coverage combine
        F->>F: coverage json
        F->>F: coverage-summary.py
    end
    F->>F: aggregate shard results
```

## Trade-offs

- **`coverage combine` over JSON merge.** `coverage combine` is the only correct way to aggregate parallel coverage data — it handles source-file deduplication and branch-level merging internally.
- **`pip install coverage[toml]` in fan-in, not full `uv sync`.** The fan-in job only runs data processing (combine + json + summary), not tests. Installing just `coverage` keeps the step fast (~5s vs ~60s).
- **Coverage steps are soft-fail (`continue-on-error`).** Trades coverage visibility for CI stability — if coverage collection breaks, the required check still passes. Acceptable for Phase 1 observability; will be revisited when gates are introduced in Phase 2+.
- **Scenario Evidence skip clause applies.** This PR changes only CI workflow files and a standalone script — no CLI behaviour change, no user-facing code paths affected. Existing test suites run green without modification.

## Benefits

1. Coverage percentage visible in every CI run's job summary — contributors see impact before review.
2. Lowest-coverage files surfaced in a collapsible table — identifies improvement targets without requiring local tooling.
3. Integration coverage correctly merged across 4 shards via `coverage combine`.
4. Shared summary script eliminates duplication — one renderer, consistent output for both pipelines.
5. Coverage never blocks a PR — soft-fail design ensures observability does not become a gate.

## Validation

<details><summary>Lint (ruff check + format)</summary>

```
$ uv run --extra dev ruff check src/ tests/
All checks passed!

$ uv run --extra dev ruff format --check src/ tests/
775 files already formatted

$ uv run --extra dev ruff check scripts/coverage-summary.py
All checks passed!
```

</details>

<details><summary>Coverage summary script — end-to-end test</summary>

```
$ uv run pytest tests/unit/test_apm_package.py --cov --cov-report=json:coverage-test.json -q
32 passed in 2.76s

$ python3 scripts/coverage-summary.py coverage-test.json --title "Test Run"
## Test Run

**Overall: 6%** (2,762/36,735 statements)

| Metric | Value |
|--------|-------|
| Statements | 36,735 |
| Covered | 2,762 |
| Missed | 33,973 |
| Coverage | 6% |
```

</details>

<details><summary>Missing-file edge case</summary>

```
$ python3 scripts/coverage-summary.py nonexistent.json
[!] coverage-summary: nonexistent.json not found -- skipping summary.
$ echo $?
0
```

</details>

## How to test

- [ ] Push this branch and observe the CI `Build & Test (Linux)` job summary — it should show a "Unit Test Coverage" markdown table with overall % and a collapsible lowest-coverage files section.
- [ ] Enqueue a merge-queue run and observe the `Integration Tests (Linux)` fan-in job summary — it should show an "Integration Test Coverage" table with correctly merged shard data.
- [ ] Verify no `fail_under` gate exists — coverage should never cause a red check.

Closes #1399

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
