### PR TITLE
fix(outdated): degrade per-dep check failures instead of crashing; stabilize e2e teardown

### DIFF
--- a/src/apm_cli/commands/outdated.py
+++ b/src/apm_cli/commands/outdated.py
@@ -29,6 +29,15 @@ logger = logging.getLogger(__name__)
 TAG_RE = re.compile(r"^v?\d+\.\d+\.\d+")
 
 
+def _unknown_row(dep) -> OutdatedRow:
+    """Degraded row for a dependency whose check raised unexpectedly.
+
+    Keeps ``apm outdated`` from crashing when a single dependency check
+    fails; the dependency is surfaced as ``unknown`` instead.
+    """
+    return OutdatedRow(package=dep.get_unique_key(), current="(none)", latest="-", status="unknown")
+
+
 def _is_tag_ref(ref: str, package_name: str | None = None) -> bool:
     """Return True when *ref* names a version tag (plain or patterned)."""
     from ..marketplace.tag_pattern import is_version_tag_ref
@@ -621,7 +630,10 @@ def _check_deps_with_progress(
                 for dep in checkable:
                     short = dep.get_unique_key().split("/")[-1]
                     progress.update(task_id, description=f"Checking {short}")
-                    result = _check_one_dep(dep, downloader, verbose, registry_ctx)
+                    try:
+                        result = _check_one_dep(dep, downloader, verbose, registry_ctx)
+                    except Exception:
+                        result = _unknown_row(dep)
                     rows.append(result)
                     progress.advance(task_id)
     except ImportError:
@@ -637,7 +649,10 @@ def _check_deps_with_progress(
             )
         else:
             for dep in checkable:
-                rows.append(_check_one_dep(dep, downloader, verbose, registry_ctx))
+                try:
+                    rows.append(_check_one_dep(dep, downloader, verbose, registry_ctx))
+                except Exception:
+                    rows.append(_unknown_row(dep))
 
     return rows
 
@@ -669,8 +684,7 @@ def _check_parallel(
             try:
                 result = fut.result()
             except Exception:
-                pkg = dep.get_unique_key()
-                result = OutdatedRow(package=pkg, current="(none)", latest="-", status="unknown")
+                result = _unknown_row(dep)
             results[dep.get_unique_key()] = result
             progress.update(task_id, visible=False)
             progress.advance(overall_id)
@@ -695,8 +709,7 @@ def _check_parallel_plain(checkable, downloader, verbose, max_workers, registry_
             try:
                 result = fut.result()
             except Exception:
-                pkg = dep.get_unique_key()
-                result = OutdatedRow(package=pkg, current="(none)", latest="-", status="unknown")
+                result = _unknown_row(dep)
             results[dep.get_unique_key()] = result
 
     return [results[dep.get_unique_key()] for dep in checkable if dep.get_unique_key() in results]

--- a/tests/integration/test_auto_install_e2e.py
+++ b/tests/integration/test_auto_install_e2e.py
@@ -36,7 +36,12 @@ pytestmark = [
 @pytest.fixture(scope="module")
 def temp_e2e_home():
     """Create a temporary home directory for E2E testing."""
-    with tempfile.TemporaryDirectory() as temp_dir:
+    # ignore_cleanup_errors guards against a teardown race: the real `copilot`
+    # CLI launched by these tests downloads its binary asynchronously into
+    # $HOME/.cache/copilot/pkg/..., and a still-running child can repopulate the
+    # tree while TemporaryDirectory's rmtree runs -> OSError [Errno 39]
+    # Directory not empty. The temp dir is ephemeral, so leftover files are fine.
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         original_home = os.environ.get("HOME")
         test_home = os.path.join(temp_dir, "e2e_home")
         os.makedirs(test_home)

--- a/tests/integration/test_wave6_outdated_view_coverage.py
+++ b/tests/integration/test_wave6_outdated_view_coverage.py
@@ -539,10 +539,33 @@ class TestOutdatedSequential:
 
         assert result.exit_code == 0
 
+    def test_sequential_check_dep_error_degrades(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unexpected error in a single dep check must not crash outdated.
 
-# ---------------------------------------------------------------------------
-# outdated -- multiple deps (parallel path)
-# ---------------------------------------------------------------------------
+        Regression for the sequential path, which previously let an exception
+        from ``_check_one_dep`` (e.g. ``TypeError: '<' not supported between
+        instances of 'MagicMock' and 'MagicMock'``) propagate and exit 1
+        instead of degrading the dependency to an ``unknown`` row.
+        """
+        monkeypatch.chdir(tmp_path)
+        _write_apm_yml(tmp_path)
+        _write_lockfile(
+            tmp_path,
+            "  - repo_url: test-org/test-repo\n"
+            "    resolved_ref: main\n"
+            "    resolved_commit: aabbccdd11223344\n",
+        )
+
+        with patch(
+            "apm_cli.commands.outdated._check_one_dep",
+            side_effect=TypeError("'<' not supported between MagicMock and MagicMock"),
+        ):
+            result = runner.invoke(cli, ["outdated", "-j", "0"])
+
+        assert result.exit_code == 0
+        assert "unknown" in result.output.lower()
 
 
 class TestOutdatedParallel:
@@ -605,6 +628,36 @@ class TestOutdatedParallel:
         assert result.exit_code == 0
         # repo-one should be outdated, repo-two up-to-date
         assert "outdated" in result.output.lower()
+
+    def test_multiple_deps_one_check_errors_degrades(
+        self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Parallel path: a raising dep check degrades to unknown, exit 0.
+
+        Regression guard mirroring the sequential case so both paths handle an
+        unexpected ``_check_one_dep`` failure identically.
+        """
+        monkeypatch.chdir(tmp_path)
+        _write_apm_yml(tmp_path)
+        sha = "aabbccdd11223344"
+        _write_lockfile(
+            tmp_path,
+            f"  - repo_url: test-org/repo-one\n"
+            f"    resolved_ref: main\n"
+            f"    resolved_commit: {sha}\n"
+            f"  - repo_url: test-org/repo-two\n"
+            f"    resolved_ref: main\n"
+            f"    resolved_commit: {sha}\n",
+        )
+
+        with patch(
+            "apm_cli.commands.outdated._check_one_dep",
+            side_effect=TypeError("'<' not supported between MagicMock and MagicMock"),
+        ):
+            result = runner.invoke(cli, ["outdated", "-j", "2"])
+
+        assert result.exit_code == 0
+        assert "unknown" in result.output.lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## TL;DR

Fixes two order-dependent integration-test flakes that broke the merge queue (run [27764731830](https://github.com/microsoft/apm/actions/runs/27764731830)) on a PR that did not touch either code path. Both are pre-existing latent issues exposed by xdist worker scheduling, not regressions from the PR under test.

## Problem (WHY)

The merge queue failed two shards on changes unrelated to the failing tests:

1. **Shard 4 - `test_wave6 ... test_multiple_deps_some_outdated`** crashed with
   `assert 1 == 0` where the result was `TypeError("'<' not supported between instances of 'MagicMock' and 'MagicMock'")`, i.e. `apm outdated` exited 1 with an unhandled exception.
2. **Shard 1 - `test_auto_install_e2e ... test_auto_install_with_qualified_path`** errored at teardown with `OSError: [Errno 39] Directory not empty: '.../e2e_home/.cache/copilot/pkg/linux-x64'`.

## Root cause

**`apm outdated` (shard 4).** The parallel check path (`_check_parallel`) already wraps each `_check_one_dep` call in `try/except` and degrades a failing dependency to an `unknown` row. The **sequential** path and the **plain-text fallback** path did not. So when any single dependency check raised unexpectedly (e.g. a leaked `MagicMock` reaching a `<` comparison under cross-test pollution), the whole command crashed with exit 1 instead of degrading that one dependency. This is a real robustness asymmetry independent of what triggered the exception.

**e2e teardown (shard 1).** The module-scoped `temp_e2e_home` fixture uses `tempfile.TemporaryDirectory()`. The test launches the real `copilot` CLI, which asynchronously downloads its binary into `$HOME/.cache/copilot/pkg/...`. A still-running child can repopulate the tree while `rmtree` runs at teardown -> `Directory not empty`.

## Approach (WHAT)

- Add a shared `_unknown_row(dep)` helper and apply the same per-dep exception guard to **all** check paths (sequential, plain sequential, and both parallel paths), so a single failing dependency check is always surfaced as `unknown` rather than crashing the command.
- Set `ignore_cleanup_errors=True` on the e2e temp-home fixture (Python 3.12+). The temp dir is ephemeral CI scratch, so leftover files are harmless - consistent with the file's existing Windows leftover-tolerant teardown.

## Validation evidence

- Added regression tests for the sequential and parallel degrade-to-unknown paths. Verified they reproduce the **exact** CI signature (`assert 1 == 0` with `TypeError("'<' not supported between MagicMock and MagicMock")`) when the guard is reverted, and pass with it in place.
- `tests/integration/test_wave6_outdated_view_coverage.py`: 51 passed.
- `tests/integration/test_auto_install_e2e.py`: collects cleanly (real-CLI/network test).
- Full CI-mirror lint chain green: `ruff check`, `ruff format --check`, pylint R0801 (10.00/10), auth-signal lint.

## How to test

```bash
uv run --extra dev python -m pytest tests/integration/test_wave6_outdated_view_coverage.py -p no:cov -q
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>