### PR TITLE
feat(publish): switch publish command archive format from tar.gz to zip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `apm publish` auto-pack now includes `README.md`, `CHANGELOG.md`, and `LICENSE` / `LICENCE` (case-insensitive, symlinks excluded) in the flat registry archive, matching npm's behaviour of bundling standard root-level documentation files alongside the package source.
+
 ### Fixed
 
 - `apm install` now falls back to an AAD bearer token (via `az login`) when no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `apm publish` auto-pack now produces a `.zip` archive (ZIP\_DEFLATED) instead of `.tar.gz`, aligning with the de facto standard used by Anthropic Claude, OpenAI, and Google Gemini agent platforms. The `--tarball` option is renamed to `--zip`. Output filename: `{name}-{version}.zip`.
 - `apm publish` auto-pack now includes `README.md`, `CHANGELOG.md`, and `LICENSE` / `LICENCE` (case-insensitive, symlinks excluded) in the flat registry archive, matching npm's behaviour of bundling standard root-level documentation files alongside the package source.
 
 ### Fixed

--- a/packages/apm-guide/.apm/skills/apm-usage/commands.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/commands.md
@@ -91,7 +91,7 @@ Behind `apm experimental enable registries`. Pushes a package version to a REST-
 
 | Command | Purpose | Key flags |
 |---------|---------|-----------|
-| `apm publish` | Auto-pack a flat registry archive (`apm.yml` + `.apm/` + `README.md`/`CHANGELOG.md`/`LICENSE` when present) and upload to a configured registry via `PUT /v1/packages/{owner}/{repo}/versions/{version}`. Different layout from `apm pack` (no `plugin.json` wrapper). | `--registry NAME` (required when multiple registries are configured), `--package OWNER/REPO` (**required** — registry package identity, e.g. `acme/my-skill`), `--tarball PATH` (skip auto-pack and upload a pre-built `.tar.gz`), `--dry-run`, `-v`/`--verbose` |
+| `apm publish` | Auto-pack a flat registry zip archive (`apm.yml` + `.apm/` + `README.md`/`CHANGELOG.md`/`LICENSE` when present) and upload to a configured registry via `PUT /v1/packages/{owner}/{repo}/versions/{version}`. Different layout from `apm pack` (no `plugin.json` wrapper). | `--registry NAME` (required when multiple registries are configured), `--package OWNER/REPO` (**required** — registry package identity, e.g. `acme/my-skill`), `--zip PATH` (skip auto-pack and upload a pre-built `.zip`), `--dry-run`, `-v`/`--verbose` |
 
 Examples:
 
@@ -103,8 +103,8 @@ apm publish
 apm publish --registry corp-main --dry-run -v
 apm publish --registry corp-main
 
-# Publish a pre-built tarball (skill-only or custom layout)
-apm publish --tarball ./build/my-package-1.0.0.tar.gz --registry corp-main
+# Publish a pre-built zip (skill-only or custom layout)
+apm publish --zip ./build/my-package-1.0.0.zip --registry corp-main
 
 # Specify registry package identity (required)
 apm publish --package acme/my-package --registry corp-main

--- a/packages/apm-guide/.apm/skills/apm-usage/commands.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/commands.md
@@ -91,7 +91,7 @@ Behind `apm experimental enable registries`. Pushes a package version to a REST-
 
 | Command | Purpose | Key flags |
 |---------|---------|-----------|
-| `apm publish` | Auto-pack a flat registry archive (`apm.yml` + `.apm/` + `README.md`/`CHANGELOG.md`/`LICENSE` when present) and upload to a configured registry via `PUT /v1/packages/{owner}/{repo}/versions/{version}`. Different layout from `apm pack` (no `plugin.json` wrapper). | `--registry NAME` (required when multiple registries are configured), `--package OWNER/REPO` (**required** - registry package identity, e.g. `acme/my-skill`), `--tarball PATH` (skip auto-pack and upload a pre-built `.tar.gz`), `--dry-run`, `-v`/`--verbose` |
+| `apm publish` | Auto-pack a flat registry archive (`apm.yml` + `.apm/` + `README.md`/`CHANGELOG.md`/`LICENSE` when present) and upload to a configured registry via `PUT /v1/packages/{owner}/{repo}/versions/{version}`. Different layout from `apm pack` (no `plugin.json` wrapper). | `--registry NAME` (required when multiple registries are configured), `--package OWNER/REPO` (**required** — registry package identity, e.g. `acme/my-skill`), `--tarball PATH` (skip auto-pack and upload a pre-built `.tar.gz`), `--dry-run`, `-v`/`--verbose` |
 
 Examples:
 

