### PR TITLE
docs(skills): correct outdated windsurf-convergence status, link #1520

### DIFF
--- a/docs/src/content/docs/producer/author-primitives/skills.md
+++ b/docs/src/content/docs/producer/author-primitives/skills.md
@@ -109,11 +109,16 @@ directory per active target. Routing is verified in
 | `agent-skills`    | `.agents/skills/<name>/SKILL.md` (explicit)  |
 
 Five harnesses converge on the cross-tool `.agents/skills/`
-directory. Claude and Windsurf keep harness-native paths because
-their runtimes scan their own roots. The whole skill folder is
-copied (`shutil.copytree`), so `scripts/`, `references/`, `assets/`,
-and `examples/` ride along. Symlinks and the `.apm-pin` cache marker
-are filtered out (`src/apm_cli/security/gate.py:ignore_non_content`).
+directory. Claude keeps its harness-native path because Claude Code's
+default scan is `.claude/skills/`; Windsurf currently uses
+`.windsurf/skills/` for the same reason, though Cascade also
+[discovers `.agents/skills/`](https://docs.windsurf.com/windsurf/cascade/skills#skill-scopes)
+natively for cross-agent compatibility (convergence tracked in
+[#1520](https://github.com/microsoft/apm/issues/1520)). The whole
+skill folder is copied (`shutil.copytree`), so `scripts/`,
+`references/`, `assets/`, and `examples/` ride along. Symlinks and
+the `.apm-pin` cache marker are filtered out
+(`src/apm_cli/security/gate.py:ignore_non_content`).
 
 To restore the pre-convergence layout where every harness gets its
 own `.<harness>/skills/` copy, pass `--legacy-skill-paths` or set


### PR DESCRIPTION
## TL;DR

Two-line correction to `docs/src/content/docs/producer/author-primitives/skills.md`. The prior wording asserted Windsurf's runtime only scans `.windsurf/skills/`. Per the [official Windsurf docs](https://docs.windsurf.com/windsurf/cascade/skills#skill-scopes), Cascade also discovers `.agents/skills/` and `~/.agents/skills/` for cross-agent compatibility.

## Why this is a separate PR

- #1486 fixes the uninstall directory-collision bug under the current deploy path; it is contract-correct and should ship on its own merits.
- The deploy-path move onto `.agents/skills/` is tracked in #1520 (load-bearing Windsurf-docs citation included there).
- This PR is a pure docs accuracy fix so we stop telling readers something the upstream tool no longer matches. No code change, no behavior change.