### PR TITLE
feat(marketplace): support local paths, file:// URIs, and generic git hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `apm marketplace add` now accepts local filesystem paths, `file://` URIs, SSH URLs, and HTTPS URLs to any git host (Azure DevOps via `ADO_APM_PAT`, GitLab, Gitea, Bitbucket Server, self-hosted). Generic-git registrations fetch `marketplace.json` via `GitCache` and never forward APM tokens; local marketplaces read the manifest directly. `apm install <plugin>@<local-marketplace>` is fully supported, including marketplaces whose `marketplace.json` uses relative plugin sources.
+
+### Security
+
+- `GitCache` now disables git hooks (`core.hooksPath=/dev/null`) and skips submodule recursion on every clone, fetch, and checkout. Hardens APM against malicious upstreams, which is on-path for the new generic-git marketplace support.
+
 ### Fixed
 
 - Copilot, Codex, Cursor, Claude, Windsurf, OpenCode, and Gemini adapters handle MCP v0.1 `runtimeArguments`/`packageArguments` with `variables` (no `type` key), matching the VS Code fix from #1444. (#1461, closes #1452, thanks @sergio-sisternes-epam)

--- a/docs/src/content/docs/consumer/installing-from-marketplaces.md
+++ b/docs/src/content/docs/consumer/installing-from-marketplaces.md
@@ -63,6 +63,39 @@ reproducible across machines and CI.
   path that enforces it. See
   [Governance on the consumer ramp](../governance-on-the-consumer-ramp/).
 
+## Local and self-hosted marketplaces
+
+`apm marketplace add` accepts more than GitHub-hosted repos. The same
+register / browse / install / update workflow works against:
+
+- **Local filesystem paths** -- `apm marketplace add /srv/marketplaces/agent-forge`
+  (or a relative path, or `~/code/marketplace`). Useful for
+  privacy-sensitive packages, offline workflows, and air-gapped
+  environments. Local marketplaces with relative plugin sources
+  install by copying from disk via `LocalDependencySource`.
+- **`file://` URIs** -- `apm marketplace add file:///srv/marketplaces/agent-forge.git`.
+  Behaves the same as a local path.
+- **Generic git URLs** -- any host APM does not classify as
+  GitHub or GitLab family flows through subprocess `git` and
+  `GitCache`. Includes Azure DevOps (auth via `ADO_APM_PAT`),
+  Gitea, Bitbucket Server, and self-hosted git servers.
+- **SSH URLs** -- `git@gitea.example.com:org/repo.git`. The host
+  is extracted, classified, and routed through the matching
+  fetcher.
+
+For generic-git marketplaces, `marketplace.json` is fetched via a
+sparse-cone clone (only the manifest path is downloaded); APM does
+not forward `GITHUB_APM_PAT` or `GITLAB_APM_TOKEN` to non-GitHub /
+non-GitLab hosts. Authentication falls through to the host's
+`*_APM_PAT` (e.g. `ADO_APM_PAT`) or your local
+`git credential-manager`. See
+[Authentication](../authentication/).
+
+**Lockfile note.** Installs from a local marketplace record a
+local-path source in `apm.lock.yaml`. Lockfiles produced this way
+are machine-specific -- do not commit them into a shared repo. See
+[lockfile reference](../../reference/lockfile-spec/).
+
 ## Where next
 
 - [Install packages](../install-packages/) -- the full `apm install`

--- a/docs/src/content/docs/reference/cli/marketplace.md
+++ b/docs/src/content/docs/reference/cli/marketplace.md
@@ -14,7 +14,7 @@ validating it, and publishing updates to consumer repositories).
 
 ```bash
 # Consume
-apm marketplace add REPO [--name N] [--branch B] [--host FQDN]
+apm marketplace add SOURCE [--name N] [--ref R | --branch B] [--host FQDN]
 apm marketplace list
 apm marketplace browse NAME
 apm marketplace update [NAME]
@@ -55,20 +55,65 @@ read; use `apm marketplace migrate` to fold them into `apm.yml`.
 
 ### `apm marketplace add`
 
-Register a marketplace from a repo reference. Accepts `OWNER/REPO`,
-`HOST/OWNER/.../REPO`, or an HTTPS git URL.
+Register a marketplace from a source reference. Accepted forms:
+
+- `OWNER/REPO` -- GitHub shorthand (`acme/marketplace`).
+- `HOST/OWNER/.../REPO` -- non-GitHub host shorthand
+  (`gitlab.com/team/marketplace`).
+- HTTPS URL -- any git host, including Azure DevOps, GitLab,
+  Gitea, Bitbucket Server, or a self-hosted git server.
+- SSH URL -- `git@host:org/repo.git` style.
+- Local filesystem path -- absolute (`/srv/marketplaces/agent-forge`),
+  relative (`./local-mkt`), or home-based (`~/code/marketplace`).
+- `file://` URI -- `file:///srv/marketplaces/agent-forge.git`.
 
 ```bash
+# GitHub shorthand
 apm marketplace add my-org/awesome-agents
+
+# GitLab via host shorthand
 apm marketplace add gitlab.com/my-org/awesome-agents --host gitlab.com
+
+# Azure DevOps (auth via ADO_APM_PAT, same as `apm install`)
+apm marketplace add https://dev.azure.com/contoso/eng/_git/agent-forge \
+    --name agent-forge
+
+# Gitea / Bitbucket Server / self-hosted git
+apm marketplace add https://gitea.example.com/org/repo.git --name custom
+
+# SSH
+apm marketplace add git@gitea.example.com:org/repo.git --name custom
+
+# Local filesystem (bare repo or working directory)
+apm marketplace add /srv/marketplaces/agent-forge.git --name agent-forge
+
+# file:// URI
+apm marketplace add file:///srv/marketplaces/agent-forge.git --name agent-forge
 ```
 
 | Flag | Description |
 |---|---|
 | `--name`, `-n` | Display name. Defaults to the repo name. |
-| `--branch`, `-b` | Branch to track. Default: `main`. |
-| `--host` | Git host FQDN. Default: `github.com`. |
+| `--ref`, `-r` | Git ref (branch, tag, or SHA). Default: `main`. |
+| `--branch`, `-b` | Deprecated alias for `--ref`. |
+| `--host` | Git host FQDN. Default: `github.com`. Ignored when `SOURCE` is a URL or local path. |
 | `--verbose`, `-v` | Show detailed output. |
+
+**Trust boundary.** APM forwards its authentication tokens
+(`GITHUB_APM_PAT`, `GITLAB_APM_TOKEN`) only when the marketplace
+host is classified as GitHub or GitLab family. For any other host
+-- generic HTTPS, SSH, Azure DevOps, self-hosted -- the
+marketplace is fetched via subprocess `git` through `GitCache`,
+and authentication falls through to the host's APM PAT (e.g.
+`ADO_APM_PAT` for Azure DevOps) or your local
+`git credential-manager`. See
+[`getting-started/authentication`](../../../getting-started/authentication/).
+
+**Azure DevOps.** ADO-hosted marketplaces fetch `marketplace.json`
+via a sparse-cone git clone (not the ADO REST API), so authentication
+uses `ADO_APM_PAT` -- identical to how `apm install` handles
+ADO-hosted package dependencies. See
+[`consumer/private-and-org-packages`](../../../consumer/private-and-org-packages/).
 
 ### `apm marketplace list`
 

--- a/packages/apm-guide/.apm/skills/apm-usage/commands.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/commands.md
@@ -81,7 +81,7 @@ If no `--target`, no `targets:` in `apm.yml`, and no harness signal is present, 
 
 | Command | Purpose | Key flags |
 |---------|---------|-----------|
-| `apm marketplace add OWNER/REPO` | Register a marketplace (also accepts `HOST/OWNER/REPO`, nested `HOST/group/sub/.../REPO`, or full HTTPS URL) | `-n NAME`, `-b BRANCH`, `--host HOST` |
+| `apm marketplace add SOURCE` | Register a marketplace. `SOURCE` accepts `OWNER/REPO`, `HOST/OWNER/REPO`, nested `HOST/group/sub/.../REPO`, HTTPS URL (any git host -- GitHub, GitLab, ADO, Gitea, self-hosted), SSH URL (`git@host:org/repo.git`), local filesystem path, or `file://` URI. | `-n NAME`, `-r REF`, `--host HOST` |
 | `apm marketplace list` | List registered marketplaces | -- |
 | `apm marketplace browse NAME` | Browse marketplace plugins | -- |
 | `apm marketplace update [NAME]` | Update marketplace index | -- |

--- a/scripts/e2e/marketplace_local_e2e.sh
+++ b/scripts/e2e/marketplace_local_e2e.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Manual end-to-end reproduction of the local-marketplace user flow.
+#
+# Not wired into CI -- keeps CI hermetic and avoids depending on
+# external repos. Reproduces the workflow the requesting team was
+# trapped in (manual editing of ~/.apm/marketplaces.json + cache
+# pre-seeding) and validates the new register / browse / install /
+# update / refresh / drift paths.
+#
+# Prereqs:
+#   - apm CLI on PATH (or run from the repo's venv)
+#   - git
+#   - network access for the initial bare clone of the demo repo
+#
+# Cleanup: removes /tmp/apm-e2e/ on success. Re-run is idempotent.
+
+set -euo pipefail
+
+E2E_ROOT="/tmp/apm-e2e"
+DEMO_REMOTE="https://github.com/epam-mbg-demo/agent-forge.git"
+BARE_REPO="${E2E_ROOT}/agent-forge.git"
+
+rm -rf "${E2E_ROOT}"
+mkdir -p "${E2E_ROOT}"
+
+echo "[1/7] Cloning demo marketplace into a local bare repo..."
+git clone --bare "${DEMO_REMOTE}" "${BARE_REPO}"
+
+echo "[2/7] Registering via local filesystem path (kind=local)..."
+apm marketplace add "${BARE_REPO}" --name agent-forge-local
+
+echo "[3/7] Registering same repo via file:// URI (kind=local, exercises git show)..."
+apm marketplace add "file://${BARE_REPO}" --name agent-forge-fileuri
+
+echo "[4/7] Browsing both registrations..."
+apm marketplace browse agent-forge-local
+apm marketplace browse agent-forge-fileuri
+
+echo "[5/7] Picking the first plugin from each registration and installing..."
+PLUGIN_NAME="$(apm marketplace browse agent-forge-local --json 2>/dev/null | python -c 'import json,sys; print(json.load(sys.stdin)["plugins"][0]["name"])' || echo "")"
+if [ -n "${PLUGIN_NAME}" ]; then
+  apm install "${PLUGIN_NAME}@agent-forge-local"
+  apm install "${PLUGIN_NAME}@agent-forge-fileuri"
+  echo "    Installed ${PLUGIN_NAME} from both registrations."
+else
+  echo "    No plugins exposed by the demo marketplace; skipping install."
+fi
+
+echo "[6/7] Refreshing both marketplaces (validates GitCache ls-remote refresh path)..."
+apm marketplace update agent-forge-local
+apm marketplace update agent-forge-fileuri
+
+echo "[7/7] Drift smoke: marketplace update picks up working-tree edits without manual cache flushing."
+# (Would need a writable working-tree mirror; bare repos don't have one.
+# Documented as a manual step: edit the working tree, re-run update,
+# observe the change.)
+
+echo ""
+echo "E2E flow completed successfully."
+echo "Workspace: ${E2E_ROOT}"
+echo "Registered marketplaces:"
+apm marketplace list

--- a/scripts/e2e/marketplace_local_e2e.sh
+++ b/scripts/e2e/marketplace_local_e2e.sh
@@ -17,8 +17,16 @@
 set -euo pipefail
 
 E2E_ROOT="/tmp/apm-e2e"
-DEMO_REMOTE="https://github.com/epam-mbg-demo/agent-forge.git"
-BARE_REPO="${E2E_ROOT}/agent-forge.git"
+# Point this at any git remote that exposes a marketplace.json at the root of
+# its default branch. Override via DEMO_REMOTE=... before invoking.
+DEMO_REMOTE="${DEMO_REMOTE:-}"
+BARE_REPO="${E2E_ROOT}/demo-marketplace.git"
+
+if [ -z "${DEMO_REMOTE}" ]; then
+  echo "Set DEMO_REMOTE to a git URL exposing marketplace.json, e.g.:" >&2
+  echo "  DEMO_REMOTE=https://example.com/org/repo.git $0" >&2
+  exit 2
+fi
 
 rm -rf "${E2E_ROOT}"
 mkdir -p "${E2E_ROOT}"
@@ -27,28 +35,28 @@ echo "[1/7] Cloning demo marketplace into a local bare repo..."
 git clone --bare "${DEMO_REMOTE}" "${BARE_REPO}"
 
 echo "[2/7] Registering via local filesystem path (kind=local)..."
-apm marketplace add "${BARE_REPO}" --name agent-forge-local
+apm marketplace add "${BARE_REPO}" --name demo-local
 
 echo "[3/7] Registering same repo via file:// URI (kind=local, exercises git show)..."
-apm marketplace add "file://${BARE_REPO}" --name agent-forge-fileuri
+apm marketplace add "file://${BARE_REPO}" --name demo-fileuri
 
 echo "[4/7] Browsing both registrations..."
-apm marketplace browse agent-forge-local
-apm marketplace browse agent-forge-fileuri
+apm marketplace browse demo-local
+apm marketplace browse demo-fileuri
 
 echo "[5/7] Picking the first plugin from each registration and installing..."
-PLUGIN_NAME="$(apm marketplace browse agent-forge-local --json 2>/dev/null | python -c 'import json,sys; print(json.load(sys.stdin)["plugins"][0]["name"])' || echo "")"
+PLUGIN_NAME="$(apm marketplace browse demo-local --json 2>/dev/null | python -c 'import json,sys; print(json.load(sys.stdin)["plugins"][0]["name"])' || echo "")"
 if [ -n "${PLUGIN_NAME}" ]; then
-  apm install "${PLUGIN_NAME}@agent-forge-local"
-  apm install "${PLUGIN_NAME}@agent-forge-fileuri"
+  apm install "${PLUGIN_NAME}@demo-local"
+  apm install "${PLUGIN_NAME}@demo-fileuri"
   echo "    Installed ${PLUGIN_NAME} from both registrations."
 else
   echo "    No plugins exposed by the demo marketplace; skipping install."
 fi
 
 echo "[6/7] Refreshing both marketplaces (validates GitCache ls-remote refresh path)..."
-apm marketplace update agent-forge-local
-apm marketplace update agent-forge-fileuri
+apm marketplace update demo-local
+apm marketplace update demo-fileuri
 
 echo "[7/7] Drift smoke: marketplace update picks up working-tree edits without manual cache flushing."
 # (Would need a writable working-tree mirror; bare repos don't have one.

--- a/src/apm_cli/cache/git_cache.py
+++ b/src/apm_cli/cache/git_cache.py
@@ -45,6 +45,32 @@ _log = logging.getLogger(__name__)
 # Full SHA pattern: 40 hex characters
 _SHA_RE = re.compile(r"^[0-9a-f]{40}$", re.IGNORECASE)
 
+
+def _safe_git_args() -> list[str]:
+    """Return hardening ``-c`` args prepended to every git subprocess.
+
+    - ``core.hooksPath=/dev/null`` disables any hook script that a
+      malicious upstream might ship (``.git/hooks/post-checkout`` etc.)
+      so a clone or checkout cannot trigger arbitrary code execution.
+    - ``submodule.recurse=false`` prevents any subcommand from
+      recursing into attacker-controlled submodule URLs.
+
+    These flags are scoped per-invocation via ``-c`` and never mutate
+    the user's gitconfig. The cache layer is the single source of
+    truth for git subprocess invocation -- callers must use this
+    helper rather than ad-hoc ``git`` argv construction.
+    """
+    from ..utils.git_env import git_long_paths_args
+
+    return [
+        *git_long_paths_args(),
+        "-c",
+        "core.hooksPath=/dev/null",
+        "-c",
+        "submodule.recurse=false",
+    ]
+
+
 # Partial bare-cache flavor suffix (perf #1433 follow-up).
 # When a caller requests sparse_paths, we use a separate bare keyed at
 # ``<shard>__p`` cloned with ``--filter=blob:none``. The partial bare
@@ -214,7 +240,7 @@ class GitCache:
         # auth-delegated: cache-layer ref resolution runs after lockfile
         # already pinned the commit; no PAT->bearer fallback applies here
         # (env is sanitized, no embedded creds).
-        cmd = [git_exe, "ls-remote", url]
+        cmd = [git_exe, *_safe_git_args(), "ls-remote", url]
         if ref:
             cmd.append(ref)
 
@@ -287,7 +313,7 @@ class GitCache:
 
         Returns the path to the bare repo directory.
         """
-        from ..utils.git_env import get_git_executable, git_long_paths_args, git_subprocess_env
+        from ..utils.git_env import get_git_executable, git_subprocess_env
 
         bare_shard = shard_key + (_PARTIAL_BARE_SUFFIX if partial else "")
         bare_dir = self._db_root / bare_shard
@@ -318,7 +344,14 @@ class GitCache:
             os.chmod(str(staged), 0o700)
 
             subprocess_env = env if env is not None else git_subprocess_env()
-            clone_args = [git_exe, *git_long_paths_args(), "clone", "--bare", "--no-tags"]
+            clone_args = [
+                git_exe,
+                *_safe_git_args(),
+                "clone",
+                "--bare",
+                "--no-tags",
+                "--no-recurse-submodules",
+            ]
             if partial:
                 # Promisor partial clone: trees + commits only. Blobs
                 # arrive lazily via the remote when the consumer needs
@@ -368,10 +401,11 @@ class GitCache:
                         subprocess.run(
                             [
                                 git_exe,
-                                *git_long_paths_args(),
+                                *_safe_git_args(),
                                 "clone",
                                 "--bare",
                                 "--no-tags",
+                                "--no-recurse-submodules",
                                 url,
                                 str(staged),
                             ],
@@ -456,7 +490,7 @@ class GitCache:
         get the lock and return immediately. Critical for CI matrix
         builds where multiple jobs hit the same uncached repo.
         """
-        from ..utils.git_env import get_git_executable, git_long_paths_args, git_subprocess_env
+        from ..utils.git_env import get_git_executable, git_subprocess_env
 
         bare_shard = shard_key + (_PARTIAL_BARE_SUFFIX if promisor_url else "")
         bare_dir = self._db_root / bare_shard
