### PR TITLE
test(integration): fix 3 semantic-merge test breakages in merge queue

### DIFF
--- a/tests/integration/test_commands_deep_coverage.py
+++ b/tests/integration/test_commands_deep_coverage.py
@@ -312,23 +312,24 @@ class TestMcpCommand:
 class TestOutdatedCommand:
     """Tests for ``apm outdated`` command."""
 
-    def test_outdated_no_lockfile(self, runner: CliRunner, project_no_deps: Path):
+    def test_outdated_no_lockfile(
+        self, runner: CliRunner, project_no_deps: Path, monkeypatch: pytest.MonkeyPatch
+    ):
         """Test outdated when no lockfile exists."""
+        # outdated resolves the project via Path.cwd(); pin it deterministically.
+        monkeypatch.chdir(project_no_deps)
         result = runner.invoke(
             cli,
             ["outdated"],
             catch_exceptions=False,
-            obj={"cwd": str(project_no_deps)},
         )
-        # outdated succeeds but reports no dependencies to check
-        assert result.exit_code == 0
-        assert (
-            "No remote dependencies" in result.output
-            or "no packages" in result.output.lower()
-            or "No locked dependencies" in result.output
-        )
+        # No lockfile is a hard error -- the command exits 1 and says so.
+        assert result.exit_code == 1
+        assert "No lockfile found" in result.output
 
-    def test_outdated_no_dependencies(self, runner: CliRunner, project_with_deps: Path):
+    def test_outdated_no_dependencies(
+        self, runner: CliRunner, project_with_deps: Path, monkeypatch: pytest.MonkeyPatch
+    ):
         """Test outdated with empty dependency list."""
         # Create project with lockfile but no dependencies
         project_path = project_with_deps
@@ -338,14 +339,16 @@ class TestOutdatedCommand:
         )
         (project_path / "apm.lock.yaml").write_text("version: 1\npackages: {}\n", encoding="utf-8")
 
+        # outdated resolves the project via Path.cwd(); pin it deterministically.
+        monkeypatch.chdir(project_path)
         result = runner.invoke(
             cli,
             ["outdated"],
             catch_exceptions=False,
-            obj={"cwd": str(project_path)},
         )
         # Should succeed with message about no dependencies
         assert result.exit_code == 0
+        assert "No locked dependencies" in result.output
 
     def test_outdated_with_mocked_checks(self, runner: CliRunner, project_with_deps: Path):
         """Test outdated command with mocked downloader."""
@@ -462,27 +465,35 @@ class TestDepsCommand:
 class TestCompileCommand:
     """Tests for ``apm compile`` command."""
 
