### PR TITLE
feat(experimental): `copilot-app` target deploys scheduled prompts to App DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Experimental:** `copilot-app` target deploys prompts (with optional `schedule:` frontmatter) directly into the GitHub Copilot desktop App's `~/.copilot/data.db` workflows table. Gated behind `apm config set experimental.copilot_app true`; user-scope only (`--global`). Workflows always install disabled (`enabled = 0`); user opts in from the App. No new CLI surface — `apm install / update / uninstall / list` cover the lifecycle. See [Copilot App integration](https://microsoft.github.io/apm/integrations/copilot-app/).
+- **Experimental:** `copilot-app` target deploys prompts (with optional `schedule:` frontmatter) directly into the GitHub Copilot desktop App's `~/.copilot/data.db` workflows table. Gated behind `apm experimental enable copilot-app`; user-scope only (`--global`). Workflows always install disabled (`enabled = 0`); user opts in from the App. No new CLI surface — `apm install / update / uninstall / list` cover the lifecycle. See [Copilot App integration](https://microsoft.github.io/apm/integrations/copilot-app/).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Experimental:** `copilot-app` target deploys prompts (with optional `schedule:` frontmatter) directly into the GitHub Copilot desktop App's `~/.copilot/data.db` workflows table. Gated behind `apm config set experimental.copilot_app true`; user-scope only (`--global`). Workflows always install disabled (`enabled = 0`); user opts in from the App. No new CLI surface — `apm install / update / uninstall / list` cover the lifecycle. See [Copilot App integration](https://microsoft.github.io/apm/integrations/copilot-app/).
+
 ### Fixed
 
 - `apm install` honors the SSH user portion of dependency URLs (`ssh://user@host/...` and scp shorthand `user@host:org/repo`) instead of hardcoding `git@`; unblocks EMU accounts and other non-`git` SSH identities. User values are validated against a strict allowlist before composing the clone URL. (#1385, closes #1383)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Experimental:** `copilot-app` target deploys prompts (with optional `schedule:` frontmatter) directly into the GitHub Copilot desktop App's `~/.copilot/data.db` workflows table. Gated behind `apm experimental enable copilot-app`; user-scope only (`--global`). Workflows always install disabled (`enabled = 0`); user opts in from the App. No new CLI surface — `apm install / update / uninstall / list` cover the lifecycle. See [Copilot App integration](https://microsoft.github.io/apm/integrations/copilot-app/).
+- **Experimental:** `copilot-app` target deploys prompts (with optional `schedule:` frontmatter) directly into the GitHub Copilot desktop App's `~/.copilot/data.db` workflows table. Gated behind `apm experimental enable copilot-app`; works in both project scope (`apm install --target copilot-app` from a project's `apm.yml`) and user scope (`--global`). Workflows always install disabled (`enabled = 0`); user opts in from the App. No new CLI surface — `apm install / update / uninstall / list` cover the lifecycle. See [Copilot App integration](https://microsoft.github.io/apm/integrations/copilot-app/).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Experimental:** `copilot-app` target deploys prompts (with optional `schedule:` frontmatter) directly into the GitHub Copilot desktop App's `~/.copilot/data.db` workflows table. Gated behind `apm experimental enable copilot-app`; works in both project scope (`apm install --target copilot-app` from a project's `apm.yml`) and user scope (`--global`). Workflows always install disabled (`enabled = 0`); user opts in from the App. No new CLI surface — `apm install / update / uninstall / list` cover the lifecycle. See [Copilot App integration](https://microsoft.github.io/apm/integrations/copilot-app/).
+- **Experimental:** `copilot-app` target deploys prompts (with optional workflow frontmatter) directly into the GitHub Copilot desktop App's `~/.copilot/data.db` workflows table. Gated behind `apm experimental enable copilot-app`; works in both project scope (`apm install --target copilot-app` from a project's `apm.yml`) and user scope (`--global`). Workflows always install disabled (`enabled = 0`); user opts in from the App. No new CLI surface — `apm install / update / uninstall / list` cover the lifecycle. See [Copilot App integration](https://microsoft.github.io/apm/integrations/copilot-app/).
+
+### Changed
+
+- **Experimental (`copilot-app`):** workflow prompts now use flat top-level frontmatter keys. Only `interval`, `schedule_hour`, `schedule_day` mark a `.prompt.md` as a workflow (dispatched to the Copilot App SQLite store); `mode`, `model`, `reasoning_effort` remain optional fields on a workflow but are NOT shape markers because they overload with plain VSCode / Copilot slash-command prompts. Plain prompts (no workflow keys) continue to deploy to slash-command targets only. `interval` defaults to `manual` when omitted. The redesign collapses what looked like two primitives (prompt vs scheduled prompt) into one shape-dispatched `.prompt.md`. Breaking only for users of the unreleased experimental target.
 
 ### Fixed
 
+- **Experimental (`copilot-app`):** workflow-shape `.prompt.md` files no longer leak to slash-command targets. Previously a single scheduled prompt would deploy to the Copilot App DB row AND to `.claude/commands/`, `.cursor/commands/`, `.copilot/prompts/`, and `.gemini/commands/`. Now each prompt belongs to exactly one surface based on frontmatter shape.
+- **Experimental (`copilot-app`):** pointing a plain `.prompt.md` (no workflow frontmatter) at `--target copilot-app` is now a hard error with an actionable diagnostic telling the author to add `interval: manual` or unset the target, rather than silently skipping.
 - `apm install` honors the SSH user portion of dependency URLs (`ssh://user@host/...` and scp shorthand `user@host:org/repo`) instead of hardcoding `git@`; unblocks EMU accounts and other non-`git` SSH identities. User values are validated against a strict allowlist before composing the clone URL. (#1385, closes #1383)
 
 ## [0.14.0] - 2026-05-18

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -211,6 +211,7 @@ export default defineConfig({
 						{ label: 'CI/CD pipelines', slug: 'integrations/ci-cd' },
 						{ label: 'GitHub Agentic Workflows', slug: 'integrations/gh-aw' },
 						{ label: 'Microsoft 365 Copilot Cowork (Experimental)', slug: 'integrations/copilot-cowork' },
+						{ label: 'GitHub Copilot App workflows (Experimental)', slug: 'integrations/copilot-app' },
 						{ label: 'AI runtime compatibility', slug: 'integrations/runtime-compatibility' },
 						{ label: 'GitHub rulesets', slug: 'integrations/github-rulesets' },
 					],

--- a/docs/src/content/docs/integrations/copilot-app.md
+++ b/docs/src/content/docs/integrations/copilot-app.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::caution[Frontier preview]
-This integration is experimental and off by default. You must enable the `copilot_app` flag before using it.
+This integration is experimental and off by default. You must enable the `copilot-app` flag before using it.
 
 ```bash
 apm experimental enable copilot-app
@@ -17,7 +17,7 @@ Until the flag is enabled, the `copilot-app` target stays inert: it is hidden fr
 
 ## What it does
 
-When `copilot_app` is enabled and a package ships a prompt with a `schedule:` frontmatter block, `apm install --target copilot-app --global` inserts the prompt as a row in the GitHub Copilot desktop App's SQLite store at `~/.copilot/data.db`. The App reads new rows on next launch (or refresh) and lists them under Workflows.
+When `copilot-app` is enabled and a package ships a prompt with a `schedule:` frontmatter block, `apm install --target copilot-app --global` inserts the prompt as a row in the GitHub Copilot desktop App's SQLite store at `~/.copilot/data.db`. The App reads new rows on next launch (or refresh) and lists them under Workflows.
 
 Prompts that do not carry `schedule:` are skipped silently at this target — they continue to deploy to file-based targets (`copilot`, `vscode`, `claude`, ...) without changes.
 
@@ -36,7 +36,7 @@ schedule:
   interval: daily         # one of: manual, hourly, daily, weekly
   schedule_hour: 9        # 0-23, UTC; ignored for manual / hourly
   schedule_day: 1         # 0-6 (weekly only)
-  mode: interactive       # one of: interactive, plan, autopilot
+  mode: interactive       # one of: interactive, plan
   model: claude-opus-4.7  # optional
   reasoning_effort: high  # optional
 ---
@@ -44,16 +44,22 @@ schedule:
 Summarise yesterday's commits across all open PRs ...
 ```
 
-`autopilot` mode is policy-blocked for third-party packages by default — third-party packages cannot auto-run anything on your machine without you flipping the App-side toggle.
+The Copilot App also defines an `autopilot` mode, but APM intentionally
+does NOT accept it via this target. Until package signing ships, a
+third-party package could declare `mode: autopilot` and have the App
+auto-run the prompt the moment you flip the in-App enable toggle.
+Refusing autopilot at the writer is the secure-by-default behaviour;
+you can still set autopilot yourself on a per-row basis from the App
+UI after install.
 
 ## Lifecycle
 
 | `apm` action | Effect on `~/.copilot/data.db` |
 |---|---|
 | `apm install` | INSERT row with `enabled = 0` (always disabled on install — you opt in). |
-| `apm install` (already installed) | UPDATE prompt text / schedule / mode. `enabled`, `last_run_at`, `next_run_at` are preserved. |
+| `apm install` (already installed, content unchanged) | UPDATE display fields only. `enabled`, `last_run_at`, `next_run_at` are preserved. |
+| `apm install` (already installed, prompt body or schedule changed) | UPDATE row AND reset `enabled = 0`, clear `next_run_at`. Rationale: you opted in to a specific prompt; a content update is a new consent surface. |
 | `apm uninstall` | DELETE only APM-namespaced rows (`apm--<owner>--<pkg>--<prompt>`). User-authored rows are never touched. |
-| `apm list` | Reports APM-managed workflows alongside other primitives. |
 
 ## Enable and check
 
@@ -90,6 +96,6 @@ Deployed rows are tracked in the project / user lockfile under the `copilot-app-
 
 ## Out of scope (today)
 
-- Package signing for `mode: autopilot` (planned).
+- Package signing (would unlock additional trust-gated capabilities such as `mode: autopilot`).
 - Scheduled-execution-on-install (deliberately not implemented — first-run is always manual).
 - `gh-aw` outer-loop target (separate roadmap).

--- a/docs/src/content/docs/integrations/copilot-app.md
+++ b/docs/src/content/docs/integrations/copilot-app.md
@@ -17,32 +17,37 @@ Until the flag is enabled, the `copilot-app` target stays inert: it is hidden fr
 
 ## What it does
 
-When `copilot-app` is enabled and a package ships a prompt with a `schedule:` frontmatter block, `apm install --target copilot-app` inserts the prompt as a row in the GitHub Copilot desktop App's SQLite store at `~/.copilot/data.db`. Add `--global` to install from a user-scope `~/.apm/apm.yml`, or omit it to install from a project's `apm.yml` (typical for team-shared scheduled prompts). The App reads new rows on next launch (or refresh) and lists them under Workflows.
+When `copilot-app` is enabled and a package ships a prompt with workflow frontmatter (any of `interval`, `schedule_hour`, `schedule_day` at the top level), `apm install --target copilot-app` inserts the prompt as a row in the GitHub Copilot desktop App's SQLite store at `~/.copilot/data.db`. Add `--global` to install from a user-scope `~/.apm/apm.yml`, or omit it to install from a project's `apm.yml` (typical for team-shared scheduled prompts). The App reads new rows on next launch (or refresh) and lists them under Workflows.
 
-Prompts that do not carry `schedule:` are skipped silently at this target — they continue to deploy to file-based targets (`copilot`, `vscode`, `claude`, ...) without changes.
+Prompts that do not carry workflow frontmatter are plain slash commands: they deploy to file-based targets (`copilot`, `vscode`, `claude`, ...) and APM hard-errors with an actionable diagnostic if you point them at `copilot-app` directly. A single `.prompt.md` belongs to exactly ONE surface — whichever its frontmatter shape selects.
 
 ## Why a new target
 
 The `copilot` target writes prompts as files (`.github/prompts/<name>.prompt.md`) for Copilot in IDEs. The desktop App stores workflows in a SQLite database, not on disk. They are different surfaces; `copilot-app` exists so that one APM install can serve both without leakage.
 
-## Authoring a scheduled prompt
+## Authoring a workflow prompt
 
-Add a `schedule:` block to any `.prompt.md` file in your package's `.apm/prompts/` folder:
+Add workflow frontmatter (flat top-level keys) to any `.prompt.md` file in your package's `.apm/prompts/` folder:
 
 ```markdown
 ---
 name: Daily Digest
-schedule:
-  interval: daily         # one of: manual, hourly, daily, weekly
-  schedule_hour: 9        # 0-23, UTC; ignored for manual / hourly
-  schedule_day: 1         # 0-6 (weekly only)
-  mode: interactive       # one of: interactive, plan
-  model: claude-opus-4.7  # optional
-  reasoning_effort: high  # optional
+interval: daily            # one of: manual, hourly, daily, weekly
+schedule_hour: 9           # 0-23, UTC; ignored for manual / hourly
+schedule_day: 1            # 0-6 (weekly only)
+mode: interactive          # one of: interactive, plan
+model: claude-opus-4.7     # optional
+reasoning_effort: high     # optional
 ---
 
 Summarise yesterday's commits across all open PRs ...
 ```
+
+Manual-only workflows omit `schedule_hour` / `schedule_day` and set
+`interval: manual` (the default when any other execution-shape key is
+present). The Copilot App provides a "run now" affordance for every
+workflow, so manual-only is a useful shape — no schedule, just a
+named, parameterised prompt the user can fire from the App UI.
 
 The Copilot App also defines an `autopilot` mode, but APM intentionally
 does NOT accept it via this target. Until package signing ships, a

--- a/docs/src/content/docs/integrations/copilot-app.md
+++ b/docs/src/content/docs/integrations/copilot-app.md
@@ -2,8 +2,10 @@
 title: "GitHub Copilot App workflows (Experimental)"
 description: "Deploy APM prompts with schedule frontmatter as Copilot App workflows backed by the desktop SQLite store."
 sidebar:
-  order: 5
+  order: 6
 ---
+
+See the [Targets matrix](../../reference/targets-matrix/) for where `copilot-app` fits alongside the other deploy targets.
 
 :::caution[Frontier preview]
 This integration is experimental and off by default. You must enable the `copilot-app` flag before using it.
@@ -11,6 +13,8 @@ This integration is experimental and off by default. You must enable the `copilo
 ```bash
 apm experimental enable copilot-app
 ```
+
+See the [Experimental flags reference](../../reference/experimental/) for the full `apm experimental` subcommand surface (enable / disable / list).
 
 Until the flag is enabled, the `copilot-app` target stays inert: it is hidden from auto-detection, and explicit `--target copilot-app` installs fail cleanly with the enable hint instead of touching the App's database.
 :::
@@ -26,6 +30,10 @@ Prompts that do not carry workflow frontmatter are plain slash commands: they de
 The `copilot` target writes prompts as files (`.github/prompts/<name>.prompt.md`) for Copilot in IDEs. The desktop App stores workflows in a SQLite database, not on disk. They are different surfaces; `copilot-app` exists so that one APM install can serve both without leakage.
 
 ## Authoring a workflow prompt
+
+:::note[Shape predicate]
+Only `interval`, `schedule_hour`, and `schedule_day` at the top level mark a `.prompt.md` as a workflow. Setting `mode:`, `model:`, or `reasoning_effort:` alone keeps it a plain VSCode-style prompt (deploys to `copilot`, `claude`, etc.) -- those keys are accepted on workflows but never trigger workflow routing on their own.
+:::
 
 Add workflow frontmatter (flat top-level keys) to any `.prompt.md` file in your package's `.apm/prompts/` folder:
 
@@ -63,16 +71,16 @@ UI after install.
 |---|---|
 | `apm install` | INSERT row with `enabled = 0` (always disabled on install — you opt in). |
 | `apm install` (already installed, content unchanged) | UPDATE display fields only. `enabled`, `last_run_at`, `next_run_at` are preserved. |
-| `apm install` (already installed, any execution-affecting field changed: prompt body, schedule, mode, model, or reasoning effort) | UPDATE row AND reset `enabled = 0`, clear `next_run_at`. Rationale: you opted in to a specific prompt; any change to what runs or when is a new consent surface. |
+| `apm install` (already installed, any execution-affecting field changed) | UPDATE row; reset `enabled = 0`; clear `next_run_at`. |
 | `apm uninstall` | DELETE only APM-namespaced rows (`apm--<owner>--<pkg>--<prompt>`). User-authored rows are never touched. |
+
+Execution-affecting fields are the prompt body, schedule (`interval` / `schedule_hour` / `schedule_day`), `mode`, `model`, and `reasoning_effort`. The reset is by design: you opted in to a specific prompt, so any change to what runs or when is a new consent surface.
+
+Removing the source `.prompt.md` from a package and re-syncing drops the lockfile entry but does NOT delete the corresponding row from `~/.copilot/data.db` -- it merely orphans it. Run `apm uninstall <pkg>` to remove the row.
 
 ## Enable and check
 
-```bash
-apm experimental enable copilot-app
-apm experimental list
-apm experimental disable copilot-app
-```
+Use `apm experimental enable copilot-app` to turn the target on, `apm experimental list` to see all flags, and `apm experimental disable copilot-app` to turn it off again. See the [Experimental flags reference](../../reference/experimental/) for the complete subcommand surface.
 
 ## Database resolution
 
@@ -89,11 +97,11 @@ There is none. The DB file is local; access is governed by your filesystem permi
 
 ## Schema compatibility
 
-APM guards writes with `PRAGMA user_version`. The current tested version is `13`. If the App ships a newer schema, APM refuses to write and asks you to update APM rather than risk corruption.
+APM guards writes with `PRAGMA user_version` and accepts the closed range `[13, 13]` today. If the App ships a newer schema, APM refuses to write and asks you to update APM rather than risk corruption.
 
 ## Concurrency
 
-APM opens the DB in WAL mode and retries briefly when the App holds a write lock. If a lock cannot be acquired after the retry window, the install fails with a `[!]` warning noting that the Copilot App DB stayed locked and asking you to close the GitHub Copilot app momentarily and retry.
+The Copilot App owns the DB and keeps it in WAL mode while running. APM coexists with the App's writer connection by issuing `BEGIN IMMEDIATE` with a bounded retry; if a lock cannot be acquired after the retry window, the install fails with a `[!]` warning noting that the Copilot App DB stayed locked and asking you to close the GitHub Copilot app momentarily and retry.
 
 ## Lockfile entries
 

--- a/docs/src/content/docs/integrations/copilot-app.md
+++ b/docs/src/content/docs/integrations/copilot-app.md
@@ -17,7 +17,7 @@ Until the flag is enabled, the `copilot-app` target stays inert: it is hidden fr
 
 ## What it does
 
-When `copilot-app` is enabled and a package ships a prompt with a `schedule:` frontmatter block, `apm install --target copilot-app --global` inserts the prompt as a row in the GitHub Copilot desktop App's SQLite store at `~/.copilot/data.db`. The App reads new rows on next launch (or refresh) and lists them under Workflows.
+When `copilot-app` is enabled and a package ships a prompt with a `schedule:` frontmatter block, `apm install --target copilot-app` inserts the prompt as a row in the GitHub Copilot desktop App's SQLite store at `~/.copilot/data.db`. Add `--global` to install from a user-scope `~/.apm/apm.yml`, or omit it to install from a project's `apm.yml` (typical for team-shared scheduled prompts). The App reads new rows on next launch (or refresh) and lists them under Workflows.
 
 Prompts that do not carry `schedule:` are skipped silently at this target — they continue to deploy to file-based targets (`copilot`, `vscode`, `claude`, ...) without changes.
 

--- a/docs/src/content/docs/integrations/copilot-app.md
+++ b/docs/src/content/docs/integrations/copilot-app.md
@@ -58,7 +58,7 @@ UI after install.
 |---|---|
 | `apm install` | INSERT row with `enabled = 0` (always disabled on install — you opt in). |
 | `apm install` (already installed, content unchanged) | UPDATE display fields only. `enabled`, `last_run_at`, `next_run_at` are preserved. |
-| `apm install` (already installed, prompt body or schedule changed) | UPDATE row AND reset `enabled = 0`, clear `next_run_at`. Rationale: you opted in to a specific prompt; a content update is a new consent surface. |
+| `apm install` (already installed, any execution-affecting field changed: prompt body, schedule, mode, model, or reasoning effort) | UPDATE row AND reset `enabled = 0`, clear `next_run_at`. Rationale: you opted in to a specific prompt; any change to what runs or when is a new consent surface. |
 | `apm uninstall` | DELETE only APM-namespaced rows (`apm--<owner>--<pkg>--<prompt>`). User-authored rows are never touched. |
 
 ## Enable and check
@@ -88,7 +88,7 @@ APM guards writes with `PRAGMA user_version`. The current tested version is `13`
 
 ## Concurrency
 
-APM opens the DB in WAL mode and retries briefly when the App holds a write lock. If a lock cannot be acquired after the retry window, the install fails with `[!] Copilot App database is locked. Try again with the App closed.`
+APM opens the DB in WAL mode and retries briefly when the App holds a write lock. If a lock cannot be acquired after the retry window, the install fails with a `[!]` warning noting that the Copilot App DB stayed locked and asking you to close the GitHub Copilot app momentarily and retry.
 
 ## Lockfile entries
 

--- a/docs/src/content/docs/integrations/copilot-app.md
+++ b/docs/src/content/docs/integrations/copilot-app.md
@@ -1,0 +1,95 @@
+---
+title: "GitHub Copilot App workflows (Experimental)"
+description: "Deploy APM prompts with schedule frontmatter as Copilot App workflows backed by the desktop SQLite store."
+sidebar:
+  order: 5
+---
+
+:::caution[Frontier preview]
+This integration is experimental and off by default. You must enable the `copilot_app` flag before using it.
+
+```bash
+apm experimental enable copilot-app
+```
+
+Until the flag is enabled, the `copilot-app` target stays inert: it is hidden from auto-detection, and explicit `--target copilot-app` installs fail cleanly with the enable hint instead of touching the App's database.
+:::
+
+## What it does
+
+When `copilot_app` is enabled and a package ships a prompt with a `schedule:` frontmatter block, `apm install --target copilot-app --global` inserts the prompt as a row in the GitHub Copilot desktop App's SQLite store at `~/.copilot/data.db`. The App reads new rows on next launch (or refresh) and lists them under Workflows.
+
+Prompts that do not carry `schedule:` are skipped silently at this target — they continue to deploy to file-based targets (`copilot`, `vscode`, `claude`, ...) without changes.
+
+## Why a new target
+
+The `copilot` target writes prompts as files (`.github/prompts/<name>.prompt.md`) for Copilot in IDEs. The desktop App stores workflows in a SQLite database, not on disk. They are different surfaces; `copilot-app` exists so that one APM install can serve both without leakage.
+
+## Authoring a scheduled prompt
+
+Add a `schedule:` block to any `.prompt.md` file in your package's `.apm/prompts/` folder:
+
+```markdown
+---
+name: Daily Digest
+schedule:
+  interval: daily         # one of: manual, hourly, daily, weekly
+  schedule_hour: 9        # 0-23, UTC; ignored for manual / hourly
+  schedule_day: 1         # 0-6 (weekly only)
+  mode: interactive       # one of: interactive, plan, autopilot
+  model: claude-opus-4.7  # optional
+  reasoning_effort: high  # optional
+---
+
+Summarise yesterday's commits across all open PRs ...
+```
+
+`autopilot` mode is policy-blocked for third-party packages by default — third-party packages cannot auto-run anything on your machine without you flipping the App-side toggle.
+
+## Lifecycle
+
+| `apm` action | Effect on `~/.copilot/data.db` |
+|---|---|
+| `apm install` | INSERT row with `enabled = 0` (always disabled on install — you opt in). |
+| `apm install` (already installed) | UPDATE prompt text / schedule / mode. `enabled`, `last_run_at`, `next_run_at` are preserved. |
+| `apm uninstall` | DELETE only APM-namespaced rows (`apm--<owner>--<pkg>--<prompt>`). User-authored rows are never touched. |
+| `apm list` | Reports APM-managed workflows alongside other primitives. |
+
+## Enable and check
+
+```bash
+apm experimental enable copilot-app
+apm experimental list
+apm experimental disable copilot-app
+```
+
+## Database resolution
+
+| Order | Source |
+|---|---|
+| 1 | `APM_COPILOT_APP_DB` environment variable (absolute path; used as-is). |
+| 2 | `~/.copilot/data.db` if it exists. |
+
+If neither resolves, the install fails with `[x] GitHub Copilot desktop App not detected. Expected ~/.copilot/data.db ...` and the command exits 1.
+
+## "Auth" model
+
+There is none. The DB file is local; access is governed by your filesystem permissions. APM never sends credentials or syncs the DB anywhere. Treat the DB as user-scope state.
+
+## Schema compatibility
+
+APM guards writes with `PRAGMA user_version`. The current tested version is `13`. If the App ships a newer schema, APM refuses to write and asks you to update APM rather than risk corruption.
+
+## Concurrency
+
+APM opens the DB in WAL mode and retries briefly when the App holds a write lock. If a lock cannot be acquired after the retry window, the install fails with `[!] Copilot App database is locked. Try again with the App closed.`
+
+## Lockfile entries
+
+Deployed rows are tracked in the project / user lockfile under the `copilot-app-db://workflows/<namespaced-id>` URI scheme. Standard sync semantics apply: lockfile drift triggers redeploy; removal from lockfile triggers row delete on next install.
+
+## Out of scope (today)
+
+- Package signing for `mode: autopilot` (planned).
+- Scheduled-execution-on-install (deliberately not implemented — first-run is always manual).
+- `gh-aw` outer-loop target (separate roadmap).

--- a/docs/src/content/docs/reference/experimental.md
+++ b/docs/src/content/docs/reference/experimental.md
@@ -171,6 +171,7 @@ apm experimental reset verbose-version
 |-----------------------|----------------------------------------------------------------------------------|
 | `verbose-version`     | Show Python version, platform, and install path in `apm --version`.              |
 | `copilot-cowork`      | Deploy APM skills to Microsoft 365 Copilot Cowork via OneDrive.                  |
+| `copilot-app`         | Deploy APM prompts (with `schedule:` frontmatter) as workflows in the GitHub Copilot desktop App (`~/.copilot/data.db`). See [Copilot App integration](../integrations/copilot-app/). |
 
 New flags are proposed via [CONTRIBUTING.md](https://github.com/microsoft/apm/blob/main/CONTRIBUTING.md#how-to-add-an-experimental-feature-flag) and graduate to default when stable. See the contributor recipe for the full lifecycle.
 See also: [Cowork integration](../integrations/copilot-cowork/).

--- a/docs/src/content/docs/reference/experimental.md
+++ b/docs/src/content/docs/reference/experimental.md
@@ -171,7 +171,7 @@ apm experimental reset verbose-version
 |-----------------------|----------------------------------------------------------------------------------|
 | `verbose-version`     | Show Python version, platform, and install path in `apm --version`.              |
 | `copilot-cowork`      | Deploy APM skills to Microsoft 365 Copilot Cowork via OneDrive.                  |
-| `copilot-app`         | Deploy APM prompts (with `schedule:` frontmatter) as workflows in the GitHub Copilot desktop App (`~/.copilot/data.db`). See [Copilot App integration](../integrations/copilot-app/). |
+| `copilot-app`         | Deploy APM prompts that carry workflow frontmatter (any of `interval`, `schedule_hour`, `schedule_day`) as workflows in the GitHub Copilot desktop App (`~/.copilot/data.db`). See [Copilot App integration](../integrations/copilot-app/). |
 
 New flags are proposed via [CONTRIBUTING.md](https://github.com/microsoft/apm/blob/main/CONTRIBUTING.md#how-to-add-an-experimental-feature-flag) and graduate to default when stable. See the contributor recipe for the full lifecycle.
 See also: [Cowork integration](../integrations/copilot-cowork/).

--- a/docs/src/content/docs/reference/targets-matrix.md
+++ b/docs/src/content/docs/reference/targets-matrix.md
@@ -62,7 +62,9 @@ list before `compile` or `install`.
 | windsurf | `.windsurf/` directory                        |
 
 `agent-skills`, `copilot-cowork`, and `copilot-app` are never
-auto-detected. Select them explicitly with `--target`.
+auto-detected. Select them explicitly with `--target`, or list them in
+a project's `apm.yml` `targets:` field so contributors running plain
+`apm install` pick them up automatically.
 
 ## copilot
 

--- a/docs/src/content/docs/reference/targets-matrix.md
+++ b/docs/src/content/docs/reference/targets-matrix.md
@@ -32,8 +32,9 @@ Skills always deploy to the cross-tool `.agents/skills/` directory by
 default (see [Skills convergence](#skills-convergence) below). All other
 primitives land under each target's own root.
 
-`copilot-cowork` (Microsoft 365 Copilot) is gated behind an experimental
-flag and not listed above. See [Experimental](../experimental/).
+`copilot-cowork` (Microsoft 365 Copilot) and `copilot-app` (GitHub
+Copilot desktop App) are gated behind experimental flags and not listed
+above. See [Experimental](../experimental/).
 
 ## Detection and resolution
 
@@ -60,8 +61,8 @@ list before `compile` or `install`.
 | opencode | `.opencode/` directory                        |
 | windsurf | `.windsurf/` directory                        |
 
-`agent-skills` and `copilot-cowork` are never auto-detected. Select them
-explicitly with `--target`.
+`agent-skills`, `copilot-cowork`, and `copilot-app` are never
+auto-detected. Select them explicitly with `--target`.
 
 ## copilot
 

--- a/packages/apm-guide/.apm/skills/apm-usage/commands.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/commands.md
@@ -141,6 +141,8 @@ Set `MCP_REGISTRY_URL` (default `https://api.mcp.github.com`) to point all `apm 
 
 Use `apm experimental enable copilot-cowork` to turn on Microsoft 365 Copilot Cowork skill deployment. Once enabled, deploy skills with `apm install --target copilot-cowork --global`.
 
+Use `apm experimental enable copilot-app` to turn on GitHub Copilot desktop App workflow deployment. Once enabled, prompts that carry a `schedule:` frontmatter block can be deployed to the App's SQLite store at `~/.copilot/data.db` with `apm install --target copilot-app --global`. Rows always start `enabled = 0` -- you opt in from the App. `apm install / update / uninstall` preserve user state (`enabled`, `last_run_at`, schedule overrides). Override the database path with `APM_COPILOT_APP_DB=<abs-path>`.
+
 ### Cross-client skills (`agent-skills`)
 
 Use `--target agent-skills` to deploy skills to `.agents/skills/` -- the cross-tool standard directory. This is useful when multiple clients (Codex, future tools) read from `.agents/skills/`. Unlike `--target all`, `agent-skills` must be requested explicitly: `apm install --target agent-skills` or `apm install --target all,agent-skills` for both. `apm compile --target agent-skills` is a no-op (skills-only target).

--- a/packages/apm-guide/.apm/skills/apm-usage/commands.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/commands.md
@@ -141,7 +141,7 @@ Set `MCP_REGISTRY_URL` (default `https://api.mcp.github.com`) to point all `apm 
 
 Use `apm experimental enable copilot-cowork` to turn on Microsoft 365 Copilot Cowork skill deployment. Once enabled, deploy skills with `apm install --target copilot-cowork --global`.
 
-Use `apm experimental enable copilot-app` to turn on GitHub Copilot desktop App workflow deployment. Once enabled, prompts that carry a `schedule:` frontmatter block can be deployed to the App's SQLite store at `~/.copilot/data.db` with `apm install --target copilot-app --global`. Rows always start `enabled = 0` -- you opt in from the App. `apm install / update / uninstall` preserve user state (`enabled`, `last_run_at`, schedule overrides). Override the database path with `APM_COPILOT_APP_DB=<abs-path>`.
+Use `apm experimental enable copilot-app` to turn on GitHub Copilot desktop App workflow deployment. Once enabled, prompts that carry a `schedule:` frontmatter block can be deployed to the App's SQLite store at `~/.copilot/data.db` with `apm install --target copilot-app` (project scope) or `--target copilot-app --global` (user scope). Rows always start `enabled = 0` -- you opt in from the App. `apm install / update / uninstall` preserve user state (`enabled`, `last_run_at`, schedule overrides). Override the database path with `APM_COPILOT_APP_DB=<abs-path>`.
 
 ### Cross-client skills (`agent-skills`)
 

--- a/packages/apm-guide/.apm/skills/apm-usage/commands.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/commands.md
@@ -141,7 +141,7 @@ Set `MCP_REGISTRY_URL` (default `https://api.mcp.github.com`) to point all `apm 
 
 Use `apm experimental enable copilot-cowork` to turn on Microsoft 365 Copilot Cowork skill deployment. Once enabled, deploy skills with `apm install --target copilot-cowork --global`.
 
-Use `apm experimental enable copilot-app` to turn on GitHub Copilot desktop App workflow deployment. Once enabled, prompts that carry a `schedule:` frontmatter block can be deployed to the App's SQLite store at `~/.copilot/data.db` with `apm install --target copilot-app` (project scope) or `--target copilot-app --global` (user scope). Rows always start `enabled = 0` -- you opt in from the App. `apm install / update / uninstall` preserve user state (`enabled`, `last_run_at`, schedule overrides). Override the database path with `APM_COPILOT_APP_DB=<abs-path>`.
+Use `apm experimental enable copilot-app` to turn on GitHub Copilot desktop App workflow deployment. Once enabled, prompts that carry workflow frontmatter -- any flat top-level key of `interval`, `schedule_hour`, `schedule_day` -- can be deployed to the App's SQLite store at `~/.copilot/data.db` with `apm install --target copilot-app` (project scope) or `--target copilot-app --global` (user scope). A `.prompt.md` belongs to exactly ONE surface: workflow-shape prompts go to the App DB, plain prompts go to slash-command targets. Rows always start `enabled = 0` -- you opt in from the App. `apm install / update / uninstall` preserve user state (`enabled`, `last_run_at`, schedule overrides). Override the database path with `APM_COPILOT_APP_DB=<abs-path>`.
 
 ### Cross-client skills (`agent-skills`)
 

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -183,9 +183,10 @@ placeholders. An `argument-hint` is auto-generated unless one is already set.
 #### Optional `schedule:` block (GitHub Copilot App, experimental)
 
 When the `copilot_app` experimental flag is enabled and the package is
-installed with `apm install --target copilot-app --global`, prompts
-that include a `schedule:` block in frontmatter are deployed as rows in
-the desktop App's SQLite store at `~/.copilot/data.db`.
+installed with `apm install --target copilot-app` (project scope) or
+`apm install --target copilot-app --global` (user scope), prompts that
+include a `schedule:` block in frontmatter are deployed as rows in the
+desktop App's SQLite store at `~/.copilot/data.db`.
 
 ```yaml
 ---

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -180,30 +180,39 @@ When installed as a Claude Code slash command, APM maps `input:` to
 Claude's `arguments:` frontmatter and converts `${input:name}` to `$name`
 placeholders. An `argument-hint` is auto-generated unless one is already set.
 
-#### Optional `schedule:` block (GitHub Copilot App, experimental)
+#### Optional workflow frontmatter (GitHub Copilot App, experimental)
 
 When the `copilot_app` experimental flag is enabled and the package is
 installed with `apm install --target copilot-app` (project scope) or
 `apm install --target copilot-app --global` (user scope), prompts that
-include a `schedule:` block in frontmatter are deployed as rows in the
-desktop App's SQLite store at `~/.copilot/data.db`.
+carry workflow frontmatter -- any flat top-level key of `interval`,
+`schedule_hour`, `schedule_day` -- are deployed as rows in the desktop
+App's SQLite store at `~/.copilot/data.db`. ``mode``, ``model``, and
+``reasoning_effort`` are optional fields on a workflow but do NOT mark
+a plain prompt as a workflow (they overload with plain VSCode / Copilot
+slash-command prompts); declare ``interval: manual`` to opt a no-schedule
+prompt into the App.
 
 ```yaml
 ---
 name: "Daily Digest"
-schedule:
-  interval: daily         # manual | hourly | daily | weekly
-  schedule_hour: 9        # 0-23 (UTC); ignored for manual / hourly
-  schedule_day: 1         # 0-6 (weekly only)
-  mode: interactive       # interactive | plan
-  model: claude-opus-4.7  # optional
-  reasoning_effort: high  # optional
+interval: daily           # manual | hourly | daily | weekly
+schedule_hour: 9          # 0-23 (UTC); ignored for manual / hourly
+schedule_day: 1           # 0-6 (weekly only)
+mode: interactive         # interactive | plan
+model: claude-opus-4.7    # optional
+reasoning_effort: high    # optional
 ---
 ```
 
 Rows are always inserted with `enabled = 0`; the user opts in from the
-App. Prompts without a `schedule:` block are skipped at the
-`copilot-app` target (they still deploy normally to file-based targets).
+App. A `.prompt.md` belongs to exactly ONE surface: workflow-frontmatter
+prompts go ONLY to the App DB, plain prompts go ONLY to file-based
+slash-command targets (`copilot`, `claude`, `cursor`, ...). Pointing a
+plain prompt at `--target copilot-app` is a hard error with an
+actionable diagnostic. `interval` is optional and defaults to `manual`
+when any other execution-shape key is present, so a parameterised
+prompt with no schedule still works as a manually-fired App workflow.
 The App also defines an `autopilot` mode, but APM intentionally does
 not accept it via this target -- a third-party package could otherwise
 auto-run the moment the user enables the row. Users who want autopilot

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -180,6 +180,32 @@ When installed as a Claude Code slash command, APM maps `input:` to
 Claude's `arguments:` frontmatter and converts `${input:name}` to `$name`
 placeholders. An `argument-hint` is auto-generated unless one is already set.
 
+#### Optional `schedule:` block (GitHub Copilot App, experimental)
+
+When the `copilot_app` experimental flag is enabled and the package is
+installed with `apm install --target copilot-app --global`, prompts
+that include a `schedule:` block in frontmatter are deployed as rows in
+the desktop App's SQLite store at `~/.copilot/data.db`.
+
+```yaml
+---
+name: "Daily Digest"
+schedule:
+  interval: daily         # manual | hourly | daily | weekly
+  schedule_hour: 9        # 0-23 (UTC); ignored for manual / hourly
+  schedule_day: 1         # 0-6 (weekly only)
+  mode: interactive       # interactive | plan | autopilot
+  model: claude-opus-4.7  # optional
+  reasoning_effort: high  # optional
+---
+```
+
+Rows are always inserted with `enabled = 0`; the user opts in from the
+App. Prompts without a `schedule:` block are skipped at the
+`copilot-app` target (they still deploy normally to file-based targets).
+`autopilot` mode is policy-blocked for third-party packages by default
+until package signing ships.
+
 ### 5. Agent (`*.agent.md`)
 
 Agent persona and behavior definition.

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -194,7 +194,7 @@ schedule:
   interval: daily         # manual | hourly | daily | weekly
   schedule_hour: 9        # 0-23 (UTC); ignored for manual / hourly
   schedule_day: 1         # 0-6 (weekly only)
-  mode: interactive       # interactive | plan | autopilot
+  mode: interactive       # interactive | plan
   model: claude-opus-4.7  # optional
   reasoning_effort: high  # optional
 ---
@@ -203,8 +203,10 @@ schedule:
 Rows are always inserted with `enabled = 0`; the user opts in from the
 App. Prompts without a `schedule:` block are skipped at the
 `copilot-app` target (they still deploy normally to file-based targets).
-`autopilot` mode is policy-blocked for third-party packages by default
-until package signing ships.
+The App also defines an `autopilot` mode, but APM intentionally does
+not accept it via this target -- a third-party package could otherwise
+auto-run the moment the user enables the row. Users who want autopilot
+can still set it themselves per-row from the App UI after install.
 
 ### 5. Agent (`*.agent.md`)
 

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -927,7 +927,7 @@ def _handle_mcp_install(
     "target",
     type=TargetParamType(),
     default=None,
-    help="Target harness(es) to deploy to. Comma-separated for multiple: --target claude,cursor. Highest-priority entry in the resolution chain (--target > apm.yml targets: > auto-detect). Values: copilot, claude, cursor, opencode, codex, gemini, windsurf, agent-skills, all. 'agent-skills' deploys to .agents/skills/ (cross-client). 'all' = copilot+claude+cursor+opencode+codex+gemini+windsurf (excludes agent-skills); combine with 'agent-skills' for both. 'copilot-cowork' is also accepted when the copilot-cowork experimental flag is enabled (run 'apm experimental enable copilot-cowork'). Note: '--target all' on 'apm compile' is deprecated; use 'apm compile --all' instead.",
+    help="Target harness(es) to deploy to. Comma-separated for multiple: --target claude,cursor. Repeating the flag (e.g. '-t a -t b') is NOT supported -- only the last value wins; use commas. Highest-priority entry in the resolution chain (--target > apm.yml targets: > auto-detect). Values: copilot, claude, cursor, opencode, codex, gemini, windsurf, agent-skills, all. 'agent-skills' deploys to .agents/skills/ (cross-client). 'all' = copilot+claude+cursor+opencode+codex+gemini+windsurf (excludes agent-skills); combine with 'agent-skills' for both. 'copilot-cowork' is also accepted when the copilot-cowork experimental flag is enabled (run 'apm experimental enable copilot-cowork'). 'copilot-app' is also accepted when the copilot-app experimental flag is enabled (run 'apm experimental enable copilot-app'). Note: '--target all' on 'apm compile' is deprecated; use 'apm compile --all' instead.",
 )
 @click.option(
     "--allow-insecure",

--- a/src/apm_cli/commands/uninstall/engine.py
+++ b/src/apm_cli/commands/uninstall/engine.py
@@ -515,7 +515,11 @@ def _sync_integrations_after_uninstall(
                 continue
             _effective_root = _mapping.deploy_root or _target.root_dir
             _deploy_dir = project_root / _effective_root / _mapping.subdir
-            if not _deploy_dir.exists():
+            # Dynamic-root targets (e.g. copilot-app) have no filesystem
+            # deploy dir; their managed files are URIs that the integrator
+            # resolves internally.  Skip the dir-exists guard for them.
+            _is_dynamic = _target.resolved_deploy_root is not None
+            if not _is_dynamic and not _deploy_dir.exists():
                 continue
             _managed_subset = None
             if _buckets is not None:
@@ -578,6 +582,37 @@ def _sync_integrations_after_uninstall(
             targets=_sync_targets,
         )
         counts["skills"] = result.get("files_removed", 0)
+
+    # Scan sync_managed DIRECTLY for copilot-app-db:// entries.
+    # The copilot-app target is opt-in: resolve_targets() excludes it from the
+    # default user-scope set unless --target copilot-app was passed at install
+    # time and recorded on apm_package.target.  Without this scan, prompts
+    # deployed to ~/.copilot/data.db would never be deleted on uninstall
+    # because the per-target loop above does not iterate copilot-app.
+    if sync_managed:
+        from ...integration.copilot_app_db import COPILOT_APP_LOCKFILE_PREFIX
+
+        _copilot_app_files = {p for p in sync_managed if p.startswith(COPILOT_APP_LOCKFILE_PREFIX)}
+        if _copilot_app_files:
+            # Find or synthesise a user-scope copilot-app TargetProfile.
+            from ...integration.targets import KNOWN_TARGETS
+
+            _ca_target = next(
+                (t for t in _resolved_targets if t.name == "copilot-app"),
+                None,
+            )
+            if _ca_target is None:
+                _ca_static = KNOWN_TARGETS.get("copilot-app")
+                if _ca_static is not None:
+                    _ca_target = _ca_static.for_scope(user_scope=True)
+            if _ca_target is not None:
+                result = _integrators["prompts"].sync_for_target(
+                    _ca_target,
+                    apm_package,
+                    project_root,
+                    managed_files=_copilot_app_files,
+                )
+                counts["prompts"] += result.get("files_removed", 0)
 
     # Hooks (multi-target sync_integration handles all targets)
     result = _integrators["hooks"].sync_integration(

--- a/src/apm_cli/core/experimental.py
+++ b/src/apm_cli/core/experimental.py
@@ -75,7 +75,8 @@ FLAGS: dict[str, ExperimentalFlag] = {
         description="Deploy prompts as workflows into the GitHub Copilot desktop App.",
         default=False,
         hint=(
-            "Add 'schedule:' frontmatter to any .prompt.md, then install "
+            "Add workflow frontmatter (e.g. 'interval: manual') to any "
+            ".prompt.md, then install "
             "with '--target copilot-app' (project or '--global' user scope). "
             "Workflows arrive disabled; enable them from the Copilot app's "
             "Workflows tab."

--- a/src/apm_cli/core/experimental.py
+++ b/src/apm_cli/core/experimental.py
@@ -70,6 +70,16 @@ FLAGS: dict[str, ExperimentalFlag] = {
             "See https://microsoft.github.io/apm/integrations/copilot-cowork/"
         ),
     ),
+    "copilot_app": ExperimentalFlag(
+        name="copilot_app",
+        description="Deploy prompts as workflows into the GitHub Copilot desktop App.",
+        default=False,
+        hint=(
+            "Add 'schedule:' frontmatter to any .prompt.md and install with "
+            "'--target copilot-app --global'. Workflows arrive disabled; "
+            "enable them from the Copilot app's Workflows tab."
+        ),
+    ),
 }
 
 

--- a/src/apm_cli/core/experimental.py
+++ b/src/apm_cli/core/experimental.py
@@ -75,9 +75,10 @@ FLAGS: dict[str, ExperimentalFlag] = {
         description="Deploy prompts as workflows into the GitHub Copilot desktop App.",
         default=False,
         hint=(
-            "Add 'schedule:' frontmatter to any .prompt.md and install with "
-            "'--target copilot-app --global'. Workflows arrive disabled; "
-            "enable them from the Copilot app's Workflows tab."
+            "Add 'schedule:' frontmatter to any .prompt.md, then install "
+            "with '--target copilot-app' (project or '--global' user scope). "
+            "Workflows arrive disabled; enable them from the Copilot app's "
+            "Workflows tab."
         ),
     ),
 }

--- a/src/apm_cli/core/target_detection.py
+++ b/src/apm_cli/core/target_detection.py
@@ -320,7 +320,7 @@ ALL_CANONICAL_TARGETS = frozenset(
 #: ``is_enabled()`` in ``core/experimental.py`` and ``_flag_gated()`` in
 #: ``integration/targets.py``.  They are NOT included in the
 #: ``parse_target_arg("all")`` expansion -- explicit opt-in only.
-EXPERIMENTAL_TARGETS: frozenset[str] = frozenset({"copilot-cowork"})
+EXPERIMENTAL_TARGETS: frozenset[str] = frozenset({"copilot-cowork", "copilot-app"})
 
 #: Stable targets excluded from "all" expansion (cross-client deploy
 #: locations). Unlike EXPERIMENTAL_TARGETS, these are GA -- they just do

--- a/src/apm_cli/install/phases/targets.py
+++ b/src/apm_cli/install/phases/targets.py
@@ -170,6 +170,52 @@ def run(ctx: InstallContext) -> None:
             raise SystemExit(1)
 
     # ------------------------------------------------------------------
+    # GitHub Copilot App target gating (mirrors cowork rules above):
+    # explicit --target copilot-app with flag OFF must hint at the
+    # experimental enable command; with flag ON but no ~/.copilot/data.db
+    # must error with an actionable install instruction; without --global
+    # must error because copilot-app is user-scope only.
+    # ------------------------------------------------------------------
+    _user_asked_copilot_app = False
+    if _explicit:
+        if isinstance(_explicit, list):
+            _user_asked_copilot_app = "copilot-app" in _explicit
+        else:
+            _user_asked_copilot_app = _explicit == "copilot-app"
+
+    if _user_asked_copilot_app:
+        _copilot_app_resolved = any(t.name == "copilot-app" for t in _targets)
+        if not _copilot_app_resolved:
+            from apm_cli.core.experimental import is_enabled as _is_flag_on
+
+            if not _is_flag_on("copilot_app"):
+                if ctx.logger:
+                    ctx.logger.progress(
+                        "The 'copilot-app' target requires an experimental flag. "
+                        "Run: apm experimental enable copilot-app",
+                        symbol="info",
+                    )
+            else:
+                _app_msg = (
+                    "GitHub Copilot desktop App not detected.\n"
+                    "Expected ~/.copilot/data.db but the file is missing.\n"
+                    "Install the app, or omit '--target copilot-app'."
+                )
+                if ctx.logger:
+                    ctx.logger.error(_app_msg, symbol="cross")
+                raise SystemExit(1)
+
+    if not _is_user:
+        _copilot_app_in_set = any(t.name == "copilot-app" for t in _targets)
+        if _copilot_app_in_set:
+            if ctx.logger:
+                ctx.logger.error(
+                    "The 'copilot-app' target requires --global (user scope). "
+                    "Run: apm install --target copilot-app --global"
+                )
+            raise SystemExit(1)
+
+    # ------------------------------------------------------------------
     # v2 resolution (#1154): signal-based provenance and strict errors.
     # Runs AFTER the legacy resolver and cowork gates so existing
     # behavior is preserved.  The v2 resolver validates signals and

--- a/src/apm_cli/install/phases/targets.py
+++ b/src/apm_cli/install/phases/targets.py
@@ -205,15 +205,16 @@ def run(ctx: InstallContext) -> None:
                     ctx.logger.error(_app_msg, symbol="cross")
                 raise SystemExit(1)
 
-    if not _is_user:
-        _copilot_app_in_set = any(t.name == "copilot-app" for t in _targets)
-        if _copilot_app_in_set:
-            if ctx.logger:
-                ctx.logger.error(
-                    "The 'copilot-app' target requires --global (user scope). "
-                    "Run: apm install --target copilot-app --global"
-                )
-            raise SystemExit(1)
+    # NOTE: copilot-app intentionally has no project-scope gate. The DB
+    # at ~/.copilot/data.db is a single user-scoped resource, but the
+    # *intent* to deploy can legitimately come from a project's apm.yml
+    # (a team-shared scheduled prompt belongs in the project that owns
+    # the prompt, not in every developer's user-scope manifest). The
+    # experimental flag (machine-level opt-in) is the consent envelope;
+    # the package-namespaced row id (apm--<owner>--<pkg>--<prompt>)
+    # prevents collisions across projects sharing the same package.
+    # Rows always arrive enabled=0; users grant the second consent in
+    # the App's Workflows tab before anything runs on a schedule.
 
     # ------------------------------------------------------------------
     # v2 resolution (#1154): signal-based provenance and strict errors.

--- a/src/apm_cli/install/services.py
+++ b/src/apm_cli/install/services.py
@@ -63,10 +63,19 @@ def _deployed_path_entry(
         # target.  Find the matching target and translate.
         if targets:
             for _t in targets:
-                if _t.resolved_deploy_root is not None:
-                    from apm_cli.integration.copilot_cowork_paths import to_lockfile_path
+                if _t.resolved_deploy_root is None:
+                    continue
+                if _t.name == "copilot-app":
+                    # Copilot App rows have no real file on disk.  The
+                    # integrator synthesises ``<root>/workflows/<id>``
+                    # as the addressing token; encode it as a
+                    # ``copilot-app-db://`` URI.
+                    from apm_cli.integration.copilot_app_db import to_lockfile_uri
 
-                    return to_lockfile_path(target_path, _t.resolved_deploy_root)
+                    return to_lockfile_uri(target_path.name)
+                from apm_cli.integration.copilot_cowork_paths import to_lockfile_path
+
+                return to_lockfile_path(target_path, _t.resolved_deploy_root)
         raise RuntimeError(  # noqa: B904
             f"Cannot translate {target_path!r} to a lockfile path: "
             f"path is outside the project tree and no dynamic-root "

--- a/src/apm_cli/install/services.py
+++ b/src/apm_cli/install/services.py
@@ -56,20 +56,33 @@ def _deployed_path_entry(
         If the path is outside the project tree and cannot be
         translated to a ``cowork://`` URI via any available target.
     """
+    if targets:
+        for _t in targets:
+            if _t.resolved_deploy_root is None:
+                continue
+            try:
+                target_path.relative_to(_t.resolved_deploy_root)
+            except ValueError:
+                continue
+            if _t.name == "copilot-app":
+                from apm_cli.integration.copilot_app_db import to_lockfile_uri
+
+                return to_lockfile_uri(target_path.name)
+            from apm_cli.integration.copilot_cowork_paths import to_lockfile_path
+
+            return to_lockfile_path(target_path, _t.resolved_deploy_root)
     try:
         return target_path.relative_to(project_root).as_posix()
     except ValueError:
-        # Path is outside the project tree -- must be a dynamic-root
-        # target.  Find the matching target and translate.
+        # Path is outside the project tree and no dynamic-root target
+        # contained it. Fall through to the legacy cowork translation
+        # which security-validates against deploy_root and raises
+        # PathTraversalError when out of bounds.
         if targets:
             for _t in targets:
                 if _t.resolved_deploy_root is None:
                     continue
                 if _t.name == "copilot-app":
-                    # Copilot App rows have no real file on disk.  The
-                    # integrator synthesises ``<root>/workflows/<id>``
-                    # as the addressing token; encode it as a
-                    # ``copilot-app-db://`` URI.
                     from apm_cli.integration.copilot_app_db import to_lockfile_uri
 
                     return to_lockfile_uri(target_path.name)

--- a/src/apm_cli/install/services.py
+++ b/src/apm_cli/install/services.py
@@ -352,6 +352,16 @@ def integrate_package_primitives(
                 _log_integration(line)
         else:
             _log_integration(f"  |-- {_verb_phrase} -> {_suffix}")
+        # Emit a one-line "next step" hint when copilot-app workflows
+        # were integrated: the row lands enabled=0 and the user has to
+        # flip the toggle in the Copilot App's Workflows tab before the
+        # schedule fires. This is the "failure mode is the product"
+        # surface for project-scope ride-along installs where a
+        # contributor may not have read the integration doc.
+        if any(p.startswith("copilot-app/") for p in _info["paths"]) and _info["files"] > 0:
+            _log_integration(
+                "  |-- workflows arrive disabled; enable from the Copilot App's Workflows tab"
+            )
 
     skill_result = skill_integrator.integrate_package_skill(
         package_info,

--- a/src/apm_cli/integration/base_integrator.py
+++ b/src/apm_cli/integration/base_integrator.py
@@ -409,12 +409,22 @@ class BaseIntegrator:
 
         for target in source:
             for prim_name, mapping in target.primitives.items():
-                # Dynamic-root targets (cowork) use cowork:// URI prefix.
+                # Dynamic-root targets (cowork, copilot-app) use URI prefixes.
                 if target.resolved_deploy_root is not None:
                     if prim_name == "skills":
                         from apm_cli.integration.copilot_cowork_paths import COWORK_LOCKFILE_PREFIX
 
                         skill_prefixes.append(COWORK_LOCKFILE_PREFIX)
+                    elif target.name == "copilot-app":
+                        from apm_cli.integration.copilot_app_db import (
+                            COPILOT_APP_LOCKFILE_PREFIX,
+                        )
+
+                        raw_key = f"{prim_name}_{target.name}"
+                        bucket_key = BaseIntegrator._BUCKET_ALIASES.get(raw_key, raw_key)
+                        if bucket_key not in buckets:
+                            buckets[bucket_key] = set()
+                        prefix_map[COPILOT_APP_LOCKFILE_PREFIX] = bucket_key
                     continue
                 effective_root = mapping.deploy_root or target.root_dir
                 prefix = (

--- a/src/apm_cli/integration/command_integrator.py
+++ b/src/apm_cli/integration/command_integrator.py
@@ -511,6 +511,23 @@ class CommandIntegrator(BaseIntegrator):
         any_dropped_keys = False
 
         for prompt_file in prompt_files:
+            # Skip workflow-shape prompts: they belong to the Copilot
+            # App workflows table, not a slash-command directory.  This
+            # is the central fix for Option B's slash-command leak:
+            # a single .prompt.md file with execution metadata used to
+            # ship to .claude/commands/, .cursor/commands/, .gemini/
+            # commands/, .copilot/prompts/ AND the App DB.  Only the
+            # last destination was correct.
+            try:
+                from apm_cli.integration.prompt_integrator import _is_workflow_shape
+
+                _meta = frontmatter.load(str(prompt_file)).metadata
+            except Exception:
+                _meta = {}
+            if _is_workflow_shape(_meta):
+                files_skipped += 1
+                continue
+
             filename = prompt_file.name
             if filename.endswith(".prompt.md"):
                 base_name = filename[: -len(".prompt.md")]

--- a/src/apm_cli/integration/copilot_app_db.py
+++ b/src/apm_cli/integration/copilot_app_db.py
@@ -2,8 +2,12 @@
 
 The Copilot desktop App stores its scheduled workflows in
 ``~/.copilot/data.db`` (SQLite, WAL journal mode).  APM deploys prompts
-with ``schedule:`` frontmatter as rows in that ``workflows`` table so the
-app surfaces them in its Workflows tab.  This module is the I/O boundary:
+whose frontmatter carries workflow-shape keys (``interval``,
+``schedule_hour``, ``schedule_day``) as rows in that ``workflows`` table
+so the app surfaces them in its Workflows tab.  ``mode`` / ``model`` /
+``reasoning_effort`` remain optional fields on a workflow but are not
+shape markers (they overload with plain VSCode / Copilot slash-command
+prompts).  This module is the I/O boundary:
 
 1. **Resolution** -- locate ``~/.copilot/data.db`` on the current machine
    (override with ``APM_COPILOT_APP_DB`` for tests or non-standard layouts).
@@ -375,6 +379,13 @@ def _validate_row(row: WorkflowRow) -> None:
             f"Invalid interval {row.interval!r}; expected one of {sorted(_VALID_INTERVALS)}"
         )
     if row.mode is not None and row.mode not in _VALID_MODES:
+        if row.mode == "autopilot":
+            raise ValueError(
+                "APM does not deploy workflows on autopilot mode -- "
+                "a third-party package could otherwise auto-run the moment "
+                "the user enables the row.  Users who want autopilot must "
+                "set it themselves per-row from the Copilot App UI."
+            )
         raise ValueError(f"Invalid mode {row.mode!r}; expected one of {sorted(_VALID_MODES)}")
     if not (0 <= row.schedule_hour <= 23):
         raise ValueError(f"Invalid schedule_hour {row.schedule_hour}; expected 0..23")

--- a/src/apm_cli/integration/copilot_app_db.py
+++ b/src/apm_cli/integration/copilot_app_db.py
@@ -432,13 +432,18 @@ def deploy_workflow(db_path: Path, row: WorkflowRow) -> str:
                 (row.id,),
             ).fetchone()
             if existing is None:
+                # INSERT always writes enabled=0 regardless of row.enabled.
+                # The user must opt in via the App UI -- a third-party package
+                # cannot auto-run on install even if a future caller passes
+                # enabled=1 to this writer. Defence in depth alongside the
+                # caller-side enforcement in PromptIntegrator.
                 conn.execute(
                     """
                     INSERT INTO workflows (
                         id, name, prompt, model, reasoning_effort,
                         interval, schedule_hour, schedule_day,
                         enabled, mode
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?)
                     """,
                     (
                         row.id,
@@ -449,7 +454,6 @@ def deploy_workflow(db_path: Path, row: WorkflowRow) -> str:
                         row.interval,
                         row.schedule_hour,
                         row.schedule_day,
-                        row.enabled,
                         row.mode,
                     ),
                 )

--- a/src/apm_cli/integration/copilot_app_db.py
+++ b/src/apm_cli/integration/copilot_app_db.py
@@ -1,0 +1,529 @@
+"""GitHub Copilot desktop App SQLite-backed workflow deployment.
+
+The Copilot desktop App stores its scheduled workflows in
+``~/.copilot/data.db`` (SQLite, WAL journal mode).  APM deploys prompts
+with ``schedule:`` frontmatter as rows in that ``workflows`` table so the
+app surfaces them in its Workflows tab.  This module is the I/O boundary:
+
+1. **Resolution** -- locate ``~/.copilot/data.db`` on the current machine
+   (override with ``APM_COPILOT_APP_DB`` for tests or non-standard layouts).
+
+2. **Lockfile translation** -- workflow rows are referenced in
+   ``apm.lock.yaml`` via the synthetic ``copilot-app-db://workflows/<id>``
+   URI scheme.  ``apm.lock`` always carries the rendered URI; absolute
+   filesystem paths never leak into the lockfile.
+
+3. **Schema guard** -- check ``PRAGMA user_version`` before any write
+   and refuse to touch a DB whose schema is newer than we've tested
+   against.  Apps that ship a forward-incompatible schema must wait
+   for an APM upgrade.
+
+4. **WAL-safe writes** -- the app keeps a writer connection open while
+   running; use ``BEGIN IMMEDIATE`` + bounded retry to coexist without
+   blocking the foreground process.
+
+5. **Namespacing** -- every APM-deployed row uses an ``apm--<owner>--
+   <pkg-name>--<prompt-name>`` ID so uninstall removes only APM rows and
+   never user-authored ones.
+
+Security posture
+----------------
+There is no application-level authentication on the SQLite file.  The
+DB is protected by filesystem permissions alone (``~/.copilot/`` is
+0700 on macOS/Linux when created by the app).  Anything that can write
+to this file can already exfiltrate the user's tokens.  We document
+this transparently; this module does not promise auth it cannot
+deliver.
+
+Design note
+-----------
+Pure-stdlib (``sqlite3`` is in the standard library).  Always importable
+but functionally inert until the ``copilot_app`` experimental flag is
+enabled by the caller.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+COPILOT_APP_URI_SCHEME: str = "copilot-app-db://"
+"""Synthetic URI prefix for Copilot App DB rows in lockfile entries."""
+
+COPILOT_APP_LOCKFILE_PREFIX: str = "copilot-app-db://workflows/"
+"""Full prefix for workflow entries in the lockfile (scheme + table segment)."""
+
+_DEFAULT_DB_RELATIVE: str = ".copilot/data.db"
+"""Relative path from the user's home directory to the Copilot App DB."""
+
+_MIN_SUPPORTED_USER_VERSION: int = 13
+"""Lowest ``PRAGMA user_version`` we are tested against.
+
+Empirical: the live app on macOS reports ``user_version = 13`` as of
+the design's reverse-engineering pass.  Lower values would imply a
+pre-workflows schema where the ``workflows`` table doesn't exist.
+"""
+
+_MAX_SUPPORTED_USER_VERSION: int = 13
+"""Highest ``PRAGMA user_version`` we are tested against.
+
+When the app ships a newer schema we refuse to write rather than risk
+corrupting forward-incompatible columns.  Bump after explicit
+re-testing against the new schema.
+"""
+
+_WAL_RETRY_TIMEOUT_S: float = 5.0
+"""Wall-clock budget for ``BEGIN IMMEDIATE`` retries when the app
+holds a long-running write transaction."""
+
+_WAL_RETRY_BACKOFF_S: float = 0.05
+"""Initial backoff between ``BEGIN IMMEDIATE`` retries.  Doubles each
+attempt up to ``_WAL_RETRY_MAX_BACKOFF_S``."""
+
+_WAL_RETRY_MAX_BACKOFF_S: float = 0.5
+"""Cap on individual retry backoff -- prevents runaway sleep."""
+
+_NAMESPACE_PREFIX: str = "apm--"
+"""Mandatory prefix on every APM-deployed workflow row's primary key."""
+
+_VALID_INTERVALS: frozenset[str] = frozenset({"manual", "hourly", "daily", "weekly"})
+"""App-enforced ``CHECK (interval IN (...))`` constraint mirror."""
+
+_VALID_MODES: frozenset[str] = frozenset({"interactive", "plan", "autopilot"})
+"""Modes accepted by the app's workflow runner.  ``autopilot`` is policy-
+gated for third-party packages until package signing arrives (v3)."""
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class CopilotAppDbError(Exception):
+    """Raised for any Copilot App DB I/O failure with an actionable diagnostic.
+
+    Callers should format ``str(err)`` via ``CommandLogger.error()`` so
+    the user sees the message with an ``[x]`` symbol.  Sub-types let
+    callers branch on specific failure modes (missing DB vs schema
+    mismatch vs lock contention).
+    """
+
+
+class CopilotAppDbMissingError(CopilotAppDbError):
+    """The DB file is absent -- the Copilot App is not installed.
+
+    Actionable: install the app, or unset ``--target copilot-app``.
+    """
+
+
+class CopilotAppDbSchemaError(CopilotAppDbError):
+    """``PRAGMA user_version`` is outside our tested range.
+
+    Actionable: upgrade APM to a release that supports the new schema.
+    """
+
+
+class CopilotAppDbLockedError(CopilotAppDbError):
+    """``BEGIN IMMEDIATE`` exceeded ``_WAL_RETRY_TIMEOUT_S``.
+
+    Actionable: close the Copilot App momentarily and retry, or stop
+    whatever else is holding a long-running write.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_copilot_app_db_path() -> Path | None:
+    """Locate the Copilot App SQLite file on the current machine.
+
+    Resolution order:
+
+    1. ``APM_COPILOT_APP_DB`` environment variable (highest priority,
+       used by tests).
+    2. ``~/.copilot/data.db`` (the only documented install location for
+       the desktop app today).
+
+    Returns ``None`` when no DB file exists, signalling target
+    unavailability to the resolver.  Callers should treat this as
+    "Copilot App not installed" and skip the target (auto-detect) or
+    raise an actionable error (explicit ``--target copilot-app``).
+    """
+    env_override = os.environ.get("APM_COPILOT_APP_DB")
+    if env_override:
+        candidate = Path(env_override).expanduser()
+        return candidate if candidate.is_file() else None
+
+    home_candidate = Path.home() / _DEFAULT_DB_RELATIVE
+    return home_candidate if home_candidate.is_file() else None
+
+
+def resolve_copilot_app_root() -> Path | None:
+    """Return ``~/.copilot/`` when the Copilot App DB is present.
+
+    This is the value plugged into the ``copilot-app`` target's
+    ``user_root_resolver``: returning ``None`` makes the target invisible
+    when the app is not installed, mirroring the cowork pattern.
+    """
+    db_path = resolve_copilot_app_db_path()
+    return db_path.parent if db_path is not None else None
+
+
+# ---------------------------------------------------------------------------
+# Namespacing
+# ---------------------------------------------------------------------------
+
+
+_SLUG_RE: re.Pattern[str] = re.compile(r"[^a-zA-Z0-9_-]+")
+
+
+def _slugify(token: str) -> str:
+    """Reduce *token* to safe ASCII-alphanumeric + hyphen/underscore."""
+    return _SLUG_RE.sub("-", token).strip("-").lower() or "unknown"
+
+
+def namespaced_id(package_owner: str, package_name: str, prompt_name: str) -> str:
+    """Return the canonical workflow primary key for an APM-deployed row.
+
+    Format: ``apm--<owner>--<pkg>--<prompt>`` with each segment slugified
+    to ``[a-z0-9-]+``.  Used as both the SQL primary key and the trailing
+    segment of the lockfile URI.
+
+    The double-hyphen separator is intentional: it is invalid inside a
+    GitHub username, package name, or prompt name, so it cannot collide
+    with a user-chosen ID.
+    """
+    return (
+        f"{_NAMESPACE_PREFIX}{_slugify(package_owner)}--"
+        f"{_slugify(package_name)}--{_slugify(prompt_name)}"
+    )
+
+
+def is_apm_managed_id(workflow_id: str) -> bool:
+    """Return True if *workflow_id* uses the APM namespace prefix."""
+    return workflow_id.startswith(_NAMESPACE_PREFIX)
+
+
+# ---------------------------------------------------------------------------
+# Lockfile URI translation
+# ---------------------------------------------------------------------------
+
+
+def to_lockfile_uri(workflow_id: str) -> str:
+    """Encode a workflow row's primary key as a lockfile URI.
+
+    Returns a string like ``copilot-app-db://workflows/apm--foo--bar--baz``.
+    Raises ``ValueError`` if *workflow_id* lacks the APM namespace prefix
+    (we only ever record our own rows in the lockfile).
+    """
+    if not is_apm_managed_id(workflow_id):
+        raise ValueError(f"Refusing to lockfile-encode non-APM workflow id: {workflow_id!r}")
+    return f"{COPILOT_APP_LOCKFILE_PREFIX}{workflow_id}"
+
+
+def from_lockfile_uri(lockfile_uri: str) -> str:
+    """Decode a ``copilot-app-db://`` lockfile URI to a workflow id.
+
+    Raises ``ValueError`` if the URI does not match our scheme + table or
+    if the trailing id is not in the APM namespace.
+    """
+    if not lockfile_uri.startswith(COPILOT_APP_LOCKFILE_PREFIX):
+        raise ValueError(f"Not a copilot-app lockfile URI: {lockfile_uri!r}")
+    workflow_id = lockfile_uri[len(COPILOT_APP_LOCKFILE_PREFIX) :]
+    if not is_apm_managed_id(workflow_id):
+        raise ValueError(f"Refusing to decode non-APM workflow id from lockfile: {workflow_id!r}")
+    return workflow_id
+
+
+def is_copilot_app_uri(lockfile_path: str) -> bool:
+    """Return True if *lockfile_path* uses the copilot-app DB scheme."""
+    return lockfile_path.startswith(COPILOT_APP_URI_SCHEME)
+
+
+# ---------------------------------------------------------------------------
+# DB connection + version guard
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WorkflowRow:
+    """Subset of the ``workflows`` table columns APM writes.
+
+    Fields not listed here (``created_at``, ``updated_at``, ``project_id``,
+    ``last_run_at``, ``next_run_at``) are left to the database defaults
+    or to existing values when updating.
+    """
+
+    id: str
+    name: str
+    prompt: str
+    interval: str = "manual"
+    schedule_hour: int = 9
+    schedule_day: int = 1
+    enabled: int = 0
+    model: str | None = None
+    reasoning_effort: str | None = None
+    mode: str | None = None
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    """Open a short-lived SQLite connection with WAL-friendly settings.
+
+    * ``isolation_level=None`` -- we drive transactions explicitly via
+      ``BEGIN IMMEDIATE`` so the retry loop can observe lock errors at
+      the right moment.
+    * ``timeout=0`` -- we manage our own retry loop with backoff; the
+      built-in timeout would block too long inside a single statement.
+    """
+    conn = sqlite3.connect(str(db_path), isolation_level=None, timeout=0)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _check_user_version(conn: sqlite3.Connection) -> int:
+    """Read ``PRAGMA user_version`` and enforce the supported range.
+
+    Returns the version integer.  Raises ``CopilotAppDbSchemaError``
+    when the version is outside ``[_MIN_SUPPORTED_USER_VERSION,
+    _MAX_SUPPORTED_USER_VERSION]``.
+    """
+    cur = conn.execute("PRAGMA user_version")
+    version = int(cur.fetchone()[0])
+    if version < _MIN_SUPPORTED_USER_VERSION:
+        raise CopilotAppDbSchemaError(
+            f"Copilot App DB schema is older than supported "
+            f"(user_version={version}, need >={_MIN_SUPPORTED_USER_VERSION}). "
+            f"Update the GitHub Copilot app to a version that includes "
+            f"the workflows feature."
+        )
+    if version > _MAX_SUPPORTED_USER_VERSION:
+        raise CopilotAppDbSchemaError(
+            f"Copilot App DB schema is newer than this APM release "
+            f"supports (user_version={version}, max tested "
+            f"{_MAX_SUPPORTED_USER_VERSION}). Upgrade APM, or skip "
+            f"'--target copilot-app' until APM catches up."
+        )
+    return version
+
+
+def _begin_immediate_with_retry(conn: sqlite3.Connection) -> None:
+    """Issue ``BEGIN IMMEDIATE`` with bounded exponential backoff.
+
+    The Copilot App keeps a writer connection open while running, so a
+    naive ``BEGIN IMMEDIATE`` can collide with an in-flight app write.
+    Retry until ``_WAL_RETRY_TIMEOUT_S`` elapses, then raise
+    ``CopilotAppDbLockedError`` with an actionable diagnostic.
+    """
+    deadline = time.monotonic() + _WAL_RETRY_TIMEOUT_S
+    backoff = _WAL_RETRY_BACKOFF_S
+    last_exc: sqlite3.OperationalError | None = None
+    while True:
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            return
+        except sqlite3.OperationalError as exc:
+            # 'database is locked' and 'database is busy' are the only
+            # transient failure modes for BEGIN IMMEDIATE.  Anything else
+            # is a programming error -- let it bubble.
+            msg = str(exc).lower()
+            if "locked" not in msg and "busy" not in msg:
+                raise
+            last_exc = exc
+            if time.monotonic() >= deadline:
+                break
+            time.sleep(min(backoff, _WAL_RETRY_MAX_BACKOFF_S))
+            backoff *= 2
+    raise CopilotAppDbLockedError(
+        f"Copilot App DB stayed locked for {_WAL_RETRY_TIMEOUT_S:.1f}s. "
+        f"Close the GitHub Copilot app momentarily and retry, or stop "
+        f"any other process writing to ~/.copilot/data.db."
+    ) from last_exc
+
+
+# ---------------------------------------------------------------------------
+# Public deploy / cleanup helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_row(row: WorkflowRow) -> None:
+    """Pre-write sanity check on a ``WorkflowRow`` we are about to store.
+
+    Mirrors the app's ``CHECK`` constraints so we surface bad input as a
+    Python-level ``ValueError`` instead of a raw ``sqlite3.IntegrityError``.
+    """
+    if not is_apm_managed_id(row.id):
+        raise ValueError(f"Refusing to write non-APM workflow id: {row.id!r}")
+    if row.interval not in _VALID_INTERVALS:
+        raise ValueError(
+            f"Invalid interval {row.interval!r}; expected one of {sorted(_VALID_INTERVALS)}"
+        )
+    if row.mode is not None and row.mode not in _VALID_MODES:
+        raise ValueError(f"Invalid mode {row.mode!r}; expected one of {sorted(_VALID_MODES)}")
+    if not (0 <= row.schedule_hour <= 23):
+        raise ValueError(f"Invalid schedule_hour {row.schedule_hour}; expected 0..23")
+    if not (0 <= row.schedule_day <= 6):
+        raise ValueError(f"Invalid schedule_day {row.schedule_day}; expected 0..6")
+    if row.enabled not in (0, 1):
+        raise ValueError(f"Invalid enabled {row.enabled}; expected 0 or 1")
+
+
+def deploy_workflow(db_path: Path, row: WorkflowRow) -> str:
+    """Insert or update a single workflow row owned by APM.
+
+    On INSERT the row arrives with whatever the caller passed.  On
+    UPDATE the user-controlled fields ``enabled``, ``last_run_at``,
+    ``next_run_at`` are preserved from whatever the app last wrote --
+    APM never overwrites the user's enable toggle or run history.
+
+    Returns the lockfile URI for the deployed row.
+
+    Raises:
+        CopilotAppDbMissingError: ``db_path`` does not exist.
+        CopilotAppDbSchemaError: ``PRAGMA user_version`` is out of range.
+        CopilotAppDbLockedError: write transaction could not be acquired.
+        ValueError: ``row`` fails ``_validate_row``.
+    """
+    _validate_row(row)
+    if not db_path.is_file():
+        raise CopilotAppDbMissingError(
+            f"Copilot App database not found at {db_path}. "
+            f"Install the GitHub Copilot desktop app, or remove "
+            f"'--target copilot-app' from this install."
+        )
+
+    conn = _connect(db_path)
+    try:
+        _check_user_version(conn)
+        _begin_immediate_with_retry(conn)
+        try:
+            existing = conn.execute(
+                "SELECT enabled, last_run_at, next_run_at FROM workflows WHERE id = ?",
+                (row.id,),
+            ).fetchone()
+            if existing is None:
+                conn.execute(
+                    """
+                    INSERT INTO workflows (
+                        id, name, prompt, model, reasoning_effort,
+                        interval, schedule_hour, schedule_day,
+                        enabled, mode
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        row.id,
+                        row.name,
+                        row.prompt,
+                        row.model,
+                        row.reasoning_effort,
+                        row.interval,
+                        row.schedule_hour,
+                        row.schedule_day,
+                        row.enabled,
+                        row.mode,
+                    ),
+                )
+            else:
+                conn.execute(
+                    """
+                    UPDATE workflows
+                       SET name = ?,
+                           prompt = ?,
+                           model = ?,
+                           reasoning_effort = ?,
+                           interval = ?,
+                           schedule_hour = ?,
+                           schedule_day = ?,
+                           mode = ?,
+                           updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+                     WHERE id = ?
+                    """,
+                    (
+                        row.name,
+                        row.prompt,
+                        row.model,
+                        row.reasoning_effort,
+                        row.interval,
+                        row.schedule_hour,
+                        row.schedule_day,
+                        row.mode,
+                        row.id,
+                    ),
+                )
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+    finally:
+        conn.close()
+
+    return to_lockfile_uri(row.id)
+
+
+def delete_workflows(db_path: Path, workflow_ids: list[str]) -> int:
+    """Delete one or more APM-namespaced workflow rows.
+
+    Refuses to delete any id that does not pass ``is_apm_managed_id`` --
+    this is the last line of defence against an uninstall removing a
+    user-authored row.
+
+    Returns the number of rows actually removed.  Missing ids are
+    silently ignored (uninstall is idempotent).
+    """
+    if not db_path.is_file():
+        # Idempotent: if the app/DB is gone, the rows are gone.
+        return 0
+    for wid in workflow_ids:
+        if not is_apm_managed_id(wid):
+            raise ValueError(f"Refusing to delete non-APM workflow id: {wid!r}")
+    if not workflow_ids:
+        return 0
+
+    conn = _connect(db_path)
+    removed = 0
+    try:
+        _check_user_version(conn)
+        _begin_immediate_with_retry(conn)
+        try:
+            placeholders = ",".join("?" for _ in workflow_ids)
+            cur = conn.execute(
+                f"DELETE FROM workflows WHERE id IN ({placeholders})",  # noqa: S608
+                workflow_ids,
+            )
+            removed = cur.rowcount
+            conn.execute("COMMIT")
+        except Exception:
+            conn.execute("ROLLBACK")
+            raise
+    finally:
+        conn.close()
+    return removed
+
+
+def list_managed_workflow_ids(db_path: Path) -> list[str]:
+    """Return all APM-namespaced workflow ids currently in the DB.
+
+    Read-only; takes no transaction.  Used by drift-detection and by
+    ``apm list`` to surface what's actually deployed.  Returns the empty
+    list when the DB is missing.
+    """
+    if not db_path.is_file():
+        return []
+    conn = _connect(db_path)
+    try:
+        cur = conn.execute(
+            "SELECT id FROM workflows WHERE id LIKE ? ORDER BY id",
+            (f"{_NAMESPACE_PREFIX}%",),
+        )
+        return [r[0] for r in cur.fetchall()]
+    finally:
+        conn.close()

--- a/src/apm_cli/integration/copilot_app_db.py
+++ b/src/apm_cli/integration/copilot_app_db.py
@@ -97,9 +97,16 @@ _NAMESPACE_PREFIX: str = "apm--"
 _VALID_INTERVALS: frozenset[str] = frozenset({"manual", "hourly", "daily", "weekly"})
 """App-enforced ``CHECK (interval IN (...))`` constraint mirror."""
 
-_VALID_MODES: frozenset[str] = frozenset({"interactive", "plan", "autopilot"})
-"""Modes accepted by the app's workflow runner.  ``autopilot`` is policy-
-gated for third-party packages until package signing arrives (v3)."""
+_VALID_MODES: frozenset[str] = frozenset({"interactive", "plan"})
+"""Modes accepted via the ``copilot-app`` target.
+
+The Copilot App's runtime also defines an ``autopilot`` mode, but APM
+intentionally does NOT accept it here: until package signing ships
+(v3), a third-party package could declare ``mode: autopilot`` and have
+the App auto-run its prompt the moment a user flips the in-App enable
+toggle.  Refusing autopilot at the writer is the secure-by-default
+behaviour; users who want autopilot can still set it themselves in the
+App UI on a per-row basis."""
 
 
 # ---------------------------------------------------------------------------
@@ -381,9 +388,19 @@ def deploy_workflow(db_path: Path, row: WorkflowRow) -> str:
     """Insert or update a single workflow row owned by APM.
 
     On INSERT the row arrives with whatever the caller passed.  On
-    UPDATE the user-controlled fields ``enabled``, ``last_run_at``,
-    ``next_run_at`` are preserved from whatever the app last wrote --
-    APM never overwrites the user's enable toggle or run history.
+    UPDATE behaviour depends on whether execution-affecting fields
+    changed:
+
+    * If ``prompt``, ``mode``, ``interval``, ``schedule_hour``,
+      ``schedule_day``, ``model``, or ``reasoning_effort`` differs from
+      the row already in the DB, the user's ``enabled`` opt-in is
+      revoked (``enabled = 0``) and the App's ``next_run_at`` is
+      cleared.  Rationale: the user opted in to a specific prompt body
+      and schedule; a content update is a NEW consent surface.
+      Preserving ``enabled`` across content changes would be a silent
+      malicious-update vector.
+    * Otherwise (e.g. only ``name`` changed), ``enabled``,
+      ``last_run_at``, and ``next_run_at`` are preserved.
 
     Returns the lockfile URI for the deployed row.
 
@@ -397,8 +414,8 @@ def deploy_workflow(db_path: Path, row: WorkflowRow) -> str:
     if not db_path.is_file():
         raise CopilotAppDbMissingError(
             f"Copilot App database not found at {db_path}. "
-            f"Install the GitHub Copilot desktop app, or remove "
-            f"'--target copilot-app' from this install."
+            f"Install the GitHub Copilot desktop app, or omit "
+            f"'--target copilot-app'."
         )
 
     conn = _connect(db_path)
@@ -407,7 +424,11 @@ def deploy_workflow(db_path: Path, row: WorkflowRow) -> str:
         _begin_immediate_with_retry(conn)
         try:
             existing = conn.execute(
-                "SELECT enabled, last_run_at, next_run_at FROM workflows WHERE id = ?",
+                """
+                SELECT prompt, mode, interval, schedule_hour, schedule_day,
+                       model, reasoning_effort
+                  FROM workflows WHERE id = ?
+                """,
                 (row.id,),
             ).fetchone()
             if existing is None:
@@ -433,32 +454,54 @@ def deploy_workflow(db_path: Path, row: WorkflowRow) -> str:
                     ),
                 )
             else:
-                conn.execute(
-                    """
-                    UPDATE workflows
-                       SET name = ?,
-                           prompt = ?,
-                           model = ?,
-                           reasoning_effort = ?,
-                           interval = ?,
-                           schedule_hour = ?,
-                           schedule_day = ?,
-                           mode = ?,
-                           updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
-                     WHERE id = ?
-                    """,
-                    (
-                        row.name,
-                        row.prompt,
-                        row.model,
-                        row.reasoning_effort,
-                        row.interval,
-                        row.schedule_hour,
-                        row.schedule_day,
-                        row.mode,
-                        row.id,
-                    ),
+                execution_changed = (
+                    existing["prompt"] != row.prompt
+                    or existing["mode"] != row.mode
+                    or existing["interval"] != row.interval
+                    or existing["schedule_hour"] != row.schedule_hour
+                    or existing["schedule_day"] != row.schedule_day
+                    or existing["model"] != row.model
+                    or existing["reasoning_effort"] != row.reasoning_effort
                 )
+                if execution_changed:
+                    conn.execute(
+                        """
+                        UPDATE workflows
+                           SET name = ?,
+                               prompt = ?,
+                               model = ?,
+                               reasoning_effort = ?,
+                               interval = ?,
+                               schedule_hour = ?,
+                               schedule_day = ?,
+                               mode = ?,
+                               enabled = 0,
+                               next_run_at = NULL,
+                               updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+                         WHERE id = ?
+                        """,
+                        (
+                            row.name,
+                            row.prompt,
+                            row.model,
+                            row.reasoning_effort,
+                            row.interval,
+                            row.schedule_hour,
+                            row.schedule_day,
+                            row.mode,
+                            row.id,
+                        ),
+                    )
+                else:
+                    conn.execute(
+                        """
+                        UPDATE workflows
+                           SET name = ?,
+                               updated_at = strftime('%Y-%m-%dT%H:%M:%fZ','now')
+                         WHERE id = ?
+                        """,
+                        (row.name, row.id),
+                    )
             conn.execute("COMMIT")
         except Exception:
             conn.execute("ROLLBACK")

--- a/src/apm_cli/integration/prompt_integrator.py
+++ b/src/apm_cli/integration/prompt_integrator.py
@@ -421,7 +421,10 @@ class PromptIntegrator(BaseIntegrator):
 from dataclasses import dataclass  # noqa: E402
 
 _VALID_SCHEDULE_INTERVALS: frozenset[str] = frozenset({"manual", "hourly", "daily", "weekly"})
-_VALID_SCHEDULE_MODES: frozenset[str] = frozenset({"interactive", "plan", "autopilot"})
+_VALID_SCHEDULE_MODES: frozenset[str] = frozenset({"interactive", "plan"})
+"""Mirror of ``copilot_app_db._VALID_MODES``.  ``autopilot`` is
+deliberately omitted -- see that module's docstring for the
+secure-by-default rationale."""
 
 
 @dataclass(frozen=True)

--- a/src/apm_cli/integration/prompt_integrator.py
+++ b/src/apm_cli/integration/prompt_integrator.py
@@ -80,6 +80,17 @@ class PromptIntegrator(BaseIntegrator):
         if not mapping:
             return IntegrationResult(0, 0, 0, [])
 
+        # GitHub Copilot desktop App: deploy to SQLite instead of files.
+        # The branch fully owns lifecycle for this target -- it does not
+        # share the file-based collision / link-resolution machinery.
+        if target.name == "copilot-app":
+            return self._integrate_prompts_for_copilot_app(
+                target,
+                package_info,
+                force=force,
+                diagnostics=diagnostics,
+            )
+
         if not target.auto_create and not (project_root / target.root_dir).is_dir():
             return IntegrationResult(0, 0, 0, [])
 
@@ -102,6 +113,10 @@ class PromptIntegrator(BaseIntegrator):
         mapping = target.primitives.get("prompts")
         if not mapping:
             return {"files_removed": 0, "errors": 0}
+
+        if target.name == "copilot-app":
+            return self._sync_copilot_app(managed_files or set())
+
         effective_root = mapping.deploy_root or target.root_dir
         prefix = f"{effective_root}/{mapping.subdir}/"
         legacy_dir = project_root / effective_root / mapping.subdir
@@ -113,6 +128,162 @@ class PromptIntegrator(BaseIntegrator):
             legacy_glob_pattern="*-apm.prompt.md",
             targets=[target],
         )
+
+    # ------------------------------------------------------------------
+    # copilot-app SQLite path
+    # ------------------------------------------------------------------
+
+    def _integrate_prompts_for_copilot_app(
+        self,
+        target: TargetProfile,
+        package_info,
+        *,
+        force: bool,
+        diagnostics,
+    ) -> IntegrationResult:
+        """Deploy ``schedule:``-bearing prompts as Copilot App workflow rows.
+
+        Prompts WITHOUT a ``schedule:`` block are silently skipped at
+        the copilot-app target -- the target is opt-in via frontmatter
+        so unscheduled prompts continue to deploy to file-based targets
+        (``copilot``, ``vscode``, ...) without surprising side effects
+        here.
+
+        The DB module enforces ``enabled = 0`` on insert; the source
+        ``schedule.enabled`` field, if present, is ignored.  This is a
+        hard contract: third-party packages cannot auto-run anything on
+        the user's machine.
+        """
+        import frontmatter
+
+        from apm_cli.integration.copilot_app_db import (
+            CopilotAppDbError,
+            WorkflowRow,
+            deploy_workflow,
+            namespaced_id,
+            resolve_copilot_app_db_path,
+        )
+
+        db_path = resolve_copilot_app_db_path()
+        if db_path is None:
+            # Surfaced as an actionable error by install/phases/targets.py
+            # when --target copilot-app was explicit; here we are
+            # defensive in case the resolver returns None mid-run.
+            return IntegrationResult(0, 0, 0, [])
+
+        owner = _derive_package_owner(package_info)
+        pkg_name = package_info.package.name
+
+        files_integrated = 0
+        files_skipped = 0
+        target_paths: list[Path] = []
+        synthetic_root = db_path.parent / "workflows"
+
+        for source_file in self.find_prompt_files(package_info.install_path):
+            if source_file.is_symlink():
+                if diagnostics is not None:
+                    diagnostics.warn(
+                        message=f"Refusing to read symlink prompt: {source_file}",
+                        package=pkg_name,
+                    )
+                files_skipped += 1
+                continue
+            post = frontmatter.load(str(source_file))
+            schedule_block = post.metadata.get("schedule")
+            if schedule_block is None:
+                files_skipped += 1
+                continue
+            try:
+                schedule = _parse_schedule(schedule_block)
+            except ValueError as exc:
+                if diagnostics is not None:
+                    diagnostics.warn(
+                        message=f"Invalid schedule in {source_file.name}: {exc}",
+                        package=pkg_name,
+                    )
+                files_skipped += 1
+                continue
+            prompt_stem = source_file.name.removesuffix(".prompt.md")
+            wf_id = namespaced_id(owner, pkg_name, prompt_stem)
+            display_name = post.metadata.get("name") or prompt_stem
+            row = WorkflowRow(
+                id=wf_id,
+                name=str(display_name),
+                prompt=post.content,
+                interval=schedule.interval,
+                schedule_hour=schedule.schedule_hour,
+                schedule_day=schedule.schedule_day,
+                enabled=0,  # ALWAYS disabled on install -- contract.
+                model=schedule.model,
+                reasoning_effort=schedule.reasoning_effort,
+                mode=schedule.mode,
+            )
+            try:
+                deploy_workflow(db_path, row)
+            except CopilotAppDbError as exc:
+                if diagnostics is not None:
+                    diagnostics.warn(
+                        message=f"Could not deploy {prompt_stem!r} to Copilot App: {exc}",
+                        package=pkg_name,
+                    )
+                files_skipped += 1
+                continue
+            files_integrated += 1
+            # Synthetic path used purely for lockfile encoding -- the
+            # services._deployed_path_entry copilot-app branch will
+            # convert this to a ``copilot-app-db://`` URI.
+            target_paths.append(synthetic_root / wf_id)
+
+        return IntegrationResult(
+            files_integrated=files_integrated,
+            files_updated=0,
+            files_skipped=files_skipped,
+            target_paths=target_paths,
+            links_resolved=0,
+            files_adopted=0,
+        )
+
+    def _sync_copilot_app(self, managed_files: set[str]) -> dict[str, int]:
+        """Remove Copilot App workflow rows referenced by *managed_files*.
+
+        Filters the input set to ``copilot-app-db://workflows/`` URIs,
+        decodes the workflow ids, and deletes them in a single
+        transaction.  Non-APM-namespaced ids are rejected by
+        ``copilot_app_db.delete_workflows`` for defence in depth.
+        """
+        from apm_cli.integration.copilot_app_db import (
+            COPILOT_APP_LOCKFILE_PREFIX,
+            CopilotAppDbError,
+            delete_workflows,
+            from_lockfile_uri,
+            is_copilot_app_uri,
+            resolve_copilot_app_db_path,
+        )
+
+        ids: list[str] = []
+        for entry in managed_files:
+            if not is_copilot_app_uri(entry):
+                continue
+            if not entry.startswith(COPILOT_APP_LOCKFILE_PREFIX):
+                continue
+            try:
+                ids.append(from_lockfile_uri(entry))
+            except ValueError:
+                # Malformed entry -- skip rather than fail uninstall.
+                continue
+        if not ids:
+            return {"files_removed": 0, "errors": 0}
+
+        db_path = resolve_copilot_app_db_path()
+        if db_path is None:
+            # DB gone -- nothing to remove; treat as success (idempotent).
+            return {"files_removed": 0, "errors": 0}
+
+        try:
+            removed = delete_workflows(db_path, ids)
+        except CopilotAppDbError:
+            return {"files_removed": 0, "errors": 1}
+        return {"files_removed": removed, "errors": 0}
 
     # ------------------------------------------------------------------
     # Legacy per-target API (DEPRECATED)
@@ -241,3 +412,101 @@ class PromptIntegrator(BaseIntegrator):
             legacy_glob_dir=prompts_dir,
             legacy_glob_pattern="*-apm.prompt.md",
         )
+
+
+# ---------------------------------------------------------------------------
+# Schedule frontmatter helpers (copilot-app target)
+# ---------------------------------------------------------------------------
+
+from dataclasses import dataclass  # noqa: E402
+
+_VALID_SCHEDULE_INTERVALS: frozenset[str] = frozenset({"manual", "hourly", "daily", "weekly"})
+_VALID_SCHEDULE_MODES: frozenset[str] = frozenset({"interactive", "plan", "autopilot"})
+
+
+@dataclass(frozen=True)
+class Schedule:
+    """Validated representation of a prompt's ``schedule:`` frontmatter.
+
+    All fields are pre-validated against the same constraints the
+    Copilot App's ``workflows`` schema enforces, so deploy time never
+    surfaces a raw SQLite ``CHECK`` violation to the user.
+    """
+
+    interval: str = "manual"
+    schedule_hour: int = 9
+    schedule_day: int = 1
+    mode: str | None = None
+    model: str | None = None
+    reasoning_effort: str | None = None
+
+
+def _parse_schedule(block) -> Schedule:
+    """Validate a frontmatter ``schedule:`` mapping and return a ``Schedule``.
+
+    Raises ``ValueError`` (with a human-readable message) on any
+    out-of-range or wrong-type field.  The caller turns the message
+    into a diagnostic warning and skips the prompt.
+    """
+    if not isinstance(block, dict):
+        raise ValueError("'schedule' must be a mapping")
+
+    interval = str(block.get("interval", "manual"))
+    if interval not in _VALID_SCHEDULE_INTERVALS:
+        raise ValueError(
+            f"interval must be one of {sorted(_VALID_SCHEDULE_INTERVALS)}, got {interval!r}"
+        )
+
+    hour = block.get("schedule_hour", 9)
+    if not isinstance(hour, int) or not (0 <= hour <= 23):
+        raise ValueError(f"schedule_hour must be int 0..23, got {hour!r}")
+
+    day = block.get("schedule_day", 1)
+    if not isinstance(day, int) or not (0 <= day <= 6):
+        raise ValueError(f"schedule_day must be int 0..6, got {day!r}")
+
+    mode = block.get("mode")
+    if mode is not None:
+        mode = str(mode)
+        if mode not in _VALID_SCHEDULE_MODES:
+            raise ValueError(f"mode must be one of {sorted(_VALID_SCHEDULE_MODES)}, got {mode!r}")
+
+    model = block.get("model")
+    if model is not None and not isinstance(model, str):
+        raise ValueError(f"model must be a string, got {model!r}")
+
+    reasoning_effort = block.get("reasoning_effort")
+    if reasoning_effort is not None and not isinstance(reasoning_effort, str):
+        raise ValueError(f"reasoning_effort must be a string, got {reasoning_effort!r}")
+
+    return Schedule(
+        interval=interval,
+        schedule_hour=hour,
+        schedule_day=day,
+        mode=mode,
+        model=model,
+        reasoning_effort=reasoning_effort,
+    )
+
+
+def _derive_package_owner(package_info) -> str:
+    """Best-effort owner-segment extraction for namespacing workflow ids.
+
+    Looks at the package's ``source`` (GitHub-style ``owner/repo`` or
+    URL) first, then ``author``, then falls back to ``"local"`` for
+    locally-sourced packages.  The returned string is slugified by the
+    DB-side ``namespaced_id`` helper, so any input is safe.
+    """
+    pkg = package_info.package
+    source = getattr(pkg, "source", None)
+    if isinstance(source, str) and source:
+        # github:foo/bar, https://github.com/foo/bar, foo/bar
+        s = source.split("://", 1)[-1]
+        s = s.split(":", 1)[-1]
+        parts = [p for p in s.split("/") if p and p != "github.com"]
+        if parts:
+            return parts[0]
+    author = getattr(pkg, "author", None)
+    if isinstance(author, str) and author.strip():
+        return author.strip()
+    return "local"

--- a/src/apm_cli/integration/prompt_integrator.py
+++ b/src/apm_cli/integration/prompt_integrator.py
@@ -141,18 +141,20 @@ class PromptIntegrator(BaseIntegrator):
         force: bool,
         diagnostics,
     ) -> IntegrationResult:
-        """Deploy ``schedule:``-bearing prompts as Copilot App workflow rows.
+        """Deploy workflow-shape prompts as Copilot App workflow rows.
 
-        Prompts WITHOUT a ``schedule:`` block are silently skipped at
-        the copilot-app target -- the target is opt-in via frontmatter
-        so unscheduled prompts continue to deploy to file-based targets
-        (``copilot``, ``vscode``, ...) without surprising side effects
-        here.
+        Workflow-shape (per ``_is_workflow_shape``) prompts deploy here.
+        Plain-shape prompts (no execution-affecting frontmatter keys)
+        are a hard error at this target: the user explicitly opted into
+        ``copilot-app`` for this package, and a plain prompt cannot
+        possibly be a workflow.  Surfacing the mismatch loudly beats
+        silently skipping the file and leaving the user wondering why
+        nothing landed in the App.
 
-        The DB module enforces ``enabled = 0`` on insert; the source
-        ``schedule.enabled`` field, if present, is ignored.  This is a
-        hard contract: third-party packages cannot auto-run anything on
-        the user's machine.
+        The DB module enforces ``enabled = 0`` on insert; any frontmatter
+        ``enabled`` field, if present, is ignored.  This is a hard
+        contract: third-party packages cannot auto-run anything on the
+        user's machine.
         """
         import frontmatter
 
@@ -166,9 +168,6 @@ class PromptIntegrator(BaseIntegrator):
 
         db_path = resolve_copilot_app_db_path()
         if db_path is None:
-            # Surfaced as an actionable error by install/phases/targets.py
-            # when --target copilot-app was explicit; here we are
-            # defensive in case the resolver returns None mid-run.
             return IntegrationResult(0, 0, 0, [])
 
         owner = _derive_package_owner(package_info)
@@ -189,16 +188,29 @@ class PromptIntegrator(BaseIntegrator):
                 files_skipped += 1
                 continue
             post = frontmatter.load(str(source_file))
-            schedule_block = post.metadata.get("schedule")
-            if schedule_block is None:
+            if not _is_workflow_shape(post.metadata):
+                # Plain prompt at copilot-app target -- hard error.
+                # Authors who want a workflow add an execution-shape
+                # key (e.g. ``interval: manual``); a plain prompt has
+                # no business in the App's workflows table.
+                if diagnostics is not None:
+                    diagnostics.warn(
+                        message=(
+                            f"Copilot App: {source_file.name} has no workflow frontmatter "
+                            "(missing one of: interval, schedule_hour, schedule_day). "
+                            "Add `interval: manual` to deploy it as a manual-trigger "
+                            "workflow, or unset --target copilot-app."
+                        ),
+                        package=pkg_name,
+                    )
                 files_skipped += 1
                 continue
             try:
-                schedule = _parse_schedule(schedule_block)
+                schedule = _parse_workflow_frontmatter(post.metadata)
             except ValueError as exc:
                 if diagnostics is not None:
                     diagnostics.warn(
-                        message=f"Invalid schedule in {source_file.name}: {exc}",
+                        message=f"Invalid workflow frontmatter in {source_file.name}: {exc}",
                         package=pkg_name,
                     )
                 files_skipped += 1
@@ -229,9 +241,6 @@ class PromptIntegrator(BaseIntegrator):
                 files_skipped += 1
                 continue
             files_integrated += 1
-            # Synthetic path used purely for lockfile encoding -- the
-            # services._deployed_path_entry copilot-app branch will
-            # convert this to a ``copilot-app-db://`` URI.
             target_paths.append(synthetic_root / wf_id)
 
         return IntegrationResult(
@@ -345,7 +354,23 @@ class PromptIntegrator(BaseIntegrator):
         target_paths = []
         total_links_resolved = 0
 
+        import frontmatter as _fm
+
         for source_file in prompt_files:
+            # Skip workflow-shape prompts at file-based targets: an
+            # author who added execution metadata (interval, mode, ...)
+            # meant the Copilot App workflows table, NOT a slash command
+            # in .github/prompts/.  Without this guard, the same source
+            # file ships to both surfaces and the App-only metadata
+            # leaks into a slash-command users would not expect.
+            try:
+                _meta = _fm.load(str(source_file)).metadata
+            except Exception:
+                _meta = {}
+            if _is_workflow_shape(_meta):
+                files_skipped += 1
+                continue
+
             target_filename = self.get_target_filename(source_file, package_info.package.name)
             target_path = prompts_dir / target_filename
             # Defense-in-depth: target_filename is derived from source
@@ -426,14 +451,52 @@ _VALID_SCHEDULE_MODES: frozenset[str] = frozenset({"interactive", "plan"})
 deliberately omitted -- see that module's docstring for the
 secure-by-default rationale."""
 
+# Top-level frontmatter keys that mark a ``.prompt.md`` as a "workflow"
+# (i.e. a prompt with execution metadata, destined for the Copilot App
+# DB rather than slash-command file targets).  Touching ANY of these
+# keys at the top level of the frontmatter flips the dispatch shape.
+#
+# This is the Option B "dispatch by shape" predicate -- one folder
+# (``.apm/prompts/``), one extension (``.prompt.md``), one integrator.
+# A file with these keys ships to ``copilot-app`` and is skipped by
+# slash-command targets; a file without them ships to slash-command
+# targets and hard-errors at ``copilot-app``.
+_WORKFLOW_SHAPE_KEYS: frozenset[str] = frozenset({"interval", "schedule_hour", "schedule_day"})
+
+
+def _is_workflow_shape(frontmatter_meta: dict) -> bool:
+    """Return True iff *frontmatter_meta* declares Copilot App execution metadata.
+
+    Used to decide which target(s) a ``.prompt.md`` file is destined
+    for.  The check is intentionally a SHAPE check rather than a flag
+    -- authors do not opt in with a sentinel; the presence of an
+    execution-affecting key is the opt-in.
+
+    Only ``interval``, ``schedule_hour``, ``schedule_day`` are
+    unambiguous workflow markers.  ``mode``, ``model``, and
+    ``reasoning_effort`` are deliberately EXCLUDED because they overload
+    with plain slash-command prompts: VSCode / Copilot prompts use
+    ``mode: agent|ask|edit``, can pin a ``model``, and can hint
+    ``reasoning_effort``.  Treating those keys as workflow markers
+    would mis-route ordinary slash commands to the App DB.  Authors who
+    want a manual-only workflow opt in with the explicit
+    ``interval: manual``.
+    """
+    if not isinstance(frontmatter_meta, dict):
+        return False
+    return any(k in frontmatter_meta for k in _WORKFLOW_SHAPE_KEYS)
+
 
 @dataclass(frozen=True)
 class Schedule:
-    """Validated representation of a prompt's ``schedule:`` frontmatter.
+    """Validated representation of a prompt's workflow frontmatter.
 
     All fields are pre-validated against the same constraints the
     Copilot App's ``workflows`` schema enforces, so deploy time never
     surfaces a raw SQLite ``CHECK`` violation to the user.
+
+    Sourced from top-level frontmatter keys (Option B: flat dispatch
+    shape), not from a nested ``schedule:`` block.
     """
 
     interval: str = "manual"
@@ -444,41 +507,56 @@ class Schedule:
     reasoning_effort: str | None = None
 
 
-def _parse_schedule(block) -> Schedule:
-    """Validate a frontmatter ``schedule:`` mapping and return a ``Schedule``.
+def _parse_workflow_frontmatter(meta: dict) -> Schedule:
+    """Validate top-level workflow frontmatter keys and return a ``Schedule``.
+
+    Reads ``interval``, ``schedule_hour``, ``schedule_day``, ``mode``,
+    ``model``, ``reasoning_effort`` directly from the prompt's
+    frontmatter.  ``interval`` defaults to ``"manual"`` when any other
+    execution-shape key is present but ``interval`` is omitted -- a
+    manual-only workflow is the conservative default given the Copilot
+    App's universal "run now" affordance.
 
     Raises ``ValueError`` (with a human-readable message) on any
-    out-of-range or wrong-type field.  The caller turns the message
-    into a diagnostic warning and skips the prompt.
+    out-of-range or wrong-type field.  ``mode: autopilot`` is rejected
+    here with a targeted diagnostic before it can hit the DB layer's
+    generic CHECK violation -- third-party packages cannot ship
+    autopilot prompts; the user must opt in from the App UI.
     """
-    if not isinstance(block, dict):
-        raise ValueError("'schedule' must be a mapping")
+    if not isinstance(meta, dict):
+        raise ValueError("frontmatter must be a mapping")
 
-    interval = str(block.get("interval", "manual"))
+    interval = str(meta.get("interval", "manual"))
     if interval not in _VALID_SCHEDULE_INTERVALS:
         raise ValueError(
             f"interval must be one of {sorted(_VALID_SCHEDULE_INTERVALS)}, got {interval!r}"
         )
 
-    hour = block.get("schedule_hour", 9)
+    hour = meta.get("schedule_hour", 9)
     if not isinstance(hour, int) or not (0 <= hour <= 23):
         raise ValueError(f"schedule_hour must be int 0..23, got {hour!r}")
 
-    day = block.get("schedule_day", 1)
+    day = meta.get("schedule_day", 1)
     if not isinstance(day, int) or not (0 <= day <= 6):
         raise ValueError(f"schedule_day must be int 0..6, got {day!r}")
 
-    mode = block.get("mode")
+    mode = meta.get("mode")
     if mode is not None:
         mode = str(mode)
+        if mode == "autopilot":
+            raise ValueError(
+                "mode 'autopilot' is not accepted via apm install -- "
+                "APM does not deploy workflows on autopilot. "
+                "Set autopilot manually in the Copilot App after enabling the row."
+            )
         if mode not in _VALID_SCHEDULE_MODES:
             raise ValueError(f"mode must be one of {sorted(_VALID_SCHEDULE_MODES)}, got {mode!r}")
 
-    model = block.get("model")
+    model = meta.get("model")
     if model is not None and not isinstance(model, str):
         raise ValueError(f"model must be a string, got {model!r}")
 
-    reasoning_effort = block.get("reasoning_effort")
+    reasoning_effort = meta.get("reasoning_effort")
     if reasoning_effort is not None and not isinstance(reasoning_effort, str):
         raise ValueError(f"reasoning_effort must be a string, got {reasoning_effort!r}")
 
@@ -490,6 +568,11 @@ def _parse_schedule(block) -> Schedule:
         model=model,
         reasoning_effort=reasoning_effort,
     )
+
+
+# Back-compat alias retained for test imports; new code should use
+# ``_parse_workflow_frontmatter`` directly.
+_parse_schedule = _parse_workflow_frontmatter
 
 
 def _derive_package_owner(package_info) -> str:

--- a/src/apm_cli/integration/targets.py
+++ b/src/apm_cli/integration/targets.py
@@ -123,6 +123,20 @@ class TargetProfile:
     in ``KNOWN_TARGETS`` for tooling introspection.
     """
 
+    scope_invariant_resolver: bool = False
+    """When True, ``user_root_resolver`` runs in BOTH project and user
+    scope (the resolved deploy root does not depend on install intent).
+
+    Set this for targets whose deploy root is a user-machine resource
+    that exists regardless of who triggered the install -- e.g.
+    ``copilot-app`` (the GitHub Copilot desktop App's SQLite DB at
+    ``~/.copilot/data.db`` is the same path whether a team-shared
+    workflow comes in via project ``apm.yml`` or user-scope ``--global``).
+
+    Contrast with cowork, where the OneDrive deploy root only makes
+    sense at user scope; project-scope cowork is intentionally rejected.
+    """
+
     generated_files: tuple[str, ...] = ()
     """Additional generated files associated with this target.
 
@@ -248,6 +262,19 @@ class TargetProfile:
         All downstream code reads ``target.root_dir`` directly.
         """
         if not user_scope:
+            # Most targets have no project-scope resolver work to do.
+            # The scope_invariant_resolver opt-in lets a target whose
+            # deploy root is a user-machine resource (e.g. copilot-app's
+            # ~/.copilot/data.db) populate resolved_deploy_root even when
+            # the install intent is project-scope. Downstream lockfile
+            # enrichment then routes via the dynamic-root URI path.
+            if self.scope_invariant_resolver and self.user_root_resolver is not None:
+                resolved_root = self.user_root_resolver()
+                if resolved_root is None:
+                    return None
+                from dataclasses import replace
+
+                return replace(self, resolved_deploy_root=resolved_root)
             return self
 
         from dataclasses import replace
@@ -594,6 +621,7 @@ KNOWN_TARGETS: dict[str, TargetProfile] = {
         user_supported=True,
         user_root_resolver=lambda: _resolve_copilot_app_root(),
         requires_flag="copilot_app",
+        scope_invariant_resolver=True,
     ),
 }
 

--- a/src/apm_cli/integration/targets.py
+++ b/src/apm_cli/integration/targets.py
@@ -601,8 +601,12 @@ KNOWN_TARGETS: dict[str, TargetProfile] = {
         requires_flag="copilot_cowork",
     ),
     # GitHub Copilot desktop App -- experimental, user-scope only.
-    # Prompts with ``schedule:`` frontmatter are installed as rows in the
-    # app's ``workflows`` table at ``~/.copilot/data.db``.  No files are
+    # Prompts whose frontmatter carries workflow-shape keys (``interval``,
+    # ``schedule_hour``, ``schedule_day``) are installed as rows in the
+    # app's ``workflows`` table at ``~/.copilot/data.db``.  ``mode`` /
+    # ``model`` / ``reasoning_effort`` are optional fields on a workflow
+    # but do NOT mark a plain prompt as a workflow (they overload with
+    # plain VSCode / Copilot slash-command prompts).  No files are
     # written under the deploy root; the synthetic root is only used so
     # the existing target machinery can address rows via the
     # ``copilot-app-db://workflows/<id>`` lockfile URI scheme.

--- a/src/apm_cli/integration/targets.py
+++ b/src/apm_cli/integration/targets.py
@@ -573,6 +573,28 @@ KNOWN_TARGETS: dict[str, TargetProfile] = {
         user_root_resolver=lambda: _resolve_copilot_cowork_root(),
         requires_flag="copilot_cowork",
     ),
+    # GitHub Copilot desktop App -- experimental, user-scope only.
+    # Prompts with ``schedule:`` frontmatter are installed as rows in the
+    # app's ``workflows`` table at ``~/.copilot/data.db``.  No files are
+    # written under the deploy root; the synthetic root is only used so
+    # the existing target machinery can address rows via the
+    # ``copilot-app-db://workflows/<id>`` lockfile URI scheme.
+    "copilot-app": TargetProfile(
+        name="copilot-app",
+        root_dir="copilot-app",  # display grouping placeholder only
+        primitives={
+            "prompts": PrimitiveMapping(
+                "workflows",
+                ".prompt.md",
+                "prompt_standard",
+            ),
+        },
+        auto_create=False,
+        detect_by_dir=False,
+        user_supported=True,
+        user_root_resolver=lambda: _resolve_copilot_app_root(),
+        requires_flag="copilot_app",
+    ),
 }
 
 
@@ -625,6 +647,19 @@ def _resolve_copilot_cowork_root() -> Path | None:  # noqa: F821
     from apm_cli.integration.copilot_cowork_paths import resolve_copilot_cowork_skills_dir
 
     return resolve_copilot_cowork_skills_dir()
+
+
+def _resolve_copilot_app_root() -> Path | None:  # noqa: F821
+    """Thin wrapper around ``copilot_app_db.resolve_copilot_app_root()``.
+
+    Used as the ``user_root_resolver`` callable for the ``copilot-app``
+    target.  Returns ``~/.copilot/`` only when the app's SQLite DB is
+    present, so the target is invisible on machines without the app
+    installed.
+    """
+    from apm_cli.integration.copilot_app_db import resolve_copilot_app_root
+
+    return resolve_copilot_app_root()
 
 
 def _is_flag_enabled(flag_name: str) -> bool:

--- a/tests/unit/core/test_scope.py
+++ b/tests/unit/core/test_scope.py
@@ -166,6 +166,7 @@ class TestTargetProfileUserScope:
             "gemini",
             "windsurf",
             "copilot-cowork",
+            "copilot-app",
             "agent-skills",
         }
         assert set(KNOWN_TARGETS.keys()) == expected

--- a/tests/unit/core/test_target_detection.py
+++ b/tests/unit/core/test_target_detection.py
@@ -899,12 +899,12 @@ class TestCoworkParserLayer:
     # -- Case 6: exact membership lock -----------------------------------
 
     def test_experimental_targets_exact_membership(self):
-        """EXPERIMENTAL_TARGETS must equal frozenset({'copilot-cowork'}) exactly.
+        """EXPERIMENTAL_TARGETS must equal the expected set exactly.
 
         This locks the constant so that adding a new experimental target
         requires an intentional test update.
         """
-        assert frozenset({"copilot-cowork"}) == EXPERIMENTAL_TARGETS
+        assert frozenset({"copilot-cowork", "copilot-app"}) == EXPERIMENTAL_TARGETS
 
     # -- Case 7: "all" expansion does NOT include "copilot-cowork" ---------------
 

--- a/tests/unit/install/test_install_target_copilot_app_e2e.py
+++ b/tests/unit/install/test_install_target_copilot_app_e2e.py
@@ -211,11 +211,10 @@ class TestCopilotAppDeployUninstall:
                 """\
                 ---
                 name: Daily Digest
-                schedule:
-                  interval: daily
-                  schedule_hour: 9
-                  schedule_day: 1
-                  mode: interactive
+                interval: daily
+                schedule_hour: 9
+                schedule_day: 1
+                mode: interactive
                 ---
                 Summarise yesterday's commits.
                 """
@@ -310,10 +309,9 @@ class TestCopilotAppDeployUninstall:
                 """\
                 ---
                 name: Daily Digest
-                schedule:
-                  interval: daily
-                  schedule_hour: 9
-                  schedule_day: 1
+                interval: daily
+                schedule_hour: 9
+                schedule_day: 1
                 ---
                 Summarise yesterday's commits.
                 """
@@ -396,10 +394,9 @@ class TestCopilotAppDeployUninstall:
                 """\
                 ---
                 name: Weekly Report
-                schedule:
-                  interval: weekly
-                  schedule_hour: 10
-                  schedule_day: 1
+                interval: weekly
+                schedule_hour: 10
+                schedule_day: 1
                 ---
                 Summarise the week.
                 """

--- a/tests/unit/install/test_install_target_copilot_app_e2e.py
+++ b/tests/unit/install/test_install_target_copilot_app_e2e.py
@@ -263,3 +263,90 @@ class TestCopilotAppDeployUninstall:
                 assert row[0] == 0, "deployed workflows must start disabled"
             finally:
                 conn.close()
+
+    def test_install_local_pkg_then_uninstall_deletes_db_row(
+        self,
+        tmp_path: Path,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Regression: ``apm uninstall`` must DELETE the workflows row.
+
+        Reproduces the bug where uninstall removed the package from apm.yml
+        and apm_modules/ but left the DB row orphaned. Models real usage:
+        ``apm install <local-path> --target copilot-app -g`` followed by
+        ``apm uninstall <local-path> -g``.
+        """
+        import apm_cli.config as _conf
+
+        monkeypatch.setattr(
+            _conf,
+            "_config_cache",
+            {"experimental": {"copilot_app": True}},
+        )
+        db = _seed_db(fake_home / "data.db")
+        monkeypatch.setenv("APM_COPILOT_APP_DB", str(db))
+
+        pkg_dir = tmp_path / "uninstall-pkg"
+        prompts_dir = pkg_dir / ".apm" / "prompts"
+        prompts_dir.mkdir(parents=True)
+        (pkg_dir / "apm.yml").write_text(
+            textwrap.dedent(
+                """\
+                name: uninstall-pkg
+                description: regression test
+                version: 0.0.1
+                """
+            ),
+            encoding="ascii",
+        )
+        (prompts_dir / "daily-digest.prompt.md").write_text(
+            textwrap.dedent(
+                """\
+                ---
+                name: Daily Digest
+                schedule:
+                  interval: daily
+                  schedule_hour: 9
+                  schedule_day: 1
+                ---
+                Summarise yesterday's commits.
+                """
+            ),
+            encoding="ascii",
+        )
+
+        from apm_cli.integration import copilot_app_db as cdb
+
+        runner = CliRunner()
+        install_result = runner.invoke(
+            cli,
+            ["install", str(pkg_dir), "--target", "copilot-app", "--global"],
+            env={**_BASE_ENV, "APM_COPILOT_APP_DB": str(db)},
+            catch_exceptions=False,
+        )
+        assert install_result.exit_code == 0, install_result.output
+
+        # Lockfile must encode the copilot-app URI with the scheme prefix so
+        # uninstall can find and delete the row.
+        lockfile_text = (fake_home / ".apm" / "apm.lock.yaml").read_text(encoding="utf-8")
+        assert "copilot-app-db://workflows/apm--" in lockfile_text, lockfile_text
+
+        ids_after_install = cdb.list_managed_workflow_ids(db)
+        assert len(ids_after_install) == 1, (
+            f"install should write exactly one row, got {ids_after_install}"
+        )
+        assert ids_after_install[0].startswith("apm--"), ids_after_install[0]
+
+        uninstall_result = runner.invoke(
+            cli,
+            ["uninstall", str(pkg_dir), "--global"],
+            env={**_BASE_ENV, "APM_COPILOT_APP_DB": str(db)},
+            catch_exceptions=False,
+        )
+        assert uninstall_result.exit_code == 0, uninstall_result.output
+
+        ids_after_uninstall = cdb.list_managed_workflow_ids(db)
+        assert ids_after_uninstall == [], (
+            f"uninstall must delete the DB row, but {ids_after_uninstall} remain"
+        )

--- a/tests/unit/install/test_install_target_copilot_app_e2e.py
+++ b/tests/unit/install/test_install_target_copilot_app_e2e.py
@@ -424,6 +424,12 @@ class TestCopilotAppDeployUninstall:
             catch_exceptions=False,
         )
         assert install_result.exit_code == 0, install_result.output
+        # Lock the user-facing contract: contributors see the prompts
+        # integrated line AND the enable-in-Copilot-App hint, so a
+        # project-scope teammate isn't left wondering why their
+        # workflow never fires (see devx-ux-expert finding on PR #1405).
+        assert "prompts integrated" in install_result.output, install_result.output
+        assert "enable from the Copilot App" in install_result.output, install_result.output
 
         # Lockfile must live in the PROJECT (not user-home) and carry
         # the copilot-app URI so uninstall can locate the DB row.

--- a/tests/unit/install/test_install_target_copilot_app_e2e.py
+++ b/tests/unit/install/test_install_target_copilot_app_e2e.py
@@ -1,15 +1,15 @@
-"""E2E regression tests for ``apm install --target copilot-app --global``.
+"""E2E regression tests for ``apm install --target copilot-app``.
 
-Three scenarios mirror the cowork suite (test_install_target_copilot_cowork_e2e.py):
+Parser scenarios:
 
   1. Flag OFF                -> enable-hint printed, exit 0.
   2. Flag ON, no ``data.db`` -> "Copilot App not detected" error, exit 1.
-  3. Project scope           -> "requires --global" error, exit 1.
+  3. Project scope           -> supported (v1.1); no --global required.
 
-A fourth happy-path test exercises the full deploy + uninstall cycle
-against a temp SQLite DB seeded with the live workflows schema, proving
-that ``apm install`` -> ``apm uninstall`` actually writes and removes
-APM-namespaced rows.
+Two happy-path tests exercise the full deploy + uninstall cycle against
+a temp SQLite DB seeded with the live workflows schema, proving that
+``apm install`` -> ``apm uninstall`` actually writes and removes
+APM-namespaced rows in BOTH user (``--global``) and project scope.
 """
 
 from __future__ import annotations
@@ -136,10 +136,16 @@ class TestCopilotAppParserE2E:
             result.output
         )
 
-    def test_project_scope_requires_global(
+    def test_project_scope_now_supported(
         self, fake_home: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Without --global, copilot-app must error with --global hint."""
+        """Project-scope install is supported (v1.1): no --global required.
+
+        The experimental flag is the consent envelope; project-scope intent
+        is legitimate (a team-shared scheduled prompt belongs in the project
+        that owns it). Verifies the parser + gate succeed without --global
+        and the flag-on + DB-present path reaches the integrator.
+        """
         import apm_cli.config as _conf
 
         monkeypatch.setattr(
@@ -147,8 +153,6 @@ class TestCopilotAppParserE2E:
             "_config_cache",
             {"experimental": {"copilot_app": True}},
         )
-        # Point env override at a real DB so resolver succeeds and we reach
-        # the project-scope gate (not the missing-db gate).
         db = _seed_db(fake_home / "data.db")
         monkeypatch.setenv("APM_COPILOT_APP_DB", str(db))
 
@@ -159,9 +163,10 @@ class TestCopilotAppParserE2E:
             env={**_BASE_ENV, "APM_COPILOT_APP_DB": str(db)},
             catch_exceptions=True,
         )
-        assert result.exit_code != 0, result.output
-        normalized = " ".join((result.output or "").split())
-        assert "requires --global" in normalized, result.output
+        # Must NOT error with the legacy --global gate.
+        assert "requires --global" not in (result.output or ""), result.output
+        # Empty project apm.yml means zero deps to deploy; install succeeds.
+        assert result.exit_code == 0, result.output
 
 
 class TestCopilotAppDeployUninstall:
@@ -349,4 +354,99 @@ class TestCopilotAppDeployUninstall:
         ids_after_uninstall = cdb.list_managed_workflow_ids(db)
         assert ids_after_uninstall == [], (
             f"uninstall must delete the DB row, but {ids_after_uninstall} remain"
+        )
+
+    def test_install_project_scope_then_uninstall_deletes_db_row(
+        self,
+        tmp_path: Path,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """v1.1 regression: project-scope install+uninstall round-trips
+        the DB row without --global. Mirror of the user-scope roundtrip
+        test above but exercises the project apm.yml path: a team-shared
+        scheduled prompt is declared in a project's apm.yml and deploys
+        to the developer's Copilot App DB on install.
+        """
+        import apm_cli.config as _conf
+
+        monkeypatch.setattr(
+            _conf,
+            "_config_cache",
+            {"experimental": {"copilot_app": True}},
+        )
+        db = _seed_db(fake_home / "data.db")
+        monkeypatch.setenv("APM_COPILOT_APP_DB", str(db))
+
+        pkg_dir = tmp_path / "project-scope-pkg"
+        prompts_dir = pkg_dir / ".apm" / "prompts"
+        prompts_dir.mkdir(parents=True)
+        (pkg_dir / "apm.yml").write_text(
+            textwrap.dedent(
+                """\
+                name: project-scope-pkg
+                description: project-scope roundtrip
+                version: 0.0.1
+                """
+            ),
+            encoding="ascii",
+        )
+        (prompts_dir / "weekly-report.prompt.md").write_text(
+            textwrap.dedent(
+                """\
+                ---
+                name: Weekly Report
+                schedule:
+                  interval: weekly
+                  schedule_hour: 10
+                  schedule_day: 1
+                ---
+                Summarise the week.
+                """
+            ),
+            encoding="ascii",
+        )
+
+        # Project consumer lives in a separate directory; CliRunner runs
+        # in cwd, so we change into it for the install + uninstall calls.
+        consumer_dir = tmp_path / "consumer-project"
+        consumer_dir.mkdir()
+        (consumer_dir / "apm.yml").write_text(_MINIMAL_APM_YML, encoding="ascii")
+        monkeypatch.chdir(consumer_dir)
+
+        from apm_cli.integration import copilot_app_db as cdb
+
+        runner = CliRunner()
+        install_result = runner.invoke(
+            cli,
+            ["install", str(pkg_dir), "--target", "copilot-app"],
+            env={**_BASE_ENV, "APM_COPILOT_APP_DB": str(db)},
+            catch_exceptions=False,
+        )
+        assert install_result.exit_code == 0, install_result.output
+
+        # Lockfile must live in the PROJECT (not user-home) and carry
+        # the copilot-app URI so uninstall can locate the DB row.
+        project_lock = consumer_dir / "apm.lock.yaml"
+        assert project_lock.exists(), "project lockfile not written"
+        lock_text = project_lock.read_text(encoding="utf-8")
+        assert "copilot-app-db://workflows/apm--" in lock_text, lock_text
+
+        ids_after_install = cdb.list_managed_workflow_ids(db)
+        assert len(ids_after_install) == 1, (
+            f"project-scope install should write exactly one row, got {ids_after_install}"
+        )
+        assert ids_after_install[0].startswith("apm--"), ids_after_install[0]
+
+        uninstall_result = runner.invoke(
+            cli,
+            ["uninstall", str(pkg_dir)],
+            env={**_BASE_ENV, "APM_COPILOT_APP_DB": str(db)},
+            catch_exceptions=False,
+        )
+        assert uninstall_result.exit_code == 0, uninstall_result.output
+
+        ids_after_uninstall = cdb.list_managed_workflow_ids(db)
+        assert ids_after_uninstall == [], (
+            f"project-scope uninstall must delete the DB row, but {ids_after_uninstall} remain"
         )

--- a/tests/unit/install/test_install_target_copilot_app_e2e.py
+++ b/tests/unit/install/test_install_target_copilot_app_e2e.py
@@ -1,0 +1,265 @@
+"""E2E regression tests for ``apm install --target copilot-app --global``.
+
+Three scenarios mirror the cowork suite (test_install_target_copilot_cowork_e2e.py):
+
+  1. Flag OFF                -> enable-hint printed, exit 0.
+  2. Flag ON, no ``data.db`` -> "Copilot App not detected" error, exit 1.
+  3. Project scope           -> "requires --global" error, exit 1.
+
+A fourth happy-path test exercises the full deploy + uninstall cycle
+against a temp SQLite DB seeded with the live workflows schema, proving
+that ``apm install`` -> ``apm uninstall`` actually writes and removes
+APM-namespaced rows.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from apm_cli.cli import cli
+
+_MINIMAL_APM_YML = "name: test\ndescription: test\nversion: 0.0.1\n"
+_BASE_ENV: dict[str, str] = {"APM_E2E_TESTS": "1"}
+
+_WORKFLOWS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS "workflows" (
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    prompt TEXT NOT NULL,
+    model TEXT,
+    reasoning_effort TEXT,
+    project_id TEXT,
+    interval TEXT NOT NULL CHECK (interval IN ('manual', 'hourly', 'daily', 'weekly')),
+    schedule_hour INTEGER NOT NULL DEFAULT 9,
+    schedule_day INTEGER NOT NULL DEFAULT 1,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    last_run_at TEXT,
+    next_run_at TEXT,
+    mode TEXT
+);
+"""
+
+
+def _seed_db(path: Path) -> Path:
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.executescript(_WORKFLOWS_SCHEMA)
+        conn.execute("PRAGMA user_version = 13")
+        conn.commit()
+    finally:
+        conn.close()
+    return path
+
+
+def _write_minimal_apm_yml(apm_dir: Path) -> None:
+    (apm_dir / "apm.yml").write_text(_MINIMAL_APM_YML, encoding="ascii")
+
+
+def _write_config_json(apm_dir: Path, cfg: dict[str, Any]) -> None:
+    (apm_dir / "config.json").write_text(json.dumps(cfg), encoding="ascii")
+
+
+@pytest.fixture()
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Isolated home wired into every APM config lookup (cowork-test parity)."""
+    home = tmp_path / "home"
+    apm_dir = home / ".apm"
+    apm_dir.mkdir(parents=True)
+    _write_minimal_apm_yml(apm_dir)
+
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: home))
+    import apm_cli.config as _conf
+
+    monkeypatch.setattr(_conf, "CONFIG_DIR", str(apm_dir))
+    monkeypatch.setattr(_conf, "CONFIG_FILE", str(apm_dir / "config.json"))
+    monkeypatch.setattr(_conf, "_config_cache", None)
+    yield home
+    monkeypatch.setattr(_conf, "_config_cache", None)
+
+
+class TestCopilotAppParserE2E:
+    def test_flag_off_emits_enable_hint(
+        self, fake_home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Flag OFF: parser accepts copilot-app, targets phase prints hint, exit 0."""
+        cfg = fake_home / ".apm" / "config.json"
+        if cfg.exists():
+            cfg.unlink()
+        monkeypatch.delenv("APM_COPILOT_APP_DB", raising=False)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["install", "--target", "copilot-app", "--global"],
+            env={**_BASE_ENV},
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.output
+        assert "is not a valid target" not in (result.output or "")
+        normalized = " ".join((result.output or "").split())
+        assert "apm experimental enable copilot-app" in normalized, result.output
+
+    def test_flag_on_db_missing_errors(
+        self, fake_home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Flag ON + no data.db: actionable error, non-zero exit."""
+        import apm_cli.config as _conf
+
+        monkeypatch.setattr(
+            _conf,
+            "_config_cache",
+            {"experimental": {"copilot_app": True}},
+        )
+        # Point env override at a non-existent file so resolver returns None.
+        monkeypatch.setenv("APM_COPILOT_APP_DB", str(fake_home / "nope.db"))
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["install", "--target", "copilot-app", "--global"],
+            env={**_BASE_ENV, "APM_COPILOT_APP_DB": str(fake_home / "nope.db")},
+            catch_exceptions=True,
+        )
+        assert "is not a valid target" not in (result.output or "")
+        assert result.exit_code != 0, result.output
+        normalized = " ".join((result.output or "").split())
+        assert "GitHub Copilot desktop App not detected" in normalized or "data.db" in normalized, (
+            result.output
+        )
+
+    def test_project_scope_requires_global(
+        self, fake_home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without --global, copilot-app must error with --global hint."""
+        import apm_cli.config as _conf
+
+        monkeypatch.setattr(
+            _conf,
+            "_config_cache",
+            {"experimental": {"copilot_app": True}},
+        )
+        # Point env override at a real DB so resolver succeeds and we reach
+        # the project-scope gate (not the missing-db gate).
+        db = _seed_db(fake_home / "data.db")
+        monkeypatch.setenv("APM_COPILOT_APP_DB", str(db))
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["install", "--target", "copilot-app"],
+            env={**_BASE_ENV, "APM_COPILOT_APP_DB": str(db)},
+            catch_exceptions=True,
+        )
+        assert result.exit_code != 0, result.output
+        normalized = " ".join((result.output or "").split())
+        assert "requires --global" in normalized, result.output
+
+
+class TestCopilotAppDeployUninstall:
+    """Full install -> verify row exists -> uninstall -> verify row gone."""
+
+    def test_install_then_uninstall_roundtrip(
+        self,
+        tmp_path: Path,
+        fake_home: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        import apm_cli.config as _conf
+
+        # Enable the experimental flag.
+        monkeypatch.setattr(
+            _conf,
+            "_config_cache",
+            {"experimental": {"copilot_app": True}},
+        )
+
+        # Seed a temp DB and pin the resolver to it.
+        db = _seed_db(fake_home / "data.db")
+        monkeypatch.setenv("APM_COPILOT_APP_DB", str(db))
+
+        # Build a tiny local APM package with one scheduled prompt.
+        pkg_dir = tmp_path / "pkg-scheduler"
+        prompts_dir = pkg_dir / ".apm" / "prompts"
+        prompts_dir.mkdir(parents=True)
+        (pkg_dir / "apm.yml").write_text(
+            textwrap.dedent(
+                """\
+                name: scheduler-pkg
+                description: test
+                version: 0.0.1
+                author: alice
+                """
+            ),
+            encoding="ascii",
+        )
+        (prompts_dir / "daily-digest.prompt.md").write_text(
+            textwrap.dedent(
+                """\
+                ---
+                name: Daily Digest
+                schedule:
+                  interval: daily
+                  schedule_hour: 9
+                  schedule_day: 1
+                  mode: interactive
+                ---
+                Summarise yesterday's commits.
+                """
+            ),
+            encoding="ascii",
+        )
+
+        # User-scope apm.yml that depends on the local package (file URL).
+        apm_dir = fake_home / ".apm"
+        (apm_dir / "apm.yml").write_text(
+            textwrap.dedent(
+                f"""\
+                name: user
+                description: user-scope test
+                version: 0.0.1
+                dependencies:
+                  apm:
+                    - source: file://{pkg_dir}
+                      name: scheduler-pkg
+                """
+            ),
+            encoding="ascii",
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["install", "--target", "copilot-app", "--global"],
+            env={**_BASE_ENV, "APM_COPILOT_APP_DB": str(db)},
+            catch_exceptions=True,
+        )
+        # If install support for ``file://`` sources isn't available in
+        # this code path, the deploy step may be a no-op.  Either way the
+        # parser + gate must succeed.
+        assert "is not a valid target" not in (result.output or "")
+        assert "experimental enable" not in (result.output or "") or result.exit_code == 0
+
+        # If deploy ran, the row must be present and disabled.
+        from apm_cli.integration import copilot_app_db as cdb
+
+        ids = cdb.list_managed_workflow_ids(db)
+        if ids:
+            assert any("daily-digest" in i for i in ids)
+            conn = sqlite3.connect(str(db))
+            try:
+                row = conn.execute(
+                    "SELECT enabled FROM workflows WHERE id = ?", (ids[0],)
+                ).fetchone()
+                assert row is not None
+                assert row[0] == 0, "deployed workflows must start disabled"
+            finally:
+                conn.close()

--- a/tests/unit/install/test_services.py
+++ b/tests/unit/install/test_services.py
@@ -50,6 +50,11 @@ def _make_cowork_target(cowork_root: Path) -> Any:
     return replace(KNOWN_TARGETS["copilot-cowork"], resolved_deploy_root=cowork_root)
 
 
+def _make_copilot_app_target(app_root: Path) -> Any:
+    """Return a TargetProfile with resolved_deploy_root set for copilot-app."""
+    return replace(KNOWN_TARGETS["copilot-app"], resolved_deploy_root=app_root)
+
+
 # ---------------------------------------------------------------------------
 # TestDeployedPathEntry
 # ---------------------------------------------------------------------------
@@ -79,6 +84,28 @@ class TestDeployedPathEntry:
         ):
             result = _deployed_path_entry(target_path, project_root, targets=[cowork_target])
         assert result == "cowork://skills/my-skill/SKILL.md"
+
+    def test_copilot_app_uri_for_out_of_tree_synthetic_path(self, tmp_path: Path) -> None:
+        """copilot-app synthesises ``<root>/workflows/<id>`` paths that
+        live outside the project tree; ``_deployed_path_entry`` must
+        encode them as ``copilot-app-db://workflows/<id>`` so the
+        lockfile pipeline does not try to make them project-relative."""
+        app_root = tmp_path / "copilot-data"
+        app_root.mkdir()
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        wf_id = "apm--acme-org--demo-pkg--daily-digest"
+        target_path = app_root / "workflows" / wf_id
+        app_target = _make_copilot_app_target(app_root)
+
+        result = _deployed_path_entry(target_path, project_root, targets=[app_target])
+
+        assert result == f"copilot-app-db://workflows/{wf_id}"
+
+        # Round-trip: the URI must decode back to the original id.
+        from apm_cli.integration.copilot_app_db import from_lockfile_uri
+
+        assert from_lockfile_uri(result) == wf_id
 
     def test_runtime_error_when_no_matching_target(self, tmp_path: Path) -> None:
         """Out-of-tree path with no dynamic-root target must raise, not silently store an absolute path."""

--- a/tests/unit/integration/test_copilot_app_db.py
+++ b/tests/unit/integration/test_copilot_app_db.py
@@ -325,7 +325,7 @@ class TestDeploy:
     def test_rejects_autopilot_mode(self, db_path: Path):
         """autopilot is intentionally not accepted via the copilot-app target."""
         wid = cdb.namespaced_id("o", "p", "n")
-        with pytest.raises(ValueError, match=r"Invalid mode"):
+        with pytest.raises(ValueError, match=r"autopilot"):
             cdb.deploy_workflow(
                 db_path,
                 cdb.WorkflowRow(id=wid, name="N", prompt="x", mode="autopilot"),

--- a/tests/unit/integration/test_copilot_app_db.py
+++ b/tests/unit/integration/test_copilot_app_db.py
@@ -1,0 +1,335 @@
+"""Unit tests for ``apm_cli.integration.copilot_app_db``.
+
+Exercises the I/O boundary in isolation against a temp SQLite file that
+mirrors the live Copilot App schema (dumped from a real ``~/.copilot/data.db``
+on a developer machine -- see fixture below).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from apm_cli.integration import copilot_app_db as cdb
+
+# ---------------------------------------------------------------------------
+# Schema fixture -- mirrors live Copilot App ``data.db`` (user_version=13).
+# ---------------------------------------------------------------------------
+
+_WORKFLOWS_SCHEMA: str = """
+CREATE TABLE IF NOT EXISTS "workflows" (
+    id TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL,
+    prompt TEXT NOT NULL,
+    model TEXT,
+    reasoning_effort TEXT,
+    project_id TEXT,
+    interval TEXT NOT NULL CHECK (interval IN ('manual', 'hourly', 'daily', 'weekly')),
+    schedule_hour INTEGER NOT NULL DEFAULT 9,
+    schedule_day INTEGER NOT NULL DEFAULT 1,
+    enabled INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    last_run_at TEXT,
+    next_run_at TEXT,
+    mode TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_workflows_enabled_next
+    ON "workflows"(enabled, next_run_at);
+"""
+
+
+def _make_db(path: Path, user_version: int = 13) -> Path:
+    """Build a fresh DB at *path* with the workflows schema + user_version."""
+    conn = sqlite3.connect(str(path))
+    try:
+        conn.executescript(_WORKFLOWS_SCHEMA)
+        conn.execute(f"PRAGMA user_version = {user_version}")
+        conn.commit()
+    finally:
+        conn.close()
+    return path
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return _make_db(tmp_path / "data.db")
+
+
+# ---------------------------------------------------------------------------
+# Namespacing / URI helpers (pure functions).
+# ---------------------------------------------------------------------------
+
+
+class TestNamespacedId:
+    def test_basic_format(self):
+        assert cdb.namespaced_id("alice", "my-pkg", "daily-news") == (
+            "apm--alice--my-pkg--daily-news"
+        )
+
+    def test_slugifies_unsafe_chars(self):
+        assert cdb.namespaced_id("Al!ce", "pkg name", "p/r:o m_pt") == (
+            "apm--al-ce--pkg-name--p-r-o-m_pt"
+        )
+
+    def test_empty_segments_become_unknown(self):
+        # Empty owner gets replaced with "unknown" (defensive default).
+        wid = cdb.namespaced_id("", "pkg", "p")
+        assert wid.startswith("apm--unknown--")
+
+    def test_is_apm_managed_id(self):
+        assert cdb.is_apm_managed_id("apm--a--b--c")
+        assert not cdb.is_apm_managed_id("my-workflow")
+        assert not cdb.is_apm_managed_id("APM--a--b--c")  # case-sensitive
+
+
+class TestLockfileUri:
+    def test_roundtrip(self):
+        wid = "apm--owner--pkg--prompt"
+        uri = cdb.to_lockfile_uri(wid)
+        assert uri == "copilot-app-db://workflows/apm--owner--pkg--prompt"
+        assert cdb.from_lockfile_uri(uri) == wid
+
+    def test_rejects_non_apm_id_on_encode(self):
+        with pytest.raises(ValueError, match=r"non-APM workflow id"):
+            cdb.to_lockfile_uri("user-workflow")
+
+    def test_rejects_non_apm_id_on_decode(self):
+        with pytest.raises(ValueError, match=r"non-APM workflow id"):
+            cdb.from_lockfile_uri("copilot-app-db://workflows/user-workflow")
+
+    def test_rejects_wrong_scheme(self):
+        with pytest.raises(ValueError, match=r"Not a copilot-app lockfile URI"):
+            cdb.from_lockfile_uri("cowork://skills/foo")
+
+    def test_is_copilot_app_uri(self):
+        assert cdb.is_copilot_app_uri("copilot-app-db://workflows/apm--a--b--c")
+        assert not cdb.is_copilot_app_uri("cowork://skills/x")
+        assert not cdb.is_copilot_app_uri(".github/skills/x")
+
+
+# ---------------------------------------------------------------------------
+# Resolver -- env override + presence-based discovery.
+# ---------------------------------------------------------------------------
+
+
+class TestResolve:
+    def test_env_override_present(self, tmp_path: Path, monkeypatch):
+        db = _make_db(tmp_path / "custom.db")
+        monkeypatch.setenv("APM_COPILOT_APP_DB", str(db))
+        assert cdb.resolve_copilot_app_db_path() == db
+        assert cdb.resolve_copilot_app_root() == db.parent
+
+    def test_env_override_missing(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("APM_COPILOT_APP_DB", str(tmp_path / "nope.db"))
+        assert cdb.resolve_copilot_app_db_path() is None
+        assert cdb.resolve_copilot_app_root() is None
+
+    def test_home_missing_returns_none(self, tmp_path: Path, monkeypatch):
+        # Point HOME at an empty tmpdir; no env override.
+        monkeypatch.delenv("APM_COPILOT_APP_DB", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        assert cdb.resolve_copilot_app_db_path() is None
+
+
+# ---------------------------------------------------------------------------
+# Version guard.
+# ---------------------------------------------------------------------------
+
+
+class TestVersionGuard:
+    def test_accepts_user_version_13(self, db_path: Path):
+        row = cdb.WorkflowRow(
+            id=cdb.namespaced_id("o", "p", "n"),
+            name="N",
+            prompt="hi",
+        )
+        cdb.deploy_workflow(db_path, row)  # no raise
+
+    def test_rejects_user_version_below_min(self, tmp_path: Path):
+        db = _make_db(tmp_path / "old.db", user_version=12)
+        row = cdb.WorkflowRow(id=cdb.namespaced_id("o", "p", "n"), name="N", prompt="x")
+        with pytest.raises(cdb.CopilotAppDbSchemaError, match=r"older than supported"):
+            cdb.deploy_workflow(db, row)
+
+    def test_rejects_user_version_above_max(self, tmp_path: Path):
+        db = _make_db(tmp_path / "new.db", user_version=999)
+        row = cdb.WorkflowRow(id=cdb.namespaced_id("o", "p", "n"), name="N", prompt="x")
+        with pytest.raises(cdb.CopilotAppDbSchemaError, match=r"newer than this APM"):
+            cdb.deploy_workflow(db, row)
+
+
+# ---------------------------------------------------------------------------
+# Deploy: INSERT + UPDATE semantics.
+# ---------------------------------------------------------------------------
+
+
+def _select_row(db_path: Path, wid: str) -> dict:
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        cur = conn.execute("SELECT * FROM workflows WHERE id = ?", (wid,))
+        r = cur.fetchone()
+        assert r is not None
+        return dict(r)
+    finally:
+        conn.close()
+
+
+class TestDeploy:
+    def test_insert_writes_full_row(self, db_path: Path):
+        wid = cdb.namespaced_id("alice", "news", "daily")
+        row = cdb.WorkflowRow(
+            id=wid,
+            name="Daily News",
+            prompt="Summarise today's headlines",
+            interval="daily",
+            schedule_hour=9,
+            schedule_day=1,
+            enabled=0,
+            mode="interactive",
+            model="gpt-4o",
+        )
+        uri = cdb.deploy_workflow(db_path, row)
+        assert uri == f"copilot-app-db://workflows/{wid}"
+        stored = _select_row(db_path, wid)
+        assert stored["name"] == "Daily News"
+        assert stored["prompt"] == "Summarise today's headlines"
+        assert stored["interval"] == "daily"
+        assert stored["enabled"] == 0
+        assert stored["mode"] == "interactive"
+        assert stored["model"] == "gpt-4o"
+
+    def test_update_preserves_user_enabled_and_run_history(self, db_path: Path):
+        wid = cdb.namespaced_id("alice", "news", "daily")
+        cdb.deploy_workflow(
+            db_path,
+            cdb.WorkflowRow(id=wid, name="V1", prompt="old", interval="manual"),
+        )
+        # Simulate the user enabling the row + the app recording a run.
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute(
+                "UPDATE workflows SET enabled=1, last_run_at=?, next_run_at=? WHERE id=?",
+                ("2025-01-01T00:00:00.000Z", "2025-01-02T00:00:00.000Z", wid),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        # Re-deploy with a new prompt body (the package was updated).
+        cdb.deploy_workflow(
+            db_path,
+            cdb.WorkflowRow(id=wid, name="V2", prompt="new", interval="hourly"),
+        )
+        stored = _select_row(db_path, wid)
+        assert stored["name"] == "V2"
+        assert stored["prompt"] == "new"
+        assert stored["interval"] == "hourly"
+        assert stored["enabled"] == 1, "user opt-in must survive update"
+        assert stored["last_run_at"] == "2025-01-01T00:00:00.000Z"
+        assert stored["next_run_at"] == "2025-01-02T00:00:00.000Z"
+
+    def test_rejects_invalid_interval(self, db_path: Path):
+        wid = cdb.namespaced_id("o", "p", "n")
+        with pytest.raises(ValueError, match=r"Invalid interval"):
+            cdb.deploy_workflow(
+                db_path,
+                cdb.WorkflowRow(id=wid, name="N", prompt="x", interval="yearly"),
+            )
+
+    def test_rejects_invalid_mode(self, db_path: Path):
+        wid = cdb.namespaced_id("o", "p", "n")
+        with pytest.raises(ValueError, match=r"Invalid mode"):
+            cdb.deploy_workflow(
+                db_path,
+                cdb.WorkflowRow(id=wid, name="N", prompt="x", mode="rogue"),
+            )
+
+    def test_rejects_non_apm_id(self, db_path: Path):
+        with pytest.raises(ValueError, match=r"non-APM workflow id"):
+            cdb.deploy_workflow(
+                db_path,
+                cdb.WorkflowRow(id="user-workflow", name="N", prompt="x"),
+            )
+
+    def test_missing_db_raises_missing_error(self, tmp_path: Path):
+        wid = cdb.namespaced_id("o", "p", "n")
+        with pytest.raises(cdb.CopilotAppDbMissingError, match=r"not found"):
+            cdb.deploy_workflow(
+                tmp_path / "nope.db",
+                cdb.WorkflowRow(id=wid, name="N", prompt="x"),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Delete: namespace defence + idempotency.
+# ---------------------------------------------------------------------------
+
+
+class TestDelete:
+    def test_removes_only_specified_apm_rows(self, db_path: Path):
+        wid_a = cdb.namespaced_id("o", "p", "a")
+        wid_b = cdb.namespaced_id("o", "p", "b")
+        cdb.deploy_workflow(db_path, cdb.WorkflowRow(id=wid_a, name="A", prompt="x"))
+        cdb.deploy_workflow(db_path, cdb.WorkflowRow(id=wid_b, name="B", prompt="y"))
+        # User-created row (raw INSERT, no APM prefix).
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute(
+                "INSERT INTO workflows (id, name, prompt, interval) VALUES (?,?,?,?)",
+                ("user-row", "Mine", "p", "manual"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        removed = cdb.delete_workflows(db_path, [wid_a])
+        assert removed == 1
+        # b + user-row survive.
+        ids = cdb.list_managed_workflow_ids(db_path)
+        assert ids == [wid_b]
+        # user-row is still in the DB.
+        conn = sqlite3.connect(str(db_path))
+        try:
+            present = conn.execute("SELECT 1 FROM workflows WHERE id = ?", ("user-row",)).fetchone()
+            assert present is not None
+        finally:
+            conn.close()
+
+    def test_refuses_non_apm_id(self, db_path: Path):
+        with pytest.raises(ValueError, match=r"non-APM workflow id"):
+            cdb.delete_workflows(db_path, ["user-row"])
+
+    def test_missing_db_returns_zero(self, tmp_path: Path):
+        # Idempotent uninstall.
+        assert cdb.delete_workflows(tmp_path / "nope.db", []) == 0
+        assert cdb.delete_workflows(tmp_path / "nope.db", [cdb.namespaced_id("a", "b", "c")]) == 0
+
+    def test_empty_list_noop(self, db_path: Path):
+        assert cdb.delete_workflows(db_path, []) == 0
+
+
+# ---------------------------------------------------------------------------
+# list_managed_workflow_ids.
+# ---------------------------------------------------------------------------
+
+
+class TestList:
+    def test_filters_to_apm_namespace(self, db_path: Path):
+        wid = cdb.namespaced_id("o", "p", "n")
+        cdb.deploy_workflow(db_path, cdb.WorkflowRow(id=wid, name="N", prompt="x"))
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute(
+                "INSERT INTO workflows (id, name, prompt, interval) VALUES (?,?,?,?)",
+                ("hand-rolled", "H", "p", "manual"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        assert cdb.list_managed_workflow_ids(db_path) == [wid]
+
+    def test_missing_db_returns_empty(self, tmp_path: Path):
+        assert cdb.list_managed_workflow_ids(tmp_path / "nope.db") == []

--- a/tests/unit/integration/test_copilot_app_db.py
+++ b/tests/unit/integration/test_copilot_app_db.py
@@ -203,13 +203,44 @@ class TestDeploy:
         assert stored["mode"] == "interactive"
         assert stored["model"] == "gpt-4o"
 
-    def test_update_preserves_user_enabled_and_run_history(self, db_path: Path):
+    def test_update_preserves_enabled_when_only_name_changes(self, db_path: Path):
+        """User's opt-in MUST survive a no-op metadata refresh."""
+        wid = cdb.namespaced_id("alice", "news", "daily")
+        cdb.deploy_workflow(
+            db_path,
+            cdb.WorkflowRow(id=wid, name="V1", prompt="body", interval="manual"),
+        )
+        # Simulate the user enabling the row + the app recording a run.
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute(
+                "UPDATE workflows SET enabled=1, last_run_at=?, next_run_at=? WHERE id=?",
+                ("2025-01-01T00:00:00.000Z", "2025-01-02T00:00:00.000Z", wid),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        # Re-deploy with ONLY the display name changed -- no execution-
+        # affecting fields move.
+        cdb.deploy_workflow(
+            db_path,
+            cdb.WorkflowRow(id=wid, name="V1-renamed", prompt="body", interval="manual"),
+        )
+        stored = _select_row(db_path, wid)
+        assert stored["name"] == "V1-renamed"
+        assert stored["prompt"] == "body"
+        assert stored["interval"] == "manual"
+        assert stored["enabled"] == 1, "user opt-in must survive no-op refresh"
+        assert stored["last_run_at"] == "2025-01-01T00:00:00.000Z"
+        assert stored["next_run_at"] == "2025-01-02T00:00:00.000Z"
+
+    def test_update_resets_enabled_when_prompt_body_changes(self, db_path: Path):
+        """Content change revokes the user's prior opt-in (silent-update vector)."""
         wid = cdb.namespaced_id("alice", "news", "daily")
         cdb.deploy_workflow(
             db_path,
             cdb.WorkflowRow(id=wid, name="V1", prompt="old", interval="manual"),
         )
-        # Simulate the user enabling the row + the app recording a run.
         conn = sqlite3.connect(str(db_path))
         try:
             conn.execute(
@@ -228,9 +259,34 @@ class TestDeploy:
         assert stored["name"] == "V2"
         assert stored["prompt"] == "new"
         assert stored["interval"] == "hourly"
-        assert stored["enabled"] == 1, "user opt-in must survive update"
+        assert stored["enabled"] == 0, "content change must revoke prior opt-in"
+        assert stored["next_run_at"] is None, "next_run_at must clear on content change"
+        # last_run_at is history -- preserved either way.
         assert stored["last_run_at"] == "2025-01-01T00:00:00.000Z"
-        assert stored["next_run_at"] == "2025-01-02T00:00:00.000Z"
+
+    def test_update_resets_enabled_when_schedule_changes(self, db_path: Path):
+        """Schedule change is also an execution-affecting change."""
+        wid = cdb.namespaced_id("alice", "news", "daily")
+        cdb.deploy_workflow(
+            db_path,
+            cdb.WorkflowRow(id=wid, name="V1", prompt="body", interval="daily", schedule_hour=9),
+        )
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute(
+                "UPDATE workflows SET enabled=1 WHERE id=?",
+                (wid,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        cdb.deploy_workflow(
+            db_path,
+            cdb.WorkflowRow(id=wid, name="V1", prompt="body", interval="daily", schedule_hour=17),
+        )
+        stored = _select_row(db_path, wid)
+        assert stored["enabled"] == 0
+        assert stored["schedule_hour"] == 17
 
     def test_rejects_invalid_interval(self, db_path: Path):
         wid = cdb.namespaced_id("o", "p", "n")
@@ -246,6 +302,15 @@ class TestDeploy:
             cdb.deploy_workflow(
                 db_path,
                 cdb.WorkflowRow(id=wid, name="N", prompt="x", mode="rogue"),
+            )
+
+    def test_rejects_autopilot_mode(self, db_path: Path):
+        """autopilot is intentionally not accepted via the copilot-app target."""
+        wid = cdb.namespaced_id("o", "p", "n")
+        with pytest.raises(ValueError, match=r"Invalid mode"):
+            cdb.deploy_workflow(
+                db_path,
+                cdb.WorkflowRow(id=wid, name="N", prompt="x", mode="autopilot"),
             )
 
     def test_rejects_non_apm_id(self, db_path: Path):

--- a/tests/unit/integration/test_copilot_app_db.py
+++ b/tests/unit/integration/test_copilot_app_db.py
@@ -203,6 +203,24 @@ class TestDeploy:
         assert stored["mode"] == "interactive"
         assert stored["model"] == "gpt-4o"
 
+    def test_insert_forces_enabled_zero_even_if_caller_passes_one(self, db_path: Path):
+        """Defence in depth: writer ignores row.enabled on INSERT to block bootstrap."""
+        wid = cdb.namespaced_id("evil", "pkg", "auto")
+        row = cdb.WorkflowRow(
+            id=wid,
+            name="Hostile Auto-Run",
+            prompt="anything",
+            interval="daily",
+            schedule_hour=9,
+            schedule_day=1,
+            enabled=1,
+            mode="interactive",
+            model="gpt-4o",
+        )
+        cdb.deploy_workflow(db_path, row)
+        stored = _select_row(db_path, wid)
+        assert stored["enabled"] == 0, "INSERT must force enabled=0 regardless of caller input"
+
     def test_update_preserves_enabled_when_only_name_changes(self, db_path: Path):
         """User's opt-in MUST survive a no-op metadata refresh."""
         wid = cdb.namespaced_id("alice", "news", "daily")

--- a/tests/unit/integration/test_copilot_app_error_ux.py
+++ b/tests/unit/integration/test_copilot_app_error_ux.py
@@ -1,0 +1,221 @@
+"""Wave 4: error UX surfacing for the copilot-app integrator.
+
+Verifies that when ``copilot_app_db.deploy_workflow`` raises one of the
+typed errors mid-install, the integrator:
+
+1. Skips the failing prompt instead of crashing the run.
+2. Surfaces an actionable diagnostic via the diagnostics collector,
+   carrying the exception message so the user can act on it.
+3. Continues with the next prompt (errors are per-prompt, not fatal).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from apm_cli.integration import copilot_app_db as db_mod
+from apm_cli.integration.copilot_app_db import (
+    CopilotAppDbLockedError,
+    CopilotAppDbMissingError,
+    CopilotAppDbSchemaError,
+)
+from apm_cli.integration.prompt_integrator import PromptIntegrator
+from apm_cli.integration.targets import KNOWN_TARGETS
+
+SCHEDULED_PROMPT = """---
+name: Daily Digest
+schedule:
+  interval: daily
+  schedule_hour: 9
+  mode: interactive
+---
+Summarise yesterday's commits.
+"""
+
+SCHEDULED_PROMPT_2 = """---
+name: Hourly Heartbeat
+schedule:
+  interval: hourly
+  mode: interactive
+---
+Hourly heartbeat body.
+"""
+
+
+class _CapturingDiagnostics:
+    def __init__(self):
+        self.warns: list[dict] = []
+
+    def warn(self, **kwargs):
+        self.warns.append(kwargs)
+
+
+def _make_pkg(tmp_path: Path) -> SimpleNamespace:
+    """Build a minimal package_info with two scheduled prompts."""
+    pkg_dir = tmp_path / "pkg"
+    prompts = pkg_dir / ".apm" / "prompts"
+    prompts.mkdir(parents=True)
+    (prompts / "daily-digest.prompt.md").write_text(SCHEDULED_PROMPT)
+    (prompts / "hourly-heartbeat.prompt.md").write_text(SCHEDULED_PROMPT_2)
+    return SimpleNamespace(
+        install_path=pkg_dir,
+        package=SimpleNamespace(
+            name="demo-pkg",
+            source="github:acme-org/demo-pkg",
+            author=None,
+        ),
+    )
+
+
+@pytest.fixture
+def copilot_app_target():
+    profile = KNOWN_TARGETS.get("copilot-app")
+    assert profile is not None, "copilot-app target must be registered"
+    return profile
+
+
+@pytest.fixture
+def fake_db(tmp_path, monkeypatch):
+    """Ensure ``resolve_copilot_app_db_path`` returns a valid path so
+    the integrator proceeds past its defensive None-guard.  The DB file
+    itself is irrelevant -- ``deploy_workflow`` will be monkeypatched."""
+    db_file = tmp_path / "data.db"
+    db_file.touch()
+    monkeypatch.setenv("APM_COPILOT_APP_DB", str(db_file))
+    return db_file
+
+
+class TestDeployErrorSurfacing:
+    @pytest.mark.parametrize(
+        "exc_cls,exc_args,expected_substring",
+        [
+            (
+                CopilotAppDbMissingError,
+                ("~/.copilot/data.db not found",),
+                "data.db not found",
+            ),
+            (
+                CopilotAppDbSchemaError,
+                ("user_version 99 is newer than tested 13",),
+                "user_version 99",
+            ),
+            (
+                CopilotAppDbLockedError,
+                ("database is locked after 5s",),
+                "database is locked",
+            ),
+        ],
+    )
+    def test_typed_errors_become_actionable_diagnostics(
+        self,
+        tmp_path,
+        monkeypatch,
+        fake_db,
+        copilot_app_target,
+        exc_cls,
+        exc_args,
+        expected_substring,
+    ):
+        """Each typed DB error surfaces as a per-prompt diagnostic warn
+        carrying the original message; install does NOT raise."""
+        pkg = _make_pkg(tmp_path)
+        diags = _CapturingDiagnostics()
+
+        def boom(*_args, **_kwargs):
+            raise exc_cls(*exc_args)
+
+        monkeypatch.setattr(db_mod, "deploy_workflow", boom)
+
+        result = PromptIntegrator().integrate_prompts_for_target(
+            copilot_app_target,
+            pkg,
+            project_root=tmp_path,
+            diagnostics=diags,
+        )
+
+        # Both prompts failed -> both skipped, neither integrated.
+        assert result.files_integrated == 0
+        assert result.files_skipped == 2
+
+        # Two diagnostics, one per prompt, each carrying the original
+        # message so the user has something actionable.
+        assert len(diags.warns) == 2
+        for entry in diags.warns:
+            assert entry["package"] == "demo-pkg"
+            assert "Copilot App" in entry["message"]
+            assert expected_substring in entry["message"]
+
+    def test_partial_failure_does_not_block_subsequent_prompts(
+        self,
+        tmp_path,
+        monkeypatch,
+        fake_db,
+        copilot_app_target,
+    ):
+        """First prompt fails with a locked DB; second prompt succeeds.
+        Counters must reflect 1 integrated + 1 skipped."""
+        pkg = _make_pkg(tmp_path)
+        diags = _CapturingDiagnostics()
+        call_count = {"n": 0}
+
+        def flaky(*_args, **_kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise CopilotAppDbLockedError("transient lock")
+
+        monkeypatch.setattr(db_mod, "deploy_workflow", flaky)
+
+        result = PromptIntegrator().integrate_prompts_for_target(
+            copilot_app_target,
+            pkg,
+            project_root=tmp_path,
+            diagnostics=diags,
+        )
+
+        assert result.files_integrated == 1
+        assert result.files_skipped == 1
+        assert len(diags.warns) == 1
+        assert "transient lock" in diags.warns[0]["message"]
+
+    def test_missing_db_resolver_returns_empty_no_exception(
+        self,
+        tmp_path,
+        monkeypatch,
+        copilot_app_target,
+    ):
+        """When the resolver returns None mid-run (e.g. DB deleted
+        between gating and integration), the integrator is defensive:
+        no crash, no diagnostics, empty result.  CLI gating in
+        install/phases/targets.py is the surface that emits the
+        actionable user-facing error."""
+        from apm_cli.integration import prompt_integrator as pi_mod
+
+        pkg = _make_pkg(tmp_path)
+        diags = _CapturingDiagnostics()
+
+        # Force the resolver path used INSIDE the integrator to None.
+        # The function is imported locally inside
+        # _integrate_prompts_for_copilot_app, so we patch on the db
+        # module.
+        monkeypatch.setattr(
+            db_mod,
+            "resolve_copilot_app_db_path",
+            lambda: None,
+        )
+
+        # Sanity: ensure we are exercising the real integrator branch.
+        assert hasattr(pi_mod.PromptIntegrator, "_integrate_prompts_for_copilot_app")
+
+        result = PromptIntegrator().integrate_prompts_for_target(
+            copilot_app_target,
+            pkg,
+            project_root=tmp_path,
+            diagnostics=diags,
+        )
+
+        assert result.files_integrated == 0
+        assert result.files_skipped == 0
+        assert diags.warns == []

--- a/tests/unit/integration/test_copilot_app_error_ux.py
+++ b/tests/unit/integration/test_copilot_app_error_ux.py
@@ -322,3 +322,55 @@ class TestDispatchByShape:
                 f"target {target_name!r} should NOT receive workflow-shape "
                 f"prompt; got {target_filenames}"
             )
+
+    def test_workflow_shape_skipped_by_copilot_prompt_integrator(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """The .github/prompts/ leak regression: a workflow-shape
+        .prompt.md must NOT ship to .github/prompts/ when --target
+        includes ``copilot`` (which routes through PromptIntegrator, not
+        CommandIntegrator).  A user running
+        ``--target copilot,copilot-app`` must see workflow metadata
+        only in the App and plain prompts only in .github/prompts/.
+        Without the shape-based skip in
+        PromptIntegrator._integrate_prompts_for_copilot, scheduled
+        prompts would leak into the slash-command surface and be
+        invoked by IDE users who never opted into the workflow."""
+        pkg_dir = tmp_path / "pkg"
+        prompts = pkg_dir / ".apm" / "prompts"
+        prompts.mkdir(parents=True)
+        (prompts / "scheduled.prompt.md").write_text(SCHEDULED_PROMPT)
+        (prompts / "plain.prompt.md").write_text(PLAIN_PROMPT)
+        pkg = SimpleNamespace(
+            install_path=pkg_dir,
+            package=SimpleNamespace(
+                name="demo-pkg",
+                source="github:acme-org/demo-pkg",
+                author=None,
+            ),
+        )
+        copilot_profile = KNOWN_TARGETS.get("copilot")
+        assert copilot_profile is not None
+        project_root = tmp_path / "proj"
+        project_root.mkdir()
+
+        result = PromptIntegrator().integrate_prompts_for_target(
+            copilot_profile,
+            pkg,
+            project_root=project_root,
+            diagnostics=_CapturingDiagnostics(),
+        )
+
+        prompts_dir = project_root / ".github" / "prompts"
+        written = [p.name for p in prompts_dir.rglob("*.prompt.md")] if prompts_dir.exists() else []
+        assert not any("scheduled" in name for name in written), (
+            f"workflow-shape prompt must NOT leak into .github/prompts/; got {written}"
+        )
+        # And the plain prompt SHOULD still deploy normally.
+        assert any("plain" in name for name in written), (
+            f"plain prompt should still deploy via --target copilot; got {written}"
+        )
+        # Sanity: the workflow-shape source was counted as skipped.
+        assert result.files_skipped >= 1

--- a/tests/unit/integration/test_copilot_app_error_ux.py
+++ b/tests/unit/integration/test_copilot_app_error_ux.py
@@ -27,19 +27,17 @@ from apm_cli.integration.targets import KNOWN_TARGETS
 
 SCHEDULED_PROMPT = """---
 name: Daily Digest
-schedule:
-  interval: daily
-  schedule_hour: 9
-  mode: interactive
+interval: daily
+schedule_hour: 9
+mode: interactive
 ---
 Summarise yesterday's commits.
 """
 
 SCHEDULED_PROMPT_2 = """---
 name: Hourly Heartbeat
-schedule:
-  interval: hourly
-  mode: interactive
+interval: hourly
+mode: interactive
 ---
 Hourly heartbeat body.
 """
@@ -219,3 +217,108 @@ class TestDeployErrorSurfacing:
         assert result.files_integrated == 0
         assert result.files_skipped == 0
         assert diags.warns == []
+
+
+# ---------------------------------------------------------------------------
+# Option B: dispatch-by-shape regression tests
+# ---------------------------------------------------------------------------
+
+PLAIN_PROMPT = """---
+name: Plain Hello
+description: A regular slash-command prompt with no execution metadata.
+---
+Say hello.
+"""
+
+
+class TestDispatchByShape:
+    def test_plain_prompt_at_copilot_app_warns_hard(
+        self,
+        copilot_app_target,
+        fake_db,
+        tmp_path,
+        monkeypatch,
+    ):
+        """A .prompt.md with NO workflow-shape keys, sent to --target
+        copilot-app, must surface an actionable diagnostic explaining
+        what to add or where to send it instead -- not silently skip."""
+        pkg_dir = tmp_path / "pkg"
+        prompts = pkg_dir / ".apm" / "prompts"
+        prompts.mkdir(parents=True)
+        (prompts / "plain.prompt.md").write_text(PLAIN_PROMPT)
+        pkg = SimpleNamespace(
+            install_path=pkg_dir,
+            package=SimpleNamespace(
+                name="demo-pkg",
+                source="github:acme-org/demo-pkg",
+                author=None,
+            ),
+        )
+        diags = _CapturingDiagnostics()
+
+        result = PromptIntegrator().integrate_prompts_for_target(
+            copilot_app_target,
+            pkg,
+            project_root=tmp_path,
+            diagnostics=diags,
+        )
+
+        assert result.files_integrated == 0
+        assert result.files_skipped == 1
+        assert len(diags.warns) == 1
+        msg = diags.warns[0]["message"]
+        # Diagnostic must name the shape requirement and the workaround.
+        assert "no workflow frontmatter" in msg
+        assert "interval" in msg
+        assert "copilot-app" in msg
+
+    def test_workflow_shape_skipped_by_slash_command_integrator(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        """The slash-command leak regression: a workflow-shape .prompt.md
+        (interval/mode/etc) must NOT ship to .claude/commands/,
+        .cursor/commands/, .copilot/prompts/, .gemini/commands/.  Without
+        the shape-based skip in CommandIntegrator, a single source file
+        used to deploy to 4 slash-command surfaces in addition to the
+        Copilot App DB row."""
+        from apm_cli.integration.command_integrator import CommandIntegrator
+        from apm_cli.integration.targets import KNOWN_TARGETS
+
+        pkg_dir = tmp_path / "pkg"
+        prompts = pkg_dir / ".apm" / "prompts"
+        prompts.mkdir(parents=True)
+        (prompts / "scheduled.prompt.md").write_text(SCHEDULED_PROMPT)
+        (prompts / "plain.prompt.md").write_text(PLAIN_PROMPT)
+        pkg = SimpleNamespace(
+            install_path=pkg_dir,
+            package=SimpleNamespace(
+                name="demo-pkg",
+                source="github:acme-org/demo-pkg",
+                author=None,
+            ),
+        )
+        # Probe every file-based command target that should observe the
+        # skip.  The integrator must deploy ONLY the plain prompt to
+        # each; the workflow-shape one must be skipped.
+        for target_name in ("claude", "cursor", "gemini"):
+            profile = KNOWN_TARGETS.get(target_name)
+            if profile is None or profile.primitives.get("prompts") is None:
+                continue
+            project_root = tmp_path / f"proj-{target_name}"
+            project_root.mkdir()
+            # Some targets are auto_create=False; create the dir so we
+            # exercise the dispatch logic rather than the early-return.
+            (project_root / profile.root_dir).mkdir(parents=True, exist_ok=True)
+            result = CommandIntegrator().integrate_commands_for_target(
+                profile,
+                pkg,
+                project_root=project_root,
+                diagnostics=_CapturingDiagnostics(),
+            )
+            target_filenames = [p.name for p in result.target_paths]
+            assert not any("scheduled" in n for n in target_filenames), (
+                f"target {target_name!r} should NOT receive workflow-shape "
+                f"prompt; got {target_filenames}"
+            )

--- a/tests/unit/integration/test_copilot_app_schedule.py
+++ b/tests/unit/integration/test_copilot_app_schedule.py
@@ -1,9 +1,9 @@
-"""Unit tests for the ``schedule:`` frontmatter parser used by the
+"""Unit tests for the workflow-frontmatter parser used by the
 ``copilot-app`` target.
 
-Lives in the integrator module because the helper is intentionally
-private to ``apm_cli.integration.prompt_integrator`` (no separate
-module surface area for Wave 2).
+Option B: dispatch is by frontmatter SHAPE (top-level keys), not by a
+nested ``schedule:`` block.  The parser consumes flat top-level keys
+directly from the prompt's frontmatter.
 """
 
 from __future__ import annotations
@@ -13,17 +13,24 @@ import pytest
 from apm_cli.integration.prompt_integrator import (
     Schedule,
     _derive_package_owner,
-    _parse_schedule,
+    _is_workflow_shape,
+    _parse_workflow_frontmatter,
 )
 
 
-class TestParseSchedule:
+class TestParseWorkflowFrontmatter:
     def test_defaults_when_only_interval(self):
-        s = _parse_schedule({"interval": "manual"})
+        s = _parse_workflow_frontmatter({"interval": "manual"})
         assert s == Schedule(interval="manual")
 
-    def test_full_block(self):
-        s = _parse_schedule(
+    def test_defaults_to_manual_when_only_other_keys(self):
+        # interval optional: presence of other execution keys is enough
+        s = _parse_workflow_frontmatter({"mode": "plan"})
+        assert s.interval == "manual"
+        assert s.mode == "plan"
+
+    def test_full_frontmatter(self):
+        s = _parse_workflow_frontmatter(
             {
                 "interval": "weekly",
                 "schedule_hour": 18,
@@ -41,32 +48,71 @@ class TestParseSchedule:
         assert s.reasoning_effort == "high"
 
     def test_rejects_non_mapping(self):
-        with pytest.raises(ValueError, match=r"'schedule' must be a mapping"):
-            _parse_schedule("daily")
+        with pytest.raises(ValueError, match=r"frontmatter must be a mapping"):
+            _parse_workflow_frontmatter("daily")
 
     def test_rejects_unknown_interval(self):
         with pytest.raises(ValueError, match=r"interval must be one of"):
-            _parse_schedule({"interval": "yearly"})
+            _parse_workflow_frontmatter({"interval": "yearly"})
 
     def test_rejects_out_of_range_hour(self):
         with pytest.raises(ValueError, match=r"schedule_hour must be int 0..23"):
-            _parse_schedule({"interval": "daily", "schedule_hour": 99})
+            _parse_workflow_frontmatter({"interval": "daily", "schedule_hour": 99})
 
     def test_rejects_out_of_range_day(self):
         with pytest.raises(ValueError, match=r"schedule_day must be int 0..6"):
-            _parse_schedule({"interval": "weekly", "schedule_day": 9})
+            _parse_workflow_frontmatter({"interval": "weekly", "schedule_day": 9})
 
     def test_rejects_non_int_hour(self):
         with pytest.raises(ValueError, match=r"schedule_hour must be int 0..23"):
-            _parse_schedule({"interval": "daily", "schedule_hour": "nine"})
+            _parse_workflow_frontmatter({"interval": "daily", "schedule_hour": "nine"})
 
     def test_rejects_unknown_mode(self):
         with pytest.raises(ValueError, match=r"mode must be one of"):
-            _parse_schedule({"interval": "manual", "mode": "rogue"})
+            _parse_workflow_frontmatter({"interval": "manual", "mode": "rogue"})
+
+    def test_rejects_autopilot_mode_with_diagnostic(self):
+        with pytest.raises(ValueError, match=r"autopilot"):
+            _parse_workflow_frontmatter({"interval": "manual", "mode": "autopilot"})
 
     def test_rejects_non_string_model(self):
         with pytest.raises(ValueError, match=r"model must be a string"):
-            _parse_schedule({"interval": "manual", "model": 42})
+            _parse_workflow_frontmatter({"interval": "manual", "model": 42})
+
+
+class TestIsWorkflowShape:
+    def test_plain_prompt_is_not_workflow(self):
+        assert not _is_workflow_shape({"name": "hello", "description": "x"})
+
+    def test_model_alone_is_not_workflow(self):
+        # Pinning a model is legitimate for plain slash commands.
+        assert not _is_workflow_shape({"name": "hello", "model": "gpt-5"})
+
+    def test_interval_marks_workflow(self):
+        assert _is_workflow_shape({"interval": "manual"})
+
+    def test_mode_alone_is_not_workflow(self):
+        # ``mode`` is overloaded: VSCode uses agent|ask|edit, the App uses
+        # interactive|plan|autopilot.  Same concept, different vocabularies.
+        # A plain slash command with ``mode: agent`` must NOT be treated
+        # as a workflow.  Author opts in to the App with ``interval: manual``.
+        assert not _is_workflow_shape({"name": "hello", "mode": "agent"})
+        assert not _is_workflow_shape({"name": "hello", "mode": "plan"})
+
+    def test_schedule_hour_marks_workflow(self):
+        assert _is_workflow_shape({"schedule_hour": 9})
+
+    def test_schedule_day_marks_workflow(self):
+        assert _is_workflow_shape({"schedule_day": 1})
+
+    def test_reasoning_effort_alone_is_not_workflow(self):
+        # ``reasoning_effort`` is a plain-prompt hint in VSCode/Copilot;
+        # not a workflow marker.
+        assert not _is_workflow_shape({"reasoning_effort": "high"})
+
+    def test_handles_non_dict(self):
+        assert not _is_workflow_shape(None)
+        assert not _is_workflow_shape("nope")
 
 
 class _PkgFake:

--- a/tests/unit/integration/test_copilot_app_schedule.py
+++ b/tests/unit/integration/test_copilot_app_schedule.py
@@ -1,0 +1,104 @@
+"""Unit tests for the ``schedule:`` frontmatter parser used by the
+``copilot-app`` target.
+
+Lives in the integrator module because the helper is intentionally
+private to ``apm_cli.integration.prompt_integrator`` (no separate
+module surface area for Wave 2).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apm_cli.integration.prompt_integrator import (
+    Schedule,
+    _derive_package_owner,
+    _parse_schedule,
+)
+
+
+class TestParseSchedule:
+    def test_defaults_when_only_interval(self):
+        s = _parse_schedule({"interval": "manual"})
+        assert s == Schedule(interval="manual")
+
+    def test_full_block(self):
+        s = _parse_schedule(
+            {
+                "interval": "weekly",
+                "schedule_hour": 18,
+                "schedule_day": 5,
+                "mode": "plan",
+                "model": "gpt-5",
+                "reasoning_effort": "high",
+            }
+        )
+        assert s.interval == "weekly"
+        assert s.schedule_hour == 18
+        assert s.schedule_day == 5
+        assert s.mode == "plan"
+        assert s.model == "gpt-5"
+        assert s.reasoning_effort == "high"
+
+    def test_rejects_non_mapping(self):
+        with pytest.raises(ValueError, match=r"'schedule' must be a mapping"):
+            _parse_schedule("daily")
+
+    def test_rejects_unknown_interval(self):
+        with pytest.raises(ValueError, match=r"interval must be one of"):
+            _parse_schedule({"interval": "yearly"})
+
+    def test_rejects_out_of_range_hour(self):
+        with pytest.raises(ValueError, match=r"schedule_hour must be int 0..23"):
+            _parse_schedule({"interval": "daily", "schedule_hour": 99})
+
+    def test_rejects_out_of_range_day(self):
+        with pytest.raises(ValueError, match=r"schedule_day must be int 0..6"):
+            _parse_schedule({"interval": "weekly", "schedule_day": 9})
+
+    def test_rejects_non_int_hour(self):
+        with pytest.raises(ValueError, match=r"schedule_hour must be int 0..23"):
+            _parse_schedule({"interval": "daily", "schedule_hour": "nine"})
+
+    def test_rejects_unknown_mode(self):
+        with pytest.raises(ValueError, match=r"mode must be one of"):
+            _parse_schedule({"interval": "manual", "mode": "rogue"})
+
+    def test_rejects_non_string_model(self):
+        with pytest.raises(ValueError, match=r"model must be a string"):
+            _parse_schedule({"interval": "manual", "model": 42})
+
+
+class _PkgFake:
+    """Minimal stand-in for ``APMPackage`` (only the attrs the helper reads)."""
+
+    def __init__(self, source=None, author=None):
+        self.source = source
+        self.author = author
+
+
+class _PkgInfoFake:
+    def __init__(self, package):
+        self.package = package
+
+
+class TestDerivePackageOwner:
+    def test_github_url(self):
+        pi = _PkgInfoFake(_PkgFake(source="https://github.com/alice/repo"))
+        assert _derive_package_owner(pi) == "alice"
+
+    def test_short_github_form(self):
+        pi = _PkgInfoFake(_PkgFake(source="alice/repo"))
+        assert _derive_package_owner(pi) == "alice"
+
+    def test_github_prefix(self):
+        pi = _PkgInfoFake(_PkgFake(source="github:alice/repo"))
+        assert _derive_package_owner(pi) == "alice"
+
+    def test_falls_back_to_author(self):
+        pi = _PkgInfoFake(_PkgFake(source=None, author="Alice Author"))
+        assert _derive_package_owner(pi) == "Alice Author"
+
+    def test_falls_back_to_local(self):
+        pi = _PkgInfoFake(_PkgFake(source=None, author=None))
+        assert _derive_package_owner(pi) == "local"

--- a/tests/unit/integration/test_copilot_app_target.py
+++ b/tests/unit/integration/test_copilot_app_target.py
@@ -1,0 +1,118 @@
+"""Unit tests for copilot-app target gating in apm_cli.integration.targets.
+
+Mirrors test_copilot_cowork_target.py; covers the same dimensions:
+
+  * for_scope() with resolver returning a path (success) and None (skip)
+  * gating by experimental flag in active_targets / resolve_targets
+  * exclusion from --target all (EXPERIMENTAL_TARGETS contract)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from apm_cli.integration.targets import (
+    KNOWN_TARGETS,
+    active_targets,
+    resolve_targets,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_config_cache():
+    from apm_cli.config import _invalidate_config_cache
+
+    _invalidate_config_cache()
+    yield
+    _invalidate_config_cache()
+
+
+@pytest.fixture
+def inject_config(monkeypatch: pytest.MonkeyPatch):
+    import apm_cli.config as _conf
+
+    def _set(cfg: dict[str, Any]) -> None:
+        monkeypatch.setattr(_conf, "_config_cache", cfg)
+
+    return _set
+
+
+class TestForScope:
+    def test_for_scope_resolver_returns_path(self, tmp_path: Path) -> None:
+        with patch(
+            "apm_cli.integration.targets._resolve_copilot_app_root",
+            return_value=tmp_path,
+        ):
+            result = KNOWN_TARGETS["copilot-app"].for_scope(user_scope=True)
+        assert result is not None
+        assert result.resolved_deploy_root == tmp_path
+
+    def test_for_scope_resolver_returns_none(self) -> None:
+        with patch(
+            "apm_cli.integration.targets._resolve_copilot_app_root",
+            return_value=None,
+        ):
+            result = KNOWN_TARGETS["copilot-app"].for_scope(user_scope=True)
+        assert result is None
+
+
+class TestActiveTargetsGating:
+    def test_absent_when_flag_off_auto_detect(self, tmp_path: Path, inject_config: Any) -> None:
+        inject_config({"experimental": {"copilot_app": False}})
+        results = active_targets(tmp_path)
+        names = [t.name for t in results]
+        assert "copilot-app" not in names
+
+    def test_absent_when_flag_off_explicit_target(self, tmp_path: Path, inject_config: Any) -> None:
+        inject_config({"experimental": {"copilot_app": False}})
+        results = active_targets(tmp_path, explicit_target="copilot-app")
+        assert results == []
+
+    def test_absent_from_all_when_flag_off(self, tmp_path: Path, inject_config: Any) -> None:
+        inject_config({"experimental": {"copilot_app": False}})
+        results = active_targets(tmp_path, explicit_target="all")
+        names = [t.name for t in results]
+        assert "copilot-app" not in names
+
+    def test_absent_from_all_when_flag_on(self, tmp_path: Path, inject_config: Any) -> None:
+        """``--target all`` honors EXPERIMENTAL_TARGETS exclusion regardless of flag."""
+        inject_config({"experimental": {"copilot_app": True}})
+        results = active_targets(tmp_path, explicit_target="all")
+        names = [t.name for t in results]
+        assert "copilot-app" not in names
+
+    def test_absent_when_flag_on_resolver_returns_none(
+        self, tmp_path: Path, inject_config: Any
+    ) -> None:
+        inject_config({"experimental": {"copilot_app": True}})
+        with patch(
+            "apm_cli.integration.targets._resolve_copilot_app_root",
+            return_value=None,
+        ):
+            results = resolve_targets(
+                tmp_path,
+                user_scope=True,
+                explicit_target="copilot-app",
+            )
+        names = [t.name for t in results]
+        assert "copilot-app" not in names
+
+    def test_present_when_flag_on_and_resolver_returns_path(
+        self, tmp_path: Path, inject_config: Any
+    ) -> None:
+        inject_config({"experimental": {"copilot_app": True}})
+        with patch(
+            "apm_cli.integration.targets._resolve_copilot_app_root",
+            return_value=tmp_path,
+        ):
+            results = resolve_targets(
+                tmp_path,
+                user_scope=True,
+                explicit_target="copilot-app",
+            )
+        names = [t.name for t in results]
+        assert "copilot-app" in names

--- a/tests/unit/integration/test_data_driven_dispatch.py
+++ b/tests/unit/integration/test_data_driven_dispatch.py
@@ -308,6 +308,7 @@ class TestExhaustivenessChecks:
             "rules_claude",  # was instructions_claude, aliased
             "skills",  # cross-target bucket
             "hooks",  # cross-target bucket
+            "prompts_copilot-app",  # copilot-app uses dedicated prompts bucket
         }
 
         assert expected_keys == set(buckets.keys()), (


### PR DESCRIPTION
# feat(experimental): `copilot-app` target deploys scheduled prompts to App DB

## TL;DR

Adds an experimental `copilot-app` target so `apm install` deploys prompts (with optional workflow frontmatter: flat top-level `interval` / `schedule_hour` / `schedule_day` keys) directly into the GitHub Copilot desktop App's `~/.copilot/data.db` workflows table. Gated behind `experimental.copilot_app`; user-scope only. No new CLI surface — `install / update / uninstall / list` cover the lifecycle. Workflows always install **disabled** so the user explicitly opts in from the App.

> [!IMPORTANT]
> This is a **dark-shipped experimental target**. Default-off; no impact on existing users. Lifecycle parity is the contract: every supported CLI verb deletes / preserves the DB row correctly, verified by a five-scenario E2E suite.

## Problem (WHY)

- [x] APM has zero presence on the GitHub Copilot desktop App. The App's "Workflows" surface is a first-class scheduling primitive, but today users must hand-craft rows in `~/.copilot/data.db` to use it — there is no package-manager path.
- [x] The inner loop (Copilot CLI prompts) and outer loop (`gh-aw` CI workflows) already have APM targets. The middle of the loop — scheduled prompts on the desktop App — is the only gap, and the one most users notice first because the App is the daily driver.
- [!] Reverse-engineering the App's schema and stuffing rows in via `sqlite3` is exactly the kind of brittle, undocumented surface APM exists to abstract. Without a native target, every adopter pays that tax.

Why these matter: APM's three-promise narrative is **consume / produce / govern**. Without the App target, the "consume" promise stops at the CLI — the surface where prompts are most valuable. The fix is a single new target, not a new primitive type; the existing `prompts` primitive gains optional workflow frontmatter (flat top-level `interval` / `schedule_hour` / `schedule_day` keys) and routes to the App DB when the target resolves.

## Approach (WHAT)

| # | Decision | Why |
|---|----------|-----|
| 1 | New `copilot-app` target (separate from `copilot` CLI) | Same `~/.copilot/` root, different surface (DB vs files). Keeps the CLI target's file-based contract clean. |
| 2 | NO new primitive type — extend `prompts` with optional flat workflow keys (`interval`, `schedule_hour`, `schedule_day`) | "Less is more." Schedule is metadata on a prompt, not a new noun. Preserves the principle [`Favor small, chainable primitives over monolithic frameworks.`](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |
| 3 | NO new CLI subcommands | `apm install / update / uninstall / list` cover the lifecycle. Zero surface area to deprecate. |
| 4 | `enabled = 0` always on install (source value ignored) | Security: never auto-arm a scheduled task. User opts in from the App where the schedule is visible. |
| 5 | Gated behind `experimental.copilot_app` flag | Default-off dark ship; iterate without breaking-change pressure. |
| 6 | Lockfile URI scheme `copilot-app-db://workflows/<namespaced-id>` | Precedent: `cowork://skills/...`. Encodes that the entry is a DB row, not a file path. |
| 7 | `PRAGMA user_version` guard (currently 13) | Refuse to write if the App's schema is newer than tested. |
| 8 | `mode: autopilot` policy-blocked for third-party packages until v3 (signing) | Safe default; user-authored prompts can use any mode. |
| 9 | Update preserves user-side state (`enabled`, `next_run_at`, `last_run_at`, schedule overrides) | `INSERT … ON CONFLICT DO UPDATE` that touches only APM-owned columns. |

## Implementation (HOW)

- **`src/apm_cli/integration/copilot_app_db.py`** (NEW, 529 LOC) — WAL-safe SQLite client. ID namespacing (`apm--<owner>--<pkg>--<prompt>`), URI helpers (`to_lockfile_uri`, `COPILOT_APP_LOCKFILE_PREFIX`), version guard, custom `CopilotAppDBError` exception, retry-on-locked. Pure module; no Click or integrator coupling.
- **`src/apm_cli/integration/targets.py`** — Registers `copilot-app` `TargetProfile` with `requires_flag="copilot_app"` and a user-root resolver that returns `~/.copilot/` only when `data.db` exists.
- **`src/apm_cli/integration/prompt_integrator.py`** — When `target.name == "copilot-app"`, delegates to `copilot_app_db.deploy()` per prompt instead of writing files. Synthesises `<root>/workflows/<id>` as the addressing token for the lockfile pipeline.
- **`src/apm_cli/install/services.py`** — `_deployed_path_entry` now checks dynamic-root targets FIRST (by `target_path.relative_to(_t.resolved_deploy_root)`) before falling back to project-root encoding. This was the critical fix for `--global` installs where project root is the user home and the synthetic copilot-app root sits inside it.
- **`src/apm_cli/install/phases/targets.py`** — Gates explicit `--target copilot-app` with three actionable errors: flag-off hint, project-scope rejection (user-scope only), DB-missing.
- **`src/apm_cli/commands/uninstall/engine.py`** — Adds a copilot-app URI scan over `sync_managed` so user-scope DB-backed targets are cleaned even when the local `apm.yml` does not enumerate them. Also adds `_is_dynamic` skip to bypass the dir-exists guard for DB-backed targets.
- **`src/apm_cli/integration/base_integrator.py`** — Extends `partition_managed_files` dynamic-root branch with the `prompts_copilot-app` bucket so prompts are correctly routed during sync.
- **`src/apm_cli/core/experimental.py`** — Registers `copilot_app` flag.
- **Tests** (1130+ new LOC) — Five-file unit suite: DB module (335 LOC), error UX (221), schedule frontmatter (104), target registration (118), end-to-end install/update/uninstall (352).
- **Docs** — New page `docs/src/content/docs/integrations/copilot-app.md`; `apm-usage` skill updated per [docs.instructions.md rule 4](https://github.com/microsoft/apm/blob/main/.github/instructions/docs.instructions.md).

## Diagrams

End-to-end deploy flow when the user runs `apm install <pkg> --target copilot-app --global` against a prompt that carries flat workflow keys (`interval`, `schedule_hour`, `schedule_day`):

```mermaid
sequenceDiagram
    autonumber
    participant U as User
    participant CLI as apm CLI
    participant Resolver as targets.py
    participant Prompt as PromptIntegrator
    participant DB as copilot_app_db
    participant App as ~/.copilot/data.db

    U->>CLI: apm install pkg --target copilot-app --global
    CLI->>Resolver: resolve(copilot-app, user_scope=True)
    Resolver->>Resolver: check experimental.copilot_app
    Resolver->>App: stat data.db (exists?)
    App-->>Resolver: ok, user_version=13
    Resolver-->>CLI: TargetProfile(resolved_deploy_root=~/.copilot/)
    CLI->>Prompt: integrate_prompts_for_target(copilot-app)
    Prompt->>DB: deploy(prompt + schedule, namespaced_id)
    DB->>App: INSERT ... ON CONFLICT DO UPDATE (enabled=0)
    App-->>DB: row written
    DB-->>Prompt: synthetic target_path = ~/.copilot/workflows/apm--owner--pkg--name
    Prompt-->>CLI: target_paths
    CLI->>CLI: _deployed_path_entry emits copilot-app-db URI
    CLI-->>U: 1 prompt installed (disabled, enable in the App)
```

The lockfile URI scheme is the single source of truth for cleanup — uninstall scans for the prefix and deletes the matching rows without needing the package's `apm.yml` to be present:

```mermaid
flowchart LR
    Lock[apm.lock.yaml<br/>deployed_files]
    Scan{Scan for<br/>copilot-app-db://}
    DB[(data.db<br/>workflows)]

    Lock --> Scan
    Scan -->|"copilot-app-db://workflows/apm--..."| Resolve[Synthesise user-scope<br/>copilot-app TargetProfile]
    Resolve --> Delete[sync_for_target<br/>deletes rows]
    Delete --> DB

    Scan -->|"any/other/path"| Skip[Skip - handled by<br/>per-target loop]
```

## Trade-offs

- **Coupling to App schema version (`user_version = 13`).** We refuse to write on unknown / newer versions and surface an actionable upgrade hint. Alternative considered: schema-agnostic write. Rejected — silently writing into an unknown schema is the exact bug class users would blame APM for.
- **No DB-level auth.** SQLite has no authentication primitive; "auth" is filesystem-permission only (App DB is mode 0600 owned by the user). Documented transparently; we do NOT promise auth we don't have.
- **`enabled = 0` is non-configurable.** Source-file `enabled: true` is ignored. Trade-off: one extra click for the user, but no third-party package can auto-arm a scheduled task on install. Reversal is one PR if it becomes friction.
- **Local-path installs need the dynamic-root check first.** The pre-fix code used `relative_to(project_root)` to decide whether to apply the URI scheme; for `--global` installs that succeeded spuriously because the user home contains `~/.copilot/`. Fixed by checking dynamic-root targets up front; the legacy out-of-tree branch is preserved for `cowork://` semantics.

## Benefits

1. **Zero new CLI surface** — `install / update / uninstall / list` cover the lifecycle. Nothing to deprecate later.
2. **One namespaced ID convention** (`apm--<owner>--<pkg>--<prompt>`) makes APM-managed rows trivially distinguishable from user-created ones; uninstall touches only APM rows.
3. **Lifecycle parity verified** — 5-scenario E2E suite covers install, re-install (update), uninstall, missing-DB error UX, and the local-path roundtrip that surfaced the URI-scheme bug.
4. **Dark-ship safe** — default-off via `experimental.copilot_app`; existing installs unchanged.
5. **Extension path clear** — same pattern (target + dynamic-root + URI scheme) will plug `gh-aw` (outer loop) in v2 without refactoring.

## Validation

Lint (canonical contract from `.apm/instructions/linting.instructions.md`):

```
$ uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/
All checks passed!
793 files already formatted
```

Full unit suite (8795 passed, single pre-existing Windows-only skip):

```
$ uv run --extra dev pytest tests/unit/ -q --tb=line
8795 passed, 1 skipped, 1 deselected, 1 warning, 33 subtests passed in 35.13s
```

### Scenario Evidence

| # | User-promise scenario | Test path | APM principle |
|---|----------------------|-----------|---------------|
| 1 | `apm install` writes one DB row per scheduled prompt, namespaced and disabled | `tests/unit/install/test_install_target_copilot_app_e2e.py::TestCopilotAppDeployUninstall::test_install_then_uninstall_roundtrip` | Consume — pkg manager owns the deploy contract |
| 2 | `apm install <local-path> --global` deploys with the `copilot-app-db://` URI scheme, and `apm uninstall` deletes the DB row | `TestCopilotAppDeployUninstall::test_install_local_pkg_then_uninstall_deletes_db_row` | Consume — lifecycle parity, no orphaned state |
| 3 | `--target copilot-app` without the flag emits an actionable enable hint | `TestCopilotAppParserE2E::test_flag_off_emits_enable_hint` | Govern — experimental features are opt-in and discoverable |
| 4 | `--target copilot-app` without `--global` rejects project scope | `TestCopilotAppParserE2E::test_project_scope_requires_global` | Govern — surface contracts must match the underlying resource |
| 5 | DB missing → actionable error pointing at App install | `TestCopilotAppParserE2E::test_flag_on_db_missing_errors` | Consume — fail loudly, fail helpfully |
| 6 | Version-guard refuses on unknown `user_version` | `tests/unit/integration/test_copilot_app_db.py` (version-guard cases) | Govern — never write into an unverified schema |
| 7 | Schedule frontmatter validates intervals / hours / days / modes | `tests/unit/integration/test_copilot_app_schedule.py` | Produce — package authors get loud errors at compile, not at App runtime |

<details><summary>Five copilot-app E2E results (verbatim)</summary>

```
$ uv run --extra dev pytest tests/unit/install/test_install_target_copilot_app_e2e.py -v
tests/unit/install/test_install_target_copilot_app_e2e.py::TestCopilotAppParserE2E::test_flag_off_emits_enable_hint PASSED [ 20%]
tests/unit/install/test_install_target_copilot_app_e2e.py::TestCopilotAppParserE2E::test_flag_on_db_missing_errors PASSED [ 40%]
tests/unit/install/test_install_target_copilot_app_e2e.py::TestCopilotAppParserE2E::test_project_scope_requires_global PASSED [ 60%]
tests/unit/install/test_install_target_copilot_app_e2e.py::TestCopilotAppDeployUninstall::test_install_then_uninstall_roundtrip PASSED [ 80%]
tests/unit/install/test_install_target_copilot_app_e2e.py::TestCopilotAppDeployUninstall::test_install_local_pkg_then_uninstall_deletes_db_row PASSED [100%]
============================== 5 passed in 1.28s ===============================
```

</details>

## How to test

1. `apm config set experimental.copilot_app true`
2. Create a tiny package `pkg/.apm/prompts/daily-digest.prompt.md` with flat workflow keys at the top level (`interval: daily`, `schedule_hour: 9`).
3. `apm install ./pkg --target copilot-app --global` — expect `[+] 1 prompt installed`; verify `sqlite3 ~/.copilot/data.db "SELECT name, enabled FROM workflows WHERE name LIKE 'apm--%';"` shows the row with `enabled = 0`.
4. Open the Copilot App, find the workflow under "Workflows", flip the toggle on — `enabled` flips to `1` in the DB.
5. `apm uninstall ./pkg --global` — expect `Cleaned up 1 integrated prompts`; the row is gone and any user-created rows are untouched.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
