### PR TITLE
fix(install): make Windows pip fallback resilient to stderr under ErrorActionPreference=Stop (closes #1874)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `apm install -g --target codex` now honors `CODEX_HOME` for user-scope
   Codex MCP config writes, falling back to `~/.codex/config.toml` when unset.
   (closes #1861) (#1863)
-- Windows pip fallback no longer terminates early when native pip writes
-  stderr under `$ErrorActionPreference = "Stop"`. (closes #1874) (#1876)
+- Windows installer staging now honors `APM_TEMP_DIR` and reports actionable
+  guidance when the temporary staging root is not writable. (closes #1874)
+  (#1876)
+- Windows pip fallback no longer terminates early when native pip writes stderr
+  under `$ErrorActionPreference = "Stop"`. (closes #1874) (#1876)
 
 ## [0.21.0] - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `apm install -g --target codex` now honors `CODEX_HOME` for user-scope
   Codex MCP config writes, falling back to `~/.codex/config.toml` when unset.
   (closes #1861) (#1863)
+- Windows pip fallback no longer terminates early when native pip writes
+  stderr under `$ErrorActionPreference = "Stop"`. (closes #1874) (#1876)
 
 ## [0.21.0] - 2026-06-19
 

--- a/install.ps1
+++ b/install.ps1
@@ -539,12 +539,46 @@ if ($pinnedVersion) {
 }
 
 $releaseDir = Join-Path $releasesDir $tagName
-$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("apm-install-" + [System.Guid]::NewGuid().ToString("N"))
+$tempRootInput = if ($env:APM_TEMP_DIR) {
+    $env:APM_TEMP_DIR.Trim().Trim('"').TrimEnd('\', '/')
+} else {
+    [System.IO.Path]::GetTempPath()
+}
+
+$tempRootDir = $null
+try {
+    $tempRootDir = [System.IO.Path]::GetFullPath($tempRootInput)
+    New-Item -ItemType Directory -Force -Path $tempRootDir | Out-Null
+} catch {
+    Write-ErrorText "Failed to prepare temporary staging root: $_"
+    if ($tempRootDir) {
+        Write-Host "Temporary staging root was: $tempRootDir"
+    } else {
+        Write-Host "Temporary staging root was: $tempRootInput"
+    }
+    Write-Host "Set APM_TEMP_DIR to a writable directory allowed by endpoint policy, then retry:"
+    Write-Host "  `$env:APM_TEMP_DIR = `"`$env:LOCALAPPDATA\Programs\apm\tmp`""
+    Write-ManualInstallHelp -GithubUrl $githubUrl -ApmRepo $apmRepo
+    exit 1
+}
+
+$tempDir = Join-Path $tempRootDir ("apm-install-" + [System.Guid]::NewGuid().ToString("N"))
 $zipPath = Join-Path $tempDir $assetName
 
-New-Item -ItemType Directory -Force -Path $tempDir | Out-Null
-New-Item -ItemType Directory -Force -Path $binDir | Out-Null
-New-Item -ItemType Directory -Force -Path $releasesDir | Out-Null
+try {
+    New-Item -ItemType Directory -Force -Path $tempDir | Out-Null
+    New-Item -ItemType Directory -Force -Path $binDir | Out-Null
+    New-Item -ItemType Directory -Force -Path $releasesDir | Out-Null
+} catch {
+    Write-ErrorText "Failed to prepare installer directories: $_"
+    Write-Host "Temporary staging directory: $tempDir"
+    Write-Host "Install bin directory: $binDir"
+    Write-Host "Releases directory: $releasesDir"
+    Write-Host "If temporary staging was denied, set APM_TEMP_DIR to a writable directory allowed by endpoint policy, then retry:"
+    Write-Host "  `$env:APM_TEMP_DIR = `"`$env:LOCALAPPDATA\Programs\apm\tmp`""
+    Write-ManualInstallHelp -GithubUrl $githubUrl -ApmRepo $apmRepo
+    exit 1
+}
 
 try {
     # ------------------------------------------------------------------

--- a/install.ps1
+++ b/install.ps1
@@ -265,14 +265,20 @@ function Install-ViaPip {
     }
     $pipIndexArgs = Get-PipIndexArgs
     try {
-        if ($pipCmd -like "* -m pip") {
-            $output = & $pythonCmd -m pip install --user @pipIndexArgs apm-cli 2>&1
-            $pipExitCode = $LASTEXITCODE
-            $output | Write-Host
-        } else {
-            $output = & $pipCmd install --user @pipIndexArgs apm-cli 2>&1
-            $pipExitCode = $LASTEXITCODE
-            $output | Write-Host
+        $previousErrorActionPreference = $ErrorActionPreference
+        try {
+            $ErrorActionPreference = "Continue"
+            if ($pipCmd -like "* -m pip") {
+                $output = & $pythonCmd -m pip install --user @pipIndexArgs apm-cli 2>&1
+                $pipExitCode = $LASTEXITCODE
+                $output | Write-Host
+            } else {
+                $output = & $pipCmd install --user @pipIndexArgs apm-cli 2>&1
+                $pipExitCode = $LASTEXITCODE
+                $output | Write-Host
+            }
+        } finally {
+            $ErrorActionPreference = $previousErrorActionPreference
         }
         if ($pipExitCode -ne 0) {
             Write-ErrorText "pip install failed (exit code $pipExitCode)."

--- a/tests/unit/test_enterprise_bootstrap_installers.py
+++ b/tests/unit/test_enterprise_bootstrap_installers.py
@@ -169,6 +169,35 @@ def test_unix_installer_fail_closed_asset_exit_code() -> None:
     assert "APM_RELEASE_BASE_URL is not configured" in combined
 
 
+def test_windows_installer_honors_apm_temp_dir_for_download_staging() -> None:
+    """install.ps1 must stage downloads under APM_TEMP_DIR when configured."""
+    text = _read_repo_file("install.ps1")
+    body = text.split("$releaseDir = Join-Path $releasesDir $tagName", 1)[1].split(
+        "try {\n    # ------------------------------------------------------------------", 1
+    )[0]
+
+    temp_env_branch = "if ($env:APM_TEMP_DIR)"
+    temp_root_input = "$tempRootInput"
+    temp_root_dir = "$tempRootDir = [System.IO.Path]::GetFullPath($tempRootInput)"
+    temp_dir = "$tempDir = Join-Path $tempRootDir"
+    default_temp = "[System.IO.Path]::GetTempPath()"
+    temp_guidance = "Set APM_TEMP_DIR to a writable directory allowed by endpoint policy"
+    example_temp_dir = "$env:LOCALAPPDATA\\Programs\\apm\\tmp"
+
+    assert temp_env_branch in body
+    assert temp_root_input in body
+    assert temp_root_dir in body
+    assert temp_dir in body
+    assert default_temp in body
+    assert temp_guidance in body
+    assert example_temp_dir in body
+    assert "Temporary staging directory: $tempDir" in body
+    assert "Join-Path ([System.IO.Path]::GetTempPath())" not in body
+    assert body.index(temp_env_branch) < body.index(temp_root_dir)
+    assert body.index(temp_root_dir) < body.index(temp_dir)
+    assert body.index(temp_dir) < body.index("$zipPath = Join-Path $tempDir $assetName")
+
+
 def test_windows_pip_fallback_scopes_native_stderr_error_action_guard() -> None:
     """install.ps1 must not let native pip stderr terminate fallback."""
     text = _read_repo_file("install.ps1")

--- a/tests/unit/test_enterprise_bootstrap_installers.py
+++ b/tests/unit/test_enterprise_bootstrap_installers.py
@@ -169,6 +169,31 @@ def test_unix_installer_fail_closed_asset_exit_code() -> None:
     assert "APM_RELEASE_BASE_URL is not configured" in combined
 
 
+def test_windows_pip_fallback_scopes_native_stderr_error_action_guard() -> None:
+    """install.ps1 must not let native pip stderr terminate fallback."""
+    text = _read_repo_file("install.ps1")
+    body = text.split("function Install-ViaPip {", 1)[1].split(
+        "function Write-ManualInstallHelp {", 1
+    )[0]
+
+    previous_guard = "$previousErrorActionPreference = $ErrorActionPreference"
+    continue_guard = '$ErrorActionPreference = "Continue"'
+    restore_guard = "$ErrorActionPreference = $previousErrorActionPreference"
+    python_pip_call = "$output = & $pythonCmd -m pip install --user @pipIndexArgs apm-cli 2>&1"
+    pip_call = "$output = & $pipCmd install --user @pipIndexArgs apm-cli 2>&1"
+
+    assert previous_guard in body
+    assert continue_guard in body
+    assert restore_guard in body
+    assert body.count(continue_guard) == 1
+    assert body.index(previous_guard) < body.index(continue_guard)
+    assert body.index(continue_guard) < body.index(python_pip_call)
+    assert body.index(continue_guard) < body.index(pip_call)
+    assert body.index(python_pip_call) < body.index("finally {")
+    assert body.index(pip_call) < body.index("finally {")
+    assert body.index("finally {") < body.index(restore_guard)
+
+
 def test_windows_installer_uses_auth_on_first_ghes_metadata_fetch() -> None:
     """install.ps1 should not make an unauthenticated GHES metadata request first."""
     text = _read_repo_file("install.ps1")


### PR DESCRIPTION
## TL;DR
Make the Windows installer resilient to both issue #1874 failure modes: pip fallback ignores non-fatal native stderr as a PowerShell terminating-error source, and download staging honors `APM_TEMP_DIR` when enterprise policy blocks the default temp root.

## Problem
With `$ErrorActionPreference = "Stop"`, PowerShell 5.1 can turn stderr redirected through `2>&1` from native pip into a terminating `NativeCommandError` before the installer checks `$LASTEXITCODE`. Separately, the installer advertised `APM_TEMP_DIR` as the policy-friendly staging override but still built the download staging directory from `[System.IO.Path]::GetTempPath()`.

## Fix
Inside `Install-ViaPip`, save the current `$ErrorActionPreference`, set it to `"Continue"` only while invoking native pip, then restore it in `finally`. For download staging, resolve `APM_TEMP_DIR` when set, create the staging root, and emit actionable path-specific guidance if the staging root or installer directories cannot be prepared.

## How to test
- `uv run --extra dev pytest tests/unit/test_enterprise_bootstrap_installers.py -q`
- Mutation-break gate: removed the scoped pip ErrorAction guard and confirmed `test_windows_pip_fallback_scopes_native_stderr_error_action_guard` fails, then restored it.
- Mutation-break gate: changed staging back to `[System.IO.Path]::GetTempPath()` and confirmed `test_windows_installer_honors_apm_temp_dir_for_download_staging` fails, then restored it.
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/`
- `bash scripts/lint-auth-signals.sh`

closes #1874