### PR TITLE
fix(ci): spec-conformance Mode B gate fails closed on unresolvable merge-base

### DIFF
--- a/.github/workflows/spec-conformance.yml
+++ b/.github/workflows/spec-conformance.yml
@@ -32,6 +32,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so the Mode B detector can deterministically
+          # resolve the merge-base against origin/main. Without this the
+          # gate's unresolvable-merge-base branch becomes reachable in CI.
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v6
 
       - name: Orphan check (anchors == manifest == Appendix C == markers)

--- a/tests/spec_conformance/mode_b_detector.sh
+++ b/tests/spec_conformance/mode_b_detector.sh
@@ -57,6 +57,14 @@ if ! MB="$(git merge-base "$BASE" HEAD 2>/dev/null)"; then
   MB="$(git merge-base "$BASE" HEAD 2>/dev/null || true)"
 fi
 if [ -z "${MB:-}" ]; then
+  # Fail closed under CI: a governance gate must never pass by failing to
+  # evaluate. Locally (shallow clones), keep the ergonomic skip.
+  if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    echo "::error::mode_b: cannot resolve merge-base against $BASE in CI;" >&2
+    echo "::error::refusing to pass without evaluating (fail closed). Ensure" >&2
+    echo "::error::actions/checkout uses fetch-depth: 0 so origin/main is reachable." >&2
+    exit 1
+  fi
   echo "[!] mode_b: cannot resolve merge-base against $BASE; skipping"
   exit 0
 fi

--- a/tests/spec_conformance/test_mode_b_detector.py
+++ b/tests/spec_conformance/test_mode_b_detector.py
@@ -162,6 +162,55 @@ def test_detector_rejects_short_waiver(tmp_path):
     assert out.returncode == 1, "detector MUST reject waivers below the 16-char minimum"
 
 
