### PR TITLE
feat(integration): converge windsurf skills onto .agents/skills/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING: Windsurf skills now deploy to `.agents/skills/<name>/SKILL.md`
+  instead of `.windsurf/skills/<name>/SKILL.md` (skill routing convergence).**
+  Cascade
+  [natively discovers `.agents/skills/`](https://docs.windsurf.com/windsurf/cascade/skills#skill-scopes)
+  at both workspace and user scope, so Windsurf joins the existing convergence
+  with Copilot, Cursor, Codex, Gemini, and OpenCode (6 clients total) and APM
+  no longer writes a separate `.windsurf/skills/` copy. Claude remains on its
+  native `.claude/skills/` routing. **Migration:** the first `apm install`
+  after upgrading auto-migrates any `.windsurf/skills/<pkg>/` recorded in
+  `apm.lock.yaml` to `.agents/skills/` and deletes the stale copy (idempotent;
+  foreign/hand-authored skills are untouched; aborts with a clear error on a
+  content collision). If you never re-run `apm install`, delete the stale
+  directories by hand: `rm -rf .windsurf/skills/<pkg>/`. Pass
+  `--legacy-skill-paths` (or set `APM_LEGACY_SKILL_PATHS=1`) to keep the
+  pre-convergence `.windsurf/skills/` layout. (closes #1520)
+
 ### Removed
 
 - `apm marketplace publish` command and consumer-repo fan-out workflow; consumers should run `apm install --update` instead. (#1134)

--- a/docs/src/content/docs/getting-started/migration.md
+++ b/docs/src/content/docs/getting-started/migration.md
@@ -104,7 +104,9 @@ skill collection layout reference.
 ## Skill routing convergence
 
 :::caution[Behavior change]
-Skills for **Copilot, Cursor, OpenCode, Codex, and Gemini** now deploy to `.agents/skills/` by default instead of per-client directories (`.github/skills/`, `.cursor/skills/`, `.gemini/skills/`, etc.). This matches the `.agents/` discovery path documented by all five clients and eliminates redundant copies when targeting multiple clients.
+Skills for **Copilot, Cursor, OpenCode, Codex, Gemini, and Windsurf** now deploy to `.agents/skills/` by default instead of per-client directories (`.github/skills/`, `.cursor/skills/`, `.gemini/skills/`, `.windsurf/skills/`, etc.). This matches the `.agents/` discovery path documented by all six clients and eliminates redundant copies when targeting multiple clients.
+
+**Windsurf joined the convergence in [#1520](https://github.com/microsoft/apm/issues/1520).** Cascade [natively discovers `.agents/skills/`](https://docs.windsurf.com/windsurf/cascade/skills#skill-scopes) at both workspace and user scope, so APM no longer writes a separate `.windsurf/skills/` copy. The next `apm install` after upgrading auto-migrates any `.windsurf/skills/<pkg>/` recorded in `apm.lock.yaml` to `.agents/skills/` and deletes the stale copy (see below). If you never re-run `apm install`, remove the stale directories by hand with `rm -rf .windsurf/skills/<pkg>/`.
 
 **Claude is unchanged** - its skills continue to deploy to `.claude/skills/`.
 
@@ -113,7 +115,7 @@ To restore the previous per-client layout, pass `--legacy-skill-paths` to any co
 
 ### Auto-migration of legacy lockfile state
 
-When you upgrade APM and run `apm install`, the tool automatically detects legacy per-client skill paths (`.github/skills/`, `.cursor/skills/`, `.opencode/skills/`, `.gemini/skills/`) recorded in your `apm.lock.yaml` and migrates them to `.agents/skills/`.
+When you upgrade APM and run `apm install`, the tool automatically detects legacy per-client skill paths (`.github/skills/`, `.cursor/skills/`, `.opencode/skills/`, `.gemini/skills/`, `.windsurf/skills/`) recorded in your `apm.lock.yaml` and migrates them to `.agents/skills/`.
 
 **What happens:**
 - Old per-client skill files are deleted after the new `.agents/skills/` files are written
@@ -135,7 +137,7 @@ per-client skill paths to `.agents/skills/` and update `apm.lock.yaml`. In
 CI pipelines, this means the working tree will show:
 
 - Deletions under `.github/skills/`, `.cursor/skills/`, `.opencode/skills/`,
-  and/or `.gemini/skills/`
+  `.gemini/skills/`, and/or `.windsurf/skills/`
 - Additions under `.agents/skills/`
 - An updated `apm.lock.yaml`
 

--- a/docs/src/content/docs/producer/author-primitives/skills.md
+++ b/docs/src/content/docs/producer/author-primitives/skills.md
@@ -99,22 +99,23 @@ in `references/`; keep `SKILL.md` to the always-relevant flow.
 | Target            | Deploy directory                             |
 |-------------------|----------------------------------------------|
 | `claude`          | `.claude/skills/<name>/SKILL.md`             |
-| `windsurf`        | `.windsurf/skills/<name>/SKILL.md`           |
 | `kiro`            | `.kiro/skills/<name>/SKILL.md`               |
 | `copilot`         | `.agents/skills/<name>/SKILL.md`             |
 | `cursor`          | `.agents/skills/<name>/SKILL.md`             |
 | `codex`           | `.agents/skills/<name>/SKILL.md`             |
 | `gemini`          | `.agents/skills/<name>/SKILL.md`             |
 | `opencode`        | `.agents/skills/<name>/SKILL.md`             |
+| `windsurf`        | `.agents/skills/<name>/SKILL.md`             |
 | `agent-skills`    | `.agents/skills/<name>/SKILL.md` (explicit)  |
 
-Five harnesses converge on the cross-tool `.agents/skills/`
+Six harnesses converge on the cross-tool `.agents/skills/`
 directory. Claude keeps its harness-native path because Claude Code's
-default scan is `.claude/skills/`; Windsurf and Kiro currently use
-`.windsurf/skills/` and `.kiro/skills/` for the same reason. Windsurf's Cascade also
-[discovers `.agents/skills/`](https://docs.windsurf.com/windsurf/cascade/skills#skill-scopes)
-natively for cross-agent compatibility (convergence tracked in
-[#1520](https://github.com/microsoft/apm/issues/1520)). The whole
+default scan is `.claude/skills/`; Kiro likewise keeps `.kiro/skills/`.
+Windsurf joined the convergence in
+[#1520](https://github.com/microsoft/apm/issues/1520): Cascade
+[natively discovers `.agents/skills/`](https://docs.windsurf.com/windsurf/cascade/skills#skill-scopes)
+at both workspace and user scope, so APM no longer ships a separate
+`.windsurf/skills/` copy. The whole
 skill folder is copied (`shutil.copytree`), so `scripts/`,
 `references/`, `assets/`, and `examples/` ride along. Symlinks and
 the `.apm-pin` cache marker are filtered out

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -157,7 +157,7 @@ A plural alias `targets:` (YAML list only) is also accepted and takes precedence
 | `opencode` | Emits to `.opencode/agents/`, `.opencode/commands/`, `.opencode/skills/`. |
 | `codex` | Emits `AGENTS.md` and deploys skills to `.agents/skills/`, agents to `.codex/agents/`. |
 | `gemini` | Emits `GEMINI.md` and deploys to `.gemini/commands/`, `.gemini/skills/`, `.gemini/settings.json`. |
-| `windsurf` | Emits `AGENTS.md` and deploys to `.windsurf/rules/`, `.windsurf/skills/`, `.windsurf/workflows/`, `.windsurf/hooks.json`. |
+| `windsurf` | Emits `AGENTS.md` and deploys skills to `.agents/skills/`, plus `.windsurf/rules/`, `.windsurf/workflows/`, `.windsurf/hooks.json`. |
 | `kiro` | Emits `AGENTS.md` and deploys to `.kiro/steering/`, `.kiro/skills/`, `.kiro/hooks/`, `.kiro/settings/mcp.json`. |
 | `all` | All targets. Cannot be combined with other values in a list. |
 | `minimal` | `AGENTS.md` only at project root. **Auto-detected only**: this value MUST NOT be set explicitly in manifests; it is an internal fallback when no target folder is detected. |

--- a/docs/src/content/docs/reference/targets-matrix.md
+++ b/docs/src/content/docs/reference/targets-matrix.md
@@ -25,13 +25,13 @@ see [Primitive types](./primitive-types/).
 | codex           | `.codex/` + `.agents/` |     [ ]      |   [ ]   |  [x]   |  [x]   |   [ ]    |  [x]  | [x] |
 | gemini          | `.gemini/`             |     [ ]      |   [ ]   |  [ ]   |  [x]   |   [x]    |  [x]  | [x] |
 | opencode        | `.opencode/`           |     [ ]      |   [ ]   |  [x]   |  [x]   |   [x]    |  [ ]  | [x] |
-| windsurf        | `.windsurf/`           |     [x]      |   [ ]   |  [ ]   |  [x]   |   [x]    |  [x]  | [x] |
+| windsurf        | `.windsurf/` + `.agents/` |  [x]      |   [ ]   |  [ ]   |  [x]   |   [x]    |  [x]  | [x] |
 | kiro            | `.kiro/`               |     [x]      |   [ ]   |  [ ]   |  [x]   |   [ ]    |  [x]  | [x] |
 | agent-skills    | `.agents/`             |     [ ]      |   [ ]   |  [ ]   |  [x]   |   [ ]    |  [ ]  | [ ] |
 
 Skills deploy to `.agents/skills/` for Copilot, Cursor, OpenCode,
-Gemini, and Codex by default (see [Skills convergence](#skills-convergence)
-below). Claude, Windsurf, and Kiro keep target-native skill directories.
+Gemini, Codex, and Windsurf by default (see [Skills convergence](#skills-convergence)
+below). Claude and Kiro keep target-native skill directories.
 
 `copilot-cowork` (Microsoft 365 Copilot), `copilot-app` (GitHub
 Copilot desktop App), and `openclaw` (OpenClaw agent runtime) are
@@ -164,11 +164,11 @@ OpenCode.
 Windsurf / Cascade.
 
 - **Detection.** `.windsurf/` directory.
-- **Deploy directory.** `.windsurf/` at project scope; `~/.codeium/windsurf/` at user scope.
+- **Deploy directory.** `.windsurf/` at project scope (`~/.codeium/windsurf/` at user scope), plus `.agents/` for skills.
 - **Supported primitives.** instructions, skills, commands, hooks, mcp.
 - **File conventions.**
   - instructions: `.windsurf/rules/<name>.md`
-  - skills: `.windsurf/skills/<name>/SKILL.md`
+  - skills: `.agents/skills/<name>/SKILL.md` (Cascade natively discovers `.agents/skills/`; [#1520](https://github.com/microsoft/apm/issues/1520))
   - commands: `.windsurf/workflows/<name>.md`
   - hooks: `.windsurf/hooks.json`
 - **Agents.** Not deployed. Cascade auto-invokes any `SKILL.md` by its `description:` frontmatter, so a separate agents primitive would collide with skills on the same path. Ship personas as skills under `.apm/skills/<name>/SKILL.md` instead.

--- a/src/apm_cli/bundle/lockfile_enrichment.py
+++ b/src/apm_cli/bundle/lockfile_enrichment.py
@@ -16,9 +16,10 @@ from ..integration.targets import KNOWN_TARGETS
 # for Copilot.  Cursor/opencode sources are niche; if someone publishes
 # skills exclusively under .cursor/, they must pack with --target cursor.
 #
-# Windsurf converts agents -> skills (lossy: AGENTS.md format is collapsed
-# into the windsurf skill envelope), so .github/agents/ maps to
-# .windsurf/skills/.
+# Windsurf converges skills onto the cross-tool .agents/skills/ directory
+# (apm#1520), so .github/skills/ maps there.  It also converts agents ->
+# skills (lossy: AGENTS.md format is collapsed into the windsurf skill
+# envelope), so .github/agents/ maps to .agents/skills/ as well.
 _CROSS_TARGET_MAPS: dict[str, dict[str, str]] = {
     "claude": {
         ".github/skills/": ".claude/skills/",
@@ -45,8 +46,8 @@ _CROSS_TARGET_MAPS: dict[str, dict[str, str]] = {
         ".github/agents/": ".codex/agents/",
     },
     "windsurf": {
-        ".github/skills/": ".windsurf/skills/",
-        ".github/agents/": ".windsurf/skills/",
+        ".github/skills/": ".agents/skills/",
+        ".github/agents/": ".agents/skills/",
     },
     "agent-skills": {
         ".github/skills/": ".agents/skills/",

--- a/src/apm_cli/install/skill_path_migration.py
+++ b/src/apm_cli/install/skill_path_migration.py
@@ -54,7 +54,11 @@ _log = logging.getLogger(__name__)
 # Legacy per-client skill prefixes that have been converged into .agents/skills/.
 # .claude/skills/ is excluded (Claude is not in the convergence set).
 # .codex/skills/ was never a legacy path (Codex always used .agents/).
-_LEGACY_SKILL_PATTERN = re.compile(r"^\.(github|cursor|opencode|gemini)/skills/([^/]+)/.+$")
+# .windsurf/skills/ joined the convergence in apm#1520; prior APM versions
+# deployed windsurf skills there, so it is migrated like the other clients.
+_LEGACY_SKILL_PATTERN = re.compile(
+    r"^\.(github|cursor|opencode|gemini|windsurf)/skills/([^/]+)/.+$"
+)
 
 # ------------------------------------------------------------------
 # Shared message templates (single source of truth — H6)

--- a/src/apm_cli/integration/targets.py
+++ b/src/apm_cli/integration/targets.py
@@ -664,8 +664,16 @@ KNOWN_TARGETS: dict[str, TargetProfile] = {
     ),
     # Windsurf/Cascade -- .windsurf/ is the workspace config directory.
     # Rules are markdown files with trigger/globs frontmatter under .windsurf/rules/.
-    # Skills use the standard SKILL.md format under .windsurf/skills/.
-    # Cascade auto-invokes them when the description frontmatter matches the
+    # Skills converge on the cross-tool ``.agents/skills/<name>/SKILL.md`` path
+    # (deploy_root=".agents"): Cascade natively discovers ``.agents/skills/`` at
+    # both workspace and user scope, so windsurf joins the same convergence as
+    # copilot/cursor/codex/gemini/opencode instead of keeping a windsurf-native
+    # ``.windsurf/skills/`` copy (apm#1520).  Pass ``--legacy-skill-paths`` (or
+    # ``APM_LEGACY_SKILL_PATHS=1``) to restore the pre-convergence
+    # ``.windsurf/skills/`` layout; ``apply_legacy_skill_paths`` resets
+    # ``deploy_root`` to ``None``.
+    # Ref: https://docs.windsurf.com/windsurf/cascade/skills#skill-scopes
+    # Cascade auto-invokes a skill when its description frontmatter matches the
     # task -- this is the universal invocation mechanism, so windsurf does
     # NOT expose a separate ``agents`` primitive.  Package authors who want
     # their content to deploy to windsurf must declare it under
@@ -688,7 +696,12 @@ KNOWN_TARGETS: dict[str, TargetProfile] = {
                 "windsurf_rules",
                 output_compare=True,
             ),
-            "skills": PrimitiveMapping("skills", "/SKILL.md", "skill_standard"),
+            "skills": PrimitiveMapping(
+                "skills",
+                "/SKILL.md",
+                "skill_standard",
+                deploy_root=".agents",
+            ),
             "commands": PrimitiveMapping("workflows", ".md", "windsurf_workflow"),
             "hooks": PrimitiveMapping("", "hooks.json", "windsurf_hooks"),
         },
@@ -697,6 +710,9 @@ KNOWN_TARGETS: dict[str, TargetProfile] = {
         user_supported="partial",
         user_root_dir=".codeium/windsurf",
         unsupported_user_primitives=("instructions",),
+        # Skills deploy to .agents/ while rules/workflows/hooks stay under
+        # .windsurf/, so pack must include both roots (mirrors codex).
+        pack_prefixes=(".windsurf/", ".agents/"),
         compile_family="agents",
         hooks_config_display=".windsurf/hooks.json",
     ),

--- a/tests/integration/test_agent_skills_target.py
+++ b/tests/integration/test_agent_skills_target.py
@@ -811,3 +811,91 @@ def test_auto_migration_collision_skips_gracefully(
     out = r2.output or ""
     assert "Skill path migration skipped" in out or "already exist" in out
     assert "--legacy-skill-paths" in out
+
+
+# ---------------------------------------------------------------------------
+# Windsurf convergence (apm#1520)
+# ---------------------------------------------------------------------------
+
+
+def _make_windsurf_project(tmp_path: Path) -> Path:
+    """Project with ``.windsurf/`` present so the windsurf target deploys.
+
+    windsurf has ``auto_create=False`` and ``detect_by_dir=True`` keyed off
+    ``.windsurf/`` (NOT ``.agents/``), so skills only deploy when the
+    workspace already has a ``.windsurf/`` directory -- even for the
+    converged ``.agents/skills/`` path.
+    """
+    project = _make_project(tmp_path / "dst", with_github=False)
+    (project / ".windsurf").mkdir()
+    return project
+
+
+def test_windsurf_install_deploys_to_agents_skills(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """apm#1520: ``apm install --target windsurf`` deploys skills to the
+    converged ``.agents/skills/<name>/SKILL.md`` path, NOT ``.windsurf/skills/``."""
+    bundle = _make_plugin_bundle(tmp_path / "src", pack_target="windsurf")
+    project = _make_windsurf_project(tmp_path)
+
+    monkeypatch.delenv("APM_LEGACY_SKILL_PATHS", raising=False)
+    result = _invoke(project, ["install", str(bundle), "--target", "windsurf"], monkeypatch)
+    assert result.exit_code == 0, f"output={result.output!r}"
+
+    assert (project / ".agents/skills" / SKILL_NAME / "SKILL.md").is_file(), (
+        "windsurf skills must converge on .agents/skills/"
+    )
+    assert not (project / ".windsurf/skills" / SKILL_NAME / "SKILL.md").exists(), (
+        "windsurf must no longer write the per-client .windsurf/skills/ copy"
+    )
+
+
+def test_windsurf_legacy_flag_produces_windsurf_skills(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--legacy-skill-paths`` restores the pre-convergence ``.windsurf/skills/``
+    layout for the windsurf target."""
+    bundle = _make_plugin_bundle(tmp_path / "src", pack_target="windsurf")
+    project = _make_windsurf_project(tmp_path)
+
+    result = _invoke(
+        project,
+        ["install", str(bundle), "--target", "windsurf", "--legacy-skill-paths"],
+        monkeypatch,
+    )
+    assert result.exit_code == 0, f"output={result.output!r}"
+
+    assert (project / ".windsurf/skills" / SKILL_NAME / "SKILL.md").is_file(), (
+        "--legacy-skill-paths must restore .windsurf/skills/ for windsurf"
+    )
+    assert not (project / ".agents/skills" / SKILL_NAME / "SKILL.md").exists(), (
+        "legacy mode must not also write the converged .agents/skills/ copy"
+    )
+
+
+def test_windsurf_auto_migration_from_windsurf_skills(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A legacy ``.windsurf/skills/`` install auto-migrates to ``.agents/skills/``
+    on the next converged ``apm install`` (apm#1520)."""
+    bundle = _make_plugin_bundle(tmp_path / "src", pack_target="windsurf")
+    project = _make_windsurf_project(tmp_path)
+
+    # --- First install: legacy mode -> .windsurf/skills/ ---
+    monkeypatch.setenv("APM_LEGACY_SKILL_PATHS", "1")
+    r1 = _invoke(project, ["install", str(bundle), "--target", "windsurf"], monkeypatch)
+    assert r1.exit_code == 0, f"legacy install failed: {r1.output!r}"
+    assert (project / ".windsurf/skills" / SKILL_NAME / "SKILL.md").is_file()
+
+    # --- Second install: converged mode -> migrate ---
+    monkeypatch.delenv("APM_LEGACY_SKILL_PATHS", raising=False)
+    r2 = _invoke(project, ["install", str(bundle), "--target", "windsurf"], monkeypatch)
+    assert r2.exit_code == 0, f"migration install failed: {r2.output!r}"
+
+    assert (project / ".agents/skills" / SKILL_NAME / "SKILL.md").is_file(), (
+        "converged path must exist after migration"
+    )
+    assert not (project / ".windsurf/skills" / SKILL_NAME / "SKILL.md").exists(), (
+        "legacy .windsurf/skills/ copy must be removed by the migration"
+    )

--- a/tests/unit/install/test_skill_path_migration.py
+++ b/tests/unit/install/test_skill_path_migration.py
@@ -58,6 +58,7 @@ class TestLegacySkillPattern:
             ".cursor/skills/review/SKILL.md",
             ".opencode/skills/deep/nested/file.md",
             ".gemini/skills/lint/SKILL.md",
+            ".windsurf/skills/my-skill/SKILL.md",
         ],
     )
     def test_matches_legacy_clients(self, path: str) -> None:
@@ -132,14 +133,34 @@ class TestDetectLegacySkillDeployments:
                         ".cursor/skills/s1/SKILL.md",
                         ".opencode/skills/s1/SKILL.md",
                         ".gemini/skills/s1/SKILL.md",
+                        ".windsurf/skills/s1/SKILL.md",
                     ]
                 ),
             }
         )
         plans = detect_legacy_skill_deployments(lf, tmp_path)
-        assert len(plans) == 4
+        assert len(plans) == 5
         for plan in plans:
             assert plan.dst_path == ".agents/skills/s1/SKILL.md"
+
+    def test_detects_windsurf_legacy(self, tmp_path: Path) -> None:
+        """apm#1520: windsurf joined the convergence, so prior-version
+        .windsurf/skills/ deployments must be migrated to .agents/skills/."""
+        lf = _StubLockFile(
+            dependencies={
+                "pkg-a": _StubDep(
+                    deployed_files=[
+                        ".windsurf/skills/my-skill/SKILL.md",
+                        ".agents/skills/my-skill/SKILL.md",  # new path -- ignored
+                    ]
+                ),
+            }
+        )
+        plans = detect_legacy_skill_deployments(lf, tmp_path)
+        assert len(plans) == 1
+        assert plans[0].src_path == ".windsurf/skills/my-skill/SKILL.md"
+        assert plans[0].dst_path == ".agents/skills/my-skill/SKILL.md"
+        assert plans[0].dep_name == "pkg-a"
 
     def test_ignores_claude_and_codex(self, tmp_path: Path) -> None:
         lf = _StubLockFile(

--- a/tests/unit/integration/test_data_driven_dispatch.py
+++ b/tests/unit/integration/test_data_driven_dispatch.py
@@ -310,7 +310,8 @@ class TestExhaustivenessChecks:
             "agents_opencode",
             "agents_codex",
             # NOTE: windsurf no longer exposes an 'agents' primitive
-            # (its content deploys as skills under .windsurf/skills/).
+            # (its content deploys as skills under the converged
+            # .agents/skills/ directory; apm#1520).
             "commands",  # was commands_claude, aliased
             "commands_cursor",
             "commands_gemini",

--- a/tests/unit/integration/test_scope_integration.py
+++ b/tests/unit/integration/test_scope_integration.py
@@ -357,7 +357,8 @@ class TestWindsurfScopeResolution:
         assert "instructions" in resolved.primitives
         assert "skills" in resolved.primitives
         # windsurf intentionally does not expose an 'agents' primitive:
-        # Cascade discovers SKILL.md uniformly under .windsurf/skills/.
+        # Cascade discovers SKILL.md uniformly under the converged
+        # .agents/skills/ directory (apm#1520).
         assert "agents" not in resolved.primitives
 
     def test_user_scope_uses_codeium_windsurf_root(self):

--- a/tests/unit/integration/test_targets.py
+++ b/tests/unit/integration/test_targets.py
@@ -219,6 +219,16 @@ class TestActiveTargets:
         names = {t.name for t in targets}
         assert names == {"windsurf", "copilot"}
 
+    def test_windsurf_not_detected_when_only_agents_dir_exists(self):
+        """apm#1520: windsurf skills converge on .agents/, but auto-detection
+        must still key off .windsurf/ (NOT the shared .agents/ dir). A workspace
+        with only .agents/ must not auto-select windsurf -- otherwise any tool
+        that creates .agents/ would silently pull in windsurf deploys."""
+        (self.root / ".agents").mkdir()
+        targets = active_targets(self.root)
+        # .agents/ alone matches no target root_dir -> copilot fallback only.
+        assert [t.name for t in targets] == ["copilot"]
+
     # -- explicit list of targets --
 
     def test_explicit_list_single_target(self):
@@ -310,16 +320,18 @@ class TestActiveTargets:
 
 
 class TestDefaultSkillRouting:
-    """Assert that the 4 documented clients route skills to .agents/ by default."""
+    """Assert that the documented clients route skills to .agents/ by default."""
 
     def test_default_skill_routing_uses_agents_dir_for_documented_clients(self):
-        """copilot, cursor, opencode, codex, gemini all have deploy_root='.agents' on skills."""
+        """copilot, cursor, opencode, codex, gemini, windsurf all have
+        deploy_root='.agents' on skills."""
         expected = {
             "copilot": ".agents",
             "cursor": ".agents",
             "opencode": ".agents",
             "codex": ".agents",
             "gemini": ".agents",
+            "windsurf": ".agents",
             "claude": None,  # not documented as .agents/-aware
         }
         for name, want_root in expected.items():
@@ -335,11 +347,12 @@ class TestDefaultSkillRouting:
         from apm_cli.integration.targets import apply_legacy_skill_paths
 
         profiles = [
-            KNOWN_TARGETS[n] for n in ("copilot", "cursor", "opencode", "codex", "claude", "gemini")
+            KNOWN_TARGETS[n]
+            for n in ("copilot", "cursor", "opencode", "codex", "claude", "gemini", "windsurf")
         ]
         restored = apply_legacy_skill_paths(profiles)
 
-        # All 6 should have deploy_root=None after legacy restore
+        # All 7 should have deploy_root=None after legacy restore
         for profile in restored:
             skills_pm = profile.primitives.get("skills")
             assert skills_pm is not None, f"{profile.name} should have skills"
@@ -373,6 +386,33 @@ class TestDefaultSkillRouting:
         assert skills_pm.deploy_root is None, (
             f"gemini: expected deploy_root=None (legacy), got {skills_pm.deploy_root!r}"
         )
+
+    def test_windsurf_skill_routing_uses_agents_dir_by_default(self):
+        """Cascade natively discovers .agents/skills/; windsurf converges there
+        (apm#1520) instead of keeping a .windsurf/skills/ copy."""
+        profile = KNOWN_TARGETS["windsurf"]
+        skills_pm = profile.primitives["skills"]
+        assert skills_pm.deploy_root == ".agents", (
+            f"windsurf: expected deploy_root='.agents', got {skills_pm.deploy_root!r}"
+        )
+
+    def test_windsurf_legacy_skill_paths_restores_per_client_routing(self):
+        """With apply_legacy_skill_paths(), windsurf deploy_root is reset to None
+        so skills fall back to the pre-convergence .windsurf/skills/ layout."""
+        from apm_cli.integration.targets import apply_legacy_skill_paths
+
+        profiles = [KNOWN_TARGETS["windsurf"]]
+        restored = apply_legacy_skill_paths(profiles)
+        skills_pm = restored[0].primitives["skills"]
+        assert skills_pm.deploy_root is None, (
+            f"windsurf: expected deploy_root=None (legacy), got {skills_pm.deploy_root!r}"
+        )
+
+    def test_windsurf_pack_prefixes_cover_both_roots(self):
+        """windsurf deploys skills to .agents/ and rules/workflows/hooks to
+        .windsurf/, so pack must include both roots (mirrors codex)."""
+        profile = KNOWN_TARGETS["windsurf"]
+        assert set(profile.effective_pack_prefixes) == {".windsurf/", ".agents/"}
 
     def test_apply_legacy_does_not_mutate_known_targets(self):
         """apply_legacy_skill_paths must not mutate the global KNOWN_TARGETS."""

--- a/tests/unit/integration/test_windsurf_uninstall_skills.py
+++ b/tests/unit/integration/test_windsurf_uninstall_skills.py
@@ -1,14 +1,20 @@
 """Regression tests for the windsurf uninstall-cleanup bug (#1481):
 ``apm uninstall`` silently failed to remove deployed skill directories
-under ``.windsurf/skills/``.
+that windsurf owned.
 
-The fix dropped the ``agents`` primitive from the windsurf
-``TargetProfile`` so that the deploy path ``.windsurf/skills/<name>/``
-is owned exclusively by the ``skills`` primitive.  These tests pin the
-post-fix shape of the windsurf profile and the directory-aware cleanup
-path so a future regression -- e.g. re-introducing an ``agents``
-primitive that aliases the same deploy path -- is caught here instead
-of silently corrupting an end-user workspace.
+The original fix (#1486) dropped the ``agents`` primitive from the
+windsurf ``TargetProfile`` so the skills deploy path is owned
+exclusively by the ``skills`` primitive -- preventing a shadowing
+``agents`` bucket from skipping directory cleanup.
+
+apm#1520 then converged windsurf skills onto the cross-tool
+``.agents/skills/<name>/SKILL.md`` path (Cascade discovers
+``.agents/skills/`` natively), so these tests pin the post-convergence
+shape of the windsurf profile and the directory-aware cleanup path.
+A future regression -- e.g. re-introducing an ``agents`` primitive that
+aliases the same deploy path, or reverting the ``.agents/`` convergence
+without updating cleanup routing -- is caught here instead of silently
+corrupting an end-user workspace.
 """
 
 from pathlib import Path
@@ -24,41 +30,48 @@ class TestWindsurfTargetProfileShape:
     def test_windsurf_does_not_expose_agents_primitive(self):
         """windsurf intentionally has no 'agents' primitive: Cascade reads
         SKILL.md uniformly, so a separate agents primitive would re-create
-        the .windsurf/skills/ path collision."""
+        the skills-path collision that caused the silent uninstall bug."""
         windsurf = KNOWN_TARGETS["windsurf"]
         assert "agents" not in windsurf.primitives, (
             "windsurf must not declare an 'agents' primitive: it shares the "
-            "deploy path '.windsurf/skills/' with the 'skills' primitive and "
-            "would re-introduce the silent uninstall-cleanup bug."
+            "skills deploy path with the 'skills' primitive and would "
+            "re-introduce the silent uninstall-cleanup bug."
         )
 
     def test_windsurf_skills_primitive_uses_standard_format(self):
         """windsurf 'skills' primitive uses the standard skill_standard
-        format (deployed as SKILL.md under .windsurf/skills/)."""
+        format, converged onto the cross-tool ``.agents/skills/`` directory
+        (apm#1520)."""
         windsurf = KNOWN_TARGETS["windsurf"]
         skills = windsurf.primitives["skills"]
         assert skills.subdir == "skills"
         assert skills.extension == "/SKILL.md"
         assert skills.format_id == "skill_standard"
+        assert skills.deploy_root == ".agents", (
+            "windsurf skills converge on .agents/skills/ (apm#1520); "
+            f"got deploy_root={skills.deploy_root!r}"
+        )
 
 
 class TestWindsurfPartitionRouting:
-    """partition_managed_files must route .windsurf/skills/ paths to the
-    cross-target 'skills' bucket -- not to a windsurf-specific agents bucket."""
+    """partition_managed_files must route windsurf's converged
+    ``.agents/skills/`` paths to the cross-target 'skills' bucket -- not to a
+    windsurf-specific agents bucket."""
 
     def test_windsurf_skill_path_routes_to_skills_bucket(self):
-        """The lockfile path '.windsurf/skills/<name>' must land in the
+        """The converged lockfile path '.agents/skills/<name>' must land in the
         'skills' bucket so SkillIntegrator (directory-aware) handles it."""
         managed = {
-            ".windsurf/skills/code-review",
-            ".windsurf/skills/grill-me",
+            ".agents/skills/code-review",
+            ".agents/skills/grill-me",
         }
         buckets = BaseIntegrator.partition_managed_files(managed)
 
-        assert ".windsurf/skills/code-review" in buckets["skills"], (
-            "windsurf skill path must be in the cross-target 'skills' bucket"
+        assert ".agents/skills/code-review" in buckets["skills"], (
+            "windsurf's converged skill path must be in the cross-target "
+            "'skills' bucket"
         )
-        assert ".windsurf/skills/grill-me" in buckets["skills"]
+        assert ".agents/skills/grill-me" in buckets["skills"]
 
     def test_no_agents_windsurf_bucket_is_created(self):
         """The 'agents_windsurf' bucket must not exist: windsurf no longer
@@ -67,28 +80,28 @@ class TestWindsurfPartitionRouting:
         assert "agents_windsurf" not in buckets
 
     def test_windsurf_skill_path_not_routed_to_other_buckets(self):
-        """A windsurf skill path must NOT leak into instructions/commands/
+        """A converged skill path must NOT leak into instructions/commands/
         hooks buckets (which would mean the prefix trie matched the wrong
         primitive)."""
-        managed = {".windsurf/skills/my-skill"}
+        managed = {".agents/skills/my-skill"}
         buckets = BaseIntegrator.partition_managed_files(managed)
 
         for bucket_name, paths in buckets.items():
             if bucket_name == "skills":
                 continue
-            assert ".windsurf/skills/my-skill" not in paths, (
-                f"windsurf skill path leaked into bucket '{bucket_name}'"
+            assert ".agents/skills/my-skill" not in paths, (
+                f"converged windsurf skill path leaked into bucket '{bucket_name}'"
             )
 
 
 class TestWindsurfSkillUninstallCleanup:
-    """End-to-end: SkillIntegrator.sync_integration must remove the
-    .windsurf/skills/<name>/ directories that install deployed."""
+    """End-to-end: SkillIntegrator.sync_integration must remove the converged
+    .agents/skills/<name>/ directories that install deployed for windsurf."""
 
-    def test_sync_removes_windsurf_skill_directories(self, tmp_path: Path):
-        """Regression: skill dirs under .windsurf/skills/ created at install
-        time must be removed when listed in managed_files."""
-        skills_root = tmp_path / ".windsurf" / "skills"
+    def test_sync_removes_converged_skill_directories(self, tmp_path: Path):
+        """Regression: skill dirs under the converged .agents/skills/ created
+        at install time must be removed when listed in managed_files."""
+        skills_root = tmp_path / ".agents" / "skills"
         skills_root.mkdir(parents=True)
 
         managed_a = skills_root / "code-review"
@@ -99,14 +112,14 @@ class TestWindsurfSkillUninstallCleanup:
         managed_b.mkdir()
         (managed_b / "SKILL.md").write_text("managed by APM\n")
 
-        # User-authored skill in the same directory must not be touched.
+        # User-authored / foreign skill in the same directory must not be touched.
         user_skill = skills_root / "my-custom"
         user_skill.mkdir()
         (user_skill / "SKILL.md").write_text("authored by user\n")
 
         managed = {
-            ".windsurf/skills/code-review",
-            ".windsurf/skills/grill-me",
+            ".agents/skills/code-review",
+            ".agents/skills/grill-me",
         }
         stats = SkillIntegrator().sync_integration(None, tmp_path, managed_files=managed)
 
@@ -117,7 +130,7 @@ class TestWindsurfSkillUninstallCleanup:
         # do not couple the test to its semantics.
         assert not managed_a.exists(), "managed skill dir 'code-review' must be removed"
         assert not managed_b.exists(), "managed skill dir 'grill-me' must be removed"
-        assert user_skill.exists(), "user-authored skill dir must be preserved"
+        assert user_skill.exists(), "foreign/user-authored skill dir must be preserved"
         assert (user_skill / "SKILL.md").read_text() == "authored by user\n"
         assert stats["errors"] == 0
         assert stats["files_removed"] == 2
@@ -125,13 +138,13 @@ class TestWindsurfSkillUninstallCleanup:
     def test_sync_handles_trailing_slash_in_managed_path(self, tmp_path: Path):
         """Lockfile entries may carry a trailing slash on directory paths;
         cleanup must work either way."""
-        skills_root = tmp_path / ".windsurf" / "skills"
+        skills_root = tmp_path / ".agents" / "skills"
         skills_root.mkdir(parents=True)
         skill = skills_root / "code-review"
         skill.mkdir()
         (skill / "SKILL.md").write_text("managed")
 
-        managed = {".windsurf/skills/code-review/"}
+        managed = {".agents/skills/code-review/"}
         stats = SkillIntegrator().sync_integration(None, tmp_path, managed_files=managed)
 
         # Primary assertion: the directory is gone regardless of how the

--- a/tests/unit/integration/test_windsurf_uninstall_skills.py
+++ b/tests/unit/integration/test_windsurf_uninstall_skills.py
@@ -68,8 +68,7 @@ class TestWindsurfPartitionRouting:
         buckets = BaseIntegrator.partition_managed_files(managed)
 
         assert ".agents/skills/code-review" in buckets["skills"], (
-            "windsurf's converged skill path must be in the cross-target "
-            "'skills' bucket"
+            "windsurf's converged skill path must be in the cross-target 'skills' bucket"
         )
         assert ".agents/skills/grill-me" in buckets["skills"]
 

--- a/tests/unit/test_lockfile_enrichment.py
+++ b/tests/unit/test_lockfile_enrichment.py
@@ -443,32 +443,50 @@ class TestWindsurfTargetParity:
         return lf
 
     def test_windsurf_target_includes_windsurf_prefix(self):
+        """``.windsurf/`` (rules/workflows/hooks, plus legacy skills) is one of
+        windsurf's two pack roots and must survive filtering."""
         lf = self._lockfile_with(
             [
-                ".windsurf/skills/x/SKILL.md",
+                ".windsurf/rules/r.md",
                 ".unrelated/foo",
             ]
         )
         result = enrich_lockfile_for_pack(lf, fmt="apm", target="windsurf")
         deployed = yaml.safe_load(result)["dependencies"][0]["deployed_files"]
-        assert ".windsurf/skills/x/SKILL.md" in deployed
+        assert ".windsurf/rules/r.md" in deployed
+        assert ".unrelated/foo" not in deployed
+
+    def test_windsurf_target_includes_agents_skills_prefix(self):
+        """apm#1520: windsurf skills converge on ``.agents/skills/``, so that
+        prefix must be one of windsurf's pack roots (was ``.windsurf/skills/``)."""
+        lf = self._lockfile_with(
+            [
+                ".agents/skills/x/SKILL.md",
+                ".unrelated/foo",
+            ]
+        )
+        result = enrich_lockfile_for_pack(lf, fmt="apm", target="windsurf")
+        deployed = yaml.safe_load(result)["dependencies"][0]["deployed_files"]
+        assert ".agents/skills/x/SKILL.md" in deployed
         assert ".unrelated/foo" not in deployed
 
     def test_windsurf_cross_map_skills_from_github(self):
-        """``.github/skills/`` files are remapped under ``.windsurf/skills/``."""
+        """``.github/skills/`` files are remapped under ``.agents/skills/``
+        (apm#1520 convergence)."""
         lf = self._lockfile_with([".github/skills/x/SKILL.md"])
         result = enrich_lockfile_for_pack(lf, fmt="apm", target="windsurf")
         deployed = yaml.safe_load(result)["dependencies"][0]["deployed_files"]
-        assert ".windsurf/skills/x/SKILL.md" in deployed
+        assert ".agents/skills/x/SKILL.md" in deployed
 
     def test_windsurf_cross_map_agents_collapse_to_skills(self):
-        """``.github/agents/`` is intentionally remapped to ``.windsurf/skills/``
-        because windsurf has no native agent surface (lossy conversion).
+        """``.github/agents/`` is intentionally remapped to ``.agents/skills/``
+        because windsurf has no native agent surface (lossy conversion), and
+        windsurf skills now live under ``.agents/skills/`` (apm#1520).
         """
         lf = self._lockfile_with([".github/agents/a.md"])
         result = enrich_lockfile_for_pack(lf, fmt="apm", target="windsurf")
         deployed = yaml.safe_load(result)["dependencies"][0]["deployed_files"]
-        assert ".windsurf/skills/a.md" in deployed
+        assert ".agents/skills/a.md" in deployed
 
     def test_target_all_includes_windsurf_files(self):
         """``--target all`` must include ``.windsurf/`` files (was missing pre-refactor)."""


### PR DESCRIPTION
## Description

Switch the windsurf target's `skills` deploy path from `.windsurf/skills/<name>/SKILL.md` to the cross-tool `.agents/skills/<name>/SKILL.md`, so windsurf joins the existing convergence with copilot, cursor, codex, gemini, and opencode (6 clients). Cascade [natively discovers `.agents/skills/`](https://docs.windsurf.com/windsurf/cascade/skills#skill-scopes) at both workspace and user scope, so the windsurf-native copy is no longer needed.

Uses the same `deploy_root=".agents"` extension point as the 5 already-converged targets; `--legacy-skill-paths` / `APM_LEGACY_SKILL_PATHS=1` still restores the pre-convergence `.windsurf/skills/` layout.

- **targets.py**: windsurf skills `deploy_root=".agents"`; add `pack_prefixes=(".windsurf/", ".agents/")` so `apm pack --target windsurf` ships both roots (mirrors codex).
- **skill_path_migration.py**: add `windsurf` to `_LEGACY_SKILL_PATTERN` so the first `apm install` after upgrade migrates stale `.windsurf/skills/<pkg>/` to `.agents/skills/` and deletes the old copy (idempotent, collision-safe).
- **lockfile_enrichment.py**: remap windsurf pack paths to `.agents/skills/`.
- **docs**: skills.md, targets-matrix.md, manifest-schema.md, migration guide, CHANGELOG (breaking-change entry + migration note).
- **tests**: registry routing, migration detection, pack parity, converged-path uninstall, plus integration coverage for the new path, the legacy flag, auto-migration, and the `.windsurf/`-only detection guard.

Detection is unchanged: windsurf still auto-detects off `.windsurf/`, never the shared `.agents/` directory.

**BREAKING CHANGE:** windsurf skills now deploy to `.agents/skills/<name>/SKILL.md` instead of `.windsurf/skills/<name>/SKILL.md`. The first `apm install` after upgrading auto-migrates lockfile-tracked `.windsurf/skills/<pkg>/` directories to `.agents/skills/` and removes the stale copies; if you never re-run `apm install`, delete them manually with `rm -rf .windsurf/skills/<pkg>/`. Pass `--legacy-skill-paths` (or set `APM_LEGACY_SKILL_PATHS=1`) to keep the old layout.

Fixes #1520

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

## Spec conformance (OpenAPM v0.1)

If this PR changes behaviour that an OpenAPM v0.1 `req-XXX` covers,
confirm the three-step ritual (see CONTRIBUTING.md "Adding or
changing a normative requirement"):

- [ ] Spec edit: `docs/src/content/docs/specs/openapm-v0.1.md` updated
      (new/changed `<a id="req-XXX"></a>` anchor + prose + Appendix C
      row).
- [ ] Manifest edit: `docs/src/content/docs/specs/manifests/openapm-v0.1.requirements.yml`
      updated.
- [ ] Test edit: a `@pytest.mark.req("req-XXX")` test under
      `tests/spec_conformance/` added or extended.
- [ ] `CONFORMANCE.{md,json}` regenerated via
      `uv run --extra dev python -m tests.spec_conformance.gen_statement`
      and committed.
- [x] N/A -- this PR does not change OpenAPM-observable behaviour.
