### PR TITLE
fix(policy): classify '=1.2.3' explicit-equality as pinned constraint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,4 @@ scout-pipeline-result.png
 server.pid
 .docs-rewrite-plan/
 build/apm-*/
+copilot-scratch/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `policy.dependencies.require_pinned_constraint: true` no longer misclassifies the npm- and cargo-style explicit-equality form `=1.2.3` as `BARE_BRANCH`. Both `1.2.3` and `=1.2.3` are now recognised as pinned constraints; the pip-style `==1.2.3` form is still rejected (not part of node-semver). Follow-up to #1494 / #1505.
+- `policy.dependencies.require_pinned_constraint: true` no longer misclassifies the npm- and cargo-style explicit-equality form `=1.2.3` as `BARE_BRANCH`. Both `1.2.3` and `=1.2.3` are now recognized as pinned constraints; the pip-style `==1.2.3` form is still rejected (not part of node-semver). Follow-up to #1494 / #1505.
 
 ## [0.15.0] - 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `policy.dependencies.require_pinned_constraint: true` no longer misclassifies the npm- and cargo-style explicit-equality form `=1.2.3` as `BARE_BRANCH`. Both `1.2.3` and `=1.2.3` are now recognised as pinned constraints; the pip-style `==1.2.3` form is still rejected (not part of node-semver). Follow-up to #1494 / #1505.
+
 ## [0.15.0] - 2026-05-27
 
 ### Security

--- a/docs/src/content/docs/consumer/manage-dependencies.md
+++ b/docs/src/content/docs/consumer/manage-dependencies.md
@@ -138,6 +138,18 @@ dependencies:
     - acme/playbooks#a1b2c3d4e5f6...            # SHA (immutable)
 ```
 
+For registry-sourced deps or when `policy.dependencies.require_pinned_constraint: true` is on, the ref slot also accepts semver constraints:
+
+| Form | Example | Meaning |
+|---|---|---|
+| Bare exact | `owner/repo#1.2.3` | Pinned to exactly 1.2.3. |
+| Explicit equality | `owner/repo#=1.2.3` | Same as bare exact (npm- and cargo-style). |
+| Caret range | `owner/repo#^1.2.3` | `>=1.2.3, <2.0.0`. |
+| Tilde range | `owner/repo#~1.2.3` | `>=1.2.3, <1.3.0`. |
+| Bounded range | `owner/repo#>=1.2.0 <2.0.0` | Explicit lower and upper bound. |
+
+Pip-style `==1.2.3` is not part of the node-semver grammar APM follows and is rejected as an unbounded ref under `require_pinned_constraint`. Use `=1.2.3` or the bare form instead.
+
 Branches move; tags and SHAs do not. For reproducibility, prefer tags or
 SHAs. The lockfile pins the resolved commit either way, so two clones
 running `apm install` get the same bytes -- but a branch ref will resolve

--- a/docs/src/content/docs/reference/policy-schema.md
+++ b/docs/src/content/docs/reference/policy-schema.md
@@ -88,7 +88,9 @@ dependencies:
     - acme/lib#main            # FAIL: bare branch (BARE_BRANCH)
     - fourth/lib#^1.2.0        # OK: caret range
     - fifth/lib#~1.2.3         # OK: tilde range
-    - sixth/lib#1.5.3          # OK: exact version
+    - sixth/lib#1.5.3          # OK: exact version (bare)
+    - sixth_eq/lib#=1.5.3      # OK: exact version (npm/cargo explicit equality)
+    - sixth_pip/lib#==1.5.3    # FAIL: pip-style operator not supported (BARE_BRANCH)
     - seventh/lib#v1.5.3       # OK: literal tag
     - eighth/lib#aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  # OK: SHA
     - ./packages/local         # OK: local-path dep (no version surface)

--- a/packages/apm-guide/.apm/skills/apm-usage/governance.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/governance.md
@@ -384,7 +384,7 @@ Violation classes:
 | `denylist` | `dependencies.deny` match | Remove dep from `apm.yml`, request org-policy update, or `--no-policy` for one-off bypass |
 | `allowlist` | Dep not in non-empty `dependencies.allow` | Add to org allowlist or switch to an approved package |
 | `required` | Missing `dependencies.require` entry, or version-pin mismatch | Add the dep (and pin) to `apm.yml`. Pin mismatches downgrade to warn under `require_resolution: project-wins`; missing required deps still block |
