### PR TITLE
fix(cache): handle ValueError from parsed.port on Windows file:// URLs

### DIFF
--- a/src/apm_cli/cache/url_normalize.py
+++ b/src/apm_cli/cache/url_normalize.py
@@ -80,14 +80,24 @@ def normalize_repo_url(url: str) -> str:
     # `parsed.hostname`/`parsed.port` can raise ValueError on malformed
     # netlocs -- notably on Windows where `file://C:\path` parses with
     # netloc `C:\path` and the drive-letter colon is interpreted as
-    # host:port. Fall back to the raw netloc (lowercased) so cache-key
-    # derivation stays deterministic and per-URL distinct without raising.
+    # host:port. Fall back to a sanitized netloc (lowercased, password
+    # stripped) so cache-key derivation stays deterministic and per-URL
+    # distinct without raising or embedding credentials in the key.
     try:
         hostname = (parsed.hostname or "").lower()
         username = parsed.username or ""
         port = parsed.port
     except ValueError:
-        authority = parsed.netloc.lower()
+        # Strip password from userinfo (keep username) before lowercasing,
+        # mirroring Step 4 in the happy path so credentials never leak into
+        # the cache key or any caller that logs the normalized form.
+        raw_netloc = parsed.netloc
+        if "@" in raw_netloc:
+            userinfo, _, hostport = raw_netloc.rpartition("@")
+            user_only = userinfo.split(":", 1)[0]
+            authority = f"{user_only}@{hostport}".lower() if user_only else hostport.lower()
+        else:
+            authority = raw_netloc.lower()
         hostname = ""
     else:
         # Step 5: Strip default ports

--- a/src/apm_cli/cache/url_normalize.py
+++ b/src/apm_cli/cache/url_normalize.py
@@ -75,23 +75,28 @@ def normalize_repo_url(url: str) -> str:
 
     # Parse the URL
     parsed = urllib.parse.urlparse(url)
-
-    # Step 3: Lowercase hostname
-    hostname = (parsed.hostname or "").lower()
-
-    # Step 4: Strip password, keep username
-    username = parsed.username or ""
-
-    # Step 5: Strip default ports
-    port = parsed.port
     scheme = (parsed.scheme or "https").lower()
-    if port and _DEFAULT_PORTS.get(scheme) == port:
-        port = None
 
-    # Reconstruct the authority
-    authority = f"{username}@{hostname}" if username else hostname
-    if port:
-        authority = f"{authority}:{port}"
+    # `parsed.hostname`/`parsed.port` can raise ValueError on malformed
+    # netlocs -- notably on Windows where `file://C:\path` parses with
+    # netloc `C:\path` and the drive-letter colon is interpreted as
+    # host:port. Fall back to the raw netloc (lowercased) so cache-key
+    # derivation stays deterministic and per-URL distinct without raising.
+    try:
+        hostname = (parsed.hostname or "").lower()
+        username = parsed.username or ""
+        port = parsed.port
+    except ValueError:
+        authority = parsed.netloc.lower()
+        hostname = ""
+    else:
+        # Step 5: Strip default ports
+        if port and _DEFAULT_PORTS.get(scheme) == port:
+            port = None
+        # Reconstruct the authority (Step 3 lowercase host, Step 4 drop password)
+        authority = f"{username}@{hostname}" if username else hostname
+        if port:
+            authority = f"{authority}:{port}"
 
     # Step 1: Strip trailing .git from path
     path = parsed.path or ""

--- a/tests/unit/cache/test_url_normalize.py
+++ b/tests/unit/cache/test_url_normalize.py
@@ -110,3 +110,14 @@ class TestMalformedNetloc:
         url_a = r"file://C:\Users\runneradmin\AppData\Local\Temp\repo_a.git"
         url_b = r"file://C:\Users\runneradmin\AppData\Local\Temp\repo_b.git"
         assert cache_shard_key(url_a) != cache_shard_key(url_b)
