### PR TITLE
test(ci): repair merge-queue Integration Tests regressions

### DIFF
--- a/tests/integration/test_dep_url_parsing_e2e.py
+++ b/tests/integration/test_dep_url_parsing_e2e.py
@@ -148,12 +148,17 @@ class TestDiscoverPolicyWithChainEMUEndToEnd:
         ) as mock_fetch:
             result = discover_policy_with_chain(tmp_path)
 
-        # Discovery reached _fetch_from_repo (proves SCP_LIKE_RE
-        # matched and org was extracted) and routed to contoso/.github.
+        # The regression guard for #1159 is the ROUTING: discovery reached
+        # _fetch_from_repo (proves SCP_LIKE_RE matched and the org was
+        # extracted) and the FIRST candidate it tried was contoso/.github.
         assert mock_fetch.call_count >= 1
         first_call_repo_ref = mock_fetch.call_args_list[0].args[0]
         assert first_call_repo_ref == "contoso/.github"
-        assert result is sentinel
+        # Cascading discovery (#1830) tries .github -> .apm -> _apm. With every
+        # candidate mocked absent, the cascade exhausts and returns a fresh
+        # terminal "absent" result -- it does NOT propagate the per-candidate
+        # sentinel object. The org-routing assertion above is the real guard.
+        assert result.outcome == "absent"
 
     def test_ado_v3_ssh_remote_routes_to_correct_org_policy_repo(self, tmp_path):
         _git_init_with_remote(
@@ -164,20 +169,21 @@ class TestDiscoverPolicyWithChainEMUEndToEnd:
 
         sentinel = PolicyFetchResult(outcome="absent")
 
+        # ADO remotes route through _fetch_from_ado_repo (#1830), which takes
+        # the org as a keyword argument rather than a "<org>/<repo>" ref.
         with patch(
-            "apm_cli.policy.discovery._fetch_from_repo", return_value=sentinel
+            "apm_cli.policy.discovery._fetch_from_ado_repo", return_value=sentinel
         ) as mock_fetch:
             result = discover_policy_with_chain(tmp_path)
 
-        # Pre-fix the repo_ref would have been constructed from
-        # org="v3" -- a silent mis-routing.  Post-fix the real org
-        # ``realorg`` is used.
+        # Pre-fix the org would have been parsed as "v3" -- a silent
+        # mis-routing.  Post-fix the real org ``realorg`` is used.
         assert mock_fetch.call_count >= 1
-        first_call_repo_ref = mock_fetch.call_args_list[0].args[0]
-        # ADO host attaches a host prefix when host != github.com.
-        assert "realorg/.github" in first_call_repo_ref
-        assert "v3/.github" not in first_call_repo_ref
-        assert result is sentinel
+        first_call_org = mock_fetch.call_args_list[0].kwargs["org"]
+        assert first_call_org == "realorg"
+        assert first_call_org != "v3"
+        # Cascade exhausts to a fresh terminal "absent" (see EMU test note).
+        assert result.outcome == "absent"
 
 
 class TestDependencyReferenceParsesEMUAndAdoSsh:

--- a/tests/integration/test_plugin_e2e.py
+++ b/tests/integration/test_plugin_e2e.py
@@ -36,6 +36,45 @@ from apm_cli.utils.helpers import find_plugin_json
 FIXTURE_DIR = Path(__file__).parent.parent / "fixtures" / "mock-marketplace-plugin"
 
 
+def _run_apm_command(
+    apm_command: str, args: list[str], cwd: Path, timeout: int = 120
+) -> subprocess.CompletedProcess[str]:
+    """Run the real APM CLI in a project directory."""
+    return subprocess.run(
+        [apm_command, *args],
+        capture_output=True,
+        text=True,
+        cwd=str(cwd),
+        timeout=timeout,
+    )
+
+
+def _locked_dependency_key(entry: dict) -> str:
+    """Return the canonical dependency key used in list-format lockfiles."""
+    virtual_path = entry.get("virtual_path")
+    return f"{entry['repo_url']}/{virtual_path}" if virtual_path else entry["repo_url"]
+
+
+def _locked_dependency(lockfile: dict, key: str) -> dict:
+    """Return one dependency entry from a parsed lockfile."""
+    for entry in lockfile["dependencies"]:
+        if _locked_dependency_key(entry) == key:
+            return entry
+    raise AssertionError(f"Dependency {key!r} missing from lockfile")
+
+
+def _existing_deployed_file_paths(project_root: Path, deployed_files: list[str]) -> list[Path]:
+    """Return deployed file paths that exist on disk and are regular filesystem paths."""
+    existing: list[Path] = []
+    for rel_path in deployed_files:
+        if "://" in rel_path:
+            continue
+        candidate = project_root / rel_path
+        if candidate.exists():
+            existing.append(candidate)
+    return existing
+
+
 def _make_package_info(
     package: APMPackage, install_path: Path, package_type: PackageType
 ) -> PackageInfo:
@@ -61,6 +100,17 @@ def _run_integrators(package_info: PackageInfo, project_root: Path):
     skill_result = SkillIntegrator().integrate_package_skill(package_info, project_root)
     command_result = CommandIntegrator().integrate_package_commands(package_info, project_root)
     return prompt_result, agent_result, skill_result, command_result
+
+
+def _write_local_skill_package(skill_dir: Path) -> None:
+    """Create a small standalone skill package for sequential-install tests."""
+    skill_dir.mkdir()
+    (skill_dir / "apm.yml").write_text(
+        "name: local-review-skill\nversion: 1.0.0\ndescription: local review skill\n"
+    )
+    skill_content = skill_dir / ".apm" / "skills" / "review-and-refactor"
+    skill_content.mkdir(parents=True)
+    (skill_content / "SKILL.md").write_text("# Review and Refactor\n")
 
 
 # ===========================================================================
@@ -366,6 +416,62 @@ class TestPluginHeroScenarios:
         parsed = yaml_lib.safe_load((plugin_dir / "apm.yml").read_text())
         assert parsed["type"] == "hybrid", f"Expected type 'hybrid', got '{parsed.get('type')}'"
 
+    @pytest.mark.requires_apm_binary
+    def test_local_plugin_uninstall_after_sequential_skill_install_cleans_deployed_files(
+        self, apm_command, tmp_path
+    ):
+        """Sequential CLI installs must retain plugin deployed_files for uninstall cleanup."""
+        import yaml as yaml_lib
+
+        if not FIXTURE_DIR.exists():
+            pytest.skip("mock-marketplace-plugin fixture not found")
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        plugin_dir = workspace / "plugin-src"
+        shutil.copytree(FIXTURE_DIR, plugin_dir)
+        skill_dir = workspace / "skill-src"
+        _write_local_skill_package(skill_dir)
+
+        project = workspace / "project"
+        project.mkdir()
+        (project / "apm.yml").write_text(
+            "name: local-sequential-plugin-test\nversion: 1.0.0\ndependencies:\n  apm: []\n"
+        )
+        (project / ".github").mkdir()
+        (project / ".github" / "copilot-instructions.md").write_text("# test\n")
+
+        plugin_install = _run_apm_command(
+            apm_command, ["install", str(plugin_dir)], project, timeout=120
+        )
+        assert plugin_install.returncode == 0, (
+            f"Plugin install failed:\n{plugin_install.stdout}\n{plugin_install.stderr}"
+        )
+        skill_install = _run_apm_command(
+            apm_command, ["install", str(skill_dir)], project, timeout=120
+        )
+        assert skill_install.returncode == 0, (
+            f"Skill install failed:\n{skill_install.stdout}\n{skill_install.stderr}"
+        )
+
+        lockfile = yaml_lib.safe_load((project / "apm.lock.yaml").read_text())
+        plugin_dep = _locked_dependency(lockfile, "_local/plugin-src")
+        deployed_files = plugin_dep.get("deployed_files", [])
+        assert ".github/agents/test-agent.agent.md" in deployed_files
+
+        deployed_paths = _existing_deployed_file_paths(project, deployed_files)
+        assert project / ".github" / "agents" / "test-agent.agent.md" in deployed_paths
+
+        uninstall = _run_apm_command(
+            apm_command, ["uninstall", str(plugin_dir)], project, timeout=60
+        )
+        assert uninstall.returncode == 0, (
+            f"Uninstall failed:\n{uninstall.stdout}\n{uninstall.stderr}"
+        )
+        combined = uninstall.stdout + uninstall.stderr
+        assert "Cleaned up 1 integrated agents" in combined
+        assert all(not path.exists() for path in deployed_paths)
+
 
 # ===========================================================================
 # Class 2 — NETWORK E2E tests (real CLI, requires GitHub token)
@@ -613,15 +719,17 @@ class TestPluginNetworkE2E:
         import yaml
 
         lockfile = yaml.safe_load((temp_project / "apm.lock.yaml").read_text())
-        dep_keys = {
-            f"{d['repo_url']}/{d.get('virtual_path', '')}" for d in lockfile["dependencies"]
-        }
-        assert "github/awesome-copilot/plugins/context-engineering" in dep_keys, (
+        dep_keys = {_locked_dependency_key(d) for d in lockfile["dependencies"]}
+        plugin_key = "github/awesome-copilot/plugins/context-engineering"
+        assert plugin_key in dep_keys, (
             f"Plugin missing from lockfile after sequential install. Keys: {dep_keys}"
         )
         assert "github/awesome-copilot/skills/review-and-refactor" in dep_keys, (
             f"Skill missing from lockfile after sequential install. Keys: {dep_keys}"
         )
+        plugin_dep = _locked_dependency(lockfile, plugin_key)
+        plugin_deployed_files = plugin_dep.get("deployed_files", [])
+        plugin_deployed_paths = _existing_deployed_file_paths(temp_project, plugin_deployed_files)
 
         # deps tree should show both
         tree = subprocess.run(
@@ -635,7 +743,9 @@ class TestPluginNetworkE2E:
         assert "context-engineering" in combined, "Plugin missing from deps tree"
         assert "review-and-refactor" in combined, "Skill missing from deps tree"
 
-        # Uninstall plugin should clean up agent files
+        # The live SAML-protected plugin can change which primitive types it ships.
+        # Verify cleanup for the files that were actually deployed instead of
+        # hard-coding that it must currently contain an agent primitive.
         r3 = subprocess.run(
             [apm_command, "uninstall", self.PLUGIN_REF],
             capture_output=True,
@@ -645,7 +755,12 @@ class TestPluginNetworkE2E:
         )
         assert r3.returncode == 0, f"Uninstall failed:\n{r3.stderr}"
         combined = r3.stdout + r3.stderr
-        assert "agent" in combined.lower(), f"Uninstall should report agent cleanup:\n{combined}"
+        if plugin_deployed_paths:
+            assert "Cleaned up" in combined and "integrated" in combined.lower(), (
+                f"Uninstall should report integration cleanup:\n{combined}"
+            )
+        remaining = [path.as_posix() for path in plugin_deployed_paths if path.exists()]
+        assert not remaining, f"Plugin deployed files remained after uninstall: {remaining}"
 
     # ---- Test 7: compile includes plugin primitives ---------------------
 


### PR DESCRIPTION
## TL;DR

The `Integration Tests` workflow (which runs **only** on `merge_group` events, not `pull_request`) was failing on three tests, blocking the merge queue for every PR. All three are **test-only** defects -- production behaviour is correct. This PR repairs them: two stale policy-discovery E2E assertions that predate cascading policy-repo discovery (#1830), and one brittle plugin E2E assertion that hard-coded a primitive type shipped by a mutable, SAML-protected external plugin.

No production code changes.

## Problem (WHY)

Because the `Integration Tests` job triggers on `merge_group`, `gh pr checks` shows green on every PR while the queue itself fails -- so these regressions were invisible at PR-open time and surfaced only when a PR entered the merge queue (e.g. #1872, run 28187496504).

Three failures across two shards:

1. `test_emu_ssh_remote_routes_to_correct_org_policy_repo` -- asserted `result is sentinel`. Cascading discovery (#1830) now tries `.github` -> `.apm` -> `_apm` and returns a **fresh terminal `absent`** result rather than propagating the per-candidate sentinel object, so the identity assertion no longer holds.
2. `test_ado_v3_ssh_remote_routes_to_correct_org_policy_repo` -- mocked `_fetch_from_repo`, but ADO remotes now route through `_fetch_from_ado_repo` (#1830). The mock was never called (`call_count == 0`).
3. `test_lockfile_preserved_on_sequential_install` -- asserted `"agent" in combined.lower()` against the **live, SAML-protected** plugin `github/awesome-copilot/plugins/context-engineering`. The merge-queue run emitted zero "Cleaned up N integrated ..." lines, meaning the plugin's deployed primitive mix drifted upstream.

## Approach (WHAT)

Keep every test's genuine regression-guard intent intact; replace assertions that coupled to implementation details (object identity, a specific fetch helper, a specific external primitive type) with assertions on observable contract.

## Implementation (HOW)

**Policy tests** (`tests/integration/test_dep_url_parsing_e2e.py`):
- EMU: preserve the #1159 SCP-regex routing guard (first candidate == `contoso/.github`); replace `result is sentinel` with `result.outcome == "absent"` (cascade-correct terminal outcome).
- ADO: re-point the patch at `_fetch_from_ado_repo` and assert the real org (`realorg`, not `v3`) is passed as a kwarg.

**Plugin test** (`tests/integration/test_plugin_e2e.py`):
- Root-caused via a **hermetic offline reproduction** (the live plugin is unreachable without SAML): a local marketplace-plugin fixture installed, then a local skill installed sequentially, then the plugin uninstalled. Result: the plugin's `deployed_files` is **preserved** across the sequential install and uninstall reports `Cleaned up 1 integrated agents` and deletes the file. The production sequential-install + uninstall-cleanup path is correct; the failure is external-content drift.
- Added that offline scenario as a permanent, network-free regression test (`test_local_plugin_uninstall_after_sequential_skill_install_cleans_deployed_files`, gated by `requires_apm_binary`) so this path is guarded without depending on mutable external content.
- Hardened the live network test to validate cleanup against the files **actually deployed** (assert integration cleanup is reported when files were deployed, and that no deployed files remain on disk) instead of hard-coding the word `agent`.

## Trade-offs

- The network test no longer fails if the upstream plugin changes its primitive mix -- intentional. Robust offline coverage of the same path is added so the contract (sequential install preserves deployed_files; uninstall cleans them) is still strictly enforced in CI.

## Validation evidence

- `tests/integration/test_plugin_e2e.py`: 10 passed, 11 skipped (network auto-skipped); new offline test passes.
- `tests/integration/test_dep_url_parsing_e2e.py`: 14 passed.
- Lint (CI-mirror, all green): `ruff check`, `ruff format --check`, `pylint R0801` (10.00/10), `scripts/lint-auth-signals.sh`.
- Branch is current with `main` (0 behind).

## How to test

```
uv run pytest tests/integration/test_dep_url_parsing_e2e.py -q
uv run pytest tests/integration/test_plugin_e2e.py::TestPluginHeroScenarios::test_local_plugin_uninstall_after_sequential_skill_install_cleans_deployed_files -q
```

The hardened live test runs in the `merge_group` Integration Tests job where the binary and network are available.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
