### PR TITLE
chore: release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-06-19
+
 ### Added
 
 - `apm audit` now surfaces unmanaged files in governance directories as a single enriched report: each finding states a factual reason (`not tracked in apm.lock.yaml`), a lazy primitive-type tag (`[type: skill|agent|instruction|mcp]`), and a deny-conflict note (`matches deny rule (<pattern>)`) when the path matches the policy's own `dependencies.deny` / `mcp.deny`. A new `unmanaged_files.exclude` policy key suppresses known harness-managed paths, and a symlink guard prevents following links out of the workspace. This is drift / divergence visibility, not supply-chain-attack prevention. (closes #1775) (#1793)
@@ -26,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Two additive, default-off policy keys under the existing `security:` namespace: `security.integrity.require_hashes` makes `apm install` fail closed when any non-local lockfile entry lacks a content hash, and `security.audit.fail_on_drift` makes `apm audit` exit non-zero when the workspace drifts from the lockfile. Both only tighten through policy inheritance. (#1794)
 - MCP dependencies can now carry harness-specific passthrough keys (for example Claude Code's remote-MCP `oauth` block with `clientId`/`callbackPort`); previously any key outside the modeled set was silently dropped on render. Passthrough keys round-trip into the generated config for every installed harness and cannot shadow a modeled field (`command`/`url`/`headers`/`env`/...), which are rejected with a warning. A future fail-closed tightening to an explicit `extra:` block is tracked in #1806. (closes #1670) (#1765)
 - `apm install owner/repo#ref` now routes to the configured default registry (project `registries.default` or `registry.<name>.default true` in `~/.apm/config.json`) instead of probing GitHub. A version selector (`#<ref>`) is required; omitting it exits `1`. Non-semver selectors (`stable`, `main`, a branch name, or any opaque string) are exact-matched against the registry's published version list. Use the `git:` URL form in `apm.yml` to force the GitHub path. (#1816)
+- `apm lock export --format cyclonedx|spdx` emits a standard SBOM inventory of installed packages, and a new declared-license recorder stores each package's manifest-declared license (`apm.yml` `license:` / `plugin.json`) in the lockfile after offline SPDX-id validation. APM records what a package declares -- it does not scan LICENSE text or gate installs on a license. (closes #1777) (#1820)
+- `apm install` / `apm pack` can now deploy an experimental Copilot-only `canvas` primitive: a package declaring `.apm/extensions/<name>/` ships verbatim to `.github/extensions/<name>/` (or `~/.copilot/extensions/<name>/` with `--global`), where Copilot CLI discovers it in-session. The surface is gated twice -- `apm experimental enable canvas` plus `--trust-canvas-extensions` for dependency-provided canvases -- and is fail-closed when the flag is off. (#1689)
+- `apm install` now blocks dependency-provided executables (hooks and `bin/`) by default, mirroring npm v12's default-deny model. A dependency's hooks or binaries deploy only after explicit approval in an `allowExecutables` block of `apm.yml`, managed via `apm approve` / `apm deny`; root-authored content and text-only primitives are unaffected. (#1723)
 
 ### Removed
 
@@ -55,6 +60,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `AGENTS.md` and `--single-agents` writes, preserving hand-authored
   content outside the APM markers. (closes #1764) (#1768)
 - `apm install` now removes orphaned skill directories when a package is uninstalled or its skills are renamed. Previously, individual files were deleted but the skill folder remained with a "Refused to remove directory entry" warning. (closes #1483) (#1767)
+- `apm install --skill <name>` now merges additively with skills already pinned for the same package in `apm.yml` instead of overwriting them, so installing a second skill subset no longer drops the first. (#1786)
+- `apm publish` and the registry resolver no longer emit stale `tar.gz` / `--tarball` references after the switch to zip-by-default; help text, docs, and extractor paths now match the actual artifact format. (#1779)
+- `apm marketplace` now propagates `--ref` to relative plugin sources, so pinning a marketplace ref resolves nested relative packages at that ref instead of the default branch. (closes #1811) (#1824)
+- `apm pack` now substitutes the `{name}` placeholder during marketplace version resolution; previously the literal `{name}` was left unresolved, breaking version lookups for templated entries. (closes #1822) (#1841)
+- `apm outdated` now degrades gracefully when a single dependency check fails, reporting the error for that entry instead of crashing the whole command. (#1836)
 
 ## [0.20.0] - 2026-06-11
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apm-cli"
-version = "0.20.0"
+version = "0.21.0"
 description = "MCP configuration tool"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -201,7 +201,7 @@ wheels = [
 
 [[package]]
 name = "apm-cli"
-version = "0.20.0"
+version = "0.21.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Cut release 0.21.0.

- Bump `pyproject.toml` to 0.21.0 (and `uv.lock`).
- Move `[Unreleased]` to `[0.21.0] - 2026-06-19` in `CHANGELOG.md`, with one short "so what?" entry per PR merged since v0.20.0.

## Why MINOR (0.21.0), not PATCH (0.20.1)

The cycle adds new user-visible surface, not just fixes:

- New target: Google Antigravity CLI (`agy`) via `--target antigravity` (#1770).
- New default-off policy keys `security.integrity.require_hashes` / `security.audit.fail_on_drift` (#1794) and `unmanaged_files.exclude` for `apm audit` (#1793).
- New `apm lock export --format cyclonedx|spdx` SBOM export + declared-license recorder (#1820).
- New experimental Copilot `canvas` primitive deployed by `apm install` / `apm pack` (#1689).
- New npm-v12-style `allowExecutables` approval gate for dependency executables (#1723).
- New default-registry routing for `owner/repo#ref` shorthands (#1816) and MCP harness-passthrough keys (#1765).

Pre-1.0 framing keeps it a MINOR: the `apm marketplace publish` / `doctor` removals (#1134) ride in a minor per 0.x semver convention rather than forcing a major. No 1.0 API-stability commitment is implied.

## Validation

Lint mirror green locally (ruff check + format, pylint R0801, auth-signals). See `.apm/instructions/linting.instructions.md` for the contract this mirrors.

## Post-merge

Tag `v0.21.0` to trigger the release workflow:

```
git tag v0.21.0
git push origin v0.21.0
```