### PR TITLE
docs: restore "What to commit" guidance (fix #1837)

### DIFF
--- a/docs/src/content/docs/consumer/install-packages.md
+++ b/docs/src/content/docs/consumer/install-packages.md
@@ -124,6 +124,19 @@ harness, see [Primitives and targets](../../concepts/primitives-and-targets/).
 
 Rule sync to Cursor (`.cursor/rules/`), Claude Code (`.claude/rules/`), Windsurf (`.windsurf/rules/`), and Kiro (`.kiro/steering/`) is automatic and idempotent -- re-running `apm install` adopts unchanged rules without rewriting them.
 
+## What to commit
+
+Commit `apm.yml`, `apm.lock.yaml`, and every harness directory APM writes to
+(`.github/`, `.claude/`, `.cursor/`, `.opencode/`, `.gemini/`, `.windsurf/`,
+`.kiro/`). Committed deployed files give teammates and cloud Copilot instant agent
+context on clone, before they run `apm install`.
+
+Add `apm_modules/` to `.gitignore` -- it is the package cache and is rebuilt from
+the lockfile on every `apm install`. APM adds the entry automatically on first install.
+
+See the [Quickstart](../../quickstart/#what-to-commit) for the full table and
+rationale.
+
 ## Transitive dependencies and the lockfile
 
 `apm install` resolves the full dependency graph, not just your

--- a/docs/src/content/docs/quickstart.mdx
+++ b/docs/src/content/docs/quickstart.mdx
@@ -148,6 +148,24 @@ For private packages, set `GITHUB_APM_PAT` -- see
 [private packages](/apm/consumer/private-and-org-packages/).
 :::
 
+## What to commit
+
+After `apm install` runs, three categories of files land in your project:
+
+| Path | Commit? | Why |
+|------|---------|-----|
+| `apm.yml` | Yes | Manifest -- declares dependencies, shared with the team |
+| `apm.lock.yaml` | Yes | Lockfile -- pins exact commits and content hashes for reproducible installs |
+| `.github/`, `.claude/`, `.cursor/`, `.opencode/`, `.gemini/`, `.windsurf/`, `.kiro/` | Yes | Deployed agent context -- gives every contributor and cloud Copilot instant access on clone, before they run `apm install` |
+| `apm_modules/` | No | Package cache -- rebuilt from the lockfile on `apm install`. Add to `.gitignore` (APM does this automatically) |
+
+:::tip[Keeping deployed files in sync]
+When you update `apm.yml`, re-run `apm install` and commit the changed deployed files
+alongside the updated manifest and lockfile. A
+[CI drift check](../integrations/ci-cd/#verify-deployed-primitives) catches stale
+files automatically.
+:::
+
 ## What next
 
 Your project is ready: dependencies pinned, primitives deployed, every


### PR DESCRIPTION
## Problem

The "What to commit / What to gitignore" guidance was added in PR #290 (issue #288) to the old quickstart. The full docs rewrite in PR #1252 replaced the quickstart file and the section was lost entirely. The only surviving copy is in an agent skill (`packages/apm-guide/.apm/skills/apm-usage/workflow.md`), which is not user-facing.

Closes #1837

## Changes

### `docs/src/content/docs/quickstart.mdx`

Added a new **"What to commit"** section between the install output block and "What next". Includes:

- A table: `apm.yml` and `apm.lock.yaml` (commit), deployed harness dirs `.github/` / `.claude/` / `.cursor/` / etc. (commit), `apm_modules/` (gitignore)
- One-line rationale for committing deployed files (instant agent context on clone)
- A tip linking to the CI drift check

### `docs/src/content/docs/consumer/install-packages.md`

Added a concise **"What to commit"** section after "Where files land" for users who navigate directly to the consumer guide. Cross-links to the quickstart table.

## No code changes

Documentation only. No CLI, schema, or behaviour changes.