### PR TITLE
test(integration): unstick 23 stale tests that drift from production code

### DIFF
--- a/tests/integration/test_context_optimizer_phase3w4.py
+++ b/tests/integration/test_context_optimizer_phase3w4.py
@@ -40,11 +40,17 @@ from apm_cli.primitives.models import Instruction
 
 
 def _make_instruction(apply_to: str | None = "**/*.py", content: str = "content") -> Instruction:
+    from pathlib import Path as _Path
+
     inst = MagicMock(spec=Instruction)
     inst.apply_to = apply_to
     inst.content = content
     inst.source_file = None
     inst.source = None
+    # Production fallback path reads instruction.file_path.stem when an
+    # instruction matches no files; spec=Instruction does not expose
+    # dataclass fields automatically, so set it explicitly.
+    inst.file_path = _Path("test.instructions.md")
     return inst
 
 

--- a/tests/integration/test_context_optimizer_placement.py
+++ b/tests/integration/test_context_optimizer_placement.py
@@ -40,11 +40,17 @@ from apm_cli.primitives.models import Instruction
 
 
 def _make_instruction(apply_to: str | None = "**/*.py", content: str = "content") -> Instruction:
+    from pathlib import Path as _Path
+
     inst = MagicMock(spec=Instruction)
     inst.apply_to = apply_to
     inst.content = content
     inst.source_file = None
     inst.source = None
+    # Production fallback path reads instruction.file_path.stem when an
+    # instruction matches no files; spec=Instruction does not expose
+    # dataclass fields automatically, so set it explicitly.
+    inst.file_path = _Path("test.instructions.md")
     return inst
 
 

--- a/tests/integration/test_git_cache_hermetic.py
+++ b/tests/integration/test_git_cache_hermetic.py
@@ -75,7 +75,7 @@ class TestGetCheckout:
     def test_cache_hit_returns_existing_checkout(self, cache: GitCache) -> None:
         url = "https://github.com/owner/repo.git"
         sha = "a" * 40
