### PR TITLE
test(codeql): fix 30 py/incomplete-url-substring-sanitization alerts

### DIFF
--- a/tests/integration/test_integrators_validation_phase3b.py
+++ b/tests/integration/test_integrators_validation_phase3b.py
@@ -16,6 +16,7 @@ Strategy:
 
 from __future__ import annotations
 
+import re
 import subprocess  # noqa: F401 -- keep for potential future use
 from datetime import datetime
 from pathlib import Path
@@ -1322,7 +1323,9 @@ class TestLogTlsFailure:
         exc = RuntimeError("TLS verification failed: bad cert")
         verbose_calls: list[str] = []
         _log_tls_failure("host.example.com", exc, lambda m: verbose_calls.append(m), logger)
-        assert any("host.example.com" in m or "bad cert" in m for m in verbose_calls)
+        assert any(
+            re.search(r"\bhost\.example\.com\b", m) or "bad cert" in m for m in verbose_calls
+        )
 
     def test_without_logger_calls_warning_with_mock(self) -> None:
         """_log_tls_failure always requires a logger; test it calls warning with the right message."""

--- a/tests/integration/test_integrators_validation_rules.py
+++ b/tests/integration/test_integrators_validation_rules.py
@@ -16,6 +16,7 @@ Strategy:
 
 from __future__ import annotations
 
+import re
 import subprocess  # noqa: F401 -- keep for potential future use
 from datetime import datetime
 from pathlib import Path
@@ -1322,7 +1323,9 @@ class TestLogTlsFailure:
         exc = RuntimeError("TLS verification failed: bad cert")
         verbose_calls: list[str] = []
         _log_tls_failure("host.example.com", exc, lambda m: verbose_calls.append(m), logger)
-        assert any("host.example.com" in m or "bad cert" in m for m in verbose_calls)
+        assert any(
+            re.search(r"\bhost\.example\.com\b", m) or "bad cert" in m for m in verbose_calls
+        )
 
     def test_without_logger_calls_warning_with_mock(self) -> None:
         """_log_tls_failure always requires a logger; test it calls warning with the right message."""

--- a/tests/integration/test_marketplace_publisher_flow.py
+++ b/tests/integration/test_marketplace_publisher_flow.py
@@ -16,6 +16,7 @@ Strategy
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
@@ -266,7 +267,7 @@ class TestMarketplaceAddUnsupportedHostError:
         msg = _marketplace_add_unsupported_host_error(
             "example.com", "'example.com'", "'example.com'", "generic"
         )
-        assert "github.com" in msg
+        assert re.search(r"\bgithub\.com\b", msg)
         assert "GITHUB_HOST" in msg or "GitLab" in msg
 
 

--- a/tests/integration/test_marketplace_publisher_phase3.py
+++ b/tests/integration/test_marketplace_publisher_phase3.py
@@ -16,6 +16,7 @@ Strategy
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
@@ -266,7 +267,7 @@ class TestMarketplaceAddUnsupportedHostError:
         msg = _marketplace_add_unsupported_host_error(
             "example.com", "'example.com'", "'example.com'", "generic"
         )
-        assert "github.com" in msg
+        assert re.search(r"\bgithub\.com\b", msg)
         assert "GITHUB_HOST" in msg or "GitLab" in msg
 
 

--- a/tests/integration/test_remaining_modules_coverage.py
+++ b/tests/integration/test_remaining_modules_coverage.py
@@ -16,9 +16,11 @@ Strategy:
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
 
 import pytest
 
@@ -1988,7 +1990,9 @@ class TestUnifiedLinkResolverForInstallation:
         source_file = tmp_path / "source.md"
         target_file = tmp_path / "target.md"
         result = r.resolve_links_for_installation(content, source_file, target_file)
-        assert "https://example.com" in result
+        urls = re.findall(r"https?://[^\s)\]\}]+", result)
+        assert len(urls) == 1
+        assert urlparse(urls[0]).hostname == "example.com"
 
 
 class TestUnifiedLinkResolverGetReferencedContexts:

--- a/tests/integration/test_remaining_modules_phase3.py
+++ b/tests/integration/test_remaining_modules_phase3.py
@@ -16,9 +16,11 @@ Strategy:
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
 
 import pytest
 