-| `pinned-constraint` | `dependencies.require_pinned_constraint: true` + a direct dep with no ref, a wildcard, a bare branch, or a bare `>=X.Y` | Pin the dep to an exact version, caret/tilde/bounded semver range, literal `vX.Y.Z` tag, or a full SHA. Roll out enforcement with `warn` before `block`. |
+| `pinned-constraint` | `dependencies.require_pinned_constraint: true` + a direct dep with no ref, a wildcard, a bare branch, or a bare `>=X.Y` | Pin the dep to an exact version (`1.2.3` or npm/cargo-style `=1.2.3`; pip-style `==1.2.3` is not supported), caret/tilde/bounded semver range, literal `vX.Y.Z` tag, or a full SHA. Roll out enforcement with `warn` before `block`. |
 | `transport` | MCP transport not in `mcp.transport.allow` | Switch transport, or request `mcp.transport.allow` update |
 | `target` | Resolved target not in `compilation.target.allow` (or violates `target.enforce`) | Re-run with `--target <allowed>`, or adjust `compilation.target` in `apm.yml` |
 | `transitive_mcp` | MCP server pulled in by a transitive dep, blocked by `mcp.deny` / `transport` / `self_defined` | Remove offending dep, request policy update, or set `mcp.trust_transitive: true` |

--- a/src/apm_cli/deps/registry/semver.py
+++ b/src/apm_cli/deps/registry/semver.py
@@ -12,7 +12,7 @@ import re
 
 from apm_cli.marketplace.semver import SemVer, parse_semver, satisfies_range
 
-_RANGE_OPERATORS = (">=", "<=", ">", "<", "^", "~")
+_RANGE_OPERATORS = (">=", "<=", ">", "<", "^", "~", "=")
 _WILDCARD_RE = re.compile(r"^\d+\.\d+\.[xX*]$")
 
 

--- a/src/apm_cli/marketplace/semver.py
+++ b/src/apm_cli/marketplace/semver.py
@@ -215,6 +215,21 @@ def _satisfies_single(version: SemVer, spec: str) -> bool:
         base = parse_semver(spec[1:])
         return base is not None and version < base
 
+    # Explicit-equality operator (npm/cargo style): =1.2.3 := exact 1.2.3.
+    # APM follows the node-semver grammar, so pip-style ``==X.Y.Z`` is
+    # NOT recognised; users who write ``==1.2.3`` get a parse-time
+    # rejection via ``is_semver_range`` (see deps/registry/semver.py).
+    if spec.startswith("=") and not spec.startswith("=="):
+        base = parse_semver(spec[1:])
+        if base is None:
+            return False
+        return (
+            version.major == base.major
+            and version.minor == base.minor
+            and version.patch == base.patch
+            and version.prerelease == base.prerelease
+        )
+
     # Wildcard: 1.2.x or 1.2.*
     wildcard_match = re.match(r"^(\d+)\.(\d+)\.[xX*]$", spec)
     if wildcard_match:

--- a/tests/integration/policy/test_require_pinned_constraint_e2e.py
+++ b/tests/integration/policy/test_require_pinned_constraint_e2e.py
@@ -158,18 +158,18 @@ class TestPromiseBPinnedDepPassesPolicyGate:
     def test_bare_exact_version_does_not_trigger_block(
         self, mock_gate, mock_preflight, mock_dl, mock_updates, project
     ):
-        # NOTE: The bare-version form ``1.2.3`` is the documented
-        # "exact version" pinning form (see #1494 commit message and
-        # tests/unit/policy/test_pinned_constraint.py). The ``=1.2.3``
-        # alternate form is NOT currently recognized as pinned -- the
-        # classifier in ``_constraint_pinning.py`` treats it as a
-        # BARE_BRANCH. Documenting that in this test by using only
-        # the documented form; flagging the ``=1.2.3`` gap in the PR
-        # body for a separate UX issue.
+        # Covers both pin shapes the classifier accepts:
+        #   * ``1.2.3``       -- bare exact version
+        #   * ``=1.2.3``      -- npm/cargo-style explicit-equality
+        # Both must pass the gate under enforcement=block +
+        # require_pinned_constraint=true. The ``=1.2.3`` half is the
+        # regression trap for the bug observed in PR #1505: before the
+        # fix, ``_constraint_pinning.py`` mis-classified ``=1.2.3`` as
+        # ``BARE_BRANCH`` and blocked the install.
         project_dir, runner = project
         _write_apm_yml(
             project_dir / "apm.yml",
-            deps=["test-org/skills#1.2.3"],
+            deps=["test-org/skills#1.2.3", "test-org/other#=1.2.3"],
         )
         fetch = _fetch(_load_fixture("apm-policy-block.yml"))
         mock_gate.return_value = fetch
