### PR TITLE
chore: release v0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Windows: GitCache sparse-cone consumer clone no longer fails with `Filename too long`; `git clone`/`checkout` pass `-c core.longpaths=true` on Windows so the nested `checkouts_v1/<shard>/<sha>/<variant>.incomplete.<pid>.<ns>/` layout stays within the Win32 path limit. (#1454)
+- Windows: `copilot-app` WS handshake no longer rejects `~/.copilot/run/ws.token` because Windows synthesises group/other bits from the read-only flag; the POSIX-only mode check now short-circuits to accept on Windows. (#1454)
 - `apm install` honours per-dependency `registry:` URLs in MCP deps instead of warning and ignoring them. (#1443, closes #1393)
 - VS Code adapter handles MCP v0.1 `runtimeArguments` with `variables`, unblocking Docker MCP servers that need workspace mounts. (#1444, closes #1391)
 - `apm install --skill <name>` persists the skill filter to `apm.yml` so subsequent runs honour the selection. (#1442, closes #1395)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,30 +7,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Performance
-
-- Cold `apm install` for subdirectory git dependencies is dramatically faster on large monorepos (validated ~30x to ~75x range on `dotnet/skills`, network-variant). `GitCache` now performs partial bare clones (`--filter=blob:none`) with promisor remotes plus sparse-cone consumer materialization, and threads the tiered resolver's resolved SHA through to skip a redundant `ls-remote`. Bare-cache disk usage drops by orders of magnitude on the validated workload. No lockfile schema, CLI surface, or auth flow changes. Servers that reject `--filter=blob:none` (older Gerrit / pre-2.20 GHE) transparently fall back to a full bare clone. (#1436, closes #1433)
+## [0.14.2] - 2026-05-22
 
 ### Added
 
-- **Experimental:** `copilot-app` target now scopes workflow rows to a real `projects` row instead of orphaning them at the App's root. When the App is running, project registration goes through the loopback WebSocket IPC surface (`~/.copilot/run/ws.{port,token}`, 0o600) so the project goes through the App's own owner/repo discovery and is immediately known to the webview; when the App is closed, registration falls through to a direct-SQLite `BEGIN IMMEDIATE` resolver against `~/.copilot/data.db`. Workflow rows are always written via SQLite (namespaced ids preserve lockfile stability). `--global` installs that carry workflow-shape prompts now emit a one-time warn-and-proceed diagnostic explaining the CWD-pivot risk and the per-row "attach to project" remediation. A one-time `Restart the Copilot App once` info hint fires on first project registration in a repo (see github/github-app#5483). (#1431)
+- **Experimental:** `copilot-app` target scopes workflows to a real project row via loopback WS IPC (App running) or direct SQLite (App closed); `--global` workflow installs emit a one-time CWD-pivot warning. (#1431)
 
 ### Changed
 
-- Shard PR-time unit tests into two pytest-split groups (each required); move global 80% coverage gate to a non-required `Coverage Combine (Linux)` job at PR time and require it on `merge_group`; move PyInstaller binary build to a parallel non-required job; reduce `merge-gate` poll interval to 5 s. (#1437)
-- Unit test coverage raised to 88% (gate: `fail_under = 80`); integration test coverage raised to 71% with first CI gate at 55%. (#1402)
+- PR-time CI shards unit tests, moves the 80% coverage gate off the critical path, and parallelises the PyInstaller build for faster contributor signal. (#1437)
+- Unit coverage raised to 88% (gate 80%); integration coverage raised to 71% (gate 55%). (#1402)
+- Replace logic-replay tests for #763 with real-flow coverage to catch real regressions. (#1340)
+
+### Performance
+
+- Cold `apm install` for subdirectory git deps is ~30x-75x faster on large monorepos via partial bare clones plus sparse-cone materialization; transparent fallback when servers reject `--filter=blob:none`. (#1436, closes #1433)
 
 ### Fixed
 
-- Comma-separated `applyTo` globs now correctly emit a YAML list under `globs:` / `paths:` in Claude, Cursor, and Windsurf instruction outputs (Copilot output unchanged -- it already preserves `applyTo` verbatim and handles comma-lists natively). The shared `parse_apply_to()` helper is brace-aware, so `**/*.{css,scss},**/*.py` is split on the top-level comma only. Closes a documented promise that was silently broken on the three non-Copilot harnesses. (#1387, closes #1366)
-- `apm update` against private Azure DevOps deps no longer fails on Windows with a misleading "az present but not logged in" diagnostic when the user IS signed in via `az login`. Root cause: Python's `subprocess.run(["az", ...])` -> `CreateProcessW` does not honor `PATHEXT` for non-`.exe` executables, so the Windows `az.cmd` wrapper could not be invoked even though `shutil.which("az")` resolved it. `AzureCliBearerProvider` now resolves the `az` binary via `shutil.which` once at construction and passes the absolute path to every subprocess call. As a defense-in-depth measure, the ADO `--update` preflight probe no longer strips `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_NOSYSTEM` / `GIT_ASKPASS`, so Git Credential Manager can answer for Entra-cached ADO credentials whenever bearer acquisition is unavailable for any reason (sandbox, proxy, future PATH quirks). The actual clone path keeps its full gitconfig isolation. (#1430)
-- Root `.apm` hooks no longer duplicate after renaming the project directory or using git worktrees; Claude, Codex, Cursor, Gemini, and Windsurf hook configs stay idempotent across checkouts. The hook source-id is now derived from `apm.yml`'s `name` field instead of `install_path.name`, and `apm install` silently heals stale same-content entries from prior checkout basenames. Copilot is unaffected (its hooks live in per-file namespaces under `.github/hooks/`, not a shared merged config). (#1392, closes #1329)
-- `apm install` now honours per-dependency `registry:` URLs in MCP dependencies instead of ignoring them with a warning. Dependencies targeting different registries are grouped and resolved against the correct registry endpoint. (#1443, closes #1393)
-- VS Code adapter now handles MCP registry v0.1 `runtimeArguments` entries with `variables` placeholders, fixing Docker-based MCP servers that require workspace mounts or other runtime parameters. (#1444, closes #1391)
-- `apm install --skill <name>` now persists the skill subset filter to `apm.yml` so subsequent `apm install` runs honour the selection. (#1442, closes #1395)
-- `apm audit` no longer false-reports non-skill primitives (instructions, agents, prompts, hooks, commands) as orphaned drift for targets with `auto_create=False` (windsurf, cursor, claude, codex, copilot, gemini, opencode). The drift replay engine now pre-creates target root directories in the ephemeral scratch space. (#1441, closes #1411)
-- Copilot harness auto-detection now recognises `.github/instructions/`, `.github/agents/`, `.github/prompts/`, and `.github/hooks/` as valid Copilot markers, and the "No harness detected" error message lists them. (#1440, closes #1435)
-- `apm install` (project-scope) keeps hook `command` paths repo-relative again, so checked-in `.claude/settings.json`, `.codex/hooks.json`, and equivalents stay portable across clones, contributors, and CI runners; user-scope (`apm install -g`) still writes absolute paths (#1310 / #1354 preserved). Re-run `apm install` on existing repos to rewrite any committed absolutized configs back to repo-relative paths. (#1394)
+- `apm install` honours per-dependency `registry:` URLs in MCP deps instead of warning and ignoring them. (#1443, closes #1393)
+- VS Code adapter handles MCP v0.1 `runtimeArguments` with `variables`, unblocking Docker MCP servers that need workspace mounts. (#1444, closes #1391)
+- `apm install --skill <name>` persists the skill filter to `apm.yml` so subsequent runs honour the selection. (#1442, closes #1395)
+- `apm audit` no longer false-flags non-skill primitives as orphaned drift on `auto_create=False` targets. (#1441, closes #1411)
+- Copilot harness auto-detection recognises `.github/instructions/`, `agents/`, `prompts/`, and `hooks/` as valid markers. (#1440, closes #1435)
+- `apm install` (project-scope) keeps hook `command` paths repo-relative so committed configs stay portable across clones and CI. (#1396, closes #1394)
+- PyInstaller binary restores `optimize=2`, shrinking the Windows Defender ML false-positive surface. (#1450)
+- Comma-separated `applyTo` globs emit proper YAML lists in Claude, Cursor, and Windsurf instruction outputs (brace-aware split). (#1387, #1449, closes #1366)
+- `GitCache` no longer crashes on Windows `file://` URLs where `urllib.parse.port` raises `ValueError`. (#1446)
+- `apm compile` discovers local-bundle instructions inside `apm_modules/` again. (#1388)
+- `apm install --target copilot-app` warns instead of failing when the App schema is newer than expected. (#1434)
+- Plugin packaging no longer destroys pre-positioned `.apm/` content during artifact mapping. (#1416)
+- `apm update` against private ADO deps no longer fails on Windows with a misleading "az not logged in" -- `az.cmd` is now resolved via `shutil.which`; ADO preflight preserves `GIT_*` env so GCM can fall back. (#1432, closes #1430)
+- Windows unit-test job is green again (Codex CLI path quoting + ADO subprocess env). (#1427)
+- Root `.apm` hooks no longer duplicate after directory renames or worktrees; hook source-ids derive from `apm.yml` `name` and self-heal stale entries. (#1392, closes #1329)
+- Codex and Gemini stdio MCP configs expand `${env:VAR}` placeholders in self-defined env vars. (#1277, closes #1266)
+- Codex CLI now supports Streamable HTTP MCP servers, matching the other harnesses. (#1262, closes #1260)
+- `apm install` preflight uses ssh (not https) on ssh-based dependency URLs. (#1303, closes #1293)
 
 ## [0.14.1] - 2026-05-20
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apm-cli"
-version = "0.14.1"
+version = "0.14.2"
 description = "MCP configuration tool"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/apm_cli/cache/git_cache.py
+++ b/src/apm_cli/cache/git_cache.py
@@ -287,7 +287,7 @@ class GitCache:
 
         Returns the path to the bare repo directory.
         """
-        from ..utils.git_env import get_git_executable, git_subprocess_env
+        from ..utils.git_env import get_git_executable, git_long_paths_args, git_subprocess_env
 
         bare_shard = shard_key + (_PARTIAL_BARE_SUFFIX if partial else "")
         bare_dir = self._db_root / bare_shard
@@ -318,7 +318,7 @@ class GitCache:
             os.chmod(str(staged), 0o700)
 
             subprocess_env = env if env is not None else git_subprocess_env()
-            clone_args = [git_exe, "clone", "--bare", "--no-tags"]
+            clone_args = [git_exe, *git_long_paths_args(), "clone", "--bare", "--no-tags"]
             if partial:
                 # Promisor partial clone: trees + commits only. Blobs
                 # arrive lazily via the remote when the consumer needs
@@ -366,7 +366,15 @@ class GitCache:
                     os.chmod(str(staged), 0o700)
                     try:
                         subprocess.run(
-                            [git_exe, "clone", "--bare", "--no-tags", url, str(staged)],
+                            [
+                                git_exe,
+                                *git_long_paths_args(),
+                                "clone",
+                                "--bare",
+                                "--no-tags",
+                                url,
+                                str(staged),
+                            ],
                             capture_output=True,
                             text=True,
                             timeout=300,
@@ -448,7 +456,7 @@ class GitCache:
         get the lock and return immediately. Critical for CI matrix
         builds where multiple jobs hit the same uncached repo.
         """
-        from ..utils.git_env import get_git_executable, git_subprocess_env
+        from ..utils.git_env import get_git_executable, git_long_paths_args, git_subprocess_env
 
         bare_shard = shard_key + (_PARTIAL_BARE_SUFFIX if promisor_url else "")
         bare_dir = self._db_root / bare_shard
@@ -497,6 +505,7 @@ class GitCache:
                 subprocess.run(
                     [
                         git_exe,
+                        *git_long_paths_args(),
                         "clone",
                         "--local",
                         "--shared",

--- a/src/apm_cli/integration/copilot_app_ws.py
+++ b/src/apm_cli/integration/copilot_app_ws.py
@@ -178,11 +178,15 @@ def _token_file_mode_ok(path: Path) -> bool:
     cost of being strict is one extra restart, while the cost of being
     permissive is a real credential leak.
 
-    POSIX-only check. On Windows ``stat.S_IRWXG`` / ``stat.S_IRWXO``
-    are reported as zero by ``os.stat`` so the check is effectively a
-    no-op there; ACL hardening on Windows is out of scope for this
+    POSIX-only check. On Windows ``os.stat`` synthesizes group/other
+    bits from the read-only flag (typically ``0o100666`` for r/w
+    files), so the POSIX-style ``& S_IRWXG | S_IRWXO`` test would
+    spuriously reject every token file. We short-circuit to ``True``
+    on Windows; ACL hardening on Windows is out of scope for this
     module.
     """
+    if os.name == "nt":
+        return True
     try:
         st = path.stat()
     except OSError:

--- a/src/apm_cli/utils/git_env.py
+++ b/src/apm_cli/utils/git_env.py
@@ -95,3 +95,20 @@ def reset_git_cache() -> None:
     global _git_executable, _git_resolved
     _git_executable = None
     _git_resolved = False
+
+
+def git_long_paths_args() -> list[str]:
+    """Return ``-c core.longpaths=true`` on Windows, ``[]`` elsewhere.
+
+    Windows enforces a 260-character ``MAX_PATH`` limit by default,
+    which the GitCache's deeply-nested ``checkouts_v1/<shard>/<sha>/
+    <variant>.incomplete.<pid>.<ns>/`` layout can exceed during
+    ``git clone`` -- git fails with ``Filename too long`` while
+    creating ``.git/hooks/`` files. Setting ``core.longpaths=true``
+    via ``-c`` opts that single subprocess into the long-path API
+    without mutating the user's global gitconfig. The flag is a
+    no-op on POSIX so callers can prepend it unconditionally.
+    """
+    if os.name == "nt":
+        return ["-c", "core.longpaths=true"]
+    return []

--- a/tests/unit/integration/test_copilot_app_project.py
+++ b/tests/unit/integration/test_copilot_app_project.py
@@ -169,7 +169,9 @@ class TestDeriveProjectRecipe:
         )
         r = cap.derive_project_recipe(ctx)
         assert r.name == "x"
-        assert r.main_repo_path == "/tmp/x"
+        # ``main_repo_path`` is the OS-native string form of the repo
+        # root; on POSIX this is ``/tmp/x``, on Windows ``\tmp\x``.
+        assert r.main_repo_path == str(Path("/tmp/x"))
         assert r.default_branch == "main"
         assert r.github_owner == "o"
         assert r.github_repo == "x"

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "apm-cli"
-version = "0.14.1"
+version = "0.14.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Cut release v0.14.2.

- Bump \`pyproject.toml\` to 0.14.2 (and \`uv.lock\`).
- Move \`[Unreleased]\` to \`[0.14.2] - 2026-05-22\` in \`CHANGELOG.md\`, with one short "so what?" entry per PR merged since v0.14.1.

Lint mirror green locally (ruff check + format, pylint R0801, auth-signals).

Post-merge: tag \`v0.14.2\` to trigger the release workflow.