@@ -1988,7 +1990,9 @@ class TestUnifiedLinkResolverForInstallation:
         source_file = tmp_path / "source.md"
         target_file = tmp_path / "target.md"
         result = r.resolve_links_for_installation(content, source_file, target_file)
-        assert "https://example.com" in result
+        urls = re.findall(r"https?://[^\s)\]\}]+", result)
+        assert len(urls) == 1
+        assert urlparse(urls[0]).hostname == "example.com"
 
 
 class TestUnifiedLinkResolverGetReferencedContexts:

--- a/tests/integration/test_runner_reference_phase3.py
+++ b/tests/integration/test_runner_reference_phase3.py
@@ -148,7 +148,8 @@ class TestParseHttpsUrls:
         ref = DR.parse("https://gitlab.com/owner/repo.git")
         canonical = ref.to_canonical()
         # Non-default host must appear in canonical form
-        assert "gitlab.com" in canonical
+        host = canonical.split("/", 1)[0]
+        assert host == "gitlab.com"
 
     def test_http_insecure_url_sets_flag(self) -> None:
         DR = _dep_ref()
@@ -399,7 +400,7 @@ class TestCanonicalAndIdentity:
         DR = _dep_ref()
         ref = DR.parse("https://gitlab.com/owner/repo.git")
         canonical = ref.to_canonical()
-        assert "gitlab.com" in canonical
+        assert canonical.split("/", 1)[0] == "gitlab.com"
 
     def test_canonical_appends_ref(self) -> None:
         DR = _dep_ref()
@@ -833,7 +834,7 @@ class TestDisplayNameAndStr:
         DR = _dep_ref()
         ref = DR.parse("https://gitlab.com/owner/repo.git")
         s = str(ref)
-        assert "gitlab.com" in s
+        assert s.split("/", 1)[0] == "gitlab.com"
 
 
 # ============================================================================

--- a/tests/integration/test_runner_reference_resolution.py
+++ b/tests/integration/test_runner_reference_resolution.py
@@ -148,7 +148,8 @@ class TestParseHttpsUrls:
         ref = DR.parse("https://gitlab.com/owner/repo.git")
         canonical = ref.to_canonical()
         # Non-default host must appear in canonical form
-        assert "gitlab.com" in canonical
+        host = canonical.split("/", 1)[0]
+        assert host == "gitlab.com"
 
     def test_http_insecure_url_sets_flag(self) -> None:
         DR = _dep_ref()
@@ -399,7 +400,7 @@ class TestCanonicalAndIdentity:
         DR = _dep_ref()
         ref = DR.parse("https://gitlab.com/owner/repo.git")
         canonical = ref.to_canonical()
-        assert "gitlab.com" in canonical
+        assert canonical.split("/", 1)[0] == "gitlab.com"
 
     def test_canonical_appends_ref(self) -> None:
         DR = _dep_ref()
@@ -833,7 +834,7 @@ class TestDisplayNameAndStr:
         DR = _dep_ref()
         ref = DR.parse("https://gitlab.com/owner/repo.git")
         s = str(ref)
-        assert "gitlab.com" in s
+        assert s.split("/", 1)[0] == "gitlab.com"
 
 
 # ============================================================================

--- a/tests/integration/test_uninstall_policy_pack_flow.py
+++ b/tests/integration/test_uninstall_policy_pack_flow.py
@@ -1244,7 +1244,8 @@ class TestAutoDiscover:
         # Should have been called with ghe.corp.com/contoso/.github
         assert mock_fetch.called
         call_arg = mock_fetch.call_args[0][0]
-        assert "ghe.corp.com" in call_arg
+        host, _, _ = call_arg.partition("/")
+        assert host == "ghe.corp.com"
 
 
 class TestPolicyCaching:

--- a/tests/integration/test_uninstall_policy_pack_phase3.py
+++ b/tests/integration/test_uninstall_policy_pack_phase3.py
@@ -1244,7 +1244,8 @@ class TestAutoDiscover:
         # Should have been called with ghe.corp.com/contoso/.github
         assert mock_fetch.called
         call_arg = mock_fetch.call_args[0][0]
-        assert "ghe.corp.com" in call_arg
+        host, _, _ = call_arg.partition("/")
+        assert host == "ghe.corp.com"
 
 
 class TestPolicyCaching:

