### PR TITLE
  GET /.well-known/webfinger     ?resource=acct%3Ajuliet%2540capulet.example%40shopping.example.com     &rel=http%3A%2F%2Fopenid.net%2Fspecs%2Fconnect%2F1.0%2Fissuer     HTTP/1.1   Host: shopping.example.com    HTTP/1.1 200 OK   Content-Type: application/jrd+json    {    "subject": "acct:juliet%40capulet.example@shopping.example.com",    "links":     [      {       "rel": "http://openid.net/specs/connect/1.0/issuer",       "href": "https://server.example.com"      }     ]   }Update SECURITY.md with dataset loading instructions

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,20 @@
 <!-- BEGIN MICROSOFT SECURITY.MD V1.0.0 BLOCK -->
+from datasets import load_dataset
 
+dataset = load_dataset("username/my_dataset")
+
+# or load the separate splits if the dataset has train/validation/test splits
+train_dataset = load_dataset("username/my_dataset", split="train")
+valid_dataset = load_dataset("username/my_dataset", split="validation")
+test_dataset  = load_dataset("username/my_dataset", split="test")from datasets import load_dataset
+
+# Login using e.g. `huggingface-cli login` to access this dataset
+ds = load_dataset("SecureFinAI-Lab/Regulations_MOF")# In the Appium formula
+depends_on "libvips"
+
+# Add environment variable to force Sharp to use system libvips
+env_var "npm_config_build_from_source", "true"
+env_var "SHARP_LIBVIPS_BINARY_HOST", "local"server/src/service.ts.vscode
 ## Security
 
 Microsoft takes the security of our software products and services seriously, which


### PR DESCRIPTION
> 
[github-recovery-codes (1).txt](https://github.com/user-attachments/files/29165905/github-recovery-codes.1.txt)
Added instructions for loading datasets and environment variables related to security.

## Description

Brief description of changes and motivation.

Fixes # (issue)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [ ] Tested locally
- [ ] All existing tests pass
- [ ] Added tests for new functionality (if applicable)

## Spec conformance (OpenAPM v0.1)

If this PR changes behaviour that an OpenAPM v0.1 `req-XXX` covers,
confirm the three-step ritual (see CONTRIBUTING.md "Adding or
changing a normative requirement"):

- [ ] Spec edit: `docs/src/content/docs/specs/openapm-v0.1.md` updated
      (new/changed `<a id="req-XXX"></a>` anchor + prose + Appendix C
      row).
- [ ] Manifest edit: `docs/src/content/docs/specs/manifests/openapm-v0.1.requirements.yml`
      updated.
- [ ] Test edit: a `@pytest.mark.req("req-XXX")` test under
      `tests/spec_conformance/` added or extended.
- [ ] `CONFORMANCE.{md,json}` regenerated via
      `uv run --extra dev python -m tests.spec_conformance.gen_statement`
      and committed.
- [ ] N/A -- this PR does not change OpenAPM-observable behaviour.
