### PR TITLE
feat(policy): declarable integrity keys (require_hashes, fail_on_drift)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Two additive, default-off policy keys under the existing `security:` namespace: `security.integrity.require_hashes` makes `apm install` fail closed when any non-local lockfile entry lacks a content hash, and `security.audit.fail_on_drift` makes `apm audit` exit non-zero when the workspace drifts from the lockfile. Both only tighten through policy inheritance. (#PRNUMBER)
+- Two additive, default-off policy keys under the existing `security:` namespace: `security.integrity.require_hashes` makes `apm install` fail closed when any non-local lockfile entry lacks a content hash, and `security.audit.fail_on_drift` makes `apm audit` exit non-zero when the workspace drifts from the lockfile. Both only tighten through policy inheritance. (#1794)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Two additive, default-off policy keys under the existing `security:` namespace: `security.integrity.require_hashes` makes `apm install` fail closed when any non-local lockfile entry lacks a content hash, and `security.audit.fail_on_drift` makes `apm audit` exit non-zero when the workspace drifts from the lockfile. Both only tighten through policy inheritance. (#PRNUMBER)
+
 ### Removed
 
 - `apm marketplace publish` command and consumer-repo fan-out workflow; consumers should run `apm install --update` instead. (#1134)

--- a/CONFORMANCE.json
+++ b/CONFORMANCE.json
@@ -621,6 +621,28 @@
       ]
     },
     {
+      "conformance_class": "governance",
+      "id": "req-pl-013",
+      "keyword": "MUST",
+      "section": "6.8",
+      "status": "active",
+      "test_count": 1,
+      "tests": [
+        "tests/spec_conformance/test_policy_reqs.py::test_policy_require_hashes_parses_and_is_specified"
+      ]
+    },
+    {
+      "conformance_class": "governance",
+      "id": "req-pl-014",
+      "keyword": "MUST",
+      "section": "6.8",
+      "status": "active",
+      "test_count": 1,
+      "tests": [
+        "tests/spec_conformance/test_policy_reqs.py::test_policy_fail_on_drift_parses_and_is_specified"
+      ]
+    },
+    {
       "conformance_class": "consumer",
       "id": "req-pr-001",
       "keyword": "MUST",
@@ -997,7 +1019,7 @@
       "xfail": 0
     },
     "governance": {
-      "active": 12,
+      "active": 14,
       "skipped": 0,
       "unbound": 0,
       "xfail": 0
@@ -1015,5 +1037,5 @@
       "xfail": 0
     }
   },
-  "total_requirements": 87
+  "total_requirements": 89
 }

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -21,7 +21,7 @@ All four conformance classes (Producer, Consumer, Registry, Governance) carry ac
 | Producer | 12 | 0 | 0 | 0 |
 | Consumer | 61 | 1 | 0 | 0 |
 | Registry | 1 | 0 | 0 | 0 |
-| Governance | 12 | 0 | 0 | 0 |
+| Governance | 14 | 0 | 0 | 0 |
 
 ## Per-requirement coverage
 
