### PR TITLE
ci: bump apm-action pin to v1.10.0 + pack-format drift trap

### DIFF
--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -40,10 +40,10 @@
       "version": "v0.80.9",
       "sha": "8c7d04ebf1ece56cd381446125da3e0f6896294a"
     },
-    "microsoft/apm-action@v1.7.2": {
+    "microsoft/apm-action@v1.10.0": {
       "repo": "microsoft/apm-action",
-      "version": "v1.7.2",
-      "sha": "b48dd081eb0050f6d7f32d0e7caa0a59a2d419fd"
+      "version": "v1.10.0",
+      "sha": "d723bb64ed70c135bbaf87d126b721dd2dae0439"
     }
   }
 }

--- a/.github/workflows/docs-sync.lock.yml
+++ b/.github/workflows/docs-sync.lock.yml
@@ -505,7 +505,7 @@ jobs:
       - name: Restore APM packages (all bundles)
         uses: microsoft/apm-action@d723bb64ed70c135bbaf87d126b721dd2dae0439 # v1.10.0
         with:
-          apm-version: 0.14.0
+          apm-version: 0.21.0
           bundles-file: /tmp/gh-aw/apm-bundle-list.txt
 
       - name: Checkout PR branch
@@ -1157,7 +1157,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token || secrets.GH_AW_PLUGINS_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         with:
-          apm-version: 0.14.0
+          apm-version: 0.21.0
           archive: "true"
           dependencies: ${{ steps.list.outputs.deps }}
           isolated: "true"

--- a/.github/workflows/docs-sync.lock.yml
+++ b/.github/workflows/docs-sync.lock.yml
@@ -1,5 +1,5 @@
 # gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"289fa02cf3ae69ffb9040564cff8dcdb4395ea1b60c43caaee3d5e33ba250057","body_hash":"188c85a7c33e1b343610b87023cd534610d331532b30085073c832eaa3915665","compiler_version":"v0.80.9","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.63"}}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_PLUGINS_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","version":"v7.0.0"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"8c7d04ebf1ece56cd381446125da3e0f6896294a","version":"v0.80.9"},{"repo":"microsoft/apm-action","sha":"b48dd081eb0050f6d7f32d0e7caa0a59a2d419fd","version":"v1.7.2"},{"repo":"ruby/setup-ruby","sha":"89f90524b88a01fe6e0b732220432cc6142926af","version":"v1.313.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.7","digest":"sha256:aae231e4635c8999d039c132f1602d3df850fe9b84a00aa2b5ac981179b5661c","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.7@sha256:aae231e4635c8999d039c132f1602d3df850fe9b84a00aa2b5ac981179b5661c"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.7","digest":"sha256:009caf2e3d88fa77b64e9a03a95a228fc58db0f1701c6d324b29ba5a3c7c79b6","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.7@sha256:009caf2e3d88fa77b64e9a03a95a228fc58db0f1701c6d324b29ba5a3c7c79b6"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.7","digest":"sha256:deb1d4e19de62d51cee0508057a596a19315c3423ada4d675cad136dc8037c96","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.7@sha256:deb1d4e19de62d51cee0508057a596a19315c3423ada4d675cad136dc8037c96"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.27","digest":"sha256:fe984bddde4ec05d756d9043edb0a32912e6b7b72f6a121b1082f29221421cc7","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.27@sha256:fe984bddde4ec05d756d9043edb0a32912e6b7b72f6a121b1082f29221421cc7"},{"image":"ghcr.io/github/gh-aw-node","digest":"sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b","pinned_image":"ghcr.io/github/gh-aw-node@sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b"},{"image":"ghcr.io/github/github-mcp-server:v1.4.0","digest":"sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036","pinned_image":"ghcr.io/github/github-mcp-server:v1.4.0@sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036"}]}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_PLUGINS_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","version":"v7.0.0"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"8c7d04ebf1ece56cd381446125da3e0f6896294a","version":"v0.80.9"},{"repo":"microsoft/apm-action","sha":"d723bb64ed70c135bbaf87d126b721dd2dae0439","version":"v1.10.0"},{"repo":"ruby/setup-ruby","sha":"89f90524b88a01fe6e0b732220432cc6142926af","version":"v1.313.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.7","digest":"sha256:aae231e4635c8999d039c132f1602d3df850fe9b84a00aa2b5ac981179b5661c","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.7@sha256:aae231e4635c8999d039c132f1602d3df850fe9b84a00aa2b5ac981179b5661c"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.7","digest":"sha256:009caf2e3d88fa77b64e9a03a95a228fc58db0f1701c6d324b29ba5a3c7c79b6","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.7@sha256:009caf2e3d88fa77b64e9a03a95a228fc58db0f1701c6d324b29ba5a3c7c79b6"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.7","digest":"sha256:deb1d4e19de62d51cee0508057a596a19315c3423ada4d675cad136dc8037c96","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.7@sha256:deb1d4e19de62d51cee0508057a596a19315c3423ada4d675cad136dc8037c96"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.27","digest":"sha256:fe984bddde4ec05d756d9043edb0a32912e6b7b72f6a121b1082f29221421cc7","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.27@sha256:fe984bddde4ec05d756d9043edb0a32912e6b7b72f6a121b1082f29221421cc7"},{"image":"ghcr.io/github/gh-aw-node","digest":"sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b","pinned_image":"ghcr.io/github/gh-aw-node@sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b"},{"image":"ghcr.io/github/github-mcp-server:v1.4.0","digest":"sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036","pinned_image":"ghcr.io/github/github-mcp-server:v1.4.0@sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036"}]}
 # This file was automatically generated by gh-aw (v0.80.9). DO NOT EDIT. To debug this workflow, load the skill at https://github.com/github/gh-aw/blob/main/debug.md
 #
 #    ___                   _   _      
@@ -48,7 +48,7 @@
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1 (source v7)
 #   - github/gh-aw-actions/setup@8c7d04ebf1ece56cd381446125da3e0f6896294a # v0.80.9
-#   - microsoft/apm-action@b48dd081eb0050f6d7f32d0e7caa0a59a2d419fd # v1.7.2
+#   - microsoft/apm-action@d723bb64ed70c135bbaf87d126b721dd2dae0439 # v1.10.0
 #   - ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
 #
 # Container images used:
@@ -503,9 +503,9 @@ jobs:
         name: Build bundle list
         run: "set -euo pipefail\nmapfile -t list < <(find /tmp/gh-aw/apm-bundles -name '*.tar.gz' | sort)\n[ ${#list[@]} -gt 0 ] || { echo '::error::no apm bundles found'; exit 1; }\nprintf '%s\\n' \"${list[@]}\" > /tmp/gh-aw/apm-bundle-list.txt\n"
       - name: Restore APM packages (all bundles)
-        uses: microsoft/apm-action@b48dd081eb0050f6d7f32d0e7caa0a59a2d419fd # v1.7.2
+        uses: microsoft/apm-action@d723bb64ed70c135bbaf87d126b721dd2dae0439 # v1.10.0
         with:
-          apm-version: 0.12.4
+          apm-version: 0.14.0
           bundles-file: /tmp/gh-aw/apm-bundle-list.txt
 
       - name: Checkout PR branch
@@ -1153,11 +1153,11 @@ jobs:
           AW_PKG: ${{ toJSON(matrix.group.packages) }}
       - name: Pack APM packages
         id: pack
-        uses: microsoft/apm-action@b48dd081eb0050f6d7f32d0e7caa0a59a2d419fd # v1.7.2
+        uses: microsoft/apm-action@d723bb64ed70c135bbaf87d126b721dd2dae0439 # v1.10.0
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token || secrets.GH_AW_PLUGINS_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         with:
-          apm-version: 0.12.4
+          apm-version: 0.14.0
           archive: "true"
           dependencies: ${{ steps.list.outputs.deps }}
           isolated: "true"

