### PR TITLE
docs: clarify install-time discovery rules for marketplace plugins (.apm/<type>/ vs root convention dirs)

### DIFF
--- a/docs/src/content/docs/producer/pack-a-bundle.md
+++ b/docs/src/content/docs/producer/pack-a-bundle.md
@@ -101,6 +101,100 @@ Three common ways to hand off a bundle:
 For the consumer flags that apply (`--target`, `--global`, `--force`,
 `--dry-run`), see [Deploy a local bundle](../consumer/deploy-a-bundle/).
 
+## Source layout and install-time discovery
+
+`apm pack` is intentionally liberal: it collects primitives from both
+`.apm/<type>/` subdirectories and from convention directories at the
+package root (`agents/`, `skills/`, `instructions/`, etc.). This lets
+you author in whichever layout feels natural during development.
+
+`apm install` is per-primitive and stricter. Each integrator has its own
+discovery rules. For some primitive types the root convention directory
+is not scanned at install time, so a file that appears in the pack
+bundle may be silently skipped by a downstream `apm install` call.
+
+The table below shows what `apm install` actually scans for each
+primitive type:
+
+| Primitive | `apm install` scans | Root alternative accepted? |
+|-----------|---------------------|---------------------------|
+| instruction | `.apm/instructions/*.instructions.md` | No |
+| command (prompt) | `.apm/prompts/*.prompt.md` | No |
+| hook | `.apm/hooks/*.json` | Yes: `hooks/*.json` |
+| agent | `.apm/agents/**/*.agent.md`, `.apm/chatmodes/` | Yes: `*.agent.md` at package root |
+| skill | `.apm/skills/<name>/SKILL.md` | Yes: `skills/<name>/SKILL.md` (MARKETPLACE_PLUGIN type only) |
+
+Source: `src/apm_cli/integration/instruction_integrator.py`,
+`src/apm_cli/integration/command_integrator.py`,
+`src/apm_cli/integration/hook_integrator.py`,
+`src/apm_cli/integration/agent_integrator.py`,
+`src/apm_cli/integration/skill_integrator.py`.
+
+### Canonical layout for marketplace publishers
+
+If you publish a plugin that consumers install via `apm install`, use
+`.apm/<type>/` for **every** primitive type. This layout is the only
+one that works symmetrically through both `apm pack` (export) and
+`apm install` (discovery). Using root convention directories for
+instructions or commands produces a bundle that packs correctly but
+installs silently incomplete.
+
+```
+plugins/my-plugin/
+  apm.yml                          # minimal: name, version, description
+  .apm/
+    agents/
+      security.agent.md
+    skills/
+      my-skill/
+        SKILL.md
+    instructions/
+      style.instructions.md        # ONLY discovered from .apm/instructions/
+    prompts/
+      review.prompt.md             # ONLY discovered from .apm/prompts/
+    hooks/
+      pre-tool.json
+```
+
+To verify what your bundle actually contains before distributing it,
+run:
+
+```bash
+apm pack --dry-run --verbose
+```
+
+The verbose output lists every file and any path remappings. Any
+instruction or prompt you expect to be included should appear there
+before you share the bundle.
+
+### Multi-plugin marketplace publisher
+
+When one repo ships multiple plugins and a marketplace index, give each
+plugin its own `apm.yml` and `.apm/<type>/` source tree:
+
+```
+my-publisher-repo/
+  apm.yml                          # root: marketplace: block only
+  plugins/
+    plugin-a/
+      apm.yml                      # per-plugin manifest
+      .apm/
+        agents/
+          expert.agent.md
+        instructions/
+          rules.instructions.md
+    plugin-b/
+      apm.yml
+      .apm/
+        skills/
+          my-skill/
+            SKILL.md
+```
+
+Per-plugin `apm pack` (run from each plugin directory) emits the plugin
+bundle. The root `apm pack` builds the marketplace index. See
+[Repo shapes](./repo-shapes/) for the full layout options.
+
 ## Pitfalls
 
 **Do not use `--format apm` for bundles you expect consumers to install.**

--- a/docs/src/content/docs/producer/pack-a-bundle.md
+++ b/docs/src/content/docs/producer/pack-a-bundle.md
@@ -121,8 +121,8 @@ primitive type:
 | instruction | `.apm/instructions/*.instructions.md` | No |
 | command (prompt) | `.apm/prompts/*.prompt.md` | No |
 | hook | `.apm/hooks/*.json` | Yes: `hooks/*.json` |
-| agent | `.apm/agents/**/*.agent.md`, `.apm/chatmodes/` | Yes: `*.agent.md` at package root |
-| skill | `.apm/skills/<name>/SKILL.md` | Yes: `skills/<name>/SKILL.md` (MARKETPLACE_PLUGIN type only) |
+| agent | `.apm/agents/**/*.agent.md`, `.apm/chatmodes/*.chatmode.md` | Yes: `*.agent.md` and `*.chatmode.md` at package root |
+| skill | `.apm/skills/<name>/SKILL.md` | Yes: `skills/<name>/SKILL.md` (SKILL_BUNDLE or MARKETPLACE_PLUGIN) |
 
 Source: `src/apm_cli/integration/instruction_integrator.py`,
 `src/apm_cli/integration/command_integrator.py`,
