### PR TITLE
docs: surface compilation.strategy=distributed default in concepts and compile reference (closes #1447)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- Surface the `compilation.strategy: distributed` default in the
+  concepts ramp and `apm compile` reference so users understand why
+  `apm compile` may add `AGENTS.md` / `CLAUDE.md` files in
+  subdirectories driven by `applyTo:` scopes. Adds a new "Where
+  compiled context files land" section to the primitives-and-targets
+  page and a distributed-layout example in the compile reference.
+  Default behavior is unchanged. (closes #1447) -- by @tillig
+
 ## [0.16.0] - 2026-05-28
 
 ### Added

--- a/docs/src/content/docs/concepts/primitives-and-targets.md
+++ b/docs/src/content/docs/concepts/primitives-and-targets.md
@@ -121,6 +121,31 @@ How to read a cell:
 - `plugins / *` -- APM unpacks the plugin at install time into the primitives in the rows above; routing then follows those rows.
 - `MCP servers / *` -- APM writes the harness's standard MCP config. Transitive MCP servers brought in by deep dependencies must be explicitly declared or trusted with `--trust-transitive-mcp` -- effectively `gated` for those, `native` for direct dependencies.
 
+## Where compiled context files land
+
+`apm compile` defaults to **distributed** placement: instead of one
+monolithic `AGENTS.md` / `CLAUDE.md` at the repo root, APM writes a
+focused target file next to each directory that has matching
+instructions. The placement is driven by each instruction's `applyTo:`
+glob in its frontmatter. For example, an instruction with
+`applyTo: "scripts/**"` lands in `scripts/AGENTS.md` rather than the
+root file.
+
+This means a fresh `apm compile` may create new `AGENTS.md` /
+`CLAUDE.md` files in subdirectories you did not previously touch.
+That is intentional -- it follows the **Minimal Context Principle**
+so each agent only loads instructions relevant to the directory it is
+working in. If you prefer one combined file at the project root, run
+`apm compile --single-agents` (or set `compilation.single_file: true`
+in `apm.yml`).
+
+To remove distributed files that are no longer produced (e.g. after
+deleting or rescoping an instruction), run `apm compile --clean`.
+
+For the full strategy reference and flag semantics, see
+[`apm compile`](/apm/reference/cli/compile/#strategy-modes) and
+[manifest schema: `compilation.strategy`](/apm/reference/manifest-schema/).
+
 ## Dev-only primitives
 
 Mark a primitive as dev-only when it is useful to the package author but should not ship to consumers: release checklists, internal debugging agents, test-fixture skills, anything tied to your own infrastructure. Author such primitives outside `.apm/` (typically `dev/`) and reference them under `devDependencies` in `apm.yml`. `apm pack` excludes them; `apm install --dev` deploys them locally.

--- a/docs/src/content/docs/reference/cli/compile.md
+++ b/docs/src/content/docs/reference/cli/compile.md
@@ -207,10 +207,31 @@ There is no `--strategy` flag. Compilation runs in one of two modes:
 - **Distributed (default)** -- writes a tree of focused target files
   (e.g. `AGENTS.md`, `CLAUDE.md`) next to the code they apply to, plus
   per-target subdirectories. This is the recommended mode and follows
-  the Minimal Context Principle.
+  the Minimal Context Principle. Set `compilation.strategy:
+  single-file` (or `compilation.single_file: true`) in `apm.yml` to
+  opt out.
 - **Single-file (`--single-agents`)** -- writes one combined file at
   `--output` (default `AGENTS.md`). Use when a harness or workflow
   requires a single context file.
+
+### Distributed layout example
+
+For a project with two scoped instructions
+(`applyTo: "scripts/**"` and `applyTo: "tests/**"`) plus a generic
+one (no `applyTo:`), `apm compile` writes:
+
+```
+AGENTS.md            # generic instructions only
+scripts/AGENTS.md    # instructions scoped to scripts/**
+tests/AGENTS.md      # instructions scoped to tests/**
+```
+
+Each agent harness then loads only the file nearest the code it is
+working in. If you did not expect new `AGENTS.md` / `CLAUDE.md` files
+in subdirectories, this is the distributed default in effect; see
+[Where compiled context files land](../../../concepts/primitives-and-targets/#where-compiled-context-files-land)
+for the rationale, or pass `--single-agents` for a single-file
+output.
 
 ## Exit codes
 


### PR DESCRIPTION
## TL;DR

Pure docs PR. Surfaces the `compilation.strategy: distributed` default in the two pages where users would actually look for it: the primitives-and-targets concepts ramp and the `apm compile` reference's Strategy modes section. No behavior change.

Closes #1447.

## Why

#1447 reports legitimate UX surprise. The user observed:

> when I ran [apm compile] it generated AGENTS.md and CLAUDE.md files in random subfolders that, frankly, shocked me [...] To find that compilation.strategy isn't set means the default is distributed, which it certainly seems to be.

The default IS distributed (`src/apm_cli/compilation/agents_compiler.py:79`) and that is intentional -- it follows the Minimal Context Principle so each agent harness only loads instructions relevant to the directory it is working in. But the default was effectively undocumented in the discoverable surfaces (concepts page, compile reference Strategy modes), buried only in a manifest-schema row and a parenthetical compile note.

This PR fixes the docs gap so the next user doesn't get the same shock.

## Scope (deliberately narrow)

Per strategic-alignment review on #1447 (verdict: aligned-with-reservations, P4 UX floor), this PR is **docs only**:

1. **Default-strategy and `--clean` default questions are out of scope.** Flipping `compilation.strategy` from distributed to single-file, or flipping `--clean` to true by default, would be a silent behavior change that loses trust. Those belong in a separate RFC-style issue with a CHANGELOG BREAKING entry. Not this PR.
2. **The Claude-duplication piece the user also flagged is already fixed-at-head** via #1445 (`agents_compiler.py:568-590` skips CLAUDE.md instructions when `.claude/rules/*.md` already exists).
3. **Copilot-dedup parity** -- on inspection, the analogous skip is missing for the AGENTS.md path when `.github/instructions/` exists. Filed as #1550 for a separate, properly-scoped PR with full TDD; not folded here.

## What changed

- `docs/src/content/docs/concepts/primitives-and-targets.md`: new "Where compiled context files land" section. Explains distributed placement is driven by `applyTo:` globs, that subdirectory `AGENTS.md` / `CLAUDE.md` files are intentional, and links forward to the compile reference and manifest schema. Mentions `--single-agents` and `--clean` as escape hatches.
- `docs/src/content/docs/reference/cli/compile.md`: expanded the existing Strategy modes section with a concrete distributed-layout example (root + `scripts/AGENTS.md` + `tests/AGENTS.md`) and a back-link to the concepts section so the user who lands on the reference page from the issue gets the full rationale.
- `CHANGELOG.md`: `### Documentation` entry under `[Unreleased]`, attributed to @tillig.

## How to test

```bash
cd docs
npm install   # if not already
npm run dev
```

Then in the local docs site:

1. Navigate to **Concepts -> Primitives and Targets**, scroll to the new "Where compiled context files land" section. Verify the cross-links to `apm compile` and the manifest schema resolve.
2. Navigate to **Reference -> apm compile**, scroll to **Strategy modes**. Verify the new "Distributed layout example" code block renders and the back-link to the concepts section resolves.
3. `grep -nP '[^[:print:][:space:]]' docs/src/content/docs/concepts/primitives-and-targets.md docs/src/content/docs/reference/cli/compile.md` returns nothing (ASCII-only contract).

## Out of scope (explicit)

- No `.py` changes. Lint contract not engaged.
- No new in-CLI warning when distributed mode places files in subdirs. Considered, deferred: a one-time ASCII info line could help, but adding it without telemetry on whether users currently want it risks adding noise to the most-run command. Capture as future RFC if the pattern recurs.
- No change to `compilation.strategy` default.
- No change to `--clean` default.

## Tracking

- #1447 -- closed by this PR.
- #1445 -- already shipped; referenced in the strategic-alignment notes above.
- #1550 -- new, filed during this work; covers the missing Copilot-side dedup parity. Not folded here.