--- a/.github/workflows/docs-sync.lock.yml
+++ b/.github/workflows/docs-sync.lock.yml
@@ -501,7 +501,7 @@ jobs:
         run: "set -euo pipefail\nexpected=$(echo \"$EXPECTED_MATRIX\" | jq -r --arg prefix \"$ARTIFACT_PREFIX\" '.group | map($prefix + \"apm-\" + .id) | sort | .[]')\nactual=$(ls /tmp/gh-aw/apm-bundles | sort)\nmissing=$(comm -23 <(echo \"$expected\") <(echo \"$actual\") || true)\nunexpected=$(comm -13 <(echo \"$expected\") <(echo \"$actual\") || true)\nif [ -n \"$missing\" ]; then\n  echo \"::error::missing APM bundles (group did not pack successfully): $missing\"\n  exit 1\nfi\nif [ -n \"$unexpected\" ]; then\n  echo \"::error::unexpected artifact in apm bundle download (collision attack?): $unexpected\"\n  exit 1\nfi\n"
       - id: bundles
         name: Build bundle list
-        run: "set -euo pipefail\nmapfile -t list < <(find /tmp/gh-aw/apm-bundles -name '*.tar.gz' | sort)\n[ ${#list[@]} -gt 0 ] || { echo '::error::no apm bundles found'; exit 1; }\nprintf '%s\\n' \"${list[@]}\" > /tmp/gh-aw/apm-bundle-list.txt\n"
+        run: "set -euo pipefail\nmapfile -t list < <(find /tmp/gh-aw/apm-bundles \\( -name '*.tar.gz' -o -name '*.zip' \\) | sort)\n[ ${#list[@]} -gt 0 ] || { echo '::error::no apm bundles found'; exit 1; }\nprintf '%s\\n' \"${list[@]}\" > /tmp/gh-aw/apm-bundle-list.txt\n"
       - name: Restore APM packages (all bundles)
         uses: microsoft/apm-action@d723bb64ed70c135bbaf87d126b721dd2dae0439 # v1.10.0
         with:

--- a/.github/workflows/pr-review-panel.lock.yml
+++ b/.github/workflows/pr-review-panel.lock.yml
@@ -505,7 +505,7 @@ jobs:
         run: "set -euo pipefail\nexpected=$(echo \"$EXPECTED_MATRIX\" | jq -r --arg prefix \"$ARTIFACT_PREFIX\" '.group | map($prefix + \"apm-\" + .id) | sort | .[]')\nactual=$(ls /tmp/gh-aw/apm-bundles | sort)\nmissing=$(comm -23 <(echo \"$expected\") <(echo \"$actual\") || true)\nunexpected=$(comm -13 <(echo \"$expected\") <(echo \"$actual\") || true)\nif [ -n \"$missing\" ]; then\n  echo \"::error::missing APM bundles (group did not pack successfully): $missing\"\n  exit 1\nfi\nif [ -n \"$unexpected\" ]; then\n  echo \"::error::unexpected artifact in apm bundle download (collision attack?): $unexpected\"\n  exit 1\nfi\n"
       - id: bundles
         name: Build bundle list
-        run: "set -euo pipefail\nmapfile -t list < <(find /tmp/gh-aw/apm-bundles -name '*.tar.gz' | sort)\n[ ${#list[@]} -gt 0 ] || { echo '::error::no apm bundles found'; exit 1; }\nprintf '%s\\n' \"${list[@]}\" > /tmp/gh-aw/apm-bundle-list.txt\n"
+        run: "set -euo pipefail\nmapfile -t list < <(find /tmp/gh-aw/apm-bundles \\( -name '*.tar.gz' -o -name '*.zip' \\) | sort)\n[ ${#list[@]} -gt 0 ] || { echo '::error::no apm bundles found'; exit 1; }\nprintf '%s\\n' \"${list[@]}\" > /tmp/gh-aw/apm-bundle-list.txt\n"
       - name: Restore APM packages (all bundles)
         uses: microsoft/apm-action@d723bb64ed70c135bbaf87d126b721dd2dae0439 # v1.10.0
         with:

--- a/.github/workflows/pr-review-panel.lock.yml
+++ b/.github/workflows/pr-review-panel.lock.yml
@@ -509,7 +509,7 @@ jobs:
       - name: Restore APM packages (all bundles)
         uses: microsoft/apm-action@d723bb64ed70c135bbaf87d126b721dd2dae0439 # v1.10.0
         with:
-          apm-version: 0.14.0
+          apm-version: 0.21.0
           bundles-file: /tmp/gh-aw/apm-bundle-list.txt
 
       - name: Configure Git credentials
@@ -1173,7 +1173,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token || secrets.GH_AW_PLUGINS_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         with:
-          apm-version: 0.14.0
+          apm-version: 0.21.0
           archive: "true"
           dependencies: ${{ steps.list.outputs.deps }}
           isolated: "true"

--- a/.github/workflows/pr-review-panel.lock.yml
+++ b/.github/workflows/pr-review-panel.lock.yml
@@ -1,5 +1,5 @@
 # gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"4a06fd901b372b5713e3f00c8142307c6322a44f148a5bc8708bee96af8a32f8","body_hash":"d79e2f7249237ae5be812ffeabd1c54f0cbdb4366176ae11d978ee064937a2ff","compiler_version":"v0.80.9","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.63"}}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_PLUGINS_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","version":"v7.0.0"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"8c7d04ebf1ece56cd381446125da3e0f6896294a","version":"v0.80.9"},{"repo":"microsoft/apm-action","sha":"b48dd081eb0050f6d7f32d0e7caa0a59a2d419fd","version":"v1.7.2"},{"repo":"ruby/setup-ruby","sha":"89f90524b88a01fe6e0b732220432cc6142926af","version":"v1.313.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.7","digest":"sha256:aae231e4635c8999d039c132f1602d3df850fe9b84a00aa2b5ac981179b5661c","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.7@sha256:aae231e4635c8999d039c132f1602d3df850fe9b84a00aa2b5ac981179b5661c"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.7","digest":"sha256:009caf2e3d88fa77b64e9a03a95a228fc58db0f1701c6d324b29ba5a3c7c79b6","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.7@sha256:009caf2e3d88fa77b64e9a03a95a228fc58db0f1701c6d324b29ba5a3c7c79b6"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.7","digest":"sha256:deb1d4e19de62d51cee0508057a596a19315c3423ada4d675cad136dc8037c96","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.7@sha256:deb1d4e19de62d51cee0508057a596a19315c3423ada4d675cad136dc8037c96"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.27","digest":"sha256:fe984bddde4ec05d756d9043edb0a32912e6b7b72f6a121b1082f29221421cc7","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.27@sha256:fe984bddde4ec05d756d9043edb0a32912e6b7b72f6a121b1082f29221421cc7"},{"image":"ghcr.io/github/gh-aw-node","digest":"sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b","pinned_image":"ghcr.io/github/gh-aw-node@sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b"},{"image":"ghcr.io/github/github-mcp-server:v1.4.0","digest":"sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036","pinned_image":"ghcr.io/github/github-mcp-server:v1.4.0@sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036"}]}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_PLUGINS_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","version":"v7.0.0"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"8c7d04ebf1ece56cd381446125da3e0f6896294a","version":"v0.80.9"},{"repo":"microsoft/apm-action","sha":"d723bb64ed70c135bbaf87d126b721dd2dae0439","version":"v1.10.0"},{"repo":"ruby/setup-ruby","sha":"89f90524b88a01fe6e0b732220432cc6142926af","version":"v1.313.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.7","digest":"sha256:aae231e4635c8999d039c132f1602d3df850fe9b84a00aa2b5ac981179b5661c","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.7@sha256:aae231e4635c8999d039c132f1602d3df850fe9b84a00aa2b5ac981179b5661c"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.7","digest":"sha256:009caf2e3d88fa77b64e9a03a95a228fc58db0f1701c6d324b29ba5a3c7c79b6","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.7@sha256:009caf2e3d88fa77b64e9a03a95a228fc58db0f1701c6d324b29ba5a3c7c79b6"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.7","digest":"sha256:deb1d4e19de62d51cee0508057a596a19315c3423ada4d675cad136dc8037c96","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.7@sha256:deb1d4e19de62d51cee0508057a596a19315c3423ada4d675cad136dc8037c96"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.27","digest":"sha256:fe984bddde4ec05d756d9043edb0a32912e6b7b72f6a121b1082f29221421cc7","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.27@sha256:fe984bddde4ec05d756d9043edb0a32912e6b7b72f6a121b1082f29221421cc7"},{"image":"ghcr.io/github/gh-aw-node","digest":"sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b","pinned_image":"ghcr.io/github/gh-aw-node@sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b"},{"image":"ghcr.io/github/github-mcp-server:v1.4.0","digest":"sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036","pinned_image":"ghcr.io/github/github-mcp-server:v1.4.0@sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036"}]}
 # This file was automatically generated by gh-aw (v0.80.9). DO NOT EDIT. To debug this workflow, load the skill at https://github.com/github/gh-aw/blob/main/debug.md
 #
 #    ___                   _   _      
