### PR TITLE
feat(outdated): support monorepo tag nameing convention

### DIFF
--- a/docs/src/content/docs/reference/cli/marketplace.md
+++ b/docs/src/content/docs/reference/cli/marketplace.md
@@ -201,6 +201,11 @@ versions available.
 | `--offline` | Use cached refs only. |
 | `--include-prerelease` | Consider prerelease tags. |
 
+When remote tags use a non-default layout (for example `my-pkg@1.0.1`), set
+`tag_pattern: "{name}@{version}"` on the package entry or under `build:` in
+`apm.yml`. If no tags match the configured pattern, `apm marketplace outdated`
+tries common layouts (`v{version}`, `{name}@{version}`, etc.) automatically.
+
 ### `apm marketplace publish`
 
 Push marketplace updates to one or more **consumer** repositories,

--- a/docs/src/content/docs/reference/cli/marketplace.md
+++ b/docs/src/content/docs/reference/cli/marketplace.md
@@ -201,10 +201,10 @@ versions available.
 | `--offline` | Use cached refs only. |
 | `--include-prerelease` | Consider prerelease tags. |
 
-When remote tags use a non-default layout (for example `my-pkg@1.0.1`), set
-`tag_pattern: "{name}@{version}"` on the package entry or under `build:` in
+When remote tags use a non-default layout (for example `my-pkg_v1.0.1`), set
+`tag_pattern: "{name}_v{version}"` on the package entry or under `build:` in
 `apm.yml`. If no tags match the configured pattern, `apm marketplace outdated`
-tries common layouts (`v{version}`, `{name}@{version}`, etc.) automatically.
+tries common layouts (`v{version}`, `{name}_v{version}`, etc.) automatically.
 
 ### `apm marketplace publish`
 

--- a/docs/src/content/docs/reference/cli/marketplace.md
+++ b/docs/src/content/docs/reference/cli/marketplace.md
@@ -203,8 +203,20 @@ versions available.
 
 When remote tags use a non-default layout (for example `my-pkg_v1.0.1`), set
 `tag_pattern: "{name}_v{version}"` on the package entry or under `build:` in
-`apm.yml`. If no tags match the configured pattern, `apm marketplace outdated`
-tries common layouts (`v{version}`, `{name}_v{version}`, etc.) automatically.
+`apm.yml`:
+
+```yaml
+packages:
+  - name: my-pkg
+    source: org/monorepo
+    version: "^1.0.0"
+    tag_pattern: "{name}_v{version}"
+```
+
+If no tags match the configured pattern, `apm marketplace outdated` tries common
+layouts (`v{version}`, `{name}_v{version}`, `{name}--v{version}`, etc.)
+automatically. Set `tag_pattern` explicitly when your producer uses a different
+layout.
 
 ### `apm marketplace publish`
 

--- a/docs/src/content/docs/reference/cli/outdated.md
+++ b/docs/src/content/docs/reference/cli/outdated.md
@@ -17,7 +17,7 @@ apm outdated [OPTIONS]
 
 `apm outdated` reads `apm.lock.yaml` and queries each remote to detect staleness:
 
-- **Tag-pinned deps** (e.g. `v1.2.3`): semver compare against the latest available remote tag.
+- **Tag-pinned deps** (e.g. `v1.2.3`, `1.2.3`, or patterned tags like `my-pkg@1.2.3`): semver compare against the latest matching remote tag. Patterned tags (`{name}@{version}`, `{name}-v{version}`, etc.) are detected automatically from the locked ref.
 - **Branch-pinned deps** (e.g. `main`): compare the locked commit SHA against the remote branch tip.
 - **Default-branch deps** (no ref): compare against `main`/`master` tip.
 - **Marketplace deps**: compare the installed ref against the marketplace entry's current `source.ref`.

--- a/docs/src/content/docs/reference/cli/outdated.md
+++ b/docs/src/content/docs/reference/cli/outdated.md
@@ -17,7 +17,7 @@ apm outdated [OPTIONS]
 
 `apm outdated` reads `apm.lock.yaml` and queries each remote to detect staleness:
 
-- **Tag-pinned deps** (e.g. `v1.2.3`, `1.2.3`, or patterned tags like `my-pkg@1.2.3`): semver compare against the latest matching remote tag. Patterned tags (`{name}@{version}`, `{name}-v{version}`, etc.) are detected automatically from the locked ref.
+- **Tag-pinned deps** (e.g. `v1.2.3`, `1.2.3`, or patterned tags like `my-pkg_v1.2.3`): semver compare against the latest matching remote tag. Patterned tags (`{name}_v{version}`, `{name}-v{version}`, etc.) are detected automatically from the locked ref.
 - **Branch-pinned deps** (e.g. `main`): compare the locked commit SHA against the remote branch tip.
 - **Default-branch deps** (no ref): compare against `main`/`master` tip.
 - **Marketplace deps**: compare the installed ref against the marketplace entry's current `source.ref`.

--- a/docs/src/content/docs/reference/cli/outdated.md
+++ b/docs/src/content/docs/reference/cli/outdated.md
@@ -17,11 +17,14 @@ apm outdated [OPTIONS]
 
 `apm outdated` reads `apm.lock.yaml` and queries each remote to detect staleness:
 
-- **Tag-pinned deps** (e.g. `v1.2.3`, `1.2.3`, or patterned tags like `my-pkg_v1.2.3`): semver compare against the latest matching remote tag. Patterned tags (`{name}_v{version}`, `{name}-v{version}`, etc.) are detected automatically from the locked ref.
+- **Plain tag-pinned deps** (e.g. `v1.2.3` or `1.2.3`): semver compare against the latest matching remote tag.
+- **Patterned tag-pinned deps** (e.g. `my-pkg_v1.2.3`, `my-pkg--v1.2.3`, or `my-pkg-v1.2.3`): semver compare against the latest tag matching the package-specific pattern inferred from the locked ref.
 - **Branch-pinned deps** (e.g. `main`): compare the locked commit SHA against the remote branch tip.
 - **Default-branch deps** (no ref): compare against `main`/`master` tip.
 - **Marketplace deps**: compare the installed ref against the marketplace entry's current `source.ref`.
 - **Registry deps** (experimental `registries` feature): compare the lockfile's exact `version` against the highest semver on the registry that satisfies the manifest range (same resolution semantics as `apm install`). Manifest ranges come from the root `apm.yml` and from installed packages' `apm.yml` files (transitive deps). When a registry lockfile entry has no manifest range, `apm outdated` compares against the highest published version and labels the source `(lockfile)`.
