### PR TITLE
feat: surface installed hook actions during apm install (closes #316)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `apm publish` auto-pack now produces a `.zip` archive (ZIP\_DEFLATED) instead of `.tar.gz`, aligning with the de facto standard used by Anthropic Claude, OpenAI, and Google Gemini agent platforms. The `--tarball` option is renamed to `--zip`. Output filename: `{name}-{version}.zip`.
 - `apm publish` auto-pack now includes `README.md`, `CHANGELOG.md`, and `LICENSE` / `LICENCE` (case-insensitive, symlinks excluded) in the flat registry archive, matching npm's behaviour of bundling standard root-level documentation files alongside the package source.
+- `apm install` now surfaces per-event hook action summaries as it integrates
+  hook primitives, with the fully rewritten hook JSON shown under `--verbose`,
+  so you can audit exactly what each hook runs at install time. The summary is
+  built from the post-rewrite data actually written to disk and executed -- it
+  faithfully reflects on-disk content across Copilot, Claude, and Gemini
+  targets (including OS-specific `windows`/`linux`/`osx` hook keys). (by
+  @harshitlarl, closes #316)
 
 ### Fixed
 

--- a/src/apm_cli/install/services.py
+++ b/src/apm_cli/install/services.py
@@ -115,6 +115,32 @@ def _deployed_path_entry(
         )
 
 
+def _log_hook_display_payloads(
+    payloads: list,
+    verbose: bool,
+    log_fn: Any,
+    logger: Any,
+) -> None:
+    """Emit per-hook-file action summaries for the hook transparency feature.
+
+    Uses post-path-rewrite data from display_payloads, so the output
+    faithfully reflects what was written to disk and will be executed.
+    """
+    for _payload in payloads:
+        _src = _payload.get("source_hook_file", "hook file")
+        _actions = _payload.get("actions", [])
+        if _actions:
+            for _act in _actions:
+                log_fn(f"  |   {_act['event']}: {_act['summary']} ({_src})")
+        else:
+            log_fn(f"  |   Hook file integrated: {_src}")
+        if verbose and logger is not None:
+            _out_path = _payload.get("output_path", "")
+            logger.verbose_detail(f"  |   Hook JSON ({_src} -> {_out_path}):")
+            for _jline in _payload.get("rendered_json", "").splitlines():
+                logger.verbose_detail(f"  |     {_jline}")
+
+
 def integrate_package_primitives(
     package_info: Any,
     project_root: Path,
@@ -344,9 +370,9 @@ def integrate_package_primitives(
                 if _target.hooks_config_display:
                     _deploy_dir = _target.hooks_config_display
                 _label = "hook(s)"
-                _payloads = getattr(_int_result, "display_payloads", None)
-                if isinstance(_payloads, list):
-                    _agg_hook_payloads.extend(_payloads)
+                _agg_hook_payloads.extend(
+                    p for p in getattr(_int_result, "display_payloads", []) or []
+                )
             else:
                 _label = _prim_name
             _agg_paths.append(_deploy_dir)
@@ -391,19 +417,12 @@ def integrate_package_primitives(
             _hook_verbose = _verbose or (
                 bool(getattr(logger, "verbose", False)) if logger is not None else False
             )
-            for _payload in _info.get("hook_payloads", []):
-                _src = _payload.get("source_hook_file", "hook file")
-                _actions = _payload.get("actions", [])
-                if _actions:
-                    for _act in _actions:
-                        _log_integration(f"  |   {_act['event']}: {_act['summary']} ({_src})")
-                else:
-                    _log_integration(f"  |   Hook file integrated: {_src}")
-                if _hook_verbose and logger is not None:
-                    _out_path = _payload.get("output_path", "")
-                    logger.verbose_detail(f"  |   Hook JSON ({_src} -> {_out_path}):")
-                    for _jline in _payload.get("rendered_json", "").splitlines():
-                        logger.verbose_detail(f"  |     {_jline}")
+            _log_hook_display_payloads(
+                _info.get("hook_payloads", []),
+                _hook_verbose,
+                _log_integration,
+                logger,
+            )
         # Emit a one-line "next step" hint when copilot-app workflows
         # were integrated: the row lands enabled=0 and the user has to
         # flip the toggle in the Copilot App's Workflows tab before the

--- a/src/apm_cli/install/services.py
+++ b/src/apm_cli/install/services.py
@@ -277,6 +277,7 @@ def integrate_package_primitives(
         _agg_files = 0
         _agg_adopted = 0
         _agg_paths: list[str] = []
+        _agg_hook_payloads: list = []
         _label = _prim_name
         for _target in targets:
             _mapping = _target.primitives.get(_prim_name)
@@ -343,6 +344,9 @@ def integrate_package_primitives(
                 if _target.hooks_config_display:
                     _deploy_dir = _target.hooks_config_display
                 _label = "hook(s)"
+                _payloads = getattr(_int_result, "display_payloads", None)
+                if isinstance(_payloads, list):
+                    _agg_hook_payloads.extend(_payloads)
             else:
                 _label = _prim_name
             _agg_paths.append(_deploy_dir)
@@ -353,6 +357,7 @@ def integrate_package_primitives(
                 "adopted": _agg_adopted,
                 "label": _label,
                 "paths": _agg_paths,
+                "hook_payloads": _agg_hook_payloads,
             }
 
     # Emit aggregated per-kind lines in dispatch order so output is stable.
@@ -379,6 +384,30 @@ def integrate_package_primitives(
                 _log_integration(line)
         else:
             _log_integration(f"  |-- {_verb_phrase} -> {_suffix}")
+        # Emit per-hook-file action summaries for the hooks primitive.
+        # display_payloads reflects post-path-rewrite data (what is
+        # actually written to disk and executed), so this is faithful.
+        if _prim_name == "hooks" and _info["files"] > 0:
+            _hook_verbose = _verbose or (
+                bool(getattr(logger, "verbose", False)) if logger is not None else False
+            )
+            for _payload in _info.get("hook_payloads", []):
+                _src = _payload.get("source_hook_file", "hook file")
+                _actions = _payload.get("actions", [])
+                if _actions:
+                    for _act in _actions:
+                        _log_integration(
+                            f"  |   {_act['event']}: {_act['summary']} ({_src})"
+                        )
+                else:
+                    _log_integration(f"  |   Hook file integrated: {_src}")
+                if _hook_verbose and logger is not None:
+                    _out_path = _payload.get("output_path", "")
+                    logger.verbose_detail(
+                        f"  |   Hook JSON ({_src} -> {_out_path}):"
+                    )
+                    for _jline in _payload.get("rendered_json", "").splitlines():
+                        logger.verbose_detail(f"  |     {_jline}")
         # Emit a one-line "next step" hint when copilot-app workflows
         # were integrated: the row lands enabled=0 and the user has to
         # flip the toggle in the Copilot App's Workflows tab before the

--- a/src/apm_cli/install/services.py
+++ b/src/apm_cli/install/services.py
@@ -131,7 +131,7 @@ def _log_hook_display_payloads(
         _actions = _payload.get("actions", [])
         if _actions:
             for _act in _actions:
-                log_fn(f"  |   {_act['event']}: {_act['summary']} ({_src})")
+                log_fn(f"  |   {_act.get('event', '?')}: {_act.get('summary', '?')} ({_src})")
         else:
             log_fn(f"  |   Hook file integrated: {_src}")
         if verbose and logger is not None:

--- a/src/apm_cli/install/services.py
+++ b/src/apm_cli/install/services.py
@@ -396,16 +396,12 @@ def integrate_package_primitives(
                 _actions = _payload.get("actions", [])
                 if _actions:
                     for _act in _actions:
-                        _log_integration(
-                            f"  |   {_act['event']}: {_act['summary']} ({_src})"
-                        )
+                        _log_integration(f"  |   {_act['event']}: {_act['summary']} ({_src})")
                 else:
                     _log_integration(f"  |   Hook file integrated: {_src}")
                 if _hook_verbose and logger is not None:
                     _out_path = _payload.get("output_path", "")
-                    logger.verbose_detail(
-                        f"  |   Hook JSON ({_src} -> {_out_path}):"
-                    )
+                    logger.verbose_detail(f"  |   Hook JSON ({_src} -> {_out_path}):")
                     for _jline in _payload.get("rendered_json", "").splitlines():
                         logger.verbose_detail(f"  |     {_jline}")
         # Emit a one-line "next step" hint when copilot-app workflows

--- a/src/apm_cli/integration/base_integrator.py
+++ b/src/apm_cli/integration/base_integrator.py
@@ -3,7 +3,7 @@
 import errno
 import os
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from apm_cli.compilation.link_resolver import UnifiedLinkResolver
@@ -44,6 +44,12 @@ class IntegrationResult:
     # ``files_integrated`` so the install summary can surface the work
     # done in adopt-only runs instead of looking like a no-op.
     files_adopted: int = 0
+
+    # Hook transparency: per-file display metadata populated by HookIntegrator.
+    # Each entry is a dict with keys: target_label, output_path, source_hook_file,
+    # actions (list of {event, summary}), rendered_json.
+    # Faithfully reflects post-path-rewrite data actually written to disk.
+    display_payloads: list = field(default_factory=list)
 
 
 def _read_bytes_no_follow(path: Path) -> bytes:

--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -403,7 +403,7 @@ class HookIntegrator(BaseIntegrator):
             for matcher in matchers:
                 if not isinstance(matcher, dict):
                     continue
-                for key in ("command", "bash", "powershell"):
+                for key in HookIntegrator.HOOK_COMMAND_KEYS:
                     value = matcher.get(key)
                     if isinstance(value, str):
                         entries.append((event_name, {key: value}))
@@ -413,7 +413,7 @@ class HookIntegrator(BaseIntegrator):
                 for hook in nested_hooks:
                     if not isinstance(hook, dict):
                         continue
-                    for key in ("command", "bash", "powershell"):
+                    for key in HookIntegrator.HOOK_COMMAND_KEYS:
                         value = hook.get(key)
                         if isinstance(value, str):
                             entries.append((event_name, {key: value}))
@@ -423,13 +423,18 @@ class HookIntegrator(BaseIntegrator):
     def _summarize_command(entry: dict) -> str:
         """Return a human-readable summary for a single hook command entry."""
         command = ""
-        for key in ("command", "bash", "powershell"):
+        for key in HookIntegrator.HOOK_COMMAND_KEYS:
             value = entry.get(key)
             if isinstance(value, str) and value.strip():
                 command = value.strip()
                 break
         if not command:
             return "runs hook command"
+        # Collapse any internal whitespace (including embedded newlines) so
+        # the summary is always single-line. A hook command containing a
+        # newline must not break install-log formatting or enable
+        # log-spoofing. Addresses Copilot inline on hook_integrator.py.
+        command = " ".join(command.split())
         for token in command.split():
             cleaned = token.strip("\"'")
             if "/" in cleaned or cleaned.startswith("."):
@@ -1241,6 +1246,11 @@ class HookIntegrator(BaseIntegrator):
         scripts_adopted = 0
         target_paths: list[Path] = []
         display_payloads: list = []
+        # Per-file display metadata is captured during the merge loop but
+        # the payloads are BUILT after the JSON config is finalized (Gemini
+        # transform applied, schema-strict _apm_source stripped) so that
+        # rendered_json reflects the actual on-disk/executed content.
+        pending_display: list = []
         # Events whose prior-owned entries have already been cleared on
         # this install run. Packages can contribute to the same event
         # from multiple hook files -- we must only strip once so earlier
@@ -1311,6 +1321,7 @@ class HookIntegrator(BaseIntegrator):
                 reverse_map.setdefault(norm_name, set()).add(source_name)
 
             entries_appended_for_file = False
+            file_event_entries: dict = {}
             for raw_event_name, entries in hooks.items():
                 if not isinstance(entries, list) or not entries:
                     continue
@@ -1418,15 +1429,24 @@ class HookIntegrator(BaseIntegrator):
                         deduped.append(entry)
                 json_config["hooks"][event_name] = deduped
                 entries_appended_for_file = True
+                # Capture the actual entry objects this file contributed to
+                # the merged config. They are the same dict references that
+                # the schema-strict strip mutates in place below, so building
+                # the display payload from them after finalization yields
+                # rendered_json that matches the on-disk/executed content
+                # (Gemini-transformed, _apm_source stripped where required).
+                file_event_entries.setdefault(event_name, []).extend(
+                    e for e in entries if isinstance(e, dict)
+                )
 
             if entries_appended_for_file:
                 hooks_integrated += 1
-                display_payloads.append(
-                    self._build_display_payload(
+                pending_display.append(
+                    (
                         config.config_filename,
                         config.config_filename,
                         hook_file,
-                        rewritten,
+                        file_event_entries,
                     )
                 )
             else:
@@ -1504,6 +1524,20 @@ class HookIntegrator(BaseIntegrator):
                     _log.warning("Failed to write sidecar %s: %s", sidecar_path, exc)
             elif sidecar_path.exists():
                 sidecar_path.unlink()
+
+        # Build display payloads from the finalized entry objects (post
+        # Gemini transform and post schema-strict _apm_source strip) so the
+        # CLI summary and rendered_json faithfully reflect what is written
+        # to disk and executed -- not the pre-transform per-file data.
+        for _label, _path, _hook_file, _file_event_entries in pending_display:
+            display_payloads.append(
+                self._build_display_payload(
+                    _label,
+                    _path,
+                    _hook_file,
+                    {"hooks": _file_event_entries},
+                )
+            )
 
         # Write the (now schema-clean) config
         with open(json_path, "w", encoding="utf-8") as f:

--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -450,14 +450,18 @@ class HookIntegrator(BaseIntegrator):
         """
         actions = []
         for event_name, entry in self._iter_hook_entries(rewritten):
-            actions.append({
-                "event": event_name,
-                "summary": self._summarize_command(entry),
-            })
+            actions.append(
+                {
+                    "event": event_name,
+                    "summary": self._summarize_command(entry),
+                }
+            )
         return {
             "target_label": target_label,
             "output_path": output_path,
-            "source_hook_file": source_hook_file.name if hasattr(source_hook_file, "name") else str(source_hook_file),
+            "source_hook_file": source_hook_file.name
+            if hasattr(source_hook_file, "name")
+            else str(source_hook_file),
             "actions": actions,
             "rendered_json": json.dumps(rewritten, indent=2, sort_keys=True),
         }

--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -49,6 +49,7 @@ import re
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -388,6 +389,78 @@ class HookIntegrator(BaseIntegrator):
         "linux",
         "osx",
     )
+
+    @staticmethod
+    def _iter_hook_entries(payload: dict) -> list[tuple[str, dict]]:
+        """Flatten hook payloads into (event_name, entry_dict) pairs."""
+        entries: list[tuple[str, dict]] = []
+        hooks = payload.get("hooks", {})
+        if not isinstance(hooks, dict):
+            return entries
+        for event_name, matchers in hooks.items():
+            if not isinstance(matchers, list):
+                continue
+            for matcher in matchers:
+                if not isinstance(matcher, dict):
+                    continue
+                for key in ("command", "bash", "powershell"):
+                    value = matcher.get(key)
+                    if isinstance(value, str):
+                        entries.append((event_name, {key: value}))
+                nested_hooks = matcher.get("hooks", [])
+                if not isinstance(nested_hooks, list):
+                    continue
+                for hook in nested_hooks:
+                    if not isinstance(hook, dict):
+                        continue
+                    for key in ("command", "bash", "powershell"):
+                        value = hook.get(key)
+                        if isinstance(value, str):
+                            entries.append((event_name, {key: value}))
+        return entries
+
+    @staticmethod
+    def _summarize_command(entry: dict) -> str:
+        """Return a human-readable summary for a single hook command entry."""
+        command = ""
+        for key in ("command", "bash", "powershell"):
+            value = entry.get(key)
+            if isinstance(value, str) and value.strip():
+                command = value.strip()
+                break
+        if not command:
+            return "runs hook command"
+        for token in command.split():
+            cleaned = token.strip("\"'")
+            if "/" in cleaned or cleaned.startswith("."):
+                return f"runs {cleaned}"
+        return f"runs {command}"
+
+    def _build_display_payload(
+        self,
+        target_label: str,
+        output_path: str,
+        source_hook_file: Any,
+        rewritten: dict,
+    ) -> dict:
+        """Build CLI display metadata for an integrated hook file.
+
+        Uses post-path-rewrite data (the 'rewritten' dict) so the summary
+        faithfully reflects what is actually written to disk and executed.
+        """
+        actions = []
+        for event_name, entry in self._iter_hook_entries(rewritten):
+            actions.append({
+                "event": event_name,
+                "summary": self._summarize_command(entry),
+            })
+        return {
+            "target_label": target_label,
+            "output_path": output_path,
+            "source_hook_file": source_hook_file.name if hasattr(source_hook_file, "name") else str(source_hook_file),
+            "actions": actions,
+            "rendered_json": json.dumps(rewritten, indent=2, sort_keys=True),
+        }
 
     def find_hook_files(self, package_path: Path) -> list[Path]:
         """Find all hook JSON files in a package.
@@ -1027,6 +1100,7 @@ class HookIntegrator(BaseIntegrator):
         scripts_copied = 0
         scripts_adopted = 0
         target_paths: list[Path] = []
+        display_payloads: list = []
 
         for hook_file in hook_files:
             data = self._parse_hook_json(hook_file)
@@ -1063,6 +1137,14 @@ class HookIntegrator(BaseIntegrator):
 
             hooks_integrated += 1
             target_paths.append(target_path)
+            display_payloads.append(
+                self._build_display_payload(
+                    f"{root_dir}/hooks/",
+                    target_filename,
+                    hook_file,
+                    rewritten,
+                )
+            )
 
             # Copy referenced scripts (individual file tracking)
             for source_file, target_rel in scripts:
@@ -1087,6 +1169,7 @@ class HookIntegrator(BaseIntegrator):
             target_paths=target_paths,
             scripts_copied=scripts_copied,
             files_adopted=scripts_adopted,
+            display_payloads=display_payloads,
         )
 
     # ------------------------------------------------------------------
@@ -1153,6 +1236,7 @@ class HookIntegrator(BaseIntegrator):
         scripts_copied = 0
         scripts_adopted = 0
         target_paths: list[Path] = []
+        display_payloads: list = []
         # Events whose prior-owned entries have already been cleared on
         # this install run. Packages can contribute to the same event
         # from multiple hook files -- we must only strip once so earlier
@@ -1333,6 +1417,14 @@ class HookIntegrator(BaseIntegrator):
 
             if entries_appended_for_file:
                 hooks_integrated += 1
+                display_payloads.append(
+                    self._build_display_payload(
+                        config.config_filename,
+                        config.config_filename,
+                        hook_file,
+                        rewritten,
+                    )
+                )
             else:
                 # Diagnostic for the fail-closed silent-skip path introduced
                 # by the integrated-counter fix (microsoft/apm#1499): a hook
@@ -1421,11 +1513,8 @@ class HookIntegrator(BaseIntegrator):
             target_paths=target_paths,
             scripts_copied=scripts_copied,
             files_adopted=scripts_adopted,
+            display_payloads=display_payloads,
         )
-
-    # ------------------------------------------------------------------
-    # DEPRECATED per-target methods -- delegate to _integrate_merged_hooks
-    # ------------------------------------------------------------------
 
     def integrate_package_hooks_claude(
         self,

--- a/tests/unit/test_install_hook_transparency.py
+++ b/tests/unit/test_install_hook_transparency.py
@@ -220,3 +220,196 @@ def test_iter_hook_entries_matches_what_build_display_payload_shows(tmp_path):
         "actions in display_payload must exactly match _iter_hook_entries on the "
         "rewritten (on-disk) dict"
     )
+
+
+# ---------------------------------------------------------------------------
+# Regression: all six HOOK_COMMAND_KEYS produce transparency output
+# ---------------------------------------------------------------------------
+
+
+def test_iter_hook_entries_includes_os_specific_keys():
+    """windows / linux / osx hook keys must each surface an action, not just
+    command / bash / powershell. Hooks using OS-specific keys deploy
+    correctly, so they must not be invisible in the transparency output."""
+    payload = {
+        "hooks": {
+            "PreToolUse": [
+                {"windows": "scripts/w.ps1", "linux": "scripts/l.sh", "osx": "scripts/m.sh"}
+            ]
+        }
+    }
+    entries = HookIntegrator._iter_hook_entries(payload)
+    keys_seen = {next(iter(entry)) for _event, entry in entries}
+    assert keys_seen == {"windows", "linux", "osx"}, (
+        "OS-specific hook keys must each produce a transparency entry"
+    )
+
+
+def test_summarize_command_handles_os_specific_keys():
+    summary = HookIntegrator._summarize_command({"linux": "bash .github/hooks/run.sh"})
+    assert "run.sh" in summary
+
+
+# ---------------------------------------------------------------------------
+# Regression: command summaries are always single-line (log-spoofing guard)
+# ---------------------------------------------------------------------------
+
+
+def test_summarize_command_collapses_internal_newlines():
+    """A hook command containing a newline must not yield a multi-line
+    summary -- that would break install-log formatting and enable
+    log-spoofing (Copilot inline finding)."""
+    summary = HookIntegrator._summarize_command({"command": "echo ok\nrm -rf safehouse"})
+    assert "\n" not in summary
+    assert "\r" not in summary
+    assert summary == "runs echo ok rm -rf safehouse"
+
+
+def test_summarize_command_collapses_tabs_and_runs():
+    summary = HookIntegrator._summarize_command({"command": "echo\t\thello   world"})
+    assert summary == "runs echo hello world"
+
+
+# ---------------------------------------------------------------------------
+# Regression: Claude rendered_json must not carry _apm_source (not on disk)
+# ---------------------------------------------------------------------------
+
+
+def test_display_payloads_claude_omit_apm_source(tmp_path):
+    """Claude settings.json is schema-strict: _apm_source is stripped before
+    the disk write. rendered_json must therefore NOT contain _apm_source,
+    or it falsely advertises a key the executed config does not have."""
+    package_info, _ = _setup_hook_package(tmp_path)
+    (tmp_path / ".claude").mkdir()
+    integrator = HookIntegrator()
+
+    result = integrator.integrate_package_hooks_claude(
+        package_info,
+        tmp_path,
+        force=False,
+        managed_files=set(),
+        diagnostics=None,
+    )
+
+    assert result.files_integrated >= 1
+    payload = result.display_payloads[0]
+    assert "_apm_source" not in payload["rendered_json"], (
+        "Claude display_payloads must not show _apm_source -- it is stripped "
+        "from the on-disk settings.json"
+    )
+
+    # And the rendered hooks must match the on-disk settings.json entries.
+    on_disk = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+    rendered = json.loads(payload["rendered_json"])
+    for event_name, matchers in rendered.get("hooks", {}).items():
+        for matcher in matchers:
+            assert matcher in on_disk["hooks"][event_name], (
+                "every rendered Claude entry must be present verbatim on disk"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Regression: Gemini rendered_json must reflect the Gemini transform on disk
+# ---------------------------------------------------------------------------
+
+
+def _setup_gemini_hook_package(tmp_path: Path) -> PackageInfo:
+    pkg_dir = tmp_path / "apm_modules" / "anthropics" / "gemini-pkg"
+    hooks_dir = pkg_dir / "hooks"
+    hooks_dir.mkdir(parents=True)
+    hook_data = {
+        "hooks": {
+            "PreToolUse": [{"bash": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/run.sh", "timeoutSec": 5}]
+        }
+    }
+    (hooks_dir / "hooks.json").write_text(json.dumps(hook_data))
+    (hooks_dir / "run.sh").write_text("#!/usr/bin/env bash\necho ok\n")
+    return _make_package_info(pkg_dir, name="gemini-pkg")
+
+
+def test_display_payloads_gemini_reflect_transform(tmp_path):
+    """Gemini disk format renames bash->command and timeoutSec(s)->timeout(ms).
+    rendered_json must show the transformed schema actually written to disk,
+    not the pre-transform Copilot schema."""
+    from apm_cli.integration.hook_integrator import _MERGE_HOOK_TARGETS
+
+    package_info = _setup_gemini_hook_package(tmp_path)
+    (tmp_path / ".gemini").mkdir()
+    integrator = HookIntegrator()
+
+    result = integrator._integrate_merged_hooks(
+        _MERGE_HOOK_TARGETS["gemini"],
+        package_info,
+        tmp_path,
+        force=False,
+        managed_files=set(),
+        diagnostics=None,
+    )
+
+    assert result.files_integrated >= 1
+    payload = result.display_payloads[0]
+    rendered_str = payload["rendered_json"]
+
+    assert '"bash"' not in rendered_str, (
+        "Gemini rendered_json must not show pre-transform 'bash' key"
+    )
+    assert '"timeoutSec"' not in rendered_str
+    assert '"command"' in rendered_str
+
+    # rendered hooks must match the transformed on-disk settings.json.
+    on_disk = json.loads((tmp_path / ".gemini" / "settings.json").read_text())
+    rendered = json.loads(rendered_str)
+    for event_name, matchers in rendered.get("hooks", {}).items():
+        for matcher in matchers:
+            assert matcher in on_disk["hooks"][event_name], (
+                "every rendered Gemini entry must be present verbatim on disk"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Coverage: the user-visible install logger for hook transparency
+# ---------------------------------------------------------------------------
+
+
+def test_log_hook_display_payloads_emits_actions_and_verbose_json():
+    """_log_hook_display_payloads is the headline user-visible function; it
+    must emit one action line per action and, in verbose mode, the rendered
+    JSON block."""
+    from apm_cli.install.services import _log_hook_display_payloads
+
+    emitted: list = []
+
+    class _Logger:
+        def __init__(self):
+            self.details: list = []
+
+        def verbose_detail(self, line):
+            self.details.append(line)
+
+    logger = _Logger()
+    payloads = [
+        {
+            "source_hook_file": "hooks.json",
+            "output_path": ".claude/settings.json",
+            "actions": [{"event": "PreToolUse", "summary": "runs .claude/hooks/x.py"}],
+            "rendered_json": '{\n  "hooks": {}\n}',
+        }
+    ]
+
+    _log_hook_display_payloads(payloads, verbose=True, log_fn=emitted.append, logger=logger)
+
+    joined = "\n".join(emitted)
+    assert "PreToolUse" in joined
+    assert "runs .claude/hooks/x.py" in joined
+    assert "hooks.json" in joined
+    # Verbose mode renders the JSON block line-by-line via the logger.
+    assert any("hooks" in d for d in logger.details)
+
+
+def test_log_hook_display_payloads_no_actions_fallback():
+    from apm_cli.install.services import _log_hook_display_payloads
+
+    emitted: list = []
+    payloads = [{"source_hook_file": "empty.json", "actions": [], "rendered_json": ""}]
+    _log_hook_display_payloads(payloads, verbose=False, log_fn=emitted.append, logger=None)
+    assert any("empty.json" in line for line in emitted)

--- a/tests/unit/test_install_hook_transparency.py
+++ b/tests/unit/test_install_hook_transparency.py
@@ -100,12 +100,12 @@ def test_display_payloads_reflect_rewritten_paths_vscode(tmp_path):
     integrator = HookIntegrator()
 
     result = integrator.integrate_package_hooks(
-        None,  # target (uses default root_dir)
         package_info,
         tmp_path,
         force=False,
         managed_files=set(),
         diagnostics=None,
+        target=None,
     )
 
     assert result.files_integrated == 1
@@ -122,7 +122,7 @@ def test_display_payloads_reflect_rewritten_paths_vscode(tmp_path):
     assert ".github" in action["summary"]
 
     # Verify rendered_json reflects what was written to disk
-    target_file = tmp_path / ".github" / "hooks" / "anthropics-hookify-hooks.json"
+    target_file = tmp_path / ".github" / "hooks" / "hookify-hooks.json"
     assert target_file.exists()
     on_disk = json.loads(target_file.read_text())
     payload_json = json.loads(payload["rendered_json"])
@@ -150,13 +150,13 @@ def test_display_payloads_reflect_rewritten_paths_claude(tmp_path):
     assert len(result.display_payloads) >= 1
 
     payload = result.display_payloads[0]
-    payload_json = json.loads(payload["rendered_json"])
 
     # The rewritten data must not contain the template variable
     rendered_str = payload["rendered_json"]
     assert "${CLAUDE_PLUGIN_ROOT}" not in rendered_str
 
     # The path in the rendered JSON must reference the .claude subtree
+    payload_json = json.loads(rendered_str)
     rendered_commands = [
         v
         for hook_list in payload_json.get("hooks", {}).values()
@@ -180,12 +180,12 @@ def test_display_payloads_empty_when_no_hooks_integrated(tmp_path):
     integrator = HookIntegrator()
 
     result = integrator.integrate_package_hooks(
-        None,
         package_info,
         tmp_path,
         force=False,
         managed_files=set(),
         diagnostics=None,
+        target=None,
     )
 
     assert result.files_integrated == 0
@@ -199,12 +199,12 @@ def test_iter_hook_entries_matches_what_build_display_payload_shows(tmp_path):
     integrator = HookIntegrator()
 
     result = integrator.integrate_package_hooks(
-        None,
         package_info,
         tmp_path,
         force=False,
         managed_files=set(),
         diagnostics=None,
+        target=None,
     )
 
     assert result.files_integrated == 1

--- a/tests/unit/test_install_hook_transparency.py
+++ b/tests/unit/test_install_hook_transparency.py
@@ -8,9 +8,6 @@ pre-rewrite paths would give false assurance.
 
 import json
 from pathlib import Path
-from unittest.mock import MagicMock
-
-import pytest
 
 from apm_cli.integration.hook_integrator import HookIntegrator
 from apm_cli.models.apm_package import APMPackage, PackageInfo
@@ -59,13 +56,7 @@ class TestIterHookEntries:
         assert entries == [("PreToolUse", {"command": "echo hi"})]
 
     def test_nested_hooks(self):
-        payload = {
-            "hooks": {
-                "PostToolUse": [
-                    {"hooks": [{"command": "python3 run.py"}]}
-                ]
-            }
-        }
+        payload = {"hooks": {"PostToolUse": [{"hooks": [{"command": "python3 run.py"}]}]}}
         entries = HookIntegrator._iter_hook_entries(payload)
         assert entries == [("PostToolUse", {"command": "python3 run.py"})]
 
@@ -79,7 +70,9 @@ class TestIterHookEntries:
 
 class TestSummarizeCommand:
     def test_path_token_extracted(self):
-        summary = HookIntegrator._summarize_command({"command": "python3 .github/hooks/scripts/x.py"})
+        summary = HookIntegrator._summarize_command(
+            {"command": "python3 .github/hooks/scripts/x.py"}
+        )
         assert summary == "runs .github/hooks/scripts/x.py"
 
     def test_no_path_falls_back_to_command(self):

--- a/tests/unit/test_install_hook_transparency.py
+++ b/tests/unit/test_install_hook_transparency.py
@@ -1,0 +1,229 @@
+"""Tests for install-time hook transparency (issue #316).
+
+Security contract: display_payloads must faithfully reflect the
+post-path-rewrite hook data that is actually written to disk and
+executed (_rewrite_hooks_data output). A summary that shows
+pre-rewrite paths would give false assurance.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from apm_cli.integration.hook_integrator import HookIntegrator
+from apm_cli.models.apm_package import APMPackage, PackageInfo
+
+
+def _make_package_info(install_path: Path, name: str = "hookify") -> PackageInfo:
+    package = APMPackage(name=name, version="1.0.0")
+    return PackageInfo(package=package, install_path=install_path)
+
+
+def _setup_hook_package(tmp_path: Path) -> tuple[PackageInfo, Path]:
+    """Create a minimal hook package with a pretooluse.py hook."""
+    pkg_dir = tmp_path / "apm_modules" / "anthropics" / "hookify"
+    hooks_dir = pkg_dir / "hooks"
+    hooks_dir.mkdir(parents=True)
+
+    hook_data = {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse.py",
+                            "timeout": 10,
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+    (hooks_dir / "hooks.json").write_text(json.dumps(hook_data))
+    (hooks_dir / "pretooluse.py").write_text("#!/usr/bin/env python3\nprint('ok')\n")
+    return _make_package_info(pkg_dir), pkg_dir
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for HookIntegrator helper methods
+# ---------------------------------------------------------------------------
+
+
+class TestIterHookEntries:
+    def test_flat_command(self):
+        payload = {"hooks": {"PreToolUse": [{"command": "echo hi"}]}}
+        entries = HookIntegrator._iter_hook_entries(payload)
+        assert entries == [("PreToolUse", {"command": "echo hi"})]
+
+    def test_nested_hooks(self):
+        payload = {
+            "hooks": {
+                "PostToolUse": [
+                    {"hooks": [{"command": "python3 run.py"}]}
+                ]
+            }
+        }
+        entries = HookIntegrator._iter_hook_entries(payload)
+        assert entries == [("PostToolUse", {"command": "python3 run.py"})]
+
+    def test_empty_payload(self):
+        assert HookIntegrator._iter_hook_entries({}) == []
+
+    def test_non_dict_hooks_skipped(self):
+        payload = {"hooks": "bad"}
+        assert HookIntegrator._iter_hook_entries(payload) == []
+
+
+class TestSummarizeCommand:
+    def test_path_token_extracted(self):
+        summary = HookIntegrator._summarize_command({"command": "python3 .github/hooks/scripts/x.py"})
+        assert summary == "runs .github/hooks/scripts/x.py"
+
+    def test_no_path_falls_back_to_command(self):
+        summary = HookIntegrator._summarize_command({"command": "echo hello"})
+        assert summary == "runs echo hello"
+
+    def test_empty_entry_returns_default(self):
+        summary = HookIntegrator._summarize_command({})
+        assert summary == "runs hook command"
+
+    def test_bash_key_used(self):
+        summary = HookIntegrator._summarize_command({"bash": "bash /scripts/run.sh"})
+        assert "run.sh" in summary
+
+
+# ---------------------------------------------------------------------------
+# Security contract: display_payloads matches on-disk/executed content
+# ---------------------------------------------------------------------------
+
+
+def test_display_payloads_reflect_rewritten_paths_vscode(tmp_path):
+    """VSCode: display_payloads must use post-rewrite paths (what's on disk),
+    not the original ${CLAUDE_PLUGIN_ROOT} template strings."""
+    package_info, _ = _setup_hook_package(tmp_path)
+    integrator = HookIntegrator()
+
+    result = integrator.integrate_package_hooks(
+        None,  # target (uses default root_dir)
+        package_info,
+        tmp_path,
+        force=False,
+        managed_files=set(),
+        diagnostics=None,
+    )
+
+    assert result.files_integrated == 1
+    assert len(result.display_payloads) == 1
+
+    payload = result.display_payloads[0]
+
+    # Verify actions are present
+    assert len(payload["actions"]) >= 1
+    action = payload["actions"][0]
+    assert action["event"] == "PreToolUse"
+    # Summary must reference the rewritten path, not the template variable
+    assert "${CLAUDE_PLUGIN_ROOT}" not in action["summary"]
+    assert ".github" in action["summary"]
+
+    # Verify rendered_json reflects what was written to disk
+    target_file = tmp_path / ".github" / "hooks" / "anthropics-hookify-hooks.json"
+    assert target_file.exists()
+    on_disk = json.loads(target_file.read_text())
+    payload_json = json.loads(payload["rendered_json"])
+    assert on_disk == payload_json, (
+        "display_payloads rendered_json must match what was written to disk"
+    )
+
+
+def test_display_payloads_reflect_rewritten_paths_claude(tmp_path):
+    """Claude: display_payloads rendered_json must reflect the rewritten data
+    that was merged into .claude/settings.json."""
+    package_info, _ = _setup_hook_package(tmp_path)
+    (tmp_path / ".claude").mkdir()
+    integrator = HookIntegrator()
+
+    result = integrator.integrate_package_hooks_claude(
+        package_info,
+        tmp_path,
+        force=False,
+        managed_files=set(),
+        diagnostics=None,
+    )
+
+    assert result.files_integrated >= 1
+    assert len(result.display_payloads) >= 1
+
+    payload = result.display_payloads[0]
+    payload_json = json.loads(payload["rendered_json"])
+
+    # The rewritten data must not contain the template variable
+    rendered_str = payload["rendered_json"]
+    assert "${CLAUDE_PLUGIN_ROOT}" not in rendered_str
+
+    # The path in the rendered JSON must reference the .claude subtree
+    rendered_commands = [
+        v
+        for hook_list in payload_json.get("hooks", {}).values()
+        for entry in hook_list
+        if isinstance(entry, dict)
+        for inner in entry.get("hooks", [entry])
+        if isinstance(inner, dict)
+        for v in [inner.get("command", "")]
+        if v
+    ]
+    assert any(".claude" in cmd for cmd in rendered_commands), (
+        "Claude display_payloads must show .claude/-rewritten paths, not templates"
+    )
+
+
+def test_display_payloads_empty_when_no_hooks_integrated(tmp_path):
+    """No hooks directory -> no payloads."""
+    pkg_dir = tmp_path / "apm_modules" / "anthropics" / "empty-pkg"
+    pkg_dir.mkdir(parents=True)
+    package_info = _make_package_info(pkg_dir, name="empty-pkg")
+    integrator = HookIntegrator()
+
+    result = integrator.integrate_package_hooks(
+        None,
+        package_info,
+        tmp_path,
+        force=False,
+        managed_files=set(),
+        diagnostics=None,
+    )
+
+    assert result.files_integrated == 0
+    assert result.display_payloads == []
+
+
+def test_iter_hook_entries_matches_what_build_display_payload_shows(tmp_path):
+    """Verify _build_display_payload uses _iter_hook_entries on the rewritten dict,
+    not the original, ensuring summary == executed content."""
+    package_info, _ = _setup_hook_package(tmp_path)
+    integrator = HookIntegrator()
+
+    result = integrator.integrate_package_hooks(
+        None,
+        package_info,
+        tmp_path,
+        force=False,
+        managed_files=set(),
+        diagnostics=None,
+    )
+
+    assert result.files_integrated == 1
+    payload = result.display_payloads[0]
+    rewritten_dict = json.loads(payload["rendered_json"])
+
+    # Re-derive actions from the same rewritten dict
+    expected_actions = [
+        {"event": ev, "summary": HookIntegrator._summarize_command(entry)}
+        for ev, entry in HookIntegrator._iter_hook_entries(rewritten_dict)
+    ]
+    assert payload["actions"] == expected_actions, (
+        "actions in display_payload must exactly match _iter_hook_entries on the "
+        "rewritten (on-disk) dict"
+    )


### PR DESCRIPTION
## Summary

This PR supersedes #409 by @harshitlarl (rebased to resolve conflicts with current main).

**Authorship preserved**: harshitlarl's original commit (8783a217) is in the git history as author.

### What this PR does

- Emit per-event hook action summaries during apm install for integrated hooks
- In verbose mode, print the fully rewritten hook JSON that is deployed/merged
- Rewrite tests to assert display_payloads == on-disk content (security invariant)

### Security contract

_build_display_payload takes the post-path-rewrite 'rewritten' dict so
display_payloads faithfully reflects what is written to disk and executed.

Closes #316
Co-authored-by: harshitlarl <zipdemonharshits012@gmail.com>