### PR TITLE
fix(mcp): preserve scoped server names when materializing harness configs (closes #1693)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm install` now preserves scoped MCP package config keys such as
+  `@playwright/mcp` across Claude, Codex, and Copilot harness configs instead
+  of truncating them to `mcp`. (#1699)
 - `apm install` now keeps format-transformed rule files (`.claude/rules`,
   `.cursor/rules`, `.windsurf/rules`) tracked in `managed_files` and rewrites
   them when the source instruction changes, instead of mis-classifying them as

--- a/src/apm_cli/adapters/client/base.py
+++ b/src/apm_cli/adapters/client/base.py
@@ -637,8 +637,9 @@ class MCPClientAdapter(ABC):
         """Return the configuration key to use for *server_url*/*server_name*.
 
         The caller-supplied *server_name* takes precedence. If it is absent,
-        preserve npm-style scoped names such as ``@scope/name`` while keeping
-        the historical ``owner/repo -> repo`` fallback for registry paths.
+        preserve npm-style scoped names such as ``@scope/name`` (one slash by
+        npm convention) while keeping the historical ``owner/repo -> repo``
+        fallback for registry paths.
 
         Args:
             server_url: Registry reference used as fallback source.

--- a/src/apm_cli/adapters/client/base.py
+++ b/src/apm_cli/adapters/client/base.py
@@ -633,22 +633,24 @@ class MCPClientAdapter(ABC):
         return server_info
 
     @staticmethod
-    def _determine_config_key(server_url: str, server_name: str) -> str:
+    def _determine_config_key(server_url: str, server_name: str | None) -> str:
         """Return the configuration key to use for *server_url*/*server_name*.
 
-        The caller-supplied *server_name* takes precedence; if empty the last
-        path segment of *server_url* is used as a fallback, which mirrors the
-        convention ``owner/repo -> repo``.
+        The caller-supplied *server_name* takes precedence. If it is absent,
+        preserve npm-style scoped names such as ``@scope/name`` while keeping
+        the historical ``owner/repo -> repo`` fallback for registry paths.
 
         Args:
             server_url: Registry reference used as fallback source.
-            server_name: Explicit caller-supplied name (may be empty string).
+            server_name: Explicit caller-supplied name, if any.
 
         Returns:
             Non-empty configuration key string.
         """
         if server_name:
             return server_name
+        if server_url.startswith("@") and server_url.count("/") == 1:
+            return server_url
         if "/" in server_url:
             return server_url.split("/")[-1]
         return server_url

--- a/src/apm_cli/adapters/client/claude.py
+++ b/src/apm_cli/adapters/client/claude.py
@@ -239,12 +239,7 @@ class ClaudeClientAdapter(CopilotClientAdapter):
                 _rich_error(f"MCP server '{server_url}' not found in registry")
                 return False
 
-            if server_name:
-                config_key = server_name
-            elif "/" in server_url:
-                config_key = server_url.split("/")[-1]
-            else:
-                config_key = server_url
+            config_key = self._determine_config_key(server_url, server_name)
 
             server_config = self._format_server_config(server_info, env_overrides, runtime_vars)
             ok = self.update_config({config_key: server_config})

--- a/src/apm_cli/adapters/client/codex.py
+++ b/src/apm_cli/adapters/client/codex.py
@@ -150,19 +150,7 @@ class CodexClientAdapter(MCPClientAdapter):
             if server_info is None:
                 return False
 
-            # Determine the server name for configuration key
-            if server_name:
-                # Use explicitly provided server name
-                config_key = server_name
-            else:  # noqa: PLR5501
-                # Extract name from server_url (part after last slash)
-                # For URLs like "microsoft/azure-devops-mcp" -> "azure-devops-mcp"
-                # For URLs like "github/github-mcp-server" -> "github-mcp-server"
-                if "/" in server_url:  # noqa: SIM108
-                    config_key = server_url.split("/")[-1]
-                else:
-                    # Fallback to full server_url if no slash
-                    config_key = server_url
+            config_key = self._determine_config_key(server_url, server_name)
 
             # Generate server configuration with environment variable resolution
             server_config = self._format_server_config(server_info, env_overrides, runtime_vars)

--- a/src/apm_cli/adapters/client/copilot.py
+++ b/src/apm_cli/adapters/client/copilot.py
@@ -206,19 +206,7 @@ class CopilotClientAdapter(MCPClientAdapter):
             # Generate server configuration with environment and runtime variable resolution
             server_config = self._format_server_config(server_info, env_overrides, runtime_vars)
 
-            # Determine the server name for configuration key
-            if server_name:
-                # Use explicitly provided server name
-                config_key = server_name
-            else:  # noqa: PLR5501
-                # Extract name from server_url (part after last slash)
-                # For URLs like "microsoft/azure-devops-mcp" -> "azure-devops-mcp"
-                # For URLs like "github/github-mcp-server" -> "github-mcp-server"
-                if "/" in server_url:  # noqa: SIM108
-                    config_key = server_url.split("/")[-1]
-                else:
-                    # Fallback to full server_url if no slash
-                    config_key = server_url
+            config_key = self._determine_config_key(server_url, server_name)
 
             # Update configuration using the chosen key
             self.update_config({config_key: server_config})

--- a/src/apm_cli/core/safe_installer.py
+++ b/src/apm_cli/core/safe_installer.py
@@ -119,10 +119,10 @@ class SafeMCPInstaller:
                     kwargs["server_info_cache"] = server_info_cache
                 if runtime_vars is not None:
                     kwargs["runtime_vars"] = runtime_vars
+                if server_ref.startswith("@") and server_ref.count("/") == 1:
+                    kwargs["server_name"] = server_ref
 
-                result = self.adapter.configure_mcp_server(
-                    server_ref, server_name=server_ref, **kwargs
-                )
+                result = self.adapter.configure_mcp_server(server_ref, **kwargs)
 
                 if result:
                     summary.add_installed(server_ref)

--- a/src/apm_cli/core/safe_installer.py
+++ b/src/apm_cli/core/safe_installer.py
@@ -120,7 +120,9 @@ class SafeMCPInstaller:
                 if runtime_vars is not None:
                     kwargs["runtime_vars"] = runtime_vars
 
-                result = self.adapter.configure_mcp_server(server_ref, **kwargs)
+                result = self.adapter.configure_mcp_server(
+                    server_ref, server_name=server_ref, **kwargs
+                )
 
                 if result:
                     summary.add_installed(server_ref)

--- a/tests/unit/test_docker_args_and_installer.py
+++ b/tests/unit/test_docker_args_and_installer.py
@@ -165,9 +165,7 @@ class TestSafeMCPInstaller(unittest.TestCase):
         self.assertEqual(summary.installed[0], "new-server")
 
         # Verify adapter was called only for new server
-        mock_adapter.configure_mcp_server.assert_called_once_with(
-            "new-server", server_name="new-server"
-        )
+        mock_adapter.configure_mcp_server.assert_called_once_with("new-server")
 
     @patch("apm_cli.core.safe_installer.ClientFactory")
     @patch("apm_cli.core.safe_installer.MCPConflictDetector")

--- a/tests/unit/test_docker_args_and_installer.py
+++ b/tests/unit/test_docker_args_and_installer.py
@@ -165,7 +165,9 @@ class TestSafeMCPInstaller(unittest.TestCase):
         self.assertEqual(summary.installed[0], "new-server")
 
         # Verify adapter was called only for new server
-        mock_adapter.configure_mcp_server.assert_called_once_with("new-server")
+        mock_adapter.configure_mcp_server.assert_called_once_with(
+            "new-server", server_name="new-server"
+        )
 
     @patch("apm_cli.core.safe_installer.ClientFactory")
     @patch("apm_cli.core.safe_installer.MCPConflictDetector")

--- a/tests/unit/test_safe_installer.py
+++ b/tests/unit/test_safe_installer.py
@@ -40,9 +40,7 @@ class TestSafeMCPInstaller(unittest.TestCase):
         self.assertEqual(summary.installed[0], "github")
 
         # Verify adapter was called
-        self.mock_adapter.configure_mcp_server.assert_called_once_with(
-            "github", server_name="github"
-        )
+        self.mock_adapter.configure_mcp_server.assert_called_once_with("github")
 
     def test_skip_existing_server(self):
         """Test skipping server that already exists."""
@@ -104,7 +102,7 @@ class TestSafeMCPInstaller(unittest.TestCase):
         def mock_configure(server_ref, **kwargs):
             if server_ref == "failing-server":
                 raise Exception("Configuration failed")
-            return server_ref == "new-server" and kwargs == {"server_name": server_ref}
+            return server_ref == "new-server" and not kwargs
 
         self.mock_conflict_detector.check_server_exists.side_effect = mock_check_exists
         self.mock_adapter.configure_mcp_server.side_effect = mock_configure

--- a/tests/unit/test_safe_installer.py
+++ b/tests/unit/test_safe_installer.py
@@ -40,7 +40,9 @@ class TestSafeMCPInstaller(unittest.TestCase):
         self.assertEqual(summary.installed[0], "github")
 
         # Verify adapter was called
-        self.mock_adapter.configure_mcp_server.assert_called_once_with("github")
+        self.mock_adapter.configure_mcp_server.assert_called_once_with(
+            "github", server_name="github"
+        )
 
     def test_skip_existing_server(self):
         """Test skipping server that already exists."""
@@ -99,10 +101,10 @@ class TestSafeMCPInstaller(unittest.TestCase):
         def mock_check_exists(server_ref):
             return server_ref == "existing-server"
 
-        def mock_configure(server_ref):
+        def mock_configure(server_ref, **kwargs):
             if server_ref == "failing-server":
                 raise Exception("Configuration failed")
-            return server_ref == "new-server"
+            return server_ref == "new-server" and kwargs == {"server_name": server_ref}
 
         self.mock_conflict_detector.check_server_exists.side_effect = mock_check_exists
         self.mock_adapter.configure_mcp_server.side_effect = mock_configure

--- a/tests/unit/test_scoped_mcp_server_names.py
+++ b/tests/unit/test_scoped_mcp_server_names.py
@@ -53,8 +53,8 @@ def test_two_scoped_server_names_do_not_collide(adapter_cls, raw_stdio_servers):
     assert captured_keys == ["@playwright/mcp", "@other/mcp"]
 
 
-def test_safe_installer_passes_declared_server_name_to_adapter():
-    """Installer must preserve the apm.yml dependency name as server_name."""
+def test_safe_installer_passes_scoped_server_name_to_adapter():
+    """Installer must preserve scoped dependency names as server_name."""
     mock_adapter = Mock()
     mock_adapter.configure_mcp_server.return_value = True
     mock_conflict_detector = Mock()
@@ -74,3 +74,24 @@ def test_safe_installer_passes_declared_server_name_to_adapter():
     mock_adapter.configure_mcp_server.assert_called_once_with(
         "@playwright/mcp", server_name="@playwright/mcp"
     )
+
+
+def test_safe_installer_keeps_owner_repo_fallback_available():
+    """Installer must not override owner/repo basename fallback keys."""
+    mock_adapter = Mock()
+    mock_adapter.configure_mcp_server.return_value = True
+    mock_conflict_detector = Mock()
+    mock_conflict_detector.check_server_exists.return_value = False
+
+    with (
+        patch("apm_cli.core.safe_installer.ClientFactory.create_client") as mock_factory,
+        patch("apm_cli.core.safe_installer.MCPConflictDetector") as mock_detector_class,
+    ):
+        mock_factory.return_value = mock_adapter
+        mock_detector_class.return_value = mock_conflict_detector
+        installer = SafeMCPInstaller("copilot")
+
+    summary = installer.install_servers(["microsoft/azure-devops-mcp"])
+
+    assert summary.installed == ["microsoft/azure-devops-mcp"]
+    mock_adapter.configure_mcp_server.assert_called_once_with("microsoft/azure-devops-mcp")

--- a/tests/unit/test_scoped_mcp_server_names.py
+++ b/tests/unit/test_scoped_mcp_server_names.py
@@ -1,0 +1,76 @@
+"""Regression tests for scoped MCP server config keys."""
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+from apm_cli.adapters.client.claude import ClaudeClientAdapter
+from apm_cli.adapters.client.codex import CodexClientAdapter
+from apm_cli.adapters.client.copilot import CopilotClientAdapter
+from apm_cli.core.safe_installer import SafeMCPInstaller
+
+
+@pytest.fixture
+def raw_stdio_servers() -> dict[str, dict]:
+    """Return self-defined stdio server fixtures keyed by declared name."""
+    return {
+        "@playwright/mcp": {"_raw_stdio": {"command": "npx", "args": ["-y", "@playwright/mcp"]}},
+        "@other/mcp": {"_raw_stdio": {"command": "npx", "args": ["-y", "@other/mcp"]}},
+    }
+
+
+@pytest.mark.parametrize(
+    "adapter_cls",
+    [ClaudeClientAdapter, CodexClientAdapter, CopilotClientAdapter],
+)
+def test_scoped_server_name_is_preserved_as_config_key(adapter_cls, raw_stdio_servers):
+    """Adapters must not truncate npm scoped package names to the basename."""
+    captured_keys = []
+    adapter = adapter_cls(project_root=Path.cwd(), user_scope=True)
+    adapter.update_config = lambda updates: captured_keys.extend(updates.keys()) or True
+
+    result = adapter.configure_mcp_server("@playwright/mcp", server_info_cache=raw_stdio_servers)
+
+    assert result is True
+    assert captured_keys == ["@playwright/mcp"]
+
+
+@pytest.mark.parametrize(
+    "adapter_cls",
+    [ClaudeClientAdapter, CodexClientAdapter, CopilotClientAdapter],
+)
+def test_two_scoped_server_names_do_not_collide(adapter_cls, raw_stdio_servers):
+    """Distinct scoped packages with the same basename must keep distinct keys."""
+    captured_keys = []
+    adapter = adapter_cls(project_root=Path.cwd(), user_scope=True)
+    adapter.update_config = lambda updates: captured_keys.extend(updates.keys()) or True
+
+    for server_ref in raw_stdio_servers:
+        result = adapter.configure_mcp_server(server_ref, server_info_cache=raw_stdio_servers)
+        assert result is True
+
+    assert captured_keys == ["@playwright/mcp", "@other/mcp"]
+
+
+def test_safe_installer_passes_declared_server_name_to_adapter():
+    """Installer must preserve the apm.yml dependency name as server_name."""
+    mock_adapter = Mock()
+    mock_adapter.configure_mcp_server.return_value = True
+    mock_conflict_detector = Mock()
+    mock_conflict_detector.check_server_exists.return_value = False
+
+    with (
+        patch("apm_cli.core.safe_installer.ClientFactory.create_client") as mock_factory,
+        patch("apm_cli.core.safe_installer.MCPConflictDetector") as mock_detector_class,
+    ):
+        mock_factory.return_value = mock_adapter
+        mock_detector_class.return_value = mock_conflict_detector
+        installer = SafeMCPInstaller("copilot")
+
+    summary = installer.install_servers(["@playwright/mcp"])
+
+    assert summary.installed == ["@playwright/mcp"]
+    mock_adapter.configure_mcp_server.assert_called_once_with(
+        "@playwright/mcp", server_name="@playwright/mcp"
+    )


### PR DESCRIPTION
Scoped MCP dependency names such as @playwright/mcp were falling back to the last slash-delimited segment, causing harness configs to use mcp and collide across scopes. This PR threads the declared dependency name through SafeMCPInstaller and centralizes adapter fallback key selection so npm-style scoped names are preserved while registry owner/repo references still use the basename. How-to-test: uv run --extra dev pytest -q tests/unit/test_scoped_mcp_server_names.py tests/unit/test_safe_installer.py tests/unit/test_docker_args_and_installer.py tests/unit/test_deps.py; uv run --extra dev pytest -q tests/unit/test_copilot_adapter_phase3.py tests/unit/test_copilot_adapter.py tests/unit/test_copilot_runtime.py tests/unit/test_codex_adapter_compatibility.py tests/unit/test_codex_adapter_phase3.py tests/unit/test_claude_mcp.py tests/unit/test_codex_runtime.py tests/unit/test_copilot_adapter_compatibility.py tests/unit/test_scoped_mcp_server_names.py tests/unit/test_safe_installer.py tests/unit/test_docker_args_and_installer.py tests/unit/test_deps.py; uv run --extra dev ruff check src/ tests/; uv run --extra dev ruff format --check src/ tests/; uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/. Closes #1693.