### PR TITLE
fix(install): skip cache for unpinned virtual deps when on-disk hash matches lockfile (closes #1548)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `apm install` no longer fails the second run with a false-positive `Content hash mismatch ... supply-chain attack` error for unpinned git/virtual-file dependencies whose lockfile entry could not record a `resolved_commit` (e.g. ADO partial-clone fallback paths). When the on-disk content still hashes to the lockfile-recorded value, the redundant re-download is now skipped, mirroring the existing cache-skip parity with pinned and registry deps. Real content divergence still falls through to the supply-chain verification path. (closes #1548) -- by @OskarKlintrot
+
 ## [0.16.0] - 2026-05-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `apm install` no longer fails the second run with a false-positive `Content hash mismatch ... supply-chain attack` error for unpinned git/virtual-file dependencies whose lockfile entry could not record a `resolved_commit` (e.g. ADO partial-clone fallback paths). When the on-disk content still hashes to the lockfile-recorded value, the redundant re-download is now skipped, mirroring the existing cache-skip parity with pinned and registry deps. Real content divergence still falls through to the supply-chain verification path. (closes #1548) -- by @OskarKlintrot
+- `apm install` no longer fails the second run with a false-positive `Content hash mismatch ... supply-chain attack` error for unpinned git/virtual-file dependencies whose lockfile entry could not record a `resolved_commit` (e.g. ADO partial-clone fallback paths). If on-disk content still matches the lockfile `content_hash`, APM skips the redundant re-download; real content divergence still falls through to the supply-chain verification path. (closes #1548) -- by @OskarKlintrot
 
 ## [0.16.0] - 2026-05-28
 

--- a/src/apm_cli/install/context.py
+++ b/src/apm_cli/install/context.py
@@ -113,6 +113,7 @@ class InstallContext:
     package_deployed_files: dict[str, list[str]] = field(default_factory=dict)
     package_types: dict[str, str] = field(default_factory=dict)
     package_hashes: dict[str, str] = field(default_factory=dict)
+    content_hash_verified_deps: set[str] = field(default_factory=set)
     # Deps whose content hash is expected to change legitimately:
     # populated by _resolve_download_strategy in phases/integrate.py
     # (branch-ref `remote_drifted` guard and v<=0.12.2 self-heal block),

--- a/src/apm_cli/install/phases/download.py
+++ b/src/apm_cli/install/phases/download.py
@@ -102,7 +102,24 @@ def run(ctx: InstallContext) -> None:
                 from apm_cli.install.phases._redownload import _should_skip_redownload
 
                 if _should_skip_redownload(_pd_locked_chk, _pd_path):
+                    ctx.content_hash_verified_deps.add(_pd_key)
                     continue
+        elif (
+            _pd_path.exists()
+            and _pd_locked_chk
+            and _pd_locked_chk.content_hash
+            and not update_refs
+            and not _pd_ref_changed
+        ):
+            # Content-hash-only lockfile entries have no commit anchor.
+            # The hash is the sole trust signal: skip only after verifying
+            # on-disk bytes still match it, otherwise fall through to the
+            # fresh-download path and its supply-chain mismatch check.
+            from apm_cli.install.phases._redownload import _should_skip_redownload
+
+            if _should_skip_redownload(_pd_locked_chk, _pd_path):
+                ctx.content_hash_verified_deps.add(_pd_key)
+                continue
         # Build download ref (use locked commit for reproducibility).
         # build_download_ref() uses the manifest ref when ref_changed is True.
         _pd_dlref = build_download_ref(

--- a/src/apm_cli/install/phases/integrate.py
+++ b/src/apm_cli/install/phases/integrate.py
@@ -158,6 +158,24 @@ def _resolve_download_strategy(
             # skip-download signal (mirrors the git content-hash fallback above).
             if _should_skip_redownload(locked_dep, install_path):
                 lockfile_match = True
+        elif locked_dep and locked_dep.content_hash and not ref_changed and not update_refs:
+            # Unpinned git/virtual deps (#1548): the lockfile recorded a
+            # content_hash but no resolved_commit (e.g. ADO partial-clone
+            # fallback could not pin a SHA, or a virtual-file dep was carved
+            # out without a commit anchor).  Without this branch the second
+            # install would re-download every time, and a non-deterministic
+            # fresh hash trips the supply-chain mismatch check at
+            # sources.py with a false-positive attack alert.
+            #
+            # Cache-skip parity with the resolved_commit branches: when the
+            # on-disk content still hashes to the lockfile-recorded value,
+            # the package is intact -- skip re-download.  This preserves
+            # supply-chain detection because we only suppress the redundant
+            # download when on-disk content is verified unchanged; any real
+            # divergence still falls through to the fresh-download path.
+            if _should_skip_redownload(locked_dep, install_path):
+                lockfile_match = True
+                lockfile_match_via_content_hash_only = True
 
     # Self-heal pipeline (PR #1158).
     #

--- a/src/apm_cli/install/phases/integrate.py
+++ b/src/apm_cli/install/phases/integrate.py
@@ -53,6 +53,7 @@ def _resolve_download_strategy(
     update_refs = ctx.update_refs
     diagnostics = ctx.diagnostics
     logger = ctx.logger
+    dep_key = dep_ref.get_unique_key()
 
     # npm-like behavior: Branches always fetch latest, only tags/commits use cache
     # Resolve git reference to determine type
@@ -64,14 +65,14 @@ def _resolve_download_strategy(
     # entirely for non-git sources.
     _source = getattr(dep_ref, "source", None)
     is_git_source = not isinstance(_source, str) or _source in (None, "git")
-    if is_git_source and dep_ref.get_unique_key() not in ctx.pre_downloaded_keys:
+    if is_git_source and dep_key not in ctx.pre_downloaded_keys:
         # Resolve when there is an explicit ref, OR when update_refs
         # is True AND we have a non-cached lockfile entry to compare
         # against (otherwise resolution is wasted work -- the package
         # will be downloaded regardless).
         _has_lockfile_sha = False
         if update_refs and existing_lockfile:
-            _lck = existing_lockfile.get_dependency(dep_ref.get_unique_key())
+            _lck = existing_lockfile.get_dependency(dep_key)
             _has_lockfile_sha = bool(
                 _lck and _lck.resolved_commit and _lck.resolved_commit != "cached"
             )
@@ -87,12 +88,10 @@ def _resolve_download_strategy(
         GitReferenceType.COMMIT,
     ]
     # Skip download if: already fetched by resolver callback, or cached tag/commit
-    already_resolved = dep_ref.get_unique_key() in ctx.callback_downloaded
+    already_resolved = dep_key in ctx.callback_downloaded
     # Detect if manifest ref changed vs what the lockfile recorded.
     # detect_ref_change() handles all transitions including None->ref.
-    _dep_locked_chk = (
-        existing_lockfile.get_dependency(dep_ref.get_unique_key()) if existing_lockfile else None
-    )
+    _dep_locked_chk = existing_lockfile.get_dependency(dep_key) if existing_lockfile else None
     ref_changed = detect_ref_change(dep_ref, _dep_locked_chk, update_refs=update_refs)
     # When the manifest ref drifted from the lockfile, the content hash
     # will legitimately change after re-download.  Mark the dep so the
@@ -100,10 +99,11 @@ def _resolve_download_strategy(
     if ref_changed:
         # resolve.py's BFS callback may have already added this;
         # set semantics make double-add safe.
-        ctx.expected_hash_change_deps.add(dep_ref.get_unique_key())
+        ctx.expected_hash_change_deps.add(dep_key)
     # Phase 5 (#171): Also skip when lockfile SHA matches local HEAD
     # -- but not when the manifest ref has changed (user wants different version).
     lockfile_match = False
+    content_hash_already_verified = dep_key in ctx.content_hash_verified_deps
     # Track whether lockfile_match was satisfied via content-hash fallback only
     # (no git HEAD verification possible -- typical for virtual packages, where
     # install_path is a carved-out subdirectory rather than a git repo).
@@ -111,7 +111,7 @@ def _resolve_download_strategy(
     # branch-ref drift bug for upgrading users.
     lockfile_match_via_content_hash_only = False
     if install_path.exists() and existing_lockfile:
-        locked_dep = existing_lockfile.get_dependency(dep_ref.get_unique_key())
+        locked_dep = existing_lockfile.get_dependency(dep_key)
         if locked_dep and locked_dep.resolved_commit and locked_dep.resolved_commit != "cached":
             if update_refs:
                 # Update mode: compare resolved remote SHA with lockfile SHA.
@@ -130,9 +130,13 @@ def _resolve_download_strategy(
                         # Git check failed (e.g. .git removed, or virtual
                         # package install_path is not a git repo). Fall back
                         # to content-hash verification (#763).
-                        if _should_skip_redownload(locked_dep, install_path):
+                        if content_hash_already_verified or _should_skip_redownload(
+                            locked_dep, install_path
+                        ):
                             lockfile_match = True
                             lockfile_match_via_content_hash_only = True
+                            content_hash_already_verified = True
+                            ctx.content_hash_verified_deps.add(dep_key)
             elif not ref_changed:
                 # Normal mode: compare local HEAD with lockfile SHA.
                 try:
@@ -145,9 +149,13 @@ def _resolve_download_strategy(
                     # Git check failed (e.g. .git removed, or virtual package
                     # install_path is not a git repo). Fall back to
                     # content-hash verification (#763).
-                    if _should_skip_redownload(locked_dep, install_path):
+                    if content_hash_already_verified or _should_skip_redownload(
+                        locked_dep, install_path
+                    ):
                         lockfile_match = True
                         lockfile_match_via_content_hash_only = True
+                        content_hash_already_verified = True
+                        ctx.content_hash_verified_deps.add(dep_key)
         elif (
             locked_dep
             and getattr(locked_dep, "source", None) == "registry"
@@ -156,8 +164,10 @@ def _resolve_download_strategy(
         ):
             # Registry deps have no resolved_commit; use content_hash as the
             # skip-download signal (mirrors the git content-hash fallback above).
-            if _should_skip_redownload(locked_dep, install_path):
+            if content_hash_already_verified or _should_skip_redownload(locked_dep, install_path):
                 lockfile_match = True
+                content_hash_already_verified = True
+                ctx.content_hash_verified_deps.add(dep_key)
         elif locked_dep and locked_dep.content_hash and not ref_changed and not update_refs:
             # Unpinned git/virtual deps (#1548): the lockfile recorded a
             # content_hash but no resolved_commit (e.g. ADO partial-clone
@@ -169,13 +179,15 @@ def _resolve_download_strategy(
             #
             # Cache-skip parity with the resolved_commit branches: when the
             # on-disk content still hashes to the lockfile-recorded value,
-            # the package is intact -- skip re-download.  This preserves
-            # supply-chain detection because we only suppress the redundant
-            # download when on-disk content is verified unchanged; any real
-            # divergence still falls through to the fresh-download path.
-            if _should_skip_redownload(locked_dep, install_path):
+            # the package is intact -- skip re-download. This branch has no
+            # commit anchor; the content hash is the only trust signal, so any
+            # divergence must fall through to the fresh-download path and its
+            # supply-chain mismatch check.
+            if content_hash_already_verified or _should_skip_redownload(locked_dep, install_path):
                 lockfile_match = True
                 lockfile_match_via_content_hash_only = True
+                content_hash_already_verified = True
+                ctx.content_hash_verified_deps.add(dep_key)
 
     # Self-heal pipeline (PR #1158).
     #
@@ -208,7 +220,12 @@ def _resolve_download_strategy(
     )
 
     # Verify content integrity when lockfile has a hash
-    if skip_download and _dep_locked_chk and _dep_locked_chk.content_hash:
+    if (
+        skip_download
+        and _dep_locked_chk
+        and _dep_locked_chk.content_hash
+        and not content_hash_already_verified
+    ):
         from apm_cli.utils.content_hash import verify_package_hash
 
         if not verify_package_hash(install_path, _dep_locked_chk.content_hash):

--- a/tests/integration/test_install_content_hash_roundtrip.py
+++ b/tests/integration/test_install_content_hash_roundtrip.py
@@ -1,0 +1,139 @@
+"""Integration coverage for content-hash-only lockfile replay.
+
+The no-``resolved_commit`` case happens for unpinned git dependencies whose
+clone path cannot provide a stable commit anchor. The lockfile still records a
+package ``content_hash``; a second install must trust only that hash and must not
+re-download unchanged on-disk bytes.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from apm_cli.cli import cli
+from apm_cli.models.apm_package import (
+    APMPackage,
+    GitReferenceType,
+    PackageInfo,
+    ResolvedReference,
+)
+from apm_cli.models.dependency.reference import DependencyReference
+
+_PATCH_UPDATES = "apm_cli.commands._helpers.check_for_updates"
+
+
+class _ContentHashOnlyDownloader:
+    """Downloader stub that changes bytes if a second download occurs."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def download_package(
+        self, repo_ref: object, target_path: Path, *args: Any, **kwargs: Any
+    ) -> PackageInfo:
+        self.calls += 1
+        dep_ref = (
+            repo_ref
+            if isinstance(repo_ref, DependencyReference)
+            else DependencyReference.parse(str(repo_ref))
+        )
+        target_path = Path(target_path)
+        target_path.mkdir(parents=True, exist_ok=True)
+        (target_path / "apm.yml").write_text(
+            yaml.safe_dump(
+                {
+                    "name": "fixture-pkg",
+                    "version": "1.0.0",
+                    "description": "content hash replay fixture",
+                }
+            ),
+            encoding="utf-8",
+        )
+        (target_path / ".apm" / "instructions").mkdir(parents=True, exist_ok=True)
+        (target_path / ".apm" / "instructions" / "fixture.instructions.md").write_text(
+            f"---\napplyTo: '**'\n---\n# Fixture\ndownload-call: {self.calls}\n",
+            encoding="utf-8",
+        )
+        package = APMPackage.from_apm_yml(target_path / "apm.yml")
+        return PackageInfo(
+            package=package,
+            install_path=target_path,
+            installed_at=datetime.now().isoformat(),
+            dependency_ref=dep_ref,
+            resolved_reference=ResolvedReference(
+                original_ref="default",
+                ref_type=GitReferenceType.BRANCH,
+                resolved_commit=None,
+                ref_name="default",
+            ),
+        )
+
+
+def _write_project(project: Path) -> None:
+    project.mkdir(parents=True, exist_ok=True)
+    (project / ".github").mkdir()
+    (project / ".github" / "copilot-instructions.md").write_text("# Project\n", encoding="utf-8")
+    (project / "apm.yml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "content-hash-roundtrip",
+                "version": "1.0.0",
+                "target": "copilot",
+                "dependencies": {"apm": ["acme/fixture-pkg"], "mcp": []},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _run_install(runner: CliRunner, project: Path, monkeypatch: pytest.MonkeyPatch) -> object:
+    monkeypatch.chdir(project)
+    with patch(_PATCH_UPDATES, return_value=None):
+        return runner.invoke(cli, ["install"], catch_exceptions=False)
+
+
+def _locked_dep(project: Path) -> dict:
+    lockfile = yaml.safe_load((project / "apm.lock.yaml").read_text(encoding="utf-8"))
+    deps = lockfile.get("dependencies") or []
+    return next(dep for dep in deps if dep.get("repo_url") == "acme/fixture-pkg")
+
+
+def test_no_resolved_commit_content_hash_reuses_on_disk_package(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Second install reuses content-hash-verified bytes without re-downloading.
+
+    The downloader deliberately mutates fixture content on every call. If the
+    second install re-downloads instead of reusing the content-hash-verified
+    install path, the fresh-download supply-chain check sees a different hash
+    from the lockfile and the install fails.
+    """
+    project = tmp_path / "project"
+    _write_project(project)
+    downloader = _ContentHashOnlyDownloader()
+
+    from apm_cli.deps import github_downloader as _ghd
+
+    monkeypatch.setattr(
+        _ghd.GitHubPackageDownloader, "download_package", downloader.download_package
+    )
+    runner = CliRunner()
+
+    first = _run_install(runner, project, monkeypatch)
+    assert first.exit_code == 0, first.output
+
+    locked = _locked_dep(project)
+    assert locked.get("content_hash"), locked
+    assert not locked.get("resolved_commit"), locked
+    assert downloader.calls == 1
+
+    second = _run_install(runner, project, monkeypatch)
+    assert second.exit_code == 0, second.output
+    assert downloader.calls == 1

--- a/tests/unit/install/test_integrate_phase3w5.py
+++ b/tests/unit/install/test_integrate_phase3w5.py
@@ -257,6 +257,43 @@ class TestResolveDownloadStrategy:
             "must skip re-download (issue #1548)"
         )
 
+    def test_unpinned_git_dep_reuses_preverified_content_hash(self, tmp_path: Path) -> None:
+        """When the download phase already verified content_hash, the sequential
+        strategy must not hash the tree again before choosing the cached path.
+        """
+        from apm_cli.install.phases.integrate import _resolve_download_strategy
+
+        ctx = _make_ctx(tmp_path)
+        ctx.content_hash_verified_deps.add("org/pkg")
+
+        locked_dep = MagicMock()
+        locked_dep.resolved_commit = None
+        locked_dep.content_hash = "deadbeef"
+        locked_dep.source = "git"
+        locked_dep.registry_prefix = None
+
+        lf = MagicMock()
+        lf.get_dependency.return_value = locked_dep
+        ctx.existing_lockfile = lf
+
+        dep_ref = _make_dep_ref(reference=None)
+        install_path = tmp_path / "pkg"
+        install_path.mkdir()
+
+        with (
+            patch("apm_cli.drift.detect_ref_change", return_value=False),
+            patch("apm_cli.install.phases.heal.run_heal_chain", return_value=(True, False)),
+            patch(
+                "apm_cli.utils.content_hash.verify_package_hash",
+                side_effect=AssertionError("hash tree should not be recomputed"),
+            ),
+        ):
+            _resolved_ref, skip_download, _locked, _changed = _resolve_download_strategy(
+                ctx, dep_ref, install_path
+            )
+
+        assert skip_download
+
     def test_unpinned_git_dep_redownloads_when_on_disk_hash_differs(self, tmp_path: Path) -> None:
         """Negative gate: the unpinned-skip branch must NOT mask a real mismatch.
         When on-disk content does not hash to the lockfile-recorded value, the

--- a/tests/unit/install/test_integrate_phase3w5.py
+++ b/tests/unit/install/test_integrate_phase3w5.py
@@ -213,6 +213,127 @@ class TestResolveDownloadStrategy:
         assert resolved_ref is None
         ctx.downloader.resolve_git_reference.assert_not_called()
 
+    def test_unpinned_git_dep_skips_when_on_disk_hash_matches(self, tmp_path: Path) -> None:
+        """Issue #1548: when a git dep has no resolved_commit (e.g. ADO partial-clone
+        fallback couldn't pin a SHA) but the lockfile recorded a content_hash, the
+        second install must NOT re-download if the on-disk content still hashes to
+        the recorded value.  Previously the cache-skip was bypassed and the fresh
+        download could trip the supply-chain mismatch check with a false positive.
+        """
+        from apm_cli.install.phases.integrate import _resolve_download_strategy
+
+        ctx = _make_ctx(tmp_path)
+
+        locked_dep = MagicMock()
+        # No pinned commit -- mirrors the partial-clone-fallback path.
+        locked_dep.resolved_commit = None
+        locked_dep.content_hash = "deadbeef"
+        # Not a registry dep.
+        locked_dep.source = "git"
+        locked_dep.registry_prefix = None
+
+        lf = MagicMock()
+        lf.get_dependency.return_value = locked_dep
+        ctx.existing_lockfile = lf
+
+        dep_ref = _make_dep_ref(reference=None)
+        install_path = tmp_path / "pkg"
+        install_path.mkdir()
+
+        with (
+            patch("apm_cli.drift.detect_ref_change", return_value=False),
+            patch("apm_cli.install.phases.heal.run_heal_chain", return_value=(False, False)),
+            patch(
+                "apm_cli.utils.content_hash.verify_package_hash",
+                return_value=True,
+            ),
+        ):
+            _resolved_ref, skip_download, _locked, _changed = _resolve_download_strategy(
+                ctx, dep_ref, install_path
+            )
+
+        assert skip_download, (
+            "unpinned git dep with on-disk content matching lockfile content_hash "
+            "must skip re-download (issue #1548)"
+        )
+
+    def test_unpinned_git_dep_redownloads_when_on_disk_hash_differs(self, tmp_path: Path) -> None:
+        """Negative gate: the unpinned-skip branch must NOT mask a real mismatch.
+        When on-disk content does not hash to the lockfile-recorded value, the
+        cache-skip must NOT fire so the normal fresh-download / supply-chain
+        verification path still runs.
+        """
+        from apm_cli.install.phases.integrate import _resolve_download_strategy
+
+        ctx = _make_ctx(tmp_path)
+
+        locked_dep = MagicMock()
+        locked_dep.resolved_commit = None
+        locked_dep.content_hash = "deadbeef"
+        locked_dep.source = "git"
+        locked_dep.registry_prefix = None
+
+        lf = MagicMock()
+        lf.get_dependency.return_value = locked_dep
+        ctx.existing_lockfile = lf
+
+        dep_ref = _make_dep_ref(reference=None)
+        install_path = tmp_path / "pkg"
+        install_path.mkdir()
+
+        with (
+            patch("apm_cli.drift.detect_ref_change", return_value=False),
+            patch("apm_cli.install.phases.heal.run_heal_chain", return_value=(False, False)),
+            patch(
+                "apm_cli.utils.content_hash.verify_package_hash",
+                return_value=False,
+            ),
+        ):
+            _resolved_ref, skip_download, _locked, _changed = _resolve_download_strategy(
+                ctx, dep_ref, install_path
+            )
+
+        assert not skip_download, (
+            "real on-disk hash mismatch must NOT be masked by the unpinned-skip "
+            "branch -- the normal fresh-download flow must run so the supply-chain "
+            "verification can detect tampering"
+        )
+
+    def test_unpinned_git_dep_no_skip_when_lockfile_lacks_content_hash(
+        self, tmp_path: Path
+    ) -> None:
+        """A locked dep with neither resolved_commit nor content_hash provides no
+        integrity anchor -- we have nothing to compare on-disk content against and
+        must not skip the download.
+        """
+        from apm_cli.install.phases.integrate import _resolve_download_strategy
+
+        ctx = _make_ctx(tmp_path)
+
+        locked_dep = MagicMock()
+        locked_dep.resolved_commit = None
+        locked_dep.content_hash = None
+        locked_dep.source = "git"
+        locked_dep.registry_prefix = None
+
+        lf = MagicMock()
+        lf.get_dependency.return_value = locked_dep
+        ctx.existing_lockfile = lf
+
+        dep_ref = _make_dep_ref(reference=None)
+        install_path = tmp_path / "pkg"
+        install_path.mkdir()
+
+        with (
+            patch("apm_cli.drift.detect_ref_change", return_value=False),
+            patch("apm_cli.install.phases.heal.run_heal_chain", return_value=(False, False)),
+        ):
+            _resolved_ref, skip_download, _locked, _changed = _resolve_download_strategy(
+                ctx, dep_ref, install_path
+            )
+
+        assert not skip_download
+
 
 # ---------------------------------------------------------------------------
 # _integrate_root_project


### PR DESCRIPTION
## Summary

Closes #1548. `apm install` was failing on the second run with a false-positive `Content hash mismatch ... supply-chain attack` error for unpinned git/virtual-file dependencies. This PR adds the missing cache-skip branch so the redundant re-download (and the false alert it triggered) goes away, without weakening supply-chain detection.

## Problem

When a git or virtual-file dep was recorded in `apm.lock.yaml` without a `resolved_commit` -- typically because the underlying transport fell back from partial-clone to full bare-clone (observed on Azure DevOps repos whose server does not support partial-clone filter v2) and APM had no SHA to pin against the floating ref -- the cache-skip logic in `_resolve_download_strategy` (`src/apm_cli/install/phases/integrate.py:113-160`) had no branch covering the case. The two existing branches required either:

1. `locked_dep.resolved_commit` to be set and not `"cached"`, or
2. `locked_dep.source == "registry"`.

Unpinned git deps fell through both, `lockfile_match` stayed `False`, and the package was re-downloaded on every install. A re-clone of a floating ref can produce a fresh hash that does not byte-match the lockfile-recorded `content_hash`, so the supply-chain check at `src/apm_cli/install/sources.py:766-787` then `sys.exit(1)` with "supply-chain attack" wording -- the false positive reported in #1548.

## Fix

Add cache-skip parity for the unpinned class. In `_resolve_download_strategy`, after the existing registry branch, add an `elif` for `(locked_dep, locked_dep.content_hash, not ref_changed, not update_refs)`. When `_should_skip_redownload` confirms the on-disk content still hashes to the lockfile-recorded value, set `lockfile_match = True` (with the `_via_content_hash_only` flag for the existing self-heal pipeline). The package is intact, so re-downloading it is wasted work and the source of the false positive.

This matches Option 1 from the triage brief. Option 2 (record a `resolved_commit` even on partial-clone-fallback paths) is more architecturally correct but ripples through the lockfile schema and self-heal chain; this PR keeps the change isolated and reversible.

## Supply-chain boundary

The supply-chain check is preserved. The new branch only fires when `verify_package_hash(install_path, locked_dep.content_hash)` returns `True` -- i.e. on-disk bytes already hash to the lockfile-recorded value. We never suppress a fresh download that would otherwise have produced a *different* hash than the lockfile; we only suppress a redundant download whose result we have already verified against the lockfile via the on-disk content. Real divergence (file actually tampered) still falls through to the fresh-download path where `sources.py` runs the existing mismatch check.

## Tests

`tests/unit/install/test_integrate_phase3w5.py` -- three new cases on `TestResolveDownloadStrategy`:

- `test_unpinned_git_dep_skips_when_on_disk_hash_matches` -- positive: with `resolved_commit=None`, `content_hash="deadbeef"`, `source="git"` and `verify_package_hash -> True`, asserts `skip_download is True`. Fails at HEAD without the fix; passes after. Verified the **mutation-break gate** by `git stash` of the integrate.py change: this test fails, confirming the fix is the cause of the green.
- `test_unpinned_git_dep_redownloads_when_on_disk_hash_differs` -- negative gate: same setup, `verify_package_hash -> False`, asserts `skip_download is False`. Proves a real on-disk mismatch is NOT masked by the new branch.
- `test_unpinned_git_dep_no_skip_when_lockfile_lacks_content_hash` -- guard: when neither `resolved_commit` nor `content_hash` are present there is no integrity anchor, so the branch must not fire.

Full suite: `1638 passed` across `tests/unit/install/`, `tests/unit/test_install_command.py`, `tests/unit/test_drift_registry.py`, `tests/unit/test_drift_detection.py`.

## How to test locally

1. Construct an `apm.yml` with a git dep on a repo whose server cannot serve a partial-clone (or any virtual-file dep that lands without a `resolved_commit`).
2. `apm install` once -- this succeeds and writes a lockfile entry with `content_hash` set and `resolved_commit` empty.
3. `apm install` a second time. Before this PR: `[x] Content hash mismatch ... supply-chain attack`. After this PR: install succeeds, the cached package is reused, no re-download, no false alert.

## Validation evidence

- `uv run --extra dev ruff check src/ tests/` -- silent.
- `uv run --extra dev ruff format --check src/ tests/` -- silent.
- `uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/` -- 10.00/10.
- `bash scripts/lint-auth-signals.sh` -- clean.
- Targeted suite: 22 / 22 in `test_integrate_phase3w5.py`; broader: 1638 / 1638 across install + drift modules.

ASCII-only.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>