@@ -180,6 +180,7 @@ class TestPromiseBPinnedDepPassesPolicyGate:
         out = result.output.lower()
         assert "blocked by org policy" not in out, result.output
         assert "unbounded constraint" not in out, result.output
+        assert "bare branch" not in out, result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/marketplace/test_semver.py
+++ b/tests/unit/marketplace/test_semver.py
@@ -226,6 +226,22 @@ class TestSatisfiesRange:
         assert satisfies_range(parse_semver("0.9.0"), "<1.0.0")  # type: ignore[arg-type]
         assert not satisfies_range(parse_semver("1.0.0"), "<1.0.0")  # type: ignore[arg-type]
 
+    # -- Explicit-equality operator (=X.Y.Z): npm / cargo style --
+
+    def test_eq_exact(self) -> None:
+        assert satisfies_range(parse_semver("1.2.3"), "=1.2.3")  # type: ignore[arg-type]
+        assert not satisfies_range(parse_semver("1.2.4"), "=1.2.3")  # type: ignore[arg-type]
+        assert not satisfies_range(parse_semver("1.2.2"), "=1.2.3")  # type: ignore[arg-type]
+
+    def test_eq_prerelease(self) -> None:
+        assert satisfies_range(parse_semver("1.2.3-beta.1"), "=1.2.3-beta.1")  # type: ignore[arg-type]
+        assert not satisfies_range(parse_semver("1.2.3"), "=1.2.3-beta.1")  # type: ignore[arg-type]
+
+    def test_eq_invalid_spec(self) -> None:
+        sv = parse_semver("1.0.0")
+        assert sv is not None
+        assert not satisfies_range(sv, "=garbage")
+
     def test_gt_invalid_spec(self) -> None:
         sv = parse_semver("1.0.0")
         assert sv is not None

--- a/tests/unit/policy/test_pinned_constraint.py
+++ b/tests/unit/policy/test_pinned_constraint.py
@@ -129,6 +129,42 @@ def test_classify_pinned_specs_return_none(spec):
     assert classify_unbounded_reason(_dep(spec)) is None
 
 
+# Regression trap for the ``=1.2.3`` alternate exact-version form
+# (npm- and cargo-style "explicit equality"). Before the fix shipped
+# alongside this test, ``_constraint_pinning.py`` mis-classified these
+# as ``BARE_BRANCH`` because ``is_semver_range`` rejected the leading
+# ``=`` operator, and ``require_pinned_constraint: true`` would block
+# the install with a confusing branch-name diagnostic.
+@pytest.mark.parametrize(
+    "spec",
+    [
+        "=1.2.3",
+        "=0.0.1",
+        "=1.2.3-beta.1",
+        "=1.2.3+build.42",
+    ],
+)
+def test_equals_prefix_exact_version_classified_as_pinned(spec):
+    assert classify_unbounded_reason(_dep(spec)) is None
+    assert is_pinned_constraint(_dep(spec)) is True
+
+
+def test_equals_prefix_exact_version_pinned_on_registry_source():
+    # Same contract for registry-routed deps: ``=1.2.3`` is a pin, not
+    # an unbounded constraint.
+    assert classify_unbounded_reason(_dep("=1.2.3", source="registry")) is None
+
+
+def test_double_equals_prefix_rejected_as_bare_branch():
+    # APM follows the npm/cargo semver grammar where ``=`` is the
+    # explicit-equality operator. The pip-style ``==`` form is NOT
+    # part of node-semver and is intentionally not recognised; it
+    # falls through to ``BARE_BRANCH`` so that a user who wrote
+    # ``==1.2.3`` gets a violation that points them at the supported
+    # syntax instead of silently accepting the wrong dialect.
+    assert classify_unbounded_reason(_dep("==1.2.3")) is UnboundedReason.BARE_BRANCH
+
+
 def test_classify_caret_range_returns_pinned_none():
     assert classify_unbounded_reason(_dep("^1.2.3")) is None
 

--- a/tests/unit/registry/test_semver.py
+++ b/tests/unit/registry/test_semver.py
@@ -35,6 +35,12 @@ class TestIsSemverRange:
             "1.2.*",
             "1.0.0-beta.1",
             "1.0.0+build.42",
+            # ``=X.Y.Z`` is the npm- and cargo-style explicit-equality
+            # operator. Treated as a valid (and pinned) range so that
+            # ``require_pinned_constraint: true`` accepts it.
+            "=1.2.3",
+            "=0.0.1",
+            "=1.2.3-beta.1",
         ],
     )
     def test_accepts_valid_ranges(self, spec):
@@ -63,6 +69,12 @@ class TestIsSemverRange:
             "1.x",
             "1.*",
             "*",
