### PR TITLE
fix(uninstall): scan devDependencies.apm so --dev installs can be removed (closes #1549)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `apm uninstall <pkg>` now scans `devDependencies.apm` in addition to `dependencies.apm`, so packages added with `apm install --dev <pkg>` can actually be removed. Previously dev-only entries reported "not found in apm.yml" and leaked forever. (closes #1549, #PR_NUMBER) -- by @aetos382
+
 ## [0.16.0] - 2026-05-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `apm uninstall <pkg>` now scans `devDependencies.apm` in addition to `dependencies.apm`, so packages added with `apm install --dev <pkg>` can actually be removed. Previously dev-only entries reported "not found in apm.yml" and leaked forever. (closes #1549, #PR_NUMBER) -- by @aetos382
+- `apm uninstall <pkg>` now scans `devDependencies.apm` in addition to `dependencies.apm`, so packages added with `apm install --dev <pkg>` can actually be removed. Previously dev-only entries reported "not found in apm.yml" and leaked forever. (closes #1549, #1552) -- by @aetos382
 
 ## [0.16.0] - 2026-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `apm uninstall <pkg>` now scans `devDependencies.apm` in addition to `dependencies.apm`, so packages added with `apm install --dev <pkg>` can actually be removed. Previously dev-only entries reported "not found in apm.yml" and leaked forever. (closes #1549, #1552) -- by @aetos382
+- `apm uninstall <pkg>` now removes packages added with `apm install --dev <pkg>` from `devDependencies.apm`, keeping dev-only manifests clean instead of reporting "not found in apm.yml". (closes #1549, #1552) -- by @aetos382
 
 ## [0.16.0] - 2026-05-28
 

--- a/docs/src/content/docs/reference/cli/uninstall.md
+++ b/docs/src/content/docs/reference/cli/uninstall.md
@@ -75,7 +75,7 @@ apm uninstall https://github.com/acme/my-package.git
 
 What gets removed, in order:
 
-1. The package entry in `apm.yml` under `dependencies.apm`.
+1. The package entry in `apm.yml` under `dependencies.apm` or `devDependencies.apm`.
 2. The package folder under `apm_modules/owner/repo/`.
 3. Transitive dependencies that no remaining package depends on (npm-style pruning, computed from `apm.lock.yaml`).
 4. Every file in the lockfile's `deployed_files` for the removed packages and pruned orphans, across all harness folders (`.github/`, `.claude/`, `.cursor/`, `.opencode/`, `.gemini/`, `.codex/`, `.windsurf/`).

--- a/src/apm_cli/commands/uninstall/cli.py
+++ b/src/apm_cli/commands/uninstall/cli.py
@@ -98,8 +98,20 @@ def uninstall(ctx, packages, dry_run, verbose, global_):
             data["dependencies"] = {}
         if "apm" not in data["dependencies"]:
             data["dependencies"]["apm"] = []
+        # Track whether devDependencies was synthesised so we don't leave
+        # an empty section behind for projects that never used --dev.
+        had_dev_section = "devDependencies" in data
+        if not had_dev_section:
+            data["devDependencies"] = {}
+        if "apm" not in data["devDependencies"]:
+            data["devDependencies"]["apm"] = []
 
-        current_deps = data["dependencies"]["apm"] or []
+        prod_deps = data["dependencies"]["apm"] or []
+        dev_deps = data["devDependencies"]["apm"] or []
+        # `apm install --dev <pkg>` writes under devDependencies.apm. Uninstall
+        # must scan both sections so dev-installed packages are removable
+        # (regression trap for #1549).
+        current_deps = list(prod_deps) + list(dev_deps)
 
         # Load lockfile early: used for marketplace ref resolution in Step 1
         # and reused for MCP state capture and transitive orphan cleanup below.
@@ -128,9 +140,19 @@ def uninstall(ctx, packages, dry_run, verbose, global_):
 
         # Step 3: Remove from apm.yml
         for package in packages_to_remove:
-            current_deps.remove(package)
+            if package in dev_deps:
+                dev_deps.remove(package)
+            elif package in prod_deps:
+                prod_deps.remove(package)
             logger.progress(f"Removed {package} from apm.yml")
-        data["dependencies"]["apm"] = current_deps
+        data["dependencies"]["apm"] = prod_deps
+        data["devDependencies"]["apm"] = dev_deps
+        # Drop empty devDependencies wrappers so the manifest stays clean
+        # for projects that never used --dev.
+        if not data["devDependencies"]["apm"]:
+            del data["devDependencies"]["apm"]
+            if not data["devDependencies"] and not had_dev_section:
+                del data["devDependencies"]
         try:
             dump_yaml(data, apm_yml_path)
             logger.success(f"Updated {apm_yml_path} (removed {len(packages_to_remove)} package(s))")

--- a/src/apm_cli/commands/uninstall/cli.py
+++ b/src/apm_cli/commands/uninstall/cli.py
@@ -142,9 +142,11 @@ def uninstall(ctx, packages, dry_run, verbose, global_):
         for package in packages_to_remove:
             if package in dev_deps:
                 dev_deps.remove(package)
+                section = "devDependencies.apm"
             elif package in prod_deps:
                 prod_deps.remove(package)
-            logger.progress(f"Removed {package} from apm.yml")
+                section = "dependencies.apm"
+            logger.progress(f"Removed {package} from {section} in apm.yml")
         data["dependencies"]["apm"] = prod_deps
         data["devDependencies"]["apm"] = dev_deps
         # Drop empty devDependencies wrappers so the manifest stays clean

--- a/tests/unit/test_uninstall_dev_dependencies.py
+++ b/tests/unit/test_uninstall_dev_dependencies.py
@@ -89,3 +89,19 @@ class TestUninstallDevDependencies:
         data = _read_apm_yml(tmp_path)
         assert data["dependencies"]["apm"] == ["acme/keep-prod"]
         assert data["devDependencies"]["apm"] == ["acme/keep-dev"]
+
+    def test_uninstall_prod_dependency_does_not_synthesize_dev_section(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Removing a prod dep must not add devDependencies to prod-only manifests."""
+        monkeypatch.chdir(tmp_path)
+        _write_apm_yml(tmp_path, deps=["microsoft/apm-sample-package"])
+
+        from apm_cli.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["uninstall", "microsoft/apm-sample-package"])
+
+        assert result.exit_code == 0, result.output
+        data = _read_apm_yml(tmp_path)
+        assert "devDependencies" not in data

--- a/tests/unit/test_uninstall_dev_dependencies.py
+++ b/tests/unit/test_uninstall_dev_dependencies.py
@@ -1,0 +1,91 @@
+"""Tests for `apm uninstall` covering the devDependencies.apm section.
+
+Regression trap for #1549: packages installed via `apm install --dev <pkg>`
+were stored under `devDependencies.apm` in apm.yml, but `apm uninstall <pkg>`
+only scanned `dependencies.apm`. The result was an unconditional
+"not found in apm.yml" warning and the dev entry leaking forever.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+
+def _write_apm_yml(root: Path, *, deps: list | None = None, dev_deps: list | None = None) -> None:
+    """Write an apm.yml with the requested dependency sections."""
+    data: dict = {"name": "test-project", "version": "1.0.0", "target": "copilot"}
+    if deps is not None:
+        data["dependencies"] = {"apm": deps}
+    if dev_deps is not None:
+        data["devDependencies"] = {"apm": dev_deps}
+    (root / "apm.yml").write_text(yaml.dump(data), encoding="utf-8")
+
+
+def _read_apm_yml(root: Path) -> dict:
+    return yaml.safe_load((root / "apm.yml").read_text(encoding="utf-8"))
+
+
+class TestUninstallDevDependencies:
+    """Regression trap for #1549."""
+
+    def test_uninstall_removes_package_from_dev_dependencies(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """A package recorded under devDependencies.apm must be removable."""
+        monkeypatch.chdir(tmp_path)
+        _write_apm_yml(tmp_path, deps=[], dev_deps=["microsoft/apm-sample-package"])
+
+        from apm_cli.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["uninstall", "microsoft/apm-sample-package"])
+
+        assert result.exit_code == 0, result.output
+        # "not found in apm.yml" is the bug-mode failure message.
+        assert "not found in apm.yml" not in result.output
+
+        data = _read_apm_yml(tmp_path)
+        dev_apm = (data.get("devDependencies") or {}).get("apm") or []
+        assert "microsoft/apm-sample-package" not in dev_apm, (
+            "package should have been removed from devDependencies.apm"
+        )
+
+    def test_uninstall_dry_run_finds_dev_dependency(self, tmp_path: Path, monkeypatch) -> None:
+        """`--dry-run` must locate dev-only packages too."""
+        monkeypatch.chdir(tmp_path)
+        _write_apm_yml(tmp_path, deps=[], dev_deps=["microsoft/apm-sample-package"])
+
+        from apm_cli.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["uninstall", "microsoft/apm-sample-package", "--dry-run"])
+
+        assert result.exit_code == 0, result.output
+        assert "not found in apm.yml" not in result.output
+        # apm.yml must be unchanged in dry-run mode.
+        data = _read_apm_yml(tmp_path)
+        assert data["devDependencies"]["apm"] == ["microsoft/apm-sample-package"]
+
+    def test_uninstall_preserves_unrelated_dev_dependency(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Removing one dev dep must not touch other dev or prod deps."""
+        monkeypatch.chdir(tmp_path)
+        _write_apm_yml(
+            tmp_path,
+            deps=["acme/keep-prod"],
+            dev_deps=["microsoft/apm-sample-package", "acme/keep-dev"],
+        )
+
+        from apm_cli.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["uninstall", "microsoft/apm-sample-package"])
+
+        assert result.exit_code == 0, result.output
+        data = _read_apm_yml(tmp_path)
+        assert data["dependencies"]["apm"] == ["acme/keep-prod"]
+        assert data["devDependencies"]["apm"] == ["acme/keep-dev"]


### PR DESCRIPTION
Closes #1549.

## Problem

`apm install --dev <pkg>` writes the package under `devDependencies.apm` in `apm.yml`, but `apm uninstall <pkg>` only reads/writes `dependencies.apm`. The result is that every dev-installed package reports

    [!] <pkg> - not found in apm.yml
    [!] No packages found in apm.yml to remove

and the entry leaks forever. There is no way to remove a `--dev` install short of editing `apm.yml` by hand.

## Fix shape

`apm uninstall` now scans **both** `dependencies.apm` and `devDependencies.apm` when looking for matches, and writes the package out of whichever section it lives in. Symmetric to install: `--dev` installs put the entry in `devDependencies.apm`; uninstall pulls it back out of the same section. Empty `devDependencies` wrappers that we synthesised purely to satisfy the read are dropped before writing, so manifests for projects that never used `--dev` stay byte-identical to today.

## Tests

New regression trap at `tests/unit/test_uninstall_dev_dependencies.py`:

- `test_uninstall_removes_package_from_dev_dependencies` -- the headline regression: a package recorded under `devDependencies.apm` is removed end-to-end.
- `test_uninstall_dry_run_finds_dev_dependency` -- `--dry-run` locates the dev entry and leaves `apm.yml` untouched.
- `test_uninstall_preserves_unrelated_dev_dependency` -- removing one dev dep does not touch other dev or prod entries.

Mutation-break gate: deleting the new `devDependencies` handling makes all three tests fail with the original `not found in apm.yml` symptom; restoring the fix makes them pass. The full `tests/unit/ -k 'uninstall or dev_depend'` suite (227 tests) and `tests/integration/` uninstall coverage (23 tests) stay green.

## How to test

    # Reproduce the bug on main
    mkdir /tmp/apm-1549 && cd /tmp/apm-1549
    apm init
    apm install --dev microsoft/apm-sample-package
    apm uninstall microsoft/apm-sample-package
    # main: '[!] microsoft/apm-sample-package - not found in apm.yml'
    # this PR: package is removed from devDependencies.apm cleanly

## Validation evidence

- `uv run --extra dev ruff check src/ tests/` -- silent
- `uv run --extra dev ruff format --check src/ tests/` -- silent
- `uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/` -- 10.00/10
- `bash scripts/lint-auth-signals.sh` -- clean
- `pytest tests/unit/ -k 'uninstall or dev_depend'` -- 227 passed
- `pytest tests/integration/test_uninstall_*.py tests/integration/test_wave5_e2e_coverage.py -k uninstall` -- 23 passed, 2 skipped