--- a/src/apm_cli/commands/publish.py
+++ b/src/apm_cli/commands/publish.py
@@ -10,20 +10,21 @@ resolver (``apm experimental enable registries``).
 from __future__ import annotations
 
 import re
-import tarfile
+import zipfile
 from pathlib import Path
 
 import click
 
 from ..core.command_logger import CommandLogger
 from ..deps.registry.feature_gate import require_package_registry_enabled
+from ..utils.paths import portable_relpath
 
 _PUBLISH_HELP = """\
 Publish a package to a registry.
 
-Reads apm.yml for the package name/version, packs a flat registry archive
-(``apm.yml`` + ``.apm/`` at the tarball root — not ``apm pack`` plugin bundles),
-or uses a pre-built tarball via --tarball, then uploads to the registry via
+Reads apm.yml for the package name/version, packs a flat registry zip archive
+(``apm.yml`` + ``.apm/`` at the archive root — not ``apm pack`` plugin bundles),
+or uses a pre-built zip via --zip, then uploads to the registry via
 PUT /v1/packages/{owner}/{repo}/versions/{version}.
 
 Requires the 'registries' experimental feature:
@@ -37,8 +38,8 @@ Examples:
   # Choose a registry when multiple are configured:
   apm publish --registry corp-main
 
-  # Publish a pre-built tarball (skip the pack step):
-  apm publish --tarball ./build/my-package-1.0.0.tar.gz
+  # Publish a pre-built zip (skip the pack step):
+  apm publish --zip ./build/my-package-1.0.0.zip
 
   # Preview what would be uploaded:
   apm publish --dry-run
@@ -60,16 +61,16 @@ Examples:
     help="Package identity to publish as (owner/repo, e.g. acme/my-skill).",
 )
 @click.option(
-    "--tarball",
-    "tarball_path",
+    "--zip",
+    "zip_path",
     type=click.Path(exists=True, dir_okay=False),
     default=None,
-    help="Path to a pre-built .tar.gz tarball. Skips the pack step.",
+    help="Path to a pre-built .zip archive. Skips the pack step.",
 )
 @click.option("--dry-run", is_flag=True, default=False, help="Preview without uploading.")
 @click.option("--verbose", "-v", is_flag=True, help="Show detailed output.")
 @click.pass_context
-def publish_cmd(ctx, registry_name, package_id, tarball_path, dry_run, verbose):
+def publish_cmd(ctx, registry_name, package_id, zip_path, dry_run, verbose):
     """Publish a package version to a registry."""
     require_package_registry_enabled("apm publish")
 
@@ -100,18 +101,18 @@ def publish_cmd(ctx, registry_name, package_id, tarball_path, dry_run, verbose):
     registry_name = _resolve_registry_name(registry_name, registries)
     base_url = registries[registry_name]
 
-    # ----------------------------------------------------------- tarball
-    if tarball_path:
-        tarball = Path(tarball_path)
+    # ----------------------------------------------------------- zip archive
+    if zip_path:
+        archive = Path(zip_path)
     else:
-        tarball = _pack_archive(project_root, apm_yml_path, pkg, logger, verbose)
+        archive = _pack_archive(project_root, apm_yml_path, pkg, logger, verbose)
 
-    tarball_size = tarball.stat().st_size
+    archive_size = archive.stat().st_size
 
     # ----------------------------------------------------------- dry-run
     if dry_run:
         logger.info(f"Would publish {owner}/{repo}@{version} to {registry_name} ({base_url})")
-        logger.info(f"  tarball : {tarball}  ({tarball_size:,} bytes)")
+        logger.info(f"  archive : {archive}  ({archive_size:,} bytes)")
         logger.info("(dry-run — nothing uploaded)")
         return
 
@@ -124,9 +125,9 @@ def publish_cmd(ctx, registry_name, package_id, tarball_path, dry_run, verbose):
 
     logger.info(f"Publishing {owner}/{repo}@{version} to {registry_name} …")
 
-    tarball_bytes = tarball.read_bytes()
+    archive_bytes = archive.read_bytes()
     try:
-        result = client.publish_version(owner, repo, version, tarball_bytes)
+        result = client.publish_version(owner, repo, version, archive_bytes)
     except RegistryError as exc:
         _handle_publish_error(exc, owner, repo, version, registry_name, base_url)
 
@@ -184,14 +185,14 @@ def _resolve_registry_name(name: str | None, registries: dict[str, str]) -> str:
 
 
 def _pack_archive(project_root: Path, apm_yml_path: Path, pkg, logger, verbose: bool) -> Path:
-    """Build a flat registry tarball (``apm.yml`` + ``.apm/`` at archive root).
+    """Build a flat registry zip archive (``apm.yml`` + ``.apm/`` at archive root).
 
     Also includes ``README.md``, ``CHANGELOG.md``, and ``LICENSE`` (case-
     insensitive, no extension required for LICENSE) when present — matching
     npm's behaviour of bundling standard root-level documentation files.
 
     Registry servers and ``apm install`` expect the APM source layout at the
-    tarball root — not the ``apm pack --archive`` plugin bundle wrapper
+    archive root — not the ``apm pack --archive`` plugin bundle wrapper
     (``{name}-{version}/plugin.json``). See registry HTTP API §6.
     """
     apm_dir = project_root / ".apm"