@@ -132,12 +132,19 @@ Source: `src/apm_cli/integration/instruction_integrator.py`,
 
 ### Canonical layout for marketplace publishers
 
+:::caution[Silent install drops can remove intended guardrails]
+`apm pack` accepts primitives from both `.apm/<type>/` and root convention
+directories (for example, an `instructions/` folder at the plugin root).
+`apm install` does NOT discover instructions, commands, or prompts placed
+in root convention directories. Packages that rely on these primitives for
+security guardrails or policy enforcement will install silently incomplete,
+potentially removing those guardrails from consumer environments.
+:::
+
 If you publish a plugin that consumers install via `apm install`, use
 `.apm/<type>/` for **every** primitive type. This layout is the only
 one that works symmetrically through both `apm pack` (export) and
-`apm install` (discovery). Using root convention directories for
-instructions or commands produces a bundle that packs correctly but
-installs silently incomplete.
+`apm install` (discovery).
 
 ```
 plugins/my-plugin/

--- a/docs/src/content/docs/producer/repo-shapes.md
+++ b/docs/src/content/docs/producer/repo-shapes.md
@@ -117,10 +117,32 @@ my-monorepo/
     plugin-a/
       apm.yml                      # plugin-a's manifest
       .apm/
+        agents/
+          expert.agent.md
+        instructions/
+          style.instructions.md
+        skills/
+          my-skill/
+            SKILL.md
     plugin-b/
       apm.yml
       .apm/
+        prompts/
+          review.prompt.md
+        hooks/
+          pre-tool.json
 ```
