### PR TITLE
docs(governance): surface install-vs-runtime plane boundary on travelled paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Agent context is executable in effect — a prompt is a program for an LLM. APM 
 
 `apm-policy.yml` lets a security team say *"these are the only sources, scopes, and primitives this org will allow"* and have every `apm install` enforce it — with tighten-only inheritance from enterprise to org to repo, a published bypass contract, and audit-mode CI gates.
 
+apm-policy.yml governs what gets installed; your agent harness governs what runs. The two planes do not overlap.
+
 - **[Governance Guide](https://microsoft.github.io/apm/enterprise/governance-guide/)** — the canonical enterprise reference: enforcement points, bypass contract, air-gapped story, failure semantics, rollout playbook
 - **[Policy reference](https://microsoft.github.io/apm/enterprise/policy-reference/)** — every check, every field, every default
 - **[Adoption playbook](https://microsoft.github.io/apm/enterprise/adoption-playbook/)** — staged rollout from warn to block across hundreds of repos

--- a/docs/src/content/docs/concepts/the-three-promises.md
+++ b/docs/src/content/docs/concepts/the-three-promises.md
@@ -92,6 +92,10 @@ dependencies. Tighten-only inheritance flows enterprise -> org ->
 repo. `apm audit --ci` wires the same checks into branch protection.
 This is the supply-chain check npm and pip cannot do.
 
+This governance covers the install and integrity plane -- what reaches
+disk and whether it conforms to policy. Runtime behavior governance
+belongs to your agent harness, not to APM.
+
 The 10-second demo:
 
 ```bash

--- a/docs/src/content/docs/concepts/what-is-apm.md
+++ b/docs/src/content/docs/concepts/what-is-apm.md
@@ -36,7 +36,7 @@ For deeper definitions, see [Primitives and targets](../primitives-and-targets/)
 
 ## What APM is not
 
-- **Not a runtime.** APM ships context to the harness; the harness runs the agent. `apm install` writes files and exits.
+- **Not a runtime.** APM governs the install and integrity plane -- what reaches disk and whether it conforms to policy. It does not govern the runtime plane -- what a running agent may do, which permissions it holds, or how it is sandboxed. That responsibility belongs to your agent harness. The two planes do not overlap. For how policy coexists with harness-managed configuration, see [Governance overview](/apm/enterprise/governance-overview/#boundary-statement).
 - **Not an LLM gateway.** APM does not route, proxy, or meter model calls. It does not see your prompts at inference time.
 - **Not a fine-tuning tool.** APM versions context, not weights.
 - **Not a marketplace.** Any git repository is a valid APM package. Marketplaces are an optional discovery surface, not a requirement.

--- a/docs/src/content/docs/consumer/governance-on-the-consumer-ramp.md
+++ b/docs/src/content/docs/consumer/governance-on-the-consumer-ramp.md
@@ -8,6 +8,9 @@ is checked against it before anything is written to disk. You did not
 write this file. Your platform or security team did. This page covers
 what that means for your day-to-day work.
 
+APM policy governs what gets installed, not what runs. For the full
+boundary explanation, see [What is APM](/apm/concepts/what-is-apm/#what-apm-is-not).
+
 ## Where the policy lives
 
 APM auto-discovers `apm-policy.yml` from your project's git remote. For

--- a/docs/src/content/docs/enterprise/apm-policy-getting-started.md
+++ b/docs/src/content/docs/enterprise/apm-policy-getting-started.md
@@ -164,6 +164,11 @@ For CI gating that runs even when a developer passes `--no-policy`
 locally, wire `apm audit --ci --policy org` into your pipeline. See
 [../enforce-in-ci/](./enforce-in-ci/).
 
+APM policy governs install-time decisions only. If you need runtime
+permission controls, those belong in your harness configuration, not in
+`apm-policy.yml`. See
+[Governance overview](/apm/enterprise/governance-overview/#boundary-statement).
+
 ## 6. What a blocked install looks like
 
 When `enforcement: block` and a check fails, the user sees an inline

--- a/docs/src/content/docs/enterprise/apm-policy.md
+++ b/docs/src/content/docs/enterprise/apm-policy.md
@@ -33,6 +33,8 @@ It declares:
 
 It does **not** scan code semantics or behave like an antivirus. It enforces declarations against an allow/deny list before APM writes any file.
 
+The policy schema addresses install-time gates exclusively. It has no fields for runtime permissions or agent sandboxing. See [Governance overview](/apm/enterprise/governance-overview/#boundary-statement) for how APM policy coexists with harness configuration.
+
 ---
 
 ## Where it lives

--- a/docs/src/content/docs/enterprise/governance-overview.md
+++ b/docs/src/content/docs/enterprise/governance-overview.md
@@ -84,6 +84,10 @@ Three execution surfaces, by environment:
 
 [i] APM enforces in the CLI and in CI. It is not a runtime sandbox. The model assumes branch protection on `<org>/.github/apm-policy.yml`, branch protection requiring `apm audit --ci` to pass, and either a registry proxy or the lockfile content-hash check covering download integrity. Take any one of those three away and the contract weakens.
 
+:::note[Does my harness's managed configuration replace APM?]
+No. `apm-policy.yml` controls what gets installed and whether it passes integrity checks. Your harness controls what runs -- permissions, sandboxing, tool access. They address different planes and do not overlap.
+:::
+
 ## Read this chapter in order
 
 1. [APM policy: getting started](./apm-policy-getting-started/) -- the smallest useful `apm-policy.yml` you can write today; what each top-level key does.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -28,7 +28,7 @@ APM is a dependency manager for AI agents. Declare the skills, prompts, instruct
     Every install scans for hidden Unicode, pins content hashes, and blocks transitive MCP servers unless they are explicitly declared or trusted. No opt-in required.
   </Card>
   <Card title="Governed by policy" icon="setting">
-    `apm-policy.yml` is enforced at install time, including transitive MCP. Tighten-only inheritance flows enterprise -> org -> repo. See the [Governance Guide](/apm/enterprise/governance-guide/).
+    `apm-policy.yml` is enforced at install time, including transitive MCP. Tighten-only inheritance flows enterprise -> org -> repo. Runtime behavior is your harness's domain. See the [Governance Guide](/apm/enterprise/governance-guide/).
   </Card>
 </CardGrid>
 

--- a/docs/src/content/docs/reference/policy-schema.md
+++ b/docs/src/content/docs/reference/policy-schema.md
@@ -90,7 +90,7 @@ Unknown top-level keys produce a warning, never an error -- so newer policy file
 
 Rules over the `dependencies:` and `mcp:` blocks declared in consumer `apm.yml` files.
 
-When a dependency matches `deny`, `apm install` will **not install that artifact** -- with `enforcement: block` the install aborts before the package is written to disk. `deny` is an install-time decision, not a runtime block: it stops a denied artifact from being installed, and does not constrain what an already-installed or otherwise-present artifact does at runtime.
+When a dependency matches `deny`, `apm install` will **not download or deploy that artifact**. With `enforcement: block`, the install aborts before any new files for the denied package are written. `deny` is an install-time decision, not a runtime block: it stops a denied artifact from being installed, and does not constrain what an already-installed or otherwise-present artifact does at runtime.
 
 | Field                | Type                  | Default          | Notes                                                                                       |
 |----------------------|-----------------------|------------------|---------------------------------------------------------------------------------------------|

--- a/docs/src/content/docs/reference/policy-schema.md
+++ b/docs/src/content/docs/reference/policy-schema.md
@@ -11,6 +11,27 @@ The `apm-policy.yml` schema. One file per org or repo. Loaded by `apm install`, 
 
 For the workflow (where to put the file, how to roll it out), see [Govern with apm-policy.yml](../enterprise/apm-policy-getting-started/). For CLI usage of `apm policy status`, see [apm policy](./cli/policy/). For the wider governance picture (rulesets, registry proxy, CI gating), see [Governance overview](../enterprise/governance-overview/).
 
+## What apm-policy.yml governs
+
+`apm-policy.yml` is the **install policy** for agent primitives. In plain terms it decides:
+
+- **Which sources are trusted** -- which dependencies and MCP servers `apm install` will accept (the `allow` / `deny` / `registry_source` rules).
+- **Which versions install** -- whether refs must be pinned to bounded constraints, and how version conflicts on required packages resolve.
+- **What the lockfile records and verifies** -- which artifacts are written, and what install-time audit checks run before they land on disk.
+
+Every rule on this page is evaluated by `apm install` and `apm audit --ci`. They govern what gets installed -- not what a running agent is later allowed to do.
+
+## What apm-policy.yml does NOT govern
+
+`apm-policy.yml` is not a runtime permission system. It does not control:
+
+- **Runtime permissions** -- what an agent may read, write, or call once it is running.
+- **Sandboxing** -- process isolation or resource limits for a running agent.
+- **Agent behavior** -- what a running agent actually does with the primitives it was given.
+- **Marketplace enablement** -- which tools or extensions a harness exposes to the agent.
+
+Those controls are owned by the **agent harness** that runs your agents, not by APM. APM stops at install: it decides what reaches disk, and the harness decides what runs.
+
 ## File location
 
 Discovery order, in priority:
@@ -68,6 +89,8 @@ Unknown top-level keys produce a warning, never an error -- so newer policy file
 ## dependencies
 
 Rules over the `dependencies:` and `mcp:` blocks declared in consumer `apm.yml` files.
+
+When a dependency matches `deny`, `apm install` will **not install that artifact** -- with `enforcement: block` the install aborts before the package is written to disk. `deny` is an install-time decision, not a runtime block: it stops a denied artifact from being installed, and does not constrain what an already-installed or otherwise-present artifact does at runtime.
 
 | Field                | Type                  | Default          | Notes                                                                                       |
 |----------------------|-----------------------|------------------|---------------------------------------------------------------------------------------------|
@@ -366,6 +389,12 @@ bin_deploy:
   deny:
     - myorg/untrusted-plugin
 ```
+
+## FAQ
+
+**Does my harness's managed configuration replace APM?**
+
+No. apm-policy.yml controls what gets installed; your harness controls what runs; they do not overlap.
 
 ## See also
 

--- a/docs/src/content/docs/reference/policy-schema.md
+++ b/docs/src/content/docs/reference/policy-schema.md
@@ -17,9 +17,9 @@ For the workflow (where to put the file, how to roll it out), see [Govern with a
 
 - **Which sources are trusted** -- which dependencies and MCP servers `apm install` will accept (the `allow` / `deny` / `registry_source` rules).
 - **Which versions install** -- whether refs must be pinned to bounded constraints, and how version conflicts on required packages resolve.
-- **What the lockfile records and verifies** -- which artifacts are written, and what install-time audit checks run before they land on disk.
+- **What the lockfile records and verifies** -- which artifacts the lockfile records, and what the install-time audit pass checks over them once written.
 
-Every rule on this page is evaluated by `apm install` and `apm audit --ci`. They govern what gets installed -- not what a running agent is later allowed to do.
+`apm install` enforces the dependency and MCP source rules during install; `apm audit --ci` evaluates every rule on this page. Together they govern what gets installed -- not what a running agent is later allowed to do.
 
 ## What apm-policy.yml does NOT govern
 
@@ -90,7 +90,7 @@ Unknown top-level keys produce a warning, never an error -- so newer policy file
 
 Rules over the `dependencies:` and `mcp:` blocks declared in consumer `apm.yml` files.
 
-When a dependency matches `deny`, `apm install` will **not download or deploy that artifact**. With `enforcement: block`, the install aborts before any new files for the denied package are written. `deny` is an install-time decision, not a runtime block: it stops a denied artifact from being installed, and does not constrain what an already-installed or otherwise-present artifact does at runtime.
+When a dependency matches `deny`, `apm install` will **not download or deploy that artifact**. With `enforcement: block`, the install aborts before the denied package is downloaded or deployed. `deny` is an install-time decision, not a runtime block: it stops a denied artifact from being installed, and does not constrain what an already-installed or otherwise-present artifact does at runtime.
 
 | Field                | Type                  | Default          | Notes                                                                                       |
 |----------------------|-----------------------|------------------|---------------------------------------------------------------------------------------------|


### PR DESCRIPTION
## Summary

Propagates the install+integrity plane vs runtime plane boundary from the deep `reference/policy-schema.md` page (clarified in #1792) onto the high-traffic docs paths readers actually travel. Today the crucial "governs vs does NOT govern" boundary and the harness-vs-APM FAQ are reachable only on a deep reference page; this surfaces them where readers form their APM scope model.

The architecture being made legible:

- **APM governs the install + integrity plane** -- what reaches disk and whether it conforms to policy.
- **The agent harness governs the runtime plane** -- what a running agent may do, which permissions it holds, how it is sandboxed.
- The two planes do not overlap.

## Stacked on #1792

[i] This PR is **stacked on #1792** (base branch `danielmeppiel/clarify-policy-docs`). #1792 fixes the boundary at the source (the policy-schema reference); this PR propagates it onto travelled paths. Merge #1792 first, or merge both together -- the file sets are disjoint, so there is no conflict in either order.

## Approach: define-once, cross-link

- Boundary **definition** lives once on `concepts/what-is-apm.md` (`#what-apm-is-not`).
- The harness **FAQ** lives once on `enterprise/governance-overview.md` (`#boundary-statement`).
- The other surfaces cross-link to those canonical homes rather than copy-pasting -- anti-bloat.

## Pages touched (8)

| Page | Change |
|---|---|
| `concepts/what-is-apm.md` | "Not a runtime" bullet rewritten into the positive two-plane framing + fwd cross-link (canonical definition) |
| `enterprise/governance-overview.md` | Full harness FAQ callout after the Boundary statement (canonical FAQ home) |
| `enterprise/apm-policy-getting-started.md` | Install-time-only guardrail sentence + cross-link |
| `concepts/the-three-promises.md` | One citability sentence under Promise 3 |
| `enterprise/apm-policy.md` | Schema scopes install-time gates exclusively; no runtime fields + cross-link |
| `consumer/governance-on-the-consumer-ramp.md` | "APM policy governs what gets installed, not what runs" + cross-link |
| `index.mdx` | "Runtime behavior is your harness's domain." appended to the "Governed by policy" card |
| `README.md` | One-line boundary note in the "Governed by policy" section (maintainer-approved wording) |

## Validation

- `npm run build` (Astro + Starlight) green; `starlight-links-validator` reports all internal links valid (including the `#boundary-statement` and `#what-apm-is-not` fragment anchors).
- ASCII-only; generic "agent harness" (no vendor names); no competitive framing.

Relates to #1776, #1774. Not for auto-merge.