### PR TITLE
fix(tests): fix Windows path comparison in TestHermesConfigPath

### DIFF
--- a/tests/unit/adapters/test_hermes_client_adapter.py
+++ b/tests/unit/adapters/test_hermes_client_adapter.py
@@ -122,15 +122,18 @@ class TestHermesConfigPath(unittest.TestCase):
 
     def test_default_config_path(self):
         adapter = HermesClientAdapter()
-        with patch.object(Path, "home", staticmethod(lambda: Path("/fake/home"))):
+        fake_home = Path("/fake/home")
+        with patch.object(Path, "home", staticmethod(lambda: fake_home)):
             path = Path(adapter.get_config_path())
-        self.assertEqual(path, Path("/fake/home/.hermes/config.yaml"))
+        expected = (fake_home / ".hermes" / "config.yaml").resolve(strict=False)
+        self.assertEqual(path, expected)
 
     def test_hermes_home_override(self):
         adapter = HermesClientAdapter()
         with patch.dict("os.environ", {"HERMES_HOME": "/custom/hermes"}):
             path = Path(adapter.get_config_path())
-        self.assertEqual(path, Path("/custom/hermes/config.yaml"))
+        expected = Path("/custom/hermes").expanduser().resolve(strict=False) / "config.yaml"
+        self.assertEqual(path, expected)
 
 
 class TestHermesUpdateConfig(unittest.TestCase):


### PR DESCRIPTION
## Description

Fix two unit tests in `TestHermesConfigPath` that fail on Windows because
`resolve(strict=False)` adds the current drive letter (e.g. `D:`) to paths
constructed from POSIX-style strings like `/fake/home`.

The production code in `resolve_hermes_root()` calls `.resolve(strict=False)`
on every path it returns. The tests were comparing the resolved output against
unresolved `Path("/fake/home/...")` literals. On Windows, these two paths differ:

- actual:   `WindowsPath('D:/fake/home/.hermes/config.yaml')`
- expected: `WindowsPath('/fake/home/.hermes/config.yaml')`

**Fix:** build the expected value with the same `.resolve(strict=False)` that
the production code applies, making the assertion platform-agnostic.

Fixes the `build-release.yml` Windows job failure introduced when
`resolve_hermes_root()` was added.

## Type of change

- [x] Bug fix

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [ ] Added tests for new functionality (if applicable)

## Spec conformance (OpenAPM v0.1)

- [x] N/A -- this PR does not change OpenAPM-observable behaviour.