### PR TITLE
docs: remove flake8/black from hello-world python template

### DIFF
--- a/templates/hello-world/.apm/instructions/python.instructions.md
+++ b/templates/hello-world/.apm/instructions/python.instructions.md
@@ -22,6 +22,6 @@ description: "Python development guidelines"
 - Use meaningful test names that describe behavior
 - Implement integration tests for external dependencies
 - Maintain test coverage above 85%
-- Use linting tools (ruff, mypy)
+- Use ruff for linting and formatting, mypy for type checking
 
 See [project architecture](../context/architecture.context.md) for detailed patterns.

--- a/templates/hello-world/.apm/instructions/python.instructions.md
+++ b/templates/hello-world/.apm/instructions/python.instructions.md
@@ -22,6 +22,6 @@ description: "Python development guidelines"
 - Use meaningful test names that describe behavior
 - Implement integration tests for external dependencies
 - Maintain test coverage above 85%
-- Use linting tools (flake8, black, mypy)
+- Use linting tools (ruff, mypy)
 
 See [project architecture](../context/architecture.context.md) for detailed patterns.


### PR DESCRIPTION
## TL;DR

Remove stale `flake8` and `black` references from the hello-world template python instructions, replacing them with `ruff` -- the tool APM actually enforces in CI.

## Problem

Issue #706 reports that `CONTRIBUTING.md` referenced `black` as a formatting tool, causing contributor confusion when running `uv run black .` reformatted 308 files. The root CONTRIBUTING.md was already updated in #999 and #1051. However, the hello-world project template (`templates/hello-world/.apm/instructions/python.instructions.md`) still listed `flake8, black, mypy` as the recommended linting tools -- propagating the same guide-vs-gate mismatch into generated projects.

## Approach

Single targeted line edit: replace `flake8, black` with `ruff` in the template python instructions file. This aligns the template with the actual enforced toolchain.

## Implementation

- `templates/hello-world/.apm/instructions/python.instructions.md`: changed `- Use linting tools (flake8, black, mypy)` to `- Use linting tools (ruff, mypy)`

## Validation evidence

- Grep confirms zero `black`-as-tool references remaining in any `.md` file (excluding spec/manifesto prose usage)
- No Python source files were modified; lint/test gates are unaffected

## How to test

```bash
grep -rn 'black' . --include='*.md' | grep -v '.git/' | grep -v 'openapm' | grep -v 'MANIFESTO' | grep -v 'black-box'
# Expected: no output (exit 1)
```

Closes #706