### PR TITLE
fix(build): restore optimize=2 + enforce explicit Click help= to clear Defender ML false positive (#1407)

### DIFF
--- a/build/apm.spec
+++ b/build/apm.spec
@@ -271,7 +271,12 @@ a = Analysis(
     win_private_assemblies=False,
     cipher=None,
     noarchive=False,
-    optimize=1,  # -O: strip asserts; keep __doc__ so Click reads command help from docstrings (#1298)
+    optimize=2,  # -OO: strip asserts AND __doc__. Reduces PYZ string surface to
+    # avoid Defender ML false positives (Trojan:Script/Wacatac.H!ml on v0.14.0; see #1407).
+    # Every @click.command() MUST set help= explicitly; the docstring fallback is gone.
+    # tests/unit/test_cli_consistency.py::test_every_registered_command_has_explicit_help
+    # is the silent-drift guard. See #1298 for the original (now-superseded) motivation
+    # to keep docstrings.
 )
 
 # Exclude bundled OpenSSL shared libraries on Linux.

--- a/src/apm_cli/commands/view.py
+++ b/src/apm_cli/commands/view.py
@@ -415,7 +415,26 @@ def display_versions(package: str, logger: CommandLogger) -> None:
 # ------------------------------------------------------------------
 
 
-@click.command(name="view")
+_VIEW_HELP = (
+    "View package metadata or list remote versions.\n\n"
+    "Without FIELD, displays local metadata for an installed package. "
+    "With FIELD, queries specific data (may contact the remote).\n\n"
+    "\b\n"
+    "Fields:\n"
+    "    versions    List available remote tags and branches\n\n"
+    "\b\n"
+    "Examples:\n"
+    "    apm view org/repo                # Local metadata\n"
+    "    apm view org/repo versions       # Remote tags/branches\n"
+    "    apm view org/repo -g             # From user scope"
+)
+
+
+@click.command(
+    name="view",
+    help=_VIEW_HELP,
+    short_help="View package metadata or list remote versions",
+)
 @click.argument("package", required=True)
 @click.argument("field", required=False, default=None)
 @click.option(
@@ -427,21 +446,7 @@ def display_versions(package: str, logger: CommandLogger) -> None:
     help="Inspect package from user scope (~/.apm/)",
 )
 def view(package: str, field: str | None, global_: bool):
-    """View package metadata or list remote versions.
-
-    Without FIELD, displays local metadata for an installed package.
-    With FIELD, queries specific data (may contact the remote).
-
-    \b
-    Fields:
-        versions    List available remote tags and branches
-
-    \b
-    Examples:
-        apm view org/repo                # Local metadata
-        apm view org/repo versions       # Remote tags/branches
-        apm view org/repo -g             # From user scope
-    """
+    """View package metadata or list remote versions."""
     from ..core.scope import InstallScope, get_apm_dir
 
     logger = CommandLogger("view")

--- a/tests/unit/test_build_spec.py
+++ b/tests/unit/test_build_spec.py
@@ -120,6 +120,38 @@ class TestSpecFileSyntax:
         assert "def _read_version_from_pyproject" in snippet
         assert "def is_upx_available" in snippet
 
+    def test_pyinstaller_optimize_is_2(self):
+        """Regression guard: Analysis(optimize=...) must be 2 (python -OO).
+
+        ``optimize=2`` strips both ``assert``s and ``__doc__`` from compiled
+        bytecode. Stripping ``__doc__`` keeps the PYZ string surface small,
+        which is critical for avoiding the Defender ML false positive
+        (Trojan:Script/Wacatac.H!ml) that affected v0.14.0 -- see #1407.
+
+        If this test fails, do NOT just lower the value to fix #1298-style
+        docstring-fallback bugs. Instead, set ``help=`` (or ``short_help=``)
+        explicitly on the offending Click command; the
+        ``test_every_registered_command_has_explicit_help`` test in
+        ``tests/unit/test_cli_consistency.py`` enforces this contract.
+        """
+        source = _SPEC_FILE.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(_SPEC_FILE))
+        analysis_optimize_values: list[int] = []
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "Analysis"
+            ):
+                for kw in node.keywords:
+                    if kw.arg == "optimize" and isinstance(kw.value, ast.Constant):
+                        analysis_optimize_values.append(kw.value.value)
+        assert analysis_optimize_values, "No Analysis(optimize=...) keyword found in build/apm.spec"
+        assert all(v == 2 for v in analysis_optimize_values), (
+            f"Analysis(optimize=...) must be 2 (got {analysis_optimize_values}). "
+            "See test docstring for context."
+        )
+
 
 # ---------------------------------------------------------------------------
 # 2. should_use_upx()

