### PR TITLE
Fix marketplace --ref not propagated to relative plugin sources (#1811)

### DIFF
--- a/src/apm_cli/marketplace/resolver.py
+++ b/src/apm_cli/marketplace/resolver.py
@@ -820,8 +820,16 @@ def resolve_marketplace_plugin(
             plugin, plugin_root=manifest.plugin_root
         )
         if in_repo_path:
+            # Fall back to the marketplace's registered ref when the plugin
+            # source itself declares no ref and no version_spec overrides it.
+            # "main" / "HEAD" are excluded because they represent the default
+            # branch -- appending them would be a no-op at best and misleading
+            # when the repo's actual default branch has a different name.
+            effective_ref = version_spec or path_ref
+            if not effective_ref and source.ref and source.ref not in ("main", "HEAD"):
+                effective_ref = source.ref
             dep_ref = _gitlab_in_marketplace_dependency_reference(
-                source, in_repo_path, version_spec or path_ref
+                source, in_repo_path, effective_ref
             )
             canonical = dep_ref.to_canonical()
 
@@ -857,6 +865,27 @@ def resolve_marketplace_plugin(
     cross_repo_misconfig_risk = _compute_cross_repo_misconfig_risk(
         plugin, source, canonical, dep_ref
     )
+
+    # ---- Propagate marketplace registered ref (#1811) ----
+    # When a marketplace is registered with ``--ref feat/xxx`` and the plugin
+    # uses a relative string source (e.g. ``"./plugins/my-plugin"``), the
+    # canonical built by ``resolve_plugin_source`` carries no ``#ref`` suffix.
+    # Without this block the plugin would resolve against the default branch
+    # instead of the registered ref.
+    # "main" / "HEAD" are excluded to avoid appending a no-op suffix; if the
+    # repo's actual default branch is not named "main" and the user pinned
+    # ``--ref main``, this condition silently drops the ref -- fixing that
+    # would require knowing the repo's real default branch which is not
+    # available at this stage.
+    if (
+        dep_ref is None
+        and not version_spec
+        and isinstance(plugin.source, str)
+        and "#" not in canonical
+        and source.ref
+        and source.ref not in ("main", "HEAD")
+    ):
+        canonical = f"{canonical}#{source.ref}"
 
     # ---- Version spec override ----
     # When version_spec is provided it either triggers semver-aware tag

--- a/tests/unit/marketplace/test_marketplace_resolver.py
+++ b/tests/unit/marketplace/test_marketplace_resolver.py
@@ -1432,3 +1432,104 @@ class TestGitLabShorthandParseVsStructuredRef:
         assert good.is_virtual is True
         assert good.repo_url == "epm-ease/ai-apm-registry"
         assert good.virtual_path == "agents/reverse-architect"
+
+
+class TestMarketplaceRefPropagation:
+    """Registered --ref must propagate to relative string plugin sources (#1811)."""
+
+    @staticmethod
+    def _manifest_with_plugin(plugin: MarketplacePlugin) -> MarketplaceManifest:
+        return MarketplaceManifest(name="mkt", plugins=(plugin,), plugin_root="")
+
+    @patch("apm_cli.marketplace.resolver.fetch_or_cache")
+    @patch("apm_cli.marketplace.resolver.get_marketplace_by_name")
+    def test_github_relative_source_propagates_registered_ref(self, mock_get, mock_fetch):
+        """A GitHub marketplace registered with --ref feat/xxx appends #feat/xxx."""
+        source = MarketplaceSource(
+            name="mkt",
+            owner="acme",
+            repo="catalog",
+            host="github.com",
+            ref="feat/my-feature",
+        )
+        plugin = MarketplacePlugin(name="my-plugin", source="./plugins/my-plugin")
+        mock_get.return_value = source
+        mock_fetch.return_value = self._manifest_with_plugin(plugin)
+
+        result = resolve_marketplace_plugin("my-plugin", "mkt")
+        assert result.canonical == "acme/catalog/plugins/my-plugin#feat/my-feature"
+        assert result.dependency_reference is None
+
+    @patch("apm_cli.marketplace.resolver.fetch_or_cache")
+    @patch("apm_cli.marketplace.resolver.get_marketplace_by_name")
+    def test_github_relative_source_main_ref_not_appended(self, mock_get, mock_fetch):
+        """ref='main' is the default -- do not append #main to the canonical."""
+        source = MarketplaceSource(
+            name="mkt",
+            owner="acme",
+            repo="catalog",
+            host="github.com",
+            ref="main",
+        )
+        plugin = MarketplacePlugin(name="my-plugin", source="./plugins/my-plugin")
+        mock_get.return_value = source
+        mock_fetch.return_value = self._manifest_with_plugin(plugin)
+
+        result = resolve_marketplace_plugin("my-plugin", "mkt")
+        assert result.canonical == "acme/catalog/plugins/my-plugin"
+
+    @patch("apm_cli.marketplace.resolver.fetch_or_cache")
+    @patch("apm_cli.marketplace.resolver.get_marketplace_by_name")
+    def test_version_spec_overrides_registered_ref(self, mock_get, mock_fetch):
+        """Explicit version_spec takes precedence over registered ref."""
+        source = MarketplaceSource(
+            name="mkt",
+            owner="acme",
+            repo="catalog",
+            host="github.com",
+            ref="feat/my-feature",
+        )
+        plugin = MarketplacePlugin(name="my-plugin", source="./plugins/my-plugin")
+        mock_get.return_value = source
+        mock_fetch.return_value = self._manifest_with_plugin(plugin)
+
+        result = resolve_marketplace_plugin("my-plugin", "mkt", version_spec="v2.0.0")
+        assert result.canonical == "acme/catalog/plugins/my-plugin#v2.0.0"
+
+    @patch("apm_cli.marketplace.resolver.fetch_or_cache")
+    @patch("apm_cli.marketplace.resolver.get_marketplace_by_name")
+    def test_gitlab_relative_source_propagates_registered_ref(self, mock_get, mock_fetch):
+        """A GitLab marketplace registered with --ref feat/xxx sets ref in dep_ref."""
+        source = MarketplaceSource(
+            name="mkt",
+            owner="acme",
+            repo="catalog",
+            host="gitlab.com",
+            ref="feat/my-feature",
+        )
+        plugin = MarketplacePlugin(name="my-plugin", source="registry/my-plugin")
+        mock_get.return_value = source
+        mock_fetch.return_value = self._manifest_with_plugin(plugin)
+
+        result = resolve_marketplace_plugin("my-plugin", "mkt")
+        assert result.dependency_reference is not None
+        assert result.dependency_reference.reference == "feat/my-feature"
+
+    @patch("apm_cli.marketplace.resolver.fetch_or_cache")
+    @patch("apm_cli.marketplace.resolver.get_marketplace_by_name")
+    def test_gitlab_relative_source_main_ref_not_propagated(self, mock_get, mock_fetch):
+        """ref='main' should not be propagated to the GitLab dep_ref."""
+        source = MarketplaceSource(
+            name="mkt",
+            owner="acme",
+            repo="catalog",
+            host="gitlab.com",
+            ref="main",
+        )
+        plugin = MarketplacePlugin(name="my-plugin", source="registry/my-plugin")
+        mock_get.return_value = source
+        mock_fetch.return_value = self._manifest_with_plugin(plugin)
+
+        result = resolve_marketplace_plugin("my-plugin", "mkt")
+        assert result.dependency_reference is not None
+        assert result.dependency_reference.reference is None


### PR DESCRIPTION
## TL;DR

Propagate the marketplace's registered `--ref` to relative string plugin sources so `apm install plugin@marketplace` resolves against the registered branch, not the default branch.

## Problem (WHY)

When a marketplace is registered with `apm marketplace add owner/repo --ref feat/xxx`, and its `marketplace.json` uses relative string sources (e.g. `"./plugins/my-plugin"`), `apm install my-plugin@my-marketplace` downloads the plugin from the **default branch** instead of the registered `--ref`.

The ref is correctly persisted and used to fetch `marketplace.json`, but `resolve_marketplace_plugin` calls `resolve_plugin_source` without passing `source.ref`. The canonical string has no `#ref` suffix, so the downloader resolves against the default branch. The same gap exists in the GitLab structured-ref path where `_gitlab_in_marketplace_dependency_reference` receives `None` for string sources.

## Approach (WHAT)

Two surgical changes in `resolve_marketplace_plugin`:

1. **GitHub-family path:** After computing the canonical, append `#source.ref` when the plugin is a relative string source, no `#ref` is already present, no explicit `version_spec` overrides it, and `source.ref` is not `"main"` or `"HEAD"`.

2. **GitLab/non-GitHub structured path:** Fall back to `source.ref` in the ref argument to `_gitlab_in_marketplace_dependency_reference` when `path_ref` is `None` and no `version_spec`.

## Validation

- 5 new regression tests covering both GitHub and GitLab hosts (ref propagation, main exclusion, version_spec override)
- All 111 existing + new tests pass
- Lint (ruff check, ruff format, pylint R0801) clean

Fixes #1811