### PR TITLE
test(release): refresh release-validation harness for v0.20.0 behavior changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-06-11
+
 ### Added
 
 - `apm install --target kiro` deploys Kiro IDE steering, skills, hooks,
@@ -20,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   emits `AGENTS.md`, and MCP servers are written to the `mcp_servers:` block
   of `~/.hermes/config.yaml` (written atomically with `0o600` perms, preserving
   unrelated config keys and refusing to overwrite a malformed file). `HERMES_HOME`
-  overrides the Hermes home directory. See the [Hermes integration guide](https://microsoft.github.io/apm/integrations/hermes/).
+  overrides the Hermes home directory. See the [Hermes integration guide](https://microsoft.github.io/apm/integrations/hermes/). (#1726)
 - Enterprise marketplace authors can stop repeating shared git base paths by
   setting `sourceBase` (one line replaces repeated URLs), while host-prefixed,
   full-URL, and local entries remain per-entry overrides. (#1736)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apm-cli"
-version = "0.19.0"
+version = "0.20.0"
 description = "MCP configuration tool"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/test-release-validation.sh
+++ b/scripts/test-release-validation.sh
@@ -286,13 +286,19 @@ test_hero_guardrailing() {
         return 1
     fi
     
-    if [[ ! -f "AGENTS.md" ]]; then
-        log_error "AGENTS.md not created by compile"
+    # Copilot compile suppresses empty AGENTS.md shells when installed
+    # instructions already live under .github/instructions/ (the guardrail
+    # surface Copilot reads directly). Validate that compiled guardrails
+    # landed there rather than insisting on an AGENTS.md shell.
+    if [[ -f "AGENTS.md" ]]; then
+        log_success "Compiled to AGENTS.md (guardrails active)"
+    elif ls .github/instructions/*.md 1>/dev/null 2>&1; then
+        log_success "Compiled guardrails to .github/instructions/ (Copilot reads them directly)"
+    else
+        log_error "compile produced no guardrail surface (neither AGENTS.md nor .github/instructions/)"
         cd ..
         return 1
     fi
-    
-    log_success "Compiled to AGENTS.md (guardrails active)"
     
     # Step 5: apm run design-review (from installed package)
     # Gated by APM_RUN_INFERENCE_TESTS — live inference is decoupled from
@@ -399,8 +405,11 @@ APMYML
             exit 1
         fi
         
-        # Verify a bundle was produced
-        if ls build/*.tar.gz 1>/dev/null 2>&1; then
+        # Verify a bundle was produced. 'apm pack --archive' now emits .zip by
+        # default (legacy pipelines opt back in with --archive-format tar.gz),
+        # so accept either extension. Test each glob independently: a single
+        # `ls a b` exits non-zero when either pattern is unmatched.
+        if ls build/*.zip 1>/dev/null 2>&1 || ls build/*.tar.gz 1>/dev/null 2>&1; then
             echo "Bundle archive produced successfully"
         else
             echo "No bundle archive found in build/"

--- a/scripts/windows/test-release-validation.ps1
+++ b/scripts/windows/test-release-validation.ps1
@@ -327,12 +327,18 @@ function Test-HeroGuardrailing {
             return $false
         }
 
-        if (-not (Test-Path "AGENTS.md")) {
-            Write-ErrorText "AGENTS.md not created by compile"
+        # Copilot compile suppresses empty AGENTS.md shells when installed
+        # instructions already live under .github/instructions/ (the guardrail
+        # surface Copilot reads directly). Validate that compiled guardrails
+        # landed there rather than insisting on an AGENTS.md shell.
+        if (Test-Path "AGENTS.md") {
+            Write-Success "Compiled to AGENTS.md (guardrails active)"
+        } elseif (Get-ChildItem -Path ".github/instructions" -Filter "*.md" -ErrorAction SilentlyContinue) {
+            Write-Success "Compiled guardrails to .github/instructions/ (Copilot reads them directly)"
+        } else {
+            Write-ErrorText "compile produced no guardrail surface (neither AGENTS.md nor .github/instructions/)"
             return $false
         }
-
-        Write-Success "Compiled to AGENTS.md (guardrails active)"
 
         # Step 5: apm run design-review (from installed package)
         Write-Host "Running: $script:BINARY_PATH run design-review (with 10s timeout)"

--- a/tests/integration/test_ado_e2e.py
+++ b/tests/integration/test_ado_e2e.py
@@ -156,7 +156,7 @@ class TestADOCompile:
     ADO_TEST_REPO = "dev.azure.com/dmeppiel-org/market-js-app/_git/compliance-rules"
 
     def test_compile_generates_agents_md(self, tmp_path):
-        """Compile should generate AGENTS.md from ADO dependencies."""
+        """Compile should keep ADO Copilot instructions outside AGENTS.md."""
         project_dir = tmp_path / "test-project"
         project_dir.mkdir()
 
@@ -182,9 +182,15 @@ class TestADOCompile:
         # Should not show orphan warnings
         assert "orphan" not in result.stdout.lower() or "0 orphan" in result.stdout.lower()
 
-        # AGENTS.md should be generated
+        # Copilot compile suppresses empty AGENTS.md shells when installed
+        # instructions already live under .github/instructions/.
         agents_md = project_dir / "AGENTS.md"
-        assert agents_md.exists(), "AGENTS.md not generated"
+        github_instructions = project_dir / ".github" / "instructions"
+        assert not agents_md.exists(), (
+            "AGENTS.md should not be generated for Copilot-only instructions"
+        )
+        assert github_instructions.is_dir(), ".github/instructions not generated"
+        assert list(github_instructions.glob("*.md")), "No Copilot instruction files generated"
 
 
 class TestADOVirtualPackage:

--- a/tests/integration/test_download_copilot_end_to_end.py
+++ b/tests/integration/test_download_copilot_end_to_end.py
@@ -87,6 +87,9 @@ def _make_host(
         api_base="https://api.github.com",
     )
     host.auth_resolver.build_error_context.return_value = "Use GITHUB_APM_PAT."
+    host._resolve_dep_auth_ctx = MagicMock(
+        side_effect=lambda *a, **k: host.auth_resolver.resolve.return_value
+    )
     return host
 
 
@@ -1443,7 +1446,8 @@ class TestResolveEnvironmentVariables:
         return adapter
 
     def test_list_form_produces_runtime_placeholders(self) -> None:
-        """List of env-var descriptors each become ${NAME} placeholders."""
+        """Required descriptors become ${NAME}; optional ones without an
+        observed value are omitted (honoring optional registry inputs, #1734)."""
         adapter = self._make_adapter()
         env_vars = [
             {"name": "GITHUB_TOKEN", "description": "GitHub token", "required": True},
@@ -1451,7 +1455,7 @@ class TestResolveEnvironmentVariables:
         ]
         result = adapter._resolve_environment_variables(env_vars)
         assert result["GITHUB_TOKEN"] == "${GITHUB_TOKEN}"
-        assert result["API_KEY"] == "${API_KEY}"
+        assert "API_KEY" not in result
 
     def test_github_toolsets_preserved_as_literal(self) -> None:
         """GITHUB_TOOLSETS default stays literal (non-secret)."""

--- a/tests/integration/test_download_copilot_phase3.py
+++ b/tests/integration/test_download_copilot_phase3.py
@@ -87,6 +87,9 @@ def _make_host(
         api_base="https://api.github.com",
     )
     host.auth_resolver.build_error_context.return_value = "Use GITHUB_APM_PAT."
+    host._resolve_dep_auth_ctx = MagicMock(
+        side_effect=lambda *a, **k: host.auth_resolver.resolve.return_value
+    )
     return host
 
 
@@ -1443,7 +1446,8 @@ class TestResolveEnvironmentVariables:
         return adapter
 
     def test_list_form_produces_runtime_placeholders(self) -> None:
-        """List of env-var descriptors each become ${NAME} placeholders."""
+        """Required descriptors become ${NAME}; optional ones without an
+        observed value are omitted (honoring optional registry inputs, #1734)."""
         adapter = self._make_adapter()
         env_vars = [
             {"name": "GITHUB_TOKEN", "description": "GitHub token", "required": True},
@@ -1451,7 +1455,7 @@ class TestResolveEnvironmentVariables:
         ]
         result = adapter._resolve_environment_variables(env_vars)
         assert result["GITHUB_TOKEN"] == "${GITHUB_TOKEN}"
-        assert result["API_KEY"] == "${API_KEY}"
+        assert "API_KEY" not in result
 
     def test_github_toolsets_preserved_as_literal(self) -> None:
         """GITHUB_TOOLSETS default stays literal (non-secret)."""

--- a/tests/integration/test_download_strategies_phase3w5.py
+++ b/tests/integration/test_download_strategies_phase3w5.py
@@ -40,6 +40,7 @@ def make_host(
     auth_resolver.classify_host.return_value = SimpleNamespace(kind="generic", api_base=api_base)
     auth_resolver.build_error_context.return_value = "Set a token."
     host.auth_resolver = auth_resolver
+    host._resolve_dep_auth_ctx = MagicMock(return_value=ctx)
     return host
 
 
@@ -639,28 +640,19 @@ class TestDownloadGithubFilePhase3W5:
             "Downloaded file: gitea.example.com/owner/repo/README.md"
         )
 
-    def test_generic_host_raw_exception_falls_back_to_contents_api(self) -> None:
+    def test_generic_host_raw_exception_raises_network_error(self) -> None:
         host = make_host(resolved_token=None)
         delegate = DownloadDelegate(host)
         dep = make_dep("owner/repo", host="gitea.example.com")
         callback = MagicMock()
-        host._resilient_get.side_effect = [
-            requests.RequestException("raw failed"),
-            fake_response(
-                200,
-                content=json.dumps({"content": "aGVsbG8=", "encoding": "base64"}).encode(),
-                headers={"Content-Type": "application/json"},
-            ),
-        ]
+        host._resilient_get.side_effect = requests.RequestException("raw failed")
 
         with (
             patch("apm_cli.deps.download_strategies.is_github_hostname", return_value=False),
             patch.object(delegate, "_build_contents_api_urls", return_value=["api-url"]),
         ):
-            result = delegate.download_github_file(dep, "README.md", verbose_callback=callback)
-
-        assert result == b"hello"
-        assert "falling back to Contents API" in callback.call_args_list[1].args[0]
+            with pytest.raises(RuntimeError, match=r"Network error downloading README\.md"):
+                delegate.download_github_file(dep, "README.md", verbose_callback=callback)
 
     def test_generic_host_contents_headers_use_builder(self) -> None:
         host = make_host(resolved_token=None)

--- a/tests/integration/test_download_strategies_selection.py
+++ b/tests/integration/test_download_strategies_selection.py
@@ -42,6 +42,7 @@ def make_host(
     auth_resolver.classify_host.return_value = SimpleNamespace(kind="generic", api_base=api_base)
     auth_resolver.build_error_context.return_value = "Set a token."
     host.auth_resolver = auth_resolver
+    host._resolve_dep_auth_ctx = MagicMock(return_value=ctx)
     return host
 
 
@@ -688,28 +689,19 @@ class TestDownloadGithubFile:
             "Downloaded file: gitea.example.com/owner/repo/README.md"
         )
 
-    def test_generic_host_raw_exception_falls_back_to_contents_api(self) -> None:
+    def test_generic_host_raw_exception_raises_network_error(self) -> None:
         host = make_host(resolved_token=None)
         delegate = DownloadDelegate(host)
         dep = make_dep("owner/repo", host="gitea.example.com")
         callback = MagicMock()
-        host._resilient_get.side_effect = [
-            requests.RequestException("raw failed"),
-            fake_response(
-                200,
-                content=json.dumps({"content": "aGVsbG8=", "encoding": "base64"}).encode(),
-                headers={"Content-Type": "application/json"},
-            ),
-        ]
+        host._resilient_get.side_effect = requests.RequestException("raw failed")
 
         with (
             patch("apm_cli.deps.download_strategies.is_github_hostname", return_value=False),
             patch.object(delegate, "_build_contents_api_urls", return_value=["api-url"]),
         ):
-            result = delegate.download_github_file(dep, "README.md", verbose_callback=callback)
-
-        assert result == b"hello"
-        assert "falling back to Contents API" in callback.call_args_list[1].args[0]
+            with pytest.raises(RuntimeError, match=r"Network error downloading README\.md"):
+                delegate.download_github_file(dep, "README.md", verbose_callback=callback)
 
     def test_generic_host_contents_headers_use_builder(self) -> None:
         host = make_host(resolved_token=None)

--- a/tests/integration/test_guardrailing_hero_e2e.py
+++ b/tests/integration/test_guardrailing_hero_e2e.py
@@ -11,7 +11,7 @@ Exercises a guardrailing workflow with mixed package types:
 This validates that:
 - Multiple APM packages can be installed (full package + virtual instruction)
 - Compilation produces combined instructions from both packages (distributed
-  across AGENTS.md and .github/instructions/)
+  through Copilot-readable .github/instructions/ files)
 - Prompts from installed packages can be executed
 """
 
@@ -187,17 +187,22 @@ class TestGuardrailingHeroScenario:
             result = run_command(f"{apm_binary} compile", cwd=project_dir, show_output=True)
             assert result.returncode == 0, f"Compilation failed: {result.stderr}"
 
-            # Verify AGENTS.md was generated
+            # Copilot compile suppresses empty AGENTS.md shells when installed
+            # instructions already live under .github/instructions/.
             agents_md = project_dir / "AGENTS.md"
-            assert agents_md.exists(), "AGENTS.md not generated"
+            github_instructions = project_dir / ".github" / "instructions"
+            assert not agents_md.exists(), (
+                "AGENTS.md should not be generated for Copilot-only instructions"
+            )
+            assert github_instructions.is_dir(), ".github/instructions not generated"
+            assert list(github_instructions.glob("*.md")), "No Copilot instruction files generated"
 
             # The distributed-primitives compile model routes instruction content
             # into per-glob files under .github/instructions/ (and, when present,
-            # .github/copilot-instructions.md), leaving the root AGENTS.md as a thin
-            # stub. Aggregate the full compiled corpus so the assertions hold
-            # regardless of where each instruction lands.
-            compiled_sources = [agents_md, project_dir / ".github" / "copilot-instructions.md"]
-            compiled_sources.extend(sorted((project_dir / ".github" / "instructions").glob("*.md")))
+            # .github/copilot-instructions.md). Aggregate the full compiled corpus
+            # so the assertions hold regardless of where each instruction lands.
+            compiled_sources = [project_dir / ".github" / "copilot-instructions.md"]
+            compiled_sources.extend(sorted(github_instructions.glob("*.md")))
             compiled_content = "\n".join(
                 p.read_text() for p in compiled_sources if p.exists()
             ).lower()
@@ -210,8 +215,8 @@ class TestGuardrailingHeroScenario:
                 "Compiled instructions don't contain code-review content from awesome-copilot"
             )
 
-            agents_content = agents_md.read_text()
-            print(f"[OK] AGENTS.md generated ({len(agents_content)} bytes)")
+            compiled_bytes = sum(p.stat().st_size for p in compiled_sources if p.exists())
+            print(f"[OK] Copilot instructions generated ({compiled_bytes} bytes)")
             print("  Contains design instructions: [OK]")
             print("  Contains code-review instructions: [OK]")
 
@@ -283,7 +288,7 @@ class TestGuardrailingHeroScenario:
             print("\n=== 2-Minute Guardrailing Hero Scenario: PASSED ===")
             print("[OK] Project initialization")
             print("[OK] Multiple APM package installation")
-            print("[OK] AGENTS.md compilation with combined instructions")
+            print("[OK] Copilot instruction compilation with combined instructions")
             print("[OK] Prompt execution from installed package")
 
 

--- a/tests/integration/test_mixed_deps.py
+++ b/tests/integration/test_mixed_deps.py
@@ -124,7 +124,7 @@ class TestMixedDependencyCompile:
     """Test compiling projects with mixed dependencies."""
 
     def test_compile_with_mixed_deps_generates_agents_md(self, temp_project, apm_command):
-        """Compile should generate AGENTS.md from both package types."""
+        """Compile should keep Copilot instructions outside AGENTS.md."""
         # Install Claude Skill (most likely to succeed)
         subprocess.run(
             [apm_command, "install", "anthropics/skills/skills/brand-guidelines"],
@@ -134,7 +134,7 @@ class TestMixedDependencyCompile:
             timeout=120,
         )
 
-        # Create a local instruction to ensure AGENTS.md has content
+        # Create a local instruction to trigger Copilot AGENTS.md deduplication.
         instructions_dir = temp_project / ".github" / "instructions"
         instructions_dir.mkdir(parents=True, exist_ok=True)
         instruction = instructions_dir / "test.instructions.md"
@@ -153,9 +153,13 @@ This is a test.
 
         assert result.returncode == 0, f"Compile failed: {result.stderr}"
 
-        # Verify AGENTS.md was created
+        # Copilot compile suppresses empty AGENTS.md shells when instructions
+        # already live under .github/instructions/.
         agents_md = temp_project / "AGENTS.md"
-        assert agents_md.exists(), "AGENTS.md not generated"
+        assert not agents_md.exists(), (
+            "AGENTS.md should not be generated for Copilot-only instructions"
+        )
+        assert instruction.exists(), "Copilot instruction file not preserved"
 
         # Verify skill was integrated to .agents/skills/
         skill_integrated = temp_project / ".agents" / "skills" / "brand-guidelines" / "SKILL.md"

--- a/tests/integration/test_wave4_pure_logic_coverage.py
+++ b/tests/integration/test_wave4_pure_logic_coverage.py
@@ -972,7 +972,7 @@ class TestUnpackBundle:
 
         output_dir = tmp_path / "output"
         output_dir.mkdir()
-        with pytest.raises(ValueError, match=r"symlink"):
+        with pytest.raises(ValueError, match=r"Symlinks and hard links are not supported"):
             unpack_bundle(tar_path, output_dir=output_dir)
 
     def test_unpack_legacy_lockfile_name(self, tmp_path: Path) -> None:

--- a/tests/integration/test_wave7_policy_registry_coverage.py
+++ b/tests/integration/test_wave7_policy_registry_coverage.py
@@ -1151,7 +1151,7 @@ class TestMCPServerOperationsCollectEnvVars:
         result = ops.collect_environment_variables(["srv"], server_info_cache=cache)
         assert result.get("MY_TOKEN") == "secret-value"
 
-    def test_e2e_mode_detected(self, monkeypatch, _no_cache_env):
+    def test_e2e_mode_omits_optional_env_without_value(self, monkeypatch, _no_cache_env):
         from apm_cli.registry.operations import MCPServerOperations
 
         monkeypatch.setenv("APM_E2E_TESTS", "1")
@@ -1174,7 +1174,7 @@ class TestMCPServerOperationsCollectEnvVars:
             }
         }
         result = ops.collect_environment_variables(["srv"], server_info_cache=cache)
-        assert result.get("GITHUB_DYNAMIC_TOOLSETS") == "1"
+        assert "GITHUB_DYNAMIC_TOOLSETS" not in result
 
 
 class TestMCPServerOperationsCollectRuntimeVars:
@@ -1761,7 +1761,7 @@ class TestResolveMarketplacePlugin:
             [{"name": "my-plugin", "source": "./plugins/my-plugin", "description": "A plugin"}]
         )
 
-        with patch("requests.get") as mock_get:
+        with patch("apm_cli.marketplace.client._HTTP_SESSION.get") as mock_get:
             mock_get.return_value = _FakeResponse(manifest_data)
             result = resolve_marketplace_plugin("my-plugin", "test-market")
 
@@ -1780,7 +1780,7 @@ class TestResolveMarketplacePlugin:
             ]
         )
 
-        with patch("requests.get") as mock_get:
+        with patch("apm_cli.marketplace.client._HTTP_SESSION.get") as mock_get:
             mock_get.return_value = _FakeResponse(manifest_data)
             result = resolve_marketplace_plugin("ext-plugin", "test-market")
 
@@ -1794,7 +1794,7 @@ class TestResolveMarketplacePlugin:
             [{"name": "existing-plugin", "source": "./plugins/existing"}]
         )
 
-        with patch("requests.get") as mock_get:
+        with patch("apm_cli.marketplace.client._HTTP_SESSION.get") as mock_get:
             mock_get.return_value = _FakeResponse(manifest_data)
             with pytest.raises(PluginNotFoundError):
                 resolve_marketplace_plugin("nonexistent-plugin", "test-market")
@@ -1816,7 +1816,7 @@ class TestResolveMarketplacePlugin:
             ]
         )
 
-        with patch("requests.get") as mock_get:
+        with patch("apm_cli.marketplace.client._HTTP_SESSION.get") as mock_get:
             mock_get.return_value = _FakeResponse(manifest_data)
             result = resolve_marketplace_plugin("versioned", "test-market", version_spec="v2.5.0")
 
@@ -1845,7 +1845,7 @@ class TestResolveMarketplacePlugin:
             ]
         )
         warnings_emitted: list[str] = []
-        with patch("requests.get") as mock_get:
+        with patch("apm_cli.marketplace.client._HTTP_SESSION.get") as mock_get:
             mock_get.return_value = _FakeResponse(manifest_data)
             result = resolve_marketplace_plugin(
                 "versioned",
@@ -1862,7 +1862,7 @@ class TestResolveMarketplacePlugin:
             [{"name": "iter-plugin", "source": "./plugins/iter-plugin"}]
         )
 
-        with patch("requests.get") as mock_get:
+        with patch("apm_cli.marketplace.client._HTTP_SESSION.get") as mock_get:
             mock_get.return_value = _FakeResponse(manifest_data)
             canonical, plugin = resolve_marketplace_plugin("iter-plugin", "test-market")
 

--- a/uv.lock
+++ b/uv.lock
@@ -201,7 +201,7 @@ wheels = [
 
 [[package]]
 name = "apm-cli"
-version = "0.19.0"
+version = "0.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## TL;DR

Fixes two stale assertions in the **release-validation shell harness** (`scripts/test-release-validation.sh` + Windows `.ps1`) that are blocking the `v0.20.0` release. Same root PRs as the #1757 integration fixes; these just live in a separate, shell-based test surface that per-PR CI never runs.

## Why the v0.20.0 release is still red

The harness keeps its **own copies** of behavior assertions that duplicate the integration suite, testing the shipped binary in isolation. Two went stale this cycle from intentional behavior changes:

| Check | Root PR | Old (stale) assertion | New behavior |
|-------|---------|----------------------|--------------|
| GH-AW compat | #1720 | grepped only `build/*.tar.gz` | `apm pack --archive` now emits `.zip` by default |
| Hero scenario 2 / AGENTS.md | #1742 | insisted `AGENTS.md` exists | copilot `apm compile` omits the empty AGENTS.md shell when instructions already live under `.github/instructions/` |

This is why release run `27375730381` showed integration **passing** on all platforms (the #1757 fix worked) but **Release Validation (Linux)** + **Build & Validate (macOS)** failing at "4/6 tests passed".

## What changed

- **`scripts/test-release-validation.sh`** (Linux + macOS):
  - Archive check: accept `build/*.zip` OR `build/*.tar.gz`. Tests each glob independently because a single `ls a b` exits non-zero when *either* pattern is unmatched (caught during local validation).
  - AGENTS.md check: success if `AGENTS.md` exists, ELSE success if `.github/instructions/*.md` exist, ELSE error. Mirrors the merged pytest fix in `test_guardrailing_hero_e2e.py`.
- **`scripts/windows/test-release-validation.ps1`**: same AGENTS.md logic in PowerShell (it has no archive check).

## Validation

- Both predicates validated locally against `apm v0.20.0`: produced `.zip` matches the OR-glob; instructions/AGENTS.md branches both pass.
- The merged pytest guardrailing e2e (copilot target) already asserts the `.github/instructions/` shape and passes.
- Full CI-mirror lint chain green (ruff check/format, pylint R0801, auth-signals). `scripts/` is not ruff-targeted, but the chain confirms no src drift.
- ASCII-clean in all edited regions.

## After merge

The `v0.20.0` tag must be re-pointed to this commit's successor on `main` and re-pushed to re-trigger the release pipeline. I will **confirm with the operator before re-tagging** rather than auto-retag.