-    def test_compile_no_apm_yml(self, runner: CliRunner, tmp_path: Path):
+    def test_compile_no_apm_yml(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
         """Test compile when no apm.yml exists."""
+        # compile resolves the project via Path.cwd(); pin it to an empty dir.
+        monkeypatch.chdir(tmp_path)
         result = runner.invoke(
             cli,
             ["compile"],
             catch_exceptions=False,
-            obj={"cwd": str(tmp_path)},
         )
-        # compile succeeds and auto-detects vscode target
-        assert result.exit_code == 0
+        # No apm.yml is a hard error -- the command exits 1 and says so.
+        assert result.exit_code == 1
+        assert "Not an APM project" in result.output
 
-    def test_compile_no_agents_md(self, runner: CliRunner, project_no_deps: Path):
+    def test_compile_no_agents_md(
+        self, runner: CliRunner, project_no_deps: Path, monkeypatch: pytest.MonkeyPatch
+    ):
         """Test compile when no agents.md exists."""
+        # compile resolves the project via Path.cwd(); pin it deterministically.
+        monkeypatch.chdir(project_no_deps)
         result = runner.invoke(
             cli,
             ["compile"],
             catch_exceptions=False,
-            obj={"cwd": str(project_no_deps)},
         )
-        # Should succeed and process available assets
-        assert result.exit_code == 0
+        # With an apm.yml but no APM content, compile exits 1 with guidance.
+        assert result.exit_code == 1
+        assert "No APM content found" in result.output
 
     def test_compile_single_file_mode(self, runner: CliRunner, project_no_deps: Path):
         """Test compile with a single agents.md file."""

--- a/tests/integration/test_wave2_adapters_coverage.py
+++ b/tests/integration/test_wave2_adapters_coverage.py
@@ -2268,7 +2268,7 @@ class TestGeminiAdapterConfigure:
         """configure_mcp_server returns True (opt-in skip) when .gemini/ absent."""
         adapter = GeminiClientAdapter(project_root=tmp_path)
         server_info = {"name": "test", "packages": []}
-        with patch.object(adapter, "_get_gemini_dir", return_value=tmp_path / ".gemini"):
+        with patch.object(adapter, "_get_config_dir", return_value=tmp_path / ".gemini"):
             result = adapter.configure_mcp_server(
                 "owner/server",
                 server_info_cache={"owner/server": server_info},

--- a/tests/integration/test_wave7_policy_registry_coverage.py
+++ b/tests/integration/test_wave7_policy_registry_coverage.py
@@ -680,7 +680,10 @@ class TestCheckUnmanagedFiles:
         policy = UnmanagedFilesPolicy(action="deny", directories=(".github/agents",))
         result = _check_unmanaged_files(tmp_path, None, policy)
         assert not result.passed
-        assert len(result.details) == 1
+        # details = one per-file line + a single trailing next-action hint.
+        file_details = [d for d in result.details if "not tracked in apm.lock.yaml" in d]
+        assert len(file_details) == 1
+        assert "stray.md" in file_details[0]
 
     def test_deployed_file_not_unmanaged(self, tmp_path):
         gov_dir = tmp_path / ".github" / "agents"


### PR DESCRIPTION
## TL;DR

Six integration tests started failing in the merge queue (run [27680546218](https://github.com/microsoft/apm/actions/runs/27680546218/job/81866974223)) across shards 1 and 4. None are flaky in the usual sense — they are **stale tests** broken by semantic merge conflicts: three recently-merged PRs each passed in isolation, but their combination on `main` left assertions/patches pointing at old behavior. This PR fixes all six.

## Root causes & fixes

### 1. `AttributeError: ... does not have the attribute '_get_gemini_dir'`
`tests/integration/test_wave2_adapters_coverage.py`

PR #1770 renamed `GeminiClientAdapter._get_gemini_dir()` → `_get_config_dir()`. PR #1788 added a test that still patches the old name. Updated the `patch.object` target.

### 2. `assert 2 == 1` on unmanaged-files details
`tests/integration/test_wave7_policy_registry_coverage.py`

PR #1793 now appends a single trailing next-action hint (`"Next: run 'apm install <ref>' ..."`) to any non-empty unmanaged-files report. `test_unmanaged_file_deny` asserted exactly one detail line. Changed it to assert on the flagged-file line itself (`"not tracked in apm.lock.yaml"` + `stray.md`) rather than the raw count, so it stays correct regardless of the hint.

### 3. Four `SystemExit(1)` failures in `outdated` / `compile`
`tests/integration/test_commands_deep_coverage.py`

These tests passed `obj={"cwd": ...}` — but **no command ever reads that key** (verified: zero `obj["cwd"]` reads in `src/`). `outdated` and `compile` resolve the project via `Path.cwd()` (`get_apm_dir(PROJECT)` returns `Path.cwd()`). The tests only passed because pytest's process CWD was the repo root (a valid APM project), never the fixture dir. Under CI's parallel xdist (`-n 2 --dist loadgroup`), a sibling test leaking `os.chdir` polluted the shared worker CWD and flipped these exit codes.

Fix: pin CWD deterministically with `monkeypatch.chdir(fixture)` (auto-restoring, so the tests can no longer be polluted *or* pollute others), and correct three assertions that never actually matched the commands' real behavior:

| Test | Old (accidental) | Real behavior in fixture dir |
|------|------------------|------------------------------|
| `test_outdated_no_lockfile` | exit 0 | exit 1, `No lockfile found` |
| `test_outdated_no_dependencies` | exit 0 | exit 0, `No locked dependencies` (now deterministic) |
| `test_compile_no_apm_yml` | exit 0 | exit 1, `Not an APM project` |
| `test_compile_no_agents_md` | exit 0 | exit 1, `No APM content found` |

## Validation

- All 6 originally-failing tests pass.
- The 3 affected files (682 tests) pass under `-n 2 --dist loadgroup`.
- Deep-coverage tests verified resilient to a simulated leaked `os.chdir` (the exact CI failure mode).
- `ruff check` + `ruff format --check` clean on all edited files.
- No `src/` changes — test-only fix matching real, intended command behavior.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>