### PR TITLE
fix(deps): resolve semver ranges against per-package subpath tags (closes #1633)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `version` constraints, and fail closed when resolution errors occur - by
   @stbenjam (#1422)
 
+### Fixed
+
+- Git-source semver ranges for virtual subdirectory dependencies now match
+  per-package `{name}-v{version}` tags, derive `{name}` from the subpath, and
+  reject malformed range-like refs with an actionable manifest error. (#1658)
+
 ### Breaking
 
 - Reject string-form `@alias` dependency shorthand at parse time with a migration error; use object form with `alias:` instead -- by @prateek (#1301)

--- a/docs/src/content/docs/consumer/manage-dependencies.md
+++ b/docs/src/content/docs/consumer/manage-dependencies.md
@@ -219,8 +219,10 @@ picks the highest tag that satisfies the range. For virtual subdirectory
 deps, `{name}` is the final path segment (for example `pkg-a` in
 `acme/mono/packages/pkg-a`). The original constraint is preserved in the
 lockfile alongside the resolved tag, so `apm install` on a fresh clone
-replays the same tag deterministically. Only `apm update` (or legacy
-`apm install --update`) or a manifest change re-resolves to a newer tag.
+replays the same tag deterministically. A malformed range-like ref is
+rejected; use a plain range such as `^1.2.0` or pin a literal tag such as
+`pkg-a-v1.2.0`. Only `apm update` (or legacy `apm install --update`) or a
+manifest change re-resolves to a newer tag.
 
 Marketplace object-form ranges use the marketplace package name in the tag
 pattern:

--- a/docs/src/content/docs/consumer/manage-dependencies.md
+++ b/docs/src/content/docs/consumer/manage-dependencies.md
@@ -213,9 +213,11 @@ dependencies:
     - acme/widget#1.5.x       # wildcard
 ```
 
-APM matches tags against `v{version}` and `{name}--v{version}` patterns
-(with `{version}` as a bare-tag fallback) and picks the highest tag that
-satisfies the range. The original constraint is preserved in the
+APM matches tags against `v{version}`, `{name}--v{version}`, and
+`{name}-v{version}` patterns (with `{version}` as a bare-tag fallback) and
+picks the highest tag that satisfies the range. For virtual subdirectory
+deps, `{name}` is the final path segment (for example `pkg-a` in
+`acme/mono/packages/pkg-a`). The original constraint is preserved in the
 lockfile alongside the resolved tag, so `apm install` on a fresh clone
 replays the same tag deterministically. Only `apm update` (or legacy
 `apm install --update`) or a manifest change re-resolves to a newer tag.

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -356,7 +356,9 @@ and original constraint are pinned in the lockfile. Subsequent
 re-resolve against current remote tags. Tag patterns are tried in order:
 `v{version}`, `{name}--v{version}`, and `{name}-v{version}`, then a bare
 `{version}` fallback. For virtual subdirectory deps, `{name}` is the
-final path segment (for example `pkg-a` in `acme/mono/packages/pkg-a`).
+final path segment (for example `pkg-a` in `acme/mono/packages/pkg-a`). A
+malformed range-like ref is rejected; use a plain range such as `^1.2.0`
+or pin a literal tag such as `pkg-a-v1.2.0`.
 
 ## Marketplace ref override
 

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -353,9 +353,10 @@ highest tag matching the range; the resolved tag, commit SHA, version,
 and original constraint are pinned in the lockfile. Subsequent
 `apm install` runs replay the lockfile without network. Use
 `apm install --update` (or change the manifest constraint) to
-re-resolve against current remote tags. Two tag patterns are tried in
-order: `v{version}` and `{name}--v{version}`, then a bare `{version}`
-fallback.
+re-resolve against current remote tags. Tag patterns are tried in order:
+`v{version}`, `{name}--v{version}`, and `{name}-v{version}`, then a bare
+`{version}` fallback. For virtual subdirectory deps, `{name}` is the
+final path segment (for example `pkg-a` in `acme/mono/packages/pkg-a`).
 
 ## Marketplace ref override
 

--- a/src/apm_cli/deps/git_semver_resolver.py
+++ b/src/apm_cli/deps/git_semver_resolver.py
@@ -52,7 +52,8 @@ __all__ = [
 # * ``{name}--v{version}`` -- Claude Code / PR #1422 per-package convention
 #   used by multi-marketplace repos.
 # * ``{name}-v{version}`` -- common single-dash per-package convention
-#   accepted by marketplace tag-pattern helpers.
+#   accepted by marketplace tag-pattern helpers. The semver regex still
+#   requires a full version, so branch-like names such as ``pkg-v1`` do not match.
 DEFAULT_TAG_PATTERNS: tuple[str, ...] = (
     "v{version}",
     "{name}--v{version}",

--- a/src/apm_cli/deps/git_semver_resolver.py
+++ b/src/apm_cli/deps/git_semver_resolver.py
@@ -50,11 +50,14 @@ __all__ = [
 #
 # * ``v{version}`` -- universal lockstep convention (most projects).
 # * ``{name}--v{version}`` -- Claude Code / PR #1422 per-package convention
-#   used by multi-marketplace repos.  Double dash is intentional and
-#   matches Claude's published convention; single-dash variants are NOT
-#   tried by default to avoid silent collisions with branch names like
-#   ``my-skills-v1`` (a hand-cut release branch).
-DEFAULT_TAG_PATTERNS: tuple[str, ...] = ("v{version}", "{name}--v{version}")
+#   used by multi-marketplace repos.
+# * ``{name}-v{version}`` -- common single-dash per-package convention
+#   accepted by marketplace tag-pattern helpers.
+DEFAULT_TAG_PATTERNS: tuple[str, ...] = (
+    "v{version}",
+    "{name}--v{version}",
+    "{name}-v{version}",
+)
 
 # Bare-version fallback (``1.2.3`` literal, no prefix).
 #

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -27,6 +27,7 @@ from apm_cli.utils.short_sha import format_short_sha
 
 if TYPE_CHECKING:
     from apm_cli.install.context import InstallContext
+    from apm_cli.models.dependency.reference import DependencyReference
 
 _logger = logging.getLogger(__name__)
 
@@ -64,9 +65,9 @@ def _require_package_registry_feature_if_needed(registries_map, existing_lockfil
     return needs_registry
 
 
-def _git_semver_package_name(dep_ref) -> str:
+def _git_semver_package_name(dep_ref: DependencyReference) -> str:
     """Return the package name used for git tag ``{name}`` matching."""
-    if dep_ref.is_virtual_subdirectory() and getattr(dep_ref, "virtual_path", None):
+    if dep_ref.is_virtual_subdirectory() and dep_ref.virtual_path:
         return dep_ref.virtual_path.rstrip("/").rsplit("/", 1)[-1]
     return dep_ref.repo_url.rsplit("/", 1)[-1]
 
@@ -701,8 +702,18 @@ def _resolve_dependencies(ctx: InstallContext) -> None:
             # would mislead users who are debugging an unsatisfied
             # constraint -- nothing was downloaded yet.
             from apm_cli.deps.git_semver_resolver import NoMatchingTagError
+            from apm_cli.models.dependency.reference import InvalidSemverRangeError
 
-            if isinstance(e, NoMatchingTagError):
+            if isinstance(e, InvalidSemverRangeError):
+                if is_direct:
+                    fail_msg = f"Invalid dependency spec for {dep_ref.repo_url}: {e}"
+                else:
+                    chain_hint = f" (via {parent_chain})" if parent_chain else ""
+                    fail_msg = (
+                        f"Invalid dependency spec for transitive dep "
+                        f"{dep_ref.repo_url}{chain_hint}: {e}"
+                    )
+            elif isinstance(e, NoMatchingTagError):
                 if is_direct:
                     fail_msg = f"No matching tag for {dep_ref.repo_url}: {e}"
                 else:

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -64,6 +64,13 @@ def _require_package_registry_feature_if_needed(registries_map, existing_lockfil
     return needs_registry
 
 
+def _git_semver_package_name(dep_ref) -> str:
+    """Return the package name used for git tag ``{name}`` matching."""
+    if dep_ref.is_virtual_subdirectory() and getattr(dep_ref, "virtual_path", None):
+        return dep_ref.virtual_path.rstrip("/").rsplit("/", 1)[-1]
+    return dep_ref.repo_url.rsplit("/", 1)[-1]
+
+
 def _maybe_resolve_git_semver(
     *,
     dep_ref,
@@ -113,7 +120,7 @@ def _maybe_resolve_git_semver(
 
     constraint = dep_ref.reference
     owner_repo = dep_ref.repo_url
-    package_name = owner_repo.rsplit("/", 1)[-1]
+    package_name = _git_semver_package_name(dep_ref)
 
     # Lockfile replay (npm semantics): if the lockfile already records a
     # resolution for this constraint, return it directly. Saves a

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -60,6 +60,11 @@ def _is_valid_registry_semver_range(spec: str) -> bool:
     return is_semver_range(spec)
 
 
+def _looks_like_invalid_semver_range(spec: str) -> bool:
+    """Return whether *spec* starts like a semver range but is invalid."""
+    return bool(re.match(r"^(>=|<=|>|<|\^|~|=)", spec.strip()))
+
+
 @dataclass
 class DependencyReference:
     """Represents a reference to an APM dependency."""
@@ -156,6 +161,13 @@ class DependencyReference:
         # routed through the git-semver resolver.
         if _is_valid_registry_semver_range(self.reference):
             return "semver"
+        if _looks_like_invalid_semver_range(self.reference):
+            raise ValueError(
+                f"Invalid semver range in ref {self.reference!r}. "
+                "Package-name prefixes belong in tag patterns, not ranges. "
+                "Use a range like '^1.2.0' or pin a literal tag like "
+                "'pkg-a-v1.2.0'."
+            )
         return "literal"
 
     # Supported file extensions for virtual packages

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -60,9 +60,16 @@ def _is_valid_registry_semver_range(spec: str) -> bool:
     return is_semver_range(spec)
 
 
+_RANGE_PREFIX_RE = re.compile(r"^(>=|<=|>|<|\^|~|=)")
+
+
+class InvalidSemverRangeError(ValueError):
+    """Raised when a ref starts like a semver range but is invalid."""
+
+
 def _looks_like_invalid_semver_range(spec: str) -> bool:
     """Return whether *spec* starts like a semver range but is invalid."""
-    return bool(re.match(r"^(>=|<=|>|<|\^|~|=)", spec.strip()))
+    return bool(_RANGE_PREFIX_RE.match(spec.strip()))
 
 
 @dataclass
@@ -162,9 +169,9 @@ class DependencyReference:
         if _is_valid_registry_semver_range(self.reference):
             return "semver"
         if _looks_like_invalid_semver_range(self.reference):
-            raise ValueError(
+            raise InvalidSemverRangeError(
                 f"Invalid semver range in ref {self.reference!r}. "
-                "Package-name prefixes belong in tag patterns, not ranges. "
+                "The ref field expects a plain semver range. "
                 "Use a range like '^1.2.0' or pin a literal tag like "
                 "'pkg-a-v1.2.0'."
             )

--- a/tests/integration/test_git_semver_install_e2e.py
+++ b/tests/integration/test_git_semver_install_e2e.py
@@ -85,6 +85,15 @@ def _refs_only_bare() -> list[RemoteRef]:
     ]
 
 
+def _refs_virtual_subdir_single_dash() -> list[RemoteRef]:
+    """Monorepo tags two packages with the ``{name}-v{version}`` pattern."""
+    return [
+        RemoteRef(name="refs/heads/main", sha="0" * 40),
+        RemoteRef(name="refs/tags/pkg-a-v0.1.0", sha="a" * 40),
+        RemoteRef(name="refs/tags/pkg-b-v9.9.9", sha="b" * 40),
+    ]
+
+
 def _refs_no_match() -> list[RemoteRef]:
     """No tag in any pattern satisfies a ^1.2.0 constraint."""
     return [
@@ -395,6 +404,37 @@ class TestTagPatternFallback:
         assert locked is not None
         assert locked.get("resolved_tag") == "1.4.2"
         assert locked.get("version") == "1.4.2"
+
+    def test_virtual_subdir_single_dash_pattern_uses_subpath_name(
+        self,
+        runner: CliRunner,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Virtual subdirectory deps use their path segment for tag matching."""
+        project = tmp_path / "promise-d-virtual-subdir"
+        _write_apm_yml(
+            project,
+            [{"git": "acme/mono", "path": "packages/pkg-a", "ref": "^0.1.0"}],
+        )
+
+        rr = _RefResolverCallRecorder({"acme/mono": _refs_virtual_subdir_single_dash()})
+        dl = _DownloaderStub({"pkg-a-v0.1.0": "a" * 40})
+        rr.install(monkeypatch)
+        dl.install(monkeypatch)
+
+        result = _run_install(runner, project, monkeypatch)
+        assert result.exit_code == 0, result.output
+
+        lockfile = _read_lockfile(project)
+        locked = _find_locked(lockfile, "acme/mono")
+        assert locked is not None, lockfile
+        assert locked.get("is_virtual") is True
+        assert locked.get("virtual_path") == "packages/pkg-a"
+        assert locked.get("resolved_tag") == "pkg-a-v0.1.0"
+        assert locked.get("version") == "0.1.0"
+        assert locked.get("resolved_commit") == "a" * 40
+        assert rr.calls == ["acme/mono"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/install/test_git_semver_wiring.py
+++ b/tests/unit/install/test_git_semver_wiring.py
@@ -14,12 +14,13 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import pytest  # noqa: F401
+import pytest
 
 from apm_cli.deps.git_semver_resolver import GitSemverResolution
 from apm_cli.deps.lockfile import LockedDependency, LockFile
 from apm_cli.drift import detect_ref_change
 from apm_cli.install.phases.resolve import _maybe_resolve_git_semver
+from apm_cli.marketplace.ref_resolver import RemoteRef
 from apm_cli.models.dependency.reference import DependencyReference
 
 
@@ -171,6 +172,43 @@ class TestMaybeResolveGitSemver:
             )
 
         assert resolution is fresh
+
+    def test_virtual_subdir_range_uses_subpath_package_name(self):
+        dep = DependencyReference(
+            host="github.com",
+            repo_url="acme/monorepo",
+            reference="^0.1.0",
+            source="git",
+            is_virtual=True,
+            virtual_path="packages/pkg-a",
+        )
+        rr_instance = MagicMock()
+        rr_instance.list_remote_refs.return_value = [
+            RemoteRef(name="refs/tags/pkg-a-v0.1.0", sha="a" * 40),
+            RemoteRef(name="refs/tags/pkg-b-v9.9.9", sha="b" * 40),
+        ]
+
+        with patch("apm_cli.marketplace.ref_resolver.RefResolver", return_value=rr_instance):
+            resolution = _maybe_resolve_git_semver(
+                dep_ref=dep,
+                existing_lockfile=None,
+                update_refs=False,
+            )
+
+        assert isinstance(resolution, GitSemverResolution)
+        assert resolution.resolved_tag == "pkg-a-v0.1.0"
+        assert resolution.resolved_version == "0.1.0"
+        assert resolution.matched_pattern == "{name}-v{version}"
+
+    def test_prefixed_range_like_ref_raises_instead_of_literal_fallback(self):
+        dep = _make_dep_ref(reference="~pkg-a-v0.1.0")
+
+        with pytest.raises(ValueError, match="Invalid semver range"):
+            _maybe_resolve_git_semver(
+                dep_ref=dep,
+                existing_lockfile=None,
+                update_refs=False,
+            )
 
 
 class TestDriftDetectRefChangeForSemver:


### PR DESCRIPTION
fix(deps): resolve subpath semver tags

## TL;DR

This PR fixes git-source semver resolution for virtual subdirectory packages in monorepos. It uses the subpath package name for `{name}` tag expansion, accepts the existing marketplace single-dash tag convention, and rejects malformed range-like refs before they silently fall back to literal resolution.

> [!NOTE]
> Closes #1633.

## Problem (WHY)

- [x] Virtual subdirectory dependencies such as `acme/mono/packages/pkg-a#^0.1.0` resolved `{name}` as `mono`, not `pkg-a`, so per-package tags could not match.
- [x] Git semver defaults omitted `{name}-v{version}` even though marketplace tag-pattern helpers already document that convention.
- [x] A ref like `~pkg-a-v0.1.0` looked range-like but was classified as literal, allowing the install path to continue without surfacing the bad selector.

Why these matter: dependency resolution must stay deterministic and reviewable. This PR keeps the fix small and composable, aligned with PROSE's guidance to ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) It also adds regression traps because Agent Skills recommends to ["do the work, run a validator (a script, a reference checklist, or a self-check), fix any issues, and repeat until validation passes."](https://agentskills.io/skill-creation/best-practices)

## Approach (WHAT)

| # | Fix |
|---|-----|
| 1 | Derive git semver `{name}` from the final virtual subdirectory path segment when the dependency is a virtual subdirectory. |
| 2 | Add `{name}-v{version}` to git semver default tag patterns, matching the marketplace tag-pattern convention already present in the codebase. |
| 3 | Treat refs that begin with semver range operators but fail semver parsing as invalid ranges, not literal refs. |
| 4 | Update user docs and the apm-usage skill docs so the documented tag patterns match runtime behavior. |

## Implementation (HOW)

- **`src/apm_cli/install/phases/resolve.py`** -- Adds `_git_semver_package_name()` and uses it before calling `GitSemverResolver`, preserving repo-basename behavior for whole-repo deps.
- **`src/apm_cli/deps/git_semver_resolver.py`** -- Extends `DEFAULT_TAG_PATTERNS` with `{name}-v{version}` while keeping the existing order and bare-version fallback.
- **`src/apm_cli/models/dependency/reference.py`** -- Adds a narrow range-like validation guard so malformed operator-prefixed refs raise a clear `ValueError`.
- **`tests/unit/install/test_git_semver_wiring.py`** -- Adds regression tests for virtual subdirectory per-package tags and malformed range-like refs.
- **Docs** -- Updates `docs/src/content/docs/consumer/manage-dependencies.md` and `packages/apm-guide/.apm/skills/apm-usage/dependencies.md` with the effective tag patterns and subpath-name rule.

## Diagrams

Legend: The dashed nodes show the new behavior this PR adds to the git semver resolution path.

```mermaid
flowchart LR
    subgraph Parse[Parse dependency]
        R[ref string]
        K[ref_kind]
    end
    subgraph Resolve[Resolve git semver]
        N[package name]
        P[tag patterns]
        T[remote tags]
    end
    subgraph Lock[Lock result]
        L[resolved tag and SHA]
    end
    R --> K
    K -->|semver range| N
    N --> P
    T --> P
    P --> L
    classDef new stroke-dasharray: 5 5;
    class N,P new;
```

## Trade-offs

- **Add default pattern instead of new config plumbing.** Chose the already-documented marketplace convention; rejected broader configuration threading because git dependency refs do not currently carry package-level `tag_pattern` metadata.
- **Raise only for operator-prefixed invalid ranges.** Chose a narrow guard; rejected treating every prefixed tag as invalid so literal tags like `v1.2.3` keep working.
- **Unit regression coverage first.** Chose focused unit tests around the resolver boundary; rejected live git tests to keep the suite hermetic.

## Benefits

1. `pkg-a-v0.1.0` resolves for `acme/mono/packages/pkg-a#^0.1.0` instead of missing because `{name}` was `mono`.
2. Sibling package tags such as `pkg-b-v9.9.9` remain ignored for `pkg-a`.
3. Malformed range-like refs fail clearly instead of being treated as literal branch or tag names.
4. Docs now list the same tag-pattern order the resolver uses.

## Validation

`uv run --extra dev pytest tests/unit/install/test_git_semver_wiring.py tests/unit/deps/test_git_semver_resolver.py -q`:

```text
31 passed in 0.62s
```

`uv run --extra dev pytest tests/ -k "semver or resolve or git_semver or tag" -q`:

```text
3249 skipped, 23520 deselected in 12.05s
```

`uv run --extra dev ruff check src/ tests/`:

```text
All checks passed!
```

`uv run --extra dev ruff format --check src/ tests/`:

```text
1215 files already formatted
```

Mutation-break gate:

```text
Reverted subpath package-name guard: targeted test failed with NoMatchingTagError, then passed after restore.
Removed single-dash pattern: targeted test failed with NoMatchingTagError, then passed after restore.
Removed invalid-range guard: targeted test failed with DID NOT RAISE ValueError, then passed after restore.
```

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|------------------------|--------------|--------------------|------|
| 1 | Install a virtual subdirectory package from a monorepo using `#^0.1.0`; APM picks that package's per-package tag. | Governed by policy, DevX | `tests/unit/install/test_git_semver_wiring.py::TestMaybeResolveGitSemver::test_virtual_subdir_range_uses_subpath_package_name` (regression-trap for #1633) | unit |
| 2 | Entering a malformed range-like ref fails clearly instead of falling through to default branch behavior. | Secure by default, DevX | `tests/unit/install/test_git_semver_wiring.py::TestMaybeResolveGitSemver::test_prefixed_range_like_ref_raises_instead_of_literal_fallback` (regression-trap for #1633) | unit |

## How to test

- [ ] Run `uv run --extra dev pytest tests/unit/install/test_git_semver_wiring.py -q`; expect all tests to pass.
- [ ] Run `uv run --extra dev pytest tests/unit/deps/test_git_semver_resolver.py -q`; expect all tests to pass.
- [ ] Inspect the docs change; expect `v{version}`, `{name}--v{version}`, `{name}-v{version}`, and bare `{version}` fallback to be documented.

Closes #1633

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
