### PR TITLE
fix(ado): resolve az binary via shutil.which for Windows az.cmd (closes #1430)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm update` against private Azure DevOps deps no longer fails on Windows with a misleading "az present but not logged in" diagnostic when the user IS signed in via `az login`. Root cause: Python's `subprocess.run(["az", ...])` -> `CreateProcessW` does not honor `PATHEXT` for non-`.exe` executables, so the Windows `az.cmd` wrapper could not be invoked even though `shutil.which("az")` resolved it. `AzureCliBearerProvider` now resolves the `az` binary via `shutil.which` once at construction and passes the absolute path to every subprocess call. As a defense-in-depth measure, the ADO `--update` preflight probe no longer strips `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_NOSYSTEM` / `GIT_ASKPASS`, so Git Credential Manager can answer for Entra-cached ADO credentials whenever bearer acquisition is unavailable for any reason (sandbox, proxy, future PATH quirks). The actual clone path keeps its full gitconfig isolation. (#1430)
+
 - Root `.apm` hooks no longer duplicate after renaming the project directory or using git worktrees; Claude, Codex, Cursor, Gemini, and Windsurf hook configs stay idempotent across checkouts. The hook source-id is now derived from `apm.yml`'s `name` field instead of `install_path.name`, and `apm install` silently heals stale same-content entries from prior checkout basenames. Copilot is unaffected (its hooks live in per-file namespaces under `.github/hooks/`, not a shared merged config). (#1392, closes #1329)
 
 ## [0.14.1] - 2026-05-20

--- a/src/apm_cli/core/azure_cli.py
+++ b/src/apm_cli/core/azure_cli.py
@@ -92,12 +92,13 @@ class AzureCliBearerProvider:
         # DOES honor PATHEXT) and storing the absolute path keeps every
         # downstream subprocess.run call portable across platforms.
         #
-        # Edge case: callers (notably tests) may pass an explicit path.
-        # If az_command already looks like a path (absolute or contains a
-        # separator) we trust it verbatim and skip re-resolution.
+        # Edge case: callers (notably tests) may pass an explicit absolute
+        # path. We trust absolute paths verbatim and skip re-resolution.
+        # Relative tokens always flow through shutil.which so a
+        # CWD-relative form like "subdir/az" cannot bypass resolution.
         #
         # PATH changes mid-process won't be detected; restart the CLI.
-        if os.path.isabs(az_command) or os.sep in az_command:
+        if os.path.isabs(az_command):
             self._az_command: str | None = az_command
         else:
             self._az_command = shutil.which(az_command)
@@ -168,6 +169,12 @@ class AzureCliBearerProvider:
         Uses ``az account show --query tenantId -o tsv``.  Returns ``None``
         on any failure -- this method never raises.
         """
+        # Explicit early-return when az was not resolved at __init__: avoids
+        # passing None as argv[0] to subprocess.run (which would TypeError
+        # and only be swallowed by the broad except below). Mirrors the
+        # is_available() guard that get_bearer_token() does.
+        if not self._az_command:
+            return None
         try:
             result = subprocess.run(
                 [self._az_command, "account", "show", "--query", "tenantId", "-o", "tsv"],

--- a/src/apm_cli/core/azure_cli.py
+++ b/src/apm_cli/core/azure_cli.py
@@ -20,6 +20,7 @@ Usage::
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import threading
@@ -82,7 +83,24 @@ class AzureCliBearerProvider:
     _EXPIRY_SLACK_SECONDS: int = 60
 
     def __init__(self, az_command: str = "az") -> None:
-        self._az_command = az_command
+        # Resolve the az executable once at construction. On Windows the
+        # Azure CLI ships as az.cmd (a batch wrapper), and Python's
+        # subprocess.run -> CreateProcessW does NOT honor PATHEXT for
+        # non-.exe executables, so a bare "az" token fails with
+        # FileNotFoundError even though `shutil.which("az")` resolves it.
+        # See microsoft/apm#1430. Resolving via shutil.which here (which
+        # DOES honor PATHEXT) and storing the absolute path keeps every
+        # downstream subprocess.run call portable across platforms.
+        #
+        # Edge case: callers (notably tests) may pass an explicit path.
+        # If az_command already looks like a path (absolute or contains a
+        # separator) we trust it verbatim and skip re-resolution.
+        #
+        # PATH changes mid-process won't be detected; restart the CLI.
+        if os.path.isabs(az_command) or os.sep in az_command:
+            self._az_command: str | None = az_command
+        else:
+            self._az_command = shutil.which(az_command)
         # Cache stores (token, expires_at_epoch_seconds). expires_at is None
         # if the response did not include an expiresOn field (very old az
         # versions); in that case the token is treated as never-expiring
@@ -93,12 +111,16 @@ class AzureCliBearerProvider:
     # -- public API ---------------------------------------------------------
 
     def is_available(self) -> bool:
-        """Return True iff the ``az`` binary is on PATH.
+        """Return True iff the ``az`` binary was found on PATH at construction.
+
+        Resolution is one-shot (performed in :meth:`__init__`). PATH changes
+        made after the provider was constructed will NOT be observed; restart
+        the CLI if you have installed ``az`` mid-session.
 
         Does NOT check whether the user is logged in -- that requires a
         subprocess call and is deferred to :meth:`get_bearer_token`.
         """
-        return shutil.which(self._az_command) is not None
+        return self._az_command is not None
 
     def get_bearer_token(self) -> str:
         """Acquire (or return cached) bearer token for Azure DevOps.

--- a/src/apm_cli/install/pipeline.py
+++ b/src/apm_cli/install/pipeline.py
@@ -157,7 +157,21 @@ def _preflight_auth_check(ctx, auth_resolver, verbose: bool) -> None:
         )
         _ctx_env = getattr(dep_ctx, "git_env", {}) or {}
         probe_env = {**os.environ, **_dl.git_env, **_ctx_env}
-        if is_generic:
+        # GIT_CONFIG_GLOBAL / GIT_CONFIG_NOSYSTEM carve-out: GitAuthEnvBuilder
+        # forces an empty global gitconfig for ALL hosts to prevent a user's
+        # ~/.gitconfig insteadOf rewrites or credential helpers from leaking
+        # tokens during a clone. But for preflight probes (a single ls-remote
+        # against the same host the dep targets), the redirection surface is
+        # nil and killing the user's global config kills Git Credential
+        # Manager along with it -- the helper most Windows ADO users rely on
+        # for Entra-cached credentials. For ADO specifically that matters
+        # because bearer acquisition can fail for reasons unrelated to login
+        # state (sandbox, proxy, microsoft/apm#1430-style PATH quirks), and
+        # GCM is the only remaining channel that can save us. Generic hosts
+        # have the same logic; widening the carve-out to ADO keeps the
+        # actual clone path isolated (it builds its own clean env) while
+        # giving the preflight probe the best chance to succeed.
+        if is_generic or is_azure_devops_hostname(host):
             for _key in ("GIT_CONFIG_GLOBAL", "GIT_CONFIG_NOSYSTEM", "GIT_ASKPASS"):
                 probe_env.pop(_key, None)
 

--- a/tests/unit/install/test_pipeline_auth_preflight.py
+++ b/tests/unit/install/test_pipeline_auth_preflight.py
@@ -194,11 +194,17 @@ class TestPreflightGenericHostAllowsCredentialHelpers:
         assert str(exc_info.value).startswith("Authentication failed for ghes.corp.example.com")
 
     @patch("subprocess.run")
-    def test_ado_host_retains_credential_blocking_env(self, mock_run):
-        """ADO hosts should retain GIT_ASKPASS (locked-down env with token in URL).
+    def test_ado_host_omits_credential_blocking_env(self, mock_run):
+        """ADO hosts strip GIT_CONFIG_GLOBAL / GIT_CONFIG_NOSYSTEM / GIT_ASKPASS
+        from the preflight probe env so Git Credential Manager can answer
+        for Entra-cached ADO creds when bearer acquisition is unavailable
+        (microsoft/apm#1430 -- Windows az.cmd resolution failure, sandboxed
+        runs, proxy issues, etc.).
 
-        Generic hosts strip GIT_ASKPASS to allow credential helpers; ADO hosts
-        keep it because auth is via token embedded in the URL.
+        The actual clone path remains isolated -- it builds its own clean
+        env via GitAuthEnvBuilder.setup_environment(). This carve-out only
+        widens the preflight PROBE leg so GCM gets a chance to authenticate
+        before we surface a misleading "az not logged in" diagnostic.
         """
         mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
 
@@ -219,9 +225,10 @@ class TestPreflightGenericHostAllowsCredentialHelpers:
         _preflight_auth_check(ctx, resolver, verbose=False)
 
         call_env = mock_run.call_args[1]["env"]
-        # ADO hosts keep the locked-down env since tokens are embedded in the URL
-        assert call_env.get("GIT_CONFIG_NOSYSTEM") == "1"
-        assert call_env.get("GIT_ASKPASS") == "echo"
+        # Layer 2 of #1430 fix: ADO preflight no longer kills GCM.
+        assert "GIT_CONFIG_NOSYSTEM" not in call_env
+        assert "GIT_ASKPASS" not in call_env
+        assert "GIT_CONFIG_GLOBAL" not in call_env
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_azure_cli.py
+++ b/tests/unit/test_azure_cli.py
@@ -32,6 +32,94 @@ class TestIsAvailable:
             provider = AzureCliBearerProvider()
             assert provider.is_available() is False
 
+    def test_is_available_stable_after_construction(self):
+        """is_available reflects construction-time resolution only.
+
+        Once the provider is built, mid-process PATH changes (or shutil.which
+        side effects) must NOT flip the answer. This is the contract that
+        keeps is_available() consistent with get_bearer_token()'s pre-check
+        and avoids a "True now / az_not_found a moment later" race.
+        """
+        with patch("apm_cli.core.azure_cli.shutil.which", return_value="/usr/bin/az"):
+            provider = AzureCliBearerProvider()
+        # Re-enter a context where which() would now say "missing": the
+        # already-constructed provider must still report True.
+        with patch("apm_cli.core.azure_cli.shutil.which", return_value=None):
+            assert provider.is_available() is True
+
+
+# ---------------------------------------------------------------------------
+# Windows az.cmd resolution (regression for microsoft/apm#1430)
+# ---------------------------------------------------------------------------
+
+
+class TestWindowsAzCmdResolution:
+    """Regression: subprocess.run must receive the shutil.which-resolved
+    path, not the bare "az" token. On Windows the resolver returns
+    "C:\\\\...\\\\az.cmd" and CreateProcessW cannot find "az" alone."""
+
+    WINDOWS_AZ_CMD = r"C:\Program Files (x86)\Microsoft SDKs\Azure\CLI2\wbin\az.cmd"
+
+    def test_init_resolves_via_shutil_which(self):
+        with patch(
+            "apm_cli.core.azure_cli.shutil.which", return_value=self.WINDOWS_AZ_CMD
+        ) as mock_which:
+            provider = AzureCliBearerProvider()
+            mock_which.assert_called_once_with("az")
+            assert provider._az_command == self.WINDOWS_AZ_CMD
+
+    def test_init_stores_none_when_not_on_path(self):
+        with patch("apm_cli.core.azure_cli.shutil.which", return_value=None):
+            provider = AzureCliBearerProvider()
+            assert provider._az_command is None
+
+    def test_init_absolute_path_skips_resolution(self):
+        """Caller passed an explicit absolute path -- trust verbatim."""
+        with patch("apm_cli.core.azure_cli.shutil.which") as mock_which:
+            provider = AzureCliBearerProvider(az_command="/opt/custom/az")
+            mock_which.assert_not_called()
+            assert provider._az_command == "/opt/custom/az"
+
+    def test_get_bearer_token_invokes_resolved_az_cmd_path(self):
+        """The exact Windows shape: shutil.which returns az.cmd; verify it
+        flows into subprocess.run as the argv[0]. Without the fix, argv[0]
+        would be the bare "az" token and CreateProcessW would fail."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = FAKE_JWT + "\n"
+        mock_result.stderr = ""
+
+        with (
+            patch("apm_cli.core.azure_cli.shutil.which", return_value=self.WINDOWS_AZ_CMD),
+            patch("apm_cli.core.azure_cli.subprocess.run", return_value=mock_result) as mock_run,
+        ):
+            provider = AzureCliBearerProvider()
+            provider.get_bearer_token()
+            assert mock_run.call_count == 1
+            cmd = mock_run.call_args[0][0]
+            assert cmd[0] == self.WINDOWS_AZ_CMD, (
+                f"subprocess.run must receive the resolved az.cmd path, got: {cmd[0]!r}"
+            )
+
+    def test_get_current_tenant_id_invokes_resolved_az_cmd_path(self):
+        """Same regression for the get_current_tenant_id() probe -- this
+        was the second swallowed-failure that drove the misleading Case 3
+        diagnostic on Windows."""
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "72f988bf-86f1-41af-91ab-2d7cd011db47\n"
+        mock_result.stderr = ""
+
+        with (
+            patch("apm_cli.core.azure_cli.shutil.which", return_value=self.WINDOWS_AZ_CMD),
+            patch("apm_cli.core.azure_cli.subprocess.run", return_value=mock_result) as mock_run,
+        ):
+            provider = AzureCliBearerProvider()
+            provider.get_current_tenant_id()
+            assert mock_run.call_count == 1
+            cmd = mock_run.call_args[0][0]
+            assert cmd[0] == self.WINDOWS_AZ_CMD
+
 
 # ---------------------------------------------------------------------------
 # get_bearer_token

--- a/tests/unit/test_azure_cli.py
+++ b/tests/unit/test_azure_cli.py
@@ -80,6 +80,16 @@ class TestWindowsAzCmdResolution:
             mock_which.assert_not_called()
             assert provider._az_command == "/opt/custom/az"
 
+    def test_init_relative_with_separator_still_resolves(self):
+        """A relative-with-separator token like 'subdir/az' must NOT bypass
+        shutil.which; otherwise a caller could hand subprocess.run a
+        CWD-relative path that the OS resolves against the wrong
+        directory. Only absolute paths are trusted verbatim."""
+        with patch("apm_cli.core.azure_cli.shutil.which", return_value="/usr/bin/az") as mock_which:
+            provider = AzureCliBearerProvider(az_command="subdir/az")
+            mock_which.assert_called_once_with("subdir/az")
+            assert provider._az_command == "/usr/bin/az"
+
     def test_get_bearer_token_invokes_resolved_az_cmd_path(self):
         """The exact Windows shape: shutil.which returns az.cmd; verify it
         flows into subprocess.run as the argv[0]. Without the fix, argv[0]
@@ -101,6 +111,40 @@ class TestWindowsAzCmdResolution:
                 f"subprocess.run must receive the resolved az.cmd path, got: {cmd[0]!r}"
             )
 
