### PR TITLE
fix(install): skip lockfile rewrite when local instructions content is unchanged (closes #1702)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   them when the source instruction changes, instead of mis-classifying them as
   user-authored collisions and skipping them; also fixes a mislabeled
   `windsurf_rules` entry in install output. (by @srid, closes #1662)
+- `apm install` no longer rewrites `apm.lock.yaml` when a project combines a
+  remote APM dependency with unchanged local `.apm/instructions` content.
+  (by @danielmeppiel, closes #1702)
+
 ### Changed
 
 - `MCPDependency.from_dict()` now emits a `[!]` warning naming every unknown

--- a/src/apm_cli/install/phases/lockfile.py
+++ b/src/apm_cli/install/phases/lockfile.py
@@ -115,6 +115,7 @@ class LockfileBuilder:
             # overwriting it -- otherwise the uninstalled packages disappear.
             lockfile = self._maybe_merge_partial(lockfile, lockfile_path, _LF)
             self._preserve_existing_mcp_state(lockfile)
+            self._preserve_existing_local_state(lockfile)
 
             # Only write when the semantic content has actually changed
             # (avoids generated_at churn in version control).
@@ -209,6 +210,23 @@ class LockfileBuilder:
                     "MCP state unchanged -- carrying forward "
                     f"{len(lockfile.mcp_servers)} server(s), "
                     f"{len(lockfile.mcp_configs)} config(s)"
+                )
+
+    def _preserve_existing_local_state(self, lockfile: LockFile) -> None:
+        """Keep local fields until post_deps_local reconciles content hashes."""
+        if self.ctx.existing_lockfile:
+            lockfile.local_deployed_files = list(self.ctx.existing_lockfile.local_deployed_files)
+            lockfile.local_deployed_file_hashes = copy.deepcopy(
+                self.ctx.existing_lockfile.local_deployed_file_hashes
+            )
+            if "." in self.ctx.existing_lockfile.dependencies:
+                lockfile.dependencies["."] = copy.deepcopy(
+                    self.ctx.existing_lockfile.dependencies["."]
+                )
+            if self.ctx.logger:
+                self.ctx.logger.verbose_detail(
+                    "Local .apm state unchanged -- carrying forward "
+                    f"{len(lockfile.local_deployed_files)} file(s)"
                 )
 
     def _write_if_changed(self, lockfile: LockFile, lockfile_path: Path, _LF: type) -> None:

--- a/src/apm_cli/install/phases/lockfile.py
+++ b/src/apm_cli/install/phases/lockfile.py
@@ -225,7 +225,7 @@ class LockfileBuilder:
                 )
             if self.ctx.logger:
                 self.ctx.logger.verbose_detail(
-                    "Local .apm state unchanged -- carrying forward "
+                    "Carrying forward local .apm state pending hash reconciliation: "
                     f"{len(lockfile.local_deployed_files)} file(s)"
                 )
 

--- a/tests/unit/install/test_mcp_lockfile_determinism.py
+++ b/tests/unit/install/test_mcp_lockfile_determinism.py
@@ -6,12 +6,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from apm_cli.core.scope import InstallScope
 from apm_cli.deps.installed_package import InstalledPackage
 from apm_cli.deps.lockfile import LockFile, get_lockfile_path
 from apm_cli.install.context import InstallContext
+from apm_cli.install.phases import post_deps_local
 from apm_cli.install.phases.lockfile import LockfileBuilder
 from apm_cli.integration.mcp_integrator import MCPIntegrator
-from apm_cli.models.apm_package import APMPackage, clear_apm_yml_cache
+from apm_cli.models.apm_package import APMPackage, DependencyReference, clear_apm_yml_cache
 
 
 class _FixedDatetime:
@@ -97,6 +99,75 @@ def _run_lockfile_phase_and_mcp_persist(
             lock_path,
             mcp_configs=MCPIntegrator.get_server_configs(mcp_deps),
         )
+
+
+def _write_local_instruction(project_root: Path) -> list[str]:
+    (project_root / ".apm" / "instructions").mkdir(parents=True, exist_ok=True)
+    (project_root / ".apm" / "instructions" / "local.instructions.md").write_text(
+        "# Local instructions\n",
+        encoding="utf-8",
+    )
+    deployed_file = project_root / ".github" / "instructions" / "local.instructions.md"
+    deployed_file.parent.mkdir(parents=True, exist_ok=True)
+    deployed_file.write_text("# Local instructions\n", encoding="utf-8")
+    return [".github/instructions/local.instructions.md"]
+
+
+def _run_lockfile_phase_and_local_persist(project_root: Path, instant: datetime) -> None:
+    lock_path = get_lockfile_path(project_root)
+    existing_lockfile = LockFile.read(lock_path)
+    local_deployed_files = _write_local_instruction(project_root)
+    dep_ref = DependencyReference(
+        repo_url="AllySummers/apm-generatedat-repro-dep",
+        reference="1111111111111111111111111111111111111111",
+    )
+    ctx = InstallContext(
+        project_root=project_root,
+        apm_dir=project_root,
+        existing_lockfile=existing_lockfile,
+        logger=MagicMock(),
+        diagnostics=MagicMock(error_count=0),
+        scope=InstallScope.PROJECT,
+    )
+    ctx.installed_packages = [
+        InstalledPackage(
+            dep_ref=dep_ref,
+            resolved_commit="a" * 40,
+            depth=1,
+            resolved_by=None,
+        )
+    ]
+    ctx.local_deployed_files = local_deployed_files
+    if existing_lockfile is not None:
+        ctx.old_local_deployed = list(existing_lockfile.local_deployed_files)
+
+    _FixedDatetime.instant = instant
+    with patch("apm_cli.deps.lockfile.datetime", _FixedDatetime):
+        LockfileBuilder(ctx).build_and_save()
+        post_deps_local.run(ctx)
+
+
+def test_unchanged_local_instructions_do_not_rewrite_lockfile(tmp_path: Path) -> None:
+    """The lockfile stays byte-stable when local instruction hashes are unchanged."""
+    first_instant = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    second_instant = datetime(2026, 1, 1, 0, 1, 0, tzinfo=timezone.utc)
+
+    _run_lockfile_phase_and_local_persist(tmp_path, first_instant)
+    lock_path = get_lockfile_path(tmp_path)
+    first_bytes = lock_path.read_bytes()
+    first_lock = LockFile.read(lock_path)
+    assert first_lock is not None
+    assert first_lock.generated_at == first_instant.isoformat()
+    assert first_lock.local_deployed_files == [".github/instructions/local.instructions.md"]
+
+    _run_lockfile_phase_and_local_persist(tmp_path, second_instant)
+    second_bytes = lock_path.read_bytes()
+    second_lock = LockFile.read(lock_path)
+    assert second_lock is not None
+
+    assert second_lock.generated_at == first_lock.generated_at
+    assert second_lock.local_deployed_file_hashes == first_lock.local_deployed_file_hashes
+    assert second_bytes == first_bytes
 
 
 def test_unchanged_mcp_dependencies_do_not_rewrite_lockfile(tmp_path: Path) -> None:


### PR DESCRIPTION
apm install was rewriting apm.lock.yaml on every run for projects with both a remote APM dependency and local .apm/instructions content because the dependency lockfile pass temporarily dropped local_deployed_files before post_deps_local restored them, refreshing generated_at despite unchanged hashes. This carries forward the existing local lockfile state until post_deps_local performs the real hash reconciliation, making this the third instance of the idempotency pattern after #450/#456 and #1532/#1568.\n\nHow-to-test:\n- uv run --extra dev pytest tests/unit/install/test_mcp_lockfile_determinism.py::test_unchanged_local_instructions_do_not_rewrite_lockfile -q\n- uv run --extra dev pytest tests/unit/install/test_mcp_lockfile_determinism.py -q\n- uv run --extra dev pytest tests/unit/test_lockfile_self_entry.py tests/unit/install/test_mcp_lockfile_determinism.py -q\n- uv run --extra dev pytest tests/unit/install -x -q -k "lock or install or idempot or instruction"\n- uv run --extra dev pytest tests/ -x -q -k "lock or install or idempot or instruction"\n- uv run --extra dev ruff check src/ tests/\n- uv run --extra dev ruff format --check src/ tests/\n- uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/\n- bash scripts/lint-auth-signals.sh\n\nCloses #1702