--- a/tests/unit/test_cli_consistency.py
+++ b/tests/unit/test_cli_consistency.py
@@ -2,10 +2,48 @@
 
 from unittest.mock import patch
 
+import click
 from click.testing import CliRunner
 
 from apm_cli.cli import cli
 from apm_cli.output.script_formatters import ScriptExecutionFormatter
+
+
+def _walk_commands(group: click.Group, prefix: tuple[str, ...] = ()):
+    """Yield (path_tuple, command) for every command reachable under group."""
+    for name, cmd in group.commands.items():
+        path = (*prefix, name)
+        yield path, cmd
+        if isinstance(cmd, click.Group):
+            yield from _walk_commands(cmd, path)
+
+
+def test_every_registered_command_has_explicit_help():
+    """Silent-drift guard: no command may rely on the docstring fallback.
+
+    The release binary is built with PyInstaller ``optimize=2`` (``python -OO``)
+    to keep the PYZ string surface small (Defender ML false-positive mitigation;
+    see #1407 and build/apm.spec). ``-OO`` strips ``__doc__``, so any Click
+    command without an explicit ``help=`` renders with an empty summary and
+    empty ``--help`` body in the binary -- exactly the regression that #1298
+    reported for ``apm view``.
+
+    Every command and sub-command registered under the top-level ``cli`` group
+    must set ``help=`` (or ``short_help=``) explicitly.
+    """
+    missing: list[str] = []
+    for path, cmd in _walk_commands(cli):
+        if cmd.hidden:
+            # Hidden aliases (e.g. ``apm info``) inherit help from their source
+            # command; checking the visible command is sufficient.
+            continue
+        help_text = (cmd.help or "").strip() or (cmd.short_help or "").strip()
+        if not help_text:
+            missing.append(" ".join(path))
+    assert not missing, (
+        "Commands missing explicit help= (would render blank under "
+        "PyInstaller optimize=2): " + ", ".join(sorted(missing))
+    )
 
 
 def test_experimental_subcommand_help_is_specific():


### PR DESCRIPTION
## TL;DR

