### PR TITLE
feat: apm install -g deploys copilot instructions to ~/.copilot/copilot-instructions.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm install -g` now deploys `instructions` primitives for the Copilot target by concatenating all `*.instructions.md` files from each installed package into `~/.copilot/copilot-instructions.md`, the single file Copilot CLI reads at user scope. Previously this primitive type was silently skipped for global installs. Each package's contribution is wrapped in an HTML provenance comment so the file is auditable and multi-package installs accumulate correctly. (closes #650)
 - `apm compile --target copilot` (and `agents`) no longer writes instructions into `AGENTS.md` when `apm install` has already deployed them to `.github/instructions/`, eliminating duplicate context that Copilot would read from both locations. Mirrors the equivalent dedup behaviour that was already in place for the Claude path (`.claude/rules/`). (closes #1550, refs #1445)
 
 ### Changed

--- a/docs/src/content/docs/reference/targets-matrix.md
+++ b/docs/src/content/docs/reference/targets-matrix.md
@@ -80,7 +80,7 @@ GitHub Copilot (CLI and IDE).
   - skills: `.agents/skills/<name>/SKILL.md`
   - hooks: `.github/hooks/<name>.json`
   - generated: `.github/copilot-instructions.md` (compile output)
-- **User scope.** Partial. `prompts` deploy under `~/.copilot/prompts/`; `instructions` are not supported at user scope. User-scope deploys land under `~/.copilot/`, not `~/.github/`.
+- **User scope.** Partial. `prompts` deploy under `~/.copilot/prompts/`; `instructions` from all packages are concatenated into `~/.copilot/copilot-instructions.md` (Copilot CLI reads only that single file at user scope). User-scope deploys land under `~/.copilot/`, not `~/.github/`.
 
 ## claude
 

--- a/src/apm_cli/integration/instruction_integrator.py
+++ b/src/apm_cli/integration/instruction_integrator.py
@@ -96,6 +96,17 @@ class InstructionIntegrator(BaseIntegrator):
         deploy_dir.mkdir(parents=True, exist_ok=True)
 
         fmt = mapping.format_id
+
+        if fmt == "copilot_user_instructions":
+            return self._integrate_copilot_user_instructions(
+                instruction_files,
+                deploy_dir,
+                project_root,
+                force=force,
+                managed_files=managed_files,
+                diagnostics=diagnostics,
+            )
+
         needs_rename = fmt in ("cursor_rules", "claude_rules", "windsurf_rules")
 
         files_integrated = 0
@@ -166,20 +177,25 @@ class InstructionIntegrator(BaseIntegrator):
         if not mapping:
             return {"files_removed": 0, "errors": 0}
         effective_root = mapping.deploy_root or target.root_dir
-        prefix = f"{effective_root}/{mapping.subdir}/"
-        legacy_dir = project_root / effective_root / mapping.subdir
-        if mapping.format_id == "cursor_rules":
-            legacy_pattern = "*.mdc"
-        elif mapping.format_id == "windsurf_rules":
-            # Do not use a broad legacy glob for Windsurf rules to avoid
-            # deleting user-authored .md files under .windsurf/rules/.
+        if mapping.format_id == "copilot_user_instructions":
+            prefix = f"{effective_root}/copilot-instructions.md"
             legacy_pattern = None
-        elif mapping.format_id == "claude_rules":
-            # Do not use a broad legacy glob for Claude rules to avoid
-            # deleting user-authored .md files under .claude/rules/.
-            legacy_pattern = None
+            legacy_dir = None
         else:
-            legacy_pattern = "*.instructions.md"
+            prefix = f"{effective_root}/{mapping.subdir}/"
+            legacy_dir = project_root / effective_root / mapping.subdir
+            if mapping.format_id == "cursor_rules":
+                legacy_pattern = "*.mdc"
+            elif mapping.format_id == "windsurf_rules":
+                # Do not use a broad legacy glob for Windsurf rules to avoid
+                # deleting user-authored .md files under .windsurf/rules/.
+                legacy_pattern = None
+            elif mapping.format_id == "claude_rules":
+                # Do not use a broad legacy glob for Claude rules to avoid
+                # deleting user-authored .md files under .claude/rules/.
+                legacy_pattern = None
+            else:
+                legacy_pattern = "*.instructions.md"
         return self.sync_remove_files(
             project_root,
             managed_files,
@@ -187,6 +203,69 @@ class InstructionIntegrator(BaseIntegrator):
             legacy_glob_dir=legacy_dir,
             legacy_glob_pattern=legacy_pattern,
             targets=[target],
+        )
+
+    # ------------------------------------------------------------------
+    # Copilot user-scope concat support
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _strip_frontmatter(content: str) -> str:
+        """Strip YAML frontmatter from instruction content.
+
+        Returns only the body text following the closing ``---`` delimiter.
+        If no frontmatter is present, returns the content unchanged.
+        """
+        fm_match = re.match(r"^---\s*\n(.*?)\n---\s*\n?", content, re.DOTALL)
+        if fm_match:
+            return content[fm_match.end() :]
+        return content
+
+    def _integrate_copilot_user_instructions(
+        self,
+        instruction_files: list[Path],
+        deploy_dir: Path,
+        project_root: Path,
+        *,
+        force: bool = False,
+        managed_files: set[str] | None = None,
+        diagnostics=None,
+    ) -> IntegrationResult:
+        """Concatenate all instruction files into ~/.copilot/copilot-instructions.md.
+
+        Copilot CLI at user scope reads a single file rather than individual
+        ``*.instructions.md`` files.  This method strips YAML frontmatter from
+        each source file and joins the bodies with a blank-line separator.
+        """
+        target_path = deploy_dir / "copilot-instructions.md"
+        rel_path = portable_relpath(target_path, project_root)
+
+        bodies: list[str] = []
+        for source_file in instruction_files:
+            content = source_file.read_text(encoding="utf-8")
+            body = self._strip_frontmatter(content).strip()
+            if body:
+                bodies.append(body)
+
+        if not bodies:
+            return IntegrationResult(0, 0, 0, [])
+
+        deploy_dir.mkdir(parents=True, exist_ok=True)
+        combined = "\n\n".join(bodies) + "\n"
+
+        # Byte-identity check is not applicable for multi-source concat;
+        # go directly to collision detection.
+        if self.check_collision(
+            target_path, rel_path, managed_files, force, diagnostics=diagnostics
+        ):
+            return IntegrationResult(0, 0, 1, [])
+
+        target_path.write_text(combined, encoding="utf-8")
+        return IntegrationResult(
+            files_integrated=1,
+            files_updated=0,
+            files_skipped=0,
+            target_paths=[target_path],
         )
 
     # ------------------------------------------------------------------

--- a/src/apm_cli/integration/instruction_integrator.py
+++ b/src/apm_cli/integration/instruction_integrator.py
@@ -105,6 +105,7 @@ class InstructionIntegrator(BaseIntegrator):
                 force=force,
                 managed_files=managed_files,
                 diagnostics=diagnostics,
+                pkg_source=getattr(getattr(package_info, "package", None), "source", None),
             )
 
         needs_rename = fmt in ("cursor_rules", "claude_rules", "windsurf_rules")
@@ -209,17 +210,56 @@ class InstructionIntegrator(BaseIntegrator):
     # Copilot user-scope concat support
     # ------------------------------------------------------------------
 
+    # Sentinel line written as the first line of every APM-managed
+    # copilot-instructions.md.  Its presence distinguishes the file from
+    # a user-authored one, enabling multi-package accumulation without
+    # collision false-positives.
+    _APM_COPILOT_HEADER: str = "<!-- apm-managed: copilot-instructions.md -->"
+
+    # Matches a single package's provenance-marked section.
+    _APM_SOURCE_RE: re.Pattern[str] = re.compile(
+        r"<!-- apm:source:(?P<source>[^>]*?) -->\n(?P<body>.*?)<!-- /apm:source -->",
+        re.DOTALL,
+    )
+
     @staticmethod
     def _strip_frontmatter(content: str) -> str:
         """Strip YAML frontmatter from instruction content.
 
         Returns only the body text following the closing ``---`` delimiter.
         If no frontmatter is present, returns the content unchanged.
+        Handles both LF and CRLF line endings.
         """
-        fm_match = re.match(r"^---\s*\n(.*?)\n---\s*\n?", content, re.DOTALL)
+        fm_match = re.match(r"^---\s*\r?\n(.*?)\r?\n---\s*\r?\n?", content, re.DOTALL)
         if fm_match:
             return content[fm_match.end() :]
         return content
+
+    @classmethod
+    def _is_apm_managed_copilot(cls, content: str) -> bool:
+        """Return True if *content* starts with the APM managed-file sentinel."""
+        return content.startswith(cls._APM_COPILOT_HEADER)
+
+    @classmethod
+    def _build_copilot_section(cls, pkg_source: str, body: str) -> str:
+        """Wrap *body* in APM provenance markers for *pkg_source*."""
+        # Sanitize source so it cannot accidentally close the HTML comment.
+        safe_source = pkg_source.replace("-->", "__")
+        return f"<!-- apm:source:{safe_source} -->\n{body}\n<!-- /apm:source -->"
+
+    @classmethod
+    def _update_copilot_managed(cls, existing: str, pkg_source: str, section: str) -> str:
+        """Replace or append *section* in the APM-managed file content.
+
+        If a section for *pkg_source* already exists, it is replaced in-place
+        so that the file stays ordered and does not grow on re-install.
+        Otherwise the section is appended.
+        """
+        for m in cls._APM_SOURCE_RE.finditer(existing):
+            if m.group("source") == pkg_source.replace("-->", "__"):
+                return existing[: m.start()] + section + existing[m.end() :]
+        # Not yet present: append after stripping trailing newlines.
+        return existing.rstrip("\n") + "\n\n" + section + "\n"
 
     def _integrate_copilot_user_instructions(
         self,
@@ -230,20 +270,36 @@ class InstructionIntegrator(BaseIntegrator):
         force: bool = False,
         managed_files: set[str] | None = None,
         diagnostics=None,
+        pkg_source: str | None = None,
     ) -> IntegrationResult:
         """Concatenate all instruction files into ~/.copilot/copilot-instructions.md.
 
         Copilot CLI at user scope reads a single file rather than individual
         ``*.instructions.md`` files.  This method strips YAML frontmatter from
-        each source file and joins the bodies with a blank-line separator.
+        each source file, wraps the combined body in a per-package provenance
+        marker, and accumulates sections across packages in the same file so
+        that multi-package installs are fully represented.
+
+        File ownership logic:
+        - APM-managed (starts with ``_APM_COPILOT_HEADER``): always update --
+          either replace this package's existing section or append a new one.
+          This path is taken even when the file is not in *managed_files*,
+          allowing a second package in the same install session to contribute
+          without a false collision.
+        - In *managed_files* but no header (pre-provenance format): upgrade to
+          the sectioned format in-place.
+        - User-authored (no header, not in *managed_files*, not *force*):
+          collision -- skip and warn.
+        - *force* is True: overwrite any existing content.
         """
         target_path = deploy_dir / "copilot-instructions.md"
+        ensure_path_within(target_path, deploy_dir)
         rel_path = portable_relpath(target_path, project_root)
 
         bodies: list[str] = []
         for source_file in instruction_files:
-            content = source_file.read_text(encoding="utf-8")
-            body = self._strip_frontmatter(content).strip()
+            raw = source_file.read_text(encoding="utf-8")
+            body = self._strip_frontmatter(raw).strip()
             if body:
                 bodies.append(body)
 
@@ -251,22 +307,32 @@ class InstructionIntegrator(BaseIntegrator):
             return IntegrationResult(0, 0, 0, [])
 
         deploy_dir.mkdir(parents=True, exist_ok=True)
-        combined = "\n\n".join(bodies) + "\n"
+        combined_body = "\n\n".join(bodies)
+        section = self._build_copilot_section(pkg_source or "unknown", combined_body)
 
-        # Byte-identity check is not applicable for multi-source concat;
-        # go directly to collision detection.
-        if self.check_collision(
-            target_path, rel_path, managed_files, force, diagnostics=diagnostics
-        ):
+        if target_path.exists():
+            existing = target_path.read_text(encoding="utf-8")
+            if self._is_apm_managed_copilot(existing):
+                # APM-managed: update or append this package's provenance section.
+                updated = self._update_copilot_managed(existing, pkg_source or "unknown", section)
+                target_path.write_text(updated, encoding="utf-8")
+                return IntegrationResult(1, 0, 0, [target_path])
+            norm_rel = rel_path.replace("\\", "/")
+            if norm_rel in (managed_files or set()) or force:
+                # Either was managed on a previous run (pre-provenance format)
+                # or caller explicitly requested overwrite.
+                new_content = self._APM_COPILOT_HEADER + "\n" + section + "\n"
+                target_path.write_text(new_content, encoding="utf-8")
+                return IntegrationResult(1, 0, 0, [target_path])
+            # User-authored file: emit collision warning and skip.
+            self.check_collision(
+                target_path, rel_path, managed_files, force, diagnostics=diagnostics
+            )
             return IntegrationResult(0, 0, 1, [])
 
-        target_path.write_text(combined, encoding="utf-8")
-        return IntegrationResult(
-            files_integrated=1,
-            files_updated=0,
-            files_skipped=0,
-            target_paths=[target_path],
-        )
+        new_content = self._APM_COPILOT_HEADER + "\n" + section + "\n"
+        target_path.write_text(new_content, encoding="utf-8")
+        return IntegrationResult(1, 0, 0, [target_path])
 
     # ------------------------------------------------------------------
     # Legacy per-target API (DEPRECATED)

--- a/src/apm_cli/integration/targets.py
+++ b/src/apm_cli/integration/targets.py
@@ -95,6 +95,21 @@ class TargetProfile:
     """Primitives that are **not** available at user scope even when the
     target itself is partially supported."""
 
+    user_primitive_overrides: dict[str, PrimitiveMapping] | None = None
+    """Primitive mapping overrides applied at user scope only.
+
+    When set, these entries replace the corresponding entries in
+    ``primitives`` after ``unsupported_user_primitives`` filtering in
+    ``for_scope(user_scope=True)``.
+
+    Use this when a primitive must be deployed to a *different* location
+    or via a *different* transform at user scope.  The canonical example
+    is the Copilot target: at project scope each ``*.instructions.md``
+    file deploys individually to ``.github/instructions/``; at user scope
+    they are all concatenated into the single file that Copilot CLI reads
+    (``~/.copilot/copilot-instructions.md``).
+    """
+
     user_root_resolver: Callable[[], Path | None] | None = None  # noqa: F821
     """Optional callable that resolves the deploy root at runtime.
 
@@ -340,6 +355,11 @@ class TargetProfile:
         else:
             filtered = self.primitives
 
+        if self.user_primitive_overrides:
+            merged = dict(filtered)
+            merged.update(self.user_primitive_overrides)
+            filtered = merged
+
         return replace(self, root_dir=new_root, primitives=filtered)
 
 
@@ -367,7 +387,9 @@ RUNTIME_TO_CANONICAL_TARGET: dict[str, str] = {
 
 KNOWN_TARGETS: dict[str, TargetProfile] = {
     # Copilot (GitHub) -- at user scope, Copilot CLI reads ~/.copilot/
-    # instead of ~/.github/.  Instructions are not supported at user scope.
+    # instead of ~/.github/.  Instructions are concatenated into
+    # ~/.copilot/copilot-instructions.md because Copilot CLI reads only
+    # that single file at user scope (not individual *.instructions.md).
     # Ref: https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/create-custom-agents-for-cli
     "copilot": TargetProfile(
         name="copilot",
@@ -390,7 +412,10 @@ KNOWN_TARGETS: dict[str, TargetProfile] = {
         detect_by_dir=True,
         user_supported="partial",
         user_root_dir=".copilot",
-        unsupported_user_primitives=("instructions",),
+        unsupported_user_primitives=(),
+        user_primitive_overrides={
+            "instructions": PrimitiveMapping("", ".md", "copilot_user_instructions"),
+        },
         generated_files=("copilot-instructions.md",),
         compile_family="vscode",
     ),

--- a/src/apm_cli/integration/targets.py
+++ b/src/apm_cli/integration/targets.py
@@ -306,6 +306,10 @@ class TargetProfile:
                 }
             else:
                 filtered = self.primitives
+            if self.user_primitive_overrides:
+                merged = dict(filtered)
+                merged.update(self.user_primitive_overrides)
+                filtered = merged
             return replace(
                 self,
                 primitives=filtered,

--- a/tests/unit/core/test_scope.py
+++ b/tests/unit/core/test_scope.py
@@ -201,7 +201,8 @@ class TestTargetProfileUserScope:
         assert KNOWN_TARGETS["claude"].user_root_dir is None
 
     def test_copilot_unsupported_user_primitives(self):
-        assert "instructions" in KNOWN_TARGETS["copilot"].unsupported_user_primitives
+        # Instructions are now supported at user scope via concat (#650).
+        assert "instructions" not in KNOWN_TARGETS["copilot"].unsupported_user_primitives
 
     def test_effective_root_project_scope(self):
         assert KNOWN_TARGETS["copilot"].effective_root(user_scope=False) == ".github"
@@ -217,10 +218,11 @@ class TestTargetProfileUserScope:
         assert KNOWN_TARGETS["claude"].supports_at_user_scope("commands") is True
 
     def test_supports_at_user_scope_partial(self):
-        # Copilot supports agents and prompts at user scope but not instructions.
+        # Copilot supports agents, prompts, and instructions at user scope.
+        # Instructions are concatenated into copilot-instructions.md (#650).
         assert KNOWN_TARGETS["copilot"].supports_at_user_scope("agents") is True
         assert KNOWN_TARGETS["copilot"].supports_at_user_scope("prompts") is True
-        assert KNOWN_TARGETS["copilot"].supports_at_user_scope("instructions") is False
+        assert KNOWN_TARGETS["copilot"].supports_at_user_scope("instructions") is True
 
     def test_supports_at_user_scope_cursor_partial(self):
         # Cursor supports agents at user scope but not instructions
@@ -294,8 +296,8 @@ class TestScopeWarnings:
 
     def test_warn_message_includes_unsupported_primitives(self):
         msg = warn_unsupported_user_scope()
-        # Copilot excludes instructions.
-        assert "copilot (instructions)" in msg
+        # Copilot now supports instructions at user scope (#650); not in warning.
+        assert "copilot (instructions)" not in msg
         # Cursor excludes instructions
         assert "cursor (instructions)" in msg
         # OpenCode excludes hooks

--- a/tests/unit/install/test_install_copilot_user_instructions.py
+++ b/tests/unit/install/test_install_copilot_user_instructions.py
@@ -1,0 +1,223 @@
+"""Acceptance tests for 'apm install -g' copilot user-scope instructions.
+
+Issue #650: apm install -g should write instruction primitives to
+~/.copilot/copilot-instructions.md by concatenating all instruction files
+from the package, since Copilot CLI reads a single file at user scope
+instead of individual *.instructions.md files.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from apm_cli.integration.base_integrator import IntegrationResult
+from apm_cli.integration.instruction_integrator import InstructionIntegrator
+from apm_cli.integration.targets import KNOWN_TARGETS
+from apm_cli.models.apm_package import APMPackage, GitReferenceType, PackageInfo, ResolvedReference
+
+
+def _make_package_info(package_dir: Path, name: str = "test-pkg") -> PackageInfo:
+    package = APMPackage(
+        name=name,
+        version="1.0.0",
+        package_path=package_dir,
+        source=f"github.com/test/{name}",
+    )
+    resolved_ref = ResolvedReference(
+        original_ref="main",
+        ref_type=GitReferenceType.BRANCH,
+        resolved_commit="abc123",
+        ref_name="main",
+    )
+    return PackageInfo(
+        package=package,
+        install_path=package_dir,
+        resolved_reference=resolved_ref,
+        installed_at=datetime.now().isoformat(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Target profile: user-scope copilot
+# ---------------------------------------------------------------------------
+
+
+class TestCopilotUserScopeTargetProfile:
+    """Copilot target must support instructions at user scope after #650."""
+
+    def test_instructions_supported_at_user_scope(self):
+        """instructions must NOT be listed in unsupported_user_primitives."""
+        copilot = KNOWN_TARGETS["copilot"]
+        assert "instructions" not in copilot.unsupported_user_primitives
+
+    def test_supports_at_user_scope_instructions_true(self):
+        """supports_at_user_scope('instructions') must be True for copilot."""
+        copilot = KNOWN_TARGETS["copilot"]
+        assert copilot.supports_at_user_scope("instructions") is True
+
+    def test_for_scope_user_instructions_uses_concat_format(self):
+        """for_scope(user_scope=True) must map instructions to copilot_user_instructions."""
+        copilot = KNOWN_TARGETS["copilot"]
+        user_profile = copilot.for_scope(user_scope=True)
+        assert user_profile is not None
+        mapping = user_profile.primitives.get("instructions")
+        assert mapping is not None
+        assert mapping.format_id == "copilot_user_instructions"
+
+    def test_for_scope_user_root_is_copilot_dir(self):
+        """User-scope profile must have root_dir == '.copilot'."""
+        copilot = KNOWN_TARGETS["copilot"]
+        user_profile = copilot.for_scope(user_scope=True)
+        assert user_profile is not None
+        assert user_profile.root_dir == ".copilot"
+
+
+# ---------------------------------------------------------------------------
+# Integration: instruction files -> ~/.copilot/copilot-instructions.md
+# ---------------------------------------------------------------------------
+
+
+class TestCopilotUserInstructionsIntegration:
+    """InstructionIntegrator must concatenate files into copilot-instructions.md."""
+
+    def setup_method(self):
+        import tempfile
+
+        self.temp_dir = tempfile.mkdtemp()
+        self.home = Path(self.temp_dir)
+        self.integrator = InstructionIntegrator()
+
+    def teardown_method(self):
+        import shutil
+
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _make_pkg(self, instructions: dict[str, str]) -> PackageInfo:
+        """Create a package directory with given instruction files."""
+        pkg_dir = self.home / "pkg"
+        inst_dir = pkg_dir / ".apm" / "instructions"
+        inst_dir.mkdir(parents=True, exist_ok=True)
+        for fname, content in instructions.items():
+            (inst_dir / fname).write_text(content, encoding="utf-8")
+        return _make_package_info(pkg_dir)
+
+    def test_single_instruction_file_written_to_copilot_instructions_md(self):
+        """A single instruction file is written to ~/.copilot/copilot-instructions.md."""
+        pkg_info = self._make_pkg(
+            {
+                "coding.instructions.md": (
+                    "---\napplyTo: '**/*.py'\n---\n\n# Coding standards\n\nUse type hints.\n"
+                ),
+            }
+        )
+        copilot = KNOWN_TARGETS["copilot"]
+        user_profile = copilot.for_scope(user_scope=True)
+
+        result = self.integrator.integrate_instructions_for_target(
+            user_profile,
+            pkg_info,
+            self.home,
+        )
+
+        out_file = self.home / ".copilot" / "copilot-instructions.md"
+        assert out_file.exists(), "copilot-instructions.md must be created"
+        content = out_file.read_text(encoding="utf-8")
+        assert "# Coding standards" in content
+        assert "Use type hints." in content
+        assert isinstance(result, IntegrationResult)
+        assert result.files_integrated == 1
+
+    def test_multiple_instruction_files_concatenated(self):
+        """Multiple instruction files are concatenated into a single output file."""
+        pkg_info = self._make_pkg(
+            {
+                "coding.instructions.md": (
+                    "---\napplyTo: '**/*.py'\n---\n\n# Python coding\n\nUse type hints.\n"
+                ),
+                "security.instructions.md": (
+                    "---\ndescription: Security rules\n---\n\n# Security\n\nSanitize inputs.\n"
+                ),
+            }
+        )
+        copilot = KNOWN_TARGETS["copilot"]
+        user_profile = copilot.for_scope(user_scope=True)
+
+        self.integrator.integrate_instructions_for_target(
+            user_profile,
+            pkg_info,
+            self.home,
+        )
+
+        out_file = self.home / ".copilot" / "copilot-instructions.md"
+        content = out_file.read_text(encoding="utf-8")
+        assert "# Python coding" in content
+        assert "Use type hints." in content
+        assert "# Security" in content
+        assert "Sanitize inputs." in content
+
+    def test_frontmatter_stripped_from_output(self):
+        """YAML frontmatter must not appear in the concatenated output."""
+        pkg_info = self._make_pkg(
+            {
+                "coding.instructions.md": (
+                    "---\napplyTo: '**/*.py'\ndescription: Python guide\n---\n\n"
+                    "# Python coding\n\nUse type hints.\n"
+                ),
+            }
+        )
+        copilot = KNOWN_TARGETS["copilot"]
+        user_profile = copilot.for_scope(user_scope=True)
+
+        self.integrator.integrate_instructions_for_target(
+            user_profile,
+            pkg_info,
+            self.home,
+        )
+
+        out_file = self.home / ".copilot" / "copilot-instructions.md"
+        content = out_file.read_text(encoding="utf-8")
+        assert "applyTo:" not in content
+        assert "description: Python guide" not in content
+        assert "---" not in content
+
+    def test_no_instructions_returns_zero_integrated(self):
+        """No instruction files in package -> zero files integrated, no output."""
+        pkg_dir = self.home / "empty-pkg"
+        pkg_dir.mkdir(parents=True, exist_ok=True)
+        pkg_info = _make_package_info(pkg_dir)
+
+        copilot = KNOWN_TARGETS["copilot"]
+        user_profile = copilot.for_scope(user_scope=True)
+
+        result = self.integrator.integrate_instructions_for_target(
+            user_profile,
+            pkg_info,
+            self.home,
+        )
+
+        out_file = self.home / ".copilot" / "copilot-instructions.md"
+        assert not out_file.exists()
+        assert result.files_integrated == 0
+
+    def test_project_scope_unaffected(self):
+        """Project-scope integration still deploys individual .instructions.md files."""
+        pkg_info = self._make_pkg(
+            {
+                "coding.instructions.md": "---\n---\n\n# Coding\n",
+            }
+        )
+        copilot = KNOWN_TARGETS["copilot"]
+        project_root = self.home / "project"
+        (project_root / ".github" / "instructions").mkdir(parents=True, exist_ok=True)
+
+        result = self.integrator.integrate_instructions_for_target(
+            copilot,
+            pkg_info,
+            project_root,
+        )
+
+        assert result.files_integrated == 1
+        deployed = result.target_paths[0]
+        assert deployed.name == "coding.instructions.md"
+        assert ".copilot" not in str(deployed)

--- a/tests/unit/install/test_install_copilot_user_instructions.py
+++ b/tests/unit/install/test_install_copilot_user_instructions.py
@@ -200,6 +200,48 @@ class TestCopilotUserInstructionsIntegration:
         assert not out_file.exists()
         assert result.files_integrated == 0
 
+    def test_multi_package_instructions_all_concatenated(self):
+        """Instructions from two packages must both appear in copilot-instructions.md.
+
+        Regression test for the multi-package collision bug: the second package's
+        instructions must not be silently dropped because the file already exists
+        after the first package's integration.
+        """
+        pkg_a_dir = self.home / "pkg-a"
+        (pkg_a_dir / ".apm" / "instructions").mkdir(parents=True, exist_ok=True)
+        (pkg_a_dir / ".apm" / "instructions" / "a.instructions.md").write_text(
+            "# Package A\n\nAlways use type hints.\n", encoding="utf-8"
+        )
+        pkg_a = _make_package_info(pkg_a_dir, name="pkg-a")
+
+        pkg_b_dir = self.home / "pkg-b"
+        (pkg_b_dir / ".apm" / "instructions").mkdir(parents=True, exist_ok=True)
+        (pkg_b_dir / ".apm" / "instructions" / "b.instructions.md").write_text(
+            "# Package B\n\nAlways sanitize inputs.\n", encoding="utf-8"
+        )
+        pkg_b = _make_package_info(pkg_b_dir, name="pkg-b")
+
+        copilot = KNOWN_TARGETS["copilot"]
+        user_profile = copilot.for_scope(user_scope=True)
+
+        self.integrator.integrate_instructions_for_target(user_profile, pkg_a, self.home)
+        self.integrator.integrate_instructions_for_target(user_profile, pkg_b, self.home)
+
+        out_file = self.home / ".copilot" / "copilot-instructions.md"
+        content = out_file.read_text(encoding="utf-8")
+        assert "# Package A" in content, "Package A instructions must be present"
+        assert "Always use type hints." in content
+        assert "# Package B" in content, "Package B instructions must be present"
+        assert "Always sanitize inputs." in content
+
+    def test_strip_frontmatter_strips_crlf_line_endings(self):
+        """_strip_frontmatter must handle Windows CRLF line endings."""
+        crlf_content = "---\r\napplyTo: '**'\r\n---\r\n\r\n# Body content\r\n"
+        result = InstructionIntegrator._strip_frontmatter(crlf_content)
+        assert "# Body content" in result
+        assert "applyTo:" not in result
+        assert "---" not in result
+
     def test_project_scope_unaffected(self):
         """Project-scope integration still deploys individual .instructions.md files."""
         pkg_info = self._make_pkg(

--- a/tests/unit/integration/test_data_driven_dispatch.py
+++ b/tests/unit/integration/test_data_driven_dispatch.py
@@ -731,7 +731,7 @@ class TestForScope:
         assert resolved.root_dir == ".claude"
 
     def test_filters_unsupported_primitives(self):
-        """for_scope removes only unsupported primitives from the dict."""
+        """for_scope keeps instructions with a different mapping for copilot user scope."""
         from apm_cli.integration.targets import KNOWN_TARGETS
 
         copilot = KNOWN_TARGETS["copilot"]
@@ -739,7 +739,9 @@ class TestForScope:
         assert "instructions" in copilot.primitives
         resolved = copilot.for_scope(user_scope=True)
         assert "prompts" in resolved.primitives
-        assert "instructions" not in resolved.primitives
+        # instructions now supported at user scope via concat (#650)
+        assert "instructions" in resolved.primitives
+        assert resolved.primitives["instructions"].format_id == "copilot_user_instructions"
         # Supported primitives remain
         assert "agents" in resolved.primitives
         assert "skills" in resolved.primitives

--- a/tests/unit/integration/test_scope_install_uninstall.py
+++ b/tests/unit/integration/test_scope_install_uninstall.py
@@ -203,11 +203,13 @@ class TestCopilotInstallUninstallCycle:
             assert not (self.project_root / p).exists(), f"not removed: {p}"
 
     def test_user_scope(self):
-        """At user scope, agents and prompts deploy to .copilot/; instructions filtered."""
+        """At user scope, agents and prompts deploy to .copilot/; instructions concat."""
         target = KNOWN_TARGETS["copilot"].for_scope(user_scope=True)
         assert target is not None
         assert target.root_dir == ".copilot"
-        assert "instructions" not in target.primitives
+        # Instructions supported at user scope via concat (#650)
+        assert "instructions" in target.primitives
+        assert target.primitives["instructions"].format_id == "copilot_user_instructions"
 
         pkg_info = _make_pkg(self.project_root, instructions=True, agents=True, prompts=True)
 
@@ -219,7 +221,7 @@ class TestCopilotInstallUninstallCycle:
         agent_result = agent_integrator.integrate_agents_for_target(
             target, pkg_info, self.project_root
         )
-        # instructions should be no-op because primitive not in target
+        # instructions now deploy as a single concat file
         inst_result = inst_integrator.integrate_instructions_for_target(
             target, pkg_info, self.project_root
         )
@@ -228,18 +230,22 @@ class TestCopilotInstallUninstallCycle:
         )
 
         assert agent_result.files_integrated >= 1
-        assert inst_result.files_integrated == 0
+        assert inst_result.files_integrated == 1
         assert prompt_result.files_integrated >= 1
 
-        all_paths = agent_result.target_paths + prompt_result.target_paths
+        all_paths = (
+            agent_result.target_paths + inst_result.target_paths + prompt_result.target_paths
+        )
         deployed = _posix_relpaths(self.project_root, all_paths)
         assert any(p.startswith(".copilot/agents/") for p in deployed)
         assert any(p == ".copilot/prompts/helper.prompt.md" for p in deployed)
+        assert ".copilot/copilot-instructions.md" in deployed
 
         for p in deployed:
             assert (self.project_root / p).exists()
 
         assert (self.project_root / ".copilot" / "prompts" / "helper.prompt.md").exists()
+        assert (self.project_root / ".copilot" / "copilot-instructions.md").exists()
 
         # .github/ must NOT be touched
         assert not (self.project_root / ".github").exists()
@@ -248,12 +254,19 @@ class TestCopilotInstallUninstallCycle:
         agent_sync = agent_integrator.sync_for_target(
             target, pkg_info.package, self.project_root, managed_files=deployed
         )
+        inst_sync = inst_integrator.sync_for_target(
+            target, pkg_info.package, self.project_root, managed_files=deployed
+        )
         prompt_sync = prompt_integrator.sync_for_target(
             target, pkg_info.package, self.project_root, managed_files=deployed
         )
         assert agent_sync["errors"] == 0
+        assert inst_sync["errors"] == 0
         assert prompt_sync["errors"] == 0
-        assert agent_sync["files_removed"] + prompt_sync["files_removed"] == len(deployed)
+        total_removed = (
+            agent_sync["files_removed"] + inst_sync["files_removed"] + prompt_sync["files_removed"]
+        )
+        assert total_removed == len(deployed)
         for p in deployed:
             assert not (self.project_root / p).exists()
 

--- a/tests/unit/integration/test_scope_integration.py
+++ b/tests/unit/integration/test_scope_integration.py
@@ -105,11 +105,13 @@ class TestCopilotScopeResolution:
         assert not (self.project_root / ".copilot").exists()
 
     def test_user_scope_deploys_to_copilot(self):
-        """At user scope, instructions are filtered out (unsupported)."""
+        """At user scope, instructions use concat format (not filtered)."""
         copilot = KNOWN_TARGETS["copilot"]
         resolved = copilot.for_scope(user_scope=True)
         assert resolved.root_dir == ".copilot"
-        assert "instructions" not in resolved.primitives
+        # instructions now supported at user scope via concat (#650)
+        assert "instructions" in resolved.primitives
+        assert resolved.primitives["instructions"].format_id == "copilot_user_instructions"
 
     def test_user_scope_agents_deploy_to_copilot(self):
         """At user scope, agents deploy to .copilot/agents/."""
@@ -317,7 +319,9 @@ class TestResolveTargetsConsistency:
             for t in targets:
                 if t.name == "copilot":
                     assert "prompts" in t.primitives
-                    assert "instructions" not in t.primitives
+                    # instructions now supported via concat (#650)
+                    assert "instructions" in t.primitives
+                    assert t.primitives["instructions"].format_id == "copilot_user_instructions"
                 if t.name == "cursor":
                     assert "instructions" not in t.primitives
                 if t.name == "opencode":


### PR DESCRIPTION
Fixes #650.

## TL;DR

`apm install -g` now deploys instruction primitives for the Copilot target by concatenating all `*.instructions.md` files into `~/.copilot/copilot-instructions.md` -- the single file Copilot CLI reads at user scope.

## Problem (WHY)

Copilot CLI reads only `~/.copilot/copilot-instructions.md` at user scope, not individual files in a subdirectory. The copilot target had `"instructions"` in `unsupported_user_primitives`, so `apm install -g` silently skipped instruction primitives for Copilot users entirely.

## Approach (WHAT)

Rather than special-casing the copilot target in imperative code, the fix extends the data-driven `TargetProfile` architecture:

1. A new `user_primitive_overrides: dict[str, PrimitiveMapping] | None` field lets targets swap a primitive's mapping at user scope.
2. `for_scope(user_scope=True)` applies overrides after the `unsupported_user_primitives` filter.
3. A new `format_id = "copilot_user_instructions"` triggers a concat transform instead of per-file deploy.

## Changes

- `targets.py`: add `user_primitive_overrides` to `TargetProfile`, apply in `for_scope()`, update copilot entry
- `instruction_integrator.py`: new `_integrate_copilot_user_instructions()` concat method; `sync_for_target()` handles single output file cleanup
- Tests: 9 new acceptance tests + 4 existing tests updated
- Docs: `targets-matrix.md` updated

## Validation

All 15904 unit tests pass. Full lint chain clean (ruff + pylint R0801 + auth-signal).