### PR TITLE
[docs] Update documentation for features from 2026-05-24

### DIFF
--- a/docs/src/content/docs/consumer/install-mcp-servers.md
+++ b/docs/src/content/docs/consumer/install-mcp-servers.md
@@ -141,6 +141,16 @@ MCP defines two transport families. APM exposes both:
   and `file://` are rejected). Use `--header KEY=VALUE` (repeatable)
   for HTTP headers such as `Authorization`.
 
+### Docker-based registry servers and workspace variables
+
+Some registry-resolved MCP servers run inside Docker containers and
+declare `{workspaceFolder}` in their runtime arguments to mount your
+project into the container. APM substitutes the current project root
+for `{workspaceFolder}` when writing the runtime config, so Docker
+volume mounts like `-v {workspaceFolder}:/workspace` resolve correctly
+across all supported harnesses: Copilot CLI, Codex, Cursor, Claude,
+Gemini, Windsurf, and OpenCode. (#1461)
+
 `--transport` is inferred when omitted: a `--url` implies a remote
 transport, a post-`--` command implies `stdio`. The mutually-exclusive
 combinations (`--url` plus stdio command, `--header` without `--url`,


### PR DESCRIPTION
## Documentation Updates - 2026-05-24

This PR updates the documentation based on features merged in the last 24 hours.

### Features Documented

- Docker-based registry MCP servers now receive `{workspaceFolder}` variable substitution across all harnesses (from #1461)

### Changes Made

- Updated `docs/src/content/docs/consumer/install-mcp-servers.md` to add a subsection under "stdio vs HTTP servers" explaining that registry-resolved Docker-based MCP servers correctly substitute `{workspaceFolder}` in their runtime arguments across Copilot, Codex, Cursor, Claude, Gemini, Windsurf, and OpenCode.

### Merged PRs Referenced

- #1461 - fix: handle MCP v0.1 runtimeArguments.variables in copilot and codex adapters (also fixes Gemini, Cursor, Claude which inherit from CopilotClientAdapter)
- #1439 - perf: O(n^2) -> O(n) hook dedup fix and scaling guards CI wiring (internal, no doc update needed)
- #1462 - fix: DIFC triage-panel exemption for external issues (internal workflow, no doc update needed)

### Notes

PR #1439 and #1462 are internal fixes (performance and CI automation respectively) with no user-facing API or behavior changes that require documentation.




> Generated by [Daily Documentation Updater](https://github.com/microsoft/apm/actions/runs/26353556481/agentic_workflow) · ● 776.1K · [◷](https://github.com/search?q=repo%3Amicrosoft%2Fapm+%22gh-aw-workflow-id%3A+daily-doc-updater%22&type=pullrequests)
>
> To install this [agentic workflow](https://github.com/githubnext/agentics/blob/b87234850bf9664d198f28a02df0f937d0447295/workflows/daily-doc-updater.md), run
> ```
> gh aw add githubnext/agentics/workflows/daily-doc-updater.md@b87234850bf9664d198f28a02df0f937d0447295
> ```
> - [x] expires <!-- gh-aw-expires: 2026-05-26T06:08:29.597Z --> on May 26, 2026, 6:08 AM UTC

<!-- gh-aw-agentic-workflow: Daily Documentation Updater, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 26353556481, workflow_id: daily-doc-updater, run: https://github.com/microsoft/apm/actions/runs/26353556481 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: daily-doc-updater -->