### PR TITLE
fix(mcp): rewrite skill-shipped MCP command paths for the Claude target

### DIFF
--- a/src/apm_cli/adapters/client/claude.py
+++ b/src/apm_cli/adapters/client/claude.py
@@ -48,6 +48,28 @@ class ClaudeClientAdapter(CopilotClientAdapter):
     # See #1152 supply-chain analysis.
     _supports_runtime_env_substitution: bool = False
 
+    # Skill packages declare self-defined MCP launchers using the cross-tool
+    # converged path ``.agents/skills/<name>/...`` (see
+    # https://microsoft.github.io/apm/reference/targets-matrix/#skills-convergence).
+    # Claude is the only target that does NOT converge to ``.agents/skills/``
+    # -- it keeps ``.claude/skills/`` (see install/skill_path_migration.py:55).
+    # Rewrite the command prefix so ``.mcp.json`` points at where the launcher
+    # actually lives after deploy.
+    _CONVERGED_SKILL_PREFIX = ".agents/skills/"
+    _CLAUDE_SKILL_PREFIX = ".claude/skills/"
+
+    @classmethod
+    def _rewrite_self_defined_skill_command(cls, command: str) -> str:
+        if isinstance(command, str) and command.startswith(cls._CONVERGED_SKILL_PREFIX):
+            return cls._CLAUDE_SKILL_PREFIX + command[len(cls._CONVERGED_SKILL_PREFIX) :]
+        return command
+
+    def _format_server_config(self, server_info, env_overrides=None, runtime_vars=None):
+        config = super()._format_server_config(server_info, env_overrides, runtime_vars)
+        if isinstance(config, dict) and "command" in config:
+            config["command"] = self._rewrite_self_defined_skill_command(config["command"])
+        return config
+
     @staticmethod
     def _normalize_mcp_entry_for_claude_code(entry: dict) -> dict:
         """Normalize a server entry to Claude Code's on-disk shape.

--- a/tests/unit/test_claude_mcp.py
+++ b/tests/unit/test_claude_mcp.py
@@ -119,6 +119,48 @@ class TestClaudeClientAdapterProject(unittest.TestCase):
         data = json.loads(self.mcp_path.read_text(encoding="utf-8"))
         self.assertIn("srv", data["mcpServers"])
 
+    def test_self_defined_skill_command_rewritten_to_claude_skills(self):
+        """Skill-shipped MCP launchers declare their command using the
+        cross-tool ``.agents/skills/<name>/...`` convention.  Claude does not
+        converge to ``.agents/skills/`` (see install/skill_path_migration.py),
+        so the prefix must be rewritten to ``.claude/skills/`` -- otherwise
+        ``.mcp.json`` points at a path that does not exist on disk.
+        """
+        with patch.object(self.adapter, "registry_client") as mock_registry:
+            mock_registry.find_server_by_reference.return_value = {
+                "name": "chrome-devtools",
+                "_raw_stdio": {
+                    "command": ".agents/skills/nix-chrome-devtools-mcp/bin/serve",
+                    "args": [],
+                    "env": {},
+                },
+            }
+            ok = self.adapter.configure_mcp_server("chrome-devtools")
+
+        self.assertTrue(ok)
+        data = json.loads(self.mcp_path.read_text(encoding="utf-8"))
+        self.assertEqual(
+            data["mcpServers"]["chrome-devtools"]["command"],
+            ".claude/skills/nix-chrome-devtools-mcp/bin/serve",
+        )
+
+    def test_self_defined_non_skill_command_left_unchanged(self):
+        """Only the ``.agents/skills/<name>/...`` prefix is rewritten;
+        bare binaries (``npx``, ``node``), absolute paths, and unrelated
+        relative paths must pass through verbatim.
+        """
+        for raw_command in (
+            "npx",
+            "/usr/local/bin/mcp-server",
+            "./scripts/run-mcp.sh",
+            ".agents/other/path",
+        ):
+            with self.subTest(command=raw_command):
+                self.assertEqual(
+                    self.adapter._rewrite_self_defined_skill_command(raw_command),
+                    raw_command,
+                )
+
     def test_configure_self_defined_stdio_preserves_env(self):
         with patch.object(self.adapter, "registry_client") as mock_registry:
             mock_registry.find_server_by_reference.return_value = {


### PR DESCRIPTION
## Summary

Self-defined MCP launchers shipped inside a skill package (e.g. [`juspay/nix-chrome-devtools-mcp`](https://github.com/juspay/nix-chrome-devtools-mcp/blob/main/apm.yml#L21)) declare their `command:` using the cross-tool [converged skill path](https://microsoft.github.io/apm/reference/targets-matrix/#skills-convergence) `.agents/skills/<name>/...`. Every other target deploys skills to `.agents/skills/`, so the upstream value is correct as-declared — but **Claude is the documented outlier** (see `install/skill_path_migration.py:55`: *".claude/skills/ is excluded (Claude is not in the convergence set)"*). Consumers whose `apm.yml` has `target: claude` end up with files at `.claude/skills/<name>/...` while `.mcp.json` still points at the non-existent `.agents/skills/<name>/...`, so Claude Code fails to launch the server.

## Repro

```yaml
# apm.yml
target: claude
dependencies:
  apm:
    - juspay/nix-chrome-devtools-mcp
```

```console
$ apm install
$ ls .agents/skills/nix-chrome-devtools-mcp/bin/serve
ls: cannot access '.agents/skills/...': No such file or directory
$ ls .claude/skills/nix-chrome-devtools-mcp/bin/serve   # the file IS here
-rwxr-xr-x ...
$ jq -r '.mcpServers["chrome-devtools"].command' .mcp.json
.agents/skills/nix-chrome-devtools-mcp/bin/serve   # ← wrong
```

## Fix

Override `_format_server_config` in `ClaudeClientAdapter` to rewrite the `.agents/skills/` prefix to `.claude/skills/` on the way out. Scoped to the prefix only — bare binaries (`npx`, `node`), absolute paths, and unrelated relative paths pass through unchanged.

Drift detection (`_detect_mcp_config_drift`) compares the upstream `dep.to_dict()` against the lockfile baseline (both upstream-shaped), not against on-disk paths, so the rewrite does not perturb idempotence. Verified: a second `apm install` reports *"already configured"* and the on-disk path remains rewritten.

## Why this layer

- `_build_self_defined_info` in `mcp_integrator.py` builds one `synthetic_info` per dep that is **reused across all `target_runtimes`** — rewriting there would either need per-runtime copies or runtime-specific knowledge in the integrator.
- Each adapter already owns its target-specific shaping (cf. `_normalize_mcp_entry_for_claude_code`), and Claude is the only target that needs this rewrite, so a single override stays local.

## Test plan

- [x] New unit test: `.agents/skills/<name>/...` → `.claude/skills/<name>/...` end-to-end through `configure_mcp_server` → `.mcp.json`
- [x] New unit test: pass-through for `npx`, absolute paths, `./scripts/...`, `.agents/other/...`
- [x] Full `tests/unit/test_claude_mcp.py` suite: 28 passed (+4 subtests)
- [x] Adapter regression: `tests/unit/adapters`, `tests/unit/test_copilot_adapter.py`, `tests/integration/test_claude_mcp_schema_fidelity.py`: 116 passed
- [x] Integration regression: `tests/unit/integration`, `tests/integration/test_agent_skills_target.py`: 1444 passed
- [x] Manual E2E: re-ran `apm install` in a `target: claude` project consuming `juspay/nix-chrome-devtools-mcp`; `.mcp.json` now points at the deployed launcher and `./.claude/skills/nix-chrome-devtools-mcp/bin/serve` boots successfully