### PR TITLE
chore: enable RUF002/RUF003 (ambiguous unicode) and fix 249 violations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,8 +88,6 @@ ignore = [
     "S602",     # subprocess-popen-with-shell -- intentional in CLI wrapping git/pip
     # --- Deferred rules: enable in dedicated future PRs ---
     "SIM102",   # collapsible-if -- 28 violations, auto-fixable style improvement
-    "RUF003",   # ambiguous-unicode-character-comment -- 14 violations, review against ASCII convention
-    "RUF002",   # ambiguous-unicode-character-docstring -- 8 violations, same as above
 ]
 
 [tool.ruff.lint.pylint]

--- a/src/apm_cli/core/token_manager.py
+++ b/src/apm_cli/core/token_manager.py
@@ -177,7 +177,7 @@ class GitHubTokenManager:
     def _get_credential_timeout(cls) -> int:
         """Return timeout (seconds) for ``git credential fill``.
 
-        Configurable via ``APM_GIT_CREDENTIAL_TIMEOUT`` (1–180).
+        Configurable via ``APM_GIT_CREDENTIAL_TIMEOUT`` (1-180).
         """
         raw = os.environ.get("APM_GIT_CREDENTIAL_TIMEOUT", "").strip()
         if not raw:

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -764,7 +764,7 @@ class DependencyReference:
     ) -> tuple[str, list[str], str | None] | None:
         """If *package* is bare host/path shorthand, return (host, path_segments, ref_str).
 
-        Returns ``None`` for ``https://``, ``git@``, or non–GitLab-class hosts.
+        Returns ``None`` for ``https://``, ``git@``, or non-GitLab-class hosts.
         """
         s = package.strip()
         ref_out: str | None = None

--- a/src/apm_cli/security/content_scanner.py
+++ b/src/apm_cli/security/content_scanner.py
@@ -124,7 +124,7 @@ def _is_emoji_char(ch: str) -> bool:
 def _zwj_in_emoji_context(text: str, idx: int) -> bool:
     """Return True if a ZWJ at *idx* sits between two emoji-like characters.
 
-    Looks backward past FE0F (VS16) and skin-tone modifiers (U+1F3FB–1F3FF)
+    Looks backward past FE0F (VS16) and skin-tone modifiers (U+1F3FB-1F3FF)
     because emoji ZWJ sequences frequently interpose these between the base
     character and the joiner, e.g. 👩🏽‍🚀 = 👩 + 🏽 + ZWJ + 🚀.
     """

--- a/tests/benchmarks/run_baseline.py
+++ b/tests/benchmarks/run_baseline.py
@@ -221,7 +221,7 @@ def main():
         _time.sleep(ms / 1000)
         return True
 
-    # Sequential: 10 tasks × 50ms each = ~500ms
+    # Sequential: 10 tasks x 50ms each = ~500ms
     def _seq_10():
         for _ in range(10):
             _simulated_work(50)
@@ -231,7 +231,7 @@ def main():
     results[key] = (med, lo, hi)
     print(f"  {key:45s}  median={med:8.2f}ms  min={lo:8.2f}ms  max={hi:8.2f}ms")
 
-    # Parallel: 10 tasks × 50ms, 4 workers → ~150ms (ceil(10/4) × 50ms)
+    # Parallel: 10 tasks x 50ms, 4 workers → ~150ms (ceil(10/4) x 50ms)
     def _par_10():
         with ThreadPoolExecutor(max_workers=4) as executor:
             futs = [executor.submit(_simulated_work, 50) for _ in range(10)]

--- a/tests/benchmarks/test_perf_benchmarks.py
+++ b/tests/benchmarks/test_perf_benchmarks.py
@@ -2,8 +2,8 @@
 
 Covers the bottlenecks identified in issue #171:
 - Primitive conflict detection (O(m) after fix, was O(m²))
-- Cycle detection (O(V+E) after fix, was O(V×D))
-- get_nodes_at_depth() (O(1) after fix, was O(V × max_depth))
+- Cycle detection (O(V+E) after fix, was O(VxD))
+- get_nodes_at_depth() (O(1) after fix, was O(V x max_depth))
 - from_apm_yml() parse caching
 - Inheritance chain caching
 
@@ -104,7 +104,7 @@ class TestPrimitiveConflictDetectionPerf:
 
 @pytest.mark.benchmark
 class TestDepthIndexPerf:
-    """Verify O(1) depth lookups (was O(V × max_depth) before #171)."""
+    """Verify O(1) depth lookups (was O(V x max_depth) before #171)."""
 
     def test_get_nodes_at_depth_large_tree(self):
         """100 packages across 10 depths — lookups should be instant."""
@@ -134,7 +134,7 @@ class TestDepthIndexPerf:
 
 @pytest.mark.benchmark
 class TestCycleDetectionPerf:
-    """Verify O(V+E) cycle detection (was O(V×D) before #171)."""
+    """Verify O(V+E) cycle detection (was O(VxD) before #171)."""
 
     def test_no_cycles_deep_chain(self):
         """50-node linear chain — O(V+E) detection."""

--- a/tests/integration/test_coverage_phase4.py
+++ b/tests/integration/test_coverage_phase4.py
@@ -1,4 +1,4 @@
-"""Integration tests – phase 4 coverage uplift.
+"""Integration tests - phase 4 coverage uplift.
 
 Covers the following high-miss files:
 1. ``src/apm_cli/install/mcp/writer.py``            (_diff_entry, add_mcp_to_apm_yml)

--- a/tests/integration/test_deps_models_phase3c.py
+++ b/tests/integration/test_deps_models_phase3c.py
@@ -103,7 +103,7 @@ def _DR():
 
 
 # ============================================================================
-# SECTION 1 – DependencyReference: HTTPS & SSH URL parsing
+# SECTION 1 - DependencyReference: HTTPS & SSH URL parsing
 # ============================================================================
 
 
@@ -285,7 +285,7 @@ class TestParseVirtualPackages:
 
 
 # ============================================================================
-# SECTION 2 – DependencyReference: ADO parsing
+# SECTION 2 - DependencyReference: ADO parsing
 # ============================================================================
 
 
@@ -332,7 +332,7 @@ class TestParseAdoUrls:
 
 
 # ============================================================================
-# SECTION 3 – DependencyReference: canonical / identity / install path
+# SECTION 3 - DependencyReference: canonical / identity / install path
 # ============================================================================
 
 
@@ -492,7 +492,7 @@ class TestVirtualPackageMethods:
 
 
 # ============================================================================
-# SECTION 4 – DependencyReference: to_apm_yml_entry / to_github_url
+# SECTION 4 - DependencyReference: to_apm_yml_entry / to_github_url
 # ============================================================================
 
 
@@ -607,7 +607,7 @@ class TestGetDisplayName:
 
 
 # ============================================================================
-# SECTION 5 – DependencyReference: parse_from_dict
+# SECTION 5 - DependencyReference: parse_from_dict
 # ============================================================================
 
 
@@ -680,7 +680,7 @@ class TestParseFromDict:
 
 
 # ============================================================================
-# SECTION 6 – DependencyReference: GitLab shorthand helpers
+# SECTION 6 - DependencyReference: GitLab shorthand helpers
 # ============================================================================
 
 
@@ -715,7 +715,7 @@ class TestGitLabShorthandHelpers:
 
 
 # ============================================================================
-# SECTION 7 – DependencyReference: __str__ and get_unique_key
+# SECTION 7 - DependencyReference: __str__ and get_unique_key
 # ============================================================================
 
 
@@ -757,7 +757,7 @@ class TestStrAndUniqueKey:
 
 
 # ============================================================================
-# SECTION 8 – GitHubPackageDownloader: download_virtual_file_package
+# SECTION 8 - GitHubPackageDownloader: download_virtual_file_package
 # ============================================================================
 
 
@@ -861,7 +861,7 @@ class TestDownloadVirtualFilePackage:
 
 
 # ============================================================================
-# SECTION 9 – GitHubPackageDownloader: download_subdirectory_package guards
+# SECTION 9 - GitHubPackageDownloader: download_subdirectory_package guards
 # ============================================================================
 
 
@@ -886,7 +886,7 @@ class TestDownloadSubdirectoryPackageGuards:
 
 
 # ============================================================================
-# SECTION 10 – GitHubPackageDownloader: _try_sparse_checkout
+# SECTION 10 - GitHubPackageDownloader: _try_sparse_checkout
 # ============================================================================
 
 
@@ -940,7 +940,7 @@ class TestTrySparseCheckout:
 
 
 # ============================================================================
-# SECTION 11 – GitHubPackageDownloader: resolve_git_reference
+# SECTION 11 - GitHubPackageDownloader: resolve_git_reference
 # ============================================================================
 
 
@@ -975,7 +975,7 @@ class TestResolveGitReference:
 
 
 # ============================================================================
-# SECTION 12 – GitHubPackageDownloader: _close_repo & debug helper
+# SECTION 12 - GitHubPackageDownloader: _close_repo & debug helper
 # ============================================================================
 
 
@@ -1014,7 +1014,7 @@ class TestCloseRepoAndDebug:
 
 
 # ============================================================================
-# SECTION 13 – GitHubPackageDownloader: download_raw_file routing
+# SECTION 13 - GitHubPackageDownloader: download_raw_file routing
 # ============================================================================
 
 
@@ -1062,7 +1062,7 @@ class TestDownloadRawFileRouting:
 
 
 # ============================================================================
-# SECTION 14 – install/pipeline.py: _run_phase
+# SECTION 14 - install/pipeline.py: _run_phase
 # ============================================================================
 
 
@@ -1116,7 +1116,7 @@ class TestRunPhase:
 
 
 # ============================================================================