@@ -505,11 +539,12 @@ class GitCache:
                 subprocess.run(
                     [
                         git_exe,
-                        *git_long_paths_args(),
+                        *_safe_git_args(),
                         "clone",
                         "--local",
                         "--shared",
                         "--no-checkout",
+                        "--no-recurse-submodules",
                         str(bare_dir),
                         str(staged),
                     ],
@@ -536,7 +571,7 @@ class GitCache:
                         subprocess.run(
                             [
                                 git_exe,
-                                *git_long_paths_args(),
+                                *_safe_git_args(),
                                 "-C",
                                 str(staged),
                                 "config",
@@ -558,13 +593,13 @@ class GitCache:
                         staged,
                         list(sparse_paths),
                         env=subprocess_env,
-                        extra_git_args=git_long_paths_args(),
+                        extra_git_args=_safe_git_args(),
                     )
                 # Checkout the specific SHA
                 subprocess.run(
                     [
                         git_exe,
-                        *git_long_paths_args(),
+                        *_safe_git_args(),
                         "-C",
                         str(staged),
                         "checkout",
@@ -606,7 +641,7 @@ class GitCache:
         subprocess_env = env if env is not None else git_subprocess_env()
         try:
             result = subprocess.run(
-                [git_exe, "-C", str(bare_dir), "cat-file", "-t", sha],
+                [git_exe, *_safe_git_args(), "-C", str(bare_dir), "cat-file", "-t", sha],
                 capture_output=True,
                 text=True,
                 timeout=10,
@@ -648,7 +683,7 @@ class GitCache:
         # so we don't pull all blobs reachable from the new SHA. Detected
         # via shard-suffix naming convention (cheap, no git config probe).
         is_partial = bare_dir.name.endswith(_PARTIAL_BARE_SUFFIX)
-        fetch_args = [git_exe, "-C", str(bare_dir), "fetch"]
+        fetch_args = [git_exe, *_safe_git_args(), "-C", str(bare_dir), "fetch"]
         if is_partial:
             fetch_args += ["--filter=blob:none"]
         fetch_args += [url, sha]
@@ -664,7 +699,7 @@ class GitCache:
         except subprocess.CalledProcessError:
             # Some servers don't allow fetching by SHA -- fetch all refs
             subprocess.run(
-                [git_exe, "-C", str(bare_dir), "fetch", "--all"],
+                [git_exe, *_safe_git_args(), "-C", str(bare_dir), "fetch", "--all"],
                 capture_output=True,
                 text=True,
                 timeout=120,

--- a/src/apm_cli/commands/marketplace/__init__.py
+++ b/src/apm_cli/commands/marketplace/__init__.py
@@ -245,80 +245,114 @@ def _check_gitignore_for_marketplace_json(logger):
             return
 
 
-def _parse_marketplace_repo(repo: str, host_flag: str | None) -> tuple[str, str, str | None]:
-    """Parse a marketplace repo argument into ``(owner, repo_name, embedded_host)``.
+def _parse_marketplace_source(source: str, host_flag: str | None) -> tuple[str, str, str | None]:
+    """Parse a marketplace source argument into ``(url, kind, embedded_host)``.
 
-    Accepted forms:
-      * ``OWNER/REPO``                       (2 segments)
-      * ``HOST/OWNER/REPO``                  (3 segments, first is FQDN)
-      * ``HOST/group/sub/.../REPO``          (N>=4 segments, first is FQDN -- GHES nested paths)
-      * ``OWNER/group/sub/.../REPO``         (N>=3 segments, first is NOT a FQDN)
-      * ``https://HOST/owner/.../repo[.git]`` (full HTTPS URL)
-      * ``http://HOST/owner/.../repo[.git]``  (full HTTP URL -- rejected with explicit error)
+    Accepted forms (auto-detected, in order of test):
 
-    Returns ``(owner, repo_name, embedded_host)`` where ``embedded_host`` is the
-    host carried by the input itself (``HOST/...`` shorthand or HTTPS URL host)
-    or ``None`` for bare ``OWNER/REPO`` shorthand.
+      * Local filesystem path -- absolute (``/...``), relative (``./...``,
+        ``../...``), home (``~/...``), or Windows drive letter
+        (``C:\\repos\\foo``). Returns ``kind="local"``, ``url`` is the
+        ``file://`` URI form, ``embedded_host=None``.
+      * ``file://`` URI -- same shape as a local path but explicit.
+      * SCP-like SSH (``git@host:org/repo.git``). Returns ``kind`` derived
+        from the host via ``AuthResolver.classify_host``, ``url`` rewritten
+        to the SCP form (subprocess git understands it natively),
+        ``embedded_host=<host>``.
+      * Full HTTPS URL. Returns the URL untouched, ``embedded_host``
+        extracted, ``kind`` classified by host. Hosts that ``AuthResolver``
+        does not recognise as github/gitlab fall through as ``kind="git"``
+        (subprocess git path).
+      * ``OWNER/REPO`` or ``HOST/OWNER/.../REPO`` shorthand. The HOST
+        segment is detected via ``is_valid_fqdn``. Returns a synthesised
+        ``https://`` URL plus the resolved host.
 
-    Raises ``ValueError`` on malformed input. The caller is responsible for
-    enforcing the trusted-host allowlist on the returned ``embedded_host``.
-
-    The returned segments are validated through ``validate_path_segments`` to
-    reject path-traversal sequences (``..``, ``.``, ``~``).
+    Raises ``ValueError`` on malformed input (single-segment, HTTP, empty,
+    or path-traversal sequences in any segment).
     """
     from urllib.parse import urlparse
 
+    from ...core.auth import AuthResolver
     from ...utils.github_host import is_valid_fqdn
 
-    raw = (repo or "").strip()
+    raw = (source or "").strip()
     if not raw:
-        raise ValueError("Empty repository argument")
-
-    # Reject control characters and percent-encoded traversal. urlparse normalizes
-    # the path but does not unescape; we unescape eagerly so the security guards
-    # below see the real bytes the user typed.
-    import urllib.parse as _up
-
+        raise ValueError("Empty source argument")
     if any(ord(c) < 32 for c in raw):
-        raise ValueError("Repository argument contains invalid control characters")
+        raise ValueError("Source argument contains invalid control characters")
 
-    embedded_host: str | None = None
+    # --- Local path detection ---------------------------------------------
+    # Catches absolute (/, ~), relative (./, ../), file:// URIs, and
+    # Windows drive letters (C:\, C:/). Done BEFORE URL parsing so a path
+    # like '/srv/foo' is not misread as a relative HTTP URL.
+    if _looks_like_local_marketplace_source(raw):
+        url = raw if raw.lower().startswith("file://") else f"file://{_expand_local_path(raw)}"
+        return url, "local", None
+
     lowered = raw.lower()
-
     if lowered.startswith("http://"):
-        # Reject HTTP at parse time. APM does not ship an --allow-insecure
-        # escape hatch for marketplace add: a MITM adversary on an HTTP fetch
-        # of marketplace.json could inject attacker-controlled plugin source
-        # URLs, with no audit trail.
         raise ValueError(
             f"Insecure HTTP URL rejected: '{raw}'. Use HTTPS for marketplace registration."
         )
 
+    # --- SCP-like SSH (git@host:org/repo.git) -----------------------------
+    scp_match = _SCP_LIKE_RE.match(raw)
+    if scp_match:
+        host = scp_match.group("host").lower()
+        path = scp_match.group("path")
+        # Validate the path component does not carry traversal markers.
+        for seg in (s for s in path.split("/") if s):
+            validate_path_segments(seg, context="marketplace SSH path", reject_empty=True)
+        host_info = AuthResolver.classify_host(host)
+        kind = _host_kind_to_fetcher_kind(host_info.kind)
+        return raw, kind, host
+
+    # --- HTTPS URL --------------------------------------------------------
     if lowered.startswith("https://"):
         parsed = urlparse(raw)
         embedded_host = (parsed.hostname or "").strip().lower()
         if not embedded_host:
             raise ValueError(f"HTTPS URL is missing a host: '{raw}'")
-        # urlparse leaves the path percent-encoded; decode for segment splitting
-        # so traversal markers like '%2E%2E' are caught by validate_path_segments.
-        path = _up.unquote(parsed.path or "")
-        if path.endswith(".git"):
-            path = path[:-4]
-        segments = [seg for seg in path.split("/") if seg]
-    else:
-        # Mirror the HTTPS branch: decode percent-encoded sequences before splitting
-        # so '%2E%2E' becomes '..' and is caught by validate_path_segments below.
-        raw_decoded = _up.unquote(raw)
-        segments = [seg for seg in raw_decoded.split("/") if seg]
+        # Validate path segments for traversal markers.
+        from urllib.parse import unquote as _unquote
 
+        path_segments = [s for s in _unquote(parsed.path or "").split("/") if s]
+        for seg in path_segments:
+            validate_path_segments(seg, context="marketplace URL path", reject_empty=True)
+        if not path_segments:
+            raise ValueError(f"HTTPS URL is missing a repo path: '{raw}'")
+        host_info = AuthResolver.classify_host(embedded_host)
+        kind = _host_kind_to_fetcher_kind(host_info.kind)
+        if kind in ("github", "gitlab") and len(path_segments) < 2:
+            # GitHub / GitLab URLs are owner/repo-shaped; a single
+            # path segment is ambiguous (no owner). Generic git URLs
+            # (kind == "git") MAY legitimately have a single segment
+            # (e.g. self-hosted ``https://gitea.example.com/repo``).
+            raise ValueError(f"Invalid format: '{raw}'. Expected 'OWNER/REPO' in the URL path.")
+        if host_flag and host_flag.strip().lower() != embedded_host:
+            import shlex as _shlex
+
+            raise ValueError(
+                f"Conflicting host: --host '{host_flag}' does not match "
+                f"'{embedded_host}' in '{raw}'.\n"
+                f"To fix: drop --host and run: apm marketplace add {_shlex.quote(raw)}"
+            )
+        return raw, kind, embedded_host
+
+    # --- Shorthand (OWNER/REPO or HOST/OWNER/.../REPO) --------------------
+    from urllib.parse import unquote as _unquote
+
+    raw_decoded = _unquote(raw)
+    segments = [seg for seg in raw_decoded.split("/") if seg]
     if len(segments) < 2:
         raise ValueError(
             f"Invalid format: '{raw}'. "
-            f"Expected 'OWNER/REPO', 'HOST/OWNER/REPO', or a full HTTPS URL."
+            f"Expected 'OWNER/REPO', 'HOST/OWNER/REPO', a full HTTPS URL, "
+            f"a local path, or an SSH URL."
         )
 
-    if embedded_host is None and is_valid_fqdn(segments[0]):
-        # Shorthand carries an explicit host (e.g. 'gitlab.com/org/repo').
+    embedded_host: str | None = None
+    if is_valid_fqdn(segments[0]):
         if len(segments) < 3:
             raise ValueError(
                 f"Invalid format: '{raw}'. When the first segment is a host FQDN, "
@@ -332,11 +366,11 @@ def _parse_marketplace_repo(repo: str, host_flag: str | None) -> tuple[str, str,
     if not owner_segments or not repo_name:
         raise ValueError(f"Invalid format: '{raw}'. Expected 'OWNER/REPO'.")
 
-    # Reject conflicting --host BEFORE security validation so the user gets the
-    # clearest possible error.
+    owner_path = "/".join(owner_segments)
+    validate_path_segments(owner_path, context="marketplace owner path", reject_empty=True)
+    validate_path_segments(repo_name, context="marketplace repo name", reject_empty=True)
+
     if embedded_host and host_flag and host_flag.strip().lower() != embedded_host:
-        # shlex.quote prevents shell-metacharacter injection in the
-        # copy-paste suggestion (round-4 supply-chain nit).
         import shlex as _shlex
 
         raise ValueError(
@@ -345,14 +379,68 @@ def _parse_marketplace_repo(repo: str, host_flag: str | None) -> tuple[str, str,
             f"To fix: drop --host and run: apm marketplace add {_shlex.quote(raw)}"
         )
 
-    # validate_path_segments rejects '.', '..', '~' and cross-platform backslash
-    # variants in any single segment. Validate the joined owner path and the
-    # repo name independently so the error messages are precise.
-    owner_path = "/".join(owner_segments)
-    validate_path_segments(owner_path, context="marketplace owner path", reject_empty=True)
-    validate_path_segments(repo_name, context="marketplace repo name", reject_empty=True)
+    from ...utils.github_host import default_host
 
-    return owner_path, repo_name, embedded_host
+    resolved_host = (host_flag or "").strip().lower() or embedded_host or default_host()
+    host_info = AuthResolver.classify_host(resolved_host)
+    kind = _host_kind_to_fetcher_kind(host_info.kind)
+    url = f"https://{resolved_host}/{owner_path}/{repo_name}"
+    return url, kind, resolved_host
+
+
+# Backward-compat alias for any external callers.
+_parse_marketplace_repo = _parse_marketplace_source
+
+
+def _host_kind_to_fetcher_kind(host_kind: str) -> str:
+    """Map ``AuthResolver.classify_host`` kinds to fetcher-table kinds.
+
+    ``github`` / ``ghe_cloud`` / ``ghes`` -> ``"github"`` (Contents API)
+    ``gitlab``                            -> ``"gitlab"`` (REST v4 raw)
+    Everything else (``ado``, ``generic``) -> ``"git"`` (subprocess + GitCache)
+    """
+    if host_kind in ("github", "ghe_cloud", "ghes"):
+        return "github"
+    if host_kind == "gitlab":
+        return "gitlab"
+    return "git"
+
+
+# SCP-like SSH form: ``user@host:path``. The path component does not need
+# to start with a slash (that is what makes it SCP-like). Matches what
+# ``git`` itself accepts as a URL.
+_SCP_LIKE_RE = re.compile(r"^(?P<user>[A-Za-z0-9._-]+)@(?P<host>[A-Za-z0-9.-]+):(?P<path>[^\s:]+)$")
+
+
+def _looks_like_local_marketplace_source(raw: str) -> bool:
+    """Heuristic match for local-path marketplace sources.
+
+    Matches: absolute paths (``/...``), explicit relative (``./...``,
+    ``../...``), home (``~``, ``~/...``), ``file://`` URIs, and Windows
+    drive letters (``C:\\`` or ``C:/``). The leading-slash check is
+    POSIX-only; on Windows, absolute paths arrive as drive-letter form.
+    """
+    if not raw:
+        return False
+    if raw.lower().startswith("file://"):
+        return True
+    if raw.startswith(("/", "./", "../", "~/")) or raw == "~":
+        return True
+    # Windows drive letter: C:\foo or C:/foo
+    return len(raw) >= 3 and raw[0].isalpha() and raw[1] == ":" and raw[2] in ("\\", "/")
+
+
+def _expand_local_path(raw: str) -> str:
+    """Expand ``~`` and normalise to an absolute filesystem path string.
+
+    Used when synthesising the ``file://`` URL stored in ``marketplaces.json``
+    for local-kind entries. The result is *not* resolved (no symlink follow)
+    because the fetcher does its own ``ensure_path_within`` guard against
+    the post-``resolve`` location.
+    """
+    import os.path as _osp
+
+    return _osp.abspath(_osp.expanduser(raw))
 
 
 # Host-trust classification is owned by AuthResolver.classify_host (see
@@ -396,26 +484,56 @@ def _marketplace_add_unsupported_host_error(
     )
 
 
-@marketplace.command(help="Register a marketplace")
-@click.argument("repo", required=True)
+_ADD_EPILOG = """
+\b
+Examples:
+  apm marketplace add owner/repo
+  apm marketplace add github.com/owner/repo
+  apm marketplace add https://gitlab.com/group/repo
+  apm marketplace add https://dev.azure.com/org/proj/_git/repo --name apm-mkt
+  apm marketplace add git@gitea.example.com:org/repo.git --name custom
+  apm marketplace add /srv/marketplaces/agent-forge --name agent-forge
+"""
+
+
+@marketplace.command(help="Register a marketplace", epilog=_ADD_EPILOG)
+@click.argument("source", metavar="SOURCE", required=True)
 @click.option("--name", "-n", default=None, help="Display name (defaults to repo name)")
-@click.option("--branch", "-b", default="main", show_default=True, help="Branch to use")
+@click.option("--ref", "-r", default=None, help="Branch, tag, or commit to use (default: main)")
+@click.option("--branch", "-b", default=None, help="Deprecated alias for --ref", hidden=True)
 @click.option("--host", default=None, help="Git host FQDN (default: github.com)")
 @click.option("--verbose", "-v", is_flag=True, help="Show detailed output")
-def add(repo, name, branch, host, verbose):
-    """Register a marketplace from OWNER/REPO, HOST/OWNER/.../REPO, or an HTTPS URL."""
+def add(source, name, ref, branch, host, verbose):
+    """Register a marketplace.
+
+    SOURCE accepts: OWNER/REPO shorthand, HOST/OWNER/REPO shorthand, a full
+    HTTPS URL (GitHub, GitLab, Azure DevOps, Gitea, Bitbucket Server, or
+    any self-hosted git server), an SSH URL (``git@host:org/repo.git``),
+    a local filesystem path, or a ``file://`` URI.
+    """
     logger = CommandLogger("marketplace-add", verbose=verbose)
     try:
         from ...marketplace.client import _auto_detect_path, fetch_marketplace
         from ...marketplace.models import MarketplaceSource
         from ...marketplace.registry import add_marketplace
-        from ...utils.github_host import default_host, is_valid_fqdn
+        from ...utils.github_host import is_valid_fqdn
+
+        # --ref / --branch reconciliation. --branch stays as a hidden alias
+        # for one release so legacy invocations keep working; passing both
+        # is a hard error so we never silently pick one.
+        if ref is not None and branch is not None:
+            logger.error(
+                "--ref and --branch are mutually exclusive. Use --ref (--branch is a deprecated alias).",
+                symbol="error",
+            )
+            sys.exit(1)
+        effective_ref = ref if ref is not None else (branch if branch is not None else "main")
 
         try:
-            owner, repo_name, embedded_host = _parse_marketplace_repo(repo, host)
+            url, kind, resolved_host = _parse_marketplace_source(source, host)
         except PathTraversalError:
             logger.error(
-                f"Invalid repo path '{repo}': contains a path-traversal sequence. "
+                f"Invalid source '{source}': contains a path-traversal sequence. "
                 f"Remove '..', '.', or '~' from each path segment."
             )
             sys.exit(1)
@@ -423,44 +541,55 @@ def add(repo, name, branch, host, verbose):
             logger.error(str(exc))
             sys.exit(1)
 
-        # Resolve the effective host: explicit --host wins, then host embedded
-        # in the argument (HOST/... shorthand or HTTPS URL), then GITHUB_HOST.
-        if host is not None:
-            normalized_host = host.strip().lower()
-            if not is_valid_fqdn(normalized_host):
-                logger.error(
-                    f"Invalid host: '{host}'. Expected a valid host FQDN "
-                    f"(for example, 'github.com').",
-                    symbol="error",
-                )
-                sys.exit(1)
-            resolved_host = normalized_host
-        elif embedded_host is not None:
-            resolved_host = embedded_host
-        else:
-            resolved_host = default_host()
-
-        # Trusted-host gate. Routes through AuthResolver.classify_host so the
-        # registration-time guard and the fetch-time guard in client.py share a
-        # single classification implementation.
-        from ...core.auth import AuthResolver
-
-        host_info = AuthResolver.classify_host(resolved_host)
-        if host_info.kind not in _TRUSTED_MARKETPLACE_HOST_KINDS:
-            import shlex as _shlex
-
-            quoted_repo = _shlex.quote(repo)
-            quoted_host = _shlex.quote(resolved_host)
+        if host is not None and not is_valid_fqdn(host.strip().lower()):
             logger.error(
-                _marketplace_add_unsupported_host_error(
-                    resolved_host, quoted_repo, quoted_host, host_info.kind
-                )
+                f"Invalid host: '{host}'. Expected a valid host FQDN (for example, 'github.com').",
+                symbol="error",
             )
             sys.exit(1)
 
-        # Hard-fail if the user-supplied --name flag is malformed; the
-        # manifest's name is validated softly below (publisher mistakes
-        # shouldn't break a successful add).
+        # --host is meaningful only for shorthand OWNER/REPO inputs. For URL
+        # / SSH / local-path inputs the host is already embedded; warn that
+        # --host is being ignored rather than silently overriding.
+        if host is not None and kind == "local":
+            logger.warning(
+                "--host is ignored when SOURCE is a local filesystem path.",
+                symbol="warning",
+            )
+        elif (
+            host is not None
+            and host.strip().lower() != (resolved_host or "").lower()
+            and kind in ("git", "github", "gitlab")
+            and (source.startswith(("https://", "git@", "file://")))
+        ):
+            logger.warning(
+                "--host is ignored when SOURCE is a full URL.",
+                symbol="warning",
+            )
+
+        # Trust gate is now scoped to kinds that would forward an APM token
+        # via header injection. The subprocess git path (kind == "git")
+        # never forwards GITHUB_APM_PAT / GITLAB_APM_TOKEN -- AuthResolver
+        # only emits credentials matching the classified host. Local-kind
+        # fetches use no credentials at all.
+        if kind in ("github", "gitlab"):
+            from ...core.auth import AuthResolver
+
+            host_info = AuthResolver.classify_host(resolved_host or "")
+            if host_info.kind not in _TRUSTED_MARKETPLACE_HOST_KINDS:
+                # Should not happen because _host_kind_to_fetcher_kind already
+                # mapped non-trusted kinds to "git", but defend in depth.
+                import shlex as _shlex
+
+                quoted_repo = _shlex.quote(source)
+                quoted_host = _shlex.quote(resolved_host or "")
+                logger.error(
+                    _marketplace_add_unsupported_host_error(
+                        resolved_host or "", quoted_repo, quoted_host, host_info.kind
+                    )
+                )
+                sys.exit(1)
+
         if name is not None and not _is_valid_alias(name):
             logger.error(
                 f"Invalid marketplace name: '{name}'. "
@@ -470,42 +599,34 @@ def add(repo, name, branch, host, verbose):
             )
             sys.exit(1)
 
-        # Probe for the marketplace.json location. The probe source's name
-        # is a placeholder -- _auto_detect_path only consults host/owner/repo.
+        # Probe for marketplace.json location. The probe source's name is a
+        # placeholder -- _auto_detect_path only consults url/ref/path/kind.
+        probe_name = name or _default_alias_from_url(url)
         probe_source = MarketplaceSource(
-            name=name or repo_name,
-            owner=owner,
-            repo=repo_name,
-            branch=branch,
-            host=resolved_host,
+            name=probe_name,
+            url=url,
+            ref=effective_ref,
         )
         detected_path = _auto_detect_path(probe_source)
 
         if detected_path is None:
             logger.error(
-                f"No marketplace.json found in '{owner}/{repo_name}'. "
+                f"No marketplace.json found in '{probe_source.display_source}'. "
                 f"Checked: marketplace.json, .github/plugin/marketplace.json, "
                 f".claude-plugin/marketplace.json",
                 symbol="error",
             )
             sys.exit(1)
 
-        # Fetch and validate the manifest before logging start, so that the
-        # success/start lines display the *final* alias the user must use.
         fetch_source = MarketplaceSource(
-            name=name or repo_name,
-            owner=owner,
-            repo=repo_name,
-            branch=branch,
-            host=resolved_host,
+            name=probe_name,
+            url=url,
+            ref=effective_ref,
             path=detected_path,
         )
         manifest = fetch_marketplace(fetch_source, force_refresh=True)
         plugin_count = len(manifest.plugins)
 
-        # Resolve final alias: --name flag > manifest.name (if valid) > repo name.
-        # Track which tier won so we can report it in verbose mode and emit a
-        # warning when a publisher-declared name had to be rejected.
         manifest_name = (manifest.name or "").strip()
         if name is not None:
             display_name = name
@@ -514,7 +635,7 @@ def add(repo, name, branch, host, verbose):
             display_name = manifest_name
             alias_source = f"manifest.name ('{manifest_name}')"
         else:
-            display_name = repo_name
+            display_name = probe_name
             if manifest_name and not _is_valid_alias(manifest_name):
                 logger.warning(
                     f"Manifest declares name '{manifest_name}' which is not a "
@@ -522,34 +643,28 @@ def add(repo, name, branch, host, verbose):
                     f"Falling back to repo name.",
                     symbol="warning",
                 )
-                alias_source = f"repo name (manifest.name '{manifest_name}' invalid)"
+                alias_source = f"derived name (manifest.name '{manifest_name}' invalid)"
             else:
-                alias_source = "repo name (manifest.name missing)"
+                alias_source = "derived name (manifest.name missing)"
 
-        # Defense-in-depth: repo names from GitHub already satisfy the alias
-        # regex, so this invariant should always hold by the time we register.
         assert _is_valid_alias(display_name), (  # noqa: S101
             f"Resolved marketplace alias '{display_name}' failed validation"
         )
 
         logger.start(f"Registering marketplace '{display_name}'...", symbol="gear")
-        logger.verbose_detail(f"    Repository: {owner}/{repo_name}")
-        logger.verbose_detail(f"    Branch: {branch}")
-        if resolved_host != "github.com":
-            logger.verbose_detail(f"    Host: {resolved_host}")
+        logger.verbose_detail(f"    Source: {fetch_source.display_source}")
+        logger.verbose_detail(f"    Kind: {kind}")
+        logger.verbose_detail(f"    Ref: {effective_ref}")
         logger.verbose_detail(f"    Detected path: {detected_path}")
         logger.verbose_detail(f"    Alias source: {alias_source}")
 
-        # Persist with the final alias.
-        source = MarketplaceSource(
+        final_source = MarketplaceSource(
             name=display_name,
-            owner=owner,
-            repo=repo_name,
-            branch=branch,
-            host=resolved_host,
+            url=url,
+            ref=effective_ref,
             path=detected_path,
         )
-        add_marketplace(source)
+        add_marketplace(final_source)
 
         logger.success(
             f"Marketplace '{display_name}' registered ({plugin_count} plugins)",
@@ -558,9 +673,7 @@ def add(repo, name, branch, host, verbose):
         if manifest.description:
             logger.verbose_detail(f"    {manifest.description}")
 
-        # Surface the install syntax only when the alias is something the user
-        # could not have predicted from OWNER/REPO. Silence is fine otherwise.
-        if name is None and display_name != repo_name:
+        if name is None and display_name != probe_name:
             logger.progress(
                 f"Install plugins with: apm install <plugin>@{display_name}",
                 symbol="info",
@@ -571,6 +684,27 @@ def add(repo, name, branch, host, verbose):
         if verbose:
             logger.progress(traceback.format_exc(), symbol="info")
         sys.exit(1)
+
+
+def _default_alias_from_url(url: str) -> str:
+    """Derive a default marketplace alias from a parsed URL.
+
+    Strips ``.git`` suffix, trailing slashes, and uses the last
+    path-segment. For ``file://`` URLs the alias falls back to the
+    final filesystem segment.
+    """
+    from urllib.parse import urlparse
+
+    parsed = urlparse(url) if "://" in url else None
+    if parsed and parsed.path:
+        tail = parsed.path.rstrip("/").rsplit("/", 1)[-1]
+    else:
+        tail = url.rstrip("/").rsplit("/", 1)[-1]
+    if tail.endswith(".git"):
+        tail = tail[:-4]
+    # Defensive: alias regex disallows '.' at end + arbitrary characters,
+    # but it tolerates dots and dashes inside which covers normal repo names.
+    return tail or "marketplace"
 
 
 @marketplace.command(name="list", help="List registered marketplaces")
@@ -585,7 +719,8 @@ def list_cmd(verbose):
 
         if not sources:
             logger.progress(
-                "No marketplaces registered. Use 'apm marketplace add OWNER/REPO' to register one.",
+                "No marketplaces registered. Use 'apm marketplace add SOURCE' to register one "
+                "(OWNER/REPO, HTTPS URL, SSH URL, or local path).",
                 symbol="info",
             )
             return
@@ -595,7 +730,7 @@ def list_cmd(verbose):
             # Colorama fallback
             logger.progress(f"{len(sources)} marketplace(s) registered:", symbol="info")
             for s in sources:
-                logger.tree_item(f"  {s.name}  ({s.owner}/{s.repo})")
+                logger.tree_item(f"  {s.name}  ({s.display_source})")
             return
 
         from rich.table import Table
@@ -607,12 +742,12 @@ def list_cmd(verbose):
             border_style="cyan",
         )
         table.add_column("Name", style="bold white", no_wrap=True)
-        table.add_column("Repository", style="white")
-        table.add_column("Branch", style="cyan")
+        table.add_column("Source", style="white")
+        table.add_column("Ref", style="cyan")
         table.add_column("Path", style="dim")
 
         for s in sources:
-            table.add_row(s.name, f"{s.owner}/{s.repo}", s.branch, s.path)
+            table.add_row(s.name, s.display_source, s.ref, s.path)
 
         console.print()
         console.print(table)

--- a/src/apm_cli/commands/marketplace/__init__.py
+++ b/src/apm_cli/commands/marketplace/__init__.py
@@ -424,7 +424,7 @@ def _looks_like_local_marketplace_source(raw: str) -> bool:
         return False
     if raw.lower().startswith("file://"):
         return True
-    if raw.startswith(("/", "./", "../", "~/")) or raw == "~":
+    if raw.startswith(("/", "./", "../", "~/", ".\\", "..\\", "~\\")) or raw == "~":
         return True
     # Windows drive letter: C:\foo or C:/foo
     return len(raw) >= 3 and raw[0].isalpha() and raw[1] == ":" and raw[2] in ("\\", "/")

--- a/src/apm_cli/commands/marketplace/__init__.py
+++ b/src/apm_cli/commands/marketplace/__init__.py
@@ -407,9 +407,10 @@ def _host_kind_to_fetcher_kind(host_kind: str) -> str:
 
 
 # SCP-like SSH form: ``user@host:path``. The path component does not need
-# to start with a slash (that is what makes it SCP-like). Matches what
-# ``git`` itself accepts as a URL.
-_SCP_LIKE_RE = re.compile(r"^(?P<user>[A-Za-z0-9._-]+)@(?P<host>[A-Za-z0-9.-]+):(?P<path>[^\s:]+)$")
+# to start with a slash (that is what makes it SCP-like). Reuses the
+# canonical regex from ``apm_cli.cache.url_normalize`` so SCP parsing here
+# stays consistent with ``DependencyReference`` and policy discovery.
+from apm_cli.cache.url_normalize import SCP_LIKE_RE as _SCP_LIKE_RE  # noqa: E402
 
 
 def _looks_like_local_marketplace_source(raw: str) -> bool:

--- a/src/apm_cli/commands/marketplace/__init__.py
+++ b/src/apm_cli/commands/marketplace/__init__.py
@@ -600,9 +600,14 @@ def add(source, name, ref, branch, host, verbose):
             )
             sys.exit(1)
 
+        # Surface progress before the slow probe + fetch (5-30s for generic-git)
+        # so the user sees activity instead of staring at a blank terminal.
+        provisional_label = name or _default_alias_from_url(url)
+        logger.start(f"Registering marketplace '{provisional_label}'...", symbol="gear")
+
         # Probe for marketplace.json location. The probe source's name is a
         # placeholder -- _auto_detect_path only consults url/ref/path/kind.
-        probe_name = name or _default_alias_from_url(url)
+        probe_name = provisional_label
         probe_source = MarketplaceSource(
             name=probe_name,
             url=url,
@@ -652,7 +657,6 @@ def add(source, name, ref, branch, host, verbose):
             f"Resolved marketplace alias '{display_name}' failed validation"
         )
 
-        logger.start(f"Registering marketplace '{display_name}'...", symbol="gear")
         logger.verbose_detail(f"    Source: {fetch_source.display_source}")
         logger.verbose_detail(f"    Kind: {kind}")
         logger.verbose_detail(f"    Ref: {effective_ref}")
@@ -893,7 +897,7 @@ def remove(name, yes, verbose):
                 )
                 sys.exit(1)
             confirmed = click.confirm(
-                f"Remove marketplace '{source.name}' ({source.owner}/{source.repo})?",
+                f"Remove marketplace '{source.name}' ({source.display_source})?",
                 default=False,
             )
             if not confirmed:

--- a/src/apm_cli/marketplace/client.py
+++ b/src/apm_cli/marketplace/client.py
@@ -324,8 +324,14 @@ def _fetch_gitlab(
     host_info,
     auth_resolver,
 ) -> dict | None:
-    """Fetch marketplace.json from GitLab via REST v4 raw file API."""
-    result = _fetch_via_api(
+    """Fetch marketplace.json from GitLab via REST v4 raw file API.
+
+    ``_fetch_via_api`` already runs ``auth_resolver.try_with_fallback`` and
+    handles 404/auth fallback internally, so there is no separate retry layer
+    here -- adding one would double-wrap ``try_with_fallback`` and risk
+    re-entering the fallback logic.
+    """
+    return _fetch_via_api(
         source,
         file_path,
         url_builder=_gitlab_file_raw_url,
@@ -334,29 +340,6 @@ def _fetch_gitlab(
         host_info=host_info,
         auth_resolver=auth_resolver,
     )
-    # GitLab returns 404 for unauthenticated access to many private projects
-    # (indistinguishable from a missing file). Retry once with auth-first
-    # already on so this rarely changes anything in practice; left for parity
-    # with the previous implementation.
-    if result is None:
-        try:
-            result = auth_resolver.try_with_fallback(
-                source.host,
-                lambda token, _env: _fetch_via_api(
-                    source,
-                    file_path,
-                    url_builder=_gitlab_file_raw_url,
-                    header_builder=_gitlab_headers,
-                    parse_response=_parse_json_text,
-                    host_info=host_info,
-                    auth_resolver=auth_resolver,
-                ),
-                org=source.owner,
-                unauth_first=False,
-            )
-        except Exception as exc:  # pragma: no cover - parity branch
-            raise MarketplaceFetchError(source.name, str(exc)) from exc
-    return result
 
 
 # ---------------------------------------------------------------------------

--- a/src/apm_cli/marketplace/client.py
+++ b/src/apm_cli/marketplace/client.py
@@ -1,21 +1,30 @@
 """Fetch, parse, and cache marketplace.json from Git hosting repositories.
 
-Uses ``AuthResolver.try_with_fallback(unauth_first=False)`` for auth-first
-access so private marketplace repos are fetched with credentials when available.
-When ``PROXY_REGISTRY_URL`` is set, fetches are routed through the registry
-proxy (Artifactory Archive Entry Download) before falling back to the
-host API: GitHub Contents API for GitHub/GHES, or GitLab REST v4 file raw
-when the host classifies as GitLab (``kind='gitlab'``).  When ``PROXY_REGISTRY_ONLY=1``, the
-direct host API fallback is blocked entirely.
-Cache lives at ``~/.apm/cache/marketplace/`` with a 1-hour TTL.
+Dispatches over a ``_FETCHERS`` table keyed by ``source.kind``:
+
+- ``github`` / ``gitlab`` -> host file API via ``_fetch_via_api`` (auth-routed
+  through ``AuthResolver.try_with_fallback`` and the JSON sidecar cache).
+- ``git`` -> generic git URL (ADO, Gitea, self-hosted, etc.) via subprocess
+  through ``GitCache``; ``git ls-remote`` is the freshness check, no JSON
+  sidecar cache.
+- ``local`` -> bare repo (``git --git-dir=... show <ref>:<file>``) or working
+  directory (direct file read with symlink-escape guard); no cache.
+
+When ``PROXY_REGISTRY_URL`` is set, GitHub/GHES fetches go through the
+Artifactory Archive Entry Download proxy first. Cache lives at
+``~/.apm/cache/marketplace/`` with a 1-hour TTL.
 """
 
 import contextlib
 import json
 import logging
 import os
+import re
+import subprocess
 import time
-from urllib.parse import quote
+from collections.abc import Callable
+from pathlib import Path
+from urllib.parse import quote, urlsplit
 
 import requests
 
@@ -40,6 +49,25 @@ _MARKETPLACE_PATHS = [
     ".claude-plugin/marketplace.json",
 ]
 
+# Safe ref pattern: letters, digits, dot, slash, hyphen, underscore.
+# Rejects empty, leading "-", colons, spaces, and shell metacharacters.
+_SAFE_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/\-]*$")
+
+
+def _validate_ref(ref: str, source_name: str) -> str:
+    """Return *ref* unchanged if it matches the safe pattern; raise otherwise.
+
+    Defends both ``_fetch_local`` (subprocess ``git show <ref>:<file>``) and
+    ``_fetch_git`` (passes ref through to ``GitCache.get_checkout``) against
+    ref-injection in user-supplied marketplace registrations.
+    """
+    if not _SAFE_REF_RE.match(ref or ""):
+        raise MarketplaceFetchError(
+            source_name,
+            f"Invalid git ref '{ref}': refs must match {_SAFE_REF_RE.pattern}",
+        )
+    return ref
+
 
 def _cache_dir() -> str:
     """Return the cache directory, creating it if needed."""
@@ -52,8 +80,6 @@ def _cache_dir() -> str:
 
 def _sanitize_cache_name(name: str) -> str:
     """Sanitize marketplace name for safe use in file paths."""
-    import re
-
     from ..utils.path_security import PathTraversalError, validate_path_segments
 
     safe = re.sub(r"[^a-zA-Z0-9._-]", "_", name)
@@ -68,8 +94,15 @@ def _sanitize_cache_name(name: str) -> str:
 
 
 def _cache_key(source: MarketplaceSource) -> str:
-    """Cache key that includes host to avoid collisions across hosts."""
-    normalized_host = source.host.lower()
+    """Cache key that includes kind+host to avoid collisions across hosts."""
+    kind = source.kind
+    if kind == "local":
+        return f"local__{_sanitize_cache_name(source.name)}"
+    if kind == "git":
+        # Generic git: include host so a.com/o/r vs b.com/o/r never collapse.
+        host = _host_from_url(source.url) or source.host or "unknown"
+        return f"git__{_sanitize_cache_name(host)}__{_sanitize_cache_name(source.name)}"
+    normalized_host = (source.host or "github.com").lower()
     if normalized_host == "github.com":
         return source.name
     return f"{_sanitize_cache_name(normalized_host)}__{source.name}"
@@ -139,7 +172,7 @@ def _clear_cache(name: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Network fetch
+# Network fetch -- API path (GitHub / GitLab)
 # ---------------------------------------------------------------------------
 
 
@@ -166,7 +199,7 @@ def _try_proxy_fetch(
         owner=source.owner,
         repo=source.repo,
         file_path=file_path,
-        ref=source.branch,
+        ref=source.ref,
         scheme=cfg.scheme,
         headers=cfg.get_headers(),
     )
@@ -188,15 +221,15 @@ def _try_proxy_fetch(
 def _github_contents_url(source: MarketplaceSource, file_path: str, host_info) -> str:
     """Build the GitHub Contents API URL for a file (GitHub / GHES / generic)."""
     api_base = host_info.api_base.rstrip("/")
-    return f"{api_base}/repos/{source.owner}/{source.repo}/contents/{file_path}?ref={source.branch}"
+    return f"{api_base}/repos/{source.owner}/{source.repo}/contents/{file_path}?ref={source.ref}"
 
 
-def _gitlab_file_raw_url(source: MarketplaceSource, host_info, file_path: str) -> str:
+def _gitlab_file_raw_url(source: MarketplaceSource, file_path: str, host_info) -> str:
     """Build the GitLab REST v4 repository file raw URL."""
     project_path = f"{source.owner}/{source.repo}"
     encoded_project = quote(project_path, safe="")
     encoded_file = quote(file_path, safe="")
-    encoded_ref = quote(source.branch, safe="")
+    encoded_ref = quote(source.ref, safe="")
     api_base = host_info.api_base.rstrip("/")
     return (
         f"{api_base}/projects/{encoded_project}/repository/files/"
@@ -204,118 +237,379 @@ def _gitlab_file_raw_url(source: MarketplaceSource, host_info, file_path: str) -
     )
 
 
+def _github_headers(token: str | None) -> dict[str, str]:
+    headers = {"Accept": "application/vnd.github.v3.raw", "User-Agent": "apm-cli"}
+    if token:
+        headers["Authorization"] = f"token {token}"
+    return headers
+
+
+def _gitlab_headers(token: str | None) -> dict[str, str]:
+    from ..core.auth import AuthResolver
+
+    headers = {"User-Agent": "apm-cli"}
+    headers.update(AuthResolver.gitlab_rest_headers(token))
+    return headers
+
+
+def _fetch_via_api(
+    source: MarketplaceSource,
+    file_path: str,
+    *,
+    url_builder: Callable,
+    header_builder: Callable[[str | None], dict[str, str]],
+    parse_response: Callable,
+    host_info,
+    auth_resolver,
+) -> dict | None:
+    """Shared API-fetch helper for github/gitlab kinds.
+
+    Owns the common boilerplate: build URL, build headers, run
+    ``try_with_fallback``, map 404 -> None, raise ``MarketplaceFetchError``
+    on unexpected errors. Specialised callers pass kind-specific URL and
+    header builders.
+    """
+    url = url_builder(source, file_path, host_info)
+
+    def _do_fetch(token, _git_env):
+        resp = requests.get(url, headers=header_builder(token), timeout=30)
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        return parse_response(resp)
+
+    try:
+        return auth_resolver.try_with_fallback(
+            source.host,
+            _do_fetch,
+            org=source.owner,
+            path=f"{source.owner}/{source.repo}",
+            unauth_first=False,
+        )
+    except Exception as exc:
+        logger.debug("API fetch failed for '%s'", source.name, exc_info=True)
+        raise MarketplaceFetchError(source.name, str(exc)) from exc
+
+
+def _parse_json_text(resp) -> dict:
+    try:
+        return json.loads(resp.text)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise ValueError(f"Invalid JSON in marketplace file: {exc}") from exc
+
+
+def _fetch_github(
+    source: MarketplaceSource,
+    file_path: str,
+    *,
+    host_info,
+    auth_resolver,
+) -> dict | None:
+    """Fetch marketplace.json from GitHub / GHE Cloud / GHES via Contents API."""
+    return _fetch_via_api(
+        source,
+        file_path,
+        url_builder=_github_contents_url,
+        header_builder=_github_headers,
+        parse_response=lambda r: r.json(),
+        host_info=host_info,
+        auth_resolver=auth_resolver,
+    )
+
+
+def _fetch_gitlab(
+    source: MarketplaceSource,
+    file_path: str,
+    *,
+    host_info,
+    auth_resolver,
+) -> dict | None:
+    """Fetch marketplace.json from GitLab via REST v4 raw file API."""
+    result = _fetch_via_api(
+        source,
+        file_path,
+        url_builder=_gitlab_file_raw_url,
+        header_builder=_gitlab_headers,
+        parse_response=_parse_json_text,
+        host_info=host_info,
+        auth_resolver=auth_resolver,
+    )
+    # GitLab returns 404 for unauthenticated access to many private projects
+    # (indistinguishable from a missing file). Retry once with auth-first
+    # already on so this rarely changes anything in practice; left for parity
+    # with the previous implementation.
+    if result is None:
+        try:
+            result = auth_resolver.try_with_fallback(
+                source.host,
+                lambda token, _env: _fetch_via_api(
+                    source,
+                    file_path,
+                    url_builder=_gitlab_file_raw_url,
+                    header_builder=_gitlab_headers,
+                    parse_response=_parse_json_text,
+                    host_info=host_info,
+                    auth_resolver=auth_resolver,
+                ),
+                org=source.owner,
+                unauth_first=False,
+            )
+        except Exception as exc:  # pragma: no cover - parity branch
+            raise MarketplaceFetchError(source.name, str(exc)) from exc
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Network fetch -- generic git path (ADO / Gitea / Bitbucket / self-hosted)
+# ---------------------------------------------------------------------------
+
+
+def _fetch_git(
+    source: MarketplaceSource,
+    file_path: str,
+    *,
+    host_info,
+    auth_resolver,
+) -> dict | None:
+    """Fetch marketplace.json from a generic git URL via subprocess + GitCache.
+
+    Sparse-cone clones only the requested manifest path. Uses
+    ``AuthResolver.resolve(host, org).git_env`` to build the git env; for
+    hosts APM doesn't recognise, the env passes through to the user's
+    credential helpers (matches ``apm install`` posture).
+    """
+    _validate_ref(source.ref, source.name)
+
+    from ..cache.git_cache import GitCache
+    from ..cache.paths import get_cache_root
+
+    org = source.owner or None
+    auth_ctx = auth_resolver.resolve(host_info.host, org)
+    git_env = auth_ctx.git_env
+
+    cache = GitCache(get_cache_root(), refresh=False)
+    try:
+        # Sparse-cone clone -- only the marketplace.json directory tree is fetched.
+        checkout_dir = cache.get_checkout(
+            source.url,
+            source.ref,
+            env=git_env,
+            sparse_paths=[file_path] if "/" in file_path else None,
+        )
+    except subprocess.CalledProcessError as exc:
+        # Map "object not found" / "couldn't find remote ref" to None so the
+        # caller's _auto_detect_path probe can try the next candidate path.
+        stderr = (getattr(exc, "stderr", b"") or b"").decode("utf-8", errors="replace")
+        if "not found" in stderr.lower() or "does not exist" in stderr.lower():
+            return None
+        raise MarketplaceFetchError(source.name, f"git fetch failed: {stderr or exc}") from exc
+    except Exception as exc:
+        logger.debug("Generic-git fetch failed for '%s'", source.name, exc_info=True)
+        raise MarketplaceFetchError(source.name, str(exc)) from exc
+
+    target = Path(checkout_dir) / file_path
+    if not target.exists():
+        return None
+    try:
+        with open(target, encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        raise MarketplaceFetchError(source.name, f"failed to read {file_path}: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Local fetch (filesystem path or file://)
+# ---------------------------------------------------------------------------
+
+
+def _fetch_local(
+    source: MarketplaceSource,
+    file_path: str,
+    *,
+    host_info=None,
+    auth_resolver=None,
+) -> dict | None:
+    """Read marketplace.json from a local filesystem path.
+
+    Supports two topologies:
+
+    1. **Bare repository** (``.git`` dir with no working tree) -> use
+       ``git --git-dir=<path> show <ref>:<file>`` to extract blob content.
+       Symlink-safe because git addresses blobs by content hash.
+    2. **Working directory** (regular checkout or unpacked tree) -> read the
+       file directly after resolving the path and validating it stays within
+       the repo root (``ensure_path_within``).
+    """
+    _validate_ref(source.ref, source.name)
+    repo_path = Path(source.local_path or source.url).expanduser()
+    try:
+        repo_path = repo_path.resolve(strict=False)
+    except OSError as exc:
+        raise MarketplaceFetchError(source.name, f"failed to resolve local path: {exc}") from exc
+
+    if not repo_path.exists():
+        raise MarketplaceFetchError(
+            source.name, f"local marketplace path does not exist: {repo_path}"
+        )
+
+    # Detect bare repo: it's either a directory with HEAD + objects/ (bare layout)
+    # or it ends in .git, or it has a .git subdirectory (worktree).
+    is_bare = (repo_path / "HEAD").is_file() and (repo_path / "objects").is_dir()
+    git_dir = (
+        repo_path if is_bare else (repo_path / ".git" if (repo_path / ".git").exists() else None)
+    )
+
+    if git_dir is not None:
+        return _fetch_local_via_git_show(source, file_path, git_dir)
+
+    # Plain directory: read the file directly with symlink-escape guard.
+    return _fetch_local_direct_read(source, file_path, repo_path)
+
+
+def _fetch_local_via_git_show(
+    source: MarketplaceSource, file_path: str, git_dir: Path
+) -> dict | None:
+    """Use ``git show <ref>:<file>`` against a bare repo or .git directory."""
+    cmd = [
+        "git",
+        "--git-dir",
+        str(git_dir),
+        "-c",
+        "core.hooksPath=/dev/null",
+        "show",
+        f"{source.ref}:{file_path}",
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            check=False,
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        raise MarketplaceFetchError(source.name, f"git show failed for {file_path}: {exc}") from exc
+
+    if result.returncode != 0:
+        stderr = result.stderr.decode("utf-8", errors="replace").strip()
+        # Missing path or ref -> None so _auto_detect_path can probe next candidate
+        if (
+            "does not exist" in stderr.lower()
+            or "exists on disk, but not in" in stderr.lower()
+            or "fatal: path" in stderr.lower()
+        ):
+            return None
+        raise MarketplaceFetchError(source.name, f"git show failed: {stderr}")
+
+    try:
+        return json.loads(result.stdout.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise MarketplaceFetchError(source.name, f"invalid JSON in {file_path}: {exc}") from exc
+
+
+def _fetch_local_direct_read(
+    source: MarketplaceSource, file_path: str, repo_root: Path
+) -> dict | None:
+    """Read a file directly from a working-dir local marketplace.
+
+    Symlink-escape guard: resolves the target through ``Path.resolve`` and
+    asserts it stays within ``repo_root`` via ``ensure_path_within``.
+    """
+    from ..utils.path_security import PathTraversalError, ensure_path_within
+
+    candidate = (repo_root / file_path).resolve(strict=False)
+    try:
+        ensure_path_within(candidate, repo_root)
+    except PathTraversalError as exc:
+        raise MarketplaceFetchError(
+            source.name, f"path escapes marketplace root: {file_path}"
+        ) from exc
+
+    if not candidate.exists():
+        return None
+    try:
+        with open(candidate, encoding="utf-8") as f:
+            return json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        raise MarketplaceFetchError(source.name, f"failed to read {file_path}: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+_FETCHERS: dict[str, Callable] = {
+    "github": _fetch_github,
+    "gitlab": _fetch_gitlab,
+    "git": _fetch_git,
+    "local": _fetch_local,
+}
+
+
 def _fetch_file(
     source: MarketplaceSource,
     file_path: str,
     auth_resolver: object | None = None,
 ) -> dict | None:
-    """Fetch a JSON file from a GitHub repo.
+    """Dispatch to the right fetcher based on ``source.kind``.
 
-    When ``PROXY_REGISTRY_URL`` is set, tries the registry proxy first via
-    Artifactory Archive Entry Download.  Falls back to the GitHub Contents
-    API unless ``PROXY_REGISTRY_ONLY=1`` blocks direct access.
-
-    Returns parsed JSON or ``None`` if the file does not exist (404).
+    Returns parsed JSON dict, or ``None`` when the file does not exist.
     Raises ``MarketplaceFetchError`` on unexpected failures.
     """
-    # Proxy-first: try Artifactory Archive Entry Download
-    proxy_result = _try_proxy_fetch(source, file_path)
-    if proxy_result is not None:
-        return proxy_result
-
-    # When registry-only mode is active, block direct GitHub API access
-    from ..deps.registry_proxy import RegistryConfig
-
-    cfg = RegistryConfig.from_env()
-    if cfg is not None and cfg.enforce_only:
-        logger.debug(
-            "PROXY_REGISTRY_ONLY blocks direct GitHub fetch for %s/%s %s",
-            source.owner,
-            source.repo,
-            file_path,
-        )
-        return None
-
-    # Fallback: host-native file API (GitLab v4 raw vs GitHub Contents)
     from ..core.auth import AuthResolver
-
-    host_info = AuthResolver.classify_host(source.host)
-
-    if host_info.kind == "gitlab":
-        url = _gitlab_file_raw_url(source, host_info, file_path)
-
-        def _do_fetch(token, _git_env):
-            headers = {"User-Agent": "apm-cli"}
-            headers.update(AuthResolver.gitlab_rest_headers(token))
-            resp = requests.get(url, headers=headers, timeout=30)
-            if resp.status_code == 404:
-                return None
-            resp.raise_for_status()
-            try:
-                return json.loads(resp.text)
-            except (json.JSONDecodeError, TypeError) as exc:
-                raise ValueError(f"Invalid JSON in marketplace file: {exc}") from exc
-
-    elif host_info.kind in ("github", "ghe_cloud", "ghes"):
-        url = _github_contents_url(source, file_path, host_info)
-
-        def _do_fetch(token, _git_env):
-            headers = {
-                "Accept": "application/vnd.github.v3.raw",
-                "User-Agent": "apm-cli",
-            }
-            if token:
-                headers["Authorization"] = f"token {token}"
-            resp = requests.get(url, headers=headers, timeout=30)
-            if resp.status_code == 404:
-                return None
-            resp.raise_for_status()
-            return resp.json()
-
-    else:
-        raise MarketplaceFetchError(
-            source.name,
-            f"Host {source.host!r} is not a supported marketplace source. "
-            "Only GitHub, GitHub Enterprise Cloud (*.ghe.com), GHES "
-            "(GITHUB_HOST), and GitLab are supported. Refusing to fetch to "
-            "avoid forwarding GitHub credentials to a non-GitHub host.",
-        )
 
     if auth_resolver is None:
         auth_resolver = AuthResolver()
 
-    try:
-        result = auth_resolver.try_with_fallback(
-            source.host,
-            _do_fetch,
-            org=source.owner,
-            path=f"{source.owner}/{source.repo}",
-            # Auth-first: marketplace repos may be private/org-scoped and the
-            # GitHub API returns 404 (not 403) for unauthenticated requests to
-            # private repos.  Because _do_fetch returns None on 404 (no
-            # exception), unauth_first would swallow the error instead of
-            # retrying with a token.
-            unauth_first=False,
-        )
-    except Exception as exc:
-        logger.debug("Fetch failed for '%s'", source.name, exc_info=True)
-        raise MarketplaceFetchError(source.name, str(exc)) from exc
+    kind = source.kind
+    fetcher = _FETCHERS.get(kind)
+    if fetcher is None:
+        raise MarketplaceFetchError(source.name, f"Unsupported marketplace source kind: {kind!r}")
 
-    # GitLab returns 404 for unauthenticated access to many private projects
-    # (indistinguishable from a missing file). ``_do_fetch`` maps 404 to
-    # ``None`` without raising, so ``unauth_first`` would skip the PAT.
-    if result is None and host_info.kind == "gitlab":
-        try:
-            result = auth_resolver.try_with_fallback(
-                source.host,
-                _do_fetch,
-                org=source.owner,
-                unauth_first=False,
+    # Proxy-aware path for github/gitlab kinds: try registry proxy first, then
+    # honour PROXY_REGISTRY_ONLY enforcement.
+    if kind in ("github", "gitlab"):
+        proxy_result = _try_proxy_fetch(source, file_path)
+        if proxy_result is not None:
+            return proxy_result
+        from ..deps.registry_proxy import RegistryConfig
+
+        cfg = RegistryConfig.from_env()
+        if cfg is not None and cfg.enforce_only:
+            logger.debug(
+                "PROXY_REGISTRY_ONLY blocks direct fetch for %s/%s %s",
+                source.owner,
+                source.repo,
+                file_path,
             )
-        except Exception as exc:
-            raise MarketplaceFetchError(source.name, str(exc)) from exc
+            return None
 
-    return result
+    host_info = None
+    if kind in ("github", "gitlab"):
+        host_info = AuthResolver.classify_host(source.host)
+    elif kind == "git":
+        # For generic git, classify the host extracted from the URL so ADO etc.
+        # get correctly-typed auth contexts.
+        host = _host_from_url(source.url)
+        host_info = AuthResolver.classify_host(host) if host else None
+
+    return fetcher(source, file_path, host_info=host_info, auth_resolver=auth_resolver)
+
+
+def _host_from_url(url: str) -> str:
+    """Extract host from a URL (handles SCP-like SSH URLs too)."""
+    if not url:
+        return ""
+    # SCP-like: git@host:path
+    if "@" in url and not url.startswith(("http", "git://", "ssh://", "file://")):
+        try:
+            return url.split("@", 1)[1].split(":", 1)[0]
+        except (IndexError, ValueError):
+            return ""
+    try:
+        return urlsplit(url).hostname or ""
+    except ValueError:
+        return ""
 
 
 def _auto_detect_path(
@@ -347,8 +641,9 @@ def fetch_marketplace(
 ) -> MarketplaceManifest:
     """Fetch and parse a marketplace manifest.
 
-    Uses cache when available (1h TTL). Falls back to stale cache on
-    network errors.
+    Uses the JSON sidecar cache for ``kind in ("github","gitlab")`` only.
+    Generic-git fetches rely on ``GitCache`` + ``git ls-remote`` for
+    freshness; local fetches read directly without caching.
 
     Args:
         source: Marketplace source to fetch.
@@ -362,30 +657,33 @@ def fetch_marketplace(
         MarketplaceFetchError: If fetch fails and no cache is available.
     """
     cache_name = _cache_key(source)
+    use_sidecar_cache = source.kind in ("github", "gitlab")
 
-    # Try fresh cache first
-    if not force_refresh:
+    # Try fresh cache first (API kinds only)
+    if use_sidecar_cache and not force_refresh:
         cached = _read_cache(cache_name)
         if cached is not None:
             logger.debug("Using cached marketplace data for '%s'", source.name)
             return parse_marketplace_json(cached, source.name)
 
-    # Fetch from network
+    # Fetch from source
     try:
         data = _fetch_file(source, source.path, auth_resolver=auth_resolver)
         if data is None:
             raise MarketplaceFetchError(
                 source.name,
-                f"marketplace.json not found at '{source.path}' in {source.owner}/{source.repo}",
+                f"marketplace.json not found at '{source.path}' in {source.display_source}",
             )
-        _write_cache(cache_name, data)
+        if use_sidecar_cache:
+            _write_cache(cache_name, data)
         return parse_marketplace_json(data, source.name)
     except MarketplaceFetchError:
-        # Stale-while-revalidate: serve expired cache on network error
-        stale = _read_stale_cache(cache_name)
-        if stale is not None:
-            logger.warning("Network error fetching '%s'; using stale cache", source.name)
-            return parse_marketplace_json(stale, source.name)
+        # Stale-while-revalidate (API kinds only): serve expired cache on network error
+        if use_sidecar_cache:
+            stale = _read_stale_cache(cache_name)
+            if stale is not None:
+                logger.warning("Network error fetching '%s'; using stale cache", source.name)
+                return parse_marketplace_json(stale, source.name)
         raise
 
 

--- a/src/apm_cli/marketplace/client.py
+++ b/src/apm_cli/marketplace/client.py
@@ -363,7 +363,7 @@ def _fetch_git(
     """
     _validate_ref(source.ref, source.name)
 
-    from ..cache.git_cache import GitCache
+    from ..cache.git_cache import GitCache, _sanitize_url
     from ..cache.paths import get_cache_root
 
     org = source.owner or None
@@ -382,13 +382,16 @@ def _fetch_git(
     except subprocess.CalledProcessError as exc:
         # Map "object not found" / "couldn't find remote ref" to None so the
         # caller's _auto_detect_path probe can try the next candidate path.
-        stderr = (getattr(exc, "stderr", b"") or b"").decode("utf-8", errors="replace")
-        if "not found" in stderr.lower() or "does not exist" in stderr.lower():
+        # Sanitize stderr in case a custom credential helper echoed a secret
+        # back through git's stderr stream.
+        stderr_raw = (getattr(exc, "stderr", b"") or b"").decode("utf-8", errors="replace")
+        if "not found" in stderr_raw.lower() or "does not exist" in stderr_raw.lower():
             return None
+        stderr = _sanitize_url(stderr_raw)
         raise MarketplaceFetchError(source.name, f"git fetch failed: {stderr or exc}") from exc
     except Exception as exc:
         logger.debug("Generic-git fetch failed for '%s'", source.name, exc_info=True)
-        raise MarketplaceFetchError(source.name, str(exc)) from exc
+        raise MarketplaceFetchError(source.name, _sanitize_url(str(exc))) from exc
 
     target = Path(checkout_dir) / file_path
     if not target.exists():
@@ -453,6 +456,8 @@ def _fetch_local_via_git_show(
     source: MarketplaceSource, file_path: str, git_dir: Path
 ) -> dict | None:
     """Use ``git show <ref>:<file>`` against a bare repo or .git directory."""
+    from ..utils.git_env import git_subprocess_env
+
     cmd = [
         "git",
         "--git-dir",
@@ -468,6 +473,7 @@ def _fetch_local_via_git_show(
             capture_output=True,
             check=False,
             timeout=30,
+            env=git_subprocess_env(),
         )
     except (subprocess.TimeoutExpired, OSError) as exc:
         raise MarketplaceFetchError(source.name, f"git show failed for {file_path}: {exc}") from exc

--- a/src/apm_cli/marketplace/models.py
+++ b/src/apm_cli/marketplace/models.py
@@ -4,52 +4,235 @@ Supports both Copilot CLI and Claude Code marketplace.json formats.
 All dataclasses are frozen for thread-safety.
 """
 
+from __future__ import annotations
+
 import logging
+import os
+import re
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 logger = logging.getLogger(__name__)
+
+
+# SCP-like git URL: e.g. git@host:org/repo.git -- captures host, path
+_SCP_LIKE_RE = re.compile(r"^(?P<user>[\w.-]+)@(?P<host>[\w.-]+):(?P<path>[^/].*)$")
+
+
+def _looks_like_local_path(value: str) -> bool:
+    """Heuristic for local filesystem paths and file:// URIs."""
+    if not value:
+        return False
+    if value.startswith("file://"):
+        return True
+    if value.startswith(("/", "./", "../", "~")):
+        return True
+    # Windows drive letter: C:\ or C:/
+    return bool(len(value) >= 3 and value[1:3] in (":\\", ":/") and value[0].isalpha())
+
+
+def _extract_host_from_url(url: str) -> str:
+    """Best-effort host extraction from any URL/path; empty for local paths."""
+    if not url or _looks_like_local_path(url):
+        return ""
+    scp = _SCP_LIKE_RE.match(url)
+    if scp:
+        return scp.group("host")
+    try:
+        parsed = urlsplit(url)
+    except ValueError:
+        return ""
+    return parsed.hostname or ""
+
+
+def _extract_owner_repo_from_url(url: str) -> tuple[str, str]:
+    """Best-effort owner/repo extraction. Empty strings if not derivable."""
+    if not url or _looks_like_local_path(url):
+        return ("", "")
+    scp = _SCP_LIKE_RE.match(url)
+    if scp:
+        path = scp.group("path")
+    else:
+        try:
+            parsed = urlsplit(url)
+        except ValueError:
+            return ("", "")
+        path = parsed.path.lstrip("/")
+    if path.endswith(".git"):
+        path = path[: -len(".git")]
+    segments = [s for s in path.split("/") if s]
+    if len(segments) >= 2:
+        return (segments[-2], segments[-1])
+    if len(segments) == 1:
+        return ("", segments[0])
+    return ("", "")
+
+
+def _local_path_from_source(value: str) -> str:
+    """Normalise a local-path source to an absolute path string."""
+    if value.startswith("file://"):
+        try:
+            parsed = urlsplit(value)
+        except ValueError:
+            return value
+        return parsed.path or value
+    return str(Path(value).expanduser())
 
 
 @dataclass(frozen=True)
 class MarketplaceSource:
     """A registered marketplace repository.
 
-    Stored in ``~/.apm/marketplaces.json``.
+    Stored in ``~/.apm/marketplaces.json``. URL-first model: ``url`` + ``ref``
+    + ``path`` are the canonical fields. Legacy ``owner`` / ``repo`` / ``host``
+    / ``branch`` kwargs are accepted for backward compatibility and are
+    synthesised from / into the URL during construction.
     """
 
     name: str  # Display name (e.g., "acme-tools")
-    owner: str  # GitHub owner
-    repo: str  # GitHub repo
+    url: str = ""  # Canonical URL or local path; synthesised from legacy fields if absent
+    ref: str = "main"  # Git ref (branch, tag, or SHA)
+    path: str = "marketplace.json"  # Path to manifest within the repo
+    # Legacy mirror fields -- populated either by the caller or by __post_init__.
+    # Retained for backward compat with code that reads source.owner / source.repo /
+    # source.host directly, and for one release of dual-emit in to_dict for downgrade.
+    owner: str = ""
+    repo: str = ""
     host: str = "github.com"
-    branch: str = "main"
-    path: str = "marketplace.json"  # Detected on add
+    branch: str = ""  # Legacy alias for ref; if both given, ref wins
+
+    def __post_init__(self) -> None:
+        # Reconcile ref / branch: ref is canonical. If only branch was set, copy it onto ref.
+        if self.branch and self.branch != "main" and (not self.ref or self.ref == "main"):
+            object.__setattr__(self, "ref", self.branch)
+        # Always mirror ref onto branch for legacy readers.
+        if self.ref:
+            object.__setattr__(self, "branch", self.ref)
+
+        # If URL absent but legacy fields are present, synthesise URL.
+        if not self.url:
+            if self.owner and self.repo:
+                host = self.host or "github.com"
+                object.__setattr__(self, "url", f"https://{host}/{self.owner}/{self.repo}")
+            # If neither URL nor legacy fields are usable, leave url empty; callers/tests
+            # that pass only name=... will fail later when something tries to use it.
+
+        # Backfill legacy mirror fields from URL when caller used URL-only signature.
+        if self.url and not self.owner and not self.repo:
+            o, r = _extract_owner_repo_from_url(self.url)
+            if o:
+                object.__setattr__(self, "owner", o)
+            if r:
+                object.__setattr__(self, "repo", r)
+        if self.url and self.host == "github.com":
+            h = _extract_host_from_url(self.url)
+            if h:
+                object.__setattr__(self, "host", h)
+
+    # -- derived properties --------------------------------------------------
+
+    @property
+    def kind(self) -> str:
+        """Derived source kind: ``local`` | ``github`` | ``gitlab`` | ``git``.
+
+        Classification:
+        - Local filesystem path or ``file://`` URI -> ``local``
+        - Host classified by AuthResolver as github/ghe_cloud/ghes -> ``github``
+        - Host classified as gitlab -> ``gitlab``
+        - Anything else (ado, generic, ssh to non-classified host) -> ``git``
+        """
+        if not self.url or _looks_like_local_path(self.url):
+            return "local"
+        host = _extract_host_from_url(self.url)
+        if not host:
+            return "git"
+        # Lazy import to keep models.py free of heavy dependencies
+        from apm_cli.core.auth import AuthResolver
+
+        host_kind = AuthResolver.classify_host(host).kind
+        if host_kind in ("github", "ghe_cloud", "ghes"):
+            return "github"
+        if host_kind == "gitlab":
+            return "gitlab"
+        return "git"
+
+    @property
+    def local_path(self) -> str:
+        """Return the resolved local filesystem path for ``kind == "local"`` sources.
+
+        Returns an empty string for non-local sources.
+        """
+        if self.kind != "local":
+            return ""
+        return _local_path_from_source(self.url)
+
+    @property
+    def display_source(self) -> str:
+        """Compact, kind-aware string for CLI list rendering."""
+        k = self.kind
+        if k in ("github", "gitlab") and self.owner and self.repo:
+            return f"{self.owner}/{self.repo}"
+        if k == "local":
+            lp = self.local_path
+            home = os.path.expanduser("~")
+            if home and lp.startswith(home):
+                return "~" + lp[len(home) :]
+            return lp or self.url
+        # generic git: strip scheme for compactness
+        url = self.url
+        for prefix in ("https://", "http://", "git://"):
+            if url.startswith(prefix):
+                return url[len(prefix) :]
+        return url
+
+    # -- serialisation -------------------------------------------------------
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialize to dict for JSON storage."""
-        result: dict[str, Any] = {
-            "name": self.name,
-            "owner": self.owner,
-            "repo": self.repo,
-        }
-        if self.host != "github.com":
-            result["host"] = self.host
-        if self.branch != "main":
-            result["branch"] = self.branch
+        """Serialize to dict for JSON storage.
+
+        Emits the new URL-first shape plus legacy ``owner``/``repo``/``host``/
+        ``branch`` mirror fields for one release so downgrades can still read.
+        """
+        result: dict[str, Any] = {"name": self.name}
+        if self.url:
+            result["url"] = self.url
+        if self.ref and self.ref != "main":
+            result["ref"] = self.ref
         if self.path != "marketplace.json":
             result["path"] = self.path
+        # Legacy mirror -- only when meaningful (suppress empty owner/repo for local sources)
+        if self.owner:
+            result["owner"] = self.owner
+        if self.repo:
+            result["repo"] = self.repo
+        if self.host and self.host != "github.com":
+            result["host"] = self.host
+        if self.branch and self.branch != "main":
+            result["branch"] = self.branch
         return result
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "MarketplaceSource":
-        """Deserialize from JSON dict."""
+    def from_dict(cls, data: dict[str, Any]) -> MarketplaceSource:
+        """Deserialize from JSON dict.
+
+        Accepts both the new URL-first shape and the legacy
+        ``{name, owner, repo, host?, branch?, path?}`` shape. Legacy entries
+        are upgraded transparently -- the URL is synthesised from the legacy
+        fields and ``ref`` mirrors ``branch``.
+        """
+        url = data.get("url", "")
+        ref = data.get("ref") or data.get("branch") or "main"
         return cls(
             name=data["name"],
-            owner=data["owner"],
-            repo=data["repo"],
-            host=data.get("host", "github.com"),
-            branch=data.get("branch", "main"),
+            url=url,
+            ref=ref,
             path=data.get("path", "marketplace.json"),
+            owner=data.get("owner", ""),
+            repo=data.get("repo", ""),
+            host=data.get("host", "github.com"),
+            branch=data.get("branch", ""),
         )
 
 

--- a/src/apm_cli/marketplace/models.py
+++ b/src/apm_cli/marketplace/models.py
@@ -8,17 +8,19 @@ from __future__ import annotations
 
 import logging
 import os
-import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
 
+from apm_cli.cache.url_normalize import SCP_LIKE_RE as _SCP_LIKE_RE
+
 logger = logging.getLogger(__name__)
 
 
-# SCP-like git URL: e.g. git@host:org/repo.git -- captures host, path
-_SCP_LIKE_RE = re.compile(r"^(?P<user>[\w.-]+)@(?P<host>[\w.-]+):(?P<path>[^/].*)$")
+# SCP-like git URL: e.g. git@host:org/repo.git -- reused canonical regex
+# from apm_cli.cache.url_normalize so dependency and marketplace SCP parsing
+# never drift.
 
 
 def _looks_like_local_path(value: str) -> bool:

--- a/src/apm_cli/marketplace/models.py
+++ b/src/apm_cli/marketplace/models.py
@@ -64,7 +64,9 @@ def _extract_owner_repo_from_url(url: str) -> tuple[str, str]:
         path = path[: -len(".git")]
     segments = [s for s in path.split("/") if s]
     if len(segments) >= 2:
-        return (segments[-2], segments[-1])
+        # Multi-segment paths (GHES nested groups, GitLab subgroups) are
+        # preserved by joining all segments except the last into `owner`.
+        return ("/".join(segments[:-1]), segments[-1])
     if len(segments) == 1:
         return ("", segments[0])
     return ("", "")

--- a/src/apm_cli/marketplace/resolver.py
+++ b/src/apm_cli/marketplace/resolver.py
@@ -199,7 +199,7 @@ def _marketplace_host_needs_explicit_git_path(host: str) -> bool:
     ``github.com`` and ``*.ghe.com`` virtual shorthand is reliable. Azure DevOps uses
     a different URL shape and is excluded. Self-managed GitLab FQDNs are often
     classified as ``generic`` by :meth:`AuthResolver.classify_host` when not listed in
-    ``GITLAB_HOST`` / ``APM_GITLAB_HOSTS`` — they still need explicit clone URLs so
+    ``GITLAB_HOST`` / ``APM_GITLAB_HOSTS`` -- they still need explicit clone URLs so
     paths like ``registry/pkg`` are not treated as extra project namespace segments.
     """
     if not host or not str(host).strip():
@@ -208,6 +208,27 @@ def _marketplace_host_needs_explicit_git_path(host: str) -> bool:
     if is_azure_devops_hostname(h):
         return False
     return not is_github_hostname(h)
+
+
+def _source_needs_explicit_git_path(source: MarketplaceSource) -> bool:
+    """Kind-aware variant of :func:`_marketplace_host_needs_explicit_git_path`.
+
+    For URL-first sources, the ``kind`` derivation already encodes the routing
+    decision: any host APM doesn't classify as github-family needs the explicit
+    git+path canonical (mirrors the existing GitLab self-managed pattern), and
+    that now includes Azure DevOps and generic git hosts since their
+    ``marketplace.json`` is fetched via subprocess git instead of an API.
+
+    Local marketplaces handle relative sources via :func:`_resolve_local_relative_source`
+    on the fast path and never reach this helper.
+    """
+    kind = source.kind
+    if kind == "github":
+        return False
+    if kind in ("gitlab", "git"):
+        return True
+    # Fall back to legacy host-based behaviour for any kind we don't recognise
+    return _marketplace_host_needs_explicit_git_path(source.host)
 
 
 def _needs_canonical_host_prefix(canonical: str, host: str) -> bool:
@@ -298,7 +319,21 @@ def _compute_cross_repo_misconfig_risk(
 
 
 def _marketplace_https_git_url(source: MarketplaceSource) -> str:
-    """HTTPS clone URL for the registered marketplace project (same project as ``marketplace.json``)."""
+    """HTTPS clone URL for the registered marketplace project.
+
+    Prefers ``source.url`` (the canonical URL stored in ``marketplaces.json``) when
+    present, falling back to synthesising from legacy owner/repo/host fields. The
+    canonical URL preserves quirky shapes like Azure DevOps' ``_git`` segment and
+    self-managed GitLab nested groups that owner/repo round-tripping cannot
+    reconstruct correctly.
+    """
+    url = (source.url or "").strip()
+    if url and url.startswith(("https://", "http://", "git://", "ssh://")):
+        return url if url.endswith(".git") else f"{url}.git"
+    # SCP-like SSH (git@host:org/repo.git) -- pass through verbatim
+    if url and "@" in url and ":" in url and not url.startswith("file://"):
+        return url
+    # Legacy synth from owner/repo/host
     segments = [p for p in f"{source.owner}/{source.repo}".split("/") if p]
     encoded = "/".join(quote(seg, safe="") for seg in segments)
     return f"https://{source.host}/{encoded}.git"
@@ -500,13 +535,23 @@ def _resolve_relative_source(
     When *plugin_root* is set (from ``metadata.pluginRoot`` in the manifest),
     bare names (no ``/``) are resolved under that directory.
     """
-    # Normalize the relative path (strip leading ./ and trailing /)
+    rel = _normalise_relative_plugin_source(source, plugin_root=plugin_root)
+    if rel and rel != ".":
+        return f"{marketplace_owner}/{marketplace_repo}/{rel}"
+    return f"{marketplace_owner}/{marketplace_repo}"
+
+
+def _normalise_relative_plugin_source(source: str, plugin_root: str = "") -> str:
+    """Normalise + validate a relative plugin source; return the normalised rel path.
+
+    Returns "" or "." when the plugin is the marketplace root.
+    Raises ``ValueError`` for paths that would escape the marketplace root.
+    """
     rel = source.strip("/")
     if rel.startswith("./"):
         rel = rel[2:]
     rel = rel.strip("/")
 
-    # If plugin_root is set and source is a bare name, prepend it
     if plugin_root and rel and rel != "." and "/" not in rel:
         root = plugin_root.strip("/")
         if root.startswith("./"):
@@ -520,8 +565,31 @@ def _resolve_relative_source(
             validate_path_segments(rel, context="relative source path")
         except PathTraversalError as exc:
             raise ValueError(str(exc)) from exc
-        return f"{marketplace_owner}/{marketplace_repo}/{rel}"
-    return f"{marketplace_owner}/{marketplace_repo}"
+    return rel
+
+
+def _resolve_local_relative_source(
+    source: str,
+    marketplace: MarketplaceSource,
+    plugin_root: str = "",
+) -> str:
+    """Resolve a relative source inside a local marketplace to a local-path canonical.
+
+    The returned string starts with ``/`` (or ``~`` / drive letter on supported
+    platforms) so :meth:`DependencyReference.is_local_path` recognises it and
+    install routes it through ``LocalDependencySource``.
+    """
+    rel = _normalise_relative_plugin_source(source, plugin_root=plugin_root)
+    base = marketplace.local_path
+    if not base:
+        raise ValueError(
+            f"Marketplace '{marketplace.name}' is kind=local but has no resolvable "
+            f"filesystem path (url={marketplace.url!r}); cannot resolve relative "
+            f"plugin source '{source}'."
+        )
+    if rel and rel != ".":
+        return f"{base.rstrip('/')}/{rel}"
+    return base
 
 
 def resolve_plugin_source(
@@ -643,6 +711,24 @@ def resolve_marketplace_plugin(
     if plugin is None:
         raise PluginNotFoundError(plugin_name, marketplace_name)
 
+    source_kind = source.kind
+
+    # ---- Local marketplace fast-path ----
+    # Relative plugin sources resolve to a local-path canonical (consumed by
+    # LocalDependencySource); dict sources (github/url/git-subdir/gitlab) keep
+    # their normal resolution because they reference external repos regardless
+    # of where the marketplace lives.
+    if source_kind == "local" and isinstance(plugin.source, str):
+        canonical = _resolve_local_relative_source(
+            plugin.source, source, plugin_root=manifest.plugin_root
+        )
+        return MarketplacePluginResolution(
+            canonical=canonical,
+            plugin=plugin,
+            dependency_reference=None,
+            cross_repo_misconfig_risk=None,
+        )
+
     canonical = resolve_plugin_source(
         plugin,
         marketplace_owner=source.owner,
@@ -651,9 +737,7 @@ def resolve_marketplace_plugin(
     )
 
     dep_ref: DependencyReference | None = None
-    if _marketplace_host_needs_explicit_git_path(source.host) and _is_in_marketplace_source(
-        plugin, source
-    ):
+    if _source_needs_explicit_git_path(source) and _is_in_marketplace_source(plugin, source):
         in_repo_path, path_ref = _extract_in_repo_path_and_ref(
             plugin, plugin_root=manifest.plugin_root
         )

--- a/tests/integration/test_commands_mcp_flow.py
+++ b/tests/integration/test_commands_mcp_flow.py
@@ -1243,29 +1243,37 @@ class TestFindDuplicateNames:
 
 
 class TestParseMarketplaceRepo:
-    """_parse_marketplace_repo — URL and shorthand parsing."""
+    """_parse_marketplace_repo -- URL and shorthand parsing.
+
+    The function is a URL-first parser: it returns ``(url, kind, host)``
+    where ``url`` is the canonical fetch URL (synthesised for shorthand
+    inputs, returned verbatim for HTTPS), ``kind`` is the fetcher kind
+    (``github``/``gitlab``/``git``/``local``), and ``host`` is the
+    embedded or resolved host FQDN.
+    """
 
     def test_simple_owner_repo(self) -> None:
         from apm_cli.commands.marketplace import _parse_marketplace_repo
 
-        owner, repo, host = _parse_marketplace_repo("myorg/myrepo", None)
-        assert owner == "myorg"
-        assert repo == "myrepo"
-        assert host is None
+        url, kind, host = _parse_marketplace_repo("myorg/myrepo", None)
+        assert url == "https://github.com/myorg/myrepo"
+        assert kind == "github"
+        assert host == "github.com"
 
     def test_https_url(self) -> None:
         from apm_cli.commands.marketplace import _parse_marketplace_repo
 
-        owner, repo, host = _parse_marketplace_repo("https://github.com/myorg/myrepo", None)
-        assert owner == "myorg"
-        assert repo == "myrepo"
+        url, kind, host = _parse_marketplace_repo("https://github.com/myorg/myrepo", None)
+        assert url == "https://github.com/myorg/myrepo"
+        assert kind == "github"
         assert host == "github.com"
 
-    def test_https_url_strips_git_suffix(self) -> None:
+    def test_https_url_preserves_git_suffix(self) -> None:
+        """HTTPS URLs are returned verbatim; subprocess git handles .git."""
         from apm_cli.commands.marketplace import _parse_marketplace_repo
 
-        _, repo, _ = _parse_marketplace_repo("https://github.com/org/myrepo.git", None)
-        assert repo == "myrepo"
+        url, _, _ = _parse_marketplace_repo("https://github.com/org/myrepo.git", None)
+        assert url == "https://github.com/org/myrepo.git"
 
     def test_http_url_rejected(self) -> None:
         from apm_cli.commands.marketplace import _parse_marketplace_repo
@@ -1301,9 +1309,9 @@ class TestParseMarketplaceRepo:
         """HOST/OWNER/REPO shorthand when first segment is valid FQDN."""
         from apm_cli.commands.marketplace import _parse_marketplace_repo
 
-        owner, repo, host = _parse_marketplace_repo("github.com/myorg/myrepo", None)
-        assert owner == "myorg"
-        assert repo == "myrepo"
+        url, kind, host = _parse_marketplace_repo("github.com/myorg/myrepo", None)
+        assert url == "https://github.com/myorg/myrepo"
+        assert kind == "github"
         assert host == "github.com"
 
 

--- a/tests/integration/test_commands_mcp_phase3c.py
+++ b/tests/integration/test_commands_mcp_phase3c.py
@@ -1243,29 +1243,37 @@ class TestFindDuplicateNames:
 
 
 class TestParseMarketplaceRepo:
-    """_parse_marketplace_repo — URL and shorthand parsing."""
+    """_parse_marketplace_repo -- URL and shorthand parsing.
+
+    The function is a URL-first parser: it returns ``(url, kind, host)``
+    where ``url`` is the canonical fetch URL (synthesised for shorthand
+    inputs, returned verbatim for HTTPS), ``kind`` is the fetcher kind
+    (``github``/``gitlab``/``git``/``local``), and ``host`` is the
+    embedded or resolved host FQDN.
+    """
 
     def test_simple_owner_repo(self) -> None:
         from apm_cli.commands.marketplace import _parse_marketplace_repo
 
-        owner, repo, host = _parse_marketplace_repo("myorg/myrepo", None)
-        assert owner == "myorg"
-        assert repo == "myrepo"
-        assert host is None
+        url, kind, host = _parse_marketplace_repo("myorg/myrepo", None)
+        assert url == "https://github.com/myorg/myrepo"
+        assert kind == "github"
+        assert host == "github.com"
 
     def test_https_url(self) -> None:
         from apm_cli.commands.marketplace import _parse_marketplace_repo
 
-        owner, repo, host = _parse_marketplace_repo("https://github.com/myorg/myrepo", None)
-        assert owner == "myorg"
-        assert repo == "myrepo"
+        url, kind, host = _parse_marketplace_repo("https://github.com/myorg/myrepo", None)
+        assert url == "https://github.com/myorg/myrepo"
+        assert kind == "github"
         assert host == "github.com"
 
-    def test_https_url_strips_git_suffix(self) -> None:
+    def test_https_url_preserves_git_suffix(self) -> None:
+        """HTTPS URLs are returned verbatim; subprocess git handles .git."""
         from apm_cli.commands.marketplace import _parse_marketplace_repo
 
-        _, repo, _ = _parse_marketplace_repo("https://github.com/org/myrepo.git", None)
-        assert repo == "myrepo"
+        url, _, _ = _parse_marketplace_repo("https://github.com/org/myrepo.git", None)
+        assert url == "https://github.com/org/myrepo.git"
 
     def test_http_url_rejected(self) -> None:
         from apm_cli.commands.marketplace import _parse_marketplace_repo
@@ -1301,9 +1309,9 @@ class TestParseMarketplaceRepo:
         """HOST/OWNER/REPO shorthand when first segment is valid FQDN."""
         from apm_cli.commands.marketplace import _parse_marketplace_repo
 
-        owner, repo, host = _parse_marketplace_repo("github.com/myorg/myrepo", None)
-        assert owner == "myorg"
-        assert repo == "myrepo"
+        url, kind, host = _parse_marketplace_repo("github.com/myorg/myrepo", None)
+        assert url == "https://github.com/myorg/myrepo"
+        assert kind == "github"
         assert host == "github.com"
 
 

--- a/tests/integration/test_git_cache_hermetic.py
+++ b/tests/integration/test_git_cache_hermetic.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from apm_cli.cache.git_cache import GitCache, _dir_size, _sanitize_url
+from apm_cli.cache.git_cache import GitCache, _dir_size, _safe_git_args, _sanitize_url
 from apm_cli.cache.url_normalize import cache_shard_key
 
 
@@ -239,6 +239,7 @@ class TestLsRemoteResolve:
 
         assert mock_run.call_args.args[0] == [
             "git",
+            *_safe_git_args(),
             "ls-remote",
             "https://example.com/repo.git",
             "main",
@@ -673,6 +674,7 @@ class TestFetchIntoBareLocked:
 
         assert mock_run.call_args_list[0].args[0] == [
             "git",
+            *_safe_git_args(),
             "-C",
             str(bare_dir),
             "fetch",
@@ -696,7 +698,14 @@ class TestFetchIntoBareLocked:
         ):
             cache._fetch_into_bare_locked(bare_dir, "https://example.com/repo.git", "b" * 40)
 
-        assert mock_run.call_args_list[1].args[0] == ["git", "-C", str(bare_dir), "fetch", "--all"]
+        assert mock_run.call_args_list[1].args[0] == [
+            "git",
+            *_safe_git_args(),
+            "-C",
+            str(bare_dir),
+            "fetch",
+            "--all",
+        ]
 
 
 class TestEvictCheckout:

--- a/tests/integration/test_git_cache_phase3w5.py
+++ b/tests/integration/test_git_cache_phase3w5.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from apm_cli.cache.git_cache import GitCache, _dir_size, _sanitize_url
+from apm_cli.cache.git_cache import GitCache, _dir_size, _safe_git_args, _sanitize_url
 from apm_cli.cache.url_normalize import cache_shard_key
 
 
@@ -239,6 +239,7 @@ class TestLsRemoteResolve:
 
         assert mock_run.call_args.args[0] == [
             "git",
+            *_safe_git_args(),
             "ls-remote",
             "https://example.com/repo.git",
             "main",
@@ -673,6 +674,7 @@ class TestFetchIntoBareLocked:
 
         assert mock_run.call_args_list[0].args[0] == [
             "git",
+            *_safe_git_args(),
             "-C",
             str(bare_dir),
             "fetch",
@@ -696,7 +698,14 @@ class TestFetchIntoBareLocked:
         ):
             cache._fetch_into_bare_locked(bare_dir, "https://example.com/repo.git", "b" * 40)
 
-        assert mock_run.call_args_list[1].args[0] == ["git", "-C", str(bare_dir), "fetch", "--all"]
+        assert mock_run.call_args_list[1].args[0] == [
+            "git",
+            *_safe_git_args(),
+            "-C",
+            str(bare_dir),
+            "fetch",
+            "--all",
+        ]
 
 
 class TestEvictCheckout:

--- a/tests/integration/test_marketplace_add_generic_git.py
+++ b/tests/integration/test_marketplace_add_generic_git.py
@@ -1,7 +1,14 @@
-"""End-to-end: ``apm marketplace add`` against a generic git URL.
+"""End-to-end: ``apm marketplace add`` against a ``file://`` bare repo URL.
 
-Uses a local bare repo accessed via ``file://`` URL — exercises ``_fetch_git``
-with a real ``GitCache`` subprocess clone end-to-end.
+``file://`` URIs to bare repos classify as ``kind="local"`` (see
+``_looks_like_local_marketplace_source``) and route through the local fetcher
+(``_fetch_local`` -> ``git show``). This test exercises that path end-to-end
+through ``apm marketplace add`` + ``fetch_or_cache``.
+
+For coverage of the generic-git path (``kind="git"`` -> ``_fetch_git`` ->
+``GitCache``), see the unit tests in ``tests/unit/marketplace/test_client_git.py``
+and ``test_resolver_local_git.py``; a hermetic integration test would need a
+running git daemon and is deliberately out of scope here.
 """
 
 from __future__ import annotations
@@ -70,12 +77,13 @@ def _seed_bare_repo(working: Path, bare: Path) -> None:
     )
 
 
-def test_marketplace_add_generic_git_via_file_uri(tmp_path: Path) -> None:
-    """Register a marketplace via a file:// URL pointing at a bare repo.
+def test_marketplace_add_file_uri_to_bare_repo(tmp_path: Path) -> None:
+    """Register a marketplace via a ``file://`` URL pointing at a bare repo.
 
-    The URL doesn't look like a local path (since it ends in ``.git`` and
-    serves as a remote), so it classifies as ``kind="git"`` once exposed via
-    file:// transport and routes through ``_fetch_git`` + ``GitCache``.
+    ``file://`` URIs classify as ``kind="local"`` and route through
+    ``_fetch_local`` (which uses ``git show`` against the bare repo). This
+    is the documented behaviour: any ``file://`` URI -- whether pointing at
+    a bare or working repo -- always routes through the local fetcher.
     """
     working = tmp_path / "src"
     bare = tmp_path / "mkt.git"

--- a/tests/integration/test_marketplace_add_generic_git.py
+++ b/tests/integration/test_marketplace_add_generic_git.py
@@ -1,0 +1,102 @@
+"""End-to-end: ``apm marketplace add`` against a generic git URL.
+
+Uses a local bare repo accessed via ``file://`` URL — exercises ``_fetch_git``
+with a real ``GitCache`` subprocess clone end-to-end.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from apm_cli.commands.marketplace import marketplace as marketplace_group
+from apm_cli.marketplace import registry
+from apm_cli.marketplace.client import fetch_or_cache
+
+GIT_AVAILABLE = shutil.which("git") is not None
+
+pytestmark = pytest.mark.skipif(not GIT_AVAILABLE, reason="git executable not available")
+
+MANIFEST = {
+    "name": "gen-mkt",
+    "owner": "test",
+    "plugins": [
+        {"name": "tool-x", "source": "./tools/x", "version": "1.0.0"},
+    ],
+}
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_dir = str(tmp_path / ".apm")
+    Path(config_dir).mkdir()
+    monkeypatch.setattr("apm_cli.config.CONFIG_DIR", config_dir)
+    monkeypatch.setattr("apm_cli.config.CONFIG_FILE", str(tmp_path / ".apm" / "config.json"))
+    monkeypatch.setattr("apm_cli.config._config_cache", None)
+    monkeypatch.setattr(registry, "_registry_cache", None)
+    # Redirect APM cache root so GitCache doesn't write to the real user cache.
+    monkeypatch.setenv("APM_HOME", str(tmp_path / ".apm"))
+
+
+def _seed_bare_repo(working: Path, bare: Path) -> None:
+    env = {
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+    working.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "init", "-b", "main", str(working)], check=True, capture_output=True, env=env
+    )
+    (working / "marketplace.json").write_text(json.dumps(MANIFEST))
+    subprocess.run(["git", "-C", str(working), "add", "."], check=True, env=env)
+    subprocess.run(
+        ["git", "-C", str(working), "commit", "-m", "seed"],
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+    subprocess.run(
+        ["git", "clone", "--bare", str(working), str(bare)],
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+
+
+def test_marketplace_add_generic_git_via_file_uri(tmp_path: Path) -> None:
+    """Register a marketplace via a file:// URL pointing at a bare repo.
+
+    The URL doesn't look like a local path (since it ends in ``.git`` and
+    serves as a remote), so it classifies as ``kind="git"`` once exposed via
+    file:// transport and routes through ``_fetch_git`` + ``GitCache``.
+    """
+    working = tmp_path / "src"
+    bare = tmp_path / "mkt.git"
+    _seed_bare_repo(working, bare)
+
+    # file:// URI to the bare repo
+    file_uri = f"file://{bare}"
+
+    runner = CliRunner()
+    result = runner.invoke(marketplace_group, ["add", file_uri, "--name", "gen-mkt"])
+    assert result.exit_code == 0, result.output
+
+    sources = registry.get_registered_marketplaces()
+    assert len(sources) == 1
+    src = sources[0]
+    assert src.name == "gen-mkt"
+    # file:// URIs to bare repos are classified as "local" by the parser; the
+    # _fetch_local fetcher handles them via "git show". This is the documented
+    # behaviour -- file:// always routes through the local fetcher.
+    assert src.kind == "local"
+
+    manifest = fetch_or_cache(src)
+    assert manifest.name == "gen-mkt"
+    assert manifest.plugins[0].name == "tool-x"

--- a/tests/integration/test_marketplace_add_local.py
+++ b/tests/integration/test_marketplace_add_local.py
@@ -1,0 +1,132 @@
+"""End-to-end integration: ``apm marketplace add`` against a real local repo.
+
+Exercises the full add -> persist -> read-back -> fetch flow against:
+- a working-directory checkout (direct file read)
+- a bare repo (``git show`` path)
+
+Drives the CLI through ``click.testing.CliRunner`` against an isolated
+``$HOME`` so no real user config is touched. Requires the ``git``
+executable in PATH.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from apm_cli.commands.marketplace import marketplace as marketplace_group
+from apm_cli.marketplace import registry
+from apm_cli.marketplace.client import fetch_or_cache
+
+GIT_AVAILABLE = shutil.which("git") is not None
+
+pytestmark = pytest.mark.skipif(not GIT_AVAILABLE, reason="git executable not available")
+
+MANIFEST = {
+    "name": "test-mkt",
+    "owner": "test",
+    "plugins": [
+        {"name": "skill-a", "source": "./skills/skill-a", "version": "0.1.0"},
+    ],
+}
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_dir = str(tmp_path / ".apm")
+    Path(config_dir).mkdir()
+    monkeypatch.setattr("apm_cli.config.CONFIG_DIR", config_dir)
+    monkeypatch.setattr("apm_cli.config.CONFIG_FILE", str(tmp_path / ".apm" / "config.json"))
+    monkeypatch.setattr("apm_cli.config._config_cache", None)
+    monkeypatch.setattr(registry, "_registry_cache", None)
+
+
+def _seed_working_dir_repo(repo: Path) -> None:
+    """Create a working-dir git repo with marketplace.json committed to main."""
+    repo.mkdir(parents=True, exist_ok=True)
+    env = {
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+    subprocess.run(
+        ["git", "init", "-b", "main", str(repo)], check=True, capture_output=True, env=env
+    )
+    (repo / "marketplace.json").write_text(json.dumps(MANIFEST))
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True, env=env)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", "seed"],
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+
+
+def _make_bare_clone(working: Path, bare: Path) -> None:
+    subprocess.run(
+        ["git", "clone", "--bare", str(working), str(bare)],
+        check=True,
+        capture_output=True,
+    )
+
+
+@pytest.mark.parametrize("topology", ["working", "bare"])
+def test_marketplace_add_local_path(topology: str, tmp_path: Path) -> None:
+    working = tmp_path / "mkt-src"
+    _seed_working_dir_repo(working)
+    if topology == "bare":
+        bare = tmp_path / "mkt.git"
+        _make_bare_clone(working, bare)
+        path = bare
+    else:
+        path = working
+
+    runner = CliRunner()
+    result = runner.invoke(marketplace_group, ["add", str(path), "--name", "local-mkt"])
+    assert result.exit_code == 0, result.output
+
+    sources = registry.get_registered_marketplaces()
+    assert len(sources) == 1
+    src = sources[0]
+    assert src.name == "local-mkt"
+    assert src.kind == "local"
+    assert src.url.startswith("file://")
+
+    manifest = fetch_or_cache(src)
+    assert manifest.name == "test-mkt"
+    assert len(manifest.plugins) == 1
+    assert manifest.plugins[0].name == "skill-a"
+
+
+def test_marketplace_add_file_uri(tmp_path: Path) -> None:
+    working = tmp_path / "mkt-src"
+    _seed_working_dir_repo(working)
+    file_uri = f"file://{working}"
+
+    runner = CliRunner()
+    result = runner.invoke(marketplace_group, ["add", file_uri, "--name", "uri-mkt"])
+    assert result.exit_code == 0, result.output
+
+    sources = registry.get_registered_marketplaces()
+    assert sources[0].kind == "local"
+
+
+def test_marketplace_add_local_list_shows_path(tmp_path: Path) -> None:
+    """``list`` after registering a local marketplace renders ``display_source``, not blank owner/repo."""
+    working = tmp_path / "mkt-src"
+    _seed_working_dir_repo(working)
+    runner = CliRunner()
+    runner.invoke(marketplace_group, ["add", str(working), "--name", "local-mkt"])
+    result = runner.invoke(marketplace_group, ["list"])
+    assert result.exit_code == 0, result.output
+    assert "local-mkt" in result.output
+    # The path may be truncated by the Rich table; check for either a path prefix
+    # or that "Source" column is rendered with a slash-like content (not empty owner/repo).
+    assert "/" in result.output  # local path renders
+    assert "Ref" in result.output  # renamed column from "Branch"

--- a/tests/integration/test_marketplace_e2e_surface.py
+++ b/tests/integration/test_marketplace_e2e_surface.py
@@ -94,15 +94,15 @@ class TestIsValidAlias:
 
 class TestParseMarketplaceRepo:
     def test_simple_owner_repo(self):
-        owner, repo, host = _parse_marketplace_repo("owner/repo", None)
-        assert owner == "owner"
-        assert repo == "repo"
-        assert host is None
+        url, kind, host = _parse_marketplace_repo("owner/repo", None)
+        assert url == "https://github.com/owner/repo"
+        assert kind == "github"
+        assert host == "github.com"
 
     def test_https_url_parsed(self):
-        owner, repo, host = _parse_marketplace_repo("https://github.com/owner/my-repo", None)
-        assert owner == "owner"
-        assert repo == "my-repo"
+        url, kind, host = _parse_marketplace_repo("https://github.com/owner/my-repo", None)
+        assert url == "https://github.com/owner/my-repo"
+        assert kind == "github"
         assert host == "github.com"
 
     def test_http_url_rejected(self):
@@ -118,10 +118,10 @@ class TestParseMarketplaceRepo:
             _parse_marketplace_repo("only-one", None)
 
     def test_fqdn_prefix_three_segment(self):
-        owner, repo, host = _parse_marketplace_repo("github.example.com/owner/my-repo", None)
+        url, kind, host = _parse_marketplace_repo("github.example.com/owner/my-repo", None)
+        assert url == "https://github.example.com/owner/my-repo"
+        assert kind == "git"
         assert host == "github.example.com"
-        assert owner == "owner"
-        assert repo == "my-repo"
 
     def test_fqdn_prefix_only_two_segments_rejected(self):
         """Line 322-326: HOST/REPO without owner is rejected."""

--- a/tests/integration/test_marketplace_install_local.py
+++ b/tests/integration/test_marketplace_install_local.py
@@ -1,0 +1,103 @@
+"""End-to-end: ``resolve_marketplace_plugin`` against a real local marketplace.
+
+Verifies the full resolution chain for an in-marketplace plugin source:
+
+1. Register a local marketplace (bare repo) via the CLI.
+2. Call ``resolve_marketplace_plugin`` against the manifest.
+3. Parse the returned canonical through ``DependencyReference``.
+4. Assert the dependency is recognised as local and points at the on-disk
+   plugin directory (the contract ``LocalDependencySource`` relies on).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from apm_cli.commands.marketplace import marketplace as marketplace_group
+from apm_cli.marketplace import registry
+from apm_cli.marketplace.resolver import resolve_marketplace_plugin
+from apm_cli.models.dependency.reference import DependencyReference
+
+GIT_AVAILABLE = shutil.which("git") is not None
+pytestmark = pytest.mark.skipif(not GIT_AVAILABLE, reason="git executable not available")
+
+
+MANIFEST = {
+    "name": "local-mkt",
+    "owner": "test",
+    "plugins": [
+        {
+            "name": "skill-a",
+            "source": "./skills/skill-a",
+            "version": "0.1.0",
+        }
+    ],
+}
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config_dir = str(tmp_path / ".apm")
+    Path(config_dir).mkdir()
+    monkeypatch.setattr("apm_cli.config.CONFIG_DIR", config_dir)
+    monkeypatch.setattr("apm_cli.config.CONFIG_FILE", str(tmp_path / ".apm" / "config.json"))
+    monkeypatch.setattr("apm_cli.config._config_cache", None)
+    monkeypatch.setattr(registry, "_registry_cache", None)
+
+
+def _seed_marketplace(repo: Path) -> None:
+    """Create a working-dir git repo + a skill dir + commit everything."""
+    env = {
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@e.x",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@e.x",
+    }
+    repo.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "init", "-b", "main", str(repo)], check=True, capture_output=True, env=env
+    )
+    (repo / "marketplace.json").write_text(json.dumps(MANIFEST))
+    skill_dir = repo / "skills" / "skill-a"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("# skill-a\n")
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True, env=env)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", "seed"],
+        check=True,
+        capture_output=True,
+        env=env,
+    )
+
+
+def test_install_resolves_local_marketplace_to_on_disk_path(tmp_path: Path) -> None:
+    repo = tmp_path / "mkt"
+    _seed_marketplace(repo)
+
+    runner = CliRunner()
+    result = runner.invoke(marketplace_group, ["add", str(repo), "--name", "local-mkt"])
+    assert result.exit_code == 0, result.output
+
+    resolved = resolve_marketplace_plugin("skill-a", "local-mkt")
+
+    # Resolver hands install side a local-path canonical
+    assert resolved.dependency_reference is None
+    canonical = resolved.canonical
+    assert DependencyReference.is_local_path(canonical), canonical
+
+    # The canonical points at the actual on-disk skill directory
+    skill_path = Path(canonical)
+    assert skill_path.exists(), f"resolver canonical does not exist on disk: {skill_path}"
+    assert (skill_path / "SKILL.md").is_file()
+
+    # Round-trip the canonical through DependencyReference to confirm it parses
+    # as a local dependency (the gate LocalDependencySource branches on).
+    dep_ref = DependencyReference.parse(canonical)
+    assert dep_ref.is_local
+    assert Path(dep_ref.local_path).resolve() == skill_path.resolve()

--- a/tests/integration/test_marketplace_phase3w4.py
+++ b/tests/integration/test_marketplace_phase3w4.py
@@ -94,15 +94,15 @@ class TestIsValidAlias:
 
 class TestParseMarketplaceRepo:
     def test_simple_owner_repo(self):
-        owner, repo, host = _parse_marketplace_repo("owner/repo", None)
-        assert owner == "owner"
-        assert repo == "repo"
-        assert host is None
+        url, kind, host = _parse_marketplace_repo("owner/repo", None)
+        assert url == "https://github.com/owner/repo"
+        assert kind == "github"
+        assert host == "github.com"
 
     def test_https_url_parsed(self):
-        owner, repo, host = _parse_marketplace_repo("https://github.com/owner/my-repo", None)
-        assert owner == "owner"
-        assert repo == "my-repo"
+        url, kind, host = _parse_marketplace_repo("https://github.com/owner/my-repo", None)
+        assert url == "https://github.com/owner/my-repo"
+        assert kind == "github"
         assert host == "github.com"
 
     def test_http_url_rejected(self):
@@ -118,10 +118,10 @@ class TestParseMarketplaceRepo:
             _parse_marketplace_repo("only-one", None)
 
     def test_fqdn_prefix_three_segment(self):
-        owner, repo, host = _parse_marketplace_repo("github.example.com/owner/my-repo", None)
+        url, kind, host = _parse_marketplace_repo("github.example.com/owner/my-repo", None)
+        assert url == "https://github.example.com/owner/my-repo"
+        assert kind == "git"
         assert host == "github.example.com"
-        assert owner == "owner"
-        assert repo == "my-repo"
 
     def test_fqdn_prefix_only_two_segments_rejected(self):
         """Line 322-326: HOST/REPO without owner is rejected."""

--- a/tests/integration/test_marketplace_publisher_flow.py
+++ b/tests/integration/test_marketplace_publisher_flow.py
@@ -279,27 +279,25 @@ class TestParseMarketplaceRepo:
     """Tests for _parse_marketplace_repo."""
 
     def test_simple_owner_repo(self) -> None:
-        owner, repo_name, embedded = _parse_marketplace_repo("acme/tools", None)
-        assert owner == "acme"
-        assert repo_name == "tools"
-        assert embedded is None
-
-    def test_https_url(self) -> None:
-        owner, repo_name, embedded = _parse_marketplace_repo("https://github.com/acme/tools", None)
-        assert owner == "acme"
-        assert repo_name == "tools"
+        url, kind, embedded = _parse_marketplace_repo("acme/tools", None)
+        assert url == "https://github.com/acme/tools"
+        assert kind == "github"
         assert embedded == "github.com"
 
-    def test_https_url_strips_dot_git(self) -> None:
-        _owner, repo_name, _embedded = _parse_marketplace_repo(
-            "https://github.com/acme/tools.git", None
-        )
-        assert repo_name == "tools"
+    def test_https_url(self) -> None:
+        url, kind, embedded = _parse_marketplace_repo("https://github.com/acme/tools", None)
+        assert url == "https://github.com/acme/tools"
+        assert kind == "github"
+        assert embedded == "github.com"
+
+    def test_https_url_preserves_dot_git(self) -> None:
+        url, _kind, _embedded = _parse_marketplace_repo("https://github.com/acme/tools.git", None)
+        assert url == "https://github.com/acme/tools.git"
 
     def test_host_shorthand_three_segments(self) -> None:
-        owner, repo_name, embedded = _parse_marketplace_repo("github.com/acme/tools", None)
-        assert owner == "acme"
-        assert repo_name == "tools"
+        url, kind, embedded = _parse_marketplace_repo("github.com/acme/tools", None)
+        assert url == "https://github.com/acme/tools"
+        assert kind == "github"
         assert embedded == "github.com"
 
     def test_http_rejected(self) -> None:
@@ -323,7 +321,7 @@ class TestParseMarketplaceRepo:
             _parse_marketplace_repo("https://github.com/acme/tools", "gitlab.com")
 
     def test_host_flag_normalised(self) -> None:
-        _owner, _repo_name, embedded = _parse_marketplace_repo(
+        _url, _kind, embedded = _parse_marketplace_repo(
             "https://github.com/acme/tools", "github.com"
         )
         assert embedded == "github.com"
@@ -336,10 +334,10 @@ class TestParseMarketplaceRepo:
 
     def test_nested_path_owner(self) -> None:
         """HOST/group/sub/repo -- multi-segment owner path."""
-        _owner, repo_name, embedded = _parse_marketplace_repo(
+        url, _kind, embedded = _parse_marketplace_repo(
             "https://gitlab.example.com/group/sub/repo", None
         )
-        assert repo_name == "repo"
+        assert url == "https://gitlab.example.com/group/sub/repo"
         assert embedded == "gitlab.example.com"
 
 

--- a/tests/integration/test_marketplace_publisher_phase3.py
+++ b/tests/integration/test_marketplace_publisher_phase3.py
@@ -279,27 +279,25 @@ class TestParseMarketplaceRepo:
     """Tests for _parse_marketplace_repo."""
 
     def test_simple_owner_repo(self) -> None:
-        owner, repo_name, embedded = _parse_marketplace_repo("acme/tools", None)
-        assert owner == "acme"
-        assert repo_name == "tools"
-        assert embedded is None
-
-    def test_https_url(self) -> None:
-        owner, repo_name, embedded = _parse_marketplace_repo("https://github.com/acme/tools", None)
-        assert owner == "acme"
-        assert repo_name == "tools"
+        url, kind, embedded = _parse_marketplace_repo("acme/tools", None)
+        assert url == "https://github.com/acme/tools"
+        assert kind == "github"
         assert embedded == "github.com"
 
-    def test_https_url_strips_dot_git(self) -> None:
-        _owner, repo_name, _embedded = _parse_marketplace_repo(
-            "https://github.com/acme/tools.git", None
-        )
-        assert repo_name == "tools"
+    def test_https_url(self) -> None:
+        url, kind, embedded = _parse_marketplace_repo("https://github.com/acme/tools", None)
+        assert url == "https://github.com/acme/tools"
+        assert kind == "github"
+        assert embedded == "github.com"
+
+    def test_https_url_preserves_dot_git(self) -> None:
+        url, _kind, _embedded = _parse_marketplace_repo("https://github.com/acme/tools.git", None)
+        assert url == "https://github.com/acme/tools.git"
 
     def test_host_shorthand_three_segments(self) -> None:
-        owner, repo_name, embedded = _parse_marketplace_repo("github.com/acme/tools", None)
-        assert owner == "acme"
-        assert repo_name == "tools"
+        url, kind, embedded = _parse_marketplace_repo("github.com/acme/tools", None)
+        assert url == "https://github.com/acme/tools"
+        assert kind == "github"
         assert embedded == "github.com"
 
     def test_http_rejected(self) -> None:
@@ -323,7 +321,7 @@ class TestParseMarketplaceRepo:
             _parse_marketplace_repo("https://github.com/acme/tools", "gitlab.com")
 
     def test_host_flag_normalised(self) -> None:
-        _owner, _repo_name, embedded = _parse_marketplace_repo(
+        _url, _kind, embedded = _parse_marketplace_repo(
             "https://github.com/acme/tools", "github.com"
         )
         assert embedded == "github.com"
@@ -336,10 +334,10 @@ class TestParseMarketplaceRepo:
 
     def test_nested_path_owner(self) -> None:
         """HOST/group/sub/repo -- multi-segment owner path."""
-        _owner, repo_name, embedded = _parse_marketplace_repo(
+        url, _kind, embedded = _parse_marketplace_repo(
             "https://gitlab.example.com/group/sub/repo", None
         )
-        assert repo_name == "repo"
+        assert url == "https://gitlab.example.com/group/sub/repo"
         assert embedded == "gitlab.example.com"
 
 

--- a/tests/integration/test_wave7_marketplace_install_coverage.py
+++ b/tests/integration/test_wave7_marketplace_install_coverage.py
@@ -1084,20 +1084,18 @@ class TestMarketplaceInternalHelpers:
         """_parse_marketplace_repo parses OWNER/REPO correctly."""
         from apm_cli.commands.marketplace import _parse_marketplace_repo
 
-        owner, repo_name, embedded_host = _parse_marketplace_repo("acme/plugins", None)
-        assert owner == "acme"
-        assert repo_name == "plugins"
-        assert embedded_host is None
+        url, kind, embedded_host = _parse_marketplace_repo("acme/plugins", None)
+        assert url == "https://github.com/acme/plugins"
+        assert kind == "github"
+        assert embedded_host == "github.com"
 
     def test_parse_marketplace_repo_https_url(self) -> None:
         """_parse_marketplace_repo handles HTTPS URLs."""
         from apm_cli.commands.marketplace import _parse_marketplace_repo
 
-        owner, repo_name, embedded_host = _parse_marketplace_repo(
-            "https://github.com/acme/plugins", None
-        )
-        assert owner == "acme"
-        assert repo_name == "plugins"
+        url, kind, embedded_host = _parse_marketplace_repo("https://github.com/acme/plugins", None)
+        assert url == "https://github.com/acme/plugins"
+        assert kind == "github"
         assert embedded_host == "github.com"
 
     def test_parse_marketplace_repo_http_rejected(self) -> None:

--- a/tests/unit/cache/test_git_cache_hardening.py
+++ b/tests/unit/cache/test_git_cache_hardening.py
@@ -1,0 +1,165 @@
+"""Supply-chain hardening tests for GitCache subprocess invocations.
+
+GitCache is the single chokepoint through which APM invokes ``git``
+against caller-supplied URLs. A malicious upstream could ship hook
+scripts (``.git/hooks/post-checkout``) or attacker-controlled
+submodule URLs that would trigger arbitrary code execution on clone
+or checkout. These tests assert that every git subprocess invoked
+by GitCache carries:
+
+- ``-c core.hooksPath=/dev/null`` -- disables hook execution
+- ``-c submodule.recurse=false`` -- prevents submodule recursion
+
+and that every ``git clone`` call also carries
+``--no-recurse-submodules`` so the flag is explicit even if a future
+git release flips its default.
+
+These guards are on-path for the generic-git marketplace registration
+path (``apm marketplace add <untrusted-url>``) -- without them, any
+user who registers a malicious marketplace would execute attacker code
+on the next ``apm marketplace update``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from apm_cli.cache.git_cache import GitCache, _safe_git_args
+
+
+def _all_cmd_argvs(mock_run: MagicMock) -> list[list[str]]:
+    """Extract every argv passed to ``subprocess.run`` across all calls."""
+    argvs = []
+    for call in mock_run.call_args_list:
+        # subprocess.run can be called positionally or with `args=`
+        argv = call.args[0] if call.args else call.kwargs.get("args")
+        if isinstance(argv, list):
+            argvs.append(argv)
+    return argvs
+
+
+class TestSafeGitArgs:
+    def test_includes_hooks_path_dev_null(self) -> None:
+        args = _safe_git_args()
+        assert "-c" in args
+        assert "core.hooksPath=/dev/null" in args
+
+    def test_includes_submodule_recurse_false(self) -> None:
+        args = _safe_git_args()
+        assert "submodule.recurse=false" in args
+
+
+class TestLsRemoteHardening:
+    @patch("subprocess.run")
+    def test_ls_remote_carries_safe_args(self, mock_run: MagicMock, tmp_path: Path) -> None:
+        cache = GitCache(tmp_path)
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=f"{'c' * 40}\trefs/heads/main\n",
+            stderr="",
+        )
+        cache._resolve_sha("https://evil.example.com/o/r", "main")
+
+        argvs = _all_cmd_argvs(mock_run)
+        assert argvs, "ls-remote subprocess.run was not invoked"
+        argv = argvs[0]
+        assert "ls-remote" in argv
+        assert "core.hooksPath=/dev/null" in argv
+        assert "submodule.recurse=false" in argv
+
+
+class TestCloneHardening:
+    """Every clone subprocess invocation must disable hooks and submodules."""
+
+    @patch("apm_cli.cache.git_cache.atomic_land", return_value=True)
+    @patch("apm_cli.cache.git_cache.verify_checkout_sha", return_value=True)
+    @patch("subprocess.run")
+    def test_bare_clone_carries_safe_args_and_no_recurse(
+        self,
+        mock_run: MagicMock,
+        _verify: MagicMock,
+        _land: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        cache = GitCache(tmp_path)
+        sha = "a" * 40
+        # ls-remote -> bare clone -> local clone -> checkout
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=f"{sha}\trefs/heads/main\n",
+            stderr="",
+        )
+        # Mocked subprocess.run doesn't actually materialise files;
+        # we only need to inspect the argvs that were attempted.
+        with contextlib.suppress(Exception):
+            cache.get_checkout("https://evil.example.com/o/r", "main")
+
+        argvs = _all_cmd_argvs(mock_run)
+        clone_argvs = [a for a in argvs if "clone" in a]
+        assert clone_argvs, "no clone subprocess invoked"
+        for argv in clone_argvs:
+            assert "core.hooksPath=/dev/null" in argv, argv
+            assert "submodule.recurse=false" in argv, argv
+            assert "--no-recurse-submodules" in argv, argv
+
+
+class TestFetchHardening:
+    @patch("subprocess.run")
+    def test_fetch_into_bare_carries_safe_args(self, mock_run: MagicMock, tmp_path: Path) -> None:
+        cache = GitCache(tmp_path)
+        # _bare_has_sha returns False, then fetch is invoked.
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="")
+
+        bare_dir = tmp_path / "bare"
+        bare_dir.mkdir()
+        # We mocked subprocess.run to return non-zero, which makes
+        # check=True raise. We only need the argv that was attempted.
+        with contextlib.suppress(Exception):
+            cache._fetch_into_bare_locked(
+                bare_dir,
+                "https://evil.example.com/o/r",
+                "a" * 40,
+            )
+
+        argvs = _all_cmd_argvs(mock_run)
+        fetch_argvs = [a for a in argvs if "fetch" in a]
+        assert fetch_argvs, "no fetch subprocess invoked"
+        for argv in fetch_argvs:
+            assert "core.hooksPath=/dev/null" in argv, argv
+            assert "submodule.recurse=false" in argv, argv
+
+
+class TestCheckoutHardening:
+    """The bare-to-working-dir clone in _create_checkout must be hardened."""
+
+    @patch("apm_cli.cache.git_cache.atomic_land", return_value=True)
+    @patch("apm_cli.cache.git_cache.verify_checkout_sha", return_value=True)
+    @patch("subprocess.run")
+    def test_create_checkout_clone_and_checkout_carry_safe_args(
+        self,
+        mock_run: MagicMock,
+        _verify: MagicMock,
+        _land: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        cache = GitCache(tmp_path)
+        sha = "a" * 40
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=f"{sha}\trefs/heads/main\n",
+            stderr="",
+        )
+        with contextlib.suppress(Exception):
+            cache.get_checkout("https://evil.example.com/o/r", "main")
+
+        argvs = _all_cmd_argvs(mock_run)
+        local_clone_argvs = [a for a in argvs if "clone" in a and "--local" in a]
+        checkout_argvs = [a for a in argvs if "checkout" in a and "clone" not in a]
+        assert local_clone_argvs, "expected a local clone argv"
+        for argv in local_clone_argvs + checkout_argvs:
+            assert "core.hooksPath=/dev/null" in argv, argv
+            assert "submodule.recurse=false" in argv, argv
+        for argv in local_clone_argvs:
+            assert "--no-recurse-submodules" in argv, argv

--- a/tests/unit/marketplace/fixtures/legacy_marketplaces.json
+++ b/tests/unit/marketplace/fixtures/legacy_marketplaces.json
@@ -1,0 +1,25 @@
+{
+  "version": "1.0",
+  "marketplaces": [
+    {
+      "name": "acme-default",
+      "owner": "acme",
+      "repo": "marketplace"
+    },
+    {
+      "name": "ghes-mkt",
+      "owner": "team",
+      "repo": "internal-marketplace",
+      "host": "ghe.contoso.com",
+      "branch": "release"
+    },
+    {
+      "name": "gitlab-mkt",
+      "owner": "group/sub",
+      "repo": "tools",
+      "host": "gitlab.com",
+      "branch": "develop",
+      "path": "custom/marketplace.json"
+    }
+  ]
+}

--- a/tests/unit/marketplace/test_client_git.py
+++ b/tests/unit/marketplace/test_client_git.py
@@ -1,0 +1,178 @@
+"""Unit coverage for the ``_fetch_git`` marketplace fetcher.
+
+Covers:
+- mock ``GitCache.get_checkout`` is called with the right URL, ref, sparse_paths, env
+- ADO URL routes via subprocess git + auth_resolver-built env
+- generic git URL with no APM creds -> empty/inherited env passed through
+- missing ``marketplace.json`` in checkout -> ``None``
+- ``GitCache`` failure surfaces as ``MarketplaceFetchError``
+- ``_FETCHERS`` dispatch regression-trap: dict[kind] points at the right callable
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apm_cli.marketplace.client import (
+    _FETCHERS,
+    _fetch_git,
+    _fetch_github,
+    _fetch_gitlab,
+    _fetch_local,
+)
+from apm_cli.marketplace.errors import MarketplaceFetchError
+from apm_cli.marketplace.models import MarketplaceSource
+
+
+def _git_source(url: str, name: str = "acme", ref: str = "main") -> MarketplaceSource:
+    return MarketplaceSource(name=name, url=url, ref=ref)
+
+
+@pytest.fixture
+def fake_host_info():
+    return SimpleNamespace(host="gitea.example.com")
+
+
+@pytest.fixture
+def fake_auth_resolver():
+    resolver = MagicMock()
+    resolver.resolve.return_value = SimpleNamespace(git_env={"GIT_TERMINAL_PROMPT": "0"})
+    return resolver
+
+
+def test_fetch_git_calls_gitcache_with_sparse_path(
+    tmp_path: Path, fake_host_info, fake_auth_resolver
+) -> None:
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    (checkout / "marketplace.json").write_text(json.dumps({"name": "acme", "plugins": []}))
+
+    gitcache_mock = MagicMock()
+    gitcache_mock.get_checkout.return_value = str(checkout)
+    with (
+        patch("apm_cli.cache.git_cache.GitCache", return_value=gitcache_mock),
+        patch("apm_cli.cache.paths.get_cache_root", return_value=tmp_path / "cache"),
+    ):
+        result = _fetch_git(
+            _git_source("https://gitea.example.com/org/repo.git"),
+            "marketplace.json",
+            host_info=fake_host_info,
+            auth_resolver=fake_auth_resolver,
+        )
+
+    assert result == {"name": "acme", "plugins": []}
+    fake_auth_resolver.resolve.assert_called_once()
+    call_kwargs = gitcache_mock.get_checkout.call_args.kwargs
+    assert call_kwargs["env"] == {"GIT_TERMINAL_PROMPT": "0"}
+
+
+def test_fetch_git_ado_url_routes_via_subprocess(
+    tmp_path: Path, fake_host_info, fake_auth_resolver
+) -> None:
+    """ADO URLs go through ``GitCache`` -- not the REST API."""
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    (checkout / "marketplace.json").write_text("{}")
+
+    gitcache_mock = MagicMock()
+    gitcache_mock.get_checkout.return_value = str(checkout)
+    fake_auth_resolver.resolve.return_value = SimpleNamespace(
+        git_env={
+            "GIT_CONFIG_KEY_0": "http.extraheader",
+            "GIT_CONFIG_VALUE_0": "AUTHORIZATION: bearer xxx",
+        }
+    )
+
+    with (
+        patch("apm_cli.cache.git_cache.GitCache", return_value=gitcache_mock),
+        patch("apm_cli.cache.paths.get_cache_root", return_value=tmp_path / "cache"),
+    ):
+        result = _fetch_git(
+            _git_source("https://dev.azure.com/org/project/_git/repo"),
+            "marketplace.json",
+            host_info=SimpleNamespace(host="dev.azure.com"),
+            auth_resolver=fake_auth_resolver,
+        )
+
+    assert result == {}
+    env = gitcache_mock.get_checkout.call_args.kwargs["env"]
+    assert "GIT_CONFIG_VALUE_0" in env
+
+
+def test_fetch_git_returns_none_when_manifest_missing(
+    tmp_path: Path, fake_host_info, fake_auth_resolver
+) -> None:
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    # No marketplace.json on disk
+
+    gitcache_mock = MagicMock()
+    gitcache_mock.get_checkout.return_value = str(checkout)
+    with (
+        patch("apm_cli.cache.git_cache.GitCache", return_value=gitcache_mock),
+        patch("apm_cli.cache.paths.get_cache_root", return_value=tmp_path / "cache"),
+    ):
+        result = _fetch_git(
+            _git_source("https://gitea.example.com/org/repo.git"),
+            "marketplace.json",
+            host_info=fake_host_info,
+            auth_resolver=fake_auth_resolver,
+        )
+
+    assert result is None
+
+
+def test_fetch_git_remote_not_found_returns_none(
+    tmp_path: Path, fake_host_info, fake_auth_resolver
+) -> None:
+    """``GitCache`` raising 'not found' surfaces as a soft None for path auto-detection."""
+    err = subprocess.CalledProcessError(returncode=128, cmd=["git"], stderr=b"remote ref not found")
+    gitcache_mock = MagicMock()
+    gitcache_mock.get_checkout.side_effect = err
+    with (
+        patch("apm_cli.cache.git_cache.GitCache", return_value=gitcache_mock),
+        patch("apm_cli.cache.paths.get_cache_root", return_value=tmp_path / "cache"),
+    ):
+        result = _fetch_git(
+            _git_source("https://gitea.example.com/org/repo.git"),
+            "marketplace.json",
+            host_info=fake_host_info,
+            auth_resolver=fake_auth_resolver,
+        )
+
+    assert result is None
+
+
+def test_fetch_git_subprocess_failure_raises_marketplace_fetch_error(
+    tmp_path: Path, fake_host_info, fake_auth_resolver
+) -> None:
+    err = subprocess.CalledProcessError(returncode=128, cmd=["git"], stderr=b"auth failed")
+    gitcache_mock = MagicMock()
+    gitcache_mock.get_checkout.side_effect = err
+    with (
+        patch("apm_cli.cache.git_cache.GitCache", return_value=gitcache_mock),
+        patch("apm_cli.cache.paths.get_cache_root", return_value=tmp_path / "cache"),
+    ):
+        with pytest.raises(MarketplaceFetchError, match="git fetch failed"):
+            _fetch_git(
+                _git_source("https://gitea.example.com/org/repo.git"),
+                "marketplace.json",
+                host_info=fake_host_info,
+                auth_resolver=fake_auth_resolver,
+            )
+
+
+def test_fetchers_dispatch_table_routes_kinds_to_correct_callable() -> None:
+    """Regression trap: locking the trust boundary into _FETCHERS."""
+    assert _FETCHERS["git"] is _fetch_git
+    assert _FETCHERS["local"] is _fetch_local
+    assert _FETCHERS["github"] is _fetch_github
+    assert _FETCHERS["gitlab"] is _fetch_gitlab
+    # Defensive: no extra entries silently appearing.
+    assert set(_FETCHERS) == {"github", "gitlab", "git", "local"}

--- a/tests/unit/marketplace/test_client_local.py
+++ b/tests/unit/marketplace/test_client_local.py
@@ -1,0 +1,142 @@
+"""Unit coverage for the ``_fetch_local`` marketplace fetcher.
+
+Covers:
+- bare-repo path (mocked ``git show``)
+- working-dir path (direct read)
+- traversal in ``source.path`` rejected
+- symlink-escape from working-dir read raises ``MarketplaceFetchError``
+- invalid ``ref`` rejected by ``_validate_ref``
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from apm_cli.marketplace.client import (
+    _fetch_local,
+    _fetch_local_direct_read,
+    _validate_ref,
+)
+from apm_cli.marketplace.errors import MarketplaceFetchError
+from apm_cli.marketplace.models import MarketplaceSource
+
+
+def _local_source(name: str, path: Path, ref: str = "main") -> MarketplaceSource:
+    return MarketplaceSource(name=name, url=f"file://{path}", ref=ref)
+
+
+def test_fetch_local_bare_repo_via_git_show(tmp_path: Path) -> None:
+    """Bare repo: ``git show`` returns blob content, parsed as JSON."""
+    bare = tmp_path / "mkt.git"
+    bare.mkdir()
+    (bare / "HEAD").write_text("ref: refs/heads/main")
+    (bare / "objects").mkdir()
+    manifest = {"name": "acme", "plugins": []}
+
+    completed = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=json.dumps(manifest).encode(), stderr=b""
+    )
+    with patch("apm_cli.marketplace.client.subprocess.run", return_value=completed) as run_mock:
+        result = _fetch_local(_local_source("acme", bare), "marketplace.json")
+
+    assert result == manifest
+    args = run_mock.call_args.args[0]
+    assert args[0] == "git"
+    assert "--git-dir" in args
+    assert "core.hooksPath=/dev/null" in args
+    assert "main:marketplace.json" in args
+
+
+def test_fetch_local_working_dir_direct_read(tmp_path: Path) -> None:
+    """Working-dir layout: read marketplace.json directly from disk."""
+    repo = tmp_path / "mkt"
+    repo.mkdir()
+    manifest = {"name": "acme", "plugins": []}
+    (repo / "marketplace.json").write_text(json.dumps(manifest))
+
+    result = _fetch_local(_local_source("acme", repo), "marketplace.json")
+    assert result == manifest
+
+
+def test_fetch_local_missing_path_raises(tmp_path: Path) -> None:
+    """Path that does not exist raises ``MarketplaceFetchError``."""
+    with pytest.raises(MarketplaceFetchError, match="does not exist"):
+        _fetch_local(_local_source("acme", tmp_path / "missing"), "marketplace.json")
+
+
+def test_fetch_local_symlink_escape_blocked(tmp_path: Path) -> None:
+    """Symlink that points outside the repo root must be rejected."""
+    repo = tmp_path / "mkt"
+    repo.mkdir()
+    secret = tmp_path / "secret.json"
+    secret.write_text('{"leaked": true}')
+    link = repo / "marketplace.json"
+    os.symlink(secret, link)
+
+    with pytest.raises(MarketplaceFetchError, match="escapes marketplace root"):
+        _fetch_local_direct_read(_local_source("acme", repo), "marketplace.json", repo.resolve())
+
+
+@pytest.mark.parametrize(
+    "bad_ref",
+    [
+        "",
+        "-rf",
+        "main; rm -rf /",
+        "main:other",
+        "main with space",
+        "..",
+    ],
+)
+def test_validate_ref_rejects_unsafe_inputs(bad_ref: str) -> None:
+    with pytest.raises(MarketplaceFetchError, match="Invalid git ref"):
+        _validate_ref(bad_ref, "acme")
+
+
+@pytest.mark.parametrize(
+    "good_ref",
+    [
+        "main",
+        "v1.2.3",
+        "feature/local-mkt",
+        "release-2024.01",
+        "abc123",
+    ],
+)
+def test_validate_ref_accepts_safe_inputs(good_ref: str) -> None:
+    assert _validate_ref(good_ref, "acme") == good_ref
+
+
+def test_fetch_local_git_show_returns_none_when_path_missing(tmp_path: Path) -> None:
+    """``git show`` reports 'does not exist' -> fetcher returns ``None`` so caller can probe next path."""
+    bare = tmp_path / "mkt.git"
+    bare.mkdir()
+    (bare / "HEAD").write_text("ref: refs/heads/main")
+    (bare / "objects").mkdir()
+
+    completed = subprocess.CompletedProcess(
+        args=[],
+        returncode=128,
+        stdout=b"",
+        stderr=b"fatal: path 'marketplace.json' does not exist in 'main'",
+    )
+    with patch("apm_cli.marketplace.client.subprocess.run", return_value=completed):
+        result = _fetch_local(_local_source("acme", bare), "marketplace.json")
+
+    assert result is None
+
+
+def test_fetch_local_traversal_in_file_path_is_blocked(tmp_path: Path) -> None:
+    """Working-dir read with traversal segments in file_path must be rejected."""
+    repo = tmp_path / "mkt"
+    repo.mkdir()
+    (tmp_path / "secret.json").write_text('{"leaked": true}')
+
+    with pytest.raises(MarketplaceFetchError, match="escapes marketplace root"):
+        _fetch_local_direct_read(_local_source("acme", repo), "../secret.json", repo.resolve())

--- a/tests/unit/marketplace/test_legacy_migration.py
+++ b/tests/unit/marketplace/test_legacy_migration.py
@@ -1,0 +1,79 @@
+"""Legacy ``marketplaces.json`` migration test.
+
+Loads a fixture with the pre-PR shape (``{owner, repo, host?, branch?}``),
+round-trips through ``_load`` + ``_save``, and asserts the resulting JSON
+file has the new URL-first shape while still emitting legacy mirror fields
+for one release of downgrade safety.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from apm_cli.marketplace import registry
+from apm_cli.marketplace.models import MarketplaceSource
+
+FIXTURE = Path(__file__).parent / "fixtures" / "legacy_marketplaces.json"
+
+
+@pytest.fixture
+def isolated_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point the registry at a temp directory with a pre-seeded legacy fixture."""
+    config_dir = tmp_path / "apm-config"
+    config_dir.mkdir()
+    shutil.copy(FIXTURE, config_dir / "marketplaces.json")
+
+    monkeypatch.setattr(registry, "_registry_cache", None)
+    with (
+        patch("apm_cli.config.CONFIG_DIR", str(config_dir)),
+        patch("apm_cli.config.ensure_config_exists", lambda: None),
+    ):
+        yield config_dir
+
+
+def test_legacy_fixture_loads_and_upgrades_to_url_shape(isolated_config: Path) -> None:
+    sources = registry._load()
+    assert len(sources) == 3
+
+    by_name = {s.name: s for s in sources}
+
+    acme = by_name["acme-default"]
+    assert acme.url == "https://github.com/acme/marketplace"
+    assert acme.ref == "main"
+    assert acme.kind == "github"
+
+    ghes = by_name["ghes-mkt"]
+    assert ghes.url == "https://ghe.contoso.com/team/internal-marketplace"
+    assert ghes.ref == "release"
+
+    gitlab = by_name["gitlab-mkt"]
+    assert gitlab.url == "https://gitlab.com/group/sub/tools"
+    assert gitlab.ref == "develop"
+    assert gitlab.path == "custom/marketplace.json"
+
+
+def test_legacy_round_trip_emits_url_and_legacy_mirror(isolated_config: Path) -> None:
+    sources = registry._load()
+    registry._save(sources)
+
+    path = isolated_config / "marketplaces.json"
+    raw = json.loads(path.read_text())
+
+    for entry in raw["marketplaces"]:
+        # The new canonical field is present
+        assert "url" in entry, f"entry {entry['name']!r} missing url after save"
+        # Legacy mirror fields preserved for one release
+        assert "owner" in entry
+        assert "repo" in entry
+
+
+def test_branch_field_accepted_as_ref_alias() -> None:
+    src = MarketplaceSource.from_dict(
+        {"name": "alias-mkt", "owner": "a", "repo": "b", "branch": "feature/x"}
+    )
+    assert src.ref == "feature/x"

--- a/tests/unit/marketplace/test_marketplace_client.py
+++ b/tests/unit/marketplace/test_marketplace_client.py
@@ -722,10 +722,13 @@ class TestCacheKey:
     def test_non_default_host_includes_host(self):
         source = MarketplaceSource(name="skills", owner="o", repo="r", host="ghes.corp.com")
         key = client_mod._cache_key(source)
-        # Host must appear in the key (form may vary: kind-prefixed or host-prefixed).
-        assert "ghes.corp.com" in key or "ghes_corp_com" in key
-        assert key.endswith("skills")
-        assert key != "skills"
+        # Assert exact key structure: ``<kind>__<host>__<name>``. Using equality
+        # (not substring containment) avoids CodeQL's "incomplete URL substring
+        # sanitization" pattern and guards against accidental host-collision bugs.
+        segments = key.split("__")
+        assert segments[0] in {"git", "ghes_corp_com"}
+        assert segments[-1] == "skills"
+        assert any(seg in {"ghes.corp.com", "ghes_corp_com"} for seg in segments[1:-1])
 
     def test_different_hosts_different_keys(self):
         s1 = MarketplaceSource(name="mkt", owner="o", repo="r", host="a.com")

--- a/tests/unit/marketplace/test_marketplace_client.py
+++ b/tests/unit/marketplace/test_marketplace_client.py
@@ -596,7 +596,14 @@ class TestDirectFetchHostRouting:
         assert len(captured_urls) == 1
         assert "/api/v3/repos/org/plugins/contents/" in captured_urls[0]
 
-    def test_generic_host_not_gitlab_is_rejected_before_request(self):
+    def test_generic_host_routes_through_git_fetcher(self):
+        """A 'generic' host (e.g. Bitbucket Cloud) now routes to _fetch_git, not rejected.
+
+        Behaviour change: previously APM hard-rejected non-GitHub/non-GitLab hosts
+        to avoid leaking GitHub PATs. Now generic hosts route through GitCache,
+        and AuthResolver itself enforces token scoping (returns token=None for
+        kind="generic"), so no credential leak is possible.
+        """
         source = MarketplaceSource(
             name="bb",
             owner="o",
@@ -604,17 +611,19 @@ class TestDirectFetchHostRouting:
             host="bitbucket.org",
         )
 
+        mock_git = MagicMock(return_value=None)
         with (
             patch("apm_cli.deps.registry_proxy.RegistryConfig.from_env", return_value=None),
             patch("apm_cli.marketplace.client.requests.get") as mock_get,
-            pytest.raises(MarketplaceFetchError) as excinfo,
+            patch.dict("apm_cli.marketplace.client._FETCHERS", {"git": mock_git}),
         ):
             resolver = AuthResolver()
-            client_mod._fetch_file(source, "marketplace.json", auth_resolver=resolver)
+            result = client_mod._fetch_file(source, "marketplace.json", auth_resolver=resolver)
+            mock_git.assert_called_once()
 
+        # No HTTP request should be issued -- generic git uses subprocess via GitCache.
         mock_get.assert_not_called()
-        assert _quoted_hosts(str(excinfo.value)) == {"bitbucket.org"}
-        assert "not a supported marketplace source" in str(excinfo.value)
+        assert result is None
 
     def test_proxy_success_does_not_call_requests_get(self):
         """PROXY_REGISTRY_URL path: no direct GitHub/GitLab HTTP when proxy returns JSON."""
@@ -713,7 +722,8 @@ class TestCacheKey:
     def test_non_default_host_includes_host(self):
         source = MarketplaceSource(name="skills", owner="o", repo="r", host="ghes.corp.com")
         key = client_mod._cache_key(source)
-        assert key.startswith("ghes.corp.com") or key.startswith("ghes_corp_com")
+        # Host must appear in the key (form may vary: kind-prefixed or host-prefixed).
+        assert "ghes.corp.com" in key or "ghes_corp_com" in key
         assert key.endswith("skills")
         assert key != "skills"
 
@@ -766,9 +776,16 @@ class TestFetchFileHostKindGuard:
     aimed at an unrelated host, leaking credentials.
     """
 
-    def test_generic_host_rejected_before_request(self):
-        """A 'generic' kind host raises and never fetches."""
-        from unittest.mock import patch
+    def test_generic_host_routes_through_git_fetcher(self):
+        """A 'generic' kind host routes through _fetch_git, never the GitHub API.
+
+        Defense-in-depth: even though _fetch_git no longer issues an
+        Authorization header by classification, this test asserts no
+        requests.get() (the GitHub API surface) is ever called for a
+        non-GitHub/non-GitLab host -- so a future regression that
+        accidentally routed back through the API path would be caught.
+        """
+        from unittest.mock import MagicMock, patch
 
         source = MarketplaceSource(
             name="evil",
@@ -777,17 +794,17 @@ class TestFetchFileHostKindGuard:
             branch="main",
             host="bitbucket.org",
         )
+        mock_git = MagicMock(return_value=None)
         with (
             patch("apm_cli.deps.registry_proxy.RegistryConfig.from_env", return_value=None),
             patch("apm_cli.marketplace.client.requests.get") as mock_get,
-            pytest.raises(MarketplaceFetchError) as excinfo,
+            patch.dict("apm_cli.marketplace.client._FETCHERS", {"git": mock_git}),
         ):
             client_mod._fetch_file(source, "marketplace.json")
+            mock_git.assert_called_once()
 
-        # No HTTP request should have been issued (no credential leakage).
+        # No HTTP request should have been issued -- generic-git uses GitCache subprocess.
         mock_get.assert_not_called()
-        assert _quoted_hosts(str(excinfo.value)) == {"bitbucket.org"}
-        assert "not a supported marketplace source" in str(excinfo.value)
 
     def test_github_host_passes_guard(self):
         """github.com sources are untouched by the guard."""

--- a/tests/unit/marketplace/test_marketplace_commands.py
+++ b/tests/unit/marketplace/test_marketplace_commands.py
@@ -366,20 +366,31 @@ class TestMarketplaceAdd:
         assert probe_source.owner == "epm-ease"
         assert probe_source.repo == "apm-registry"
 
-    def test_add_rejects_generic_host_without_gitlab_classification(self, runner):
-        """Unknown FQDN stays generic; registration fails with GHES and GitLab hints."""
+    @patch("apm_cli.marketplace.client.fetch_marketplace")
+    @patch("apm_cli.marketplace.client._auto_detect_path")
+    def test_add_accepts_generic_host_via_git_fetcher(self, mock_detect, mock_fetch, runner):
+        """Unknown FQDN is now accepted: kind=git routes through GitCache.
+
+        Before this change, an unknown host was rejected with an explicit
+        "not supported" error and a GHES/GitLab export hint. The trust
+        gate now applies only to kinds that would forward an APM token
+        (github/gitlab); the subprocess git path uses no APM credentials
+        unless AuthResolver.classify_host recognises the host.
+        """
         from apm_cli.commands.marketplace import marketplace
+
+        mock_detect.return_value = "marketplace.json"
+        mock_fetch.return_value = MarketplaceManifest(
+            name="m", plugins=(MarketplacePlugin(name="p1"),)
+        )
 
         result = runner.invoke(
             marketplace, ["add", "https://git.example.com/acme/team/plugin-marketplace"]
         )
-        assert result.exit_code != 0
-        assert _quoted_hosts(result.output) == {"git.example.com"}
-        assert "not supported" in result.output.lower()
-        normalized = " ".join(result.output.split())
-        assert "export GITHUB_HOST=git.example.com" in normalized
-        assert "export GITLAB_HOST=git.example.com" in normalized
-        assert "APM_GITLAB_HOSTS" in result.output
+        assert result.exit_code == 0, result.output
+        probe_source = mock_detect.call_args[0][0]
+        assert probe_source.kind == "git"
+        assert probe_source.host == "git.example.com"
 
     def test_add_rejects_http_url(self, runner):
         """Plain HTTP URLs are rejected -- no --allow-insecure escape hatch."""
@@ -458,41 +469,61 @@ class TestMarketplaceAdd:
             "classification is owned by AuthResolver.classify_host"
         )
 
-    def test_untrusted_host_error_has_action_in_first_sentence(self, runner):
-        """Round 3 panel: untrusted-host error leads with the outcome and the fix,
-        not internal security rationale."""
+    @patch("apm_cli.marketplace.client.fetch_marketplace")
+    @patch("apm_cli.marketplace.client._auto_detect_path")
+    def test_unknown_host_no_longer_rejects_with_export_hint(self, mock_detect, mock_fetch, runner):
+        """Replacement for the round-3 'untrusted host' regression trap.
+
+        Before this change, an unknown host produced a rejection message
+        leading with 'not supported' plus an ``export GITHUB_HOST=...``
+        hint. With kind-aware routing, the same input is accepted and
+        falls through to the subprocess-git fetcher (no APM token leak
+        possible -- AuthResolver only emits credentials matching a
+        classified host).
+        """
         from apm_cli.commands.marketplace import marketplace
+
+        mock_detect.return_value = "marketplace.json"
+        mock_fetch.return_value = MarketplaceManifest(
+            name="m", plugins=(MarketplacePlugin(name="p1"),)
+        )
 
         result = runner.invoke(
             marketplace,
             ["add", "https://git.example.com/acme/team/plugin-marketplace"],
         )
-        assert result.exit_code != 0
-        # First non-empty line must state the outcome ("not supported") and name
-        # the host. Security rationale ("forward GitHub credentials", "credential
-        # leak", etc.) must NOT appear in the default error path.
-        first_line = next((line for line in result.output.splitlines() if line.strip()), "").lower()
-        assert "not supported" in first_line
-        assert _quoted_hosts(first_line) == {"git.example.com"}
-        assert "credential" not in result.output.lower()
-        assert "leak" not in result.output.lower()
+        assert result.exit_code == 0, result.output
+        normalized = " ".join(result.output.split())
+        # No 'not supported' rejection in the success path.
+        assert "not supported" not in result.output.lower()
+        # No misleading 'export GITHUB_HOST=...' hint.
+        assert "export GITHUB_HOST=" not in normalized
 
-    def test_untrusted_host_error_includes_copyable_export_and_rerun(self, runner):
-        """Round 4 panel (devx-ux required): GHES users must get a one-copy-paste
-        recovery -- the resolved host appears in an `export GITHUB_HOST=...` line
-        and the original repo string appears in the `apm marketplace add ...`
-        re-run line."""
+    @patch("apm_cli.marketplace.client.fetch_marketplace")
+    @patch("apm_cli.marketplace.client._auto_detect_path")
+    def test_ghes_shorthand_routes_through_git_fetcher_when_unclassified(
+        self, mock_detect, mock_fetch, runner
+    ):
+        """Replacement for the round-4 'copyable export and rerun' trap.
+
+        Before this change, an unconfigured GHES host produced a hard
+        rejection plus a copy-paste GHES setup recipe. With kind-aware
+        routing, the same input is accepted; the user can still set
+        GITHUB_HOST explicitly if they want the Contents-API code path
+        (faster) but generic git via GitCache is the safe default.
+        """
         from apm_cli.commands.marketplace import marketplace
 
-        result = runner.invoke(
-            marketplace,
-            ["add", "myghes.corp/org/repo"],
+        mock_detect.return_value = "marketplace.json"
+        mock_fetch.return_value = MarketplaceManifest(
+            name="m", plugins=(MarketplacePlugin(name="p1"),)
         )
-        assert result.exit_code != 0
-        normalized = " ".join(result.output.split())
-        assert "export GITHUB_HOST=myghes.corp" in normalized
-        assert "export GITLAB_HOST=myghes.corp" in normalized
-        assert "apm marketplace add myghes.corp/org/repo" in normalized
+
+        result = runner.invoke(marketplace, ["add", "myghes.corp/org/repo"])
+        assert result.exit_code == 0, result.output
+        probe_source = mock_detect.call_args[0][0]
+        assert probe_source.kind == "git"
+        assert probe_source.host == "myghes.corp"
 
     def test_path_traversal_error_message_no_double_exception_text(self, runner):
         """Round 3 panel: PathTraversalError message must not embed the raw

--- a/tests/unit/marketplace/test_marketplace_commands_phase3.py
+++ b/tests/unit/marketplace/test_marketplace_commands_phase3.py
@@ -289,22 +289,18 @@ class TestParseMarketplaceRepo:
     def test_owner_repo_simple(self) -> None:
         from apm_cli.commands.marketplace import _parse_marketplace_repo
 
-        owner, repo, host = _parse_marketplace_repo("acme/plugins", None)
-        assert owner == "acme"
-        assert repo == "plugins"
-        assert host is None
+        url, kind, host = _parse_marketplace_repo("acme/plugins", None)
+        assert url == "https://github.com/acme/plugins"
+        assert kind == "github"
+        assert host == "github.com"
 
     def test_https_url_parsed(self) -> None:
-        from urllib.parse import urlparse
-
         from apm_cli.commands.marketplace import _parse_marketplace_repo
 
-        owner, repo, host = _parse_marketplace_repo("https://github.com/acme/plugins", None)
-        assert owner == "acme"
-        assert repo == "plugins"
-        # host should be github.com - verified through urlparse
-        parsed = urlparse(f"https://{host}")
-        assert parsed.hostname == "github.com"
+        url, kind, host = _parse_marketplace_repo("https://github.com/acme/plugins", None)
+        assert url == "https://github.com/acme/plugins"
+        assert kind == "github"
+        assert host == "github.com"
 
     def test_conflicting_host_flag_raises(self) -> None:
         from apm_cli.commands.marketplace import _parse_marketplace_repo
@@ -330,10 +326,14 @@ class TestParseMarketplaceRepo:
             _parse_marketplace_repo("github.com/only-repo", None)
 
     def test_dot_git_suffix_stripped(self) -> None:
+        # The model strips ``.git`` when deriving owner/repo from the URL;
+        # the parser preserves it in the URL itself.
         from apm_cli.commands.marketplace import _parse_marketplace_repo
+        from apm_cli.marketplace.models import MarketplaceSource
 
-        _, repo, _ = _parse_marketplace_repo("https://github.com/acme/plugins.git", None)
-        assert repo == "plugins"
+        url, _, _ = _parse_marketplace_repo("https://github.com/acme/plugins.git", None)
+        src = MarketplaceSource(name="x", url=url)
+        assert src.repo == "plugins"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/marketplace/test_marketplace_commands_surface.py
+++ b/tests/unit/marketplace/test_marketplace_commands_surface.py
@@ -289,22 +289,18 @@ class TestParseMarketplaceRepo:
     def test_owner_repo_simple(self) -> None:
         from apm_cli.commands.marketplace import _parse_marketplace_repo
 
-        owner, repo, host = _parse_marketplace_repo("acme/plugins", None)
-        assert owner == "acme"
-        assert repo == "plugins"
-        assert host is None
+        url, kind, host = _parse_marketplace_repo("acme/plugins", None)
+        assert url == "https://github.com/acme/plugins"
+        assert kind == "github"
+        assert host == "github.com"
 
     def test_https_url_parsed(self) -> None:
-        from urllib.parse import urlparse
-
         from apm_cli.commands.marketplace import _parse_marketplace_repo
 
-        owner, repo, host = _parse_marketplace_repo("https://github.com/acme/plugins", None)
-        assert owner == "acme"
-        assert repo == "plugins"
-        # host should be github.com - verified through urlparse
-        parsed = urlparse(f"https://{host}")
-        assert parsed.hostname == "github.com"
+        url, kind, host = _parse_marketplace_repo("https://github.com/acme/plugins", None)
+        assert url == "https://github.com/acme/plugins"
+        assert kind == "github"
+        assert host == "github.com"
 
     def test_conflicting_host_flag_raises(self) -> None:
         from apm_cli.commands.marketplace import _parse_marketplace_repo
@@ -330,10 +326,14 @@ class TestParseMarketplaceRepo:
             _parse_marketplace_repo("github.com/only-repo", None)
 
     def test_dot_git_suffix_stripped(self) -> None:
+        # The model strips ``.git`` when deriving owner/repo from the URL;
+        # the parser preserves it in the URL itself.
         from apm_cli.commands.marketplace import _parse_marketplace_repo
+        from apm_cli.marketplace.models import MarketplaceSource
 
-        _, repo, _ = _parse_marketplace_repo("https://github.com/acme/plugins.git", None)
-        assert repo == "plugins"
+        url, _, _ = _parse_marketplace_repo("https://github.com/acme/plugins.git", None)
+        src = MarketplaceSource(name="x", url=url)
+        assert src.repo == "plugins"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/marketplace/test_marketplace_models.py
+++ b/tests/unit/marketplace/test_marketplace_models.py
@@ -30,7 +30,13 @@ class TestMarketplaceSource:
     def test_to_dict_defaults(self):
         src = MarketplaceSource(name="acme", owner="acme-org", repo="plugins")
         d = src.to_dict()
-        assert d == {"name": "acme", "owner": "acme-org", "repo": "plugins"}
+        # URL is synthesised from legacy fields, plus legacy mirror retained for downgrade safety
+        assert d == {
+            "name": "acme",
+            "url": "https://github.com/acme-org/plugins",
+            "owner": "acme-org",
+            "repo": "plugins",
+        }
         assert "host" not in d  # default omitted
         assert "branch" not in d
 

--- a/tests/unit/marketplace/test_parser.py
+++ b/tests/unit/marketplace/test_parser.py
@@ -74,19 +74,25 @@ def test_https_untrusted_host_classified_as_git() -> None:
 def test_https_github_classified_as_github() -> None:
     url, kind, _host = _parse_marketplace_source("https://github.com/owner/repo", host_flag=None)
     assert kind == "github"
-    assert "github.com/owner/repo" in url
+    parsed = urlsplit(url)
+    assert parsed.hostname == "github.com"
+    assert parsed.path == "/owner/repo"
 
 
 def test_owner_repo_shorthand_classified_as_github_by_default() -> None:
     url, kind, _host = _parse_marketplace_source("owner/repo", host_flag=None)
     assert kind == "github"
-    assert "owner/repo" in url
+    parsed = urlsplit(url)
+    assert parsed.hostname == "github.com"
+    assert parsed.path.rstrip("/") == "/owner/repo"
 
 
 def test_host_owner_repo_shorthand_uses_host_flag() -> None:
     url, kind, _host = _parse_marketplace_source("ghe.contoso.com/team/repo", host_flag=None)
     # GHES classification depends on env; the key invariant is that the host is preserved.
-    assert "ghe.contoso.com/team/repo" in url
+    parsed = urlsplit(url)
+    assert parsed.hostname == "ghe.contoso.com"
+    assert parsed.path.rstrip("/") == "/team/repo"
     assert kind in ("github", "git")
 
 
@@ -97,7 +103,9 @@ def test_single_segment_input_rejected() -> None:
 
 def test_explicit_host_flag_combined_with_owner_repo() -> None:
     url, _kind, _host = _parse_marketplace_source("owner/repo", host_flag="ghes.example.com")
-    assert "ghes.example.com/owner/repo" in url
+    parsed = urlsplit(url)
+    assert parsed.hostname == "ghes.example.com"
+    assert parsed.path.rstrip("/") == "/owner/repo"
 
 
 def test_https_ado_url_classified_as_git() -> None:

--- a/tests/unit/marketplace/test_parser.py
+++ b/tests/unit/marketplace/test_parser.py
@@ -1,0 +1,107 @@
+"""Unit coverage for the URL-first marketplace source parser.
+
+Covers:
+- local absolute / relative / ``file://`` / ``~/`` paths
+- Windows local-path cases (drive letter, .\\, ~\\)
+- SCP-like ``git@host:org/repo.git`` SSH
+- HTTPS to untrusted host classified as kind=git (was: rejected pre-PR)
+- single-segment input -> ValueError
+- existing GitHub/GitLab cases still pass
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from apm_cli.commands.marketplace import _parse_marketplace_source
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "/srv/marketplaces/agent-forge",
+        "./relative/path",
+        "../up/path",
+        "~/code/marketplace",
+        "~",
+        "file:///srv/marketplaces/agent-forge.git",
+    ],
+)
+def test_local_paths_classified_as_local(raw: str) -> None:
+    url, kind, host = _parse_marketplace_source(raw, host_flag=None)
+    assert kind == "local"
+    assert url.startswith("file://")
+    assert host is None
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        r"C:\repos\mkt",
+        r"C:/repos/mkt",
+        r".\local",
+    ],
+)
+def test_windows_paths_classified_as_local(raw: str) -> None:
+    url, kind, _host = _parse_marketplace_source(raw, host_flag=None)
+    assert kind == "local"
+    assert url.startswith("file://") or url.startswith("file:") or url.startswith(("./", "../"))
+
+
+def test_scp_ssh_url_classified_as_git() -> None:
+    url, kind, host = _parse_marketplace_source(
+        "git@gitea.example.com:org/repo.git", host_flag=None
+    )
+    assert kind == "git"
+    assert "gitea.example.com" in url
+    assert host == "gitea.example.com"
+
+
+def test_https_untrusted_host_classified_as_git() -> None:
+    """Previously rejected: HTTPS to a host APM doesn't classify as github/gitlab now flows through."""
+    url, kind, host = _parse_marketplace_source(
+        "https://gitea.example.com/org/repo.git", host_flag=None
+    )
+    assert kind == "git"
+    assert url == "https://gitea.example.com/org/repo.git"
+    assert host == "gitea.example.com"
+
+
+def test_https_github_classified_as_github() -> None:
+    url, kind, _host = _parse_marketplace_source("https://github.com/owner/repo", host_flag=None)
+    assert kind == "github"
+    assert "github.com/owner/repo" in url
+
+
+def test_owner_repo_shorthand_classified_as_github_by_default() -> None:
+    url, kind, _host = _parse_marketplace_source("owner/repo", host_flag=None)
+    assert kind == "github"
+    assert "owner/repo" in url
+
+
+def test_host_owner_repo_shorthand_uses_host_flag() -> None:
+    url, kind, _host = _parse_marketplace_source("ghe.contoso.com/team/repo", host_flag=None)
+    # GHES classification depends on env; the key invariant is that the host is preserved.
+    assert "ghe.contoso.com/team/repo" in url
+    assert kind in ("github", "git")
+
+
+def test_single_segment_input_rejected() -> None:
+    with pytest.raises(ValueError):
+        _parse_marketplace_source("repo-with-no-slash", host_flag=None)
+
+
+def test_explicit_host_flag_combined_with_owner_repo() -> None:
+    url, _kind, _host = _parse_marketplace_source("owner/repo", host_flag="ghes.example.com")
+    assert "ghes.example.com/owner/repo" in url
+
+
+def test_https_ado_url_classified_as_git() -> None:
+    """ADO is no longer rejected at the parser layer."""
+    url, kind, host = _parse_marketplace_source(
+        "https://dev.azure.com/contoso/eng/_git/agent-forge", host_flag=None
+    )
+    # ADO classification routes through "git" kind so subprocess-git fetcher handles it
+    assert kind == "git"
+    assert "dev.azure.com" in url
+    assert host == "dev.azure.com"

--- a/tests/unit/marketplace/test_parser.py
+++ b/tests/unit/marketplace/test_parser.py
@@ -11,6 +11,8 @@ Covers:
 
 from __future__ import annotations
 
+from urllib.parse import urlsplit
+
 import pytest
 
 from apm_cli.commands.marketplace import _parse_marketplace_source
@@ -53,7 +55,9 @@ def test_scp_ssh_url_classified_as_git() -> None:
         "git@gitea.example.com:org/repo.git", host_flag=None
     )
     assert kind == "git"
-    assert "gitea.example.com" in url
+    # SCP-style remains as-is (no scheme); assert exact form to avoid
+    # arbitrary-substring matches CodeQL flags as URL-sanitization weakness.
+    assert url == "git@gitea.example.com:org/repo.git"
     assert host == "gitea.example.com"
 
 
@@ -101,7 +105,8 @@ def test_https_ado_url_classified_as_git() -> None:
     url, kind, host = _parse_marketplace_source(
         "https://dev.azure.com/contoso/eng/_git/agent-forge", host_flag=None
     )
-    # ADO classification routes through "git" kind so subprocess-git fetcher handles it
+    # ADO classification routes through "git" kind so subprocess-git fetcher handles it.
     assert kind == "git"
-    assert "dev.azure.com" in url
+    # Use urlsplit().hostname for exact host match (CodeQL: avoid substring sanitization).
+    assert urlsplit(url).hostname == "dev.azure.com"
     assert host == "dev.azure.com"

--- a/tests/unit/marketplace/test_resolver_local_git.py
+++ b/tests/unit/marketplace/test_resolver_local_git.py
@@ -9,6 +9,7 @@ Covers:
 
 from __future__ import annotations
 
+from contextlib import AbstractContextManager
 from pathlib import Path
 from unittest.mock import patch
 
@@ -23,7 +24,9 @@ from apm_cli.marketplace.resolver import resolve_marketplace_plugin
 from apm_cli.models.dependency.reference import DependencyReference
 
 
-def _patch_marketplace(source: MarketplaceSource, plugins: list[MarketplacePlugin]):
+def _patch_marketplace(
+    source: MarketplaceSource, plugins: list[MarketplacePlugin]
+) -> tuple[AbstractContextManager, AbstractContextManager]:
     manifest = MarketplaceManifest(
         name=source.name,
         owner_name="",
@@ -35,7 +38,7 @@ def _patch_marketplace(source: MarketplaceSource, plugins: list[MarketplacePlugi
     )
 
 
-def _plugin(name: str, source) -> MarketplacePlugin:
+def _plugin(name: str, source: object) -> MarketplacePlugin:
     return MarketplacePlugin(name=name, source=source)
 
 
@@ -98,7 +101,9 @@ def test_generic_git_marketplace_relative_source_builds_virtual_path_dep_ref() -
     dep_ref = result.dependency_reference
     assert dep_ref.virtual_path == "skills/my-skill"
     assert dep_ref.host == "gitea.example.com"
-    assert "org/repo" in dep_ref.repo_url
+    # repo_url here is the owner/repo identifier, not a full URL; assert on
+    # exact equality rather than substring (CodeQL py/incomplete-url-substring-sanitization).
+    assert dep_ref.repo_url == "org/repo"
 
 
 def test_local_marketplace_absolute_github_source_keeps_github_canonical(tmp_path: Path) -> None:
@@ -109,8 +114,11 @@ def test_local_marketplace_absolute_github_source_keeps_github_canonical(tmp_pat
     with p1, p2:
         result = resolve_marketplace_plugin("absolute", "local-mkt")
 
-    # Absolute github source still resolves to an owner/repo canonical
-    assert "foo/bar" in result.canonical
+    # Absolute github source still resolves to an owner/repo canonical.
+    # Canonical is not a URL but a colon-separated identifier; split and
+    # compare structured segments to avoid substring-style URL matching.
+    parts = result.canonical.split(":")
+    assert any(seg.endswith("foo/bar") for seg in parts)
 
 
 def test_ado_marketplace_relative_source_builds_virtual_path_dep_ref() -> None:

--- a/tests/unit/marketplace/test_resolver_local_git.py
+++ b/tests/unit/marketplace/test_resolver_local_git.py
@@ -1,0 +1,131 @@
+"""Resolver coverage for local + generic-git marketplaces.
+
+Covers:
+- local marketplace + relative plugin source -> local-path canonical recognised by ``DependencyReference.is_local_path``
+- generic-git marketplace + relative plugin source -> virtual-path dep_ref against the marketplace URL
+- local marketplace + absolute github plugin source -> unchanged GitHub canonical
+- github backfill / cross-repo misconfig sentinel unchanged on existing paths
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from apm_cli.marketplace.models import (
+    MarketplaceManifest,
+    MarketplacePlugin,
+    MarketplaceSource,
+)
+from apm_cli.marketplace.resolver import resolve_marketplace_plugin
+from apm_cli.models.dependency.reference import DependencyReference
+
+
+def _patch_marketplace(source: MarketplaceSource, plugins: list[MarketplacePlugin]):
+    manifest = MarketplaceManifest(
+        name=source.name,
+        owner_name="",
+        plugins=plugins,
+    )
+    return (
+        patch("apm_cli.marketplace.resolver.get_marketplace_by_name", return_value=source),
+        patch("apm_cli.marketplace.resolver.fetch_or_cache", return_value=manifest),
+    )
+
+
+def _plugin(name: str, source) -> MarketplacePlugin:
+    return MarketplacePlugin(name=name, source=source)
+
+
+def test_local_marketplace_relative_source_yields_local_path_canonical(tmp_path: Path) -> None:
+    src = MarketplaceSource(name="local-mkt", url=f"file://{tmp_path}", ref="main")
+    plugin = _plugin("my-skill", "./skills/my-skill")
+
+    p1, p2 = _patch_marketplace(src, [plugin])
+    with p1, p2:
+        result = resolve_marketplace_plugin("my-skill", "local-mkt")
+
+    assert result.dependency_reference is None
+    assert result.canonical == f"{tmp_path}/skills/my-skill"
+    assert DependencyReference.is_local_path(result.canonical)
+
+
+def test_local_marketplace_bare_name_source_with_plugin_root(tmp_path: Path) -> None:
+    src = MarketplaceSource(name="local-mkt", url=f"file://{tmp_path}", ref="main")
+    plugin = _plugin("hello", "hello")
+    manifest = MarketplaceManifest(
+        name="local-mkt", owner_name="", plugins=[plugin], plugin_root="plugins"
+    )
+
+    with (
+        patch("apm_cli.marketplace.resolver.get_marketplace_by_name", return_value=src),
+        patch("apm_cli.marketplace.resolver.fetch_or_cache", return_value=manifest),
+    ):
+        result = resolve_marketplace_plugin("hello", "local-mkt")
+
+    assert result.canonical == f"{tmp_path}/plugins/hello"
+
+
+def test_local_marketplace_root_source_returns_repo_root(tmp_path: Path) -> None:
+    src = MarketplaceSource(name="local-mkt", url=f"file://{tmp_path}", ref="main")
+    plugin = _plugin("root-plugin", ".")
+    p1, p2 = _patch_marketplace(src, [plugin])
+    with p1, p2:
+        result = resolve_marketplace_plugin("root-plugin", "local-mkt")
+    assert result.canonical == str(tmp_path)
+
+
+def test_local_marketplace_traversal_in_source_rejected(tmp_path: Path) -> None:
+    src = MarketplaceSource(name="local-mkt", url=f"file://{tmp_path}", ref="main")
+    plugin = _plugin("evil", "../escape")
+    p1, p2 = _patch_marketplace(src, [plugin])
+    with p1, p2, pytest.raises(ValueError):
+        resolve_marketplace_plugin("evil", "local-mkt")
+
+
+def test_generic_git_marketplace_relative_source_builds_virtual_path_dep_ref() -> None:
+    src = MarketplaceSource(
+        name="gitea-mkt", url="https://gitea.example.com/org/repo.git", ref="main"
+    )
+    plugin = _plugin("my-skill", "./skills/my-skill")
+    p1, p2 = _patch_marketplace(src, [plugin])
+    with p1, p2:
+        result = resolve_marketplace_plugin("my-skill", "gitea-mkt")
+
+    assert result.dependency_reference is not None
+    dep_ref = result.dependency_reference
+    assert dep_ref.virtual_path == "skills/my-skill"
+    assert dep_ref.host == "gitea.example.com"
+    assert "org/repo" in dep_ref.repo_url
+
+
+def test_local_marketplace_absolute_github_source_keeps_github_canonical(tmp_path: Path) -> None:
+    """Plugin pointing to an absolute GitHub repo is fetched from GitHub regardless of where the marketplace lives."""
+    src = MarketplaceSource(name="local-mkt", url=f"file://{tmp_path}", ref="main")
+    plugin = _plugin("absolute", {"type": "github", "repo": "github.com/foo/bar"})
+    p1, p2 = _patch_marketplace(src, [plugin])
+    with p1, p2:
+        result = resolve_marketplace_plugin("absolute", "local-mkt")
+
+    # Absolute github source still resolves to an owner/repo canonical
+    assert "foo/bar" in result.canonical
+
+
+def test_ado_marketplace_relative_source_builds_virtual_path_dep_ref() -> None:
+    """ADO is a new first-class host; in-marketplace plugins go through explicit git+path."""
+    src = MarketplaceSource(
+        name="ado-mkt",
+        url="https://dev.azure.com/contoso/eng/_git/agent-forge",
+        ref="main",
+    )
+    plugin = _plugin("skill-foo", "./skills/skill-foo")
+    p1, p2 = _patch_marketplace(src, [plugin])
+    with p1, p2:
+        result = resolve_marketplace_plugin("skill-foo", "ado-mkt")
+
+    assert result.dependency_reference is not None
+    assert result.dependency_reference.virtual_path == "skills/skill-foo"
+    assert result.dependency_reference.host == "dev.azure.com"
+    assert result.dependency_reference.ado_organization == "contoso"


### PR DESCRIPTION
## TL;DR

`apm marketplace add` now accepts local paths, `file://` URIs, SSH URLs, and HTTPS URLs to any git host -- not just GitHub `owner/repo` shorthand. The change is URL-first under the hood: a small parser classifies each source into `local | github | gitlab | git` and dispatches through a fetcher table, so the existing GitHub Contents API path is untouched while local and self-hosted git become first-class citizens. Verified end-to-end against a public GitHub marketplace exposing 64 plugins and bare/working-tree/`file://` repos in one mixed registry.

## Problem (WHY)

- Marketplace registration was hard-wired to the GitHub Contents API. Anyone hosting an APM package on a local disk, self-hosted git, GitLab, Gitea, Bitbucket Server, or Azure DevOps could not register a marketplace at all.
- The documented workaround was to hand-edit `~/.apm/marketplaces.json` and pre-seed `~/.apm/cache/marketplace/` with a long TTL so APM would never attempt a network fetch. This silently broke after every `apm pack` because the cache went stale.
- `--host` only accepted FQDNs, so even sentinel values like `--host local` were rejected.
- The authoring side (`apm marketplace init`, `apm pack`) already worked against local repos. Only the consumer side (`add`, `browse`, `update`, `install`) lagged, which is exactly the asymmetry that pushed users to manual cache editing.

> [!NOTE]
> The change keeps Progressive Disclosure for trust: only sources that actually hit the network trigger the trust prompt. Local and `file://` sources never prompt. ["Context arrives just-in-time, not just-in-case."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)

## Approach (WHAT)

URL-first model with a small fetcher dispatch table:

| Layer | Before | After |
|---|---|---|
| Source model | `owner/repo/host/branch` fields | `MarketplaceSource` with `url`, `kind`, `ref`; legacy fields kept as backward-compat properties |
| CLI parser | GitHub shorthand only | `_parse_marketplace_source` returns `(url, kind, embedded_host)` covering 6 source forms |
| Fetcher | Single hard-coded GitHub Contents API call | `_FETCHERS` dispatch on `kind`: `_fetch_local` / `_fetch_via_api` / `_fetch_git` |
| Resolver | Single GitCache path for every plugin | `kind=local` fast-paths to on-disk; `kind=git/gitlab` uses GitCache with hooks/submodules disabled; `kind=github` unchanged |
| `marketplaces.json` | No discriminator | `kind` field added; legacy entries migrate lazily on read |

Six accepted source forms across `add`, `list`, `browse`, `update`, and `install`:

```
apm marketplace add owner/repo                                   # GitHub shorthand (unchanged)
apm marketplace add github.com/owner/repo                        # GitHub explicit
apm marketplace add https://gitlab.com/group/repo
apm marketplace add https://dev.azure.com/org/proj/_git/repo
apm marketplace add git@gitea.example.com:org/repo.git
apm marketplace add /srv/marketplaces/my-mkt                # local working tree or bare repo
apm marketplace add file:///srv/marketplaces/my-mkt.git
```

## Implementation (HOW)

| File | What changed |
|---|---|
| `src/apm_cli/marketplace/models.py` | `MarketplaceSource` rewritten URL-first. `kind` / `display_source` / `ref` properties added. Multi-segment owners (e.g. ADO `org/proj/_git/repo`) preserved by `_extract_owner_repo_from_url`. Legacy fields remain readable for older `marketplaces.json` entries. |
| `src/apm_cli/marketplace/client.py` | New `_FETCHERS` dispatch table. `_fetch_local` (bare repo via `git show`, working tree via direct read), `_fetch_git` (generic remote via `git archive`), `_fetch_via_api` (existing GitHub path, unchanged). `_validate_ref` rejects unsafe refs before any subprocess call. |
| `src/apm_cli/commands/marketplace/__init__.py` | `_parse_marketplace_source` classifies the input. `add()` rewritten: `SOURCE` metavar, `--ref` (with `--branch` alias for backward compat), 6-example epilog, kind-scoped trust gate. `list_cmd` shows `display_source` and renames the column to "Ref". |
| `src/apm_cli/marketplace/resolver.py` | `resolve_marketplace_plugin` branches on `source.kind`. Local marketplaces fast-path through `_resolve_local_relative_source` (no GitCache). Generic-git uses GitCache; `_marketplace_https_git_url` now prefers `source.url` so ADO `_git/` segments and GitLab nested groups round-trip correctly. |
| `src/apm_cli/cache/git_cache.py` | Hooks disabled (`core.hooksPath=/dev/null`) and submodules not auto-fetched when materializing a generic-git marketplace. On-path hardening because generic git is newly trusted. |
| Tests | 50 new unit tests across `test_client_local.py`, `test_client_git.py`, `test_parser.py`, `test_resolver_local_git.py`, `test_legacy_migration.py`, `test_git_cache_hardening.py`. 6 new integration tests (`test_marketplace_add_local.py`, `test_marketplace_add_generic_git.py`, `test_marketplace_install_local.py`). |
| Docs | `reference/cli/marketplace.md` synopsis + `add` section rewritten with 6 forms + trust callout + ADO note. `consumer/installing-from-marketplaces.md` gains a "Local and self-hosted marketplaces" section. `apm-usage/commands.md` row updated. `CHANGELOG.md` Unreleased entry. |
| E2E | `scripts/e2e/marketplace_local_e2e.sh`: not wired into CI (keeps CI hermetic) but provides one-shot reproduction against a real bare repo. |

## Diagram

Source classification and fetcher dispatch:

```mermaid
flowchart LR
    SRC["apm marketplace add SOURCE"] --> P{"_parse_marketplace_source"}
    P -->|"owner/repo"| GH["kind=github"]
    P -->|"https://gitlab.com/..."| GL["kind=gitlab"]
    P -->|"ssh / generic https"| GG["kind=git"]
    P -->|"/path or file://"| LO["kind=local"]
    GH --> FA["_fetch_via_api (Contents API)"]
    GL --> FG["_fetch_git (archive / ls-remote)"]
    GG --> FG
    LO --> FL["_fetch_local (git show / direct read)"]
    FA --> MJ["marketplace.json"]
    FG --> MJ
    FL --> MJ
```

## Trade-offs

- **Generic git uses `git archive` / GitCache, not a shallow clone per call.** Higher first-use latency than the GitHub Contents API, but no per-host adapter to maintain. The Contents API path is still used for `kind=github` so existing users see no regression.
- **`kind` discriminator persisted to `marketplaces.json` instead of inferred on every read.** Slightly more state to migrate, but it means the trust prompt and fetcher dispatch are deterministic without re-parsing the source string on each command. Legacy entries are migrated lazily, so no upgrade step is required.
- **Local sources skip the trust prompt.** Justified because the user already controls the path; mirroring the existing `apm install` behavior for local paths. Documented in `reference/cli/marketplace.md` so the boundary is explicit.
- **E2E script kept out of CI.** Keeps CI hermetic and avoids depending on a live external repo. Reproduction is one `bash scripts/e2e/marketplace_local_e2e.sh` away.

## Benefits

1. Self-hosted git (GitLab, Gitea, Bitbucket Server, Azure DevOps) can now publish APM marketplaces with no manual cache editing.
2. Offline-first / air-gapped workflows: a local bare repo is a valid marketplace source.
3. The "manual edit `~/.apm/marketplaces.json` then pre-seed cache" workaround is retired. `apm pack` -> `apm marketplace update` is now a closed loop.
4. GitHub registrations are unchanged (Contents API path still used). 64-plugin smoke against a public GitHub marketplace passed.
5. Generic-git path is hardened on the way through: hooks disabled, submodules not auto-fetched.

## Validation

> [!IMPORTANT]
> Lint chain green on the merge commit. 15,036 unit tests + 6 new integration tests passing. Manual end-to-end covers all four source classes side-by-side.

<details><summary>Test counts</summary>

```
uv run --extra dev pytest tests/unit tests/integration/test_marketplace_add_local.py tests/integration/test_marketplace_add_generic_git.py tests/integration/test_marketplace_install_local.py -q
15042 passed, 1 skipped, 19 warnings, 36 subtests passed in 42.50s
```

</details>

<details><summary>Lint chain (CI-mirror)</summary>

```
uv run --extra dev ruff check src/ tests/                 # All checks passed!
uv run --extra dev ruff format --check src/ tests/        # 1066 files already formatted
uv run --extra dev python -m pylint --disable=all --enable=R0801 \
    --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/ # 10.00/10
bash scripts/lint-auth-signals.sh                          # auth-signal lint clean
```

</details>

<details><summary>Manual end-to-end (mixed registry)</summary>

```
=== Test 1: local working dir ===
[+] Marketplace 'e2e-working' registered (1 plugins)
=== Test 2: local bare repo ===
[+] Marketplace 'e2e-bare' registered (1 plugins)
=== Test 3: file:// URI ===
[+] Marketplace 'e2e-fileuri' registered (1 plugins)
=== Test 4: GitHub regression (public marketplace, 64 plugins) ===
[+] Marketplace 'gh-demo' registered (64 plugins)

apm marketplace list:
| e2e-working    | ~/upstream                | main | marketplace.json                |
| e2e-bare       | ~/bare.git                | main | marketplace.json                |
| e2e-fileuri    | ~/bare.git                | main | marketplace.json                |
| gh-demo        | owner/repo                | main | .claude-plugin/marketplace.json |

apm marketplace browse / update on all four: OK
```

</details>

### Scenario evidence

| User-promise scenario (APM principle) | Test |
|---|---|
| Register a marketplace from a local working tree (consumer reach) | `tests/integration/test_marketplace_add_local.py::test_add_local_marketplace[working]` |
| Register a marketplace from a bare repo (consumer reach) | `tests/integration/test_marketplace_add_local.py::test_add_local_marketplace[bare]` |
| Register from `file://` URI (consumer reach) | `tests/integration/test_marketplace_add_generic_git.py::test_add_file_uri_marketplace` |
| Resolve and install a plugin from a local marketplace (closed loop authoring -> install) | `tests/integration/test_marketplace_install_local.py::test_install_resolves_to_local_path` |
| GitHub `owner/repo` shorthand still uses Contents API (no regression) | `tests/unit/marketplace/test_marketplace_client.py` (existing suite, all green) |
| Legacy `marketplaces.json` entries migrate without user action (upgrade safety) | `tests/unit/marketplace/test_legacy_migration.py` |
| Generic-git marketplaces materialize without firing hooks or submodules (supply-chain hardening) | `tests/unit/cache/test_git_cache_hardening.py` |

## How to test

1. [ ] `gh pr checkout 1476`
2. [ ] `uv run --extra dev apm marketplace add <any-github-owner/repo> --name gh-demo` -- expect `registered (N plugins)`.
3. [ ] Create a local bare repo with a `marketplace.json`, then `uv run --extra dev apm marketplace add /path/to/bare.git --name local-bare` -- expect `registered (N plugins)` with no trust prompt.
4. [ ] `uv run --extra dev apm marketplace list` -- expect both entries with the new `Ref` column.
5. [ ] `bash scripts/e2e/marketplace_local_e2e.sh` for the full end-to-end reproduction.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
