### PR TITLE
test(integration): fix guardrailing hero E2E against distributed-compile model

### DIFF
--- a/tests/integration/test_guardrailing_hero_e2e.py
+++ b/tests/integration/test_guardrailing_hero_e2e.py
@@ -10,7 +10,8 @@ Exercises a guardrailing workflow with mixed package types:
 
 This validates that:
 - Multiple APM packages can be installed (full package + virtual instruction)
-- AGENTS.md is generated with combined instructions from both packages
+- Compilation produces combined instructions from both packages (distributed
+  across AGENTS.md and .github/instructions/)
 - Prompts from installed packages can be executed
 """
 
@@ -117,7 +118,7 @@ class TestGuardrailingHeroScenario:
         1. apm init my-project creates minimal project
         2. apm install microsoft/apm-sample-package succeeds
         3. apm install github/awesome-copilot/instructions/code-review-generic.instructions.md succeeds
-        4. apm compile generates AGENTS.md with instructions from both packages
+        4. apm compile produces combined instructions from both packages
         5. apm run design-review executes prompt from first installed package
         """
 
@@ -190,15 +191,26 @@ class TestGuardrailingHeroScenario:
             agents_md = project_dir / "AGENTS.md"
             assert agents_md.exists(), "AGENTS.md not generated"
 
-            # Verify AGENTS.md contains instructions from both packages
-            agents_content = agents_md.read_text()
-            assert "design" in agents_content.lower(), (
-                "AGENTS.md doesn't contain design-related content from apm-sample-package"
+            # The distributed-primitives compile model routes instruction content
+            # into per-glob files under .github/instructions/ (and, when present,
+            # .github/copilot-instructions.md), leaving the root AGENTS.md as a thin
+            # stub. Aggregate the full compiled corpus so the assertions hold
+            # regardless of where each instruction lands.
+            compiled_sources = [agents_md, project_dir / ".github" / "copilot-instructions.md"]
+            compiled_sources.extend(sorted((project_dir / ".github" / "instructions").glob("*.md")))
+            compiled_content = "\n".join(
+                p.read_text() for p in compiled_sources if p.exists()
+            ).lower()
+
+            # Verify the compiled corpus contains instructions from both packages
+            assert "design" in compiled_content, (
+                "Compiled instructions don't contain design-related content from apm-sample-package"
             )
-            assert "review" in agents_content.lower() or "code" in agents_content.lower(), (
-                "AGENTS.md doesn't contain code-review content from awesome-copilot"
+            assert "review" in compiled_content or "code" in compiled_content, (
+                "Compiled instructions don't contain code-review content from awesome-copilot"
             )
 
+            agents_content = agents_md.read_text()
             print(f"[OK] AGENTS.md generated ({len(agents_content)} bytes)")
             print("  Contains design instructions: [OK]")
             print("  Contains code-review instructions: [OK]")


### PR DESCRIPTION
## TL;DR

`test_2_minute_guardrailing_flow` was failing in CI ([run 26893310988](https://github.com/microsoft/apm/actions/runs/26893310988/job/79325592660)) because it asserted the root `AGENTS.md` contains `design` and `review/code` instruction content. Under the current distributed-primitives compile model, that content is routed into `.github/instructions/*.md` (gated by `applyTo`), leaving root `AGENTS.md` as a thin stub. The test now asserts against the full compiled corpus.

## Problem

```
AssertionError: AGENTS.md doesn't contain design-related content from apm-sample-package
```

The generated root `AGENTS.md` is intentionally a stub. This is **not a product regression** -- `apm compile` distributes per-glob instruction content into `.github/instructions/` (and `.github/copilot-instructions.md` when applicable). The test's assumption that all content is inlined into root `AGENTS.md` was stale.

## Approach

Aggregate the full compiled corpus before asserting: `AGENTS.md`, `.github/copilot-instructions.md` (when present), and `.github/instructions/*.md`. Then assert `design` and `review`/`code` appear somewhere in that combined corpus.

## Validation

Reproduced the exact live flow locally (init -> install `microsoft/apm-sample-package` -> install awesome-copilot instruction -> compile):
- Root `AGENTS.md` is a 233-byte stub (no instruction body).
- `design` content -> `.github/instructions/design-standards.instructions.md`.
- `review`/`code` content -> `.github/instructions/code-review-generic.instructions.md`.

Test now passes (1 passed in 14.91s). `ruff check` + `ruff format --check` clean.

## How to test

```bash
export GITHUB_TOKEN=$(gh auth token) APM_E2E_TESTS=1 APM_RUN_INTEGRATION_TESTS=1
export APM_BINARY_PATH=$PWD/.venv/bin/apm PATH="$PWD/.venv/bin:$PATH"
uv run --extra dev pytest tests/integration/test_guardrailing_hero_e2e.py -q
```