The `Trojan:Script/Wacatac.H!ml` Defender detection blocking the v0.14.0 winget submission (winget-pkgs#376283) and breaking `irm aka.ms/apm-windows | iex` for an increasing number of users (#1407) is not caused by the recent `install.ps1` changes (#1390, #1408) — that script is never bundled in the released zip. The trigger is **PR #1307**, which shipped in v0.14.0 and lowered PyInstaller `optimize=2` → `optimize=1` to keep Click command docstrings as a `--help` fallback. By its own measurement (#1307 description) this re-embedded ~1.4 MB / +14 % of marshalled docstring text into the PYZ blob inside `apm.exe` — exactly the lexical surface ML-trained generic-dropper classifiers latch onto.

This PR reverts the byte surface and replaces the docstring fallback with a hard, CI-enforced contract: every Click command must set `help=` explicitly.

## Problem (WHY)

- **winget-pkgs#376283** validation log: `[FAIL] Installer failed security check. Detection: Trojan:Script/Wacatac.H!ml, Defender Security Intelligence 1.449.698.0`.
- **#1407** reproduces the same failure end-user: `Operation did not complete successfully because the file contains a virus or potentially unwanted software` thrown by `apm.exe --version` smoke test inside `install.ps1`, followed by failed pip fallback (Python 3.14 out of range).
- The detection is generic ML (`!ml` suffix = machine-learning classified). Same family as `Trojan:Win32/Bearfoos.B!ml` previously fixed in #487/#490 by disabling UPX on Windows and embedding PE `VSVersionInfo` — both pure feature-surface mitigations, no behaviour change.
- The only material change to the bundled bytes between v0.13.0 (clean) and v0.14.0 (flagged) is `build/apm.spec`: `optimize=2` → `optimize=1` from #1307. The rest of the v0.13..v0.14 diff in bundled paths is a ~15-line `Write-Warning` block in `setup-codex.ps1` (negligible signal).

## Approach (WHAT)

Two coordinated changes:

1. **Restore `optimize=2`** (`python -OO`) in `build/apm.spec`. Asserts AND `__doc__` are stripped. Binary shrinks by ~1.4 MB; the docstring text surface goes back to pre-v0.14.0 levels. This is the actual mitigation.
2. **Replace the docstring fallback with an explicit-help contract.** #1307's premise — "keep docstrings so commands without `help=` aren't blank" — was the wrong fix. The right fix is to require `help=` on every command and fail CI when it's missing. This converts the silent-drift trap of #1298 (`apm view`) and #1216 (`apm outdated`) into a loud, permanent guard at the source level, not the binary level.

## Implementation (HOW)

- `build/apm.spec`: `optimize=1` → `optimize=2` with an inline comment pointing at the new test, so future contributors don't repeat #1307.
- `src/apm_cli/commands/view.py`: lift the help body out of the docstring into a module-level `_VIEW_HELP` string and pass it as `help=` plus a `short_help=` for the top-level command index. The hidden `apm info` alias (`cli.py` line 79–87) reads `view_cmd.help`, so it is fixed automatically as a side-effect — same as #1307 noted, but the right way.
- `tests/unit/test_cli_consistency.py::test_every_registered_command_has_explicit_help`: walks every command and sub-command reachable under the top-level `cli` group via `click.Group.commands`, and asserts `cmd.help` (or `cmd.short_help`) is non-empty. Hidden alias commands (`cmd.hidden == True`) are skipped because they inherit help from their source command. **This is the permanent regression trap for #1298 / #1216 / #1407.**
- `tests/unit/test_build_spec.py::test_pyinstaller_optimize_is_2`: AST-parses `build/apm.spec`, locates the `Analysis(...)` call, and asserts every `optimize=` kwarg equals `2`. Pins the trade-off so a future PR cannot quietly lower it again to paper over a missing `help=` kwarg.

## Trade-offs

- **No Click command may omit `help=` going forward.** Enforced in CI. Cost: ~one extra kwarg per new command, mechanical to add.
- **Asserts and `__doc__` stripped from the binary.** Asserts: same as v0.13.0 and earlier. Docstrings: unused in the binary's runtime path (Click reads `cmd.help`, not `cmd.__doc__`, once `help=` is set explicitly).
- **Not a permanent fix for AV false positives.** Authenticode signing via Azure Trusted Signing is the durable answer for any unsigned PyInstaller binary at this distribution scale. Out of scope here — tracked separately. This PR is the smallest change that unblocks v0.14.x today.

## Validation

- `uv run --extra dev ruff check src/ tests/` — clean
- `uv run --extra dev ruff format --check src/ tests/` — 1049 files already formatted
- `uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/` — 10.00/10
- `bash scripts/lint-auth-signals.sh` — `[+] auth-signal lint clean`
- `uv run --extra dev pytest tests/unit/ -n auto` — **14905 passed, 1 skipped, 0 failed**
- Smoke test under `-OO`:
  ```
  $ PYTHONOPTIMIZE=2 python -m apm_cli.cli view --help
  Usage: python -m apm_cli.cli view [OPTIONS] PACKAGE [FIELD]
    View package metadata or list remote versions.
    Without FIELD, displays local metadata for an installed package. With FIELD,
    queries specific data (may contact the remote).
    Fields:
        versions    List available remote tags and branches
    Examples:
        apm view org/repo                # Local metadata
        ...
  $ PYTHONOPTIMIZE=2 python -m apm_cli.cli --help | grep view
    view          View package metadata or list remote versions
  ```
  Help renders correctly under stripped docstrings — proves the new explicit `help=` works in the binary code path.

## How to test (post-merge, on Windows)

1. Tag v0.14.2 (or pre-release) after merge; CI builds and publishes `apm-windows-x86_64.zip`.
2. On a Defender-enabled Windows host: `irm https://aka.ms/apm-windows | iex`. Expect: no AV interception, install completes through the binary smoke test.
3. Submit the new zip SHA to https://www.microsoft.com/wdsi/filesubmission for false-positive review to also clear cached v0.14.0/v0.14.1 detonations on older installs.
4. Re-trigger winget-pkgs#376283 once v0.14.2 is out (or update the manifest to point at it).

## Not in scope

- **Authenticode signing.** Permanent fix for AV false positives on unsigned PE binaries. Azure Trusted Signing is the modern path (no USB HSM, signing via GH Actions, OIDC-federated). Should be its own issue/PR; ~1 day work once Identity Validation is provisioned.
- **Re-submitting v0.14.0 to MS WDSI.** Manual operator step, post-merge.

## Refs

- Closes #1407
- Reverts binary-surface effect of #1307
- Same family as #487 / #490 (previous AV ML mitigation; UPX disable + VSVersionInfo)
- Original missing-help bugs: #1298 (`view`), #1216 (`outdated`)
- Downstream: winget-pkgs#376283
