### PR TITLE
fix: install summary reflects actual changes on no-op runs (closes #1557)

### DIFF
--- a/src/apm_cli/core/command_logger.py
+++ b/src/apm_cli/core/command_logger.py
@@ -812,6 +812,11 @@ class InstallLogger(CommandLogger):
                 f"Installation failed with {errors} error(s){timing_suffix}.",
                 symbol="error",
             )
+        else:
+            _rich_info(
+                f"No changes -- install state already up to date{timing_suffix}.",
+                symbol="info",
+            )
 
     def install_interrupted(self, elapsed_seconds: float):
         """Log a minimal elapsed-time line when the normal summary did

--- a/src/apm_cli/install/phases/integrate.py
+++ b/src/apm_cli/install/phases/integrate.py
@@ -338,7 +338,7 @@ def _integrate_root_project(
             logger.verbose_detail(f"Deployed {_local_total} local primitive(s) from .apm/")
 
         return {
-            "installed": 1,
+            "installed": int(_local_total > 0),
             "prompts": _root_result["prompts"],
             "agents": _root_result["agents"],
             "skills": _root_result.get("skills", 0),

--- a/src/apm_cli/install/sources.py
+++ b/src/apm_cli/install/sources.py
@@ -413,7 +413,7 @@ class CachedDependencySource(DependencySource):
                 display_name, ref=_ref, sha=_sha, cached=not self.fetched_this_run
             )
 
-        deltas: dict[str, int] = {"installed": 1}
+        deltas: dict[str, int] = {"installed": int(self.fetched_this_run)}
         if not dep_ref.reference:
             deltas["unpinned"] = 1
 

--- a/src/apm_cli/install/template.py
+++ b/src/apm_cli/install/template.py
@@ -101,7 +101,7 @@ def _integrate_materialization(
             ),
             ctx=ctx,
         )
-        for k in (
+        mutation_keys = (
             "prompts",
             "agents",
             "skills",
@@ -109,9 +109,11 @@ def _integrate_materialization(
             "instructions",
             "commands",
             "hooks",
-            "links_resolved",
-        ):
+        )
+        for k in (*mutation_keys, "links_resolved"):
             deltas[k] = int_result[k]
+        if any(int_result[k] > 0 for k in mutation_keys):
+            deltas["installed"] = 1
         ctx.package_deployed_files[dep_key] = int_result["deployed_files"]
     except Exception as e:
         # Per-source error wording: each DependencySource subclass

--- a/src/apm_cli/install/template.py
+++ b/src/apm_cli/install/template.py
@@ -112,6 +112,7 @@ def _integrate_materialization(
         )
         for k in (*mutation_keys, "links_resolved"):
             deltas[k] = int_result[k]
+        # Source-level install deltas are promoted only when primitives changed.
         if any(int_result[k] > 0 for k in mutation_keys):
             deltas["installed"] = 1
         ctx.package_deployed_files[dep_key] = int_result["deployed_files"]

--- a/tests/unit/install/test_noop_summary.py
+++ b/tests/unit/install/test_noop_summary.py
@@ -1,0 +1,130 @@
+"""Regression coverage for no-op install summary rendering."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from apm_cli.cli import cli
+from apm_cli.models.apm_package import (
+    APMPackage,
+    GitReferenceType,
+    PackageInfo,
+    ResolvedReference,
+    clear_apm_yml_cache,
+)
+from apm_cli.models.dependency.reference import DependencyReference
+
+_PATCH_UPDATES = "apm_cli.commands._helpers.check_for_updates"
+
+
+class _StableDownloader:
+    """Downloader stub whose second install must be a cache/no-op path."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def download_package(
+        self,
+        repo_ref: object,
+        target_path: Path,
+        *args: Any,
+        **kwargs: Any,
+    ) -> PackageInfo:
+        self.calls += 1
+        dep_ref = (
+            repo_ref
+            if isinstance(repo_ref, DependencyReference)
+            else DependencyReference.parse(str(repo_ref))
+        )
+        target_path = Path(target_path)
+        target_path.mkdir(parents=True, exist_ok=True)
+        (target_path / "apm.yml").write_text(
+            yaml.safe_dump({"name": "fixture-pkg", "version": "1.0.0"}),
+            encoding="utf-8",
+        )
+        instructions_dir = target_path / ".apm" / "instructions"
+        instructions_dir.mkdir(parents=True, exist_ok=True)
+        (instructions_dir / "fixture.instructions.md").write_text(
+            "---\napplyTo: '**'\n---\n# Fixture\n",
+            encoding="utf-8",
+        )
+        package = APMPackage.from_apm_yml(target_path / "apm.yml")
+        return PackageInfo(
+            package=package,
+            install_path=target_path,
+            installed_at=datetime.now().isoformat(),
+            dependency_ref=dep_ref,
+            resolved_reference=ResolvedReference(
+                original_ref="v1.0.0",
+                ref_type=GitReferenceType.TAG,
+                resolved_commit="abc123",
+                ref_name="v1.0.0",
+            ),
+        )
+
+
+@pytest.fixture(autouse=True)
+def _clear_package_cache() -> None:
+    clear_apm_yml_cache()
+    yield
+    clear_apm_yml_cache()
+
+
+def _write_project(project: Path) -> None:
+    project.mkdir(parents=True, exist_ok=True)
+    (project / ".github").mkdir()
+    (project / ".github" / "copilot-instructions.md").write_text("# Project\n", encoding="utf-8")
+    (project / "apm.yml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "noop-summary",
+                "version": "1.0.0",
+                "target": "copilot",
+                "dependencies": {"apm": ["acme/fixture-pkg#v1.0.0"], "mcp": []},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _run_install(runner: CliRunner, project: Path, monkeypatch: pytest.MonkeyPatch) -> object:
+    monkeypatch.chdir(project)
+    with patch(_PATCH_UPDATES, return_value=None):
+        return runner.invoke(cli, ["install"], catch_exceptions=False)
+
+
+def test_second_noop_install_reports_no_changes_in_summary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cache/no-op reinstall must not claim a dependency was installed."""
+    project = tmp_path / "project"
+    _write_project(project)
+    downloader = _StableDownloader()
+
+    from apm_cli.deps import github_downloader as _ghd
+
+    monkeypatch.setattr(
+        _ghd.GitHubPackageDownloader,
+        "download_package",
+        downloader.download_package,
+    )
+    runner = CliRunner()
+
+    first = _run_install(runner, project, monkeypatch)
+    assert first.exit_code == 0, first.output
+    assert downloader.calls == 1
+
+    second = _run_install(runner, project, monkeypatch)
+    assert second.exit_code == 0, second.output
+    assert downloader.calls == 1
+    assert "(files unchanged)" in second.output
+    assert "Installed 1 APM dependency" not in second.output
+    assert "No changes" in second.output