-# SECTION 15 – install/pipeline.py: run_install_pipeline early exits
+# SECTION 15 - install/pipeline.py: run_install_pipeline early exits
 # ============================================================================
 
 
@@ -1193,7 +1193,7 @@ class TestRunInstallPipelineEarlyExits:
 
 
 # ============================================================================
-# SECTION 16 – install/pipeline.py: _preflight_auth_check
+# SECTION 16 - install/pipeline.py: _preflight_auth_check
 # ============================================================================
 
 
@@ -1268,7 +1268,7 @@ class TestPreflightAuthCheck:
 
 
 # ============================================================================
-# SECTION 17 – install/drift.py: normalization helpers
+# SECTION 17 - install/drift.py: normalization helpers
 # ============================================================================
 
 
@@ -1317,7 +1317,7 @@ class TestNormalizationHelpers:
 
 
 # ============================================================================
-# SECTION 18 – install/drift.py: scratch directory lifecycle
+# SECTION 18 - install/drift.py: scratch directory lifecycle
 # ============================================================================
 
 
@@ -1359,7 +1359,7 @@ class TestScratchDirectoryLifecycle:
 
 
 # ============================================================================
-# SECTION 19 – install/drift.py: _walk_managed / _collect_tracked_files
+# SECTION 19 - install/drift.py: _walk_managed / _collect_tracked_files
 # ============================================================================
 
 
@@ -1411,7 +1411,7 @@ class TestWalkManaged:
 
 
 # ============================================================================
-# SECTION 20 – install/drift.py: _governed_root_dirs
+# SECTION 20 - install/drift.py: _governed_root_dirs
 # ============================================================================
 
 
@@ -1441,7 +1441,7 @@ class TestGovernedRootDirs:
 
 
 # ============================================================================
-# SECTION 21 – install/drift.py: diff_scratch_against_project
+# SECTION 21 - install/drift.py: diff_scratch_against_project
 # ============================================================================
 
 
@@ -1548,7 +1548,7 @@ class TestDiffScratchAgainstProject:
 
 
 # ============================================================================
-# SECTION 22 – install/drift.py: render functions
+# SECTION 22 - install/drift.py: render functions
 # ============================================================================
 
 
@@ -1632,7 +1632,7 @@ class TestRenderDrift:
 
 
 # ============================================================================
-# SECTION 23 – install/drift.py: CheckLogger
+# SECTION 23 - install/drift.py: CheckLogger
 # ============================================================================
 
 
@@ -1701,7 +1701,7 @@ class TestCheckLogger:
 
 
 # ============================================================================
-# SECTION 24 – install/drift.py: DriftFinding / ReplayConfig / CacheMissError
+# SECTION 24 - install/drift.py: DriftFinding / ReplayConfig / CacheMissError
 # ============================================================================
 
 
@@ -1749,7 +1749,7 @@ class TestDriftDataClasses:
 
 
 # ============================================================================
-# SECTION 25 – install/drift.py: _materialize_install_path
+# SECTION 25 - install/drift.py: _materialize_install_path
 # ============================================================================
 
 
@@ -1841,7 +1841,7 @@ class TestMaterializeInstallPath:
 
 
 # ============================================================================
-# SECTION 26 – install/drift.py: _build_package_info
+# SECTION 26 - install/drift.py: _build_package_info
 # ============================================================================
 
 
@@ -1890,7 +1890,7 @@ class TestBuildPackageInfo:
 
 
 # ============================================================================
-# SECTION 27 – install/drift.py: _make_integrators / _filter_targets
+# SECTION 27 - install/drift.py: _make_integrators / _filter_targets
 # ============================================================================
 
 
@@ -1928,7 +1928,7 @@ class TestMakeIntegratorsAndFilterTargets:
 
 
 # ============================================================================
-# SECTION 28 – install/drift.py: _inline_diff_for
+# SECTION 28 - install/drift.py: _inline_diff_for
 # ============================================================================
 
 
@@ -1957,7 +1957,7 @@ class TestInlineDiffFor:
 
 
 # ============================================================================
-# SECTION 29 – DependencyReference: is_local_path static edge cases
+# SECTION 29 - DependencyReference: is_local_path static edge cases
 # ============================================================================
 
 
@@ -1991,7 +1991,7 @@ class TestIsLocalPath:
 
 
 # ============================================================================
-# SECTION 30 – Additional edge case parsing
+# SECTION 30 - Additional edge case parsing
 # ============================================================================
 
 

--- a/tests/integration/test_deps_models_validation.py
+++ b/tests/integration/test_deps_models_validation.py
@@ -103,7 +103,7 @@ def _DR():
 
 
 # ============================================================================
-# SECTION 1 – DependencyReference: HTTPS & SSH URL parsing
+# SECTION 1 - DependencyReference: HTTPS & SSH URL parsing
 # ============================================================================
 
 
@@ -285,7 +285,7 @@ class TestParseVirtualPackages:
 
 
 # ============================================================================
-# SECTION 2 – DependencyReference: ADO parsing
+# SECTION 2 - DependencyReference: ADO parsing
 # ============================================================================
 
 
@@ -332,7 +332,7 @@ class TestParseAdoUrls:
 
 
 # ============================================================================
-# SECTION 3 – DependencyReference: canonical / identity / install path
+# SECTION 3 - DependencyReference: canonical / identity / install path
 # ============================================================================
 
 
@@ -492,7 +492,7 @@ class TestVirtualPackageMethods:
 
 
 # ============================================================================
-# SECTION 4 – DependencyReference: to_apm_yml_entry / to_github_url
+# SECTION 4 - DependencyReference: to_apm_yml_entry / to_github_url
 # ============================================================================
 
 
@@ -607,7 +607,7 @@ class TestGetDisplayName:
 
 
 # ============================================================================
-# SECTION 5 – DependencyReference: parse_from_dict
+# SECTION 5 - DependencyReference: parse_from_dict
 # ============================================================================
 
 
@@ -680,7 +680,7 @@ class TestParseFromDict:
 
 
 # ============================================================================
-# SECTION 6 – DependencyReference: GitLab shorthand helpers
+# SECTION 6 - DependencyReference: GitLab shorthand helpers
 # ============================================================================
 
 
@@ -715,7 +715,7 @@ class TestGitLabShorthandHelpers:
 
 
 # ============================================================================
-# SECTION 7 – DependencyReference: __str__ and get_unique_key
+# SECTION 7 - DependencyReference: __str__ and get_unique_key
 # ============================================================================
 
 
@@ -757,7 +757,7 @@ class TestStrAndUniqueKey:
 
 
 # ============================================================================
-# SECTION 8 – GitHubPackageDownloader: download_virtual_file_package
+# SECTION 8 - GitHubPackageDownloader: download_virtual_file_package
 # ============================================================================
 
 
@@ -861,7 +861,7 @@ class TestDownloadVirtualFilePackage:
 
 
 # ============================================================================
-# SECTION 9 – GitHubPackageDownloader: download_subdirectory_package guards
+# SECTION 9 - GitHubPackageDownloader: download_subdirectory_package guards
 # ============================================================================
 
 
@@ -886,7 +886,7 @@ class TestDownloadSubdirectoryPackageGuards:
 
 
 # ============================================================================
-# SECTION 10 – GitHubPackageDownloader: _try_sparse_checkout
+# SECTION 10 - GitHubPackageDownloader: _try_sparse_checkout
 # ============================================================================
 
 
@@ -940,7 +940,7 @@ class TestTrySparseCheckout:
 
 
 # ============================================================================
-# SECTION 11 – GitHubPackageDownloader: resolve_git_reference
+# SECTION 11 - GitHubPackageDownloader: resolve_git_reference
 # ============================================================================
 
 
@@ -975,7 +975,7 @@ class TestResolveGitReference:
 
 
 # ============================================================================
-# SECTION 12 – GitHubPackageDownloader: _close_repo & debug helper
+# SECTION 12 - GitHubPackageDownloader: _close_repo & debug helper
 # ============================================================================
 
 
@@ -1014,7 +1014,7 @@ class TestCloseRepoAndDebug:
 
 
 # ============================================================================
-# SECTION 13 – GitHubPackageDownloader: download_raw_file routing
+# SECTION 13 - GitHubPackageDownloader: download_raw_file routing
 # ============================================================================
 
 
@@ -1062,7 +1062,7 @@ class TestDownloadRawFileRouting:
 
 
 # ============================================================================
-# SECTION 14 – install/pipeline.py: _run_phase
+# SECTION 14 - install/pipeline.py: _run_phase
 # ============================================================================
 
 
@@ -1116,7 +1116,7 @@ class TestRunPhase:
 
 
 # ============================================================================
-# SECTION 15 – install/pipeline.py: run_install_pipeline early exits
+# SECTION 15 - install/pipeline.py: run_install_pipeline early exits
 # ============================================================================
 
 
@@ -1193,7 +1193,7 @@ class TestRunInstallPipelineEarlyExits:
 
 
 # ============================================================================
-# SECTION 16 – install/pipeline.py: _preflight_auth_check
+# SECTION 16 - install/pipeline.py: _preflight_auth_check
 # ============================================================================
 
 
@@ -1268,7 +1268,7 @@ class TestPreflightAuthCheck:
 
 
 # ============================================================================
-# SECTION 17 – install/drift.py: normalization helpers
+# SECTION 17 - install/drift.py: normalization helpers
 # ============================================================================
 
 
@@ -1317,7 +1317,7 @@ class TestNormalizationHelpers:
 
 
 # ============================================================================
-# SECTION 18 – install/drift.py: scratch directory lifecycle
+# SECTION 18 - install/drift.py: scratch directory lifecycle
 # ============================================================================
 
 
@@ -1359,7 +1359,7 @@ class TestScratchDirectoryLifecycle:
 
 
 # ============================================================================
