### PR TITLE
fix(marketplace): handle Windows file:// URI shapes in _local_path_from_source

### DIFF
--- a/src/apm_cli/marketplace/models.py
+++ b/src/apm_cli/marketplace/models.py
@@ -75,8 +75,22 @@ def _extract_owner_repo_from_url(url: str) -> tuple[str, str]:
 
 
 def _local_path_from_source(value: str) -> str:
-    """Normalise a local-path source to an absolute path string."""
+    """Normalise a local-path source to an absolute path string.
+
+    Handles three ``file://`` shapes so Windows callers get the right answer:
+    - POSIX: ``file:///abs/path`` -> ``/abs/path``
+    - Windows proper: ``file:///C:/path`` -> ``C:/path``
+    - Windows malformed (e.g. ``f"file://{Path}"`` where Path is ``C:\\...``):
+      ``file://C:\\path`` -> ``C:\\path``
+    ``urlsplit`` mis-parses the Windows-shaped forms (treats ``C:`` as a host),
+    so do the strip manually after detecting a drive-letter prefix.
+    """
     if value.startswith("file://"):
+        rest = value[len("file://") :]
+        if len(rest) >= 3 and rest[0] == "/" and rest[1].isalpha() and rest[2] == ":":
+            return rest[1:]
+        if len(rest) >= 2 and rest[0].isalpha() and rest[1] == ":":
+            return rest
         try:
             parsed = urlsplit(value)
         except ValueError:

--- a/tests/unit/marketplace/test_marketplace_models.py
+++ b/tests/unit/marketplace/test_marketplace_models.py
@@ -373,3 +373,32 @@ class TestParseMarketplaceJson:
         data = {"name": "Test", "metadata": {"version": "1.0"}, "plugins": []}
         manifest = parse_marketplace_json(data)
         assert manifest.plugin_root == ""
+
+
+class TestLocalPathFromSource:
+    """Regression coverage for _local_path_from_source across file:// URI shapes.
+
+    Prevents Windows-only failures where ``f"file://{Path}"`` produces a
+    URI that urlsplit mis-parses (CI Windows job, after PR #1476).
+    """
+
+    def test_posix_file_uri(self):
+        from apm_cli.marketplace.models import _local_path_from_source
+
+        assert _local_path_from_source("file:///tmp/foo") == "/tmp/foo"
+
+    def test_windows_malformed_file_uri_from_fstring(self):
+        """f'file://{Path(C:\\\\...)}' yields file://C:\\... which urlsplit mis-parses."""
+        from apm_cli.marketplace.models import _local_path_from_source
+
+        assert _local_path_from_source("file://C:\\Users\\runner\\x") == "C:\\Users\\runner\\x"
+
+    def test_windows_proper_file_uri(self):
+        from apm_cli.marketplace.models import _local_path_from_source
+
+        assert _local_path_from_source("file:///C:/Users/runner/x") == "C:/Users/runner/x"
+
+    def test_plain_posix_path_passes_through(self):
+        from apm_cli.marketplace.models import _local_path_from_source
+
+        assert _local_path_from_source("/home/user/foo") == "/home/user/foo"


### PR DESCRIPTION
Hotfix for the Windows unit-test job failing on main after PR #1476 merged.

**Failing job:** https://github.com/microsoft/apm/actions/runs/26466816675/job/77929232540
**Failing tests (3, all in `tests/unit/marketplace/test_resolver_local_git.py`):**
- `test_local_marketplace_relative_source_yields_local_path_canonical`
- `test_local_marketplace_bare_name_source_with_plugin_root`
- `test_local_marketplace_root_source_returns_repo_root`

## Root cause

PR #1476 added `_local_path_from_source` which uses `urlsplit()` to strip the `file://` scheme. On Windows, tests construct URIs as `f"file://{tmp_path}"` which yields `file://C:\\Users\\...` — urlsplit treats `C:` as a host, leaves `path` empty, and the helper falls back to returning the original `file://...` string. The canonical then keeps the `file://` prefix, and the assertion `result.canonical == f"{tmp_path}/skills/my-skill"` fails with a leading-prefix mismatch.

## Fix

Strip the `file://` scheme manually after detecting a drive-letter prefix. Covers all three real-world shapes:

| Shape | Example | Stripped |
|---|---|---|
| POSIX | `file:///tmp/foo` | `/tmp/foo` |
| Windows proper | `file:///C:/path` | `C:/path` |
| Windows malformed (f-string) | `file://C:\\path` | `C:\\path` |

## Validation

- Unit tests: 1396 passed (full `tests/unit/marketplace/`)
- Added 4 regression tests for `_local_path_from_source` covering all three URI shapes + plain path.
- Lint chain green (ruff check, ruff format --check, pylint R0801, lint-auth-signals).
- Cannot reproduce locally on macOS, but the fix is verified deterministically against the exact Windows-shape string from the failing assertion: `_local_path_from_source('file://C:\\Users\\runner\\x') == 'C:\\Users\\runner\\x'`.