### PR TITLE
fix(install): cover skill bundles with per-file content-integrity + target-scoped union manifest (closes #1716)

### DIFF
--- a/.agents/skills/apm-review-panel/SKILL.md
+++ b/.agents/skills/apm-review-panel/SKILL.md
@@ -4,16 +4,16 @@ description: >-
   Use this skill to run a multi-persona expert advisory review on a labelled
   pull request in microsoft/apm. The panel fans out to five mandatory
   specialists plus a test-coverage specialist (active on every PR that
-  touches src/) plus two conditional specialists (auth, doc-writer),
-  all running in their own agent threads, and a CEO
+  touches src/) plus three conditional specialists (auth, doc-writer,
+  performance-expert), all running in their own agent threads, and a CEO
   synthesizer. The orchestrator is the sole writer to the PR: ONE
   recommendation comment, no verdict labels, no merge gating. The panel
   is advisory -- it surfaces findings, prioritizes follow-ups, and renders
   a ship-recommendation that the maintainer and author weigh. Activate
   when a non-trivial PR needs a cross-cutting recommendation
   (architecture, CLI logging, DevX UX, supply-chain security,
-  growth/positioning, optionally auth, docs, and test coverage, with CEO
-  arbitration).
+  growth/positioning, optionally auth, docs, perf, and test coverage,
+  with CEO arbitration).
 ---
 
 # APM Review Panel - Fan-Out Advisory Review
@@ -71,6 +71,7 @@ surfaces findings; the maintainer and the PR author decide ship.
 | [Auth Expert](../../agents/auth-expert.agent.md) | Auth / Token Reviewer | Conditional (see below) |
 | [Doc Writer](../../agents/doc-writer.agent.md) | Documentation Reviewer | Conditional (see below) |
 | [Test Coverage Expert](../../agents/test-coverage-expert.agent.md) | Test-Presence Reviewer (paired with DevX UX) | Yes (skipped only on docs-only PRs -- see below) |
+| [Performance Expert](../../agents/performance-expert.agent.md) | Package-Manager Performance Reviewer | Conditional (see below) |
 | [APM CEO](../../agents/apm-ceo.agent.md) | Strategic Arbiter / Synthesizer | Yes |
 
 ## Topology
@@ -113,10 +114,10 @@ surfaces findings; the maintainer and the PR author decide ship.
 
 ## Conditional panelists
 
-Two personas are conditional (auth, doc-writer). A third
-(test-coverage) is mandatory on every PR that touches `src/` and only
-skipped on documentation-only PRs -- see its section below for why.
-The orchestrator ALWAYS spawns ALL three tasks to keep the schema
+Three personas are conditional (auth, doc-writer, performance-expert). A
+fourth (test-coverage) is mandatory on every PR that touches `src/` and
+only skipped on documentation-only PRs -- see its section below for why.
+The orchestrator ALWAYS spawns ALL four tasks to keep the schema
 return shape uniform; the prompt instructs the subagent to set
 `active: false` with an `inactive_reason` if the condition does not
 hold.
@@ -167,6 +168,35 @@ prerequisites), (d) discoverability (cross-links, sidebar order if
 Starlight content). When the doc-writer is active because of code
 changes that SHOULD have updated docs but did not, the persona surfaces
 that gap as a finding.
+
+### Performance Expert
+
+Activate when the PR changes any of:
+- `src/apm_cli/cache/**`
+- `src/apm_cli/deps/**`
+- `src/apm_cli/install/phases/**`
+- `src/apm_cli/install/pipeline.py`
+- `src/apm_cli/install/resolve.py`
+- `scripts/perf/**`
+- `src/apm_cli/core/command_logger.py` (when the diff adds perf-instrumentation logs)
+
+Also activate when the PR description claims a performance win
+(speedup ratio, latency reduction, bytes-on-disk reduction, throughput
+improvement) or attaches a perf-harness measurement table.
+
+Fallback self-check (when no fast-path file matched): "Does this PR
+change the hot path for dependency download, materialization, cache
+layout, transport (git protocol, partial clone, sparse checkout),
+parallelism, or any user-visible install/update wall-time? If unsure,
+answer YES."
+
+When active, the performance-expert reviews against the package-manager
+performance playbook: transport minimization (depth, filter, sparse
+scope), cache layering and dedup keys, parallelism and lock contention,
+working-tree materialization cost, perf-harness methodology (cache
+wipe, warm/cold separation, statistical noise), and pervasive
+application of the chosen technique across install / update / run
+surfaces (not just the one path the PR exercises).
 
 ### Test Coverage Expert
 
@@ -249,6 +279,7 @@ output to the PR before step 6.
    - `auth-expert` (always - active per step 2)
    - `doc-writer` (always - active per step 2)
    - `test-coverage-expert` (always - active per step 2)
+   - `performance-expert` (always - active per step 2)
 
    Each task prompt MUST:
    - Reference its persona file by relative path so the subagent loads

--- a/.agents/skills/apm-review-panel/assets/panelist-return-schema.json
+++ b/.agents/skills/apm-review-panel/assets/panelist-return-schema.json
@@ -18,12 +18,13 @@
         "oss-growth-hacker",
         "auth-expert",
         "doc-writer",