-# SECTION 19 – install/drift.py: _walk_managed / _collect_tracked_files
+# SECTION 19 - install/drift.py: _walk_managed / _collect_tracked_files
 # ============================================================================
 
 
@@ -1411,7 +1411,7 @@ class TestWalkManaged:
 
 
 # ============================================================================
-# SECTION 20 – install/drift.py: _governed_root_dirs
+# SECTION 20 - install/drift.py: _governed_root_dirs
 # ============================================================================
 
 
@@ -1441,7 +1441,7 @@ class TestGovernedRootDirs:
 
 
 # ============================================================================
-# SECTION 21 – install/drift.py: diff_scratch_against_project
+# SECTION 21 - install/drift.py: diff_scratch_against_project
 # ============================================================================
 
 
@@ -1548,7 +1548,7 @@ class TestDiffScratchAgainstProject:
 
 
 # ============================================================================
-# SECTION 22 – install/drift.py: render functions
+# SECTION 22 - install/drift.py: render functions
 # ============================================================================
 
 
@@ -1632,7 +1632,7 @@ class TestRenderDrift:
 
 
 # ============================================================================
-# SECTION 23 – install/drift.py: CheckLogger
+# SECTION 23 - install/drift.py: CheckLogger
 # ============================================================================
 
 
@@ -1701,7 +1701,7 @@ class TestCheckLogger:
 
 
 # ============================================================================
-# SECTION 24 – install/drift.py: DriftFinding / ReplayConfig / CacheMissError
+# SECTION 24 - install/drift.py: DriftFinding / ReplayConfig / CacheMissError
 # ============================================================================
 
 
@@ -1749,7 +1749,7 @@ class TestDriftDataClasses:
 
 
 # ============================================================================
-# SECTION 25 – install/drift.py: _materialize_install_path
+# SECTION 25 - install/drift.py: _materialize_install_path
 # ============================================================================
 
 
@@ -1841,7 +1841,7 @@ class TestMaterializeInstallPath:
 
 
 # ============================================================================
-# SECTION 26 – install/drift.py: _build_package_info
+# SECTION 26 - install/drift.py: _build_package_info
 # ============================================================================
 
 
@@ -1890,7 +1890,7 @@ class TestBuildPackageInfo:
 
 
 # ============================================================================
-# SECTION 27 – install/drift.py: _make_integrators / _filter_targets
+# SECTION 27 - install/drift.py: _make_integrators / _filter_targets
 # ============================================================================
 
 
@@ -1928,7 +1928,7 @@ class TestMakeIntegratorsAndFilterTargets:
 
 
 # ============================================================================
-# SECTION 28 – install/drift.py: _inline_diff_for
+# SECTION 28 - install/drift.py: _inline_diff_for
 # ============================================================================
 
 
@@ -1957,7 +1957,7 @@ class TestInlineDiffFor:
 
 
 # ============================================================================
-# SECTION 29 – DependencyReference: is_local_path static edge cases
+# SECTION 29 - DependencyReference: is_local_path static edge cases
 # ============================================================================
 
 
@@ -1991,7 +1991,7 @@ class TestIsLocalPath:
 
 
 # ============================================================================
-# SECTION 30 – Additional edge case parsing
+# SECTION 30 - Additional edge case parsing
 # ============================================================================
 
 

--- a/tests/integration/test_deps_resolver_phase3b.py
+++ b/tests/integration/test_deps_resolver_phase3b.py
@@ -96,7 +96,7 @@ def _write_apm_yml(path: Path, content: dict[str, Any]) -> None:
 
 
 # ============================================================================
-# SECTION 1 – GitHubPackageDownloader: helper / utility methods
+# SECTION 1 - GitHubPackageDownloader: helper / utility methods
 # ============================================================================
 
 
@@ -464,7 +464,7 @@ class TestGitHubDownloaderTrySparseCheckout:
 
 
 # ============================================================================
-# SECTION 2 – APMDependencyResolver
+# SECTION 2 - APMDependencyResolver
 # ============================================================================
 
 
@@ -917,7 +917,7 @@ class TestResolverTryLoadDependencyPackageWithCallback:
 
 
 # ============================================================================
-# SECTION 3 – ScriptRunner
+# SECTION 3 - ScriptRunner
 # ============================================================================
 
 
@@ -1348,7 +1348,7 @@ class TestPromptCompilerSubstituteAndCompile:
 
 
 # ============================================================================
-# SECTION 4 – plugin_parser
+# SECTION 4 - plugin_parser
 # ============================================================================
 
 

--- a/tests/integration/test_deps_resolver_resolution.py
+++ b/tests/integration/test_deps_resolver_resolution.py
@@ -96,7 +96,7 @@ def _write_apm_yml(path: Path, content: dict[str, Any]) -> None:
 
 
 # ============================================================================
-# SECTION 1 – GitHubPackageDownloader: helper / utility methods
+# SECTION 1 - GitHubPackageDownloader: helper / utility methods
 # ============================================================================
 
 
@@ -464,7 +464,7 @@ class TestGitHubDownloaderTrySparseCheckout:
 
 
 # ============================================================================
-# SECTION 2 – APMDependencyResolver
+# SECTION 2 - APMDependencyResolver
 # ============================================================================
 
 
@@ -917,7 +917,7 @@ class TestResolverTryLoadDependencyPackageWithCallback:
 
 
 # ============================================================================
-# SECTION 3 – ScriptRunner
+# SECTION 3 - ScriptRunner
 # ============================================================================
 
 
@@ -1348,7 +1348,7 @@ class TestPromptCompilerSubstituteAndCompile:
 
 
 # ============================================================================
-# SECTION 4 – plugin_parser
+# SECTION 4 - plugin_parser
 # ============================================================================
 
 