@@ -48,7 +48,7 @@
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1 (source v7)
 #   - github/gh-aw-actions/setup@8c7d04ebf1ece56cd381446125da3e0f6896294a # v0.80.9
-#   - microsoft/apm-action@b48dd081eb0050f6d7f32d0e7caa0a59a2d419fd # v1.7.2
+#   - microsoft/apm-action@d723bb64ed70c135bbaf87d126b721dd2dae0439 # v1.10.0
 #   - ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
 #
 # Container images used:
@@ -507,9 +507,9 @@ jobs:
         name: Build bundle list
         run: "set -euo pipefail\nmapfile -t list < <(find /tmp/gh-aw/apm-bundles -name '*.tar.gz' | sort)\n[ ${#list[@]} -gt 0 ] || { echo '::error::no apm bundles found'; exit 1; }\nprintf '%s\\n' \"${list[@]}\" > /tmp/gh-aw/apm-bundle-list.txt\n"
       - name: Restore APM packages (all bundles)
-        uses: microsoft/apm-action@b48dd081eb0050f6d7f32d0e7caa0a59a2d419fd # v1.7.2
+        uses: microsoft/apm-action@d723bb64ed70c135bbaf87d126b721dd2dae0439 # v1.10.0
         with:
-          apm-version: 0.12.4
+          apm-version: 0.14.0
           bundles-file: /tmp/gh-aw/apm-bundle-list.txt
 
       - name: Configure Git credentials
@@ -1169,11 +1169,11 @@ jobs:
           AW_PKG: ${{ toJSON(matrix.group.packages) }}
       - name: Pack APM packages
         id: pack
-        uses: microsoft/apm-action@b48dd081eb0050f6d7f32d0e7caa0a59a2d419fd # v1.7.2
+        uses: microsoft/apm-action@d723bb64ed70c135bbaf87d126b721dd2dae0439 # v1.10.0
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token || secrets.GH_AW_PLUGINS_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         with:
-          apm-version: 0.12.4
+          apm-version: 0.14.0
           archive: "true"
           dependencies: ${{ steps.list.outputs.deps }}
           isolated: "true"

--- a/.github/workflows/shared/apm.md
+++ b/.github/workflows/shared/apm.md
@@ -473,7 +473,7 @@ steps:
     id: bundles
     run: |
       set -euo pipefail
-      mapfile -t list < <(find /tmp/gh-aw/apm-bundles -name '*.tar.gz' | sort)
+      mapfile -t list < <(find /tmp/gh-aw/apm-bundles \( -name '*.tar.gz' -o -name '*.zip' \) | sort)
       [ ${#list[@]} -gt 0 ] || { echo '::error::no apm bundles found'; exit 1; }
       printf '%s\n' "${list[@]}" > /tmp/gh-aw/apm-bundle-list.txt
   - name: Restore APM packages (all bundles)

--- a/.github/workflows/shared/apm.md
+++ b/.github/workflows/shared/apm.md
@@ -172,19 +172,24 @@ import-schema:
   apm-version:
     type: string
     required: false
-    # MAINTENANCE: this default MUST mirror the apm-version default shipped
-    # by the pinned microsoft/apm-action ref used in the Pack and Restore
-    # steps below. gh-aw substitutes this value at compile time when a
-    # consumer omits apm-version, so an empty string is never forwarded to
-    # apm-action (an empty apm-version floats the action to 'latest', the
-    # opposite of the pinned default). Bump this in lockstep with the action.
-    default: '0.14.0'
+    # MAINTENANCE: this is the apm CLI version gh-aw substitutes when a
+    # consumer omits apm-version. It is forwarded to BOTH the Pack and
+    # Restore steps below, so it alone decides the produced archive format
+    # (an empty string would float apm-action to 'latest' -- never emit
+    # one). It does NOT need to equal apm-action's own apm-version default:
+    # Pack and Restore receive this one value so the CLI cannot skew between
+    # them, and apm-action restores whatever format it detects. The binding
+    # contract (verify-shared-apm-matrix Job C) is that the format THIS
+    # version produces is in the pinned apm-action's detected set. Keep it on
+    # the repo's current CLI line so the default path exercises the shipped
+    # pack format.
+    default: '0.21.0'
     description: >
       apm CLI version for apm-action to install, as a bare semver tag (e.g.
-      '0.14.0'); pass 'latest' to opt into floating to the newest release.
-      Omit to use apm-action's pinned default. Applied to both the Pack and
-      Restore apm-action steps so the CLI version cannot skew between packing
-      and restoring.
+      '0.21.0'); pass 'latest' to opt into floating to the newest release.
+      Omit to use this workflow's pinned default. Applied to both the Pack
+      and Restore apm-action steps so the CLI version cannot skew between
+      packing and restoring.
 
 jobs:
   apm-prep:

--- a/.github/workflows/shared/apm.md
+++ b/.github/workflows/shared/apm.md
@@ -10,7 +10,7 @@
 # Pre-agent-steps then download all bundles and restore them in one apm-action call.
 #
 # Source of truth: https://github.com/microsoft/apm/blob/main/.github/workflows/shared/apm.md
-# apm-action pin:  microsoft/apm-action@v1.7.2
+# apm-action pin:  microsoft/apm-action@v1.10.0
 # To check whether a vendored copy is current, compare these two lines.
 #
 # Documentation: https://microsoft.github.io/apm/integrations/gh-aw/
@@ -178,10 +178,10 @@ import-schema:
     # consumer omits apm-version, so an empty string is never forwarded to
     # apm-action (an empty apm-version floats the action to 'latest', the
     # opposite of the pinned default). Bump this in lockstep with the action.
-    default: '0.12.4'
+    default: '0.14.0'
     description: >
       apm CLI version for apm-action to install, as a bare semver tag (e.g.
-      '0.12.4'); pass 'latest' to opt into floating to the newest release.
+      '0.14.0'); pass 'latest' to opt into floating to the newest release.
       Omit to use apm-action's pinned default. Applied to both the Pack and
       Restore apm-action steps so the CLI version cannot skew between packing
       and restoring.
@@ -394,7 +394,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
       - name: Pack APM packages
         id: pack
