### PR TITLE
fix(install): rewrite outbound relative links from skill bundles (closes #1625)

### DIFF
--- a/docs/src/content/docs/producer/package-relative-links.md
+++ b/docs/src/content/docs/producer/package-relative-links.md
@@ -45,7 +45,7 @@ primitive points back into it.
 ## What APM rewrites
 
 A markdown link with text `[text]` and target `(path)` is rewritten only
-when **all** hold (`src/apm_cli/compilation/link_resolver.py:391-529`):
+when **all** hold (`src/apm_cli/compilation/link_resolver.py:400-545`):
 
 1. The link is relative -- no URL scheme (`http:`, `mailto:`, ...), not
    protocol-relative (`//host`), not root-absolute (`/foo`), not a bare

--- a/src/apm_cli/compilation/link_resolver.py
+++ b/src/apm_cli/compilation/link_resolver.py
@@ -42,6 +42,10 @@ class LinkResolutionContext:
     # are a true 1:1 pair. Compilation must leave this False because the
     # source_file is a synthetic AGENTS.md output dir, not per-link provenance.
     enable_asset_rewrite: bool = False
+    # Source subtree copied whole to the target. Relative links whose targets
+    # stay inside this subtree already resolve after copy and should remain
+    # portable bundle-local links.
+    preserved_source_root: Path | None = None
 
 
 class UnifiedLinkResolver:
@@ -96,7 +100,11 @@ class UnifiedLinkResolver:
                 self.context_registry[qualified_name] = context.file_path
 
     def resolve_links_for_installation(
-        self, content: str, source_file: Path, target_file: Path
+        self,
+        content: str,
+        source_file: Path,
+        target_file: Path,
+        preserved_source_root: Path | None = None,
     ) -> str:
         """Resolve links when copying files during installation.
 
@@ -116,6 +124,7 @@ class UnifiedLinkResolver:
             content: File content to process
             source_file: Original file path in apm_modules/
             target_file: Target path in .github/
+            preserved_source_root: Source subtree copied intact with the target.
 
         Returns:
             Content with resolved links
@@ -128,6 +137,7 @@ class UnifiedLinkResolver:
             available_contexts=self.context_registry,
             package_root=self.package_root,
             enable_asset_rewrite=self.package_root is not None,
+            preserved_source_root=preserved_source_root,
         )
 
         return self._rewrite_markdown_links(content, ctx)
@@ -492,6 +502,13 @@ class UnifiedLinkResolver:
 
         if not candidate.exists() or not candidate.is_file():
             return None
+
+        if ctx.preserved_source_root is not None:
+            try:
+                ensure_path_within(candidate, ctx.preserved_source_root)
+                return None
+            except PathTraversalError:
+                pass
 
         try:
             ensure_path_within(candidate, ctx.package_root)

--- a/src/apm_cli/integration/base_integrator.py
+++ b/src/apm_cli/integration/base_integrator.py
@@ -609,7 +609,13 @@ class BaseIntegrator:
         except Exception:
             self.link_resolver = None
 
-    def resolve_links(self, content: str, source: Path, target: Path) -> tuple:
+    def resolve_links(
+        self,
+        content: str,
+        source: Path,
+        target: Path,
+        preserved_source_root: Path | None = None,
+    ) -> tuple:
         """Resolve context links in *content*.
 
         Returns:
@@ -622,6 +628,7 @@ class BaseIntegrator:
             content=content,
             source_file=source,
             target_file=target,
+            preserved_source_root=preserved_source_root,
         )
         if resolved == content:
             return content, 0

--- a/src/apm_cli/integration/skill_integrator.py
+++ b/src/apm_cli/integration/skill_integrator.py
@@ -535,7 +535,7 @@ class SkillIntegrator(BaseIntegrator):
         source_root: Path,
         target_root: Path,
     ) -> int:
-        """Rewrite outbound links in markdown copied as a skill bundle."""
+        """Read copied skill markdown from source and write resolved target content."""
         links_resolved = 0
         for target_file in target_root.rglob("*.md"):
             if not target_file.is_file() or target_file.is_symlink():
@@ -555,8 +555,8 @@ class SkillIntegrator(BaseIntegrator):
                 links_resolved += count
         return links_resolved
 
