### PR TITLE
[docs] Update documentation for features from 2026-05-22

### DIFF
--- a/docs/src/content/docs/consumer/install-mcp-servers.md
+++ b/docs/src/content/docs/consumer/install-mcp-servers.md
@@ -29,20 +29,35 @@ dependencies:
     # 1. Registry reference (bare string)
     - io.github.github/github-mcp-server
 
-    # 2. Self-defined stdio (local process)
+    # 2. Registry reference with a per-dep custom registry URL
+    - name: my-internal-server
+      registry: https://registry.internal.example.com
+
+    # 3. Self-defined stdio (local process)
     - name: filesystem
       registry: false
       transport: stdio
       command: npx
       args: ["-y", "@modelcontextprotocol/server-filesystem", "/workspace"]
 
-    # 3. Self-defined remote (HTTP / SSE)
+    # 4. Self-defined remote (HTTP / SSE)
     - name: linear
       registry: false
       transport: http
       url: https://mcp.linear.app/sse
       headers:
         Authorization: "Bearer ${LINEAR_TOKEN}"
+```
+
+When `registry:` is a string URL (form 2 above), APM routes that entry through
+the specified registry instead of the global default (`https://api.mcp.github.com`).
+Each dependency can point to a different registry; APM groups them and installs
+each group via its own registry client. The `registry:` URL is persisted to
+`apm.yml` and honored on every subsequent `apm install`. You can also set the
+custom URL from the CLI with `--registry URL` when first adding the entry:
+
+```bash
+apm install --mcp my-internal-server --registry https://registry.internal.example.com
 ```
 
 The full grammar (overlays, `${input:...}` variables, `tools:`

--- a/docs/src/content/docs/reference/cli/targets.md
+++ b/docs/src/content/docs/reference/cli/targets.md
@@ -92,7 +92,7 @@ match per target is enough to activate it.
 | Target | Signal(s) APM looks for | Deploy directory |
 |--------|-------------------------|------------------|
 | `claude` | `.claude/` directory, or `CLAUDE.md` file | `.claude/` |
-| `copilot` | `.github/copilot-instructions.md` file | `.github/` |
+| `copilot` | `.github/copilot-instructions.md` file (monolithic), or `.github/instructions/`, `.github/agents/`, `.github/prompts/`, `.github/hooks/` directories (file-based layout) | `.github/` |
 | `cursor` | `.cursor/` directory, or `.cursorrules` file (legacy) | `.cursor/` |
 | `codex` | `.codex/` directory | `.codex/` |
 | `gemini` | `.gemini/` directory, or `GEMINI.md` file | `.gemini/` |
@@ -104,6 +104,10 @@ Notes:
 
 - Detection is filesystem-only. APM does not inspect file contents to
   decide whether a marker is "real".
+- Copilot is detected by either the monolithic `.github/copilot-instructions.md`
+  file OR by the presence of any file-based layout directory
+  (`.github/instructions/`, `.github/agents/`, `.github/prompts/`,
+  `.github/hooks/`). Any one of these is sufficient.
 - A `CLAUDE.md` written as documentation will still activate the
   `claude` target. Pin `targets:` in `apm.yml` to override.
 - If no signals are found and `apm.yml` declares no `targets:`,

--- a/docs/src/content/docs/reference/targets-matrix.md
+++ b/docs/src/content/docs/reference/targets-matrix.md
@@ -54,7 +54,7 @@ list before `compile` or `install`.
 | Target   | Signals (any one activates the target)        |
 |----------|-----------------------------------------------|
 | claude   | `.claude/` directory, or `CLAUDE.md` file     |
-| copilot  | `.github/copilot-instructions.md` file        |
+| copilot  | `.github/copilot-instructions.md` file, or `.github/instructions/`, `.github/agents/`, `.github/prompts/`, `.github/hooks/` directories |
 | cursor   | `.cursor/` directory, or `.cursorrules` file  |
 | codex    | `.codex/` directory                           |
 | gemini   | `.gemini/` directory, or `GEMINI.md` file     |
@@ -70,7 +70,7 @@ a project's `apm.yml` `targets:` field so contributors running plain
 
 GitHub Copilot (CLI and IDE).
 
-- **Detection.** `.github/copilot-instructions.md`.
+- **Detection.** `.github/copilot-instructions.md` (monolithic), or any of `.github/instructions/`, `.github/agents/`, `.github/prompts/`, `.github/hooks/` directories (file-based layout).
 - **Deploy directory.** `.github/` at project scope; `~/.copilot/` at user scope.
 - **Supported primitives.** instructions, prompts, agents, skills, hooks, mcp.
 - **File conventions.**


### PR DESCRIPTION
## Documentation Updates - 2026-05-22

This PR updates the documentation based on user-facing features and fixes merged in the last 24 hours.

### Features Documented

- Expanded Copilot harness auto-detection to file-based signal directories (from #1440)
- Per-dependency `registry:` URL now honored during MCP install (from #1443)

### Changes Made

- Updated `docs/src/content/docs/reference/targets-matrix.md` to list the new Copilot detection signals: `.github/instructions/`, `.github/agents/`, `.github/prompts/`, `.github/hooks/`
- Updated `docs/src/content/docs/reference/cli/targets.md` Detection signals table and notes for copilot target
- Updated `docs/src/content/docs/consumer/install-mcp-servers.md` to document per-dep `registry: URL` form and the `--registry` CLI flag with examples

### Merged PRs Referenced

- #1440 - fix(detect): expand copilot harness markers to file-based signals
- #1443 - fix(mcp): honour per-dep registry URL during install

### PRs Reviewed But Not Requiring Docs Updates

- #1442 - fix(install): persist --skill filter to apm.yml (CLI reference already documented this as the intended behavior; was a bug fix)
- #1444 - fix(vscode): handle v0.1 runtimeArguments with variables for Docker MCP (internal VS Code adapter fix; no user-facing API change)
- #1456 - fix(cache): apply core.longpaths to post-clone git ops on Windows (Windows plumbing fix)
- #1451 - feat(batch-bug-shepherd): operator visibility + fold-in invariant (skill/agent primitive update, documented in the skill itself)
- #1454 - chore: release v0.14.2 (release; CHANGELOG updated by the release workflow)




> [!NOTE]
> <details>
> <summary>🔒 Integrity filter blocked 2 items</summary>
>
> The following items were blocked because they don't meet the GitHub integrity level.
>
> - [#1416](https://github.com/microsoft/apm/pull/1416) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#1396](https://github.com/microsoft/apm/pull/1396) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/26325037718/agentic_workflow) · ● 1.2M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+%22gh-aw-workflow-id%3A+daily-doc-updater%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/blob/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-05-25T06:00:25.996Z --> on May 25, 2026, 6:00 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 26325037718, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/26325037718 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->