### PR TITLE
feat(init): suggest agentrc in Next Steps when no instructions exist

### DIFF
--- a/docs/src/content/docs/reference/cli/init.md
+++ b/docs/src/content/docs/reference/cli/init.md
@@ -104,6 +104,14 @@ $ apm init --yes --target copilot,claude,cursor
   pre-checks targets read from its existing `target:` field.
 - **Codex hint:** if `.codex/` is present, suggests
   `--target agent-skills` to also deploy skills to `.agents/skills/`.
+- **agentrc suggestion:** when no agent instruction files are found
+  (`.github/copilot-instructions.md`, `AGENTS.md`, `.github/instructions/`),
+  the Next Steps panel suggests generating agent instructions:
+  - `agentrc` in PATH: prepends `Generate agent instructions: agentrc init`
+    as the first next step.
+  - `agentrc` not in PATH: prints a tip line with a link to
+    `https://github.com/microsoft/agentrc`.
+  - Instructions already exist: no mention (suppressed entirely).
 - **Exit codes:** `0` on success or user-aborted prompt; `1` on invalid
   project or plugin name, or unhandled error.
 

--- a/packages/apm-guide/.apm/skills/apm-usage/commands.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/commands.md
@@ -4,7 +4,7 @@
 
 | Command | Purpose | Key flags |
 |---------|---------|-----------|
-| `apm init [NAME]` | Initialize a new APM project | `-y` skip prompts, `--plugin` plugin authoring mode, `--marketplace` seed apm.yml with a `marketplace:` block |
+| `apm init [NAME]` | Initialize a new APM project | `-y` skip prompts, `--plugin` plugin authoring mode, `--marketplace` seed apm.yml with a `marketplace:` block. After init, Next Steps contextually suggests `agentrc init` (if agentrc is in PATH) or prints a tip link when no agent instruction files exist. |
 
 ## Dependency management
 

--- a/src/apm_cli/commands/init.py
+++ b/src/apm_cli/commands/init.py
@@ -1,6 +1,7 @@
 """APM init command."""
 
 import os
+import shutil
 import sys
 from pathlib import Path
 
@@ -28,6 +29,25 @@ from ._helpers import (
     _validate_plugin_name,
     _validate_project_name,
 )