### PR DESCRIPTION
# fix(install): report no-op installs as unchanged

## TL;DR

This PR makes the final `apm install` summary reflect actual file mutations instead of cached dependency visits. A second install with identical deployed files now reports `No changes -- install state already up to date` rather than `Installed 1 APM dependency`. This closes #1557 and preserves the named-package `--update` selection surface by limiting the change to install-summary counters and rendering.

> [!NOTE]
> Closes #1557. The regression test exercises the observable CLI summary, not an internal counter.

## Problem (WHY)

- [x] A no-op reinstall printed `(files unchanged)` in the package detail but still ended with `Installed 1 APM dependency`, which contradicted the observable work performed.
- [x] Cached package materialization counted as installed even when no primitives were written, so the headline measured integration passes rather than mutations.
- [!] The misleading headline weakens the DevX promise that install output should be trustworthy and scannable.

Why this matters: this is a CLI-output trust bug. The project skill guidance says, "Before reporting changes, check if anything actually changed. Don't report no-ops." The user-facing regression in #1557 was exactly that mismatch.

## Approach (WHAT)

| # | Fix |
|---|-----|
| 1 | Treat cached dependencies as installed only when they were fetched in this run or when integration writes actual primitives. |
| 2 | Treat root `.apm/` integration as installed only when local primitives were deployed. |
| 3 | Add a zero-change final summary path that says the install state is already up to date. |
| 4 | Add an end-to-end observable CLI regression test for the second no-op install. |

## Implementation (HOW)

