### PR TITLE
refactor(auth): debug-log all exception handlers in credential cascade (closes #935)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `auth.py`: add `logger.debug` calls to all silent `except` clauses in the
+  credential cascade; bind `AzureCliBearerError` and `ImportError` catches with
+  explicit `as exc` clauses; keep broad `Exception` guards on caller-provided
+  callables with justification comments. (#935)
+
 ## [0.18.0] - 2026-06-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `auth.py`: add `logger.debug` calls to all silent `except` clauses in the
-  credential cascade; bind `AzureCliBearerError` and `ImportError` catches with
-  explicit `as exc` clauses; keep broad `Exception` guards on caller-provided
-  callables with justification comments. (#935)
+- Auth credential cascade now emits debug-level logs for every fallback step,
+  making token misconfiguration diagnosable without adding noise to normal output. (#935)
 
 ## [0.18.0] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Auth credential cascade now emits debug-level logs for every fallback step,
-  making token misconfiguration diagnosable without adding noise to normal output. (#935)
+  making token misconfiguration diagnosable without adding noise to normal output.
+  Enable with ``apm --verbose`` or ``APM_LOG_LEVEL=DEBUG``.
+  (by @danielmeppiel, closes #935, #1664)
 
 ## [0.18.0] - 2026-06-04
 

--- a/src/apm_cli/cli.py
+++ b/src/apm_cli/cli.py
@@ -4,6 +4,7 @@ Thin wiring layer  -- all command logic lives in ``apm_cli.commands.*`` modules.
 """
 
 import ctypes
+import logging
 import os
 import sys
 import warnings
@@ -61,6 +62,48 @@ _CLI_EPILOG = (
 )
 
 
+def _configure_logging(verbose: bool = False) -> None:
+    """Configure stdlib logging for the ``apm_cli`` package.
+
+    Two mechanisms activate debug-level output (either is sufficient):
+
+    * ``--verbose`` / ``-v`` flag on the ``apm`` command.
+    * ``APM_LOG_LEVEL=DEBUG`` environment variable (accepts any stdlib
+      level name: DEBUG, INFO, WARNING, ERROR, CRITICAL).
+
+    When neither is set the ``apm_cli`` logger defaults to WARNING so
+    routine runs stay silent.  A :class:`~apm_cli.core.auth.SecretRedactionFilter`
+    is always installed on the ``apm_cli`` logger to strip token-bearing
+    exception strings from debug records regardless of which mechanism
+    activated debug mode.
+    """
+    env_level_str = os.environ.get("APM_LOG_LEVEL", "").strip().upper()
+    env_level: int | None = (
+        getattr(logging, env_level_str, None) if env_level_str.isalpha() else None
+    )
+
+    if verbose:
+        level = logging.DEBUG
+    elif env_level is not None:
+        level = env_level
+    else:
+        level = logging.WARNING
+
+    logging.basicConfig(
+        level=level,
+        format="%(levelname)s %(name)s %(message)s",
+        stream=sys.stderr,
+    )
+    apm_logger = logging.getLogger("apm_cli")
+    apm_logger.setLevel(level)
+
+    # Install secret-redaction filter (idempotent: skip if already present).
+    from apm_cli.core.auth import SecretRedactionFilter
+
+    if not any(isinstance(f, SecretRedactionFilter) for f in apm_logger.filters):
+        apm_logger.addFilter(SecretRedactionFilter())
+
+
 @click.group(
     help="Agent Package Manager (APM): The package manager for AI-Native Development",
     epilog=_CLI_EPILOG,
@@ -73,10 +116,22 @@ _CLI_EPILOG = (
     is_eager=True,
     help="Show version and exit.",
 )
+@click.option(
+    "--verbose",
+    "-v",
+    is_flag=True,
+    default=False,
+    help="Enable debug-level logging (equivalent to APM_LOG_LEVEL=DEBUG).",
+)
 @click.pass_context
-def cli(ctx):
+def cli(ctx, verbose: bool) -> None:
     """Main entry point for the APM CLI."""
     ctx.ensure_object(dict)
+    ctx.obj["verbose"] = verbose
+
+    if verbose:
+        # Upgrade to DEBUG when the flag is set; env-var path runs in main().
+        _configure_logging(verbose=True)
 
     # Suppress only the agents-target deprecation warning so CLI users see
     # the formatted logger.warning() in the install phase, not a double print.
@@ -267,6 +322,7 @@ def _configure_encoding() -> None:
 
 def main():
     """Main entry point for the CLI."""
+    _configure_logging()  # honours APM_LOG_LEVEL env var; --verbose upgrades in cli()
     _configure_encoding()
     try:
         cli(obj={})

--- a/src/apm_cli/core/auth.py
+++ b/src/apm_cli/core/auth.py
@@ -28,6 +28,7 @@ For operations with automatic auth/unauth fallback::
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 import threading
@@ -47,6 +48,8 @@ if TYPE_CHECKING:
     from apm_cli.models.dependency.reference import DependencyReference
 
 T = TypeVar("T")
+
+logger = logging.getLogger(__name__)
 
 _PORT_CREDENTIAL_DOCS_URL = (
     "https://microsoft.github.io/apm/getting-started/authentication/"
@@ -468,11 +471,24 @@ class AuthResolver:
                 # Success on fallback -- emit deferred diagnostic warning
                 self.emit_stale_pat_diagnostic(auth_ctx.host_info.display_name)
                 return result
-            except AzureCliBearerError:
-                pass  # Bearer acquisition itself failed; fall through to original error
-            except Exception:
-                # Bearer also failed (Case 4). Re-raise the ORIGINAL PAT exception.
-                pass
+            except AzureCliBearerError as bearer_exc:
+                # az CLI bearer acquisition failed (not logged in, token expired, etc.).
+                # Fall through to the original PAT error.
+                logger.debug(
+                    "ADO bearer acquisition failed for %s; falling through to PAT error: %s",
+                    host_info.display_name,
+                    bearer_exc,
+                )
+            except Exception as bearer_op_exc:
+                # The operation callable may raise any exception type; broad catch is
+                # required because we cannot restrict the caller API without a behavior
+                # change (Case 4: bearer op itself failed after PAT rejection).
+                logger.debug(
+                    "ADO bearer fallback operation raised for %s; re-raising original PAT"
+                    " exception: %s",
+                    host_info.display_name,
+                    bearer_op_exc,
+                )
             raise exc
 
         # Hosts that never have public repos -> auth-only
@@ -481,6 +497,13 @@ class AuthResolver:
             try:
                 return operation(auth_ctx.token, git_env)
             except Exception as exc:
+                # operation is caller-provided; broad catch required -- cannot narrow
+                # without restricting the caller API.
+                logger.debug(
+                    "Auth-only operation failed for ghe_cloud host %s: %s",
+                    host_info.display_name,
+                    exc,
+                )
                 return _try_credential_fallback(exc)
 
         # ADO: auth-first with bearer fallback when PAT fails
@@ -489,6 +512,13 @@ class AuthResolver:
             try:
                 return operation(auth_ctx.token, git_env)
             except Exception as exc:
+                # operation is caller-provided; broad catch required -- cannot narrow
+                # without restricting the caller API.
+                logger.debug(
+                    "Auth-only operation failed for ado host %s; trying bearer fallback: %s",
+                    host_info.display_name,
+                    exc,
+                )
                 return _try_ado_bearer_fallback(exc)
 
         if unauth_first:
@@ -496,13 +526,26 @@ class AuthResolver:
             try:
                 _log(f"Trying unauthenticated access to {host_info.display_name}")
                 return operation(None, git_env)
-            except Exception:
+            except Exception as exc:
+                # operation is caller-provided; broad catch required -- cannot narrow
+                # without restricting the caller API.
+                logger.debug(
+                    "Unauthenticated access failed for %s; will retry with token: %s",
+                    host_info.display_name,
+                    exc,
+                )
                 if auth_ctx.token:
                     _log(f"Unauthenticated failed, retrying with token (source: {auth_ctx.source})")
                     try:
                         return operation(auth_ctx.token, git_env)
-                    except Exception as exc:
-                        return _try_credential_fallback(exc)
+                    except Exception as retry_exc:
+                        # operation is caller-provided; broad catch required.
+                        logger.debug(
+                            "Authenticated retry also failed for %s: %s",
+                            host_info.display_name,
+                            retry_exc,
+                        )
+                        return _try_credential_fallback(retry_exc)
                 raise
         # Download path: auth-first for higher rate limits
         elif auth_ctx.token:
@@ -513,11 +556,24 @@ class AuthResolver:
                 )
                 return operation(auth_ctx.token, git_env)
             except Exception as exc:
+                # operation is caller-provided; broad catch required -- cannot narrow
+                # without restricting the caller API.
+                logger.debug(
+                    "Authenticated access failed for %s; will retry unauthenticated: %s",
+                    host_info.display_name,
+                    exc,
+                )
                 if host_info.has_public_repos:
                     _log("Authenticated failed, retrying without token")
                     try:
                         return operation(None, git_env)
-                    except Exception:
+                    except Exception as unauth_exc:
+                        # operation is caller-provided; broad catch required.
+                        logger.debug(
+                            "Unauthenticated retry also failed for %s: %s",
+                            host_info.display_name,
+                            unauth_exc,
+                        )
                         return _try_credential_fallback(exc)
                 return _try_credential_fallback(exc)
         else:
@@ -757,10 +813,14 @@ class AuthResolver:
                 try:
                     bearer = provider.get_bearer_token()
                     return bearer, GitHubTokenManager.ADO_BEARER_SOURCE, "bearer"
-                except AzureCliBearerError:
+                except AzureCliBearerError as exc:
                     # az is on PATH but token acquisition failed (e.g., not logged in).
                     # Fall through to token=None; build_error_context will render Case 3.
-                    pass
+                    logger.debug(
+                        "ADO bearer token acquisition failed for %s: %s",
+                        host_info.host,
+                        exc,
+                    )
             return None, "none", "basic"
 
         # ADO uses ADO_APM_PAT (single var) + AAD bearer fallback;
@@ -891,8 +951,8 @@ class AuthResolver:
 
             _rich_warning(msg, symbol="warning")
             _rich_warning(f"    {detail}", symbol="warning")
-        except ImportError:
-            pass  # console module not importable in some test contexts
+        except ImportError as exc:
+            logger.debug("Console module unavailable for stale-PAT warning; skipping: %s", exc)
 
     # Backwards-compat alias for any in-tree caller still importing the
     # private name. Safe to remove once all callers move to the public name.
@@ -931,8 +991,10 @@ class AuthResolver:
 
                 _rich_echo(line, color="dim")
                 return
-            except ImportError:
-                pass
+            except ImportError as exc:
+                logger.debug(
+                    "Console module unavailable for auth-source logging; skipping: %s", exc
+                )
         # No logger wired -- the install path always wires one in the
         # bearer branch, so this fallback only fires in unit-test contexts
         # that opt-in via APM_VERBOSE=1.
@@ -982,18 +1044,29 @@ class AuthResolver:
             return BearerFallbackOutcome(primary, False)
         try:
             from apm_cli.core.azure_cli import AzureCliBearerError, get_bearer_provider
-        except ImportError:
+        except ImportError as exc:
+            logger.debug(
+                "azure_cli module unavailable for bearer fallback in execute_with_bearer_fallback;"
+                " skipping: %s",
+                exc,
+            )
             return BearerFallbackOutcome(primary, False)
         provider = get_bearer_provider()
         if not provider.is_available():
             return BearerFallbackOutcome(primary, False)
         try:
             bearer = provider.get_bearer_token()
-        except AzureCliBearerError:
+        except AzureCliBearerError as exc:
+            logger.debug("Bearer token acquisition failed in execute_with_bearer_fallback: %s", exc)
             return BearerFallbackOutcome(primary, False)
         try:
             fallback = bearer_op(bearer)
-        except Exception:
+        except Exception as exc:
+            # bearer_op is caller-provided; broad catch required -- cannot narrow
+            # without restricting the caller API.
+            logger.debug(
+                "bearer_op raised an exception during execute_with_bearer_fallback: %s", exc
+            )
             return BearerFallbackOutcome(primary, True)
         if fallback is None or is_auth_failure(fallback):
             return BearerFallbackOutcome(primary, True)

--- a/src/apm_cli/core/auth.py
+++ b/src/apm_cli/core/auth.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import sys
 import threading
 from collections.abc import Callable
@@ -50,6 +51,60 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Secret redaction -- applied by SecretRedactionFilter to all debug records
+# ---------------------------------------------------------------------------
+
+# Patterns that indicate a secret value follows.  Covers:
+#   token=VALUE, Authorization: Bearer VALUE, Authorization: Basic VALUE,
+#   URL credentials (https://user:pass@host), and bare bearer strings.
+_SECRET_RE = re.compile(
+    r"(?:"
+    r"(?:token|password|secret|authorization|bearer)"  # keyword prefix
+    r"(?:\s*[:=]\s*|\s+)"  # separator
+    r"[\w.~!*\'();:@&=+$,/?#\[\]\-]{4,}"  # value (>= 4 chars)
+    r"|"
+    r"://[^:@/\s]+:[^:@/\s]+@"  # URL user:pass@
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _redact_secrets(text: str) -> str:
+    """Replace obvious credential patterns in ``text`` with ``[REDACTED]``.
+
+    Called by :class:`SecretRedactionFilter` before log records are emitted.
+    Also safe to call directly in tests.  Preserves text that contains no
+    secret patterns so non-sensitive messages are returned verbatim.
+    """
+    return _SECRET_RE.sub("[REDACTED]", text)
+
+
+class SecretRedactionFilter(logging.Filter):
+    """Logging filter that redacts secret patterns from all emitted log records.
+
+    Install on the ``apm_cli`` logger (or a sub-logger) when debug logging is
+    enabled so that exception messages carrying HTTP client error strings --
+    which some libraries embed auth headers or token values in -- do not leak
+    credentials into the debug stream.
+
+    Usage::
+
+        logging.getLogger("apm_cli").addFilter(SecretRedactionFilter())
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            msg = record.getMessage()
+            redacted = _redact_secrets(msg)
+            if redacted != msg:
+                record.msg = redacted
+                record.args = ()
+        except Exception:
+            pass
+        return True
+
 
 _PORT_CREDENTIAL_DOCS_URL = (
     "https://microsoft.github.io/apm/getting-started/authentication/"
@@ -474,6 +529,7 @@ class AuthResolver:
             except AzureCliBearerError as bearer_exc:
                 # az CLI bearer acquisition failed (not logged in, token expired, etc.).
                 # Fall through to the original PAT error.
+                # Safe: str() emits message only, not stderr attribute.
                 logger.debug(
                     "ADO bearer acquisition failed for %s; falling through to PAT error: %s",
                     host_info.display_name,
@@ -483,9 +539,10 @@ class AuthResolver:
                 # The operation callable may raise any exception type; broad catch is
                 # required because we cannot restrict the caller API without a behavior
                 # change (Case 4: bearer op itself failed after PAT rejection).
+                # Use %r so the exception type is visible in the debug record.
                 logger.debug(
                     "ADO bearer fallback operation raised for %s; re-raising original PAT"
-                    " exception: %s",
+                    " exception: %r",
                     host_info.display_name,
                     bearer_op_exc,
                 )
@@ -498,9 +555,9 @@ class AuthResolver:
                 return operation(auth_ctx.token, git_env)
             except Exception as exc:
                 # operation is caller-provided; broad catch required -- cannot narrow
-                # without restricting the caller API.
+                # without restricting the caller API.  Use %r so the type is visible.
                 logger.debug(
-                    "Auth-only operation failed for ghe_cloud host %s: %s",
+                    "Auth-only operation failed for ghe_cloud host %s: %r",
                     host_info.display_name,
                     exc,
                 )
@@ -513,9 +570,9 @@ class AuthResolver:
                 return operation(auth_ctx.token, git_env)
             except Exception as exc:
                 # operation is caller-provided; broad catch required -- cannot narrow
-                # without restricting the caller API.
+                # without restricting the caller API.  Use %r so the type is visible.
                 logger.debug(
-                    "Auth-only operation failed for ado host %s; trying bearer fallback: %s",
+                    "Auth-only operation failed for ado host %s; trying bearer fallback: %r",
                     host_info.display_name,
                     exc,
                 )
@@ -528,9 +585,9 @@ class AuthResolver:
                 return operation(None, git_env)
             except Exception as exc:
                 # operation is caller-provided; broad catch required -- cannot narrow
-                # without restricting the caller API.
+                # without restricting the caller API.  Use %r so the type is visible.
                 logger.debug(
-                    "Unauthenticated access failed for %s; will retry with token: %s",
+                    "Unauthenticated access failed for %s; will retry with token: %r",
                     host_info.display_name,
                     exc,
                 )
@@ -541,7 +598,7 @@ class AuthResolver:
                     except Exception as retry_exc:
                         # operation is caller-provided; broad catch required.
                         logger.debug(
-                            "Authenticated retry also failed for %s: %s",
+                            "Authenticated retry also failed for %s: %r",
                             host_info.display_name,
                             retry_exc,
                         )
@@ -557,9 +614,9 @@ class AuthResolver:
                 return operation(auth_ctx.token, git_env)
             except Exception as exc:
                 # operation is caller-provided; broad catch required -- cannot narrow
-                # without restricting the caller API.
+                # without restricting the caller API.  Use %r so the type is visible.
                 logger.debug(
-                    "Authenticated access failed for %s; will retry unauthenticated: %s",
+                    "Authenticated access failed for %s; will retry unauthenticated: %r",
                     host_info.display_name,
                     exc,
                 )
@@ -570,7 +627,7 @@ class AuthResolver:
                     except Exception as unauth_exc:
                         # operation is caller-provided; broad catch required.
                         logger.debug(
-                            "Unauthenticated retry also failed for %s: %s",
+                            "Unauthenticated retry also failed for %s: %r",
                             host_info.display_name,
                             unauth_exc,
                         )

--- a/src/apm_cli/core/auth.py
+++ b/src/apm_cli/core/auth.py
@@ -818,7 +818,7 @@ class AuthResolver:
                     # Fall through to token=None; build_error_context will render Case 3.
                     logger.debug(
                         "ADO bearer token acquisition failed for %s: %s",
-                        host_info.host,
+                        host_info.display_name,
                         exc,
                     )
             return None, "none", "basic"

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,5 +1,6 @@
 """Unit tests for AuthResolver, HostInfo, and AuthContext."""
 
+import logging
 import os
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -1473,3 +1474,40 @@ class TestCredentialFallbackOrderRegressionTrap:
         assert seen[0] is None, (
             "When no token is available, unauthenticated access (None) must be tried"
         )
+
+    def test_cascade_exception_emits_debug_log(self, caplog):
+        """Debug logging fires when the initial op raises (fallback triggered) -- #935."""
+        with patch.dict(os.environ, {"GITHUB_APM_PAT": "test-token"}, clear=True):
+            with patch.object(GitHubTokenManager, "resolve_credential_from_git", return_value=None):
+                resolver = AuthResolver()
+
+                def op_fail_on_token(token, env):
+                    if token is not None:
+                        raise Exception("simulated token rejection")
+                    return "ok"
+
+                with caplog.at_level(logging.DEBUG, logger="apm_cli.core.auth"):
+                    resolver.try_with_fallback("github.com", op_fail_on_token, path="owner/repo")
+
+        debug_msgs = [r.message for r in caplog.records if r.levelno == logging.DEBUG]
+        assert debug_msgs, (
+            "Expected at least one debug log during cascade fallback; none emitted (#935)"
+        )
+
+    def test_debug_logs_do_not_contain_token_values(self, caplog):
+        """Credential values must not appear in debug log output -- security guard (#935)."""
+        sentinel = "ghp_SENTINEL_TOKEN_DO_NOT_LOG_12345"
+        with patch.dict(os.environ, {"GITHUB_APM_PAT": sentinel}, clear=True):
+            with patch.object(GitHubTokenManager, "resolve_credential_from_git", return_value=None):
+                resolver = AuthResolver()
+
+                def op_fail_on_token(token, env):
+                    if token is not None:
+                        raise Exception("simulated token rejection")
+                    return "ok"
+
+                with caplog.at_level(logging.DEBUG, logger="apm_cli.core.auth"):
+                    resolver.try_with_fallback("github.com", op_fail_on_token, path="owner/repo")
+
+        full_log = " ".join(r.message for r in caplog.records)
+        assert sentinel not in full_log, "Credential values must not appear in debug log output"

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1373,3 +1373,103 @@ class TestGhCliShortCircuitsCredentialFill:
 
             assert result == "ok:gho_from_gh_cli"
             mock_cred_fill.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# TestCredentialFallbackOrderRegressionTrap
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialFallbackOrderRegressionTrap:
+    """Regression trap: the credential-resolution priority order for GitHub-class
+    hosts must not silently change.
+
+    Issue #935: while auditing silent except clauses we locked in the current
+    cascade order so any future refactor that shifts priorities is forced to
+    update this test explicitly.
+
+    Priority order (per-org PAT -> global PAT -> GITHUB_TOKEN -> GH_TOKEN ->
+    gh CLI -> git credential fill) is verified by observing which token reaches
+    the operation callable first across a series of isolated env configurations.
+    """
+
+    def _run_op(self, resolver, token_seen, org=None):
+        """Helper: run try_with_fallback and capture the token passed to op."""
+
+        def op(token, env):
+            token_seen.append(token)
+            return "ok"
+
+        return resolver.try_with_fallback("github.com", op, path="owner/repo", org=org)
+
+    def test_per_org_pat_beats_global_pat(self):
+        org = "owner"
+        per_org_key = f"GITHUB_APM_PAT_{org.upper()}"
+        with patch.dict(
+            os.environ,
+            {per_org_key: "per-org-token", "GITHUB_APM_PAT": "global-token"},
+            clear=True,
+        ):
+            with patch.object(GitHubTokenManager, "resolve_credential_from_git", return_value=None):
+                seen = []
+                resolver = AuthResolver()
+                self._run_op(resolver, seen, org=org)
+        assert seen[0] == "per-org-token", (
+            "per-org PAT must be tried before global PAT; cascade order changed"
+        )
+
+    def test_global_pat_beats_github_token(self):
+        with patch.dict(
+            os.environ,
+            {"GITHUB_APM_PAT": "global-pat", "GITHUB_TOKEN": "gh-token"},
+            clear=True,
+        ):
+            with patch.object(GitHubTokenManager, "resolve_credential_from_git", return_value=None):
+                seen = []
+                resolver = AuthResolver()
+                self._run_op(resolver, seen)
+        assert seen[0] == "global-pat", (
+            "GITHUB_APM_PAT must be tried before GITHUB_TOKEN; cascade order changed"
+        )
+
+    def test_github_token_beats_gh_token(self):
+        with patch.dict(
+            os.environ,
+            {"GITHUB_TOKEN": "gh-token-env", "GH_TOKEN": "gh-token-alt"},
+            clear=True,
+        ):
+            with patch.object(GitHubTokenManager, "resolve_credential_from_git", return_value=None):
+                seen = []
+                resolver = AuthResolver()
+                self._run_op(resolver, seen)
+        assert seen[0] == "gh-token-env", (
+            "GITHUB_TOKEN must be tried before GH_TOKEN; cascade order changed"
+        )
+
+    def test_gh_cli_token_beats_git_credential_fill(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(
+                GitHubTokenManager,
+                "resolve_credential_from_gh_cli",
+                return_value="gho_cli",
+            ):
+                with patch.object(
+                    GitHubTokenManager, "resolve_credential_from_git"
+                ) as mock_git_cred:
+                    seen = []
+                    resolver = AuthResolver()
+                    self._run_op(resolver, seen)
+        assert seen[0] == "gho_cli", (
+            "gh CLI token must be tried before git credential fill; cascade order changed"
+        )
+        mock_git_cred.assert_not_called()
+
+    def test_no_token_falls_back_to_unauthenticated(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(GitHubTokenManager, "resolve_credential_from_git", return_value=None):
+                seen = []
+                resolver = AuthResolver()
+                self._run_op(resolver, seen)
+        assert seen[0] is None, (
+            "When no token is available, unauthenticated access (None) must be tried"
+        )

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1511,3 +1511,103 @@ class TestCredentialFallbackOrderRegressionTrap:
 
         full_log = " ".join(r.message for r in caplog.records)
         assert sentinel not in full_log, "Credential values must not appear in debug log output"
+
+    def test_ado_attempts_bearer_before_raising(self):
+        """ADO: when PAT fails with auth signal, bearer MUST be attempted before raising.
+
+        Regression trap -- if the _try_ado_bearer_fallback() call is removed from the
+        ADO branch of try_with_fallback, this test fails because get_bearer_token() is
+        never called and the original PAT exception propagates without the bearer attempt.
+        """
+        from apm_cli.core.azure_cli import AzureCliBearerError
+
+        bearer_calls = []
+
+        with patch.dict(os.environ, {"ADO_APM_PAT": "stale-pat"}, clear=True):
+            with patch("apm_cli.core.azure_cli.AzureCliBearerProvider") as mock_cls:
+                mock_provider = mock_cls.return_value
+                mock_provider.is_available.return_value = True
+
+                def _get_bearer():
+                    bearer_calls.append(1)
+                    raise AzureCliBearerError("no az login")
+
+                mock_provider.get_bearer_token.side_effect = _get_bearer
+
+                resolver = AuthResolver()
+
+                def ado_op(token, env):
+                    raise RuntimeError("401 unauthorized")
+
+                with pytest.raises(RuntimeError, match="401 unauthorized"):
+                    resolver.try_with_fallback("dev.azure.com", ado_op)
+
+        assert bearer_calls, (
+            "ADO bearer must be attempted before re-raising original PAT error; "
+            "cascade order changed (regression trap #935)"
+        )
+
+    def test_ghe_cloud_never_falls_back_to_unauth(self):
+        """ghe_cloud: unauthenticated fallback must NEVER be attempted.
+
+        GitHub Enterprise Cloud has no public repos; passing None as the token
+        would expose a useless attempt and violate the auth-only contract.
+        This regression trap verifies that `None` is never sent to the operation
+        callable for a ghe_cloud host, even when the authenticated attempt fails.
+        """
+        tokens_seen = []
+
+        with patch.dict(os.environ, {"GITHUB_APM_PAT": "ghe-pat"}, clear=True):
+            with patch.object(GitHubTokenManager, "resolve_credential_from_git", return_value=None):
+                resolver = AuthResolver()
+
+                def op_capture(token, env):
+                    tokens_seen.append(token)
+                    raise RuntimeError("ghe_cloud op always fails")
+
+                with pytest.raises(RuntimeError):
+                    resolver.try_with_fallback("contoso.ghe.com", op_capture)
+
+        assert None not in tokens_seen, (
+            "ghe_cloud must never fall back to unauthenticated (None token) access; "
+            "contract violated (regression trap #935)"
+        )
+        assert tokens_seen, "Operation was never called -- test is mis-wired"
+
+    def test_token_in_exception_message_is_redacted(self, caplog):
+        """A secret pattern embedded in an exception message must be stripped from debug output.
+
+        Supply-chain hardening (#935): HTTP client libraries sometimes embed auth
+        headers or token values in their exception messages.  SecretRedactionFilter
+        must intercept those before they reach any log handler.
+        """
+        from apm_cli.core.auth import SecretRedactionFilter
+
+        sentinel = "ghp_EMBEDDED_SECRET_IN_EXC_99999"
+        auth_logger = logging.getLogger("apm_cli.core.auth")
+        redaction_filter = SecretRedactionFilter()
+        auth_logger.addFilter(redaction_filter)
+
+        try:
+            with patch.dict(os.environ, {"GITHUB_APM_PAT": "safe-outer-token"}, clear=True):
+                with patch.object(
+                    GitHubTokenManager, "resolve_credential_from_git", return_value=None
+                ):
+                    resolver = AuthResolver()
+
+                    def op_embed_secret(token, env):
+                        if token is not None:
+                            # Simulates an HTTP library embedding a bearer token in
+                            # the exception message (the real supply-chain risk).
+                            raise RuntimeError(f"Bearer {sentinel} was rejected by server")
+                        return "ok"
+
+                    with caplog.at_level(logging.DEBUG, logger="apm_cli.core.auth"):
+                        resolver.try_with_fallback("github.com", op_embed_secret, path="owner/repo")
+        finally:
+            auth_logger.removeFilter(redaction_filter)
+
+        full_log = " ".join(r.message for r in caplog.records)
+        assert sentinel not in full_log, (
+            "Secret embedded in exception message must be redacted by SecretRedactionFilter"
+        )


### PR DESCRIPTION
refactor(auth): debug-log all exception handlers in credential cascade (closes #935)

## TL;DR

Add `logger.debug` calls to every silent `except` clause in `src/apm_cli/core/auth.py`'s credential cascade.  Fourteen exception handlers now emit structured debug messages; six specific catches gain explicit `as exc` bindings; all eight broad `except Exception` guards keep their scope (caller-provided callables) and receive justification comments.  Debug output is now reachable via `apm --verbose` or `APM_LOG_LEVEL=DEBUG`.  A `SecretRedactionFilter` guards all debug records against exception messages that embed token values.

## Problem (WHY)

Silent `except` clauses in the auth credential cascade make it impossible to trace why a specific token source was skipped when debugging auth failures.  Issue #935 requested an audit and logging pass.

## Approach (WHAT)

- Add `logger = logging.getLogger(__name__)` at module level
- Add `logger.debug(...)` to all 14 silent except clauses
- Bind specific catches (`AzureCliBearerError`, `ImportError`) with `as exc`
- Keep all broad `except Exception` guards; they guard caller-provided `operation` / `bearer_op` callables that can raise anything -- narrowing would break callers
- Add justification comments to every broad catch explaining why it cannot be narrowed
- Rename shadowed `exc` bindings in `_try_ado_bearer_fallback` to `bearer_exc` / `bearer_op_exc` (PLR1704)
- Add `--verbose` / `-v` flag to the `apm` CLI group and `APM_LOG_LEVEL` env-var support; both wire to stdlib `logging.DEBUG` so the new debug calls are reachable
- Add `_redact_secrets()` helper + `SecretRedactionFilter` to strip token-bearing patterns from exception messages before they reach any log handler

## Implementation (HOW)

### src/apm_cli/core/auth.py

| Location | Clause | Change |
|---|---|---|
| `_try_ado_bearer_fallback` | `except AzureCliBearerError` | bind + debug log + safety comment |
| `_try_ado_bearer_fallback` | `except Exception` | bind + debug log (%r) + justification comment |
| `try_with_fallback` ghe_cloud | `except Exception as exc` | debug log (%r) + justification |
| `try_with_fallback` ADO | `except Exception as exc` | debug log (%r) + justification |
| `try_with_fallback` unauth_first outer | `except Exception` | bind + debug log (%r) + justification |
| `try_with_fallback` unauth_first inner | `except Exception as exc` | debug log (%r) + justification |
| `try_with_fallback` auth-first | `except Exception as exc` | debug log (%r) + justification |
| `try_with_fallback` auth-first unauth retry | `except Exception` | bind as `unauth_exc` + debug log (%r) + justification |
| `_resolve_token` ADO bearer | `except AzureCliBearerError` | bind + debug log |
| `emit_stale_pat_diagnostic` | `except ImportError` | bind + debug log |
| `notify_auth_source` | `except ImportError` | bind + debug log |
| `execute_with_bearer_fallback` | `except ImportError` | bind + debug log |
| `execute_with_bearer_fallback` | `except AzureCliBearerError` | bind + debug log |
| `execute_with_bearer_fallback` | `except Exception` | bind + debug log + justification |

### src/apm_cli/cli.py

- `--verbose` / `-v` flag added to the `apm` CLI group; sets logging to `DEBUG`
- `APM_LOG_LEVEL` env var read at startup; accepts any stdlib level name
- `_configure_logging(verbose)` installs `SecretRedactionFilter` on the `apm_cli` logger

### src/apm_cli/core/auth.py (new helpers)

- `_redact_secrets(text: str) -> str`: regex helper that strips `token=VALUE`, `Authorization: Bearer VALUE`, and URL credential patterns
- `SecretRedactionFilter(logging.Filter)`: installed on the `apm_cli` logger; modifies log records in-place before any handler processes them

### tests/unit/test_auth.py

Extends `TestCredentialFallbackOrderRegressionTrap` with five new tests:
- `test_per_org_pat_beats_global_pat`
- `test_global_pat_beats_github_token`
- `test_github_token_beats_gh_token`
- `test_gh_cli_token_beats_git_credential_fill`
- `test_no_token_falls_back_to_unauthenticated`
- `test_cascade_exception_emits_debug_log`
- `test_debug_logs_do_not_contain_token_values`
- `test_ado_attempts_bearer_before_raising` (new -- bearer call verified before PAT re-raise; mutation-break confirmed)
- `test_ghe_cloud_never_falls_back_to_unauth` (new -- None never passed to op; mutation-break confirmed)
- `test_token_in_exception_message_is_redacted` (new -- bearer token embedded in exc message stripped by filter; mutation-break confirmed)

## Trade-offs

- All broad catches remain broad -- they guard caller-provided `operation` / `bearer_op` callables that can raise anything; narrowing would require breaking the public API.
- Debug messages use `%s` / `%r` formatting (not f-strings) to avoid eagerly evaluating the exception repr when debug logging is disabled.
- `SecretRedactionFilter` modifies records in-place and is idempotent (installed once per logger instance).

## Validation evidence

- `uv run --extra dev ruff check src/ tests/`: All checks passed
- `uv run --extra dev ruff format --check src/ tests/`: 1224 files already formatted
- `uv run --extra dev python -m pylint --disable=all --enable=R0801 ...`: 10.00/10
- `bash scripts/lint-auth-signals.sh`: auth-signal lint clean
- `uv run --extra dev pytest tests/unit/test_auth.py -q`: 115 passed
- Mutation-break evidence: 3 mutations verified (ADO bearer skip, ghe_cloud unauth, redaction disabled -- each causes exactly the corresponding test to fail)

## How to test

```bash
uv run --extra dev pytest tests/unit/test_auth.py -q

# Enable debug logging to observe the new messages (either mechanism):
apm --verbose install <some-dep> 2>&1 | grep 'apm_cli.core.auth'
APM_LOG_LEVEL=DEBUG apm install <some-dep> 2>&1 | grep 'apm_cli.core.auth'
```

> **Note**: This PR touches `src/apm_cli/core/auth.py` and `src/apm_cli/cli.py` -- the auth surface and CLI entry point. Auth Expert review is warranted.

Closes #935