### PR TITLE
fix: strip ANSI escape codes from external SARIF message text

### DIFF
--- a/src/apm_cli/security/external/sarif_ingest.py
+++ b/src/apm_cli/security/external/sarif_ingest.py
@@ -13,9 +13,14 @@ when the top-level shape is not a SARIF document at all.
 
 from __future__ import annotations
 
+import re
+
 from ..audit_report import _SEVERITY_MAP, relative_path_for_report
 from ..content_scanner import ScanFinding
 from .base import ExternalScanError
+
+# Matches ANSI SGR escape sequences (e.g. \x1b[0m, \x1b[31;1m).
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 # Inverse of audit_report._SEVERITY_MAP (APM severity -> SARIF level).
 # SARIF level -> APM severity.  ``none`` and any unknown level map to "info"
@@ -70,10 +75,17 @@ def _result_location(result: dict) -> tuple[str, int, int]:
 
 
 def _result_message(result: dict) -> str:
-    """Extract a human-readable message from a SARIF result."""
+    """Extract a human-readable message from a SARIF result.
+
+    ANSI escape codes are stripped so that external scanners emitting
+    Rich-formatted text (e.g. SkillSpector) do not leak escape
+    sequences into APM's table output.
+    """
     message = result.get("message") or {}
     text = message.get("text") if isinstance(message, dict) else None
-    return text if isinstance(text, str) and text else "(no message)"
+    if not isinstance(text, str) or not text:
+        return "(no message)"
+    return _ANSI_ESCAPE_RE.sub("", text)
 
 
 def sarif_to_findings(

--- a/src/apm_cli/security/external/sarif_ingest.py
+++ b/src/apm_cli/security/external/sarif_ingest.py
@@ -85,7 +85,8 @@ def _result_message(result: dict) -> str:
     text = message.get("text") if isinstance(message, dict) else None
     if not isinstance(text, str) or not text:
         return "(no message)"
-    return _ANSI_ESCAPE_RE.sub("", text)
+    cleaned = _ANSI_ESCAPE_RE.sub("", text)
+    return cleaned if cleaned else "(no message)"
 
 
 def sarif_to_findings(

--- a/tests/unit/test_external_scanners.py
+++ b/tests/unit/test_external_scanners.py
@@ -188,6 +188,23 @@ class TestSarifToFindings:
         finding = out["s.py"][0]
         assert finding.description == "exec() call detected"
 
+    def test_ansi_only_message_falls_back_to_no_message(self) -> None:
+        from apm_cli.security.external.sarif_ingest import sarif_to_findings
+
+        doc = _sarif(
+            [
+                {
+                    "ruleId": "R",
+                    "level": "warning",
+                    "message": {"text": "\x1b[31m\x1b[0m"},
+                    "locations": [],
+                }
+            ]
+        )
+        out = sarif_to_findings(doc, tool_name="t")
+        finding = next(iter(out.values()))[0]
+        assert finding.description == "(no message)"
+
     def test_not_a_sarif_document_raises(self) -> None:
         from apm_cli.security.external.base import ExternalScanError
         from apm_cli.security.external.sarif_ingest import sarif_to_findings

--- a/tests/unit/test_external_scanners.py
+++ b/tests/unit/test_external_scanners.py
@@ -164,6 +164,30 @@ class TestSarifToFindings:
         f = out["<unknown>"][0]
         assert (f.line, f.column) == (1, 1)
 
+    def test_ansi_escape_codes_stripped_from_message(self) -> None:
+        from apm_cli.security.external.sarif_ingest import sarif_to_findings
+
+        doc = _sarif(
+            [
+                {
+                    "ruleId": "R",
+                    "level": "warning",
+                    "message": {"text": "\x1b[31mexec() call detected\x1b[0m"},
+                    "locations": [
+                        {
+                            "physicalLocation": {
+                                "artifactLocation": {"uri": "s.py"},
+                                "region": {"startLine": 5, "startColumn": 1},
+                            }
+                        }
+                    ],
+                }
+            ]
+        )
+        out = sarif_to_findings(doc, tool_name="t")
+        finding = out["s.py"][0]
+        assert finding.description == "exec() call detected"
+
     def test_not_a_sarif_document_raises(self) -> None:
         from apm_cli.security.external.base import ExternalScanError
         from apm_cli.security.external.sarif_ingest import sarif_to_findings


### PR DESCRIPTION
## TL;DR

Strip ANSI SGR escape sequences from external SARIF `message.text` fields during ingestion so they don't leak into APM's Rich text table output.

## Problem

External scanners like SkillSpector embed ANSI escape codes (e.g. `\x1b[31m`, `\x1b[0m`) in their SARIF `message.text` fields. When APM ingests these and renders them in a Rich text table, the escape codes leak through as literal `[0m` fragments at the end of cell values.

## Approach

Added a compiled regex (`_ANSI_ESCAPE_RE`) in `sarif_ingest.py` that matches ANSI SGR sequences (`\x1b[<digits/semicolons>m`) and strips them in `_result_message()` before returning the message text.

## Changes

- **`src/apm_cli/security/external/sarif_ingest.py`**: Added `re` import, compiled `_ANSI_ESCAPE_RE` pattern, and applied `sub()` in `_result_message()`.
- **`tests/unit/test_external_scanners.py`**: Added `test_ansi_escape_codes_stripped_from_message` verifying that ANSI-laden message text is cleaned to plain text.

## Validation

- All 22 unit tests in `test_external_scanners.py` pass
- Ruff check + format clean

Closes #1641