-        uses: microsoft/apm-action@v1.7.2
+        uses: microsoft/apm-action@v1.10.0
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token || secrets.GH_AW_PLUGINS_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         with:
@@ -477,7 +477,7 @@ steps:
       [ ${#list[@]} -gt 0 ] || { echo '::error::no apm bundles found'; exit 1; }
       printf '%s\n' "${list[@]}" > /tmp/gh-aw/apm-bundle-list.txt
   - name: Restore APM packages (all bundles)
-    uses: microsoft/apm-action@v1.7.2
+    uses: microsoft/apm-action@v1.10.0
     with:
       apm-version: ${{ github.aw.import-inputs.apm-version }}
       bundles-file: /tmp/gh-aw/apm-bundle-list.txt
@@ -491,7 +491,7 @@ in parallel one matrix replica per credential group, packs each group's packages
 with `microsoft/apm-action`, and uploads a per-group bundle artifact. The agent
 job's pre-agent-steps then download all bundles and restore them in a single
 `apm-action` invocation (using the `bundles-file:` input shipped in
-`microsoft/apm-action@v1.7.2`).
+`microsoft/apm-action@v1.10.0`).
 
 ### How it works
 
@@ -505,7 +505,7 @@ job's pre-agent-steps then download all bundles and restore them in a single
 3. **Restore** (agent pre-agent-steps): all `apm-*` artifacts are downloaded,
    validated against the matrix manifest (defends against same-run artifact-name
    collision attacks), and restored in one call via the `bundles-file:` input
-   on `microsoft/apm-action@v1.7.2`.
+   on `microsoft/apm-action@v1.10.0`.
 
 ### Authentication
 

--- a/.github/workflows/triage-panel.lock.yml
+++ b/.github/workflows/triage-panel.lock.yml
@@ -519,7 +519,7 @@ jobs:
       - name: Restore APM packages (all bundles)
         uses: microsoft/apm-action@d723bb64ed70c135bbaf87d126b721dd2dae0439 # v1.10.0
         with:
-          apm-version: 0.14.0
+          apm-version: 0.21.0
           bundles-file: /tmp/gh-aw/apm-bundle-list.txt
 
       - name: Configure Git credentials
@@ -1263,7 +1263,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token || secrets.GH_AW_PLUGINS_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         with:
-          apm-version: 0.14.0
+          apm-version: 0.21.0
           archive: "true"
           dependencies: ${{ steps.list.outputs.deps }}
           isolated: "true"

--- a/.github/workflows/triage-panel.lock.yml
+++ b/.github/workflows/triage-panel.lock.yml
@@ -515,7 +515,7 @@ jobs:
         run: "set -euo pipefail\nexpected=$(echo \"$EXPECTED_MATRIX\" | jq -r --arg prefix \"$ARTIFACT_PREFIX\" '.group | map($prefix + \"apm-\" + .id) | sort | .[]')\nactual=$(ls /tmp/gh-aw/apm-bundles | sort)\nmissing=$(comm -23 <(echo \"$expected\") <(echo \"$actual\") || true)\nunexpected=$(comm -13 <(echo \"$expected\") <(echo \"$actual\") || true)\nif [ -n \"$missing\" ]; then\n  echo \"::error::missing APM bundles (group did not pack successfully): $missing\"\n  exit 1\nfi\nif [ -n \"$unexpected\" ]; then\n  echo \"::error::unexpected artifact in apm bundle download (collision attack?): $unexpected\"\n  exit 1\nfi\n"
       - id: bundles
         name: Build bundle list
-        run: "set -euo pipefail\nmapfile -t list < <(find /tmp/gh-aw/apm-bundles -name '*.tar.gz' | sort)\n[ ${#list[@]} -gt 0 ] || { echo '::error::no apm bundles found'; exit 1; }\nprintf '%s\\n' \"${list[@]}\" > /tmp/gh-aw/apm-bundle-list.txt\n"
+        run: "set -euo pipefail\nmapfile -t list < <(find /tmp/gh-aw/apm-bundles \\( -name '*.tar.gz' -o -name '*.zip' \\) | sort)\n[ ${#list[@]} -gt 0 ] || { echo '::error::no apm bundles found'; exit 1; }\nprintf '%s\\n' \"${list[@]}\" > /tmp/gh-aw/apm-bundle-list.txt\n"
       - name: Restore APM packages (all bundles)
         uses: microsoft/apm-action@d723bb64ed70c135bbaf87d126b721dd2dae0439 # v1.10.0
         with:

--- a/.github/workflows/triage-panel.lock.yml
+++ b/.github/workflows/triage-panel.lock.yml
@@ -1,5 +1,5 @@
 # gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"81b598766ed96e8792d98abc5c3b63de6afc7129c129fba622aebd3159b05b6b","body_hash":"830c2609b0ebcec7a310810d8550606cb129d9d8fff2aa1bdcde0a0aa0a1f6a6","compiler_version":"v0.80.9","strict":true,"agent_id":"copilot","engine_versions":{"copilot":"1.0.63"}}
-# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_PLUGINS_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","version":"v7.0.0"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"8c7d04ebf1ece56cd381446125da3e0f6896294a","version":"v0.80.9"},{"repo":"microsoft/apm-action","sha":"b48dd081eb0050f6d7f32d0e7caa0a59a2d419fd","version":"v1.7.2"},{"repo":"ruby/setup-ruby","sha":"89f90524b88a01fe6e0b732220432cc6142926af","version":"v1.313.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.7","digest":"sha256:aae231e4635c8999d039c132f1602d3df850fe9b84a00aa2b5ac981179b5661c","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.7@sha256:aae231e4635c8999d039c132f1602d3df850fe9b84a00aa2b5ac981179b5661c"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.7","digest":"sha256:009caf2e3d88fa77b64e9a03a95a228fc58db0f1701c6d324b29ba5a3c7c79b6","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.7@sha256:009caf2e3d88fa77b64e9a03a95a228fc58db0f1701c6d324b29ba5a3c7c79b6"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.7","digest":"sha256:deb1d4e19de62d51cee0508057a596a19315c3423ada4d675cad136dc8037c96","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.7@sha256:deb1d4e19de62d51cee0508057a596a19315c3423ada4d675cad136dc8037c96"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.27","digest":"sha256:fe984bddde4ec05d756d9043edb0a32912e6b7b72f6a121b1082f29221421cc7","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.27@sha256:fe984bddde4ec05d756d9043edb0a32912e6b7b72f6a121b1082f29221421cc7"},{"image":"ghcr.io/github/gh-aw-node","digest":"sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b","pinned_image":"ghcr.io/github/gh-aw-node@sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b"},{"image":"ghcr.io/github/github-mcp-server:v1.4.0","digest":"sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036","pinned_image":"ghcr.io/github/github-mcp-server:v1.4.0@sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036"}]}
+# gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GH_AW_PLUGINS_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/cache/restore","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/cache/save","sha":"27d5ce7f107fe9357f9df03efb73ab90386fccae","version":"v5.0.5"},{"repo":"actions/checkout","sha":"9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0","version":"v7.0.0"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7"},{"repo":"github/gh-aw-actions/setup","sha":"8c7d04ebf1ece56cd381446125da3e0f6896294a","version":"v0.80.9"},{"repo":"microsoft/apm-action","sha":"d723bb64ed70c135bbaf87d126b721dd2dae0439","version":"v1.10.0"},{"repo":"ruby/setup-ruby","sha":"89f90524b88a01fe6e0b732220432cc6142926af","version":"v1.313.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.27.7","digest":"sha256:aae231e4635c8999d039c132f1602d3df850fe9b84a00aa2b5ac981179b5661c","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.27.7@sha256:aae231e4635c8999d039c132f1602d3df850fe9b84a00aa2b5ac981179b5661c"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.7","digest":"sha256:009caf2e3d88fa77b64e9a03a95a228fc58db0f1701c6d324b29ba5a3c7c79b6","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.27.7@sha256:009caf2e3d88fa77b64e9a03a95a228fc58db0f1701c6d324b29ba5a3c7c79b6"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.27.7","digest":"sha256:deb1d4e19de62d51cee0508057a596a19315c3423ada4d675cad136dc8037c96","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.27.7@sha256:deb1d4e19de62d51cee0508057a596a19315c3423ada4d675cad136dc8037c96"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.27","digest":"sha256:fe984bddde4ec05d756d9043edb0a32912e6b7b72f6a121b1082f29221421cc7","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.27@sha256:fe984bddde4ec05d756d9043edb0a32912e6b7b72f6a121b1082f29221421cc7"},{"image":"ghcr.io/github/gh-aw-node","digest":"sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b","pinned_image":"ghcr.io/github/gh-aw-node@sha256:529d02eb970b1161aa25c593a9c3df57fdfad5a8add328cb3b6eccef66f3183b"},{"image":"ghcr.io/github/github-mcp-server:v1.4.0","digest":"sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036","pinned_image":"ghcr.io/github/github-mcp-server:v1.4.0@sha256:2afb26356481d1a350e14544a6e160f7f7ec1561a1ea309b823665abf0309036"}]}
 # This file was automatically generated by gh-aw (v0.80.9). DO NOT EDIT. To debug this workflow, load the skill at https://github.com/github/gh-aw/blob/main/debug.md
 #
 #    ___                   _   _      
@@ -47,7 +47,7 @@
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1 (source v7)
 #   - github/gh-aw-actions/setup@8c7d04ebf1ece56cd381446125da3e0f6896294a # v0.80.9
-#   - microsoft/apm-action@b48dd081eb0050f6d7f32d0e7caa0a59a2d419fd # v1.7.2
+#   - microsoft/apm-action@d723bb64ed70c135bbaf87d126b721dd2dae0439 # v1.10.0
 #   - ruby/setup-ruby@89f90524b88a01fe6e0b732220432cc6142926af # v1.313.0
 #
 # Container images used:
@@ -517,9 +517,9 @@ jobs:
         name: Build bundle list
         run: "set -euo pipefail\nmapfile -t list < <(find /tmp/gh-aw/apm-bundles -name '*.tar.gz' | sort)\n[ ${#list[@]} -gt 0 ] || { echo '::error::no apm bundles found'; exit 1; }\nprintf '%s\\n' \"${list[@]}\" > /tmp/gh-aw/apm-bundle-list.txt\n"
       - name: Restore APM packages (all bundles)
-        uses: microsoft/apm-action@b48dd081eb0050f6d7f32d0e7caa0a59a2d419fd # v1.7.2
+        uses: microsoft/apm-action@d723bb64ed70c135bbaf87d126b721dd2dae0439 # v1.10.0
         with:
-          apm-version: 0.12.4
+          apm-version: 0.14.0
           bundles-file: /tmp/gh-aw/apm-bundle-list.txt
 
       - name: Configure Git credentials
@@ -1259,11 +1259,11 @@ jobs:
           AW_PKG: ${{ toJSON(matrix.group.packages) }}
       - name: Pack APM packages
         id: pack
-        uses: microsoft/apm-action@b48dd081eb0050f6d7f32d0e7caa0a59a2d419fd # v1.7.2
+        uses: microsoft/apm-action@d723bb64ed70c135bbaf87d126b721dd2dae0439 # v1.10.0
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token || secrets.GH_AW_PLUGINS_TOKEN || secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         with:
-          apm-version: 0.12.4
+          apm-version: 0.14.0
           archive: "true"
           dependencies: ${{ steps.list.outputs.deps }}
           isolated: "true"

--- a/.github/workflows/verify-shared-apm-matrix.yml
+++ b/.github/workflows/verify-shared-apm-matrix.yml
@@ -39,8 +39,10 @@ name: Verify shared/apm.md matrix secret-stripping fix
 #      Proves the `apm pack --archive` default archive format (.zip) stays
 #      inside the extension set the pinned microsoft/apm-action release
 #      detects when it scans the build dir for a bundle. Source of truth:
-#      src/apm_cli/bundle/packer.py (producer default) vs apm-action
-#      src/bundler.ts at the pinned ref (consumer detection). Fails on the
+#      src/apm_cli/commands/pack.py (the --archive-format Click default the
+#      CLI exposes and apm-action invokes) vs apm-action src/bundler.ts at the
+#      pinned ref (consumer detection); the bundle/packer.py dataclass default
+#      is asserted consistent. Fails on the
 #      'apm pack produced no bundle' outage shape -- the CLI default flipped
 #      from .tar.gz to .zip while apm-action still filtered only .tar.gz, so
 #      the GH-AW Compatibility job saw no bundle. Keep the CLI default in
@@ -411,26 +413,42 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          # 'apm pack --archive' defaults to .zip (packer.py). apm-action scans
-          # the build dir for an archive bundle by filtering on a fixed
-          # extension set. When the CLI default flipped from .tar.gz to .zip
-          # but apm-action still filtered only '.tar.gz', the GH-AW
-          # Compatibility job failed with 'apm pack produced no bundle'. This
-          # guard cross-references the two repos so the producer default can
-          # never silently drift out of the set the pinned apm-action release
-          # detects.
+          # 'apm pack --archive' defaults to .zip. apm-action scans the build
+          # dir for an archive bundle by filtering on a fixed extension set.
+          # When the CLI default flipped from .tar.gz to .zip but apm-action
+          # still filtered only '.tar.gz', the GH-AW Compatibility job failed
+          # with 'apm pack produced no bundle'. This guard cross-references the
+          # two repos so the producer default can never silently drift out of
+          # the set the pinned apm-action release detects.
 
-          # Producer side (source of truth in THIS repo): the default archive
-          # format 'apm pack --archive' emits when --archive-format is omitted.
-          producer_fmt=$(grep -m1 -E '^[[:space:]]*archive_format: str = "' \
-            src/apm_cli/bundle/packer.py | sed -E 's/.*= "([^"]+)".*/\1/')
+          # Producer side (source of truth in THIS repo): apm-action invokes
+          # `apm pack --archive` WITHOUT --archive-format, so the user-facing
+          # default that decides the emitted extension is the Click option
+          # default in commands/pack.py -- NOT the internal dataclass default
+          # in bundle/packer.py. Read the CLI surface, then assert the dataclass
+          # default stays consistent so a future split is caught here too.
+          pack_cli=src/apm_cli/commands/pack.py
+          producer_fmt=$(grep -A8 '"--archive-format"' "$pack_cli" \
+            | grep -m1 -E '^[[:space:]]*default="' | sed -E 's/.*default="([^"]+)".*/\1/')
           case "$producer_fmt" in
             zip)    producer_ext=".zip" ;;
             tar.gz) producer_ext=".tar.gz" ;;
