### PR TITLE
fix(preview): unpack all three values returned by _auto_compile_prompts

### DIFF
--- a/src/apm_cli/commands/run.py
+++ b/src/apm_cli/commands/run.py
@@ -138,7 +138,7 @@ def preview(ctx, script_name, param, verbose):
 
                 # Auto-compile prompts to show what would be executed.
                 # preview only needs the command and compiled prompt file list.
-                compiled_command, compiled_prompt_files, *_ = script_runner._auto_compile_prompts(
+                compiled_command, compiled_prompt_files, _ = script_runner._auto_compile_prompts(
                     command, params
                 )
 
@@ -178,7 +178,7 @@ def preview(ctx, script_name, param, verbose):
                 logger.progress("Original command:")
                 click.echo(f"  {command}")
 
-                compiled_command, compiled_prompt_files, *_ = script_runner._auto_compile_prompts(
+                compiled_command, compiled_prompt_files, _ = script_runner._auto_compile_prompts(
                     command, params
                 )
 

--- a/src/apm_cli/commands/run.py
+++ b/src/apm_cli/commands/run.py
@@ -137,7 +137,9 @@ def preview(ctx, script_name, param, verbose):
                 _rich_panel(command, title=" Original command", style="blue")
 
                 # Auto-compile prompts to show what would be executed
-                compiled_command, compiled_prompt_files = script_runner._auto_compile_prompts(
+                # _auto_compile_prompts returns (compiled_command, prompt_files, runtime_content);
+                # preview only needs the first two values.
+                compiled_command, compiled_prompt_files, _ = script_runner._auto_compile_prompts(
                     command, params
                 )
 
@@ -177,7 +179,7 @@ def preview(ctx, script_name, param, verbose):
                 logger.progress("Original command:")
                 click.echo(f"  {command}")
 
-                compiled_command, compiled_prompt_files = script_runner._auto_compile_prompts(
+                compiled_command, compiled_prompt_files, _ = script_runner._auto_compile_prompts(
                     command, params
                 )
 

--- a/src/apm_cli/commands/run.py
+++ b/src/apm_cli/commands/run.py
@@ -136,10 +136,9 @@ def preview(ctx, script_name, param, verbose):
                 # Show original and compiled commands in panels
                 _rich_panel(command, title=" Original command", style="blue")
 
-                # Auto-compile prompts to show what would be executed
-                # _auto_compile_prompts returns (compiled_command, prompt_files, runtime_content);
-                # preview only needs the first two values.
-                compiled_command, compiled_prompt_files, _ = script_runner._auto_compile_prompts(
+                # Auto-compile prompts to show what would be executed.
+                # preview only needs the command and compiled prompt file list.
+                compiled_command, compiled_prompt_files, *_ = script_runner._auto_compile_prompts(
                     command, params
                 )
 
@@ -179,7 +178,7 @@ def preview(ctx, script_name, param, verbose):
                 logger.progress("Original command:")
                 click.echo(f"  {command}")
 
-                compiled_command, compiled_prompt_files, _ = script_runner._auto_compile_prompts(
+                compiled_command, compiled_prompt_files, *_ = script_runner._auto_compile_prompts(
                     command, params
                 )
 

--- a/tests/unit/commands/test_run_command_surface.py
+++ b/tests/unit/commands/test_run_command_surface.py
@@ -25,15 +25,19 @@ def _make_script_runner(
     *,
     run_success: bool = True,
     scripts: dict[str, str] | None = None,
-    auto_compile_result: tuple[str, list[str]] | None = None,
+    auto_compile_result: tuple[str, list[str], str | None] | None = None,
 ) -> MagicMock:
     """Build a MagicMock that looks like a ScriptRunner instance."""
     runner = MagicMock()
     runner.run_script.return_value = run_success
     runner.list_scripts.return_value = scripts or {"start": "echo hello"}
     if auto_compile_result is not None:
-        compiled_cmd, prompt_files = auto_compile_result
-        runner._auto_compile_prompts.return_value = (compiled_cmd, prompt_files)
+        compiled_cmd, prompt_files, runtime_content = auto_compile_result
+        runner._auto_compile_prompts.return_value = (
+            compiled_cmd,
+            prompt_files,
+            runtime_content,
+        )
     return runner
 
 
@@ -239,7 +243,7 @@ class TestPreviewNoScriptName:
         """'start' script is used automatically when no name given."""
         mock_runner = _make_script_runner(
             scripts={"start": "echo hi"},
-            auto_compile_result=("echo hi", []),
+            auto_compile_result=("echo hi", [], None),
         )
         with (
             patch("apm_cli.commands.run._get_default_script", return_value="start"),
@@ -258,7 +262,7 @@ class TestPreviewScriptFound:
         """When no .prompt.md files compiled, shows 'no compilation' panel."""
         mock_runner = _make_script_runner(
             scripts={"build": "make all"},
-            auto_compile_result=("make all", []),
+            auto_compile_result=("make all", [], None),
         )
         with (
             patch("apm_cli.core.script_runner.ScriptRunner", MagicMock(return_value=mock_runner)),
@@ -274,7 +278,7 @@ class TestPreviewScriptFound:
         """When .prompt.md files are compiled, shows compiled command panel."""
         mock_runner = _make_script_runner(
             scripts={"run": "apm run my.prompt.md"},
-            auto_compile_result=("apm run compiled.txt", ["my.prompt.md"]),
+            auto_compile_result=("apm run compiled.txt", ["my.prompt.md"], None),
         )
         with (
             patch("apm_cli.core.script_runner.ScriptRunner", MagicMock(return_value=mock_runner)),
@@ -299,7 +303,7 @@ class TestPreviewScriptFound:
         """--param values are forwarded to _auto_compile_prompts."""
         mock_runner = _make_script_runner(
             scripts={"s": "cmd"},
-            auto_compile_result=("cmd", []),
+            auto_compile_result=("cmd", [], None),
         )
         with (
             patch("apm_cli.core.script_runner.ScriptRunner", MagicMock(return_value=mock_runner)),
@@ -313,7 +317,7 @@ class TestPreviewScriptFound:
         """Output filename is stem with .prompt removed + .txt extension."""
         mock_runner = _make_script_runner(
             scripts={"s": "cmd agent.prompt.md"},
-            auto_compile_result=("cmd compiled.txt", ["agent.prompt.md"]),
+            auto_compile_result=("cmd compiled.txt", ["agent.prompt.md"], None),
         )
         with (
             patch("apm_cli.core.script_runner.ScriptRunner", MagicMock(return_value=mock_runner)),
@@ -334,7 +338,7 @@ class TestPreviewFallbackRendering:
         """Fallback path (no rich) prints command via click.echo."""
         mock_runner = _make_script_runner(
             scripts={"s": "make all"},
-            auto_compile_result=("make all", []),
+            auto_compile_result=("make all", [], None),
         )
         with (
             patch("apm_cli.core.script_runner.ScriptRunner", MagicMock(return_value=mock_runner)),
@@ -352,7 +356,7 @@ class TestPreviewFallbackRendering:
         """Fallback path (no rich) prints compiled command and file list."""
         mock_runner = _make_script_runner(
             scripts={"s": "run a.prompt.md"},
-            auto_compile_result=("run compiled.txt", ["a.prompt.md"]),
+            auto_compile_result=("run compiled.txt", ["a.prompt.md"], None),
         )
         with (
             patch("apm_cli.core.script_runner.ScriptRunner", MagicMock(return_value=mock_runner)),
@@ -387,7 +391,7 @@ class TestPreviewFallbackRendering:
         """--verbose flag is accepted by preview command."""
         mock_runner = _make_script_runner(
             scripts={"s": "cmd"},
-            auto_compile_result=("cmd", []),
+            auto_compile_result=("cmd", [], None),
         )
         with (
             patch("apm_cli.core.script_runner.ScriptRunner", MagicMock(return_value=mock_runner)),

--- a/tests/unit/commands/test_run_phase3.py
+++ b/tests/unit/commands/test_run_phase3.py
@@ -25,15 +25,19 @@ def _make_script_runner(
     *,
     run_success: bool = True,
     scripts: dict[str, str] | None = None,
-    auto_compile_result: tuple[str, list[str]] | None = None,
+    auto_compile_result: tuple[str, list[str], str | None] | None = None,
 ) -> MagicMock:
     """Build a MagicMock that looks like a ScriptRunner instance."""
     runner = MagicMock()
     runner.run_script.return_value = run_success
     runner.list_scripts.return_value = scripts or {"start": "echo hello"}
     if auto_compile_result is not None:
-        compiled_cmd, prompt_files = auto_compile_result
-        runner._auto_compile_prompts.return_value = (compiled_cmd, prompt_files)
+        compiled_cmd, prompt_files, runtime_content = auto_compile_result
+        runner._auto_compile_prompts.return_value = (
+            compiled_cmd,
+            prompt_files,
+            runtime_content,
+        )
     return runner
 
 
@@ -239,7 +243,7 @@ class TestPreviewNoScriptName:
         """'start' script is used automatically when no name given."""
         mock_runner = _make_script_runner(
             scripts={"start": "echo hi"},
-            auto_compile_result=("echo hi", []),
+            auto_compile_result=("echo hi", [], None),
         )
         with (
             patch("apm_cli.commands.run._get_default_script", return_value="start"),
@@ -258,7 +262,7 @@ class TestPreviewScriptFound:
         """When no .prompt.md files compiled, shows 'no compilation' panel."""
         mock_runner = _make_script_runner(
             scripts={"build": "make all"},
-            auto_compile_result=("make all", []),
+            auto_compile_result=("make all", [], None),
         )
         with (
             patch("apm_cli.core.script_runner.ScriptRunner", MagicMock(return_value=mock_runner)),
@@ -274,7 +278,7 @@ class TestPreviewScriptFound:
         """When .prompt.md files are compiled, shows compiled command panel."""
         mock_runner = _make_script_runner(
             scripts={"run": "apm run my.prompt.md"},
-            auto_compile_result=("apm run compiled.txt", ["my.prompt.md"]),
+            auto_compile_result=("apm run compiled.txt", ["my.prompt.md"], None),
         )
         with (
             patch("apm_cli.core.script_runner.ScriptRunner", MagicMock(return_value=mock_runner)),
@@ -299,7 +303,7 @@ class TestPreviewScriptFound:
         """--param values are forwarded to _auto_compile_prompts."""
         mock_runner = _make_script_runner(
             scripts={"s": "cmd"},
-            auto_compile_result=("cmd", []),
+            auto_compile_result=("cmd", [], None),
         )
         with (
             patch("apm_cli.core.script_runner.ScriptRunner", MagicMock(return_value=mock_runner)),
@@ -313,7 +317,7 @@ class TestPreviewScriptFound:
         """Output filename is stem with .prompt removed + .txt extension."""
         mock_runner = _make_script_runner(
             scripts={"s": "cmd agent.prompt.md"},
-            auto_compile_result=("cmd compiled.txt", ["agent.prompt.md"]),
+            auto_compile_result=("cmd compiled.txt", ["agent.prompt.md"], None),
         )
         with (
             patch("apm_cli.core.script_runner.ScriptRunner", MagicMock(return_value=mock_runner)),
@@ -334,7 +338,7 @@ class TestPreviewFallbackRendering:
         """Fallback path (no rich) prints command via click.echo."""
         mock_runner = _make_script_runner(
             scripts={"s": "make all"},
-            auto_compile_result=("make all", []),
+            auto_compile_result=("make all", [], None),
         )
         with (
             patch("apm_cli.core.script_runner.ScriptRunner", MagicMock(return_value=mock_runner)),
@@ -352,7 +356,7 @@ class TestPreviewFallbackRendering:
         """Fallback path (no rich) prints compiled command and file list."""
         mock_runner = _make_script_runner(
             scripts={"s": "run a.prompt.md"},
-            auto_compile_result=("run compiled.txt", ["a.prompt.md"]),
+            auto_compile_result=("run compiled.txt", ["a.prompt.md"], None),
         )
         with (
             patch("apm_cli.core.script_runner.ScriptRunner", MagicMock(return_value=mock_runner)),
@@ -387,7 +391,7 @@ class TestPreviewFallbackRendering:
         """--verbose flag is accepted by preview command."""
         mock_runner = _make_script_runner(
             scripts={"s": "cmd"},
-            auto_compile_result=("cmd", []),
+            auto_compile_result=("cmd", [], None),
         )
         with (
             patch("apm_cli.core.script_runner.ScriptRunner", MagicMock(return_value=mock_runner)),


### PR DESCRIPTION
## Problem

`apm preview <script>` crashes with:

```
ValueError: too many values to unpack (expected 2)
```

This happens for **every script definition** regardless of content.

## Root Cause

`_auto_compile_prompts()` in `src/apm_cli/core/script_runner.py` has return type `tuple[str, list[str], str]` and always returns three values:

```python
return compiled_command, compiled_prompt_files, runtime_content
```

`_execute_script_command()` correctly unpacks all three:

```python
compiled_command, compiled_prompt_files, runtime_content = self._auto_compile_prompts(command, params)
```

But `preview()` in `src/apm_cli/commands/run.py` unpacks only two values in **both** its code paths:

1. The rich-UI `try` block (line ~142)
2. The `except (ImportError, NameError)` fallback path (line ~182)

## Fix

Add `_` to capture the unused `runtime_content` in both call-sites, matching how `_execute_script_command` already handles the return value. Preview does not execute the script, so `runtime_content` is not needed.

## Reproduction

Any `apm.yml` with a `scripts:` block:

```yaml
scripts:
  start: "echo hello"
```

```
$ apm preview start
Error previewing script: too many values to unpack (expected 2)
```

Tested against APM 0.19.0.