### PR TITLE
Fix apm pack omitting version for INTERNAL/private github.com repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm pack` now preserves plugin metadata such as `version` for
+  INTERNAL/private `github.com` package repos by falling back from the raw
+  CDN to the GitHub Contents API when raw metadata returns 404.
+  (by @sergio-sisternes-epam; closes #1847) (#1854)
 - Registry deps with non-semver version selectors (e.g. `stable`, `main`) no longer report perpetual `outdated`. The drift check now uses literal equality for non-semver registry pins rather than range comparison, which always returned `True` against a semver range. (#1816)
 - Non-semver registry version selectors are now exact-matched against the registry's published version list at install time. Previously they were rejected with "not a valid semver range". (#1816)
 

--- a/src/apm_cli/marketplace/builder.py
+++ b/src/apm_cli/marketplace/builder.py
@@ -905,9 +905,12 @@ class MarketplaceBuilder:
         A token resolved for the builder's default host is never sent to
         another host.
 
-        Metadata is fetched via the GitHub REST API (Contents endpoint
-        with raw media type) on the package's host.  For non-GitHub-class
-        hosts, metadata enrichment is skipped.
+        github.com packages use the fast raw.githubusercontent.com CDN
+        first, then fall back to the GitHub REST Contents endpoint when
+        raw returns 404 (the private / INTERNAL repository symptom).
+        GHES and GHE Cloud packages use the GitHub REST API on the
+        package's host.  For non-GitHub-class hosts, metadata enrichment
+        is skipped.
         """
         try:
             path_prefix = f"{pkg.subdir}/" if pkg.subdir else ""
@@ -948,21 +951,42 @@ class MarketplaceBuilder:
                 return None
 
             if effective_host == "github.com":
-                # github.com -- REST API at api.github.com
-                api_base = (host_info.api_base if host_info else None) or "https://api.github.com"
+                raw_url = (
+                    f"https://raw.githubusercontent.com/{pkg.source_repo}/{pkg.sha}/{file_path}"
+                )
+                req = urllib.request.Request(raw_url)  # noqa: S310
+                if token:
+                    req.add_header("Authorization", f"token {token}")
+                try:
+                    with urllib.request.urlopen(req, timeout=5) as resp:  # noqa: S310
+                        raw = resp.read().decode("utf-8")
+                except urllib.error.HTTPError as exc:
+                    if exc.code != 404:
+                        raise
+                    api_base = (
+                        host_info.api_base if host_info else None
+                    ) or "https://api.github.com"
+                    rest_url = (
+                        f"{api_base}/repos/{pkg.source_repo}/contents/{file_path}?ref={pkg.sha}"
+                    )
+                    req = urllib.request.Request(rest_url)  # noqa: S310
+                    req.add_header("Accept", "application/vnd.github.raw")
+                    if token:
+                        req.add_header("Authorization", f"token {token}")
+                    with urllib.request.urlopen(req, timeout=5) as resp:  # noqa: S310
+                        raw = resp.read().decode("utf-8")
             else:
-                # GHES / GHE Cloud -- REST API on the package's host
                 api_base = (
                     host_info.api_base if host_info else None
                 ) or f"https://{effective_host}/api/v3"
-            url = f"{api_base}/repos/{pkg.source_repo}/contents/{file_path}?ref={pkg.sha}"
-            req = urllib.request.Request(url)  # noqa: S310
-            req.add_header("Accept", "application/vnd.github.raw")
-            if token:
-                req.add_header("Authorization", f"token {token}")
+                url = f"{api_base}/repos/{pkg.source_repo}/contents/{file_path}?ref={pkg.sha}"
+                req = urllib.request.Request(url)  # noqa: S310
+                req.add_header("Accept", "application/vnd.github.raw")
+                if token:
+                    req.add_header("Authorization", f"token {token}")
 
-            with urllib.request.urlopen(req, timeout=5) as resp:  # noqa: S310
-                raw = resp.read().decode("utf-8")
+                with urllib.request.urlopen(req, timeout=5) as resp:  # noqa: S310
+                    raw = resp.read().decode("utf-8")
             data = yaml.safe_load(raw)
             if not isinstance(data, dict):
                 return None

--- a/src/apm_cli/marketplace/builder.py
+++ b/src/apm_cli/marketplace/builder.py
@@ -905,11 +905,9 @@ class MarketplaceBuilder:
         A token resolved for the builder's default host is never sent to
         another host.
 
-        Each package is fetched from its own host: ``github.com``
-        packages use the fast ``raw.githubusercontent.com`` CDN; GHES
-        and GHE Cloud packages use the GitHub REST API on the package's
-        host.  For non-GitHub-class hosts, metadata enrichment is
-        skipped.
+        Metadata is fetched via the GitHub REST API (Contents endpoint
+        with raw media type) on the package's host.  For non-GitHub-class
+        hosts, metadata enrichment is skipped.
         """
         try:
             path_prefix = f"{pkg.subdir}/" if pkg.subdir else ""
@@ -950,21 +948,18 @@ class MarketplaceBuilder:
                 return None
 
             if effective_host == "github.com":
-                # github.com -- use fast raw.githubusercontent.com CDN
-                url = f"https://raw.githubusercontent.com/{pkg.source_repo}/{pkg.sha}/{file_path}"
-                req = urllib.request.Request(url)  # noqa: S310
-                if token:
-                    req.add_header("Authorization", f"token {token}")
+                # github.com -- REST API at api.github.com
+                api_base = (host_info.api_base if host_info else None) or "https://api.github.com"
             else:
-                # GHES / GHE Cloud -- use REST API on the package's host
+                # GHES / GHE Cloud -- REST API on the package's host
                 api_base = (
                     host_info.api_base if host_info else None
                 ) or f"https://{effective_host}/api/v3"
-                url = f"{api_base}/repos/{pkg.source_repo}/contents/{file_path}?ref={pkg.sha}"
-                req = urllib.request.Request(url)  # noqa: S310
-                req.add_header("Accept", "application/vnd.github.raw")
-                if token:
-                    req.add_header("Authorization", f"token {token}")
+            url = f"{api_base}/repos/{pkg.source_repo}/contents/{file_path}?ref={pkg.sha}"
+            req = urllib.request.Request(url)  # noqa: S310
+            req.add_header("Accept", "application/vnd.github.raw")
+            if token:
+                req.add_header("Authorization", f"token {token}")
 
             with urllib.request.urlopen(req, timeout=5) as resp:  # noqa: S310
                 raw = resp.read().decode("utf-8")

--- a/tests/unit/marketplace/test_builder.py
+++ b/tests/unit/marketplace/test_builder.py
@@ -2402,8 +2402,13 @@ class TestFetchRemoteMetadataGHEHost:
         assert parsed.path.startswith("/api/v3/repos/")
         assert req.get_header("Accept") == "application/vnd.github.raw"
 
-    def test_metadata_fetch_github_com_uses_rest_api(self, tmp_path: Path) -> None:
-        """github.com host uses REST API (not raw CDN) -- fixes INTERNAL/private repos."""
+    def test_metadata_fetch_github_com_falls_back_to_rest_api_on_raw_404(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """github.com raw 404 falls back to REST API for INTERNAL/private repos."""
+        import urllib.error
+
         pkg = self._make_pkg(source_repo="acme/private-tools", subdir="plugins/core")
         builder = self._make_builder(tmp_path)
         builder._host = "github.com"
@@ -2412,19 +2417,69 @@ class TestFetchRemoteMetadataGHEHost:
             kind="github",
             api_base="https://api.github.com",
         )
+        raw_404 = urllib.error.HTTPError(
+            url="https://raw.githubusercontent.com/acme/private-tools/sha/plugins/core/apm.yml",
+            code=404,
+            msg="Not Found",
+            hdrs=None,
+            fp=None,  # type: ignore[arg-type]
+        )
         yaml_body = b"description: Private tool\nversion: 2.1.0\n"
         mock_resp = _FakeHTTPResponse(yaml_body)
         with patch(
             "apm_cli.marketplace.builder.urllib.request.urlopen",
-            return_value=mock_resp,
+            side_effect=[raw_404, mock_resp],
         ) as mock_open:
             result = builder._fetch_remote_metadata(pkg)
         assert result == {"description": "Private tool", "version": "2.1.0"}
+        raw_req = mock_open.call_args_list[0][0][0]
+        raw_parsed = urllib.parse.urlparse(raw_req.full_url)
+        assert raw_parsed.hostname == "raw.githubusercontent.com"
+        assert raw_parsed.path == (f"/acme/private-tools/{_SHA_A}/plugins/core/apm.yml")
+        assert raw_req.get_header("Authorization") == "token ghp_test_token"
+
+        rest_req = mock_open.call_args_list[1][0][0]
+        rest_parsed = urllib.parse.urlparse(rest_req.full_url)
+        assert rest_parsed.hostname == "api.github.com"
+        assert rest_parsed.path == ("/repos/acme/private-tools/contents/plugins/core/apm.yml")
+        assert rest_parsed.query == f"ref={_SHA_A}"
+        assert rest_req.get_header("Accept") == "application/vnd.github.raw"
+        assert rest_req.get_header("Authorization") == "token ghp_test_token"
+
+    def test_metadata_fetch_github_com_non_404_does_not_fallback(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """github.com raw non-404 errors do not trigger the REST fallback."""
+        import urllib.error
+
+        pkg = self._make_pkg(source_repo="acme/private-tools", subdir="plugins/core")
+        builder = self._make_builder(tmp_path)
+        builder._host = "github.com"
+        builder._github_token = "ghp_test_token"
+        builder._host_info = SimpleNamespace(
+            kind="github",
+            api_base="https://api.github.com",
+        )
+        raw_403 = urllib.error.HTTPError(
+            url="https://raw.githubusercontent.com/acme/private-tools/sha/plugins/core/apm.yml",
+            code=403,
+            msg="Forbidden",
+            hdrs=None,
+            fp=None,  # type: ignore[arg-type]
+        )
+        with patch(
+            "apm_cli.marketplace.builder.urllib.request.urlopen",
+            side_effect=raw_403,
+        ) as mock_open:
+            result = builder._fetch_remote_metadata(pkg)
+
+        assert result is None
+        assert mock_open.call_count == 1
         req = mock_open.call_args[0][0]
         parsed = urllib.parse.urlparse(req.full_url)
-        assert parsed.hostname == "api.github.com"
-        assert "/repos/acme/private-tools/contents/plugins/core/apm.yml" in parsed.path
-        assert req.get_header("Accept") == "application/vnd.github.raw"
+        assert parsed.hostname == "raw.githubusercontent.com"
+        assert parsed.path == (f"/acme/private-tools/{_SHA_A}/plugins/core/apm.yml")
         assert req.get_header("Authorization") == "token ghp_test_token"
 
     def test_metadata_fetch_non_github_skipped(self, tmp_path: Path) -> None:

--- a/tests/unit/marketplace/test_builder.py
+++ b/tests/unit/marketplace/test_builder.py
@@ -2402,6 +2402,31 @@ class TestFetchRemoteMetadataGHEHost:
         assert parsed.path.startswith("/api/v3/repos/")
         assert req.get_header("Accept") == "application/vnd.github.raw"
 
+    def test_metadata_fetch_github_com_uses_rest_api(self, tmp_path: Path) -> None:
+        """github.com host uses REST API (not raw CDN) -- fixes INTERNAL/private repos."""
+        pkg = self._make_pkg(source_repo="acme/private-tools", subdir="plugins/core")
+        builder = self._make_builder(tmp_path)
+        builder._host = "github.com"
+        builder._github_token = "ghp_test_token"
+        builder._host_info = SimpleNamespace(
+            kind="github",
+            api_base="https://api.github.com",
+        )
+        yaml_body = b"description: Private tool\nversion: 2.1.0\n"
+        mock_resp = _FakeHTTPResponse(yaml_body)
+        with patch(
+            "apm_cli.marketplace.builder.urllib.request.urlopen",
+            return_value=mock_resp,
+        ) as mock_open:
+            result = builder._fetch_remote_metadata(pkg)
+        assert result == {"description": "Private tool", "version": "2.1.0"}
+        req = mock_open.call_args[0][0]
+        parsed = urllib.parse.urlparse(req.full_url)
+        assert parsed.hostname == "api.github.com"
+        assert "/repos/acme/private-tools/contents/plugins/core/apm.yml" in parsed.path
+        assert req.get_header("Accept") == "application/vnd.github.raw"
+        assert req.get_header("Authorization") == "token ghp_test_token"
+
     def test_metadata_fetch_non_github_skipped(self, tmp_path: Path) -> None:
         """Non-GitHub host (kind='generic') returns None without any HTTP request."""
         pkg = self._make_pkg()
@@ -2437,9 +2462,9 @@ class TestFetchRemoteMetadataGHEHost:
 
         Regression guard: previously ``_fetch_remote_metadata`` branched
         only on ``self._host``, so a GHE-hosted package would be fetched
-        from ``raw.githubusercontent.com`` -- potentially returning an
-        unrelated github.com repo's metadata.  After the fix, the
-        package's own host drives every decision.
+        from the wrong API endpoint -- potentially returning an
+        unrelated repo's metadata.  After the fix, the package's own
+        host drives every decision.
         """
         from unittest.mock import MagicMock
 


### PR DESCRIPTION
## Description

`apm pack` silently drops the per-plugin `version` field from generated `marketplace.json` when marketplace packages reference INTERNAL or private repositories on `github.com`. The root cause is that `_fetch_remote_metadata` uses the `raw.githubusercontent.com` CDN for `github.com` hosts, but that CDN returns HTTP 404 for INTERNAL/private repos even with a valid token. The GitHub REST `/contents` API works correctly with the same token but was only used for GHES/GHE-Cloud hosts.

The fix unifies all GitHub host types (github.com, GHES, GHE Cloud) on the REST API Contents endpoint with `Accept: application/vnd.github.raw`, removing the CDN path entirely. This is architecturally consistent with how `download_strategies.py` handles the same trade-off (CDN only for unauthenticated public access) and avoids the double-latency penalty a try/except fallback would incur.

Fixes: #1847

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

Added `test_metadata_fetch_github_com_uses_rest_api` verifying that github.com packages use `api.github.com` with proper auth headers and the `application/vnd.github.raw` accept type.

## Spec conformance (OpenAPM v0.1)

- [x] N/A -- this PR does not change OpenAPM-observable behaviour.