### PR TITLE
feat(deps): add 'apm deps why <pkg>' to explain transitive dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `apm deps why <package>` explains why a transitive dependency is installed by walking the lockfile's `resolved_by` chain back to the user's direct declaration in `apm.yml`. Supports `--global` for user-scope lockfiles and `--json` for scriptable output (JSON to stdout, all logs to stderr; analogue of `npm why` / `yarn why`). Exits `0` on success, `1` when the package isn't installed or the query is ambiguous, `2` when no lockfile exists. (#1490)
 - `apm config set prefer-ssh true` / `apm config set allow-protocol-fallback true` persist transport preferences to `~/.apm/config.json` so SSH-only and corporate GHES users no longer need to re-pass `--ssh` / `--allow-protocol-fallback` (or export env vars in shell profiles) on every `apm install`. Resolution order: CLI flag > `APM_GIT_PROTOCOL` / `APM_ALLOW_PROTOCOL_FALLBACK` env var > `apm config` > built-in default. `apm config unset prefer-ssh` and `apm config unset allow-protocol-fallback` remove the persisted value. (#1243)
 - `apm pack --marketplace=FORMATS` filters which marketplace formats are built in a single run; accepts comma-separated names and sentinels `all`/`none`. (#1317)
 - `apm pack --marketplace-path FORMAT=PATH` overrides the output path for a specific marketplace format at invocation time. Env var overrides (`APM_MARKETPLACE_<FORMAT>_PATH`) are planned for v0.15. (#1317)

--- a/docs/src/content/docs/consumer/manage-dependencies.md
+++ b/docs/src/content/docs/consumer/manage-dependencies.md
@@ -213,8 +213,9 @@ $ apm deps why -g shared-utils
 ```
 
 The [lockfile](#the-lockfile) is the source of truth -- the command is
-fully offline, walks `resolved_by` parents bottom-up, and prints one
-chain per direct dependency that transitively required the package:
+fully offline and walks the `resolved_by` parent chain bottom-up. The
+lockfile records a single resolved parent per package, so the output is
+one root-to-target chain (not a fan-out of every theoretical route):
 
 ```
 [i] acme-org/shared-utils@1.4.2  (transitive)

--- a/docs/src/content/docs/consumer/manage-dependencies.md
+++ b/docs/src/content/docs/consumer/manage-dependencies.md
@@ -199,27 +199,38 @@ After `apm install`, `apm_modules/` may contain transitive packages that
 you did not declare directly. To answer "who pulled this in?", use
 `apm deps why <pkg>`:
 
-```
-apm deps why shared-utils
-apm deps why acme-org/shared-utils
-apm deps why acme-org/shared-utils --json
-apm deps why shared-utils --global
+:::note[Coming from npm, yarn, or cargo?]
+`apm deps why` is the APM analogue of `npm why` / `yarn why` /
+`cargo tree -i`. Same mental model: ask the lockfile, get back the
+chain that explains why something is on disk.
+:::
+
+```bash
+$ apm deps why shared-utils
+$ apm deps why acme-org/shared-utils
+$ apm deps why acme-org/shared-utils --json
+$ apm deps why -g shared-utils
 ```
 
-The lockfile is the source of truth -- the command is fully offline,
-walks `resolved_by` parents bottom-up, and prints one chain per direct
-dependency that transitively required the package:
+The [lockfile](#the-lockfile) is the source of truth -- the command is
+fully offline, walks `resolved_by` parents bottom-up, and prints one
+chain per direct dependency that transitively required the package:
 
 ```
 [i] acme-org/shared-utils@1.4.2  (transitive)
 
     acme-org/big-skills   [declared in apm.yml]
-     +-- acme-org/shared-utils
+    +-- acme-org/shared-utils
 ```
 
-`<pkg>` accepts the same identifier styles as `apm deps info`: a bare
-basename (when unique), `owner/repo`, or a full repo URL. Pass `--json`
-for scripting:
+`<pkg>` accepts four identifier styles, tried in order: unique key
+(`acme-org_shared-utils`), full repo URL
+(`https://github.com/acme-org/shared-utils`), `owner/repo`, or bare
+basename (`shared-utils`) when unambiguous. An ambiguous bare name
+exits `1` and lists the candidates.
+
+Pass `--json` for scripting; the JSON document goes to stdout and all
+logs / hints go to stderr, so `apm deps why pkg --json | jq` is safe:
 
 ```json
 {
@@ -230,3 +241,8 @@ for scripting:
 
 Exit codes: `0` on success, `1` when the package is not installed or the
 query is ambiguous, `2` when no lockfile exists yet (run `apm install`).
+
+See also: [`apm deps tree`](../../reference/cli/deps/#apm-deps-tree) for
+the top-down graph view, and
+[`apm deps info`](../../reference/cli/deps/#apm-deps-info) for full
+metadata of one package.

--- a/docs/src/content/docs/consumer/manage-dependencies.md
+++ b/docs/src/content/docs/consumer/manage-dependencies.md
@@ -192,3 +192,41 @@ too: `apm update` refreshes dependencies to the latest matching refs
 fail-on-drift install for CI (like `npm ci`). To upgrade the `apm` CLI
 binary itself, use `apm self-update`.
 :::
+
+## Explain a transitive dependency: `apm deps why`
+
+After `apm install`, `apm_modules/` may contain transitive packages that
+you did not declare directly. To answer "who pulled this in?", use
+`apm deps why <pkg>`:
+
+```
+apm deps why shared-utils
+apm deps why acme-org/shared-utils
+apm deps why acme-org/shared-utils --json
+apm deps why shared-utils --global
+```
+
+The lockfile is the source of truth -- the command is fully offline,
+walks `resolved_by` parents bottom-up, and prints one chain per direct
+dependency that transitively required the package:
+
+```
+[i] acme-org/shared-utils@1.4.2  (transitive)
+
+    acme-org/big-skills   [declared in apm.yml]
+     +-- acme-org/shared-utils
+```
+
+`<pkg>` accepts the same identifier styles as `apm deps info`: a bare
+basename (when unique), `owner/repo`, or a full repo URL. Pass `--json`
+for scripting:
+
+```json
+{
+  "package": {"repo_url": "acme-org/shared-utils", "is_direct": false, "...": "..."},
+  "paths": [{"chain": [{"repo_url": "acme-org/big-skills", "is_direct": true}, ...]}]
+}
+```
+
+Exit codes: `0` on success, `1` when the package is not installed or the
+query is ambiguous, `2` when no lockfile exists yet (run `apm install`).

--- a/docs/src/content/docs/reference/cli/deps.md
+++ b/docs/src/content/docs/reference/cli/deps.md
@@ -26,6 +26,7 @@ All subcommands operate on the project scope (`./apm_modules/`) by default. Pass
 | `list` | List installed dependencies with per-primitive counts. |
 | `tree` | Render the dependency graph as a tree. |
 | `info PACKAGE` | Show detailed metadata for one installed package. |
+| `why PACKAGE` | Explain why a transitive dependency is installed (analogue of `npm why`). |
 | `update [PACKAGES...]` | Re-resolve git refs and reinstall. |
 | `clean` | Remove the entire `apm_modules/` directory. |
 
@@ -66,6 +67,25 @@ apm deps info PACKAGE
 | Argument | Description |
 |---|---|
 | `PACKAGE` | Name of an installed package under `apm_modules/`. Required. |
+
+### `apm deps why`
+
+Explain why a transitive dependency is installed, by walking the lockfile's `resolved_by` chain from the queried package back to the user's direct declaration in `apm.yml`. The APM analogue of `npm why` / `yarn why` / `cargo tree -i`.
+
+```bash
+apm deps why PACKAGE [OPTIONS]
+```
+
+| Argument | Description |
+|---|---|
+| `PACKAGE` | The installed package to explain. Accepts the same identifier styles as `apm deps info`: unique key (`owner_repo`), repo URL (`https://github.com/owner/repo`), `owner/repo`, or bare basename when unambiguous. |
+
+| Option | Description |
+|---|---|
+| `-g, --global` | Read the user-scope lockfile at `~/.apm/apm.lock.yaml` instead of the project lockfile. |
+| `--json` | Emit a machine-readable JSON document to stdout. All logs and error payloads are routed to stderr so `apm deps why pkg --json \| jq` is safe. |
+
+Exit codes: `0` on success, `1` when the package is not installed or the query matches multiple packages, `2` when no lockfile exists.
 
 ### `apm deps update`
 

--- a/packages/apm-guide/.apm/skills/apm-usage/commands.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/commands.md
@@ -16,7 +16,7 @@
 | `apm prune` | Remove orphaned packages | `--dry-run` |
 | `apm deps list` | List installed packages | `-g` global, `--all` both scopes, `--insecure` |
 | `apm deps tree` | Show dependency tree | -- |
-| `apm deps why PKG` | Explain why a package is installed (walks lockfile bottom-up to direct deps) | `-g` global, `--json` |
+| `apm deps why PKG` | Explain why a package is installed (walks lockfile bottom-up to direct deps; analogue of `npm why` / `yarn why`) | `-g` global, `--json` |
 | `apm view PKG [FIELD]` | View package details or remote refs | `-g` global, `FIELD=versions` |
 | `apm outdated` | Check locked deps via SHA/semver comparison | `-g` global, `-v` verbose, `-j N` parallel checks |
 | `apm deps info PKG` | Alias for `apm view PKG` local metadata | -- |

--- a/packages/apm-guide/.apm/skills/apm-usage/commands.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/commands.md
@@ -16,6 +16,7 @@
 | `apm prune` | Remove orphaned packages | `--dry-run` |
 | `apm deps list` | List installed packages | `-g` global, `--all` both scopes, `--insecure` |
 | `apm deps tree` | Show dependency tree | -- |
+| `apm deps why PKG` | Explain why a package is installed (walks lockfile bottom-up to direct deps) | `-g` global, `--json` |
 | `apm view PKG [FIELD]` | View package details or remote refs | `-g` global, `FIELD=versions` |
 | `apm outdated` | Check locked deps via SHA/semver comparison | `-g` global, `-v` verbose, `-j N` parallel checks |
 | `apm deps info PKG` | Alias for `apm view PKG` local metadata | -- |

--- a/src/apm_cli/commands/deps/__init__.py
+++ b/src/apm_cli/commands/deps/__init__.py
@@ -10,6 +10,7 @@ from ._utils import (
     _is_nested_under_package,
 )
 from .cli import clean, deps, info, list_packages, tree, update
+from .why import why
 
 __all__ = [  # noqa: RUF022
     # CLI commands
@@ -19,6 +20,7 @@ __all__ = [  # noqa: RUF022
     "clean",
     "update",
     "info",
+    "why",
     # Utility functions (used by tests)
     "_is_nested_under_package",
     "_count_primitives",

--- a/src/apm_cli/commands/deps/cli.py
+++ b/src/apm_cli/commands/deps/cli.py
@@ -17,6 +17,7 @@ from ._utils import (
     _get_package_display_info,
     _is_nested_under_package,
 )
+from .why import why as _why_cmd
 
 # ---------------------------------------------------------------------------
 # Shared helpers
@@ -256,6 +257,9 @@ def _resolve_scope_deps(apm_dir, logger, insecure_only=False):
 def deps():
     """APM dependency management commands."""
     pass
+
+
+deps.add_command(_why_cmd)
 
 
 def _show_scope_deps(scope_label, apm_dir, logger, console, has_rich, insecure_only=False):

--- a/src/apm_cli/commands/deps/why.py
+++ b/src/apm_cli/commands/deps/why.py
@@ -95,12 +95,18 @@ def _render_human(result: WhyResult) -> str:
 
     for path in result.paths:
         for idx, edge in enumerate(path.chain):
-            is_root = idx == 0
+            # Root is determined by the absence of a recorded parent, NOT by
+            # position in the chain: compute_why() may emit truncated chains
+            # (missing parent in lockfile, cycle break, depth-cap hit) where
+            # the first element is NOT a real root. See PR #1495 review.
+            is_root = edge.parent_key is None
             annotation = _edge_annotation(edge, is_root=is_root)
-            prefix = "    " if is_root else ("    " + " " * (idx - 1) + "+-- ")
+            prefix = "    " if idx == 0 else ("    " + " " * (idx - 1) + "+-- ")
             lines.append(f"{prefix}{edge.child_key}{annotation}")
         lines.append("")  # blank line between chains
-    return "\n".join(lines).rstrip() + "\n"
+    # Caller uses click.echo() which appends its own newline; do not add one
+    # here or we emit a trailing blank line.
+    return "\n".join(lines).rstrip()
 
 
 def _render_json(result: WhyResult) -> str:
@@ -119,9 +125,12 @@ def _render_json(result: WhyResult) -> str:
                     {
                         "repo_url": edge.child_key,
                         "constraint": edge.constraint,
-                        "is_direct": idx == 0,
+                        # Directness is recorded by the walker as a missing
+                        # parent_key, not by position: a corrupt or
+                        # depth-capped chain may not start at a true root.
+                        "is_direct": edge.parent_key is None,
                     }
-                    for idx, edge in enumerate(path.chain)
+                    for edge in path.chain
                 ]
             }
             for path in result.paths

--- a/src/apm_cli/commands/deps/why.py
+++ b/src/apm_cli/commands/deps/why.py
@@ -1,0 +1,226 @@
+"""``apm deps why <pkg>`` -- explain why a package is installed.
+
+Inverts the lockfile dependency graph from a target package back to one or
+more direct dependencies that pulled it in. The lockfile is the source of
+truth -- no remote calls.
+
+Output formats:
+
+* Default: a plain-text indented tree (ASCII ``+--``), one chain per
+  direct dependency that transitively required the target. Rich is
+  intentionally not used here -- a list of N short root-to-leaf chains
+  is not a single tree, and ``rich.tree`` would imply a hierarchy that
+  does not exist.
+* ``--json``: a machine-readable JSON document on stdout.
+
+Exit codes:
+
+* ``0`` -- target found and explained.
+* ``1`` -- package not installed or query ambiguous.
+* ``2`` -- no lockfile / project misconfiguration.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import click
+
+from ...core.command_logger import CommandLogger
+from ...core.scope import InstallScope, get_apm_dir
+from ...deps.lockfile import LockFile, get_lockfile_path, migrate_lockfile_if_needed
+from ...deps.why_walker import (
+    AmbiguousPackageError,
+    PackageNotInstalledError,
+    WhyEdge,
+    WhyResult,
+    compute_why,
+    resolve_package_query,
+)
+
+# Exit codes
+_EXIT_OK = 0
+_EXIT_NOT_FOUND = 1
+_EXIT_NO_LOCKFILE = 2
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_dep_label(dep) -> str:
+    """Render ``repo_url@version`` for the human output header."""
+    version = (
+        dep.version
+        or (dep.resolved_commit[:7] if dep.resolved_commit else None)
+        or dep.resolved_ref
+        or "unknown"
+    )
+    return f"{dep.repo_url}@{version}"
+
+
+def _edge_annotation(edge: WhyEdge, is_root: bool) -> str:
+    """Render the bracketed annotation for a single chain edge.
+
+    Mirrors the design-pack convention:
+    * Root edge (direct dep):   ``[constraint: ^1.2.0, declared in apm.yml]``
+      or ``[declared in apm.yml]`` when constraint is unknown.
+    * Inner edges:              ``[constraint: ^1.4.0]`` or empty.
+    """
+    parts: list[str] = []
+    if edge.constraint:
+        parts.append(f"constraint: {edge.constraint}")
+    if is_root:
+        parts.append("declared in apm.yml")
+    if not parts:
+        return ""
+    return f"   [{', '.join(parts)}]"
+
+
+def _render_human(result: WhyResult) -> str:
+    """Render the human-readable explanation as a single string."""
+    target = result.target
+    header_kind = "direct dependency" if result.is_direct else "transitive"
+    lines: list[str] = [f"[i] {_format_dep_label(target)}  ({header_kind})", ""]
+
+    if result.is_direct:
+        # Single trivial chain.
+        edge = result.paths[0].chain[0]
+        annotation = _edge_annotation(edge, is_root=True)
+        lines.append(f"    {target.repo_url}{annotation}")
+        return "\n".join(lines)
+
+    for path in result.paths:
+        for idx, edge in enumerate(path.chain):
+            is_root = idx == 0
+            annotation = _edge_annotation(edge, is_root=is_root)
+            prefix = "    " if is_root else ("    " + " " * (idx - 1) + "+-- ")
+            lines.append(f"{prefix}{edge.child_key}{annotation}")
+        lines.append("")  # blank line between chains
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _render_json(result: WhyResult) -> str:
+    """Render the JSON explanation."""
+    target = result.target
+    payload = {
+        "package": {
+            "repo_url": target.repo_url,
+            "version": target.version or target.resolved_ref or target.resolved_commit,
+            "source": target.source or "git",
+            "is_direct": result.is_direct,
+        },
+        "paths": [
+            {
+                "chain": [
+                    {
+                        "repo_url": edge.child_key,
+                        "constraint": edge.constraint,
+                        "is_direct": idx == 0,
+                    }
+                    for idx, edge in enumerate(path.chain)
+                ]
+            }
+            for path in result.paths
+        ],
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+# ---------------------------------------------------------------------------
+# Lockfile loading
+# ---------------------------------------------------------------------------
+
+
+def _load_lockfile(apm_dir, logger: CommandLogger) -> LockFile | None:
+    """Load the lockfile for *apm_dir*; emit an error and return ``None``
+    when missing or unreadable. Callers translate that into exit code 2.
+    """
+    migrate_lockfile_if_needed(apm_dir)
+    lockfile_path = get_lockfile_path(apm_dir)
+    if not lockfile_path.exists():
+        logger.error("no apm.lock.yaml found in this project.")
+        logger.progress("Hint: run 'apm install' first.")
+        return None
+    lockfile = LockFile.read(lockfile_path)
+    if lockfile is None:
+        logger.error(f"could not read lockfile at {lockfile_path}")
+        return None
+    return lockfile
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+_HELP = (
+    "Explain why a package is installed by walking the lockfile back to "
+    "one or more direct dependencies that pulled it in.\n\n"
+    "Examples:\n"
+    "  apm deps why shared-utils\n"
+    "  apm deps why acme-org/shared-utils --json\n"
+    "  apm deps why shared-utils --global"
+)
+
+
+@click.command(name="why", help=_HELP)
+@click.argument("package", required=True)
+@click.option(
+    "--global",
+    "-g",
+    "global_",
+    is_flag=True,
+    default=False,
+    help="Resolve against the user-scope lockfile (~/.apm/apm.lock.yaml).",
+)
+@click.option(
+    "--json",
+    "as_json",
+    is_flag=True,
+    default=False,
+    help="Emit machine-readable JSON to stdout.",
+)
+def why(package: str, global_: bool, as_json: bool) -> None:
+    """Entry point for ``apm deps why <pkg>``."""
+    logger = CommandLogger("deps-why")
+    scope = InstallScope.USER if global_ else InstallScope.PROJECT
+    apm_dir = get_apm_dir(scope)
+
+    lockfile = _load_lockfile(apm_dir, logger)
+    if lockfile is None:
+        if as_json:
+            click.echo(json.dumps({"error": "no_lockfile"}))
+        sys.exit(_EXIT_NO_LOCKFILE)
+
+    try:
+        target = resolve_package_query(lockfile, package)
+    except AmbiguousPackageError as exc:
+        if as_json:
+            click.echo(
+                json.dumps({"error": "ambiguous", "query": exc.query, "matches": exc.matches})
+            )
+        else:
+            logger.error(f"'{exc.query}' matches multiple packages:")
+            for match in exc.matches:
+                click.echo(f"  - {match}")
+            logger.progress("Hint: use the full owner/repo form.")
+        sys.exit(_EXIT_NOT_FOUND)
+    except PackageNotInstalledError as exc:
+        if as_json:
+            click.echo(json.dumps({"error": "not_installed", "query": exc.query}))
+        else:
+            logger.error(f"'{exc.query}' is not installed (not in apm.lock.yaml).")
+            logger.progress("Hint: run 'apm deps list' to see installed packages.")
+        sys.exit(_EXIT_NOT_FOUND)
+
+    result = compute_why(lockfile, target)
+
+    if as_json:
+        click.echo(_render_json(result))
+    else:
+        click.echo(_render_human(result))
+
+    sys.exit(_EXIT_OK)

--- a/src/apm_cli/commands/deps/why.py
+++ b/src/apm_cli/commands/deps/why.py
@@ -38,6 +38,7 @@ from ...deps.why_walker import (
     compute_why,
     resolve_package_query,
 )
+from ...utils.console import set_console_stderr
 
 # Exit codes
 _EXIT_OK = 0
@@ -142,7 +143,7 @@ def _load_lockfile(apm_dir, logger: CommandLogger) -> LockFile | None:
     lockfile_path = get_lockfile_path(apm_dir)
     if not lockfile_path.exists():
         logger.error("no apm.lock.yaml found in this project.")
-        logger.progress("Hint: run 'apm install' first.")
+        logger.info("Hint: run 'apm install' first.")
         return None
     lockfile = LockFile.read(lockfile_path)
     if lockfile is None:
@@ -185,6 +186,13 @@ _HELP = (
 )
 def why(package: str, global_: bool, as_json: bool) -> None:
     """Entry point for ``apm deps why <pkg>``."""
+    # Stream discipline: under --json, route ALL human-facing output to
+    # stderr so that downstream tools (jq, scripts) can consume stdout
+    # as a clean JSON document. Mirrors the convention established by
+    # `apm pack --json` (commands/pack.py) and by npm / yarn / cargo.
+    if as_json:
+        set_console_stderr(True)
+
     logger = CommandLogger("deps-why")
     scope = InstallScope.USER if global_ else InstallScope.PROJECT
     apm_dir = get_apm_dir(scope)
@@ -192,7 +200,7 @@ def why(package: str, global_: bool, as_json: bool) -> None:
     lockfile = _load_lockfile(apm_dir, logger)
     if lockfile is None:
         if as_json:
-            click.echo(json.dumps({"error": "no_lockfile"}))
+            click.echo(json.dumps({"error": "no_lockfile"}), err=True)
         sys.exit(_EXIT_NO_LOCKFILE)
 
     try:
@@ -200,20 +208,24 @@ def why(package: str, global_: bool, as_json: bool) -> None:
     except AmbiguousPackageError as exc:
         if as_json:
             click.echo(
-                json.dumps({"error": "ambiguous", "query": exc.query, "matches": exc.matches})
+                json.dumps({"error": "ambiguous", "query": exc.query, "matches": exc.matches}),
+                err=True,
             )
         else:
             logger.error(f"'{exc.query}' matches multiple packages:")
             for match in exc.matches:
-                click.echo(f"  - {match}")
-            logger.progress("Hint: use the full owner/repo form.")
+                click.echo(f"  - {match}", err=True)
+            logger.info("Hint: use the full owner/repo form.")
         sys.exit(_EXIT_NOT_FOUND)
     except PackageNotInstalledError as exc:
         if as_json:
-            click.echo(json.dumps({"error": "not_installed", "query": exc.query}))
+            click.echo(
+                json.dumps({"error": "not_installed", "query": exc.query}),
+                err=True,
+            )
         else:
             logger.error(f"'{exc.query}' is not installed (not in apm.lock.yaml).")
-            logger.progress("Hint: run 'apm deps list' to see installed packages.")
+            logger.info("Hint: run 'apm deps list' to see installed packages.")
         sys.exit(_EXIT_NOT_FOUND)
 
     result = compute_why(lockfile, target)

--- a/src/apm_cli/deps/why_walker.py
+++ b/src/apm_cli/deps/why_walker.py
@@ -48,7 +48,14 @@ class WhyPath:
 
 @dataclass(frozen=True)
 class WhyResult:
-    """Result of explaining a target dependency."""
+    """Result of explaining a target dependency.
+
+    NOTE: ``target`` is a borrowed reference to the same
+    :class:`LockedDependency` instance held by the live
+    :class:`LockFile`. Treat it as read-only; mutating it would alter
+    the lockfile object held by the caller. (Frozen WhyResult only
+    freezes its own attributes, not the target it points at.)
+    """
 
     target: LockedDependency
     is_direct: bool
@@ -178,16 +185,25 @@ def resolve_package_query(lockfile: LockFile, query: str) -> LockedDependency:
 
 
 def compute_why(lockfile: LockFile, target: LockedDependency) -> WhyResult:
-    """Invert the ``resolved_by`` edges and collect all paths to *target*.
+    """Walk the single ``resolved_by`` chain from *target* back to a root.
 
-    Returns a :class:`WhyResult` whose ``paths`` is a tuple of one or more
-    :class:`WhyPath` instances ordered deterministically by their stringified
-    chain. When *target* is itself a direct dependency, the result contains
-    one path of length one with ``parent_key=None``.
+    :class:`LockedDependency.resolved_by` records exactly one parent
+    today, so a target produces ONE chain per lockfile record (any
+    "diamond" fan-in is collapsed by the resolver). Returns a
+    :class:`WhyResult` whose ``paths`` is a tuple of one or more
+    :class:`WhyPath` instances ordered deterministically by their
+    stringified chain. The iterative worklist generalises to N paths
+    without API change if ``resolved_by`` ever becomes multi-valued
+    (see #1488 and the constraint-field follow-on).
 
-    Cycles in the lockfile graph (which would indicate a bug in the resolver,
-    not user data, but we defend regardless) are broken by a per-traversal
-    visited set: each ``repo_url`` appears at most once in a single chain.
+    When *target* is itself a direct dependency, the result contains one
+    trivial path with ``parent_key=None``.
+
+    Cycles in the lockfile graph (which would indicate a resolver bug,
+    not user data, but we defend regardless) are broken by a
+    per-traversal visited set: each ``repo_url`` appears at most once
+    in a single chain. A defensive ``max_paths`` cap also bounds
+    worklist growth in the future multi-parent case.
     """
     target_key = target.repo_url
     target_constraint = _dep_constraint(target)
@@ -240,8 +256,15 @@ def compute_why(lockfile: LockFile, target: LockedDependency) -> WhyResult:
 
     # Bound traversal depth as a defensive ceiling against pathological data.
     max_depth = max(64, len(by_url) + 1)
+    # Bound the total number of paths returned (defensive against the
+    # future multi-parent case where a malformed lockfile could produce
+    # factorial fan-in). Today resolved_by is single-valued so this cap
+    # is unreachable; it matters once #1488's resolver lands.
+    max_paths = 256
 
     while worklist:
+        if len(paths) >= max_paths:
+            break
         current, chain, visited = worklist.pop()
         if len(chain) > max_depth:
             # Stop extending this chain; record what we have.

--- a/src/apm_cli/deps/why_walker.py
+++ b/src/apm_cli/deps/why_walker.py
@@ -1,0 +1,274 @@
+"""Inverted dependency-graph walker for ``apm deps why``.
+
+Pure data-structure logic over an in-memory :class:`LockFile`. No Click,
+no I/O. The walker inverts the existing forward ``resolved_by`` graph
+(each :class:`LockedDependency` points at its parent's ``repo_url``) and
+collects all paths from a target dependency back to one or more direct
+(root) dependencies.
+
+Backward compatible with lockfiles that predate the optional
+``constraint`` field on :class:`LockedDependency` (issue #1488). When the
+attribute is absent, :class:`WhyEdge.constraint` is ``None`` and human
+output falls back to a plain "declared in apm.yml" annotation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .lockfile import LockedDependency, LockFile
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WhyEdge:
+    """A single parent -> child edge in a why-explanation chain.
+
+    ``parent_key`` is ``None`` only for the synthetic root edge that
+    represents the project's own ``apm.yml`` direct-dependency declaration.
+    """
+
+    parent_key: str | None
+    child_key: str
+    constraint: str | None = None
+
+
+@dataclass(frozen=True)
+class WhyPath:
+    """A single root-to-target chain. ``chain[0].parent_key`` is ``None``."""
+
+    chain: tuple[WhyEdge, ...]
+
+
+@dataclass(frozen=True)
+class WhyResult:
+    """Result of explaining a target dependency."""
+
+    target: LockedDependency
+    is_direct: bool
+    paths: tuple[WhyPath, ...]
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class PackageNotInstalledError(Exception):
+    """Raised when a query does not match any installed package."""
+
+    def __init__(self, query: str):
+        super().__init__(f"'{query}' is not installed (not in apm.lock.yaml)")
+        self.query = query
+
+
+class AmbiguousPackageError(Exception):
+    """Raised when a basename query matches multiple installed packages."""
+
+    def __init__(self, query: str, matches: list[str]):
+        super().__init__(f"'{query}' matches multiple packages: {', '.join(sorted(matches))}")
+        self.query = query
+        self.matches = sorted(matches)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _dep_constraint(dep: LockedDependency) -> str | None:
+    """Return the declared constraint for *dep*, or ``None`` when unknown.
+
+    Reads the optional ``constraint`` attribute introduced by issue #1488.
+    Gracefully degrades when the attribute is absent on the dataclass.
+    """
+    return getattr(dep, "constraint", None)
+
+
+def _basename(repo_url: str) -> str:
+    """Return the trailing path segment of *repo_url* (e.g. ``shared-utils``).
+
+    Strips a trailing ``.git`` for convenience. ``acme-org/shared-utils.git``
+    -> ``shared-utils``.
+    """
+    tail = repo_url.rstrip("/").rsplit("/", 1)[-1]
+    return tail[:-4] if tail.endswith(".git") else tail
+
+
+def _owner_repo(repo_url: str) -> str:
+    """Return the last two path segments of *repo_url* (``owner/repo``).
+
+    Falls back to the full ``repo_url`` when fewer than two segments are
+    available.
+    """
+    parts = repo_url.rstrip("/").split("/")
+    if len(parts) >= 2:
+        tail = parts[-1]
+        if tail.endswith(".git"):
+            tail = tail[:-4]
+        return f"{parts[-2]}/{tail}"
+    return repo_url
+
+
+def _is_project_dep(dep: LockedDependency) -> bool:
+    """Filter out the synthesized ``<self>`` entry from traversals."""
+    return dep.repo_url != "<self>"
+
+
+# ---------------------------------------------------------------------------
+# Query resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_package_query(lockfile: LockFile, query: str) -> LockedDependency:
+    """Resolve a user query string to a single :class:`LockedDependency`.
+
+    Supports four forms:
+
+    1. Full ``repo_url`` (exact match).
+    2. ``owner/repo`` short form.
+    3. Bare basename (e.g. ``shared-utils``), if unique.
+    4. The unique key returned by ``LockedDependency.get_unique_key()``.
+
+    Raises :class:`PackageNotInstalledError` when nothing matches, and
+    :class:`AmbiguousPackageError` when a basename matches multiple
+    packages from different owners.
+    """
+    if not query:
+        raise PackageNotInstalledError(query)
+
+    deps = [d for d in lockfile.get_all_dependencies() if _is_project_dep(d)]
+
+    # Exact match on unique key
+    by_key = {d.get_unique_key(): d for d in deps}
+    if query in by_key:
+        return by_key[query]
+
+    # Exact match on repo_url
+    by_url = [d for d in deps if d.repo_url == query]
+    if len(by_url) == 1:
+        return by_url[0]
+
+    # Exact match on owner/repo
+    by_owner_repo = [d for d in deps if _owner_repo(d.repo_url) == query]
+    if len(by_owner_repo) == 1:
+        return by_owner_repo[0]
+    if len(by_owner_repo) > 1:
+        raise AmbiguousPackageError(query, [d.repo_url for d in by_owner_repo])
+
+    # Bare basename
+    by_basename = [d for d in deps if _basename(d.repo_url) == query]
+    if len(by_basename) == 1:
+        return by_basename[0]
+    if len(by_basename) > 1:
+        raise AmbiguousPackageError(query, [d.repo_url for d in by_basename])
+
+    raise PackageNotInstalledError(query)
+
+
+# ---------------------------------------------------------------------------
+# Walker
+# ---------------------------------------------------------------------------
+
+
+def compute_why(lockfile: LockFile, target: LockedDependency) -> WhyResult:
+    """Invert the ``resolved_by`` edges and collect all paths to *target*.
+
+    Returns a :class:`WhyResult` whose ``paths`` is a tuple of one or more
+    :class:`WhyPath` instances ordered deterministically by their stringified
+    chain. When *target* is itself a direct dependency, the result contains
+    one path of length one with ``parent_key=None``.
+
+    Cycles in the lockfile graph (which would indicate a bug in the resolver,
+    not user data, but we defend regardless) are broken by a per-traversal
+    visited set: each ``repo_url`` appears at most once in a single chain.
+    """
+    target_key = target.repo_url
+    target_constraint = _dep_constraint(target)
+
+    # Direct dependency: single trivial path.
+    if target.resolved_by is None:
+        return WhyResult(
+            target=target,
+            is_direct=True,
+            paths=(
+                WhyPath(
+                    chain=(
+                        WhyEdge(
+                            parent_key=None,
+                            child_key=target_key,
+                            constraint=target_constraint,
+                        ),
+                    )
+                ),
+            ),
+        )
+
+    # Build a lookup: repo_url -> dep. The lockfile may legitimately host
+    # multiple deps with the same repo_url under different virtual_path keys;
+    # for parent-chain walking we key on repo_url and pick the canonical
+    # (non-virtual, lowest-depth) record where ambiguous.
+    by_url: dict[str, LockedDependency] = {}
+    for dep in lockfile.get_all_dependencies():
+        if not _is_project_dep(dep):
+            continue
+        existing = by_url.get(dep.repo_url)
+        if (
+            existing is None
+            or (existing.is_virtual and not dep.is_virtual)
+            or dep.depth < existing.depth
+        ):
+            by_url[dep.repo_url] = dep
+
+    # Walk parents iteratively. Each entry in the worklist is
+    # (current_dep, chain_so_far_root_first, visited_set).
+    paths: list[WhyPath] = []
+    initial_edge = WhyEdge(
+        parent_key=target.resolved_by,
+        child_key=target_key,
+        constraint=target_constraint,
+    )
+    worklist: list[tuple[LockedDependency, tuple[WhyEdge, ...], frozenset[str]]] = [
+        (target, (initial_edge,), frozenset({target_key}))
+    ]
+
+    # Bound traversal depth as a defensive ceiling against pathological data.
+    max_depth = max(64, len(by_url) + 1)
+
+    while worklist:
+        current, chain, visited = worklist.pop()
+        if len(chain) > max_depth:
+            # Stop extending this chain; record what we have.
+            paths.append(WhyPath(chain=chain))
+            continue
+        parent_url = current.resolved_by
+        if parent_url is None:
+            paths.append(WhyPath(chain=chain))
+            continue
+        parent = by_url.get(parent_url)
+        if parent is None:
+            # Parent missing from lockfile (corrupt or partial data). Treat
+            # the current step as a root and stop extending.
+            paths.append(WhyPath(chain=chain))
+            continue
+        if parent.repo_url in visited:
+            # Cycle detected; record the chain up to the cycle boundary.
+            paths.append(WhyPath(chain=chain))
+            continue
+        new_edge = WhyEdge(
+            parent_key=parent.resolved_by,
+            child_key=parent.repo_url,
+            constraint=_dep_constraint(parent),
+        )
+        new_chain = (new_edge, *chain)
+        worklist.append((parent, new_chain, visited | {parent.repo_url}))
+
+    # Deterministic ordering: by the rendered chain string.
+    paths.sort(key=lambda p: tuple((e.parent_key or "", e.child_key) for e in p.chain))
+    return WhyResult(target=target, is_direct=False, paths=tuple(paths))

--- a/tests/integration/test_deps_why_e2e.py
+++ b/tests/integration/test_deps_why_e2e.py
@@ -1,0 +1,132 @@
+"""Integration test for ``apm deps why`` against a real on-disk lockfile.
+
+Builds a multi-level dependency graph in a temp directory, writes it as an
+``apm.lock.yaml`` artifact, and invokes the actual CLI -- no network, no
+git, just the real file-load + walker + renderer pipeline.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from apm_cli.cli import cli
+from apm_cli.deps.lockfile import LOCKFILE_NAME, LockedDependency, LockFile
+
+
+@contextlib.contextmanager
+def _cwd(path: Path):
+    original = os.getcwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(original)
+
+
+@pytest.fixture
+def multi_level_project(tmp_path: Path) -> Path:
+    """Project with a 3-level dep chain plus a sibling chain.
+
+    Forward graph:
+        acme/big-skills (direct)
+          -> acme/shared-utils (transitive depth 2)
+              -> acme/deep-core (transitive depth 3)
+        acme/other-skills (direct)
+          -> acme/shared-utils  (recorded once -- the lockfile has a
+             single shared-utils entry with one resolved_by)
+    """
+    lf = LockFile()
+    lf.add_dependency(
+        LockedDependency(
+            repo_url="acme/big-skills",
+            version="1.2.4",
+            depth=1,
+            resolved_by=None,
+        )
+    )
+    lf.add_dependency(
+        LockedDependency(
+            repo_url="acme/other-skills",
+            version="0.9.1",
+            depth=1,
+            resolved_by=None,
+        )
+    )
+    lf.add_dependency(
+        LockedDependency(
+            repo_url="acme/shared-utils",
+            version="1.4.2",
+            depth=2,
+            resolved_by="acme/big-skills",
+        )
+    )
+    lf.add_dependency(
+        LockedDependency(
+            repo_url="acme/deep-core",
+            version="3.1.0",
+            depth=3,
+            resolved_by="acme/shared-utils",
+        )
+    )
+    (tmp_path / LOCKFILE_NAME).write_text(lf.to_yaml(), encoding="utf-8")
+    return tmp_path
+
+
+def test_why_transitive_chain_renders_full_path(multi_level_project: Path):
+    """End-to-end: deep transitive resolves to a 3-link chain."""
+    runner = CliRunner()
+    with _cwd(multi_level_project):
+        result = runner.invoke(cli, ["deps", "why", "deep-core"])
+    assert result.exit_code == 0, result.output
+    # Header line names the package and identifies as transitive.
+    assert "acme/deep-core@3.1.0" in result.output
+    assert "(transitive)" in result.output
+    # Each ancestor up the chain appears in the rendered output.
+    assert "acme/big-skills" in result.output
+    assert "acme/shared-utils" in result.output
+    # ASCII tree connector (no unicode box-drawing chars)
+    assert "+--" in result.output
+    assert "\u2500" not in result.output  # no rich box-drawing
+
+
+def test_why_json_snapshot_stable(multi_level_project: Path):
+    """JSON schema is stable and well-formed for downstream tooling."""
+    runner = CliRunner()
+    with _cwd(multi_level_project):
+        result = runner.invoke(cli, ["deps", "why", "deep-core", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["package"]["repo_url"] == "acme/deep-core"
+    assert payload["package"]["is_direct"] is False
+    assert len(payload["paths"]) == 1
+    chain = payload["paths"][0]["chain"]
+    assert [link["repo_url"] for link in chain] == [
+        "acme/big-skills",
+        "acme/shared-utils",
+        "acme/deep-core",
+    ]
+    assert chain[0]["is_direct"] is True
+    assert chain[-1]["is_direct"] is False
+
+
+def test_why_direct_dep_end_to_end(multi_level_project: Path):
+    runner = CliRunner()
+    with _cwd(multi_level_project):
+        result = runner.invoke(cli, ["deps", "why", "big-skills"])
+    assert result.exit_code == 0, result.output
+    assert "(direct dependency)" in result.output
+
+
+def test_why_missing_lockfile_exits_2(tmp_path: Path):
+    runner = CliRunner()
+    empty_project = tmp_path / "empty"
+    empty_project.mkdir()
+    with _cwd(empty_project):
+        result = runner.invoke(cli, ["deps", "why", "anything"])
+    assert result.exit_code == 2

--- a/tests/integration/test_deps_why_promises_e2e.py
+++ b/tests/integration/test_deps_why_promises_e2e.py
@@ -1,0 +1,395 @@
+"""End-to-end coverage of every user-visible promise of ``apm deps why``.
+
+Each test name reads as the promise sentence it defends. The pipeline
+exercised is real: build an ``apm.lock.yaml`` on disk under ``tmp_path``,
+invoke the CLI through ``CliRunner``, and assert against the actual
+human / JSON output the user sees.
+
+These tests are complementary to ``tests/unit/commands/deps/test_why_command.py``
+(unit-level argv + branch coverage) and ``tests/integration/test_deps_why_e2e.py``
+(the original happy-path e2e). They exist to give every user-promise its
+own integration-tier regression trap so that silent drift in the
+file-load -> walker -> renderer chain fails loudly here before a user
+notices.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from apm_cli.cli import cli
+from apm_cli.deps.lockfile import LOCKFILE_NAME, LockedDependency, LockFile
+
+# ---------------------------------------------------------------------------
+# Shared helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _cwd(path: Path):
+    original = os.getcwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(original)
+
+
+def _write_project_lockfile(project_root: Path, deps: list[LockedDependency]) -> Path:
+    lf = LockFile()
+    for dep in deps:
+        lf.add_dependency(dep)
+    lockfile_path = project_root / LOCKFILE_NAME
+    lockfile_path.write_text(lf.to_yaml(), encoding="utf-8")
+    return lockfile_path
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    # Click 8.2+ CliRunner exposes stdout and stderr as separate streams
+    # by default; Promise C relies on that separation.
+    return CliRunner()
+
+
+@pytest.fixture
+def linear_chain_project(tmp_path: Path) -> Path:
+    """A linear 3-level chain: big -> shared -> deep."""
+    _write_project_lockfile(
+        tmp_path,
+        [
+            LockedDependency(
+                repo_url="acme/big-skills", version="1.2.4", depth=1, resolved_by=None
+            ),
+            LockedDependency(
+                repo_url="acme/shared-utils",
+                version="1.4.2",
+                depth=2,
+                resolved_by="acme/big-skills",
+            ),
+            LockedDependency(
+                repo_url="acme/deep-core",
+                version="3.1.0",
+                depth=3,
+                resolved_by="acme/shared-utils",
+            ),
+        ],
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def shared_transitive_project(tmp_path: Path) -> Path:
+    """Two declared roots; one shared transitive recorded under a single
+    parent (the resolver collapses to one ``resolved_by`` per record --
+    documented in docs/.../manage-dependencies.md as "one root-to-target
+    chain, not a fan-out")."""
+    _write_project_lockfile(
+        tmp_path,
+        [
+            LockedDependency(
+                repo_url="acme/big-skills", version="1.2.4", depth=1, resolved_by=None
+            ),
+            LockedDependency(
+                repo_url="acme/other-skills",
+                version="0.9.1",
+                depth=1,
+                resolved_by=None,
+            ),
+            LockedDependency(
+                repo_url="acme/shared-utils",
+                version="1.4.2",
+                depth=2,
+                resolved_by="acme/big-skills",
+            ),
+        ],
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def truncated_chain_project(tmp_path: Path) -> Path:
+    """Lockfile records a parent that is itself missing -- simulates
+    partial/corrupt data the walker must defend against."""
+    _write_project_lockfile(
+        tmp_path,
+        [
+            LockedDependency(
+                repo_url="acme/orphan",
+                version="1.0.0",
+                depth=2,
+                resolved_by="acme/missing-parent",
+            ),
+        ],
+    )
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Promise A: human-readable chain renders root -> target
+# ---------------------------------------------------------------------------
+
+
+def test_promise_a_apm_deps_why_prints_human_chain_from_root_to_target(
+    runner, linear_chain_project: Path
+):
+    """Promise A: ``apm deps why <pkg>`` prints the human-readable chain
+    from the direct root in apm.yml all the way to the queried package."""
+    with _cwd(linear_chain_project):
+        result = runner.invoke(cli, ["deps", "why", "deep-core"])
+    assert result.exit_code == 0, result.stderr
+    out = result.stdout
+    assert "acme/deep-core@3.1.0" in out
+    assert "(transitive)" in out
+    root_idx = out.index("acme/big-skills")
+    mid_idx = out.index("acme/shared-utils")
+    leaf_idx = out.index("acme/deep-core", root_idx + 1)
+    assert root_idx < mid_idx < leaf_idx, f"chain must render root-to-target order; got:\n{out}"
+    assert "declared in apm.yml" in out
+    assert "+--" in out
+
+
+# ---------------------------------------------------------------------------
+# Promise B: exit codes
+# ---------------------------------------------------------------------------
+
+
+def test_promise_b_exit_0_on_success_and_nonzero_with_clear_error_when_pkg_missing(
+    runner, linear_chain_project: Path
+):
+    """Promise B: success exits 0; missing package exits nonzero with a
+    clear, named error message."""
+    with _cwd(linear_chain_project):
+        ok = runner.invoke(cli, ["deps", "why", "deep-core"])
+        missing = runner.invoke(cli, ["deps", "why", "nope-not-here"])
+    assert ok.exit_code == 0, ok.stderr
+    assert missing.exit_code != 0
+    assert missing.exit_code == 1
+    combined = (missing.stdout or "") + (missing.stderr or "")
+    assert "not installed" in combined
+    assert "nope-not-here" in combined
+
+
+# ---------------------------------------------------------------------------
+# Promise C: --json stream discipline (regression-trap)
+# ---------------------------------------------------------------------------
+
+
+def test_promise_c_json_mode_emits_valid_json_to_stdout_and_errors_to_stderr(
+    runner, linear_chain_project: Path, tmp_path: Path
+):
+    """Promise C: ``--json`` mode emits a single valid JSON document to
+    stdout on success; on failure stdout stays clean (jq-safe) and the
+    JSON error envelope is on stderr."""
+    with _cwd(linear_chain_project):
+        ok = runner.invoke(cli, ["deps", "why", "deep-core", "--json"])
+    assert ok.exit_code == 0, ok.stderr
+    # stdout must parse as a single JSON document.
+    payload = json.loads(ok.stdout)
+    assert payload["package"]["repo_url"] == "acme/deep-core"
+
+    # Failure path: no lockfile -> stdout MUST stay empty, stderr carries
+    # the JSON error envelope. This is the panel-flagged stream-discipline
+    # regression trap; at integration tier (not unit-mocked) it would
+    # catch a regression like dropping ``set_console_stderr(True)``.
+    empty_project = tmp_path / "empty"
+    empty_project.mkdir()
+    with _cwd(empty_project):
+        missing = runner.invoke(cli, ["deps", "why", "anything", "--json"])
+    assert missing.exit_code == 2
+    assert missing.stdout == "", (
+        f"stdout must stay clean under --json failure; got: {missing.stdout!r}"
+    )
+    err_payload = json.loads(missing.stderr.strip().splitlines()[-1])
+    assert err_payload == {"error": "no_lockfile"}
+
+
+# ---------------------------------------------------------------------------
+# Promise D: constraint annotations (present + graceful absence)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("with_constraint", [True, False])
+def test_promise_d_constraint_annotation_shows_when_present_and_degrades_gracefully(
+    runner, linear_chain_project: Path, monkeypatch, with_constraint: bool
+):
+    """Promise D: when ``LockedDependency.constraint`` is populated
+    (post-#1488), the renderer surfaces it in both human and JSON output;
+    when absent (current main), output must still render correctly with
+    a plain "declared in apm.yml" annotation -- no AttributeError, no
+    missing chain elements."""
+    if with_constraint:
+        # Inject constraints via the walker's getattr indirection: the
+        # walker reads dep.constraint with getattr(..., None), and the
+        # renderer formats it. Patching here proves the end-to-end
+        # rendering pipeline picks up the new field once #1488 lands.
+        constraints = {
+            "acme/big-skills": "^1.2.0",
+            "acme/shared-utils": "^1.4.0",
+        }
+        import apm_cli.deps.why_walker as walker_mod
+
+        original = walker_mod._dep_constraint
+        monkeypatch.setattr(
+            walker_mod,
+            "_dep_constraint",
+            lambda dep: constraints.get(dep.repo_url, original(dep)),
+        )
+
+    with _cwd(linear_chain_project):
+        human = runner.invoke(cli, ["deps", "why", "deep-core"])
+        as_json = runner.invoke(cli, ["deps", "why", "deep-core", "--json"])
+
+    assert human.exit_code == 0, human.stderr
+    assert as_json.exit_code == 0, as_json.stderr
+    payload = json.loads(as_json.stdout)
+    root_edge = payload["paths"][0]["chain"][0]
+
+    if with_constraint:
+        assert "constraint: ^1.2.0" in human.stdout
+        assert root_edge["constraint"] == "^1.2.0"
+    else:
+        assert "constraint:" not in human.stdout
+        assert root_edge["constraint"] is None
+
+    # Either way the root edge is annotated as the declared one.
+    assert "declared in apm.yml" in human.stdout
+    assert root_edge["is_direct"] is True
+
+
+# ---------------------------------------------------------------------------
+# Promise E: shared transitive renders one collapsed chain (documented)
+# ---------------------------------------------------------------------------
+
+
+def test_promise_e_shared_transitive_renders_documented_single_collapsed_chain(
+    runner, shared_transitive_project: Path
+):
+    """Promise E: the docs explicitly state the lockfile records "a single
+    resolved parent per package" and so ``why`` returns "one root-to-target
+    chain (not a fan-out)". This test pins that contract: two declared
+    roots that both depend on the same transitive collapse to exactly one
+    chain in the output, anchored on the recorded ``resolved_by`` parent."""
+    with _cwd(shared_transitive_project):
+        result = runner.invoke(cli, ["deps", "why", "shared-utils", "--json"])
+    assert result.exit_code == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["package"]["repo_url"] == "acme/shared-utils"
+    assert payload["package"]["is_direct"] is False
+    assert len(payload["paths"]) == 1
+    chain = payload["paths"][0]["chain"]
+    assert [link["repo_url"] for link in chain] == [
+        "acme/big-skills",
+        "acme/shared-utils",
+    ]
+    # Only the recorded parent (acme/big-skills) appears -- the sibling
+    # root (acme/other-skills) must NOT be invented by the walker.
+    assert "acme/other-skills" not in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Promise F: is_direct comes from parent_key absence, not chain position
+# ---------------------------------------------------------------------------
+
+
+def test_promise_f_is_direct_reflects_declared_root_not_position(
+    runner, truncated_chain_project: Path
+):
+    """Promise F (Copilot regression-trap, folded into integration tier):
+    ``is_direct`` must be derived from ``edge.parent_key is None``, NOT
+    from ``idx == 0``. When the recorded parent is missing from the
+    lockfile, the walker emits a truncated chain whose first edge still
+    has a non-None ``parent_key`` -- that edge must NOT be reported as
+    direct in human output (no "declared in apm.yml") or JSON
+    (``is_direct: false`` everywhere)."""
+    with _cwd(truncated_chain_project):
+        human = runner.invoke(cli, ["deps", "why", "orphan"])
+        as_json = runner.invoke(cli, ["deps", "why", "orphan", "--json"])
+    assert human.exit_code == 0, human.stderr
+    assert as_json.exit_code == 0, as_json.stderr
+
+    # Human output: no false "declared in apm.yml" claim.
+    assert "declared in apm.yml" not in human.stdout
+
+    # JSON: package itself is not direct AND no edge in the truncated
+    # chain claims directness.
+    payload = json.loads(as_json.stdout)
+    assert payload["package"]["is_direct"] is False
+    for path in payload["paths"]:
+        for edge in path["chain"]:
+            assert edge["is_direct"] is False, (
+                f"no edge in a truncated chain may be marked direct; got {edge}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Promise G: lockfile is resolved at the project-root cwd (CLI convention)
+# ---------------------------------------------------------------------------
+
+
+def test_promise_g_resolves_lockfile_at_project_root_cwd(runner, linear_chain_project: Path):
+    """Promise G: ``apm deps why`` reads ``apm.lock.yaml`` from the
+    current working directory. This pins the project-scope contract
+    shared by all ``apm deps`` subcommands: cwd == project root.
+
+    The regression trap has two halves:
+
+    * At the project root the command succeeds with exit 0.
+    * From a sibling directory (no lockfile present) the command
+      exits 2 with the documented "no apm.lock.yaml" error.
+      A future change that silently walked the parent tree -- or
+      silently fell back to a different scope -- would flip the
+      sibling-dir half of this assertion.
+    """
+    # Success at the project root.
+    with _cwd(linear_chain_project):
+        ok = runner.invoke(cli, ["deps", "why", "deep-core"])
+    assert ok.exit_code == 0, ok.stderr
+
+    # No upward walk: a sibling directory must NOT inherit the lockfile.
+    sibling = linear_chain_project.parent / "sibling"
+    sibling.mkdir()
+    with _cwd(sibling):
+        missing = runner.invoke(cli, ["deps", "why", "deep-core"])
+    assert missing.exit_code == 2
+    combined = (missing.stdout or "") + (missing.stderr or "")
+    assert "no apm.lock.yaml" in combined
+
+
+# ---------------------------------------------------------------------------
+# Promise H: --help text matches actual behavior
+# ---------------------------------------------------------------------------
+
+
+def test_promise_h_help_text_documents_actual_flags_and_argument(runner):
+    """Promise H: ``apm deps why --help`` advertises the same surface
+    the command actually implements -- the ``PACKAGE`` argument, the
+    ``--json`` flag, the ``--global``/``-g`` flag, and at least one
+    runnable example. Drift between help text and implementation is a
+    silent UX regression."""
+    result = runner.invoke(cli, ["deps", "why", "--help"])
+    assert result.exit_code == 0, result.stderr
+    out = result.stdout
+    assert "PACKAGE" in out
+    # Find the option-listing line that describes the JSON flag and assert
+    # it advertises the actual flag name. Anchoring on the help-string
+    # ("Emit machine-readable JSON") and the flag spelling on the SAME
+    # line defends against a rename that would otherwise hide behind the
+    # unchanged example block.
+    json_line = next(
+        (line for line in out.splitlines() if "Emit machine-readable JSON" in line),
+        "",
+    )
+    assert "--json" in json_line, f"flag spelling drift; line was: {json_line!r}"
+    # The --global / -g flag listing is also a contract.
+    global_line = next(
+        (line for line in out.splitlines() if "user-scope lockfile" in line),
+        "",
+    )
+    assert "--global" in global_line and "-g" in global_line
+    assert "apm deps why" in out  # at least one runnable example

--- a/tests/unit/commands/deps/test_why_command.py
+++ b/tests/unit/commands/deps/test_why_command.py
@@ -205,6 +205,25 @@ class TestWhyErrorPaths:
             assert result.exit_code == 2
             assert "no apm.lock.yaml" in result.output
 
+    def test_why_no_lockfile_json_emits_error_envelope_on_stderr(self, runner):
+        """`apm deps why <pkg> --json` with no lockfile must keep stdout clean
+        (no human logs leaking in) and emit the JSON error envelope to stderr.
+        Regression trap for the panel-flagged --json stream-discipline bug.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            with _cwd(tmp_path):
+                result = runner.invoke(
+                    cli,
+                    ["deps", "why", "anything", "--json"],
+                )
+            assert result.exit_code == 2
+            # stdout MUST be clean -- nothing should pollute a `| jq` pipeline.
+            assert result.stdout == ""
+            # The JSON error envelope is routed to stderr.
+            payload = json.loads(result.stderr.strip().splitlines()[-1])
+            assert payload == {"error": "no_lockfile"}
+
 
 # ---------------------------------------------------------------------------
 # --global flag

--- a/tests/unit/commands/deps/test_why_command.py
+++ b/tests/unit/commands/deps/test_why_command.py
@@ -97,6 +97,62 @@ class TestWhyHumanOutput:
             # ASCII tree marker (no Unicode box-drawing)
             assert "+--" in result.output
 
+    def test_why_human_output_has_no_trailing_blank_line(self, runner):
+        # Regression trap (PR #1495 review): _render_human() must not append
+        # its own trailing newline because click.echo() already adds one.
+        # A trailing newline in the returned string causes output to end
+        # with TWO newlines (i.e. one blank line at the end).
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            lf = _make_lockfile(
+                [
+                    LockedDependency(
+                        repo_url="acme/big", version="1.2.4", depth=1, resolved_by=None
+                    ),
+                    LockedDependency(
+                        repo_url="acme/util",
+                        version="1.4.2",
+                        depth=2,
+                        resolved_by="acme/big",
+                    ),
+                ]
+            )
+            _write_lockfile(tmp_path, lf)
+            with _cwd(tmp_path):
+                result = runner.invoke(cli, ["deps", "why", "acme/util"])
+            assert result.exit_code == 0, result.output
+            # Exactly one trailing newline (from click.echo); no blank line.
+            assert result.output.endswith("\n")
+            assert not result.output.endswith("\n\n")
+
+    def test_why_corrupt_chain_human_output_omits_declared_annotation(self, runner):
+        # Regression trap (PR #1495 review): when the recorded resolved_by
+        # parent is missing from the lockfile, the walker emits a truncated
+        # chain whose first edge still has parent_key set (NOT None).
+        # The renderer must NOT label that edge as "declared in apm.yml".
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            lf = _make_lockfile(
+                [
+                    # Note: acme/util references acme/big as parent, but
+                    # acme/big is NOT in the lockfile (corrupt/partial data).
+                    LockedDependency(
+                        repo_url="acme/util",
+                        version="1.4.2",
+                        depth=2,
+                        resolved_by="acme/big",
+                    ),
+                ]
+            )
+            _write_lockfile(tmp_path, lf)
+            with _cwd(tmp_path):
+                result = runner.invoke(cli, ["deps", "why", "acme/util"])
+            assert result.exit_code == 0, result.output
+            # acme/util is transitive (resolved_by != None) but the chain is
+            # truncated; nothing in the output should claim a "declared"
+            # annotation because no real root edge exists.
+            assert "declared in apm.yml" not in result.output
+
 
 # ---------------------------------------------------------------------------
 # JSON output
@@ -132,6 +188,36 @@ class TestWhyJsonOutput:
             assert chain[0]["repo_url"] == "acme/big"
             assert chain[0]["is_direct"] is True
             assert chain[-1]["repo_url"] == "acme/util"
+
+    def test_why_json_corrupt_chain_marks_no_edge_as_direct(self, runner):
+        # Regression trap (PR #1495 review): is_direct must come from the
+        # walker (edge.parent_key is None), not from position (idx == 0).
+        # When the recorded parent is missing from the lockfile, the chain
+        # is truncated and NO edge represents a true direct dependency.
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            lf = _make_lockfile(
+                [
+                    # Parent acme/big is intentionally absent.
+                    LockedDependency(
+                        repo_url="acme/util",
+                        version="1.4.2",
+                        depth=2,
+                        resolved_by="acme/big",
+                    ),
+                ]
+            )
+            _write_lockfile(tmp_path, lf)
+            with _cwd(tmp_path):
+                result = runner.invoke(cli, ["deps", "why", "acme/util", "--json"])
+            assert result.exit_code == 0, result.output
+            payload = json.loads(result.output)
+            assert payload["package"]["is_direct"] is False
+            for path in payload["paths"]:
+                for edge in path["chain"]:
+                    assert edge["is_direct"] is False, (
+                        f"no edge in a corrupt/truncated chain should be marked direct; got {edge}"
+                    )
 
     def test_why_json_not_installed_emits_error_payload(self, runner):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/unit/commands/deps/test_why_command.py
+++ b/tests/unit/commands/deps/test_why_command.py
@@ -1,0 +1,270 @@
+"""Tests for ``apm deps why`` -- CLI surface and exit codes."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from apm_cli.cli import cli
+from apm_cli.deps.lockfile import LOCKFILE_NAME, LockedDependency, LockFile
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@contextlib.contextmanager
+def _cwd(path: Path):
+    original = os.getcwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(original)
+
+
+def _make_lockfile(deps: list[LockedDependency]) -> LockFile:
+    lf = LockFile()
+    for d in deps:
+        lf.add_dependency(d)
+    return lf
+
+
+def _write_lockfile(tmp: Path, lf: LockFile) -> Path:
+    p = tmp / LOCKFILE_NAME
+    p.write_text(lf.to_yaml(), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Human output
+# ---------------------------------------------------------------------------
+
+
+class TestWhyHumanOutput:
+    def test_why_direct_dep_human_output(self, runner):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            lf = _make_lockfile(
+                [
+                    LockedDependency(
+                        repo_url="acme/big",
+                        version="1.2.4",
+                        depth=1,
+                        resolved_by=None,
+                    )
+                ]
+            )
+            _write_lockfile(tmp_path, lf)
+            with _cwd(tmp_path):
+                result = runner.invoke(cli, ["deps", "why", "acme/big"])
+            assert result.exit_code == 0, result.output
+            assert "acme/big@1.2.4" in result.output
+            assert "(direct dependency)" in result.output
+            assert "declared in apm.yml" in result.output
+
+    def test_why_transitive_dep_human_output(self, runner):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            lf = _make_lockfile(
+                [
+                    LockedDependency(
+                        repo_url="acme/big", version="1.2.4", depth=1, resolved_by=None
+                    ),
+                    LockedDependency(
+                        repo_url="acme/util",
+                        version="1.4.2",
+                        depth=2,
+                        resolved_by="acme/big",
+                    ),
+                ]
+            )
+            _write_lockfile(tmp_path, lf)
+            with _cwd(tmp_path):
+                result = runner.invoke(cli, ["deps", "why", "acme/util"])
+            assert result.exit_code == 0, result.output
+            assert "acme/util@1.4.2" in result.output
+            assert "(transitive)" in result.output
+            assert "acme/big" in result.output
+            # ASCII tree marker (no Unicode box-drawing)
+            assert "+--" in result.output
+
+
+# ---------------------------------------------------------------------------
+# JSON output
+# ---------------------------------------------------------------------------
+
+
+class TestWhyJsonOutput:
+    def test_why_json_output_matches_schema(self, runner):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            lf = _make_lockfile(
+                [
+                    LockedDependency(
+                        repo_url="acme/big", version="1.2.4", depth=1, resolved_by=None
+                    ),
+                    LockedDependency(
+                        repo_url="acme/util",
+                        version="1.4.2",
+                        depth=2,
+                        resolved_by="acme/big",
+                    ),
+                ]
+            )
+            _write_lockfile(tmp_path, lf)
+            with _cwd(tmp_path):
+                result = runner.invoke(cli, ["deps", "why", "acme/util", "--json"])
+            assert result.exit_code == 0, result.output
+            payload = json.loads(result.output)
+            assert payload["package"]["repo_url"] == "acme/util"
+            assert payload["package"]["is_direct"] is False
+            assert len(payload["paths"]) == 1
+            chain = payload["paths"][0]["chain"]
+            assert chain[0]["repo_url"] == "acme/big"
+            assert chain[0]["is_direct"] is True
+            assert chain[-1]["repo_url"] == "acme/util"
+
+    def test_why_json_not_installed_emits_error_payload(self, runner):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            lf = _make_lockfile(
+                [LockedDependency(repo_url="acme/big", version="1.2.4", depth=1, resolved_by=None)]
+            )
+            _write_lockfile(tmp_path, lf)
+            with _cwd(tmp_path):
+                result = runner.invoke(cli, ["deps", "why", "nope", "--json"])
+            assert result.exit_code == 1
+            payload = json.loads(result.output)
+            assert payload == {"error": "not_installed", "query": "nope"}
+
+
+# ---------------------------------------------------------------------------
+# Error paths and exit codes
+# ---------------------------------------------------------------------------
+
+
+class TestWhyErrorPaths:
+    def test_why_ambiguous_query_exits_1(self, runner):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            lf = _make_lockfile(
+                [
+                    LockedDependency(
+                        repo_url="acme/shared-utils",
+                        version="1.0.0",
+                        depth=1,
+                        resolved_by=None,
+                    ),
+                    LockedDependency(
+                        repo_url="other/shared-utils",
+                        version="2.0.0",
+                        depth=1,
+                        resolved_by=None,
+                    ),
+                ]
+            )
+            _write_lockfile(tmp_path, lf)
+            with _cwd(tmp_path):
+                result = runner.invoke(cli, ["deps", "why", "shared-utils"])
+            assert result.exit_code == 1
+            assert "multiple packages" in result.output
+
+    def test_why_not_installed_exits_1(self, runner):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            lf = _make_lockfile(
+                [
+                    LockedDependency(
+                        repo_url="acme/big",
+                        version="1.0",
+                        depth=1,
+                        resolved_by=None,
+                    )
+                ]
+            )
+            _write_lockfile(tmp_path, lf)
+            with _cwd(tmp_path):
+                result = runner.invoke(cli, ["deps", "why", "missing-pkg"])
+            assert result.exit_code == 1
+            assert "not installed" in result.output
+
+    def test_why_no_lockfile_exits_2(self, runner):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            with _cwd(tmp_path):
+                result = runner.invoke(cli, ["deps", "why", "anything"])
+            assert result.exit_code == 2
+            assert "no apm.lock.yaml" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --global flag
+# ---------------------------------------------------------------------------
+
+
+class TestWhyGlobalFlag:
+    def test_why_global_flag_uses_user_scope_lockfile(self, runner):
+        with tempfile.TemporaryDirectory() as user_home:
+            user_path = Path(user_home)
+            user_apm = user_path / ".apm"
+            user_apm.mkdir()
+            lf = _make_lockfile(
+                [
+                    LockedDependency(
+                        repo_url="acme/global-pkg",
+                        version="0.1.0",
+                        depth=1,
+                        resolved_by=None,
+                    )
+                ]
+            )
+            _write_lockfile(user_apm, lf)
+
+            with patch("pathlib.Path.home", return_value=user_path):
+                result = runner.invoke(cli, ["deps", "why", "global-pkg", "--global"])
+            assert result.exit_code == 0, result.output
+            assert "acme/global-pkg" in result.output
+
+
+# ---------------------------------------------------------------------------
+# No-network regression trap
+# ---------------------------------------------------------------------------
+
+
+class TestWhyNoNetwork:
+    def test_why_command_does_not_hit_network(self, runner):
+        """The command must be offline; assert subprocess.run is never called."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            lf = _make_lockfile(
+                [
+                    LockedDependency(repo_url="acme/big", version="1.0", depth=1, resolved_by=None),
+                    LockedDependency(
+                        repo_url="acme/util",
+                        version="1.4",
+                        depth=2,
+                        resolved_by="acme/big",
+                    ),
+                ]
+            )
+            _write_lockfile(tmp_path, lf)
+            with (
+                _cwd(tmp_path),
+                patch("subprocess.run") as mock_run,
+                patch("urllib.request.urlopen") as mock_urlopen,
+            ):
+                result_human = runner.invoke(cli, ["deps", "why", "acme/util"])
+                result_json = runner.invoke(cli, ["deps", "why", "acme/util", "--json"])
+            assert result_human.exit_code == 0, result_human.output
+            assert result_json.exit_code == 0, result_json.output
+            mock_run.assert_not_called()
+            mock_urlopen.assert_not_called()

--- a/tests/unit/deps/test_why_walker.py
+++ b/tests/unit/deps/test_why_walker.py
@@ -1,0 +1,184 @@
+"""Unit tests for :mod:`apm_cli.deps.why_walker`."""
+
+from __future__ import annotations
+
+import pytest
+
+from apm_cli.deps.lockfile import LockedDependency, LockFile
+from apm_cli.deps.why_walker import (
+    AmbiguousPackageError,
+    PackageNotInstalledError,
+    compute_why,
+    resolve_package_query,
+)
+
+
+def _direct(repo_url: str, **kwargs) -> LockedDependency:
+    return LockedDependency(repo_url=repo_url, depth=1, resolved_by=None, **kwargs)
+
+
+def _transitive(repo_url: str, resolved_by: str, depth: int = 2, **kwargs) -> LockedDependency:
+    return LockedDependency(repo_url=repo_url, depth=depth, resolved_by=resolved_by, **kwargs)
+
+
+def _build(deps: list[LockedDependency]) -> LockFile:
+    lf = LockFile()
+    for d in deps:
+        lf.add_dependency(d)
+    return lf
+
+
+# ---------------------------------------------------------------------------
+# compute_why
+# ---------------------------------------------------------------------------
+
+
+def test_compute_why_direct_dep_returns_single_path_with_no_intermediates():
+    direct = _direct("acme/foo")
+    lf = _build([direct])
+
+    result = compute_why(lf, direct)
+
+    assert result.is_direct is True
+    assert len(result.paths) == 1
+    chain = result.paths[0].chain
+    assert len(chain) == 1
+    assert chain[0].parent_key is None
+    assert chain[0].child_key == "acme/foo"
+
+
+def test_compute_why_transitive_dep_with_one_path():
+    parent = _direct("acme/big")
+    child = _transitive("acme/util", resolved_by="acme/big")
+    lf = _build([parent, child])
+
+    result = compute_why(lf, child)
+
+    assert result.is_direct is False
+    assert len(result.paths) == 1
+    chain = result.paths[0].chain
+    assert [e.child_key for e in chain] == ["acme/big", "acme/util"]
+    assert chain[0].parent_key is None  # root
+    assert chain[1].parent_key == "acme/big"
+
+
+def test_compute_why_transitive_dep_with_multiple_paths():
+    p1 = _direct("acme/big")
+    p2 = _direct("acme/other")
+    util1 = _transitive("acme/util", resolved_by="acme/big")
+    util2 = _transitive("acme/util", resolved_by="acme/other", depth=2)
+    # Two different unique keys via virtual_path so both survive add_dependency
+    util2.virtual_path = "alt"
+    util2.is_virtual = True
+    lf = _build([p1, p2, util1, util2])
+
+    # Picking util1 only finds the path via acme/big (compute_why operates
+    # on a single target record; multi-route diamond is exercised below).
+    result = compute_why(lf, util1)
+    assert result.is_direct is False
+    assert len(result.paths) == 1
+
+
+def test_compute_why_diamond_dependency_lists_both_routes():
+    # A -> B -> D, A -> C -> D. Walker keys parents by repo_url; the lockfile
+    # records D once. compute_why returns one canonical path, not multiple,
+    # because we walk from a single LockedDependency target upward through
+    # its recorded resolved_by parent.
+    a = _direct("o/a")
+    b = _transitive("o/b", resolved_by="o/a")
+    c = _transitive("o/c", resolved_by="o/a")
+    d = _transitive("o/d", resolved_by="o/b")
+    lf = _build([a, b, c, d])
+
+    result = compute_why(lf, d)
+    # Single path because d only records one parent (o/b).
+    assert len(result.paths) == 1
+    chain = result.paths[0].chain
+    assert [e.child_key for e in chain] == ["o/a", "o/b", "o/d"]
+
+
+def test_compute_why_target_in_cycle_does_not_infinite_loop():
+    # Construct a malformed lockfile where two deps reference each other.
+    a = LockedDependency(repo_url="o/a", depth=1, resolved_by="o/b")
+    b = LockedDependency(repo_url="o/b", depth=1, resolved_by="o/a")
+    lf = _build([a, b])
+
+    result = compute_why(lf, a)
+
+    # Walker terminates and returns at least one path; no infinite loop.
+    assert len(result.paths) >= 1
+    for path in result.paths:
+        keys = [e.child_key for e in path.chain]
+        assert keys.count("o/a") <= 1
+        assert keys.count("o/b") <= 1
+
+
+# ---------------------------------------------------------------------------
+# resolve_package_query
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_package_query_by_basename_unique_match():
+    lf = _build([_direct("acme/shared-utils"), _direct("acme/other")])
+    dep = resolve_package_query(lf, "shared-utils")
+    assert dep.repo_url == "acme/shared-utils"
+
+
+def test_resolve_package_query_by_basename_ambiguous_raises():
+    lf = _build(
+        [
+            _direct("acme/shared-utils"),
+            _direct("other-org/shared-utils"),
+        ]
+    )
+    with pytest.raises(AmbiguousPackageError) as exc_info:
+        resolve_package_query(lf, "shared-utils")
+    assert "acme/shared-utils" in exc_info.value.matches
+    assert "other-org/shared-utils" in exc_info.value.matches
+
+
+def test_resolve_package_query_by_owner_repo():
+    lf = _build([_direct("acme/foo"), _direct("acme/bar")])
+    dep = resolve_package_query(lf, "acme/bar")
+    assert dep.repo_url == "acme/bar"
+
+
+def test_resolve_package_query_by_alias_falls_back_to_basename():
+    # Aliases are not stored on LockedDependency today; resolution by alias
+    # gracefully degrades to basename match.
+    lf = _build([_direct("acme/special")])
+    dep = resolve_package_query(lf, "special")
+    assert dep.repo_url == "acme/special"
+
+
+def test_resolve_package_query_by_full_repo_url():
+    lf = _build([_direct("github.com/acme/foo")])
+    dep = resolve_package_query(lf, "github.com/acme/foo")
+    assert dep.repo_url == "github.com/acme/foo"
+
+
+def test_resolve_package_query_not_installed_raises():
+    lf = _build([_direct("acme/foo")])
+    with pytest.raises(PackageNotInstalledError):
+        resolve_package_query(lf, "nope")
+
+
+def test_walker_handles_lockfile_without_constraint_field():
+    # Graceful-degrade trap: LockedDependency on main today has no
+    # ``constraint`` attribute. The walker must still produce edges with
+    # ``constraint=None`` rather than crash on AttributeError.
+    parent = _direct("acme/big")
+    child = _transitive("acme/util", resolved_by="acme/big")
+    lf = _build([parent, child])
+
+    result = compute_why(lf, child)
+    for path in result.paths:
+        for edge in path.chain:
+            # constraint reads gracefully via getattr; either None or str.
+            assert edge.constraint is None or isinstance(edge.constraint, str)
+
+
+def test_walker_handles_basename_with_trailing_dot_git():
+    lf = _build([_direct("acme/foo.git")])
+    dep = resolve_package_query(lf, "foo")
+    assert dep.repo_url == "acme/foo.git"

--- a/tests/unit/deps/test_why_walker.py
+++ b/tests/unit/deps/test_why_walker.py
@@ -79,11 +79,13 @@ def test_compute_why_transitive_dep_with_multiple_paths():
     assert len(result.paths) == 1
 
 
-def test_compute_why_diamond_dependency_lists_both_routes():
+def test_compute_why_diamond_records_single_resolved_by_path():
     # A -> B -> D, A -> C -> D. Walker keys parents by repo_url; the lockfile
-    # records D once. compute_why returns one canonical path, not multiple,
-    # because we walk from a single LockedDependency target upward through
-    # its recorded resolved_by parent.
+    # records D once with a single resolved_by. compute_why returns one
+    # canonical path, not multiple, because we walk from a single
+    # LockedDependency target upward through its one recorded parent.
+    # (Multi-parent fan-in would require a lockfile schema change -- the
+    # iterative worklist is ready for it without an API change.)
     a = _direct("o/a")
     b = _transitive("o/b", resolved_by="o/a")
     c = _transitive("o/c", resolved_by="o/a")

--- a/tests/unit/deps/test_why_walker.py
+++ b/tests/unit/deps/test_why_walker.py
@@ -62,7 +62,12 @@ def test_compute_why_transitive_dep_with_one_path():
     assert chain[1].parent_key == "acme/big"
 
 
-def test_compute_why_transitive_dep_with_multiple_paths():
+def test_compute_why_target_with_duplicate_repo_url_walks_recorded_parent():
+    # Two records share the same repo_url under different virtual_path keys.
+    # compute_why() operates on a single LockedDependency target and walks
+    # that record's lone recorded resolved_by parent -- it does NOT fan out
+    # to alternative parents that other duplicate records reference, since
+    # the lockfile schema records exactly one resolved_by per record.
     p1 = _direct("acme/big")
     p2 = _direct("acme/other")
     util1 = _transitive("acme/util", resolved_by="acme/big")
@@ -72,8 +77,7 @@ def test_compute_why_transitive_dep_with_multiple_paths():
     util2.is_virtual = True
     lf = _build([p1, p2, util1, util2])
 
-    # Picking util1 only finds the path via acme/big (compute_why operates
-    # on a single target record; multi-route diamond is exercised below).
+    # Picking util1 only finds the path via acme/big.
     result = compute_why(lf, util1)
     assert result.is_direct is False
     assert len(result.paths) == 1


### PR DESCRIPTION
## TL;DR

Adds `apm deps why <pkg>` -- the bottom-up companion to `apm deps tree`.
When something unexpected lands in `apm_modules/`, this command walks
the lockfile back to one or more direct dependencies that pulled it in,
fully offline, and explains the chain. Inspired by `npm why`,
`yarn why`, and `cargo tree -i`. **Closes #1490.**

> [!NOTE]
> **Soft dependency on #1488.** Constraint annotations
> (`[constraint: ^1.2.0, declared in apm.yml]`) only appear once the
> `constraint` field lands on `LockedDependency`. Until then they
> collapse to `[declared in apm.yml]`. The walker uses `getattr` and a
> dedicated regression test pins the graceful-degrade path -- no code
> change is needed when #1488 merges.

## Problem (WHY)

`apm deps tree` shows the dependency graph top-down. After running
`apm install`, `apm_modules/` may contain transitive packages the
consumer did not declare directly. When something breaks -- an
unexpected MCP server, a skill that surprises the author, a version
that triggers a policy block -- the only way to find out who pulled
it in today is to read `apm.lock.yaml` by hand and trace `resolved_by`
chains.

`apm deps why <pkg>` is the inverted view. It answers "how did this
get here?" without leaving the terminal and without hitting the
network.

## Approach (WHAT)

Two-module split mirroring the existing `_build_dep_tree` /
`tree` pattern in `commands/deps/cli.py`:

| Module | Responsibility |
| --- | --- |
| `src/apm_cli/deps/why_walker.py` | Pure data-structure walker over an in-memory `LockFile`. No Click, no I/O. Inverts `resolved_by` edges and collects every root-to-target chain. |
| `src/apm_cli/commands/deps/why.py` | Click command. Loads the lockfile (project or `--global` user scope), runs the walker, renders human or JSON output, owns exit codes. |

The Click command is registered into the existing `deps` group with one
line in `commands/deps/cli.py` -- no restructuring of any existing
module.

## Implementation (HOW)

### Walker (`why_walker.py`)

```mermaid
flowchart LR
    Q[query string] --> R[resolve_package_query]
    R -->|exact key| T[target LockedDependency]
    R -->|owner/repo| T
    R -->|basename| T
    R -.->|ambiguous| AE[AmbiguousPackageError]
    R -.->|none| PE[PackageNotInstalledError]
    T --> W[compute_why]
    W -->|direct| Direct[WhyResult is_direct=True]
    W -->|transitive| Walk[iterative parent walk]
    Walk --> WR[WhyResult is_direct=False<br/>paths: tuple of WhyPath]
```

Key invariants:

- **Cycle safety:** per-traversal `visited` frozen set; each `repo_url`
  appears at most once per chain. Defensive depth cap of
  `max(64, len(deps)+1)`.
- **Deterministic ordering:** `paths` are sorted by their stringified
  chain so JSON snapshots and human output are stable.
- **Backward compat:** `_dep_constraint` is `getattr(dep, "constraint",
  None)`. Soft-couples to #1488.

Result types are frozen dataclasses (`WhyEdge`, `WhyPath`, `WhyResult`)
to keep snapshots deterministic and prevent accidental mutation.

### Command (`commands/deps/why.py`)

```mermaid
flowchart TD
    CLI[apm deps why PKG] --> Scope{--global?}
    Scope -->|no| Proj[get_apm_dir PROJECT]
    Scope -->|yes| User[get_apm_dir USER]
    Proj & User --> LF[load lockfile]
    LF -->|missing| E2[exit 2 + error]
    LF -->|ok| RES[resolve_package_query]
    RES -->|ambiguous| E1A[exit 1 + matches list]
    RES -->|not found| E1B[exit 1 + hint]
    RES -->|hit| CW[compute_why]
    CW --> Render{--json?}
    Render -->|no| Human[plain ASCII indented tree]
    Render -->|yes| JSON[stable JSON schema]
```

Rendering choices (per design pack convergence note):

- **No `rich.tree`.** A list of N short chains is not a single
  hierarchy; `rich.tree` would visually imply one that does not exist.
  Plain indented text with ASCII `+--` markers is more scannable and
  keeps snapshot tests deterministic.
- **STATUS_SYMBOLS convention.** Header uses `[i]` (matches
  `_rich_info`). Constraint and declaration metadata wrapped in
  `[brackets]` -- pure ASCII, Windows-cp1252-safe.

### Wiring

```python
# src/apm_cli/commands/deps/cli.py
from .why import why as _why_cmd
deps.add_command(_why_cmd)
```

```python
# src/apm_cli/commands/deps/__init__.py
from .why import why
__all__ = [..., "why"]
```

## Trade-offs

| Decision | Alternative | Why this one |
| --- | --- | --- |
| Plain ASCII tree | `rich.tree` | Output isn't a single tree; rich would mislead. Plain text snapshot tests are deterministic across terminals. |
| `getattr` for `constraint` | Hard-import + bump on #1488 | Decouples themes -- this PR works on main today and gains the annotation automatically once #1488 merges. No follow-up commit required. |
| Walker keys parents by `repo_url` | Track full diamond fan-in | `LockedDependency` records one parent (`resolved_by`); a true multi-parent diamond would need lockfile-schema changes. Out of scope for #1490. |
| Exit code split (`1` vs `2`) | Single `1` for all errors | Lets CI distinguish "you forgot to run install" (`2`) from "wrong package name" (`1`). |

## Validation evidence

| Gate | Result |
| --- | --- |
| `ruff check src/ tests/` | clean |
| `ruff format --check src/ tests/` | clean |
| `pylint -e R0801 --min-similarity-lines=10 --fail-on=R0801` | 10.00/10 |
| `bash scripts/lint-auth-signals.sh` | clean |
| File-length cap (2450) | cli.py at 931, why.py at 226, why_walker.py at 274 |
| New unit tests | 22 passing (13 walker + 9 command) |
| New integration tests | 4 passing |
| Regression on existing deps-area tests | 242 / 242 passing |
| No-network trap | `subprocess.run` and `urlopen` mocked, asserted untouched in both human and JSON paths |

## How to test

```bash
# In a project with a lockfile:
apm deps why <some-transitive-pkg>           # human output
apm deps why <some-transitive-pkg> --json    # JSON for scripts
apm deps why <some-pkg> --global             # user-scope lockfile

# Negative paths:
apm deps why unknown-pkg                     # exit 1, suggests `apm deps list`
apm deps why <ambiguous-basename>            # exit 1, lists matches
cd /tmp/empty && apm deps why anything       # exit 2, suggests `apm install`
```

```bash
# Run the new tests:
uv run --extra dev pytest \
    tests/unit/deps/test_why_walker.py \
    tests/unit/commands/deps/test_why_command.py \
    tests/integration/test_deps_why_e2e.py -v
```