--- a/tests/unit/compilation/test_link_resolver_phase3.py
+++ b/tests/unit/compilation/test_link_resolver_phase3.py
@@ -19,8 +19,10 @@ Covers error/edge branches not exercised by the main test_link_resolver.py:
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
 
 import pytest
 
@@ -466,7 +468,9 @@ class TestResolveMarkdownLinks:
     def test_external_url_preserved(self, base_dir: Path) -> None:
         content = "[Example](https://example.com)"
         result = resolve_markdown_links(content, base_dir)
-        assert "https://example.com" in result
+        urls = re.findall(r"https?://[^\s)\]\}]+", result)
+        assert len(urls) == 1
+        assert urlparse(urls[0]).hostname == "example.com"
 
     def test_anchor_link_preserved(self, base_dir: Path) -> None:
         content = "[Section](#heading)"

--- a/tests/unit/compilation/test_link_resolver_resolution.py
+++ b/tests/unit/compilation/test_link_resolver_resolution.py
@@ -19,8 +19,10 @@ Covers error/edge branches not exercised by the main test_link_resolver.py:
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
 
 import pytest
 
@@ -466,7 +468,9 @@ class TestResolveMarkdownLinks:
     def test_external_url_preserved(self, base_dir: Path) -> None:
         content = "[Example](https://example.com)"
         result = resolve_markdown_links(content, base_dir)
-        assert "https://example.com" in result
+        urls = re.findall(r"https?://[^\s)\]\}]+", result)
+        assert len(urls) == 1
+        assert urlparse(urls[0]).hostname == "example.com"
 
     def test_anchor_link_preserved(self, base_dir: Path) -> None:
         content = "[Section](#heading)"

--- a/tests/unit/deps/test_download_strategies_phase3.py
+++ b/tests/unit/deps/test_download_strategies_phase3.py
@@ -27,6 +27,7 @@ import json
 import zipfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
 
 import pytest
 import requests
@@ -406,7 +407,7 @@ class TestBuildRepoUrl:
             backend.build_clone_https_url.return_value = "https://ghes.company.com/owner/repo.git"
             mock_backend_for.return_value = backend
             url = d.build_repo_url("owner/repo", dep_ref=dep)
-        assert "ghes.company.com" in url
+        assert urlparse(url).hostname == "ghes.company.com"
 
     def test_ado_backend_without_org_falls_to_generic(self) -> None:
         """ADO dep_ref missing ado_organization must fall through to generic GitHub-style URL."""
@@ -1370,7 +1371,7 @@ class TestBuildContentsApiUrls:
         from urllib.parse import urlparse
 
         parsed = urlparse(urls[0])
-        assert "myorg.ghe.com" in parsed.netloc
+        assert parsed.hostname == "myorg.ghe.com"
 
     def test_ghes_custom_uses_host_api_v3(self) -> None:
         with patch.dict("os.environ", {"GITHUB_HOST": "ghes.company.com"}):
@@ -1383,21 +1384,21 @@ class TestBuildContentsApiUrls:
                 is_github_host=True,
             )
         assert len(urls) >= 1
-        assert "ghes.company.com" in urls[0]
+        assert urlparse(urls[0]).hostname == "ghes.company.com"
 
     def test_generic_host_returns_multiple_candidates(self) -> None:
         urls = DownloadDelegate._build_contents_api_urls(
             "gitea.myorg.com", "owner", "repo", "apm.yml", "main"
         )
         assert len(urls) >= 1
-        assert "gitea.myorg.com" in urls[0]
+        assert urlparse(urls[0]).hostname == "gitea.myorg.com"
 
     def test_is_github_host_none_auto_detected(self) -> None:
         """When is_github_host=None, github.com is auto-detected as GitHub."""
         urls = DownloadDelegate._build_contents_api_urls(
             "github.com", "owner", "repo", "apm.yml", "main", is_github_host=None
         )
-        assert "api.github.com" in urls[0]
+        assert urlparse(urls[0]).hostname == "api.github.com"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/deps/test_download_strategies_selection.py
+++ b/tests/unit/deps/test_download_strategies_selection.py
@@ -27,6 +27,7 @@ import json
 import zipfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
 
 import pytest
 import requests
