### PR TITLE
test(integration): repair stale integration-test drift from recent refactors

### DIFF
--- a/tests/integration/marketplace/test_pack_ux_e2e.py
+++ b/tests/integration/marketplace/test_pack_ux_e2e.py
@@ -237,35 +237,21 @@ class TestPathTraversal:
 
 
 class TestDeprecationRouting:
-    """--marketplace-output deprecation warning must go to stderr, not stdout."""
+    """--marketplace-output was removed; Click rejects it as an unknown option."""
 
-    def test_deprecation_on_stderr(self, tmp_path):
-        """Deprecation message for --marketplace-output should be on stderr."""
+    def test_marketplace_output_removed(self, tmp_path):
+        """--marketplace-output is no longer a valid option."""
         _setup_project(tmp_path)
-        mock_result = _mock_build_result()
 
-        with patch("apm_cli.commands.pack.BuildOrchestrator") as MockOrch:
-            MockOrch.return_value.run.return_value = mock_result
-            runner = CliRunner()
-            result = runner.invoke(
-                pack_cmd,
-                ["--marketplace-output", "test.json", "--json"],
-                catch_exceptions=False,
-            )
-            stdout = result.output.strip()
-            # Under --json, deprecation uses click.echo(err=True) so
-            # with default CliRunner (mix_stderr=True) it appears in output.
-            # Key assertion: the JSON portion is still parseable — strip
-            # the deprecation line and parse the rest.
-            lines = stdout.split("\n")
-            json_lines = [line for line in lines if not line.startswith("Warning:")]
-            json_str = "\n".join(json_lines).strip()
-            if json_str:
-                try:
-                    data = json.loads(json_str)
-                    assert data["ok"] is True
-                except json.JSONDecodeError:
-                    pytest.fail(f"Non-JSON content leaked to stdout:\n{json_str[:500]}")
+        runner = CliRunner()
+        result = runner.invoke(
+            pack_cmd,
+            ["--marketplace-output", "test.json", "--json"],
+        )
+        assert result.exit_code != 0
+        assert "no such option" in (result.output or "").lower() or isinstance(
+            result.exception, SystemExit
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/marketplace/test_pack_ux_e2e.py
+++ b/tests/integration/marketplace/test_pack_ux_e2e.py
@@ -249,9 +249,8 @@ class TestDeprecationRouting:
             ["--marketplace-output", "test.json", "--json"],
         )
         assert result.exit_code != 0
-        assert "no such option" in (result.output or "").lower() or isinstance(
-            result.exception, SystemExit
-        )
+        assert "no such option" in (result.output or "").lower()
+        assert "--marketplace-output" in (result.output or "")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_commands_mcp_flow.py
+++ b/tests/integration/test_commands_mcp_flow.py
@@ -1066,9 +1066,8 @@ class TestPackCommandHelp:
             result = runner.invoke(pack_cmd, ["--marketplace-output", "dist/mkt.json"])
 
         assert result.exit_code != 0
-        assert "no such option" in (result.output or "").lower() or isinstance(
-            result.exception, SystemExit
-        )
+        assert "no such option" in (result.output or "").lower()
+        assert "--marketplace-output" in (result.output or "")
 
     def test_pack_build_error_exits_nonzero(self, tmp_path: Path) -> None:
         """BuildError from orchestrator surfaces as non-zero exit."""

--- a/tests/integration/test_commands_mcp_flow.py
+++ b/tests/integration/test_commands_mcp_flow.py
@@ -1054,8 +1054,8 @@ class TestPackCommandHelp:
 
         assert "deprecated" in result.output.lower() or result.exit_code in (0, 1)
 
-    def test_pack_deprecated_marketplace_output(self, tmp_path: Path) -> None:
-        """--marketplace-output emits deprecation warning."""
+    def test_pack_marketplace_output_removed(self, tmp_path: Path) -> None:
+        """--marketplace-output was removed; Click rejects it."""
         from apm_cli.commands.pack import pack_cmd
 
         runner = CliRunner()
@@ -1063,13 +1063,12 @@ class TestPackCommandHelp:
             (Path(".") / "apm.yml").write_text(_APM_YML_MINIMAL, encoding="utf-8")
             (Path(".") / "apm.lock.yaml").write_text(_LOCKFILE_TEMPLATE, encoding="utf-8")
 