-        checkout_dir = cache._checkouts_root / cache_shard_key(url) / sha
+        checkout_dir = cache._checkouts_root / cache_shard_key(url) / sha / "full"
         checkout_dir.mkdir(parents=True)
 
         with (
@@ -93,7 +93,7 @@ class TestGetCheckout:
     def test_cache_hit_with_failed_integrity_evicts_and_recreates(self, cache: GitCache) -> None:
         url = "https://github.com/owner/repo.git"
         sha = "b" * 40
-        checkout_dir = cache._checkouts_root / cache_shard_key(url) / sha
+        checkout_dir = cache._checkouts_root / cache_shard_key(url) / sha / "full"
         checkout_dir.mkdir(parents=True)
         recreated = checkout_dir.parent / "recreated"
 
@@ -108,8 +108,10 @@ class TestGetCheckout:
 
         assert result == recreated
         mock_evict.assert_called_once_with(checkout_dir)
-        mock_ensure.assert_called_once_with(url, cache_shard_key(url), sha, env=None)
-        mock_create.assert_called_once_with(url, cache_shard_key(url), sha, env=None)
+        mock_ensure.assert_called_once_with(url, cache_shard_key(url), sha, env=None, partial=False)
+        mock_create.assert_called_once_with(
+            url, cache_shard_key(url), sha, env=None, sparse_paths=None, promisor_url=None
+        )
 
     def test_refresh_ignores_existing_checkout(self, tmp_path: Path) -> None:
         with (
@@ -119,7 +121,7 @@ class TestGetCheckout:
             cache = GitCache(tmp_path, refresh=True)
         url = "https://github.com/owner/repo.git"
         sha = "c" * 40
-        checkout_dir = cache._checkouts_root / cache_shard_key(url) / sha
+        checkout_dir = cache._checkouts_root / cache_shard_key(url) / sha / "full"
         checkout_dir.mkdir(parents=True)
 
         with (
@@ -138,7 +140,7 @@ class TestGetCheckout:
     def test_cache_miss_creates_checkout(self, cache: GitCache) -> None:
         url = "https://github.com/owner/repo.git"
         sha = "d" * 40
-        checkout_dir = cache._checkouts_root / cache_shard_key(url) / sha
+        checkout_dir = cache._checkouts_root / cache_shard_key(url) / sha / "full"
 
         with (
             patch.object(cache, "_resolve_sha", return_value=sha),
@@ -148,8 +150,12 @@ class TestGetCheckout:
             result = cache.get_checkout(url, None, locked_sha=sha, env={"A": "1"})
 
         assert result == checkout_dir
-        mock_ensure.assert_called_once_with(url, cache_shard_key(url), sha, env={"A": "1"})
-        mock_create.assert_called_once_with(url, cache_shard_key(url), sha, env={"A": "1"})
+        mock_ensure.assert_called_once_with(
+            url, cache_shard_key(url), sha, env={"A": "1"}, partial=False
+        )
+        mock_create.assert_called_once_with(
+            url, cache_shard_key(url), sha, env={"A": "1"}, sparse_paths=None, promisor_url=None
+        )
 
 
 class TestResolveSha:
@@ -447,7 +453,7 @@ class TestCreateCheckout:
     def test_write_dedup_hit_under_lock_returns_existing_checkout(self, cache: GitCache) -> None:
         url = "https://example.com/repo.git"
         shard_key = cache_shard_key(url)
-        final_dir = cache._checkouts_root / shard_key / ("a" * 40)
+        final_dir = cache._checkouts_root / shard_key / ("a" * 40) / "full"
         final_dir.mkdir(parents=True)
 
         with (
@@ -465,7 +471,7 @@ class TestCreateCheckout:
         shard_key = cache_shard_key(url)
         bare_dir = cache._db_root / shard_key
         bare_dir.mkdir(parents=True)
-        final_dir = cache._checkouts_root / shard_key / ("b" * 40)
+        final_dir = cache._checkouts_root / shard_key / ("b" * 40) / "full"
         final_dir.mkdir(parents=True)
 
         def _land(staged: Path, final: Path, _lock: object) -> bool:
@@ -534,7 +540,7 @@ class TestCreateCheckout:
     def test_atomic_land_false_accepts_valid_winner(self, cache: GitCache) -> None:
         url = "https://example.com/repo.git"
         shard_key = cache_shard_key(url)
-        final_dir = cache._checkouts_root / shard_key / ("e" * 40)
+        final_dir = cache._checkouts_root / shard_key / ("e" * 40) / "full"
         final_dir.mkdir(parents=True)
         (cache._db_root / shard_key).mkdir(parents=True)
 
@@ -556,7 +562,7 @@ class TestCreateCheckout:
     def test_atomic_land_false_with_invalid_winner_evicts_and_raises(self, cache: GitCache) -> None:
         url = "https://example.com/repo.git"
         shard_key = cache_shard_key(url)
-        final_dir = cache._checkouts_root / shard_key / ("f" * 40)
+        final_dir = cache._checkouts_root / shard_key / ("f" * 40) / "full"
         final_dir.mkdir(parents=True)
         (cache._db_root / shard_key).mkdir(parents=True)
 

--- a/tests/integration/test_git_cache_phase3w5.py
+++ b/tests/integration/test_git_cache_phase3w5.py
@@ -75,7 +75,7 @@ class TestGetCheckout:
     def test_cache_hit_returns_existing_checkout(self, cache: GitCache) -> None:
         url = "https://github.com/owner/repo.git"
         sha = "a" * 40
-        checkout_dir = cache._checkouts_root / cache_shard_key(url) / sha
+        checkout_dir = cache._checkouts_root / cache_shard_key(url) / sha / "full"
         checkout_dir.mkdir(parents=True)
 
         with (
@@ -93,7 +93,7 @@ class TestGetCheckout:
     def test_cache_hit_with_failed_integrity_evicts_and_recreates(self, cache: GitCache) -> None:
         url = "https://github.com/owner/repo.git"
         sha = "b" * 40
-        checkout_dir = cache._checkouts_root / cache_shard_key(url) / sha
+        checkout_dir = cache._checkouts_root / cache_shard_key(url) / sha / "full"
         checkout_dir.mkdir(parents=True)
         recreated = checkout_dir.parent / "recreated"
 
@@ -108,8 +108,10 @@ class TestGetCheckout:
 
         assert result == recreated
         mock_evict.assert_called_once_with(checkout_dir)
-        mock_ensure.assert_called_once_with(url, cache_shard_key(url), sha, env=None)
-        mock_create.assert_called_once_with(url, cache_shard_key(url), sha, env=None)
+        mock_ensure.assert_called_once_with(url, cache_shard_key(url), sha, env=None, partial=False)
+        mock_create.assert_called_once_with(
+            url, cache_shard_key(url), sha, env=None, sparse_paths=None, promisor_url=None
+        )
 
     def test_refresh_ignores_existing_checkout(self, tmp_path: Path) -> None:
         with (
@@ -119,7 +121,7 @@ class TestGetCheckout:
             cache = GitCache(tmp_path, refresh=True)
         url = "https://github.com/owner/repo.git"
         sha = "c" * 40
-        checkout_dir = cache._checkouts_root / cache_shard_key(url) / sha
+        checkout_dir = cache._checkouts_root / cache_shard_key(url) / sha / "full"
         checkout_dir.mkdir(parents=True)
 
         with (
@@ -138,7 +140,7 @@ class TestGetCheckout:
     def test_cache_miss_creates_checkout(self, cache: GitCache) -> None:
         url = "https://github.com/owner/repo.git"
         sha = "d" * 40
-        checkout_dir = cache._checkouts_root / cache_shard_key(url) / sha
+        checkout_dir = cache._checkouts_root / cache_shard_key(url) / sha / "full"
 
         with (
             patch.object(cache, "_resolve_sha", return_value=sha),
@@ -148,8 +150,12 @@ class TestGetCheckout:
             result = cache.get_checkout(url, None, locked_sha=sha, env={"A": "1"})
 
         assert result == checkout_dir
-        mock_ensure.assert_called_once_with(url, cache_shard_key(url), sha, env={"A": "1"})
-        mock_create.assert_called_once_with(url, cache_shard_key(url), sha, env={"A": "1"})
+        mock_ensure.assert_called_once_with(
+            url, cache_shard_key(url), sha, env={"A": "1"}, partial=False
+        )
+        mock_create.assert_called_once_with(
+            url, cache_shard_key(url), sha, env={"A": "1"}, sparse_paths=None, promisor_url=None
+        )
 
 
 class TestResolveSha:
@@ -447,7 +453,7 @@ class TestCreateCheckout:
     def test_write_dedup_hit_under_lock_returns_existing_checkout(self, cache: GitCache) -> None:
         url = "https://example.com/repo.git"
         shard_key = cache_shard_key(url)
-        final_dir = cache._checkouts_root / shard_key / ("a" * 40)
+        final_dir = cache._checkouts_root / shard_key / ("a" * 40) / "full"
         final_dir.mkdir(parents=True)
 
         with (
@@ -465,7 +471,7 @@ class TestCreateCheckout:
         shard_key = cache_shard_key(url)
         bare_dir = cache._db_root / shard_key
         bare_dir.mkdir(parents=True)
-        final_dir = cache._checkouts_root / shard_key / ("b" * 40)
+        final_dir = cache._checkouts_root / shard_key / ("b" * 40) / "full"
         final_dir.mkdir(parents=True)
 
         def _land(staged: Path, final: Path, _lock: object) -> bool:
@@ -534,7 +540,7 @@ class TestCreateCheckout:
     def test_atomic_land_false_accepts_valid_winner(self, cache: GitCache) -> None:
         url = "https://example.com/repo.git"
         shard_key = cache_shard_key(url)
-        final_dir = cache._checkouts_root / shard_key / ("e" * 40)
+        final_dir = cache._checkouts_root / shard_key / ("e" * 40) / "full"
         final_dir.mkdir(parents=True)
         (cache._db_root / shard_key).mkdir(parents=True)
 
@@ -556,7 +562,7 @@ class TestCreateCheckout:
     def test_atomic_land_false_with_invalid_winner_evicts_and_raises(self, cache: GitCache) -> None:
         url = "https://example.com/repo.git"
         shard_key = cache_shard_key(url)
-        final_dir = cache._checkouts_root / shard_key / ("f" * 40)
+        final_dir = cache._checkouts_root / shard_key / ("f" * 40) / "full"
         final_dir.mkdir(parents=True)
         (cache._db_root / shard_key).mkdir(parents=True)
 

--- a/tests/integration/test_mcp_integrator_characterisation.py
+++ b/tests/integration/test_mcp_integrator_characterisation.py
@@ -297,13 +297,23 @@ class TestCollectTransitive:
         pkg.name = "good"
         pkg.get_mcp_dependencies.return_value = [dep]
 
+        # Side-effect order must follow the filesystem-discovery order of
+        # apm.yml files (which Path.iterdir does not guarantee to be
+        # alphabetic across OSes/filesystems). Determine the order
+        # lazily so the bad-then-good (ValueError-then-pkg) sequence
+        # always lines up with whichever directory is enumerated first.
+        def _from_apm_yml(path, *_args, **_kw):
+            if path == first:
+                raise ValueError("bad")
+            return pkg
+
         with patch("apm_cli.models.apm_package.APMPackage") as mock_pkg_cls:
-            mock_pkg_cls.from_apm_yml.side_effect = [ValueError("bad"), pkg]
+            mock_pkg_cls.from_apm_yml.side_effect = _from_apm_yml
             result = MCPIntegrator.collect_transitive(apm_modules)
 
         assert result == [dep]
-        assert mock_pkg_cls.from_apm_yml.call_args_list[0].args[0] == first
-        assert mock_pkg_cls.from_apm_yml.call_args_list[1].args[0] == second
+        called_paths = {call.args[0] for call in mock_pkg_cls.from_apm_yml.call_args_list}
+        assert called_paths == {first, second}
 
     def test_supports_lock_entries_with_virtual_path(self, tmp_path: Path) -> None:
         apm_modules = tmp_path / "apm_modules"

--- a/tests/integration/test_mcp_integrator_install_flow.py
+++ b/tests/integration/test_mcp_integrator_install_flow.py
@@ -329,6 +329,10 @@ class TestApplyOverlay:
         assert any("version" in str(w.message) for w in caught)
 
     def test_registry_overlay_warns_when_string(self):
+        # Historical behavior: a string `registry` field on an MCPDependency
+        # emitted a runtime warning. The warning was removed when the field
+        # became a no-op overlay (kept for forward-compat with newer apm.yml
+        # schemas that may attach it). Assert the silent-noop contract.
         dep = _make_dep("srv")
         dep.version = None
         dep.registry = "custom-registry"
@@ -336,7 +340,7 @@ class TestApplyOverlay:
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             MCPIntegrator._apply_overlay(cache, dep)
-        assert any("registry" in str(w.message) for w in caught)
+        assert not any("registry" in str(w.message) for w in caught)
 
     def test_unknown_server_is_noop(self):
         dep = _make_dep("missing-srv", transport="stdio")

--- a/tests/integration/test_mcp_integrator_phase3w4.py
+++ b/tests/integration/test_mcp_integrator_phase3w4.py
@@ -329,6 +329,10 @@ class TestApplyOverlay:
         assert any("version" in str(w.message) for w in caught)
 
     def test_registry_overlay_warns_when_string(self):
+        # Historical behavior: a string `registry` field on an MCPDependency
+        # emitted a runtime warning. The warning was removed when the field
+        # became a no-op overlay (kept for forward-compat with newer apm.yml
+        # schemas that may attach it). Assert the silent-noop contract.
         dep = _make_dep("srv")
         dep.version = None
         dep.registry = "custom-registry"
@@ -336,7 +340,7 @@ class TestApplyOverlay:
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             MCPIntegrator._apply_overlay(cache, dep)
-        assert any("registry" in str(w.message) for w in caught)
+        assert not any("registry" in str(w.message) for w in caught)
 
     def test_unknown_server_is_noop(self):
         dep = _make_dep("missing-srv", transport="stdio")

--- a/tests/integration/test_mcp_integrator_phase3w5.py
+++ b/tests/integration/test_mcp_integrator_phase3w5.py
@@ -297,13 +297,23 @@ class TestCollectTransitive:
         pkg.name = "good"
         pkg.get_mcp_dependencies.return_value = [dep]
 
+        # Side-effect order must follow the filesystem-discovery order of
+        # apm.yml files (which Path.iterdir does not guarantee to be
+        # alphabetic across OSes/filesystems). Determine the order
+        # lazily so the bad-then-good (ValueError-then-pkg) sequence
+        # always lines up with whichever directory is enumerated first.
+        def _from_apm_yml(path, *_args, **_kw):
+            if path == first:
+                raise ValueError("bad")
+            return pkg
+
         with patch("apm_cli.models.apm_package.APMPackage") as mock_pkg_cls:
-            mock_pkg_cls.from_apm_yml.side_effect = [ValueError("bad"), pkg]
+            mock_pkg_cls.from_apm_yml.side_effect = _from_apm_yml
             result = MCPIntegrator.collect_transitive(apm_modules)
 
         assert result == [dep]
-        assert mock_pkg_cls.from_apm_yml.call_args_list[0].args[0] == first
-        assert mock_pkg_cls.from_apm_yml.call_args_list[1].args[0] == second
+        called_paths = {call.args[0] for call in mock_pkg_cls.from_apm_yml.call_args_list}
+        assert called_paths == {first, second}
 
     def test_supports_lock_entries_with_virtual_path(self, tmp_path: Path) -> None:
         apm_modules = tmp_path / "apm_modules"

--- a/tests/integration/test_wave8_codex_download_coverage.py
+++ b/tests/integration/test_wave8_codex_download_coverage.py
@@ -174,12 +174,17 @@ class TestCodexConfigureMcpServer:
         assert "custom" in data["mcp_servers"]
 
     def test_remote_only_rejected(self, tmp_path: Path) -> None:
+        # Codex now accepts remote-only streamable-http servers (see
+        # CodexClientAdapter._format_server_config). Only SSE and
+        # non-https / empty-URL remotes are rejected. Assert the SSE
+        # rejection branch which is the actual remote-only "reject"
+        # contract.
         from apm_cli.adapters.client.codex import CodexClientAdapter
 
         adapter = CodexClientAdapter(project_root=tmp_path)
         server_info = {
             "name": "remote",
-            "remotes": [{"url": "https://example.com/sse"}],
+            "remotes": [{"url": "https://example.com/sse", "transport_type": "sse"}],
             "packages": [],
         }
         with patch.object(adapter, "_fetch_server_info", return_value=server_info):


### PR DESCRIPTION
## Summary

Integration Tests have been silently skipped in CI/CD Pipeline because Build & Test was failing on Windows. Once #1456 made Windows green, the integration matrix ran for the first time in weeks and surfaced accumulated test rot — 23 stale tests across 9 files.

## Fixes

| Tests | Drift |
|---|---|
| `test_git_cache_{hermetic,phase3w5}` (14) | GitCache now lays out checkouts under `<shard>/<sha>/<variant>` (perf #1433). Tests expected pre-variant layout. |
| `test_context_optimizer_{phase3w4,placement}` (6) | ContextOptimizer fallback reads `instruction.file_path.stem`; `MagicMock(spec=Instruction)` does not expose dataclass fields. |
| `test_mcp_integrator_{install_flow,phase3w4}::test_registry_overlay_warns_when_string` (2) | `_apply_overlay` no longer warns on string `registry` (silent no-op). |
| `test_mcp_integrator_{characterisation,phase3w5}::test_skips_parse_errors_and_continues` (2) | Assertion depended on `Path.iterdir` ordering (not guaranteed across filesystems). |
| `test_wave8_codex_download_coverage::test_remote_only_rejected` (1) | Codex now accepts streamable-http remote-only; only SSE rejected. |

## Validation

Full local integration run: `9000 passed, 222 skipped, 2 xfailed in 311.62s`. All lint gates pass.

## Why this matters

This unblocks the v0.14.2 release pipeline (run 26311614440).