+
+    def test_fallback_strips_password_from_netloc(self) -> None:
+        """Malformed-netloc fallback must still drop the password (Step 4).
+
+        Otherwise credentials end up baked into cache keys and any caller
+        that logs the normalized URL leaks them.
+        """
+        with_secret = normalize_repo_url("https://user:secret@host:badport/repo")
+        without_secret = normalize_repo_url("https://user@host:badport/repo")
+        assert "secret" not in with_secret
+        assert with_secret == without_secret

--- a/tests/unit/cache/test_url_normalize.py
+++ b/tests/unit/cache/test_url_normalize.py
@@ -89,3 +89,24 @@ class TestCacheShardKey:
         key1 = cache_shard_key("https://github.com/owner/repo")
         key2 = cache_shard_key("https://github.com/owner/repo")
         assert key1 == key2
+
+
+class TestMalformedNetloc:
+    """Malformed netlocs (e.g. Windows file:// URLs) must not raise.
+
+    Regression: on Windows, `file://C:\\path\\bare.git` parses with the
+    drive-letter colon interpreted as a host:port separator, so
+    `parsed.port` raises ValueError. Cache-key derivation must stay
+    deterministic and per-URL distinct without raising.
+    """
+
+    def test_windows_file_url_does_not_raise(self) -> None:
+        url = r"file://C:\Users\runneradmin\AppData\Local\Temp\bare.git"
+        # Must not raise:
+        key = cache_shard_key(url)
+        assert len(key) == 16
+
+    def test_windows_file_urls_distinct_paths_distinct_keys(self) -> None:
+        url_a = r"file://C:\Users\runneradmin\AppData\Local\Temp\repo_a.git"
+        url_b = r"file://C:\Users\runneradmin\AppData\Local\Temp\repo_b.git"
+        assert cache_shard_key(url_a) != cache_shard_key(url_b)


### PR DESCRIPTION
## Problem

Windows CI ([run 26252988143](https://github.com/microsoft/apm/actions/runs/26252988143/job/77268625021)) failed with:

```
ValueError: Port could not be cast to integer value as '\\Users\\runneradmin\\AppData\\Local\\Temp\\...\\bare.git'
```

at `src/apm_cli/cache/url_normalize.py:86` (`port = parsed.port`).

**Root cause:** On Windows, `urlparse("file://C:\\path\\bare.git")` places `C:\path...` into the `netloc`. Python's `parsed.port` property splits the netloc on `:` and interprets the drive-letter colon as a host:port separator -- raising `ValueError` because the 'port' isn't a digit. This crashed `cache_shard_key()` for every test that constructed a `file://{tmp_path}` URL (e.g. `TestGetCheckoutLayout.test_full_variant_layout`).

Linux/macOS were unaffected because their tmp paths start with `/`, producing an empty netloc.

## Fix

Wrap hostname/username/port extraction in `try/except ValueError`. On failure, fall back to the raw lowercased `netloc` as the authority. This keeps cache-key derivation:

- **Non-raising** -- never crashes on malformed netlocs
- **Deterministic** -- same URL always yields same shard
- **Per-URL distinct** -- different Windows paths (`C:\repo_a.git` vs `C:\repo_b.git`) still get different shards (the prior trivial fix collapsed them all to `file://c`)

## Tests

Added two regression tests in `tests/unit/cache/test_url_normalize.py`:

- `test_windows_file_url_does_not_raise` -- verifies no `ValueError`
- `test_windows_file_urls_distinct_paths_distinct_keys` -- verifies shard-key distinctness

## Validation

- `uv run --extra dev pytest tests/unit/cache/ -q` -> 44 passed
- `uv run --extra dev ruff check src/ tests/` -> All checks passed
- `uv run --extra dev ruff format --check src/ tests/` -> 1046 files already formatted
- `uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/` -> 10.00/10
- `bash scripts/lint-auth-signals.sh` -> auth-signal lint clean