### PR TITLE
docs: add compilation.agents_md sub-object to manifest-schema reference

### DIFF
--- a/docs/src/content/docs/producer/compile.md
+++ b/docs/src/content/docs/producer/compile.md
@@ -170,6 +170,9 @@ keeps hand-written content in `AGENTS.md` alongside APM-managed rules,
 use **managed-section mode** to update only the APM-owned block while
 leaving everything else untouched.
 
+For the full `apm.yml` key reference for `compilation.agents_md`, see
+[Section 6.2 of the manifest schema](../../reference/manifest-schema/#62-compilationagents_md).
+
 **1. Add markers to `AGENTS.md`:**
 
 ```md

--- a/docs/src/content/docs/producer/compile.md
+++ b/docs/src/content/docs/producer/compile.md
@@ -171,7 +171,7 @@ use **managed-section mode** to update only the APM-owned block while
 leaving everything else untouched.
 
 For the full `apm.yml` key reference for `compilation.agents_md`, see
-[Section 6.2 of the manifest schema](../../reference/manifest-schema/#62-compilationagents_md).
+[the `compilation.agents_md` section in the manifest schema](../reference/manifest-schema/#62-compilationagents_md).
 
 **1. Add markers to `AGENTS.md`:**
 

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -586,6 +586,7 @@ The `compilation` key is OPTIONAL. It controls [`apm compile`](./cli/compile/) b
 | `source_attribution` | `bool` | `false` | | Include source-file origin comments in compiled output (opt-in). |
 | `exclude` | `list<string>` or `string` | `[]` | Glob patterns | Directories to skip during compilation (e.g. `apm_modules/**`). |
 | `placement` | `object` | unset | | Placement tuning. See Section 6.1. |
+| `agents_md` | `object` | unset | | AGENTS.md output tuning. See Section 6.2. |
 
 ### 6.1. `compilation.placement`
 
@@ -603,6 +604,28 @@ compilation:
     - "tmp/**"
   placement:
     min_instructions_per_file: 1
+```
+
+### 6.2. `compilation.agents_md`
+
+Controls how `apm compile` writes the `AGENTS.md` output file. All fields are OPTIONAL; omitting the entire sub-object keeps the default full-overwrite behaviour.
+
+| Field | Type | Default | Constraint | Description |
+|---|---|---|---|---|
+| `mode` | `enum<string>` | `full` | `full`, `managed_section` | `full` overwrites the entire file on every compile. `managed_section` replaces only the block between `start_marker` and `end_marker`, leaving surrounding content untouched. |
+| `start_marker` | `string` | `<!-- apm:start -->` | Non-empty, distinct from `end_marker` | Opening HTML comment that delimits the APM-managed block. Required in the output file when `mode: managed_section`. |
+| `end_marker` | `string` | `<!-- apm:end -->` | Non-empty, distinct from `start_marker` | Closing HTML comment that delimits the APM-managed block. Required in the output file when `mode: managed_section`. |
+
+Both markers must appear **exactly once** in the file; a missing or duplicate marker raises `ManagedSectionError` rather than silently overwriting content.
+
+See [Managed-section mode](../../producer/compile/#managed-section-mode) in the compile guide for usage and marker setup instructions.
+
+```yaml
+compilation:
+  agents_md:
+    mode: managed_section
+    start_marker: "<!-- apm:start -->"
+    end_marker: "<!-- apm:end -->"
 ```
 
 ---

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -608,7 +608,7 @@ compilation:
 
 ### 6.2. `compilation.agents_md`
 
-Controls how `apm compile` writes the `AGENTS.md` output file. All fields are OPTIONAL; omitting the entire sub-object keeps the default full-overwrite behaviour.
+Controls how `apm compile` writes the `AGENTS.md` output file. All fields are OPTIONAL; omitting the entire sub-object keeps the default full-overwrite behaviour. Use `managed_section` mode when your `AGENTS.md` contains hand-written content you want to preserve across recompiles.
 
 | Field | Type | Default | Constraint | Description |
 |---|---|---|---|---|
@@ -618,7 +618,7 @@ Controls how `apm compile` writes the `AGENTS.md` output file. All fields are OP
 
 Both markers must appear **exactly once** in the file; a missing or duplicate marker raises `ManagedSectionError` rather than silently overwriting content.
 
-See [Managed-section mode](../../producer/compile/#managed-section-mode) in the compile guide for usage and marker setup instructions.
+See [Managed-section mode](../producer/compile/#managed-section-mode) in the compile guide for usage and marker setup instructions.
 
 ```yaml
 compilation:


### PR DESCRIPTION
## TL;DR

Document the `compilation.agents_md` sub-object (introduced by PR #1589) in the manifest-schema reference and add a cross-link from the compile guide.

Closes #1594

## Problem

PR #1589 merged three new `apm.yml` keys under `compilation.agents_md` (`mode`, `start_marker`, `end_marker`), but the manifest-schema reference (Section 6 CompilationConfig table) was not updated. A reader consulting the schema reference would not find managed-section mode. Additionally, the new Managed-section mode section in `compile.md` had no cross-links back to the schema reference, creating a drift risk.

## Approach

Two surgical doc changes, no code changes:

- **Gap 1**: Add an `agents_md` row to the Section 6 CompilationConfig table and a new Section 6.2 subsection documenting all three keys with types, defaults, constraints, and a usage example.
- **Gap 2**: Add a cross-link from the Managed-section mode section in `compile.md` pointing to the new Section 6.2 anchor in the manifest-schema reference.

## Implementation

- `docs/src/content/docs/reference/manifest-schema.md`: Added `agents_md` row to the top-level CompilationConfig table (Section 6) and a new Section 6.2 with a full field table and YAML example.
- `docs/src/content/docs/producer/compile.md`: Added a cross-reference sentence under the Managed-section mode heading pointing to Section 6.2.

## Trade-offs

- No README.md changes needed (no drift).
- No `commands.md` update needed: the change documents a config sub-object, not a new CLI flag.

## Validation evidence

- Lint: all checks passed (`ruff check`, `ruff format --check`, `pylint R0801`, `lint-auth-signals.sh`)
- Docs-only change; no Python source modified.
- Cross-links use relative paths consistent with Starlight conventions.