### PR TITLE
feat: make apm update a superset of apm deps update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one-directional (APM only reads vendor SARIF), and are install-method
   neutral -- they work with the self-contained APM binary with no `pip`
   extra to install.
+- `apm update` now accepts `-g/--global`, positional `[PACKAGES]...`, `--force`, and `--parallel-downloads`, making it a strict superset of `apm deps update`. A single verb now covers project and user scope, per-package refresh, and collision overwrite -- all behind the same interactive plan with `--dry-run`/`--yes`. (closes #1525)
+
+### Deprecated
+
+- `apm deps update` is deprecated in favor of `apm update`, which now exposes every flag it had. It prints a one-line banner pointing to `apm update` and keeps working for one release; it will be removed in the next breaking release. (closes #1525)
+
 ### Fixed
 
 - `apm pack --check-clean` now emits a copy-pasteable recovery recipe when `marketplace.json` drifts from source: `git commit --amend --no-edit` + `git push --force-with-lease` to fold the diff into the current commit, or a follow-up commit variant. Producers get the right command at the point of failure without consulting external docs. (closes #1381)

--- a/docs/src/content/docs/consumer/update-and-refresh.mdx
+++ b/docs/src/content/docs/consumer/update-and-refresh.mdx
@@ -26,15 +26,22 @@ apm update
 
 Re-resolves every dependency in `apm.yml` to its latest matching Git
 reference, prints the planned changes, and prompts for consent before
-rewriting `apm.lock.yaml` and redeploying primitives.
+rewriting `apm.lock.yaml` and redeploying primitives. Pass one or more
+package names (`apm update org/pkg-a org/pkg-b`) to refresh only those.
 
 Useful flags:
 
 - `--dry-run` -- show the resolution plan and exit; never writes.
 - `--yes` -- skip the consent prompt (for scripts and CI).
 - `-v, --verbose` -- show per-dependency resolution detail.
+- `-g, --global` -- refresh user-scope dependencies under `~/.apm/`
+  instead of the current project (pairs with `apm outdated -g`).
+- `--force` -- overwrite locally-authored files on collision.
+- `--parallel-downloads N` -- cap concurrent downloads (default 4;
+  `0` disables parallelism).
 
-This is the command that actually changes versions in your project.
+This is the command that actually changes versions in your project. It
+is a strict superset of the deprecated `apm deps update`.
 
 ## Inspect first
 

--- a/docs/src/content/docs/reference/cli/deps.md
+++ b/docs/src/content/docs/reference/cli/deps.md
@@ -89,6 +89,10 @@ Exit codes: `0` on success, `1` when the package is not installed or the query m
 
 ### `apm deps update`
 
+:::caution[Deprecated]
+`apm deps update` is deprecated in favor of [`apm update`](../update/), which is now a strict superset: it supports `-g/--global`, `[PACKAGES...]`, `--force`, and `--parallel-downloads`, plus an interactive plan, `--dry-run`, and `--yes`. `apm deps update` keeps working for one release and is removed in the next breaking release.
+:::
+
 Re-resolve git references for installed dependencies (direct and transitive), download updated content, re-integrate primitives, and regenerate `apm.lock.yaml`.
 
 ```bash

--- a/docs/src/content/docs/reference/cli/update.md
+++ b/docs/src/content/docs/reference/cli/update.md
@@ -10,12 +10,14 @@ Refresh the dependencies declared in `apm.yml` to the latest matching Git refs, 
 ## Synopsis
 
 ```bash
-apm update [OPTIONS]
+apm update [OPTIONS] [PACKAGES...]
 ```
 
 ## Description
 
 `apm update` re-resolves every dependency in your project's `apm.yml` against the newest Git ref allowed by its constraint, prints a structured plan -- **added**, **updated**, **removed**, **unchanged** -- and prompts before touching anything. Decline the prompt and APM exits cleanly: no lockfile writes, no filesystem changes.
+
+Pass one or more `PACKAGES` to refresh only those dependencies, or `-g/--global` to refresh the user-scope dependencies under `~/.apm/` instead of the current project. With these flags `apm update` is a strict superset of the deprecated [`apm deps update`](../deps/#apm-deps-update).
 
 This is the dependency-refresh command. To upgrade the APM CLI binary itself, see [`apm self-update`](../self-update/).
 
@@ -25,6 +27,12 @@ The interactive prompt defaults to **No**. In non-interactive contexts (CI, pipe
 
 For a read-only install that pins to whatever is already in `apm.lock.yaml` -- the right command for CI -- use [`apm install --frozen`](../install/).
 
+## Arguments
+
+| Argument | Description |
+| --- | --- |
+| `PACKAGES...` | Optional. One or more dependency names to refresh (short name like `compliance-rules` or canonical `owner/repo`). Omit to refresh everything. Unknown names exit non-zero with the available list. |
+
 ## Options
 
 | Flag | Default | Description |
@@ -32,6 +40,9 @@ For a read-only install that pins to whatever is already in `apm.lock.yaml` -- t
 | `--yes`, `-y` | off | Skip the interactive prompt and accept the plan. Required for non-interactive use. |
 | `--dry-run` | off | Compute and print the plan without prompting and without writing the lockfile or filesystem. |
 | `--verbose`, `-v` | off | Show per-dependency resolution detail (old ref, new ref, source) and full error context. |
+| `--global`, `-g` | off | Refresh user-scope dependencies under `~/.apm/` instead of the current project (mirrors `apm install -g`). |
+| `--force` | off | Overwrite locally-authored files on collision. |
+| `--parallel-downloads N` | `4` | Max concurrent package downloads. `0` disables parallelism. |
 | `--target TARGET`, `-t TARGET` | auto-detect | Agent harness(es) to update for. Accepts a single value (`claude`, `copilot`, `cursor`, `windsurf`, `codex`, `opencode`, `gemini`) or comma-separated list (`--target claude,cursor`). Overrides `apm.yml targets:` and auto-detection. |
 
 ## Examples
@@ -53,6 +64,18 @@ Accept non-interactively (CI, scripts):
 
 ```bash
 apm update --yes
+```
+
+Refresh only specific packages:
+
+```bash
+apm update org/pkg-a org/pkg-b
+```
+
+Refresh user-scope dependencies installed with `apm install -g`:
+
+```bash
+apm update -g
 ```
 
 Decline the prompt -- nothing is written:

--- a/packages/apm-guide/.apm/skills/apm-usage/commands.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/commands.md
@@ -21,7 +21,7 @@
 | `apm outdated` | Check locked deps via SHA/semver comparison | `-g` global, `-v` verbose, `-j N` parallel checks |
 | `apm deps info PKG` | Alias for `apm view PKG` local metadata | -- |
 | `apm deps clean` | Clean dependency cache | `--dry-run`, `-y` skip confirm |
-| `apm deps update [PKGS...]` | Update specific packages | `--verbose`, `--force`, `--target` (comma-separated), `--parallel-downloads N` |
+| `apm deps update [PKGS...]` | Deprecated -- use `apm update` instead (now a strict superset). Update specific packages | `--verbose`, `--force`, `--target` (comma-separated), `--parallel-downloads N`, `-g/--global`, `--legacy-skill-paths` |
 
 ### Install validation chain (virtual subdirectory packages)
 
@@ -199,7 +199,7 @@ Experimental flags MUST NOT gate security-critical behaviour (content scanning, 
 | `apm config get [KEY]` | Get a config value (`auto-integrate`, `temp-dir`, `allow-protocol-fallback`, `prefer-ssh`, `copilot-cowork-skills-dir`) | -- |
 | `apm config set KEY VALUE` | Set a config value (`auto-integrate`, `temp-dir`, `allow-protocol-fallback`, `prefer-ssh`; `copilot-cowork-skills-dir` requires `apm experimental enable copilot-cowork`) | -- |
 | `apm config unset KEY` | Remove a stored config value (`temp-dir`, `allow-protocol-fallback`, `prefer-ssh`, `copilot-cowork-skills-dir`) | -- |
-| `apm update` | Refresh APM dependencies in the current project: resolves `apm.yml` against the latest refs, prints a structured plan (added/updated/removed/unchanged), and prompts before mutating anything (default `[y/N]`). Skips the prompt with `--yes`; previews without changes with `--dry-run`. | `--yes`, `--dry-run`, `--verbose` |
+| `apm update [PKGS...]` | Refresh APM dependencies: resolves `apm.yml` against the latest refs, prints a structured plan (added/updated/removed/unchanged), and prompts before mutating anything (default `[y/N]`). Pass `[PKGS...]` to refresh only those deps, or `-g` for user scope (`~/.apm/`). Strict superset of the deprecated `apm deps update`. Skips the prompt with `--yes`; previews with `--dry-run`. | `--yes`, `--dry-run`, `--verbose`, `-g/--global`, `--force`, `--parallel-downloads N`, `--target` (comma-separated) |
 | `apm self-update` | Update the APM CLI itself (or show distributor guidance when self-update is disabled at build time). | `--check` only check |
 
 `apm config set prefer-ssh true` and `apm config set allow-protocol-fallback true` persist transport preferences to `~/.apm/config.json` so SSH-only and corporate GHES users no longer need to re-pass `--ssh` / `--allow-protocol-fallback` on every `apm install`. Resolution order: CLI flag > `APM_GIT_PROTOCOL` / `APM_ALLOW_PROTOCOL_FALLBACK` env var > `apm config` value > built-in default (`false`). `apm config unset prefer-ssh` and `apm config unset allow-protocol-fallback` remove the persisted value. In `apm config` / `apm config get` (no key), the two transport rows surface only when they have been enabled (the `false`-default rows are suppressed to keep the output noise-free); `apm config get <key>` always returns the effective value. Setting `allow-protocol-fallback=true` while `CI=1` emits a warning because the persisted value affects every subsequent `apm install` on a shared `$HOME`; prefer the env var in CI.

--- a/src/apm_cli/commands/_helpers.py
+++ b/src/apm_cli/commands/_helpers.py
@@ -349,7 +349,10 @@ class UnknownPackageError(Exception):
         super().__init__(f"Package '{token}' not found")
 
 
-def resolve_requested_packages(packages, all_deps):
+def resolve_requested_packages(
+    packages: tuple[str, ...] | list[str],
+    all_deps: list,
+) -> list[str] | None:
     """Map requested package tokens to canonical dependency keys.
 
     The install engine matches ``only_packages`` by ``DependencyReference``

--- a/src/apm_cli/commands/_helpers.py
+++ b/src/apm_cli/commands/_helpers.py
@@ -331,6 +331,71 @@ def _check_orphaned_packages():
         return []
 
 
+# ------------------------------------------------------------------
+# Dependency-update helpers (shared by `apm update` and `apm deps update`)
+# ------------------------------------------------------------------
+
+
+class UnknownPackageError(Exception):
+    """A requested package token matched no declared dependency.
+
+    Carries the offending *token* and the list of *available* display
+    names so the CLI caller can render a consistent error message.
+    """
+
+    def __init__(self, token: str, available: list[str]):
+        self.token = token
+        self.available = available
+        super().__init__(f"Package '{token}' not found")
+
+
+def resolve_requested_packages(packages, all_deps):
+    """Map requested package tokens to canonical dependency keys.
+
+    The install engine matches ``only_packages`` by ``DependencyReference``
+    identity (e.g. ``owner/repo``), so short names like ``compliance-rules``
+    must be normalised to their canonical key before the engine is called.
+
+    Args:
+        packages: Raw tokens from the CLI ``[PACKAGES]...`` argument.
+        all_deps: Declared dependencies (direct + dev) to match against.
+
+    Returns:
+        An order-preserving, de-duplicated list of canonical keys, or
+        ``None`` when *packages* is empty (meaning "refresh everything").
+
+    Raises:
+        UnknownPackageError: when a token matches no declared dependency.
+    """
+    if not packages:
+        return None
+
+    token_to_canonical: dict[str, str] = {}
+    for dep in all_deps:
+        canonical_key = dep.get_unique_key() or dep.repo_url or dep.get_display_name()
+        tokens = {canonical_key, dep.get_display_name(), dep.repo_url}
+        if getattr(dep, "alias", None):
+            tokens.add(dep.alias)
+        parts = dep.repo_url.split("/")
+        if len(parts) >= 2:
+            tokens.add(parts[-1])
+        for token in tokens:
+            if token and token not in token_to_canonical:
+                token_to_canonical[token] = canonical_key
+
+    resolved: list[str] = []
+    seen: set[str] = set()
+    for pkg in packages:
+        canonical = token_to_canonical.get(pkg)
+        if not canonical:
+            available = [dep.get_display_name() for dep in all_deps]
+            raise UnknownPackageError(pkg, available)
+        if canonical not in seen:
+            seen.add(canonical)
+            resolved.append(canonical)
+    return resolved
+
+
 def print_version(ctx, param, value):
     """Print version and exit."""
     if not value or ctx.resilient_parsing:

--- a/src/apm_cli/commands/deps/cli.py
+++ b/src/apm_cli/commands/deps/cli.py
@@ -11,7 +11,12 @@ from ...constants import APM_MODULES_DIR, APM_YML_FILENAME, SKILL_MD_FILENAME
 from ...core.command_logger import CommandLogger
 from ...core.target_detection import TargetParamType
 from ...models.apm_package import APMPackage, ValidationResult, validate_apm_package  # noqa: F401
-from .._helpers import _expand_with_ancestors, _standalone_installed_packages
+from .._helpers import (
+    UnknownPackageError,
+    _expand_with_ancestors,
+    _standalone_installed_packages,
+    resolve_requested_packages,
+)
 from ._utils import (
     _count_primitives,
     _get_package_display_info,
@@ -761,10 +766,21 @@ def update(packages, verbose, force, target, parallel_downloads, global_, legacy
     """
     from ...core.auth import AuthResolver
     from ...core.command_logger import InstallLogger
+    from ...utils.console import _rich_warning
     from ..install import (
         _APM_IMPORT_ERROR,
         APM_DEPS_AVAILABLE,
         _install_apm_dependencies,
+    )
+
+    # Soft-deprecation (issue #1525): `apm update` is now a strict superset
+    # of this command. Kept working for one release; removed in the next
+    # breaking release.
+    _rich_warning(
+        "'apm deps update' is deprecated; use 'apm update' instead. "
+        "'apm update' now supports -g/--global, [PACKAGES]..., --force, and "
+        "--parallel-downloads, plus an interactive plan, --dry-run, and --yes.",
+        symbol="warning",
     )
 
     logger = InstallLogger(verbose=verbose, partial=bool(packages))
@@ -798,36 +814,14 @@ def update(packages, verbose, force, target, parallel_downloads, global_, legacy
         return
 
     # Validate and normalize requested packages to canonical dependency keys.
-    # The install engine matches only_packages by DependencyReference identity
-    # (e.g. "owner/repo"), so short names like "compliance-rules" must be
-    # mapped to their canonical form before calling the engine.
-    only_pkgs = None
-    if packages:
-        token_to_canonical: dict[str, str] = {}
-        for dep in all_deps:
-            canonical_key = dep.get_unique_key() or dep.repo_url or dep.get_display_name()
-            tokens = {canonical_key, dep.get_display_name(), dep.repo_url}
-            if hasattr(dep, "alias") and dep.alias:
-                tokens.add(dep.alias)
-            parts = dep.repo_url.split("/")
-            if len(parts) >= 2:
-                tokens.add(parts[-1])
-            for token in tokens:
-                if token and token not in token_to_canonical:
-                    token_to_canonical[token] = canonical_key
-
-        only_pkgs = []
-        seen: dict[str, bool] = {}
-        for pkg in packages:
-            canonical = token_to_canonical.get(pkg)
-            if not canonical:
-                available = ", ".join(dep.get_display_name() for dep in all_deps)
-                logger.error(f"Package '{pkg}' not found in {APM_YML_FILENAME}")
-                logger.progress(f"Available: {available}")
-                sys.exit(1)
-            if canonical not in seen:
-                seen[canonical] = True
-                only_pkgs.append(canonical)
+    # Shared with `apm update` (see commands/_helpers.py) so the two update
+    # surfaces resolve short names identically.
+    try:
+        only_pkgs = resolve_requested_packages(packages, all_deps)
+    except UnknownPackageError as e:
+        logger.error(f"Package '{e.token}' not found in {APM_YML_FILENAME}")
+        logger.progress(f"Available: {', '.join(e.available)}")
+        sys.exit(1)
 
     # Migrate legacy lockfile first, then snapshot SHAs for before/after diff
     from ...deps.lockfile import LockFile, get_lockfile_path, migrate_lockfile_if_needed

--- a/src/apm_cli/commands/update.py
+++ b/src/apm_cli/commands/update.py
@@ -29,14 +29,22 @@ Flags
 * ``--dry-run``    -- render the plan and exit without prompting.
 * ``--verbose``/``-v`` -- show unchanged deps in the plan and pipeline
   diagnostics.
+* ``--global``/``-g`` -- refresh user-scope dependencies under
+  ``~/.apm/`` instead of the current project (mirrors
+  ``apm install -g``).
+* ``[PACKAGES]...`` -- positional names to refresh only those
+  dependencies; omit to refresh everything.
+* ``--force`` -- overwrite locally-authored files on collision.
+* ``--parallel-downloads`` -- max concurrent package downloads
+  (0 disables parallelism).
 * ``--target``/``-t`` -- agent harness(es) to deploy to (e.g.
   ``claude``, ``copilot``, ``cursor``, ``windsurf``, ``codex``,
   ``opencode``, ``gemini``); comma-separated for multiple targets.
   Overrides ``apm.yml targets:`` and auto-detection.
 
-Other ``apm install`` flags are NOT mirrored here on purpose -- the
-update command stays focused on the refresh-and-confirm loop.
-``apm install --update`` remains the swiss-army-knife escape hatch.
+These flags make ``apm update`` a strict superset of the deprecated
+``apm deps update`` (issue #1525). ``apm install --update`` remains the
+swiss-army-knife escape hatch for the rest of the install surface.
 """
 
 from __future__ import annotations
@@ -56,6 +64,7 @@ from ..install.errors import (
 )
 from ..install.plan import UpdatePlan, render_plan_text
 from ..utils.console import _rich_echo, _rich_error, _rich_info, _rich_success, _rich_warning
+from ._helpers import UnknownPackageError, resolve_requested_packages
 
 
 def _find_apm_yml(start: Path | None = None) -> Path | None:
@@ -97,6 +106,7 @@ def _stdin_is_tty() -> bool:
     name="update",
     help="Refresh APM dependencies to the latest matching refs",
 )
+@click.argument("packages", nargs=-1)
 @click.option(
     "--yes",
     "-y",
@@ -117,6 +127,27 @@ def _stdin_is_tty() -> bool:
     is_flag=True,
     default=False,
     help="Show unchanged deps and detailed pipeline diagnostics",
+)
+@click.option(
+    "--global",
+    "-g",
+    "global_",
+    is_flag=True,
+    default=False,
+    help="Refresh user-scope dependencies (~/.apm/) instead of the current project",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Overwrite locally-authored files on collision",
+)
+@click.option(
+    "--parallel-downloads",
+    type=int,
+    default=4,
+    show_default=True,
+    help="Max concurrent package downloads (0 to disable parallelism)",
 )
 @click.option(
     "--check",
@@ -142,67 +173,92 @@ def _stdin_is_tty() -> bool:
 @click.pass_context
 def update(
     ctx: click.Context,
+    packages: tuple[str, ...],
     assume_yes: bool,
     dry_run: bool,
     verbose: bool,
+    global_: bool,
+    force: bool,
+    parallel_downloads: int,
     check_only: bool,
     target: str | list[str] | None,
 ) -> None:
     """Refresh APM dependencies to the latest matching refs.
 
     Examples:
-        apm update              # Resolve, show plan, prompt, then install
-        apm update --dry-run    # Show plan only, do not change anything
-        apm update --yes        # Skip the prompt (CI-safe)
-        apm update --verbose    # Include unchanged deps in the plan
+        apm update                      # Resolve, show plan, prompt, then install
+        apm update --dry-run            # Show plan only, do not change anything
+        apm update --yes                # Skip the prompt (CI-safe)
+        apm update org/pkg-a org/pkg-b  # Refresh only the named packages
+        apm update -g                   # Refresh user-scope deps (~/.apm/)
     """
-    manifest_path = _find_apm_yml()
-    if manifest_path is None:
-        # Back-compat shim (one-release): when run outside a project,
-        # forward to the renamed self-updater so existing users keep
-        # working while we publicise ``apm self-update``.  Removed in
-        # the release after this one.
-        from apm_cli.commands.self_update import self_update as _self_update_cmd
+    from apm_cli.core.scope import InstallScope, get_apm_dir
 
-        if target is not None:
+    if global_:
+        # User scope: operate on ~/.apm/apm.yml. The cwd manifest walk and
+        # the self-update back-compat shim apply only to project scope.
+        scope = InstallScope.USER
+        manifest_path = get_apm_dir(scope) / "apm.yml"
+        if not manifest_path.is_file():
+            _rich_error(
+                "No apm.yml found in ~/.apm/. Run 'apm install -g <org/repo>' to create one."
+            )
+            sys.exit(1)
+        if check_only:
             _rich_warning(
-                "--target is ignored when forwarding to 'apm self-update' "
-                "(no apm.yml found). Use 'apm self-update' directly.",
+                "--check applies only to the self-update shim and is ignored with --global.",
                 symbol="warning",
             )
-        _rich_warning(
-            "'apm update' refreshes APM dependencies. To update the CLI binary, "
-            "use 'apm self-update'. Forwarding for back-compat (deprecated).",
-            symbol="warning",
-        )
-        ctx.invoke(_self_update_cmd, check=check_only)
-        return
+        project_root = manifest_path.parent
+    else:
+        scope = InstallScope.PROJECT
+        manifest_path = _find_apm_yml()
+        if manifest_path is None:
+            # Back-compat shim (one-release): when run outside a project,
+            # forward to the renamed self-updater so existing users keep
+            # working while we publicise ``apm self-update``.  Removed in
+            # the release after this one.
+            from apm_cli.commands.self_update import self_update as _self_update_cmd
 
-    if check_only:
-        from apm_cli.commands.self_update import self_update as _self_update_cmd
-
-        if target is not None:
+            if target is not None:
+                _rich_warning(
+                    "--target is ignored when forwarding to 'apm self-update' "
+                    "(no apm.yml found). Use 'apm self-update' directly.",
+                    symbol="warning",
+                )
             _rich_warning(
-                "--target is ignored when forwarding to 'apm self-update --check'. "
-                "Use 'apm update --dry-run' to preview dependency changes.",
+                "'apm update' refreshes APM dependencies. To update the CLI binary, "
+                "use 'apm self-update'. Forwarding for back-compat (deprecated).",
                 symbol="warning",
             )
-        _rich_warning(
-            "'apm update --check' is the deprecated self-updater shim. "
-            "Use 'apm update --dry-run' to preview dependency changes, "
-            "or 'apm self-update --check' to check for a new CLI binary. "
-            "Forwarding for back-compat (deprecated).",
-            symbol="warning",
-        )
-        ctx.invoke(_self_update_cmd, check=True)
-        return
+            ctx.invoke(_self_update_cmd, check=check_only)
+            return
 
-    project_root = manifest_path.parent
-    if project_root != Path.cwd().resolve():
-        _rich_info(
-            f"Using apm.yml at {manifest_path} (project root: {project_root})",
-            symbol="info",
-        )
+        if check_only:
+            from apm_cli.commands.self_update import self_update as _self_update_cmd
+
+            if target is not None:
+                _rich_warning(
+                    "--target is ignored when forwarding to 'apm self-update --check'. "
+                    "Use 'apm update --dry-run' to preview dependency changes.",
+                    symbol="warning",
+                )
+            _rich_warning(
+                "'apm update --check' is the deprecated self-updater shim. "
+                "Use 'apm update --dry-run' to preview dependency changes, "
+                "or 'apm self-update --check' to check for a new CLI binary. "
+                "Forwarding for back-compat (deprecated).",
+                symbol="warning",
+            )
+            ctx.invoke(_self_update_cmd, check=True)
+            return
+
+        project_root = manifest_path.parent
+        if project_root != Path.cwd().resolve():
+            _rich_info(
+                f"Using apm.yml at {manifest_path} (project root: {project_root})",
+                symbol="info",
+            )
 
     _run_dep_update(
         assume_yes=assume_yes,
@@ -210,6 +266,10 @@ def update(
         verbose=verbose,
         project_root=project_root,
         target=target,
+        scope=scope,
+        packages=packages,
+        force=force,
+        parallel_downloads=parallel_downloads,
     )
 
 
@@ -220,6 +280,10 @@ def _run_dep_update(
     verbose: bool,
     project_root: Path | None = None,
     target: str | list[str] | None = None,
+    scope=None,
+    packages: tuple[str, ...] = (),
+    force: bool = False,
+    parallel_downloads: int = 4,
 ) -> None:
     """Core ``apm update`` flow: resolve, plan, prompt, install.
 
@@ -227,6 +291,10 @@ def _run_dep_update(
     switched to it before running so install pipeline paths
     (``apm.yml``, ``apm.lock.yaml``, deployed primitives) resolve
     against the discovered project root, not the caller's cwd.
+
+    ``scope`` selects project vs user deployment (defaults to project).
+    ``packages`` narrows the refresh to the named dependencies; ``force``
+    and ``parallel_downloads`` mirror the install-pipeline flags.
     """
     import os
 
@@ -253,6 +321,9 @@ def _run_dep_update(
         _rich_error(f"APM dependency system not available: {e}")
         sys.exit(1)
 
+    if scope is None:
+        scope = InstallScope.PROJECT
+
     try:
         apm_package = APMPackage.from_apm_yml(Path("apm.yml"))
     except (FileNotFoundError, ValueError) as e:
@@ -263,7 +334,19 @@ def _run_dep_update(
         _rich_success("No APM dependencies declared in apm.yml -- nothing to update.")
         return
 
-    logger = InstallLogger(verbose=verbose, dry_run=dry_run, partial=False)
+    # Map any positional [PACKAGES] to canonical dependency keys for the
+    # engine's only_packages filter; None means "refresh everything".
+    try:
+        only_packages = resolve_requested_packages(
+            packages,
+            apm_package.get_apm_dependencies() + apm_package.get_dev_apm_dependencies(),
+        )
+    except UnknownPackageError as e:
+        _rich_error(f"Package '{e.token}' not found in apm.yml")
+        _rich_info(f"Available: {', '.join(e.available)}", symbol="info")
+        sys.exit(1)
+
+    logger = InstallLogger(verbose=verbose, dry_run=dry_run, partial=bool(packages))
 
     plan_state: dict[str, UpdatePlan | bool] = {"plan": None, "proceeded": False}
 
@@ -312,7 +395,10 @@ def _run_dep_update(
             apm_package,
             update_refs=True,
             verbose=verbose,
-            scope=InstallScope.PROJECT,
+            scope=scope,
+            only_packages=only_packages,
+            force=force,
+            parallel_downloads=parallel_downloads,
             logger=logger,
             plan_callback=_plan_callback,
             target=target,

--- a/tests/unit/commands/test_update_command.py
+++ b/tests/unit/commands/test_update_command.py
@@ -642,3 +642,161 @@ class TestUpdatePlanStatePaths:
                 result = runner.invoke(cli, ["update"])
             assert result.exit_code == 0, result.output
             assert "update applied" in result.output.lower()
+
+
+# -----------------------------------------------------------------------------
+# apm update -- superset flags from issue #1525:
+# [PACKAGES]... / --force / --parallel-downloads / -g
+# -----------------------------------------------------------------------------
+
+
+def _capturing_install(captured: dict, *, installed_count: int = 0):
+    """Build a fake _install_apm_dependencies that records kwargs.
+
+    Drives the plan_callback with an empty (no-change) plan so the command
+    completes the happy path without prompting.
+    """
+
+    def fake_install(_apm, **kwargs):
+        from apm_cli.models.results import InstallResult
+
+        captured.update(kwargs)
+        kwargs["plan_callback"](UpdatePlan(entries=()))
+        return InstallResult(installed_count=installed_count)
+
+    return fake_install
+
+
+class TestUpdatePerPackage:
+    def test_packages_forwarded_as_only_packages(self, runner, tmp_path):
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            _make_apm_yml(Path.cwd())
+            captured: dict = {}
+            with patch(
+                "apm_cli.commands.install._install_apm_dependencies",
+                side_effect=_capturing_install(captured),
+            ):
+                result = runner.invoke(cli, ["update", "microsoft/apm"])
+            assert result.exit_code == 0, result.output
+            assert captured["only_packages"] == ["microsoft/apm"]
+
+    def test_no_packages_forwards_none(self, runner, tmp_path):
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            _make_apm_yml(Path.cwd())
+            captured: dict = {}
+            with patch(
+                "apm_cli.commands.install._install_apm_dependencies",
+                side_effect=_capturing_install(captured),
+            ):
+                result = runner.invoke(cli, ["update"])
+            assert result.exit_code == 0, result.output
+            assert captured["only_packages"] is None
+
+    def test_unknown_package_exits_1_without_installing(self, runner, tmp_path):
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            _make_apm_yml(Path.cwd())
+            engine = MagicMock()
+            with patch("apm_cli.commands.install._install_apm_dependencies", engine):
+                result = runner.invoke(cli, ["update", "no/such-pkg"])
+            assert result.exit_code == 1
+            assert "not found in apm.yml" in result.output
+            assert "Available:" in result.output
+            engine.assert_not_called()
+
+
+class TestUpdateForceAndParallel:
+    def test_force_forwarded(self, runner, tmp_path):
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            _make_apm_yml(Path.cwd())
+            captured: dict = {}
+            with patch(
+                "apm_cli.commands.install._install_apm_dependencies",
+                side_effect=_capturing_install(captured),
+            ):
+                result = runner.invoke(cli, ["update", "--force"])
+            assert result.exit_code == 0, result.output
+            assert captured["force"] is True
+
+    def test_parallel_downloads_forwarded(self, runner, tmp_path):
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            _make_apm_yml(Path.cwd())
+            captured: dict = {}
+            with patch(
+                "apm_cli.commands.install._install_apm_dependencies",
+                side_effect=_capturing_install(captured),
+            ):
+                result = runner.invoke(cli, ["update", "--parallel-downloads", "0"])
+            assert result.exit_code == 0, result.output
+            assert captured["parallel_downloads"] == 0
+
+
+class TestUpdateGlobalScope:
+    def test_global_flag_uses_user_scope(self, runner, tmp_path):
+        from apm_cli.core.scope import InstallScope
+
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            user_apm = Path.cwd() / "user_apm"
+            user_apm.mkdir()
+            _make_apm_yml(user_apm)
+            captured: dict = {}
+            with (
+                patch("apm_cli.core.scope.get_apm_dir", return_value=user_apm),
+                patch(
+                    "apm_cli.commands.install._install_apm_dependencies",
+                    side_effect=_capturing_install(captured),
+                ),
+            ):
+                result = runner.invoke(cli, ["update", "-g"])
+            assert result.exit_code == 0, result.output
+            assert captured["scope"] == InstallScope.USER
+
+    def test_global_flag_missing_user_manifest_exits_1(self, runner, tmp_path):
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            user_apm = Path.cwd() / "user_apm"  # intentionally not created
+            engine = MagicMock()
+            with (
+                patch("apm_cli.core.scope.get_apm_dir", return_value=user_apm),
+                patch("apm_cli.commands.install._install_apm_dependencies", engine),
+            ):
+                result = runner.invoke(cli, ["update", "-g"])
+            assert result.exit_code == 1
+            assert "No apm.yml found" in result.output
+            engine.assert_not_called()
+
+
+class TestResolveRequestedPackages:
+    """Direct unit tests for the shared package-token resolver."""
+
+    @staticmethod
+    def _dep(repo_url, *, unique_key=None, display=None, alias=None):
+        dep = MagicMock()
+        dep.repo_url = repo_url
+        dep.alias = alias
+        dep.get_unique_key.return_value = unique_key or repo_url
+        dep.get_display_name.return_value = display or repo_url
+        return dep
+
+    def test_empty_returns_none(self):
+        from apm_cli.commands._helpers import resolve_requested_packages
+
+        assert resolve_requested_packages((), [self._dep("org/a")]) is None
+
+    def test_short_name_maps_to_canonical(self):
+        from apm_cli.commands._helpers import resolve_requested_packages
+
+        deps = [self._dep("owner/compliance-rules")]
+        assert resolve_requested_packages(("compliance-rules",), deps) == ["owner/compliance-rules"]
+
+    def test_dedup_preserves_order(self):
+        from apm_cli.commands._helpers import resolve_requested_packages
+
+        deps = [self._dep("org/a"), self._dep("org/b")]
+        assert resolve_requested_packages(("org/b", "org/a", "org/b"), deps) == ["org/b", "org/a"]
+
+    def test_unknown_token_raises(self):
+        from apm_cli.commands._helpers import UnknownPackageError, resolve_requested_packages
+
+        with pytest.raises(UnknownPackageError) as exc:
+            resolve_requested_packages(("nope",), [self._dep("org/a")])
+        assert exc.value.token == "nope"
+        assert "org/a" in exc.value.available

--- a/tests/unit/commands/test_update_command.py
+++ b/tests/unit/commands/test_update_command.py
@@ -800,3 +800,9 @@ class TestResolveRequestedPackages:
             resolve_requested_packages(("nope",), [self._dep("org/a")])
         assert exc.value.token == "nope"
         assert "org/a" in exc.value.available
+
+    def test_alias_maps_to_canonical(self):
+        from apm_cli.commands._helpers import resolve_requested_packages
+
+        deps = [self._dep("org/compliance-rules", alias="my-rules")]
+        assert resolve_requested_packages(("my-rules",), deps) == ["org/compliance-rules"]

--- a/tests/unit/test_deps_update_command.py
+++ b/tests/unit/test_deps_update_command.py
@@ -107,6 +107,17 @@ class TestDepsUpdateCommand:
             assert result.exit_code == 1
             assert "No apm.yml found" in result.output
 
+    def test_deprecation_banner_points_to_apm_update(self):
+        """A deprecation banner pointing to `apm update` is printed (issue #1525).
+
+        Emitted before the apm.yml pre-flight check, so it shows even on the
+        no-manifest error path.
+        """
+        with self._chdir_tmp():
+            result = self.runner.invoke(cli, ["deps", "update"])
+            assert "deprecated" in result.output.lower()
+            assert "apm update" in result.output
+
     @patch(_PATCH_APM_PACKAGE)
     def test_no_deps_exits_0(self, mock_pkg_cls):
         """Exit 0 with informational message when apm.yml has no APM deps."""


### PR DESCRIPTION
## Description

`apm update` now accepts `-g/--global`, positional `[PACKAGES]...`, `--force`, and `--parallel-downloads`, making it a strict superset of `apm deps update`.
One verb now handles project and user scope, single-package refreshes, and collision overwrites - all behind the plan + confirmation + `--dry-run` gate `apm update` already had. `apm deps update` is soft-deprecated (still works, prints a banner, to be removed in the next breaking release).

Closes #1525 

#### Before

<img width="781" height="716" alt="Screenshot From 2026-06-01 14-56-42" src="https://github.com/user-attachments/assets/0050800c-adac-4e4b-958b-c9b235b44ff9" />

#### After

<img width="1337" height="822" alt="Screenshot From 2026-06-01 14-51-11" src="https://github.com/user-attachments/assets/e326c59d-a839-4e8e-9b5f-26e563a7d59b" />


## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)
<img width="1121" height="661" alt="image" src="https://github.com/user-attachments/assets/203d6ccc-76f3-4f28-8c08-e90c3fe29442" />


## Spec conformance (OpenAPM v0.1)

If this PR changes behaviour that an OpenAPM v0.1 `req-XXX` covers,
confirm the three-step ritual (see CONTRIBUTING.md "Adding or
changing a normative requirement"):

- [ ] Spec edit: `docs/src/content/docs/specs/openapm-v0.1.md` updated
      (new/changed `<a id="req-XXX"></a>` anchor + prose + Appendix C
      row).
- [ ] Manifest edit: `docs/src/content/docs/specs/manifests/openapm-v0.1.requirements.yml`
      updated.
- [ ] Test edit: a `@pytest.mark.req("req-XXX")` test under
      `tests/spec_conformance/` added or extended.
- [ ] `CONFORMANCE.{md,json}` regenerated via
      `uv run --extra dev python -m tests.spec_conformance.gen_statement`
      and committed.
- [x] N/A -- this PR does not change OpenAPM-observable behaviour.
