### PR TITLE
feat(marketplace): add sourceBase for package sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   overrides the Hermes home directory. See the [Hermes integration guide](https://microsoft.github.io/apm/integrations/hermes/).
 - Marketplace authors can set `sourceBase` so package sources resolve relative
   to enterprise git base paths, while host-prefixed, full-URL, and local entries
-  remain per-entry overrides. (#1519)
+  remain per-entry overrides. (#1736)
 
 ## [0.19.0] - 2026-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of `~/.hermes/config.yaml` (written atomically with `0o600` perms, preserving
   unrelated config keys and refusing to overwrite a malformed file). `HERMES_HOME`
   overrides the Hermes home directory. See the [Hermes integration guide](https://microsoft.github.io/apm/integrations/hermes/).
+- Marketplace authors can set `sourceBase` so package sources resolve relative
+  to enterprise git base paths, while host-prefixed, full-URL, and local entries
+  remain per-entry overrides. (#1519)
 
 ## [0.19.0] - 2026-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of `~/.hermes/config.yaml` (written atomically with `0o600` perms, preserving
   unrelated config keys and refusing to overwrite a malformed file). `HERMES_HOME`
   overrides the Hermes home directory. See the [Hermes integration guide](https://microsoft.github.io/apm/integrations/hermes/).
-- Marketplace authors can set `sourceBase` so package sources resolve relative
-  to enterprise git base paths, while host-prefixed, full-URL, and local entries
-  remain per-entry overrides. (#1736)
+- Enterprise marketplace authors can stop repeating shared git base paths by
+  setting `sourceBase`, while host-prefixed, full-URL, and local entries remain
+  per-entry overrides. (#1736)
 - `apm marketplace add` now accepts git URLs with `#ref`, local file paths,
   and hosted `marketplace.json` URLs -- so teams can consume private,
   offline, or hosted catalogs without publishing a GitHub repo (closes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unrelated config keys and refusing to overwrite a malformed file). `HERMES_HOME`
   overrides the Hermes home directory. See the [Hermes integration guide](https://microsoft.github.io/apm/integrations/hermes/).
 - Enterprise marketplace authors can stop repeating shared git base paths by
-  setting `sourceBase`, while host-prefixed, full-URL, and local entries remain
-  per-entry overrides. (#1736)
+  setting `sourceBase` (one line replaces repeated URLs), while host-prefixed,
+  full-URL, and local entries remain per-entry overrides. (#1736)
 - `apm marketplace add` now accepts git URLs with `#ref`, local file paths,
   and hosted `marketplace.json` URLs -- so teams can consume private,
   offline, or hosted catalogs without publishing a GitHub repo (closes

--- a/docs/src/content/docs/producer/publish-to-a-marketplace.md
+++ b/docs/src/content/docs/producer/publish-to-a-marketplace.md
@@ -125,27 +125,35 @@ such as a GitLab group with nested subgroups. Any relative source composes
 onto the base, including two-segment values like `acme-org/pinned-package`.
 Host-prefixed sources like `github.com/acme/tool`, full HTTPS URLs, and
 local `./` paths remain per-entry overrides. If `sourceBase` is absent,
-existing `owner/repo` source behavior is unchanged.
+existing `owner/repo` source behavior is unchanged. See the
+[manifest schema](../reference/manifest-schema/#75-marketplacepackages)
+for the full validation and override rules.
 
 Before:
 
 ```yaml
-packages:
-  - name: review
-    source: https://gitlab.corp.example.com/platform/agent-marketplace/review
-  - name: pinned
-    source: https://gitlab.corp.example.com/platform/agent-marketplace/acme-org/pinned-package
+marketplace:
+  packages:
+    - name: review
+      source: https://gitlab.corp.example.com/platform/agent-marketplace/review
+      ref: v1.0.0
+    - name: pinned
+      source: https://gitlab.corp.example.com/platform/agent-marketplace/acme-org/pinned-package
+      ref: main
 ```
 
 After:
 
 ```yaml
-sourceBase: https://gitlab.corp.example.com/platform/agent-marketplace
-packages:
-  - name: review
-    source: review
-  - name: pinned
-    source: acme-org/pinned-package
+marketplace:
+  sourceBase: https://gitlab.corp.example.com/platform/agent-marketplace
+  packages:
+    - name: review
+      source: review
+      ref: v1.0.0
+    - name: pinned
+      source: acme-org/pinned-package
+      ref: main
 ```
 
 Add and edit packages without leaving the shell:

--- a/docs/src/content/docs/producer/publish-to-a-marketplace.md
+++ b/docs/src/content/docs/producer/publish-to-a-marketplace.md
@@ -93,13 +93,16 @@ marketplace:
   codex:
     output: .agents/plugins/marketplace.json
 
+  # Optional: package sources can be relative to this git base.
+  sourceBase: https://gitlab.corp.example.com/platform/agent-marketplace
+
   build:
     tagPattern: "v{version}"
 
   packages:
     - name: example-package
       description: Human-readable description consumers see
-      source: acme-org/example-package
+      source: example-package
       version: "^1.0.0"
 
     - name: pinned-package
@@ -116,6 +119,13 @@ The key in `apm.yml` is `packages:`. It becomes `plugins:` in the
 compiled `marketplace.json` -- that rename is the only structural
 transform `apm pack` performs. Strict schema: unknown keys raise an
 error, never silently ignored.
+
+Use `sourceBase` when every package lives under the same enterprise git
+base, such as a GitLab group with nested subgroups. Relative package
+sources compose onto the base. Host-prefixed sources like
+`github.com/acme/tool`, full HTTPS URLs, and local `./` paths remain
+per-entry overrides. If `sourceBase` is absent, existing `owner/repo`
+source behavior is unchanged.
 
 Add and edit packages without leaving the shell:
 

--- a/docs/src/content/docs/producer/publish-to-a-marketplace.md
+++ b/docs/src/content/docs/producer/publish-to-a-marketplace.md
@@ -102,11 +102,11 @@ marketplace:
   packages:
     - name: example-package
       description: Human-readable description consumers see
-      source: example-package
+      source: example-package           # -> .../agent-marketplace/example-package
       version: "^1.0.0"
 
     - name: pinned-package
-      source: acme-org/pinned-package
+      source: acme-org/pinned-package   # -> .../agent-marketplace/acme-org/pinned-package
       ref: 3f2a9b1c
 
     - name: local-tool
@@ -120,12 +120,33 @@ compiled `marketplace.json` -- that rename is the only structural
 transform `apm pack` performs. Strict schema: unknown keys raise an
 error, never silently ignored.
 
-Use `sourceBase` when every package lives under the same enterprise git
-base, such as a GitLab group with nested subgroups. Relative package
-sources compose onto the base. Host-prefixed sources like
-`github.com/acme/tool`, full HTTPS URLs, and local `./` paths remain
-per-entry overrides. If `sourceBase` is absent, existing `owner/repo`
-source behavior is unchanged.
+Use `sourceBase` when packages live under the same enterprise git base,
+such as a GitLab group with nested subgroups. Any relative source composes
+onto the base, including two-segment values like `acme-org/pinned-package`.
+Host-prefixed sources like `github.com/acme/tool`, full HTTPS URLs, and
+local `./` paths remain per-entry overrides. If `sourceBase` is absent,
+existing `owner/repo` source behavior is unchanged.
+
+Before:
+
+```yaml
+packages:
+  - name: review
+    source: https://gitlab.corp.example.com/platform/agent-marketplace/review
+  - name: pinned
+    source: https://gitlab.corp.example.com/platform/agent-marketplace/acme-org/pinned-package
+```
+
+After:
+
+```yaml
+sourceBase: https://gitlab.corp.example.com/platform/agent-marketplace
+packages:
+  - name: review
+    source: review
+  - name: pinned
+    source: acme-org/pinned-package
+```
 
 Add and edit packages without leaving the shell:
 

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -811,6 +811,8 @@ The first three `source` forms target a remote git host; the second and third na
 
 When `sourceBase` is set, relative package sources compose onto that base. For example, `sourceBase: https://gitlab.corp.example.com/platform/agent-marketplace` plus `source: review` emits `https://gitlab.corp.example.com/platform/agent-marketplace/review`. Host-prefixed and full URL sources are overrides and ignore `sourceBase`; local `./` sources also ignore it. Without `sourceBase`, existing `owner/repo` behavior is unchanged and single-segment relative sources are rejected.
 
+A relative `source` may use arbitrary path depth. A value whose leading segments form a host-prefixed shape (`<host.tld>/<owner>/<repo>`) or a full `https://` URL is always treated as a per-entry override and ignores `sourceBase`. A value that looks like it is trying to name a host (a dotted, FQDN-like first segment) but does **not** form a valid override shape is rejected at parse time rather than silently composed onto the base -- this avoids a confused-deputy footgun. To target a different host, use an explicit host-prefixed override or a full `https://` URL instead of a relative source.
+
 `sourceBase` must start with `https://`, use a FQDN host, include at least one path segment, and omit userinfo, ports, query strings, fragments, and a trailing `.git`. Each path segment uses letters, digits, `.`, `_`, or `-`; empty, `.` and `..` segments are refused.
 
 Non-default hosts authenticate via the standard APM token chain -- see the [authentication guide](../getting-started/authentication/) for the per-host-class lookup order. A token resolved for the default host is never forwarded to a non-default host.

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -754,6 +754,7 @@ Overrides exist for the rare case where the published marketplace identity diffe
 | `description` | `string` | OPTIONAL (override) | inherited | Override of top-level `description`. |
 | `version` | `string` | OPTIONAL (override) | inherited | Override of top-level `version`. Validated as semver. |
 | `owner` | `Owner` | REQUIRED | -- | Marketplace publisher identity. See Section 7.3. |
+| `sourceBase` | `string` | OPTIONAL | unset | HTTPS git base that relative `packages[].source` values compose onto. See Section 7.5. |
 | `output` | `string` | OPTIONAL | `.claude-plugin/marketplace.json` | Output path for the generated marketplace JSON. |
 | `metadata` | `object` | OPTIONAL | `{}` | Free-form metadata forwarded verbatim to `marketplace.json` (e.g. `homepage`, `support`). |
 | `build` | `Build` | OPTIONAL | `tagPattern: "v{version}"` | Build configuration for resolving package refs. See Section 7.4. |
@@ -790,7 +791,7 @@ Each entry MUST be a mapping. Unknown keys are rejected.
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `name` | `string` | REQUIRED | Package identifier as it appears in the marketplace. |
-| `source` | `string` | REQUIRED | One of: `<owner>/<repo>` (remote on the default host), `<host.tld>/<owner>/<repo>` (remote on a non-default host such as GitHub Enterprise or self-hosted GitLab -- shorthand), `https://<host.tld>/<owner>/<repo>[.git]` (same, full URL form -- a trailing `.git` is stripped), or `./<path>` (local). Must match the source pattern; path traversal (`..`) is refused, and URL forms with userinfo (`user@host`), ports, query strings, or non-`https` schemes are rejected. |
+| `source` | `string` | REQUIRED | One of: `<owner>/<repo>` (remote on the default host), `<host.tld>/<owner>/<repo>` (remote on a non-default host such as GitHub Enterprise or self-hosted GitLab -- shorthand), `https://<host.tld>/<owner>/<repo>[.git]` (same, full URL form -- a trailing `.git` is stripped), `./<path>` (local), or a relative path when `marketplace.sourceBase` is set. Must match the source pattern; path traversal (`..`) is refused, and URL forms with userinfo (`user@host`), ports, query strings, or non-`https` schemes are rejected. |
 | `subdir` | `string` | OPTIONAL | Subdirectory inside the source repo. Path-traversal-validated. Ignored for local sources. |
 | `version` | `string` | Conditional | Semver range (e.g. `^1.0.0`, `~2.1.0`, `>=3.0`). Stored as a string; resolution happens at pack time. REQUIRED for remote packages unless `ref` is given. |
 | `ref` | `string` | Conditional | Explicit git ref (SHA, tag, or branch). Overrides `version` range when both are present. REQUIRED for remote packages unless `version` is given. |
@@ -808,6 +809,10 @@ Remote packages MUST declare at least one of `version` or `ref`. Local packages 
 
 The first three `source` forms target a remote git host; the second and third name a non-default host (e.g. GitHub Enterprise, self-hosted GitLab) as either a shorthand or a full HTTPS URL with an optional `.git` suffix that is normalized away. Path traversal (`..`) in local paths, userinfo (`user@host`), ports, query strings, and non-`https` URL schemes are rejected at parse time.
 
+When `sourceBase` is set, relative package sources compose onto that base. For example, `sourceBase: https://gitlab.corp.example.com/platform/agent-marketplace` plus `source: review` emits `https://gitlab.corp.example.com/platform/agent-marketplace/review`. Host-prefixed and full URL sources are overrides and ignore `sourceBase`; local `./` sources also ignore it. Without `sourceBase`, existing `owner/repo` behavior is unchanged and single-segment relative sources are rejected.
+
+`sourceBase` must start with `https://`, use a FQDN host, include at least one path segment, and omit userinfo, ports, query strings, fragments, and a trailing `.git`. Each path segment uses letters, digits, `.`, `_`, or `-`; empty, `.` and `..` segments are refused.
+
 Non-default hosts authenticate via the standard APM token chain -- see the [authentication guide](../getting-started/authentication/) for the per-host-class lookup order. A token resolved for the default host is never forwarded to a non-default host.
 
 ### 7.6. Complete Marketplace Block
@@ -819,6 +824,9 @@ marketplace:
     name: contoso
     url:  https://github.com/contoso
 
+  # Optional: packages can name repos relative to this git base.
+  sourceBase: https://gitlab.corp.example.com/platform/agent-marketplace
+
   output: .claude-plugin/marketplace.json
 
   metadata:
@@ -829,7 +837,7 @@ marketplace:
 
   packages:
     - name: code-review
-      source: contoso/code-review
+      source: code-review                    # resolves under sourceBase
       version: "^1.0.0"
       description: AI code-review skills
       tags: [review, quality]

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -814,7 +814,7 @@ Remote packages MUST declare at least one of `version` or `ref`. Local packages 
 
 The first three `source` forms target a remote git host; the second and third name a non-default host (e.g. GitHub Enterprise, self-hosted GitLab) as either a shorthand or a full HTTPS URL with an optional `.git` suffix that is normalized away. Path traversal (`..`) in local paths, userinfo (`user@host`), ports, query strings, and non-`https` URL schemes are rejected at parse time.
 
-When `sourceBase` is set, relative package sources compose onto that base. For example, `sourceBase: https://gitlab.corp.example.com/platform/agent-marketplace` plus `source: review` emits `https://gitlab.corp.example.com/platform/agent-marketplace/review`. Host-prefixed and full URL sources are overrides and ignore `sourceBase`; local `./` sources also ignore it. Without `sourceBase`, existing `owner/repo` behavior is unchanged and single-segment relative sources are rejected.
+When `sourceBase` is set, relative package sources compose onto that base. For example, `sourceBase: https://gitlab.corp.example.com/platform/agent-marketplace` plus `source: review` emits `https://gitlab.corp.example.com/platform/agent-marketplace/review`. This includes two-segment `owner/repo` values and deeper relative paths; only host-prefixed sources, full HTTPS URLs, and local `./` sources are overrides that ignore `sourceBase`. Without `sourceBase`, existing `owner/repo` behavior is unchanged and single-segment relative sources are rejected.
 
 A relative `source` may use arbitrary path depth. A value whose leading segments form a host-prefixed shape (`<host.tld>/<owner>/<repo>`) or a full `https://` URL is always treated as a per-entry override and ignores `sourceBase`. A value that looks like it is trying to name a host (a dotted, FQDN-like first segment) but does **not** form a valid override shape is rejected at parse time rather than silently composed onto the base -- this avoids a confused-deputy footgun. To target a different host, use an explicit host-prefixed override or a full `https://` URL instead of a relative source.
 
@@ -850,7 +850,7 @@ marketplace:
       tags: [review, quality]
 
     - name: pinned-helper
-      source: contoso/pinned-helper
+      source: contoso/pinned-helper          # also resolves under sourceBase
       ref: main                              # explicit ref overrides version
       tag_pattern: "pinned-helper-v{version}"
 
@@ -972,3 +972,4 @@ marketplace:
 | 0.1 | 2026-03-06 | Initial Working Draft. |
 | 0.2 | 2026-05-10 | Added Section 7 (Marketplace authoring block). Documented `scripts.start` as the default `apm run` entry point. Cross-links updated to reference CLI paths. ASCII-only enforcement. |
 | 0.3 | 2026-05-20 | Added Section 4.3 (`dependencies.lsp`). LSP servers as a third dependency kind. Updated document structure, devDependencies known keys, and Appendix A. |
+| 0.4 | 2026-06-11 | Added `marketplace.sourceBase` and Section 7.5 source composition semantics. |

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -379,11 +379,16 @@ marketplace:
     - name: review
       source: review
       ref: v1.0.0
+    - name: pinned
+      source: team/pinned
+      ref: main
 ```
 
-Relative `packages[].source` values compose onto the base. Host-prefixed
-sources, full HTTPS URLs, and local `./` paths remain per-entry overrides.
-Without `sourceBase`, existing `owner/repo` source behavior is unchanged.
+Relative `packages[].source` values compose onto the base, including
+`owner/repo` shapes like `team/pinned`. Host-prefixed sources, full HTTPS
+URLs, and local `./` paths remain per-entry overrides. Without `sourceBase`,
+existing `owner/repo` source behavior is unchanged. The manifest schema
+Section 7.5 is canonical for the full validation and override rules.
 
 ## Step-by-step: create and publish
 

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -367,6 +367,24 @@ target is present. Authoring rules:
 - Governance: a `bin_deploy` policy rule can deny deployment per package.
   See the [policy schema](../../../../../docs/src/content/docs/reference/policy-schema.md#bin_deploy).
 
+## Marketplace source bases
+
+Marketplace publishers can declare `marketplace.sourceBase` when package
+repositories share an enterprise git base path:
+
+```yaml
+marketplace:
+  sourceBase: https://gitlab.corp.example.com/platform/agent-marketplace
+  packages:
+    - name: review
+      source: review
+      ref: v1.0.0
+```
+
+Relative `packages[].source` values compose onto the base. Host-prefixed
+sources, full HTTPS URLs, and local `./` paths remain per-entry overrides.
+Without `sourceBase`, existing `owner/repo` source behavior is unchanged.
+
 ## Step-by-step: create and publish
 
 ```bash

--- a/src/apm_cli/marketplace/builder.py
+++ b/src/apm_cli/marketplace/builder.py
@@ -62,7 +62,12 @@ from .output_profiles import (
 from .ref_resolver import RefResolver
 from .semver import SemVer, parse_semver, satisfies_range
 from .tag_pattern import build_tag_regex
-from .yml_schema import MarketplaceYml, PackageEntry, load_marketplace_yml
+from .yml_schema import (
+    MarketplaceYml,
+    PackageEntry,
+    load_marketplace_yml,
+    split_source_base,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -93,6 +98,7 @@ class ResolvedPackage:
     tags: tuple[str, ...]
     is_prerelease: bool  # True if the resolved ref was a prerelease semver
     host: str | None = None  # non-default git host parsed from apm.yml source
+    source_url: str | None = None  # canonical URL for sourceBase-composed entries
 
 
 @dataclass(frozen=True)
@@ -498,6 +504,31 @@ class MarketplaceBuilder:
 
     # -- single-entry resolution --------------------------------------------
 
+    def _remote_source_coordinates(
+        self,
+        entry: PackageEntry,
+    ) -> tuple[str | None, str, str | None]:
+        """Return ``(host, repo_path, source_url)`` for a remote package entry."""
+        if entry.host:
+            return entry.host, entry.source, None
+        yml = self._load_yml()
+        if yml.source_base:
+            base_host, base_path = split_source_base(yml.source_base)
+            repo_path = f"{base_path}/{entry.source}"
+            return base_host, repo_path, f"{yml.source_base}/{entry.source}"
+        return None, entry.source, None
+
+    def _resolved_output_host(
+        self,
+        *,
+        source_host: str | None,
+        source_url: str | None,
+    ) -> str | None:
+        """Return the host marker mappers should use for the resolved package."""
+        if source_url is not None:
+            return source_host
+        return self._effective_host(source_host)
+
     def _resolve_entry(self, entry: PackageEntry) -> ResolvedPackage:
         """Resolve a single package entry to a concrete tag + SHA."""
         # Local-path packages skip git resolution entirely.
@@ -513,19 +544,35 @@ class MarketplaceBuilder:
                 is_prerelease=False,
             )
         yml = self._load_yml()
-        resolver = self._get_resolver_for_host(entry.host)
-        owner_repo = entry.source
+        source_host, owner_repo, source_url = self._remote_source_coordinates(entry)
+        resolver = self._get_resolver_for_host(source_host)
 
         if entry.ref is not None:
-            return self._resolve_explicit_ref(entry, resolver, owner_repo)
+            return self._resolve_explicit_ref(
+                entry,
+                resolver,
+                owner_repo,
+                source_host=source_host,
+                source_url=source_url,
+            )
         # version range resolution
-        return self._resolve_version_range(entry, resolver, owner_repo, yml)
+        return self._resolve_version_range(
+            entry,
+            resolver,
+            owner_repo,
+            yml,
+            source_host=source_host,
+            source_url=source_url,
+        )
 
     def _resolve_explicit_ref(
         self,
         entry: PackageEntry,
         resolver: RefResolver,
         owner_repo: str,
+        *,
+        source_host: str | None = None,
+        source_url: str | None = None,
     ) -> ResolvedPackage:
         """Resolve an entry with an explicit ``ref:`` field."""
         ref_text = entry.ref
@@ -543,7 +590,8 @@ class MarketplaceBuilder:
                 requested_version=entry.version,
                 tags=entry.tags,
                 is_prerelease=sv.is_prerelease if sv else False,
-                host=self._effective_host(entry.host),
+                host=self._resolved_output_host(source_host=source_host, source_url=source_url),
+                source_url=source_url,
             )
 
         refs = resolver.list_remote_refs(owner_repo)
@@ -564,7 +612,8 @@ class MarketplaceBuilder:
                     requested_version=entry.version,
                     tags=entry.tags,
                     is_prerelease=sv.is_prerelease if sv else False,
-                    host=self._effective_host(entry.host),
+                    host=self._resolved_output_host(source_host=source_host, source_url=source_url),
+                    source_url=source_url,
                 )
 
         # Try as full refname
@@ -584,7 +633,8 @@ class MarketplaceBuilder:
                     requested_version=entry.version,
                     tags=entry.tags,
                     is_prerelease=sv.is_prerelease if sv else False,
-                    host=self._effective_host(entry.host),
+                    host=self._resolved_output_host(source_host=source_host, source_url=source_url),
+                    source_url=source_url,
                 )
 
         # Try as branch name
@@ -601,7 +651,8 @@ class MarketplaceBuilder:
                     requested_version=entry.version,
                     tags=entry.tags,
                     is_prerelease=False,
-                    host=self._effective_host(entry.host),
+                    host=self._resolved_output_host(source_host=source_host, source_url=source_url),
+                    source_url=source_url,
                 )
 
         # HEAD special case
@@ -617,6 +668,9 @@ class MarketplaceBuilder:
         resolver: RefResolver,
         owner_repo: str,
         yml: MarketplaceYml,
+        *,
+        source_host: str | None = None,
+        source_url: str | None = None,
     ) -> ResolvedPackage:
         """Resolve an entry using its ``version:`` semver range."""
         version_range = entry.version
@@ -660,7 +714,8 @@ class MarketplaceBuilder:
             requested_version=version_range,
             tags=entry.tags,
             is_prerelease=best_sv.is_prerelease,
-            host=self._effective_host(entry.host),
+            host=self._resolved_output_host(source_host=source_host, source_url=source_url),
+            source_url=source_url,
         )
 
     # -- concurrent resolution ----------------------------------------------

--- a/src/apm_cli/marketplace/builder.py
+++ b/src/apm_cli/marketplace/builder.py
@@ -102,6 +102,20 @@ class ResolvedPackage:
 
 
 @dataclass(frozen=True)
+class _SourceBaseCoords:
+    """Parsed sourceBase coordinates cached for one marketplace build."""
+
+    host: str
+    path_prefix: str
+    source_base: str
+
+    @property
+    def org_hint(self) -> str:
+        """Return the leading path segment used for per-org auth lookup."""
+        return self.path_prefix.split("/", 1)[0]
+
+
+@dataclass(frozen=True)
 class ResolveResult:
     """Result of resolving package refs in a marketplace build."""
 
@@ -316,12 +330,12 @@ class MarketplaceBuilder:
         self._host: str = default_host() or "github.com"
         self._host_info: HostInfo | None = None
         self._auth_resolved: bool = False
-        # Per-host RefResolver cache, keyed by host override on PackageEntry.
+        # Per-host RefResolver cache, keyed by host and optional org hint.
         # Pre-warmed on the main thread before workers spawn; lock guards
         # against future refactors that allow worker-side cache misses.
-        self._host_resolvers: dict[str, RefResolver] = {}
+        self._host_resolvers: dict[tuple[str, str | None], RefResolver] = {}
         self._host_resolvers_lock = threading.Lock()
-        self._source_base_parts: tuple[str, str, str] | None = None
+        self._source_base_parts: _SourceBaseCoords | None = None
         self._source_base_parts_loaded = False
 
     @classmethod
@@ -365,13 +379,18 @@ class MarketplaceBuilder:
                 self._yml = load_marketplace_yml(self._yml_path)
         return self._yml
 
-    def _get_source_base_parts(self) -> tuple[str, str, str] | None:
-        """Return cached ``(host, path_prefix, source_base)`` coordinates."""
+    def _get_source_base_parts(self) -> _SourceBaseCoords | None:
+        """Return cached sourceBase coordinates for this builder."""
         if not self._source_base_parts_loaded:
             yml = self._load_yml()
-            if yml.source_base:
-                base_host, base_path = split_source_base(yml.source_base)
-                self._source_base_parts = (base_host, base_path, yml.source_base)
+            source_base = getattr(yml, "source_base", None)
+            if isinstance(source_base, str) and source_base:
+                base_host, base_path = split_source_base(source_base)
+                self._source_base_parts = _SourceBaseCoords(
+                    host=base_host,
+                    path_prefix=base_path,
+                    source_base=source_base,
+                )
             self._source_base_parts_loaded = True
         return self._source_base_parts
 
@@ -400,39 +419,40 @@ class MarketplaceBuilder:
             return None
         return host
 
-    def _get_resolver_for_host(self, host: str | None) -> RefResolver:
-        """Return a RefResolver bound to *host* (default when ``None``).
+    def _get_resolver_for_host(self, host: str | None, *, org: str | None = None) -> RefResolver:
+        """Return a RefResolver bound to *host* and optional auth org hint.
 
-        Non-default hosts go through ``AuthResolver.resolve(host)`` so that
-        ``GITHUB_APM_PAT``, ``GITHUB_APM_PAT_{ORG}``, ``GITHUB_TOKEN`` and
-        ``GH_TOKEN`` are consulted before falling back to ambient git
-        credentials (SSH key / credential helper).  Per-host resolvers are
-        cached for the lifetime of the build so each unique host pays the
-        auth-resolution cost only once.
+        Non-default hosts and sourceBase-derived org hints go through
+        ``AuthResolver.resolve(host, org=org)`` so per-org variables are
+        honored before ambient git credentials.  Existing default-host calls
+        without an org hint keep the legacy resolver path.
         """
-        if host is None or host == self._host:
+        if org is None and (host is None or host == self._host):
             return self._get_resolver()
+        resolved_host = host or self._host
+        key = (resolved_host, org)
         with self._host_resolvers_lock:
-            cached = self._host_resolvers.get(host)
+            cached = self._host_resolvers.get(key)
             if cached is not None:
                 return cached
-            token = self._resolve_token_for_host(host)
+            token = self._resolve_token_for_host(resolved_host, org=org)
             logger.debug(
-                "Creating per-host RefResolver for %s (token=%s)",
-                host,
+                "Creating per-host RefResolver for %s (org=%s, token=%s)",
+                resolved_host,
+                org or "none",
                 "set" if token else "unset",
             )
             resolver = RefResolver(
                 timeout_seconds=self._options.timeout_seconds,
                 offline=self._options.offline,
-                host=host,
+                host=resolved_host,
                 token=token,
             )
-            self._host_resolvers[host] = resolver
+            self._host_resolvers[key] = resolver
             return resolver
 
-    def _resolve_token_for_host(self, host: str) -> str | None:
-        """Resolve an auth token for a non-default *host* via ``AuthResolver``.
+    def _resolve_token_for_host(self, host: str, *, org: str | None = None) -> str | None:
+        """Resolve an auth token for *host* via ``AuthResolver``.
 
         Returns ``None`` -- letting ``git`` fall back to ambient credentials
         -- when offline, when no token is configured for the host, or when
@@ -447,7 +467,7 @@ class MarketplaceBuilder:
             if resolver is None:
                 resolver = AuthResolver()
                 self._auth_resolver = resolver
-            ctx = resolver.resolve(host)  # type: ignore[union-attr]
+            ctx = resolver.resolve(host) if org is None else resolver.resolve(host, org=org)
             if ctx.token:
                 logger.debug("Resolved token for host %s (source=%s)", host, ctx.source)
                 return ctx.token
@@ -519,16 +539,22 @@ class MarketplaceBuilder:
     def _remote_source_coordinates(
         self,
         entry: PackageEntry,
-    ) -> tuple[str | None, str, str | None]:
-        """Return ``(host, repo_path, source_url)`` for a remote package entry."""
+    ) -> tuple[str | None, str, str | None, str | None]:
+        """Return ``(host, repo_path, source_url, org_hint)`` for a remote entry."""
         if entry.host:
-            return entry.host, entry.source, None
+            return entry.host, entry.source, None, None
         source_base_parts = self._get_source_base_parts()
         if source_base_parts is not None:
-            base_host, base_path, source_base = source_base_parts
-            repo_path = f"{base_path}/{entry.source}"
-            return base_host, repo_path, f"{source_base}/{entry.source}"
-        return None, entry.source, None
+            repo_path = f"{source_base_parts.path_prefix}/{entry.source}"
+            source_url = f"{source_base_parts.source_base}/{entry.source}"
+            logger.debug(
+                "Composed marketplace source %r onto sourceBase %r as %r",
+                entry.source,
+                source_base_parts.source_base,
+                repo_path,
+            )
+            return source_base_parts.host, repo_path, source_url, source_base_parts.org_hint
+        return None, entry.source, None, None
 
     def _resolved_output_host(
         self,
@@ -556,8 +582,11 @@ class MarketplaceBuilder:
                 is_prerelease=False,
             )
         yml = self._load_yml()
-        source_host, owner_repo, source_url = self._remote_source_coordinates(entry)
-        resolver = self._get_resolver_for_host(source_host)
+        source_host, owner_repo, source_url, source_org = self._remote_source_coordinates(entry)
+        if source_org is None:
+            resolver = self._get_resolver_for_host(source_host)
+        else:
+            resolver = self._get_resolver_for_host(source_host, org=source_org)
 
         if entry.ref is not None:
             return self._resolve_explicit_ref(
@@ -757,9 +786,12 @@ class MarketplaceBuilder:
         # spawning workers -- avoids a race on _ensure_auth() and
         # matches the pattern used in _prefetch_metadata().
         self._get_resolver()
-        # Pre-warm any per-host resolvers needed by entries that override the
-        # default host via the ``host.tld/owner/repo`` source form.  Done on
-        # the main thread so workers never race to create the same resolver.
+        # Pre-warm per-host resolvers on the main thread so workers never race
+        # to create the same resolver. Include the sourceBase host because
+        # base-relative entries derive their host during composition.
+        source_base_parts = self._get_source_base_parts()
+        if source_base_parts is not None:
+            self._get_resolver_for_host(source_base_parts.host, org=source_base_parts.org_hint)
         for entry in entries:
             if entry.host:
                 self._get_resolver_for_host(entry.host)

--- a/src/apm_cli/marketplace/builder.py
+++ b/src/apm_cli/marketplace/builder.py
@@ -321,6 +321,8 @@ class MarketplaceBuilder:
         # against future refactors that allow worker-side cache misses.
         self._host_resolvers: dict[str, RefResolver] = {}
         self._host_resolvers_lock = threading.Lock()
+        self._source_base_parts: tuple[str, str, str] | None = None
+        self._source_base_parts_loaded = False
 
     @classmethod
     def from_config(
@@ -362,6 +364,16 @@ class MarketplaceBuilder:
             else:
                 self._yml = load_marketplace_yml(self._yml_path)
         return self._yml
+
+    def _get_source_base_parts(self) -> tuple[str, str, str] | None:
+        """Return cached ``(host, path_prefix, source_base)`` coordinates."""
+        if not self._source_base_parts_loaded:
+            yml = self._load_yml()
+            if yml.source_base:
+                base_host, base_path = split_source_base(yml.source_base)
+                self._source_base_parts = (base_host, base_path, yml.source_base)
+            self._source_base_parts_loaded = True
+        return self._source_base_parts
 
     def _get_resolver(self) -> RefResolver:
         if self._resolver is None:
@@ -511,11 +523,11 @@ class MarketplaceBuilder:
         """Return ``(host, repo_path, source_url)`` for a remote package entry."""
         if entry.host:
             return entry.host, entry.source, None
-        yml = self._load_yml()
-        if yml.source_base:
-            base_host, base_path = split_source_base(yml.source_base)
+        source_base_parts = self._get_source_base_parts()
+        if source_base_parts is not None:
+            base_host, base_path, source_base = source_base_parts
             repo_path = f"{base_path}/{entry.source}"
-            return base_host, repo_path, f"{yml.source_base}/{entry.source}"
+            return base_host, repo_path, f"{source_base}/{entry.source}"
         return None, entry.source, None
 
     def _resolved_output_host(

--- a/src/apm_cli/marketplace/output_mappers.py
+++ b/src/apm_cli/marketplace/output_mappers.py
@@ -178,16 +178,14 @@ class ClaudeMarketplaceMapper(MarketplaceOutputMapper):
                 # URL so Claude Code can clone from a non-default host (e.g.
                 # GHE) -- the ``github`` shorthand only resolves to github.com.
                 source_obj: dict[str, Any] = OrderedDict()
+                remote_url = _remote_source_url(pkg)
                 if pkg.subdir:
                     source_obj["source"] = "git-subdir"
-                    if pkg.host:
-                        source_obj["url"] = f"https://{pkg.host}/{pkg.source_repo}"
-                    else:
-                        source_obj["url"] = pkg.source_repo
+                    source_obj["url"] = remote_url or pkg.source_repo
                     source_obj["path"] = pkg.subdir
-                elif pkg.host:
+                elif remote_url:
                     source_obj["source"] = "url"
-                    source_obj["url"] = f"https://{pkg.host}/{pkg.source_repo}"
+                    source_obj["url"] = remote_url
                 else:
                     source_obj["source"] = "github"
                     source_obj["repo"] = pkg.source_repo
@@ -267,6 +265,15 @@ MARKETPLACE_OUTPUT_MAPPERS: dict[str, MarketplaceOutputMapper] = {
 }
 
 
+def _remote_source_url(pkg: ResolvedPackage) -> str | None:
+    """Return the canonical URL for remote packages that cannot use github shorthand."""
+    if pkg.source_url:
+        return pkg.source_url
+    if pkg.host:
+        return f"https://{pkg.host}/{pkg.source_repo}"
+    return None
+
+
 def _codex_source(entry: PackageEntry, pkg: ResolvedPackage) -> dict[str, Any]:
     if entry.is_local:
         return OrderedDict(
@@ -278,10 +285,7 @@ def _codex_source(entry: PackageEntry, pkg: ResolvedPackage) -> dict[str, Any]:
     if pkg.subdir:
         source_obj: dict[str, Any] = OrderedDict()
         source_obj["source"] = "git-subdir"
-        if pkg.host:
-            source_obj["url"] = f"https://{pkg.host}/{pkg.source_repo}"
-        else:
-            source_obj["url"] = pkg.source_repo
+        source_obj["url"] = _remote_source_url(pkg) or pkg.source_repo
         source_obj["path"] = pkg.subdir
         if pkg.ref:
             source_obj["ref"] = pkg.ref
@@ -291,10 +295,7 @@ def _codex_source(entry: PackageEntry, pkg: ResolvedPackage) -> dict[str, Any]:
 
     source_obj = OrderedDict()
     source_obj["source"] = "url"
-    if pkg.host:
-        source_obj["url"] = f"https://{pkg.host}/{pkg.source_repo}"
-    else:
-        source_obj["url"] = pkg.source_repo
+    source_obj["url"] = _remote_source_url(pkg) or pkg.source_repo
     if pkg.ref:
         source_obj["ref"] = pkg.ref
     if pkg.sha:

--- a/src/apm_cli/marketplace/yml_editor.py
+++ b/src/apm_cli/marketplace/yml_editor.py
@@ -22,7 +22,8 @@ from ..utils.path_security import PathTraversalError, validate_path_segments
 from ._io import atomic_write
 from .errors import MarketplaceYmlError
 from .yml_schema import (
-    SOURCE_RE,
+    _parse_source_base,
+    _validate_source_value,
     load_marketplace_from_apm_yml,
     load_marketplace_yml,
 )
@@ -129,23 +130,17 @@ def _find_entry_index(packages, name: str) -> int:
     raise MarketplaceYmlError(f"Package '{name}' not found")
 
 
-def _validate_source(source: str) -> None:
-    """Validate that *source* has one of the accepted shapes.
+def _validate_source(source: str, *, source_base: str | None = None) -> None:
+    """Validate that *source* has one of the accepted shapes."""
+    _validate_source_value(source, context="source", source_base=source_base)
 
-    Accepts ``owner/repo``, ``host.tld/owner/repo``, ``https://host.tld/
-    owner/repo[.git]`` (remote forms), or ``./<path>`` (local).
-    """
-    if not SOURCE_RE.match(source):
-        raise MarketplaceYmlError(
-            f"'source' must be one of "
-            f"'<owner>/<repo>', '<host.tld>/<owner>/<repo>', "
-            f"'https://<host.tld>/<owner>/<repo>[.git]', or './<path>', "
-            f"got '{source}'"
-        )
-    try:
-        validate_path_segments(source, context="source", allow_current_dir=True)
-    except PathTraversalError as exc:
-        raise MarketplaceYmlError(str(exc)) from exc
+
+def _default_name_from_source(source: str) -> str:
+    """Derive the package name from the final path segment in a source value."""
+    normalized = source.rstrip("/")
+    if normalized.endswith(".git"):
+        normalized = normalized[: -len(".git")]
+    return normalized.rsplit("/", 1)[-1]
 
 
 def _validate_subdir(subdir: str) -> None:
@@ -177,8 +172,13 @@ def add_plugin_entry(
 
     Returns the resolved package name.
     """
+    # --- load ---
+    data, original_text = _load_rt(yml_path)
+    container = _get_marketplace_container(data)
+    source_base = _parse_source_base(container.get("sourceBase"))
+
     # --- input validation ---
-    _validate_source(source)
+    _validate_source(source, source_base=source_base)
 
     if version is not None and ref is not None:
         raise MarketplaceYmlError("Cannot specify both 'version' and 'ref' -- pick one")
@@ -190,11 +190,8 @@ def add_plugin_entry(
 
     # Derive name from source repo if not provided.
     if name is None:
-        name = source.split("/", 1)[1]
+        name = _default_name_from_source(source)
 
-    # --- load ---
-    data, original_text = _load_rt(yml_path)
-    container = _get_marketplace_container(data)
     packages = container.get("packages")
     if packages is None:
         from ruamel.yaml.comments import CommentedSeq

--- a/src/apm_cli/marketplace/yml_editor.py
+++ b/src/apm_cli/marketplace/yml_editor.py
@@ -22,10 +22,10 @@ from ..utils.path_security import PathTraversalError, validate_path_segments
 from ._io import atomic_write
 from .errors import MarketplaceYmlError
 from .yml_schema import (
-    _parse_source_base,
-    _validate_source_value,
     load_marketplace_from_apm_yml,
     load_marketplace_yml,
+    parse_source_base,
+    validate_source_value,
 )
 
 __all__ = [
@@ -132,7 +132,7 @@ def _find_entry_index(packages, name: str) -> int:
 
 def _validate_source(source: str, *, source_base: str | None = None) -> None:
     """Validate that *source* has one of the accepted shapes."""
-    _validate_source_value(source, context="source", source_base=source_base)
+    validate_source_value(source, context="source", source_base=source_base)
 
 
 def _default_name_from_source(source: str) -> str:
@@ -175,7 +175,7 @@ def add_plugin_entry(
     # --- load ---
     data, original_text = _load_rt(yml_path)
     container = _get_marketplace_container(data)
-    source_base = _parse_source_base(container.get("sourceBase"))
+    source_base = parse_source_base(container.get("sourceBase"))
 
     # --- input validation ---
     _validate_source(source, source_base=source_base)

--- a/src/apm_cli/marketplace/yml_schema.py
+++ b/src/apm_cli/marketplace/yml_schema.py
@@ -32,6 +32,7 @@ Key design rules
 from __future__ import annotations
 
 import re
+import urllib.parse as _urlparse
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Mapping  # noqa: UP035
@@ -44,6 +45,7 @@ from .output_profiles import MARKETPLACE_OUTPUTS, known_output_names
 
 __all__ = [
     "LOCAL_SOURCE_RE",
+    "SOURCE_BASE_RE",
     "SOURCE_RE",
     "MarketplaceBuild",
     "MarketplaceClaudeConfig",
@@ -85,7 +87,9 @@ _SEMVER_RE = re.compile(
 # (``git@host:path``) and non-``https`` URL schemes are explicitly rejected
 # to avoid RFC 3986 confused-deputy attacks.
 _HOST_PAT = r"(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\.)+[A-Za-z][A-Za-z0-9-]*"
-_OWNER_REPO_PAT = r"[A-Za-z0-9._-]+/[A-Za-z0-9._-]+"
+_SEGMENT_PAT = r"[A-Za-z0-9._-]+"
+_OWNER_REPO_PAT = rf"{_SEGMENT_PAT}/{_SEGMENT_PAT}"
+_RELATIVE_SOURCE_PAT = rf"{_SEGMENT_PAT}(?:/{_SEGMENT_PAT})*"
 
 SOURCE_RE = re.compile(
     r"^(?:"
@@ -96,10 +100,19 @@ SOURCE_RE = re.compile(
     r")$"
 )
 LOCAL_SOURCE_RE = re.compile(r"^\./")
+SOURCE_BASE_RE = re.compile(rf"^https://{_HOST_PAT}/{_RELATIVE_SOURCE_PAT}$")
+_RELATIVE_SOURCE_RE = re.compile(rf"^{_RELATIVE_SOURCE_PAT}$")
 # Matches ``host.tld/owner/repo`` (3 segments, first is FQDN-ish).
 _HOST_PREFIXED_SOURCE_RE = re.compile(rf"^({_HOST_PAT})/({_OWNER_REPO_PAT})$")
 # Matches ``https://host.tld/owner/repo[.git]`` and captures host + owner/repo.
 _HTTPS_URL_SOURCE_RE = re.compile(rf"^https://({_HOST_PAT})/({_OWNER_REPO_PAT})(?:\.git)?$")
+
+
+def split_source_base(source_base: str) -> tuple[str, str]:
+    """Split a validated ``sourceBase`` into ``(host, path_prefix)``."""
+    without_scheme = source_base.removeprefix("https://")
+    host, path_prefix = without_scheme.split("/", 1)
+    return host, path_prefix
 
 
 def split_host_from_source(source: str) -> tuple[str | None, str]:
@@ -216,6 +229,7 @@ _APM_MARKETPLACE_KEYS = frozenset(
         "description",  # optional override of top-level apm.yml description
         "version",  # optional override of top-level apm.yml version
         "owner",
+        "sourceBase",
         "output",
         "outputs",
         "claude",
@@ -388,6 +402,7 @@ class MarketplaceConfig:
     metadata: dict[str, Any] = field(default_factory=dict)
     build: MarketplaceBuild = field(default_factory=MarketplaceBuild)
     versioning: MarketplaceVersioning = field(default_factory=MarketplaceVersioning)
+    source_base: str | None = None
     packages: tuple[PackageEntry, ...] = ()
     output_specs: tuple[MarketplaceOutputSpec, ...] = ()
     warnings: tuple[str, ...] = ()
@@ -433,27 +448,95 @@ def _validate_semver(version: str, *, context: str = "version") -> None:
         )
 
 
-def _validate_source(source: str, *, index: int) -> None:
-    """Validate ``source`` field shape and path safety.
+def _source_error(ctx: str, source: str, *, source_base: str | None) -> MarketplaceYmlError:
+    forms = [
+        "'<owner>/<repo>'",
+        "'<host.tld>/<owner>/<repo>'",
+        "'https://<host.tld>/<owner>/<repo>[.git]'",
+        "'./<path>'",
+    ]
+    if source_base is not None:
+        forms.append("'<relative-path>' when sourceBase is set")
+    return MarketplaceYmlError(f"'{ctx}' must be one of {', '.join(forms)}, got '{source}'")
 
-    Accepts ``owner/repo``, ``host.tld/owner/repo``, ``https://host.tld/
-    owner/repo[.git]``, or ``./<path>``.
-    """
-    ctx = f"packages[{index}].source"
-    if not SOURCE_RE.match(source):
-        raise MarketplaceYmlError(
-            f"'{ctx}' must be one of "
-            f"'<owner>/<repo>', '<host.tld>/<owner>/<repo>', "
-            f"'https://<host.tld>/<owner>/<repo>[.git]', or './<path>', "
-            f"got '{source}'"
+
+def _validate_source_value(
+    source: str,
+    *,
+    context: str,
+    source_base: str | None = None,
+) -> None:
+    """Validate a package ``source`` field shape and path safety."""
+    matches_existing_shape = bool(SOURCE_RE.match(source))
+    if not matches_existing_shape:
+        first_segment = source.split("/", 1)[0]
+        looks_like_unsupported_host_override = "/" in source and bool(
+            re.fullmatch(_HOST_PAT, first_segment)
         )
+        matches_relative_source = bool(_RELATIVE_SOURCE_RE.match(source))
+        if (
+            source_base is None
+            or looks_like_unsupported_host_override
+            or not matches_relative_source
+        ):
+            raise _source_error(context, source, source_base=source_base)
     is_local = bool(LOCAL_SOURCE_RE.match(source))
     try:
         # Local paths legitimately start with ``.`` (current dir) and
         # may have trailing-slash forms like ``./``.  Allow ``.`` here.
-        validate_path_segments(source, context=ctx, allow_current_dir=is_local)
+        validate_path_segments(source, context=context, allow_current_dir=is_local)
     except PathTraversalError as exc:
         raise MarketplaceYmlError(str(exc)) from exc
+
+
+def _validate_source(source: str, *, index: int, source_base: str | None = None) -> None:
+    """Validate ``source`` field shape and path safety."""
+    _validate_source_value(
+        source,
+        context=f"packages[{index}].source",
+        source_base=source_base,
+    )
+
+
+def _parse_source_base(raw: Any) -> str | None:
+    """Parse and validate marketplace-level ``sourceBase``."""
+    if raw is None:
+        return None
+    if not isinstance(raw, str) or not raw.strip():
+        raise MarketplaceYmlError("'sourceBase' must be a non-empty string")
+
+    source_base = raw.strip()
+    if source_base.endswith("/"):
+        source_base = source_base[:-1]
+    if not source_base.startswith("https://"):
+        raise MarketplaceYmlError("'sourceBase' must start with https://")
+
+    parsed = _urlparse.urlparse(source_base)
+    if parsed.username or parsed.password or "@" in parsed.netloc:
+        raise MarketplaceYmlError("'sourceBase' must not include userinfo")
+    if ":" in parsed.netloc:
+        raise MarketplaceYmlError("'sourceBase' must not include a port")
+    if parsed.query:
+        raise MarketplaceYmlError("'sourceBase' must not include a query string")
+    if parsed.fragment:
+        raise MarketplaceYmlError("'sourceBase' must not include a fragment")
+    if not parsed.hostname or not re.fullmatch(_HOST_PAT, parsed.hostname):
+        raise MarketplaceYmlError("'sourceBase' host must be a FQDN")
+    if source_base.endswith(".git"):
+        raise MarketplaceYmlError("'sourceBase' must not end with .git")
+
+    path = parsed.path.lstrip("/")
+    if not path:
+        raise MarketplaceYmlError("'sourceBase' must include at least one path segment")
+    try:
+        validate_path_segments(path, context="sourceBase", reject_empty=True)
+    except PathTraversalError as exc:
+        raise MarketplaceYmlError(str(exc)) from exc
+    if not SOURCE_BASE_RE.match(source_base):
+        raise MarketplaceYmlError(
+            "'sourceBase' path segments may only contain letters, digits, dot, underscore, or hyphen"
+        )
+    return source_base
 
 
 def _validate_tag_pattern(pattern: str, *, context: str) -> None:
@@ -700,7 +783,11 @@ def _parse_outputs(
     return tuple(outputs_list), tuple(specs_list)
 
 
-def _parse_package_entry(raw: Any, index: int) -> PackageEntry:
+def _parse_package_entry(
+    raw: Any,
+    index: int,
+    source_base: str | None = None,
+) -> PackageEntry:
     """Parse and validate a single ``packages`` entry."""
     if not isinstance(raw, dict):
         raise MarketplaceYmlError(f"packages[{index}] must be a mapping")
@@ -710,7 +797,7 @@ def _parse_package_entry(raw: Any, index: int) -> PackageEntry:
 
     name = _require_str(raw, "name", context=f"packages[{index}]")
     source = _require_str(raw, "source", context=f"packages[{index}]")
-    _validate_source(source, index=index)
+    _validate_source(source, index=index, source_base=source_base)
     is_local = bool(LOCAL_SOURCE_RE.match(source))
     # Detect host-prefixed source (e.g. ``host.tld/owner/repo``) and split
     # the host off so downstream consumers continue to see ``owner/repo``.
@@ -1119,6 +1206,9 @@ def _build_config(
         except PathTraversalError as exc:
             raise MarketplaceYmlError(str(exc)) from exc
 
+    # -- marketplace source base --
+    source_base = _parse_source_base(marketplace_dict.get("sourceBase"))
+
     # -- build --
     build = _parse_build(marketplace_dict.get("build"))
 
@@ -1176,7 +1266,7 @@ def _build_config(
     entries: list[PackageEntry] = []
     seen_names: dict[str, int] = {}
     for idx, raw_entry in enumerate(raw_packages):
-        entry = _parse_package_entry(raw_entry, idx)
+        entry = _parse_package_entry(raw_entry, idx, source_base=source_base)
         lower_name = entry.name.lower()
         if lower_name in seen_names:
             raise MarketplaceYmlError(
@@ -1208,6 +1298,7 @@ def _build_config(
         codex=codex,
         metadata=metadata,
         build=build,
+        source_base=source_base,
         versioning=versioning,
         packages=tuple(entries),
         output_specs=output_specs,

--- a/src/apm_cli/marketplace/yml_schema.py
+++ b/src/apm_cli/marketplace/yml_schema.py
@@ -59,6 +59,10 @@ __all__ = [
     "load_marketplace_from_apm_yml",
     "load_marketplace_from_legacy_yml",
     "load_marketplace_yml",
+    "parse_source_base",
+    "split_host_from_source",
+    "split_source_base",
+    "validate_source_value",
 ]
 
 # ---------------------------------------------------------------------------
@@ -460,7 +464,7 @@ def _source_error(ctx: str, source: str, *, source_base: str | None) -> Marketpl
     return MarketplaceYmlError(f"'{ctx}' must be one of {', '.join(forms)}, got '{source}'")
 
 
-def _validate_source_value(
+def validate_source_value(
     source: str,
     *,
     context: str,
@@ -496,27 +500,26 @@ def _validate_source_value(
 
 def _validate_source(source: str, *, index: int, source_base: str | None = None) -> None:
     """Validate ``source`` field shape and path safety."""
-    _validate_source_value(
+    validate_source_value(
         source,
         context=f"packages[{index}].source",
         source_base=source_base,
     )
 
 
-def _parse_source_base(raw: Any) -> str | None:
+def parse_source_base(raw: Any) -> str | None:
     """Parse and validate marketplace-level ``sourceBase``."""
     if raw is None:
         return None
     if not isinstance(raw, str) or not raw.strip():
         raise MarketplaceYmlError("'sourceBase' must be a non-empty string")
 
-    source_base = raw.strip()
-    if source_base.endswith("/"):
-        source_base = source_base[:-1]
-    if not source_base.startswith("https://"):
+    raw_source_base = raw.strip()
+    if not raw_source_base.startswith("https://"):
         raise MarketplaceYmlError("'sourceBase' must start with https://")
 
-    parsed = _urlparse.urlparse(source_base)
+    parsed = _urlparse.urlparse(raw_source_base)
+    source_base = raw_source_base.rstrip("/")
     if parsed.username or parsed.password or "@" in parsed.netloc:
         raise MarketplaceYmlError("'sourceBase' must not include userinfo")
     if ":" in parsed.netloc:
@@ -531,6 +534,8 @@ def _parse_source_base(raw: Any) -> str | None:
         raise MarketplaceYmlError("'sourceBase' must not end with .git")
 
     path = parsed.path.lstrip("/")
+    if path.endswith("/"):
+        path = path[:-1]
     if not path:
         raise MarketplaceYmlError("'sourceBase' must include at least one path segment")
     try:
@@ -1212,7 +1217,7 @@ def _build_config(
             raise MarketplaceYmlError(str(exc)) from exc
 
     # -- marketplace source base --
-    source_base = _parse_source_base(marketplace_dict.get("sourceBase"))
+    source_base = parse_source_base(marketplace_dict.get("sourceBase"))
 
     # -- build --
     build = _parse_build(marketplace_dict.get("build"))

--- a/src/apm_cli/marketplace/yml_schema.py
+++ b/src/apm_cli/marketplace/yml_schema.py
@@ -91,6 +91,8 @@ _SEMVER_RE = re.compile(
 # (``git@host:path``) and non-``https`` URL schemes are explicitly rejected
 # to avoid RFC 3986 confused-deputy attacks.
 _HOST_PAT = r"(?:[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?\.)+[A-Za-z][A-Za-z0-9-]*"
+# SECURITY: segment regexes are shape filters only. Traversal defense lives in
+# validate_path_segments(), which rejects empty, '.', and '..' path segments.
 _SEGMENT_PAT = r"[A-Za-z0-9._-]+"
 _OWNER_REPO_PAT = rf"{_SEGMENT_PAT}/{_SEGMENT_PAT}"
 _RELATIVE_SOURCE_PAT = rf"{_SEGMENT_PAT}(?:/{_SEGMENT_PAT})*"
@@ -113,7 +115,7 @@ _HTTPS_URL_SOURCE_RE = re.compile(rf"^https://({_HOST_PAT})/({_OWNER_REPO_PAT})(
 
 
 def split_source_base(source_base: str) -> tuple[str, str]:
-    """Split a validated ``sourceBase`` into ``(host, path_prefix)``."""
+    """Split a ``parse_source_base``-validated value into host and path."""
     without_scheme = source_base.removeprefix("https://")
     host, path_prefix = without_scheme.split("/", 1)
     return host, path_prefix
@@ -483,11 +485,13 @@ def validate_source_value(
             re.fullmatch(_HOST_PAT, first_segment)
         )
         matches_relative_source = bool(_RELATIVE_SOURCE_RE.match(source))
-        if (
-            source_base is None
-            or looks_like_unsupported_host_override
-            or not matches_relative_source
-        ):
+        if looks_like_unsupported_host_override:
+            raise MarketplaceYmlError(
+                f"'{context}' looks like a host-prefixed source but does not match "
+                f"'<host.tld>/<owner>/<repo>'. Use a full HTTPS URL override "
+                f"('https://...') or remove the host to compose onto sourceBase."
+            )
+        if source_base is None or not matches_relative_source:
             raise _source_error(context, source, source_base=source_base)
     is_local = bool(LOCAL_SOURCE_RE.match(source))
     try:

--- a/src/apm_cli/marketplace/yml_schema.py
+++ b/src/apm_cli/marketplace/yml_schema.py
@@ -469,6 +469,11 @@ def _validate_source_value(
     """Validate a package ``source`` field shape and path safety."""
     matches_existing_shape = bool(SOURCE_RE.match(source))
     if not matches_existing_shape:
+        # The source matched no supported shape. If its first segment looks
+        # like a FQDN it is trying to name a host but does not form a valid
+        # host-prefixed override (host/owner/repo) -- reject it rather than
+        # silently compose it onto ``sourceBase`` (confused-deputy footgun,
+        # documented in manifest-schema.md Section 7.5).
         first_segment = source.split("/", 1)[0]
         looks_like_unsupported_host_override = "/" in source and bool(
             re.fullmatch(_HOST_PAT, first_segment)

--- a/tests/integration/test_marketplace_builder_hermetic.py
+++ b/tests/integration/test_marketplace_builder_hermetic.py
@@ -996,6 +996,40 @@ class TestResolveGithubToken:
 
 
 class TestBuildPipeline:
+    def test_build_writes_source_base_composed_url_to_output_json(self, tmp_path):
+        apm_yml = tmp_path / "apm.yml"
+        apm_yml.write_text(
+            yaml.safe_dump(
+                {
+                    "name": "source-base-marketplace",
+                    "description": "Source base marketplace",
+                    "version": "1.0.0",
+                    "marketplace": {
+                        "owner": {"name": "ACME"},
+                        "sourceBase": "https://gitlab.example.com/platform/marketplaces",
+                        "claude": {"output": "marketplace.json"},
+                        "packages": [
+                            {
+                                "name": "tool",
+                                "source": "team/tool",
+                                "ref": "a" * 40,
+                            }
+                        ],
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        builder = MarketplaceBuilder(apm_yml, options=BuildOptions(offline=True))
+
+        report = builder.build()
+
+        assert report.primary_output.errors == ()
+        output = json.loads((tmp_path / "marketplace.json").read_text(encoding="utf-8"))
+        source = output["plugins"][0]["source"]
+        assert source["source"] == "url"
+        assert source["url"] == "https://gitlab.example.com/platform/marketplaces/team/tool"
+
     def test_build_calls_resolve_and_write_output(self, tmp_path):
         yml = _make_marketplace_yml_file(tmp_path)
         builder = MarketplaceBuilder(yml)

--- a/tests/unit/marketplace/test_marketplace_source_base.py
+++ b/tests/unit/marketplace/test_marketplace_source_base.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
+
+from apm_cli.marketplace.builder import BuildOptions, MarketplaceBuilder
+from apm_cli.marketplace.errors import MarketplaceYmlError
+from apm_cli.marketplace.migration import load_marketplace_config
+from apm_cli.marketplace.yml_editor import add_plugin_entry
+from apm_cli.marketplace.yml_schema import MarketplaceConfig
+
+_SHA = "a" * 40
+
+
+def _write(path: Path, content: str) -> Path:
+    path.write_text(textwrap.dedent(content).lstrip(), encoding="utf-8")
+    return path
+
+
+def _apm_yml(source_base: str | None, packages: str) -> str:
+    lines = [
+        "name: source-base-marketplace",
+        "description: Source base marketplace",
+        "version: 1.0.0",
+        "marketplace:",
+        "  owner:",
+        "    name: ACME",
+    ]
+    if source_base is not None:
+        lines.append(f"  sourceBase: {source_base}")
+    lines.append("  packages:")
+    lines.append(textwrap.indent(textwrap.dedent(packages).strip(), "    "))
+    return "\n".join(lines) + "\n"
+
+
+def _load_config(tmp_path: Path, source_base: str | None, packages: str) -> MarketplaceConfig:
+    _write(tmp_path / "apm.yml", _apm_yml(source_base, packages))
+    return load_marketplace_config(tmp_path)
+
+
+class TestSourceBaseSchema:
+    def test_accepts_single_and_nested_relative_sources_when_source_base_is_set(
+        self, tmp_path: Path
+    ) -> None:
+        config = _load_config(
+            tmp_path,
+            "https://gitlab.example.com/platform/marketplaces/",
+            f"""
+            - name: single
+              source: single-tool
+              ref: {_SHA}
+            - name: nested
+              source: team/tools/nested-tool
+              ref: {_SHA}
+            """,
+        )
+
+        assert config.source_base == "https://gitlab.example.com/platform/marketplaces"
+        assert config.packages[0].source == "single-tool"
+        assert config.packages[0].host is None
+        assert config.packages[1].source == "team/tools/nested-tool"
+        assert config.packages[1].host is None
+
+    def test_absent_source_base_keeps_owner_repo_source_unchanged(self, tmp_path: Path) -> None:
+        config = _load_config(
+            tmp_path,
+            None,
+            f"""
+            - name: existing
+              source: owner/repo
+              ref: {_SHA}
+            """,
+        )
+
+        assert config.source_base is None
+        assert config.packages[0].source == "owner/repo"
+        assert config.packages[0].host is None
+
+    @pytest.mark.parametrize(
+        ("source_base", "message"),
+        [
+            ("http://gitlab.example.com/group", "https"),
+            ("https://user@gitlab.example.com/group", "userinfo"),
+            ("https://gitlab.example.com:443/group", "port"),
+            ("https://gitlab.example.com/group?token=x", "query"),
+            ("https://gitlab.example.com/group#frag", "fragment"),
+            ("https://gitlab.example.com/group.git", r"\.git"),
+            ("https://localhost/group", "FQDN"),
+            ("https://gitlab.example.com/group//repo", "empty"),
+            ("https://gitlab.example.com/group//", "empty"),
+            ("https://gitlab.example.com/group/../repo", "traversal"),
+        ],
+    )
+    def test_rejects_source_base_security_guard_violations(
+        self, tmp_path: Path, source_base: str, message: str
+    ) -> None:
+        with pytest.raises(MarketplaceYmlError, match=message):
+            _load_config(
+                tmp_path,
+                source_base,
+                f"""
+                - name: tool
+                  source: tool
+                  ref: {_SHA}
+                """,
+            )
+
+    def test_rejects_single_segment_source_without_source_base(self, tmp_path: Path) -> None:
+        with pytest.raises(MarketplaceYmlError, match="must be one of"):
+            _load_config(
+                tmp_path,
+                None,
+                f"""
+                - name: tool
+                  source: tool
+                  ref: {_SHA}
+                """,
+            )
+
+
+class TestSourceBaseBuildComposition:
+    def test_composes_relative_source_onto_base_for_resolution_and_output(
+        self, tmp_path: Path
+    ) -> None:
+        config = _load_config(
+            tmp_path,
+            "https://gitlab.example.com/platform/marketplaces",
+            f"""
+            - name: tool
+              source: team/tool
+              ref: {_SHA}
+            """,
+        )
+        builder = MarketplaceBuilder.from_config(config, tmp_path, BuildOptions(offline=True))
+
+        resolved = builder._resolve_entry(config.packages[0])
+        assert resolved.source_repo == "platform/marketplaces/team/tool"
+        assert resolved.host == "gitlab.example.com"
+        parsed = urlparse(resolved.source_url or "")
+        assert parsed.scheme == "https"
+        assert parsed.hostname == "gitlab.example.com"
+        assert parsed.path == "/platform/marketplaces/team/tool"
+
+        doc = builder.compose_marketplace_json([resolved])
+        source = doc["plugins"][0]["source"]
+        assert source["source"] == "url"
+        parsed = urlparse(source["url"])
+        assert parsed.scheme == "https"
+        assert parsed.hostname == "gitlab.example.com"
+        assert parsed.path == "/platform/marketplaces/team/tool"
+
+    def test_host_prefixed_source_overrides_source_base(self, tmp_path: Path) -> None:
+        config = _load_config(
+            tmp_path,
+            "https://gitlab.example.com/platform/marketplaces",
+            f"""
+            - name: override
+              source: ghe.example.com/acme/tool
+              ref: {_SHA}
+            """,
+        )
+        builder = MarketplaceBuilder.from_config(config, tmp_path, BuildOptions(offline=True))
+
+        resolved = builder._resolve_entry(config.packages[0])
+        assert resolved.source_repo == "acme/tool"
+        assert resolved.host == "ghe.example.com"
+        assert resolved.source_url is None
+
+        doc = builder.compose_marketplace_json([resolved])
+        source = doc["plugins"][0]["source"]
+        assert source["source"] == "url"
+        parsed = urlparse(source["url"])
+        assert parsed.scheme == "https"
+        assert parsed.hostname == "ghe.example.com"
+        assert parsed.path == "/acme/tool"
+
+
+class TestSourceBaseEditor:
+    def test_add_plugin_entry_accepts_relative_source_when_source_base_is_set(
+        self, tmp_path: Path
+    ) -> None:
+        yml_path = _write(
+            tmp_path / "apm.yml",
+            _apm_yml(
+                "https://gitlab.example.com/platform/marketplaces",
+                f"""
+                - name: existing
+                  source: existing-tool
+                  ref: {_SHA}
+                """,
+            ),
+        )
+
+        name = add_plugin_entry(yml_path, source="new-tool", ref=_SHA)
+
+        assert name == "new-tool"
+        config = load_marketplace_config(tmp_path)
+        added = next(pkg for pkg in config.packages if pkg.name == "new-tool")
+        assert added.source == "new-tool"
+        assert added.host is None

--- a/tests/unit/marketplace/test_marketplace_source_base.py
+++ b/tests/unit/marketplace/test_marketplace_source_base.py
@@ -120,6 +120,32 @@ class TestSourceBaseSchema:
                 """,
             )
 
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "team.tools/owner/repo/extra",
+            "gitlab.example.com/owner/repo/extra",
+        ],
+    )
+    def test_rejects_relative_source_with_fqdn_first_segment_when_source_base_is_set(
+        self, tmp_path: Path, source: str
+    ) -> None:
+        # A value with a FQDN-like first segment that forms neither a valid
+        # owner/repo nor host/owner/repo override shape is rejected even with
+        # sourceBase set, rather than being silently composed onto the base:
+        # that disambiguation avoids a confused-deputy footgun
+        # (manifest-schema.md Section 7.5).
+        with pytest.raises(MarketplaceYmlError, match="must be one of"):
+            _load_config(
+                tmp_path,
+                "https://gitlab.example.com/platform/marketplaces",
+                f"""
+                - name: tool
+                  source: {source}
+                  ref: {_SHA}
+                """,
+            )
+
 
 class TestSourceBaseBuildComposition:
     def test_composes_relative_source_onto_base_for_resolution_and_output(

--- a/tests/unit/marketplace/test_marketplace_source_base.py
+++ b/tests/unit/marketplace/test_marketplace_source_base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import textwrap
 from pathlib import Path
+from types import SimpleNamespace
 from urllib.parse import urlparse
 
 import pytest
@@ -34,6 +35,17 @@ class _MockRefResolver:
 
     def close(self) -> None:
         pass
+
+
+class _RecordingAuthResolver:
+    """Record AuthResolver calls while returning a token-bearing context."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str | None]] = []
+
+    def resolve(self, host: str, org: str | None = None):
+        self.calls.append((host, org))
+        return SimpleNamespace(token="token", source="test-auth")
 
 
 def _write(path: Path, content: str) -> Path:
@@ -156,13 +168,27 @@ class TestSourceBaseSchema:
         # sourceBase set, rather than being silently composed onto the base:
         # that disambiguation avoids a confused-deputy footgun
         # (manifest-schema.md Section 7.5).
-        with pytest.raises(MarketplaceYmlError, match="must be one of"):
+        with pytest.raises(MarketplaceYmlError, match="host-prefixed source"):
             _load_config(
                 tmp_path,
                 "https://gitlab.example.com/platform/marketplaces",
                 f"""
                 - name: tool
                   source: {source}
+                  ref: {_SHA}
+                """,
+            )
+
+    def test_rejects_host_looking_relative_source_with_actionable_message(
+        self, tmp_path: Path
+    ) -> None:
+        with pytest.raises(MarketplaceYmlError, match="looks like a host-prefixed source"):
+            _load_config(
+                tmp_path,
+                "https://gitlab.example.com/platform/marketplaces",
+                f"""
+                - name: tool
+                  source: gitlab.example.com/team/tool/extra
                   ref: {_SHA}
                 """,
             )
@@ -249,7 +275,9 @@ class TestSourceBaseBuildComposition:
                 RemoteRef(name="refs/tags/v2.0.0", sha="d" * 40),
             ]
         }
-        builder._get_resolver_for_host = lambda _host: _MockRefResolver(refs)  # type: ignore[assignment]
+        builder._get_resolver_for_host = (  # type: ignore[assignment]
+            lambda _host, **_kwargs: _MockRefResolver(refs)
+        )
 
         resolved = builder._resolve_entry(config.packages[0])
         assert resolved.source_repo == composed_repo
@@ -322,6 +350,29 @@ class TestSourceBaseBuildComposition:
         parsed = urlparse(resolved.source_url or "")
         assert parsed.hostname == "gitlab.example.com"
         assert parsed.path == "/platform/marketplaces/team.tools/repo"
+
+    def test_source_base_resolution_uses_base_org_for_auth_context(self, tmp_path: Path) -> None:
+        config = _load_config(
+            tmp_path,
+            "https://github.com/contoso/marketplaces",
+            f"""
+            - name: tool
+              source: tool
+              ref: {_SHA}
+            """,
+        )
+        auth = _RecordingAuthResolver()
+        builder = MarketplaceBuilder.from_config(
+            config,
+            tmp_path,
+            BuildOptions(offline=False),
+            auth_resolver=auth,
+        )
+
+        resolved = builder._resolve_entry(config.packages[0])
+
+        assert resolved.source_repo == "contoso/marketplaces/tool"
+        assert auth.calls == [("github.com", "contoso")]
 
 
 class TestSourceBaseEditor:

--- a/tests/unit/marketplace/test_marketplace_source_base.py
+++ b/tests/unit/marketplace/test_marketplace_source_base.py
@@ -9,10 +9,31 @@ import pytest
 from apm_cli.marketplace.builder import BuildOptions, MarketplaceBuilder
 from apm_cli.marketplace.errors import MarketplaceYmlError
 from apm_cli.marketplace.migration import load_marketplace_config
+from apm_cli.marketplace.ref_resolver import RemoteRef
 from apm_cli.marketplace.yml_editor import add_plugin_entry
 from apm_cli.marketplace.yml_schema import MarketplaceConfig
 
 _SHA = "a" * 40
+
+
+class _MockRefResolver:
+    """In-process RefResolver stub keyed by composed ``owner/repo`` path.
+
+    The version-range branch of ``MarketplaceBuilder._resolve_entry`` calls
+    ``list_remote_refs(owner_repo)`` where ``owner_repo`` is the base-composed
+    coordinate (e.g. ``platform/marketplaces/team/tool``). Keying the stub on
+    that composed path proves the base composition reaches the resolver on the
+    ``version:`` branch, not just the explicit-``ref`` branch.
+    """
+
+    def __init__(self, refs_by_remote: dict[str, list[RemoteRef]]) -> None:
+        self._refs = refs_by_remote
+
+    def list_remote_refs(self, owner_repo: str) -> list[RemoteRef]:
+        return self._refs.get(owner_repo, [])
+
+    def close(self) -> None:
+        pass
 
 
 def _write(path: Path, content: str) -> Path:
@@ -202,6 +223,105 @@ class TestSourceBaseBuildComposition:
         assert parsed.scheme == "https"
         assert parsed.hostname == "ghe.example.com"
         assert parsed.path == "/acme/tool"
+
+    def test_composes_relative_source_onto_base_for_version_range_resolution(
+        self, tmp_path: Path
+    ) -> None:
+        # Lock the compose-onto-base behavior for the ``version:`` branch too.
+        # The explicit-``ref`` test exercises one branch of ``_resolve_entry``;
+        # ``_resolve_version_range`` threads the same source_host/source_url and
+        # must select a tag against the composed ``owner/repo`` coordinate.
+        config = _load_config(
+            tmp_path,
+            "https://gitlab.example.com/platform/marketplaces",
+            """
+            - name: tool
+              source: team/tool
+              version: "^1.0.0"
+            """,
+        )
+        builder = MarketplaceBuilder.from_config(config, tmp_path, BuildOptions(offline=True))
+        composed_repo = "platform/marketplaces/team/tool"
+        refs = {
+            composed_repo: [
+                RemoteRef(name="refs/tags/v1.0.0", sha="b" * 40),
+                RemoteRef(name="refs/tags/v1.2.0", sha="c" * 40),
+                RemoteRef(name="refs/tags/v2.0.0", sha="d" * 40),
+            ]
+        }
+        builder._get_resolver_for_host = lambda _host: _MockRefResolver(refs)  # type: ignore[assignment]
+
+        resolved = builder._resolve_entry(config.packages[0])
+        assert resolved.source_repo == composed_repo
+        assert resolved.host == "gitlab.example.com"
+        assert resolved.ref == "v1.2.0"
+        assert resolved.sha == "c" * 40
+        parsed = urlparse(resolved.source_url or "")
+        assert parsed.scheme == "https"
+        assert parsed.hostname == "gitlab.example.com"
+        assert parsed.path == "/platform/marketplaces/team/tool"
+
+        doc = builder.compose_marketplace_json([resolved])
+        source = doc["plugins"][0]["source"]
+        assert source["source"] == "url"
+        parsed = urlparse(source["url"])
+        assert parsed.hostname == "gitlab.example.com"
+        assert parsed.path == "/platform/marketplaces/team/tool"
+
+    def test_ado_shaped_source_base_composes_relative_repo(self, tmp_path: Path) -> None:
+        # Forward-compat guard for the #1010 / future-ADO reuse: an Azure DevOps
+        # base (``org/project/_git`` 3-part path, underscore-leading ``_git``
+        # segment) must validate and compose a relative repo onto it. ADO will
+        # REUSE sourceBase rather than add a separate ``host`` field, so the
+        # field shape must not be narrowed to reject this base.
+        config = _load_config(
+            tmp_path,
+            "https://dev.azure.com/contoso/platform/_git",
+            f"""
+            - name: ado-tool
+              source: agent-skills
+              ref: {_SHA}
+            """,
+        )
+        assert config.source_base == "https://dev.azure.com/contoso/platform/_git"
+        assert config.packages[0].source == "agent-skills"
+        assert config.packages[0].host is None
+
+        builder = MarketplaceBuilder.from_config(config, tmp_path, BuildOptions(offline=True))
+        resolved = builder._resolve_entry(config.packages[0])
+        assert resolved.source_repo == "contoso/platform/_git/agent-skills"
+        assert resolved.host == "dev.azure.com"
+        parsed = urlparse(resolved.source_url or "")
+        assert parsed.scheme == "https"
+        assert parsed.hostname == "dev.azure.com"
+        assert parsed.path == "/contoso/platform/_git/agent-skills"
+
+    def test_dotted_subgroup_relative_source_composes_onto_base(self, tmp_path: Path) -> None:
+        # A relative source whose owner segment legitimately contains a dot
+        # (e.g. a GitLab subgroup named ``team.tools``) is a valid two-segment
+        # ``owner/repo`` shape and MUST compose onto the base -- it is NOT a
+        # host-looking value the confused-deputy guard rejects. Locks the
+        # accepted behavior so future guard changes cannot silently start
+        # blocking valid dotted subgroup names.
+        config = _load_config(
+            tmp_path,
+            "https://gitlab.example.com/platform/marketplaces",
+            f"""
+            - name: dotted
+              source: team.tools/repo
+              ref: {_SHA}
+            """,
+        )
+        assert config.packages[0].source == "team.tools/repo"
+        assert config.packages[0].host is None
+
+        builder = MarketplaceBuilder.from_config(config, tmp_path, BuildOptions(offline=True))
+        resolved = builder._resolve_entry(config.packages[0])
+        assert resolved.source_repo == "platform/marketplaces/team.tools/repo"
+        assert resolved.host == "gitlab.example.com"
+        parsed = urlparse(resolved.source_url or "")
+        assert parsed.hostname == "gitlab.example.com"
+        assert parsed.path == "/platform/marketplaces/team.tools/repo"
 
 
 class TestSourceBaseEditor:


### PR DESCRIPTION
feat(marketplace): add sourceBase for package sources

## TL;DR

Adds a marketplace-level `sourceBase` field so marketplace authors can name package repositories relative to an enterprise git base path. Per-entry host-prefixed, full HTTPS URL, and local sources remain overrides, so this is additive when `sourceBase` is absent. This implements @leocamello's ratified Option A design and closes #1519.

Closes #1519

## Problem (WHY)

- Enterprise marketplace repos often sit under nested git paths; the issue's triage captured the need as "Self-hosted GitLab with subgroup nesting is the canonical enterprise pattern" (#1519).
- `sourceBase` is a source-routing input, so the issue required that "the security guards from #1288 ... must apply to `sourceBase` as strictly as they do to per-entry source values" (#1519).
- The intentional behavior change is scoped to manifests that opt in: "Bare `owner/repo` no longer silently routes to github.com when a base is declared" (#1519).

## Approach (WHAT)

| Area | Decision |
| --- | --- |
| Parse | Add optional `marketplace.sourceBase` with HTTPS/FQDN/path validation and context-aware `packages[].source` validation. |
| Compose | Resolve host-less remote package sources against the base at build time and carry the canonical URL into output mappers. |
| Override | Leave host-prefixed, full HTTPS URL, and `./` local sources independent from the base. |
| Compatibility | Keep absent-`sourceBase` manifests on the existing `owner/repo` -> default-host path. |
| Docs | Document the schema, authoring workflow, guide skill, and changelog entry. |

## Implementation (HOW)

| File | What changed |
| --- | --- |
| `src/apm_cli/marketplace/yml_schema.py` | Adds `SOURCE_BASE_RE`, `source_base` on `MarketplaceConfig`, strict `sourceBase` parsing, and context-aware package source validation. |
| `src/apm_cli/marketplace/yml_editor.py` | Mirrors loader validation for package edits and derives names from the final source segment so single-segment relative sources work. |
| `src/apm_cli/marketplace/builder.py` | Composes base-relative sources before ref resolution while preserving per-host resolver routing for overrides. |
| `src/apm_cli/marketplace/output_mappers.py` | Emits canonical HTTPS URLs for composed entries in Claude and Codex outputs without changing existing github shorthand output. |
| `tests/unit/marketplace/test_marketplace_source_base.py` | Covers composition, override precedence, inherited guard failures, and no-base compatibility. |
| Docs and changelog | Updates schema reference, marketplace publishing guide, packaged usage guide, and `[Unreleased]`. |

## Diagram

The diagram shows the new build-time routing decision. Only host-less remote entries compose onto `sourceBase`; overrides bypass it.

```mermaid
flowchart LR
    A["marketplace.sourceBase"] --> C["packages source"]
    C --> D{"local path"}
    D -->|"yes"| L["emit local source unchanged"]
    D -->|"no"| H{"host or HTTPS URL present"}
    H -->|"yes"| O["use per-entry override"]
    H -->|"no"| B{"base declared"}
    B -->|"yes"| N["compose base plus source"]
    B -->|"no"| G["preserve default-host owner/repo behavior"]
```

## Trade-offs

- Keeps Option B deferred: arbitrary-depth host-prefixed shorthand without a base remains out of scope, matching the board decision.
- Stores a canonical `source_url` only on resolved packages rather than changing the resolver contract; this keeps the resolver URL-driven.
- Requires explicit `github.com/owner/repo` inside a `sourceBase` marketplace when the package really lives on public GitHub; this is the intended confused-deputy fix.
- Keeps `sourceBase` out of generated marketplace JSON; consumers receive standard Claude/Codex source objects.

## Benefits

1. Marketplace authors can publish packages from nested GitLab or enterprise group paths without repeating the base on every entry.
2. Existing manifests without `sourceBase` retain their previous parse and output behavior.
3. Cross-host packages remain explicit through host-prefixed or full URL overrides.
4. The source-routing validation surface inherits the #1288 guard set and adds path-depth checks.

## Validation

### Scenario evidence

| Scenario | APM promise | Proof |
| --- | --- | --- |
| Relative package sources compose onto `sourceBase`. | Produce | `tests/unit/marketplace/test_marketplace_source_base.py::TestSourceBaseBuildComposition::test_composes_relative_source_onto_base_for_resolution_and_output` |
| Host-prefixed entries override the base. | Govern | `tests/unit/marketplace/test_marketplace_source_base.py::TestSourceBaseBuildComposition::test_host_prefixed_source_overrides_source_base` |
| Guard violations fail closed. | Govern | `tests/unit/marketplace/test_marketplace_source_base.py::TestSourceBaseSchema::test_rejects_source_base_security_guard_violations` |
| No-base manifests keep `owner/repo` behavior. | Consume | `tests/unit/marketplace/test_marketplace_source_base.py::TestSourceBaseSchema::test_absent_source_base_keeps_owner_repo_source_unchanged` |

<details><summary>Commands run</summary>

```text
uv run --extra dev pytest tests/unit/marketplace tests/unit/commands/test_marketplace_*.py tests/integration/test_yml_schema_validation.py tests/integration/test_yml_schema_phase3w5.py tests/integration/test_marketplace_builder_hermetic.py tests/integration/test_marketplace_builder_phase3w4.py -q --tb=short
2112 passed in 11.08s

uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/ && uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/ && bash scripts/lint-auth-signals.sh
All checks passed!
1238 files already formatted
pylint rated 10.00/10
[+] auth-signal lint clean

python3 guardrail script for YAML I/O, file length, and raw relative_to checks
guardrails clean

TMPDIR=$PWD/.copilot-pr/tmp npm_config_cache=$PWD/.copilot-pr/npm-cache npx --yes -p @mermaid-js/mermaid-cli mmdc ... --quiet
mermaid validation passed
```

</details>

## How to test

- [ ] Add `sourceBase: https://gitlab.example.com/group/marketplace` to a marketplace block.
- [ ] Add `packages[].source: tool-name` with a `ref` or `version`.
- [ ] Run `apm pack --dry-run --offline` against cached refs or a test repo and confirm the output source URL includes `/group/marketplace/tool-name`.
- [ ] Add `source: github.com/owner/repo` and confirm it emits as an override rather than under the base.
- [ ] Remove `sourceBase` and confirm bare `owner/repo` entries still parse as before.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
