### PR TITLE
Fix {name} placeholder ignored in apm pack marketplace version resolution (#1822)

### DIFF
--- a/src/apm_cli/marketplace/builder.py
+++ b/src/apm_cli/marketplace/builder.py
@@ -716,7 +716,7 @@ class MarketplaceBuilder:
         # Determine tag pattern: entry > build > default
         pattern = entry.tag_pattern or yml.build.tag_pattern
 
-        tag_rx = build_tag_regex(pattern)
+        tag_rx = build_tag_regex(pattern, name=entry.name)
         refs = resolver.list_remote_refs(owner_repo)
 
         # Filter tags matching the pattern and extract versions

--- a/tests/unit/marketplace/test_builder.py
+++ b/tests/unit/marketplace/test_builder.py
@@ -636,6 +636,134 @@ class TestTagPatternOverride:
 
 
 # ---------------------------------------------------------------------------
+# Monorepo name-scoped tag pattern (issue #1822)
+# ---------------------------------------------------------------------------
+
+
+class TestMonorepoNameScopedTagPattern:
+    """Regression tests for issue #1822 -- {name} must scope tag resolution per package.
+
+    When build.tagPattern (or entry-level tag_pattern) contains ``{name}``,
+    each package must resolve against its OWN tags only.  Before the fix,
+    ``build_tag_regex(pattern)`` was called without ``name=entry.name``,
+    making ``{name}`` a wildcard that matched all packages' tags, causing
+    every entry to resolve to the single highest version in the repo.
+    """
+
+    def test_two_packages_resolve_independently(self, tmp_path: Path) -> None:
+        """Each package resolves to its own highest matching tag, not the global maximum."""
+        yml = """\
+        name: test-mkt
+        description: Test
+        version: 1.0.0
+        owner:
+          name: Test
+        build:
+          tagPattern: "{name}-v{version}"
+        packages:
+          - name: pkg-a
+            source: acme/catalog
+            subdir: packages/pkg-a
+            version: ">=1.0.0"
+          - name: pkg-b
+            source: acme/catalog
+            subdir: packages/pkg-b
+            version: ">=1.0.0"
+        """
+        # pkg-a tagged at v1.0.0, pkg-b at v2.0.0 (higher global version).
+        # Before the fix, both packages resolved to pkg-b-v2.0.0 because
+        # {name} was treated as a wildcard [^/]+.
+        refs = {
+            "acme/catalog": _make_refs(
+                "pkg-a-v1.0.0",
+                "pkg-b-v2.0.0",
+            )
+        }
+        report = _build_with_mock(tmp_path, yml, refs)
+        resolved_by_name = {r.name: r.ref for r in report.resolved}
+        assert resolved_by_name["pkg-a"] == "pkg-a-v1.0.0"
+        assert resolved_by_name["pkg-b"] == "pkg-b-v2.0.0"
+
+    def test_two_packages_double_dash_pattern(self, tmp_path: Path) -> None:
+        """Canonical ``{name}--v{version}`` double-dash pattern also resolves per-package."""
+        yml = """\
+        name: test-mkt
+        description: Test
+        version: 1.0.0
+        owner:
+          name: Test
+        build:
+          tagPattern: "{name}--v{version}"
+        packages:
+          - name: pkg-a
+            source: acme/catalog
+            version: ">=1.0.0"
+          - name: pkg-b
+            source: acme/catalog
+            version: ">=1.0.0"
+        """
+        refs = {
+            "acme/catalog": _make_refs(
+                "pkg-a--v1.0.0",
+                "pkg-b--v2.0.0",
+            )
+        }
+        report = _build_with_mock(tmp_path, yml, refs)
+        resolved_by_name = {r.name: r.ref for r in report.resolved}
+        assert resolved_by_name["pkg-a"] == "pkg-a--v1.0.0"
+        assert resolved_by_name["pkg-b"] == "pkg-b--v2.0.0"
+
+    def test_per_entry_tag_pattern_scopes_to_name(self, tmp_path: Path) -> None:
+        """Per-entry ``tag_pattern`` containing ``{name}`` is also scoped correctly."""
+        yml = """\
+        name: test-mkt
+        description: Test
+        version: 1.0.0
+        owner:
+          name: Test
+        packages:
+          - name: pkg-a
+            source: acme/catalog
+            version: ">=1.0.0"
+            tag_pattern: "{name}-v{version}"
+          - name: pkg-b
+            source: acme/catalog
+            version: ">=1.0.0"
+            tag_pattern: "{name}-v{version}"
+        """
+        refs = {
+            "acme/catalog": _make_refs(
+                "pkg-a-v1.0.0",
+                "pkg-b-v2.0.0",
+            )
+        }
+        report = _build_with_mock(tmp_path, yml, refs)
+        resolved_by_name = {r.name: r.ref for r in report.resolved}
+        assert resolved_by_name["pkg-a"] == "pkg-a-v1.0.0"
+        assert resolved_by_name["pkg-b"] == "pkg-b-v2.0.0"
+
+    def test_no_match_when_only_other_package_tags_exist(self, tmp_path: Path) -> None:
+        """pkg-a with no matching tags raises NoMatchingVersionError (not pkg-b's tag)."""
+        yml = """\
+        name: test-mkt
+        description: Test
+        version: 1.0.0
+        owner:
+          name: Test
+        build:
+          tagPattern: "{name}-v{version}"
+        packages:
+          - name: pkg-a
+            source: acme/catalog
+            version: "^1.0.0"
+        """
+        # Only pkg-b tags present -- pkg-a should NOT pick these up
+        refs = {"acme/catalog": _make_refs("pkg-b-v1.0.0", "pkg-b-v2.0.0")}
+        with pytest.raises(NoMatchingVersionError):
+            _build_with_mock(tmp_path, yml, refs)
+
+
+# ---------------------------------------------------------------------------
 # No match error
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## TL;DR

`apm pack` was pinning every monorepo package to the same (highest global) version tag instead of each package's own tag. One missing argument caused `{name}` to become a wildcard.

## Problem (WHY)

When `_resolve_version_range` in `builder.py` builds the tag-matching regex:

```python
# Before
tag_rx = build_tag_regex(pattern)
```

The `name` keyword argument was omitted. `build_tag_regex` handles a missing `name` by substituting `[^/]+` (wildcard) for `{name}` in the compiled regex. In a monorepo marketplace with pattern `{name}-v{version}`, this means:

- `pkg-a-v1.0.0` matched (wildcard covers `pkg-a`)
- `pkg-b-v2.0.0` also matched (wildcard covers `pkg-b`)

Both packages competed in the same candidate pool, so the one with the highest semver won -- `pkg-b-v2.0.0` for **both** entries. Closes #1822.

## Approach (WHAT)

Pass `name=entry.name` to `build_tag_regex`:

```python
# After
tag_rx = build_tag_regex(pattern, name=entry.name)
```

`build_tag_regex` already supports this argument (`re.escape(name)` substitution, implemented at `tag_pattern.py:124`). It is correctly used in `infer_tag_pattern`, `parse_tag_version`, and `version_resolver.resolve_version_constraint`. The omission in `_resolve_version_range` was the sole source of the bug.

## Implementation (HOW)

```diff
-        tag_rx = build_tag_regex(pattern)
+        tag_rx = build_tag_regex(pattern, name=entry.name)
```

One line, one file. `build_tag_regex` is fully defensive: patterns without `{name}` are unaffected (the guard `_PLACEHOLDER_NAME in pattern and name` short-circuits). Empty names and names with special chars are safe (`re.escape`).

## Diagrams

```mermaid
flowchart TD
    A["_resolve_version_range(entry, ...)"] --> B["pattern = entry.tag_pattern or yml.build.tag_pattern"]
    B --> C{"pattern contains {name}?"}
    C -->|"Before fix (no name arg)"| D["build_tag_regex(pattern)\n{name} -> [^/]+ wildcard"]
    C -->|"After fix"| E["build_tag_regex(pattern, name=entry.name)\n{name} -> re.escape(entry.name)"]
    D --> F["All packages' tags match\n-> highest global version wins"]
    E --> G["Only this package's tags match\n-> correct per-package resolution"]
```

## Trade-offs

- `version_resolver.resolve_version_constraint` uses a different but equivalent pattern (external `str.replace` before calling `build_tag_regex`). Both patterns are correct; standardizing on the `name=` kwarg form is deferred as a clean-up (no functional impact).

## Validation evidence

Full lint chain passes:
```
ruff check src/ tests/  -- All checks passed
ruff format --check     -- 1294 files already formatted
pylint R0801            -- 10.00/10
lint-auth-signals.sh    -- [+] auth-signal lint clean
```

New regression tests (all passing):
```
TestMonorepoNameScopedTagPattern::test_two_packages_resolve_independently        PASSED
TestMonorepoNameScopedTagPattern::test_two_packages_double_dash_pattern          PASSED
TestMonorepoNameScopedTagPattern::test_per_entry_tag_pattern_scopes_to_name      PASSED
TestMonorepoNameScopedTagPattern::test_no_match_when_only_other_package_tags_exist PASSED
```

Full `test_builder.py`: 138 passed.

## How to test

```bash
# Run the regression suite
uv run --extra dev pytest tests/unit/marketplace/test_builder.py::TestMonorepoNameScopedTagPattern -v

# Run full builder + version resolver tests
uv run --extra dev pytest tests/unit/marketplace/test_builder.py tests/unit/marketplace/test_version_resolver.py -v
```