### PR TITLE
fix: surface clear 'file does not exist' error in managed_section mode

### DIFF
--- a/src/apm_cli/compilation/agents_compiler.py
+++ b/src/apm_cli/compilation/agents_compiler.py
@@ -1205,7 +1205,12 @@ class AgentsCompiler:
 
         if config.agents_md_mode == "managed_section":
             target = Path(output_path)
-            existing = target.read_text(encoding="utf-8") if target.exists() else ""
+            if not target.exists():
+                raise ValueError(
+                    f"{target} does not exist yet. "
+                    "Create it with markers first, or use mode: full for initial generation."
+                )
+            existing = target.read_text(encoding="utf-8")
             try:
                 content = apply_managed_section(
                     existing,

--- a/tests/unit/compilation/test_managed_section.py
+++ b/tests/unit/compilation/test_managed_section.py
@@ -251,3 +251,25 @@ class TestManagedSectionWriteIntegration:
         compiler.config = config
         with pytest.raises(ManagedSectionError):
             compiler._write_output_file_with_config(str(output_file), "New content.\n", config)
+
+    def test_write_output_file_managed_section_file_not_found(self, tmp_path):
+        """When mode=managed_section and the target file doesn't exist, raise a clear ValueError."""
+        from apm_cli.compilation.agents_compiler import AgentsCompiler, CompilationConfig
+
+        start = "<!-- apm:start -->"
+        end = "<!-- apm:end -->"
+        output_file = tmp_path / "AGENTS.md"
+        # File does NOT exist
+
+        config = CompilationConfig(
+            output_path=str(output_file),
+            agents_md_mode="managed_section",
+            agents_md_start_marker=start,
+            agents_md_end_marker=end,
+            dry_run=False,
+        )
+
+        compiler = AgentsCompiler(str(tmp_path))
+        compiler.config = config
+        with pytest.raises(ValueError, match=r"(?i)does not exist"):
+            compiler._write_output_file_with_config(str(output_file), "New content.\n", config)


### PR DESCRIPTION
## Problem

When `agents_md.mode: managed_section` is configured but the target file doesn't exist, the current code passes an empty string to `apply_managed_section()` which then raises `ManagedSectionError` saying *`markers not found`* — confusing because the real root cause is that the file doesn't exist at all.

## Fix

Detect the missing file first in `_write_output_file_with_config` and raise a clear `ValueError`:

> `AGENTS.md does not exist yet. Create it with markers first, or use mode: full for initial generation.`

## Test Plan

- [x] Added `test_write_output_file_managed_section_file_not_found` — verifies `ValueError` with `match=r"(?i)does not exist"`
- [x] All 21 managed-section tests pass (`TestApplyManagedSection`, `TestManagedSectionInCompilationConfig`, `TestManagedSectionWriteIntegration`)
- [x] Full compilation test suite: 1088 passed in 2.98s

Closes #1593

### For reviewers

This addresses the devx-ux-expert finding from PR #1589: *'markers not found' implies the file exists but markers are absent. 'File does not exist' is a distinct root cause requiring a distinct, actionable message.*