@@ -82,6 +82,8 @@ All four conformance classes (Producer, Consumer, Registry, Governance) carry ac
 | [req-pl-010](docs/src/content/docs/specs/openapm-v0.1.md#req-pl-010) | MUST | 6.2 | governance | active | 1 |
 | [req-pl-011](docs/src/content/docs/specs/openapm-v0.1.md#req-pl-011) | MUST | 6.1.1 | governance | active | 1 |
 | [req-pl-012](docs/src/content/docs/specs/openapm-v0.1.md#req-pl-012) | MUST | 6.1.1 | governance | active | 1 |
+| [req-pl-013](docs/src/content/docs/specs/openapm-v0.1.md#req-pl-013) | MUST | 6.8 | governance | active | 1 |
+| [req-pl-014](docs/src/content/docs/specs/openapm-v0.1.md#req-pl-014) | MUST | 6.8 | governance | active | 1 |
 | [req-pr-001](docs/src/content/docs/specs/openapm-v0.1.md#req-pr-001) | MUST | 8.2 | consumer | active | 1 |
 | [req-pr-002](docs/src/content/docs/specs/openapm-v0.1.md#req-pr-002) | MUST | 8.3 | consumer | active | 1 |
 | [req-pr-003](docs/src/content/docs/specs/openapm-v0.1.md#req-pr-003) | MUST | 8.3 | consumer | active | 1 |

--- a/docs/public/specs/manifests/openapm-v0.1.requirements.yml
+++ b/docs/public/specs/manifests/openapm-v0.1.requirements.yml
@@ -235,6 +235,14 @@ requirements:
     keyword: MUST
     section: "6.1.1"
     conformance_class: governance
+  - id: req-pl-013
+    keyword: MUST
+    section: "6.8"
+    conformance_class: governance
+  - id: req-pl-014
+    keyword: MUST
+    section: "6.8"
+    conformance_class: governance
   - id: req-rs-001
     keyword: MUST
     section: "7.2"

--- a/docs/src/content/docs/reference/policy-schema.md
+++ b/docs/src/content/docs/reference/policy-schema.md
@@ -163,6 +163,8 @@ experimental flag to take effect; ignored otherwise.
 | `audit.on_install`   | enum or null    | `null`  | `off` / `warn` / `block`. Minimum install-time audit mode (a **floor**). `null` = no opinion. `warn` records findings; `block` halts installs on critical findings. |
 | `audit.external`     | list of strings | `null`  | External SARIF scanner names (e.g. `skillspector`) that MUST run during the install audit. A required scanner that is unavailable fails the install closed. |
 | `audit.scanners`     | mapping or null | `null`  | Per-scanner governance, keyed by scanner name. Each value accepts `allow_args` (boolean). **Restrict-only**: see below. Unknown scanner names are a warning, not an error (forward-compat). |
+| `audit.fail_on_drift` | boolean        | `false` | When `true`, a bare `apm audit` exits non-zero if the workspace content has drifted from the lockfile. Default-off keeps drift advisory (rendered, exit 0). Only changes the exit code -- the drift scan itself is unchanged. `apm audit --ci` already gates on drift regardless of this key. |
+| `integrity.require_hashes` | boolean   | `false` | When `true`, every non-local lockfile entry MUST carry a content hash; a missing or empty hash **fails the install closed**. Default-off preserves current behavior. Asserts hash-presence on the lockfile entry (no second hashing pass). Local dependencies are exempt (verified via deployed-file hashes). |
 
 ### Per-scanner governance (`audit.scanners`)
 
@@ -194,6 +196,23 @@ allowlist validation for arg safety.
 `apm install --audit` / `apm config audit-on-install`, never relax it. `apm
 install --force` downgrades a `block` to `warn` for that invocation; `apm
 install --no-policy` skips the policy floor entirely.
+
+### Integrity and drift enforcement
+
+```yaml
+security:
+  integrity:
+    require_hashes: true    # fail the install if any locked entry lacks a hash
+  audit:
+    fail_on_drift: true     # `apm audit` exits non-zero on workspace drift
+```
+
+Both keys are additive, optional, and default off. `require_hashes` is
+enforced during `apm install` (the lockfile must record a content hash for
+every non-local entry, or the install fails closed). `fail_on_drift` is
+enforced by `apm audit`: when drift is detected it escalates the exit code to
+`1`. Both keys only ever tighten -- a child policy cannot relax a parent that
+turned them on.
 
 ## Inheritance
 
@@ -230,6 +249,8 @@ inherited list (see the tri-state table below).
 | `security.audit.on_install` | Stricter wins (`block` > `warn` > `off`). `null` is transparent.                 |
 | `security.audit.external`   | Union, deduplicated. `null` is transparent.                                      |
 | `security.audit.scanners`   | Union of scanner names; per scanner `allow_args` is AND-merged (any ancestor `false` wins -- tightening). `null` is transparent.                  |
+| `security.audit.fail_on_drift` | Logical OR -- once a parent enables it, a child cannot relax.                  |
+| `security.integrity.require_hashes` | Logical OR -- once a parent enables it, a child cannot relax.             |
 | `compilation.*.enforce`     | First non-null wins (parent precedence).                                         |
 | `compilation.source_attribution` | Logical OR.                                                                 |
 

--- a/docs/src/content/docs/specs/openapm-v0.1.md
+++ b/docs/src/content/docs/specs/openapm-v0.1.md
@@ -1229,8 +1229,9 @@ behaves exactly as it did before these keys existed.
 - `security.integrity.require_hashes` (boolean, default `false`):
   when `true`, the install operation fails closed if any resolved
   non-local dependency selected for installation lacks a recorded
-  integrity hash in `apm.lock.yaml`. Local dependencies are exempt
-  (they are anchored by deployed-file hashes, not a package digest).
+  content hash (the `content_hash` lockfile field) in `apm.lock.yaml`.
+  Local dependencies are exempt (they are anchored by deployed-file
+  hashes, not a package digest).
 - `security.audit.fail_on_drift` (boolean, default `false`): when
   `true`, a bare `apm audit` exits non-zero if lockfile drift is
   detected or the drift check cannot complete.
@@ -1342,7 +1343,8 @@ is unaffected.
 honours `security.integrity.require_hashes: true` MUST fail the
 install operation with a fail-closed diagnostic when any resolved
 non-local dependency selected for installation lacks a recorded
-integrity hash in `apm.lock.yaml`. The same fail-closed behaviour
+content hash (the `content_hash` lockfile field) in `apm.lock.yaml`.
+The same fail-closed behaviour
 MUST hold when the lockfile is absent or unreadable at the point of
 the check. Local dependencies are exempt; they are anchored by
 deployed-file hashes rather than a package content hash.

--- a/docs/src/content/docs/specs/openapm-v0.1.md
+++ b/docs/src/content/docs/specs/openapm-v0.1.md
@@ -136,7 +136,7 @@ between the companion corpus and the implementation.
 
 ### 1.3 Document conventions
 
-- OpenAPM v0.1 carries **87 normative statements** indexed in
+- OpenAPM v0.1 carries **89 normative statements** indexed in
   [Appendix C](#appendix-c-index-of-normative-statements).
 - All on-disk files defined by this specification are **YAML 1.2**
   parsed under the safe subset defined in
@@ -1220,6 +1220,27 @@ requirement).
 The `unmanaged_files` block governs files in primitive target
 directories that are not recorded in `apm.lock.yaml`.
 
+#### 6.3.6 `security`
+
+The `security` block declares opt-in supply-chain controls. Every
+key defaults to `false` (off), so a policy that omits the block
+behaves exactly as it did before these keys existed.
+
+- `security.integrity.require_hashes` (boolean, default `false`):
+  when `true`, the install operation fails closed if any resolved
+  non-local dependency selected for installation lacks a recorded
+  integrity hash in `apm.lock.yaml`. Local dependencies are exempt
+  (they are anchored by deployed-file hashes, not a package digest).
+- `security.audit.fail_on_drift` (boolean, default `false`): when
+  `true`, a bare `apm audit` exits non-zero if lockfile drift is
+  detected or the drift check cannot complete.
+
+The normative behaviour for both keys is specified in
+[Section 6.8](#68-integrity-controls-governance). Both merge by
+logical OR across an `extends:` chain (see
+[Section 6.4](#64-inheritance-and-merge-rules)): once any ancestor
+sets a key to `true`, a descendant cannot relax it back to `false`.
+
 ### 6.4 Inheritance and merge rules
 
 Policies form a chain via `extends:`.
@@ -1255,6 +1276,8 @@ merge a policy chain per the following table:
 | `mcp.trust_transitive`                | Logical AND.                                                           |
 | `manifest.scripts`                    | Stricter wins (`deny` > `allow`).                                      |
 | `unmanaged_files.action`              | Stricter wins (`deny` > `warn` > `ignore`).                            |
+| `security.integrity.require_hashes`   | Logical OR (once `true`, stays `true`).                                |
+| `security.audit.fail_on_drift`        | Logical OR (once `true`, stays `true`).                                |
 
 ### 6.5 Allow-list / deny-list tri-state semantics
 
@@ -1308,7 +1331,34 @@ manifest:
     - license
 ```
 
-### 6.8 Conformance requirements (governance)
+### 6.8 Integrity controls (governance)
+
+The `security.integrity` and `security.audit` blocks declare opt-in,
+fail-closed controls. Both are default-off; a policy that omits them
+is unaffected.
+
+<a id="req-pl-013"></a>
+**[req-pl-013]** A conforming **governance** implementation that
+honours `security.integrity.require_hashes: true` MUST fail the
+install operation with a fail-closed diagnostic when any resolved
+non-local dependency selected for installation lacks a recorded
+integrity hash in `apm.lock.yaml`. The same fail-closed behaviour
+MUST hold when the lockfile is absent or unreadable at the point of
+the check. Local dependencies are exempt; they are anchored by
+deployed-file hashes rather than a package content hash.
+
+<a id="req-pl-014"></a>
+**[req-pl-014]** A conforming **governance** implementation that
+honours `security.audit.fail_on_drift: true` MUST cause the audit
+operation to terminate with a non-zero exit status when lockfile
+drift is detected, or when the drift check fails to complete (for
+example, an unreadable or corrupt local dependency graph). A drift
+check that is merely skipped for an advisory reason, such as a cache
+miss, does not by itself alter the exit status. When
+`security.audit.fail_on_drift` is absent or `false`, detected drift
+MUST be reported without, by itself, altering the audit exit status.
+
+### 6.9 Conformance requirements (governance)
 
 This section's normative statements are:
 
@@ -1317,7 +1367,8 @@ This section's normative statements are:
   [req-pl-005](#req-pl-005), [req-pl-006](#req-pl-006),
   [req-pl-007](#req-pl-007), [req-pl-008](#req-pl-008),
   [req-pl-009](#req-pl-009), [req-pl-010](#req-pl-010),
-  [req-pl-011](#req-pl-011), [req-pl-012](#req-pl-012).
+  [req-pl-011](#req-pl-011), [req-pl-012](#req-pl-012),
+  [req-pl-013](#req-pl-013), [req-pl-014](#req-pl-014).
 
 ---
 
@@ -2221,7 +2272,7 @@ own pack).
 Section-level conformance summaries
 ([Section 4.9](#49-conformance-requirements-manifest),
 [Section 5.7](#57-conformance-requirements-lockfile),
-[Section 6.8](#68-conformance-requirements-governance),
+[Section 6.9](#69-conformance-requirements-governance),
 [Section 7.11](#711-conformance-requirements-resolution),
 [Section 8.7](#87-conformance-requirements-primitives-and-targets))
 are reader-aids that restate the Appendix C rows for the section's
@@ -2310,7 +2361,8 @@ v0.2 will formalise the surrounding HTTP wire envelope.
 [req-pl-005](#req-pl-005), [req-pl-006](#req-pl-006),
 [req-pl-007](#req-pl-007), [req-pl-008](#req-pl-008),
 [req-pl-009](#req-pl-009), [req-pl-010](#req-pl-010),
-[req-pl-011](#req-pl-011), [req-pl-012](#req-pl-012).
+[req-pl-011](#req-pl-011), [req-pl-012](#req-pl-012),
+[req-pl-013](#req-pl-013), [req-pl-014](#req-pl-014).
 
 ### 11.4 Worked conformance examples (informative)
 
@@ -2656,6 +2708,8 @@ renumbering of conformance classes.
 | [req-pl-010](#req-pl-010)                | MUST    | 6.2     | governance  |
 | [req-pl-011](#req-pl-011)                | MUST    | 6.1.1   | governance  |
 | [req-pl-012](#req-pl-012)                | MUST    | 6.1.1   | governance  |
+| [req-pl-013](#req-pl-013)                | MUST    | 6.8     | governance  |
+| [req-pl-014](#req-pl-014)                | MUST    | 6.8     | governance  |
 | [req-rs-001](#req-rs-001)                | MUST    | 7.2     | consumer    |
 | [req-rs-002](#req-rs-002)                | MUST    | 7.3     | consumer    |
 | [req-rs-003](#req-rs-003)                | MUST    | 7.3     | consumer    |
@@ -2691,7 +2745,7 @@ renumbering of conformance classes.
 | [req-cf-001](#req-cf-001)                | MUST    | 12.5    | consumer    |
 | [req-cf-002](#req-cf-002)                | MUST    | 12.3    | consumer    |
 
-**Total normative statements: 87** (82 MUST, 5 SHOULD).
+**Total normative statements: 89** (84 MUST, 5 SHOULD).
 
 ---
 
@@ -2703,6 +2757,7 @@ renumbering of conformance classes.
 | 0.1-r2  | 2026-05-17 | Round-2 adversarial revision. Closed mandatory FOLDs F1-F10: pinned semver dialect (node-semver + semver 2.0.0); tri-modal transitive conflict resolution; vendor-host neutrality (default_host, pluggable policy discovery, host class via PSL+aliases); hash envelope on every stored hash; canonical git tree-hash definition; mirror-tolerant fetch; producer release contract (tag-version alignment, SHOULD-sign); update operation semantics; lockfile_version monotonicity; reserved-slot prose for 11 deferrals (workspaces, x-* extensions, machine-readable conformance, update --aggressive, frozen-default flip, target registry companion, version yank, attestations, registry HTTP, mirror-tolerance, .agents/ partition); inline JSON Schemas in Appendix A; YAML safe subset; archive container binding; credential redaction. Conformance-statement count: 56 -> 83. Companion seed fixture tree shipped under `tests/fixtures/spec-conformance/`. |
 | 0.1.1   | 2026-05-24 | v1.1 editorial+defensive fold. Closed convergent round-2 followups: Section 12.3 CI-binding MUST-for-claim (req-cf-002); req-mf-019 class reclassification (producer -> consumer); three stale heading labels in req-cf-001 and Appendix E.4; depEntry oneOf source-key requirement plus new fixture `manifest/invalid-no-source-key.yml`; normative-count reconciliation across Section 1.3, Appendix C trailer, and this row; bare-hex pattern anchored to exactly 64 hex characters; req-sc-007 redaction scope extended to packed bundles, lockfiles, and audit records, plus producer secret-pattern refuse-to-pack rule; workspaces MUST-NOT-use in v0.1 (req-mf-021); nest-mode reject-in-v0.1 (req-rs-013); tag-name regex tightened to the semver.org 2.0.0 reference grammar; build-metadata tie-break rule (req-rs-014); mirror-tolerance editorial note (replicate-verbatim); req-rg-001 cross-references added in Section 7.5.1 and Section 10.5; bare-hex reader-tolerance deprecation horizon; interoperability informative note Section 6.1.2; conformance-summary precedence rule in Section 11.1; wildcard typo `x.y.x` -> `x.y.z`; resolved_by worked-example fragment in Section 7.4. Statement count: 83 -> 87. Drift-detection scaffolding lands in-spec and in-tree (informative machine-readable manifest at `docs/public/specs/manifests/openapm-v0.1.requirements.yml`; 4-way orphan_check + spec-conformance pytest suite + generated `CONFORMANCE.{md,json}` at repo root); Section 12.3 language updated to identify HTML anchors as the canonical source. No normative count change. |
 | 0.1.2   | 2026-05-28 | Round-3 spec-guardian editorial fold (no new normative statements; statement count remains 87). Section 11.3.2 Consumer enumeration appended `[req-rs-014]` and `[req-cf-002]` (closing drift vs Appendix C). req-lk-005 extended: writers MUST canonicalise the `dependencies` list in ascending lexicographic order of (`repo_url`, `virtual_path`) so frozen-install diffs are stable across implementations. req-sc-003 extended: consumers MUST drop the originating Authorization header before issuing a cross-host-class redirect (closes the mirror-redirect token-leak surface in Section 10.3). req-rg-001 extended with publish-side idempotency clause: a Registry MUST either reject a republish or accept ONLY if bytes are byte-identical to the previously-served bytes. Section 6.2 + Section 6.3.1 defaults pinned: `fetch_failure` defaults to `warn` and `dependencies.require_resolution` defaults to `project-wins` (mirrored as advisory `"default"` annotations in `policy-v0.1.schema.json`). Manifest schema `conflict_resolution` enum aligned to prose: renamed `intersect` -> `intersection-pick`, dropped `nest` from the v0.1 enum (`nest` remains reserved-for-v0.2 per req-rs-013, now noted via schema `$comment`). Mode B silent-extension detector landed in `.github/workflows/spec-conformance.yml` and `tests/spec_conformance/mode_b_detector.sh`; closes the named sole-implementer rot risk by gating PRs that add substantive code under critical paths (`primitives/`, `deps/`, `policy/`, `registry/`, `runtime/`, `install/`, `integration/`) without a spec citation, with auditable `apm-spec-waiver:` opt-out. |
+| 0.1.3   | 2026-06-16 | Spec-citation fold for the declarable integrity policy keys. Added two governance MUSTs under a new Section 6.8 "Integrity controls": [req-pl-013] (`security.integrity.require_hashes` -- fail-closed install when a resolved non-local dependency lacks a recorded hash in `apm.lock.yaml`, or the lockfile is absent/unreadable) and [req-pl-014] (`security.audit.fail_on_drift` -- audit exits non-zero on detected or indeterminate drift). Both keys are default-off and merge by logical OR (tighten-not-relax). Added the non-normative Section 6.3.6 `security` field reference and two merge-table rows; renumbered the governance conformance trailer 6.8 -> 6.9. Statement count: 87 -> 89 (84 MUST, 5 SHOULD). NOTE: a sibling spec-citation amendment also edits the shared count sites (Section 1.3, Appendix C trailer, this revision history); whichever lands second reconciles the cumulative total and takes the union of the added Appendix C rows. |
 
 Errata (none at publication).
 

--- a/packages/apm-guide/.apm/skills/apm-usage/governance.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/governance.md
@@ -90,6 +90,25 @@ The check fires from all four call sites (`policy_gate`,
 `apm install`, `apm install <pkg>`, `apm deps update`, and
 `apm audit --ci` all enforce the same gate.
 
+## Integrity and drift enforcement
+
+Two additive, optional, default-off keys under the existing `security:`
+namespace, both backed by enforcement that exists today.
+
+```yaml
+# .github/apm-policy.yml
+security:
+  integrity:
+    require_hashes: true    # fail install closed if any locked entry lacks a hash
+  audit:
+    fail_on_drift: true     # `apm audit` exits non-zero on workspace drift
+```
+
+| Field | Default | Behavior |
+|-------|---------|----------|
+| `integrity.require_hashes` | `false` | When `true`, every non-local lockfile entry MUST carry a content hash; a missing or empty hash fails `apm install` closed. Asserts hash-presence on the freshly-built lockfile (no second hashing pass). Local deps are exempt. Logical OR on inheritance. |
+| `audit.fail_on_drift` | `false` | When `true`, a bare `apm audit` exits non-zero when workspace content drifts from the lockfile (default-off keeps drift advisory at exit 0). Only changes the exit code; `apm audit --ci` already gates on drift. Logical OR on inheritance. |
+
 ## External scanner governance (experimental)
 
 Gate the behaviour of third-party SARIF scanners run by `apm audit

--- a/src/apm_cli/commands/audit.py
+++ b/src/apm_cli/commands/audit.py
@@ -969,11 +969,14 @@ def _audit_content_scan(
 
     # Bare `apm audit` is advisory for drift by default: drift findings are
     # rendered (text/json/sarif) but DO NOT escalate the exit code. When
-    # `security.audit.fail_on_drift` is enabled, actual drift escalates a clean
-    # run to exit 1 (matching the `apm audit --ci` gate). Policy is discovered
-    # only when drift was detected, so the no-drift common case is unchanged.
-    _ = drift_failed  # retained for symmetry; --ci gate lives in _audit_ci_gate.
-    if drift_findings and exit_code == 0 and _resolve_fail_on_drift(project_root):
+    # `security.audit.fail_on_drift` is enabled, any drift-check FAILURE
+    # escalates a clean run to exit 1 -- matching the `apm audit --ci` gate,
+    # which fails on the same `drift_check.passed is False` signal. That covers
+    # both detected drift AND a drift check that could not run (corrupt local
+    # graph, unsupported replay); an advisory cache-miss SKIP stays passed=True
+    # and does NOT gate. Policy is discovered only when a drift failure
+    # occurred, so the clean common case is unchanged.
+    if drift_failed and exit_code == 0 and _resolve_fail_on_drift(project_root):
         exit_code = 1
 
     if effective_format == "text":

--- a/src/apm_cli/commands/audit.py
+++ b/src/apm_cli/commands/audit.py
@@ -782,6 +782,28 @@ def _run_external_scanners(
         sys.exit(3)
 
 
+def _resolve_fail_on_drift(project_root: Path) -> bool:
+    """Return True when ``security.audit.fail_on_drift`` is enabled.
+
+    Respects ``APM_POLICY_DISABLE`` and fails open on any discovery error so a
+    transient policy-resolution failure never converts advisory drift into a
+    hard failure. Discovery is invoked by the caller only when drift was
+    actually detected, keeping the no-drift common path free of extra work.
+    """
+    if os.environ.get("APM_POLICY_DISABLE"):
+        return False
+    try:
+        from ..policy.discovery import discover_policy_with_chain
+
+        fetch_result = discover_policy_with_chain(project_root)
+    except Exception:
+        return False
+    policy = getattr(fetch_result, "policy", None)
+    if policy is None:
+        return False
+    return bool(policy.security.audit.fail_on_drift)
+
+
 def _audit_content_scan(
     cfg: _AuditConfig,
     package: str | None,
@@ -945,10 +967,14 @@ def _audit_content_scan(
         all_findings = [f for ff in findings_by_file.values() for f in ff]
         exit_code = 1 if ContentScanner.has_critical(all_findings) else 2
 
-    # Note: bare `apm audit` is advisory for drift; drift findings are
-    # rendered (text/json/sarif) but DO NOT escalate the exit code. Use
-    # `apm audit --ci` (handled in _audit_ci_gate) to gate on drift.
-    _ = drift_failed  # retained for symmetry; gate path lives in --ci.
+    # Bare `apm audit` is advisory for drift by default: drift findings are
+    # rendered (text/json/sarif) but DO NOT escalate the exit code. When
+    # `security.audit.fail_on_drift` is enabled, actual drift escalates a clean
+    # run to exit 1 (matching the `apm audit --ci` gate). Policy is discovered
+    # only when drift was detected, so the no-drift common case is unchanged.
+    _ = drift_failed  # retained for symmetry; --ci gate lives in _audit_ci_gate.
+    if drift_findings and exit_code == 0 and _resolve_fail_on_drift(project_root):
+        exit_code = 1
 
     if effective_format == "text":
         if cfg.output_path:

--- a/src/apm_cli/install/integrity.py
+++ b/src/apm_cli/install/integrity.py
@@ -1,0 +1,57 @@
+"""Fail-closed enforcement for ``security.integrity.require_hashes``.
+
+When the policy enables ``require_hashes``, every non-local lockfile entry MUST
+carry a content hash. A missing or empty hash is treated as a FAILURE, never a
+silent pass -- an unhashed entry could let a tampered lockfile redirect a
+download without detection.
+
+This module only asserts hash-presence on the already-built lockfile entries;
+it does NOT add a second filesystem hash pass (the install pipeline already
+computes and records hashes via the lockfile phase). Local deps are exempt,
+mirroring :func:`apm_cli.deps.registry_proxy.RegistryProxy.find_missing_hashes`
+-- local packages are verified through ``deployed_file_hashes`` rather than a
+package ``content_hash``.
+"""
+
+from __future__ import annotations
+
+from ..deps.lockfile import LockedDependency
+
+
+def unhashed_dependencies(
+    deps: list[LockedDependency],
+) -> list[LockedDependency]:
+    """Return non-local lockfile entries that lack a usable ``content_hash``.
+
+    An entry is flagged when its ``content_hash`` is ``None`` or empty. Entries
+    whose ``source`` is ``"local"`` are skipped (they are not hash-anchored on a
+    package digest).
+    """
+    flagged: list[LockedDependency] = []
+    for dep in deps:
+        if dep.source == "local":
+            continue
+        if not dep.content_hash:
+            flagged.append(dep)
+    return flagged
+
+
+def enforce_require_hashes(deps: list[LockedDependency], *, enabled: bool) -> None:
+    """Fail closed when ``require_hashes`` is on and any entry lacks a hash.
+
+    When *enabled* is ``False`` this is a no-op, preserving today's default
+    behavior. When ``True`` and one or more non-local entries are missing a
+    content hash, a :class:`RuntimeError` is raised naming the offending
+    dependencies.
+    """
+    if not enabled:
+        return
+    missing = unhashed_dependencies(deps)
+    if not missing:
+        return
+    names = ", ".join(sorted(d.repo_url for d in missing))
+    raise RuntimeError(
+        "security.integrity.require_hashes is enabled but these locked "
+        f"dependencies have no content hash (fail-closed): {names}. "
+        "Re-run the install so the lockfile records a hash for every entry."
+    )

--- a/src/apm_cli/install/integrity.py
+++ b/src/apm_cli/install/integrity.py
@@ -49,7 +49,9 @@ def enforce_require_hashes(deps: list[LockedDependency], *, enabled: bool) -> No
     missing = unhashed_dependencies(deps)
     if not missing:
         return
-    names = ", ".join(sorted(d.repo_url for d in missing))
+    from .mcp.registry import _redact_url_credentials
+
+    names = ", ".join(sorted(_redact_url_credentials(d.repo_url) for d in missing))
     raise RuntimeError(
         "security.integrity.require_hashes is enabled but these locked "
         f"dependencies have no content hash (fail-closed): {names}. "

--- a/src/apm_cli/install/pipeline.py
+++ b/src/apm_cli/install/pipeline.py
@@ -316,6 +316,38 @@ def _preflight_auth_check(ctx, auth_resolver, verbose: bool) -> None:
             _trace(f"Preflight: {host_display} -- accepted")
 
 
+def _enforce_require_hashes(ctx) -> None:
+    """Fail closed when ``security.integrity.require_hashes`` is enabled.
+
+    Reads the freshly-written lockfile and asserts every non-local entry has a
+    content hash. No-op when policy is disabled (``--no-policy``), no policy was
+    resolved, or the key is off -- preserving today's default behavior. Raises
+    :class:`~apm_cli.install.phases.policy_gate.PolicyViolationError` so the
+    failure routes through the pipeline's existing policy-violation handling.
+    """
+    if getattr(ctx, "no_policy", False):
+        return
+    policy_fetch = getattr(ctx, "policy_fetch", None)
+    policy = getattr(policy_fetch, "policy", None) if policy_fetch else None
+    if policy is None:
+        return
+    if not policy.security.integrity.require_hashes:
+        return
+
+    from ..deps.lockfile import LockFile, get_lockfile_path
+    from .integrity import enforce_require_hashes
+    from .phases.policy_gate import PolicyViolationError
+
+    apm_dir = getattr(ctx, "apm_dir", None) or ctx.project_root
+    lockfile = LockFile.read(get_lockfile_path(apm_dir))
+    if lockfile is None:
+        return
+    try:
+        enforce_require_hashes(lockfile.get_package_dependencies(), enabled=True)
+    except RuntimeError as exc:
+        raise PolicyViolationError(str(exc)) from exc
+
+
 def _write_empty_lockfile_only(apm_dir: Path) -> None:
     """Materialise an empty ``apm.lock.yaml`` for a depless ``apm lock`` run.
 
@@ -828,6 +860,12 @@ def run_install_pipeline(  # noqa: PLR0913, RUF100
         from .phases.lockfile import LockfileBuilder
 
         LockfileBuilder(ctx).build_and_save()
+
+        # Fail-closed integrity gate: when security.integrity.require_hashes is
+        # on, every non-local lockfile entry must carry a content hash. A
+        # missing hash stops the install (the key only asserts hash-presence on
+        # the freshly-built lockfile; it does not add a second hashing pass).
+        _enforce_require_hashes(ctx)
 
         # ------------------------------------------------------------------
         # Phase: Post-deps local .apm/ content.

--- a/src/apm_cli/install/pipeline.py
+++ b/src/apm_cli/install/pipeline.py
@@ -339,9 +339,17 @@ def _enforce_require_hashes(ctx) -> None:
     from .phases.policy_gate import PolicyViolationError
 
     apm_dir = getattr(ctx, "apm_dir", None) or ctx.project_root
-    lockfile = LockFile.read(get_lockfile_path(apm_dir))
+    lockfile_path = get_lockfile_path(apm_dir)
+    lockfile = LockFile.read(lockfile_path)
     if lockfile is None:
-        return
+        # Fail closed: require_hashes is on but the freshly-written lockfile is
+        # missing or unreadable. Returning here would silently defeat the gate,
+        # so surface it as a policy violation instead of letting install pass.
+        raise PolicyViolationError(
+            "security.integrity.require_hashes is enabled but the lockfile at "
+            f"{lockfile_path} could not be read (missing or corrupt); "
+            "failing closed. Re-run 'apm install' to regenerate it."
+        )
     try:
         enforce_require_hashes(lockfile.get_package_dependencies(), enabled=True)
     except RuntimeError as exc:

--- a/src/apm_cli/policy/inheritance.py
+++ b/src/apm_cli/policy/inheritance.py
@@ -19,6 +19,7 @@ from .schema import (
     CompilationStrategyPolicy,
     CompilationTargetPolicy,
     DependencyPolicy,
+    IntegrityPolicy,
     ManifestPolicy,
     McpPolicy,
     McpTransportPolicy,
@@ -299,6 +300,12 @@ def _merge_security(parent: SecurityPolicy, child: SecurityPolicy) -> SecurityPo
             on_install=on_install,
             external=_merge_list_field(p.external, c.external),
             scanners=_merge_scanners(p.scanners, c.scanners),
+            # Tighten-not-relax: OR-merge keeps a parent True even when a child
+            # is silent (False default), and lets a child tighten an off parent.
+            fail_on_drift=p.fail_on_drift or c.fail_on_drift,
+        ),
+        integrity=IntegrityPolicy(
+            require_hashes=parent.integrity.require_hashes or child.integrity.require_hashes,
         ),
     )
 

--- a/src/apm_cli/policy/parser.py
+++ b/src/apm_cli/policy/parser.py
@@ -16,6 +16,7 @@ from .schema import (
     CompilationStrategyPolicy,
     CompilationTargetPolicy,
     DependencyPolicy,
+    IntegrityPolicy,
     ManifestPolicy,
     McpPolicy,
     McpTransportPolicy,
@@ -187,7 +188,21 @@ def validate_policy(data: dict) -> tuple[list[str], list[str]]:
                     f"security.audit.on_install must be one of "
                     f"{sorted(_VALID_AUDIT_ON_INSTALL)}, got '{on_install}'"
                 )
+            fail_on_drift = audit.get("fail_on_drift")
+            if fail_on_drift is not None and not isinstance(fail_on_drift, bool):
+                errors.append(
+                    f"security.audit.fail_on_drift must be a boolean, got '{fail_on_drift}'"
+                )
             _validate_scanners(audit.get("scanners"), errors, warnings)
+        integrity = security.get("integrity")
+        if integrity is not None and not isinstance(integrity, dict):
+            errors.append("security.integrity must be a YAML mapping")
+        elif isinstance(integrity, dict):
+            require_hashes = integrity.get("require_hashes")
+            if require_hashes is not None and not isinstance(require_hashes, bool):
+                errors.append(
+                    f"security.integrity.require_hashes must be a boolean, got '{require_hashes}'"
+                )
 
     return errors, warnings
 
@@ -277,6 +292,8 @@ def _build_policy(data: dict) -> ApmPolicy:
     on_install = audit_data.get("on_install")
     if isinstance(on_install, bool):
         on_install = _YAML_BOOL_COERCE.get(on_install, str(on_install))
+    raw_integrity = sec_data.get("integrity")
+    integrity_data = raw_integrity if isinstance(raw_integrity, dict) else {}
     security = SecurityPolicy(
         audit=AuditPolicy(
             on_install=on_install,
@@ -284,6 +301,10 @@ def _build_policy(data: dict) -> ApmPolicy:
             if "external" not in audit_data or audit_data["external"] is None
             else _parse_tuple(audit_data["external"]),
             scanners=_parse_scanners(audit_data.get("scanners")),
+            fail_on_drift=bool(audit_data.get("fail_on_drift", False)),
+        ),
+        integrity=IntegrityPolicy(
+            require_hashes=bool(integrity_data.get("require_hashes", False)),
         ),
     )
 

--- a/src/apm_cli/policy/schema.py
+++ b/src/apm_cli/policy/schema.py
@@ -188,6 +188,25 @@ class AuditPolicy:
     on_install: str | None = None  # None | off | warn | block
     external: tuple[str, ...] | None = None  # required external scanners at install
     scanners: tuple[tuple[str, ScannerGovernance], ...] | None = None
+    # When True, ``apm audit`` exits non-zero if the workspace content drifts
+    # from the lockfile. Default off preserves today's advisory behavior (bare
+    # ``apm audit`` renders drift but exits 0). Tighten-not-relax on merge.
+    fail_on_drift: bool = False
+
+
+@dataclass(frozen=True)
+class IntegrityPolicy:
+    """Rules governing supply-chain integrity of locked dependencies.
+
+    ``require_hashes``: when ``True``, every non-local lockfile entry MUST carry
+    a content hash. A missing or empty hash is a FAILURE (fail-closed), never a
+    silent pass -- an unhashed entry could let a tampered lockfile redirect a
+    download without detection. Default off preserves today's behavior. The key
+    only asserts hash-presence on the lockfile entry; it does not add a second
+    filesystem hash pass (the install pipeline already computes+records hashes).
+    """
+
+    require_hashes: bool = False
 
 
 @dataclass(frozen=True)
@@ -195,6 +214,7 @@ class SecurityPolicy:
     """Rules governing APM's security checks (content audit and scanners)."""
 
     audit: AuditPolicy = field(default_factory=AuditPolicy)
+    integrity: IntegrityPolicy = field(default_factory=IntegrityPolicy)
 
 
 @dataclass(frozen=True)

--- a/tests/fixtures/policy/apm-policy-fail-on-drift-off.yml
+++ b/tests/fixtures/policy/apm-policy-fail-on-drift-off.yml
@@ -1,0 +1,9 @@
+# Fixture: drift stays advisory (matches default)
+# Tests: security.audit.fail_on_drift parses false without warning
+name: fail-on-drift-off-policy
+version: "1.0.0"
+enforcement: warn
+
+security:
+  audit:
+    fail_on_drift: false

--- a/tests/fixtures/policy/apm-policy-fail-on-drift-on.yml
+++ b/tests/fixtures/policy/apm-policy-fail-on-drift-on.yml
@@ -1,0 +1,10 @@
+# Fixture: audit fails (non-zero) when workspace drifts from the lockfile
+# Tests: security.audit.fail_on_drift parses true alongside on_install
+name: fail-on-drift-on-policy
+version: "1.0.0"
+enforcement: block
+
+security:
+  audit:
+    on_install: warn
+    fail_on_drift: true

--- a/tests/fixtures/policy/apm-policy-integrity-combined.yml
+++ b/tests/fixtures/policy/apm-policy-integrity-combined.yml
@@ -1,0 +1,12 @@
+# Fixture: both new integrity keys on under the existing security namespace
+# Tests: require_hashes + fail_on_drift coexist with on_install
+name: integrity-combined-policy
+version: "1.0.0"
+enforcement: block
+
+security:
+  integrity:
+    require_hashes: true
+  audit:
+    on_install: block
+    fail_on_drift: true

--- a/tests/fixtures/policy/apm-policy-require-hashes-off.yml
+++ b/tests/fixtures/policy/apm-policy-require-hashes-off.yml
@@ -1,0 +1,9 @@
+# Fixture: require_hashes explicitly disabled (matches default)
+# Tests: security.integrity.require_hashes parses false without warning
+name: require-hashes-off-policy
+version: "1.0.0"
+enforcement: warn
+
+security:
+  integrity:
+    require_hashes: false

--- a/tests/fixtures/policy/apm-policy-require-hashes-on.yml
+++ b/tests/fixtures/policy/apm-policy-require-hashes-on.yml
@@ -1,0 +1,9 @@
+# Fixture: require_hashes enforced (fail-closed on missing lockfile hash)
+# Tests: security.integrity.require_hashes parses true; default-off elsewhere
+name: require-hashes-on-policy
+version: "1.0.0"
+enforcement: block
+
+security:
+  integrity:
+    require_hashes: true

--- a/tests/fixtures/policy/golden/parsed-policies.json
+++ b/tests/fixtures/policy/golden/parsed-policies.json
@@ -1,0 +1,1516 @@
+{
+  "apm-policy-allow.yml": {
+    "bin_deploy": {
+      "deny": [],
+      "deny_all": false
+    },
+    "cache": {
+      "ttl": 3600
+    },
+    "compilation": {
+      "source_attribution": false,
+      "strategy": {
+        "enforce": null
+      },
+      "target": {
+        "allow": null,
+        "enforce": null
+      }
+    },
+    "dependencies": {
+      "allow": [
+        "DevExpGbb/*",
+        "microsoft/*"
+      ],
+      "deny": null,
+      "max_depth": 50,
+      "require": null,
+      "require_pinned_constraint": false,
+      "require_resolution": "project-wins"
+    },
+    "enforcement": "warn",
+    "extends": null,
+    "fetch_failure": "warn",
+    "manifest": {
+      "content_types": null,
+      "require_explicit_includes": false,
+      "required_fields": [],
+      "scripts": "allow"
+    },
+    "mcp": {
+      "allow": null,
+      "deny": [],
+      "self_defined": "warn",
+      "transport": {
+        "allow": null
+      },
+      "trust_transitive": false
+    },
+    "name": "allow-list-policy",
+    "registry_source": {
+      "allow_non_registry": true,
+      "require": []
+    },
+    "security": {
+      "audit": {
+        "external": null,
+        "fail_on_drift": false,
+        "on_install": null,
+        "scanners": null
+      },
+      "integrity": {
+        "require_hashes": false
+      }
+    },
+    "unmanaged_files": {
+      "action": null,
+      "directories": null
+    },
+    "version": "1.0.0"
+  },
+  "apm-policy-block.yml": {
+    "bin_deploy": {
+      "deny": [],
+      "deny_all": false
+    },
+    "cache": {
+      "ttl": 3600
+    },
+    "compilation": {
+      "source_attribution": false,
+      "strategy": {
+        "enforce": null
+      },
+      "target": {
+        "allow": null,
+        "enforce": null
+      }
+    },
+    "dependencies": {
+      "allow": null,
+      "deny": null,
+      "max_depth": 50,
+      "require": null,
+      "require_pinned_constraint": false,
+      "require_resolution": "project-wins"
+    },
+    "enforcement": "block",
+    "extends": null,
+    "fetch_failure": "warn",
+    "manifest": {
+      "content_types": null,
+      "require_explicit_includes": false,
+      "required_fields": [],
+      "scripts": "allow"
+    },
+    "mcp": {
+      "allow": null,
+      "deny": [],
+      "self_defined": "warn",
+      "transport": {
+        "allow": null
+      },
+      "trust_transitive": false
+    },
+    "name": "block-mode-policy",
+    "registry_source": {
+      "allow_non_registry": true,
+      "require": []
+    },
+    "security": {
+      "audit": {
+        "external": null,
+        "fail_on_drift": false,
+        "on_install": null,
+        "scanners": null
+      },
+      "integrity": {
+        "require_hashes": false
+      }
+    },
+    "unmanaged_files": {
+      "action": null,
+      "directories": null
+    },
+    "version": "1.0.0"
+  },
+  "apm-policy-deny.yml": {
+    "bin_deploy": {
+      "deny": [],
+      "deny_all": false
+    },
+    "cache": {
+      "ttl": 3600
+    },
+    "compilation": {
+      "source_attribution": false,
+      "strategy": {
+        "enforce": null
+      },
+      "target": {
+        "allow": null,
+        "enforce": null
+      }
+    },
+    "dependencies": {
+      "allow": null,
+      "deny": [
+        "test-blocked/*"
+      ],
+      "max_depth": 50,
+      "require": null,
+      "require_pinned_constraint": false,
+      "require_resolution": "project-wins"
+    },
+    "enforcement": "block",
+    "extends": null,
+    "fetch_failure": "warn",
+    "manifest": {
+      "content_types": null,
+      "require_explicit_includes": false,
+      "required_fields": [],
+      "scripts": "allow"
+    },
+    "mcp": {
+      "allow": null,
+      "deny": [],
+      "self_defined": "warn",
+      "transport": {
+        "allow": null
+      },
+      "trust_transitive": false
+    },
+    "name": "deny-list-policy",
+    "registry_source": {
+      "allow_non_registry": true,
+      "require": []
+    },
+    "security": {
+      "audit": {
+        "external": null,
+        "fail_on_drift": false,
+        "on_install": null,
+        "scanners": null
+      },
+      "integrity": {
+        "require_hashes": false
+      }
+    },
+    "unmanaged_files": {
+      "action": null,
+      "directories": null
+    },
+    "version": "1.0.0"
+  },
+  "apm-policy-extends-404-parent.yml": {
+    "bin_deploy": {
+      "deny": [],
+      "deny_all": false
+    },
+    "cache": {
+      "ttl": 3600
+    },
+    "compilation": {
+      "source_attribution": false,
+      "strategy": {
+        "enforce": null
+      },
+      "target": {
+        "allow": null,
+        "enforce": null
+      }
+    },
+    "dependencies": {
+      "allow": null,
+      "deny": null,
+      "max_depth": 50,
+      "require": null,
+      "require_pinned_constraint": false,
+      "require_resolution": "project-wins"
+    },
+    "enforcement": "warn",
+    "extends": "nonexistent-org/nonexistent-policy-repo",
+    "fetch_failure": "warn",
+    "manifest": {
+      "content_types": null,
+      "require_explicit_includes": false,
+      "required_fields": [],
+      "scripts": "allow"
+    },
+    "mcp": {
+      "allow": null,
+      "deny": [],
+      "self_defined": "warn",
+      "transport": {
+        "allow": null
+      },
+      "trust_transitive": false
+    },
+    "name": "extends-missing-parent-policy",
+    "registry_source": {
+      "allow_non_registry": true,
+      "require": []
+    },
+    "security": {
+      "audit": {
+        "external": null,
+        "fail_on_drift": false,
+        "on_install": null,
+        "scanners": null
+      },
+      "integrity": {
+        "require_hashes": false
+      }
+    },
+    "unmanaged_files": {
+      "action": null,
+      "directories": null
+    },
+    "version": "1.0.0"
+  },
+  "apm-policy-extends-cycle-parent.yml": {
+    "bin_deploy": {
+      "deny": [],
+      "deny_all": false
+    },
+    "cache": {
+      "ttl": 3600
+    },
+    "compilation": {
+      "source_attribution": false,
+      "strategy": {
+        "enforce": null
+      },
+      "target": {
+        "allow": null,
+        "enforce": null
+      }
+    },
+    "dependencies": {
+      "allow": null,
+      "deny": null,
+      "max_depth": 50,
+      "require": null,
+      "require_pinned_constraint": false,
+      "require_resolution": "project-wins"
+    },
+    "enforcement": "block",
+    "extends": "cycle-policy-a",
+    "fetch_failure": "warn",
+    "manifest": {
+      "content_types": null,
+      "require_explicit_includes": false,
+      "required_fields": [],
+      "scripts": "allow"
+    },
+    "mcp": {
+      "allow": null,
+      "deny": [],
+      "self_defined": "warn",
+      "transport": {
+        "allow": null
+      },
+      "trust_transitive": false
+    },
+    "name": "cycle-policy-b",
+    "registry_source": {
+      "allow_non_registry": true,
+      "require": []
+    },
+    "security": {
+      "audit": {
+        "external": null,
+        "fail_on_drift": false,
+        "on_install": null,
+        "scanners": null
+      },
+      "integrity": {
+        "require_hashes": false
+      }
+    },
+    "unmanaged_files": {
+      "action": null,
+      "directories": null
+    },
+    "version": "1.0.0"
+  },
+  "apm-policy-extends-cycle.yml": {
+    "bin_deploy": {
+      "deny": [],
+      "deny_all": false
+    },
+    "cache": {
+      "ttl": 3600
+    },
+    "compilation": {
+      "source_attribution": false,
+      "strategy": {
+        "enforce": null
+      },
+      "target": {
+        "allow": null,
+        "enforce": null
+      }
+    },
+    "dependencies": {
+      "allow": null,
+      "deny": [
+        "test-blocked/*"
+      ],
+      "max_depth": 50,
+      "require": null,
+      "require_pinned_constraint": false,
+      "require_resolution": "project-wins"
+    },
+    "enforcement": "warn",
+    "extends": "cycle-policy-b",
+    "fetch_failure": "warn",
+    "manifest": {
+      "content_types": null,
+      "require_explicit_includes": false,
+      "required_fields": [],
+      "scripts": "allow"
+    },
+    "mcp": {
+      "allow": null,
+      "deny": [],
+      "self_defined": "warn",
+      "transport": {
+        "allow": null
+      },
+      "trust_transitive": false
+    },
+    "name": "cycle-policy-a",
+    "registry_source": {
+      "allow_non_registry": true,
+      "require": []
+    },
+    "security": {
+      "audit": {
+        "external": null,
+        "fail_on_drift": false,
+        "on_install": null,
+        "scanners": null
+      },
+      "integrity": {
+        "require_hashes": false
+      }
+    },
+    "unmanaged_files": {
+      "action": null,
+      "directories": null
+    },
+    "version": "1.0.0"
+  },
+  "apm-policy-extends-depth.yml": {
+    "bin_deploy": {
+      "deny": [],
+      "deny_all": false
+    },
+    "cache": {
+      "ttl": 3600
+    },
+    "compilation": {
+      "source_attribution": false,
+      "strategy": {
+        "enforce": null
+      },
+      "target": {
+        "allow": null,
+        "enforce": null
+      }
+    },
+    "dependencies": {
+      "allow": null,
+      "deny": [
+        "untrusted/*"
+      ],
+      "max_depth": 50,
+      "require": null,
+      "require_pinned_constraint": false,
+      "require_resolution": "project-wins"
+    },
+    "enforcement": "warn",
+    "extends": "contoso-depth-5/policy",
+    "fetch_failure": "warn",
+    "manifest": {
+      "content_types": null,
+      "require_explicit_includes": false,
+      "required_fields": [],
+      "scripts": "allow"
+    },
+    "mcp": {
+      "allow": null,
+      "deny": [],
+      "self_defined": "warn",
+      "transport": {
+        "allow": null
+      },
+      "trust_transitive": false
+    },
+    "name": "depth-leaf-policy",
+    "registry_source": {
+      "allow_non_registry": true,
+      "require": []
+    },
+    "security": {
+      "audit": {
+        "external": null,
+        "fail_on_drift": false,
+        "on_install": null,
+        "scanners": null
+      },
+      "integrity": {
+        "require_hashes": false
+      }
+    },
+    "unmanaged_files": {
+      "action": null,
+      "directories": null
+    },
+    "version": "1.0.0"
+  },
+  "apm-policy-fail-on-drift-off.yml": {
+    "bin_deploy": {
+      "deny": [],
+      "deny_all": false
+    },
+    "cache": {
+      "ttl": 3600
+    },
+    "compilation": {
+      "source_attribution": false,
+      "strategy": {
+        "enforce": null
+      },
+      "target": {
+        "allow": null,
+        "enforce": null
+      }
+    },
+    "dependencies": {
+      "allow": null,
+      "deny": null,
+      "max_depth": 50,
+      "require": null,
+      "require_pinned_constraint": false,
+      "require_resolution": "project-wins"
+    },
+    "enforcement": "warn",
+    "extends": null,
+    "fetch_failure": "warn",
+    "manifest": {
+      "content_types": null,
+      "require_explicit_includes": false,
+      "required_fields": [],
+      "scripts": "allow"
+    },
+    "mcp": {
+      "allow": null,
+      "deny": [],
+      "self_defined": "warn",
+      "transport": {
+        "allow": null
+      },
+      "trust_transitive": false
+    },
+    "name": "fail-on-drift-off-policy",
+    "registry_source": {
+      "allow_non_registry": true,
+      "require": []
+    },
+    "security": {
+      "audit": {
+        "external": null,
+        "fail_on_drift": false,
+        "on_install": null,
+        "scanners": null
+      },
+      "integrity": {
+        "require_hashes": false
+      }
+    },
+    "unmanaged_files": {
+      "action": null,
+      "directories": null
+    },
+    "version": "1.0.0"
+  },
+  "apm-policy-fail-on-drift-on.yml": {
+    "bin_deploy": {
+      "deny": [],
+      "deny_all": false
+    },
+    "cache": {
+      "ttl": 3600
+    },
+    "compilation": {
+      "source_attribution": false,
+      "strategy": {
+        "enforce": null
+      },
+      "target": {
+        "allow": null,
+        "enforce": null
+      }
+    },
+    "dependencies": {
+      "allow": null,
+      "deny": null,
+      "max_depth": 50,
+      "require": null,
+      "require_pinned_constraint": false,
+      "require_resolution": "project-wins"
+    },
+    "enforcement": "block",
+    "extends": null,
+    "fetch_failure": "warn",
+    "manifest": {
+      "content_types": null,
+      "require_explicit_includes": false,
+      "required_fields": [],
+      "scripts": "allow"
+    },
+    "mcp": {
+      "allow": null,
+      "deny": [],
+      "self_defined": "warn",
+      "transport": {
+        "allow": null
+      },
+      "trust_transitive": false
+    },
+    "name": "fail-on-drift-on-policy",
+    "registry_source": {
+      "allow_non_registry": true,
+      "require": []
+    },
+    "security": {
+      "audit": {
+        "external": null,
+        "fail_on_drift": true,
+        "on_install": "warn",
+        "scanners": null
+      },
+      "integrity": {
+        "require_hashes": false
+      }
+    },
+    "unmanaged_files": {
+      "action": null,
+      "directories": null
+    },
+    "version": "1.0.0"
+  },
+  "apm-policy-integrity-combined.yml": {
+    "bin_deploy": {
+      "deny": [],
+      "deny_all": false
+    },
+    "cache": {
+      "ttl": 3600
+    },
+    "compilation": {
+      "source_attribution": false,
+      "strategy": {
+        "enforce": null
+      },
+      "target": {
+        "allow": null,
+        "enforce": null
+      }
+    },
+    "dependencies": {
+      "allow": null,
+      "deny": null,
+      "max_depth": 50,
+      "require": null,
+      "require_pinned_constraint": false,
+      "require_resolution": "project-wins"
+    },
+    "enforcement": "block",
+    "extends": null,
+    "fetch_failure": "warn",
+    "manifest": {
+      "content_types": null,
+      "require_explicit_includes": false,
+      "required_fields": [],
+      "scripts": "allow"
+    },
+    "mcp": {
+      "allow": null,
+      "deny": [],
+      "self_defined": "warn",
+      "transport": {
+        "allow": null
+      },
+      "trust_transitive": false
+    },
+    "name": "integrity-combined-policy",
+    "registry_source": {
+      "allow_non_registry": true,
+      "require": []
+    },
+    "security": {
+      "audit": {
+        "external": null,
+        "fail_on_drift": true,
+        "on_install": "block",
+        "scanners": null
+      },
+      "integrity": {
+        "require_hashes": true
+      }
+    },
+    "unmanaged_files": {
+      "action": null,
+      "directories": null
+    },
+    "version": "1.0.0"
+  },
+  "apm-policy-mcp.yml": {
+    "bin_deploy": {
+      "deny": [],
+      "deny_all": false
+    },
+    "cache": {
+      "ttl": 3600
+    },
+    "compilation": {
+      "source_attribution": false,
+      "strategy": {
+        "enforce": null
+      },
+      "target": {
+        "allow": null,
+        "enforce": null
+      }
+    },
+    "dependencies": {
+      "allow": null,
+      "deny": null,
+      "max_depth": 50,
+      "require": null,
+      "require_pinned_constraint": false,
+      "require_resolution": "project-wins"
+    },
+    "enforcement": "block",
+    "extends": null,
+    "fetch_failure": "warn",
+    "manifest": {
+      "content_types": null,
+      "require_explicit_includes": false,
+      "required_fields": [],
+      "scripts": "allow"
+    },
+    "mcp": {
+      "allow": [
+        "io.github.github/*",
+        "io.github.modelcontextprotocol/*"
+      ],
+      "deny": [
+        "io.github.untrusted/*"
+      ],
+      "self_defined": "warn",
+      "transport": {
+        "allow": [
+          "stdio",
+          "http"
+        ]
+      },
+      "trust_transitive": false
+    },
+    "name": "mcp-enforcement-policy",
+    "registry_source": {
+      "allow_non_registry": true,
+      "require": []
+    },
+    "security": {
+      "audit": {
+        "external": null,
+        "fail_on_drift": false,
+        "on_install": null,
+        "scanners": null
+      },
+      "integrity": {
+        "require_hashes": false
+      }
+    },
+    "unmanaged_files": {
+      "action": null,
+      "directories": null
+    },
+    "version": "1.0.0"
+  },
+  "apm-policy-off.yml": {
+    "bin_deploy": {
+      "deny": [],
+      "deny_all": false
+    },
+    "cache": {
+      "ttl": 3600
+    },
+    "compilation": {
+      "source_attribution": false,
+      "strategy": {
+        "enforce": null
+      },
+      "target": {
+        "allow": null,
+        "enforce": null
+      }
+    },
+    "dependencies": {
+      "allow": null,
+      "deny": null,
+      "max_depth": 50,
+      "require": null,
+      "require_pinned_constraint": false,
+      "require_resolution": "project-wins"
+    },
+    "enforcement": "off",
+    "extends": null,
+    "fetch_failure": "warn",
+    "manifest": {
+      "content_types": null,
+      "require_explicit_includes": false,
+      "required_fields": [],
+      "scripts": "allow"
+    },
+    "mcp": {
+      "allow": null,
+      "deny": [],
+      "self_defined": "warn",
+      "transport": {
+        "allow": null
+      },
+      "trust_transitive": false
+    },
+    "name": "enforcement-off-policy",
+    "registry_source": {
+      "allow_non_registry": true,
+      "require": []
+    },
+    "security": {
+      "audit": {
+        "external": null,
+        "fail_on_drift": false,
+        "on_install": null,
+        "scanners": null
+      },
+      "integrity": {
+        "require_hashes": false
+      }
+    },
+    "unmanaged_files": {
+      "action": null,
+      "directories": null
+    },
+    "version": "1.0.0"
+  },
+  "apm-policy-require-hashes-off.yml": {
+    "bin_deploy": {
+      "deny": [],
+      "deny_all": false
+    },
+    "cache": {
+      "ttl": 3600
+    },
+    "compilation": {
+      "source_attribution": false,
+      "strategy": {
+        "enforce": null
+      },
+      "target": {
+        "allow": null,
+        "enforce": null
+      }
+    },
+    "dependencies": {
+      "allow": null,
+      "deny": null,
+      "max_depth": 50,
+      "require": null,
+      "require_pinned_constraint": false,
+      "require_resolution": "project-wins"
+    },
+    "enforcement": "warn",
+    "extends": null,
+    "fetch_failure": "warn",
+    "manifest": {
+      "content_types": null,
+      "require_explicit_includes": false,
+      "required_fields": [],
+      "scripts": "allow"
+    },
+    "mcp": {
+      "allow": null,
+      "deny": [],
+      "self_defined": "warn",
+      "transport": {
+        "allow": null
+      },
+      "trust_transitive": false
+    },
+    "name": "require-hashes-off-policy",
+    "registry_source": {
+      "allow_non_registry": true,
+      "require": []
+    },
+    "security": {
+      "audit": {
+        "external": null,
+        "fail_on_drift": false,
+        "on_install": null,
+        "scanners": null
+      },
+      "integrity": {
+        "require_hashes": false
+      }
+    },
+    "unmanaged_files": {
+      "action": null,
+      "directories": null
+    },
+    "version": "1.0.0"
+  },
+  "apm-policy-require-hashes-on.yml": {
+    "bin_deploy": {
+      "deny": [],
+      "deny_all": false
+    },
+    "cache": {
+      "ttl": 3600
+    },
+    "compilation": {
+      "source_attribution": false,
+      "strategy": {
+        "enforce": null
+      },
+      "target": {
+        "allow": null,
+        "enforce": null
+      }
+    },
+    "dependencies": {
+      "allow": null,
+      "deny": null,
+      "max_depth": 50,
+      "require": null,
+      "require_pinned_constraint": false,
+      "require_resolution": "project-wins"
+    },
+    "enforcement": "block",
+    "extends": null,
+    "fetch_failure": "warn",
+    "manifest": {
+      "content_types": null,
+      "require_explicit_includes": false,
+      "required_fields": [],
+      "scripts": "allow"
+    },
+    "mcp": {
+      "allow": null,
+      "deny": [],
+      "self_defined": "warn",
+      "transport": {
+        "allow": null
+      },
+      "trust_transitive": false
+    },
+    "name": "require-hashes-on-policy",
+    "registry_source": {
+      "allow_non_registry": true,
+      "require": []
+    },
+    "security": {
+      "audit": {
+        "external": null,
+        "fail_on_drift": false,
+        "on_install": null,
+        "scanners": null
+      },
+      "integrity": {
+        "require_hashes": true
+      }
+    },
+    "unmanaged_files": {
+      "action": null,
+      "directories": null
+    },
+    "version": "1.0.0"
+  },
+  "apm-policy-required-version.yml": {
+    "bin_deploy": {
+      "deny": [],
+      "deny_all": false
+    },
+    "cache": {
+      "ttl": 3600
+    },
+    "compilation": {
+      "source_attribution": false,
+      "strategy": {
+        "enforce": null
+      },
+      "target": {
+        "allow": null,
+        "enforce": null
+      }
+    },
+    "dependencies": {
+      "allow": null,
+      "deny": null,
+      "max_depth": 50,
+      "require": [
+        "DevExpGbb/required-standards#v2.0.0"
+      ],
+      "require_pinned_constraint": false,
+      "require_resolution": "project-wins"
+    },
+    "enforcement": "block",
+    "extends": null,
+    "fetch_failure": "warn",
+    "manifest": {
+      "content_types": null,
+      "require_explicit_includes": false,
+      "required_fields": [],
+      "scripts": "allow"
+    },
+    "mcp": {
+      "allow": null,
+      "deny": [],
+      "self_defined": "warn",
+      "transport": {
+        "allow": null
+      },
+      "trust_transitive": false
+    },
+    "name": "required-version-pin-policy",
+    "registry_source": {
+      "allow_non_registry": true,
+      "require": []
+    },
+    "security": {
+      "audit": {
+        "external": null,
+        "fail_on_drift": false,
+        "on_install": null,
+        "scanners": null
+      },
+      "integrity": {
+        "require_hashes": false
+      }
+    },
+    "unmanaged_files": {
+      "action": null,
+      "directories": null
+    },
+    "version": "1.0.0"
+  },
+  "apm-policy-required.yml": {
+    "bin_deploy": {
+      "deny": [],
+      "deny_all": false
+    },
+    "cache": {
+      "ttl": 3600
+    },
+    "compilation": {
+      "source_attribution": false,
+      "strategy": {
+        "enforce": null
+      },
+      "target": {
+        "allow": null,
+        "enforce": null
+      }
+    },
+    "dependencies": {
+      "allow": null,
+      "deny": null,
+      "max_depth": 50,
+      "require": [
+        "DevExpGbb/required-standards"
+      ],
+      "require_pinned_constraint": false,
+      "require_resolution": "project-wins"
+    },
+    "enforcement": "block",
+    "extends": null,
+    "fetch_failure": "warn",
+    "manifest": {
+      "content_types": null,
+      "require_explicit_includes": false,
+      "required_fields": [],
+      "scripts": "allow"
+    },
+    "mcp": {
+      "allow": null,
+      "deny": [],
+      "self_defined": "warn",
+      "transport": {
+        "allow": null
+      },
+      "trust_transitive": false
+    },
+    "name": "required-deps-policy",
+    "registry_source": {
+      "allow_non_registry": true,
+      "require": []
+    },
+    "security": {
+      "audit": {
+        "external": null,
+        "fail_on_drift": false,
+        "on_install": null,
+        "scanners": null
+      },
+      "integrity": {
+        "require_hashes": false
+      }
+    },
+    "unmanaged_files": {
+      "action": null,
+      "directories": null
+    },
+    "version": "1.0.0"
+  },
+  "apm-policy-target-allow.yml": {
+    "bin_deploy": {
+      "deny": [],
+      "deny_all": false
+    },
+    "cache": {
+      "ttl": 3600
+    },
+    "compilation": {
+      "source_attribution": false,
+      "strategy": {
+        "enforce": null
+      },
+      "target": {
+        "allow": [
+          "vscode"
+        ],
+        "enforce": null
+      }
+    },
+    "dependencies": {
+      "allow": null,
+      "deny": null,
+      "max_depth": 50,
+      "require": null,
+      "require_pinned_constraint": false,
+      "require_resolution": "project-wins"
+    },
+    "enforcement": "block",
+    "extends": null,
+    "fetch_failure": "warn",
+    "manifest": {
+      "content_types": null,
+      "require_explicit_includes": false,
+      "required_fields": [],
+      "scripts": "allow"
+    },
+    "mcp": {
+      "allow": null,
+      "deny": [],
+      "self_defined": "warn",
+      "transport": {
+        "allow": null
+      },
+      "trust_transitive": false
+    },
+    "name": "target-restriction-policy",
+    "registry_source": {
+      "allow_non_registry": true,
+      "require": []
+    },
+    "security": {
+      "audit": {
+        "external": null,
+        "fail_on_drift": false,
+        "on_install": null,
+        "scanners": null
+      },
+      "integrity": {
+        "require_hashes": false
+      }
+    },
+    "unmanaged_files": {
+      "action": null,
+      "directories": null
+    },
+    "version": "1.0.0"
+  },
+  "apm-policy-warn.yml": {
+    "bin_deploy": {
+      "deny": [],
+      "deny_all": false
+    },
+    "cache": {
+      "ttl": 3600
+    },
+    "compilation": {
+      "source_attribution": false,
+      "strategy": {
+        "enforce": null
+      },
+      "target": {
+        "allow": null,
+        "enforce": null
+      }
+    },
+    "dependencies": {
+      "allow": null,
+      "deny": null,
+      "max_depth": 50,
+      "require": null,
+      "require_pinned_constraint": false,
+      "require_resolution": "project-wins"
+    },
+    "enforcement": "warn",
+    "extends": null,
+    "fetch_failure": "warn",
+    "manifest": {
+      "content_types": null,
+      "require_explicit_includes": false,
+      "required_fields": [],
+      "scripts": "allow"
+    },
+    "mcp": {
+      "allow": null,
+      "deny": [],
+      "self_defined": "warn",
+      "transport": {
+        "allow": null
+      },
+      "trust_transitive": false
+    },
+    "name": "warn-mode-policy",
+    "registry_source": {
+      "allow_non_registry": true,
+      "require": []
+    },
+    "security": {
+      "audit": {
+        "external": null,
+        "fail_on_drift": false,
+        "on_install": null,
+        "scanners": null
+      },
+      "integrity": {
+        "require_hashes": false
+      }
+    },
+    "unmanaged_files": {
+      "action": null,
+      "directories": null
+    },
+    "version": "1.0.0"
+  },
+  "enterprise-hub-policy.yml": {
+    "bin_deploy": {
+      "deny": [],
+      "deny_all": false
+    },
+    "cache": {
+      "ttl": 3600
+    },
+    "compilation": {
+      "source_attribution": false,
+      "strategy": {
+        "enforce": null
+      },
+      "target": {
+        "allow": null,
+        "enforce": null
+      }
+    },
+    "dependencies": {
+      "allow": [
+        "contoso-*/*",
+        "microsoft/*",
+        "github/*"
+      ],
+      "deny": [
+        "untrusted-vendor/*"
+      ],
+      "max_depth": 50,
+      "require": [
+        "contoso-governance/coding-standards",
+        "contoso-governance/security-hooks#v2.0.0"
+      ],
+      "require_pinned_constraint": false,
+      "require_resolution": "policy-wins"
+    },
+    "enforcement": "block",
+    "extends": null,
+    "fetch_failure": "warn",
+    "manifest": {
+      "content_types": null,
+      "require_explicit_includes": false,
+      "required_fields": [],
+      "scripts": "allow"
+    },
+    "mcp": {
+      "allow": null,
+      "deny": [],
+      "self_defined": "warn",
+      "transport": {
+        "allow": null
+      },
+      "trust_transitive": false
+    },
+    "name": "contoso-enterprise-policy",
+    "registry_source": {
+      "allow_non_registry": true,
+      "require": []
+    },
+    "security": {
+      "audit": {
+        "external": null,
+        "fail_on_drift": false,
+        "on_install": null,
+        "scanners": null
+      },
+      "integrity": {
+        "require_hashes": false
+      }
+    },
+    "unmanaged_files": {
+      "action": "deny",
+      "directories": null
+    },
+    "version": "1.0.0"
+  },
+  "minimal-policy.yml": {
+    "bin_deploy": {
+      "deny": [],
+      "deny_all": false
+    },
+    "cache": {
+      "ttl": 3600
+    },
+    "compilation": {
+      "source_attribution": false,
+      "strategy": {
+        "enforce": null
+      },
+      "target": {
+        "allow": null,
+        "enforce": null
+      }
+    },
+    "dependencies": {
+      "allow": null,
+      "deny": null,
+      "max_depth": 50,
+      "require": null,
+      "require_pinned_constraint": false,
+      "require_resolution": "project-wins"
+    },
+    "enforcement": "warn",
+    "extends": null,
+    "fetch_failure": "warn",
+    "manifest": {
+      "content_types": null,
+      "require_explicit_includes": false,
+      "required_fields": [],
+      "scripts": "allow"
+    },
+    "mcp": {
+      "allow": null,
+      "deny": [],
+      "self_defined": "warn",
+      "transport": {
+        "allow": null
+      },
+      "trust_transitive": false
+    },
+    "name": "minimal",
+    "registry_source": {
+      "allow_non_registry": true,
+      "require": []
+    },
+    "security": {
+      "audit": {
+        "external": null,
+        "fail_on_drift": false,
+        "on_install": null,
+        "scanners": null
+      },
+      "integrity": {
+        "require_hashes": false
+      }
+    },
+    "unmanaged_files": {
+      "action": null,
+      "directories": null
+    },
+    "version": "1.0.0"
+  },
+  "org-policy.yml": {
+    "bin_deploy": {
+      "deny": [],
+      "deny_all": false
+    },
+    "cache": {
+      "ttl": 3600
+    },
+    "compilation": {
+      "source_attribution": true,
+      "strategy": {
+        "enforce": "distributed"
+      },
+      "target": {
+        "allow": [
+          "vscode",
+          "claude",
+          "all"
+        ],
+        "enforce": null
+      }
+    },
+    "dependencies": {
+      "allow": [
+        "DevExpGbb/*",
+        "microsoft/*",
+        "github/*"
+      ],
+      "deny": [
+        "test-blocked/*"
+      ],
+      "max_depth": 50,
+      "require": [
+        "DevExpGbb/required-standards"
+      ],
+      "require_pinned_constraint": false,
+      "require_resolution": "project-wins"
+    },
+    "enforcement": "warn",
+    "extends": null,
+    "fetch_failure": "warn",
+    "manifest": {
+      "content_types": {
+        "allow": [
+          "instructions",
+          "skill",
+          "hybrid",
+          "prompts"
+        ]
+      },
+      "require_explicit_includes": false,
+      "required_fields": [
+        "version",
+        "description"
+      ],
+      "scripts": "allow"
+    },
+    "mcp": {
+      "allow": [
+        "io.github.github/*",
+        "io.github.modelcontextprotocol/*"
+      ],
+      "deny": [],
+      "self_defined": "warn",
+      "transport": {
+        "allow": [
+          "stdio",
+          "http"
+        ]
+      },
+      "trust_transitive": false
+    },
+    "name": "devexpgbb-test-policy",
+    "registry_source": {
+      "allow_non_registry": true,
+      "require": []
+    },
+    "security": {
+      "audit": {
+        "external": null,
+        "fail_on_drift": false,
+        "on_install": null,
+        "scanners": null
+      },
+      "integrity": {
+        "require_hashes": false
+      }
+    },
+    "unmanaged_files": {
+      "action": "warn",
+      "directories": []
+    },
+    "version": "1.0.0"
+  },
+  "repo-override-policy.yml": {
+    "bin_deploy": {
+      "deny": [],
+      "deny_all": false
+    },
+    "cache": {
+      "ttl": 3600
+    },
+    "compilation": {
+      "source_attribution": false,
+      "strategy": {
+        "enforce": null
+      },
+      "target": {
+        "allow": null,
+        "enforce": null
+      }
+    },
+    "dependencies": {
+      "allow": null,
+      "deny": [
+        "experimental/*"
+      ],
+      "max_depth": 50,
+      "require": null,
+      "require_pinned_constraint": false,
+      "require_resolution": "project-wins"
+    },
+    "enforcement": "warn",
+    "extends": "org",
+    "fetch_failure": "warn",
+    "manifest": {
+      "content_types": null,
+      "require_explicit_includes": false,
+      "required_fields": [],
+      "scripts": "allow"
+    },
+    "mcp": {
+      "allow": null,
+      "deny": [],
+      "self_defined": "warn",
+      "transport": {
+        "allow": null
+      },
+      "trust_transitive": false
+    },
+    "name": "repo-specific-policy",
+    "registry_source": {
+      "allow_non_registry": true,
+      "require": []
+    },
+    "security": {
+      "audit": {
+        "external": null,
+        "fail_on_drift": false,
+        "on_install": null,
+        "scanners": null
+      },
+      "integrity": {
+        "require_hashes": false
+      }
+    },
+    "unmanaged_files": {
+      "action": null,
+      "directories": null
+    },
+    "version": "1.0.0"
+  }
+}

--- a/tests/fixtures/spec-conformance/policy/security-integrity.yml
+++ b/tests/fixtures/spec-conformance/policy/security-integrity.yml
@@ -1,0 +1,11 @@
+# Exercises: req-pl-013, req-pl-014
+# Opt-in, fail-closed integrity controls under the security: namespace.
+# req-pl-013: security.integrity.require_hashes fail-closed install.
+# req-pl-014: security.audit.fail_on_drift non-zero audit exit on drift.
+name: contoso-integrity-baseline
+enforcement: block
+security:
+  integrity:
+    require_hashes: true
+  audit:
+    fail_on_drift: true

--- a/tests/spec_conformance/test_policy_reqs.py
+++ b/tests/spec_conformance/test_policy_reqs.py
@@ -126,4 +126,42 @@ def test_policy_provides_default_deny_list_shape():
     assert "deny" in deps and deps["deny"]["oneOf"][0]["type"] == "array"
 
 
+@pytest.mark.req("req-pl-013")
+def test_policy_require_hashes_parses_and_is_specified():
+    """req-pl-013: security.integrity.require_hashes fail-closed install.
+
+    Binds the parsed boolean to the spec MUST. The install enforcement
+    itself is exercised by tests/unit/install/test_require_hashes.py;
+    here we assert the parser surfaces the key and the spec language
+    that mandates the fail-closed behaviour is intact.
+    """
+    from apm_cli.policy.parser import load_policy
+
+    policy, _ = load_policy(fixture_path("policy", "security-integrity.yml"))
+    assert policy.security.integrity.require_hashes is True
+    assert_spec_contains(
+        "`security.integrity.require_hashes: true`",
+        "fail-closed diagnostic",
+    )
+
+
+@pytest.mark.req("req-pl-014")
+def test_policy_fail_on_drift_parses_and_is_specified():
+    """req-pl-014: security.audit.fail_on_drift non-zero audit exit.
+
+    Binds the parsed boolean to the spec MUST. The audit exit-code
+    path is exercised by tests/unit/test_audit_fail_on_drift.py; here
+    we assert the parser surfaces the key and the spec language that
+    mandates the non-zero exit is intact.
+    """
+    from apm_cli.policy.parser import load_policy
+
+    policy, _ = load_policy(fixture_path("policy", "security-integrity.yml"))
+    assert policy.security.audit.fail_on_drift is True
+    assert_spec_contains(
+        "`security.audit.fail_on_drift: true`",
+        "non-zero exit status when lockfile",
+    )
+
+
 _ = waive  # keep import for any future structural waiver

--- a/tests/unit/install/test_require_hashes.py
+++ b/tests/unit/install/test_require_hashes.py
@@ -12,7 +12,12 @@ than a package ``content_hash``, mirroring the existing
 
 from __future__ import annotations
 
+import tempfile
 import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+from urllib.parse import urlparse
 
 from apm_cli.deps.lockfile import LockedDependency
 from apm_cli.install.integrity import enforce_require_hashes, unhashed_dependencies
@@ -80,6 +85,64 @@ class TestEnforceRequireHashes(unittest.TestCase):
 
     def test_enabled_ignores_local_only(self):
         enforce_require_hashes([_dep("a", None, source="local")], enabled=True)
+
+    def test_enabled_redacts_credentials_in_message(self):
+        # A repo_url may carry inline ``user:token@host`` credentials. The
+        # fail-closed error names offenders, so it MUST redact the secret
+        # before formatting -- otherwise the token leaks into terminal/CI logs.
+        dep = LockedDependency(
+            repo_url="https://alice:s3cr3t-token@git.example.com/x.git",
+            resolved_commit="a" * 40,
+            content_hash=None,
+            source=None,
+        )
+        with self.assertRaises(RuntimeError) as ctx:
+            enforce_require_hashes([dep], enabled=True)
+        msg = str(ctx.exception)
+        urls = [tok.strip("(),.;'\"") for tok in msg.split() if "://" in tok]
+        self.assertEqual(len(urls), 1)
+        parsed = urlparse(urls[0])
+        self.assertEqual(parsed.hostname, "git.example.com")
+        self.assertNotEqual(parsed.password, "s3cr3t-token")
+        self.assertNotIn("s3cr3t-token", msg)
+
+
+def _gate_ctx(apm_dir: Path, require_hashes: bool):
+    """Minimal install-context stub for ``_enforce_require_hashes``."""
+    integrity = SimpleNamespace(require_hashes=require_hashes)
+    security = SimpleNamespace(integrity=integrity)
+    policy = SimpleNamespace(security=security)
+    policy_fetch = SimpleNamespace(policy=policy)
+    return SimpleNamespace(
+        no_policy=False,
+        policy_fetch=policy_fetch,
+        apm_dir=apm_dir,
+        project_root=apm_dir,
+    )
+
+
+class TestPipelineEnforceRequireHashes(unittest.TestCase):
+    """The pipeline gate must fail closed on an unreadable lockfile."""
+
+    def test_unreadable_lockfile_fails_closed_when_enabled(self):
+        from apm_cli.install.phases.policy_gate import PolicyViolationError
+        from apm_cli.install.pipeline import _enforce_require_hashes
+
+        with tempfile.TemporaryDirectory() as d:
+            ctx = _gate_ctx(Path(d), require_hashes=True)
+            with patch("apm_cli.deps.lockfile.LockFile.read", return_value=None):
+                with self.assertRaises(PolicyViolationError) as exc:
+                    _enforce_require_hashes(ctx)
+        self.assertIn("require_hashes", str(exc.exception))
+
+    def test_unreadable_lockfile_noop_when_disabled(self):
+        from apm_cli.install.pipeline import _enforce_require_hashes
+
+        with tempfile.TemporaryDirectory() as d:
+            ctx = _gate_ctx(Path(d), require_hashes=False)
+            with patch("apm_cli.deps.lockfile.LockFile.read", return_value=None):
+                # Default-off must not raise even if the lockfile is unreadable.
+                _enforce_require_hashes(ctx)
 
 
 if __name__ == "__main__":

--- a/tests/unit/install/test_require_hashes.py
+++ b/tests/unit/install/test_require_hashes.py
@@ -1,0 +1,86 @@
+"""Seam 3 (part A): fail-closed enforcement for ``require_hashes``.
+
+A lockfile entry whose ``content_hash`` is missing or empty must be treated
+as a FAILURE when ``security.integrity.require_hashes`` is on -- never a silent
+pass. ``unhashed_dependencies`` is the pure decision function; it is wired into
+the install pipeline so a hashless non-local entry stops the install.
+
+Local deps are exempt: they are verified via ``deployed_file_hashes`` rather
+than a package ``content_hash``, mirroring the existing
+``registry_proxy.find_missing_hashes`` rule.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from apm_cli.deps.lockfile import LockedDependency
+from apm_cli.install.integrity import enforce_require_hashes, unhashed_dependencies
+
+
+def _dep(name: str, content_hash, source=None) -> LockedDependency:
+    return LockedDependency(
+        repo_url=f"https://example.com/{name}.git",
+        resolved_commit="a" * 40,
+        content_hash=content_hash,
+        source=source,
+    )
+
+
+class TestUnhashedDependencies(unittest.TestCase):
+    def test_missing_hash_is_flagged(self):
+        deps = [_dep("a", None)]
+        flagged = unhashed_dependencies(deps)
+        self.assertEqual([d.repo_url for d in flagged], ["https://example.com/a.git"])
+
+    def test_empty_hash_is_flagged(self):
+        deps = [_dep("a", "")]
+        self.assertEqual(len(unhashed_dependencies(deps)), 1)
+
+    def test_present_hash_passes(self):
+        deps = [_dep("a", "sha256:" + "0" * 64)]
+        self.assertEqual(unhashed_dependencies(deps), [])
+
+    def test_local_dep_exempt(self):
+        deps = [_dep("a", None, source="local")]
+        self.assertEqual(unhashed_dependencies(deps), [])
+
+    def test_mixed(self):
+        deps = [
+            _dep("good", "sha256:abc"),
+            _dep("bad", None),
+            _dep("local", None, source="local"),
+            _dep("empty", ""),
+        ]
+        flagged = {d.repo_url for d in unhashed_dependencies(deps)}
+        self.assertIn("https://example.com/bad.git", flagged)
+        self.assertIn("https://example.com/empty.git", flagged)
+        self.assertNotIn("https://example.com/good.git", flagged)
+        self.assertNotIn("https://example.com/local.git", flagged)
+
+
+class TestEnforceRequireHashes(unittest.TestCase):
+    """The enforcement wrapper fails closed only when enabled."""
+
+    def test_disabled_is_noop_even_with_missing_hash(self):
+        # Default-off must preserve current behavior: no raise.
+        enforce_require_hashes([_dep("a", None)], enabled=False)
+
+    def test_enabled_with_all_hashed_passes(self):
+        enforce_require_hashes([_dep("a", "sha256:abc")], enabled=True)
+
+    def test_enabled_with_missing_hash_fails_closed(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            enforce_require_hashes([_dep("a", None)], enabled=True)
+        self.assertIn("require_hashes", str(ctx.exception))
+
+    def test_enabled_with_empty_hash_fails_closed(self):
+        with self.assertRaises(RuntimeError):
+            enforce_require_hashes([_dep("a", "")], enabled=True)
+
+    def test_enabled_ignores_local_only(self):
+        enforce_require_hashes([_dep("a", None, source="local")], enabled=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/policy/test_integrity_keys.py
+++ b/tests/unit/policy/test_integrity_keys.py
@@ -1,0 +1,159 @@
+"""TDD seams for issue #1778 -- declarable integrity policy keys.
+
+Covers the two additive, default-off keys nested under the existing
+``security:`` namespace:
+
+* ``security.integrity.require_hashes`` -- require lockfile content hashes
+  for all installs; a MISSING hash is a failure (fail-closed).
+* ``security.audit.fail_on_drift`` -- make ``apm audit`` exit non-zero when
+  workspace content drifts from the lockfile.
+
+Three mandatory seams live here (None-transparency on merge + fail-closed for
+``require_hashes``); the golden parse-equivalence seam is in
+``test_policy_golden.py`` and the ``fail_on_drift`` exit-code seam is in
+``tests/unit/test_audit_fail_on_drift.py``.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from apm_cli.policy.inheritance import merge_policies
+from apm_cli.policy.parser import load_policy, validate_policy
+from apm_cli.policy.schema import (
+    ApmPolicy,
+    AuditPolicy,
+    IntegrityPolicy,
+    SecurityPolicy,
+)
+
+
+class TestIntegritySchemaDefaults(unittest.TestCase):
+    """Both keys default OFF so existing policies are unchanged."""
+
+    def test_integrity_default_off(self):
+        self.assertFalse(IntegrityPolicy().require_hashes)
+
+    def test_security_has_integrity_block(self):
+        sec = SecurityPolicy()
+        self.assertIsInstance(sec.integrity, IntegrityPolicy)
+        self.assertFalse(sec.integrity.require_hashes)
+
+    def test_audit_fail_on_drift_default_off(self):
+        self.assertFalse(AuditPolicy().fail_on_drift)
+
+    def test_apm_policy_defaults_off(self):
+        p = ApmPolicy()
+        self.assertFalse(p.security.integrity.require_hashes)
+        self.assertFalse(p.security.audit.fail_on_drift)
+
+    def test_frozen(self):
+        ig = IntegrityPolicy()
+        with self.assertRaises(AttributeError):
+            ig.require_hashes = True  # type: ignore[misc]
+
+
+class TestIntegrityParsing(unittest.TestCase):
+    """The parser reads both keys from the security namespace."""
+
+    def test_require_hashes_parsed(self):
+        policy, _ = load_policy("name: p\nsecurity:\n  integrity:\n    require_hashes: true\n")
+        self.assertTrue(policy.security.integrity.require_hashes)
+
+    def test_fail_on_drift_parsed(self):
+        policy, _ = load_policy("name: p\nsecurity:\n  audit:\n    fail_on_drift: true\n")
+        self.assertTrue(policy.security.audit.fail_on_drift)
+
+    def test_both_default_off_when_silent(self):
+        policy, _ = load_policy("name: p\nsecurity:\n  audit:\n    on_install: warn\n")
+        self.assertFalse(policy.security.integrity.require_hashes)
+        self.assertFalse(policy.security.audit.fail_on_drift)
+
+    def test_no_unknown_key_warning(self):
+        _, warnings = load_policy(
+            "name: p\nsecurity:\n  integrity:\n    require_hashes: true\n"
+            "  audit:\n    fail_on_drift: true\n"
+        )
+        joined = " ".join(warnings)
+        self.assertNotIn("integrity", joined)
+        self.assertNotIn("fail_on_drift", joined)
+
+
+class TestIntegrityValidation(unittest.TestCase):
+    """Non-boolean values are rejected (no false-assurance via typos)."""
+
+    def test_require_hashes_must_be_bool(self):
+        errors, _ = validate_policy({"security": {"integrity": {"require_hashes": "yes"}}})
+        self.assertTrue(any("require_hashes" in e for e in errors))
+
+    def test_fail_on_drift_must_be_bool(self):
+        errors, _ = validate_policy({"security": {"audit": {"fail_on_drift": "soon"}}})
+        self.assertTrue(any("fail_on_drift" in e for e in errors))
+
+    def test_integrity_must_be_mapping(self):
+        errors, _ = validate_policy({"security": {"integrity": ["nope"]}})
+        self.assertTrue(any("integrity" in e for e in errors))
+
+    def test_valid_booleans_pass(self):
+        errors, _ = validate_policy(
+            {
+                "security": {
+                    "integrity": {"require_hashes": True},
+                    "audit": {"fail_on_drift": False},
+                }
+            }
+        )
+        self.assertEqual(errors, [])
+
+
+class TestNoneTransparencyOnMerge(unittest.TestCase):
+    """Seam 2: a child silent on a new key does NOT relax a parent that set it."""
+
+    def test_require_hashes_parent_set_child_silent(self):
+        parent = ApmPolicy(security=SecurityPolicy(integrity=IntegrityPolicy(require_hashes=True)))
+        merged = merge_policies(parent, ApmPolicy())
+        self.assertTrue(merged.security.integrity.require_hashes)
+
+    def test_fail_on_drift_parent_set_child_silent(self):
+        parent = ApmPolicy(security=SecurityPolicy(audit=AuditPolicy(fail_on_drift=True)))
+        merged = merge_policies(parent, ApmPolicy())
+        self.assertTrue(merged.security.audit.fail_on_drift)
+
+    def test_child_can_tighten(self):
+        child = ApmPolicy(
+            security=SecurityPolicy(
+                integrity=IntegrityPolicy(require_hashes=True),
+                audit=AuditPolicy(fail_on_drift=True),
+            )
+        )
+        merged = merge_policies(ApmPolicy(), child)
+        self.assertTrue(merged.security.integrity.require_hashes)
+        self.assertTrue(merged.security.audit.fail_on_drift)
+
+    def test_child_cannot_relax_parent(self):
+        parent = ApmPolicy(
+            security=SecurityPolicy(
+                integrity=IntegrityPolicy(require_hashes=True),
+                audit=AuditPolicy(fail_on_drift=True),
+            )
+        )
+        # Child explicitly off must not relax the parent's tightened floor.
+        child = ApmPolicy(
+            security=SecurityPolicy(
+                integrity=IntegrityPolicy(require_hashes=False),
+                audit=AuditPolicy(fail_on_drift=False),
+            )
+        )
+        merged = merge_policies(parent, child)
+        self.assertTrue(merged.security.integrity.require_hashes)
+        self.assertTrue(merged.security.audit.fail_on_drift)
+
+    def test_on_install_still_carried(self):
+        # Regression: adding the new keys must not drop the existing on_install.
+        parent = ApmPolicy(security=SecurityPolicy(audit=AuditPolicy(on_install="block")))
+        merged = merge_policies(parent, ApmPolicy())
+        self.assertEqual(merged.security.audit.on_install, "block")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/policy/test_policy_golden.py
+++ b/tests/unit/policy/test_policy_golden.py
@@ -60,6 +60,18 @@ class TestPolicyGoldenParseEquivalence(unittest.TestCase):
 
         golden = json.loads(GOLDEN_PATH.read_text(encoding="utf-8"))
 
+        # Exactness guard: the fixture set on disk and the golden set must
+        # match 1:1. Without this, adding a new *.yml fixture WITHOUT
+        # regenerating the snapshot would still pass -- the new fixture is
+        # simply absent from `golden` and never asserted, silently skipping
+        # coverage. Compare the key sets directly.
+        self.assertEqual(
+            set(snapshot.keys()),
+            set(golden.keys()),
+            "fixture set and golden snapshot set diverged; regenerate with "
+            "APM_REGEN_POLICY_GOLDEN=1 after adding or removing a policy fixture",
+        )
+
         # Every previously-snapshotted fixture must parse identically.
         for name, canonical in golden.items():
             with self.subTest(fixture=name):

--- a/tests/unit/policy/test_policy_golden.py
+++ b/tests/unit/policy/test_policy_golden.py
@@ -1,0 +1,86 @@
+"""Seam 1: golden parse-equivalence over every policy fixture.
+
+Loads EVERY top-level fixture under ``tests/fixtures/policy/``, parses each to
+an :class:`ApmPolicy`, canonicalizes it to a stable JSON form, and asserts it
+equals a checked-in golden snapshot.
+
+Why this proves the additive / non-breaking claim: the golden snapshot is
+regenerated only when the schema legitimately changes. Adding the two
+default-off integrity keys (``security.integrity.require_hashes`` and
+``security.audit.fail_on_drift``) appears in the golden diff as exactly those
+two additive fields and nothing else -- any unexpected change to how an
+existing field parses would surface as an extra diff and fail review.
+
+``APM_REGEN_POLICY_GOLDEN=1 pytest ...`` regenerates the snapshot; the test
+also bootstraps the snapshot on first run if it is missing.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import unittest
+from pathlib import Path
+
+from apm_cli.policy.parser import load_policy
+
+FIXTURES_DIR = Path(__file__).resolve().parents[2] / "fixtures" / "policy"
+GOLDEN_PATH = FIXTURES_DIR / "golden" / "parsed-policies.json"
+
+
+def _canonicalize(policy) -> dict:
+    """Recursive, JSON-stable canonical form of a parsed ApmPolicy.
+
+    Round-trips through JSON so tuples and lists compare equal -- the snapshot
+    and the checked-in golden are both normalized to JSON primitives.
+    """
+    return json.loads(json.dumps(dataclasses.asdict(policy), sort_keys=True))
+
+
+def _build_snapshot() -> dict[str, dict]:
+    snapshot: dict[str, dict] = {}
+    for yml in sorted(FIXTURES_DIR.glob("*.yml")):
+        policy, _ = load_policy(yml)
+        snapshot[yml.name] = _canonicalize(policy)
+    return snapshot
+
+
+class TestPolicyGoldenParseEquivalence(unittest.TestCase):
+    def test_fixtures_match_golden(self):
+        snapshot = _build_snapshot()
+
+        regen = os.environ.get("APM_REGEN_POLICY_GOLDEN") == "1"
+        if regen or not GOLDEN_PATH.exists():
+            GOLDEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+            GOLDEN_PATH.write_text(
+                json.dumps(snapshot, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+
+        golden = json.loads(GOLDEN_PATH.read_text(encoding="utf-8"))
+
+        # Every previously-snapshotted fixture must parse identically.
+        for name, canonical in golden.items():
+            with self.subTest(fixture=name):
+                self.assertIn(name, snapshot, f"fixture {name} disappeared")
+                self.assertEqual(
+                    snapshot[name],
+                    canonical,
+                    f"parse output for {name} drifted from golden snapshot",
+                )
+
+    def test_silent_fixtures_get_default_off_keys(self):
+        """Fixtures that never mention the new keys parse them as default-off."""
+        for yml in sorted(FIXTURES_DIR.glob("*.yml")):
+            raw = yml.read_text(encoding="utf-8")
+            if "require_hashes" in raw or "fail_on_drift" in raw:
+                continue
+            policy, _ = load_policy(yml)
+            with self.subTest(fixture=yml.name):
+                self.assertFalse(policy.security.integrity.require_hashes)
+                self.assertFalse(policy.security.audit.fail_on_drift)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_audit_fail_on_drift.py
+++ b/tests/unit/test_audit_fail_on_drift.py
@@ -36,7 +36,15 @@ def _drift_return():
     return drift_check, [MagicMock()]
 
 
-def _run(tmp_path, fail_on_drift):
+def _drift_could_not_run():
+    """A drift check that FAILED to run: passed=False with zero findings."""
+    drift_check = MagicMock()
+    drift_check.passed = False
+    drift_check.message = "drift replay unsupported: scheme not yet handled"
+    return drift_check, []
+
+
+def _run(tmp_path, fail_on_drift, drift_ret=None):
     (tmp_path / "apm.yml").write_text("name: demo\n", encoding="utf-8")
     (tmp_path / "apm.lock.yaml").write_text("{}", encoding="utf-8")
     cfg = _make_cfg(tmp_path)
@@ -44,7 +52,10 @@ def _run(tmp_path, fail_on_drift):
     from apm_cli.commands import audit as audit_mod
 
     with (
-        patch("apm_cli.policy.ci_checks._check_drift", return_value=_drift_return()),
+        patch(
+            "apm_cli.policy.ci_checks._check_drift",
+            return_value=drift_ret if drift_ret is not None else _drift_return(),
+        ),
         patch.object(audit_mod.LockFile, "read", return_value=MagicMock()),
         patch.object(audit_mod, "scan_lockfile_packages", return_value=({}, 1)),
         patch.object(audit_mod, "_resolve_fail_on_drift", return_value=fail_on_drift),
@@ -61,3 +72,15 @@ def test_drift_with_fail_on_drift_exits_nonzero(tmp_path):
 
 def test_drift_default_off_exits_zero(tmp_path):
     assert _run(tmp_path, fail_on_drift=False) == 0
+
+
+def test_drift_check_could_not_run_with_fail_on_drift_exits_nonzero(tmp_path):
+    # A drift check that fails to RUN (passed=False, no findings) must still
+    # gate when fail_on_drift is on -- matching `apm audit --ci`, which fails
+    # on the same drift_check.passed signal. Otherwise the gate silently
+    # fails open on a broken drift replay.
+    assert _run(tmp_path, fail_on_drift=True, drift_ret=_drift_could_not_run()) != 0
+
+
+def test_drift_check_could_not_run_default_off_exits_zero(tmp_path):
+    assert _run(tmp_path, fail_on_drift=False, drift_ret=_drift_could_not_run()) == 0

--- a/tests/unit/test_audit_fail_on_drift.py
+++ b/tests/unit/test_audit_fail_on_drift.py
@@ -1,0 +1,63 @@
+"""Seam 3 (part B): ``security.audit.fail_on_drift`` exit-code escalation.
+
+Bare ``apm audit`` treats workspace drift as advisory: it renders drift but
+exits 0. When ``security.audit.fail_on_drift`` is on, a drifted workspace must
+exit non-zero. Default-off must preserve today's advisory behavior exactly.
+
+The drift detection itself is unchanged -- this key only changes the exit code,
+it does not add a second drift pass. Tests mock ``_check_drift`` (the same seam
+the existing suite uses) and the policy resolver helper.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_cfg(tmp_path):
+    from apm_cli.commands.audit import _AuditConfig
+    from apm_cli.core.command_logger import CommandLogger
+
+    return _AuditConfig(
+        project_root=tmp_path,
+        logger=CommandLogger("audit", verbose=False),
+        verbose=False,
+        output_format="text",
+        output_path=None,
+    )
+
+
+def _drift_return():
+    drift_check = MagicMock()
+    drift_check.passed = False
+    drift_check.message = "drift detected"
+    return drift_check, [MagicMock()]
+
+
+def _run(tmp_path, fail_on_drift):
+    (tmp_path / "apm.yml").write_text("name: demo\n", encoding="utf-8")
+    (tmp_path / "apm.lock.yaml").write_text("{}", encoding="utf-8")
+    cfg = _make_cfg(tmp_path)
+
+    from apm_cli.commands import audit as audit_mod
+
+    with (
+        patch("apm_cli.policy.ci_checks._check_drift", return_value=_drift_return()),
+        patch.object(audit_mod.LockFile, "read", return_value=MagicMock()),
+        patch.object(audit_mod, "scan_lockfile_packages", return_value=({}, 1)),
+        patch.object(audit_mod, "_resolve_fail_on_drift", return_value=fail_on_drift),
+        patch("apm_cli.install.drift.render_drift_text", return_value=""),
+        pytest.raises(SystemExit) as exc,
+    ):
+        audit_mod._audit_content_scan(cfg, package=None, file_path=None, strip=False, dry_run=False)
+    return exc.value.code
+
+
+def test_drift_with_fail_on_drift_exits_nonzero(tmp_path):
+    assert _run(tmp_path, fail_on_drift=True) != 0
+
+
+def test_drift_default_off_exits_zero(tmp_path):
+    assert _run(tmp_path, fail_on_drift=False) == 0


### PR DESCRIPTION
## Problem

`apm-policy.yml` can express several governance floors (audit-on-install, registry routing, scanner restrictions), but it cannot yet declare two integrity guarantees that the install/audit pipeline already enforces operationally:

1. A team that wants reproducible, tamper-evident installs has no way to *require* that every locked dependency carries a content hash. Today a missing hash passes silently.
2. A team that wants `apm audit` to be a hard CI/local gate on workspace drift has to remember `--ci`; a bare `apm audit` renders drift but exits 0.

Both behaviors exist in the code today -- they just are not declarable as policy.

## What changed: two keys, and only two

Both are additive, optional, and **default off**, nested under the **existing** `security:` namespace (no new top-level namespace, no top-level `audit:`):

- **`security.integrity.require_hashes`** (bool, default off) -- require lockfile content hashes for all installs. A missing/empty hash on a non-local lockfile entry is a **failure (fail-closed)**, not a silent pass.
- **`security.audit.fail_on_drift`** (bool, default off) -- make a bare `apm audit` exit non-zero when workspace content drifts from the lockfile. Sits alongside the existing `security.audit.on_install`.

### Why only two

Every field in the policy schema maps 1:1 to a concrete `apm` check that enforces it today. `require_hashes` asserts hash-presence on the freshly-built lockfile entry (the install pipeline already computes + records hashes -- no second hashing pass). `fail_on_drift` reuses the existing drift detection and only changes the exit code -- it does not add a second drift pass. Keys for signatures / provenance / sbom are deliberately **not** added here (deferred to #1777): a key that validates but enforces nothing is a false-assurance liability.

## Fail-closed behavior

- `require_hashes: true` + any non-local locked entry with an empty/missing `content_hash` -> install fails closed (offenders named). Local dependencies are exempt. No-op when the key is off, `--no-policy`, or no policy resolves.
- `fail_on_drift: true` + detected drift -> `apm audit` escalates exit code to 1. Default-off preserves today's advisory (rendered, exit 0) behavior.

Both keys carry through policy inheritance with **logical-OR / tighten-not-relax** semantics: once a parent enables a key a child cannot relax it, and a child silent on the key preserves the parent's value (None-transparency). The structural merge coverage guard from #1791 stays green.

## Test seams (TDD, red first)

1. **Golden parse-equivalence** -- parse every fixture under `tests/fixtures/policy/`, canonicalize, and assert equality with a checked-in golden snapshot, proving old policies parse identically after the new keys are added (the additive / non-breaking claim).
2. **None-transparency on merge** -- a child silent on `require_hashes` / `fail_on_drift` does not override a parent that set them.
3. **Fail-closed** -- a lockfile entry with a missing/empty hash fails under `require_hashes: true` (and passes when present); `fail_on_drift: true` makes a drifted workspace exit non-zero while default-off preserves current behavior.

New on/off fixtures per key were added; a mutation-break was confirmed (forcing `require_hashes` to treat a missing hash as a pass fails the suite) and restored.

## Validation evidence (all green)

```
uv run --extra dev ruff check src/ tests/            # All checks passed
uv run --extra dev ruff format --check src/ tests/   # 1270 files already formatted
uv run --extra dev python -m pylint --disable=all --enable=R0801 \
  --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/   # 10.00/10
bash scripts/lint-auth-signals.sh                    # auth-signal lint clean
uv run --extra dev pytest tests/unit -k "policy or audit or inheritance or integrity or drift or require_hashes" -q
  # 1950 passed, 1 xfailed
```

All source files stay under 2450 lines; ASCII only.

## Docs

- `docs/src/content/docs/reference/policy-schema.md`: documented both keys (default off; what each enforces) + merge rules.
- `packages/apm-guide/.apm/skills/apm-usage/governance.md`: integrity/drift governance subsection.
- `CHANGELOG.md`: Unreleased `### Added` entry.

## Spec citation (OpenAPM v0.1)

Both keys are now first-class normative requirements in the OpenAPM v0.1 specification (maintainer governance call: author the citation, not a waiver):

- **req-pl-013** (`security.integrity.require_hashes`, MUST, governance) and **req-pl-014** (`security.audit.fail_on_drift`, MUST, governance) land under a new **Section 6.8 "Integrity controls"**, with a non-normative **6.3.6 `security`** field reference, two req-pl-006 merge-table rows (logical OR / tighten-not-relax), an Appendix C index row each, and a requirements-manifest entry each. Statement count 87 -> 89 (84 MUST, 5 SHOULD).
- The `apm-spec-guardian` adversarial panel returned `fold_and_ship` (shocked-meter avg 7.75/10, zero blocking across all four reviewers). The single convergent recommended finding -- bind the phrase "recorded integrity hash" to the concrete `content_hash` lockfile field the implementation checks -- was folded.

> **Cross-PR count reconcile:** this PR bumps the shared spec count sites (Section 1.3 count sentence, Appendix C trailer, Appendix D revision history) from base **87 -> 89**. The sibling spec-citation PR **#1793** edits the same shared sites independently. Whichever of #1793 / #1794 merges **second** will need a trivial reconcile: bump the cumulative count to the union total and take the union of the added Appendix C / manifest rows. Authored independently; no count coordination attempted between the two PRs.

Part of #1774
