### PR TITLE
fix(install): detect Windows Defender AV block and emit specific guidance

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -275,28 +275,38 @@ function Get-Sha256Hex {
 }
 
 function Test-AccessDeniedError {
-    # AppLocker / WDAC / App Control for Business denies CreateProcess on EXEs
-    # under user-writable paths (e.g. %TEMP%, %LOCALAPPDATA%\Temp) with HRESULT
-    # 0x80070005 (E_ACCESSDENIED), surfaced by PowerShell as "Access is denied".
+    # AppLocker / WDAC / App Control for Business / SRP / Group Policy deny
+    # CreateProcess on EXEs under user-writable paths (e.g. %TEMP%,
+    # %LOCALAPPDATA%\Temp) with one of:
+    #   0x80070005 (E_ACCESSDENIED, Win32 5)         -> "Access is denied"
+    #   0x800704EC (ERROR_ACCESS_DISABLED_BY_POLICY, -> "This program is
+    #               Win32 1260)                          blocked by group policy"
+    # Both belong in the AppControl/AppLocker guidance bucket.
     param([string]$Text)
     if (-not $Text) { return $false }
-    return ($Text -match 'Access is denied' -or $Text -match '0x80070005')
+    return (
+        $Text -match 'Access is denied' -or
+        $Text -match 'blocked by group policy' -or
+        $Text -match '0x80070005' -or
+        $Text -match '0x800704EC'
+    )
 }
 
 function Test-AntivirusBlockError {
     # Defender / 3rd-party AV real-time protection blocks CreateProcess on
-    # binaries it flags with HRESULT 0x800700E1 (ERROR_VIRUS_INFECTED) or
-    # 0x800704EC (ERROR_VIRUS_DELETED). PowerShell surfaces these as
-    # "Operation did not complete successfully because the file contains a
-    # virus or potentially unwanted software". Our PyInstaller-built apm.exe
-    # is unsigned, which routinely trips false-positive heuristics.
+    # binaries it flags with HRESULT 0x800700E1 (ERROR_VIRUS_INFECTED,
+    # Win32 225) or 0x800700E2 (ERROR_VIRUS_DELETED, Win32 226). PowerShell
+    # surfaces these as "Operation did not complete successfully because
+    # the file contains a virus or potentially unwanted software". Our
+    # PyInstaller-built apm.exe is unsigned, which routinely trips
+    # false-positive heuristics.
     param([string]$Text)
     if (-not $Text) { return $false }
     return (
         $Text -match 'contains a virus' -or
         $Text -match 'potentially unwanted software' -or
         $Text -match '0x800700E1' -or
-        $Text -match '0x800704EC'
+        $Text -match '0x800700E2'
     )
 }
 
@@ -333,24 +343,33 @@ function Write-AntivirusGuidance {
     )
     Write-Host ""
     Write-ErrorText "An antivirus product blocked execution of $Path."
-    Write-Host "Windows Defender (or another real-time scanner) flagged the binary as"
-    Write-Host "potentially unwanted software. The apm.exe release is built with"
-    Write-Host "PyInstaller and is currently unsigned, which routinely trips false-"
-    Write-Host "positive heuristics. The file is not actually malicious."
+    Write-Host "Windows Defender (or another real-time scanner) flagged the binary."
+    Write-Host "The apm.exe release is built with PyInstaller and is currently"
+    Write-Host "unsigned, which routinely trips false-positive heuristics on"
+    Write-Host "unsigned binaries. Most blocks of apm.exe are false positives, but"
+    Write-Host "you should verify integrity before excluding it:"
     Write-Host ""
-    Write-Info "Options to unblock:"
+    Write-Host "  1. Verify the SHA256 of apm.exe against the published .sha256"
+    Write-Host "     sidecar on the release page before adding any AV exclusion."
+    Write-Host "     Do not exclude a binary whose checksum you have not verified."
+    Write-Host ""
+    Write-Info "If the checksum matches, options to unblock:"
     if ($TargetInstallDir) {
-        Write-Host "  1. Add a Defender exclusion for the install directory (run in an"
-        Write-Host "     elevated PowerShell, then rerun this installer):"
-        Write-Host "       Add-MpPreference -ExclusionPath '$TargetInstallDir'"
+        # Single-quote-escape the path so the printed command stays valid
+        # even if the install directory contains a "'" character (rare but
+        # possible in usernames).
+        $escapedDir = $TargetInstallDir -replace "'", "''"
+        Write-Host "  a. Add a Defender exclusion for the install directory (run in"
+        Write-Host "     an elevated PowerShell, then rerun this installer):"
+        Write-Host "       Add-MpPreference -ExclusionPath '$escapedDir'"
     } else {
-        Write-Host "  1. Add a Defender exclusion for apm.exe (run in an elevated"
+        Write-Host "  a. Add a Defender exclusion for apm.exe (run in an elevated"
         Write-Host "     PowerShell, then rerun this installer):"
         Write-Host "       Add-MpPreference -ExclusionProcess 'apm.exe'"
     }
