### PR TITLE
test: fix Windows-only CI failures across 8 unit tests

### DIFF
--- a/tests/unit/commands/test_self_update_air_gapped.py
+++ b/tests/unit/commands/test_self_update_air_gapped.py
@@ -314,6 +314,10 @@ class TestEnterpriseBootstrapSelfUpdate:
                 "APM_RELEASE_METADATA_URL": "https://mirror.corp.example/apm/latest.json",
                 "APM_INSTALLER_BASE_URL": "https://mirror.corp.example/apm/installers",
                 "APM_TEMP_DIR": str(self.scratch),
+                # Disable the CLI-startup update notifier so its cache-gated
+                # metadata fetch (which fires on a cold Windows runner cache but
+                # not on a warm Unix one) does not perturb the request list.
+                "APM_E2E_TESTS": "1",
             }
         )
         requested_urls: list[str] = []

--- a/tests/unit/deps/test_revision_pin_resolver.py
+++ b/tests/unit/deps/test_revision_pin_resolver.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -168,6 +169,10 @@ def test_apply_revision_pin_updates_rejects_non_manifest_path(tmp_path: Path) ->
         )
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Windows does not honor POSIX file modes; st_mode & 0o777 is not 0o600",
+)
 def test_apply_revision_pin_updates_writes_restrictive_permissions(tmp_path: Path) -> None:
     manifest = tmp_path / "apm.yml"
     manifest.write_text(

--- a/tests/unit/integration/test_kiro_target.py
+++ b/tests/unit/integration/test_kiro_target.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from datetime import datetime
 from pathlib import Path
 
@@ -236,12 +237,14 @@ def test_kiro_hooks_expand_each_apm_hook_to_individual_json(tmp_path: Path) -> N
     assert pre_data["then"]["command"] == "python .kiro/hooks/hookify/hooks/check.py"
     assert pre_data["description"] == "Validate before tool use"
     assert "hooks" not in pre_data
-    assert pre_tool.stat().st_mode & 0o777 == 0o600
+    if sys.platform != "win32":
+        assert pre_tool.stat().st_mode & 0o777 == 0o600
 
     prompt_data = json.loads(prompt_submit.read_text(encoding="utf-8"))
     assert prompt_data["when"] == {"type": "promptSubmit"}
     assert prompt_data["then"]["command"] == "python .kiro/hooks/hookify/hooks/prompt.py"
-    assert prompt_submit.stat().st_mode & 0o777 == 0o600
+    if sys.platform != "win32":
+        assert prompt_submit.stat().st_mode & 0o777 == 0o600
 
     assert (tmp_path / ".kiro" / "hooks" / "hookify" / "hooks" / "check.py").exists()
     assert (tmp_path / ".kiro" / "hooks" / "hookify" / "hooks" / "prompt.py").exists()
@@ -282,7 +285,8 @@ def test_kiro_hooks_convert_prompt_actions_to_ask_agent(tmp_path: Path) -> None:
         "type": "askAgent",
         "prompt": "Review the submitted prompt for policy drift.",
     }
-    assert target.stat().st_mode & 0o777 == 0o600
+    if sys.platform != "win32":
+        assert target.stat().st_mode & 0o777 == 0o600
 
 
 def test_kiro_hooks_skip_when_project_has_no_kiro_dir(tmp_path: Path) -> None:

