### PR TITLE
fix(install): keep copilot in multi-target --target lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `apm install --target` with a comma-separated list containing `copilot` (or the `vscode`/`agents` aliases) no longer silently drops the Copilot target; closes #1746.
+- `apm install --target` with a comma-separated list containing `copilot` (or the `vscode`/`agents` aliases) no longer silently drops the Copilot target. (by @Addono, closes #1746, #1749)
 - `apm install` now resolves relative `path:` deps declared by remote monorepo packages when they stay inside the same remote repo, while still rejecting absolute, escaping, or cross-repo paths; closes #1571. (#1732)
 - Dependencies with the same path on different git hosts no longer collide in `apm.lock.yaml`; `apm install` keeps GitHub/GitLab PATs off generic-host file downloads, routes bespoke GitLab hosts through `type: gitlab`, and surfaces non-404 download failures with host and endpoint context. Reading private files from a generic non-default host now requires a whole-repo git dependency or explicit backend signal; see the dependency and lockfile docs (closes #773). (#1735)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm install --target` with a comma-separated list containing `copilot` (or the `vscode`/`agents` aliases) no longer silently drops the Copilot target; closes #1746.
 - `apm install` now resolves relative `path:` deps declared by remote monorepo packages when they stay inside the same remote repo, while still rejecting absolute, escaping, or cross-repo paths; closes #1571. (#1732)
 - Dependencies with the same path on different git hosts no longer collide in `apm.lock.yaml`; `apm install` keeps GitHub/GitLab PATs off generic-host file downloads, routes bespoke GitLab hosts through `type: gitlab`, and surfaces non-404 download failures with host and endpoint context. Reading private files from a generic non-default host now requires a whole-repo git dependency or explicit backend signal; see the dependency and lockfile docs (closes #773). (#1735)
 

--- a/src/apm_cli/install/phases/targets.py
+++ b/src/apm_cli/install/phases/targets.py
@@ -68,7 +68,7 @@ def _as_yaml_targets(value: str | list[str] | None) -> list[str] | None:
 
 
 def _normalize_runtime_target_aliases(tokens: Iterable[str]) -> list[str]:
-    """Map runtime target aliases to canonical target names and dedupe them."""
+    """Map runtime aliases to canonical target names in first-seen order."""
     from apm_cli.integration.targets import RUNTIME_TO_CANONICAL_TARGET
 
     normalized: list[str] = []
@@ -375,6 +375,7 @@ def _resolve_targets_by_scope(
             parts = [t.strip() for t in raw_override.split(",") if t.strip()]
         else:
             parts = list(raw_override)
+        # Multi-token CLI parsing returns runtime aliases; convert them before filtering.
         parts = _normalize_runtime_target_aliases(parts)
         parts = [p for p in parts if p in _CANONICAL]
         if len(parts) == 1:

--- a/src/apm_cli/install/phases/targets.py
+++ b/src/apm_cli/install/phases/targets.py
@@ -67,6 +67,24 @@ def _as_yaml_targets(value: str | list[str] | None) -> list[str] | None:
     return parts or None
 
 
+def _normalize_runtime_target_aliases(tokens: Iterable[str]) -> list[str]:
+    """Map runtime target aliases to canonical target names and dedupe them."""
+    from apm_cli.integration.targets import RUNTIME_TO_CANONICAL_TARGET
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for token in tokens:
+        raw = str(token).strip()
+        if not raw:
+            continue
+        canonical = RUNTIME_TO_CANONICAL_TARGET.get(raw, raw)
+        if canonical in seen:
+            continue
+        seen.add(canonical)
+        normalized.append(canonical)
+    return normalized
+
+
 def _read_yaml_targets(ctx) -> list[str] | None:
     """Read targets/target from raw apm.yml using v2 parser.
 
@@ -357,6 +375,7 @@ def _resolve_targets_by_scope(
             parts = [t.strip() for t in raw_override.split(",") if t.strip()]
         else:
             parts = list(raw_override)
+        parts = _normalize_runtime_target_aliases(parts)
         parts = [p for p in parts if p in _CANONICAL]
         if len(parts) == 1:
             _v2_flag = parts[0]
@@ -551,9 +570,10 @@ def run_targets_phase(ctx) -> None:
         if isinstance(ctx.target_override, str):
             # Handle CSV form
             parts = [t.strip() for t in ctx.target_override.split(",") if t.strip()]
-            flag = parts if len(parts) > 1 else parts[0] if parts else None
         else:
-            flag = ctx.target_override
+            parts = list(ctx.target_override)
+        parts = _normalize_runtime_target_aliases(parts)
+        flag = parts if len(parts) > 1 else parts[0] if parts else None
 
     # Get yaml_targets from apm_package.
     try:

--- a/tests/unit/install/phases/test_targets_phase_v2.py
+++ b/tests/unit/install/phases/test_targets_phase_v2.py
@@ -108,7 +108,13 @@ def test_run_targets_phase_normalizes_vscode_alias(
 
 
 def test_cli_parse_claude_copilot_installs_both_targets(tmp_path: Path) -> None:
-    """The exact CLI parse result for --target claude,copilot keeps copilot."""
+    """Regression trap for #1746: --target claude,copilot resolves both targets.
+
+    parse_target_field intentionally returns the runtime alias spelling for
+    multi-token input ("copilot" -> "vscode"); the targets phase must then
+    normalize that alias back to the canonical "copilot" profile instead of
+    silently dropping it.
+    """
     from apm_cli.core.target_detection import parse_target_field
     from apm_cli.install.phases.targets import run
 
@@ -119,7 +125,9 @@ def test_cli_parse_claude_copilot_installs_both_targets(tmp_path: Path) -> None:
     ctx = _make_ctx(project, target_override=parsed)
     run(ctx)
 
+    # Multi-token parsing yields the runtime alias, not the canonical name.
     assert parsed == ["claude", "vscode"]
+    # The phase normalizes the alias so the copilot profile is preserved.
     assert _target_names(ctx) == ["claude", "copilot"]
     assert (project / ".claude").is_dir()
     assert (project / ".github").is_dir()

--- a/tests/unit/install/phases/test_targets_phase_v2.py
+++ b/tests/unit/install/phases/test_targets_phase_v2.py
@@ -30,7 +30,7 @@ from apm_cli.core.scope import InstallScope
 def _make_ctx(
     project_root: Path,
     *,
-    target_override: str | None = None,
+    target_override: str | list[str] | None = None,
     yaml_target: str | None = None,
     yaml_targets: list[str] | None = None,
 ) -> MagicMock:
@@ -46,7 +46,13 @@ def _make_ctx(
     ctx.logger = MagicMock()
     ctx.targets = []
     ctx.integrators = {}
+    ctx.legacy_skill_paths = False
     return ctx
+
+
+def _target_names(ctx: MagicMock) -> list[str]:
+    """Return the resolved target profile names from a phase context."""
+    return [target.name for target in ctx.targets]
 
 
 def _target_root_dirs(ctx, project_root: Path) -> list[Path]:
@@ -66,6 +72,89 @@ def _target_root_dirs(ctx, project_root: Path) -> list[Path]:
         if root_dir:
             out.append(project_root / root_dir)
     return out
+
+
+def test_runtime_alias_list_preserves_copilot_profile_and_dirs(tmp_path: Path) -> None:
+    """Multi-target runtime aliases resolve through the copilot profile."""
+    from apm_cli.install.phases.targets import run
+
+    project = tmp_path / "project"
+    project.mkdir()
+
+    ctx = _make_ctx(project, target_override=["claude", "vscode"])
+    run(ctx)
+
+    assert _target_names(ctx) == ["claude", "copilot"]
+    assert (project / ".claude").is_dir()
+    assert (project / ".github").is_dir()
+
+
+@pytest.mark.parametrize("target_override", [["vscode"], "vscode"])
+def test_run_targets_phase_normalizes_vscode_alias(
+    tmp_path: Path,
+    target_override: str | list[str],
+) -> None:
+    """The v2 wrapper accepts vscode as the runtime alias for copilot."""
+    from apm_cli.install.phases.targets import run_targets_phase
+
+    project = tmp_path / "project"
+    project.mkdir()
+
+    ctx = _make_ctx(project, target_override=target_override)
+    run_targets_phase(ctx)
+
+    assert _target_names(ctx) == ["copilot"]
+    assert (project / ".github").is_dir()
+
+
+def test_cli_parse_claude_copilot_installs_both_targets(tmp_path: Path) -> None:
+    """The exact CLI parse result for --target claude,copilot keeps copilot."""
+    from apm_cli.core.target_detection import parse_target_field
+    from apm_cli.install.phases.targets import run
+
+    project = tmp_path / "project"
+    project.mkdir()
+
+    parsed = parse_target_field("claude,copilot")
+    ctx = _make_ctx(project, target_override=parsed)
+    run(ctx)
+
+    assert parsed == ["claude", "vscode"]
+    assert _target_names(ctx) == ["claude", "copilot"]
+    assert (project / ".claude").is_dir()
+    assert (project / ".github").is_dir()
+
+
+def test_run_targets_phase_dedupes_copilot_runtime_aliases(tmp_path: Path) -> None:
+    """Mixed canonical/runtime tokens collapse to one copilot profile."""
+    from apm_cli.install.phases.targets import run_targets_phase
+
+    project = tmp_path / "project"
+    project.mkdir()
+
+    ctx = _make_ctx(project, target_override=["copilot", "vscode"])
+    run_targets_phase(ctx)
+
+    assert _target_names(ctx) == ["copilot"]
+
+
+def test_experimental_target_override_skips_v2_resolver(tmp_path: Path) -> None:
+    """Non-canonical experimental targets stay on the legacy-only path."""
+    from apm_cli.install.phases.targets import _resolve_targets_by_scope
+    from apm_cli.integration.targets import KNOWN_TARGETS
+
+    project = tmp_path / "project"
+    project.mkdir()
+
+    ctx = _make_ctx(project, target_override="copilot-cowork")
+    targets = _resolve_targets_by_scope(
+        ctx,
+        [KNOWN_TARGETS["copilot-cowork"]],
+        "copilot-cowork",
+        False,
+    )
+
+    assert [target.name for target in targets] == ["copilot-cowork"]
 
 
 def test_three_guard_collapse_no_skip(tmp_path):


### PR DESCRIPTION
# fix(install): keep copilot in multi-target `--target` lists

## TL;DR

`apm install --target claude,copilot` silently dropped the Copilot target — only Claude was installed, with no error. The install targets phase filtered the parsed flag tokens against `CANONICAL_TARGETS` *before* normalizing runtime aliases, so the `vscode` token (which multi-token parsing produces for `copilot`) was discarded. This PR normalizes runtime aliases through the existing shared `RUNTIME_TO_CANONICAL_TARGET` table before the canonical filter, mirroring the precedent already in `mcp_integrator`.

> [!NOTE]
> Closes microsoft/apm#1746. Single-token `--target copilot` was never affected — that's what made the bug easy to miss.

## Problem (WHY)

- [x] `apm install --target claude,copilot` prints `Targets: claude  (source: --target flag)` and installs only for Claude; verbose logs from the issue and a local repro both confirm Copilot is dropped without any warning.
- [x] `parse_target_field` resolves **multi-token** input through `TARGET_ALIASES` (`copilot → vscode`), while single-token input is returned as-is — a documented asymmetry ([`core/target_detection.py`](https://github.com/microsoft/apm/blob/5c03d1aab461bd5670933734e6cf6eecf670ec5f/src/apm_cli/core/target_detection.py#L558-L569): "every downstream consumer … already accepts both alias spellings").
- [x] But `_resolve_targets_by_scope` did **not** accept both spellings: `parts = [p for p in parts if p in _CANONICAL]` dropped `vscode` because `CANONICAL_TARGETS` contains `copilot`, not `vscode` ([`install/phases/targets.py`](https://github.com/microsoft/apm/blob/5c03d1aab461bd5670933734e6cf6eecf670ec5f/src/apm_cli/install/phases/targets.py#L360)).
- [x] The trailing legacy merge then dropped the legacy-resolved copilot profile too, because its name *is* canonical — so neither resolution path delivered it.
- [!] This is the exact bug class the shared alias table was created to prevent: ["a silent drift would strip a runtime even when its canonical target is active (the same class of bug as #1335)"](https://github.com/microsoft/apm/blob/5c03d1aab461bd5670933734e6cf6eecf670ec5f/src/apm_cli/integration/targets.py#L444-L446).

## Approach (WHAT)

| # | Fix |
|---|-----|
| 1 | Add `_normalize_runtime_target_aliases()`: map each flag token through `RUNTIME_TO_CANONICAL_TARGET` (`vscode`/`agents`/`intellij` → `copilot`), dedupe preserving order. |
| 2 | Call it in `_resolve_targets_by_scope` **before** the `p in _CANONICAL` filter — same precedent as [`mcp_integrator.py`](https://github.com/microsoft/apm/blob/5c03d1aab461bd5670933734e6cf6eecf670ec5f/src/apm_cli/integration/mcp_integrator.py#L1038-L1046), which normalizes aliases "BEFORE passing the flag to resolve_targets". |
| 3 | Apply the same normalization in `run_targets_phase` (test-only v2 wrapper) so it no longer raises `UnknownTargetError` on `vscode`. |

Genuinely non-canonical tokens (e.g. experimental `copilot-cowork`) still skip the v2 resolver and are preserved via the legacy merge — unchanged.

## Implementation (HOW)

- **`src/apm_cli/install/phases/targets.py`** — new 16-line helper plus two one-line call sites. Deliberately did *not* touch `parse_target_field` / `TARGET_ALIASES`: the single-vs-multi-token asymmetry is documented as intentional and consumed by the compile path (`agents_compiler` routes on `vscode`), so flipping the alias direction would be a visible behaviour change far beyond this bug.
- **`tests/unit/install/phases/test_targets_phase_v2.py`** — six regression tests (see Scenario Evidence), reusing the file's existing `_make_ctx` MagicMock pattern.
- **`CHANGELOG.md`** — one `Fixed` entry under `[Unreleased]`.

## Diagrams

Legend: flow of a `--target claude,copilot` flag through the install targets phase; the dashed box is the new normalization step that stops `vscode` from being filtered out.

```mermaid
flowchart LR
    subgraph parse ["CLI parse"]
        A["--target claude,copilot"] --> B["parse_target_field"]
        B --> C["claude, vscode"]
    end
    subgraph phase ["_resolve_targets_by_scope"]
        N["_normalize_runtime_target_aliases<br/>vscode to copilot"]
        F["filter: p in CANONICAL_TARGETS"]
        R["resolve_targets v2"]
    end
    C --> N --> F --> R
    R --> O["targets: claude, copilot"]
    C -.->|"before: vscode dropped by filter"| F
    classDef new stroke-dasharray: 5 5;
    class N new;
```

## Trade-offs

- **Normalize at the consumer, not the parser.** Chose to align `install/phases/targets.py` with the `mcp_integrator` precedent; rejected changing `TARGET_ALIASES`/`parse_target_field` because the comment block there explicitly defends the asymmetry and the compile family routing depends on the `vscode` spelling.
- **`run_targets_phase` fix included although test-only.** Keeping the wrapper consistent costs one line and removes a latent `UnknownTargetError` trap for future tests.
- **Helper imports `RUNTIME_TO_CANONICAL_TARGET` lazily** (inside the function) to match the file's existing import-at-use style and avoid a module-level import cycle risk.

## Benefits

1. `apm install --target claude,copilot` now installs for **both** harnesses — verified end-to-end (below).
2. All alias spellings (`vscode`, `agents`, `intellij`) behave identically in multi-target lists, single-target form, string and list forms.
3. Six regression tests pin the exact issue command path (`parse_target_field("claude,copilot")` → claude + copilot), so the drop cannot silently return.

## Validation

End-to-end repro of the exact issue command, before and after the fix (skill-only demo package):

```
=== PRE-FIX: apm install --target claude,copilot --verbose ===
[i] Targets: claude  (source: --target flag)
Created .claude/ (claude target)

=== POST-FIX: apm install --target claude,copilot --verbose ===
[i] Targets: claude, copilot  (source: --target flag)
Created .claude/ (claude target)
Created .github/ (copilot target)
  |-- 1 skill(s) integrated: .agents/skills/ + .claude/skills/

=== POST-FIX: apm install --target copilot,claude,gemini --verbose ===
[i] Targets: claude, copilot, gemini  (source: --target flag)

=== POST-FIX: apm install --target copilot (single, unchanged) ===
[i] Targets: copilot  (source: --target flag)
```

Full suite and CI lint mirror:

```
uv run pytest tests/unit tests/test_console.py -q
16914 passed, 2 skipped, 21 xfailed, 19 warnings, 40 subtests passed in 69.56s

ruff check src/ tests/            -> All checks passed!
ruff format --check src/ tests/   -> 1241 files already formatted
pylint R0801 duplication gate     -> 10.00/10
scripts/lint-auth-signals.sh      -> clean
```

All six new tests were confirmed failing before the fix (copilot dropped / `UnknownTargetError` on `vscode`) and pass after.

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|------------------------|--------------|--------------------|------|
| 1 | "`--target claude,copilot` installs for both harnesses" | Multi-harness | `tests/unit/install/phases/test_targets_phase_v2.py::test_cli_parse_claude_copilot_installs_both_targets` | unit |
| 2 | Alias list (`["claude", "vscode"]`) resolves both profiles and creates both deploy dirs | Multi-harness | `...::test_runtime_alias_list_preserves_copilot_profile_and_dirs` | unit |
| 3 | `vscode` (string and list form) resolves to copilot | Multi-harness / DevX | `...::test_run_targets_phase_normalizes_vscode_alias[vscode0/vscode1]` | unit |
| 4 | Mixed `copilot,vscode` dedupes to one copilot profile | DevX | `...::test_run_targets_phase_dedupes_copilot_runtime_aliases` | unit |
| 5 | Experimental targets still skip the v2 resolver (no regression) | Multi-harness | `...::test_experimental_target_override_skips_v2_resolver` | unit |

## How to test

- [ ] In an empty dir with a skill dependency in `apm.yml`, run `apm install --target claude,copilot --verbose` → log shows `Targets: claude, copilot  (source: --target flag)` and both `.claude/` and `.github/` are created.
- [ ] Run `apm install --target copilot,claude,gemini --verbose` → all three targets listed (issue's third repro).
- [ ] Run `apm install --target copilot --verbose` → unchanged single-target behaviour.
- [ ] `uv run pytest tests/unit/install/phases/test_targets_phase_v2.py -q` → all pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
