### PR TITLE
fix(deps): scope shorthand-alias guard to exclude @ in #ref fragment (closes #1696)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm install` now accepts marketplace git-subdir refs with package-version
+  tags such as `package@v1.0.1` inside the `#ref` fragment while still
+  rejecting retired string-form `@alias` shorthand. (closes #1696, #1698)
 - `apm install` now keeps format-transformed rule files (`.claude/rules`,
   `.cursor/rules`, `.windsurf/rules`) tracked in `managed_files` and rewrites
   them when the source instruction changes, instead of mis-classifying them as

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -511,9 +511,10 @@ class DependencyReference:
         retired the ``@`` separator to avoid the npm/go/cargo ``@version``
         collision). The dedicated SSH parsers handle ``@`` in ``ssh://`` URLs
         and SCP shorthand (``<user>@host:path``) as userinfo, not aliases; this
-        guard fires for the remaining cases like
-        ``owner/repo[/sub]@alias[#ref]``, which would otherwise silently leak
-        the alias into ``virtual_path`` or ``reference``.
+        guard only inspects the pre-fragment shorthand portion, so refs like
+        ``owner/repo#package@v1.0.1`` stay valid while cases like
+        ``owner/repo[/sub]@alias[#ref]`` are rejected before the alias can leak
+        into ``virtual_path`` or ``reference``.
         """
         stripped = dependency_str.strip()
         shorthand_part = stripped.partition("#")[0]

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -512,11 +512,12 @@ class DependencyReference:
         collision). The dedicated SSH parsers handle ``@`` in ``ssh://`` URLs
         and SCP shorthand (``<user>@host:path``) as userinfo, not aliases; this
         guard fires for the remaining cases like
-        ``owner/repo[/sub][#ref]@alias``, which would otherwise silently leak
+        ``owner/repo[/sub]@alias[#ref]``, which would otherwise silently leak
         the alias into ``virtual_path`` or ``reference``.
         """
         stripped = dependency_str.strip()
-        if "@" not in stripped:
+        shorthand_part = stripped.partition("#")[0]
+        if "@" not in shorthand_part:
             return
         if stripped.lower().startswith(("https://", "http://", "ssh://")):
             return

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -46,6 +46,7 @@ _DEFAULT_SCHEME_PORTS: dict[str, int] = {"https": 443, "http": 80, "ssh": 22}
 # list-form ``argv`` so there is no shell-expansion vector.
 _ADO_PATH_SEGMENT_RE = r"^[a-zA-Z0-9._\- ]+$"
 _NON_ADO_PATH_SEGMENT_RE = r"^[a-zA-Z0-9._~-]+$"
+_REF_VERSION_SUFFIX_RE = re.compile(r"^v?\d+(?:\.\d+)*(?:[-+][A-Za-z0-9][A-Za-z0-9._-]*)?$")
 
 
 def _path_segment_pattern(is_ado_host: bool) -> str:
@@ -511,19 +512,22 @@ class DependencyReference:
         retired the ``@`` separator to avoid the npm/go/cargo ``@version``
         collision). The dedicated SSH parsers handle ``@`` in ``ssh://`` URLs
         and SCP shorthand (``<user>@host:path``) as userinfo, not aliases; this
-        guard only inspects the pre-fragment shorthand portion, so refs like
-        ``owner/repo#package@v1.0.1`` stay valid while cases like
-        ``owner/repo[/sub]@alias[#ref]`` are rejected before the alias can leak
-        into ``virtual_path`` or ``reference``.
+        guard rejects ``@`` in the pre-fragment shorthand portion and keeps the
+        retired ``#ref@alias`` shape rejected, while version-style tag suffixes
+        such as ``owner/repo#package@v1.0.1`` remain valid literal refs.
         """
         stripped = dependency_str.strip()
-        shorthand_part = stripped.partition("#")[0]
-        if "@" not in shorthand_part:
+        if "@" not in stripped:
             return
         if stripped.lower().startswith(("https://", "http://", "ssh://")):
             return
         if SCP_LIKE_RE.match(stripped):
             return
+        shorthand_part, _, ref_part = stripped.partition("#")
+        if "@" not in shorthand_part:
+            _, _, ref_suffix = ref_part.rpartition("@")
+            if _REF_VERSION_SUFFIX_RE.fullmatch(ref_suffix):
+                return
         preview = "".join(ch if 32 <= ord(ch) <= 126 else "?" for ch in stripped)
         if len(preview) > 160:
             preview = f"{preview[:157]}..."

--- a/tests/unit/models/test_dependency_reference_semver_routing.py
+++ b/tests/unit/models/test_dependency_reference_semver_routing.py
@@ -103,3 +103,7 @@ class TestLiteralTagRegressionTrap:
     def test_shorthand_alias_before_ref_fragment_is_still_rejected(self) -> None:
         with pytest.raises(ValueError, match="Shorthand '@alias' is not supported"):
             DependencyReference.parse("owner/repo@alias")
+
+    def test_subpath_shorthand_alias_before_ref_fragment_is_still_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Shorthand '@alias' is not supported"):
+            DependencyReference.parse("owner/repo/subpath@alias#main")

--- a/tests/unit/models/test_dependency_reference_semver_routing.py
+++ b/tests/unit/models/test_dependency_reference_semver_routing.py
@@ -8,6 +8,8 @@ existing literal-routing behaviour.
 
 from __future__ import annotations
 
+import pytest
+
 from apm_cli.models.dependency.reference import DependencyReference
 
 
@@ -89,3 +91,15 @@ class TestLiteralTagRegressionTrap:
         dep = DependencyReference.parse("acme/some-skills#1.2.3")
         assert dep.reference == "1.2.3"
         assert dep.ref_kind == "semver"
+
+    def test_subpath_tag_with_at_v_separator_parses_as_literal_ref(self) -> None:
+        dep = DependencyReference.parse("owner/repo/packages/somepackage#somepackage@v1.0.1")
+
+        assert dep.repo_url == "owner/repo"
+        assert dep.virtual_path == "packages/somepackage"
+        assert dep.reference == "somepackage@v1.0.1"
+        assert dep.ref_kind == "literal"
+
+    def test_shorthand_alias_before_ref_fragment_is_still_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Shorthand '@alias' is not supported"):
+            DependencyReference.parse("owner/repo@alias")


### PR DESCRIPTION
Marketplace git-subdir installs can canonicalize per-package tags into refs like owner/repo/packages/somepackage#somepackage@v1.0.1, but the shorthand-alias guard treated any at sign as owner/repo@alias. This scopes that guard to the portion before the #ref fragment, preserving rejection of owner/repo@alias while allowing at signs inside literal git tags. How-to-test: uv run --extra dev pytest -q tests/unit/models/test_dependency_reference_semver_routing.py tests/unit/test_reference_registry_shorthand.py tests/unit/marketplace/test_marketplace_resolver.py tests/unit/marketplace/test_resolver_local_git.py tests/unit/deps/test_apm_resolver_edge_cases.py tests/unit/deps/test_apm_resolver_phase3.py; uv run --extra dev ruff check src/ tests/ --quiet; uv run --extra dev ruff format --check src/ tests/ --quiet. closes #1696