-            with patch("apm_cli.core.build_orchestrator.BuildOrchestrator.run") as mock_run:
-                mock_result = MagicMock()
-                mock_result.producer_results = []
-                mock_run.return_value = mock_result
-                result = runner.invoke(pack_cmd, ["--marketplace-output", "dist/mkt.json"])
+            result = runner.invoke(pack_cmd, ["--marketplace-output", "dist/mkt.json"])
 
-        assert "deprecated" in result.output.lower() or result.exit_code in (0, 1)
+        assert result.exit_code != 0
+        assert "no such option" in (result.output or "").lower() or isinstance(
+            result.exception, SystemExit
+        )
 
     def test_pack_build_error_exits_nonzero(self, tmp_path: Path) -> None:
         """BuildError from orchestrator surfaces as non-zero exit."""

--- a/tests/integration/test_commands_mcp_phase3c.py
+++ b/tests/integration/test_commands_mcp_phase3c.py
@@ -1066,9 +1066,8 @@ class TestPackCommandHelp:
             result = runner.invoke(pack_cmd, ["--marketplace-output", "dist/mkt.json"])
 
         assert result.exit_code != 0
-        assert "no such option" in (result.output or "").lower() or isinstance(
-            result.exception, SystemExit
-        )
+        assert "no such option" in (result.output or "").lower()
+        assert "--marketplace-output" in (result.output or "")
 
     def test_pack_build_error_exits_nonzero(self, tmp_path: Path) -> None:
         """BuildError from orchestrator surfaces as non-zero exit."""

--- a/tests/integration/test_commands_mcp_phase3c.py
+++ b/tests/integration/test_commands_mcp_phase3c.py
@@ -1054,8 +1054,8 @@ class TestPackCommandHelp:
 
         assert "deprecated" in result.output.lower() or result.exit_code in (0, 1)
 
-    def test_pack_deprecated_marketplace_output(self, tmp_path: Path) -> None:
-        """--marketplace-output emits deprecation warning."""
+    def test_pack_marketplace_output_removed(self, tmp_path: Path) -> None:
+        """--marketplace-output was removed; Click rejects it."""
         from apm_cli.commands.pack import pack_cmd
 
         runner = CliRunner()
@@ -1063,13 +1063,12 @@ class TestPackCommandHelp:
             (Path(".") / "apm.yml").write_text(_APM_YML_MINIMAL, encoding="utf-8")
             (Path(".") / "apm.lock.yaml").write_text(_LOCKFILE_TEMPLATE, encoding="utf-8")
 
-            with patch("apm_cli.core.build_orchestrator.BuildOrchestrator.run") as mock_run:
-                mock_result = MagicMock()
-                mock_result.producer_results = []
-                mock_run.return_value = mock_result
-                result = runner.invoke(pack_cmd, ["--marketplace-output", "dist/mkt.json"])
+            result = runner.invoke(pack_cmd, ["--marketplace-output", "dist/mkt.json"])
 
-        assert "deprecated" in result.output.lower() or result.exit_code in (0, 1)
+        assert result.exit_code != 0
+        assert "no such option" in (result.output or "").lower() or isinstance(
+            result.exception, SystemExit
+        )
 
     def test_pack_build_error_exits_nonzero(self, tmp_path: Path) -> None:
         """BuildError from orchestrator surfaces as non-zero exit."""

--- a/tests/integration/test_deps_models_phase3c.py
+++ b/tests/integration/test_deps_models_phase3c.py
@@ -1780,6 +1780,7 @@ class TestMaterializeInstallPath:
         lock_dep.local_path = local_pkg_rel
         lock_dep.repo_url = "_local/my-tool"
         lock_dep.resolved_commit = None
