### PR TITLE
Add Nadav Yogev (JFrog) to maintainers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,6 +4,7 @@
 
 * Daniel Meppiel (@danielmeppiel) — Microsoft
 * Sergio Sisternes (@sergio-sisternes-epam) — EPAM Systems
+* Nadav Yogev (@nadav-y) — JFrog
 
 Maintainers' work on APM is supported by their employers. Project
 decisions are made in the interest of APM and its users, independent


### PR DESCRIPTION
## What

Adds Nadav Yogev (@nadav-y) from JFrog to the Maintainers list in `AUTHORS`.

## Why

JFrog joins the APM maintainers.