### PR TITLE
chore: release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-06-11
+
 ### Added
 
 - `apm install --target kiro` deploys Kiro IDE steering, skills, hooks,
@@ -20,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   emits `AGENTS.md`, and MCP servers are written to the `mcp_servers:` block
   of `~/.hermes/config.yaml` (written atomically with `0o600` perms, preserving
   unrelated config keys and refusing to overwrite a malformed file). `HERMES_HOME`
-  overrides the Hermes home directory. See the [Hermes integration guide](https://microsoft.github.io/apm/integrations/hermes/).
+  overrides the Hermes home directory. See the [Hermes integration guide](https://microsoft.github.io/apm/integrations/hermes/). (#1726)
 - Enterprise marketplace authors can stop repeating shared git base paths by
   setting `sourceBase` (one line replaces repeated URLs), while host-prefixed,
   full-URL, and local entries remain per-entry overrides. (#1736)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apm-cli"
-version = "0.19.0"
+version = "0.20.0"
 description = "MCP configuration tool"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -201,7 +201,7 @@ wheels = [
 
 [[package]]
 name = "apm-cli"
-version = "0.19.0"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Cut release 0.20.0.

- Bump `pyproject.toml` to 0.20.0 (and `uv.lock`).
- Move `[Unreleased]` to `[0.20.0] - 2026-06-11` in `CHANGELOG.md`, with one short "so what?" entry per PR merged since v0.19.0.

## Why MINOR (0.20.0), not PATCH (0.19.1)

Multiple MINOR signals fired this cycle: two new experimental targets (`apm install --target kiro` #1741, `--target hermes` #1726), enterprise bootstrap mirror mode (#1733), a new `apm pack --archive-format` flag (#1720), a new `sourceBase` marketplace manifest field (#1736), new `apm marketplace add` source kinds (#1739), SHA-pin auto-update (#1738), and git-transport path fetching (#1740). The remaining PRs are bug fixes subordinate to those signals.

Pre-1.0 framing keeps this a MINOR (not MAJOR): the one breaking change rides in a minor bump.

**BREAKING this cycle:** `apm pack --archive` now produces `.zip` by default instead of `.tar.gz` (#1720), matching `apm publish` output and plugin-host expectations. Use `--archive-format tar.gz` to opt back in.

## Validation

Lint mirror green locally (ruff check + format, pylint R0801, auth-signals). See `.apm/instructions/linting.instructions.md` for the contract this mirrors.

## Post-merge

Tag `v0.20.0` to trigger the release workflow:

```
git tag v0.20.0
git push origin v0.20.0
```