--- a/tests/integration/test_marketplace_publisher_flow.py
+++ b/tests/integration/test_marketplace_publisher_flow.py
@@ -170,7 +170,7 @@ def _make_manifest(
 
 
 # ---------------------------------------------------------------------------
-# Section 1 – Pure helper functions (commands/__init__.py)
+# Section 1 - Pure helper functions (commands/__init__.py)
 # ---------------------------------------------------------------------------
 
 
@@ -272,7 +272,7 @@ class TestMarketplaceAddUnsupportedHostError:
 
 
 # ---------------------------------------------------------------------------
-# Section 2 – _parse_marketplace_repo
+# Section 2 - _parse_marketplace_repo
 # ---------------------------------------------------------------------------
 
 
@@ -343,7 +343,7 @@ class TestParseMarketplaceRepo:
 
 
 # ---------------------------------------------------------------------------
-# Section 3 – _load_targets_file
+# Section 3 - _load_targets_file
 # ---------------------------------------------------------------------------
 
 
@@ -431,7 +431,7 @@ class TestLoadTargetsFile:
 
 
 # ---------------------------------------------------------------------------
-# Section 4 – ConsumerTarget validation (publisher.py)
+# Section 4 - ConsumerTarget validation (publisher.py)
 # ---------------------------------------------------------------------------
 
 
@@ -466,7 +466,7 @@ class TestConsumerTarget:
 
 
 # ---------------------------------------------------------------------------
-# Section 5 – _sanitise_branch_segment (publisher.py)
+# Section 5 - _sanitise_branch_segment (publisher.py)
 # ---------------------------------------------------------------------------
 
 
@@ -489,12 +489,12 @@ class TestSanitiseBranchSegment:
 
 
 # ---------------------------------------------------------------------------
-# Section 6 – PublishState (publisher.py)
+# Section 6 - PublishState (publisher.py)
 # ---------------------------------------------------------------------------
 
 
 class TestPublishState:
-    """Tests for PublishState – state file write/read lifecycle."""
+    """Tests for PublishState - state file write/read lifecycle."""
 
     def test_load_from_missing_path_returns_fresh(self, tmp_path: Path) -> None:
         state = PublishState.load(tmp_path / "nonexistent")
@@ -592,7 +592,7 @@ class TestPublishState:
 
 
 # ---------------------------------------------------------------------------
-# Section 7 – MarketplacePublisher.plan (publisher.py)
+# Section 7 - MarketplacePublisher.plan (publisher.py)
 # ---------------------------------------------------------------------------
 
 
@@ -688,7 +688,7 @@ class TestMarketplacePublisherPlan:
 
 
 # ---------------------------------------------------------------------------
-# Section 8 – MarketplacePublisher.execute + _process_single_target
+# Section 8 - MarketplacePublisher.execute + _process_single_target
 # ---------------------------------------------------------------------------
 
 
@@ -957,7 +957,7 @@ dependencies:
 
 
 # ---------------------------------------------------------------------------
-# Section 9 – MarketplacePublisher.safe_force_push (publisher.py)
+# Section 9 - MarketplacePublisher.safe_force_push (publisher.py)
 # ---------------------------------------------------------------------------
 
 
@@ -1006,7 +1006,7 @@ class TestSafeForPush:
 
 
 # ---------------------------------------------------------------------------
-# Section 10 – CLI commands via CliRunner
+# Section 10 - CLI commands via CliRunner
 # ---------------------------------------------------------------------------
 
 
@@ -1291,7 +1291,7 @@ class TestMarketplaceGroupBuildDeprecated:
 
 
 # ---------------------------------------------------------------------------
-# Section 11 – PublishPlan field assertions
+# Section 11 - PublishPlan field assertions
 # ---------------------------------------------------------------------------
 
 
@@ -1332,7 +1332,7 @@ class TestPublishPlan:
 
 
 # ---------------------------------------------------------------------------
-# Section 12 – PublishOutcome enum
+# Section 12 - PublishOutcome enum
 # ---------------------------------------------------------------------------
 
 
@@ -1357,7 +1357,7 @@ class TestPublishOutcomeEnum:
 
 
 # ---------------------------------------------------------------------------
-# Section 13 – _check_gitignore_for_marketplace_json
+# Section 13 - _check_gitignore_for_marketplace_json
 # ---------------------------------------------------------------------------
 
 
@@ -1429,7 +1429,7 @@ class TestCheckGitignoreForMarketplaceJson:
 
 
 # ---------------------------------------------------------------------------
-# Section 14 – _load_yml_or_exit (indirectly via CWD + sys.exit mocking)
+# Section 14 - _load_yml_or_exit (indirectly via CWD + sys.exit mocking)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/integration/test_marketplace_publisher_phase3.py
+++ b/tests/integration/test_marketplace_publisher_phase3.py
@@ -170,7 +170,7 @@ def _make_manifest(
 
 
 # ---------------------------------------------------------------------------
-# Section 1 – Pure helper functions (commands/__init__.py)
+# Section 1 - Pure helper functions (commands/__init__.py)
 # ---------------------------------------------------------------------------
 
 
@@ -272,7 +272,7 @@ class TestMarketplaceAddUnsupportedHostError:
 
 
 # ---------------------------------------------------------------------------
-# Section 2 – _parse_marketplace_repo
+# Section 2 - _parse_marketplace_repo
 # ---------------------------------------------------------------------------
 
 
@@ -343,7 +343,7 @@ class TestParseMarketplaceRepo:
 
 
 # ---------------------------------------------------------------------------
-# Section 3 – _load_targets_file
+# Section 3 - _load_targets_file
 # ---------------------------------------------------------------------------
 
 
@@ -431,7 +431,7 @@ class TestLoadTargetsFile:
 
 
 # ---------------------------------------------------------------------------
-# Section 4 – ConsumerTarget validation (publisher.py)
+# Section 4 - ConsumerTarget validation (publisher.py)
 # ---------------------------------------------------------------------------
 
 
@@ -466,7 +466,7 @@ class TestConsumerTarget:
 
 
 # ---------------------------------------------------------------------------
-# Section 5 – _sanitise_branch_segment (publisher.py)
+# Section 5 - _sanitise_branch_segment (publisher.py)
 # ---------------------------------------------------------------------------
 
 
@@ -489,12 +489,12 @@ class TestSanitiseBranchSegment:
 
 
 # ---------------------------------------------------------------------------
-# Section 6 – PublishState (publisher.py)
+# Section 6 - PublishState (publisher.py)
 # ---------------------------------------------------------------------------
 
 
 class TestPublishState:
-    """Tests for PublishState – state file write/read lifecycle."""
+    """Tests for PublishState - state file write/read lifecycle."""
 
     def test_load_from_missing_path_returns_fresh(self, tmp_path: Path) -> None:
         state = PublishState.load(tmp_path / "nonexistent")
@@ -592,7 +592,7 @@ class TestPublishState:
 
 
 # ---------------------------------------------------------------------------
-# Section 7 – MarketplacePublisher.plan (publisher.py)
+# Section 7 - MarketplacePublisher.plan (publisher.py)
 # ---------------------------------------------------------------------------
 
 
@@ -688,7 +688,7 @@ class TestMarketplacePublisherPlan:
 
 
 # ---------------------------------------------------------------------------
-# Section 8 – MarketplacePublisher.execute + _process_single_target
+# Section 8 - MarketplacePublisher.execute + _process_single_target
 # ---------------------------------------------------------------------------
 
 
@@ -957,7 +957,7 @@ dependencies:
 
 
 # ---------------------------------------------------------------------------
-# Section 9 – MarketplacePublisher.safe_force_push (publisher.py)
+# Section 9 - MarketplacePublisher.safe_force_push (publisher.py)
 # ---------------------------------------------------------------------------
 
 
@@ -1006,7 +1006,7 @@ class TestSafeForPush:
 
 
 # ---------------------------------------------------------------------------
-# Section 10 – CLI commands via CliRunner
+# Section 10 - CLI commands via CliRunner
 # ---------------------------------------------------------------------------
 
 
@@ -1291,7 +1291,7 @@ class TestMarketplaceGroupBuildDeprecated:
 
 
 # ---------------------------------------------------------------------------
-# Section 11 – PublishPlan field assertions
+# Section 11 - PublishPlan field assertions
 # ---------------------------------------------------------------------------
 
 
@@ -1332,7 +1332,7 @@ class TestPublishPlan:
 
 
 # ---------------------------------------------------------------------------
-# Section 12 – PublishOutcome enum
+# Section 12 - PublishOutcome enum
 # ---------------------------------------------------------------------------
 
 
@@ -1357,7 +1357,7 @@ class TestPublishOutcomeEnum:
 
 
 # ---------------------------------------------------------------------------
-# Section 13 – _check_gitignore_for_marketplace_json
+# Section 13 - _check_gitignore_for_marketplace_json
 # ---------------------------------------------------------------------------
 
 
@@ -1429,7 +1429,7 @@ class TestCheckGitignoreForMarketplaceJson:
 
 
 # ---------------------------------------------------------------------------
-# Section 14 – _load_yml_or_exit (indirectly via CWD + sys.exit mocking)
+# Section 14 - _load_yml_or_exit (indirectly via CWD + sys.exit mocking)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/integration/test_runner_reference_phase3.py
+++ b/tests/integration/test_runner_reference_phase3.py
@@ -35,7 +35,7 @@ def _dep_ref():
 
 
 # ============================================================================
-# SECTION 1 – DependencyReference: basic shorthand parsing
+# SECTION 1 - DependencyReference: basic shorthand parsing
 # ============================================================================
 
 
@@ -105,7 +105,7 @@ class TestParseShorthand:
 
 
 # ============================================================================
-# SECTION 2 – DependencyReference: HTTPS URL parsing
+# SECTION 2 - DependencyReference: HTTPS URL parsing
 # ============================================================================
 
 
@@ -164,7 +164,7 @@ class TestParseHttpsUrls:
 
 
 # ============================================================================
-# SECTION 3 – DependencyReference: SSH URL parsing
+# SECTION 3 - DependencyReference: SSH URL parsing
 # ============================================================================
 
 
@@ -231,7 +231,7 @@ class TestParseSshUrls:
 
 
 # ============================================================================
-# SECTION 4 – DependencyReference: virtual packages
+# SECTION 4 - DependencyReference: virtual packages
 # ============================================================================
 
 
@@ -315,7 +315,7 @@ class TestVirtualPackages:
 
 
 # ============================================================================
-# SECTION 5 – DependencyReference: local paths
+# SECTION 5 - DependencyReference: local paths
 # ============================================================================
 
 
@@ -382,7 +382,7 @@ class TestLocalPaths:
 
 
 # ============================================================================
-# SECTION 6 – DependencyReference: to_canonical / get_identity
+# SECTION 6 - DependencyReference: to_canonical / get_identity
 # ============================================================================
 
 
@@ -446,7 +446,7 @@ class TestCanonicalAndIdentity:
 
 
 # ============================================================================
-# SECTION 7 – DependencyReference: to_github_url / to_apm_yml_entry
+# SECTION 7 - DependencyReference: to_github_url / to_apm_yml_entry
 # ============================================================================
 
 
@@ -520,7 +520,7 @@ class TestToGithubUrlAndApmYmlEntry:
 
 
 # ============================================================================
-# SECTION 8 – DependencyReference: get_install_path
+# SECTION 8 - DependencyReference: get_install_path
 # ============================================================================
 
 
@@ -582,7 +582,7 @@ class TestGetInstallPath:
 
 
 # ============================================================================
-# SECTION 9 – DependencyReference: Azure DevOps parsing
+# SECTION 9 - DependencyReference: Azure DevOps parsing
 # ============================================================================
 
 
@@ -621,7 +621,7 @@ class TestAzureDevOpsParsing:
 
 
 # ============================================================================
-# SECTION 10 – DependencyReference: parse_from_dict
+# SECTION 10 - DependencyReference: parse_from_dict
 # ============================================================================
 
 
@@ -714,7 +714,7 @@ class TestParseFromDict:
 
 
 # ============================================================================
-# SECTION 11 – DependencyReference: GitLab shorthand helpers
+# SECTION 11 - DependencyReference: GitLab shorthand helpers
 # ============================================================================
 
 
@@ -801,7 +801,7 @@ class TestGitlabShorthandHelpers:
 
 
 # ============================================================================
-# SECTION 12 – DependencyReference: display name and __str__
+# SECTION 12 - DependencyReference: display name and __str__
 # ============================================================================
 
 
@@ -838,7 +838,7 @@ class TestDisplayNameAndStr:
 
 
 # ============================================================================
-# SECTION 13 – PromptCompiler: compile and parameter substitution
+# SECTION 13 - PromptCompiler: compile and parameter substitution
 # ============================================================================
 
 
@@ -950,7 +950,7 @@ class TestPromptCompiler:
 
 
 # ============================================================================
-# SECTION 14 – ScriptRunner: list_scripts and _load_config
+# SECTION 14 - ScriptRunner: list_scripts and _load_config
 # ============================================================================
 
 
@@ -1003,7 +1003,7 @@ class TestScriptRunnerConfig:
 
 
 # ============================================================================
-# SECTION 15 – ScriptRunner: runtime detection helpers
+# SECTION 15 - ScriptRunner: runtime detection helpers
 # ============================================================================
 
 
@@ -1112,7 +1112,7 @@ class TestScriptRunnerRuntimeDetection:
 
 
 # ============================================================================
-# SECTION 16 – ScriptRunner: _detect_installed_runtime
+# SECTION 16 - ScriptRunner: _detect_installed_runtime
 # ============================================================================
 
 
@@ -1153,7 +1153,7 @@ class TestDetectInstalledRuntime:
 
 
 # ============================================================================
-# SECTION 17 – ScriptRunner: _generate_runtime_command
+# SECTION 17 - ScriptRunner: _generate_runtime_command
 # ============================================================================
 
 
@@ -1195,7 +1195,7 @@ class TestGenerateRuntimeCommand:
 
 
 # ============================================================================
-# SECTION 18 – ScriptRunner: _transform_runtime_command
+# SECTION 18 - ScriptRunner: _transform_runtime_command
 # ============================================================================
 
 
@@ -1263,7 +1263,7 @@ class TestTransformRuntimeCommand:
 
 
 # ============================================================================
-# SECTION 19 – ScriptRunner: _discover_prompt_file
+# SECTION 19 - ScriptRunner: _discover_prompt_file
 # ============================================================================
 
 
@@ -1348,7 +1348,7 @@ class TestDiscoverPromptFile:
 
 
 # ============================================================================
-# SECTION 20 – ScriptRunner: _is_virtual_package_reference
+# SECTION 20 - ScriptRunner: _is_virtual_package_reference
 # ============================================================================
 
 
@@ -1388,7 +1388,7 @@ class TestIsVirtualPackageReference:
 
 
 # ============================================================================
-# SECTION 21 – ScriptRunner: run_script with explicit scripts
+# SECTION 21 - ScriptRunner: run_script with explicit scripts
 # ============================================================================
 
 
@@ -1457,7 +1457,7 @@ class TestRunScriptExplicit:
 
 
 # ============================================================================
-# SECTION 22 – ScriptRunner: auto-compile path in _auto_compile_prompts
+# SECTION 22 - ScriptRunner: auto-compile path in _auto_compile_prompts
 # ============================================================================
 
 
@@ -1502,7 +1502,7 @@ class TestAutoCompilePrompts:
 
 
 # ============================================================================
-# SECTION 23 – ScriptRunner: _collect_dependency_dirs
+# SECTION 23 - ScriptRunner: _collect_dependency_dirs
 # ============================================================================
 
 
@@ -1545,7 +1545,7 @@ class TestCollectDependencyDirs:
 
 
 # ============================================================================
-# SECTION 24 – ScriptRunner: _add_dependency_to_config
+# SECTION 24 - ScriptRunner: _add_dependency_to_config
 # ============================================================================
 
 
@@ -1588,7 +1588,7 @@ class TestAddDependencyToConfig:
 
 
 # ============================================================================
-# SECTION 25 – ScriptRunner: _create_minimal_config
+# SECTION 25 - ScriptRunner: _create_minimal_config
 # ============================================================================
 
 

--- a/tests/integration/test_runner_reference_resolution.py
+++ b/tests/integration/test_runner_reference_resolution.py
@@ -35,7 +35,7 @@ def _dep_ref():
 
 
 # ============================================================================
-# SECTION 1 – DependencyReference: basic shorthand parsing
+# SECTION 1 - DependencyReference: basic shorthand parsing
 # ============================================================================
 
 
@@ -105,7 +105,7 @@ class TestParseShorthand:
 
 
 # ============================================================================
-# SECTION 2 – DependencyReference: HTTPS URL parsing
+# SECTION 2 - DependencyReference: HTTPS URL parsing
 # ============================================================================
 
 
@@ -164,7 +164,7 @@ class TestParseHttpsUrls:
 
 
 # ============================================================================
-# SECTION 3 – DependencyReference: SSH URL parsing
+# SECTION 3 - DependencyReference: SSH URL parsing
 # ============================================================================
 
 
@@ -231,7 +231,7 @@ class TestParseSshUrls:
 
 
 # ============================================================================
-# SECTION 4 – DependencyReference: virtual packages
+# SECTION 4 - DependencyReference: virtual packages
 # ============================================================================
 
 
@@ -315,7 +315,7 @@ class TestVirtualPackages:
 
 
 # ============================================================================
-# SECTION 5 – DependencyReference: local paths
+# SECTION 5 - DependencyReference: local paths
 # ============================================================================
 
 
@@ -382,7 +382,7 @@ class TestLocalPaths:
 
 
 # ============================================================================
-# SECTION 6 – DependencyReference: to_canonical / get_identity
+# SECTION 6 - DependencyReference: to_canonical / get_identity
 # ============================================================================
 
 
@@ -446,7 +446,7 @@ class TestCanonicalAndIdentity:
 
 
 # ============================================================================
-# SECTION 7 – DependencyReference: to_github_url / to_apm_yml_entry
+# SECTION 7 - DependencyReference: to_github_url / to_apm_yml_entry
 # ============================================================================
 
 
@@ -520,7 +520,7 @@ class TestToGithubUrlAndApmYmlEntry:
 
 
 # ============================================================================
-# SECTION 8 – DependencyReference: get_install_path
+# SECTION 8 - DependencyReference: get_install_path
 # ============================================================================
 
 
@@ -582,7 +582,7 @@ class TestGetInstallPath:
 
 
 # ============================================================================
-# SECTION 9 – DependencyReference: Azure DevOps parsing
+# SECTION 9 - DependencyReference: Azure DevOps parsing
 # ============================================================================
 
 
@@ -621,7 +621,7 @@ class TestAzureDevOpsParsing:
 
 
 # ============================================================================
-# SECTION 10 – DependencyReference: parse_from_dict
+# SECTION 10 - DependencyReference: parse_from_dict
 # ============================================================================
 
 
@@ -714,7 +714,7 @@ class TestParseFromDict:
 
 
 # ============================================================================
-# SECTION 11 – DependencyReference: GitLab shorthand helpers
+# SECTION 11 - DependencyReference: GitLab shorthand helpers
 # ============================================================================
 
 
@@ -801,7 +801,7 @@ class TestGitlabShorthandHelpers:
 
 
 # ============================================================================
-# SECTION 12 – DependencyReference: display name and __str__
+# SECTION 12 - DependencyReference: display name and __str__
 # ============================================================================
 
 
@@ -838,7 +838,7 @@ class TestDisplayNameAndStr:
 
 
 # ============================================================================
-# SECTION 13 – PromptCompiler: compile and parameter substitution
+# SECTION 13 - PromptCompiler: compile and parameter substitution
 # ============================================================================
 
 
@@ -950,7 +950,7 @@ class TestPromptCompiler:
 
 
 # ============================================================================
-# SECTION 14 – ScriptRunner: list_scripts and _load_config
+# SECTION 14 - ScriptRunner: list_scripts and _load_config
 # ============================================================================
 
 
@@ -1003,7 +1003,7 @@ class TestScriptRunnerConfig:
 
 
 # ============================================================================
-# SECTION 15 – ScriptRunner: runtime detection helpers
+# SECTION 15 - ScriptRunner: runtime detection helpers
 # ============================================================================
 
 
@@ -1112,7 +1112,7 @@ class TestScriptRunnerRuntimeDetection:
 
 
 # ============================================================================
-# SECTION 16 – ScriptRunner: _detect_installed_runtime
+# SECTION 16 - ScriptRunner: _detect_installed_runtime
 # ============================================================================
 
 
@@ -1153,7 +1153,7 @@ class TestDetectInstalledRuntime:
 
 
 # ============================================================================
-# SECTION 17 – ScriptRunner: _generate_runtime_command
+# SECTION 17 - ScriptRunner: _generate_runtime_command
 # ============================================================================
 
 
@@ -1195,7 +1195,7 @@ class TestGenerateRuntimeCommand:
 
 
 # ============================================================================
-# SECTION 18 – ScriptRunner: _transform_runtime_command
+# SECTION 18 - ScriptRunner: _transform_runtime_command
 # ============================================================================
 
 
@@ -1263,7 +1263,7 @@ class TestTransformRuntimeCommand:
 
 
 # ============================================================================
-# SECTION 19 – ScriptRunner: _discover_prompt_file
+# SECTION 19 - ScriptRunner: _discover_prompt_file
 # ============================================================================
 
 
@@ -1348,7 +1348,7 @@ class TestDiscoverPromptFile:
 
 
 # ============================================================================
-# SECTION 20 – ScriptRunner: _is_virtual_package_reference
+# SECTION 20 - ScriptRunner: _is_virtual_package_reference
 # ============================================================================
 
 
@@ -1388,7 +1388,7 @@ class TestIsVirtualPackageReference:
 
 
 # ============================================================================
-# SECTION 21 – ScriptRunner: run_script with explicit scripts
+# SECTION 21 - ScriptRunner: run_script with explicit scripts
 # ============================================================================
 
 
@@ -1457,7 +1457,7 @@ class TestRunScriptExplicit:
 
 
 # ============================================================================
-# SECTION 22 – ScriptRunner: auto-compile path in _auto_compile_prompts
+# SECTION 22 - ScriptRunner: auto-compile path in _auto_compile_prompts
 # ============================================================================
 
 
@@ -1502,7 +1502,7 @@ class TestAutoCompilePrompts:
 
 
 # ============================================================================
-# SECTION 23 – ScriptRunner: _collect_dependency_dirs
+# SECTION 23 - ScriptRunner: _collect_dependency_dirs
 # ============================================================================
 
 
@@ -1545,7 +1545,7 @@ class TestCollectDependencyDirs:
 
 
 # ============================================================================
-# SECTION 24 – ScriptRunner: _add_dependency_to_config
+# SECTION 24 - ScriptRunner: _add_dependency_to_config
 # ============================================================================
 
 
@@ -1588,7 +1588,7 @@ class TestAddDependencyToConfig:
 
 
 # ============================================================================
-# SECTION 25 – ScriptRunner: _create_minimal_config
+# SECTION 25 - ScriptRunner: _create_minimal_config
 # ============================================================================
 
 

--- a/tests/integration/test_wave7_marketplace_install_coverage.py
+++ b/tests/integration/test_wave7_marketplace_install_coverage.py
@@ -1,4 +1,4 @@
-"""Integration tests for Wave 7 – marketplace and install coverage.
+"""Integration tests for Wave 7 - marketplace and install coverage.
 
 Targets:
   1. src/apm_cli/commands/marketplace/__init__.py  (~39% covered, 406 lines missing)
@@ -100,7 +100,7 @@ def runner() -> CliRunner:
 
 
 # ===========================================================================
-# Marketplace – list command
+# Marketplace - list command
 # ===========================================================================
 
 
@@ -166,7 +166,7 @@ class TestMarketplaceList:
 
 
 # ===========================================================================
-# Marketplace – browse command
+# Marketplace - browse command
 # ===========================================================================
 
 
@@ -243,7 +243,7 @@ class TestMarketplaceBrowse:
 
 
 # ===========================================================================
-# Marketplace – search command
+# Marketplace - search command
 # ===========================================================================
 
 
@@ -357,7 +357,7 @@ class TestMarketplaceSearch:
 
 
 # ===========================================================================
-# Marketplace – update command
+# Marketplace - update command
 # ===========================================================================
 
 
@@ -449,7 +449,7 @@ class TestMarketplaceUpdate:
 
 
 # ===========================================================================
-# Marketplace – remove command
+# Marketplace - remove command
 # ===========================================================================
 
 
@@ -502,7 +502,7 @@ class TestMarketplaceRemove:
 
 
 # ===========================================================================
-# Marketplace – add command
+# Marketplace - add command
 # ===========================================================================
 
 
@@ -659,7 +659,7 @@ class TestMarketplaceAdd:
 
 
 # ===========================================================================
-# Marketplace – removed 'build' subcommand
+# Marketplace - removed 'build' subcommand
 # ===========================================================================
 
 
@@ -676,7 +676,7 @@ class TestMarketplaceBuildRemoved:
 
 
 # ===========================================================================
-# Marketplace – validate command
+# Marketplace - validate command
 # ===========================================================================
 
 
@@ -708,7 +708,7 @@ build:
 
 
 # ===========================================================================
-# Install – basic invocation
+# Install - basic invocation
 # ===========================================================================
 
 
@@ -753,7 +753,7 @@ class TestInstallBasic:
 
 
 # ===========================================================================
-# Install – with packages argument
+# Install - with packages argument
 # ===========================================================================
 
 
@@ -834,7 +834,7 @@ class TestInstallWithPackages:
 
 
 # ===========================================================================
-# Install – flags and options
+# Install - flags and options
 # ===========================================================================
 
 
@@ -927,7 +927,7 @@ class TestInstallFlags:
 
 
 # ===========================================================================
-# Install – lockfile scenarios
+# Install - lockfile scenarios
 # ===========================================================================
 
 
@@ -970,7 +970,7 @@ class TestInstallWithLockfile:
 
 
 # ===========================================================================
-# Install – apm.yml auto-bootstrap
+# Install - apm.yml auto-bootstrap
 # ===========================================================================
 
 
@@ -994,7 +994,7 @@ class TestInstallAutoBootstrap:
 
 
 # ===========================================================================
-# Install – error paths
+# Install - error paths
 # ===========================================================================
 
 
@@ -1036,7 +1036,7 @@ class TestInstallErrorPaths:
 
 
 # ===========================================================================
-# Install – global scope
+# Install - global scope
 # ===========================================================================
 
 
@@ -1061,7 +1061,7 @@ class TestInstallGlobalScope:
 
 
 # ===========================================================================
-# Marketplace – internal helpers (unit-style but via real code paths)
+# Marketplace - internal helpers (unit-style but via real code paths)
 # ===========================================================================
 
 
@@ -1178,7 +1178,7 @@ class TestMarketplaceInternalHelpers:
 
 
 # ===========================================================================
-# Install – internal helper tests
+# Install - internal helper tests
 # ===========================================================================
 
 

--- a/tests/integration/test_wave7_policy_registry_coverage.py
+++ b/tests/integration/test_wave7_policy_registry_coverage.py
@@ -53,7 +53,7 @@ from apm_cli.marketplace.resolver import (
 )
 from apm_cli.models.dependency.mcp import MCPDependency
 from apm_cli.models.dependency.reference import DependencyReference
-from apm_cli.policy.models import CheckResult  # noqa: F401 – used implicitly
+from apm_cli.policy.models import CheckResult  # noqa: F401 - used implicitly
 from apm_cli.policy.policy_checks import (
     _INCLUDES_NOT_PROVIDED,
     _check_compilation_strategy,

--- a/tests/unit/commands/test_marketplace_coverage.py
+++ b/tests/unit/commands/test_marketplace_coverage.py
@@ -86,7 +86,7 @@ class TestMarketplaceInitWriteError:
 
 
 # ---------------------------------------------------------------------------
-# marketplace/plugin/__init__.py – _yml_path
+# marketplace/plugin/__init__.py - _yml_path
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/compilation/test_agents_compiler_coverage.py
+++ b/tests/unit/compilation/test_agents_compiler_coverage.py
@@ -53,7 +53,7 @@ def _make_primitives(*instructions):
 
 
 # ---------------------------------------------------------------------------
-# CompilationConfig.from_apm_yml() – additional fields
+# CompilationConfig.from_apm_yml() - additional fields
 # ---------------------------------------------------------------------------
 
 
@@ -157,7 +157,7 @@ class TestCompilationConfigPostInit(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# AgentsCompiler.compile() – exception path
+# AgentsCompiler.compile() - exception path
 # ---------------------------------------------------------------------------
 
 
@@ -199,7 +199,7 @@ class TestAgentsCompilerCompileException(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# AgentsCompiler.validate_primitives() – error branches
+# AgentsCompiler.validate_primitives() - error branches
 # ---------------------------------------------------------------------------
 
 
@@ -286,7 +286,7 @@ class TestValidatePrimitivesErrors(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# AgentsCompiler._write_output_file() – error path
+# AgentsCompiler._write_output_file() - error path
 # ---------------------------------------------------------------------------
 
 
@@ -547,7 +547,7 @@ class TestMergeResults(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# compile_agents_md() convenience function – error path
+# compile_agents_md() convenience function - error path
 # ---------------------------------------------------------------------------
 
 
@@ -608,7 +608,7 @@ class TestCompileAgentsMdFunction(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# _compile_claude_md – constitution injection failure path (G2)
+# _compile_claude_md - constitution injection failure path (G2)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/compilation/test_compile_cli_phase3.py
+++ b/tests/unit/compilation/test_compile_cli_phase3.py
@@ -3,12 +3,12 @@
 Covers the helper functions and compile-command branches that are not yet
 reached by test_compile_target_flag.py:
 
-* _display_single_file_summary  – console present, console absent, fallback
-* _display_next_steps           – console present, ImportError fallback
-* _display_validation_errors    – console present, ImportError/NameError fallback
-* _get_validation_suggestion    – every suggestion branch
-* _resolve_effective_target     – explicit flag, apm.yml, auto-detect paths
-* compile command               – no-apm-yml, --all + --target conflict,
+* _display_single_file_summary  - console present, console absent, fallback
+* _display_next_steps           - console present, ImportError fallback
+* _display_validation_errors    - console present, ImportError/NameError fallback
+* _get_validation_suggestion    - every suggestion branch
+* _resolve_effective_target     - explicit flag, apm.yml, auto-detect paths
+* compile command               - no-apm-yml, --all + --target conflict,
                                   --all target expansion, validate mode,
                                   watch mode routing, distributed success,
                                   zero-output warning, result errors,
@@ -604,7 +604,7 @@ class TestCompileCommandWatchMode:
 
 
 class TestCompileCommandDistributedSuccess:
-    """compile command – distributed strategy success path."""
+    """compile command - distributed strategy success path."""
 
     def _setup_project_dir(self) -> None:
         Path("apm.yml").write_text("name: test\nversion: 0.1.0\n")
@@ -774,7 +774,7 @@ class TestCompileCommandDistributedSuccess:
 
 
 class TestCompileCommandWarnings:
-    """compile command – warnings propagation."""
+    """compile command - warnings propagation."""
 
     def test_result_warnings_appear_in_output(self) -> None:
         """result.warnings should be printed."""
@@ -820,7 +820,7 @@ class TestCompileCommandWarnings:
 
 
 class TestCompileCommandNoContent:
-    """compile command – no content to compile branches."""
+    """compile command - no content to compile branches."""
 
     def test_no_apm_modules_no_local_apm_content(self) -> None:
         """When no apm_modules, no .apm content, no constitution → exit 1."""
@@ -859,7 +859,7 @@ class TestCompileCommandNoContent:
 
 
 class TestCompileCommandImportError:
-    """compile command – ImportError path."""
+    """compile command - ImportError path."""
 
     def test_import_error_in_compilation_exits_1(self) -> None:
         """ImportError inside the try block should exit with code 1."""

--- a/tests/unit/compilation/test_compile_cli_surface.py
+++ b/tests/unit/compilation/test_compile_cli_surface.py
@@ -3,12 +3,12 @@
 Covers the helper functions and compile-command branches that are not yet
 reached by test_compile_target_flag.py:
 
-* _display_single_file_summary  – console present, console absent, fallback
-* _display_next_steps           – console present, ImportError fallback
-* _display_validation_errors    – console present, ImportError/NameError fallback
-* _get_validation_suggestion    – every suggestion branch
-* _resolve_effective_target     – explicit flag, apm.yml, auto-detect paths
-* compile command               – no-apm-yml, --all + --target conflict,
+* _display_single_file_summary  - console present, console absent, fallback
+* _display_next_steps           - console present, ImportError fallback
+* _display_validation_errors    - console present, ImportError/NameError fallback
+* _get_validation_suggestion    - every suggestion branch
+* _resolve_effective_target     - explicit flag, apm.yml, auto-detect paths
+* compile command               - no-apm-yml, --all + --target conflict,
                                   --all target expansion, validate mode,
                                   watch mode routing, distributed success,
                                   zero-output warning, result errors,
@@ -604,7 +604,7 @@ class TestCompileCommandWatchMode:
 
 
 class TestCompileCommandDistributedSuccess:
-    """compile command – distributed strategy success path."""
+    """compile command - distributed strategy success path."""
 
     def _setup_project_dir(self) -> None:
         Path("apm.yml").write_text("name: test\nversion: 0.1.0\n")
@@ -774,7 +774,7 @@ class TestCompileCommandDistributedSuccess:
 
 
 class TestCompileCommandWarnings:
-    """compile command – warnings propagation."""
+    """compile command - warnings propagation."""
 
     def test_result_warnings_appear_in_output(self) -> None:
         """result.warnings should be printed."""
@@ -820,7 +820,7 @@ class TestCompileCommandWarnings:
 
 
 class TestCompileCommandNoContent:
-    """compile command – no content to compile branches."""
+    """compile command - no content to compile branches."""
 
     def test_no_apm_modules_no_local_apm_content(self) -> None:
         """When no apm_modules, no .apm content, no constitution → exit 1."""
@@ -859,7 +859,7 @@ class TestCompileCommandNoContent:
 
 
 class TestCompileCommandImportError:
-    """compile command – ImportError path."""
+    """compile command - ImportError path."""
 
     def test_import_error_in_compilation_exits_1(self) -> None:
         """ImportError inside the try block should exit with code 1."""

--- a/tests/unit/compilation/test_context_optimizer.py
+++ b/tests/unit/compilation/test_context_optimizer.py
@@ -849,7 +849,7 @@ class TestApmModulesExclusion:
         # 50 packages x sub-directory each = 150+ dirs if not excluded.
         # Real project has at most ~5 dirs (root, src, src/components, tests, docs).
         assert len(optimizer._directory_cache) <= 10, (
-            f"Cache has {len(optimizer._directory_cache)} dirs — apm_modules likely not excluded"
+            f"Cache has {len(optimizer._directory_cache)} dirs -- apm_modules likely not excluded"
         )
 
     def test_os_walk_prunes_apm_modules(self, project_with_apm_modules):

--- a/tests/unit/compilation/test_context_optimizer.py
+++ b/tests/unit/compilation/test_context_optimizer.py
@@ -846,7 +846,7 @@ class TestApmModulesExclusion:
         optimizer = ContextOptimizer(base_dir=str(project_with_apm_modules))
         optimizer._analyze_project_structure()
 
-        # 50 packages × sub-directory each = 150+ dirs if not excluded.
+        # 50 packages x sub-directory each = 150+ dirs if not excluded.
         # Real project has at most ~5 dirs (root, src, src/components, tests, docs).
         assert len(optimizer._directory_cache) <= 10, (
             f"Cache has {len(optimizer._directory_cache)} dirs — apm_modules likely not excluded"

--- a/tests/unit/compilation/test_coverage_guarantees.py
+++ b/tests/unit/compilation/test_coverage_guarantees.py
@@ -2,7 +2,7 @@
 
 Tests the core mathematical foundation:
 - Hierarchical coverage verification: ∀file_matching_pattern → can_inherit_instruction
-- Coverage-constrained optimization: minimize Σ(context_pollution × directory_weight) subject to coverage
+- Coverage-constrained optimization: minimize Σ(context_pollution x directory_weight) subject to coverage
 - Data loss prevention: no files are left without applicable instructions
 - Coverage-first principle: coverage takes priority over efficiency
 """
@@ -349,7 +349,7 @@ class TestCoverageGuarantees:
     ):
         """Test that the mathematical constraints are satisfied as a system.
 
-        Verifies: minimize Σ(context_pollution × directory_weight) subject to ∀file → coverage
+        Verifies: minimize Σ(context_pollution x directory_weight) subject to ∀file → coverage
         """
         optimizer = ContextOptimizer(str(complex_project))
 

--- a/tests/unit/compilation/test_distributed_compiler_hermetic.py
+++ b/tests/unit/compilation/test_distributed_compiler_hermetic.py
@@ -796,7 +796,7 @@ class TestGetCompilationResultsForDisplay:
 
 
 # ---------------------------------------------------------------------------
-# compile_distributed – integration-style
+# compile_distributed - integration-style
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/compilation/test_distributed_compiler_phase3.py
+++ b/tests/unit/compilation/test_distributed_compiler_phase3.py
@@ -796,7 +796,7 @@ class TestGetCompilationResultsForDisplay:
 
 
 # ---------------------------------------------------------------------------
-# compile_distributed – integration-style
+# compile_distributed - integration-style
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/deps/test_apm_resolver_edge_cases.py
+++ b/tests/unit/deps/test_apm_resolver_edge_cases.py
@@ -280,7 +280,7 @@ class TestExpandParentRepoDecl:
 
 
 # ---------------------------------------------------------------------------
-# build_dependency_tree – root parse error
+# build_dependency_tree - root parse error
 # ---------------------------------------------------------------------------
 
 
@@ -553,7 +553,7 @@ class TestEffectiveBaseDir:
 
 
 # ---------------------------------------------------------------------------
-# _try_load_dependency_package – low-level path tests
+# _try_load_dependency_package - low-level path tests
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/deps/test_apm_resolver_phase3.py
+++ b/tests/unit/deps/test_apm_resolver_phase3.py
@@ -280,7 +280,7 @@ class TestExpandParentRepoDecl:
 
 
 # ---------------------------------------------------------------------------
-# build_dependency_tree – root parse error
+# build_dependency_tree - root parse error
 # ---------------------------------------------------------------------------
 
 
@@ -553,7 +553,7 @@ class TestEffectiveBaseDir:
 
 
 # ---------------------------------------------------------------------------
-# _try_load_dependency_package – low-level path tests
+# _try_load_dependency_package - low-level path tests
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/install/test_mcp_conflicts.py
+++ b/tests/unit/install/test_mcp_conflicts.py
@@ -75,7 +75,7 @@ class TestValidCallNoErrors:
 
 
 # ---------------------------------------------------------------------------
-# E10 – flags require --mcp
+# E10 - flags require --mcp
 # ---------------------------------------------------------------------------
 
 
@@ -116,7 +116,7 @@ class TestE10FlagsRequireMcp:
 
 
 # ---------------------------------------------------------------------------
-# E7 – empty mcp_name
+# E7 - empty mcp_name
 # ---------------------------------------------------------------------------
 
 
@@ -127,7 +127,7 @@ class TestE7EmptyMcpName:
 
 
 # ---------------------------------------------------------------------------
-# E8 – mcp_name starts with '-'
+# E8 - mcp_name starts with '-'
 # ---------------------------------------------------------------------------
 
 
@@ -145,7 +145,7 @@ class TestE8McpNameStartsWithDash:
 
 
 # ---------------------------------------------------------------------------
-# E1 – positional packages mixed with --mcp
+# E1 - positional packages mixed with --mcp
 # ---------------------------------------------------------------------------
 
 
@@ -163,7 +163,7 @@ class TestE1PositionalPackagesMixedWithMcp:
 
 
 # ---------------------------------------------------------------------------
-# E2 – --global not supported for MCP entries
+# E2 - --global not supported for MCP entries
 # ---------------------------------------------------------------------------
 
 
@@ -177,7 +177,7 @@ class TestE2GlobalNotSupportedForMcp:
 
 
 # ---------------------------------------------------------------------------
-# E3 – --only apm conflicts with --mcp
+# E3 - --only apm conflicts with --mcp
 # ---------------------------------------------------------------------------
 
 
@@ -194,7 +194,7 @@ class TestE3OnlyApmConflictsWithMcp:
 
 
 # ---------------------------------------------------------------------------
-# E4 – transport selection flags don't apply to MCP
+# E4 - transport selection flags don't apply to MCP
 # ---------------------------------------------------------------------------
 
 
@@ -216,7 +216,7 @@ class TestE4TransportSelectionFlags:
 
 
 # ---------------------------------------------------------------------------
-# E5 – --update is for refreshing
+# E5 - --update is for refreshing
 # ---------------------------------------------------------------------------
 
 
@@ -230,7 +230,7 @@ class TestE5UpdateFlag:
 
 
 # ---------------------------------------------------------------------------
-# E9 – --header requires --url
+# E9 - --header requires --url
 # ---------------------------------------------------------------------------
 
 
@@ -247,7 +247,7 @@ class TestE9HeaderRequiresUrl:
 
 
 # ---------------------------------------------------------------------------
-# E11 – --url with stdio command
+# E11 - --url with stdio command
 # ---------------------------------------------------------------------------
 
 
@@ -266,7 +266,7 @@ class TestE11UrlWithStdioCommand:
 
 
 # ---------------------------------------------------------------------------
-# E12 – --transport stdio with --url
+# E12 - --transport stdio with --url
 # ---------------------------------------------------------------------------
 
 
@@ -283,7 +283,7 @@ class TestE12StdioTransportWithUrl:
 
 
 # ---------------------------------------------------------------------------
-# E13 – remote transports with stdio command
+# E13 - remote transports with stdio command
 # ---------------------------------------------------------------------------
 
 
@@ -301,7 +301,7 @@ class TestE13RemoteTransportWithStdioCommand:
 
 
 # ---------------------------------------------------------------------------
-# E14 – --env with --url and no command
+# E14 - --env with --url and no command
 # ---------------------------------------------------------------------------
 
 
@@ -323,7 +323,7 @@ class TestE14EnvWithUrlNoCommand:
 
 
 # ---------------------------------------------------------------------------
-# E15 – --registry only applies to registry-resolved entries
+# E15 - --registry only applies to registry-resolved entries
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/install/test_sources_materialisation.py
+++ b/tests/unit/install/test_sources_materialisation.py
@@ -3,7 +3,7 @@
 Covers the DependencySource strategy classes and their helpers that are not
 yet reached by test_sources_classification.py:
 
-* Materialization dataclass – field defaults and custom deltas
+* Materialization dataclass - field defaults and custom deltas
 * LocalDependencySource.acquire
   - USER-scope + relative path → skip + return None
   - USER-scope + absolute path → allowed
@@ -589,7 +589,7 @@ class TestCachedDependencySourceAcquire:
             result = source.acquire()
 
         assert result is not None
-        # resolved_ref was None; the code builds a fallback – we just confirm no crash
+        # resolved_ref was None; the code builds a fallback - we just confirm no crash
 
     def test_unpinned_dep_sets_delta(self, tmp_path: Path) -> None:
         """dep_ref.reference=None → deltas['unpinned']=1."""

--- a/tests/unit/install/test_sources_phase3.py
+++ b/tests/unit/install/test_sources_phase3.py
@@ -3,7 +3,7 @@
 Covers the DependencySource strategy classes and their helpers that are not
 yet reached by test_sources_classification.py:
 
-* Materialization dataclass – field defaults and custom deltas
+* Materialization dataclass - field defaults and custom deltas
 * LocalDependencySource.acquire
   - USER-scope + relative path → skip + return None
   - USER-scope + absolute path → allowed
@@ -589,7 +589,7 @@ class TestCachedDependencySourceAcquire:
             result = source.acquire()
 
         assert result is not None
-        # resolved_ref was None; the code builds a fallback – we just confirm no crash
+        # resolved_ref was None; the code builds a fallback - we just confirm no crash
 
     def test_unpinned_dep_sets_delta(self, tmp_path: Path) -> None:
         """dep_ref.reference=None → deltas['unpinned']=1."""

--- a/tests/unit/marketplace/test_yml_editor.py
+++ b/tests/unit/marketplace/test_yml_editor.py
@@ -1,4 +1,4 @@
-"""Tests for ``apm_cli.marketplace.yml_editor`` – round-trip YAML editor."""
+"""Tests for ``apm_cli.marketplace.yml_editor`` - round-trip YAML editor."""
 
 from __future__ import annotations
 
@@ -42,7 +42,7 @@ packages:
 
 
 # ---------------------------------------------------------------------------
-# add_plugin_entry – happy paths
+# add_plugin_entry - happy paths
 # ---------------------------------------------------------------------------
 
 
@@ -116,7 +116,7 @@ class TestAddPluginHappy:
 
 
 # ---------------------------------------------------------------------------
-# add_plugin_entry – error paths
+# add_plugin_entry - error paths
 # ---------------------------------------------------------------------------
 
 
@@ -190,7 +190,7 @@ class TestAddPluginErrors:
 
 
 # ---------------------------------------------------------------------------
-# add_plugin_entry – comment preservation
+# add_plugin_entry - comment preservation
 # ---------------------------------------------------------------------------
 
 
@@ -218,7 +218,7 @@ class TestAddPluginCommentPreservation:
 
 
 # ---------------------------------------------------------------------------
-# update_plugin_entry – happy paths
+# update_plugin_entry - happy paths
 # ---------------------------------------------------------------------------
 
 
@@ -284,7 +284,7 @@ class TestUpdatePluginHappy:
 
 
 # ---------------------------------------------------------------------------
-# update_plugin_entry – error paths
+# update_plugin_entry - error paths
 # ---------------------------------------------------------------------------
 
 
@@ -306,7 +306,7 @@ class TestUpdatePluginErrors:
 
 
 # ---------------------------------------------------------------------------
-# remove_plugin_entry – happy paths
+# remove_plugin_entry - happy paths
 # ---------------------------------------------------------------------------
 
 
@@ -327,7 +327,7 @@ class TestRemovePluginHappy:
 
 
 # ---------------------------------------------------------------------------
-# remove_plugin_entry – error paths
+# remove_plugin_entry - error paths
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/test_auth_scoping.py
+++ b/tests/unit/test_auth_scoping.py
@@ -62,7 +62,7 @@ def _url_host(url: str) -> str:
 
 
 # ===========================================================================
-# _build_repo_url – token scoping
+# _build_repo_url - token scoping
 # ===========================================================================
 
 
@@ -177,7 +177,7 @@ class TestBuildRepoUrlTokenScoping:
 
 
 # ===========================================================================
-# _clone_with_fallback – env relaxation for generic hosts
+# _clone_with_fallback - env relaxation for generic hosts
 # ===========================================================================
 
 
@@ -769,7 +769,7 @@ class TestParseFromDict:
 
 
 # ===========================================================================
-# from_apm_yml – mixed string + dict dependencies
+# from_apm_yml - mixed string + dict dependencies
 # ===========================================================================
 
 

--- a/tests/unit/test_models_validation_phase3.py
+++ b/tests/unit/test_models_validation_phase3.py
@@ -597,7 +597,7 @@ class TestApmYmlDeclaresdependencies:
 
 
 # ---------------------------------------------------------------------------
-# validate_apm_package – top-level dispatcher
+# validate_apm_package - top-level dispatcher
 # ---------------------------------------------------------------------------
 
 
@@ -808,7 +808,7 @@ class TestEnumValues:
 
 
 # ---------------------------------------------------------------------------
-# _validate_apm_package_with_yml – direct path
+# _validate_apm_package_with_yml - direct path
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/test_models_validation_rules.py
+++ b/tests/unit/test_models_validation_rules.py
@@ -597,7 +597,7 @@ class TestApmYmlDeclaresdependencies:
 
 
 # ---------------------------------------------------------------------------
-# validate_apm_package – top-level dispatcher
+# validate_apm_package - top-level dispatcher
 # ---------------------------------------------------------------------------
 
 
@@ -808,7 +808,7 @@ class TestEnumValues:
 
 
 # ---------------------------------------------------------------------------
-# _validate_apm_package_with_yml – direct path
+# _validate_apm_package_with_yml - direct path
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/test_transitive_mcp.py
+++ b/tests/unit/test_transitive_mcp.py
@@ -42,7 +42,7 @@ def _isolated_targets():
 
 
 # ---------------------------------------------------------------------------
-# APMPackage – MCP dict parsing
+# APMPackage - MCP dict parsing
 # ---------------------------------------------------------------------------
 class TestAPMPackageMCPParsing:
     """Ensure apm_package preserves both string and dict MCP entries."""
@@ -818,7 +818,7 @@ class TestCheckSelfDefinedServersNeeding:
 
 
 # ---------------------------------------------------------------------------
-# _install_mcp_dependencies – self-defined skip logic
+# _install_mcp_dependencies - self-defined skip logic
 # ---------------------------------------------------------------------------
 @pytest.mark.usefixtures("_bypass_target_gate")
 class TestInstallSelfDefinedSkipLogic:


### PR DESCRIPTION
## TL;DR

Enable ruff rules RUF002 (ambiguous-unicode-character-docstring) and RUF003
(ambiguous-unicode-character-comment), then fix all 249 resulting violations
across 34 files.

## Problem (WHY)

PR #999 deferred these two rules to avoid scope creep. The violations are
EN DASH (`-`, U+2013) and MULTIPLICATION SIGN (`x`, U+00D7) characters
embedded in docstrings and comments. These violate the repo's cross-platform
ASCII-only encoding convention (`.github/instructions/encoding.instructions.md`)
and would raise `UnicodeEncodeError` on Windows cp1252 terminals.

## Approach (WHAT)

1. Remove `"RUF002"` and `"RUF003"` from the `ignore` list in `pyproject.toml`.
2. Replace every flagged character globally across all affected files:
   - EN DASH (`U+2013`) -> hyphen-minus `-`
   - MULTIPLICATION SIGN (`U+00D7`) -> letter `x`

No legitimate internationalised content was affected; all violations were
annotation-style punctuation in comments and docstrings.

## Implementation (HOW)

Violation breakdown before fix:

| Character | Rule | Count | Replacement |
|-----------|------|-------|-------------|
| EN DASH (U+2013) | RUF003 | 209 | `-` |
| EN DASH (U+2013) | RUF002 |  30 | `-` |
| MULTIPLICATION SIGN (U+00D7) | RUF002 |   6 | `x` |
| MULTIPLICATION SIGN (U+00D7) | RUF003 |   4 | `x` |

Files changed: 3 in `src/`, 31 in `tests/`, plus `pyproject.toml`.

## Trade-offs

- The fix is mechanical (character substitution); no semantic meaning is lost.
- Comments like `# SECTION N - ...` and `O(V x max_depth)` remain readable.
- The `->" arrow (U+2192) appears in some comments but is NOT flagged by
  RUF003 (it is not in ruff's ambiguous-unicode list), so it was left as-is.

## Validation evidence

```
uv run --extra dev ruff check src/ tests/
=> All checks passed!

uv run --extra dev ruff format --check src/ tests/
=> 1165 files already formatted

uv run --extra dev python -m pylint --disable=all --enable=R0801   --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/
=> Your code has been rated at 10.00/10

bash scripts/lint-auth-signals.sh
=> [+] auth-signal lint clean

pytest -q tests/unit/install/test_mcp_conflicts.py tests/unit/marketplace/test_yml_editor.py   tests/unit/compilation/test_coverage_guarantees.py tests/unit/test_auth_scoping.py   tests/unit/deps/test_apm_resolver_edge_cases.py
=> 199 passed
```

## How to test

```bash
git checkout danielmeppiel/1005-ruf002-ruf003
uv run --extra dev ruff check --select RUF002,RUF003 src/ tests/
# => All checks passed!
```

Closes #1005

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>