@@ -406,7 +407,7 @@ class TestBuildRepoUrl:
             backend.build_clone_https_url.return_value = "https://ghes.company.com/owner/repo.git"
             mock_backend_for.return_value = backend
             url = d.build_repo_url("owner/repo", dep_ref=dep)
-        assert "ghes.company.com" in url
+        assert urlparse(url).hostname == "ghes.company.com"
 
     def test_ado_backend_without_org_falls_to_generic(self) -> None:
         """ADO dep_ref missing ado_organization must fall through to generic GitHub-style URL."""
@@ -1370,7 +1371,7 @@ class TestBuildContentsApiUrls:
         from urllib.parse import urlparse
 
         parsed = urlparse(urls[0])
-        assert "myorg.ghe.com" in parsed.netloc
+        assert parsed.hostname == "myorg.ghe.com"
 
     def test_ghes_custom_uses_host_api_v3(self) -> None:
         with patch.dict("os.environ", {"GITHUB_HOST": "ghes.company.com"}):
@@ -1383,21 +1384,21 @@ class TestBuildContentsApiUrls:
                 is_github_host=True,
             )
         assert len(urls) >= 1
-        assert "ghes.company.com" in urls[0]
+        assert urlparse(urls[0]).hostname == "ghes.company.com"
 
     def test_generic_host_returns_multiple_candidates(self) -> None:
         urls = DownloadDelegate._build_contents_api_urls(
             "gitea.myorg.com", "owner", "repo", "apm.yml", "main"
         )
         assert len(urls) >= 1
-        assert "gitea.myorg.com" in urls[0]
+        assert urlparse(urls[0]).hostname == "gitea.myorg.com"
 
     def test_is_github_host_none_auto_detected(self) -> None:
         """When is_github_host=None, github.com is auto-detected as GitHub."""
         urls = DownloadDelegate._build_contents_api_urls(
             "github.com", "owner", "repo", "apm.yml", "main", is_github_host=None
         )
-        assert "api.github.com" in urls[0]
+        assert urlparse(urls[0]).hostname == "api.github.com"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/install/test_pipeline_phase3.py
+++ b/tests/unit/install/test_pipeline_phase3.py
@@ -13,6 +13,7 @@ test_pipeline_auth_preflight.py:
 
 from __future__ import annotations
 
+import re
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -226,7 +227,7 @@ class TestPreflightAuthCheckADOAuthFailure:
         resolver = _make_resolver()
         with pytest.raises(AuthenticationError) as exc_info:
             _preflight_auth_check(ctx, resolver, verbose=False)
-        assert "dev.azure.com" in str(exc_info.value)
+        assert re.search(r"\bdev\.azure\.com\b", str(exc_info.value))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/install/test_pipeline_preflight.py
+++ b/tests/unit/install/test_pipeline_preflight.py
@@ -13,6 +13,7 @@ test_pipeline_auth_preflight.py:
 
 from __future__ import annotations
 
+import re
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -226,7 +227,7 @@ class TestPreflightAuthCheckADOAuthFailure:
         resolver = _make_resolver()
         with pytest.raises(AuthenticationError) as exc_info:
             _preflight_auth_check(ctx, resolver, verbose=False)
-        assert "dev.azure.com" in str(exc_info.value)
+        assert re.search(r"\bdev\.azure\.com\b", str(exc_info.value))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/install/test_validation_error_handling.py
+++ b/tests/unit/install/test_validation_error_handling.py
@@ -17,6 +17,7 @@ Covers branches not hit by existing validation tests:
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -102,7 +103,7 @@ class TestLogTlsFailure:
         calls: list[str] = []
         exc = RuntimeError("TLS verification failed: self signed")
         _log_tls_failure("example.com", exc, verbose_log=calls.append, logger=logger)
-        assert any("example.com" in c for c in calls)
+        assert any(re.search(r"\bexample\.com\b", c) for c in calls)
         assert any("TLS" in c or "self signed" in c for c in calls)
 
     def test_verbose_none_skips_verbose_log(self) -> None:

--- a/tests/unit/install/test_validation_phase3.py
+++ b/tests/unit/install/test_validation_phase3.py
@@ -17,6 +17,7 @@ Covers branches not hit by existing validation tests:
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -102,7 +103,7 @@ class TestLogTlsFailure:
         calls: list[str] = []
         exc = RuntimeError("TLS verification failed: self signed")
         _log_tls_failure("example.com", exc, verbose_log=calls.append, logger=logger)