+def test_detector_fails_closed_in_ci_on_unresolvable_merge_base(tmp_path):
+    """Under CI (GITHUB_ACTIONS=true), an unresolvable merge-base MUST
+    fail closed (exit non-zero) instead of skipping. A governance gate
+    that cannot evaluate must never pass by luck of the checkout.
+    Locally (no GITHUB_ACTIONS), the ergonomic skip (exit 0) is kept."""
+    repo = _make_repo(tmp_path)
+    target = repo / "src" / "apm_cli" / "deps" / "new_behaviour.py"
+    target.write_text(
+        "def new_resolver_branch(x):\n"
+        + "\n".join(f"    y_{i} = x + {i}" for i in range(40))
+        + "\n    return y_0\n"
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-m", "silent extension under deps/")
+
+    # Point BASE at a ref that does not exist so merge-base cannot
+    # resolve (the on-demand fetch/unshallow fail against a local repo
+    # with no real remote, leaving MB empty).
+    base = "origin/does-not-exist"
+
+    ci = _run_detector_with_env(repo, BASE_REF=base, GITHUB_ACTIONS="true")
+    assert ci.returncode != 0, (
+        "detector MUST fail closed in CI when the merge-base is "
+        f"unresolvable; got exit {ci.returncode}\nstdout: {ci.stdout}\n"
+        f"stderr: {ci.stderr}"
+    )
+    assert "cannot resolve merge-base" in ci.stderr, ci.stderr
+
+    local = _run_detector_with_env(repo, BASE_REF=base)
+    assert local.returncode == 0, (
+        "detector MUST keep the ergonomic skip locally (no "
+        f"GITHUB_ACTIONS); got exit {local.returncode}\n"
+        f"stdout: {local.stdout}\nstderr: {local.stderr}"
+    )
+    assert "skipping" in local.stdout, local.stdout
+
+
+def test_workflow_checkout_uses_full_history():
+    """The CI workflow MUST check out full history (fetch-depth: 0) so
+    the Mode B detector can deterministically resolve the merge-base.
+    Without this, the detector's unresolvable-merge-base branch becomes
+    reachable in CI -- the root-cause fail-open hole this gate closes."""
+    body = WORKFLOW.read_text()
+    assert "fetch-depth: 0" in body, (
+        ".github/workflows/spec-conformance.yml MUST set fetch-depth: 0 "
+        "on actions/checkout so origin/main is reachable for merge-base"
+    )
+
+
 def test_workflow_invokes_detector_after_orphan_check():
     """The CI workflow MUST wire the detector as a step."""
     body = WORKFLOW.read_text()
@@ -239,6 +288,24 @@ def _run_detector(repo: Path) -> subprocess.CompletedProcess:
     # Disable the env-var waiver path; we test commit-trailer waivers
     # by leaving GH_PR_BODY unset.
     env.pop("GH_PR_BODY", None)
+    return subprocess.run(
+        ["bash", "tests/spec_conformance/mode_b_detector.sh"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _run_detector_with_env(repo: Path, **overrides: str) -> subprocess.CompletedProcess:
+    """Run the detector with explicit env overrides. GH_PR_BODY is
+    cleared so only the supplied vars drive behaviour."""
+    env = {**os.environ}
+    env.pop("GH_PR_BODY", None)
+    # Strip any ambient GITHUB_ACTIONS so callers control it explicitly.
+    env.pop("GITHUB_ACTIONS", None)
+    env.update(overrides)
     return subprocess.run(
         ["bash", "tests/spec_conformance/mode_b_detector.sh"],
         cwd=repo,


### PR DESCRIPTION
## TL;DR

The OpenAPM **Spec conformance gate** (Mode B silent-extension detector) failed **open**. This PR closes that hole: full-history checkout in CI plus a fail-closed branch in the detector, locked by a regression test.

## Problem (WHY)

`.github/workflows/spec-conformance.yml` checked out shallow (no `fetch-depth: 0`), and `tests/spec_conformance/mode_b_detector.sh` did `exit 0` (skip == pass) whenever it could not resolve the merge-base against `origin/main`. So a PR adding uncited substantive code under a normative critical path could pass the gate **by luck of the checkout** -- a fail-open hole in a governance gate. Full diagnosis in #1800.

## Approach (WHAT)

- `[*]` **Root-cause fix** -- `actions/checkout@v4` now uses `fetch-depth: 0`, so the merge-base is deterministically resolvable in CI and the skip branch is unreachable there.
- `[*]` **Defense in depth** -- under `GITHUB_ACTIONS=true`, an unresolvable merge-base now emits an `::error::` diagnostic and `exit 1` (fail closed). Local dev (shallow clones) keeps the ergonomic skip (`exit 0`).
- `[*]` **Regression lock** -- new tests pin both invariants (CI fail-closed + local skip) and assert the workflow sets `fetch-depth: 0`.

## Implementation (HOW)

```
.github/workflows/spec-conformance.yml   + fetch-depth: 0 on checkout
tests/spec_conformance/mode_b_detector.sh   CI -> ::error:: + exit 1; local -> [!] skip + exit 0
tests/spec_conformance/test_mode_b_detector.py   +2 regression tests, +1 helper
```

## Validation evidence (HOW-tested)

- `[+]` `uv run --extra dev pytest tests/spec_conformance/test_mode_b_detector.py -p no:randomly -q` -- 11 passed
- `[+]` `uv run --extra dev pytest tests/spec_conformance -p no:randomly -q` -- 120 passed, 2 skipped
- `[+]` Mutation-break: reverting the new `exit 1` back to `exit 0` makes `test_detector_fails_closed_in_ci_on_unresolvable_merge_base` fail; restored.
- `[+]` Sanity: `BASE_REF=origin/main bash tests/spec_conformance/mode_b_detector.sh` on this branch -> `no critical-path diff; OK` (does not self-block; this PR touches only `.github/` + `tests/spec_conformance/`, which are not in `critical_paths.txt`).
- `[+]` CI-mirror lint: `ruff check`, `ruff format --check`, `pylint R0801`, `scripts/lint-auth-signals.sh` -- all clean.

ASCII-only output throughout.

Closes #1800
Part of #1774