### PR TITLE
fix(compile): match applyTo globs without following symlinks into node_modules

### DIFF
--- a/src/apm_cli/compilation/context_optimizer.py
+++ b/src/apm_cli/compilation/context_optimizer.py
@@ -7,7 +7,6 @@ following the Minimal Context Principle.
 
 import builtins
 import fnmatch
-import glob
 import os
 import time
 from collections import defaultdict
@@ -25,7 +24,7 @@ from ..output.models import (
     ProjectAnalysis,
 )
 from ..primitives.models import Instruction
-from ..utils.exclude import should_exclude, validate_exclude_patterns
+from ..utils.exclude import matches_glob, should_exclude, validate_exclude_patterns
 from ..utils.paths import portable_relpath
 from ..utils.patterns import has_top_level_comma, parse_apply_to
 
@@ -172,15 +171,35 @@ class ContextOptimizer:
         return result
 
     def _cached_glob(self, pattern: str) -> builtins.list[str]:
-        """Cache glob results to avoid repeated filesystem scans."""
+        """Return project files matching ``pattern`` (``**`` recursive), cached.
+
+        Replaces ``glob.glob(pattern, recursive=True)``, whose ``**`` follows
+        directory **symlinks** and descends excluded trees like
+        ``node_modules``/``dist``. On a pnpm project the symlinked ``.pnpm``
+        store exposes shared packages through exponentially many paths, so a
+        single ``**`` pattern made ``apm compile`` walk an effectively
+        unbounded space -- pinning one core near 100% CPU with multi-GB RSS and
+        never terminating.
+
+        Instead, filter the cached project file list (:meth:`_get_all_files`,
+        which walks once with :func:`os.walk` -- no symlink following -- and
+        prunes excluded/hidden dirs) with the shared ``**``-aware matcher
+        (:func:`apm_cli.utils.exclude.matches_glob`).
+        """
         if pattern not in self._glob_cache:
-            old_cwd = os.getcwd()
-            try:
-                os.chdir(str(self.base_dir))  # Convert Path to string for os.chdir
-                self._glob_cache[pattern] = glob.glob(pattern, recursive=True)
-            finally:
-                os.chdir(old_cwd)
+            self._glob_cache[pattern] = self._safe_recursive_glob(pattern)
         return self._glob_cache[pattern]
+
+    def _safe_recursive_glob(self, pattern: str) -> builtins.list[str]:
+        """Symlink-safe, exclusion-aware ``glob(recursive=True)`` replacement:
+        match the cached project file list against ``pattern`` (POSIX rel paths).
+        """
+        results: builtins.list[str] = []
+        for path in self._get_all_files():
+            rel = portable_relpath(path, self.base_dir)
+            if matches_glob(rel, pattern):
+                results.append(rel)
+        return results
 
     def _get_all_files(self) -> builtins.list[Path]:
         """Get cached list of all files in project."""

