### PR TITLE
fix: deterministic lockfile for unchanged MCP deps (closes #1532)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Linux standalone `apm` binaries no longer fail git shared-cache clones with shared-library symbol lookup errors caused by PyInstaller dynamic-library paths leaking into child processes. (closes #1534)
 - Avoid 13-minute `apm install` hangs in large local projects by limiting synthetic `_local` discovery to `.apm/` and `.github/`, while preserving package metadata discovery. (closes #1507) -- by @ioannispoulios
 - `apm install -g <package>#<ref>` now updates an existing unpinned global dependency entry instead of leaving the manifest floating. (#1559)
+- `apm install` no longer rewrites `apm.lock.yaml` when MCP dependencies are unchanged, keeping no-op installs byte-stable. (#1568)
 - `apm install` now honors manifest `targets:` without falling back to the legacy Copilot target when singular `target:` is absent. (#1560)
 
 ## [0.16.0] - 2026-05-28

--- a/src/apm_cli/install/phases/lockfile.py
+++ b/src/apm_cli/install/phases/lockfile.py
@@ -191,9 +191,16 @@ class LockfileBuilder:
         return lockfile
 
     def _preserve_existing_mcp_state(self, lockfile: LockFile) -> None:
+        """Keep MCP fields until MCPIntegrator reconciles them later in install."""
         if self.ctx.existing_lockfile:
             lockfile.mcp_servers = list(self.ctx.existing_lockfile.mcp_servers)
             lockfile.mcp_configs = dict(self.ctx.existing_lockfile.mcp_configs)
+            if self.ctx.logger:
+                self.ctx.logger.verbose_detail(
+                    "Preserved existing MCP state in apm.lock.yaml "
+                    f"({len(lockfile.mcp_servers)} server(s), "
+                    f"{len(lockfile.mcp_configs)} config(s))"
+                )
 
     def _write_if_changed(self, lockfile: LockFile, lockfile_path: Path, _LF: type) -> None:
         # Re-read the on-disk lockfile for the semantic comparison.

--- a/src/apm_cli/install/phases/lockfile.py
+++ b/src/apm_cli/install/phases/lockfile.py
@@ -107,6 +107,7 @@ class LockfileBuilder:
             # merge new entries into the existing lockfile instead of
             # overwriting it -- otherwise the uninstalled packages disappear.
             lockfile = self._maybe_merge_partial(lockfile, lockfile_path, _LF)
+            self._preserve_existing_mcp_state(lockfile)
 
             # Only write when the semantic content has actually changed
             # (avoids generated_at churn in version control).
@@ -188,6 +189,11 @@ class LockfileBuilder:
                     existing.add_dependency(dep)
                 lockfile = existing
         return lockfile
+
+    def _preserve_existing_mcp_state(self, lockfile: LockFile) -> None:
+        if self.ctx.existing_lockfile:
+            lockfile.mcp_servers = list(self.ctx.existing_lockfile.mcp_servers)
+            lockfile.mcp_configs = dict(self.ctx.existing_lockfile.mcp_configs)
 
     def _write_if_changed(self, lockfile: LockFile, lockfile_path: Path, _LF: type) -> None:
         # Re-read the on-disk lockfile for the semantic comparison.

--- a/src/apm_cli/install/phases/lockfile.py
+++ b/src/apm_cli/install/phases/lockfile.py
@@ -15,6 +15,7 @@ Exposes:
 
 from __future__ import annotations
 
+import copy
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -193,13 +194,15 @@ class LockfileBuilder:
     def _preserve_existing_mcp_state(self, lockfile: LockFile) -> None:
         """Keep MCP fields until MCPIntegrator reconciles them later in install."""
         if self.ctx.existing_lockfile:
+            # MCPIntegrator.update_lockfile runs after this phase and reconciles
+            # these carried-forward fields against the current manifest.
             lockfile.mcp_servers = list(self.ctx.existing_lockfile.mcp_servers)
-            lockfile.mcp_configs = dict(self.ctx.existing_lockfile.mcp_configs)
+            lockfile.mcp_configs = copy.deepcopy(self.ctx.existing_lockfile.mcp_configs)
             if self.ctx.logger:
                 self.ctx.logger.verbose_detail(
-                    "Preserved existing MCP state in apm.lock.yaml "
-                    f"({len(lockfile.mcp_servers)} server(s), "
-                    f"{len(lockfile.mcp_configs)} config(s))"
+                    "MCP state unchanged -- carrying forward "
+                    f"{len(lockfile.mcp_servers)} server(s), "
+                    f"{len(lockfile.mcp_configs)} config(s)"
                 )
 
     def _write_if_changed(self, lockfile: LockFile, lockfile_path: Path, _LF: type) -> None:

--- a/src/apm_cli/integration/mcp_integrator.py
+++ b/src/apm_cli/integration/mcp_integrator.py
@@ -14,6 +14,7 @@ import logging
 import re
 import shutil
 import warnings
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional  # noqa: F401, UP035
 
@@ -767,12 +768,18 @@ class MCPIntegrator:
         if not lock_path.exists():
             return
         try:
+            existing_lockfile = LockFile.read(lock_path)
+            if existing_lockfile is None:
+                return
             lockfile = LockFile.read(lock_path)
             if lockfile is None:
                 return
             lockfile.mcp_servers = sorted(mcp_server_names)
             if mcp_configs is not None:
                 lockfile.mcp_configs = mcp_configs
+            if lockfile.is_semantically_equivalent(existing_lockfile):
+                return
+            lockfile.generated_at = datetime.now(timezone.utc).isoformat()
             lockfile.save(lock_path)
         except Exception:
             _log.debug(

--- a/src/apm_cli/integration/mcp_integrator.py
+++ b/src/apm_cli/integration/mcp_integrator.py
@@ -10,6 +10,7 @@ The existing adapters (client/, package_manager/) and registry operations
 """
 
 import builtins
+import copy
 import logging
 import re
 import shutil
@@ -771,13 +772,12 @@ class MCPIntegrator:
             existing_lockfile = LockFile.read(lock_path)
             if existing_lockfile is None:
                 return
-            lockfile = LockFile.read(lock_path)
-            if lockfile is None:
-                return
+            lockfile = copy.deepcopy(existing_lockfile)
             lockfile.mcp_servers = sorted(mcp_server_names)
             if mcp_configs is not None:
                 lockfile.mcp_configs = mcp_configs
             if lockfile.is_semantically_equivalent(existing_lockfile):
+                _log.debug("MCP lockfile unchanged -- skipping write")
                 return
             lockfile.generated_at = datetime.now(timezone.utc).isoformat()
             lockfile.save(lock_path)

--- a/tests/unit/install/test_mcp_lockfile_determinism.py
+++ b/tests/unit/install/test_mcp_lockfile_determinism.py
@@ -1,0 +1,113 @@
+"""Regression tests for MCP lockfile determinism."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from apm_cli.deps.installed_package import InstalledPackage
+from apm_cli.deps.lockfile import LockFile, get_lockfile_path
+from apm_cli.install.context import InstallContext
+from apm_cli.install.phases.lockfile import LockfileBuilder
+from apm_cli.integration.mcp_integrator import MCPIntegrator
+from apm_cli.models.apm_package import APMPackage, clear_apm_yml_cache
+
+
+class _FixedDatetime:
+    instant = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    @classmethod
+    def now(cls, tz: timezone | None = None) -> datetime:
+        if tz is None:
+            return cls.instant.replace(tzinfo=None)
+        return cls.instant.astimezone(tz)
+
+
+def _write_manifest_with_mcp(project_root: Path) -> APMPackage:
+    (project_root / "packages" / "dep" / ".apm" / "instructions").mkdir(parents=True)
+    (project_root / "packages" / "dep" / "apm.yml").write_text(
+        'name: dep\nversion: "1.0.0"\n',
+        encoding="utf-8",
+    )
+    deployed_file = project_root / ".github" / "instructions" / "dep.instructions.md"
+    deployed_file.parent.mkdir(parents=True)
+    deployed_file.write_text(
+        '---\napplyTo: "**"\n---\n# Dep\n',
+        encoding="utf-8",
+    )
+    (project_root / "apm.yml").write_text(
+        """
+name: repro
+version: "1.0.0"
+dependencies:
+  apm:
+    - ./packages/dep
+  mcp:
+    - name: atlassian
+      registry: false
+      transport: http
+      url: https://mcp.atlassian.com/v1/mcp
+""".lstrip(),
+        encoding="utf-8",
+    )
+    clear_apm_yml_cache()
+    return APMPackage.from_apm_yml(project_root / "apm.yml")
+
+
+def _run_lockfile_phase_and_mcp_persist(
+    project_root: Path,
+    package: APMPackage,
+    instant: datetime,
+) -> None:
+    lock_path = get_lockfile_path(project_root)
+    dep_ref = package.get_apm_dependencies()[0]
+    ctx = InstallContext(
+        project_root=project_root,
+        apm_dir=project_root,
+        apm_package=package,
+        existing_lockfile=LockFile.read(lock_path),
+        logger=MagicMock(),
+        diagnostics=MagicMock(),
+    )
+    ctx.installed_packages = [
+        InstalledPackage(dep_ref=dep_ref, resolved_commit=None, depth=1, resolved_by=None)
+    ]
+    dep_key = dep_ref.get_unique_key()
+    ctx.package_deployed_files = {dep_key: [".github/instructions/dep.instructions.md"]}
+    ctx.package_types = {dep_key: "apm_package"}
+
+    _FixedDatetime.instant = instant
+    with (
+        patch("apm_cli.deps.lockfile.datetime", _FixedDatetime),
+        patch("apm_cli.integration.mcp_integrator.datetime", _FixedDatetime),
+    ):
+        LockfileBuilder(ctx).build_and_save()
+        mcp_deps = package.get_mcp_dependencies()
+        MCPIntegrator.update_lockfile(
+            MCPIntegrator.get_server_names(mcp_deps),
+            lock_path,
+            mcp_configs=MCPIntegrator.get_server_configs(mcp_deps),
+        )
+
+
+def test_unchanged_mcp_dependencies_do_not_rewrite_lockfile(tmp_path: Path) -> None:
+    """The real lockfile phase stays byte-stable when MCP inputs are unchanged."""
+    package = _write_manifest_with_mcp(tmp_path)
+    first_instant = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    second_instant = datetime(2026, 1, 1, 0, 1, 0, tzinfo=timezone.utc)
+
+    _run_lockfile_phase_and_mcp_persist(tmp_path, package, first_instant)
+    lock_path = get_lockfile_path(tmp_path)
+    first_bytes = lock_path.read_bytes()
+    first_lock = LockFile.read(lock_path)
+    assert first_lock is not None
+    assert first_lock.generated_at == first_instant.isoformat()
+
+    _run_lockfile_phase_and_mcp_persist(tmp_path, package, second_instant)
+    second_bytes = lock_path.read_bytes()
+    second_lock = LockFile.read(lock_path)
+    assert second_lock is not None
+
+    assert second_lock.generated_at == first_lock.generated_at
+    assert second_bytes == first_bytes

--- a/tests/unit/install/test_mcp_lockfile_determinism.py
+++ b/tests/unit/install/test_mcp_lockfile_determinism.py
@@ -24,30 +24,38 @@ class _FixedDatetime:
         return cls.instant.astimezone(tz)
 
 
-def _write_manifest_with_mcp(project_root: Path) -> APMPackage:
-    (project_root / "packages" / "dep" / ".apm" / "instructions").mkdir(parents=True)
+def _write_manifest_with_mcp(
+    project_root: Path,
+    *,
+    server_name: str = "atlassian",
+    server_url: str = "https://mcp.atlassian.com/v1/mcp",
+) -> APMPackage:
+    (project_root / "packages" / "dep" / ".apm" / "instructions").mkdir(
+        parents=True,
+        exist_ok=True,
+    )
     (project_root / "packages" / "dep" / "apm.yml").write_text(
         'name: dep\nversion: "1.0.0"\n',
         encoding="utf-8",
     )
     deployed_file = project_root / ".github" / "instructions" / "dep.instructions.md"
-    deployed_file.parent.mkdir(parents=True)
+    deployed_file.parent.mkdir(parents=True, exist_ok=True)
     deployed_file.write_text(
         '---\napplyTo: "**"\n---\n# Dep\n',
         encoding="utf-8",
     )
     (project_root / "apm.yml").write_text(
-        """
+        f"""
 name: repro
 version: "1.0.0"
 dependencies:
   apm:
     - ./packages/dep
   mcp:
-    - name: atlassian
+    - name: {server_name}
       registry: false
       transport: http
-      url: https://mcp.atlassian.com/v1/mcp
+      url: {server_url}
 """.lstrip(),
         encoding="utf-8",
     )
@@ -111,3 +119,39 @@ def test_unchanged_mcp_dependencies_do_not_rewrite_lockfile(tmp_path: Path) -> N
 
     assert second_lock.generated_at == first_lock.generated_at
     assert second_bytes == first_bytes
+
+
+def test_changed_mcp_dependencies_update_lockfile(tmp_path: Path) -> None:
+    """The no-write optimization still persists changed MCP inputs."""
+    package = _write_manifest_with_mcp(tmp_path)
+    first_instant = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    second_instant = datetime(2026, 1, 1, 0, 1, 0, tzinfo=timezone.utc)
+
+    _run_lockfile_phase_and_mcp_persist(tmp_path, package, first_instant)
+    lock_path = get_lockfile_path(tmp_path)
+    first_bytes = lock_path.read_bytes()
+    first_lock = LockFile.read(lock_path)
+    assert first_lock is not None
+    assert first_lock.mcp_servers == ["atlassian"]
+
+    changed_package = _write_manifest_with_mcp(
+        tmp_path,
+        server_name="github",
+        server_url="https://api.githubcopilot.com/mcp/",
+    )
+    _run_lockfile_phase_and_mcp_persist(tmp_path, changed_package, second_instant)
+    second_bytes = lock_path.read_bytes()
+    second_lock = LockFile.read(lock_path)
+    assert second_lock is not None
+
+    assert second_lock.generated_at == second_instant.isoformat()
+    assert second_lock.mcp_servers == ["github"]
+    assert second_lock.mcp_configs == {
+        "github": {
+            "name": "github",
+            "registry": False,
+            "transport": "http",
+            "url": "https://api.githubcopilot.com/mcp/",
+        }
+    }
+    assert second_bytes != first_bytes

--- a/tests/unit/test_mcp_integrator_overlay.py
+++ b/tests/unit/test_mcp_integrator_overlay.py
@@ -475,17 +475,17 @@ class TestUpdateLockfile:
         MCPIntegrator.update_lockfile({"server-a"}, lock_path=lock_path)
 
     def test_updates_mcp_servers_in_lockfile(self, tmp_path):
+        from apm_cli.deps.lockfile import LockFile
         from apm_cli.integration.mcp_integrator import MCPIntegrator
 
         lock_path = tmp_path / "apm.lock.yaml"
-        lock_path.write_text("lock_version: '1'\ndependencies: {}\n", encoding="utf-8")
+        LockFile().save(lock_path)
 
-        mock_lockfile = MagicMock()
-        with patch("apm_cli.deps.lockfile.LockFile.read", return_value=mock_lockfile):
-            MCPIntegrator.update_lockfile({"server-a", "server-b"}, lock_path=lock_path)
+        MCPIntegrator.update_lockfile({"server-a", "server-b"}, lock_path=lock_path)
 
-        assert mock_lockfile.mcp_servers == sorted({"server-a", "server-b"})
-        mock_lockfile.save.assert_called_once_with(lock_path)
+        lockfile = LockFile.read(lock_path)
+        assert lockfile is not None
+        assert lockfile.mcp_servers == sorted({"server-a", "server-b"})
 
     def test_noop_when_lockfile_read_returns_none(self, tmp_path):
         from apm_cli.integration.mcp_integrator import MCPIntegrator
@@ -498,16 +498,18 @@ class TestUpdateLockfile:
             MCPIntegrator.update_lockfile({"srv"}, lock_path=lock_path)
 
     def test_mcp_configs_written_when_provided(self, tmp_path):
+        from apm_cli.deps.lockfile import LockFile
         from apm_cli.integration.mcp_integrator import MCPIntegrator
 
         lock_path = tmp_path / "apm.lock.yaml"
-        lock_path.write_text("lock_version: '1'\n", encoding="utf-8")
+        LockFile().save(lock_path)
 
-        mock_lockfile = MagicMock()
         configs = {"srv": {"key": "val"}}
-        with patch("apm_cli.deps.lockfile.LockFile.read", return_value=mock_lockfile):
-            MCPIntegrator.update_lockfile({"srv"}, lock_path=lock_path, mcp_configs=configs)
-        assert mock_lockfile.mcp_configs == configs
+        MCPIntegrator.update_lockfile({"srv"}, lock_path=lock_path, mcp_configs=configs)
+
+        lockfile = LockFile.read(lock_path)
+        assert lockfile is not None
+        assert lockfile.mcp_configs == configs
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mcp_integrator_phase3w4.py
+++ b/tests/unit/test_mcp_integrator_phase3w4.py
@@ -475,17 +475,17 @@ class TestUpdateLockfile:
         MCPIntegrator.update_lockfile({"server-a"}, lock_path=lock_path)
 
     def test_updates_mcp_servers_in_lockfile(self, tmp_path):
+        from apm_cli.deps.lockfile import LockFile
         from apm_cli.integration.mcp_integrator import MCPIntegrator
 
         lock_path = tmp_path / "apm.lock.yaml"
-        lock_path.write_text("lock_version: '1'\ndependencies: {}\n", encoding="utf-8")
+        LockFile().save(lock_path)
 
-        mock_lockfile = MagicMock()
-        with patch("apm_cli.deps.lockfile.LockFile.read", return_value=mock_lockfile):
-            MCPIntegrator.update_lockfile({"server-a", "server-b"}, lock_path=lock_path)
+        MCPIntegrator.update_lockfile({"server-a", "server-b"}, lock_path=lock_path)
 
-        assert mock_lockfile.mcp_servers == sorted({"server-a", "server-b"})
-        mock_lockfile.save.assert_called_once_with(lock_path)
+        lockfile = LockFile.read(lock_path)
+        assert lockfile is not None
+        assert lockfile.mcp_servers == sorted({"server-a", "server-b"})
 
     def test_noop_when_lockfile_read_returns_none(self, tmp_path):
         from apm_cli.integration.mcp_integrator import MCPIntegrator
@@ -498,16 +498,18 @@ class TestUpdateLockfile:
             MCPIntegrator.update_lockfile({"srv"}, lock_path=lock_path)
 
     def test_mcp_configs_written_when_provided(self, tmp_path):
+        from apm_cli.deps.lockfile import LockFile
         from apm_cli.integration.mcp_integrator import MCPIntegrator
 
         lock_path = tmp_path / "apm.lock.yaml"
-        lock_path.write_text("lock_version: '1'\n", encoding="utf-8")
+        LockFile().save(lock_path)
 
-        mock_lockfile = MagicMock()
         configs = {"srv": {"key": "val"}}
-        with patch("apm_cli.deps.lockfile.LockFile.read", return_value=mock_lockfile):
-            MCPIntegrator.update_lockfile({"srv"}, lock_path=lock_path, mcp_configs=configs)
-        assert mock_lockfile.mcp_configs == configs
+        MCPIntegrator.update_lockfile({"srv"}, lock_path=lock_path, mcp_configs=configs)
+
+        lockfile = LockFile.read(lock_path)
+        assert lockfile is not None
+        assert lockfile.mcp_configs == configs
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Context

Fixes lockfile churn when an unchanged project has both APM and MCP dependencies. The APM lockfile phase now preserves existing MCP state before semantic comparison, and MCP lockfile persistence skips writes when the resulting lockfile is semantically unchanged.

## How to test

- Reproduced on HEAD with a local APM dependency plus self-defined MCP dependency: the second install changed only generated_at.
- Verified the same two-install scenario is byte-stable after the fix.
- uv run --locked --extra dev pytest tests/unit/install/test_mcp_lockfile_determinism.py -q
- uv run --locked --extra dev pytest tests/unit/install tests/unit/integration/test_mcp_integrator.py tests/test_lockfile.py -q
- uv run --locked --extra dev ruff check --quiet src/ tests/
- uv run --locked --extra dev ruff format --check --quiet src/ tests/

Mutation-break gate: removing the MCP preservation guard makes the regression test fail with generated_at changing from the first timestamp to the second.

Closes #1532