### PR TITLE
Fix Windows CRLF handling in install safety tests

### DIFF
--- a/tests/unit/install/test_install_safety.py
+++ b/tests/unit/install/test_install_safety.py
@@ -34,13 +34,23 @@ SENTINEL_BEGIN = re.compile(r"^# INSTALL_SAFETY_BEGIN", re.MULTILINE)
 SENTINEL_END = re.compile(r"^# INSTALL_SAFETY_END", re.MULTILINE)
 
 
+def _read_install_sh() -> str:
+    """Read install.sh in a shell-safe form across platforms.
+
+    GitHub Actions on Windows can check out files with CRLF line endings. Bash
+    treats stray carriage returns in the sourced function block as syntax
+    errors, so normalize them before extracting or asserting on the script.
+    """
+    return INSTALL_SH.read_text(encoding="utf-8").replace("\r\n", "\n").replace("\r", "\n")
+
+
 def _load_validator():
     """Extract the apm_lib_dir_validate() block from install.sh and return the
     source text of the function plus a small driver wrapper. Tests source the
     result into a fresh shell to invoke the function in isolation -- no network
     and no real installation side effects.
     """
-    text = INSTALL_SH.read_text(encoding="utf-8")
+    text = _read_install_sh()
     match_end = SENTINEL_END.search(text)
     assert match_end is not None, "INSTALL_SAFETY_END sentinel missing in install.sh"
     match_begin = SENTINEL_BEGIN.search(text)
@@ -340,11 +350,11 @@ class TestSentinelInvariants:
     """
 
     def test_begin_sentinel_present(self):
-        text = INSTALL_SH.read_text(encoding="utf-8")
+        text = _read_install_sh()
         assert SENTINEL_BEGIN.search(text) is not None
 
     def test_end_sentinel_present(self):
-        text = INSTALL_SH.read_text(encoding="utf-8")
+        text = _read_install_sh()
         assert SENTINEL_END.search(text) is not None
 
     def test_function_defined_in_extracted_block(self):


### PR DESCRIPTION
Fixes the Windows-only CI failure in install safety tests by normalizing CRLF line endings before extracting the shell validator block.

## What changed
- Added a small reader helper in `tests/unit/install/test_install_safety.py` to normalize `\r\n` and `\r` to `\n` before extracting the shell block.
- Updated the test extraction and sentinel assertions to use that normalized reader.

## Why
GitHub Actions on Windows checks out files with CRLF line endings. The test sources the extracted shell block into `bash`; stray carriage returns caused syntax errors and returned exit code 1 instead of the expected safety-validator exit codes.

## Validation
- `uv run --extra dev python -m pytest tests/unit/install/test_install_safety.py -q`
- `uv run --extra dev ruff check tests/unit/install/test_install_safety.py`
- `uv run --extra dev ruff format --check tests/unit/install/test_install_safety.py`