### PR TITLE
fix(panels): unbreak panel workflows -- gh-aw v0.76+ harvests expression tokens from bash comments

### DIFF
--- a/.github/workflows/docs-sync.lock.yml
+++ b/.github/workflows/docs-sync.lock.yml
@@ -1038,9 +1038,16 @@ jobs:
           # ROW_PRIVATE_KEY values so downstream tolerance is irrelevant.
           pk="${pk%$'\n'}"
           # Defence in depth: the PK is already masked because it came from
-          # a $GH_AW_EXPR_36F7BDB0 reference at compile time, but registering it
-          # again here makes the contract explicit and survives any future
-          # gh-aw template churn that might lose the secret tag.
+          # a secrets-context reference at compile time (gh-aw substitutes
+          # the configured private-key secret into AW_APM_*), but
+          # registering it again here makes the contract explicit and
+          # survives any future gh-aw template churn that might lose the
+          # secret tag. NOTE: do not write GitHub Actions expression syntax
+          # (dollar-doublecurly ... doublecurly) inside this comment.
+          # gh-aw v0.76+ harvests such tokens out of bash run-block bodies
+          # (even inside `#` comments) and hoists them into the step env,
+          # which fails workflow load when the inner expression resolves
+          # to a sequence (e.g. wildcard secrets-context references).
           echo "::add-mask::$pk"
           # Use a random heredoc delimiter to eliminate any chance of a PEM
           # line collision terminating the value early. The official docs
@@ -1054,7 +1061,8 @@ jobs:
             printf '%s\n' "$delim"
           } >> "$GITHUB_ENV"
         env:
-          GH_AW_EXPR_36F7BDB0: ${{ secrets.* }}
+          ROW_INDEX: ${{ matrix.group.index }}
+          ROW_KIND: ${{ matrix.group.kind }}
       - name: Mint installation token
         id: token
         if: ${{ matrix.group.has-app == 'true' }}

--- a/.github/workflows/pr-review-panel.lock.yml
+++ b/.github/workflows/pr-review-panel.lock.yml
@@ -1068,9 +1068,16 @@ jobs:
           # ROW_PRIVATE_KEY values so downstream tolerance is irrelevant.
           pk="${pk%$'\n'}"
           # Defence in depth: the PK is already masked because it came from
-          # a $GH_AW_EXPR_36F7BDB0 reference at compile time, but registering it
-          # again here makes the contract explicit and survives any future
-          # gh-aw template churn that might lose the secret tag.
+          # a secrets-context reference at compile time (gh-aw substitutes
+          # the configured private-key secret into AW_APM_*), but
+          # registering it again here makes the contract explicit and
+          # survives any future gh-aw template churn that might lose the
+          # secret tag. NOTE: do not write GitHub Actions expression syntax
+          # (dollar-doublecurly ... doublecurly) inside this comment.
+          # gh-aw v0.76+ harvests such tokens out of bash run-block bodies
+          # (even inside `#` comments) and hoists them into the step env,
+          # which fails workflow load when the inner expression resolves
+          # to a sequence (e.g. wildcard secrets-context references).
           echo "::add-mask::$pk"
           # Use a random heredoc delimiter to eliminate any chance of a PEM
           # line collision terminating the value early. The official docs
@@ -1084,7 +1091,8 @@ jobs:
             printf '%s\n' "$delim"
           } >> "$GITHUB_ENV"
         env:
-          GH_AW_EXPR_36F7BDB0: ${{ secrets.* }}
+          ROW_INDEX: ${{ matrix.group.index }}
+          ROW_KIND: ${{ matrix.group.kind }}
       - name: Mint installation token
         id: token
         if: ${{ matrix.group.has-app == 'true' }}

--- a/.github/workflows/shared/apm.md
+++ b/.github/workflows/shared/apm.md
@@ -322,9 +322,16 @@ jobs:
           # ROW_PRIVATE_KEY values so downstream tolerance is irrelevant.
           pk="${pk%$'\n'}"
           # Defence in depth: the PK is already masked because it came from
-          # a ${{ secrets.* }} reference at compile time, but registering it
-          # again here makes the contract explicit and survives any future
-          # gh-aw template churn that might lose the secret tag.
+          # a secrets-context reference at compile time (gh-aw substitutes
+          # the configured private-key secret into AW_APM_*), but
+          # registering it again here makes the contract explicit and
+          # survives any future gh-aw template churn that might lose the
+          # secret tag. NOTE: do not write GitHub Actions expression syntax
+          # (dollar-doublecurly ... doublecurly) inside this comment.
+          # gh-aw v0.76+ harvests such tokens out of bash run-block bodies
+          # (even inside `#` comments) and hoists them into the step env,
+          # which fails workflow load when the inner expression resolves
+          # to a sequence (e.g. wildcard secrets-context references).
           echo "::add-mask::$pk"
           # Use a random heredoc delimiter to eliminate any chance of a PEM
           # line collision terminating the value early. The official docs

