### PR TITLE
refactor(models): separate package-format detection into composition model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `apm_cli.models` internals: package-format detection extracted into a composition model (`PackageFormatRegistry` + per-format detectors + `NormalizationPlanner`); `detect_package_type()` is now a thin facade with no user-visible behaviour change. (#1618)
 - `apm compile` no longer emits cosmetic debug comments (APM version, source-file headers, footer) in generated `CLAUDE.md` and `copilot-instructions.md` files by default. The `compilation.source_attribution` flag now defaults to `false` (was `true`), reducing token overhead for every LLM context window that reads these files. Load-bearing markers (`_COPILOT_ROOT_GENERATED_MARKER` and Build ID) are always emitted regardless of the flag. To restore the previous behaviour, set `compilation: source_attribution: true` in `apm.yml`. (closes #1341)
 ### Removed
 

--- a/src/apm_cli/models/__init__.py
+++ b/src/apm_cli/models/__init__.py
@@ -8,6 +8,20 @@ from .dependency import (
     ResolvedReference,
     parse_git_reference,
 )
+from .format_detection import (
+    ApmYmlDetector,
+    ApmYmlFormatEvidence,
+    ClaudePluginDetector,
+    ClaudePluginFormatEvidence,
+    DetectionReport,
+    FormatDetector,
+    HookJsonDetector,
+    HookJsonFormatEvidence,
+    NormalizationPlanner,
+    PackageFormatRegistry,
+    SkillMdDetector,
+    SkillMdFormatEvidence,
+)
 from .results import InstallResult, PrimitiveCounts
 from .validation import (
     InvalidVirtualPackageExtensionError,
@@ -30,6 +44,19 @@ __all__ = [  # noqa: RUF022
     "MCPDependency",
     "ResolvedReference",
     "parse_git_reference",
+    # Format detection (new composition model from #782)
+    "ApmYmlDetector",
+    "ApmYmlFormatEvidence",
+    "ClaudePluginDetector",
+    "ClaudePluginFormatEvidence",
+    "DetectionReport",
+    "FormatDetector",
+    "HookJsonDetector",
+    "HookJsonFormatEvidence",
+    "NormalizationPlanner",
+    "PackageFormatRegistry",
+    "SkillMdDetector",
+    "SkillMdFormatEvidence",
     # Validation
     "InvalidVirtualPackageExtensionError",
     "PackageContentType",

--- a/src/apm_cli/models/format_detection.py
+++ b/src/apm_cli/models/format_detection.py
@@ -1,0 +1,397 @@
+"""Package-format detection: detectors, registry, report, and planner.
+
+This module implements the composition model for package-format detection
+described in issue #782. Each format has its own ``FormatDetector`` that
+inspects the filesystem and returns per-format evidence independently of
+the others. ``PackageFormatRegistry`` runs all detectors and produces a
+``DetectionReport`` (a set of per-format evidences -- not a single type).
+``NormalizationPlanner`` reads the report and resolves which
+``PackageType`` to assign (backward-compat) and, in future, which
+normalizer callables to invoke.
+
+This replaces the positional-priority if/elif cascade in
+``detect_package_type`` so that new formats are additive and ordering
+bugs are structurally impossible.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+from ..constants import APM_DIR, APM_YML_FILENAME, SKILL_MD_FILENAME
+
+# Canonical directory names that form part of the Claude Code marketplace
+# plugin layout.  Order is preserved in ``ClaudePluginFormatEvidence``
+# and asserted by existing tests.
+_PLUGIN_DIRS: tuple[str, ...] = ("agents", "skills", "commands")
+
+
+# ---------------------------------------------------------------------------
+# Per-format evidence dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ApmYmlFormatEvidence:
+    """File-system signals gathered by ``ApmYmlDetector``.
+
+    Fields
+    ------
+    apm_yml_path:
+        Absolute path to the ``apm.yml`` that was found.
+    has_apm_dir:
+        ``True`` iff a ``.apm/`` directory exists alongside ``apm.yml``.
+    declares_dependencies:
+        ``True`` iff ``apm.yml`` lists at least one dependency under
+        ``dependencies.apm``, ``dependencies.mcp``,
+        ``devDependencies.apm``, or ``devDependencies.mcp``.
+    """
+
+    apm_yml_path: Path
+    has_apm_dir: bool
+    declares_dependencies: bool
+
+
+@dataclass(frozen=True)
+class SkillMdFormatEvidence:
+    """File-system signals gathered by ``SkillMdDetector``.
+
+    Fields
+    ------
+    skill_md_path:
+        Path to the *root* ``SKILL.md`` if present, ``None`` otherwise.
+    nested_skill_dirs:
+        Names of ``skills/<name>/`` directories that contain a
+        ``SKILL.md`` (canonical sorted order).
+    """
+
+    skill_md_path: Path | None
+    nested_skill_dirs: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class HookJsonFormatEvidence:
+    """File-system signals gathered by ``HookJsonDetector``.
+
+    Fields
+    ------
+    hooks_dirs_found:
+        Directories (``hooks/`` or ``.apm/hooks/``) in which at least
+        one ``*.json`` file was discovered.
+    """
+
+    hooks_dirs_found: tuple[Path, ...]
+
+
+@dataclass(frozen=True)
+class ClaudePluginFormatEvidence:
+    """File-system signals gathered by ``ClaudePluginDetector``.
+
+    Fields
+    ------
+    plugin_json_path:
+        Path to ``plugin.json`` (in one of the spec-defined locations)
+        if found, ``None`` otherwise.
+    has_claude_plugin_dir:
+        ``True`` iff a ``.claude-plugin/`` directory is present at the
+        package root.
+    plugin_dirs_present:
+        Subset of ``("agents", "skills", "commands")`` whose directories
+        exist under the package root (canonical order).
+    """
+
+    plugin_json_path: Path | None
+    has_claude_plugin_dir: bool
+    plugin_dirs_present: tuple[str, ...]
+
+
+# ---------------------------------------------------------------------------
+# DetectionReport -- aggregated output of PackageFormatRegistry
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DetectionReport:
+    """Aggregated result of running all ``FormatDetector`` instances.
+
+    Each field holds the per-format evidence produced by its detector, or
+    ``None`` when that detector found no signals for its format.  All four
+    detectors run independently, so the report can capture mixed packages
+    (e.g. a Claude plugin that also ships hooks).
+
+    This object doubles as the observability payload -- verbose detection
+    traces and near-miss warnings can be derived from it without a second
+    filesystem scan.
+    """
+
+    apm_yml: ApmYmlFormatEvidence | None = None
+    skill_md: SkillMdFormatEvidence | None = None
+    hook_json: HookJsonFormatEvidence | None = None
+    claude_plugin: ClaudePluginFormatEvidence | None = None
+
+
+# ---------------------------------------------------------------------------
+# FormatDetector protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class FormatDetector(Protocol):
+    """Detector interface: inspect a directory for one format's signals.
+
+    Implementations are pure (no side-effects, no file mutations) and
+    return ``None`` when their format is absent.
+    """
+
+    def detect(
+        self, package_path: Path
+    ) -> (
+        ApmYmlFormatEvidence
+        | SkillMdFormatEvidence
+        | HookJsonFormatEvidence
+        | ClaudePluginFormatEvidence
+        | None
+    ):
+        """Inspect ``package_path`` and return per-format evidence, or ``None``."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Detector implementations
+# ---------------------------------------------------------------------------
+
+
+def _collect_nested_skill_dirs(package_path: Path) -> tuple[str, ...]:
+    """Return sorted names of ``skills/<name>/`` dirs containing a SKILL.md."""
+    skills_dir = package_path / "skills"
+    if not skills_dir.is_dir():
+        return ()
+    return tuple(
+        d.name
+        for d in sorted(skills_dir.iterdir())
+        if d.is_dir() and (d / SKILL_MD_FILENAME).exists()
+    )
+
+
+def _check_has_hook_json(package_path: Path) -> tuple[Path, ...]:
+    """Return dirs (hooks/ or .apm/hooks/) that contain at least one *.json."""
+    found: list[Path] = []
+    for hooks_dir in [package_path / "hooks", package_path / APM_DIR / "hooks"]:
+        if hooks_dir.exists() and any(hooks_dir.glob("*.json")):
+            found.append(hooks_dir)
+    return tuple(found)
+
+
+class ApmYmlDetector:
+    """Detects ``apm.yml``-based package signals.
+
+    Returns ``ApmYmlFormatEvidence`` when ``apm.yml`` is present,
+    ``None`` otherwise.
+    """
+
+    def detect(self, package_path: Path) -> ApmYmlFormatEvidence | None:
+        apm_yml_path = package_path / APM_YML_FILENAME
+        if not apm_yml_path.exists():
+            return None
+        has_apm_dir = (package_path / APM_DIR).is_dir()
+        from .validation import _apm_yml_declares_dependencies
+
+        declares_deps = _apm_yml_declares_dependencies(apm_yml_path)
+        return ApmYmlFormatEvidence(
+            apm_yml_path=apm_yml_path,
+            has_apm_dir=has_apm_dir,
+            declares_dependencies=declares_deps,
+        )
+
+
+class SkillMdDetector:
+    """Detects root ``SKILL.md`` and nested ``skills/<name>/SKILL.md`` signals.
+
+    Returns ``SkillMdFormatEvidence`` when either a root SKILL.md or
+    nested skill directories are found, ``None`` otherwise.
+    """
+
+    def detect(self, package_path: Path) -> SkillMdFormatEvidence | None:
+        skill_md_path = package_path / SKILL_MD_FILENAME
+        root_found = skill_md_path.exists()
+        nested = _collect_nested_skill_dirs(package_path)
+        if not root_found and not nested:
+            return None
+        return SkillMdFormatEvidence(
+            skill_md_path=skill_md_path if root_found else None,
+            nested_skill_dirs=nested,
+        )
+
+
+class HookJsonDetector:
+    """Detects ``hooks/*.json`` signals.
+
+    Returns ``HookJsonFormatEvidence`` when at least one hook JSON file
+    is found, ``None`` otherwise.
+    """
+
+    def detect(self, package_path: Path) -> HookJsonFormatEvidence | None:
+        dirs_found = _check_has_hook_json(package_path)
+        if not dirs_found:
+            return None
+        return HookJsonFormatEvidence(hooks_dirs_found=dirs_found)
+
+
+class ClaudePluginDetector:
+    """Detects Claude Code marketplace plugin signals.
+
+    Returns ``ClaudePluginFormatEvidence`` when a plugin manifest
+    (``plugin.json`` or ``.claude-plugin/``) is present, ``None``
+    otherwise.
+    """
+
+    def detect(self, package_path: Path) -> ClaudePluginFormatEvidence | None:
+        from ..utils.helpers import find_plugin_json
+
+        plugin_json_path = find_plugin_json(package_path)
+        has_claude_plugin_dir = (package_path / ".claude-plugin").is_dir()
+        plugin_dirs_present = tuple(name for name in _PLUGIN_DIRS if (package_path / name).is_dir())
+        if plugin_json_path is None and not has_claude_plugin_dir:
+            return None
+        return ClaudePluginFormatEvidence(
+            plugin_json_path=plugin_json_path,
+            has_claude_plugin_dir=has_claude_plugin_dir,
+            plugin_dirs_present=plugin_dirs_present,
+        )
+
+
+# ---------------------------------------------------------------------------
+# PackageFormatRegistry
+# ---------------------------------------------------------------------------
+
+# Default ordered set of detectors.  Order here does NOT affect
+# classification priority (that lives in NormalizationPlanner); all
+# detectors always run.
+_DEFAULT_DETECTORS: tuple[
+    ApmYmlDetector | SkillMdDetector | HookJsonDetector | ClaudePluginDetector,
+    ...,
+] = (
+    ClaudePluginDetector(),
+    SkillMdDetector(),
+    ApmYmlDetector(),
+    HookJsonDetector(),
+)
+
+
+class PackageFormatRegistry:
+    """Runs all registered ``FormatDetector`` instances and collects a report.
+
+    All detectors run independently for every call to :meth:`detect`,
+    ensuring that mixed packages are captured fully.  The resulting
+    ``DetectionReport`` holds ``None`` for any format that was absent.
+    """
+
+    def __init__(
+        self,
+        detectors: (
+            tuple[
+                ApmYmlDetector | SkillMdDetector | HookJsonDetector | ClaudePluginDetector,
+                ...,
+            ]
+            | None
+        ) = None,
+    ) -> None:
+        self._detectors = detectors if detectors is not None else _DEFAULT_DETECTORS
+
+    def detect(self, package_path: Path) -> DetectionReport:
+        """Run all detectors against ``package_path`` and return the report."""
+        apm_yml_ev: ApmYmlFormatEvidence | None = None
+        skill_md_ev: SkillMdFormatEvidence | None = None
+        hook_json_ev: HookJsonFormatEvidence | None = None
+        claude_plugin_ev: ClaudePluginFormatEvidence | None = None
+
+        for detector in self._detectors:
+            result = detector.detect(package_path)
+            if isinstance(result, ApmYmlFormatEvidence):
+                apm_yml_ev = result
+            elif isinstance(result, SkillMdFormatEvidence):
+                skill_md_ev = result
+            elif isinstance(result, HookJsonFormatEvidence):
+                hook_json_ev = result
+            elif isinstance(result, ClaudePluginFormatEvidence):
+                claude_plugin_ev = result
+
+        return DetectionReport(
+            apm_yml=apm_yml_ev,
+            skill_md=skill_md_ev,
+            hook_json=hook_json_ev,
+            claude_plugin=claude_plugin_ev,
+        )
+
+
+# ---------------------------------------------------------------------------
+# NormalizationPlanner
+# ---------------------------------------------------------------------------
+
+
+class NormalizationPlanner:
+    """Maps a ``DetectionReport`` to a ``(PackageType, plugin_json_path)`` tuple.
+
+    Encodes the same cascade priority as the old if/elif chain, but the
+    logic is now explicit and the source of each branch is traceable to
+    the independent detector that produced the evidence.
+
+    Cascade (first match wins):
+
+    1. ``MARKETPLACE_PLUGIN`` -- Claude plugin detector found a manifest
+       (``plugin.json`` or ``.claude-plugin/``).
+    2. ``HYBRID`` -- root ``SKILL.md`` AND ``apm.yml`` both present.
+    3. ``CLAUDE_SKILL`` -- root ``SKILL.md`` only (no ``apm.yml``).
+    4. ``SKILL_BUNDLE`` -- nested ``skills/<name>/SKILL.md`` found.
+    5. ``APM_PACKAGE`` -- ``apm.yml`` with ``.apm/`` or declared deps.
+    6. ``HOOK_PACKAGE`` -- hooks JSON found, nothing else.
+    7. ``INVALID`` -- no recognisable signals.
+
+    Future: :meth:`plan_normalizers` will return an ordered list of
+    normalizer callables so mixed packages can run multiple passes.
+    """
+
+    def plan(self, report: DetectionReport) -> tuple[object, Path | None]:
+        """Resolve ``PackageType`` and optional ``plugin_json_path`` from report.
+
+        Returns a ``(PackageType, plugin_json_path)`` tuple identical in
+        shape and semantics to the old ``detect_package_type`` return value.
+        """
+        from .validation import PackageType
+
+        cp = report.claude_plugin
+        sm = report.skill_md
+        ay = report.apm_yml
+        hj = report.hook_json
+
+        # 1. Claude plugin manifest present -> MARKETPLACE_PLUGIN
+        if cp is not None:
+            return PackageType.MARKETPLACE_PLUGIN, cp.plugin_json_path
+
+        # 2. Root SKILL.md + apm.yml -> HYBRID
+        has_root_skill_md = sm is not None and sm.skill_md_path is not None
+        if ay is not None and has_root_skill_md:
+            return PackageType.HYBRID, None
+
+        # 3. Root SKILL.md only (no apm.yml) -> CLAUDE_SKILL
+        if has_root_skill_md:
+            return PackageType.CLAUDE_SKILL, None
+
+        # 4. Nested skills/<name>/SKILL.md -> SKILL_BUNDLE (apm.yml optional)
+        if sm is not None and sm.nested_skill_dirs:
+            return PackageType.SKILL_BUNDLE, None
+
+        # 5. apm.yml present -> APM classification
+        if ay is not None:
+            if ay.has_apm_dir or ay.declares_dependencies:
+                return PackageType.APM_PACKAGE, None
+            return PackageType.INVALID, None
+
+        # 6. hooks/*.json only -> HOOK_PACKAGE
+        if hj is not None:
+            return PackageType.HOOK_PACKAGE, None
+
+        # 7. Nothing recognisable -> INVALID
+        return PackageType.INVALID, None

--- a/src/apm_cli/models/format_detection.py
+++ b/src/apm_cli/models/format_detection.py
@@ -18,7 +18,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from .validation import PackageType
 
 from ..constants import APM_DIR, APM_YML_FILENAME, SKILL_MD_FILENAME
 
@@ -196,12 +199,20 @@ class ApmYmlDetector:
         if not apm_yml_path.exists():
             return None
         has_apm_dir = (package_path / APM_DIR).is_dir()
+        if has_apm_dir:
+            # .apm/ directory present -- APM_PACKAGE eligibility is already
+            # determined; skip YAML parsing on this hot path.
+            return ApmYmlFormatEvidence(
+                apm_yml_path=apm_yml_path,
+                has_apm_dir=True,
+                declares_dependencies=False,
+            )
         from .validation import _apm_yml_declares_dependencies
 
         declares_deps = _apm_yml_declares_dependencies(apm_yml_path)
         return ApmYmlFormatEvidence(
             apm_yml_path=apm_yml_path,
-            has_apm_dir=has_apm_dir,
+            has_apm_dir=False,
             declares_dependencies=declares_deps,
         )
 
@@ -353,7 +364,7 @@ class NormalizationPlanner:
     normalizer callables so mixed packages can run multiple passes.
     """
 
-    def plan(self, report: DetectionReport) -> tuple[object, Path | None]:
+    def plan(self, report: DetectionReport) -> tuple[PackageType, Path | None]:
         """Resolve ``PackageType`` and optional ``plugin_json_path`` from report.
 
         Returns a ``(PackageType, plugin_json_path)`` tuple identical in

--- a/src/apm_cli/models/validation.py
+++ b/src/apm_cli/models/validation.py
@@ -183,30 +183,53 @@ def gather_detection_evidence(package_path: Path) -> DetectionEvidence:
     Pure: no side-effects, no file mutations.  Cheap (a handful of stat
     calls).  See :class:`DetectionEvidence` for the shape of the return
     value.
+
+    Internally delegates to :class:`~.format_detection.PackageFormatRegistry`
+    so each signal is gathered by its dedicated detector.
+
+    Note: ``plugin_dirs_present`` is always populated (enumerating
+    ``agents/``, ``skills/``, ``commands/`` if they exist) even when no
+    plugin manifest is present, because observability callers use the field
+    for near-miss warnings independently of classification.
     """
-    from ..utils.helpers import find_plugin_json
+    from .format_detection import (
+        _PLUGIN_DIRS,
+        ApmYmlDetector,
+        ClaudePluginDetector,
+        HookJsonDetector,
+        PackageFormatRegistry,
+        SkillMdDetector,
+    )
 
-    plugin_dirs_present = tuple(name for name in _PLUGIN_DIRS if (package_path / name).is_dir())
-    plugin_json_path = find_plugin_json(package_path)
-    has_claude_plugin_dir = (package_path / ".claude-plugin").is_dir()
-
-    # Plugin manifest = plugin.json OR .claude-plugin/ directory.
-    has_plugin_manifest = plugin_json_path is not None or has_claude_plugin_dir
-
-    # Nested skill dirs: directories under skills/ that contain a SKILL.md.
-    nested_skill_dirs: tuple[str, ...] = ()
-    skills_dir = package_path / "skills"
-    if skills_dir.is_dir():
-        nested_skill_dirs = tuple(
-            d.name
-            for d in sorted(skills_dir.iterdir())
-            if d.is_dir() and (d / SKILL_MD_FILENAME).exists()
+    registry = PackageFormatRegistry(
+        detectors=(
+            ClaudePluginDetector(),
+            SkillMdDetector(),
+            ApmYmlDetector(),
+            HookJsonDetector(),
         )
+    )
+    report = registry.detect(package_path)
+
+    cp = report.claude_plugin
+    sm = report.skill_md
+    ay = report.apm_yml
+    hj = report.hook_json
+
+    plugin_json_path = cp.plugin_json_path if cp is not None else None
+    has_claude_plugin_dir = cp.has_claude_plugin_dir if cp is not None else False
+    has_plugin_manifest = cp is not None
+
+    # Always enumerate plugin-layout dirs for observability (near-miss warnings
+    # want to know about agents/skills/commands even when no manifest is present).
+    plugin_dirs_present = tuple(name for name in _PLUGIN_DIRS if (package_path / name).is_dir())
+
+    nested_skill_dirs = sm.nested_skill_dirs if sm is not None else ()
 
     return DetectionEvidence(
-        has_apm_yml=(package_path / APM_YML_FILENAME).exists(),
-        has_skill_md=(package_path / SKILL_MD_FILENAME).exists(),
-        has_hook_json=_has_hook_json(package_path),
+        has_apm_yml=ay is not None,
+        has_skill_md=sm is not None and sm.skill_md_path is not None,
+        has_hook_json=hj is not None,
         plugin_json_path=plugin_json_path,
         plugin_dirs_present=plugin_dirs_present,
         has_claude_plugin_dir=has_claude_plugin_dir,
@@ -220,21 +243,20 @@ def detect_package_type(
 ) -> tuple[PackageType, Path | None]:
     """Classify a package directory into a ``PackageType``.
 
-    Single source of truth for the detection cascade.  Pure: no
-    side-effects, no file mutations.
+    Thin facade over :class:`~.format_detection.PackageFormatRegistry` +
+    :class:`~.format_detection.NormalizationPlanner`.  All detection logic
+    lives in those classes; this function preserves the existing call-site
+    signature ``(PackageType, plugin_json_path | None)``.
 
-    Cascade order (first match wins):
+    Cascade order (first match wins -- implemented in NormalizationPlanner):
 
     1. ``MARKETPLACE_PLUGIN`` -- plugin manifest present: ``plugin.json``
-       OR ``.claude-plugin/`` directory.  This is the strictest signal
-       (explicit plugin packaging intent).
+       OR ``.claude-plugin/`` directory.
     2. ``HYBRID`` -- root ``SKILL.md`` AND ``apm.yml`` present.
     3. ``CLAUDE_SKILL`` -- root ``SKILL.md`` only (no ``apm.yml``).
     4. ``SKILL_BUNDLE`` -- nested ``skills/<x>/SKILL.md`` detected;
        ``apm.yml`` optional; no ``.apm/`` required.
-    5. ``APM_PACKAGE`` -- ``apm.yml`` present. ``.apm/`` is optional: a
-       dep-only ``apm.yml`` (no ``.apm/`` and no nested skills) is a valid
-       curated aggregator that contributes no own primitives (#1094).
+    5. ``APM_PACKAGE`` -- ``apm.yml`` present with ``.apm/`` or declared deps.
     6. ``HOOK_PACKAGE`` -- ``hooks/*.json`` only, no other signals.
     7. ``INVALID`` -- nothing recognisable.
 
@@ -243,43 +265,11 @@ def detect_package_type(
         is non-None only when ``MARKETPLACE_PLUGIN`` was matched via an
         actual ``plugin.json`` file (not via directory evidence alone).
     """
-    evidence = gather_detection_evidence(package_path)
+    from .format_detection import NormalizationPlanner, PackageFormatRegistry
 
-    # 1. Plugin manifest present -> MARKETPLACE_PLUGIN
-    if evidence.has_plugin_manifest:
-        return PackageType.MARKETPLACE_PLUGIN, evidence.plugin_json_path
-
-    # 2. Root SKILL.md + apm.yml -> HYBRID
-    if evidence.has_apm_yml and evidence.has_skill_md:
-        return PackageType.HYBRID, None
-
-    # 3. Root SKILL.md only -> CLAUDE_SKILL
-    if evidence.has_skill_md:
-        return PackageType.CLAUDE_SKILL, None
-
-    # 4. Nested skills/<x>/SKILL.md -> SKILL_BUNDLE (apm.yml optional)
-    if evidence.nested_skill_dirs:
-        return PackageType.SKILL_BUNDLE, None
-
-    # 5. apm.yml present -> APM classification.
-    #    With .apm/ OR declared dependencies, a valid APM_PACKAGE.
-    #    Without either, INVALID (the user committed to "this is an APM
-    #    package" by adding apm.yml; we trust that signal and surface the
-    #    standard "missing .apm/" diagnostic instead of silently falling
-    #    through to a hooks/skill-bundle classification). Dep-only is
-    #    valid as a curated aggregator (#1094).
-    if evidence.has_apm_yml:
-        apm_dir = package_path / APM_DIR
-        if apm_dir.exists() or _apm_yml_declares_dependencies(package_path / APM_YML_FILENAME):
-            return PackageType.APM_PACKAGE, None
-        return PackageType.INVALID, None
-
-    # 6. hooks/*.json only -> HOOK_PACKAGE
-    if evidence.has_hook_json:
-        return PackageType.HOOK_PACKAGE, None
-
-    # 7. Nothing recognisable -> INVALID
-    return PackageType.INVALID, None
+    report = PackageFormatRegistry().detect(package_path)
+    pkg_type, plugin_json_path = NormalizationPlanner().plan(report)
+    return pkg_type, plugin_json_path  # type: ignore[return-value]
 
 
 def _apm_yml_declares_dependencies(apm_yml_path: Path) -> bool:

--- a/src/apm_cli/models/validation.py
+++ b/src/apm_cli/models/validation.py
@@ -180,9 +180,10 @@ class DetectionEvidence:
 def gather_detection_evidence(package_path: Path) -> DetectionEvidence:
     """Collect all package-type signals from a directory in one pass.
 
-    Pure: no side-effects, no file mutations.  Cheap (a handful of stat
-    calls).  See :class:`DetectionEvidence` for the shape of the return
-    value.
+    Pure: no side-effects, no file mutations. Stat-cheap except when
+    ``apm.yml`` is present without a ``.apm/`` directory, in which case it
+    is parsed once to detect declared dependencies.  See
+    :class:`DetectionEvidence` for the shape of the return value.
 
     Internally delegates to :class:`~.format_detection.PackageFormatRegistry`
     so each signal is gathered by its dedicated detector.
@@ -194,21 +195,10 @@ def gather_detection_evidence(package_path: Path) -> DetectionEvidence:
     """
     from .format_detection import (
         _PLUGIN_DIRS,
-        ApmYmlDetector,
-        ClaudePluginDetector,
-        HookJsonDetector,
         PackageFormatRegistry,
-        SkillMdDetector,
     )
 
-    registry = PackageFormatRegistry(
-        detectors=(
-            ClaudePluginDetector(),
-            SkillMdDetector(),
-            ApmYmlDetector(),
-            HookJsonDetector(),
-        )
-    )
+    registry = PackageFormatRegistry()
     report = registry.detect(package_path)
 
     cp = report.claude_plugin
@@ -269,7 +259,7 @@ def detect_package_type(
 
     report = PackageFormatRegistry().detect(package_path)
     pkg_type, plugin_json_path = NormalizationPlanner().plan(report)
-    return pkg_type, plugin_json_path  # type: ignore[return-value]
+    return pkg_type, plugin_json_path
 
 
 def _apm_yml_declares_dependencies(apm_yml_path: Path) -> bool:

--- a/tests/unit/test_format_detection.py
+++ b/tests/unit/test_format_detection.py
@@ -141,7 +141,7 @@ class TestHookJsonDetector:
         (hooks / "hook.json").write_text("{}")
         ev = HookJsonDetector().detect(tmp_path)
         assert isinstance(ev, HookJsonFormatEvidence)
-        assert any(str(hooks) in str(d) for d in ev.hooks_dirs_found)
+        assert hooks in ev.hooks_dirs_found
 
     def test_returns_evidence_for_apm_hooks(self, tmp_path: Path) -> None:
         apm_hooks = tmp_path / ".apm" / "hooks"

--- a/tests/unit/test_format_detection.py
+++ b/tests/unit/test_format_detection.py
@@ -1,0 +1,411 @@
+"""Unit tests for apm_cli.models.format_detection.
+
+Covers the composition-model classes introduced in issue #782:
+- Per-format evidence dataclasses
+- ApmYmlDetector, SkillMdDetector, HookJsonDetector, ClaudePluginDetector
+- PackageFormatRegistry
+- NormalizationPlanner
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from apm_cli.models.format_detection import (
+    ApmYmlDetector,
+    ApmYmlFormatEvidence,
+    ClaudePluginDetector,
+    ClaudePluginFormatEvidence,
+    DetectionReport,
+    FormatDetector,
+    HookJsonDetector,
+    HookJsonFormatEvidence,
+    NormalizationPlanner,
+    PackageFormatRegistry,
+    SkillMdDetector,
+    SkillMdFormatEvidence,
+)
+from apm_cli.models.validation import PackageType
+
+# ---------------------------------------------------------------------------
+# ApmYmlDetector
+# ---------------------------------------------------------------------------
+
+
+class TestApmYmlDetector:
+    """Tests for ApmYmlDetector."""
+
+    def test_returns_none_when_no_apm_yml(self, tmp_path: Path) -> None:
+        ev = ApmYmlDetector().detect(tmp_path)
+        assert ev is None
+
+    def test_returns_evidence_when_apm_yml_present(self, tmp_path: Path) -> None:
+        (tmp_path / "apm.yml").write_text("name: pkg\nversion: 1.0.0\n")
+        ev = ApmYmlDetector().detect(tmp_path)
+        assert isinstance(ev, ApmYmlFormatEvidence)
+        assert ev.apm_yml_path == tmp_path / "apm.yml"
+
+    def test_has_apm_dir_false_when_absent(self, tmp_path: Path) -> None:
+        (tmp_path / "apm.yml").write_text("name: pkg\nversion: 1.0.0\n")
+        ev = ApmYmlDetector().detect(tmp_path)
+        assert ev is not None
+        assert ev.has_apm_dir is False
+
+    def test_has_apm_dir_true_when_present(self, tmp_path: Path) -> None:
+        (tmp_path / "apm.yml").write_text("name: pkg\nversion: 1.0.0\n")
+        (tmp_path / ".apm").mkdir()
+        ev = ApmYmlDetector().detect(tmp_path)
+        assert ev is not None
+        assert ev.has_apm_dir is True
+
+    def test_declares_dependencies_true_with_apm_deps(self, tmp_path: Path) -> None:
+        (tmp_path / "apm.yml").write_text(
+            "name: pkg\nversion: 1.0.0\ndependencies:\n  apm:\n    - other\n"
+        )
+        ev = ApmYmlDetector().detect(tmp_path)
+        assert ev is not None
+        assert ev.declares_dependencies is True
+
+    def test_declares_dependencies_false_without_deps(self, tmp_path: Path) -> None:
+        (tmp_path / "apm.yml").write_text("name: pkg\nversion: 1.0.0\n")
+        ev = ApmYmlDetector().detect(tmp_path)
+        assert ev is not None
+        assert ev.declares_dependencies is False
+
+
+# ---------------------------------------------------------------------------
+# SkillMdDetector
+# ---------------------------------------------------------------------------
+
+
+class TestSkillMdDetector:
+    """Tests for SkillMdDetector."""
+
+    def test_returns_none_when_no_skill_md_and_no_nested(self, tmp_path: Path) -> None:
+        ev = SkillMdDetector().detect(tmp_path)
+        assert ev is None
+
+    def test_returns_evidence_when_root_skill_md_present(self, tmp_path: Path) -> None:
+        (tmp_path / "SKILL.md").write_text("---\nname: s\ndescription: d\n---\n")
+        ev = SkillMdDetector().detect(tmp_path)
+        assert isinstance(ev, SkillMdFormatEvidence)
+        assert ev.skill_md_path == tmp_path / "SKILL.md"
+        assert ev.nested_skill_dirs == ()
+
+    def test_returns_none_skill_md_path_when_only_nested(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / "skills" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# skill")
+        ev = SkillMdDetector().detect(tmp_path)
+        assert isinstance(ev, SkillMdFormatEvidence)
+        assert ev.skill_md_path is None
+        assert "my-skill" in ev.nested_skill_dirs
+
+    def test_detects_both_root_and_nested(self, tmp_path: Path) -> None:
+        (tmp_path / "SKILL.md").write_text("---\nname: s\ndescription: d\n---\n")
+        skill_dir = tmp_path / "skills" / "nested"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# nested")
+        ev = SkillMdDetector().detect(tmp_path)
+        assert isinstance(ev, SkillMdFormatEvidence)
+        assert ev.skill_md_path is not None
+        assert "nested" in ev.nested_skill_dirs
+
+    def test_nested_dirs_sorted(self, tmp_path: Path) -> None:
+        for name in ("beta", "alpha", "gamma"):
+            d = tmp_path / "skills" / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text("# skill")
+        ev = SkillMdDetector().detect(tmp_path)
+        assert ev is not None
+        assert ev.nested_skill_dirs == ("alpha", "beta", "gamma")
+
+
+# ---------------------------------------------------------------------------
+# HookJsonDetector
+# ---------------------------------------------------------------------------
+
+
+class TestHookJsonDetector:
+    """Tests for HookJsonDetector."""
+
+    def test_returns_none_when_no_hooks(self, tmp_path: Path) -> None:
+        ev = HookJsonDetector().detect(tmp_path)
+        assert ev is None
+
+    def test_returns_evidence_for_hooks_dir(self, tmp_path: Path) -> None:
+        hooks = tmp_path / "hooks"
+        hooks.mkdir()
+        (hooks / "hook.json").write_text("{}")
+        ev = HookJsonDetector().detect(tmp_path)
+        assert isinstance(ev, HookJsonFormatEvidence)
+        assert any(str(hooks) in str(d) for d in ev.hooks_dirs_found)
+
+    def test_returns_evidence_for_apm_hooks(self, tmp_path: Path) -> None:
+        apm_hooks = tmp_path / ".apm" / "hooks"
+        apm_hooks.mkdir(parents=True)
+        (apm_hooks / "hook.json").write_text("{}")
+        ev = HookJsonDetector().detect(tmp_path)
+        assert isinstance(ev, HookJsonFormatEvidence)
+        assert ev.hooks_dirs_found  # at least one found
+
+    def test_returns_none_when_hooks_dir_has_no_json(self, tmp_path: Path) -> None:
+        hooks = tmp_path / "hooks"
+        hooks.mkdir()
+        (hooks / "README.md").write_text("# hooks")
+        ev = HookJsonDetector().detect(tmp_path)
+        assert ev is None
+
+
+# ---------------------------------------------------------------------------
+# ClaudePluginDetector
+# ---------------------------------------------------------------------------
+
+
+class TestClaudePluginDetector:
+    """Tests for ClaudePluginDetector."""
+
+    def test_returns_none_when_no_plugin(self, tmp_path: Path) -> None:
+        ev = ClaudePluginDetector().detect(tmp_path)
+        assert ev is None
+
+    def test_returns_evidence_for_plugin_json(self, tmp_path: Path) -> None:
+        (tmp_path / "plugin.json").write_text("{}")
+        ev = ClaudePluginDetector().detect(tmp_path)
+        assert isinstance(ev, ClaudePluginFormatEvidence)
+        assert ev.plugin_json_path == tmp_path / "plugin.json"
+        assert ev.has_claude_plugin_dir is False
+
+    def test_returns_evidence_for_claude_plugin_dir(self, tmp_path: Path) -> None:
+        (tmp_path / ".claude-plugin").mkdir()
+        ev = ClaudePluginDetector().detect(tmp_path)
+        assert isinstance(ev, ClaudePluginFormatEvidence)
+        assert ev.plugin_json_path is None
+        assert ev.has_claude_plugin_dir is True
+
+    def test_plugin_dirs_present_enumerated(self, tmp_path: Path) -> None:
+        (tmp_path / "plugin.json").write_text("{}")
+        (tmp_path / "agents").mkdir()
+        (tmp_path / "commands").mkdir()
+        ev = ClaudePluginDetector().detect(tmp_path)
+        assert ev is not None
+        assert "agents" in ev.plugin_dirs_present
+        assert "commands" in ev.plugin_dirs_present
+
+    def test_plugin_dirs_absent_without_manifest(self, tmp_path: Path) -> None:
+        """Detector returns None when only dir signals but no manifest."""
+        (tmp_path / "agents").mkdir()
+        (tmp_path / "skills").mkdir()
+        ev = ClaudePluginDetector().detect(tmp_path)
+        assert ev is None
+
+
+# ---------------------------------------------------------------------------
+# FormatDetector protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestFormatDetectorProtocol:
+    """Verify all detectors satisfy the FormatDetector protocol."""
+
+    @pytest.mark.parametrize(
+        "detector",
+        [ApmYmlDetector(), SkillMdDetector(), HookJsonDetector(), ClaudePluginDetector()],
+    )
+    def test_conforms_to_protocol(self, detector: object) -> None:
+        assert isinstance(detector, FormatDetector)
+
+
+# ---------------------------------------------------------------------------
+# PackageFormatRegistry
+# ---------------------------------------------------------------------------
+
+
+class TestPackageFormatRegistry:
+    """Tests for PackageFormatRegistry.detect()."""
+
+    def test_empty_dir_all_none(self, tmp_path: Path) -> None:
+        report = PackageFormatRegistry().detect(tmp_path)
+        assert isinstance(report, DetectionReport)
+        assert report.apm_yml is None
+        assert report.skill_md is None
+        assert report.hook_json is None
+        assert report.claude_plugin is None
+
+    def test_apm_yml_detected(self, tmp_path: Path) -> None:
+        (tmp_path / "apm.yml").write_text("name: pkg\nversion: 1.0.0\n")
+        report = PackageFormatRegistry().detect(tmp_path)
+        assert report.apm_yml is not None
+        assert report.claude_plugin is None
+
+    def test_skill_md_detected(self, tmp_path: Path) -> None:
+        (tmp_path / "SKILL.md").write_text("---\nname: s\ndescription: d\n---\n")
+        report = PackageFormatRegistry().detect(tmp_path)
+        assert report.skill_md is not None
+        assert report.skill_md.skill_md_path is not None
+
+    def test_claude_plugin_detected(self, tmp_path: Path) -> None:
+        (tmp_path / "plugin.json").write_text("{}")
+        report = PackageFormatRegistry().detect(tmp_path)
+        assert report.claude_plugin is not None
+        assert report.claude_plugin.plugin_json_path is not None
+
+    def test_hook_json_detected(self, tmp_path: Path) -> None:
+        hooks = tmp_path / "hooks"
+        hooks.mkdir()
+        (hooks / "h.json").write_text("{}")
+        report = PackageFormatRegistry().detect(tmp_path)
+        assert report.hook_json is not None
+
+    def test_all_detectors_run_independently(self, tmp_path: Path) -> None:
+        """All detectors run even when one finds evidence."""
+        (tmp_path / "plugin.json").write_text("{}")
+        (tmp_path / "SKILL.md").write_text("---\nname: s\ndescription: d\n---\n")
+        hooks = tmp_path / "hooks"
+        hooks.mkdir()
+        (hooks / "h.json").write_text("{}")
+        report = PackageFormatRegistry().detect(tmp_path)
+        assert report.claude_plugin is not None
+        assert report.skill_md is not None
+        assert report.hook_json is not None
+
+
+# ---------------------------------------------------------------------------
+# NormalizationPlanner
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizationPlanner:
+    """Tests for NormalizationPlanner.plan() cascade."""
+
+    def _make_report(
+        self,
+        *,
+        apm_yml: ApmYmlFormatEvidence | None = None,
+        skill_md: SkillMdFormatEvidence | None = None,
+        hook_json: HookJsonFormatEvidence | None = None,
+        claude_plugin: ClaudePluginFormatEvidence | None = None,
+    ) -> DetectionReport:
+        return DetectionReport(
+            apm_yml=apm_yml,
+            skill_md=skill_md,
+            hook_json=hook_json,
+            claude_plugin=claude_plugin,
+        )
+
+    def _plugin_evidence(
+        self,
+        plugin_json_path: Path | None = None,
+        has_claude_plugin_dir: bool = False,
+    ) -> ClaudePluginFormatEvidence:
+        return ClaudePluginFormatEvidence(
+            plugin_json_path=plugin_json_path,
+            has_claude_plugin_dir=has_claude_plugin_dir,
+            plugin_dirs_present=(),
+        )
+
+    def _apm_yml_evidence(
+        self,
+        has_apm_dir: bool = False,
+        declares_dependencies: bool = False,
+    ) -> ApmYmlFormatEvidence:
+        return ApmYmlFormatEvidence(
+            apm_yml_path=Path("/fake/apm.yml"),
+            has_apm_dir=has_apm_dir,
+            declares_dependencies=declares_dependencies,
+        )
+
+    def _skill_md_evidence(
+        self,
+        has_root: bool = True,
+        nested: tuple[str, ...] = (),
+    ) -> SkillMdFormatEvidence:
+        return SkillMdFormatEvidence(
+            skill_md_path=Path("/fake/SKILL.md") if has_root else None,
+            nested_skill_dirs=nested,
+        )
+
+    def test_marketplace_plugin_via_plugin_json(self, tmp_path: Path) -> None:
+        plugin_path = tmp_path / "plugin.json"
+        report = self._make_report(
+            claude_plugin=self._plugin_evidence(plugin_json_path=plugin_path)
+        )
+        pkg_type, plugin_json = NormalizationPlanner().plan(report)
+        assert pkg_type == PackageType.MARKETPLACE_PLUGIN
+        assert plugin_json == plugin_path
+
+    def test_marketplace_plugin_via_claude_plugin_dir(self) -> None:
+        report = self._make_report(claude_plugin=self._plugin_evidence(has_claude_plugin_dir=True))
+        pkg_type, plugin_json = NormalizationPlanner().plan(report)
+        assert pkg_type == PackageType.MARKETPLACE_PLUGIN
+        assert plugin_json is None
+
+    def test_hybrid(self) -> None:
+        report = self._make_report(
+            apm_yml=self._apm_yml_evidence(has_apm_dir=True),
+            skill_md=self._skill_md_evidence(has_root=True),
+        )
+        pkg_type, _ = NormalizationPlanner().plan(report)
+        assert pkg_type == PackageType.HYBRID
+
+    def test_claude_skill(self) -> None:
+        report = self._make_report(skill_md=self._skill_md_evidence(has_root=True))
+        pkg_type, _ = NormalizationPlanner().plan(report)
+        assert pkg_type == PackageType.CLAUDE_SKILL
+
+    def test_skill_bundle(self) -> None:
+        report = self._make_report(
+            skill_md=self._skill_md_evidence(has_root=False, nested=("skill-a",))
+        )
+        pkg_type, _ = NormalizationPlanner().plan(report)
+        assert pkg_type == PackageType.SKILL_BUNDLE
+
+    def test_apm_package_with_apm_dir(self) -> None:
+        report = self._make_report(apm_yml=self._apm_yml_evidence(has_apm_dir=True))
+        pkg_type, _ = NormalizationPlanner().plan(report)
+        assert pkg_type == PackageType.APM_PACKAGE
+
+    def test_apm_package_with_declared_deps(self) -> None:
+        report = self._make_report(apm_yml=self._apm_yml_evidence(declares_dependencies=True))
+        pkg_type, _ = NormalizationPlanner().plan(report)
+        assert pkg_type == PackageType.APM_PACKAGE
+
+    def test_invalid_apm_yml_no_apm_dir_no_deps(self) -> None:
+        report = self._make_report(
+            apm_yml=self._apm_yml_evidence(has_apm_dir=False, declares_dependencies=False)
+        )
+        pkg_type, _ = NormalizationPlanner().plan(report)
+        assert pkg_type == PackageType.INVALID
+
+    def test_hook_package(self) -> None:
+        report = self._make_report(
+            hook_json=HookJsonFormatEvidence(hooks_dirs_found=(Path("/fake/hooks"),))
+        )
+        pkg_type, _ = NormalizationPlanner().plan(report)
+        assert pkg_type == PackageType.HOOK_PACKAGE
+
+    def test_invalid_empty_report(self) -> None:
+        report = self._make_report()
+        pkg_type, _ = NormalizationPlanner().plan(report)
+        assert pkg_type == PackageType.INVALID
+
+    def test_plugin_wins_over_hybrid_signals(self) -> None:
+        """Claude plugin beats hybrid when all signals present (cascade step 1 wins)."""
+        report = self._make_report(
+            claude_plugin=self._plugin_evidence(plugin_json_path=Path("/fake/plugin.json")),
+            apm_yml=self._apm_yml_evidence(has_apm_dir=True),
+            skill_md=self._skill_md_evidence(has_root=True),
+        )
+        pkg_type, _ = NormalizationPlanner().plan(report)
+        assert pkg_type == PackageType.MARKETPLACE_PLUGIN
+
+    def test_skill_bundle_wins_over_apm_only(self) -> None:
+        """Nested skills beat plain apm.yml (cascade step 4 before step 5)."""
+        report = self._make_report(
+            apm_yml=self._apm_yml_evidence(has_apm_dir=True),
+            skill_md=self._skill_md_evidence(has_root=False, nested=("s",)),
+        )
+        pkg_type, _ = NormalizationPlanner().plan(report)
+        assert pkg_type == PackageType.SKILL_BUNDLE

--- a/tests/unit/test_models_validation_phase3.py
+++ b/tests/unit/test_models_validation_phase3.py
@@ -372,143 +372,68 @@ class TestGatherDetectionEvidence:
 
 
 class TestDetectPackageTypeCascade:
-    """Test each branch in detect_package_type()."""
+    """Test each branch in detect_package_type() using real filesystem fixtures.
+
+    These tests exercise the full detection pipeline
+    (PackageFormatRegistry -> NormalizationPlanner) without mocking
+    internals, so they remain valid across implementation refactors.
+    """
 
     def test_marketplace_plugin_via_plugin_json(self, tmp_path: Path) -> None:
         """plugin.json -> MARKETPLACE_PLUGIN (cascade step 1)."""
-        with patch("apm_cli.models.validation.gather_detection_evidence") as mock_ev:
-            mock_ev.return_value = DetectionEvidence(
-                has_apm_yml=True,
-                has_skill_md=True,
-                has_hook_json=False,
-                plugin_json_path=tmp_path / "plugin.json",
-                plugin_dirs_present=(),
-                has_claude_plugin_dir=False,
-                nested_skill_dirs=(),
-                has_plugin_manifest=True,
-            )
-            pkg_type, plugin_path = detect_package_type(tmp_path)
+        plugin_json: Path = tmp_path / "plugin.json"
+        plugin_json.write_text("{}")
+        pkg_type, plugin_path = detect_package_type(tmp_path)
         assert pkg_type == PackageType.MARKETPLACE_PLUGIN
-        assert plugin_path == tmp_path / "plugin.json"
+        assert plugin_path == plugin_json
 
     def test_marketplace_plugin_via_claude_plugin_dir(self, tmp_path: Path) -> None:
         """.claude-plugin/ dir -> MARKETPLACE_PLUGIN (cascade step 1, no plugin.json)."""
-        with patch("apm_cli.models.validation.gather_detection_evidence") as mock_ev:
-            mock_ev.return_value = DetectionEvidence(
-                has_apm_yml=False,
-                has_skill_md=False,
-                has_hook_json=False,
-                plugin_json_path=None,
-                plugin_dirs_present=(),
-                has_claude_plugin_dir=True,
-                nested_skill_dirs=(),
-                has_plugin_manifest=True,
-            )
-            pkg_type, plugin_path = detect_package_type(tmp_path)
+        (tmp_path / ".claude-plugin").mkdir()
+        pkg_type, plugin_path = detect_package_type(tmp_path)
         assert pkg_type == PackageType.MARKETPLACE_PLUGIN
         assert plugin_path is None
 
     def test_hybrid_apm_yml_and_skill_md(self, tmp_path: Path) -> None:
         """apm.yml + SKILL.md -> HYBRID (cascade step 2)."""
-        with patch("apm_cli.models.validation.gather_detection_evidence") as mock_ev:
-            mock_ev.return_value = DetectionEvidence(
-                has_apm_yml=True,
-                has_skill_md=True,
-                has_hook_json=False,
-                plugin_json_path=None,
-                plugin_dirs_present=(),
-                has_claude_plugin_dir=False,
-                nested_skill_dirs=(),
-                has_plugin_manifest=False,
-            )
-            pkg_type, plugin_path = detect_package_type(tmp_path)
+        (tmp_path / "apm.yml").write_text("name: pkg\nversion: 1.0.0\n")
+        (tmp_path / "SKILL.md").write_text("---\nname: s\ndescription: d\n---\n")
+        pkg_type, plugin_path = detect_package_type(tmp_path)
         assert pkg_type == PackageType.HYBRID
         assert plugin_path is None
 
     def test_claude_skill_skill_md_only(self, tmp_path: Path) -> None:
         """SKILL.md only -> CLAUDE_SKILL (cascade step 3)."""
-        with patch("apm_cli.models.validation.gather_detection_evidence") as mock_ev:
-            mock_ev.return_value = DetectionEvidence(
-                has_apm_yml=False,
-                has_skill_md=True,
-                has_hook_json=False,
-                plugin_json_path=None,
-                plugin_dirs_present=(),
-                has_claude_plugin_dir=False,
-                nested_skill_dirs=(),
-                has_plugin_manifest=False,
-            )
-            pkg_type, _ = detect_package_type(tmp_path)
+        (tmp_path / "SKILL.md").write_text("---\nname: s\ndescription: d\n---\n")
+        pkg_type, _ = detect_package_type(tmp_path)
         assert pkg_type == PackageType.CLAUDE_SKILL
 
     def test_skill_bundle_nested_skills(self, tmp_path: Path) -> None:
         """Nested skills/<x>/SKILL.md -> SKILL_BUNDLE (cascade step 4)."""
-        with patch("apm_cli.models.validation.gather_detection_evidence") as mock_ev:
-            mock_ev.return_value = DetectionEvidence(
-                has_apm_yml=False,
-                has_skill_md=False,
-                has_hook_json=False,
-                plugin_json_path=None,
-                plugin_dirs_present=(),
-                has_claude_plugin_dir=False,
-                nested_skill_dirs=("skill-a",),
-                has_plugin_manifest=False,
-            )
-            pkg_type, _ = detect_package_type(tmp_path)
+        skill_dir: Path = tmp_path / "skills" / "skill-a"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# skill-a")
+        pkg_type, _ = detect_package_type(tmp_path)
         assert pkg_type == PackageType.SKILL_BUNDLE
 
     def test_apm_package_with_apm_dir(self, tmp_path: Path) -> None:
         """apm.yml + .apm/ directory -> APM_PACKAGE (cascade step 5)."""
-        apm_dir: Path = tmp_path / ".apm"
-        apm_dir.mkdir()
-        with patch("apm_cli.models.validation.gather_detection_evidence") as mock_ev:
-            mock_ev.return_value = DetectionEvidence(
-                has_apm_yml=True,
-                has_skill_md=False,
-                has_hook_json=False,
-                plugin_json_path=None,
-                plugin_dirs_present=(),
-                has_claude_plugin_dir=False,
-                nested_skill_dirs=(),
-                has_plugin_manifest=False,
-            )
-            pkg_type, _ = detect_package_type(tmp_path)
-        # apm.yml exists but .apm/ existence check is done inside detect_package_type
-        # It calls _apm_yml_declares_dependencies on tmp_path/apm.yml
-        # Since tmp_path doesn't have apm.yml, _apm_yml_declares_dependencies returns False
-        # The .apm dir DOES exist -> APM_PACKAGE
+        (tmp_path / "apm.yml").write_text("name: pkg\nversion: 1.0.0\n")
+        (tmp_path / ".apm").mkdir()
+        pkg_type, _ = detect_package_type(tmp_path)
         assert pkg_type == PackageType.APM_PACKAGE
 
     def test_hook_package_hook_json_only(self, tmp_path: Path) -> None:
         """hooks/*.json only -> HOOK_PACKAGE (cascade step 6)."""
-        with patch("apm_cli.models.validation.gather_detection_evidence") as mock_ev:
-            mock_ev.return_value = DetectionEvidence(
-                has_apm_yml=False,
-                has_skill_md=False,
-                has_hook_json=True,
-                plugin_json_path=None,
-                plugin_dirs_present=(),
-                has_claude_plugin_dir=False,
-                nested_skill_dirs=(),
-                has_plugin_manifest=False,
-            )
-            pkg_type, _ = detect_package_type(tmp_path)
+        hooks_dir: Path = tmp_path / "hooks"
+        hooks_dir.mkdir()
+        (hooks_dir / "hook.json").write_text("{}")
+        pkg_type, _ = detect_package_type(tmp_path)
         assert pkg_type == PackageType.HOOK_PACKAGE
 
     def test_invalid_nothing_recognizable(self, tmp_path: Path) -> None:
         """Nothing recognizable -> INVALID (cascade step 7)."""
-        with patch("apm_cli.models.validation.gather_detection_evidence") as mock_ev:
-            mock_ev.return_value = DetectionEvidence(
-                has_apm_yml=False,
-                has_skill_md=False,
-                has_hook_json=False,
-                plugin_json_path=None,
-                plugin_dirs_present=(),
-                has_claude_plugin_dir=False,
-                nested_skill_dirs=(),
-                has_plugin_manifest=False,
-            )
-            pkg_type, _ = detect_package_type(tmp_path)
+        pkg_type, _ = detect_package_type(tmp_path)
         assert pkg_type == PackageType.INVALID
 
     def test_apm_yml_no_apm_dir_no_deps_returns_invalid(self, tmp_path: Path) -> None:

--- a/tests/unit/test_models_validation_rules.py
+++ b/tests/unit/test_models_validation_rules.py
@@ -372,143 +372,68 @@ class TestGatherDetectionEvidence:
 
 
 class TestDetectPackageTypeCascade:
-    """Test each branch in detect_package_type()."""
+    """Test each branch in detect_package_type() using real filesystem fixtures.
+
+    These tests exercise the full detection pipeline
+    (PackageFormatRegistry -> NormalizationPlanner) without mocking
+    internals, so they remain valid across implementation refactors.
+    """
 
     def test_marketplace_plugin_via_plugin_json(self, tmp_path: Path) -> None:
         """plugin.json -> MARKETPLACE_PLUGIN (cascade step 1)."""
-        with patch("apm_cli.models.validation.gather_detection_evidence") as mock_ev:
-            mock_ev.return_value = DetectionEvidence(
-                has_apm_yml=True,
-                has_skill_md=True,
-                has_hook_json=False,
-                plugin_json_path=tmp_path / "plugin.json",
-                plugin_dirs_present=(),
-                has_claude_plugin_dir=False,
-                nested_skill_dirs=(),
-                has_plugin_manifest=True,
-            )
-            pkg_type, plugin_path = detect_package_type(tmp_path)
+        plugin_json: Path = tmp_path / "plugin.json"
+        plugin_json.write_text("{}")
+        pkg_type, plugin_path = detect_package_type(tmp_path)
         assert pkg_type == PackageType.MARKETPLACE_PLUGIN
-        assert plugin_path == tmp_path / "plugin.json"
+        assert plugin_path == plugin_json
 
     def test_marketplace_plugin_via_claude_plugin_dir(self, tmp_path: Path) -> None:
         """.claude-plugin/ dir -> MARKETPLACE_PLUGIN (cascade step 1, no plugin.json)."""
-        with patch("apm_cli.models.validation.gather_detection_evidence") as mock_ev:
-            mock_ev.return_value = DetectionEvidence(
-                has_apm_yml=False,
-                has_skill_md=False,
-                has_hook_json=False,
-                plugin_json_path=None,
-                plugin_dirs_present=(),
-                has_claude_plugin_dir=True,
-                nested_skill_dirs=(),
-                has_plugin_manifest=True,
-            )
-            pkg_type, plugin_path = detect_package_type(tmp_path)
+        (tmp_path / ".claude-plugin").mkdir()
+        pkg_type, plugin_path = detect_package_type(tmp_path)
         assert pkg_type == PackageType.MARKETPLACE_PLUGIN
         assert plugin_path is None
 
     def test_hybrid_apm_yml_and_skill_md(self, tmp_path: Path) -> None:
         """apm.yml + SKILL.md -> HYBRID (cascade step 2)."""
-        with patch("apm_cli.models.validation.gather_detection_evidence") as mock_ev:
-            mock_ev.return_value = DetectionEvidence(
-                has_apm_yml=True,
-                has_skill_md=True,
-                has_hook_json=False,
-                plugin_json_path=None,
-                plugin_dirs_present=(),
-                has_claude_plugin_dir=False,
-                nested_skill_dirs=(),
-                has_plugin_manifest=False,
-            )
-            pkg_type, plugin_path = detect_package_type(tmp_path)
+        (tmp_path / "apm.yml").write_text("name: pkg\nversion: 1.0.0\n")
+        (tmp_path / "SKILL.md").write_text("---\nname: s\ndescription: d\n---\n")
+        pkg_type, plugin_path = detect_package_type(tmp_path)
         assert pkg_type == PackageType.HYBRID
         assert plugin_path is None
 
     def test_claude_skill_skill_md_only(self, tmp_path: Path) -> None:
         """SKILL.md only -> CLAUDE_SKILL (cascade step 3)."""
-        with patch("apm_cli.models.validation.gather_detection_evidence") as mock_ev:
-            mock_ev.return_value = DetectionEvidence(
-                has_apm_yml=False,
-                has_skill_md=True,
-                has_hook_json=False,
-                plugin_json_path=None,
-                plugin_dirs_present=(),
-                has_claude_plugin_dir=False,
-                nested_skill_dirs=(),
-                has_plugin_manifest=False,
-            )
-            pkg_type, _ = detect_package_type(tmp_path)
+        (tmp_path / "SKILL.md").write_text("---\nname: s\ndescription: d\n---\n")
+        pkg_type, _ = detect_package_type(tmp_path)
         assert pkg_type == PackageType.CLAUDE_SKILL
 
     def test_skill_bundle_nested_skills(self, tmp_path: Path) -> None:
         """Nested skills/<x>/SKILL.md -> SKILL_BUNDLE (cascade step 4)."""
-        with patch("apm_cli.models.validation.gather_detection_evidence") as mock_ev:
-            mock_ev.return_value = DetectionEvidence(
-                has_apm_yml=False,
-                has_skill_md=False,
-                has_hook_json=False,
-                plugin_json_path=None,
-                plugin_dirs_present=(),
-                has_claude_plugin_dir=False,
-                nested_skill_dirs=("skill-a",),
-                has_plugin_manifest=False,
-            )
-            pkg_type, _ = detect_package_type(tmp_path)
+        skill_dir: Path = tmp_path / "skills" / "skill-a"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# skill-a")
+        pkg_type, _ = detect_package_type(tmp_path)
         assert pkg_type == PackageType.SKILL_BUNDLE
 
     def test_apm_package_with_apm_dir(self, tmp_path: Path) -> None:
         """apm.yml + .apm/ directory -> APM_PACKAGE (cascade step 5)."""
-        apm_dir: Path = tmp_path / ".apm"
-        apm_dir.mkdir()
-        with patch("apm_cli.models.validation.gather_detection_evidence") as mock_ev:
-            mock_ev.return_value = DetectionEvidence(
-                has_apm_yml=True,
-                has_skill_md=False,
-                has_hook_json=False,
-                plugin_json_path=None,
-                plugin_dirs_present=(),
-                has_claude_plugin_dir=False,
-                nested_skill_dirs=(),
-                has_plugin_manifest=False,
-            )
-            pkg_type, _ = detect_package_type(tmp_path)
-        # apm.yml exists but .apm/ existence check is done inside detect_package_type
-        # It calls _apm_yml_declares_dependencies on tmp_path/apm.yml
-        # Since tmp_path doesn't have apm.yml, _apm_yml_declares_dependencies returns False
-        # The .apm dir DOES exist -> APM_PACKAGE
+        (tmp_path / "apm.yml").write_text("name: pkg\nversion: 1.0.0\n")
+        (tmp_path / ".apm").mkdir()
+        pkg_type, _ = detect_package_type(tmp_path)
         assert pkg_type == PackageType.APM_PACKAGE
 
     def test_hook_package_hook_json_only(self, tmp_path: Path) -> None:
         """hooks/*.json only -> HOOK_PACKAGE (cascade step 6)."""
-        with patch("apm_cli.models.validation.gather_detection_evidence") as mock_ev:
-            mock_ev.return_value = DetectionEvidence(
-                has_apm_yml=False,
-                has_skill_md=False,
-                has_hook_json=True,
-                plugin_json_path=None,
-                plugin_dirs_present=(),
-                has_claude_plugin_dir=False,
-                nested_skill_dirs=(),
-                has_plugin_manifest=False,
-            )
-            pkg_type, _ = detect_package_type(tmp_path)
+        hooks_dir: Path = tmp_path / "hooks"
+        hooks_dir.mkdir()
+        (hooks_dir / "hook.json").write_text("{}")
+        pkg_type, _ = detect_package_type(tmp_path)
         assert pkg_type == PackageType.HOOK_PACKAGE
 
     def test_invalid_nothing_recognizable(self, tmp_path: Path) -> None:
         """Nothing recognizable -> INVALID (cascade step 7)."""
-        with patch("apm_cli.models.validation.gather_detection_evidence") as mock_ev:
-            mock_ev.return_value = DetectionEvidence(
-                has_apm_yml=False,
-                has_skill_md=False,
-                has_hook_json=False,
-                plugin_json_path=None,
-                plugin_dirs_present=(),
-                has_claude_plugin_dir=False,
-                nested_skill_dirs=(),
-                has_plugin_manifest=False,
-            )
-            pkg_type, _ = detect_package_type(tmp_path)
+        pkg_type, _ = detect_package_type(tmp_path)
         assert pkg_type == PackageType.INVALID
 
     def test_apm_yml_no_apm_dir_no_deps_returns_invalid(self, tmp_path: Path) -> None:


### PR DESCRIPTION
refactor(models): separate package-format detection into composition model

## TL;DR

Extracts the 7-branch if/elif cascade in `detect_package_type()` from `validation.py` into a new `format_detection.py` module built around a `FormatDetector` protocol, `PackageFormatRegistry`, `DetectionReport`, and `NormalizationPlanner`. All existing callers and outputs are unchanged — `detect_package_type()` is now a 2-line facade. New formats are additive: add a detector class, not an elif branch.

> [!NOTE]
> Closes #782. The `DetectionEvidence` dataclass and `gather_detection_evidence()` introduced in #781 are preserved unchanged; this PR restructures only the detection-strategy layer beneath them.

## Problem (WHY)

- [x] `detect_package_type()` in `validation.py` encodes format priority as a single 7-branch if/elif chain — adding a new format requires reading and mutating the full cascade, with no guard against ordering bugs.
- [x] All four format-specific filesystem queries (apm.yml, SKILL.md, hooks/*.json, plugin.json) are embedded inline in one 80-line function with no independent testability.
- [!] `gather_detection_evidence()` and `detect_package_type()` share an implicit coupling: the former must always populate every field the latter reads, creating a hidden ordering contract between two functions split across the same file.

The cascade conflates "does this format exist?" (detection) with "which format wins?" (normalization) — the structural problem described in [#782](https://github.com/microsoft/apm/issues/782).

## Approach (WHAT)

| # | Change |
|---|--------|
| 1 | `FormatDetector` `@runtime_checkable` Protocol — each detector independently testable and composable |
| 2 | 4 frozen evidence dataclasses (`ApmYmlFormatEvidence`, `SkillMdFormatEvidence`, `HookJsonFormatEvidence`, `ClaudePluginFormatEvidence`) |
| 3 | `PackageFormatRegistry.detect()` runs all detectors with no short-circuit, produces a `DetectionReport` |
| 4 | `NormalizationPlanner.plan()` owns the cascade priority exclusively — backward-compat order encoded once, in one place |
| 5 | `detect_package_type()` becomes a 2-line facade; no callers touched |

## Implementation (HOW)

- **`src/apm_cli/models/format_detection.py`** (new, 397 lines) — full composition model: `FormatDetector` protocol, 4 evidence dataclasses, 4 detector classes, `DetectionReport`, `PackageFormatRegistry`, `NormalizationPlanner`. Import from `validation.py` is deferred inside `ApmYmlDetector.detect()` to avoid circular import at load time.
- **`src/apm_cli/models/validation.py`** — `detect_package_type()` delegates to `PackageFormatRegistry` + `NormalizationPlanner` (behavior identical). `gather_detection_evidence()` uses the registry internally and always populates `plugin_dirs_present` directly to preserve the observability invariant for near-miss warnings.
- **`src/apm_cli/models/__init__.py`** — exports all 12 new public names from `format_detection`.
- **`tests/unit/test_format_detection.py`** (new, 42 tests) — per-detector, registry, and planner cascade tests using real filesystem fixtures.
- **`tests/unit/test_models_validation_{rules,phase3}.py`** — `TestDetectPackageTypeCascade` updated from mock-based to real filesystem fixtures, since `detect_package_type()` no longer calls `gather_detection_evidence()` internally.

## Diagrams

The refactor replaces the inline cascade with a registry-and-planner composition; `detect_package_type` becomes a facade.

```mermaid
flowchart LR
    subgraph Before["Before"]
        B1["7-branch if/elif cascade\ninside detect_package_type()"]
    end
    subgraph After["After"]
        R["PackageFormatRegistry\ndetect(path)"]
        DR["DetectionReport"]
        NP["NormalizationPlanner\nplan(report)"]
        RT["PackageType, path"]
        R --> DR --> NP --> RT
    end
    Before -.->|"replaced by"| After
    classDef new stroke-dasharray: 5 5;
    class R,DR,NP,RT new;
```

Each detector runs independently and returns typed evidence for its format; `DetectionReport` aggregates all four.

```mermaid
flowchart LR
    FD["FormatDetector Protocol"]
    A["ApmYmlDetector"]
    B["SkillMdDetector"]
    C["HookJsonDetector"]
    D["ClaudePluginDetector"]
    AE["ApmYmlFormatEvidence"]
    BE["SkillMdFormatEvidence"]
    CE["HookJsonFormatEvidence"]
    DE["ClaudePluginFormatEvidence"]
    R["DetectionReport"]
    FD --> A
    FD --> B
    FD --> C
    FD --> D
    A --> AE
    B --> BE
    C --> CE
    D --> DE
    AE --> R
    BE --> R
    CE --> R
    DE --> R
    classDef new stroke-dasharray: 5 5;
    class FD,A,B,C,D,AE,BE,CE,DE,R new;
```

## Trade-offs

- **Deferred import over third-module extraction.** `ApmYmlDetector.detect()` imports `_apm_yml_declares_dependencies` from `validation.py` inside the method body to avoid a circular import at load time. Extracting the helper to a shared module would be cleaner but widens scope beyond #782.
- **`gather_detection_evidence()` retained, not removed.** Downstream consumers depend on `DetectionEvidence` from `validation.py`. Removal is a separate PR.
- **Test mocking strategy replaced with real fixtures.** The old `TestDetectPackageTypeCascade` mocked `gather_detection_evidence`; after the refactor that mock had no effect on the new code path. Real filesystem fixtures are more robust and test actual behavior.

## Benefits

1. Adding a new package format requires one new detector class and one new evidence dataclass — no if/elif editing, no cascade ordering risk.
2. Each detector is independently unit-testable: 42 new tests with real filesystem fixtures cover all detector × signal combinations.
3. `NormalizationPlanner.plan()` is the single source of truth for cascade priority — previously encoded implicitly inside `detect_package_type()`.
4. `DetectionReport` is a first-class observability payload: near-miss warnings and future diagnostics derive from one frozen dataclass without a second filesystem scan.

## Validation

<details><summary>Full test run: 15,937 passed, 1 skipped, 21 xfailed</summary>

```
uv run --extra dev pytest tests/unit/ -q
...
15937 passed, 1 skipped, 21 xfailed, 19 warnings, 40 subtests passed in 92.78s
```

</details>

<details><summary>Lint gate: ruff, pylint R0801, auth-signals — all clean</summary>

```
uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/
All checks passed!
1167 files already formatted

uv run --extra dev python -m pylint --disable=all --enable=R0801 \
  --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/
Your code has been rated at 10.00/10

bash scripts/lint-auth-signals.sh
[+] auth-signal lint clean
```

</details>

### Scenario Evidence

This is a behavior-preserving refactor: all callers receive identical results. Tests were updated from mock-based to real-filesystem fixtures because the internal plumbing changed, not because behavior changed. The existing 15,937-test suite proves every scenario; key scenarios mapped below.

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|------------------------|--------------|--------------------|------|
| 1 | `apm install` on a package with `apm.yml` + `.apm/` dir resolves to `APM_PACKAGE` | DevX, Portability by manifest | `tests/unit/test_format_detection.py::TestNormalizationPlanner::test_apm_package_with_apm_dir` | unit |
| 2 | `apm install` on a package with `apm.yml` + `SKILL.md` resolves to `HYBRID` | DevX, Portability by manifest | `tests/unit/test_format_detection.py::TestNormalizationPlanner::test_hybrid` | unit |
| 3 | `apm install` on a package with `plugin.json` resolves to `MARKETPLACE_PLUGIN`, plugin path returned | DevX, Multi-harness support | `tests/unit/test_format_detection.py::TestNormalizationPlanner::test_marketplace_plugin_via_plugin_json` | unit |
| 4 | Claude plugin format wins cascade when multiple format signals coexist | Governed by policy | `tests/unit/test_format_detection.py::TestNormalizationPlanner::test_plugin_wins_over_hybrid_signals` | unit |
| 5 | All existing cascade branches unchanged end-to-end through validation dispatch | DevX, Portability by manifest | `tests/unit/test_models_validation_rules.py::TestDetectPackageTypeCascade` (all methods) | unit |

## How to test

- [ ] `uv run --extra dev pytest tests/unit/test_format_detection.py -v` — 42 new tests, all green.
- [ ] `uv run --extra dev pytest tests/unit/test_models_validation_rules.py tests/unit/test_models_validation_phase3.py -v` — all cascade and gather tests green.
- [ ] `uv run --extra dev pytest tests/unit/ -q` — full unit suite green, no regressions.
- [ ] `python -c "from apm_cli.models import PackageFormatRegistry, NormalizationPlanner, DetectionReport; print('import ok')"` — new public names importable from `apm_cli.models`.
- [ ] In a temp directory with `apm.yml` + `SKILL.md`, run `apm install` — type resolves to `HYBRID` as before.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
