### PR TITLE
fix(tests): make Windows CI-failing tests platform-portable

### DIFF
--- a/tests/unit/security/test_executables.py
+++ b/tests/unit/security/test_executables.py
@@ -13,6 +13,7 @@ Covers:
 
 from __future__ import annotations
 
+import os
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -590,8 +591,12 @@ class TestSaveUserExecutablesAtomic:
         monkeypatch.setattr(ex, "_user_config_file", lambda: cfg)
         ex.save_user_executables({"pkg#1.0": {"hooks": True}}, {})
         assert cfg.is_file()
-        # Owner-only perms on the freshly-created file.
-        assert (cfg.stat().st_mode & 0o777) == 0o600
+        # Owner-only perms on the freshly-created file. POSIX mode bits are not
+        # enforced on Windows, where atomic_write_text documents that the mode
+        # hint is silently ignored, so only assert the permission contract on
+        # platforms that honour it.
+        if os.name != "nt":
+            assert (cfg.stat().st_mode & 0o777) == 0o600
         # Content round-trips and preserves co-resident keys on rewrite.
         cfg.write_text(json.dumps({"default_client": "vscode"}), encoding="utf-8")
         ex.save_user_executables({"pkg#1.0": {"hooks": True}}, {})

--- a/tests/unit/test_codex_adapter_compatibility.py
+++ b/tests/unit/test_codex_adapter_compatibility.py
@@ -122,6 +122,12 @@ class TestGetConfigPath:
     ) -> None:
         home = tmp_path / "home"
         monkeypatch.setenv("HOME", str(home))
+        # ``Path.expanduser`` resolves ``~`` from USERPROFILE (or
+        # HOMEDRIVE+HOMEPATH) on Windows rather than HOME, so set every var the
+        # platform may consult to keep the expansion deterministic everywhere.
+        monkeypatch.setenv("USERPROFILE", str(home))
+        monkeypatch.setenv("HOMEDRIVE", home.drive)
+        monkeypatch.setenv("HOMEPATH", str(home)[len(home.drive) :])
         monkeypatch.setenv("CODEX_HOME", "~/codex-config")
 
         adapter = _make_adapter(user_scope=True)


### PR DESCRIPTION
## TL;DR

`main`'s CI/CD Pipeline has been red on the **windows-latest** Build & Test job for several commits. Two tests merged through the queue (#1875 and #1863) make POSIX-only assumptions. This PR makes them platform-portable. **No source code changes** — both implementations are already correct and Windows-safe.

## Problem (WHY)

The Windows runner reported `2 failed, 17500 passed`:

1. `tests/unit/security/test_executables.py::TestSaveUserExecutablesAtomic::test_atomic_write_sets_owner_only_mode`
   - `AssertionError: assert (33206 & 511) == 384` — asserted POSIX `0o600` mode bits, but Windows does not enforce POSIX mode bits. `atomic_write_text` already documents that the `new_file_mode` hint is *silently ignored* where `os.fchmod` is unavailable (Windows).

2. `tests/unit/test_codex_adapter_compatibility.py::TestGetConfigPath::test_user_scope_expands_codex_home_env`
   - `AssertionError: 'C:\\Users\\R...' == 'C:\\Users\\r...'` — relied on `~` expansion via `HOME`, but `ntpath.expanduser` resolves `~` from `USERPROFILE` / `HOMEDRIVE`+`HOMEPATH` on Windows, not `HOME`, producing a path that doesn't match the monkeypatched home.

The "weird after the merge queue" symptom is just that these were independently-merged PRs whose combination kept the Windows job red on `main`.

## Approach (WHAT)

Fix the tests, not the (correct) implementations:

- Guard the owner-only permission assertion to non-Windows (`os.name != "nt"`), matching the documented contract in `atomic_write_text`.
- Monkeypatch `USERPROFILE`, `HOMEDRIVE`, and `HOMEPATH` (in addition to `HOME`) so `~` expansion is deterministic on every platform.

## Validation evidence

- Affected tests pass locally (`TestSaveUserExecutablesAtomic` + `TestGetConfigPath`): 7 passed.
- `ruff check` + `ruff format --check` clean on both touched files.

## How to test

```bash
uv run --extra dev python -m pytest \
  tests/unit/security/test_executables.py::TestSaveUserExecutablesAtomic \
  tests/unit/test_codex_adapter_compatibility.py::TestGetConfigPath -q
```

Cross-platform confirmation comes from the windows-latest matrix leg going green on this PR.