--- a/tests/unit/test_enterprise_bootstrap_installers.py
+++ b/tests/unit/test_enterprise_bootstrap_installers.py
@@ -3,6 +3,7 @@
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -130,6 +131,10 @@ def _run_unix_installer(extra_env: dict[str, str]) -> subprocess.CompletedProces
     )
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="install.sh is the Unix installer; its OS guard rejects MINGW/Windows before env-var checks",
+)
 def test_unix_installer_fail_closed_metadata_exit_code() -> None:
     """Fail-closed metadata path exits non-zero with actionable guidance.
 
@@ -147,6 +152,10 @@ def test_unix_installer_fail_closed_metadata_exit_code() -> None:
     assert "APM_RELEASE_METADATA_URL is not configured" in combined
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="install.sh is the Unix installer; its OS guard rejects MINGW/Windows before env-var checks",
+)
 def test_unix_installer_fail_closed_asset_exit_code() -> None:
     """Fail-closed asset path (pinned VERSION) exits non-zero, no public fallback."""
     if shutil.which("sh") is None:

--- a/tests/unit/test_kiro_mcp.py
+++ b/tests/unit/test_kiro_mcp.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -49,7 +50,8 @@ class TestKiroClientAdapter:
         data = json.loads(mcp_json.read_text(encoding="utf-8"))
         assert data["mcpServers"]["srv"]["command"] == "node"
         assert data["mcpServers"]["srv"]["args"] == ["server.js"]
-        assert mcp_json.stat().st_mode & 0o777 == 0o600
+        if sys.platform != "win32":
+            assert mcp_json.stat().st_mode & 0o777 == 0o600
 
     def test_user_scope_writes_without_existing_kiro_dir(self, tmp_path: Path) -> None:
         with patch("pathlib.Path.home", return_value=tmp_path):
@@ -59,7 +61,8 @@ class TestKiroClientAdapter:
         mcp_json = tmp_path / ".kiro" / "settings" / "mcp.json"
         data = json.loads(mcp_json.read_text(encoding="utf-8"))
         assert data["mcpServers"]["srv"]["command"] == "node"
-        assert mcp_json.stat().st_mode & 0o777 == 0o600
+        if sys.platform != "win32":
+            assert mcp_json.stat().st_mode & 0o777 == 0o600
 
     def test_remote_config_uses_kiro_url_headers_and_tool_extensions(self) -> None:
         adapter = KiroClientAdapter()


### PR DESCRIPTION
## TL;DR

Eight unit tests passed on macOS/Linux but failed only on `windows-latest` ([failing run](https://github.com/microsoft/apm/actions/runs/27358858704/job/80840498410)). All three root causes are platform-environment artifacts, not production bugs, so the fixes are test-only.

## Root causes & fixes

**1. POSIX permission assertions (5 tests)** — `st_mode & 0o777 == 0o600` cannot hold on Windows, which does not honor POSIX file modes (it reports `0o666`/`33206`).
- `tests/unit/deps/test_revision_pin_resolver.py` — the test asserts *only* the permission, so it gets a function-level `@pytest.mark.skipif(sys.platform == "win32")`.
- `tests/unit/test_kiro_mcp.py` (2) and `tests/unit/integration/test_kiro_target.py` (3) — guarded just the mode assertion with `if sys.platform != "win32":`, so the functional JSON-content assertions still run on Windows.

**2. Unix installer execution tests (2 tests)** — `tests/unit/test_enterprise_bootstrap_installers.py` shells out to `install.sh`, whose OS guard rejects `MINGW64_NT-10.0-...` with `Unsupported operating system` *before* the `APM_NO_DIRECT_FALLBACK` fail-closed checks run, so the asserted error string never appears. Skipped on win32 — `install.sh` is the Unix installer; `install.ps1` has its own coverage.

**3. self-update mirror request list (1 test)** — `test_self_update_uses_mirrors_without_public_hosts` asserts an exact 2-item request list, but the CLI-startup update notifier (`_check_and_notify_updates`) adds a **cache-gated** `latest.json` fetch. On a cold `windows-latest` runner cache the gate opens and fires an extra request (3 total); on a warm Unix cache it stays closed (2 total). Setting `APM_E2E_TESTS=1` disables the notifier so the request list is deterministic across platforms.

## Validation

- Reproduced the exact Windows double-fetch locally by forcing the cache gate open: `['/apm/latest.json', '/apm/latest.json', '/apm/installers/install.sh']` → with `APM_E2E_TESTS=1`: `['/apm/latest.json', '/apm/installers/install.sh']`.
- All 65 tests in the 5 affected files pass on macOS.
- `ruff check src/ tests/` and `ruff format --check` are clean.

## How to test

```bash
uv run --extra dev pytest \
  tests/unit/deps/test_revision_pin_resolver.py \
  tests/unit/test_kiro_mcp.py \
  tests/unit/integration/test_kiro_target.py \
  tests/unit/test_enterprise_bootstrap_installers.py \
  tests/unit/commands/test_self_update_air_gapped.py -q
```