### PR TITLE
fix: dedup deployed_files and scope --update to named packages (closes #1558)

### DIFF
--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -53,6 +53,7 @@ from apm_cli.install.package_resolution import (
     update_existing_dependency_entry_if_needed,
     user_scope_rejection_reason,
 )
+from apm_cli.install.package_selection import only_packages_from_validation
 
 # Re-export local-content leaf helpers so that callers inside this module
 # (e.g. _install_apm_dependencies) and any future test patches against
@@ -229,24 +230,6 @@ class InstallContext:
     plan_callback: "Callable[[UpdatePlan], bool] | None" = None
     skill_subset: "builtins.tuple[str, ...] | None" = None
     skill_subset_from_cli: bool = False
-
-
-def _only_packages_from_validation(
-    packages: tuple[str, ...] | None,
-    outcome: _ValidationOutcome | None,
-) -> list[str] | None:
-    """Return canonical package specs for a positional install request."""
-    if not packages:
-        return None
-    if outcome is None:
-        return []
-    seen = set()
-    selected = []
-    for canonical, _already_present in outcome.valid:
-        if canonical not in seen:
-            seen.add(canonical)
-            selected.append(canonical)
-    return selected
 
 
 # ---------------------------------------------------------------------------
@@ -1517,7 +1500,7 @@ def install(  # noqa: PLR0913
             install_mode=InstallMode(only) if only else InstallMode.ALL,
             packages=packages,
             refresh=refresh,
-            only_packages=_only_packages_from_validation(packages, outcome),
+            only_packages=only_packages_from_validation(packages, outcome),
             manifest_snapshot=_manifest_snapshot,
             snapshot_manifest_path=_snapshot_manifest_path,
             legacy_skill_paths=legacy_skill_paths,

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -231,6 +231,24 @@ class InstallContext:
     skill_subset_from_cli: bool = False
 
 
+def _only_packages_from_validation(
+    packages: tuple[str, ...] | None,
+    outcome: _ValidationOutcome | None,
+) -> list[str] | None:
+    """Return canonical package specs for a positional install request."""
+    if not packages:
+        return None
+    if outcome is None:
+        return []
+    seen = builtins.set()
+    selected = []
+    for canonical, _already_present in outcome.valid:
+        if canonical not in seen:
+            seen.add(canonical)
+            selected.append(canonical)
+    return selected
+
+
 # ---------------------------------------------------------------------------
 # Argv `--` boundary helpers (W3 --mcp flag)
 # ---------------------------------------------------------------------------
@@ -1444,7 +1462,6 @@ def install(  # noqa: PLR0913
             sys.exit(1)
 
         # If packages are specified, validate and add them to apm.yml first
-        validated_packages = []
         outcome = None
         if packages:
             # -- W2-pkg-rollback (#827): snapshot raw bytes BEFORE mutation --
@@ -1456,7 +1473,7 @@ def install(  # noqa: PLR0913
                 _manifest_snapshot = manifest_path.read_bytes()
                 _snapshot_manifest_path = manifest_path
 
-            validated_packages, outcome = _validate_and_add_packages_to_apm_yml(
+            _validated_packages, outcome = _validate_and_add_packages_to_apm_yml(
                 packages,
                 dry_run,
                 dev=dev,
@@ -1470,8 +1487,8 @@ def install(  # noqa: PLR0913
             # Short-circuit: all packages failed validation -- nothing to install
             if outcome.all_failed:
                 return
-            # Note: Empty validated_packages is OK if packages are already in apm.yml
-            # We'll proceed with installation from apm.yml to ensure everything is synced
+            # Note: Empty validated_packages is OK if packages are already in apm.yml;
+            # only_packages is derived from validation outcomes below.
 
         # Build install context
         install_ctx = InstallContext(
@@ -1500,7 +1517,7 @@ def install(  # noqa: PLR0913
             install_mode=InstallMode(only) if only else InstallMode.ALL,
             packages=packages,
             refresh=refresh,
-            only_packages=builtins.list(validated_packages) if packages else None,
+            only_packages=_only_packages_from_validation(packages, outcome),
             manifest_snapshot=_manifest_snapshot,
             snapshot_manifest_path=_snapshot_manifest_path,
             legacy_skill_paths=legacy_skill_paths,

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -240,7 +240,7 @@ def _only_packages_from_validation(
         return None
     if outcome is None:
         return []
-    seen = builtins.set()
+    seen = set()
     selected = []
     for canonical, _already_present in outcome.valid:
         if canonical not in seen:

--- a/src/apm_cli/deps/lockfile.py
+++ b/src/apm_cli/deps/lockfile.py
@@ -20,6 +20,11 @@ logger = logging.getLogger(__name__)
 _SELF_KEY = "."
 
 
+def _dedupe_preserving_order(values: list[str]) -> list[str]:
+    """Return values without duplicates, preserving first-seen order."""
+    return list(dict.fromkeys(values))
+
+
 @dataclass
 class LockedDependency:
     """A resolved dependency with exact commit/version information."""
@@ -104,7 +109,7 @@ class LockedDependency:
         if self.package_type:
             result["package_type"] = self.package_type
         if self.deployed_files:
-            result["deployed_files"] = sorted(dict.fromkeys(self.deployed_files))
+            result["deployed_files"] = sorted(_dedupe_preserving_order(self.deployed_files))
         if self.deployed_file_hashes:
             result["deployed_file_hashes"] = dict(sorted(self.deployed_file_hashes.items()))
         if self.source:
@@ -149,7 +154,7 @@ class LockedDependency:
         - Old ``deployed_skills`` lists are migrated to ``deployed_files``
           paths under ``.github/skills/`` and ``.claude/skills/``.
         """
-        deployed_files = list(data.get("deployed_files", []))
+        deployed_files = _dedupe_preserving_order(list(data.get("deployed_files", [])))
 
         # Migrate legacy deployed_skills -> deployed_files
         old_skills = data.get("deployed_skills", [])
@@ -414,6 +419,7 @@ class LockFile:
         keeping the in-memory state consistent with what ``to_yaml()``
         would emit (design section 6.1; issue #1488).
         """
+        dep.deployed_files = _dedupe_preserving_order(dep.deployed_files)
         self.dependencies[dep.get_unique_key()] = dep
         if self.lockfile_version == "1" and (
             dep.source == "registry" or dep.constraint or dep.resolved_tag or dep.resolved_at

--- a/src/apm_cli/deps/lockfile.py
+++ b/src/apm_cli/deps/lockfile.py
@@ -104,7 +104,7 @@ class LockedDependency:
         if self.package_type:
             result["package_type"] = self.package_type
         if self.deployed_files:
-            result["deployed_files"] = sorted(self.deployed_files)
+            result["deployed_files"] = sorted(dict.fromkeys(self.deployed_files))
         if self.deployed_file_hashes:
             result["deployed_file_hashes"] = dict(sorted(self.deployed_file_hashes.items()))
         if self.source:

--- a/src/apm_cli/install/__init__.py
+++ b/src/apm_cli/install/__init__.py
@@ -13,6 +13,7 @@ Architecture:
     sources.py      DependencySource Strategy hierarchy
     template.py     run_integration_template() Template Method
     validation.py   manifest validation (dependency syntax, existence checks)
+    package_selection.py scoped package selection from validation outcomes
 
     phases/         one module per pipeline phase
     helpers/        cross-cutting helpers (security scan, gitignore)

--- a/src/apm_cli/install/package_selection.py
+++ b/src/apm_cli/install/package_selection.py
@@ -1,0 +1,26 @@
+"""Helpers for deriving scoped package install selections."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from apm_cli.core.command_logger import _ValidationOutcome
+
+
+def only_packages_from_validation(
+    packages: tuple[str, ...] | None,
+    outcome: _ValidationOutcome | None,
+) -> list[str] | None:
+    """Return canonical package specs for a positional install request."""
+    if not packages:
+        return None
+    if outcome is None:
+        return []
+    seen = set()
+    selected = []
+    for canonical, _already_present in outcome.valid:
+        if canonical not in seen:
+            seen.add(canonical)
+            selected.append(canonical)
+    return selected

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -125,6 +125,8 @@ class TestLockedDependency:
             )
         )
 
+        assert lock.get_dependency("owner/repo").deployed_files == ["b.md", "a.md"]
+
         lock_path = tmp_path / "apm.lock.yaml"
         lock.write(lock_path)
 

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -115,6 +115,23 @@ class TestLockedDependency:
         dep = LockedDependency(repo_url="owner/repo")
         assert "deployed_file_hashes" not in dep.to_dict()
 
+    def test_deployed_files_deduplicated_when_serialized_after_repeated_update(self, tmp_path):
+        """Repeated installs may append the same path; lock output stays canonical."""
+        lock = LockFile()
+        lock.add_dependency(
+            LockedDependency(
+                repo_url="owner/repo",
+                deployed_files=["b.md", "a.md", "b.md", "a.md"],
+            )
+        )
+
+        lock_path = tmp_path / "apm.lock.yaml"
+        lock.write(lock_path)
+
+        data = yaml.safe_load(lock_path.read_text(encoding="utf-8"))
+        [dep_data] = data["dependencies"]
+        assert dep_data["deployed_files"] == ["a.md", "b.md"]
+
     def test_from_dict_missing_hashes_defaults_empty(self):
         loaded = LockedDependency.from_dict({"repo_url": "owner/repo"})
         assert loaded.deployed_file_hashes == {}

--- a/tests/unit/commands/test_install_phase3.py
+++ b/tests/unit/commands/test_install_phase3.py
@@ -628,14 +628,21 @@ class TestInstallUpdatePackageScoping:
             encoding="utf-8",
         )
 
+        service_requests = []
+
+        def capture_request(_self, request):
+            service_requests.append(request)
+            return InstallResult(installed_count=1, diagnostics=None)
+
         with (
-            patch("apm_cli.commands.install._validate_package_exists", return_value=True),
             patch(
-                "apm_cli.commands.install._install_apm_dependencies",
-                return_value=InstallResult(installed_count=1, diagnostics=None),
-            ) as install_apm,
+                "apm_cli.commands.install._get_invocation_argv",
+                return_value=["apm", "install", "--update", "owner/target"],
+            ),
+            patch("apm_cli.commands.install._validate_package_exists", return_value=True),
+            patch("apm_cli.install.service.InstallService.run", capture_request),
         ):
             result = CliRunner().invoke(install, ["--update", "owner/target"])
 
         assert result.exit_code == 0, result.output
-        assert install_apm.call_args.args[3] == ["owner/target"]
+        assert service_requests[0].only_packages == ["owner/target"]

--- a/tests/unit/commands/test_install_phase3.py
+++ b/tests/unit/commands/test_install_phase3.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from click.testing import CliRunner
 
 from apm_cli.commands.install import (
     _check_package_conflicts,
@@ -606,3 +607,35 @@ class TestInstallContextDefaults:
         )
         ctx.refresh = True
         assert ctx.refresh is True
+
+
+class TestInstallUpdatePackageScoping:
+    def test_update_existing_named_package_scopes_apm_install_to_that_package(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """--update for an already-declared package must not integrate every dep."""
+        from apm_cli.commands.install import install
+        from apm_cli.models.results import InstallResult
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "apm.yml").write_text(
+            "name: test\n"
+            "version: 0.1.0\n"
+            "dependencies:\n"
+            "  apm:\n"
+            "    - owner/target\n"
+            "    - owner/other\n",
+            encoding="utf-8",
+        )
+
+        with (
+            patch("apm_cli.commands.install._validate_package_exists", return_value=True),
+            patch(
+                "apm_cli.commands.install._install_apm_dependencies",
+                return_value=InstallResult(installed_count=1, diagnostics=None),
+            ) as install_apm,
+        ):
+            result = CliRunner().invoke(install, ["--update", "owner/target"])
+
+        assert result.exit_code == 0, result.output
+        assert install_apm.call_args.args[3] == ["owner/target"]


### PR DESCRIPTION
## Context
Fixes #1558. Positional install requests that validate as already present now keep their canonical package selection, so apm install --update <pkg> does not fall through to all manifest dependencies. Lockfile serialization also canonicalizes deployed_files by removing duplicate paths before writing.

## How to test
- uv run --locked --extra dev pytest tests/test_lockfile.py tests/unit/commands/test_install_phase3.py tests/unit/install/test_resolve_phase3w5.py -q
- uv run --locked --extra dev ruff check src/ tests/
- uv run --locked --extra dev ruff format --check src/ tests/
- uv run --locked --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/
- bash scripts/lint-auth-signals.sh

Mutation-break verified for both new regression tests.