### PR TITLE
Fix marketplace install ignoring GitLab host for url-type sources (#1848)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm install <pkg>@<marketplace>` now preserves GitLab and other
+  non-GitHub hosts from url-type marketplace plugin sources, so auth
+  resolution no longer falls back to `github.com` for those installs.
+  (by @sergio-sisternes-epam; closes #1848) (#1853)
 - Registry deps with non-semver version selectors (e.g. `stable`, `main`) no longer report perpetual `outdated`. The drift check now uses literal equality for non-semver registry pins rather than range comparison, which always returned `True` against a semver range. (#1816)
 - Non-semver registry version selectors are now exact-matched against the registry's published version list at install time. Previously they were rejected with "not a valid semver range". (#1816)
 

--- a/src/apm_cli/marketplace/resolver.py
+++ b/src/apm_cli/marketplace/resolver.py
@@ -833,6 +833,34 @@ def resolve_marketplace_plugin(
             )
             canonical = dep_ref.to_canonical()
 
+    # ---- Build dep_ref for url-type sources on non-GitHub-family hosts (#1848) ----
+    # When the plugin declares a ``url`` source and the marketplace is on a
+    # host that needs explicit git paths (GitLab, generic git), the URL
+    # already carries the full clone target.  Build a structured dep_ref so
+    # downstream auth resolves at the correct host instead of defaulting to
+    # github.com.
+    if dep_ref is None and _source_needs_explicit_git_path(source):
+        if isinstance(plugin.source, dict):
+            _src_type = _coerce_dict_plugin_type(plugin.source)
+            if _src_type == "url":
+                _url = (plugin.source.get("url", "") or "").strip()
+                if _url:
+                    _ref = plugin.source.get("ref", "")
+                    _effective_ref = version_spec or (
+                        _ref.strip() if isinstance(_ref, str) and _ref.strip() else ""
+                    )
+                    _entry: dict = {"git": _url}
+                    if _effective_ref:
+                        _entry["ref"] = _effective_ref
+                    dep_ref = DependencyReference.parse_from_dict(_entry)
+                    canonical = dep_ref.to_canonical()
+                    logger.debug(
+                        "Built dep_ref from url source for %s@%s -> %s (#1848)",
+                        plugin_name,
+                        marketplace_name,
+                        canonical,
+                    )
+
     # ---- Backfill host on canonical for GitHub-family enterprise hosts ----
     # ``*.ghe.com`` marketplaces keep virtual shorthand (no structured ``dep_ref``)
     # because there is no nested-group ambiguity to disambiguate, but the bare

--- a/src/apm_cli/marketplace/resolver.py
+++ b/src/apm_cli/marketplace/resolver.py
@@ -833,7 +833,7 @@ def resolve_marketplace_plugin(
             )
             canonical = dep_ref.to_canonical()
 
-    # ---- Build dep_ref for url-type sources on non-GitHub-family hosts (#1848) ----
+    # ---- Build dep_ref for url-type sources on non-GitHub-family hosts ----
     # When the plugin declares a ``url`` source and the marketplace is on a
     # host that needs explicit git paths (GitLab, generic git), the URL
     # already carries the full clone target.  Build a structured dep_ref so
@@ -855,7 +855,7 @@ def resolve_marketplace_plugin(
                     dep_ref = DependencyReference.parse_from_dict(_entry)
                     canonical = dep_ref.to_canonical()
                     logger.debug(
-                        "Built dep_ref from url source for %s@%s -> %s (#1848)",
+                        "Built dep_ref from url source for %s@%s -> %s (non-github-host url source)",
                         plugin_name,
                         marketplace_name,
                         canonical,

--- a/tests/unit/marketplace/test_marketplace_resolver.py
+++ b/tests/unit/marketplace/test_marketplace_resolver.py
@@ -692,8 +692,9 @@ class TestResolveMarketplacePluginGitLabMonorepo:
         assert result.dependency_reference is not None
         dep = result.dependency_reference
         assert dep.host == "gitlab.com"
-        assert "my-name/apm" in dep.repo_url or "my-name" in dep.repo_url
-        assert "gitlab.com" in result.canonical
+        assert dep.repo_url == "my-name/apm/my-first-skill"
+        assert dep.reference == "v1.0.0"
+        assert result.canonical == "gitlab.com/my-name/apm/my-first-skill#v1.0.0"
 
     @patch("apm_cli.marketplace.resolver.fetch_or_cache")
     @patch("apm_cli.marketplace.resolver.get_marketplace_by_name")

--- a/tests/unit/marketplace/test_marketplace_resolver.py
+++ b/tests/unit/marketplace/test_marketplace_resolver.py
@@ -673,6 +673,78 @@ class TestResolveMarketplacePluginGitLabMonorepo:
 
     @patch("apm_cli.marketplace.resolver.fetch_or_cache")
     @patch("apm_cli.marketplace.resolver.get_marketplace_by_name")
+    def test_url_source_on_gitlab_preserves_host(
+        self, mock_get, mock_fetch, gitlab_marketplace_source
+    ):
+        """#1848: url-type source on GitLab marketplace must preserve host in dep_ref."""
+        plugin = MarketplacePlugin(
+            name="my-first-skill",
+            source={
+                "source": "url",
+                "url": "https://gitlab.com/my-name/apm/my-first-skill",
+                "ref": "v1.0.0",
+            },
+        )
+        mock_get.return_value = gitlab_marketplace_source
+        mock_fetch.return_value = self._manifest_with_plugin(plugin)
+
+        result = resolve_marketplace_plugin("my-first-skill", "apm-reg")
+        assert result.dependency_reference is not None
+        dep = result.dependency_reference
+        assert dep.host == "gitlab.com"
+        assert "my-name/apm" in dep.repo_url or "my-name" in dep.repo_url
+        assert "gitlab.com" in result.canonical
+
+    @patch("apm_cli.marketplace.resolver.fetch_or_cache")
+    @patch("apm_cli.marketplace.resolver.get_marketplace_by_name")
+    def test_url_source_on_gitlab_with_version_spec_override(
+        self, mock_get, mock_fetch, gitlab_marketplace_source
+    ):
+        """#1848: version_spec overrides the ref from the url source."""
+        plugin = MarketplacePlugin(
+            name="my-skill",
+            source={
+                "source": "url",
+                "url": "https://gitlab.com/org/repo",
+                "ref": "v1.0.0",
+            },
+        )
+        mock_get.return_value = gitlab_marketplace_source
+        mock_fetch.return_value = self._manifest_with_plugin(plugin)
+
+        result = resolve_marketplace_plugin("my-skill", "apm-reg", version_spec="v2.0.0")
+        assert result.dependency_reference is not None
+        dep = result.dependency_reference
+        assert dep.host == "gitlab.com"
+        assert dep.reference == "v2.0.0"
+
+    @patch("apm_cli.marketplace.resolver.fetch_or_cache")
+    @patch("apm_cli.marketplace.resolver.get_marketplace_by_name")
+    def test_url_source_on_github_no_dep_ref(self, mock_get, mock_fetch):
+        """url-type source on github.com marketplace should NOT build dep_ref (existing behaviour)."""
+        github_source = MarketplaceSource(
+            name="gh-mkt",
+            owner="owner",
+            repo="marketplace-repo",
+            host="github.com",
+            branch="main",
+        )
+        plugin = MarketplacePlugin(
+            name="pkg",
+            source={
+                "source": "url",
+                "url": "https://github.com/other/repo",
+            },
+        )
+        mock_get.return_value = github_source
+        mock_fetch.return_value = self._manifest_with_plugin(plugin)
+
+        result = resolve_marketplace_plugin("pkg", "gh-mkt")
+        # github.com marketplace does not need explicit git path -> no dep_ref built
+        assert result.dependency_reference is None
+
+    @patch("apm_cli.marketplace.resolver.fetch_or_cache")
+    @patch("apm_cli.marketplace.resolver.get_marketplace_by_name")
     def test_external_gitlab_dict_type_no_monorepo_rule(
         self, mock_get, mock_fetch, gitlab_marketplace_source
     ):


### PR DESCRIPTION
## Description

When installing a package via `apm install pkg@marketplace` where the marketplace is on GitLab, the CLI silently discards the GitLab host from the resolved URL and defaults to `github.com` for auth resolution. The marketplace cache correctly stores the full GitLab URL, but the install path loses the host during the resolution step.

The root cause is in `resolve_marketplace_plugin()`: for plugins with a `url`-type source on non-GitHub-family hosts, `_resolve_url_source()` strips the host from the canonical, and no downstream block rebuilds a structured `DependencyReference` to restore it. The existing host-backfill only covers GitHub-family enterprise hosts (`.ghe.com`).

This PR adds a new block that builds a structured `DependencyReference` directly from the plugin's URL when the marketplace is on a non-GitHub-family host (GitLab, generic git) and the plugin source type is `"url"`. This preserves the host through to auth resolution.

Fixes: #1848

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

Three new test cases added:
- `test_url_source_on_gitlab_preserves_host` -- verifies dep_ref is built with gitlab.com host
- `test_url_source_on_gitlab_with_version_spec_override` -- verifies version_spec overrides source ref
- `test_url_source_on_github_no_dep_ref` -- confirms github.com marketplace behaviour unchanged

## Spec conformance (OpenAPM v0.1)

- [x] N/A -- this PR does not change OpenAPM-observable behaviour.