### PR TITLE
fix(docs): restore reachability of alternative installation methods page (closes #1748)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -36,7 +36,6 @@ export default defineConfig({
 		'/introduction/anatomy-of-an-apm-package': '/apm/concepts/package-anatomy',
 		// Legacy getting-started -> persona ramps
 		'/getting-started/quick-start': '/apm/quickstart',
-		'/getting-started/installation': '/apm/quickstart',
 		'/getting-started/authentication': '/apm/consumer/authentication',
 		'/getting-started/migration': '/apm/troubleshooting/migration',
 		// Legacy guides -> consumer/producer ramps
@@ -154,6 +153,7 @@ export default defineConfig({
 					label: 'Start here',
 					items: [
 						{ label: 'Quickstart', slug: 'quickstart' },
+						{ label: 'Installation', slug: 'getting-started/installation' },
 						{ label: 'Your first package', slug: 'getting-started/first-package' },
 					],
 				},


### PR DESCRIPTION
Restores the alternative installation methods page by removing the legacy redirect that sent /getting-started/installation back to /quickstart, and adds the page to the Start here sidebar so it is directly discoverable. How to test: npm --prefix docs run build; confirm docs/dist/getting-started/installation/index.html exists, contains Homebrew, Scoop, and air-gapped installation content, and no longer contains a meta refresh redirect to quickstart. Python ruff lint is N/A because this change touches only docs/astro.config.mjs. Closes #1748.