+    @staticmethod
     def _promote_sub_skills(
-        self,
         sub_skills_dir: Path,
         target_skills_root: Path,
         parent_name: str,
@@ -569,6 +569,7 @@ class SkillIntegrator(BaseIntegrator):
         project_root: Path | None = None,
         logger=None,
         name_filter: "set | None" = None,
+        link_rewriter: "SkillIntegrator | None" = None,
     ) -> tuple[int, list[Path]]:
         """Promote sub-skills from .apm/skills/ to top-level skill entries.
 
@@ -675,7 +676,8 @@ class SkillIntegrator(BaseIntegrator):
             from apm_cli.security.gate import ignore_non_content
 
             shutil.copytree(sub_skill_path, target, dirs_exist_ok=True, ignore=ignore_non_content)
-            self._resolve_markdown_links_in_skill_bundle(sub_skill_path, target)
+            if link_rewriter is not None:
+                link_rewriter._resolve_markdown_links_in_skill_bundle(sub_skill_path, target)
             promoted += 1
             deployed.append(target)
         return promoted, deployed
@@ -808,6 +810,7 @@ class SkillIntegrator(BaseIntegrator):
                 managed_files=managed_files if is_primary else None,
                 force=force,
                 project_root=project_root,
+                link_rewriter=self,
             )
             if is_primary:
                 count = n
@@ -1029,6 +1032,7 @@ class SkillIntegrator(BaseIntegrator):
                 force=force,
                 project_root=project_root,
                 logger=logger if is_primary else None,
+                link_rewriter=self,
             )
             all_target_paths.extend(sub_deployed)
 
@@ -1137,6 +1141,7 @@ class SkillIntegrator(BaseIntegrator):
                 project_root=project_root,
                 logger=logger if is_primary else None,
                 name_filter=_name_filter,
+                link_rewriter=self,
             )
             if is_primary:
                 total_promoted = n

--- a/src/apm_cli/integration/skill_integrator.py
+++ b/src/apm_cli/integration/skill_integrator.py
@@ -282,7 +282,7 @@ def copy_skill_to_target(
     When *targets* is provided, only those targets are used.
     Otherwise falls back to ``active_targets()``.
 
-    Source SKILL.md is copied verbatim -- no metadata injection.
+    Source SKILL.md gets no metadata injection; outbound package links are rewritten.
 
     Copies:
     - SKILL.md (required)
@@ -390,6 +390,9 @@ def copy_skill_to_target(
         from apm_cli.security.gate import ignore_non_content
 
         shutil.copytree(source_path, skill_dir, ignore=ignore_non_content)
+        rewriter = SkillIntegrator()
+        rewriter.init_link_resolver(package_info, target_base)
+        rewriter._resolve_markdown_links_in_skill_bundle(source_path, skill_dir)
         deployed.append(skill_dir)
 
     return deployed
@@ -527,8 +530,33 @@ class SkillIntegrator(BaseIntegrator):
                 return False
         return True
 
-    @staticmethod
+    def _resolve_markdown_links_in_skill_bundle(
+        self,
+        source_root: Path,
+        target_root: Path,
+    ) -> int:
+        """Rewrite outbound links in markdown copied as a skill bundle."""
+        links_resolved = 0
+        for target_file in target_root.rglob("*.md"):
+            if not target_file.is_file() or target_file.is_symlink():
+                continue
+            source_file = source_root / target_file.relative_to(target_root)
+            if not source_file.is_file() or source_file.is_symlink():
+                continue
+            content = source_file.read_text(encoding="utf-8")
+            resolved, count = self.resolve_links(
+                content,
+                source_file,
+                target_file,
+                preserved_source_root=source_root,
+            )
+            if count:
+                target_file.write_text(resolved, encoding="utf-8")
+                links_resolved += count
+        return links_resolved
+
     def _promote_sub_skills(
+        self,
         sub_skills_dir: Path,
         target_skills_root: Path,
         parent_name: str,
@@ -647,6 +675,7 @@ class SkillIntegrator(BaseIntegrator):
             from apm_cli.security.gate import ignore_non_content
 
             shutil.copytree(sub_skill_path, target, dirs_exist_ok=True, ignore=ignore_non_content)
+            self._resolve_markdown_links_in_skill_bundle(sub_skill_path, target)
             promoted += 1
             deployed.append(target)
         return promoted, deployed
@@ -726,6 +755,7 @@ class SkillIntegrator(BaseIntegrator):
         Returns:
             tuple[int, list[Path]]: (count of promoted sub-skills, list of deployed dirs)
         """
+        self.init_link_resolver(package_info, project_root)
         package_path = package_info.install_path
         sub_skills_dir = package_path / ".apm" / "skills"
         if not sub_skills_dir.is_dir():
@@ -805,8 +835,8 @@ class SkillIntegrator(BaseIntegrator):
         The skill folder name is the source folder name (e.g., ``mcp-builder``),
         validated and normalized per the agentskills.io spec.
 
-        Source SKILL.md is copied verbatim -- no metadata injection. Orphan
-        detection uses apm.lock via directory name matching instead.
+        Source SKILL.md gets no metadata injection; outbound package links are rewritten.
+        Orphan detection uses apm.lock via directory name matching instead.
 
         Copies:
         - SKILL.md (required)
