### PR TITLE
fix(mcp): honor optional registry inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `apm install` now resolves relative `path:` deps declared by remote monorepo packages when they stay inside the same remote repo, while still rejecting absolute, escaping, or cross-repo paths; closes #1571. (#1732)
+- `apm install` now treats optional MCP registry env/input fields as optional: unset values are no longer prompted or written into generated runtime config, and reinstalls preserve user-edited optional values. (Refs #20)
 
 ## [0.19.0] - 2026-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `apm install` now resolves relative `path:` deps declared by remote monorepo packages when they stay inside the same remote repo, while still rejecting absolute, escaping, or cross-repo paths; closes #1571. (#1732)
-- Optional-auth MCP registry servers now install without token prompts when values are unset; `apm install` also omits empty runtime config entries and preserves user-edited optional values on reinstall. (refs #20, #1734)
+- Optional-auth MCP registry servers now install without token prompts when values are unset; `apm install` also omits empty runtime config entries and preserves user-edited optional values on reinstall; refs #20. (#1734)
 - Dependencies with the same path on different git hosts no longer collide in `apm.lock.yaml`; `apm install` keeps GitHub/GitLab PATs off generic-host file downloads, routes bespoke GitLab hosts through `type: gitlab`, and surfaces non-404 download failures with host and endpoint context. Reading private files from a generic non-default host now requires a whole-repo git dependency or explicit backend signal; see the dependency and lockfile docs (closes #773). (#1735)
 
 ## [0.19.0] - 2026-06-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `apm install` now resolves relative `path:` deps declared by remote monorepo packages when they stay inside the same remote repo, while still rejecting absolute, escaping, or cross-repo paths; closes #1571. (#1732)
-- `apm install` now treats optional MCP registry env/input fields as optional: unset values are no longer prompted or written into generated runtime config, and reinstalls preserve user-edited optional values. (Refs #20)
+- `apm install` now treats optional MCP registry env/input fields as optional: unset values are no longer prompted or written into generated runtime config, and reinstalls preserve user-edited optional values. (refs #20, #1734)
 
 ## [0.19.0] - 2026-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `apm install` now resolves relative `path:` deps declared by remote monorepo packages when they stay inside the same remote repo, while still rejecting absolute, escaping, or cross-repo paths; closes #1571. (#1732)
-- `apm install` now treats optional MCP registry env/input fields as optional: unset values are no longer prompted or written into generated runtime config, and reinstalls preserve user-edited optional values. (refs #20, #1734)
+- Optional-auth MCP registry servers now install without token prompts when values are unset; `apm install` also omits empty runtime config entries and preserves user-edited optional values on reinstall. (refs #20, #1734)
 
 ## [0.19.0] - 2026-06-09
 

--- a/docs/src/content/docs/consumer/install-mcp-servers.md
+++ b/docs/src/content/docs/consumer/install-mcp-servers.md
@@ -75,6 +75,13 @@ For every harness APM detects in your environment, `apm install`
 writes a runtime-specific MCP config file. The schemas differ; the
 `apm.yml` source of truth does not.
 
+Registry-declared environment variables honor the registry's
+`required` flag. Required variables may be collected at install time or
+materialized as runtime prompts/placeholders. Optional variables are not
+prompted and are not added to generated config when no value is
+available; if a user already edited an optional value in the runtime
+config, reinstall preserves it.
+
 | Harness | File | Scope | Format |
 |---|---|---|---|
 | GitHub Copilot CLI | `~/.copilot/mcp-config.json` | global | JSON `mcpServers` |

--- a/docs/src/content/docs/consumer/install-mcp-servers.md
+++ b/docs/src/content/docs/consumer/install-mcp-servers.md
@@ -76,11 +76,10 @@ writes a runtime-specific MCP config file. The schemas differ; the
 `apm.yml` source of truth does not.
 
 Registry-declared environment variables honor the registry's
-`required` flag. Required variables may be collected at install time or
-materialized as runtime prompts/placeholders. Optional variables are not
-prompted and are not added to generated config when no value is
-available; if a user already edited an optional value in the runtime
-config, reinstall preserves it.
+`required` flag. Servers with optional auth install without token
+prompts until you choose to configure one. See the
+[manifest schema reference](../../reference/manifest-schema/#424-variable-references-in-headers-and-env)
+for the full required-vs-optional runtime config rule.
 
 | Harness | File | Scope | Format |
 |---|---|---|---|

--- a/docs/src/content/docs/producer/author-primitives/mcp-as-primitive.md
+++ b/docs/src/content/docs/producer/author-primitives/mcp-as-primitive.md
@@ -122,6 +122,11 @@ The `github-mcp-server` is a special case: APM injects an
 the Copilot CLI config. See
 [Token injection](../../consumer/install-mcp-servers/#token-injection-github-mcp-server).
 
+When a registry server marks an env/input variable optional, APM does
+not force a prompt and does not create a generated runtime config entry
+unless a value is already available. User-edited optional entries in a
+runtime config are preserved on reinstall.
+
 ## Direct vs transitive: the trust boundary
 
 A self-defined MCP server (`registry: false`) declared by your package

--- a/docs/src/content/docs/producer/author-primitives/mcp-as-primitive.md
+++ b/docs/src/content/docs/producer/author-primitives/mcp-as-primitive.md
@@ -123,9 +123,10 @@ the Copilot CLI config. See
 [Token injection](../../consumer/install-mcp-servers/#token-injection-github-mcp-server).
 
 When a registry server marks an env/input variable optional, APM does
-not force a prompt and does not create a generated runtime config entry
-unless a value is already available. User-edited optional entries in a
-runtime config are preserved on reinstall.
+not generate a prompt or runtime config entry unless a value is already
+available. See the
+[manifest schema reference](../../reference/manifest-schema/#424-variable-references-in-headers-and-env)
+for the canonical required-vs-optional rule.
 
 ## Direct vs transitive: the trust boundary
 

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -548,7 +548,7 @@ Values in `headers` and `env` may contain three placeholder syntaxes. APM resolv
 - **Copilot CLI** has native `${VAR}` interpolation in `~/.copilot/mcp-config.json`; APM normalizes `${env:VAR}` and legacy `<VAR>` to `${VAR}`.
 - **Codex, Gemini, and Cursor** have no runtime interpolation, so APM resolves `${VAR}`, `${env:VAR}`, and the legacy `<VAR>` at install time using `os.environ` (or an interactive prompt when missing). Resolved values are not re-scanned, so a value containing literal `${...}` text is preserved.
 - **Recommended:** Use `${VAR}` or `${env:VAR}` in all new manifests - they work on every target that supports remote MCP servers. `<VAR>` is legacy; in VS Code it would silently render as literal text in the generated config.
-- **Registry-backed servers** - APM auto-generates input prompts from registry metadata for `${input:...}`.
+- **Registry-backed servers** - APM auto-generates input prompts from registry metadata only for required variables. Optional variables are omitted when no value is available, and existing user-edited optional values in runtime config are preserved on reinstall.
 - **Self-defined servers** - APM detects `${input:...}` patterns in `apm.yml` and generates matching input definitions automatically.
 
 GitHub Actions templates (`${{ ... }}`) are intentionally left untouched.

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -548,7 +548,7 @@ Values in `headers` and `env` may contain three placeholder syntaxes. APM resolv
 - **Copilot CLI** has native `${VAR}` interpolation in `~/.copilot/mcp-config.json`; APM normalizes `${env:VAR}` and legacy `<VAR>` to `${VAR}`.
 - **Codex, Gemini, and Cursor** have no runtime interpolation, so APM resolves `${VAR}`, `${env:VAR}`, and the legacy `<VAR>` at install time using `os.environ` (or an interactive prompt when missing). Resolved values are not re-scanned, so a value containing literal `${...}` text is preserved.
 - **Recommended:** Use `${VAR}` or `${env:VAR}` in all new manifests - they work on every target that supports remote MCP servers. `<VAR>` is legacy; in VS Code it would silently render as literal text in the generated config.
-- **Registry-backed servers** - APM auto-generates input prompts from registry metadata only for required variables. Optional variables are omitted when no value is available, and existing user-edited optional values in runtime config are preserved on reinstall.
+- **Registry-backed servers** - APM auto-generates input prompts from registry metadata only for required variables. Optional variables do not generate prompts or runtime config entries when no value is available. If a user has already edited an optional value in runtime config, reinstall preserves that value rather than overwriting it.
 - **Self-defined servers** - APM detects `${input:...}` patterns in `apm.yml` and generates matching input definitions automatically.
 
 GitHub Actions templates (`${{ ... }}`) are intentionally left untouched.

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -323,7 +323,7 @@ dependencies:
         #   ${input:<id>}         -> VS Code prompts user at runtime
         #   <VAR>                 -> deprecated; auto-translated, emits a warning
         # Registry-declared optional env/input fields are omitted when unset;
-        # reinstall preserves user-edited optional values already in runtime config.
+        # see manifest-schema for reinstall preservation semantics.
         Authorization: "Bearer ${MY_TOKEN}"
       tools: ["repos", "issues"]
 

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -322,6 +322,8 @@ dependencies:
         #                            Codex: passed through unchanged.
         #   ${input:<id>}         -> VS Code prompts user at runtime
         #   <VAR>                 -> deprecated; auto-translated, emits a warning
+        # Registry-declared optional env/input fields are omitted when unset;
+        # reinstall preserves user-edited optional values already in runtime config.
         Authorization: "Bearer ${MY_TOKEN}"
       tools: ["repos", "issues"]
 

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -327,7 +327,7 @@ dependencies:
         #   ${input:<id>}         -> VS Code prompts user at runtime
         #   <VAR>                 -> deprecated; auto-translated, emits a warning
         # Registry-declared optional env/input fields are omitted when unset;
-        # see manifest-schema for reinstall preservation semantics.
+        # see manifest-schema section 4.2.4 for reinstall preservation semantics.
         Authorization: "Bearer ${MY_TOKEN}"
       tools: ["repos", "issues"]
 

--- a/src/apm_cli/adapters/client/base.py
+++ b/src/apm_cli/adapters/client/base.py
@@ -29,6 +29,11 @@ _ENV_PLACEHOLDER_RE = re.compile(r"<([A-Z_][A-Z0-9_]*)>|" + _ENV_VAR_RE.pattern)
 _LEGACY_ANGLE_VAR_RE = re.compile(r"<([A-Z_][A-Z0-9_]*)>")
 
 
+def _registry_field_is_required(field):
+    """Return True unless registry metadata explicitly marks a field optional."""
+    return field.get("required", field.get("is_required", True)) is not False
+
+
 def _translate_env_placeholder(value):
     """Pure-textual translation of env-var placeholders to the canonical
     ``${VAR}`` runtime-substitution syntax.
@@ -481,7 +486,7 @@ class MCPClientAdapter(ABC):
             name = env_var.get("name", "")
             if not name:
                 continue
-            required = env_var.get("required", True)
+            required = _registry_field_is_required(env_var)
 
             value = env_overrides.get(name) or os.getenv(name)
             if not value and required and not skip_prompting:
@@ -797,7 +802,9 @@ class MCPClientAdapter(ABC):
         )
 
         # First pass: identify variables with empty values to warn the user.
-        empty_value_vars = [ev for ev in env_vars if ev.get("required") and not ev.get("value")]
+        empty_value_vars = [
+            ev for ev in env_vars if _registry_field_is_required(ev) and not ev.get("value")
+        ]
         if empty_value_vars and skip_prompting:
             var_names = [ev.get("name") for ev in empty_value_vars]
             _rich_warning(
@@ -837,9 +844,9 @@ class MCPClientAdapter(ABC):
 
             # Priority 4: interactive prompt
             default_value = env_var.get("value", "")
-            required = env_var.get("required", False)
+            required = _registry_field_is_required(env_var)
 
-            if not skip_prompting:
+            if not skip_prompting and required:
                 from rich.prompt import Prompt
 
                 description = env_var.get("description", "")
@@ -863,7 +870,5 @@ class MCPClientAdapter(ABC):
                     f"The MCP server may not function correctly."
                 )
                 resolved[name] = ""
-            else:
-                resolved[name] = default_value
 
         return resolved

--- a/src/apm_cli/adapters/client/base.py
+++ b/src/apm_cli/adapters/client/base.py
@@ -29,7 +29,7 @@ _ENV_PLACEHOLDER_RE = re.compile(r"<([A-Z_][A-Z0-9_]*)>|" + _ENV_VAR_RE.pattern)
 _LEGACY_ANGLE_VAR_RE = re.compile(r"<([A-Z_][A-Z0-9_]*)>")
 
 
-def _registry_field_is_required(field):
+def registry_field_is_required(field):
     """Return True unless registry metadata explicitly marks a field optional."""
     return field.get("required", field.get("is_required", True)) is not False
 
@@ -486,7 +486,7 @@ class MCPClientAdapter(ABC):
             name = env_var.get("name", "")
             if not name:
                 continue
-            required = _registry_field_is_required(env_var)
+            required = registry_field_is_required(env_var)
 
             value = env_overrides.get(name) or os.getenv(name)
             if not value and required and not skip_prompting:
@@ -803,13 +803,14 @@ class MCPClientAdapter(ABC):
 
         # First pass: identify variables with empty values to warn the user.
         empty_value_vars = [
-            ev for ev in env_vars if _registry_field_is_required(ev) and not ev.get("value")
+            ev for ev in env_vars if registry_field_is_required(ev) and not ev.get("value")
         ]
         if empty_value_vars and skip_prompting:
             var_names = [ev.get("name") for ev in empty_value_vars]
             _rich_warning(
                 f"Warning: The following required environment variables have no default "
-                f"value and cannot be prompted in non-interactive mode: {var_names}"
+                f"value and cannot be prompted in non-interactive mode: {var_names}. "
+                "Set them in your environment and rerun apm install."
             )
 
         for env_var in env_vars:
@@ -844,7 +845,7 @@ class MCPClientAdapter(ABC):
 
             # Priority 4: interactive prompt
             default_value = env_var.get("value", "")
-            required = _registry_field_is_required(env_var)
+            required = registry_field_is_required(env_var)
 
             if not skip_prompting and required:
                 from rich.prompt import Prompt
@@ -867,7 +868,8 @@ class MCPClientAdapter(ABC):
             elif required:
                 _rich_warning(
                     f"Warning: Required environment variable '{name}' could not be resolved. "
-                    f"The MCP server may not function correctly."
+                    f"The MCP server may not function correctly. Set {name} in your "
+                    "environment and rerun apm install."
                 )
                 resolved[name] = ""
 

--- a/src/apm_cli/adapters/client/base.py
+++ b/src/apm_cli/adapters/client/base.py
@@ -4,7 +4,7 @@ import os
 import re
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from ...utils.console import _rich_error, _rich_warning
 
@@ -29,7 +29,7 @@ _ENV_PLACEHOLDER_RE = re.compile(r"<([A-Z_][A-Z0-9_]*)>|" + _ENV_VAR_RE.pattern)
 _LEGACY_ANGLE_VAR_RE = re.compile(r"<([A-Z_][A-Z0-9_]*)>")
 
 
-def registry_field_is_required(field):
+def registry_field_is_required(field: dict[str, Any]) -> bool:
     """Return True unless registry metadata explicitly marks a field optional."""
     return field.get("required", field.get("is_required", True)) is not False
 
@@ -808,9 +808,9 @@ class MCPClientAdapter(ABC):
         if empty_value_vars and skip_prompting:
             var_names = [ev.get("name") for ev in empty_value_vars]
             _rich_warning(
-                f"Warning: The following required environment variables have no default "
-                f"value and cannot be prompted in non-interactive mode: {var_names}. "
-                "Set them in your environment and rerun apm install."
+                f"Required environment variables have no default value and cannot be "
+                f"prompted in non-interactive mode: {var_names}. Set them in your "
+                "environment and rerun `apm install`."
             )
 
         for env_var in env_vars:
@@ -867,9 +867,9 @@ class MCPClientAdapter(ABC):
                 resolved[name] = default_value
             elif required:
                 _rich_warning(
-                    f"Warning: Required environment variable '{name}' could not be resolved. "
+                    f"Required environment variable '{name}' could not be resolved. "
                     f"The MCP server may not function correctly. Set {name} in your "
-                    "environment and rerun apm install."
+                    "environment and rerun `apm install`."
                 )
                 resolved[name] = ""
 

--- a/src/apm_cli/adapters/client/copilot.py
+++ b/src/apm_cli/adapters/client/copilot.py
@@ -25,6 +25,7 @@ from .base import (
     MCPClientAdapter,
     _extract_legacy_angle_vars,
     _has_env_placeholder,
+    _registry_field_is_required,
     _stringify_env_literal,
 )
 from .base import (
@@ -698,6 +699,7 @@ class CopilotClientAdapter(MCPClientAdapter):
             return translated
 
         if self._supports_runtime_env_substitution:
+            env_overrides = env_overrides or {}
             resolved = {}
             placeholder_keys = []
             for env_var in env_vars:
@@ -706,12 +708,18 @@ class CopilotClientAdapter(MCPClientAdapter):
                 name = env_var.get("name", "")
                 if not name:
                     continue
+                required = _registry_field_is_required(env_var)
+                override_value = env_overrides.get(name)
+                has_override = bool(
+                    override_value.strip() if isinstance(override_value, str) else override_value
+                )
                 if name in default_github_env:
                     # Non-secret literal default -- preserve as-is.
                     resolved[name] = default_github_env[name]
-                else:
+                elif required or has_override:
                     # Emit a runtime-substitution placeholder; APM never reads
-                    # or stores the value.
+                    # or stores the value. Optional variables are included only
+                    # when install-time collection observed a value.
                     resolved[name] = self._format_runtime_env_placeholder(name)
                     placeholder_keys.append(name)
             # Record for the post-install summary line and the

--- a/src/apm_cli/adapters/client/copilot.py
+++ b/src/apm_cli/adapters/client/copilot.py
@@ -25,8 +25,8 @@ from .base import (
     MCPClientAdapter,
     _extract_legacy_angle_vars,
     _has_env_placeholder,
-    _registry_field_is_required,
     _stringify_env_literal,
+    registry_field_is_required,
 )
 from .base import (
     _translate_env_placeholder as _translate_env_placeholder,
@@ -708,7 +708,7 @@ class CopilotClientAdapter(MCPClientAdapter):
                 name = env_var.get("name", "")
                 if not name:
                     continue
-                required = _registry_field_is_required(env_var)
+                required = registry_field_is_required(env_var)
                 override_value = env_overrides.get(name)
                 has_override = bool(
                     override_value.strip() if isinstance(override_value, str) else override_value

--- a/src/apm_cli/adapters/client/vscode.py
+++ b/src/apm_cli/adapters/client/vscode.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from ...registry.client import SimpleRegistryClient
 from ...registry.integration import RegistryIntegration
 from ...utils.console import _rich_warning
-from .base import _ENV_VAR_RE, _INPUT_VAR_RE, MCPClientAdapter
+from .base import _ENV_VAR_RE, _INPUT_VAR_RE, MCPClientAdapter, _registry_field_is_required
 
 # Legacy ``<VAR>`` placeholder (Copilot CLI / Codex only). VS Code does not
 # resolve angle-bracket placeholders, so emitting them produces literal
@@ -173,9 +173,23 @@ class VSCodeClientAdapter(MCPClientAdapter):
                     f"Failed to retrieve server details for '{server_url}'. Server not found in registry."
                 )
 
+            # Use provided server name or fallback to server_url
+            config_key = server_name or server_url
+
+            # Get current config before formatting so optional registry fields
+            # that the user already edited can be preserved on reinstall.
+            current_config = self.get_current_config(logger=logger)
+            existing_servers = current_config.get("servers")
+            if not isinstance(existing_servers, dict):
+                existing_servers = {}
+            existing_server_config = existing_servers.get(config_key)
+
             # Generate server configuration
             server_config, input_vars = self._format_server_config(
-                server_info, runtime_vars=runtime_vars
+                server_info,
+                runtime_vars=runtime_vars,
+                env_overrides=env_overrides,
+                existing_server_config=existing_server_config,
             )
 
             if not server_config:
@@ -185,16 +199,10 @@ class VSCodeClientAdapter(MCPClientAdapter):
                     print(f"Unable to configure server: {server_url}")
                 return False
 
-            # Use provided server name or fallback to server_url
-            config_key = server_name or server_url
-
-            # Get current config
-            current_config = self.get_current_config(logger=logger)
-
             # Ensure servers and inputs sections exist
-            if "servers" not in current_config:
+            if "servers" not in current_config or not isinstance(current_config["servers"], dict):
                 current_config["servers"] = {}
-            if "inputs" not in current_config:
+            if "inputs" not in current_config or not isinstance(current_config["inputs"], list):
                 current_config["inputs"] = []
 
             # Add the server configuration
@@ -229,12 +237,20 @@ class VSCodeClientAdapter(MCPClientAdapter):
                 print(f"Error configuring MCP server: {e}")
             return False
 
-    def _format_server_config(self, server_info, runtime_vars=None):
+    def _format_server_config(
+        self,
+        server_info,
+        runtime_vars=None,
+        env_overrides=None,
+        existing_server_config=None,
+    ):
         """Format server details into VSCode mcp.json compatible format.
 
         Args:
             server_info (dict): Server information from registry.
             runtime_vars (dict, optional): Runtime variable substitutions.
+            env_overrides (dict, optional): Environment values collected at install time.
+            existing_server_config (dict, optional): Current config for this server.
 
         Returns:
             tuple: (server_config, input_vars) where:
@@ -327,30 +343,47 @@ class VSCodeClientAdapter(MCPClientAdapter):
 
                 server_config = {"type": "stdio", "command": runtime_hint, "args": args}
 
-            # Add environment variables if present
+            # Add environment variables if present. Optional registry env vars
+            # are emitted only when the user already has a value in config or
+            # install-time collection found one; otherwise they would create an
+            # unwanted VS Code prompt on every server start.
             env_vars = (
                 package.get("environment_variables") or package.get("environmentVariables") or []
             )
             if env_vars:
-                server_config["env"] = {}
+                env_config = {}
                 for env_var in env_vars:
-                    if "name" in env_var:
-                        # Convert variable name to lowercase and replace underscores with hyphens for VS Code convention
-                        input_var_name = env_var["name"].lower().replace("_", "-")
-
-                        # Create the input variable reference
-                        server_config["env"][env_var["name"]] = f"${{input:{input_var_name}}}"
-
-                        # Create the input variable definition
-                        input_var_def = {
-                            "type": "promptString",
-                            "id": input_var_name,
-                            "description": env_var.get(
-                                "description", f"{env_var['name']} for MCP server"
-                            ),
-                            "password": True,  # Default to True for security
-                        }
-                        input_vars.append(input_var_def)
+                    if "name" not in env_var:
+                        continue
+                    name = env_var["name"]
+                    input_var_name = name.lower().replace("_", "-")
+                    input_ref = f"${{input:{input_var_name}}}"
+                    env_value = self._value_for_declared_vscode_env(
+                        env_var,
+                        env_overrides=env_overrides,
+                        existing_server_config=existing_server_config,
+                        input_ref=input_ref,
+                    )
+                    if env_value is None:
+                        continue
+                    env_config[name] = env_value
+                    if env_value == input_ref:
+                        input_vars.append(
+                            {
+                                "type": "promptString",
+                                "id": input_var_name,
+                                "description": env_var.get("description", f"{name} for MCP server"),
+                                "password": True,
+                            }
+                        )
+                    else:
+                        input_vars.extend(
+                            self._extract_input_variables(
+                                {name: env_value}, server_info.get("name", "")
+                            )
+                        )
+                if env_config:
+                    server_config["env"] = env_config
 
         # If no server config was created from packages, check for other server types
         if not server_config:
@@ -416,6 +449,54 @@ class VSCodeClientAdapter(MCPClientAdapter):
                 )
 
         return server_config, input_vars
+
+    @staticmethod
+    def _has_value(value):
+        """Return True when a user/config value is present and non-empty."""
+        if value is None:
+            return False
+        if isinstance(value, str):
+            return bool(value.strip())
+        return True
+
+    @staticmethod
+    def _existing_mapping_value(existing_server_config, section, name):
+        """Return an existing server mapping value for *section[name]*, if any."""
+        if not isinstance(existing_server_config, dict):
+            return None
+        existing_mapping = existing_server_config.get(section)
+        if not isinstance(existing_mapping, dict):
+            return None
+        return existing_mapping.get(name)
+
+    def _value_for_declared_vscode_env(
+        self,
+        env_var,
+        *,
+        env_overrides=None,
+        existing_server_config=None,
+        input_ref,
+    ):
+        """Return the VS Code env value for a registry-declared env var.
+
+        Required variables keep the existing promptString behavior. Optional
+        variables are omitted unless a value was collected for this install or
+        the user already has an edited value in the existing config.
+        """
+        name = env_var["name"]
+        if _registry_field_is_required(env_var):
+            return input_ref
+
+        existing_value = self._existing_mapping_value(existing_server_config, "env", name)
+        if self._has_value(existing_value):
+            return existing_value
+
+        env_overrides = env_overrides or {}
+        override_value = env_overrides.get(name)
+        if self._has_value(override_value):
+            return f"${{env:{name}}}"
+
+        return None
 
     @staticmethod
     def _translate_env_vars_for_vscode(mapping):

--- a/src/apm_cli/adapters/client/vscode.py
+++ b/src/apm_cli/adapters/client/vscode.py
@@ -469,8 +469,8 @@ class VSCodeClientAdapter(MCPClientAdapter):
             return None
         return existing_mapping.get(name)
 
+    @staticmethod
     def _value_for_declared_vscode_env(
-        self,
         env_var,
         *,
         env_overrides=None,
@@ -489,13 +489,15 @@ class VSCodeClientAdapter(MCPClientAdapter):
         if registry_field_is_required(env_var):
             return input_ref
 
-        existing_value = self._existing_mapping_value(existing_server_config, "env", name)
-        if self._has_value(existing_value):
+        existing_value = VSCodeClientAdapter._existing_mapping_value(
+            existing_server_config, "env", name
+        )
+        if VSCodeClientAdapter._has_value(existing_value):
             return existing_value
 
         env_overrides = env_overrides or {}
         override_value = env_overrides.get(name)
-        if self._has_value(override_value):
+        if VSCodeClientAdapter._has_value(override_value):
             return f"${{env:{name}}}"
 
         return None

--- a/src/apm_cli/adapters/client/vscode.py
+++ b/src/apm_cli/adapters/client/vscode.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from ...registry.client import SimpleRegistryClient
 from ...registry.integration import RegistryIntegration
 from ...utils.console import _rich_warning
-from .base import _ENV_VAR_RE, _INPUT_VAR_RE, MCPClientAdapter, _registry_field_is_required
+from .base import _ENV_VAR_RE, _INPUT_VAR_RE, MCPClientAdapter, registry_field_is_required
 
 # Legacy ``<VAR>`` placeholder (Copilot CLI / Codex only). VS Code does not
 # resolve angle-bracket placeholders, so emitting them produces literal
@@ -481,10 +481,12 @@ class VSCodeClientAdapter(MCPClientAdapter):
 
         Required variables keep the existing promptString behavior. Optional
         variables are omitted unless a value was collected for this install or
-        the user already has an edited value in the existing config.
+        the user already has an edited value in the existing config. Collected
+        optional values are emitted as ``${env:NAME}``, which VS Code resolves
+        from the VS Code process environment when the server starts.
         """
         name = env_var["name"]
-        if _registry_field_is_required(env_var):
+        if registry_field_is_required(env_var):
             return input_ref
 
         existing_value = self._existing_mapping_value(existing_server_config, "env", name)

--- a/src/apm_cli/registry/operations.py
+++ b/src/apm_cli/registry/operations.py
@@ -372,7 +372,7 @@ class MCPServerOperations:
                                     collected_env_vars[var_name] = var_info
                                 else:
                                     logger.debug(
-                                        "Skipping optional MCP env var %s for %s: no value/default available",
+                                        "Skipping optional MCP env var %s for %s: no value/default; omitted from runtime config",
                                         var_name,
                                         server_ref,
                                     )

--- a/src/apm_cli/registry/operations.py
+++ b/src/apm_cli/registry/operations.py
@@ -357,10 +357,19 @@ class MCPServerOperations:
                         for env_var in env_vars:
                             if isinstance(env_var, dict) and "name" in env_var:
                                 var_name = env_var["name"]
-                                all_required_vars[var_name] = {
+                                var_info = {
                                     "description": env_var.get("description", ""),
-                                    "required": env_var.get("required", True),
+                                    "required": env_var.get(
+                                        "required", env_var.get("is_required", True)
+                                    ),
                                 }
+                                default_value = env_var.get("value", "")
+                                if default_value:
+                                    var_info["value"] = default_value
+                                required = var_info["required"] is not False
+                                existing_value = os.getenv(var_name)
+                                if required or existing_value or default_value:
+                                    all_required_vars[var_name] = var_info
 
             except Exception:  # noqa: S112
                 # Skip servers we can't analyze
@@ -394,9 +403,15 @@ class MCPServerOperations:
             for var_name in sorted(required_vars.keys()):
                 var_info = required_vars[var_name]
                 existing_value = os.getenv(var_name)
+                required = var_info.get("required", True) is not False
+                default_value = var_info.get("value", "")
 
                 if existing_value:
                     env_vars[var_name] = existing_value
+                elif not required:
+                    if default_value:
+                        env_vars[var_name] = default_value
+                    continue
                 else:  # noqa: PLR5501
                     # Provide sensible defaults for known variables
                     if var_name == "GITHUB_DYNAMIC_TOOLSETS":
@@ -432,7 +447,8 @@ class MCPServerOperations:
             for var_name in sorted(required_vars.keys()):
                 var_info = required_vars[var_name]
                 description = var_info.get("description", "")
-                required = var_info.get("required", True)
+                required = var_info.get("required", True) is not False
+                default_value = var_info.get("value", "")
 
                 # Check if already set in environment
                 existing_value = os.getenv(var_name)
@@ -440,6 +456,10 @@ class MCPServerOperations:
                 if existing_value:
                     console.print(f"  [+] {var_name}: [dim]using existing value[/dim]")
                     env_vars[var_name] = existing_value
+                elif not required:
+                    if default_value:
+                        env_vars[var_name] = default_value
+                    continue
                 else:
                     # Determine if this looks like a password/secret
                     is_sensitive = any(
@@ -451,10 +471,7 @@ class MCPServerOperations:
                     if description:
                         prompt_text += f" ({description})"
 
-                    if required:
-                        value = Prompt.ask(prompt_text, password=is_sensitive)
-                    else:
-                        value = Prompt.ask(prompt_text, default="", password=is_sensitive)
+                    value = Prompt.ask(prompt_text, password=is_sensitive)
 
                     env_vars[var_name] = value
 
@@ -469,12 +486,18 @@ class MCPServerOperations:
             for var_name in sorted(required_vars.keys()):
                 var_info = required_vars[var_name]
                 description = var_info.get("description", "")
+                required = var_info.get("required", True) is not False
+                default_value = var_info.get("value", "")
 
                 existing_value = os.getenv(var_name)
 
                 if existing_value:
                     click.echo(f"  [+] {var_name}: using existing value")
                     env_vars[var_name] = existing_value
+                elif not required:
+                    if default_value:
+                        env_vars[var_name] = default_value
+                    continue
                 else:
                     prompt_text = f"  {var_name}"
                     if description:

--- a/src/apm_cli/registry/operations.py
+++ b/src/apm_cli/registry/operations.py
@@ -267,7 +267,7 @@ class MCPServerOperations:
         Returns:
             Dictionary mapping runtime variable names to their values
         """
-        all_required_vars = {}  # var_name -> {description, required, etc.}
+        collected_runtime_vars = {}  # var_name -> {description, required, etc.}
 
         # Use cached server info if available, otherwise fetch on-demand
         if server_info_cache is None:
@@ -290,7 +290,7 @@ class MCPServerOperations:
                                 variables = arg.get("variables", {})
                                 for var_name, var_info in variables.items():
                                     if isinstance(var_info, dict):
-                                        all_required_vars[var_name] = {
+                                        collected_runtime_vars[var_name] = {
                                             "description": var_info.get("description", ""),
                                             "required": var_info.get("is_required", True),
                                         }
@@ -299,9 +299,9 @@ class MCPServerOperations:
                 # Skip servers we can't analyze
                 continue
 
-        # Prompt user for each runtime variable
-        if all_required_vars:
-            return self._prompt_for_environment_variables(all_required_vars)
+        # Prompt user for collected runtime variables.
+        if collected_runtime_vars:
+            return self._prompt_for_environment_variables(collected_runtime_vars)
 
         return {}
 
@@ -320,7 +320,7 @@ class MCPServerOperations:
             Dictionary mapping environment variable names to their values
         """
         shared_env_vars = {}
-        all_required_vars = {}  # var_name -> {description, required, etc.}
+        collected_env_vars = {}  # var_name -> {description, required, optional value, etc.}
 
         # Use cached server info if available, otherwise fetch on-demand
         if server_info_cache is None:
@@ -340,8 +340,8 @@ class MCPServerOperations:
                         for arg in docker_args:
                             if isinstance(arg, str) and arg.startswith("${") and arg.endswith("}"):
                                 var_name = arg[2:-1]  # Remove ${ and }
-                                if var_name not in all_required_vars:
-                                    all_required_vars[var_name] = {
+                                if var_name not in collected_env_vars:
+                                    collected_env_vars[var_name] = {
                                         "description": f"Environment variable for {server_info.get('name', server_ref)}",
                                         "required": True,
                                     }
@@ -369,15 +369,21 @@ class MCPServerOperations:
                                 required = var_info["required"] is not False
                                 existing_value = os.getenv(var_name)
                                 if required or existing_value or default_value:
-                                    all_required_vars[var_name] = var_info
+                                    collected_env_vars[var_name] = var_info
+                                else:
+                                    logger.debug(
+                                        "Skipping optional MCP env var %s for %s: no value/default available",
+                                        var_name,
+                                        server_ref,
+                                    )
 
             except Exception:  # noqa: S112
                 # Skip servers we can't analyze
                 continue
 
-        # Prompt user for each environment variable
-        if all_required_vars:
-            shared_env_vars = self._prompt_for_environment_variables(all_required_vars)
+        # Prompt user for collected environment variables.
+        if collected_env_vars:
+            shared_env_vars = self._prompt_for_environment_variables(collected_env_vars)
 
         return shared_env_vars
 

--- a/tests/integration/test_vscode_adapter_phase3w4.py
+++ b/tests/integration/test_vscode_adapter_phase3w4.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from apm_cli.adapters.client.vscode import VSCodeClientAdapter
+from apm_cli.integration.mcp_integrator_install import run_mcp_install
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -21,6 +22,29 @@ from apm_cli.adapters.client.vscode import VSCodeClientAdapter
 
 def _make_adapter(tmp_path: Path) -> VSCodeClientAdapter:
     return VSCodeClientAdapter(project_root=tmp_path)
+
+
+def _context7_optional_env_server_info() -> dict:
+    """Return registry metadata with an unset optional token env var."""
+    return {
+        "name": "context7",
+        "packages": [
+            {
+                "runtime_hint": "npx",
+                "name": "@upstash/context7-mcp",
+                "registry_name": "npm",
+                "runtime_arguments": [],
+                "package_arguments": [],
+                "environment_variables": [
+                    {
+                        "name": "CONTEXT7_API_KEY",
+                        "description": "Optional Context7 authorization token",
+                        "required": False,
+                    }
+                ],
+            }
+        ],
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -231,6 +255,41 @@ class TestConfigureMcpServer:
                 server_info_cache={"empty-server": server_info},
                 logger=logger,
             )
+
+    def test_optional_env_vars_omitted_from_vscode_config_on_install(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CONTEXT7_API_KEY", raising=False)
+        server_info = _context7_optional_env_server_info()
+        logger = MagicMock()
+
+        with (
+            patch("apm_cli.integration.mcp_integrator._get_console", return_value=None),
+            patch(
+                "apm_cli.registry.operations.MCPServerOperations.validate_servers_exist",
+                return_value=(["context7"], []),
+            ),
+            patch(
+                "apm_cli.registry.operations.MCPServerOperations.check_servers_needing_installation",
+                return_value=["context7"],
+            ),
+            patch(
+                "apm_cli.registry.operations.MCPServerOperations.batch_fetch_server_info",
+                return_value={"context7": server_info},
+            ),
+        ):
+            configured = run_mcp_install(
+                ["context7"],
+                runtime="vscode",
+                explicit_target="vscode",
+                project_root=tmp_path,
+                logger=logger,
+            )
+
+        config = json.loads((tmp_path / ".vscode" / "mcp.json").read_text(encoding="utf-8"))
+        server = config["servers"]["context7"]
+
+        assert configured == 1
+        assert "CONTEXT7_API_KEY" not in server.get("env", {})
+        assert config.get("inputs", []) == []
 
     def test_adds_input_variables_without_duplicates(self, tmp_path):
         vscode_dir = tmp_path / ".vscode"

--- a/tests/integration/test_vscode_adapter_phase3w4.py
+++ b/tests/integration/test_vscode_adapter_phase3w4.py
@@ -291,6 +291,64 @@ class TestConfigureMcpServer:
         assert "CONTEXT7_API_KEY" not in server.get("env", {})
         assert config.get("inputs", []) == []
 
+    def test_optional_env_vars_preserved_on_reinstall(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("CONTEXT7_API_KEY", raising=False)
+        vscode_dir = tmp_path / ".vscode"
+        vscode_dir.mkdir()
+        mcp_json = vscode_dir / "mcp.json"
+        mcp_json.write_text(
+            json.dumps(
+                {
+                    "servers": {
+                        "context7": {
+                            "type": "stdio",
+                            "command": "npx",
+                            "args": ["-y", "@upstash/context7-mcp"],
+                            "env": {"CONTEXT7_API_KEY": "${env:CONTEXT7_API_KEY}"},
+                        }
+                    },
+                    "inputs": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        server_info = _context7_optional_env_server_info()
+        logger = MagicMock()
+
+        with (
+            patch("apm_cli.integration.mcp_integrator._get_console", return_value=None),
+            patch(
+                "apm_cli.registry.operations.MCPServerOperations.validate_servers_exist",
+                return_value=(["context7"], []),
+            ),
+            patch(
+                "apm_cli.registry.operations.MCPServerOperations.check_servers_needing_installation",
+                return_value=["context7"],
+            ),
+            patch(
+                "apm_cli.registry.operations.MCPServerOperations.batch_fetch_server_info",
+                return_value={"context7": server_info},
+            ),
+            patch(
+                "apm_cli.core.conflict_detector.MCPConflictDetector.check_server_exists",
+                return_value=False,
+            ),
+        ):
+            configured = run_mcp_install(
+                ["context7"],
+                runtime="vscode",
+                explicit_target="vscode",
+                project_root=tmp_path,
+                logger=logger,
+            )
+
+        config = json.loads(mcp_json.read_text(encoding="utf-8"))
+        server = config["servers"]["context7"]
+
+        assert configured == 1
+        assert server["env"] == {"CONTEXT7_API_KEY": "${env:CONTEXT7_API_KEY}"}
+        assert config.get("inputs", []) == []
+
     def test_adds_input_variables_without_duplicates(self, tmp_path):
         vscode_dir = tmp_path / ".vscode"
         vscode_dir.mkdir()

--- a/tests/unit/adapters/test_vscode_docker_runtime_args.py
+++ b/tests/unit/adapters/test_vscode_docker_runtime_args.py
@@ -272,10 +272,13 @@ class TestConfigureMcpServerPassesRuntimeVars(unittest.TestCase):
                 "playwright-mcp",
                 runtime_vars=runtime_vars,
             )
-            mock_fmt.assert_called_once_with(
-                self.server_info,
-                runtime_vars=runtime_vars,
-            )
+            # Board #20 added env_overrides + existing_server_config kwargs for
+            # reinstall-preservation; assert runtime_vars is still threaded through
+            # without over-constraining the full call signature.
+            mock_fmt.assert_called_once()
+            args, kwargs = mock_fmt.call_args
+            self.assertEqual(args[0], self.server_info)
+            self.assertEqual(kwargs.get("runtime_vars"), runtime_vars)
 
 
 if __name__ == "__main__":

--- a/tests/unit/install/test_mcp_optional_inputs.py
+++ b/tests/unit/install/test_mcp_optional_inputs.py
@@ -1,0 +1,159 @@
+"""Regression tests for optional MCP registry inputs."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from apm_cli.adapters.client.base import MCPClientAdapter
+from apm_cli.adapters.client.copilot import CopilotClientAdapter
+from apm_cli.adapters.client.vscode import VSCodeClientAdapter
+from apm_cli.registry.operations import MCPServerOperations
+
+
+def _context7_server_info() -> dict[str, Any]:
+    """Return registry metadata shaped like context7's optional token env."""
+    return {
+        "id": "context7-id",
+        "name": "context7",
+        "packages": [
+            {
+                "name": "@upstash/context7-mcp",
+                "registry_name": "npm",
+                "runtime_hint": "npx",
+                "environment_variables": [
+                    {
+                        "name": "CONTEXT7_API_KEY",
+                        "description": "Optional Context7 authorization token",
+                        "required": False,
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_collect_environment_variables_does_not_prompt_optional_without_value(
+    monkeypatch,
+) -> None:
+    """Optional registry env vars are not force-prompted as required vars."""
+    monkeypatch.delenv("CONTEXT7_API_KEY", raising=False)
+    monkeypatch.delenv("REQUIRED_TOKEN", raising=False)
+    operations = MCPServerOperations()
+    prompted: dict[str, dict[str, Any]] = {}
+
+    def fake_prompt(required_vars: dict[str, dict[str, Any]]) -> dict[str, str]:
+        prompted.update(required_vars)
+        return {"REQUIRED_TOKEN": "required-value"}
+
+    monkeypatch.setattr(operations, "_prompt_for_environment_variables", fake_prompt)
+
+    result = operations.collect_environment_variables(
+        ["context7"],
+        {
+            "context7": {
+                "name": "context7",
+                "packages": [
+                    {
+                        "environment_variables": [
+                            {
+                                "name": "CONTEXT7_API_KEY",
+                                "description": "Optional Context7 authorization token",
+                                "required": False,
+                            },
+                            {
+                                "name": "OPTIONAL_INPUT",
+                                "description": "Optional input metadata variant",
+                                "is_required": False,
+                            },
+                            {
+                                "name": "REQUIRED_TOKEN",
+                                "description": "Required token",
+                                "required": True,
+                            },
+                        ]
+                    }
+                ],
+            }
+        },
+    )
+
+    assert prompted == {"REQUIRED_TOKEN": {"description": "Required token", "required": True}}
+    assert result == {"REQUIRED_TOKEN": "required-value"}
+
+
+def test_base_env_resolver_omits_optional_env_when_no_value_provided(monkeypatch) -> None:
+    """Legacy adapters must not write empty optional env entries."""
+    monkeypatch.delenv("OPTIONAL_TOKEN", raising=False)
+
+    result = MCPClientAdapter._resolve_env_vars_with_prompting(
+        [{"name": "OPTIONAL_TOKEN", "is_required": False}], {}, {}
+    )
+
+    assert result == {}
+
+
+def test_copilot_omits_optional_env_placeholder_when_no_value_provided() -> None:
+    """Copilot config must not create placeholders for unset optional env vars."""
+    adapter = CopilotClientAdapter()
+
+    config = adapter._format_server_config(
+        _context7_server_info(), env_overrides={}, runtime_vars={}
+    )
+
+    assert "env" not in config
+
+
+def test_vscode_omits_optional_env_inputs_when_no_value_provided(tmp_path) -> None:
+    """VS Code config must not create prompt inputs for unset optional env vars."""
+    adapter = VSCodeClientAdapter(project_root=tmp_path)
+
+    assert adapter.configure_mcp_server(
+        "context7",
+        server_name="context7",
+        server_info_cache={"context7": _context7_server_info()},
+        env_overrides={},
+    )
+
+    config = json.loads((tmp_path / ".vscode" / "mcp.json").read_text(encoding="utf-8"))
+    server = config["servers"]["context7"]
+
+    assert "env" not in server
+    assert config.get("inputs", []) == []
+
+
+def test_vscode_reinstall_preserves_user_edited_optional_env(tmp_path) -> None:
+    """Reinstall must not overwrite an existing user-edited optional env field."""
+    vscode_dir = tmp_path / ".vscode"
+    vscode_dir.mkdir()
+    mcp_json = vscode_dir / "mcp.json"
+    mcp_json.write_text(
+        json.dumps(
+            {
+                "servers": {
+                    "context7": {
+                        "type": "stdio",
+                        "command": "npx",
+                        "args": ["-y", "@upstash/context7-mcp"],
+                        "env": {"CONTEXT7_API_KEY": "${env:CONTEXT7_API_KEY}"},
+                    }
+                },
+                "inputs": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    adapter = VSCodeClientAdapter(project_root=tmp_path)
+
+    assert adapter.configure_mcp_server(
+        "context7",
+        server_name="context7",
+        server_info_cache={"context7": _context7_server_info()},
+        env_overrides={},
+    )
+
+    config = json.loads(mcp_json.read_text(encoding="utf-8"))
+    server = config["servers"]["context7"]
+
+    assert server["env"] == {"CONTEXT7_API_KEY": "${env:CONTEXT7_API_KEY}"}
+    assert config.get("inputs", []) == []

--- a/tests/unit/test_registry_operations_phase3.py
+++ b/tests/unit/test_registry_operations_phase3.py
@@ -540,15 +540,27 @@ class TestPromptForEnvironmentVariables:
             )
         assert "MY_API_KEY" in result
 
-    def test_e2e_mode_other_var_defaults_to_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_e2e_mode_optional_var_omitted_unless_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Board #20: a declared-but-optional var with no value must NOT be
+        # written into the resolved env; one carrying a declared default still is.
         monkeypatch.setenv("APM_E2E_TESTS", "1")
         monkeypatch.delenv("RANDOM_CONFIG_VAR", raising=False)
+        monkeypatch.delenv("OPTIONAL_WITH_DEFAULT", raising=False)
         ops = _make_ops()
         result = ops._prompt_for_environment_variables(
-            {"RANDOM_CONFIG_VAR": {"description": "misc", "required": False}}
+            {
+                "RANDOM_CONFIG_VAR": {"description": "misc", "required": False},
+                "OPTIONAL_WITH_DEFAULT": {
+                    "description": "misc",
+                    "required": False,
+                    "value": "preset",
+                },
+            }
         )
-        assert "RANDOM_CONFIG_VAR" in result
-        assert result["RANDOM_CONFIG_VAR"] == ""
+        assert "RANDOM_CONFIG_VAR" not in result
+        assert result["OPTIONAL_WITH_DEFAULT"] == "preset"
 
     def test_rich_prompt_used_in_interactive_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("APM_E2E_TESTS", raising=False)
@@ -626,8 +638,11 @@ class TestPromptForEnvironmentVariables:
         monkeypatch.delenv("CI", raising=False)
         monkeypatch.setenv("GITHUB_ACTIONS", "true")
         ops = _make_ops()
+        # A required var is auto-defaulted (not prompted) in CI mode, proving CI
+        # detection. An optional var would be skipped in BOTH modes (board #20
+        # optional-omit) and so cannot distinguish CI from interactive.
         result = ops._prompt_for_environment_variables(
-            {"SOME_VAR": {"description": "d", "required": False}}
+            {"SOME_VAR": {"description": "d", "required": True}}
         )
         assert "SOME_VAR" in result
 
@@ -640,6 +655,6 @@ class TestPromptForEnvironmentVariables:
         monkeypatch.setenv("BUILDKITE", "true")
         ops = _make_ops()
         result = ops._prompt_for_environment_variables(
-            {"ANOTHER_VAR": {"description": "d", "required": False}}
+            {"ANOTHER_VAR": {"description": "d", "required": True}}
         )
         assert "ANOTHER_VAR" in result

--- a/tests/unit/test_registry_operations_state.py
+++ b/tests/unit/test_registry_operations_state.py
@@ -540,15 +540,27 @@ class TestPromptForEnvironmentVariables:
             )
         assert "MY_API_KEY" in result
 
-    def test_e2e_mode_other_var_defaults_to_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_e2e_mode_optional_var_omitted_unless_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Board #20: a declared-but-optional var with no value must NOT be
+        # written into the resolved env; one carrying a declared default still is.
         monkeypatch.setenv("APM_E2E_TESTS", "1")
         monkeypatch.delenv("RANDOM_CONFIG_VAR", raising=False)
+        monkeypatch.delenv("OPTIONAL_WITH_DEFAULT", raising=False)
         ops = _make_ops()
         result = ops._prompt_for_environment_variables(
-            {"RANDOM_CONFIG_VAR": {"description": "misc", "required": False}}
+            {
+                "RANDOM_CONFIG_VAR": {"description": "misc", "required": False},
+                "OPTIONAL_WITH_DEFAULT": {
+                    "description": "misc",
+                    "required": False,
+                    "value": "preset",
+                },
+            }
         )
-        assert "RANDOM_CONFIG_VAR" in result
-        assert result["RANDOM_CONFIG_VAR"] == ""
+        assert "RANDOM_CONFIG_VAR" not in result
+        assert result["OPTIONAL_WITH_DEFAULT"] == "preset"
 
     def test_rich_prompt_used_in_interactive_mode(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("APM_E2E_TESTS", raising=False)
@@ -626,8 +638,11 @@ class TestPromptForEnvironmentVariables:
         monkeypatch.delenv("CI", raising=False)
         monkeypatch.setenv("GITHUB_ACTIONS", "true")
         ops = _make_ops()
+        # A required var is auto-defaulted (not prompted) in CI mode, proving CI
+        # detection. An optional var would be skipped in BOTH modes (board #20
+        # optional-omit) and so cannot distinguish CI from interactive.
         result = ops._prompt_for_environment_variables(
-            {"SOME_VAR": {"description": "d", "required": False}}
+            {"SOME_VAR": {"description": "d", "required": True}}
         )
         assert "SOME_VAR" in result
 
@@ -640,6 +655,6 @@ class TestPromptForEnvironmentVariables:
         monkeypatch.setenv("BUILDKITE", "true")
         ops = _make_ops()
         result = ops._prompt_for_environment_variables(
-            {"ANOTHER_VAR": {"description": "d", "required": False}}
+            {"ANOTHER_VAR": {"description": "d", "required": True}}
         )
         assert "ANOTHER_VAR" in result


### PR DESCRIPTION
fix(mcp): honor optional registry inputs

## TL;DR

This PR fixes the scoped #20 bug where registry-declared optional MCP env/input fields were treated like required prompts and re-written into runtime config. Optional fields with no value are now omitted, while existing user-edited optional values are preserved on reinstall. Required fields keep the existing prompt/placeholder behavior.

> [!NOTE]
> Part of #20 only. This intentionally does **not** add `apm mcp export`, custom-registry URL wiring, consumer token allow-lists, or private MCP repo sourcing.

## Problem (WHY)

- [x] The reported context7 flow prompted for an auth token even though the user said it was "not mandatory" in #20.
- [x] Reinstall rewrote `.vscode/mcp.json` after a user deleted the optional env config; the issue says "on subsequent installs, that configuration is overridden".
- [!] The registry path collapsed required and optional metadata into one collection path, so adapters could not distinguish "missing required value" from "unset optional value".

Why this matters: APM should keep generated config predictable and reviewable. The repo docs describe `apm.yml` as the "source of truth" for runtime config, but optional registry inputs with no user value are not source data and should not be materialized.

## Approach (WHAT)

| # | Fix (and why) |
|---|---|
| 1 | Normalize registry `required` / `is_required` metadata once and use it before prompting or generating env entries. |
| 2 | Filter optional unset env vars out of `MCPServerOperations.collect_environment_variables()` so shared install state does not force downstream adapters to write them. |
| 3 | Teach VS Code config formatting to omit optional unset env vars and to preserve an existing user-edited optional env value on reinstall. |
| 4 | Keep the change surgical: no schema expansion, no export command, and no token allow-list work. |

## Implementation (HOW)

| File | Intent |
|---|---|
| `src/apm_cli/adapters/client/base.py` | Adds a shared required-metadata helper and prevents legacy prompt resolution from prompting or writing empty optional values. |
| `src/apm_cli/adapters/client/copilot.py` | Keeps Copilot runtime placeholders for required or provided values, but skips optional unset registry env fields. |
| `src/apm_cli/adapters/client/vscode.py` | Reads existing server config before formatting, omits optional unset env fields, and preserves existing optional env edits. |
| `src/apm_cli/registry/operations.py` | Filters optional unset env vars before shared prompting and honors both `required` and `is_required`. |
| `tests/unit/install/test_mcp_optional_inputs.py` | Adds regression traps for context7-shaped optional env metadata, VS Code omission, and reinstall preservation. |
| Docs / changelog | Updates the MCP install guide, manifest reference, producer guide, apm-usage skill note, and changelog. |

## Diagrams

Legend: the dashed nodes are the new behavior added by this PR: optional unset fields are omitted, and existing user edits survive reinstall.

```mermaid
flowchart LR
    subgraph Registry[Registry metadata]
        E1[environment variables]
    end
    subgraph Collect[Collect]
        C1[MCPServerOperations]
        D1{required?}
    end
    subgraph Runtime[Runtime config]
        R1[Prompt or placeholder]
        R2[Omit optional unset]
        R3[Preserve existing edit]
    end
    E1 --> C1
    C1 --> D1
    D1 -->|"yes"| R1
    D1 -->|"no value"| R2
    D1 -->|"existing value"| R3
    classDef new stroke-dasharray: 5 5;
    class R2,R3 new;
```

## Trade-offs

- **Metadata-only fix.** Chose to honor existing registry `required` / `is_required`; rejected a new `apm.yml` optional-input schema because the board scoped this to the bug only.
- **Preserve user edits, do not prune stale inputs.** Chose not to delete unrelated existing `inputs` entries; removing stale runtime config safely is broader cleanup behavior.
- **Keep token policy deferred.** This does not implement token-env allow-lists or conditional auth logic; those remain design items under #20.

## Benefits

1. Running install for a context7-shaped registry server no longer prompts for an unset optional token.
2. Fresh VS Code config for an unset optional env var contains no `env` entry and no generated `inputs` prompt.
3. Reinstall preserves a user-edited optional VS Code env value instead of replacing it with `${input:...}`.
4. Required env vars still flow through the existing prompt/placeholder paths.

## Validation

`uv run --extra dev pytest tests/unit/install/test_mcp_optional_inputs.py tests/integration/test_vscode_adapter_phase3w4.py tests/unit/test_registry_operations_phase3.py tests/unit/test_registry_operations_state.py tests/unit/test_vscode_adapter.py -q`:

```
244 passed in 4.95s
```

`uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/ && uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/ && bash scripts/lint-auth-signals.sh`:

```
All checks passed!
1242 files already formatted

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

[*] Rule A: get_bearer_provider boundary (any reference)
[*] Rule B: git ls-remote auth-delegated annotation
[+] auth-signal lint clean
```

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|------------------------|--------------|--------------------|------|
| 1 | Install a registry MCP server with an unset optional token; APM does not prompt or write an empty runtime field. | DevX (pragmatic as npm), Secure by default | `tests/unit/install/test_mcp_optional_inputs.py::test_collect_environment_variables_does_not_prompt_optional_without_value` (regression-trap for #20)<br/>`tests/unit/install/test_mcp_optional_inputs.py::test_base_env_resolver_omits_optional_env_when_no_value_provided`<br/>`tests/unit/install/test_mcp_optional_inputs.py::test_copilot_omits_optional_env_placeholder_when_no_value_provided`<br/>`tests/unit/install/test_mcp_optional_inputs.py::test_vscode_omits_optional_env_inputs_when_no_value_provided`<br/>`tests/integration/test_vscode_adapter_phase3w4.py::TestConfigureMcpServer::test_optional_env_vars_omitted_from_vscode_config_on_install` | unit + integration |
| 2 | Reinstall after a user edits an optional VS Code env field; APM keeps the user edit instead of clobbering it. | DevX (pragmatic as npm), Multi-harness support | `tests/unit/install/test_mcp_optional_inputs.py::test_vscode_reinstall_preserves_user_edited_optional_env` (regression-trap for #20)<br/>`tests/integration/test_vscode_adapter_phase3w4.py::TestConfigureMcpServer::test_optional_env_vars_preserved_on_reinstall` | unit + integration |

## How to test

- [ ] Create an `apm.yml` with a registry MCP server whose package metadata declares an optional env var and no local value; run `apm install --target vscode`; expect no env/input prompt for that optional field.
- [ ] Add a user-edited optional env value to `.vscode/mcp.json`; rerun install; expect the value to remain unchanged.
- [ ] Run `uv run --extra dev pytest tests/unit/install/test_mcp_optional_inputs.py -q`; expect all tests to pass.

Refs #20

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