--- a/.github/workflows/triage-panel.lock.yml
+++ b/.github/workflows/triage-panel.lock.yml
@@ -1136,9 +1136,16 @@ jobs:
           # ROW_PRIVATE_KEY values so downstream tolerance is irrelevant.
           pk="${pk%$'\n'}"
           # Defence in depth: the PK is already masked because it came from
-          # a $GH_AW_EXPR_36F7BDB0 reference at compile time, but registering it
-          # again here makes the contract explicit and survives any future
-          # gh-aw template churn that might lose the secret tag.
+          # a secrets-context reference at compile time (gh-aw substitutes
+          # the configured private-key secret into AW_APM_*), but
+          # registering it again here makes the contract explicit and
+          # survives any future gh-aw template churn that might lose the
+          # secret tag. NOTE: do not write GitHub Actions expression syntax
+          # (dollar-doublecurly ... doublecurly) inside this comment.
+          # gh-aw v0.76+ harvests such tokens out of bash run-block bodies
+          # (even inside `#` comments) and hoists them into the step env,
+          # which fails workflow load when the inner expression resolves
+          # to a sequence (e.g. wildcard secrets-context references).
           echo "::add-mask::$pk"
           # Use a random heredoc delimiter to eliminate any chance of a PEM
           # line collision terminating the value early. The official docs
@@ -1152,7 +1159,8 @@ jobs:
             printf '%s\n' "$delim"
           } >> "$GITHUB_ENV"
         env:
-          GH_AW_EXPR_36F7BDB0: ${{ secrets.* }}
+          ROW_INDEX: ${{ matrix.group.index }}
+          ROW_KIND: ${{ matrix.group.kind }}
       - name: Mint installation token
         id: token
         if: ${{ matrix.group.has-app == 'true' }}


### PR DESCRIPTION
## TL;DR

The PR Review Panel, Triage Panel, and Docs-Sync workflows have been failing at template-load time on every triggering event since the `gh-aw v0.71.5 -> v0.76.1` recompile in #1487 (commit 9680e679). Symptom on the affected runs:

```
##[error]The template is not valid.
.github/workflows/pr-review-panel.lock.yml (Line: 1087, Col: 32):
A sequence was not expected
```

Example failure: https://github.com/microsoft/apm/actions/runs/26625014231/job/78460262895?pr=1538

## Root cause

`gh-aw` v0.76+ scans the body of `run:` blocks for GitHub Actions expression tokens (`${{ ... }}`) and hoists them into the step's `env:` block. **It does this even for tokens that appear inside `#` shell comments.** v0.71.5 did not.

`shared/apm.md` (the imported APM credential-prep shared block) had a comment that, for documentation purposes, included the literal expression form of a secrets-context reference:

```yaml
# Defence in depth: the PK is already masked because it came from
# a ${{ secrets.* }} reference at compile time, but registering it
# again here makes the contract explicit ...
```

v0.76+ harvested that comment token into:

```yaml
env:
  GH_AW_EXPR_36F7BDB0: ${{ secrets.* }}
```

`secrets.*` is the wildcard secrets-context filter, which evaluates to a **sequence** (array of secret values), not a string. Actions refuses to coerce a sequence into an env value, so the workflow fails to load before any step runs. Same root cause hit `pr-review-panel.lock.yml`, `triage-panel.lock.yml`, and `docs-sync.lock.yml` because they all import `shared/apm.md`.

I verified this is not fixed in the latest gh-aw pre-release (v0.77.1) either, so this is the right surface to fix.

## Fix

Rewrite the offending comment in `shared/apm.md` so it documents the contract without spelling out the literal expression syntax (no `${{ ... }}` form, no `${{ ... }}` placeholder either — gh-aw harvests that too). Recompiled all three affected lock files.

After the fix, the rebuilt step env block in each lock file carries only the intended values:

```yaml
env:
  ROW_INDEX: ${{ matrix.group.index }}
  ROW_KIND: ${{ matrix.group.kind }}
```

No runtime behaviour change — the `Resolve APM credentials` step continues to read `AW_APM_LEGACY_*` and `AW_APM_APPS` (which gh-aw still wires up at the job env level), mask the PEM, and write `ROW_APP_ID` / `ROW_PRIVATE_KEY` to `$GITHUB_ENV`.

## Validation

- [x] `gh aw compile` clean (0 errors, 2 unrelated pre-existing `pull_request_target` warnings on panels — see comment in `pr-review-panel.md`).
- [x] `grep -r 'GH_AW_EXPR_36F7BDB0\|secrets\.\*' .github/workflows/*.yml` returns no matches in `env:` blocks (only inside cautionary documentation comments).
- [x] `bash scripts/lint-auth-signals.sh` passes.
- [x] Diff is minimal: 3 lock.yml files + 1 source `.md`, all in the same step body. No primitive, CLI, or runtime code touched.

## Upstream follow-up

Filing a bug at `github/gh-aw` so the v0.76+ expression-harvesting pass respects shell-comment boundaries inside `run:` blocks. Will link the issue here once filed.

## Risk

Low. This is the exact lock file shape gh-aw v0.71.5 produced (minus the action/container SHA bumps that already shipped in #1487), with a clean comment that no longer trips the v0.76+ harvester.