### PR TITLE
feat(registry): [FEATURE] Add package registry support for dependency…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add experimental registry resolver and `apm-policy.yml` source-mandate enforcement. Git-based dependencies are unchanged. Enable with `apm experimental enable registries`; configure per-registry credentials via `apm config set registry.<name>.{url,token}`; mandate registry usage in `apm-policy.yml` via `registry_source: {require: [...], allow_non_registry: false}`. Framing: APM dependency governance — controlled sources, locked versions, and byte-level SHA-256 verification. Package signing, SBOM generation, and SLSA provenance are not included at v1.
+
 ### Fixed
 
 - `apm install` now re-resolves a dependency when its ref pin is changed in `apm.yml`; previously the locked commit always won, silently ignoring the edit -- by @sergio-sisternes-epam (#1473)

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -201,6 +201,8 @@ export default defineConfig({
 						{ label: 'Security and supply chain', slug: 'enterprise/security-and-supply-chain' },
 						{ label: 'Drift detection', slug: 'enterprise/drift-detection' },
 						{ label: 'Registry proxy and air-gapped', slug: 'enterprise/registry-proxy' },
+						{ label: 'Registries', slug: 'guides/registries' },
+						{ label: 'Private registries', slug: 'guides/private-registries' },
 						{ label: 'GitHub rulesets', slug: 'enterprise/github-rulesets' },
 					],
 				},

--- a/docs/src/content/docs/consumer/manage-dependencies.md
+++ b/docs/src/content/docs/consumer/manage-dependencies.md
@@ -63,21 +63,37 @@ parser. The supported forms:
 | SSH SCP-style | `git@gitlab.com:acme/repo.git` | SSH with default port. |
 | SSH protocol | `ssh://git@gitlab.com/acme/repo.git` | SSH with explicit scheme or port. |
 | Local path | `./packages/shared` or `/abs/path` | Sibling package on disk. |
-| Object form | `{ git: <url>, path: <subpath>, ref: <ref> }` | Escape hatch for nested groups, monorepo subpaths, or aliases that the string forms cannot express. |
+| Object form (git) | `{ git: <url>, path: <subpath>, ref: <ref> }` | Escape hatch for nested groups, monorepo subpaths, or aliases that the string forms cannot express. |
+| Registry shorthand | `owner/repo#^2.0.0` with a default registry configured | Routes dep through the default registry instead of git. Default may come from `apm.yml` or `~/.apm/config.json`. Requires `registries` experimental flag. |
+| Registry object form | `{ id: owner/repo, version: ^2.0.0 }` | Explicit registry dep. `registry:` optional when a default registry is configured. Requires `registries` experimental flag. |
 
 Object form in YAML:
 
 ```yaml
 dependencies:
   apm:
+    # Git dep with sub-path
     - git: https://gitlab.com/acme/coding-standards.git
       path: instructions/security
       ref: v2.0
       alias: security
+
+    # Registry dep (experimental) — whole package via default registry
+    - id: acme/code-review-prompts
+      version: ^2.0.0
+
+    # Registry dep — named registry, virtual sub-path
+    - registry: corp-main
+      id: acme/prompt-library
+      path: prompts/review.prompt.md
+      version: 1.4.0
 ```
 
 For private repos and non-GitHub hosts, see
 [Private and org packages](../private-and-org-packages/).
+
+For registry-sourced dependencies (internal packages on Artifactory or a custom registry), see
+[Private registries](../../guides/private-registries/).
 
 ## Add a dependency
 

--- a/docs/src/content/docs/enterprise/registry-proxy.md
+++ b/docs/src/content/docs/enterprise/registry-proxy.md
@@ -14,6 +14,22 @@ APM supports three layered controls for that:
 3. `apm marketplace add --host ...` to register internal marketplaces
    served from GHES, GHE.com, or GitLab self-managed.
 
+:::note[Not to be confused with **Registries**]
+The **registry proxy** documented here transparently fronts an upstream Git
+host (GitHub, GitLab) so dependency clones flow through your enterprise
+infrastructure. Configured per-machine via `PROXY_REGISTRY_*` env vars.
+
+A **dedicated registry** ([Registries guide](../../guides/registries/)) is a
+separate, additive package source that speaks the [Registry HTTP API](../../reference/registry-http-api/)
+directly — no Git host upstream. Configured per-project in `apm.yml` via the
+top-level `registries:` block, and currently requires `apm experimental enable registries`.
+
+Both can be used together; they're orthogonal.
+:::
+
+For the *policy-cache* offline story (a different mechanism), see
+[Governance #9](../governance-guide/#9-air-gapped-and-offline).
+
 For consumer-side token setup, see
 [Authentication](../../consumer/authentication/) and
 [Private and org packages](../../consumer/private-and-org-packages/).

--- a/docs/src/content/docs/enterprise/security.md
+++ b/docs/src/content/docs/enterprise/security.md
@@ -57,9 +57,23 @@ dependencies:
 
 The `resolved_commit` field is a full 40-character SHA, not a branch name or tag. Subsequent `apm install` calls resolve to the same commit unless the lock file is explicitly updated.
 
-### No registry
+### Registry security model
 
-APM does not use a package registry. Dependencies are specified as git repository URLs in `apm.yml`. This eliminates the registry compromise vector entirely — there is no centralized service that can be poisoned to redirect installs.
+By default, APM resolves dependencies as git repository URLs, eliminating the centralized-registry compromise vector.
+
+The experimental `registries` feature adds REST-based package sources. When enabled:
+
+- **Byte-level reproducibility.** `resolved_hash` in `apm.lock.yaml` is a SHA-256 digest of the downloaded archive. Re-installs verify bytes against the lockfile hash before writing to disk. A mismatch **fails closed** — the install aborts before any archive contents are extracted.
+- **Token containment.** Tokens for registry auth MUST NOT appear in repo-tracked YAML files. APM hard-fails if a `token:` key is found in `apm.yml` or `apm-policy.yml`. Tokens belong in `APM_REGISTRY_TOKEN_<NAME>` env vars or `~/.apm/config.json`.
+- **Policy enforcement.** The `registry_source` block in `apm-policy.yml` lets platform teams mandate specific registries and block non-registry sources. Checks apply transitively.
+
+**Known limitations:**
+
+- **No package signing.** The `resolved_hash` detects corruption and post-download tampering but does not verify publisher identity. Package signing is a planned hardening item.
+- **No SBOM or provenance attestations.** The lockfile records resolved version and hash, which is suitable for internal audit, but is not a standards-format SBOM (SPDX/CycloneDX) and does not include SLSA provenance.
+- **SHA-256 floor only.** The hash algorithm is fixed at SHA-256 with no upgrade path to SHA-384/512.
+
+Do not represent this feature as "supply-chain secure," "tamper-proof," "SLSA-compliant," or "signed" in compliance documentation or vendor assessments. The appropriate framing is **APM dependency governance**: controlled sources, locked versions, and byte-level verification.
 
 ### HTTP (insecure) dependencies
 
@@ -165,7 +179,7 @@ Content scanning detects hidden Unicode characters. It does not detect:
 
 ## Content integrity hashing
 
-APM computes a SHA-256 hash of each downloaded package's file tree and stores it in `apm.lock.yaml` as `content_hash`. On subsequent installs, cached packages are verified against the lockfile hash. A mismatch triggers a warning and re-download.
+APM computes a SHA-256 hash of each downloaded package's file tree and stores it in `apm.lock.yaml` as `content_hash`. On subsequent installs, cached packages under `apm_modules/` are verified against the lockfile hash. When the on-disk tree no longer matches, APM logs a warning and re-downloads. If freshly downloaded content still does not match the lockfile record, the install **aborts** (possible supply-chain tampering). Use `apm install --update` to accept new upstream content and refresh the lockfile.
 
 ```yaml
 # apm.lock.yaml
@@ -305,7 +319,7 @@ See [Azure DevOps AAD bearer tokens](#azure-devops-aad-bearer-tokens) above for 
 
 | Vector | Traditional package manager | APM |
 |---|---|---|
-| Registry compromise | Attacker poisons central registry | No registry exists |
+| Registry compromise | Attacker poisons central registry | No registry by default (git-direct). With experimental `registries`: `resolved_hash` detects tampered archives; token containment enforced; package signing not yet supported. |
 | Version substitution | Malicious version replaces legitimate one | Lock file pins exact commit SHA; content hash detects post-download tampering |
 | Post-install scripts | Arbitrary code runs after install | No code execution |
 | Typosquatting | Similar package names on registry | Dependencies are full git URLs |

--- a/docs/src/content/docs/getting-started/authentication.md
+++ b/docs/src/content/docs/getting-started/authentication.md
@@ -51,6 +51,8 @@ For Azure DevOps, APM resolves `ADO_APM_PAT`, then an Entra ID (AAD) bearer toke
 
 For Artifactory registry proxies, use `PROXY_REGISTRY_TOKEN`. See [Registry proxy (Artifactory)](#registry-proxy-artifactory).
 
+For dedicated APM registries (`registries:` block in `apm.yml`), use `APM_REGISTRY_TOKEN_{NAME}`. See [Registry tokens](#registry-tokens) below.
+
 For Copilot/runtime token variables (`GITHUB_COPILOT_PAT`, etc.), see [Agent Workflows](../../guides/agent-workflows/).
 
 ### Configuration variables
@@ -331,6 +333,34 @@ The following env vars still work but emit a `DeprecationWarning`. Migrate to th
 | `ARTIFACTORY_BASE_URL` | `PROXY_REGISTRY_URL` |
 | `ARTIFACTORY_APM_TOKEN` | `PROXY_REGISTRY_TOKEN` |
 | `ARTIFACTORY_ONLY` | `PROXY_REGISTRY_ONLY` |
+
+## Registry tokens
+
+Dedicated APM registries (declared in `apm.yml`, `~/.apm/config.json`, or both) use a dedicated env-var prefix that is **distinct** from `GITHUB_APM_PAT_*`, `PROXY_REGISTRY_*`, and `ARTIFACTORY_APM_TOKEN` — there is no collision with Git auth.
+
+Package registries are experimental. Run `apm experimental enable registries` before using these tokens with registry-sourced dependencies.
+
+| Env var | Auth method |
+|---|---|
+| `APM_REGISTRY_TOKEN_{NAME}` | `Authorization: Bearer <token>` |
+| `APM_REGISTRY_USER_{NAME}` + `APM_REGISTRY_PASS_{NAME}` | `Authorization: Basic <base64(user:pass)>` |
+
+`{NAME}` is the registry name, uppercased, with `-` and `.` mapped to `_` (e.g. `jf-skills` -> `JF_SKILLS`). When both forms are set, Bearer wins. When neither is set, APM tries the request anonymously and surfaces a remediation message on `401`/`403`.
+
+:::caution[Silent auth failures]
+A misspelled env var is indistinguishable from a missing token — APM attempts anonymous access and only reports auth failure from the server. Names `corp-main` and `corp.main` map to the same `APM_REGISTRY_TOKEN_CORP_MAIN`; do not register both. See [Registries guide — pitfalls](../../guides/registries/#pitfalls).
+:::
+
+Token precedence (highest wins): `APM_REGISTRY_TOKEN_{NAME}` env var → `registry.<name>.token` in `~/.apm/config.json`.
+
+```bash
+export APM_REGISTRY_TOKEN_JF_SKILLS=eyJ...
+# or persist locally:
+apm config set registry.jf-skills.token eyJ...
+apm install
+```
+
+For the full registry workflow — declaring registries, scoping dependencies, and lockfile semantics — see the [Registries guide](../../guides/registries/).
 
 ## Troubleshooting
 

--- a/docs/src/content/docs/guides/private-registries.md
+++ b/docs/src/content/docs/guides/private-registries.md
@@ -1,0 +1,331 @@
+---
+title: "Private Registries"
+description: "Configure REST-based APM package registries for internal packages. Covers enabling the feature, per-registry credentials, config.json defaults, apm.yml dependency shapes, and apm-policy.yml governance."
+sidebar:
+  order: 7
+---
+
+A **private registry** is a REST endpoint that implements the [Registry HTTP API](../../reference/registry-http-api/) and hosts packages your team controls. Typical deployments are Artifactory, JFrog Platform, or any custom service.
+
+This page is the end-to-end reference for the private-registry workflow: feature flag, credentials, `apm.yml` dependency shapes, and `apm-policy.yml` governance enforcement.
+
+For the general registry concept (public or private), see [Registries](../registries/) — start with [Try it now](../registries/#try-it-now) for a minimal install path. For the wire contract a registry server must implement, see [Registry HTTP API](../../reference/registry-http-api/).
+
+::::caution[Experimental — dependency governance feature]
+Package registries are behind an experimental flag. Nothing about your existing git-based dependencies changes when you enable it. The flag gates only the `registries:` block parsing, registry resolver, and `registry.*` config keys.
+
+```bash
+apm experimental enable registries
+```
+::::
+
+---
+
+## 1. Enable the feature
+
+```bash
+apm experimental enable registries
+```
+
+Verify:
+
+```bash
+apm experimental list
+# registries    enabled
+```
+
+Revert at any time:
+
+```bash
+apm experimental reset registries
+```
+
+---
+
+## 2. Declare registries
+
+Registry names and URLs can be declared in the project manifest, in user config, or both. APM merges them at install time.
+
+### Option A — team-shared URLs in `apm.yml`
+
+Add a top-level `registries:` block:
+
+```yaml
+name: my-project
+version: 1.0.0
+
+registries:
+  corp-main:
+    url: https://artifactory.corp.example.com/artifactory/api/apm/corp-main-local
+  corp-snapshots:
+    url: https://artifactory.corp.example.com/artifactory/api/apm/corp-snapshots-local
+  default: corp-main   # optional — routes unscoped deps to this registry
+```
+
+Rules:
+- Registry names use lowercase letters, digits, `-`, and `.`.
+- `url:` MUST start with `https://` (or `http://` for local dev).
+- Credentials MUST NOT appear here. Store them outside `apm.yml` (see §3).
+- Unknown keys under a registry entry are rejected at parse time (typo guard).
+- `default:` MUST name one of the configured entries.
+
+### Option B — workstation-only setup in `~/.apm/config.json`
+
+When every developer points at the same private registry, configure URL, token, and default locally and keep `apm.yml` free of a `registries:` block:
+
+```bash
+apm experimental enable registries
+apm config set registry.corp-main.url \
+  https://artifactory.corp.example.com/artifactory/api/apm/corp-main-local
+apm config set registry.corp-main.token eyJ...
+apm config set registry.corp-main.default true
+```
+
+```yaml
+# apm.yml — dependencies only; no registries: block
+name: my-project
+version: 1.0.0
+
+dependencies:
+  apm:
+    - acme/code-review-prompts#^2.0.0
+```
+
+Only one registry may be default at a time. Project `registries.default` in `apm.yml` wins over `registry.<name>.default` in `config.json` when both are set.
+
+---
+
+## 3. Configure credentials
+
+### Environment variables (CI / short-lived)
+
+```bash
+# Bearer token (preferred for JFrog / Artifactory)
+export APM_REGISTRY_TOKEN_CORP_MAIN=eyJ...
+
+# HTTP Basic (some enterprise registries)
+export APM_REGISTRY_USER_CORP_MAIN=alice@corp.example.com
+export APM_REGISTRY_PASS_CORP_MAIN=secret
+```
+
+The env-var name is derived from the registry name: uppercase, `-` and `.` → `_`.
+
+| Registry name | Env var |
+|---|---|
+| `corp-main` | `APM_REGISTRY_TOKEN_CORP_MAIN` |
+| `corp.snapshots` | `APM_REGISTRY_TOKEN_CORP_SNAPSHOTS` |
+
+Bearer wins when both forms are set.
+
+### `~/.apm/config.json` (developer workstations)
+
+Use `apm config set` to store credentials locally without env vars:
+
+```bash
+# Requires: apm experimental enable registries
+
+apm config set registry.corp-main.url \
+  https://artifactory.corp.example.com/artifactory/api/apm/corp-main-local
+
+apm config set registry.corp-main.token eyJ...
+apm config set registry.corp-main.default true
+
+# Inspect
+apm config get registry.corp-main.url
+apm config get registry.corp-main.token
+apm config get registry.corp-main.default
+
+# Remove
+apm config unset registry.corp-main.token
+apm config unset registry.corp-main.url
+apm config unset registry.corp-main.default
+```
+
+Credentials stored in `~/.apm/config.json` are **user-scoped** and never committed to a repository. Token precedence (highest wins): `APM_REGISTRY_TOKEN_<NAME>` env var → `~/.apm/config.json`.
+
+### Precedence chain (full)
+
+From highest to lowest:
+
+1. `APM_REGISTRY_TOKEN_<NAME>` / `APM_REGISTRY_USER_<NAME>` + `APM_REGISTRY_PASS_<NAME>` (env vars)
+2. `registry.<name>.token` in `~/.apm/config.json`
+3. Unauthenticated (APM surfaces a remediation hint on 401/403)
+
+Registry URL precedence (highest to lowest): `apm-policy.yml` → project `apm.yml` → workspace `~/.apm/apm.yml` → `~/.apm/config.json`.
+
+Default registry precedence (highest to lowest): project `apm.yml` `registries.default` → `registry.<name>.default true` in `~/.apm/config.json`.
+
+---
+
+## 4. Declare registry dependencies
+
+### String shorthand (requires a default registry)
+
+When a default registry is configured — in `apm.yml` or `~/.apm/config.json` — shorthand entries with a `#<ref>` route through it automatically:
+
+```yaml
+dependencies:
+  apm:
+    - acme/code-review-prompts#^2.0.0    # → corp-main (default)
+    - acme/security-baseline#~1.4.0      # → corp-main (default)
+    - acme/git-server#main               # still routed to default registry when active
+```
+
+### Object form — whole package
+
+```yaml
+dependencies:
+  apm:
+    # Explicit registry
+    - registry: corp-main
+      id: acme/code-review-prompts
+      version: ^2.0.0
+
+    # Default registry (registry: omitted; a default must be configured)
+    - id: acme/security-baseline
+      version: ~1.4.0
+```
+
+### Object form — virtual package (sub-path)
+
+```yaml
+dependencies:
+  apm:
+    - registry: corp-main
+      id: acme/prompt-library
+      path: prompts/code-review.prompt.md
+      version: 1.4.0
+      alias: code-review
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `id` | yes | Package identity at the registry: `owner/repo`. |
+| `version` | yes | Semver range (`^1.0.0`, `~1.2.3`, `>=1.2.0 <2.0.0`) or exact selector. |
+| `registry` | no | Name from the merged registry map. Defaults to the effective default registry when omitted. |
+| `path` | no | Virtual sub-path inside the package. Omit to install the whole package. |
+| `alias` | no | Local alias (controls install directory name). |
+
+### Version selectors
+
+Registry-routed entries must include a version selector (`#<ref>` on shorthand entries, or `version:` on object entries). Use `- git:` to keep a dependency on Git when a default registry is active.
+
+| Selector | Behavior |
+|---|---|
+| `^1.0.0`, `~1.2.3`, `>=1.0.0 <2.0.0` | Semver range — APM picks the highest matching registry version. |
+| `1.4.0` | Exact semver version. |
+
+---
+
+## 5. Governance with `apm-policy.yml`
+
+Platform teams can mandate registry usage and block non-registry sources organization-wide.
+
+### Mandate registry usage
+
+Require that specific registries be reachable. APM **fails-closed** if a listed registry has no URL in the merged registry map — from project `apm.yml`, workspace `~/.apm/apm.yml`, or `~/.apm/config.json`:
+
+```yaml
+# .github/apm-policy.yml
+registry_source:
+  require:
+    - corp-main
+```
+
+### Block non-registry sources
+
+Refuse installation of any dependency not routed through a configured registry:
+
+```yaml
+registry_source:
+  require:
+    - corp-main
+  allow_non_registry: false
+```
+
+With `allow_non_registry: false`, git-sourced dependencies (including shorthand `owner/repo` entries without a semver range) are blocked at install time.
+
+### Policy fields
+
+| Field | Default | Description |
+|---|---|---|
+| `require` | `[]` | Registry names that MUST be reachable. Fail-closed if missing from the merged registry map. |
+| `allow_non_registry` | `true` | When `false`, blocks any dep not routed through a configured registry. |
+
+Policy checks apply to direct and transitive dependencies.
+
+---
+
+## 6. Known limitations and threat model
+
+### What this provides
+
+- **Byte-level reproducibility.** `resolved_hash` in `apm.lock.yaml` pins the SHA-256 of the downloaded archive. Re-installs verify bytes against the lockfile hash before writing to disk; a mismatch aborts the install.
+- **Token containment.** Tokens stored in `~/.apm/config.json` are user-scoped and never committed to a repository.
+- **Policy enforcement.** `registry_source` in `apm-policy.yml` allows platform teams to mandate and restrict dependency sources across the org.
+
+### What this does not yet provide
+
+- **Package signing.** Registry packages are not cryptographically signed. The `resolved_hash` detects corruption or tampering after download, but does not verify publisher identity.
+- **SBOM generation.** APM does not produce SLSA provenance attestations or SPDX/CycloneDX bills of materials from registry packages. The lockfile (`apm.lock.yaml`) records the resolved version and hash and is suitable for internal audit, but is not a standards-format SBOM.
+- **SHA-256 algorithm agility.** The hash floor is SHA-256. No upgrade path to SHA-384/512 is currently implemented.
+
+Do not represent this feature as "supply-chain secure," "tamper-proof," or "SLSA-compliant" in compliance documentation or vendor assessments.
+
+---
+
+## 7. Full example
+
+```yaml
+# apm.yml
+name: my-project
+version: 1.0.0
+
+registries:
+  corp-main:
+    url: https://artifactory.corp.example.com/artifactory/api/apm/corp-main-local
+  default: corp-main
+
+dependencies:
+  apm:
+    # String shorthand → corp-main (semver range triggers routing)
+    - acme/code-review-prompts#^2.0.0
+
+    # Object form, whole package, explicit registry
+    - registry: corp-main
+      id: acme/security-baseline
+      version: ~1.4.0
+
+    # Object form, virtual package
+    - registry: corp-main
+      id: acme/prompt-library
+      path: prompts/code-review.prompt.md
+      version: 1.4.0
+```
+
+```yaml
+# .github/apm-policy.yml
+registry_source:
+  require:
+    - corp-main
+  allow_non_registry: false
+```
+
+```bash
+# Developer workstation setup (Option B — config-only registry)
+apm experimental enable registries
+apm config set registry.corp-main.url https://artifactory.corp.example.com/artifactory/api/apm/corp-main-local
+apm config set registry.corp-main.token "$(cat ~/.corp-apm-token)"
+apm config set registry.corp-main.default true
+apm install
+```
+
+---
+
+## See also
+
+- [Registries](../registries/) — general registry concept and authentication reference.
+- [Registry HTTP API](../../reference/registry-http-api/) — wire contract for registry servers.
+- [apm config](../../reference/cli/config/) — full config key reference.
+- [Policy schema](../../reference/policy-schema/#registry_source) — `registry_source` field reference.
+- [Security model](../../enterprise/security/) — threat model and known limitations.

--- a/docs/src/content/docs/guides/registries.md
+++ b/docs/src/content/docs/guides/registries.md
@@ -1,0 +1,398 @@
+---
+title: "Registries"
+description: "Declare REST-based APM registries in apm.yml or ~/.apm/config.json and consume packages from them alongside Git-hosted dependencies."
+sidebar:
+  order: 6
+---
+
+A **registry** is a REST-based source for APM packages. Any service that implements the [Registry HTTP API](../../reference/registry-http-api/) qualifies. Registries sit alongside the existing Git resolver: declare registry names and URLs in `apm.yml`, in `~/.apm/config.json`, or both, then route individual dependencies to a registry by name or through a default. Registries are strictly additive — when the experimental flag is off, or when no default registry is configured at any layer, every existing dependency form continues to resolve through Git exactly as before.
+
+::::caution[Experimental]
+Package registries are currently behind an experimental flag. Enable them before adding `registries:` or registry-sourced dependencies:
+
+```bash
+apm experimental enable registries
+```
+::::
+
+## Compatible backends
+
+| Backend | Status | Notes |
+|---|---|---|
+| Any server implementing the [Registry HTTP API](../../reference/registry-http-api/) | Supported | Base URL like `https://registry.example.com/api/<name>`; must expose §3 endpoints and §6 publish validation |
+| GitHub / Git remotes | Not a registry | Default resolver; use `- git:` when a default registry is active |
+| APM marketplace | Different surface | Git-hosted index via `apm pack` — not `apm publish` |
+
+## Try it now
+
+Install a package that is already on your registry. Replace the URL, token, and dependency with yours.
+
+```bash
+apm experimental enable registries
+apm config set registry.corp.url https://registry.example.com/api/my-team
+apm config set registry.corp.token "$YOUR_TOKEN"
+apm config set registry.corp.default true
+
+mkdir registry-demo && cd registry-demo
+cat > apm.yml <<'EOF'
+name: registry-demo
+version: 1.0.0
+dependencies:
+  apm:
+    - acme/internal-tools#^1.0.0
+EOF
+
+apm install
+```
+
+On success, `apm.lock` records `source: registry` and `resolved_hash`. A `404` usually means the package is not published or the `owner/repo` is wrong; `401`/`403` usually means the token is missing — registry name `corp` maps to `APM_REGISTRY_TOKEN_CORP`. See [Pitfalls](#pitfalls) for env-var typos and default-routing surprises.
+
+## Declare a registry
+
+### Project manifest (`apm.yml`)
+
+Add a top-level `registries:` block when the team shares registry URLs in-repo:
+
+```yaml
+registries:
+  jf-skills:
+    url: https://registry.example.com/apm/jf-skills
+  default: jf-skills
+```
+
+Each entry is a name mapped to a base URL. The optional `default:` key names one of the configured entries; when set, plain string-shorthand APM dependencies route through it (see [Default routing](#default-routing) below). Registry URLs MUST start with `https://` (or `http://` for local development).
+
+The registry name is used for env-var auth lookup. Use lowercase letters, digits, `-`, and `.`.
+
+### User-level default (`~/.apm/config.json`)
+
+For developer workstations, you can configure URL, token, and default entirely in user config and omit `registries:` from `apm.yml`:
+
+```bash
+apm experimental enable registries
+apm config set registry.jf-skills.url https://registry.example.com/apm/jf-skills
+apm config set registry.jf-skills.token eyJ...
+apm config set registry.jf-skills.default true
+```
+
+Only one registry may be default at a time. Setting `registry.<name>.default true` clears any previous default. Project `registries.default` in `apm.yml` wins when both are set.
+
+## Reference a registry-sourced dependency
+
+There are two ways to point a dependency at a registry.
+
+### 1. String shorthand routed through the default
+
+When a default registry is configured — via `registries.default` in `apm.yml` or `registry.<name>.default true` in `~/.apm/config.json` — plain `owner/repo` shorthand entries route through that registry. The same syntax already used for GitHub dependencies, but now resolved over HTTP:
+
+```yaml
+registries:
+  jf-skills:
+    url: https://registry.example.com/apm/jf-skills
+  default: jf-skills
+
+dependencies:
+  apm:
+    - acme/foo#^1.2.3        # semver range → resolved via jf-skills
+    - acme/bar#stable        # any ref, including opaque labels → resolved via jf-skills
+```
+
+Routing is unconditional: every still-unrouted shorthand entry with a `#<ref>` is sent through the default registry, regardless of what the ref looks like. Object-form entries (`- git:`, `- path:`, `- id:`) are left alone.
+
+### 2. Object form
+
+Use the object form for explicit per-dep registry routing, or to install a **virtual package** (a single file or sub-directory inside a published package):
+
+```yaml
+dependencies:
+  apm:
+    # Whole package via the default registry
+    - id: acme/toolkit
+      version: ^2.0.0
+
+    # Whole package routed to a specific registry
+    - registry: jf-skills
+      id: acme/toolkit
+      version: ^2.0.0
+
+    # Virtual package — one file from inside a published package
+    - registry: jf-skills
+      id: acme/prompt-pack
+      path: prompts/review.prompt.md
+      version: 1.4.0
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `id` | yes | Package identity at the registry, in `owner/repo` form. |
+| `version` | yes | Exact version or semver range. |
+| `registry` | no | Name from the merged registry map. Defaults to the effective default registry when omitted. |
+| `path` | no | Sub-path to a file or directory within the published package. Omit to install the whole package. |
+| `alias` | no | Local alias (controls install directory name). |
+
+## Version selectors
+
+Registry-routed entries must specify a version selector — the registry uses it
+to look up or range-match against the versions it has published. Version strings
+are opaque to APM; the registry decides what they mean. Semver ranges are
+supported when the registry publishes semver-tagged versions:
+
+| Selector | Behavior |
+|---|---|
+| `1.0.0`, `v1.4.2` | Exact version string — matched literally against the registry catalogue |
+| `^1.0.0`, `~1.2.3`, `>=1.2.0 <2.0.0` | Semver range — APM picks the highest matching version |
+| `stable`, `latest` | Opaque label — matched literally; server decides what it resolves to |
+| unset (no `#<ref>`) | Rejected — a version is always required for registry-routed dependencies |
+
+```yaml
+dependencies:
+  apm:
+    - acme/foo#^1.2.3                        # semver range → registry
+    - acme/bar#stable                        # opaque label → registry
+    - acme/baz#v2.0.0                        # v-prefixed → registry
+    - git: https://github.com/acme/qux.git   # explicit Git pin
+      ref: main
+```
+
+Registry-routed deps are byte-for-byte reproducible via `resolved_hash`;
+Git-routed deps are SHA-reproducible via `resolved_commit`.
+
+## Default routing
+
+When a default registry is configured at any layer, all string-shorthand entries route to the
+registry — regardless of what the ref looks like. Use the explicit `- git:`
+object form to keep a dependency on Git when a default registry is active:
+
+:::caution[Behavior change — not a warning at install time]
+There is no one-time migration prompt. Existing Git shorthand deps begin routing to the registry as soon as a default is configured. Plan the audit before enabling the default; see [Pitfalls — default registry rerouting](#default-registry-silently-reroutes-git-shorthand) and [Migration paths](../../troubleshooting/migration/#6-default-registry-adoption-git--registry-routing).
+:::
+
+**Default precedence (highest wins):** project `apm.yml` `registries.default` → `registry.<name>.default true` in `~/.apm/config.json`.
+
+| Entry form | Routed to |
+|---|---|
+| `owner/repo#<any-ref>` | Default registry |
+| `- id:` object form (no `registry:`) | Default registry |
+| `- registry:` object form (with `registry:`) | Named registry |
+| `- git:` object form | Git (always — explicit override) |
+| `- path:` object form | Local filesystem (unchanged) |
+
+A shorthand entry without any ref (`acme/foo`) is always rejected — a version
+selector is required for registry-routed dependencies.
+
+## Authentication
+
+APM reads credentials from environment variables named after the registry. `{NAME}` is the registry name uppercased, with `-` and `.` mapped to `_`.
+
+| Env var | Auth method |
+|---|---|
+| `APM_REGISTRY_TOKEN_{NAME}` | `Authorization: Bearer <token>` |
+| `APM_REGISTRY_USER_{NAME}` + `APM_REGISTRY_PASS_{NAME}` | `Authorization: Basic <base64(user:pass)>` |
+
+Bearer wins when both forms are set. When neither is set, APM tries the request anonymously and surfaces a remediation pointing at `APM_REGISTRY_TOKEN_<NAME>` on `401`/`403`.
+
+```bash
+# Registry name "jf-skills" -> APM_REGISTRY_TOKEN_JF_SKILLS
+export APM_REGISTRY_TOKEN_JF_SKILLS=eyJ...
+
+# Or HTTP Basic for enterprise registries that issue username/password
+export APM_REGISTRY_USER_JF_SKILLS=alice@example.com
+export APM_REGISTRY_PASS_JF_SKILLS=...
+```
+
+The `APM_REGISTRY_*` prefix is distinct from `GITHUB_APM_PAT_*`, `PROXY_REGISTRY_*`, and `ARTIFACTORY_APM_TOKEN` — there is no collision. For the broader auth model, see [Authentication](../../getting-started/authentication/).
+
+## What gets recorded in the lockfile
+
+Registry-sourced dependencies add four fields to their lockfile entry: `source: registry`, `version`, `resolved_url`, and `resolved_hash` (sha256 of the archive bytes). The lockfile bumps to `lockfile_version: "2"` opportunistically — only when at least one registry dep is present. Projects that never opt into a registry keep `lockfile_version: "1"` forever, even on a newer client.
+
+```yaml
+dependencies:
+  - repo_url: acme/foo
+    source: registry
+    version: "1.4.0"
+    resolved_url: https://registry.example.com/apm/jf-skills/v1/packages/acme/foo/versions/1.4.0/download
+    resolved_hash: "sha256:abc123..."
+    depth: 1
+    package_type: apm_package
+    deployed_files:
+      - .github/skills/foo/SKILL.md
+```
+
+`resolved_url` is the trust anchor for re-installs — APM re-fetches from the URL stored in the lockfile, not from the registry name, and re-verifies bytes against `resolved_hash`. A hash mismatch aborts the install before extraction. See [Lockfile spec](../../reference/lockfile-spec/) for full field semantics.
+
+## End to end: publish and install
+
+```bash
+# Producer — package root with apm.yml, .apm/, and a registries: block
+apm publish --dry-run -v
+apm publish
+
+# Consumer — another repo (or registry-demo above)
+apm install acme/internal-tools#^1.0.0
+```
+
+That is the loop. [`apm publish`](../../reference/cli/publish/) reads `apm.yml`, builds a **flat registry archive** (`.tar.gz` with `apm.yml` and `.apm/` at the tarball root), and uploads via `PUT /v1/packages/{owner}/{repo}/versions/{version}`. Consumers with a default registry configured install with the same `owner/repo#version` shorthand they would use for GitHub.
+
+Registry archives use the **APM source layout** that `apm install` and the [Registry HTTP API §6](../../reference/registry-http-api/#6-server-validation-rules-publish) expect — not the plugin bundle wrapper from `apm pack --archive` (`{name}-{version}/plugin.json`). If you already ship marketplace plugin bundles, either repack as a flat archive or pass `--tarball`.
+
+**Auto-pack requirements:**
+
+- `apm.yml` with `name:` and `version:` (and `source:` when the registry identity differs from the package name)
+- A `.apm/` directory with your primitives (skills, instructions, hooks, etc.)
+
+Auto-pack writes `{name}-{version}.tar.gz` in the project root and skips macOS `._*` / `.DS_Store` sidecars.
+
+**Skill-only or custom layouts** — build the tarball yourself and pass `--tarball`:
+
+```bash
+tar czf my-skill-0.0.1.tar.gz apm.yml SKILL.md
+apm publish --tarball my-skill-0.0.1.tar.gz
+```
+
+Some registries accept archives without validating `apm.yml` on upload; APM still validates on install. Prefer a valid flat layout at publish time.
+
+```bash
+# Auto-pack flat archive and publish to the only configured registry
+apm publish
+
+# Choose a registry when multiple are configured
+apm publish --registry corp-main
+
+# Publish a pre-built flat tarball (skip auto-pack)
+apm publish --tarball ./build/my-package-1.0.0.tar.gz
+
+# Preview what would be uploaded without uploading
+apm publish --dry-run
+```
+
+| Option | Description |
+|---|---|
+| `--registry NAME` | Registry name from the `registries:` block. Required when multiple registries are configured. |
+| `--package OWNER/REPO` | Override owner/repo identity (default: parsed from `source:` in `apm.yml`). |
+| `--tarball PATH` | Path to a pre-built flat `.tar.gz` tarball. Skips auto-pack. |
+| `--dry-run` | Preview without uploading. |
+| `--verbose` / `-v` | Show detailed output. |
+
+`apm.yml` must declare a `version:` field. Publishing the same version twice returns `409 Conflict` — bump the version to publish again.
+
+:::note[`apm pack` vs `apm publish`]
+[`apm pack`](../../reference/cli/pack/) produces distributable **plugin bundles** (and marketplace artifacts) for Git/marketplace flows. [`apm publish`](../../reference/cli/publish/) produces **flat registry archives** for REST registries. The two commands serve different distribution surfaces.
+:::
+
+## Planned features
+
+:::note[Planned]
+The following are deferred to a later milestone and not yet implemented:
+
+- **Yank** — marking a published version unavailable.
+- **Signature verification** — cryptographic signing of registry-published packages.
+:::
+
+## User-level config
+
+Registry URLs can live in `apm.yml` (committed, shared with your team), in `~/.apm/config.json` (user-scoped), or both — APM merges them at install time. Tokens are per-user and must never be committed:
+
+```bash
+# Store URL, token, and default for a workstation-only setup
+apm config set registry.jf-skills.url https://registry.example.com/apm/jf-skills
+apm config set registry.jf-skills.token eyJ...
+apm config set registry.jf-skills.default true
+
+# Or store only the token when the URL is already in apm.yml
+apm config set registry.jf-skills.token eyJ...
+
+# Read back
+apm config get registry.jf-skills.token
+apm config get registry.jf-skills.default
+
+# Remove
+apm config unset registry.jf-skills.token
+apm config unset registry.jf-skills.default
+```
+
+Token precedence (highest wins): `APM_REGISTRY_TOKEN_<NAME>` env var → `~/.apm/config.json`.
+
+URL precedence (highest wins): `apm-policy.yml` → project `apm.yml` → workspace `~/.apm/apm.yml` → `~/.apm/config.json`.
+
+`apm config set registry.<name>.url` is also useful for workspace-level URL overrides (e.g. redirecting a registry to a staging server, or reinstalling from a lockfile when the project removed its `registries:` block). For normal team use, the URL usually lives in `apm.yml`; for single-machine private-registry workflows, URL + default in `config.json` lets `apm.yml` list only dependencies.
+
+:::caution
+Never put credentials in `apm.yml` or `apm-policy.yml`. Use `APM_REGISTRY_TOKEN_<NAME>` env vars or `apm config set registry.<name>.token` instead.
+:::
+
+These commands are gated behind `apm experimental enable registries`.
+
+## Policy governance
+
+Org admins can mandate registry usage via `apm-policy.yml`:
+
+```yaml
+registry_source:
+  require:
+    - jf-skills          # every dep must be reachable via this registry
+  allow_non_registry: false   # block any dep not routed through a registry
+```
+
+| Field | Default | Description |
+|---|---|---|
+| `require` | `[]` | Registry names that MUST be reachable. APM fails-closed if a listed registry has no URL in the merged registry map (from `apm.yml`, `~/.apm/apm.yml`, or `~/.apm/config.json`). |
+| `allow_non_registry` | `true` | When `false`, APM blocks installation of any dependency not routed through a configured registry. |
+
+The policy check applies transitively — transitive deps pulled in by registry packages are also validated.
+
+## Pitfalls
+
+### Misspelled env vars look like auth failures
+
+When no registry token is found, APM sends the request **anonymously** first and only prints credential remediation on `401`/`403`. A typo in the env var name (for example `APM_REGISTRY_TOKEN_JF_SKILL` instead of `APM_REGISTRY_TOKEN_JF_SKILLS`) is treated the same as a missing token — you get a generic auth error, not “unknown env var.”
+
+Verify the exact variable name:
+
+```bash
+# Registry name jf-skills -> APM_REGISTRY_TOKEN_JF_SKILLS
+echo "$APM_REGISTRY_TOKEN_JF_SKILLS" | wc -c   # should be > 1
+apm config get registry.jf-skills.token        # config.json fallback
+```
+
+Use `apm config set registry.<name>.token` when debugging locally so a missing export does not masquerade as a server-side permission problem.
+
+### Default registry silently reroutes Git shorthand
+
+Enabling a default registry (`registries.default` or `registry.<name>.default true`) routes **every** `owner/repo#ref` shorthand to the registry — including deps that previously installed from GitHub. There is no migration warning on `apm install`; the first signal is often a registry 404 (“no versions”) instead of a git clone.
+
+**Before turning on a default registry:**
+
+1. Audit `apm.yml` (and transitive packages) for shorthand deps that must stay on Git.
+2. Pin those entries explicitly:
+
+   ```yaml
+   dependencies:
+     apm:
+       - git: https://github.com/microsoft/apm-sample-package.git
+         ref: v1.0.0
+   ```
+
+3. Run `apm install --dry-run` or a trial install in a branch and confirm lockfile `source:` fields.
+
+See [Migration paths — default registry adoption](../../troubleshooting/migration/#6-default-registry-adoption-git--registry-routing).
+
+### Registry names that sanitize to the same env var
+
+Env var names derive from the registry name by uppercasing and mapping `-` and `.` to `_`. Distinct registry names can collapse to the **same** env var:
+
+| Registry names in `apm.yml` | Shared env var |
+|---|---|
+| `corp-main` | `APM_REGISTRY_TOKEN_CORP_MAIN` |
+| `corp.main` | `APM_REGISTRY_TOKEN_CORP_MAIN` |
+| `Corp-Main` | `APM_REGISTRY_TOKEN_CORP_MAIN` |
+
+Do not configure two different registries whose names sanitize identically — they would share one token slot. Prefer hyphenated names (`corp-main`) and avoid dots in registry names when multiple registries coexist.
+
+## See also
+
+- [Manifest schema](../../reference/manifest-schema/) — formal grammar for the `registries:` block and `- id:` object form.
+- [Lockfile spec](../../reference/lockfile-spec/) — lockfile schema and registry-specific fields.
+- [Authentication](../../getting-started/authentication/) — full token-resolution chain.
+
+If you operate a registry server, see the [Registry HTTP API](../../reference/registry-http-api/) for the full wire contract.

--- a/docs/src/content/docs/reference/cli/config.md
+++ b/docs/src/content/docs/reference/cli/config.md
@@ -45,7 +45,7 @@ Write `KEY` to `~/.apm/config.json`. Validates the value before writing:
 
 ### `apm config unset KEY`
 
-Remove `KEY` from `~/.apm/config.json`. No-op if the key is not set. Only `temp-dir` and `copilot-cowork-skills-dir` are unsettable; boolean keys are reset by `set`-ing them to their default.
+Remove `KEY` from `~/.apm/config.json`. No-op if the key is not set. Supported unset keys: `temp-dir`, `copilot-cowork-skills-dir`, and `registry.<name>.{url,token,default}`. Other boolean keys are reset by `set`-ing them to their default.
 
 ## Configuration keys
 
@@ -54,6 +54,9 @@ Remove `KEY` from `~/.apm/config.json`. No-op if the key is not set. Only `temp-
 | `auto-integrate` | boolean | `true` | Auto-discover `.prompt.md` files under `.github/prompts/` and `.apm/prompts/` and merge them into compiled `AGENTS.md` output. |
 | `temp-dir` | path | system temp | Directory used for clone and download operations. Useful when the OS temp directory is locked down (for example, corporate Windows endpoints rejecting `%TEMP%` with `[WinError 5]`). |
 | `copilot-cowork-skills-dir` | absolute path | auto-detected | Override the resolved Cowork OneDrive skills directory. Requires the `copilot-cowork` experimental flag for `set`. |
+| `registry.<name>.url` | URL | — | Base URL for registry `<name>`. Requires `registries` experimental flag. |
+| `registry.<name>.token` | string | — | Bearer token for registry `<name>`. Stored in `~/.apm/config.json`; never in repo-tracked files. Requires `registries` experimental flag. |
+| `registry.<name>.default` | boolean | `false` | Mark `<name>` as the user-scoped default registry. Only one registry may be default at a time; setting `true` clears any previous default. Requires `registries` experimental flag. |
 
 ### Resolution order
 
@@ -62,6 +65,24 @@ Remove `KEY` from `~/.apm/config.json`. No-op if the key is not set. Only `temp-
 1. Environment variable (`APM_TEMP_DIR`, `APM_COPILOT_COWORK_SKILLS_DIR`)
 2. Value in `~/.apm/config.json`
 3. Built-in default (system temp / platform auto-detection)
+
+Registry tokens are resolved as:
+
+1. `APM_REGISTRY_TOKEN_<NAME>` environment variable (uppercase name, `-`/`.` → `_`)
+2. `registry.<name>.token` in `~/.apm/config.json`
+3. Unauthenticated (APM surfaces a remediation hint on 401/403)
+
+Registry URLs are merged at install time (highest wins):
+
+1. `apm-policy.yml`
+2. Project `apm.yml` `registries:` block
+3. Workspace `~/.apm/apm.yml`
+4. `registry.<name>.url` in `~/.apm/config.json`
+
+Default registry selection (highest wins):
+
+1. `registries.default` in project `apm.yml`
+2. The registry entry in `~/.apm/config.json` with `"default": true` (set via `registry.<name>.default true`)
 
 ## Examples
 
@@ -100,6 +121,20 @@ apm config set copilot-cowork-skills-dir ~/Library/CloudStorage/OneDrive-Contoso
 apm config unset copilot-cowork-skills-dir
 ```
 
+Configure a private registry (experimental):
+
+```bash
+apm experimental enable registries
+apm config set registry.corp-main.url https://artifactory.corp.example.com/artifactory/api/apm/corp-main-local
+apm config set registry.corp-main.token eyJ...
+apm config set registry.corp-main.default true
+apm config get registry.corp-main.url
+apm config get registry.corp-main.default
+apm config unset registry.corp-main.token
+```
+
+With URL, token, and default set in `config.json`, a project can omit the top-level `registries:` block from `apm.yml` and still route shorthand deps through `corp-main`. See [Private registries](../../../guides/private-registries/).
+
 ## Configuration file
 
 - **Location:** `~/.apm/config.json`
@@ -112,4 +147,5 @@ Internal JSON keys use snake_case (`auto_integrate`, `temp_dir`, `copilot_cowork
 
 - [`apm install`](../install/) -- consumes `temp-dir` for clone/download work.
 - [`apm compile`](../compile/) -- affected by `auto-integrate`.
-- [`apm experimental`](../experimental/) -- gates `copilot-cowork-skills-dir`.
+- [`apm experimental`](../experimental/) -- gates `copilot-cowork-skills-dir` and `registry.*` keys.
+- [Private registries](../../../guides/private-registries/) -- full private registry setup guide.

--- a/docs/src/content/docs/reference/cli/install.md
+++ b/docs/src/content/docs/reference/cli/install.md
@@ -180,11 +180,48 @@ apm install owner/skill-bundle --skill '*'   # reset to all skills
 - **Claude target prompt rewrite.** When deploying to `.claude/commands/`, prompt files with an `input:` front-matter key are rewritten to Claude's `arguments:` shape and `${input:name}` placeholders become `$name`. Argument names must match `^[A-Za-z][\w-]{0,63}$`; rejected names are dropped with a warning.
 - **Copilot CLI env-var passthrough.** When deploying MCP entries to `~/.copilot/mcp-config.json`, `${env:VAR}` and `<VAR>` placeholders are translated to `${VAR}` so Copilot CLI resolves them at server-start. Plaintext secrets are never written to disk. Other targets currently resolve placeholders at install time.
 
+### Install from a private registry (experimental)
+
+Enable the feature, configure the registry (in `apm.yml` and/or `~/.apm/config.json`), and run install normally. APM resolves registry-sourced deps alongside git deps:
+
+```bash
+apm experimental enable registries
+
+# Option A: apm.yml has a registries: block and registry-routed deps
+apm install
+
+# Option B: workstation config only (no registries: block in apm.yml)
+apm config set registry.corp-main.url https://artifactory.corp.example.com/apm
+apm config set registry.corp-main.token eyJ...
+apm config set registry.corp-main.default true
+apm install
+
+# In CI: use env var for the token, never commit it
+APM_REGISTRY_TOKEN_CORP_MAIN=eyJ... apm install --frozen
+```
+
+See [Private registries](../../../guides/private-registries/) for the full setup guide.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Success. All requested dependencies and local content deployed. |
+| `1` | Install failure: security scan blocked a critical finding, auth error, manifest write error, dependency resolution error, `--frozen` with a missing lockfile or a direct dependency absent from `apm.lock.yaml`, or unhandled exception. The diagnostic summary names the cause. |
+| `2` | Usage error: no deployment target detectable (no `--target`, no `targets:` in `apm.yml`, no harness signal in the project), `--ssh` and `--https` both passed, `--frozen` and `--update` both passed, or a Click flag conflict. |
+
+## Notes
+
+- **`--force` is dual-purpose.** It overwrites locally-authored files on collision **and** disables the critical-finding block from the built-in security scan. It does **not** refresh remote refs -- for routine ref updates, run [`apm update`](../update/). To remediate findings, prefer `apm audit --strip`. See [Drift and secure by default](../../../consumer/drift-and-secure-by-default/).
+- **Claude target prompt rewrite.** When deploying to `.claude/commands/`, prompt files with an `input:` front-matter key are rewritten to Claude's `arguments:` shape and `${input:name}` placeholders become `$name`. Argument names must match `^[A-Za-z][\w-]{0,63}$`; rejected names are dropped with a warning.
+- **Copilot CLI env-var passthrough.** When deploying MCP entries to `~/.copilot/mcp-config.json`, `${env:VAR}` and `<VAR>` placeholders are translated to `${VAR}` so Copilot CLI resolves them at server-start. Plaintext secrets are never written to disk. Other targets currently resolve placeholders at install time.
+
 ## Related
 
 - [`apm update`](../update/) -- refresh dependencies in `apm.yml` to their latest matching refs, with a consent gate.
 - [`apm self-update`](../self-update/) -- upgrade the `apm` CLI binary itself.
 - [`apm prune`](../prune/) -- remove orphaned packages and stale files.
+- [Private registries](../../../guides/private-registries/) -- end-to-end guide for registry-sourced dependencies.
 - [`apm audit`](../audit/) -- explicit security reporting and remediation after install.
 - [`apm targets`](../targets/) -- print which harnesses APM detects in the current directory.
 - [Install packages (consumer guide)](../../../consumer/install-packages/) -- task-oriented walkthrough.

--- a/docs/src/content/docs/reference/cli/outdated.md
+++ b/docs/src/content/docs/reference/cli/outdated.md
@@ -21,6 +21,7 @@ apm outdated [OPTIONS]
 - **Branch-pinned deps** (e.g. `main`): compare the locked commit SHA against the remote branch tip.
 - **Default-branch deps** (no ref): compare against `main`/`master` tip.
 - **Marketplace deps**: compare the installed ref against the marketplace entry's current `source.ref`.
+- **Registry deps** (experimental `registries` feature): compare the lockfile's exact `version` against the highest semver on the registry that satisfies the manifest range (same resolution semantics as `apm install`). Manifest ranges come from the root `apm.yml` and from installed packages' `apm.yml` files (transitive deps). When a registry lockfile entry has no manifest range, `apm outdated` compares against the highest published version and labels the source `(lockfile)`.
 
 Local dependencies and Artifactory-hosted deps are skipped. Legacy `apm.lock` files are migrated to `apm.lock.yaml` automatically on read.
 
@@ -31,7 +32,7 @@ To apply the suggested updates, run `apm install --update` (see [Related](#relat
 | Option | Description |
 |---|---|
 | `-g, --global` | Check user-scope dependencies in `~/.apm/` instead of the current project. |
-| `-v, --verbose` | For outdated tag-pinned deps, also list up to 10 newer available tags. |
+| `-v, --verbose` | For outdated tag-pinned or registry deps, also list up to 10 newer available versions/tags. |
 | `-j, --parallel-checks N` | Max concurrent remote checks. Default `4`. `0` forces sequential. |
 
 ## Examples
@@ -51,6 +52,8 @@ Sample output:
   acme/agent-skills             v1.2.0    v1.4.1        outdated    git tags
   acme/prompt-pack              main      9c1ab2f0      outdated    git branch
   acme/lint-rules               v0.3.0    v0.3.0        up-to-date  git tags
+  nadavy/e2e-demo               1.0.1     1.1.1         outdated    registry: corp
+  microsoft/apm-review-panel    0.1.1     0.1.2         outdated    registry: corp (lockfile)
   pirate-skill@apm-marketplace  v0.2.1    v0.3.0 (...)  outdated    marketplace: apm-marketplace
 
   [!] 2 outdated dependencies found
@@ -79,8 +82,15 @@ apm outdated -j 8
 | Status | Meaning |
 |---|---|
 | `up-to-date` | Locked ref matches the remote. |
-| `outdated` | A newer tag (or branch tip SHA) is available. |
-| `unknown` | The remote could not be queried, or the ref could not be resolved. |
+| `outdated` | A newer tag, branch tip SHA, or registry version in the manifest range is available. |
+| `unknown` | The remote could not be queried, or the ref could not be resolved. For registry deps, also check auth (`APM_REGISTRY_TOKEN_{NAME}`) and that the registry URL is configured. |
+
+Registry `Source` values:
+
+| Source pattern | Meaning |
+|---|---|
+| `registry: NAME` | Compared using the manifest semver range from `apm.yml` (root or an installed package). |
+| `registry: NAME (lockfile)` | No manifest range found; compared against the highest published version on the registry. |
 
 ## Exit codes
 
@@ -96,3 +106,4 @@ apm outdated -j 8
 - [`apm install`](../install/) -- pass `--update` to upgrade outdated deps and rewrite the lockfile.
 - [`apm view`](../view/) -- inspect a single package's metadata or available versions.
 - [`apm audit`](../audit/) -- security scan over installed primitives, suitable for CI gating.
+- [Registries guide](../../guides/registries/) -- declare registries, publish flat archives, and consume registry-sourced deps.

--- a/docs/src/content/docs/reference/cli/publish.md
+++ b/docs/src/content/docs/reference/cli/publish.md
@@ -1,0 +1,120 @@
+---
+title: apm publish
+description: Upload a flat registry archive to a REST-based APM package registry.
+sidebar:
+  order: 18
+---
+
+## Synopsis
+
+```bash
+apm publish [OPTIONS]
+```
+
+## Description
+
+`apm publish` uploads a package version to a configured registry via `PUT /v1/packages/{owner}/{repo}/versions/{version}`.
+
+By default the command **auto-packs** a flat registry archive in the project root (`{name}-{version}.tar.gz`) containing `apm.yml` and `.apm/` at the tarball root. This is **not** the plugin bundle layout from [`apm pack`](./pack/) (`{name}-{version}/plugin.json`).
+
+Requires the experimental `registries` feature:
+
+```bash
+apm experimental enable registries
+```
+
+The project's `apm.yml` must declare a `registries:` block with at least one registry URL. Publish credentials resolve via `APM_REGISTRY_TOKEN_{NAME}` or `apm config set registry.<name>.token`.
+
+## Options
+
+| Flag | Default | Description |
+|---|---|---|
+| `--registry NAME` | _(required when multiple registries configured)_ | Registry name from the `registries:` block. |
+| `--package OWNER/REPO` | parsed from `source:` in `apm.yml` | Override the registry package identity. |
+| `--tarball PATH` | auto-pack | Path to a pre-built `.tar.gz`. Skips auto-pack. |
+| `--dry-run` | off | Print what would be uploaded; do not call the registry. |
+| `--verbose`, `-v` | off | Show auto-pack details (tarball path). |
+
+## Examples
+
+Auto-pack and publish when only one registry is configured:
+
+```bash
+apm publish
+```
+
+Choose a registry and preview first:
+
+```bash
+apm publish --registry corp-main --dry-run -v
+apm publish --registry corp-main
+```
+
+Publish a skill-only or custom tarball:
+
+```bash
+tar czf my-skill-0.0.1.tar.gz apm.yml SKILL.md
+apm publish --tarball my-skill-0.0.1.tar.gz
+```
+
+Override owner/repo when `source:` is absent or wrong:
+
+```bash
+apm publish --package acme/my-package --registry corp-main
+```
+
+## Output
+
+### Successful publish
+
+```
+[i] Publishing acme/my-package@1.2.3 to corp-main …
+[+] Published acme/my-package@1.2.3
+  digest      : sha256:abc123…
+  published_at: 2026-05-26T10:15:00Z
+  registry    : https://registry.example.com/apm/corp-main
+```
+
+With `--verbose`, auto-pack also prints:
+
+```
+[i] Packing flat registry archive -> my-package-1.2.3.tar.gz
+```
+
+### Dry run
+
+```
+[i] Would publish acme/my-package@1.2.3 to corp-main (https://registry.example.com/apm/corp-main)
+[i]   tarball : /path/to/project/my-package-1.2.3.tar.gz  (12,345 bytes)
+[i] (dry-run — nothing uploaded)
+```
+
+### Common errors
+
+| Message | Cause |
+|---|---|
+| `requires the experimental registries feature` | Run `apm experimental enable registries`. |
+| `apm.yml not found` | Run from the package root. |
+| `requires a flat APM package (.apm/ directory)` | Add `.apm/` or pass `--tarball`. |
+| `Multiple registries configured` | Pass `--registry NAME`. |
+| `Version '…' already exists … immutable` | HTTP 409 — bump `version:` in `apm.yml`. |
+| `Registry rejected the package (validation failed)` | HTTP 422 — tarball layout invalid for the server. |
+| `Forbidden — your token does not have publish permission` | HTTP 403 — check `APM_REGISTRY_TOKEN_{NAME}`. |
+| `401` / credentials remediation | HTTP 401 — token missing or expired. |
+
+Some registries return `201` with an empty body; APM still treats the upload as successful when the HTTP status is success-class.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Published successfully, or `--dry-run` completed without error. |
+| `1` | Publish failure: missing `apm.yml` or `.apm/`, invalid manifest, auth error (401/403), version conflict (409), server validation rejection (422), network/registry error, registries feature disabled, or other unhandled error. |
+| `2` | Usage error: cannot infer `owner/repo`, multiple registries without `--registry`, unknown `--registry` name, or invalid flag combination. |
+
+## Related
+
+- [Registries (guide)](../../../guides/registries/) — declare registries, auth, default routing, and policy.
+- [`apm pack`](./pack/) — plugin bundles and marketplace artifacts (different layout from registry publish).
+- [`apm install`](./install/) — consumer side; installs registry packages with `resolved_hash` verification.
+- [Registry HTTP API](../../registry-http-api/) — wire contract for `PUT …/versions/{version}`.

--- a/docs/src/content/docs/reference/experimental.md
+++ b/docs/src/content/docs/reference/experimental.md
@@ -172,6 +172,8 @@ apm experimental reset verbose-version
 | `verbose-version`     | Show Python version, platform, and install path in `apm --version`.              |
 | `copilot-cowork`      | Deploy APM skills to Microsoft 365 Copilot Cowork via OneDrive.                  |
 | `copilot-app`         | Deploy APM prompts that carry workflow frontmatter (any of `interval`, `schedule_hour`, `schedule_day`) as workflows in the GitHub Copilot desktop App (`~/.copilot/data.db`). See [Copilot App integration](../integrations/copilot-app/). |
+| `marketplace-authoring`| Enable marketplace authoring commands (init, build, publish, etc.).              |
+| `registries`          | Enable REST-based APM package registries in `apm.yml`.                           |
 
 New flags are proposed via [CONTRIBUTING.md](https://github.com/microsoft/apm/blob/main/CONTRIBUTING.md#how-to-add-an-experimental-feature-flag) and graduate to default when stable. See the contributor recipe for the full lifecycle.
 See also: [Cowork integration](../integrations/copilot-cowork/).

--- a/docs/src/content/docs/reference/lockfile-spec.md
+++ b/docs/src/content/docs/reference/lockfile-spec.md
@@ -11,6 +11,12 @@ reproducible installs and for drift detection. Commit it.
 
 ## Purpose
 
+This is a **Working Draft**. The lock file format has two versions in use:
+`"1"` (Git-only projects) and `"2"` (projects with at least one registry-sourced
+dependency). The bump is opportunistic; see [Version bumping](#version-bumping).
+Registry-sourced dependencies require the experimental registries feature
+(`apm experimental enable registries`) before install or replay.
+
 The lockfile gives APM four things:
 
 1. **Reproducibility.** `apm install --frozen` reinstalls the exact commits
@@ -43,9 +49,32 @@ lockfile_version: "1"
 generated_at: "2026-05-10T20:14:00+00:00"
 apm_version: "0.6.4"
 dependencies:
-  - repo_url: github.com/octocat/example-skills
-    resolved_commit: 7f3c9a...
-    # ...
+  - repo_url: https://github.com/acme-corp/security-baseline
+    resolved_commit: a1b2c3d4e5f6789012345678901234567890abcd
+    resolved_ref: v2.1.0
+    version: "2.1.0"
+    depth: 1
+    package_type: apm_package
+    deployed_files:
+      - .github/instructions/security.instructions.md
+      - .github/agents/security-auditor.agent.md
+
+  - repo_url: https://github.com/acme-corp/common-prompts
+    resolved_commit: f6e5d4c3b2a1098765432109876543210fedcba9
+    resolved_ref: main
+    depth: 2
+    resolved_by: https://github.com/acme-corp/security-baseline
+    package_type: apm_package
+    deployed_files:
+      - .github/instructions/common-guidelines.instructions.md
+
+  - repo_url: https://github.com/acme-corp/security-baseline
+    source: registry
+    version: "2.1.0"
+    resolved_url: https://registry.example.com/v1/packages/acme/security-baseline/versions/2.1.0/download
+    resolved_hash: "sha256:abc123..."
+    depth: 1
+    package_type: apm_package
 mcp_servers:
   - github
 mcp_configs:
@@ -61,7 +90,7 @@ local_deployed_file_hashes:
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
-| `lockfile_version` | string | yes | Schema version. Currently `"1"`. Bumped on breaking format changes. |
+| `lockfile_version` | string | yes | Schema version. `"1"` for Git-only projects; `"2"` when any dependency has `source: "registry"`. |
 | `generated_at` | ISO 8601 string | yes | UTC timestamp of the last write. Ignored by equivalence checks. |
 | `apm_version` | string | no | APM CLI version that wrote the file. Diagnostic only. |
 | `dependencies` | list | yes | Resolved APM packages. See [per-entry fields](#per-entry-fields). |
@@ -82,7 +111,7 @@ Each item in `dependencies` describes one resolved package.
 | `registry_prefix` | string | no | URL path prefix when resolved through a registry proxy (e.g. `artifactory/github`). |
 | `resolved_ref` | string | no | The user-supplied ref from `apm.yml` (`main`, `v1.2.0`, a SHA). |
 | `resolved_commit` | string | no | Exact 40-char commit SHA installed. The pin. |
-| `version` | string | no | Resolved semver when the source advertises one. |
+| `version` | string | no | Resolved package version/ref selector. For registry entries this is the exact version selected from the registry, whether semver or not. |
 | `virtual_path` | string | no | Subpath inside the repo for virtual packages (monorepo subpaths). |
 | `is_virtual` | bool | no | `true` when the entry is a virtual subpath package. |
 | `depth` | int | no | Position in the dependency tree. `0` is the project itself, `1` is a direct dep, higher is transitive. Defaults to `1`. |
@@ -91,7 +120,9 @@ Each item in `dependencies` describes one resolved package.
 | `skill_subset` | list of strings | no | For `skill_bundle` packages: the sorted subset of skill names the manifest selected. Empty means "all". |
 | `deployed_files` | list of strings | no | Project-relative paths APM wrote for this dep. Sorted. Powers `prune` and `audit`'s file-presence check. |
 | `deployed_file_hashes` | map | no | `path -> sha256` for the files in `deployed_files`. Powers `audit`'s content-integrity check. Directory entries (trailing `/`) have no hash. |
-| `source` | string | no | `"local"` for path dependencies. Absent for remote deps. |
+| `source` | string | no | `"local"` for path dependencies, `"registry"` for dedicated-registry resolutions. Absent for Git deps. |
+| `resolved_url` | string | registry only | Fully-qualified download URL used to re-fetch registry archives. |
+| `resolved_hash` | string | registry only | SHA-256 digest of the registry archive bytes, verified on every install. |
 | `local_path` | string | no | Original path from `apm.yml` for local deps, relative to project root. |
 | `content_hash` | string | no | SHA-256 of the local package's source tree. Lets APM detect upstream changes to a path dep. |
 | `is_dev` | bool | no | `true` when the dep was declared under `devDependencies`. |
@@ -125,6 +156,23 @@ all "owned" files uniformly. This synthesized entry has:
 The synthesized entry is **not** written back to YAML - the flat
 `local_deployed_*` fields remain the on-disk source of truth. Treat the self
 entry as an implementation detail; do not author it by hand.
+
+## Version bumping
+
+The lock file uses two schema versions:
+
+| Version | Triggered by | Adds |
+|---|---|---|
+| `"1"` | Default for Git-only projects. | Baseline schema. |
+| `"2"` | Any dependency with `source: "registry"`. | `resolved_url`, `resolved_hash`, and the `version` field on registry entries. |
+
+The bump is **opportunistic**: a project that never opts into a registry keeps
+`lockfile_version: "1"` forever, even on a newer client. The first registry
+dep added to the graph promotes the lockfile to `"2"`; if every registry dep is
+later removed, the next write demotes back to `"1"`. Both versions are valid
+on-disk formats; consumers MUST handle either.
+
+For the registry workflow this enables, see the [Registries guide](../../guides/registries/).
 
 ## Pack section
 

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -50,6 +50,7 @@ target:        <enum | list<enum>>
 type:          <enum>
 scripts:       <map<string, string>>
 includes:      <enum | list<string>>
+registries:    <map<string, RegistryEntry> & {default?: <string>}>
 dependencies:
   apm:         <list<ApmDependency>>
   mcp:         <list<McpDependency>>
@@ -247,6 +248,37 @@ policy:
 
 Full semantics (network failure matrix, hash pin verification, policy precedence) live in the [Policy reference](../../enterprise/policy-reference/).
 
+### 3.11. `registries`
+
+::::caution[Experimental]
+The `registries:` field and registry-routed APM dependency forms require `apm experimental enable registries`.
+::::
+
+| | |
+|---|---|
+| **Type** | `map<string, RegistryEntry>` with optional `default: <string>` key |
+| **Required** | OPTIONAL |
+| **Description** | Declares REST-based APM registries for the project. Strictly additive — absent or empty block leaves Git resolution unchanged unless a default registry is configured in `~/.apm/config.json`. URLs from all layers are merged at install time; see the [Registries guide](../../guides/registries/#user-level-config). |
+
+```yaml
+registries:
+  jf-skills:
+    url: https://artifactory.example.com/artifactory/api/skills/jf-skills-local
+  default: jf-skills           # OPTIONAL — name of one of the configured entries
+```
+
+| Sub-key | Type | Required | Constraint | Semantic |
+|---|---|---|---|---|
+| `<name>` | `RegistryEntry` | at least one when block is non-empty | Name uses lowercase letters, digits, `-`, `.` | Registered registry. |
+| `<name>.url` | `string` | REQUIRED per entry | MUST start with `https://` or `http://`; no trailing slash required | Base URL the client appends `/v1/...` paths to. |
+| `default` | `string` | OPTIONAL | MUST name one of the configured entries | When set, plain string-shorthand APM deps and object-form deps without an explicit `registry:` key route through this registry. Project value wins over `registry.<name>.default` in `~/.apm/config.json`. |
+
+Unknown keys under a registry entry MUST be rejected at parse time (typo guard).
+
+**Effective default registry:** project `registries.default` if present; otherwise the registry marked `"default": true` in `~/.apm/config.json` (via `apm config set registry.<name>.default true`). Only one default is active at a time.
+
+For full client semantics — auth, lockfile fields, and routing rules — see the [Registries guide](../../guides/registries/). For the wire contract servers implement, see the [Registry HTTP API](../registry-http-api/).
+
 ---
 
 ## 4. Dependencies
@@ -276,7 +308,9 @@ shorthand_form  = [host "/"] owner "/" repo ["/" virtual_path] ["#" ref]
 local_path_form = ("./" / "../" / "/" / "~/" / ".\\" / "..\\" / "~\\") path
 ```
 
-`clone-url` MAY include a `:port` segment on `https://`, `http://`, and `ssh://git@` forms (e.g. `ssh://git@host:7999/owner/repo.git`). The SCP shorthand `git@host:path` cannot carry a port because `:` is the path separator in that form. When a port is present, APM preserves it across all clone attempts: the SSH attempt uses `ssh://host:PORT/...` and the HTTPS fallback uses `https://host:PORT/...` (same port on both protocols).
+When a default registry is configured — via `registries.default` in `apm.yml` or `registry.<name>.default true` in `~/.apm/config.json` — plain `shorthand_form` entries with a `#<selector>` route through that registry instead of Git.
+
+`clone-url` MAY include a `:port` segment on `https://`, `http://`, and `ssh://git@` forms (e.g. `ssh://git@host:7999/owner/repo.git`). The SCP shorthand `git@host:path` cannot carry a port — `:` is the path separator in that form. When a port is present, APM preserves it across all clone attempts: the SSH attempt uses `ssh://host:PORT/...` and the HTTPS fallback uses `https://host:PORT/...` (same port on both protocols).
 
 | Segment | Required | Pattern | Description |
 |---|---|---|---|
@@ -357,6 +391,28 @@ Monorepo sibling reference (`git: parent`):
 ```
 
 The literal sentinel `git: parent` is valid only inside a transitively resolved package whose clone coordinates are known to the resolver. APM expands `parent` to the consumer's `host`, `repo_url`, and resolved `ref`, with `virtual_path` set from `path`. The lockfile records the **expanded** coordinates: `parent` MUST NOT appear as durable identity (`repo_url` / `source`). `path` is REQUIRED for `git: parent` and is normalised to a single relative path; absolute paths and `..` traversal are refused. `ref` and `alias` overrides are accepted; when `ref` is omitted the parent's resolved ref is inherited.
+
+Registry dependency (whole package or virtual sub-path):
+
+```yaml
+# Whole package via the default registry
+- id: acme/toolkit
+  version: ^2.0.0
+
+# Whole package routed to a named registry
+- registry: jf-skills              # OPTIONAL — defaults to the effective default registry
+  id: acme/toolkit                 # REQUIRED — owner/repo identity at the registry
+  version: ^2.0.0                  # REQUIRED — opaque version selector (semver when supported)
+
+# Virtual package (sub-path inside a published package)
+- registry: jf-skills
+  id: acme/prompt-pack
+  path: prompts/review.prompt.md   # OPTIONAL — omit to install the whole package
+  version: 1.4.0
+  alias: review                    # OPTIONAL
+```
+
+`id:` (or `registry:`) and `git:` are mutually exclusive on the same entry. `version:` MUST be a non-empty string — opaque selectors such as `stable`, `main`, or commit pins are valid; semver ranges (`^1.2.3`) are interpreted as ranges when the registry publishes semver-tagged versions. When `registry:` is omitted, a default registry MUST be configured — in project `apm.yml` or via `registry.<name>.default true` in `~/.apm/config.json`; APM hard-fails otherwise.
 
 #### 4.1.3. Virtual Packages
 

--- a/docs/src/content/docs/reference/policy-schema.md
+++ b/docs/src/content/docs/reference/policy-schema.md
@@ -34,11 +34,12 @@ The `<ref>` accepts:
 | `enforcement`      | enum                | `warn`           | no       | `off` / `warn` / `block`. See [Enforcement modes](#enforcement-modes).            |
 | `fetch_failure`    | enum                | `warn`           | no       | `warn` / `block`. Behavior when a remote policy cannot be fetched or parsed.      |
 | `cache`            | object              | `{ttl: 3600}`    | no       | Cache settings for remote policy fetches.                                         |
-| `dependencies`    | object              | see section      | no       | Rules over APM dependencies.                                                       |
+| `dependencies`     | object              | see section      | no       | Rules over APM dependencies.                                                       |
 | `mcp`              | object              | see section      | no       | Rules over MCP servers (direct and transitive).                                   |
 | `compilation`      | object              | see section      | no       | Rules over `apm compile` outputs.                                                 |
 | `manifest`         | object              | see section      | no       | Rules over `apm.yml` content.                                                     |
 | `unmanaged_files`  | object              | see section      | no       | Rules over files in target directories not tracked by the lockfile.               |
+| `registry_source`  | object              | see section      | no       | Mandate registry usage and block non-registry sources (requires `registries` flag). |
 
 Unknown top-level keys produce a warning, never an error -- so newer policy files load on older clients.
 
@@ -229,6 +230,26 @@ unmanaged_files:
   directories:
     - .github/instructions
     - .github/prompts
+```
+
+## registry_source
+
+::::caution[Experimental]
+Requires `apm experimental enable registries`. Ignored on clients without the flag enabled.
+::::
+
+Mandate that APM dependencies come from configured registries. Checks apply transitively (including transitive deps pulled in by registry packages).
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `require` | `list<string>` | `[]` | Registry names that MUST be reachable. APM **fails-closed** if a listed name has no URL in the merged registry map (from project `apm.yml`, workspace `~/.apm/apm.yml`, or `~/.apm/config.json`) — this is intentional: a missing registry config is treated as a policy violation, not a no-op. |
+| `allow_non_registry` | `bool` | `true` | When `false`, APM blocks installation of any dependency not routed through a configured registry. |
+
+```yaml
+registry_source:
+  require:
+    - jf-skills
+  allow_non_registry: false
 ```
 
 ## See also

--- a/docs/src/content/docs/reference/registry-http-api.md
+++ b/docs/src/content/docs/reference/registry-http-api.md
@@ -1,0 +1,461 @@
+---
+title: "Registry HTTP API"
+description: "The wire-level contract for APM dedicated registries — endpoints, auth, error model, and conformance rules for server implementers."
+sidebar:
+  order: 4
+---
+
+<dl>
+<dt>Version</dt><dd>v1 (implementable)</dd>
+<dt>Audience</dt><dd>Server implementers (Artifactory plugins, Nexus formats, OSS reference servers)</dd>
+<dt>Format</dt><dd>JSON over HTTPS</dd>
+</dl>
+
+This document is the wire-level contract. It is self-contained — a server implementer should be able to build a conformant registry from this doc alone. For the client side and how to declare registries in `apm.yml`, see the [Registries guide](../../guides/registries/).
+
+::::caution[Experimental client support]
+The HTTP API contract is implementable, but APM client consumption of package registries is currently behind an experimental flag. Users must run `apm experimental enable registries` before installing from `registries:` entries.
+::::
+
+---
+
+## Table of contents
+
+1. [Conventions](#1-conventions)
+2. [Authentication](#2-authentication)
+3. [Endpoints](#3-endpoints)
+   1. [`GET /v1/packages/{owner}/{repo}/versions`](#31-get-v1packagesownerrepoversions--list-versions)
+   2. [`GET /v1/packages/{owner}/{repo}/versions/{version}/download`](#32-get-v1packagesownerrepoversionsversiondownload--download-archive)
+   3. [`PUT /v1/packages/{owner}/{repo}/versions/{version}`](#33-put-v1packagesownerrepoversionsversion--publish)
+
+4. [Error model](#4-error-model)
+5. [Conformance: required vs optional](#5-conformance-required-vs-optional)
+6. [Server validation rules (publish)](#6-server-validation-rules-publish)
+7. [Caching, rate limiting, and headers](#7-caching-rate-limiting-and-headers)
+8. [Security checklist](#8-security-checklist)
+9. [Reference test fixtures](#9-reference-test-fixtures)
+
+---
+
+## 1. Conventions
+
+### 1.1 Base URL
+
+The registry's **base URL** is vendor-defined — for example, `https://registry.example.com/apm`. Clients always append paths starting with `/v1/...` to it. The base URL MUST NOT contain a trailing slash; if vendors return one in their UI, the client strips it (see `RegistryClient.__init__`).
+
+### 1.2 Identity
+
+`{owner}/{repo}` in path segments matches `DependencyReference.get_identity()` for GitHub-origin packages. For non-GitHub origins, identity is **percent-encoded** (each `/` in the identity becomes `%2F`):
+
+| Origin | Identity | Path segment |
+|---|---|---|
+| GitHub | `acme/web-skills` | `acme/web-skills` (two segments) |
+| GitLab | `gitlab.com/acme/web-skills` | `gitlab.com%2Facme%2Fweb-skills` (one encoded segment) |
+| Azure DevOps | `dev.azure.com/org/proj/repo` | `dev.azure.com%2Forg%2Fproj%2Frepo` (one encoded segment) |
+
+Servers MUST decode percent-encoded path segments before lookup.
+
+### 1.3 Versions
+
+Version strings are opaque, case-sensitive selectors. Servers MAY use
+[semver 2.0](https://semver.org/) strings when they want clients to support
+range selection (`^1.2.3`, `>=1.2.0 <2.0.0`), but semver is optional so
+registries can mirror existing Git flows (`main`, `stable`, `v1.2.3`, commit
+pins, or other enterprise naming conventions).
+
+Clients interpret semver-looking selectors as ranges. Non-semver selectors are
+matched exactly against the `version` values returned by `/versions`.
+
+### 1.3.1 Field naming convention
+
+All JSON field names use **`snake_case`** (matches npm, Cargo, PyPI conventions). Servers MUST NOT emit camelCase variants alongside or instead of the canonical names.
+
+The reference client is intentionally **strict** — it reads only the spec-canonical field name and ignores camelCase variants without raising. This is by design: silent client tolerance hides server spec drift. A server emitting `publishedAt` instead of `published_at` is non-conformant and clients SHOULD treat its absence as if the field were not provided.
+
+### 1.4 Content types
+
+| Resource | Type |
+|---|---|
+| List versions, problem details, publish response | `application/json; charset=utf-8` |
+| RFC 7807 problem detail | `application/problem+json; charset=utf-8` |
+| Archive download (gzip) | `application/gzip` |
+| Archive download (zip) | `application/zip` |
+
+Servers SHOULD set `charset=utf-8` on JSON responses but clients MUST NOT depend on it.
+
+### 1.5 Versioning the API itself
+
+The leading `/v1/` path segment is the API version. Future breaking changes ship under `/v2/`. Servers SHOULD support multiple versions in parallel during migration.
+
+### 1.6 Idempotency and immutability
+
+- **Versions are immutable.** A successful `PUT .../versions/{version}` cannot be overwritten — subsequent PUTs return `409 Conflict`. This is a hard requirement; clients depend on it for the lockfile trust model.
+- **List queries are idempotent.** `GET /versions` MUST return the same set of versions on identical inputs.
+
+
+---
+
+## 2. Authentication
+
+### 2.1 Bearer token
+
+Every endpoint accepts `Authorization: Bearer <token>`. Tokens are opaque strings issued by the registry; the client treats them as bytes (no parsing, no inspection).
+
+When the header is absent, the server MAY:
+- accept the request (anonymous read on a public registry), OR
+- reject with `401 Unauthorized` (authenticated reads only).
+
+Clients try anonymous first when no env var is configured for a URL (per design §6.2). Servers SHOULD return `401` rather than `403` for missing-credential cases so clients can distinguish "auth required" from "auth provided but not authorized."
+
+### 2.1.1 HTTP Basic auth (alternative)
+
+Servers MAY accept `Authorization: Basic <base64(username:password)>` as a v1 alternative to Bearer. This is a first-class option for compatibility with enterprise registries that already support Basic and where Bearer-token issuance from end-user credentials is a separate, registry-specific flow.
+
+Servers MUST treat both forms as semantically identical for scope evaluation: a Basic-authed `admin:password` request and a Bearer-authed equivalent token MUST produce the same scope grants.
+
+Clients that support Basic auth read credentials from `APM_REGISTRY_USER_{NAME}` + `APM_REGISTRY_PASS_{NAME}` environment variables (see §2.3). When both Bearer and Basic env vars are set for the same registry, clients send Bearer.
+
+### 2.2 Scopes (server-side enforcement)
+
+Tokens MUST carry one or more of these scopes. Clients never see scope strings — the server enforces them on each request.
+
+| Scope | Required for | Notes |
+|---|---|---|
+| `read` | `GET /versions`, `GET /download` | Coarse read access |
+| `read:{owner}/{repo}` | Same as `read` but scoped | Optional fine-grained variant |
+| `publish:{owner}/{repo}` | `PUT .../versions/{version}` | Per-package publish authority |
+| `publish:{owner}/*` | Same, all repos under owner | Convenience wildcard |
+
+Servers MUST reject mismatched-scope requests with `403 Forbidden` and an RFC 7807 body citing which scope is missing.
+
+### 2.3 Client env-var conventions
+
+Clients use the following environment variables, where `{NAME}` is the uppercased registry name with `-` and `.` mapped to `_`:
+
+| Env var | Auth method |
+|---|---|
+| `APM_REGISTRY_TOKEN_{NAME}` | `Authorization: Bearer <value>` |
+| `APM_REGISTRY_USER_{NAME}` + `APM_REGISTRY_PASS_{NAME}` | `Authorization: Basic <base64(user:pass)>` |
+
+When both are set, Bearer wins. When neither is set, the client tries the request anonymously and falls back to a clear remediation message on 401/403.
+
+The prefix is distinct from `GITHUB_TOKEN`, `GITHUB_APM_PAT`, `PROXY_REGISTRY_*`, and `ARTIFACTORY_APM_TOKEN`. Servers don't see these — included here for protocol completeness.
+
+---
+
+## 3. Endpoints
+
+### 3.1 `GET /v1/packages/{owner}/{repo}/versions` — list versions
+
+Returns all published versions for a package.
+
+**Request**
+
+```
+GET /v1/packages/acme/web-skills/versions HTTP/1.1
+Host: registry.example.com
+Authorization: Bearer <token>
+Accept: application/json
+```
+
+**Response 200**
+
+```json
+{
+  "package": "acme/web-skills",
+  "versions": [
+    {
+      "version": "1.2.0",
+      "digest": "sha256:abc123...",
+      "published_at": "2026-03-01T12:00:00Z",
+      "size_bytes": 24576
+    },
+    {
+      "version": "1.1.0",
+      "digest": "sha256:def456...",
+      "published_at": "2026-02-14T08:00:00Z",
+      "size_bytes": 23000
+    }
+  ]
+}
+```
+
+**Field requirements**
+
+| Field | Required | Notes |
+|---|---|---|
+| `package` | yes | Echoes the requested identity. Useful for clients that fetched via percent-encoded path. |
+| `versions[]` | yes | May be empty (`[]`); MUST NOT be omitted. |
+| `versions[].version` | yes | Opaque version/ref selector. Semver strings enable client-side range matching; non-semver strings are matched exactly. |
+| `versions[].digest` | yes | sha256 of the archive bytes. Format: `sha256:<64 lowercase hex chars>`. |
+| `versions[].published_at` | yes | ISO 8601 UTC timestamp. |
+| `versions[].size_bytes` | optional | Archive size; informational. |
+
+**Ordering.** Servers SHOULD return versions in publish-time descending order (newest first). Clients MUST NOT depend on order. For semver range selectors, clients sort semver-compatible versions client-side; exact selectors do direct string matching.
+
+**Errors**
+
+| Status | Reason |
+|---|---|
+| `401` | Missing/invalid token, anonymous reads disabled |
+| `403` | Token lacks `read` scope for this package |
+| `404` | Package not found |
+
+**Caching.** Versions are immutable, but the SET of versions changes when new releases ship. Servers SHOULD set `Cache-Control: max-age=60` (or shorter); clients MAY honor it.
+
+---
+
+### 3.2 `GET /v1/packages/{owner}/{repo}/versions/{version}/download` — download archive
+
+Streams the immutable package archive. The endpoint is named `/download` (not `/tarball`) because both gzip and zip archives are valid responses; `Content-Type` discriminates.
+
+**Request**
+
+```
+GET /v1/packages/acme/web-skills/versions/1.2.0/download HTTP/1.1
+Host: registry.example.com
+Authorization: Bearer <token>
+Accept: application/gzip, application/zip
+```
+
+Clients SHOULD send the `Accept` header to advertise both formats. Servers SHOULD honor `Accept` if they store both, but MAY ignore it and return whatever was published.
+
+**Response 200**
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/gzip          ← or application/zip
+Content-Length: 24576
+Digest: sha256=<base64-of-binary-digest>   (RFC 3230)
+ETag: "sha256:abc123..."
+
+<binary archive body>
+```
+
+**Required headers**
+
+| Header | Required | Notes |
+|---|---|---|
+| `Content-Type` | yes | One of `application/gzip` or `application/zip`. |
+| `Content-Length` | recommended | Streamed delivery is fine; if absent, clients buffer to memory. |
+| `Digest` | recommended | RFC 3230 hash. Clients verify against `versions[].digest` from /versions, not this header. |
+| `ETag` | optional | Conditional GET support; clients may use it for caching across runs. |
+
+**Body.** Raw archive bytes. The same bytes that hash to the `digest` advertised in `/versions`.
+
+**Format selection at publish time.** APM publishes via `apm pack` (tar.gz). Anthropic skills publish via standard zip. Servers store and return whatever was uploaded; format conversion is NOT a server responsibility.
+
+**Errors**
+
+| Status | Reason |
+|---|---|
+| `401`, `403` | Same semantics as 3.1 |
+| `404` | No such (owner, repo, version) tuple |
+| `410` | Version yanked (v2; reserved) |
+
+**Hash verification on client.** Per design §6.1, clients re-hash the body against `versions[].digest` from a fresh `/versions` call OR from the lockfile's `resolved_hash`. A mismatch fails closed before extraction. Servers SHOULD NOT rely on this — they provide bytes; the trust gate is client-side.
+
+---
+
+### 3.3 `PUT /v1/packages/{owner}/{repo}/versions/{version}` — publish
+
+Uploads a new version. Versions are immutable: re-publishing returns `409`.
+
+**Request**
+
+```
+PUT /v1/packages/acme/web-skills/versions/1.2.0 HTTP/1.1
+Host: registry.example.com
+Authorization: Bearer <publish-token>
+Content-Type: application/gzip
+Content-Length: 24576
+
+<binary archive body>
+```
+
+**Body.** Archive bytes — either tar.gz (`application/gzip`) or zip (`application/zip`). The server records the Content-Type and replays it on subsequent `GET /download`.
+
+**Response 201**
+
+```json
+{
+  "package": "acme/web-skills",
+  "version": "1.2.0",
+  "digest": "sha256:abc123...",
+  "published_at": "2026-03-01T12:00:00Z",
+  "size_bytes": 24576
+}
+```
+
+**Errors**
+
+| Status | Reason |
+|---|---|
+| `400` | Malformed body (e.g. corrupt gzip, invalid zip directory). Body: RFC 7807 with `detail` describing the parse error. |
+| `401`, `403` | Auth missing / scope mismatch |
+| `409` | Version already exists. Body: RFC 7807 with `detail: "version 1.2.0 already published at 2026-02-14T08:00:00Z"`. |
+| `413` | Body exceeds the registry's per-archive size limit. |
+| `415` | `Content-Type` is neither `application/gzip` nor `application/zip`. |
+| `422` | Server-side validation failed (see §6). Body lists validation errors in `extensions.errors[]`. |
+
+Idempotency for `PUT` is **not** the standard "same request always succeeds" — it's "same `(owner, repo, version)` always returns 409 after the first success." This is the immutability invariant clients depend on for the lockfile trust model.
+
+---
+
+## 4. Error model
+
+All `4xx` and `5xx` responses use **RFC 7807 Problem Details** in `application/problem+json`:
+
+```json
+{
+  "type": "https://docs.apm.dev/errors/version-conflict",
+  "title": "Version already published",
+  "status": 409,
+  "detail": "Version 1.2.0 of acme/web-skills was already published at 2026-02-14T08:00:00Z",
+  "instance": "/v1/packages/acme/web-skills/versions/1.2.0",
+  "extensions": {
+    "previous_publish": "2026-02-14T08:00:00Z",
+    "previous_digest": "sha256:..."
+  }
+}
+```
+
+**Required fields:** `title`, `status`. All others optional but recommended.
+
+**Vendor extensions** belong under `extensions.*` per RFC 7807. Clients MUST ignore unknown extensions.
+
+---
+
+## 5. Conformance: required vs optional
+
+A **conformant v1 server** MUST implement:
+
+- `GET /v1/packages/{owner}/{repo}/versions`
+- `GET /v1/packages/{owner}/{repo}/versions/{version}/download`
+- `PUT /v1/packages/{owner}/{repo}/versions/{version}`
+- RFC 7807 error bodies on all 4xx/5xx
+- Bearer auth on all endpoints (anonymous reads optional)
+- sha256 digest accuracy (the byte sequence served at `/download` MUST match the digest advertised at `/versions`)
+- Version immutability (a successful PUT cannot be overwritten)
+
+A **fully-featured v1 server** SHOULD additionally implement:
+
+- `Cache-Control` and `ETag` on read endpoints
+- Conditional `GET` (`If-None-Match`) returning `304`
+- Per-version `size_bytes` field
+
+Clients MUST NOT crash on missing optional fields; they MUST parse `versions[]` even with no `published_at`.
+
+---
+
+## 6. Server validation rules (publish)
+
+On `PUT .../versions/{version}`, the server MUST validate (returning `422` on failure with errors in `extensions.errors[]`):
+
+1. **Version is a non-empty opaque selector** after URL decoding. Reject control characters and empty strings; do not treat the selector as a filesystem path.
+2. **Archive parses cleanly** as the declared `Content-Type` (gzip or zip).
+3. **Archive contains an `apm.yml` at the root** of the extraction tree.
+4. **`apm.yml` is valid YAML** with required fields (`name`, `version`).
+5. **`apm.yml.version` is present**. Servers MAY require it to match the URL path version when their registry policy wants manifest/version lockstep.
+6. **`apm.yml.name` matches the URL path identity** (or its repo-name suffix — implementation-defined).
+7. **Archive entries are safe** — no absolute paths, no `..` traversal, no symlinks/hardlinks.
+8. **Archive size is within limits** — vendor-defined; suggested default 50 MB.
+
+**Out of scope for v1:**
+
+- License-text validation
+- Vulnerability scanning (servers MAY block but it's not required by the spec)
+- Signature verification (deferred to v2)
+
+---
+
+## 7. Caching, rate limiting, and headers
+
+### 7.1 Caching
+
+| Endpoint | Recommended `Cache-Control` |
+|---|---|
+| `GET /versions` | `max-age=60, public` |
+| `GET /download` | `max-age=86400, immutable` (versions are immutable) |
+
+
+Clients MAY ignore these. APM v1 client does no HTTP caching.
+
+### 7.2 Rate limiting
+
+Servers SHOULD return `429 Too Many Requests` with a `Retry-After` header (seconds) when limits are exceeded. The body SHOULD be RFC 7807 with `extensions.limit` and `extensions.remaining`.
+
+### 7.3 Required response headers
+
+`Content-Type` is always required. Other headers are recommended but optional.
+
+---
+
+## 8. Security checklist
+
+For server implementers:
+
+- [ ] **TLS only.** Plain HTTP MUST NOT be supported in production. (Local dev is fine.)
+- [ ] **Token storage.** Use a one-way hash (bcrypt/argon2) for stored bearer tokens; never store plaintext.
+- [ ] **Path traversal prevention.** Reject `..` segments in `{owner}` and `{repo}` path params before any storage lookup; store `{version}` as an opaque key rather than a filesystem path.
+- [ ] **Archive scanning at publish.** Validate per §6 before persistence; reject zip slip / symlink attacks.
+- [ ] **Constant-time digest comparison.** When comparing a client-provided digest (e.g. for conditional GET) to the stored value.
+- [ ] **Audit log.** Record every successful `PUT` with (token-id, owner/repo, version, sha256, timestamp).
+- [ ] **Quota enforcement.** Per-token / per-owner archive size and count limits.
+
+For client implementers (informational):
+
+- [ ] Verify sha256 against `versions[].digest` before extraction.
+- [ ] Reject `..`, absolute paths, symlinks, and hardlinks during extraction.
+- [ ] Persist `resolved_url` in the lockfile (not the registry name) — it's the trust anchor for re-installs.
+- [ ] On `401/403`, surface a remediation message pointing at `APM_REGISTRY_TOKEN_<NAME>`.
+
+---
+
+## 9. Reference test fixtures
+
+A conformance test suite for server implementers SHOULD exercise:
+
+### 9.1 Round-trip publish-then-fetch
+
+1. `PUT .../versions/1.0.0` with a valid tar.gz body → `201` with the right digest.
+2. `GET .../versions/1.0.0/download` → returns the same bytes.
+3. sha256 of the returned bytes equals the digest from the `201` response.
+4. `GET .../versions` → contains the `1.0.0` entry with the same digest.
+
+### 9.2 Immutability
+
+1. `PUT .../versions/1.0.0` → `201`.
+2. `PUT .../versions/1.0.0` (same body) → `409`.
+3. `PUT .../versions/1.0.0` (different body) → `409`.
+
+### 9.3 Format dispatch
+
+1. `PUT .../versions/1.0.0` with `Content-Type: application/zip` → `201`.
+2. `GET .../versions/1.0.0/download` → returns `Content-Type: application/zip` and the same bytes.
+3. Hash matches.
+
+### 9.4 Validation
+
+1. `PUT` with a tarball missing `apm.yml` → `422` with appropriate error message.
+2. `PUT` with `apm.yml.version` ≠ URL version → `422`.
+3. `PUT` with absolute paths in tar → `422`.
+4. `PUT` with symlink in zip → `422`.
+
+### 9.5 Auth
+
+1. Anonymous `GET /versions` on a public package → `200` (or `401` on private registry).
+2. `GET /versions` with token lacking `read` scope → `403`.
+3. `PUT` with token lacking `publish` scope → `403`.
+4. `PUT` with no token → `401`.
+
+### 9.6 Error format
+
+1. Any `4xx` response has `Content-Type: application/problem+json`.
+2. Body is valid JSON with at least `title` and `status`.
+
+---
+
+## Changelog
+
+- Initial release — `versions`, `download`, `publish`. tar.gz + zip both supported. RFC 7807 errors. Bearer auth. Immutable versions.

--- a/docs/src/content/docs/troubleshooting/migration.md
+++ b/docs/src/content/docs/troubleshooting/migration.md
@@ -116,7 +116,37 @@ Existing target output is untouched. The new target's directory is created fresh
 
 Discovery: `apm targets` lists every supported target on the current binary.
 
-## 6. Marketplace switchover (hand-rolled MCP -> APM-managed)
+## 6. Default registry adoption (Git → registry routing)
+
+Adopting a default registry changes how **existing** shorthand dependencies resolve. Entries like `microsoft/apm-sample-package#^1.0.0` that previously cloned from GitHub route to the configured registry instead. APM does not print a migration banner — failures show up as registry errors (`no versions`, `401`) on the next `apm install`.
+
+Recommended rollout:
+
+1. **Inventory** — list shorthand deps in the root `apm.yml` and in installed packages under `apm_modules/` that are not yet published to your registry.
+
+2. **Pin Git-only deps** before enabling the default:
+
+   ```yaml
+   dependencies:
+     apm:
+       - git: https://github.com/microsoft/apm-sample-package.git
+         ref: v1.0.0
+   ```
+
+3. **Enable gradually** — start with `registries:` in `apm.yml` without `default:`, publish packages, then set `registry.<name>.default true` or `registries.default` once shorthand deps exist on the registry.
+
+4. **Verify lockfile** — after the first install with the default, confirm each entry has the intended `source:` (`registry` vs git commit SHA):
+
+   ```bash
+   apm install
+   grep -E 'source:|repo_url:' apm.lock.yaml
+   ```
+
+5. **Publish or remove** — deps that must stay on Git use `- git:`; deps moving to the registry need a published version before the team enables the default org-wide.
+
+See [Registries guide — pitfalls](../guides/registries/#pitfalls) for env-var typos and name-sanitization collisions.
+
+## 7. Marketplace switchover (hand-rolled MCP -> APM-managed)
 
 If your project has a hand-edited `.mcp.json` (or VS Code `mcp.json`) declaring servers directly:
 
@@ -127,7 +157,7 @@ If your project has a hand-edited `.mcp.json` (or VS Code `mcp.json`) declaring 
 
 For publishing your own marketplace entries, see [Marketplace authoring](../guides/pack-distribute/marketplace-authoring/).
 
-## 7. Breaking-change checklist when upgrading APM
+## 8. Breaking-change checklist when upgrading APM
 
 Before bumping `apm` across major or minor versions in a project that other people depend on:
 

--- a/src/apm_cli/cli.py
+++ b/src/apm_cli/cli.py
@@ -34,6 +34,7 @@ from apm_cli.commands.pack import pack_cmd, unpack_cmd
 from apm_cli.commands.plugin import plugin as plugin_cmd
 from apm_cli.commands.policy import policy
 from apm_cli.commands.prune import prune
+from apm_cli.commands.publish import publish_cmd
 from apm_cli.commands.run import preview, run
 from apm_cli.commands.runtime import runtime
 from apm_cli.commands.self_update import self_update
@@ -87,6 +88,7 @@ cli.add_command(
 )
 cli.add_command(pack_cmd, name="pack")
 cli.add_command(unpack_cmd, name="unpack")
+cli.add_command(publish_cmd, name="publish")
 cli.add_command(init)
 cli.add_command(install)
 cli.add_command(uninstall)

--- a/src/apm_cli/commands/config.py
+++ b/src/apm_cli/commands/config.py
@@ -1,6 +1,7 @@
 """APM config command group."""
 
 import builtins
+import re
 import sys
 from pathlib import Path
 
@@ -16,6 +17,7 @@ set = builtins.set
 
 _BOOLEAN_TRUE_VALUES = {"true", "1", "yes"}
 _BOOLEAN_FALSE_VALUES = {"false", "0", "no"}
+_REGISTRY_KEY_RE = re.compile(r"^registry\.([a-zA-Z0-9._-]+)\.(url|token|default)$")
 _CONFIG_KEY_DISPLAY_NAMES = {
     "auto_integrate": "auto-integrate",
     "temp_dir": "temp-dir",
@@ -58,6 +60,10 @@ def _valid_config_keys() -> str:
     keys = ["auto-integrate", "temp-dir"]
     if is_enabled("copilot_cowork"):
         keys.append("copilot-cowork-skills-dir")
+    if is_enabled("registries"):
+        keys.append("registry.<name>.url")
+        keys.append("registry.<name>.token")
+        keys.append("registry.<name>.default")
     return ", ".join(keys)
 
 
@@ -190,6 +196,39 @@ def set(key, value):  # noqa: F811
     from ..config import get_temp_dir, set_temp_dir
 
     logger = CommandLogger("config set")
+
+    registry_match = _REGISTRY_KEY_RE.match(key)
+    if registry_match:
+        from ..core.experimental import is_enabled
+
+        if not is_enabled("registries"):
+            logger.error(
+                f"'{key}' requires the registries experimental flag. "
+                "Run: apm experimental enable registries"
+            )
+            sys.exit(1)
+        reg_name, field = registry_match.group(1), registry_match.group(2)
+        from ..config import set_registry_default, set_registry_token, set_registry_url
+
+        if field == "url":
+            set_registry_url(reg_name, value)
+            logger.success(f"registry.{reg_name}.url set")
+        elif field == "token":
+            set_registry_token(reg_name, value)
+            logger.success(f"registry.{reg_name}.token set")
+        else:
+            try:
+                is_default = _parse_bool_value(value)
+            except ValueError as exc:
+                logger.error(str(exc))
+                sys.exit(1)
+            set_registry_default(reg_name, is_default)
+            if is_default:
+                logger.success(f"registry.{reg_name}.default set")
+            else:
+                logger.success(f"registry.{reg_name}.default cleared")
+        return
+
     if key == "copilot-cowork-skills-dir":
         from ..core.experimental import is_enabled
 
@@ -256,6 +295,31 @@ def get(key):
     logger = CommandLogger("config get")
     getters = _get_config_getters()
     if key:
+        registry_match = _REGISTRY_KEY_RE.match(key)
+        if registry_match:
+            from ..core.experimental import is_enabled
+
+            if not is_enabled("registries"):
+                logger.error(
+                    f"'{key}' requires the registries experimental flag. "
+                    "Run: apm experimental enable registries"
+                )
+                sys.exit(1)
+            reg_name, field = registry_match.group(1), registry_match.group(2)
+            from ..config import get_registry_config, is_registry_default
+
+            cfg = get_registry_config(reg_name)
+            if field == "default":
+                val = is_registry_default(reg_name)
+                click.echo(f"{key}: {'true' if val else 'false'}")
+                return
+            val = (cfg or {}).get(field)
+            if val is None:
+                click.echo(f"{key}: Not set")
+            else:
+                click.echo(f"{key}: {val}")
+            return
+
         if key == "copilot-cowork-skills-dir":
             from ..config import get_copilot_cowork_skills_dir
 
@@ -317,6 +381,30 @@ def unset(key):
         apm config unset copilot-cowork-skills-dir
     """
     logger = CommandLogger("config unset")
+
+    registry_match = _REGISTRY_KEY_RE.match(key)
+    if registry_match:
+        from ..core.experimental import is_enabled
+
+        if not is_enabled("registries"):
+            logger.error(
+                f"'{key}' requires the registries experimental flag. "
+                "Run: apm experimental enable registries"
+            )
+            sys.exit(1)
+        reg_name, field = registry_match.group(1), registry_match.group(2)
+        from ..config import set_registry_default, unset_registry_token, unset_registry_url
+
+        if field == "url":
+            unset_registry_url(reg_name)
+            logger.success(f"registry.{reg_name}.url removed")
+        elif field == "token":
+            unset_registry_token(reg_name)
+            logger.success(f"registry.{reg_name}.token removed")
+        else:
+            set_registry_default(reg_name, False)
+            logger.success(f"registry.{reg_name}.default removed")
+        return
 
     if key == "temp-dir":
         from ..config import unset_temp_dir

--- a/src/apm_cli/commands/outdated.py
+++ b/src/apm_cli/commands/outdated.py
@@ -9,26 +9,15 @@ import logging
 import os
 import re
 import sys
-from dataclasses import dataclass, field
 from typing import List  # noqa: F401, UP035
 
 import click
 
+from ..deps.outdated_row import OutdatedRow
+
 logger = logging.getLogger(__name__)
 
 TAG_RE = re.compile(r"^v?\d+\.\d+\.\d+")
-
-
-@dataclass(frozen=True)
-class OutdatedRow:
-    """One row of ``apm outdated`` output."""
-
-    package: str
-    current: str
-    latest: str
-    status: str
-    extra_tags: list[str] = field(default_factory=list)
-    source: str = ""
 
 
 def _is_tag_ref(ref: str) -> bool:
@@ -158,13 +147,18 @@ def _check_marketplace_ref(dep, verbose):
     )
 
 
-def _check_one_dep(dep, downloader, verbose):
+def _check_one_dep(dep, downloader, verbose, registry_ctx=None):
     """Check a single dependency against remote refs.
 
     Returns an ``OutdatedRow`` instance.
 
     This function is safe to call from a thread pool.
     """
+    if dep.source == "registry":
+        from ..deps.registry.outdated import check_registry_locked_dep
+
+        return check_registry_locked_dep(dep, registry_ctx, verbose=verbose)
+
     # Try marketplace-based check first for marketplace-sourced deps
     marketplace_result = _check_marketplace_ref(dep, verbose)
     if marketplace_result is not None:
@@ -376,8 +370,16 @@ def outdated(global_, verbose, parallel_checks):
         logger.success("No remote dependencies to check")
         return
 
+    registry_ctx = None
+    if any(dep.source == "registry" for dep in checkable):
+        from ..deps.registry.outdated import load_registry_outdated_context
+
+        registry_ctx = load_registry_outdated_context(project_root, lockfile)
+
     # Check deps with progress feedback and optional parallelism
-    rows = _check_deps_with_progress(checkable, downloader, verbose, parallel_checks, logger)
+    rows = _check_deps_with_progress(
+        checkable, downloader, verbose, parallel_checks, logger, registry_ctx
+    )
 
     if not rows:
         logger.success("No remote dependencies to check")
@@ -410,7 +412,7 @@ def outdated(global_, verbose, parallel_checks):
         table.add_column("Current", style="white", min_width=10)
         table.add_column("Latest", style="white", min_width=10)
         table.add_column("Status", min_width=12)
-        table.add_column("Source", style="dim", min_width=14)
+        table.add_column("Source", style="dim", min_width=20, no_wrap=True)
 
         status_styles = {
             "up-to-date": "green",
@@ -456,7 +458,9 @@ def outdated(global_, verbose, parallel_checks):
         logger.progress("Some dependencies could not be checked (branch/commit refs)")
 
 
-def _check_deps_with_progress(checkable, downloader, verbose, parallel_checks, logger):
+def _check_deps_with_progress(
+    checkable, downloader, verbose, parallel_checks, logger, registry_ctx=None
+):
     """Check all deps with Rich progress bar and optional parallelism."""
     rows = []
     total = len(checkable)
@@ -485,6 +489,7 @@ def _check_deps_with_progress(checkable, downloader, verbose, parallel_checks, l
                     parallel_checks,
                     progress,
                     logger,
+                    registry_ctx,
                 )
             else:
                 task_id = progress.add_task(
@@ -494,7 +499,7 @@ def _check_deps_with_progress(checkable, downloader, verbose, parallel_checks, l
                 for dep in checkable:
                     short = dep.get_unique_key().split("/")[-1]
                     progress.update(task_id, description=f"Checking {short}")
-                    result = _check_one_dep(dep, downloader, verbose)
+                    result = _check_one_dep(dep, downloader, verbose, registry_ctx)
                     rows.append(result)
                     progress.advance(task_id)
     except ImportError:
@@ -506,15 +511,18 @@ def _check_deps_with_progress(checkable, downloader, verbose, parallel_checks, l
                 downloader,
                 verbose,
                 parallel_checks,
+                registry_ctx,
             )
         else:
             for dep in checkable:
-                rows.append(_check_one_dep(dep, downloader, verbose))
+                rows.append(_check_one_dep(dep, downloader, verbose, registry_ctx))
 
     return rows
 
 
-def _check_parallel(checkable, downloader, verbose, max_workers, progress, logger):
+def _check_parallel(
+    checkable, downloader, verbose, max_workers, progress, logger, registry_ctx=None
+):
     """Run checks in parallel with Rich progress display."""
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -531,7 +539,7 @@ def _check_parallel(checkable, downloader, verbose, max_workers, progress, logge
         for dep in checkable:
             short = dep.get_unique_key().split("/")[-1]
             task_id = progress.add_task(f"Checking {short}", total=None)
-            fut = executor.submit(_check_one_dep, dep, downloader, verbose)
+            fut = executor.submit(_check_one_dep, dep, downloader, verbose, registry_ctx)
             futures[fut] = (dep, task_id)
 
         for fut in as_completed(futures):
@@ -549,7 +557,7 @@ def _check_parallel(checkable, downloader, verbose, max_workers, progress, logge
     return [results[dep.get_unique_key()] for dep in checkable if dep.get_unique_key() in results]
 
 
-def _check_parallel_plain(checkable, downloader, verbose, max_workers):
+def _check_parallel_plain(checkable, downloader, verbose, max_workers, registry_ctx=None):
     """Run checks in parallel without Rich (plain fallback)."""
     from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -557,7 +565,8 @@ def _check_parallel_plain(checkable, downloader, verbose, max_workers):
     results = {}
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = {
-            executor.submit(_check_one_dep, dep, downloader, verbose): dep for dep in checkable
+            executor.submit(_check_one_dep, dep, downloader, verbose, registry_ctx): dep
+            for dep in checkable
         }
         for fut in as_completed(futures):
             dep = futures[fut]

--- a/src/apm_cli/commands/publish.py
+++ b/src/apm_cli/commands/publish.py
@@ -1,0 +1,255 @@
+"""``apm publish`` command — upload a packed tarball to a registry.
+
+Implements docs/proposals/registry-api.md §5.3:
+``PUT /v1/packages/{owner}/{repo}/versions/{version}``
+
+Gated behind the same ``registries`` experimental feature as the registry
+resolver (``apm experimental enable registries``).
+"""
+
+from __future__ import annotations
+
+import re
+import tarfile
+from pathlib import Path
+
+import click
+
+from ..core.command_logger import CommandLogger
+from ..deps.registry.feature_gate import require_package_registry_enabled
+
+_PUBLISH_HELP = """\
+Publish a package to a registry.
+
+Reads apm.yml for the package name/version, packs a flat registry archive
+(``apm.yml`` + ``.apm/`` at the tarball root — not ``apm pack`` plugin bundles),
+or uses a pre-built tarball via --tarball, then uploads to the registry via
+PUT /v1/packages/{owner}/{repo}/versions/{version}.
+
+Requires the 'registries' experimental feature:
+  apm experimental enable registries
+
+Examples:
+
+  # Auto-pack and publish to the only configured registry:
+  apm publish
+
+  # Choose a registry when multiple are configured:
+  apm publish --registry corp-main
+
+  # Publish a pre-built tarball (skip the pack step):
+  apm publish --tarball ./build/my-package-1.0.0.tar.gz
+
+  # Preview what would be uploaded:
+  apm publish --dry-run
+"""
+
+
+@click.command(name="publish", help=_PUBLISH_HELP)
+@click.option(
+    "--registry",
+    "registry_name",
+    default=None,
+    help="Registry name (from apm.yml 'registries:' block). Required when multiple registries are configured.",
+)
+@click.option(
+    "--package",
+    "package_id",
+    default=None,
+    metavar="OWNER/REPO",
+    help="Override owner/repo identity (default: parsed from 'source:' in apm.yml).",
+)
+@click.option(
+    "--tarball",
+    "tarball_path",
+    type=click.Path(exists=True, dir_okay=False),
+    default=None,
+    help="Path to a pre-built .tar.gz tarball. Skips the pack step.",
+)
+@click.option("--dry-run", is_flag=True, default=False, help="Preview without uploading.")
+@click.option("--verbose", "-v", is_flag=True, help="Show detailed output.")
+@click.pass_context
+def publish_cmd(ctx, registry_name, package_id, tarball_path, dry_run, verbose):
+    """Publish a package version to a registry."""
+    require_package_registry_enabled("apm publish")
+
+    logger = CommandLogger("publish", verbose=verbose, dry_run=dry_run)
+
+    # ------------------------------------------------------------------ apm.yml
+    project_root = Path.cwd()
+    apm_yml_path = project_root / "apm.yml"
+    if not apm_yml_path.exists():
+        raise click.ClickException("apm.yml not found in the current directory.")
+
+    from ..models.apm_package import APMPackage
+
+    try:
+        pkg = APMPackage.from_apm_yml(apm_yml_path)
+    except Exception as exc:
+        raise click.ClickException(f"Failed to read apm.yml: {exc}") from exc
+
+    version = pkg.version
+    if not version:
+        raise click.ClickException("apm.yml must declare a 'version:' field to publish.")
+
+    # ----------------------------------------------------------- owner/repo
+    owner, repo = _resolve_package_id(pkg, package_id)
+
+    # ----------------------------------------------------------- registry
+    registries: dict[str, str] = pkg.registries or {}
+    registry_name = _resolve_registry_name(registry_name, registries)
+    base_url = registries[registry_name]
+
+    # ----------------------------------------------------------- tarball
+    if tarball_path:
+        tarball = Path(tarball_path)
+    else:
+        tarball = _pack_archive(project_root, apm_yml_path, pkg, logger, verbose)
+
+    tarball_size = tarball.stat().st_size
+
+    # ----------------------------------------------------------- dry-run
+    if dry_run:
+        logger.info(f"Would publish {owner}/{repo}@{version} to {registry_name} ({base_url})")
+        logger.info(f"  tarball : {tarball}  ({tarball_size:,} bytes)")
+        logger.info("(dry-run — nothing uploaded)")
+        return
+
+    # ----------------------------------------------------------- upload
+    from ..deps.registry.auth import make_auth_context
+    from ..deps.registry.client import RegistryClient, RegistryError
+
+    auth = make_auth_context(registry_name)
+    client = RegistryClient(base_url, auth)
+
+    logger.info(f"Publishing {owner}/{repo}@{version} to {registry_name} …")
+
+    tarball_bytes = tarball.read_bytes()
+    try:
+        result = client.publish_version(owner, repo, version, tarball_bytes)
+    except RegistryError as exc:
+        _handle_publish_error(exc, owner, repo, version, registry_name, base_url)
+
+    logger.success(
+        f"Published {result.package}@{result.version}\n"
+        f"  digest      : {result.digest}\n"
+        f"  published_at: {result.published_at or '(not returned by server)'}\n"
+        f"  registry    : {base_url}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_package_id(pkg, override: str | None) -> tuple[str, str]:
+    """Return (owner, repo) from --package override or apm.yml source field."""
+    raw = override or pkg.source or ""
+    # strip https://github.com/ and similar prefixes
+    raw = re.sub(r"^https?://[^/]+/", "", raw).strip("/")
+    parts = [p for p in raw.split("/") if p]
+    if len(parts) >= 2:
+        return parts[-2], parts[-1]
+    raise click.UsageError(
+        "Cannot infer owner/repo for publish.\n"
+        "Either set 'source: owner/repo' in apm.yml, or pass --package owner/repo."
+    )
+
+
+def _resolve_registry_name(name: str | None, registries: dict[str, str]) -> str:
+    """Pick the registry name to publish to."""
+    if not registries:
+        raise click.ClickException(
+            "No registries configured in apm.yml.\n"
+            "Add a 'registries:' block — see 'apm experimental enable registries'."
+        )
+    if name:
+        if name not in registries:
+            available = ", ".join(sorted(registries))
+            raise click.ClickException(
+                f"Registry {name!r} not found in apm.yml. Available: {available}"
+            )
+        return name
+    if len(registries) == 1:
+        return next(iter(registries))
+    available = ", ".join(sorted(registries))
+    raise click.UsageError(
+        f"Multiple registries configured ({available}). Use --registry NAME to choose one."
+    )
+
+
+def _pack_archive(project_root: Path, apm_yml_path: Path, pkg, logger, verbose: bool) -> Path:
+    """Build a flat registry tarball (``apm.yml`` + ``.apm/`` at archive root).
+
+    Registry servers and ``apm install`` expect the APM source layout at the
+    tarball root — not the ``apm pack --archive`` plugin bundle wrapper
+    (``{name}-{version}/plugin.json``). See registry HTTP API §6.
+    """
+    apm_dir = project_root / ".apm"
+    if not apm_dir.is_dir():
+        raise click.ClickException(
+            "Registry publish requires a flat APM package (.apm/ directory).\n"
+            "Add .apm/ with your primitives (skills, instructions, etc.), "
+            "or pass --tarball with a pre-built flat archive."
+        )
+
+    archive_name = f"{pkg.name}-{pkg.version}.tar.gz"
+    dest = project_root / archive_name
+    if dest.exists():
+        dest.unlink()
+
+    if verbose:
+        logger.info(f"Packing flat registry archive -> {dest.name}")
+
+    def _tar_filter(ti: tarfile.TarInfo) -> tarfile.TarInfo | None:
+        # Skip macOS AppleDouble sidecars (._*) that break registry validation.
+        if any(part.startswith("._") for part in Path(ti.name).parts):
+            return None
+        if Path(ti.name).name == ".DS_Store":
+            return None
+        return ti
+
+    with tarfile.open(dest, mode="w:gz") as tar:
+        tar.add(apm_yml_path, arcname="apm.yml", filter=_tar_filter, recursive=False)
+        tar.add(apm_dir, arcname=".apm", filter=_tar_filter)
+
+    return dest
+
+
+def _handle_publish_error(
+    exc,
+    owner: str,
+    repo: str,
+    version: str,
+    registry_name: str,
+    base_url: str,
+) -> None:
+    """Translate RegistryError HTTP statuses into user-friendly messages."""
+    status = exc.status
+    detail = exc.problem.get("detail", "") if exc.problem else ""
+
+    if status == 409:
+        raise click.ClickException(
+            f"Version {version!r} of {owner}/{repo} already exists in "
+            f"{registry_name!r} and is immutable. Bump the version in apm.yml."
+        )
+    if status == 422:
+        msg = "Registry rejected the package (validation failed)"
+        if detail:
+            msg += f": {detail}"
+        raise click.ClickException(msg)
+    if status == 403:
+        from ..deps.registry.auth import registry_token_env_var
+
+        raise click.ClickException(
+            f"Forbidden — your token does not have publish permission for "
+            f"{owner}/{repo} in {registry_name!r}.\n"
+            f"Check the token configured via {registry_token_env_var(registry_name)}."
+        )
+    if status == 401:
+        from ..deps.registry.auth import remediation_message
+
+        raise click.ClickException(remediation_message(base_url))
+
+    raise click.ClickException(str(exc))

--- a/src/apm_cli/config.py
+++ b/src/apm_cli/config.py
@@ -193,6 +193,111 @@ def unset_copilot_cowork_skills_dir() -> None:
     _invalidate_config_cache()
 
 
+def _get_registries_section() -> dict:
+    """Return the ``registries`` section from config.json as a dict."""
+    regs = get_config().get("registries", {})
+    return regs if isinstance(regs, dict) else {}
+
+
+def get_registry_config(name: str) -> "dict | None":
+    """Return the config.json entry for registry *name*, or None."""
+    entry = _get_registries_section().get(name)
+    return entry if isinstance(entry, dict) else None
+
+
+def set_registry_url(name: str, url: str) -> None:
+    """Write registry.<name>.url to config.json."""
+    regs = dict(_get_registries_section())
+    entry = dict(regs.get(name) or {})
+    entry["url"] = url
+    regs[name] = entry
+    update_config({"registries": regs})
+
+
+def set_registry_token(name: str, token: str) -> None:
+    """Write registry.<name>.token to config.json."""
+    regs = dict(_get_registries_section())
+    entry = dict(regs.get(name) or {})
+    entry["token"] = token
+    regs[name] = entry
+    update_config({"registries": regs})
+
+
+def unset_registry_url(name: str) -> None:
+    """Remove registry.<name>.url from config.json."""
+    regs = dict(_get_registries_section())
+    entry = dict(regs.get(name) or {})
+    entry.pop("url", None)
+    if entry:
+        regs[name] = entry
+    else:
+        regs.pop(name, None)
+    update_config({"registries": regs})
+
+
+def unset_registry_token(name: str) -> None:
+    """Remove registry.<name>.token from config.json."""
+    regs = dict(_get_registries_section())
+    entry = dict(regs.get(name) or {})
+    entry.pop("token", None)
+    if entry:
+        regs[name] = entry
+    else:
+        regs.pop(name, None)
+    update_config({"registries": regs})
+
+
+def unset_registry(name: str) -> None:
+    """Remove the entire registry.<name> entry from config.json."""
+    regs = dict(_get_registries_section())
+    if name in regs:
+        del regs[name]
+        update_config({"registries": regs})
+
+
+def get_config_json_default_registry() -> str | None:
+    """Return the registry name marked ``default: true`` in config.json."""
+    found: str | None = None
+    for name, body in _get_registries_section().items():
+        if not isinstance(name, str) or not name.strip():
+            continue
+        if not isinstance(body, dict):
+            continue
+        if body.get("default") is True:
+            found = name.strip()
+    return found
+
+
+def set_registry_default(name: str, is_default: bool) -> None:
+    """Mark *name* as the user-scoped default registry in config.json."""
+    regs = dict(_get_registries_section())
+    if is_default:
+        for reg_name, body in list(regs.items()):
+            if not isinstance(body, dict):
+                continue
+            if reg_name == name:
+                continue
+            if body.pop("default", None) is not None:
+                regs[reg_name] = body if body else regs[reg_name]
+        entry = dict(regs.get(name) or {})
+        entry["default"] = True
+        regs[name] = entry
+    else:
+        entry = dict(regs.get(name) or {})
+        entry.pop("default", None)
+        if entry:
+            regs[name] = entry
+        else:
+            regs.pop(name, None)
+    update_config({"registries": regs})
+
+
+def is_registry_default(name: str) -> bool:
+    """Return whether *name* is marked as the config.json default registry."""
+    cfg = get_registry_config(name)
+    return bool(cfg and cfg.get("default") is True)
+
+
 def get_apm_temp_dir() -> str | None:
     """Return the effective temporary directory for APM operations.
 

--- a/src/apm_cli/core/experimental.py
+++ b/src/apm_cli/core/experimental.py
@@ -82,6 +82,18 @@ FLAGS: dict[str, ExperimentalFlag] = {
             "Workflows tab."
         ),
     ),
+    "marketplace_authoring": ExperimentalFlag(
+        name="marketplace_authoring",
+        description="Enable marketplace authoring commands (init, build, publish, etc.).",
+        default=False,
+        hint="Run 'apm marketplace --help' to see available commands.",
+    ),
+    "registries": ExperimentalFlag(
+        name="registries",
+        description="Enable REST-based APM package registries in apm.yml.",
+        default=False,
+        hint=("Use registries: in apm.yml. See https://microsoft.github.io/apm/guides/registries/"),
+    ),
 }
 
 

--- a/src/apm_cli/deps/git_reference_resolver.py
+++ b/src/apm_cli/deps/git_reference_resolver.py
@@ -316,6 +316,40 @@ class GitReferenceResolver:
                 ref_name=effective_ref,
             )
 
+        # Semver range resolution: enumerate remote tags, pick the highest match.
+        # Non-semver refs fall through to the existing branch/commit/clone path.
+        if ref:
+            from ..deps.registry.semver import is_semver_range, pick_best
+
+            if is_semver_range(ref):
+                remote_refs = self.list_remote_refs(dep_ref)
+                # Build version-string → (tag_name, sha) map.
+                # Strip the common 'v' prefix (e.g. 'v1.2.3' → '1.2.3').
+                candidates: dict[str, tuple[str, str]] = {}
+                for rr in remote_refs:
+                    if rr.ref_type != GitReferenceType.TAG:
+                        continue
+                    raw_tag = rr.name
+                    version_str = raw_tag[1:] if raw_tag.startswith("v") else raw_tag
+                    from ..marketplace.semver import parse_semver
+
+                    if parse_semver(version_str) is not None:
+                        candidates[version_str] = (raw_tag, rr.commit_sha)
+                best_version = pick_best(ref, list(candidates.keys()))
+                if best_version is None:
+                    available = sorted(candidates.keys())[:10]
+                    raise ValueError(
+                        f"No git tag in {dep_ref.repo_url!r} satisfies semver range {ref!r}. "
+                        f"Available semver tags: {available}"
+                    )
+                best_tag, best_sha = candidates[best_version]
+                return ResolvedReference(
+                    original_ref=ref,
+                    ref_type=GitReferenceType.TAG,
+                    ref_name=best_tag,
+                    resolved_commit=best_sha,
+                )
+
         is_likely_commit = bool(ref) and re.match(r"^[a-f0-9]{7,40}$", ref.lower()) is not None
 
         temp_dir = None

--- a/src/apm_cli/deps/installed_package.py
+++ b/src/apm_cli/deps/installed_package.py
@@ -9,9 +9,10 @@ field self-documenting.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional  # noqa: F401
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from apm_cli.deps.registry.resolver import RegistryResolution
     from apm_cli.deps.registry_proxy import RegistryConfig
     from apm_cli.models.dependency.reference import DependencyReference
 
@@ -44,6 +45,13 @@ class InstalledPackage:
         when this package was downloaded, or ``None`` for direct VCS installs.
         When present, the lockfile stores the proxy host (FQDN) and prefix so
         that subsequent installs replay through the same proxy.
+    registry_resolution:
+        The :class:`~apm_cli.deps.registry.resolver.RegistryResolution` produced
+        by the dedicated-registry resolver, or ``None`` for git/local/proxy
+        installs. When present, the lockfile records ``resolved_url`` /
+        ``resolved_hash`` / ``version`` from it so re-installs verify against
+        the same content (design §6.1). Distinct concept from ``registry_config``
+        (Artifactory VCS proxy).
     """
 
     dep_ref: DependencyReference
@@ -52,3 +60,4 @@ class InstalledPackage:
     resolved_by: str | None
     is_dev: bool = False
     registry_config: RegistryConfig | None = None
+    registry_resolution: RegistryResolution | None = None

--- a/src/apm_cli/deps/lockfile.py
+++ b/src/apm_cli/deps/lockfile.py
@@ -3,11 +3,13 @@
 Provides deterministic, reproducible installs by capturing exact resolved versions.
 """
 
+from __future__ import annotations
+
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional  # noqa: F401, UP035
+from typing import Any
 
 import yaml
 
@@ -45,6 +47,13 @@ class LockedDependency:
     is_insecure: bool = False  # True when the locked source was http://
     allow_insecure: bool = False  # True when the manifest explicitly allowed HTTP
     skill_subset: list[str] = field(default_factory=list)  # Sorted skill names for SKILL_BUNDLE
+
+    # Registry resolver fields (design §6.1).
+    # Populated when source == "registry"; absent otherwise. resolved_hash is
+    # the sole non-negotiable trust anchor on every install — bytes are fetched
+    # from resolved_url and re-verified against this digest.
+    resolved_url: str | None = None
+    resolved_hash: str | None = None
 
     def get_unique_key(self) -> str:
         """Returns unique key for this dependency."""
@@ -101,10 +110,14 @@ class LockedDependency:
             result["allow_insecure"] = True
         if self.skill_subset:
             result["skill_subset"] = sorted(self.skill_subset)
+        if self.resolved_url:
+            result["resolved_url"] = self.resolved_url
+        if self.resolved_hash:
+            result["resolved_hash"] = self.resolved_hash
         return result
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "LockedDependency":
+    def from_dict(cls, data: dict[str, Any]) -> LockedDependency:
         """Deserialize from dict.
 
         Handles backwards compatibility:
@@ -155,6 +168,8 @@ class LockedDependency:
             is_insecure=data.get("is_insecure", False),
             allow_insecure=data.get("allow_insecure", False),
             skill_subset=list(data.get("skill_subset") or []),
+            resolved_url=data.get("resolved_url"),
+            resolved_hash=data.get("resolved_hash"),
         )
 
     @classmethod
@@ -166,7 +181,8 @@ class LockedDependency:
         resolved_by: str | None,
         is_dev: bool = False,
         registry_config=None,
-    ) -> "LockedDependency":
+        registry_resolution=None,
+    ) -> LockedDependency:
         """Create from a DependencyReference with resolution info.
 
         Args:
@@ -176,10 +192,15 @@ class LockedDependency:
             resolved_by: Parent repo URL, or ``None`` for direct dependencies.
             is_dev: Whether this is a dev-only dependency.
             registry_config: Optional :class:`~apm_cli.deps.registry_proxy.RegistryConfig`
-                used for this download.  When provided, ``host`` is set to the
-                pure FQDN (e.g. ``"art.example.com"``) and ``registry_prefix``
-                is set to the URL path prefix (e.g. ``"artifactory/github"``),
-                ensuring correct auth routing on subsequent installs.
+                used for this download (Artifactory VCS proxy — pre-existing
+                concept, distinct from the new dedicated-registry resolver).
+                When provided, ``host`` is set to the pure FQDN and
+                ``registry_prefix`` to the URL path prefix.
+            registry_resolution: Optional :class:`~apm_cli.deps.registry.resolver.RegistryResolution`
+                produced by the dedicated-registry resolver. When provided,
+                ``source`` is set to ``"registry"`` and ``resolved_url`` /
+                ``resolved_hash`` / ``version`` are populated from it (the
+                trust anchor for re-installs per design §6.1).
         """
         if registry_config is not None:
             host = registry_config.host
@@ -187,6 +208,16 @@ class LockedDependency:
         else:
             host = dep_ref.host
             registry_prefix = None
+
+        # Determine source: explicit registry resolution wins; else local;
+        # else inherit from dep_ref.source (which may be "git" or None).
+        if registry_resolution is not None:
+            source = "registry"
+        elif dep_ref.is_local:
+            source = "local"
+        else:
+            source = None
+
         return cls(
             repo_url=dep_ref.repo_url,
             host=host,
@@ -194,11 +225,12 @@ class LockedDependency:
             registry_prefix=registry_prefix,
             resolved_commit=resolved_commit,
             resolved_ref=dep_ref.reference,
+            version=(registry_resolution.version if registry_resolution is not None else None),
             virtual_path=dep_ref.virtual_path,
             is_virtual=dep_ref.is_virtual,
             depth=depth,
             resolved_by=resolved_by,
-            source="local" if dep_ref.is_local else None,
+            source=source,
             local_path=dep_ref.local_path if dep_ref.is_local else None,
             is_dev=is_dev,
             is_insecure=dep_ref.is_insecure,
@@ -206,15 +238,33 @@ class LockedDependency:
             skill_subset=sorted(dep_ref.skill_subset)
             if isinstance(getattr(dep_ref, "skill_subset", None), list)
             else [],
+            resolved_url=(
+                registry_resolution.resolved_url if registry_resolution is not None else None
+            ),
+            resolved_hash=(
+                registry_resolution.resolved_hash if registry_resolution is not None else None
+            ),
         )
 
     def to_dependency_ref(self) -> DependencyReference:
-        """Reconstruct a DependencyReference from this locked dependency."""
+        """Reconstruct a DependencyReference from this locked dependency.
+
+        Registry-sourced deps come back with ``source="registry"`` so the
+        install pipeline routes them to the registry resolver. The exact
+        locked version is in ``reference`` (the registry resolver still calls
+        /versions and the hash-check on download enforces the lockfile's
+        intent).
+        """
+        # Registry deps: prefer the locked exact version over resolved_ref so
+        # the resolver picks up the exact-version constraint, not the original
+        # range (e.g. ``^1.2.0`` -> ``1.5.3``).
+        is_registry = self.source == "registry"
+        ref = self.version if (is_registry and self.version) else self.resolved_ref
         return DependencyReference(
             repo_url=self.repo_url,
             host=self.host,
             port=self.port,
-            reference=self.resolved_ref,
+            reference=ref,
             virtual_path=self.virtual_path,
             is_virtual=self.is_virtual,
             artifactory_prefix=self.registry_prefix,
@@ -222,6 +272,7 @@ class LockedDependency:
             local_path=self.local_path,
             is_insecure=self.is_insecure,
             allow_insecure=self.allow_insecure,
+            source=self.source,
         )
 
 
@@ -239,8 +290,15 @@ class LockFile:
     local_deployed_file_hashes: dict[str, str] = field(default_factory=dict)
 
     def add_dependency(self, dep: LockedDependency) -> None:
-        """Add a dependency to the lock file."""
+        """Add a dependency to the lock file.
+
+        Adding a registry-sourced dep promotes ``lockfile_version`` to
+        ``"2"`` immediately, keeping the in-memory state consistent with
+        what ``to_yaml()`` would emit (design §6.1).
+        """
         self.dependencies[dep.get_unique_key()] = dep
+        if dep.source == "registry" and self.lockfile_version == "1":
+            self.lockfile_version = "2"
 
     def get_dependency(self, key: str) -> LockedDependency | None:
         """Get a dependency by its unique key."""
@@ -258,8 +316,26 @@ class LockFile:
         """Get all dependencies excluding the virtual self-entry."""
         return [d for d in self.get_all_dependencies() if d.local_path != "."]
 
+    def _needs_v2(self) -> bool:
+        """Whether the resolved graph requires lockfile schema v2.
+
+        Per design §6.1 (and invariant §2.1.4): bump opportunistically — only
+        when at least one dep is sourced from a dedicated registry. A project
+        that never opts into the registry keeps v1 forever, even on a newer
+        client.
+        """
+        return any(d.source == "registry" for d in self.dependencies.values())
+
     def to_yaml(self) -> str:
         """Serialize to YAML string."""
+        # Opportunistic v1<->v2 derivation (design §6.1, invariant §2.1.4):
+        # the lockfile_version field always reflects current content at
+        # emit time. ``add_dependency`` bumps to "2" eagerly, but callers
+        # that mutate ``self.dependencies`` directly or remove the last
+        # registry dep need the field re-derived here so the on-disk
+        # version is correct in both directions.
+        self.lockfile_version = "2" if self._needs_v2() else "1"
+        emit_version = self.lockfile_version
         # The synthesized self-entry (key ".") is an in-memory normalization
         # of the flat local_deployed_files / local_deployed_file_hashes
         # fields. It must not be written back into the dependencies list,
@@ -267,7 +343,7 @@ class LockFile:
         _self_dep = self.dependencies.pop(_SELF_KEY, None)
         try:
             data: dict[str, Any] = {
-                "lockfile_version": self.lockfile_version,
+                "lockfile_version": emit_version,
                 "generated_at": self.generated_at,
             }
             if self.apm_version:
@@ -291,7 +367,7 @@ class LockFile:
                 self.dependencies[_SELF_KEY] = _self_dep
 
     @classmethod
-    def from_yaml(cls, yaml_str: str) -> "LockFile":
+    def from_yaml(cls, yaml_str: str) -> LockFile:
         """Deserialize from YAML string."""
         data = yaml.safe_load(yaml_str)
         if not data:
@@ -329,7 +405,7 @@ class LockFile:
         path.write_text(self.to_yaml(), encoding="utf-8")
 
     @classmethod
-    def read(cls, path: Path) -> Optional["LockFile"]:
+    def read(cls, path: Path) -> LockFile | None:
         """Read lock file from disk. Returns None if not exists or corrupt."""
         if not path.exists():
             return None
@@ -339,7 +415,7 @@ class LockFile:
             return None
 
     @classmethod
-    def load_or_create(cls, path: Path) -> "LockFile":
+    def load_or_create(cls, path: Path) -> LockFile:
         """Load existing lock file or create a new one."""
         return cls.read(path) or cls()
 
@@ -348,7 +424,7 @@ class LockFile:
         cls,
         installed_packages,
         dependency_graph,
-    ) -> "LockFile":
+    ) -> LockFile:
         """Create a lock file from installed packages.
 
         Args:
@@ -372,6 +448,7 @@ class LockFile:
         lock = cls(apm_version=apm_version)
 
         for entry in installed_packages:
+            registry_resolution = None
             if isinstance(entry, InstalledPackage):
                 dep_ref = entry.dep_ref
                 resolved_commit = entry.resolved_commit
@@ -379,6 +456,7 @@ class LockFile:
                 resolved_by = entry.resolved_by
                 is_dev = entry.is_dev
                 registry_config = getattr(entry, "registry_config", None)
+                registry_resolution = getattr(entry, "registry_resolution", None)
             elif len(entry) >= 5:
                 dep_ref, resolved_commit, depth, resolved_by, is_dev = entry[:5]
                 registry_config = None
@@ -394,6 +472,7 @@ class LockFile:
                 resolved_by=resolved_by,
                 is_dev=is_dev,
                 registry_config=registry_config,
+                registry_resolution=registry_resolution,
             )
             lock.add_dependency(locked_dep)
 
@@ -434,7 +513,7 @@ class LockFile:
         """Save lock file to disk (alias for write)."""
         self.write(path)
 
-    def is_semantically_equivalent(self, other: "LockFile") -> bool:
+    def is_semantically_equivalent(self, other: LockFile) -> bool:
         """Return True if *other* has the same deps, MCP servers, and configs.
 
         Ignores ``generated_at`` and ``apm_version`` so that a no-change

--- a/src/apm_cli/deps/outdated_row.py
+++ b/src/apm_cli/deps/outdated_row.py
@@ -1,0 +1,17 @@
+"""Shared row type for ``apm outdated`` results."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class OutdatedRow:
+    """One row of ``apm outdated`` output."""
+
+    package: str
+    current: str
+    latest: str
+    status: str
+    extra_tags: list[str] = field(default_factory=list)
+    source: str = ""

--- a/src/apm_cli/deps/registry/__init__.py
+++ b/src/apm_cli/deps/registry/__init__.py
@@ -1,0 +1,62 @@
+"""Dedicated registry API resolver.
+
+Additive resolver mode that fetches APM packages over a REST registry contract
+(see docs/proposals/registry-api.md). Sits alongside the existing Git resolver;
+opt-in via ``apm experimental enable registries`` before using the
+top-level ``registries:`` block in ``apm.yml``.
+
+This package is intentionally separate from ``src/apm_cli/registry/`` (the MCP
+registry client) — the two address different concepts and must not be confused.
+"""
+
+from .auth import (
+    RegistryAuthContext,
+    make_auth_context,
+    registry_token_env_var,
+    resolve_registry_basic,
+    resolve_registry_token,
+)
+from .client import RegistryClient, RegistryError, VersionEntry
+from .config_loader import load_merged_registries, resolve_effective_registries
+from .extractor import (
+    extract_archive,
+    extract_tarball,
+    extract_zip,
+    verify_sha256,
+)
+from .feature_gate import (
+    DISPLAY_NAME,
+    ENABLE_COMMAND,
+    FLAG_NAME,
+    PackageRegistryFeatureDisabledError,
+    is_package_registry_enabled,
+    require_package_registry_enabled,
+)
+from .resolver import RegistryPackageResolver
+from .semver import is_semver_range, match_version
+
+__all__ = [
+    "DISPLAY_NAME",
+    "ENABLE_COMMAND",
+    "FLAG_NAME",
+    "PackageRegistryFeatureDisabledError",
+    "RegistryAuthContext",
+    "RegistryClient",
+    "RegistryError",
+    "RegistryPackageResolver",
+    "VersionEntry",
+    "extract_archive",
+    "extract_tarball",
+    "extract_zip",
+    "is_package_registry_enabled",
+    "is_semver_range",
+    "load_merged_registries",
+    "make_auth_context",
+    "match_version",
+    "registry_token_env_var",
+    "require_package_registry_enabled",
+    "resolve_effective_registries",
+    "resolve_registry_basic",
+    "resolve_registry_token",
+    "verify_sha256",
+]

--- a/src/apm_cli/deps/registry/auth.py
+++ b/src/apm_cli/deps/registry/auth.py
@@ -1,0 +1,235 @@
+"""Registry credential resolution.
+
+Per docs/proposals/registry-api.md §7.1, the primary convention is
+``APM_REGISTRY_TOKEN_{NAME}`` (HTTP Bearer). A second convention covers
+HTTP Basic auth — required by enterprise registries like JFrog Artifactory
+that don't expose Bearer-token issuance via Basic-auth themselves:
+
+    APM_REGISTRY_TOKEN_{NAME}  -> Authorization: Bearer <token>
+    APM_REGISTRY_USER_{NAME}   ┐
+    APM_REGISTRY_PASS_{NAME}   ┴ -> Authorization: Basic <base64(user:pass)>
+
+If both are set, ``TOKEN_*`` wins. ``{NAME}`` is the uppercased registry
+name with ``-`` and ``.`` mapped to ``_``.
+
+URL-based lookup (§6.2) is also implemented here: a user who clones a project
+whose lockfile references a registry URL they've never configured needs to
+install. The chain is::
+
+    resolved_url ─→ registry name (apm.yml registries: block) ─→ env-var creds
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import urllib.parse
+from dataclasses import dataclass, replace
+from typing import Any
+
+from ...models.dependency.reference import DependencyReference
+
+
+@dataclass(frozen=True)
+class RegistryAuthContext:
+    """Auth payload for a single registry HTTP call.
+
+    All-empty fields mean "anonymous" — the first attempt when no env vars
+    are set (§6.2 rule 2). The client tries anonymously and only surfaces
+    the remediation message on 401/403.
+
+    Bearer beats Basic: when both ``token`` and ``username``/``password``
+    are populated, the ``Authorization`` header is the Bearer form.
+    """
+
+    registry_name: str | None
+    token: str | None
+    # HTTP Basic auth (alternative to Bearer; required for some enterprise
+    # registries — JFrog Artifactory's /access endpoints, for example).
+    username: str | None = None
+    password: str | None = None
+
+    def auth_header(self) -> str | None:
+        """Return the ``Authorization`` header value, or ``None`` when anonymous."""
+        if self.token:
+            return f"Bearer {self.token}"
+        if self.username is not None and self.password is not None:
+            credentials = f"{self.username}:{self.password}".encode()
+            return f"Basic {base64.b64encode(credentials).decode('ascii')}"
+        return None
+
+
+def _sanitized(registry_name: str) -> str:
+    return registry_name.upper().replace("-", "_").replace(".", "_")
+
+
+def registry_token_env_var(registry_name: str) -> str:
+    """Return the ``APM_REGISTRY_TOKEN_*`` env var name for *registry_name*.
+
+    ``corp-main`` -> ``APM_REGISTRY_TOKEN_CORP_MAIN``
+    ``corp.main`` -> ``APM_REGISTRY_TOKEN_CORP_MAIN``
+    """
+    return f"APM_REGISTRY_TOKEN_{_sanitized(registry_name)}"
+
+
+def _env_key(registry_name: str) -> str:
+    """Bearer-token env-var key per §7.1."""
+    return registry_token_env_var(registry_name)
+
+
+def _env_key_user(registry_name: str) -> str:
+    """HTTP Basic auth username env-var key.
+
+    ``corp-main`` -> ``APM_REGISTRY_USER_CORP_MAIN``
+    """
+    return f"APM_REGISTRY_USER_{_sanitized(registry_name)}"
+
+
+def _env_key_pass(registry_name: str) -> str:
+    """HTTP Basic auth password env-var key.
+
+    ``corp-main`` -> ``APM_REGISTRY_PASS_CORP_MAIN``
+    """
+    return f"APM_REGISTRY_PASS_{_sanitized(registry_name)}"
+
+
+def resolve_registry_token(registry_name: str) -> str | None:
+    """Look up the Bearer token for *registry_name*: env var first, then config.json."""
+    token = os.environ.get(_env_key(registry_name))
+    if token:
+        return token
+    from ...config import get_registry_config
+
+    cfg = get_registry_config(registry_name)
+    if cfg and isinstance(cfg.get("token"), str) and cfg["token"]:
+        return cfg["token"]
+    return None
+
+
+def resolve_registry_basic(
+    registry_name: str,
+) -> tuple[str | None, str | None]:
+    """Look up the (username, password) pair for HTTP Basic auth.
+
+    Returns ``(None, None)`` when either is missing — the caller treats this
+    as "no Basic auth available" and falls back to whatever else applies.
+    """
+    user = os.environ.get(_env_key_user(registry_name))
+    pwd = os.environ.get(_env_key_pass(registry_name))
+    if user is None or pwd is None:
+        return None, None
+    return user, pwd
+
+
+def make_auth_context(registry_name: str) -> RegistryAuthContext:
+    """Build a ``RegistryAuthContext`` from env vars for *registry_name*.
+
+    Reads both Bearer and Basic env vars; both can populate the context but
+    Bearer wins at the header-rendering level (see ``auth_header``).
+    """
+    token = resolve_registry_token(registry_name)
+    user, pwd = resolve_registry_basic(registry_name)
+    return RegistryAuthContext(
+        registry_name=registry_name,
+        token=token,
+        username=user,
+        password=pwd,
+    )
+
+
+def _normalize_url_prefix(url: str) -> str:
+    """Normalize a URL for prefix matching.
+
+    Strips trailing slashes; lowercases the scheme + host. Path segments stay
+    case-sensitive (registries running on case-sensitive filesystems may treat
+    ``/Foo`` and ``/foo`` distinctly).
+    """
+    parsed = urllib.parse.urlparse(url)
+    scheme = parsed.scheme.lower()
+    host = (parsed.hostname or "").lower()
+    port = f":{parsed.port}" if parsed.port else ""
+    path = parsed.path.rstrip("/")
+    return f"{scheme}://{host}{port}{path}"
+
+
+def lookup_name_for_url(target_url: str, registries: dict[str, str]) -> str | None:
+    """Find which configured registry owns *target_url* by URL prefix.
+
+    *registries* is the ``name -> url`` mapping from apm.yml's ``registries:``
+    block (or merged with user config). Returns the longest-prefix-matching
+    name, or ``None`` if no registered URL is a prefix of *target_url*.
+
+    The longest-prefix rule is what lets a user safely register both
+    ``https://corp/apm`` and ``https://corp/apm/team-a`` without one shadowing
+    the other.
+    """
+    if not target_url or not registries:
+        return None
+    normalized_target = _normalize_url_prefix(target_url)
+    best_name: str | None = None
+    best_len = -1
+    for name, url in registries.items():
+        if not isinstance(url, str) or not url:
+            continue
+        prefix = _normalize_url_prefix(url)
+        if normalized_target == prefix or normalized_target.startswith(prefix + "/"):
+            if len(prefix) > best_len:
+                best_name = name
+                best_len = len(prefix)
+    return best_name
+
+
+def dependency_ref_with_registry_name_from_lockfile(
+    dep_ref: DependencyReference,
+    registries_map: dict[str, str],
+    *,
+    locked_dep: Any = None,
+    existing_lockfile: Any = None,
+) -> DependencyReference:
+    """Set ``registry_name`` from a lockfile URL when missing (clone / reinstall).
+
+    ``locked_dep`` wins when provided (fresh-install path); otherwise the row
+    is loaded from ``existing_lockfile`` (resolve-phase callback path).
+    """
+    if dep_ref.registry_name is not None or not registries_map:
+        return dep_ref
+    if getattr(dep_ref, "source", None) != "registry":
+        return dep_ref
+
+    locked = locked_dep
+    if locked is None and existing_lockfile is not None:
+        locked = existing_lockfile.get_dependency(dep_ref.get_unique_key())
+
+    resolved_url = getattr(locked, "resolved_url", None) if locked else None
+    if not resolved_url:
+        return dep_ref
+
+    name = lookup_name_for_url(resolved_url, registries_map)
+    if not name:
+        return dep_ref
+    return replace(dep_ref, registry_name=name)
+
+
+def resolve_for_url(target_url: str, registries: dict[str, str]) -> RegistryAuthContext:
+    """End-to-end auth resolution for a lockfile-recorded URL.
+
+    Looks up which registered name owns *target_url* and reads its env-var
+    credentials (Bearer + Basic) for that name. If no registered URL
+    matches, returns an anonymous context — the caller will try anonymous
+    fetch and surface the §6.2 remediation message on 401/403.
+    """
+    name = lookup_name_for_url(target_url, registries)
+    if name is None:
+        return RegistryAuthContext(registry_name=None, token=None)
+    return make_auth_context(name)
+
+
+def remediation_message(target_url: str) -> str:
+    """The standard 401/403 remediation per §6.2 rule 3."""
+    return (
+        f"error: this project depends on a package from\n"
+        f"  {target_url}\n"
+        f"but no credentials for that registry are configured on this machine.\n"
+        f"Add a registry entry whose URL matches (in apm.yml or ~/.apm/config.json)\n"
+        f"and set APM_REGISTRY_TOKEN_<NAME>=<token> in your environment."
+    )

--- a/src/apm_cli/deps/registry/client.py
+++ b/src/apm_cli/deps/registry/client.py
@@ -1,0 +1,367 @@
+"""HTTP client for the dedicated registry API.
+
+Implements docs/proposals/registry-api.md §5:
+
+- ``GET /v1/packages/{owner}/{repo}/versions`` — list versions
+- ``GET /v1/packages/{owner}/{repo}/versions/{version}/download`` — fetch archive
+
+- ``PUT /v1/packages/{owner}/{repo}/versions/{version}`` — publish
+
+Design notes:
+
+- All endpoints use ``Authorization: Bearer <token>`` when an env-var token is
+  configured for the registry. Anonymous fetch is the fallback (§6.2 rule 2).
+- Errors surface as ``RegistryError`` carrying the HTTP status and a parsed
+  RFC 7807 Problem Details body when present. The install path turns 401/403
+  into the §6.2 remediation message at a higher level.
+- No HTTP cache layer — ``Cache-Control: max-age=60`` from the server is
+  advisory only. In-process memoization can be added later.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.parse
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+
+from .auth import RegistryAuthContext
+
+
+class RegistryError(Exception):
+    """A registry HTTP call failed.
+
+    ``status`` is the HTTP status code (or ``None`` for transport-level
+    failures); ``problem`` is the parsed RFC 7807 body when available.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status: int | None = None,
+        problem: dict[str, Any] | None = None,
+        url: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status = status
+        self.problem = problem or {}
+        self.url = url
+
+
+@dataclass(frozen=True)
+class VersionEntry:
+    """One row from ``GET /v1/packages/.../versions``."""
+
+    version: str
+    digest: str
+    published_at: str
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> VersionEntry:
+        version = payload.get("version")
+        digest = payload.get("digest")
+        if not isinstance(version, str) or not version:
+            raise RegistryError(f"malformed version entry (missing 'version'): {payload!r}")
+        if not isinstance(digest, str) or not digest:
+            raise RegistryError(f"malformed version entry (missing 'digest') for {version!r}")
+        # ``published_at`` is the spec-canonical key (snake_case throughout
+        # — see registry-http-api.md §3.1). The client is intentionally
+        # strict: a server that emits ``publishedAt`` (camelCase) is non-
+        # conformant. Accepting both would mask spec drift; reject silently
+        # by reading only the canonical name.
+        published = payload.get("published_at")
+        if not isinstance(published, str) or not published:
+            raise RegistryError(f"malformed version entry (missing 'published_at') for {version!r}")
+        return cls(
+            version=version,
+            digest=digest,
+            published_at=published,
+        )
+
+
+@dataclass(frozen=True)
+class PublishResult:
+    """Response from ``PUT /v1/packages/.../versions/{version}``."""
+
+    package: str  # "owner/repo"
+    version: str
+    digest: str  # "sha256:abc123..."
+    published_at: str | None = None
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> PublishResult:
+        package = payload.get("package")
+        version = payload.get("version")
+        digest = payload.get("digest")
+        if not isinstance(package, str) or not package:
+            raise RegistryError(f"malformed publish response (missing 'package'): {payload!r}")
+        if not isinstance(version, str) or not version:
+            raise RegistryError(f"malformed publish response (missing 'version'): {payload!r}")
+        if not isinstance(digest, str) or not digest:
+            raise RegistryError(f"malformed publish response (missing 'digest'): {payload!r}")
+        published = payload.get("published_at")
+        return cls(
+            package=package,
+            version=version,
+            digest=digest,
+            published_at=published if isinstance(published, str) else None,
+        )
+
+
+_DEFAULT_TIMEOUT = (10, 60)  # (connect, read) seconds
+
+
+class RegistryClient:
+    """Minimal HTTP client for the registry API.
+
+    One client per registry URL. Stateless aside from the auth context — safe
+    to instantiate per install or share for an entire resolution graph.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        auth: RegistryAuthContext,
+        *,
+        session: requests.Session | None = None,
+        timeout: tuple[float, float] | None = None,
+    ) -> None:
+        if not base_url:
+            raise ValueError("base_url is required")
+        # Strip trailing slash so we can join cleanly.
+        self._base_url = base_url.rstrip("/")
+        self._auth = auth
+        self._session = session or requests.Session()
+        self._timeout = timeout or _DEFAULT_TIMEOUT
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+    def _headers(self, accept: str = "application/json") -> dict[str, str]:
+        headers = {"Accept": accept}
+        auth_header = self._auth.auth_header()
+        if auth_header:
+            headers["Authorization"] = auth_header
+        return headers
+
+    def _url(self, path: str) -> str:
+        if not path.startswith("/"):
+            path = "/" + path
+        return f"{self._base_url}{path}"
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        accept: str = "application/json",
+        stream: bool = False,
+    ) -> requests.Response:
+        url = self._url(path)
+        try:
+            # Pass ``url`` as a keyword so test doubles can inspect it without
+            # depending on positional-argument ordering.
+            response = self._session.request(
+                method,
+                url=url,
+                headers=self._headers(accept=accept),
+                timeout=self._timeout,
+                stream=stream,
+            )
+        except requests.RequestException as exc:
+            raise RegistryError(
+                f"transport error talking to registry: {exc}",
+                url=url,
+            ) from exc
+        if response.status_code >= 400:
+            problem: dict[str, Any] = {}
+            try:
+                ctype = response.headers.get("Content-Type", "")
+                if "json" in ctype:
+                    problem = response.json()
+            except (ValueError, json.JSONDecodeError):
+                problem = {}
+            raise RegistryError(
+                _format_error(response.status_code, problem, url),
+                status=response.status_code,
+                problem=problem,
+                url=url,
+            )
+        return response
+
+    def _response_json(self, response: requests.Response, endpoint: str) -> Any:
+        try:
+            return response.json()
+        except (ValueError, json.JSONDecodeError) as exc:
+            raise RegistryError(
+                f"registry returned non-JSON for {endpoint}: {exc}",
+                url=response.url,
+            ) from exc
+
+    # ------------------------------------------------------------------ §5.1
+    def list_versions(self, owner: str, repo: str) -> list[VersionEntry]:
+        """``GET /v1/packages/{owner}/{repo}/versions``."""
+        path = f"/v1/packages/{_quote(owner)}/{_quote(repo)}/versions"
+        response = self._request("GET", path)
+        payload = self._response_json(response, "/versions")
+        raw_versions = payload.get("versions") if isinstance(payload, dict) else None
+        if not isinstance(raw_versions, list):
+            raise RegistryError(
+                f"registry response missing 'versions' array: {payload!r}",
+                url=response.url,
+            )
+        return [VersionEntry.from_dict(row) for row in raw_versions]
+
+    # ------------------------------------------------------------------ §5.2
+    def download_archive(
+        self,
+        owner: str,
+        repo: str,
+        version: str,
+    ) -> tuple[bytes, str]:
+        """``GET /v1/packages/{owner}/{repo}/versions/{version}/download``.
+
+        Endpoint is format-neutral; the server replies with ``application/gzip``
+        (tar.gz) or ``application/zip`` (Anthropic skills format) and the
+        client dispatches on content type.
+
+        Returns ``(body_bytes, content_type)``. Caller is responsible for
+        sha256 verification (use ``extractor.verify_sha256``) and for picking
+        the right extractor (``extractor.extract_archive`` does this for you).
+        """
+        path = f"/v1/packages/{_quote(owner)}/{_quote(repo)}/versions/{_quote(version)}/download"
+        # Accept both archive types; v1 doesn't constrain via Accept (the
+        # publisher chose the format at upload time).
+        response = self._request("GET", path, accept="application/gzip, application/zip")
+        content_type = (response.headers.get("Content-Type") or "").split(";", 1)[0].strip()
+        return response.content, content_type
+
+    def archive_url(self, owner: str, repo: str, version: str) -> str:
+        """The canonical ``resolved_url`` for a given (owner, repo, version)."""
+        return self._url(
+            f"/v1/packages/{_quote(owner)}/{_quote(repo)}/versions/{_quote(version)}/download"
+        )
+
+    def fetch_from_url(self, url: str) -> tuple[bytes, str]:
+        """Fetch an absolute URL with auth headers (lockfile replay path).
+
+        Unlike ``_request``, this takes a fully-qualified URL (not a path
+        relative to ``_base_url``), so the caller controls the exact endpoint.
+        Used by ``RegistryPackageResolver.download_from_lockfile`` to fetch
+        from the URL recorded in the lockfile without re-querying ``/versions``.
+        """
+        try:
+            response = self._session.request(
+                "GET",
+                url=url,
+                headers=self._headers(accept="application/gzip, application/zip"),
+                timeout=self._timeout,
+            )
+        except requests.RequestException as exc:
+            raise RegistryError(f"transport error fetching {url}: {exc}", url=url) from exc
+        if response.status_code >= 400:
+            problem: dict[str, Any] = {}
+            try:
+                ctype = response.headers.get("Content-Type", "")
+                if "json" in ctype:
+                    problem = response.json()
+            except (ValueError, json.JSONDecodeError):
+                problem = {}
+            raise RegistryError(
+                _format_error(response.status_code, problem, url),
+                status=response.status_code,
+                problem=problem,
+                url=url,
+            )
+        content_type = (response.headers.get("Content-Type") or "").split(";", 1)[0].strip()
+        return response.content, content_type
+
+    # ------------------------------------------------------------------ §5.3
+    def publish_version(
+        self,
+        owner: str,
+        repo: str,
+        version: str,
+        tarball_bytes: bytes,
+    ) -> PublishResult:
+        """``PUT /v1/packages/{owner}/{repo}/versions/{version}`` — publish.
+
+        Uploads *tarball_bytes* (an ``application/gzip`` tarball produced by
+        ``apm pack --archive``) and returns the registry's 201 response as a
+        ``PublishResult``.
+
+        Errors surface as ``RegistryError`` with the HTTP status set:
+
+        - 403 — caller lacks publish permission for this owner/repo
+        - 409 — version already exists (immutable; republish is rejected)
+        - 422 — server-side lint/validation failed
+        """
+        path = f"/v1/packages/{_quote(owner)}/{_quote(repo)}/versions/{_quote(version)}"
+        url = self._url(path)
+        headers = self._headers(accept="application/json")
+        headers["Content-Type"] = "application/gzip"
+        try:
+            response = self._session.request(
+                "PUT",
+                url=url,
+                headers=headers,
+                data=tarball_bytes,
+                timeout=self._timeout,
+            )
+        except requests.RequestException as exc:
+            raise RegistryError(
+                f"transport error talking to registry: {exc}",
+                url=url,
+            ) from exc
+        if response.status_code >= 400:
+            problem: dict[str, Any] = {}
+            try:
+                ctype = response.headers.get("Content-Type", "")
+                if "json" in ctype:
+                    problem = response.json()
+            except (ValueError, json.JSONDecodeError):
+                problem = {}
+            raise RegistryError(
+                _format_error(response.status_code, problem, url),
+                status=response.status_code,
+                problem=problem,
+                url=url,
+            )
+        body = (response.content or b"").strip()
+        if not body:
+            # Some registries (e.g. JFrog) return 201 with an empty body.
+            import hashlib
+
+            digest = f"sha256:{hashlib.sha256(tarball_bytes).hexdigest()}"
+            return PublishResult(
+                package=f"{owner}/{repo}",
+                version=version,
+                digest=digest,
+                published_at=None,
+            )
+        payload = self._response_json(response, "PUT /versions")
+        return PublishResult.from_dict(payload)
+
+
+def _quote(s: str) -> str:
+    """Percent-encode a path segment, allowing ``.``, ``-``, and ``_`` raw.
+
+    ``_`` is an RFC 3986 unreserved character and must not be percent-encoded;
+    omitting it caused owner/repo names containing underscores to be serialised
+    as ``%5F`` in registry URLs.
+    """
+    return urllib.parse.quote(s, safe=".-_")
+
+
+def _format_error(status: int, problem: Mapping[str, Any], url: str) -> str:
+    title = problem.get("title") if isinstance(problem, Mapping) else None
+    detail = problem.get("detail") if isinstance(problem, Mapping) else None
+    body = " - ".join(part for part in (title, detail) if part)
+    if body:
+        return f"registry HTTP {status} from {url}: {body}"
+    return f"registry HTTP {status} from {url}"

--- a/src/apm_cli/deps/registry/config_loader.py
+++ b/src/apm_cli/deps/registry/config_loader.py
@@ -1,0 +1,124 @@
+"""Registry configuration precedence chain.
+
+Merges registry name→URL maps from (highest to lowest precedence):
+  1. apm-policy.yml  (policy-level mandates)
+  2. project apm.yml (already parsed by APMPackage.registries)
+  3. workspace ~/.apm/apm.yml
+  4. ~/.apm/config.json
+
+Only the URL is merged here; token resolution stays in auth.py.
+The first (highest-precedence) definition of a name wins.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _load_yaml_registries(yaml_path: Path) -> dict[str, str]:
+    """Return {name: url} from a YAML file's top-level ``registries:`` block.
+
+    Silently returns an empty dict on any parse error so a broken
+    workspace file never blocks a project install.
+    """
+    try:
+        import yaml
+
+        with yaml_path.open(encoding="utf-8") as fh:
+            data = yaml.safe_load(fh) or {}
+        if not isinstance(data, dict):
+            return {}
+        raw = data.get("registries")
+        if not isinstance(raw, dict):
+            return {}
+        result: dict[str, str] = {}
+        for name, body in raw.items():
+            if not isinstance(name, str) or not name.strip():
+                continue
+            if isinstance(body, dict):
+                url = body.get("url")
+                if isinstance(url, str) and url.strip():
+                    result[name] = url.strip()
+        return result
+    except Exception:
+        return {}
+
+
+def _load_config_json_registries() -> dict[str, str]:
+    """Return {name: url} from ~/.apm/config.json."""
+    from ...config import _get_registries_section
+
+    result: dict[str, str] = {}
+    for name, body in _get_registries_section().items():
+        if not isinstance(name, str) or not name.strip():
+            continue
+        if isinstance(body, dict):
+            url = body.get("url")
+            if isinstance(url, str) and url.strip():
+                result[name] = url.strip()
+    return result
+
+
+def load_merged_registries(
+    project_registries: dict[str, str] | None = None,
+    policy_registries: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Return merged registry name→URL map with precedence applied.
+
+    Build order: config.json (lowest) → workspace apm.yml → project apm.yml
+    → policy (highest). Later updates override earlier ones, so highest
+    precedence lands last.
+    """
+    merged: dict[str, str] = {}
+
+    # 4. config.json (lowest)
+    merged.update(_load_config_json_registries())
+
+    # 3. workspace ~/.apm/apm.yml
+    workspace_yml = Path.home() / ".apm" / "apm.yml"
+    if workspace_yml.exists():
+        merged.update(_load_yaml_registries(workspace_yml))
+
+    # 2. project apm.yml
+    if project_registries:
+        merged.update(project_registries)
+
+    # 1. policy (highest)
+    if policy_registries:
+        merged.update(policy_registries)
+
+    return merged
+
+
+def resolve_effective_registries(
+    project_registries: dict[str, str] | None,
+    project_default: str | None,
+    *,
+    policy_registries: dict[str, str] | None = None,
+) -> tuple[dict[str, str] | None, str | None]:
+    """Merge registry URLs and resolve the effective default registry.
+
+    Default precedence (highest wins):
+      1. ``registries.default`` from project ``apm.yml``
+      2. ``default: true`` on a registry entry in ``~/.apm/config.json``
+
+    Returns ``(merged_map, default_name)``. *merged_map* is ``None`` when no
+    registry URLs are configured at any layer.
+    """
+    from ...config import get_config_json_default_registry
+
+    merged = load_merged_registries(
+        project_registries=project_registries,
+        policy_registries=policy_registries,
+    )
+    default_name = project_default
+    if default_name is None:
+        default_name = get_config_json_default_registry()
+
+    if default_name is not None and default_name not in merged:
+        default_name = None
+
+    if not merged:
+        return None, None
+
+    return merged, default_name

--- a/src/apm_cli/deps/registry/extractor.py
+++ b/src/apm_cli/deps/registry/extractor.py
@@ -1,0 +1,277 @@
+"""Archive extraction with sha256 verification.
+
+Per docs/proposals/registry-api.md §5.2 and §6.1: the client MUST verify the
+sha256 digest of the archive against the value advertised by ``GET /versions``
+or recorded in the lockfile *before* extracting. A mismatch fails closed —
+this is the only security-critical check on the install path.
+
+Two archive formats are supported, dispatched by Content-Type from
+``RegistryClient.download_archive``:
+
+- ``application/gzip`` — gzipped tar (default APM ``apm pack`` output)
+- ``application/zip``  — zip archive (Anthropic / open-claude-skills format)
+
+The ``extract_archive`` dispatcher picks the right path and applies the same
+security gates to both: no absolute paths, no path traversal, no symlinks or
+hardlinks. The hash is checked against the raw bytes regardless of format —
+a wrong-format guess produces a clean error, not a security issue.
+
+Layout: archives are extracted into ``apm_modules/{owner}/{repo}/`` (the same
+shape the Git resolver produces after ``git clone``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import tarfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+class HashMismatchError(Exception):
+    """Raised when an archive's sha256 does not match the expected digest."""
+
+
+class UnsafeTarballError(Exception):
+    """Raised when an archive entry would escape the extraction root.
+
+    Name kept for backward compat; covers both tar and zip cases.
+    """
+
+
+class UnknownArchiveFormatError(Exception):
+    """Raised when the archive format can't be inferred from content type or magic bytes."""
+
+
+@dataclass(frozen=True)
+class _ArchiveFormat:
+    label: str
+    content_types: tuple[str, ...]
+    magic: bytes
+
+
+_READ_CHUNK_SIZE = 64 * 1024
+
+_TAR_GZIP_FORMAT = _ArchiveFormat(
+    label="tar+gzip",
+    content_types=(
+        "application/gzip",
+        "application/x-gzip",
+        "application/x-tar+gzip",
+    ),
+    magic=b"\x1f\x8b",
+)
+_ZIP_FORMAT = _ArchiveFormat(
+    label="zip",
+    content_types=(
+        "application/zip",
+        "application/x-zip-compressed",
+    ),
+    magic=b"PK\x03\x04",
+)
+_ARCHIVE_FORMATS = (_TAR_GZIP_FORMAT, _ZIP_FORMAT)
+_FORMAT_BY_CONTENT_TYPE = {
+    content_type: archive_format
+    for archive_format in _ARCHIVE_FORMATS
+    for content_type in archive_format.content_types
+}
+
+
+def _detect_format(data: bytes, content_type: str | None) -> _ArchiveFormat:
+    """Return the detected archive format.
+
+    Content-Type wins; magic bytes are fallback.
+    """
+    if content_type:
+        ct = content_type.lower().strip()
+        archive_format = _FORMAT_BY_CONTENT_TYPE.get(ct)
+        if archive_format is not None:
+            return archive_format
+    # Fallback to magic bytes
+    for archive_format in _ARCHIVE_FORMATS:
+        if data.startswith(archive_format.magic):
+            return archive_format
+    raise UnknownArchiveFormatError(
+        f"cannot determine archive format from content_type={content_type!r}; "
+        f"first bytes were {data[:8]!r}"
+    )
+
+
+def _normalize_digest(digest: str) -> str:
+    """Strip the ``sha256:`` / ``sha256=`` prefix if present and lowercase."""
+    s = digest.strip().lower()
+    for prefix in ("sha256:", "sha256="):
+        if s.startswith(prefix):
+            return s[len(prefix) :]
+    return s
+
+
+def verify_sha256(data: bytes, expected_digest: str) -> str:
+    """Verify *data*'s sha256 matches *expected_digest*.
+
+    Accepts the digest with or without a ``sha256:`` / ``sha256=`` prefix.
+    Returns the actual hex digest on success; raises ``HashMismatchError`` on
+    mismatch.
+    """
+    actual = hashlib.sha256(data).hexdigest()
+    expected = _normalize_digest(expected_digest)
+    if actual != expected:
+        raise HashMismatchError(f"tarball sha256 mismatch: expected {expected}, got {actual}")
+    return actual
+
+
+def _safe_member_path(member_name: str, dest_root: Path) -> Path | None:
+    """Return the absolute extraction path for *member_name* if safe.
+
+    Rejects:
+    - Absolute paths (``/etc/passwd``)
+    - Path traversal via ``..`` segments
+    - Symlink-style escapes (caller should also reject symlinks via type check)
+
+    Returns ``None`` if the member should be skipped (empty name).
+    """
+    if not member_name or member_name in (".", "/"):
+        return None
+    # Tarball member names use forward slashes regardless of platform; reject
+    # anything that looks like an absolute path on either side.
+    if member_name.startswith(("/", "\\")) or (len(member_name) >= 2 and member_name[1] == ":"):
+        raise UnsafeTarballError(f"absolute path in tarball: {member_name!r}")
+    candidate = (dest_root / member_name).resolve()
+    dest_resolved = dest_root.resolve()
+    try:
+        candidate.relative_to(dest_resolved)
+    except ValueError as exc:
+        raise UnsafeTarballError(f"tarball entry {member_name!r} escapes extraction root") from exc
+    return candidate
+
+
+def _safe_extract(tar: tarfile.TarFile, dest_root: Path) -> None:
+    """Extract *tar* into *dest_root* with traversal/symlink rejection."""
+    dest_root.mkdir(parents=True, exist_ok=True)
+    for member in tar.getmembers():
+        # Reject device files, FIFOs, symlinks, hard links — keep extraction
+        # to plain files and dirs only. Symlinks are rejected because they
+        # are the simplest path-traversal vector inside a tarball.
+        if member.isdev() or member.issym() or member.islnk():
+            raise UnsafeTarballError(f"unsupported tarball entry type: {member.name!r}")
+        target = _safe_member_path(member.name, dest_root)
+        if target is None:
+            continue
+        if member.isdir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # Stream the file contents through tarfile's extractor, but write to
+        # the verified path explicitly so we never call extract() with the
+        # raw member name (which is what would honor a symlink).
+        src = tar.extractfile(member)
+        if src is None:
+            continue
+        with open(target, "wb") as fh:
+            while True:
+                chunk = src.read(_READ_CHUNK_SIZE)
+                if not chunk:
+                    break
+                fh.write(chunk)
+        # Preserve mode bits but drop setuid/setgid/sticky for safety.
+        os.chmod(target, member.mode & 0o755)
+
+
+def extract_tarball(
+    data: bytes,
+    expected_digest: str,
+    dest_root: Path,
+) -> str:
+    """Verify *data*'s sha256 then extract its gzipped tar contents into *dest_root*.
+
+    Returns the actual hex digest of *data* on success. Raises
+    ``HashMismatchError`` if the digest doesn't match, or
+    ``UnsafeTarballError`` if any member would escape *dest_root*.
+    """
+    actual = verify_sha256(data, expected_digest)
+    import io  # local import — only needed on the install path
+
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
+        _safe_extract(tar, Path(dest_root))
+    return actual
+
+
+def _safe_extract_zip(zf: zipfile.ZipFile, dest_root: Path) -> None:
+    """Extract *zf* into *dest_root* with the same gates as the tar path.
+
+    Reject absolute paths, path traversal, and any entry that would resolve
+    outside *dest_root*. Symlinks in zip files are encoded as a Unix mode bit
+    (S_IFLNK in ``external_attr``) — we reject those too.
+    """
+    dest_root.mkdir(parents=True, exist_ok=True)
+    for info in zf.infolist():
+        # Symlinks in zip: high 16 bits of external_attr carry Unix mode.
+        # 0xA000 == S_IFLNK. Refuse to extract any symlink-typed entry.
+        unix_mode = (info.external_attr >> 16) & 0xFFFF
+        if unix_mode and (unix_mode & 0xF000) == 0xA000:
+            raise UnsafeTarballError(f"unsupported zip entry type (symlink): {info.filename!r}")
+        target = _safe_member_path(info.filename, dest_root)
+        if target is None:
+            continue
+        if info.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # Stream content explicitly so we never call zf.extract() with the
+        # raw filename (avoids any zip-slip surprises in older Pythons).
+        with zf.open(info, "r") as src, open(target, "wb") as fh:
+            while True:
+                chunk = src.read(_READ_CHUNK_SIZE)
+                if not chunk:
+                    break
+                fh.write(chunk)
+        # Preserve mode bits if present, dropping setuid/setgid/sticky.
+        if unix_mode:
+            os.chmod(target, unix_mode & 0o755)
+
+
+def extract_zip(
+    data: bytes,
+    expected_digest: str,
+    dest_root: Path,
+) -> str:
+    """Verify *data*'s sha256 then extract its zip contents into *dest_root*.
+
+    Returns the actual hex digest of *data* on success. Raises
+    ``HashMismatchError`` on mismatch, or ``UnsafeTarballError`` (name kept
+    for backward compat) if any member would escape *dest_root*.
+    """
+    actual = verify_sha256(data, expected_digest)
+    import io  # local import — only needed on the install path
+
+    try:
+        with zipfile.ZipFile(io.BytesIO(data), mode="r") as zf:
+            _safe_extract_zip(zf, Path(dest_root))
+    except zipfile.BadZipFile as exc:
+        raise UnknownArchiveFormatError(f"malformed zip archive: {exc}") from exc
+    return actual
+
+
+def extract_archive(
+    data: bytes,
+    expected_digest: str,
+    dest_root: Path,
+    *,
+    content_type: str | None = None,
+) -> str:
+    """Dispatcher: pick the right extractor based on Content-Type / magic bytes.
+
+    The hash check happens identically for both formats. A mismatch fails
+    before extraction even starts; format-detection errors fail before any
+    bytes are written.
+    """
+    fmt = _detect_format(data, content_type)
+    if fmt is _TAR_GZIP_FORMAT:
+        return extract_tarball(data, expected_digest, dest_root)
+    if fmt is _ZIP_FORMAT:
+        return extract_zip(data, expected_digest, dest_root)
+    # _detect_format raises UnknownArchiveFormatError otherwise; this is
+    # belt-and-braces.
+    raise UnknownArchiveFormatError(f"unsupported archive format: {fmt.label!r}")

--- a/src/apm_cli/deps/registry/feature_gate.py
+++ b/src/apm_cli/deps/registry/feature_gate.py
@@ -1,0 +1,29 @@
+"""Experimental feature gate for REST-based APM package registries."""
+
+from __future__ import annotations
+
+FLAG_NAME = "registries"
+DISPLAY_NAME = "registries"
+ENABLE_COMMAND = f"apm experimental enable {DISPLAY_NAME}"
+
+
+class PackageRegistryFeatureDisabledError(ValueError):
+    """Raised when registries behavior is used without opt-in."""
+
+
+def is_package_registry_enabled() -> bool:
+    """Return whether the registries experimental flag is enabled."""
+    from apm_cli.core.experimental import is_enabled
+
+    return is_enabled(FLAG_NAME)
+
+
+def require_package_registry_enabled(action: str = "APM package registries") -> None:
+    """Raise a consistent error if REST package registries are disabled."""
+    if is_package_registry_enabled():
+        return
+    raise PackageRegistryFeatureDisabledError(
+        f"{action} requires the experimental {DISPLAY_NAME} feature. "
+        f"Enable with: {ENABLE_COMMAND}. "
+        "Run 'apm experimental list' to see available experimental features."
+    )

--- a/src/apm_cli/deps/registry/outdated.py
+++ b/src/apm_cli/deps/registry/outdated.py
@@ -1,0 +1,296 @@
+"""Registry-backed outdated checks for ``apm outdated``.
+
+Compares the lockfile's exact registry ``version`` against the highest semver
+on the registry that satisfies the manifest range (same ``pick_best`` semantics
+as install).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ...constants import APM_MODULES_DIR, APM_YML_FILENAME
+from ...deps.outdated_row import OutdatedRow
+from ...marketplace.semver import SemVer, parse_semver
+from ...models.dependency.reference import DependencyReference
+from .auth import make_auth_context
+from .client import RegistryClient, RegistryError
+from .config_loader import resolve_effective_registries
+from .feature_gate import is_package_registry_enabled
+from .resolver import _split_owner_repo
+from .semver import is_semver_range, pick_best
+
+if TYPE_CHECKING:
+    from ...deps.lockfile import LockedDependency, LockFile
+
+
+@dataclass(frozen=True)
+class RegistryOutdatedContext:
+    """Manifest + registry config needed to check registry lockfile rows."""
+
+    manifest_index: dict[str, DependencyReference]
+    registries: dict[str, str]
+    default_registry: str | None
+
+
+def _highest_semver(version_strings: list[str]) -> str | None:
+    """Return the highest parseable semver in *version_strings*."""
+    candidates: list[tuple[SemVer, str]] = []
+    for raw in version_strings:
+        parsed = parse_semver(raw)
+        if parsed is not None:
+            candidates.append((parsed, raw))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda pair: pair[0])
+    return candidates[-1][1]
+
+
+def _add_registry_manifest_deps(
+    apm_yml: Path,
+    manifest_index: dict[str, DependencyReference],
+    default_registry: str | None,
+) -> None:
+    """Merge registry-routed deps from one ``apm.yml`` into *manifest_index*."""
+    from ...models.apm_package import APMPackage, _route_unscoped_to_default_registry
+
+    if not apm_yml.is_file():
+        return
+    try:
+        pkg = APMPackage.from_apm_yml(apm_yml)
+    except (ValueError, FileNotFoundError, OSError):
+        return
+
+    dep_list = pkg.get_apm_dependencies() + pkg.get_dev_apm_dependencies()
+    if default_registry:
+        _route_unscoped_to_default_registry(dep_list, default_registry)
+    for dep in dep_list:
+        if dep.source != "registry":
+            continue
+        manifest_index.setdefault(dep.get_unique_key(), dep)
+
+
+def _index_installed_manifest_deps(
+    project_root: Path,
+    lockfile: LockFile | None,
+    manifest_index: dict[str, DependencyReference],
+    default_registry: str | None,
+) -> None:
+    """Index registry manifest ranges declared by installed packages."""
+    if lockfile:
+        for locked in lockfile.dependencies.values():
+            if locked.source != "local" or not locked.local_path:
+                continue
+            _add_registry_manifest_deps(
+                project_root / locked.local_path / APM_YML_FILENAME,
+                manifest_index,
+                default_registry,
+            )
+
+    modules_dir = project_root / APM_MODULES_DIR
+    if not modules_dir.is_dir():
+        return
+    for apm_yml in modules_dir.rglob(APM_YML_FILENAME):
+        if ".apm" in apm_yml.parts:
+            continue
+        _add_registry_manifest_deps(apm_yml, manifest_index, default_registry)
+
+
+def load_registry_outdated_context(
+    project_root: Path,
+    lockfile: LockFile | None = None,
+) -> RegistryOutdatedContext:
+    """Build manifest index and merged registry map from *project_root*."""
+    from ...models.apm_package import APMPackage, _route_unscoped_to_default_registry
+
+    apm_yml = project_root / "apm.yml"
+    manifest_index: dict[str, DependencyReference] = {}
+    project_registries: dict[str, str] | None = None
+    project_default: str | None = None
+
+    if apm_yml.is_file():
+        pkg = APMPackage.from_apm_yml(apm_yml)
+        project_registries = pkg.registries
+        project_default = pkg.default_registry
+        dep_list = pkg.get_apm_dependencies() + pkg.get_dev_apm_dependencies()
+        merged, default_name = resolve_effective_registries(
+            project_registries,
+            project_default,
+        )
+        if default_name:
+            _route_unscoped_to_default_registry(dep_list, default_name)
+        for dep in dep_list:
+            manifest_index[dep.get_unique_key()] = dep
+        registries = merged or {}
+        default_registry = default_name
+    else:
+        registries, default_registry = resolve_effective_registries(None, None)
+
+    if registries is None:
+        registries = {}
+
+    _index_installed_manifest_deps(
+        project_root,
+        lockfile,
+        manifest_index,
+        default_registry,
+    )
+
+    return RegistryOutdatedContext(
+        manifest_index=manifest_index,
+        registries=registries,
+        default_registry=default_registry,
+    )
+
+
+def _semver_lt(left: str, right: str) -> bool:
+    vl, vr = parse_semver(left), parse_semver(right)
+    if vl is None or vr is None:
+        return left != right
+    return vl < vr
+
+
+def check_registry_locked_dep(
+    locked: LockedDependency,
+    ctx: RegistryOutdatedContext | None,
+    *,
+    client_factory=None,
+    verbose: bool = False,
+) -> OutdatedRow:
+    """Compare *locked* against the newest registry version in manifest range."""
+    package_name = locked.get_unique_key()
+    current = locked.version or ""
+
+    if ctx is None:
+        return OutdatedRow(
+            package=package_name,
+            current=current or "(none)",
+            latest="-",
+            status="unknown",
+            source="registry",
+        )
+
+    if not is_package_registry_enabled():
+        return OutdatedRow(
+            package=package_name,
+            current=current or "(none)",
+            latest="-",
+            status="unknown",
+            source="registry (feature disabled)",
+        )
+
+    manifest_dep = ctx.manifest_index.get(package_name)
+    lockfile_only = manifest_dep is None
+    manifest_range: str | None = None
+    if manifest_dep is not None:
+        manifest_range = manifest_dep.reference
+        if not manifest_range or not is_semver_range(manifest_range):
+            return OutdatedRow(
+                package=package_name,
+                current=current or "(none)",
+                latest="-",
+                status="unknown",
+                source="registry (invalid manifest range)",
+            )
+
+    if not current:
+        return OutdatedRow(
+            package=package_name,
+            current="(none)",
+            latest="-",
+            status="unknown",
+            source="registry (missing locked version)",
+        )
+
+    registry_name = (manifest_dep.registry_name if manifest_dep else None) or ctx.default_registry
+    if not registry_name:
+        return OutdatedRow(
+            package=package_name,
+            current=current,
+            latest="-",
+            status="unknown",
+            source="registry (no default registry)",
+        )
+
+    base_url = ctx.registries.get(registry_name)
+    if not base_url:
+        return OutdatedRow(
+            package=package_name,
+            current=current,
+            latest="-",
+            status="unknown",
+            source=f"registry ({registry_name!r} not configured)",
+        )
+
+    source_label = f"registry: {registry_name}"
+    if lockfile_only:
+        source_label = f"{source_label} (lockfile)"
+
+    try:
+        owner, repo = _split_owner_repo(locked.repo_url)
+    except Exception:
+        return OutdatedRow(
+            package=package_name,
+            current=current,
+            latest="-",
+            status="unknown",
+            source=source_label,
+        )
+
+    factory = client_factory or (lambda url, auth: RegistryClient(url, auth))
+    client = factory(base_url, make_auth_context(registry_name))
+
+    try:
+        version_entries = client.list_versions(owner, repo)
+    except RegistryError:
+        return OutdatedRow(
+            package=package_name,
+            current=current,
+            latest="-",
+            status="unknown",
+            source=source_label,
+        )
+
+    version_strings = [entry.version for entry in version_entries]
+    if lockfile_only:
+        latest = _highest_semver(version_strings)
+    else:
+        latest = pick_best(manifest_range, version_strings)
+    if latest is None:
+        return OutdatedRow(
+            package=package_name,
+            current=current,
+            latest="-",
+            status="unknown",
+            source=source_label,
+        )
+
+    extra: list[str] = []
+    if verbose:
+        sorted_versions = sorted(
+            version_strings,
+            key=lambda s: parse_semver(s) or parse_semver("0.0.0"),
+            reverse=True,
+        )
+        if lockfile_only:
+            extra = [v for v in sorted_versions if _semver_lt(current, v)][:10]
+        else:
+            extra = [v for v in sorted_versions if pick_best(manifest_range, [v]) == v][:10]
+
+    if current == latest:
+        status = "up-to-date"
+    elif _semver_lt(current, latest):
+        status = "outdated"
+    else:
+        status = "up-to-date"
+
+    return OutdatedRow(
+        package=package_name,
+        current=current,
+        latest=latest,
+        status=status,
+        extra_tags=extra,
+        source=source_label,
+    )

--- a/src/apm_cli/deps/registry/resolver.py
+++ b/src/apm_cli/deps/registry/resolver.py
@@ -1,0 +1,426 @@
+"""Registry-backed package resolver.
+
+Implements the install-side of docs/proposals/registry-api.md: given a
+``DependencyReference`` whose ``source == "registry"``, fetch its tarball from
+the configured registry, verify the sha256, extract into the target directory,
+and build a ``PackageInfo`` that the rest of the install pipeline consumes
+without further changes (per §8 the only new branch is the download itself).
+
+This object satisfies the ``DownloadCallback`` shape used by the existing
+resolver: it exposes a ``download_package(dep_ref, target_path, ...)`` method
+that returns a ``PackageInfo``. Wiring into the install pipeline is done in
+``install/phases/resolve.py`` (separate commit) — this module is a pure unit.
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from ...models.apm_package import PackageInfo, validate_apm_package
+from ...models.dependency.reference import DependencyReference
+from ...models.dependency.types import GitReferenceType, ResolvedReference
+from .auth import (
+    RegistryAuthContext,
+    make_auth_context,
+    remediation_message,
+    resolve_for_url,
+)
+from .client import RegistryClient, RegistryError, VersionEntry
+from .extractor import extract_archive
+from .semver import is_semver_range, pick_best
+
+
+class RegistryResolutionError(Exception):
+    """A registry-sourced install failed in a way the user must act on.
+
+    Wraps lower-level errors (auth, hash mismatch, no matching version, missing
+    URL) into a single exception type the install pipeline can catch and
+    surface with the §6.2 remediation message intact.
+    """
+
+
+def _split_owner_repo(repo_url: str) -> tuple[str, str]:
+    """Split ``owner/repo`` (or longer paths) into (owner, repo) for the API.
+
+    For paths with more than two segments (e.g. ``group/subgroup/repo``), we
+    treat the last segment as the repo and the rest as the owner — the API
+    contract uses ``{owner}/{repo}`` as a flat two-segment identity.
+    """
+    parts = [p for p in repo_url.split("/") if p]
+    if len(parts) < 2:
+        raise RegistryResolutionError(
+            f"registry-sourced dep needs an 'owner/repo' identity, got {repo_url!r}"
+        )
+    if len(parts) == 2:
+        return parts[0], parts[1]
+    return "/".join(parts[:-1]), parts[-1]
+
+
+def _clear_install_target(target_path: Path) -> None:
+    """Ensure *target_path* is empty (mirrors Git downloader retry semantics)."""
+    target_path.mkdir(parents=True, exist_ok=True)
+    if not any(target_path.iterdir()):
+        return
+    for child in target_path.iterdir():
+        if child.is_dir():
+            shutil.rmtree(child, ignore_errors=True)
+        else:
+            child.unlink(missing_ok=True)
+
+
+def _package_info_from_extracted_registry_tree(
+    dep_ref: DependencyReference,
+    target_path: Path,
+    chosen: VersionEntry,
+    actual_hash: str,
+    client: RegistryClient,
+    owner: str,
+    repo: str,
+) -> tuple[PackageInfo, RegistryResolution]:
+    """Validate extracted tree, attach registry URL, return install metadata."""
+    if dep_ref.is_virtual and dep_ref.virtual_path and dep_ref.is_virtual_subdirectory():
+        sub = target_path / dep_ref.virtual_path
+        if not sub.exists():
+            raise RegistryResolutionError(
+                f"virtual sub-path {dep_ref.virtual_path!r} not found in "
+                f"package {dep_ref.repo_url!r} at version {chosen.version}"
+            )
+
+    validation_result = validate_apm_package(target_path)
+    if not validation_result.is_valid:
+        errs = "\n  - ".join(validation_result.errors)
+        raise RegistryResolutionError(
+            f"registry tarball for {dep_ref.repo_url!r} did not validate "
+            f"as an APM package:\n  - {errs}"
+        )
+    package = validation_result.package
+    if package is None:
+        raise RegistryResolutionError(
+            f"registry tarball for {dep_ref.repo_url!r} validated but produced no package metadata"
+        )
+    resolved_url = client.archive_url(owner, repo, chosen.version)
+    package.source = resolved_url
+
+    reg_resolution = RegistryResolution(
+        resolved_url=resolved_url,
+        resolved_hash=f"sha256:{actual_hash}",
+        version=chosen.version,
+    )
+
+    resolved_ref = ResolvedReference(
+        original_ref=dep_ref.reference or chosen.version,
+        ref_type=GitReferenceType.TAG,
+        ref_name=chosen.version,
+        resolved_commit=None,
+    )
+
+    package_info = PackageInfo(
+        package=package,
+        install_path=target_path,
+        resolved_reference=resolved_ref,
+        installed_at=datetime.now().isoformat(),
+        dependency_ref=dep_ref,
+        package_type=validation_result.package_type,
+    )
+    return package_info, reg_resolution
+
+
+class RegistryPackageResolver:
+    """Drop-in download callback that fetches packages from a REST registry.
+
+    One instance per resolution graph is fine — the resolver picks the right
+    registry per dep based on ``dep_ref.registry_name`` and the configured
+    ``registries`` mapping.
+    """
+
+    def __init__(
+        self,
+        registries: dict[str, str],
+        *,
+        client_factory: Callable[[str, RegistryAuthContext], RegistryClient] | None = None,
+    ) -> None:
+        """
+        Args:
+            registries: Mapping of registry name -> base URL, sourced from the
+                top-level ``registries:`` block in apm.yml (merged with user
+                config). The ``"default"`` key, if present, may either be a
+                string registry name or a string URL — it is consumed at
+                routing time, not here, so this map should already be
+                normalized to ``{name: url, ...}`` without ``"default"``.
+            client_factory: Optional override for ``RegistryClient`` construction.
+                Tests inject this to swap in a fake HTTP client.
+        """
+        self._registries = dict(registries)
+        self._client_factory = client_factory or (lambda url, auth: RegistryClient(url, auth))
+
+    def _registry_call(
+        self,
+        dep_ref: DependencyReference,
+        base_url: str,
+        fn: Callable[[], Any],
+    ) -> Any:
+        """Run *fn*; map ``RegistryError`` to ``RegistryResolutionError``."""
+        try:
+            return fn()
+        except RegistryError as exc:
+            self._raise_for_http(exc, dep_ref, base_url)
+            raise
+
+    # The dep tracker stores a per-dep "resolution result" used by the
+    # lockfile writer to fill in resolved_url + resolved_hash. It's exposed
+    # via this lookup so the install pipeline can read it after the callback
+    # returns. Keyed by ``DependencyReference.get_unique_key()``.
+    @property
+    def last_resolutions(self) -> dict[str, RegistryResolution]:
+        if not hasattr(self, "_last_resolutions"):
+            self._last_resolutions = {}
+        return self._last_resolutions
+
+    # ------------------------------------------------------------------
+    def _resolve_registry_url(self, registry_name: str | None) -> str:
+        if not registry_name:
+            raise RegistryResolutionError(
+                "registry-sourced dep is missing registry_name "
+                "(parser bug or unconfigured default registry)"
+            )
+        url = self._registries.get(registry_name)
+        if not url:
+            raise RegistryResolutionError(
+                f"registry {registry_name!r} is not configured in apm.yml's registries: block"
+            )
+        return url
+
+    def _build_client(self, registry_name: str, base_url: str) -> RegistryClient:
+        auth = make_auth_context(registry_name)
+        return self._client_factory(base_url, auth)
+
+    def _build_client_for_url(self, base_url: str) -> RegistryClient:
+        """Build a client for a URL whose registry name we look up from config.
+
+        Used on the lockfile re-install path (§6.2): the URL is already
+        recorded; we walk the configured registries to find which name owns
+        that URL, then resolve its token. If no match, fall back to anonymous.
+        """
+        auth = resolve_for_url(base_url, self._registries)
+        return self._client_factory(base_url, auth)
+
+    def _pick_version(
+        self, dep_ref: DependencyReference, versions: list[VersionEntry]
+    ) -> VersionEntry:
+        spec = dep_ref.reference or ""
+        if not spec:
+            raise RegistryResolutionError(
+                f"registry-sourced dep {dep_ref.repo_url!r} has no version "
+                f"constraint (semver range required)"
+            )
+        if not is_semver_range(spec):
+            # The parser should have rejected this earlier; this is defense in
+            # depth for direct callers that bypass the parser.
+            raise RegistryResolutionError(
+                f"version constraint {spec!r} on {dep_ref.repo_url!r} is not a valid semver range"
+            )
+        version_strings = [v.version for v in versions]
+        best = pick_best(spec, version_strings)
+        if best is None:
+            raise RegistryResolutionError(
+                f"no version of {dep_ref.repo_url!r} matches {spec!r} "
+                f"in registry {dep_ref.registry_name!r} "
+                f"(available: {', '.join(version_strings) or '<none>'})"
+            )
+        chosen = next((v for v in versions if v.version == best), None)
+        if chosen is None:
+            raise RegistryResolutionError(
+                f"internal error: picked {best!r} but no matching VersionEntry"
+            )
+        return chosen
+
+    # ------------------------------------------------------------------
+    def download_package(
+        self,
+        repo_ref,  # str | DependencyReference (mirrors GitHubPackageDownloader)
+        target_path: Path,
+        progress_task_id=None,
+        progress_obj=None,
+        verbose_callback=None,
+    ) -> PackageInfo:
+        """Fetch *repo_ref* from its configured registry into *target_path*.
+
+        Mirrors ``GitHubPackageDownloader.download_package``'s signature so
+        both can be invoked through the same ``DownloadCallback`` shape in
+        ``install/phases/resolve.py``.
+        """
+        dep_ref = (
+            repo_ref
+            if isinstance(repo_ref, DependencyReference)
+            else DependencyReference.parse(repo_ref)
+        )
+        if dep_ref.source != "registry":
+            raise RegistryResolutionError(
+                f"RegistryPackageResolver invoked for non-registry dep "
+                f"{dep_ref.repo_url!r} (source={dep_ref.source!r})"
+            )
+
+        owner, repo = _split_owner_repo(dep_ref.repo_url)
+        base_url = self._resolve_registry_url(dep_ref.registry_name)
+        client = self._build_client(dep_ref.registry_name, base_url)
+
+        versions = self._registry_call(
+            dep_ref,
+            base_url,
+            lambda: client.list_versions(owner, repo),
+        )
+        if not versions:
+            raise RegistryResolutionError(
+                f"registry {dep_ref.registry_name!r} reports no versions for {dep_ref.repo_url!r}"
+            )
+
+        chosen = self._pick_version(dep_ref, versions)
+
+        archive_bytes, content_type = self._registry_call(
+            dep_ref,
+            base_url,
+            lambda: client.download_archive(owner, repo, chosen.version),
+        )
+
+        _clear_install_target(target_path)
+
+        # extract_archive dispatches on Content-Type (with magic-bytes
+        # fallback) — supports both tar.gz (default) and zip (Anthropic
+        # skills format). Hash check happens before any extraction.
+        actual_hash = extract_archive(
+            archive_bytes,
+            chosen.digest,
+            target_path,
+            content_type=content_type,
+        )
+
+        # Subdirectory virtual packages: registry serves the parent tarball;
+        # we extract the full tree then validate the requested sub-path exists.
+        package_info, reg_resolution = _package_info_from_extracted_registry_tree(
+            dep_ref,
+            target_path,
+            chosen,
+            actual_hash,
+            client,
+            owner,
+            repo,
+        )
+        self.last_resolutions[dep_ref.get_unique_key()] = reg_resolution
+        return package_info
+
+    # ------------------------------------------------------------------
+    def download_from_lockfile(
+        self,
+        dep_ref: DependencyReference,
+        target_path: Path,
+        *,
+        resolved_url: str,
+        resolved_hash: str,
+        version: str,
+    ) -> PackageInfo:
+        """Fetch from the locked URL and verify against the locked hash.
+
+        This is the npm-install-model lockfile replay path: instead of calling
+        ``/versions`` to re-negotiate the best semver match, we fetch directly
+        from ``resolved_url`` (recorded in the lockfile) and re-verify the
+        bytes against ``resolved_hash``.  Called by ``apm install`` when the
+        lockfile has full replay data and the manifest range still covers the
+        locked version.  ``apm update`` bypasses this path entirely via
+        ``update_refs=True``.
+        """
+        client = self._build_client_for_url(resolved_url)
+        try:
+            archive_bytes, content_type = client.fetch_from_url(resolved_url)
+        except RegistryError as exc:
+            self._raise_for_http(exc, dep_ref, resolved_url)
+            raise  # unreachable; appeases type checker
+
+        _clear_install_target(target_path)
+        actual_hash = extract_archive(
+            archive_bytes,
+            resolved_hash,  # verify against LOCKFILE hash, not API digest
+            target_path,
+            content_type=content_type,
+        )
+
+        if dep_ref.is_virtual and dep_ref.virtual_path and dep_ref.is_virtual_subdirectory():
+            sub = target_path / dep_ref.virtual_path
+            if not sub.exists():
+                raise RegistryResolutionError(
+                    f"virtual sub-path {dep_ref.virtual_path!r} not found in "
+                    f"package {dep_ref.repo_url!r} at version {version}"
+                )
+
+        validation_result = validate_apm_package(target_path)
+        if not validation_result.is_valid:
+            errs = "\n  - ".join(validation_result.errors)
+            raise RegistryResolutionError(
+                f"registry tarball for {dep_ref.repo_url!r} did not validate "
+                f"as an APM package:\n  - {errs}"
+            )
+        package = validation_result.package
+        if package is None:
+            raise RegistryResolutionError(
+                f"registry tarball for {dep_ref.repo_url!r} validated but "
+                f"produced no package metadata"
+            )
+        package.source = resolved_url
+
+        reg_resolution = RegistryResolution(
+            resolved_url=resolved_url,
+            resolved_hash=f"sha256:{actual_hash}",
+            version=version,
+        )
+        resolved_ref = ResolvedReference(
+            original_ref=dep_ref.reference or version,
+            ref_type=GitReferenceType.TAG,
+            ref_name=version,
+            resolved_commit=None,
+        )
+        package_info = PackageInfo(
+            package=package,
+            install_path=target_path,
+            resolved_reference=resolved_ref,
+            installed_at=datetime.now().isoformat(),
+            dependency_ref=dep_ref,
+            package_type=validation_result.package_type,
+        )
+        self.last_resolutions[dep_ref.get_unique_key()] = reg_resolution
+        return package_info
+
+    # ------------------------------------------------------------------
+    def _raise_for_http(
+        self,
+        exc: RegistryError,
+        dep_ref: DependencyReference,
+        base_url: str,
+    ) -> None:
+        if exc.status in (401, 403):
+            raise RegistryResolutionError(f"{exc}\n{remediation_message(base_url)}") from exc
+        if exc.status == 404:
+            raise RegistryResolutionError(
+                f"registry {dep_ref.registry_name!r} has no package "
+                f"{dep_ref.repo_url!r} (HTTP 404 from {exc.url})"
+            ) from exc
+        raise RegistryResolutionError(str(exc)) from exc
+
+
+# Carried out-of-band from download_package() so the install pipeline can
+# read it when writing the lockfile (resolved_url + resolved_hash). Keeping
+# the PackageInfo shape unchanged keeps existing callers byte-identical.
+@dataclass(frozen=True, slots=True)
+class RegistryResolution:
+    resolved_url: str
+    resolved_hash: str
+    version: str
+
+    def __repr__(self) -> str:  # pragma: no cover - debug aid
+        return (
+            f"RegistryResolution(version={self.version!r}, "
+            f"url={self.resolved_url!r}, hash={self.resolved_hash[:24]!r}...)"
+        )

--- a/src/apm_cli/deps/registry/semver.py
+++ b/src/apm_cli/deps/registry/semver.py
@@ -1,0 +1,68 @@
+"""Registry-facing wrappers around APM's canonical semver matcher.
+
+Registry dependencies are not shipped yet, so they intentionally reuse the
+existing marketplace semver grammar instead of carrying a separate dialect.
+The public helpers here keep the registry resolver API small while delegating
+all version parsing, ordering, and range matching to ``apm_cli.marketplace``.
+"""
+
+from __future__ import annotations
+
+import re
+
+from apm_cli.marketplace.semver import SemVer, parse_semver, satisfies_range
+
+_RANGE_OPERATORS = (">=", "<=", ">", "<", "^", "~")
+_WILDCARD_RE = re.compile(r"^\d+\.\d+\.[xX*]$")
+
+
+def _is_range_component(component: str) -> bool:
+    """Return whether one space-separated range component is syntactically valid."""
+    if not component:
+        return False
+    if _WILDCARD_RE.match(component):
+        return True
+    for op in _RANGE_OPERATORS:
+        if component.startswith(op):
+            return parse_semver(component[len(op) :]) is not None
+    return parse_semver(component) is not None
+
+
+def is_semver_range(spec: str) -> bool:
+    """Return ``True`` iff *spec* is a valid semver version or range.
+
+    Used at parse time to reject branch names, commit SHAs, and arbitrary refs
+    when an entry routes through a registry.
+    """
+    parts = spec.strip().split()
+    return bool(parts) and all(_is_range_component(part) for part in parts)
+
+
+def match_version(spec: str, version: str) -> bool:
+    """Return ``True`` iff *version* satisfies the semver range *spec*."""
+    if not is_semver_range(spec):
+        return False
+    v = parse_semver(version)
+    if v is None:
+        return False
+    return satisfies_range(v, spec)
+
+
+def pick_best(spec: str, versions: list[str]) -> str | None:
+    """Return the highest *version* in *versions* that satisfies *spec*.
+
+    Returns ``None`` if no version matches or the spec is invalid.
+    """
+    if not is_semver_range(spec):
+        return None
+    candidates: list[tuple[SemVer, str]] = []
+    for raw in versions:
+        v = parse_semver(raw)
+        if v is None:
+            continue
+        if satisfies_range(v, spec):
+            candidates.append((v, raw))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda pair: pair[0])
+    return candidates[-1][1]

--- a/src/apm_cli/deps/registry_proxy.py
+++ b/src/apm_cli/deps/registry_proxy.py
@@ -21,6 +21,15 @@ Deprecated aliases (still functional, emit ``DeprecationWarning``)::
     ARTIFACTORY_BASE_URL  -> PROXY_REGISTRY_URL
     ARTIFACTORY_APM_TOKEN -> PROXY_REGISTRY_TOKEN
     ARTIFACTORY_ONLY      -> PROXY_REGISTRY_ONLY
+
+Related: :mod:`apm_cli.deps.registry`
+    A separate, additive package source that fetches APM packages over a
+    REST contract instead of a VCS proxy. Suitable when the package
+    server speaks the APM Registry HTTP API directly rather than acting
+    as a transparent Git mirror. Configured per-project in ``apm.yml``
+    via the top-level ``registries:`` block; orthogonal to the
+    ``PROXY_REGISTRY_*`` env vars documented here. See
+    ``docs/src/content/docs/guides/registries.md``.
 """
 
 from __future__ import annotations

--- a/src/apm_cli/drift.py
+++ b/src/apm_cli/drift.py
@@ -52,7 +52,7 @@ from __future__ import annotations
 import builtins
 from dataclasses import replace as _dataclass_replace
 from pathlib import Path  # noqa: F401
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set  # noqa: F401, UP035
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from apm_cli.deps.lockfile import LockedDependency, LockFile
@@ -62,6 +62,26 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Ref drift
 # ---------------------------------------------------------------------------
+
+
+def _registry_range_covers_locked_version(
+    manifest_range: str | None,
+    locked_version: str | None,
+) -> bool:
+    """True when the lockfile's exact registry version still satisfies the manifest range."""
+    if not manifest_range or not locked_version:
+        return False
+    from apm_cli.deps.registry.semver import is_semver_range, match_version
+
+    return bool(is_semver_range(manifest_range) and match_version(manifest_range, locked_version))
+
+
+def _normalize_dep_source(dep: Any) -> str:
+    """Return the resolver source label for *dep*, defaulting to ``git``."""
+    raw = getattr(dep, "source", None)
+    if not isinstance(raw, str) or not raw:
+        return "git"
+    return raw
 
 
 def detect_ref_change(
@@ -101,8 +121,32 @@ def detect_ref_change(
         return False
     if locked_dep is None:
         return False  # new package — not drift, just a first install
-    # Direct comparison: handles None→value, value→None, and value→value.
-    # No truthiness guard on locked_dep.resolved_ref — None != "v1.0.0" is True.
+
+    # Source flip drift: manifest changed resolver between installs (e.g.
+    # was ``- git: ...``, now ``acme/foo@corp#^1.0.0``). The install path,
+    # auth chain, and trust anchor all change — force a re-resolve.
+    # Note: source=None and source="git" are equivalent (legacy default).
+    manifest_source = _normalize_dep_source(dep_ref)
+    locked_source = _normalize_dep_source(locked_dep)
+    if manifest_source != locked_source:
+        return True
+
+    # Registry-sourced deps: the manifest carries a semver range
+    # (e.g. ``^1.2.0``) while the lockfile records an exact version
+    # (e.g. ``1.5.3``). Plain string comparison would be a false
+    # positive — instead, ask whether the locked version still
+    # satisfies the manifest range. If yes, no drift; if no, drift
+    # (the user expanded/contracted the range away from the locked
+    # version and we need to re-resolve).
+    if manifest_source == "registry":
+        return not _registry_range_covers_locked_version(
+            dep_ref.reference,
+            locked_dep.version,
+        )
+
+    # Git/local deps: direct ref comparison. Handles None→value, value→None,
+    # and value→value. No truthiness guard on locked_dep.resolved_ref —
+    # None != "v1.0.0" is True.
     if dep_ref.reference != locked_dep.resolved_ref:
         return True
 
@@ -220,6 +264,13 @@ def detect_config_drift(
 # ---------------------------------------------------------------------------
 
 
+def _registry_replay_overrides_from_lock(locked_dep: Any) -> dict[str, Any] | None:
+    """Fields to merge onto dep_ref so a registry install replays the locked version."""
+    if locked_dep.source == "registry" and locked_dep.version:
+        return {"reference": locked_dep.version, "source": "registry"}
+    return None
+
+
 def build_download_ref(
     dep_ref: DependencyReference,
     existing_lockfile: LockFile | None,
@@ -273,8 +324,11 @@ def build_download_ref(
                 overrides["is_insecure"] = True
                 overrides["allow_insecure"] = getattr(locked_dep, "allow_insecure", False)
 
+            reg_replay = _registry_replay_overrides_from_lock(locked_dep)
+            if reg_replay is not None:
+                overrides.update(reg_replay)
             # Use locked commit SHA for byte-for-byte reproducibility.
-            if locked_dep.resolved_commit and locked_dep.resolved_commit != "cached":
+            elif locked_dep.resolved_commit and locked_dep.resolved_commit != "cached":
                 overrides["reference"] = locked_dep.resolved_commit
             # For proxy deps without a commit SHA (Artifactory zip archives),
             # preserve the locked ref so we download the same ref on replay.

--- a/src/apm_cli/install/context.py
+++ b/src/apm_cli/install/context.py
@@ -96,7 +96,8 @@ class InstallContext:
     # Pre-integrate inputs (populated by caller before integrate phase)
     # ------------------------------------------------------------------
     diagnostics: Any = None  # DiagnosticCollector
-    registry_config: Any = None  # RegistryConfig
+    registry_config: Any = None  # RegistryConfig (proxy registry; pre-existing)
+    registry_resolver: Any = None  # RegistryPackageResolver -- dedicated registry resolver
     managed_files: set[str] = field(default_factory=set)
 
     # ------------------------------------------------------------------

--- a/src/apm_cli/install/phases/download.py
+++ b/src/apm_cli/install/phases/download.py
@@ -42,6 +42,7 @@ def run(ctx: InstallContext) -> None:
     apm_modules_dir = ctx.apm_modules_dir
     downloader = ctx.downloader
     callback_downloaded = ctx.callback_downloaded
+    callback_failures = ctx.callback_failures
 
     # Phase 4 (#171): Parallel package downloads using ThreadPoolExecutor
     # Pre-download all non-cached packages in parallel for wall-clock speedup.
@@ -60,6 +61,15 @@ def run(ctx: InstallContext) -> None:
         )
         # Skip local packages -- they are copied, not downloaded
         if _pd_ref.is_local:
+            continue
+        # Skip deps that already failed during BFS resolution (#1111 C2).
+        # Without this, registry failures fall through to the git downloader
+        # and hang on a non-existent github.com/{owner}/{repo} clone (~180s).
+        if _pd_key in callback_failures:
+            continue
+        # Registry-sourced deps are fetched in resolve.py's callback; the git
+        # downloader must never handle them here.
+        if getattr(_pd_ref, "source", None) == "registry":
             continue
         # Skip if already downloaded during BFS resolution
         if _pd_key in callback_downloaded:

--- a/src/apm_cli/install/phases/integrate.py
+++ b/src/apm_cli/install/phases/integrate.py
@@ -57,7 +57,14 @@ def _resolve_download_strategy(
     # npm-like behavior: Branches always fetch latest, only tags/commits use cache
     # Resolve git reference to determine type
     resolved_ref = None
-    if dep_ref.get_unique_key() not in ctx.pre_downloaded_keys:
+    # Registry-sourced deps don't have a git reference to resolve — calling
+    # ``resolve_git_reference`` on them would issue ``git ls-remote`` against
+    # the dep's notional host (default github.com), which can trigger an SSH
+    # key-acceptance prompt or a wasted network call. Skip the git probe
+    # entirely for non-git sources.
+    _source = getattr(dep_ref, "source", None)
+    is_git_source = not isinstance(_source, str) or _source in (None, "git")
+    if is_git_source and dep_ref.get_unique_key() not in ctx.pre_downloaded_keys:
         # Resolve when there is an explicit ref, OR when update_refs
         # is True AND we have a non-cached lockfile entry to compare
         # against (otherwise resolution is wasted work -- the package
@@ -141,6 +148,16 @@ def _resolve_download_strategy(
                     if _should_skip_redownload(locked_dep, install_path):
                         lockfile_match = True
                         lockfile_match_via_content_hash_only = True
+        elif (
+            locked_dep
+            and getattr(locked_dep, "source", None) == "registry"
+            and not ref_changed
+            and not update_refs
+        ):
+            # Registry deps have no resolved_commit; use content_hash as the
+            # skip-download signal (mirrors the git content-hash fallback above).
+            if _should_skip_redownload(locked_dep, install_path):
+                lockfile_match = True
 
     # Self-heal pipeline (PR #1158).
     #

--- a/src/apm_cli/install/phases/policy_gate.py
+++ b/src/apm_cli/install/phases/policy_gate.py
@@ -101,6 +101,13 @@ def run(ctx: InstallContext) -> None:
     apm_package = getattr(ctx, "apm_package", None)
     if apm_package is not None:
         extra_kwargs["manifest_includes"] = getattr(apm_package, "includes", None)
+        # Plumb the manifest registries: block so _check_registry_source
+        # can distinguish "configured" from "unreachable". Without this,
+        # any policy.registry_source.require name is falsely flagged as
+        # unconfigured even when the user wired the registry correctly.
+        registries_map = getattr(apm_package, "registries", None)
+        if registries_map is not None:
+            extra_kwargs["registries"] = registries_map
 
     audit_result = run_dependency_policy_checks(
         ctx.deps_to_install,

--- a/src/apm_cli/install/phases/policy_target_check.py
+++ b/src/apm_cli/install/phases/policy_target_check.py
@@ -67,6 +67,8 @@ def run(ctx: InstallContext) -> None:
 
     policy = ctx.policy_fetch.policy
 
+    registries_map = getattr(ctx.apm_package, "registries", None) if ctx.apm_package else None
+
     audit_result = run_dependency_policy_checks(
         ctx.deps_to_install,
         lockfile=ctx.existing_lockfile,
@@ -74,6 +76,7 @@ def run(ctx: InstallContext) -> None:
         effective_target=effective_target,
         fetch_outcome=ctx.policy_fetch.outcome,
         fail_fast=False,  # ensure target check runs even if dep checks re-pass
+        registries=registries_map,
     )
 
     # ------------------------------------------------------------------

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -31,6 +31,34 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 
+def _lockfile_has_registry_deps(existing_lockfile) -> bool:
+    """True when the on-disk lockfile records at least one registry-sourced dep.
+
+    Used to construct the registry resolver even when apm.yml's
+    ``registries:`` block has been removed but locked deps still need to
+    re-install. A user clones a repo, the apm.yml has no registries: block
+    but the lockfile says some deps are ``source: registry`` — we still
+    want them to install (they'll fail at auth lookup if the URL doesn't
+    match anything configured, with a clear remediation per §6.2).
+    """
+    if not existing_lockfile:
+        return False
+    return any(
+        getattr(dep, "source", None) == "registry"
+        for dep in existing_lockfile.dependencies.values()
+    )
+
+
+def _require_package_registry_feature_if_needed(registries_map, existing_lockfile) -> bool:
+    """Validate the gate and return whether registry support is needed."""
+    needs_registry = bool(registries_map) or _lockfile_has_registry_deps(existing_lockfile)
+    if needs_registry:
+        from apm_cli.deps.registry.feature_gate import require_package_registry_enabled
+
+        require_package_registry_enabled("Registry-sourced installs")
+    return needs_registry
+
+
 def run(ctx: InstallContext) -> None:
     """Execute the resolve phase.
 
@@ -159,6 +187,31 @@ def run(ctx: InstallContext) -> None:
         )
 
     # ------------------------------------------------------------------
+    # 3b. Dedicated registry resolver (design §3.1, §8)
+    # ------------------------------------------------------------------
+    # Built when:
+    #   - the manifest's apm.yml has a top-level ``registries:`` block, OR
+    #   - the on-disk lockfile has at least one ``source: registry`` entry
+    #     (re-install of a project whose authors removed the block but the
+    #     locked deps still need somewhere to land).
+    # In the second case the URL is the trust anchor — auth resolves by
+    # URL prefix against the apm.yml registries map (which may be empty,
+    # forcing anonymous fetch).
+    registry_resolver = None
+    _apply_lockfile_registry_name = None
+    registries_map = getattr(ctx.apm_package, "registries", None) or {}
+    needs_registry = _require_package_registry_feature_if_needed(registries_map, existing_lockfile)
+    if needs_registry:
+        from apm_cli.deps.registry.auth import (
+            dependency_ref_with_registry_name_from_lockfile,
+        )
+        from apm_cli.deps.registry.resolver import RegistryPackageResolver
+
+        registry_resolver = RegistryPackageResolver(registries_map)
+        _apply_lockfile_registry_name = dependency_ref_with_registry_name_from_lockfile
+    ctx.registry_resolver = registry_resolver
+
+    # ------------------------------------------------------------------
     # 4. Tracking variables (phase-local except where noted)
     # ------------------------------------------------------------------
     # direct_dep_keys is phase-local (only read inside download_callback)
@@ -233,6 +286,64 @@ def run(ctx: InstallContext) -> None:
                 if _tui is None or not _tui.is_animating():
                     logger.resolving_heartbeat(_display)
         try:
+            # ─── Registry-sourced dep (design §8) ──────────────────────
+            # Routed before local/git so the registry resolver owns the
+            # download for source=="registry" entries. Lockfile re-installs
+            # may arrive with registry_name=None — look it up by URL prefix
+            # against the configured registries map.
+            if dep_ref.source == "registry":
+                from apm_cli.deps.registry.feature_gate import (
+                    require_package_registry_enabled,
+                )
+
+                require_package_registry_enabled("Registry-sourced downloads")
+
+                if registry_resolver is None:
+                    raise RuntimeError(
+                        f"dep {dep_ref.repo_url!r} is registry-sourced but no "
+                        f"registries: block is configured in apm.yml and the "
+                        f"lockfile carries no resolved_url for it."
+                    )
+                dep_ref = _apply_lockfile_registry_name(
+                    dep_ref,
+                    registries_map,
+                    existing_lockfile=existing_lockfile,
+                )
+                # Registry T5: honor lockfile on apm install (mirrors git T5
+                # at lines below). When the lockfile has full replay data and
+                # the manifest range still covers the locked version, fetch
+                # from the locked URL and verify against the locked hash
+                # (npm install model — no /versions API call).
+                _locked_reg = (
+                    existing_lockfile.get_dependency(dep_ref.get_unique_key())
+                    if existing_lockfile
+                    else None
+                )
+                if (
+                    not update_refs
+                    and _locked_reg
+                    and _locked_reg.resolved_url
+                    and _locked_reg.resolved_hash
+                    and _locked_reg.version
+                ):
+                    from apm_cli.drift import detect_ref_change as _detect_ref_change
+
+                    if not _detect_ref_change(dep_ref, _locked_reg, update_refs=False):
+                        registry_resolver.download_from_lockfile(
+                            dep_ref,
+                            install_path,
+                            resolved_url=_locked_reg.resolved_url,
+                            resolved_hash=_locked_reg.resolved_hash,
+                            version=_locked_reg.version,
+                        )
+                        callback_downloaded[dep_ref.get_unique_key()] = None
+                        return install_path
+                registry_resolver.download_package(dep_ref, install_path)
+                # Mark as already-downloaded so the parallel pre-download
+                # phase skips this dep. No SHA for registry deps.
+                callback_downloaded[dep_ref.get_unique_key()] = None
+                return install_path
+
             # Handle local packages: copy instead of git clone
             if dep_ref.is_local and dep_ref.local_path:
                 if (

--- a/src/apm_cli/install/registry_wiring.py
+++ b/src/apm_cli/install/registry_wiring.py
@@ -1,0 +1,63 @@
+"""Install-phase glue for the dedicated package registry (REST), not HTTP client logic.
+
+``deps.registry`` owns fetching and verifying registry packages. This module
+owns how the install pipeline reads ``InstallContext.registry_resolver`` and
+lockfile rows to populate ``InstalledPackage.registry_resolution`` — i.e.
+orchestration only, kept out of ``sources.py`` so that file stays strategy-shaped.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from apm_cli.install.context import InstallContext
+
+
+def get_registry_resolver(ctx: Any) -> Any:
+    """Return ``ctx.registry_resolver`` when set (resolve phase may leave it ``None``)."""
+    return getattr(ctx, "registry_resolver", None)
+
+
+def resolver_last_registry_resolution(ctx: Any, dep_key: str) -> Any | None:
+    """Per-dep snapshot from the in-process resolver (``last_resolutions``), if any."""
+    resolver = get_registry_resolver(ctx)
+    if resolver is None:
+        return None
+    return resolver.last_resolutions.get(dep_key)
+
+
+def registry_resolution_for_cached_registry_dep(
+    ctx: InstallContext,
+    dep_ref: Any,
+    dep_key: str,
+    dep_locked_chk: Any,
+) -> Any | None:
+    """Build ``RegistryResolution`` for a registry dep on the cached install path.
+
+    Two sources, so the lockfile keeps ``resolved_url``, ``resolved_hash``, and
+    ``version`` when the package is reused from disk instead of re-downloaded:
+
+    1. The resolver's ``last_resolutions`` map — filled when the BFS callback in
+       ``resolve.py`` just downloaded this dep during dependency-graph resolution
+       (e.g. first install with no prior lockfile). This path was the bug fix.
+    2. The existing lockfile row — used on re-install when the tree is already on
+       disk and was verified earlier (original phase-7 wiring).
+
+    If neither applies, a registry dep on the cached path would degrade to a
+    v1-shaped lockfile entry (missing registry resolution fields).
+    """
+    if dep_ref.source != "registry":
+        return None
+    hit = resolver_last_registry_resolution(ctx, dep_key)
+    if hit is not None:
+        return hit
+    if dep_locked_chk and dep_locked_chk.resolved_url:
+        from apm_cli.deps.registry.resolver import RegistryResolution
+
+        return RegistryResolution(
+            resolved_url=dep_locked_chk.resolved_url,
+            resolved_hash=dep_locked_chk.resolved_hash or "",
+            version=dep_locked_chk.version or (dep_ref.reference or ""),
+        )
+    return None

--- a/src/apm_cli/install/sources.py
+++ b/src/apm_cli/install/sources.py
@@ -33,6 +33,11 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional  # noqa: F401, UP035
 
+from apm_cli.install.registry_wiring import (
+    get_registry_resolver,
+    registry_resolution_for_cached_registry_dep,
+    resolver_last_registry_resolution,
+)
 from apm_cli.utils.console import _rich_error, _rich_success
 from apm_cli.utils.short_sha import format_short_sha
 
@@ -448,6 +453,17 @@ class CachedDependencySource(DependencySource):
         ):
             _cached_registry = ctx.registry_config
 
+        _cached_resolution = None
+        if dep_ref.source == "registry":
+            from apm_cli.deps.registry.feature_gate import (
+                require_package_registry_enabled,
+            )
+
+            require_package_registry_enabled("Registry-sourced cached installs")
+            _cached_resolution = registry_resolution_for_cached_registry_dep(
+                ctx, dep_ref, dep_key, dep_locked_chk
+            )
+
         ctx.installed_packages.append(
             InstalledPackage(
                 dep_ref=dep_ref,
@@ -456,6 +472,7 @@ class CachedDependencySource(DependencySource):
                 resolved_by=resolved_by,
                 is_dev=_is_dev,
                 registry_config=_cached_registry,
+                registry_resolution=_cached_resolution,
             )
         )
         if install_path.is_dir():
@@ -543,6 +560,60 @@ class FreshDependencySource(DependencySource):
 
             if dep_key in ctx.pre_download_results:
                 package_info = ctx.pre_download_results[dep_key]
+            elif dep_ref.source == "registry":
+                from apm_cli.deps.registry.feature_gate import (
+                    require_package_registry_enabled,
+                )
+
+                require_package_registry_enabled("Registry-sourced downloads")
+
+                # Registry-sourced dep: dispatch to the dedicated-registry
+                # resolver instead of the GitHub downloader. This branch
+                # fires when (a) the BFS callback skipped due to existing
+                # install path on a re-install, or (b) parallel pre-download
+                # was skipped (registry deps aren't pre-downloaded).
+                _registry_resolver = get_registry_resolver(ctx)
+                if _registry_resolver is None:
+                    raise RuntimeError(
+                        f"dep {dep_ref.repo_url!r} is registry-sourced but "
+                        f"no registry resolver was constructed (apm.yml may "
+                        f"be missing a 'registries:' block)."
+                    )
+                # Lockfile re-install path: registry_name might be absent —
+                # look it up from the lockfile's resolved_url.
+                from apm_cli.deps.registry.auth import (
+                    dependency_ref_with_registry_name_from_lockfile,
+                )
+
+                _regs = getattr(ctx.apm_package, "registries", None) or {}
+                download_ref = dependency_ref_with_registry_name_from_lockfile(
+                    download_ref,
+                    _regs,
+                    locked_dep=dep_locked_chk,
+                )
+                # Lockfile replay (npm install model): fetch directly from the
+                # locked URL and verify against the locked hash when available
+                # and the manifest range still covers the locked version.
+                if (
+                    not ctx.update_refs
+                    and dep_locked_chk
+                    and dep_locked_chk.resolved_url
+                    and dep_locked_chk.resolved_hash
+                    and dep_locked_chk.version
+                    and not ref_changed
+                ):
+                    package_info = _registry_resolver.download_from_lockfile(
+                        download_ref,
+                        install_path,
+                        resolved_url=dep_locked_chk.resolved_url,
+                        resolved_hash=dep_locked_chk.resolved_hash,
+                        version=dep_locked_chk.version,
+                    )
+                else:
+                    package_info = _registry_resolver.download_package(
+                        download_ref,
+                        install_path,
+                    )
             else:
                 package_info = ctx.downloader.download_package(
                     download_ref,
@@ -569,7 +640,11 @@ class FreshDependencySource(DependencySource):
                     # F3 (#1116): centralised hex/sentinel-aware short SHA helper.
                     _sha = format_short_sha(resolved.resolved_commit)
                 logger.download_complete(display_name, ref=_ref, sha=_sha)
-                if ctx.auth_resolver:
+                # Only emit the per-package git auth diagnostic for git deps.
+                # Registry-sourced deps don't talk to git hosts; resolving
+                # github.com auth here for them is misleading (and can issue
+                # network calls via auth.AuthResolver providers).
+                if ctx.auth_resolver and dep_ref.source in (None, "git"):
                     try:
                         _host = dep_ref.host or "github.com"
                         _org = (
@@ -605,6 +680,14 @@ class FreshDependencySource(DependencySource):
             depth = node.depth if node else 1
             resolved_by = node.parent.dependency_ref.repo_url if node and node.parent else None
             _is_dev = node.is_dev if node else False
+            # Registry-sourced deps: pull the captured resolution out of
+            # the resolver's per-graph map so the lockfile records
+            # resolved_url + resolved_hash + version (design §6.1).
+            _registry_resolution = (
+                resolver_last_registry_resolution(ctx, dep_key)
+                if dep_ref.source == "registry"
+                else None
+            )
             ctx.installed_packages.append(
                 InstalledPackage(
                     dep_ref=dep_ref,
@@ -612,7 +695,8 @@ class FreshDependencySource(DependencySource):
                     depth=depth,
                     resolved_by=resolved_by,
                     is_dev=_is_dev,
-                    registry_config=ctx.registry_config if not dep_ref.is_local else None,
+                    registry_config=(ctx.registry_config if not dep_ref.is_local else None),
+                    registry_resolution=_registry_resolution,
                 )
             )
             if install_path.is_dir():

--- a/src/apm_cli/marketplace/models.py
+++ b/src/apm_cli/marketplace/models.py
@@ -64,6 +64,16 @@ class MarketplacePlugin:
     tags: tuple[str, ...] = ()
     source_marketplace: str = ""  # Populated during resolution
 
+    # Dedicated registry routing per docs/proposals/registry-api.md §4.5.
+    # When set, the plugin resolves through the named APM registry (rather
+    # than the existing Git resolver). ``version`` is interpreted as a
+    # semver range. ``registry == ""`` (default) keeps existing semantics:
+    # the plugin resolves via Git and ``version`` is a Git ref/tag.
+    # The discriminator is a separate field (not piggybacking on ``source``)
+    # to avoid colliding with the existing source-location semantics where
+    # ``source`` is a string path or ``{type: github, repo: ...}`` dict.
+    registry: str = ""
+
     def matches_query(self, query: str) -> bool:
         """Return True if the plugin matches a search query (case-insensitive)."""
         q = query.lower()
@@ -160,6 +170,40 @@ def _parse_plugin_entry(entry: dict[str, Any], source_name: str) -> MarketplaceP
         logger.debug("Plugin '%s' has no source or repository field", name)
         return None
 
+    # Optional dedicated-registry routing (design §4.5). When ``registry``
+    # is set, ``version`` is interpreted as a semver range and the plugin
+    # resolves via the dedicated-registry resolver. The marketplace.json
+    # parser is intentionally permissive — invalid values are downgraded
+    # to "no registry routing" and a debug log line, so a malformed entry
+    # doesn't break a whole marketplace fetch.
+    registry_name = ""
+    raw_registry = entry.get("registry")
+    if raw_registry is not None:
+        if isinstance(raw_registry, str) and raw_registry.strip():
+            registry_name = raw_registry.strip()
+        else:
+            logger.debug(
+                "Plugin '%s' has invalid 'registry' field (expected non-empty string), ignoring",
+                name,
+            )
+
+    if registry_name and version:
+        # Validate semver range for registry-routed plugins. A bad ref
+        # surfaces here as a debug log + downgrade to "no registry"
+        # rather than a hard fail, since one malformed plugin shouldn't
+        # poison a whole marketplace.
+        from apm_cli.deps.registry.semver import is_semver_range
+
+        if not is_semver_range(version):
+            logger.debug(
+                "Plugin '%s' has registry='%s' but version '%s' is not a "
+                "semver range; ignoring registry routing for this entry",
+                name,
+                registry_name,
+                version,
+            )
+            registry_name = ""
+
     return MarketplacePlugin(
         name=name,
         source=source,
@@ -167,6 +211,7 @@ def _parse_plugin_entry(entry: dict[str, Any], source_name: str) -> MarketplaceP
         version=version,
         tags=tags,
         source_marketplace=source_name,
+        registry=registry_name,
     )
 
 

--- a/src/apm_cli/models/apm_package.py
+++ b/src/apm_cli/models/apm_package.py
@@ -6,9 +6,10 @@ Dependency and validation types have been extracted to sibling modules
 compatibility.
 """
 
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Union  # noqa: F401, UP035
+from typing import Any
 
 import yaml
 
@@ -66,6 +67,141 @@ def clear_apm_yml_cache() -> None:
     _apm_yml_cache.clear()
 
 
+def _parse_registries_block(data: dict, apm_yml_path: Path):
+    """Parse the top-level ``registries:`` block per design §3.1.
+
+    Schema::
+
+        registries:
+          corp-main:
+            url: https://registry.corp.example.com/apm
+          corp-other:
+            url: https://other.example.com/apm
+          default: corp-main           # optional; routes unscoped deps here
+
+    Returns ``(registries_map, default_name)`` where *registries_map* is
+    ``{name: url}`` and *default_name* is the value of ``default:`` (or
+    ``None``). Absent block returns ``(None, None)``.
+    """
+    raw = data.get("registries")
+    if raw is None:
+        return None, None
+    if raw != {}:
+        from ..deps.registry.feature_gate import require_package_registry_enabled
+
+        require_package_registry_enabled("Top-level 'registries:' blocks")
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"Top-level 'registries:' block in {apm_yml_path} must be a "
+            f"mapping (name -> {{url: ...}})"
+        )
+
+    default_value = raw.get("default")
+    registries_map: dict[str, str] = {}
+    for name, body in raw.items():
+        if name == "default":
+            continue
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError(
+                f"Registry name in 'registries:' block must be a non-empty string (got {name!r})"
+            )
+        if not isinstance(body, dict):
+            raise ValueError(
+                f"Registry {name!r} must be a mapping with at least 'url:' "
+                f"(got {type(body).__name__})"
+            )
+        # Token trap: tokens must never appear in repo-tracked YAML files.
+        if "token" in body:
+            from ..deps.registry.auth import registry_token_env_var
+
+            raise ValueError(
+                f"Registry {name!r}: 'token' must not appear in apm.yml. "
+                f"Use the {registry_token_env_var(name)} "
+                f"environment variable or 'apm config set registry.{name}.token <value>'."
+            )
+        url = body.get("url")
+        if not isinstance(url, str) or not url.strip():
+            raise ValueError(f"Registry {name!r} is missing required field 'url:'")
+        url = url.strip()
+        if not url.startswith(("https://", "http://")):
+            raise ValueError(
+                f"Registry {name!r} URL must start with https:// or http:// (got {url!r})"
+            )
+        # Reject any unknown keys to catch typos early.
+        unknown = set(body.keys()) - {"url"}
+        if unknown:
+            raise ValueError(
+                f"Registry {name!r} has unknown fields: {sorted(unknown)} (known fields: ['url'])"
+            )
+        registries_map[name] = url
+
+    default_name: str | None = None
+    if default_value is not None:
+        if not isinstance(default_value, str) or not default_value.strip():
+            raise ValueError(
+                f"'registries.default' in {apm_yml_path} must be a non-empty "
+                f"string naming one of the configured registries"
+            )
+        default_name = default_value.strip()
+        if default_name not in registries_map:
+            raise ValueError(
+                f"'registries.default: {default_name}' refers to an "
+                f"unconfigured registry. Configured: {sorted(registries_map.keys())}"
+            )
+
+    if not registries_map and default_name is None:
+        return None, None
+
+    return registries_map, default_name
+
+
+def _route_unscoped_to_default_registry(
+    dep_list: list,
+    default_registry: str,
+) -> None:
+    """Route unscoped APM deps to *default_registry* in place.
+
+    Two cases:
+    * Object-form entries already parsed as ``source="registry"`` but with no
+      ``registry_name`` (i.e. ``registry:`` key was omitted, caller relies on
+      the project-level ``registries.default``).
+    * String-shorthand entries with any ref — when a default registry is
+      configured, all shorthands route there regardless of whether the ref
+      looks like semver. Use the explicit ``- git:`` object form to pin a
+      dependency to Git when a default registry is active.
+    """
+    for dep in dep_list:
+        if not isinstance(dep, DependencyReference):
+            continue
+        if dep.source == "registry" and dep.registry_name is None:
+            dep.registry_name = default_registry
+        elif dep.source not in {"git", "registry"} and not dep.is_local:
+            ref = dep.reference
+            if ref:
+                dep.source = "registry"
+                dep.registry_name = default_registry
+            else:
+                raise ValueError(
+                    f"no version constraint: '{dep.repo_url}' has no '#<version>' "
+                    f"but would route to registry '{default_registry}'. "
+                    f"Add a version selector (e.g. '{dep.repo_url}#1.0.0') or use "
+                    f"'- git:' to keep this dependency on Git."
+                )
+
+
+def _iter_apm_dependency_lists(
+    dependencies: dict[str, Any] | None,
+    dev_dependencies: dict[str, Any] | None,
+) -> Iterator[list[Any]]:
+    """Yield each parsed ``dependencies['apm']`` / ``devDependencies['apm']`` list."""
+    for bucket in (dependencies, dev_dependencies):
+        if not bucket:
+            continue
+        apm_list = bucket.get("apm") if isinstance(bucket, dict) else None
+        if isinstance(apm_list, list):
+            yield apm_list
+
+
 @dataclass
 class APMPackage:
     """Represents an APM package with metadata."""
@@ -106,6 +242,12 @@ class APMPackage:
         None  # Package content type: instructions, skill, hybrid, or prompts
     )
     includes: str | list[str] | None = None  # Include-only manifest: 'auto' or list of repo paths
+
+    # Top-level ``registries:`` block per docs/proposals/registry-api.md §3.1.
+    # Maps registry name -> base URL. None when no ``registries:`` block is present.
+    registries: dict[str, str] | None = None
+    # Value of ``registries.default:`` — routes unscoped deps to this registry.
+    default_registry: str | None = None
 
     @classmethod
     def _parse_dependency_dict(cls, raw_deps: dict, label: str = "") -> dict:
@@ -208,6 +350,9 @@ class APMPackage:
         if "version" not in data:
             raise ValueError("Missing required field 'version' in apm.yml")
 
+        # Top-level ``registries:`` block per design §3.1.
+        registries, default_registry = _parse_registries_block(data, apm_yml_path)
+
         # Parse dependencies
         dependencies = None
         raw_deps = data.get("dependencies")
@@ -237,6 +382,20 @@ class APMPackage:
                     "      - owner/repo"
                 )
             dev_dependencies = cls._parse_dependency_dict(raw_dev_deps, label="dev ")
+
+        # Merge user/policy registry URLs and config.json default routing.
+        from ..deps.registry.config_loader import resolve_effective_registries
+
+        registries, default_registry = resolve_effective_registries(registries, default_registry)
+        if registries or default_registry:
+            from ..deps.registry.feature_gate import require_package_registry_enabled
+
+            require_package_registry_enabled("Registry configuration")
+
+        # Route unscoped deps to the effective default registry when configured.
+        if default_registry:
+            for dep_list in _iter_apm_dependency_lists(dependencies, dev_dependencies):
+                _route_unscoped_to_default_registry(dep_list, default_registry)
 
         # Parse package content type
         pkg_type = None
@@ -305,6 +464,8 @@ class APMPackage:
             targets=targets_value,
             type=pkg_type,
             includes=includes,
+            registries=registries,
+            default_registry=default_registry,
         )
         _apm_yml_cache[cache_key] = result
         return result
@@ -353,7 +514,7 @@ class PackageInfo:
     install_path: Path
     resolved_reference: ResolvedReference | None = None
     installed_at: str | None = None  # ISO timestamp
-    dependency_ref: Optional["DependencyReference"] = (
+    dependency_ref: DependencyReference | None = (
         None  # Original dependency reference for canonical string
     )
     package_type: PackageType | None = None  # APM_PACKAGE, CLAUDE_SKILL, or HYBRID
@@ -382,7 +543,13 @@ class PackageInfo:
         apm_dir = self.get_primitives_path()
         if apm_dir.exists():
             # Check for any primitive files in .apm/ subdirectories
-            for primitive_type in ["instructions", "chatmodes", "contexts", "prompts", "hooks"]:
+            for primitive_type in [
+                "instructions",
+                "chatmodes",
+                "contexts",
+                "prompts",
+                "hooks",
+            ]:
                 primitive_dir = apm_dir / primitive_type
                 if primitive_dir.exists() and any(primitive_dir.iterdir()):
                     return True

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -53,6 +53,13 @@ def _path_segment_pattern(is_ado_host: bool) -> str:
     return _ADO_PATH_SEGMENT_RE if is_ado_host else _NON_ADO_PATH_SEGMENT_RE
 
 
+def _is_valid_registry_semver_range(spec: str) -> bool:
+    """Defer importing ``deps.registry`` until call time (avoids import cycles)."""
+    from ...deps.registry.semver import is_semver_range
+
+    return is_semver_range(spec)
+
+
 @dataclass
 class DependencyReference:
     """Represents a reference to an APM dependency."""
@@ -96,6 +103,17 @@ class DependencyReference:
     # identity stays user-agnostic (lockfile pinning + dedup work the same
     # whether a project uses ``git@`` or an EMU/custom SSH account).
     ssh_user: str | None = None
+
+    # Registry resolver fields (optional; default to None/git semantics)
+    # source: which resolver should fetch this dep. None and "git" are equivalent
+    # (legacy default). Set to "registry" by the parser when an entry routes to
+    # a configured registry (via top-level registries: block or
+    # object-form `- registry:` / `- id:` discriminator).
+    # registry_name: name of the registry from apm.yml's registries: block when
+    # source == "registry". Carried in-memory only; never serialized into the
+    # lockfile (the lockfile uses URL-based identity per design §6.1).
+    source: str | None = None
+    registry_name: str | None = None
 
     # Supported file extensions for virtual packages
     VIRTUAL_FILE_EXTENSIONS = (
@@ -534,6 +552,18 @@ class DependencyReference:
         Raises:
             ValueError: If the entry is missing required fields or has invalid format
         """
+        # Object-form registry package — design §3.2.
+        # Discriminated by the ``registry:`` or ``id:`` key (``registry:`` is
+        # optional when a ``registries.default:`` is configured).  Mutually
+        # exclusive with ``git:``.
+        if "registry" in entry or "id" in entry:
+            if "git" in entry:
+                raise ValueError(
+                    "Object-style dependency cannot mix 'registry:'/'id:' and 'git:' "
+                    "keys — choose one resolver."
+                )
+            return cls._parse_registry_object_entry(entry)
+
         # Support dict-form local path: { path: ./local/dir }
         if "path" in entry and "git" not in entry:
             local = entry["path"]
@@ -549,7 +579,9 @@ class DependencyReference:
             return cls.parse(local)
 
         if "git" not in entry:
-            raise ValueError("Object-style dependency must have a 'git' or 'path' field")
+            raise ValueError(
+                "Object-style dependency must have a 'git', 'path', or 'registry' field"
+            )
 
         git_url = entry["git"]
         if not isinstance(git_url, str) or not git_url.strip():
@@ -615,6 +647,10 @@ class DependencyReference:
         # Parse the git URL using the standard parser
         dep = cls.parse(git_url)
         dep.allow_insecure = allow_insecure
+        # Object-form ``- git:`` is an explicit Git resolver pin, even when
+        # a top-level ``registries.default`` is set. Mark source so the
+        # default-routing pass in apm_package.py leaves it alone.
+        dep.source = "git"
 
         # Apply overrides from the object fields
         if ref_override is not None:
@@ -803,6 +839,98 @@ class DependencyReference:
             return 2
 
         return n
+
+    @classmethod
+    def _parse_registry_object_entry(cls, entry: dict) -> "DependencyReference":
+        """Parse the object-form registry entry per §3.2.
+
+        Required keys:
+            id:       <owner>/<repo>   # package identity at the registry
+            version:  <any-string>      # opaque version string; registry resolves it
+
+        Optional:
+            registry: <name>           # routes to named registry; omit to use default
+            path:     prompts/foo.md   # virtual sub-path; omit to install the whole package
+            alias:    <name>           # same meaning as in other object forms
+        """
+        from ...deps.registry.feature_gate import require_package_registry_enabled
+
+        require_package_registry_enabled("Object-form registry dependencies")
+
+        _registry_raw = entry.get("registry")
+        registry_name: str | None = None
+        if _registry_raw is not None:
+            if not isinstance(_registry_raw, str) or not _registry_raw.strip():
+                raise ValueError(
+                    "Object-form registry entry: 'registry' must be a non-empty "
+                    "string (the name of an entry in the apm.yml registries: block)"
+                )
+            registry_name = _registry_raw.strip()
+
+        pkg_id = entry.get("id")
+        if not isinstance(pkg_id, str) or not pkg_id.strip():
+            raise ValueError(
+                "Object-form registry entry: 'id' is required and must be a "
+                "non-empty 'owner/repo' string"
+            )
+        pkg_id = pkg_id.strip()
+        if "/" not in pkg_id:
+            raise ValueError(
+                f"Object-form registry entry: 'id' must be 'owner/repo', got {pkg_id!r}"
+            )
+
+        raw_path = entry.get("path")
+        sub_path: str | None = None
+        if raw_path is not None:
+            if not isinstance(raw_path, str) or not raw_path.strip():
+                raise ValueError(
+                    "Object-form registry entry: 'path' must be a non-empty string "
+                    "when provided (e.g. 'prompts/review.prompt.md')"
+                )
+            sub_path = raw_path.strip().strip("/").replace("\\", "/").strip("/")
+            validate_path_segments(sub_path, context="path")
+
+        version = entry.get("version")
+        if not isinstance(version, str) or not version.strip():
+            raise ValueError("Object-form registry entry: 'version' is required")
+        version = version.strip()
+
+        alias = entry.get("alias")
+        if alias is not None:
+            if not isinstance(alias, str) or not alias.strip():
+                raise ValueError("'alias' field must be a non-empty string")
+            alias = alias.strip()
+            if not re.match(r"^[a-zA-Z0-9._-]+$", alias):
+                raise ValueError(
+                    f"Invalid alias: {alias}. Aliases can only contain "
+                    f"letters, numbers, dots, underscores, and hyphens"
+                )
+
+        # Reject any unknown keys to catch typos early.
+        known = {"registry", "id", "path", "version", "alias"}
+        unknown = set(entry.keys()) - known
+        if unknown:
+            raise ValueError(
+                f"Object-form registry entry has unknown fields: "
+                f"{sorted(unknown)}. Known fields: {sorted(known)}"
+            )
+
+        owner_segments = pkg_id.split("/")
+        validate_path_segments(pkg_id, context="registry id")
+        for seg in owner_segments:
+            if not re.match(r"^[a-zA-Z0-9._-]+$", seg):
+                raise ValueError(f"Invalid registry id segment: {seg!r} in {pkg_id!r}")
+
+        return cls(
+            repo_url=pkg_id,
+            host=default_host(),
+            reference=version,
+            virtual_path=sub_path,
+            is_virtual=sub_path is not None,
+            alias=alias,
+            source="registry",
+            registry_name=registry_name,
+        )
 
     @classmethod
     def _detect_virtual_package(cls, dependency_str: str):

--- a/src/apm_cli/policy/__init__.py
+++ b/src/apm_cli/policy/__init__.py
@@ -16,6 +16,7 @@ from .schema import (
     McpPolicy,
     McpTransportPolicy,
     PolicyCache,
+    RegistrySourcePolicy,
     UnmanagedFilesPolicy,
 )
 
@@ -34,6 +35,7 @@ __all__ = [
     "PolicyFetchResult",
     "PolicyInheritanceError",
     "PolicyValidationError",
+    "RegistrySourcePolicy",
     "UnmanagedFilesPolicy",
     "check_dependency_allowed",
     "check_mcp_allowed",

--- a/src/apm_cli/policy/install_preflight.py
+++ b/src/apm_cli/policy/install_preflight.py
@@ -71,6 +71,7 @@ def run_policy_preflight(
     no_policy: bool = False,
     logger,
     dry_run: bool = False,
+    registries: dict[str, str] | None = None,
 ) -> tuple[PolicyFetchResult | None, bool]:
     """Discover + enforce policy for a non-pipeline command site.
 
@@ -149,6 +150,7 @@ def run_policy_preflight(
         policy=policy,
         mcp_deps=mcp_deps,
         fail_fast=(enforcement == "block"),
+        registries=registries,
     )
 
     if not audit_result.passed:

--- a/src/apm_cli/policy/parser.py
+++ b/src/apm_cli/policy/parser.py
@@ -18,6 +18,7 @@ from .schema import (
     McpPolicy,
     McpTransportPolicy,
     PolicyCache,
+    RegistrySourcePolicy,
     UnmanagedFilesPolicy,
 )
 
@@ -232,6 +233,12 @@ def _build_policy(data: dict) -> ApmPolicy:
         directories = _parse_tuple(uf_data.get("directories")) if "directories" in uf_data else None
         unmanaged_files = UnmanagedFilesPolicy(action=action, directories=directories)
 
+    reg_data = data.get("registry_source") or {}
+    registry_source = RegistrySourcePolicy(
+        require=_parse_tuple(reg_data.get("require")),
+        allow_non_registry=bool(reg_data.get("allow_non_registry", True)),
+    )
+
     return ApmPolicy(
         name=data.get("name", "") or "",
         version=data.get("version", "") or "",
@@ -244,6 +251,7 @@ def _build_policy(data: dict) -> ApmPolicy:
         compilation=compilation,
         manifest=manifest,
         unmanaged_files=unmanaged_files,
+        registry_source=registry_source,
     )
 
 

--- a/src/apm_cli/policy/policy_checks.py
+++ b/src/apm_cli/policy/policy_checks.py
@@ -769,6 +769,64 @@ def _check_unmanaged_files(
     )
 
 
+def _check_registry_source(
+    deps: list[DependencyReference],
+    policy: RegistrySourcePolicy,
+    registries_map: dict[str, str] | None,
+) -> CheckResult:
+    """Check registry source policy (require / allow_non_registry).
+
+    Fail-closed when a required registry name has no URL configured in
+    *registries_map* — that means the registry source is unreachable by
+    definition and the install must not proceed.
+    """
+    check_name = "registry-source"
+    no_op = not policy.require and policy.allow_non_registry
+    if no_op:
+        return CheckResult(name=check_name, passed=True, message="No registry source policy")
+
+    violations: list[str] = []
+
+    # Fail-closed: required registry names must be configured.
+    for req_name in policy.require:
+        if not registries_map or req_name not in registries_map:
+            violations.append(
+                f"required registry '{req_name}' is not configured — "
+                "add it to the 'registries:' block or via 'apm config set registry."
+                f"{req_name}.url <url>'"
+            )
+
+    for dep in deps:
+        key = dep.get_canonical_dependency_string()
+        is_registry = getattr(dep, "source", None) == "registry"
+        registry_name = getattr(dep, "registry_name", None)
+
+        if not policy.allow_non_registry and not is_registry:
+            violations.append(
+                f"{key}: non-registry source not permitted (policy requires registry sources only)"
+            )
+            continue
+
+        if policy.require and is_registry and registry_name not in policy.require:
+            violations.append(
+                f"{key}: sourced from registry '{registry_name}' "
+                f"but policy requires one of {sorted(policy.require)}"
+            )
+
+    if violations:
+        return CheckResult(
+            name=check_name,
+            passed=False,
+            message=f"{len(violations)} registry source violation(s)",
+            details=violations,
+        )
+    return CheckResult(
+        name=check_name,
+        passed=True,
+        message="All dependencies satisfy registry source policy",
+    )
+
+
 # -- Aggregate runners ---------------------------------------------
 
 
@@ -782,6 +840,7 @@ def run_dependency_policy_checks(
     fetch_outcome: str | None = None,
     fail_fast: bool = True,
     manifest_includes=_INCLUDES_NOT_PROVIDED,
+    registries: dict[str, str] | None = None,
 ) -> CIAuditResult:
     """Evaluate :class:`ApmPolicy` against an already-resolved dependency set.
 
@@ -861,7 +920,11 @@ def run_dependency_policy_checks(
     if _run(_check_transitive_depth(lockfile, policy.dependencies)):
         return result
 
-    # -- MCP checks (7-10) ----------------------------------------
+    # -- Registry source check (7) ---------------------------------
+    if _run(_check_registry_source(deps_list, policy.registry_source, registries)):
+        return result
+
+    # -- MCP checks (8-11) ----------------------------------------
     # When mcp_deps is None (not provided), skip MCP checks entirely.
     # When mcp_deps is an empty list (provided but no MCP deps), still
     # run MCP checks so they report "no X configured" for completeness.
@@ -964,6 +1027,7 @@ def run_policy_checks(
         # effective_target=None: target checks handled below from raw_yml
         fail_fast=fail_fast,
         manifest_includes=manifest.includes,
+        registries=getattr(manifest, "registries", None),
     )
     result.checks.extend(dep_result.checks)
 

--- a/src/apm_cli/policy/schema.py
+++ b/src/apm_cli/policy/schema.py
@@ -123,6 +123,20 @@ class UnmanagedFilesPolicy:
 
 
 @dataclass(frozen=True)
+class RegistrySourcePolicy:
+    """Rules governing which registries APM dependencies may use.
+
+    ``require``: registry names that MUST be the source for all deps.
+    ``allow_non_registry``: when ``False``, any dep that is not
+    registry-sourced (git, local, etc.) is blocked. Applied transitively
+    across the full resolved dep graph.
+    """
+
+    require: tuple[str, ...] = ()
+    allow_non_registry: bool = True
+
+
+@dataclass(frozen=True)
 class ApmPolicy:
     """Top-level APM policy model."""
 
@@ -137,3 +151,4 @@ class ApmPolicy:
     compilation: CompilationPolicy = field(default_factory=CompilationPolicy)
     manifest: ManifestPolicy = field(default_factory=ManifestPolicy)
     unmanaged_files: UnmanagedFilesPolicy = field(default_factory=UnmanagedFilesPolicy)
+    registry_source: RegistrySourcePolicy = field(default_factory=RegistrySourcePolicy)

--- a/tests/integration/test_runner_reference_phase3.py
+++ b/tests/integration/test_runner_reference_phase3.py
@@ -671,7 +671,7 @@ class TestParseFromDict:
 
     def test_missing_git_and_path_raises(self) -> None:
         DR = _dep_ref()
-        with pytest.raises(ValueError, match="'git' or 'path' field"):
+        with pytest.raises(ValueError, match=r"'git', 'path', or 'registry' field"):
             DR.parse_from_dict({"version": "1.0"})
 
     def test_allow_insecure_non_bool_raises(self) -> None:

--- a/tests/integration/test_runner_reference_resolution.py
+++ b/tests/integration/test_runner_reference_resolution.py
@@ -671,7 +671,7 @@ class TestParseFromDict:
 
     def test_missing_git_and_path_raises(self) -> None:
         DR = _dep_ref()
-        with pytest.raises(ValueError, match="'git' or 'path' field"):
+        with pytest.raises(ValueError, match=r"'git', 'path', or 'registry' field"):
             DR.parse_from_dict({"version": "1.0"})
 
     def test_allow_insecure_non_bool_raises(self) -> None:

--- a/tests/unit/commands/test_publish_registry_archive.py
+++ b/tests/unit/commands/test_publish_registry_archive.py
@@ -1,0 +1,66 @@
+"""Tests for ``apm publish`` flat registry archive packing."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from click.exceptions import ClickException
+
+from apm_cli.commands.publish import _pack_archive
+from apm_cli.models.apm_package import APMPackage
+
+
+def _list_tar_members(data: bytes) -> list[str]:
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
+        return sorted(m.name for m in tar.getmembers())
+
+
+class TestPackRegistryArchive:
+    def test_flat_apm_yml_and_dot_apm_at_root(self, tmp_path: Path) -> None:
+        (tmp_path / "apm.yml").write_text(
+            "name: demo\nversion: 1.2.3\ndescription: x\nauthor: a\n",
+            encoding="utf-8",
+        )
+        skill = tmp_path / ".apm" / "skills" / "demo" / "SKILL.md"
+        skill.parent.mkdir(parents=True)
+        skill.write_text("---\nname: demo\n---\n\n# Demo\n", encoding="utf-8")
+
+        pkg = APMPackage(name="demo", version="1.2.3")
+        logger = MagicMock()
+        tarball = _pack_archive(tmp_path, tmp_path / "apm.yml", pkg, logger, verbose=False)
+
+        assert tarball.name == "demo-1.2.3.tar.gz"
+        members = _list_tar_members(tarball.read_bytes())
+        assert "apm.yml" in members
+        assert any(m.startswith(".apm/skills/demo/SKILL.md") for m in members)
+        assert not any("/plugin.json" in m for m in members)
+        assert not any(m.startswith("demo-1.2.3/") for m in members)
+
+    def test_skips_appledouble_sidecars(self, tmp_path: Path) -> None:
+        (tmp_path / "apm.yml").write_text(
+            "name: demo\nversion: 1.0.0\ndescription: x\nauthor: a\n",
+            encoding="utf-8",
+        )
+        apm_dir = tmp_path / ".apm" / "skills" / "demo"
+        apm_dir.mkdir(parents=True)
+        (apm_dir / "SKILL.md").write_text("# skill\n", encoding="utf-8")
+        (tmp_path / "._apm.yml").write_bytes(b"junk")
+        (apm_dir / "._SKILL.md").write_bytes(b"junk")
+
+        pkg = APMPackage(name="demo", version="1.0.0")
+        tarball = _pack_archive(tmp_path, tmp_path / "apm.yml", pkg, MagicMock(), verbose=False)
+        members = _list_tar_members(tarball.read_bytes())
+        assert not any("._" in m for m in members)
+
+    def test_missing_dot_apm_rejected(self, tmp_path: Path) -> None:
+        (tmp_path / "apm.yml").write_text(
+            "name: demo\nversion: 1.0.0\ndescription: x\nauthor: a\n",
+            encoding="utf-8",
+        )
+        pkg = APMPackage(name="demo", version="1.0.0")
+        with pytest.raises(ClickException, match="requires a flat APM package"):
+            _pack_archive(tmp_path, tmp_path / "apm.yml", pkg, MagicMock(), verbose=False)

--- a/tests/unit/core/test_experimental.py
+++ b/tests/unit/core/test_experimental.py
@@ -567,3 +567,53 @@ class TestCoworkFlagRegistration:
         from apm_cli.core.experimental import FLAGS
 
         assert FLAGS["copilot_cowork"].name == "copilot_cowork"
+
+
+# ---------------------------------------------------------------------------
+# Package registry flag registration
+# ---------------------------------------------------------------------------
+
+
+class TestPackageRegistryFlagRegistration:
+    """Tests for the registries experimental flag registration."""
+
+    def test_package_registry_flag_is_registered(self) -> None:
+        from apm_cli.core.experimental import FLAGS
+
+        assert "registries" in FLAGS
+
+    def test_package_registry_flag_default_is_false(self) -> None:
+        from apm_cli.core.experimental import FLAGS
+
+        assert FLAGS["registries"].default is False
+
+    def test_package_registry_flag_is_disabled_by_default(self, inject_config: Any) -> None:
+        inject_config({})
+        from apm_cli.core.experimental import is_enabled
+
+        assert is_enabled("registries") is False
+
+    def test_package_registry_flag_can_be_enabled(self, isolated_config: Any) -> None:
+        from apm_cli.core.experimental import enable, is_enabled
+
+        enable("registries")
+        assert is_enabled("registries") is True
+
+    def test_package_registry_flag_hint_contains_docs_url(self) -> None:
+        from urllib.parse import urlparse
+
+        from apm_cli.core.experimental import FLAGS
+
+        hint = FLAGS["registries"].hint
+        assert hint is not None
+        urls = re.findall(r"https?://\S+", hint)
+        assert urls, "hint must contain at least one URL"
+        parsed = urlparse(urls[0])
+        assert parsed.scheme == "https"
+        assert parsed.hostname is not None
+        assert parsed.path.endswith("/guides/registries/")
+
+    def test_package_registry_key_equals_name(self) -> None:
+        from apm_cli.core.experimental import FLAGS
+
+        assert FLAGS["registries"].name == "registries"

--- a/tests/unit/install/test_policy_gate_phase.py
+++ b/tests/unit/install/test_policy_gate_phase.py
@@ -831,6 +831,77 @@ class TestExplicitIncludesWiring:
 
     @patch(_PATCH_CHECKS)
     @patch(_PATCH_DISCOVER)
+    def test_deps_to_install_forwarded_as_first_positional(self, mock_discover, mock_checks):
+        """Transitive enforcement contract: ``policy_gate`` forwards
+        ``ctx.deps_to_install`` (the BFS-flattened set produced by the
+        resolve phase) directly as the first positional arg to the dep
+        check seam. The check then iterates every dep in that list.
+
+        This pins down the coupling so a refactor that accidentally
+        filtered deps to "direct only" before the policy gate would
+        fail this test.
+        """
+        from apm_cli.models.apm_package import DependencyReference
+
+        mock_discover.return_value = _make_fetch_result("found", enforcement="block")
+        mock_checks.return_value = _passing_audit()
+        direct = DependencyReference(repo_url="acme/direct", reference="main")
+        transitive = DependencyReference(repo_url="acme/nested", reference="main")
+        ctx = _make_ctx(deps=[direct, transitive])
+
+        run(ctx)
+
+        # First positional arg to run_dependency_policy_checks is the deps list.
+        args, _ = mock_checks.call_args
+        assert list(args[0]) == [direct, transitive], (
+            "policy_gate must forward ctx.deps_to_install unchanged (transitive set included)"
+        )
+
+    @patch(_PATCH_CHECKS)
+    @patch(_PATCH_DISCOVER)
+    def test_registries_plumbed_from_apm_package(self, mock_discover, mock_checks):
+        """``policy_gate.run()`` must forward ``apm_package.registries``
+        as the ``registries=`` kwarg so the dep check seam can
+        distinguish 'configured' from 'unreachable' in the registry-
+        source policy check.
+        """
+        mock_discover.return_value = _make_fetch_result("found", enforcement="block")
+        mock_checks.return_value = _passing_audit()
+
+        fake_pkg = MagicMock()
+        fake_pkg.includes = None
+        fake_pkg.registries = {"corp-main": "https://registry.corp.example.com"}
+        ctx = _make_ctx(apm_package=fake_pkg)
+
+        run(ctx)
+
+        kwargs = mock_checks.call_args[1]
+        assert kwargs.get("registries") == fake_pkg.registries
+
+    @patch(_PATCH_CHECKS)
+    @patch(_PATCH_DISCOVER)
+    def test_registries_kwarg_omitted_when_manifest_has_no_registries(
+        self, mock_discover, mock_checks
+    ):
+        """When ``apm_package.registries`` is ``None`` (no registries:
+        block in the manifest), the kwarg should not be passed -- so the
+        check defaults to fail-closed for any ``policy.require`` name.
+        """
+        mock_discover.return_value = _make_fetch_result("found", enforcement="block")
+        mock_checks.return_value = _passing_audit()
+
+        fake_pkg = MagicMock()
+        fake_pkg.includes = None
+        fake_pkg.registries = None
+        ctx = _make_ctx(apm_package=fake_pkg)
+
+        run(ctx)
+
+        kwargs = mock_checks.call_args[1]
+        assert "registries" not in kwargs
+
+    @patch(_PATCH_CHECKS)
+    @patch(_PATCH_DISCOVER)
     def test_explicit_includes_violation_raises(self, mock_discover, mock_checks):
         # Simulate the seam returning an explicit-includes violation;
         # under enforcement=block, run() must raise PolicyViolationError.

--- a/tests/unit/install/test_resolve_registry.py
+++ b/tests/unit/install/test_resolve_registry.py
@@ -1,0 +1,358 @@
+"""Tests for the registry-resolver wiring in ``install/phases/resolve.py``.
+
+Covers:
+- ``_lockfile_has_registry_deps`` helper
+- ``ctx.registry_resolver`` is constructed when apm.yml has a registries:
+  block OR the lockfile carries registry-sourced entries
+- ``ctx.registry_resolver`` is left ``None`` for projects without either
+- The download_callback dispatch logic — direct call against the inner
+  closure is awkward, so we exercise it via a focused fake-resolver test
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from apm_cli.deps.lockfile import LockedDependency, LockFile
+from apm_cli.install.phases.resolve import (
+    _lockfile_has_registry_deps,
+    _require_package_registry_feature_if_needed,
+)
+
+
+def _set_package_registry(monkeypatch, enabled: bool):
+    import apm_cli.config as _conf
+
+    monkeypatch.setattr(
+        _conf,
+        "_config_cache",
+        {"experimental": {"registries": enabled}},
+    )
+
+
+class TestLockfileHasRegistryDeps:
+    def test_none_lockfile_returns_false(self):
+        assert _lockfile_has_registry_deps(None) is False
+
+    def test_empty_lockfile_returns_false(self):
+        assert _lockfile_has_registry_deps(LockFile()) is False
+
+    def test_only_git_deps_returns_false(self):
+        lock = LockFile()
+        lock.add_dependency(
+            LockedDependency(
+                repo_url="acme/foo",
+                resolved_commit="abc123",
+                host="github.com",
+            )
+        )
+        assert _lockfile_has_registry_deps(lock) is False
+
+    def test_only_local_deps_returns_false(self):
+        lock = LockFile()
+        lock.add_dependency(
+            LockedDependency(
+                repo_url="_local/x",
+                source="local",
+                local_path="./x",
+            )
+        )
+        assert _lockfile_has_registry_deps(lock) is False
+
+    def test_one_registry_dep_returns_true(self):
+        lock = LockFile()
+        lock.add_dependency(
+            LockedDependency(
+                repo_url="acme/foo",
+                resolved_commit="abc",
+                host="github.com",
+            )
+        )
+        lock.add_dependency(
+            LockedDependency(
+                repo_url="acme/bar",
+                source="registry",
+                resolved_url="https://r/v1/.../download",
+                resolved_hash="sha256:abc",
+                version="1.0.0",
+            )
+        )
+        assert _lockfile_has_registry_deps(lock) is True
+
+
+class TestResolverConstruction:
+    """``ctx.registry_resolver`` is built (or not) based on the manifest + lockfile state."""
+
+    def _make_ctx(
+        self,
+        tmp_path,
+        *,
+        registries: dict | None = None,
+        existing_lockfile: LockFile | None = None,
+        deps: list | None = None,
+    ):
+        from apm_cli.install.context import InstallContext
+
+        # Build a stand-in apm_package with the registries: attribute the
+        # phase reads. We don't need a real APMPackage for this test.
+        apm_package = MagicMock()
+        apm_package.registries = registries
+        apm_package.default_registry = None
+
+        ctx = InstallContext(project_root=tmp_path, apm_dir=tmp_path)
+        ctx.apm_package = apm_package
+        ctx.all_apm_deps = deps or []
+        ctx.update_refs = False
+        ctx.scope = MagicMock()
+        return ctx
+
+    def test_no_registries_no_lockfile_means_no_resolver(self, monkeypatch, tmp_path):
+        """Vanilla project (no registries:, no lockfile-registry-deps) skips resolver build."""
+        from apm_cli.install.phases import resolve as _resolve_mod
+
+        ctx = self._make_ctx(tmp_path)
+        # Stub out the rest of the phase so we only exercise resolver construction.
+        # We can't easily call run() end-to-end without a full pipeline; instead
+        # test the resolver-build logic directly via the helper + branch.
+        existing_lockfile = None
+        registries_map = ctx.apm_package.registries or {}
+        needs_registry = bool(registries_map) or _resolve_mod._lockfile_has_registry_deps(
+            existing_lockfile
+        )
+        assert needs_registry is False
+
+    def test_registries_block_triggers_resolver(self, tmp_path):
+        from apm_cli.install.phases import resolve as _resolve_mod
+
+        ctx = self._make_ctx(tmp_path, registries={"corp": "https://corp.example.com/apm"})
+        registries_map = ctx.apm_package.registries or {}
+        needs = bool(registries_map) or _resolve_mod._lockfile_has_registry_deps(None)
+        assert needs is True
+
+    def test_lockfile_registry_deps_trigger_resolver_even_without_block(self, tmp_path):
+        from apm_cli.install.phases import resolve as _resolve_mod
+
+        lock = LockFile()
+        lock.add_dependency(
+            LockedDependency(
+                repo_url="acme/x",
+                source="registry",
+                resolved_url="https://r/x",
+                resolved_hash="sha256:x",
+                version="1.0.0",
+            )
+        )
+        ctx = self._make_ctx(tmp_path)  # no registries: block
+        registries_map = ctx.apm_package.registries or {}
+        needs = bool(registries_map) or _resolve_mod._lockfile_has_registry_deps(lock)
+        assert needs is True
+
+
+class TestPackageRegistryExperimentalGate:
+    def test_no_registry_need_does_not_require_flag(self, monkeypatch):
+        _set_package_registry(monkeypatch, enabled=False)
+        assert _require_package_registry_feature_if_needed({}, None) is False
+
+    def test_registries_block_requires_flag(self, monkeypatch):
+        _set_package_registry(monkeypatch, enabled=False)
+        with pytest.raises(ValueError, match="apm experimental enable registries"):
+            _require_package_registry_feature_if_needed(
+                {"corp": "https://corp.example.com/apm"},
+                None,
+            )
+
+    def test_lockfile_registry_dep_requires_flag(self, monkeypatch):
+        _set_package_registry(monkeypatch, enabled=False)
+        lock = LockFile()
+        lock.add_dependency(
+            LockedDependency(
+                repo_url="acme/x",
+                source="registry",
+                resolved_url="https://r/x",
+                resolved_hash="sha256:x",
+                version="1.0.0",
+            )
+        )
+        with pytest.raises(ValueError, match="apm experimental enable registries"):
+            _require_package_registry_feature_if_needed({}, lock)
+
+    def test_registry_need_allowed_when_flag_enabled(self, monkeypatch):
+        _set_package_registry(monkeypatch, enabled=True)
+        assert (
+            _require_package_registry_feature_if_needed(
+                {"corp": "https://corp.example.com/apm"},
+                None,
+            )
+            is True
+        )
+
+
+class TestRegistryLockfileReplay:
+    """Phase 1 download_callback: registry T5 — honor lockfile on apm install."""
+
+    def _make_locked_dep(self, version="1.2.0"):
+        return LockedDependency(
+            repo_url="acme/web-skills",
+            source="registry",
+            version=version,
+            resolved_url=(
+                f"https://reg.example.com/apm/v1/packages/acme/web-skills"
+                f"/versions/{version}/download"
+            ),
+            resolved_hash="sha256:" + "a" * 64,
+        )
+
+    def _make_lockfile(self, version="1.2.0"):
+        lock = LockFile()
+        lock.add_dependency(self._make_locked_dep(version))
+        return lock
+
+    def test_download_from_lockfile_called_when_replay_available(self, tmp_path):
+        """With lockfile + matching range + not update_refs → download_from_lockfile."""
+        from unittest.mock import MagicMock, patch
+
+        from apm_cli.deps.lockfile import LockFile
+        from apm_cli.deps.registry.resolver import RegistryPackageResolver
+        from apm_cli.models.dependency.reference import DependencyReference
+
+        locked = self._make_locked_dep("1.2.0")
+        lock = LockFile()
+        lock.add_dependency(locked)
+
+        dep_ref = DependencyReference(
+            repo_url="acme/web-skills",
+            reference="^1.2.0",
+            source="registry",
+            registry_name="corp-main",
+        )
+
+        resolver = MagicMock(spec=RegistryPackageResolver)
+        install_path = tmp_path / "acme" / "web-skills"
+        install_path.mkdir(parents=True)
+
+        from apm_cli.deps.registry import feature_gate as _fg
+
+        with patch.object(_fg, "require_package_registry_enabled"):
+            # Simulate the registry T5 logic directly
+            _locked_reg = lock.get_dependency(dep_ref.get_unique_key())
+            assert _locked_reg is not None
+            assert _locked_reg.resolved_url
+            assert _locked_reg.resolved_hash
+            assert _locked_reg.version
+
+            from apm_cli.drift import detect_ref_change
+
+            ref_changed = detect_ref_change(dep_ref, _locked_reg, update_refs=False)
+            assert ref_changed is False  # "^1.2.0" covers "1.2.0"
+
+            # This confirms the T5 replay path would fire
+            resolver.download_from_lockfile(
+                dep_ref,
+                install_path,
+                resolved_url=_locked_reg.resolved_url,
+                resolved_hash=_locked_reg.resolved_hash,
+                version=_locked_reg.version,
+            )
+            resolver.download_from_lockfile.assert_called_once()
+            resolver.download_package.assert_not_called()
+
+    def test_replay_skipped_when_update_refs_true(self, tmp_path):
+        """With update_refs=True, the replay path is bypassed."""
+        from apm_cli.deps.lockfile import LockFile
+        from apm_cli.models.dependency.reference import DependencyReference
+
+        locked = self._make_locked_dep("1.2.0")
+        lock = LockFile()
+        lock.add_dependency(locked)
+
+        dep_ref = DependencyReference(
+            repo_url="acme/web-skills",
+            reference="^1.2.0",
+            source="registry",
+            registry_name="corp-main",
+        )
+
+        # update_refs=True → the replay guard fires at the outermost check
+        update_refs = True
+        _locked_reg = lock.get_dependency(dep_ref.get_unique_key())
+        # The `not update_refs` short-circuit means replay is bypassed
+        replay_would_fire = (
+            not update_refs
+            and _locked_reg
+            and _locked_reg.resolved_url
+            and _locked_reg.resolved_hash
+            and _locked_reg.version
+        )
+        assert replay_would_fire is False
+
+    def test_replay_skipped_when_range_no_longer_covers_locked_version(self):
+        """If the manifest range was bumped past the locked version, replay is skipped."""
+        from apm_cli.deps.lockfile import LockFile
+        from apm_cli.drift import detect_ref_change
+        from apm_cli.models.dependency.reference import DependencyReference
+
+        locked = self._make_locked_dep("1.2.0")
+        lock = LockFile()
+        lock.add_dependency(locked)
+
+        # Manifest was bumped to ^2.0.0 — no longer covers locked 1.2.0
+        dep_ref = DependencyReference(
+            repo_url="acme/web-skills",
+            reference="^2.0.0",
+            source="registry",
+            registry_name="corp-main",
+        )
+
+        _locked_reg = lock.get_dependency(dep_ref.get_unique_key())
+        ref_changed = detect_ref_change(dep_ref, _locked_reg, update_refs=False)
+        assert ref_changed is True  # range no longer covers locked version
+
+
+class TestRegistryResolutionFlowsToLockfile:
+    """End-to-end: a fake registry install captures resolved_url/hash into the lockfile."""
+
+    def test_installed_package_carries_resolution_to_locked_dependency(self):
+        # This test exercises the from_dependency_ref + InstalledPackage chain
+        # without spinning up the full install pipeline. The wiring already
+        # has resolver-level e2e tests; this one just confirms the data
+        # flows through InstalledPackage correctly to the LockFile.
+        from apm_cli.deps.installed_package import InstalledPackage
+        from apm_cli.deps.registry.resolver import RegistryResolution
+        from apm_cli.models.dependency.reference import DependencyReference
+
+        dep = DependencyReference(
+            repo_url="acme/web",
+            reference="^1.2.0",
+            source="registry",
+            registry_name="corp",
+        )
+        resolution = RegistryResolution(
+            resolved_url="https://corp.example.com/apm/v1/packages/acme/web/versions/1.2.3/download",
+            resolved_hash="sha256:" + "a" * 64,
+            version="1.2.3",
+        )
+        pkg = InstalledPackage(
+            dep_ref=dep,
+            resolved_commit=None,
+            depth=1,
+            resolved_by=None,
+            registry_resolution=resolution,
+        )
+
+        # Mock dependency_graph not actually needed for from_installed_packages
+        # without a real graph — pass a lightweight stub.
+        class _StubGraph:
+            pass
+
+        lock = LockFile.from_installed_packages([pkg], _StubGraph())
+        locked = lock.get_dependency("acme/web")
+        assert locked.source == "registry"
+        assert locked.resolved_url == resolution.resolved_url
+        assert locked.resolved_hash == "sha256:" + "a" * 64
+        assert locked.version == "1.2.3"
+
+        # And the lockfile bumps to v2 on emit.
+        yaml_out = lock.to_yaml()
+        assert "lockfile_version: '2'" in yaml_out

--- a/tests/unit/marketplace/test_registry_integration.py
+++ b/tests/unit/marketplace/test_registry_integration.py
@@ -1,0 +1,139 @@
+"""Tests for the marketplace.json registry-routing extension.
+
+Covers docs/proposals/registry-api.md §4.5:
+- New ``registry`` field on plugin entries (semver-validated)
+- Backwards-compat: existing marketplace.json files (no ``registry``
+  field) parse byte-identically.
+"""
+
+from __future__ import annotations
+
+from apm_cli.marketplace.models import (
+    parse_marketplace_json,
+)
+
+# ───────────────────────────────────────────────────────────────────────────
+# Schema extension: ``registry`` field on plugin entries
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestRegistryFieldParsing:
+    def test_plugin_without_registry_field_unchanged(self):
+        # Sanity: existing marketplace.json shape parses with registry="".
+        manifest = parse_marketplace_json(
+            {
+                "name": "acme",
+                "plugins": [
+                    {
+                        "name": "review",
+                        "repository": "acme/review",
+                        "description": "x",
+                        "version": "v1.0",
+                    }
+                ],
+            },
+            source_name="acme",
+        )
+        plugin = manifest.plugins[0]
+        assert plugin.name == "review"
+        assert plugin.version == "v1.0"
+        assert plugin.registry == ""
+
+    def test_plugin_with_valid_registry_routing(self):
+        manifest = parse_marketplace_json(
+            {
+                "name": "acme",
+                "plugins": [
+                    {
+                        "name": "enterprise-skills",
+                        "repository": "acme/enterprise-skills",
+                        "registry": "corp-main",
+                        "version": "^3.0.0",
+                        "description": "x",
+                    }
+                ],
+            },
+            source_name="acme",
+        )
+        plugin = manifest.plugins[0]
+        assert plugin.registry == "corp-main"
+        assert plugin.version == "^3.0.0"
+
+    def test_invalid_registry_field_downgrades_silently(self):
+        # Empty string, non-string, or invalid types: log + downgrade.
+        manifest = parse_marketplace_json(
+            {
+                "name": "acme",
+                "plugins": [
+                    {
+                        "name": "x",
+                        "repository": "a/b",
+                        "registry": 123,  # not a string
+                    }
+                ],
+            },
+            source_name="acme",
+        )
+        assert manifest.plugins[0].registry == ""
+
+    def test_invalid_semver_disables_registry_routing(self):
+        # If registry is set but version isn't a semver range, drop the
+        # routing to "" so the plugin doesn't silently mis-resolve.
+        manifest = parse_marketplace_json(
+            {
+                "name": "acme",
+                "plugins": [
+                    {
+                        "name": "x",
+                        "repository": "a/b",
+                        "registry": "corp",
+                        "version": "main",  # branch, not semver
+                    }
+                ],
+            },
+            source_name="acme",
+        )
+        assert manifest.plugins[0].registry == ""
+
+    def test_registry_with_no_version(self):
+        # Registry set, no version: parser keeps registry routing but
+        # leaves version="" — the resolver will reject it later. This
+        # matches "fail at resolve time, not at parse time" since the
+        # marketplace parser is permissive by design.
+        manifest = parse_marketplace_json(
+            {
+                "name": "acme",
+                "plugins": [
+                    {
+                        "name": "x",
+                        "repository": "a/b",
+                        "registry": "corp",
+                    }
+                ],
+            },
+            source_name="acme",
+        )
+        plugin = manifest.plugins[0]
+        assert plugin.registry == "corp"
+        assert plugin.version == ""
+
+    def test_existing_source_field_unchanged_alongside_registry(self):
+        # The new ``registry`` field MUST NOT collide with the existing
+        # source-location semantics. Both fields can coexist on one entry.
+        manifest = parse_marketplace_json(
+            {
+                "name": "acme",
+                "plugins": [
+                    {
+                        "name": "x",
+                        "source": {"type": "github", "repo": "a/b"},
+                        "registry": "corp",
+                        "version": "^1.0.0",
+                    }
+                ],
+            },
+            source_name="acme",
+        )
+        plugin = manifest.plugins[0]
+        assert plugin.source == {"type": "github", "repo": "a/b"}
+        assert plugin.registry == "corp"

--- a/tests/unit/policy/test_policy_checks.py
+++ b/tests/unit/policy/test_policy_checks.py
@@ -859,8 +859,8 @@ class TestUnmanagedFiles:
 
 
 class TestRunPolicyChecks:
-    def test_returns_all_17_checks(self, tmp_path):
-        """Full run should produce exactly 17 checks."""
+    def test_returns_all_18_checks(self, tmp_path):
+        """Full run should produce exactly 18 checks."""
         _write_apm_yml(
             tmp_path,
             {
@@ -884,7 +884,7 @@ class TestRunPolicyChecks:
 
         policy = ApmPolicy()
         result = run_policy_checks(tmp_path, policy)
-        assert len(result.checks) == 17
+        assert len(result.checks) == 18
         # Default policy = all checks pass
         assert result.passed
 

--- a/tests/unit/policy/test_run_dependency_policy_checks.py
+++ b/tests/unit/policy/test_run_dependency_policy_checks.py
@@ -26,6 +26,7 @@ from apm_cli.policy.schema import (
     DependencyPolicy,
     McpPolicy,
     McpTransportPolicy,
+    RegistrySourcePolicy,
 )
 
 # -- Helpers --------------------------------------------------------
@@ -542,3 +543,240 @@ class TestExplicitIncludesSeam:
             assert "explicit-includes" not in _failed_names(result), (
                 f"unexpected violation for includes={value!r}"
             )
+
+
+# -- Registry source policy (gap #5 verification) -----------------
+
+
+def _make_registry_dep(repo_url: str, registry_name: str, reference: str = "^1.0.0"):
+    """Build a DependencyReference for a registry-sourced dep."""
+    from apm_cli.models.apm_package import DependencyReference
+
+    return DependencyReference(
+        repo_url=repo_url,
+        reference=reference,
+        source="registry",
+        registry_name=registry_name,
+    )
+
+
+class TestRegistrySourcePolicyWiring:
+    """Verify gap #5: does ``registries=`` flow correctly into the check?
+
+    Each test calls ``run_dependency_policy_checks`` with the same args
+    used by the install pipeline (``policy_gate``) and varies only the
+    ``registries=`` kwarg. The behavior difference IS the bug.
+    """
+
+    def test_no_registries_kwarg_still_fails_closed(self):
+        """When the caller does NOT pass ``registries=`` (legacy callers
+        or callers without manifest access), the check must fail-closed:
+        any ``policy.require`` name is treated as unconfigured.
+
+        This is correct fail-closed behavior. Callers with manifest
+        access (install pipeline, audit --ci) should always pass
+        ``registries=`` so users with correctly-wired registries are
+        not falsely blocked -- see the next test.
+        """
+        deps = [_make_registry_dep("acme/foo", "corp-main")]
+        policy = ApmPolicy(
+            registry_source=RegistrySourcePolicy(require=("corp-main",)),
+        )
+        result = run_dependency_policy_checks(deps, policy=policy)
+        reg_checks = [c for c in result.checks if c.name == "registry-source"]
+        assert reg_checks, "registry-source check should have run"
+        assert not reg_checks[0].passed
+        assert any("corp-main" in d for d in (reg_checks[0].details or []))
+
+    def test_correctly_configured_registry_passes_when_registries_passed(self):
+        """Fix path: passing ``registries={'corp-main': '<url>'}`` lets
+        the check distinguish 'configured' from 'unreachable' and the
+        install proceeds.
+        """
+        deps = [_make_registry_dep("acme/foo", "corp-main")]
+        policy = ApmPolicy(
+            registry_source=RegistrySourcePolicy(require=("corp-main",)),
+        )
+        result = run_dependency_policy_checks(
+            deps,
+            policy=policy,
+            registries={"corp-main": "https://registry.corp.example.com"},
+        )
+        reg_checks = [c for c in result.checks if c.name == "registry-source"]
+        assert reg_checks, "registry-source check should have run"
+        assert reg_checks[0].passed, (
+            "with registries= passed, a correctly-routed dep should pass; "
+            "got: " + str(reg_checks[0].details)
+        )
+
+    def test_config_json_only_registry_counts_as_configured(self, tmp_path, monkeypatch):
+        """Merged config.json registries on APMPackage satisfy policy.require."""
+        import apm_cli.config as _conf
+        from apm_cli.models.apm_package import APMPackage, clear_apm_yml_cache
+
+        monkeypatch.setattr(
+            _conf,
+            "_config_cache",
+            {
+                "experimental": {"registries": True},
+                "registries": {
+                    "corp-main": {
+                        "url": "https://registry.corp.example.com",
+                        "default": True,
+                    }
+                },
+            },
+        )
+        clear_apm_yml_cache()
+        p = tmp_path / "apm.yml"
+        p.write_text("name: x\nversion: 1.0.0\ndependencies:\n  apm:\n    - acme/foo#^1.0.0\n")
+        pkg = APMPackage.from_apm_yml(p)
+        policy = ApmPolicy(
+            registry_source=RegistrySourcePolicy(require=("corp-main",)),
+        )
+        result = run_dependency_policy_checks(
+            pkg.get_apm_dependencies(),
+            policy=policy,
+            registries=pkg.registries,
+        )
+        reg_checks = [c for c in result.checks if c.name == "registry-source"]
+        assert reg_checks and reg_checks[0].passed
+
+    def test_unconfigured_required_registry_blocks_with_clear_message(self):
+        """Spec behavior: forgot to configure ``corp-main`` in apm.yml.
+        Caller passes an empty registries map. The check must fail-closed
+        with a message naming the missing registry.
+        """
+        deps = [_make_registry_dep("acme/foo", "corp-main")]
+        policy = ApmPolicy(
+            registry_source=RegistrySourcePolicy(require=("corp-main",)),
+        )
+        result = run_dependency_policy_checks(
+            deps,
+            policy=policy,
+            registries={},  # caller plumbed the map; it's just empty
+        )
+        reg_checks = [c for c in result.checks if c.name == "registry-source"]
+        assert reg_checks and not reg_checks[0].passed
+        assert any("corp-main" in d for d in (reg_checks[0].details or [])), (
+            "violation message should name the missing registry"
+        )
+
+    def test_no_op_when_policy_empty(self):
+        """Sanity: empty policy.require + allow_non_registry=True is no-op
+        regardless of registries= argument.
+        """
+        deps = _make_dep_refs(["owner/git-pkg"])
+        policy = ApmPolicy()  # default RegistrySourcePolicy()
+        result = run_dependency_policy_checks(deps, policy=policy)
+        reg_checks = [c for c in result.checks if c.name == "registry-source"]
+        assert reg_checks and reg_checks[0].passed
+
+
+class TestRegistrySourcePolicyTransitive:
+    """Verify gap #5: ``registry_source`` policy applies transitively
+    across the resolved dep graph (the governance-primitive requirement).
+
+    These tests pass a deps list that mixes a direct and a transitive dep
+    to ``run_dependency_policy_checks`` -- they assert the CHECK iterates
+    every dep, not just the first. They do NOT exercise the resolve phase
+    (a separate integration test pins down that ``ctx.deps_to_install``
+    is the BFS-flattened set; see ``TestPolicyGateRegistrySourceWiring``).
+    """
+
+    def test_transitive_dep_wrong_registry_is_blocked(self):
+        """Direct dep is from corp-main (allowed); transitive dep is from
+        an unapproved registry. Policy requires corp-main. The transitive
+        dep must be flagged.
+        """
+        deps = [
+            _make_registry_dep("acme/direct", "corp-main"),
+            _make_registry_dep("acme/nested", "shadow-mirror"),  # transitive, wrong reg
+        ]
+        policy = ApmPolicy(
+            registry_source=RegistrySourcePolicy(require=("corp-main",)),
+        )
+        result = run_dependency_policy_checks(
+            deps,
+            policy=policy,
+            registries={"corp-main": "https://registry.corp.example.com"},
+        )
+        reg = next(c for c in result.checks if c.name == "registry-source")
+        assert not reg.passed, "transitive dep from wrong registry must block"
+        # Detail messages name the offending dep so the user can locate it.
+        joined = " ".join(reg.details or [])
+        assert "acme/nested" in joined
+        assert "shadow-mirror" in joined
+
+    def test_transitive_git_dep_blocked_when_non_registry_forbidden(self):
+        """``allow_non_registry=False`` means EVERY dep in the resolved
+        graph must be registry-sourced. A transitive git dep pulled in by
+        a registry-correct direct dep must block the install.
+        """
+        from apm_cli.models.apm_package import DependencyReference
+
+        deps = [
+            _make_registry_dep("acme/direct", "corp-main"),
+            # transitive git dep -- source is None (= git), no registry_name
+            DependencyReference(repo_url="random/lib", reference="main"),
+        ]
+        policy = ApmPolicy(
+            registry_source=RegistrySourcePolicy(
+                require=("corp-main",),
+                allow_non_registry=False,
+            ),
+        )
+        result = run_dependency_policy_checks(
+            deps,
+            policy=policy,
+            registries={"corp-main": "https://registry.corp.example.com"},
+        )
+        reg = next(c for c in result.checks if c.name == "registry-source")
+        assert not reg.passed
+        joined = " ".join(reg.details or [])
+        assert "random/lib" in joined
+
+    def test_transitive_dep_correctly_sourced_passes(self):
+        """All deps -- direct AND transitive -- routed through corp-main
+        and registries plumbed: install proceeds.
+        """
+        deps = [
+            _make_registry_dep("acme/direct", "corp-main"),
+            _make_registry_dep("acme/nested", "corp-main"),
+        ]
+        policy = ApmPolicy(
+            registry_source=RegistrySourcePolicy(
+                require=("corp-main",),
+                allow_non_registry=False,
+            ),
+        )
+        result = run_dependency_policy_checks(
+            deps,
+            policy=policy,
+            registries={"corp-main": "https://registry.corp.example.com"},
+        )
+        reg = next(c for c in result.checks if c.name == "registry-source")
+        assert reg.passed, f"unexpected violations: {reg.details}"
+
+    def test_transitive_enforcement_passes_when_registries_plumbed(self):
+        """With ``registries={...}`` correctly plumbed, transitive
+        registry-correct deps proceed -- including when the policy also
+        bans non-registry sources transitively.
+        """
+        deps = [
+            _make_registry_dep("acme/direct", "corp-main"),
+            _make_registry_dep("acme/nested", "corp-main"),
+        ]
+        policy = ApmPolicy(
+            registry_source=RegistrySourcePolicy(
+                require=("corp-main",),
+                allow_non_registry=False,
+            ),
+        )
+        result = run_dependency_policy_checks(
+            deps,
+            policy=policy,
+            registries={"corp-main": "https://registry.corp.example.com"},
+        )
+        reg = next(c for c in result.checks if c.name == "registry-source")
+        assert reg.passed, "correctly-routed transitive graph should pass; got: " + str(reg.details)

--- a/tests/unit/registry/test_auth.py
+++ b/tests/unit/registry/test_auth.py
@@ -1,0 +1,232 @@
+"""Tests for registry auth resolution.
+
+Covers the env-var key derivation (``APM_REGISTRY_TOKEN_{NAME}``), URL-prefix
+matching for lockfile re-installs, and the §6.2 remediation message.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apm_cli.deps.registry.auth import (
+    RegistryAuthContext,
+    _env_key,
+    _normalize_url_prefix,
+    lookup_name_for_url,
+    remediation_message,
+    resolve_for_url,
+    resolve_registry_token,
+)
+
+
+class TestEnvKey:
+    """Env-var key derivation per design §7.1."""
+
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("corp", "APM_REGISTRY_TOKEN_CORP"),
+            ("corp-main", "APM_REGISTRY_TOKEN_CORP_MAIN"),
+            ("corp.main", "APM_REGISTRY_TOKEN_CORP_MAIN"),
+            ("Corp-Main", "APM_REGISTRY_TOKEN_CORP_MAIN"),
+            ("a-b.c", "APM_REGISTRY_TOKEN_A_B_C"),
+        ],
+    )
+    def test_key_form(self, name, expected):
+        assert _env_key(name) == expected
+
+
+class TestResolveRegistryToken:
+    def test_returns_env_value(self, monkeypatch):
+        monkeypatch.setenv("APM_REGISTRY_TOKEN_CORP_MAIN", "tok-123")
+        assert resolve_registry_token("corp-main") == "tok-123"
+
+    def test_missing_env_returns_none(self, monkeypatch):
+        monkeypatch.delenv("APM_REGISTRY_TOKEN_NOPE", raising=False)
+        assert resolve_registry_token("nope") is None
+
+
+class TestRegistryAuthContext:
+    def test_anonymous_has_no_header(self):
+        ctx = RegistryAuthContext(registry_name="corp", token=None)
+        assert ctx.auth_header() is None
+
+    def test_token_produces_bearer_header(self):
+        ctx = RegistryAuthContext(registry_name="corp", token="abc")
+        assert ctx.auth_header() == "Bearer abc"
+
+    def test_basic_auth_when_user_password_set(self):
+        ctx = RegistryAuthContext(
+            registry_name="corp",
+            token=None,
+            username="admin",
+            password="hunter2",
+        )
+        # Authorization: Basic base64("admin:hunter2") == "YWRtaW46aHVudGVyMg=="
+        assert ctx.auth_header() == "Basic YWRtaW46aHVudGVyMg=="
+
+    def test_bearer_wins_over_basic(self):
+        # When both are populated, Bearer is authoritative.
+        ctx = RegistryAuthContext(
+            registry_name="corp",
+            token="bearer-tok",
+            username="u",
+            password="p",
+        )
+        assert ctx.auth_header() == "Bearer bearer-tok"
+
+    def test_partial_basic_returns_anonymous(self):
+        # Only username set — no Basic header (need both).
+        ctx = RegistryAuthContext(
+            registry_name="corp",
+            token=None,
+            username="admin",
+            password=None,
+        )
+        assert ctx.auth_header() is None
+
+
+class TestBasicAuthEnvVars:
+    def test_user_pass_env_keys(self, monkeypatch):
+        from apm_cli.deps.registry.auth import _env_key_pass, _env_key_user
+
+        assert _env_key_user("corp-main") == "APM_REGISTRY_USER_CORP_MAIN"
+        assert _env_key_pass("corp-main") == "APM_REGISTRY_PASS_CORP_MAIN"
+        assert _env_key_user("corp.main") == "APM_REGISTRY_USER_CORP_MAIN"
+
+    def test_resolve_registry_basic(self, monkeypatch):
+        from apm_cli.deps.registry.auth import resolve_registry_basic
+
+        monkeypatch.setenv("APM_REGISTRY_USER_CORP", "admin")
+        monkeypatch.setenv("APM_REGISTRY_PASS_CORP", "hunter2")
+        assert resolve_registry_basic("corp") == ("admin", "hunter2")
+
+    def test_resolve_registry_basic_partial_returns_none(self, monkeypatch):
+        from apm_cli.deps.registry.auth import resolve_registry_basic
+
+        monkeypatch.setenv("APM_REGISTRY_USER_CORP", "admin")
+        monkeypatch.delenv("APM_REGISTRY_PASS_CORP", raising=False)
+        # Either missing -> (None, None)
+        assert resolve_registry_basic("corp") == (None, None)
+
+
+class TestMakeAuthContext:
+    def test_bearer_only(self, monkeypatch):
+        from apm_cli.deps.registry.auth import make_auth_context
+
+        monkeypatch.setenv("APM_REGISTRY_TOKEN_CORP", "bearer-tok")
+        monkeypatch.delenv("APM_REGISTRY_USER_CORP", raising=False)
+        monkeypatch.delenv("APM_REGISTRY_PASS_CORP", raising=False)
+        ctx = make_auth_context("corp")
+        assert ctx.token == "bearer-tok"
+        assert ctx.username is None
+        assert ctx.password is None
+        assert ctx.auth_header().startswith("Bearer ")
+
+    def test_basic_only(self, monkeypatch):
+        from apm_cli.deps.registry.auth import make_auth_context
+
+        monkeypatch.delenv("APM_REGISTRY_TOKEN_CORP", raising=False)
+        monkeypatch.setenv("APM_REGISTRY_USER_CORP", "admin")
+        monkeypatch.setenv("APM_REGISTRY_PASS_CORP", "hunter2")
+        ctx = make_auth_context("corp")
+        assert ctx.token is None
+        assert ctx.username == "admin"
+        assert ctx.password == "hunter2"
+        assert ctx.auth_header().startswith("Basic ")
+
+    def test_both_bearer_wins(self, monkeypatch):
+        from apm_cli.deps.registry.auth import make_auth_context
+
+        monkeypatch.setenv("APM_REGISTRY_TOKEN_CORP", "tok")
+        monkeypatch.setenv("APM_REGISTRY_USER_CORP", "admin")
+        monkeypatch.setenv("APM_REGISTRY_PASS_CORP", "hunter2")
+        ctx = make_auth_context("corp")
+        # Both populated; auth_header renders Bearer.
+        assert ctx.auth_header() == "Bearer tok"
+
+
+class TestUrlNormalize:
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            ("https://Corp.example.com/apm", "https://corp.example.com/apm"),
+            ("HTTPS://corp.example.com/apm/", "https://corp.example.com/apm"),
+            ("https://corp:8443/apm/", "https://corp:8443/apm"),
+            ("https://corp/apm/foo/", "https://corp/apm/foo"),
+        ],
+    )
+    def test_normalize(self, url, expected):
+        assert _normalize_url_prefix(url) == expected
+
+
+class TestLookupNameForUrl:
+    """URL prefix matching for lockfile re-install auth (§6.2 rule 1)."""
+
+    def test_exact_match(self):
+        regs = {"corp": "https://corp.example.com/apm"}
+        assert lookup_name_for_url("https://corp.example.com/apm", regs) == "corp"
+
+    def test_path_prefix_match(self):
+        regs = {"corp": "https://corp.example.com/apm"}
+        url = "https://corp.example.com/apm/v1/packages/acme/web/versions/1.0.0/tarball"
+        assert lookup_name_for_url(url, regs) == "corp"
+
+    def test_longest_prefix_wins(self):
+        regs = {
+            "corp": "https://corp.example.com/apm",
+            "corp-team-a": "https://corp.example.com/apm/team-a",
+        }
+        team_url = "https://corp.example.com/apm/team-a/foo"
+        assert lookup_name_for_url(team_url, regs) == "corp-team-a"
+        other_url = "https://corp.example.com/apm/some-other"
+        assert lookup_name_for_url(other_url, regs) == "corp"
+
+    def test_no_match_returns_none(self):
+        regs = {"corp": "https://corp.example.com/apm"}
+        assert lookup_name_for_url("https://other.com/apm", regs) is None
+
+    def test_case_insensitive_host(self):
+        regs = {"corp": "https://CORP.example.com/apm"}
+        assert lookup_name_for_url("https://corp.example.com/apm", regs) == "corp"
+
+    def test_partial_path_does_not_match(self):
+        # The configured URL is /apm but the target is /apm-team — must not match.
+        regs = {"corp": "https://corp.example.com/apm"}
+        assert lookup_name_for_url("https://corp.example.com/apm-team", regs) is None
+
+    def test_empty_inputs(self):
+        assert lookup_name_for_url("", {"corp": "https://corp.example.com"}) is None
+        assert lookup_name_for_url("https://corp.example.com", {}) is None
+
+
+class TestResolveForUrl:
+    """End-to-end auth resolution: URL -> name -> token."""
+
+    def test_returns_token_when_url_matches(self, monkeypatch):
+        monkeypatch.setenv("APM_REGISTRY_TOKEN_CORP", "tok-abc")
+        regs = {"corp": "https://corp.example.com/apm"}
+        ctx = resolve_for_url(
+            "https://corp.example.com/apm/v1/packages/x/y/versions/1.0.0/tarball", regs
+        )
+        assert ctx.registry_name == "corp"
+        assert ctx.token == "tok-abc"
+
+    def test_url_match_without_env_returns_anonymous(self, monkeypatch):
+        monkeypatch.delenv("APM_REGISTRY_TOKEN_CORP", raising=False)
+        regs = {"corp": "https://corp.example.com/apm"}
+        ctx = resolve_for_url("https://corp.example.com/apm/foo", regs)
+        assert ctx.registry_name == "corp"
+        assert ctx.token is None
+
+    def test_no_url_match_returns_anonymous(self):
+        ctx = resolve_for_url("https://other.example.com/foo", {"corp": "https://corp/apm"})
+        assert ctx.registry_name is None
+        assert ctx.token is None
+
+
+class TestRemediationMessage:
+    def test_includes_url_and_env_var_hint(self):
+        msg = remediation_message("https://corp.example.com/apm")
+        assert "https://corp.example.com/apm" in msg
+        assert "APM_REGISTRY_TOKEN_<NAME>" in msg

--- a/tests/unit/registry/test_client.py
+++ b/tests/unit/registry/test_client.py
@@ -1,0 +1,396 @@
+"""Tests for the registry HTTP client.
+
+Uses mocked ``requests.Session`` to avoid network access. Confirms:
+- URL construction (path joining, percent-encoding)
+- Auth header forwarding
+- JSON parsing of /versions responses
+- Error mapping (RFC 7807 problem detail extraction; transport errors)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from apm_cli.deps.registry.auth import RegistryAuthContext
+from apm_cli.deps.registry.client import (
+    RegistryClient,
+    RegistryError,
+    VersionEntry,
+    _quote,
+)
+
+
+def _make_response(
+    *,
+    status: int = 200,
+    json_body=None,
+    body: bytes = b"",
+    content_type: str = "application/json",
+):
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status
+    resp.url = "<test>"
+    resp.headers = {"Content-Type": content_type}
+    if json_body is not None:
+        resp.json.return_value = json_body
+    else:
+        resp.json.side_effect = ValueError("no body")
+    resp.content = body
+    return resp
+
+
+def _make_session(response):
+    session = MagicMock(spec=requests.Session)
+    session.request.return_value = response
+    return session
+
+
+class TestUrlConstruction:
+    def test_versions_url(self):
+        session = _make_session(_make_response(json_body={"package": "a/b", "versions": []}))
+        client = RegistryClient(
+            "https://r.example.com/apm/",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        client.list_versions("acme", "web-skills")
+        call = session.request.call_args
+        assert call.args == ("GET",)
+        assert call.kwargs["url"] == (
+            "https://r.example.com/apm/v1/packages/acme/web-skills/versions"
+        ), call.kwargs
+
+    def test_archive_url_helper(self):
+        client = RegistryClient(
+            "https://r.example.com/apm",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=MagicMock(spec=requests.Session),
+        )
+        url = client.archive_url("acme", "web-skills", "1.2.0")
+        assert url == (
+            "https://r.example.com/apm/v1/packages/acme/web-skills/versions/1.2.0/download"
+        )
+
+    def test_strips_trailing_slash_from_base(self):
+        client = RegistryClient(
+            "https://r.example.com/apm///",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=MagicMock(spec=requests.Session),
+        )
+        assert client.base_url == "https://r.example.com/apm"
+
+
+class TestAuth:
+    def test_anonymous_omits_authorization(self):
+        session = _make_session(_make_response(json_body={"versions": []}))
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        client.list_versions("a", "b")
+        headers = session.request.call_args.kwargs["headers"]
+        assert "Authorization" not in headers
+
+    def test_token_sets_bearer_header(self):
+        session = _make_session(_make_response(json_body={"versions": []}))
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token="tok-1"),
+            session=session,
+        )
+        client.list_versions("a", "b")
+        headers = session.request.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer tok-1"
+
+
+class TestListVersions:
+    def test_parses_versions(self):
+        session = _make_session(
+            _make_response(
+                json_body={
+                    "package": "acme/web-skills",
+                    "versions": [
+                        {
+                            "version": "1.2.0",
+                            "digest": "sha256:abc",
+                            "published_at": "2026-03-01T12:00:00Z",
+                        },
+                        {
+                            "version": "1.1.0",
+                            "digest": "sha256:def",
+                            "published_at": "2026-02-01T08:00:00Z",
+                        },
+                    ],
+                }
+            )
+        )
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        result = client.list_versions("acme", "web-skills")
+        assert result == [
+            VersionEntry("1.2.0", "sha256:abc", "2026-03-01T12:00:00Z"),
+            VersionEntry("1.1.0", "sha256:def", "2026-02-01T08:00:00Z"),
+        ]
+
+    def test_camel_case_published_at_is_rejected(self):
+        # The spec is strict (snake_case throughout). A server emitting
+        # ``publishedAt`` (camelCase) is non-conformant; the client MUST NOT
+        # silently accept it — that would mask spec drift. Because
+        # ``published_at`` is now required, the absent snake_case field causes
+        # a RegistryError even when the camelCase variant is present.
+        session = _make_session(
+            _make_response(
+                json_body={
+                    "package": "acme/foo",
+                    "versions": [
+                        {
+                            "version": "1.0.0",
+                            "digest": "sha256:abc",
+                            "publishedAt": "2026-04-26T14:00:00Z",
+                        }
+                    ],
+                }
+            )
+        )
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        with pytest.raises(RegistryError, match="missing 'published_at'"):
+            client.list_versions("acme", "foo")
+
+    def test_missing_versions_array_raises(self):
+        session = _make_session(_make_response(json_body={"package": "x"}))
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        with pytest.raises(RegistryError, match="missing 'versions' array"):
+            client.list_versions("a", "b")
+
+    def test_malformed_entry_raises(self):
+        session = _make_session(_make_response(json_body={"versions": [{"version": "1.0.0"}]}))
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        with pytest.raises(RegistryError, match="missing 'digest'"):
+            client.list_versions("a", "b")
+
+
+class TestDownloadArchive:
+    def test_returns_body_and_gzip_content_type(self):
+        session = _make_session(
+            _make_response(body=b"\x1f\x8b...", content_type="application/gzip")
+        )
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        body, ctype = client.download_archive("acme", "web-skills", "1.2.0")
+        assert body == b"\x1f\x8b..."
+        assert ctype == "application/gzip"
+
+    def test_returns_body_and_zip_content_type(self):
+        session = _make_session(
+            _make_response(body=b"PK\x03\x04...", content_type="application/zip")
+        )
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        body, ctype = client.download_archive("acme", "skill", "1.0.0")
+        assert body.startswith(b"PK")
+        assert ctype == "application/zip"
+
+    def test_strips_charset_param_from_content_type(self):
+        session = _make_session(
+            _make_response(
+                body=b"\x1f\x8b...",
+                content_type="application/gzip; charset=utf-8",
+            )
+        )
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        _, ctype = client.download_archive("a", "b", "1.0.0")
+        assert ctype == "application/gzip"
+
+    def test_url_path_is_download_not_tarball(self):
+        session = _make_session(_make_response(body=b"x", content_type="application/gzip"))
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        client.download_archive("acme", "web", "1.0.0")
+        url = session.request.call_args.kwargs["url"]
+        assert url.endswith("/versions/1.0.0/download")
+
+    def test_404_raises_with_status(self):
+        session = _make_session(
+            _make_response(
+                status=404,
+                json_body={"title": "Not Found", "detail": "no such version"},
+                content_type="application/problem+json",
+            )
+        )
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        with pytest.raises(RegistryError) as excinfo:
+            client.download_archive("a", "b", "9.9.9")
+        assert excinfo.value.status == 404
+        assert "Not Found" in str(excinfo.value)
+
+
+class TestFetchFromUrl:
+    """Tests for ``fetch_from_url`` — the lockfile-replay absolute-URL fetch."""
+
+    def test_happy_path_returns_bytes_and_content_type(self):
+        body = b"\x1f\x8b..."
+        session = _make_session(_make_response(body=body, content_type="application/gzip"))
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token="tok"),
+            session=session,
+        )
+        got_body, got_ct = client.fetch_from_url(
+            "https://r.example.com/v1/packages/a/b/versions/1.2.3/download"
+        )
+        assert got_body == body
+        assert got_ct == "application/gzip"
+
+    def test_passes_auth_header(self):
+        session = _make_session(_make_response(body=b"x", content_type="application/gzip"))
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token="mytoken"),
+            session=session,
+        )
+        url = "https://r.example.com/v1/packages/a/b/versions/1.0.0/download"
+        client.fetch_from_url(url)
+        call = session.request.call_args
+        assert call.kwargs["url"] == url
+        assert call.kwargs["headers"]["Authorization"] == "Bearer mytoken"
+
+    def test_uses_absolute_url_not_base_url(self):
+        """fetch_from_url must use the passed URL exactly, not prepend base_url."""
+        session = _make_session(_make_response(body=b"x", content_type="application/gzip"))
+        client = RegistryClient(
+            "https://r.example.com/apm",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        full_url = "https://other-host.example.com/packages/a/b/1.0/download"
+        client.fetch_from_url(full_url)
+        assert session.request.call_args.kwargs["url"] == full_url
+
+    def test_404_raises_registry_error_with_status(self):
+        session = _make_session(
+            _make_response(
+                status=404,
+                json_body={"title": "Not Found", "detail": "gone"},
+                content_type="application/problem+json",
+            )
+        )
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        with pytest.raises(RegistryError) as excinfo:
+            client.fetch_from_url("https://r.example.com/v1/packages/a/b/1.0/download")
+        assert excinfo.value.status == 404
+
+    def test_transport_error_wraps_to_registry_error(self):
+        session = MagicMock(spec=requests.Session)
+        session.request.side_effect = requests.ConnectionError("no route")
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        with pytest.raises(RegistryError, match="transport error"):
+            client.fetch_from_url("https://r.example.com/v1/packages/a/b/1.0/download")
+
+    def test_strips_charset_from_content_type(self):
+        session = _make_session(
+            _make_response(body=b"x", content_type="application/gzip; charset=utf-8")
+        )
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        _, ct = client.fetch_from_url("https://r.example.com/v1/packages/a/b/1.0/download")
+        assert ct == "application/gzip"
+
+
+class TestErrorMapping:
+    def test_transport_error_wraps(self):
+        session = MagicMock(spec=requests.Session)
+        session.request.side_effect = requests.ConnectionError("dns failed")
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        with pytest.raises(RegistryError, match="transport error"):
+            client.list_versions("a", "b")
+
+    def test_401_includes_problem_detail(self):
+        session = _make_session(
+            _make_response(
+                status=401,
+                json_body={"title": "Unauthorized", "detail": "missing token"},
+            )
+        )
+        client = RegistryClient(
+            "https://r.example.com",
+            RegistryAuthContext(registry_name="x", token=None),
+            session=session,
+        )
+        with pytest.raises(RegistryError) as excinfo:
+            client.list_versions("a", "b")
+        assert excinfo.value.status == 401
+        assert "missing token" in str(excinfo.value)
+
+
+class TestQuote:
+    """_quote must treat ``_`` as an RFC 3986 unreserved character."""
+
+    def test_underscore_is_not_encoded(self):
+        # Regression: previously safe=".-" caused '_' → '%5F'
+        assert _quote("my_org") == "my_org"
+
+    def test_hyphen_is_not_encoded(self):
+        assert _quote("my-org") == "my-org"
+
+    def test_dot_is_not_encoded(self):
+        assert _quote("my.org") == "my.org"
+
+    def test_slash_is_encoded(self):
+        assert _quote("a/b") == "a%2Fb"
+
+    def test_space_is_encoded(self):
+        assert _quote("a b") == "a%20b"
+
+    def test_mixed_underscore_hyphen_dot(self):
+        assert _quote("my_org.corp-main") == "my_org.corp-main"

--- a/tests/unit/registry/test_compat_matrix.py
+++ b/tests/unit/registry/test_compat_matrix.py
@@ -1,0 +1,420 @@
+"""Backwards-compatibility matrix per docs/proposals/registry-api.md §2.1.
+
+Each test asserts one explicit invariant. These are HARD requirements — any
+implementation PR that violates one must be rejected.
+
+Hand-traceable to invariant numbers in the proposal:
+
+- §2.1.1  Zero-config parity
+- §2.1.2  apm.yml stability
+- §2.1.3  Default source is git
+- §2.1.4  apm.lock stability (read; v1 stays v1; v2 readable)
+- §2.1.6  No env-var renames or semantics changes
+- §2.1.8  No identity changes
+- §2.1.10 Marketplace unchanged
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from apm_cli.deps.lockfile import LockedDependency, LockFile
+from apm_cli.deps.registry.resolver import RegistryResolution
+from apm_cli.models.apm_package import APMPackage, clear_apm_yml_cache
+from apm_cli.models.dependency.reference import DependencyReference
+
+
+@pytest.fixture
+def write_apm_yml(tmp_path):
+    def _write(content: str) -> Path:
+        clear_apm_yml_cache()
+        p = tmp_path / "apm.yml"
+        p.write_text(textwrap.dedent(content).strip() + "\n")
+        return p
+
+    return _write
+
+
+@pytest.fixture(autouse=True)
+def _enable_package_registry(monkeypatch):
+    """Registry compatibility tests opt in unless they explicitly disable it."""
+    import apm_cli.config as _conf
+
+    monkeypatch.setattr(
+        _conf,
+        "_config_cache",
+        {"experimental": {"registries": True}},
+    )
+
+
+def _disable_package_registry(monkeypatch):
+    import apm_cli.config as _conf
+
+    clear_apm_yml_cache()
+    monkeypatch.setattr(_conf, "_config_cache", {"experimental": {}})
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# §2.1.1 — Zero-config parity
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestZeroConfigParity:
+    """A user who never adds ``registries:`` MUST observe identical behavior."""
+
+    def test_no_registries_block_means_no_routing(self, write_apm_yml):
+        p = write_apm_yml("""
+            name: x
+            version: 1.0.0
+            dependencies:
+              apm:
+                - acme/foo#main
+                - acme/bar#abc1234
+                - acme/baz
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        # Block + default both unset
+        assert pkg.registries is None
+        assert pkg.default_registry is None
+        # No dep flipped to registry source
+        for dep in pkg.dependencies["apm"]:
+            assert dep.source is None
+            assert dep.registry_name is None
+
+    def test_branch_refs_remain_valid_without_block(self, write_apm_yml):
+        # §2.1.3 — branch refs and SHAs MUST remain valid when no
+        # registries: block is set. The strict-semver gate only fires on
+        # registry-routed entries.
+        p = write_apm_yml("""
+            name: x
+            version: 1.0.0
+            dependencies:
+              apm:
+                - acme/foo#main
+                - acme/foo#abc123def4567890abc123def4567890abc12345
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        # Both parsed successfully (no parse error)
+        assert pkg.dependencies["apm"][0].reference == "main"
+        assert pkg.dependencies["apm"][1].reference.startswith("abc123def")
+
+    def test_flag_off_does_not_affect_legacy_manifest(self, write_apm_yml, monkeypatch):
+        _disable_package_registry(monkeypatch)
+        p = write_apm_yml("""
+            name: x
+            version: 1.0.0
+            dependencies:
+              apm:
+                - acme/foo#main
+                - ./local/pkg
+                - git: https://github.com/acme/bar.git
+                  ref: develop
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        deps = pkg.dependencies["apm"]
+        assert deps[0].source is None
+        assert deps[1].is_local
+        assert deps[2].source == "git"
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# §2.1.2 — apm.yml stability
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestApmYmlStability:
+    def test_legacy_object_form_git_unchanged(self, write_apm_yml):
+        p = write_apm_yml("""
+            name: x
+            version: 1.0.0
+            dependencies:
+              apm:
+                - git: https://github.com/owner/repo.git
+                  ref: v2.0
+                  alias: my-pkg
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        d = pkg.dependencies["apm"][0]
+        # source=="git" is the new explicit marker; semantically same as None
+        assert d.source == "git"
+        assert d.alias == "my-pkg"
+        assert d.reference == "v2.0"
+
+    def test_legacy_object_form_local_unchanged(self, write_apm_yml):
+        p = write_apm_yml("""
+            name: x
+            version: 1.0.0
+            dependencies:
+              apm:
+                - path: ./local/pkg
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        d = pkg.dependencies["apm"][0]
+        assert d.is_local
+        assert d.local_path == "./local/pkg"
+
+    def test_unknown_top_level_key_does_not_break(self, write_apm_yml):
+        # A future apm.yml key shouldn't break this version of the parser.
+        p = write_apm_yml("""
+            name: x
+            version: 1.0.0
+            future_key: whatever
+            dependencies:
+              apm:
+                - acme/foo#v1.0
+            """)
+        # Should parse without error
+        pkg = APMPackage.from_apm_yml(p)
+        assert pkg.dependencies["apm"][0].reference == "v1.0"
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# §2.1.4 — apm.lock stability
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestLockfileStability:
+    def test_v1_lockfile_parses_without_migration(self):
+        v1_yaml = textwrap.dedent("""
+            lockfile_version: '1'
+            generated_at: 2026-01-01T00:00:00Z
+            dependencies:
+            - repo_url: acme/foo
+              resolved_commit: abc123
+              resolved_ref: v1.0
+              host: github.com
+              deployed_files:
+              - .apm/skills/foo/SKILL.md
+              package_type: APM_PACKAGE
+            """).strip()
+        lock = LockFile.from_yaml(v1_yaml)
+        assert lock.lockfile_version == "1"
+        dep = lock.get_dependency("acme/foo")
+        assert dep.resolved_commit == "abc123"
+        # No registry fields injected
+        assert dep.source is None
+        assert dep.resolved_url is None
+        assert dep.resolved_hash is None
+
+    def test_v1_lockfile_reemits_as_v1(self):
+        v1_yaml = textwrap.dedent("""
+            lockfile_version: '1'
+            generated_at: 2026-01-01T00:00:00Z
+            dependencies:
+            - repo_url: acme/foo
+              resolved_commit: abc123
+              host: github.com
+            """).strip()
+        lock = LockFile.from_yaml(v1_yaml)
+        out = lock.to_yaml()
+        assert "lockfile_version: '1'" in out
+        # No registry fields in the emitted yaml
+        assert "resolved_url" not in out
+        assert "resolved_hash" not in out
+
+    def test_v2_only_when_registry_dep_present(self):
+        # First — git-only project stays v1 forever.
+        lock = LockFile()
+        lock.add_dependency(
+            LockedDependency(repo_url="acme/git", resolved_commit="abc", host="github.com")
+        )
+        assert "lockfile_version: '1'" in lock.to_yaml()
+
+        # Add a registry dep — now v2.
+        lock.add_dependency(
+            LockedDependency(
+                repo_url="acme/registry",
+                source="registry",
+                resolved_url="https://r/v1/.../download",
+                resolved_hash="sha256:abc",
+                version="1.0.0",
+            )
+        )
+        assert "lockfile_version: '2'" in lock.to_yaml()
+
+        # Remove it — back to v1.
+        del lock.dependencies["acme/registry"]
+        assert "lockfile_version: '1'" in lock.to_yaml()
+
+    def test_v2_lockfile_round_trip_preserves_all_fields(self):
+        # End-to-end: v2-shaped entry survives round-trip without loss.
+        lock = LockFile()
+        lock.add_dependency(
+            LockedDependency(
+                repo_url="acme/web",
+                source="registry",
+                version="1.5.3",
+                resolved_url="https://r/v1/.../download",
+                resolved_hash="sha256:abc123",
+                host="github.com",
+            )
+        )
+        out = lock.to_yaml()
+        roundtrip = LockFile.from_yaml(out)
+        dep = roundtrip.get_dependency("acme/web")
+        assert dep.source == "registry"
+        assert dep.version == "1.5.3"
+        assert dep.resolved_url == "https://r/v1/.../download"
+        assert dep.resolved_hash == "sha256:abc123"
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# §2.1.6 — No env-var collisions
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestEnvVarPrefixCollision:
+    """``APM_REGISTRY_TOKEN_*`` must NOT collide with existing prefixes."""
+
+    def test_token_prefix_distinct_from_existing(self):
+        from apm_cli.deps.registry.auth import _env_key
+
+        existing_prefixes = (
+            "GITHUB_TOKEN",
+            "GITHUB_APM_PAT",
+            "GH_TOKEN",
+            "PROXY_REGISTRY_",
+            "ARTIFACTORY_APM_TOKEN",
+        )
+        for name in ("corp", "corp-main", "team-a"):
+            key = _env_key(name)
+            assert key.startswith("APM_REGISTRY_TOKEN_")
+            for existing in existing_prefixes:
+                assert not key.startswith(existing)
+                assert key != existing
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# §2.1.8 — Identity preservation
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestIdentityPreservation:
+    """``DependencyReference.get_identity()`` must be stable across modes."""
+
+    @pytest.mark.xfail(reason="@registry shorthand deferred to v2", strict=True)
+    def test_identity_unchanged_by_registry_scope(self):
+        d_git = DependencyReference.parse("acme/foo#1.0.0")
+        d_reg = DependencyReference.parse("acme/foo@corp-main#1.0.0")
+        assert d_git.get_identity() == d_reg.get_identity() == "acme/foo"
+
+    def test_identity_unchanged_by_object_form_registry(self):
+        d_git = DependencyReference.parse("acme/foo#1.0.0")
+        d_reg_obj = DependencyReference.parse_from_dict(
+            {
+                "registry": "corp",
+                "id": "acme/foo",
+                "path": "x.prompt.md",
+                "version": "1.0.0",
+            }
+        )
+        # Identity for non-virtual: ``acme/foo``
+        # Identity for virtual: includes the path
+        # Both share the ``acme/foo`` package identity though
+        assert d_git.get_identity() == "acme/foo"
+        assert d_reg_obj.get_identity().startswith("acme/foo/")
+
+    @pytest.mark.xfail(reason="@registry shorthand deferred to v2", strict=True)
+    def test_unique_key_includes_repo_url_for_both(self):
+        d_git = DependencyReference.parse("acme/foo#1.0.0")
+        d_reg = DependencyReference.parse("acme/foo@corp-main#1.0.0")
+        assert d_git.get_unique_key() == d_reg.get_unique_key() == "acme/foo"
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# §2.1.10 — Marketplace unchanged
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestMarketplaceUnchanged:
+    def test_existing_marketplace_json_parses_byte_identically(self):
+        # Pre-PR marketplace.json shape with no `registry` field.
+        from apm_cli.marketplace.models import parse_marketplace_json
+
+        manifest = parse_marketplace_json(
+            {
+                "name": "acme",
+                "plugins": [
+                    {
+                        "name": "review",
+                        "repository": "acme/review",
+                        "ref": "v1.0",
+                        "version": "v1.0",
+                        "description": "x",
+                    }
+                ],
+            },
+            source_name="acme",
+        )
+        plugin = manifest.plugins[0]
+        # registry defaults to "" (no routing)
+        assert plugin.registry == ""
+        # All other fields preserved
+        assert plugin.name == "review"
+        assert plugin.version == "v1.0"
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# End-to-end install path: parser -> lockfile (no network)
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestEndToEndInstallPath:
+    """Confirm a registry-sourced apm.yml flows through to a v2 lockfile.
+
+    Uses the resolver with a fake HTTP client so we exercise the full
+    parser -> resolver -> InstalledPackage -> LockFile chain.
+    """
+
+    def test_apm_yml_to_lockfile_v2(self, write_apm_yml, tmp_path):
+        from apm_cli.deps.installed_package import InstalledPackage
+
+        # 1. Parse apm.yml with default-registry routing
+        p = write_apm_yml("""
+            name: project
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com/apm
+              default: corp
+            dependencies:
+              apm:
+                - acme/web#^1.2.0
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        dep = pkg.dependencies["apm"][0]
+        assert dep.source == "registry"
+        assert dep.registry_name == "corp"
+
+        # 2. Simulate a resolver-produced RegistryResolution.
+        resolution = RegistryResolution(
+            resolved_url="https://corp.example.com/apm/v1/packages/acme/web/versions/1.5.3/download",
+            resolved_hash="sha256:" + "f" * 64,
+            version="1.5.3",
+        )
+
+        # 3. Build InstalledPackage and assemble lockfile
+        installed = InstalledPackage(
+            dep_ref=dep,
+            resolved_commit=None,
+            depth=1,
+            resolved_by=None,
+            registry_resolution=resolution,
+        )
+
+        class _StubGraph:
+            pass
+
+        lock = LockFile.from_installed_packages([installed], _StubGraph())
+        out = lock.to_yaml()
+        assert "lockfile_version: '2'" in out
+
+        # 4. Round-trip and re-derive dep_ref
+        roundtrip = LockFile.from_yaml(out)
+        locked = roundtrip.get_dependency("acme/web")
+        ref = locked.to_dependency_ref()
+        assert ref.source == "registry"
+        assert ref.reference == "1.5.3"  # exact locked version

--- a/tests/unit/registry/test_config_loader.py
+++ b/tests/unit/registry/test_config_loader.py
@@ -1,0 +1,48 @@
+"""Tests for registry config merging and default resolution."""
+
+from __future__ import annotations
+
+import apm_cli.config as _conf
+from apm_cli.deps.registry.config_loader import resolve_effective_registries
+
+
+def test_resolve_effective_registries_uses_config_default(monkeypatch):
+    monkeypatch.setattr(
+        _conf,
+        "_config_cache",
+        {
+            "registries": {
+                "corp-main": {
+                    "url": "https://corp.example.com/apm",
+                    "default": True,
+                }
+            }
+        },
+    )
+    merged, default = resolve_effective_registries(None, None)
+    assert merged == {"corp-main": "https://corp.example.com/apm"}
+    assert default == "corp-main"
+
+
+def test_project_default_overrides_config_default(monkeypatch):
+    monkeypatch.setattr(
+        _conf,
+        "_config_cache",
+        {
+            "registries": {
+                "corp-main": {
+                    "url": "https://corp.example.com/apm",
+                    "default": True,
+                }
+            }
+        },
+    )
+    merged, default = resolve_effective_registries(
+        {"project-main": "https://project.example.com/apm"},
+        "project-main",
+    )
+    assert merged == {
+        "corp-main": "https://corp.example.com/apm",
+        "project-main": "https://project.example.com/apm",
+    }
+    assert default == "project-main"

--- a/tests/unit/registry/test_extractor.py
+++ b/tests/unit/registry/test_extractor.py
@@ -1,0 +1,252 @@
+"""Tests for tarball extraction with sha256 verification.
+
+The extractor is the security-critical gate on the install path (design §6.1):
+hash mismatches and traversal attempts MUST fail closed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import tarfile
+import zipfile
+
+import pytest
+
+from apm_cli.deps.registry.extractor import (
+    HashMismatchError,
+    UnknownArchiveFormatError,
+    UnsafeTarballError,
+    _normalize_digest,
+    extract_archive,
+    extract_tarball,
+    extract_zip,
+    verify_sha256,
+)
+
+
+def _build_tar(entries: list[tuple[str, bytes]], *, mode: str = "w:gz") -> bytes:
+    """Build an in-memory tarball from a list of (name, content) pairs."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode=mode) as tar:
+        for name, content in entries:
+            ti = tarfile.TarInfo(name=name)
+            ti.size = len(content)
+            tar.addfile(ti, io.BytesIO(content))
+    return buf.getvalue()
+
+
+def _build_tar_with(extra_setup) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        extra_setup(tar)
+    return buf.getvalue()
+
+
+class TestNormalizeDigest:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("abc", "abc"),
+            ("ABC", "abc"),
+            ("sha256:abc", "abc"),
+            ("sha256=ABC", "abc"),
+            ("  sha256:abc  ", "abc"),
+        ],
+    )
+    def test_normalize(self, raw, expected):
+        assert _normalize_digest(raw) == expected
+
+
+class TestVerifySha256:
+    def test_match_returns_actual_hex(self):
+        data = b"hello"
+        h = hashlib.sha256(data).hexdigest()
+        assert verify_sha256(data, h) == h
+
+    def test_match_with_prefix(self):
+        data = b"hello"
+        h = hashlib.sha256(data).hexdigest()
+        assert verify_sha256(data, f"sha256:{h}") == h
+
+    def test_mismatch_raises(self):
+        with pytest.raises(HashMismatchError):
+            verify_sha256(b"hello", "0" * 64)
+
+
+class TestExtractTarball:
+    def test_extract_validates_hash_first(self, tmp_path):
+        data = _build_tar([("apm.yml", b"name: x\n")])
+        with pytest.raises(HashMismatchError):
+            extract_tarball(data, "0" * 64, tmp_path)
+        # Nothing extracted on hash failure
+        assert not list(tmp_path.iterdir())
+
+    def test_extract_writes_files(self, tmp_path):
+        data = _build_tar([("apm.yml", b"name: acme/x\n"), (".apm/.keep", b"")])
+        digest = hashlib.sha256(data).hexdigest()
+        actual = extract_tarball(data, digest, tmp_path)
+        assert actual == digest
+        assert (tmp_path / "apm.yml").read_bytes() == b"name: acme/x\n"
+        assert (tmp_path / ".apm" / ".keep").exists()
+
+    def test_extract_accepts_sha256_prefix(self, tmp_path):
+        data = _build_tar([("apm.yml", b"name: y\n")])
+        digest = hashlib.sha256(data).hexdigest()
+        extract_tarball(data, f"sha256:{digest}", tmp_path)
+        assert (tmp_path / "apm.yml").exists()
+
+    # ─── Path traversal & unsafe entries ────────────────────────────────
+
+    def test_rejects_absolute_path(self, tmp_path):
+        data = _build_tar([("/etc/passwd", b"x")])
+        digest = hashlib.sha256(data).hexdigest()
+        with pytest.raises(UnsafeTarballError):
+            extract_tarball(data, digest, tmp_path)
+
+    def test_rejects_path_traversal(self, tmp_path):
+        data = _build_tar([("../escape.txt", b"x")])
+        digest = hashlib.sha256(data).hexdigest()
+        with pytest.raises(UnsafeTarballError):
+            extract_tarball(data, digest, tmp_path)
+
+    def test_rejects_symlink(self, tmp_path):
+        def add_symlink(tar):
+            ti = tarfile.TarInfo(name="link")
+            ti.type = tarfile.SYMTYPE
+            ti.linkname = "/etc/passwd"
+            tar.addfile(ti)
+
+        data = _build_tar_with(add_symlink)
+        digest = hashlib.sha256(data).hexdigest()
+        with pytest.raises(UnsafeTarballError):
+            extract_tarball(data, digest, tmp_path)
+
+    def test_rejects_hard_link(self, tmp_path):
+        def add_hardlink(tar):
+            ti = tarfile.TarInfo(name="link")
+            ti.type = tarfile.LNKTYPE
+            ti.linkname = "apm.yml"
+            tar.addfile(ti)
+
+        data = _build_tar_with(add_hardlink)
+        digest = hashlib.sha256(data).hexdigest()
+        with pytest.raises(UnsafeTarballError):
+            extract_tarball(data, digest, tmp_path)
+
+    def test_creates_intermediate_directories(self, tmp_path):
+        data = _build_tar([("a/b/c/file.txt", b"hello")])
+        digest = hashlib.sha256(data).hexdigest()
+        extract_tarball(data, digest, tmp_path)
+        assert (tmp_path / "a" / "b" / "c" / "file.txt").read_bytes() == b"hello"
+
+
+def _build_zip(entries: list[tuple[str, bytes]]) -> bytes:
+    """Build an in-memory zip from (name, content) pairs."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for name, content in entries:
+            zf.writestr(name, content)
+    return buf.getvalue()
+
+
+class TestExtractZip:
+    """Same security gates as the tar path, applied to zip archives."""
+
+    def test_validates_hash_first(self, tmp_path):
+        data = _build_zip([("apm.yml", b"name: x\n")])
+        with pytest.raises(HashMismatchError):
+            extract_zip(data, "0" * 64, tmp_path)
+        assert not list(tmp_path.iterdir())
+
+    def test_writes_files(self, tmp_path):
+        data = _build_zip([("apm.yml", b"name: y\n"), (".apm/.keep", b"")])
+        digest = hashlib.sha256(data).hexdigest()
+        extract_zip(data, digest, tmp_path)
+        assert (tmp_path / "apm.yml").read_bytes() == b"name: y\n"
+        assert (tmp_path / ".apm" / ".keep").exists()
+
+    def test_rejects_path_traversal(self, tmp_path):
+        data = _build_zip([("../escape.txt", b"x")])
+        digest = hashlib.sha256(data).hexdigest()
+        with pytest.raises(UnsafeTarballError):
+            extract_zip(data, digest, tmp_path)
+
+    def test_rejects_absolute_path(self, tmp_path):
+        data = _build_zip([("/etc/passwd", b"x")])
+        digest = hashlib.sha256(data).hexdigest()
+        with pytest.raises(UnsafeTarballError):
+            extract_zip(data, digest, tmp_path)
+
+    def test_rejects_symlink(self, tmp_path):
+        # Build a zip with a symlink entry by setting external_attr to S_IFLNK.
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, mode="w") as zf:
+            info = zipfile.ZipInfo("link")
+            # 0xA000 == S_IFLNK; place in high 16 bits
+            info.external_attr = (0xA000 | 0o777) << 16
+            zf.writestr(info, b"/etc/passwd")
+        data = buf.getvalue()
+        digest = hashlib.sha256(data).hexdigest()
+        with pytest.raises(UnsafeTarballError, match="symlink"):
+            extract_zip(data, digest, tmp_path)
+
+    def test_malformed_zip(self, tmp_path):
+        # Hash check happens first, so we have to feed the right digest for
+        # the bytes we're sending — the BadZipFile path is what we want to test.
+        bad = b"not a zip"
+        digest = hashlib.sha256(bad).hexdigest()
+        with pytest.raises(UnknownArchiveFormatError):
+            extract_zip(bad, digest, tmp_path)
+
+
+class TestExtractArchiveDispatcher:
+    """The dispatcher picks the right extractor from Content-Type or magic bytes."""
+
+    def test_dispatches_to_tar_for_gzip_content_type(self, tmp_path):
+        data = _build_tar([("apm.yml", b"name: x\n")])
+        digest = hashlib.sha256(data).hexdigest()
+        extract_archive(data, digest, tmp_path, content_type="application/gzip")
+        assert (tmp_path / "apm.yml").exists()
+
+    def test_dispatches_to_zip_for_zip_content_type(self, tmp_path):
+        data = _build_zip([("apm.yml", b"name: x\n")])
+        digest = hashlib.sha256(data).hexdigest()
+        extract_archive(data, digest, tmp_path, content_type="application/zip")
+        assert (tmp_path / "apm.yml").exists()
+
+    def test_falls_back_to_magic_bytes_for_gzip(self, tmp_path):
+        data = _build_tar([("apm.yml", b"name: x\n")])
+        digest = hashlib.sha256(data).hexdigest()
+        extract_archive(data, digest, tmp_path, content_type=None)
+        assert (tmp_path / "apm.yml").exists()
+
+    def test_falls_back_to_magic_bytes_for_zip(self, tmp_path):
+        data = _build_zip([("apm.yml", b"name: x\n")])
+        digest = hashlib.sha256(data).hexdigest()
+        extract_archive(data, digest, tmp_path, content_type=None)
+        assert (tmp_path / "apm.yml").exists()
+
+    def test_unknown_format_raises(self, tmp_path):
+        # Random bytes with no recognizable magic header.
+        data = b"not-an-archive-of-any-known-type"
+        digest = hashlib.sha256(data).hexdigest()
+        with pytest.raises(UnknownArchiveFormatError):
+            extract_archive(data, digest, tmp_path)
+
+    def test_hash_mismatch_fails_before_extraction_for_both(self, tmp_path):
+        for data in (
+            _build_tar([("apm.yml", b"x")]),
+            _build_zip([("apm.yml", b"x")]),
+        ):
+            with pytest.raises(HashMismatchError):
+                extract_archive(data, "0" * 64, tmp_path)
+            assert not list(tmp_path.iterdir())
+
+    def test_unrecognized_content_type_falls_back_to_magic(self, tmp_path):
+        # Server sends a generic content type — magic bytes should still
+        # win and identify the archive.
+        data = _build_tar([("apm.yml", b"x")])
+        digest = hashlib.sha256(data).hexdigest()
+        extract_archive(data, digest, tmp_path, content_type="application/octet-stream")
+        assert (tmp_path / "apm.yml").exists()

--- a/tests/unit/registry/test_outdated.py
+++ b/tests/unit/registry/test_outdated.py
@@ -1,0 +1,307 @@
+"""Unit tests for registry-backed ``apm outdated`` checks."""
+
+from __future__ import annotations
+
+import textwrap
+from unittest.mock import MagicMock
+
+import pytest
+
+from apm_cli.deps.lockfile import LockedDependency, LockFile
+from apm_cli.deps.registry.client import RegistryError, VersionEntry
+from apm_cli.deps.registry.outdated import (
+    RegistryOutdatedContext,
+    check_registry_locked_dep,
+    load_registry_outdated_context,
+)
+from apm_cli.models.dependency.reference import DependencyReference
+
+
+def _ctx(
+    *,
+    repo_url: str = "nadavy/e2e-demo",
+    manifest_range: str = "^1.0.0",
+    registry_name: str = "test-reg",
+    registries: dict[str, str] | None = None,
+) -> RegistryOutdatedContext:
+    dep = DependencyReference(
+        repo_url=repo_url,
+        reference=manifest_range,
+        source="registry",
+        registry_name=registry_name,
+    )
+    return RegistryOutdatedContext(
+        manifest_index={repo_url: dep},
+        registries=registries or {registry_name: "https://reg.example.com/apm"},
+        default_registry=registry_name,
+    )
+
+
+def _locked(
+    *,
+    repo_url: str = "nadavy/e2e-demo",
+    version: str = "1.0.1",
+) -> LockedDependency:
+    return LockedDependency(
+        repo_url=repo_url,
+        source="registry",
+        version=version,
+    )
+
+
+def _fake_client(versions: list[str]):
+    fake = MagicMock()
+    fake.list_versions.return_value = [
+        VersionEntry(version=v, digest=f"sha256:{v}", published_at="2026-01-01T00:00:00Z")
+        for v in versions
+    ]
+    return fake
+
+
+@pytest.fixture(autouse=True)
+def _enable_package_registry(monkeypatch):
+    import apm_cli.config as _conf
+
+    monkeypatch.setattr(
+        _conf,
+        "_config_cache",
+        {"experimental": {"registries": True}},
+    )
+
+
+class TestCheckRegistryLockedDep:
+    def test_outdated_when_newer_version_in_range(self):
+        ctx = _ctx(manifest_range="^1.0.0")
+        locked = _locked(version="1.0.1")
+        fake = _fake_client(["1.0.1", "1.1.1"])
+
+        result = check_registry_locked_dep(
+            locked,
+            ctx,
+            client_factory=lambda url, auth: fake,
+        )
+
+        assert result.status == "outdated"
+        assert result.current == "1.0.1"
+        assert result.latest == "1.1.1"
+        assert result.source == "registry: test-reg"
+        fake.list_versions.assert_called_once_with("nadavy", "e2e-demo")
+
+    def test_up_to_date_when_locked_matches_best(self):
+        ctx = _ctx(manifest_range="^1.0.0")
+        locked = _locked(version="1.1.1")
+        fake = _fake_client(["1.0.1", "1.1.1"])
+
+        result = check_registry_locked_dep(
+            locked,
+            ctx,
+            client_factory=lambda url, auth: fake,
+        )
+
+        assert result.status == "up-to-date"
+        assert result.latest == "1.1.1"
+
+    def test_unknown_when_feature_disabled(self, monkeypatch):
+        import apm_cli.config as _conf
+
+        monkeypatch.setattr(_conf, "_config_cache", {"experimental": {}})
+        ctx = _ctx()
+        locked = _locked()
+
+        result = check_registry_locked_dep(locked, ctx)
+
+        assert result.status == "unknown"
+        assert "feature disabled" in result.source
+
+    def test_unknown_when_not_in_manifest_and_registry_unreachable(self):
+        ctx = RegistryOutdatedContext(
+            manifest_index={},
+            registries={"test-reg": "https://reg.example.com/apm"},
+            default_registry="test-reg",
+        )
+        locked = _locked()
+        fake = MagicMock()
+        fake.list_versions.side_effect = RegistryError("401 unauthorized")
+
+        result = check_registry_locked_dep(
+            locked,
+            ctx,
+            client_factory=lambda url, auth: fake,
+        )
+
+        assert result.status == "unknown"
+        assert "(lockfile)" in result.source
+
+    def test_lockfile_only_compares_against_highest_published(self):
+        ctx = RegistryOutdatedContext(
+            manifest_index={},
+            registries={"test-reg": "https://reg.example.com/apm"},
+            default_registry="test-reg",
+        )
+        locked = _locked(version="1.0.1")
+        fake = _fake_client(["1.0.1", "1.1.1", "2.0.0"])
+
+        result = check_registry_locked_dep(
+            locked,
+            ctx,
+            client_factory=lambda url, auth: fake,
+        )
+
+        assert result.status == "outdated"
+        assert result.latest == "2.0.0"
+        assert "(lockfile)" in result.source
+
+    def test_unknown_when_invalid_manifest_range(self):
+        dep = DependencyReference(
+            repo_url="nadavy/e2e-demo",
+            reference="main",
+            source="registry",
+            registry_name="test-reg",
+        )
+        ctx = RegistryOutdatedContext(
+            manifest_index={"nadavy/e2e-demo": dep},
+            registries={"test-reg": "https://reg.example.com/apm"},
+            default_registry="test-reg",
+        )
+        locked = _locked()
+
+        result = check_registry_locked_dep(locked, ctx)
+
+        assert result.status == "unknown"
+        assert "invalid manifest range" in result.source
+
+    def test_unknown_when_registry_list_versions_fails(self):
+        ctx = _ctx()
+        locked = _locked()
+        fake = MagicMock()
+        fake.list_versions.side_effect = RegistryError("401 unauthorized")
+
+        result = check_registry_locked_dep(
+            locked,
+            ctx,
+            client_factory=lambda url, auth: fake,
+        )
+
+        assert result.status == "unknown"
+        assert result.latest == "-"
+
+    def test_verbose_lists_matching_versions(self):
+        ctx = _ctx(manifest_range="^1.0.0")
+        locked = _locked(version="1.0.1")
+        fake = _fake_client(["1.0.0", "1.0.1", "1.1.1", "2.0.0"])
+
+        result = check_registry_locked_dep(
+            locked,
+            ctx,
+            client_factory=lambda url, auth: fake,
+            verbose=True,
+        )
+
+        assert result.status == "outdated"
+        assert "1.1.1" in result.extra_tags
+        assert "2.0.0" not in result.extra_tags
+
+
+class TestLoadRegistryOutdatedContext:
+    def test_loads_manifest_and_registries_from_apm_yml(self, tmp_path, monkeypatch):
+        import apm_cli.config as _conf
+        from apm_cli.models.apm_package import clear_apm_yml_cache
+
+        monkeypatch.setattr(
+            _conf,
+            "_config_cache",
+            {
+                "experimental": {"registries": True},
+                "registries": {
+                    "global-reg": {
+                        "url": "https://global.example.com/apm",
+                        "default": True,
+                    }
+                },
+            },
+        )
+        clear_apm_yml_cache()
+        (tmp_path / "apm.yml").write_text(
+            textwrap.dedent(
+                """
+                name: demo
+                version: 1.0.0
+                registries:
+                  project-reg:
+                    url: https://project.example.com/apm
+                  default: project-reg
+                dependencies:
+                  apm:
+                    - nadavy/e2e-demo#^1.0.0
+                """
+            ).strip()
+            + "\n"
+        )
+
+        ctx = load_registry_outdated_context(tmp_path)
+
+        assert "nadavy/e2e-demo" in ctx.manifest_index
+        assert ctx.manifest_index["nadavy/e2e-demo"].source == "registry"
+        assert ctx.default_registry == "project-reg"
+        assert ctx.registries["project-reg"] == "https://project.example.com/apm"
+        assert ctx.registries["global-reg"] == "https://global.example.com/apm"
+
+    def test_indexes_transitive_registry_dep_from_installed_package(self, tmp_path, monkeypatch):
+        import apm_cli.config as _conf
+        from apm_cli.constants import APM_MODULES_DIR
+        from apm_cli.models.apm_package import clear_apm_yml_cache
+
+        monkeypatch.setattr(
+            _conf,
+            "_config_cache",
+            {"experimental": {"registries": True}},
+        )
+        clear_apm_yml_cache()
+
+        (tmp_path / "apm.yml").write_text(
+            textwrap.dedent(
+                """
+                name: consumer
+                version: 1.0.0
+                registries:
+                  test-reg:
+                    url: https://reg.example.com/apm
+                  default: test-reg
+                dependencies:
+                  apm:
+                    - microsoft/batch-bug-shepherd#^0.1.0
+                """
+            ).strip()
+            + "\n"
+        )
+
+        parent_dir = tmp_path / APM_MODULES_DIR / "microsoft" / "batch-bug-shepherd"
+        parent_dir.mkdir(parents=True)
+        (parent_dir / "apm.yml").write_text(
+            textwrap.dedent(
+                """
+                name: batch-bug-shepherd
+                version: 0.1.0
+                dependencies:
+                  apm:
+                    - microsoft/apm-review-panel#^0.1.0
+                """
+            ).strip()
+            + "\n"
+        )
+
+        lockfile = LockFile()
+        lockfile.add_dependency(
+            LockedDependency(
+                repo_url="microsoft/apm-review-panel",
+                source="registry",
+                version="0.1.1",
+                depth=2,
+                resolved_by="microsoft/batch-bug-shepherd",
+            )
+        )
+
+        ctx = load_registry_outdated_context(tmp_path, lockfile)
+
+        assert "microsoft/apm-review-panel" in ctx.manifest_index
+        assert ctx.manifest_index["microsoft/apm-review-panel"].reference == "^0.1.0"

--- a/tests/unit/registry/test_resolver.py
+++ b/tests/unit/registry/test_resolver.py
@@ -1,0 +1,345 @@
+"""End-to-end resolver tests with a fake HTTP client.
+
+Confirms the install-side orchestration: list_versions -> pick best -> download
+-> verify -> extract -> validate -> build PackageInfo. Failure paths checked:
+hash mismatch, no matching version, 401/403 surfaces remediation, 404 surfaces
+clear "no package" message.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import tarfile
+from unittest.mock import MagicMock
+
+import pytest
+
+from apm_cli.deps.registry.client import RegistryClient, RegistryError, VersionEntry
+from apm_cli.deps.registry.resolver import (
+    RegistryPackageResolver,
+    RegistryResolutionError,
+)
+from apm_cli.models.dependency.reference import DependencyReference
+
+
+def _make_apm_tarball(name: str = "acme-web-skills", version: str = "1.2.0"):
+    """Build a minimal valid APM package tarball + return (bytes, sha256_hex)."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        apm_yml = (f"name: {name}\nversion: {version}\ndescription: x\nauthor: a\n").encode()
+        ti = tarfile.TarInfo(name="apm.yml")
+        ti.size = len(apm_yml)
+        tar.addfile(ti, io.BytesIO(apm_yml))
+        keep = tarfile.TarInfo(name=".apm/.keep")
+        keep.size = 0
+        tar.addfile(keep, io.BytesIO(b""))
+    data = buf.getvalue()
+    return data, hashlib.sha256(data).hexdigest()
+
+
+def _make_apm_zip(name: str = "acme-skill", version: str = "1.0.0"):
+    """Build a minimal valid APM package zip + return (bytes, sha256_hex)."""
+    import zipfile as _zip
+
+    buf = io.BytesIO()
+    apm_yml = f"name: {name}\nversion: {version}\ndescription: x\nauthor: a\n"
+    with _zip.ZipFile(buf, mode="w", compression=_zip.ZIP_DEFLATED) as zf:
+        zf.writestr("apm.yml", apm_yml)
+        zf.writestr(".apm/.keep", "")
+    data = buf.getvalue()
+    return data, hashlib.sha256(data).hexdigest()
+
+
+def _make_resolver(client_double):
+    return RegistryPackageResolver(
+        {"corp-main": "https://reg.example.com/apm"},
+        client_factory=lambda url, auth: client_double,
+    )
+
+
+def _make_dep(version: str = "^1.2.0") -> DependencyReference:
+    return DependencyReference(
+        repo_url="acme/web-skills",
+        reference=version,
+        source="registry",
+        registry_name="corp-main",
+    )
+
+
+class TestHappyPath:
+    def test_install_full_package(self, tmp_path):
+        raw, digest = _make_apm_tarball()
+        fake = MagicMock(spec=RegistryClient)
+        fake.list_versions.return_value = [
+            VersionEntry(
+                version="1.2.0", digest=f"sha256:{digest}", published_at="2026-01-01T00:00:00Z"
+            )
+        ]
+        fake.download_archive.return_value = (raw, "application/gzip")
+        fake.archive_url.return_value = (
+            "https://reg.example.com/apm/v1/packages/acme/web-skills/versions/1.2.0/download"
+        )
+
+        resolver = _make_resolver(fake)
+        target = tmp_path / "apm_modules" / "acme" / "web-skills"
+        info = resolver.download_package(_make_dep(), target)
+
+        assert info.install_path == target
+        assert (target / "apm.yml").exists()
+        assert (target / ".apm").is_dir()
+
+        res = resolver.last_resolutions[_make_dep().get_unique_key()]
+        assert res.version == "1.2.0"
+        assert res.resolved_hash == f"sha256:{digest}"
+        assert res.resolved_url.endswith("/versions/1.2.0/download")
+
+    def test_install_zip_archive(self, tmp_path):
+        # Anthropic skill format: zip with the same package shape.
+        raw, digest = _make_apm_zip()
+        fake = MagicMock(spec=RegistryClient)
+        fake.list_versions.return_value = [
+            VersionEntry(
+                version="1.0.0", digest=f"sha256:{digest}", published_at="2026-01-01T00:00:00Z"
+            )
+        ]
+        fake.download_archive.return_value = (raw, "application/zip")
+        fake.archive_url.return_value = (
+            "https://reg.example.com/apm/v1/packages/acme/skill/versions/1.0.0/download"
+        )
+
+        resolver = _make_resolver(fake)
+        target = tmp_path / "apm_modules" / "acme" / "skill"
+        info = resolver.download_package(
+            DependencyReference(
+                repo_url="acme/skill",
+                reference="^1.0.0",
+                source="registry",
+                registry_name="corp-main",
+            ),
+            target,
+        )
+        assert (target / "apm.yml").exists()
+        assert (target / ".apm").is_dir()
+        assert info.install_path == target
+
+    def test_picks_highest_matching_version(self, tmp_path):
+        raw, digest = _make_apm_tarball(version="1.5.3")
+        fake = MagicMock(spec=RegistryClient)
+        fake.list_versions.return_value = [
+            VersionEntry(
+                version="1.2.0", digest=f"sha256:{digest}", published_at="2026-01-01T00:00:00Z"
+            ),
+            VersionEntry(
+                version="1.5.3", digest=f"sha256:{digest}", published_at="2026-01-01T00:00:00Z"
+            ),
+            VersionEntry(
+                version="2.0.0", digest=f"sha256:{digest}", published_at="2026-01-01T00:00:00Z"
+            ),
+        ]
+        fake.download_archive.return_value = (raw, "application/gzip")
+        fake.archive_url.return_value = "https://x/download"
+
+        resolver = _make_resolver(fake)
+        target = tmp_path / "p"
+        resolver.download_package(_make_dep("^1.0.0"), target)
+
+        # Confirm download_archive was asked for the highest matching version.
+        fake.download_archive.assert_called_once_with("acme", "web-skills", "1.5.3")
+
+
+class TestFailurePaths:
+    def test_hash_mismatch_fails_closed(self, tmp_path):
+        raw, _ = _make_apm_tarball()
+        fake = MagicMock(spec=RegistryClient)
+        fake.list_versions.return_value = [
+            VersionEntry(
+                version="1.2.0", digest="sha256:" + "0" * 64, published_at="2026-01-01T00:00:00Z"
+            )
+        ]
+        fake.download_archive.return_value = (raw, "application/gzip")
+        fake.archive_url.return_value = "https://x"
+
+        resolver = _make_resolver(fake)
+        with pytest.raises(Exception) as excinfo:
+            resolver.download_package(_make_dep(), tmp_path / "p")
+        # Either HashMismatchError or RegistryResolutionError wrapping it.
+        assert "mismatch" in str(excinfo.value).lower() or "Hash" in type(excinfo.value).__name__
+
+    def test_no_matching_version(self, tmp_path):
+        _, digest = _make_apm_tarball()
+        fake = MagicMock(spec=RegistryClient)
+        fake.list_versions.return_value = [
+            VersionEntry(
+                version="2.0.0", digest=f"sha256:{digest}", published_at="2026-01-01T00:00:00Z"
+            )
+        ]
+        resolver = _make_resolver(fake)
+        with pytest.raises(RegistryResolutionError, match="no version"):
+            resolver.download_package(_make_dep("^1.0.0"), tmp_path / "p")
+
+    def test_empty_versions_list(self, tmp_path):
+        fake = MagicMock(spec=RegistryClient)
+        fake.list_versions.return_value = []
+        resolver = _make_resolver(fake)
+        with pytest.raises(RegistryResolutionError, match="no versions"):
+            resolver.download_package(_make_dep(), tmp_path / "p")
+
+    def test_401_includes_remediation(self, tmp_path):
+        fake = MagicMock(spec=RegistryClient)
+        fake.list_versions.side_effect = RegistryError(
+            "auth required",
+            status=401,
+            url="https://reg.example.com/apm/v1/packages/acme/web-skills/versions",
+        )
+        resolver = _make_resolver(fake)
+        with pytest.raises(RegistryResolutionError) as excinfo:
+            resolver.download_package(_make_dep(), tmp_path / "p")
+        msg = str(excinfo.value)
+        assert "APM_REGISTRY_TOKEN_<NAME>" in msg
+        assert "https://reg.example.com/apm" in msg
+
+    def test_404_clear_message(self, tmp_path):
+        fake = MagicMock(spec=RegistryClient)
+        fake.list_versions.side_effect = RegistryError(
+            "not found",
+            status=404,
+            url="https://reg.example.com/apm/v1/packages/acme/web-skills/versions",
+        )
+        resolver = _make_resolver(fake)
+        with pytest.raises(RegistryResolutionError) as excinfo:
+            resolver.download_package(_make_dep(), tmp_path / "p")
+        assert "no package" in str(excinfo.value)
+
+    def test_unconfigured_registry_name(self, tmp_path):
+        # Resolver knows about 'corp-main', dep references 'corp-other'.
+        fake = MagicMock(spec=RegistryClient)
+        resolver = RegistryPackageResolver(
+            {"corp-main": "https://reg.example.com/apm"},
+            client_factory=lambda url, auth: fake,
+        )
+        dep = DependencyReference(
+            repo_url="acme/x",
+            reference="1.0.0",
+            source="registry",
+            registry_name="corp-other",
+        )
+        with pytest.raises(RegistryResolutionError, match="not configured"):
+            resolver.download_package(dep, tmp_path / "p")
+
+    def test_non_registry_dep_rejected(self, tmp_path):
+        fake = MagicMock(spec=RegistryClient)
+        resolver = _make_resolver(fake)
+        dep = DependencyReference(repo_url="acme/x", reference="1.0.0", source="git")
+        with pytest.raises(RegistryResolutionError, match="non-registry"):
+            resolver.download_package(dep, tmp_path / "p")
+
+    def test_invalid_semver_constraint_rejected_at_resolver(self, tmp_path):
+        # Defense in depth: if a "registry" dep slips past the parser with a
+        # branch name, the resolver still rejects it.
+        fake = MagicMock(spec=RegistryClient)
+        fake.list_versions.return_value = [
+            VersionEntry(
+                version="1.0.0", digest="sha256:" + "0" * 64, published_at="2026-01-01T00:00:00Z"
+            )
+        ]
+        resolver = _make_resolver(fake)
+        dep = DependencyReference(
+            repo_url="acme/x",
+            reference="main",
+            source="registry",
+            registry_name="corp-main",
+        )
+        with pytest.raises(RegistryResolutionError, match="not a valid semver"):
+            resolver.download_package(dep, tmp_path / "p")
+
+
+class TestDownloadFromLockfile:
+    """``download_from_lockfile`` — npm-style lockfile replay path.
+
+    Verifies that the locked URL is fetched directly (no /versions call) and
+    the bytes are verified against the locked hash, not the API's digest.
+    """
+
+    def test_happy_path_skips_versions_api(self, tmp_path):
+        raw, digest = _make_apm_tarball()
+        locked_url = (
+            "https://reg.example.com/apm/v1/packages/acme/web-skills/versions/1.2.0/download"
+        )
+        locked_hash = f"sha256:{digest}"
+        fake = MagicMock(spec=RegistryClient)
+        fake.fetch_from_url.return_value = (raw, "application/gzip")
+
+        resolver = _make_resolver(fake)
+        target = tmp_path / "acme" / "web-skills"
+        info = resolver.download_from_lockfile(
+            _make_dep("^1.2.0"),
+            target,
+            resolved_url=locked_url,
+            resolved_hash=locked_hash,
+            version="1.2.0",
+        )
+
+        # Must NOT call list_versions
+        fake.list_versions.assert_not_called()
+        # Must call fetch_from_url with the locked URL
+        fake.fetch_from_url.assert_called_once_with(locked_url)
+        assert info.install_path == target
+        assert (target / "apm.yml").exists()
+
+    def test_last_resolutions_populated(self, tmp_path):
+        raw, digest = _make_apm_tarball()
+        locked_url = (
+            "https://reg.example.com/apm/v1/packages/acme/web-skills/versions/1.2.0/download"
+        )
+        fake = MagicMock(spec=RegistryClient)
+        fake.fetch_from_url.return_value = (raw, "application/gzip")
+
+        resolver = _make_resolver(fake)
+        dep = _make_dep("^1.2.0")
+        resolver.download_from_lockfile(
+            dep,
+            tmp_path / "p",
+            resolved_url=locked_url,
+            resolved_hash=f"sha256:{digest}",
+            version="1.2.0",
+        )
+
+        res = resolver.last_resolutions[dep.get_unique_key()]
+        assert res.version == "1.2.0"
+        assert res.resolved_url == locked_url
+        assert res.resolved_hash == f"sha256:{digest}"
+
+    def test_hash_mismatch_fails_closed(self, tmp_path):
+        raw, _ = _make_apm_tarball()
+        fake = MagicMock(spec=RegistryClient)
+        fake.fetch_from_url.return_value = (raw, "application/gzip")
+
+        resolver = _make_resolver(fake)
+        with pytest.raises(Exception) as excinfo:
+            resolver.download_from_lockfile(
+                _make_dep(),
+                tmp_path / "p",
+                resolved_url="https://reg.example.com/apm/v1/x/download",
+                resolved_hash="sha256:" + "0" * 64,  # wrong hash
+                version="1.2.0",
+            )
+        assert "mismatch" in str(excinfo.value).lower() or "Hash" in type(excinfo.value).__name__
+
+    def test_http_error_surfaces_as_resolution_error(self, tmp_path):
+        from apm_cli.deps.registry.client import RegistryError
+
+        fake = MagicMock(spec=RegistryClient)
+        fake.fetch_from_url.side_effect = RegistryError(
+            "not found", status=404, url="https://reg.example.com/x"
+        )
+
+        resolver = _make_resolver(fake)
+        with pytest.raises(RegistryResolutionError):
+            resolver.download_from_lockfile(
+                _make_dep(),
+                tmp_path / "p",
+                resolved_url="https://reg.example.com/x",
+                resolved_hash="sha256:" + "a" * 64,
+                version="1.2.0",
+            )

--- a/tests/unit/registry/test_resolver_e2e_http.py
+++ b/tests/unit/registry/test_resolver_e2e_http.py
@@ -1,0 +1,329 @@
+"""End-to-end registry-resolver tests against a real local HTTP server.
+
+Stronger guarantee than the MagicMock-based tests in ``test_resolver.py``:
+this exercises the full ``RegistryClient`` -> network -> ``RegistryClient``
+parsing path. We spin up a stdlib ``http.server.HTTPServer`` in a thread,
+register fake routes, and run the resolver against ``http://localhost:<port>``.
+
+Tested:
+- Happy path with tar.gz archive
+- Happy path with zip archive (Anthropic skills format)
+- 404 surfaces a clear "no package" message
+- 401 surfaces the §6.2 remediation (auth)
+- Tarball with sha256 mismatch fails closed before any extraction
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import io
+import json
+import socket
+import tarfile
+import threading
+import zipfile
+from collections.abc import Callable
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import ClassVar
+
+import pytest
+
+from apm_cli.deps.registry.resolver import (
+    RegistryPackageResolver,
+    RegistryResolutionError,
+)
+from apm_cli.models.dependency.reference import DependencyReference
+
+# ───────────────────────────────────────────────────────────────────────────
+# Test HTTP server scaffolding
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class _FakeRegistryHandler(BaseHTTPRequestHandler):
+    """Per-request handler. Routes installed via class-level ``ROUTES``."""
+
+    ROUTES: ClassVar[dict[str, Callable]] = {}
+
+    # Suppress noisy default logging
+    def log_message(self, format, *args):
+        pass
+
+    def do_GET(self):
+        route = self.ROUTES.get(self.path)
+        if route is None:
+            self.send_response(404)
+            self.send_header("Content-Type", "application/problem+json")
+            body = json.dumps({"title": "Not Found", "detail": f"no route {self.path}"}).encode()
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        # Routes return (status, content_type, body_bytes)
+        status, ctype, body = route(self)
+        self.send_response(status)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+@contextlib.contextmanager
+def _running_server(routes: dict[str, Callable]):
+    """Yield a (host, port) tuple for a running HTTP server with *routes* installed."""
+    # Find a free port
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+
+    # Patch routes onto the handler class. We use a unique handler subclass
+    # per test to avoid cross-test contamination.
+    handler_cls = type(
+        "_PerTestHandler",
+        (_FakeRegistryHandler,),
+        {"ROUTES": dict(routes)},
+    )
+    server = HTTPServer(("127.0.0.1", port), handler_cls)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield ("127.0.0.1", port)
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Archive helpers
+# ───────────────────────────────────────────────────────────────────────────
+
+
+def _build_apm_tarball():
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        apm_yml = b"name: acme-web\nversion: 1.0.0\ndescription: x\nauthor: a\n"
+        ti = tarfile.TarInfo("apm.yml")
+        ti.size = len(apm_yml)
+        tar.addfile(ti, io.BytesIO(apm_yml))
+        keep = tarfile.TarInfo(".apm/.keep")
+        keep.size = 0
+        tar.addfile(keep, io.BytesIO(b""))
+    data = buf.getvalue()
+    return data, hashlib.sha256(data).hexdigest()
+
+
+def _build_apm_zip():
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("apm.yml", "name: acme-skill\nversion: 1.0.0\ndescription: x\nauthor: a\n")
+        zf.writestr(".apm/.keep", "")
+    data = buf.getvalue()
+    return data, hashlib.sha256(data).hexdigest()
+
+
+def _make_dep(name: str = "acme/web") -> DependencyReference:
+    return DependencyReference(
+        repo_url=name,
+        reference="^1.0.0",
+        source="registry",
+        registry_name="corp",
+    )
+
+
+def _versions_payload(name: str, version: str, digest_hex: str) -> bytes:
+    return json.dumps(
+        {
+            "package": name,
+            "versions": [
+                {
+                    "version": version,
+                    "digest": f"sha256:{digest_hex}",
+                    "published_at": "2026-01-01T00:00:00Z",
+                }
+            ],
+        }
+    ).encode()
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Tests
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestE2EHappyPath:
+    def test_install_tar_gz(self, tmp_path):
+        data, digest = _build_apm_tarball()
+        routes = {
+            "/v1/packages/acme/web/versions": lambda h: (
+                200,
+                "application/json",
+                _versions_payload("acme/web", "1.0.0", digest),
+            ),
+            "/v1/packages/acme/web/versions/1.0.0/download": lambda h: (
+                200,
+                "application/gzip",
+                data,
+            ),
+        }
+        with _running_server(routes) as (host, port):
+            base = f"http://{host}:{port}"
+            resolver = RegistryPackageResolver({"corp": base})
+            target = tmp_path / "apm_modules" / "acme" / "web"
+            resolver.download_package(_make_dep(), target)
+            assert (target / "apm.yml").exists()
+            assert (target / ".apm").is_dir()
+            res = resolver.last_resolutions[_make_dep().get_unique_key()]
+            assert res.version == "1.0.0"
+            assert res.resolved_hash == f"sha256:{digest}"
+            assert res.resolved_url.endswith("/versions/1.0.0/download")
+
+    def test_install_zip(self, tmp_path):
+        data, digest = _build_apm_zip()
+        routes = {
+            "/v1/packages/acme/skill/versions": lambda h: (
+                200,
+                "application/json",
+                _versions_payload("acme/skill", "1.0.0", digest),
+            ),
+            "/v1/packages/acme/skill/versions/1.0.0/download": lambda h: (
+                200,
+                "application/zip",
+                data,
+            ),
+        }
+        with _running_server(routes) as (host, port):
+            base = f"http://{host}:{port}"
+            resolver = RegistryPackageResolver({"corp": base})
+            target = tmp_path / "apm_modules" / "acme" / "skill"
+            resolver.download_package(_make_dep("acme/skill"), target)
+            assert (target / "apm.yml").exists()
+            assert (target / ".apm").is_dir()
+
+
+class TestE2EErrorPaths:
+    def test_404_no_package(self, tmp_path):
+        # No routes — every GET returns 404.
+        with _running_server({}) as (host, port):
+            base = f"http://{host}:{port}"
+            resolver = RegistryPackageResolver({"corp": base})
+            with pytest.raises(RegistryResolutionError, match="no package"):
+                resolver.download_package(_make_dep("acme/missing"), tmp_path / "p")
+
+    def test_401_surfaces_remediation(self, tmp_path):
+        routes = {
+            "/v1/packages/acme/web/versions": lambda h: (
+                401,
+                "application/problem+json",
+                json.dumps({"title": "Unauthorized", "detail": "missing token"}).encode(),
+            )
+        }
+        with _running_server(routes) as (host, port):
+            base = f"http://{host}:{port}"
+            resolver = RegistryPackageResolver({"corp": base})
+            with pytest.raises(RegistryResolutionError) as excinfo:
+                resolver.download_package(_make_dep(), tmp_path / "p")
+            msg = str(excinfo.value)
+            assert "APM_REGISTRY_TOKEN_<NAME>" in msg
+            assert base in msg
+
+    def test_hash_mismatch_fails_closed(self, tmp_path):
+        data, _real_digest = _build_apm_tarball()
+        bogus = "0" * 64  # advertise a wrong digest
+        routes = {
+            "/v1/packages/acme/web/versions": lambda h: (
+                200,
+                "application/json",
+                _versions_payload("acme/web", "1.0.0", bogus),
+            ),
+            "/v1/packages/acme/web/versions/1.0.0/download": lambda h: (
+                200,
+                "application/gzip",
+                data,
+            ),
+        }
+        with _running_server(routes) as (host, port):
+            base = f"http://{host}:{port}"
+            resolver = RegistryPackageResolver({"corp": base})
+            with pytest.raises(Exception) as excinfo:
+                resolver.download_package(_make_dep(), tmp_path / "p")
+            # Either HashMismatchError directly or wrapped in RegistryResolutionError
+            assert (
+                "mismatch" in str(excinfo.value).lower() or "Hash" in type(excinfo.value).__name__
+            )
+
+    def test_no_matching_version(self, tmp_path):
+        _data, digest = _build_apm_tarball()
+        routes = {
+            # Only 2.x available; manifest asks for ^1.0.0
+            "/v1/packages/acme/web/versions": lambda h: (
+                200,
+                "application/json",
+                _versions_payload("acme/web", "2.0.0", digest),
+            ),
+        }
+        with _running_server(routes) as (host, port):
+            base = f"http://{host}:{port}"
+            resolver = RegistryPackageResolver({"corp": base})
+            with pytest.raises(RegistryResolutionError, match="no version"):
+                resolver.download_package(_make_dep(), tmp_path / "p")
+
+
+class TestE2EAuthHeader:
+    """Confirm Bearer header is forwarded and observed by the server."""
+
+    def test_token_sent_when_env_set(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("APM_REGISTRY_TOKEN_CORP", "secret-token-123")
+        data, digest = _build_apm_tarball()
+        seen_headers: dict = {}
+
+        def versions_route(h):
+            seen_headers["versions"] = dict(h.headers)
+            return (
+                200,
+                "application/json",
+                _versions_payload("acme/web", "1.0.0", digest),
+            )
+
+        def download_route(h):
+            seen_headers["download"] = dict(h.headers)
+            return (200, "application/gzip", data)
+
+        routes = {
+            "/v1/packages/acme/web/versions": versions_route,
+            "/v1/packages/acme/web/versions/1.0.0/download": download_route,
+        }
+        with _running_server(routes) as (host, port):
+            base = f"http://{host}:{port}"
+            resolver = RegistryPackageResolver({"corp": base})
+            resolver.download_package(_make_dep(), tmp_path / "x")
+        assert seen_headers["versions"].get("Authorization") == "Bearer secret-token-123"
+        assert seen_headers["download"].get("Authorization") == "Bearer secret-token-123"
+
+    def test_anonymous_when_no_env(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("APM_REGISTRY_TOKEN_CORP", raising=False)
+        data, digest = _build_apm_tarball()
+        seen_headers: dict = {}
+
+        def route(h):
+            seen_headers["versions"] = dict(h.headers)
+            return (
+                200,
+                "application/json",
+                _versions_payload("acme/web", "1.0.0", digest),
+            )
+
+        routes = {
+            "/v1/packages/acme/web/versions": route,
+            "/v1/packages/acme/web/versions/1.0.0/download": lambda h: (
+                200,
+                "application/gzip",
+                data,
+            ),
+        }
+        with _running_server(routes) as (host, port):
+            base = f"http://{host}:{port}"
+            resolver = RegistryPackageResolver({"corp": base})
+            resolver.download_package(_make_dep(), tmp_path / "x")
+        assert seen_headers["versions"].get("Authorization") is None

--- a/tests/unit/registry/test_semver.py
+++ b/tests/unit/registry/test_semver.py
@@ -1,0 +1,149 @@
+"""Tests for registry wrappers around the canonical APM semver matcher.
+
+Covers the parse-time gate (``is_semver_range``) that rejects branch names and
+commit SHAs when an entry routes to a registry, plus the range-matching logic
+used by the resolver to pick the best published version.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apm_cli.deps.registry.semver import (
+    is_semver_range,
+    match_version,
+    pick_best,
+)
+
+
+class TestIsSemverRange:
+    """``is_semver_range`` is the parse-time gate for registry-routed deps."""
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            "1.0.0",
+            "^1.0.0",
+            "^1.2.3",
+            "~1.2.3",
+            ">=1.0.0",
+            "<2.0.0",
+            ">=1.0.0 <2.0.0",
+            ">1.0.0",
+            "<=2.0.0",
+            "1.2.x",
+            "1.2.*",
+            "1.0.0-beta.1",
+            "1.0.0+build.42",
+        ],
+    )
+    def test_accepts_valid_ranges(self, spec):
+        assert is_semver_range(spec)
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            "main",
+            "develop",
+            "abc123d",
+            "abc123def4567",
+            "latest",
+            "",
+            "v1@bad",
+            "not-a-version",
+            "@invalid",
+            "v1.0.0",
+            "1.2",
+            "1",
+            "^1.2",
+            "~1.2",
+            ">=1",
+            "<2",
+            ">=1,<2",
+            "1.x",
+            "1.*",
+            "*",
+        ],
+    )
+    def test_rejects_invalid_refs(self, spec):
+        assert not is_semver_range(spec)
+
+
+class TestMatchVersion:
+    """Range-matching semantics."""
+
+    @pytest.mark.parametrize(
+        "spec,version",
+        [
+            ("^1.2.0", "1.2.0"),
+            ("^1.2.0", "1.5.0"),
+            ("^1.2.0", "1.99.99"),
+            ("^0.2.3", "0.2.3"),
+            ("^0.2.3", "0.2.99"),
+            ("~1.2.3", "1.2.3"),
+            ("~1.2.3", "1.2.99"),
+            ("1.2.x", "1.2.0"),
+            ("1.2.x", "1.2.99"),
+            (">=1.0.0 <2.0.0", "1.99.0"),
+            (">=1.0.0", "1.0.0"),
+            ("1.0.0", "1.0.0"),
+            ("1.0.0-beta.1", "1.0.0-beta.1"),
+        ],
+    )
+    def test_match(self, spec, version):
+        assert match_version(spec, version)
+
+    @pytest.mark.parametrize(
+        "spec,version",
+        [
+            ("^1.2.0", "2.0.0"),
+            ("^1.2.0", "1.1.99"),
+            ("^0.2.3", "0.3.0"),
+            ("^0.2.3", "0.2.2"),
+            ("~1.2.3", "1.3.0"),
+            ("1.2.x", "1.3.0"),
+            (">=1.0.0 <2.0.0", "2.0.0"),
+            ("1.0.0", "1.0.1"),
+            ("1.0.0", "0.9.99"),
+        ],
+    )
+    def test_no_match(self, spec, version):
+        assert not match_version(spec, version)
+
+    def test_invalid_spec_does_not_match(self):
+        assert not match_version("main", "1.0.0")
+
+    def test_invalid_version_does_not_match(self):
+        assert not match_version("^1.0.0", "abc")
+
+
+class TestPickBest:
+    """``pick_best`` returns the highest matching version, or None."""
+
+    def test_picks_highest_in_range(self):
+        versions = ["1.0.0", "1.2.0", "1.5.3", "2.0.0"]
+        assert pick_best("^1.0.0", versions) == "1.5.3"
+
+    def test_skips_outside_range(self):
+        versions = ["1.0.0", "1.2.0", "2.0.0"]
+        assert pick_best("~1.2.0", versions) == "1.2.0"
+
+    def test_no_match_returns_none(self):
+        assert pick_best(">=2.0.0", ["1.0.0"]) is None
+
+    def test_invalid_spec_returns_none(self):
+        assert pick_best("main", ["1.0.0"]) is None
+
+    def test_skips_unparseable_versions(self):
+        # An unparseable entry in the list is silently skipped, not raised.
+        versions = ["1.0.0", "garbage", "1.5.0"]
+        assert pick_best("^1.0.0", versions) == "1.5.0"
+
+    def test_caret_zero_zero_x(self):
+        """^0.0.x semantics: only the patch matches exactly."""
+        assert pick_best("^0.0.3", ["0.0.3", "0.0.4"]) == "0.0.3"
+        assert pick_best("^0.0.3", ["0.0.4", "0.0.5"]) is None
+
+    def test_prerelease_sorts_before_release(self):
+        versions = ["1.0.0-beta.1", "1.0.0"]
+        assert pick_best(">=1.0.0-beta.1 <2.0.0", versions) == "1.0.0"

--- a/tests/unit/test_apm_yml_registries.py
+++ b/tests/unit/test_apm_yml_registries.py
@@ -1,0 +1,502 @@
+"""Tests for the top-level ``registries:`` block in apm.yml.
+
+Covers ``APMPackage.from_apm_yml`` parsing of the new block plus the
+default-registry routing pass per docs/proposals/registry-api.md §3.1/§3.2.
+
+The hardest invariant: a project without a ``registries:`` block is
+byte-identical to pre-PR behavior (invariant §2.1.1).
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from apm_cli.models.apm_package import APMPackage, clear_apm_yml_cache
+
+
+@pytest.fixture
+def write_yml(tmp_path):
+    """Yield a helper that writes ``apm.yml`` content to a temp dir."""
+
+    def _write(content: str) -> Path:
+        clear_apm_yml_cache()
+        p = tmp_path / "apm.yml"
+        p.write_text(textwrap.dedent(content).strip() + "\n")
+        return p
+
+    return _write
+
+
+@pytest.fixture(autouse=True)
+def _enable_package_registry(monkeypatch):
+    """Most tests in this module exercise the experimental registry feature."""
+    import apm_cli.config as _conf
+
+    monkeypatch.setattr(
+        _conf,
+        "_config_cache",
+        {"experimental": {"registries": True}},
+    )
+
+
+def _disable_package_registry(monkeypatch):
+    import apm_cli.config as _conf
+
+    clear_apm_yml_cache()
+    monkeypatch.setattr(_conf, "_config_cache", {"experimental": {}})
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Block parsing
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestRegistriesBlockParsing:
+    def test_no_block_means_no_change(self, write_yml):
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            dependencies:
+              apm:
+                - acme/foo#main
+                - acme/bar#v1.0
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        assert pkg.registries is None
+        assert pkg.default_registry is None
+        for dep in pkg.dependencies["apm"]:
+            assert dep.source is None
+
+    def test_block_without_default(self, write_yml):
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            registries:
+              corp-main:
+                url: https://corp.example.com/apm
+            dependencies:
+              apm:
+                - acme/foo#v1.0
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        assert pkg.registries == {"corp-main": "https://corp.example.com/apm"}
+        assert pkg.default_registry is None
+        # Without a default, plain shorthand stays on Git.
+        assert pkg.dependencies["apm"][0].source is None
+
+    def test_block_with_default(self, write_yml):
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com/apm
+              default: corp
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        assert pkg.default_registry == "corp"
+        assert "corp" in pkg.registries
+
+    def test_multiple_registries(self, write_yml):
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            registries:
+              corp-a:
+                url: https://a.example.com/apm
+              corp-b:
+                url: https://b.example.com/apm
+              default: corp-a
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        assert set(pkg.registries.keys()) == {"corp-a", "corp-b"}
+        assert pkg.default_registry == "corp-a"
+
+    def test_empty_block(self, write_yml):
+        # ``registries: {}`` is harmless and yields no fields set.
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            registries: {}
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        assert pkg.registries is None
+        assert pkg.default_registry is None
+
+
+class TestPackageRegistryExperimentalGate:
+    def test_non_empty_registries_block_requires_flag(self, write_yml, monkeypatch):
+        _disable_package_registry(monkeypatch)
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com/apm
+            """)
+        with pytest.raises(ValueError, match="apm experimental enable registries"):
+            APMPackage.from_apm_yml(p)
+
+    def test_empty_registries_block_allowed_without_flag(self, write_yml, monkeypatch):
+        _disable_package_registry(monkeypatch)
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            registries: {}
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        assert pkg.registries is None
+        assert pkg.default_registry is None
+
+
+class TestRegistriesBlockValidation:
+    def test_non_mapping_block_rejected(self, write_yml):
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            registries: not-a-mapping
+            """)
+        with pytest.raises(ValueError, match="must be a mapping"):
+            APMPackage.from_apm_yml(p)
+
+    def test_missing_url_rejected(self, write_yml):
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            registries:
+              corp: {}
+            """)
+        with pytest.raises(ValueError, match="missing required field 'url:'"):
+            APMPackage.from_apm_yml(p)
+
+    def test_non_http_url_rejected(self, write_yml):
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: ftp://corp.example.com
+            """)
+        with pytest.raises(ValueError, match="https:// or http://"):
+            APMPackage.from_apm_yml(p)
+
+    def test_token_field_rejected(self, write_yml):
+        # Tokens must never appear in apm.yml — use env vars or config.
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com/apm
+                token: oops-not-here
+            """)
+        with pytest.raises(ValueError, match=r"must not appear in apm\.yml"):
+            APMPackage.from_apm_yml(p)
+
+    def test_unknown_default_rejected(self, write_yml):
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com
+              default: nonexistent
+            """)
+        with pytest.raises(ValueError, match="unconfigured registry"):
+            APMPackage.from_apm_yml(p)
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Default-registry routing pass
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestDefaultRouting:
+    def test_shorthand_routes_to_default(self, write_yml):
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com/apm
+              default: corp
+            dependencies:
+              apm:
+                - acme/foo#^1.0.0
+                - acme/bar#1.2.3
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        for dep in pkg.dependencies["apm"]:
+            assert dep.source == "registry"
+            assert dep.registry_name == "corp"
+
+    @pytest.mark.xfail(reason="@registry scope shorthand not yet implemented", strict=True)
+    def test_at_scope_overrides_default(self, write_yml):
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            registries:
+              corp-main:
+                url: https://main.example.com/apm
+              corp-other:
+                url: https://other.example.com/apm
+              default: corp-main
+            dependencies:
+              apm:
+                - acme/foo@corp-other#^1.0.0
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        d = pkg.dependencies["apm"][0]
+        assert d.registry_name == "corp-other"
+
+    def test_explicit_git_object_form_not_routed(self, write_yml):
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com/apm
+              default: corp
+            dependencies:
+              apm:
+                - git: https://github.com/owner/repo.git
+                  ref: v2.0
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        d = pkg.dependencies["apm"][0]
+        assert d.source == "git"  # explicit, not "registry"
+
+    def test_object_form_registry_preserved(self, write_yml):
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            registries:
+              corp-main:
+                url: https://main.example.com/apm
+              corp-other:
+                url: https://other.example.com/apm
+              default: corp-main
+            dependencies:
+              apm:
+                - registry: corp-other
+                  id: acme/prompts
+                  path: a/b.prompt.md
+                  version: 1.0.0
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        d = pkg.dependencies["apm"][0]
+        assert d.registry_name == "corp-other"
+
+    def test_local_path_not_routed(self, write_yml):
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com/apm
+              default: corp
+            dependencies:
+              apm:
+                - ./local-pkg
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        d = pkg.dependencies["apm"][0]
+        assert d.is_local
+        assert d.source is None
+
+    def test_dev_dependencies_routed_too(self, write_yml):
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com/apm
+              default: corp
+            devDependencies:
+              apm:
+                - acme/foo#1.0.0
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        d = pkg.dev_dependencies["apm"][0]
+        assert d.source == "registry"
+        assert d.registry_name == "corp"
+
+
+class TestDefaultRoutingErrors:
+    def test_branch_ref_routed_to_registry(self, write_yml):
+        # Routing is unconditional — any ref (including branch names) routes
+        # to the default registry. Use ``- git:`` to keep a dep on Git.
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com/apm
+              default: corp
+            dependencies:
+              apm:
+                - acme/foo#main
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        d = pkg.dependencies["apm"][0]
+        assert d.source == "registry"
+        assert d.registry_name == "corp"
+
+    def test_commit_sha_routed_to_registry(self, write_yml):
+        # Commit SHAs are opaque version strings to the registry.
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com/apm
+              default: corp
+            dependencies:
+              apm:
+                - acme/foo#abc123d
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        d = pkg.dependencies["apm"][0]
+        assert d.source == "registry"
+        assert d.registry_name == "corp"
+
+    def test_missing_ref_rejected(self, write_yml):
+        # A shorthand with no ref at all is always rejected — the registry
+        # requires a version selector.
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com/apm
+              default: corp
+            dependencies:
+              apm:
+                - acme/foo
+            """)
+        with pytest.raises(ValueError, match="no version constraint"):
+            APMPackage.from_apm_yml(p)
+
+    def test_non_semver_ref_routed_to_registry(self, write_yml):
+        # Non-semver labels like branch names are valid registry version
+        # selectors — the registry decides what they resolve to.
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            registries:
+              corp:
+                url: https://corp.example.com/apm
+              default: corp
+            dependencies:
+              apm:
+                - acme/foo#develop
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        d = pkg.dependencies["apm"][0]
+        assert d.source == "registry"
+        assert d.registry_name == "corp"
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Backwards-compatibility invariants
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestBackwardsCompatibility:
+    """A project without ``registries:`` MUST behave byte-identically to pre-PR."""
+
+    def test_branch_ref_still_valid_without_registries(self, write_yml):
+        # Per invariant §2.1.3, branch refs remain valid in the absence of
+        # a registries: block — the parser stays ref-opaque on the Git path.
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            dependencies:
+              apm:
+                - acme/foo#main
+                - acme/foo#abc123d
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        for dep in pkg.dependencies["apm"]:
+            assert dep.source is None
+
+    def test_no_version_still_valid_without_registries(self, write_yml):
+        # `acme/foo` without a #ref is fine when no default registry is set.
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            dependencies:
+              apm:
+                - acme/foo
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        assert pkg.dependencies["apm"][0].reference is None
+
+
+class TestConfigJsonDefaultRegistry:
+    def test_config_default_routes_without_apm_yml_block(self, write_yml, monkeypatch):
+        import apm_cli.config as _conf
+
+        monkeypatch.setattr(
+            _conf,
+            "_config_cache",
+            {
+                "experimental": {"registries": True},
+                "registries": {
+                    "corp-main": {
+                        "url": "https://corp.example.com/apm",
+                        "default": True,
+                    }
+                },
+            },
+        )
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            dependencies:
+              apm:
+                - acme/foo#^1.0.0
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        assert pkg.registries == {"corp-main": "https://corp.example.com/apm"}
+        assert pkg.default_registry == "corp-main"
+        dep = pkg.dependencies["apm"][0]
+        assert dep.source == "registry"
+        assert dep.registry_name == "corp-main"
+
+    def test_apm_yml_default_wins_over_config_default(self, write_yml, monkeypatch):
+        import apm_cli.config as _conf
+
+        monkeypatch.setattr(
+            _conf,
+            "_config_cache",
+            {
+                "experimental": {"registries": True},
+                "registries": {
+                    "config-only": {
+                        "url": "https://config.example.com/apm",
+                        "default": True,
+                    }
+                },
+            },
+        )
+        p = write_yml("""
+            name: x
+            version: 1.0.0
+            registries:
+              project-main:
+                url: https://project.example.com/apm
+              default: project-main
+            dependencies:
+              apm:
+                - acme/foo#^1.0.0
+            """)
+        pkg = APMPackage.from_apm_yml(p)
+        assert pkg.default_registry == "project-main"
+        assert pkg.registries["project-main"] == "https://project.example.com/apm"
+        assert pkg.registries["config-only"] == "https://config.example.com/apm"
+        dep = pkg.dependencies["apm"][0]
+        assert dep.registry_name == "project-main"

--- a/tests/unit/test_drift_registry.py
+++ b/tests/unit/test_drift_registry.py
@@ -1,0 +1,246 @@
+"""Source-aware drift rules for registry-sourced deps.
+
+Covers the docs/proposals/registry-api.md §6.1 invariants:
+
+- Manifest carries a semver range (e.g. ``^1.2.0``); lockfile carries an exact
+  version (e.g. ``1.5.3``). Direct string comparison would be a false
+  positive — drift is "did the locked version stop matching the manifest
+  range?".
+- Source-flip drift (git -> registry or vice versa) forces a re-resolve.
+- ``build_download_ref`` replays the exact locked version for registry deps,
+  not the manifest range.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from apm_cli.drift import build_download_ref, detect_ref_change
+from apm_cli.models.dependency.reference import DependencyReference
+
+
+@dataclass
+class _LockedDep:
+    """Minimal LockedDependency stand-in for drift tests."""
+
+    repo_url: str = "acme/web"
+    resolved_ref: str | None = None
+    resolved_commit: str | None = None
+    host: str | None = "github.com"
+    registry_prefix: str | None = None
+    virtual_path: str | None = None
+    source: str | None = None
+    local_path: str | None = None
+    version: str | None = None
+    resolved_url: str | None = None
+    resolved_hash: str | None = None
+    is_insecure: bool = False
+    allow_insecure: bool = False
+
+
+class _LockfileStub:
+    """Pretend lockfile that just exposes get_dependency for build_download_ref."""
+
+    def __init__(self, deps_by_key):
+        self._deps = deps_by_key
+
+    def get_dependency(self, key):
+        return self._deps.get(key)
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Source-flip drift
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestSourceFlipDrift:
+    def test_git_to_registry_is_drift(self):
+        dep = DependencyReference(repo_url="acme/web", reference="^1.2.0", source="registry")
+        locked = _LockedDep(resolved_ref="v1.0", source=None)  # legacy git
+        assert detect_ref_change(dep, locked) is True
+
+    def test_registry_to_git_is_drift(self):
+        dep = DependencyReference(repo_url="acme/web", reference="v1.0")  # git
+        locked = _LockedDep(source="registry", version="1.0.0")
+        assert detect_ref_change(dep, locked) is True
+
+    def test_legacy_none_source_equals_git(self):
+        # Lockfile from before this PR has source=None for git deps.
+        # A new manifest dep with source=None (Git default) MUST NOT be
+        # treated as a source flip.
+        dep = DependencyReference(repo_url="acme/web", reference="v1.0")
+        locked = _LockedDep(resolved_ref="v1.0", source=None)
+        assert detect_ref_change(dep, locked) is False
+
+    def test_explicit_git_to_legacy_none_no_drift(self):
+        # source="git" and source=None are equivalent.
+        dep = DependencyReference(repo_url="acme/web", reference="v1.0", source="git")
+        locked = _LockedDep(resolved_ref="v1.0", source=None)
+        assert detect_ref_change(dep, locked) is False
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Registry semver-range matching
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestRegistryRangeMatching:
+    def test_locked_version_inside_range_no_drift(self):
+        dep = DependencyReference(repo_url="acme/web", reference="^1.2.0", source="registry")
+        locked = _LockedDep(source="registry", version="1.5.3")
+        assert detect_ref_change(dep, locked) is False
+
+    def test_locked_version_outside_range_is_drift(self):
+        # User tightened the range; locked version no longer matches.
+        dep = DependencyReference(repo_url="acme/web", reference="~1.5.4", source="registry")
+        locked = _LockedDep(source="registry", version="1.5.3")
+        assert detect_ref_change(dep, locked) is True
+
+    def test_user_expanded_range_to_include_locked_no_drift(self):
+        # ``^1.0.0`` widens to include 1.5.3 — no drift, keep using it.
+        dep = DependencyReference(repo_url="acme/web", reference="^1.0.0", source="registry")
+        locked = _LockedDep(source="registry", version="1.5.3")
+        assert detect_ref_change(dep, locked) is False
+
+    def test_user_changed_to_major_bump_is_drift(self):
+        dep = DependencyReference(repo_url="acme/web", reference="^2.0.0", source="registry")
+        locked = _LockedDep(source="registry", version="1.5.3")
+        assert detect_ref_change(dep, locked) is True
+
+    def test_exact_version_match_no_drift(self):
+        dep = DependencyReference(repo_url="acme/web", reference="1.5.3", source="registry")
+        locked = _LockedDep(source="registry", version="1.5.3")
+        assert detect_ref_change(dep, locked) is False
+
+    def test_missing_version_in_lockfile_is_drift(self):
+        # A registry dep with no `version` recorded is corrupt — fail loud.
+        dep = DependencyReference(repo_url="acme/web", reference="^1.0.0", source="registry")
+        locked = _LockedDep(source="registry", version=None)
+        assert detect_ref_change(dep, locked) is True
+
+    def test_missing_manifest_ref_is_drift(self):
+        dep = DependencyReference(repo_url="acme/web", reference=None, source="registry")
+        locked = _LockedDep(source="registry", version="1.0.0")
+        assert detect_ref_change(dep, locked) is True
+
+    def test_invalid_manifest_range_is_drift(self):
+        # Branch-shaped ref slipped past parsing for some reason — fail
+        # loud on the drift path so it surfaces.
+        dep = DependencyReference(repo_url="acme/web", reference="main", source="registry")
+        locked = _LockedDep(source="registry", version="1.0.0")
+        assert detect_ref_change(dep, locked) is True
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Backwards-compat: git deps unchanged
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestGitDriftUnchanged:
+    def test_same_ref_no_drift(self):
+        dep = DependencyReference(repo_url="acme/web", reference="v1.0")
+        locked = _LockedDep(resolved_ref="v1.0")
+        assert detect_ref_change(dep, locked) is False
+
+    def test_changed_ref_is_drift(self):
+        dep = DependencyReference(repo_url="acme/web", reference="v2.0")
+        locked = _LockedDep(resolved_ref="v1.0")
+        assert detect_ref_change(dep, locked) is True
+
+    def test_added_ref_is_drift(self):
+        dep = DependencyReference(repo_url="acme/web", reference="v2.0")
+        locked = _LockedDep(resolved_ref=None)
+        assert detect_ref_change(dep, locked) is True
+
+    def test_removed_ref_is_drift(self):
+        dep = DependencyReference(repo_url="acme/web", reference=None)
+        locked = _LockedDep(resolved_ref="v1.0")
+        assert detect_ref_change(dep, locked) is True
+
+    def test_update_refs_skips_drift(self):
+        dep = DependencyReference(repo_url="acme/web", reference="v2.0")
+        locked = _LockedDep(resolved_ref="v1.0")
+        assert detect_ref_change(dep, locked, update_refs=True) is False
+
+    def test_no_locked_dep_is_first_install_not_drift(self):
+        dep = DependencyReference(repo_url="acme/web", reference="v1.0")
+        assert detect_ref_change(dep, None) is False
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# build_download_ref for registry deps
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestBuildDownloadRefRegistry:
+    def test_registry_dep_replays_locked_version(self):
+        # Manifest has ``^1.2.0`` (range), lockfile has ``1.5.3`` (exact).
+        # The downloader should see ``1.5.3`` so the resolver picks the
+        # exact locked version, not whatever ``^1.2.0`` resolves to today.
+        dep = DependencyReference(
+            repo_url="acme/web",
+            reference="^1.2.0",
+            source="registry",
+            registry_name="corp",
+        )
+        locked = _LockedDep(
+            source="registry",
+            version="1.5.3",
+            resolved_url="https://r/v1/.../download",
+            resolved_hash="sha256:abc",
+        )
+        lockfile = _LockfileStub({"acme/web": locked})
+        result = build_download_ref(dep, lockfile, update_refs=False, ref_changed=False)
+        assert result.reference == "1.5.3"
+        assert result.source == "registry"
+        # registry_name is not in the override set; preserves manifest value
+        assert result.registry_name == "corp"
+
+    def test_registry_dep_with_ref_changed_uses_manifest_range(self):
+        # The manifest range was tightened past the locked version. Drift
+        # detection returns True; build_download_ref must NOT pin to the
+        # locked version (it's now outside the range). Use the manifest.
+        dep = DependencyReference(
+            repo_url="acme/web",
+            reference="~2.0.0",
+            source="registry",
+            registry_name="corp",
+        )
+        locked = _LockedDep(source="registry", version="1.5.3")
+        lockfile = _LockfileStub({"acme/web": locked})
+        result = build_download_ref(dep, lockfile, update_refs=False, ref_changed=True)
+        assert result.reference == "~2.0.0"
+
+    def test_registry_dep_with_update_refs_uses_manifest_range(self):
+        # ``apm install --update`` always re-resolves from the manifest.
+        dep = DependencyReference(
+            repo_url="acme/web",
+            reference="^1.2.0",
+            source="registry",
+            registry_name="corp",
+        )
+        locked = _LockedDep(source="registry", version="1.5.3")
+        lockfile = _LockfileStub({"acme/web": locked})
+        result = build_download_ref(dep, lockfile, update_refs=True, ref_changed=False)
+        assert result.reference == "^1.2.0"
+
+    def test_git_dep_unchanged_uses_locked_commit(self):
+        # Sanity: existing git path is byte-identical post-Phase-8.
+        dep = DependencyReference(repo_url="acme/web", reference="v1.0")
+        locked = _LockedDep(resolved_ref="v1.0", resolved_commit="abc123def4567890")
+        lockfile = _LockfileStub({"acme/web": locked})
+        result = build_download_ref(dep, lockfile, update_refs=False, ref_changed=False)
+        assert result.reference == "abc123def4567890"
+
+    def test_no_locked_dep_returns_dep_unchanged(self):
+        dep = DependencyReference(
+            repo_url="acme/web",
+            reference="^1.2.0",
+            source="registry",
+            registry_name="corp",
+        )
+        lockfile = _LockfileStub({})
+        result = build_download_ref(dep, lockfile, update_refs=False, ref_changed=False)
+        # No override applied — same identity, same range.
+        assert result.reference == "^1.2.0"
+        assert result.source == "registry"

--- a/tests/unit/test_install_command.py
+++ b/tests/unit/test_install_command.py
@@ -889,7 +889,8 @@ class TestInstallGlobalFlag:
                 ):
                     result = self.runner.invoke(cli, ["install", "--global"])
                 assert result.exit_code == 1
-                assert "apm.yml" in result.output
+                # Rich may soft-wrap long paths; join wrapped segments for substring checks.
+                assert "apm.yml" in result.output.replace("\n", "")
             finally:
                 os.chdir(self.original_dir)
 

--- a/tests/unit/test_install_update.py
+++ b/tests/unit/test_install_update.py
@@ -442,6 +442,7 @@ class TestRefChangedDetection:
         locked_dep = Mock()
         locked_dep.resolved_ref = resolved_ref
         locked_dep.resolved_commit = resolved_commit
+        locked_dep.source = None
         return locked_dep
 
     def test_no_drift_when_refs_match(self):

--- a/tests/unit/test_lockfile_v2_bump.py
+++ b/tests/unit/test_lockfile_v2_bump.py
@@ -1,0 +1,275 @@
+"""Tests for the lockfile v1->v2 opportunistic bump.
+
+Covers docs/proposals/registry-api.md §6.1 (registry resolver fields:
+``resolved_url``, ``resolved_hash``) and the invariant that a project that
+never uses the registry keeps lockfile_version "1" forever (§2.1.4).
+"""
+
+from __future__ import annotations
+
+from apm_cli.deps.lockfile import LockedDependency, LockFile
+from apm_cli.deps.registry.resolver import RegistryResolution
+from apm_cli.models.dependency.reference import DependencyReference
+
+
+def _git_dep(**kwargs) -> LockedDependency:
+    defaults = dict(
+        repo_url="acme/foo",
+        host="github.com",
+        resolved_commit="abc123",
+        resolved_ref="v1.0",
+    )
+    defaults.update(kwargs)
+    return LockedDependency(**defaults)
+
+
+def _registry_dep(**kwargs) -> LockedDependency:
+    defaults = dict(
+        repo_url="acme/web",
+        host="github.com",
+        source="registry",
+        version="1.2.0",
+        resolved_url=("https://reg.example.com/apm/v1/packages/acme/web/versions/1.2.0/tarball"),
+        resolved_hash="sha256:" + "a" * 64,
+    )
+    defaults.update(kwargs)
+    return LockedDependency(**defaults)
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Schema bump (invariant §2.1.4)
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestVersionFieldStaysInSync:
+    """Regression: ``lockfile_version`` must reflect content in the in-memory
+    object, not just at to_yaml() emit time. Otherwise the equivalence check
+    sees ``"1"`` in-memory vs ``"2"`` on-disk and rewrites the file on every
+    no-op install.
+    """
+
+    def test_add_registry_dep_promotes_field_to_v2(self):
+        lock = LockFile()  # default "1"
+        assert lock.lockfile_version == "1"
+        lock.add_dependency(_registry_dep())
+        assert lock.lockfile_version == "2"
+
+    def test_add_git_dep_keeps_field_at_v1(self):
+        lock = LockFile()
+        lock.add_dependency(_git_dep())
+        assert lock.lockfile_version == "1"
+
+    def test_inmem_and_disk_equivalent_after_add(self):
+        in_memory = LockFile()
+        in_memory.add_dependency(_registry_dep())
+        on_disk = LockFile.from_yaml(in_memory.to_yaml())
+        assert in_memory.lockfile_version == on_disk.lockfile_version == "2"
+        assert in_memory.is_semantically_equivalent(on_disk)
+        assert on_disk.is_semantically_equivalent(in_memory)
+
+    def test_to_yaml_self_heals_direct_dict_mutation(self):
+        # Defense-in-depth: a caller that bypasses add_dependency by
+        # mutating ``self.dependencies`` directly will still get the
+        # right emit version on first to_yaml() call.
+        lock = LockFile()
+        lock.dependencies[_registry_dep().get_unique_key()] = _registry_dep()
+        assert lock.lockfile_version == "1"  # bypass — field stale
+        out = lock.to_yaml()
+        assert lock.lockfile_version == "2"  # to_yaml self-healed
+        assert "lockfile_version: '2'" in out
+
+
+class TestSchemaBumpOpportunistic:
+    def test_v1_stays_v1_without_registry_deps(self):
+        lock = LockFile()
+        lock.add_dependency(_git_dep())
+        yaml_out = lock.to_yaml()
+        assert "lockfile_version: '1'" in yaml_out
+
+    def test_v2_emitted_when_registry_dep_present(self):
+        lock = LockFile()
+        lock.add_dependency(_git_dep())
+        lock.add_dependency(_registry_dep())
+        yaml_out = lock.to_yaml()
+        assert "lockfile_version: '2'" in yaml_out
+
+    def test_only_local_deps_stays_v1(self):
+        lock = LockFile()
+        lock.add_dependency(
+            LockedDependency(repo_url="_local/x", source="local", local_path="./local/x")
+        )
+        assert "lockfile_version: '1'" in lock.to_yaml()
+
+    def test_v2_back_to_v1_when_registry_dep_removed(self):
+        lock = LockFile()
+        lock.add_dependency(_registry_dep())
+        assert "lockfile_version: '2'" in lock.to_yaml()
+        # Remove the registry dep; lockfile re-emits as v1.
+        del lock.dependencies["acme/web"]
+        lock.add_dependency(_git_dep())
+        assert "lockfile_version: '1'" in lock.to_yaml()
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# Field round-trip
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestRegistryFieldsRoundTrip:
+    def test_resolved_url_and_hash_emitted(self):
+        lock = LockFile()
+        lock.add_dependency(_registry_dep())
+        yaml_out = lock.to_yaml()
+        assert "resolved_url" in yaml_out
+        assert "resolved_hash" in yaml_out
+
+    def test_resolved_url_and_hash_omitted_for_git_deps(self):
+        lock = LockFile()
+        lock.add_dependency(_git_dep())
+        yaml_out = lock.to_yaml()
+        assert "resolved_url" not in yaml_out
+        assert "resolved_hash" not in yaml_out
+
+    def test_round_trip_preserves_registry_fields(self):
+        lock = LockFile()
+        lock.add_dependency(_registry_dep())
+        out = LockFile.from_yaml(lock.to_yaml())
+        reg = out.get_dependency("acme/web")
+        assert reg.source == "registry"
+        assert reg.resolved_url.endswith("/tarball")
+        assert reg.resolved_hash.startswith("sha256:")
+        assert reg.version == "1.2.0"
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# v1 lockfile compatibility (§2.1.4 read invariant)
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestV1ReadCompat:
+    def test_v1_lockfile_parses_without_migration(self):
+        v1_yaml = (
+            "lockfile_version: '1'\n"
+            "generated_at: 2026-01-01T00:00:00Z\n"
+            "dependencies:\n"
+            "- repo_url: acme/old\n"
+            "  resolved_commit: abc123\n"
+            "  resolved_ref: v1.0\n"
+            "  host: github.com\n"
+        )
+        lock = LockFile.from_yaml(v1_yaml)
+        old = lock.get_dependency("acme/old")
+        assert old.resolved_url is None
+        assert old.resolved_hash is None
+        assert old.source is None
+
+    def test_v1_lockfile_reemits_as_v1(self):
+        v1_yaml = (
+            "lockfile_version: '1'\n"
+            "generated_at: 2026-01-01T00:00:00Z\n"
+            "dependencies:\n"
+            "- repo_url: acme/old\n"
+            "  resolved_commit: abc123\n"
+            "  host: github.com\n"
+        )
+        lock = LockFile.from_yaml(v1_yaml)
+        out = lock.to_yaml()
+        assert "lockfile_version: '1'" in out
+
+    def test_v2_lockfile_with_registry_field_parses(self):
+        v2_yaml = (
+            "lockfile_version: '2'\n"
+            "generated_at: 2026-01-01T00:00:00Z\n"
+            "dependencies:\n"
+            "- repo_url: acme/web\n"
+            "  source: registry\n"
+            "  version: 1.2.0\n"
+            "  resolved_url: https://r/tarball\n"
+            "  resolved_hash: sha256:abc\n"
+            "  host: github.com\n"
+        )
+        lock = LockFile.from_yaml(v2_yaml)
+        reg = lock.get_dependency("acme/web")
+        assert reg.source == "registry"
+        assert reg.resolved_url == "https://r/tarball"
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# from_dependency_ref + RegistryResolution
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestFromDependencyRefWithResolution:
+    def test_registry_resolution_populates_fields(self):
+        dep = DependencyReference(
+            repo_url="acme/x",
+            reference="^1.0.0",
+            source="registry",
+            registry_name="corp",
+        )
+        resolution = RegistryResolution(
+            resolved_url="https://r/v1/packages/acme/x/versions/1.5.0/tarball",
+            resolved_hash="sha256:def",
+            version="1.5.0",
+        )
+        locked = LockedDependency.from_dependency_ref(
+            dep,
+            resolved_commit=None,
+            depth=1,
+            resolved_by=None,
+            registry_resolution=resolution,
+        )
+        assert locked.source == "registry"
+        assert locked.resolved_url == resolution.resolved_url
+        assert locked.resolved_hash == "sha256:def"
+        assert locked.version == "1.5.0"
+
+    def test_no_resolution_means_no_registry_fields(self):
+        # Existing git-resolver call site (no registry_resolution arg)
+        # produces a lockfile entry with source=None and no registry fields.
+        dep = DependencyReference(repo_url="acme/x", reference="v1.0")
+        locked = LockedDependency.from_dependency_ref(
+            dep, resolved_commit="abc", depth=1, resolved_by=None
+        )
+        assert locked.source is None
+        assert locked.resolved_url is None
+        assert locked.resolved_hash is None
+
+    def test_local_dep_unchanged(self):
+        dep = DependencyReference(repo_url="_local/pkg", is_local=True, local_path="./pkg")
+        locked = LockedDependency.from_dependency_ref(
+            dep, resolved_commit=None, depth=1, resolved_by=None
+        )
+        assert locked.source == "local"
+        assert locked.local_path == "./pkg"
+
+
+# ───────────────────────────────────────────────────────────────────────────
+# to_dependency_ref restores source field
+# ───────────────────────────────────────────────────────────────────────────
+
+
+class TestToDependencyRefRestoresSource:
+    def test_registry_source_restored(self):
+        locked = _registry_dep()
+        ref = locked.to_dependency_ref()
+        assert ref.source == "registry"
+
+    def test_registry_uses_locked_version_not_range(self):
+        # If a registry dep was originally pinned with ``^1.2.0`` and resolved
+        # to 1.5.3, the lockfile records 1.5.3 in `version`. to_dependency_ref
+        # must surface the exact version so re-installs are reproducible.
+        locked = _registry_dep(version="1.5.3", resolved_ref="^1.2.0")
+        ref = locked.to_dependency_ref()
+        assert ref.reference == "1.5.3"
+
+    def test_git_source_restored_as_none(self):
+        locked = _git_dep()
+        ref = locked.to_dependency_ref()
+        assert ref.source is None
+
+    def test_local_source_restored(self):
+        locked = LockedDependency(repo_url="_local/x", source="local", local_path="./x")
+        ref = locked.to_dependency_ref()
+        assert ref.source == "local"
+        assert ref.is_local

--- a/tests/unit/test_outdated_command.py
+++ b/tests/unit/test_outdated_command.py
@@ -423,6 +423,93 @@ class TestOutdatedCommand:
             assert "art/pkg" not in result.output
             assert mock_downloader.list_remote_refs.call_count == 1
 
+    # --- Registry dep ---
+
+    @patch("apm_cli.deps.registry.outdated.make_auth_context")
+    @patch("apm_cli.deps.registry.outdated.RegistryClient")
+    @patch(_PATCH_AUTH)
+    @patch(_PATCH_DOWNLOADER)
+    @patch(_PATCH_MIGRATE)
+    @patch(_PATCH_GET_LOCKFILE_PATH)
+    @patch(_PATCH_GET_APM_DIR)
+    @patch(_PATCH_LOCKFILE)
+    def test_registry_dep_shows_outdated(
+        self,
+        mock_lf_cls,
+        mock_get_apm_dir,
+        mock_get_path,
+        mock_migrate,
+        mock_dl_cls,
+        mock_auth,
+        mock_client_cls,
+        mock_make_auth,
+        monkeypatch,
+    ):
+        """Registry lockfile deps compare locked version against manifest range best."""
+        import apm_cli.config as _conf
+        from apm_cli.deps.registry.client import VersionEntry
+        from apm_cli.models.apm_package import clear_apm_yml_cache
+
+        monkeypatch.setattr(
+            _conf,
+            "_config_cache",
+            {"experimental": {"registries": True}},
+        )
+
+        with self._chdir_tmp() as tmp:
+            mock_get_apm_dir.return_value = tmp
+            mock_get_path.return_value = tmp / "apm.lock.yaml"
+
+            clear_apm_yml_cache()
+            (tmp / "apm.yml").write_text(
+                "name: demo\n"
+                "version: 1.0.0\n"
+                "registries:\n"
+                "  corp:\n"
+                "    url: https://reg.example.com/apm\n"
+                "  default: corp\n"
+                "dependencies:\n"
+                "  apm:\n"
+                "    - nadavy/e2e-demo#^1.0.0\n"
+            )
+
+            deps = {
+                "nadavy/e2e-demo": LockedDependency(
+                    repo_url="nadavy/e2e-demo",
+                    source="registry",
+                    version="1.0.1",
+                ),
+            }
+            mock_lf_cls.read.return_value = _make_lockfile(deps)
+
+            mock_downloader = MagicMock()
+            mock_dl_cls.return_value = mock_downloader
+
+            mock_client = MagicMock()
+            mock_client.list_versions.return_value = [
+                VersionEntry(
+                    version="1.0.1",
+                    digest="sha256:a",
+                    published_at="2026-01-01T00:00:00Z",
+                ),
+                VersionEntry(
+                    version="1.1.1",
+                    digest="sha256:b",
+                    published_at="2026-02-01T00:00:00Z",
+                ),
+            ]
+            mock_client_cls.return_value = mock_client
+
+            result = self.runner.invoke(cli, ["outdated"])
+
+            assert result.exit_code == 0
+            assert "nadavy/e2e-demo" in result.output
+            assert "1.0.1" in result.output
+            assert "1.1.1" in result.output
+            assert "outdated" in result.output.lower()
+            mock_downloader.list_remote_refs.assert_not_called()
+            mock_client.list_versions.assert_called_once_with("nadavy", "e2e-demo")
+
     # --- Error fetching refs for one dep (graceful degradation) ---
 
     @patch(_PATCH_AUTH)

--- a/tests/unit/test_reference_registry_shorthand.py
+++ b/tests/unit/test_reference_registry_shorthand.py
@@ -1,0 +1,387 @@
+"""Tests for the ``owner/repo@<name>#<semver>`` registry-scope shorthand.
+
+Covers the parser change in ``DependencyReference.parse`` per
+docs/proposals/registry-api.md §3.2/§3.3:
+
+- Routes a string-shorthand entry to a named registry when it carries the
+  ``@<name>`` scope suffix.
+- Rejects branch names and commit SHAs at parse time when the entry routes
+  to a registry (parse-time gate, not install-time).
+- Does NOT change the meaning of any existing shorthand: ``acme/foo#v1.0``,
+  ``git@host:...``, ``https://...`` all parse byte-identically.
+- Does NOT collide with the marketplace ``code-review@plugins`` shape (no
+  ``/`` on the LHS).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apm_cli.models.dependency.reference import DependencyReference
+
+
+@pytest.fixture(autouse=True)
+def _enable_package_registry(monkeypatch):
+    """Most tests in this module exercise the experimental registry feature."""
+    import apm_cli.config as _conf
+
+    monkeypatch.setattr(
+        _conf,
+        "_config_cache",
+        {"experimental": {"registries": True}},
+    )
+
+
+def _disable_package_registry(monkeypatch):
+    import apm_cli.config as _conf
+
+    monkeypatch.setattr(_conf, "_config_cache", {"experimental": {}})
+
+
+@pytest.mark.xfail(reason="@registry shorthand deferred to v2", strict=True)
+class TestRegistryScopeRouting:
+    """Strings of the form ``owner/repo@<name>#<semver>`` route to a registry."""
+
+    def test_basic_caret_range(self):
+        d = DependencyReference.parse("acme/foo@corp-main#^1.2.3")
+        assert d.repo_url == "acme/foo"
+        assert d.reference == "^1.2.3"
+        assert d.source == "registry"
+        assert d.registry_name == "corp-main"
+
+    def test_exact_version(self):
+        d = DependencyReference.parse("acme/foo@corp-other#1.2.3")
+        assert d.source == "registry"
+        assert d.registry_name == "corp-other"
+        assert d.reference == "1.2.3"
+
+    def test_patch_wildcard_range(self):
+        d = DependencyReference.parse("acme/foo@corp-main#1.2.x")
+        assert d.source == "registry"
+        assert d.reference == "1.2.x"
+
+    def test_tilde_range(self):
+        d = DependencyReference.parse("acme/foo@corp-main#~1.2.3")
+        assert d.reference == "~1.2.3"
+
+    def test_dotted_registry_name(self):
+        d = DependencyReference.parse("acme/foo@corp.main#1.0.0")
+        assert d.registry_name == "corp.main"
+
+    def test_underscore_registry_name(self):
+        # Hyphens, dots, underscores — all valid in registry names.
+        d = DependencyReference.parse("acme/foo@corp_main#1.0.0")
+        assert d.registry_name == "corp_main"
+
+    def test_extended_repo_path(self):
+        # Non-default-host shorthand: ``host/owner/repo@<name>#<semver>`` —
+        # the LHS regex captures multi-segment paths.
+        d = DependencyReference.parse("gitlab.com/owner/repo@corp-main#1.0.0")
+        assert d.source == "registry"
+        assert d.registry_name == "corp-main"
+        # repo_url after normalization is ``owner/repo`` (host extracted).
+        assert d.repo_url == "owner/repo"
+
+
+class TestPackageRegistryExperimentalGate:
+    @pytest.mark.xfail(reason="@registry shorthand deferred to v2", strict=True)
+    def test_registry_scope_requires_flag(self, monkeypatch):
+        _disable_package_registry(monkeypatch)
+        with pytest.raises(ValueError, match="apm experimental enable registries"):
+            DependencyReference.parse("acme/foo@corp-main#^1.2.3")
+
+    def test_registry_object_form_requires_flag(self, monkeypatch):
+        _disable_package_registry(monkeypatch)
+        with pytest.raises(ValueError, match="apm experimental enable registries"):
+            DependencyReference.parse_from_dict(
+                {
+                    "registry": "corp-main",
+                    "id": "acme/prompt-pack",
+                    "path": "prompts/review.prompt.md",
+                    "version": "1.4.0",
+                }
+            )
+
+    def test_git_and_local_forms_remain_available_without_flag(self, monkeypatch):
+        _disable_package_registry(monkeypatch)
+        git_dep = DependencyReference.parse("acme/foo#main")
+        local_dep = DependencyReference.parse("./local/pkg")
+        assert git_dep.source is None
+        assert local_dep.is_local
+
+
+@pytest.mark.xfail(reason="@registry shorthand deferred to v2", strict=True)
+class TestSemverEnforcement:
+    """Parse-time semver validation per design §3.3."""
+
+    def test_branch_name_rejected(self):
+        with pytest.raises(ValueError, match="not a semver"):
+            DependencyReference.parse("acme/foo@corp-main#main")
+
+    def test_develop_branch_rejected(self):
+        with pytest.raises(ValueError, match="not a semver"):
+            DependencyReference.parse("acme/foo@corp-main#develop")
+
+    def test_commit_sha_rejected(self):
+        with pytest.raises(ValueError, match="not a semver"):
+            DependencyReference.parse("acme/foo@corp-main#abc123d")
+
+    def test_long_commit_sha_rejected(self):
+        with pytest.raises(ValueError, match="not a semver"):
+            DependencyReference.parse("acme/foo@corp-main#abc1234567890def1234567890abcdef12345678")
+
+    def test_latest_rejected(self):
+        with pytest.raises(ValueError, match="not a semver"):
+            DependencyReference.parse("acme/foo@corp-main#latest")
+
+    def test_missing_version_rejected(self):
+        with pytest.raises(ValueError, match="missing a version"):
+            DependencyReference.parse("acme/foo@corp-main")
+
+    def test_error_message_suggests_git_alternative(self):
+        with pytest.raises(ValueError) as excinfo:
+            DependencyReference.parse("acme/foo@corp-main#main")
+        msg = str(excinfo.value)
+        assert "- git:" in msg
+        assert "semver" in msg.lower()
+
+
+class TestNoCollisionsWithExistingShapes:
+    """The new rule must NOT change any existing parse outcome."""
+
+    def test_plain_shorthand_unchanged(self):
+        d = DependencyReference.parse("acme/foo#v1.0")
+        assert d.source is None
+        assert d.registry_name is None
+        assert d.reference == "v1.0"
+        assert d.repo_url == "acme/foo"
+
+    def test_shorthand_with_branch_ref_still_works(self):
+        # When NOT routed to a registry, branch refs remain valid (Git is
+        # ref-opaque). This is invariant §2.1.3.
+        d = DependencyReference.parse("acme/foo#main")
+        assert d.source is None
+        assert d.reference == "main"
+
+    def test_ssh_url_unchanged(self):
+        d = DependencyReference.parse("git@github.com:owner/repo.git")
+        assert d.source is None
+        assert d.registry_name is None
+
+    def test_ssh_url_with_alias_unchanged(self):
+        # ``#ref@alias`` shape — alias comes after ``#``, must not be
+        # interpreted as a registry name.
+        d = DependencyReference.parse("git@github.com:owner/repo.git#main@my-alias")
+        assert d.source is None
+        assert d.alias == "my-alias"
+
+    def test_https_url_unchanged(self):
+        d = DependencyReference.parse("https://github.com/owner/repo")
+        assert d.source is None
+
+    def test_https_url_with_basic_auth_unchanged(self):
+        # User:password@host inside an HTTPS URL must not trigger registry
+        # scope (the ``://`` guard catches this).
+        # Note: actual parse may or may not accept this — what we're asserting
+        # is that the registry-scope detector does NOT fire.
+        try:
+            d = DependencyReference.parse("https://user:pass@host.com/owner/repo")
+            assert d.source is None
+        except ValueError:
+            pass  # parser may reject for unrelated reasons; that's fine.
+
+    def test_marketplace_shape_falls_through(self):
+        # ``review-skills@plugins`` has no ``/`` on the LHS — it does NOT
+        # route to a registry. The registry detector returns None and the
+        # existing parse logic raises (since 'review-skills' isn't a valid
+        # owner/repo on its own). What matters: the error is the existing
+        # one, not the new "missing version" one.
+        with pytest.raises(ValueError) as excinfo:
+            DependencyReference.parse("review-skills@plugins")
+        assert "missing a version" not in str(excinfo.value)
+
+    def test_local_path_unchanged(self):
+        d = DependencyReference.parse("./local/pkg")
+        assert d.is_local
+        assert d.source is None
+
+
+class TestObjectFormRegistry:
+    """Object-form ``- registry: <name>`` entry per design §3.2.
+
+    Used for virtual packages — the four fields (id, registry, path, version)
+    don't compose cleanly in shorthand.
+    """
+
+    def test_happy_path(self):
+        d = DependencyReference.parse_from_dict(
+            {
+                "registry": "corp-main",
+                "id": "acme/prompt-pack",
+                "path": "prompts/review.prompt.md",
+                "version": "1.4.0",
+            }
+        )
+        assert d.repo_url == "acme/prompt-pack"
+        assert d.virtual_path == "prompts/review.prompt.md"
+        assert d.is_virtual is True
+        assert d.reference == "1.4.0"
+        assert d.source == "registry"
+        assert d.registry_name == "corp-main"
+
+    def test_with_alias(self):
+        d = DependencyReference.parse_from_dict(
+            {
+                "registry": "corp",
+                "id": "a/b",
+                "path": "x.prompt.md",
+                "version": "^1.0.0",
+                "alias": "my-x",
+            }
+        )
+        assert d.alias == "my-x"
+
+    def test_caret_range(self):
+        d = DependencyReference.parse_from_dict(
+            {
+                "registry": "corp",
+                "id": "a/b",
+                "path": "x.prompt.md",
+                "version": "^1.2.3",
+            }
+        )
+        assert d.reference == "^1.2.3"
+
+    @pytest.mark.parametrize(
+        "missing_key",
+        ["id", "version"],  # registry and path are optional
+    )
+    def test_missing_required_field_rejected(self, missing_key):
+        full = {
+            "registry": "corp",
+            "id": "a/b",
+            "path": "x.prompt.md",
+            "version": "1.0.0",
+        }
+        full.pop(missing_key)
+        with pytest.raises(ValueError):
+            DependencyReference.parse_from_dict(full)
+
+    def test_mixing_registry_and_git_rejected(self):
+        with pytest.raises(ValueError, match="cannot mix"):
+            DependencyReference.parse_from_dict(
+                {
+                    "registry": "corp",
+                    "git": "https://github.com/a/b.git",
+                    "id": "a/b",
+                    "path": "x.prompt.md",
+                    "version": "1.0.0",
+                }
+            )
+
+    def test_invalid_id_shape_rejected(self):
+        with pytest.raises(ValueError, match="owner/repo"):
+            DependencyReference.parse_from_dict(
+                {
+                    "registry": "corp",
+                    "id": "noseparator",
+                    "path": "x",
+                    "version": "1.0.0",
+                }
+            )
+
+    def test_branch_version_accepted(self):
+        # Version strings are opaque — the registry resolves them.
+        # Branch names are valid version selectors (no semver gate).
+        d = DependencyReference.parse_from_dict(
+            {"registry": "corp", "id": "a/b", "path": "p", "version": "main"}
+        )
+        assert d.reference == "main"
+        assert d.source == "registry"
+
+    def test_commit_sha_version_accepted(self):
+        # Commit SHAs are valid opaque version strings.
+        d = DependencyReference.parse_from_dict(
+            {"registry": "corp", "id": "a/b", "path": "p", "version": "abc123d"}
+        )
+        assert d.reference == "abc123d"
+        assert d.source == "registry"
+
+    def test_unknown_field_rejected(self):
+        with pytest.raises(ValueError, match="unknown fields"):
+            DependencyReference.parse_from_dict(
+                {
+                    "registry": "corp",
+                    "id": "a/b",
+                    "path": "p",
+                    "version": "1.0.0",
+                    "typo": "oops",
+                }
+            )
+
+    def test_path_traversal_rejected(self):
+        with pytest.raises(ValueError):
+            DependencyReference.parse_from_dict(
+                {
+                    "registry": "corp",
+                    "id": "a/b",
+                    "path": "../escape",
+                    "version": "1.0.0",
+                }
+            )
+
+    def test_invalid_alias_rejected(self):
+        with pytest.raises(ValueError, match="Invalid alias"):
+            DependencyReference.parse_from_dict(
+                {
+                    "registry": "corp",
+                    "id": "a/b",
+                    "path": "p",
+                    "version": "1.0.0",
+                    "alias": "bad alias!",
+                }
+            )
+
+    def test_empty_strings_rejected(self):
+        for field in ("registry", "id", "path", "version"):
+            entry = {
+                "registry": "corp",
+                "id": "a/b",
+                "path": "x.prompt.md",
+                "version": "1.0.0",
+            }
+            entry[field] = "   "
+            with pytest.raises(ValueError):
+                DependencyReference.parse_from_dict(entry)
+
+    def test_existing_git_object_form_marks_source_git(self):
+        # Object-form ``- git:`` now explicitly sets source="git" so the
+        # default-registry routing pass leaves it alone. Per design,
+        # source=None and source="git" are equivalent (legacy default), so
+        # this is observable but functionally compatible.
+        d = DependencyReference.parse_from_dict(
+            {"git": "https://github.com/owner/repo.git", "ref": "v1.0"}
+        )
+        assert d.source == "git"
+        assert d.registry_name is None
+
+    def test_existing_local_object_form_unchanged(self):
+        d = DependencyReference.parse_from_dict({"path": "./local/pkg"})
+        assert d.is_local
+        assert d.source is None
+
+
+@pytest.mark.xfail(reason="@registry shorthand deferred to v2", strict=True)
+class TestRegistryFieldsRoundTrip:
+    """The parser sets ``source`` + ``registry_name`` consistently with the
+    object-form path (Phase 4 will add a parallel parser for object form)."""
+
+    def test_unique_key_includes_repo_url(self):
+        d = DependencyReference.parse("acme/foo@corp-main#1.0.0")
+        assert d.get_unique_key() == "acme/foo"
+
+    def test_identity_unchanged_by_registry_scope(self):
+        # The registry routing is metadata, not part of the package identity.
+        d_git = DependencyReference.parse("acme/foo#1.0.0")
+        d_reg = DependencyReference.parse("acme/foo@corp-main#1.0.0")
+        assert d_git.get_identity() == d_reg.get_identity() == "acme/foo"


### PR DESCRIPTION
… resolution

Implements the full package registry feature — dedicated resolver, publish command, lockfile replay, and policy wiring — as described in the official feature request "[FEATURE] Add package registry support for dependency resolution".

* feat(deps): dedicated registry resolver alongside the Git resolver
  - Object-form deps {registry, id, path, version} resolved via the new RegistryPackageResolver against a v1 HTTP API.
  - Experimental flag renamed package_registry -> registries.
  - Registry config in ~/.apm/config.json (apm config set registry.<name>.url|token). Token trap rejects token: in repo YAML.
  - String-shorthand semver refs auto-route to registries.default.

* fix(registry): require published_at in VersionEntry to match spec

* feat(publish): add apm publish command PUT /v1/packages/{owner}/{repo}/versions/{version} for producer push to the registry.

* feat(registry): lockfile replay (npm install model) Honor apm.lock.yaml during apm install for registry-sourced deps. Bypass /versions, fetch from locked resolved_url, verify against locked resolved_hash. apm update bypasses replay.

* feat(policy): plumb manifest registries: into registry-source check run_dependency_policy_checks now receives apm_package.registries from all four call sites (policy_gate, policy_target_check, run_policy_checks, run_policy_preflight). Closes the wiring gap where the fail-closed branch fired for every policy.require name regardless of apm.yml configuration. Adds transitive-enforcement tests and an integration tripwire at the policy_gate call site.

* feat(registry): require registry+path in object form; defer @shorthand to v2 Object form fields are now required. The acme/foo@corp-main#1.0.0 shorthand is deferred — @ collides with npm/cargo/pip version syntax, with SSH git@host, and with marketplace plugin shorthand.

## Description

Brief description of changes and motivation.

Fixes # (issue)

## Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [X] Tested locally
- [X] All existing tests pass
- [X] Added tests for new functionality (if applicable)
