### PR TITLE
fix(git-env): strip LD_LIBRARY_PATH from git subprocess env to prevent shared lib conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Linux packaged `apm` binaries no longer leak PyInstaller dynamic-library paths into git subprocesses, preventing shared-library symbol lookup failures during shared-cache clones. (closes #1534)
+
 ## [0.16.0] - 2026-05-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Linux packaged `apm` binaries no longer leak PyInstaller dynamic-library paths into git subprocesses, preventing shared-library symbol lookup failures during shared-cache clones. (closes #1534)
+- Linux standalone `apm` binaries no longer fail git shared-cache clones with shared-library symbol lookup errors caused by PyInstaller dynamic-library paths leaking into child processes. (closes #1534)
 
 ## [0.16.0] - 2026-05-28
 

--- a/build/apm.spec
+++ b/build/apm.spec
@@ -279,21 +279,43 @@ a = Analysis(
     # to keep docstrings.
 )
 
-# Exclude bundled OpenSSL shared libraries on Linux.
-# PyInstaller's bootloader sets LD_LIBRARY_PATH to the binary directory in
-# --onedir mode. When apm spawns git, git-remote-https inherits that path
-# and loads the bundled (build-machine) libssl instead of the system one.
-# On distros where system libcurl requires a newer OpenSSL ABI than the
-# build machine provides (e.g. Fedora 43 with OPENSSL_3.2.0), this causes
-# "symbol lookup error" and git clone failures. Excluding these libs lets
-# the system OpenSSL be used instead, which is expected to be available on
-# supported Linux targets. Python's _ssl module still works because it finds
-# system libssl via the standard dynamic linker search path. See:
-# github.com/microsoft/apm/issues/462
+# Exclude non-Python shared libraries from the bundle on Linux.
+# PyInstaller's bootloader in --onedir mode sets LD_LIBRARY_PATH to the
+# binary directory.  When apm spawns git (or any child process), those
+# processes inherit LD_LIBRARY_PATH and load the bundled build-machine
+# libraries instead of the system ones.  If the bundled versions differ
+# from what the child process expects (different ABI, missing symbols),
+# the child fails with "symbol lookup error".
+#
+# Fix #1 (git_env.py) strips LD_LIBRARY_PATH from the git subprocess env
+# as the primary defense.  This exclusion is defense-in-depth: removing
+# the libraries from the bundle entirely so they cannot leak regardless
+# of any env-propagation bug in the future.
+#
+# Python's own _ssl, _hashlib, etc. find system libraries via the
+# standard dynamic linker search path and are unaffected.
+#
+# See: github.com/microsoft/apm/issues/462 (original OpenSSL fix)
+#      github.com/microsoft/apm/issues/1534 (generalized to all non-Python libs)
 if sys.platform == 'linux':
-    _openssl_libs = {'libssl.so.3', 'libcrypto.so.3'}
+    _exclude_libs = {
+        # OpenSSL (original fix, issue #462)
+        "libssl.so.3",
+        "libcrypto.so.3",
+        # Readline + terminfo (breaks /bin/sh, bash, git subprocesses)
+        "libreadline.so.8",
+        "libtinfo.so.6",
+        # Compression (breaks git clone/remote helpers)
+        "libz.so.1",
+        "liblzma.so.5",
+        "libbz2.so.1.0",
+        # General-purpose system libs (break various child processes)
+        "libffi.so.8",
+        "libsqlite3.so.0",
+        "libuuid.so.1",
+    }
     a.binaries = [(name, path, typ) for name, path, typ in a.binaries
-                  if name not in _openssl_libs]
+                  if name not in _exclude_libs]
 
 pyz = PYZ(a.pure, a.zipped_data, cipher=None)
 

--- a/src/apm_cli/utils/git_env.py
+++ b/src/apm_cli/utils/git_env.py
@@ -9,12 +9,14 @@ Preserved variables (user-controlled config for proxy/auth):
 - GIT_HTTP_USER_AGENT, GIT_TERMINAL_PROMPT
 - GIT_CONFIG_GLOBAL, GIT_CONFIG_SYSTEM
 
-Stripped variables (ambient git state):
+Stripped variables (ambient state that would bias git operations):
 - GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE
 - GIT_OBJECT_DIRECTORY, GIT_ALTERNATE_OBJECT_DIRECTORIES
 - GIT_COMMON_DIR, GIT_NAMESPACE, GIT_INDEX_VERSION
 - GIT_CEILING_DIRECTORIES, GIT_DISCOVERY_ACROSS_FILESYSTEM
 - GIT_REPLACE_REF_BASE, GIT_GRAFTS_FILE, GIT_SHALLOW_FILE
+- LD_LIBRARY_PATH  (PyInstaller bootloader sets this; bundled shared libs
+  such as libreadline would break git's /bin/sh subprocesses)
 """
 
 from __future__ import annotations
@@ -45,6 +47,14 @@ _STRIP_GIT_VARS: frozenset[str] = frozenset(
         "GIT_REPLACE_REF_BASE",
         "GIT_GRAFTS_FILE",
         "GIT_SHALLOW_FILE",
+        # PyInstaller's bootloader sets LD_LIBRARY_PATH so the bundled
+        # Python can find libpython3.12.  When this leaks into git
+        # subprocesses, bundled shared libs (libreadline, libz,
+        # liblzma, etc.) shadow the system libraries that /bin/sh and
+        # git need, causing symbol lookup errors and clone failures.
+        # See https://github.com/microsoft/apm/issues/462 for the
+        # original OpenSSL instance of this class of bug.
+        "LD_LIBRARY_PATH",
     }
 )
 

--- a/src/apm_cli/utils/git_env.py
+++ b/src/apm_cli/utils/git_env.py
@@ -9,20 +9,20 @@ Preserved variables (user-controlled config for proxy/auth):
 - GIT_HTTP_USER_AGENT, GIT_TERMINAL_PROMPT
 - GIT_CONFIG_GLOBAL, GIT_CONFIG_SYSTEM
 
-Stripped variables (ambient state that would bias git operations):
+Git state variables stripped after external-process sanitization:
 - GIT_DIR, GIT_WORK_TREE, GIT_INDEX_FILE
 - GIT_OBJECT_DIRECTORY, GIT_ALTERNATE_OBJECT_DIRECTORIES
 - GIT_COMMON_DIR, GIT_NAMESPACE, GIT_INDEX_VERSION
 - GIT_CEILING_DIRECTORIES, GIT_DISCOVERY_ACROSS_FILESYSTEM
 - GIT_REPLACE_REF_BASE, GIT_GRAFTS_FILE, GIT_SHALLOW_FILE
-- LD_LIBRARY_PATH  (PyInstaller bootloader sets this; bundled shared libs
-  such as libreadline would break git's /bin/sh subprocesses)
 """
 
 from __future__ import annotations
 
 import os
 import shutil
+
+from apm_cli.utils.subprocess_env import external_process_env
 
 # Module-level cached git executable path (resolved once per process)
 _git_executable: str | None = None
@@ -47,14 +47,6 @@ _STRIP_GIT_VARS: frozenset[str] = frozenset(
         "GIT_REPLACE_REF_BASE",
         "GIT_GRAFTS_FILE",
         "GIT_SHALLOW_FILE",
-        # PyInstaller's bootloader sets LD_LIBRARY_PATH so the bundled
-        # Python can find libpython3.12.  When this leaks into git
-        # subprocesses, bundled shared libs (libreadline, libz,
-        # liblzma, etc.) shadow the system libraries that /bin/sh and
-        # git need, causing symbol lookup errors and clone failures.
-        # See https://github.com/microsoft/apm/issues/462 for the
-        # original OpenSSL instance of this class of bug.
-        "LD_LIBRARY_PATH",
     }
 )
 
@@ -91,13 +83,15 @@ def get_git_executable() -> str:
 def git_subprocess_env() -> dict[str, str]:
     """Return a sanitized environment dict for git subprocesses.
 
-    Strips ambient git state variables while preserving user-controlled
+    Restores PyInstaller-managed dynamic-library variables first, then
+    strips ambient git state variables while preserving user-controlled
     configuration (proxy, auth, SSH settings).
 
     Returns:
-        A copy of ``os.environ`` with problematic git variables removed.
+        An external-process-safe copy of ``os.environ`` with problematic
+        git variables removed.
     """
-    return {k: v for k, v in os.environ.items() if k not in _STRIP_GIT_VARS}
+    return {k: v for k, v in external_process_env().items() if k not in _STRIP_GIT_VARS}
 
 
 def reset_git_cache() -> None:

--- a/tests/unit/cache/test_git_env.py
+++ b/tests/unit/cache/test_git_env.py
@@ -107,3 +107,8 @@ class TestGitSubprocessEnv:
             env = git_subprocess_env()
             assert env["HOME"] == "/home/user"
             assert env["PATH"] == "/usr/bin"
+
+    def test_strips_ld_library_path(self) -> None:
+        with patch.dict(os.environ, {"LD_LIBRARY_PATH": "/some/custom/lib"}):
+            env = git_subprocess_env()
+            assert "LD_LIBRARY_PATH" not in env

--- a/tests/unit/cache/test_git_env.py
+++ b/tests/unit/cache/test_git_env.py
@@ -1,6 +1,7 @@
 """Tests for git subprocess environment sanitization."""
 
 import os
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -108,7 +109,31 @@ class TestGitSubprocessEnv:
             assert env["HOME"] == "/home/user"
             assert env["PATH"] == "/usr/bin"
 
-    def test_strips_ld_library_path(self) -> None:
-        with patch.dict(os.environ, {"LD_LIBRARY_PATH": "/some/custom/lib"}):
+    def test_strips_pyinstaller_ld_library_path_when_frozen(self) -> None:
+        with (
+            patch.object(sys, "frozen", True, create=True),
+            patch.dict(os.environ, {"LD_LIBRARY_PATH": "/bundle/internal"}, clear=True),
+        ):
             env = git_subprocess_env()
             assert "LD_LIBRARY_PATH" not in env
+
+    def test_restores_original_ld_library_path_when_frozen(self) -> None:
+        with (
+            patch.object(sys, "frozen", True, create=True),
+            patch.dict(
+                os.environ,
+                {
+                    "LD_LIBRARY_PATH": "/bundle/internal",
+                    "LD_LIBRARY_PATH_ORIG": "/custom/lib",
+                },
+                clear=True,
+            ),
+        ):
+            env = git_subprocess_env()
+            assert env["LD_LIBRARY_PATH"] == "/custom/lib"
+            assert "LD_LIBRARY_PATH_ORIG" not in env
+
+    def test_preserves_ld_library_path_when_not_frozen(self) -> None:
+        with patch.dict(os.environ, {"LD_LIBRARY_PATH": "/custom/lib"}, clear=True):
+            env = git_subprocess_env()
+            assert env["LD_LIBRARY_PATH"] == "/custom/lib"


### PR DESCRIPTION
## Description

Strips `LD_LIBRARY_PATH` from the git subprocess environment to prevent PyInstaller-bundled shared libraries from leaking into child processes.

PyInstaller's bootloader sets `LD_LIBRARY_PATH` so the bundled Python can find `libpython3.12.so`. This leaks into every `subprocess.run()` call, including `materialize_from_bare()` in `bare_cache.py`. Bundled shared libs (libreadline.so.8, libz.so.1, libsqlite3.so.0, etc.) shadow system libraries, breaking `/bin/sh`:

```
/bin/sh: symbol lookup error: /bin/sh: undefined symbol: rl_print_keybinding
fatal: Could not read from remote repository.
```

This causes `git clone --local --shared --no-checkout` to exit 128 in the shared clone cache path (`SharedCloneCache`).

**Fix 1 (primary):** Add `LD_LIBRARY_PATH` to `_STRIP_GIT_VARS` in `git_env.py`. This sanitizer exists precisely to clean ambient variables from git subprocess environments — `LD_LIBRARY_PATH` leaking is a sanitization failure.

**Fix 2 (defense-in-depth):** Expand the `apm.spec` exclusion list to remove all non-Python shared libs from the bundle. The original exclusion only covered OpenSSL (issue #462). This extends it to libreadline, libz, liblzma, libsqlite3, libffi, libbz2, libuuid, and libtinfo — preventing any future env-propagation regression.

Fixes #1534

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally (built patched binary, validated in real APM project with 4 virtual subdirectory deps from the same repo — previously failed with exit 128, now installs clean)
- [x] All existing tests pass (15,668 passed; 4 files skipped due to pre-existing git config issues in test environment unrelated to this PR)
- [x] Added tests for new functionality (`test_strips_ld_library_path` in `test_git_env.py`)

## Spec conformance (OpenAPM v0.1)

- [x] N/A -- this PR does not change OpenAPM-observable behaviour.