-            "")     echo "::error file=src/apm_cli/bundle/packer.py::could not read archive_format default"; exit 1 ;;
-            *)      echo "::error file=src/apm_cli/bundle/packer.py::unrecognized archive_format default '$producer_fmt'"; exit 1 ;;
+            "")     echo "::error file=$pack_cli::could not read the --archive-format Click default"; exit 1 ;;
+            *)      echo "::error file=$pack_cli::unrecognized --archive-format default '$producer_fmt'"; exit 1 ;;
           esac
-          echo "producer: apm pack --archive default format = '$producer_fmt' (ext '$producer_ext')"
+          echo "producer: 'apm pack --archive' default format = '$producer_fmt' (ext '$producer_ext') [commands/pack.py]"
+
+          # Consistency: the bundle/packer.py dataclass default must agree with
+          # the CLI default. apm pack constructs the packer from the CLI option,
+          # so a divergence here means the two could disagree under some code
+          # path -- fail loudly rather than trust a single side.
+          packer_fmt=$(grep -m1 -E '^[[:space:]]*archive_format: str = "' \
+            src/apm_cli/bundle/packer.py | sed -E 's/.*= "([^"]+)".*/\1/')
+          if [ -n "$packer_fmt" ] && [ "$packer_fmt" != "$producer_fmt" ]; then
+            echo "::error file=src/apm_cli/bundle/packer.py::archive_format dataclass default '$packer_fmt' disagrees with the --archive-format CLI default '$producer_fmt' (commands/pack.py) -- reconcile the two before relying on the drift guard."
+            exit 1
+          fi
+          echo "consistency: packer.py dataclass default '$packer_fmt' matches CLI default"
 
           # Consumer side (cross-repo): read apm-action's archive-detection
           # extension set from the ref shared/apm.md pins (the release CI runs).

