### PR TITLE
docs(changelog): reconcile [Unreleased] with PRs merged since v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Org-wide policy discovery now cascades through candidate repo names
+  (`.github`, then `.apm`, then `_apm`) and speaks the Azure DevOps Items
+  API, so Azure DevOps organizations -- which forbid repo names that begin
+  or end with `.` -- can host an APM governance policy repo for the first
+  time. (by @sergio-sisternes-epam; closes #1813) (#1830)
+
 ### Fixed
 
+- `apm install <pkg>@<marketplace>` now preserves GitLab and other
+  non-GitHub hosts from url-type marketplace plugin sources, so auth
+  resolution no longer falls back to `github.com` for those installs.
+  (by @sergio-sisternes-epam; closes #1848) (#1853)
+- `apm pack` no longer drops the per-plugin `version` field for INTERNAL or
+  private `github.com` marketplace repos; all GitHub host types now resolve
+  metadata through the REST Contents API instead of the raw CDN, which
+  returned 404 for private repos. (by @sergio-sisternes-epam) (#1854)
 - `apm audit --ci` no longer flags pinned remote dependencies declared by
   local-path sub-packages as orphaned when they are resolved transitively.
-  (closes #1846) (#1855)
+  (by @sergio-sisternes-epam; closes #1846) (#1855)
+- `apm update` stale-file cleanup no longer deletes a file when another
+  installed package also deploys one at the same path; a cross-package
+  ownership guard now excludes shared paths from the stale set.
+  (by @sergio-sisternes-epam; closes #1831) (#1856)
 - `apm install -g --target codex` now honors `CODEX_HOME` for user-scope
   Codex MCP config writes, falling back to `~/.codex/config.toml` when unset.
   (closes #1861) (#1863)
@@ -48,10 +68,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `apm install <pkg>@<marketplace>` now preserves GitLab and other
-  non-GitHub hosts from url-type marketplace plugin sources, so auth
-  resolution no longer falls back to `github.com` for those installs.
-  (by @sergio-sisternes-epam; closes #1848) (#1853)
 - Registry deps with non-semver version selectors (e.g. `stable`, `main`) no longer report perpetual `outdated`. The drift check now uses literal equality for non-semver registry pins rather than range comparison, which always returned `True` against a semver range. (#1816)
 - Non-semver registry version selectors are now exact-matched against the registry's published version list at install time. Previously they were rejected with "not a valid semver range". (#1816)
 - Cursor hook integration: emit required top-level `version: 1` in `.cursor/hooks.json`.


### PR DESCRIPTION
## TL;DR

Makes the `CHANGELOG.md` `[Unreleased]` block faithful to what has actually merged since the **v0.21.0** tag. No version bump, no dated heading -- everything stays under `[Unreleased]`. This is changelog hygiene only; it does not cut a release.

## What changed

Enumerated every PR merged after the v0.21.0 tag (commit `975f8f0`, 2026-06-19 16:46) and reconciled the changelog against it.

### Added to `[Unreleased]` (were missing)
- **#1830** -> new `### Added` -- cascading org-policy repo discovery (`.github` -> `.apm` -> `_apm`) plus Azure DevOps Items API support, so ADO orgs can host a governance policy repo. (by @sergio-sisternes-epam; closes #1813)
- **#1854** -> `### Fixed` -- `apm pack` no longer drops `version` for INTERNAL/private `github.com` marketplace repos (REST Contents API instead of the raw CDN, which 404s on private repos). (by @sergio-sisternes-epam)
- **#1856** -> `### Fixed` -- cross-package file-protection guard in stale cleanup. (by @sergio-sisternes-epam; closes #1831)

### Attribution fix
- **#1855** -- added the missing `by @sergio-sisternes-epam` credit (external contributor; consistent with the released entries).

### Misfiled entry moved
- **#1853** was listed under the released `[0.21.0]` section but merged 2026-06-20, **after** the v0.21.0 tag (verified: its commit is not an ancestor of the tag). Moved into `[Unreleased]` where it factually belongs.

### Correctly omitted
- **#1870** (remove daily test-improver workflow) -- internal `.github/workflows/` change, not user-facing.

## Validation evidence
- Changelog-only diff (`+21 / -5`), printable ASCII per the encoding contract.
- No `src/` or `tests/` changes, so the CI lint mirror (ruff / pylint R0801 / auth-signals) has no new code surface to flag.

## How to test
- `git show --stat HEAD` -- confirms a single-file (`CHANGELOG.md`) change.
- `grep -c "#1853" CHANGELOG.md` -- returns `1` (now only in `[Unreleased]`, removed from `[0.21.0]`).

> [!NOTE]
> Reviewer check on the **#1853 move**: if v0.21.0's published artifact was intended to include #1853, revert just that hunk. The branch base is a few commits behind `main`; the changelog hunks do not conflict (none of the post-tag PRs added their own `[Unreleased]` entries).