### PR TITLE
chore: audit F401 noqa suppressions -- remove dead imports, document re-exports

### DIFF
--- a/src/apm_cli/adapters/client/vscode.py
+++ b/src/apm_cli/adapters/client/vscode.py
@@ -6,7 +6,6 @@ https://code.visualstudio.com/docs/copilot/chat/mcp-servers
 """
 
 import json
-import os  # noqa: F401
 import re
 from pathlib import Path
 

--- a/src/apm_cli/bundle/lockfile_enrichment.py
+++ b/src/apm_cli/bundle/lockfile_enrichment.py
@@ -2,7 +2,6 @@
 
 import posixpath
 from datetime import datetime, timezone
-from typing import Dict, List, Tuple, Union  # noqa: F401, UP035
 
 from ..deps.lockfile import LockFile
 from ..integration.targets import KNOWN_TARGETS

--- a/src/apm_cli/bundle/packer.py
+++ b/src/apm_cli/bundle/packer.py
@@ -1,11 +1,9 @@
 """Bundle packer  -- creates self-contained APM bundles from the resolved dependency tree."""
 
-import os  # noqa: F401
 import shutil
 import tarfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional, Union  # noqa: F401, UP035
 
 from ..core.target_detection import detect_target
 from ..deps.lockfile import LockFile, get_lockfile_path, migrate_lockfile_if_needed

--- a/src/apm_cli/bundle/plugin_exporter.py
+++ b/src/apm_cli/bundle/plugin_exporter.py
@@ -9,12 +9,10 @@ under ``pack.bundle_files`` (issue #1098).
 
 import hashlib
 import json
-import os  # noqa: F401
 import re
 import shutil
 import tarfile
 from pathlib import Path, PurePosixPath
-from typing import Dict, List, Optional, Set, Tuple  # noqa: F401, UP035
 
 import yaml
 

--- a/src/apm_cli/bundle/unpacker.py
+++ b/src/apm_cli/bundle/unpacker.py
@@ -6,7 +6,6 @@ import tarfile
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path, PureWindowsPath
-from typing import Dict, List  # noqa: F401, UP035
 
 from ..deps.lockfile import LEGACY_LOCKFILE_NAME, LOCKFILE_NAME, LockFile
 from ..utils.path_security import PathTraversalError, validate_path_segments

--- a/src/apm_cli/commands/_apm_yml_writer.py
+++ b/src/apm_cli/commands/_apm_yml_writer.py
@@ -6,7 +6,6 @@ field.  Keeps write-back logic isolated and unit-testable.
 """
 
 from pathlib import Path
-from typing import List, Optional  # noqa: F401, UP035
 
 from ..models.dependency.reference import DependencyReference
 from ..utils.yaml_io import dump_yaml, load_yaml

--- a/src/apm_cli/commands/_helpers.py
+++ b/src/apm_cli/commands/_helpers.py
@@ -14,14 +14,15 @@ from colorama import Fore, Style
 from colorama import init as colorama_init
 
 from ..constants import (
-    APM_LOCK_FILENAME,  # noqa: F401
     APM_MODULES_DIR,
     APM_MODULES_GITIGNORE_PATTERN,
     APM_YML_FILENAME,
     GITIGNORE_FILENAME,
 )
 from ..update_policy import get_update_hint_message, is_self_update_enabled
-from ..utils.atomic_io import atomic_write_text as _atomic_write  # noqa: F401
+from ..utils.atomic_io import (
+    atomic_write_text as _atomic_write,  # noqa: F401 -- re-exported; tests import from apm_cli.commands._helpers
+)
 from ..utils.console import _rich_echo, _rich_info, _rich_warning
 from ..utils.path_security import PathTraversalError, validate_path_segments
 from ..utils.version_checker import check_for_updates

--- a/src/apm_cli/commands/audit.py
+++ b/src/apm_cli/commands/audit.py
@@ -14,7 +14,6 @@ Exit codes:
 import dataclasses
 import sys
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple  # noqa: F401, UP035
 
 import click
 
@@ -29,7 +28,6 @@ from ..utils.console import (
     _rich_echo,
     _rich_error,
     _rich_success,
-    _rich_warning,  # noqa: F401
 )
 
 # -- Shared config --------------------------------------------------
