### PR TITLE
chore: release v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-06-01
+
+### Added
+
+- `apm doctor` is now a top-level command (promoted from `marketplace doctor`) that diagnoses environment problems such as runtime setup, PATH wiring, and configuration, so users can health-check an install without remembering the `marketplace` namespace. (#1539)
+
+### Fixed
+
+- `apm install -g --target copilot` now deploys prompt primitives to `~/.copilot/prompts/` while continuing to filter unsupported user-scope instructions. (closes #1482, #1570)
+- Linux standalone `apm` binaries no longer fail git shared-cache clones with shared-library symbol lookup errors caused by PyInstaller dynamic-library paths leaking into child processes. (closes #1534)
+- Avoid 13-minute `apm install` hangs in large local projects by limiting synthetic `_local` discovery to `.apm/` and `.github/`, while preserving package metadata discovery. (closes #1507) -- by @ioannispoulios
+- `apm install -g <package>#<ref>` now updates an existing unpinned global dependency entry instead of leaving the manifest floating. (#1559)
+- `apm install` no longer rewrites `apm.lock.yaml` when MCP dependencies are unchanged, keeping no-op installs byte-stable. (#1568)
+- `apm install` now honors manifest `targets:` without falling back to the legacy Copilot target when singular `target:` is absent. (#1560)
+- `apm install` now preserves executable permission bits when materializing package files through the reflink copy fast path and Artifactory ZIP extraction, so installed executables stay runnable. (closes #1563, #1566)
+- `apm install` summary now reflects actual file mutations: a re-install with identical deployed files reports `No changes -- install state already up to date` instead of falsely claiming `Installed 1 APM dependency`. (closes #1557, #1569)
+- `apm install --update <pkg>` no longer falls through to all manifest dependencies when the positional request already validates as present; lockfile serialization also de-duplicates `deployed_files` paths. (closes #1558, #1567)
+- `apm install` no longer fails on a second run with a false-positive `Content hash mismatch ... supply-chain attack` error for unpinned git or virtual-file dependencies; the redundant re-download is skipped when the on-disk hash matches the lockfile. (closes #1548, #1553)
+- `apm uninstall <pkg>` now scans `devDependencies.apm`, so packages added with `apm install --dev` can be removed instead of leaking in `apm.yml`. (closes #1549, #1552)
+
+### Performance
+
+- `apm install` is substantially faster on large projects and monorepos: primitive discovery is memoized across (integrator, target) pairs, the per-file `Path.resolve()` call is dropped, and skipped directories are expanded (up to 30-40x faster in the worst cases). (closes #1533, #1538)
+
 ### Documentation
 
 - Surface the `compilation.strategy: distributed` default in the
@@ -16,15 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compiled context files land" section to the primitives-and-targets
   page and a distributed-layout example in the compile reference.
   Default behavior is unchanged. (closes #1447) -- by @tillig
-  
-### Fixed
-
-- `apm install -g --target copilot` now deploys prompt primitives to `~/.copilot/prompts/` while continuing to filter unsupported user-scope instructions. (closes #1482, #1570)
-- Linux standalone `apm` binaries no longer fail git shared-cache clones with shared-library symbol lookup errors caused by PyInstaller dynamic-library paths leaking into child processes. (closes #1534)
-- Avoid 13-minute `apm install` hangs in large local projects by limiting synthetic `_local` discovery to `.apm/` and `.github/`, while preserving package metadata discovery. (closes #1507) -- by @ioannispoulios
-- `apm install -g <package>#<ref>` now updates an existing unpinned global dependency entry instead of leaving the manifest floating. (#1559)
-- `apm install` no longer rewrites `apm.lock.yaml` when MCP dependencies are unchanged, keeping no-op installs byte-stable. (#1568)
-- `apm install` now honors manifest `targets:` without falling back to the legacy Copilot target when singular `target:` is absent. (#1560)
 
 ## [0.16.0] - 2026-05-28
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apm-cli"
-version = "0.16.0"
+version = "0.16.1"
 description = "MCP configuration tool"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -358,9 +358,12 @@ run_e2e_tests() {
     log_info "Invoking pytest tests/integration/ (marker registry handles per-test gating)"
     # Allow CI to pass extra pytest args (sharding, xdist) via the
     # PYTEST_EXTRA_ARGS env var. Empty by default for local runs.
+    # The ${arr[@]+"${arr[@]}"} guard keeps an empty array expansion safe
+    # under `set -u` on bash 3.2 (the default /bin/bash on macOS), where a
+    # bare "${arr[@]}" on an empty array raises an unbound-variable error.
     # shellcheck disable=SC2206
     extra_args=(${PYTEST_EXTRA_ARGS:-})
-    if pytest tests/integration/ -v --tb=short "${extra_args[@]}"; then
+    if pytest tests/integration/ -v --tb=short ${extra_args[@]+"${extra_args[@]}"}; then
         log_success "Integration test suite passed (collected and ran via pytest discovery)"
     else
         log_error "Integration test suite reported failures"

--- a/tests/unit/test_download_strategies.py
+++ b/tests/unit/test_download_strategies.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import io
 import os
 import stat
+import sys
 import zipfile
 from types import SimpleNamespace
 from unittest.mock import patch
+
+import pytest
 
 from apm_cli.deps.download_strategies import DownloadDelegate
 
@@ -26,6 +29,10 @@ def _zip_with_executable_script() -> bytes:
     return buf.getvalue()
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows does not honor POSIX execute bits; st_mode & 0o111 is not preserved",
+)
 def test_artifactory_archive_preserves_executable_bits(tmp_path):
     response = SimpleNamespace(status_code=200, content=_zip_with_executable_script())
     host = SimpleNamespace(registry_config=None, artifactory_token=None)

--- a/tests/unit/test_file_ops.py
+++ b/tests/unit/test_file_ops.py
@@ -4,7 +4,7 @@ import errno
 import os
 import shutil
 import stat
-import sys  # noqa: F401
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -245,6 +245,10 @@ class TestRetryOnLock:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows does not honor POSIX execute bits; st_mode & 0o111 is not preserved",
+)
 def test_robust_copy2_preserves_executable_bits_on_reflink_fast_path(tmp_path):
     src = tmp_path / "source.sh"
     dst = tmp_path / "dest.sh"

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,7 @@ wheels = [
 
 [[package]]
 name = "apm-cli"
-version = "0.16.0"
+version = "0.16.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Cut release v0.16.1.

- Bump `pyproject.toml` to 0.16.1 (and `uv.lock`).
- Move `[Unreleased]` to `[0.16.1] - 2026-06-01` in `CHANGELOG.md`, with one short "so what?" entry per user-facing PR merged since v0.16.0.

This branch also carries two test-infra fixes that unblock CI and local integration runs (see commits below); they are internal and intentionally carry no CHANGELOG entry per the release entry-sanitizer.

## What's in this release

Enumerated every PR merged since `v0.16.0` (2026-05-28) and folded the user-facing ones into the changelog. The prior `[Unreleased]` block was stale -- it was missing 8 merged user-facing PRs, now added:

### Added
- `apm doctor` top-level command, promoted from `marketplace doctor` (#1539)

### Fixed
- executable permission bits preserved on install (#1566)
- install summary reports no-op runs as unchanged (#1569)
- `--update <pkg>` scoping + lockfile `deployed_files` de-dup (#1567)
- false-positive content-hash "supply-chain attack" on unpinned virtual deps (#1553)
- `apm uninstall` can remove `--dev` installs (#1552)

### Performance
- `apm install` discovery memoized; up to 30-40x faster on large repos (#1538)

Dropped as internal per the entry-sanitizer DROP list: #1545 (panel workflows), #1531 (docs housekeeping / sidebar IA), #1527 (cut-release skill). #1554 (#1507) and #1536 (#1534) were already represented.

## Why PATCH (0.16.1), not MINOR (0.17.0)

Full transparency for the reviewer before tagging: the semver-rubric's Row 2 ("ANY PR added a NEW user-visible CLI command -> MINOR") is technically tripped by #1539, which would mechanically point at 0.17.0.

It is shipped here as a PATCH (0.16.1) for two reasons:

1. The operator explicitly requested v0.16.1 for this cut.
2. `apm doctor` is a *promotion/alias* of the pre-existing `marketplace doctor` subcommand -- a new invocation surface over functionality that already shipped, not net-new capability. No behavior changed; nothing broke.

Every other merged PR in the window is a fix, a perf improvement, or internal. If a maintainer considers the new command surface minor-worthy, retarget to 0.17.0 before tagging -- the bump is the only thing that changes.

## Validation

- Lint mirror green locally (ruff check + format, pylint R0801, auth-signals). See `.apm/instructions/linting.instructions.md`.
- Windows-only unit failures fixed by skipping POSIX execute-bit assertions on `win32` (the original CI breakage this branch started from). Integration suite validated locally under CI-equivalent (warm-cache) conditions: 9208 passed.

## Post-merge

Tag `v0.16.1` to trigger the release workflow (do NOT tag before merge):

```
git tag v0.16.1
git push origin v0.16.1
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>