### PR TITLE
fix(deps): reject shorthand alias syntax (supersedes #1301)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking
+
+- Reject string-form `@alias` dependency shorthand at parse time with a migration error; use object form with `alias:` instead -- by @prateek (#1301)
+
 ## [0.17.0] - 2026-06-03
 
 ### Added

--- a/docs/src/content/docs/consumer/manage-dependencies.md
+++ b/docs/src/content/docs/consumer/manage-dependencies.md
@@ -54,8 +54,6 @@ parser. The supported forms:
 |---|---|---|
 | GitHub shorthand | `owner/repo` | Public GitHub repo, latest default branch. |
 | Pinned ref | `owner/repo#v1.0.0` | Pin to a tag, branch, or full commit SHA. |
-| Aliased | `owner/repo@my-alias` | Install under a custom directory name. |
-| Pinned + aliased | `owner/repo#v1.0.0@my-alias` | Combine the two. |
 | FQDN shorthand | `gitlab.com/acme/repo#v2.0` | Any git host, not just github.com. |
 | Virtual subdirectory | `owner/repo/skills/review` | Install one skill folder from a monorepo. |
 | Virtual file | `owner/repo/prompts/review.prompt.md` | Install a single primitive file. |
@@ -64,7 +62,7 @@ parser. The supported forms:
 | SSH protocol | `ssh://git@gitlab.com/acme/repo.git` | SSH with explicit scheme or port. |
 | SSH with non-default user | `myuser@host:acme/repo.git` or `ssh://myuser@host/acme/repo.git` | Honors a non-`git` SSH user from the URL — useful for Enterprise Managed User (EMU) accounts or any server where the SSH login is not `git`. Username is validated against `^[a-zA-Z0-9_][a-zA-Z0-9_.+-]*$` (64-char cap); percent-encoded userinfo is rejected. The username is presentation-only and not part of dependency identity. |
 | Local path | `./packages/shared` or `/abs/path` | Sibling package on disk. |
-| Object form (git) | `{ git: <url>, path: <subpath>, ref: <ref> }` | Escape hatch for nested groups, monorepo subpaths, or aliases that the string forms cannot express. |
+| Object form (git) | `{ git: <url>, path: <subpath>, ref: <ref>, alias: <name> }` | Custom directory name (`alias`), nested groups, monorepo subpaths, or anything the string forms cannot express. |
 | Registry shorthand | `owner/repo#^2.0.0` with a default registry configured | Routes dep through the default registry instead of git. Default may come from `apm.yml` or `~/.apm/config.json`. Requires `registries` experimental flag. |
 | Registry object form | `{ id: owner/repo, version: ^2.0.0 }` | Explicit registry dep. `registry:` optional when a default registry is configured. Requires `registries` experimental flag. |
 
@@ -92,6 +90,13 @@ dependencies:
 
 For private repos and non-GitHub hosts, see
 [Private and org packages](../private-and-org-packages/).
+
+:::caution[Alias migration]
+The shorthand `@alias` suffix is not supported on string references. Use
+object form instead: `- git: https://github.com/owner/repo.git` plus
+`alias: my-name`. This keeps `@` reserved for git usernames and future
+package-manager-compatible version syntax.
+:::
 
 For registry-sourced dependencies (internal packages on Artifactory or a custom registry), see
 [Registries](../../guides/registries/).

--- a/docs/src/content/docs/consumer/manage-dependencies.md
+++ b/docs/src/content/docs/consumer/manage-dependencies.md
@@ -93,9 +93,16 @@ For private repos and non-GitHub hosts, see
 
 :::caution[Alias migration]
 The shorthand `@alias` suffix is not supported on string references. Use
-object form instead: `- git: https://github.com/owner/repo.git` plus
-`alias: my-name`. This keeps `@` reserved for git usernames and future
-package-manager-compatible version syntax.
+object form instead:
+
+```yaml
+- git: https://github.com/owner/repo.git
+  path: skills/example
+  alias: my-name
+```
+
+Omit `path:` for whole-repo dependencies. Keeping aliases explicit reserves
+`@` for git usernames and future package-manager-compatible version syntax.
 :::
 
 For registry-sourced dependencies (internal packages on Artifactory or a custom registry), see

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -118,7 +118,8 @@ both protocols.
 ## Object form (complex cases)
 
 Use object form when you need a custom install directory name. The legacy
-string suffix `@alias` is not supported; write `alias:` explicitly instead.
+string suffix `@alias` is not supported; write `alias:` explicitly instead so
+`@` remains reserved for git usernames and version syntax.
 
 ```yaml
 - git: https://gitlab.com/acme/repo.git

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -117,6 +117,9 @@ both protocols.
 
 ## Object form (complex cases)
 
+Use object form when you need a custom install directory name. The legacy
+string suffix `@alias` is not supported; write `alias:` explicitly instead.
+
 ```yaml
 - git: https://gitlab.com/acme/repo.git
   path: instructions/security                   # virtual sub-path

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -477,11 +477,11 @@ class DependencyReference:
 
         Bare ``@alias`` is not part of the supported reference grammar (#340
         retired the ``@`` separator to avoid the npm/go/cargo ``@version``
-        collision). The dedicated SSH parsers extract ``@alias`` from
-        ``ssh://`` URLs and SCP shorthand (``<user>@host:path``); this guard
-        fires for the remaining cases like ``owner/repo[/sub][#ref]@alias``,
-        which would otherwise silently leak the alias into ``virtual_path``
-        or ``reference``.
+        collision). The dedicated SSH parsers handle ``@`` in ``ssh://`` URLs
+        and SCP shorthand (``<user>@host:path``) as userinfo, not aliases; this
+        guard fires for the remaining cases like
+        ``owner/repo[/sub][#ref]@alias``, which would otherwise silently leak
+        the alias into ``virtual_path`` or ``reference``.
         """
         stripped = dependency_str.strip()
         if "@" not in stripped:
@@ -490,10 +490,13 @@ class DependencyReference:
             return
         if SCP_LIKE_RE.match(stripped):
             return
+        preview = "".join(ch if 32 <= ord(ch) <= 126 else "?" for ch in stripped)
+        if len(preview) > 160:
+            preview = f"{preview[:157]}..."
         raise ValueError(
-            f"Shorthand '@alias' is not supported in '{dependency_str}'. "
-            f"Use the object form with an 'alias:' field to install a "
-            f"dependency under a custom directory name. "
+            f"Shorthand '@alias' is not supported in '{preview}'. "
+            f"Use object form with 'git:', optional 'path:', and 'alias:' "
+            f"fields to install a dependency under a custom directory name. "
             f"See: https://microsoft.github.io/apm/consumer/manage-dependencies/#reference-formats"
         )
 

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -472,6 +472,32 @@ class DependencyReference:
         return result
 
     @staticmethod
+    def _reject_shorthand_alias(dependency_str: str) -> None:
+        """Reject bare-shorthand ``@alias`` with an actionable migration error.
+
+        Bare ``@alias`` is not part of the supported reference grammar (#340
+        retired the ``@`` separator to avoid the npm/go/cargo ``@version``
+        collision). The dedicated SSH parsers extract ``@alias`` from
+        ``ssh://`` URLs and SCP shorthand (``<user>@host:path``); this guard
+        fires for the remaining cases like ``owner/repo[/sub][#ref]@alias``,
+        which would otherwise silently leak the alias into ``virtual_path``
+        or ``reference``.
+        """
+        stripped = dependency_str.strip()
+        if "@" not in stripped:
+            return
+        if stripped.lower().startswith(("https://", "http://", "ssh://")):
+            return
+        if SCP_LIKE_RE.match(stripped):
+            return
+        raise ValueError(
+            f"Shorthand '@alias' is not supported in '{dependency_str}'. "
+            f"Use the object form with an 'alias:' field to install a "
+            f"dependency under a custom directory name. "
+            f"See: https://microsoft.github.io/apm/consumer/manage-dependencies/#reference-formats"
+        )
+
+    @staticmethod
     def _parse_ssh_protocol_url(url: str):
         """Parse an ``ssh://`` protocol URL using ``urllib.parse.urlparse``.
 
@@ -1645,8 +1671,6 @@ class DependencyReference:
         - user/repo#v1.0.0
         - user/repo#commit_sha
         - github.com/user/repo#ref
-        - user/repo@alias
-        - user/repo#ref@alias
         - user/repo/path/to/file.prompt.md (virtual file package)
         - user/repo/skills/foo (virtual subdirectory package)
         - user/repo/collections/foo (virtual subdirectory package)
@@ -1703,6 +1727,8 @@ class DependencyReference:
             raise ValueError(
                 unsupported_host_error("//...", context="Protocol-relative URLs are not supported")
             )
+
+        cls._reject_shorthand_alias(dependency_str)
 
         maybe_raise_bare_fqdn_github_gitlab_conflict(dependency_str)
 

--- a/tests/unit/test_canonicalization.py
+++ b/tests/unit/test_canonicalization.py
@@ -32,16 +32,51 @@ class TestToCanonical:
         dep = DependencyReference.parse("microsoft/apm-sample-package#v1.0")
         assert dep.to_canonical() == "microsoft/apm-sample-package#v1.0"
 
-    def test_shorthand_with_alias_shorthand_removed(self):
-        """Shorthand @alias syntax is no longer supported in parsing."""
-        with pytest.raises(ValueError):
+    def test_shorthand_alias_rejected(self):
+        """Shorthand @alias syntax is rejected with a migration error."""
+        with pytest.raises(ValueError, match="Shorthand '@alias' is not supported"):
             DependencyReference.parse("microsoft/apm-sample-package@my-alias")
 
-    def test_shorthand_with_ref_and_alias_shorthand_not_parsed(self):
-        """Shorthand #ref@alias — @ is no longer parsed as alias separator."""
-        dep = DependencyReference.parse("microsoft/apm-sample-package#main@my-alias")
-        assert dep.to_canonical() == "microsoft/apm-sample-package#main@my-alias"
-        assert dep.alias is None  # @ is part of the ref, not an alias
+    def test_shorthand_with_ref_and_alias_rejected(self):
+        """Shorthand #ref@alias is rejected with a migration error."""
+        with pytest.raises(ValueError, match="Shorthand '@alias' is not supported"):
+            DependencyReference.parse("microsoft/apm-sample-package#main@my-alias")
+
+    def test_shorthand_with_subpath_and_alias_rejected(self):
+        """Subpath + @alias rejected loudly (was the silent-miscoercion bug)."""
+        with pytest.raises(ValueError, match="Shorthand '@alias' is not supported"):
+            DependencyReference.parse("stablyai/orca/skills/orchestration@orca-stration")
+
+    def test_shorthand_with_deeper_subpath_and_alias_rejected(self):
+        """Multi-segment subpath + @alias is also rejected."""
+        with pytest.raises(ValueError, match="Shorthand '@alias' is not supported"):
+            DependencyReference.parse("owner/repo/skills/foo/deeper@my-alias")
+
+    def test_shorthand_with_subpath_ref_and_alias_rejected(self):
+        """All four parts (subpath + #ref + @alias) trip the same uniform error."""
+        with pytest.raises(ValueError, match="Shorthand '@alias' is not supported"):
+            DependencyReference.parse("owner/repo/skills/foo#main@my-alias")
+
+    def test_fqdn_shorthand_with_alias_rejected(self):
+        """FQDN shorthand + @alias is rejected (covers the non-nested-group FQDN path)."""
+        with pytest.raises(ValueError, match="Shorthand '@alias' is not supported"):
+            DependencyReference.parse("github.com/owner/repo@my-alias")
+
+    def test_url_encoded_at_in_alias_shorthand_rejected(self):
+        """Percent-encoded ``@`` in shorthand is also rejected."""
+        with pytest.raises(ValueError, match="Shorthand '@alias' is not supported"):
+            DependencyReference.parse("owner/repo%40my-alias")
+
+    def test_trailing_at_with_no_alias_rejected(self):
+        """A bare trailing ``@`` is rejected (not silently stripped)."""
+        with pytest.raises(ValueError, match="Shorthand '@alias' is not supported"):
+            DependencyReference.parse("owner/repo@")
+
+    def test_https_with_embedded_credentials_parses(self):
+        """Guard must not fire on HTTPS userinfo (regression: don't over-reject ``@``)."""
+        dep = DependencyReference.parse("https://user@github.com/owner/repo.git")
+        assert dep.repo_url == "owner/repo"
+        assert dep.alias is None
 
     def test_fqdn_github(self):
         """FQDN with default host strips the host."""
@@ -145,15 +180,9 @@ class TestGetIdentity:
         dep = DependencyReference.parse("owner/repo#v1.0")
         assert dep.get_identity() == "owner/repo"
 
-    def test_shorthand_with_alias_shorthand_removed(self):
-        """Shorthand @alias syntax is no longer supported."""
-        with pytest.raises(ValueError):
-            DependencyReference.parse("owner/repo@my-alias")
-
-    def test_shorthand_with_ref_and_alias_shorthand_not_parsed(self):
-        """Shorthand #ref@alias — @ becomes part of the ref, identity still strips ref."""
-        dep = DependencyReference.parse("owner/repo#main@my-alias")
-        assert dep.get_identity() == "owner/repo"
+    # Shorthand @alias rejection is covered in TestToCanonical; parse() raises
+    # before get_identity() runs, so duplicating the cases here would prove
+    # nothing about identity semantics.
 
     def test_fqdn_github(self):
         """Default host is stripped from identity."""

--- a/tests/unit/test_generic_git_urls.py
+++ b/tests/unit/test_generic_git_urls.py
@@ -624,17 +624,20 @@ class TestNestedGroupSupport:
         assert dep.reference == "v2.0"
         assert dep.is_virtual is False
 
-    def test_nested_group_with_alias_shorthand_removed(self):
-        """Shorthand @alias on nested groups is no longer supported."""
-        with pytest.raises(ValueError):
+    def test_nested_group_alias_rejected(self):
+        """Shorthand @alias on nested groups is rejected."""
+        with pytest.raises(ValueError, match="Shorthand '@alias' is not supported"):
             DependencyReference.parse("gitlab.com/group/subgroup/repo@my-alias")
 
-    def test_nested_group_with_ref_and_alias_shorthand_not_parsed(self):
-        """Shorthand #ref@alias on nested groups — @ is no longer parsed as alias separator."""
-        dep = DependencyReference.parse("gitlab.com/group/subgroup/repo#main@alias")
-        assert dep.repo_url == "group/subgroup/repo"
-        assert dep.reference == "main@alias"
-        assert dep.alias is None
+    def test_nested_group_with_ref_and_alias_rejected(self):
+        """Shorthand #ref@alias on nested groups is rejected at parse time."""
+        with pytest.raises(ValueError, match="Shorthand '@alias' is not supported"):
+            DependencyReference.parse("gitlab.com/group/subgroup/repo#main@alias")
+
+    def test_nested_group_with_subpath_and_alias_rejected(self):
+        """Subpath + alias under a nested group is rejected (silent-miscoercion bug fix)."""
+        with pytest.raises(ValueError, match="Shorthand '@alias' is not supported"):
+            DependencyReference.parse("gitlab.com/group/subgroup/repo/skills/foo@my-alias")
 
     # --- SSH URLs ---
 

--- a/tests/unit/test_package_identity.py
+++ b/tests/unit/test_package_identity.py
@@ -54,16 +54,15 @@ class TestCanonicalDependencyString:
         dep = DependencyReference.parse("owner/repo#v1.0.0")
         assert dep.get_canonical_dependency_string() == "owner/repo"
 
-    def test_regular_github_package_with_alias_shorthand_removed(self):
-        """Shorthand @alias syntax is no longer supported."""
-        with pytest.raises(ValueError):
+    def test_regular_github_package_alias_rejected(self):
+        """Shorthand @alias syntax is rejected with a migration error."""
+        with pytest.raises(ValueError, match="Shorthand '@alias' is not supported"):
             DependencyReference.parse("owner/repo@myalias")
 
-    def test_regular_github_package_with_reference_and_alias_shorthand_not_parsed(self):
-        """Shorthand #ref@alias — @ is no longer parsed as alias separator."""
-        dep = DependencyReference.parse("owner/repo#main@myalias")
-        assert dep.reference == "main@myalias"
-        assert dep.alias is None
+    def test_regular_github_package_with_reference_and_alias_rejected(self):
+        """Shorthand #ref@alias is rejected at parse time with a migration error."""
+        with pytest.raises(ValueError, match="Shorthand '@alias' is not supported"):
+            DependencyReference.parse("owner/repo#main@myalias")
 
     def test_virtual_file_package(self):
         """Virtual file includes full path."""


### PR DESCRIPTION
fix(deps): reject shorthand alias syntax with migration guidance

## TL;DR

This supersedes #1301 because the maintainer token could not update the contributor fork after rebasing onto latest `main`. It keeps @prateek's parser fix, folds the required Breaking changelog entry, adds migration docs, and clarifies the parse error so users can move to object form.

> [!NOTE]
> Supersedes #1301. Original author commit is preserved; the follow-up commit includes an author co-author trailer.

## Problem (WHY)

- [x] String-form `owner/repo/sub/path@alias` silently treated `@alias` as part of `virtual_path`, producing a later install failure instead of a parse-time migration error.
- [x] The original PR was `CONFLICTING` / `DIRTY` against latest `main`, so the branch needed a rebase before it could land.
- [!] Because this is a breaking parse behavior change, users needed the change called out in `CHANGELOG.md` and the dependency-format docs before merge.

Why these matter: a parser should reject unsupported dependency syntax before resolution or filesystem work, and the reviewer needs deterministic evidence for that behavior. This follows the PR-description skill anchor: ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/).

## Approach (WHAT)

| # | Fix | Principle | Source |
|---|-----|-----------|--------|
| 1 | Reject string-form `@alias` after URL-decoding but before protocol dispatch. | ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) | `src/apm_cli/models/dependency/reference.py` |
| 2 | Keep valid `@` forms for HTTPS userinfo, `ssh://` userinfo, and SCP shorthand. | ["Add what the agent lacks, omit what it knows"](https://agentskills.io/skill-creation/best-practices) | Unit regression tests |
| 3 | Add the Breaking changelog entry plus web-doc and package-guide migration notes. | ["agents pattern-match well against concrete structures"](https://agentskills.io/skill-creation/best-practices) | `CHANGELOG.md`, docs |

## Implementation (HOW)

- **`src/apm_cli/models/dependency/reference.py`** -- adds `_reject_shorthand_alias()` in the parse pipeline, sanitizes/truncates the rejected input before echoing it, and keeps legitimate `@`-userinfo URL forms on their existing parser paths.
- **`tests/unit/test_canonicalization.py`** -- covers whole-repo, subpath, ref-plus-alias, percent-encoded, and trailing-at shorthand rejection, including the original subpath regression.
- **`tests/unit/test_generic_git_urls.py`** and **`tests/unit/test_package_identity.py`** -- extend generic-host and identity coverage so GitLab nested subpaths and canonical strings reject shorthand aliases consistently.
- **`CHANGELOG.md`**, **`docs/src/content/docs/consumer/manage-dependencies.md`**, and **`packages/apm-guide/.apm/skills/apm-usage/dependencies.md`** -- document the breaking migration path and show copy-paste object-form aliases.

## Diagrams

Legend: The parser now fails unsupported alias shorthand before any protocol-specific parsing or virtual-path detection can misclassify it.

```mermaid
flowchart LR
    subgraph Input[Input]
        Raw["dependency string"]
        Decode["urllib.parse.unquote"]
    end
    subgraph Guard[Guard]
        Local{"local path?"}
        Alias{"unsupported @alias?"}
        Error["ValueError with object-form migration"]
    end
    subgraph Parse[Protocol parse]
        SSH["ssh and SCP userinfo"]
        URL["http or https URL"]
        Virtual["virtual path detection"]
    end
    Raw --> Decode
    Decode --> Local
    Local -->|"yes"| Parse
    Local -->|"no"| Alias
    Alias -->|"yes"| Error
    Alias -->|"no"| SSH
    Alias -->|"no"| URL
    Alias -->|"no"| Virtual
    classDef new stroke-dasharray: 5 5;
    class Alias,Error new;
```

## Trade-offs

- **Reject, do not normalize.** Chose a parse-time error; rejected silently converting shorthand into object form because that would hide deprecated syntax and keep ambiguity around `@`.
- **Unit boundary proof.** Chose direct `DependencyReference.parse()` tests; rejected broader install tests because the changed contract is the parser boundary and all install callers flow through it.
- **Superseding branch.** Chose a maintainer-owned superseding PR after fork push was rejected; rejected further fork-push retries because GitHub refused workflow-history updates without `workflow` scope.

## Benefits

1. Unsupported `@alias` forms now fail at parse time with one migration message.
2. Valid auth/userinfo forms using `@` still parse, preserving SSH and HTTPS credential behavior.
3. Users get migration guidance in the CLI error, changelog, web docs, and packaged APM usage guide.
4. The PR is rebased onto latest `origin/main` and no longer carries the prior conflicting state.

## Validation

`uv run --extra dev pytest tests/unit/test_canonicalization.py tests/unit/test_generic_git_urls.py tests/unit/test_package_identity.py -q`:

```
279 passed in 0.93s
```

`uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/`:

```
All checks passed!
1210 files already formatted
```

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|------------------------|--------------|--------------------|------|
| 1 | A user declaring `owner/repo/skills/foo@alias` gets a clear migration error instead of a later missing-subdirectory failure. | Secure by default, DevX | `tests/unit/test_canonicalization.py::TestToCanonical::test_shorthand_with_subpath_and_alias_rejected` | unit |
| 2 | A user with legitimate HTTPS or SSH userinfo containing `@` is not blocked by the shorthand guard. | Vendor-neutral, DevX | `tests/unit/test_canonicalization.py::TestToCanonical::test_https_with_embedded_credentials_parses`; `tests/unit/test_generic_git_urls.py` SSH cases | unit |
| 3 | GitLab-style nested subpaths reject shorthand alias syntax the same way as GitHub shorthand. | Vendor-neutral, Secure by default | `tests/unit/test_generic_git_urls.py::TestNestedGroupSupport::test_nested_group_with_subpath_and_alias_rejected` | unit |

## How to test

- [ ] Run the targeted pytest command above -> expect `279 passed`.
- [ ] Run the ruff lint pair above -> expect `All checks passed!` and formatter check success.
- [ ] Parse `owner/repo/skills/foo@alias` in a Python shell -> expect `ValueError` that points to object form with `alias:`.
- [ ] Parse `https://user@github.com/owner/repo.git` -> expect `repo_url == "owner/repo"` and no shorthand-alias error.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
