### PR TITLE
[docs] Update documentation for comma-separated applyTo glob behavior from 2026-05-22

### DIFF
--- a/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
+++ b/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
@@ -64,8 +64,8 @@ Multiple globs are supported via comma-separation:
 applyTo: "**/src/**,**/api/**,**/services/**"
 ```
 
-Targets that use YAML lists (claude, cursor, windsurf) expand the
-comma-separated value into a proper list automatically. Brace
+When compiling for claude, cursor, and windsurf, APM expands the
+comma-separated value into a proper YAML list. Brace
 alternations like `**/*.{css,scss}` are treated as a single glob and
 are not split.
 

--- a/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
+++ b/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
@@ -58,6 +58,17 @@ unconditional and gets folded into compiled context files
 (`AGENTS.md`, `GEMINI.md`) instead of a per-file rule directory. With
 it, each harness wraps the body in its own scoping syntax.
 
+Multiple globs are supported via comma-separation:
+
+```yaml
+applyTo: "**/src/**,**/api/**,**/services/**"
+```
+
+Targets that use YAML lists (claude, cursor, windsurf) expand the
+comma-separated value into a proper list automatically. Brace
+alternations like `**/*.{css,scss}` are treated as a single glob and
+are not split.
+
 ### Body conventions
 
 - Lead with bullets, not prose. Instructions are read by an agent
@@ -72,10 +83,10 @@ it, each harness wraps the body in its own scoping syntax.
 
 | Target | Output path | Transform |
 |---|---|---|
-| copilot | `.github/instructions/<name>.instructions.md` | verbatim; `applyTo` preserved |
-| claude | `.claude/rules/<name>.md` | `applyTo` -> `paths:` list |
-| cursor | `.cursor/rules/<name>.mdc` | `applyTo` -> `globs:`; description auto-derived if missing |
-| windsurf | `.windsurf/rules/<name>.md` | `applyTo` -> `trigger: glob` + `globs:`; missing `applyTo` -> `trigger: always_on` |
+| copilot | `.github/instructions/<name>.instructions.md` | verbatim; `applyTo` preserved as-is |
+| claude | `.claude/rules/<name>.md` | `applyTo` -> `paths:` list; comma-separated value expanded to YAML list |
+| cursor | `.cursor/rules/<name>.mdc` | `applyTo` -> `globs:`; comma-separated value expanded to YAML list; description auto-derived if missing |
+| windsurf | `.windsurf/rules/<name>.md` | `applyTo` -> `trigger: glob` + `globs:`; comma-separated value expanded to YAML list; missing `applyTo` -> `trigger: always_on` |
 | codex | folded into `AGENTS.md` | compile-only, no per-file deploy |
 | gemini | folded into `GEMINI.md` | compile-only, no per-file deploy |
 | opencode | folded into `AGENTS.md` | compile-only, no per-file deploy |


### PR DESCRIPTION
## Documentation Updates - 2026-05-22

This PR updates the documentation based on features merged in the last 24 hours.

### Features Documented

- Comma-separated `applyTo` glob expansion into YAML lists for Claude/Cursor/Windsurf targets (from #1387)

### Changes Made

- Updated `docs/src/content/docs/producer/author-primitives/instructions-and-agents.md`:
  - Added explanation that multi-glob comma-separated values are expanded into YAML lists by Claude, Cursor, and Windsurf targets
  - Added a concrete `applyTo` multi-glob example
  - Clarified that brace alternations like `**/*.{css,scss}` are treated as a single glob (not split)
  - Updated "What compiles where" table to explicitly note the comma-expansion behavior per target
  - Noted that the Copilot target preserves the `applyTo` value verbatim (no splitting)

### Merged PRs Referenced

- #1387 - fix(integration): respect comma-separated applyTo globs in Claude/Cursor/Windsurf
- #1446 - fix(cache): handle ValueError from parsed.port on Windows (redacted) URLs (internal fix, no docs needed)

### Notes

PR #1446 is a Windows-only internal cache bug fix that requires no documentation changes.
PR #1387 is user-facing: it fixes `applyTo` multi-glob handling for three targets and the behavior is now correctly reflected in the docs.




> [!NOTE]
> <details>
> <summary>🔒 Integrity filter blocked 4 items</summary>
>
> The following items were blocked because they don't meet the GitHub integrity level.
>
> - [#1340](https://github.com/microsoft/apm/pull/1340) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1303](https://github.com/microsoft/apm/pull/1303) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1277](https://github.com/microsoft/apm/pull/1277) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1262](https://github.com/microsoft/apm/pull/1262) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/26271385024/agentic_workflow) · ● 935.8K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+%22gh-aw-workflow-id%3A+daily-doc-updater%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/blob/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-05-24T06:18:09.093Z --> on May 24, 2026, 6:18 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 26271385024, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/26271385024 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->