### PR TITLE
fix: restore devDependencies.mcp on apm install (closes #1780)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `apm marketplace doctor` subcommand alias (deprecated); use `apm doctor` instead. (#1134)
 ### Fixed
 
-- `apm install` now restores MCP servers declared in `devDependencies.mcp`, keeping dev MCP configs and lockfile entries in sync on fresh installs. (closes #1780)
+- `apm install` now restores MCP servers declared in `devDependencies.mcp`, keeping dev MCP configs and lockfile entries in sync on fresh installs. (closes #1780) (#1787)
 - `apm install` now removes orphaned skill directories when a package is uninstalled or its skills are renamed. Previously, individual files were deleted but the skill folder remained with a "Refused to remove directory entry" warning. (closes #1483) (#1767)
 
 ## [0.20.0] - 2026-06-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `apm marketplace doctor` subcommand alias (deprecated); use `apm doctor` instead. (#1134)
 ### Fixed
 
+- `apm install` now restores MCP servers declared in `devDependencies.mcp`, keeping dev MCP configs and lockfile entries in sync on fresh installs. (closes #1780)
 - `apm install` now removes orphaned skill directories when a package is uninstalled or its skills are renamed. Previously, individual files were deleted but the skill folder remained with a "Refused to remove directory entry" warning. (closes #1483) (#1767)
 
 ## [0.20.0] - 2026-06-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `apm marketplace doctor` subcommand alias (deprecated); use `apm doctor` instead. (#1134)
 ### Fixed
 
-- `apm install` now restores MCP servers declared in `devDependencies.mcp`, keeping dev MCP configs and lockfile entries in sync on fresh installs. (closes #1780) (#1787)
+- `apm install` no longer silently ignores MCP servers declared in `devDependencies.mcp`; dev MCP configs and lockfile entries now stay in sync on fresh installs. (closes #1780) (#1787)
 - `apm install` now removes orphaned skill directories when a package is uninstalled or its skills are renamed. Previously, individual files were deleted but the skill folder remained with a "Refused to remove directory entry" warning. (closes #1483) (#1767)
 
 ## [0.20.0] - 2026-06-11

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -1673,13 +1673,20 @@ def _install_apm_packages(ctx, outcome):
             if apm_package.get_dev_apm_dependencies()
             else ""
         )
+        + (
+            f", {len(apm_package.get_dev_mcp_dependencies())} dev MCP deps"
+            if apm_package.get_dev_mcp_dependencies()
+            else ""
+        )
     )
 
     # Get APM and MCP dependencies
     apm_deps = apm_package.get_apm_dependencies()
     dev_apm_deps = apm_package.get_dev_apm_dependencies()
     has_any_apm_deps = bool(apm_deps) or bool(dev_apm_deps)
-    mcp_deps = apm_package.get_mcp_dependencies()
+    mcp_deps = list(apm_package.get_mcp_dependencies()) + list(
+        apm_package.get_dev_mcp_dependencies()
+    )
 
     all_apm_deps = list(apm_deps) + list(dev_apm_deps)
     _check_insecure_dependencies(all_apm_deps, ctx.allow_insecure, logger)

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -1665,28 +1665,20 @@ def _install_apm_packages(ctx, outcome):
         logger.error(f"Failed to parse {ctx.manifest_display}: {e}")
         sys.exit(1)
 
-    logger.verbose_detail(
-        f"Parsed {APM_YML_FILENAME}: {len(apm_package.get_apm_dependencies())} APM deps, "
-        f"{len(apm_package.get_mcp_dependencies())} MCP deps"
-        + (
-            f", {len(apm_package.get_dev_apm_dependencies())} dev deps"
-            if apm_package.get_dev_apm_dependencies()
-            else ""
-        )
-        + (
-            f", {len(apm_package.get_dev_mcp_dependencies())} dev MCP deps"
-            if apm_package.get_dev_mcp_dependencies()
-            else ""
-        )
-    )
-
-    # Get APM and MCP dependencies
     apm_deps = apm_package.get_apm_dependencies()
     dev_apm_deps = apm_package.get_dev_apm_dependencies()
-    has_any_apm_deps = bool(apm_deps) or bool(dev_apm_deps)
-    mcp_deps = list(apm_package.get_mcp_dependencies()) + list(
-        apm_package.get_dev_mcp_dependencies()
+    prod_mcp_deps = apm_package.get_mcp_dependencies()
+    dev_mcp_deps = apm_package.get_dev_mcp_dependencies()
+    mcp_deps = apm_package.get_all_mcp_dependencies()
+
+    logger.verbose_detail(
+        f"Parsed {APM_YML_FILENAME}: {len(apm_deps)} APM deps, "
+        f"{len(prod_mcp_deps)} MCP deps"
+        + (f", {len(dev_apm_deps)} dev APM deps" if dev_apm_deps else "")
+        + (f", {len(dev_mcp_deps)} dev MCP deps" if dev_mcp_deps else "")
     )
+
+    has_any_apm_deps = bool(apm_deps) or bool(dev_apm_deps)
 
     all_apm_deps = list(apm_deps) + list(dev_apm_deps)
     _check_insecure_dependencies(all_apm_deps, ctx.allow_insecure, logger)
@@ -1900,7 +1892,6 @@ def _install_apm_packages(ctx, outcome):
             logger.render_summary()
             sys.exit(1)
 
-    # Continue with MCP installation (existing logic)
     mcp_count = 0
     new_mcp_servers: builtins.set = builtins.set()
     # Forward only the targets-key the user actually declared so parse_targets_field

--- a/src/apm_cli/install/pipeline.py
+++ b/src/apm_cli/install/pipeline.py
@@ -573,7 +573,9 @@ def run_install_pipeline(  # noqa: PLR0913, RUF100
 
         # Populate direct MCP deps from the manifest so the policy gate
         # can enforce MCP allow/deny rules on them (S2 fix).
-        ctx.direct_mcp_deps = apm_package.get_mcp_dependencies()
+        ctx.direct_mcp_deps = list(apm_package.get_mcp_dependencies()) + list(
+            apm_package.get_dev_mcp_dependencies()
+        )
 
         # Populate direct LSP deps from the manifest for LSP integration.
         ctx.direct_lsp_deps = apm_package.get_lsp_dependencies()

--- a/src/apm_cli/install/pipeline.py
+++ b/src/apm_cli/install/pipeline.py
@@ -573,9 +573,7 @@ def run_install_pipeline(  # noqa: PLR0913, RUF100
 
         # Populate direct MCP deps from the manifest so the policy gate
         # can enforce MCP allow/deny rules on them (S2 fix).
-        ctx.direct_mcp_deps = list(apm_package.get_mcp_dependencies()) + list(
-            apm_package.get_dev_mcp_dependencies()
-        )
+        ctx.direct_mcp_deps = apm_package.get_all_mcp_dependencies()
 
         # Populate direct LSP deps from the manifest for LSP integration.
         ctx.direct_lsp_deps = apm_package.get_lsp_dependencies()

--- a/src/apm_cli/models/apm_package.py
+++ b/src/apm_cli/models/apm_package.py
@@ -533,6 +533,10 @@ class APMPackage:
             if isinstance(dep, MCPDependency)
         ]
 
+    def get_all_mcp_dependencies(self) -> list["MCPDependency"]:
+        """Get production and dev MCP dependencies in manifest order."""
+        return self.get_mcp_dependencies() + self.get_dev_mcp_dependencies()
+
     def get_lsp_dependencies(self) -> list["LSPDependency"]:
         """Get list of LSP dependencies."""
         if not self.dependencies or "lsp" not in self.dependencies:

--- a/tests/integration/test_mcp_install_flow.py
+++ b/tests/integration/test_mcp_install_flow.py
@@ -8,11 +8,16 @@ Strategy: hermetic -- mocks registry, runtime, console.
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
+from click.testing import CliRunner
 
+from apm_cli.cli import cli
 from apm_cli.core.null_logger import NullCommandLogger
+from apm_cli.deps.lockfile import LockFile
 from apm_cli.integration.mcp_integrator_install import run_mcp_install
 
 # ---------------------------------------------------------------------------
@@ -45,6 +50,48 @@ def _make_self_defined_dep(
     dep.transport = transport
     dep.env = env or {}
     return dep
+
+
+def test_install_restores_dev_mcp_dependencies_to_lockfile_and_config(tmp_path, monkeypatch):
+    """apm install restores dev MCP servers to runtime config and lockfile."""
+    monkeypatch.chdir(tmp_path)
+    LockFile().write(tmp_path / "apm.lock.yaml")
+    (tmp_path / "apm.yml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "dev-mcp-project",
+                "version": "0.0.1",
+                "target": "copilot",
+                "dependencies": {"apm": [], "mcp": []},
+                "devDependencies": {
+                    "mcp": [
+                        {
+                            "name": "dev-server",
+                            "registry": False,
+                            "transport": "stdio",
+                            "command": "python",
+                            "args": ["-m", "dev_server"],
+                        }
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(cli, ["install", "--runtime", "vscode", "--target", "copilot"])
+
+    assert result.exit_code == 0, result.output
+    config = json.loads((tmp_path / ".vscode" / "mcp.json").read_text(encoding="utf-8"))
+    assert config["servers"]["dev-server"] == {
+        "type": "stdio",
+        "command": "python",
+        "args": ["-m", "dev_server"],
+    }
+    lockfile = LockFile.read(tmp_path / "apm.lock.yaml")
+    assert lockfile is not None
+    assert lockfile.mcp_servers == ["dev-server"]
+    assert lockfile.mcp_configs["dev-server"]["command"] == "python"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_install_command.py
+++ b/tests/unit/test_install_command.py
@@ -580,6 +580,41 @@ class TestTransitiveDepParentChain:
 class TestDownloadCallbackErrorMessages:
     """Tests for direct vs transitive dep error message differentiation."""
 
+    def test_install_processes_dev_mcp_dependencies(self, tmp_path, monkeypatch):
+        """apm install restores MCP servers declared under devDependencies.mcp."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "apm.yml").write_text(
+            yaml.safe_dump(
+                {
+                    "name": "test-project",
+                    "version": "0.0.1",
+                    "dependencies": {"apm": [], "mcp": []},
+                    "devDependencies": {
+                        "mcp": [
+                            {
+                                "name": "test-server",
+                                "registry": False,
+                                "transport": "stdio",
+                                "command": "echo",
+                                "args": ["test"],
+                            }
+                        ]
+                    },
+                }
+            )
+        )
+
+        with (
+            patch("apm_cli.commands.install.MCPIntegrator.install", return_value=1) as install,
+            patch("apm_cli.commands.install.MCPIntegrator.update_lockfile"),
+        ):
+            result = CliRunner().invoke(cli, ["install"])
+
+        assert result.exit_code == 0, result.output
+        assert install.call_count == 1
+        installed_deps = install.call_args.args[0]
+        assert [dep.name for dep in installed_deps] == ["test-server"]
+
     def test_direct_dep_failure_says_download_dependency(self, tmp_path, monkeypatch):
         """Direct dependency failure uses 'Failed to download dependency', not 'transitive dep'."""
         from apm_cli.commands.install import _install_apm_dependencies

--- a/tests/unit/test_install_command.py
+++ b/tests/unit/test_install_command.py
@@ -577,8 +577,8 @@ class TestTransitiveDepParentChain:
         assert ">" in chain, f"Expected '>' separator in chain, got: '{chain}'"
 
 
-class TestDownloadCallbackErrorMessages:
-    """Tests for direct vs transitive dep error message differentiation."""
+class TestDevMcpDependenciesInstall:
+    """Tests for restoring MCP servers declared as dev dependencies."""
 
     def test_install_processes_dev_mcp_dependencies(self, tmp_path, monkeypatch):
         """apm install restores MCP servers declared under devDependencies.mcp."""
@@ -614,6 +614,10 @@ class TestDownloadCallbackErrorMessages:
         assert install.call_count == 1
         installed_deps = install.call_args.args[0]
         assert [dep.name for dep in installed_deps] == ["test-server"]
+
+
+class TestDownloadCallbackErrorMessages:
+    """Tests for direct vs transitive dep error message differentiation."""
 
     def test_direct_dep_failure_says_download_dependency(self, tmp_path, monkeypatch):
         """Direct dependency failure uses 'Failed to download dependency', not 'transitive dep'."""

--- a/tests/unit/test_install_pipeline_orchestration.py
+++ b/tests/unit/test_install_pipeline_orchestration.py
@@ -157,6 +157,7 @@ class TestRunInstallPipelineDirectMcpDeps:
         pkg.get_dev_apm_dependencies.return_value = []
         pkg.get_mcp_dependencies.return_value = [prod_mcp]
         pkg.get_dev_mcp_dependencies.return_value = [dev_mcp]
+        pkg.get_all_mcp_dependencies.return_value = [prod_mcp, dev_mcp]
         pkg.get_lsp_dependencies.return_value = []
         seen_direct_mcp_deps = []
 

--- a/tests/unit/test_install_pipeline_orchestration.py
+++ b/tests/unit/test_install_pipeline_orchestration.py
@@ -143,6 +143,50 @@ class TestRunInstallPipelineShortCircuit:
         logger.nothing_to_install.assert_called_once()
 
 
+class TestRunInstallPipelineDirectMcpDeps:
+    """MCP policy preflight sees the same root MCP set that install restores."""
+
+    def test_policy_gate_receives_dev_mcp_dependencies(self, tmp_path):
+        from apm_cli.install.pipeline import run_install_pipeline
+
+        apm_dep = MagicMock()
+        prod_mcp = MagicMock()
+        dev_mcp = MagicMock()
+        pkg = MagicMock()
+        pkg.get_apm_dependencies.return_value = [apm_dep]
+        pkg.get_dev_apm_dependencies.return_value = []
+        pkg.get_mcp_dependencies.return_value = [prod_mcp]
+        pkg.get_dev_mcp_dependencies.return_value = [dev_mcp]
+        pkg.get_lsp_dependencies.return_value = []
+        seen_direct_mcp_deps = []
+
+        def _phase_runner(name, _phase, ctx):
+            if name == "resolve":
+                ctx.deps_to_install = [apm_dep]
+                ctx.transitive_failures = []
+                return None
+            if name == "policy_gate":
+                seen_direct_mcp_deps.extend(ctx.direct_mcp_deps)
+                raise RuntimeError("stop after policy gate")
+            return None
+
+        with (
+            patch("apm_cli.core.scope.get_deploy_root", return_value=tmp_path),
+            patch("apm_cli.core.scope.get_source_root", return_value=tmp_path),
+            patch("apm_cli.core.scope.get_apm_dir", return_value=tmp_path),
+            patch(
+                "apm_cli.install.phases.local_content._project_has_root_primitives",
+                return_value=False,
+            ),
+            patch("apm_cli.deps.lockfile.LockFile.read", return_value=None),
+            patch("apm_cli.install.pipeline._run_phase", side_effect=_phase_runner),
+        ):
+            with pytest.raises(RuntimeError, match="stop after policy gate"):
+                run_install_pipeline(pkg)
+
+        assert seen_direct_mcp_deps == [prod_mcp, dev_mcp]
+
+
 # ---------------------------------------------------------------------------
 # run_install_pipeline -- plan_callback
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
apm install now includes root devDependencies.mcp entries in the MCP restore set and in the pipeline policy direct MCP set, so fresh installs restore dev MCP servers instead of dropping them from runtime config and lockfile state. How to test: uv run --extra dev pytest tests/unit/test_install_command.py tests/unit/test_install_pipeline_orchestration.py tests/unit/install/test_pipeline_preflight.py tests/unit/install/test_policy_gate_phase.py -q; uv run --extra dev ruff check src/ tests/; uv run --extra dev ruff format --check src/ tests/. closes #1780