### PR TITLE
fix(install): strip non-ASCII bytes from install.ps1 (unblocks self-update on cp1252 consoles)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -729,7 +729,7 @@ try {
     # there is still a small gap where neither path exists; doing it this
     # way minimizes that gap and lets us roll back if the second rename
     # fails. Concurrent apm invocations during that window will fail and
-    # need a retry — acceptable for an install/self-update operation.
+    # need a retry -- acceptable for an install/self-update operation.
     $backupDir = $null
     if (Test-Path $releaseDir) {
         $backupDir = "$releaseDir.old-" + [System.Guid]::NewGuid().ToString("N")
@@ -802,7 +802,8 @@ try {
     # Write the shim as ASCII. cmd.exe interprets .cmd files via the system
     # OEM/ANSI code page and does NOT reliably auto-detect UTF-16LE (even
     # with a BOM) when batch files are invoked via PATH or double-click; a
-    # UTF-16 shim surfaces as garbled output like ">��@" and exit code 1.
+    # UTF-16 shim surfaces as garbled bytes (the cmd.exe prompt followed
+    # by replacement-character noise) and exit code 1.
     # ASCII is safe for our payload because the %LOCALAPPDATA% literal
     # token (issue #1509) keeps the embedded shim target ASCII-only even
     # when the user's profile directory contains non-ASCII characters.


### PR DESCRIPTION
## TL;DR

Follow-up to #1522. The Windows CI `apm self-update` test ([run 26543072369](https://github.com/microsoft/apm/actions/runs/26543072369/job/78188839048)) fails with:

```
[x] Update failed: 'charmap' codec can't encode characters in position 33941-33942: character maps to <undefined>
```

`install.ps1` contained two non-ASCII byte sequences -- an em-dash (pre-existing) and replacement chars I introduced in a comment. The v0.13.0 self-updater downloads install.ps1 via Python urllib and prints it through a cp1252 console; non-ASCII bytes raise `UnicodeEncodeError`.

## Problem (WHY)

Per the repo's encoding contract (`.github/instructions/encoding.instructions.md`):

> All source code files and CLI output strings must stay within printable ASCII (U+0020-U+007E). Windows cp1252 terminals raise UnicodeEncodeError: 'charmap' codec can't encode character for any character outside cp1252.

Two violations in install.ps1:

1. **Em-dash (U+2014) at byte 29170** -- pre-existing comment: `# need a retry — acceptable for an install/self-update operation.`
2. **Replacement characters (U+FFFD U+FFFD) at byte 33139** -- introduced by #1522 in the comment I added describing what a UTF-16 cmd.exe parse failure looks like. I literally pasted the garbled-output illustration verbatim instead of describing it in ASCII.

Why this only surfaced now: #1522 fixed the `apm.cmd` shim, which previously crashed before reaching the self-update path. With the shim working, Test 5 can now exercise self-update end-to-end -- and immediately hits the cp1252 wall on the downloaded install.ps1.

## Approach (WHAT)

Replace both non-ASCII sequences with their ASCII equivalents:

- `—` (em-dash) -> `--` (ASCII digraph)
- `">��@"` (replacement chars) -> plain ASCII prose describing the failure mode

`install.ps1` now contains zero bytes above 0x7E (verified by hand-scan).

## Validation evidence

- `python3 -c "data = open('install.ps1','rb').read(); ..."` reports no bytes > 127.
- 8/8 regression tests in `tests/unit/install/test_windows_shim_template.py` still pass.
- Full lint chain silent: ruff check, ruff format, pylint R0801.
- The actual Windows CI `apm self-update` test will run on this PR -- the only ground-truth verification.

## Trade-offs

None. ASCII-equivalent prose is strictly required by the repo's encoding rule; this PR brings install.ps1 into compliance.

Refs #1522.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>