### PR TITLE
fix: deploy prompts for user-scope copilot installs (closes #1482)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   
 ### Fixed
 
+- `apm install -g --target copilot` now deploys prompt primitives to `~/.copilot/prompts/` while continuing to filter unsupported user-scope instructions. (closes #1482, #1570)
 - Linux standalone `apm` binaries no longer fail git shared-cache clones with shared-library symbol lookup errors caused by PyInstaller dynamic-library paths leaking into child processes. (closes #1534)
 - Avoid 13-minute `apm install` hangs in large local projects by limiting synthetic `_local` discovery to `.apm/` and `.github/`, while preserving package metadata discovery. (closes #1507) -- by @ioannispoulios
 - `apm install -g <package>#<ref>` now updates an existing unpinned global dependency entry instead of leaving the manifest floating. (#1559)

--- a/docs/src/content/docs/reference/targets-matrix.md
+++ b/docs/src/content/docs/reference/targets-matrix.md
@@ -80,7 +80,7 @@ GitHub Copilot (CLI and IDE).
   - skills: `.agents/skills/<name>/SKILL.md`
   - hooks: `.github/hooks/<name>.json`
   - generated: `.github/copilot-instructions.md` (compile output)
-- **User scope.** Partial. `prompts` and `instructions` are not supported at user scope; user-scope deploys land under `~/.copilot/`, not `~/.github/`.
+- **User scope.** Partial. `prompts` deploy under `~/.copilot/prompts/`; `instructions` are not supported at user scope. User-scope deploys land under `~/.copilot/`, not `~/.github/`.
 
 ## claude
 

--- a/src/apm_cli/integration/prompt_integrator.py
+++ b/src/apm_cli/integration/prompt_integrator.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 class PromptIntegrator(BaseIntegrator):
-    """Handles integration of APM package prompts into .github/prompts/."""
+    """Handles integration of APM package prompts into target prompt directories."""
 
     def find_prompt_files(self, package_path: Path) -> list[Path]:
         """Find all .prompt.md files in a package.
@@ -116,6 +116,7 @@ class PromptIntegrator(BaseIntegrator):
             force=force,
             managed_files=managed_files,
             diagnostics=diagnostics,
+            target=target,
         )
 
     def sync_for_target(
@@ -215,8 +216,9 @@ class PromptIntegrator(BaseIntegrator):
         managed_files: set = None,  # noqa: RUF013
         diagnostics=None,
         logger=None,
+        target: TargetProfile | None = None,
     ) -> IntegrationResult:
-        """Integrate all prompts from a package into .github/prompts/.
+        """Integrate all prompts from a package into the target prompts directory.
 
         Deploys with clean filenames. Skips files that exist locally and
         are not tracked in any package's deployed_files (user-authored),
@@ -227,11 +229,20 @@ class PromptIntegrator(BaseIntegrator):
             project_root: Root directory of the project
             force: If True, overwrite user-authored files on collision
             managed_files: Set of relative paths known to be APM-managed
+            target: Target profile that determines the prompt deploy directory.
 
         Returns:
             IntegrationResult: Results of the integration operation
         """
         self.init_link_resolver(package_info, project_root)
+
+        if target is None:
+            from apm_cli.integration.targets import KNOWN_TARGETS
+
+            target = KNOWN_TARGETS["copilot"]
+        mapping = target.primitives.get("prompts")
+        if mapping is None:
+            return IntegrationResult(0, 0, 0, [])
 
         # Find all prompt files in the package
         prompt_files = self.find_prompt_files(package_info.install_path)
@@ -244,8 +255,8 @@ class PromptIntegrator(BaseIntegrator):
                 target_paths=[],
             )
 
-        # Create .github/prompts/ if it doesn't exist
-        prompts_dir = project_root / ".github" / "prompts"
+        effective_root = mapping.deploy_root or target.root_dir
+        prompts_dir = project_root / effective_root / mapping.subdir
         prompts_dir.mkdir(parents=True, exist_ok=True)
 
         # Process each prompt file
@@ -261,7 +272,7 @@ class PromptIntegrator(BaseIntegrator):
             # Skip workflow-shape prompts at file-based targets: an
             # author who added execution metadata (interval, mode, ...)
             # meant the Copilot App workflows table, NOT a slash command
-            # in .github/prompts/.  Without this guard, the same source
+            # in a file-based prompt directory.  Without this guard, the same source
             # file ships to both surfaces and the App-only metadata
             # leaks into a slash-command users would not expect.
             try:

--- a/src/apm_cli/integration/targets.py
+++ b/src/apm_cli/integration/targets.py
@@ -93,8 +93,7 @@ class TargetProfile:
 
     unsupported_user_primitives: tuple[str, ...] = ()
     """Primitives that are **not** available at user scope even when the
-    target itself is partially supported (e.g. Copilot CLI cannot deploy
-    prompts at user scope)."""
+    target itself is partially supported."""
 
     user_root_resolver: Callable[[], Path | None] | None = None  # noqa: F821
     """Optional callable that resolves the deploy root at runtime.
@@ -368,7 +367,7 @@ RUNTIME_TO_CANONICAL_TARGET: dict[str, str] = {
 
 KNOWN_TARGETS: dict[str, TargetProfile] = {
     # Copilot (GitHub) -- at user scope, Copilot CLI reads ~/.copilot/
-    # instead of ~/.github/.  Prompts and instructions are not supported at user scope.
+    # instead of ~/.github/.  Instructions are not supported at user scope.
     # Ref: https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/create-custom-agents-for-cli
     "copilot": TargetProfile(
         name="copilot",
@@ -391,7 +390,7 @@ KNOWN_TARGETS: dict[str, TargetProfile] = {
         detect_by_dir=True,
         user_supported="partial",
         user_root_dir=".copilot",
-        unsupported_user_primitives=("prompts", "instructions"),
+        unsupported_user_primitives=("instructions",),
         generated_files=("copilot-instructions.md",),
         compile_family="vscode",
     ),

--- a/tests/unit/core/test_scope.py
+++ b/tests/unit/core/test_scope.py
@@ -201,7 +201,6 @@ class TestTargetProfileUserScope:
         assert KNOWN_TARGETS["claude"].user_root_dir is None
 
     def test_copilot_unsupported_user_primitives(self):
-        assert "prompts" in KNOWN_TARGETS["copilot"].unsupported_user_primitives
         assert "instructions" in KNOWN_TARGETS["copilot"].unsupported_user_primitives
 
     def test_effective_root_project_scope(self):
@@ -218,9 +217,9 @@ class TestTargetProfileUserScope:
         assert KNOWN_TARGETS["claude"].supports_at_user_scope("commands") is True
 
     def test_supports_at_user_scope_partial(self):
-        # Copilot supports agents at user scope but not prompts or instructions
+        # Copilot supports agents and prompts at user scope but not instructions.
         assert KNOWN_TARGETS["copilot"].supports_at_user_scope("agents") is True
-        assert KNOWN_TARGETS["copilot"].supports_at_user_scope("prompts") is False
+        assert KNOWN_TARGETS["copilot"].supports_at_user_scope("prompts") is True
         assert KNOWN_TARGETS["copilot"].supports_at_user_scope("instructions") is False
 
     def test_supports_at_user_scope_cursor_partial(self):
@@ -295,8 +294,8 @@ class TestScopeWarnings:
 
     def test_warn_message_includes_unsupported_primitives(self):
         msg = warn_unsupported_user_scope()
-        # Copilot excludes prompts and instructions
-        assert "copilot (prompts, instructions)" in msg
+        # Copilot excludes instructions.
+        assert "copilot (instructions)" in msg
         # Cursor excludes instructions
         assert "cursor (instructions)" in msg
         # OpenCode excludes hooks

--- a/tests/unit/integration/test_data_driven_dispatch.py
+++ b/tests/unit/integration/test_data_driven_dispatch.py
@@ -731,14 +731,14 @@ class TestForScope:
         assert resolved.root_dir == ".claude"
 
     def test_filters_unsupported_primitives(self):
-        """for_scope removes unsupported primitives from the dict."""
+        """for_scope removes only unsupported primitives from the dict."""
         from apm_cli.integration.targets import KNOWN_TARGETS
 
         copilot = KNOWN_TARGETS["copilot"]
         assert "prompts" in copilot.primitives
         assert "instructions" in copilot.primitives
         resolved = copilot.for_scope(user_scope=True)
-        assert "prompts" not in resolved.primitives
+        assert "prompts" in resolved.primitives
         assert "instructions" not in resolved.primitives
         # Supported primitives remain
         assert "agents" in resolved.primitives

--- a/tests/unit/integration/test_scope_install_uninstall.py
+++ b/tests/unit/integration/test_scope_install_uninstall.py
@@ -203,13 +203,11 @@ class TestCopilotInstallUninstallCycle:
             assert not (self.project_root / p).exists(), f"not removed: {p}"
 
     def test_user_scope(self):
-        """At user scope, agents deploy to .copilot/; instructions filtered."""
+        """At user scope, agents and prompts deploy to .copilot/; instructions filtered."""
         target = KNOWN_TARGETS["copilot"].for_scope(user_scope=True)
         assert target is not None
         assert target.root_dir == ".copilot"
-        # instructions and prompts filtered out at user scope
         assert "instructions" not in target.primitives
-        assert "prompts" not in target.primitives
 
         pkg_info = _make_pkg(self.project_root, instructions=True, agents=True, prompts=True)
 
@@ -231,23 +229,31 @@ class TestCopilotInstallUninstallCycle:
 
         assert agent_result.files_integrated >= 1
         assert inst_result.files_integrated == 0
-        assert prompt_result.files_integrated == 0
+        assert prompt_result.files_integrated >= 1
 
-        deployed = _posix_relpaths(self.project_root, agent_result.target_paths)
+        all_paths = agent_result.target_paths + prompt_result.target_paths
+        deployed = _posix_relpaths(self.project_root, all_paths)
         assert any(p.startswith(".copilot/agents/") for p in deployed)
+        assert any(p == ".copilot/prompts/helper.prompt.md" for p in deployed)
 
         for p in deployed:
             assert (self.project_root / p).exists()
+
+        assert (self.project_root / ".copilot" / "prompts" / "helper.prompt.md").exists()
 
         # .github/ must NOT be touched
         assert not (self.project_root / ".github").exists()
 
         # -- uninstall -----------------------------------------------------
-        sync = agent_integrator.sync_for_target(
+        agent_sync = agent_integrator.sync_for_target(
             target, pkg_info.package, self.project_root, managed_files=deployed
         )
-        assert sync["errors"] == 0
-        assert sync["files_removed"] == len(deployed)
+        prompt_sync = prompt_integrator.sync_for_target(
+            target, pkg_info.package, self.project_root, managed_files=deployed
+        )
+        assert agent_sync["errors"] == 0
+        assert prompt_sync["errors"] == 0
+        assert agent_sync["files_removed"] + prompt_sync["files_removed"] == len(deployed)
         for p in deployed:
             assert not (self.project_root / p).exists()
 

--- a/tests/unit/integration/test_scope_integration.py
+++ b/tests/unit/integration/test_scope_integration.py
@@ -316,7 +316,7 @@ class TestResolveTargetsConsistency:
             targets = resolve_targets(Path(tmp), user_scope=True, explicit_target="all")
             for t in targets:
                 if t.name == "copilot":
-                    assert "prompts" not in t.primitives
+                    assert "prompts" in t.primitives
                     assert "instructions" not in t.primitives
                 if t.name == "cursor":
                     assert "instructions" not in t.primitives


### PR DESCRIPTION
# fix(copilot): deploy user-scope prompts

## TL;DR

This fixes #1482 by allowing Copilot user-scope installs to keep prompt primitives and deploy them under `.copilot/prompts/`. Instructions remain filtered at user scope because #1485 is out of scope. Regression coverage now checks deployed behavior instead of only inspecting target metadata.

> [!NOTE]
> The mutation break was verified: re-adding `prompts` to Copilot's unsupported user primitives makes the new regression test fail.

## Problem (WHY)

- [x] Issue #1482 reports that `apm install -g` for Copilot silently drops prompt primitives.
- [x] Copilot's user-scope target filtered both `prompts` and `instructions`, so prompt integration saw no prompt mapping and returned zero deployed files.
- [x] Existing tests encoded the old wrong behavior by asserting prompts were absent at user scope.
- [!] Docs also said Copilot user-scope prompts were unsupported, which would keep the drift alive after the code fix.

## Approach (WHAT)

| # | Fix |
|---|-----|
| 1 | Remove only `prompts` from Copilot's user-scope unsupported primitive list. |
| 2 | Route prompt integration through the active target mapping so user-scope Copilot writes `.copilot/prompts/` while project scope still writes `.github/prompts/`. |
| 3 | Update stale tests and docs to keep `instructions` out of scope while making prompt deployment observable. |

## Implementation (HOW)

- **`src/apm_cli/integration/targets.py`** - Keeps `instructions` unsupported at Copilot user scope, but no longer filters `prompts`.
- **`src/apm_cli/integration/prompt_integrator.py`** - Passes the active target into prompt deployment and derives the prompt directory from `mapping.deploy_root or target.root_dir` plus `mapping.subdir`.
- **`tests/unit/integration/test_scope_install_uninstall.py`** - Adds the regression trap: a user-scope Copilot install with a prompt now must deploy `.copilot/prompts/helper.prompt.md` and leave `.github/` untouched.
- **`tests/unit/core/test_scope.py`, `tests/unit/integration/test_data_driven_dispatch.py`, `tests/unit/integration/test_scope_integration.py`** - Updates stale expectations that asserted the old prompt filter.
- **`docs/src/content/docs/reference/targets-matrix.md`** - Documents that Copilot user-scope prompts deploy under `~/.copilot/prompts/`; user-scope instructions remain unsupported.

## Diagrams

Legend: the highlighted nodes show the new path that keeps prompt primitives during user-scope resolution and writes them under `.copilot/prompts/`.

```mermaid
flowchart LR
    subgraph Scope[User scope resolution]
        T[KNOWN_TARGETS copilot]
        F[for_scope user_scope true]:::new
    end
    subgraph Deploy[Prompt deployment]
        P[PromptIntegrator]
        D[.copilot prompts]:::new
    end
    T --> F
    F -->|"keeps prompts"| P
    P --> D
    classDef new stroke-dasharray: 5 5;
    class F,D new;
```

## Trade-offs

- **Prompts only.** Chose to fix prompt deployment; rejected changing `instructions` because the linked #1485 scenario is explicitly out of scope.
- **Target-aware prompt integration.** Chose to derive prompt paths from the existing target mapping; rejected hard-coding `.copilot/prompts/` in the integrator so project-scope Copilot and other callers keep their existing behavior.
- **Behavior regression test.** Chose to assert an actual deployed prompt file; rejected tuple-only coverage because it would not prove install behavior.

## Benefits

1. `apm install -g --target copilot` can now deploy prompt files to the documented user-scope Copilot prompt directory.
2. The regression test fails if `prompts` is re-added to Copilot's unsupported user primitives.
3. Existing scope and warning tests now describe the corrected support matrix.
4. The docs matrix no longer tells users that Copilot user-scope prompts are unsupported.

## Validation

`uv run --locked --extra dev pytest tests/unit/integration/test_scope_install_uninstall.py tests/unit/core/test_scope.py tests/unit/integration/test_data_driven_dispatch.py tests/unit/integration/test_prompt_integrator.py tests/unit/integration/test_scope_integration.py -q`:

```
164 passed in 1.06s
```

`uv run --locked --extra dev ruff check src/ tests/ && uv run --locked --extra dev ruff format --check src/ tests/`:

```
All checks passed!
1154 files already formatted
```

Mutation break:

```
FAILED tests/unit/integration/test_scope_install_uninstall.py::TestCopilotInstallUninstallCycle::test_user_scope
E       assert 0 >= 1
```

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|--------------------------|--------------|--------------------|------|
| 1 | `apm install -g --target copilot` deploys package prompts to the user Copilot prompt directory | Multi-harness support, DevX (pragmatic as npm) | `tests/unit/integration/test_scope_install_uninstall.py::TestCopilotInstallUninstallCycle::test_user_scope` (regression-trap for #1482) | integration |
| 2 | User-scope Copilot still filters instructions while keeping supported primitives | Multi-harness support | `tests/unit/core/test_scope.py::TestTargetProfileUserScope::test_supports_at_user_scope_partial` | unit |

## How to test

- [ ] Install this branch and run a user-scope Copilot install from a package that contains `.apm/prompts/*.prompt.md`.
- [ ] Confirm the prompt appears under `~/.copilot/prompts/`.
- [ ] Confirm `~/.github/` is not created for that user-scope prompt deployment.
- [ ] Re-run the targeted pytest command above.

Closes #1482

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
