### PR TITLE
feat(bootstrap): fold panel follow-ups for enterprise mirror mode (post-#1733)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and hosted `marketplace.json` URLs -- so teams can consume private,
   offline, or hosted catalogs without publishing a GitHub repo (closes
   #676). (#1739)
-- Enterprise bootstrap mirror mode adds `APM_RELEASE_METADATA_URL`, `APM_RELEASE_BASE_URL`, `APM_INSTALLER_BASE_URL`, `APM_PYPI_INDEX_URL`, and `APM_NO_DIRECT_FALLBACK` so `install.sh`, `install.ps1`, and `apm self-update` can use internal mirrors with fail-closed public fallback; closes #1680. (#1733)
+- Enterprise bootstrap mirror mode (`APM_RELEASE_METADATA_URL`, `APM_RELEASE_BASE_URL`, `APM_INSTALLER_BASE_URL`, `APM_PYPI_INDEX_URL`, `APM_NO_DIRECT_FALLBACK`) routes `install.sh`, `install.ps1`, and `apm self-update` through internal mirrors with fail-closed public fallback; closes #1680. (#1733)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and hosted `marketplace.json` URLs -- so teams can consume private,
   offline, or hosted catalogs without publishing a GitHub repo (closes
   #676). (#1739)
-- Enterprise bootstrap mirror mode lets `install.sh`, `install.ps1`, and `apm self-update` use `APM_RELEASE_METADATA_URL`, `APM_RELEASE_BASE_URL`, `APM_INSTALLER_BASE_URL`, `APM_PYPI_INDEX_URL`, and `APM_NO_DIRECT_FALLBACK` for internal release, installer, and PyPI mirrors with fail-closed public fallback, and closes #1680. (#1733)
+- Enterprise bootstrap mirror mode adds `APM_RELEASE_METADATA_URL`, `APM_RELEASE_BASE_URL`, `APM_INSTALLER_BASE_URL`, `APM_PYPI_INDEX_URL`, and `APM_NO_DIRECT_FALLBACK` so `install.sh`, `install.ps1`, and `apm self-update` can use internal mirrors with fail-closed public fallback; closes #1680. (#1733)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and hosted `marketplace.json` URLs -- so teams can consume private,
   offline, or hosted catalogs without publishing a GitHub repo (closes
   #676). (#1739)
-- Enterprise bootstrap mirror mode lets `install.sh`, `install.ps1`, and `apm self-update` use internal release, installer, and PyPI mirrors with fail-closed public fallback, and closes #1680. (#1733)
+- Enterprise bootstrap mirror mode lets `install.sh`, `install.ps1`, and `apm self-update` use `APM_RELEASE_METADATA_URL`, `APM_RELEASE_BASE_URL`, `APM_INSTALLER_BASE_URL`, `APM_PYPI_INDEX_URL`, and `APM_NO_DIRECT_FALLBACK` for internal release, installer, and PyPI mirrors with fail-closed public fallback, and closes #1680. (#1733)
 
 ### Fixed
 

--- a/docs/src/content/docs/getting-started/installation.md
+++ b/docs/src/content/docs/getting-started/installation.md
@@ -102,7 +102,7 @@ jobs:
 
 ### Enterprise bootstrap mirror mode
 
-Mirror mode lets locked-down workstations install and update APM without direct public egress:
+APM ships native enterprise mirror support: five env vars route bootstrap traffic through internal hosts, with fail-closed mode ensuring no public fallback.
 
 ```bash
 export APM_INSTALLER_BASE_URL="https://artifactory.mycorp.example/generic/apm-install"
@@ -144,7 +144,7 @@ apm-releases/
 
 #### What fail-closed does and does not cover
 
-Fail-closed scoping keys off the public `github.com` default. The guard only blocks egress when the resolved host would be public GitHub (`github.com` / `api.github.com`), `aka.ms`, or public PyPI. It does **not** suppress egress to a custom `GITHUB_URL`: if you set a GHES host (for example `GITHUB_URL=https://github.corp.com`) together with `APM_NO_DIRECT_FALLBACK=1` and no release mirror, the installer still reaches that GHES host. This is intentional coexistence with GHES, but "no direct fallback" should not be read as "zero egress" -- it means "no fallback to public hosts". For true zero-egress, set the `APM_RELEASE_METADATA_URL` / `APM_RELEASE_BASE_URL` / `APM_INSTALLER_BASE_URL` / `APM_PYPI_INDEX_URL` mirrors so every request resolves to your internal hosts. The GitHub token is attached only when the request targets the canonical GitHub / configured GHES host; it is never sent to a mirror host.
+Fail-closed scoping keys off the public `github.com` default. The guard only blocks egress when the resolved host would be public GitHub (`github.com` / `api.github.com`), `aka.ms`, or public PyPI. It does **not** suppress egress to a custom `GITHUB_URL`: if you set a GHES host (for example `GITHUB_URL=https://github.corp.com`) together with `APM_NO_DIRECT_FALLBACK=1` and no release mirror, the installer still reaches that GHES host. This is intentional coexistence with GHES, but "no direct fallback" should not be read as "zero egress" -- it means "no fallback to public hosts". For true zero-egress, set the `APM_RELEASE_METADATA_URL` / `APM_RELEASE_BASE_URL` / `APM_INSTALLER_BASE_URL` / `APM_PYPI_INDEX_URL` mirrors so every request resolves to your internal hosts. When `APM_RELEASE_METADATA_URL` is unset, GHES metadata requests intentionally use the resolved GitHub token for that host; mirror metadata requests never receive it. The GitHub token is attached only when the request targets the canonical GitHub / configured GHES host, never a mirror host.
 
 Homebrew and Scoop mirror support is docs-only in this v0: mirror the tap or bucket with your package manager's normal enterprise controls, but the APM env vars above do not rewrite Homebrew or Scoop internals.
 
@@ -187,13 +187,17 @@ chmod +x .apm-mirror-smoke/bin/curl .apm-mirror-smoke/bin/pip .apm-mirror-smoke/
 python3 -m http.server 8765 --directory .apm-mirror-smoke/mirror > .apm-mirror-smoke/server.log 2>&1 &
 server_pid=$!
 trap 'kill "$server_pid" 2>/dev/null || true' EXIT
+set +e
 PATH="$PWD/.apm-mirror-smoke/bin:$PATH" \
   APM_INSTALLER_BASE_URL="http://127.0.0.1:8765/apm-install" \
   APM_RELEASE_METADATA_URL="http://127.0.0.1:8765/apm-releases/latest.json" \
   APM_RELEASE_BASE_URL="http://127.0.0.1:8765/apm-releases" \
   APM_PYPI_INDEX_URL="http://127.0.0.1:8765/pypi/simple" \
   APM_NO_DIRECT_FALLBACK=1 \
-  sh .apm-mirror-smoke/mirror/apm-install/install.sh || test $? -eq 1
+  sh .apm-mirror-smoke/mirror/apm-install/install.sh
+status=$?
+set -e
+test "$status" -ne 0
 ```
 
 For `apm self-update`, run `apm self-update --check` with the same env vars and verify your proxy, firewall, or CI egress logs show only the mirror host. Use a disposable runner for a full `apm self-update` because it executes the mirrored installer.

--- a/docs/src/content/docs/getting-started/installation.md
+++ b/docs/src/content/docs/getting-started/installation.md
@@ -198,6 +198,7 @@ PATH="$PWD/.apm-mirror-smoke/bin:$PATH" \
 status=$?
 set -e
 test "$status" -ne 0
+# Success: installer failed closed with an actionable error, as expected.
 ```
 
 For `apm self-update`, run `apm self-update --check` with the same env vars and verify your proxy, firewall, or CI egress logs show only the mirror host. Use a disposable runner for a full `apm self-update` because it executes the mirrored installer.

--- a/docs/src/content/docs/getting-started/installation.md
+++ b/docs/src/content/docs/getting-started/installation.md
@@ -102,7 +102,7 @@ jobs:
 
 ### Enterprise bootstrap mirror mode
 
-APM ships native enterprise mirror support: five env vars route bootstrap traffic through internal hosts, with fail-closed mode ensuring no public fallback.
+Mirror mode routes bootstrap traffic through internal hosts. Four URL variables point install and self-update at your mirror; `APM_NO_DIRECT_FALLBACK=1` fails closed so no request reaches a public host:
 
 ```bash
 export APM_INSTALLER_BASE_URL="https://artifactory.mycorp.example/generic/apm-install"

--- a/docs/src/content/docs/reference/cli/self-update.md
+++ b/docs/src/content/docs/reference/cli/self-update.md
@@ -35,7 +35,7 @@ Some package-manager distributions (for example, Homebrew) disable self-update a
 
 ## Enterprise bootstrap mirrors
 
-`apm self-update` uses the same mirror contract as the installer scripts. The canonical bootstrap mirror table lives in [installation](../../../getting-started/installation/#enterprise-bootstrap-mirror-mode); this command-specific table shows the same knobs alongside legacy update settings:
+`apm self-update` uses the same mirror contract as the installer scripts. See the [installation bootstrap mirror section](../../../getting-started/installation/#enterprise-bootstrap-mirror-mode) for the canonical setup; this command-specific table shows the same knobs alongside legacy update settings:
 
 | Variable | Default | Effect |
 |----------|---------|--------|

--- a/docs/src/content/docs/reference/cli/self-update.md
+++ b/docs/src/content/docs/reference/cli/self-update.md
@@ -41,7 +41,7 @@ Some package-manager distributions (for example, Homebrew) disable self-update a
 |----------|---------|--------|
 | `APM_RELEASE_METADATA_URL` | _(unset)_ | Exact URL for mirrored release metadata, usually a static `latest.json` with at least `{"tag_name":"vX.Y.Z"}`. Overrides GitHub release metadata lookup. |
 | `APM_INSTALLER_BASE_URL` | _(unset)_ | Base URL containing `install.sh` and `install.ps1`. `apm self-update` downloads the platform script from this base. |
-| `APM_RELEASE_BASE_URL` | _(unset)_ | Base URL containing release assets at `{base}/{tag}/{asset}`. The downloaded installer subprocess inherits this value. |
+| `APM_RELEASE_BASE_URL` | _(unset)_ | Base URL containing release assets at `{base}/{tag}/{asset}`. Used when self-update runs the installer to fetch binary archives. |
 | `APM_PYPI_INDEX_URL` | _(unset)_ | PyPI-compatible index used by installer pip fallback. |
 | `APM_NO_DIRECT_FALLBACK` | _(unset)_ | Set to `1` to fail closed instead of using public GitHub, `aka.ms`, or PyPI fallback. |
 | `GITHUB_URL` | `https://github.com` | Legacy GitHub/GHES base URL. Still supported when mirror env vars are not set. |
@@ -61,9 +61,7 @@ apm self-update --check
 apm self-update
 ```
 
-With `APM_NO_DIRECT_FALLBACK=1`, missing or unreachable mirror settings are hard failures with a non-zero exit. APM does not fall back to public GitHub, `aka.ms`, or PyPI in that mode.
-
-Fail-closed scoping keys off the public `github.com` default: it blocks fallback to public hosts, not all egress. A custom `GITHUB_URL` (a GHES host) combined with `APM_NO_DIRECT_FALLBACK=1` and no release mirror still egresses to that GHES host -- this is intentional GHES coexistence. For zero public egress set the `APM_RELEASE_METADATA_URL` / `APM_RELEASE_BASE_URL` / `APM_INSTALLER_BASE_URL` / `APM_PYPI_INDEX_URL` mirrors. The GitHub token is sent only to the canonical GitHub / configured GHES host, never to a mirror host.
+With `APM_NO_DIRECT_FALLBACK=1`, missing or unreachable mirror settings are hard failures with a non-zero exit. For the full fail-closed scope, GHES token boundary, and no-egress smoke recipe, see [Enterprise bootstrap mirror mode](../../../getting-started/installation/#enterprise-bootstrap-mirror-mode).
 
 ## Options
 

--- a/docs/src/content/docs/reference/cli/self-update.md
+++ b/docs/src/content/docs/reference/cli/self-update.md
@@ -35,7 +35,7 @@ Some package-manager distributions (for example, Homebrew) disable self-update a
 
 ## Enterprise bootstrap mirrors
 
-`apm self-update` uses the same mirror contract as the installer scripts. These variables are additive to the older `GITHUB_URL` / `APM_REPO` / `VERSION` flow:
+`apm self-update` uses the same mirror contract as the installer scripts. The canonical bootstrap mirror table lives in [installation](../../../getting-started/installation/#enterprise-bootstrap-mirror-mode); this command-specific table shows the same knobs alongside legacy update settings:
 
 | Variable | Default | Effect |
 |----------|---------|--------|

--- a/install.ps1
+++ b/install.ps1
@@ -479,6 +479,7 @@ if ($pinnedVersion) {
         exit 1
     }
     $latestUri = Get-ReleaseMetadataUri
+    # Mirror metadata URLs must never receive GitHub/GHES credentials.
     $headers = if ($releaseMetadataUrl) { @{} } else { Get-AuthHeader }
     $metadataError = $null
     try {

--- a/install.ps1
+++ b/install.ps1
@@ -479,9 +479,10 @@ if ($pinnedVersion) {
         exit 1
     }
     $latestUri = Get-ReleaseMetadataUri
+    $headers = if ($releaseMetadataUrl) { @{} } else { Get-AuthHeader }
     $metadataError = $null
     try {
-        $release = Invoke-RestMethod -Uri $latestUri
+        $release = Invoke-GitHubJson -Uri $latestUri -Headers $headers
     } catch {
         $metadataError = $_
     }

--- a/install.sh
+++ b/install.sh
@@ -101,6 +101,7 @@ is_public_github_url() {
 }
 
 fail_closed_error() {
+    # $1 is a literal env var name from this script, not user input.
     printf '%b\n' "${RED}Error: APM_NO_DIRECT_FALLBACK is set, but $1 is not configured.${NC}"
     shift
     printf '%s\n' "$*"

--- a/install.sh
+++ b/install.sh
@@ -97,7 +97,15 @@ is_truthy() {
 }
 
 is_public_github_url() {
-    [ "${GITHUB_URL%/}" = "https://github.com" ]
+    [ "${GITHUB_URL:-https://github.com}" = "https://github.com" ] || [ "${GITHUB_URL%/}" = "https://github.com" ]
+}
+
+fail_closed_error() {
+    _mirror_var="$1"
+    shift
+    echo -e "${RED}Error: APM_NO_DIRECT_FALLBACK is set, but $_mirror_var is not configured.${NC}"
+    echo "$*"
+    exit 1
 }
 
 join_url_path() {
@@ -190,9 +198,7 @@ try_pip_installation() {
         PIP_INSTALL_OK=0
         $PIP_CMD install --user --index-url "$APM_PYPI_INDEX_URL" apm-cli || PIP_INSTALL_OK=$?
     elif is_truthy "$APM_NO_DIRECT_FALLBACK"; then
-        echo -e "${RED}Error: APM_NO_DIRECT_FALLBACK is set, but APM_PYPI_INDEX_URL is not configured.${NC}"
-        echo "Set APM_PYPI_INDEX_URL to your internal PyPI proxy before using pip fallback."
-        return 1
+        fail_closed_error APM_PYPI_INDEX_URL "Set APM_PYPI_INDEX_URL to your internal PyPI proxy before using pip fallback."
     else
         PIP_INSTALL_OK=0
         $PIP_CMD install --user apm-cli || PIP_INSTALL_OK=$?
@@ -297,9 +303,7 @@ fi
 if [ -n "$VERSION" ]; then
     TAG_NAME="$VERSION"
     if is_truthy "$APM_NO_DIRECT_FALLBACK" && [ -z "$APM_RELEASE_BASE_URL" ] && is_public_github_url; then
-        echo -e "${RED}Error: APM_NO_DIRECT_FALLBACK is set, but APM_RELEASE_BASE_URL is not configured.${NC}"
-        echo "Set APM_RELEASE_BASE_URL to a mirror containing $TAG_NAME/$DOWNLOAD_BINARY."
-        exit 1
+        fail_closed_error APM_RELEASE_BASE_URL "Set APM_RELEASE_BASE_URL to a mirror containing $TAG_NAME/$DOWNLOAD_BINARY."
     fi
     DOWNLOAD_URL=$(release_asset_url "$TAG_NAME" "$DOWNLOAD_BINARY")
     echo -e "${GREEN}Version: $TAG_NAME${NC}"
@@ -311,9 +315,7 @@ if [ -z "$TAG_NAME" ]; then
 echo -e "${YELLOW}Fetching latest release information...${NC}"
 
 if is_truthy "$APM_NO_DIRECT_FALLBACK" && [ -z "$APM_RELEASE_METADATA_URL" ] && is_public_github_url; then
-    echo -e "${RED}Error: APM_NO_DIRECT_FALLBACK is set, but APM_RELEASE_METADATA_URL is not configured.${NC}"
-    echo "Set APM_RELEASE_METADATA_URL to mirrored latest.json, or set VERSION to a pinned release."
-    exit 1
+    fail_closed_error APM_RELEASE_METADATA_URL "Set APM_RELEASE_METADATA_URL to mirrored latest.json, or set VERSION to a pinned release."
 fi
 
 LATEST_RELEASE_URL=$(release_metadata_url)
@@ -397,9 +399,7 @@ fi
 # Use grep -o to extract just the matching portion (handles single-line JSON)
 TAG_NAME=$(echo "$LATEST_RELEASE" | grep -o '"tag_name": *"[^"]*"' | awk -F'"' '{print $4}')
 if is_truthy "$APM_NO_DIRECT_FALLBACK" && [ -z "$APM_RELEASE_BASE_URL" ] && is_public_github_url; then
-    echo -e "${RED}Error: APM_NO_DIRECT_FALLBACK is set, but APM_RELEASE_BASE_URL is not configured.${NC}"
-    echo "Set APM_RELEASE_BASE_URL to a mirror containing $TAG_NAME/$DOWNLOAD_BINARY."
-    exit 1
+    fail_closed_error APM_RELEASE_BASE_URL "Set APM_RELEASE_BASE_URL to a mirror containing $TAG_NAME/$DOWNLOAD_BINARY."
 fi
 DOWNLOAD_URL=$(release_asset_url "$TAG_NAME" "$DOWNLOAD_BINARY")
 

--- a/install.sh
+++ b/install.sh
@@ -101,10 +101,9 @@ is_public_github_url() {
 }
 
 fail_closed_error() {
-    _mirror_var="$1"
+    printf '%b\n' "${RED}Error: APM_NO_DIRECT_FALLBACK is set, but $1 is not configured.${NC}"
     shift
-    echo -e "${RED}Error: APM_NO_DIRECT_FALLBACK is set, but $_mirror_var is not configured.${NC}"
-    echo "$*"
+    printf '%s\n' "$*"
     exit 1
 }
 

--- a/packages/apm-guide/.apm/skills/apm-usage/installation.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/installation.md
@@ -69,7 +69,7 @@ irm https://aka.ms/apm-windows | iex
 
 ## Enterprise bootstrap mirrors
 
-Set `APM_INSTALLER_BASE_URL`, `APM_RELEASE_METADATA_URL`, `APM_RELEASE_BASE_URL`, `APM_PYPI_INDEX_URL`, and `APM_NO_DIRECT_FALLBACK=1` to install and update APM through an internal mirror while failing closed on public fallback. The canonical variable table, GHES scoping note, and no-egress smoke recipe live in [installation.md](https://github.com/microsoft/apm/blob/main/docs/src/content/docs/getting-started/installation.md#enterprise-bootstrap-mirror-mode).
+Set `APM_INSTALLER_BASE_URL`, `APM_RELEASE_METADATA_URL`, `APM_RELEASE_BASE_URL`, `APM_PYPI_INDEX_URL`, and `APM_NO_DIRECT_FALLBACK=1` to install and update APM through an internal mirror while failing closed on public fallback. For verification, run the installer and `apm self-update --check` behind an egress proxy or wrappers that deny public GitHub, `aka.ms`, PyPI, Homebrew, and Scoop; only your mirror host should appear. The canonical variable table, GHES scoping note, and full no-egress smoke recipe live in [installation.md](https://github.com/microsoft/apm/blob/main/docs/src/content/docs/getting-started/installation.md#enterprise-bootstrap-mirror-mode).
 
 ```bash
 export APM_INSTALLER_BASE_URL="https://artifactory.mycorp.example/generic/apm-install"

--- a/packages/apm-guide/.apm/skills/apm-usage/installation.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/installation.md
@@ -69,15 +69,7 @@ irm https://aka.ms/apm-windows | iex
 
 ## Enterprise bootstrap mirrors
 
-Use these env vars to install and update APM through an internal mirror and fail closed when a public fallback would be required:
-
-| Variable | Purpose |
-|----------|---------|
-| `APM_INSTALLER_BASE_URL` | Base URL containing `install.sh` and `install.ps1`. |
-| `APM_RELEASE_METADATA_URL` | Exact URL for mirrored `latest.json` release metadata. |
-| `APM_RELEASE_BASE_URL` | Base URL for release assets at `{base}/{tag}/{asset}`. |
-| `APM_PYPI_INDEX_URL` | PyPI proxy used by installer pip fallback. |
-| `APM_NO_DIRECT_FALLBACK` | Set to `1` to block public GitHub, `aka.ms`, and PyPI fallback. |
+Set `APM_INSTALLER_BASE_URL`, `APM_RELEASE_METADATA_URL`, `APM_RELEASE_BASE_URL`, `APM_PYPI_INDEX_URL`, and `APM_NO_DIRECT_FALLBACK=1` to install and update APM through an internal mirror while failing closed on public fallback. The canonical variable table, GHES scoping note, and no-egress smoke recipe live in [installation.md](https://github.com/microsoft/apm/blob/main/docs/src/content/docs/getting-started/installation.md#enterprise-bootstrap-mirror-mode).
 
 ```bash
 export APM_INSTALLER_BASE_URL="https://artifactory.mycorp.example/generic/apm-install"
@@ -90,10 +82,6 @@ apm self-update --check
 ```
 
 For dependency installs after bootstrap, keep using `PROXY_REGISTRY_URL` and `PROXY_REGISTRY_ONLY=1`. Homebrew and Scoop mirroring is package-manager documentation only in v0; these env vars do not rewrite Homebrew or Scoop internals.
-
-Fail-closed scoping keys off the public `github.com` default: it blocks fallback to public hosts, not all egress. A custom `GITHUB_URL` (GHES host) plus `APM_NO_DIRECT_FALLBACK=1` and no release mirror still reaches that GHES host. Set the four mirror URLs for zero public egress. The GitHub token is attached only to the canonical GitHub / configured GHES host, never to a mirror host (symmetric across `install.sh` and `install.ps1`).
-
-No-egress smoke test: run the installer on a disposable runner with `curl` and `pip` wrappers (or an egress proxy) that deny `github.com`, `api.github.com`, `aka.ms`, `pypi.org`, `pythonhosted.org`, Homebrew, and Scoop upstreams. Wrapping `pip` keeps the proof honest about the PyPI fallback path. With all mirror env vars set, the only allowed outbound host should be your mirror. Run `apm self-update --check` under the same env vars and confirm proxy logs show only the mirror host.
 
 ## Troubleshooting
 

--- a/packages/apm-guide/.apm/skills/apm-usage/installation.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/installation.md
@@ -69,7 +69,7 @@ irm https://aka.ms/apm-windows | iex
 
 ## Enterprise bootstrap mirrors
 
-Set `APM_INSTALLER_BASE_URL`, `APM_RELEASE_METADATA_URL`, `APM_RELEASE_BASE_URL`, `APM_PYPI_INDEX_URL`, and `APM_NO_DIRECT_FALLBACK=1` to install and update APM through an internal mirror while failing closed on public fallback. For verification, run the installer and `apm self-update --check` behind an egress proxy or wrappers that deny public GitHub, `aka.ms`, PyPI, Homebrew, and Scoop; only your mirror host should appear. The canonical variable table, GHES scoping note, and full no-egress smoke recipe live in [installation.md](https://github.com/microsoft/apm/blob/main/docs/src/content/docs/getting-started/installation.md#enterprise-bootstrap-mirror-mode).
+Set `APM_INSTALLER_BASE_URL`, `APM_RELEASE_METADATA_URL`, `APM_RELEASE_BASE_URL`, `APM_PYPI_INDEX_URL`, and `APM_NO_DIRECT_FALLBACK=1` to install and update APM through an internal mirror while failing closed on public fallback. For verification, run the installer and `apm self-update --check` behind an egress proxy or wrappers that deny public GitHub, `aka.ms`, PyPI, Homebrew, and Scoop; only your mirror host should appear. The canonical setup, GHES scoping note, and full no-egress smoke recipe live in the [installation bootstrap mirror section](https://github.com/microsoft/apm/blob/main/docs/src/content/docs/getting-started/installation.md#enterprise-bootstrap-mirror-mode).
 
 ```bash
 export APM_INSTALLER_BASE_URL="https://artifactory.mycorp.example/generic/apm-install"

--- a/src/apm_cli/bootstrap_mirror.py
+++ b/src/apm_cli/bootstrap_mirror.py
@@ -9,7 +9,7 @@ APM_RELEASE_METADATA_URL = "APM_RELEASE_METADATA_URL"
 APM_INSTALLER_BASE_URL = "APM_INSTALLER_BASE_URL"
 APM_PYPI_INDEX_URL = "APM_PYPI_INDEX_URL"
 APM_NO_DIRECT_FALLBACK = "APM_NO_DIRECT_FALLBACK"
-VERSION_ENV_VAR = "VERSION"
+_VERSION_ENV_VAR = "VERSION"
 
 _PUBLIC_GITHUB_URL = "https://github.com"
 _TRUE_VALUES = {"1", "true", "yes", "on"}
@@ -80,7 +80,7 @@ def release_metadata_public_lookup_blocked(github_url: str | None = None) -> boo
         no_direct_fallback_enabled()
         and is_public_github_url(github_url)
         and get_release_metadata_url() is None
-        and not os.environ.get(VERSION_ENV_VAR, "").strip()
+        and not os.environ.get(_VERSION_ENV_VAR, "").strip()
     )
 
 

--- a/src/apm_cli/bootstrap_mirror.py
+++ b/src/apm_cli/bootstrap_mirror.py
@@ -2,12 +2,14 @@
 
 import os
 
+from apm_cli.utils.path_security import PathTraversalError, validate_path_segments
+
 APM_RELEASE_BASE_URL = "APM_RELEASE_BASE_URL"
 APM_RELEASE_METADATA_URL = "APM_RELEASE_METADATA_URL"
 APM_INSTALLER_BASE_URL = "APM_INSTALLER_BASE_URL"
 APM_PYPI_INDEX_URL = "APM_PYPI_INDEX_URL"
 APM_NO_DIRECT_FALLBACK = "APM_NO_DIRECT_FALLBACK"
-VERSION = "VERSION"
+VERSION_ENV_VAR = "VERSION"
 
 _PUBLIC_GITHUB_URL = "https://github.com"
 _TRUE_VALUES = {"1", "true", "yes", "on"}
@@ -30,8 +32,18 @@ def no_direct_fallback_enabled() -> bool:
 
 
 def append_url_path(base_url: str, *parts: str) -> str:
-    """Join a base URL and path parts without introducing double slashes."""
-    cleaned = [part.strip("/") for part in parts if part]
+    """Join a base URL and path parts without unsafe dot segments."""
+    cleaned: list[str] = []
+    for part in parts:
+        if not part:
+            continue
+        segment = part.strip("/")
+        try:
+            validate_path_segments(segment, context="URL path part")
+        except PathTraversalError as exc:
+            raise ValueError("URL path parts must not contain dot segments") from exc
+        if segment:
+            cleaned.append(segment)
     if not cleaned:
         return base_url.rstrip("/")
     return "/".join([base_url.rstrip("/"), *cleaned])
@@ -68,7 +80,7 @@ def release_metadata_public_lookup_blocked(github_url: str | None = None) -> boo
         no_direct_fallback_enabled()
         and is_public_github_url(github_url)
         and get_release_metadata_url() is None
-        and not os.environ.get(VERSION, "").strip()
+        and not os.environ.get(VERSION_ENV_VAR, "").strip()
     )
 
 

--- a/src/apm_cli/commands/self_update.py
+++ b/src/apm_cli/commands/self_update.py
@@ -79,7 +79,7 @@ def _get_manual_update_command() -> str:
             try:
                 installer_url = _get_update_installer_url()
             except RuntimeError:
-                return "Set APM_INSTALLER_BASE_URL to your mirror base URL, then re-run 'apm self-update'."
+                return "Set APM_INSTALLER_BASE_URL=<mirror> and re-run: apm self-update"
         return f"powershell -ExecutionPolicy Bypass -c 'irm \"{installer_url}\" | iex'"
 
     if get_installer_base_url() is not None:
@@ -88,9 +88,7 @@ def _get_manual_update_command() -> str:
         try:
             installer_url = _get_update_installer_url()
         except RuntimeError:
-            return (
-                "Set APM_INSTALLER_BASE_URL to your mirror base URL, then re-run 'apm self-update'."
-            )
+            return "Set APM_INSTALLER_BASE_URL=<mirror> and re-run: apm self-update"
     return f'curl -sSL "{installer_url}" | sh'
 
 
@@ -119,11 +117,11 @@ def _get_installer_run_command(script_path: str) -> list[str]:
     help=(
         "Update the APM CLI binary itself to the latest version.\n\n"
         "Set these to route updates through an internal mirror (optional):\n"
-        "  APM_RELEASE_METADATA_URL  Mirror latest.json release metadata.\n"
-        "  APM_RELEASE_BASE_URL      Mirror release assets at {base}/{tag}/{asset}.\n"
-        "  APM_INSTALLER_BASE_URL    Mirror install.sh/install.ps1 for self-update.\n"
-        "  APM_PYPI_INDEX_URL        PyPI mirror for installer pip fallback.\n"
-        "  APM_NO_DIRECT_FALLBACK    Set to 1 to fail closed on public fallback.\n"
+        "  APM_RELEASE_METADATA_URL  latest.json mirror URL.\n"
+        "  APM_RELEASE_BASE_URL      release asset mirror base URL.\n"
+        "  APM_INSTALLER_BASE_URL    install.sh/install.ps1 mirror base URL.\n"
+        "  APM_PYPI_INDEX_URL        PyPI mirror for installer fallback.\n"
+        "  APM_NO_DIRECT_FALLBACK    1 means fail closed on public fallback.\n"
     ),
 )
 @click.option("--check", is_flag=True, help="Only check for updates without installing")

--- a/src/apm_cli/commands/self_update.py
+++ b/src/apm_cli/commands/self_update.py
@@ -79,7 +79,7 @@ def _get_manual_update_command() -> str:
             try:
                 installer_url = _get_update_installer_url()
             except RuntimeError:
-                return "Set APM_INSTALLER_BASE_URL and re-run 'apm self-update'."
+                return "Set APM_INSTALLER_BASE_URL to your mirror base URL, then re-run 'apm self-update'."
         return f"powershell -ExecutionPolicy Bypass -c 'irm \"{installer_url}\" | iex'"
 
     if get_installer_base_url() is not None:
@@ -88,7 +88,9 @@ def _get_manual_update_command() -> str:
         try:
             installer_url = _get_update_installer_url()
         except RuntimeError:
-            return "Set APM_INSTALLER_BASE_URL and re-run 'apm self-update'."
+            return (
+                "Set APM_INSTALLER_BASE_URL to your mirror base URL, then re-run 'apm self-update'."
+            )
     return f'curl -sSL "{installer_url}" | sh'
 
 

--- a/src/apm_cli/commands/self_update.py
+++ b/src/apm_cli/commands/self_update.py
@@ -71,7 +71,7 @@ def _get_update_installer_suffix() -> str:
 
 
 def _get_manual_update_command() -> str:
-    """Return the manual update command for the current platform."""
+    """Return the manual update action for the current platform."""
     if _is_windows_platform():
         if get_installer_base_url() is not None:
             installer_url = "$env:APM_INSTALLER_BASE_URL/install.ps1"
@@ -79,7 +79,7 @@ def _get_manual_update_command() -> str:
             try:
                 installer_url = _get_update_installer_url()
             except RuntimeError:
-                installer_url = "$env:APM_INSTALLER_BASE_URL/install.ps1"
+                return "Set APM_INSTALLER_BASE_URL and re-run 'apm self-update'."
         return f"powershell -ExecutionPolicy Bypass -c 'irm \"{installer_url}\" | iex'"
 
     if get_installer_base_url() is not None:
@@ -88,7 +88,7 @@ def _get_manual_update_command() -> str:
         try:
             installer_url = _get_update_installer_url()
         except RuntimeError:
-            installer_url = "$APM_INSTALLER_BASE_URL/install.sh"
+            return "Set APM_INSTALLER_BASE_URL and re-run 'apm self-update'."
     return f'curl -sSL "{installer_url}" | sh'
 
 
@@ -112,7 +112,18 @@ def _get_installer_run_command(script_path: str) -> list[str]:
     return [shell_path, script_path]
 
 
-@click.command(name="self-update", help="Update the APM CLI binary itself to the latest version")
+@click.command(
+    name="self-update",
+    help=(
+        "Update the APM CLI binary itself to the latest version.\n\n"
+        "Environment variables for enterprise bootstrap mirrors:\n"
+        "  APM_RELEASE_METADATA_URL  Mirror latest.json release metadata.\n"
+        "  APM_RELEASE_BASE_URL      Mirror release assets at {base}/{tag}/{asset}.\n"
+        "  APM_INSTALLER_BASE_URL    Mirror install.sh/install.ps1 for self-update.\n"
+        "  APM_PYPI_INDEX_URL        PyPI mirror for installer pip fallback.\n"
+        "  APM_NO_DIRECT_FALLBACK    Set to 1 to fail closed on public fallback.\n"
+    ),
+)
 @click.option("--check", is_flag=True, help="Only check for updates without installing")
 def self_update(check):
     """Update APM CLI to the latest version (like npm update -g npm).
@@ -174,7 +185,7 @@ def self_update(check):
                 )
             else:
                 logger.error("Unable to fetch latest version from remote")
-                logger.progress("Please check your internet connection or try again later")
+                logger.info("Check your internet connection or try again later.")
             sys.exit(1)
 
         from ..utils.version_checker import is_newer_version
@@ -259,12 +270,12 @@ def self_update(check):
 
         except ImportError:
             logger.error("'requests' library not available")
-            logger.progress("Please update manually using:")
+            logger.info("Update manually using:")
             click.echo(f"  {_get_manual_update_command()}")
             sys.exit(1)
         except Exception as e:
             logger.error(f"Update failed: {e}")
-            logger.progress("Please update manually using:")
+            logger.info("Update manually using:")
             click.echo(f"  {_get_manual_update_command()}")
             sys.exit(1)
 

--- a/src/apm_cli/commands/self_update.py
+++ b/src/apm_cli/commands/self_update.py
@@ -116,7 +116,7 @@ def _get_installer_run_command(script_path: str) -> list[str]:
     name="self-update",
     help=(
         "Update the APM CLI binary itself to the latest version.\n\n"
-        "Environment variables for enterprise bootstrap mirrors:\n"
+        "Set these to route updates through an internal mirror (optional):\n"
         "  APM_RELEASE_METADATA_URL  Mirror latest.json release metadata.\n"
         "  APM_RELEASE_BASE_URL      Mirror release assets at {base}/{tag}/{asset}.\n"
         "  APM_INSTALLER_BASE_URL    Mirror install.sh/install.ps1 for self-update.\n"

--- a/src/apm_cli/core/auth.py
+++ b/src/apm_cli/core/auth.py
@@ -231,6 +231,11 @@ class AuthResolver:
         the logger before it knows it needs an AuthResolver elsewhere."""
         self._logger = logger
 
+    def clear_cache(self) -> None:
+        """Clear resolved auth contexts when a caller needs fresh env state."""
+        with self._lock:
+            self._cache.clear()
+
     # -- host classification ------------------------------------------------
 
     @staticmethod

--- a/src/apm_cli/core/auth.py
+++ b/src/apm_cli/core/auth.py
@@ -203,8 +203,11 @@ class AuthResolver:
         self,
         token_manager: GitHubTokenManager | None = None,
         logger: object | None = None,
+        *,
+        allow_external_fallback: bool = True,
     ):
         self._token_manager = token_manager or GitHubTokenManager()
+        self._allow_external_fallback = allow_external_fallback
         self._cache: dict[AuthCacheKey, AuthContext] = {}
         self._lock = threading.Lock()
         # F2/F3 #852: optional logger lets the install command route the
@@ -940,6 +943,9 @@ class AuthResolver:
         if token:
             source = self._identify_env_source(purpose)
             return token, source, "basic"
+
+        if not self._allow_external_fallback:
+            return None, "none", "basic"
 
         # 3. gh CLI active account (eligibility gated inside the call;
         #    unsupported hosts return None instantly without a subprocess)

--- a/src/apm_cli/utils/version_checker.py
+++ b/src/apm_cli/utils/version_checker.py
@@ -15,6 +15,7 @@ from ..core.auth import AuthResolver
 _DEFAULT_REPO = "microsoft/apm"
 _PUBLIC_GITHUB_URL = "https://github.com"
 _PUBLIC_API_BASE = "https://api.github.com"
+_VERSION_CHECK_AUTH_RESOLVER: AuthResolver | None = None
 
 
 def _get_air_gap_github_url() -> str:
@@ -50,6 +51,22 @@ def _build_releases_api_url(
     return f"{github_url}/api/v3/repos/{repo}/releases/latest"
 
 
+def _get_version_check_auth_resolver() -> AuthResolver:
+    """Return the reusable resolver for non-blocking version checks."""
+    global _VERSION_CHECK_AUTH_RESOLVER
+    if _VERSION_CHECK_AUTH_RESOLVER is None:
+        _VERSION_CHECK_AUTH_RESOLVER = AuthResolver(allow_external_fallback=False)
+    else:
+        _VERSION_CHECK_AUTH_RESOLVER.clear_cache()
+    return _VERSION_CHECK_AUTH_RESOLVER
+
+
+def _reset_version_check_auth_resolver_for_tests() -> None:
+    """Reset the cached version-check resolver for isolated unit tests."""
+    global _VERSION_CHECK_AUTH_RESOLVER
+    _VERSION_CHECK_AUTH_RESOLVER = None
+
+
 def _get_github_token(github_url: str | None = None, repo: str | None = None) -> str | None:
     """Return a GitHub token through AuthResolver, or None.
 
@@ -61,7 +78,7 @@ def _get_github_token(github_url: str | None = None, repo: str | None = None) ->
     host = parsed.hostname or "github.com"
     effective_repo = repo or _get_air_gap_repo()
     org = effective_repo.split("/", 1)[0] if "/" in effective_repo else None
-    context = AuthResolver(allow_external_fallback=False).resolve(host, org=org)
+    context = _get_version_check_auth_resolver().resolve(host, org=org)
     return context.token
 
 

--- a/src/apm_cli/utils/version_checker.py
+++ b/src/apm_cli/utils/version_checker.py
@@ -4,11 +4,13 @@ import os
 import re
 import sys
 from pathlib import Path
+from urllib.parse import urlparse
 
 from ..bootstrap_mirror import (
     get_release_metadata_url,
     release_metadata_public_lookup_blocked,
 )
+from ..core.auth import AuthResolver
 
 _DEFAULT_REPO = "microsoft/apm"
 _PUBLIC_GITHUB_URL = "https://github.com"
@@ -31,7 +33,9 @@ def _get_air_gap_version() -> str | None:
     return v if v else None
 
 
-def _build_releases_api_url(github_url: str, repo: str) -> str:
+def _build_releases_api_url(
+    github_url: str, repo: str, release_metadata_url: str | None = None
+) -> str:
     """Build the release metadata URL for the given host and repository.
 
     ``APM_RELEASE_METADATA_URL`` wins when configured so enterprise mirrors can
@@ -39,7 +43,6 @@ def _build_releases_api_url(github_url: str, repo: str) -> str:
     public GitHub, targets api.github.com directly. For GitHub Enterprise Server
     (any other GITHUB_URL value), uses the /api/v3 prefix on the configured host.
     """
-    release_metadata_url = get_release_metadata_url()
     if release_metadata_url is not None:
         return release_metadata_url
     if github_url == _PUBLIC_GITHUB_URL:
@@ -47,20 +50,19 @@ def _build_releases_api_url(github_url: str, repo: str) -> str:
     return f"{github_url}/api/v3/repos/{repo}/releases/latest"
 
 
-def _get_github_token() -> str | None:
-    """Return a GitHub token following canonical precedence, or None.
+def _get_github_token(github_url: str | None = None, repo: str | None = None) -> str | None:
+    """Return a GitHub token through AuthResolver, or None.
 
-    Precedence mirrors TOKEN_PRECEDENCE["modules"] in core/token_manager.py:
-      GITHUB_APM_PAT -> GITHUB_TOKEN -> GH_TOKEN
-
-    The token value is never logged or included in any output.
+    Version checks only need environment-scoped tokens. Disabling external
+    fallback avoids invoking gh or git credential helpers from the non-blocking
+    startup update check while keeping the token precedence centralized.
     """
-    return (
-        os.environ.get("GITHUB_APM_PAT")
-        or os.environ.get("GITHUB_TOKEN")
-        or os.environ.get("GH_TOKEN")
-        or None
-    )
+    parsed = urlparse(github_url or _get_air_gap_github_url())
+    host = parsed.hostname or "github.com"
+    effective_repo = repo or _get_air_gap_repo()
+    org = effective_repo.split("/", 1)[0] if "/" in effective_repo else None
+    context = AuthResolver(allow_external_fallback=False).resolve(host, org=org)
+    return context.token
 
 
 def get_latest_version_from_github(repo: str | None = None, timeout: int = 2) -> str | None:
@@ -110,14 +112,13 @@ def get_latest_version_from_github(repo: str | None = None, timeout: int = 2) ->
     try:
         effective_repo = _get_air_gap_repo() if repo is None else repo
         github_url = _get_air_gap_github_url()
+        release_metadata_url = get_release_metadata_url()
         if release_metadata_public_lookup_blocked(github_url):
             return None
-        url = _build_releases_api_url(github_url, effective_repo)
-        token = _get_github_token()
+        url = _build_releases_api_url(github_url, effective_repo, release_metadata_url)
+        token = _get_github_token(github_url, effective_repo)
         headers = (
-            {"Authorization": f"token {token}"}
-            if token and get_release_metadata_url() is None
-            else {}
+            {"Authorization": f"token {token}"} if token and release_metadata_url is None else {}
         )
         response = requests.get(url, headers=headers, timeout=timeout)
 

--- a/src/apm_cli/utils/version_checker.py
+++ b/src/apm_cli/utils/version_checker.py
@@ -3,6 +3,7 @@
 import os
 import re
 import sys
+import threading
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -16,6 +17,7 @@ _DEFAULT_REPO = "microsoft/apm"
 _PUBLIC_GITHUB_URL = "https://github.com"
 _PUBLIC_API_BASE = "https://api.github.com"
 _VERSION_CHECK_AUTH_RESOLVER: AuthResolver | None = None
+_VERSION_CHECK_AUTH_RESOLVER_LOCK = threading.RLock()
 
 
 def _get_air_gap_github_url() -> str:
@@ -54,17 +56,17 @@ def _build_releases_api_url(
 def _get_version_check_auth_resolver() -> AuthResolver:
     """Return the reusable resolver for non-blocking version checks."""
     global _VERSION_CHECK_AUTH_RESOLVER
-    if _VERSION_CHECK_AUTH_RESOLVER is None:
-        _VERSION_CHECK_AUTH_RESOLVER = AuthResolver(allow_external_fallback=False)
-    else:
-        _VERSION_CHECK_AUTH_RESOLVER.clear_cache()
-    return _VERSION_CHECK_AUTH_RESOLVER
+    with _VERSION_CHECK_AUTH_RESOLVER_LOCK:
+        if _VERSION_CHECK_AUTH_RESOLVER is None:
+            _VERSION_CHECK_AUTH_RESOLVER = AuthResolver(allow_external_fallback=False)
+        return _VERSION_CHECK_AUTH_RESOLVER
 
 
 def _reset_version_check_auth_resolver_for_tests() -> None:
     """Reset the cached version-check resolver for isolated unit tests."""
     global _VERSION_CHECK_AUTH_RESOLVER
-    _VERSION_CHECK_AUTH_RESOLVER = None
+    with _VERSION_CHECK_AUTH_RESOLVER_LOCK:
+        _VERSION_CHECK_AUTH_RESOLVER = None
 
 
 def _get_github_token(github_url: str | None = None, repo: str | None = None) -> str | None:
@@ -78,7 +80,12 @@ def _get_github_token(github_url: str | None = None, repo: str | None = None) ->
     host = parsed.hostname or "github.com"
     effective_repo = repo or _get_air_gap_repo()
     org = effective_repo.split("/", 1)[0] if "/" in effective_repo else None
-    context = _get_version_check_auth_resolver().resolve(host, org=org)
+    with _VERSION_CHECK_AUTH_RESOLVER_LOCK:
+        resolver = _get_version_check_auth_resolver()
+        # Version checks run in env-sensitive startup/test paths; reuse the
+        # resolver object but refresh contexts so token env changes are visible.
+        resolver.clear_cache()
+        context = resolver.resolve(host, org=org)
     return context.token
 
 

--- a/tests/unit/commands/test_self_update_air_gapped.py
+++ b/tests/unit/commands/test_self_update_air_gapped.py
@@ -201,10 +201,7 @@ class TestInstallerUrlAirGap:
             ):
                 command = update_module._get_manual_update_command()
 
-        assert (
-            command
-            == "Set APM_INSTALLER_BASE_URL to your mirror base URL, then re-run 'apm self-update'."
-        )
+        assert command == "Set APM_INSTALLER_BASE_URL=<mirror> and re-run: apm self-update"
         assert "APM_INSTALLER_BASE_URL/" not in command
 
     def test_manual_command_no_direct_fallback_unix_uses_env_reference(self) -> None:
@@ -218,10 +215,7 @@ class TestInstallerUrlAirGap:
             ):
                 command = update_module._get_manual_update_command()
 
-        assert (
-            command
-            == "Set APM_INSTALLER_BASE_URL to your mirror base URL, then re-run 'apm self-update'."
-        )
+        assert command == "Set APM_INSTALLER_BASE_URL=<mirror> and re-run: apm self-update"
 
     def test_manual_command_no_direct_fallback_windows_uses_env_reference(self) -> None:
         """Fail-closed manual Windows guidance should reference the mirror env var."""
@@ -234,10 +228,7 @@ class TestInstallerUrlAirGap:
             ):
                 command = update_module._get_manual_update_command()
 
-        assert (
-            command
-            == "Set APM_INSTALLER_BASE_URL to your mirror base URL, then re-run 'apm self-update'."
-        )
+        assert command == "Set APM_INSTALLER_BASE_URL=<mirror> and re-run: apm self-update"
 
     def test_manual_command_mirror_base_does_not_print_credentials(self) -> None:
         """Manual guidance should not echo credentials embedded in mirror URLs."""

--- a/tests/unit/commands/test_self_update_air_gapped.py
+++ b/tests/unit/commands/test_self_update_air_gapped.py
@@ -188,6 +188,22 @@ class TestInstallerUrlAirGap:
         assert parsed.hostname == "mirror.corp.example"
         assert parsed.path == "/apm-install/install.ps1"
 
+    def test_manual_command_no_direct_fallback_without_base_gives_action_not_pseudo_url(
+        self,
+    ) -> None:
+        """Fail-closed manual guidance should tell users to set the mirror base."""
+        env = self._clean_env()
+        env["APM_NO_DIRECT_FALLBACK"] = "1"
+        with patch.dict("os.environ", env, clear=True):
+            with patch(
+                "apm_cli.commands.self_update._is_windows_platform",
+                return_value=False,
+            ):
+                command = update_module._get_manual_update_command()
+
+        assert command == "Set APM_INSTALLER_BASE_URL and re-run 'apm self-update'."
+        assert "APM_INSTALLER_BASE_URL/" not in command
+
     def test_manual_command_no_direct_fallback_unix_uses_env_reference(self) -> None:
         """Fail-closed manual Unix guidance should reference the mirror env var."""
         env = self._clean_env()
@@ -199,7 +215,7 @@ class TestInstallerUrlAirGap:
             ):
                 command = update_module._get_manual_update_command()
 
-        assert command == 'curl -sSL "$APM_INSTALLER_BASE_URL/install.sh" | sh'
+        assert command == "Set APM_INSTALLER_BASE_URL and re-run 'apm self-update'."
 
     def test_manual_command_no_direct_fallback_windows_uses_env_reference(self) -> None:
         """Fail-closed manual Windows guidance should reference the mirror env var."""
@@ -212,10 +228,7 @@ class TestInstallerUrlAirGap:
             ):
                 command = update_module._get_manual_update_command()
 
-        assert command == (
-            "powershell -ExecutionPolicy Bypass -c "
-            "'irm \"$env:APM_INSTALLER_BASE_URL/install.ps1\" | iex'"
-        )
+        assert command == "Set APM_INSTALLER_BASE_URL and re-run 'apm self-update'."
 
     def test_manual_command_mirror_base_does_not_print_credentials(self) -> None:
         """Manual guidance should not echo credentials embedded in mirror URLs."""
@@ -259,6 +272,20 @@ class TestEnterpriseBootstrapSelfUpdate:
             "APM_TEMP_DIR",
         }
         return {k: v for k, v in os.environ.items() if k not in mirrored_vars}
+
+    def test_self_update_help_lists_enterprise_mirror_env_vars(self) -> None:
+        """Users can discover enterprise mirror env vars from self-update help."""
+        result = self.runner.invoke(cli, ["self-update", "--help"])
+
+        assert result.exit_code == 0
+        for name in (
+            "APM_RELEASE_BASE_URL",
+            "APM_RELEASE_METADATA_URL",
+            "APM_INSTALLER_BASE_URL",
+            "APM_PYPI_INDEX_URL",
+            "APM_NO_DIRECT_FALLBACK",
+        ):
+            assert name in result.output
 
     def test_no_direct_fallback_blocks_public_metadata_lookup(self) -> None:
         """APM_NO_DIRECT_FALLBACK refuses public latest-release lookup without a mirror."""

--- a/tests/unit/commands/test_self_update_air_gapped.py
+++ b/tests/unit/commands/test_self_update_air_gapped.py
@@ -201,7 +201,10 @@ class TestInstallerUrlAirGap:
             ):
                 command = update_module._get_manual_update_command()
 
-        assert command == "Set APM_INSTALLER_BASE_URL and re-run 'apm self-update'."
+        assert (
+            command
+            == "Set APM_INSTALLER_BASE_URL to your mirror base URL, then re-run 'apm self-update'."
+        )
         assert "APM_INSTALLER_BASE_URL/" not in command
 
     def test_manual_command_no_direct_fallback_unix_uses_env_reference(self) -> None:
@@ -215,7 +218,10 @@ class TestInstallerUrlAirGap:
             ):
                 command = update_module._get_manual_update_command()
 
-        assert command == "Set APM_INSTALLER_BASE_URL and re-run 'apm self-update'."
+        assert (
+            command
+            == "Set APM_INSTALLER_BASE_URL to your mirror base URL, then re-run 'apm self-update'."
+        )
 
     def test_manual_command_no_direct_fallback_windows_uses_env_reference(self) -> None:
         """Fail-closed manual Windows guidance should reference the mirror env var."""
@@ -228,7 +234,10 @@ class TestInstallerUrlAirGap:
             ):
                 command = update_module._get_manual_update_command()
 
-        assert command == "Set APM_INSTALLER_BASE_URL and re-run 'apm self-update'."
+        assert (
+            command
+            == "Set APM_INSTALLER_BASE_URL to your mirror base URL, then re-run 'apm self-update'."
+        )
 
     def test_manual_command_mirror_base_does_not_print_credentials(self) -> None:
         """Manual guidance should not echo credentials embedded in mirror URLs."""

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -228,13 +228,36 @@ class TestResolve:
             assert ctx.source == "GITHUB_APM_PAT"
 
     def test_no_token_returns_none(self):
-        """No tokens at all → token is None."""
+        """No tokens at all -> token is None."""
         with patch.dict(os.environ, {}, clear=True):
             with patch.object(GitHubTokenManager, "resolve_credential_from_git", return_value=None):
                 resolver = AuthResolver()
                 ctx = resolver.resolve("github.com")
                 assert ctx.token is None
                 assert ctx.source == "none"
+
+    def test_allow_external_fallback_false_skips_gh_cli_and_git_credentials(self):
+        """Disabled external fallback never probes gh CLI or git credentials."""
+        with patch.dict(os.environ, {}, clear=True):
+            with (
+                patch.object(
+                    GitHubTokenManager,
+                    "resolve_credential_from_gh_cli",
+                    side_effect=AssertionError("gh cli should not be probed"),
+                ) as mock_gh_cli,
+                patch.object(
+                    GitHubTokenManager,
+                    "resolve_credential_from_git",
+                    side_effect=AssertionError("git credentials should not be probed"),
+                ) as mock_git,
+            ):
+                resolver = AuthResolver(allow_external_fallback=False)
+                ctx = resolver.resolve("github.com", org="microsoft")
+
+        assert ctx.token is None
+        assert ctx.source == "none"
+        mock_gh_cli.assert_not_called()
+        mock_git.assert_not_called()
 
     def test_caching(self):
         """Second call returns cached result."""

--- a/tests/unit/test_bootstrap_mirror.py
+++ b/tests/unit/test_bootstrap_mirror.py
@@ -1,0 +1,38 @@
+"""Unit tests for enterprise bootstrap mirror helper functions."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from apm_cli.bootstrap_mirror import append_url_path, get_env_url
+
+
+def test_get_env_url_strips_quotes_whitespace_and_trailing_slash() -> None:
+    """Mirror URL env values are normalized before callers use them."""
+    with patch.dict(os.environ, {"APM_TEST_URL": "  'https://mirror.corp.example/path/'  "}):
+        assert get_env_url("APM_TEST_URL") == "https://mirror.corp.example/path"
+
+
+@pytest.mark.parametrize("value", ["", "   "])
+def test_get_env_url_returns_none_for_empty_values(value: str) -> None:
+    """Unset or blank mirror URL env values are treated as absent."""
+    with patch.dict(os.environ, {"APM_TEST_URL": value}):
+        assert get_env_url("APM_TEST_URL") is None
+
+
+def test_append_url_path_joins_base_and_strips_slashes() -> None:
+    """URL path joining avoids duplicate slashes across base and parts."""
+    assert (
+        append_url_path("https://mirror.corp.example/root/", "/v1.2.3/", "asset.zip")
+        == "https://mirror.corp.example/root/v1.2.3/asset.zip"
+    )
+
+
+@pytest.mark.parametrize("part", [".", "..", "nested/../asset.zip", "./asset.zip"])
+def test_append_url_path_rejects_dot_segments(part: str) -> None:
+    """Mirror URL path parts reject dot segments before joining."""
+    with pytest.raises(ValueError, match="dot segments"):
+        append_url_path("https://mirror.corp.example/root", part)

--- a/tests/unit/test_enterprise_bootstrap_installers.py
+++ b/tests/unit/test_enterprise_bootstrap_installers.py
@@ -158,3 +158,22 @@ def test_unix_installer_fail_closed_asset_exit_code() -> None:
     combined = result.stdout + result.stderr
     assert "APM_NO_DIRECT_FALLBACK is set" in combined
     assert "APM_RELEASE_BASE_URL is not configured" in combined
+
+
+def test_windows_installer_uses_auth_on_first_ghes_metadata_fetch() -> None:
+    """install.ps1 should not make an unauthenticated GHES metadata request first."""
+    text = _read_repo_file("install.ps1")
+
+    assert "$headers = if ($releaseMetadataUrl) { @{} } else { Get-AuthHeader }" in text
+    assert "$release = Invoke-GitHubJson -Uri $latestUri -Headers $headers" in text
+    assert "$release = Invoke-RestMethod -Uri $latestUri" not in text
+
+
+def test_unix_installer_centralizes_fail_closed_error_style() -> None:
+    """install.sh fail-closed guards should share one actionable error helper."""
+    text = _read_repo_file("install.sh")
+
+    assert "fail_closed_error()" in text
+    assert text.count("fail_closed_error APM_RELEASE_BASE_URL") == 2
+    assert text.count("fail_closed_error APM_RELEASE_METADATA_URL") == 1
+    assert text.count("fail_closed_error APM_PYPI_INDEX_URL") == 1

--- a/tests/unit/test_version_checker.py
+++ b/tests/unit/test_version_checker.py
@@ -249,7 +249,7 @@ class TestGitHubTokenResolution(unittest.TestCase):
         self.assertEqual(_get_github_token(), "resolver_token")
 
         mock_resolver_cls.assert_called_once_with(allow_external_fallback=False)
-        mock_resolver.clear_cache.assert_called_once()
+        self.assertEqual(mock_resolver.clear_cache.call_count, 2)
         self.assertEqual(mock_resolver.resolve.call_count, 2)
 
 

--- a/tests/unit/test_version_checker.py
+++ b/tests/unit/test_version_checker.py
@@ -201,6 +201,32 @@ class TestGitHubTokenResolution(unittest.TestCase):
         token = _get_github_token()
         self.assertEqual(token, "gh_value")
 
+    @patch.dict("os.environ", {}, clear=True)
+    @patch("apm_cli.core.token_manager.GitHubTokenManager.resolve_credential_from_git")
+    @patch("apm_cli.core.token_manager.GitHubTokenManager.resolve_credential_from_gh_cli")
+    def test_version_check_token_resolution_does_not_probe_external_helpers(
+        self, mock_gh_cli, mock_git
+    ):
+        """Version checks use AuthResolver without gh/git credential probing."""
+        mock_gh_cli.side_effect = AssertionError("gh cli should not be probed")
+        mock_git.side_effect = AssertionError("git credentials should not be probed")
+
+        self.assertIsNone(_get_github_token())
+        mock_gh_cli.assert_not_called()
+        mock_git.assert_not_called()
+
+    @patch.dict("os.environ", {"GITHUB_TOKEN": "resolver_token"}, clear=True)
+    @patch("apm_cli.utils.version_checker.AuthResolver")
+    def test_version_check_token_resolution_uses_auth_resolver(self, mock_resolver_cls):
+        """Version checks resolve GitHub tokens through AuthResolver."""
+        mock_context = Mock(token="resolver_token")
+        mock_resolver = Mock()
+        mock_resolver.resolve.return_value = mock_context
+        mock_resolver_cls.return_value = mock_resolver
+
+        self.assertEqual(_get_github_token(), "resolver_token")
+        mock_resolver.resolve.assert_called_once()
+
 
 class TestGitHubVersionFetchAuth(unittest.TestCase):
     """Test that get_latest_version_from_github sends auth headers correctly."""

--- a/tests/unit/test_version_checker.py
+++ b/tests/unit/test_version_checker.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock, patch
 
 from apm_cli.utils.version_checker import (
     _get_github_token,
+    _reset_version_check_auth_resolver_for_tests,
     check_for_updates,
     get_latest_version_from_github,
     is_newer_version,
@@ -170,6 +171,14 @@ class TestGitHubVersionFetch(unittest.TestCase):
 class TestGitHubTokenResolution(unittest.TestCase):
     """Test GitHub token resolution helper."""
 
+    def setUp(self):
+        """Reset the version-check resolver cache between env-sensitive tests."""
+        _reset_version_check_auth_resolver_for_tests()
+
+    def tearDown(self):
+        """Drop any patched resolver before the next test runs."""
+        _reset_version_check_auth_resolver_for_tests()
+
     @patch.dict("os.environ", {}, clear=True)
     def test_no_token_when_env_empty(self):
         """Returns None when no token env vars are set."""
@@ -226,6 +235,22 @@ class TestGitHubTokenResolution(unittest.TestCase):
 
         self.assertEqual(_get_github_token(), "resolver_token")
         mock_resolver.resolve.assert_called_once()
+
+    @patch.dict("os.environ", {"GITHUB_TOKEN": "resolver_token"}, clear=True)
+    @patch("apm_cli.utils.version_checker.AuthResolver")
+    def test_version_check_token_resolution_reuses_resolver(self, mock_resolver_cls):
+        """Version checks reuse one AuthResolver without stale cache reads."""
+        mock_context = Mock(token="resolver_token")
+        mock_resolver = Mock()
+        mock_resolver.resolve.return_value = mock_context
+        mock_resolver_cls.return_value = mock_resolver
+
+        self.assertEqual(_get_github_token(), "resolver_token")
+        self.assertEqual(_get_github_token(), "resolver_token")
+
+        mock_resolver_cls.assert_called_once_with(allow_external_fallback=False)
+        mock_resolver.clear_cache.assert_called_once()
+        self.assertEqual(mock_resolver.resolve.call_count, 2)
 
 
 class TestGitHubVersionFetchAuth(unittest.TestCase):


### PR DESCRIPTION
## Summary

This PR salvages the apm-review-panel follow-ups for #1680 that were folded after #1733 had already been squash-merged by a human. The merge landed at head 0251f0f9, while the fold pass continued on the old branch through a69632fe; this fresh branch reapplies only that follow-up delta on current main.

## Salvaged follow-ups

1. Dedicated `bootstrap_mirror` unit tests.
2. Dot-segment URL path validation.
3. Self-update help epilog for enterprise mirror environment variables.
4. Manual fail-closed guidance.
5. `install.sh` fail-closed helper consistency.
6. `install.ps1` first GHES metadata auth.
7. AuthResolver-backed version-check tokens.
8. Documentation dedupe plus GHES token note.
9. CHANGELOG environment-variable keywords.

## Scope fence

- Keeps #1680 v0 environment variable names locked.
- Keeps Homebrew and Scoop to docs-only guidance.
- Does not add `apm doctor network`.
- Preserves fail-closed behavior: actionable errors, non-zero exits, and no public fallback when direct fallback is disabled.

## Validation

- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/`
- `bash scripts/lint-auth-signals.sh`
- `uv run --extra dev pytest tests/unit/test_bootstrap_mirror.py tests/unit/test_version_checker.py tests/unit/test_enterprise_bootstrap_installers.py tests/unit/commands/test_self_update_air_gapped.py -q`
- Portable local equivalents of the YAML I/O, file-length, and raw `str(path.relative_to(...))` CI guards.
