### PR TITLE
feat(skills): add cut-release skill

### DIFF
--- a/.apm/skills/cut-release/SKILL.md
+++ b/.apm/skills/cut-release/SKILL.md
@@ -145,7 +145,7 @@ Rewrite the CHANGELOG.md `[Unreleased]` block in place:
 ```
 ## [Unreleased]
 
-## [vX.Y.Z] - YYYY-MM-DD
+## [X.Y.Z] - YYYY-MM-DD
 
 ### Added
 ...

--- a/.apm/skills/cut-release/SKILL.md
+++ b/.apm/skills/cut-release/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: cut-release
+description: >-
+  Use this skill to cut an APM release from the current worktree:
+  assess whether the cycle since the last tag warrants a patch or
+  minor bump (semver discipline against the merged-since-last-tag
+  diff), sanitize the [Unreleased] CHANGELOG block into a dated
+  version block with one concise "so what" entry per merged PR
+  (drop internal-only churn, consolidate duplicates), bump
+  pyproject.toml + uv.lock, run the CI-mirror lint chain, and open
+  the release PR. Activate on "ship a release", "cut v0.x",
+  "release prep", "bump and PR", "open release PR", "what kind of
+  release do we need", or any phrasing that ends in opening a
+  release PR -- even when the user does not say "skill". Stops
+  BEFORE tagging; tagging stays a human gate that triggers the
+  release workflow. Refuses to bump to a major (>= 1.0.0) version
+  without explicit operator confirmation.
+---
+
+# cut-release -- assess, sanitize, bump, lint, open PR
+
+This skill drives the release-cut workflow end-to-end on the current
+worktree. It STOPS at "PR open"; tagging is the human-gated trigger
+that fires the release workflow.
+
+## When to use
+
+Trigger this skill on any of these intents:
+
+- "cut a release"
+- "ship v0.x" / "ship the release"
+- "release prep" / "prepare the release"
+- "bump and open the PR"
+- "open the release PR"
+- "what kind of release do we need now"
+- "we have enough merged for a release"
+- Any phrasing that ends in opening a release PR.
+
+Do NOT trigger on:
+
+- "tag v0.16.0" -- tagging is the post-merge step the operator runs.
+- "publish a blog post" / "draft release notes for the website".
+- "what changed since v0.15.0" -- enumeration only, no release.
+- "regenerate uv.lock" / raw version-string edits.
+- "rollback to v0.15.0" -- release reversal is a different skill.
+
+## Companion primitives
+
+The skill DEPENDS on these existing primitives in the same source
+tree. Do not duplicate their content; reference them.
+
+- `.apm/skills/apm-strategy/SKILL.md` -- versioning judgement and
+  breaking-change lens. Auto-loads via its own trigger on
+  `CHANGELOG.md` and release-pipeline edits. Treat it as the
+  authoritative lens for "is this BREAKING" and "does this
+  positioning change warrant a migration note".
+- `.apm/instructions/linting.instructions.md` -- canonical
+  CI-mirror lint chain. Reference; do not re-derive ruff / pylint
+  command lists in this skill.
+- `.github/instructions/changelog.instructions.md` -- Keep-a-
+  Changelog format contract. Reference; do not redefine the
+  format.
+
+## Output charset rule
+
+Per `.github/instructions/encoding.instructions.md`, source files in
+this bundle (SKILL.md, assets, scripts) MUST stay in printable ASCII.
+The PR body and changelog entries this skill produces are also
+written to repo files (CHANGELOG.md, PR body), so they MUST stay
+ASCII too. Use `--` for em dashes, `[!]` / `[+]` / `[x]` for status
+markers, and so on.
+
+## Procedure
+
+Run these phases in order. Reload `plan.md` (the session memento)
+at the start of each phase and after every tool return.
+
+### Phase 0 -- ground state
+
+1. Read the current branch with `git rev-parse --abbrev-ref HEAD`.
+   The skill assumes you are on a release-prep branch (or are
+   willing to create one). If you are on `main`, STOP and ask the
+   operator to put you on a branch.
+2. Resolve the last release tag with `git describe --tags --abbrev=0`.
+3. Persist the goal to plan.md:
+   - Range: `<last-tag>..HEAD`.
+   - Acceptance: release PR is open, lint mirror green, no version
+     bumped beyond what the cycle warrants.
+
+### Phase 1 -- enumerate merged PRs
+
+Run `scripts/list-changes-since-tag.sh` (no arguments). It emits
+JSON on stdout: one object per merged PR with fields `pr`, `title`,
+`labels`, `author`, `paths_summary`, `is_user_facing_guess`.
+
+The script's heuristic for `is_user_facing_guess` is
+intentionally conservative -- it flags as INTERNAL only when the
+diff is fully contained in `.apm/`, `.github/instructions/`,
+`tests/`, `docs/`, or matches `chore(repo)`. Treat the field as a
+HINT, not a verdict; the LLM makes the final call per
+`assets/entry-sanitizer.md`.
+
+DO NOT rely on training-recalled PR titles. Truth #5: pretraining
+is frozen. Every PR title in the changelog must come from the
+script's stdout.
+
+### Phase 2 -- pick the bump (B10 CHECKPOINT 1)
+
+Load `assets/semver-rubric.md`. Walk every PR from Phase 1
+against the rubric. The rubric outputs PATCH, MINOR, or
+ESCALATE-TO-MAJOR.
+
+Show the operator:
+
+- The chosen bump and the next version number.
+- Per-PR rationale (which signal fired).
+- The "why patch/minor" one-liner that will go into the PR body.
+
+If the rubric outputs ESCALATE-TO-MAJOR (>= 1.0.0), STOP and
+surface the escalation per `assets/semver-rubric.md` "Major bump"
+section. Do not bump to 1.0.0 without explicit operator
+confirmation.
+
+Wait for the operator's confirm before continuing.
+
+### Phase 3 -- sanitize the changelog (B10 CHECKPOINT 2)
+
+Load `assets/entry-sanitizer.md`. For each PR classified as
+user-facing in Phase 1:
+
+1. Choose its section: Added (new feature, new command, new spec),
+   Changed (behavior change in existing surface), Fixed (bug fix),
+   Deprecated, Removed, Security, Performance.
+2. Write ONE entry per PR. Two-sentence cap. "So what" framing.
+   PR number in parentheses at the end. Preserve `by @author` for
+   external contributors.
+3. Consolidate any pre-existing Unreleased entries that point at
+   the same PR.
+4. Drop INTERNAL PRs entirely (the script flagged most of them;
+   the rubric in entry-sanitizer.md confirms).
+5. Mark BREAKING entries with `**BREAKING:**` prefix.
+
+Rewrite the CHANGELOG.md `[Unreleased]` block in place:
+
+```
+## [Unreleased]
+
+## [vX.Y.Z] - YYYY-MM-DD
+
+### Added
+...
+### Changed
+...
+### Fixed
+...
+```
+
+Keep an empty `[Unreleased]` placeholder above the new version
+heading. The date is today (read from the operator's environment,
+not recall).
+
+Show the operator the unified diff against CHANGELOG.md. Wait for
+confirm before continuing.
+
+### Phase 4 -- bump version files
+
+Run `scripts/bump-version.sh <new-version>`. The script edits
+`pyproject.toml` (the `version = "..."` line in `[project]`) and
+runs `uv lock` to refresh `uv.lock`. It prints a unified diff to
+stdout for human review.
+
+If the script exits non-zero, surface the error and STOP -- do not
+continue with a partial bump.
+
+### Phase 5 -- verify lint mirror (S4 gate; B10 CHECKPOINT 3 on fail)
+
+Run `scripts/verify-lint-mirror.sh`. It mirrors the four CI lint
+steps from `.apm/instructions/linting.instructions.md` verbatim
+(ruff check, ruff format --check, pylint R0801, auth-signals).
+
+If it passes (exit 0), proceed to Phase 6.
+
+If it fails (exit 1), STOP. Surface the failures to the operator.
+Common cures:
+
+- ruff diagnostics -- run `uv run --extra dev ruff check src/
+  tests/ --fix` and `uv run --extra dev ruff format src/ tests/`.
+- pylint R0801 -- duplication landed via a recent main commit;
+  merge main first, then re-run.
+- auth-signals -- consult `scripts/lint-auth-signals.sh` output.
+
+Do NOT push or open the PR until lint is green. The PR description
+will claim CI is green; that claim must hold.
+
+### Phase 6 -- commit, push, open PR
+
+1. `git add CHANGELOG.md pyproject.toml uv.lock`.
+2. `git commit -m "chore: release vX.Y.Z" -m "<short body>"`.
+   The body mirrors prior release commits (#1410, #1454, #1526):
+   one paragraph naming what was bumped and the lint-mirror
+   confirmation, plus the "post-merge: tag vX.Y.Z" reminder.
+   Include the standard `Co-authored-by` trailer.
+3. `git push -u origin HEAD`.
+4. Compose the PR body from `assets/pr-body-template.md`,
+   substituting `{version}`, `{date}`, `{bump_rationale}`, and
+   (if BREAKING) `{breaking_summary}`.
+5. `gh pr create --base main --head <branch> --title
+   "chore: release vX.Y.Z" --body-file <tmpfile>`.
+6. Echo the PR URL.
+7. Surface the post-merge step explicitly: "Post-merge: tag
+   `vX.Y.Z` to trigger the release workflow." Do NOT tag.
+
+### Phase 7 -- update plan and exit
+
+Mark each plan.md todo as done. The session ends here. Tagging is
+the operator's decision and lives outside this skill.
+
+## Anti-patterns this skill refuses
+
+- TAGGING. Tagging is a separate, human-gated step. If asked to
+  tag inside this session, decline and remind the operator that
+  the release workflow expects `git tag vX.Y.Z && git push --tags`
+  after PR merge.
+- BUMP-TO-MAJOR-UNPROMPTED. 0.x -> 1.0.0 is a positioning
+  decision. ESCALATE per `assets/semver-rubric.md`.
+- HAND-ROLLED PR TITLES. Every changelog entry must be backed by
+  a PR title from `scripts/list-changes-since-tag.sh` stdout. No
+  recall.
+- CHATTY GATE. Three operator checkpoints, no more (version pick,
+  sanitized changelog, lint-fail recovery). Do not ask per-PR or
+  per-section.
+- PARTIAL PUSH. If lint fails, do not push. The release PR
+  asserts green CI; pushing red breaks the contract.
+- SKIPPED LINT. Do not skip Phase 5 even if the diff looks
+  trivial. The lint mirror catches code-duplication drift on the
+  merge commit, which is invisible to a local diff inspection.
+
+## Boundary
+
+This skill does NOT:
+
+- Tag the release.
+- Run the test suite or build PyInstaller binaries.
+- Publish a GitHub Release body, blog post, or announcement.
+- Decide whether a release should happen -- the operator decided
+  that by activating this skill.
+- Bump to >= 1.0.0 without explicit operator confirmation.
+- Review code quality or test coverage (use `apm-review-panel`
+  before activating this skill if a recent PR needs review).

--- a/.apm/skills/cut-release/SKILL.md
+++ b/.apm/skills/cut-release/SKILL.md
@@ -202,8 +202,12 @@ will claim CI is green; that claim must hold.
    Include the standard `Co-authored-by` trailer.
 3. `git push -u origin HEAD`.
 4. Compose the PR body from `assets/pr-body-template.md`,
-   substituting `{version}`, `{date}`, `{bump_rationale}`, and
-   (if BREAKING) `{breaking_summary}`.
+   substituting `{version}` (unprefixed, e.g. `0.16.1` -- used by
+   `CHANGELOG.md` and `pyproject.toml`), `{tag}` (v-prefixed, e.g.
+   `v0.16.1` -- used by the post-merge `git tag` block, since the
+   release workflow's stable-release regex requires the `v` prefix
+   per `.github/workflows/build-release.yml`), `{date}`,
+   `{bump_rationale}`, and (if BREAKING) `{breaking_summary}`.
 5. `gh pr create --base main --head <branch> --title
    "chore: release vX.Y.Z" --body-file <tmpfile>`.
 6. Echo the PR URL.

--- a/.apm/skills/cut-release/assets/entry-sanitizer.md
+++ b/.apm/skills/cut-release/assets/entry-sanitizer.md
@@ -1,0 +1,159 @@
+# entry-sanitizer -- one concise "so what" per PR
+
+Loaded by `cut-release` at Phase 3. Rewrites the [Unreleased]
+block into a dated version block with one entry per
+user-facing PR.
+
+## Per-entry rubric
+
+For each PR that survives the DROP list below:
+
+1. ONE entry per PR. Do not split into multiple bullets across
+   sections unless the same PR genuinely changed two distinct
+   user-visible surfaces (rare; usually a sign the PR was
+   under-scoped).
+2. TWO-SENTENCE CAP. First sentence: what changed (concrete CLI
+   surface or behavior). Second sentence (optional): the "so
+   what" -- what the user can now do, what bug stopped biting,
+   what failure mode is closed. Drop everything else.
+3. PR NUMBER at the end in parentheses: `(#1495)`. If the PR
+   closes an issue, prefix: `(closes #1488, #1496)`. Multiple
+   numbers go inside one parenthesis group.
+4. ATTRIBUTION for external contributors: append
+   `(by @username, #NNNN)`. Internal contributors are not named.
+5. BREAKING marker: prefix entry with `**BREAKING:**`. Always
+   land breakings in the appropriate section (usually Changed or
+   Security); never bury them in Fixed.
+6. CONCRETE LANGUAGE. Use the exact CLI surface affected:
+   ``\`apm install -g\` now ...`` not "global install is now ...".
+7. NO REPO INTERNALS. The reader is a user, not a maintainer.
+   "Refactored the BFS resolver" is wrong; "`apm install --update`
+   now re-resolves direct git-source semver dependencies" is right.
+
+## Section mapping
+
+| Diff shape | Section |
+|------------|---------|
+| New CLI command, new flag with new default ON, new manifest field, new spec, new policy, new feature | **Added** |
+| Behavior change to existing surface (default flip, output format change, exit code change, BREAKING) | **Changed** |
+| Bug fix to existing surface (was wrong, now right) | **Fixed** |
+| Surface marked for removal with timeline | **Deprecated** |
+| Surface removed from the CLI / config / manifest | **Removed** |
+| Security-relevant fix or hardening (CVE, attack surface closed) | **Security** |
+| Measurable speedup / memory reduction on a user-visible path | **Performance** |
+
+If a PR fits two sections, pick the user-MOST-VISIBLE one and
+mention the other in the body. Do not double-list.
+
+## DROP list (do NOT include in changelog)
+
+A PR is INTERNAL and gets dropped if ANY of these hold:
+
+- Diff is fully contained in `.apm/` (skills, agents, instructions,
+  prompts that are part of the maintainer toolkit -- the project's
+  own dogfooding primitives).
+- Diff is fully contained in `.github/instructions/`,
+  `.github/workflows/` (unless the workflow change affects users,
+  e.g. release binaries), or `.github/ISSUE_TEMPLATE/`.
+- Diff is fully contained in `tests/` (test-only PR).
+- Diff is fully contained in `docs/` AND the change is doc
+  housekeeping (typo, restructure) rather than a doc-bug fix that
+  was misleading users. Doc-bug fixes DO go in Fixed.
+- Title starts with `chore(repo):`, `chore(deps):` (Dependabot-
+  style), `ci:`, or `test:`.
+- Title is `Merge ...` / `Revert ...` (handled separately if a
+  revert is user-visible -- usually it ends up matching another
+  fix entry anyway).
+
+Phase 1's script flags these heuristically via
+`is_user_facing_guess`; the rubric here is the authoritative
+verdict.
+
+EDGE CASE -- mixed-surface PRs. A PR that touches both `.apm/`
+and `src/` is NOT internal -- the `src/` change is user-facing
+even if the bulk of the diff is skill content. Read the `src/`
+hunk to write the entry; ignore the `.apm/` noise.
+
+## Consolidation rules
+
+The existing [Unreleased] block may already have entries the
+contributor wrote. Treat them as drafts, not gospel:
+
+- If two existing entries point at the same PR (#NNNN appears
+  twice), MERGE into one entry. Keep the longer / more specific
+  prose.
+- If an existing entry violates the rubric (six sentences,
+  internal jargon, no "so what"), REWRITE it -- do not preserve
+  the original phrasing out of politeness.
+- If an existing entry references a PR not in Phase 1's output
+  (likely because it was tagged Unreleased before the previous
+  release), that's a bug in the previous release's sanitizer
+  pass. Surface to the operator at checkpoint 2; ask whether to
+  keep it (likely "fix the typo and ship") or drop it.
+
+## Output shape
+
+The rewritten block goes in place of `[Unreleased]`:
+
+```
+## [Unreleased]
+
+## [vX.Y.Z] - YYYY-MM-DD
+
+### Added
+
+- <entry>. (#NNNN)
+- <entry>. (closes #AAAA, #BBBB)
+
+### Changed
+
+- **BREAKING:** <entry>. (#NNNN)
+- <entry>. (#NNNN)
+
+### Fixed
+
+- <entry>. (#NNNN)
+- <entry>. (by @user, #NNNN)
+```
+
+An empty `[Unreleased]` placeholder stays above the new version
+heading -- the next release cycle adds entries to it.
+
+The date is TODAY in `YYYY-MM-DD` (read from the operator's
+environment / current_datetime in the session header; do not
+recall).
+
+## Worked example (v0.16.0)
+
+Inputs from Phase 1: 19 PRs. Drop list killed 5 (skill refactor,
+docs-only PRs, internal test, chore). Remaining 14:
+
+```
+### Added
+- OpenAPM v0.1 normative spec ... (closes #1502, #1517)
+- `ref:` on git-source dependencies now accepts semver ranges ... (closes #1488, #1496)
+- `apm deps why <package>` ... (#1495)
+- `policy.dependencies.require_pinned_constraint: true` ... (#1494)
+- Deterministic Artifactory boundary probe ... (#1472)
+
+### Changed
+- **BREAKING:** `apm install` now exits `1` ... (#1496)
+- Artifactory parse-time boundary detection ... (#1472)
+
+### Fixed
+- `install.ps1` on Windows ... (closes #1509, #1512)
+- `apm.cmd` Windows shim is now written as ASCII ... (#1522)
+- `install.ps1` is now strict ASCII ... (#1523)
+- `apm install --target opencode` ... (Phase 1 of #581, #1513)
+- `apm compile --target claude` ... (closes #1445, #1514)
+- `apm install git@gitlab.com:` ... (closes #1501, #1515)
+- `apm install -g` hook integration ... (closes #1499, #1516)
+- `apm install --update` re-resolves git-semver ... (#1496)
+- `=1.2.3` pinned classification ... (follow-up to #1494, #1506)
+- `apm uninstall` windsurf cleanup ... (by @yoelabril, #1486)
+- `apm unpack` deprecation banner softened ... (#1511)
+```
+
+Two PRs from Phase 1 attached to the same `#1472` -- consolidated
+across Added / Changed / Fixed (the PR genuinely changed three
+surfaces, so three entries is correct here, not over-listing).

--- a/.apm/skills/cut-release/assets/entry-sanitizer.md
+++ b/.apm/skills/cut-release/assets/entry-sanitizer.md
@@ -98,7 +98,7 @@ The rewritten block goes in place of `[Unreleased]`:
 ```
 ## [Unreleased]
 
-## [vX.Y.Z] - YYYY-MM-DD
+## [X.Y.Z] - YYYY-MM-DD
 
 ### Added
 

--- a/.apm/skills/cut-release/assets/pr-body-template.md
+++ b/.apm/skills/cut-release/assets/pr-body-template.md
@@ -15,9 +15,9 @@ Lint mirror green locally (ruff check + format, pylint R0801, auth-signals). See
 
 ## Post-merge
 
-Tag `{version}` to trigger the release workflow:
+Tag `{tag}` to trigger the release workflow:
 
 ```
-git tag {version}
-git push origin {version}
+git tag {tag}
+git push origin {tag}
 ```

--- a/.apm/skills/cut-release/assets/pr-body-template.md
+++ b/.apm/skills/cut-release/assets/pr-body-template.md
@@ -1,0 +1,23 @@
+Cut release {version}.
+
+- Bump `pyproject.toml` to {version} (and `uv.lock`).
+- Move `[Unreleased]` to `[{version}] - {date}` in `CHANGELOG.md`, with one short "so what?" entry per PR merged since {prev_version}.
+
+## Why {bump_kind} ({version}), not {alt_bump_kind} ({alt_version})
+
+{bump_rationale}
+
+{breaking_summary_block}
+
+## Validation
+
+Lint mirror green locally (ruff check + format, pylint R0801, auth-signals). See `.apm/instructions/linting.instructions.md` for the contract this mirrors.
+
+## Post-merge
+
+Tag `{version}` to trigger the release workflow:
+
+```
+git tag {version}
+git push origin {version}
+```

--- a/.apm/skills/cut-release/assets/semver-rubric.md
+++ b/.apm/skills/cut-release/assets/semver-rubric.md
@@ -1,0 +1,118 @@
+# semver-rubric -- pick the bump
+
+Loaded by `cut-release` at Phase 2. Walks every PR enumerated in
+Phase 1 against a fixed signal table; the highest-severity signal
+wins.
+
+## Signal table (highest severity wins)
+
+| Signal (read top-down; first match wins) | Bump |
+|------------------------------------------|------|
+| 1. ANY PR title or [Unreleased] entry contains literal `**BREAKING:**` or `(BREAKING)` | **MINOR** (pre-1.0) / **MAJOR** (>= 1.0) |
+| 2. ANY PR added a NEW user-visible CLI command (e.g. `apm deps why`, `apm publish`) | **MINOR** |
+| 3. ANY PR added a NEW user-facing feature flag, config field, manifest field, or schema entry | **MINOR** |
+| 4. ANY PR added a NEW normative spec, JSON Schema, or contract surface | **MINOR** |
+| 5. ANY PR added a NEW dependency-resolution mode (e.g. semver ranges on git deps) | **MINOR** |
+| 6. ANY PR added a NEW supported target / adapter / integration host | **MINOR** |
+| 7. All remaining PRs are bug fixes, security patches, doc-only, internal | **PATCH** |
+| 8. NO PRs since last tag | **REFUSE** -- nothing to release |
+
+Read top to bottom. The first row whose condition matches is the
+chosen bump. Do not "average" across rows.
+
+## Pre-1.0 vs post-1.0 framing
+
+This rubric is calibrated for the current 0.x line. Per the
+project's stated semver discipline (`pyproject.toml` follows
+semver, see `.github/instructions/changelog.instructions.md`):
+
+- PRE-1.0 (0.x.y): BREAKING changes are allowed in a MINOR bump.
+  This is the standard pre-1.0 semver convention. Mark the entry
+  `**BREAKING:**` so users can grep for it, but do NOT bump to
+  1.0 just because the cycle has a breaking change.
+- POST-1.0 (>= 1.0): BREAKING requires MAJOR. Period.
+
+## Major bump (escalate)
+
+If the rubric would output >= 1.0.0 (the cycle contains a BREAKING
+change AND the current version is already 0.99.x OR the operator
+explicitly named a major bump), STOP and surface to the operator:
+
+> The signals point to a major bump (>= 1.0.0). 1.0 is a
+> positioning decision (API stability commitment), not a
+> mechanical one. Confirm explicitly, or pick a different
+> versioning strategy (e.g. ship as 0.X.Y+1 minor and defer 1.0
+> to a planned release).
+
+Do NOT bump to 1.0.0 without an explicit "yes, ship 1.0" from the
+operator. Default to MINOR in the 0.x line even with breakings.
+
+## Calculating the next version
+
+Given current version `MAJOR.MINOR.PATCH`:
+
+- PATCH bump: `MAJOR.MINOR.(PATCH+1)`.
+- MINOR bump: `MAJOR.(MINOR+1).0`.
+- MAJOR bump: `(MAJOR+1).0.0` (escalate first; see above).
+
+Read the current version from `pyproject.toml` via
+`grep '^version = ' pyproject.toml`. Do not recall it.
+
+## Worked examples (calibration anchors)
+
+### v0.16.0 cycle (the cycle that produced this skill)
+
+Signals seen:
+- One BREAKING in [Unreleased] (`apm install` exit-code change). -> Row 1.
+- New command `apm deps why` (#1495). -> Row 2.
+- New policy `require_pinned_constraint` (#1494). -> Row 3.
+- New spec OpenAPM v0.1 (#1517). -> Row 4.
+- New resolution mode: semver ranges on git deps (#1496). -> Row 5.
+
+First match: Row 1 (BREAKING). Pre-1.0 framing -> **MINOR**.
+Result: `0.15.0 -> 0.16.0`.
+
+### Hypothetical patch-only cycle
+
+Signals seen:
+- Three PRs, all `fix(install): ...`. No BREAKING. No new
+  command. No new schema.
+
+First match: Row 7. -> **PATCH**.
+Result: `0.16.0 -> 0.16.1`.
+
+### Hypothetical no-op cycle
+
+Signals seen:
+- Five PRs, all touching `.apm/` skills, `.github/instructions/`,
+  or `tests/`. All marked INTERNAL by Phase 1's script.
+
+After dropping internals: 0 user-facing PRs.
+
+First match: Row 8 (NO PRs). -> **REFUSE**. Surface to operator:
+"Nothing user-facing has merged since v0.16.0. Release would be
+no-op; recommend waiting for a real fix or feature."
+
+## Output contract
+
+Phase 2 must emit a structured summary to the operator before
+checkpoint 1:
+
+```
+Next version: vX.Y.Z (BUMP from vA.B.C)
+Signal: <row N> -- <one-line description>
+
+Per-PR rationale:
+  #1517 OpenAPM v0.1 spec       -> Row 4 (new spec)
+  #1496 git-source semver       -> Row 5 (new resolution mode) + carries BREAKING (Row 1)
+  #1495 apm deps why            -> Row 2 (new command)
+  #1494 require_pinned_constraint -> Row 3 (new policy)
+  ...
+  #1486 windsurf uninstall fix  -> Row 7 (fix; subordinate to Row 1 above)
+
+Why MINOR (not PATCH): Row 1 fired (BREAKING) AND Rows 2-5 fired.
+Why MINOR (not MAJOR): pre-1.0 framing; breakings ride in minor.
+```
+
+This block is what the operator sees at checkpoint 1; it is also
+what the PR body's "Why this bump" section quotes.

--- a/.apm/skills/cut-release/evals/evals.json
+++ b/.apm/skills/cut-release/evals/evals.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": 1,
+  "skill": "cut-release",
+  "skill_path": "../SKILL.md",
+  "notes": "Trigger evals only. Content evals are deferred to real-task refinement: the next release cycle exercises the skill end-to-end against a real worktree, and the diff vs without-skill is logged manually. This mirrors the deferred-content pattern in docs-sync/.",
+  "triggers": {
+    "split": "val",
+    "should_fire_rate_min": 0.5,
+    "should_not_fire_rate_max": 0.5,
+    "items": [
+      {"id": "fire-01", "query": "cut a release", "expected": "fire", "split": "train"},
+      {"id": "fire-02", "query": "ship v0.16.0", "expected": "fire", "split": "train"},
+      {"id": "fire-03", "query": "release prep -- bump and open the PR", "expected": "fire", "split": "train"},
+      {"id": "fire-04", "query": "what kind of release do we need now, v0.15.1 or v0.16.0?", "expected": "fire", "split": "train"},
+      {"id": "fire-05", "query": "we have enough merged for a release, can you cut it?", "expected": "fire", "split": "train"},
+      {"id": "fire-06", "query": "open the release PR after sanitizing changelog", "expected": "fire", "split": "val"},
+      {"id": "fire-07", "query": "prepare the next minor", "expected": "fire", "split": "val"},
+      {"id": "fire-08", "query": "bump version and open PR", "expected": "fire", "split": "val"},
+      {"id": "fire-09", "query": "let's ship the release", "expected": "fire", "split": "val"},
+      {"id": "fire-10", "query": "sanitize unreleased and cut", "expected": "fire", "split": "val"},
+
+      {"id": "no-fire-01", "query": "tag v0.16.0", "expected": "no-fire", "split": "train", "notes": "Tagging is the post-merge step; cut-release explicitly stops at PR open."},
+      {"id": "no-fire-02", "query": "publish a blog post about the v0.16.0 release", "expected": "no-fire", "split": "train", "notes": "Announcement work; out of scope."},
+      {"id": "no-fire-03", "query": "what changed since v0.15.0?", "expected": "no-fire", "split": "train", "notes": "Pure enumeration; no release being cut."},
+      {"id": "no-fire-04", "query": "review this PR", "expected": "no-fire", "split": "train", "notes": "apm-review-panel territory."},
+      {"id": "no-fire-05", "query": "update the CHANGELOG entry for #1526", "expected": "no-fire", "split": "train", "notes": "Single-PR doc edit, not a release cut."},
+      {"id": "no-fire-06", "query": "rollback to v0.15.0", "expected": "no-fire", "split": "val", "notes": "Release reversal; different workflow."},
+      {"id": "no-fire-07", "query": "regenerate uv.lock after a dep bump", "expected": "no-fire", "split": "val", "notes": "Lockfile maintenance, not a release."},
+      {"id": "no-fire-08", "query": "set version to 0.16.0 in pyproject.toml", "expected": "no-fire", "split": "val", "notes": "Raw version edit; bypasses the rubric and the changelog."},
+      {"id": "no-fire-09", "query": "draft release notes for the website", "expected": "no-fire", "split": "val", "notes": "Marketing copy; out of scope."},
+      {"id": "no-fire-10", "query": "triage the open issues", "expected": "no-fire", "split": "val", "notes": "apm-triage-panel territory."}
+    ]
+  },
+  "stop_list": [
+    "tag the release",
+    "tag v",
+    "git tag",
+    "blog post",
+    "release notes for",
+    "rollback",
+    "regenerate uv.lock",
+    "review this pr",
+    "triage"
+  ]
+}

--- a/.apm/skills/cut-release/scripts/bump-version.sh
+++ b/.apm/skills/cut-release/scripts/bump-version.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# bump-version.sh -- bump pyproject.toml version + refresh uv.lock.
+#
+# Edits the `version = "..."` line under [project] in pyproject.toml,
+# then runs `uv lock` to update uv.lock. Emits a unified diff of both
+# files on stdout for review.
+#
+# Exit codes:
+#   0 success
+#   1 malformed input / target equals current version / file missing
+#   2 usage error
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: bump-version.sh <new_version>
+
+Edit `version = "..."` in pyproject.toml to <new_version>, then
+refresh uv.lock via `uv lock`. Emit a unified diff of both files
+on stdout.
+
+<new_version> must match the pattern MAJOR.MINOR.PATCH (digits
+only, dot-separated, no v-prefix, no pre-release suffix).
+
+Examples:
+  bump-version.sh 0.16.0
+  bump-version.sh 0.16.1
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+if [[ $# -ne 1 ]]; then
+    echo "[x] expected exactly one argument: <new_version>" >&2
+    usage >&2
+    exit 2
+fi
+
+NEW_VERSION="$1"
+
+if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "[x] malformed version: $NEW_VERSION (expected MAJOR.MINOR.PATCH)" >&2
+    exit 1
+fi
+
+if [[ ! -f pyproject.toml ]]; then
+    echo "[x] pyproject.toml not found in cwd: $(pwd)" >&2
+    exit 1
+fi
+
+CURRENT=$(grep -E '^version = ' pyproject.toml | head -1 | sed -E 's/^version = "([^"]+)".*/\1/')
+if [[ -z "$CURRENT" ]]; then
+    echo "[x] could not parse current version from pyproject.toml" >&2
+    exit 1
+fi
+
+if [[ "$CURRENT" == "$NEW_VERSION" ]]; then
+    echo "[x] target version equals current ($CURRENT); nothing to do" >&2
+    exit 1
+fi
+
+echo "[i] current: $CURRENT" >&2
+echo "[i] target:  $NEW_VERSION" >&2
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "[x] missing required tool: uv" >&2
+    exit 1
+fi
+
+# Snapshot for diff.
+BEFORE_PYPROJECT=$(mktemp)
+BEFORE_LOCK=$(mktemp)
+trap 'rm -f "$BEFORE_PYPROJECT" "$BEFORE_LOCK"' EXIT
+cp pyproject.toml "$BEFORE_PYPROJECT"
+if [[ -f uv.lock ]]; then
+    cp uv.lock "$BEFORE_LOCK"
+fi
+
+# Edit pyproject.toml in place. Match only the top-level project
+# version (the first match anchored at column 0).
+TMP=$(mktemp)
+awk -v cur="$CURRENT" -v new="$NEW_VERSION" '
+    !done && $0 == "version = \"" cur "\"" { print "version = \"" new "\""; done=1; next }
+    { print }
+' pyproject.toml > "$TMP"
+
+if ! grep -q "^version = \"$NEW_VERSION\"$" "$TMP"; then
+    echo "[x] failed to apply version edit (no matching line found)" >&2
+    rm -f "$TMP"
+    exit 1
+fi
+mv "$TMP" pyproject.toml
+
+# Refresh uv.lock.
+echo "[*] running uv lock" >&2
+if ! uv lock >&2; then
+    echo "[x] uv lock failed" >&2
+    exit 1
+fi
+
+# Emit unified diff on stdout.
+echo "=== pyproject.toml ==="
+diff -u "$BEFORE_PYPROJECT" pyproject.toml || true
+echo
+echo "=== uv.lock (apm-cli package entry) ==="
+if [[ -f "$BEFORE_LOCK" ]]; then
+    diff -u "$BEFORE_LOCK" uv.lock | grep -E '^[-+@].*(apm-cli|version)' | head -20 || true
+else
+    echo "(uv.lock did not exist before)"
+fi
+
+echo
+echo "[+] bumped $CURRENT -> $NEW_VERSION"

--- a/.apm/skills/cut-release/scripts/list-changes-since-tag.sh
+++ b/.apm/skills/cut-release/scripts/list-changes-since-tag.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# list-changes-since-tag.sh -- enumerate PRs merged since the last release tag.
+#
+# Emits a JSON array on stdout. Diagnostics on stderr. Non-interactive.
+# Requires: git, gh (>= 2.40), jq.
+#
+# Output schema (per PR):
+#   {
+#     "pr": 1495,
+#     "title": "feat(deps): add 'apm deps why <pkg>' ...",
+#     "labels": ["enhancement"],
+#     "author": "danielmeppiel",
+#     "paths_summary": ["src/apm_cli/...", "tests/...", "docs/..."],
+#     "is_user_facing_guess": true,
+#     "commit_sha": "61fe5066..."
+#   }
+#
+# is_user_facing_guess is a HINT (true = touches user-visible surface;
+# false = fully contained in maintainer/internal paths). The LLM caller
+# in cut-release makes the final inclusion call per
+# assets/entry-sanitizer.md.
+#
+# Exit codes:
+#   0 success
+#   1 missing dependency / missing last tag / git failure
+#   2 usage error
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: list-changes-since-tag.sh [--help]
+
+Enumerate PRs merged since the last release tag (as determined by
+`git describe --tags --abbrev=0`). Emits a JSON array on stdout.
+
+No arguments. Stops at the first git/gh failure.
+
+Environment:
+  GH_TOKEN / GITHUB_TOKEN -- used by `gh` if set.
+
+Examples:
+  list-changes-since-tag.sh > /tmp/prs.json
+  list-changes-since-tag.sh | jq '.[] | select(.is_user_facing_guess)'
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+if [[ $# -gt 0 ]]; then
+    echo "[x] unexpected arguments: $*" >&2
+    usage >&2
+    exit 2
+fi
+
+for tool in git gh jq; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "[x] missing required tool: $tool" >&2
+        exit 1
+    fi
+done
+
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+if [[ -z "$LAST_TAG" ]]; then
+    echo "[x] no tags found; cannot enumerate range" >&2
+    exit 1
+fi
+echo "[i] last release tag: $LAST_TAG" >&2
+
+# Collect (sha, subject) for non-merge commits since the tag.
+COMMITS=$(git log "${LAST_TAG}..HEAD" --no-merges --pretty=format:'%H%x09%s')
+if [[ -z "$COMMITS" ]]; then
+    echo "[i] no commits since $LAST_TAG; emitting empty array" >&2
+    echo "[]"
+    exit 0
+fi
+
+# Extract PR numbers from commit subjects (squash-merge convention: "(#NNNN)").
+# Fallback: use `gh pr list --search` keyed by sha if no number is in the subject.
+PR_NUMS=()
+declare -A SHA_OF_PR
+while IFS=$'\t' read -r SHA SUBJECT; do
+    if [[ "$SUBJECT" =~ \(#([0-9]+)\)$ ]]; then
+        NUM="${BASH_REMATCH[1]}"
+        PR_NUMS+=("$NUM")
+        SHA_OF_PR[$NUM]="$SHA"
+    fi
+done <<< "$COMMITS"
+
+if [[ ${#PR_NUMS[@]} -eq 0 ]]; then
+    echo "[!] no PR numbers extracted from commit subjects" >&2
+    echo "[]"
+    exit 0
+fi
+
+echo "[i] resolved ${#PR_NUMS[@]} PR number(s)" >&2
+
+# Internal-path predicate. A path is "internal" if it falls entirely
+# inside any of these prefixes.
+internal_path() {
+    local p="$1"
+    case "$p" in
+        .apm/*|.github/instructions/*|.github/workflows/*|.github/ISSUE_TEMPLATE/*|tests/*|docs/*)
+            return 0 ;;
+        *)
+            return 1 ;;
+    esac
+}
+
+# Emit JSON array.
+printf '['
+FIRST=1
+for NUM in "${PR_NUMS[@]}"; do
+    PR_JSON=$(gh pr view "$NUM" --json title,labels,author,files 2>/dev/null || echo "")
+    if [[ -z "$PR_JSON" ]]; then
+        echo "[!] failed to fetch PR #$NUM; skipping" >&2
+        continue
+    fi
+
+    TITLE=$(jq -r '.title' <<< "$PR_JSON")
+    LABELS=$(jq -c '[.labels[].name]' <<< "$PR_JSON")
+    AUTHOR=$(jq -r '.author.login' <<< "$PR_JSON")
+    PATHS=$(jq -r '.files[].path' <<< "$PR_JSON")
+
+    # Classify: user-facing iff at least one path is NOT internal.
+    USER_FACING="false"
+    PATHS_SUMMARY=()
+    while IFS= read -r P; do
+        [[ -z "$P" ]] && continue
+        PATHS_SUMMARY+=("$P")
+        if ! internal_path "$P"; then
+            USER_FACING="true"
+        fi
+    done <<< "$PATHS"
+
+    # Cap paths_summary at 10 entries (diagnostic, not exhaustive).
+    if [[ ${#PATHS_SUMMARY[@]} -gt 10 ]]; then
+        PATHS_SUMMARY=("${PATHS_SUMMARY[@]:0:10}")
+        PATHS_SUMMARY+=("...")
+    fi
+    PATHS_JSON=$(printf '%s\n' "${PATHS_SUMMARY[@]}" | jq -R . | jq -s .)
+
+    [[ $FIRST -eq 0 ]] && printf ','
+    FIRST=0
+
+    jq -c -n \
+        --argjson pr "$NUM" \
+        --arg title "$TITLE" \
+        --argjson labels "$LABELS" \
+        --arg author "$AUTHOR" \
+        --argjson paths "$PATHS_JSON" \
+        --arg sha "${SHA_OF_PR[$NUM]}" \
+        --argjson user_facing "$USER_FACING" \
+        '{pr: $pr, title: $title, labels: $labels, author: $author,
+          paths_summary: $paths, is_user_facing_guess: $user_facing,
+          commit_sha: $sha}'
+done
+printf ']\n'

--- a/.apm/skills/cut-release/scripts/verify-lint-mirror.sh
+++ b/.apm/skills/cut-release/scripts/verify-lint-mirror.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# verify-lint-mirror.sh -- run the CI Lint job mirror locally.
+#
+# Mirrors `.apm/instructions/linting.instructions.md` verbatim.
+# Stops at the first failure. Diagnostics on stderr; structured
+# pass/fail summary on stdout.
+#
+# Exit codes:
+#   0 all checks passed
+#   1 one or more checks failed
+#   2 usage error / missing dependency
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: verify-lint-mirror.sh [--help]
+
+Run the four CI-mirror lint steps from
+.apm/instructions/linting.instructions.md verbatim:
+
+  1. ruff check (style + imports + lint)
+  2. ruff format --check
+  3. pylint R0801 duplication guard (min-similarity-lines=10)
+  4. auth-signals boundary lint (scripts/lint-auth-signals.sh)
+
+Stops at first failure. Stdout: one PASS/FAIL line per step plus
+final summary. Stderr: tool diagnostics.
+
+No arguments. Run from the worktree root.
+
+Note: the YAML I/O guard, file-length guardrail, and
+`relative_to` guard from the CI job are pure-grep one-liners that
+this mirror does NOT run -- they are cheap to invoke directly and
+were skipped to keep this script focused. Run them manually if you
+touched those surfaces.
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+if [[ $# -gt 0 ]]; then
+    echo "[x] unexpected arguments: $*" >&2
+    usage >&2
+    exit 2
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "[x] missing required tool: uv" >&2
+    exit 2
+fi
+
+# Track step status. STEP_STATUS holds "PASS" or "FAIL <msg>".
+declare -a STEP_NAMES=(
+    "ruff check"
+    "ruff format --check"
+    "pylint R0801 duplication"
+    "auth-signals boundary"
+)
+declare -a STEP_CMDS=(
+    "uv run --extra dev ruff check src/ tests/"
+    "uv run --extra dev ruff format --check src/ tests/"
+    "uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/"
+    "bash scripts/lint-auth-signals.sh"
+)
+declare -a STEP_STATUS=()
+
+OVERALL=0
+for i in "${!STEP_CMDS[@]}"; do
+    NAME="${STEP_NAMES[$i]}"
+    CMD="${STEP_CMDS[$i]}"
+    echo "[*] $NAME" >&2
+    if eval "$CMD" >&2; then
+        STEP_STATUS+=("PASS")
+        echo "[+] $NAME" >&2
+    else
+        STEP_STATUS+=("FAIL")
+        echo "[x] $NAME -- see diagnostics above" >&2
+        OVERALL=1
+        break
+    fi
+done
+
+echo
+echo "=== verify-lint-mirror summary ==="
+for i in "${!STEP_NAMES[@]}"; do
+    STATUS="${STEP_STATUS[$i]:-SKIPPED}"
+    printf "  %-30s %s\n" "${STEP_NAMES[$i]}" "$STATUS"
+done
+
+if [[ $OVERALL -eq 0 ]]; then
+    echo "[+] all lint-mirror checks PASSED"
+else
+    echo "[x] lint-mirror FAILED -- fix and re-run before pushing"
+fi
+exit $OVERALL


### PR DESCRIPTION
## TL;DR

Adds `.apm/skills/cut-release/` -- a reusable skill that encodes the v0.16.0 release process (decide bump, sanitize `[Unreleased]`, bump `pyproject.toml` + `uv.lock`, run CI-mirror lint, open the release PR). Stops at "PR open"; tagging stays a human gate.

## Why

The v0.16.0 cycle (#1526) was cut by walking the same steps manually for the third time:

1. Read `git log v0.15.0..HEAD` + `gh pr view` for each PR.
2. Decide patch vs minor by hand (BREAKING markers + new commands -> minor).
3. Rewrite each verbose `[Unreleased]` bullet into a one-line "so what" entry.
4. Drop internal-only churn (`.apm/`, `tests/`, `.github/instructions/` -- nothing user-visible).
5. Bump `pyproject.toml`, regenerate `uv.lock`, run the four-step CI lint mirror.
6. Open the release PR with a rationale paragraph.

That procedure is now a primitive. Activation: "cut a release", "ship v0.x", "what kind of release do we need", etc.

## How (architecture)

Designed via the `genesis` skill; the step-6 handoff packet is persisted in the session `plan.md` (architecture is the source of truth for future refactors, not the natural-language body).

- **Single-thread sequential**, not a panel. One lens (release strategy), one rubric -- pattern-tradeoffs matrix #4 (NO SHARED STATE + SEQUENTIAL) cuts the choice.
- **3 B10 HUMAN CHECKPOINTS**: version pick, sanitized changelog diff, lint-fail recovery. Irreversible steps (push, PR open) are gated.
- **3 S7 deterministic tool bridges** (under `scripts/`):
  - `list-changes-since-tag.sh` -- `git log` + `gh pr view`, emits JSON, classifies internal-vs-user-facing by path prefix.
  - `bump-version.sh` -- edits `pyproject.toml` version line, runs `uv lock`, emits unified diff.
  - `verify-lint-mirror.sh` -- mirrors the four-step CI Lint job verbatim from `.apm/instructions/linting.instructions.md`.
- **3 assets** (under `assets/`): `semver-rubric.md` (signal table + pre/post-1.0 framing), `entry-sanitizer.md` (per-entry rubric + DROP list), `pr-body-template.md` (variable-substituted PR body).

### Composition

| Dependency | Mode | Why |
|---|---|---|
| `apm-strategy` (existing) | LOCAL SIBLING, auto-loads via CHANGELOG.md trigger | Owns release positioning + breaking-change calls. Depend, don't re-derive. |
| `.apm/instructions/linting.instructions.md` | LOCAL SIBLING (path-attached rule) | Canonical CI-mirror command list. `verify-lint-mirror.sh` is a thin invoker. |
| `.github/instructions/changelog.instructions.md` | LOCAL SIBLING (path-attached rule) | Owns Keep-a-Changelog format. Reference only. |

No EXTERNAL MODULE declared. No PHANTOM DEPENDENCY risk.

## Boundary

The skill explicitly does NOT:

- Tag the release (post-merge, human-gated, triggers the release workflow).
- Run the full test suite or build PyInstaller binaries (CI gates handle that; the skill mirrors only the Lint job that the changelog claims green).
- Publish release notes anywhere else (no GitHub Release body, no blog, no announcement).
- Bump to >= 1.0.0 without explicit operator confirmation (B10 escalation).

## Self-dogfooded

The worked examples in `assets/semver-rubric.md` and `assets/entry-sanitizer.md` cite the v0.16.0 cycle (#1526) as calibration. Next bug-fix release will be the first real run of the skill end-to-end -- if it diverges from what we'd do manually, the assets get tightened.

## Evals

- 20 trigger evals (10 should-fire, 10 near-miss should-not-fire) in `evals/evals.json`.
- Content evals deferred to real-task refinement on the next release cycle (with-skill vs without-skill diff is captured manually).

## How to test

```bash
bash .apm/skills/cut-release/scripts/list-changes-since-tag.sh --help
bash .apm/skills/cut-release/scripts/verify-lint-mirror.sh --help
bash .apm/skills/cut-release/scripts/bump-version.sh --help
```

Each prints usage and exits 0. The first dry-runnable end-to-end test is "cut a release" on the next worktree that has merged PRs since v0.16.0.