--- a/.github/workflows/verify-shared-apm-matrix.yml
+++ b/.github/workflows/verify-shared-apm-matrix.yml
@@ -35,6 +35,18 @@ name: Verify shared/apm.md matrix secret-stripping fix
 #            action's action.yml at that exact ref and compares. Fails if
 #            the mirror drifts (see the MAINTENANCE note in shared/apm.md).
 #
+#   D. pack-format-consumer-compat (cross-repo drift guard)
+#      Proves the `apm pack --archive` default archive format (.zip) stays
+#      inside the extension set the pinned microsoft/apm-action release
+#      detects when it scans the build dir for a bundle. Source of truth:
+#      src/apm_cli/bundle/packer.py (producer default) vs apm-action
+#      src/bundler.ts at the pinned ref (consumer detection). Fails on the
+#      'apm pack produced no bundle' outage shape -- the CLI default flipped
+#      from .tar.gz to .zip while apm-action still filtered only .tar.gz, so
+#      the GH-AW Compatibility job saw no bundle. Keep the CLI default in
+#      apm-action's detected set, or bump the pinned apm-action ref in
+#      lockstep.
+#
 # Self-contained: no real GitHub-App credentials required. The synthetic
 # PEM below is registered at runtime via ::add-mask:: which feeds the same
 # HostContext.SecretMasker that processes repo / org secrets.
@@ -45,6 +57,7 @@ on:
       - .github/workflows/shared/apm.md
       - .github/workflows/verify-shared-apm-matrix.yml
       - .github/workflows/*.lock.yml
+      - src/apm_cli/bundle/packer.py
   push:
     branches:
       - main
@@ -52,6 +65,7 @@ on:
       - .github/workflows/shared/apm.md
       - .github/workflows/verify-shared-apm-matrix.yml
       - .github/workflows/*.lock.yml
+      - src/apm_cli/bundle/packer.py
   workflow_dispatch:
 
 permissions:
@@ -380,3 +394,77 @@ jobs:
             exit 1
           fi
           echo "[OK] schema default '$schema_default' mirrors apm-action@${action_ref} -- no drift."
+
+  # =====================================================================
+  # Job set D: apm pack archive-format <-> apm-action consumer detection.
+  # Outage shape: GH-AW Compatibility job 'apm pack produced no bundle'.
+  # =====================================================================
+  d-pack-format-consumer-compat:
+    name: D. apm pack default archive format is detected by apm-action
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Producer default archive ext is in the pinned apm-action detected set
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # 'apm pack --archive' defaults to .zip (packer.py). apm-action scans
+          # the build dir for an archive bundle by filtering on a fixed
+          # extension set. When the CLI default flipped from .tar.gz to .zip
+          # but apm-action still filtered only '.tar.gz', the GH-AW
+          # Compatibility job failed with 'apm pack produced no bundle'. This
+          # guard cross-references the two repos so the producer default can
+          # never silently drift out of the set the pinned apm-action release
+          # detects.
+
+          # Producer side (source of truth in THIS repo): the default archive
+          # format 'apm pack --archive' emits when --archive-format is omitted.
+          producer_fmt=$(grep -m1 -E '^[[:space:]]*archive_format: str = "' \
+            src/apm_cli/bundle/packer.py | sed -E 's/.*= "([^"]+)".*/\1/')
+          case "$producer_fmt" in
+            zip)    producer_ext=".zip" ;;
+            tar.gz) producer_ext=".tar.gz" ;;
+            "")     echo "::error file=src/apm_cli/bundle/packer.py::could not read archive_format default"; exit 1 ;;
+            *)      echo "::error file=src/apm_cli/bundle/packer.py::unrecognized archive_format default '$producer_fmt'"; exit 1 ;;
+          esac
+          echo "producer: apm pack --archive default format = '$producer_fmt' (ext '$producer_ext')"
+
+          # Consumer side (cross-repo): read apm-action's archive-detection
+          # extension set from the ref shared/apm.md pins (the release CI runs).
+          src=.github/workflows/shared/apm.md
+          action_ref=$(grep -m1 -oE 'microsoft/apm-action@[A-Za-z0-9._-]+' "$src" | cut -d@ -f2)
+          if [ -z "$action_ref" ]; then
+            echo "::error file=$src::could not extract microsoft/apm-action ref"; exit 1
+          fi
+          bundler=$(gh api "repos/microsoft/apm-action/contents/src/bundler.ts?ref=${action_ref}" --jq '.content' | base64 -d)
+          # Consumer contract anchor: the ARCHIVE_EXTENSIONS constant lists the
+          # extensions apm-action's findBundleOrNull() accepts in archive mode
+          # (e.g. const ARCHIVE_EXTENSIONS = ['.zip', '.tar.gz']). Older releases
+          # inline the set as archives = entries.filter(e => e.endsWith('.x') ...);
+          # fall back to that shape so the guard reads both.
+          detected=$(printf '%s\n' "$bundler" \
+            | grep -E 'ARCHIVE_EXTENSIONS[[:space:]]*=[[:space:]]*\[' \
+            | grep -oE "'\.[A-Za-z.]+'" | tr -d "'" | sort -u)
+          if [ -z "$detected" ]; then
+            detected=$(printf '%s\n' "$bundler" \
+              | grep -E 'archives[[:space:]]*=[[:space:]]*entries\.filter' \
+              | grep -oE "endsWith\('\.[A-Za-z.]+'\)" \
+              | grep -oE "'\.[A-Za-z.]+'" | tr -d "'" | sort -u)
+          fi
+          if [ -z "$detected" ]; then
+            echo "::error::could not read apm-action's archive-mode extension set (ARCHIVE_EXTENSIONS constant or archives = entries.filter ... endsWith) from microsoft/apm-action@${action_ref} src/bundler.ts -- the consumer contract may have moved; update this guard"
+            exit 1
+          fi
+          echo "consumer: apm-action@${action_ref} detects archive extensions:"
+          printf '  %s\n' $detected
+
+          if printf '%s\n' "$detected" | grep -Fxq "$producer_ext"; then
+            echo "[OK] apm pack default '$producer_ext' is in apm-action@${action_ref}'s detected set -- no producer/consumer drift."
+          else
+            echo "::error file=src/apm_cli/bundle/packer.py::apm pack default archive ext '$producer_ext' is NOT detected by microsoft/apm-action@${action_ref} (detects: $(echo $detected | tr '\n' ' '))"
+            echo "::error::This is the 'apm pack produced no bundle' outage shape. Keep the CLI default in apm-action's detected set, or bump the pinned apm-action ref in $src to a release that detects '$producer_ext'."
+            exit 1
+          fi