-        "test-coverage-expert"
+        "test-coverage-expert",
+        "performance-expert"
       ]
     },
     "active": {
       "type": "boolean",
-      "description": "Set to false ONLY for conditional personas (auth-expert, doc-writer, test-coverage-expert) when their fast-path file triggers and fallback self-check both miss. All mandatory personas MUST set active=true. When false, findings MUST be empty and inactive_reason MUST be a one-sentence explanation citing the touched files."
+      "description": "Set to false ONLY for conditional personas (auth-expert, doc-writer, test-coverage-expert, performance-expert) when their fast-path file triggers and fallback self-check both miss. All mandatory personas MUST set active=true. When false, findings MUST be empty and inactive_reason MUST be a one-sentence explanation citing the touched files."
     },
     "inactive_reason": {
       "type": "string",

--- a/.agents/skills/apm-spec-guardian/SKILL.md
+++ b/.agents/skills/apm-spec-guardian/SKILL.md
@@ -95,11 +95,11 @@ The maintainer's general `docs-sync` skill covers those.
 
 | Agent | Role | Always active? |
 |-------|------|----------------|
-| [Swagger / OpenAPI Editor](../../agents/spec-swagger-editor.agent.md) | Interface-contract discipline (schemas, $ref hygiene, oneOf discriminators, conformance enumeration) | Yes |
-| [OCI Distribution Editor](../../agents/spec-oci-editor.agent.md) | Registry-HTTP rigor (hash envelopes, mirror tolerance, fail-closed extraction, supply-chain threat model) | Yes |
-| [Package-Manager Registry-Contract Editor](../../agents/spec-pkgmgr-editor.agent.md) | Dependency-resolution rigor (semver dialect pinning, lockfile determinism, transitive conflict policy, reserved-slot defensive MUSTs) | Yes |
-| [W3C TAG Architect](../../agents/spec-tag-architect.agent.md) | Web-platform integration / architecture (extensibility, layering, fingerprinting, machine-readable contract surface) | Yes |
-| [Spec Editor Synthesizer](../../agents/spec-editor-synthesizer.agent.md) | Same hand that drafted; aggregates panel returns, computes shocked_meter_avg, clusters convergent themes, produces fold-now / defer / reject lists and ship_decision | Yes |
+| [Swagger / OpenAPI Editor](../../../.apm/agents/spec-swagger-editor.agent.md) | Interface-contract discipline (schemas, $ref hygiene, oneOf discriminators, conformance enumeration) | Yes |
+| [OCI Distribution Editor](../../../.apm/agents/spec-oci-editor.agent.md) | Registry-HTTP rigor (hash envelopes, mirror tolerance, fail-closed extraction, supply-chain threat model) | Yes |
+| [Package-Manager Registry-Contract Editor](../../../.apm/agents/spec-pkgmgr-editor.agent.md) | Dependency-resolution rigor (semver dialect pinning, lockfile determinism, transitive conflict policy, reserved-slot defensive MUSTs) | Yes |
+| [W3C TAG Architect](../../../.apm/agents/spec-tag-architect.agent.md) | Web-platform integration / architecture (extensibility, layering, fingerprinting, machine-readable contract surface) | Yes |
+| [Spec Editor Synthesizer](../../../.apm/agents/spec-editor-synthesizer.agent.md) | Same hand that drafted; aggregates panel returns, computes shocked_meter_avg, clusters convergent themes, produces fold-now / defer / reject lists and ship_decision | Yes |
 
 The roster is invariant for the v0.1 lineage. Changing it requires
 bumping the skill version.

--- a/.agents/skills/apm-strategy/SKILL.md
+++ b/.agents/skills/apm-strategy/SKILL.md
@@ -9,7 +9,7 @@ description: >-
 
 # APM Strategy Skill
 
-[APM CEO persona](../../agents/apm-ceo.agent.md)
+[APM CEO persona](../../../.apm/agents/apm-ceo.agent.md)
 
 ## When to activate
 

--- a/.agents/skills/auth/SKILL.md
+++ b/.agents/skills/auth/SKILL.md
@@ -8,7 +8,7 @@ description: >
 
 # Auth Skill
 
-[Auth expert persona](../../agents/auth-expert.agent.md)
+[Auth expert persona](../../../.apm/agents/auth-expert.agent.md)
 
 ## When to activate
 

--- a/.agents/skills/cli-logging-ux/SKILL.md
+++ b/.agents/skills/cli-logging-ux/SKILL.md
@@ -9,7 +9,7 @@ description: >
   if the user doesn't mention "logging" or "UX" explicitly.
 ---
 
-[CLI Logging UX expert persona](../../agents/cli-logging-expert.agent.md)
+[CLI Logging UX expert persona](../../../.apm/agents/cli-logging-expert.agent.md)
 
 # CLI Logging & Developer Experience
 

--- a/.agents/skills/cut-release/SKILL.md
+++ b/.agents/skills/cut-release/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: cut-release
+description: >-
+  Use this skill to cut an APM release from the current worktree:
+  assess whether the cycle since the last tag warrants a patch or
+  minor bump (semver discipline against the merged-since-last-tag
+  diff), sanitize the [Unreleased] CHANGELOG block into a dated
+  version block with one concise "so what" entry per merged PR
+  (drop internal-only churn, consolidate duplicates), bump
+  pyproject.toml + uv.lock, run the CI-mirror lint chain, and open
+  the release PR. Activate on "ship a release", "cut v0.x",
+  "release prep", "bump and PR", "open release PR", "what kind of
+  release do we need", or any phrasing that ends in opening a
+  release PR -- even when the user does not say "skill". Stops
+  BEFORE tagging; tagging stays a human gate that triggers the
+  release workflow. Refuses to bump to a major (>= 1.0.0) version
+  without explicit operator confirmation.
+---
+
+# cut-release -- assess, sanitize, bump, lint, open PR
+
+This skill drives the release-cut workflow end-to-end on the current
+worktree. It STOPS at "PR open"; tagging is the human-gated trigger
+that fires the release workflow.
+
+## When to use
+
+Trigger this skill on any of these intents:
+
+- "cut a release"
+- "ship v0.x" / "ship the release"
+- "release prep" / "prepare the release"
+- "bump and open the PR"
+- "open the release PR"
+- "what kind of release do we need now"
+- "we have enough merged for a release"
+- Any phrasing that ends in opening a release PR.
+
+Do NOT trigger on:
+
+- "tag v0.16.0" -- tagging is the post-merge step the operator runs.
+- "publish a blog post" / "draft release notes for the website".
+- "what changed since v0.15.0" -- enumeration only, no release.
+- "regenerate uv.lock" / raw version-string edits.
+- "rollback to v0.15.0" -- release reversal is a different skill.
+
+## Companion primitives
+
+The skill DEPENDS on these existing primitives in the same source
+tree. Do not duplicate their content; reference them.
+
+- `.apm/skills/apm-strategy/SKILL.md` -- versioning judgement and
+  breaking-change lens. Auto-loads via its own trigger on
+  `CHANGELOG.md` and release-pipeline edits. Treat it as the
+  authoritative lens for "is this BREAKING" and "does this
+  positioning change warrant a migration note".
+- `.apm/instructions/linting.instructions.md` -- canonical
+  CI-mirror lint chain. Reference; do not re-derive ruff / pylint
+  command lists in this skill.
+- `.github/instructions/changelog.instructions.md` -- Keep-a-
+  Changelog format contract. Reference; do not redefine the
+  format.
+
+## Output charset rule
+
+Per `.github/instructions/encoding.instructions.md`, source files in
+this bundle (SKILL.md, assets, scripts) MUST stay in printable ASCII.
+The PR body and changelog entries this skill produces are also
+written to repo files (CHANGELOG.md, PR body), so they MUST stay
+ASCII too. Use `--` for em dashes, `[!]` / `[+]` / `[x]` for status
+markers, and so on.
+
+## Procedure
+
+Run these phases in order. Reload `plan.md` (the session memento)
+at the start of each phase and after every tool return.
+
+### Phase 0 -- ground state
+
+1. Read the current branch with `git rev-parse --abbrev-ref HEAD`.
+   The skill assumes you are on a release-prep branch (or are
+   willing to create one). If you are on `main`, STOP and ask the
+   operator to put you on a branch.
+2. Resolve the last release tag with `git describe --tags --abbrev=0`.
+3. Persist the goal to plan.md:
+   - Range: `<last-tag>..HEAD`.
+   - Acceptance: release PR is open, lint mirror green, no version
+     bumped beyond what the cycle warrants.
+
+### Phase 1 -- enumerate merged PRs
+
+Run `scripts/list-changes-since-tag.sh` (no arguments). It emits
+JSON on stdout: one object per merged PR with fields `pr`, `title`,
+`labels`, `author`, `paths_summary`, `is_user_facing_guess`.
+
+The script's heuristic for `is_user_facing_guess` is
+intentionally conservative -- it flags as INTERNAL only when the
+diff is fully contained in `.apm/`, `.github/instructions/`,
+`tests/`, `docs/`, or matches `chore(repo)`. Treat the field as a
+HINT, not a verdict; the LLM makes the final call per
+`assets/entry-sanitizer.md`.
+
+DO NOT rely on training-recalled PR titles. Truth #5: pretraining
+is frozen. Every PR title in the changelog must come from the
+script's stdout.
+
+### Phase 2 -- pick the bump (B10 CHECKPOINT 1)
+
+Load `assets/semver-rubric.md`. Walk every PR from Phase 1
+against the rubric. The rubric outputs PATCH, MINOR, or
+ESCALATE-TO-MAJOR.
+
+Show the operator:
+
+- The chosen bump and the next version number.
+- Per-PR rationale (which signal fired).
+- The "why patch/minor" one-liner that will go into the PR body.
+
+If the rubric outputs ESCALATE-TO-MAJOR (>= 1.0.0), STOP and
+surface the escalation per `assets/semver-rubric.md` "Major bump"
+section. Do not bump to 1.0.0 without explicit operator
+confirmation.
+
+Wait for the operator's confirm before continuing.
+
+### Phase 3 -- sanitize the changelog (B10 CHECKPOINT 2)
+
+Load `assets/entry-sanitizer.md`. For each PR classified as
+user-facing in Phase 1:
+
+1. Choose its section: Added (new feature, new command, new spec),
+   Changed (behavior change in existing surface), Fixed (bug fix),
+   Deprecated, Removed, Security, Performance.
+2. Write ONE entry per PR. Two-sentence cap. "So what" framing.
+   PR number in parentheses at the end. Preserve `by @author` for
+   external contributors.
+3. Consolidate any pre-existing Unreleased entries that point at
+   the same PR.
+4. Drop INTERNAL PRs entirely (the script flagged most of them;
+   the rubric in entry-sanitizer.md confirms).
+5. Mark BREAKING entries with `**BREAKING:**` prefix.
+
+Rewrite the CHANGELOG.md `[Unreleased]` block in place:
+
+```
+## [Unreleased]
+
+## [X.Y.Z] - YYYY-MM-DD
+
+### Added
+...
+### Changed
+...
+### Fixed
+...
+```
+
+Keep an empty `[Unreleased]` placeholder above the new version
+heading. The date is today (read from the operator's environment,
+not recall).
+
+Show the operator the unified diff against CHANGELOG.md. Wait for
+confirm before continuing.
+
+### Phase 4 -- bump version files
+
+Run `scripts/bump-version.sh <new-version>`. The script edits
+`pyproject.toml` (the `version = "..."` line in `[project]`) and
+runs `uv lock` to refresh `uv.lock`. It prints a unified diff to
+stdout for human review.
+
+If the script exits non-zero, surface the error and STOP -- do not
+continue with a partial bump.
+
+### Phase 5 -- verify lint mirror (S4 gate; B10 CHECKPOINT 3 on fail)
+
+Run `scripts/verify-lint-mirror.sh`. It mirrors the four CI lint
+steps from `.apm/instructions/linting.instructions.md` verbatim
+(ruff check, ruff format --check, pylint R0801, auth-signals).
+
+If it passes (exit 0), proceed to Phase 6.
+
+If it fails (exit 1), STOP. Surface the failures to the operator.
+Common cures:
+
+- ruff diagnostics -- run `uv run --extra dev ruff check src/
+  tests/ --fix` and `uv run --extra dev ruff format src/ tests/`.
+- pylint R0801 -- duplication landed via a recent main commit;
+  merge main first, then re-run.
+- auth-signals -- consult `scripts/lint-auth-signals.sh` output.
+
+Do NOT push or open the PR until lint is green. The PR description
+will claim CI is green; that claim must hold.
+
+### Phase 6 -- commit, push, open PR
+
+1. `git add CHANGELOG.md pyproject.toml uv.lock`.
+2. `git commit -m "chore: release vX.Y.Z" -m "<short body>"`.
+   The body mirrors prior release commits (#1410, #1454, #1526):
+   one paragraph naming what was bumped and the lint-mirror
+   confirmation, plus the "post-merge: tag vX.Y.Z" reminder.
+   Include the standard `Co-authored-by` trailer.
+3. `git push -u origin HEAD`.
+4. Compose the PR body from `assets/pr-body-template.md`,
+   substituting `{version}` (unprefixed, e.g. `0.16.1` -- used by
+   `CHANGELOG.md` and `pyproject.toml`), `{tag}` (v-prefixed, e.g.
+   `v0.16.1` -- used by the post-merge `git tag` block, since the
+   release workflow's stable-release regex requires the `v` prefix
+   per `.github/workflows/build-release.yml`), `{date}`,
+   `{bump_rationale}`, and (if BREAKING) `{breaking_summary}`.
+5. `gh pr create --base main --head <branch> --title
+   "chore: release vX.Y.Z" --body-file <tmpfile>`.
+6. Echo the PR URL.
+7. Surface the post-merge step explicitly: "Post-merge: tag
+   `vX.Y.Z` to trigger the release workflow." Do NOT tag.
+
+### Phase 7 -- update plan and exit
+
+Mark each plan.md todo as done. The session ends here. Tagging is
+the operator's decision and lives outside this skill.
+
+## Anti-patterns this skill refuses
+
+- TAGGING. Tagging is a separate, human-gated step. If asked to
+  tag inside this session, decline and remind the operator that
+  the release workflow expects `git tag vX.Y.Z && git push --tags`
+  after PR merge.
+- BUMP-TO-MAJOR-UNPROMPTED. 0.x -> 1.0.0 is a positioning
+  decision. ESCALATE per `assets/semver-rubric.md`.
+- HAND-ROLLED PR TITLES. Every changelog entry must be backed by
+  a PR title from `scripts/list-changes-since-tag.sh` stdout. No
+  recall.
+- CHATTY GATE. Three operator checkpoints, no more (version pick,
+  sanitized changelog, lint-fail recovery). Do not ask per-PR or
+  per-section.
+- PARTIAL PUSH. If lint fails, do not push. The release PR
+  asserts green CI; pushing red breaks the contract.
+- SKIPPED LINT. Do not skip Phase 5 even if the diff looks
+  trivial. The lint mirror catches code-duplication drift on the
+  merge commit, which is invisible to a local diff inspection.
+
+## Boundary
+
+This skill does NOT:
+
+- Tag the release.
+- Run the test suite or build PyInstaller binaries.
+- Publish a GitHub Release body, blog post, or announcement.
+- Decide whether a release should happen -- the operator decided
+  that by activating this skill.
+- Bump to >= 1.0.0 without explicit operator confirmation.
+- Review code quality or test coverage (use `apm-review-panel`
+  before activating this skill if a recent PR needs review).

--- a/.agents/skills/cut-release/assets/entry-sanitizer.md
+++ b/.agents/skills/cut-release/assets/entry-sanitizer.md
@@ -1,0 +1,159 @@
+# entry-sanitizer -- one concise "so what" per PR
+
+Loaded by `cut-release` at Phase 3. Rewrites the [Unreleased]
+block into a dated version block with one entry per
+user-facing PR.
+
+## Per-entry rubric
+
+For each PR that survives the DROP list below:
+
+1. ONE entry per PR. Do not split into multiple bullets across
+   sections unless the same PR genuinely changed two distinct
+   user-visible surfaces (rare; usually a sign the PR was
+   under-scoped).
+2. TWO-SENTENCE CAP. First sentence: what changed (concrete CLI
+   surface or behavior). Second sentence (optional): the "so
+   what" -- what the user can now do, what bug stopped biting,
+   what failure mode is closed. Drop everything else.
+3. PR NUMBER at the end in parentheses: `(#1495)`. If the PR
+   closes an issue, prefix: `(closes #1488, #1496)`. Multiple
+   numbers go inside one parenthesis group.
+4. ATTRIBUTION for external contributors: append
+   `(by @username, #NNNN)`. Internal contributors are not named.
+5. BREAKING marker: prefix entry with `**BREAKING:**`. Always
+   land breakings in the appropriate section (usually Changed or
+   Security); never bury them in Fixed.
+6. CONCRETE LANGUAGE. Use the exact CLI surface affected:
+   ``\`apm install -g\` now ...`` not "global install is now ...".
+7. NO REPO INTERNALS. The reader is a user, not a maintainer.
+   "Refactored the BFS resolver" is wrong; "`apm install --update`
+   now re-resolves direct git-source semver dependencies" is right.
+
+## Section mapping
+
+| Diff shape | Section |
+|------------|---------|
+| New CLI command, new flag with new default ON, new manifest field, new spec, new policy, new feature | **Added** |
+| Behavior change to existing surface (default flip, output format change, exit code change, BREAKING) | **Changed** |
+| Bug fix to existing surface (was wrong, now right) | **Fixed** |
+| Surface marked for removal with timeline | **Deprecated** |
+| Surface removed from the CLI / config / manifest | **Removed** |
+| Security-relevant fix or hardening (CVE, attack surface closed) | **Security** |
+| Measurable speedup / memory reduction on a user-visible path | **Performance** |
+
+If a PR fits two sections, pick the user-MOST-VISIBLE one and
+mention the other in the body. Do not double-list.
+
+## DROP list (do NOT include in changelog)
+
+A PR is INTERNAL and gets dropped if ANY of these hold:
+
+- Diff is fully contained in `.apm/` (skills, agents, instructions,
+  prompts that are part of the maintainer toolkit -- the project's
+  own dogfooding primitives).
+- Diff is fully contained in `.github/instructions/`,
+  `.github/workflows/` (unless the workflow change affects users,
+  e.g. release binaries), or `.github/ISSUE_TEMPLATE/`.
+- Diff is fully contained in `tests/` (test-only PR).
+- Diff is fully contained in `docs/` AND the change is doc
+  housekeeping (typo, restructure) rather than a doc-bug fix that
+  was misleading users. Doc-bug fixes DO go in Fixed.
+- Title starts with `chore(repo):`, `chore(deps):` (Dependabot-
+  style), `ci:`, or `test:`.
+- Title is `Merge ...` / `Revert ...` (handled separately if a
+  revert is user-visible -- usually it ends up matching another
+  fix entry anyway).
+
+Phase 1's script flags these heuristically via
+`is_user_facing_guess`; the rubric here is the authoritative
+verdict.
+
+EDGE CASE -- mixed-surface PRs. A PR that touches both `.apm/`
+and `src/` is NOT internal -- the `src/` change is user-facing
+even if the bulk of the diff is skill content. Read the `src/`
+hunk to write the entry; ignore the `.apm/` noise.
+
+## Consolidation rules
+
+The existing [Unreleased] block may already have entries the
+contributor wrote. Treat them as drafts, not gospel:
+
+- If two existing entries point at the same PR (#NNNN appears
+  twice), MERGE into one entry. Keep the longer / more specific
+  prose.
+- If an existing entry violates the rubric (six sentences,
+  internal jargon, no "so what"), REWRITE it -- do not preserve
+  the original phrasing out of politeness.
+- If an existing entry references a PR not in Phase 1's output
+  (likely because it was tagged Unreleased before the previous
+  release), that's a bug in the previous release's sanitizer
+  pass. Surface to the operator at checkpoint 2; ask whether to
+  keep it (likely "fix the typo and ship") or drop it.
+
+## Output shape
+
+The rewritten block goes in place of `[Unreleased]`:
+
+```
+## [Unreleased]
+
+## [X.Y.Z] - YYYY-MM-DD
+
+### Added
+
+- <entry>. (#NNNN)
+- <entry>. (closes #AAAA, #BBBB)
+
+### Changed
+
+- **BREAKING:** <entry>. (#NNNN)
+- <entry>. (#NNNN)
+
+### Fixed
+
+- <entry>. (#NNNN)
+- <entry>. (by @user, #NNNN)
+```
+
+An empty `[Unreleased]` placeholder stays above the new version
+heading -- the next release cycle adds entries to it.
+
+The date is TODAY in `YYYY-MM-DD` (read from the operator's
+environment / current_datetime in the session header; do not
+recall).
+
+## Worked example (v0.16.0)
+
+Inputs from Phase 1: 19 PRs. Drop list killed 5 (skill refactor,
+docs-only PRs, internal test, chore). Remaining 14:
+
+```
+### Added
+- OpenAPM v0.1 normative spec ... (closes #1502, #1517)
+- `ref:` on git-source dependencies now accepts semver ranges ... (closes #1488, #1496)
+- `apm deps why <package>` ... (#1495)
+- `policy.dependencies.require_pinned_constraint: true` ... (#1494)
+- Deterministic Artifactory boundary probe ... (#1472)
+
+### Changed
+- **BREAKING:** `apm install` now exits `1` ... (#1496)
+- Artifactory parse-time boundary detection ... (#1472)
+
+### Fixed
+- `install.ps1` on Windows ... (closes #1509, #1512)
+- `apm.cmd` Windows shim is now written as ASCII ... (#1522)
+- `install.ps1` is now strict ASCII ... (#1523)
+- `apm install --target opencode` ... (Phase 1 of #581, #1513)
+- `apm compile --target claude` ... (closes #1445, #1514)
+- `apm install git@gitlab.com:` ... (closes #1501, #1515)
+- `apm install -g` hook integration ... (closes #1499, #1516)
+- `apm install --update` re-resolves git-semver ... (#1496)
+- `=1.2.3` pinned classification ... (follow-up to #1494, #1506)
+- `apm uninstall` windsurf cleanup ... (by @yoelabril, #1486)
+- `apm unpack` deprecation banner softened ... (#1511)
+```
+
+Two PRs from Phase 1 attached to the same `#1472` -- consolidated
+across Added / Changed / Fixed (the PR genuinely changed three
+surfaces, so three entries is correct here, not over-listing).

--- a/.agents/skills/cut-release/assets/pr-body-template.md
+++ b/.agents/skills/cut-release/assets/pr-body-template.md
@@ -1,0 +1,23 @@
+Cut release {version}.
+
+- Bump `pyproject.toml` to {version} (and `uv.lock`).
+- Move `[Unreleased]` to `[{version}] - {date}` in `CHANGELOG.md`, with one short "so what?" entry per PR merged since {prev_version}.
+
+## Why {bump_kind} ({version}), not {alt_bump_kind} ({alt_version})
+
+{bump_rationale}
+
+{breaking_summary_block}
+
+## Validation
+
+Lint mirror green locally (ruff check + format, pylint R0801, auth-signals). See `.apm/instructions/linting.instructions.md` for the contract this mirrors.
+
+## Post-merge
+
+Tag `{tag}` to trigger the release workflow:
+
+```
+git tag {tag}
+git push origin {tag}
+```

--- a/.agents/skills/cut-release/assets/semver-rubric.md
+++ b/.agents/skills/cut-release/assets/semver-rubric.md
@@ -1,0 +1,118 @@
+# semver-rubric -- pick the bump
+
+Loaded by `cut-release` at Phase 2. Walks every PR enumerated in
+Phase 1 against a fixed signal table; the highest-severity signal
+wins.
+
+## Signal table (highest severity wins)
+
+| Signal (read top-down; first match wins) | Bump |
+|------------------------------------------|------|
+| 1. ANY PR title or [Unreleased] entry contains literal `**BREAKING:**` or `(BREAKING)` | **MINOR** (pre-1.0) / **MAJOR** (>= 1.0) |
+| 2. ANY PR added a NEW user-visible CLI command (e.g. `apm deps why`, `apm publish`) | **MINOR** |
+| 3. ANY PR added a NEW user-facing feature flag, config field, manifest field, or schema entry | **MINOR** |
+| 4. ANY PR added a NEW normative spec, JSON Schema, or contract surface | **MINOR** |
+| 5. ANY PR added a NEW dependency-resolution mode (e.g. semver ranges on git deps) | **MINOR** |
+| 6. ANY PR added a NEW supported target / adapter / integration host | **MINOR** |
+| 7. All remaining PRs are bug fixes, security patches, doc-only, internal | **PATCH** |
+| 8. NO PRs since last tag | **REFUSE** -- nothing to release |
+
+Read top to bottom. The first row whose condition matches is the
+chosen bump. Do not "average" across rows.
+
+## Pre-1.0 vs post-1.0 framing
+
+This rubric is calibrated for the current 0.x line. Per the
+project's stated semver discipline (`pyproject.toml` follows
+semver, see `.github/instructions/changelog.instructions.md`):
+
+- PRE-1.0 (0.x.y): BREAKING changes are allowed in a MINOR bump.
+  This is the standard pre-1.0 semver convention. Mark the entry
+  `**BREAKING:**` so users can grep for it, but do NOT bump to
+  1.0 just because the cycle has a breaking change.
+- POST-1.0 (>= 1.0): BREAKING requires MAJOR. Period.
+
+## Major bump (escalate)
+
+If the rubric would output >= 1.0.0 (the cycle contains a BREAKING
+change AND the current version is already 0.99.x OR the operator
+explicitly named a major bump), STOP and surface to the operator:
+
+> The signals point to a major bump (>= 1.0.0). 1.0 is a
+> positioning decision (API stability commitment), not a
+> mechanical one. Confirm explicitly, or pick a different
+> versioning strategy (e.g. ship as 0.X.Y+1 minor and defer 1.0
+> to a planned release).
+
+Do NOT bump to 1.0.0 without an explicit "yes, ship 1.0" from the
+operator. Default to MINOR in the 0.x line even with breakings.
+
+## Calculating the next version
+
+Given current version `MAJOR.MINOR.PATCH`:
+
+- PATCH bump: `MAJOR.MINOR.(PATCH+1)`.
+- MINOR bump: `MAJOR.(MINOR+1).0`.
+- MAJOR bump: `(MAJOR+1).0.0` (escalate first; see above).
+
+Read the current version from `pyproject.toml` via
+`grep '^version = ' pyproject.toml`. Do not recall it.
+
+## Worked examples (calibration anchors)
+
+### v0.16.0 cycle (the cycle that produced this skill)
+
+Signals seen:
+- One BREAKING in [Unreleased] (`apm install` exit-code change). -> Row 1.
+- New command `apm deps why` (#1495). -> Row 2.
+- New policy `require_pinned_constraint` (#1494). -> Row 3.
+- New spec OpenAPM v0.1 (#1517). -> Row 4.
+- New resolution mode: semver ranges on git deps (#1496). -> Row 5.
+
+First match: Row 1 (BREAKING). Pre-1.0 framing -> **MINOR**.
+Result: `0.15.0 -> 0.16.0`.
+
+### Hypothetical patch-only cycle
+
+Signals seen:
+- Three PRs, all `fix(install): ...`. No BREAKING. No new
+  command. No new schema.
+
+First match: Row 7. -> **PATCH**.
+Result: `0.16.0 -> 0.16.1`.
+
+### Hypothetical no-op cycle
+
+Signals seen:
+- Five PRs, all touching `.apm/` skills, `.github/instructions/`,
+  or `tests/`. All marked INTERNAL by Phase 1's script.
+
+After dropping internals: 0 user-facing PRs.
+
+First match: Row 8 (NO PRs). -> **REFUSE**. Surface to operator:
+"Nothing user-facing has merged since v0.16.0. Release would be
+no-op; recommend waiting for a real fix or feature."
+
+## Output contract
+
+Phase 2 must emit a structured summary to the operator before
+checkpoint 1:
+
+```
+Next version: vX.Y.Z (BUMP from vA.B.C)
+Signal: <row N> -- <one-line description>
+
+Per-PR rationale:
+  #1517 OpenAPM v0.1 spec       -> Row 4 (new spec)
+  #1496 git-source semver       -> Row 5 (new resolution mode) + carries BREAKING (Row 1)
+  #1495 apm deps why            -> Row 2 (new command)
+  #1494 require_pinned_constraint -> Row 3 (new policy)
+  ...
+  #1486 windsurf uninstall fix  -> Row 7 (fix; subordinate to Row 1 above)
+
+Why MINOR (not PATCH): Row 1 fired (BREAKING) AND Rows 2-5 fired.
+Why MINOR (not MAJOR): pre-1.0 framing; breakings ride in minor.
+```
+
+This block is what the operator sees at checkpoint 1; it is also
+what the PR body's "Why this bump" section quotes.

--- a/.agents/skills/cut-release/evals/evals.json
+++ b/.agents/skills/cut-release/evals/evals.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": 1,
+  "skill": "cut-release",
+  "skill_path": "../SKILL.md",
+  "notes": "Trigger evals only. Content evals are deferred to real-task refinement: the next release cycle exercises the skill end-to-end against a real worktree, and the diff vs without-skill is logged manually. This mirrors the deferred-content pattern in docs-sync/.",
+  "triggers": {
+    "split": "val",
+    "should_fire_rate_min": 0.5,
+    "should_not_fire_rate_max": 0.5,
+    "items": [
+      {"id": "fire-01", "query": "cut a release", "expected": "fire", "split": "train"},
+      {"id": "fire-02", "query": "ship v0.16.0", "expected": "fire", "split": "train"},
+      {"id": "fire-03", "query": "release prep -- bump and open the PR", "expected": "fire", "split": "train"},
+      {"id": "fire-04", "query": "what kind of release do we need now, v0.15.1 or v0.16.0?", "expected": "fire", "split": "train"},
+      {"id": "fire-05", "query": "we have enough merged for a release, can you cut it?", "expected": "fire", "split": "train"},
+      {"id": "fire-06", "query": "open the release PR after sanitizing changelog", "expected": "fire", "split": "val"},
+      {"id": "fire-07", "query": "prepare the next minor", "expected": "fire", "split": "val"},
+      {"id": "fire-08", "query": "bump version and open PR", "expected": "fire", "split": "val"},
+      {"id": "fire-09", "query": "let's ship the release", "expected": "fire", "split": "val"},
+      {"id": "fire-10", "query": "sanitize unreleased and cut", "expected": "fire", "split": "val"},
+
+      {"id": "no-fire-01", "query": "tag v0.16.0", "expected": "no-fire", "split": "train", "notes": "Tagging is the post-merge step; cut-release explicitly stops at PR open."},
+      {"id": "no-fire-02", "query": "publish a blog post about the v0.16.0 release", "expected": "no-fire", "split": "train", "notes": "Announcement work; out of scope."},
+      {"id": "no-fire-03", "query": "what changed since v0.15.0?", "expected": "no-fire", "split": "train", "notes": "Pure enumeration; no release being cut."},
+      {"id": "no-fire-04", "query": "review this PR", "expected": "no-fire", "split": "train", "notes": "apm-review-panel territory."},
+      {"id": "no-fire-05", "query": "update the CHANGELOG entry for #1526", "expected": "no-fire", "split": "train", "notes": "Single-PR doc edit, not a release cut."},
+      {"id": "no-fire-06", "query": "rollback to v0.15.0", "expected": "no-fire", "split": "val", "notes": "Release reversal; different workflow."},
+      {"id": "no-fire-07", "query": "regenerate uv.lock after a dep bump", "expected": "no-fire", "split": "val", "notes": "Lockfile maintenance, not a release."},
+      {"id": "no-fire-08", "query": "set version to 0.16.0 in pyproject.toml", "expected": "no-fire", "split": "val", "notes": "Raw version edit; bypasses the rubric and the changelog."},
+      {"id": "no-fire-09", "query": "draft release notes for the website", "expected": "no-fire", "split": "val", "notes": "Marketing copy; out of scope."},
+      {"id": "no-fire-10", "query": "triage the open issues", "expected": "no-fire", "split": "val", "notes": "apm-triage-panel territory."}
+    ]
+  },
+  "stop_list": [
+    "tag the release",
+    "tag v",
+    "git tag",
+    "blog post",
+    "release notes for",
+    "rollback",
+    "regenerate uv.lock",
+    "review this pr",
+    "triage"
+  ]
+}

--- a/.agents/skills/cut-release/scripts/bump-version.sh
+++ b/.agents/skills/cut-release/scripts/bump-version.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# bump-version.sh -- bump pyproject.toml version + refresh uv.lock.
+#
+# Edits the `version = "..."` line under [project] in pyproject.toml,
+# then runs `uv lock` to update uv.lock. Emits a unified diff of both
+# files on stdout for review.
+#
+# Exit codes:
+#   0 success
+#   1 malformed input / target equals current version / file missing
+#   2 usage error
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: bump-version.sh <new_version>
+
+Edit `version = "..."` in pyproject.toml to <new_version>, then
+refresh uv.lock via `uv lock`. Emit a unified diff of both files
+on stdout.
+
+<new_version> must match the pattern MAJOR.MINOR.PATCH (digits
+only, dot-separated, no v-prefix, no pre-release suffix).
+
+Examples:
+  bump-version.sh 0.16.0
+  bump-version.sh 0.16.1
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+if [[ $# -ne 1 ]]; then
+    echo "[x] expected exactly one argument: <new_version>" >&2
+    usage >&2
+    exit 2
+fi
+
+NEW_VERSION="$1"
+
+if ! [[ "$NEW_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "[x] malformed version: $NEW_VERSION (expected MAJOR.MINOR.PATCH)" >&2
+    exit 1
+fi
+
+if [[ ! -f pyproject.toml ]]; then
+    echo "[x] pyproject.toml not found in cwd: $(pwd)" >&2
+    exit 1
+fi
+
+CURRENT=$(grep -E '^version = ' pyproject.toml | head -1 | sed -E 's/^version = "([^"]+)".*/\1/')
+if [[ -z "$CURRENT" ]]; then
+    echo "[x] could not parse current version from pyproject.toml" >&2
+    exit 1
+fi
+
+if [[ "$CURRENT" == "$NEW_VERSION" ]]; then
+    echo "[x] target version equals current ($CURRENT); nothing to do" >&2
+    exit 1
+fi
+
+echo "[i] current: $CURRENT" >&2
+echo "[i] target:  $NEW_VERSION" >&2
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "[x] missing required tool: uv" >&2
+    exit 1
+fi
+
+# Snapshot for diff.
+BEFORE_PYPROJECT=$(mktemp)
+BEFORE_LOCK=$(mktemp)
+trap 'rm -f "$BEFORE_PYPROJECT" "$BEFORE_LOCK"' EXIT
+cp pyproject.toml "$BEFORE_PYPROJECT"
+if [[ -f uv.lock ]]; then
+    cp uv.lock "$BEFORE_LOCK"
+fi
+
+# Edit pyproject.toml in place. Match only the top-level project
+# version (the first match anchored at column 0).
+TMP=$(mktemp)
+awk -v cur="$CURRENT" -v new="$NEW_VERSION" '
+    !done && $0 == "version = \"" cur "\"" { print "version = \"" new "\""; done=1; next }
+    { print }
+' pyproject.toml > "$TMP"
+
+if ! grep -q "^version = \"$NEW_VERSION\"$" "$TMP"; then
+    echo "[x] failed to apply version edit (no matching line found)" >&2
+    rm -f "$TMP"
+    exit 1
+fi
+mv "$TMP" pyproject.toml
+
+# Refresh uv.lock.
+echo "[*] running uv lock" >&2
+if ! uv lock >&2; then
+    echo "[x] uv lock failed" >&2
+    exit 1
+fi
+
+# Emit unified diff on stdout.
+echo "=== pyproject.toml ==="
+diff -u "$BEFORE_PYPROJECT" pyproject.toml || true
+echo
+echo "=== uv.lock (apm-cli package entry) ==="
+if [[ -f "$BEFORE_LOCK" ]]; then
+    diff -u "$BEFORE_LOCK" uv.lock | grep -E '^[-+@].*(apm-cli|version)' | head -20 || true
+else
+    echo "(uv.lock did not exist before)"
+fi
+
+echo
+echo "[+] bumped $CURRENT -> $NEW_VERSION"

--- a/.agents/skills/cut-release/scripts/list-changes-since-tag.sh
+++ b/.agents/skills/cut-release/scripts/list-changes-since-tag.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# list-changes-since-tag.sh -- enumerate PRs merged since the last release tag.
+#
+# Emits a JSON array on stdout. Diagnostics on stderr. Non-interactive.
+# Requires: git, gh (>= 2.40), jq.
+#
+# Output schema (per PR):
+#   {
+#     "pr": 1495,
+#     "title": "feat(deps): add 'apm deps why <pkg>' ...",
+#     "labels": ["enhancement"],
+#     "author": "danielmeppiel",
+#     "paths_summary": ["src/apm_cli/...", "tests/...", "docs/..."],
+#     "is_user_facing_guess": true,
+#     "commit_sha": "61fe5066..."
+#   }
+#
+# is_user_facing_guess is a HINT (true = touches user-visible surface;
+# false = fully contained in maintainer/internal paths). The LLM caller
+# in cut-release makes the final inclusion call per
+# assets/entry-sanitizer.md.
+#
+# Exit codes:
+#   0 success
+#   1 missing dependency / missing last tag / git failure
+#   2 usage error
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: list-changes-since-tag.sh [--help]
+
+Enumerate PRs merged since the last release tag (as determined by
+`git describe --tags --abbrev=0`). Emits a JSON array on stdout.
+
+No arguments. Stops at the first git/gh failure.
+
+Environment:
+  GH_TOKEN / GITHUB_TOKEN -- used by `gh` if set.
+
+Examples:
+  list-changes-since-tag.sh > /tmp/prs.json
+  list-changes-since-tag.sh | jq '.[] | select(.is_user_facing_guess)'
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+if [[ $# -gt 0 ]]; then
+    echo "[x] unexpected arguments: $*" >&2
+    usage >&2
+    exit 2
+fi
+
+for tool in git gh jq; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "[x] missing required tool: $tool" >&2
+        exit 1
+    fi
+done
+
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
+if [[ -z "$LAST_TAG" ]]; then
+    echo "[x] no tags found; cannot enumerate range" >&2
+    exit 1
+fi
+echo "[i] last release tag: $LAST_TAG" >&2
+
+# Collect (sha, subject) for non-merge commits since the tag.
+COMMITS=$(git log "${LAST_TAG}..HEAD" --no-merges --pretty=format:'%H%x09%s')
+if [[ -z "$COMMITS" ]]; then
+    echo "[i] no commits since $LAST_TAG; emitting empty array" >&2
+    echo "[]"
+    exit 0
+fi
+
+# Extract PR numbers from commit subjects (squash-merge convention: "(#NNNN)").
+# Fallback: use `gh pr list --search` keyed by sha if no number is in the subject.
+PR_NUMS=()
+declare -A SHA_OF_PR
+while IFS=$'\t' read -r SHA SUBJECT; do
+    if [[ "$SUBJECT" =~ \(#([0-9]+)\)$ ]]; then
+        NUM="${BASH_REMATCH[1]}"
+        PR_NUMS+=("$NUM")
+        SHA_OF_PR[$NUM]="$SHA"
+    fi
+done <<< "$COMMITS"
+
+if [[ ${#PR_NUMS[@]} -eq 0 ]]; then
+    echo "[!] no PR numbers extracted from commit subjects" >&2
+    echo "[]"
+    exit 0
+fi
+
+echo "[i] resolved ${#PR_NUMS[@]} PR number(s)" >&2
+
+# Internal-path predicate. A path is "internal" if it falls entirely
+# inside any of these prefixes.
+internal_path() {
+    local p="$1"
+    case "$p" in
+        .apm/*|.github/instructions/*|.github/workflows/*|.github/ISSUE_TEMPLATE/*|tests/*|docs/*)
+            return 0 ;;
+        *)
+            return 1 ;;
+    esac
+}
+
+# Emit JSON array.
+printf '['
+FIRST=1
+for NUM in "${PR_NUMS[@]}"; do
+    PR_JSON=$(gh pr view "$NUM" --json title,labels,author,files 2>/dev/null || echo "")
+    if [[ -z "$PR_JSON" ]]; then
+        echo "[!] failed to fetch PR #$NUM; skipping" >&2
+        continue
+    fi
+
+    TITLE=$(jq -r '.title' <<< "$PR_JSON")
+    LABELS=$(jq -c '[.labels[].name]' <<< "$PR_JSON")
+    AUTHOR=$(jq -r '.author.login' <<< "$PR_JSON")
+    PATHS=$(jq -r '.files[].path' <<< "$PR_JSON")
+
+    # Classify: user-facing iff at least one path is NOT internal.
+    USER_FACING="false"
+    PATHS_SUMMARY=()
+    while IFS= read -r P; do
+        [[ -z "$P" ]] && continue
+        PATHS_SUMMARY+=("$P")
+        if ! internal_path "$P"; then
+            USER_FACING="true"
+        fi
+    done <<< "$PATHS"
+
+    # Cap paths_summary at 10 entries (diagnostic, not exhaustive).
+    if [[ ${#PATHS_SUMMARY[@]} -gt 10 ]]; then
+        PATHS_SUMMARY=("${PATHS_SUMMARY[@]:0:10}")
+        PATHS_SUMMARY+=("...")
+    fi
+    PATHS_JSON=$(printf '%s\n' "${PATHS_SUMMARY[@]}" | jq -R . | jq -s .)
+
+    [[ $FIRST -eq 0 ]] && printf ','
+    FIRST=0
+
+    jq -c -n \
+        --argjson pr "$NUM" \
+        --arg title "$TITLE" \
+        --argjson labels "$LABELS" \
+        --arg author "$AUTHOR" \
+        --argjson paths "$PATHS_JSON" \
+        --arg sha "${SHA_OF_PR[$NUM]}" \
+        --argjson user_facing "$USER_FACING" \
+        '{pr: $pr, title: $title, labels: $labels, author: $author,
+          paths_summary: $paths, is_user_facing_guess: $user_facing,
+          commit_sha: $sha}'
+done
+printf ']\n'

--- a/.agents/skills/cut-release/scripts/verify-lint-mirror.sh
+++ b/.agents/skills/cut-release/scripts/verify-lint-mirror.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# verify-lint-mirror.sh -- run the CI Lint job mirror locally.
+#
+# Mirrors `.apm/instructions/linting.instructions.md` verbatim.
+# Stops at the first failure. Diagnostics on stderr; structured
+# pass/fail summary on stdout.
+#
+# Exit codes:
+#   0 all checks passed
+#   1 one or more checks failed
+#   2 usage error / missing dependency
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: verify-lint-mirror.sh [--help]
+
+Run the four CI-mirror lint steps from
+.apm/instructions/linting.instructions.md verbatim:
+
+  1. ruff check (style + imports + lint)
+  2. ruff format --check
+  3. pylint R0801 duplication guard (min-similarity-lines=10)
+  4. auth-signals boundary lint (scripts/lint-auth-signals.sh)
+
+Stops at first failure. Stdout: one PASS/FAIL line per step plus
+final summary. Stderr: tool diagnostics.
+
+No arguments. Run from the worktree root.
+
+Note: the YAML I/O guard, file-length guardrail, and
+`relative_to` guard from the CI job are pure-grep one-liners that
+this mirror does NOT run -- they are cheap to invoke directly and
+were skipped to keep this script focused. Run them manually if you
+touched those surfaces.
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+if [[ $# -gt 0 ]]; then
+    echo "[x] unexpected arguments: $*" >&2
+    usage >&2
+    exit 2
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "[x] missing required tool: uv" >&2
+    exit 2
+fi
+
+# Track step status. STEP_STATUS holds "PASS" or "FAIL <msg>".
+declare -a STEP_NAMES=(
+    "ruff check"
+    "ruff format --check"
+    "pylint R0801 duplication"
+    "auth-signals boundary"
+)
+declare -a STEP_CMDS=(
+    "uv run --extra dev ruff check src/ tests/"
+    "uv run --extra dev ruff format --check src/ tests/"
+    "uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/"
+    "bash scripts/lint-auth-signals.sh"
+)
+declare -a STEP_STATUS=()
+
+OVERALL=0
+for i in "${!STEP_CMDS[@]}"; do
+    NAME="${STEP_NAMES[$i]}"
+    CMD="${STEP_CMDS[$i]}"
+    echo "[*] $NAME" >&2
+    if eval "$CMD" >&2; then
+        STEP_STATUS+=("PASS")
+        echo "[+] $NAME" >&2
+    else
+        STEP_STATUS+=("FAIL")
+        echo "[x] $NAME -- see diagnostics above" >&2
+        OVERALL=1
+        break
+    fi
+done
+
+echo
+echo "=== verify-lint-mirror summary ==="
+for i in "${!STEP_NAMES[@]}"; do
+    STATUS="${STEP_STATUS[$i]:-SKIPPED}"
+    printf "  %-30s %s\n" "${STEP_NAMES[$i]}" "$STATUS"
+done
+
+if [[ $OVERALL -eq 0 ]]; then
+    echo "[+] all lint-mirror checks PASSED"
+else
+    echo "[x] lint-mirror FAILED -- fix and re-run before pushing"
+fi
+exit $OVERALL

--- a/.agents/skills/devx-ux/SKILL.md
+++ b/.agents/skills/devx-ux/SKILL.md
@@ -8,7 +8,7 @@ description: >-
 
 # Developer Tooling UX Skill
 
-[Developer Tooling UX expert persona](../../agents/devx-ux-expert.agent.md)
+[Developer Tooling UX expert persona](../../../.apm/agents/devx-ux-expert.agent.md)
 
 ## When to activate
 

--- a/.agents/skills/docs-corpus-audit/SKILL.md
+++ b/.agents/skills/docs-corpus-audit/SKILL.md
@@ -45,10 +45,10 @@ These two skills share substrate. Be explicit:
 | Shared resource | Owner | Both use |
 |---|---|---|
 | `.apm/docs-index.yml` (corpus map) | docs-sync | yes |
-| [doc-writer](../../agents/doc-writer.agent.md) persona | shared | yes (per-page edits) |
-| [python-architect](../../agents/python-architect.agent.md) persona | shared | yes (S7 verification) |
-| [editorial-owner](../../agents/editorial-owner.agent.md) persona | shared | optional (voice pass at scale) |
-| [cdo](../../agents/cdo.agent.md) persona | shared | yes (final synthesis) |
+| [doc-writer](../../../.apm/agents/doc-writer.agent.md) persona | shared | yes (per-page edits) |
+| [python-architect](../../../.apm/agents/python-architect.agent.md) persona | shared | yes (S7 verification) |
+| [editorial-owner](../../../.apm/agents/editorial-owner.agent.md) persona | shared | optional (voice pass at scale) |
+| [cdo](../../../.apm/agents/cdo.agent.md) persona | shared | yes (final synthesis) |
 | `assets/panelist-return-schema.json` | docs-sync (mirrored) | yes |
 
 **Trigger boundary (avoid DISPATCH COLLISION):**
@@ -96,11 +96,11 @@ verifier" role; that's R3 EXTRACT in reverse.
 
 | Role | Persona | Always active? |
 |---|---|---|
-| Per-scope verifier+editor | [python-architect](../../agents/python-architect.agent.md) (S7) and [doc-writer](../../agents/doc-writer.agent.md) (edits), bundled into one subagent prompt per scope | Yes -- one per page scope, parallel fan-out |
+| Per-scope verifier+editor | [python-architect](../../../.apm/agents/python-architect.agent.md) (S7) and [doc-writer](../../../.apm/agents/doc-writer.agent.md) (edits), bundled into one subagent prompt per scope | Yes -- one per page scope, parallel fan-out |
 | Cross-corpus post-pass | orchestrator (deterministic greps via `scripts/scan-cross-corpus-drift.sh`) | Yes -- once after waves return |
 | Alignment-loop checker | orchestrator (deterministic re-grep + targeted re-dispatch) | Yes -- once after post-pass |
-| Voice pass (optional) | [editorial-owner](../../agents/editorial-owner.agent.md) | Only when >20 edits to keep tone coherent |
-| Final synthesis | [cdo](../../agents/cdo.agent.md) | Once, for the PR summary comment |
+| Voice pass (optional) | [editorial-owner](../../../.apm/agents/editorial-owner.agent.md) | Only when >20 edits to keep tone coherent |
+| Final synthesis | [cdo](../../../.apm/agents/cdo.agent.md) | Once, for the PR summary comment |
 
 The per-scope subagent prompt that composes `python-architect` +
 `doc-writer` is in `assets/subagent-prompt-template.md` -- the

--- a/.agents/skills/docs-sync/SKILL.md
+++ b/.agents/skills/docs-sync/SKILL.md
@@ -44,14 +44,14 @@ edit-in-place), plus optional label sweeps.
 
 | Role | Agent | Always active? |
 |---|---|---|
-| Classifier | [doc-analyser](../../agents/doc-analyser.agent.md) inside [docs-impact-classifier](../docs-impact-classifier/SKILL.md) | Yes (every run) |
-| Localizer | [docs-impact-localizer](../docs-impact-localizer/SKILL.md) | Only on `in_place` verdict |
-| Architect | [docs-impact-architect](../docs-impact-architect/SKILL.md) | Only on `structural` verdict |
-| Writer | [doc-writer](../../agents/doc-writer.agent.md) | Per candidate page (fan-out) |
-| Verifier | [python-architect](../../agents/python-architect.agent.md) | Per candidate page (fan-out, S7) |
-| Editorial | [editorial-owner](../../agents/editorial-owner.agent.md) | Once across all redrafts |
-| Growth | [oss-growth-hacker](../../agents/oss-growth-hacker.agent.md) | Once across all redrafts |
-| Synthesizer | [cdo](../../agents/cdo.agent.md) | Once, with ALIGNMENT LOOP up to 3 redrafts |
+| Classifier | [doc-analyser](../../../.apm/agents/doc-analyser.agent.md) inside [docs-impact-classifier](../../../.apm/skills/docs-impact-classifier/SKILL.md) | Yes (every run) |
+| Localizer | [docs-impact-localizer](../../../.apm/skills/docs-impact-localizer/SKILL.md) | Only on `in_place` verdict |
+| Architect | [docs-impact-architect](../../../.apm/skills/docs-impact-architect/SKILL.md) | Only on `structural` verdict |
+| Writer | [doc-writer](../../../.apm/agents/doc-writer.agent.md) | Per candidate page (fan-out) |
+| Verifier | [python-architect](../../../.apm/agents/python-architect.agent.md) | Per candidate page (fan-out, S7) |
+| Editorial | [editorial-owner](../../../.apm/agents/editorial-owner.agent.md) | Once across all redrafts |
+| Growth | [oss-growth-hacker](../../../.apm/agents/oss-growth-hacker.agent.md) | Once across all redrafts |
+| Synthesizer | [cdo](../../../.apm/agents/cdo.agent.md) | Once, with ALIGNMENT LOOP up to 3 redrafts |
 
 ## Topology
 

--- a/.agents/skills/oss-growth/SKILL.md
+++ b/.agents/skills/oss-growth/SKILL.md
@@ -9,7 +9,7 @@ description: >-
 
 # OSS Growth Skill
 
-[OSS growth hacker persona](../../agents/oss-growth-hacker.agent.md)
+[OSS growth hacker persona](../../../.apm/agents/oss-growth-hacker.agent.md)
 
 ## When to activate
 

--- a/.agents/skills/python-architecture/SKILL.md
+++ b/.agents/skills/python-architecture/SKILL.md
@@ -7,7 +7,7 @@ description: >
 
 # Python Architecture Skill
 
-[Python architect persona](../../agents/python-architect.agent.md)
+[Python architect persona](../../../.apm/agents/python-architect.agent.md)
 
 ## When to activate
 

--- a/.agents/skills/supply-chain-security/SKILL.md
+++ b/.agents/skills/supply-chain-security/SKILL.md
@@ -9,7 +9,7 @@ description: >-
 
 # Supply Chain Security Skill
 
-[Supply chain security expert persona](../../agents/supply-chain-security-expert.agent.md)
+[Supply chain security expert persona](../../../.apm/agents/supply-chain-security-expert.agent.md)
 
 ## When to activate
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,13 +265,15 @@ jobs:
         uv run ./scripts/build-binary.sh
 
   # Dogfood the audit-only CI gate we ship and document to users:
-  #   - Gate A (consumer-side): `apm audit --ci --no-drift` -- lockfile /
-  #     content-integrity check. setup-only: true keeps managed files
-  #     untouched so the SHA-256 content-integrity check can detect tampered
-  #     files. The drift check (install-replay comparison) is skipped
-  #     via --no-drift because there is no warm cache in a setup-only
-  #     run; content-integrity covers the same tamper signal.
-  # See microsoft/apm#883 for context. Tier 1 (no secrets needed).
+  #   - `apm audit --ci` -- the full producer+consumer gate. Runs the
+  #     lockfile / content-integrity checks AND the install-replay drift
+  #     check. The drift replay is cache-free here because every dependency
+  #     in apm.lock.yaml is local (self ``.apm/`` + in-repo ``packages/*``,
+  #     resolved from the checkout via path anchoring), so no warm cache or
+  #     prior ``apm install`` is required. setup-only: the committed managed
+  #     files are left untouched so both content-integrity (SHA-256 tamper)
+  #     and drift (replay vs committed tree, incl. ``.agents/skills/``) can
+  #     detect divergence. See microsoft/apm#883 and #1716. Tier 1.
   apm-self-check:
     name: APM Self-Check
     runs-on: ubuntu-24.04
@@ -288,33 +290,22 @@ jobs:
       # release. The published action (0.14.0 default; 0.16.1 too) false-flags
       # those deps on ref-consistency and no-orphaned-packages. `uv run` syncs
       # the project and runs the in-tree apm. No `apm install` is run, so the
-      # committed managed files are preserved and content-integrity can still
-      # detect tampered file hashes.
+      # committed managed files are preserved: content-integrity detects
+      # tampered file hashes and the drift replay compares the committed tree
+      # (including .agents/skills/) against a fresh cache-free replay.
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
 
-      # Gate A: lockfile / install fidelity (consumer-side).
-      # Verifies every file in lockfile.deployed_files exists, ref consistency
-      # between apm.yml and apm.lock.yaml, no orphan packages, and
-      # content-integrity (SHA-256 hashes against deployed_file_hashes in the
-      # lockfile) on deployed package content. --no-drift skips the
-      # install-replay because there is no warm cache (no apm install ran);
-      # content-integrity still catches tampered files.
-      - name: apm audit --ci --no-drift
-        run: uv run apm audit --ci --no-drift
+      # Full producer+consumer gate. Verifies every file in
+      # lockfile.deployed_files exists, ref consistency between apm.yml and
+      # apm.lock.yaml, no orphan packages, content-integrity (SHA-256 hashes
+      # against deployed_file_hashes in the lockfile) on deployed content, AND
+      # drift: a cache-free install-replay compared against the committed tree
+      # across every governed deploy root (.github AND .agents). The replay is
+      # cache-free because all deps are local (see job comment); dropping
+      # --no-drift is therefore safe and closes the gap where committed
+      # .agents/skills/ content could silently diverge from source (#1716).
+      - name: apm audit --ci
+        run: uv run apm audit --ci
 
-      # Gate B: regeneration drift (producer-side) -- legacy bash fallback.
-      # NOTE: No `apm install` runs in this job, so this step is a guaranteed
-      # no-op: the working tree is unchanged and the git status check always
-      # finds nothing. It is kept so the pattern is visible; a full
-      # install+audit workflow would rely on this step to detect hand-edits
-      # to regenerated .github/ files.
-      - name: Check APM integration drift (legacy bash fallback, see #1071)
-        run: |
-          if [ -n "$(git status --porcelain -- .github/ .claude/ .cursor/ .opencode/)" ]; then
-            echo "::error::APM integration files are out of date."
-            echo "Run 'apm install' locally (with .github/ present) and commit the result."
-            git --no-pager diff -- .github/ .claude/ .cursor/ .opencode/
-            exit 1
-          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm audit` now detects drift and tampering in committed deployed skill
+  bundles under `.agents/skills/**`. The lockfile integrity manifest is now
+  target-complete (per-file `deployed_files` + `deployed_file_hashes` for every
+  committed file-based deploy target, not just one), the drift differ walks each
+  primitive's `deploy_root`, and the `apm-self-check` CI job runs the drift gate
+  (dropped `--no-drift`). Previously a multi-target deploy left the manifest
+  single-target, so deployed skill content could silently diverge from its
+  `packages/**` / `.apm/**` source with every gate staying green. (by
+  @danielmeppiel, closes #1716)
 - `apm install` now falls back to an AAD bearer token (via `az login`) when no
   `ADO_APM_PAT` is configured for Azure DevOps file downloads, and fail-closes
   when ADO returns an interactive HTML sign-in page with HTTP 200 instead of

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -427,14 +427,14 @@ local_deployed_files:
 - .github/instructions/python.instructions.md
 - .github/instructions/tests.instructions.md
 local_deployed_file_hashes:
-  .agents/skills/apm-spec-guardian/SKILL.md: sha256:72239a2347c0e36ac8a8a774f658e066e37d1823a0bf54d58096a044425fd1ee
+  .agents/skills/apm-spec-guardian/SKILL.md: sha256:5e2b98792b458ca946d3bfc06a1e0c661f9a0dc05a4606602eb71d7d8afae4dd
   .agents/skills/apm-spec-guardian/assets/comment-template.md: sha256:8f5703aa98d1036d2418ffa45eac9d0270504dac33f3e9b1892884a9d48da1a6
   .agents/skills/apm-spec-guardian/assets/linter-checklist.md: sha256:4b71113da805c5504b4d74029f3113402044bc7e5c48abd010c0b8df3f18938b
   .agents/skills/apm-spec-guardian/assets/panelist-return-schema.json: sha256:bb66b270394c386665c6b93d83befe05ce9f8206abf8d656079c29d65729fefd
   .agents/skills/apm-spec-guardian/assets/synthesizer-return-schema.json: sha256:e6e2771f2fe8578e72d12e51edcc3817717f8a0bbef66d8a8a5c556f0dce06d7
-  .agents/skills/apm-strategy/SKILL.md: sha256:a529560f4229bd45fc240d7e31f08ed6baa4a7176e5ef664665b1ff039405b43
-  .agents/skills/auth/SKILL.md: sha256:ddca1dcf2be047ba68c3f700c0b4d59cd88bf2b9f44ee50879f59742173250cc
-  .agents/skills/cli-logging-ux/SKILL.md: sha256:892879f075ab74ebf6e361e804f8d66a6041ea7e5a11640193c71fffa8cbe51b
+  .agents/skills/apm-strategy/SKILL.md: sha256:6c7fbc821fef930ab76764c7b33d55bd181f31cdd406cff5ce7cf14d1071c2ef
+  .agents/skills/auth/SKILL.md: sha256:bf1039cb63dbb968d50dbf4a9e4ceec9a4c30e40e8dd666d404f1c39eda55bc0
+  .agents/skills/cli-logging-ux/SKILL.md: sha256:b04d5282a9f21b33c75ac98c41c7eab7e562eafea8c89bbb5732d9956958fe7c
   .agents/skills/cut-release/SKILL.md: sha256:07c15054e54679c07c5798ccad9b4348399beb8de3aac11bc1002ad1c07b6b9a
   .agents/skills/cut-release/assets/entry-sanitizer.md: sha256:b78d605f1bb17b042681b678e07a6431209ae11934ea320e0b573da313649743
   .agents/skills/cut-release/assets/pr-body-template.md: sha256:8034ad7d64a1f2a9e8677d332ffa1ebbf19071f3b30ba6ecdda660c82bb11917
@@ -443,8 +443,8 @@ local_deployed_file_hashes:
   .agents/skills/cut-release/scripts/bump-version.sh: sha256:bc382b5024f415998a3d66689a36596f0458e0a3c79370e96705477a5672a1d4
   .agents/skills/cut-release/scripts/list-changes-since-tag.sh: sha256:4aaacc7f61ca85be9776e921d02a67112569b370d31b581d045e0c3dc941a071
   .agents/skills/cut-release/scripts/verify-lint-mirror.sh: sha256:ab3f4a9ebc8f2b8c357c4cf81e0ada3be093cfc94c06703805d56c87f6fd7ecc
-  .agents/skills/devx-ux/SKILL.md: sha256:7b8ce1ca7a1a43cafbf32ff2dc01e023f4720c4900f932209116b495ea999fe8
-  .agents/skills/docs-corpus-audit/SKILL.md: sha256:8eabe182ebd6dbde1eb2a98a46db33c2fa12312e5da00c11ee30c2299d61194f
+  .agents/skills/devx-ux/SKILL.md: sha256:e66de2f844eebbfccf641b1a6fdf0ff9bb8c476364bda87266ce47f7ebfa7e5a
+  .agents/skills/docs-corpus-audit/SKILL.md: sha256:d20498ee8c1a38553303e23fc2f184c59fab624d1f701839f00dc7b291db3afb
   .agents/skills/docs-corpus-audit/assets/panelist-return-schema.json: sha256:720e2d7a7a51b23bda19feff90072c64dc5322916218f1030e4fd9e388b34f4b
   .agents/skills/docs-corpus-audit/assets/subagent-prompt-template.md: sha256:19799c05fae7873c02d6183294ebf6e5f29372bc393a19f1d400f5ed36251760
   .agents/skills/docs-corpus-audit/evals/README.md: sha256:6cd4924f82e8192f3b0c76aaa086ee6da5055f9f807dda9252842b0b59fb4c8f
@@ -635,16 +635,16 @@ local_deployed_file_hashes:
   .agents/skills/docs-impact-architect/SKILL.md: sha256:3bc13d5ac9e59b094573565ef5fd07cdbf355b6ba64235e399e2f72b2ba587c6
   .agents/skills/docs-impact-classifier/SKILL.md: sha256:3540bb7062835ba254d971be636a60763448aa6b7e0dd1b7624d959c9495e6c2
   .agents/skills/docs-impact-localizer/SKILL.md: sha256:1a46fb1da757ace60ed4bd80a308136a4c0e7ecd62447f1581a51664993dbe0e
-  .agents/skills/docs-sync/SKILL.md: sha256:b535912a50121370ecf5a6b4458f3725a87f665405d0705d0ec519bc27125600
+  .agents/skills/docs-sync/SKILL.md: sha256:2214d7ce6770f3e8cfe53a3b7de6efccceb5810db3e78da79de7a970a4be23bd
   .agents/skills/docs-sync/assets/advisory-comment-template.md: sha256:9abbd82239925a85a2b2c08d84130259044660c8114245b7e939d4c761c0053e
   .agents/skills/docs-sync/assets/classifier-return-schema.json: sha256:9e9fda0c39bfe684f367f4c89e69814d43a23e68c18a3603e9d212659c1a8689
   .agents/skills/docs-sync/assets/panelist-return-schema.json: sha256:6e661b1042e8475e15fcc943a290891f041509a903dfa770a6e0ef4bc793326d
   .agents/skills/docs-sync/evals/README.md: sha256:7dbf5dfa89e78f7d5a3214b01bb5fabfee59c2979827c2a0c72f008fa9c69de5
   .agents/skills/docs-sync/evals/content-evals.json: sha256:31a8b26677f84337775b81971145e12d327c6b65dfc21b2c6f5b886462410dc2
   .agents/skills/docs-sync/evals/trigger-evals.json: sha256:b0da21a8a6e588676247a9a15d792ef6596389f16ae100f83fa423ee47992501
-  .agents/skills/oss-growth/SKILL.md: sha256:692be91a6704ff2e428e851f33b1f340ee9aa42beafabf62c2108cace7dae674
-  .agents/skills/python-architecture/SKILL.md: sha256:acb858a97de695f98fba01af588f317a86833cc98c3405d6c5eea0d063f00021
-  .agents/skills/supply-chain-security/SKILL.md: sha256:60e87189fc9ebea724a1b9b7cf2c6c5c11458ae3c3c67d7a9ede6d0377177095
+  .agents/skills/oss-growth/SKILL.md: sha256:90b5d0369032de850f2255910f4cf5caafb7d60f07bda8a2146d394bfa459918
+  .agents/skills/python-architecture/SKILL.md: sha256:e4a209765072f75cee6dc5fbe95d9924055e2c5d59c804c8075f887795c83fa9
+  .agents/skills/supply-chain-security/SKILL.md: sha256:55ef10cd0f6b68e0db5a435a79851c055eab74d93fd552c6626df631deb51df4
   .github/agents/agentic-workflows.agent.md: sha256:d1ea2d038e2af8be11d6c95b3213b03b9777fae46f0438efa95d5a803e6c3765
   .github/agents/apm-ceo.agent.md: sha256:484da64428ea46a6183dffd3f30c9fc5fc5c747639c0c79e55be69dba0899323
   .github/agents/apm-primitives-architect.agent.md: sha256:6c01eab74ba18d70f21d45010d636cc6535d63cee81da12e61898d8036e0b028

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,40 +1,675 @@
 lockfile_version: '1'
-generated_at: '2026-06-02T18:54:45.470196+00:00'
-apm_version: 0.16.1
+generated_at: '2026-06-09T16:13:13.873738+00:00'
+apm_version: 0.18.0
 dependencies:
 - repo_url: _local/apm-issue-autopilot
   package_type: apm_package
   deployed_files:
+  - .agents/skills/apm-issue-autopilot
+  - .agents/skills/apm-issue-autopilot/SKILL.md
+  - .agents/skills/apm-issue-autopilot/assets/acceptance-observer.md
+  - .agents/skills/apm-issue-autopilot/assets/autopilot-triage-schema.json
+  - .agents/skills/apm-issue-autopilot/assets/confidence-gate-rubric.md
+  - .agents/skills/apm-issue-autopilot/assets/final-report-template.md
+  - .agents/skills/apm-issue-autopilot/assets/ground-truth-table.md
+  - .agents/skills/apm-issue-autopilot/assets/ideate-prompt.md
+  - .agents/skills/apm-issue-autopilot/assets/implement-bug.md
+  - .agents/skills/apm-issue-autopilot/assets/implement-docs.md
+  - .agents/skills/apm-issue-autopilot/assets/implement-feature.md
+  - .agents/skills/apm-issue-autopilot/assets/implement-refactor.md
+  - .agents/skills/apm-issue-autopilot/assets/model-routing.md
+  - .agents/skills/apm-issue-autopilot/assets/plan-panel-prompt.md
+  - .agents/skills/apm-issue-autopilot/assets/plan-schema.json
+  - .agents/skills/apm-issue-autopilot/assets/solution-pipeline-prompt.md
+  - .agents/skills/apm-issue-autopilot/assets/task-implement-prompt.md
+  - .agents/skills/apm-issue-autopilot/assets/triage-digest-template.md
+  - .agents/skills/apm-issue-autopilot/assets/triage-prompt.md
+  - .agents/skills/apm-issue-autopilot/assets/wave-gate-rubric.md
+  - .agents/skills/apm-issue-autopilot/evals/.gitignore
+  - .agents/skills/apm-issue-autopilot/evals/README.md
+  - .agents/skills/apm-issue-autopilot/evals/content/gate-escalate-doubtful.json
+  - .agents/skills/apm-issue-autopilot/evals/content/gate-proceed-clean-accept.json
+  - .agents/skills/apm-issue-autopilot/evals/content/mixed-types-one-review.json
+  - .agents/skills/apm-issue-autopilot/evals/evals.json
+  - .agents/skills/apm-issue-autopilot/evals/real-task-refinement.md
+  - .agents/skills/apm-issue-autopilot/evals/triggers.json
+  - .agents/skills/apm-issue-autopilot/scripts/run_evals.py
   - copilot-app-db://workflows/apm--_local--apm-issue-autopilot--apm-issue-autopilot
+  deployed_file_hashes:
+    .agents/skills/apm-issue-autopilot/SKILL.md: sha256:428fd804932b75977ee72ec9b820e0d300190cda095f4f38343f27dedbde6ef2
+    .agents/skills/apm-issue-autopilot/assets/acceptance-observer.md: sha256:e4ddab439f62bb372f5ad608775294dd44653ef475eeca8ef5517af7f5e42699
+    .agents/skills/apm-issue-autopilot/assets/autopilot-triage-schema.json: sha256:35d672ce4584fb576b3c16ce4dffbe29de6b3f6711725855b3c6eb0f338d464d
+    .agents/skills/apm-issue-autopilot/assets/confidence-gate-rubric.md: sha256:2d6eff739cd4ac1eb4533868cbdcf0c44d469ae247447f29595d05858b2d8a97
+    .agents/skills/apm-issue-autopilot/assets/final-report-template.md: sha256:8088fe8f5bb9fd1ec93fbe806971465bb7f6850019af5be1a329e252d4818df2
+    .agents/skills/apm-issue-autopilot/assets/ground-truth-table.md: sha256:00dd5a35ef0b39ba299e5fcd7f9ca682fc322792ec20440f7861edd39997d40e
+    .agents/skills/apm-issue-autopilot/assets/ideate-prompt.md: sha256:abab1a5e2a765229d1cdd215b90c57036cdb4b2764866b68399eb81a51362ddc
+    .agents/skills/apm-issue-autopilot/assets/implement-bug.md: sha256:4c74c8dfa0f98987ab5beede16d3e8c0e8113fac60955826d2ed61949624bcc5
+    .agents/skills/apm-issue-autopilot/assets/implement-docs.md: sha256:81f2f9b617587df4a6f422838b05c63a5e05e0c8afd6d80952a9aa5cdad88b5a
+    .agents/skills/apm-issue-autopilot/assets/implement-feature.md: sha256:394b25a0b0b41b0f99b250590af782968c0f25673c156d0b87d4f1f9b205de75
+    .agents/skills/apm-issue-autopilot/assets/implement-refactor.md: sha256:5175ea7edefdaaf787d1701ba6f7fce8433d04134718d9a6445ca524ececa3bc
+    .agents/skills/apm-issue-autopilot/assets/model-routing.md: sha256:4d1ffaf63fab75a7a7de265ff77d457c0636939d36a373dc9ce485ba76275209
+    .agents/skills/apm-issue-autopilot/assets/plan-panel-prompt.md: sha256:422daafc8fcdf26f1096787075b2e8c15722df6b51e1d1784ea3b1435809b09f
+    .agents/skills/apm-issue-autopilot/assets/plan-schema.json: sha256:f766382fbac2a2b99c0dad1d0327659103c4482cc155854ea7ef2e3c82fce8f2
+    .agents/skills/apm-issue-autopilot/assets/solution-pipeline-prompt.md: sha256:812487116b89e66414562312992204dfb3132cc5e9265392b718d78e33cd9973
+    .agents/skills/apm-issue-autopilot/assets/task-implement-prompt.md: sha256:397ab60c270f0312a3ddaac0fbc03e853fa16552a962f6b2ebca5ed27bab2818
+    .agents/skills/apm-issue-autopilot/assets/triage-digest-template.md: sha256:78c2e7be93543122e485eb494a2b50ecac6e18d7e077a9e8edde12b478242ca9
+    .agents/skills/apm-issue-autopilot/assets/triage-prompt.md: sha256:5136ab42be575b58730a8d8a1614394813014ca74e2d6df3e56948e94c419470
+    .agents/skills/apm-issue-autopilot/assets/wave-gate-rubric.md: sha256:a8bf5270c8d63c1d9ffcf0b3f18ba22d591b062e7b969982320150986ab211cd
+    .agents/skills/apm-issue-autopilot/evals/.gitignore: sha256:f370ad043ec0c98a166fd98646c3b94280ed78bc996223b6cca2ba936f7c6781
+    .agents/skills/apm-issue-autopilot/evals/README.md: sha256:79bb6636a89edce40fc24bde9576e351de57a0f828181def37c423a284cd1ef8
+    .agents/skills/apm-issue-autopilot/evals/content/gate-escalate-doubtful.json: sha256:20bcabed2b58be8552421f68e9522cea3a1206a1796c26d2f77e65a3982d438f
+    .agents/skills/apm-issue-autopilot/evals/content/gate-proceed-clean-accept.json: sha256:f304138fe9aafe48989710bd2c68238342b32e643281f9747c0678b7cb1ae244
+    .agents/skills/apm-issue-autopilot/evals/content/mixed-types-one-review.json: sha256:df2b1b66e1ec64743cc8d66e465e5cca931de6fb51974cc51c81908efad58eb5
+    .agents/skills/apm-issue-autopilot/evals/evals.json: sha256:a94ed339f171e7ca557df3e7ed10c8e55f9a14befcba940b7263c9d7fe4d8ca1
+    .agents/skills/apm-issue-autopilot/evals/real-task-refinement.md: sha256:183d6d7270dc5f865a02d42643ba0afbae9046509f0e3b2481559fc9c1dcb64a
+    .agents/skills/apm-issue-autopilot/evals/triggers.json: sha256:59bbb6e937d6de8db69aee4478989fccff561c77e86cc6894e7994eb841defd0
+    .agents/skills/apm-issue-autopilot/scripts/run_evals.py: sha256:8f4580cb2bdb88e7e570e4feb60cbf244d7fbe3e8217a8eadfd9dff2c763b615
   source: local
   local_path: ./packages/apm-issue-autopilot
 - repo_url: _local/batch-bug-shepherd
   package_type: apm_package
   deployed_files:
+  - .agents/skills/batch-bug-shepherd
+  - .agents/skills/batch-bug-shepherd/SKILL.md
+  - .agents/skills/batch-bug-shepherd/assets/final-report-template.md
+  - .agents/skills/batch-bug-shepherd/assets/fix-prompt.md
+  - .agents/skills/batch-bug-shepherd/assets/ground-truth-table.md
+  - .agents/skills/batch-bug-shepherd/assets/progress-diagram.md
+  - .agents/skills/batch-bug-shepherd/assets/strategic-alignment-prompt.md
+  - .agents/skills/batch-bug-shepherd/assets/triage-prompt.md
+  - .agents/skills/batch-bug-shepherd/assets/verdict-schema.json
+  - .agents/skills/batch-bug-shepherd/evals/.gitignore
+  - .agents/skills/batch-bug-shepherd/evals/README.md
+  - .agents/skills/batch-bug-shepherd/evals/content/sweep-bug-queue.json
+  - .agents/skills/batch-bug-shepherd/evals/content/three-issues-mixed.json
+  - .agents/skills/batch-bug-shepherd/evals/evals.json
+  - .agents/skills/batch-bug-shepherd/evals/fixtures/sweep-bug-queue.with_skill.md
+  - .agents/skills/batch-bug-shepherd/evals/fixtures/sweep-bug-queue.without_skill.md
+  - .agents/skills/batch-bug-shepherd/evals/fixtures/three-issues-mixed.with_skill.md
+  - .agents/skills/batch-bug-shepherd/evals/fixtures/three-issues-mixed.without_skill.md
+  - .agents/skills/batch-bug-shepherd/evals/triggers.json
+  - .agents/skills/batch-bug-shepherd/references/invariants.md
+  - .agents/skills/batch-bug-shepherd/references/strategic-alignment-gate.md
+  - .agents/skills/batch-bug-shepherd/scripts/run_evals.py
   - copilot-app-db://workflows/apm--_local--batch-bug-shepherd--batch-bug-shepherd
+  deployed_file_hashes:
+    .agents/skills/batch-bug-shepherd/SKILL.md: sha256:a9d4c3b924e7a62eaf8f968cd78df2676a49fef5b47b892d149f4590733f6816
+    .agents/skills/batch-bug-shepherd/assets/final-report-template.md: sha256:d843d23d44c91eb488746b92b055ec0f507a646670bd63246127e9ae241037cd
+    .agents/skills/batch-bug-shepherd/assets/fix-prompt.md: sha256:02c4e450930efc7c306db7d9b6f7734af4976d72ac782ca432d2a20150a5366a
+    .agents/skills/batch-bug-shepherd/assets/ground-truth-table.md: sha256:981ebeee98596beb6a00db6edb35a8e871acdd52a938faa8d8915edfd01ba15b
+    .agents/skills/batch-bug-shepherd/assets/progress-diagram.md: sha256:72c4606899f50b0761a7683f6ab17878472bc45b18fe03869aae65e3bd6a7bb2
+    .agents/skills/batch-bug-shepherd/assets/strategic-alignment-prompt.md: sha256:67db0bb51d6cbdafad4ea8224ab2012f02e6341b2fd4eb7a09b2a24cc9cb4d7e
+    .agents/skills/batch-bug-shepherd/assets/triage-prompt.md: sha256:51bab548ac85044400b77858c6a1554f59bda197c388d9a8546076d87380b060
+    .agents/skills/batch-bug-shepherd/assets/verdict-schema.json: sha256:d82b7ed0791b89617be965097fce1ace9ec6f6b5a33d9a1567cdf4b3651cd83a
+    .agents/skills/batch-bug-shepherd/evals/.gitignore: sha256:f370ad043ec0c98a166fd98646c3b94280ed78bc996223b6cca2ba936f7c6781
+    .agents/skills/batch-bug-shepherd/evals/README.md: sha256:7d0a5c983612953289a8e34c0b95995ccad7273653c4ab145c3f10b9adafa905
+    .agents/skills/batch-bug-shepherd/evals/content/sweep-bug-queue.json: sha256:8213fc770f8f373281d310082c0e44939f7f43d6c96b9d9a45b3175b490f2a59
+    .agents/skills/batch-bug-shepherd/evals/content/three-issues-mixed.json: sha256:40af3256645f7020019f897b4eea60d785e63d484ddad32c3238dfa37ea4007f
+    .agents/skills/batch-bug-shepherd/evals/evals.json: sha256:0b47a8ea4c49c375a575d0f44d488b65c0d797bff5022ebb79746808495dab26
+    .agents/skills/batch-bug-shepherd/evals/fixtures/sweep-bug-queue.with_skill.md: sha256:1dfdd8942667640929715b2de55fbfb8e22abb9d0c75819a55ff96c6b4659fe1
+    .agents/skills/batch-bug-shepherd/evals/fixtures/sweep-bug-queue.without_skill.md: sha256:83a2a11ac6dc2a188bb95a92f24dc7f94568f8af30ec4979ae85f52bd3102ee6
+    .agents/skills/batch-bug-shepherd/evals/fixtures/three-issues-mixed.with_skill.md: sha256:5dba73e00c9e9bbdcc915b40a91738d0bef9e52b89ec8ff988dcda0f637bc5b0
+    .agents/skills/batch-bug-shepherd/evals/fixtures/three-issues-mixed.without_skill.md: sha256:8bf17d4cdc3c10beb54bcb1348efb4a111846d49d9548ca714e4354b4eccff22
+    .agents/skills/batch-bug-shepherd/evals/triggers.json: sha256:f195dc4b80b66f23a5fd9cfc6c60cf3fa1bba5b09b97f044d31f8dae27445470
+    .agents/skills/batch-bug-shepherd/references/invariants.md: sha256:e2eec0a2e648819bc79c08384335e15e13000d67012641b90dfb1a70e967439a
+    .agents/skills/batch-bug-shepherd/references/strategic-alignment-gate.md: sha256:66613a8344411a2f9d5147b4acea798887bed20132ffd27bac9b3f5ba6bb65ed
+    .agents/skills/batch-bug-shepherd/scripts/run_evals.py: sha256:ecc003164e65cb002f301a7cdff9c0a2e39eddc35a81ede63da8934519e483c9
   source: local
   local_path: ./packages/batch-bug-shepherd
 - repo_url: _local/apm-triage-panel
   depth: 2
   resolved_by: _local/apm-issue-autopilot
   package_type: hybrid
+  deployed_files:
+  - .agents/skills/apm-triage-panel
+  - .agents/skills/apm-triage-panel/SKILL.md
+  - .agents/skills/apm-triage-panel/apm.yml
+  - .agents/skills/apm-triage-panel/assets/triage-template.md
+  deployed_file_hashes:
+    .agents/skills/apm-triage-panel/SKILL.md: sha256:2ef70329aefd0cbec1302aad3975f6caa0a27654d58005bba622ef1021267d1e
+    .agents/skills/apm-triage-panel/apm.yml: sha256:e8b7946f433abdc8342241483963bac2895182916ea66f5aa39497d00c7930a4
+    .agents/skills/apm-triage-panel/assets/triage-template.md: sha256:69a027959eaec5335668e087c86babd814ba20cf21662ed524cf285b178e21d1
   source: local
   local_path: ../apm-triage-panel
 - repo_url: _local/pr-description-skill
   depth: 2
   resolved_by: _local/apm-issue-autopilot
   package_type: hybrid
+  deployed_files:
+  - .agents/skills/pr-description-skill
+  - .agents/skills/pr-description-skill/SKILL.md
+  - .agents/skills/pr-description-skill/apm.yml
+  - .agents/skills/pr-description-skill/assets/mermaid-conventions.md
+  - .agents/skills/pr-description-skill/assets/pr-body-template.md
+  - .agents/skills/pr-description-skill/assets/scenario-evidence-rubric.md
+  - .agents/skills/pr-description-skill/assets/section-rubric.md
+  - .agents/skills/pr-description-skill/evals/.gitignore
+  - .agents/skills/pr-description-skill/evals/README.md
+  - .agents/skills/pr-description-skill/evals/content/auth-refactor.json
+  - .agents/skills/pr-description-skill/evals/content/dep-bump.json
+  - .agents/skills/pr-description-skill/evals/content/docs-only.json
+  - .agents/skills/pr-description-skill/evals/evals.json
+  - .agents/skills/pr-description-skill/evals/fixtures/auth-refactor__with_skill.md
+  - .agents/skills/pr-description-skill/evals/fixtures/auth-refactor__without_skill.md
+  - .agents/skills/pr-description-skill/evals/fixtures/dep-bump__with_skill.md
+  - .agents/skills/pr-description-skill/evals/fixtures/dep-bump__without_skill.md
+  - .agents/skills/pr-description-skill/evals/fixtures/docs-only__with_skill.md
+  - .agents/skills/pr-description-skill/evals/fixtures/docs-only__without_skill.md
+  - .agents/skills/pr-description-skill/evals/results/.gitkeep
+  - .agents/skills/pr-description-skill/evals/triggers.json
+  - .agents/skills/pr-description-skill/scripts/run_evals.py
+  deployed_file_hashes:
+    .agents/skills/pr-description-skill/SKILL.md: sha256:d07254e9d0b95ea52d1a81d3262ca42da8c4c51d801eac4f11b6bc454cfb01a0
+    .agents/skills/pr-description-skill/apm.yml: sha256:ee9bb48581e62279708a9a12dc57174c9f5f7d347a384e4ca6b99c050c63879d
+    .agents/skills/pr-description-skill/assets/mermaid-conventions.md: sha256:3d9c7adf95d40db00833ec087d699a7d04b3d799e9b9d07271cf2ae7d51524ca
+    .agents/skills/pr-description-skill/assets/pr-body-template.md: sha256:aaeb885fbfa87364724f575eb150c9c39dc3cb60ab0459972e76185df9c98f97
+    .agents/skills/pr-description-skill/assets/scenario-evidence-rubric.md: sha256:bbb386b6f48974bbb78a380fd4674ed7a3a81810a6c2136e30c80158153596ae
+    .agents/skills/pr-description-skill/assets/section-rubric.md: sha256:f07fbbc5c741c4fd30f32edec985d8301d20e3deebb1761dd92b04da51c5e42d
+    .agents/skills/pr-description-skill/evals/.gitignore: sha256:dc810cf3561d22d2d47b89fd0697de46aff0068819b3514577842cb2a2a1c332
+    .agents/skills/pr-description-skill/evals/README.md: sha256:92b4529515917d25cbf5e597d1d46751e602dd4eb80be20a97ac81597f410cd0
+    .agents/skills/pr-description-skill/evals/content/auth-refactor.json: sha256:86791ada2f4983fde709237eaae9ef9c5a0f87a28f14e8b0f26b4b7e5b0e73c9
+    .agents/skills/pr-description-skill/evals/content/dep-bump.json: sha256:5136278ecf83a6c3a618176810ef62634cc988527dcdb8bd343ae83278f9e1d7
+    .agents/skills/pr-description-skill/evals/content/docs-only.json: sha256:78a6f98f939b1b8e0efa1b67a57a4b9008ddffd3b4f02fbde4f9843c4f29b39a
+    .agents/skills/pr-description-skill/evals/evals.json: sha256:1d137370f60955469a089a7ef085371aa14bbb74a80675957f4d6e0a694252cc
+    .agents/skills/pr-description-skill/evals/fixtures/auth-refactor__with_skill.md: sha256:b5ebacb04c4ace19e0d634e9b9104ef70b72330afb9f29ac0de07a03f1e78628
+    .agents/skills/pr-description-skill/evals/fixtures/auth-refactor__without_skill.md: sha256:81c42403d4f1406ba2689106bb6e1cdf0a74f1921681f6e096cefac0c46efd46
+    .agents/skills/pr-description-skill/evals/fixtures/dep-bump__with_skill.md: sha256:60df233958541ed42b94c1751a3d2d99324ec83f263fa0becc3abcb4a682ee91
+    .agents/skills/pr-description-skill/evals/fixtures/dep-bump__without_skill.md: sha256:1410a89d81b6745d14242181197d2d05ec5aba5078f1ad3ae702e3341a3fc798
+    .agents/skills/pr-description-skill/evals/fixtures/docs-only__with_skill.md: sha256:e4ca53c7dc8c8a65f4945e2e4e4cc878b433c5662d13c5b613d957d6d505029c
+    .agents/skills/pr-description-skill/evals/fixtures/docs-only__without_skill.md: sha256:7e790d6711b8a33702c6bf0f7486e1928c58c60b4dad0a998c570a07d6a05fec
+    .agents/skills/pr-description-skill/evals/results/.gitkeep: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    .agents/skills/pr-description-skill/evals/triggers.json: sha256:6762c7f071195491700cc59ce5329ff185b0493682c93efdcf01db8fb522bbe4
+    .agents/skills/pr-description-skill/scripts/run_evals.py: sha256:a1792f8cb95b4fb37a4133af079908e2a3b5643c1a81d97e4dcda399bac069a2
   source: local
   local_path: ../pr-description-skill
 - repo_url: _local/shepherd-driver
   depth: 2
   resolved_by: _local/apm-issue-autopilot
   package_type: hybrid
+  deployed_files:
+  - .agents/skills/shepherd-driver
+  - .agents/skills/shepherd-driver/SKILL.md
+  - .agents/skills/shepherd-driver/apm.yml
+  - .agents/skills/shepherd-driver/assets/ci-recovery-checklist.md
+  - .agents/skills/shepherd-driver/assets/completion-schema.json
+  - .agents/skills/shepherd-driver/assets/conflict-resolution-prompt.md
+  - .agents/skills/shepherd-driver/assets/copilot-classification-prompt.md
+  - .agents/skills/shepherd-driver/assets/fold-vs-defer-rubric.md
+  - .agents/skills/shepherd-driver/assets/pr-comment-templates.md
+  - .agents/skills/shepherd-driver/assets/shepherd-driver-prompt.md
+  - .agents/skills/shepherd-driver/references/mergeability-gate.md
+  deployed_file_hashes:
+    .agents/skills/shepherd-driver/SKILL.md: sha256:654e08a073133ba09937e4244c7ad37cdc9b586e1b081ad3e180444122c00d73
+    .agents/skills/shepherd-driver/apm.yml: sha256:d53355a3862fee76c099f99eeb49ed6fd9ce1c24d648451ce9a2efdced9fda4b
+    .agents/skills/shepherd-driver/assets/ci-recovery-checklist.md: sha256:21801867a8459d9713e45efe68e612c4d22a2cb577c23eceab55cd855bbd23ef
+    .agents/skills/shepherd-driver/assets/completion-schema.json: sha256:9ede05a8c42de124688a899d599e8faacb83b4ed23fe91e317cf70c66e474eb4
+    .agents/skills/shepherd-driver/assets/conflict-resolution-prompt.md: sha256:453237e56043e4008c37c5a89d9da5e77a1fa46b028ea172321dcc39a737c679
+    .agents/skills/shepherd-driver/assets/copilot-classification-prompt.md: sha256:71c0ad6c5d2c422dcc7fc0c44e13d8b3b049b37c04418ade7daf9722fe115c1f
+    .agents/skills/shepherd-driver/assets/fold-vs-defer-rubric.md: sha256:50ece018b83c70508ca3fc4b3d267e39df2de4497938ce4aa56d3b49c594f75f
+    .agents/skills/shepherd-driver/assets/pr-comment-templates.md: sha256:24fe0ec64286c7b39037a5e93acfa607a43dbb4763d653f3955a1c4d65d68882
+    .agents/skills/shepherd-driver/assets/shepherd-driver-prompt.md: sha256:e9cfd182845efa6c33346b504b656ad2dd2dcc271c5535d8f3de9861bb01ebff
+    .agents/skills/shepherd-driver/references/mergeability-gate.md: sha256:90bf5cd838d1025dd0fa223a0843be926cd509c85c91ef683cc9bfc98b5e8785
   source: local
   local_path: ../shepherd-driver
 - repo_url: _local/apm-review-panel
   depth: 3
   resolved_by: _local/shepherd-driver
   package_type: hybrid
+  deployed_files:
+  - .agents/skills/apm-review-panel
+  - .agents/skills/apm-review-panel/SKILL.md
+  - .agents/skills/apm-review-panel/apm.yml
+  - .agents/skills/apm-review-panel/assets/ceo-return-schema.json
+  - .agents/skills/apm-review-panel/assets/panelist-return-schema.json
+  - .agents/skills/apm-review-panel/assets/recommendation-template.md
+  - .agents/skills/apm-review-panel/evals/README.md
+  - .agents/skills/apm-review-panel/evals/fixtures/01-ship-now-pr1084-shape.json
+  - .agents/skills/apm-review-panel/evals/fixtures/01-ship-now-pr1084-shape.rendered.md
+  - .agents/skills/apm-review-panel/evals/fixtures/02-needs-rework-shape.json
+  - .agents/skills/apm-review-panel/evals/fixtures/02-needs-rework-shape.rendered.md
+  - .agents/skills/apm-review-panel/evals/render_eval.py
+  - .agents/skills/apm-review-panel/evals/trigger-evals.json
+  deployed_file_hashes:
+    .agents/skills/apm-review-panel/SKILL.md: sha256:fe6a731933ce17d1bafd230817415994b16b0ca4a6743dd80cd1c90a45328af5
+    .agents/skills/apm-review-panel/apm.yml: sha256:80c403c4d3c59a91bb27b85650e21a466e9cd0cbc28e92bf0f3e53c6ea71cb2c
+    .agents/skills/apm-review-panel/assets/ceo-return-schema.json: sha256:d8707211968efb0471d083f880d5353d66a0eda84635e803a930f60c91837468
+    .agents/skills/apm-review-panel/assets/panelist-return-schema.json: sha256:e3cf2ae17e93dd934f2659ed77d2640ea9601fbe8698f63ba800edf046691f99
+    .agents/skills/apm-review-panel/assets/recommendation-template.md: sha256:ed973263897671ea04c980cb54c76b33aaa9bb7d1b5b24082df89b388d4329b8
+    .agents/skills/apm-review-panel/evals/README.md: sha256:40e7abb1fa15403a71505797e23dde8433f31ca70546657886c3f9760974bfb8
+    .agents/skills/apm-review-panel/evals/fixtures/01-ship-now-pr1084-shape.json: sha256:108fc261680f17bdade3e2bdf8e64fc908d16a37ec9c29c53169b394530bdd67
+    .agents/skills/apm-review-panel/evals/fixtures/01-ship-now-pr1084-shape.rendered.md: sha256:ca1fdd3cd24e0fd8ec15b37690c597921ebf1c872270166edb2727d54ee155d8
+    .agents/skills/apm-review-panel/evals/fixtures/02-needs-rework-shape.json: sha256:faa41c6c83c4a7955447bcb8fc0ad5a3b8afb4235db257462f649ba0a901913e
+    .agents/skills/apm-review-panel/evals/fixtures/02-needs-rework-shape.rendered.md: sha256:b69cd113a428b61d8bbb9381a85261b3ee3acd3f101c08d06419e26aab03bba8
+    .agents/skills/apm-review-panel/evals/render_eval.py: sha256:690baf6267775077ad011b98839eda1001e207bbae78a7a8454c4d39bb8a2864
+    .agents/skills/apm-review-panel/evals/trigger-evals.json: sha256:c715ba52cd2131f294c1cf685a10995a08e4ee6971f97cf5d36e09df28d3af91
   source: local
   local_path: ../apm-review-panel
+local_deployed_files:
+- .agents/skills/apm-spec-guardian
+- .agents/skills/apm-spec-guardian/SKILL.md
+- .agents/skills/apm-spec-guardian/assets/comment-template.md
+- .agents/skills/apm-spec-guardian/assets/linter-checklist.md
+- .agents/skills/apm-spec-guardian/assets/panelist-return-schema.json
+- .agents/skills/apm-spec-guardian/assets/synthesizer-return-schema.json
+- .agents/skills/apm-strategy
+- .agents/skills/apm-strategy/SKILL.md
+- .agents/skills/auth
+- .agents/skills/auth/SKILL.md
+- .agents/skills/cli-logging-ux
+- .agents/skills/cli-logging-ux/SKILL.md
+- .agents/skills/cut-release
+- .agents/skills/cut-release/SKILL.md
+- .agents/skills/cut-release/assets/entry-sanitizer.md
+- .agents/skills/cut-release/assets/pr-body-template.md
+- .agents/skills/cut-release/assets/semver-rubric.md
+- .agents/skills/cut-release/evals/evals.json
+- .agents/skills/cut-release/scripts/bump-version.sh
+- .agents/skills/cut-release/scripts/list-changes-since-tag.sh
+- .agents/skills/cut-release/scripts/verify-lint-mirror.sh
+- .agents/skills/devx-ux
+- .agents/skills/devx-ux/SKILL.md
+- .agents/skills/docs-corpus-audit
+- .agents/skills/docs-corpus-audit/SKILL.md
+- .agents/skills/docs-corpus-audit/assets/panelist-return-schema.json
+- .agents/skills/docs-corpus-audit/assets/subagent-prompt-template.md
+- .agents/skills/docs-corpus-audit/evals/README.md
+- .agents/skills/docs-corpus-audit/evals/content-evals.json
+- .agents/skills/docs-corpus-audit/evals/trigger-evals.json
+- .agents/skills/docs-corpus-audit/scripts/scan-cross-corpus-drift.sh
+- .agents/skills/docs-grounding-verifier
+- .agents/skills/docs-grounding-verifier/SKILL.md
+- .agents/skills/docs-grounding-verifier/assets/judge-prompt.md
+- .agents/skills/docs-grounding-verifier/evals/content-evals.json
+- .agents/skills/docs-grounding-verifier/evals/run-evals.sh
+- .agents/skills/docs-grounding-verifier/evals/runs/20260527-194228/seeded-corpus/drift-install-flag/page.md
+- .agents/skills/docs-grounding-verifier/evals/runs/20260527-194228/seeded-corpus/drift-install-flag/scenario.json
+- .agents/skills/docs-grounding-verifier/evals/runs/20260527-194228/seeded-corpus/drift-policy-reject/page.md
+- .agents/skills/docs-grounding-verifier/evals/runs/20260527-194228/seeded-corpus/drift-policy-reject/scenario.json
+- .agents/skills/docs-grounding-verifier/evals/runs/20260527-194228/seeded-corpus/drift-registry-resolver/page.md
+- .agents/skills/docs-grounding-verifier/evals/runs/20260527-194228/seeded-corpus/drift-registry-resolver/scenario.json
+- .agents/skills/docs-grounding-verifier/evals/runs/20260527-194228/trigger-prompts.txt
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/claims/copilot.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/claims/install.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/claims/pkgtypes.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/claims/policy.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/claims/registries.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c1.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c10.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c11.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c12.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c13.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c14.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c15.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c2.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c3.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c4.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c5.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c6.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c7.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c8.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c9.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/judge-batch-docs_src_content_docs_integrations_copilot-app_md.txt
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c1.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c10.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c11.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c12.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c13.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c14.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c15.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c2.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c3.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c4.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c5.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c6.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c7.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c8.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c9.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/install/judge-batch-docs_src_content_docs_reference_cli_install_md.txt
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c1.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c10.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c11.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c12.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c13.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c14.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c15.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c2.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c3.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c4.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c5.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c6.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c7.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c8.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c9.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/judge-batch-docs_src_content_docs_reference_package-types_md.txt
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c1.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c10.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c11.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c12.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c13.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c14.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c15.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c2.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c3.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c4.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c5.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c6.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c7.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c8.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c9.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/judge-batch-docs_src_content_docs_enterprise_apm-policy_md.txt
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c1.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c10.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c11.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c12.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c13.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c14.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c15.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c2.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c3.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c4.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c5.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c6.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c7.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c8.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c9.json
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/judge-batch-docs_src_content_docs_guides_registries_md.txt
+- .agents/skills/docs-grounding-verifier/evals/runs/proof/trigger-responses.json
+- .agents/skills/docs-grounding-verifier/evals/trigger-evals.json
+- .agents/skills/docs-grounding-verifier/scripts/extract-claims.py
+- .agents/skills/docs-grounding-verifier/scripts/retrieve-evidence.sh
+- .agents/skills/docs-grounding-verifier/scripts/verify-page.sh
+- .agents/skills/docs-impact-architect
+- .agents/skills/docs-impact-architect/SKILL.md
+- .agents/skills/docs-impact-classifier
+- .agents/skills/docs-impact-classifier/SKILL.md
+- .agents/skills/docs-impact-localizer
+- .agents/skills/docs-impact-localizer/SKILL.md
+- .agents/skills/docs-sync
+- .agents/skills/docs-sync/SKILL.md
+- .agents/skills/docs-sync/assets/advisory-comment-template.md
+- .agents/skills/docs-sync/assets/classifier-return-schema.json
+- .agents/skills/docs-sync/assets/panelist-return-schema.json
+- .agents/skills/docs-sync/evals/README.md
+- .agents/skills/docs-sync/evals/content-evals.json
+- .agents/skills/docs-sync/evals/trigger-evals.json
+- .agents/skills/oss-growth
+- .agents/skills/oss-growth/SKILL.md
+- .agents/skills/python-architecture
+- .agents/skills/python-architecture/SKILL.md
+- .agents/skills/supply-chain-security
+- .agents/skills/supply-chain-security/SKILL.md
+- .github/agents/agentic-workflows.agent.md
+- .github/agents/apm-ceo.agent.md
+- .github/agents/apm-primitives-architect.agent.md
+- .github/agents/auth-expert.agent.md
+- .github/agents/cdo.agent.md
+- .github/agents/cli-logging-expert.agent.md
+- .github/agents/devx-ux-expert.agent.md
+- .github/agents/doc-analyser.agent.md
+- .github/agents/doc-writer.agent.md
+- .github/agents/editorial-owner.agent.md
+- .github/agents/oss-growth-hacker.agent.md
+- .github/agents/performance-expert.agent.md
+- .github/agents/python-architect.agent.md
+- .github/agents/spec-editor-synthesizer.agent.md
+- .github/agents/spec-oci-editor.agent.md
+- .github/agents/spec-pkgmgr-editor.agent.md
+- .github/agents/spec-swagger-editor.agent.md
+- .github/agents/spec-tag-architect.agent.md
+- .github/agents/supply-chain-security-expert.agent.md
+- .github/instructions/changelog.instructions.md
+- .github/instructions/cicd.instructions.md
+- .github/instructions/cli.instructions.md
+- .github/instructions/doc-sync.instructions.md
+- .github/instructions/encoding.instructions.md
+- .github/instructions/integrators.instructions.md
+- .github/instructions/linting.instructions.md
+- .github/instructions/python.instructions.md
+- .github/instructions/tests.instructions.md
+local_deployed_file_hashes:
+  .agents/skills/apm-spec-guardian/SKILL.md: sha256:72239a2347c0e36ac8a8a774f658e066e37d1823a0bf54d58096a044425fd1ee
+  .agents/skills/apm-spec-guardian/assets/comment-template.md: sha256:8f5703aa98d1036d2418ffa45eac9d0270504dac33f3e9b1892884a9d48da1a6
+  .agents/skills/apm-spec-guardian/assets/linter-checklist.md: sha256:4b71113da805c5504b4d74029f3113402044bc7e5c48abd010c0b8df3f18938b
+  .agents/skills/apm-spec-guardian/assets/panelist-return-schema.json: sha256:bb66b270394c386665c6b93d83befe05ce9f8206abf8d656079c29d65729fefd
+  .agents/skills/apm-spec-guardian/assets/synthesizer-return-schema.json: sha256:e6e2771f2fe8578e72d12e51edcc3817717f8a0bbef66d8a8a5c556f0dce06d7
+  .agents/skills/apm-strategy/SKILL.md: sha256:a529560f4229bd45fc240d7e31f08ed6baa4a7176e5ef664665b1ff039405b43
+  .agents/skills/auth/SKILL.md: sha256:ddca1dcf2be047ba68c3f700c0b4d59cd88bf2b9f44ee50879f59742173250cc
+  .agents/skills/cli-logging-ux/SKILL.md: sha256:892879f075ab74ebf6e361e804f8d66a6041ea7e5a11640193c71fffa8cbe51b
+  .agents/skills/cut-release/SKILL.md: sha256:07c15054e54679c07c5798ccad9b4348399beb8de3aac11bc1002ad1c07b6b9a
+  .agents/skills/cut-release/assets/entry-sanitizer.md: sha256:b78d605f1bb17b042681b678e07a6431209ae11934ea320e0b573da313649743
+  .agents/skills/cut-release/assets/pr-body-template.md: sha256:8034ad7d64a1f2a9e8677d332ffa1ebbf19071f3b30ba6ecdda660c82bb11917
+  .agents/skills/cut-release/assets/semver-rubric.md: sha256:61b9a2001cbbb41360de509c4b56eb3859333cbf9ea74a896fb9e03a1d3a5244
+  .agents/skills/cut-release/evals/evals.json: sha256:96f07f2e46e47930c9cf5e565f6470f4ca26aa88caa8ad1f63f0a3b80adfdb35
+  .agents/skills/cut-release/scripts/bump-version.sh: sha256:bc382b5024f415998a3d66689a36596f0458e0a3c79370e96705477a5672a1d4
+  .agents/skills/cut-release/scripts/list-changes-since-tag.sh: sha256:4aaacc7f61ca85be9776e921d02a67112569b370d31b581d045e0c3dc941a071
+  .agents/skills/cut-release/scripts/verify-lint-mirror.sh: sha256:ab3f4a9ebc8f2b8c357c4cf81e0ada3be093cfc94c06703805d56c87f6fd7ecc
+  .agents/skills/devx-ux/SKILL.md: sha256:7b8ce1ca7a1a43cafbf32ff2dc01e023f4720c4900f932209116b495ea999fe8
+  .agents/skills/docs-corpus-audit/SKILL.md: sha256:8eabe182ebd6dbde1eb2a98a46db33c2fa12312e5da00c11ee30c2299d61194f
+  .agents/skills/docs-corpus-audit/assets/panelist-return-schema.json: sha256:720e2d7a7a51b23bda19feff90072c64dc5322916218f1030e4fd9e388b34f4b
+  .agents/skills/docs-corpus-audit/assets/subagent-prompt-template.md: sha256:19799c05fae7873c02d6183294ebf6e5f29372bc393a19f1d400f5ed36251760
+  .agents/skills/docs-corpus-audit/evals/README.md: sha256:6cd4924f82e8192f3b0c76aaa086ee6da5055f9f807dda9252842b0b59fb4c8f
+  .agents/skills/docs-corpus-audit/evals/content-evals.json: sha256:f498fd7fe5c53021be2738d0961bcf50a2a054589f95c43818e74b242e3c0a5b
+  .agents/skills/docs-corpus-audit/evals/trigger-evals.json: sha256:ebecf51a2a2b84adf7b3a5799f73f30a6b87f21a3e7970a9086aadb2c17da085
+  .agents/skills/docs-corpus-audit/scripts/scan-cross-corpus-drift.sh: sha256:5793571642a4ab008987da66c793d878e91071dc6f0df1d3e39e4d6b30b77705
+  .agents/skills/docs-grounding-verifier/SKILL.md: sha256:4d136a7ccdff7b686585864b770f6ec6efd95746b21d4a7ef92fb5ceb6fec58d
+  .agents/skills/docs-grounding-verifier/assets/judge-prompt.md: sha256:0a767c6166c4b1bb3ea2525d652f6b7ee23ffcfc6e83bd800666e1a35fa029ea
+  .agents/skills/docs-grounding-verifier/evals/content-evals.json: sha256:ff8070b95ee54eeb664ae7bd3e7fa43ed65ac0bbead3ae5752f23763f04ad979
+  .agents/skills/docs-grounding-verifier/evals/run-evals.sh: sha256:bbcda2bf81c651235d154fbb716747c125923f4bd7302e911126ba833390da0e
+  .agents/skills/docs-grounding-verifier/evals/runs/20260527-194228/seeded-corpus/drift-install-flag/page.md: sha256:7c49ae61d391a0a8e5581b11473a3cc5d0c4151a73579c506ea334bcbacc783f
+  .agents/skills/docs-grounding-verifier/evals/runs/20260527-194228/seeded-corpus/drift-install-flag/scenario.json: sha256:2eb59c0c7efc804a6bda738fb5930a408e1edffc144f211efb9d9d7aff7d06b3
+  .agents/skills/docs-grounding-verifier/evals/runs/20260527-194228/seeded-corpus/drift-policy-reject/page.md: sha256:c96f432f2320087c3b77ceb8ec8d6e9291d1836cdf61522189ef69853bcb8dae
+  .agents/skills/docs-grounding-verifier/evals/runs/20260527-194228/seeded-corpus/drift-policy-reject/scenario.json: sha256:056c820e98a4776d2340c779d6dd6ddcd0d94ea251b7f2b8c5e8087de16939cf
+  .agents/skills/docs-grounding-verifier/evals/runs/20260527-194228/seeded-corpus/drift-registry-resolver/page.md: sha256:21d6c3fd4e031c5f4ac1f6d2e9f697dc944e3b4ba64d735d467ff3fb1e6308a8
+  .agents/skills/docs-grounding-verifier/evals/runs/20260527-194228/seeded-corpus/drift-registry-resolver/scenario.json: sha256:df77802b6769e5a284f936867f3253ff7521f9e232d99719c1899ce8ce38da65
+  .agents/skills/docs-grounding-verifier/evals/runs/20260527-194228/trigger-prompts.txt: sha256:a168e4843165e53388597959ab7ad5bac511fc48ceb1ff5beb5c5da377a8358d
+  .agents/skills/docs-grounding-verifier/evals/runs/proof/claims/copilot.json: sha256:7900a8157d70297557d055ec85fce7f77800883f697467aaf5f17ba6fd4632c3
+  .agents/skills/docs-grounding-verifier/evals/runs/proof/claims/install.json: sha256:4858c69c3c474655630f0a6ff91dbc92b12c460fcc994a14086953726109afd0
+  .agents/skills/docs-grounding-verifier/evals/runs/proof/claims/pkgtypes.json: sha256:1075130429de6d56c4a6af7874be9b1d4ff96e51e7968044efae73608ccbcaec
+  .agents/skills/docs-grounding-verifier/evals/runs/proof/claims/policy.json: sha256:4d3e1a19b6404bc268f775c819b1620997c347ef48247d97f655a8dd80a5db37
+  .agents/skills/docs-grounding-verifier/evals/runs/proof/claims/registries.json: sha256:7e98df45fc8863bc608e957afee1a4a557972ad26210dfcce528261de902397f
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c1.json
+  : sha256:11a4590ed3b358df495ffa71a787f6689545dbaf1c82f750890a2a8aa7167d0d
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c10.json
+  : sha256:2d893a5cc9ff8f72e357b11645b4942fa919c498aec8bd69a514149b23e6e5b0
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c11.json
+  : sha256:5014f4c44f9ee48f8e551b6d156941973dc3e98ec2db8dac30ba40e31d6f2d09
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c12.json
+  : sha256:9aab3c4ed34e68c331cdea360c0e51ea09780c0e1ecfd025fb232d62e76b08a2
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c13.json
+  : sha256:7bd568d557621fcad5a195320ec2c0868f74816ff567fe4877d4e7d17740726b
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c14.json
+  : sha256:dfc4986521f54cbe08cd57cdc7e43136991bb4f38c87bccc98aa9c390706256d
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c15.json
+  : sha256:3a0803126c8809fdd5a552c6b986fff79c2e51a98f4152ce6f5e706aba905fc3
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c2.json
+  : sha256:1a66e59ce2d9ff29714c3b29dd16020822057808ce779093b869133345bd1038
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c3.json
+  : sha256:259f4eed7bf78bd63193f6ecf4e3cf9af3acdde3049c13c9491972cc19cf16b4
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c4.json
+  : sha256:0c13b2af4c86ba7fe57a9b9f27c521c1c0e566cde876e4d3ffba12af03a8b200
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c5.json
+  : sha256:ac81afbc6f1775ab14f80bbe9865b82035b97354c8ab42daf85dbf7fb0cea9e7
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c6.json
+  : sha256:853c8e85cf2b2bcbcfc2d2c7ac5d494e2eac02203dde2af55d833e2fc61c556d
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c7.json
+  : sha256:212341fcf309a244fa3da72e76510ef3cda443da9bedaaae114ff97aa8a8e358
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c8.json
+  : sha256:08f68cb8ceffcf73d2db9074b2739e27c96b2297a5c9592c2b829dc9395c18f8
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/evidence/docs_src_content_docs_integrations_copilot-app_md_c9.json
+  : sha256:82dab7bb099c6b5fccf24825cf9becba0f443ae33b57415375e25eb9a4908c4f
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/copilot/judge-batch-docs_src_content_docs_integrations_copilot-app_md.txt
+  : sha256:a19634cdebf04aab002382cc8d71d1ec3fcbd2867f957e43b5001e655e928618
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c1.json
+  : sha256:08c01483523348c208e3f6fe2188b967002edd59adcf98f130efb4394774403a
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c10.json
+  : sha256:dd7a632f6c4a4a1aa7f97235ae8e5e6598d0411fffd96ce99e40137b12be307f
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c11.json
+  : sha256:e3770a85c08d8047e9ea9c6d4f54b00c9c003fe4e5c6c8d7f0a113bff21358eb
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c12.json
+  : sha256:03d93269acc4fdcf85673c06bbd956298159230dbcbe06ffeedec880d518f9b1
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c13.json
+  : sha256:767c131a2eca0698a572140e0984542d5cf43d284702fcc0d07420d030c5f59a
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c14.json
+  : sha256:63bf64427c7c4621a06aff93ad411f71b38ac7e0d876467d7fe2e3101d46138f
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c15.json
+  : sha256:2f594c1afe45bdb2d0b184daa9c33f4e684a979d61127fc4d7f282f6a2daa915
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c2.json
+  : sha256:a155cc6087fbb73fa2a419f74a9ef84a1e6f5fb145fe31b43ab3b3e9f70c65c4
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c3.json
+  : sha256:9011bbd6311bee94500ac255c75739a01143c895fcb8f4dd0e831bbcd163cb10
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c4.json
+  : sha256:f52b83178fbf2e8e6dcb5815b74c9050be62273a40cc891a62321d5032b7cc71
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c5.json
+  : sha256:8ac41732ab40d31fcce05550c2b53c26baf14605a6cb7f28ba0aace494f6d85d
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c6.json
+  : sha256:23431dd26eace6040553dbec405198411064428269d2b2a10e535e2c0fd8a017
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c7.json
+  : sha256:bbcd251365a7a4f16c3f71ded2dc52902859bed50ef05b5fe3dc12daa1ffb0bf
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c8.json
+  : sha256:74706c3bfd419cb29e848930415903f45684ceb85089f1c96e307a8b431b097a
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/install/evidence/docs_src_content_docs_reference_cli_install_md_c9.json
+  : sha256:8658f138f866c2bc9e6e396cf70bf5b5efcca010ad6681a5554b9bec219909bf
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/install/judge-batch-docs_src_content_docs_reference_cli_install_md.txt
+  : sha256:61d821a41e4ef7f8d2b4bda479e7d0371e0199a4100f986ab805fe8df97388ab
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c1.json
+  : sha256:aa03612dd2db02699a80d72e0fa9cf30dc83fc0186da3bda195b9ef039744c63
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c10.json
+  : sha256:28c753a4fc182342eb70144bf6f7e4cf46f9ff296959bc2160302c724deb03a6
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c11.json
+  : sha256:eccc398bbc2f0afd4d42b8222628a36eddff02984f72cc40bc1553af559b0cf0
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c12.json
+  : sha256:8afda93ba1f2b19b87709ae4da6925b5d1f96eb5d925ee2715b88f9bee67eaa7
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c13.json
+  : sha256:fe0f6759224109c21c5721e2f681d277e06dcfe17ced2bc807495b922ca77064
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c14.json
+  : sha256:a15aa164faddfc0d7eb75b6e8393971d55ed2af1551d08d7b1f924aa146186eb
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c15.json
+  : sha256:bb1d42aa51d46a2c0274f502f250af57ffd49b030e0f742519853164e8d1184e
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c2.json
+  : sha256:562f69f0d6d40ff2ba4e7af16df7d9bee11fee0c5af5d9e03b67bfadd4bedb3a
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c3.json
+  : sha256:447a6ceb4964aad579b1a9a240d42692088330bc56de024b1818349ae5d441f5
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c4.json
+  : sha256:8698d41bb991c118140d85b176e1405c42f143885eb9e8e0852a08a350809151
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c5.json
+  : sha256:316351e399963440ec8a48366b2466eba472a01ce5b4ecfb9e75387338b862c8
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c6.json
+  : sha256:9a755529eb958a7416cd383f5c1a0579a56caa5e920e867b930966e66be28ba3
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c7.json
+  : sha256:c99428c2320ce13c2323c95fc60f642e68eedd13829653072796f71d6e7d00c5
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c8.json
+  : sha256:63b0b76dd92db3d2962d4576cd79f64b1994385bf2ea79edde59d6fac8800800
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/evidence/docs_src_content_docs_reference_package-types_md_c9.json
+  : sha256:8038f4bb1b609b55736e4244e0c0360d127ebcca561e1293a865469354a6c8fe
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/pkgtypes/judge-batch-docs_src_content_docs_reference_package-types_md.txt
+  : sha256:99f87397610abe9bb7881d959bc41740563322d13af9cfa498f4a8d3854dc22b
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c1.json
+  : sha256:41cc929fa549dae9cd1113ec8269c111eeb66a93ff363f828e322e165698cd2e
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c10.json
+  : sha256:6032e38c860412389acd7a6d4a630c892189f04e4dd2153c4efb0cd868c1bad7
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c11.json
+  : sha256:b97abe20f0ce7c916848e0df01ffbfea4aaafead96d588e57035e26cd1530f34
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c12.json
+  : sha256:64dae53182bb569bcbb232ef57886f48015bd9bf1dc3ebc1d12de8a8feec3e53
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c13.json
+  : sha256:1c6f59d6bd36ae8b91689adc73bd65e215582785cf3cae8a643e116bc002083e
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c14.json
+  : sha256:ec7d388fd9b3da5719f1829917dbc5c462a2154b8c6bc9ab5893fe06bd8a1979
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c15.json
+  : sha256:5e06f4250786f406be51b42bf99d6a0f53a2ef51352b3fe2b6ea05bd5e399fcf
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c2.json
+  : sha256:7fc0acd68b9612fcf634d685ed267bd4959b6ed2993b34d4842b911d04afb05a
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c3.json
+  : sha256:d828a0859911b50f84f1ea24dd8c77ff73195af82ce3f8f2ce23f0259339fb1b
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c4.json
+  : sha256:fff64cab449a06473dfbcae9f7d63e9f138823868146d8df61552d38c1f0b1df
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c5.json
+  : sha256:7ca428b39d76a08287ffaa16c19a89c93a77c1930f4e391bda03d16fa9343461
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c6.json
+  : sha256:c8f0f1b0b29ea3eb5c5471e0a795e508aede78e1f983fee003771a95057bc07c
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c7.json
+  : sha256:fb3e636541002e8f0f569b002803f8f58feff34d9872df4a0ef3a95d81800362
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c8.json
+  : sha256:63bd17c2ca2cd6b05c475cb1dd72fb86a483606860b7f3e082d5f5e587f2d99c
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/evidence/docs_src_content_docs_enterprise_apm-policy_md_c9.json
+  : sha256:0e70ce442c1753cfde74d6b43b2dfa69f5679e693ab95efb93612ab314ea7d02
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/policy/judge-batch-docs_src_content_docs_enterprise_apm-policy_md.txt
+  : sha256:03fd0106dc9ff6993c5cf98ec84ac165848442b47023d3e7bd0e2e18653275bb
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c1.json
+  : sha256:0e17b582b9e1befcb48e82f1075e96b8b0a504b3b1ae3c7437217c9705d6d6e8
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c10.json
+  : sha256:a5d295a4e9e65ef49bb0d955dd730d1692eabe941c53182e4b8317af92619ec7
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c11.json
+  : sha256:614d5555be43e18e933561f1e2594be5fe03a9d496c707928b60e3fafe073379
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c12.json
+  : sha256:ee997677db367770c27e2339ca368339026f4316323369dab675be1afc84817b
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c13.json
+  : sha256:33d58c49665767f92f87c65ddc892a614bb02a3ec0dab51eee31f3e57639b954
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c14.json
+  : sha256:693dbb84172320c7160432a156c1c3730ded4fb06ec5ee39d8150e82118f9ddb
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c15.json
+  : sha256:4d52c6b564eea4516852a8c15076d4840d9ace06bdf70be5db7efe1efecc928c
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c2.json
+  : sha256:2922bc71c4d03708e9d119b5f161eefdb3a5ed1b0dd674846fed9882661afcbc
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c3.json
+  : sha256:a74b49ce7eb3ae607cd9bc6e242c19e305d48d84c0b6b388d62eb846410b5b0d
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c4.json
+  : sha256:363a5c9ee672381075f3ce0be50ad73d9a9c86e4eacd4bf0ee1df681b900829f
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c5.json
+  : sha256:0a9d8a3d19fefd810522e90cbe9ffbb14ca38fa83310a022a9c64fc186d327fb
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c6.json
+  : sha256:3ded4bef426433b26c8f53a0b48f0cbfcb2735f4b6787815458da7e590a6f36c
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c7.json
+  : sha256:7fc768249ead8d05af7b0e43c26a91db37889d56dbf9d0a6c0fdc2530628d1f6
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c8.json
+  : sha256:ffb12fc71daff5a7a40351f8cbaf8136d0213dfaff4a0130796cc8749672d335
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/evidence/docs_src_content_docs_guides_registries_md_c9.json
+  : sha256:32df71cf9748cb36eca8f135ffa2de3ae078bf5df94fd9d5ea6999270c6a49d9
+  ? .agents/skills/docs-grounding-verifier/evals/runs/proof/registries/judge-batch-docs_src_content_docs_guides_registries_md.txt
+  : sha256:05b1f00ad9fd75e10da501a5357237bfd0d869e95cc5a051433ce92432e3156f
+  .agents/skills/docs-grounding-verifier/evals/runs/proof/trigger-responses.json: sha256:393748120d700b3ac9af42f060f0681607e53177759c20eeb41f7f1b2b12078f
+  .agents/skills/docs-grounding-verifier/evals/trigger-evals.json: sha256:5f5f8f3404c6bd95597c7b567186c14711cc91c9f66fe590bda57cf69a84c92d
+  .agents/skills/docs-grounding-verifier/scripts/extract-claims.py: sha256:baabcb5bcd0ba4bdd7f125ac8f30f8d422089b7deb0825a473a868390e1b8441
+  .agents/skills/docs-grounding-verifier/scripts/retrieve-evidence.sh: sha256:c045f28399705c129145bf3eb808c1d0fc15fcd19f3fb6441d8d6a57950bb6e9
+  .agents/skills/docs-grounding-verifier/scripts/verify-page.sh: sha256:36258e6ce8ff9763699f1db28927358370ea369a07e6e20a76e31819398b8ede
+  .agents/skills/docs-impact-architect/SKILL.md: sha256:3bc13d5ac9e59b094573565ef5fd07cdbf355b6ba64235e399e2f72b2ba587c6
+  .agents/skills/docs-impact-classifier/SKILL.md: sha256:3540bb7062835ba254d971be636a60763448aa6b7e0dd1b7624d959c9495e6c2
+  .agents/skills/docs-impact-localizer/SKILL.md: sha256:1a46fb1da757ace60ed4bd80a308136a4c0e7ecd62447f1581a51664993dbe0e
+  .agents/skills/docs-sync/SKILL.md: sha256:b535912a50121370ecf5a6b4458f3725a87f665405d0705d0ec519bc27125600
+  .agents/skills/docs-sync/assets/advisory-comment-template.md: sha256:9abbd82239925a85a2b2c08d84130259044660c8114245b7e939d4c761c0053e
+  .agents/skills/docs-sync/assets/classifier-return-schema.json: sha256:9e9fda0c39bfe684f367f4c89e69814d43a23e68c18a3603e9d212659c1a8689
+  .agents/skills/docs-sync/assets/panelist-return-schema.json: sha256:6e661b1042e8475e15fcc943a290891f041509a903dfa770a6e0ef4bc793326d
+  .agents/skills/docs-sync/evals/README.md: sha256:7dbf5dfa89e78f7d5a3214b01bb5fabfee59c2979827c2a0c72f008fa9c69de5
+  .agents/skills/docs-sync/evals/content-evals.json: sha256:31a8b26677f84337775b81971145e12d327c6b65dfc21b2c6f5b886462410dc2
+  .agents/skills/docs-sync/evals/trigger-evals.json: sha256:b0da21a8a6e588676247a9a15d792ef6596389f16ae100f83fa423ee47992501
+  .agents/skills/oss-growth/SKILL.md: sha256:692be91a6704ff2e428e851f33b1f340ee9aa42beafabf62c2108cace7dae674
+  .agents/skills/python-architecture/SKILL.md: sha256:acb858a97de695f98fba01af588f317a86833cc98c3405d6c5eea0d063f00021
+  .agents/skills/supply-chain-security/SKILL.md: sha256:60e87189fc9ebea724a1b9b7cf2c6c5c11458ae3c3c67d7a9ede6d0377177095
+  .github/agents/agentic-workflows.agent.md: sha256:d1ea2d038e2af8be11d6c95b3213b03b9777fae46f0438efa95d5a803e6c3765
+  .github/agents/apm-ceo.agent.md: sha256:484da64428ea46a6183dffd3f30c9fc5fc5c747639c0c79e55be69dba0899323
+  .github/agents/apm-primitives-architect.agent.md: sha256:6c01eab74ba18d70f21d45010d636cc6535d63cee81da12e61898d8036e0b028
+  .github/agents/auth-expert.agent.md: sha256:18264a933cba432b77d133e6ae11eee294c92ed245629af8c9b7a5bb7a9a300c
+  .github/agents/cdo.agent.md: sha256:71e7684942679f86199b6720fc69d52ef796a0ec28981250b9ad275a1ed41d31
+  .github/agents/cli-logging-expert.agent.md: sha256:3ed7fe1a2e28e03a40311d4999ef54330908920d6515205708dd3f037abfcf0f
+  .github/agents/devx-ux-expert.agent.md: sha256:8310d130cca5bc548baf4a2a84e3c9680c9dc5d83a2718150636896ab2aa1f30
+  .github/agents/doc-analyser.agent.md: sha256:47b1d0204904b786c19d4fe84343e86cdab6f92f862f676ba741ffe6e1385679
+  .github/agents/doc-writer.agent.md: sha256:328a5b9ea079869b8ccd914a6e2135c204225a5eedb42f59a1ec73058f7f0b47
+  .github/agents/editorial-owner.agent.md: sha256:9dd101a9476dd93b67da1b823cc3b649f1227168fd809b108c74f9304262d860
+  .github/agents/oss-growth-hacker.agent.md: sha256:1cd56bb78ab37d52c50e45ab69d759f775cd49cdf35981b3dc6c4004315c6b83
+  .github/agents/performance-expert.agent.md: sha256:5262b505660c3e8ec2064cbd2f9e2732e6cae2d65b0292abe99b90b077c26ef4
+  .github/agents/python-architect.agent.md: sha256:7587ee7c684c61046a83dfa1b7e39d1345f2f119c3395478e3ca2dbbaaaff0e9
+  .github/agents/spec-editor-synthesizer.agent.md: sha256:dad51758c91753528f3a80e1102f5a71460b816897d650c0f0ad4eeb7b1c8928
+  .github/agents/spec-oci-editor.agent.md: sha256:d96482cb733b0540b14ba0812fde48c07d8937ef11507b81c28a239b35b4f94a
+  .github/agents/spec-pkgmgr-editor.agent.md: sha256:42a1eb939892bdaca2f3bf139911956893d5da03f60b4cbc0642ae88c2084deb
+  .github/agents/spec-swagger-editor.agent.md: sha256:51019f52b2a2aed2a269187b58e6a867802636a79d1410153dc9b5b28d5d1b25
+  .github/agents/spec-tag-architect.agent.md: sha256:82907265c5e7cf1ac61ad96866fa7c5683b69c8f09b7a4c5f3cc241acc9568ca
+  .github/agents/supply-chain-security-expert.agent.md: sha256:8fb8cc426d6af17ba084a28b3f026c2b475b62e3ca63ed2f88b83bd823f877af
+  .github/instructions/changelog.instructions.md: sha256:1e51ec4c74e847967962bd279dc4c6e582c5d3578490b3c28d5f3acd3e05f73e
+  .github/instructions/cicd.instructions.md: sha256:9c0fafc74f743aa97e5adba2168d66c9e3a327b135065e3b804bdbb5f04cda5d
+  .github/instructions/cli.instructions.md: sha256:8e39e8d5047ce88575cb02f87c2bcede584dfef258bd86f7466c7badf136541a
+  .github/instructions/doc-sync.instructions.md: sha256:bb3816254f8df6bffc6faacd556871f36903e9d7f348982f1e2de0339384c696
+  .github/instructions/encoding.instructions.md: sha256:93db7377dc896f6efecf2c5d8c5d89255a555562f468d034d64c42edd5cf46d5
+  .github/instructions/integrators.instructions.md: sha256:b151e0438088d2c0b636dfc28532ecf43c3b51e5f1070a354b8d5b57c345e335
+  .github/instructions/linting.instructions.md: sha256:8d31137f18842570bef6c93f8396587ac691e5fc973988bd865b008b0983f90d
+  .github/instructions/python.instructions.md: sha256:45173f778eddc126c37c7ace96acd0e17adb1895031eec134ec0754638d3ba37
+  .github/instructions/tests.instructions.md: sha256:b527ccaecf0e92f74d300fc9027f1bc49bb43d8ddcdd36338c1556fcde0d8b2d

--- a/src/apm_cli/install/drift.py
+++ b/src/apm_cli/install/drift.py
@@ -41,6 +41,7 @@ from apm_cli.utils.guards import _ReadOnlyProjectGuard
 
 if TYPE_CHECKING:
     from apm_cli.deps.lockfile import LockedDependency, LockFile
+    from apm_cli.integration.targets import TargetProfile
 
 
 # ---------------------------------------------------------------------------
@@ -530,7 +531,7 @@ def run_replay(config: ReplayConfig, logger: CheckLogger) -> Path:
 _INLINE_DIFF_BYTE_CAP = 100 * 1024  # 100 KB
 
 
-def _governed_root_dirs(targets) -> set[str]:
+def _governed_root_dirs(targets: list[TargetProfile]) -> set[str]:
     """Return the set of top-level managed directory names to walk.
 
     Includes each target's top-level ``root_dir`` (plus ``.apm``) AND every

--- a/src/apm_cli/install/drift.py
+++ b/src/apm_cli/install/drift.py
@@ -533,21 +533,26 @@ _INLINE_DIFF_BYTE_CAP = 100 * 1024  # 100 KB
 def _governed_root_dirs(targets) -> set[str]:
     """Return the set of top-level managed directory names to walk.
 
-    Deliberately limited to each target's top-level ``root_dir`` (plus
-    ``.apm``). Per-primitive ``deploy_root`` overrides (e.g. the ``copilot``
-    target routing ``skills`` to ``.agents``) are intentionally NOT walked
-    here: the drift replay does not faithfully reproduce the deploy-time
-    cross-primitive link rewrite for skill bundles, so walking ``.agents/``
-    would surface byte-identical skills as false-positive drift. Skill
-    content drift is instead covered by the per-file content-integrity gate
-    (``apm audit --ci --no-drift``); see issue #1716 and the deferred
-    replay-link-rewrite follow-up.
+    Includes each target's top-level ``root_dir`` (plus ``.apm``) AND every
+    per-primitive ``deploy_root`` override (e.g. the ``copilot`` target routing
+    ``skills`` to ``.agents``). Walking the deploy roots is what lets the drift
+    differ compare committed skill bundles under ``.agents/skills/`` against the
+    replay, closing the gap where deployed skill content could silently diverge
+    from source (issue #1716). The replay reproduces the deploy-time link
+    rewrite faithfully, so byte-identical skills do not surface as false drift.
+    Only the first path segment is kept so nested deploy roots collapse to a
+    single walk root.
     """
     roots: set[str] = {".apm"}
     for t in targets or []:
         root = getattr(t, "root_dir", None)
         if root:
             roots.add(str(root).split("/", 1)[0])
+        primitives = getattr(t, "primitives", None) or {}
+        for mapping in primitives.values():
+            deploy_root = getattr(mapping, "deploy_root", None)
+            if deploy_root:
+                roots.add(str(deploy_root).split("/", 1)[0])
     return roots
 
 

--- a/src/apm_cli/install/drift.py
+++ b/src/apm_cli/install/drift.py
@@ -531,7 +531,18 @@ _INLINE_DIFF_BYTE_CAP = 100 * 1024  # 100 KB
 
 
 def _governed_root_dirs(targets) -> set[str]:
-    """Return the set of top-level managed directory names to walk."""
+    """Return the set of top-level managed directory names to walk.
+
+    Deliberately limited to each target's top-level ``root_dir`` (plus
+    ``.apm``). Per-primitive ``deploy_root`` overrides (e.g. the ``copilot``
+    target routing ``skills`` to ``.agents``) are intentionally NOT walked
+    here: the drift replay does not faithfully reproduce the deploy-time
+    cross-primitive link rewrite for skill bundles, so walking ``.agents/``
+    would surface byte-identical skills as false-positive drift. Skill
+    content drift is instead covered by the per-file content-integrity gate
+    (``apm audit --ci --no-drift``); see issue #1716 and the deferred
+    replay-link-rewrite follow-up.
+    """
     roots: set[str] = {".apm"}
     for t in targets or []:
         root = getattr(t, "root_dir", None)

--- a/src/apm_cli/install/manifest_reconcile.py
+++ b/src/apm_cli/install/manifest_reconcile.py
@@ -1,0 +1,107 @@
+"""Target-scoped manifest reconciliation shared by lockfile build sites.
+
+On-disk stale cleanup is target-scoped: it preserves files belonging to
+OTHER deploy targets (``phases/cleanup.py``). The lockfile manifest must
+reconcile with the same symmetry. An ``apm install`` only governs its own
+targets' deploy roots and URI schemes, so manifest entries written by a
+prior install for OTHER targets must be PRESERVED rather than clobbered.
+
+Without this symmetry a multi-target deploy (e.g. the ``copilot`` target
+writing ``.github/`` + ``.agents/skills/`` files, then a later
+``copilot-app`` install writing DB-URI rows) leaves the committed lockfile
+single-target: the surviving on-disk files become orphaned from the
+manifest and escape every manifest-driven audit gate -- deployed-files-
+present, content-integrity, and drift (issue #1716).
+
+Two manifest blocks need this reconciliation:
+
+* per-dependency ``deployed_files`` / ``deployed_file_hashes``
+  (``phases/lockfile.py``), and
+* project-root ``local_deployed_files`` / ``local_deployed_file_hashes``
+  (``phases/post_deps_local.py``).
+
+Both import :func:`union_preserving` so the behaviour stays identical.
+"""
+
+from __future__ import annotations
+
+
+def install_governance(targets) -> tuple[set[str], set[str]]:
+    """Return ``(file_roots, uri_schemes)`` governed by *targets*.
+
+    ``file_roots`` is the set of top-level managed directory names -- each
+    target's ``root_dir`` plus every primitive ``deploy_root`` override (the
+    ``copilot`` target routes its ``skills`` primitive to ``.agents`` via
+    ``deploy_root`` even though ``root_dir`` is ``.github``).
+
+    ``uri_schemes`` is the set of lockfile URI schemes used by dynamic /
+    user-machine targets (``copilot-app`` -> ``copilot-app-db://``,
+    ``copilot-cowork`` -> ``cowork://``).
+    """
+    from apm_cli.integration.copilot_app_db import COPILOT_APP_URI_SCHEME
+    from apm_cli.integration.copilot_cowork_paths import COWORK_URI_SCHEME
+
+    file_roots: set[str] = set()
+    uri_schemes: set[str] = set()
+    for target in targets or []:
+        name = getattr(target, "name", None)
+        if name == "copilot-app":
+            uri_schemes.add(COPILOT_APP_URI_SCHEME)
+            continue
+        if name == "copilot-cowork":
+            uri_schemes.add(COWORK_URI_SCHEME)
+            continue
+        root = getattr(target, "root_dir", None)
+        if root:
+            file_roots.add(str(root).split("/", 1)[0])
+        primitives = getattr(target, "primitives", None)
+        if isinstance(primitives, dict):
+            for mapping in primitives.values():
+                deploy_root = getattr(mapping, "deploy_root", None)
+                if deploy_root:
+                    file_roots.add(str(deploy_root).split("/", 1)[0])
+    return file_roots, uri_schemes
+
+
+def is_governed_by_install(path: str, file_roots: set[str], uri_schemes: set[str]) -> bool:
+    """Return ``True`` if *path* is owned by the current install's targets.
+
+    File paths are matched by top-level directory; scheme URIs (e.g.
+    ``copilot-app-db://``, ``cowork://``) are matched by their scheme.
+    """
+    if "://" in path:
+        scheme = path.split("://", 1)[0] + "://"
+        return scheme in uri_schemes
+    top = path.split("/", 1)[0]
+    return top in file_roots
+
+
+def union_preserving(
+    current_files,
+    current_hashes,
+    prior_files,
+    prior_hashes,
+    targets,
+) -> tuple[list[str], dict[str, str]]:
+    """Union the current install's manifest with preserved other-target entries.
+
+    ``current_files`` / ``current_hashes`` describe what THIS install
+    deployed (and thus governs). ``prior_files`` / ``prior_hashes`` come from
+    the existing lockfile. Returns ``(files, hashes)`` -- the current entries
+    plus any prior entries that belong to OTHER targets (not governed by this
+    install). Entries the current install governs are authoritative, so a
+    same-target reinstall still drops files removed from the package.
+    """
+    file_roots, uri_schemes = install_governance(targets)
+    current_set = set(current_files or ())
+    merged_hashes = dict(current_hashes or {})
+    preserved: list[str] = []
+    for path in prior_files or ():
+        if path in current_set:
+            continue
+        if is_governed_by_install(path, file_roots, uri_schemes):
+            continue
+        preserved.append(path)
+        if prior_hashes and path in prior_hashes:
+            merged_hashes[path] = prior_hashes[path]
+    return list(current_files or ()) + preserved, merged_hashes

--- a/src/apm_cli/install/manifest_reconcile.py
+++ b/src/apm_cli/install/manifest_reconcile.py
@@ -25,8 +25,13 @@ Both import :func:`union_preserving` so the behaviour stays identical.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 
-def install_governance(targets) -> tuple[set[str], set[str]]:
+if TYPE_CHECKING:
+    from apm_cli.integration.targets import TargetProfile
+
+
+def install_governance(targets: list[TargetProfile]) -> tuple[set[str], set[str]]:
     """Return ``(file_roots, uri_schemes)`` governed by *targets*.
 
     ``file_roots`` is the set of top-level managed directory names -- each
@@ -77,11 +82,11 @@ def is_governed_by_install(path: str, file_roots: set[str], uri_schemes: set[str
 
 
 def union_preserving(
-    current_files,
-    current_hashes,
-    prior_files,
-    prior_hashes,
-    targets,
+    current_files: list[str],
+    current_hashes: dict[str, str],
+    prior_files: list[str],
+    prior_hashes: dict[str, str],
+    targets: list[TargetProfile],
 ) -> tuple[list[str], dict[str, str]]:
     """Union the current install's manifest with preserved other-target entries.
 

--- a/src/apm_cli/install/phases/lockfile.py
+++ b/src/apm_cli/install/phases/lockfile.py
@@ -133,16 +133,34 @@ class LockfileBuilder:
     # -- private helpers (verbatim from original inline block) ----------
 
     def _attach_deployed_files(self, lockfile: LockFile) -> None:
-        for dep_key, dep_files in self.ctx.package_deployed_files.items():
-            if dep_key in lockfile.dependencies:
-                lockfile.dependencies[dep_key].deployed_files = dep_files
-                # Hash the files as they exist on disk AFTER stale
-                # cleanup so the recorded hashes match what is now
-                # deployed (provenance for the next install's stale
-                # cleanup).
-                lockfile.dependencies[dep_key].deployed_file_hashes = compute_deployed_hashes(
-                    dep_files, self.ctx.project_root
-                )
+        """Attach per-dependency deployed-file manifests, unioning targets.
+
+        Reconciliation is **target-scoped**, mirroring the symmetry that
+        on-disk stale cleanup already has (``phases/cleanup.py``). Entries a
+        prior install recorded for OTHER targets are preserved rather than
+        clobbered, so a multi-target deploy keeps every target's files in the
+        committed lockfile and they stay covered by the audit gates (issue
+        #1716). See :mod:`apm_cli.install.manifest_reconcile`.
+        """
+        from apm_cli.install.manifest_reconcile import union_preserving
+
+        existing = self.ctx.existing_lockfile
+        for dep_key, locked_dep in lockfile.dependencies.items():
+            current = list(self.ctx.package_deployed_files.get(dep_key, []))
+            current_hashes = compute_deployed_hashes(current, self.ctx.project_root)
+            prev = existing.get_dependency(dep_key) if existing is not None else None
+            prior_files = prev.deployed_files if prev is not None else []
+            prior_hashes = prev.deployed_file_hashes if prev is not None else {}
+            files, hashes = union_preserving(
+                current, current_hashes, prior_files, prior_hashes, self.ctx.targets
+            )
+            if not files:
+                # Nothing this install governs and nothing to carry forward;
+                # leave deployed_files untouched so the whole-dep
+                # _merge_existing path can preserve it intact.
+                continue
+            locked_dep.deployed_files = files
+            locked_dep.deployed_file_hashes = hashes
 
     def _attach_package_types(self, lockfile: LockFile) -> None:
         for dep_key, pkg_type in self.ctx.package_types.items():

--- a/src/apm_cli/install/phases/post_deps_local.py
+++ b/src/apm_cli/install/phases/post_deps_local.py
@@ -107,10 +107,24 @@ def run(ctx: InstallContext) -> None:
 
     _lock_path = _get_lfp(ctx.apm_dir)
     _persist_lock = _LF.read(_lock_path) or _LF()
-    _persist_lock.local_deployed_files = sorted(ctx.local_deployed_files)
-    _persist_lock.local_deployed_file_hashes = _hash_deployed(
-        ctx.local_deployed_files, ctx.project_root
+    # Target-scoped union: preserve project-root files deployed by OTHER
+    # targets (a prior install) rather than clobbering them. Symmetric with
+    # the per-dependency reconciliation in phases/lockfile.py and with
+    # on-disk stale cleanup, so a multi-target deploy keeps content-integrity
+    # coverage for every committed deploy target (issue #1716).
+    from apm_cli.install.manifest_reconcile import union_preserving as _union
+
+    _current_files = sorted(ctx.local_deployed_files)
+    _current_hashes = _hash_deployed(ctx.local_deployed_files, ctx.project_root)
+    _files, _hashes = _union(
+        _current_files,
+        _current_hashes,
+        list(_persist_lock.local_deployed_files),
+        dict(_persist_lock.local_deployed_file_hashes),
+        ctx.targets,
     )
+    _persist_lock.local_deployed_files = sorted(_files)
+    _persist_lock.local_deployed_file_hashes = _hashes
     # Only write if changed.
     _existing_for_cmp = _LF.read(_lock_path)
     if not _existing_for_cmp or not _persist_lock.is_semantically_equivalent(_existing_for_cmp):

--- a/src/apm_cli/install/services.py
+++ b/src/apm_cli/install/services.py
@@ -115,6 +115,39 @@ def _deployed_path_entry(
         )
 
 
+def _skill_bundle_file_entries(
+    skill_dir: Path,
+    project_root: Path,
+    targets: Any,
+) -> list[str]:
+    """Return per-file lockfile entries for a deployed skill bundle directory.
+
+    A skill is deployed as a directory (e.g. ``.agents/skills/<s>``). Recording
+    only the directory leaves its contents unhashed, so skill content drift
+    escapes ``content-integrity`` (the ``apm audit --ci --no-drift`` gate).
+    This expands the bundle into per-file entries (``SKILL.md``, ``assets/``,
+    ``scripts/``) so ``compute_deployed_hashes`` hashes them. The directory
+    entry itself is recorded by the caller and intentionally excluded here.
+
+    Mocked or file-shaped ``target_paths`` (used in unit tests) are not real
+    directories on disk and yield an empty list, so callers pass them through
+    unchanged.
+    """
+    try:
+        if not (skill_dir.is_dir() and not skill_dir.is_symlink()):
+            return []
+    except OSError:
+        return []
+    entries: list[str] = []
+    for bundle_file in sorted(skill_dir.rglob("*")):
+        try:
+            if bundle_file.is_file() and not bundle_file.is_symlink():
+                entries.append(_deployed_path_entry(bundle_file, project_root, targets))
+        except OSError:
+            continue
+    return entries
+
+
 def _log_hook_display_payloads(
     payloads: list,
     verbose: bool,
@@ -492,6 +525,13 @@ def integrate_package_primitives(
         )
     for tp in skill_result.target_paths:
         deployed.append(_deployed_path_entry(tp, project_root, targets))
+        # #1716: also record the bundle's contained files so per-file
+        # content hashes cover SKILL.md / assets / scripts. The directory
+        # entry above is retained (cleanup's directory-rejection gate and
+        # the manifest dir-exclusion contract depend on it); the file
+        # entries give ``content-integrity`` its per-file coverage so skill
+        # drift is caught under ``apm audit --ci --no-drift``.
+        deployed.extend(_skill_bundle_file_entries(tp, project_root, targets))
 
     # A3: warm-cache visibility. If nothing was integrated for any kind AND
     # no skill was created, emit one annotation so the user knows the dep

--- a/tests/integration/test_install_services_orchestration.py
+++ b/tests/integration/test_install_services_orchestration.py
@@ -582,6 +582,35 @@ class TestIntegratePackagePrimitives:
 
         assert result["deployed_files"] == [".claude/skills/demo/SKILL.md"]
 
+    def test_deployed_files_expand_skill_dir_to_contained_files(self, tmp_path: Path) -> None:
+        # #1716 regression trap: a deployed skill DIRECTORY must also record
+        # its contained files so per-file content hashes
+        # (compute_deployed_hashes -> content-integrity) cover
+        # SKILL.md / assets / scripts. Without the expansion, skills are
+        # dir-only entries and skill content drift escapes the documented
+        # ``apm audit --ci --no-drift`` gate.
+        skill_dir = tmp_path / ".agents" / "skills" / "demo"
+        (skill_dir / "assets").mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text("# demo skill\n")
+        (skill_dir / "assets" / "schema.json").write_text("{}\n")
+
+        result, _, _, _ = invoke_integrate(
+            tmp_path,
+            targets=[make_target(primitives={})],
+            skill_result=make_skill_result(
+                target_paths=[skill_dir],
+                skill_created=True,
+            ),
+        )
+
+        df = result["deployed_files"]
+        # Directory entry retained (cleanup's directory-rejection gate +
+        # manifest dir-exclusion contract depend on it).
+        assert ".agents/skills/demo" in df
+        # Per-file entries added -> content-integrity coverage.
+        assert ".agents/skills/demo/SKILL.md" in df
+        assert ".agents/skills/demo/assets/schema.json" in df
+
     def test_two_target_paths_are_collapsed_on_one_line(self, tmp_path: Path) -> None:
         targets = [
             make_target(name="claude", root_dir=".claude", primitives={"prompts": make_mapping()}),

--- a/tests/unit/install/phases/test_lockfile_union.py
+++ b/tests/unit/install/phases/test_lockfile_union.py
@@ -1,0 +1,184 @@
+"""Regression traps for target-scoped lockfile manifest reconciliation.
+
+These tests pin the fix for issue #1716: a multi-target deploy must not
+leave the committed lockfile manifest single-target. On-disk stale cleanup
+is target-scoped (it preserves files belonging to other targets), so the
+manifest reconciliation in ``LockfileBuilder._attach_deployed_files`` must
+be symmetric -- it must UNION across targets rather than REPLACE with the
+current install's target only. Otherwise files deployed by a prior target
+(e.g. ``.agents/skills/<s>/SKILL.md`` from the ``copilot`` target) remain on
+disk but vanish from the manifest, escaping every manifest-driven audit
+gate (deployed-files-present, content-integrity, drift).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from apm_cli.deps.lockfile import LockedDependency, LockFile
+from apm_cli.install.phases.lockfile import LockfileBuilder
+
+
+def _target(name, root_dir=None, deploy_roots=None):
+    """Build a minimal target-profile stand-in for governance computation."""
+    primitives = {}
+    for idx, droot in enumerate(deploy_roots or []):
+        primitives[f"prim{idx}"] = SimpleNamespace(deploy_root=droot)
+    return SimpleNamespace(name=name, root_dir=root_dir, primitives=primitives)
+
+
+def _ctx(*, package_deployed_files, existing_lockfile, targets, project_root):
+    return SimpleNamespace(
+        package_deployed_files=package_deployed_files,
+        existing_lockfile=existing_lockfile,
+        targets=targets,
+        project_root=project_root,
+    )
+
+
+class TestAttachDeployedFilesUnion:
+    def test_preserves_other_target_entry_when_dep_absent_from_current_install(self, tmp_path):
+        """copilot install records .agents/skills; a later copilot-app install
+        (which records nothing for this skill-only dep) must NOT erase them."""
+        key = "owner/pkg"
+        prior = LockFile()
+        prior.add_dependency(
+            LockedDependency(
+                repo_url=key,
+                deployed_files=[".agents/skills/demo/SKILL.md", ".github/agents/demo.md"],
+                deployed_file_hashes={
+                    ".agents/skills/demo/SKILL.md": "sha256:aaa",
+                    ".github/agents/demo.md": "sha256:bbb",
+                },
+            )
+        )
+        new = LockFile()
+        new.add_dependency(LockedDependency(repo_url=key))
+
+        ctx = _ctx(
+            package_deployed_files={},  # copilot-app records nothing for this dep
+            existing_lockfile=prior,
+            targets=[_target("copilot-app")],
+            project_root=tmp_path,
+        )
+        LockfileBuilder(ctx)._attach_deployed_files(new)
+
+        dep = new.get_dependency(key)
+        assert ".agents/skills/demo/SKILL.md" in dep.deployed_files
+        assert dep.deployed_file_hashes[".agents/skills/demo/SKILL.md"] == "sha256:aaa"
+
+    def test_replaces_current_target_entries_but_unions_other_target(self, tmp_path):
+        """A copilot-app install replaces its own URI rows yet preserves the
+        file-based copilot entries from the prior install."""
+        key = "owner/pkg"
+        prior = LockFile()
+        prior.add_dependency(
+            LockedDependency(
+                repo_url=key,
+                deployed_files=[
+                    ".agents/skills/demo/SKILL.md",
+                    "copilot-app-db://workflows/old-id",
+                ],
+                deployed_file_hashes={".agents/skills/demo/SKILL.md": "sha256:aaa"},
+            )
+        )
+        new = LockFile()
+        new.add_dependency(LockedDependency(repo_url=key))
+
+        ctx = _ctx(
+            package_deployed_files={key: ["copilot-app-db://workflows/new-id"]},
+            existing_lockfile=prior,
+            targets=[_target("copilot-app")],
+            project_root=tmp_path,
+        )
+        LockfileBuilder(ctx)._attach_deployed_files(new)
+
+        dep = new.get_dependency(key)
+        # current-target URI row replaced
+        assert "copilot-app-db://workflows/new-id" in dep.deployed_files
+        assert "copilot-app-db://workflows/old-id" not in dep.deployed_files
+        # other-target file rows preserved
+        assert ".agents/skills/demo/SKILL.md" in dep.deployed_files
+
+    def test_file_target_reinstall_drops_stale_in_target_files(self, tmp_path):
+        """A same-target reinstall must still drop files removed from the
+        package (no false preservation within the governed roots)."""
+        key = "owner/pkg"
+        (tmp_path / ".github").mkdir()
+        kept = tmp_path / ".github" / "kept.md"
+        kept.write_text("x", encoding="utf-8")
+        prior = LockFile()
+        prior.add_dependency(
+            LockedDependency(
+                repo_url=key,
+                deployed_files=[".github/kept.md", ".github/removed.md"],
+            )
+        )
+        new = LockFile()
+        new.add_dependency(LockedDependency(repo_url=key))
+
+        ctx = _ctx(
+            package_deployed_files={key: [".github/kept.md"]},
+            existing_lockfile=prior,
+            targets=[_target("copilot", root_dir=".github", deploy_roots=[".agents"])],
+            project_root=tmp_path,
+        )
+        LockfileBuilder(ctx)._attach_deployed_files(new)
+
+        dep = new.get_dependency(key)
+        assert ".github/kept.md" in dep.deployed_files
+        assert ".github/removed.md" not in dep.deployed_files
+
+
+class TestCurrentInstallGovernance:
+    def test_file_target_includes_root_and_primitive_deploy_roots(self, tmp_path):
+        from apm_cli.install.manifest_reconcile import install_governance
+
+        targets = [_target("copilot", root_dir=".github", deploy_roots=[".agents"])]
+        file_roots, uri_schemes = install_governance(targets)
+        assert ".github" in file_roots
+        assert ".agents" in file_roots
+        assert uri_schemes == set()
+
+    def test_copilot_app_target_uses_uri_scheme(self, tmp_path):
+        from apm_cli.install.manifest_reconcile import install_governance
+
+        _file_roots, uri_schemes = install_governance([_target("copilot-app")])
+        assert any(s.startswith("copilot-app-db://") for s in uri_schemes)
+
+
+class TestLocalDeployedFilesUnion:
+    def test_copilot_app_install_preserves_prior_copilot_local_files(self):
+        """The project-root local_deployed_files block must also union: a
+        copilot-app install (no project file deployment) must NOT erase the
+        .agents/.github files a prior copilot install recorded -- the bug that
+        wiped content-integrity coverage entirely (issue #1716)."""
+        from apm_cli.install.manifest_reconcile import union_preserving
+
+        prior_files = [".agents/skills/demo/SKILL.md", ".github/agents/demo.md"]
+        prior_hashes = {
+            ".agents/skills/demo/SKILL.md": "sha256:aaa",
+            ".github/agents/demo.md": "sha256:bbb",
+        }
+        files, hashes = union_preserving(
+            current_files=[],  # copilot-app deploys no project files
+            current_hashes={},
+            prior_files=prior_files,
+            prior_hashes=prior_hashes,
+            targets=[_target("copilot-app")],
+        )
+        assert ".agents/skills/demo/SKILL.md" in files
+        assert hashes[".agents/skills/demo/SKILL.md"] == "sha256:aaa"
+
+    def test_same_target_reinstall_drops_removed_local_file(self):
+        from apm_cli.install.manifest_reconcile import union_preserving
+
+        files, _ = union_preserving(
+            current_files=[".agents/skills/demo/SKILL.md"],
+            current_hashes={".agents/skills/demo/SKILL.md": "sha256:new"},
+            prior_files=[".agents/skills/demo/SKILL.md", ".agents/skills/gone/SKILL.md"],
+            prior_hashes={},
+            targets=[_target("copilot", root_dir=".github", deploy_roots=[".agents"])],
+        )
+        assert ".agents/skills/demo/SKILL.md" in files
+        assert ".agents/skills/gone/SKILL.md" not in files

--- a/tests/unit/install/test_drift.py
+++ b/tests/unit/install/test_drift.py
@@ -20,6 +20,7 @@ from apm_cli.install.drift import (
     CheckLogger,
     DriftFinding,
     ReplayConfig,
+    _governed_root_dirs,
     _normalize_line_endings,
     _strip_bom,
     _strip_build_id,
@@ -227,6 +228,69 @@ def test_diff_engine_100kb_inline_cap(tmp_path):
     assert len(findings) == 1
     assert findings[0].kind == "modified"
     assert "too large for inline diff" in findings[0].inline_diff
+
+
+# ---------------------------------------------------------------------------
+# Governed roots: per-primitive deploy_root walking (issue #1716)
+# ---------------------------------------------------------------------------
+
+
+def _target_with_skill_deploy_root(root_dir: str = ".github", deploy_root: str = ".agents"):
+    """Build a minimal TargetProfile-like stub for governed-root tests."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        root_dir=root_dir,
+        primitives={"skills": SimpleNamespace(deploy_root=deploy_root)},
+    )
+
+
+def test_governed_root_dirs_includes_primitive_deploy_root():
+    """The differ must walk per-primitive deploy roots (copilot skills ->
+    .agents), not only the target's top-level root_dir -- otherwise committed
+    .agents/skills/ content escapes drift detection (issue #1716)."""
+    roots = _governed_root_dirs([_target_with_skill_deploy_root()])
+    assert ".apm" in roots
+    assert ".github" in roots
+    assert ".agents" in roots
+
+
+def test_governed_root_dirs_collapses_nested_deploy_root_to_first_segment():
+    roots = _governed_root_dirs([_target_with_skill_deploy_root(deploy_root=".agents/nested")])
+    assert ".agents" in roots
+    assert ".agents/nested" not in roots
+
+
+def test_diff_engine_walks_skill_deploy_root_detects_drift(tmp_path):
+    """Trap B (drift): a committed skill under the deploy_root that diverges
+    from the replay must be flagged. Fails before the deploy_root walk is
+    added because .agents is never compared."""
+    scratch = tmp_path / "scratch"
+    project = tmp_path / "project"
+    rel = ".agents/skills/demo/SKILL.md"
+    _write(scratch / rel, b"fresh replay content\n")
+    _write(project / rel, b"stale committed content\n")
+    targets = [_target_with_skill_deploy_root()]
+
+    findings = diff_scratch_against_project(scratch, project, _empty_lockfile(), targets=targets)
+    assert len(findings) == 1
+    assert findings[0].kind == "modified"
+    assert findings[0].path == rel
+
+
+def test_diff_engine_skill_deploy_root_clean_when_identical(tmp_path):
+    """No false-positive drift when the committed skill matches the replay
+    byte-for-byte under the deploy_root."""
+    scratch = tmp_path / "scratch"
+    project = tmp_path / "project"
+    rel = ".agents/skills/demo/SKILL.md"
+    same = b"identical bytes\n"
+    _write(scratch / rel, same)
+    _write(project / rel, same)
+    targets = [_target_with_skill_deploy_root()]
+
+    findings = diff_scratch_against_project(scratch, project, _empty_lockfile(), targets=targets)
+    assert findings == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/policy/test_ci_checks.py
+++ b/tests/unit/policy/test_ci_checks.py
@@ -488,6 +488,67 @@ class TestContentIntegrity:
             result.details
         )
 
+    def test_agents_skill_tamper_fails_content_integrity(self, tmp_path):
+        # Trap A (issue #1716): a deployed skill under the copilot skills
+        # deploy_root (.agents/skills/<s>/SKILL.md) must be covered by the
+        # per-file content-integrity manifest. Tampering the deployed file
+        # without re-installing has to fail `apm audit --ci --no-drift`.
+        from apm_cli.utils.content_hash import compute_file_hash
+
+        rel = ".agents/skills/demo/SKILL.md"
+        _make_deployed_file(tmp_path, rel, "---\nname: demo\n---\nOriginal skill\n")
+        recorded_hash = compute_file_hash(tmp_path / rel)
+        _write_lockfile(
+            tmp_path,
+            textwrap.dedent(f"""\
+                lockfile_version: '1'
+                generated_at: '2025-01-01T00:00:00Z'
+                dependencies:
+                  - repo_url: owner/repo
+                    deployed_files:
+                      - .agents/skills/demo
+                      - {rel}
+                    deployed_file_hashes:
+                      {rel}: '{recorded_hash}'
+            """),
+        )
+        # Tamper the deployed skill after install (no re-deploy).
+        (tmp_path / rel).write_text("---\nname: demo\n---\nTampered skill\n", encoding="utf-8")
+
+        from apm_cli.deps.lockfile import LockFile, get_lockfile_path
+
+        lock = LockFile.read(get_lockfile_path(tmp_path))
+        result = _check_content_integrity(tmp_path, lock)
+        assert not result.passed
+        assert any("hash-drift" in d and rel in d for d in result.details), result.details
+
+    def test_agents_skill_clean_passes_content_integrity(self, tmp_path):
+        # Companion to Trap A: an untampered deployed skill hashes clean.
+        from apm_cli.utils.content_hash import compute_file_hash
+
+        rel = ".agents/skills/demo/SKILL.md"
+        _make_deployed_file(tmp_path, rel, "---\nname: demo\n---\nOriginal skill\n")
+        recorded_hash = compute_file_hash(tmp_path / rel)
+        _write_lockfile(
+            tmp_path,
+            textwrap.dedent(f"""\
+                lockfile_version: '1'
+                generated_at: '2025-01-01T00:00:00Z'
+                dependencies:
+                  - repo_url: owner/repo
+                    deployed_files:
+                      - .agents/skills/demo
+                      - {rel}
+                    deployed_file_hashes:
+                      {rel}: '{recorded_hash}'
+            """),
+        )
+        from apm_cli.deps.lockfile import LockFile, get_lockfile_path
+
+        lock = LockFile.read(get_lockfile_path(tmp_path))
+        result = _check_content_integrity(tmp_path, lock)
+        assert result.passed, result.details
+
     def test_hash_skips_missing_file(self, tmp_path):
         # Lockfile records a file with a hash, but the file is missing on
         # disk -- _check_deployed_files_present owns that signal, so


### PR DESCRIPTION
# fix(install): catch silent drift in committed `.agents/skills` bundles

## TL;DR

Committed deployed content under `.agents/skills/**` could silently drift from its `packages/**` / `.apm/**` source while every CI gate stayed green (#1716). The fix makes the lockfile integrity manifest **target-complete** (per-file hashes for every committed deploy target), makes the drift differ **target-aware** (walks each primitive's `deploy_root`), and runs that gate live in CI by dropping `--no-drift`. Two regression traps lock the behavior in.

> [!NOTE]
> Closes #1716. Discovered while shipping #1714 (fixes #1712), where `apm.lock.yaml` was deliberately left untouched to preserve evidence for this investigation.

## Problem (WHY)

- [x] `.agents/skills/apm-review-panel/SKILL.md` shipped drifted (415 deployed lines vs 446 in source — an entire persona missing) yet `apm audit --ci --no-drift` stayed green.
- [x] The committed `apm.lock.yaml` carried **zero** `deployed_file_hashes`: a multi-target deploy then a `copilot-app` install rewrote the manifest to a single target, orphaning the committed `.github/` + `.agents/` files from every manifest-driven gate.
- [x] Skills were recorded as a single directory entry (e.g. `.agents/skills/auth`), and `compute_deployed_hashes` skips directories (`phases/lockfile.py` line 42), so `SKILL.md` had no per-file hash coverage.
- [!] The drift differ never walked `.agents/` at all — `_governed_root_dirs` returned only `.apm` + `.github`, so even with drift enabled the skill tree was invisible.

Why these matter: `apm audit` is APM's governance gate, and a gate that cannot observe its own deployed artifacts is not a gate. Grounding the audit in a deterministic install-replay is what makes drift verifiable rather than assumed — per PROSE, ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)

## Approach (WHAT)

| # | Fix |
|---|-----|
| 1 | **Target-complete manifest** — new `manifest_reconcile.union_preserving` reconciles the lockfile symmetrically with on-disk cleanup: the current install's entries are authoritative, other targets' entries are preserved (not clobbered). |
| 2 | **Per-file skill entries** — `services._skill_bundle_file_entries` expands each deployed skill dir into the dir entry **plus** its files, so `content-integrity` hashes `SKILL.md` / assets / scripts. |
| 3 | **Target-aware differ** — `drift._governed_root_dirs` now includes every primitive's `deploy_root` first segment, so the replay differ walks `.agents/skills/**`. |
| 4 | **Live CI gate** — `ci.yml` `apm-self-check` drops `--no-drift` and deletes a dead Gate-B git-status step (a guaranteed no-op). |
| 5 | **Tree correction** — regenerated 10 skill bundles to the deterministic `apm install` output (stale broken `../../agents/` links → `../../../.apm/agents/`) and refreshed `apm.lock.yaml` hashes. |

## Implementation (HOW)

- **`src/apm_cli/install/manifest_reconcile.py`** (new) — `union_preserving` + `install_governance`; a small shared helper imported by both manifest build sites so the reconciliation logic is identical.
- **`src/apm_cli/install/services.py`** — `_skill_bundle_file_entries` at the single skill-integration chokepoint; the directory entry is retained (cleanup's directory-rejection contract depends on it).
- **`src/apm_cli/install/phases/lockfile.py`** & **`post_deps_local.py`** — call `union_preserving` for the per-dependency and project-root manifests.
- **`src/apm_cli/install/drift.py`** — `_governed_root_dirs` walks each `deploy_root`; the replay reproduces the deploy-time link rewrite, so byte-identical skills do not surface as false drift.
- **`.github/workflows/ci.yml`** — Gate A is now `apm audit --ci`; dead Gate B removed.
- **`apm.lock.yaml`** + **`.agents/skills/<10>/SKILL.md`** — regenerated tool output (data, not logic).

## Diagrams

Legend: the manifest path — how a `copilot-app` install used to clobber skill coverage, and how `union_preserving` (dashed) plus per-file skill entries (dashed) restore per-file hashing under `content-integrity`.

```mermaid
flowchart LR
    subgraph Deploy["Deploy"]
        D1["copilot target writes .agents/skills + .github"]
        D2["copilot-app install writes DB-URI rows"]
    end
    subgraph Manifest["Lockfile manifest"]
        M3["union_preserving reconcile"]
        M1["deployed_files"]
        M4["per-file skill entries SKILL.md + assets"]
        M2["deployed_file_hashes"]
    end
    subgraph Audit["apm audit"]
        A1["content-integrity hashes each file"]
    end
    D1 --> M1
    D2 --> M3
    M3 --> M1
    M1 --> M4
    M4 --> M2
    M2 --> A1
    classDef new stroke-dasharray: 5 5;
    class M3,M4 new;
```

Legend: the drift path — `apm audit --ci` replays the install into a scratch tree, and the differ now walks the `.agents` deploy root (dashed) so committed skill bundles are compared against the replay.

```mermaid
flowchart LR
    subgraph Source["Source"]
        S1[".apm/skills + packages"]
    end
    subgraph Replay["apm audit --ci replay"]
        R1["install replay scratch tree"]
        R2["_governed_root_dirs adds .agents deploy_root"]
    end
    subgraph Compare["Differ"]
        C1["walk .agents/skills"]
        C2["drift found, exit 1"]
    end
    S1 --> R1
    R1 --> R2
    R2 --> C1
    C1 --> C2
    classDef new stroke-dasharray: 5 5;
    class R2,C1 new;
```

## Trade-offs

- **Shared helper vs inline reconciliation.** Extracted `manifest_reconcile` rather than duplicating the union logic in both build sites — one source of truth, in the spirit of PROSE's ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)
- **Regenerated the committed tree to tool output.** The committed skill links were stale and broken (`../../agents/` resolves to a non-existent `.agents/agents/`); a fresh `apm install` deterministically emits `../../../.apm/agents/`. Chose to make committed == install output so the differ is clean in steady state.
- **Latent install non-idempotency left in place.** `apm install` won't self-heal an already-deployed skill dir whose bytes match source; the new drift gate now *catches* this, but a self-healing install is a separate PR.
- **`post_deps_local` union over overwrite.** Could in principle preserve a stale entry for an ungoverned top-level file; verified unreachable today (`local_deployed_files` holds only `.github/**` + `.agents/**`, both governed by the copilot target).

## Benefits

1. Tampering any deployed `.agents/skills/<s>/SKILL.md` now fails `apm audit --ci --no-drift` (exit 1) instead of passing silently.
2. Editing a source skill now fails `apm audit --ci` with the exact deployed path that drifted.
3. The committed `apm.lock.yaml` covers every committed file-based deploy target (42 per-file skill entries), not one.
4. The CI `apm-self-check` job runs the drift gate on every PR — no `--no-drift` escape hatch.

## Validation

`apm audit --ci` (drift gate now live, `--no-drift` dropped):

```
[+] Replayed 7 package(s)
[+] No drift detected
[+] content-integrity        No critical hidden Unicode or hash drift detected
[+] drift                    no drift detected against lockfile
[*] All 9 check(s) passed
```

<details><summary>Live trap reproduction (both gates fail on drift)</summary>

```
# Trap A — tamper a deployed skill
$ printf '\nTAMPER\n' >> .agents/skills/auth/SKILL.md
$ uv run apm audit --ci --no-drift   # exit 1: content-integrity hash drift

# Trap B — edit the source skill
$ printf '\n<!-- drift -->\n' >> .apm/skills/auth/SKILL.md
$ uv run apm audit --ci              # exit 1: drift detected: .agents/skills/auth/SKILL.md
```

</details>

CI on head `420ab863`: all required checks green, including **APM Self-Check** running the new target-aware drift gate. Local unit gate: `pytest tests/unit tests/test_console.py -n 2 --dist worksteal` → **16819 passed**.

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|------------------------|--------------|--------------------|------|
| 1 | A hand-edit to a deployed `.agents/skills/<s>/SKILL.md` is caught by `apm audit --ci --no-drift` | Governed by policy, Secure by default | `tests/unit/policy/test_ci_checks.py::test_agents_skill_tamper_fails_content_integrity` (regression-trap for #1716) | unit |
| 2 | Editing a source skill surfaces as drift at the deployed path under `apm audit --ci` | Governed by policy | `tests/unit/install/test_drift.py::test_diff_engine_walks_skill_deploy_root_detects_drift` (regression-trap for #1716) | unit |
| 3 | A byte-identical deployed skill is NOT a false positive | Governed by policy, DevX | `tests/unit/install/test_drift.py::test_diff_engine_skill_deploy_root_clean_when_identical` | unit |
| 4 | The differ's governed roots include each primitive's `deploy_root` (`.agents`) | Portability by manifest | `tests/unit/install/test_drift.py::test_governed_root_dirs_includes_primitive_deploy_root` | unit |

## How to test

- [ ] Run `uv run apm audit --ci` on a clean checkout → all 9 checks pass.
- [ ] `printf '\nX\n' >> .agents/skills/auth/SKILL.md` then `uv run apm audit --ci --no-drift` → exit 1 (`content-integrity`); restore with `git checkout`.
- [ ] `printf '\nX\n' >> .apm/skills/auth/SKILL.md` then `uv run apm audit --ci` → exit 1 (`drift: .agents/skills/auth/SKILL.md`); restore.
- [ ] `uv run pytest tests/unit/install/test_drift.py tests/unit/policy/test_ci_checks.py -q` → green.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
