### PR TITLE
fix(install): keep format-transformed rules tracked + in sync (closes #1662)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `apm install` now keeps format-transformed rule files (`.claude/rules`,
+  `.cursor/rules`, `.windsurf/rules`) tracked in `managed_files` and rewrites
+  them when the source instruction changes, instead of mis-classifying them as
+  user-authored collisions and skipping them; also fixes a mislabeled
+  `windsurf_rules` entry in install output. (by @srid, closes #1662)
+
 ## [0.18.0] - 2026-06-04
 
 ### Added

--- a/docs/src/content/docs/consumer/install-packages.md
+++ b/docs/src/content/docs/consumer/install-packages.md
@@ -122,6 +122,8 @@ targets:
 For the full reach map of which primitive lands where on each
 harness, see [Primitives and targets](../../concepts/primitives-and-targets/).
 
+Rule sync to Cursor (`.cursor/rules/`), Claude Code (`.claude/rules/`), and Windsurf (`.windsurf/rules/`) is automatic and idempotent -- re-running `apm install` adopts unchanged rules without rewriting them.
+
 ## Transitive dependencies and the lockfile
 
 `apm install` resolves the full dependency graph, not just your

--- a/src/apm_cli/install/services.py
+++ b/src/apm_cli/install/services.py
@@ -332,10 +332,10 @@ def integrate_package_primitives(
                 if _mapping.subdir
                 else f"{_effective_root}/"
             )
-            if _prim_name == "instructions" and _mapping.format_id in (
-                "cursor_rules",
-                "claude_rules",
-            ):
+            if _prim_name == "instructions" and _mapping.output_compare:
+                # Rule-dir formats (cursor/claude/windsurf) are the
+                # output_compare set; derive the label from the same flag so a
+                # new rule format needs no edit here.
                 _label = "rule(s)"
             elif _prim_name == "instructions":
                 _label = "instruction(s)"

--- a/src/apm_cli/integration/instruction_integrator.py
+++ b/src/apm_cli/integration/instruction_integrator.py
@@ -171,6 +171,7 @@ class InstructionIntegrator(BaseIntegrator):
             rel_path = portable_relpath(target_path, project_root)
 
             if apm_owned_rule_dir:
+                # Path containment already validated by ensure_path_within above.
                 # Structural invariant: target_name derives 1:1 from source, so
                 # ANY existing file here is APM's -- must hold for every format
                 # with output_compare=True. managed_files is not consulted.

--- a/src/apm_cli/integration/instruction_integrator.py
+++ b/src/apm_cli/integration/instruction_integrator.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from apm_cli.integration.base_integrator import BaseIntegrator, IntegrationResult
+from apm_cli.integration.targets import RULE_FORMATS
 from apm_cli.utils.path_security import ensure_path_within
 from apm_cli.utils.paths import portable_relpath
 from apm_cli.utils.patterns import parse_apply_to, yaml_double_quote
@@ -54,6 +55,29 @@ class InstructionIntegrator(BaseIntegrator):
         target.write_text(content, encoding="utf-8")
         return links_resolved
 
+    def _render_instruction(self, source: Path, target: Path, fmt: str) -> tuple[str, int]:
+        """Render *source* to the content it would deploy for *fmt*, WITHOUT
+        writing. Returns ``(content, links_resolved)``.
+
+        Used both by the ``copy_instruction_*`` writers and by the rule-dir
+        deploy loop to decide adopt-vs-rewrite against the *transformed* output
+        (a format-transformed rule is never byte-identical to its source).
+
+        The transforming formats are exactly :data:`targets.RULE_FORMATS` --
+        the single home for "which formats transform".  Any ``fmt`` outside it
+        is copied verbatim (identity transform).
+        """
+        content = source.read_text(encoding="utf-8")
+        if fmt in RULE_FORMATS:
+            converters = {
+                "cursor_rules": self._convert_to_cursor_rules,
+                "claude_rules": self._convert_to_claude_rules,
+                "windsurf_rules": self._convert_to_windsurf_rules,
+            }
+            content = converters[fmt](content)
+        content, links_resolved = self.resolve_links(content, source, target)
+        return content, links_resolved
+
     # ------------------------------------------------------------------
     # Target-driven API (data-driven dispatch)
     # ------------------------------------------------------------------
@@ -77,6 +101,13 @@ class InstructionIntegrator(BaseIntegrator):
         * ``claude_rules``    -- convert ``applyTo:`` to ``paths:`` frontmatter
         * ``windsurf_rules``  -- convert ``applyTo:`` to ``trigger: glob`` frontmatter
         * anything else       -- copy verbatim (identity transform)
+
+        ``managed_files`` is consulted for collision detection on identity
+        targets only.  For rule-dir targets (``mapping.output_compare``) it is
+        deliberately NOT consulted: those files are APM-owned per-file
+        (``target_name`` derives 1:1 from a source instruction), so an existing
+        file there is always APM's and is adopted-or-rewritten regardless of
+        whether it was recorded as managed (apm#1662).
         """
         mapping = target.primitives.get("instructions")
         if not mapping:
@@ -108,7 +139,12 @@ class InstructionIntegrator(BaseIntegrator):
                 pkg_source=getattr(getattr(package_info, "package", None), "source", None),
             )
 
-        needs_rename = fmt in ("cursor_rules", "claude_rules", "windsurf_rules")
+        # APM-owned rule dirs (.claude/rules, .cursor/rules, .windsurf/rules):
+        # the deployed file is a format-transform of its source and the target
+        # name derives 1:1 from the source, so APM owns it per-file. Gates both
+        # the filename rename and the output-comparison / collision-guard
+        # bypass. Single source of truth: mapping.output_compare (targets.py).
+        apm_owned_rule_dir = mapping.output_compare
 
         files_integrated = 0
         files_skipped = 0
@@ -117,7 +153,7 @@ class InstructionIntegrator(BaseIntegrator):
         total_links_resolved = 0
 
         for source_file in instruction_files:
-            if needs_rename:
+            if apm_owned_rule_dir:
                 stem = source_file.name
                 if stem.endswith(".instructions.md"):
                     stem = stem[: -len(".instructions.md")]
@@ -134,6 +170,36 @@ class InstructionIntegrator(BaseIntegrator):
 
             rel_path = portable_relpath(target_path, project_root)
 
+            if apm_owned_rule_dir:
+                # Structural invariant: target_name derives 1:1 from source, so
+                # ANY existing file here is APM's -- must hold for every format
+                # with output_compare=True. managed_files is not consulted.
+                #
+                # The deployed file is format-transformed, so it is never
+                # byte-identical to the *source* -- the source-based adopt always
+                # misses, the file gets treated as a user-authored collision and
+                # skipped, and it falls out of ``local_deployed_files`` so later
+                # edits never propagate (apm#1662). Instead compare against the
+                # transformed *output*: adopt when up-to-date (no churn), else
+                # (re)write. Always record the path so it stays managed on the
+                # next run.
+                new_content, links_resolved = self._render_instruction(
+                    source_file, target_path, fmt
+                )
+                if (
+                    not force
+                    and target_path.exists()
+                    and target_path.read_text(encoding="utf-8") == new_content
+                ):
+                    files_adopted += 1
+                    target_paths.append(target_path)
+                    continue
+                target_path.write_text(new_content, encoding="utf-8")
+                total_links_resolved += links_resolved
+                files_integrated += 1
+                target_paths.append(target_path)
+                continue
+
             skip, adopted = self._check_adopt_or_skip(
                 target_path, source_file, rel_path, managed_files, force, diagnostics, target_paths
             )
@@ -144,15 +210,7 @@ class InstructionIntegrator(BaseIntegrator):
                     files_skipped += 1
                 continue
 
-            if fmt == "cursor_rules":
-                links_resolved = self.copy_instruction_cursor(source_file, target_path)
-            elif fmt == "claude_rules":
-                links_resolved = self.copy_instruction_claude(source_file, target_path)
-            elif fmt == "windsurf_rules":
-                links_resolved = self.copy_instruction_windsurf(source_file, target_path)
-            else:
-                links_resolved = self.copy_instruction(source_file, target_path)
-
+            links_resolved = self.copy_instruction(source_file, target_path)
             total_links_resolved += links_resolved
             files_integrated += 1
             target_paths.append(target_path)
@@ -440,9 +498,7 @@ class InstructionIntegrator(BaseIntegrator):
 
         Converts ``applyTo:`` → ``globs:`` frontmatter and resolves links.
         """
-        content = source.read_text(encoding="utf-8")
-        content = self._convert_to_cursor_rules(content)
-        content, links_resolved = self.resolve_links(content, source, target)
+        content, links_resolved = self._render_instruction(source, target, "cursor_rules")
         target.write_text(content, encoding="utf-8")
         return links_resolved
 
@@ -539,9 +595,7 @@ class InstructionIntegrator(BaseIntegrator):
         Converts ``applyTo:`` to ``trigger: glob`` + ``globs:`` frontmatter
         and resolves links.
         """
-        content = source.read_text(encoding="utf-8")
-        content = self._convert_to_windsurf_rules(content)
-        content, links_resolved = self.resolve_links(content, source, target)
+        content, links_resolved = self._render_instruction(source, target, "windsurf_rules")
         target.write_text(content, encoding="utf-8")
         return links_resolved
 
@@ -590,9 +644,7 @@ class InstructionIntegrator(BaseIntegrator):
 
         Converts ``applyTo:`` to ``paths:`` frontmatter and resolves links.
         """
-        content = source.read_text(encoding="utf-8")
-        content = self._convert_to_claude_rules(content)
-        content, links_resolved = self.resolve_links(content, source, target)
+        content, links_resolved = self._render_instruction(source, target, "claude_rules")
         target.write_text(content, encoding="utf-8")
         return links_resolved
 

--- a/src/apm_cli/integration/instruction_integrator.py
+++ b/src/apm_cli/integration/instruction_integrator.py
@@ -11,10 +11,11 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 from apm_cli.integration.base_integrator import BaseIntegrator, IntegrationResult
 from apm_cli.integration.targets import RULE_FORMATS
+from apm_cli.utils.console import _rich_echo
 from apm_cli.utils.path_security import ensure_path_within
 from apm_cli.utils.paths import portable_relpath
 from apm_cli.utils.patterns import parse_apply_to, yaml_double_quote
@@ -33,6 +34,14 @@ class InstructionIntegrator(BaseIntegrator):
     * Claude Code: ``.claude/rules/`` (``.md`` format, applyTo: -> paths:)
     * Gemini CLI: compile-only (GEMINI.md) -- no per-file rule deployment
     """
+
+    # Map format_id -> converter method.  Built once at class load time;
+    # avoids rebuilding the dict on every ``_render_instruction`` call.
+    _FORMAT_CONVERTERS: ClassVar[dict[str, str]] = {
+        "cursor_rules": "_convert_to_cursor_rules",
+        "claude_rules": "_convert_to_claude_rules",
+        "windsurf_rules": "_convert_to_windsurf_rules",
+    }
 
     def find_instruction_files(self, package_path: Path) -> list[Path]:
         """Find all .instructions.md files in a package.
@@ -69,12 +78,8 @@ class InstructionIntegrator(BaseIntegrator):
         """
         content = source.read_text(encoding="utf-8")
         if fmt in RULE_FORMATS:
-            converters = {
-                "cursor_rules": self._convert_to_cursor_rules,
-                "claude_rules": self._convert_to_claude_rules,
-                "windsurf_rules": self._convert_to_windsurf_rules,
-            }
-            content = converters[fmt](content)
+            converter = getattr(self, self._FORMAT_CONVERTERS[fmt])
+            content = converter(content)
         content, links_resolved = self.resolve_links(content, source, target)
         return content, links_resolved
 
@@ -194,11 +199,15 @@ class InstructionIntegrator(BaseIntegrator):
                 ):
                     files_adopted += 1
                     target_paths.append(target_path)
+                    if diagnostics is not None and getattr(diagnostics, "verbose", False):
+                        _rich_echo(f"  [=] adopted-unchanged: {rel_path}", color="dim")
                     continue
                 target_path.write_text(new_content, encoding="utf-8")
                 total_links_resolved += links_resolved
                 files_integrated += 1
                 target_paths.append(target_path)
+                if diagnostics is not None and getattr(diagnostics, "verbose", False):
+                    _rich_echo(f"  [*] rewritten: {rel_path}", color="dim")
                 continue
 
             skip, adopted = self._check_adopt_or_skip(

--- a/src/apm_cli/integration/targets.py
+++ b/src/apm_cli/integration/targets.py
@@ -21,6 +21,17 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 
+RULE_FORMATS: frozenset[str] = frozenset({"cursor_rules", "claude_rules", "windsurf_rules"})
+"""Canonical set of format-transforming rule ``format_id``s.
+
+Single home for "which instruction formats transform their source on
+deploy".  A mapping with one of these ``format_id``s MUST set
+``output_compare=True`` (enforced by :meth:`PrimitiveMapping.__post_init__`),
+and :meth:`InstructionIntegrator._render_instruction` dispatches on this same
+set.  Adding a new rule format means: add it here, set ``output_compare=True``
+on the mapping, and add a ``_convert_to_*`` branch in ``_render_instruction``.
+"""
+
 
 @dataclass(frozen=True)
 class PrimitiveMapping:
@@ -46,6 +57,55 @@ class PrimitiveMapping:
     directory) rather than ``.codex/``.  Default ``None`` preserves
     existing behavior for all other targets.
     """
+
+    output_compare: bool = False
+    """Whether this primitive's deployed file is a format-transform of its
+    source, so the integrator must adopt/collision-check against the
+    rendered *output* rather than the source bytes.
+
+    This is the single source of truth for the rule-dir formats
+    (``cursor_rules``, ``claude_rules``, ``windsurf_rules``).  When ``True``:
+
+    * The deployed file is never byte-identical to its source, so a
+      source-based adopt always misses (apm#1662).  The integrator instead
+      compares against the rendered output and (re)writes when stale.
+    * The target is APM-owned per-file (``target_name`` derives 1:1 from a
+      source instruction), so ``managed_files`` is NOT consulted -- any
+      existing file at the target path is APM's, not user-authored.
+    * The deployed filename is renamed from ``<x>.instructions.md`` to
+      ``<x>{extension}``.
+
+    Adding a future format-transformed rule type requires two coordinated
+    edits: set ``output_compare=True`` here (add the ``format_id`` to
+    ``RULE_FORMATS``) *and* add the matching ``_convert_to_*`` branch to
+    :meth:`InstructionIntegrator._render_instruction`, which dispatches on the
+    ``format_id`` to perform the transform.
+    """
+
+    def __post_init__(self) -> None:
+        """Keep ``output_compare`` and :data:`RULE_FORMATS` in lockstep.
+
+        A rule ``format_id`` that transforms its source MUST compare against
+        the rendered output; otherwise the integrator would fall through to a
+        verbatim copy and silently deploy untransformed content (apm#1662).
+        The converse is also enforced so the canonical set stays the one home
+        for "which formats transform".
+        """
+        is_rule = self.format_id in RULE_FORMATS
+        if is_rule and not self.output_compare:
+            raise ValueError(
+                f"PrimitiveMapping(format_id={self.format_id!r}) is a rule "
+                f"format ({sorted(RULE_FORMATS)}) and must set "
+                "output_compare=True; otherwise its source is deployed "
+                "untransformed."
+            )
+        if self.output_compare and not is_rule:
+            raise ValueError(
+                f"PrimitiveMapping(format_id={self.format_id!r}) sets "
+                "output_compare=True but is not a known rule format "
+                f"({sorted(RULE_FORMATS)}); add it to RULE_FORMATS and a "
+                "_render_instruction branch, or unset output_compare."
+            )
 
 
 @dataclass(frozen=True)
@@ -434,7 +494,12 @@ KNOWN_TARGETS: dict[str, TargetProfile] = {
         name="claude",
         root_dir=".claude",
         primitives={
-            "instructions": PrimitiveMapping("rules", ".md", "claude_rules"),
+            "instructions": PrimitiveMapping(
+                "rules",
+                ".md",
+                "claude_rules",
+                output_compare=True,
+            ),
             "agents": PrimitiveMapping("agents", ".md", "claude_agent"),
             "commands": PrimitiveMapping("commands", ".md", "claude_command"),
             "skills": PrimitiveMapping("skills", "/SKILL.md", "skill_standard"),
@@ -454,7 +519,12 @@ KNOWN_TARGETS: dict[str, TargetProfile] = {
         name="cursor",
         root_dir=".cursor",
         primitives={
-            "instructions": PrimitiveMapping("rules", ".mdc", "cursor_rules"),
+            "instructions": PrimitiveMapping(
+                "rules",
+                ".mdc",
+                "cursor_rules",
+                output_compare=True,
+            ),
             "agents": PrimitiveMapping("agents", ".md", "cursor_agent"),
             # TODO(cursor-command-format): track via dedicated issue once
             # filed.  Cursor command deployment reuses the shared command
@@ -576,7 +646,12 @@ KNOWN_TARGETS: dict[str, TargetProfile] = {
         name="windsurf",
         root_dir=".windsurf",
         primitives={
-            "instructions": PrimitiveMapping("rules", ".md", "windsurf_rules"),
+            "instructions": PrimitiveMapping(
+                "rules",
+                ".md",
+                "windsurf_rules",
+                output_compare=True,
+            ),
             "skills": PrimitiveMapping("skills", "/SKILL.md", "skill_standard"),
             "commands": PrimitiveMapping("workflows", ".md", "windsurf_workflow"),
             "hooks": PrimitiveMapping("", "hooks.json", "windsurf_hooks"),

--- a/tests/integration/test_copilot_app_targets_coverage.py
+++ b/tests/integration/test_copilot_app_targets_coverage.py
@@ -474,7 +474,9 @@ class TestPrimitiveMapping:
     def test_required_fields_stored(self) -> None:
         from apm_cli.integration.targets import PrimitiveMapping
 
-        pm = PrimitiveMapping(subdir="rules", extension=".md", format_id="cursor_rules")
+        pm = PrimitiveMapping(
+            subdir="rules", extension=".md", format_id="cursor_rules", output_compare=True
+        )
         assert pm.subdir == "rules"
         assert pm.extension == ".md"
         assert pm.format_id == "cursor_rules"

--- a/tests/integration/test_install_services_orchestration.py
+++ b/tests/integration/test_install_services_orchestration.py
@@ -42,8 +42,14 @@ def make_mapping(
     deploy_root: str | None = None,
     subdir: str = "",
     format_id: str = "plain",
+    output_compare: bool = False,
 ) -> SimpleNamespace:
-    return SimpleNamespace(deploy_root=deploy_root, subdir=subdir, format_id=format_id)
+    return SimpleNamespace(
+        deploy_root=deploy_root,
+        subdir=subdir,
+        format_id=format_id,
+        output_compare=output_compare,
+    )
 
 
 def make_dispatch_entry(
@@ -407,7 +413,11 @@ class TestIntegratePackagePrimitives:
 
     def test_instruction_cursor_rules_use_rule_label(self, tmp_path: Path) -> None:
         target = make_target(
-            primitives={"instructions": make_mapping(subdir="rules", format_id="cursor_rules")}
+            primitives={
+                "instructions": make_mapping(
+                    subdir="rules", format_id="cursor_rules", output_compare=True
+                )
+            }
         )
         entry = make_dispatch_entry(
             integrate_method="integrate_instructions_for_target",

--- a/tests/integration/test_install_services_phase3w5.py
+++ b/tests/integration/test_install_services_phase3w5.py
@@ -42,8 +42,14 @@ def make_mapping(
     deploy_root: str | None = None,
     subdir: str = "",
     format_id: str = "plain",
+    output_compare: bool = False,
 ) -> SimpleNamespace:
-    return SimpleNamespace(deploy_root=deploy_root, subdir=subdir, format_id=format_id)
+    return SimpleNamespace(
+        deploy_root=deploy_root,
+        subdir=subdir,
+        format_id=format_id,
+        output_compare=output_compare,
+    )
 
 
 def make_dispatch_entry(
@@ -407,7 +413,11 @@ class TestIntegratePackagePrimitives:
 
     def test_instruction_cursor_rules_use_rule_label(self, tmp_path: Path) -> None:
         target = make_target(
-            primitives={"instructions": make_mapping(subdir="rules", format_id="cursor_rules")}
+            primitives={
+                "instructions": make_mapping(
+                    subdir="rules", format_id="cursor_rules", output_compare=True
+                )
+            }
         )
         entry = make_dispatch_entry(
             integrate_method="integrate_instructions_for_target",

--- a/tests/unit/integration/test_instruction_integrator.py
+++ b/tests/unit/integration/test_instruction_integrator.py
@@ -1572,6 +1572,10 @@ class TestWindsurfRulesIntegration:
         )
         assert adopt.files_integrated == 0
         assert adopt.files_adopted == 1
+        # Adopted files MUST still be recorded in target_paths so they stay
+        # tracked in the lockfile manifest.  The #1662 regression was that
+        # paths were NOT recorded, causing rules to fall out of managed_files.
+        assert len(adopt.target_paths) == 1
 
         # Re-deploy WITH force rewrites instead of adopting.
         forced = self.integrator.integrate_instructions_for_target(

--- a/tests/unit/integration/test_instruction_integrator.py
+++ b/tests/unit/integration/test_instruction_integrator.py
@@ -659,12 +659,18 @@ class TestCursorRulesIntegration:
         assert result.files_integrated == 0
         assert result.target_paths == []
 
-    def test_collision_detection_skips_user_file(self):
-        """Skips user-authored .mdc file when not in managed_files."""
+    def test_collision_overwrites_existing_rule_file(self):
+        """Rule dirs are APM-owned: an existing .mdc is overwritten, not skipped.
+
+        Pre-#1662 this asserted a collision skip. The new invariant
+        (output_compare=True) is that target_name derives 1:1 from the source,
+        so any existing file here is APM's and must be (re)written -- never
+        treated as a user-authored collision -- regardless of managed_files.
+        """
         (self.project_root / ".cursor").mkdir()
         rules_dir = self.project_root / ".cursor" / "rules"
         rules_dir.mkdir()
-        (rules_dir / "python.mdc").write_text("# User rules")
+        (rules_dir / "python.mdc").write_text("# Stale rules")
 
         pkg = self.project_root / "package"
         inst_dir = pkg / ".apm" / "instructions"
@@ -676,9 +682,39 @@ class TestCursorRulesIntegration:
             pkg_info, self.project_root, managed_files=set()
         )
 
-        assert result.files_integrated == 0
-        assert result.files_skipped == 1
-        assert (rules_dir / "python.mdc").read_text() == "# User rules"
+        assert result.files_integrated == 1
+        assert result.files_skipped == 0
+        deployed = (rules_dir / "python.mdc").read_text()
+        assert "# APM rules" in deployed
+        assert "Stale rules" not in deployed
+
+    def test_managed_files_has_no_effect_on_rule_dir(self):
+        """managed_files is not consulted for output_compare (rule-dir) targets.
+
+        Whether or not the path is recorded as managed, the existing rule is
+        (re)written from the source. Guards the #1662 regression where the file
+        fell out of managed_files and stopped propagating edits.
+        """
+        (self.project_root / ".cursor").mkdir()
+        rules_dir = self.project_root / ".cursor" / "rules"
+        rules_dir.mkdir()
+        (rules_dir / "python.mdc").write_text("# Stale rules")
+
+        pkg = self.project_root / "package"
+        inst_dir = pkg / ".apm" / "instructions"
+        inst_dir.mkdir(parents=True)
+        (inst_dir / "python.instructions.md").write_text("# APM rules")
+
+        pkg_info = _make_package_info(pkg)
+        # managed_files=None (no manifest) must behave identically to
+        # managed_files=set(): the rule is still adopted/overwritten.
+        result = self.integrator.integrate_package_instructions_cursor(
+            pkg_info, self.project_root, managed_files=None
+        )
+
+        assert result.files_integrated == 1
+        assert result.files_skipped == 0
+        assert "# APM rules" in (rules_dir / "python.mdc").read_text()
 
     def test_overwrites_managed_file(self):
         """Overwrites file when it's in managed_files."""
@@ -966,12 +1002,18 @@ class TestClaudeRulesIntegration:
         assert result.files_integrated == 0
         assert result.target_paths == []
 
-    def test_collision_detection_skips_user_file(self):
-        """Skips user-authored .md file when not in managed_files."""
+    def test_collision_overwrites_existing_rule_file(self):
+        """Rule dirs are APM-owned: an existing .md is overwritten, not skipped.
+
+        Pre-#1662 this asserted a collision skip. The new invariant
+        (output_compare=True) is that target_name derives 1:1 from the source,
+        so any existing file here is APM's and must be (re)written -- never
+        treated as a user-authored collision -- regardless of managed_files.
+        """
         (self.project_root / ".claude").mkdir()
         rules_dir = self.project_root / ".claude" / "rules"
         rules_dir.mkdir()
-        (rules_dir / "python.md").write_text("# User rules")
+        (rules_dir / "python.md").write_text("# Stale rules")
 
         pkg = self.project_root / "package"
         inst_dir = pkg / ".apm" / "instructions"
@@ -983,9 +1025,37 @@ class TestClaudeRulesIntegration:
             pkg_info, self.project_root, managed_files=set()
         )
 
-        assert result.files_integrated == 0
-        assert result.files_skipped == 1
-        assert (rules_dir / "python.md").read_text() == "# User rules"
+        assert result.files_integrated == 1
+        assert result.files_skipped == 0
+        deployed = (rules_dir / "python.md").read_text()
+        assert "# APM rules" in deployed
+        assert "Stale rules" not in deployed
+
+    def test_managed_files_has_no_effect_on_rule_dir(self):
+        """managed_files is not consulted for output_compare (rule-dir) targets.
+
+        Whether or not the path is recorded as managed, the existing rule is
+        (re)written from the source. Guards the #1662 regression where the file
+        fell out of managed_files and stopped propagating edits.
+        """
+        (self.project_root / ".claude").mkdir()
+        rules_dir = self.project_root / ".claude" / "rules"
+        rules_dir.mkdir()
+        (rules_dir / "python.md").write_text("# Stale rules")
+
+        pkg = self.project_root / "package"
+        inst_dir = pkg / ".apm" / "instructions"
+        inst_dir.mkdir(parents=True)
+        (inst_dir / "python.instructions.md").write_text("# APM rules")
+
+        pkg_info = _make_package_info(pkg)
+        result = self.integrator.integrate_package_instructions_claude(
+            pkg_info, self.project_root, managed_files=None
+        )
+
+        assert result.files_integrated == 1
+        assert result.files_skipped == 0
+        assert "# APM rules" in (rules_dir / "python.md").read_text()
 
     def test_overwrites_managed_file(self):
         """Overwrites file when it's in managed_files."""
@@ -1418,3 +1488,94 @@ class TestWindsurfRulesIntegration:
         rules_dir = self.project_root / ".windsurf" / "rules"
         assert (rules_dir / "python.md").exists()
         assert (rules_dir / "testing.md").exists()
+
+    def test_collision_overwrites_existing_rule_file(self):
+        """Rule dirs are APM-owned: an existing .md is overwritten, not skipped.
+
+        Matches the cursor/claude invariant for the third output_compare format.
+        """
+        from apm_cli.integration.targets import KNOWN_TARGETS
+
+        (self.project_root / ".windsurf").mkdir()
+        rules_dir = self.project_root / ".windsurf" / "rules"
+        rules_dir.mkdir()
+        (rules_dir / "python.md").write_text("# Stale rules")
+
+        pkg = self.project_root / "package"
+        inst_dir = pkg / ".apm" / "instructions"
+        inst_dir.mkdir(parents=True)
+        (inst_dir / "python.instructions.md").write_text("# APM rules")
+
+        pkg_info = _make_package_info(pkg)
+        windsurf = KNOWN_TARGETS["windsurf"]
+        result = self.integrator.integrate_instructions_for_target(
+            windsurf, pkg_info, self.project_root, managed_files=set()
+        )
+
+        assert result.files_integrated == 1
+        assert result.files_skipped == 0
+        deployed = (rules_dir / "python.md").read_text()
+        assert "# APM rules" in deployed
+        assert "Stale rules" not in deployed
+
+    def test_managed_files_has_no_effect_on_rule_dir(self):
+        """managed_files is not consulted for output_compare (rule-dir) targets."""
+        from apm_cli.integration.targets import KNOWN_TARGETS
+
+        (self.project_root / ".windsurf").mkdir()
+        rules_dir = self.project_root / ".windsurf" / "rules"
+        rules_dir.mkdir()
+        (rules_dir / "python.md").write_text("# Stale rules")
+
+        pkg = self.project_root / "package"
+        inst_dir = pkg / ".apm" / "instructions"
+        inst_dir.mkdir(parents=True)
+        (inst_dir / "python.instructions.md").write_text("# APM rules")
+
+        pkg_info = _make_package_info(pkg)
+        windsurf = KNOWN_TARGETS["windsurf"]
+        result = self.integrator.integrate_instructions_for_target(
+            windsurf, pkg_info, self.project_root, managed_files=None
+        )
+
+        assert result.files_integrated == 1
+        assert result.files_skipped == 0
+        assert "# APM rules" in (rules_dir / "python.md").read_text()
+
+    def test_force_rewrites_byte_identical_rule(self):
+        """force=True rewrites even a byte-identical rule (no silent adopt).
+
+        The no-churn adopt path is gated on ``not force`` so ``--force`` always
+        rewrites and counts the file as integrated, not adopted.
+        """
+        from apm_cli.integration.targets import KNOWN_TARGETS
+
+        (self.project_root / ".windsurf").mkdir()
+
+        pkg = self.project_root / "package"
+        inst_dir = pkg / ".apm" / "instructions"
+        inst_dir.mkdir(parents=True)
+        (inst_dir / "python.instructions.md").write_text("# Python")
+
+        pkg_info = _make_package_info(pkg)
+        windsurf = KNOWN_TARGETS["windsurf"]
+
+        # First deploy creates the file.
+        first = self.integrator.integrate_instructions_for_target(
+            windsurf, pkg_info, self.project_root
+        )
+        assert first.files_integrated == 1
+
+        # Re-deploy without force adopts (byte-identical, no churn).
+        adopt = self.integrator.integrate_instructions_for_target(
+            windsurf, pkg_info, self.project_root
+        )
+        assert adopt.files_integrated == 0
+        assert adopt.files_adopted == 1
+
+        # Re-deploy WITH force rewrites instead of adopting.
+        forced = self.integrator.integrate_instructions_for_target(
+            windsurf, pkg_info, self.project_root, force=True
+        )
+        assert forced.files_integrated == 1
+        assert forced.files_adopted == 0

--- a/tests/unit/integration/test_instruction_integrator.py
+++ b/tests/unit/integration/test_instruction_integrator.py
@@ -1583,3 +1583,60 @@ class TestWindsurfRulesIntegration:
         )
         assert forced.files_integrated == 1
         assert forced.files_adopted == 0
+
+    def test_verbose_breadcrumb_rewrite_vs_adopt(self):
+        """adopt-vs-rewrite breadcrumbs are emitted only under verbose diagnostics.
+
+        When diagnostics.verbose is True:
+        - a rewrite emits a '[*] rewritten:' line
+        - a subsequent adopt emits a '[=] adopted-unchanged:' line
+        When diagnostics.verbose is False, neither line is emitted.
+        """
+        from unittest.mock import patch
+
+        from apm_cli.integration.targets import KNOWN_TARGETS
+        from apm_cli.utils.diagnostics import DiagnosticCollector
+
+        (self.project_root / ".windsurf").mkdir()
+
+        pkg = self.project_root / "package"
+        inst_dir = pkg / ".apm" / "instructions"
+        inst_dir.mkdir(parents=True)
+        (inst_dir / "python.instructions.md").write_text("# Python")
+
+        pkg_info = _make_package_info(pkg)
+        windsurf = KNOWN_TARGETS["windsurf"]
+
+        diag_verbose = DiagnosticCollector(verbose=True)
+        captured: list[str] = []
+
+        def _fake_echo(msg, **_kw):
+            captured.append(msg)
+
+        # First deploy (rewrite): verbose breadcrumb must appear.
+        with patch("apm_cli.integration.instruction_integrator._rich_echo", side_effect=_fake_echo):
+            result = self.integrator.integrate_instructions_for_target(
+                windsurf, pkg_info, self.project_root, diagnostics=diag_verbose
+            )
+        assert result.files_integrated == 1
+        assert any("[*] rewritten:" in m for m in captured), f"no rewrite breadcrumb in {captured}"
+
+        # Second deploy (adopt, byte-identical): verbose breadcrumb must appear.
+        captured.clear()
+        with patch("apm_cli.integration.instruction_integrator._rich_echo", side_effect=_fake_echo):
+            adopt = self.integrator.integrate_instructions_for_target(
+                windsurf, pkg_info, self.project_root, diagnostics=diag_verbose
+            )
+        assert adopt.files_adopted == 1
+        assert any("[=] adopted-unchanged:" in m for m in captured), (
+            f"no adopt breadcrumb in {captured}"
+        )
+
+        # Non-verbose diagnostics: no breadcrumb lines at all.
+        captured.clear()
+        diag_quiet = DiagnosticCollector(verbose=False)
+        with patch("apm_cli.integration.instruction_integrator._rich_echo", side_effect=_fake_echo):
+            self.integrator.integrate_instructions_for_target(
+                windsurf, pkg_info, self.project_root, diagnostics=diag_quiet
+            )
+        assert not captured, f"unexpected output under quiet diagnostics: {captured}"

--- a/tests/unit/integration/test_targets.py
+++ b/tests/unit/integration/test_targets.py
@@ -4,7 +4,42 @@ import shutil
 import tempfile
 from pathlib import Path
 
-from apm_cli.integration.targets import KNOWN_TARGETS, active_targets
+import pytest
+
+from apm_cli.integration.targets import (
+    KNOWN_TARGETS,
+    RULE_FORMATS,
+    PrimitiveMapping,
+    active_targets,
+)
+
+
+class TestPrimitiveMappingValidation:
+    """output_compare must stay in lockstep with RULE_FORMATS (apm#1662)."""
+
+    @pytest.mark.parametrize("fmt", sorted(RULE_FORMATS))
+    def test_rule_format_without_output_compare_raises(self, fmt):
+        with pytest.raises(ValueError, match="output_compare=True"):
+            PrimitiveMapping("rules", ".md", fmt)
+
+    @pytest.mark.parametrize("fmt", sorted(RULE_FORMATS))
+    def test_rule_format_with_output_compare_ok(self, fmt):
+        m = PrimitiveMapping("rules", ".md", fmt, output_compare=True)
+        assert m.output_compare is True
+
+    def test_output_compare_on_non_rule_format_raises(self):
+        with pytest.raises(ValueError, match="not a known rule format"):
+            PrimitiveMapping("instructions", ".md", "copilot", output_compare=True)
+
+    def test_non_rule_format_default_ok(self):
+        m = PrimitiveMapping("agents", ".md", "claude_agent")
+        assert m.output_compare is False
+
+    def test_known_rule_targets_set_output_compare(self):
+        for name in ("claude", "cursor", "windsurf"):
+            mapping = KNOWN_TARGETS[name].primitives["instructions"]
+            assert mapping.format_id in RULE_FORMATS
+            assert mapping.output_compare is True
 
 
 class TestActiveTargets:


### PR DESCRIPTION
Closes #1662

## Root cause

Format-transforming instruction targets — `.claude/rules`, `.cursor/rules`, `.windsurf/rules` — convert each source `*.instructions.md` into a tool-specific rule file (e.g. `applyTo:` → `globs:`/`paths:`/`trigger:`). The deployed file is therefore **never byte-identical to its source**.

`integrate_instructions_for_target()` decided adopt-vs-skip by comparing the existing deployed file against the **source** bytes. For these rule dirs that comparison always missed, so an already-deployed APM rule was treated as a *user-authored collision* and **skipped**:

- it was never (re)written, so edits to the source instruction never reached the deployed rule;
- it was never recorded in `local_deployed_files`, so it **fell out of `managed_files`** on the next run — making the problem self-perpetuating.

`apm compile` masked the bug because it reads the live source when generating `AGENTS.md`/`CLAUDE.md`, so the stale per-file rule went unnoticed.

## The fix

These rule dirs are **APM-owned per-file**: the target name derives 1:1 from a source instruction, so any existing file at that path is APM's, not user-authored. So:

- compare against the **transformed output**, not the source — adopt when up-to-date (no churn), otherwise (re)write;
- **always record** the path so it stays managed on the next run;
- `managed_files` is not consulted for these targets (the file is APM's by construction).

To kill the dual-maintenance trap that *is* the #1662 root-cause class, the format-transforming set `{cursor_rules, claude_rules, windsurf_rules}` — previously hardcoded in 3+ places — now has **one home**: a `PrimitiveMapping.output_compare` boolean set where the formats are defined (`targets.py`). The rename gate, the output-comparison branch, and the install-log `rule(s)` label in `services.py` all derive from it. Adding a future rule format is now a single edit. (The `services.py` label copy had also silently omitted `windsurf_rules` — a latent label bug — now fixed by deriving from the flag.)

The gate is renamed `needs_rename` → `apm_owned_rule_dir` to name what it actually controls (output-comparison + collision-guard bypass, not the incidental filename rename). `force=True` now rewrites even a byte-identical rule (the no-churn adopt is gated on `not force`). `_render_instruction()` (approved in review) is kept; the `copy_instruction_*` writers still delegate to it with behavior unchanged.

## Tests

- Rewrote the cursor/claude collision tests to assert the **new** invariant — an existing rule is overwritten/adopted, **not** skipped.
- Added the missing **windsurf** equivalent.
- Added `managed_files`-has-no-effect tests for all three rule formats (documents the new behavior + guards the regression where the file fell out of `managed_files`).
- Added a force-rewrites-byte-identical test (covers the `not force` adopt gate).
- Updated the `services.py` orchestration label tests to drive `output_compare`.

Full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
