### PR TITLE
feat(marketplace): inherit description/version from local-path apm.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `apm publish` auto-pack now includes `README.md`, `CHANGELOG.md`, and `LICENSE` / `LICENCE` (case-insensitive, symlinks excluded) in the flat registry archive, matching npm's behaviour of bundling standard root-level documentation files alongside the package source.
 
+### Fixed
+
+- `apm pack` now fills local-path marketplace package `description` and `version` from each package's own `apm.yml` when the root `marketplace.packages[]` entry omits them, so monorepo marketplaces no longer show empty browse columns. (closes #1725) -- by @imbabamba (#1581)
+
 ## [0.16.1] - 2026-06-01
 
 ### Added

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -671,11 +671,11 @@ Each entry MUST be a mapping. Unknown keys are rejected.
 | `name` | `string` | REQUIRED | Package identifier as it appears in the marketplace. |
 | `source` | `string` | REQUIRED | One of: `<owner>/<repo>` (remote on the default host), `<host.tld>/<owner>/<repo>` (remote on a non-default host such as GitHub Enterprise or self-hosted GitLab -- shorthand), `https://<host.tld>/<owner>/<repo>[.git]` (same, full URL form -- a trailing `.git` is stripped), or `./<path>` (local). Must match the source pattern; path traversal (`..`) is refused, and URL forms with userinfo (`user@host`), ports, query strings, or non-`https` schemes are rejected. |
 | `subdir` | `string` | OPTIONAL | Subdirectory inside the source repo. Path-traversal-validated. Ignored for local sources. |
-| `version` | `string` | Conditional | Semver range (e.g. `^1.0.0`, `~2.1.0`, `>=3.0`). Stored as a string; resolution happens at pack time. REQUIRED for remote packages unless `ref` is given. |
+| `version` | `string` | Conditional | Semver range (e.g. `^1.0.0`, `~2.1.0`, `>=3.0`). Stored as a string; resolution happens at pack time. REQUIRED for remote packages unless `ref` is given. Falls back to the package's own `apm.yml` when omitted (see note below). |
 | `ref` | `string` | Conditional | Explicit git ref (SHA, tag, or branch). Overrides `version` range when both are present. REQUIRED for remote packages unless `version` is given. |
 | `tag_pattern` | `string` | OPTIONAL | Per-package override of `build.tagPattern`. Same placeholder rule. |
 | `include_prerelease` | `bool` | `false` | Whether semver pre-release tags are eligible for resolution. |
-| `description` | `string` | OPTIONAL | Pass-through to `marketplace.json`. |
+| `description` | `string` | OPTIONAL | Pass-through to `marketplace.json`; falls back to the package's own `apm.yml` when omitted (see note below). |
 | `homepage` | `string` | OPTIONAL | Pass-through to `marketplace.json`. |
 | `tags` | `list<string>` | OPTIONAL | Pass-through to `marketplace.json`. Limited to 50 tags, 100 chars each. |
 | `keywords` | `list<string>` | OPTIONAL | Alias merged into `tags` (deduplicated). |
@@ -685,7 +685,7 @@ Each entry MUST be a mapping. Unknown keys are rejected.
 
 Remote packages MUST declare at least one of `version` or `ref`. Local packages (sources beginning with `./`) skip git resolution and have no version requirement.
 
-When `description` or `version` is omitted from a `packages[]` entry, `apm pack` reads the matching field from the referenced package's own `apm.yml` and uses it in the generated `marketplace.json`. Remote packages are fetched over HTTPS (skipped under `--offline`); local packages are read from disk under the project root. A curator-side value still wins when both are set.
+When `description` or `version` is omitted from a `packages[]` entry, `apm pack` reads the matching field from the referenced package's own `apm.yml` and uses it in the generated `marketplace.json`. Remote packages are fetched over HTTPS (skipped under `--offline`); local packages are read from disk under the project root. A value set on the `packages[]` entry still wins when both are present.
 
 The first three `source` forms target a remote git host; the second and third name a non-default host (e.g. GitHub Enterprise, self-hosted GitLab) as either a shorthand or a full HTTPS URL with an optional `.git` suffix that is normalized away. Path traversal (`..`) in local paths, userinfo (`user@host`), ports, query strings, and non-`https` URL schemes are rejected at parse time.
 

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -685,6 +685,8 @@ Each entry MUST be a mapping. Unknown keys are rejected.
 
 Remote packages MUST declare at least one of `version` or `ref`. Local packages (sources beginning with `./`) skip git resolution and have no version requirement.
 