@@ -823,6 +853,7 @@ class SkillIntegrator(BaseIntegrator):
         Returns:
             SkillIntegrationResult: Results of the integration operation
         """
+        self.init_link_resolver(package_info, project_root)
         package_path = package_info.install_path
 
         # Use the source folder name as the skill name
@@ -976,6 +1007,7 @@ class SkillIntegrator(BaseIntegrator):
                 )
 
             shutil.copytree(package_path, target_skill_dir, ignore=_ignore_non_content_and_apm)
+            self._resolve_markdown_links_in_skill_bundle(package_path, target_skill_dir)
             all_target_paths.append(target_skill_dir)
 
             if is_primary:
@@ -1054,6 +1086,7 @@ class SkillIntegrator(BaseIntegrator):
         Returns:
             SkillIntegrationResult with all promoted skills.
         """
+        self.init_link_resolver(package_info, project_root)
         if targets is None:
             from apm_cli.integration.targets import active_targets
 

--- a/tests/integration/test_link_rewrite_e2e.py
+++ b/tests/integration/test_link_rewrite_e2e.py
@@ -317,13 +317,18 @@ class TestSkillBundleInternalLinkUnchanged:
         ws.mkdir()
         producer = ws / "producer"
         _write_yaml(producer / "apm.yml", {"name": "producer", "version": "1.0.0"})
-        # Skill bundle with internal reference doc
-        skill = producer / ".apm" / "skills" / "demo"
+        # Root SKILL_BUNDLE with internal reference doc and outbound package docs.
+        skill = producer / "skills" / "demo"
         _write(skill / "REFERENCE.md", "# Reference\nHelpful info.\n")
+        _write(producer / "references" / "local.md", "# Local reference\n")
+        _write(producer / ".apm" / "context" / "in-apm.md", "# APM context\n")
         _write(
             skill / "SKILL.md",
             "---\nname: demo\ndescription: Demo skill.\n---\n"
-            "# Demo skill\n\nSee [REFERENCE](REFERENCE.md) for details.\n",
+            "# Demo skill\n\n"
+            "See [REFERENCE](REFERENCE.md) for details.\n"
+            "Use the [local reference](../../references/local.md).\n"
+            "Read the [APM context](../../.apm/context/in-apm.md).\n",
         )
         consumer = _make_consumer(ws)
         # Skills under copilot deploy_root=.agents/, so create it for
@@ -352,15 +357,46 @@ class TestSkillBundleInternalLinkUnchanged:
 
         body = deployed_skill.read_text(encoding="utf-8")
         link = _link_target(body, "REFERENCE")
+        assert link == "REFERENCE.md"
 
-        # The link MUST resolve on disk -- whether kept as the in-bundle
-        # relative path "REFERENCE.md" or rewritten through apm_modules/
-        # is an implementation choice, but the deployed link must work.
         resolved = (deployed_skill.parent / link).resolve()
         assert resolved.exists(), (
             f"In-bundle link does not resolve after install: {link} -> {resolved}"
         )
         assert resolved.read_text(encoding="utf-8").startswith("# Reference")
+
+    def test_outbound_skill_links_rewritten_to_apm_modules(self, workspace, apm_command):
+        consumer, producer = workspace
+        result = _run_install(apm_command, consumer, str(producer))
+        assert result.returncode == 0, f"Install failed:\n{result.stderr}\n{result.stdout}"
+
+        deployed_skills = [
+            p for p in consumer.rglob("SKILL.md") if p.is_file() and "apm_modules" not in p.parts
+        ]
+        assert deployed_skills, (
+            f"SKILL.md not deployed. consumer tree:\n"
+            f"{[str(p.relative_to(consumer)) for p in consumer.rglob('*') if p.is_file()]}"
+        )
+        deployed_skill = deployed_skills[0]
+        body = deployed_skill.read_text(encoding="utf-8")
+
+        local_ref = _link_target(body, "local reference")
+        assert local_ref == "../../../apm_modules/_local/producer/references/local.md"
+        assert (
+            (deployed_skill.parent / local_ref)
+            .resolve()
+            .read_text(encoding="utf-8")
+            .startswith("# Local reference")
+        )
+
+        apm_context = _link_target(body, "APM context")
+        assert apm_context == "../../../apm_modules/_local/producer/.apm/context/in-apm.md"
+        assert (
+            (deployed_skill.parent / apm_context)
+            .resolve()
+            .read_text(encoding="utf-8")
+            .startswith("# APM context")
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Context

Fixes #1625. Skill bundles were copied with shutil.copytree, so markdown links from inside a deployed skill to package sibling directories stayed pointed at the pre-install author layout and broke in consumer repos.

## Changes

- Route copied skill bundle markdown through the existing install-time link resolver.
- Preserve bundle-local links for files copied alongside SKILL.md.
- Add an E2E regression test covering outbound links from SKILL.md to package sibling docs and .apm context.

## How to test

- uv run --extra dev pytest tests/integration/test_link_rewrite_e2e.py -k "SkillBundleInternalLinkUnchanged" -q
- uv run --extra dev pytest tests/ -k "link or skill or rewrite or integrat" -q
- uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format --check src/ tests/

## Mutation check

Removed the new skill-bundle resolve_links wiring and confirmed the outbound skill link regression test failed, then restored it.