-        assert any("example.com" in c for c in calls)
+        assert any(re.search(r"\bexample\.com\b", c) for c in calls)
         assert any("TLS" in c or "self signed" in c for c in calls)
 
     def test_verbose_none_skips_verbose_log(self) -> None:

--- a/tests/unit/test_github_host.py
+++ b/tests/unit/test_github_host.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from apm_cli.utils import github_host
@@ -352,7 +354,7 @@ def test_unsupported_host_error_with_context():
     assert "Protocol-relative URLs are not supported" in error_msg
 
     # Should still include standard guidance
-    assert "github.com" in error_msg
+    assert re.search(r"\bgithub\.com\b", error_msg)
     assert "GITHUB_HOST" in error_msg
 
 


### PR DESCRIPTION
## Summary

Fixes all 30 open CodeQL `py/incomplete-url-substring-sanitization` (high-severity) alerts across the test suite by replacing substring assertions on hostname-shaped literals with parsed-component checks, per the canonical test rule in `.github/instructions/tests.instructions.md`.

Alerts addressed: #127 – #156 (each in both the canonical and `_phase3` test mirror).

## Why

> Substring assertions like `assert "host.example.com" in msg` or
> `assert "https://x" in url` are flagged by CodeQL as
> `py/incomplete-url-substring-sanitization` (high severity, "the string
> may be at an arbitrary position in the URL") and **will fail CI**.
> — `.github/instructions/tests.instructions.md`

## What changed

Three substitution patterns, applied test-by-test based on what the assertion really targets:

| Original assertion shape | Replacement |
|---|---|
| Hostname in a URL string | `urllib.parse.urlparse(url).hostname == "host"` |
| Hostname embedded in error/log text (no scheme) | `re.search(r"\bhost\.tld\b", text)` (word-boundary regex) |
| Slug-style canonical form (`host/owner/repo`) | `canonical.split("/", 1)[0] == "host"` |

For markdown / multi-URL output, URLs are extracted with a regex and asserted with hostname equality on the parsed token — mirroring the `_printed_urls` helper pattern already used in `tests/unit/test_mcp_command.py`.

## Files (19)

Each touched file has a canonical / `_phase3` mirror, so changes are paired:

- `tests/unit/test_github_host.py`
- `tests/unit/install/test_validation_phase3.py` + `test_validation_error_handling.py`
- `tests/unit/install/test_pipeline_phase3.py` + `test_pipeline_preflight.py`
- `tests/unit/compilation/test_link_resolver_phase3.py` + `test_link_resolver_resolution.py`
- `tests/unit/deps/test_download_strategies_phase3.py` + `test_download_strategies_selection.py` (5 alerts each)
- `tests/integration/test_uninstall_policy_pack_phase3.py` + `test_uninstall_policy_pack_flow.py`
- `tests/integration/test_runner_reference_phase3.py` + `test_runner_reference_resolution.py` (3 alerts each)
- `tests/integration/test_remaining_modules_phase3.py` + `test_remaining_modules_coverage.py`
- `tests/integration/test_marketplace_publisher_phase3.py` + `test_marketplace_publisher_flow.py`
- `tests/integration/test_integrators_validation_phase3b.py` + `test_integrators_validation_rules.py`

## Validation

- `uv run --extra dev ruff check src/ tests/` — clean
- `uv run --extra dev ruff format --check src/ tests/` — clean
- `uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/` — clean
- `bash scripts/lint-auth-signals.sh` — clean
- `pytest` on all 19 touched files — **1951 passed**

## Scope notes

- Test-only changes; no production behaviour modified.
- Semantics preserved: each assertion still checks the same hostname / URL component, just via parsed equality rather than substring.

## Not in scope

One open alert is **not** included:

- **#160** `actions/untrusted-checkout/high` in `.github/workflows/daily-test-improver.lock.yml`. This file is auto-generated by `gh-aw` (`compiler_version: v0.76.1`); manual edits would be overwritten on next compile. The flagged checkout step is guarded by an `if` excluding `issue_comment` / `pull_request_review_comment` events, but CodeQL flags the workflow holistically. Suggested follow-up: dismiss as "won't fix" with that explanation, or upgrade `gh-aw` once an upstream fix lands.