+When `description` or `version` is omitted from a `packages[]` entry, `apm pack` reads the matching field from the referenced package's own `apm.yml` and uses it in the generated `marketplace.json`. Remote packages are fetched over HTTPS (skipped under `--offline`); local packages are read from disk under the project root. A curator-side value still wins when both are set.
+
 The first three `source` forms target a remote git host; the second and third name a non-default host (e.g. GitHub Enterprise, self-hosted GitLab) as either a shorthand or a full HTTPS URL with an optional `.git` suffix that is normalized away. Path traversal (`..`) in local paths, userinfo (`user@host`), ports, query strings, and non-`https` URL schemes are rejected at parse time.
 
 Non-default hosts authenticate via the standard APM token chain -- see the [authentication guide](../getting-started/authentication/) for the per-host-class lookup order. A token resolved for the default host is never forwarded to a non-default host.

--- a/src/apm_cli/marketplace/builder.py
+++ b/src/apm_cli/marketplace/builder.py
@@ -733,7 +733,62 @@ class MarketplaceBuilder:
                 ordered.append(results[idx])
         return ResolveResult(entries=tuple(ordered), errors=tuple(errors))
 
-    # -- remote description fetcher -----------------------------------------
+    # -- description/version metadata fetchers ------------------------------
+
+    def _fetch_local_metadata(self, pkg: ResolvedPackage) -> dict[str, str] | None:
+        """Best-effort: read ``description`` and ``version`` from a
+        local-path package's ``apm.yml`` on disk.
+
+        Local-path packages (``source: ./...``) record the curator's
+        ``source`` value on ``ResolvedPackage.subdir``; the package's
+        own ``apm.yml`` lives at ``<project_root>/<subdir>/apm.yml``.
+        Returns a dict with ``description`` and/or ``version`` keys, or
+        ``None`` when the file is missing or unreadable.  Mirrors
+        ``_fetch_remote_metadata``: cosmetic enrichment only, failures
+        are logged at debug level and never propagate.
+
+        The resolved path is constrained to ``self._project_root`` so a
+        curator entry pointing outside the tree is skipped.  A source
+        that resolves to the project root itself is also skipped -- that
+        file is the marketplace's own ``apm.yml``, not a package
+        manifest.
+        """
+        if not pkg.subdir:
+            return None
+        try:
+            package_root = ensure_path_within(self._project_root / pkg.subdir, self._project_root)
+            if package_root == self._project_root.resolve():
+                return None
+            file_path = package_root / "apm.yml"
+            if not file_path.is_file():
+                return None
+            data = yaml.safe_load(file_path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                return None
+            result: dict[str, str] = {}
+            desc = data.get("description")
+            if isinstance(desc, str) and desc:
+                result["description"] = desc
+            ver = data.get("version")
+            if ver is not None:
+                ver_str = str(ver).strip()
+                if ver_str:
+                    result["version"] = ver_str
+            if result:
+                logger.debug(
+                    "Read local metadata for %s from %s: %s",
+                    pkg.name,
+                    file_path,
+                    ", ".join(result.keys()),
+                )
+                return result
+        except Exception:
+            logger.debug(
+                "Could not read local metadata for %s",
+                pkg.name,
+                exc_info=True,
+            )
+        return None
 
     def _fetch_remote_metadata(self, pkg: ResolvedPackage) -> dict[str, str] | None:
         """Best-effort: fetch ``description`` and ``version`` from the
@@ -865,27 +920,39 @@ class MarketplaceBuilder:
         return None
 
     def _prefetch_metadata(self, resolved: list[ResolvedPackage]) -> dict[str, dict[str, str]]:
-        """Concurrently fetch remote metadata for all packages.
+        """Fetch ``description``/``version`` metadata for resolved packages.
 
         Returns a mapping of ``{package_name: {"description": ..., "version": ...}}``
-        for successful fetches.  Skipped entirely when ``--offline`` is set.
-        Local-path packages are skipped (they carry their own metadata).
+        for successful fetches.  Both local-path and remote packages are
+        read from each package's own ``apm.yml`` so the output mapper can
+        apply one fallback rule regardless of source kind.
 
-        A GitHub token is resolved once before spawning worker threads and
-        stored on ``self._github_token`` for the workers to read.
+        Local reads always run (filesystem only).  Remote fetches are
+        skipped when ``--offline`` is set.  A GitHub token is resolved
+        once before spawning worker threads and stored on
+        ``self._github_token`` for the workers to read.
         """
-        if self._options.offline:
-            return {}
+        results: dict[str, dict[str, str]] = {}
 
-        # Filter out local-path entries -- they don't have a remote to fetch from.
+        # Local-path packages: read each apm.yml directly from disk.
+        # Cheap and serial -- no network, no thread pool needed.
+        for pkg in resolved:
+            if pkg.source_repo:
+                continue
+            meta = self._fetch_local_metadata(pkg)
+            if meta:
+                results[pkg.name] = meta
+
+        if self._options.offline:
+            return results
+
         remote = [pkg for pkg in resolved if pkg.source_repo]
         if not remote:
-            return {}
+            return results
 
         # Resolve token once -- threads read self._github_token (immutable).
         self._ensure_auth()
 
-        results: dict[str, dict[str, str]] = {}
         workers = min(self._options.concurrency, len(remote))
         with ThreadPoolExecutor(max_workers=workers) as pool:
             future_to_name = {

--- a/src/apm_cli/marketplace/output_mappers.py
+++ b/src/apm_cli/marketplace/output_mappers.py
@@ -88,79 +88,53 @@ class ClaudeMarketplaceMapper(MarketplaceOutputMapper):
             plugin: dict[str, Any] = OrderedDict()
             plugin["name"] = pkg.name
 
+            meta = remote_metadata.get(pkg.name, {})
             if is_local:
-                meta = remote_metadata.get(pkg.name, {})
-                if entry.description:
-                    plugin["description"] = entry.description
-                    local_desc = meta.get("description", "")
-                    if local_desc and local_desc != entry.description:
-                        override_count += 1
-                        diagnostics.append(
-                            BuildDiagnostic(
-                                level="verbose",
-                                message=(
-                                    f"[i] Package '{pkg.name}': using curator "
-                                    f"description (package: "
-                                    f"'{local_desc[:40]}')"
-                                ),
-                            )
-                        )
-                elif meta.get("description"):
-                    plugin["description"] = meta["description"]
-                if entry.version:
-                    plugin["version"] = entry.version
-                    local_ver = meta.get("version", "")
-                    if local_ver and local_ver != entry.version:
-                        override_count += 1
-                        diagnostics.append(
-                            BuildDiagnostic(
-                                level="verbose",
-                                message=(
-                                    f"[i] Package '{pkg.name}': using curator "
-                                    f"version '{entry.version}' "
-                                    f"(package: '{local_ver}')"
-                                ),
-                            )
-                        )
-                elif meta.get("version"):
-                    plugin["version"] = meta["version"]
+                if _apply_field_with_precedence(
+                    plugin,
+                    diagnostics,
+                    field="description",
+                    entry_value=entry.description,
+                    meta_value=meta.get("description"),
+                    pkg_name=pkg.name,
+                    source_label="package",
+                ):
+                    override_count += 1
+                if _apply_field_with_precedence(
+                    plugin,
+                    diagnostics,
+                    field="version",
+                    entry_value=entry.version,
+                    meta_value=meta.get("version"),
+                    pkg_name=pkg.name,
+                    source_label="package",
+                ):
+                    override_count += 1
             else:
-                meta = remote_metadata.get(pkg.name, {})
-                if entry and entry.description:
-                    plugin["description"] = entry.description
-                    remote_desc = meta.get("description", "")
-                    if remote_desc and remote_desc != entry.description:
-                        override_count += 1
-                        diagnostics.append(
-                            BuildDiagnostic(
-                                level="verbose",
-                                message=(
-                                    f"[i] Package '{pkg.name}': using curator "
-                                    f"description (remote: "
-                                    f"'{remote_desc[:40]}')"
-                                ),
-                            )
-                        )
-                elif meta.get("description"):
-                    plugin["description"] = meta["description"]
-
-                if entry and _is_display_version(entry.version):
-                    plugin["version"] = entry.version
-                    remote_ver = meta.get("version", "")
-                    if remote_ver and remote_ver != entry.version:
-                        override_count += 1
-                        diagnostics.append(
-                            BuildDiagnostic(
-                                level="verbose",
-                                message=(
-                                    f"[i] Package '{pkg.name}': using curator "
-                                    f"version '{entry.version}' "
-                                    f"(remote: '{remote_ver}')"
-                                ),
-                            )
-                        )
-                elif meta.get("version"):
-                    plugin["version"] = meta["version"]
+                entry_description = entry.description if entry else None
+                entry_version = (
+                    entry.version if entry and _is_display_version(entry.version) else None
+                )
+                if _apply_field_with_precedence(
+                    plugin,
+                    diagnostics,
+                    field="description",
+                    entry_value=entry_description,
+                    meta_value=meta.get("description"),
+                    pkg_name=pkg.name,
+                    source_label="remote",
+                ):
+                    override_count += 1
+                if _apply_field_with_precedence(
+                    plugin,
+                    diagnostics,
+                    field="version",
+                    entry_value=entry_version,
+                    meta_value=meta.get("version"),
+                    pkg_name=pkg.name,
+                    source_label="remote",
+                ):
+                    override_count += 1
 
             if entry and entry.author:
                 plugin["author"] = dict(entry.author)
@@ -234,9 +208,7 @@ class ClaudeMarketplaceMapper(MarketplaceOutputMapper):
         if plugin_root and strip_count > 0:
             summary_parts.append(f"stripped from {strip_count} local source(s)")
         if override_count > 0:
-            summary_parts.append(
-                f"{override_count} remote entry(ies) used curator-supplied overrides"
-            )
+            summary_parts.append(f"{override_count} entry(ies) used curator-supplied overrides")
         if summary_parts:
             diagnostics.append(
                 BuildDiagnostic(
@@ -331,6 +303,62 @@ def _codex_source(entry: PackageEntry, pkg: ResolvedPackage) -> dict[str, Any]:
     if pkg.sha:
         source_obj["sha"] = pkg.sha
     return source_obj
+
+
+def _apply_field_with_precedence(
+    plugin: dict[str, Any],
+    diagnostics: list[BuildDiagnostic],
+    *,
+    field: str,
+    entry_value: str | None,
+    meta_value: Any,
+    pkg_name: str,
+    source_label: str,
+) -> bool:
+    """Apply curator-wins metadata precedence and report override diagnostics."""
+    meta_text = meta_value if isinstance(meta_value, str) else ""
+    if entry_value:
+        plugin[field] = entry_value
+        if meta_text and meta_text != entry_value:
+            diagnostics.append(
+                BuildDiagnostic(
+                    level="verbose",
+                    message=_override_message(
+                        pkg_name=pkg_name,
+                        field=field,
+                        entry_value=entry_value,
+                        source_label=source_label,
+                        meta_value=meta_text,
+                    ),
+                )
+            )
+            return True
+    elif meta_text:
+        plugin[field] = meta_text
+    return False
+
+
+def _override_message(
+    *,
+    pkg_name: str,
+    field: str,
+    entry_value: str,
+    source_label: str,
+    meta_value: str,
+) -> str:
+    """Build a compact verbose diagnostic for curator override choices."""
+    field_detail = f"{field} '{entry_value}'" if field == "version" else field
+    return (
+        f"[i] Package '{pkg_name}': using curator {field_detail} "
+        f"({source_label}: '{_diagnostic_preview(meta_value)}')"
+    )
+
+
+def _diagnostic_preview(value: str, *, limit: int = 40) -> str:
+    """Return a compact diagnostic preview with an explicit truncation marker."""
+    if len(value) <= limit:
+        return value
+    return value[:limit] + "..."
 
 
 def _duplicate_name_warnings(plugins: list[dict[str, Any]]) -> list[str]:

--- a/src/apm_cli/marketplace/output_mappers.py
+++ b/src/apm_cli/marketplace/output_mappers.py
@@ -89,10 +89,41 @@ class ClaudeMarketplaceMapper(MarketplaceOutputMapper):
             plugin["name"] = pkg.name
 
             if is_local:
+                meta = remote_metadata.get(pkg.name, {})
                 if entry.description:
                     plugin["description"] = entry.description
+                    local_desc = meta.get("description", "")
+                    if local_desc and local_desc != entry.description:
+                        override_count += 1
+                        diagnostics.append(
+                            BuildDiagnostic(
+                                level="verbose",
+                                message=(
+                                    f"[i] Package '{pkg.name}': using curator "
+                                    f"description (package: "
+                                    f"'{local_desc[:40]}')"
+                                ),
+                            )
+                        )
+                elif meta.get("description"):
+                    plugin["description"] = meta["description"]
                 if entry.version:
                     plugin["version"] = entry.version
+                    local_ver = meta.get("version", "")
+                    if local_ver and local_ver != entry.version:
+                        override_count += 1
+                        diagnostics.append(
+                            BuildDiagnostic(
+                                level="verbose",
+                                message=(
+                                    f"[i] Package '{pkg.name}': using curator "
+                                    f"version '{entry.version}' "
+                                    f"(package: '{local_ver}')"
+                                ),
+                            )
+                        )
+                elif meta.get("version"):
+                    plugin["version"] = meta["version"]
             else:
                 meta = remote_metadata.get(pkg.name, {})
                 if entry and entry.description:

--- a/tests/unit/marketplace/test_builder.py
+++ b/tests/unit/marketplace/test_builder.py
@@ -1786,6 +1786,113 @@ class TestFetchRemoteMetadata:
         assert req.get_header("Authorization") is None
 
 
+# ---------------------------------------------------------------------------
+# _fetch_local_metadata tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchLocalMetadata:
+    """Tests for best-effort local apm.yml metadata reads."""
+
+    def _make_pkg(
+        self,
+        *,
+        name: str = "local-tool",
+        subdir: str | None = "./packages/local-tool",
+    ) -> ResolvedPackage:
+        return ResolvedPackage(
+            name=name,
+            source_repo="",
+            subdir=subdir,
+            ref="",
+            sha="",
+            requested_version=None,
+            tags=(),
+            is_prerelease=False,
+        )
+
+    def _make_builder(self, tmp_path: Path) -> MarketplaceBuilder:
+        yml_path = _write_yml(tmp_path, _BASIC_YML)
+        return MarketplaceBuilder(yml_path)
+
+    def test_reads_description_and_version_from_apm_yml(self, tmp_path: Path) -> None:
+        """File on disk with both fields -> both returned."""
+        pkg_dir = tmp_path / "packages" / "local-tool"
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / "apm.yml").write_text(
+            "name: local-tool\ndescription: A local tool\nversion: 1.2.3\n",
+            encoding="utf-8",
+        )
+        builder = self._make_builder(tmp_path)
+        result = builder._fetch_local_metadata(self._make_pkg())
+        assert result is not None
+        assert result["description"] == "A local tool"
+        assert result["version"] == "1.2.3"
+
+    def test_description_only(self, tmp_path: Path) -> None:
+        """File with description but no version -> only description returned."""
+        pkg_dir = tmp_path / "packages" / "local-tool"
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / "apm.yml").write_text(
+            "name: local-tool\ndescription: Only desc\n",
+            encoding="utf-8",
+        )
+        builder = self._make_builder(tmp_path)
+        result = builder._fetch_local_metadata(self._make_pkg())
+        assert result is not None
+        assert result["description"] == "Only desc"
+        assert "version" not in result
+
+    def test_missing_apm_yml_returns_none(self, tmp_path: Path) -> None:
+        """Subdir exists but has no apm.yml -> None, no crash."""
+        (tmp_path / "packages" / "local-tool").mkdir(parents=True)
+        builder = self._make_builder(tmp_path)
+        result = builder._fetch_local_metadata(self._make_pkg())
+        assert result is None
+
+    def test_missing_subdir_returns_none(self, tmp_path: Path) -> None:
+        """Subdir does not exist -> None, no crash."""
+        builder = self._make_builder(tmp_path)
+        result = builder._fetch_local_metadata(self._make_pkg())
+        assert result is None
+
+    def test_path_escapes_project_root_returns_none(self, tmp_path: Path) -> None:
+        """A subdir that resolves outside the project root is skipped."""
+        builder = self._make_builder(tmp_path)
+        pkg = self._make_pkg(subdir="../escape")
+        result = builder._fetch_local_metadata(pkg)
+        assert result is None
+
+    def test_subdir_resolves_to_project_root_returns_none(self, tmp_path: Path) -> None:
+        """Source that resolves to project root reads the marketplace's own
+        apm.yml, not a package manifest -- skip rather than emit the
+        marketplace description as a package description.
+        """
+        builder = self._make_builder(tmp_path)
+        pkg = self._make_pkg(subdir="./")
+        result = builder._fetch_local_metadata(pkg)
+        assert result is None
+
+    def test_malformed_yaml_returns_none(self, tmp_path: Path) -> None:
+        """Bad YAML -> None, no exception propagates."""
+        pkg_dir = tmp_path / "packages" / "local-tool"
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / "apm.yml").write_text(
+            "name: local-tool\ndescription: [unclosed",
+            encoding="utf-8",
+        )
+        builder = self._make_builder(tmp_path)
+        result = builder._fetch_local_metadata(self._make_pkg())
+        assert result is None
+
+    def test_empty_subdir_field_returns_none(self, tmp_path: Path) -> None:
+        """Defensive: a ResolvedPackage with subdir=None is skipped."""
+        builder = self._make_builder(tmp_path)
+        pkg = self._make_pkg(subdir=None)
+        result = builder._fetch_local_metadata(pkg)
+        assert result is None
+
+
 class _FakeHTTPResponse:
     """Minimal file-like mock for urllib.request.urlopen return value."""
 

--- a/tests/unit/marketplace/test_local_path_compose.py
+++ b/tests/unit/marketplace/test_local_path_compose.py
@@ -516,6 +516,45 @@ def test_compose_local_curator_description_wins_over_package(
     assert doc["plugins"][0]["description"] == "Curator-side blurb."
 
 
+def test_compose_local_curator_version_wins_over_package(tmp_path: Path) -> None:
+    """Curator-side ``version`` still overrides the package manifest --
+    same precedence as the existing remote path.
+    """
+    _write(
+        tmp_path / "apm.yml",
+        """\
+        name: my-project
+        description: M.
+        version: 1.0.0
+        marketplace:
+          owner:
+            name: ACME
+          packages:
+            - name: local-tool
+              source: ./packages/local-tool
+              version: 2.0.0
+        """,
+    )
+    package_dir = tmp_path / "packages" / "local-tool"
+    package_dir.mkdir(parents=True)
+    _write(
+        package_dir / "apm.yml",
+        """\
+        name: local-tool
+        version: 0.3.0
+        description: Package-side blurb.
+        """,
+    )
+
+    config = load_marketplace_config(tmp_path)
+    builder = MarketplaceBuilder.from_config(config, tmp_path, BuildOptions(offline=True))
+    local_entry = next(p for p in config.packages if p.is_local)
+    resolved = builder._resolve_entry(local_entry)
+    doc = builder.compose_marketplace_json([resolved])
+
+    assert doc["plugins"][0]["version"] == "2.0.0"
+
+
 def test_compose_local_missing_package_apm_yml_omits_description(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/marketplace/test_local_path_compose.py
+++ b/tests/unit/marketplace/test_local_path_compose.py
@@ -400,3 +400,166 @@ marketplace:
     resolved = [builder._resolve_entry(local_entry)]
     with pytest.raises(BuildError, match="yields empty path"):
         builder.compose_marketplace_json(resolved)
+
+
+# ---------------------------------------------------------------------------
+# Local apm.yml metadata inheritance
+# ---------------------------------------------------------------------------
+
+
+_APM_LOCAL_NO_CURATOR_METADATA = """\
+name: my-project
+description: Marketplace description.
+version: 1.0.0
+marketplace:
+  owner:
+    name: ACME
+  packages:
+    - name: local-tool
+      source: ./packages/local-tool
+"""
+
+
+def test_compose_local_inherits_description_from_package_apm_yml(
+    tmp_path: Path,
+) -> None:
+    """When the curator entry omits ``description``, ``apm pack`` reads it
+    from the local package's own ``apm.yml`` -- parity with remote sources.
+    """
+    _write(tmp_path / "apm.yml", _APM_LOCAL_NO_CURATOR_METADATA)
+    package_dir = tmp_path / "packages" / "local-tool"
+    package_dir.mkdir(parents=True)
+    _write(
+        package_dir / "apm.yml",
+        """\
+        name: local-tool
+        version: 0.3.0
+        description: From the package manifest.
+        """,
+    )
+
+    config = load_marketplace_config(tmp_path)
+    builder = MarketplaceBuilder.from_config(config, tmp_path, BuildOptions(offline=True))
+    local_entry = next(p for p in config.packages if p.is_local)
+    resolved = builder._resolve_entry(local_entry)
+    doc = builder.compose_marketplace_json([resolved])
+
+    plugin = doc["plugins"][0]
+    assert plugin["description"] == "From the package manifest."
+
+
+def test_compose_local_inherits_version_from_package_apm_yml(
+    tmp_path: Path,
+) -> None:
+    """When the curator entry omits ``version``, it falls back to the local
+    package's own ``apm.yml``.
+    """
+    _write(tmp_path / "apm.yml", _APM_LOCAL_NO_CURATOR_METADATA)
+    package_dir = tmp_path / "packages" / "local-tool"
+    package_dir.mkdir(parents=True)
+    _write(
+        package_dir / "apm.yml",
+        """\
+        name: local-tool
+        version: 0.3.0
+        description: A tool.
+        """,
+    )
+
+    config = load_marketplace_config(tmp_path)
+    builder = MarketplaceBuilder.from_config(config, tmp_path, BuildOptions(offline=True))
+    local_entry = next(p for p in config.packages if p.is_local)
+    resolved = builder._resolve_entry(local_entry)
+    doc = builder.compose_marketplace_json([resolved])
+
+    assert doc["plugins"][0]["version"] == "0.3.0"
+
+
+def test_compose_local_curator_description_wins_over_package(
+    tmp_path: Path,
+) -> None:
+    """Curator-side ``description`` still overrides the package manifest --
+    same precedence as the existing remote path.
+    """
+    _write(
+        tmp_path / "apm.yml",
+        """\
+        name: my-project
+        description: M.
+        version: 1.0.0
+        marketplace:
+          owner:
+            name: ACME
+          packages:
+            - name: local-tool
+              source: ./packages/local-tool
+              description: Curator-side blurb.
+        """,
+    )
+    package_dir = tmp_path / "packages" / "local-tool"
+    package_dir.mkdir(parents=True)
+    _write(
+        package_dir / "apm.yml",
+        """\
+        name: local-tool
+        version: 0.3.0
+        description: Package-side blurb.
+        """,
+    )
+
+    config = load_marketplace_config(tmp_path)
+    builder = MarketplaceBuilder.from_config(config, tmp_path, BuildOptions(offline=True))
+    local_entry = next(p for p in config.packages if p.is_local)
+    resolved = builder._resolve_entry(local_entry)
+    doc = builder.compose_marketplace_json([resolved])
+
+    assert doc["plugins"][0]["description"] == "Curator-side blurb."
+
+
+def test_compose_local_missing_package_apm_yml_omits_description(
+    tmp_path: Path,
+) -> None:
+    """When the curator omits ``description`` and the package has no
+    ``apm.yml`` on disk, the output stays silent -- no key emitted.
+    """
+    _write(tmp_path / "apm.yml", _APM_LOCAL_NO_CURATOR_METADATA)
+    # No packages/local-tool/ directory at all.
+
+    config = load_marketplace_config(tmp_path)
+    builder = MarketplaceBuilder.from_config(config, tmp_path, BuildOptions(offline=True))
+    local_entry = next(p for p in config.packages if p.is_local)
+    resolved = builder._resolve_entry(local_entry)
+    doc = builder.compose_marketplace_json([resolved])
+
+    plugin = doc["plugins"][0]
+    assert "description" not in plugin
+    assert "version" not in plugin
+
+
+def test_compose_local_skips_project_root_apm_yml(tmp_path: Path) -> None:
+    """A local source that resolves to the project root must not read the
+    marketplace's own ``apm.yml`` as if it were a package manifest.
+    """
+    _write(
+        tmp_path / "apm.yml",
+        """\
+        name: my-project
+        description: Marketplace-level description.
+        version: 1.0.0
+        marketplace:
+          owner:
+            name: ACME
+          packages:
+            - name: root-tool
+              source: ./
+        """,
+    )
+
+    config = load_marketplace_config(tmp_path)
+    builder = MarketplaceBuilder.from_config(config, tmp_path, BuildOptions(offline=True))
+    local_entry = next(p for p in config.packages if p.is_local)
+    resolved = builder._resolve_entry(local_entry)
+    doc = builder.compose_marketplace_json([resolved])
+
+    plugin = doc["plugins"][0]
+    assert "description" not in plugin


### PR DESCRIPTION
## TL;DR

`apm pack` now auto-fills `description` and `version` in
`marketplace.json` from each local-path package's own `apm.yml` --
the same fallback the remote source path has used since #1061.
A curator-side value under `marketplace.packages` still wins when
set, and the local read is path-traversal-guarded against the
project root.  Validated against the full unit suite (15837 tests)
with 13 new tests covering the local fallback path.

## Problem (WHY)

The remote branch in `ClaudeMarketplaceMapper.compose` already reads
`description` and `version` from each resolved package's own
`apm.yml` when the curator entry omits them; `_fetch_remote_metadata`
populates that lookup over HTTPS.

The local branch had no such fallback.  It emitted only what the
curator wrote in root `apm.yml`'s `marketplace.packages[]`.  A stale
comment in `_prefetch_metadata` even claimed "Local-path packages are
skipped (they carry their own metadata)" -- but the local code path
never read any metadata at all.

For a monorepo marketplace using `source: ./plugins/<name>` entries,
that gap leaves producers with two options:

- Duplicate the description between root `apm.yml`'s
  `marketplace.packages[]` and each `plugins/<name>/apm.yml`.  The
  two copies drift over time -- the producer edits one and forgets
  the other.
- Run custom sync tooling outside `apm pack` to keep them aligned.

Remote sources do not have this gap.  This PR closes it for local
sources by mirroring the existing remote behavior exactly.

## Approach (WHAT)

| Layer | Before | After |
|---|---|---|
| `builder._prefetch_metadata` | Filtered out local packages.  Returned `{}` under `--offline`. | Reads local packages from disk first (always), then remote concurrently (still skipped under `--offline`).  Returns one dict the mapper consumes the same way regardless of source kind. |
| `builder._fetch_local_metadata` | Did not exist. | New method.  Reads `<project_root>/<subdir>/apm.yml`, extracts `description` and `version`.  Path-traversal-guarded via `ensure_path_within`.  Skips a source that resolves to the project root itself. |
| `output_mappers.ClaudeMarketplaceMapper.compose` (`is_local` branch) | Emitted curator-side fields only.  No fallback. | Same hierarchy as the remote branch: curator wins; otherwise fall back to package-manifest meta.  Verbose diagnostic on divergence. |
| `docs/reference/manifest-schema.md` | `description` row read "Pass-through to `marketplace.json`" with no mention of the fallback. | One-paragraph note after the `marketplace.packages` table covers the fallback for both source kinds. |

Remote-source override semantics are unchanged, including the
verbose diagnostic that logs divergence between curator and package
manifest.  Local sources log the equivalent diagnostic with
`(package: ...)` instead of `(remote: ...)`.

## Implementation (HOW)

| File | What changed |
|---|---|
| `src/apm_cli/marketplace/builder.py` | New `_fetch_local_metadata(pkg)`, mirroring the `_fetch_remote_metadata` shape -- reads `pkg.subdir` from disk, validates path containment, returns dict or `None`.  `_prefetch_metadata` rewritten to process local packages serially first (no thread pool needed), then remote concurrently.  Stale "Local-path packages are skipped" comment removed. |
| `src/apm_cli/marketplace/output_mappers.py` | `is_local` branch in `ClaudeMarketplaceMapper.compose` reads `meta = remote_metadata.get(pkg.name, {})` and applies the same curator-wins-else-meta hierarchy as the remote branch.  Verbose diagnostic on divergence. |
| `tests/unit/marketplace/test_builder.py` | New `TestFetchLocalMetadata` class -- 8 tests: happy path (description + version), description-only, missing apm.yml, missing subdir, path-escape, project-root edge, malformed YAML, empty `subdir` field. |
| `tests/unit/marketplace/test_local_path_compose.py` | 5 new compose-level tests: description inherited from package manifest, version inherited, curator override wins, missing per-package apm.yml omits both fields, project-root edge does not read the marketplace's own `apm.yml`. |
| `docs/src/content/docs/reference/manifest-schema.md` | One-paragraph note after the `marketplace.packages` table covering the fallback rule. |

## Edge cases handled

- **Missing per-package `apm.yml`**: returns `None`; no key emitted.
- **Malformed YAML**: returns `None`; error logged at debug level;
  the build continues.
- **Source escapes project root**: `ensure_path_within` raises;
  `_fetch_local_metadata` catches and returns `None`.
- **Source resolves to the project root itself**: explicit check;
  returns `None` so the marketplace's own `apm.yml` is never read
  as a package manifest.
- **Empty `subdir` on the `ResolvedPackage`**: defensive early
  return.
- **`--offline`**: local reads always run (filesystem, no network);
  remote reads are still skipped.

## Validation evidence

```
$ uv run --extra dev ruff check src/ tests/            # All checks passed!
$ uv run --extra dev ruff format --check src/ tests/   # 1158 files already formatted
```

Tests: `15837 passed, 1 skipped, 21 xfailed` (full `tests/unit` +
`tests/test_console.py`, ~1:25).  `1418 passed` across
`tests/unit/marketplace`, including the 13 new tests added in this
PR.

## Follow-up to #1061

#1061 added the remote-source fallback (`_fetch_remote_metadata`)
to close the "remote-source pass-through metadata dropped" gap.
The same gap existed for local sources.  This PR closes it.
