### PR TITLE
fix: skip .gitignore update for global scope installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm install -g` (USER scope) no longer writes `apm_modules/` to the working-directory `.gitignore`; only project-scope installs update it. (closes #1577)
 - `apm install -g --target copilot` now deploys prompt primitives to `~/.copilot/prompts/` while continuing to filter unsupported user-scope instructions. (closes #1482, #1570)
 - Linux standalone `apm` binaries no longer fail git shared-cache clones with shared-library symbol lookup errors caused by PyInstaller dynamic-library paths leaking into child processes. (closes #1534)
 - Avoid 13-minute `apm install` hangs in large local projects by limiting synthetic `_local` discovery to `.apm/` and `.github/`, while preserving package metadata discovery. (closes #1507) -- by @ioannispoulios

--- a/docs/src/content/docs/enterprise/security-and-supply-chain.md
+++ b/docs/src/content/docs/enterprise/security-and-supply-chain.md
@@ -87,10 +87,11 @@ APM has no secret store. The contract is:
   `src/apm_cli/install/mcp/entry.py`,
   `src/apm_cli/integration/mcp_integrator_install.py` (orchestration) and
   `src/apm_cli/integration/mcp_integrator.py` (runtime wiring).
-- **`apm install` writes `apm_modules/` to `.gitignore` automatically**
+- **`apm install` (project scope) writes `apm_modules/` to `.gitignore` automatically**
   on first install. Source:
   `src/apm_cli/commands/_helpers.py:414` (`_update_gitignore_for_apm_modules`).
-  This keeps cached source trees out of commits.
+  This keeps cached source trees out of commits. Global installs (`apm install -g`)
+  do **not** modify `.gitignore` in the current working directory.
 - **`apm.yml` is committed; `.env` is yours.** APM never reads `.env`
   files itself; that is delegated to the agent harness.
 

--- a/src/apm_cli/install/pipeline.py
+++ b/src/apm_cli/install/pipeline.py
@@ -680,6 +680,8 @@ def run_install_pipeline(  # noqa: PLR0913, RUF100
             from apm_cli.commands._helpers import _update_gitignore_for_apm_modules
 
             _update_gitignore_for_apm_modules(logger=logger)
+        elif verbose and logger is not None:
+            logger.verbose_detail("Skipping .gitignore update (global scope install).")
 
         # ------------------------------------------------------------------
         # Phase: Orphan cleanup + intra-package stale-file cleanup

--- a/src/apm_cli/install/pipeline.py
+++ b/src/apm_cli/install/pipeline.py
@@ -674,10 +674,12 @@ def run_install_pipeline(  # noqa: PLR0913, RUF100
                 "One or more direct dependencies failed validation. Run with --verbose for details."
             )
 
-        # Update .gitignore
-        from apm_cli.commands._helpers import _update_gitignore_for_apm_modules
+        # Update .gitignore only for project-scoped installs (#1577).
+        # Global installs (InstallScope.USER) must not touch the CWD.
+        if scope == InstallScope.PROJECT:
+            from apm_cli.commands._helpers import _update_gitignore_for_apm_modules
 
-        _update_gitignore_for_apm_modules(logger=logger)
+            _update_gitignore_for_apm_modules(logger=logger)
 
         # ------------------------------------------------------------------
         # Phase: Orphan cleanup + intra-package stale-file cleanup

--- a/tests/unit/install/test_gitignore_scope_guard.py
+++ b/tests/unit/install/test_gitignore_scope_guard.py
@@ -1,0 +1,110 @@
+"""Regression test for #1577: apm install -g must not write .gitignore.
+
+Verifies that _update_gitignore_for_apm_modules is NOT called when
+scope=InstallScope.USER (global install), and IS called for PROJECT scope.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from apm_cli.core.scope import InstallScope
+
+
+def _make_pkg_with_dep():
+    pkg = MagicMock()
+    dep = MagicMock()
+    dep.repo_url = "owner/repo"
+    dep.host = "github.com"
+    pkg.get_apm_dependencies.return_value = [dep]
+    pkg.get_dev_apm_dependencies.return_value = []
+    pkg.get_mcp_dependencies.return_value = []
+    return pkg
+
+
+def _common_patches():
+    """Return a list of (target, kwargs) patch pairs shared by all tests."""
+    return [
+        patch("apm_cli.deps.lockfile.LockFile"),
+        patch("apm_cli.deps.lockfile.get_lockfile_path", return_value=None),
+        patch("apm_cli.core.scope.get_deploy_root", return_value=MagicMock()),
+        patch("apm_cli.core.scope.get_apm_dir", return_value=None),
+        patch(
+            "apm_cli.install.phases.local_content._project_has_root_primitives",
+            return_value=False,
+        ),
+        patch("apm_cli.install.pipeline._run_phase"),
+        patch("apm_cli.utils.install_tui.InstallTui"),
+        patch("apm_cli.deps.registry_proxy.RegistryConfig.from_env", return_value=None),
+        patch(
+            "apm_cli.integration.base_integrator.BaseIntegrator.normalize_managed_files",
+            return_value=set(),
+        ),
+        patch("apm_cli.commands._helpers._update_gitignore_for_apm_modules"),
+    ]
+
+
+class TestGitignoreScopeGuard:
+    """_update_gitignore_for_apm_modules must not run under InstallScope.USER."""
+
+    def test_global_scope_does_not_call_update_gitignore(self) -> None:
+        """Regression: apm install -g (USER scope) must never touch .gitignore."""
+        from apm_cli.install.pipeline import run_install_pipeline
+
+        pkg = _make_pkg_with_dep()
+
+        patches = _common_patches()
+        with (
+            patches[0] as mock_lf_cls,
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5] as mock_run_phase,
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9] as mock_gitignore,
+        ):
+            mock_lf_cls.read.return_value = None
+
+            def _resolve_sets_deps(name, phase, ctx):
+                if name == "resolve":
+                    ctx.deps_to_install = [MagicMock()]
+
+            mock_run_phase.side_effect = _resolve_sets_deps
+
+            run_install_pipeline(pkg, scope=InstallScope.USER)
+
+        mock_gitignore.assert_not_called()
+
+    def test_project_scope_calls_update_gitignore(self) -> None:
+        """PROJECT scope (the default) must still update .gitignore."""
+        from apm_cli.install.pipeline import run_install_pipeline
+
+        pkg = _make_pkg_with_dep()
+
+        patches = _common_patches()
+        with (
+            patches[0] as mock_lf_cls,
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5] as mock_run_phase,
+            patches[6],
+            patches[7],
+            patches[8],
+            patches[9] as mock_gitignore,
+        ):
+            mock_lf_cls.read.return_value = None
+
+            def _resolve_sets_deps(name, phase, ctx):
+                if name == "resolve":
+                    ctx.deps_to_install = [MagicMock()]
+
+            mock_run_phase.side_effect = _resolve_sets_deps
+
+            run_install_pipeline(pkg, scope=InstallScope.PROJECT)
+
+        mock_gitignore.assert_called_once()

--- a/tests/unit/install/test_gitignore_scope_guard.py
+++ b/tests/unit/install/test_gitignore_scope_guard.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 from apm_cli.core.scope import InstallScope
 
 
-def _make_pkg_with_dep():
+def _make_pkg_with_dep() -> MagicMock:
     pkg = MagicMock()
     dep = MagicMock()
     dep.repo_url = "owner/repo"
@@ -23,7 +23,7 @@ def _make_pkg_with_dep():
 
 
 def _common_patches():
-    """Return a list of (target, kwargs) patch pairs shared by all tests."""
+    """Return a list of patch context managers shared by all tests."""
     return [
         patch("apm_cli.deps.lockfile.LockFile"),
         patch("apm_cli.deps.lockfile.get_lockfile_path", return_value=None),


### PR DESCRIPTION
## Problem

`apm install -g` (`InstallScope.USER`) unconditionally called `_update_gitignore_for_apm_modules`, writing or modifying a `.gitignore` file in whatever directory the user happened to be in at the time of install. A global install has no concept of a project root, so touching `.gitignore` there is wrong.

## Approach

Guard the `_update_gitignore_for_apm_modules` call in `src/apm_cli/install/pipeline.py` so it only runs when `scope == InstallScope.PROJECT`. The `InstallScope` import was already present at line 368.

## Implementation

**`src/apm_cli/install/pipeline.py`** (lines 677-680): Wrap the `_update_gitignore_for_apm_modules` call in `if scope == InstallScope.PROJECT:`.

**`tests/unit/install/test_gitignore_scope_guard.py`**: Adds two regression tests:
- `test_global_scope_does_not_call_update_gitignore` -- asserts the fn is NOT called under `InstallScope.USER`
- `test_project_scope_calls_update_gitignore` -- asserts the fn IS called under `InstallScope.PROJECT`

Both tests confirmed red pre-fix, green post-fix, and re-break on mutation revert.

## Validation evidence

```
# Pre-fix: test_global_scope_does_not_call_update_gitignore FAILED (gitignore fn called 1 time)
# Post-fix:
uv run --extra dev pytest tests/unit/install/test_gitignore_scope_guard.py -v
  test_global_scope_does_not_call_update_gitignore PASSED
  test_project_scope_calls_update_gitignore PASSED
  2 passed in 1.18s

uv run --extra dev pytest tests/unit/install/ tests/unit/test_command_helpers.py tests/unit/commands/test_helpers_coverage.py -q
  1557 passed in 13.99s

uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/
  All checks passed!

uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/
  Your code has been rated at 10.00/10

bash scripts/lint-auth-signals.sh
  [+] auth-signal lint clean
```

Closes #1577