### PR TITLE
ci(runtime): make live-inference smoke honestly non-blocking

### DIFF
--- a/.github/workflows/ci-runtime.yml
+++ b/.github/workflows/ci-runtime.yml
@@ -70,6 +70,8 @@ jobs:
         run: uv run pytest tests/integration/test_runtime_smoke.py -v
 
       - name: Run inference validation
+        id: inference
+        continue-on-error: true
         env:
           APM_RUN_INFERENCE_TESTS: "1"
           APM_E2E_TESTS: "1"
@@ -83,8 +85,16 @@ jobs:
       - name: Annotate result
         if: always()
         run: |
-          if [[ "${{ job.status }}" == "success" ]]; then
-            echo "::notice::✅ Runtime inference tests passed"
+          # The inference validation step is a non-blocking live-inference
+          # smoke (it exercises `apm run` against GitHub Models). It is
+          # decoupled from the release gate on purpose: live inference depends
+          # on a Copilot-entitled credential and a GitHub Models-compatible
+          # runtime, neither of which is guaranteed in CI (see apm#605: codex
+          # >= v0.116 is incompatible with GitHub Models). Read the step's own
+          # outcome rather than job.status so this annotation is truthful even
+          # though continue-on-error keeps the job green.
+          if [[ "${{ steps.inference.outcome }}" == "success" ]]; then
+            echo "::notice::Runtime inference smoke passed"
           else
-            echo "::warning::⚠️ Runtime inference tests failed — this does not block releases"
+            echo "::warning::Runtime inference smoke failed -- non-blocking. Known causes: the CI token is not a Copilot-entitled credential for live inference, and codex >= v0.116 is incompatible with GitHub Models (apm#605). This does NOT gate releases."
           fi


### PR DESCRIPTION
## TL;DR

The nightly `Live Inference Smoke` job in `ci-runtime.yml` hard-failed on `main` every night even though its own annotation says the result "does not block releases." This makes the step honestly non-blocking so the daily false-red stops, while keeping the real gate intact.

## Problem (WHY)

`ci-runtime.yml`'s `Run inference validation` step had **no `continue-on-error`**, so its `exit 1` reddened the whole job. The very next step (`Annotate result`) emitted `"... this does not block releases"` — purely cosmetic. The documented intent and the actual gate **disagreed**, producing a persistent, misleading red on `main`.

The live-inference hero scenarios behind that step exercise `apm run` against **GitHub Models** and require:
- a **Copilot-entitled** credential for the launched runtime, and
- a GitHub Models-**compatible** runtime — codex `>= v0.116` is incompatible with GitHub Models (`/responses` 404s), see apm#605.

Neither is guaranteed in CI, so these tests are a **smoke signal**, not a release gate.

## Approach (WHAT)

- Add `id: inference` + `continue-on-error: true` to the `Run inference validation` step.
- Rewrite `Annotate result` to read `steps.inference.outcome` (not `job.status`) so the annotation stays **truthful** (it still reports the real failure) while the job goes **green-with-warning**.
- Document the known causes inline in the annotation.

The real gate — `Run smoke tests` (pytest, `tests/integration/test_runtime_smoke.py`) — stays blocking and is unaffected.

## Scope notes

- This is the **Thing B** half of a broader CI reliability sweep. The separate, genuine compatibility break (`apm pack` now defaults `--archive` to `.zip`, which the GH-AW Compatibility job's `microsoft/apm-action` consumer didn't detect) is fixed independently in **microsoft/apm-action#49**.
- No source or test code changes; workflow-only.

## How to test

- Trigger `ci-runtime.yml` via `workflow_dispatch`. With a non-entitled CI token the inference step will fail, but the **job concludes green** and surfaces a `::warning::` annotation naming the known causes. The pytest smoke step still gates as before.