+
+Common monorepo layouts are detected automatically for `outdated` reporting. Set an explicit marketplace `tag_pattern` when your producer uses a different layout than the built-in patterns.
 
 Local dependencies and Artifactory-hosted deps are skipped. Legacy `apm.lock` files are migrated to `apm.lock.yaml` automatically on read.
 

--- a/packages/apm-guide/.apm/skills/apm-usage/commands.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/commands.md
@@ -19,7 +19,7 @@
 | `apm deps why PKG` | Explain why a package is installed (walks lockfile bottom-up to direct deps; analogue of `npm why` / `yarn why`) | `-g` global, `--json` |
 | `apm find <PATH>` | Trace a deployed file back to the package(s) that contributed it (inverse of install; reads `apm.lock.yaml` only) | `--source` show OCI/git/local origin, `--path` show full why-chain (same as `apm deps why`) |
 | `apm view PKG [FIELD]` | View package details or remote refs | `-g` global, `FIELD=versions` |
-| `apm outdated` | Check locked deps via SHA/semver comparison | `-g` global, `-v` verbose, `-j N` parallel checks |
+| `apm outdated` | Check locked deps via SHA/semver comparison; patterned per-package tags are auto-detected | `-g` global, `-v` verbose, `-j N` parallel checks |
 | `apm deps info PKG` | Alias for `apm view PKG` local metadata | -- |
 | `apm deps clean` | Clean dependency cache | `--dry-run`, `-y` skip confirm |
 | `apm deps update [PKGS...]` | Deprecated -- use `apm update` instead (now a strict superset). Update specific packages | `--verbose`, `--force`, `--target` (comma-separated), `--parallel-downloads N`, `-g/--global`, `--legacy-skill-paths` |
