### PR TITLE
fix: polish managed-section error messages

### DIFF
--- a/docs/src/content/docs/producer/compile.md
+++ b/docs/src/content/docs/producer/compile.md
@@ -192,8 +192,10 @@ The default markers are `<!-- apm:start -->` and `<!-- apm:end -->`, so
 you can omit `start_marker` and `end_marker` if you use those verbatim.
 
 **Constraints:**
+- Managed-section mode requires a pre-existing `AGENTS.md`; if the file does not exist APM has nothing to update.
 - Both markers must be present in the file exactly once (missing or
   duplicate markers raise a loud error so no content is silently lost).
+- The start marker must appear before the end marker; reversed order raises a loud error.
 - `start_marker` and `end_marker` must be distinct non-empty strings.
 - Content outside the markers is preserved verbatim across every compile
   run; only the block between the markers is replaced.

--- a/docs/src/content/docs/producer/compile.md
+++ b/docs/src/content/docs/producer/compile.md
@@ -192,7 +192,7 @@ The default markers are `<!-- apm:start -->` and `<!-- apm:end -->`, so
 you can omit `start_marker` and `end_marker` if you use those verbatim.
 
 **Constraints:**
-- Managed-section mode requires a pre-existing `AGENTS.md`; if the file does not exist APM has nothing to update.
+- Managed-section mode requires a pre-existing `AGENTS.md` containing both markers; if the file is absent the marker check fails with a markers-not-found error telling you to add them.
 - Both markers must be present in the file exactly once (missing or
   duplicate markers raise a loud error so no content is silently lost).
 - The start marker must appear before the end marker; reversed order raises a loud error.

--- a/src/apm_cli/compilation/agents_compiler.py
+++ b/src/apm_cli/compilation/agents_compiler.py
@@ -1244,7 +1244,7 @@ class AgentsCompiler:
                     config.agents_md_end_marker,
                 )
             except ManagedSectionError as exc:
