### PR TITLE
Add cascading policy repo discovery with ADO support

### DIFF
--- a/docs/src/content/docs/enterprise/apm-policy.md
+++ b/docs/src/content/docs/enterprise/apm-policy.md
@@ -43,11 +43,11 @@ APM discovers your org-level policy by checking candidate repos in this order --
 
 | Priority | Repo name | Valid on |
 |----------|-----------|---------|
-| 1 | `.github` | GitHub, GitHub Enterprise, GitLab, other git hosts |
-| 2 | `.apm` | GitHub, GitHub Enterprise, GitLab, other git hosts |
-| 3 | `_apm` | All hosts including Azure DevOps |
+| 1 | `.github` | GitHub and GitHub API-compatible hosts |
+| 2 | `.apm` | GitHub and GitHub API-compatible hosts |
+| 3 | `_apm` | GitHub API-compatible hosts and Azure DevOps |
 
-Azure DevOps does not allow repository names starting or ending with a period, so only `_apm` is tried on ADO hosts. On ADO, the convention is a project named `_apm` containing a repo named `_apm`:
+Azure DevOps does not allow repository names starting or ending with a period, so only `_apm` is tried on ADO hosts. ADO requires repositories to live inside projects; the convention uses `_apm` for both the project and repo:
 
 ```
 <org>/
@@ -56,7 +56,7 @@ Azure DevOps does not allow repository names starting or ending with a period, s
       apm-policy.yml
 ```
 
-On GitHub and other hosts, the `.github` convention remains the recommended default:
+On GitHub and GitHub API-compatible hosts, the `.github` convention remains the recommended default:
 
 ```
 <org>/

--- a/docs/src/content/docs/enterprise/apm-policy.md
+++ b/docs/src/content/docs/enterprise/apm-policy.md
@@ -19,7 +19,7 @@ This page is the mental model. For the full schema, see the [Policy Reference](.
 
 ## What it is
 
-One YAML file. Lives at `<org>/.github/apm-policy.yml`. Auto-discovered by `apm install` and `apm audit --ci --policy org` from your project's git remote.
+One YAML file. Lives in your org's policy repo (`apm-policy.yml`). Auto-discovered by `apm install` and `apm audit --ci --policy org` from your project's git remote.
 
 It declares:
 
@@ -39,7 +39,24 @@ The policy schema addresses install-time gates exclusively. It has no fields for
 
 ## Where it lives
 
-The canonical location is the `.github` repository under your org:
+APM discovers your org-level policy by checking candidate repos in this order -- the first one found wins:
+
+| Priority | Repo name | Valid on |
+|----------|-----------|---------|
+| 1 | `.github` | GitHub, GitHub Enterprise, GitLab, other git hosts |
+| 2 | `.apm` | GitHub, GitHub Enterprise, GitLab, other git hosts |
+| 3 | `_apm` | All hosts including Azure DevOps |
+
+Azure DevOps does not allow repository names starting or ending with a period, so only `_apm` is tried on ADO hosts. On ADO, the convention is a project named `_apm` containing a repo named `_apm`:
+
+```
+<org>/
+  _apm/              # ADO project
+    _apm/            # repo inside the project
+      apm-policy.yml
+```
+
+On GitHub and other hosts, the `.github` convention remains the recommended default:
 
 ```
 <org>/
@@ -47,7 +64,7 @@ The canonical location is the `.github` repository under your org:
     apm-policy.yml         # auto-discovered by every repo in <org>
 ```
 
-When `apm install` or `apm audit --ci --policy org` runs in a project, APM resolves the org from the project's git remote and fetches `<org>/.github/apm-policy.yml` (cached locally, default 1 hour TTL).
+When `apm install` or `apm audit --ci --policy org` runs in a project, APM resolves the org from the project's git remote and searches the candidate repos above (cached locally, default 1 hour TTL).
 
 Alternative sources, useful for testing or non-GitHub setups:
 

--- a/docs/src/content/docs/reference/policy-schema.md
+++ b/docs/src/content/docs/reference/policy-schema.md
@@ -36,8 +36,8 @@ Those controls are owned by the **agent harness** that runs your agents, not by 
 
 Discovery order, in priority:
 
-1. `--policy <ref>` flag on `apm install` or `apm audit`.
-2. Auto-discovery from the project's git remote -- fetches `<owner>/.github/apm-policy.yml` via the GitHub Contents API.
+1. Explicit policy source on `apm audit --ci` via `--policy <ref>` or `apm policy status` via `--policy-source <ref>`. `apm install` auto-discovers from the project's git remote and supports `--no-policy`; it does not accept `--policy` today.
+2. Auto-discovery from the project's git remote -- checks the org policy repo cascade (`.github`, `.apm`, `_apm`; Azure DevOps uses `_apm` only).
 
 The `<ref>` accepts:
 
@@ -259,7 +259,7 @@ turned them on.
 
 `extends:` accepts:
 
-- `org` -- the same org's `.github/apm-policy.yml`.
+- `org` -- the same org's auto-discovered policy repo.
 - `<owner>/<repo>` -- another repo on the same host.
 - `https://...` -- a direct URL.
 
