### PR TITLE
docs(compile): document targets: to pin the committed generated set (#1342)

### DIFF
--- a/docs/src/content/docs/getting-started/first-package.md
+++ b/docs/src/content/docs/getting-started/first-package.md
@@ -225,6 +225,9 @@ in the current directory. To target explicitly, see the
 > plain `agents`-protocol hosts). Gemini also receives commands, skills,
 > hooks, and MCP via `apm install`. Copilot, Claude Code, and Cursor read
 > the per-skill directories directly -- no compile step needed.
+> If your project commits those generated files, set `targets:` in `apm.yml`
+> to keep the committed set consistent across machines. See
+> [Pin committed output with targets:](/apm/reference/cli/compile/#pin-committed-output-with-targets).
 
 Now open Copilot or Claude in this project. Ask "draft a PR description for
 my last commit". The `pr-description` skill activates on its own. To get the

--- a/docs/src/content/docs/reference/cli/compile.md
+++ b/docs/src/content/docs/reference/cli/compile.md
@@ -53,6 +53,36 @@ The compiled output is scanned for hidden Unicode before any file is
 written. Critical findings cause the command to exit non-zero. See
 [Drift and secure by default](../../../consumer/drift-and-secure-by-default/).
 
+## Pinning the committed generated set
+
+`apm compile` generates derived files: `AGENTS.md`, `CLAUDE.md`,
+`.claude/commands/`, `.cursor/rules/`, `.github/copilot-instructions.md`,
+`.agents/`, and similar. Teams that commit these files into source
+control face a consistency problem: without `target:` set in `apm.yml`,
+auto-detection decides which files to produce based on which tool folders
+exist on the current machine. A developer with `.github/` and `.claude/`
+locally produces `copilot` + `claude` output; a contributor with only
+`.claude/` produces `claude` output only. The committed set silently
+tracks whoever last ran `apm compile`.
+
+Set `target:` in `apm.yml` to declare exactly which agent formats the
+project supports. Every run of `apm compile` -- local developer, CI,
+cloud agent -- then writes the same files regardless of which tool
+folders exist on that machine:
+
+```yaml
+# apm.yml
+target: [claude, cursor]   # compile writes exactly these two sets; nothing else
+```
+
+This makes the committed generated files deterministic for humans,
+cloud agents, and contributors who do not run `apm compile` locally
+and rely on the checked-in artifacts.
+
+Accepted values: `copilot`, `claude`, `cursor`, `opencode`, `codex`,
+`gemini`, `windsurf`, `all`. Full reference:
+[manifest schema -- target](../../../reference/manifest-schema/#36-target).
+
 ## Options
 
 ### Target selection

--- a/docs/src/content/docs/reference/cli/compile.md
+++ b/docs/src/content/docs/reference/cli/compile.md
@@ -55,24 +55,26 @@ written. Critical findings cause the command to exit non-zero. See
 
 ## Pinning the committed generated set
 
-`apm compile` generates derived files: `AGENTS.md`, `CLAUDE.md`,
-`.claude/commands/`, `.cursor/rules/`, `.github/copilot-instructions.md`,
-`.agents/`, and similar. Teams that commit these files into source
-control face a consistency problem: without `target:` set in `apm.yml`,
+`apm compile` generates root context files: `AGENTS.md`, `CLAUDE.md`,
+`GEMINI.md`, `.github/copilot-instructions.md` (see
+[Output layout per target](#output-layout-per-target) below for the
+full per-target breakdown). Teams that commit these files into source
+control face a consistency problem: without `targets:` set in `apm.yml`,
 auto-detection decides which files to produce based on which tool folders
-exist on the current machine. A developer with `.github/` and `.claude/`
-locally produces `copilot` + `claude` output; a contributor with only
-`.claude/` produces `claude` output only. The committed set silently
-tracks whoever last ran `apm compile`.
+exist on the current machine. A contributor with only `.claude/` locally
+produces `claude` output only; a developer who also has `.github/`
+triggers the two-or-more-folders rule and gets the full `all` expansion
+-- including `GEMINI.md` and every other target. The committed set
+silently tracks whoever last ran `apm compile`.
 
-Set `target:` in `apm.yml` to declare exactly which agent formats the
+Set `targets:` in `apm.yml` to declare exactly which agent formats the
 project supports. Every run of `apm compile` -- local developer, CI,
 cloud agent -- then writes the same files regardless of which tool
 folders exist on that machine:
 
 ```yaml
 # apm.yml
-target: [claude, cursor]   # compile writes exactly these two sets; nothing else
+targets: [claude, cursor]   # compile writes exactly these two sets; nothing else
 ```
 
 This makes the committed generated files deterministic for humans,
@@ -81,7 +83,7 @@ and rely on the checked-in artifacts.
 
 Accepted values: `copilot`, `claude`, `cursor`, `opencode`, `codex`,
 `gemini`, `windsurf`, `all`. Full reference:
-[manifest schema -- target](../../../reference/manifest-schema/#36-target).
+[manifest schema -- targets](../../../reference/manifest-schema/#36-target).
 
 ## Options
 

--- a/docs/src/content/docs/reference/cli/compile.md
+++ b/docs/src/content/docs/reference/cli/compile.md
@@ -158,7 +158,7 @@ cloud agents, and contributors who do not run `apm compile` locally
 and rely on the checked-in artifacts.
 
 Accepted values: `copilot`, `claude`, `cursor`, `opencode`, `codex`,
-`gemini`, `windsurf`, `all`. Full reference:
+`gemini`, `antigravity`, `windsurf`, `kiro`, `all`. Full reference:
 [manifest schema -- targets](../../../reference/manifest-schema/#36-target).
 
 ## Examples

--- a/docs/src/content/docs/reference/cli/compile.md
+++ b/docs/src/content/docs/reference/cli/compile.md
@@ -53,38 +53,6 @@ The compiled output is scanned for hidden Unicode before any file is
 written. Critical findings cause the command to exit non-zero. See
 [Drift and secure by default](../../../consumer/drift-and-secure-by-default/).
 
-## Pinning the committed generated set
-
-`apm compile` generates root context files: `AGENTS.md`, `CLAUDE.md`,
-`GEMINI.md`, `.github/copilot-instructions.md` (see
-[Output layout per target](#output-layout-per-target) below for the
-full per-target breakdown). Teams that commit these files into source
-control face a consistency problem: without `targets:` set in `apm.yml`,
-auto-detection decides which files to produce based on which tool folders
-exist on the current machine. A contributor with only `.claude/` locally
-produces `claude` output only; a developer who also has `.github/`
-triggers the two-or-more-folders rule and gets the full `all` expansion
--- including `GEMINI.md` and every other target. The committed set
-silently tracks whoever last ran `apm compile`.
-
-Set `targets:` in `apm.yml` to declare exactly which agent formats the
-project supports. Every run of `apm compile` -- local developer, CI,
-cloud agent -- then writes the same files regardless of which tool
-folders exist on that machine:
-
-```yaml
-# apm.yml
-targets: [claude, cursor]   # compile writes exactly these two sets; nothing else
-```
-
-This makes the committed generated files deterministic for humans,
-cloud agents, and contributors who do not run `apm compile` locally
-and rely on the checked-in artifacts.
-
-Accepted values: `copilot`, `claude`, `cursor`, `opencode`, `codex`,
-`gemini`, `windsurf`, `all`. Full reference:
-[manifest schema -- targets](../../../reference/manifest-schema/#36-target).
-
 ## Options
 
 ### Target selection
@@ -159,6 +127,39 @@ APM-generated marker) are never overwritten.
 ```bash
 apm compile -g
 ```
+
+## Pin committed output with targets:
+
+`apm compile` generates root context files: `AGENTS.md`, `CLAUDE.md`,
+`GEMINI.md`, `.github/copilot-instructions.md` (see
+[Output layout per target](#output-layout-per-target) below for the
+full per-target breakdown). Teams that commit these files into source
+control face a consistency problem: without `targets:` set in `apm.yml`,
+auto-detection decides which files to produce based on which tool folders
+exist on the current machine. A contributor with only `.claude/` locally
+produces `claude` output only; a developer who also has `.github/`
+triggers the two-or-more-folders rule and gets the full `all` expansion
+-- producing `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`,
+`.github/copilot-instructions.md`, and every other target. The committed
+set silently tracks whoever last ran `apm compile`.
+
+Set `targets:` in `apm.yml` to declare exactly which agent formats the
+project supports. Every run of `apm compile` -- local developer, CI,
+cloud agent -- then writes the same files regardless of which tool
+folders exist on that machine:
+
+```yaml
+# apm.yml
+targets: [claude, cursor]   # compile writes exactly these two sets; nothing else
+```
+
+This makes the committed generated files deterministic for humans,
+cloud agents, and contributors who do not run `apm compile` locally
+and rely on the checked-in artifacts.
+
+Accepted values: `copilot`, `claude`, `cursor`, `opencode`, `codex`,
+`gemini`, `windsurf`, `all`. Full reference:
+[manifest schema -- targets](../../../reference/manifest-schema/#36-target).
 
 ## Examples
 

--- a/docs/src/content/docs/reference/cli/compile.md
+++ b/docs/src/content/docs/reference/cli/compile.md
@@ -134,13 +134,13 @@ apm compile -g
 `GEMINI.md`, `.github/copilot-instructions.md` (see
 [Output layout per target](#output-layout-per-target) below for the
 full per-target breakdown). Teams that commit these files into source
-control face a consistency problem: without `targets:` set in `apm.yml`,
-auto-detection decides which files to produce based on which tool folders
-exist on the current machine. A contributor with only `.claude/` locally
+control face a consistency problem: without `target:` or `targets:` set in
+`apm.yml`, auto-detection decides which files to produce based on which tool
+folders exist on the current machine. A contributor with only `.claude/` locally
 produces `claude` output only; a developer who also has `.github/`
 triggers the two-or-more-folders rule and gets the full `all` expansion
--- producing `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`,
-`.github/copilot-instructions.md`, and every other target. The committed
+-- producing `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and
+`.github/copilot-instructions.md`. The committed
 set silently tracks whoever last ran `apm compile`.
 
 Set `targets:` in `apm.yml` to declare exactly which agent formats the
@@ -157,8 +157,7 @@ This makes the committed generated files deterministic for humans,
 cloud agents, and contributors who do not run `apm compile` locally
 and rely on the checked-in artifacts.
 
-Accepted values: `copilot`, `claude`, `cursor`, `opencode`, `codex`,
-`gemini`, `antigravity`, `windsurf`, `kiro`, `all`. Full reference:
+For the full list of accepted `targets:` values, see
 [manifest schema -- targets](../../../reference/manifest-schema/#36-target).
 
 ## Examples

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -177,8 +177,8 @@ A plural alias `targets:` (YAML list only) is also accepted and takes precedence
 
 :::tip[Deterministic committed output]
 Teams that commit the files `apm compile` generates face a consistency problem:
-without `targets:` set, auto-detection decides which files to produce based on
-which tool folders exist on the local machine. The committed set silently tracks
+without `target:` or `targets:` set, auto-detection decides which files to produce
+based on which tool folders exist on the local machine. The committed set silently tracks
 whoever last ran `apm compile`. Setting `targets:` makes the output deterministic
 for every developer, CI runner, and cloud agent that relies on the checked-in
 generated files without running `apm compile` locally. See

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -175,14 +175,15 @@ A plural alias `targets:` (YAML list only) is also accepted and takes precedence
 | `all` | All targets. Cannot be combined with other values in a list. |
 | `minimal` | `AGENTS.md` only at project root. **Auto-detected only**: this value MUST NOT be set explicitly in manifests; it is an internal fallback when no target folder is detected. |
 
-**Deterministic committed output.** Teams that commit the files `apm compile`
-generates face a consistency problem: without `targets:` set, auto-detection
-decides which files to produce based on which tool folders exist on the local
-machine. The committed set silently tracks whoever last ran `apm compile`.
-Setting `targets:` makes the output deterministic for every developer, CI
-runner, and cloud agent that relies on the checked-in generated files without
-running `apm compile` locally. See
-[Pinning the committed generated set](./cli/compile/#pinning-the-committed-generated-set).
+:::tip[Deterministic committed output]
+Teams that commit the files `apm compile` generates face a consistency problem:
+without `targets:` set, auto-detection decides which files to produce based on
+which tool folders exist on the local machine. The committed set silently tracks
+whoever last ran `apm compile`. Setting `targets:` makes the output deterministic
+for every developer, CI runner, and cloud agent that relies on the checked-in
+generated files without running `apm compile` locally. See
+[Pin committed output with targets:](./cli/compile/#pin-committed-output-with-targets).
+:::
 
 ### 3.7. `type`
 

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -175,6 +175,15 @@ A plural alias `targets:` (YAML list only) is also accepted and takes precedence
 | `all` | All targets. Cannot be combined with other values in a list. |
 | `minimal` | `AGENTS.md` only at project root. **Auto-detected only**: this value MUST NOT be set explicitly in manifests; it is an internal fallback when no target folder is detected. |
 
+**Deterministic committed output.** Teams that commit the files `apm compile`
+generates face a consistency problem: without `target:` set, auto-detection
+decides which files to produce based on which tool folders exist on the local
+machine. The committed set silently tracks whoever last ran `apm compile`.
+Setting `target:` makes the output deterministic for every developer, CI
+runner, and cloud agent that relies on the checked-in generated files without
+running `apm compile` locally. See
+[Pinning the committed generated set](./cli/compile/#pinning-the-committed-generated-set).
+
 ### 3.7. `type`
 
 | | |

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -176,10 +176,10 @@ A plural alias `targets:` (YAML list only) is also accepted and takes precedence
 | `minimal` | `AGENTS.md` only at project root. **Auto-detected only**: this value MUST NOT be set explicitly in manifests; it is an internal fallback when no target folder is detected. |
 
 **Deterministic committed output.** Teams that commit the files `apm compile`
-generates face a consistency problem: without `target:` set, auto-detection
+generates face a consistency problem: without `targets:` set, auto-detection
 decides which files to produce based on which tool folders exist on the local
 machine. The committed set silently tracks whoever last ran `apm compile`.
-Setting `target:` makes the output deterministic for every developer, CI
+Setting `targets:` makes the output deterministic for every developer, CI
 runner, and cloud agent that relies on the checked-in generated files without
 running `apm compile` locally. See
 [Pinning the committed generated set](./cli/compile/#pinning-the-committed-generated-set).


### PR DESCRIPTION
## Description

Documents how to make `apm compile` output deterministic for repos that commit generated artifacts by explicitly setting `targets:` in `apm.yml`, rather than relying on auto-detection from locally-present harness folders.

**What this resolves:** Issue #1342 originally proposed three code changes (.gitignore coverage, an `apm add-vcsignore` command, and compile-refuse-overwrite). The maintainer rejected all three code changes and approved the docs-only resolution. This PR implements exactly that maintainer-endorsed scope.

**The problem documented:** When teams commit the files `apm compile` generates (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md`) without setting `targets:` in `apm.yml`, auto-detection governs which files are produced. A contributor with only `.claude/` locally produces `claude` output only; a developer who also has `.github/` triggers the two-or-more-folders rule and gets the full `all` expansion. The committed set silently tracks whoever last ran `apm compile`.

**The fix documented:** Set `targets:` in `apm.yml` (preferred spelling per manifest-schema 3.6) to declare exactly which agent formats the project supports:

```yaml
targets: [claude, cursor]   # compile writes exactly these two sets; nothing else
```

Every invocation of `apm compile` -- local developer, CI, cloud agent -- then writes the same files regardless of which tool folders exist on that machine.

**Pages changed:**

- `docs/src/content/docs/reference/cli/compile.md` -- new **"Pin committed output with targets:"** section placed after Options (before Examples), with corrected file list (`AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `.github/copilot-instructions.md` only -- `apm install` outputs excluded) and corrected auto-detect behavior (≥2 folders → `all`, not a union of detected targets)
- `docs/src/content/docs/reference/manifest-schema.md` -- "Deterministic committed output" guidance upgraded to a Starlight `:::tip` admonition in section 3.6, with cross-link updated to match renamed section heading
- `docs/src/content/docs/getting-started/first-package.md` -- breadcrumb added in step 4's `apm compile` callout pointing users to the pinning guidance before they hit the committed-set consistency pain

No source code (`src/`) changes.

**Docs build validation:**

```
[build] 112 page(s) built in 24.64s
All internal links are valid.
[build] Complete!
```

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [ ] Added tests for new functionality (if applicable)

## Spec conformance (OpenAPM v0.1)

- [x] N/A -- this PR does not change OpenAPM-observable behaviour.