-    Write-Host "  2. Install via pip into your user site (avoids the binary entirely):"
+    Write-Host "  b. Install via pip into your user site (avoids the binary entirely):"
     Write-Host "       pip install --user apm-cli"
-    Write-Host "  3. Help us get the false positive cleared by submitting the binary"
+    Write-Host "  c. Help us get the false positive cleared by submitting the binary"
     Write-Host "     to Microsoft: https://www.microsoft.com/en-us/wdsi/filesubmission"
     Write-Host ""
 }

--- a/install.ps1
+++ b/install.ps1
@@ -283,6 +283,23 @@ function Test-AccessDeniedError {
     return ($Text -match 'Access is denied' -or $Text -match '0x80070005')
 }
 
+function Test-AntivirusBlockError {
+    # Defender / 3rd-party AV real-time protection blocks CreateProcess on
+    # binaries it flags with HRESULT 0x800700E1 (ERROR_VIRUS_INFECTED) or
+    # 0x800704EC (ERROR_VIRUS_DELETED). PowerShell surfaces these as
+    # "Operation did not complete successfully because the file contains a
+    # virus or potentially unwanted software". Our PyInstaller-built apm.exe
+    # is unsigned, which routinely trips false-positive heuristics.
+    param([string]$Text)
+    if (-not $Text) { return $false }
+    return (
+        $Text -match 'contains a virus' -or
+        $Text -match 'potentially unwanted software' -or
+        $Text -match '0x800700E1' -or
+        $Text -match '0x800704EC'
+    )
+}
+
 function Write-AppControlGuidance {
     param(
         [string]$Path,
@@ -306,6 +323,35 @@ function Write-AppControlGuidance {
     Write-Host "       `$env:APM_TEMP_DIR = `"`$env:LOCALAPPDATA\Programs\apm\tmp`""
     Write-Host "  3. Install via pip into your user site:"
     Write-Host "       pip install --user apm-cli"
+    Write-Host ""
+}
+
+function Write-AntivirusGuidance {
+    param(
+        [string]$Path,
+        [string]$TargetInstallDir
+    )
+    Write-Host ""
+    Write-ErrorText "An antivirus product blocked execution of $Path."
+    Write-Host "Windows Defender (or another real-time scanner) flagged the binary as"
+    Write-Host "potentially unwanted software. The apm.exe release is built with"
+    Write-Host "PyInstaller and is currently unsigned, which routinely trips false-"
+    Write-Host "positive heuristics. The file is not actually malicious."
+    Write-Host ""
+    Write-Info "Options to unblock:"
+    if ($TargetInstallDir) {
+        Write-Host "  1. Add a Defender exclusion for the install directory (run in an"
+        Write-Host "     elevated PowerShell, then rerun this installer):"
+        Write-Host "       Add-MpPreference -ExclusionPath '$TargetInstallDir'"
+    } else {
+        Write-Host "  1. Add a Defender exclusion for apm.exe (run in an elevated"
+        Write-Host "     PowerShell, then rerun this installer):"
+        Write-Host "       Add-MpPreference -ExclusionProcess 'apm.exe'"
+    }
+    Write-Host "  2. Install via pip into your user site (avoids the binary entirely):"
+    Write-Host "       pip install --user apm-cli"
+    Write-Host "  3. Help us get the false positive cleared by submitting the binary"
+    Write-Host "     to Microsoft: https://www.microsoft.com/en-us/wdsi/filesubmission"
     Write-Host ""
 }
 
@@ -645,8 +691,11 @@ try {
 
     if ($testFailure) {
         $denied = Test-AccessDeniedError -Text $testFailure
+        $avBlocked = Test-AntivirusBlockError -Text $testFailure
         Write-ErrorText "Downloaded binary failed to run: $testFailure"
-        if ($denied) {
+        if ($avBlocked) {
+            Write-AntivirusGuidance -Path $stagedExe -TargetInstallDir $releaseDir
+        } elseif ($denied) {
             Write-AppControlGuidance -Path $stagedExe -TargetInstallDir $releaseDir
         }
         Remove-Item -Recurse -Force $stagingDir -ErrorAction SilentlyContinue

--- a/scripts/windows/test-install-script.ps1
+++ b/scripts/windows/test-install-script.ps1
@@ -83,7 +83,7 @@ Remove-Module Microsoft.PowerShell.Utility -Force -ErrorAction SilentlyContinue
 $($match.Value)
 Write-Output (Get-Sha256Hex -Path '$tempFile')
 "@
-        $childScriptPath = [System.IO.Path]::GetTempFileName() + ".ps1"
+        $childScriptPath = [System.IO.Path]::Combine($env:TEMP, [System.IO.Path]::GetRandomFileName() + ".ps1")
         Set-Content -Path $childScriptPath -Value $childScript -Encoding UTF8
         try {
             $actual = & powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File $childScriptPath 2>&1
@@ -176,34 +176,55 @@ $($accessMatch.Value)
 `$defenderMsg = "Program 'apm.exe' failed to run: Operation did not complete successfully because the file contains a virus or potentially unwanted softwareAt C:\\Users\\X\\AppData\\Local\\Temp\\tmpfoo.ps1:639 char:23"
 `$puaMsg      = "blocked: potentially unwanted software detected"
 `$hresultMsg  = "CreateProcess failed with 0x800700E1"
+`$deletedMsg  = "Operation failed with 0x800700E2 (file removed by antivirus)"
 `$accessMsg   = "Program 'apm.exe' failed to run: Access is denied"
+`$gpoMsg      = "This program is blocked by group policy. For more information, contact your system administrator. (0x800704EC)"
 `$benignMsg   = "exit code 1 - apm: command not found"
 
 `$results = @{
     defender_match = (Test-AntivirusBlockError -Text `$defenderMsg)
     pua_match      = (Test-AntivirusBlockError -Text `$puaMsg)
     hresult_match  = (Test-AntivirusBlockError -Text `$hresultMsg)
+    deleted_match  = (Test-AntivirusBlockError -Text `$deletedMsg)
     access_no_av   = (-not (Test-AntivirusBlockError -Text `$accessMsg))
+    gpo_no_av      = (-not (Test-AntivirusBlockError -Text `$gpoMsg))
     benign_no_av   = (-not (Test-AntivirusBlockError -Text `$benignMsg))
     empty_no_av    = (-not (Test-AntivirusBlockError -Text ''))
-    # Cross-check: the Defender message must NOT be classified as AppLocker.
+    # Cross-class: AppLocker/SRP/GPO must NOT be misclassified as AV.
     defender_not_access = (-not (Test-AccessDeniedError -Text `$defenderMsg))
+    # GPO/SRP block (0x800704EC) belongs in the AppControl bucket, not AV.
+    gpo_is_access  = (Test-AccessDeniedError -Text `$gpoMsg)
+    access_is_access = (Test-AccessDeniedError -Text `$accessMsg)
 }
-`$results | ConvertTo-Json -Compress
+Write-Output '---APM-JSON-BEGIN---'
+Write-Output (`$results | ConvertTo-Json -Compress)
+Write-Output '---APM-JSON-END---'
 "@
 
-    $tempScript = [System.IO.Path]::GetTempFileName() + ".ps1"
+    # Use GetRandomFileName so we don't leak the GetTempFileName-created
+    # zero-byte .tmp companion file every run.
+    $tempScript = [System.IO.Path]::Combine($env:TEMP, [System.IO.Path]::GetRandomFileName() + ".ps1")
     try {
         Set-Content -Path $tempScript -Value $childScript -Encoding UTF8
-        $json = & pwsh -NoProfile -NonInteractive -File $tempScript 2>&1 | Select-Object -Last 1
+        $raw = & pwsh -NoProfile -NonInteractive -File $tempScript 2>&1
+        $lines = ($raw | Out-String) -split "`r?`n"
+        $begin = [Array]::IndexOf($lines, '---APM-JSON-BEGIN---')
+        $end   = [Array]::IndexOf($lines, '---APM-JSON-END---')
+        Assert-True (($begin -ge 0) -and ($end -gt $begin)) "Located JSON sentinels in child output"
+        if (($begin -lt 0) -or ($end -le $begin)) { return }
+        $json = ($lines[($begin + 1)..($end - 1)] -join '').Trim()
         $r = $json | ConvertFrom-Json
         Assert-True ([bool]$r.defender_match)      "Matches real Defender 'contains a virus' message"
         Assert-True ([bool]$r.pua_match)           "Matches 'potentially unwanted software' message"
-        Assert-True ([bool]$r.hresult_match)       "Matches HRESULT 0x800700E1"
+        Assert-True ([bool]$r.hresult_match)       "Matches HRESULT 0x800700E1 (ERROR_VIRUS_INFECTED)"
+        Assert-True ([bool]$r.deleted_match)       "Matches HRESULT 0x800700E2 (ERROR_VIRUS_DELETED)"
         Assert-True ([bool]$r.access_no_av)        "Does not misclassify 'Access is denied' as AV block"
+        Assert-True ([bool]$r.gpo_no_av)           "Does not misclassify GPO/SRP block (0x800704EC) as AV"
         Assert-True ([bool]$r.benign_no_av)        "Does not misclassify benign failure text as AV block"
         Assert-True ([bool]$r.empty_no_av)         "Does not match empty input"
         Assert-True ([bool]$r.defender_not_access) "Defender message is not classified as AppLocker/WDAC"
+        Assert-True ([bool]$r.gpo_is_access)       "GPO/SRP block (0x800704EC) routes to AppControl guidance"
+        Assert-True ([bool]$r.access_is_access)    "'Access is denied' still routes to AppControl guidance"
     } finally {
         Remove-Item -Path $tempScript -Force -ErrorAction SilentlyContinue
     }

--- a/scripts/windows/test-install-script.ps1
+++ b/scripts/windows/test-install-script.ps1
@@ -146,6 +146,70 @@ function Test-MoveThenTestOrdering {
 }
 
 # ---------------------------------------------------------------------------
+# Test 2b: Test-AntivirusBlockError detects Windows Defender / AV signatures.
+# Issue: Defender flags the unsigned PyInstaller binary as PUA (HRESULT
+# 0x800700E1), and the installer must distinguish that from AppLocker /
+# WDAC denial so it can emit the right guidance (exclusion + pip fallback,
+# not allow-list rule).
+# ---------------------------------------------------------------------------
+
+function Test-AntivirusDetector {
+    Write-Step "Test 2b: Test-AntivirusBlockError matches Defender PUA signatures"
+
+    $content = Get-Content $InstallScript -Raw
+    $pattern = '(?s)function Test-AntivirusBlockError\s*\{.*?\n\}'
+    $match = [regex]::Match($content, $pattern)
+    Assert-True $match.Success "Extracted Test-AntivirusBlockError from install.ps1"
+    if (-not $match.Success) { return }
+
+    $accessPattern = '(?s)function Test-AccessDeniedError\s*\{.*?\n\}'
+    $accessMatch = [regex]::Match($content, $accessPattern)
+    Assert-True $accessMatch.Success "Extracted Test-AccessDeniedError from install.ps1"
+    if (-not $accessMatch.Success) { return }
+
+    $childScript = @"
+`$ErrorActionPreference = 'Stop'
+$($match.Value)
+$($accessMatch.Value)
+
+# Real Defender failure text from issue #1389 follow-up:
+`$defenderMsg = "Program 'apm.exe' failed to run: Operation did not complete successfully because the file contains a virus or potentially unwanted softwareAt C:\\Users\\X\\AppData\\Local\\Temp\\tmpfoo.ps1:639 char:23"
+`$puaMsg      = "blocked: potentially unwanted software detected"
+`$hresultMsg  = "CreateProcess failed with 0x800700E1"
+`$accessMsg   = "Program 'apm.exe' failed to run: Access is denied"
+`$benignMsg   = "exit code 1 - apm: command not found"
+
+`$results = @{
+    defender_match = (Test-AntivirusBlockError -Text `$defenderMsg)
+    pua_match      = (Test-AntivirusBlockError -Text `$puaMsg)
+    hresult_match  = (Test-AntivirusBlockError -Text `$hresultMsg)
+    access_no_av   = (-not (Test-AntivirusBlockError -Text `$accessMsg))
+    benign_no_av   = (-not (Test-AntivirusBlockError -Text `$benignMsg))
+    empty_no_av    = (-not (Test-AntivirusBlockError -Text ''))
+    # Cross-check: the Defender message must NOT be classified as AppLocker.
+    defender_not_access = (-not (Test-AccessDeniedError -Text `$defenderMsg))
+}
+`$results | ConvertTo-Json -Compress
+"@
+
+    $tempScript = [System.IO.Path]::GetTempFileName() + ".ps1"
+    try {
+        Set-Content -Path $tempScript -Value $childScript -Encoding UTF8
+        $json = & pwsh -NoProfile -NonInteractive -File $tempScript 2>&1 | Select-Object -Last 1
+        $r = $json | ConvertFrom-Json
+        Assert-True ([bool]$r.defender_match)      "Matches real Defender 'contains a virus' message"
+        Assert-True ([bool]$r.pua_match)           "Matches 'potentially unwanted software' message"
+        Assert-True ([bool]$r.hresult_match)       "Matches HRESULT 0x800700E1"
+        Assert-True ([bool]$r.access_no_av)        "Does not misclassify 'Access is denied' as AV block"
+        Assert-True ([bool]$r.benign_no_av)        "Does not misclassify benign failure text as AV block"
+        Assert-True ([bool]$r.empty_no_av)         "Does not match empty input"
+        Assert-True ([bool]$r.defender_not_access) "Defender message is not classified as AppLocker/WDAC"
+    } finally {
+        Remove-Item -Path $tempScript -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# ---------------------------------------------------------------------------
 # Test 3: Run install.ps1 end-to-end into an isolated prefix.
 # ---------------------------------------------------------------------------
 
@@ -392,6 +456,7 @@ Write-Host ""
 
 Test-Sha256Fallback
 Test-MoveThenTestOrdering
+Test-AntivirusDetector
 Test-EndToEndInstall
 Test-CrossVersionUpgrade
 Test-SameVersionReinstall


### PR DESCRIPTION
## Problem

The Windows installer (and `apm self-update`) fails on hosts where Windows Defender (or another real-time AV) flags the unsigned PyInstaller `apm.exe` as potentially unwanted software. The binary smoke test throws:

> Program 'apm.exe' failed to run: Operation did not complete successfully because the file contains a virus or potentially unwanted software

This is HRESULT `0x800700E1` (`ERROR_VIRUS_INFECTED`). PR #1390 added `Test-AccessDeniedError` for AppLocker / App Control for Business denials (HRESULT `0x80070005`), but did not cover this distinct AV error class. The installer therefore fell through to a generic "failed to run" message and a pip fallback that itself died on hosts running an unsupported Python (e.g. 3.14), leaving the user stuck with no actionable guidance.

## Changes

- **`install.ps1`**: add `Test-AntivirusBlockError` mirroring the `Test-AccessDeniedError` contract. Matches the Defender PUA message, the generic `contains a virus` / `potentially unwanted software` phrasing, and HRESULTs `0x800700E1` and `0x800704EC`.
- **`install.ps1`**: add `Write-AntivirusGuidance` with three actionable options:
  1. `Add-MpPreference -ExclusionPath` on the install root (elevated PowerShell).
  2. `pip install --user apm-cli` (avoids the binary entirely).
  3. Submit the binary to the Microsoft false-positive portal.

  Wired into the `testFailure` branch ahead of the AppLocker guidance check — the two error classes are distinct and must not be conflated.
- **`scripts/windows/test-install-script.ps1`**: new `Test-AntivirusDetector` covering real Defender output, generic PUA text, both HRESULTs, cross-class disambiguation (access-denied must NOT be classified as AV, and vice versa), and empty/benign strings.

## Validation

All 7 detector cases pass locally against the `install.ps1` functions. The new `Test-AntivirusDetector` runs in the existing windows-latest CI matrix entry alongside the rest of the install-script integration tests.

## Not in scope

- **Signing the release binary.** Proper long-term fix; tracked separately as a CI/release-infra change, not an installer change.
- **Auto-applying a Defender exclusion.** Requires elevation and changes endpoint security posture — must remain an explicit user action.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>