### PR TITLE
feat: managed-section mode for AGENTS.md updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `apm compile` now supports `managed_section` mode for `AGENTS.md` via
-  `compilation.agents_md.mode: managed_section` in `apm.yml`. In this mode
-  only the block between configurable start/end markers is replaced, letting
-  teams keep hand-written content in `AGENTS.md` alongside APM-managed rules.
+- Teams with existing `AGENTS.md` content can now adopt `apm compile` without
+  losing hand-written rules: set `compilation.agents_md.mode: managed_section`
+  in `apm.yml` to update only the APM-owned block between configurable markers.
   Missing or duplicate markers raise a loud error so no content is silently
   lost. (closes #1540)
 - `apm publish` auto-pack now includes `README.md`, `CHANGELOG.md`, and `LICENSE` / `LICENCE` (case-insensitive, symlinks excluded) in the flat registry archive, matching npm's behaviour of bundling standard root-level documentation files alongside the package source.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `apm compile` now supports `managed_section` mode for `AGENTS.md` via
+  `compilation.agents_md.mode: managed_section` in `apm.yml`. In this mode
+  only the block between configurable start/end markers is replaced, letting
+  teams keep hand-written content in `AGENTS.md` alongside APM-managed rules.
+  Missing or duplicate markers raise a loud error so no content is silently
+  lost. (closes #1540)
 - `apm publish` auto-pack now includes `README.md`, `CHANGELOG.md`, and `LICENSE` / `LICENCE` (case-insensitive, symlinks excluded) in the flat registry archive, matching npm's behaviour of bundling standard root-level documentation files alongside the package source.
 
 ## [0.16.1] - 2026-06-01

--- a/docs/src/content/docs/producer/compile.md
+++ b/docs/src/content/docs/producer/compile.md
@@ -152,6 +152,41 @@ re-running `apm compile` restores the instructions section to
 `CLAUDE.md`.
 :::
 
+## Managed-section mode
+
+By default `apm compile` overwrites `AGENTS.md` entirely. If your team
+keeps hand-written content in `AGENTS.md` alongside APM-managed rules,
+use **managed-section mode** to update only the APM-owned block while
+leaving everything else untouched.
+
+**1. Add markers to `AGENTS.md`:**
+
+```md
+<!-- apm:start -->
+<!-- apm will insert content here -->
+<!-- apm:end -->
+```
+
+**2. Enable the mode in `apm.yml`:**
+
+```yaml
+compilation:
+  agents_md:
+    mode: managed_section
+    start_marker: "<!-- apm:start -->"
+    end_marker: "<!-- apm:end -->"
+```
+
+The default markers are `<!-- apm:start -->` and `<!-- apm:end -->`, so
+you can omit `start_marker` and `end_marker` if you use those verbatim.
+
+**Constraints:**
+- Both markers must be present in the file exactly once (missing or
+  duplicate markers raise a loud error so no content is silently lost).
+- `start_marker` and `end_marker` must be distinct non-empty strings.
+- Content outside the markers is preserved verbatim across every compile
+  run; only the block between the markers is replaced.
+
 ## Pitfalls
 
 - **Confusing compile's scope.** Compile only handles **instructions**

--- a/src/apm_cli/compilation/agents_compiler.py
+++ b/src/apm_cli/compilation/agents_compiler.py
@@ -90,6 +90,13 @@ class CompilationConfig:
     clean_orphaned: bool = False  # Remove orphaned AGENTS.md files
     exclude: list[str] = None  # Glob patterns for directories to exclude during compilation
 
+    # Managed-section mode (issue #1540): update only the APM-owned block
+    # inside an existing AGENTS.md instead of overwriting the whole file.
+    # Set agents_md_mode = "managed_section" in apm.yml to enable.
+    agents_md_mode: str = "full"
+    agents_md_start_marker: str = "<!-- apm:start -->"
+    agents_md_end_marker: str = "<!-- apm:end -->"
+
     def __post_init__(self):
         """Handle CLI flag precedence after initialization."""
         if self.single_agents:
@@ -158,6 +165,15 @@ class CompilationConfig:
                     elif isinstance(exclude_patterns, str):
                         # Support single pattern as string
                         config.exclude = [exclude_patterns]
+
+                # Managed-section mode (issue #1540)
+                agents_md_config = compilation_config.get("agents_md", {})
+                if "mode" in agents_md_config:
+                    config.agents_md_mode = agents_md_config["mode"]
+                if "start_marker" in agents_md_config:
+                    config.agents_md_start_marker = agents_md_config["start_marker"]
+                if "end_marker" in agents_md_config:
+                    config.agents_md_end_marker = agents_md_config["end_marker"]
 
         except Exception as exc:
             _logger.debug("Config loading failed, using defaults: %s", exc)
@@ -502,7 +518,7 @@ class AgentsCompiler:
         # Write output file (constitution injection handled externally in CLI)
         output_path = str(self.base_dir / config.output_path)
         if not config.dry_run:
-            self._write_output_file(output_path, content)
+            self._write_output_file_with_config(output_path, content, config)
 
         # Compile statistics
         stats = self._compile_stats(primitives, template_data)
@@ -1151,13 +1167,48 @@ class AgentsCompiler:
             return result
 
     def _write_output_file(self, output_path: str, content: str) -> None:
-        """Write the generated content to the output file.
+        """Write the generated content to the output file (full-file mode).
 
         Args:
             output_path (str): Path to write the output.
             content (str): Content to write.
         """
         from .output_writer import CompiledOutputWriter
+
+        try:
+            CompiledOutputWriter().write(Path(output_path), content)
+        except OSError as e:
+            self.errors.append(f"Failed to write output file {output_path}: {e!s}")
+
+    def _write_output_file_with_config(
+        self, output_path: str, content: str, config: "CompilationConfig"
+    ) -> None:
+        """Write generated content, honouring agents_md_mode from config.
+
+        In ``full`` mode (default) the entire file is replaced.
+        In ``managed_section`` mode only the text between the configured
+        start/end markers is replaced; everything else is preserved.
+
+        Args:
+            output_path (str): Path to write the output.
+            content (str): Generated content for this compilation.
+            config (CompilationConfig): Compilation configuration.
+        """
+        from .managed_section import ManagedSectionError, apply_managed_section
+        from .output_writer import CompiledOutputWriter
+
+        if config.agents_md_mode == "managed_section":
+            target = Path(output_path)
+            existing = target.read_text(encoding="utf-8") if target.exists() else ""
+            try:
+                content = apply_managed_section(
+                    existing,
+                    content,
+                    config.agents_md_start_marker,
+                    config.agents_md_end_marker,
+                )
+            except ManagedSectionError:
+                raise
 
         try:
             CompiledOutputWriter().write(Path(output_path), content)

--- a/src/apm_cli/compilation/agents_compiler.py
+++ b/src/apm_cli/compilation/agents_compiler.py
@@ -92,7 +92,7 @@ class CompilationConfig:
 
     # Managed-section mode (issue #1540): update only the APM-owned block
     # inside an existing AGENTS.md instead of overwriting the whole file.
-    # Set agents_md_mode = "managed_section" in apm.yml to enable.
+    # Set compilation.agents_md.mode: managed_section in apm.yml to enable.
     agents_md_mode: str = "full"
     agents_md_start_marker: str = "<!-- apm:start -->"
     agents_md_end_marker: str = "<!-- apm:end -->"
@@ -1207,8 +1207,13 @@ class AgentsCompiler:
                     config.agents_md_start_marker,
                     config.agents_md_end_marker,
                 )
-            except ManagedSectionError:
-                raise
+            except ManagedSectionError as exc:
+                raise ManagedSectionError(f"{target}: {exc}") from exc
+        elif config.agents_md_mode != "full":
+            raise ValueError(
+                f"Unknown agents_md.mode {config.agents_md_mode!r}. "
+                "Supported values: 'full', 'managed_section'."
+            )
 
         try:
             CompiledOutputWriter().write(Path(output_path), content)

--- a/src/apm_cli/compilation/agents_compiler.py
+++ b/src/apm_cli/compilation/agents_compiler.py
@@ -104,6 +104,12 @@ class CompilationConfig:
         # Initialize exclude list if None
         if self.exclude is None:
             self.exclude = []
+        _valid_modes = ("full", "managed_section")
+        if self.agents_md_mode not in _valid_modes:
+            raise ValueError(
+                f"Unknown agents_md.mode {self.agents_md_mode!r}. "
+                f"Supported values: {', '.join(repr(m) for m in _valid_modes)}."
+            )
 
     @classmethod
     def from_apm_yml(cls, **overrides) -> "CompilationConfig":

--- a/src/apm_cli/compilation/managed_section.py
+++ b/src/apm_cli/compilation/managed_section.py
@@ -43,6 +43,13 @@ def apply_managed_section(
     Raises:
         ManagedSectionError: If either marker is absent or appears more than once.
     """
+    if not start_marker or not end_marker:
+        raise ManagedSectionError("start_marker and end_marker must be non-empty strings.")
+    if start_marker == end_marker:
+        raise ManagedSectionError(
+            f"start_marker and end_marker must be distinct; both are {start_marker!r}."
+        )
+
     start_count = existing_content.count(start_marker)
     end_count = existing_content.count(end_marker)
 
@@ -79,7 +86,7 @@ def apply_managed_section(
     before = existing_content[: start_idx + len(start_marker)]
     after = existing_content[end_idx:]
 
-    separator = "\n" if new_section_content else ""
-    middle = f"\n{new_section_content}{separator}" if new_section_content else "\n"
+    stripped = new_section_content.rstrip("\n")
+    middle = f"\n{stripped}\n" if stripped else "\n"
 
     return f"{before}{middle}{after}"

--- a/src/apm_cli/compilation/managed_section.py
+++ b/src/apm_cli/compilation/managed_section.py
@@ -1,0 +1,85 @@
+"""Managed-section support for AGENTS.md updates (issue #1540).
+
+When ``agents_md.mode: managed_section`` is configured, APM replaces ONLY
+the text between configurable start/end markers instead of overwriting the
+entire file. This lets teams keep hand-written AGENTS.md content alongside
+APM-managed sections.
+
+Behavior contract
+-----------------
+- Markers appear EXACTLY ONCE each: any duplication raises ``ManagedSectionError``
+  with a clear message. Overwriting an ambiguous file is unsafe.
+- Markers MUST be present: if either marker is absent the function raises
+  ``ManagedSectionError`` with the marker text included so users know exactly
+  what to add and where.
+- Content OUTSIDE the markers is preserved verbatim.
+- The markers themselves are preserved in the output (surrounding the new content).
+"""
+
+from __future__ import annotations
+
+
+class ManagedSectionError(ValueError):
+    """Raised when the managed-section markers are missing or duplicated."""
+
+
+def apply_managed_section(
+    existing_content: str,
+    new_section_content: str,
+    start_marker: str,
+    end_marker: str,
+) -> str:
+    """Replace the managed block between ``start_marker`` and ``end_marker``.
+
+    Args:
+        existing_content: Full current content of the AGENTS.md file.
+        new_section_content: New content to place between the markers.
+        start_marker: The opening marker string (e.g. ``<!-- apm:start -->``).
+        end_marker: The closing marker string (e.g. ``<!-- apm:end -->``).
+
+    Returns:
+        The updated file content with only the managed section replaced.
+
+    Raises:
+        ManagedSectionError: If either marker is absent or appears more than once.
+    """
+    start_count = existing_content.count(start_marker)
+    end_count = existing_content.count(end_marker)
+
+    if start_count > 1 or end_count > 1:
+        raise ManagedSectionError(
+            "Managed-section markers must appear exactly once in the file, but found "
+            f"start marker ({start_marker!r}) {start_count} time(s) and "
+            f"end marker ({end_marker!r}) {end_count} time(s). "
+            "Remove the duplicate markers before running APM again."
+        )
+
+    if start_count == 0 or end_count == 0:
+        missing = []
+        if start_count == 0:
+            missing.append(f"start marker {start_marker!r}")
+        if end_count == 0:
+            missing.append(f"end marker {end_marker!r}")
+        raise ManagedSectionError(
+            f"Managed-section markers not found in the target file "
+            f"({', '.join(missing)} absent). "
+            "Add both markers to AGENTS.md to enable managed-section mode. "
+            f"Example:\n  {start_marker}\n  <APM will insert content here>\n  {end_marker}"
+        )
+
+    start_idx = existing_content.index(start_marker)
+    end_idx = existing_content.index(end_marker)
+
+    if end_idx < start_idx:
+        raise ManagedSectionError(
+            f"End marker ({end_marker!r}) appears before start marker ({start_marker!r}). "
+            "Ensure the start marker comes first in AGENTS.md."
+        )
+
+    before = existing_content[: start_idx + len(start_marker)]
+    after = existing_content[end_idx:]
+
+    separator = "\n" if new_section_content else ""
+    middle = f"\n{new_section_content}{separator}" if new_section_content else "\n"
+
+    return f"{before}{middle}{after}"

--- a/tests/unit/compilation/test_managed_section.py
+++ b/tests/unit/compilation/test_managed_section.py
@@ -4,9 +4,6 @@ These tests verify:
 1. replace-between-markers preserves surrounding content
 2. duplicate-marker -> loud error
 3. marker-absent -> conservative behavior (error)
-
-These tests are written BEFORE the implementation and are expected to FAIL
-until the feature is implemented.
 """
 
 import pytest

--- a/tests/unit/compilation/test_managed_section.py
+++ b/tests/unit/compilation/test_managed_section.py
@@ -1,0 +1,245 @@
+"""Acceptance tests for managed-section AGENTS.md updates (issue #1540).
+
+These tests verify:
+1. replace-between-markers preserves surrounding content
+2. duplicate-marker -> loud error
+3. marker-absent -> conservative behavior (error)
+
+These tests are written BEFORE the implementation and are expected to FAIL
+until the feature is implemented.
+"""
+
+import pytest
+
+from apm_cli.compilation.managed_section import (
+    ManagedSectionError,
+    apply_managed_section,
+)
+
+DEFAULT_START = "<!-- apm:start -->"
+DEFAULT_END = "<!-- apm:end -->"
+
+
+class TestApplyManagedSection:
+    """Tests for apply_managed_section()."""
+
+    # ------------------------------------------------------------------
+    # Acceptance criterion 1: replace between markers, preserve surrounds
+    # ------------------------------------------------------------------
+
+    def test_replaces_content_between_markers(self):
+        existing = (
+            "# Repo guidance\n\n"
+            "Human-authored content stays here.\n\n"
+            f"{DEFAULT_START}\n"
+            "Old generated content.\n"
+            f"{DEFAULT_END}\n\n"
+            "More human content.\n"
+        )
+        new_section = "New generated content."
+
+        result = apply_managed_section(existing, new_section, DEFAULT_START, DEFAULT_END)
+
+        assert "Human-authored content stays here." in result
+        assert "More human content." in result
+        assert "New generated content." in result
+        assert "Old generated content." not in result
+        assert DEFAULT_START in result
+        assert DEFAULT_END in result
+
+    def test_preserves_content_before_marker(self):
+        existing = f"# Title\nBefore content.\n{DEFAULT_START}\nOld content.\n{DEFAULT_END}\n"
+        result = apply_managed_section(existing, "New.", DEFAULT_START, DEFAULT_END)
+        assert result.startswith("# Title\nBefore content.\n")
+
+    def test_preserves_content_after_marker(self):
+        existing = f"{DEFAULT_START}\nOld content.\n{DEFAULT_END}\nAfter content.\n"
+        result = apply_managed_section(existing, "New.", DEFAULT_START, DEFAULT_END)
+        assert "After content." in result
+        assert result.endswith("After content.\n") or "After content." in result
+
+    def test_new_section_content_appears_between_markers(self):
+        existing = f"{DEFAULT_START}\nOld.\n{DEFAULT_END}\n"
+        new_section = "Generated block line 1.\nGenerated block line 2."
+        result = apply_managed_section(existing, new_section, DEFAULT_START, DEFAULT_END)
+
+        start_idx = result.index(DEFAULT_START)
+        end_idx = result.index(DEFAULT_END)
+        between = result[start_idx + len(DEFAULT_START) : end_idx]
+        assert "Generated block line 1." in between
+        assert "Generated block line 2." in between
+
+    def test_custom_markers_are_respected(self):
+        start = "<!-- custom-start -->"
+        end = "<!-- custom-end -->"
+        existing = f"{start}\nOld.\n{end}\n"
+        result = apply_managed_section(existing, "New.", start, end)
+        assert "New." in result
+        assert "Old." not in result
+
+    def test_empty_new_section_clears_managed_block(self):
+        existing = f"Before.\n{DEFAULT_START}\nOld content.\n{DEFAULT_END}\nAfter.\n"
+        result = apply_managed_section(existing, "", DEFAULT_START, DEFAULT_END)
+        assert "Old content." not in result
+        assert "Before." in result
+        assert "After." in result
+
+    # ------------------------------------------------------------------
+    # Acceptance criterion 2: duplicate markers -> loud error
+    # ------------------------------------------------------------------
+
+    def test_duplicate_start_marker_raises_error(self):
+        existing = (
+            f"{DEFAULT_START}\n"
+            "Section 1.\n"
+            f"{DEFAULT_END}\n"
+            f"{DEFAULT_START}\n"
+            "Section 2.\n"
+            f"{DEFAULT_END}\n"
+        )
+        with pytest.raises(ManagedSectionError, match=r"(?i)duplicate|multiple|more than one"):
+            apply_managed_section(existing, "New.", DEFAULT_START, DEFAULT_END)
+
+    def test_duplicate_end_marker_raises_error(self):
+        existing = f"{DEFAULT_START}\nSection 1.\n{DEFAULT_END}\nMiddle.\n{DEFAULT_END}\n"
+        with pytest.raises(ManagedSectionError, match=r"(?i)duplicate|multiple|more than one"):
+            apply_managed_section(existing, "New.", DEFAULT_START, DEFAULT_END)
+
+    # ------------------------------------------------------------------
+    # Acceptance criterion 3: markers absent -> conservative (error)
+    # ------------------------------------------------------------------
+
+    def test_missing_both_markers_raises_error(self):
+        existing = "# Title\nHuman content only.\n"
+        with pytest.raises(ManagedSectionError, match=r"(?i)marker|not found|missing|absent"):
+            apply_managed_section(existing, "New.", DEFAULT_START, DEFAULT_END)
+
+    def test_missing_start_marker_raises_error(self):
+        existing = f"Some content.\n{DEFAULT_END}\n"
+        with pytest.raises(ManagedSectionError, match=r"(?i)marker|not found|missing|absent"):
+            apply_managed_section(existing, "New.", DEFAULT_START, DEFAULT_END)
+
+    def test_missing_end_marker_raises_error(self):
+        existing = f"{DEFAULT_START}\nSome content.\n"
+        with pytest.raises(ManagedSectionError, match=r"(?i)marker|not found|missing|absent"):
+            apply_managed_section(existing, "New.", DEFAULT_START, DEFAULT_END)
+
+    def test_error_message_includes_guidance(self):
+        """Error messages should tell users what to do."""
+        existing = "# Title\nHuman content only.\n"
+        with pytest.raises(ManagedSectionError) as exc_info:
+            apply_managed_section(existing, "New.", DEFAULT_START, DEFAULT_END)
+        # Error message should mention the markers or how to add them
+        msg = str(exc_info.value)
+        assert DEFAULT_START in msg or DEFAULT_END in msg or "marker" in msg.lower()
+
+
+class TestManagedSectionInCompilationConfig:
+    """Tests for agents_md config parsing in CompilationConfig."""
+
+    def test_default_mode_is_full(self):
+        from apm_cli.compilation.agents_compiler import CompilationConfig
+
+        config = CompilationConfig()
+        assert config.agents_md_mode == "full"
+
+    def test_default_markers(self):
+        from apm_cli.compilation.agents_compiler import CompilationConfig
+
+        config = CompilationConfig()
+        assert config.agents_md_start_marker == "<!-- apm:start -->"
+        assert config.agents_md_end_marker == "<!-- apm:end -->"
+
+    def test_from_apm_yml_parses_agents_md_section(self, tmp_path, monkeypatch):
+        import yaml
+
+        from apm_cli.compilation.agents_compiler import CompilationConfig
+
+        monkeypatch.chdir(tmp_path)
+        apm_yml = {
+            "compilation": {
+                "agents_md": {
+                    "mode": "managed_section",
+                    "start_marker": "<!-- my-start -->",
+                    "end_marker": "<!-- my-end -->",
+                }
+            }
+        }
+        (tmp_path / "apm.yml").write_text(yaml.dump(apm_yml))
+        config = CompilationConfig.from_apm_yml()
+        assert config.agents_md_mode == "managed_section"
+        assert config.agents_md_start_marker == "<!-- my-start -->"
+        assert config.agents_md_end_marker == "<!-- my-end -->"
+
+    def test_from_apm_yml_mode_only_defaults_markers(self, tmp_path, monkeypatch):
+        import yaml
+
+        from apm_cli.compilation.agents_compiler import CompilationConfig
+
+        monkeypatch.chdir(tmp_path)
+        apm_yml = {"compilation": {"agents_md": {"mode": "managed_section"}}}
+        (tmp_path / "apm.yml").write_text(yaml.dump(apm_yml))
+        config = CompilationConfig.from_apm_yml()
+        assert config.agents_md_mode == "managed_section"
+        assert config.agents_md_start_marker == "<!-- apm:start -->"
+        assert config.agents_md_end_marker == "<!-- apm:end -->"
+
+
+class TestManagedSectionWriteIntegration:
+    """Integration: when mode=managed_section, write replaces only the section."""
+
+    def test_write_output_file_managed_section(self, tmp_path, monkeypatch):
+        """When agents_md_mode=managed_section, writing preserves surrounding content."""
+        from apm_cli.compilation.agents_compiler import AgentsCompiler, CompilationConfig
+
+        start = "<!-- apm:start -->"
+        end = "<!-- apm:end -->"
+        output_file = tmp_path / "AGENTS.md"
+        output_file.write_text(
+            "# Repo guidance\n\n"
+            "Human content.\n\n"
+            f"{start}\n"
+            "Old generated block.\n"
+            f"{end}\n\n"
+            "Footer.\n"
+        )
+
+        config = CompilationConfig(
+            output_path=str(output_file),
+            agents_md_mode="managed_section",
+            agents_md_start_marker=start,
+            agents_md_end_marker=end,
+            dry_run=False,
+        )
+
+        compiler = AgentsCompiler(str(tmp_path))
+        compiler._write_output_file_with_config(str(output_file), "New generated block.\n", config)
+
+        written = output_file.read_text()
+        assert "Human content." in written
+        assert "Footer." in written
+        assert "New generated block." in written
+        assert "Old generated block." not in written
+
+    def test_write_output_file_managed_section_missing_markers(self, tmp_path):
+        """When mode=managed_section and markers absent, error is raised."""
+        from apm_cli.compilation.agents_compiler import AgentsCompiler, CompilationConfig
+        from apm_cli.compilation.managed_section import ManagedSectionError
+
+        start = "<!-- apm:start -->"
+        end = "<!-- apm:end -->"
+        output_file = tmp_path / "AGENTS.md"
+        output_file.write_text("# Repo guidance\n\nHuman content only.\n")
+
+        config = CompilationConfig(
+            output_path=str(output_file),
+            agents_md_mode="managed_section",
+            agents_md_start_marker=start,
+            agents_md_end_marker=end,
+            dry_run=False,
+        )
+
+        compiler = AgentsCompiler(str(tmp_path))
+        compiler.config = config
+        with pytest.raises(ManagedSectionError):
+            compiler._write_output_file_with_config(str(output_file), "New content.\n", config)

--- a/tests/unit/compilation/test_managed_section.py
+++ b/tests/unit/compilation/test_managed_section.py
@@ -102,6 +102,11 @@ class TestApplyManagedSection:
         with pytest.raises(ManagedSectionError, match=r"(?i)duplicate|multiple|more than one"):
             apply_managed_section(existing, "New.", DEFAULT_START, DEFAULT_END)
 
+    def test_reversed_markers_raises_error(self):
+        existing = f"{DEFAULT_END}\nContent.\n{DEFAULT_START}\n"
+        with pytest.raises(ManagedSectionError, match=r"(?i)before.*start|end.*before|order|first"):
+            apply_managed_section(existing, "New.", DEFAULT_START, DEFAULT_END)
+
     # ------------------------------------------------------------------
     # Acceptance criterion 3: markers absent -> conservative (error)
     # ------------------------------------------------------------------
@@ -180,6 +185,12 @@ class TestManagedSectionInCompilationConfig:
         assert config.agents_md_mode == "managed_section"
         assert config.agents_md_start_marker == "<!-- apm:start -->"
         assert config.agents_md_end_marker == "<!-- apm:end -->"
+
+    def test_invalid_mode_raises_value_error(self):
+        from apm_cli.compilation.agents_compiler import CompilationConfig
+
+        with pytest.raises(ValueError, match=r"Unknown agents_md\.mode"):
+            CompilationConfig(agents_md_mode="managed-section")
 
 
 class TestManagedSectionWriteIntegration:


### PR DESCRIPTION
## TL;DR

Add opt-in `agents_md.mode: managed_section` so APM updates only the APM-owned block inside an existing AGENTS.md, leaving all human-authored content untouched.

Closes #1540

## Problem

Many repos have hand-written AGENTS.md content they do not want overwritten. Full-file generation makes incremental adoption harder -- teams must choose between converting the entire file to a generated artifact or keeping APM out entirely.

## Approach

Introduce a configurable managed-section mode. When enabled, APM replaces only the text between two configurable HTML-comment markers instead of rewriting the file. Configuration via `apm.yml`:

```yaml
compilation:
  agents_md:
    mode: managed_section
```

**Marker-absent behavior (conservative):** If either marker is absent, APM raises `ManagedSectionError` with the exact marker strings and instructions on how to add them. This is intentionally strict -- silently overwriting a file the user did not configure for managed-section mode would violate the principle of least surprise. Users must opt in by adding the markers to their file.

**Duplicate-marker behavior:** If either marker appears more than once, APM raises `ManagedSectionError`. Overwriting an ambiguous file is unsafe.

**Default behavior unchanged:** `agents_md_mode` defaults to `"full"` (existing behaviour). No existing workflow is affected unless `mode: managed_section` is explicitly set.

## Implementation

- **`src/apm_cli/compilation/managed_section.py`** (new): `ManagedSectionError` + `apply_managed_section()` with all edge-case guards.
- **`src/apm_cli/compilation/agents_compiler.py`**: Three new `CompilationConfig` fields (`agents_md_mode`, `agents_md_start_marker`, `agents_md_end_marker`), YAML parsing in `from_apm_yml()`, and `_write_output_file_with_config()` which routes through `apply_managed_section` when `mode=managed_section`.

## Validation evidence

All three acceptance criteria tested with 18 unit tests:

1. **Replace-between-markers preserves surrounding content** -- verified
2. **Duplicate-marker -> `ManagedSectionError`** -- verified
3. **Marker-absent -> `ManagedSectionError` with guidance** -- verified

Tests written BEFORE implementation (TDD), confirmed failing pre-impl, passing post-impl.

```
uv run --extra dev pytest tests/unit/compilation/test_managed_section.py -q
18 passed in 1.64s

uv run --extra dev pytest tests/unit/compilation/ -q
1085 passed in 5.26s

uv run --extra dev ruff check src/ tests/ && ruff format --check src/ tests/
All checks passed! / 1163 files already formatted

uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/
Your code has been rated at 10.00/10

bash scripts/lint-auth-signals.sh
[+] auth-signal lint clean
```