-                raise ManagedSectionError(f"{target}: {exc}") from exc
+                raise ManagedSectionError(f"[{target}] {exc}") from exc
         elif config.agents_md_mode != "full":
             raise ValueError(
                 f"Unknown agents_md.mode {config.agents_md_mode!r}. "

--- a/src/apm_cli/compilation/managed_section.py
+++ b/src/apm_cli/compilation/managed_section.py
@@ -54,11 +54,15 @@ def apply_managed_section(
     end_count = existing_content.count(end_marker)
 
     if start_count > 1 or end_count > 1:
+        duplicated = []
+        if start_count > 1:
+            duplicated.append(f"start marker ({start_marker!r}) {start_count} time(s)")
+        if end_count > 1:
+            duplicated.append(f"end marker ({end_marker!r}) {end_count} time(s)")
         raise ManagedSectionError(
             "Managed-section markers must appear exactly once in the file, but found "
-            f"start marker ({start_marker!r}) {start_count} time(s) and "
-            f"end marker ({end_marker!r}) {end_count} time(s). "
-            "Remove the duplicate markers before running APM again."
+            + " and ".join(duplicated)
+            + ". Remove the duplicate markers before running APM again."
         )
 
     if start_count == 0 or end_count == 0:
@@ -70,7 +74,7 @@ def apply_managed_section(
         raise ManagedSectionError(
             f"Managed-section markers not found in the target file "
             f"({', '.join(missing)} absent). "
-            "Add both markers to AGENTS.md to enable managed-section mode. "
+            "Add the missing marker(s) to AGENTS.md to enable managed-section mode. "
             f"Example:\n  {start_marker}\n  <APM will insert content here>\n  {end_marker}"
         )
 

--- a/tests/unit/compilation/test_managed_section.py
+++ b/tests/unit/compilation/test_managed_section.py
@@ -155,7 +155,7 @@ class TestApplyManagedSection:
             apply_managed_section(existing, "New.", DEFAULT_START, DEFAULT_END)
         msg = str(exc_info.value)
         # end marker appears exactly once -- should not appear in duplicate report
-        assert "end marker" not in msg or DEFAULT_END not in msg
+        assert "end marker" not in msg and DEFAULT_END not in msg
 
     def test_duplicate_only_end_does_not_mention_start_count(self):
         """When only the end marker is duplicated, message must not report start marker count."""
@@ -164,7 +164,7 @@ class TestApplyManagedSection:
             apply_managed_section(existing, "New.", DEFAULT_START, DEFAULT_END)
         msg = str(exc_info.value)
         # start marker appears exactly once -- should not appear in duplicate report
-        assert "start marker" not in msg or DEFAULT_START not in msg
+        assert "start marker" not in msg and DEFAULT_START not in msg
 
 
 class TestManagedSectionInCompilationConfig:
@@ -307,3 +307,4 @@ class TestManagedSectionWriteIntegration:
         msg = str(exc_info.value)
         # filename must be wrapped in square brackets: [AGENTS.md] ...
         assert msg.startswith("[")
+        assert "] " in msg

--- a/tests/unit/compilation/test_managed_section.py
+++ b/tests/unit/compilation/test_managed_section.py
@@ -135,6 +135,37 @@ class TestApplyManagedSection:
         msg = str(exc_info.value)
         assert DEFAULT_START in msg or DEFAULT_END in msg or "marker" in msg.lower()
 
+    # ------------------------------------------------------------------
+    # Issue #1595: message polish
+    # ------------------------------------------------------------------
+
+    def test_missing_one_marker_says_missing_not_both(self):
+        """When only start marker is absent, message must not say 'both markers'."""
+        existing = f"Some content.\n{DEFAULT_END}\n"
+        with pytest.raises(ManagedSectionError) as exc_info:
+            apply_managed_section(existing, "New.", DEFAULT_START, DEFAULT_END)
+        msg = str(exc_info.value)
+        assert "both markers" not in msg.lower()
+        assert "missing marker" in msg.lower() or "marker(s)" in msg.lower()
+
+    def test_duplicate_only_start_does_not_mention_end_count(self):
+        """When only the start marker is duplicated, message must not report end marker count."""
+        existing = f"{DEFAULT_START}\nSection 1.\n{DEFAULT_END}\n{DEFAULT_START}\nSection 2.\n"
+        with pytest.raises(ManagedSectionError) as exc_info:
+            apply_managed_section(existing, "New.", DEFAULT_START, DEFAULT_END)
+        msg = str(exc_info.value)
+        # end marker appears exactly once -- should not appear in duplicate report
+        assert "end marker" not in msg or DEFAULT_END not in msg
+
+    def test_duplicate_only_end_does_not_mention_start_count(self):
+        """When only the end marker is duplicated, message must not report start marker count."""
+        existing = f"{DEFAULT_START}\nSection 1.\n{DEFAULT_END}\nMiddle.\n{DEFAULT_END}\n"
+        with pytest.raises(ManagedSectionError) as exc_info:
+            apply_managed_section(existing, "New.", DEFAULT_START, DEFAULT_END)
+        msg = str(exc_info.value)
+        # start marker appears exactly once -- should not appear in duplicate report
+        assert "start marker" not in msg or DEFAULT_START not in msg
+
 
 class TestManagedSectionInCompilationConfig:
     """Tests for agents_md config parsing in CompilationConfig."""
@@ -251,3 +282,28 @@ class TestManagedSectionWriteIntegration:
         compiler.config = config
         with pytest.raises(ManagedSectionError):
             compiler._write_output_file_with_config(str(output_file), "New content.\n", config)
+
+    def test_write_reraise_uses_bracket_format(self, tmp_path):
+        """Re-raised ManagedSectionError must wrap filename in [brackets]."""
+        from apm_cli.compilation.agents_compiler import AgentsCompiler, CompilationConfig
+        from apm_cli.compilation.managed_section import ManagedSectionError
+
+        start = "<!-- apm:start -->"
+        end = "<!-- apm:end -->"
+        output_file = tmp_path / "AGENTS.md"
+        output_file.write_text("# Repo guidance\n\nHuman content only.\n")
+
+        config = CompilationConfig(
+            output_path=str(output_file),
+            agents_md_mode="managed_section",
+            agents_md_start_marker=start,
+            agents_md_end_marker=end,
+            dry_run=False,
+        )
+
+        compiler = AgentsCompiler(str(tmp_path))
+        with pytest.raises(ManagedSectionError) as exc_info:
+            compiler._write_output_file_with_config(str(output_file), "New content.\n", config)
+        msg = str(exc_info.value)
+        # filename must be wrapped in square brackets: [AGENTS.md] ...
+        assert msg.startswith("[")


### PR DESCRIPTION
## TL;DR

Polish three error-message nits in managed-section mode raised by the PR #1589 review panel, and add two missing constraint bullets to the docs.

## Problem (WHY)

The PR #1589 review panel (cli-logging-expert + doc-writer) flagged:

1. **Missing-markers message** said `Add both markers` even when only one marker was absent -- misleading when a user already has one marker in place.
2. **Duplicate-markers message** always reported counts for both markers even when only one was duplicated -- noisy and confusing.
3. **Re-raise format** `{target}: {exc}` buried the filename in the error text without visual separation; inconsistent with `STATUS_SYMBOLS` bracket notation.
4. **Docs** omitted the reversed-marker constraint from the constraint list.
5. **Docs** did not mention that managed-section mode requires a pre-existing `AGENTS.md`.

## Approach (WHAT)

Surgical message-only edits in `managed_section.py` and `agents_compiler.py`; two bullet additions in `docs/producer/compile.md`. No behavioral changes.

## Implementation (HOW)

### `src/apm_cli/compilation/managed_section.py`
- **Missing-markers:** replace `"Add both markers"` with `"Add the missing marker(s)"` so the wording is accurate for one-missing as well as both-missing cases.
- **Duplicate-markers:** build the error string only from the offending marker(s) (`start` / `end` / both), so a singly-duplicated marker does not also report the clean marker.

### `src/apm_cli/compilation/agents_compiler.py`
- **Re-raise format:** change `f"{target}: {exc}"` to `f"[{target}] {exc}"` for bracket-style visual separation consistent with `STATUS_SYMBOLS`.

### `docs/src/content/docs/producer/compile.md`
- Add constraint: managed-section mode requires a pre-existing `AGENTS.md`.
- Add constraint: the start marker must appear before the end marker; reversed order raises a loud error.

## Mermaid diagram

```mermaid
flowchart TD
    A[apply_managed_section] --> B{duplicate?}
    B -- only start --> C[report start count only]
    B -- only end --> D[report end count only]
    B -- both --> E[report both counts]
    A --> F{missing?}
    F -- one absent --> G[Add the missing marker(s).]
    F -- both absent --> G
```

## Trade-offs

- No API changes; `ManagedSectionError` still raised on same conditions.
- Strictly additive doc change; no existing sentence removed.

## Validation evidence

- 4 new TDD tests added (confirmed red before fix, green after).
- All 24 tests in `test_managed_section.py` pass: `24 passed in 0.50s`.
- Full lint gate green: `ruff check`, `ruff format --check`, `pylint R0801 10.00/10`, `lint-auth-signals.sh`.

## How to test

```bash
uv run --extra dev pytest tests/unit/compilation/test_managed_section.py -q
# expected: 24 passed
```

Closes #1595