--- a/.github/workflows/verify-shared-apm-matrix.yml
+++ b/.github/workflows/verify-shared-apm-matrix.yml
@@ -317,14 +317,21 @@ jobs:
           echo "[OK] row kind=$ROW_KIND app_id=$ROW_APP_ID pk_sha=$got_sha matches expected."
 
   # =====================================================================
-  # Job set C: apm-version pinning (import-default fix, PR #1842).
+  # Job set C: apm-version default correctness.
+  #   1. non-opting consumer locks pin a bare-semver apm-version (no
+  #      float-to-latest) -- import-default fix, PR #1842.
+  #   2. the format that default version produces is detected by the
+  #      pinned apm-action (format-compat). This supersedes the old
+  #      version-equality guard: equality (schema default == apm-action's
+  #      own default) never caught the pack-format outage and could both
+  #      false-pass and false-fail (see step comment).
   # =====================================================================
   c-apm-version-pinning:
     name: C. apm-version default pins non-opting consumers
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Compiled consumer locks pin apm-version (no float-to-latest)
         run: |
@@ -363,7 +370,7 @@ jobs:
           fi
           echo "[OK] all ${#locks[@]} consumer lock(s) pin apm-version -- no float-to-latest path."
 
-      - name: Drift guard - schema default mirrors apm-action's pinned default
+      - name: Format-compat - the default apm-version produces a format the pinned apm-action detects
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -376,26 +383,67 @@ jobs:
             | grep -m1 '^    default:' | tr -d "\"' " | sed 's/.*default://')
           # The apm-action ref the Pack and Restore steps pin to.
           action_ref=$(grep -m1 -oE 'microsoft/apm-action@[A-Za-z0-9._-]+' "$src" | cut -d@ -f2)
-          echo "shared/apm.md schema default = '$schema_default'  (apm-action ref: $action_ref)"
           if [ -z "$schema_default" ] || [ -z "$action_ref" ]; then
             echo "::error file=$src::could not extract schema default ('$schema_default') or apm-action ref ('$action_ref')"
             exit 1
           fi
-          # Source of truth: apm-action's own apm-version input default at the
-          # pinned ref. The schema default MUST mirror it (see MAINTENANCE note).
-          action_default=$(gh api "repos/microsoft/apm-action/contents/action.yml?ref=${action_ref}" --jq '.content' \
-            | base64 -d \
-            | grep -A15 '^  apm-version:' | grep -m1 '^    default:' | tr -d "\"' " | sed 's/.*default://')
-          echo "apm-action@${action_ref} apm-version default = '$action_default'"
-          if [ -z "$action_default" ]; then
-            echo "::error::could not extract apm-version default from microsoft/apm-action@${action_ref}"
+          # The outage we guard ('apm pack produced no bundle') is a PACK
+          # FORMAT the pinned apm-action cannot detect -- NOT a version
+          # mismatch between this default and apm-action's own default. Pack
+          # and Restore both receive this one substituted value, so the CLI
+          # version cannot skew between them, and apm-action restores whatever
+          # format it detects. Version equality is therefore neither necessary
+          # nor sufficient: it false-passes when apm-action keeps an old
+          # default but drops a format, and false-fails on a harmless version
+          # diff. Assert the real contract instead -- the format THIS default
+          # emits is in apm-action's detected set (the same check Job D runs
+          # for THIS repo's CLI default).
+          if ! printf '%s' "$schema_default" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error file=$src::apm-version default '$schema_default' is not a bare semver -- the format-compat guard needs a concrete version to map to a pack format"
             exit 1
           fi
-          if [ "$schema_default" != "$action_default" ]; then
-            echo "::error file=$src::apm-version schema default '$schema_default' != apm-action@${action_ref} default '$action_default' -- bump in lockstep with the action (see MAINTENANCE note)"
+          # Version -> pack format boundary: `apm pack --archive` defaults to
+          # .zip at apm >= 0.20.0 (BREAKING #1720); earlier releases default
+          # to .tar.gz. sort -V puts the smaller version first, so the boundary
+          # sorting first means schema_default >= 0.20.0.
+          lowest=$(printf '%s\n0.20.0\n' "$schema_default" | sort -V | head -n1)
+          if [ "$lowest" = "0.20.0" ]; then
+            default_ext=".zip"
+          else
+            default_ext=".tar.gz"
+          fi
+          echo "shared/apm.md apm-version default = '$schema_default' -> emits '$default_ext'  (apm-action ref: $action_ref)"
+          # Consumer side: read apm-action's archive-detection extension set
+          # from the immutable SHA the production locks pin (mirrors Job D's
+          # read). Fall back to the tag only if the lock entry is absent.
+          lock=.github/aw/actions-lock.json
+          action_sha=$(jq -r --arg k "microsoft/apm-action@${action_ref}" '.entries[$k].sha // empty' "$lock" 2>/dev/null || true)
+          fetch_ref="${action_sha:-$action_ref}"
+          bundler=$(gh api "repos/microsoft/apm-action/contents/src/bundler.ts?ref=${fetch_ref}" --jq '.content' | base64 -d)
+          # Accept the ARCHIVE_EXTENSIONS constant or the older inline
+          # entries.filter(...endsWith...) shape, single- OR double-quoted.
+          detected=$(printf '%s\n' "$bundler" \
+            | grep -E 'ARCHIVE_EXTENSIONS[[:space:]]*=[[:space:]]*\[' \
+            | grep -oE "['\"]\.[A-Za-z.]+['\"]" | tr -d "'\"" | sort -u)
+          if [ -z "$detected" ]; then
+            detected=$(printf '%s\n' "$bundler" \
+              | grep -E 'archives[[:space:]]*=[[:space:]]*entries\.filter' \
+              | grep -oE "endsWith\(['\"]\.[A-Za-z.]+['\"]\)" \
+              | grep -oE "['\"]\.[A-Za-z.]+['\"]" | tr -d "'\"" | sort -u)
+          fi
+          if [ -z "$detected" ]; then
+            echo "::error::could not read apm-action's archive-mode extension set (ARCHIVE_EXTENSIONS or entries.filter ... endsWith) from microsoft/apm-action@${action_ref} src/bundler.ts -- the consumer contract may have moved; update this guard"
             exit 1
           fi
-          echo "[OK] schema default '$schema_default' mirrors apm-action@${action_ref} -- no drift."
+          echo "apm-action@${action_ref} (src/bundler.ts @ ${fetch_ref}) detects archive extensions:"
+          printf '  %s\n' $detected
+          if printf '%s\n' "$detected" | grep -Fxq "$default_ext"; then
+            echo "[OK] default apm-version '$schema_default' emits '$default_ext', detected by apm-action@${action_ref} -- no producer/consumer drift."
+          else
+            echo "::error file=$src::default apm-version '$schema_default' emits '$default_ext', NOT detected by microsoft/apm-action@${action_ref} (detects: $(echo $detected | tr '\n' ' '))"
+            echo "::error::This is the 'apm pack produced no bundle' outage shape. Bump the pinned apm-action ref to a release that detects '$default_ext', or set apm-version to a release whose pack format apm-action detects."
+            exit 1
+          fi
 
   # =====================================================================
   # Job set D: apm pack archive-format <-> apm-action consumer detection.
@@ -406,7 +454,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Producer default archive ext is in the pinned apm-action detected set
         env:

--- a/.github/workflows/verify-shared-apm-matrix.yml
+++ b/.github/workflows/verify-shared-apm-matrix.yml
@@ -428,7 +428,10 @@ jobs:
           # in bundle/packer.py. Read the CLI surface, then assert the dataclass
           # default stays consistent so a future split is caught here too.
           pack_cli=src/apm_cli/commands/pack.py
