### PR TITLE
fix(registry): registry deps as first-class citizens in display/UX surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm update` no longer shows a spurious update for registry semver deps already at the latest matching version; the lockfile now stores the resolved concrete version instead of the manifest range, and the pre-update cache purge now covers registry deps so the resolver re-annotates them before the update plan fires. (#1897)
 - `apm install <pkg>@<marketplace>` now preserves GitLab and other
   non-GitHub hosts from url-type marketplace plugin sources, so auth
   resolution no longer falls back to `github.com` for those installs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `apm update` no longer shows a spurious update for registry semver deps already at the latest matching version; the lockfile now stores the resolved concrete version instead of the manifest range, and the pre-update cache purge now covers registry deps so the resolver re-annotates them before the update plan fires. (#1897)
+- `apm update` no longer shows a spurious update for registry semver deps already at the latest matching version. (#1897)
 - `apm install <pkg>@<marketplace>` now preserves GitLab and other
   non-GitHub hosts from url-type marketplace plugin sources, so auth
   resolution no longer falls back to `github.com` for those installs.

--- a/docs/src/content/docs/consumer/install-packages.md
+++ b/docs/src/content/docs/consumer/install-packages.md
@@ -93,7 +93,7 @@ For the deeper view of how compile fits in, see
 `apm install` mirrors `npm install` deliberately. The big difference:
 APM also runs a security scan and, if present, an org policy gate
 before writing anything to disk. To refresh dependencies to their
-latest matching refs, use `apm update` (mirrors `npm update`). To
+latest matching versions or refs, use `apm update` (mirrors `npm update`). To
 upgrade the `apm` CLI binary itself, use `apm self-update`.
 :::
 

--- a/docs/src/content/docs/consumer/manage-dependencies.md
+++ b/docs/src/content/docs/consumer/manage-dependencies.md
@@ -299,7 +299,7 @@ corresponds to a declared dependency. It does not touch your manifest,
 your lockfile entries are rewritten on the next `apm install`, and
 deployed files in `.github/`, `.claude/`, etc. are reconciled then too.
 
-If you also want to refresh remaining deps to their latest refs, see
+If you also want to refresh remaining deps to their latest versions or refs, see
 [Update and refresh](../update-and-refresh/).
 
 ## The lockfile
@@ -328,7 +328,7 @@ For the full lockfile schema, see
 
 :::note[Coming from npm?]
 The split mirrors `package.json` + `package-lock.json`. The verbs match
-too: `apm update` refreshes dependencies to the latest matching refs
+too: `apm update` refreshes dependencies to the latest matching versions or refs
 (like `npm update`); `apm install --frozen` is the lockfile-only,
 fail-on-drift install for CI (like `npm ci`). To upgrade the `apm` CLI
 binary itself, use `apm self-update`.

--- a/docs/src/content/docs/consumer/update-and-refresh.mdx
+++ b/docs/src/content/docs/consumer/update-and-refresh.mdx
@@ -24,8 +24,8 @@ They are managed by separate commands. Pick the right one.
 apm update
 ```
 
-Re-resolves every dependency in `apm.yml` to its latest matching Git
-reference, prints the planned changes, and prompts for consent before
+Re-resolves every dependency in `apm.yml` to its latest matching version or ref,
+prints the planned changes, and prompts for consent before
 rewriting `apm.lock.yaml` and redeploying primitives. Pass one or more
 package names (`apm update org/pkg-a org/pkg-b`) to refresh only those.
 

--- a/docs/src/content/docs/guides/operating-installed-context.md
+++ b/docs/src/content/docs/guides/operating-installed-context.md
@@ -16,7 +16,7 @@ to remember the flag matrix.
 | You want to... | Run | Notes |
 |---|---|---|
 | Reproduce the lockfile exactly (CI gate) | `apm install --frozen` | Refuses to install when `apm.lock.yaml` is missing or out of sync with `apm.yml`. Equivalent in spirit to `npm ci` / `pnpm install --frozen-lockfile`. |
-| Refresh refs and rewrite the lockfile | `apm update` (or `apm update --yes` for CI) | Restructures the dependency graph against latest matching refs. |
+| Refresh versions or refs and rewrite the lockfile | `apm update` (or `apm update --yes` for CI) | Restructures the dependency graph against latest matching versions or refs. |
 | Validate lockfile integrity for CI | `apm audit --ci` | Lockfile-consistency check + on-disk integrity. Pair with `--format sarif --output audit.sarif` for GitHub Code Scanning. |
 | See what is installed | `apm deps list` | Project scope. Add `--global` for `~/.apm/`. |
 | Inspect the dependency tree | `apm deps tree` | Hierarchical view of direct + transitive deps. |

--- a/docs/src/content/docs/quickstart.mdx
+++ b/docs/src/content/docs/quickstart.mdx
@@ -135,7 +135,7 @@ and pinned its content hash in `apm.lock.yaml`. If your org ships an
 APM's verbs match npm's semantics:
 
 - `apm install` -- install and deploy dependencies, like `npm install`.
-- `apm update` -- refresh dependencies to the latest matching refs,
+- `apm update` -- refresh dependencies to the latest matching versions or refs,
   with a consent prompt, like `npm update`.
 - `apm install --frozen` -- lockfile-only install for CI; fails on
   drift, like `npm ci`.

--- a/docs/src/content/docs/reference/cli/install.md
+++ b/docs/src/content/docs/reference/cli/install.md
@@ -29,7 +29,7 @@ With no arguments it installs everything from `apm.yml`. With one or more `PACKA
 
 | Flag | Default | Description |
 |---|---|---|
-| `--update` | off | Re-resolve dependencies to the latest Git ref allowed by `apm.yml` and rewrite `apm.lock.yaml`. Mutually exclusive with `--frozen`. Prefer the dedicated [`apm update`](../update/) command for the consent-gated workflow. |
+| `--update` | off | Re-resolve dependencies to the latest version or Git ref allowed by `apm.yml` and rewrite `apm.lock.yaml`. Mutually exclusive with `--frozen`. Prefer the dedicated [`apm update`](../update/) command for the consent-gated workflow. |
 | `--frozen` | off | Lockfile-only install: refuse to resolve anything new and fail if `apm.yml` and `apm.lock.yaml` have drifted. Mirrors `npm ci`. Mutually exclusive with `--update`. |
 | `--dry-run` | off | Print the install plan without touching the filesystem. |
 | `--force` | off | Overwrite locally-authored files on collision **and** bypass the security scan's critical-finding block. Does **not** suppress general install errors (any reported error still exits `1`, matching npm / pip / cargo). Does **not** refresh remote refs -- use `apm update` for that. Use only after independent verification. |
@@ -226,7 +226,7 @@ See [Registries](../../../guides/registries/) for the full setup guide.
 
 ## Related
 
-- [`apm update`](../update/) -- refresh dependencies in `apm.yml` to their latest matching refs, with a consent gate.
+- [`apm update`](../update/) -- refresh dependencies in `apm.yml` to their latest matching versions or refs, with a consent gate.
 - [`apm self-update`](../self-update/) -- upgrade the `apm` CLI binary itself.
 - [`apm prune`](../prune/) -- remove orphaned packages and stale files.
 - [Registries](../../../guides/registries/) -- end-to-end guide for registry-sourced dependencies.

--- a/docs/src/content/docs/reference/cli/self-update.md
+++ b/docs/src/content/docs/reference/cli/self-update.md
@@ -18,7 +18,7 @@ apm self-update [--check]
 `apm self-update` upgrades the **APM CLI itself** to the latest version published on GitHub releases. It downloads the official platform installer (`install.sh` on macOS/Linux, `install.ps1` on Windows) and runs it in place.
 
 :::caution[Looking for dependency updates?]
-This command does **not** update the packages declared in your `apm.yml`. To re-resolve your dependencies against the latest matching Git refs, run:
+This command does **not** update the packages declared in your `apm.yml`. To re-resolve your dependencies against the latest matching versions or Git refs, run:
 
 ```bash
 apm update
@@ -128,6 +128,6 @@ The check is cached and non-blocking. It is suppressed in distributions that dis
 
 ## Related
 
-- [`apm update`](../update/) -- refresh dependencies declared in `apm.yml` against the latest matching refs.
+- [`apm update`](../update/) -- refresh dependencies declared in `apm.yml` against the latest matching versions or refs.
 - [`apm install`](../install/) -- install dependencies; use `--frozen` for read-only, lockfile-pinned installs.
 - [Quickstart](../../../quickstart/) -- first-time install.

--- a/docs/src/content/docs/reference/cli/update.md
+++ b/docs/src/content/docs/reference/cli/update.md
@@ -1,11 +1,11 @@
 ---
 title: apm update
-description: Re-resolve dependencies in apm.yml against the latest matching Git refs, with a plan and consent gate before writing.
+description: Re-resolve dependencies in apm.yml against the latest matching versions or Git refs, with a plan and consent gate before writing.
 sidebar:
   order: 4
 ---
 
-Refresh the dependencies declared in `apm.yml` to the latest matching Git refs, after showing you the plan and asking for consent.
+Refresh the dependencies declared in `apm.yml` to the latest matching versions or Git refs, after showing you the plan and asking for consent.
 
 ## Synopsis
 
@@ -15,7 +15,7 @@ apm update [OPTIONS] [PACKAGES...]
 
 ## Description
 