+        lock_dep.resolved_by = None
 
         path = _materialize_install_path(
             lock_dep, project_root, tmp_path / "apm_modules", cache_only=True
@@ -1802,6 +1803,7 @@ class TestMaterializeInstallPath:
         lock_dep = MagicMock()
         lock_dep.source = "local"
         lock_dep.local_path = "nonexistent/path"
+        lock_dep.resolved_by = None
 
         with pytest.raises(CacheMissError, match="local source missing"):
             _materialize_install_path(lock_dep, tmp_path, tmp_path, cache_only=True)

--- a/tests/integration/test_deps_models_validation.py
+++ b/tests/integration/test_deps_models_validation.py
@@ -1780,6 +1780,7 @@ class TestMaterializeInstallPath:
         lock_dep.local_path = local_pkg_rel
         lock_dep.repo_url = "_local/my-tool"
         lock_dep.resolved_commit = None
+        lock_dep.resolved_by = None
 
         path = _materialize_install_path(
             lock_dep, project_root, tmp_path / "apm_modules", cache_only=True
@@ -1802,6 +1803,7 @@ class TestMaterializeInstallPath:
         lock_dep = MagicMock()
         lock_dep.source = "local"
         lock_dep.local_path = "nonexistent/path"
+        lock_dep.resolved_by = None
 
         with pytest.raises(CacheMissError, match="local source missing"):
             _materialize_install_path(lock_dep, tmp_path, tmp_path, cache_only=True)

--- a/tests/integration/test_install_services_orchestration.py
+++ b/tests/integration/test_install_services_orchestration.py
@@ -80,11 +80,15 @@ def make_skill_result(
     target_paths: list[Path] | None = None,
     skill_created: bool = False,
     sub_skills_promoted: int = 0,
+    bin_deployed: int = 0,
+    bin_skipped_reason: str | None = None,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         target_paths=target_paths or [],
         skill_created=skill_created,
         sub_skills_promoted=sub_skills_promoted,
+        bin_deployed=bin_deployed,
+        bin_skipped_reason=bin_skipped_reason,
     )
 
 

--- a/tests/integration/test_install_services_phase3w5.py
+++ b/tests/integration/test_install_services_phase3w5.py
@@ -80,11 +80,15 @@ def make_skill_result(
     target_paths: list[Path] | None = None,
     skill_created: bool = False,
     sub_skills_promoted: int = 0,
+    bin_deployed: int = 0,
+    bin_skipped_reason: str | None = None,
 ) -> SimpleNamespace:
     return SimpleNamespace(
         target_paths=target_paths or [],
         skill_created=skill_created,
         sub_skills_promoted=sub_skills_promoted,
+        bin_deployed=bin_deployed,
+        bin_skipped_reason=bin_skipped_reason,
     )
 
 

--- a/tests/integration/test_integrators_end_to_end.py
+++ b/tests/integration/test_integrators_end_to_end.py
@@ -381,7 +381,7 @@ class TestSkillIntegratorFindFiles:
 
 
 # ===========================================================================
-# SkillIntegrator._dircmp_equal / _dircmp_equal
+# SkillIntegrator.is_skill_dir_identical_to_source / _dircmp_equal
 # ===========================================================================
 
 

--- a/tests/integration/test_integrators_end_to_end.py
+++ b/tests/integration/test_integrators_end_to_end.py
@@ -381,7 +381,7 @@ class TestSkillIntegratorFindFiles:
 
 
 # ===========================================================================
-# SkillIntegrator._dirs_equal / _dircmp_equal
+# SkillIntegrator._dircmp_equal / _dircmp_equal
 # ===========================================================================
 
 
@@ -393,7 +393,7 @@ class TestSkillIntegratorDirsEqual:
         dir_b.mkdir()
         (dir_a / "SKILL.md").write_text("same content")
         (dir_b / "SKILL.md").write_text("same content")
-        assert SkillIntegrator._dirs_equal(dir_a, dir_b) is True
+        assert SkillIntegrator.is_skill_dir_identical_to_source(dir_a, dir_b) is True
 
     def test_different_content(self, tmp_path: Path) -> None:
         dir_a = tmp_path / "a"
@@ -402,7 +402,7 @@ class TestSkillIntegratorDirsEqual:
         dir_b.mkdir()
         (dir_a / "SKILL.md").write_text("version 1")
         (dir_b / "SKILL.md").write_text("version 2")
-        assert SkillIntegrator._dirs_equal(dir_a, dir_b) is False
+        assert SkillIntegrator.is_skill_dir_identical_to_source(dir_a, dir_b) is False
 
     def test_different_files(self, tmp_path: Path) -> None:
         dir_a = tmp_path / "a"
@@ -411,14 +411,14 @@ class TestSkillIntegratorDirsEqual:
         dir_b.mkdir()
         (dir_a / "SKILL.md").write_text("same")
         (dir_b / "OTHER.md").write_text("same")
-        assert SkillIntegrator._dirs_equal(dir_a, dir_b) is False
+        assert SkillIntegrator.is_skill_dir_identical_to_source(dir_a, dir_b) is False
 
     def test_empty_dirs_equal(self, tmp_path: Path) -> None:
         dir_a = tmp_path / "a"
         dir_b = tmp_path / "b"
         dir_a.mkdir()
         dir_b.mkdir()
-        assert SkillIntegrator._dirs_equal(dir_a, dir_b) is True
+        assert SkillIntegrator.is_skill_dir_identical_to_source(dir_a, dir_b) is True
 
 
 # ===========================================================================

--- a/tests/integration/test_marketplace_builder_hermetic.py
+++ b/tests/integration/test_marketplace_builder_hermetic.py
@@ -342,12 +342,6 @@ class TestEnsureAuth:
 
 
 class TestOutputPath:
-    def test_marketplace_output_option_wins(self, tmp_path):
-        yml = _make_marketplace_yml_file(tmp_path)
-        out_path = tmp_path / "custom.json"
-        builder = MarketplaceBuilder(yml, options=BuildOptions(marketplace_output=out_path))
-        assert builder._output_path() == out_path
-
     def test_output_override_used_when_no_marketplace_output(self, tmp_path):
         yml = _make_marketplace_yml_file(tmp_path)
         out_path = tmp_path / "override.json"

--- a/tests/integration/test_marketplace_builder_phase3w4.py
+++ b/tests/integration/test_marketplace_builder_phase3w4.py
@@ -342,12 +342,6 @@ class TestEnsureAuth:
 
 
 class TestOutputPath:
-    def test_marketplace_output_option_wins(self, tmp_path):
-        yml = _make_marketplace_yml_file(tmp_path)
-        out_path = tmp_path / "custom.json"
-        builder = MarketplaceBuilder(yml, options=BuildOptions(marketplace_output=out_path))
-        assert builder._output_path() == out_path
-
     def test_output_override_used_when_no_marketplace_output(self, tmp_path):
         yml = _make_marketplace_yml_file(tmp_path)
         out_path = tmp_path / "override.json"

--- a/tests/integration/test_pack_install_phase3w4.py
+++ b/tests/integration/test_pack_install_phase3w4.py
@@ -99,7 +99,7 @@ class TestPackCmd:
         assert result.exit_code == 0
         assert "deprecated" in result.output.lower() or result.exit_code == 0
 
-    def test_pack_marketplace_output_deprecated_translates(self, runner, tmp_path, monkeypatch):
+    def test_pack_marketplace_output_removed(self, runner, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         plugin_dir = tmp_path / ".github" / "plugins" / "mypkg"
         plugin_dir.mkdir(parents=True)
@@ -121,8 +121,11 @@ marketplace:
 """,
         )
         result = runner.invoke(pack_cmd, ["--marketplace-output", "dist/marketplace.json"])
-        # Deprecation warning should be printed
-        assert "deprecated" in result.output.lower()
+        # Flag was removed; Click rejects it with a usage error.
+        assert result.exit_code != 0
+        assert "no such option" in (result.output or "").lower() or isinstance(
+            result.exception, SystemExit
+        )
 
     def test_pack_marketplace_path_invalid_format(self, runner, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)

--- a/tests/integration/test_pack_install_phase3w4.py
+++ b/tests/integration/test_pack_install_phase3w4.py
@@ -123,9 +123,8 @@ marketplace:
         result = runner.invoke(pack_cmd, ["--marketplace-output", "dist/marketplace.json"])
         # Flag was removed; Click rejects it with a usage error.
         assert result.exit_code != 0
-        assert "no such option" in (result.output or "").lower() or isinstance(
-            result.exception, SystemExit
-        )
+        assert "no such option" in (result.output or "").lower()
+        assert "--marketplace-output" in (result.output or "")
 
     def test_pack_marketplace_path_invalid_format(self, runner, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)

--- a/tests/integration/test_pack_unified.py
+++ b/tests/integration/test_pack_unified.py
@@ -193,7 +193,7 @@ class TestPackUnified:
         )
         claude_override = tmp_path / "dist" / "legacy-override.json"
 
-        result = runner.invoke(pack_cmd, ["--marketplace-output", str(claude_override)])
+        result = runner.invoke(pack_cmd, ["--marketplace-path", f"claude={claude_override}"])
 
         assert result.exit_code == 0, result.output
         assert claude_override.exists()
@@ -274,7 +274,7 @@ marketplace:
         _write_marketplace_block_yml(tmp_path)
 
         out_path = tmp_path / "out" / "m.json"
-        result = runner.invoke(pack_cmd, ["--marketplace-output", str(out_path)])
+        result = runner.invoke(pack_cmd, ["--marketplace-path", f"claude={out_path}"])
 
         assert result.exit_code == 0, result.output
         assert out_path.exists()

--- a/tests/integration/test_skill_integrator_phase3w4.py
+++ b/tests/integration/test_skill_integrator_phase3w4.py
@@ -236,7 +236,7 @@ class TestDircmpEqual:
         (a / "file.txt").write_text("hello")
         (b / "file.txt").write_text("hello")
 
-        assert SkillIntegrator._dirs_equal(a, b) is True
+        assert SkillIntegrator.is_skill_dir_identical_to_source(a, b) is True
 
     def test_different_content_returns_false(self, tmp_path):
         a = tmp_path / "a"
@@ -246,7 +246,7 @@ class TestDircmpEqual:
         (a / "file.txt").write_text("hello")
         (b / "file.txt").write_text("world")
 
-        assert SkillIntegrator._dirs_equal(a, b) is False
+        assert SkillIntegrator.is_skill_dir_identical_to_source(a, b) is False
 
     def test_extra_file_returns_false(self, tmp_path):
         a = tmp_path / "a"
@@ -257,7 +257,7 @@ class TestDircmpEqual:
         (b / "file.txt").write_text("hello")
         (b / "extra.txt").write_text("extra")
 
-        assert SkillIntegrator._dirs_equal(a, b) is False
+        assert SkillIntegrator.is_skill_dir_identical_to_source(a, b) is False
 
     def test_nested_identical_dirs_returns_true(self, tmp_path):
         """Lines 525-527: recursive subdirectory comparison."""
@@ -268,7 +268,7 @@ class TestDircmpEqual:
         (a / "sub" / "nested.md").write_text("same content")
         (b / "sub" / "nested.md").write_text("same content")
 
-        assert SkillIntegrator._dirs_equal(a, b) is True
+        assert SkillIntegrator.is_skill_dir_identical_to_source(a, b) is True
 
     def test_nested_different_dirs_returns_false(self, tmp_path):
         a = tmp_path / "a"
@@ -278,7 +278,7 @@ class TestDircmpEqual:
         (a / "sub" / "nested.md").write_text("version A")
         (b / "sub" / "nested.md").write_text("version B")
 
-        assert SkillIntegrator._dirs_equal(a, b) is False
+        assert SkillIntegrator.is_skill_dir_identical_to_source(a, b) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_uninstall_policy_pack_flow.py
+++ b/tests/integration/test_uninstall_policy_pack_flow.py
@@ -1775,10 +1775,10 @@ class TestPackCmdMarketplaceFilter:
         result = runner.invoke(pack_cmd, ["--marketplace-path", "unknownfmt=out.json"])
         assert result.exit_code != 0
 
-    def test_deprecated_marketplace_output_flag(
+    def test_marketplace_output_flag_removed(
         self, runner: CliRunner, tmp_path: Path, monkeypatch: Any
     ) -> None:
-        """--marketplace-output is deprecated, emits warning, translates to --marketplace-path."""
+        """--marketplace-output was removed; Click rejects it."""
         from apm_cli.commands.pack import pack_cmd
 
         monkeypatch.chdir(tmp_path)
@@ -1786,8 +1786,10 @@ class TestPackCmdMarketplaceFilter:
         (tmp_path / "apm.lock.yaml").write_text(_LOCKFILE_TEMPLATE, encoding="utf-8")
 
         result = runner.invoke(pack_cmd, ["--marketplace-output", "dist/marketplace.json"])
-        # Should warn about deprecation
-        assert "deprecated" in (result.output + (result.stderr or "")).lower()
+        assert result.exit_code != 0
+        assert "no such option" in (result.output or "").lower() or isinstance(
+            result.exception, SystemExit
+        )
 
 
 class TestPackCmdJsonOutput:

--- a/tests/integration/test_uninstall_policy_pack_flow.py
+++ b/tests/integration/test_uninstall_policy_pack_flow.py
@@ -1787,9 +1787,8 @@ class TestPackCmdMarketplaceFilter:
 
         result = runner.invoke(pack_cmd, ["--marketplace-output", "dist/marketplace.json"])
         assert result.exit_code != 0
-        assert "no such option" in (result.output or "").lower() or isinstance(
-            result.exception, SystemExit
-        )
+        assert "no such option" in (result.output or "").lower()
+        assert "--marketplace-output" in (result.output or "")
 
 
 class TestPackCmdJsonOutput:

--- a/tests/integration/test_uninstall_policy_pack_phase3.py
+++ b/tests/integration/test_uninstall_policy_pack_phase3.py
@@ -1775,10 +1775,10 @@ class TestPackCmdMarketplaceFilter:
         result = runner.invoke(pack_cmd, ["--marketplace-path", "unknownfmt=out.json"])
         assert result.exit_code != 0
 
-    def test_deprecated_marketplace_output_flag(
+    def test_marketplace_output_flag_removed(
         self, runner: CliRunner, tmp_path: Path, monkeypatch: Any
     ) -> None:
-        """--marketplace-output is deprecated, emits warning, translates to --marketplace-path."""
+        """--marketplace-output was removed; Click rejects it."""
         from apm_cli.commands.pack import pack_cmd
 
         monkeypatch.chdir(tmp_path)
@@ -1786,8 +1786,10 @@ class TestPackCmdMarketplaceFilter:
         (tmp_path / "apm.lock.yaml").write_text(_LOCKFILE_TEMPLATE, encoding="utf-8")
 
         result = runner.invoke(pack_cmd, ["--marketplace-output", "dist/marketplace.json"])
-        # Should warn about deprecation
-        assert "deprecated" in (result.output + (result.stderr or "")).lower()
+        assert result.exit_code != 0
+        assert "no such option" in (result.output or "").lower() or isinstance(
+            result.exception, SystemExit
+        )
 
 
 class TestPackCmdJsonOutput:

--- a/tests/integration/test_uninstall_policy_pack_phase3.py
+++ b/tests/integration/test_uninstall_policy_pack_phase3.py
@@ -1787,9 +1787,8 @@ class TestPackCmdMarketplaceFilter:
 
         result = runner.invoke(pack_cmd, ["--marketplace-output", "dist/marketplace.json"])
         assert result.exit_code != 0
-        assert "no such option" in (result.output or "").lower() or isinstance(
-            result.exception, SystemExit
-        )
+        assert "no such option" in (result.output or "").lower()
+        assert "--marketplace-output" in (result.output or "")
 
 
 class TestPackCmdJsonOutput:

--- a/tests/integration/test_wave6_init_pack_coverage.py
+++ b/tests/integration/test_wave6_init_pack_coverage.py
@@ -607,9 +607,8 @@ class TestPackMarketplaceOutput:
             cli, ["pack", "--marketplace-output", str(tmp_path / "marketplace.json")]
         )
         assert result.exit_code != 0
-        assert "no such option" in (result.output or "").lower() or isinstance(
-            result.exception, SystemExit
-        )
+        assert "no such option" in (result.output or "").lower()
+        assert "--marketplace-output" in (result.output or "")
 
 
 class TestPackMarketplacePath:

--- a/tests/integration/test_wave6_init_pack_coverage.py
+++ b/tests/integration/test_wave6_init_pack_coverage.py
@@ -596,18 +596,20 @@ class TestPackMarketplaceFilter:
 
 
 class TestPackMarketplaceOutput:
-    """Tests for deprecated --marketplace-output flag."""
+    """Tests for the removed --marketplace-output flag."""
 
-    def test_pack_marketplace_output_deprecated(self, runner, tmp_path, monkeypatch):
-        """--marketplace-output triggers a deprecation warning."""
+    def test_pack_marketplace_output_removed(self, runner, tmp_path, monkeypatch):
+        """--marketplace-output was removed; Click rejects it."""
         monkeypatch.chdir(tmp_path)
         clear_apm_yml_cache()
         _make_skill_project(tmp_path)
         result = runner.invoke(
             cli, ["pack", "--marketplace-output", str(tmp_path / "marketplace.json")]
         )
-        assert result.exit_code == 0, result.output
-        assert "deprecated" in result.output.lower()
+        assert result.exit_code != 0
+        assert "no such option" in (result.output or "").lower() or isinstance(
+            result.exception, SystemExit
+        )
 
 
 class TestPackMarketplacePath:


### PR DESCRIPTION
## TL;DR

Fixes all deterministic integration-test failures observed in CI run [26889317923](https://github.com/microsoft/apm/actions/runs/26889317923). The failures were **stale-test drift**: recent refactor PRs updated production code + unit tests but missed the parallel integration tests. No production code changes — tests only.

Local result: `tests/integration/` **9098 passed, 0 failed** (211 skipped — live/e2e/benchmark, deselected as in CI).

## Root causes & fixes

Four independent clusters, all caused by integration tests lagging behind merged refactors:

**A. `make_skill_result` helper missing fields (~64 tests)** — `install/services.py` now reads `skill_result.bin_deployed` / `bin_skipped_reason`, but the test helper's `SimpleNamespace` lacked them (`AttributeError`). Added both fields (defaults from `SkillIntegrationResult`) in `test_install_services_orchestration.py` and `test_install_services_phase3w5.py`.

**B. `_dirs_equal` removed (9 tests)** — `SkillIntegrator._dirs_equal(a, b)` no longer exists; the private `_dircmp_equal` now takes a `dircmp` object. Switched the two-path call sites to the public `is_skill_dir_identical_to_source(a, b)` in `test_skill_integrator_phase3w4.py` and `test_integrators_end_to_end.py`.

**C. `--marketplace-output` flag removed in #1585 (11 tests)** — the flag is gone (Click now errors "No such option"). Mirrored #1585's own test treatment:
- Real override tests → converted to the replacement `--marketplace-path claude=PATH`.
- Deprecation-only tests → rewritten as removed-flag traps (`exit_code != 0` + "no such option").
- Two `BuildOptions(marketplace_output=...)` builder tests → deleted (the field no longer exists; #1585 deleted the analogous unit test).

**D. `resolved_by` MagicMock truthy (4 tests)** — top-level local `MagicMock` deps left `resolved_by` unset, so it auto-returned a truthy Mock and path anchoring raised `LocalResolutionError`. Set `resolved_by = None` in the affected `TestMaterializeInstallPath` tests.

## Validation

- Affected files run green individually and as a batch.
- Full `APM_RUN_INTEGRATION_TESTS=1 uv run pytest tests/integration/ -n auto`: **9098 passed, 0 failed**.
- Lint gate clean: `ruff check`, `ruff format --check`, pylint R0801 (10.00/10), `scripts/lint-auth-signals.sh`.

## Out of scope (not changed — deliberately)

Two failure groups from the CI run were **not** stale-test drift and **pass/skip locally**, so they are excluded:
- `test_selective_install_mcp.py` (3 tests) — failed in CI with an org-policy block (`enforcement=block`, `ghcr.io/acme/mcp-shared not in allowed sources`); not reproducible locally. Looks like a CI policy-floor / state-leakage condition, not a code/test bug.
- `test_guardrailing_hero_e2e.py::test_2_minute_guardrailing_flow` — `requires_e2e_mode`, depends on external `apm-sample-package` content; skipped locally without `APM_E2E_TESTS`.

These should be looked at separately as CI-environment / external-dependency issues rather than test drift.

## How to test

```bash
APM_RUN_INTEGRATION_TESTS=1 uv run pytest tests/integration/ -q -n auto
```