### PR TITLE
refactor: extract skip_download and locked_ref helpers into _skip_logic.py (#552)

### DIFF
--- a/src/apm_cli/drift.py
+++ b/src/apm_cli/drift.py
@@ -339,7 +339,8 @@ def build_download_ref(
             reg_replay = _registry_replay_overrides_from_lock(locked_dep)
             if reg_replay is not None:
                 overrides.update(reg_replay)
-            # Use locked commit SHA for byte-for-byte reproducibility.
+            # Use locked commit SHA for byte-for-byte reproducibility
+            # (bypassed during --update, also guarded by the helper itself).
             elif _should_use_locked_ref(locked_dep.resolved_commit, update_refs):
                 overrides["reference"] = locked_dep.resolved_commit
             # For proxy deps without a commit SHA (Artifactory zip archives),

--- a/src/apm_cli/drift.py
+++ b/src/apm_cli/drift.py
@@ -54,6 +54,8 @@ from dataclasses import replace as _dataclass_replace
 from pathlib import Path  # noqa: F401
 from typing import TYPE_CHECKING, Any
 
+from apm_cli.install.phases._skip_logic import _should_use_locked_ref
+
 if TYPE_CHECKING:
     from apm_cli.deps.lockfile import LockedDependency, LockFile
     from apm_cli.models.apm_package import DependencyReference
@@ -338,7 +340,7 @@ def build_download_ref(
             if reg_replay is not None:
                 overrides.update(reg_replay)
             # Use locked commit SHA for byte-for-byte reproducibility.
-            elif locked_dep.resolved_commit and locked_dep.resolved_commit != "cached":
+            elif _should_use_locked_ref(locked_dep.resolved_commit, update_refs):
                 overrides["reference"] = locked_dep.resolved_commit
             # For proxy deps without a commit SHA (Artifactory zip archives),
             # preserve the locked ref so we download the same ref on replay.

--- a/src/apm_cli/install/phases/_skip_logic.py
+++ b/src/apm_cli/install/phases/_skip_logic.py
@@ -1,0 +1,51 @@
+"""Pure-logic helpers for the per-package skip / locked-ref decisions.
+
+These functions are the single source of truth for two key boolean decisions
+in the install pipeline.  Both the sequential integration loop
+(``phases/integrate.py``) and the unit test suite import from here, so the
+tests exercise the real condition rather than a mirrored copy.
+"""
+
+from __future__ import annotations
+
+
+def _compute_skip_download(
+    install_path_exists: bool,
+    is_cacheable: bool,
+    update_refs: bool,
+    already_resolved: bool,
+    lockfile_match: bool,
+) -> bool:
+    """Return True when the sequential loop should skip downloading a package.
+
+    A package can be skipped when the install path already exists on disk AND
+    at least one of the following is true:
+
+    * The ref is a pinned tag / commit (``is_cacheable``) and the user has not
+      requested an update (``not update_refs``).
+    * The BFS callback already fetched the package (``already_resolved``) and
+      the user has not requested an update.
+    * The lockfile SHA matches the local checkout (``lockfile_match``).
+
+    Callers may further override this result (e.g. content-hash verification
+    or registry-only enforcement) -- this function only computes the initial
+    decision.
+    """
+    return install_path_exists and (
+        (is_cacheable and not update_refs)
+        or (already_resolved and not update_refs)
+        or lockfile_match
+    )
+
+
+def _should_use_locked_ref(locked_ref: str | None, update_refs: bool) -> bool:
+    """Return True when the download should be pinned to the locked commit SHA.
+
+    Uses the locked commit SHA from the lockfile for byte-for-byte
+    reproducibility.  Returns False when:
+
+    * ``locked_ref`` is absent or falsy -- no SHA was recorded.
+    * ``locked_ref == "cached"`` -- sentinel meaning no real SHA is stored.
+    * ``update_refs`` is True -- the user explicitly requested re-resolution.
+    """
+    return bool(locked_ref) and locked_ref != "cached" and not update_refs

--- a/src/apm_cli/install/phases/_skip_logic.py
+++ b/src/apm_cli/install/phases/_skip_logic.py
@@ -47,5 +47,11 @@ def _should_use_locked_ref(locked_ref: str | None, update_refs: bool) -> bool:
     * ``locked_ref`` is absent or falsy -- no SHA was recorded.
     * ``locked_ref == "cached"`` -- sentinel meaning no real SHA is stored.
     * ``update_refs`` is True -- the user explicitly requested re-resolution.
+
+    Note: in ``build_download_ref`` (drift.py) the caller already gates the
+    entire locked-dep block on ``not update_refs`` (outer guard at L314), so
+    the ``not update_refs`` check here is redundant at that call site.  It is
+    kept intentionally so the helper is self-contained and correct when called
+    from future contexts that lack the outer guard.
     """
     return bool(locked_ref) and locked_ref != "cached" and not update_refs

--- a/src/apm_cli/install/phases/integrate.py
+++ b/src/apm_cli/install/phases/integrate.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple  # noqa: F401, UP035
 
 from apm_cli.install.phases._redownload import _should_skip_redownload
+from apm_cli.install.phases._skip_logic import _compute_skip_download
 from apm_cli.install.phases.heal import run_heal_chain
 from apm_cli.install.services import integrate_local_content
 from apm_cli.install.sources import make_dependency_source
@@ -213,10 +214,12 @@ def _resolve_download_strategy(
         ref_changed=ref_changed,
     )
 
-    skip_download = install_path.exists() and (
-        (is_cacheable and not update_refs)
-        or (already_resolved and not update_refs)
-        or lockfile_match
+    skip_download = _compute_skip_download(
+        install_path_exists=install_path.exists(),
+        is_cacheable=is_cacheable,
+        update_refs=update_refs,
+        already_resolved=already_resolved,
+        lockfile_match=lockfile_match,
     )
 
     # Verify content integrity when lockfile has a hash

--- a/tests/unit/test_install_update_refs.py
+++ b/tests/unit/test_install_update_refs.py
@@ -13,45 +13,16 @@ Covers two code paths fixed in issue #548:
 
 import pytest
 
+from apm_cli.install.phases._skip_logic import (
+    _compute_skip_download,
+    _should_use_locked_ref,
+)
+
 # ---------------------------------------------------------------------------
-# Pure-logic helpers that mirror the two changed conditions in install.py.
-# Tested in isolation -- the full _install_apm_dependencies() stack is not
-# needed and would require network access / a real project root.
+# Both helpers are imported directly from the production module so that any
+# change to the real condition immediately surfaces as a test failure.
+# See issue #552 for the rationale.
 # ---------------------------------------------------------------------------
-
-
-def _should_use_locked_ref(locked_ref, update_refs):
-    """Mirror the locked-ref decision from download_callback (install.py ~L1268).
-
-    Returns True when the download should be pinned to the locked SHA from the
-    lockfile instead of using the manifest ref for re-resolution.
-
-    Condition verbatim from source:
-        if locked_ref and not update_refs:
-            download_dep = _dc_replace(dep_ref, reference=locked_ref)
-    """
-    return bool(locked_ref) and not update_refs
-
-
-def _compute_skip_download(
-    install_path_exists, is_cacheable, update_refs, already_resolved, lockfile_match
-):
-    """Mirror the skip_download expression from the sequential loop (install.py ~L1920).
-
-    Returns True when the loop should skip downloading a package.
-
-    Expression verbatim from source:
-        skip_download = install_path.exists() and (
-            (is_cacheable and not update_refs)
-            or (already_resolved and not update_refs)
-            or lockfile_match
-        )
-    """
-    return install_path_exists and (
-        (is_cacheable and not update_refs)
-        or (already_resolved and not update_refs)
-        or lockfile_match
-    )
 
 
 # ===========================================================================


### PR DESCRIPTION
## TL;DR

Extract the two key install-pipeline boolean decisions into a shared production module so the unit test suite imports from the real code rather than maintaining mirrored copies.

## Problem (WHY)

Issue #552 identified a test-quality anti-pattern in `tests/unit/test_install_update_refs.py` (introduced in #550): the file defined `_should_use_locked_ref` and `_compute_skip_download` as local mirror functions that duplicated the logic from the production pipeline. Tests exercising these mirrors could pass even if the real conditions in `integrate.py` or `drift.py` changed without the mirrors being updated -- a silent regression risk.

## Approach (WHAT)

Option (a) from the issue: extract the shared helpers into a single production module and import from there in both the pipeline and the tests.

New module `src/apm_cli/install/phases/_skip_logic.py` exposes:
- `_compute_skip_download(install_path_exists, is_cacheable, update_refs, already_resolved, lockfile_match) -> bool` -- the canonical skip decision for the sequential integration loop.
- `_should_use_locked_ref(locked_ref, update_refs) -> bool` -- the canonical gate for pinning a download to the lockfile commit SHA.

## Implementation (HOW)

```
src/apm_cli/install/phases/_skip_logic.py   (new)   -- shared helpers
src/apm_cli/install/phases/integrate.py     (edit)  -- import + call _compute_skip_download
src/apm_cli/drift.py                        (edit)  -- import + call _should_use_locked_ref
tests/unit/test_install_update_refs.py      (edit)  -- import from production; remove mirrors
```

```mermaid
graph TD
    A[_skip_logic.py] -->|imports| B[integrate.py]
    A -->|imports| C[drift.py]
    A -->|imports| D[test_install_update_refs.py]
    B -- _compute_skip_download --> E[skip decision]
    C -- _should_use_locked_ref --> F[locked-ref decision]
    D -- both helpers --> G[unit tests]
```

## Trade-offs

- **Behavior-preserving**: no logic change; the extracted expressions are identical to the originals.
- **Scope minimal**: only the two helpers called out in #552 are extracted.
- `_should_use_locked_ref` adds the `!= 'cached'` sentinel guard that was already present in `build_download_ref()` but absent from the test mirror -- a minor correctness improvement with zero test-impact (no existing test uses `'cached'` as input).

## Validation evidence

- All 27 targeted tests pass: `pytest tests/unit/test_install_update_refs.py -v`
- Full unit suite green: `15895 passed, 1 skipped, 21 xfailed`
- All lint gates pass: ruff check, ruff format, pylint R0801 (10.00/10), auth-signals

## How to test

```bash
uv run --extra dev pytest tests/unit/test_install_update_refs.py -v
uv run --extra dev pytest tests/unit/ -q
```

Closes #552