### PR TITLE
perf(integrate): narrow project-scope local discovery to .apm/ to avoid full-tree walks (closes #1507)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `apm install` integrate phase no longer walks the entire project tree on local-content discovery: scope is now narrowed to `.apm/` and `.github/` for the synthetic project-scope `_local` package, mirroring the existing `$HOME` narrowing (#830). Previously a 50k+ file monorepo with only a handful of primitives under `.apm/` could hang for 13 minutes before integrate completed. (closes #1507) -- by @ioannispoulios
+
 ## [0.16.0] - 2026-05-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `apm install` integrate phase no longer walks the entire project tree on local-content discovery: scope is now narrowed to `.apm/` and `.github/` for the synthetic project-scope `_local` package, mirroring the existing `$HOME` narrowing (#830). Previously a 50k+ file monorepo with only a handful of primitives under `.apm/` could hang for 13 minutes before integrate completed. (closes #1507) -- by @ioannispoulios
+- Avoid 13-minute `apm install` hangs in large local projects by limiting synthetic `_local` discovery to `.apm/` and `.github/`, while preserving package metadata discovery. (closes #1507) -- by @ioannispoulios
 
 ## [0.16.0] - 2026-05-28
 

--- a/src/apm_cli/integration/base_integrator.py
+++ b/src/apm_cli/integration/base_integrator.py
@@ -528,27 +528,65 @@ class BaseIntegrator:
     # Link resolution helpers
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _is_root_local_package(package_info, project_root: Path) -> bool:
+        """Return True when *package_info* represents the project's own
+        synthetic ``_local`` package (install_path == project_root).
+
+        Used to scope discovery to ``.apm/`` and ``.github/`` instead of
+        walking the entire project tree -- see issue #1507.
+        """
+        try:
+            return Path(package_info.install_path).resolve() == Path(project_root).resolve()
+        except (OSError, RuntimeError):
+            return False
+
     def init_link_resolver(self, package_info, project_root: Path) -> None:
         """Initialise and register the link resolver for a package."""
         self.link_resolver = UnifiedLinkResolver(project_root)
         try:
-            scan_root = package_info.install_path
-            # When install_path is $HOME (user-scope local package),
-            # only scan the .apm/ subdirectory to avoid recursive-
-            # globbing the entire home tree.  See issue #830.
-            if scan_root == Path.home():
-                scan_root = scan_root / ".apm"
-            primitives = discover_primitives(scan_root)
-            self.link_resolver.register_contexts(primitives)
+            install_path = package_info.install_path
+            # Determine which directories to scan for primitives.
+            # Default: the package's install_path itself (for real
+            # installed dependencies under apm_modules/...).
+            #
+            # Narrowing rules:
+            # - $HOME (user-scope local package): scan only ~/.apm/ to
+            #   avoid recursive-globbing the entire home tree (#830).
+            # - Project-scope synthetic _local package (install_path
+            #   equals project_root): scan only ./.apm/ and ./.github/
+            #   to avoid full-tree walks on large monorepos (#1507).
+            #   Generic patterns like ``**/*.instructions.md`` would
+            #   otherwise traverse every file in the repo even when
+            #   the user only has a handful of primitives under .apm/.
+            if install_path == Path.home():
+                scan_roots = [install_path / ".apm"]
+                narrowed_local = False
+            elif self._is_root_local_package(package_info, project_root):
+                candidates = [install_path / ".apm", install_path / ".github"]
+                scan_roots = [p for p in candidates if p.is_dir()]
+                narrowed_local = True
+            else:
+                scan_roots = [install_path]
+                narrowed_local = False
+
+            for root in scan_roots:
+                primitives = discover_primitives(root)
+                self.link_resolver.register_contexts(primitives)
+
             # Generalized in-package asset link rewriting (#1147) needs the
             # authoritative source-package root. Use install_path directly:
             # for installed deps it is apm_modules/<owner>/<repo>/ (or any
             # ADO/virtual subdir variant), for local packages it is the
-            # package's apm_modules/_local/<name>/ copy. Skip when scan_root
-            # was narrowed to .apm/ (user-scope) so we do not let asset
-            # links escape the .apm/ boundary on $HOME packages.
-            if scan_root == package_info.install_path and Path(scan_root).is_dir():
-                self.link_resolver.package_root = Path(scan_root)
+            # package's apm_modules/_local/<name>/ copy. For the project-
+            # scope synthetic _local package, the authoritative root is
+            # the project itself, even though discovery was narrowed to
+            # .apm/ and .github/. Skip only when scan_root was narrowed
+            # to ~/.apm/ (user-scope $HOME) so we do not let asset links
+            # escape the .apm/ boundary on $HOME packages.
+            if install_path != Path.home() and Path(install_path).is_dir():
+                if narrowed_local or (len(scan_roots) == 1 and scan_roots[0] == install_path):
+                    self.link_resolver.package_root = Path(install_path)
         except Exception:
             self.link_resolver = None
 

--- a/src/apm_cli/integration/base_integrator.py
+++ b/src/apm_cli/integration/base_integrator.py
@@ -545,7 +545,9 @@ class BaseIntegrator:
         """Initialise and register the link resolver for a package."""
         self.link_resolver = UnifiedLinkResolver(project_root)
         try:
-            install_path = package_info.install_path
+            install_path = Path(package_info.install_path)
+            project_root = Path(project_root)
+            home_root = Path.home()
             # Determine which directories to scan for primitives.
             # Default: the package's install_path itself (for real
             # installed dependencies under apm_modules/...).
@@ -559,7 +561,7 @@ class BaseIntegrator:
             #   Generic patterns like ``**/*.instructions.md`` would
             #   otherwise traverse every file in the repo even when
             #   the user only has a handful of primitives under .apm/.
-            if install_path == Path.home():
+            if install_path.resolve() == home_root.resolve():
                 home_apm_root = install_path / ".apm"
                 scan_roots = [home_apm_root] if home_apm_root.is_dir() else []
                 narrowed_local = False
@@ -585,7 +587,7 @@ class BaseIntegrator:
             # .apm/ and .github/. Skip only when scan_root was narrowed
             # to ~/.apm/ (user-scope $HOME) so we do not let asset links
             # escape the .apm/ boundary on $HOME packages.
-            if install_path != Path.home() and Path(install_path).is_dir():
+            if install_path.resolve() != home_root.resolve() and install_path.is_dir():
                 if narrowed_local or (len(scan_roots) == 1 and scan_roots[0] == install_path):
                     self.link_resolver.package_root = Path(install_path)
         except Exception:

--- a/src/apm_cli/integration/base_integrator.py
+++ b/src/apm_cli/integration/base_integrator.py
@@ -560,7 +560,8 @@ class BaseIntegrator:
             #   otherwise traverse every file in the repo even when
             #   the user only has a handful of primitives under .apm/.
             if install_path == Path.home():
-                scan_roots = [install_path / ".apm"]
+                home_apm_root = install_path / ".apm"
+                scan_roots = [home_apm_root] if home_apm_root.is_dir() else []
                 narrowed_local = False
             elif self._is_root_local_package(package_info, project_root):
                 candidates = [install_path / ".apm", install_path / ".github"]

--- a/tests/unit/integration/test_base_integrator.py
+++ b/tests/unit/integration/test_base_integrator.py
@@ -664,14 +664,138 @@ class TestInitLinkResolverHomeScoping:
     @patch("apm_cli.integration.base_integrator.discover_primitives")
     @patch("apm_cli.integration.base_integrator.UnifiedLinkResolver")
     def test_uses_install_path_when_not_home(self, mock_resolver_cls, mock_discover, tmp_path):
+        """Real installed dependencies (install_path under apm_modules/, NOT
+        equal to project_root) must scan install_path directly."""
         mock_discover.return_value = []
+        bi = BaseIntegrator()
+        pkg_info = MagicMock()
+        # Simulate a real installed package: install_path is a sub-path
+        # of project_root (apm_modules/owner/repo), not the project root.
+        install_path = tmp_path / "apm_modules" / "owner" / "repo"
+        install_path.mkdir(parents=True)
+        pkg_info.install_path = install_path
+
+        bi.init_link_resolver(pkg_info, tmp_path)
+
+        mock_discover.assert_called_once_with(install_path)
+
+
+# ---------------------------------------------------------------------------
+# init_link_resolver -- project-scope local narrowing (#1507)
+# ---------------------------------------------------------------------------
+
+
+class TestInitLinkResolverLocalScoping:
+    """When ``install_path == project_root`` (synthetic ``_local`` package),
+    init_link_resolver must scope discover_primitives to ``.apm/`` and
+    ``.github/`` so a project tree with thousands of unrelated files does
+    not get walked end-to-end. See issue #1507 (13-minute hang).
+    """
+
+    @patch("apm_cli.integration.base_integrator.discover_primitives")
+    @patch("apm_cli.integration.base_integrator.UnifiedLinkResolver")
+    def test_narrows_to_apm_and_github_when_install_path_is_project_root(
+        self, mock_resolver_cls, mock_discover, tmp_path
+    ):
+        mock_discover.return_value = []
+        (tmp_path / ".apm").mkdir()
+        (tmp_path / ".github").mkdir()
+        # Noise: a giant subtree that must NOT be walked.
+        (tmp_path / "noise").mkdir()
+        (tmp_path / "noise" / "deep").mkdir()
+        (tmp_path / "noise" / "deep" / "irrelevant.txt").write_text("x")
+
         bi = BaseIntegrator()
         pkg_info = MagicMock()
         pkg_info.install_path = tmp_path
 
         bi.init_link_resolver(pkg_info, tmp_path)
 
-        mock_discover.assert_called_once_with(tmp_path)
+        called_roots = [call.args[0] for call in mock_discover.call_args_list]
+        assert tmp_path / ".apm" in called_roots
+        assert tmp_path / ".github" in called_roots
+        # Critically: project_root itself was NOT passed to discover_primitives.
+        assert tmp_path not in called_roots
+        # And no noise subtree was passed either.
+        for root in called_roots:
+            assert "noise" not in Path(root).parts
+
+    @patch("apm_cli.integration.base_integrator.discover_primitives")
+    @patch("apm_cli.integration.base_integrator.UnifiedLinkResolver")
+    def test_skips_missing_directories(self, mock_resolver_cls, mock_discover, tmp_path):
+        """If only ``.apm/`` exists, only ``.apm/`` is scanned -- no waste
+        from probing a non-existent ``.github/``."""
+        mock_discover.return_value = []
+        (tmp_path / ".apm").mkdir()
+        # No .github/
+
+        bi = BaseIntegrator()
+        pkg_info = MagicMock()
+        pkg_info.install_path = tmp_path
+
+        bi.init_link_resolver(pkg_info, tmp_path)
+
+        called_roots = [call.args[0] for call in mock_discover.call_args_list]
+        assert called_roots == [tmp_path / ".apm"]
+
+    @patch("apm_cli.integration.base_integrator.discover_primitives")
+    @patch("apm_cli.integration.base_integrator.UnifiedLinkResolver")
+    def test_no_apm_or_github_means_no_walk(self, mock_resolver_cls, mock_discover, tmp_path):
+        """Project root with no .apm/ or .github/ must not walk anything."""
+        mock_discover.return_value = []
+
+        bi = BaseIntegrator()
+        pkg_info = MagicMock()
+        pkg_info.install_path = tmp_path
+
+        bi.init_link_resolver(pkg_info, tmp_path)
+
+        mock_discover.assert_not_called()
+
+    def test_real_walk_does_not_traverse_noise_subtree(self, tmp_path):
+        """End-to-end: with a real (non-mocked) discover_primitives call,
+        confirm files under a noise subtree do NOT get walked. Acts as a
+        regression trap for the original 13-minute hang on large repos.
+
+        Asserts via a spy on the underlying ``os.walk`` driver that no
+        directory outside ``.apm/`` / ``.github/`` is ever visited.
+        """
+        import os
+
+        (tmp_path / ".apm" / "instructions").mkdir(parents=True)
+        (tmp_path / ".apm" / "instructions" / "real.instructions.md").write_text(
+            "---\napplyTo: '**'\n---\nbody\n"
+        )
+        # Noise: a deep subtree that must not be walked at all.
+        (tmp_path / "noise" / "deep" / "deeper").mkdir(parents=True)
+        (tmp_path / "noise" / "deep" / "deeper" / "x.txt").write_text("x")
+        # And a noise file that WOULD match the generic
+        # ``**/*.instructions.md`` pattern if a full-tree walk happened.
+        (tmp_path / "noise" / "looksLike.instructions.md").write_text(
+            "---\napplyTo: '**'\n---\nbody\n"
+        )
+
+        visited_dirs: list[str] = []
+        real_walk = os.walk
+
+        def spy_walk(top, *args, **kwargs):
+            for dirpath, dirnames, filenames in real_walk(top, *args, **kwargs):
+                visited_dirs.append(dirpath)
+                yield dirpath, dirnames, filenames
+
+        bi = BaseIntegrator()
+        pkg_info = MagicMock()
+        pkg_info.install_path = tmp_path
+
+        with patch("apm_cli.primitives.discovery.os.walk", side_effect=spy_walk):
+            bi.init_link_resolver(pkg_info, tmp_path)
+
+        # The noise subtree must never appear in any walked directory.
+        for d in visited_dirs:
+            assert "noise" not in Path(d).parts, f"discovery walked noise subtree: {d}"
+        # And the real instruction under .apm/ should still be findable.
+        # (Sanity check: confirm we did walk the .apm subtree.)
+        assert any(".apm" in Path(d).parts for d in visited_dirs)
 
 
 # Cowork additive tests

--- a/tests/unit/integration/test_base_integrator.py
+++ b/tests/unit/integration/test_base_integrator.py
@@ -682,6 +682,20 @@ class TestInitLinkResolverHomeScoping:
 
     @patch("apm_cli.integration.base_integrator.discover_primitives")
     @patch("apm_cli.integration.base_integrator.UnifiedLinkResolver")
+    def test_scopes_string_home_install_path_to_apm_subdir(self, mock_resolver_cls, mock_discover):
+        """String HOME install paths still use the ~/.apm discovery boundary."""
+        mock_discover.return_value = []
+        (Path.home() / ".apm").mkdir(parents=True, exist_ok=True)
+        bi = BaseIntegrator()
+        pkg_info = MagicMock()
+        pkg_info.install_path = str(Path.home())
+
+        bi.init_link_resolver(pkg_info, Path.home())
+
+        mock_discover.assert_called_once_with(Path.home() / ".apm")
+
+    @patch("apm_cli.integration.base_integrator.discover_primitives")
+    @patch("apm_cli.integration.base_integrator.UnifiedLinkResolver")
     def test_skips_home_apm_when_not_directory(
         self, mock_resolver_cls, mock_discover, tmp_path, monkeypatch
     ):

--- a/tests/unit/integration/test_base_integrator.py
+++ b/tests/unit/integration/test_base_integrator.py
@@ -653,6 +653,7 @@ class TestInitLinkResolverHomeScoping:
     @patch("apm_cli.integration.base_integrator.UnifiedLinkResolver")
     def test_scopes_to_apm_subdir_when_install_path_is_home(self, mock_resolver_cls, mock_discover):
         mock_discover.return_value = []
+        (Path.home() / ".apm").mkdir(parents=True, exist_ok=True)
         bi = BaseIntegrator()
         pkg_info = MagicMock()
         pkg_info.install_path = Path.home()
@@ -678,6 +679,25 @@ class TestInitLinkResolverHomeScoping:
         bi.init_link_resolver(pkg_info, tmp_path)
 
         mock_discover.assert_called_once_with(install_path)
+
+    @patch("apm_cli.integration.base_integrator.discover_primitives")
+    @patch("apm_cli.integration.base_integrator.UnifiedLinkResolver")
+    def test_skips_home_apm_when_not_directory(
+        self, mock_resolver_cls, mock_discover, tmp_path, monkeypatch
+    ):
+        """If ~/.apm is a file, home-scoped discovery must not scan it."""
+        mock_discover.return_value = []
+        home_root = tmp_path / "home"
+        home_root.mkdir()
+        (home_root / ".apm").write_text("not a directory")
+        monkeypatch.setattr(Path, "home", lambda: home_root)
+        bi = BaseIntegrator()
+        pkg_info = MagicMock()
+        pkg_info.install_path = home_root
+
+        bi.init_link_resolver(pkg_info, home_root)
+
+        mock_discover.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -712,6 +732,7 @@ class TestInitLinkResolverLocalScoping:
         bi.init_link_resolver(pkg_info, tmp_path)
 
         called_roots = [call.args[0] for call in mock_discover.call_args_list]
+        assert mock_resolver_cls.return_value.package_root == tmp_path
         assert tmp_path / ".apm" in called_roots
         assert tmp_path / ".github" in called_roots
         # Critically: project_root itself was NOT passed to discover_primitives.


### PR DESCRIPTION
## Symptom

On a 50k+ file monorepo with only 2 instructions and 1 prompt under `.apm/`, `apm install` hangs for ~13 minutes during the integrate phase before completing. Reported by @ioannispoulios in #1507.

## Trace

1. `src/apm_cli/install/services.py:465-477` builds a synthetic `_local` `PackageInfo` with `install_path = project_root` and calls `integrate_package_primitives()`.
2. `src/apm_cli/integration/prompt_integrator.py:234` invokes `self.init_link_resolver(package_info, project_root)`.
3. `src/apm_cli/integration/base_integrator.py:531-553` (pre-fix) sets `scan_root = package_info.install_path` and only narrows to `scan_root/.apm` when `scan_root == Path.home()` (issue #830). For project-scope local content, `scan_root` stays at the project root.
4. `src/apm_cli/primitives/discovery.py:590` walks `base_dir` with `os.walk`. Because `LOCAL_PRIMITIVE_PATTERNS` contains generic patterns like `**/*.instructions.md`, the walk traverses the entire repo even when no local primitive lives outside `.apm/`. Result: O(repo size) work proportional to the monorepo, not to APM content.

## Fix

Extend the existing `$HOME` narrowing to also apply when `install_path == project_root` (i.e. the synthetic `_local` `PackageInfo`). For that case, scan only `.apm/` and `.github/` -- the two supported locations for local primitives per `LOCAL_PRIMITIVE_PATTERNS`. Real installed packages (`apm_modules/<owner>/<repo>/...`) keep scanning their `install_path` directly because their `install_path` differs from `project_root`.

The `link_resolver.package_root` sentinel for in-package asset rewriting (#1147) is preserved as the project root for the local case, so asset links inside `.apm/` continue to resolve against the project tree.

## Tests (TDD + mutation-break gate)

`tests/unit/integration/test_base_integrator.py::TestInitLinkResolverLocalScoping`:

- `test_narrows_to_apm_and_github_when_install_path_is_project_root` -- mocks `discover_primitives`, asserts it is called with `.apm/` and `.github/` and never with `project_root` itself.
- `test_skips_missing_directories` -- only `.apm/` exists, so only `.apm/` is scanned.
- `test_no_apm_or_github_means_no_walk` -- no scannable dirs, `discover_primitives` is never called.
- `test_real_walk_does_not_traverse_noise_subtree` -- end-to-end with a real walk; spies on `os.walk` to assert no `noise/...` directory is visited even though the noise subtree contains a file matching the generic `**/*.instructions.md` pattern.

Mutation-break gate: deleting the narrowing branch causes all four new tests to fail.

The pre-existing `test_uses_install_path_when_not_home` was updated to use `install_path = tmp_path / "apm_modules" / "owner" / "repo"` so it reflects the real-package contract (install_path != project_root) it was always meant to exercise.

## How to test on a synthetic large-tree fixture

```bash
mkdir -p /tmp/big-repo/.apm/instructions /tmp/big-repo/noise
echo '---\napplyTo: "**"\n---' > /tmp/big-repo/.apm/instructions/x.instructions.md
# Generate ~50k noise files
python3 -c "
import os
for i in range(500):
    d = f'/tmp/big-repo/noise/d{i}'
    os.makedirs(d, exist_ok=True)
    for j in range(100):
        open(f'{d}/f{j}.txt', 'w').close()
"
cd /tmp/big-repo && apm init --no-interactive && time apm install
```

Before this PR: minutes. After: sub-second integrate phase.

## Validation evidence

- `uv run --extra dev pytest tests/unit/integration/ tests/unit/install/ tests/unit/test_local_content_install.py -q` -> 2959 passed.
- Lint chain (`ruff check`, `ruff format --check`, `pylint R0801`, `lint-auth-signals.sh`) -> all silent / 10.00.

Closes #1507.