-          producer_fmt=$(grep -A8 '"--archive-format"' "$pack_cli" \
+          # Read the whole @click.option("--archive-format", ...) block (to the
+          # next decorator or def) rather than a fixed -A window, so reordering
+          # the option kwargs can never slip default= out of range.
+          producer_fmt=$(sed -nE '/"--archive-format"/,/^(@|def )/p' "$pack_cli" \
             | grep -m1 -E '^[[:space:]]*default="' | sed -E 's/.*default="([^"]+)".*/\1/')
           case "$producer_fmt" in
             zip)    producer_ext=".zip" ;;
@@ -444,7 +447,11 @@ jobs:
           # path -- fail loudly rather than trust a single side.
           packer_fmt=$(grep -m1 -E '^[[:space:]]*archive_format: str = "' \
             src/apm_cli/bundle/packer.py | sed -E 's/.*= "([^"]+)".*/\1/')
-          if [ -n "$packer_fmt" ] && [ "$packer_fmt" != "$producer_fmt" ]; then
+          if [ -z "$packer_fmt" ]; then
+            echo "::error file=src/apm_cli/bundle/packer.py::could not read the archive_format dataclass default -- the field may have been renamed or moved; update this guard so the consistency check cannot silently go inert."
+            exit 1
+          fi
+          if [ "$packer_fmt" != "$producer_fmt" ]; then
             echo "::error file=src/apm_cli/bundle/packer.py::archive_format dataclass default '$packer_fmt' disagrees with the --archive-format CLI default '$producer_fmt' (commands/pack.py) -- reconcile the two before relying on the drift guard."
             exit 1
           fi
@@ -457,26 +464,35 @@ jobs:
           if [ -z "$action_ref" ]; then
             echo "::error file=$src::could not extract microsoft/apm-action ref"; exit 1
           fi
-          bundler=$(gh api "repos/microsoft/apm-action/contents/src/bundler.ts?ref=${action_ref}" --jq '.content' | base64 -d)
+          # Resolve the tag to the immutable SHA the production locks pin, so the
+          # guard reads bundler.ts at the exact commit the workflows execute --
+          # not a mutable tag that could be force-moved out from under the check.
+          # Fall back to the tag only if the lock entry is absent.
+          lock=.github/aw/actions-lock.json
+          action_sha=$(jq -r --arg k "microsoft/apm-action@${action_ref}" '.entries[$k].sha // empty' "$lock" 2>/dev/null || true)
+          fetch_ref="${action_sha:-$action_ref}"
+          bundler=$(gh api "repos/microsoft/apm-action/contents/src/bundler.ts?ref=${fetch_ref}" --jq '.content' | base64 -d)
           # Consumer contract anchor: the ARCHIVE_EXTENSIONS constant lists the
           # extensions apm-action's findBundleOrNull() accepts in archive mode
           # (e.g. const ARCHIVE_EXTENSIONS = ['.zip', '.tar.gz']). Older releases
           # inline the set as archives = entries.filter(e => e.endsWith('.x') ...);
-          # fall back to that shape so the guard reads both.
+          # fall back to that shape so the guard reads both. Accept single- OR
+          # double-quoted string literals so a prettier reformat in apm-action
+          # cannot blind the guard.
           detected=$(printf '%s\n' "$bundler" \
             | grep -E 'ARCHIVE_EXTENSIONS[[:space:]]*=[[:space:]]*\[' \
-            | grep -oE "'\.[A-Za-z.]+'" | tr -d "'" | sort -u)
+            | grep -oE "['\"]\.[A-Za-z.]+['\"]" | tr -d "'\"" | sort -u)
           if [ -z "$detected" ]; then
             detected=$(printf '%s\n' "$bundler" \
               | grep -E 'archives[[:space:]]*=[[:space:]]*entries\.filter' \
-              | grep -oE "endsWith\('\.[A-Za-z.]+'\)" \
-              | grep -oE "'\.[A-Za-z.]+'" | tr -d "'" | sort -u)
+              | grep -oE "endsWith\(['\"]\.[A-Za-z.]+['\"]\)" \
+              | grep -oE "['\"]\.[A-Za-z.]+['\"]" | tr -d "'\"" | sort -u)
           fi
           if [ -z "$detected" ]; then
             echo "::error::could not read apm-action's archive-mode extension set (ARCHIVE_EXTENSIONS constant or archives = entries.filter ... endsWith) from microsoft/apm-action@${action_ref} src/bundler.ts -- the consumer contract may have moved; update this guard"
             exit 1
           fi
-          echo "consumer: apm-action@${action_ref} detects archive extensions:"
+          echo "consumer: apm-action@${action_ref} (src/bundler.ts @ ${fetch_ref}) detects archive extensions:"
           printf '  %s\n' $detected
 
           if printf '%s\n' "$detected" | grep -Fxq "$producer_ext"; then


### PR DESCRIPTION
## TL;DR

Propagates the released **apm-action v1.10.0** (`.zip` bundle detection) into the shared gh-aw workflow and lands a cross-repo drift trap that guards the exact outage shape that motivated it.

## Why

`apm pack --archive` defaults to `.zip` at apm >= 0.20 (`#1720`). apm-action `@v1.7.2` only detected `.tar.gz`, so the release **GH-AW Compatibility** job failed with "apm pack produced no bundle". apm-action **v1.10.0** is now released (`microsoft/apm-action#52`) and adds `.zip` detection (`ARCHIVE_EXTENSIONS = ['.zip', '.tar.gz']`); the floating `v1` tag has moved, so `@v1` consumers are already healed. This PR brings the **pinned** shared workflow up to the same release and prevents silent re-drift.

## What changed

**`shared/apm.md`**
- Pin `microsoft/apm-action@v1.7.2` -> `@v1.10.0` (5 references).
- apm-version schema `default: '0.12.4'` -> `'0.14.0'` in lockstep. Job Set C requires the schema default to mirror the pinned action's apm-version default, and v1.10.0 ships `0.14.0`. **Side effect:** non-opting gh-aw consumers now default to apm CLI `0.14.0` (already every other consumer's effective default — a staleness catch-up, the pin was 2 releases behind).

**3 apm-action consumer locks** (docs-sync, pr-review-panel, triage-panel), recompiled on gh-aw v0.80.9:
- `apm-action@d723bb64 # v1.10.0` and `apm-version 0.14.0` at all call sites; `actions-lock.json` re-keyed to the v1.10.0 SHA. **No compiler/firewall churn** — the diff is pin/version-scoped only (5 files + the trap).

**`verify-shared-apm-matrix.yml` — new Job Set D (pack-format consumer compat)**
- Cross-references the producer default archive format in `src/apm_cli/bundle/packer.py` (`.zip`) against the archive-extension set the **pinned** apm-action release detects (`src/bundler.ts`). Fails on the "apm pack produced no bundle" outage shape. Adds `packer.py` to the trigger paths.

## Empirical validation

| Check | Result |
|-------|--------|
| Recompile scope | exactly 6 files; no compiler/firewall re-stamp |
| Pin propagation | 9 `uses:` sites @ `d723bb64`, 6 apm-version @ `0.14.0`; zero stale `v1.7.2`/`0.12.4`/`b48dd081` |
| Trap @ v1.10.0 | **PASSES** — detects `.zip` + `.tar.gz`; producer `.zip` in set |
| Trap @ v1.7.2 (counterfactual) | **FAILS** — detects only `.tar.gz` — proves it's a real guard |
| YAML / JSON parse | all changed files parse |
| ASCII | clean |

## Decisions taken (maintainer-approved)

- Approved the `0.12.4 -> 0.14.0` apm-version default side-effect of the pin bump.
- Folded the pack-format trap into this PR (it guards the very pin this PR bumps) rather than a separate PR.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
