### PR TITLE
fix(lock): always write apm.lock.yaml and repair local-dep e2e syntax

### DIFF
--- a/src/apm_cli/install/phases/lockfile.py
+++ b/src/apm_cli/install/phases/lockfile.py
@@ -67,12 +67,18 @@ class LockfileBuilder:
 
     def build_and_save(self) -> None:
         """Assemble lockfile from ctx state and write it (no-op when nothing was installed)."""
-        if not self.ctx.installed_packages:
+        if not self.ctx.installed_packages and not self.ctx.lockfile_only:
             # Even with nothing newly installed, a pre-existing
             # lockfile may need its cache pin markers refreshed --
             # e.g. user upgraded APM and their cache pre-dates the
             # marker contract. Sync best-effort against the on-disk
             # lockfile.
+            #
+            # In lockfile_only mode (``apm lock``) we deliberately fall
+            # through even with zero dependencies: the command's core
+            # promise is to always materialise an ``apm.lock.yaml`` (an
+            # empty one for a depless project), mirroring
+            # ``cargo generate-lockfile``.
             self._sync_cache_pin_markers_from_disk()
             return
         try:

--- a/src/apm_cli/install/pipeline.py
+++ b/src/apm_cli/install/pipeline.py
@@ -316,6 +316,44 @@ def _preflight_auth_check(ctx, auth_resolver, verbose: bool) -> None:
             _trace(f"Preflight: {host_display} -- accepted")
 
 
+def _write_empty_lockfile_only(apm_dir: Path) -> None:
+    """Materialise an empty ``apm.lock.yaml`` for a depless ``apm lock`` run.
+
+    ``apm lock`` promises to always produce a lockfile, even when the
+    project declares zero dependencies (mirroring ``cargo
+    generate-lockfile``). The write is skipped when an equivalent
+    lockfile already exists so repeat runs don't churn ``generated_at``.
+    """
+    from ..deps.lockfile import LockFile, get_lockfile_path
+
+    lock_path = get_lockfile_path(apm_dir)
+    new_lock = LockFile.from_installed_packages([], None)
+    existing_lock = LockFile.read(lock_path) if lock_path.exists() else None
+    if not (existing_lock and new_lock.is_semantically_equivalent(existing_lock)):
+        new_lock.save(lock_path)
+
+
+def _is_no_work_install(
+    *,
+    all_apm_deps,
+    root_has_local_primitives: bool,
+    old_local_deployed,
+    has_orphan_deps: bool,
+    lockfile_only: bool,
+    apm_dir: Path | None,
+) -> bool:
+    """Return True when there is genuinely no install/cleanup work to do.
+
+    In ``lockfile_only`` mode (``apm lock``) an empty lockfile is written
+    before returning so the command always materialises its artefact.
+    """
+    if all_apm_deps or root_has_local_primitives or old_local_deployed or has_orphan_deps:
+        return False
+    if lockfile_only and apm_dir:
+        _write_empty_lockfile_only(apm_dir)
+    return True
+
+
 def run_install_pipeline(  # noqa: PLR0913, RUF100
     apm_package: APMPackage,
     update_refs: bool = False,
@@ -424,11 +462,13 @@ def run_install_pipeline(  # noqa: PLR0913, RUF100
         _early_lockfile and any(k != _SELF_KEY for k in _early_lockfile.dependencies)
     )
 
-    if (
-        not all_apm_deps
-        and not _root_has_local_primitives
-        and not _old_local_deployed
-        and not _has_orphan_deps
+    if _is_no_work_install(
+        all_apm_deps=all_apm_deps,
+        root_has_local_primitives=_root_has_local_primitives,
+        old_local_deployed=_old_local_deployed,
+        has_orphan_deps=_has_orphan_deps,
+        lockfile_only=lockfile_only,
+        apm_dir=apm_dir,
     ):
         return InstallResult()
 

--- a/tests/integration/test_lock_e2e.py
+++ b/tests/integration/test_lock_e2e.py
@@ -137,7 +137,7 @@ class TestLockLocalDep:
         pkg_dir = tmp_path / "my-skills"
         _make_local_package(pkg_dir, "my-skills")
 
-        _write_apm_yml(project, deps=[f"local:{pkg_dir}"])
+        _write_apm_yml(project, deps=[str(pkg_dir)])
 
         result = _run_apm(apm_command, ["lock"], project)
 
@@ -165,7 +165,7 @@ class TestLockLocalDep:
         pkg_dir = tmp_path / "my-skills"
         _make_local_package(pkg_dir, "my-skills")
 
-        _write_apm_yml(project, deps=[f"local:{pkg_dir}"])
+        _write_apm_yml(project, deps=[str(pkg_dir)])
         _run_apm(apm_command, ["lock"], project)
 
         lockfile = project / "apm.lock.yaml"
@@ -182,7 +182,7 @@ class TestLockLocalDep:
 
         pkg_dir = tmp_path / "my-skills"
         _make_local_package(pkg_dir, "my-skills")
-        _write_apm_yml(project, deps=[f"local:{pkg_dir}"])
+        _write_apm_yml(project, deps=[str(pkg_dir)])
 
         _run_apm(apm_command, ["lock"], project)
         first = (project / "apm.lock.yaml").read_text(encoding="utf-8")


### PR DESCRIPTION
## TL;DR

Fixes the 5 failing `tests/integration/test_lock_e2e.py` tests ([CI run](https://github.com/microsoft/apm/actions/runs/26897603919/job/79341391633)). Two distinct bugs: `apm lock` produced no lockfile for a depless project, and the local-dep tests used an unsupported dependency syntax.

## Problem

1. **Empty-deps `apm lock` wrote no lockfile.** `run_install_pipeline` short-circuits with `InstallResult()` when there are zero dependencies and no local primitives — *before* the lockfile phase runs. So `apm lock` exited 0 but never produced `apm.lock.yaml`, breaking the command's core promise (always materialise a lockfile, like `cargo generate-lockfile`).
2. **Local-dep tests used unsupported syntax.** The tests declared deps as `local:<path>`, but APM's local-dependency syntax is a **bare path** (`./x`, `/abs/x`). The `local:` prefix was rejected by the dependency reference parser, so `apm lock` exited 1.

## Approach

- **`pipeline.py`** — In `lockfile_only` mode, materialise an (empty) `apm.lock.yaml` before the no-work short-circuit. Extracted `_is_no_work_install` and `_write_empty_lockfile_only` helpers so `run_install_pipeline` stays under the C901 complexity gate (was at the 50 limit). The write is skipped when an equivalent lockfile already exists, so repeat runs don't churn `generated_at`.
- **`phases/lockfile.py`** — Let `lockfile_only` mode fall through to write a lockfile even with zero installed packages (covers the edge case where a project has root `.apm/` primitives but no declared deps).
- **`test_lock_e2e.py`** — Use the supported bare local-path dependency syntax.

## Validation

- All 5 `test_lock_e2e.py` tests pass locally.
- Broader regression sweep: install/lockfile/pipeline unit + integration suites (3700+ tests) pass, no regressions.
- Full lint chain green: ruff check/format, pylint R0801 duplication, auth-signal boundary.

## How to test

```bash
PATH="$(pwd)/.venv/bin:$PATH" uv run --extra dev pytest tests/integration/test_lock_e2e.py -q
```