@@ -136,7 +136,7 @@ Credentials resolve via `APM_REGISTRY_TOKEN_{NAME}` env var (or `apm config set 
 |---------|---------|-----------|
 | `apm marketplace init` | Append a `marketplace:` block to `apm.yml` and create `.claude-plugin/` | `--force`, `--no-gitignore-check`, `--name`, `--owner` |
 | `apm marketplace migrate` | Fold a legacy `marketplace.yml` into `apm.yml`'s `marketplace:` block; deletes `marketplace.yml` on success | `--force`/`--yes`/`-y`, `--dry-run`, `-v` |
-| `apm marketplace outdated` | Report upgradable plugins, range-aware | `--offline`, `--include-prerelease`, `-v` |
+| `apm marketplace outdated` | Report upgradable plugins, range-aware; respects `tag_pattern` and common monorepo tag layouts | `--offline`, `--include-prerelease`, `-v` |
 | `apm marketplace check` | Validate the `marketplace:` block and verify refs resolve | `--offline`, `-v` |
 | `apm marketplace doctor` | Diagnose git, network, auth, marketplace config readiness, and (when a `marketplace:` block is present) **format coverage** -- which output profiles are configured vs. supported, so producers can spot easy reach wins (e.g. add `codex: {}` to also publish for Codex consumers). All marketplace-specific rows are informational and never affect exit code. | `-v` |
 | `apm marketplace publish` | Open PRs on consumer repos from `consumer-targets.yml` | `--targets PATH`, `--dry-run`, `--no-pr`, `--draft`, `--allow-downgrade`, `--allow-ref-change`, `--parallel N`, `-y` |

--- a/src/apm_cli/commands/marketplace/__init__.py
+++ b/src/apm_cli/commands/marketplace/__init__.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import builtins
 import json
+import logging
 import re
 import sys
 import traceback
@@ -48,6 +49,8 @@ from ...marketplace.semver import SemVer, parse_semver, satisfies_range
 from ...marketplace.yml_schema import load_marketplace_yml
 from ...utils.path_security import PathTraversalError, validate_path_segments
 from .._helpers import _get_console, _is_interactive
+
+logger = logging.getLogger(__name__)
 
 # Restore builtins shadowed by subcommand names
 list = builtins.list
@@ -1048,6 +1051,12 @@ def _extract_tag_versions(refs, entry, yml, include_prerelease):
     if not results:
         inferred = infer_tag_pattern_from_refs(refs, entry.name)
         if inferred and inferred != pattern:
+            logger.debug(
+                "Configured tag pattern %r matched no tags for %s; inferred %r",
+                pattern,
+                entry.name,
+                inferred,
+            )
             results = _collect(inferred)
     return results
 

--- a/src/apm_cli/commands/marketplace/__init__.py
+++ b/src/apm_cli/commands/marketplace/__init__.py
@@ -1025,15 +1025,26 @@ def _load_current_versions():
 def _extract_tag_versions(refs, entry, yml, include_prerelease):
     """Extract (SemVer, tag_name) pairs from remote refs for a package entry."""
     from ...marketplace._shared import iter_semver_tags
-    from ...marketplace.tag_pattern import build_tag_regex
+    from ...marketplace.tag_pattern import (
+        build_tag_regex,
+        infer_tag_pattern_from_refs,
+    )
+
+    def _collect(pattern: str) -> list:
+        tag_rx = build_tag_regex(pattern)
+        collected = []
+        for sv, tag_name, _ in iter_semver_tags(refs, tag_rx):
+            if sv.is_prerelease and not (include_prerelease or entry.include_prerelease):
+                continue
+            collected.append((sv, tag_name))
+        return collected
 
     pattern = entry.tag_pattern or yml.build.tag_pattern
-    tag_rx = build_tag_regex(pattern)
-    results = []
-    for sv, tag_name, _ in iter_semver_tags(refs, tag_rx):
-        if sv.is_prerelease and not (include_prerelease or entry.include_prerelease):
-            continue
-        results.append((sv, tag_name))
+    results = _collect(pattern)
+    if not results:
+        inferred = infer_tag_pattern_from_refs(refs, entry.name)
+        if inferred and inferred != pattern:
+            results = _collect(inferred)
     return results
 
 

--- a/src/apm_cli/commands/marketplace/__init__.py
+++ b/src/apm_cli/commands/marketplace/__init__.py
@@ -1031,7 +1031,11 @@ def _extract_tag_versions(refs, entry, yml, include_prerelease):
     )
 
     def _collect(pattern: str) -> list:
-        tag_rx = build_tag_regex(pattern)
+        tag_rx = (
+            build_tag_regex(pattern, name=entry.name)
+            if "{name}" in pattern
+            else build_tag_regex(pattern)
+        )
         collected = []
         for sv, tag_name, _ in iter_semver_tags(refs, tag_rx):
             if sv.is_prerelease and not (include_prerelease or entry.include_prerelease):

--- a/src/apm_cli/commands/outdated.py
+++ b/src/apm_cli/commands/outdated.py
@@ -19,14 +19,57 @@ logger = logging.getLogger(__name__)
 TAG_RE = re.compile(r"^v?\d+\.\d+\.\d+")
 
 
-def _is_tag_ref(ref: str) -> bool:
-    """Return True when *ref* looks like a semver tag (v1.2.3 or 1.2.3)."""
-    return bool(TAG_RE.match(ref)) if ref else False
+def _is_tag_ref(ref: str, package_name: str | None = None) -> bool:
+    """Return True when *ref* names a version tag (plain or patterned)."""
+    from ..marketplace.tag_pattern import is_version_tag_ref
+
+    return is_version_tag_ref(ref, package_name)
 
 
 def _strip_v(ref: str) -> str:
     """Strip leading 'v' prefix from a version string."""
     return ref[1:] if ref and ref.startswith("v") else (ref or "")
+
+
+def _package_basename(dep) -> str:
+    """Return the display name used in ``{name}`` tag patterns."""
+    if dep.marketplace_plugin_name:
+        return dep.marketplace_plugin_name
+    repo = dep.repo_url or ""
+    if not repo:
+        return ""
+    return repo.rstrip("/").split("/")[-1]
+
+
+def _resolve_tag_pattern(current_ref: str, package_name: str) -> str | None:
+    """Return the tag pattern for *current_ref*, or ``None`` if not a version tag."""
+    from ..marketplace.tag_pattern import infer_tag_pattern
+
+    inferred = infer_tag_pattern(current_ref, package_name)
+    if inferred:
+        return inferred
+    if TAG_RE.match(current_ref or ""):
+        return "v{version}" if (current_ref or "").startswith(("v", "V")) else "{version}"
+    return None
+
+
+def _semver_tag_candidates(tag_refs, pattern: str):
+    """Return ``(SemVer, tag_name)`` pairs matching *pattern*, highest first."""
+    from ..marketplace.semver import SemVer, parse_semver
+    from ..marketplace.tag_pattern import build_tag_regex, parse_tag_version
+
+    tag_rx = build_tag_regex(pattern)
+    candidates: list[tuple[SemVer, str]] = []
+    for remote_ref in tag_refs:
+        match = tag_rx.match(remote_ref.name)
+        if not match:
+            continue
+        version = match.group("version")
+        parsed = parse_semver(version)
+        if parsed is not None:
+            candidates.append((parsed, remote_ref.name))
+    candidates.sort(key=lambda pair: pair[0], reverse=True)
+    return candidates
 
 
 def _find_remote_tip(ref_name, remote_refs):
@@ -189,7 +232,9 @@ def _check_one_dep(dep, downloader, verbose, registry_ctx=None):
             package=package_name, current=current_ref or "(none)", latest="-", status="unknown"
         )
 
-    is_tag = _is_tag_ref(current_ref)
+    package_basename = _package_basename(dep)
+    tag_pattern = _resolve_tag_pattern(current_ref, package_basename)
+    is_tag = tag_pattern is not None
 
     if is_tag:
         tag_refs = [r for r in remote_refs if r.ref_type == GitReferenceType.TAG]
@@ -202,12 +247,24 @@ def _check_one_dep(dep, downloader, verbose, registry_ctx=None):
                 source="git tags",
             )
 
-        latest_tag = tag_refs[0].name
-        current_ver = _strip_v(current_ref)
-        latest_ver = _strip_v(latest_tag)
+        from ..marketplace.tag_pattern import parse_tag_version
+
+        candidates = _semver_tag_candidates(tag_refs, tag_pattern)
+        if not candidates:
+            return OutdatedRow(
+                package=package_name,
+                current=current_ref,
+                latest="-",
+                status="unknown",
+                source="git tags",
+            )
+
+        _, latest_tag = candidates[0]
+        current_ver = parse_tag_version(current_ref, tag_pattern) or _strip_v(current_ref)
+        latest_ver = parse_tag_version(latest_tag, tag_pattern) or _strip_v(latest_tag)
 
         if is_newer_version(current_ver, latest_ver):
-            extra = [r.name for r in tag_refs[:10]] if verbose else []
+            extra = [name for _, name in candidates[:10]] if verbose else []
             return OutdatedRow(
                 package=package_name,
                 current=current_ref,

--- a/src/apm_cli/commands/outdated.py
+++ b/src/apm_cli/commands/outdated.py
@@ -49,16 +49,20 @@ def _resolve_tag_pattern(current_ref: str, package_name: str) -> str | None:
     if inferred:
         return inferred
     if TAG_RE.match(current_ref or ""):
-        return "v{version}" if (current_ref or "").startswith(("v", "V")) else "{version}"
+        return "v{version}" if (current_ref or "").startswith("v") else "{version}"
     return None
 
 
-def _semver_tag_candidates(tag_refs, pattern: str):
+def _semver_tag_candidates(tag_refs, pattern: str, package_name: str = ""):
     """Return ``(SemVer, tag_name)`` pairs matching *pattern*, highest first."""
     from ..marketplace.semver import SemVer, parse_semver
-    from ..marketplace.tag_pattern import build_tag_regex, parse_tag_version
+    from ..marketplace.tag_pattern import build_tag_regex
 
-    tag_rx = build_tag_regex(pattern)
+    tag_rx = (
+        build_tag_regex(pattern, name=package_name)
+        if "{name}" in pattern and package_name
+        else build_tag_regex(pattern)
+    )
     candidates: list[tuple[SemVer, str]] = []
     for remote_ref in tag_refs:
         match = tag_rx.match(remote_ref.name)
@@ -249,7 +253,7 @@ def _check_one_dep(dep, downloader, verbose, registry_ctx=None):
 
         from ..marketplace.tag_pattern import parse_tag_version
 
-        candidates = _semver_tag_candidates(tag_refs, tag_pattern)
+        candidates = _semver_tag_candidates(tag_refs, tag_pattern, package_basename)
         if not candidates:
             return OutdatedRow(
                 package=package_name,
@@ -260,8 +264,12 @@ def _check_one_dep(dep, downloader, verbose, registry_ctx=None):
             )
 
         _, latest_tag = candidates[0]
-        current_ver = parse_tag_version(current_ref, tag_pattern) or _strip_v(current_ref)
-        latest_ver = parse_tag_version(latest_tag, tag_pattern) or _strip_v(latest_tag)
+        current_ver = (
+            parse_tag_version(current_ref, tag_pattern, name=package_basename) or _strip_v(current_ref)
+        )
+        latest_ver = (
+            parse_tag_version(latest_tag, tag_pattern, name=package_basename) or _strip_v(latest_tag)
+        )
 
         if is_newer_version(current_ver, latest_ver):
             extra = [name for _, name in candidates[:10]] if verbose else []

--- a/src/apm_cli/commands/outdated.py
+++ b/src/apm_cli/commands/outdated.py
@@ -16,6 +16,7 @@ from ..deps.outdated_row import OutdatedRow
 
 logger = logging.getLogger(__name__)
 
+# Fallback heuristic for _resolve_tag_pattern when inference misses plain tags.
 TAG_RE = re.compile(r"^v?\d+\.\d+\.\d+")
 
 
@@ -47,6 +48,12 @@ def _resolve_tag_pattern(current_ref: str, package_name: str) -> str | None:
 
     inferred = infer_tag_pattern(current_ref, package_name)
     if inferred:
+        logger.debug(
+            "Resolved tag pattern %r for %s from ref %s",
+            inferred,
+            package_name,
+            current_ref,
+        )
         return inferred
     if TAG_RE.match(current_ref or ""):
         return "v{version}" if (current_ref or "").startswith("v") else "{version}"
@@ -264,11 +271,11 @@ def _check_one_dep(dep, downloader, verbose, registry_ctx=None):
             )
 
         _, latest_tag = candidates[0]
-        current_ver = (
-            parse_tag_version(current_ref, tag_pattern, name=package_basename) or _strip_v(current_ref)
-        )
-        latest_ver = (
-            parse_tag_version(latest_tag, tag_pattern, name=package_basename) or _strip_v(latest_tag)
+        current_ver = parse_tag_version(
+            current_ref, tag_pattern, name=package_basename
+        ) or _strip_v(current_ref)
+        latest_ver = parse_tag_version(latest_tag, tag_pattern, name=package_basename) or _strip_v(
+            latest_tag
         )
 
         if is_newer_version(current_ver, latest_ver):

--- a/src/apm_cli/marketplace/tag_pattern.py
+++ b/src/apm_cli/marketplace/tag_pattern.py
@@ -32,6 +32,7 @@ DEFAULT_TAG_PATTERNS: tuple[str, ...] = (
     "v{version}",
     "{version}",
     "{name}_v{version}",
+    "{name}--v{version}",
     "{name}-v{version}",
 )
 
@@ -120,10 +121,7 @@ def build_tag_regex(pattern: str, *, name: str | None = None) -> re.Pattern[str]
     )
 
     escaped = escaped.replace(re.escape(_sentinel_version), _VERSION_RX)
-    if _PLACEHOLDER_NAME in pattern and name:
-        name_rx = re.escape(name)
-    else:
-        name_rx = r"[^/]+"
+    name_rx = re.escape(name) if _PLACEHOLDER_NAME in pattern and name else r"[^/]+"
     escaped = escaped.replace(re.escape(_sentinel_name), name_rx)
 
     return re.compile(r"^" + escaped + r"$")

--- a/src/apm_cli/marketplace/tag_pattern.py
+++ b/src/apm_cli/marketplace/tag_pattern.py
@@ -18,9 +18,27 @@ from __future__ import annotations
 import re
 
 __all__ = [
+    "DEFAULT_TAG_PATTERNS",
     "build_tag_regex",
+    "infer_tag_pattern",
+    "infer_tag_pattern_from_refs",
+    "is_version_tag_ref",
+    "parse_tag_version",
     "render_tag",
 ]
+
+# Common tag layouts tried when no explicit ``tag_pattern`` is configured.
+DEFAULT_TAG_PATTERNS: tuple[str, ...] = (
+    "v{version}",
+    "{version}",
+    "{name}@{version}",
+    "{name}-v{version}",
+)
+
+_PLAIN_SEMVER_RE = re.compile(
+    r"^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
 
 # Placeholders we recognise.
 _PLACEHOLDER_VERSION = "{version}"
@@ -101,3 +119,45 @@ def build_tag_regex(pattern: str) -> re.Pattern[str]:
     escaped = escaped.replace(re.escape(_sentinel_name), r"[^/]+")
 
     return re.compile(r"^" + escaped + r"$")
+
+
+def infer_tag_pattern(tag: str, package_name: str = "") -> str | None:
+    """Return the first default pattern that matches *tag*, or ``None``.
+
+    *package_name* is accepted for API symmetry with :func:`render_tag` but
+    is not required for matching because ``{name}`` is a wildcard.
+    """
+    del package_name  # reserved for callers that pass the package display name
+    for pattern in DEFAULT_TAG_PATTERNS:
+        if build_tag_regex(pattern).match(tag):
+            return pattern
+    return None
+
+
+def infer_tag_pattern_from_refs(refs: list, package_name: str = "") -> str | None:
+    """Infer a tag pattern from the first semver-like tag in *refs*."""
+    for remote_ref in refs:
+        name = getattr(remote_ref, "name", "") or ""
+        if name.startswith("refs/tags/"):
+            name = name[len("refs/tags/") :]
+        found = infer_tag_pattern(name, package_name)
+        if found:
+            return found
+    return None
+
+
+def parse_tag_version(tag: str, pattern: str) -> str | None:
+    """Extract the semver substring from *tag* using *pattern*."""
+    match = build_tag_regex(pattern).match(tag)
+    if match is None:
+        return None
+    return match.group("version")
+
+
+def is_version_tag_ref(ref: str, package_name: str | None = None) -> bool:
+    """Return True when *ref* names a version tag (plain or patterned)."""
+    if not ref:
+        return False
+    if _PLAIN_SEMVER_RE.match(ref):
+        return True
+    return infer_tag_pattern(ref, package_name or "") is not None

--- a/src/apm_cli/marketplace/tag_pattern.py
+++ b/src/apm_cli/marketplace/tag_pattern.py
@@ -31,7 +31,7 @@ __all__ = [
 DEFAULT_TAG_PATTERNS: tuple[str, ...] = (
     "v{version}",
     "{version}",
-    "{name}@{version}",
+    "{name}_v{version}",
     "{name}-v{version}",
 )
 

--- a/src/apm_cli/marketplace/tag_pattern.py
+++ b/src/apm_cli/marketplace/tag_pattern.py
@@ -67,18 +67,22 @@ def render_tag(pattern: str, *, name: str, version: str) -> str:
     return result
 
 
-def build_tag_regex(pattern: str) -> re.Pattern[str]:
+def build_tag_regex(pattern: str, *, name: str | None = None) -> re.Pattern[str]:
     """Return a compiled regex that captures ``{version}`` from a tag.
 
     Literal text in *pattern* is escaped so that special regex characters
     (e.g. dots, parens) are matched verbatim.  ``{version}`` becomes a
     named capture group ``(?P<version>...)`` matching a semver-like
-    string.  ``{name}`` becomes a non-capturing wildcard ``[^/]+``.
+    string.  ``{name}`` becomes a non-capturing wildcard ``[^/]+``, or
+    the literal *name* when provided (for monorepo per-package tags).
 
     Parameters
     ----------
     pattern:
         Tag pattern string, e.g. ``"v{version}"``.
+    name:
+        When set and the pattern contains ``{name}``, match only this
+        package name instead of any ``[^/]+`` segment.
 
     Returns
     -------
@@ -116,7 +120,11 @@ def build_tag_regex(pattern: str) -> re.Pattern[str]:
     )
 
     escaped = escaped.replace(re.escape(_sentinel_version), _VERSION_RX)
-    escaped = escaped.replace(re.escape(_sentinel_name), r"[^/]+")
+    if _PLACEHOLDER_NAME in pattern and name:
+        name_rx = re.escape(name)
+    else:
+        name_rx = r"[^/]+"
+    escaped = escaped.replace(re.escape(_sentinel_name), name_rx)
 
     return re.compile(r"^" + escaped + r"$")
 
@@ -124,12 +132,16 @@ def build_tag_regex(pattern: str) -> re.Pattern[str]:
 def infer_tag_pattern(tag: str, package_name: str = "") -> str | None:
     """Return the first default pattern that matches *tag*, or ``None``.
 
-    *package_name* is accepted for API symmetry with :func:`render_tag` but
-    is not required for matching because ``{name}`` is a wildcard.
+    When *package_name* is set, patterns containing ``{name}`` only match
+    tags for that package (monorepo-safe).
     """
-    del package_name  # reserved for callers that pass the package display name
     for pattern in DEFAULT_TAG_PATTERNS:
-        if build_tag_regex(pattern).match(tag):
+        rx = (
+            build_tag_regex(pattern, name=package_name)
+            if _PLACEHOLDER_NAME in pattern and package_name
+            else build_tag_regex(pattern)
+        )
+        if rx.match(tag):
             return pattern
     return None
 
@@ -146,12 +158,19 @@ def infer_tag_pattern_from_refs(refs: list, package_name: str = "") -> str | Non
     return None
 
 
-def parse_tag_version(tag: str, pattern: str) -> str | None:
+def parse_tag_version(tag: str, pattern: str, *, name: str | None = None) -> str | None:
     """Extract the semver substring from *tag* using *pattern*."""
-    match = build_tag_regex(pattern).match(tag)
+    if _PLACEHOLDER_VERSION not in pattern:
+        return None
+    rx = (
+        build_tag_regex(pattern, name=name)
+        if _PLACEHOLDER_NAME in pattern and name
+        else build_tag_regex(pattern)
+    )
+    match = rx.match(tag)
     if match is None:
         return None
-    return match.group("version")
+    return match.groupdict().get("version")
 
 
 def is_version_tag_ref(ref: str, package_name: str | None = None) -> bool:

--- a/tests/integration/marketplace/test_outdated_integration.py
+++ b/tests/integration/marketplace/test_outdated_integration.py
@@ -61,6 +61,15 @@ def _refs_alpha():
     ]
 
 
+def _refs_alpha_named():
+    """alpha: monorepo-style tags with package name prefix."""
+    return [
+        RemoteRef(name="refs/tags/alpha_v1.0.0", sha="a" * 40),
+        RemoteRef(name="refs/tags/alpha_v1.1.0", sha="b" * 40),
+        RemoteRef(name="refs/tags/beta_v9.9.9", sha="c" * 40),
+    ]
+
+
 def _refs_beta():
     """beta: v2.0.0 only -- no newer version available."""
     return [
@@ -78,6 +87,7 @@ def _refs_pinned():
 def _side_effect(owner_repo: str):
     return {
         "org/alpha": _refs_alpha(),
+        "org/alpha-monorepo": _refs_alpha_named(),
         "org/beta": _refs_beta(),
         "org/pinned": _refs_pinned(),
     }.get(owner_repo, [])
@@ -205,6 +215,26 @@ class TestOutdatedVersionRanges:
         combined = result.output
         # v2.0.0 is the latest overall; it should appear in the overall-latest column
         assert "v2.0.0" in combined
+
+    def test_name_underscore_tags_are_inferred_end_to_end(self, tmp_path: Path):
+        """Monorepo tags like alpha_v1.1.0 are reported through the CLI path."""
+        yml_content = """\
+name: outdated-test
+description: Marketplace for outdated tests
+version: 1.0.0
+owner:
+  name: Test Org
+packages:
+  - name: alpha
+    source: org/alpha-monorepo
+    version: "^1.0.0"
+    tags:
+      - test
+"""
+        result = _run_outdated(tmp_path, yml_content=yml_content)
+        assert result.exit_code == 1
+        assert "alpha_v1.1.0" in result.output
+        assert "beta_v9.9.9" not in result.output
 
 
 class TestOutdatedMissingYml:

--- a/tests/integration/test_outdated_coverage.py
+++ b/tests/integration/test_outdated_coverage.py
@@ -47,10 +47,14 @@ class TestIsTagRef:
         assert _is_tag_ref("v1") is False
         assert _is_tag_ref("v1.2") is False
 
-    def test_name_at_version_pattern(self):
-        """Recognizes ``{name}@{version}`` style tags."""
-        assert _is_tag_ref("api-governance@1.0.1") is True
-        assert _is_tag_ref("my-tool@2.0.0") is True
+    def test_name_underscore_v_version_pattern(self):
+        """Recognizes ``{name}_v{version}`` style tags."""
+        assert _is_tag_ref("api-governance_v1.0.1") is True
+        assert _is_tag_ref("my-tool_v2.0.0") is True
+
+    def test_name_at_version_not_recognized(self):
+        """``@`` is marketplace install syntax, not inferred as a git tag."""
+        assert _is_tag_ref("api-governance@1.0.1") is False
 
     def test_empty_string(self):
         """Empty string returns False."""

--- a/tests/integration/test_outdated_coverage.py
+++ b/tests/integration/test_outdated_coverage.py
@@ -47,6 +47,11 @@ class TestIsTagRef:
         assert _is_tag_ref("v1") is False
         assert _is_tag_ref("v1.2") is False
 
+    def test_name_at_version_pattern(self):
+        """Recognizes ``{name}@{version}`` style tags."""
+        assert _is_tag_ref("api-governance@1.0.1") is True
+        assert _is_tag_ref("my-tool@2.0.0") is True
+
     def test_empty_string(self):
         """Empty string returns False."""
         assert _is_tag_ref("") is False

--- a/tests/unit/commands/test_marketplace_outdated.py
+++ b/tests/unit/commands/test_marketplace_outdated.py
@@ -100,9 +100,9 @@ def yml_cwd(tmp_path, monkeypatch):
 
 
 class TestExtractTagVersionsInference:
-    """``_extract_tag_versions`` infers ``{name}@{version}`` when default fails."""
+    """``_extract_tag_versions`` infers ``{name}_v{version}`` when default fails."""
 
-    def test_infers_name_at_version_from_remote_tags(self):
+    def test_infers_name_underscore_v_version_from_remote_tags(self):
         from types import SimpleNamespace
 
         from apm_cli.commands.marketplace import _extract_tag_versions
@@ -114,13 +114,13 @@ class TestExtractTagVersionsInference:
         )
         yml = SimpleNamespace(build=SimpleNamespace(tag_pattern="v{version}"))
         refs = [
-            RemoteRef(name="refs/tags/api-governance@1.0.1", sha=_SHA_A),
-            RemoteRef(name="refs/tags/api-governance@1.0.2", sha=_SHA_B),
+            RemoteRef(name="refs/tags/api-governance_v1.0.1", sha=_SHA_A),
+            RemoteRef(name="refs/tags/api-governance_v1.0.2", sha=_SHA_B),
         ]
         results = _extract_tag_versions(refs, entry, yml, include_prerelease=False)
         tag_names = [tag for _sv, tag in results]
-        assert "api-governance@1.0.1" in tag_names
-        assert "api-governance@1.0.2" in tag_names
+        assert "api-governance_v1.0.1" in tag_names
+        assert "api-governance_v1.0.2" in tag_names
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/commands/test_marketplace_outdated.py
+++ b/tests/unit/commands/test_marketplace_outdated.py
@@ -95,6 +95,35 @@ def yml_cwd(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Tag-pattern inference
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTagVersionsInference:
+    """``_extract_tag_versions`` infers ``{name}@{version}`` when default fails."""
+
+    def test_infers_name_at_version_from_remote_tags(self):
+        from types import SimpleNamespace
+
+        from apm_cli.commands.marketplace import _extract_tag_versions
+
+        entry = SimpleNamespace(
+            name="api-governance",
+            tag_pattern=None,
+            include_prerelease=False,
+        )
+        yml = SimpleNamespace(build=SimpleNamespace(tag_pattern="v{version}"))
+        refs = [
+            RemoteRef(name="refs/tags/api-governance@1.0.1", sha=_SHA_A),
+            RemoteRef(name="refs/tags/api-governance@1.0.2", sha=_SHA_B),
+        ]
+        results = _extract_tag_versions(refs, entry, yml, include_prerelease=False)
+        tag_names = [tag for _sv, tag in results]
+        assert "api-governance@1.0.1" in tag_names
+        assert "api-governance@1.0.2" in tag_names
+
+
+# ---------------------------------------------------------------------------
 # Happy path
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/commands/test_marketplace_outdated.py
+++ b/tests/unit/commands/test_marketplace_outdated.py
@@ -116,11 +116,32 @@ class TestExtractTagVersionsInference:
         refs = [
             RemoteRef(name="refs/tags/api-governance_v1.0.1", sha=_SHA_A),
             RemoteRef(name="refs/tags/api-governance_v1.0.2", sha=_SHA_B),
+            RemoteRef(name="refs/tags/other-pkg_v9.9.9", sha=_SHA_C),
         ]
         results = _extract_tag_versions(refs, entry, yml, include_prerelease=False)
         tag_names = [tag for _sv, tag in results]
         assert "api-governance_v1.0.1" in tag_names
         assert "api-governance_v1.0.2" in tag_names
+        assert "other-pkg_v9.9.9" not in tag_names
+
+    def test_collect_ignores_other_package_tags_in_monorepo(self):
+        from types import SimpleNamespace
+
+        from apm_cli.commands.marketplace import _extract_tag_versions
+
+        entry = SimpleNamespace(
+            name="apm1",
+            tag_pattern="{name}_v{version}",
+            include_prerelease=False,
+        )
+        yml = SimpleNamespace(build=SimpleNamespace(tag_pattern="v{version}"))
+        refs = [
+            RemoteRef(name="refs/tags/apm1_v1.0.0", sha=_SHA_A),
+            RemoteRef(name="refs/tags/apm2_v1.0.0", sha=_SHA_B),
+        ]
+        results = _extract_tag_versions(refs, entry, yml, include_prerelease=False)
+        tag_names = [tag for _sv, tag in results]
+        assert tag_names == ["apm1_v1.0.0"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/marketplace/test_tag_pattern.py
+++ b/tests/unit/marketplace/test_tag_pattern.py
@@ -159,6 +159,11 @@ class TestBuildTagRegex:
         assert m is not None
         assert m.group("version") == "2.0.0"
 
+    def test_name_specialized_to_package(self) -> None:
+        rx = build_tag_regex("{name}_v{version}", name="apm1")
+        assert rx.match("apm1_v1.0.0") is not None
+        assert rx.match("apm2_v1.0.0") is None
+
     def test_complex_pattern(self) -> None:
         rx = build_tag_regex("{name}@{version}")
         m = rx.match("tool@3.1.4")
@@ -232,6 +237,10 @@ class TestInferTagPattern:
     def test_name_underscore_v_version(self) -> None:
         assert infer_tag_pattern("api-governance_v1.0.1") == "{name}_v{version}"
 
+    def test_name_underscore_v_scoped_to_package(self) -> None:
+        assert infer_tag_pattern("apm1_v1.0.1", "apm1") == "{name}_v{version}"
+        assert infer_tag_pattern("apm2_v1.0.1", "apm1") is None
+
     def test_name_at_version_not_inferred(self) -> None:
         assert infer_tag_pattern("api-governance@1.0.1") is None
 
@@ -258,7 +267,13 @@ class TestIsVersionTagRef:
 
 class TestParseTagVersion:
     def test_name_underscore_v_version(self) -> None:
-        assert parse_tag_version("api-governance_v1.0.1", "{name}_v{version}") == "1.0.1"
+        assert (
+            parse_tag_version("api-governance_v1.0.1", "{name}_v{version}", name="api-governance")
+            == "1.0.1"
+        )
+
+    def test_pattern_without_version_returns_none(self) -> None:
+        assert parse_tag_version("tool-latest", "{name}-latest") is None
 
 
 class TestInferTagPatternFromRefs:

--- a/tests/unit/marketplace/test_tag_pattern.py
+++ b/tests/unit/marketplace/test_tag_pattern.py
@@ -216,7 +216,7 @@ class TestRoundTrip:
             ("{version}", "pkg", "0.0.1"),
             ("{name}-v{version}", "my-tool", "2.0.0"),
             ("release-{version}", "x", "10.20.30"),
-            ("{name}@{version}", "tool", "1.0.0-beta.1"),
+            ("{name}_v{version}", "tool", "1.0.0-beta.1"),
         ],
     )
     def test_roundtrip(self, pattern: str, name: str, version: str) -> None:
@@ -229,8 +229,11 @@ class TestRoundTrip:
 
 
 class TestInferTagPattern:
-    def test_name_at_version(self) -> None:
-        assert infer_tag_pattern("api-governance@1.0.1") == "{name}@{version}"
+    def test_name_underscore_v_version(self) -> None:
+        assert infer_tag_pattern("api-governance_v1.0.1") == "{name}_v{version}"
+
+    def test_name_at_version_not_inferred(self) -> None:
+        assert infer_tag_pattern("api-governance@1.0.1") is None
 
     def test_plain_v_prefix(self) -> None:
         assert infer_tag_pattern("v1.2.3") == "v{version}"
@@ -243,16 +246,19 @@ class TestInferTagPattern:
 
 
 class TestIsVersionTagRef:
-    def test_name_at_version_is_tag(self) -> None:
-        assert is_version_tag_ref("api-governance@1.0.1") is True
+    def test_name_underscore_v_version_is_tag(self) -> None:
+        assert is_version_tag_ref("api-governance_v1.0.1") is True
+
+    def test_name_at_version_not_tag(self) -> None:
+        assert is_version_tag_ref("api-governance@1.0.1") is False
 
     def test_main_is_not_tag(self) -> None:
         assert is_version_tag_ref("main") is False
 
 
 class TestParseTagVersion:
-    def test_name_at_version(self) -> None:
-        assert parse_tag_version("api-governance@1.0.1", "{name}@{version}") == "1.0.1"
+    def test_name_underscore_v_version(self) -> None:
+        assert parse_tag_version("api-governance_v1.0.1", "{name}_v{version}") == "1.0.1"
 
 
 class TestInferTagPatternFromRefs:
@@ -261,5 +267,5 @@ class TestInferTagPatternFromRefs:
             def __init__(self, name: str) -> None:
                 self.name = name
 
-        refs = [_Ref("refs/tags/api-governance@1.0.1")]
-        assert infer_tag_pattern_from_refs(refs, "api-governance") == "{name}@{version}"
+        refs = [_Ref("refs/tags/api-governance_v1.0.1")]
+        assert infer_tag_pattern_from_refs(refs, "api-governance") == "{name}_v{version}"

--- a/tests/unit/marketplace/test_tag_pattern.py
+++ b/tests/unit/marketplace/test_tag_pattern.py
@@ -6,7 +6,14 @@ import re
 
 import pytest
 
-from apm_cli.marketplace.tag_pattern import build_tag_regex, render_tag
+from apm_cli.marketplace.tag_pattern import (
+    build_tag_regex,
+    infer_tag_pattern,
+    infer_tag_pattern_from_refs,
+    is_version_tag_ref,
+    parse_tag_version,
+    render_tag,
+)
 
 # ---------------------------------------------------------------------------
 # render_tag
@@ -219,3 +226,40 @@ class TestRoundTrip:
         assert m is not None, f"Pattern {pattern!r} did not match rendered tag {tag!r}"
         if "{version}" in pattern:
             assert m.group("version") == version
+
+
+class TestInferTagPattern:
+    def test_name_at_version(self) -> None:
+        assert infer_tag_pattern("api-governance@1.0.1") == "{name}@{version}"
+
+    def test_plain_v_prefix(self) -> None:
+        assert infer_tag_pattern("v1.2.3") == "v{version}"
+
+    def test_plain_semver(self) -> None:
+        assert infer_tag_pattern("1.2.3") == "{version}"
+
+    def test_branch_not_matched(self) -> None:
+        assert infer_tag_pattern("main") is None
+
+
+class TestIsVersionTagRef:
+    def test_name_at_version_is_tag(self) -> None:
+        assert is_version_tag_ref("api-governance@1.0.1") is True
+
+    def test_main_is_not_tag(self) -> None:
+        assert is_version_tag_ref("main") is False
+
+
+class TestParseTagVersion:
+    def test_name_at_version(self) -> None:
+        assert parse_tag_version("api-governance@1.0.1", "{name}@{version}") == "1.0.1"
+
+
+class TestInferTagPatternFromRefs:
+    def test_infers_from_remote_ref(self) -> None:
+        class _Ref:
+            def __init__(self, name: str) -> None:
+                self.name = name
+
+        refs = [_Ref("refs/tags/api-governance@1.0.1")]
+        assert infer_tag_pattern_from_refs(refs, "api-governance") == "{name}@{version}"

--- a/tests/unit/marketplace/test_tag_pattern.py
+++ b/tests/unit/marketplace/test_tag_pattern.py
@@ -222,6 +222,7 @@ class TestRoundTrip:
             ("{name}-v{version}", "my-tool", "2.0.0"),
             ("release-{version}", "x", "10.20.30"),
             ("{name}_v{version}", "tool", "1.0.0-beta.1"),
+            ("{name}--v{version}", "tool", "1.0.1"),
         ],
     )
     def test_roundtrip(self, pattern: str, name: str, version: str) -> None:
@@ -236,6 +237,9 @@ class TestRoundTrip:
 class TestInferTagPattern:
     def test_name_underscore_v_version(self) -> None:
         assert infer_tag_pattern("api-governance_v1.0.1") == "{name}_v{version}"
+
+    def test_name_double_dash_v_version(self) -> None:
+        assert infer_tag_pattern("api-governance--v1.0.1") == "{name}--v{version}"
 
     def test_name_underscore_v_scoped_to_package(self) -> None:
         assert infer_tag_pattern("apm1_v1.0.1", "apm1") == "{name}_v{version}"
@@ -257,6 +261,9 @@ class TestInferTagPattern:
 class TestIsVersionTagRef:
     def test_name_underscore_v_version_is_tag(self) -> None:
         assert is_version_tag_ref("api-governance_v1.0.1") is True
+
+    def test_name_double_dash_v_version_is_tag(self) -> None:
+        assert is_version_tag_ref("api-governance--v1.0.1") is True
 
     def test_name_at_version_not_tag(self) -> None:
         assert is_version_tag_ref("api-governance@1.0.1") is False

--- a/tests/unit/test_outdated_phase3w5.py
+++ b/tests/unit/test_outdated_phase3w5.py
@@ -372,6 +372,7 @@ class TestCheckOneDep:
         ref_tags = [
             _make_remote_ref("api-governance_v1.0.2", "tag", "sha2"),
             _make_remote_ref("api-governance_v1.0.1", "tag", "sha1"),
+            _make_remote_ref("other-pkg_v9.9.9", "tag", "sha9"),
         ]
         downloader = MagicMock()
         downloader.list_remote_refs.return_value = ref_tags
@@ -388,6 +389,7 @@ class TestCheckOneDep:
         assert result.status == "outdated"
         assert result.latest == "api-governance_v1.0.2"
         assert result.source == "git tags"
+        assert "other-pkg" not in (result.latest or "")
 
     def test_tag_no_tags_returns_unknown(self):
         from apm_cli.commands.outdated import _check_one_dep

--- a/tests/unit/test_outdated_phase3w5.py
+++ b/tests/unit/test_outdated_phase3w5.py
@@ -361,17 +361,17 @@ class TestCheckOneDep:
             result = _check_one_dep(dep, downloader, False)
         assert result.status == "up-to-date"
 
-    def test_name_at_version_tag_outdated(self):
+    def test_name_underscore_v_version_tag_outdated(self):
         from apm_cli.commands.outdated import _check_one_dep
 
         dep = _make_dep(
             key="org/api-governance",
             repo_url="org/api-governance",
-            resolved_ref="api-governance@1.0.1",
+            resolved_ref="api-governance_v1.0.1",
         )
         ref_tags = [
-            _make_remote_ref("api-governance@1.0.2", "tag", "sha2"),
-            _make_remote_ref("api-governance@1.0.1", "tag", "sha1"),
+            _make_remote_ref("api-governance_v1.0.2", "tag", "sha2"),
+            _make_remote_ref("api-governance_v1.0.1", "tag", "sha1"),
         ]
         downloader = MagicMock()
         downloader.list_remote_refs.return_value = ref_tags
@@ -386,7 +386,7 @@ class TestCheckOneDep:
             result = _check_one_dep(dep, downloader, False)
 
         assert result.status == "outdated"
-        assert result.latest == "api-governance@1.0.2"
+        assert result.latest == "api-governance_v1.0.2"
         assert result.source == "git tags"
 
     def test_tag_no_tags_returns_unknown(self):

--- a/tests/unit/test_outdated_phase3w5.py
+++ b/tests/unit/test_outdated_phase3w5.py
@@ -361,6 +361,34 @@ class TestCheckOneDep:
             result = _check_one_dep(dep, downloader, False)
         assert result.status == "up-to-date"
 
+    def test_name_at_version_tag_outdated(self):
+        from apm_cli.commands.outdated import _check_one_dep
+
+        dep = _make_dep(
+            key="org/api-governance",
+            repo_url="org/api-governance",
+            resolved_ref="api-governance@1.0.1",
+        )
+        ref_tags = [
+            _make_remote_ref("api-governance@1.0.2", "tag", "sha2"),
+            _make_remote_ref("api-governance@1.0.1", "tag", "sha1"),
+        ]
+        downloader = MagicMock()
+        downloader.list_remote_refs.return_value = ref_tags
+
+        with (
+            patch("apm_cli.commands.outdated._check_marketplace_ref", return_value=None),
+            patch(
+                "apm_cli.utils.version_checker.is_newer_version",
+                return_value=True,
+            ),
+        ):
+            result = _check_one_dep(dep, downloader, False)
+
+        assert result.status == "outdated"
+        assert result.latest == "api-governance@1.0.2"
+        assert result.source == "git tags"
+
     def test_tag_no_tags_returns_unknown(self):
         from apm_cli.commands.outdated import _check_one_dep
 


### PR DESCRIPTION
# What
apm outdated and apm marketplace outdated now understand monorepo-style git tags like my-package_v1.0.1, not only v1.0.0.

# Why
Repos that tag per package often use package_v1.0.0. Before this change, APM treated those refs as branch names, so outdated showed unknown instead of a real Latest / Status.

Idea is when you have a monorepo with multiple apm's 
````
examples/monorepo-multi-apm/
├── README.md
├── TAGGING.md
├── apm.yml                      # marketplace index (apm1 + apm2)
└── packages/
    ├── apm1/
    │   ├── apm.yml
    │   └── .apm/skills/hello/SKILL.md
    └── apm2/
        ├── apm.yml
        └── .apm/skills/hello/SKILL.md
````

# Note

We use _v (e.g. api-governance_v1.0.2), not @, because @ is already used for marketplace installs (apm install pkg@my-marketplace). If any other prefered standard is wanted, this can be changed.