### PR TITLE
fix: honor CODEX_HOME for user-scope codex config (closes #1861)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `apm install -g --target codex` now honors `CODEX_HOME` for user-scope
+  Codex MCP config writes, falling back to `~/.codex/config.toml` when unset.
+  (closes #1861) (#1863)
+
 ## [0.21.0] - 2026-06-19
 
 ### Added

--- a/docs/src/content/docs/consumer/install-mcp-servers.md
+++ b/docs/src/content/docs/consumer/install-mcp-servers.md
@@ -104,7 +104,7 @@ for the full required-vs-optional runtime config rule.
 | VS Code (Copilot) | `.vscode/mcp.json` | project | JSON `servers` |
 | Claude Code | `.mcp.json` (project) or `~/.claude.json` (`-g`) | both | JSON `mcpServers` |
 | Cursor | `.cursor/mcp.json` | project (only if `.cursor/` exists) | JSON `mcpServers` |
-| Codex CLI | `.codex/config.toml` (project, only if `.codex/` exists) or `~/.codex/config.toml` (`-g`) | both | TOML `[mcp_servers.*]` |
+| Codex CLI | `.codex/config.toml` (project, only if `.codex/` exists) or `$CODEX_HOME/config.toml` (`-g`, falling back to `~/.codex/config.toml`) | both | TOML `[mcp_servers.*]` |
 | Gemini CLI | `.gemini/settings.json` (project, only if `.gemini/` exists) or `~/.gemini/settings.json` (`-g`) | both | JSON `mcpServers` |
 | Antigravity CLI | `.agents/mcp_config.json` (project, only if `.agents/` exists) or `~/.gemini/config/mcp_config.json` (`-g`) | both | JSON `mcpServers` |
 | OpenCode | `opencode.json` | project (only if `.opencode/` exists) | JSON `mcp` |
@@ -147,7 +147,7 @@ declare one in `apm.yml`. (#1335)
 `apm install -g --mcp NAME` is a deliberate carve-out: it routes the
 write to each runtime's user-scope MCP config (for example, Copilot CLI to
 `~/.copilot/mcp-config.json`, Claude Code to `~/.claude.json`, Codex CLI to
-`~/.codex/config.toml`, Gemini CLI to `~/.gemini/settings.json`, Antigravity CLI to `~/.gemini/config/mcp_config.json`, Windsurf to
+`$CODEX_HOME/config.toml` when `CODEX_HOME` is set or `~/.codex/config.toml` otherwise, Gemini CLI to `~/.gemini/settings.json`, Antigravity CLI to `~/.gemini/config/mcp_config.json`, Windsurf to
 `~/.codeium/windsurf/mcp_config.json`, Kiro to `~/.kiro/settings/mcp.json`,
 and JetBrains Copilot to its OS-specific user config). It does not consult
 the project-scope `targets:` whitelist -- user-scope writes are by

--- a/docs/src/content/docs/consumer/install-mcp-servers.md
+++ b/docs/src/content/docs/consumer/install-mcp-servers.md
@@ -104,7 +104,7 @@ for the full required-vs-optional runtime config rule.
 | VS Code (Copilot) | `.vscode/mcp.json` | project | JSON `servers` |
 | Claude Code | `.mcp.json` (project) or `~/.claude.json` (`-g`) | both | JSON `mcpServers` |
 | Cursor | `.cursor/mcp.json` | project (only if `.cursor/` exists) | JSON `mcpServers` |
-| Codex CLI | `.codex/config.toml` (project, only if `.codex/` exists) or `$CODEX_HOME/config.toml` (`-g`, falling back to `~/.codex/config.toml`) | both | TOML `[mcp_servers.*]` |
+| Codex CLI | `.codex/config.toml` (project, only if `.codex/` exists) or `$CODEX_HOME/config.toml` (`-g`, when non-blank; otherwise `~/.codex/config.toml`) | both | TOML `[mcp_servers.*]` |
 | Gemini CLI | `.gemini/settings.json` (project, only if `.gemini/` exists) or `~/.gemini/settings.json` (`-g`) | both | JSON `mcpServers` |
 | Antigravity CLI | `.agents/mcp_config.json` (project, only if `.agents/` exists) or `~/.gemini/config/mcp_config.json` (`-g`) | both | JSON `mcpServers` |
 | OpenCode | `opencode.json` | project (only if `.opencode/` exists) | JSON `mcp` |
@@ -147,7 +147,7 @@ declare one in `apm.yml`. (#1335)
 `apm install -g --mcp NAME` is a deliberate carve-out: it routes the
 write to each runtime's user-scope MCP config (for example, Copilot CLI to
 `~/.copilot/mcp-config.json`, Claude Code to `~/.claude.json`, Codex CLI to
-`$CODEX_HOME/config.toml` when `CODEX_HOME` is set or `~/.codex/config.toml` otherwise, Gemini CLI to `~/.gemini/settings.json`, Antigravity CLI to `~/.gemini/config/mcp_config.json`, Windsurf to
+`$CODEX_HOME/config.toml` when `CODEX_HOME` is set to a non-whitespace value or `~/.codex/config.toml` otherwise, Gemini CLI to `~/.gemini/settings.json`, Antigravity CLI to `~/.gemini/config/mcp_config.json`, Windsurf to
 `~/.codeium/windsurf/mcp_config.json`, Kiro to `~/.kiro/settings/mcp.json`,
 and JetBrains Copilot to its OS-specific user config). It does not consult
 the project-scope `targets:` whitelist -- user-scope writes are by

--- a/src/apm_cli/adapters/client/codex.py
+++ b/src/apm_cli/adapters/client/codex.py
@@ -49,13 +49,16 @@ class CodexClientAdapter(MCPClientAdapter):
         self.registry_client = SimpleRegistryClient(registry_url)
         self.registry_integration = RegistryIntegration(registry_url)
 
-    def _get_codex_dir(self):
+    def _get_codex_dir(self) -> Path:
         """Return the root directory used for Codex config in the current scope."""
         if self.user_scope:
+            codex_home = os.environ.get("CODEX_HOME", "")
+            if codex_home.strip():
+                return Path(codex_home).expanduser()
             return Path.home() / ".codex"
         return self.project_root / ".codex"
 
-    def get_config_path(self):
+    def get_config_path(self) -> str:
         """Get the path to the Codex CLI MCP configuration file.
 
         Returns:
@@ -322,7 +325,7 @@ class CodexClientAdapter(MCPClientAdapter):
                     all_args = processed_runtime_args + processed_package_args
                     if all_args:
                         # If runtime_arguments already include the package (bare or
-                        # versioned), use them as-is — they are authoritative from
+                        # versioned), use them as-is -- they are authoritative from
                         # the registry and may carry a version pin.
                         has_pkg = any(
                             a == package_name or a.startswith(f"{package_name}@") for a in all_args

--- a/src/apm_cli/adapters/client/codex.py
+++ b/src/apm_cli/adapters/client/codex.py
@@ -10,6 +10,7 @@ import toml
 from ...registry.client import SimpleRegistryClient
 from ...registry.integration import RegistryIntegration
 from ...utils.console import _rich_success, _rich_warning
+from ...utils.path_security import PathTraversalError
 from ._mcp_runtime_args import process_v01_value_hint_arg
 from .base import MCPClientAdapter
 
@@ -54,7 +55,13 @@ class CodexClientAdapter(MCPClientAdapter):
         if self.user_scope:
             codex_home = os.environ.get("CODEX_HOME", "")
             if codex_home.strip():
-                return Path(codex_home).expanduser()
+                codex_home_path = Path(codex_home).expanduser()
+                if not codex_home_path.is_absolute():
+                    raise PathTraversalError(
+                        "CODEX_HOME is set to a non-absolute path; cannot locate the "
+                        "Codex CLI configuration directory."
+                    )
+                return codex_home_path
             return Path.home() / ".codex"
         return self.project_root / ".codex"
 

--- a/tests/unit/test_codex_adapter_compatibility.py
+++ b/tests/unit/test_codex_adapter_compatibility.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 import pytest
 
 from apm_cli.adapters.client.codex import CodexClientAdapter
+from apm_cli.utils.path_security import PathTraversalError
 
 # ---------------------------------------------------------------------------
 # Helpers / fixtures
@@ -81,7 +82,10 @@ class TestInit:
 class TestGetConfigPath:
     """Tests for scope-aware config path resolution."""
 
-    def test_project_scope_uses_project_root(self, tmp_path: Path) -> None:
+    def test_project_scope_uses_project_root(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path / "ignored-codex-home"))
         adapter = _make_adapter(project_root=tmp_path, user_scope=False)
         expected = str(tmp_path / ".codex" / "config.toml")
         assert adapter.get_config_path() == expected
@@ -124,6 +128,16 @@ class TestGetConfigPath:
 
         expected = home / "codex-config" / "config.toml"
         assert adapter.get_config_path() == str(expected)
+
+    def test_user_scope_rejects_relative_codex_home_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CODEX_HOME", "relative-codex")
+
+        adapter = _make_adapter(user_scope=True)
+
+        with pytest.raises(PathTraversalError, match=r"CODEX_HOME.*non-absolute path"):
+            adapter.get_config_path()
 
     def test_config_path_ends_with_config_toml(self, tmp_path: Path) -> None:
         adapter = _make_adapter(project_root=tmp_path)

--- a/tests/unit/test_codex_adapter_compatibility.py
+++ b/tests/unit/test_codex_adapter_compatibility.py
@@ -92,6 +92,39 @@ class TestGetConfigPath:
         expected = str(home / ".codex" / "config.toml")
         assert adapter.get_config_path() == expected
 
+    def test_user_scope_honors_codex_home_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home = tmp_path / "home"
+        custom_codex_home = tmp_path / "custom-codex"
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("CODEX_HOME", str(custom_codex_home))
+
+        adapter = _make_adapter(user_scope=True)
+
+        assert adapter._get_codex_dir() == custom_codex_home
+        assert adapter.get_config_path() == str(custom_codex_home / "config.toml")
+
+        monkeypatch.setenv("CODEX_HOME", "     ")
+        assert adapter._get_codex_dir() == home / ".codex"
+        assert adapter.get_config_path() == str(home / ".codex" / "config.toml")
+
+        monkeypatch.delenv("CODEX_HOME", raising=False)
+        assert adapter._get_codex_dir() == home / ".codex"
+        assert adapter.get_config_path() == str(home / ".codex" / "config.toml")
+
+    def test_user_scope_expands_codex_home_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        home = tmp_path / "home"
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("CODEX_HOME", "~/codex-config")
+
+        adapter = _make_adapter(user_scope=True)
+
+        expected = home / "codex-config" / "config.toml"
+        assert adapter.get_config_path() == str(expected)
+
     def test_config_path_ends_with_config_toml(self, tmp_path: Path) -> None:
         adapter = _make_adapter(project_root=tmp_path)
         assert adapter.get_config_path().endswith("config.toml")


### PR DESCRIPTION
This fixes user-scope Codex MCP installs so CODEX_HOME, when set to a non-whitespace value, resolves the Codex config directory for apm install -g before falling back to ~/.codex; project-scope .codex/config.toml behavior is unchanged, and the consumer docs now describe the precedence. How to test: uv run --extra dev pytest tests/unit/test_codex_adapter_compatibility.py -k 'codex_home or user_scope_honors' -q; uv run --extra dev pytest tests/ -k codex -q; uv run --extra dev pytest tests/unit/adapters tests/unit/test_codex_adapter_compatibility.py -q; uv run --extra dev ruff check src/ tests/; uv run --extra dev ruff format --check src/ tests/. Closes #1861.