### PR TITLE
fix: preserve executable permission bits on install (closes #1563)

### DIFF
--- a/src/apm_cli/deps/download_strategies.py
+++ b/src/apm_cli/deps/download_strategies.py
@@ -355,12 +355,15 @@ class DownloadDelegate:
                             if not dest.resolve().is_relative_to(target_path.resolve()):
                                 _debug(f"Skipping zip entry escaping target: {member.filename}")
                                 continue
+                            unix_mode = (member.external_attr >> 16) & 0xFFFF
                             if member.is_dir():
                                 dest.mkdir(parents=True, exist_ok=True)
                             else:
                                 dest.parent.mkdir(parents=True, exist_ok=True)
                                 with zf.open(member) as src, open(dest, "wb") as dst:
                                     dst.write(src.read())
+                                if unix_mode:
+                                    os.chmod(dest, unix_mode & 0o755)
                     _debug(f"Extracted Artifactory archive to {target_path}")
                     return
                 else:

--- a/src/apm_cli/utils/file_ops.py
+++ b/src/apm_cli/utils/file_ops.py
@@ -222,6 +222,7 @@ def _reflink_copy_file(src: str, dst: str, *, follow_symlinks: bool = True) -> s
     try:
         if follow_symlinks and not os.path.islink(src):
             if clone_file(src, dst):
+                shutil.copystat(src, dst, follow_symlinks=follow_symlinks)
                 return dst
     except OSError:
         # Defensive: clone_file is documented as never-raises but the

--- a/tests/integration/test_download_strategies_selection.py
+++ b/tests/integration/test_download_strategies_selection.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import io
 import json
+import os
+import stat
 import zipfile
 from pathlib import Path
 from types import SimpleNamespace
@@ -92,6 +94,23 @@ def make_zip(entries: dict[str, bytes], *, root_prefix: str = "repo-main/") -> b
                 zf.mkdir(full_name)
             else:
                 zf.writestr(full_name, payload)
+    return buffer.getvalue()
+
+
+def make_zip_with_file_modes(
+    entries: dict[str, tuple[bytes, int]],
+    *,
+    root_prefix: str = "repo-main/",
+) -> bytes:
+    buffer = io.BytesIO()
+    root_info = zipfile.ZipInfo(root_prefix)
+    root_info.external_attr = (stat.S_IFDIR | 0o755) << 16
+    with zipfile.ZipFile(buffer, "w") as zf:
+        zf.writestr(root_info, b"")
+        for name, (payload, mode) in entries.items():
+            file_info = zipfile.ZipInfo(root_prefix + name)
+            file_info.external_attr = (stat.S_IFREG | mode) << 16
+            zf.writestr(file_info, payload)
     return buffer.getvalue()
 
 
@@ -214,6 +233,36 @@ class TestDownloadArtifactoryArchive:
         assert (tmp_path / "nested").is_dir()
         assert (tmp_path / "nested" / "file.txt").read_text() == "safe"
         assert not (tmp_path.parent / "escape.txt").exists()
+
+    def test_executable_bits_survive_archive_extraction(self, tmp_path: Path) -> None:
+        host = make_host()
+        delegate = DownloadDelegate(host)
+        archive_bytes = make_zip_with_file_modes(
+            {
+                "bin/run-driver": (b"#!/bin/sh\n", 0o755),
+                "README.md": (b"hello", 0o644),
+            }
+        )
+        host._resilient_get.return_value = fake_response(200, content=archive_bytes)
+
+        with patch(
+            "apm_cli.deps.download_strategies.build_artifactory_archive_url",
+            return_value=["https://art.example.com/archive.zip"],
+        ):
+            delegate.download_artifactory_archive(
+                "art.example.com",
+                "proxy",
+                "owner",
+                "repo",
+                "main",
+                tmp_path,
+            )
+
+        script = tmp_path / "bin" / "run-driver"
+        readme = tmp_path / "README.md"
+        assert script.read_bytes() == b"#!/bin/sh\n"
+        assert os.stat(script).st_mode & 0o111 == 0o111
+        assert os.stat(readme).st_mode & 0o111 == 0
 
     def test_request_exception_becomes_last_error(self, tmp_path: Path) -> None:
         host = make_host()

--- a/tests/unit/test_download_strategies.py
+++ b/tests/unit/test_download_strategies.py
@@ -1,0 +1,49 @@
+"""Tests for backend-specific download delegates."""
+
+from __future__ import annotations
+
+import io
+import os
+import stat
+import zipfile
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from apm_cli.deps.download_strategies import DownloadDelegate
+
+
+def _zip_with_executable_script() -> bytes:
+    """Build a GitHub-style archive containing an executable script."""
+    root_info = zipfile.ZipInfo("repo-main/")
+    root_info.external_attr = (stat.S_IFDIR | 0o755) << 16
+    script_info = zipfile.ZipInfo("repo-main/scripts/do-driver")
+    script_info.external_attr = (stat.S_IFREG | 0o755) << 16
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(root_info, b"")
+        zf.writestr(script_info, b"#!/bin/sh\n")
+    return buf.getvalue()
+
+
+def test_artifactory_archive_preserves_executable_bits(tmp_path):
+    response = SimpleNamespace(status_code=200, content=_zip_with_executable_script())
+    host = SimpleNamespace(registry_config=None, artifactory_token=None)
+    host._resilient_get = lambda *args, **kwargs: response
+
+    with patch(
+        "apm_cli.deps.download_strategies.build_artifactory_archive_url",
+        return_value=["https://art.example/archive.zip"],
+    ):
+        DownloadDelegate(host).download_artifactory_archive(
+            "art.example",
+            "apm",
+            "owner",
+            "repo",
+            "main",
+            tmp_path,
+        )
+
+    script = tmp_path / "scripts" / "do-driver"
+    assert script.read_bytes() == b"#!/bin/sh\n"
+    assert os.stat(script).st_mode & 0o111 == 0o111

--- a/tests/unit/test_file_ops.py
+++ b/tests/unit/test_file_ops.py
@@ -5,7 +5,7 @@ import os
 import shutil
 import stat
 import sys  # noqa: F401
-from pathlib import Path  # noqa: F401
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -243,6 +243,23 @@ class TestRetryOnLock:
 # ---------------------------------------------------------------------------
 # robust_rmtree
 # ---------------------------------------------------------------------------
+
+
+def test_robust_copy2_preserves_executable_bits_on_reflink_fast_path(tmp_path):
+    src = tmp_path / "source.sh"
+    dst = tmp_path / "dest.sh"
+    src.write_text("#!/bin/sh\n")
+    src.chmod(0o755)
+
+    def fake_clone(src_path: str, dst_path: str) -> bool:
+        Path(dst_path).write_bytes(Path(src_path).read_bytes())
+        return True
+
+    with patch("apm_cli.utils.reflink.clone_file", side_effect=fake_clone):
+        robust_copy2(src, dst)
+
+    assert dst.read_text() == "#!/bin/sh\n"
+    assert os.stat(dst).st_mode & 0o111 == 0o111
 
 
 class TestRobustRmtree:


### PR DESCRIPTION
Preserves executable permission bits when materializing package files through the reflink copy fast path and the Artifactory ZIP extraction path, aligning archive extraction with the registry extractor's Unix mode handling. How to test: uv run --locked --extra dev pytest tests/unit/test_file_ops.py tests/unit/test_reflink_phase3w5.py tests/unit/test_download_strategies.py tests/unit/install/test_artifactory_resolver.py -q; uv run --locked --extra dev ruff check src/ tests/ --quiet; uv run --locked --extra dev ruff format --check src/ tests/ --quiet. Closes #1563.