+
+
+def _detect_agentrc(project_root: Path) -> tuple[bool, bool]:
+    """Return (agentrc_installed, has_instructions).
+
+    has_instructions is True when any known agent-instructions artifact exists
+    under project_root, meaning the user already has instructions and does not
+    need a suggestion.
+    """
+    installed = shutil.which("agentrc") is not None
+    has_instructions = any(
+        [
+            (project_root / ".github" / "copilot-instructions.md").exists(),
+            (project_root / "AGENTS.md").exists(),
+            (project_root / ".github" / "instructions").is_dir(),
+        ]
+    )
+    return installed, has_instructions
+
 
 # Display order for the prompt (matches scope S1 UX spec)
 _PROMPT_TARGETS_ORDERED: list[str] = [
@@ -272,6 +292,23 @@ def _perform_init(
                 "Author your own plugin:         apm pack",
             ]
 
+        # Agentrc integration (#518): suggest agentrc when no instructions exist.
+        # Only applies to consumer init (not plugin mode).
+        agentrc_tip: str | None = None
+        if not plugin and source == "init":
+            agentrc_installed, has_instructions = _detect_agentrc(Path.cwd())
+            if not has_instructions:
+                if agentrc_installed:
+                    next_steps.insert(
+                        0,
+                        "Generate agent instructions: agentrc init",
+                    )
+                else:
+                    agentrc_tip = (
+                        "Tip: use agentrc to generate tailored agent instructions "
+                        "from your codebase. https://github.com/microsoft/agentrc"
+                    )
+
         try:
             _rich_panel(
                 "\n".join(f"* {step}" for step in next_steps),
@@ -282,6 +319,9 @@ def _perform_init(
             logger.progress("Next steps:")
             for step in next_steps:
                 click.echo(f"  * {step}")
+
+        if agentrc_tip:
+            logger.progress(agentrc_tip, symbol="info")
 
         # Codex tip: suggest agent-skills target when .codex/ exists
         if Path(".codex").is_dir():

--- a/src/apm_cli/commands/init.py
+++ b/src/apm_cli/commands/init.py
@@ -40,11 +40,11 @@ def _detect_agentrc(project_root: Path) -> tuple[bool, bool]:
     """
     installed = shutil.which("agentrc") is not None
     has_instructions = any(
-        [
+        (
             (project_root / ".github" / "copilot-instructions.md").exists(),
             (project_root / "AGENTS.md").exists(),
             (project_root / ".github" / "instructions").is_dir(),
-        ]
+        )
     )
     return installed, has_instructions
 
@@ -161,6 +161,7 @@ def _perform_init(
         else:
             project_dir = Path.cwd()
             final_project_name = project_dir.name
+        project_root = Path.cwd()
 
         # Validate plugin name early
         if plugin and not _validate_plugin_name(final_project_name):
@@ -197,7 +198,7 @@ def _perform_init(
         # --- Target selection (must run before the confirmation panel so
         #     the chosen targets render in the "About to create" summary). ---
         resolved_targets = _resolve_init_targets(
-            project_root=Path.cwd(),
+            project_root=project_root,
             target_flag=target_flag,
             yes=yes,
             apm_yml_exists=apm_yml_exists,
@@ -296,16 +297,16 @@ def _perform_init(
         # Only applies to consumer init (not plugin mode).
         agentrc_tip: str | None = None
         if not plugin and source == "init":
-            agentrc_installed, has_instructions = _detect_agentrc(Path.cwd())
+            agentrc_installed, has_instructions = _detect_agentrc(project_root)
             if not has_instructions:
                 if agentrc_installed:
                     next_steps.insert(
-                        0,
-                        "Generate agent instructions: agentrc init",
+                        1,
+                        "Generate agent instructions:     agentrc init",
                     )
                 else:
                     agentrc_tip = (
-                        "Tip: use agentrc to generate tailored agent instructions "
+                        "Tip: Use agentrc to generate tailored agent instructions "
                         "from your codebase. https://github.com/microsoft/agentrc"
                     )
 

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -2,9 +2,11 @@
 
 import json  # noqa: F401
 import os
+import re
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 import pytest  # noqa: F401
 import yaml
@@ -841,12 +843,19 @@ class TestInitAgentrcSuggestion:
 
     def test_agentrc_not_in_path_no_instructions_shows_tip(self):
         """When agentrc NOT in PATH and no instructions, show tip line."""
+        _url_re = re.compile(r"https?://[^\s\[\]<>'\"]+")
         with self.runner.isolated_filesystem():
             with patch("apm_cli.commands.init.shutil.which", return_value=None):
                 result = self.runner.invoke(cli, ["init", "--yes"])
             assert result.exit_code == 0
             assert "agentrc" in result.output
-            assert "https://github.com/microsoft/agentrc" in result.output
+            urls = [urlparse(m) for m in _url_re.findall(result.output)]
+            assert any(
+                u.scheme == "https"
+                and u.hostname == "github.com"
+                and u.path.startswith("/microsoft/agentrc")
+                for u in urls
+            ), "agentrc URL not found in output"
 
     def test_agentrc_suppressed_when_copilot_instructions_exist(self):
         """When .github/copilot-instructions.md exists, no agentrc mention."""
@@ -877,8 +886,8 @@ class TestInitAgentrcSuggestion:
             assert result.exit_code == 0
             assert "agentrc" not in result.output
 
-    def test_agentrc_in_path_step_is_first(self):
-        """agentrc init step appears before other next steps."""
+    def test_agentrc_in_path_step_is_after_install(self):
+        """agentrc init step appears after 'apm install' but before other steps."""
         with self.runner.isolated_filesystem():
             with patch("apm_cli.commands.init.shutil.which", return_value="/usr/bin/agentrc"):
                 result = self.runner.invoke(cli, ["init", "--yes"])
@@ -887,4 +896,12 @@ class TestInitAgentrcSuggestion:
             install_pos = result.output.find("apm install")
             assert agentrc_pos != -1
             assert install_pos != -1
-            assert agentrc_pos < install_pos
+            assert agentrc_pos > install_pos
+
+    def test_agentrc_suppressed_in_plugin_mode(self):
+        """When invoked via 'apm init --plugin', no agentrc mention."""
+        with self.runner.isolated_filesystem():
+            with patch("apm_cli.commands.init.shutil.which", return_value="/usr/bin/agentrc"):
+                result = self.runner.invoke(cli, ["init", "--plugin", "--yes", "my-plugin"])
+            assert result.exit_code == 0
+            assert "agentrc" not in result.output

--- a/tests/unit/test_init_command.py
+++ b/tests/unit/test_init_command.py
@@ -812,3 +812,79 @@ class TestToggleInputParser:
 
         _, err = _parse_toggle_input("abc", 7)
         assert err is not None
+
+
+class TestInitAgentrcSuggestion:
+    """Tests for #518: apm init suggests agentrc in Next Steps panel."""
+
+    def setup_method(self):
+        self.runner = CliRunner()
+        try:
+            self.original_dir = os.getcwd()
+        except FileNotFoundError:
+            self.original_dir = str(Path(__file__).parent.parent.parent)
+            os.chdir(self.original_dir)
+
+    def teardown_method(self):
+        try:
+            os.chdir(self.original_dir)
+        except (FileNotFoundError, OSError):
+            os.chdir(str(Path(__file__).parent.parent.parent))
+
+    def test_agentrc_in_path_no_instructions_shows_next_step(self):
+        """When agentrc is in PATH and no instructions exist, prepend step."""
+        with self.runner.isolated_filesystem():
+            with patch("apm_cli.commands.init.shutil.which", return_value="/usr/bin/agentrc"):
+                result = self.runner.invoke(cli, ["init", "--yes"])
+            assert result.exit_code == 0
+            assert "agentrc init" in result.output
+
+    def test_agentrc_not_in_path_no_instructions_shows_tip(self):
+        """When agentrc NOT in PATH and no instructions, show tip line."""
+        with self.runner.isolated_filesystem():
+            with patch("apm_cli.commands.init.shutil.which", return_value=None):
+                result = self.runner.invoke(cli, ["init", "--yes"])
+            assert result.exit_code == 0
+            assert "agentrc" in result.output
+            assert "https://github.com/microsoft/agentrc" in result.output
+
+    def test_agentrc_suppressed_when_copilot_instructions_exist(self):
+        """When .github/copilot-instructions.md exists, no agentrc mention."""
+        with self.runner.isolated_filesystem():
+            Path(".github").mkdir()
+            Path(".github/copilot-instructions.md").write_text("# My instructions\n")
+            with patch("apm_cli.commands.init.shutil.which", return_value="/usr/bin/agentrc"):
+                result = self.runner.invoke(cli, ["init", "--yes"])
+            assert result.exit_code == 0
+            assert "agentrc" not in result.output
+
+    def test_agentrc_suppressed_when_agents_md_exists(self):
+        """When AGENTS.md exists, no agentrc mention."""
+        with self.runner.isolated_filesystem():
+            Path("AGENTS.md").write_text("# Agents\n")
+            with patch("apm_cli.commands.init.shutil.which", return_value=None):
+                result = self.runner.invoke(cli, ["init", "--yes"])
+            assert result.exit_code == 0
+            assert "agentrc" not in result.output
+
+    def test_agentrc_suppressed_when_instructions_dir_exists(self):
+        """When .github/instructions/ dir exists, no agentrc mention."""
+        with self.runner.isolated_filesystem():
+            Path(".github").mkdir()
+            Path(".github/instructions").mkdir()
+            with patch("apm_cli.commands.init.shutil.which", return_value="/usr/bin/agentrc"):
+                result = self.runner.invoke(cli, ["init", "--yes"])
+            assert result.exit_code == 0
+            assert "agentrc" not in result.output
+
+    def test_agentrc_in_path_step_is_first(self):
+        """agentrc init step appears before other next steps."""
+        with self.runner.isolated_filesystem():
+            with patch("apm_cli.commands.init.shutil.which", return_value="/usr/bin/agentrc"):
+                result = self.runner.invoke(cli, ["init", "--yes"])
+            assert result.exit_code == 0
+            agentrc_pos = result.output.find("agentrc init")
+            install_pos = result.output.find("apm install")
+            assert agentrc_pos != -1
+            assert install_pos != -1
+            assert agentrc_pos < install_pos


### PR DESCRIPTION
## TL;DR

After `apm init` creates `apm.yml`, the Next Steps panel contextually suggests [agentrc](https://github.com/microsoft/agentrc) when the project has no agent instruction files yet.

## Problem (WHY)

APM and agentrc are complementary: agentrc generates tailored agent instructions from real code analysis; APM distributes and governs them. The agentrc side already bridges to APM (`agentrc init` detects APM and offers to run `apm init`, merged in [microsoft/agentrc#94](https://github.com/microsoft/agentrc/pull/94)). The reverse bridge was missing. Developers who discover APM first should learn about agentrc at the right moment.

## Approach (WHAT)

Implement the behavior matrix from the issue spec in ~30 lines:

| State | Output |
|---|---|
| `agentrc` in PATH + no instructions exist | First next step: `Generate agent instructions: agentrc init` |
| `agentrc` not in PATH + no instructions exist | Tip line after panel: link to https://github.com/microsoft/agentrc |
| Instructions already exist | No mention |
| Plugin mode (`--plugin`) or `source != 'init'` | No mention |

Detection checks for: `.github/copilot-instructions.md`, `AGENTS.md`, `.github/instructions/`.

## Implementation (HOW)

`src/apm_cli/commands/init.py`:
- `import shutil` added at module level (stdlib, no new dep).
- New `_detect_agentrc(project_root)` pure helper: returns `(installed, has_instructions)`.
- In `_perform_init()`, after building `next_steps`, call `_detect_agentrc(Path.cwd())` and conditionally prepend the step or set a tip line. Tip is printed after the panel via the existing `logger.progress(..., symbol="info")` pattern.
- No subprocess calls, no prompts, no new dependencies.

```mermaid
flowchart TD
    A[apm init creates apm.yml] --> B{plugin mode?}
    B -- yes --> Z[skip agentrc logic]
    B -- no --> C{instructions exist?}
    C -- yes --> Z
    C -- no --> D{agentrc in PATH?}
    D -- yes --> E[prepend step to Next Steps panel]
    D -- no --> F[print tip line after panel]
```

## Trade-offs

- **Detection is filesystem-only, no network.** Fast, deterministic, never blocks CI.
- **Informational only.** No subprocess `agentrc init` call; preserves `apm init` speed guarantee.
- **Suppressed when instructions exist.** Avoids noise for teams already managing instructions.

## Validation evidence

All lint gates pass:
- `ruff check` + `ruff format --check`: clean
- `pylint R0801`: 10.00/10
- `bash scripts/lint-auth-signals.sh`: clean

Test suite: 136 init tests pass (6 new acceptance tests for the behavior matrix).

## How to test

```bash
# Scenario 1: agentrc installed, no instructions
cd /tmp/test-apm-init && apm init --yes
# Expect: 'Generate agent instructions: agentrc init' as first Next Step

# Scenario 2: agentrc not installed (or mock shutil.which -> None)
# Expect: tip line with https://github.com/microsoft/agentrc after panel

# Scenario 3: AGENTS.md present
touch AGENTS.md && apm init --yes
# Expect: no agentrc mention
```

> **README.md drift note:** README.md is not updated per policy (requires maintainer approval). No drift detected -- README does not describe the Next Steps panel output.

Closes #518