### PR TITLE
docs(cli): list kiro in update target help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm update --target` help text now lists `kiro` as a valid example
+  target, matching `apm install`. (#1821)
 - `apm marketplace check` no longer fails with exit 128 for entries on
   non-default hosts, including relative entries composed onto
   `marketplace.sourceBase` (self-managed GitLab / GHES / Azure DevOps). It now

--- a/src/apm_cli/commands/update.py
+++ b/src/apm_cli/commands/update.py
@@ -39,7 +39,7 @@ Flags
   (0 disables parallelism).
 * ``--target``/``-t`` -- agent harness(es) to deploy to (e.g.
   ``claude``, ``copilot``, ``cursor``, ``windsurf``, ``codex``,
-  ``opencode``, ``gemini``); comma-separated for multiple targets.
+  ``opencode``, ``gemini``, ``kiro``); comma-separated for multiple targets.
   Overrides ``apm.yml targets:`` and auto-detection.
 
 These flags make ``apm update`` a strict superset of the deprecated
@@ -251,7 +251,7 @@ def _annotate_lockfile_revision_tags(project_root: Path, updates: list[RevisionP
     default=None,
     help=(
         "Agent target(s) to update for "
-        "(e.g. claude, copilot, cursor, windsurf, codex, opencode, gemini). "
+        "(e.g. claude, copilot, cursor, windsurf, codex, opencode, gemini, kiro). "
         "Comma-separated for multiple: --target claude,cursor. "
         "Highest-priority entry in the resolution chain "
         "(--target > apm.yml targets: > auto-detect)."

--- a/src/apm_cli/commands/update.py
+++ b/src/apm_cli/commands/update.py
@@ -38,8 +38,8 @@ Flags
 * ``--parallel-downloads`` -- max concurrent package downloads
   (0 disables parallelism).
 * ``--target``/``-t`` -- agent harness(es) to deploy to (e.g.
-  ``claude``, ``copilot``, ``cursor``, ``windsurf``, ``codex``,
-  ``opencode``, ``gemini``, ``kiro``); comma-separated for multiple targets.
+  ``claude``, ``copilot``, ``cursor``, ``windsurf``, ``kiro``,
+  ``codex``, ``opencode``, ``gemini``); comma-separated for multiple targets.
   Overrides ``apm.yml targets:`` and auto-detection.
 
 These flags make ``apm update`` a strict superset of the deprecated
@@ -251,7 +251,7 @@ def _annotate_lockfile_revision_tags(project_root: Path, updates: list[RevisionP
     default=None,
     help=(
         "Agent target(s) to update for "
-        "(e.g. claude, copilot, cursor, windsurf, codex, opencode, gemini, kiro). "
+        "(e.g. claude, copilot, cursor, windsurf, kiro, codex, opencode, gemini). "
         "Comma-separated for multiple: --target claude,cursor. "
         "Highest-priority entry in the resolution chain "
         "(--target > apm.yml targets: > auto-detect)."

--- a/tests/unit/test_update_command.py
+++ b/tests/unit/test_update_command.py
@@ -256,6 +256,14 @@ class TestUpdateCommandLogic(unittest.TestCase):
         self.assertIn("development mode", result.output)
         self.assertNotIn("reinstall", result.output)
 
+    def test_dependency_update_help_lists_kiro_target_example(self):
+        """`apm update --help` should keep target examples aligned with supported targets."""
+        result = self.runner.invoke(cli, ["update", "--help"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertIn("kiro", result.output)
+        self.assertIn("--target claude,cursor", result.output)
+
     @patch("apm_cli.utils.version_checker.get_latest_version_from_github", return_value=None)
     @patch("apm_cli.commands.self_update.get_version", return_value="1.0.0")
     def test_update_cannot_fetch_latest_exits_1(self, mock_version, mock_latest):

--- a/tests/unit/test_update_command.py
+++ b/tests/unit/test_update_command.py
@@ -261,8 +261,21 @@ class TestUpdateCommandLogic(unittest.TestCase):
         result = self.runner.invoke(cli, ["update", "--help"])
 
         self.assertEqual(result.exit_code, 0)
-        self.assertIn("kiro", result.output)
-        self.assertIn("--target claude,cursor", result.output)
+        target_help_lines = []
+        for line in result.output.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("-t, --target"):
+                target_help_lines.append(stripped)
+                continue
+            if target_help_lines:
+                if stripped.startswith("-") and not stripped.startswith("--target"):
+                    break
+                target_help_lines.append(stripped)
+
+        target_help = " ".join(target_help_lines)
+        self.assertIn("--target", target_help)
+        self.assertIn("gemini", target_help)
+        self.assertIn("kiro", target_help)
 
     @patch("apm_cli.utils.version_checker.get_latest_version_from_github", return_value=None)
     @patch("apm_cli.commands.self_update.get_version", return_value="1.0.0")


### PR DESCRIPTION
## Summary
- add `kiro` to the `apm update --target` help example list
- keep the command docstring aligned with the visible help text
- add a focused regression test for the help output

## Context
Follow-up for #1817, item 3 in the CLI Consistency Report. `kiro` is supported by the target parser and documented in the CLI reference, but the `apm update --target` help examples still omitted it.

## Testing
- `.venv-codex/bin/python -m pytest tests/unit/test_update_command.py -q`
- `.venv-codex/bin/ruff check src/apm_cli/commands/update.py tests/unit/test_update_command.py`
- `.venv-codex/bin/apm update --help | rg -n 'Agent target|kiro|--target|claude,cursor'`