--- a/src/apm_cli/utils/exclude.py
+++ b/src/apm_cli/utils/exclude.py
@@ -90,6 +90,16 @@ def should_exclude(
     return False
 
 
+def matches_glob(rel_path: str, pattern: str) -> bool:
+    """Return True if forward-slash ``rel_path`` matches glob ``pattern``.
+
+    Supports ``**`` recursive segments. Shared by ``compilation.exclude``
+    filtering and instruction ``applyTo`` placement so both stay on a single
+    glob-matching implementation.
+    """
+    return _matches_pattern(rel_path, pattern)
+
+
 def _matches_pattern(rel_path_str: str, pattern: str) -> bool:
     """Check if a relative path string matches a single exclusion pattern.
 

--- a/tests/unit/compilation/test_context_optimizer_cache_and_placement.py
+++ b/tests/unit/compilation/test_context_optimizer_cache_and_placement.py
@@ -2,17 +2,21 @@
 
 Covers:
 - ``_cached_glob`` reusing cached results across repeated calls without
-  re-invoking the underlying ``glob.glob`` (cache layer populated via
-  ``_glob_cache``).
+  re-running the underlying scan (``_safe_recursive_glob``; cache layer
+  populated via ``_glob_cache``).
+- ``_safe_recursive_glob`` excluding ``node_modules`` and not following
+  directory symlinks, so a pnpm-style symlink cycle cannot make
+  compilation hang (regression for the recursive-glob hang).
 - Lowest-common-ancestor placement when matches share a deep subtree, for
   both placement strategies that can route through the LCA helper:
     * ``_optimize_selective_placement`` (medium distribution, 0.3-0.7).
     * ``_optimize_single_point_placement`` (low distribution, < 0.3).
 """
 
-import glob as glob_module
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 from apm_cli.compilation.context_optimizer import ContextOptimizer
 from apm_cli.primitives.models import Instruction
@@ -32,25 +36,52 @@ class TestCachedGlobUsesFileList:
 
         Regression coverage for the cache layer added in #871: once a pattern
         has been resolved, subsequent calls must hit the cache and never
-        re-invoke ``glob.glob`` for the same pattern.
+        re-run the underlying scan for the same pattern.
         """
         (tmp_path / "a.py").touch()
         optimizer = ContextOptimizer(base_dir=str(tmp_path))
 
-        with patch(
-            "apm_cli.compilation.context_optimizer.glob.glob",
-            wraps=glob_module.glob,
-        ) as glob_spy:
+        with patch.object(
+            optimizer,
+            "_safe_recursive_glob",
+            wraps=optimizer._safe_recursive_glob,
+        ) as scan_spy:
             first = optimizer._cached_glob("**/*.py")
             second = optimizer._cached_glob("**/*.py")
 
-        assert first == second
+        assert first == second == ["a.py"]
         assert "**/*.py" in optimizer._glob_cache
         assert first == optimizer._glob_cache["**/*.py"]
-        # No-rescan guarantee: glob.glob must run exactly once for the pattern.
-        assert glob_spy.call_count == 1, (
-            f"expected exactly one glob.glob invocation, got {glob_spy.call_count}"
-        )
+        # No-rescan guarantee: the scan must run exactly once for the pattern.
+        assert scan_spy.call_count == 1, f"expected exactly one scan, got {scan_spy.call_count}"
+
+    def test_cached_glob_excludes_node_modules_and_symlink_cycles(self, tmp_path: Path) -> None:
+        """A ``**`` pattern must not descend ``node_modules`` or follow symlinks.
+
+        Regression for the recursive-glob hang: ``glob.glob(recursive=True)``
+        follows directory symlinks and descends excluded trees, so a pnpm-style
+        ``node_modules`` (a symlink forest with cycles) made ``apm compile``
+        walk an unbounded path space and never terminate. Filtering the
+        ``os.walk``-based project file list (no symlink following, excluded
+        dirs pruned) makes the cycle below harmless and drops ``node_modules``.
+        """
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "app.ts").touch()
+
+        pkg = tmp_path / "node_modules" / "pkg"
+        pkg.mkdir(parents=True)
+        (pkg / "index.ts").touch()
+        try:
+            # pnpm-style self-referential symlink -> infinite loop if followed.
+            (pkg / "loop").symlink_to(tmp_path / "node_modules", target_is_directory=True)
+        except OSError:
+            pytest.skip("symlink creation not supported on this platform")
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        matches = optimizer._cached_glob("**/*.ts")  # must terminate
+
+        assert "src/app.ts" in matches
+        assert not any(m.startswith("node_modules") for m in matches)
 
 
 class TestSelectivePlacementNonRootLCA:


### PR DESCRIPTION
**`apm compile` hangs indefinitely — one core pinned near 100% CPU, RSS climbing past 4 GB — on a project with a pnpm `node_modules`.** The placement optimizer resolves each instruction's `applyTo` pattern with `glob.glob(pattern, recursive=True)`, and that call both *follows directory symlinks* and *ignores* the optimizer's own `DEFAULT_EXCLUDED_DIRNAMES`. pnpm's `node_modules/.pnpm` store is a dense symlink forest where shared packages are reachable through exponentially many paths, so a single `**` pattern sends the walk into an effectively unbounded space that never terminates.

### Reproduced in [juspay/kolu](https://github.com/juspay/kolu)

This surfaced as `apm compile --target codex,opencode` spinning forever (`99.5% CPU`, `4.1 GB` RSS, never exiting) in working trees of [Kolu](https://github.com/juspay/kolu), which consumes APM for its Claude/Codex/OpenCode instructions. I reproduced it from a clean `juspay/kolu` checkout on an isolated Linux box and pinned it with `py-spy` — every sample sat in the same stack:

```
glob._rlistdir                          (recursing, 30+ frames deep)
  _cached_glob               context_optimizer.py
  _file_matches_pattern
  _find_matching_directories
  optimize_instruction_placement
  compile_distributed
```

### Why Kolu specifically (and what would *not* trigger it)

The hang needs **two** ingredients at once, and a Kolu worktree has both:

| Ingredient | Kolu | Why it matters |
| --- | --- | --- |
| **pnpm** `node_modules` | ~**2,400** symlinks in the `.pnpm` virtual store | `glob`'s `**` *follows* dir symlinks; shared packages are reachable via exponentially many paths → unbounded walk |
| `applyTo` patterns containing `**` | `apm.yml`/instructions use `applyTo: "**"`, `**/*.nix`, `docs/**`, `packages/client/src/**`, … | only `**` patterns hit the recursive-glob path in `_cached_glob`; `applyTo: "**"` walks from the repo root |

Take either ingredient away and it stays fast: a **fresh clone with no `node_modules`** compiles in ~2 s, and so does a synthetic `node_modules` of **48k plain files with no symlinks** — proving it's the *symlink graph*, not file count. Projects on **npm / yarn-classic** (flatter, far fewer symlinks) or whose instructions carry **no `**` `applyTo`** patterns won't detonate. Kolu is the unlucky intersection: pnpm **and** `applyTo: "**"`.

### The fix

Stop walking the tree inside `_cached_glob`. Filter the optimizer's **already-cached** project file list (`_get_all_files`, a single `os.walk` that **does not follow symlinks** and prunes excluded/hidden dirs) through the project's **existing** `**`-aware matcher — exposed as `exclude.matches_glob`, a thin wrapper over `exclude._matches_pattern` that `compilation.exclude` already uses.

| | Old (`glob.glob(recursive=True)`) | New (filter `_get_all_files`) |
| --- | --- | --- |
| Follows dir symlinks | **yes** → pnpm cycles explode | no (`os.walk` default) |
| Excludes `node_modules`/`dist`/`.git` | no | yes (`DEFAULT_EXCLUDED_DIRNAMES`) |
| Walks per pattern | yes (one `glob` per pattern) | no (one cached walk, N filters) |
| Glob-match implementation | stdlib `glob` | the matcher the repo already maintains |

_No new glob engine: `matches_glob` reuses `utils/exclude.py`, which the module docstring already calls "the shared matcher used by the context optimizer and primitive discovery." The dotfile policy now lives only in the walk (`_get_all_files`), not duplicated in the matcher._

### Validation

- **Identical output** to the old glob across representative `applyTo` patterns (`**/*.ts`, `packages/client/src/**`, `docs/**`, `**`, `**/*.nix`, …) by set-equality on a terminating tree.
- **The hang is gone**: on the real Kolu repo (pnpm, ~2,400 `node_modules` symlinks) the same `apm compile --target codex,opencode` went from *never finishing* (killed at a 120 s timeout, 100% CPU) to **~2.5 s**, with byte-identical AGENTS.md placement.
- **1179** compilation/optimizer tests and **556** exclude-matcher tests pass; `ruff check` + `ruff format` clean.
- Added a regression test that builds a `node_modules` symlink cycle and asserts the scan terminates and excludes `node_modules` (skipped where symlink creation needs privileges) — it hangs on the old implementation.

## Type of change

- [x] Bug fix

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

## Spec conformance (OpenAPM v0.1)

- [x] N/A — does not change OpenAPM-observable behaviour. Compiled output is byte-identical; only the directory-traversal mechanism changes.

---
_Generated by Claude Code (model `claude-opus-4-8`)._