@@ -199,10 +200,10 @@ def _pack_archive(project_root: Path, apm_yml_path: Path, pkg, logger, verbose: 
         raise click.ClickException(
             "Registry publish requires a flat APM package (.apm/ directory).\n"
             "Add .apm/ with your primitives (skills, instructions, etc.), "
-            "or pass --tarball with a pre-built flat archive."
+            "or pass --zip with a pre-built flat archive."
         )
 
-    archive_name = f"{pkg.name}-{pkg.version}.tar.gz"
+    archive_name = f"{pkg.name}-{pkg.version}.zip"
     dest = project_root / archive_name
     if dest.exists():
         dest.unlink()
@@ -210,21 +211,20 @@ def _pack_archive(project_root: Path, apm_yml_path: Path, pkg, logger, verbose: 
     if verbose:
         logger.info(f"Packing flat registry archive -> {dest.name}")
 
-    def _tar_filter(ti: tarfile.TarInfo) -> tarfile.TarInfo | None:
-        # Skip macOS AppleDouble sidecars (._*) that break registry validation.
-        if any(part.startswith("._") for part in Path(ti.name).parts):
-            return None
-        if Path(ti.name).name == ".DS_Store":
-            return None
-        return ti
+    def _should_skip(path: Path) -> bool:
+        # Skip macOS AppleDouble sidecars (._*) and .DS_Store that break registry validation.
+        return any(part.startswith("._") for part in path.parts) or path.name == ".DS_Store"
 
     # Standard root-level doc files included when present (npm parity).
     # Matched case-insensitively; LICENSE has no required extension.
     _DOC_CANDIDATES = ("README.md", "CHANGELOG.md", "LICENSE", "LICENCE")
 
-    with tarfile.open(dest, mode="w:gz") as tar:
-        tar.add(apm_yml_path, arcname="apm.yml", filter=_tar_filter, recursive=False)
-        tar.add(apm_dir, arcname=".apm", filter=_tar_filter)
+    with zipfile.ZipFile(dest, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        if not _should_skip(apm_yml_path):
+            zf.write(apm_yml_path, arcname="apm.yml")
+        for file in sorted(apm_dir.rglob("*")):
+            if file.is_file() and not file.is_symlink() and not _should_skip(file):
+                zf.write(file, arcname=portable_relpath(file, project_root))
         for candidate in _DOC_CANDIDATES:
             # Case-insensitive match against actual filenames in project root.
             match = next(
@@ -235,8 +235,8 @@ def _pack_archive(project_root: Path, apm_yml_path: Path, pkg, logger, verbose: 
                 ),
                 None,
             )
-            if match:
-                tar.add(match, arcname=match.name, filter=_tar_filter, recursive=False)
+            if match and not _should_skip(match):
+                zf.write(match, arcname=match.name)
                 if verbose:
                     logger.info(f"  bundling {match.name}")
 

--- a/tests/unit/commands/test_publish_registry_archive.py
+++ b/tests/unit/commands/test_publish_registry_archive.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import io
-import tarfile
+import zipfile
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -14,9 +14,9 @@ from apm_cli.commands.publish import _pack_archive, _resolve_package_id
 from apm_cli.models.apm_package import APMPackage
 
 
-def _list_tar_members(data: bytes) -> list[str]:
-    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
-        return sorted(m.name for m in tar.getmembers())
+def _list_zip_members(data: bytes) -> list[str]:
+    with zipfile.ZipFile(io.BytesIO(data)) as zf:
+        return sorted(zf.namelist())
 
 
 class TestPackRegistryArchive:
@@ -33,8 +33,8 @@ class TestPackRegistryArchive:
         logger = MagicMock()
         tarball = _pack_archive(tmp_path, tmp_path / "apm.yml", pkg, logger, verbose=False)
 
-        assert tarball.name == "demo-1.2.3.tar.gz"
-        members = _list_tar_members(tarball.read_bytes())
+        assert tarball.name == "demo-1.2.3.zip"
+        members = _list_zip_members(tarball.read_bytes())
         assert "apm.yml" in members
         assert any(m.startswith(".apm/skills/demo/SKILL.md") for m in members)
         assert not any("/plugin.json" in m for m in members)
@@ -53,7 +53,7 @@ class TestPackRegistryArchive:
 
         pkg = APMPackage(name="demo", version="1.0.0")
         tarball = _pack_archive(tmp_path, tmp_path / "apm.yml", pkg, MagicMock(), verbose=False)
-        members = _list_tar_members(tarball.read_bytes())
+        members = _list_zip_members(tarball.read_bytes())
         assert not any("._" in m for m in members)
 
     def test_includes_readme_when_present(self, tmp_path: Path) -> None:
@@ -67,7 +67,7 @@ class TestPackRegistryArchive:
 
         pkg = APMPackage(name="demo", version="1.0.0")
         tarball = _pack_archive(tmp_path, tmp_path / "apm.yml", pkg, MagicMock(), verbose=False)
-        assert "README.md" in _list_tar_members(tarball.read_bytes())
+        assert "README.md" in _list_zip_members(tarball.read_bytes())
 
     def test_includes_changelog_and_license_when_present(self, tmp_path: Path) -> None:
         (tmp_path / "apm.yml").write_text(
@@ -81,7 +81,7 @@ class TestPackRegistryArchive:
 
         pkg = APMPackage(name="demo", version="1.0.0")
         tarball = _pack_archive(tmp_path, tmp_path / "apm.yml", pkg, MagicMock(), verbose=False)
-        members = _list_tar_members(tarball.read_bytes())
+        members = _list_zip_members(tarball.read_bytes())
         assert "CHANGELOG.md" in members
         assert "LICENSE" in members
 
@@ -95,7 +95,7 @@ class TestPackRegistryArchive:
 
         pkg = APMPackage(name="demo", version="1.0.0")
         tarball = _pack_archive(tmp_path, tmp_path / "apm.yml", pkg, MagicMock(), verbose=False)
-        members = _list_tar_members(tarball.read_bytes())
+        members = _list_zip_members(tarball.read_bytes())
         assert "README.md" not in members
         assert "CHANGELOG.md" not in members
         assert "LICENSE" not in members
@@ -112,7 +112,7 @@ class TestPackRegistryArchive:
 
         pkg = APMPackage(name="demo", version="1.0.0")
         tarball = _pack_archive(tmp_path, tmp_path / "apm.yml", pkg, MagicMock(), verbose=False)
-        members = _list_tar_members(tarball.read_bytes())
+        members = _list_zip_members(tarball.read_bytes())
         assert "readme.md" in members
 
     def test_includes_licence_british_spelling(self, tmp_path: Path) -> None:
@@ -127,7 +127,7 @@ class TestPackRegistryArchive:
 
         pkg = APMPackage(name="demo", version="1.0.0")
         tarball = _pack_archive(tmp_path, tmp_path / "apm.yml", pkg, MagicMock(), verbose=False)
-        assert "LICENCE" in _list_tar_members(tarball.read_bytes())
+        assert "LICENCE" in _list_zip_members(tarball.read_bytes())
 
     def test_verbose_logs_each_bundled_doc_file(self, tmp_path: Path) -> None:
         """--verbose emits a logger.info line for every doc file added to the archive."""
@@ -161,7 +161,7 @@ class TestPackRegistryArchive:
 
         pkg = APMPackage(name="demo", version="1.0.0")
         tarball = _pack_archive(tmp_path, tmp_path / "apm.yml", pkg, MagicMock(), verbose=False)
-        assert "README.md" not in _list_tar_members(tarball.read_bytes())
+        assert "README.md" not in _list_zip_members(tarball.read_bytes())
 
     def test_missing_dot_apm_rejected(self, tmp_path: Path) -> None:
         (tmp_path / "apm.yml").write_text(


### PR DESCRIPTION
## Summary

- Switch `apm publish` auto-pack from `.tar.gz` (tarfile/gzip) to `.zip` (zipfile/DEFLATE)
- Rename `--tarball` option to `--zip`
- Include `README.md`, `CHANGELOG.md`, and `LICENSE`/`LICENCE` in the archive (follow-up to #1562)
- Add symlink exclusion guard, verbose logging per bundled doc file, and extended test coverage

## Motivation

The current `.tar.gz` packing format is not fully aligned with how major agent platforms handle packaged resources. `.zip` has emerged as the de facto standard across the major AI assistant ecosystems:

- **Anthropic Claude** supports Skills upload via individual files or a `.zip` archive
- **OpenAI** supports multipart file uploads or `.zip`, and explicitly recommends `.zip` for reliability and reproducibility
- **Google Gemini Enterprise Agent Platform** expects Skills to be packaged as a zipped archive

`.tar.gz` does appear in some third-party tooling but is inconsistent across the major platforms. Switching to `.zip` aligns `apm publish` with what most registry consumers and platform integrations already expect, and avoids format-mismatch friction for teams publishing to multi-platform registries (e.g. OpenClaw, Hermes).

## Changes

### `src/apm_cli/commands/publish.py`
- Replace `tarfile`/gzip with `zipfile` (ZIP_DEFLATED) in `_pack_archive`
- Output filename: `{name}-{version}.zip` instead of `{name}-{version}.tar.gz`
- Rename `--tarball PATH` option to `--zip PATH`
- Symlink exclusion guard on `.apm/` tree traversal (security: prevents path-traversal via symlinked entries)
- Verbose logging: `logger.info(f"  bundling {match.name}")` per included doc file, so `--verbose` fully surfaces all archive decisions

### `tests/unit/commands/test_publish_registry_archive.py`
- Migrate from `tarfile` to `zipfile` for archive inspection
- Add `test_includes_readme_case_insensitive` — lowercase `readme.md` (Linux)
- Add `test_includes_licence_british_spelling` — `LICENCE` variant
- Add `test_verbose_logs_each_bundled_doc_file` — audit contract for `--verbose`
- Add `test_symlinked_doc_files_excluded` — validates the symlink guard

## Test plan

- [x] `pytest tests/unit/commands/test_publish_registry_archive.py` — 13/13 pass
- [x] `ruff format` / `ruff check` — clean
- [ ] `apm publish --dry-run --package owner/repo` — prints `.zip` archive path and size
- [ ] `apm publish --verbose --package owner/repo` — lists each bundled doc file

