### PR TITLE
test: add edge-case coverage for empty and identical managed-section markers

### DIFF
--- a/tests/unit/compilation/test_managed_section.py
+++ b/tests/unit/compilation/test_managed_section.py
@@ -82,6 +82,22 @@ class TestApplyManagedSection:
         assert "After." in result
 
     # ------------------------------------------------------------------
+    # Input-validation guards: empty / identical markers
+    # ------------------------------------------------------------------
+
+    def test_empty_start_marker_raises_error(self):
+        with pytest.raises(ManagedSectionError, match=r"non-empty"):
+            apply_managed_section("content", "new", "", DEFAULT_END)
+
+    def test_empty_end_marker_raises_error(self):
+        with pytest.raises(ManagedSectionError, match=r"non-empty"):
+            apply_managed_section("content", "new", DEFAULT_START, "")
+
+    def test_identical_markers_raises_error(self):
+        with pytest.raises(ManagedSectionError, match=r"distinct"):
+            apply_managed_section("content", "new", "<!-- x -->", "<!-- x -->")
+
+    # ------------------------------------------------------------------
     # Acceptance criterion 2: duplicate markers -> loud error
     # ------------------------------------------------------------------
 


### PR DESCRIPTION
## TL;DR

Lock the two input-validation guards in `apply_managed_section()` that had no test coverage, preventing silent regression.

## Problem (WHY)

Two defensive branches in `managed_section.py` were introduced in PR #1589 but never covered by tests (flagged by the apm-review-panel test-coverage-expert):

- **Empty marker guard** (line 46-47): raises `ManagedSectionError` when `start_marker` or `end_marker` is an empty string.
- **Identical markers guard** (line 48-51): raises `ManagedSectionError` when both markers are the same string.

Without tests these contracts can regress silently.

## Approach (WHAT)

Add three characterization tests to `tests/unit/compilation/test_managed_section.py` under a clearly labelled section:

| Test | Validates |
|------|-----------|
| `test_empty_start_marker_raises_error` | empty `start_marker` -> `ManagedSectionError` matching `non-empty` |
| `test_empty_end_marker_raises_error` | empty `end_marker` -> `ManagedSectionError` matching `non-empty` |
| `test_identical_markers_raises_error` | `start_marker == end_marker` -> `ManagedSectionError` matching `distinct` |

No production code changed.

## Implementation (HOW)

Single file change: `tests/unit/compilation/test_managed_section.py` (+16 lines, 0 deletions).

## Validation evidence

- All 3 new tests: PASSED
- Full existing test suite for the file: unchanged, no regressions
- Lint gate (ruff check, ruff format --check, pylint R0801, auth-signal): all clean / exit 0

Closes #1596