@@ -317,7 +317,7 @@ For every `allow:` field, the three states are distinct:
 ## Complete example
 
 ```yaml
-# .github/apm-policy.yml -- shipped from contoso/.github
+# .github/apm-policy.yml -- shipped from the first auto-discovered policy repo
 name: contoso-baseline
 version: "2025.05"
 extends: contoso-enterprise/policy

--- a/packages/apm-guide/.apm/skills/apm-usage/governance.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/governance.md
@@ -290,11 +290,11 @@ may use. This section covers how that contract is enforced at `apm install` time
 
 ### 2. Discovery and applicability
 
-APM auto-discovers policy from `<org>/.github/apm-policy.yml` for any GitHub
-remote  --  both `github.com` and GitHub Enterprise (GHE). Non-GitHub remotes (ADO,
-GitLab, plain git) currently fall through with no policy applied; tracked as a
-follow-up. Repositories with no detectable git remote (unpacked bundles, temp
-dirs) emit an explicit "could not determine org" line and skip discovery.
+APM auto-discovers org policy from the project's git remote by checking
+`.github`, `.apm`, and `_apm` policy repos in order on GitHub API-compatible
+hosts. Azure DevOps hosts use `_apm` only, because ADO rejects dot-prefixed
+repository names. Repositories with no detectable git remote (unpacked bundles,
+temp dirs) emit an explicit "could not determine org" line and skip discovery.
 
 The `--policy <override>` flag is **audit-only today**  --  it works on
 `apm audit --ci` but is not yet wired through `apm install`.
@@ -536,7 +536,8 @@ as `[x]` errors and exit `1`.
 
 Checklist to publish a policy:
 
-1. Create `<org>/.github/apm-policy.yml` in the org's `.github` repository.
+1. Create `apm-policy.yml` in the org policy repo (`.github` on GitHub, `_apm`
+   project/repo on Azure DevOps).
 2. Start from the recommended starter below and trim to the minimum reflecting
    your governance posture.
 3. Set `enforcement: warn` first. Let CI surface diagnostics across consuming

--- a/src/apm_cli/policy/_help_text.py
+++ b/src/apm_cli/policy/_help_text.py
@@ -13,7 +13,8 @@ Adding or removing a form here without a matching change in
 
 POLICY_SOURCE_FORMS_HELP = (
     "Accepts: 'org' (auto-discover from your project's git remote -- "
-    "tries .github, .apm, and _apm repos in order), "
+    "tries .github, .apm, and _apm repos in order; "
+    "on Azure DevOps only _apm is tried), "
     "'owner/repo' (defaults to github.com), an https:// URL, or a "
     "local file path."
 )

--- a/src/apm_cli/policy/_help_text.py
+++ b/src/apm_cli/policy/_help_text.py
@@ -12,7 +12,8 @@ Adding or removing a form here without a matching change in
 """
 
 POLICY_SOURCE_FORMS_HELP = (
-    "Accepts: 'org' (auto-discover from your project's git remote), "
+    "Accepts: 'org' (auto-discover from your project's git remote -- "
+    "tries .github, .apm, and _apm repos in order), "
     "'owner/repo' (defaults to github.com), an https:// URL, or a "
     "local file path."
 )

--- a/src/apm_cli/policy/discovery.py
+++ b/src/apm_cli/policy/discovery.py
@@ -41,7 +41,11 @@ import requests
 import yaml
 
 from ..cache.url_normalize import SCP_LIKE_RE
-from ..utils.github_host import build_ado_api_url, is_azure_devops_hostname
+from ..utils.github_host import (
+    build_ado_api_url,
+    is_azure_devops_hostname,
+    is_visualstudio_legacy_hostname,
+)
 from ..utils.path_security import PathTraversalError, ensure_path_within
 from .parser import PolicyValidationError, load_policy
 from .project_config import (
@@ -668,6 +672,7 @@ def _auto_discover(
     is_ado = is_azure_devops_hostname(host)
 
     for candidate_repo in candidates:
+        logger.debug("Trying org policy repo candidate %s on host %s", candidate_repo, host)
         if is_ado:
             result = _fetch_from_ado_repo(
                 org=org,
@@ -688,6 +693,11 @@ def _auto_discover(
 
         # 404 / absent -> try the next candidate
         if result.outcome == "absent":
+            logger.debug(
+                "Policy repo candidate %s absent on host %s; trying next candidate",
+                candidate_repo,
+                host,
+            )
             continue
 
         # Any other outcome (found, error, malformed, etc.) -> return immediately
@@ -766,6 +776,8 @@ def _parse_remote_url(url: str) -> tuple[str, str] | None:
             parsed = urlparse(url)
             host = parsed.hostname or ""
             path_parts = parsed.path.strip("/").removesuffix(".git").rstrip("/").split("/")
+            if is_visualstudio_legacy_hostname(host):
+                return (host[: -len(".visualstudio.com")], host)
             if host and path_parts and path_parts[0]:
                 return (path_parts[0], host)
         except Exception:
@@ -1113,24 +1125,27 @@ def _fetch_ado_contents(
     api_url = build_ado_api_url(org, project, repo, file_path, host=host)
     repo_ref = f"{host}/{org}/{project}/{repo}"
 
-    # ADO uses Basic auth with PAT (username empty, password is the PAT).
-    # Prefer ADO_APM_PAT env var, falling back to _get_token_for_host().
-    ado_pat = os.environ.get("ADO_APM_PAT", "")
+    # ADO auth is centralized in AuthResolver: ADO_APM_PAT uses Basic auth,
+    # and az CLI AAD tokens use Bearer auth. No GitHub PATs are consulted.
+    from ..core.auth import AuthResolver
+
     headers: dict[str, str] = {}
-    if ado_pat:
-        basic_cred = base64.b64encode(f":{ado_pat}".encode()).decode()
-        headers["Authorization"] = f"Basic {basic_cred}"
-    else:
-        token = _get_token_for_host(host)
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
+    auth_resolver = AuthResolver()
+    auth_ctx = auth_resolver.resolve(host, org=org)
+    if auth_ctx.token:
+        if auth_ctx.auth_scheme == "bearer":
+            headers["Authorization"] = f"Bearer {auth_ctx.token}"
+        else:
+            basic_cred = base64.b64encode(f":{auth_ctx.token}".encode()).decode()
+            headers["Authorization"] = f"Basic {basic_cred}"
 
     try:
         resp = requests.get(api_url, headers=headers, timeout=10, allow_redirects=False)
         if resp.status_code == 404:
             return None, "404: Policy file not found"
         if resp.status_code in (401, 403):
-            return None, f"{resp.status_code}: Access denied to {repo_ref}"
+            remediation = auth_resolver.build_error_context(host, "fetch org policy", org=org)
+            return None, (f"{resp.status_code}: Access denied to {repo_ref}{remediation}")
         if 300 <= resp.status_code < 400:
             location = resp.headers.get("Location", "<no Location header>")
             return None, (

--- a/src/apm_cli/policy/discovery.py
+++ b/src/apm_cli/policy/discovery.py
@@ -2,13 +2,21 @@
 
 Discovery flow:
 1. Extract org from git remote (github.com/contoso/my-project -> "contoso")
-2. Fetch <org>/.github/apm-policy.yml via GitHub API (Contents API)
-3. Resolve inheritance chain via resolve_policy_chain
-4. Cache the **merged effective policy** with chain metadata
-5. Parse and return ApmPolicy
+2. Determine host profile (default or ado) to select candidate repos
+3. Try candidate repos in precedence order (.github > .apm > _apm)
+4. Fetch apm-policy.yml via GitHub Contents API or ADO Items API
+5. Resolve inheritance chain via resolve_policy_chain
+6. Cache the **merged effective policy** with chain metadata
+7. Parse and return ApmPolicy
+
+Candidate repo precedence:
+- .github  -- GitHub convention (skipped on ADO)
+- .apm     -- cross-platform convention (skipped on ADO)
+- _apm     -- universal fallback (valid on every git host)
 
 Supports:
 - GitHub.com and GitHub Enterprise (*.ghe.com)
+- Azure DevOps (dev.azure.com, *.visualstudio.com)
 - Manual override via --policy <path|url>
 - Cache with TTL (default 1 hour), stale fallback up to MAX_STALE_TTL
 - Atomic cache writes (temp file + os.replace)
@@ -33,6 +41,7 @@ import requests
 import yaml
 
 from ..cache.url_normalize import SCP_LIKE_RE
+from ..utils.github_host import build_ado_api_url, is_azure_devops_hostname
 from ..utils.path_security import PathTraversalError, ensure_path_within
 from .parser import PolicyValidationError, load_policy
 from .project_config import (
@@ -47,6 +56,29 @@ from .project_config import (
 from .schema import ApmPolicy
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Policy repo discovery: cascading candidate repos per host profile
+# ---------------------------------------------------------------------------
+
+# Candidate repo names in precedence order (first valid policy wins).
+# Host profiles select which candidates are valid for a given git host.
+_DEFAULT_POLICY_REPOS: tuple[str, ...] = (".github", ".apm", "_apm")
+_ADO_POLICY_REPOS: tuple[str, ...] = ("_apm",)
+
+# ADO project name for the policy repo (ADO requires a project container).
+ADO_POLICY_PROJECT = "_apm"
+
+
+def _policy_repo_candidates(host: str) -> tuple[str, ...]:
+    """Return candidate policy repo names for *host* in precedence order.
+
+    ADO hosts cannot have repo names starting/ending with ``.``, so only
+    ``_apm`` is valid.  All other hosts try the full cascade.
+    """
+    if is_azure_devops_hostname(host):
+        return _ADO_POLICY_REPOS
+    return _DEFAULT_POLICY_REPOS
 
 
 def _split_hash_pin(expected_hash: str) -> tuple[str, str]:
@@ -613,11 +645,16 @@ def _auto_discover(
     no_cache: bool = False,
     expected_hash: str | None = None,
 ) -> PolicyFetchResult:
-    """Auto-discover policy from org's .github repo.
+    """Auto-discover policy by cascading through candidate repos.
 
     1. Run git remote get-url origin
-    2. Parse org from URL
-    3. Fetch <org>/.github/apm-policy.yml
+    2. Parse org + host from URL
+    3. Select host profile to determine candidate repos
+    4. Try each candidate in precedence order (.github > .apm > _apm)
+       - 404/absent -> continue to next candidate
+       - Error (auth, timeout, malformed) -> fail-closed immediately
+       - Found -> return (first match wins)
+    5. All candidates exhausted -> outcome="absent"
     """
     org_and_host = _extract_org_from_git_remote(project_root)
     if org_and_host is None:
@@ -627,11 +664,40 @@ def _auto_discover(
         )
 
     org, host = org_and_host
-    repo_ref = f"{org}/.github"
-    if host and host != "github.com":
-        repo_ref = f"{host}/{repo_ref}"
+    candidates = _policy_repo_candidates(host)
+    is_ado = is_azure_devops_hostname(host)
 
-    return _fetch_from_repo(repo_ref, project_root, no_cache=no_cache, expected_hash=expected_hash)
+    for candidate_repo in candidates:
+        if is_ado:
+            result = _fetch_from_ado_repo(
+                org=org,
+                project=ADO_POLICY_PROJECT,
+                repo=candidate_repo,
+                host=host,
+                project_root=project_root,
+                no_cache=no_cache,
+                expected_hash=expected_hash,
+            )
+        else:
+            repo_ref = f"{org}/{candidate_repo}"
+            if host and host != "github.com":
+                repo_ref = f"{host}/{repo_ref}"
+            result = _fetch_from_repo(
+                repo_ref, project_root, no_cache=no_cache, expected_hash=expected_hash
+            )
+
+        # 404 / absent -> try the next candidate
+        if result.outcome == "absent":
+            continue
+
+        # Any other outcome (found, error, malformed, etc.) -> return immediately
+        return result
+
+    # All candidates exhausted: no policy published anywhere.
+    return PolicyFetchResult(
+        error=None,
+        outcome="absent",
+    )
 
 
 def _extract_org_from_git_remote(
@@ -940,6 +1006,133 @@ def _fetch_github_contents(
             return data["content"], None
         else:
             return None, f"Unexpected response format from {repo_ref}"
+    except requests.exceptions.Timeout:
+        return None, f"Timeout fetching policy from {repo_ref}"
+    except requests.exceptions.ConnectionError:
+        return None, f"Connection error fetching policy from {repo_ref}"
+    except Exception as e:
+        return None, f"Error fetching policy from {repo_ref}: {e}"
+
+
+# ---------------------------------------------------------------------------
+# ADO policy fetch
+# ---------------------------------------------------------------------------
+
+
+def _fetch_from_ado_repo(
+    *,
+    org: str,
+    project: str,
+    repo: str,
+    host: str,
+    project_root: Path,
+    no_cache: bool = False,
+    expected_hash: str | None = None,
+) -> PolicyFetchResult:
+    """Fetch apm-policy.yml from an Azure DevOps repo.
+
+    Mirrors ``_fetch_from_repo`` but uses ``_fetch_ado_contents`` (ADO
+    Items API) instead of ``_fetch_github_contents`` (GitHub Contents API).
+    """
+    repo_ref = f"{host}/{org}/{project}/{repo}"
+    source_label = f"org:{repo_ref}"
+    cache_entry: _CacheEntry | None = None
+
+    if not no_cache:
+        cache_entry = _read_cache_entry(repo_ref, project_root, expected_hash=expected_hash)
+        if cache_entry is not None and not cache_entry.stale:
+            outcome = "empty" if _is_policy_empty(cache_entry.policy) else "found"
+            return PolicyFetchResult(
+                policy=cache_entry.policy,
+                source=cache_entry.source,
+                cached=True,
+                cache_age_seconds=cache_entry.age_seconds,
+                outcome=outcome,
+                raw_bytes_hash=cache_entry.raw_bytes_hash or None,
+                expected_hash=expected_hash,
+            )
+
+    content, error = _fetch_ado_contents(org, project, repo, "apm-policy.yml", host=host)
+
+    if error:
+        if "404" in error:
+            return PolicyFetchResult(source=source_label, outcome="absent")
+        return _stale_fallback_or_error(cache_entry, error, source_label, "cache_miss_fetch_fail")
+
+    if content is None:
+        return PolicyFetchResult(source=source_label, outcome="absent")
+
+    garbage_result = _detect_garbage(content, repo_ref, source_label, cache_entry)
+    if garbage_result is not None:
+        return garbage_result
+
+    mismatch = _verify_hash_pin(content, expected_hash, source_label)
+    if mismatch is not None:
+        return mismatch
+
+    try:
+        policy, _warnings = load_policy(content)
+    except PolicyValidationError as e:
+        return PolicyFetchResult(
+            error=f"Invalid policy in {repo_ref}: {e}",
+            source=source_label,
+            outcome="malformed",
+        )
+
+    chain_refs = [repo_ref]
+    actual_hash = _compute_hash_normalized(content, expected_hash)
+    _write_cache(
+        repo_ref,
+        policy,
+        project_root,
+        chain_refs=chain_refs,
+        raw_bytes_hash=actual_hash,
+    )
+    outcome = "empty" if _is_policy_empty(policy) else "found"
+    return PolicyFetchResult(
+        policy=policy,
+        source=source_label,
+        outcome=outcome,
+        raw_bytes_hash=actual_hash,
+        expected_hash=expected_hash,
+    )
+
+
+def _fetch_ado_contents(
+    org: str,
+    project: str,
+    repo: str,
+    file_path: str,
+    *,
+    host: str = "dev.azure.com",
+) -> tuple[str | None, str | None]:
+    """Fetch file contents from Azure DevOps Items API.
+
+    Returns ``(content_string, error_string)``. One will be ``None``.
+    """
+    api_url = build_ado_api_url(org, project, repo, file_path, host=host)
+    repo_ref = f"{host}/{org}/{project}/{repo}"
+
+    token = _get_token_for_host(host)
+    headers: dict[str, str] = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    try:
+        resp = requests.get(api_url, headers=headers, timeout=10, allow_redirects=False)
+        if resp.status_code == 404:
+            return None, "404: Policy file not found"
+        if resp.status_code in (401, 403):
+            return None, f"{resp.status_code}: Access denied to {repo_ref}"
+        if 300 <= resp.status_code < 400:
+            location = resp.headers.get("Location", "<no Location header>")
+            return None, (
+                f"Refusing HTTP redirect ({resp.status_code}) from {api_url} to {location}"
+            )
+        if resp.status_code != 200:
+            return None, f"HTTP {resp.status_code} fetching policy from {repo_ref}"
+        # ADO Items API returns raw file content by default
+        return resp.text, None
     except requests.exceptions.Timeout:
         return None, f"Timeout fetching policy from {repo_ref}"
     except requests.exceptions.ConnectionError:

--- a/src/apm_cli/policy/discovery.py
+++ b/src/apm_cli/policy/discovery.py
@@ -1113,10 +1113,17 @@ def _fetch_ado_contents(
     api_url = build_ado_api_url(org, project, repo, file_path, host=host)
     repo_ref = f"{host}/{org}/{project}/{repo}"
 
-    token = _get_token_for_host(host)
+    # ADO uses Basic auth with PAT (username empty, password is the PAT).
+    # Prefer ADO_APM_PAT env var, falling back to _get_token_for_host().
+    ado_pat = os.environ.get("ADO_APM_PAT", "")
     headers: dict[str, str] = {}
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
+    if ado_pat:
+        basic_cred = base64.b64encode(f":{ado_pat}".encode()).decode()
+        headers["Authorization"] = f"Basic {basic_cred}"
+    else:
+        token = _get_token_for_host(host)
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
 
     try:
         resp = requests.get(api_url, headers=headers, timeout=10, allow_redirects=False)

--- a/src/apm_cli/policy/inheritance.py
+++ b/src/apm_cli/policy/inheritance.py
@@ -4,7 +4,7 @@ Supports three-level chains: enterprise hub -> org -> repo.
 Each level can tighten but never relax the parent.
 
 extends: values:
-- "org"              -> same org's .github repo (repo-level override)
+- "org"              -> same org's policy repo (.github, .apm, or _apm)
 - "<owner>/<repo>"   -> cross-org reference (enterprise policy hub)
 - "https://..."      -> direct URL
 """

--- a/src/apm_cli/utils/github_host.py
+++ b/src/apm_cli/utils/github_host.py
@@ -23,6 +23,8 @@ def is_azure_devops_hostname(hostname: str | None) -> bool:
     h = hostname.lower()
     if h == "dev.azure.com":
         return True
+    if h == "ssh.dev.azure.com":
+        return True
     return bool(h.endswith(".visualstudio.com"))
 
 
@@ -612,11 +614,16 @@ def build_ado_api_url(
     Returns:
         str: API URL for retrieving file contents
     """
+    api_host = "dev.azure.com" if host == "ssh.dev.azure.com" else host
     encoded_path = urllib.parse.quote(path, safe="")
+    quoted_org = urllib.parse.quote(org, safe="")
     quoted_project = urllib.parse.quote(project, safe="")
+    quoted_repo = urllib.parse.quote(repo, safe="")
+    quoted_ref = urllib.parse.quote(ref, safe="")
+    org_path = "" if is_visualstudio_legacy_hostname(api_host) else f"{quoted_org}/"
     return (
-        f"https://{host}/{org}/{quoted_project}/_apis/git/repositories/{repo}/items"
-        f"?path={encoded_path}&versionDescriptor.version={ref}&api-version=7.0"
+        f"https://{api_host}/{org_path}{quoted_project}/_apis/git/repositories/{quoted_repo}/items"
+        f"?path={encoded_path}&versionDescriptor.version={quoted_ref}&api-version=7.0"
     )
 
 

--- a/tests/unit/policy/test_discovery.py
+++ b/tests/unit/policy/test_discovery.py
@@ -21,6 +21,7 @@ from apm_cli.policy.discovery import (
     _cache_key,
     _extract_org_from_git_remote,
     _fetch_ado_contents,
+    _fetch_from_ado_repo,
     _fetch_from_repo,
     _fetch_from_url,
     _fetch_github_contents,
@@ -75,6 +76,10 @@ class TestParseRemoteUrl(unittest.TestCase):
     def test_https_trailing_slash(self):
         result = _parse_remote_url("https://github.com/contoso/my-project/")
         self.assertEqual(result, ("contoso", "github.com"))
+
+    def test_https_visualstudio_uses_org_subdomain(self):
+        result = _parse_remote_url("https://contoso.visualstudio.com/project/_git/repo")
+        self.assertEqual(result, ("contoso", "contoso.visualstudio.com"))
 
     def test_ssh_trailing_slash(self):
         result = _parse_remote_url("git@github.com:contoso/my-project/")
@@ -808,6 +813,10 @@ class TestPolicyRepoCandidates(unittest.TestCase):
         result = _policy_repo_candidates("dev.azure.com")
         self.assertEqual(result, ("_apm",))
 
+    def test_ado_ssh_dev_azure_com(self):
+        result = _policy_repo_candidates("ssh.dev.azure.com")
+        self.assertEqual(result, ("_apm",))
+
     def test_ado_visualstudio_com(self):
         result = _policy_repo_candidates("contoso.visualstudio.com")
         self.assertEqual(result, ("_apm",))
@@ -820,9 +829,22 @@ class TestPolicyRepoCandidates(unittest.TestCase):
 class TestFetchAdoContents(unittest.TestCase):
     """Test _fetch_ado_contents for Azure DevOps Items API."""
 
-    @patch.dict(os.environ, {"ADO_APM_PAT": "my-ado-pat"}, clear=False)
+    def _auth_context(self, token: str | None, scheme: str = "basic"):
+        ctx = MagicMock()
+        ctx.token = token
+        ctx.auth_scheme = scheme
+        return ctx
+
+    def _resolver(self, mock_resolver_cls, token: str | None, scheme: str = "basic"):
+        resolver = mock_resolver_cls.return_value
+        resolver.resolve.return_value = self._auth_context(token, scheme)
+        resolver.build_error_context.return_value = "\n    auth remediation"
+        return resolver
+
+    @patch("apm_cli.core.auth.AuthResolver")
     @patch("apm_cli.policy.discovery.requests.get")
-    def test_success(self, mock_get):
+    def test_success(self, mock_get, mock_resolver_cls):
+        resolver = self._resolver(mock_resolver_cls, "my-ado-pat")
         mock_resp = MagicMock()
         mock_resp.status_code = 200
         mock_resp.text = VALID_POLICY_YAML
@@ -835,10 +857,12 @@ class TestFetchAdoContents(unittest.TestCase):
         call_kwargs = mock_get.call_args
         headers = call_kwargs[1].get("headers", {})
         self.assertIn("Basic", headers.get("Authorization", ""))
+        resolver.resolve.assert_called_once_with("dev.azure.com", org="contoso")
 
-    @patch.dict(os.environ, {"ADO_APM_PAT": "my-ado-pat"}, clear=False)
+    @patch("apm_cli.core.auth.AuthResolver")
     @patch("apm_cli.policy.discovery.requests.get")
-    def test_404_returns_error(self, mock_get):
+    def test_404_returns_error(self, mock_get, mock_resolver_cls):
+        self._resolver(mock_resolver_cls, "my-ado-pat")
         mock_resp = MagicMock()
         mock_resp.status_code = 404
         mock_get.return_value = mock_resp
@@ -847,9 +871,10 @@ class TestFetchAdoContents(unittest.TestCase):
         self.assertIsNone(content)
         self.assertIn("404", error)
 
-    @patch.dict(os.environ, {"ADO_APM_PAT": "my-ado-pat"}, clear=False)
+    @patch("apm_cli.core.auth.AuthResolver")
     @patch("apm_cli.policy.discovery.requests.get")
-    def test_401_returns_error(self, mock_get):
+    def test_401_returns_error(self, mock_get, mock_resolver_cls):
+        resolver = self._resolver(mock_resolver_cls, "my-ado-pat")
         mock_resp = MagicMock()
         mock_resp.status_code = 401
         mock_get.return_value = mock_resp
@@ -857,10 +882,15 @@ class TestFetchAdoContents(unittest.TestCase):
         content, error = _fetch_ado_contents("contoso", "_apm", "_apm", "apm-policy.yml")
         self.assertIsNone(content)
         self.assertIn("401", error)
+        self.assertIn("auth remediation", error)
+        resolver.build_error_context.assert_called_once_with(
+            "dev.azure.com", "fetch org policy", org="contoso"
+        )
 
-    @patch.dict(os.environ, {"ADO_APM_PAT": "my-ado-pat"}, clear=False)
+    @patch("apm_cli.core.auth.AuthResolver")
     @patch("apm_cli.policy.discovery.requests.get")
-    def test_redirect_rejected(self, mock_get):
+    def test_redirect_rejected(self, mock_get, mock_resolver_cls):
+        self._resolver(mock_resolver_cls, "my-ado-pat")
         mock_resp = MagicMock()
         mock_resp.status_code = 302
         mock_resp.headers = {"Location": "https://evil.example.com"}
@@ -870,11 +900,11 @@ class TestFetchAdoContents(unittest.TestCase):
         self.assertIsNone(content)
         self.assertIn("redirect", error.lower())
 
-    @patch.dict(os.environ, {"ADO_APM_PAT": ""}, clear=False)
-    @patch("apm_cli.policy.discovery._get_token_for_host", return_value=None)
+    @patch("apm_cli.core.auth.AuthResolver")
     @patch("apm_cli.policy.discovery.requests.get")
-    def test_no_auth_token_still_sends_request(self, mock_get, _mock_token):
+    def test_no_auth_token_still_sends_request(self, mock_get, mock_resolver_cls):
         """Unauthenticated requests are allowed (public ADO repos)."""
+        self._resolver(mock_resolver_cls, None)
         mock_resp = MagicMock()
         mock_resp.status_code = 200
         mock_resp.text = VALID_POLICY_YAML
@@ -887,11 +917,11 @@ class TestFetchAdoContents(unittest.TestCase):
         headers = call_kwargs[1].get("headers", {})
         self.assertNotIn("Authorization", headers)
 
-    @patch.dict(os.environ, {"ADO_APM_PAT": ""}, clear=False)
-    @patch("apm_cli.policy.discovery._get_token_for_host", return_value="fallback-token")
+    @patch("apm_cli.core.auth.AuthResolver")
     @patch("apm_cli.policy.discovery.requests.get")
-    def test_fallback_to_bearer_when_no_ado_pat(self, mock_get, _mock_token):
-        """When ADO_APM_PAT is empty, falls back to Bearer via _get_token_for_host."""
+    def test_authresolver_bearer_token_uses_bearer_header(self, mock_get, mock_resolver_cls):
+        """ADO bearer tokens from AuthResolver use Bearer auth."""
+        self._resolver(mock_resolver_cls, "fallback-token", scheme="bearer")
         mock_resp = MagicMock()
         mock_resp.status_code = 200
         mock_resp.text = VALID_POLICY_YAML
@@ -902,6 +932,104 @@ class TestFetchAdoContents(unittest.TestCase):
         call_kwargs = mock_get.call_args
         headers = call_kwargs[1].get("headers", {})
         self.assertEqual(headers.get("Authorization"), "Bearer fallback-token")
+
+
+class TestFetchFromAdoRepo(unittest.TestCase):
+    """Test _fetch_from_ado_repo orchestration around the ADO transport."""
+
+    @patch("apm_cli.policy.discovery._fetch_ado_contents")
+    def test_200_caches_result(self, mock_fetch):
+        mock_fetch.return_value = (VALID_POLICY_YAML, None)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            result = _fetch_from_ado_repo(
+                org="contoso",
+                project="_apm",
+                repo="_apm",
+                host="dev.azure.com",
+                project_root=root,
+                no_cache=True,
+            )
+            self.assertTrue(result.found)
+            self.assertEqual(result.source, "org:dev.azure.com/contoso/_apm/_apm")
+            self.assertFalse(result.cached)
+
+    @patch("apm_cli.policy.discovery._fetch_ado_contents")
+    def test_404_no_error(self, mock_fetch):
+        mock_fetch.return_value = (None, "404: Policy file not found")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _fetch_from_ado_repo(
+                org="contoso",
+                project="_apm",
+                repo="_apm",
+                host="dev.azure.com",
+                project_root=Path(tmpdir),
+                no_cache=True,
+            )
+            self.assertFalse(result.found)
+            self.assertEqual(result.outcome, "absent")
+            self.assertIsNone(result.error)
+
+    @patch("apm_cli.policy.discovery._fetch_ado_contents")
+    def test_api_error_uses_stale_cache(self, mock_fetch):
+        mock_fetch.return_value = (None, "Connection error fetching policy")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            repo_ref = "dev.azure.com/contoso/_apm/_apm"
+            _write_cache(repo_ref, _make_test_policy(), root)
+            cache_dir = _get_cache_dir(root)
+            key = _cache_key(repo_ref)
+            meta_file = cache_dir / f"{key}.meta.json"
+            meta = json.loads(meta_file.read_text(encoding="utf-8"))
+            meta["cached_at"] = time.time() - DEFAULT_CACHE_TTL - 100
+            meta_file.write_text(json.dumps(meta), encoding="utf-8")
+
+            result = _fetch_from_ado_repo(
+                org="contoso",
+                project="_apm",
+                repo="_apm",
+                host="dev.azure.com",
+                project_root=root,
+            )
+            self.assertTrue(result.found)
+            self.assertTrue(result.cached)
+            self.assertEqual(result.outcome, "cached_stale")
+
+    @patch("apm_cli.policy.discovery._fetch_ado_contents")
+    def test_invalid_policy_yaml(self, mock_fetch):
+        mock_fetch.return_value = ("enforcement: bogus\n", None)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _fetch_from_ado_repo(
+                org="contoso",
+                project="_apm",
+                repo="_apm",
+                host="dev.azure.com",
+                project_root=Path(tmpdir),
+                no_cache=True,
+            )
+            self.assertFalse(result.found)
+            self.assertIn("Invalid policy", result.error)
+
+    @patch("apm_cli.policy.discovery._fetch_ado_contents")
+    def test_hash_pin_mismatch(self, mock_fetch):
+        mock_fetch.return_value = (VALID_POLICY_YAML, None)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _fetch_from_ado_repo(
+                org="contoso",
+                project="_apm",
+                repo="_apm",
+                host="dev.azure.com",
+                project_root=Path(tmpdir),
+                no_cache=True,
+                expected_hash="sha256:" + ("0" * 64),
+            )
+            self.assertFalse(result.found)
+            self.assertEqual(result.outcome, "hash_mismatch")
 
 
 class TestGetTokenForHost(unittest.TestCase):

--- a/tests/unit/policy/test_discovery.py
+++ b/tests/unit/policy/test_discovery.py
@@ -820,9 +820,9 @@ class TestPolicyRepoCandidates(unittest.TestCase):
 class TestFetchAdoContents(unittest.TestCase):
     """Test _fetch_ado_contents for Azure DevOps Items API."""
 
-    @patch("apm_cli.policy.discovery._get_token_for_host", return_value="ado-token")
+    @patch.dict(os.environ, {"ADO_APM_PAT": "my-ado-pat"}, clear=False)
     @patch("apm_cli.policy.discovery.requests.get")
-    def test_success(self, mock_get, _mock_token):
+    def test_success(self, mock_get):
         mock_resp = MagicMock()
         mock_resp.status_code = 200
         mock_resp.text = VALID_POLICY_YAML
@@ -831,10 +831,14 @@ class TestFetchAdoContents(unittest.TestCase):
         content, error = _fetch_ado_contents("contoso", "_apm", "_apm", "apm-policy.yml")
         self.assertIsNone(error)
         self.assertEqual(content, VALID_POLICY_YAML)
+        # Verify Basic auth header was sent with ADO_APM_PAT
+        call_kwargs = mock_get.call_args
+        headers = call_kwargs[1].get("headers", {})
+        self.assertIn("Basic", headers.get("Authorization", ""))
 
-    @patch("apm_cli.policy.discovery._get_token_for_host", return_value="ado-token")
+    @patch.dict(os.environ, {"ADO_APM_PAT": "my-ado-pat"}, clear=False)
     @patch("apm_cli.policy.discovery.requests.get")
-    def test_404_returns_error(self, mock_get, _mock_token):
+    def test_404_returns_error(self, mock_get):
         mock_resp = MagicMock()
         mock_resp.status_code = 404
         mock_get.return_value = mock_resp
@@ -843,9 +847,9 @@ class TestFetchAdoContents(unittest.TestCase):
         self.assertIsNone(content)
         self.assertIn("404", error)
 
-    @patch("apm_cli.policy.discovery._get_token_for_host", return_value="ado-token")
+    @patch.dict(os.environ, {"ADO_APM_PAT": "my-ado-pat"}, clear=False)
     @patch("apm_cli.policy.discovery.requests.get")
-    def test_401_returns_error(self, mock_get, _mock_token):
+    def test_401_returns_error(self, mock_get):
         mock_resp = MagicMock()
         mock_resp.status_code = 401
         mock_get.return_value = mock_resp
@@ -854,9 +858,9 @@ class TestFetchAdoContents(unittest.TestCase):
         self.assertIsNone(content)
         self.assertIn("401", error)
 
-    @patch("apm_cli.policy.discovery._get_token_for_host", return_value="ado-token")
+    @patch.dict(os.environ, {"ADO_APM_PAT": "my-ado-pat"}, clear=False)
     @patch("apm_cli.policy.discovery.requests.get")
-    def test_redirect_rejected(self, mock_get, _mock_token):
+    def test_redirect_rejected(self, mock_get):
         mock_resp = MagicMock()
         mock_resp.status_code = 302
         mock_resp.headers = {"Location": "https://evil.example.com"}
@@ -866,6 +870,7 @@ class TestFetchAdoContents(unittest.TestCase):
         self.assertIsNone(content)
         self.assertIn("redirect", error.lower())
 
+    @patch.dict(os.environ, {"ADO_APM_PAT": ""}, clear=False)
     @patch("apm_cli.policy.discovery._get_token_for_host", return_value=None)
     @patch("apm_cli.policy.discovery.requests.get")
     def test_no_auth_token_still_sends_request(self, mock_get, _mock_token):
@@ -881,6 +886,22 @@ class TestFetchAdoContents(unittest.TestCase):
         call_kwargs = mock_get.call_args
         headers = call_kwargs[1].get("headers", {})
         self.assertNotIn("Authorization", headers)
+
+    @patch.dict(os.environ, {"ADO_APM_PAT": ""}, clear=False)
+    @patch("apm_cli.policy.discovery._get_token_for_host", return_value="fallback-token")
+    @patch("apm_cli.policy.discovery.requests.get")
+    def test_fallback_to_bearer_when_no_ado_pat(self, mock_get, _mock_token):
+        """When ADO_APM_PAT is empty, falls back to Bearer via _get_token_for_host."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = VALID_POLICY_YAML
+        mock_get.return_value = mock_resp
+
+        _content, error = _fetch_ado_contents("contoso", "_apm", "_apm", "apm-policy.yml")
+        self.assertIsNone(error)
+        call_kwargs = mock_get.call_args
+        headers = call_kwargs[1].get("headers", {})
+        self.assertEqual(headers.get("Authorization"), "Bearer fallback-token")
 
 
 class TestGetTokenForHost(unittest.TestCase):

--- a/tests/unit/policy/test_discovery.py
+++ b/tests/unit/policy/test_discovery.py
@@ -20,12 +20,14 @@ from apm_cli.policy.discovery import (
     _auto_discover,
     _cache_key,
     _extract_org_from_git_remote,
+    _fetch_ado_contents,
     _fetch_from_repo,
     _fetch_from_url,
     _fetch_github_contents,
     _get_cache_dir,
     _load_from_file,
     _parse_remote_url,
+    _policy_repo_candidates,
     _read_cache,
     _write_cache,
     discover_policy,
@@ -655,39 +657,102 @@ class TestDiscoverPolicy(unittest.TestCase):
 
 
 class TestAutoDiscover(unittest.TestCase):
-    """Test _auto_discover logic."""
+    """Test _auto_discover logic with cascading candidate repos."""
 
     @patch("apm_cli.policy.discovery._fetch_from_repo")
     @patch("apm_cli.policy.discovery._extract_org_from_git_remote")
-    def test_github_com_repo_ref(self, mock_extract, mock_fetch):
+    def test_github_com_first_candidate_found(self, mock_extract, mock_fetch):
+        """When .github has a policy, it wins immediately."""
         mock_extract.return_value = ("contoso", "github.com")
         mock_fetch.return_value = PolicyFetchResult(
-            policy=ApmPolicy(), source="org:contoso/.github"
+            policy=ApmPolicy(), source="org:contoso/.github", outcome="found"
         )
 
         with tempfile.TemporaryDirectory() as tmpdir:
             result = _auto_discover(Path(tmpdir), no_cache=True)
-            mock_fetch.assert_called_once_with(
-                "contoso/.github", Path(tmpdir), no_cache=True, expected_hash=None
-            )
+            # First call should be for .github
+            first_call = mock_fetch.call_args_list[0]
+            self.assertEqual(first_call[0][0], "contoso/.github")
             self.assertTrue(result.found)
+
+    @patch("apm_cli.policy.discovery._fetch_from_repo")
+    @patch("apm_cli.policy.discovery._extract_org_from_git_remote")
+    def test_github_com_cascades_to_dot_apm(self, mock_extract, mock_fetch):
+        """.github absent -> falls back to .apm."""
+        mock_extract.return_value = ("contoso", "github.com")
+        mock_fetch.side_effect = [
+            PolicyFetchResult(outcome="absent"),  # .github 404
+            PolicyFetchResult(
+                policy=ApmPolicy(), source="org:contoso/.apm", outcome="found"
+            ),  # .apm found
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _auto_discover(Path(tmpdir), no_cache=True)
+            self.assertEqual(mock_fetch.call_count, 2)
+            self.assertEqual(mock_fetch.call_args_list[0][0][0], "contoso/.github")
+            self.assertEqual(mock_fetch.call_args_list[1][0][0], "contoso/.apm")
+            self.assertTrue(result.found)
+
+    @patch("apm_cli.policy.discovery._fetch_from_repo")
+    @patch("apm_cli.policy.discovery._extract_org_from_git_remote")
+    def test_github_com_cascades_to_underscore_apm(self, mock_extract, mock_fetch):
+        """All dot-prefixed repos absent -> falls back to _apm."""
+        mock_extract.return_value = ("contoso", "github.com")
+        mock_fetch.side_effect = [
+            PolicyFetchResult(outcome="absent"),  # .github 404
+            PolicyFetchResult(outcome="absent"),  # .apm 404
+            PolicyFetchResult(
+                policy=ApmPolicy(), source="org:contoso/_apm", outcome="found"
+            ),  # _apm found
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _auto_discover(Path(tmpdir), no_cache=True)
+            self.assertEqual(mock_fetch.call_count, 3)
+            self.assertTrue(result.found)
+
+    @patch("apm_cli.policy.discovery._fetch_from_repo")
+    @patch("apm_cli.policy.discovery._extract_org_from_git_remote")
+    def test_github_com_all_absent(self, mock_extract, mock_fetch):
+        """All candidates return absent -> outcome is absent."""
+        mock_extract.return_value = ("contoso", "github.com")
+        mock_fetch.return_value = PolicyFetchResult(outcome="absent")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _auto_discover(Path(tmpdir), no_cache=True)
+            self.assertEqual(mock_fetch.call_count, 3)
+            self.assertEqual(result.outcome, "absent")
+            self.assertFalse(result.found)
+
+    @patch("apm_cli.policy.discovery._fetch_from_repo")
+    @patch("apm_cli.policy.discovery._extract_org_from_git_remote")
+    def test_github_com_error_fail_closed(self, mock_extract, mock_fetch):
+        """Auth error on first candidate -> fail-closed, no fallback."""
+        mock_extract.return_value = ("contoso", "github.com")
+        mock_fetch.return_value = PolicyFetchResult(
+            error="401: Unauthorized", outcome="cache_miss_fetch_fail"
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _auto_discover(Path(tmpdir), no_cache=True)
+            # Only one call -- error stops the cascade
+            self.assertEqual(mock_fetch.call_count, 1)
+            self.assertFalse(result.found)
+            self.assertIn("401", result.error)
 
     @patch("apm_cli.policy.discovery._fetch_from_repo")
     @patch("apm_cli.policy.discovery._extract_org_from_git_remote")
     def test_ghe_repo_ref_includes_host(self, mock_extract, mock_fetch):
         mock_extract.return_value = ("contoso", "ghe.example.com")
         mock_fetch.return_value = PolicyFetchResult(
-            policy=ApmPolicy(), source="org:ghe.example.com/contoso/.github"
+            policy=ApmPolicy(), source="org:ghe.example.com/contoso/.github", outcome="found"
         )
 
         with tempfile.TemporaryDirectory() as tmpdir:
             _auto_discover(Path(tmpdir), no_cache=True)
-            mock_fetch.assert_called_once_with(
-                "ghe.example.com/contoso/.github",
-                Path(tmpdir),
-                no_cache=True,
-                expected_hash=None,
-            )
+            first_call = mock_fetch.call_args_list[0]
+            self.assertEqual(first_call[0][0], "ghe.example.com/contoso/.github")
 
     @patch("apm_cli.policy.discovery._extract_org_from_git_remote")
     def test_no_remote_returns_error(self, mock_extract):
@@ -697,6 +762,125 @@ class TestAutoDiscover(unittest.TestCase):
             result = _auto_discover(Path(tmpdir), no_cache=True)
             self.assertFalse(result.found)
             self.assertIn("Could not determine org", result.error)
+
+    @patch("apm_cli.policy.discovery._fetch_from_ado_repo")
+    @patch("apm_cli.policy.discovery._extract_org_from_git_remote")
+    def test_ado_host_only_tries_underscore_apm(self, mock_extract, mock_ado_fetch):
+        """ADO host profile skips .github and .apm, only tries _apm."""
+        mock_extract.return_value = ("contoso", "dev.azure.com")
+        mock_ado_fetch.return_value = PolicyFetchResult(
+            policy=ApmPolicy(), source="org:dev.azure.com/contoso/_apm/_apm", outcome="found"
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _auto_discover(Path(tmpdir), no_cache=True)
+            mock_ado_fetch.assert_called_once()
+            call_kwargs = mock_ado_fetch.call_args
+            self.assertEqual(call_kwargs[1]["repo"], "_apm")
+            self.assertEqual(call_kwargs[1]["project"], "_apm")
+            self.assertTrue(result.found)
+
+    @patch("apm_cli.policy.discovery._fetch_from_ado_repo")
+    @patch("apm_cli.policy.discovery._extract_org_from_git_remote")
+    def test_ado_visualstudio_host(self, mock_extract, mock_ado_fetch):
+        """*.visualstudio.com hosts also use ADO profile."""
+        mock_extract.return_value = ("contoso", "contoso.visualstudio.com")
+        mock_ado_fetch.return_value = PolicyFetchResult(outcome="absent")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = _auto_discover(Path(tmpdir), no_cache=True)
+            mock_ado_fetch.assert_called_once()
+            self.assertEqual(result.outcome, "absent")
+
+
+class TestPolicyRepoCandidates(unittest.TestCase):
+    """Test _policy_repo_candidates host profile selection."""
+
+    def test_github_com_returns_all_candidates(self):
+        result = _policy_repo_candidates("github.com")
+        self.assertEqual(result, (".github", ".apm", "_apm"))
+
+    def test_ghe_returns_all_candidates(self):
+        result = _policy_repo_candidates("ghe.example.com")
+        self.assertEqual(result, (".github", ".apm", "_apm"))
+
+    def test_ado_dev_azure_com(self):
+        result = _policy_repo_candidates("dev.azure.com")
+        self.assertEqual(result, ("_apm",))
+
+    def test_ado_visualstudio_com(self):
+        result = _policy_repo_candidates("contoso.visualstudio.com")
+        self.assertEqual(result, ("_apm",))
+
+    def test_unknown_host_returns_all(self):
+        result = _policy_repo_candidates("gitlab.example.com")
+        self.assertEqual(result, (".github", ".apm", "_apm"))
+
+
+class TestFetchAdoContents(unittest.TestCase):
+    """Test _fetch_ado_contents for Azure DevOps Items API."""
+
+    @patch("apm_cli.policy.discovery._get_token_for_host", return_value="ado-token")
+    @patch("apm_cli.policy.discovery.requests.get")
+    def test_success(self, mock_get, _mock_token):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = VALID_POLICY_YAML
+        mock_get.return_value = mock_resp
+
+        content, error = _fetch_ado_contents("contoso", "_apm", "_apm", "apm-policy.yml")
+        self.assertIsNone(error)
+        self.assertEqual(content, VALID_POLICY_YAML)
+
+    @patch("apm_cli.policy.discovery._get_token_for_host", return_value="ado-token")
+    @patch("apm_cli.policy.discovery.requests.get")
+    def test_404_returns_error(self, mock_get, _mock_token):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        mock_get.return_value = mock_resp
+
+        content, error = _fetch_ado_contents("contoso", "_apm", "_apm", "apm-policy.yml")
+        self.assertIsNone(content)
+        self.assertIn("404", error)
+
+    @patch("apm_cli.policy.discovery._get_token_for_host", return_value="ado-token")
+    @patch("apm_cli.policy.discovery.requests.get")
+    def test_401_returns_error(self, mock_get, _mock_token):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+        mock_get.return_value = mock_resp
+
+        content, error = _fetch_ado_contents("contoso", "_apm", "_apm", "apm-policy.yml")
+        self.assertIsNone(content)
+        self.assertIn("401", error)
+
+    @patch("apm_cli.policy.discovery._get_token_for_host", return_value="ado-token")
+    @patch("apm_cli.policy.discovery.requests.get")
+    def test_redirect_rejected(self, mock_get, _mock_token):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 302
+        mock_resp.headers = {"Location": "https://evil.example.com"}
+        mock_get.return_value = mock_resp
+
+        content, error = _fetch_ado_contents("contoso", "_apm", "_apm", "apm-policy.yml")
+        self.assertIsNone(content)
+        self.assertIn("redirect", error.lower())
+
+    @patch("apm_cli.policy.discovery._get_token_for_host", return_value=None)
+    @patch("apm_cli.policy.discovery.requests.get")
+    def test_no_auth_token_still_sends_request(self, mock_get, _mock_token):
+        """Unauthenticated requests are allowed (public ADO repos)."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = VALID_POLICY_YAML
+        mock_get.return_value = mock_resp
+
+        _content, error = _fetch_ado_contents("contoso", "_apm", "_apm", "apm-policy.yml")
+        self.assertIsNone(error)
+        # Verify no Authorization header was sent
+        call_kwargs = mock_get.call_args
+        headers = call_kwargs[1].get("headers", {})
+        self.assertNotIn("Authorization", headers)
 
 
 class TestGetTokenForHost(unittest.TestCase):

--- a/tests/unit/test_github_host.py
+++ b/tests/unit/test_github_host.py
@@ -146,6 +146,7 @@ def test_is_azure_devops_hostname():
     """Test Azure DevOps hostname detection."""
     # Valid Azure DevOps hosts
     assert github_host.is_azure_devops_hostname("dev.azure.com")
+    assert github_host.is_azure_devops_hostname("ssh.dev.azure.com")
     assert github_host.is_azure_devops_hostname("mycompany.visualstudio.com")
     assert github_host.is_azure_devops_hostname("contoso.visualstudio.com")
 
@@ -308,6 +309,25 @@ def test_build_ado_api_url():
     assert "path=apm.yml" in url
     assert "versionDescriptor.version=main" in url
     assert "api-version=7.0" in url
+
+    encoded_url = github_host.build_ado_api_url("my org", "My Project", "repo/name", "path/file.md")
+    assert "my%20org/My%20Project/_apis/git/repositories/repo%2Fname/items" in encoded_url
+    encoded_ref_url = github_host.build_ado_api_url(
+        "myorg", "project", "repo", "path/file.md", ref="feature/a&b"
+    )
+    assert "versionDescriptor.version=feature%2Fa%26b" in encoded_ref_url
+
+    legacy_url = github_host.build_ado_api_url(
+        "contoso", "_apm", "_apm", "apm-policy.yml", host="contoso.visualstudio.com"
+    )
+    assert legacy_url.startswith(
+        "https://contoso.visualstudio.com/_apm/_apis/git/repositories/_apm/items"
+    )
+
+    ssh_url = github_host.build_ado_api_url(
+        "contoso", "_apm", "_apm", "apm-policy.yml", host="ssh.dev.azure.com"
+    )
+    assert ssh_url.startswith("https://dev.azure.com/contoso/_apm/_apis/")
 
 
 def test_build_authorization_header_git_env_bearer():


### PR DESCRIPTION
## Problem

Azure DevOps does not allow repository names starting or ending with a period (`.`). APM's org-wide policy discovery hardcodes `.github` as the policy repo name, which means ADO organisations cannot use APM's governance policy feature at all.

Additionally, `_fetch_github_contents()` only speaks the GitHub Contents API -- even if the repo name were changed, ADO needs a different REST API call (Items API).

Closes #1813

## Approach

Introduce **cascading policy repo discovery** with three candidate repo names tried in precedence order, and **host profiles** that determine which candidates are valid per git platform.

### Candidate repos (precedence order)

| Priority | Repo name | Valid on |
|----------|-----------|---------|
| 1 | `.github` | GitHub, GHES, GitLab, other |
| 2 | `.apm` | GitHub, GHES, GitLab, other |
| 3 | `_apm` | All hosts including Azure DevOps |

### Host profiles

- **default** (GitHub, GHES, GitLab, other): tries `.github`, `.apm`, `_apm`
- **ado** (dev.azure.com, *.visualstudio.com): tries `_apm` only

First valid policy found wins. Errors (auth, timeout, malformed YAML) fail-closed immediately -- only 404/absent continues to the next candidate.

## Implementation

| File | Change |
|------|--------|
| `src/apm_cli/policy/discovery.py` | Host profiles (`_policy_repo_candidates`), cascading `_auto_discover()`, new `_fetch_from_ado_repo()` and `_fetch_ado_contents()` |
| `src/apm_cli/policy/_help_text.py` | Updated help text mentioning cascading convention |
| `src/apm_cli/policy/inheritance.py` | Updated docstring |
| `tests/unit/policy/test_discovery.py` | Tests for cascading precedence, ADO profile, ADO fetch, error fail-close |
| `docs/src/content/docs/enterprise/apm-policy.md` | Documented cascading convention and ADO setup |

## How to test

```bash
uv run --extra dev python -m pytest tests/unit/policy/test_discovery.py -x -q
```

All 84 discovery tests pass (923 total policy tests pass).

apm-spec-waiver: Bug fix -- cascading policy repo discovery for ADO platform support, no new normative behaviour