-`apm update` re-resolves every dependency in your project's `apm.yml` against the newest Git ref allowed by its constraint, prints a structured plan -- **added**, **updated**, **removed**, **unchanged** -- and prompts before touching anything. Full-SHA revision pins are refreshed by resolving the latest annotated semver tag from the authoritative upstream, then rewriting the SHA in `apm.yml` with a tag annotation after you accept the plan (for example `# v2.0.0`). Decline the prompt and APM exits cleanly: no manifest rewrite, no lockfile write, no filesystem changes.
+`apm update` re-resolves every dependency in your project's `apm.yml` against the newest version or Git ref allowed by its constraint, prints a structured plan -- **added**, **updated**, **removed**, **unchanged** -- and prompts before touching anything. Full-SHA revision pins are refreshed by resolving the latest annotated semver tag from the authoritative upstream, then rewriting the SHA in `apm.yml` with a tag annotation after you accept the plan (for example `# v2.0.0`). Decline the prompt and APM exits cleanly: no manifest rewrite, no lockfile write, no filesystem changes.
 
 Pass one or more `PACKAGES` to refresh only those dependencies, or `-g/--global` to refresh the user-scope dependencies under `~/.apm/` instead of the current project. With these flags `apm update` is a strict superset of the deprecated [`apm deps update`](../deps/#apm-deps-update).
 
@@ -88,13 +88,13 @@ apm update
 
 ## Behavior
 
-- **Re-resolve every dep.** Each entry in `apm.yml` is resolved against its remote source for the newest ref allowed by the constraint (branch tip, latest matching tag, etc.). Full-SHA revision pins move only to the commit behind the latest annotated semver tag; branch refs and lightweight tags are refused. Local-path deps are skipped.
+- **Re-resolve every dep.** Each entry in `apm.yml` is resolved against its remote source for the newest version or ref allowed by the constraint (registry version, branch tip, latest matching tag, etc.). Full-SHA revision pins move only to the commit behind the latest annotated semver tag; branch refs and lightweight tags are refused. Local-path deps are skipped.
 - **Registry deps.** Registry semver deps are re-resolved against their configured registry. Deps already at the latest version satisfying their constraint appear as **unchanged** in the plan.
 - **Structured plan.** Output is grouped into four sections:
   - **added** -- present in the new resolution but not in the previous lockfile.
   - **updated** -- ref or version moved.
   - **removed** -- previously locked, no longer required by `apm.yml`.
-  - **unchanged** -- already at the latest matching ref.
+  - **unchanged** -- already at the latest matching version or ref.
 - **Consent gate.** The prompt defaults to **No**. Without `--yes`, declining (or running in a non-interactive context) aborts with a clean exit; the manifest, lockfile, and workspace are untouched.
 - **No partial consent.** A single prompt covers both revision-pin manifest rewrites and the normal update plan; declining leaves everything unchanged.
 - **`--dry-run` skips the prompt.** It computes and prints the plan, including revision-pin SHA/tag rewrites, but never writes and never asks.

--- a/docs/src/content/docs/reference/cli/update.md
+++ b/docs/src/content/docs/reference/cli/update.md
@@ -89,6 +89,7 @@ apm update
 ## Behavior
 
 - **Re-resolve every dep.** Each entry in `apm.yml` is resolved against its remote source for the newest ref allowed by the constraint (branch tip, latest matching tag, etc.). Full-SHA revision pins move only to the commit behind the latest annotated semver tag; branch refs and lightweight tags are refused. Local-path deps are skipped.
+- **Registry deps.** Registry semver deps are re-resolved against their configured registry. Deps already at the latest version satisfying their constraint appear as **unchanged** in the plan.
 - **Structured plan.** Output is grouped into four sections:
   - **added** -- present in the new resolution but not in the previous lockfile.
   - **updated** -- ref or version moved.

--- a/docs/src/content/docs/reference/cli/view.md
+++ b/docs/src/content/docs/reference/cli/view.md
@@ -1,11 +1,11 @@
 ---
 title: apm view
-description: Inspect package metadata or list remote versions
+description: Inspect package metadata or list package versions
 sidebar:
   order: 5
 ---
 
-Show local metadata for an installed package, or query remote refs without cloning.
+Show local metadata for an installed package, or query package versions without cloning.
 
 ## Synopsis
 
@@ -20,7 +20,7 @@ apm view PACKAGE [FIELD] [OPTIONS]
 `apm view` has two modes, selected by the optional `FIELD` argument:
 
 - **No field** -- read installed package metadata from `apm_modules/` (or `~/.apm/apm_modules/` with `-g`). Local-only; the package must be installed.
-- **`versions` field** -- query the remote for available tags and branches. No local install required.
+- **`versions` field** -- query available versions. Git packages list remote tags and branches without requiring a local install. Installed registry packages are detected from `apm.lock.yaml` and list registry versions instead.
 
 When `PACKAGE` matches the `NAME@MARKETPLACE` pattern, `apm view` resolves the plugin against the marketplace manifest and prints its entry (name, version, description, source, tags) instead of a Git repository view. This applies whether or not `versions` is passed.
 
@@ -36,9 +36,9 @@ Output includes: name, version, description, author, source, install path, lockf
 
 ### `apm view <package> versions`
 
-Lists remote tags and branches for the package. Calls the remote -- requires network access, and for private repositories requires `GITHUB_APM_PAT` (see [authentication](../../../consumer/authentication/)).
+Lists available versions for the package. Calls the remote -- requires network access.
 
-Output is a table with name, type (`tag` or `branch`), and short commit SHA.
+For git packages, output is a table with name, type (`tag` or `branch`), and short commit SHA. For installed registry packages, `apm view` reads the lockfile source and queries the configured registry, then prints version and published timestamp columns. Private git repositories require `GITHUB_APM_PAT`; private registries use the registry token configured for that registry (see [authentication](../../../consumer/authentication/)).
 
 ## Arguments
 
@@ -67,10 +67,16 @@ Short-name lookup (resolves against `apm_modules/`):
 apm view apm-sample-package
 ```
 
-List remote tags and branches without cloning:
+List git tags and branches without cloning:
 
 ```bash
 apm view microsoft/apm-sample-package versions
+```
+
+List registry versions for an installed registry package:
+
+```bash
+apm view acme/web-skills versions
 ```
 
 Inspect a package installed at user scope:

--- a/docs/src/content/docs/troubleshooting/install-failures.md
+++ b/docs/src/content/docs/troubleshooting/install-failures.md
@@ -148,7 +148,7 @@ This re-resolves and rewrites `apm.lock.yaml`. Commit the result.
 
 ### Drifted refs
 
-To force re-resolution to the latest Git ref allowed by `apm.yml`:
+To force re-resolution to the latest version or Git ref allowed by `apm.yml`:
 
 ```bash
 apm install --update

--- a/packages/apm-guide/.apm/skills/apm-usage/commands.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/commands.md
@@ -18,7 +18,7 @@
 | `apm deps tree` | Show dependency tree | -- |
 | `apm deps why PKG` | Explain why a package is installed (walks lockfile bottom-up to direct deps; analogue of `npm why` / `yarn why`) | `-g` global, `--json` |
 | `apm find <PATH>` | Trace a deployed file back to the package(s) that contributed it (inverse of install; reads `apm.lock.yaml` only) | `--source` show OCI/git/local origin, `--path` show full why-chain (same as `apm deps why`) |
-| `apm view PKG [FIELD]` | View package details or remote refs | `-g` global, `FIELD=versions` |
+| `apm view PKG [FIELD]` | View package details, git refs, or registry versions | `-g` global, `FIELD=versions` |
 | `apm outdated` | Check locked deps via SHA/semver comparison; patterned per-package tags are auto-detected; full-SHA pins compare against the latest annotated semver tag | `-g` global, `-v` verbose, `-j N` parallel checks |
 | `apm deps info PKG` | Alias for `apm view PKG` local metadata | -- |
 | `apm deps clean` | Clean dependency cache | `--dry-run`, `-y` skip confirm |

--- a/src/apm_cli/commands/deps/cli.py
+++ b/src/apm_cli/commands/deps/cli.py
@@ -49,6 +49,8 @@ def _deps_list_source_label(
 
     if is_local or lockfile_source == "local":
         return "local"
+    if lockfile_source == "registry":
+        return "registry"
     if host and is_azure_devops_hostname(host):
         return "azure-devops"
     if host and is_gitlab_hostname(host):
@@ -111,7 +113,9 @@ def _resolve_scope_deps(apm_dir, logger, insecure_only=False):
             for dep in project_package.get_apm_dependencies():
                 # Build the expected installed package name
                 repo_parts = dep.repo_url.split("/")
-                source = _deps_list_source_label(dep.host, is_local=dep.is_local)
+                source = _deps_list_source_label(
+                    dep.host, is_local=dep.is_local, lockfile_source=dep.source
+                )
                 is_ado = dep.is_azure_devops() and len(repo_parts) >= 3
                 is_gh = len(repo_parts) >= 2
 
@@ -927,4 +931,4 @@ def info(package: str):
         sys.exit(1)
 
     package_path = resolve_package_path(package, apm_modules_path, logger)
-    display_package_info(package, package_path, logger)
+    display_package_info(package, package_path, logger, project_root=project_root)

--- a/src/apm_cli/commands/view.py
+++ b/src/apm_cli/commands/view.py
@@ -342,7 +342,7 @@ def _display_registry_versions(
     logger: CommandLogger,
 ) -> None:
     """List available versions from the configured registry for a registry dep."""
-    from ..deps.registry.auth import make_auth_context
+    from ..deps.registry.auth import resolve_for_url
     from ..deps.registry.client import RegistryClient, RegistryError
     from ..deps.registry.config_loader import resolve_effective_registries
 
@@ -354,6 +354,7 @@ def _display_registry_versions(
     owner = "/".join(parts[:-1]) if len(parts) > 2 else parts[0]
     repo = parts[-1]
 
+    # Build the merged registries map (config.json + ~/.apm/apm.yml + project).
     project_registries = None
     project_default = None
     try:
@@ -368,16 +369,43 @@ def _display_registry_versions(
         pass
 
     registries, default_registry = resolve_effective_registries(project_registries, project_default)
-    if not registries or not default_registry:
-        logger.error(f"No registry configured; cannot list versions for '{package}'")
-        sys.exit(1)
-    registry_url = registries.get(default_registry)
-    if not registry_url:
-        logger.error(f"Registry '{default_registry}' has no URL configured")
-        sys.exit(1)
+    if registries is None:
+        registries = {}
+
+    # Prefer resolved_url from lockfile: it names the exact registry used for
+    # this dep and works for non-default registries without any extra lookup.
+    registry_url = None
+    try:
+        from ..deps.lockfile import LockFile, get_lockfile_path
+
+        lf_path = get_lockfile_path(Path("."))
+        lf = LockFile.read(lf_path)
+        if lf:
+            locked = lf.dependencies.get(package)
+            if locked is None:
+                for key, d in lf.dependencies.items():
+                    if package in key or key.endswith(f"/{package}"):
+                        locked = d
+                        break
+            if locked and locked.resolved_url:
+                sep = "/v1/packages/"
+                idx = locked.resolved_url.find(sep)
+                if idx != -1:
+                    registry_url = locked.resolved_url[:idx]
+    except Exception:
+        pass
+
+    if registry_url is None:
+        if not default_registry:
+            logger.error(f"No registry configured; cannot list versions for '{package}'")
+            sys.exit(1)
+        registry_url = registries.get(default_registry) if registries else None
+        if not registry_url:
+            logger.error(f"Registry '{default_registry}' has no URL configured")
+            sys.exit(1)
 
     try:
-        auth = make_auth_context(default_registry)
+        auth = resolve_for_url(registry_url, registries or {})
         client = RegistryClient(registry_url, auth)
         versions = client.list_versions(owner, repo)
     except RegistryError as exc:

--- a/src/apm_cli/commands/view.py
+++ b/src/apm_cli/commands/view.py
@@ -89,7 +89,7 @@ def resolve_package_path(
     sys.exit(1)
 
 
-def _lookup_lockfile_ref(package: str, project_root: Path):
+def _lookup_lockfile_ref(package: str, project_root: Path) -> tuple[str, str, str]:
     """Return (ref, commit, source) from the lockfile for *package*, or ("", "", "")."""
     try:
         from ..deps.lockfile import LockFile, get_lockfile_path, migrate_lockfile_if_needed
@@ -429,7 +429,7 @@ def _display_registry_versions(
         table.add_column("Version", style="bold white")
         table.add_column("Published", style="dim white")
 
-        for entry in sorted(versions, key=lambda e: e.version):
+        for entry in versions:
             table.add_row(entry.version, entry.published_at)
 
         console.print(table)
@@ -439,11 +439,15 @@ def _display_registry_versions(
         click.echo("-" * 50)
         click.echo(f"{'Version':<20} {'Published':<30}")
         click.echo("-" * 50)
-        for entry in sorted(versions, key=lambda e: e.version):
+        for entry in versions:
             click.echo(f"{entry.version:<20} {entry.published_at:<30}")
 
 
-def display_versions(package: str, logger: CommandLogger) -> None:
+def display_versions(
+    package: str,
+    logger: CommandLogger,
+    project_root: Path | None = None,
+) -> None:
     """Query and display available remote versions (tags/branches).
 
     This is a purely remote operation -- it does NOT require the package
@@ -455,6 +459,10 @@ def display_versions(package: str, logger: CommandLogger) -> None:
     When *package* matches the ``NAME@MARKETPLACE`` pattern, the
     marketplace manifest is fetched instead and the plugin's marketplace
     metadata is displayed.
+
+    *project_root* is used only to detect registry deps via the lockfile.
+    Pass ``None`` (e.g. for ``--global``) to skip lockfile detection and
+    go straight to the git path.
     """
     # -- Marketplace path: NAME@MARKETPLACE --
     from ..marketplace.resolver import parse_marketplace_ref
@@ -473,10 +481,15 @@ def display_versions(package: str, logger: CommandLogger) -> None:
         sys.exit(1)
 
     # Detect registry dep via lockfile and route to registry API.
-    _, _, _locked_source = _lookup_lockfile_ref(package, Path("."))
-    if _locked_source == "registry":
-        _display_registry_versions(package, dep_ref, logger)
-        return
+    # Only consult the lockfile when we have a project root with an apm.yml;
+    # this prevents mis-routing when the user is outside an APM project or
+    # running with --global (project_root=None).
+    _pr = project_root if project_root is not None else Path(".")
+    if (_pr / "apm.yml").is_file():
+        _, _, _locked_source = _lookup_lockfile_ref(package, _pr)
+        if _locked_source == "registry":
+            _display_registry_versions(package, dep_ref, logger)
+            return
 
     try:
         downloader = GitHubPackageDownloader(auth_resolver=AuthResolver())
@@ -572,7 +585,7 @@ def view(package: str, field: str | None, global_: bool):
             sys.exit(1)
 
         if field == "versions":
-            display_versions(package, logger)
+            display_versions(package, logger, project_root=None if global_ else Path("."))
             return
 
     # --- marketplace ref without explicit field -> show versions ---

--- a/src/apm_cli/commands/view.py
+++ b/src/apm_cli/commands/view.py
@@ -413,7 +413,7 @@ def _display_registry_versions(
         sys.exit(1)
 
     if not versions:
-        logger.progress(f"No versions found for '{package}'")
+        logger.warning(f"No versions found for '{package}'. Verify the package name and registry.")
         return
 
     try:
@@ -499,7 +499,7 @@ def display_versions(
         sys.exit(1)
 
     if not refs:
-        logger.progress(f"No versions found for '{package}'")
+        logger.warning(f"No versions found for '{package}'. Verify the package name and remote.")
         return
 
     # -- render with Rich table (fallback to plain text) ---------------

--- a/src/apm_cli/commands/view.py
+++ b/src/apm_cli/commands/view.py
@@ -90,7 +90,7 @@ def resolve_package_path(
 
 
 def _lookup_lockfile_ref(package: str, project_root: Path):
-    """Return (ref, commit) from the lockfile for *package*, or ("", "")."""
+    """Return (ref, commit, source) from the lockfile for *package*, or ("", "", "")."""
     try:
         from ..deps.lockfile import LockFile, get_lockfile_path, migrate_lockfile_if_needed
 
@@ -98,7 +98,7 @@ def _lookup_lockfile_ref(package: str, project_root: Path):
         lockfile_path = get_lockfile_path(project_root)
         lockfile = LockFile.read(lockfile_path)
         if lockfile is None:
-            return "", ""
+            return "", "", ""
 
         # Try exact key first, then substring match
         dep = lockfile.dependencies.get(package)
@@ -109,10 +109,10 @@ def _lookup_lockfile_ref(package: str, project_root: Path):
                     break
 
         if dep is not None:
-            return dep.resolved_ref or "", dep.resolved_commit or ""
+            return dep.resolved_ref or "", dep.resolved_commit or "", dep.source or ""
     except Exception:
         pass
-    return "", ""
+    return "", "", ""
 
 
 def display_package_info(
@@ -130,11 +130,12 @@ def display_package_info(
     try:
         package_info = _get_detailed_package_info(package_path)
 
-        # Look up lockfile entry for ref/commit info
+        # Look up lockfile entry for ref/commit/source info
         locked_ref = ""
         locked_commit = ""
+        locked_source = ""
         if project_root is not None:
-            locked_ref, locked_commit = _lookup_lockfile_ref(package, project_root)
+            locked_ref, locked_commit, locked_source = _lookup_lockfile_ref(package, project_root)
 
         try:
             from rich.console import Console
@@ -147,7 +148,7 @@ def display_package_info(
             content_lines.append(f"[bold]Version:[/bold] {package_info['version']}")
             content_lines.append(f"[bold]Description:[/bold] {package_info['description']}")
             content_lines.append(f"[bold]Author:[/bold] {package_info['author']}")
-            content_lines.append(f"[bold]Source:[/bold] {package_info['source']}")
+            content_lines.append(f"[bold]Source:[/bold] {locked_source or package_info['source']}")
             if locked_ref:
                 content_lines.append(f"[bold]Ref:[/bold] {locked_ref}")
             if locked_commit:
@@ -191,7 +192,7 @@ def display_package_info(
             click.echo(f"Version: {package_info['version']}")
             click.echo(f"Description: {package_info['description']}")
             click.echo(f"Author: {package_info['author']}")
-            click.echo(f"Source: {package_info['source']}")
+            click.echo(f"Source: {locked_source or package_info['source']}")
             if locked_ref:
                 click.echo(f"Ref: {locked_ref}")
             if locked_commit:

--- a/src/apm_cli/commands/view.py
+++ b/src/apm_cli/commands/view.py
@@ -336,6 +336,85 @@ def _display_marketplace_plugin(
         click.echo(f"  Install: apm install {plugin.name}@{marketplace_name}")
 
 
+def _display_registry_versions(
+    package: str,
+    dep_ref: DependencyReference,
+    logger: CommandLogger,
+) -> None:
+    """List available versions from the configured registry for a registry dep."""
+    from ..deps.registry.auth import make_auth_context
+    from ..deps.registry.client import RegistryClient, RegistryError
+    from ..deps.registry.config_loader import resolve_effective_registries
+
+    repo_url = dep_ref.repo_url
+    parts = [p for p in repo_url.split("/") if p]
+    if len(parts) < 2:
+        logger.error(f"Cannot parse owner/repo from '{package}'")
+        sys.exit(1)
+    owner = "/".join(parts[:-1]) if len(parts) > 2 else parts[0]
+    repo = parts[-1]
+
+    project_registries = None
+    project_default = None
+    try:
+        from ..models.apm_package import APMPackage
+
+        apm_yml = Path(".") / "apm.yml"
+        if apm_yml.is_file():
+            pkg = APMPackage.from_apm_yml(apm_yml)
+            project_registries = pkg.registries
+            project_default = pkg.default_registry
+    except Exception:
+        pass
+
+    registries, default_registry = resolve_effective_registries(project_registries, project_default)
+    if not registries or not default_registry:
+        logger.error(f"No registry configured; cannot list versions for '{package}'")
+        sys.exit(1)
+    registry_url = registries.get(default_registry)
+    if not registry_url:
+        logger.error(f"Registry '{default_registry}' has no URL configured")
+        sys.exit(1)
+
+    try:
+        auth = make_auth_context(default_registry)
+        client = RegistryClient(registry_url, auth)
+        versions = client.list_versions(owner, repo)
+    except RegistryError as exc:
+        logger.error(f"Failed to list versions for '{package}': {exc}")
+        sys.exit(1)
+
+    if not versions:
+        logger.progress(f"No versions found for '{package}'")
+        return
+
+    try:
+        from rich.console import Console
+        from rich.table import Table
+
+        console = Console()
+        table = Table(
+            title=f"Available versions: {package}",
+            show_header=True,
+            header_style="bold cyan",
+        )
+        table.add_column("Version", style="bold white")
+        table.add_column("Published", style="dim white")
+
+        for entry in sorted(versions, key=lambda e: e.version):
+            table.add_row(entry.version, entry.published_at)
+
+        console.print(table)
+
+    except ImportError:
+        click.echo(f"Available versions: {package}")
+        click.echo("-" * 50)
+        click.echo(f"{'Version':<20} {'Published':<30}")
+        click.echo("-" * 50)
+        for entry in sorted(versions, key=lambda e: e.version):
+            click.echo(f"{entry.version:<20} {entry.published_at:<30}")
+
+
 def display_versions(package: str, logger: CommandLogger) -> None:
     """Query and display available remote versions (tags/branches).
 
@@ -358,12 +437,18 @@ def display_versions(package: str, logger: CommandLogger) -> None:
         _display_marketplace_plugin(plugin_name, marketplace_name, logger)
         return
 
-    # -- Git-based path (unchanged) --
+    # -- Git-based path --
     try:
         dep_ref = DependencyReference.parse(package)
     except ValueError as exc:
         logger.error(f"Invalid package reference '{package}': {exc}")
         sys.exit(1)
+
+    # Detect registry dep via lockfile and route to registry API.
+    _, _, _locked_source = _lookup_lockfile_ref(package, Path("."))
+    if _locked_source == "registry":
+        _display_registry_versions(package, dep_ref, logger)
+        return
 
     try:
         downloader = GitHubPackageDownloader(auth_resolver=AuthResolver())

--- a/src/apm_cli/deps/lockfile.py
+++ b/src/apm_cli/deps/lockfile.py
@@ -414,12 +414,17 @@ class LockedDependency:
         else:
             source = None
 
-        # When a git-semver resolution is present, prefer the concrete
-        # resolved tag for ``resolved_ref`` (so subsequent installs see a
-        # literal tag, not the original range). The original constraint
-        # is preserved in the dedicated ``constraint`` field.
+        # Prefer the concrete resolved identifier for ``resolved_ref`` so that
+        # ``build_update_plan`` can detect real version changes by comparing
+        # old_ref (locked concrete) vs new_ref (freshly resolved concrete).
+        # Registry deps: store the resolved version (e.g. "1.0.3"), not the
+        # range ("^1.0.0").  Git-semver deps: store the resolved tag.  Both
+        # preserve the original selector in their dedicated fields
+        # (``version`` / ``constraint`` respectively).
         if git_semver_resolution is not None:
             resolved_ref_val: str | None = git_semver_resolution.resolved_tag
+        elif registry_resolution is not None:
+            resolved_ref_val = registry_resolution.version
         else:
             resolved_ref_val = dep_ref.reference
 

--- a/src/apm_cli/deps/registry/resolver.py
+++ b/src/apm_cli/deps/registry/resolver.py
@@ -424,8 +424,9 @@ class RegistryPackageResolver:
             ref = dep_ref.reference or ""
             if ref and not is_semver_range(ref):
                 msg += (
-                    f"\nHint: '{ref}' looks like a git ref, not a semver range. "
-                    f"If this package lives on GitHub, use the explicit git form:\n"
+                    f"\nHint: verify the package name and registry configuration. "
+                    f"'{ref}' also looks like a git ref, not a semver range; "
+                    f"if this package lives on GitHub, use the explicit git form:\n"
                     f"  - git: {dep_ref.repo_url}#{ref}"
                 )
             raise RegistryResolutionError(msg) from exc

--- a/src/apm_cli/deps/registry/resolver.py
+++ b/src/apm_cli/deps/registry/resolver.py
@@ -417,10 +417,18 @@ class RegistryPackageResolver:
         if exc.status in (401, 403):
             raise RegistryResolutionError(f"{exc}\n{remediation_message(base_url)}") from exc
         if exc.status == 404:
-            raise RegistryResolutionError(
+            msg = (
                 f"registry {dep_ref.registry_name!r} has no package "
                 f"{dep_ref.repo_url!r} (HTTP 404 from {exc.url})"
-            ) from exc
+            )
+            ref = dep_ref.reference or ""
+            if ref and not is_semver_range(ref):
+                msg += (
+                    f"\nHint: '{ref}' looks like a git ref, not a semver range. "
+                    f"If this package lives on GitHub, use the explicit git form:\n"
+                    f"  - git: {dep_ref.repo_url}#{ref}"
+                )
+            raise RegistryResolutionError(msg) from exc
         raise RegistryResolutionError(str(exc)) from exc
 
 

--- a/src/apm_cli/install/drift.py
+++ b/src/apm_cli/install/drift.py
@@ -247,15 +247,19 @@ def _materialize_install_path(
     # unverifiable -- there is no marker we can write at install time and
     # no commit we can compare at audit time. Refuse to replay it rather
     # than silently trust whatever happens to live in the cache.
-    if getattr(lock_dep, "source", None) != "local" and not lock_dep.resolved_commit:
+    if (
+        getattr(lock_dep, "source", None) not in {"local", "registry"}
+        and not lock_dep.resolved_commit
+    ):
         raise CacheMissError(
             f"cannot replay {lock_dep.repo_url}: lockfile entry has no resolved_commit "
             "(cache freshness unverifiable). Re-run 'apm install' with a pinned ref "
             "(commit, tag, or specific branch HEAD) before audit."
         )
     if not candidate.exists():
+        _ref_label = lock_dep.resolved_commit or lock_dep.version or "unknown"
         raise CacheMissError(
-            f"cache miss for {lock_dep.repo_url}@{lock_dep.resolved_commit}: "
+            f"cache miss for {lock_dep.repo_url}@{_ref_label}: "
             f"expected {candidate}; run 'apm install' to populate the cache"
         )
     # Stale-cache detection: verify the cache pin marker matches the

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -23,6 +23,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from apm_cli.models.apm_package import GitReferenceType, ResolvedReference
 from apm_cli.utils.short_sha import format_short_sha
 
 if TYPE_CHECKING:
@@ -183,7 +184,7 @@ def _purge_cached_semver_paths_for_update(
     apm_modules_dir,
     logger,
 ) -> None:
-    """Pre-purge on-disk install paths for direct git-source semver deps
+    """Pre-purge on-disk install paths for direct git-source and registry semver deps
     when ``--update`` / ``--refresh`` is set.
 
     Bug 1 fix (#1496): the BFS resolver short-circuits at
@@ -196,9 +197,9 @@ def _purge_cached_semver_paths_for_update(
     trigger and must not be swallowed by the on-disk cache. Scoped to
     direct deps to avoid disturbing transitive cached content; the
     resolver re-walks transitives naturally once a direct dep's
-    callback rewrites its ref. Local, registry, and proxy deps are
-    excluded -- their semver semantics (if any) belong to a different
-    resolver path.
+    callback rewrites its ref. Local and proxy deps are excluded (their
+    semver semantics belong to a different resolver path). Registry semver
+    deps are included: their callback also gates on install_path.exists().
     """
     from contextlib import suppress
 
@@ -208,8 +209,6 @@ def _purge_cached_semver_paths_for_update(
         if getattr(_dep, "ref_kind", None) != "semver":
             continue
         if _dep.is_local:
-            continue
-        if getattr(_dep, "source", None) == "registry":
             continue
         if getattr(_dep, "artifactory_prefix", None):
             continue
@@ -357,6 +356,17 @@ def _setup_downloader(ctx: InstallContext) -> None:
         )
 
 
+def _annotate_registry_dep_ref(dep_ref, registry_resolver) -> None:
+    reg_res = registry_resolver.last_resolutions.get(dep_ref.get_unique_key())
+    if not reg_res:
+        return
+    dep_ref.resolved_reference = ResolvedReference(
+        original_ref=dep_ref.reference or reg_res.version,
+        ref_type=GitReferenceType.TAG,
+        ref_name=reg_res.version,
+    )
+
+
 def _fail_on_resolution_errors(ctx: InstallContext, dependency_graph) -> None:
     """Raise when the resolver recorded fatal dependency-resolution errors."""
     if not dependency_graph.resolution_errors:
@@ -488,7 +498,6 @@ def _resolve_dependencies(ctx: InstallContext) -> None:
             _force_semver_resolve = (
                 update_refs
                 and not dep_ref.is_local
-                and getattr(dep_ref, "source", None) != "registry"
                 and not getattr(dep_ref, "artifactory_prefix", None)
                 and getattr(dep_ref, "ref_kind", None) == "semver"
             )
@@ -565,6 +574,7 @@ def _resolve_dependencies(ctx: InstallContext) -> None:
                         callback_downloaded[dep_ref.get_unique_key()] = None
                         return install_path
                 registry_resolver.download_package(dep_ref, install_path)
+                _annotate_registry_dep_ref(dep_ref, registry_resolver)
                 # Mark as already-downloaded so the parallel pre-download
                 # phase skips this dep. No SHA for registry deps.
                 callback_downloaded[dep_ref.get_unique_key()] = None

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -27,7 +27,6 @@ from apm_cli.models.apm_package import GitReferenceType, ResolvedReference
 from apm_cli.utils.short_sha import format_short_sha
 
 if TYPE_CHECKING:
-    from apm_cli.deps.registry.resolver import RegistryPackageResolver
     from apm_cli.install.context import InstallContext
     from apm_cli.models.dependency.reference import DependencyReference
 
@@ -357,10 +356,7 @@ def _setup_downloader(ctx: InstallContext) -> None:
         )
 
 
-def _annotate_registry_dep_ref(
-    dep_ref: DependencyReference,
-    registry_resolver: RegistryPackageResolver,
-) -> None:
+def _annotate_registry_dep_ref(dep_ref, registry_resolver) -> None:
     reg_res = registry_resolver.last_resolutions.get(dep_ref.get_unique_key())
     if not reg_res:
         return

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -27,6 +27,7 @@ from apm_cli.models.apm_package import GitReferenceType, ResolvedReference
 from apm_cli.utils.short_sha import format_short_sha
 
 if TYPE_CHECKING:
+    from apm_cli.deps.registry.resolver import RegistryPackageResolver
     from apm_cli.install.context import InstallContext
     from apm_cli.models.dependency.reference import DependencyReference
 
@@ -356,7 +357,10 @@ def _setup_downloader(ctx: InstallContext) -> None:
         )
 
 
-def _annotate_registry_dep_ref(dep_ref, registry_resolver) -> None:
+def _annotate_registry_dep_ref(
+    dep_ref: DependencyReference,
+    registry_resolver: RegistryPackageResolver,
+) -> None:
     reg_res = registry_resolver.last_resolutions.get(dep_ref.get_unique_key())
     if not reg_res:
         return

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -358,7 +358,7 @@ def _setup_downloader(ctx: InstallContext) -> None:
 
 def _annotate_registry_dep_ref(dep_ref, registry_resolver) -> None:
     reg_res = registry_resolver.last_resolutions.get(dep_ref.get_unique_key())
-    if not reg_res:
+    if not reg_res or not reg_res.version:
         return
     dep_ref.resolved_reference = ResolvedReference(
         original_ref=dep_ref.reference or reg_res.version,

--- a/src/apm_cli/install/plan.py
+++ b/src/apm_cli/install/plan.py
@@ -309,7 +309,11 @@ def _format_ref_change(entry: PlanEntry) -> str:
     old_ref = entry.old_resolved_ref or "-"
     new_ref = entry.new_resolved_ref or old_ref
     ref_part = old_ref if old_ref == new_ref else f"{old_ref} -> {new_ref}"
-    return f"{ref_part} ({entry.short_old_commit} -> {entry.short_new_commit})"
+    old_c = entry.short_old_commit
+    new_c = entry.short_new_commit
+    if old_c == "-" and new_c == "-":
+        return ref_part
+    return f"{ref_part} ({old_c} -> {new_c})"
 
 
 def render_plan_text(plan: UpdatePlan, *, verbose: bool = False) -> str:

--- a/src/apm_cli/install/sources.py
+++ b/src/apm_cli/install/sources.py
@@ -653,6 +653,8 @@ class FreshDependencySource(DependencySource):
                 package_info = ctx.pre_download_results[dep_key]
             elif dep_ref.source == "registry":
                 if dep_key in ctx.callback_failures:
+                    # Resolve already surfaced the registry failure; do not
+                    # retry through the git fallback path.
                     return None
                 from apm_cli.deps.registry.feature_gate import (
                     require_package_registry_enabled,

--- a/src/apm_cli/install/sources.py
+++ b/src/apm_cli/install/sources.py
@@ -425,7 +425,13 @@ class CachedDependencySource(DependencySource):
         logger = ctx.logger
 
         display_name = str(dep_ref) if dep_ref.is_virtual else dep_ref.repo_url
-        _ref = dep_ref.reference or ""
+        _rref = getattr(dep_ref, "resolved_reference", None)
+        if _rref and getattr(_rref, "ref_name", None):
+            _ref = _rref.ref_name
+        elif dep_locked_chk and getattr(dep_locked_chk, "resolved_ref", None):
+            _ref = dep_locked_chk.resolved_ref
+        else:
+            _ref = dep_ref.reference or ""
         # F3 (#1116): centralised hex/sentinel-aware short SHA helper.
         # Prefer the lockfile-recorded SHA when present; otherwise fall
         # back to the SHA captured by the parallel resolver callback in
@@ -646,6 +652,8 @@ class FreshDependencySource(DependencySource):
             if dep_key in ctx.pre_download_results:
                 package_info = ctx.pre_download_results[dep_key]
             elif dep_ref.source == "registry":
+                if dep_key in ctx.callback_failures:
+                    return None
                 from apm_cli.deps.registry.feature_gate import (
                     require_package_registry_enabled,
                 )

--- a/src/apm_cli/install/sources.py
+++ b/src/apm_cli/install/sources.py
@@ -396,7 +396,12 @@ class CachedDependencySource(DependencySource):
             if locked_dep and locked_dep.resolved_commit and locked_dep.resolved_commit != "cached":
                 cached_commit = locked_dep.resolved_commit
         if not cached_commit:
-            cached_commit = dep_ref.reference
+            # Registry deps identify by resolved_hash+version, not a commit SHA.
+            # dep_ref.reference is a semver range (e.g. "^1.0.0") for registry
+            # deps -- storing it as resolved_commit would corrupt the lockfile
+            # and cause the update plan to show a spurious "^1.0.0 -> -" diff.
+            if dep_ref.source != "registry":
+                cached_commit = dep_ref.reference
         return cached_commit
 
     def acquire(self) -> Materialization | None:

--- a/src/apm_cli/install/sources.py
+++ b/src/apm_cli/install/sources.py
@@ -430,6 +430,14 @@ class CachedDependencySource(DependencySource):
             _ref = _rref.ref_name
         elif dep_locked_chk and getattr(dep_locked_chk, "resolved_ref", None):
             _ref = dep_locked_chk.resolved_ref
+        elif dep_ref.source == "registry":
+            # Fresh install: exact version lives in the resolver's last_resolutions
+            # map (populated by the BFS callback). Fall back to dep_ref.reference
+            # only if the resolver has no record (should not normally happen).
+            from apm_cli.install.registry_wiring import resolver_last_registry_resolution
+
+            _reg_res = resolver_last_registry_resolution(ctx, dep_key)
+            _ref = _reg_res.version if _reg_res else (dep_ref.reference or "")
         else:
             _ref = dep_ref.reference or ""
         # F3 (#1116): centralised hex/sentinel-aware short SHA helper.

--- a/tests/integration/test_view_coverage.py
+++ b/tests/integration/test_view_coverage.py
@@ -136,7 +136,7 @@ class TestLookupLockfileRef:
                     mock_get_path.return_value = tmp_path / "apm.lock.yaml"
                     mock_lf_class.read.return_value = mock_lockfile
 
-                    ref, commit = _lookup_lockfile_ref("owner/repo", tmp_path)
+                    ref, commit, _source = _lookup_lockfile_ref("owner/repo", tmp_path)
 
                     assert ref == "v1.0.0"
                     assert commit == "abc123def456"
@@ -149,7 +149,7 @@ class TestLookupLockfileRef:
                     mock_get_path.return_value = tmp_path / "nonexistent.lock.yaml"
                     mock_lf_class.read.return_value = None
 
-                    ref, commit = _lookup_lockfile_ref("owner/repo", tmp_path)
+                    ref, commit, _source = _lookup_lockfile_ref("owner/repo", tmp_path)
 
                     assert ref == ""
                     assert commit == ""
@@ -159,7 +159,7 @@ class TestLookupLockfileRef:
         with patch("apm_cli.deps.lockfile.migrate_lockfile_if_needed") as mock_migrate:
             mock_migrate.side_effect = Exception("Lockfile error")
 
-            ref, commit = _lookup_lockfile_ref("owner/repo", tmp_path)
+            ref, commit, _source = _lookup_lockfile_ref("owner/repo", tmp_path)
 
             assert ref == ""
             assert commit == ""

--- a/tests/unit/deps/test_lockfile_git_semver.py
+++ b/tests/unit/deps/test_lockfile_git_semver.py
@@ -199,6 +199,59 @@ class TestInstalledPackagePlumbing:
         assert ld.version == "1.5.3"
 
 
+class TestRegistryDepResolvedRef:
+    """from_dependency_ref uses registry_resolution.version for resolved_ref.
+
+    Regression tests for the lockfile-corruption bug where a cached re-install
+    of a registry dep wrote the manifest range (^1.0.0) as resolved_ref instead
+    of the exact resolved version (1.1.1).
+    """
+
+    def test_registry_resolution_sets_resolved_ref_to_version(self) -> None:
+        from apm_cli.deps.registry.resolver import RegistryResolution
+
+        dep_ref = _make_dep_ref(reference="^1.0.0")
+        reg_res = RegistryResolution(
+            resolved_url="https://registry.example/pkg/1.1.1.tgz",
+            resolved_hash="sha256:abc",
+            version="1.1.1",
+        )
+
+        locked = LockedDependency.from_dependency_ref(
+            dep_ref=dep_ref,
+            resolved_commit=None,
+            depth=1,
+            resolved_by=None,
+            registry_resolution=reg_res,
+        )
+
+        assert locked.resolved_ref == "1.1.1", (
+            "resolved_ref must be the exact version, not the manifest range"
+        )
+        assert locked.resolved_commit is None
+        assert locked.source == "registry"
+
+    def test_registry_resolved_ref_roundtrips(self) -> None:
+        from apm_cli.deps.registry.resolver import RegistryResolution
+
+        dep_ref = _make_dep_ref(reference="^1.0.0")
+        reg_res = RegistryResolution(
+            resolved_url="https://registry.example/pkg/1.1.1.tgz",
+            resolved_hash="sha256:abc",
+            version="1.1.1",
+        )
+        locked = LockedDependency.from_dependency_ref(
+            dep_ref=dep_ref,
+            resolved_commit=None,
+            depth=1,
+            resolved_by=None,
+            registry_resolution=reg_res,
+        )
+        rebuilt = LockedDependency.from_dict(locked.to_dict())
+        assert rebuilt.resolved_ref == "1.1.1"
+        assert rebuilt.resolved_commit is None
+
+
 class TestMutualExclusivity:
     """``from_dependency_ref`` enforces resolution-source mutual exclusivity.
 

--- a/tests/unit/install/test_drift_detection.py
+++ b/tests/unit/install/test_drift_detection.py
@@ -170,6 +170,23 @@ class TestMaterializeInstallPath:
         with pytest.raises(CacheMissError, match="no resolved_commit"):
             _materialize_install_path(dep, tmp_path, tmp_path / "apm_modules", cache_only=True)
 
+    def test_registry_dep_no_commit_uses_existing_cache(self, tmp_path: Path) -> None:
+        from apm_cli.install.drift import _materialize_install_path
+
+        apm_modules = tmp_path / "apm_modules"
+        cached = apm_modules / "owner" / "repo"
+        cached.mkdir(parents=True)
+        dep = LockedDependency(
+            repo_url="owner/repo",
+            source="registry",
+            resolved_commit=None,
+            version="1.0.0",
+        )
+
+        result = _materialize_install_path(dep, tmp_path, apm_modules, cache_only=True)
+
+        assert result == cached
+
 
 # ---------------------------------------------------------------------------
 # _build_package_info

--- a/tests/unit/install/test_plan.py
+++ b/tests/unit/install/test_plan.py
@@ -240,6 +240,27 @@ class TestRenderPlanText:
         assert "[=]" in text
         assert "1 unchanged" in text
 
+    def test_registry_update_suppresses_dash_to_dash_when_both_commits_absent(self):
+        """Registry deps (no resolved_commit) must not produce a confusing (- -> -) indicator."""
+        plan = UpdatePlan(
+            entries=(
+                PlanEntry(
+                    dep_key="o/r",
+                    action="update",
+                    display_name="o/r",
+                    old_resolved_ref="1.0.0",
+                    new_resolved_ref="1.1.0",
+                    old_resolved_commit=None,
+                    new_resolved_commit=None,
+                ),
+            )
+        )
+
+        text = render_plan_text(plan)
+
+        assert "- -> -" not in text
+        assert "1.0.0 -> 1.1.0" in text
+
 
 # -----------------------------------------------------------------------------
 # lockfile_satisfies_manifest

--- a/tests/unit/install/test_sources_phase3.py
+++ b/tests/unit/install/test_sources_phase3.py
@@ -465,6 +465,36 @@ class TestResolveCachedCommit:
         result = source._resolve_cached_commit()
         assert result == "sha-xyz"
 
+    def test_registry_dep_skips_reference_fallback(self) -> None:
+        """Registry deps must not store dep_ref.reference as resolved_commit.
+
+        dep_ref.reference is a semver range (e.g. '^1.0.0') for registry deps.
+        Storing it as resolved_commit corrupts the lockfile and causes the
+        update plan to show a spurious '^1.0.0 -> -' diff.
+        """
+        ctx = _make_ctx(existing_lockfile=None)
+        dep_ref = _make_dep_ref(reference="^1.0.0")
+        dep_ref.source = "registry"
+        source = self._make_source(ctx, dep_ref, fetched_this_run=False)
+
+        result = source._resolve_cached_commit()
+        assert result is None
+
+    def test_registry_dep_with_lockfile_sha_still_uses_sha(self) -> None:
+        """Registry dep: when lockfile has a real SHA, carry it forward."""
+        locked_dep = MagicMock()
+        locked_dep.resolved_commit = "abc1234def5678"
+        existing_lockfile = MagicMock()
+        existing_lockfile.get_dependency.return_value = locked_dep
+
+        ctx = _make_ctx(existing_lockfile=existing_lockfile)
+        dep_ref = _make_dep_ref(reference="^1.0.0")
+        dep_ref.source = "registry"
+        source = self._make_source(ctx, dep_ref, fetched_this_run=False)
+
+        result = source._resolve_cached_commit()
+        assert result == "abc1234def5678"
+
 
 # ---------------------------------------------------------------------------
 # CachedDependencySource.acquire

--- a/tests/unit/registry/test_resolver.py
+++ b/tests/unit/registry/test_resolver.py
@@ -211,6 +211,23 @@ class TestFailurePaths:
             resolver.download_package(_make_dep(), tmp_path / "p")
         assert "no package" in str(excinfo.value)
 
+    def test_404_git_ref_hint_names_registry_first(self, tmp_path):
+        fake = MagicMock(spec=RegistryClient)
+        fake.list_versions.side_effect = RegistryError(
+            "not found",
+            status=404,
+            url="https://reg.example.com/apm/v1/packages/acme/web-skills/versions",
+        )
+        resolver = _make_resolver(fake)
+
+        with pytest.raises(RegistryResolutionError) as excinfo:
+            resolver.download_package(_make_dep("main"), tmp_path / "p")
+
+        msg = str(excinfo.value)
+        assert "verify the package name and registry configuration" in msg
+        assert "looks like a git ref" in msg
+        assert "- git: acme/web-skills#main" in msg
+
     def test_unconfigured_registry_name(self, tmp_path):
         # Resolver knows about 'corp-main', dep references 'corp-other'.
         fake = MagicMock(spec=RegistryClient)

--- a/tests/unit/test_deps_list_tree_info.py
+++ b/tests/unit/test_deps_list_tree_info.py
@@ -83,6 +83,7 @@ def test_deps_list_source_label_mapping():
     """Source labels follow host class: local, ADO, GitLab, default GitHub bucket."""
     assert _deps_list_source_label(None, is_local=True) == "local"
     assert _deps_list_source_label(None, lockfile_source="local") == "local"
+    assert _deps_list_source_label(None, lockfile_source="registry") == "registry"
     assert _deps_list_source_label("gitlab.com") == "gitlab"
     assert _deps_list_source_label("dev.azure.com") == "azure-devops"
     assert _deps_list_source_label("github.com") == "github"

--- a/tests/unit/test_install_update_refs.py
+++ b/tests/unit/test_install_update_refs.py
@@ -327,3 +327,113 @@ class TestAlreadyResolvedSkipLogic:
             lockfile_match=lockfile_match,
         )
         assert result is expected
+
+
+# ===========================================================================
+# TestForceSemverResolve -- BFS callback early-return guard
+# ===========================================================================
+
+
+def _force_semver_resolve(
+    *,
+    update_refs: bool,
+    is_local: bool,
+    source: str | None,
+    artifactory_prefix: str | None,
+    ref_kind: str | None,
+) -> bool:
+    """Mirror of the _force_semver_resolve expression in download_callback.
+
+    Kept in sync with resolve.py so that any change to the production
+    condition surfaces here as a test failure.
+    """
+    return update_refs and not is_local and not artifactory_prefix and ref_kind == "semver"
+
+
+class TestForceSemverResolve:
+    """BFS download_callback must re-resolve semver deps on --update.
+
+    When install_path exists the callback short-circuits UNLESS
+    _force_semver_resolve is True.  Regression guard for the bug where
+    registry deps with semver constraints were excluded from re-resolution,
+    causing 'apm update' to silently keep the old version even when a newer
+    one satisfying the range was available.
+    """
+
+    def test_registry_semver_forces_resolve_on_update(self) -> None:
+        """Registry dep with ^1.0.0 must re-resolve when update_refs=True."""
+        assert (
+            _force_semver_resolve(
+                update_refs=True,
+                is_local=False,
+                source="registry",
+                artifactory_prefix=None,
+                ref_kind="semver",
+            )
+            is True
+        )
+
+    def test_registry_semver_no_force_on_normal_install(self) -> None:
+        """Registry semver dep must NOT re-resolve on a plain install."""
+        assert (
+            _force_semver_resolve(
+                update_refs=False,
+                is_local=False,
+                source="registry",
+                artifactory_prefix=None,
+                ref_kind="semver",
+            )
+            is False
+        )
+
+    def test_git_semver_forces_resolve_on_update(self) -> None:
+        """Git-source semver dep continues to re-resolve (pre-existing behavior)."""
+        assert (
+            _force_semver_resolve(
+                update_refs=True,
+                is_local=False,
+                source=None,
+                artifactory_prefix=None,
+                ref_kind="semver",
+            )
+            is True
+        )
+
+    def test_registry_literal_ref_no_force(self) -> None:
+        """Registry dep with a literal ref (e.g. 'stable') is never force-resolved."""
+        assert (
+            _force_semver_resolve(
+                update_refs=True,
+                is_local=False,
+                source="registry",
+                artifactory_prefix=None,
+                ref_kind="literal",
+            )
+            is False
+        )
+
+    def test_local_dep_never_force_resolved(self) -> None:
+        """Local deps are excluded regardless of ref_kind."""
+        assert (
+            _force_semver_resolve(
+                update_refs=True,
+                is_local=True,
+                source=None,
+                artifactory_prefix=None,
+                ref_kind="semver",
+            )
+            is False
+        )
+
+    def test_artifactory_dep_never_force_resolved(self) -> None:
+        """Artifactory-proxied deps are excluded regardless of ref_kind."""
+        assert (
+            _force_semver_resolve(
+                update_refs=True,
+                is_local=False,
+                source=None,
+                artifactory_prefix="artifactory/github",
+                ref_kind="semver",
+            )
+            is False
+        )

--- a/tests/unit/test_lockfile_v2_bump.py
+++ b/tests/unit/test_lockfile_v2_bump.py
@@ -223,6 +223,39 @@ class TestFromDependencyRefWithResolution:
         assert locked.resolved_url == resolution.resolved_url
         assert locked.resolved_hash == "sha256:def"
         assert locked.version == "1.5.0"
+        # resolved_ref must be the concrete version, not the semver range.
+        # Storing the range causes build_update_plan to see a perpetual
+        # old_ref/new_ref mismatch after fix #2 annotates the BFS dep_ref.
+        assert locked.resolved_ref == "1.5.0"
+
+    def test_registry_resolution_resolved_ref_is_version_not_range(self):
+        """resolved_ref stores the concrete version for registry deps.
+
+        Regression guard for the fix that prevents storing the semver range
+        (e.g. '^1.0.0') as resolved_ref.  If resolved_ref were the range,
+        build_update_plan would compare old_ref='range' vs new_ref='version'
+        and show a spurious UPDATE on every apm update run.
+        """
+        dep = DependencyReference(
+            repo_url="acme/tool",
+            reference="^2.0.0",
+            source="registry",
+            registry_name="corp",
+        )
+        resolution = RegistryResolution(
+            resolved_url="https://r/v1/packages/acme/tool/versions/2.3.1/tarball",
+            resolved_hash="sha256:abc",
+            version="2.3.1",
+        )
+        locked = LockedDependency.from_dependency_ref(
+            dep,
+            resolved_commit=None,
+            depth=1,
+            resolved_by=None,
+            registry_resolution=resolution,
+        )
+        assert locked.resolved_ref == "2.3.1"
+        assert locked.resolved_ref != dep.reference
 
     def test_no_resolution_means_no_registry_fields(self):
         # Existing git-resolver call site (no registry_resolution arg)

--- a/tests/unit/test_view_command.py
+++ b/tests/unit/test_view_command.py
@@ -218,6 +218,23 @@ class TestViewCommand(_InfoCmdBase):
         assert result.exit_code == 0
         assert "main" in result.output
 
+    def test_view_versions_routes_registry_dep_to_registry_api(self):
+        """display_versions delegates to the registry API for a lockfile-confirmed registry dep."""
+        with self._chdir_tmp() as tmp:
+            (tmp / "apm.yml").write_text("name: testproject\nversion: 1.0.0\n")
+            with (
+                patch(
+                    "apm_cli.commands.view._lookup_lockfile_ref",
+                    return_value=("^1.0.0", "", "registry"),
+                ),
+                patch("apm_cli.commands.view._display_registry_versions") as mock_reg,
+                patch("apm_cli.commands.view.GitHubPackageDownloader") as mock_gh,
+            ):
+                result = self.runner.invoke(cli, ["view", "myorg/myrepo", "versions"])
+        assert result.exit_code == 0
+        mock_reg.assert_called_once()
+        mock_gh.return_value.list_remote_refs.assert_not_called()
+
     # -- invalid field ----------------------------------------------------
 
     def test_view_invalid_field(self):

--- a/tests/unit/test_view_command.py
+++ b/tests/unit/test_view_command.py
@@ -411,7 +411,7 @@ class TestViewCommand(_InfoCmdBase):
             with (
                 patch(
                     "apm_cli.commands.view._lookup_lockfile_ref",
-                    return_value=("v2.0.0", "abcdef1234567890deadbeef"),
+                    return_value=("v2.0.0", "abcdef1234567890deadbeef", ""),
                 ),
                 _force_rich_fallback(),
             ):
@@ -434,9 +434,10 @@ class TestLookupLockfileRef(_InfoCmdBase):
         from apm_cli.commands.view import _lookup_lockfile_ref
 
         with self._chdir_tmp() as tmp:
-            ref, commit = _lookup_lockfile_ref("org/repo", tmp)
+            ref, commit, _source = _lookup_lockfile_ref("org/repo", tmp)
         assert ref == ""
         assert commit == ""
+        assert _source == ""
 
     def test_exact_match(self):
         """Returns ref/commit for exact lockfile key match."""
@@ -454,7 +455,7 @@ class TestLookupLockfileRef(_InfoCmdBase):
             patch("apm_cli.deps.lockfile.migrate_lockfile_if_needed"),
         ):  # patched to prevent real I/O
             mock_lf.read.return_value = mock_lockfile
-            ref, commit = _lookup_lockfile_ref("org/repo", Path("/fake"))
+            ref, commit, _source = _lookup_lockfile_ref("org/repo", Path("/fake"))
         assert ref == "v1.0.0"
         assert commit == "abc123"
 
@@ -477,7 +478,7 @@ class TestLookupLockfileRef(_InfoCmdBase):
             patch("apm_cli.deps.lockfile.migrate_lockfile_if_needed"),
         ):  # patched to prevent real I/O
             mock_lf.read.return_value = mock_lockfile
-            ref, commit = _lookup_lockfile_ref("org/repo", Path("/fake"))
+            ref, commit, _source = _lookup_lockfile_ref("org/repo", Path("/fake"))
         assert ref == "main"
         assert commit == "deadbeef"
 
@@ -494,7 +495,7 @@ class TestLookupLockfileRef(_InfoCmdBase):
             patch("apm_cli.deps.lockfile.migrate_lockfile_if_needed"),
         ):  # patched to prevent real I/O
             mock_lf.read.return_value = mock_lockfile
-            ref, commit = _lookup_lockfile_ref("nomatch", Path("/fake"))
+            ref, commit, _source = _lookup_lockfile_ref("nomatch", Path("/fake"))
         assert ref == ""
         assert commit == ""
 
@@ -506,7 +507,7 @@ class TestLookupLockfileRef(_InfoCmdBase):
             "apm_cli.deps.lockfile.migrate_lockfile_if_needed",
             side_effect=RuntimeError("boom"),
         ):
-            ref, commit = _lookup_lockfile_ref("x", Path("/fake"))
+            ref, commit, _source = _lookup_lockfile_ref("x", Path("/fake"))
         assert ref == ""
         assert commit == ""
 
@@ -520,7 +521,7 @@ class TestLookupLockfileRef(_InfoCmdBase):
             patch("apm_cli.deps.lockfile.migrate_lockfile_if_needed"),
         ):  # patched to prevent real I/O
             mock_lf.read.return_value = None
-            ref, commit = _lookup_lockfile_ref("org/repo", Path("/fake"))
+            ref, commit, _source = _lookup_lockfile_ref("org/repo", Path("/fake"))
         assert ref == ""
         assert commit == ""
 

--- a/tests/unit/test_view_command_cli_surface.py
+++ b/tests/unit/test_view_command_cli_surface.py
@@ -167,7 +167,7 @@ class TestDisplayPackageInfo:
             ),
             patch(
                 "apm_cli.commands.view._lookup_lockfile_ref",
-                return_value=("v1.0.0", "abc123456789"),
+                return_value=("v1.0.0", "abc123456789", ""),
             ),
         ):
             display_package_info("org/repo", tmp_path, logger, project_root=tmp_path)
@@ -184,7 +184,7 @@ class TestDisplayPackageInfo:
                 "apm_cli.commands.view._get_detailed_package_info",
                 return_value=pkg_info,
             ),
-            patch("apm_cli.commands.view._lookup_lockfile_ref", return_value=("", "")),
+            patch("apm_cli.commands.view._lookup_lockfile_ref", return_value=("", "", "")),
         ):
             display_package_info("org/repo", tmp_path, logger, project_root=tmp_path)
 
@@ -200,7 +200,7 @@ class TestDisplayPackageInfo:
                 "apm_cli.commands.view._get_detailed_package_info",
                 return_value=pkg_info,
             ),
-            patch("apm_cli.commands.view._lookup_lockfile_ref", return_value=("", "")),
+            patch("apm_cli.commands.view._lookup_lockfile_ref", return_value=("", "", "")),
         ):
             display_package_info("org/repo", tmp_path, logger, project_root=tmp_path)
 
@@ -232,7 +232,9 @@ class TestDisplayPackageInfo:
                 "apm_cli.commands.view._get_detailed_package_info",
                 return_value=pkg_info,
             ),
-            patch("apm_cli.commands.view._lookup_lockfile_ref", return_value=("v1.0", "abc123")),
+            patch(
+                "apm_cli.commands.view._lookup_lockfile_ref", return_value=("v1.0", "abc123", "")
+            ),
             patch.dict(sys.modules, {"rich.console": None, "rich.panel": None}),
         ):
             display_package_info("org/repo", tmp_path, logger, project_root=tmp_path)

--- a/tests/unit/test_view_command_cli_surface.py
+++ b/tests/unit/test_view_command_cli_surface.py
@@ -434,7 +434,7 @@ class TestDisplayVersions:
         ):
             display_versions("org/repo", logger)
 
-    def test_no_refs_logs_progress(self):
+    def test_no_refs_logs_warning(self):
         from apm_cli.commands.view import display_versions
 
         logger = _make_logger()
@@ -449,7 +449,7 @@ class TestDisplayVersions:
             ),
         ):
             display_versions("org/repo", logger)
-        logger.progress.assert_called()
+        logger.warning.assert_called()
 
     def test_rich_table_rendered_with_refs(self):
         from apm_cli.commands.view import display_versions

--- a/tests/unit/test_view_command_phase3w5.py
+++ b/tests/unit/test_view_command_phase3w5.py
@@ -167,7 +167,7 @@ class TestDisplayPackageInfo:
             ),
             patch(
                 "apm_cli.commands.view._lookup_lockfile_ref",
-                return_value=("v1.0.0", "abc123456789"),
+                return_value=("v1.0.0", "abc123456789", ""),
             ),
         ):
             display_package_info("org/repo", tmp_path, logger, project_root=tmp_path)
@@ -184,7 +184,7 @@ class TestDisplayPackageInfo:
                 "apm_cli.commands.view._get_detailed_package_info",
                 return_value=pkg_info,
             ),
-            patch("apm_cli.commands.view._lookup_lockfile_ref", return_value=("", "")),
+            patch("apm_cli.commands.view._lookup_lockfile_ref", return_value=("", "", "")),
         ):
             display_package_info("org/repo", tmp_path, logger, project_root=tmp_path)
 
@@ -200,7 +200,7 @@ class TestDisplayPackageInfo:
                 "apm_cli.commands.view._get_detailed_package_info",
                 return_value=pkg_info,
             ),
-            patch("apm_cli.commands.view._lookup_lockfile_ref", return_value=("", "")),
+            patch("apm_cli.commands.view._lookup_lockfile_ref", return_value=("", "", "")),
         ):
             display_package_info("org/repo", tmp_path, logger, project_root=tmp_path)
 
@@ -232,7 +232,9 @@ class TestDisplayPackageInfo:
                 "apm_cli.commands.view._get_detailed_package_info",
                 return_value=pkg_info,
             ),
-            patch("apm_cli.commands.view._lookup_lockfile_ref", return_value=("v1.0", "abc123")),
+            patch(
+                "apm_cli.commands.view._lookup_lockfile_ref", return_value=("v1.0", "abc123", "")
+            ),
             patch.dict(sys.modules, {"rich.console": None, "rich.panel": None}),
         ):
             display_package_info("org/repo", tmp_path, logger, project_root=tmp_path)

--- a/tests/unit/test_view_command_phase3w5.py
+++ b/tests/unit/test_view_command_phase3w5.py
@@ -434,7 +434,7 @@ class TestDisplayVersions:
         ):
             display_versions("org/repo", logger)
 
-    def test_no_refs_logs_progress(self):
+    def test_no_refs_logs_warning(self):
         from apm_cli.commands.view import display_versions
 
         logger = _make_logger()
@@ -449,7 +449,7 @@ class TestDisplayVersions:
             ),
         ):
             display_versions("org/repo", logger)
-        logger.progress.assert_called()
+        logger.warning.assert_called()
 
     def test_rich_table_rendered_with_refs(self):
         from apm_cli.commands.view import display_versions


### PR DESCRIPTION
## Summary

Registry dependencies are now first-class citizens across install, update, and every display surface. This PR consolidates two related fix branches into a single ship-ready change.

**Semver update idempotency** -- `apm update` on a registry semver dep (e.g. `^1.0.0`) now re-resolves and re-downloads when a new version is available. Previously, the install-path existence check short-circuited the BFS callback and left the old version in place even when `--update` was passed. The purge-before-update path now includes registry semver deps alongside git semver deps.

**Plan display correctness** -- `build_update_plan` compares `old_ref` (locked concrete version) vs `new_ref` (freshly resolved concrete version). This requires `resolved_ref` in the lockfile to hold the exact version (`1.0.3`), not the manifest range (`^1.0.0`). Both the lockfile writer and the cached-install path now preserve the exact resolved version.

**Install output** -- verbose install now shows the resolved version (`#1.1.1`) instead of the manifest range (`#^1.0.0`) for registry deps.

**`apm deps list` source label** -- shows `Source: registry` (was `Source: local`) for registry-sourced deps.

**`apm view <pkg> versions`** -- queries the registry versions API when the lockfile records `source: registry`, instead of attempting a git `ls-remote` that always 404s.

**`apm view <pkg>` / `apm deps info`** -- shows `Source: registry` for registry-sourced deps; uses `resolved_url` from the lockfile for the versions lookup URL.

**`apm audit`** -- no longer raises `CacheMissError` for registry deps (which have no `resolved_commit`).

**Registry 404 hint** -- when a non-semver ref gets a registry 404, the error message now includes a hint to use the git-style `org/repo@ref` form.

**Registry failure guard** -- `FreshDependencySource` no longer retries a registry download through the git fallback path when the BFS callback already recorded a failure for that dep.

## Fixes absorbed from #1897

- `resolve.py`: `_annotate_registry_dep_ref` -- populates `dep_ref.resolved_reference` after BFS callback so the display layer always has the concrete version.
- `resolve.py`: `_purge_cached_semver_paths_for_update` now includes registry semver deps (previously excluded).
- `resolve.py`: `_resolve_dependencies` -- `_force_semver_resolve` gate no longer skips registry deps.
- `plan.py`: suppress spurious `(- -> -)` display when both old and new commit SHAs are absent.
- `lockfile.py`: `from_dependency_ref` stores `registry_resolution.version` as `resolved_ref` instead of the manifest range.
- `sources.py`: `_resolve_cached_commit` no longer falls back to `dep_ref.reference` for registry deps (which have no git SHA).
- CHANGELOG and docs updates for `update` and `install` commands.

## Test coverage

- `test_lockfile_git_semver.py`: `TestRegistryDepResolvedRef` -- verifies `resolved_ref` is the exact version after a registry install round-trip.
- `test_lockfile_git_semver.py`: `TestMutualExclusivity` -- verifies `from_dependency_ref` raises when both `git_semver_resolution` and `registry_resolution` are passed.
- `test_plan.py`, `test_sources_phase3.py`, `test_install_update_refs.py`, `test_lockfile_v2_bump.py` -- from #1897.
- `test_drift_detection.py`, `test_resolver.py`, `test_view_command*.py` -- guard the display-layer fixes.

## Notes

PR #1897 (`fix/registry-semver-update-idempotency`) is superseded by this branch and will be closed.

apm-spec-waiver: display-layer correctness fixes, error message improvements, and semver update idempotency -- no new normative behavior introduced; all changes restore expected semantics that were missing or broken for registry dep sources