### PR TITLE
[codex] Share target help fragments

### DIFF
--- a/src/apm_cli/commands/compile/cli.py
+++ b/src/apm_cli/commands/compile/cli.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 from ...compilation import AgentsCompiler, CompilationConfig
 from ...constants import AGENTS_MD_FILENAME, APM_DIR, APM_MODULES_DIR, APM_YML_FILENAME
 from ...core.command_logger import CommandLogger
-from ...core.target_detection import TargetParamType
+from ...core.target_detection import TARGET_HELP_DETAILS, TargetParamType
 from ...primitives.discovery import clear_discovery_cache, discover_primitives
 from ...utils import perf_stats
 from ...utils.console import (
@@ -890,7 +890,10 @@ def _run_compilation(
     "-t",
     type=TargetParamType(),
     default=None,
-    help="Target platform (comma-separated). Values: copilot, claude, cursor, opencode, codex, gemini, antigravity, windsurf, kiro, agent-skills, all. 'agent-skills' deploys to .agents/skills/ (cross-client). 'antigravity' (alias 'agy') deploys to .agents/ and is explicit-only -- not part of 'all'. 'all' = copilot+claude+cursor+opencode+codex+gemini+windsurf+kiro (excludes agent-skills and antigravity); combine with 'agent-skills' or 'antigravity' to add them.",
+    help=(
+        f"Target platform (comma-separated). {TARGET_HELP_DETAILS} "
+        "For compile, '--target all' is deprecated; use '--all' instead."
+    ),
 )
 @click.option(
     "--dry-run",

--- a/src/apm_cli/commands/deps/cli.py
+++ b/src/apm_cli/commands/deps/cli.py
@@ -9,7 +9,7 @@ import click
 # Import existing APM components
 from ...constants import APM_MODULES_DIR, APM_YML_FILENAME, SKILL_MD_FILENAME
 from ...core.command_logger import CommandLogger
-from ...core.target_detection import TargetParamType
+from ...core.target_detection import TARGET_HELP_DETAILS, TargetParamType
 from ...models.apm_package import APMPackage
 from .._helpers import (
     UnknownPackageError,
@@ -733,7 +733,11 @@ def clean(dry_run: bool, yes: bool):
     "-t",
     type=TargetParamType(),
     default=None,
-    help="Target platform (comma-separated). Values: copilot, claude, cursor, opencode, codex, gemini, antigravity, windsurf, kiro, agent-skills, all. 'agent-skills' deploys to .agents/skills/ (cross-client). 'antigravity' (alias 'agy') deploys to .agents/ and is explicit-only -- not part of 'all'. 'all' = copilot+claude+cursor+opencode+codex+gemini+windsurf+kiro (excludes agent-skills and antigravity); combine with 'agent-skills' or 'antigravity' to add them. 'copilot-cowork' is also accepted when the copilot-cowork experimental flag is enabled (run 'apm experimental enable copilot-cowork').",
+    help=(
+        f"Target platform (comma-separated). {TARGET_HELP_DETAILS} "
+        "'copilot-cowork' is also accepted when the copilot-cowork experimental "
+        "flag is enabled (run 'apm experimental enable copilot-cowork')."
+    ),
 )
 @click.option(
     "--parallel-downloads",

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -97,7 +97,11 @@ from ..constants import (
 )
 from ..core.auth import AuthResolver
 from ..core.command_logger import InstallLogger, _ValidationOutcome
-from ..core.target_detection import TargetParamType, manifest_targets_from_target_option
+from ..core.target_detection import (
+    TARGET_HELP_DETAILS,
+    TargetParamType,
+    manifest_targets_from_target_option,
+)
 
 # MCP --mcp helpers (module-level re-exports for test patches); must stay at
 # import time per comments in the original mid-file block.
@@ -942,7 +946,20 @@ def _handle_mcp_install(
     "target",
     type=TargetParamType(),
     default=None,
-    help="Target harness(es) to deploy to. Comma-separated for multiple: --target claude,cursor. Repeating the flag (e.g. '-t a -t b') is NOT supported -- only the last value wins; use commas. Highest-priority entry in the resolution chain (--target > apm.yml targets: > apm config target > auto-detect). Values: copilot, claude, cursor, opencode, codex, gemini, antigravity, windsurf, kiro, agent-skills, all. 'agent-skills' deploys to .agents/skills/ (cross-client). 'antigravity' (alias 'agy') deploys to .agents/ (AGENTS.md + rules + skills + hooks.json + mcp_config.json) and is explicit-only -- not part of 'all' or auto-detection. 'all' = copilot+claude+cursor+opencode+codex+gemini+windsurf+kiro (excludes agent-skills and antigravity); combine with 'agent-skills' or 'antigravity' to add them. 'copilot-cowork' is also accepted when the copilot-cowork experimental flag is enabled (run 'apm experimental enable copilot-cowork'). 'copilot-app' is also accepted when the copilot-app experimental flag is enabled (run 'apm experimental enable copilot-app'). Note: '--target all' on 'apm compile' is deprecated; use 'apm compile --all' instead.",
+    help=(
+        "Target harness(es) to deploy to. Comma-separated for multiple: "
+        "--target claude,cursor. Repeating the flag (e.g. '-t a -t b') is "
+        "NOT supported -- only the last value wins; use commas. Highest-priority "
+        "entry in the resolution chain "
+        "(--target > apm.yml targets: > apm config target > auto-detect). "
+        f"{TARGET_HELP_DETAILS} "
+        "'copilot-cowork' is also accepted when the copilot-cowork experimental "
+        "flag is enabled (run 'apm experimental enable copilot-cowork'). "
+        "'copilot-app' is also accepted when the copilot-app experimental flag "
+        "is enabled (run 'apm experimental enable copilot-app'). Note: "
+        "'--target all' on 'apm compile' is deprecated; use 'apm compile --all' "
+        "instead."
+    ),
 )
 @click.option(
     "--allow-insecure",

--- a/src/apm_cli/commands/update.py
+++ b/src/apm_cli/commands/update.py
@@ -60,7 +60,7 @@ from git.exc import GitCommandError
 
 from ..core.auth import AuthResolver
 from ..core.command_logger import InstallLogger
-from ..core.target_detection import TargetParamType
+from ..core.target_detection import TARGET_HELP_EXAMPLE_CSV, TargetParamType
 from ..deps.github_downloader import GitHubPackageDownloader
 from ..deps.revision_pins import (
     RemoteRefDownloader,
@@ -252,7 +252,7 @@ def _annotate_lockfile_revision_tags(project_root: Path, updates: list[RevisionP
     default=None,
     help=(
         "Agent target(s) to update for "
-        "(e.g. claude, copilot, cursor, windsurf, kiro, codex, opencode, gemini). "
+        f"(e.g. {TARGET_HELP_EXAMPLE_CSV}). "
         "Comma-separated for multiple: --target claude,cursor. "
         "Highest-priority entry in the resolution chain "
         "(--target > apm.yml targets: > auto-detect)."

--- a/src/apm_cli/core/target_detection.py
+++ b/src/apm_cli/core/target_detection.py
@@ -727,12 +727,28 @@ CANONICAL_TARGETS_ORDERED: list[str] = [
     "claude",
     "copilot",
     "cursor",
-    "codex",
-    "gemini",
-    "opencode",
     "windsurf",
     "kiro",
+    "codex",
+    "opencode",
+    "gemini",
 ]
+
+TARGET_HELP_EXAMPLE_CSV = ", ".join(CANONICAL_TARGETS_ORDERED)
+TARGET_HELP_VALUES_CSV = ", ".join(
+    [*CANONICAL_TARGETS_ORDERED, "antigravity", "agent-skills", "all"]
+)
+TARGET_ALL_HELP_EXPANSION = "+".join(CANONICAL_TARGETS_ORDERED)
+TARGET_HELP_DETAILS = (
+    f"Values: {TARGET_HELP_VALUES_CSV}. "
+    "'agent-skills' deploys to .agents/skills/ (cross-client). "
+    "'antigravity' (alias 'agy') deploys to .agents/ "
+    "(AGENTS.md + rules + skills + hooks.json + mcp_config.json) "
+    "and is explicit-only -- not part of 'all' or auto-detection. "
+    f"'all' = {TARGET_ALL_HELP_EXPANSION} "
+    "(excludes agent-skills and antigravity); combine with 'agent-skills' "
+    "or 'antigravity' to add them."
+)
 
 # Canonical deploy directories for each target.
 CANONICAL_DEPLOY_DIRS: dict[str, str] = {

--- a/tests/unit/test_cli_consistency.py
+++ b/tests/unit/test_cli_consistency.py
@@ -6,6 +6,11 @@ import click
 from click.testing import CliRunner
 
 from apm_cli.cli import cli
+from apm_cli.core.target_detection import (
+    TARGET_ALL_HELP_EXPANSION,
+    TARGET_HELP_EXAMPLE_CSV,
+    TARGET_HELP_VALUES_CSV,
+)
 from apm_cli.output.script_formatters import ScriptExecutionFormatter
 
 
@@ -16,6 +21,17 @@ def _walk_commands(group: click.Group, prefix: tuple[str, ...] = ()):
         yield path, cmd
         if isinstance(cmd, click.Group):
             yield from _walk_commands(cmd, path)
+
+
+def _option_help(path: tuple[str, ...], option_name: str) -> str:
+    command: click.Command = cli
+    for name in path:
+        assert isinstance(command, click.Group)
+        command = command.commands[name]
+    for param in command.params:
+        if isinstance(param, click.Option) and option_name in param.opts:
+            return param.help or ""
+    raise AssertionError(f"{' '.join(path)} is missing {option_name}")
 
 
 def test_every_registered_command_has_explicit_help():
@@ -117,6 +133,23 @@ def test_mcp_install_forwards_unknown_options_before_double_dash():
 
     assert result.exit_code == 0
     assert "would add MCP server 'myserver'" in result.output
+
+
+def test_target_help_uses_shared_display_fragments():
+    """Keep target help examples aligned with target_detection.py."""
+    for path in (("install",), ("compile",), ("deps", "update")):
+        help_text = _option_help(path, "--target")
+        assert TARGET_HELP_VALUES_CSV in help_text
+        assert TARGET_ALL_HELP_EXPANSION in help_text
+
+    install_help = _option_help(("install",), "--target")
+    assert "apm config target" in install_help
+
+    compile_help = _option_help(("compile",), "--target")
+    assert "'--target all' is deprecated; use '--all' instead" in compile_help
+
+    update_help = _option_help(("update",), "--target")
+    assert TARGET_HELP_EXAMPLE_CSV in update_help
 
 
 def test_pack_unpack_dry_run_help_has_no_trailing_period():


### PR DESCRIPTION
## Summary
- add shared target-help display fragments next to the target parser constants
- reuse those fragments in install, compile, deps update, and update help text
- keep command-specific guidance intact: install still documents `apm config target`, and compile still nudges users from deprecated `--target all` to `--all`
- pin the shared fragments with CLI consistency coverage

## Context
Follow-up to #1821 and the review-panel observation that target help examples are maintained independently across commands. This keeps the visible target list and `all` expansion aligned with the canonical display order while preserving the newer install fallback chain wording from main and compile's `--all` deprecation UX.

## Testing
- `.venv/Scripts/python.exe -m pytest tests/unit/test_cli_consistency.py tests/unit/test_update_command.py::TestUpdateCommandLogic::test_dependency_update_help_lists_kiro_target_example tests/unit/core/test_target_detection.py::TestTargetParamType tests/unit/core/test_target_resolution_v2.py -q` (96 passed)
- `.venv/Scripts/python.exe -m pytest tests/unit/commands/test_update_command.py -q` (53 passed)
- `.venv/Scripts/ruff.exe check src/apm_cli/commands/compile/cli.py src/apm_cli/commands/deps/cli.py src/apm_cli/commands/install.py src/apm_cli/commands/update.py src/apm_cli/core/target_detection.py tests/unit/test_cli_consistency.py`
- `.venv/Scripts/ruff.exe format --check src/apm_cli/commands/compile/cli.py src/apm_cli/commands/deps/cli.py src/apm_cli/commands/install.py src/apm_cli/commands/update.py src/apm_cli/core/target_detection.py tests/unit/test_cli_consistency.py`
- `git diff --check origin/main..HEAD`
