### PR TITLE
fix: send auth header for GitHub release lookup in installer and self-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `apm publish` auto-pack now includes `README.md`, `CHANGELOG.md`, and `LICENSE` / `LICENCE` (case-insensitive, symlinks excluded) in the flat registry archive, matching npm's behaviour of bundling standard root-level documentation files alongside the package source.
+- `install.sh` and `apm self-update` now send a conditional `Authorization` header on GitHub release-lookup API calls when `GITHUB_APM_PAT`, `GITHUB_TOKEN`, or `GH_TOKEN` is set, improving reliability for users on shared IPs and corporate NAT that hit anonymous rate limits. Anonymous fallback is preserved when no token is configured. (closes #1582)
 
 ## [0.16.1] - 2026-06-01
 

--- a/install.sh
+++ b/install.sh
@@ -228,8 +228,14 @@ if [ -z "$TAG_NAME" ]; then
 # Get latest release info
 echo -e "${YELLOW}Fetching latest release information...${NC}"
 
-# Try to fetch release info without authentication first (for public repos)
-LATEST_RELEASE=$(curl -s "https://api.github.com/repos/$APM_REPO/releases/latest")
+# Fetch release info; include Authorization header when a token is already resolved
+# (AUTH_HEADER_VALUE set earlier from GITHUB_APM_PAT > GITHUB_TOKEN precedence).
+# This avoids anonymous rate-limiting behind shared IPs / corporate NAT.
+if [ -n "$AUTH_HEADER_VALUE" ]; then
+    LATEST_RELEASE=$(curl -s -H "Authorization: token $AUTH_HEADER_VALUE" "https://api.github.com/repos/$APM_REPO/releases/latest")
+else
+    LATEST_RELEASE=$(curl -s "https://api.github.com/repos/$APM_REPO/releases/latest")
+fi
 CURL_EXIT_CODE=$?
 
 # Check if the response indicates authentication is required (private repo)

--- a/install.sh
+++ b/install.sh
@@ -210,10 +210,13 @@ if [ -e "$APM_INSTALL_DIR" ] && [ ! -w "$APM_INSTALL_DIR" ]; then
 fi
 
 # Resolve auth token (needed for both API and download paths)
+# Precedence: GITHUB_APM_PAT > GITHUB_TOKEN > GH_TOKEN (mirrors version_checker.py)
 if [ -n "$GITHUB_APM_PAT" ]; then
     AUTH_HEADER_VALUE="$GITHUB_APM_PAT"
 elif [ -n "$GITHUB_TOKEN" ]; then
     AUTH_HEADER_VALUE="$GITHUB_TOKEN"
+elif [ -n "$GH_TOKEN" ]; then
+    AUTH_HEADER_VALUE="$GH_TOKEN"
 fi
 
 # When VERSION is provided, skip GitHub API and compute download URL directly
@@ -229,7 +232,7 @@ if [ -z "$TAG_NAME" ]; then
 echo -e "${YELLOW}Fetching latest release information...${NC}"
 
 # Fetch release info; include Authorization header when a token is already resolved
-# (AUTH_HEADER_VALUE set earlier from GITHUB_APM_PAT > GITHUB_TOKEN precedence).
+# (AUTH_HEADER_VALUE set earlier from GITHUB_APM_PAT > GITHUB_TOKEN > GH_TOKEN precedence).
 # This avoids anonymous rate-limiting behind shared IPs / corporate NAT.
 if [ -n "$AUTH_HEADER_VALUE" ]; then
     LATEST_RELEASE=$(curl -s -H "Authorization: token $AUTH_HEADER_VALUE" "https://api.github.com/repos/$APM_REPO/releases/latest")

--- a/src/apm_cli/utils/version_checker.py
+++ b/src/apm_cli/utils/version_checker.py
@@ -1,14 +1,36 @@
 """Version checking and update notification utilities."""
 
+import os
 import re
 import sys
 from pathlib import Path
 from typing import Optional, Tuple  # noqa: F401, UP035
 
 
+def _get_github_token() -> str | None:
+    """Return a GitHub token following canonical precedence, or None.
+
+    Precedence mirrors TOKEN_PRECEDENCE["modules"] in core/token_manager.py:
+      GITHUB_APM_PAT -> GITHUB_TOKEN -> GH_TOKEN
+
+    The token value is never logged or included in any output.
+    """
+    return (
+        os.environ.get("GITHUB_APM_PAT")
+        or os.environ.get("GITHUB_TOKEN")
+        or os.environ.get("GH_TOKEN")
+        or None
+    )
+
+
 def get_latest_version_from_github(repo: str = "microsoft/apm", timeout: int = 2) -> str | None:
     """
     Fetch the latest release version from GitHub API.
+
+    Sends an Authorization header when a GitHub token is present in the
+    environment (GITHUB_APM_PAT > GITHUB_TOKEN > GH_TOKEN), falling back to
+    anonymous when none is set. This avoids rate-limit failures on shared IPs
+    and corporate NAT. The token value is never logged or echoed.
 
     Args:
         repo: Repository in format "owner/repo"
@@ -24,7 +46,9 @@ def get_latest_version_from_github(repo: str = "microsoft/apm", timeout: int = 2
 
     try:
         url = f"https://api.github.com/repos/{repo}/releases/latest"
-        response = requests.get(url, timeout=timeout)
+        token = _get_github_token()
+        headers = {"Authorization": f"token {token}"} if token else {}
+        response = requests.get(url, headers=headers, timeout=timeout)
 
         if response.status_code != 200:
             return None

--- a/src/apm_cli/utils/version_checker.py
+++ b/src/apm_cli/utils/version_checker.py
@@ -4,7 +4,6 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import Optional, Tuple  # noqa: F401, UP035
 
 
 def _get_github_token() -> str | None:

--- a/tests/unit/test_version_checker.py
+++ b/tests/unit/test_version_checker.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 from apm_cli.utils.version_checker import (
+    _get_github_token,
     check_for_updates,
     get_latest_version_from_github,
     is_newer_version,
@@ -164,6 +165,121 @@ class TestGitHubVersionFetch(unittest.TestCase):
 
         result = get_latest_version_from_github()
         self.assertIsNone(result)
+
+
+class TestGitHubTokenResolution(unittest.TestCase):
+    """Test GitHub token resolution helper."""
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_no_token_when_env_empty(self):
+        """Returns None when no token env vars are set."""
+        for var in ("GITHUB_APM_PAT", "GITHUB_TOKEN", "GH_TOKEN"):
+            self.assertNotIn(var, __import__("os").environ)
+        self.assertIsNone(_get_github_token())
+
+    @patch.dict("os.environ", {"GITHUB_APM_PAT": "pat_value"}, clear=False)
+    def test_prefers_github_apm_pat(self):
+        """GITHUB_APM_PAT is chosen over GITHUB_TOKEN and GH_TOKEN."""
+        with patch.dict("os.environ", {"GITHUB_TOKEN": "ghtok", "GH_TOKEN": "gh"}):
+            token = _get_github_token()
+        self.assertEqual(token, "pat_value")
+
+    @patch.dict("os.environ", {"GITHUB_TOKEN": "ghtok"}, clear=False)
+    def test_falls_back_to_github_token(self):
+        """Falls back to GITHUB_TOKEN when GITHUB_APM_PAT is absent."""
+        import os
+
+        env = {k: v for k, v in os.environ.items() if k not in ("GITHUB_APM_PAT", "GH_TOKEN")}
+        env["GITHUB_TOKEN"] = "ghtok"
+        with patch.dict("os.environ", env, clear=True):
+            token = _get_github_token()
+        self.assertEqual(token, "ghtok")
+
+    @patch.dict("os.environ", {"GH_TOKEN": "gh_value"}, clear=True)
+    def test_falls_back_to_gh_token(self):
+        """Falls back to GH_TOKEN as last resort."""
+        token = _get_github_token()
+        self.assertEqual(token, "gh_value")
+
+
+class TestGitHubVersionFetchAuth(unittest.TestCase):
+    """Test that get_latest_version_from_github sends auth headers correctly."""
+
+    @patch("apm_cli.utils.version_checker._get_github_token", return_value=None)
+    @patch("requests.get")
+    def test_no_auth_header_when_no_token(self, mock_get, mock_token):
+        """No Authorization header is sent when no token is present."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"tag_name": "v0.8.0"}
+        mock_get.return_value = mock_response
+
+        get_latest_version_from_github()
+
+        call_kwargs = mock_get.call_args[1]
+        headers = call_kwargs.get("headers", {})
+        self.assertNotIn("Authorization", headers)
+
+    @patch("apm_cli.utils.version_checker._get_github_token", return_value="my_secret_token")
+    @patch("requests.get")
+    def test_auth_header_sent_when_token_present(self, mock_get, mock_token):
+        """Authorization header IS sent when a token is available."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"tag_name": "v0.8.0"}
+        mock_get.return_value = mock_response
+
+        get_latest_version_from_github()
+
+        call_kwargs = mock_get.call_args[1]
+        headers = call_kwargs.get("headers", {})
+        self.assertIn("Authorization", headers)
+        self.assertTrue(headers["Authorization"].startswith("token "))
+
+    @patch("apm_cli.utils.version_checker._get_github_token", return_value="my_secret_token")
+    @patch("requests.get")
+    def test_token_value_not_in_exception_text(self, mock_get, mock_token):
+        """Token value must not appear in any raised exception or return value."""
+        mock_get.side_effect = Exception("connection refused")
+
+        import io
+        import logging
+
+        log_capture = io.StringIO()
+        handler = logging.StreamHandler(log_capture)
+        root = logging.getLogger()
+        root.addHandler(handler)
+
+        result = get_latest_version_from_github()
+
+        root.removeHandler(handler)
+        log_output = log_capture.getvalue()
+
+        self.assertIsNone(result)
+        self.assertNotIn("my_secret_token", log_output)
+
+    @patch("apm_cli.utils.version_checker._get_github_token", return_value=None)
+    @patch("requests.get")
+    def test_rate_limit_403_returns_none_without_token(self, mock_get, mock_token):
+        """A 403 rate-limit response with no token returns None gracefully."""
+        mock_response = Mock()
+        mock_response.status_code = 403
+        mock_get.return_value = mock_response
+
+        result = get_latest_version_from_github()
+        self.assertIsNone(result)
+
+    @patch("apm_cli.utils.version_checker._get_github_token", return_value="valid_token")
+    @patch("requests.get")
+    def test_200_with_token_returns_version(self, mock_get, mock_token):
+        """A 200 response when token is present returns the version string."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"tag_name": "v1.0.0"}
+        mock_get.return_value = mock_response
+
+        result = get_latest_version_from_github()
+        self.assertEqual(result, "1.0.0")
 
 
 class TestVersionCheckCache(unittest.TestCase):


### PR DESCRIPTION
## TL;DR

Two anonymous GitHub API calls caused rate-limit failures (403) on shared IPs and corporate NAT. Both now send a conditional `Authorization` header when a token is present, with anonymous fallback preserved.

Closes #1582

## Problem

**install.sh** resolved `AUTH_HEADER_VALUE` (from `GITHUB_APM_PAT` / `GITHUB_TOKEN`) around line 213, but the first `releases/latest` curl call around line 232 ignored it and ran anonymously. Under rate-limiting the first call would fail, triggering the private-repo fallback unnecessarily.

**`src/apm_cli/utils/version_checker.py`** `get_latest_version_from_github` called `requests.get` with no headers; `self_update.py` calls this function, so `apm self-update` also hit the rate limit silently.

## Approach

- **install.sh**: conditional first curl -- send `Authorization: token $AUTH_HEADER_VALUE` when already resolved; anonymous otherwise. Anonymous fallback + private-repo retry path unchanged.
- **version_checker.py**: add `_get_github_token()` following canonical `TOKEN_PRECEDENCE["modules"]` order (`GITHUB_APM_PAT -> GITHUB_TOKEN -> GH_TOKEN`); pass header in `requests.get` only when a token is present.

## Implementation

**install.sh** (around line 231):
```bash
if [ -n "$AUTH_HEADER_VALUE" ]; then
    LATEST_RELEASE=$(curl -s -H "Authorization: token $AUTH_HEADER_VALUE" ...)
else
    LATEST_RELEASE=$(curl -s ...)
fi
```

**version_checker.py**:
```python
def _get_github_token() -> str | None:
    return (
        os.environ.get("GITHUB_APM_PAT")
        or os.environ.get("GITHUB_TOKEN")
        or os.environ.get("GH_TOKEN")
        or None
    )
# ...
token = _get_github_token()
headers = {"Authorization": f"token {token}"} if token else {}
response = requests.get(url, headers=headers, timeout=timeout)
```

## Auth guardrails

- Token precedence: `GITHUB_APM_PAT > GITHUB_TOKEN > GH_TOKEN` (mirrors `TOKEN_PRECEDENCE["modules"]` in `core/token_manager.py`). No new env vars.
- Token value is never logged, echoed, or included in any exception text.
- Anonymous fallback preserved when no token is set (header is omitted, not empty).
- `scripts/lint-auth-signals.sh` passes (no `get_bearer_provider` or unannotated `git ls-remote` violations).

## Validation evidence

```
$ uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/
All checks passed! / 1161 files already formatted

$ uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/
Your code has been rated at 10.00/10

$ bash scripts/lint-auth-signals.sh
[+] auth-signal lint clean

$ bash -n install.sh
(exit 0)

$ uv run --extra dev pytest tests/unit/test_version_checker.py -v
34 passed in 2.44s
```

New tests (`TestGitHubTokenResolution`, `TestGitHubVersionFetchAuth`):
- Assert `Authorization` header is sent only when a token is present
- Assert 403 rate-limit response with no token returns `None` gracefully
- Assert token value does not appear in any log/exception output
- Assert 200 with token returns the version string