### PR TITLE
fix: pass --no-llm to SkillSpector and handle non-JSON stdout

### DIFF
--- a/src/apm_cli/security/external/skillspector.py
+++ b/src/apm_cli/security/external/skillspector.py
@@ -82,9 +82,12 @@ class SkillSpectorAdapter:
         except json.JSONDecodeError as exc:
             # SkillSpector writes errors (e.g. missing API key) to stdout,
             # not stderr.  Surface the first line so users can diagnose.
-            first_line = completed.stdout.strip().splitlines()[0][:200]
+            # Strip non-printable / non-ASCII chars to honour the repo's
+            # printable-ASCII output contract.
+            raw_line = completed.stdout.strip().splitlines()[0][:200]
+            safe_line = "".join(ch if 0x20 <= ord(ch) <= 0x7E else "?" for ch in raw_line)
             raise ExternalScanError(
-                f"SkillSpector output is not valid JSON SARIF: {first_line}"
+                f"SkillSpector output is not valid JSON SARIF: {safe_line}"
             ) from exc
 
         return sarif_to_findings(document, tool_name=self.name)

--- a/src/apm_cli/security/external/skillspector.py
+++ b/src/apm_cli/security/external/skillspector.py
@@ -58,7 +58,7 @@ class SkillSpectorAdapter:
             )
 
         targets = [str(p) for p in paths] or ["."]
-        cmd = [binary, "scan", "--format", "sarif", *targets]
+        cmd = [binary, "scan", "--format", "sarif", "--no-llm", *targets]
         try:
             completed = subprocess.run(
                 cmd,
@@ -80,6 +80,11 @@ class SkillSpectorAdapter:
         try:
             document = json.loads(completed.stdout)
         except json.JSONDecodeError as exc:
-            raise ExternalScanError(f"SkillSpector output is not valid JSON SARIF: {exc}") from exc
+            # SkillSpector writes errors (e.g. missing API key) to stdout,
+            # not stderr.  Surface the first line so users can diagnose.
+            first_line = completed.stdout.strip().splitlines()[0][:200]
+            raise ExternalScanError(
+                f"SkillSpector output is not valid JSON SARIF: {first_line}"
+            ) from exc
 
         return sarif_to_findings(document, tool_name=self.name)

--- a/tests/unit/test_external_scanners.py
+++ b/tests/unit/test_external_scanners.py
@@ -314,6 +314,24 @@ class TestSkillSpectorAdapter:
         with pytest.raises(ExternalScanError, match=r"NVIDIA_API_KEY not set"):
             mod.SkillSpectorAdapter().scan([tmp_path])
 
+    def test_scan_non_json_stdout_sanitises_non_ascii(self, monkeypatch, tmp_path: Path) -> None:
+        """Non-printable / non-ASCII chars in vendor stdout are replaced with '?'."""
+        import apm_cli.security.external.skillspector as mod
+        from apm_cli.security.external.base import ExternalScanError
+
+        monkeypatch.setattr(mod.shutil, "which", lambda _name: "/usr/bin/skillspector")
+
+        # ANSI escape + non-ASCII char embedded in vendor error output.
+        error_text = "\x1b[31mError\x1b[0m: caf\u00e9 failure"
+
+        def fake_run(cmd, **_kwargs):
+            return mod.subprocess.CompletedProcess(cmd, 1, stdout=error_text, stderr="")
+
+        monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+        with pytest.raises(ExternalScanError, match=r"\?.*Error.*\?.*caf\?"):
+            mod.SkillSpectorAdapter().scan([tmp_path])
+
 
 # ---------------------------------------------------------------------------
 # registry

--- a/tests/unit/test_external_scanners.py
+++ b/tests/unit/test_external_scanners.py
@@ -277,6 +277,43 @@ class TestSkillSpectorAdapter:
         monkeypatch.setattr(mod.shutil, "which", lambda _name: "/usr/bin/skillspector")
         assert mod.SkillSpectorAdapter().is_available() == (True, None)
 
+    def test_scan_passes_no_llm_flag(self, monkeypatch, tmp_path: Path) -> None:
+        """--no-llm must be part of the command so scans work without an API key."""
+        import apm_cli.security.external.skillspector as mod
+
+        monkeypatch.setattr(mod.shutil, "which", lambda _name: "/usr/bin/skillspector")
+
+        captured_cmd: list[str] = []
+        sarif = (
+            '{"version":"2.1.0","runs":[{"tool":{"driver":{"name":"s","rules":[]}},"results":[]}]}'
+        )
+
+        def fake_run(cmd, **_kwargs):
+            captured_cmd.extend(cmd)
+            return mod.subprocess.CompletedProcess(cmd, 0, stdout=sarif, stderr="")
+
+        monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+        mod.SkillSpectorAdapter().scan([tmp_path])
+        assert "--no-llm" in captured_cmd
+
+    def test_scan_non_json_stdout_surfaces_first_line(self, monkeypatch, tmp_path: Path) -> None:
+        """When SkillSpector writes an error to stdout, the message is surfaced."""
+        import apm_cli.security.external.skillspector as mod
+        from apm_cli.security.external.base import ExternalScanError
+
+        monkeypatch.setattr(mod.shutil, "which", lambda _name: "/usr/bin/skillspector")
+
+        error_text = "Error: NVIDIA_API_KEY not set. Please configure an API key."
+
+        def fake_run(cmd, **_kwargs):
+            return mod.subprocess.CompletedProcess(cmd, 1, stdout=error_text, stderr="")
+
+        monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+        with pytest.raises(ExternalScanError, match=r"NVIDIA_API_KEY not set"):
+            mod.SkillSpectorAdapter().scan([tmp_path])
+
 
 # ---------------------------------------------------------------------------
 # registry


### PR DESCRIPTION
## Summary

Fixes #1640 -- the SkillSpector adapter now works without an LLM API key and produces actionable error messages when the vendor CLI writes non-JSON to stdout.

## Problem

SkillSpector requires an LLM API key by default. When none is configured, the CLI writes an error message to **stdout** (not stderr). APM then tries to parse that error text as SARIF JSON, producing a confusing `JSONDecodeError` instead of surfacing the real problem.

## Changes

1. **`--no-llm` flag** -- added to the default command so scans use static analysis only, removing the API key requirement.
2. **Non-JSON stdout handling** -- the `JSONDecodeError` handler now surfaces the first line of stdout (truncated to 200 chars) so users see the actual vendor error message.
3. **Tests** -- two new tests verify the flag is passed and that non-JSON stdout produces a clear error.

## Validation

- `uv run --extra dev pytest tests/unit/test_external_scanners.py -x` -- 23/23 pass
- `ruff check` + `ruff format --check` -- clean