+    def test_bare_az_would_raise_filenotfound_but_resolved_path_succeeds(self):
+        """Explicit regression trap for the #1430 cascade.
+
+        Pre-fix: subprocess.run(["az", ...]) raised FileNotFoundError on
+        Windows (CreateProcessW does not honor PATHEXT for az.cmd), which
+        _run_get_access_token caught as AzureCliBearerError(kind=
+        "subprocess_error"). The error propagated and was rendered as the
+        misleading "az present but not logged in" Case 3 diagnostic.
+
+        Post-fix: the constructor resolves to the .cmd absolute path, so
+        subprocess.run receives a path CreateProcessW CAN find and the
+        bearer succeeds. This test pins both halves of the contract:
+        bare 'az' -> FileNotFoundError; resolved path -> success.
+        """
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = FAKE_JWT + "\n"
+        mock_result.stderr = ""
+
+        def fake_run(cmd, *args, **kwargs):
+            if cmd[0] == "az":
+                # Simulate the Windows CreateProcessW behavior pre-fix.
+                raise FileNotFoundError(2, "No such file or directory", "az")
+            return mock_result
+
+        with (
+            patch("apm_cli.core.azure_cli.shutil.which", return_value=self.WINDOWS_AZ_CMD),
+            patch("apm_cli.core.azure_cli.subprocess.run", side_effect=fake_run),
+        ):
+            provider = AzureCliBearerProvider()
+            # Would raise AzureCliBearerError(kind='subprocess_error') pre-fix.
+            token = provider.get_bearer_token()
+            assert token == FAKE_JWT
+
     def test_get_current_tenant_id_invokes_resolved_az_cmd_path(self):
         """Same regression for the get_current_tenant_id() probe -- this
         was the second swallowed-failure that drove the misleading Case 3
@@ -119,6 +163,20 @@ class TestWindowsAzCmdResolution:
             assert mock_run.call_count == 1
             cmd = mock_run.call_args[0][0]
             assert cmd[0] == self.WINDOWS_AZ_CMD
+
+    def test_get_current_tenant_id_returns_none_without_subprocess_when_az_missing(self):
+        """Explicit early-return guard: when az was not resolved at __init__,
+        get_current_tenant_id() must short-circuit to None rather than
+        passing None as argv[0] (which would TypeError and only be caught
+        by the broad except). Mirrors get_bearer_token's is_available()
+        pre-check."""
+        with (
+            patch("apm_cli.core.azure_cli.shutil.which", return_value=None),
+            patch("apm_cli.core.azure_cli.subprocess.run") as mock_run,
+        ):
+            provider = AzureCliBearerProvider()
+            assert provider.get_current_tenant_id() is None
+            mock_run.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## TL;DR

`apm update` against private Azure DevOps deps fails on Windows with `Authentication failed for dev.azure.com` and the diagnostic *"az present but not logged in"* — even when the user IS signed in via `az login`. The root cause is that `subprocess.run(["az", ...])` calls `CreateProcessW`, which does not honor `PATHEXT` for non-`.exe` executables, so the Windows `az.cmd` wrapper cannot be invoked despite `shutil.which("az")` resolving it. This PR resolves `az` via `shutil.which` once at construction and widens the ADO preflight carve-out so Git Credential Manager survives as a fallback. Closes #1430.

## Problem (WHY)

> [!IMPORTANT]
> The user is shown a remediation message instructing them to run `az login` — the exact action they have already taken. Worst-possible-failure-mode for diagnostics.

The bug surfaces only on `apm update`, not `apm install`, because the preflight is gated on `update_refs`. The Windows-only cascade:

1. `AzureCliBearerProvider.is_available()` returns `True` (`shutil.which` honors `PATHEXT`).
2. Every `subprocess.run([self._az_command, ...])` raises `FileNotFoundError` (`CreateProcessW` does not honor `PATHEXT`).
3. `_run_get_access_token` wraps the `OSError` as `AzureCliBearerError(kind="subprocess_error")`.
4. `_resolve_token` in `core/auth.py` swallows it -> `(None, "none", "basic")`.
5. `_preflight_auth_check` builds a probe env that strips `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_NOSYSTEM`, killing Git Credential Manager — the only remaining channel that could have rescued the probe with an Entra-cached credential.
6. `git ls-remote` returns 401. `build_error_context` re-hits the same broken subprocess in `get_current_tenant_id()`, swallows the failure, and renders **Case 3: "az present but not logged in"**.

PROSE anchor: ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) The fix replaces a probabilistic PATH lookup (left to `CreateProcessW`) with a deterministic resolution (`shutil.which`).

## Approach (WHAT)

Two layers, both required:

| Layer | Where | What |
|---|---|---|
| **Root cause** | `src/apm_cli/core/azure_cli.py` | Resolve `az` via `shutil.which` once in `__init__`; pass the absolute path to every `subprocess.run`. |
| **Defense in depth** | `src/apm_cli/install/pipeline.py` | Widen the existing generic-host carve-out so ADO preflight probes also keep the user's `~/.gitconfig` available, preserving Git Credential Manager as a fallback channel. |

## Implementation (HOW)

**`src/apm_cli/core/azure_cli.py`** — `__init__` resolves `az_command` via `shutil.which` once and stores either the absolute path or `None`. Absolute paths supplied by callers (test injection) are trusted verbatim; everything else flows through `shutil.which` so a CWD-relative token like `subdir/az` cannot bypass resolution. `is_available()` becomes state-only (no per-call `shutil.which`), so it can no longer disagree with `get_bearer_token()`'s pre-check. `get_current_tenant_id()` gains an explicit early-return when `_az_command is None` to avoid passing `None` as argv[0] (previously masked by a broad `except`).

**`src/apm_cli/install/pipeline.py`** — the carve-out at line 160 changes from `if is_generic:` to `if is_generic or is_azure_devops_hostname(host):`. `_dl.git_env` (built by `GitAuthEnvBuilder.setup_environment`) still forces an empty global gitconfig for the actual clone path; only the single `ls-remote` probe leg gains GCM access. The bearer-fallback `_bearer_op` builds its own clean env via `_build_git_env(scheme="bearer")` and is unaffected.

## Diagrams

Cascade before and after the fix — every step is a real call site in the diff.

```mermaid
flowchart LR
    subgraph Before["Before (Windows, az.cmd installed, user logged in)"]
        A1["is_available()<br/>shutil.which → True"] --> B1["subprocess.run(['az', ...])<br/>CreateProcessW: FileNotFoundError"]
        B1 --> C1["AzureCliBearerError<br/>kind=subprocess_error"]
        C1 --> D1["_resolve_token<br/>→ (None, 'none', 'basic')"]
        D1 --> E1["preflight strips<br/>GIT_CONFIG_GLOBAL"]
        E1 --> F1["GCM disabled<br/>ls-remote 401"]
        F1 --> G1["Case 3:<br/>'az present, not logged in'"]
    end
    subgraph After["After"]
        A2["__init__<br/>shutil.which → C:\\...\\az.cmd"] --> B2["subprocess.run(['C:\\...\\az.cmd', ...])<br/>CreateProcessW OK"]
        B2 --> C2["bearer token<br/>preflight passes"]
    end
    style G1 stroke:#d00,stroke-width:2px
    style C2 stroke:#070,stroke-width:2px
```

## Trade-offs

- **`is_available()` is now construction-time only.** PATH changes mid-process won't be observed; restart the CLI if you install `az` after APM is running. Acceptable: tokens are cached anyway and the provider is a process-wide singleton.
- **ADO preflight now consults `~/.gitconfig`.** A user's `insteadOf` rewrite could redirect the `ls-remote` probe to a different host. Mitigations: the probe is read-only; the actual clone path retains full gitconfig isolation; "attacker controls `~/.gitconfig`" implies the attacker already owns the git client. Generic hosts already had this carve-out (#1082); the security argument applies equally to ADO.
- **Unconditional carve-out vs feature flag.** Considered an opt-in env var; rejected. The surface is narrow (one read-only probe), GCM-for-ADO is the expected corporate setup, and a flag adds maintenance for negligible upside.

## Benefits

1. Windows ADO users on the documented `az login` path can `apm update` again.
2. The diagnostic no longer lies — `is_available()` and `get_bearer_token()` now agree.
3. GCM remains a viable fallback when bearer acquisition fails for *any* reason (sandbox, proxy, future PATH quirks).
4. Test injection contract preserved: callers can still pass an absolute path verbatim.

## Validation

> [!NOTE]
> CI lint mirror green; affected suites all pass locally.

```
$ uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/ \
    && uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 \
       --fail-on=R0801 src/apm_cli/ && bash scripts/lint-auth-signals.sh
All checks passed!
1037 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean

$ uv run --extra dev pytest tests/unit/test_azure_cli.py \
    tests/unit/install/test_pipeline_auth_preflight.py \
    tests/integration/test_ado_preflight_bearer_fallback_e2e.py -q
41 passed in 1.65s
```

### Scenario evidence

| User-promise scenario | Test | Principle |
|---|---|---|
| Windows `az.cmd` resolves to subprocess argv[0] | `tests/unit/test_azure_cli.py::TestWindowsAzCmdResolution::test_get_bearer_token_invokes_resolved_az_cmd_path` | Portability-by-manifest |
| Pre-fix `FileNotFoundError` shape no longer surfaces as `subprocess_error` | `tests/unit/test_azure_cli.py::TestWindowsAzCmdResolution::test_bare_az_would_raise_filenotfound_but_resolved_path_succeeds` | Determinism |
| `is_available()` is consistent with `get_bearer_token()` pre-check | `tests/unit/test_azure_cli.py::TestIsAvailable::test_is_available_stable_after_construction` | DevX (no misleading diagnostics) |
| ADO preflight no longer disables GCM | `tests/unit/install/test_pipeline_auth_preflight.py::TestPreflightGenericHostAllowsCredentialHelpers::test_ado_host_omits_credential_blocking_env` | Auth-fallback contract |
| Existing ADO PAT→bearer fallback still works | `tests/integration/test_ado_preflight_bearer_fallback_e2e.py` (unchanged, passes) | Regression-trap |
| `get_current_tenant_id` short-circuits cleanly when `az` missing | `tests/unit/test_azure_cli.py::TestWindowsAzCmdResolution::test_get_current_tenant_id_returns_none_without_subprocess_when_az_missing` | Explicit > swallowed exception |

## How to test

1. [ ] On Windows with `az.cmd` installed and `az login` completed: clone a repo with a private ADO dep in `apm.yml`, run `apm update`. Pre-fix: fails with "az present but not logged in". Post-fix: succeeds.
2. [ ] On Windows without `az` installed but with GCM configured for `dev.azure.com`: run `apm update`. Post-fix: GCM resolves the credential and the probe passes.
3. [ ] On Linux/macOS: run the focused suite — `uv run --extra dev pytest tests/unit/test_azure_cli.py tests/unit/install/test_pipeline_auth_preflight.py tests/integration/test_ado_preflight_bearer_fallback_e2e.py`.
4. [ ] Lint mirror — `uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/`.

Closes #1430.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