| File | Intent |
|---|---|
| `src/apm_cli/install/sources.py` | Cached sources now seed `installed` from `fetched_this_run`, avoiding false positives when the package was only reused from cache. |
| `src/apm_cli/install/template.py` | The integration template promotes a dependency to `installed` only when primitive counters show actual file writes. |
| `src/apm_cli/install/phases/integrate.py` | Root project primitive integration now contributes to the installed count only when local content changed. |
| `src/apm_cli/core/command_logger.py` | `InstallLogger.install_summary()` renders an explicit no-change summary when APM, MCP, and error counts are all zero. |
| `tests/unit/install/test_noop_summary.py` | Adds a regression-trap CLI test that installs once, reinstalls without mutation, and asserts the rendered second summary is no-op text. |

## Diagrams

Legend: the changed path is the cached reinstall branch; the new summary depends on primitive mutation counts instead of dependency traversal.

```mermaid
flowchart LR
    subgraph Acquire[Acquire]
        A1[CachedDependencySource]
        A2[fetched_this_run flag]
    end
    subgraph Integrate[Integrate]
        I1[run_integration_template]
        I2[primitive mutation counters]
    end
    subgraph Render[Render]
        R1[InstallLogger.install_summary]
        R2[No changes summary]
    end
    A1 --> A2
    A2 --> I1
    I1 --> I2
    I2 --> R1
    R1 --> R2
    classDef new stroke-dasharray: 5 5;
    class A2,I2,R2 new;
```

## Trade-offs

- **Counter semantics over contract expansion.** Chose to reuse the existing `installed` delta field; rejected a new result contract to avoid coupling with concurrent install work.
- **No-op wording is generic.** Chose `No changes -- install state already up to date`; rejected dependency-count wording because the current summary API does not receive the verified dependency total.
- **Unit-level end-to-end coverage.** Chose a hermetic `CliRunner` test with a downloader stub; rejected a live GitHub dependency because tests must avoid network calls.

## Benefits

1. A no-op second install no longer emits `Installed 1 APM dependency`.
2. The package detail `(files unchanged)` and final summary now agree.
3. The regression trap fails if cached source counting is reverted to per-dependency traversal.
4. Existing install summary, command logger, and install unit suites remain green.

## Validation

Mutation-break gate:

```text
$ uv run --locked --extra dev pytest tests/unit/install/test_noop_summary.py -x
FAILED tests/unit/install/test_noop_summary.py::test_second_noop_install_reports_no_changes_in_summary
AssertionError: assert 'Installed 1 APM dependency' not in ...
```

After restore:

```text
$ uv run --locked --extra dev pytest tests/unit/install/test_noop_summary.py -x
1 passed in 3.15s
```

<details><summary>Relevant suite and lint output</summary>

```text
$ uv run --locked --extra dev pytest tests/unit/install tests/unit/test_install_command.py -x
1587 passed in 14.79s

$ uv run --locked --extra dev ruff check --quiet src/ tests/

$ uv run --locked --extra dev ruff format --check --quiet src/ tests/

$ uv run --locked --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ bash scripts/lint-auth-signals.sh
[*] Rule A: get_bearer_provider boundary (any reference)
[*] Rule B: git ls-remote auth-delegated annotation
[+] auth-signal lint clean
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|------------------------|--------------|--------------------|------|
| 1 | Run `apm install` twice with no second-run file mutations; the second summary reports no changes instead of a fresh install | DevX (pragmatic as npm) | `tests/unit/install/test_noop_summary.py::test_second_noop_install_reports_no_changes_in_summary` (regression-trap for #1557) | unit |

## How to test

- [ ] Run `uv run --locked --extra dev pytest tests/unit/install/test_noop_summary.py -x` and observe the regression test pass.
- [ ] Run `uv run --locked --extra dev pytest tests/unit/install tests/unit/test_install_command.py -x` and observe the install unit suites pass.
- [ ] Run `uv run --locked --extra dev ruff check --quiet src/ tests/` and observe no output.
- [ ] Run `uv run --locked --extra dev ruff format --check --quiet src/ tests/` and observe no output.
- [ ] Run `bash scripts/lint-auth-signals.sh` and observe `[+] auth-signal lint clean`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
