### PR TITLE
fix: emit required "version": 1 in .cursor/hooks.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Cursor hook integration: emit required top-level `version: 1` in `.cursor/hooks.json`.
+  Affected versions: v0.14.1-v0.20.0. Hooks were silently ignored by Cursor on those
+  versions. Run `apm install` (or `apm install --target cursor`) to repair existing
+  installations. (closes #1823) (#1840)
 - `apm marketplace check` no longer fails with exit 128 for entries on
   non-default hosts, including relative entries composed onto
   `marketplace.sourceBase` (self-managed GitLab / GHES / Azure DevOps). It now

--- a/docs/src/content/docs/reference/common-errors.md
+++ b/docs/src/content/docs/reference/common-errors.md
@@ -1,0 +1,37 @@
+---
+title: Common errors
+description: Symptoms, causes, and fixes for frequently reported APM errors.
+sidebar:
+  order: 11
+---
+
+This page lists error messages and silent failures that users report most
+frequently, along with their cause and the shortest path to a fix.
+
+---
+
+### Cursor: "Config version must be a number"
+
+**Symptom:** Cursor reports `Config version must be a number` or
+`Failed to parse project hooks configuration`, or silently loads no project
+hooks even though `apm install` succeeded and `.cursor/hooks.json` exists.
+
+**Cause:** APM versions v0.14.1--v0.20.0 omitted the required top-level
+`"version": 1` field from `.cursor/hooks.json`. Cursor rejects the entire
+file when that field is absent.
+
+**Fix:** Re-run hook integration to regenerate a valid config:
+
+```bash
+apm install --target cursor
+```
+
+Or, if you install all targets at once:
+
+```bash
+apm install
+```
+
+APM v0.21.0+ always writes `"version": 1` to `.cursor/hooks.json` on a
+fresh install. Existing files that already contain a `"version"` key are
+left untouched.

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -36,6 +36,7 @@ Per-command pages live under [`reference/cli/`](./cli/install/). Grouped by life
 | [Package types](./package-types/)                            | APM packages, plugins, marketplaces                              |
 | [Examples](./examples/)                                      | Worked end-to-end examples                                       |
 | [Experimental](./experimental/)                              | Surface area still subject to change                             |
+| [Common errors](./common-errors/)                            | Symptoms, causes, and fixes for frequently reported errors       |
 
 ## Conventions used in reference pages
 

--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -29,6 +29,7 @@ Hook JSON format (GitHub Copilot  -- flat arrays with bash/powershell keys):
 
 Hook JSON format (Cursor  -- flat arrays with command key):
     {
+        "version": 1,
         "hooks": {
             "afterFileEdit": [
                 {"command": "./hooks/format.sh"}
@@ -104,7 +105,7 @@ class _MergeHookConfig:
     # Cursor) that APM does not otherwise write.  Existing keys are never
     # overwritten -- the guard in _integrate_merged_hooks() preserves any
     # value the user has set manually.
-    top_level_defaults: dict = field(default_factory=dict)
+    top_level_defaults: dict[str, Any] = field(default_factory=dict)
 
 
 # Per-target hook event name mapping.  Packages are authored with

--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -1410,13 +1410,22 @@ class HookIntegrator(BaseIntegrator):
         container = config.event_container_key
         if container not in json_config:
             json_config[container] = {}
+            _log.debug("Seeded hook container '%s' in %s", container, config.config_filename)
 
         # Inject any target-specific top-level defaults (e.g. "version": 1 for
         # Cursor) that are absent from the existing file.  Existing values are
         # never overwritten so a user-set "version" is preserved across reinstalls.
+        injected_keys: list[str] = []
         for key, value in config.top_level_defaults.items():
             if key not in json_config:
                 json_config[key] = value
+                injected_keys.append(key)
+        if injected_keys:
+            _log.debug(
+                "Injected top_level_defaults into %s: %s",
+                config.config_filename,
+                injected_keys,
+            )
 
         for hook_file in hook_files:
             data = self._parse_hook_json(hook_file)

--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -47,7 +47,7 @@ import json
 import logging
 import re
 import shutil
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -99,6 +99,12 @@ class _MergeHookConfig:
     # single name "apm" as its container and leaves sibling user hook-names
     # untouched.
     event_container_key: str = "hooks"
+    # Target-specific top-level keys to inject into the config file when
+    # absent.  Used to emit required schema fields (e.g. "version": 1 for
+    # Cursor) that APM does not otherwise write.  Existing keys are never
+    # overwritten -- the guard in _integrate_merged_hooks() preserves any
+    # value the user has set manually.
+    top_level_defaults: dict = field(default_factory=dict)
 
 
 # Per-target hook event name mapping.  Packages are authored with
@@ -335,6 +341,7 @@ _MERGE_HOOK_TARGETS: dict[str, _MergeHookConfig] = {
         config_filename="hooks.json",
         target_key="cursor",
         require_dir=True,
+        top_level_defaults={"version": 1},
     ),
     "codex": _MergeHookConfig(
         config_filename="hooks.json",
@@ -1402,6 +1409,13 @@ class HookIntegrator(BaseIntegrator):
         container = config.event_container_key
         if container not in json_config:
             json_config[container] = {}
+
+        # Inject any target-specific top-level defaults (e.g. "version": 1 for
+        # Cursor) that are absent from the existing file.  Existing values are
+        # never overwritten so a user-set "version" is preserved across reinstalls.
+        for key, value in config.top_level_defaults.items():
+            if key not in json_config:
+                json_config[key] = value
 
         for hook_file in hook_files:
             data = self._parse_hook_json(hook_file)

--- a/tests/integration/test_integrators_hooks_execution.py
+++ b/tests/integration/test_integrators_hooks_execution.py
@@ -1010,6 +1010,7 @@ class TestIntegratePackageHooksCursor:
         assert hooks_json.exists()
         data = json.loads(hooks_json.read_text())
         assert "hooks" in data
+        assert data.get("version") == 1
 
 
 class TestIntegratePackageHooksCodex:

--- a/tests/unit/integration/test_hook_integrator.py
+++ b/tests/unit/integration/test_hook_integrator.py
@@ -1263,6 +1263,7 @@ class TestCursorIntegration:
 
         config = json.loads(hooks_path.read_text())
         assert "hooks" in config
+        assert config["version"] == 1
         assert "PreToolUse" in config["hooks"]
         assert "PostToolUse" in config["hooks"]
         assert "Stop" in config["hooks"]
@@ -1428,6 +1429,31 @@ class TestCursorIntegration:
 
         updated = json.loads(hooks_path.read_text())
         assert "hooks" not in updated
+
+    def test_cursor_version_emitted_on_fresh_install(self, temp_project):
+        """Fresh .cursor/hooks.json must contain top-level "version": 1."""
+        pkg_info = self._setup_hookify_package(temp_project)
+        integrator = HookIntegrator()
+
+        integrator.integrate_package_hooks_cursor(pkg_info, temp_project)
+
+        hooks_path = temp_project / ".cursor" / "hooks.json"
+        assert hooks_path.exists()
+        config = json.loads(hooks_path.read_text())
+        assert config.get("version") == 1
+
+    def test_cursor_existing_version_preserved(self, temp_project):
+        """A pre-existing "version" value in hooks.json must not be overwritten."""
+        hooks_path = temp_project / ".cursor" / "hooks.json"
+        hooks_path.write_text(json.dumps({"version": 2, "hooks": {}}))
+
+        pkg_info = self._setup_hookify_package(temp_project)
+        integrator = HookIntegrator()
+
+        integrator.integrate_package_hooks_cursor(pkg_info, temp_project)
+
+        config = json.loads(hooks_path.read_text())
+        assert config.get("version") == 2
 
 
 # ─── Sync/cleanup tests ──────────────────────────────────────────────────────


### PR DESCRIPTION
## TL;DR

`apm install` (cursor target) was writing `.cursor/hooks.json` without the
top-level `"version": 1` field that Cursor requires to load project hooks.
Every APM-installed hook was silently dead on arrival. This PR fixes it.

---

## Problem (WHY)

Cursor's hook loader validates the project config against a schema that
requires a top-level `"version"` field. Without it the **entire file is
rejected**:

```
ERROR: Invalid project config: Config version must be a number
ERROR: Failed to parse project hooks configuration
No project hooks configuration found
```

Root cause in `_integrate_merged_hooks()`:

```python
json_config: dict = {}          # starts empty
if container not in json_config:
    json_config[container] = {}  # only "hooks" key is seeded
# "version" is never written
```

Package templates that carry `"version": 1` have it stripped at parse time
because `_integrate_merged_hooks()` only reads the `hooks` map from each
source file. This affected **every cursor user with hook-based packages**
(APM 0.14.1 -- 0.20.0).

---

## Approach (WHAT)

Add a declarative `top_level_defaults` field to `_MergeHookConfig` that
specifies target-specific top-level keys to inject when absent. Set
`{"version": 1}` for cursor. Inject missing defaults after seeding the
event container.

---

## Implementation (HOW)

### `src/apm_cli/integration/hook_integrator.py`

1. Add `field` to the `dataclasses` import.
2. Add `top_level_defaults: dict = field(default_factory=dict)` to the
   `_MergeHookConfig` frozen dataclass.
3. Populate `top_level_defaults={"version": 1}` in the `cursor` entry of
   `_MERGE_HOOK_TARGETS`.
4. In `_integrate_merged_hooks()`, after seeding the event container:

```python
for key, value in config.top_level_defaults.items():
    if key not in json_config:
        json_config[key] = value
```

The `if key not in json_config` guard means reinstalling over a file
that already carries `"version"` is a no-op -- the user's value is
preserved.

### `tests/unit/integration/test_hook_integrator.py`

- `test_integrate_hookify_cursor`: added `assert config["version"] == 1`
- `test_cursor_version_emitted_on_fresh_install` (new): fresh `.cursor/`
  dir produces `"version": 1`
- `test_cursor_existing_version_preserved` (new): pre-existing
  `"version": 2` survives a reinstall

---

## Architecture

```mermaid
flowchart LR
  A["_MergeHookConfig\ntop_level_defaults={'version':1}"] --> B["_integrate_merged_hooks()"]
  B --> C{key in json_config?}
  C -- No --> D["json_config[key] = value"]
  C -- Yes --> E["preserve existing value"]
  D --> F["json.dump to .cursor/hooks.json"]
  E --> F
```

---

## Trade-offs

| Decision | Rationale |
|----------|-----------|
| `top_level_defaults: dict` field on `_MergeHookConfig` | Declarative, co-located with other target config, scales to future targets (codex, windsurf) without code changes |
| `if key not in json_config` guard | Idempotent on reinstall; preserves user-set values |
| Only cursor gets `{"version": 1}` | Other targets (claude, codex, gemini, windsurf) do not require a schema version field |

---

## Validation evidence

- 163 unit tests in `tests/unit/integration/test_hook_integrator.py` -- all pass
- `ruff check` -- no diagnostics
- `pylint R0801` -- 10.00/10
- `lint-auth-signals.sh` -- clean

Fixes #1823