@@ -333,7 +331,6 @@ def _preview_strip(
 
 def _render_ci_results(ci_result: "CIAuditResult") -> None:
     """Render CI check results as a Rich table (text format)."""
-    from ..policy.models import CIAuditResult  # noqa: F401
 
     console = _get_console()
 

--- a/src/apm_cli/commands/deps/_utils.py
+++ b/src/apm_cli/commands/deps/_utils.py
@@ -1,7 +1,7 @@
 """Utility helpers for APM dependency commands."""
 
 from pathlib import Path
-from typing import Any, Dict  # noqa: F401, UP035
+from typing import Any
 
 from ...constants import APM_DIR, APM_YML_FILENAME, SKILL_MD_FILENAME
 from ...models.apm_package import APMPackage

--- a/src/apm_cli/commands/deps/cli.py
+++ b/src/apm_cli/commands/deps/cli.py
@@ -10,7 +10,7 @@ import click
 from ...constants import APM_MODULES_DIR, APM_YML_FILENAME, SKILL_MD_FILENAME
 from ...core.command_logger import CommandLogger
 from ...core.target_detection import TargetParamType
-from ...models.apm_package import APMPackage, ValidationResult, validate_apm_package  # noqa: F401
+from ...models.apm_package import APMPackage
 from .._helpers import (
     UnknownPackageError,
     _expand_with_ancestors,

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -33,12 +33,12 @@ from apm_cli.install.insecure_policy import (
     InsecureDependencyPolicyError,
     _allow_insecure_host_callback,
     _check_insecure_dependencies,
-    _collect_insecure_dependency_infos,  # noqa: F401
+    _collect_insecure_dependency_infos,  # noqa: F401 -- re-exported; test_architecture_invariants checks importability
     _format_insecure_dependency_requirements,
-    _format_insecure_dependency_warning,  # noqa: F401
+    _format_insecure_dependency_warning,  # noqa: F401 -- re-exported; test_architecture_invariants checks importability
     _get_insecure_dependency_url,
-    _guard_transitive_insecure_dependencies,  # noqa: F401
-    _InsecureDependencyInfo,  # noqa: F401
+    _guard_transitive_insecure_dependencies,  # noqa: F401 -- re-exported; test_architecture_invariants checks importability
+    _InsecureDependencyInfo,  # noqa: F401 -- re-exported; test_architecture_invariants checks importability
 )
 
 # Re-export MCP add/build helpers under their underscore-prefixed legacy
@@ -59,8 +59,8 @@ from apm_cli.install.package_selection import only_packages_from_validation
 # (e.g. _install_apm_dependencies) and any future test patches against
 # "apm_cli.commands.install._copy_local_package" keep working.
 from apm_cli.install.phases.local_content import (
-    _copy_local_package,  # noqa: F401
-    _has_local_apm_content,  # noqa: F401
+    _copy_local_package,  # noqa: F401 -- re-exported; test_architecture_invariants checks importability
+    _has_local_apm_content,  # noqa: F401 -- re-exported; test_architecture_invariants checks importability
     _project_has_root_primitives,
 )
 
@@ -72,8 +72,8 @@ from apm_cli.install.phases.lockfile import compute_deployed_hashes as _hash_dep
 # Re-export DI-seam helpers from the install services module so that test
 # patches against ``apm_cli.commands.install._integrate_*`` keep working.
 from apm_cli.install.services import (
-    _integrate_local_content,  # noqa: F401
-    _integrate_package_primitives,  # noqa: F401
+    _integrate_local_content,  # noqa: F401 -- re-exported; test_architecture_invariants checks importability
+    _integrate_package_primitives,  # noqa: F401 -- re-exported; tests import/patch from apm_cli.commands.install
 )
 
 # Re-export validation leaf helpers so that existing test patches like
@@ -84,7 +84,7 @@ from apm_cli.install.services import (
 # intercepts those calls without test changes.
 from apm_cli.install.validation import (
     _local_path_failure_reason,
-    _local_path_no_markers_hint,  # noqa: F401
+    _local_path_no_markers_hint,  # noqa: F401 -- re-exported; test_architecture_invariants checks importability
     _validate_package_exists,
 )
 from apm_cli.utils.diagnostics import DiagnosticCollector  # noqa: F401
@@ -112,11 +112,15 @@ from ..install.mcp.registry import (
 from ..install.mcp.registry import (
     validate_registry_url as _validate_registry_url,
 )
-from ..utils.console import _rich_echo, _rich_error, _rich_info, _rich_success  # noqa: F401
+from ..utils.console import (  # noqa: F401 -- _rich_success re-exported; tests patch commands.install._rich_success
+    _rich_echo,
+    _rich_error,
+    _rich_info,
+    _rich_success,
+)
 from ._helpers import (
     _create_minimal_apm_yml,
     _get_default_config,
-    _update_gitignore_for_apm_modules,  # noqa: F401
 )
 
 # ---------------------------------------------------------------------------
@@ -273,9 +277,7 @@ APM_DEPS_AVAILABLE = False
 _APM_IMPORT_ERROR = None
 try:
     from ..deps.apm_resolver import APMDependencyResolver
-    from ..deps.github_downloader import GitHubPackageDownloader  # noqa: F401
     from ..deps.lockfile import LockFile, get_lockfile_path, migrate_lockfile_if_needed
-    from ..integration import AgentIntegrator, PromptIntegrator  # noqa: F401
     from ..integration.mcp_integrator import MCPIntegrator
     from ..models.apm_package import APMPackage, DependencyReference
 

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -28,7 +28,9 @@ if TYPE_CHECKING:
 # this module and ``tests/unit/test_install_scanning.py``'s direct import
 # (``from apm_cli.commands.install import _pre_deploy_security_scan``) keep
 # working without modification.
-from apm_cli.install.helpers.security_scan import _pre_deploy_security_scan  # noqa: F401
+from apm_cli.install.helpers.security_scan import (
+    _pre_deploy_security_scan,  # noqa: F401 -- re-exported; test_install_scanning.py imports directly from apm_cli.commands.install
+)
 from apm_cli.install.insecure_policy import (
     InsecureDependencyPolicyError,
     _allow_insecure_host_callback,
@@ -43,8 +45,12 @@ from apm_cli.install.insecure_policy import (
 
 # Re-export MCP add/build helpers under their underscore-prefixed legacy
 # names. Aliases live in mcp/writer.py and mcp/entry.py respectively.
-from apm_cli.install.mcp.entry import _build_mcp_entry  # noqa: F401
-from apm_cli.install.mcp.writer import _add_mcp_to_apm_yml  # noqa: F401
+from apm_cli.install.mcp.entry import (
+    _build_mcp_entry,  # noqa: F401 -- re-exported; legacy call sites import from apm_cli.commands.install
+)
+from apm_cli.install.mcp.writer import (
+    _add_mcp_to_apm_yml,  # noqa: F401 -- re-exported; legacy call sites import from apm_cli.commands.install
+)
 from apm_cli.install.package_resolution import (
     GIT_PARENT_USER_SCOPE_ERROR,
     dependency_reference_to_yaml_entry,
@@ -67,7 +73,9 @@ from apm_cli.install.phases.local_content import (
 # Re-export lockfile hash helper so existing call sites and the regression
 # test pinned in #762 (test_hash_deployed_is_module_level_and_works) keep
 # working via "apm_cli.commands.install._hash_deployed".
-from apm_cli.install.phases.lockfile import compute_deployed_hashes as _hash_deployed  # noqa: F401
+from apm_cli.install.phases.lockfile import (
+    compute_deployed_hashes as _hash_deployed,  # noqa: F401 -- re-exported; test_hash_deployed_is_module_level_and_works pins this import path
+)
 
 # Re-export DI-seam helpers from the install services module so that test
 # patches against ``apm_cli.commands.install._integrate_*`` keep working.
@@ -87,7 +95,9 @@ from apm_cli.install.validation import (
     _local_path_no_markers_hint,  # noqa: F401 -- re-exported; test_architecture_invariants checks importability
     _validate_package_exists,
 )
-from apm_cli.utils.diagnostics import DiagnosticCollector  # noqa: F401
+from apm_cli.utils.diagnostics import (
+    DiagnosticCollector,  # noqa: F401 -- re-exported; test_architecture_invariants checks importability from apm_cli.commands.install
+)
 
 from ..constants import (
     APM_YML_FILENAME,

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -28,9 +28,7 @@ if TYPE_CHECKING:
 # this module and ``tests/unit/test_install_scanning.py``'s direct import
 # (``from apm_cli.commands.install import _pre_deploy_security_scan``) keep
 # working without modification.
-from apm_cli.install.helpers.security_scan import (
-    _pre_deploy_security_scan,  # noqa: F401 -- re-exported; test_install_scanning.py imports directly from apm_cli.commands.install
-)
+from apm_cli.install.helpers.security_scan import _pre_deploy_security_scan  # noqa: F401
 from apm_cli.install.insecure_policy import (
     InsecureDependencyPolicyError,
     _allow_insecure_host_callback,
@@ -45,12 +43,8 @@ from apm_cli.install.insecure_policy import (
 
 # Re-export MCP add/build helpers under their underscore-prefixed legacy
 # names. Aliases live in mcp/writer.py and mcp/entry.py respectively.
-from apm_cli.install.mcp.entry import (
-    _build_mcp_entry,  # noqa: F401 -- re-exported; legacy call sites import from apm_cli.commands.install
-)
-from apm_cli.install.mcp.writer import (
-    _add_mcp_to_apm_yml,  # noqa: F401 -- re-exported; legacy call sites import from apm_cli.commands.install
-)
+from apm_cli.install.mcp.entry import _build_mcp_entry  # noqa: F401
+from apm_cli.install.mcp.writer import _add_mcp_to_apm_yml  # noqa: F401
 from apm_cli.install.package_resolution import (
     GIT_PARENT_USER_SCOPE_ERROR,
     dependency_reference_to_yaml_entry,
@@ -73,9 +67,7 @@ from apm_cli.install.phases.local_content import (
 # Re-export lockfile hash helper so existing call sites and the regression
 # test pinned in #762 (test_hash_deployed_is_module_level_and_works) keep
 # working via "apm_cli.commands.install._hash_deployed".
-from apm_cli.install.phases.lockfile import (
-    compute_deployed_hashes as _hash_deployed,  # noqa: F401 -- re-exported; test_hash_deployed_is_module_level_and_works pins this import path
-)
+from apm_cli.install.phases.lockfile import compute_deployed_hashes as _hash_deployed  # noqa: F401
 
 # Re-export DI-seam helpers from the install services module so that test
 # patches against ``apm_cli.commands.install._integrate_*`` keep working.
@@ -95,9 +87,7 @@ from apm_cli.install.validation import (
     _local_path_no_markers_hint,  # noqa: F401 -- re-exported; test_architecture_invariants checks importability
     _validate_package_exists,
 )
-from apm_cli.utils.diagnostics import (
-    DiagnosticCollector,  # noqa: F401 -- re-exported; test_architecture_invariants checks importability from apm_cli.commands.install
-)
+from apm_cli.utils.diagnostics import DiagnosticCollector  # noqa: F401
 
 from ..constants import (
     APM_YML_FILENAME,

--- a/src/apm_cli/commands/list_cmd.py
+++ b/src/apm_cli/commands/list_cmd.py
@@ -8,7 +8,6 @@ import click
 from ..core.command_logger import CommandLogger
 from ..utils.console import (
     STATUS_SYMBOLS,
-    _rich_echo,  # noqa: F401
     _rich_panel,
 )
 from ._helpers import HIGHLIGHT, RESET, _get_console, _list_available_scripts

--- a/src/apm_cli/commands/marketplace/__init__.py
+++ b/src/apm_cli/commands/marketplace/__init__.py
@@ -46,7 +46,6 @@ from ...marketplace.publisher import (
 from ...marketplace.ref_resolver import RefResolver, RemoteRef
 from ...marketplace.semver import SemVer, parse_semver, satisfies_range
 from ...marketplace.yml_schema import load_marketplace_yml
-from ...utils.console import _rich_info, _rich_warning  # noqa: F401
 from ...utils.path_security import PathTraversalError, validate_path_segments
 from .._helpers import _get_console, _is_interactive
 

--- a/src/apm_cli/commands/marketplace/plugin/__init__.py
+++ b/src/apm_cli/commands/marketplace/plugin/__init__.py
@@ -12,10 +12,8 @@ import yaml
 from ....core.command_logger import CommandLogger
 from ....marketplace.errors import (
     GitLsRemoteError,
-    MarketplaceYmlError,  # noqa: F401
     OfflineMissError,
 )
-from ..._helpers import _is_interactive  # noqa: F401
 
 _SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 

--- a/src/apm_cli/commands/marketplace/plugin/remove.py
+++ b/src/apm_cli/commands/marketplace/plugin/remove.py
@@ -8,9 +8,9 @@ import click
 
 from ....core.command_logger import CommandLogger
 from ....marketplace.errors import MarketplaceYmlError
+from ..._helpers import _is_interactive
 from . import (
     _ensure_yml_exists,
-    _is_interactive,
     package,
 )
 

--- a/src/apm_cli/commands/outdated.py
+++ b/src/apm_cli/commands/outdated.py
@@ -9,7 +9,6 @@ import logging
 import os
 import re
 import sys
-from typing import List  # noqa: F401, UP035
 
 import click
 

--- a/src/apm_cli/commands/policy.py
+++ b/src/apm_cli/commands/policy.py
@@ -15,14 +15,13 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Optional  # noqa: F401, UP035
+from typing import Any
 
 import click
 
 from ..core.command_logger import CommandLogger
 from ..policy._help_text import POLICY_SOURCE_FORMS_HELP
 from ..policy.discovery import (
-    DEFAULT_CACHE_TTL,  # noqa: F401
     MAX_STALE_TTL,
     PolicyFetchResult,
     _read_cache_entry,
@@ -33,7 +32,6 @@ from ..policy.schema import ApmPolicy
 from ..utils.console import (
     RICH_AVAILABLE,
     _get_console,
-    _rich_echo,  # noqa: F401
     _rich_error,
     _rich_panel,
 )

--- a/src/apm_cli/commands/prune.py
+++ b/src/apm_cli/commands/prune.py
@@ -6,13 +6,13 @@ from pathlib import Path
 
 import click
 
-from ..constants import APM_LOCK_FILENAME, APM_MODULES_DIR, APM_YML_FILENAME  # noqa: F401
+from ..constants import APM_MODULES_DIR, APM_YML_FILENAME
 from ..core.command_logger import CommandLogger
 
 # APM Dependencies
 from ..deps.lockfile import LockFile, get_lockfile_path
 from ..models.apm_package import APMPackage
-from ..utils.path_security import PathTraversalError, safe_rmtree  # noqa: F401
+from ..utils.path_security import safe_rmtree
 from ._helpers import (
     _build_expected_install_paths,
     _expand_with_ancestors,

--- a/src/apm_cli/commands/uninstall/cli.py
+++ b/src/apm_cli/commands/uninstall/cli.py
@@ -3,11 +3,10 @@
 import builtins
 import sys
 import traceback
-from pathlib import Path  # noqa: F401
 
 import click
 
-from ...constants import APM_MODULES_DIR, APM_YML_FILENAME  # noqa: F401
+from ...constants import APM_YML_FILENAME
 from ...core.command_logger import CommandLogger
 from ...models.apm_package import APMPackage
 from .engine import (

--- a/src/apm_cli/commands/uninstall/engine.py
+++ b/src/apm_cli/commands/uninstall/engine.py
@@ -3,11 +3,11 @@
 import builtins
 from pathlib import Path
 
-from ...constants import APM_MODULES_DIR, APM_YML_FILENAME  # noqa: F401
+from ...constants import APM_MODULES_DIR
 from ...core.command_logger import CommandLogger
 from ...deps.lockfile import LockFile
 from ...integration.mcp_integrator import MCPIntegrator
-from ...models.apm_package import APMPackage, DependencyReference  # noqa: F401
+from ...models.apm_package import DependencyReference
 from ...utils.path_security import PathTraversalError, safe_rmtree
 from ...utils.paths import portable_relpath
 

--- a/src/apm_cli/commands/view.py
+++ b/src/apm_cli/commands/view.py
@@ -8,7 +8,6 @@ reused by the backward-compatible ``apm deps info`` alias.
 
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Optional  # noqa: F401, UP035
 
 import click
 
@@ -17,7 +16,7 @@ from ..core.auth import AuthResolver
 from ..core.command_logger import CommandLogger
 from ..deps.github_downloader import GitHubPackageDownloader
 from ..models.dependency.reference import DependencyReference
-from ..models.dependency.types import GitReferenceType, RemoteRef  # noqa: F401
+from ..models.dependency.types import RemoteRef
 from ..utils.path_security import PathTraversalError, ensure_path_within, validate_path_segments
 from .deps._utils import _get_detailed_package_info
 

--- a/src/apm_cli/compilation/agents_compiler.py
+++ b/src/apm_cli/compilation/agents_compiler.py
@@ -9,7 +9,7 @@ import hashlib
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional  # noqa: F401, UP035
+from typing import Any, Callable  # noqa: UP035
 
 from ..core.target_detection import (
     CompileTargetType,

--- a/src/apm_cli/compilation/claude_formatter.py
+++ b/src/apm_cli/compilation/claude_formatter.py
@@ -8,7 +8,6 @@ output format specifically optimized for Claude's project memory system.
 import builtins
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional, Set  # noqa: F401, UP035
 
 from ..primitives.models import Chatmode, Instruction, PrimitiveCollection
 from ..utils.paths import resolve_base_and_source_dirs

--- a/src/apm_cli/compilation/constitution.py
+++ b/src/apm_cli/compilation/constitution.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, Optional  # noqa: F401, UP035
 
 from .constants import CONSTITUTION_RELATIVE_PATH
 

--- a/src/apm_cli/compilation/constitution_block.py
+++ b/src/apm_cli/compilation/constitution_block.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 import re
 from dataclasses import dataclass
-from typing import Optional  # noqa: F401
 
 from .constants import (
     CONSTITUTION_MARKER_BEGIN,

--- a/src/apm_cli/compilation/context_optimizer.py
+++ b/src/apm_cli/compilation/context_optimizer.py
@@ -12,9 +12,7 @@ import os
 import time
 from collections import defaultdict
 from dataclasses import dataclass, field
-from functools import lru_cache  # noqa: F401
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple  # noqa: F401, UP035
 
 from ..output.models import (
     CompilationResults,

--- a/src/apm_cli/compilation/distributed_compiler.py
+++ b/src/apm_cli/compilation/distributed_compiler.py
@@ -6,11 +6,9 @@ for nested agent context files.
 """
 
 import builtins
-import os  # noqa: F401
 from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple  # noqa: F401, UP035
 
 from ..output.formatters import CompilationFormatter
 from ..output.models import CompilationResults
@@ -20,11 +18,8 @@ from ..version import get_version
 from .constants import BUILD_ID_PLACEHOLDER
 from .context_optimizer import ContextOptimizer
 from .link_resolver import UnifiedLinkResolver
-from .template_builder import (  # noqa: F401
-    TemplateData,
+from .template_builder import (
     build_attributed_instructions,
-    find_chatmode_by_name,
-    render_instructions_block,
 )
 
 # CRITICAL: Shadow Click commands to prevent namespace collision

--- a/src/apm_cli/compilation/gemini_formatter.py
+++ b/src/apm_cli/compilation/gemini_formatter.py
@@ -9,7 +9,6 @@ the AGENTS.md pipeline already produces.
 import builtins
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional  # noqa: F401, UP035
 
 from ..primitives.models import Instruction, PrimitiveCollection
 from ..version import get_version

--- a/src/apm_cli/compilation/injector.py
+++ b/src/apm_cli/compilation/injector.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Literal, Optional  # noqa: F401
+from typing import Literal
 
-from .constants import CONSTITUTION_MARKER_BEGIN, CONSTITUTION_MARKER_END  # noqa: F401
 from .constitution import read_constitution
 from .constitution_block import find_existing_block, render_block
 

--- a/src/apm_cli/compilation/link_resolver.py
+++ b/src/apm_cli/compilation/link_resolver.py
@@ -13,7 +13,6 @@ import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Set  # noqa: F401, UP035
 from urllib.parse import urlparse
 
 from apm_cli.utils.path_security import PathTraversalError, ensure_path_within

--- a/src/apm_cli/compilation/template_builder.py
+++ b/src/apm_cli/compilation/template_builder.py
@@ -1,10 +1,8 @@
 """Template building system for AGENTS.md compilation."""
 
-import re  # noqa: F401
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple  # noqa: F401, UP035
 
 from ..primitives.models import Chatmode, Instruction
 from ..utils.paths import portable_relpath

--- a/src/apm_cli/config.py
+++ b/src/apm_cli/config.py
@@ -3,7 +3,6 @@
 import contextlib
 import json
 import os
-from typing import Optional  # noqa: F401
 
 # ---------------------------------------------------------------------------
 # Public env-var names (re-declared here to avoid a circular import with the

--- a/src/apm_cli/core/auth.py
+++ b/src/apm_cli/core/auth.py
@@ -33,7 +33,7 @@ import sys
 import threading
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, NamedTuple, Optional, TypeVar  # noqa: F401
+from typing import TYPE_CHECKING, NamedTuple, TypeVar
 
 from apm_cli.core.token_manager import GitHubTokenManager
 from apm_cli.utils.github_host import (

--- a/src/apm_cli/core/azure_cli.py
+++ b/src/apm_cli/core/azure_cli.py
@@ -26,7 +26,6 @@ import subprocess
 import threading
 import time
 from datetime import datetime, timezone
-from typing import Optional, Tuple  # noqa: F401, UP035
 
 # ---------------------------------------------------------------------------
 # Exceptions

--- a/src/apm_cli/core/command_logger.py
+++ b/src/apm_cli/core/command_logger.py
@@ -6,7 +6,6 @@ from apm_cli.utils.console — no new output primitives.
 """
 
 from dataclasses import dataclass
-from typing import Optional  # noqa: F401
 
 from apm_cli.utils.console import (
     _rich_echo,
@@ -685,7 +684,6 @@ class InstallLogger(CommandLogger):
                 hint).  When provided, a dim secondary line with
                 remediation guidance is rendered under the inline error.
         """
-        from apm_cli.utils.diagnostics import CATEGORY_POLICY  # noqa: F401
 
         # F9 dedupe: some callers pass reason with a "{dep_ref}: " prefix
         # (the detail strings produced by policy_checks.py do this).

--- a/src/apm_cli/core/conflict_detector.py
+++ b/src/apm_cli/core/conflict_detector.py
@@ -1,6 +1,6 @@
 """MCP server conflict detection and resolution."""
 
-from typing import Any, Dict  # noqa: F401, UP035
+from typing import Any
 
 from ..adapters.client.base import MCPClientAdapter
 

--- a/src/apm_cli/core/docker_args.py
+++ b/src/apm_cli/core/docker_args.py
@@ -1,7 +1,5 @@
 """Docker arguments processing utilities for MCP configuration."""
 
-from typing import Dict, List, Tuple  # noqa: F401, UP035
-
 
 class DockerArgsProcessor:
     """Handles Docker argument processing with deduplication."""

--- a/src/apm_cli/core/safe_installer.py
+++ b/src/apm_cli/core/safe_installer.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional  # noqa: F401, UP035
+from typing import Any
 
 from ..factory import ClientFactory
 from ..utils.console import _rich_error, _rich_success, _rich_warning

--- a/src/apm_cli/core/scope.py
+++ b/src/apm_cli/core/scope.py
@@ -31,7 +31,6 @@ from __future__ import annotations
 import contextvars
 from enum import Enum
 from pathlib import Path
-from typing import List  # noqa: F401, UP035
 
 # ---------------------------------------------------------------------------
 # Constants

--- a/src/apm_cli/core/script_runner.py
+++ b/src/apm_cli/core/script_runner.py
@@ -6,9 +6,6 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Dict, Optional  # noqa: F401, UP035
-
-import yaml  # noqa: F401
 
 from ..output.script_formatters import ScriptExecutionFormatter
 from ..runtime.utils import find_runtime_binary

--- a/src/apm_cli/core/target_detection.py
+++ b/src/apm_cli/core/target_detection.py
@@ -23,7 +23,7 @@ are accepted as aliases and map to the same internal value.
 
 import warnings
 from pathlib import Path
-from typing import List, Literal, Optional, Tuple, Union  # noqa: F401, UP035
+from typing import Literal, Union
 
 import click
 

--- a/src/apm_cli/core/token_manager.py
+++ b/src/apm_cli/core/token_manager.py
@@ -24,7 +24,6 @@ import logging
 import os
 import subprocess
 import sys
-from typing import Dict, Optional, Tuple  # noqa: F401, UP035
 from urllib.parse import urlparse
 
 from apm_cli.utils.github_host import (

--- a/src/apm_cli/deps/aggregator.py
+++ b/src/apm_cli/deps/aggregator.py
@@ -1,11 +1,8 @@
 """Workflow dependency aggregator for APM."""
 
 import glob
-import os  # noqa: F401
-from pathlib import Path  # noqa: F401
 
 import frontmatter
-import yaml  # noqa: F401
 
 
 def scan_workflows_for_dependencies():

--- a/src/apm_cli/deps/apm_resolver.py
+++ b/src/apm_cli/deps/apm_resolver.py
@@ -8,12 +8,11 @@ from collections import deque
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 from pathlib import Path
-from typing import List, Optional, Protocol, Set, Tuple  # noqa: F401, UP035
+from typing import Optional, Protocol
 
 from ..models.apm_package import APMPackage, DependencyReference
 from .dependency_graph import (
     CircularRef,
-    ConflictInfo,  # noqa: F401
     DependencyGraph,
     DependencyNode,
     DependencyTree,

--- a/src/apm_cli/deps/artifactory_entry.py
+++ b/src/apm_cli/deps/artifactory_entry.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from typing import TYPE_CHECKING, List, Optional  # noqa: F401, UP035
+from typing import TYPE_CHECKING
 from urllib.parse import quote
 
 import requests as _requests

--- a/src/apm_cli/deps/dependency_graph.py
+++ b/src/apm_cli/deps/dependency_graph.py
@@ -2,8 +2,7 @@
 
 from collections import defaultdict
 from dataclasses import dataclass, field
-from pathlib import Path  # noqa: F401
-from typing import Any, Dict, List, Optional, Set, Tuple  # noqa: F401, UP035
+from typing import Any, Optional
 
 from ..models.apm_package import APMPackage, DependencyReference
 

--- a/src/apm_cli/deps/download_strategies.py
+++ b/src/apm_cli/deps/download_strategies.py
@@ -22,8 +22,6 @@ from ..core.auth import AuthResolver, HostInfo
 from ..models.apm_package import DependencyReference
 from ..utils.github_host import (
     build_ado_api_url,
-    build_ado_https_clone_url,  # noqa: F401  -- re-exported for tests/back-compat
-    build_ado_ssh_url,  # noqa: F401  -- re-exported for tests/back-compat
     build_artifactory_archive_url,
     build_https_clone_url,
     build_raw_content_url,

--- a/src/apm_cli/deps/git_remote_ops.py
+++ b/src/apm_cli/deps/git_remote_ops.py
@@ -6,7 +6,6 @@ no side effects.
 """
 
 import re
-from typing import Dict, List  # noqa: F401, UP035
 
 from ..models.apm_package import GitReferenceType, RemoteRef
 

--- a/src/apm_cli/deps/github_downloader.py
+++ b/src/apm_cli/deps/github_downloader.py
@@ -3,7 +3,6 @@
 import contextlib
 import os
 import re
-import stat  # noqa: F401
 import subprocess
 import sys
 import tempfile
@@ -14,7 +13,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Union
 
-import git  # noqa: F401  # re-exported for tests that patch github_downloader.git
+import git  # noqa: F401  -- re-exported; tests patch apm_cli.deps.github_downloader.git
 import requests
 from git import RemoteProgress, Repo
 from git.exc import GitCommandError
@@ -30,10 +29,11 @@ from ..models.apm_package import (
     ResolvedReference,
     validate_apm_package,
 )
-from ..utils.console import _rich_warning  # noqa: F401  # re-exported for tests
+from ..utils.console import (
+    _rich_warning,  # noqa: F401  -- re-exported; tests patch github_downloader._rich_warning
+)
 from ..utils.github_host import (
     default_host,
-    is_azure_devops_hostname,  # noqa: F401
     is_github_hostname,
     sanitize_token_url_in_message,
 )

--- a/src/apm_cli/deps/package_validator.py
+++ b/src/apm_cli/deps/package_validator.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import os  # noqa: F401
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional  # noqa: F401, UP035
+from typing import TYPE_CHECKING
 
 from ..models.apm_package import (
     APMPackage,

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -16,7 +16,7 @@ import logging
 import os
 import shutil
 from pathlib import Path
-from typing import Any, Dict, List, Optional  # noqa: F401, UP035
+from typing import Any
 
 import yaml
 

--- a/src/apm_cli/deps/registry_proxy.py
+++ b/src/apm_cli/deps/registry_proxy.py
@@ -38,7 +38,7 @@ import os
 import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Optional, Protocol, runtime_checkable  # noqa: F401, UP035
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 from urllib.parse import urlparse
 
 if TYPE_CHECKING:

--- a/src/apm_cli/deps/transport_selection.py
+++ b/src/apm_cli/deps/transport_selection.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 import os
 import subprocess
 import threading
-from dataclasses import dataclass, field  # noqa: F401
+from dataclasses import dataclass
 from enum import Enum
-from typing import List, Optional, Protocol, runtime_checkable  # noqa: F401, UP035
+from typing import Protocol, runtime_checkable
 
 # Public env vars (also recognized by CLI flag plumbing).
 ENV_PROTOCOL = "APM_GIT_PROTOCOL"

--- a/src/apm_cli/deps/verifier.py
+++ b/src/apm_cli/deps/verifier.py
@@ -1,9 +1,6 @@
 """Dependency verification for APM-CLI."""
 
-import os  # noqa: F401
 from pathlib import Path
-
-import yaml  # noqa: F401
 
 from ..factory import ClientFactory, PackageManagerFactory
 

--- a/src/apm_cli/drift.py
+++ b/src/apm_cli/drift.py
@@ -51,7 +51,6 @@ from __future__ import annotations
 
 import builtins
 from dataclasses import replace as _dataclass_replace
-from pathlib import Path  # noqa: F401
 from typing import TYPE_CHECKING, Any
 
 from apm_cli.install.phases._skip_logic import _should_use_locked_ref

--- a/src/apm_cli/install/context.py
+++ b/src/apm_cli/install/context.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple  # noqa: F401, UP035
+from typing import Any
 
 
 @dataclass

--- a/src/apm_cli/install/drift.py
+++ b/src/apm_cli/install/drift.py
@@ -93,9 +93,7 @@ class CacheMissError(RuntimeError):
 # the drift module.
 # ---------------------------------------------------------------------------
 
-from apm_cli.utils.normalization import (  # noqa: E402, F401  -- re-exported for back-compat
-    _BOM,
-    _BUILD_ID_PATTERN,
+from apm_cli.utils.normalization import (  # noqa: E402, F401  -- re-exported; tests import helpers from apm_cli.install.drift
     _normalize,
     _normalize_line_endings,
     _strip_bom,

--- a/src/apm_cli/install/errors.py
+++ b/src/apm_cli/install/errors.py
@@ -27,7 +27,7 @@ external callers keep working.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional  # noqa: F401
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - import for type hints only
     from apm_cli.policy.models import CIAuditResult

--- a/src/apm_cli/install/mcp/args.py
+++ b/src/apm_cli/install/mcp/args.py
@@ -7,7 +7,6 @@ LOC budget (sibling to ``warnings.py`` / ``registry.py``).
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Dict, Optional  # noqa: F401, UP035
 
 import click
 

--- a/src/apm_cli/install/mcp/command.py
+++ b/src/apm_cli/install/mcp/command.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Optional  # noqa: F401
 
 import click
 

--- a/src/apm_cli/install/mcp/conflicts.py
+++ b/src/apm_cli/install/mcp/conflicts.py
@@ -9,7 +9,6 @@ turns invalid ``apm install --mcp`` flag combinations into
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Optional, Tuple  # noqa: F401, UP035
 
 import click
 

--- a/src/apm_cli/install/mcp/entry.py
+++ b/src/apm_cli/install/mcp/entry.py
@@ -11,7 +11,7 @@ opaque; see #938 for the regression that motivates this rule.
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Any, Dict, Optional, Tuple, Union  # noqa: F401, UP035
+from typing import Any
 
 
 def build_mcp_entry(

--- a/src/apm_cli/install/mcp/registry.py
+++ b/src/apm_cli/install/mcp/registry.py
@@ -23,7 +23,6 @@ import contextlib
 import ipaddress
 import os
 from collections.abc import Iterator, Mapping, Sequence
-from typing import Any, Optional, Tuple  # noqa: F401, UP035
 from urllib.parse import urlparse, urlunparse
 
 import click

--- a/src/apm_cli/install/mcp/warnings.py
+++ b/src/apm_cli/install/mcp/warnings.py
@@ -22,8 +22,6 @@ from __future__ import annotations
 
 import ipaddress
 import socket
-from collections.abc import Iterable  # noqa: F401
-from typing import Optional  # noqa: F401
 
 # F7: tokens that would be evaluated by a real shell but are NOT evaluated
 # when an MCP stdio server runs through ``execve``-style spawning.

--- a/src/apm_cli/install/mcp/writer.py
+++ b/src/apm_cli/install/mcp/writer.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union  # noqa: F401, UP035
+from typing import Any, Union
 
 import click
 

--- a/src/apm_cli/install/phases/integrate.py
+++ b/src/apm_cli/install/phases/integrate.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import builtins
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple  # noqa: F401, UP035
+from typing import TYPE_CHECKING, Any
 
 from apm_cli.install.phases._redownload import _should_skip_redownload
 from apm_cli.install.phases._skip_logic import _compute_skip_download

--- a/src/apm_cli/install/pipeline.py
+++ b/src/apm_cli/install/pipeline.py
@@ -44,13 +44,13 @@ import builtins
 import contextlib
 import sys
 import time
-from typing import TYPE_CHECKING, List, Optional  # noqa: F401, UP035
+from typing import TYPE_CHECKING
 
 from ..models.results import InstallResult
 from ..utils.console import _rich_error
 from ..utils.diagnostics import DiagnosticCollector
 from ..utils.path_security import PathTraversalError
-from .errors import AuthenticationError, DirectDependencyError, PolicyViolationError  # noqa: F401
+from .errors import AuthenticationError, DirectDependencyError
 
 if TYPE_CHECKING:
     from ..core.auth import AuthResolver

--- a/src/apm_cli/install/presentation/dry_run.py
+++ b/src/apm_cli/install/presentation/dry_run.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import builtins
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any, Optional  # noqa: F401
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from pathlib import Path

--- a/src/apm_cli/install/request.py
+++ b/src/apm_cli/install/request.py
@@ -9,7 +9,7 @@ the ``InstallService`` consumes.  This is the typed-IO companion to
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple  # noqa: F401, UP035
+from typing import TYPE_CHECKING, Any, Callable  # noqa: UP035
 
 if TYPE_CHECKING:
     from apm_cli.core.auth import AuthResolver

--- a/src/apm_cli/install/sources.py
+++ b/src/apm_cli/install/sources.py
@@ -31,7 +31,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Optional  # noqa: F401, UP035
+from typing import TYPE_CHECKING, Any
 
 from apm_cli.install.registry_wiring import (
     get_registry_resolver,
@@ -568,7 +568,6 @@ class FreshDependencySource(DependencySource):
     def acquire(self) -> Materialization | None:
         from apm_cli.deps.installed_package import InstalledPackage
         from apm_cli.drift import build_download_ref
-        from apm_cli.models.apm_package import PackageType  # noqa: F401
         from apm_cli.utils.content_hash import compute_package_hash as _compute_hash
         from apm_cli.utils.path_security import safe_rmtree
 

--- a/src/apm_cli/install/template.py
+++ b/src/apm_cli/install/template.py
@@ -13,8 +13,6 @@ This is the Template Method companion to the Strategy pattern in
 
 from __future__ import annotations
 
-from typing import Dict, Optional  # noqa: F401, UP035
-
 from apm_cli.install.helpers.security_scan import _pre_deploy_security_scan
 from apm_cli.install.services import integrate_package_primitives
 from apm_cli.install.sources import DependencySource, Materialization

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List  # noqa: F401, UP035
+from typing import TYPE_CHECKING
 
 import yaml
 

--- a/src/apm_cli/integration/base_integrator.py
+++ b/src/apm_cli/integration/base_integrator.py
@@ -3,9 +3,8 @@
 import errno
 import os
 import re
-from dataclasses import dataclass, field  # noqa: F401
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Set  # noqa: F401, UP035
 
 from apm_cli.compilation.link_resolver import UnifiedLinkResolver
 from apm_cli.primitives.discovery import discover_primitives

--- a/src/apm_cli/integration/cleanup.py
+++ b/src/apm_cli/integration/cleanup.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Optional  # noqa: F401, UP035
 
 from .base_integrator import BaseIntegrator
 

--- a/src/apm_cli/integration/command_integrator.py
+++ b/src/apm_cli/integration/command_integrator.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple  # noqa: F401, UP035
+from typing import TYPE_CHECKING, Any
 
 import frontmatter
 

--- a/src/apm_cli/integration/dispatch.py
+++ b/src/apm_cli/integration/dispatch.py
@@ -12,7 +12,6 @@ primitives are dispatched per-target in the outer loop.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Type  # noqa: F401, UP035
 
 from apm_cli.integration.base_integrator import BaseIntegrator
 

--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -47,9 +47,8 @@ import json
 import logging
 import re
 import shutil
-from dataclasses import dataclass, field  # noqa: F401
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple  # noqa: F401, UP035
 
 import yaml
 

--- a/src/apm_cli/integration/instruction_integrator.py
+++ b/src/apm_cli/integration/instruction_integrator.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Set  # noqa: F401, UP035
+from typing import TYPE_CHECKING
 
 from apm_cli.integration.base_integrator import BaseIntegrator, IntegrationResult
 from apm_cli.utils.path_security import ensure_path_within

--- a/src/apm_cli/integration/mcp_integrator.py
+++ b/src/apm_cli/integration/mcp_integrator.py
@@ -17,15 +17,12 @@ import shutil
 import warnings
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List, Optional  # noqa: F401, UP035
-
-import click  # noqa: F401
 
 from apm_cli.core.null_logger import NullCommandLogger
 from apm_cli.deps.lockfile import LockFile, get_lockfile_path
 from apm_cli.runtime.utils import find_runtime_binary
 from apm_cli.utils.console import (
-    _get_console,  # noqa: F401  -- module attribute; patched by tests and used via re-export
+    _get_console,  # noqa: F401 -- re-exported; mcp_integrator_install imports this via lazy import
     _rich_error,
     _rich_info,
     _rich_success,

--- a/src/apm_cli/integration/prompt_integrator.py
+++ b/src/apm_cli/integration/prompt_integrator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Set  # noqa: F401, UP035
+from typing import TYPE_CHECKING
 
 from apm_cli.integration.base_integrator import BaseIntegrator, IntegrationResult
 from apm_cli.utils.path_security import PathTraversalError, ensure_path_within

--- a/src/apm_cli/integration/skill_integrator.py
+++ b/src/apm_cli/integration/skill_integrator.py
@@ -5,11 +5,7 @@ import hashlib
 import re
 import shutil
 from dataclasses import dataclass, replace
-from datetime import datetime  # noqa: F401
 from pathlib import Path
-from typing import Dict, List, Optional  # noqa: F401, UP035
-
-import frontmatter  # noqa: F401
 
 from apm_cli.integration.base_integrator import BaseIntegrator
 

--- a/src/apm_cli/integration/skill_transformer.py
+++ b/src/apm_cli/integration/skill_transformer.py
@@ -2,7 +2,6 @@
 
 import re
 from pathlib import Path
-from typing import Optional  # noqa: F401
 
 from ..primitives.models import Skill
 

--- a/src/apm_cli/integration/targets.py
+++ b/src/apm_cli/integration/targets.py
@@ -19,8 +19,7 @@ the result is an empty list (no silent ``[copilot]`` fallback).
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass, field  # noqa: F401
-from typing import Dict, List, Optional, Tuple, Union  # noqa: F401, UP035
+from dataclasses import dataclass
 
 
 @dataclass(frozen=True)

--- a/src/apm_cli/marketplace/builder.py
+++ b/src/apm_cli/marketplace/builder.py
@@ -26,7 +26,7 @@ import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple  # noqa: F401, UP035
+from typing import TYPE_CHECKING, Any
 
 import yaml
 
@@ -42,7 +42,6 @@ from .errors import (
     BuildError,
     HeadNotAllowedError,
     NoMatchingVersionError,
-    OfflineMissError,  # noqa: F401
     RefNotFoundError,
 )
 from .output_mappers import (
@@ -60,9 +59,9 @@ from .output_profiles import (
     DEFAULT_MARKETPLACE_OUTPUT,
     MarketplaceOutputProfile,
 )
-from .ref_resolver import RefResolver, RemoteRef  # noqa: F401
+from .ref_resolver import RefResolver
 from .semver import SemVer, parse_semver, satisfies_range
-from .tag_pattern import build_tag_regex, render_tag  # noqa: F401
+from .tag_pattern import build_tag_regex
 from .yml_schema import MarketplaceYml, PackageEntry, load_marketplace_yml
 
 logger = logging.getLogger(__name__)

--- a/src/apm_cli/marketplace/migration.py
+++ b/src/apm_cli/marketplace/migration.py
@@ -23,7 +23,6 @@ import enum
 import logging
 from io import StringIO
 from pathlib import Path
-from typing import Optional  # noqa: F401
 
 import yaml
 

--- a/src/apm_cli/marketplace/pr_integration.py
+++ b/src/apm_cli/marketplace/pr_integration.py
@@ -27,7 +27,6 @@ import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional  # noqa: F401
 
 from ._git_utils import redact_token as _redact_token
 from .git_stderr import translate_git_stderr

--- a/src/apm_cli/marketplace/publisher.py
+++ b/src/apm_cli/marketplace/publisher.py
@@ -32,11 +32,11 @@ import subprocess
 import tempfile
 from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass, field  # noqa: F401
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import Any, Optional  # noqa: F401
+from typing import Any
 
 import yaml
 
@@ -47,14 +47,13 @@ from ..utils.path_security import (
 )
 from ._git_utils import redact_token as _redact_token
 from ._io import atomic_write
-from .errors import MarketplaceError, MarketplaceYmlError  # noqa: F401
+from .errors import MarketplaceError
 from .git_stderr import translate_git_stderr
 from .migration import load_marketplace_config
 from .ref_resolver import RefResolver
 from .resolver import parse_marketplace_ref
 from .semver import parse_semver
 from .tag_pattern import render_tag
-from .yml_schema import load_marketplace_yml  # noqa: F401  (kept for back-compat)
 
 logger = logging.getLogger(__name__)
 

--- a/src/apm_cli/marketplace/ref_resolver.py
+++ b/src/apm_cli/marketplace/ref_resolver.py
@@ -21,8 +21,7 @@ import re
 import subprocess
 import threading
 import time
-from dataclasses import dataclass, field  # noqa: F401
-from typing import Dict, List, Optional  # noqa: F401, UP035
+from dataclasses import dataclass
 
 from ..utils.github_host import build_https_clone_url, default_host
 from ._git_utils import redact_token as _redact_token

--- a/src/apm_cli/marketplace/registry.py
+++ b/src/apm_cli/marketplace/registry.py
@@ -4,7 +4,6 @@ import json
 import logging
 import os
 import threading
-from typing import Dict, List, Optional  # noqa: F401, UP035
 
 from .errors import MarketplaceNotFoundError
 from .models import MarketplaceSource

--- a/src/apm_cli/marketplace/semver.py
+++ b/src/apm_cli/marketplace/semver.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Optional  # noqa: F401
 
 __all__ = [
     "SemVer",

--- a/src/apm_cli/marketplace/shadow_detector.py
+++ b/src/apm_cli/marketplace/shadow_detector.py
@@ -11,7 +11,6 @@ never propagate to the caller.
 
 import logging
 from dataclasses import dataclass
-from typing import List, Optional  # noqa: F401, UP035
 
 from .client import fetch_or_cache
 from .registry import get_registered_marketplaces

--- a/src/apm_cli/marketplace/validator.py
+++ b/src/apm_cli/marketplace/validator.py
@@ -11,7 +11,6 @@ rules on the successfully parsed entries.
 
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import List  # noqa: F401, UP035
 
 from .models import MarketplaceManifest, MarketplacePlugin
 

--- a/src/apm_cli/marketplace/version_pins.py
+++ b/src/apm_cli/marketplace/version_pins.py
@@ -24,7 +24,6 @@ and never block resolution.
 import json
 import logging
 import os
-from typing import Optional  # noqa: F401
 
 logger = logging.getLogger(__name__)
 

--- a/src/apm_cli/marketplace/yml_editor.py
+++ b/src/apm_cli/marketplace/yml_editor.py
@@ -13,10 +13,8 @@ atomic-write-then-revalidate pattern:
 
 from __future__ import annotations
 
-import re  # noqa: F401
 from io import StringIO
 from pathlib import Path
-from typing import List, Optional  # noqa: F401, UP035
 
 from ruamel.yaml import YAML
 

--- a/src/apm_cli/marketplace/yml_schema.py
+++ b/src/apm_cli/marketplace/yml_schema.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Tuple  # noqa: F401, UP035
+from typing import Any, Mapping  # noqa: UP035
 
 import yaml
 

--- a/src/apm_cli/models/dependency/mcp.py
+++ b/src/apm_cli/models/dependency/mcp.py
@@ -2,7 +2,7 @@
 
 import re
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional  # noqa: F401, UP035
+from typing import Any
 from urllib.parse import urlparse
 
 from apm_cli.utils.path_security import PathTraversalError, validate_path_segments

--- a/src/apm_cli/models/dependency/types.py
+++ b/src/apm_cli/models/dependency/types.py
@@ -3,7 +3,6 @@
 import re
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional  # noqa: F401
 
 
 class GitReferenceType(Enum):

--- a/src/apm_cli/models/plugin.py
+++ b/src/apm_cli/models/plugin.py
@@ -3,7 +3,7 @@
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional  # noqa: F401, UP035
+from typing import Any
 
 
 @dataclass

--- a/src/apm_cli/models/results.py
+++ b/src/apm_cli/models/results.py
@@ -1,7 +1,6 @@
 """Typed result containers for APM operations."""
 
 from dataclasses import dataclass, field
-from typing import Dict  # noqa: F401, UP035
 
 
 @dataclass

--- a/src/apm_cli/models/validation.py
+++ b/src/apm_cli/models/validation.py
@@ -6,7 +6,7 @@ import re
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Tuple  # noqa: F401, UP035
+from typing import TYPE_CHECKING
 
 from ..constants import APM_DIR, APM_YML_FILENAME, SKILL_MD_FILENAME
 

--- a/src/apm_cli/output/formatters.py
+++ b/src/apm_cli/output/formatters.py
@@ -1,18 +1,13 @@
 """Professional CLI output formatters for APM compilation."""
 
-import time  # noqa: F401
 from pathlib import Path
-from typing import List, Optional  # noqa: F401, UP035
 
 try:
-    from io import StringIO  # noqa: F401
-
     from rich import box
     from rich.console import Console
     from rich.panel import Panel
     from rich.table import Table
     from rich.text import Text
-    from rich.tree import Tree  # noqa: F401
 
     RICH_AVAILABLE = True
 except ImportError:

--- a/src/apm_cli/output/models.py
+++ b/src/apm_cli/output/models.py
@@ -3,7 +3,6 @@
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Dict, List, Optional, Set  # noqa: F401, UP035
 
 from ..primitives.models import Instruction
 

--- a/src/apm_cli/output/script_formatters.py
+++ b/src/apm_cli/output/script_formatters.py
@@ -1,7 +1,6 @@
 """Professional CLI output formatters for APM script execution."""
 
 from pathlib import Path
-from typing import Dict, List, Optional  # noqa: F401, UP035
 
 try:
     from rich.console import Console

--- a/src/apm_cli/policy/ci_checks.py
+++ b/src/apm_cli/policy/ci_checks.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Sequence  # noqa: F401, UP035
+from typing import TYPE_CHECKING, Sequence  # noqa: UP035
 
 from ..deps.lockfile import _SELF_KEY, LEGACY_LOCKFILE_NAME, LOCKFILE_NAME
 from .models import CheckResult, CIAuditResult

--- a/src/apm_cli/policy/discovery.py
+++ b/src/apm_cli/policy/discovery.py
@@ -27,7 +27,6 @@ import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional, Tuple  # noqa: F401, UP035
 from urllib.parse import urlparse
 
 import requests

--- a/src/apm_cli/policy/inheritance.py
+++ b/src/apm_cli/policy/inheritance.py
@@ -11,8 +11,6 @@ extends: values:
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Tuple  # noqa: F401, UP035
-
 from .schema import (
     ApmPolicy,
     AuditPolicy,

--- a/src/apm_cli/policy/install_preflight.py
+++ b/src/apm_cli/policy/install_preflight.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Optional, Tuple  # noqa: F401, UP035
 
 # #832: Canonical exception type lives in ``apm_cli.install.errors``.
 # ``PolicyBlockError`` remains as an alias re-exported below so external
@@ -23,10 +22,8 @@ from typing import Optional, Tuple  # noqa: F401, UP035
 from apm_cli.install.errors import PolicyViolationError
 
 from .discovery import PolicyFetchResult, discover_policy_with_chain
-from .models import CIAuditResult  # noqa: F401
 from .outcome_routing import route_discovery_outcome
 from .policy_checks import run_dependency_policy_checks
-from .schema import ApmPolicy  # noqa: F401
 
 # Deprecated alias kept for backward compatibility (#832).  New code
 # should ``raise``/``except`` :class:`PolicyViolationError` directly.

--- a/src/apm_cli/policy/matcher.py
+++ b/src/apm_cli/policy/matcher.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import re
 from functools import lru_cache
-from typing import Optional, Tuple  # noqa: F401, UP035
 
 from .schema import DependencyPolicy, McpPolicy
 

--- a/src/apm_cli/policy/models.py
+++ b/src/apm_cli/policy/models.py
@@ -7,7 +7,6 @@ baseline checks (``ci_checks``) and policy checks (``policy_checks``).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List  # noqa: F401, UP035
 
 # Check name -> most relevant artifact for SARIF locations.
 _CHECK_ARTIFACT_MAP: dict[str, str] = {

--- a/src/apm_cli/policy/outcome_routing.py
+++ b/src/apm_cli/policy/outcome_routing.py
@@ -24,7 +24,7 @@ and the exact gating semantics match the pre-extraction behaviour.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional  # noqa: F401
+from typing import TYPE_CHECKING
 
 from apm_cli.install.errors import PolicyViolationError
 

--- a/src/apm_cli/policy/parser.py
+++ b/src/apm_cli/policy/parser.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import errno
 from pathlib import Path
-from typing import Any, List, Optional, Tuple, Union  # noqa: F401, UP035
+from typing import Any
 
 import yaml
 

--- a/src/apm_cli/policy/policy_checks.py
+++ b/src/apm_cli/policy/policy_checks.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import List, Optional  # noqa: F401, UP035
 
 from .models import CheckResult, CIAuditResult
 

--- a/src/apm_cli/policy/project_config.py
+++ b/src/apm_cli/policy/project_config.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Optional  # noqa: F401, UP035
+from typing import Any
 
 import yaml
 

--- a/src/apm_cli/policy/schema.py
+++ b/src/apm_cli/policy/schema.py
@@ -16,7 +16,6 @@ Deny/require list semantics:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, Optional, Tuple  # noqa: F401, UP035
 
 
 @dataclass(frozen=True)

--- a/src/apm_cli/primitives/discovery.py
+++ b/src/apm_cli/primitives/discovery.py
@@ -1,12 +1,10 @@
 """Discovery functionality for primitive files."""
 
 import fnmatch
-import glob  # noqa: F401
 import logging
 import os
 import time
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple  # noqa: F401, UP035
 
 from ..constants import DEFAULT_SKIP_DIRS
 from ..utils import perf_stats

--- a/src/apm_cli/primitives/models.py
+++ b/src/apm_cli/primitives/models.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Union  # noqa: F401, UP035
+from typing import Union
 
 
 @dataclass

--- a/src/apm_cli/primitives/parser.py
+++ b/src/apm_cli/primitives/parser.py
@@ -1,8 +1,6 @@
 """Parser for primitive definition files."""
 
-import os  # noqa: F401
 from pathlib import Path
-from typing import List, Union  # noqa: F401, UP035
 
 import frontmatter
 

--- a/src/apm_cli/registry/client.py
+++ b/src/apm_cli/registry/client.py
@@ -4,7 +4,7 @@ import logging
 import os
 import re
 import warnings
-from typing import Any, Dict, List, Optional, Tuple  # noqa: F401, UP035
+from typing import Any
 from urllib.parse import quote, urlparse
 
 import requests

--- a/src/apm_cli/registry/integration.py
+++ b/src/apm_cli/registry/integration.py
@@ -1,8 +1,6 @@
 """Integration module for connecting registry client with package manager."""
 
-from typing import Any, Dict, List, Optional  # noqa: F401, UP035
-
-import requests  # noqa: F401
+from typing import Any
 
 from .client import SimpleRegistryClient
 

--- a/src/apm_cli/registry/operations.py
+++ b/src/apm_cli/registry/operations.py
@@ -3,7 +3,6 @@
 import logging
 import os
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple  # noqa: F401, UP035
 
 import requests
 

--- a/src/apm_cli/runtime/base.py
+++ b/src/apm_cli/runtime/base.py
@@ -2,7 +2,7 @@
 
 import subprocess
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional  # noqa: F401, UP035
+from typing import Any
 
 
 def _stream_subprocess_output(cmd: list, timeout: int | None = None) -> tuple[list, int]:

--- a/src/apm_cli/runtime/codex_runtime.py
+++ b/src/apm_cli/runtime/codex_runtime.py
@@ -1,7 +1,7 @@
 """Codex runtime adapter for APM."""
 
 import subprocess
-from typing import Any, Dict, Optional  # noqa: F401, UP035
+from typing import Any
 
 from .base import RuntimeAdapter
 from .utils import find_runtime_binary
@@ -33,8 +33,6 @@ class CodexRuntime(RuntimeAdapter):
         Returns:
             str: The response text from Codex
         """
-        import os  # noqa: F401
-        import sys  # noqa: F401
 
         try:
             # Use codex exec to execute the prompt with real-time streaming

--- a/src/apm_cli/runtime/copilot_runtime.py
+++ b/src/apm_cli/runtime/copilot_runtime.py
@@ -1,10 +1,9 @@
 """GitHub Copilot CLI runtime adapter for APM."""
 
 import json
-import os  # noqa: F401
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, Optional  # noqa: F401, UP035
+from typing import Any
 
 from .base import RuntimeAdapter, _stream_subprocess_output
 from .utils import find_runtime_binary

--- a/src/apm_cli/runtime/factory.py
+++ b/src/apm_cli/runtime/factory.py
@@ -1,6 +1,6 @@
 """Runtime factory for automatic runtime detection and instantiation."""
 
-from typing import Any, Dict, List, Optional, Type  # noqa: F401, UP035
+from typing import Any
 
 from .base import RuntimeAdapter
 from .codex_runtime import CodexRuntime

--- a/src/apm_cli/runtime/llm_runtime.py
+++ b/src/apm_cli/runtime/llm_runtime.py
@@ -1,9 +1,7 @@
 """LLM runtime adapter for APM."""
 
-import os  # noqa: F401
 import subprocess
-import tempfile  # noqa: F401
-from typing import Any, Dict, Optional  # noqa: F401, UP035
+from typing import Any
 
 from .base import RuntimeAdapter, _stream_subprocess_output
 

--- a/src/apm_cli/runtime/manager.py
+++ b/src/apm_cli/runtime/manager.py
@@ -9,7 +9,6 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Dict, List, Optional  # noqa: F401, UP035
 
 import click
 from colorama import Fore, Style

--- a/src/apm_cli/security/audit_report.py
+++ b/src/apm_cli/security/audit_report.py
@@ -2,7 +2,7 @@
 
 import json
 from pathlib import Path
-from typing import Any, Dict, List  # noqa: F401, UP035
+from typing import Any
 
 from .content_scanner import ScanFinding
 

--- a/src/apm_cli/security/content_scanner.py
+++ b/src/apm_cli/security/content_scanner.py
@@ -12,7 +12,6 @@ be tested and used independently.
 import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple  # noqa: F401, UP035
 
 
 @dataclass(frozen=True)

--- a/src/apm_cli/security/file_scanner.py
+++ b/src/apm_cli/security/file_scanner.py
@@ -7,7 +7,6 @@ Extracted from ``commands/audit.py`` so the policy module can call
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple  # noqa: F401, UP035
 
 from ..deps.lockfile import LockFile, get_lockfile_path
 from ..integration.base_integrator import BaseIntegrator

--- a/src/apm_cli/security/gate.py
+++ b/src/apm_cli/security/gate.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, List, Literal, Optional  # noqa: F401, UP035
+from typing import Literal
 
 from ..utils.paths import portable_relpath
 from .content_scanner import ContentScanner, ScanFinding

--- a/src/apm_cli/utils/console.py
+++ b/src/apm_cli/utils/console.py
@@ -1,9 +1,8 @@
 """Console utility functions for formatting and output."""
 
-import sys  # noqa: F401
 import threading
 from contextlib import contextmanager
-from typing import Any, Optional  # noqa: F401
+from typing import Any
 
 import click
 

--- a/src/apm_cli/utils/content_hash.py
+++ b/src/apm_cli/utils/content_hash.py
@@ -2,7 +2,6 @@
 
 import hashlib
 from pathlib import Path
-from typing import Optional  # noqa: F401
 
 from apm_cli.install.cache_pin import MARKER_FILENAME as _APM_PIN_MARKER
 

--- a/src/apm_cli/utils/diagnostics.py
+++ b/src/apm_cli/utils/diagnostics.py
@@ -8,11 +8,10 @@ output when many packages are involved.
 """
 
 import threading
-from dataclasses import dataclass, field  # noqa: F401
-from typing import Dict, List, Optional  # noqa: F401, UP035
+from dataclasses import dataclass
 
 from apm_cli.utils.console import (
-    _get_console,  # noqa: F401  -- re-exported for back-compat (tests patch this name)
+    _get_console,  # noqa: F401 -- re-exported; tests patch apm_cli.utils.diagnostics._get_console
     _rich_echo,
     _rich_info,
     _rich_warning,

--- a/src/apm_cli/utils/exclude.py
+++ b/src/apm_cli/utils/exclude.py
@@ -9,7 +9,6 @@ import fnmatch
 import logging
 import os
 from pathlib import Path
-from typing import List, Optional  # noqa: F401, UP035
 
 logger = logging.getLogger(__name__)
 

--- a/src/apm_cli/utils/helpers.py
+++ b/src/apm_cli/utils/helpers.py
@@ -1,12 +1,10 @@
 """Helper utility functions for APM."""
 
-import os  # noqa: F401
 import platform
 import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Optional  # noqa: F401
 
 
 def is_tool_available(tool_name):

--- a/src/apm_cli/utils/yaml_io.py
+++ b/src/apm_cli/utils/yaml_io.py
@@ -13,7 +13,7 @@ Public API::
 """
 
 from pathlib import Path
-from typing import Any, Dict, Optional, Union  # noqa: F401, UP035
+from typing import Any
 
 import yaml
 

--- a/src/apm_cli/workflow/runner.py
+++ b/src/apm_cli/workflow/runner.py
@@ -1,13 +1,11 @@
 """Runner for workflow execution."""
 
 import os
-import re  # noqa: F401
 
 from colorama import Fore, Style
 
 from ..runtime.factory import RuntimeFactory
 from .discovery import discover_workflows
-from .parser import WorkflowDefinition  # noqa: F401
 
 # Color constants (matching cli.py)
 WARNING = f"{Fore.YELLOW}"


### PR DESCRIPTION
## TL;DR

Remove ~200 dead import suppressions accumulated from PR #999's F401 blanket, keep 21 legitimate re-exports with justification comments.

## Problem (WHY)

PR #999 added `# noqa: F401` directives wholesale to preserve existing import patterns when enabling Ruff's F401 rule. Many suppressions masked genuinely dead imports (unused `typing` aliases, stdlib modules, internal symbols) rather than protecting intentional re-exports. This left the codebase with ~219 suppression directives, most of which were dead code hiding under noqa.

> "Strip all # noqa: F401 directives, run ruff auto-fix to remove ~407 genuinely dead imports" -- this refactor's commit message

## Approach (WHAT)

1. **Strip all `# noqa: F401` directives** from src/ (handling combined forms like `# noqa: F401, UP035` -> `# noqa: UP035`)
2. **Run `ruff check --fix --select F401`** to auto-remove all genuinely dead imports
3. **Restore 21 legitimate re-exports** with `-- re-exported; <reason>` justification comments
4. **Verify** lint CI-mirror passes with zero regressions

## Implementation (HOW)

Dead imports removed (examples):
- Unused `typing` aliases: `Optional, List, Dict, Tuple, Union` replaced by builtins
- Dead stdlib: `os`, `sys`, `yaml`, `re`, `glob`, `tempfile`, `stat` in files that never used them
- Dead re-exports: `_rich_info/_rich_warning` from `marketplace/__init__`, `MarketplaceYmlError/_is_interactive` from `plugin/__init__.py`, `load_marketplace_yml` from publisher, `build_ado_*_url` from download_strategies

Legitimate re-exports kept (21 remaining, each justified):
- `github_downloader.git` -- tests patch this attribute
- `github_downloader._rich_warning` -- tests patch this name
- `diagnostics._get_console` -- tests patch this name
- `mcp_integrator._get_console` -- lazy import re-export
- `install.drift` normalization helpers -- tests import from this facade
- `commands/install.py` -- 15 internal symbols that test_architecture_invariants imports/patches
- `commands/_helpers._atomic_write` -- tests import from _helpers

## Validation

- 137 files changed, 95 insertions(+), 229 deletions(-)
- `ruff check src/ tests/` -- all checks passed
- `ruff format --check src/ tests/` -- 1193 files already formatted
- `pylint R0801` -- 10.00/10
- `bash scripts/lint-auth-signals.sh` -- auth-signal lint clean
- Unit tests: 16,183 tests pass

## How to test

```bash
# Verify no F401 regressions
uv run --extra dev ruff check src/ tests/ --select F401
# Count remaining suppressions (should be 21)
grep -rn 'noqa.*F401' src/ | wc -l
# Full lint suite
uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/ && bash scripts/lint-auth-signals.sh
```

Closes #1003