+            # pip-style ``==1.2.3`` is NOT part of the node-semver grammar
+            # APM follows; rejecting it points users at the supported
+            # ``=1.2.3`` / bare ``1.2.3`` forms.
+            "==1.2.3",
+            "=garbage",
+            "=1.2",
         ],
     )
     def test_rejects_invalid_refs(self, spec):


### PR DESCRIPTION
## TL;DR

`policy.dependencies.require_pinned_constraint: true` (shipped in #1494) treated the npm- and cargo-style explicit-equality form `=1.2.3` as `BARE_BRANCH`, blocking the install with a confusing "bare branch '=1.2.3' tracks a moving tip" diagnostic. This PR teaches the semver parser and the runtime matcher to accept `=X.Y.Z` as an exact pin, so users get the behaviour the #1494 commit message promised ("exact versions" among the pinned forms). Pip-style `==1.2.3` stays rejected so users do not silently get the wrong dialect.

## Problem (WHY)

- The constraint classifier in `_constraint_pinning.py` defers to `is_semver_range` from `apm_cli.deps.registry.semver` to decide whether a ref is a valid semver range. That helper's `_RANGE_OPERATORS` tuple omitted the `=` prefix, so `=1.2.3` failed the parse-time gate and fell through to the `BARE_BRANCH` bucket.
- The e2e agent that opened #1505 observed this directly and documented it as a known gap in `tests/integration/policy/test_require_pinned_constraint_e2e.py`:
  > "The `=1.2.3` alternate form is NOT currently recognized as pinned -- the classifier in `_constraint_pinning.py` treats it as a BARE_BRANCH."
- Reference precedent in popular package managers: npm treats `pkg@=1.2.3` and `pkg@1.2.3` as equivalent (node-semver). Cargo treats `=1.2.3` as the **stricter** explicit pin (bare `1.2.3` is implicitly caret-equivalent). Pip alone uses `==1.2.3` and rejects `=1.2.3`. APM follows the node-semver grammar.
- Net effect before this fix: a user who wrote `dep: =1.2.3` in `apm.yml` with `require_pinned_constraint: true` got an install block citing a "bare branch" their ref clearly is not.

## Approach (WHAT)

| Decision | Choice | Why |
|---|---|---|
| Accept `=1.2.3` as a pin? | Yes | Matches npm + cargo precedent; user-friendly |
| Accept `==1.2.3` as a pin? | No | Pip-style; not in node-semver grammar APM follows. Reject loudly so users see a violation pointing at the supported form rather than silent acceptance of the wrong dialect |
| Where to add the operator? | Both layers | Parse-time gate (`deps/registry/semver.py`) so the classifier sees it as a range; runtime matcher (`marketplace/semver.py`) so resolution can match versions |

## Implementation (HOW)

| File | Change |
|---|---|
| `src/apm_cli/deps/registry/semver.py` | Add `"="` to `_RANGE_OPERATORS`. The existing `_is_range_component` loop strips the operator and validates the suffix via `parse_semver`, so `=1.2.3` becomes a valid range, `=garbage` stays invalid, and `==1.2.3` is rejected because `parse_semver("=1.2.3")` returns `None`. |
| `src/apm_cli/marketplace/semver.py` | Add an `=` branch in `_satisfies_single` that parses the suffix and matches the exact `(major, minor, patch, prerelease)` tuple, mirroring the existing "Exact match" fallback semantics. Guarded with `not spec.startswith("==")` so the pip-style form falls through to the invalid path. |
| `src/apm_cli/policy/_constraint_pinning.py` | No change. Once `is_semver_range("=1.2.3")` returns `True`, the existing `_classify_range` single-component branch returns `None` (pinned) because `=1.2.3` does not start with `>=` or `>`. |

## Diagram

> Legend: classification flow for a constraint string. **Bold** node is the path that was previously broken for `=1.2.3` and is now reachable.

```mermaid
flowchart LR
    A["dep ref =1.2.3"] --> B{"is_semver_range(spec)"}
    B -->|"True (after fix)"| C["_classify_range(spec)"]
    B -->|"False (before fix)"| D["BARE_BRANCH (incorrect)"]
    C --> E{"starts with '>=' or '>'?"}
    E -->|"No"| F["return None - pinned"]
    E -->|"Yes"| G["OPEN_UPPER / GREATER_THAN_ONLY"]
```

## Trade-offs

- **Accepting `=` but rejecting `==`** could surprise users coming from pip. The error message will say "bare branch" until the diagnostic gets its own follow-up; opted not to bundle that with the correctness fix.
- **No new operator for inverse-equality (`!=`).** Cargo supports it; npm does not. APM follows npm here, deferring the question until a real user asks.
- **Two-file fix instead of one.** Adding `=` only to the classifier would have made the policy gate accept `=1.2.3` while resolution silently failed to find a matching version. Both layers must agree on the grammar.

## Benefits

1. Users who follow npm/cargo muscle memory (`=1.2.3`) no longer get blocked by a policy whose own commit message advertised exact versions as pinned.
2. The `_constraint_pinning.py` contract advertised in the module docstring ("Exact semver versions (`1.2.3`)") is now honoured for both spellings of an exact version.
3. Removes a documented test caveat in the #1505 e2e file -- the "known gap" comment is gone, replaced by the regression trap.
4. Mutation-break verified: deleting either half of the fix fails a test that points at the deletion.

## Validation

All four lint guards pass silently and the targeted test set is green.

<details><summary>Lint chain (CI-mirror, all silent / exit 0)</summary>

```
$ uv run --extra dev ruff check src/ tests/
All checks passed!

$ uv run --extra dev ruff format --check src/ tests/
1107 files already formatted

$ uv run --extra dev python -m pylint --disable=all --enable=R0801 \
    --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ bash scripts/lint-auth-signals.sh
[+] auth-signal lint clean
```

</details>

<details><summary>Targeted test run</summary>

```
$ uv run --extra dev pytest tests/unit/policy tests/unit/registry \
    tests/unit/marketplace/test_semver.py tests/integration/policy \
    -q --tb=line -k "pin or constraint or semver or registry"
421 passed, 658 deselected, 3 xfailed in 10.74s
```

</details>

### Scenario evidence

| User-promise scenario | Test proving it | APM principle |
|---|---|---|
| `require_pinned_constraint: true` accepts `dep: =1.2.3` and does not block install | `tests/integration/policy/test_require_pinned_constraint_e2e.py::TestPromiseBPinnedDepPassesPolicyGate::test_bare_exact_version_does_not_trigger_block` (extended to include `=1.2.3` alongside `1.2.3`) | Deterministic policy gates |
| Classifier recognises `=X.Y.Z`, `=X.Y.Z-prerelease`, `=X.Y.Z+build` as pinned for both git-source and registry-source deps | `tests/unit/policy/test_pinned_constraint.py::test_equals_prefix_exact_version_classified_as_pinned` + `::test_equals_prefix_exact_version_pinned_on_registry_source` | Source-agnostic shape decides |
| Pip-style `==1.2.3` still falls through to `BARE_BRANCH` so users see a violation pointing at the supported form | `tests/unit/policy/test_pinned_constraint.py::test_double_equals_prefix_rejected_as_bare_branch` | Cite-or-omit: do not silently accept a foreign dialect |
| `satisfies_range` matches `=1.2.3` against `1.2.3` (and not `1.2.4`, not `1.2.3-beta.1`) | `tests/unit/marketplace/test_semver.py::TestSatisfiesRange::test_eq_exact` + `::test_eq_prerelease` | Runtime matcher honours parse-time grammar |
| Parse-time gate accepts `=1.2.3` and rejects `==1.2.3` / `=garbage` / `=1.2` | `tests/unit/registry/test_semver.py::TestIsSemverRange::test_accepts_valid_ranges` + `::test_rejects_invalid_refs` | One canonical semver grammar across the codebase |

### Mutation-break evidence

| Deletion | Test that fails |
|---|---|
| Remove `"="` from `_RANGE_OPERATORS` in `deps/registry/semver.py` | 8 tests fail: 4x `test_equals_prefix_exact_version_classified_as_pinned`, 3x `test_accepts_valid_ranges[=...]`, 1x `test_bare_exact_version_does_not_trigger_block` |
| Remove the `=` branch in `marketplace/semver.py::_satisfies_single` | 2 tests fail: `test_eq_exact`, `test_eq_prerelease` |

## How to test

1. `git fetch && git checkout fix/policy-equals-prefix-pinned`
2. `uv run --extra dev pytest tests/unit/policy/test_pinned_constraint.py tests/unit/registry/test_semver.py tests/unit/marketplace/test_semver.py tests/integration/policy/test_require_pinned_constraint_e2e.py -q` -- expect all green
3. Create a sample project with `dependencies.apm: ["owner/repo#=1.2.3"]` and an org policy with `enforcement: block` + `dependencies.require_pinned_constraint: true`; run `apm install` and confirm the policy gate does NOT abort with "bare branch '=1.2.3'"
4. Same as (3) but with `==1.2.3` -- confirm the install IS blocked and the diagnostic still points at the offending dep

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
