### PR TITLE
feat(marketplace): add sourceBase for nested package sources (#1519)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `apm.yml` marketplace blocks accept an optional `sourceBase` field: a git base
+  (`https://host/path`, arbitrary depth) that host-less relative package `source`
+  values compose onto, enabling deeply nested enterprise GitLab group paths that
+  the `host.tld/owner/repo` shorthand cannot express. Per-entry host-prefixed and
+  full-URL sources override the base; local and base-less configs are unchanged.
+  (by @leocamello, #1519)
+
 ## [0.18.0] - 2026-06-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   full-URL sources override the base; local and base-less configs are unchanged.
   (by @leocamello, #1519)
 
+### Fixed
+
+- `apm marketplace check` now resolves each package against its effective host
+  with that host's token (matching `apm pack`), instead of always probing the
+  default host with no token. Entries on a non-default host -- a
+  `host.tld/owner/repo` shorthand or a relative source composed onto
+  `marketplace.sourceBase` -- now validate correctly, and local `./` packages
+  skip the network entirely. (by @leocamello, #1519)
+
 ## [0.18.0] - 2026-06-04
 
 ### Added

--- a/docs/src/content/docs/producer/publish-to-a-marketplace.md
+++ b/docs/src/content/docs/producer/publish-to-a-marketplace.md
@@ -117,6 +117,33 @@ compiled `marketplace.json` -- that rename is the only structural
 transform `apm pack` performs. Strict schema: unknown keys raise an
 error, never silently ignored.
 
+### Deeply nested hosts: `sourceBase`
+
+If your packages live on a self-managed host whose group nesting is
+deeper than the `host.tld/owner/repo` shorthand can express (a common
+self-managed GitLab shape), declare a `sourceBase` once and write each
+`source` relative to it:
+
+```yaml
+marketplace:
+  owner:
+    name: acme-org
+  sourceBase: https://gitlab.acme.example.com/group/sub-group/team/projects
+  packages:
+    - name: my-package
+      source: my-package                  # -> .../team/projects/my-package
+      version: "^1.0.0"
+    - name: from-github
+      source: github.com/acme-org/helper  # host-prefixed: overrides the base
+      ref: v1.0.0
+```
+
+A host-less `source` composes onto `sourceBase`; a `source` that names
+its own host (the `host.tld/owner/repo` or full `https://` URL form) or
+a local `./` path overrides it and the base is ignored. Marketplaces
+without a `sourceBase` resolve exactly as before. See the
+[manifest schema](../reference/manifest-schema/) for the full rules.
+
 Add and edit packages without leaving the shell:
 
 ```bash

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -757,6 +757,7 @@ Overrides exist for the rare case where the published marketplace identity diffe
 | `output` | `string` | OPTIONAL | `.claude-plugin/marketplace.json` | Output path for the generated marketplace JSON. |
 | `metadata` | `object` | OPTIONAL | `{}` | Free-form metadata forwarded verbatim to `marketplace.json` (e.g. `homepage`, `support`). |
 | `build` | `Build` | OPTIONAL | `tagPattern: "v{version}"` | Build configuration for resolving package refs. See Section 7.4. |
+| `sourceBase` | `string` | OPTIONAL | -- | Git base (`https://<host.tld>/<path>`, arbitrary depth) that host-less relative package `source` values compose onto. See Section 7.5. |
 | `packages` | `list<Package>` | OPTIONAL | `[]` | Packages exposed in the marketplace. See Section 7.5. |
 
 Unknown keys inside `marketplace:` are rejected at parse time.
@@ -790,7 +791,7 @@ Each entry MUST be a mapping. Unknown keys are rejected.
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `name` | `string` | REQUIRED | Package identifier as it appears in the marketplace. |
-| `source` | `string` | REQUIRED | One of: `<owner>/<repo>` (remote on the default host), `<host.tld>/<owner>/<repo>` (remote on a non-default host such as GitHub Enterprise or self-hosted GitLab -- shorthand), `https://<host.tld>/<owner>/<repo>[.git]` (same, full URL form -- a trailing `.git` is stripped), or `./<path>` (local). Must match the source pattern; path traversal (`..`) is refused, and URL forms with userinfo (`user@host`), ports, query strings, or non-`https` schemes are rejected. |
+| `source` | `string` | REQUIRED | One of: `<owner>/<repo>` (remote on the default host), `<host.tld>/<owner>/<repo>` (remote on a non-default host such as GitHub Enterprise or self-hosted GitLab -- shorthand), `https://<host.tld>/<owner>/<repo>[.git]` (same, full URL form -- a trailing `.git` is stripped), or `./<path>` (local). When the block declares `sourceBase` (Section 7.2), a host-less relative form (`my-package`, `a/b/c`) is additionally accepted and composes onto the base; without a `sourceBase` the relative form is rejected. Must match the source pattern; path traversal (`..`) is refused, and URL forms with userinfo (`user@host`), ports, query strings, or non-`https` schemes are rejected. |
 | `subdir` | `string` | OPTIONAL | Subdirectory inside the source repo. Path-traversal-validated. Ignored for local sources. |
 | `version` | `string` | Conditional | Semver range (e.g. `^1.0.0`, `~2.1.0`, `>=3.0`). Stored as a string; resolution happens at pack time. REQUIRED for remote packages unless `ref` is given. |
 | `ref` | `string` | Conditional | Explicit git ref (SHA, tag, or branch). Overrides `version` range when both are present. REQUIRED for remote packages unless `version` is given. |
@@ -809,6 +810,43 @@ Remote packages MUST declare at least one of `version` or `ref`. Local packages 
 The first three `source` forms target a remote git host; the second and third name a non-default host (e.g. GitHub Enterprise, self-hosted GitLab) as either a shorthand or a full HTTPS URL with an optional `.git` suffix that is normalized away. Path traversal (`..`) in local paths, userinfo (`user@host`), ports, query strings, and non-`https` URL schemes are rejected at parse time.
 
 Non-default hosts authenticate via the standard APM token chain -- see the [authentication guide](../getting-started/authentication/) for the per-host-class lookup order. A token resolved for the default host is never forwarded to a non-default host.
+
+#### Composing relative sources onto `marketplace.sourceBase`
+
+`sourceBase` (Section 7.2) declares a git base -- `https://<host.tld>/<path>` with arbitrary path depth -- that host-less relative `source` values compose onto. It exists for enterprise hosts whose group nesting is deeper than the `host.tld/owner/repo` shorthand can express, e.g. a self-managed GitLab subgroup path `gitlab.example.com/group/sub-group/team/projects`.
+
+`sourceBase` is validated with the same posture as a per-entry `source`: it MUST be `https://`, the host MUST be an FQDN, and userinfo (`user@host`), ports, query strings, fragments, and a trailing `.git` are rejected. Each path segment is traversal-checked (`..` refused) and a trailing `/` is normalized away.
+
+When `sourceBase` is set, each package `source` resolves as:
+
+| `source` shape | Resolves to |
+|---|---|
+| `my-package` (relative, 1 segment) | `sourceBase` + `/my-package` |
+| `a/b/c` (relative, N segments) | `sourceBase` + `/a/b/c` |
+| `host.tld/owner/repo` (host-prefixed) | that host -- **base ignored (override)** |
+| `https://host.tld/owner/repo[.git]` (full URL) | that URL -- **base ignored (override)** |
+| `./local-pkg` (local) | local path -- **base ignored** |
+
+The rule: a `source` that carries its own host (host-prefixed or full-URL forms) or is local **overrides** the base; a host-less `source` **composes** onto it. Per-entry overrides are absolute and do not inherit the base path.
+
+Two consequences are intentional:
+
+- **Migration.** Existing marketplaces that do not declare `sourceBase` are unaffected -- every `source` resolves exactly as before. There is no migration step.
+- **No silent default-host routing.** Once `sourceBase` is declared, a bare `owner/repo` composes onto the base rather than resolving to the default host. To target the default host (e.g. github.com) from inside a `sourceBase` marketplace, write the explicit `github.com/owner/repo` host-prefixed form.
+
+```yaml
+marketplace:
+  owner:
+    name: contoso
+  sourceBase: https://gitlab.example.com/group/sub-group/team/projects
+  packages:
+    - name: my-package
+      source: my-package                  # -> https://gitlab.example.com/group/sub-group/team/projects/my-package
+      version: "^1.0.0"
+    - name: upstream-helper
+      source: github.com/contoso/helper   # host-prefixed override: base ignored
+      ref: v1.0.0
+```
 
 ### 7.6. Complete Marketplace Block
 

--- a/src/apm_cli/commands/marketplace/check.py
+++ b/src/apm_cli/commands/marketplace/check.py
@@ -8,6 +8,7 @@ import traceback
 import click
 
 from ...core.command_logger import CommandLogger
+from ...marketplace.auth_helpers import resolve_token_for_host
 from ...marketplace.errors import GitLsRemoteError, OfflineMissError
 from ...marketplace.ref_resolver import RefResolver
 from ...marketplace.semver import satisfies_range
@@ -40,15 +41,44 @@ def check(offline, verbose):
             symbol="info",
         )
 
-    resolver = RefResolver(offline=offline)
+    # One resolver per effective host. A package whose ``source`` named a
+    # non-default host -- a #1288 host-prefixed entry, or a relative entry
+    # composed onto ``marketplace.sourceBase`` -- carries that host on
+    # ``entry.host``; it must be resolved with a host-bound resolver and the
+    # host's token (e.g. GITLAB_APM_PAT), exactly like ``apm pack`` does.
+    # Default-host entries (``entry.host is None``) keep today's behaviour:
+    # a bare ``RefResolver(offline=...)`` with ambient credentials.
+    resolvers: dict[str | None, RefResolver] = {}
+
+    def _resolver_for(host: str | None) -> RefResolver:
+        if host not in resolvers:
+            if host is None:
+                resolvers[host] = RefResolver(offline=offline)
+            else:
+                token = resolve_token_for_host(host, offline=offline)
+                resolvers[host] = RefResolver(offline=offline, host=host, token=token)
+        return resolvers[host]
+
     results = []
     failure_count = 0
 
     try:
         for entry in yml.packages:
+            # Local-path packages skip git resolution entirely.
+            if entry.is_local:
+                results.append(
+                    _CheckResult(
+                        name=entry.name,
+                        reachable=True,
+                        version_found=True,
+                        ref_ok=True,
+                        error="",
+                    )
+                )
+                continue
             try:
-                # Attempt to resolve each entry
-                refs = resolver.list_remote_refs(entry.source)
+                # Attempt to resolve each entry against its effective host.
+                refs = _resolver_for(entry.host).list_remote_refs(entry.source)
 
                 # Check version/ref resolution
                 ref_ok = False
@@ -152,4 +182,5 @@ def check(offline, verbose):
             logger.success(f"All {total} entries OK", symbol="check")
 
     finally:
-        resolver.close()
+        for resolver in resolvers.values():
+            resolver.close()

--- a/src/apm_cli/marketplace/auth_helpers.py
+++ b/src/apm_cli/marketplace/auth_helpers.py
@@ -1,0 +1,48 @@
+"""Shared auth helpers for marketplace commands.
+
+Both ``apm pack`` (``MarketplaceBuilder``) and ``apm marketplace check`` need
+to resolve a per-host token before running ``git ls-remote`` against a
+non-default host (self-managed GitLab, GHES, ADO, Bitbucket DC). This module
+is the single home for that logic so the two paths cannot drift.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..core.auth import AuthResolver
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_token_for_host(
+    host: str,
+    *,
+    offline: bool = False,
+    auth_resolver: AuthResolver | None = None,
+) -> str | None:
+    """Resolve an auth token for a non-default *host* via ``AuthResolver``.
+
+    Returns ``None`` -- letting ``git`` fall back to ambient credentials --
+    when offline, when no token is configured for the host, or when
+    ``AuthResolver`` raises. Never raises.
+
+    Pass *auth_resolver* to reuse a cached resolver across many calls (the
+    builder does this during metadata prefetch); otherwise a fresh one is
+    created per call.
+    """
+    if offline:
+        return None
+    try:
+        from ..core.auth import AuthResolver  # lazy import to avoid cycles
+
+        resolver = auth_resolver if auth_resolver is not None else AuthResolver()
+        ctx = resolver.resolve(host)
+        if ctx.token:
+            logger.debug("Resolved token for host %s (source=%s)", host, ctx.source)
+            return ctx.token
+    except Exception:
+        logger.debug("Could not resolve token for host %s", host, exc_info=True)
+    return None

--- a/src/apm_cli/marketplace/builder.py
+++ b/src/apm_cli/marketplace/builder.py
@@ -416,26 +416,26 @@ class MarketplaceBuilder:
     def _resolve_token_for_host(self, host: str) -> str | None:
         """Resolve an auth token for a non-default *host* via ``AuthResolver``.
 
-        Returns ``None`` -- letting ``git`` fall back to ambient credentials
-        -- when offline, when no token is configured for the host, or when
-        ``AuthResolver`` raises.  Never raises.
+        Delegates to the shared
+        :func:`marketplace.auth_helpers.resolve_token_for_host` so ``apm pack``
+        and ``apm marketplace check`` share one implementation, reusing a
+        cached ``AuthResolver`` across calls. Returns ``None`` -- letting
+        ``git`` fall back to ambient credentials -- when offline, when no token
+        is configured, or on any error. Never raises.
         """
         if self._options.offline:
             return None
-        try:
-            from ..core.auth import AuthResolver  # lazy import
+        from .auth_helpers import resolve_token_for_host
 
-            resolver = self._auth_resolver
-            if resolver is None:
-                resolver = AuthResolver()
-                self._auth_resolver = resolver
-            ctx = resolver.resolve(host)  # type: ignore[union-attr]
-            if ctx.token:
-                logger.debug("Resolved token for host %s (source=%s)", host, ctx.source)
-                return ctx.token
-        except Exception:
-            logger.debug("Could not resolve token for host %s", host, exc_info=True)
-        return None
+        if self._auth_resolver is None:
+            try:
+                from ..core.auth import AuthResolver  # lazy import
+
+                self._auth_resolver = AuthResolver()
+            except Exception:
+                logger.debug("Could not create AuthResolver for host %s", host, exc_info=True)
+                return None
+        return resolve_token_for_host(host, auth_resolver=self._auth_resolver)
 
     def _ensure_auth(self) -> None:
         """Lazily resolve host classification and GitHub token.

--- a/src/apm_cli/marketplace/yml_editor.py
+++ b/src/apm_cli/marketplace/yml_editor.py
@@ -22,6 +22,7 @@ from ..utils.path_security import PathTraversalError, validate_path_segments
 from ._io import atomic_write
 from .errors import MarketplaceYmlError
 from .yml_schema import (
+    RELATIVE_SOURCE_RE,
     SOURCE_RE,
     load_marketplace_from_apm_yml,
     load_marketplace_yml,
@@ -129,23 +130,39 @@ def _find_entry_index(packages, name: str) -> int:
     raise MarketplaceYmlError(f"Package '{name}' not found")
 
 
-def _validate_source(source: str) -> None:
+def _validate_source(source: str, source_base: str | None = None) -> None:
     """Validate that *source* has one of the accepted shapes.
 
     Accepts ``owner/repo``, ``host.tld/owner/repo``, ``https://host.tld/
-    owner/repo[.git]`` (remote forms), or ``./<path>`` (local).
+    owner/repo[.git]`` (remote forms), or ``./<path>`` (local). When
+    *source_base* is set (the file declares ``marketplace.sourceBase``), a
+    host-less relative form (``my-package``, ``a/b/c``) is also accepted and
+    composes onto the base. Mirrors ``yml_schema._validate_source``.
     """
-    if not SOURCE_RE.match(source):
-        raise MarketplaceYmlError(
-            f"'source' must be one of "
-            f"'<owner>/<repo>', '<host.tld>/<owner>/<repo>', "
-            f"'https://<host.tld>/<owner>/<repo>[.git]', or './<path>', "
-            f"got '{source}'"
-        )
-    try:
-        validate_path_segments(source, context="source", allow_current_dir=True)
-    except PathTraversalError as exc:
-        raise MarketplaceYmlError(str(exc)) from exc
+    if SOURCE_RE.match(source):
+        try:
+            validate_path_segments(source, context="source", allow_current_dir=True)
+        except PathTraversalError as exc:
+            raise MarketplaceYmlError(str(exc)) from exc
+        return
+    if source_base is not None and RELATIVE_SOURCE_RE.match(source):
+        try:
+            validate_path_segments(source, context="source")
+        except PathTraversalError as exc:
+            raise MarketplaceYmlError(str(exc)) from exc
+        return
+    hint = (
+        " (or a host-less relative path like '<owner>/<repo>' that composes "
+        "onto marketplace.sourceBase)"
+        if source_base is not None
+        else " -- to use a relative path, declare 'marketplace.sourceBase'"
+    )
+    raise MarketplaceYmlError(
+        f"'source' must be one of "
+        f"'<owner>/<repo>', '<host.tld>/<owner>/<repo>', "
+        f"'https://<host.tld>/<owner>/<repo>[.git]', or './<path>'"
+        f"{hint}, got '{source}'"
+    )
 
 
 def _validate_subdir(subdir: str) -> None:
@@ -177,8 +194,14 @@ def add_plugin_entry(
 
     Returns the resolved package name.
     """
+    # --- load first so a declared sourceBase can inform source validation ---
+    data, original_text = _load_rt(yml_path)
+    container = _get_marketplace_container(data)
+    raw_base = container.get("sourceBase")
+    source_base = raw_base.strip() if isinstance(raw_base, str) and raw_base.strip() else None
+
     # --- input validation ---
-    _validate_source(source)
+    _validate_source(source, source_base=source_base)
 
     if version is not None and ref is not None:
         raise MarketplaceYmlError("Cannot specify both 'version' and 'ref' -- pick one")
@@ -188,13 +211,10 @@ def add_plugin_entry(
     if subdir is not None:
         _validate_subdir(subdir)
 
-    # Derive name from source repo if not provided.
+    # Derive name from the source's last path segment if not provided
+    # ('owner/repo' -> 'repo', 'a/b/c' -> 'c', 'my-package' -> 'my-package').
     if name is None:
-        name = source.split("/", 1)[1]
-
-    # --- load ---
-    data, original_text = _load_rt(yml_path)
-    container = _get_marketplace_container(data)
+        name = source.rstrip("/").rsplit("/", 1)[-1]
     packages = container.get("packages")
     if packages is None:
         from ruamel.yaml.comments import CommentedSeq

--- a/src/apm_cli/marketplace/yml_schema.py
+++ b/src/apm_cli/marketplace/yml_schema.py
@@ -44,6 +44,8 @@ from .output_profiles import MARKETPLACE_OUTPUTS, known_output_names
 
 __all__ = [
     "LOCAL_SOURCE_RE",
+    "RELATIVE_SOURCE_RE",
+    "SOURCE_BASE_RE",
     "SOURCE_RE",
     "MarketplaceBuild",
     "MarketplaceClaudeConfig",
@@ -100,6 +102,24 @@ LOCAL_SOURCE_RE = re.compile(r"^\./")
 _HOST_PREFIXED_SOURCE_RE = re.compile(rf"^({_HOST_PAT})/({_OWNER_REPO_PAT})$")
 # Matches ``https://host.tld/owner/repo[.git]`` and captures host + owner/repo.
 _HTTPS_URL_SOURCE_RE = re.compile(rf"^https://({_HOST_PAT})/({_OWNER_REPO_PAT})(?:\.git)?$")
+
+# Single path segment (same charset as ``owner``/``repo``). Shared by the
+# ``sourceBase`` and relative-source patterns below.
+_SEGMENT = r"[A-Za-z0-9._-]+"
+
+# Marketplace-level ``sourceBase``: ``https://host.tld/<segment>(/<segment>)*``.
+# Unlike per-entry ``source`` this allows arbitrary path depth (enterprise
+# GitLab nested groups), but keeps #1288's security posture otherwise:
+# https only, FQDN host, no ``.git`` / query / fragment / port / userinfo.
+# ``..`` survives this charset, so callers MUST also run the path through
+# ``validate_path_segments`` (defense in depth).
+SOURCE_BASE_RE = re.compile(rf"^https://{_HOST_PAT}/{_SEGMENT}(?:/{_SEGMENT})*$")
+
+# A host-less relative source (``my-package``, ``a/b/c``). Only meaningful when
+# a marketplace ``sourceBase`` is declared, in which case it composes onto the
+# base. Standard 2-segment ``owner/repo`` already matches ``SOURCE_RE``; this
+# pattern additionally admits the 1-segment and 3+-segment relative forms.
+RELATIVE_SOURCE_RE = re.compile(rf"^{_SEGMENT}(?:/{_SEGMENT})*$")
 
 
 def split_host_from_source(source: str) -> tuple[str | None, str]:
@@ -224,6 +244,7 @@ _APM_MARKETPLACE_KEYS = frozenset(
         "codex",
         "packages",
         "versioning",
+        "sourceBase",  # optional git base that relative package sources compose onto
     }
 )
 
@@ -388,6 +409,9 @@ class MarketplaceConfig:
     metadata: dict[str, Any] = field(default_factory=dict)
     build: MarketplaceBuild = field(default_factory=MarketplaceBuild)
     versioning: MarketplaceVersioning = field(default_factory=MarketplaceVersioning)
+    # Optional git base (``https://host/path``) that host-less relative package
+    # sources compose onto. ``None`` preserves today's behavior exactly.
+    source_base: str | None = None
     packages: tuple[PackageEntry, ...] = ()
     output_specs: tuple[MarketplaceOutputSpec, ...] = ()
     warnings: tuple[str, ...] = ()
@@ -433,27 +457,89 @@ def _validate_semver(version: str, *, context: str = "version") -> None:
         )
 
 
-def _validate_source(source: str, *, index: int) -> None:
+def _split_source_base(source_base: str) -> tuple[str, str]:
+    """Split a normalized ``sourceBase`` into ``(host, base_path)``.
+
+    ``source_base`` must already be validated and normalized (https scheme,
+    no trailing slash) by :func:`_validate_source_base`.
+    """
+    without_scheme = source_base[len("https://") :]
+    host, _, base_path = without_scheme.partition("/")
+    return host, base_path
+
+
+def _validate_source_base(raw: str) -> str:
+    """Validate and normalize the marketplace ``sourceBase`` field.
+
+    Inherits #1288's per-entry source security posture (https only, FQDN
+    host, no userinfo/port/query/fragment/.git) with one relaxation: the
+    path may be of arbitrary depth (enterprise GitLab nested groups). A
+    trailing ``/`` is stripped so composition is a clean ``base + "/" +
+    source``. Returns the normalized value.
+    """
+    value = raw.strip().rstrip("/")
+    # A base is a group path, not a repository -- reject a trailing ``.git``
+    # (the segment charset below would otherwise admit it).
+    if value.endswith(".git"):
+        raise MarketplaceYmlError(
+            "'marketplace.sourceBase' is a group path, not a repository; "
+            f"it must not end with '.git', got '{raw}'"
+        )
+    if not SOURCE_BASE_RE.match(value):
+        raise MarketplaceYmlError(
+            "'marketplace.sourceBase' must be an https URL of the form "
+            "'https://<host.tld>/<path>' (FQDN host, arbitrary depth; no "
+            "userinfo, port, query, fragment, or '.git' suffix), "
+            f"got '{raw}'"
+        )
+    # Defense in depth: the segment charset admits ``.``/``..``, so run the
+    # path through the sanctioned traversal guard as well.
+    _, base_path = _split_source_base(value)
+    try:
+        validate_path_segments(base_path, context="marketplace.sourceBase")
+    except PathTraversalError as exc:
+        raise MarketplaceYmlError(str(exc)) from exc
+    return value
+
+
+def _validate_source(source: str, *, index: int, source_base: str | None = None) -> None:
     """Validate ``source`` field shape and path safety.
 
     Accepts ``owner/repo``, ``host.tld/owner/repo``, ``https://host.tld/
-    owner/repo[.git]``, or ``./<path>``.
+    owner/repo[.git]``, or ``./<path>``. When *source_base* is set, also
+    accepts a host-less relative form (``my-package``, ``a/b/c``) that
+    composes onto the base. Without a base the relative form stays rejected
+    (fail-closed -- there is nothing to compose onto, and a bare name must
+    not silently route to the default host).
     """
     ctx = f"packages[{index}].source"
-    if not SOURCE_RE.match(source):
-        raise MarketplaceYmlError(
-            f"'{ctx}' must be one of "
-            f"'<owner>/<repo>', '<host.tld>/<owner>/<repo>', "
-            f"'https://<host.tld>/<owner>/<repo>[.git]', or './<path>', "
-            f"got '{source}'"
-        )
-    is_local = bool(LOCAL_SOURCE_RE.match(source))
-    try:
-        # Local paths legitimately start with ``.`` (current dir) and
-        # may have trailing-slash forms like ``./``.  Allow ``.`` here.
-        validate_path_segments(source, context=ctx, allow_current_dir=is_local)
-    except PathTraversalError as exc:
-        raise MarketplaceYmlError(str(exc)) from exc
+    if SOURCE_RE.match(source):
+        is_local = bool(LOCAL_SOURCE_RE.match(source))
+        try:
+            # Local paths legitimately start with ``.`` (current dir) and
+            # may have trailing-slash forms like ``./``.  Allow ``.`` here.
+            validate_path_segments(source, context=ctx, allow_current_dir=is_local)
+        except PathTraversalError as exc:
+            raise MarketplaceYmlError(str(exc)) from exc
+        return
+    if source_base is not None and RELATIVE_SOURCE_RE.match(source):
+        try:
+            validate_path_segments(source, context=ctx)
+        except PathTraversalError as exc:
+            raise MarketplaceYmlError(str(exc)) from exc
+        return
+    hint = (
+        " (or a host-less relative path like '<owner>/<repo>' that composes "
+        "onto marketplace.sourceBase)"
+        if source_base is not None
+        else " -- to use a relative path, declare 'marketplace.sourceBase'"
+    )
+    raise MarketplaceYmlError(
+        f"'{ctx}' must be one of "
+        f"'<owner>/<repo>', '<host.tld>/<owner>/<repo>', "
+        f"'https://<host.tld>/<owner>/<repo>[.git]', or './<path>'"
+        f"{hint}, got '{source}'"
+    )
 
 
 def _validate_tag_pattern(pattern: str, *, context: str) -> None:
@@ -700,8 +786,12 @@ def _parse_outputs(
     return tuple(outputs_list), tuple(specs_list)
 
 
-def _parse_package_entry(raw: Any, index: int) -> PackageEntry:
-    """Parse and validate a single ``packages`` entry."""
+def _parse_package_entry(raw: Any, index: int, *, source_base: str | None = None) -> PackageEntry:
+    """Parse and validate a single ``packages`` entry.
+
+    When *source_base* is set, a host-less relative ``source`` composes onto
+    the base (see :func:`_validate_source` and the rewrite below).
+    """
     if not isinstance(raw, dict):
         raise MarketplaceYmlError(f"packages[{index}] must be a mapping")
 
@@ -710,13 +800,24 @@ def _parse_package_entry(raw: Any, index: int) -> PackageEntry:
 
     name = _require_str(raw, "name", context=f"packages[{index}]")
     source = _require_str(raw, "source", context=f"packages[{index}]")
-    _validate_source(source, index=index)
+    _validate_source(source, index=index, source_base=source_base)
     is_local = bool(LOCAL_SOURCE_RE.match(source))
     # Detect host-prefixed source (e.g. ``host.tld/owner/repo``) and split
     # the host off so downstream consumers continue to see ``owner/repo``.
     host: str | None = None
     if not is_local:
         host, source = split_host_from_source(source)
+        # A host-less source under a declared ``sourceBase`` composes onto the
+        # base: rewrite it to the equivalent host-prefixed form so every
+        # downstream consumer (resolver, builder, output mappers) treats it
+        # exactly like a #1288 ``host.tld/owner/repo`` entry -- no special
+        # casing needed beyond this point. Host-prefixed and full-URL sources
+        # already carry their own host, so they are left untouched as
+        # per-entry overrides (the base is ignored), per the locked semantics.
+        if host is None and source_base is not None:
+            base_host, base_path = _split_source_base(source_base)
+            host = base_host
+            source = f"{base_path}/{source}"
 
     # APM-only: subdir (irrelevant for local packages but harmless)
     subdir: str | None = raw.get("subdir")
@@ -1166,6 +1267,14 @@ def _build_config(
                 )
     output_specs = tuple(final_specs_list)
 
+    # -- sourceBase (optional git base for host-less relative package sources) --
+    raw_source_base = marketplace_dict.get("sourceBase")
+    source_base: str | None = None
+    if raw_source_base is not None:
+        if not isinstance(raw_source_base, str) or not raw_source_base.strip():
+            raise MarketplaceYmlError("'marketplace.sourceBase' must be a non-empty string")
+        source_base = _validate_source_base(raw_source_base)
+
     # -- packages --
     raw_packages = marketplace_dict.get("packages")
     if raw_packages is None:
@@ -1176,7 +1285,7 @@ def _build_config(
     entries: list[PackageEntry] = []
     seen_names: dict[str, int] = {}
     for idx, raw_entry in enumerate(raw_packages):
-        entry = _parse_package_entry(raw_entry, idx)
+        entry = _parse_package_entry(raw_entry, idx, source_base=source_base)
         lower_name = entry.name.lower()
         if lower_name in seen_names:
             raise MarketplaceYmlError(
@@ -1209,6 +1318,7 @@ def _build_config(
         metadata=metadata,
         build=build,
         versioning=versioning,
+        source_base=source_base,
         packages=tuple(entries),
         output_specs=output_specs,
         warnings=tuple(warnings_sink),

--- a/tests/unit/commands/test_marketplace_check.py
+++ b/tests/unit/commands/test_marketplace_check.py
@@ -538,3 +538,129 @@ class TestCheckRefHeadsPrefix:
         # refs/tags/main stripped to "main" → tag_name == "main" == entry.ref → passes
         # (this also tests the tags branch hits and indirectly confirms the heads branch too)
         assert result.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# Per-host resolution (#1519 follow-up: check must honour entry.host + token)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPerHostResolution:
+    """`check` must resolve each entry against its effective host with that
+    host's token -- matching `apm pack`. A relative source composed onto
+    `sourceBase`, or a #1288 host-prefixed source, carries a non-default host
+    on `entry.host`; bare `owner/repo` keeps the default-host path.
+    """
+
+    @patch("apm_cli.commands.marketplace.check.resolve_token_for_host", return_value="glpat-xyz")
+    @patch("apm_cli.commands.marketplace.check.RefResolver")
+    @patch("apm_cli.commands.marketplace.check._load_config_or_exit")
+    def test_sourcebase_composed_entry_uses_host_and_token(
+        self, mock_load, MockResolver, mock_token, runner, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "marketplace.yml").write_text("---\n", encoding="utf-8")
+        mock_load.return_value = (
+            tmp_path,
+            MarketplaceYml(
+                name="m",
+                description="d",
+                version="1.0.0",
+                owner=MarketplaceOwner(name="o"),
+                source_base="https://gitlab.example.com/group/sub/team/sub2",
+                packages=(
+                    PackageEntry(
+                        name="my-package",
+                        source="group/sub/team/sub2/my-package",  # composed at parse time
+                        version="^1.0.0",
+                        host="gitlab.example.com",
+                    ),
+                ),
+            ),
+        )
+        mock_inst = MockResolver.return_value
+        mock_inst.list_remote_refs.return_value = _REFS_GOOD
+        mock_inst.close = MagicMock()
+
+        result = runner.invoke(marketplace, ["check"])
+
+        assert result.exit_code == 0
+        # token resolved for the GitLab host, not github.com
+        mock_token.assert_called_once_with("gitlab.example.com", offline=False)
+        # resolver bound to that host with that token
+        MockResolver.assert_called_once_with(
+            offline=False, host="gitlab.example.com", token="glpat-xyz"
+        )
+        # ls-remote runs against the composed nested path
+        mock_inst.list_remote_refs.assert_called_once_with("group/sub/team/sub2/my-package")
+
+    @patch("apm_cli.commands.marketplace.check.resolve_token_for_host", return_value="ghp-tok")
+    @patch("apm_cli.commands.marketplace.check.RefResolver")
+    @patch("apm_cli.commands.marketplace.check._load_config_or_exit")
+    def test_host_prefixed_override_uses_that_host(
+        self, mock_load, MockResolver, mock_token, runner, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "marketplace.yml").write_text("---\n", encoding="utf-8")
+        mock_load.return_value = (
+            tmp_path,
+            MarketplaceYml(
+                name="m",
+                description="d",
+                version="1.0.0",
+                owner=MarketplaceOwner(name="o"),
+                source_base="https://gitlab.example.com/group/sub",
+                packages=(
+                    PackageEntry(
+                        name="helper",
+                        source="owner/repo",
+                        version="^1.0.0",
+                        host="github.com",  # host-prefixed override: base ignored
+                    ),
+                ),
+            ),
+        )
+        mock_inst = MockResolver.return_value
+        mock_inst.list_remote_refs.return_value = _REFS_GOOD
+        mock_inst.close = MagicMock()
+
+        result = runner.invoke(marketplace, ["check"])
+
+        assert result.exit_code == 0
+        mock_token.assert_called_once_with("github.com", offline=False)
+        MockResolver.assert_called_once_with(offline=False, host="github.com", token="ghp-tok")
+        mock_inst.list_remote_refs.assert_called_once_with("owner/repo")
+
+    @patch("apm_cli.commands.marketplace.check.resolve_token_for_host")
+    @patch("apm_cli.commands.marketplace.check.RefResolver")
+    @patch("apm_cli.commands.marketplace.check._load_config_or_exit")
+    def test_local_entry_makes_zero_ls_remote_calls(
+        self, mock_load, MockResolver, mock_token, runner, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "marketplace.yml").write_text("---\n", encoding="utf-8")
+        mock_load.return_value = (
+            tmp_path,
+            MarketplaceYml(
+                name="m",
+                description="d",
+                version="1.0.0",
+                owner=MarketplaceOwner(name="o"),
+                source_base="https://gitlab.example.com/group/sub",
+                packages=(
+                    PackageEntry(
+                        name="local-tool",
+                        source="./packages/local-tool",
+                        is_local=True,
+                    ),
+                ),
+            ),
+        )
+
+        result = runner.invoke(marketplace, ["check"])
+
+        assert result.exit_code == 0
+        assert "All 1 entries OK" in result.output
+        # local sources never touch the network or the token resolver
+        MockResolver.assert_not_called()
+        mock_token.assert_not_called()

--- a/tests/unit/marketplace/test_source_base.py
+++ b/tests/unit/marketplace/test_source_base.py
@@ -1,0 +1,284 @@
+"""Tests for the marketplace ``sourceBase`` field (issue #1519).
+
+``sourceBase`` declares a git base that host-less relative package sources
+compose onto, enabling deeply nested enterprise GitLab group paths that the
+3-segment ``host.tld/owner/repo`` shorthand cannot express. Per-entry
+host-prefixed and full-URL sources act as overrides (the base is ignored);
+local ``./`` sources are untouched; and when no base is declared, behavior is
+byte-for-byte identical to before.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from apm_cli.marketplace.errors import MarketplaceYmlError
+from apm_cli.marketplace.output_mappers import ClaudeMarketplaceMapper
+from apm_cli.marketplace.yml_schema import load_marketplace_from_apm_yml
+
+# The canonical repro from the issue: a GitLab nested-group base.
+_BASE = "https://gitlab.example.com/group/sub-group/team/projects"
+
+
+def _write_apm(tmp_path: Path, *, source_base: str | None, packages: str) -> Path:
+    """Write an apm.yml with a marketplace block and return its path.
+
+    *packages* is a raw YAML fragment of one or more ``- {...}`` entries; each
+    line is indented to sit under ``packages:``. *source_base*, when given, is
+    emitted as a quoted ``sourceBase:`` line.
+    """
+    lines = [
+        "name: my-project",
+        "description: Project description.",
+        "version: 1.2.3",
+        "marketplace:",
+        "  owner:",
+        "    name: ACME",
+    ]
+    if source_base is not None:
+        lines.append(f'  sourceBase: "{source_base}"')
+    lines.append("  packages:")
+    for pkg_line in textwrap.dedent(packages).strip().splitlines():
+        lines.append("    " + pkg_line)
+    apm = tmp_path / "apm.yml"
+    apm.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return apm
+
+
+def _entry(cfg, name):
+    return next(e for e in cfg.packages if e.name == name)
+
+
+# ---------------------------------------------------------------------------
+# sourceBase field validation
+# ---------------------------------------------------------------------------
+
+
+class TestSourceBaseValidation:
+    def test_valid_deep_base_accepted_and_stored(self, tmp_path: Path) -> None:
+        apm = _write_apm(
+            tmp_path,
+            source_base=_BASE,
+            packages="- {name: p, source: p, version: '^1.0.0'}",
+        )
+        cfg = load_marketplace_from_apm_yml(apm)
+        assert cfg.source_base == _BASE
+
+    def test_trailing_slash_normalized(self, tmp_path: Path) -> None:
+        apm = _write_apm(
+            tmp_path,
+            source_base=_BASE + "/",
+            packages="- {name: p, source: p, version: '^1.0.0'}",
+        )
+        cfg = load_marketplace_from_apm_yml(apm)
+        assert cfg.source_base == _BASE  # no trailing slash
+
+    @pytest.mark.parametrize(
+        "bad_base",
+        [
+            "http://gitlab.example.com/group",  # non-https scheme
+            "https://user@gitlab.example.com/group",  # userinfo
+            "https://gitlab.example.com:443/group",  # port
+            "https://gitlab.example.com/group?ref=main",  # query
+            "https://gitlab.example.com/group#frag",  # fragment
+            "https://gitlab.example.com/group/repo.git",  # .git suffix
+            "https://localhost/group",  # non-FQDN host (no dot)
+            "https://gitlab.example.com",  # host only, no path
+            "git@gitlab.example.com:group/repo",  # SCP/ssh form
+        ],
+    )
+    def test_unsafe_base_forms_rejected(self, tmp_path: Path, bad_base: str) -> None:
+        apm = _write_apm(
+            tmp_path,
+            source_base=bad_base,
+            packages="- {name: p, source: owner/repo, version: '^1.0.0'}",
+        )
+        with pytest.raises(MarketplaceYmlError, match="sourceBase"):
+            load_marketplace_from_apm_yml(apm)
+
+    def test_path_traversal_in_base_rejected(self, tmp_path: Path) -> None:
+        apm = _write_apm(
+            tmp_path,
+            source_base="https://gitlab.example.com/group/../../etc",
+            packages="- {name: p, source: owner/repo, version: '^1.0.0'}",
+        )
+        with pytest.raises(MarketplaceYmlError, match=r"traversal|sourceBase"):
+            load_marketplace_from_apm_yml(apm)
+
+    def test_empty_base_rejected(self, tmp_path: Path) -> None:
+        apm = _write_apm(
+            tmp_path,
+            source_base="   ",
+            packages="- {name: p, source: owner/repo, version: '^1.0.0'}",
+        )
+        with pytest.raises(MarketplaceYmlError, match="sourceBase"):
+            load_marketplace_from_apm_yml(apm)
+
+
+# ---------------------------------------------------------------------------
+# Relative-source composition onto the base
+# ---------------------------------------------------------------------------
+
+
+class TestRelativeComposition:
+    def test_single_segment_relative_composes(self, tmp_path: Path) -> None:
+        apm = _write_apm(
+            tmp_path,
+            source_base=_BASE,
+            packages="- {name: my-package, source: my-package, version: '^1.0.0'}",
+        )
+        cfg = load_marketplace_from_apm_yml(apm)
+        e = _entry(cfg, "my-package")
+        assert e.host == "gitlab.example.com"
+        assert e.source == "group/sub-group/team/projects/my-package"
+
+    def test_issue_repro_exact(self, tmp_path: Path) -> None:
+        """The exact 4+ segment GitLab path from #1519 now resolves."""
+        apm = _write_apm(
+            tmp_path,
+            source_base=_BASE,
+            packages="- {name: my-package, source: my-package, ref: v1.2.0}",
+        )
+        cfg = load_marketplace_from_apm_yml(apm)
+        e = _entry(cfg, "my-package")
+        # Composed shape is identical to a host-prefixed entry pointing at the
+        # full nested path -- the URL a real git ls-remote / clone will use.
+        assert e.host == "gitlab.example.com"
+        assert e.source == "group/sub-group/team/projects/my-package"
+
+    def test_owner_repo_relative_composes(self, tmp_path: Path) -> None:
+        apm = _write_apm(
+            tmp_path,
+            source_base=_BASE,
+            packages="- {name: t, source: owner/repo, version: '^1.0.0'}",
+        )
+        e = _entry(load_marketplace_from_apm_yml(apm), "t")
+        assert e.host == "gitlab.example.com"
+        assert e.source == "group/sub-group/team/projects/owner/repo"
+
+    def test_n_segment_relative_composes(self, tmp_path: Path) -> None:
+        apm = _write_apm(
+            tmp_path,
+            source_base=_BASE,
+            packages="- {name: t, source: a/b/c, ref: main}",
+        )
+        e = _entry(load_marketplace_from_apm_yml(apm), "t")
+        assert e.host == "gitlab.example.com"
+        assert e.source == "group/sub-group/team/projects/a/b/c"
+
+
+# ---------------------------------------------------------------------------
+# Per-entry overrides (base ignored) and local sources
+# ---------------------------------------------------------------------------
+
+
+class TestOverridePrecedence:
+    def test_host_prefixed_source_overrides_base(self, tmp_path: Path) -> None:
+        apm = _write_apm(
+            tmp_path,
+            source_base=_BASE,
+            packages="- {name: t, source: github.com/owner/repo, version: '^1.0.0'}",
+        )
+        e = _entry(load_marketplace_from_apm_yml(apm), "t")
+        assert e.host == "github.com"
+        assert e.source == "owner/repo"  # base NOT prepended
+
+    def test_full_url_source_overrides_base(self, tmp_path: Path) -> None:
+        apm = _write_apm(
+            tmp_path,
+            source_base=_BASE,
+            packages='- {name: t, source: "https://other.example.com/x/y.git", ref: v1}',
+        )
+        e = _entry(load_marketplace_from_apm_yml(apm), "t")
+        assert e.host == "other.example.com"
+        assert e.source == "x/y"  # base NOT prepended, .git normalized
+
+    def test_local_source_untouched_by_base(self, tmp_path: Path) -> None:
+        apm = _write_apm(
+            tmp_path,
+            source_base=_BASE,
+            packages="- {name: t, source: ./local-pkg}",
+        )
+        e = _entry(load_marketplace_from_apm_yml(apm), "t")
+        assert e.is_local is True
+        assert e.host is None
+        assert e.source == "./local-pkg"  # base ignored for local
+
+
+# ---------------------------------------------------------------------------
+# No base declared -> behavior identical to today (fail-closed)
+# ---------------------------------------------------------------------------
+
+
+class TestNoBaseUnchanged:
+    def test_single_segment_rejected_without_base(self, tmp_path: Path) -> None:
+        apm = _write_apm(
+            tmp_path,
+            source_base=None,
+            packages="- {name: t, source: my-package, version: '^1.0.0'}",
+        )
+        with pytest.raises(MarketplaceYmlError, match="source"):
+            load_marketplace_from_apm_yml(apm)
+
+    def test_four_segment_rejected_without_base(self, tmp_path: Path) -> None:
+        apm = _write_apm(
+            tmp_path,
+            source_base=None,
+            packages="- {name: t, source: a/b/c/d, version: '^1.0.0'}",
+        )
+        with pytest.raises(MarketplaceYmlError, match="source"):
+            load_marketplace_from_apm_yml(apm)
+
+    def test_owner_repo_unchanged_without_base(self, tmp_path: Path) -> None:
+        apm = _write_apm(
+            tmp_path,
+            source_base=None,
+            packages="- {name: t, source: owner/repo, version: '^1.0.0'}",
+        )
+        cfg = load_marketplace_from_apm_yml(apm)
+        assert cfg.source_base is None
+        e = _entry(cfg, "t")
+        assert e.host is None
+        assert e.source == "owner/repo"  # no composition
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 contract: the composed entry emits the right marketplace.json URL
+# (verifies the output mapper needs no change -- a composed relative entry is
+# byte-identical to a host-prefixed entry by emit time).
+# ---------------------------------------------------------------------------
+
+
+class TestComposedUrlEmission:
+    def test_claude_mapper_emits_composed_gitlab_url(self, tmp_path: Path) -> None:
+        from apm_cli.marketplace.builder import ResolvedPackage
+
+        apm = _write_apm(
+            tmp_path,
+            source_base=_BASE,
+            packages="- {name: my-package, source: my-package, ref: v1.2.0}",
+        )
+        cfg = load_marketplace_from_apm_yml(apm)
+        e = _entry(cfg, "my-package")
+        # Mirror what builder._resolve_entry produces from the parsed entry.
+        resolved = ResolvedPackage(
+            name=e.name,
+            source_repo=e.source,
+            subdir=e.subdir,
+            ref="v1.2.0",
+            sha="0" * 40,
+            requested_version=e.version,
+            tags=e.tags,
+            is_prerelease=False,
+            host=e.host,
+        )
+        result = ClaudeMarketplaceMapper().compose(config=cfg, resolved=(resolved,))
+        source = result.document["plugins"][0]["source"]
+        assert source["source"] == "url"
+        assert source["url"] == (
+            "https://gitlab.example.com/group/sub-group/team/projects/my-package"
+        )
+        assert source["ref"] == "v1.2.0"


### PR DESCRIPTION
<!--
DRAFT PR body for #1519. Target: microsoft/apm:main from
leocamello/apm:feature/marketplace-sourcebase. Follows the repo PR template.
Working doc — not committed. Content is generic (no internal host/path).
-->

## Description

Adds an optional `marketplace.sourceBase` field so marketplace authors on
self-managed hosts (canonical case: GitLab nested subgroups) can declare a git
base once and write each package `source` relative to it. The per-entry `source`
shorthand tops out at `host.tld/owner/repo` (3 segments); enterprise GitLab
nesting is routinely deeper (`.../group/sub-group/team/project/<pkg>`), which the
shorthand cannot express.

```yaml
marketplace:
  sourceBase: https://gitlab.example.com/group/sub-group/team/projects
  packages:
    - name: my-package
      source: my-package                  # -> .../projects/my-package
      version: "^1.0.0"
    - name: from-github
      source: github.com/acme/helper      # host-prefixed: overrides the base
      ref: v1.0.0
```

Semantics ("relative to base, always"): a host-less `source` composes onto the
base; a `source` carrying its own host (`host.tld/owner/repo` or full URL) or a
local `./` source overrides the base; with no `sourceBase` declared, behaviour is
byte-for-byte unchanged and a host-less single-segment source stays rejected
(fail-closed — no silent routing to the default host).

**Implementation:** composition happens at parse time (`yml_schema.py`) — a
relative entry is rewritten to the equivalent host-prefixed form, so the
resolver, builder, and output mappers treat it identically to a #1288
host-prefixed entry with no changes to those modules. `sourceBase` is validated
with #1288's posture (https-only, FQDN host, no userinfo/port/query/fragment/
`.git`) plus `validate_path_segments`. `apm marketplace plugin add` accepts
relative sources when a base is declared.

**Also fixes `apm marketplace check`:** it was building a single default-host
resolver with no token and ignoring `entry.host`, so it failed (`git ls-remote`
exit 128) for any non-default host — every `sourceBase` entry, and the
pre-existing #1288 host-prefixed form. It now uses the same per-host resolver +
per-host token pattern as `apm pack` (extracted into a shared
`marketplace/auth_helpers.resolve_token_for_host`) and short-circuits local
packages, so `check` and `pack` agree.

Validated end-to-end against a real self-managed GitLab (4-segment nested group):
`apm marketplace check` exits 0, and `apm pack` emits a `source: url` entry with
the composed URL and a real resolved `sha`.

The consumer-side install gap for non-default-host marketplaces
(`apm install <pkg>@<marketplace>` strips the host) is independent, reproduces on
stock 0.18.0, and is tracked in #1010 — out of scope here.

Fixes #1519

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

`tests/unit/marketplace/test_source_base.py` (validation, composition for 1 and N
segments, override precedence, base-less rejection, composed marketplace.json
URL) and `tests/unit/commands/test_marketplace_check.py` (per-host resolution:
composed→GitLab+token, host-prefixed override→github, local→zero ls-remote).
`uv run pytest tests/unit tests/test_console.py` is green except one pre-existing,
environment-dependent `test_auth_scoping` failure unrelated to this change.
`ruff check` / `ruff format --check` clean.

## Spec conformance (OpenAPM v0.1)

- [x] N/A -- this PR does not change OpenAPM-observable behaviour.

(`src/apm_cli/marketplace/` is not a Mode-B critical path and
`CONFORMANCE.{json,md}` regenerate with no diff.)
