### PR TITLE
Fix no-orphaned-packages false positive for local-path sub-package deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `apm audit --ci` no longer flags pinned remote dependencies declared by
+  local-path sub-packages as orphaned when they are resolved transitively.
+  (closes #1846) (#1855)
+
 ## [0.21.0] - 2026-06-19
 
 ### Added

--- a/src/apm_cli/deps/dependency_graph.py
+++ b/src/apm_cli/deps/dependency_graph.py
@@ -87,11 +87,14 @@ class DependencyTree:
     def add_node(self, node: DependencyNode) -> None:
         """Add a node to the tree."""
         node_id = node.get_id()
+        unique_key = node.dependency_ref.get_unique_key()
         is_new = node_id not in self.nodes
         self.nodes[node_id] = node
-        self._nodes_by_unique_key[node.dependency_ref.get_unique_key()] = node
         if is_new:
+            self._nodes_by_unique_key.setdefault(unique_key, node)
             self._nodes_by_depth[node.depth].append(node)
+        else:
+            self._nodes_by_unique_key[unique_key] = node
         self.max_depth = max(self.max_depth, node.depth)
 
     def get_node(self, unique_key: str) -> DependencyNode | None:

--- a/src/apm_cli/deps/dependency_graph.py
+++ b/src/apm_cli/deps/dependency_graph.py
@@ -80,6 +80,7 @@ class DependencyTree:
     _nodes_by_depth: dict[int, list[DependencyNode]] = field(
         default_factory=lambda: defaultdict(list)
     )
+    _nodes_by_unique_key: dict[str, DependencyNode] = field(default_factory=dict)
     max_depth: int = 0
     resolution_errors: list[str] = field(default_factory=list)
 
@@ -88,13 +89,20 @@ class DependencyTree:
         node_id = node.get_id()
         is_new = node_id not in self.nodes
         self.nodes[node_id] = node
+        self._nodes_by_unique_key[node.dependency_ref.get_unique_key()] = node
         if is_new:
             self._nodes_by_depth[node.depth].append(node)
         self.max_depth = max(self.max_depth, node.depth)
 
     def get_node(self, unique_key: str) -> DependencyNode | None:
-        """Get a node by its unique key."""
-        return self.nodes.get(unique_key)
+        """Get a node by its unique key.
+
+        Looks up by ``DependencyReference.get_unique_key()`` which does
+        NOT include the ``#reference`` suffix.  The primary ``nodes``
+        dict is keyed by ``DependencyNode.get_id()`` which DOES include
+        it, so a plain ``dict.get`` would miss pinned deps (#1846).
+        """
+        return self._nodes_by_unique_key.get(unique_key) or self.nodes.get(unique_key)
 
     def get_nodes_at_depth(self, depth: int) -> list[DependencyNode]:
         """Get all nodes at a specific depth level."""

--- a/tests/unit/deps/test_dependency_tree_lookup.py
+++ b/tests/unit/deps/test_dependency_tree_lookup.py
@@ -1,0 +1,59 @@
+"""Tests for DependencyTree node lookup with pinned references (#1846)."""
+
+from __future__ import annotations
+
+from apm_cli.deps.dependency_graph import DependencyNode, DependencyTree
+from apm_cli.models.apm_package import APMPackage, DependencyReference
+
+
+def _make_node(repo_url: str, reference: str | None = None, depth: int = 1, parent=None):
+    dep_ref = DependencyReference(repo_url=repo_url, reference=reference)
+    pkg = APMPackage(name=repo_url.split("/")[-1], version="0.0.0")
+    return DependencyNode(package=pkg, dependency_ref=dep_ref, depth=depth, parent=parent)
+
+
+class TestDependencyTreeGetNode:
+    """get_node() must find nodes regardless of whether they have a pinned ref."""
+
+    def test_get_node_without_reference(self):
+        root = APMPackage(name="root", version="1.0.0")
+        tree = DependencyTree(root_package=root)
+
+        node = _make_node("owner/repo")
+        tree.add_node(node)
+
+        assert tree.get_node("owner/repo") is node
+
+    def test_get_node_with_pinned_reference(self):
+        """Nodes stored with get_id() = 'repo#sha' must be found by unique_key = 'repo'."""
+        root = APMPackage(name="root", version="1.0.0")
+        tree = DependencyTree(root_package=root)
+
+        node = _make_node("prisma/skills", reference="0b8e83cddde30b3e028fb4e0f6770948c6160e08")
+        tree.add_node(node)
+
+        # get_id() includes the reference
+        assert node.get_id() == "prisma/skills#0b8e83cddde30b3e028fb4e0f6770948c6160e08"
+        # get_node() should still find it by unique_key (without reference)
+        assert tree.get_node("prisma/skills") is node
+
+    def test_get_node_transitive_with_parent(self):
+        """Transitive dep with ref: parent is accessible via get_node() lookup."""
+        root = APMPackage(name="root", version="1.0.0")
+        tree = DependencyTree(root_package=root)
+
+        parent_node = _make_node("_local/agent-config", depth=1)
+        tree.add_node(parent_node)
+
+        child_node = _make_node(
+            "prisma/skills",
+            reference="0b8e83cddde30b3e028fb4e0f6770948c6160e08",
+            depth=2,
+            parent=parent_node,
+        )
+        tree.add_node(child_node)
+
+        found = tree.get_node("prisma/skills")
+        assert found is not None
+        assert found.parent is parent_node
+        assert found.parent.dependency_ref.repo_url == "_local/agent-config"

--- a/tests/unit/deps/test_dependency_tree_lookup.py
+++ b/tests/unit/deps/test_dependency_tree_lookup.py
@@ -57,3 +57,15 @@ class TestDependencyTreeGetNode:
         assert found is not None
         assert found.parent is parent_node
         assert found.parent.dependency_ref.repo_url == "_local/agent-config"
+
+    def test_get_node_preserves_first_ref_for_same_unique_key(self):
+        """The unique-key index follows the graph's first-wins conflict policy."""
+        root = APMPackage(name="root", version="1.0.0")
+        tree = DependencyTree(root_package=root)
+
+        first_node = _make_node("owner/repo", reference="1111111")
+        second_node = _make_node("owner/repo", reference="2222222")
+        tree.add_node(first_node)
+        tree.add_node(second_node)
+
+        assert tree.get_node("owner/repo") is first_node

--- a/tests/unit/policy/test_ci_checks.py
+++ b/tests/unit/policy/test_ci_checks.py
@@ -310,6 +310,41 @@ class TestNoOrphans:
         result = _check_no_orphans(manifest, lock)
         assert result.passed, result.details
 
+    def test_remote_deps_of_local_path_subpackage_not_orphaned(self, tmp_path):
+        """Remote deps declared by a local-path sub-package are transitive.
+
+        Topology: root -> ./packages/agent-config (local-path) ->
+        prisma/skills (remote, pinned SHA). The lockfile should record
+        ``resolved_by: _local/agent-config`` for ``prisma/skills`` so
+        ``_check_no_orphans`` exempts it. Regression test for #1846.
+        """
+        _write_apm_yml(tmp_path, deps=["./packages/agent-config"])
+        _write_lockfile(
+            tmp_path,
+            textwrap.dedent("""\
+                lockfile_version: '1'
+                generated_at: '2025-01-01T00:00:00Z'
+                dependencies:
+                  - repo_url: _local/agent-config
+                    source: local
+                    local_path: ./packages/agent-config
+                    depth: 1
+                    deployed_files: []
+                  - repo_url: prisma/skills
+                    resolved_ref: 0b8e83cddde30b3e028fb4e0f6770948c6160e08
+                    depth: 2
+                    resolved_by: _local/agent-config
+                    deployed_files: []
+            """),
+        )
+        from apm_cli.deps.lockfile import LockFile, get_lockfile_path
+        from apm_cli.models.apm_package import APMPackage
+
+        manifest = APMPackage.from_apm_yml(tmp_path / "apm.yml")
+        lock = LockFile.read(get_lockfile_path(tmp_path))
+        result = _check_no_orphans(manifest, lock)
+        assert result.passed, f"False positive orphan: {result.details}"
+
 
 # -- Config consistency ---------------------------------------------
 


### PR DESCRIPTION
## Description

`DependencyTree.get_node()` failed to find nodes with a pinned reference because nodes are stored by `get_id()` (`repo_url#ref`) but looked up by `get_unique_key()` (`repo_url` only). This caused `resolved_by` to be null for transitive deps declared by a local-path sub-package, triggering false `no-orphaned-packages` audit failures in `apm audit --ci`.

The fix adds a `_nodes_by_unique_key` secondary index to `DependencyTree` so `get_node()` correctly resolves deps regardless of whether they carry a pinned reference suffix.

Fixes #1846

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

New tests:
- `test_dependency_tree_lookup.py` -- verifies `get_node()` finds nodes with pinned refs
- `test_remote_deps_of_local_path_subpackage_not_orphaned` -- regression test for the exact topology from the issue (root -> local-path -> remote pinned deps)

## Spec conformance (OpenAPM v0.1)

- [x] N/A -- this PR does not change OpenAPM-observable behaviour.