### PR TITLE
fix(tests): skip install.sh safety tests when POSIX bash is unavailable

### DIFF
--- a/tests/unit/install/test_install_safety.py
+++ b/tests/unit/install/test_install_safety.py
@@ -34,6 +34,42 @@ SENTINEL_BEGIN = re.compile(r"^# INSTALL_SAFETY_BEGIN", re.MULTILINE)
 SENTINEL_END = re.compile(r"^# INSTALL_SAFETY_END", re.MULTILINE)
 
 
+def _usable_bash() -> bool:
+    """Return True only when a real POSIX bash is invocable.
+
+    install.sh is the Unix installer (Windows uses install.ps1), and these
+    tests shell out to ``bash`` to exercise its safety validator. On
+    ``windows-latest`` GitHub runners the ambient ``bash`` on PATH is the WSL
+    stub (``C:\\Windows\\System32\\bash.exe``); with no distribution installed
+    it exits non-zero for every invocation, which would otherwise make every
+    bash-dependent test here fail with a uniform exit code rather than skip.
+    Probe with a trivial POSIX command and treat anything unexpected as "no
+    usable bash" so the suite skips instead of failing on such platforms.
+    """
+    try:
+        proc = subprocess.run(
+            ["bash", "-c", "printf ok"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return proc.returncode == 0 and proc.stdout.strip() == "ok"
+
+
+_BASH_USABLE = _usable_bash()
+
+requires_bash = pytest.mark.skipif(
+    not _BASH_USABLE,
+    reason="POSIX bash unavailable (e.g. Windows WSL stub); install.sh is the Unix installer",
+)
+
+# Prevent Git Bash (MSYS2) from rewriting POSIX-looking arguments such as
+# /usr/local/lib/apm into Windows paths when a real bash is present.
+_BASH_ENV_EXTRA = {"MSYS_NO_PATHCONV": "1", "MSYS2_ARG_CONV_EXCL": "*"}
+
+
 def _read_install_sh() -> str:
     """Read install.sh in a shell-safe form across platforms.
 
@@ -81,7 +117,7 @@ apm_lib_dir_validate "$1"
             input="",
             capture_output=True,
             text=True,
-            env={**os.environ, "HOME": home},
+            env={**os.environ, "HOME": home, **_BASH_ENV_EXTRA},
             cwd=tmp,
             timeout=10,
         )
@@ -102,7 +138,7 @@ apm_prepare_lib_parent "$1"
             input="",
             capture_output=True,
             text=True,
-            env={**os.environ, "HOME": home},
+            env={**os.environ, "HOME": home, **_BASH_ENV_EXTRA},
             cwd=tmp,
             timeout=10,
         )
@@ -114,6 +150,7 @@ apm_prepare_lib_parent "$1"
 # ---------------------------------------------------------------------------
 
 
+@requires_bash
 class TestAbsolutePathGuard:
     def test_accepts_unix_absolute(self):
         assert _run_validator("/usr/local/lib/apm") == 0
@@ -133,6 +170,7 @@ class TestAbsolutePathGuard:
 # ---------------------------------------------------------------------------
 
 
+@requires_bash
 class TestSuffixGuard:
     def test_accepts_apm_suffix(self):
         assert _run_validator("/opt/apm") == 0
@@ -172,6 +210,7 @@ class TestSuffixGuard:
 # ---------------------------------------------------------------------------
 
 
+@requires_bash
 class TestBlocklistGuard:
     @pytest.mark.parametrize(
         "broad_path",
@@ -244,6 +283,7 @@ class TestBlocklistGuard:
 # ---------------------------------------------------------------------------
 
 
+@requires_bash
 class TestMarkerFileGuard:
     """Guard 4 only fires when the directory exists and is non-empty. The
     Python harness stages directories under a tempdir and calls the validator
@@ -306,6 +346,7 @@ class TestMarkerFileGuard:
 # ---------------------------------------------------------------------------
 
 
+@requires_bash
 class TestUserLocalInstall:
     def test_prepare_parent_creates_missing_user_local_lib_without_sudo(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -328,6 +369,7 @@ class TestUserLocalInstall:
                 protected.chmod(0o755)
 
 
+@requires_bash
 class TestReportedIncident:
     """The exact command from issue #1690's reproduction must be blocked."""
 


### PR DESCRIPTION
## TL;DR

The `Build & Test (windows-latest)` CI job was failing with 30 test failures in `tests/unit/install/test_install_safety.py`, all with a uniform `assert 1 == <expected>`. These tests shell out to `bash` to exercise the Unix installer's safety validator; on `windows-latest` runners the ambient `bash` is the WSL stub and exits `1` for every call. This PR skips the bash-dependent tests where no usable POSIX bash exists.

## Problem (WHY)

`tests/unit/install/test_install_safety.py` sources the `apm_lib_dir_validate()` block out of `install.sh` and runs it under `bash` to assert exit codes (`0`, `11`, `12`, `14`). On `windows-latest` GitHub runners, the `bash` on PATH resolves to the **WSL stub** (`C:\Windows\System32\bash.exe`). With no Linux distribution installed, that stub exits `1` for *every* invocation — so all 30 bash-dependent tests failed with the same `assert 1 == 0/11/12/14`, while the 3 pure-Python sentinel tests passed.

`install.sh` is the Unix installer; Windows installs via `install.ps1`. There is no value in running these shell-validator tests on a Windows runner that has no POSIX bash.

Linux (x64/arm64) and macOS jobs were green — the failure was Windows-only.

## Approach (WHAT)

Detect whether a real POSIX `bash` is invocable, and skip the bash-dependent test classes when it is not — instead of letting them fail with a misleading uniform exit code. The pure-Python sentinel-invariant tests keep running on every platform.

## Implementation (HOW)

In `tests/unit/install/test_install_safety.py`:

- Added `_usable_bash()`: probes `bash -c "printf ok"` and returns true only when it exits `0` and prints `ok`. Any `OSError` / `SubprocessError` / non-zero exit (the WSL-stub case) yields `False`.
- Added a module-level `requires_bash = pytest.mark.skipif(...)` and applied it to the six bash-dependent classes (`TestAbsolutePathGuard`, `TestSuffixGuard`, `TestBlocklistGuard`, `TestMarkerFileGuard`, `TestUserLocalInstall`, `TestReportedIncident`). `TestSentinelInvariants` is pure-Python and stays unmarked.
- Set `MSYS_NO_PATHCONV=1` / `MSYS2_ARG_CONV_EXCL=*` on the subprocess env so a *real* Git Bash (MSYS2) runner does not rewrite POSIX path arguments like `/usr/local/lib/apm` into Windows paths.

## Trade-offs

- On a Windows runner with no POSIX bash, these validator tests are skipped rather than executed. That is correct: the code under test (`install.sh`) never runs on Windows, and the existing CRLF-normalization plus sentinel tests still guard the script's testability invariants. Linux and macOS continue to execute the full validator matrix.

## Validation evidence

- macOS (bash usable): `43 passed` — unchanged from baseline.
- Simulated WSL stub (a fake `bash` on PATH that exits `1`): `3 passed, 40 skipped` — the bash-dependent tests skip cleanly and the pure-Python sentinel tests still run.
- `ruff check` and `ruff format --check` on the changed file: clean.

## How to test

```bash
# Normal (POSIX bash present): all tests run
uv run --extra dev pytest tests/unit/install/test_install_safety.py -q

# Simulate the windows-latest WSL stub locally:
mkdir -p /tmp/fakebash && printf '#!/bin/sh\nexit 1\n' > /tmp/fakebash/bash
chmod +x /tmp/fakebash/bash
PATH="/tmp/fakebash:$PATH" uv run --extra dev pytest tests/unit/install/test_install_safety.py -q
# expect: 3 passed, 40 skipped
rm -rf /tmp/fakebash
```

Failing run for reference: https://github.com/microsoft/apm/actions/runs/27216959181/job/80361090943