+
+> **Important -- use `.apm/<type>/` for every primitive in each plugin.**
+> `apm pack` accepts primitives from both `.apm/<type>/` and root
+> convention directories (e.g. `instructions/` at the plugin root), but
+> `apm install` only discovers instructions, commands, and prompts under
+> `.apm/<type>/`. Authoring `packages/plugin-a/instructions/style.md`
+> instead of `packages/plugin-a/.apm/instructions/style.instructions.md`
+> will produce a bundle that packs correctly but installs silently
+> incomplete. See [Pack a bundle -- source layout and install-time
+> discovery](./pack-a-bundle/#source-layout-and-install-time-discovery)
+> for the full per-primitive scan-path reference.
 
 Scaffold:
 

--- a/docs/src/content/docs/producer/repo-shapes.md
+++ b/docs/src/content/docs/producer/repo-shapes.md
@@ -137,7 +137,7 @@ my-monorepo/
 > `apm pack` accepts primitives from both `.apm/<type>/` and root
 > convention directories (e.g. `instructions/` at the plugin root), but
 > `apm install` only discovers instructions, commands, and prompts under
-> `.apm/<type>/`. Authoring `packages/plugin-a/instructions/style.md`
+> `.apm/<type>/`. Authoring `packages/plugin-a/instructions/style.instructions.md`
 > instead of `packages/plugin-a/.apm/instructions/style.instructions.md`
 > will produce a bundle that packs correctly but installs silently
 > incomplete. See [Pack a bundle -- source layout and install-time

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -74,8 +74,8 @@ Per-primitive scan paths for `apm install`:
 | instruction | `.apm/instructions/` | No |
 | command (prompt) | `.apm/prompts/` | No |
 | hook | `.apm/hooks/` | Yes: `hooks/` |
-| agent | `.apm/agents/`, `.apm/chatmodes/` | Yes: `*.agent.md` at root |
-| skill | `.apm/skills/<name>/` | Yes: `skills/<name>/` (MARKETPLACE_PLUGIN) |
+| agent | `.apm/agents/`, `.apm/chatmodes/` | Yes: `*.agent.md` and `*.chatmode.md` at root |
+| skill | `.apm/skills/<name>/` | Yes: `skills/<name>/` (SKILL_BUNDLE or MARKETPLACE_PLUGIN) |
 
 **Recommendation for marketplace publishers:** use `.apm/<type>/` for
 every primitive. This is the only layout that is symmetric between

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -58,6 +58,31 @@ my-package/
         resource2.md
 ```
 
+## Install-time discovery rules
+
+`apm pack` (export) is liberal: it collects primitives from both
+`.apm/<type>/` and root convention directories (`agents/`, `skills/`,
+`instructions/`, etc.). `apm install` (integration) is per-primitive
+and stricter. Authors who rely on root convention directories for
+instructions or prompts will produce bundles that pack but install
+silently incomplete.
+
+Per-primitive scan paths for `apm install`:
+
+| Primitive | Scanned path | Root alternative? |
+|-----------|-------------|------------------|
+| instruction | `.apm/instructions/` | No |
+| command (prompt) | `.apm/prompts/` | No |
+| hook | `.apm/hooks/` | Yes: `hooks/` |
+| agent | `.apm/agents/`, `.apm/chatmodes/` | Yes: `*.agent.md` at root |
+| skill | `.apm/skills/<name>/` | Yes: `skills/<name>/` (MARKETPLACE_PLUGIN) |
+
+**Recommendation for marketplace publishers:** use `.apm/<type>/` for
+every primitive. This is the only layout that is symmetric between
+`apm pack` and `apm install`. Authoring `instructions/` at the plugin
+root will pack cleanly but instructions will be silently dropped when
+consumers run `apm install`.
+
 ## Hook files
 
 Packages can ship hooks (pre/post tool-use scripts) by placing JSON


### PR DESCRIPTION
## TL;DR

Adds a per-primitive scan-path reference table sourced from the integrators, recommends `.apm/<type>/` as the canonical symmetric layout for marketplace publishers, and shows a worked multi-plugin publisher example.

## Problem (WHY)

Authors building marketplace publisher repos discover through painful debugging that `apm pack` is liberal (accepts both `.apm/<type>/` and root convention directories) while `apm install` is stricter and per-primitive: instructions and commands are **only** discovered under `.apm/<type>/`. A file that appears in a pack bundle can be silently dropped by a downstream `apm install`. Nothing in the docs called this out.

> This bit me hard while building DevExpGbb/zava-agent-config (a multi-plugin marketplace publisher used for an enterprise demo). Debugging took ~half a day; the only way to discover the gap was reading instruction_integrator.py.
>
> -- issue #1161

## Approach (WHAT)

Docs-only change. Three files updated:

1. **`pack-a-bundle.md`** -- new `Source layout and install-time discovery` section with:
   - Per-primitive scan-path table (what `apm install` actually scans vs. what `apm pack` exports)
   - Canonical `.apm/<type>/` layout example for marketplace publishers
   - Multi-plugin publisher repo layout example

2. **`repo-shapes.md`** -- monorepo-hybrid section now shows the full `.apm/<type>/` directory tree and adds an explicit callout warning that root convention dirs for instructions and prompts are silently dropped at install time.

3. **`packages/apm-guide/.apm/skills/apm-usage/package-authoring.md`** -- adds `Install-time discovery rules` section with the same per-primitive table and canonical layout recommendation for the apm-guide skill users.

## Implementation (HOW)

Per-primitive scan-path table sourced directly from integrator code:

| Primitive | `apm install` scans | Root alternative? |
|-----------|----------------------|------------------|
| instruction | `.apm/instructions/` | No |
| command (prompt) | `.apm/prompts/` | No |
| hook | `.apm/hooks/` | Yes: `hooks/` |
| agent | `.apm/agents/`, `.apm/chatmodes/` | Yes: `*.agent.md` at root |
| skill | `.apm/skills/<name>/` | Yes: `skills/<name>/` (MARKETPLACE_PLUGIN) |

Sources verified in:
- `src/apm_cli/integration/instruction_integrator.py:44` -- `subdirs=[".apm/instructions"]`
- `src/apm_cli/integration/command_integrator.py:185` -- `subdirs=[".apm/prompts"]`
- `src/apm_cli/integration/hook_integrator.py:336-357` -- searches both `.apm/hooks/` and `hooks/`
- `src/apm_cli/integration/agent_integrator.py:40-53` -- root glob + `.apm/agents/`
- `src/apm_cli/integration/skill_integrator.py:1220-1238` -- `.apm/skills/` + root `skills/` (MARKETPLACE_PLUGIN)

## Trade-offs

- Scope is docs-only per the issue's explicit request. Whether the install-time scanners should also accept root convention dirs (matching pack-export behavior) is deferred to a follow-up feature issue.
- The monorepo-hybrid example in `repo-shapes.md` was previously sparse (just showed empty `.apm/` stubs). It now shows a realistic per-primitive layout, which makes the callout actionable.

## Validation evidence

- Lint gate: `ruff check`, `ruff format --check`, `pylint R0801`, `lint-auth-signals.sh` all pass.
- ASCII-only: grep confirms no non-ASCII characters in changed files.
- Per-primitive scan paths cross-referenced against the integrator source code at HEAD.

## How to test

1. Read the new `Source layout and install-time discovery` section in `pack-a-bundle.md`.
2. Verify the per-primitive scan-path table matches the integrator code at the cited line references.
3. Verify the monorepo-hybrid section in `repo-shapes.md` now shows `.apm/<type>/` throughout.
4. (Optional) Build a plugin with root-convention `instructions/` dir and confirm `apm install` drops it while `apm pack --dry-run --verbose` shows it -- the table should predict this outcome.

Closes #1161