### PR TITLE
fix(install): write deployed files with LF on every platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,10 +102,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `apm update` no longer shows a spurious update for registry semver deps already at the latest matching version. (#1897)
-- Deployed files are now written with LF line endings on every platform, so
-  identical content no longer produces different `local_deployed_file_hashes` /
-  `deployed_file_hashes` between Windows and Linux (which previously churned the
-  lockfile across machines and CI).
+- APM-written deployed text files now use LF line endings on every platform,
+  so identical content no longer produces different
+  `local_deployed_file_hashes` / `deployed_file_hashes` between Windows and
+  Linux (which previously churned the lockfile across machines and CI).
 - `apm install <pkg>@<marketplace>` now preserves GitLab and other
   non-GitHub hosts from url-type marketplace plugin sources, so auth
   resolution no longer falls back to `github.com` for those installs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `apm update` no longer shows a spurious update for registry semver deps already at the latest matching version. (#1897)
+- Deployed files are now written with LF line endings on every platform, so
+  identical content no longer produces different `local_deployed_file_hashes` /
+  `deployed_file_hashes` between Windows and Linux (which previously churned the
+  lockfile across machines and CI).
 - `apm install <pkg>@<marketplace>` now preserves GitLab and other
   non-GitHub hosts from url-type marketplace plugin sources, so auth
   resolution no longer falls back to `github.com` for those installs.

--- a/src/apm_cli/compilation/agents_compiler.py
+++ b/src/apm_cli/compilation/agents_compiler.py
@@ -21,6 +21,7 @@ from ..core.target_detection import (
 )
 from ..primitives.discovery import discover_primitives
 from ..primitives.models import PrimitiveCollection
+from ..utils.atomic_io import write_text_lf
 from ..utils.path_security import PathTraversalError, ensure_path_within
 from ..utils.paths import portable_relpath
 from ..version import get_version
@@ -1353,7 +1354,7 @@ class AgentsCompiler:
 
         try:
             output_path.parent.mkdir(parents=True, exist_ok=True)
-            output_path.write_text(content, encoding="utf-8")
+            write_text_lf(output_path, content)
             result.stats["copilot_root_instructions_written"] = 1
             result.stats["copilot_root_instructions_unchanged"] = 0
             return result

--- a/src/apm_cli/compilation/user_root_context.py
+++ b/src/apm_cli/compilation/user_root_context.py
@@ -28,6 +28,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from ..utils.atomic_io import write_text_lf
+
 if TYPE_CHECKING:
     import logging as _logging_module
 
@@ -286,7 +288,7 @@ def compile_user_root_contexts(
                     )
                 )
                 continue
-            output_path.write_text(content, encoding="utf-8")
+            write_text_lf(output_path, content)
             log.debug("user_root_context: wrote %s", output_path)
             results.append(
                 UserRootCompileResult(

--- a/src/apm_cli/install/services.py
+++ b/src/apm_cli/install/services.py
@@ -741,6 +741,7 @@ def integrate_local_bundle(
     import hashlib
     import shutil
 
+    from apm_cli.utils.atomic_io import normalize_crlf_to_lf, write_text_lf
     from apm_cli.utils.content_hash import compute_file_hash
 
     from ..core.scope import InstallScope
@@ -774,6 +775,16 @@ def integrate_local_bundle(
             if rel == "apm.lock.yaml" or rel.lower() == "plugin.json" or rel.lower() == ".mcp.json":
                 continue
             pack_files[rel] = hashlib.sha256(fp.read_bytes()).hexdigest()
+
+    text_bundle_suffixes = {".json", ".md", ".toml", ".txt", ".yaml", ".yml"}
+
+    def _normalized_bundle_text(path: Path) -> str | None:
+        if path.suffix.lower() not in text_bundle_suffixes:
+            return None
+        try:
+            return normalize_crlf_to_lf(path.read_bytes().decode("utf-8"))
+        except UnicodeDecodeError:
+            return None
 
     deployed_files: list[str] = []
     deployed_hashes: dict[str, str] = {}
@@ -987,15 +998,21 @@ def integrate_local_bundle(
             except ValueError:
                 record = dest.as_posix()
 
+            normalized_text = _normalized_bundle_text(src)
+            if normalized_text is None:
+                desired_hash = expected_hash
+            else:
+                desired_hash = hashlib.sha256(normalized_text.encode("utf-8")).hexdigest()
+
             if dry_run:
                 deployed_files.append(record)
                 # Normalize to "sha256:<hex>" so the dry-run lockfile preview
                 # matches the format written by ``compute_file_hash`` on the
-                # real deploy path.  ``expected_hash`` here is bare hex from
-                # ``pack.bundle_files``; without the prefix, downstream
+                # real deploy path.  ``desired_hash`` here is bare hex for
+                # the bytes this deploy path writes; without the prefix, downstream
                 # exact-match comparisons (e.g. ``cleanup.py`` provenance
                 # check) treat the file as user-edited and skip cleanup.
-                deployed_hashes[record] = f"sha256:{expected_hash}"
+                deployed_hashes[record] = f"sha256:{desired_hash}"
                 if logger:
                     logger.verbose_detail(f"[dry-run] would deploy {record}")
                 continue
@@ -1007,7 +1024,7 @@ def integrate_local_bundle(
                     existing_hash = hashlib.sha256(dest.read_bytes()).hexdigest()
                 except OSError:
                     existing_hash = None
-                if existing_hash and existing_hash != expected_hash:
+                if existing_hash and existing_hash != desired_hash:
                     skipped += 1
                     msg = (
                         f"Skipped {record}: file exists with different "
@@ -1019,12 +1036,14 @@ def integrate_local_bundle(
                         logger.warning(msg)
                     continue
             dest.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(src, dest, follow_symlinks=False)
-            # IM4: hash the deployed file (post-copy) rather than trusting
-            # the source bundle's expected_hash.  Today the integrator is a
-            # raw copy so the values match, but documenting deployed-file
-            # provenance now keeps the lockfile honest if future transforms
-            # (frontmatter injection, etc.) mutate content during deploy.
+            if normalized_text is None:
+                shutil.copy2(src, dest, follow_symlinks=False)
+            else:
+                write_text_lf(dest, normalized_text)
+            # IM4: hash the deployed file after the deploy transform rather
+            # than trusting the source bundle's expected_hash.  Local bundle
+            # text files may be LF-normalized during deploy, so the lockfile
+            # must bind the actual on-disk bytes.
             deployed_files.append(record)
             # Use ``compute_file_hash`` so the recorded value carries the
             # canonical ``sha256:<hex>`` prefix.  Matches the format written

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -15,6 +15,7 @@ import yaml
 
 from apm_cli.integration.base_integrator import BaseIntegrator, IntegrationResult
 from apm_cli.integration.opencode_frontmatter import validate_opencode_frontmatter
+from apm_cli.utils.atomic_io import write_text_lf
 from apm_cli.utils.path_security import PathTraversalError, ensure_path_within
 from apm_cli.utils.paths import portable_relpath
 
@@ -248,7 +249,7 @@ class AgentIntegrator(BaseIntegrator):
             raise ValueError(f"Refusing to read symlink source: {source}")
         content = source.read_text(encoding="utf-8")
         content, links_resolved = self.resolve_links(content, source, target)
-        target.write_text(content, encoding="utf-8")
+        write_text_lf(target, content)
         return links_resolved
 
     # ------------------------------------------------------------------
@@ -332,7 +333,7 @@ class AgentIntegrator(BaseIntegrator):
             "description": description,
             "developer_instructions": body.strip(),
         }
-        target.write_text(_toml.dumps(doc), encoding="utf-8")
+        write_text_lf(target, _toml.dumps(doc))
 
     # DEPRECATED: use integrate_agents_for_target(KNOWN_TARGETS["copilot"], ...) instead.
     def integrate_package_agents(

--- a/src/apm_cli/integration/command_integrator.py
+++ b/src/apm_cli/integration/command_integrator.py
@@ -15,6 +15,7 @@ import frontmatter
 
 from apm_cli.integration.base_integrator import BaseIntegrator, IntegrationResult
 from apm_cli.security.gate import BLOCK_POLICY, SecurityGate
+from apm_cli.utils.atomic_io import write_text_lf
 from apm_cli.utils.path_security import (
     PathTraversalError,
     ensure_path_within,
@@ -694,7 +695,7 @@ class CommandIntegrator(BaseIntegrator):
             doc = {"description": description, "prompt": prompt_text}
 
         target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(_toml.dumps(doc), encoding="utf-8")
+        write_text_lf(target, _toml.dumps(doc))
 
     # ------------------------------------------------------------------
     # Legacy per-target API (DEPRECATED)

--- a/src/apm_cli/integration/instruction_integrator.py
+++ b/src/apm_cli/integration/instruction_integrator.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 from apm_cli.integration.base_integrator import BaseIntegrator, IntegrationResult
 from apm_cli.integration.targets import RULE_FORMATS
+from apm_cli.utils.atomic_io import write_text_lf
 from apm_cli.utils.console import _rich_echo
 from apm_cli.utils.path_security import ensure_path_within
 from apm_cli.utils.paths import portable_relpath
@@ -63,7 +64,7 @@ class InstructionIntegrator(BaseIntegrator):
         """
         content = source.read_text(encoding="utf-8")
         content, links_resolved = self.resolve_links(content, source, target)
-        target.write_text(content, encoding="utf-8")
+        write_text_lf(target, content)
         return links_resolved
 
     def _render_instruction(self, source: Path, target: Path, fmt: str) -> tuple[str, int]:
@@ -204,7 +205,7 @@ class InstructionIntegrator(BaseIntegrator):
                     if diagnostics is not None and getattr(diagnostics, "verbose", False):
                         _rich_echo(f"  [=] adopted-unchanged: {rel_path}", color="dim")
                     continue
-                target_path.write_text(new_content, encoding="utf-8")
+                write_text_lf(target_path, new_content)
                 total_links_resolved += links_resolved
                 files_integrated += 1
                 target_paths.append(target_path)
@@ -388,14 +389,14 @@ class InstructionIntegrator(BaseIntegrator):
             if self._is_apm_managed_copilot(existing):
                 # APM-managed: update or append this package's provenance section.
                 updated = self._update_copilot_managed(existing, pkg_source or "unknown", section)
-                target_path.write_text(updated, encoding="utf-8")
+                write_text_lf(target_path, updated)
                 return IntegrationResult(1, 0, 0, [target_path])
             norm_rel = rel_path.replace("\\", "/")
             if norm_rel in (managed_files or set()) or force:
                 # Either was managed on a previous run (pre-provenance format)
                 # or caller explicitly requested overwrite.
                 new_content = self._APM_COPILOT_HEADER + "\n" + section + "\n"
-                target_path.write_text(new_content, encoding="utf-8")
+                write_text_lf(target_path, new_content)
                 return IntegrationResult(1, 0, 0, [target_path])
             # User-authored file: emit collision warning and skip.
             self.check_collision(
@@ -404,7 +405,7 @@ class InstructionIntegrator(BaseIntegrator):
             return IntegrationResult(0, 0, 1, [])
 
         new_content = self._APM_COPILOT_HEADER + "\n" + section + "\n"
-        target_path.write_text(new_content, encoding="utf-8")
+        write_text_lf(target_path, new_content)
         return IntegrationResult(1, 0, 0, [target_path])
 
     # ------------------------------------------------------------------
@@ -514,7 +515,7 @@ class InstructionIntegrator(BaseIntegrator):
         Converts ``applyTo:`` → ``globs:`` frontmatter and resolves links.
         """
         content, links_resolved = self._render_instruction(source, target, "cursor_rules")
-        target.write_text(content, encoding="utf-8")
+        write_text_lf(target, content)
         return links_resolved
 
     # DEPRECATED: use integrate_instructions_for_target(KNOWN_TARGETS["cursor"], ...) instead.
@@ -611,7 +612,7 @@ class InstructionIntegrator(BaseIntegrator):
         and resolves links.
         """
         content, links_resolved = self._render_instruction(source, target, "windsurf_rules")
-        target.write_text(content, encoding="utf-8")
+        write_text_lf(target, content)
         return links_resolved
 
     # ------------------------------------------------------------------
@@ -720,7 +721,7 @@ class InstructionIntegrator(BaseIntegrator):
         Converts ``applyTo:`` to ``paths:`` frontmatter and resolves links.
         """
         content, links_resolved = self._render_instruction(source, target, "claude_rules")
-        target.write_text(content, encoding="utf-8")
+        write_text_lf(target, content)
         return links_resolved
 
     # DEPRECATED: use integrate_instructions_for_target(KNOWN_TARGETS["claude"], ...) instead.

--- a/src/apm_cli/integration/instruction_integrator.py
+++ b/src/apm_cli/integration/instruction_integrator.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 from apm_cli.integration.base_integrator import BaseIntegrator, IntegrationResult
 from apm_cli.integration.targets import RULE_FORMATS
-from apm_cli.utils.atomic_io import _to_lf, write_text_lf
+from apm_cli.utils.atomic_io import normalize_crlf_to_lf, write_text_lf
 from apm_cli.utils.console import _rich_echo
 from apm_cli.utils.path_security import ensure_path_within
 from apm_cli.utils.paths import portable_relpath
@@ -203,7 +203,8 @@ class InstructionIntegrator(BaseIntegrator):
                 if (
                     not force
                     and target_path.exists()
-                    and target_path.read_bytes() == _to_lf(new_content).encode("utf-8")
+                    and target_path.read_bytes()
+                    == normalize_crlf_to_lf(new_content).encode("utf-8")
                 ):
                     files_adopted += 1
                     target_paths.append(target_path)

--- a/src/apm_cli/integration/instruction_integrator.py
+++ b/src/apm_cli/integration/instruction_integrator.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, ClassVar
 
 from apm_cli.integration.base_integrator import BaseIntegrator, IntegrationResult
 from apm_cli.integration.targets import RULE_FORMATS
-from apm_cli.utils.atomic_io import write_text_lf
+from apm_cli.utils.atomic_io import _to_lf, write_text_lf
 from apm_cli.utils.console import _rich_echo
 from apm_cli.utils.path_security import ensure_path_within
 from apm_cli.utils.paths import portable_relpath
@@ -195,10 +195,15 @@ class InstructionIntegrator(BaseIntegrator):
                 new_content, links_resolved = self._render_instruction(
                     source_file, target_path, fmt
                 )
+                # Compare the on-disk bytes against the exact bytes
+                # write_text_lf would emit (LF-normalized). A text-mode
+                # read_text() comparison would collapse CRLF->LF and wrongly
+                # adopt a stale CRLF file left by a pre-fix install, pinning a
+                # platform-dependent hash in the lockfile (apm#1889).
                 if (
                     not force
                     and target_path.exists()
-                    and target_path.read_text(encoding="utf-8") == new_content
+                    and target_path.read_bytes() == _to_lf(new_content).encode("utf-8")
                 ):
                     files_adopted += 1
                     target_paths.append(target_path)

--- a/src/apm_cli/integration/lsp_integrator.py
+++ b/src/apm_cli/integration/lsp_integrator.py
@@ -17,6 +17,7 @@ from apm_cli.core.null_logger import NullCommandLogger
 from apm_cli.deps.lockfile import LockFile, get_lockfile_path
 from apm_cli.integration._shared import deduplicate_deps, resolve_locked_apm_yml_paths
 from apm_cli.runtime.utils import find_runtime_binary
+from apm_cli.utils.atomic_io import write_text_lf
 
 _log = logging.getLogger(__name__)
 
@@ -341,7 +342,7 @@ class LSPIntegrator:
             existing[name] = server_config
 
         config_path.parent.mkdir(parents=True, exist_ok=True)
-        config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+        write_text_lf(config_path, json.dumps(config, indent=2) + "\n")
         return changed
 
     @staticmethod
@@ -369,7 +370,7 @@ class LSPIntegrator:
         if removed:
             if servers_key is not None:
                 config[servers_key] = servers
-            config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+            write_text_lf(config_path, json.dumps(config, indent=2) + "\n")
         return removed
 
     # ------------------------------------------------------------------

--- a/src/apm_cli/integration/mcp_integrator.py
+++ b/src/apm_cli/integration/mcp_integrator.py
@@ -23,6 +23,7 @@ from apm_cli.core.null_logger import NullCommandLogger
 from apm_cli.deps.lockfile import LockFile, get_lockfile_path
 from apm_cli.integration._shared import deduplicate_deps, resolve_locked_apm_yml_paths
 from apm_cli.runtime.utils import find_runtime_binary
+from apm_cli.utils.atomic_io import write_text_lf
 from apm_cli.utils.console import (
     _get_console,  # noqa: F401 -- re-exported; mcp_integrator_install imports this via lazy import
     _rich_error,
@@ -86,7 +87,7 @@ def _clean_json_mcp_config(
             text = json.dumps(config, indent=2)
             if trailing_newline:
                 text += "\n"
-            config_path.write_text(text, encoding="utf-8")
+            write_text_lf(config_path, text)
             for name in removed:
                 msg = f"Removed stale MCP server '{name}' from {label}"
                 if use_rich:
@@ -131,7 +132,7 @@ def _clean_toml_mcp_config(
         for name in removed:
             del servers[name]
         if removed:
-            config_path.write_text(_toml.dumps(config), encoding="utf-8")
+            write_text_lf(config_path, _toml.dumps(config))
             for name in removed:
                 msg = f"Removed stale MCP server '{name}' from {label}"
                 if use_rich:
@@ -180,7 +181,7 @@ def _clean_claude_config(
         for name in removed:
             del servers[name]
         if removed:
-            config_path.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+            write_text_lf(config_path, json.dumps(config, indent=2) + "\n")
             for name in removed:
                 logger.progress(f"Removed stale MCP server '{name}' from {label}")
         return len(removed)
@@ -717,7 +718,7 @@ class MCPIntegrator:
                     for name in removed:
                         del servers[name]
                     if removed:
-                        intellij_mcp.write_text(_json.dumps(config, indent=2), encoding="utf-8")
+                        write_text_lf(intellij_mcp, _json.dumps(config, indent=2))
                         for name in removed:
                             _rich_success(
                                 f"Removed stale MCP server '{name}' from {intellij_mcp}",

--- a/src/apm_cli/integration/prompt_integrator.py
+++ b/src/apm_cli/integration/prompt_integrator.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from apm_cli.integration.base_integrator import BaseIntegrator, IntegrationResult
+from apm_cli.utils.atomic_io import write_text_lf
 from apm_cli.utils.path_security import PathTraversalError, ensure_path_within
 from apm_cli.utils.paths import portable_relpath
 
@@ -45,7 +46,7 @@ class PromptIntegrator(BaseIntegrator):
             raise ValueError(f"Refusing to read symlink source: {source}")
         content = source.read_text(encoding="utf-8")
         content, links_resolved = self.resolve_links(content, source, target)
-        target.write_text(content, encoding="utf-8")
+        write_text_lf(target, content)
         return links_resolved
 
     def get_target_filename(self, source_file: Path, package_name: str) -> str:

--- a/src/apm_cli/integration/skill_integrator.py
+++ b/src/apm_cli/integration/skill_integrator.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 
 from apm_cli.integration.base_integrator import BaseIntegrator
+from apm_cli.utils.atomic_io import write_text_lf
 
 
 def _build_copy_ignore(
@@ -576,7 +577,7 @@ class SkillIntegrator(BaseIntegrator):
                 preserved_source_root=source_root,
             )
             if count:
-                target_file.write_text(resolved, encoding="utf-8")
+                write_text_lf(target_file, resolved)
                 links_resolved += count
         return links_resolved
 

--- a/src/apm_cli/integration/skill_transformer.py
+++ b/src/apm_cli/integration/skill_transformer.py
@@ -4,6 +4,7 @@ import re
 from pathlib import Path
 
 from ..primitives.models import Skill
+from ..utils.atomic_io import write_text_lf
 
 
 def to_hyphen_case(name: str) -> str:
@@ -67,7 +68,7 @@ class SkillTransformer:
 
         # Create directory and write file
         agent_path.parent.mkdir(parents=True, exist_ok=True)
-        agent_path.write_text(agent_content, encoding="utf-8")
+        write_text_lf(agent_path, agent_content)
 
         return agent_path
 

--- a/src/apm_cli/utils/atomic_io.py
+++ b/src/apm_cli/utils/atomic_io.py
@@ -17,7 +17,7 @@ import tempfile
 from pathlib import Path
 
 
-def _to_lf(data: str) -> str:
+def normalize_crlf_to_lf(data: str) -> str:
     """Normalize CRLF to LF (leaves bare CR alone, like the drift normalizer).
 
     Mirrors :func:`apm_cli.utils.normalization._normalize_line_endings` at the
@@ -32,12 +32,12 @@ def _to_lf(data: str) -> str:
 def write_text_lf(path: Path, data: str) -> None:
     """Write ``data`` to ``path`` as UTF-8 with deterministic LF line endings.
 
-    Non-atomic counterpart to :func:`atomic_write_text`. ``newline=""`` disables
-    the platform newline translation that ``Path.write_text`` performs in text
-    mode, so the on-disk bytes (and therefore their content hash) are identical
-    on every OS.
+    Non-atomic counterpart to :func:`atomic_write_text`. Caller must ensure
+    ``path.parent`` exists. ``newline=""`` disables the platform newline
+    translation that ``Path.write_text`` performs in text mode, so the on-disk
+    bytes (and therefore their content hash) are identical on every OS.
     """
-    path.write_text(_to_lf(data), encoding="utf-8", newline="")
+    path.write_text(normalize_crlf_to_lf(data), encoding="utf-8", newline="")
 
 
 def atomic_write_text(path: Path, data: str, *, new_file_mode: int | None = None) -> None:
@@ -68,7 +68,7 @@ def atomic_write_text(path: Path, data: str, *, new_file_mode: int | None = None
         fh = os.fdopen(fd, "w", encoding="utf-8", newline="")
         fd_wrapped = True
         with fh:
-            fh.write(_to_lf(data))
+            fh.write(normalize_crlf_to_lf(data))
         os.replace(tmp_name, path)
     except Exception:
         if not fd_wrapped:

--- a/src/apm_cli/utils/atomic_io.py
+++ b/src/apm_cli/utils/atomic_io.py
@@ -17,6 +17,29 @@ import tempfile
 from pathlib import Path
 
 
+def _to_lf(data: str) -> str:
+    """Normalize CRLF to LF (leaves bare CR alone, like the drift normalizer).
+
+    Mirrors :func:`apm_cli.utils.normalization._normalize_line_endings` at the
+    string level. Combined with ``newline=""`` on the open() call, this keeps
+    written bytes platform-independent so deployed-file hashes do not diverge
+    between Windows (which would otherwise translate ``\\n`` -> ``\\r\\n``) and
+    POSIX.
+    """
+    return data.replace("\r\n", "\n")
+
+
+def write_text_lf(path: Path, data: str) -> None:
+    """Write ``data`` to ``path`` as UTF-8 with deterministic LF line endings.
+
+    Non-atomic counterpart to :func:`atomic_write_text`. ``newline=""`` disables
+    the platform newline translation that ``Path.write_text`` performs in text
+    mode, so the on-disk bytes (and therefore their content hash) are identical
+    on every OS.
+    """
+    path.write_text(_to_lf(data), encoding="utf-8", newline="")
+
+
 def atomic_write_text(path: Path, data: str, *, new_file_mode: int | None = None) -> None:
     """Atomically write ``data`` (UTF-8) to ``path``.
 
@@ -42,10 +65,10 @@ def atomic_write_text(path: Path, data: str, *, new_file_mode: int | None = None
         if new_file_mode is not None and not existed and hasattr(os, "fchmod"):
             with contextlib.suppress(OSError):
                 os.fchmod(fd, new_file_mode)
-        fh = os.fdopen(fd, "w", encoding="utf-8")
+        fh = os.fdopen(fd, "w", encoding="utf-8", newline="")
         fd_wrapped = True
         with fh:
-            fh.write(data)
+            fh.write(_to_lf(data))
         os.replace(tmp_name, path)
     except Exception:
         if not fd_wrapped:

--- a/tests/integration/test_install_local_bundle_e2e.py
+++ b/tests/integration/test_install_local_bundle_e2e.py
@@ -628,6 +628,50 @@ class TestLocalBundleHashFormatCrossFlow:
                 "Stale-cleanup provenance check would mis-classify this file as user-edited."
             )
 
+    def test_crlf_source_records_same_hash_as_lf_source(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """CRLF source content deploys as LF and records the same hash as LF source."""
+        from apm_cli.utils.content_hash import compute_file_hash
+
+        def install_skill_source(root: Path, source_content: str) -> tuple[bytes, str]:
+            bundle = _make_plugin_bundle(
+                root / "src",
+                files={"skills/coding/SKILL.md": source_content},
+            )
+            project = _make_project(root / "dst")
+
+            result = _invoke_install(
+                project, str(bundle), "--target", "copilot", monkeypatch=monkeypatch
+            )
+            assert result.exit_code == 0, f"stdout={result.output!r}\nstderr={result.stderr!r}"
+
+            deployed = project / ".agents" / "skills" / "coding" / "SKILL.md"
+            deployed_bytes = deployed.read_bytes()
+            data = yaml.safe_load((project / "apm.lock.yaml").read_text(encoding="utf-8"))
+            deployed_hashes = data.get("local_deployed_file_hashes") or {}
+
+            recorded_hashes = []
+            for record_path, recorded in deployed_hashes.items():
+                candidate = Path(record_path)
+                if not candidate.is_absolute():
+                    candidate = project / candidate
+                if candidate == deployed:
+                    recorded_hashes.append(recorded)
+
+            assert recorded_hashes == [compute_file_hash(deployed)]
+            return deployed_bytes, recorded_hashes[0]
+
+        lf_bytes, lf_hash = install_skill_source(
+            tmp_path / "lf", "# Coding Skill\nHelps with code.\n"
+        )
+        crlf_bytes, crlf_hash = install_skill_source(
+            tmp_path / "crlf", "# Coding Skill\r\nHelps with code.\r\n"
+        )
+
+        assert lf_bytes == crlf_bytes == b"# Coding Skill\nHelps with code.\n"
+        assert crlf_hash == lf_hash
+
     def test_recorded_hash_compares_equal_in_cleanup_provenance_check(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/integration/test_instruction_integrator.py
+++ b/tests/unit/integration/test_instruction_integrator.py
@@ -1163,9 +1163,7 @@ class TestClaudeRulesIntegration:
         assert b"\r\n" in target.read_bytes()
 
         # Re-install must rewrite (not adopt) so bytes converge back to LF.
-        result = self.integrator.integrate_package_instructions_claude(
-            pkg_info, self.project_root
-        )
+        result = self.integrator.integrate_package_instructions_claude(pkg_info, self.project_root)
         assert result.files_integrated == 1
         assert result.files_adopted == 0
         assert target.read_bytes() == lf_bytes
@@ -1182,9 +1180,7 @@ class TestClaudeRulesIntegration:
         pkg_info = _make_package_info(pkg)
 
         self.integrator.integrate_package_instructions_claude(pkg_info, self.project_root)
-        result = self.integrator.integrate_package_instructions_claude(
-            pkg_info, self.project_root
-        )
+        result = self.integrator.integrate_package_instructions_claude(pkg_info, self.project_root)
         assert result.files_adopted == 1
         assert result.files_integrated == 0
 

--- a/tests/unit/integration/test_instruction_integrator.py
+++ b/tests/unit/integration/test_instruction_integrator.py
@@ -1135,6 +1135,59 @@ class TestClaudeRulesIntegration:
         assert "# General" in deployed
         assert "Always lint." in deployed
 
+    def test_crlf_rule_file_rewritten_to_lf_not_adopted(self):
+        """A stale CRLF rule file is rewritten to LF, not adopted (apm#1889).
+
+        read_text() collapses CRLF->LF, so a text-mode equality check would
+        wrongly adopt a CRLF file left by a pre-fix Windows install and pin a
+        platform-dependent hash in the lockfile. The adopt check compares the
+        on-disk bytes against the LF output, so the file is re-written as LF.
+        """
+        (self.project_root / ".claude").mkdir()
+        pkg = self.project_root / "package"
+        inst_dir = pkg / ".apm" / "instructions"
+        inst_dir.mkdir(parents=True)
+        (inst_dir / "python.instructions.md").write_text(
+            "---\napplyTo: '**/*.py'\n---\n\n# Python rules\n"
+        )
+        pkg_info = _make_package_info(pkg)
+
+        # First install writes the canonical LF output.
+        self.integrator.integrate_package_instructions_claude(pkg_info, self.project_root)
+        target = self.project_root / ".claude" / "rules" / "python.md"
+        lf_bytes = target.read_bytes()
+        assert b"\r\n" not in lf_bytes
+
+        # Simulate a pre-fix Windows deploy: identical content, CRLF endings.
+        target.write_bytes(lf_bytes.replace(b"\n", b"\r\n"))
+        assert b"\r\n" in target.read_bytes()
+
+        # Re-install must rewrite (not adopt) so bytes converge back to LF.
+        result = self.integrator.integrate_package_instructions_claude(
+            pkg_info, self.project_root
+        )
+        assert result.files_integrated == 1
+        assert result.files_adopted == 0
+        assert target.read_bytes() == lf_bytes
+
+    def test_lf_rule_file_adopted_unchanged(self):
+        """An up-to-date LF rule file is adopted on re-install (no churn)."""
+        (self.project_root / ".claude").mkdir()
+        pkg = self.project_root / "package"
+        inst_dir = pkg / ".apm" / "instructions"
+        inst_dir.mkdir(parents=True)
+        (inst_dir / "python.instructions.md").write_text(
+            "---\napplyTo: '**/*.py'\n---\n\n# Python rules\n"
+        )
+        pkg_info = _make_package_info(pkg)
+
+        self.integrator.integrate_package_instructions_claude(pkg_info, self.project_root)
+        result = self.integrator.integrate_package_instructions_claude(
+            pkg_info, self.project_root
+        )
+        assert result.files_adopted == 1
+        assert result.files_integrated == 0
+
 
 class TestClaudeRulesSyncIntegration:
     """Test sync_integration_claude (manifest-based removal)."""

--- a/tests/unit/test_content_hash.py
+++ b/tests/unit/test_content_hash.py
@@ -5,7 +5,12 @@ from pathlib import Path  # noqa: F401
 
 import pytest
 
-from apm_cli.utils.content_hash import compute_package_hash, verify_package_hash
+from apm_cli.utils.content_hash import (
+    _EMPTY_HASH,
+    compute_file_hash,
+    compute_package_hash,
+    verify_package_hash,
+)
 
 # ---------------------------------------------------------------------------
 # compute_package_hash
@@ -212,6 +217,46 @@ class TestVerifyPackageHash:
         expected = compute_package_hash(tmp_path)
         (tmp_path / "extra.txt").write_text("injected")
         assert verify_package_hash(tmp_path, expected) is False
+
+
+# ---------------------------------------------------------------------------
+# compute_file_hash (per-deployed-file provenance)
+# ---------------------------------------------------------------------------
+
+
+class TestComputeFileHash:
+    def test_prefix_and_length(self, tmp_path):
+        """Returns the canonical ``sha256:<64-hex>`` form."""
+        f = tmp_path / "a.md"
+        f.write_bytes(b"# Title\n\nbody\n")
+        result = compute_file_hash(f)
+        assert result.startswith("sha256:")
+        assert len(result) == len("sha256:") + 64
+
+    def test_hashes_raw_bytes_as_written(self, tmp_path):
+        """Hash is over the exact on-disk bytes (req-lk-012), no normalization.
+
+        CRLF and LF variants of the same text are distinct on disk, so they
+        MUST hash differently -- the provenance hash binds the bytes as
+        written, which is what ``apm audit`` re-verifies.
+        """
+        lf = tmp_path / "lf.md"
+        lf.write_bytes(b"# H\n\ntext\n")
+        crlf = tmp_path / "crlf.md"
+        crlf.write_bytes(b"# H\r\n\r\ntext\r\n")
+        assert compute_file_hash(lf) != compute_file_hash(crlf)
+
+    def test_real_content_change_differs(self, tmp_path):
+        """A genuine content edit changes the hash."""
+        a = tmp_path / "a.md"
+        a.write_bytes(b"# H\n\noriginal\n")
+        h1 = compute_file_hash(a)
+        a.write_bytes(b"# H\n\nedited\n")
+        assert compute_file_hash(a) != h1
+
+    def test_missing_file_returns_empty_hash(self, tmp_path):
+        """A path that does not exist yields the empty-content hash."""
+        assert compute_file_hash(tmp_path / "nope.md") == _EMPTY_HASH
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/utils/test_atomic_io.py
+++ b/tests/unit/utils/test_atomic_io.py
@@ -20,7 +20,7 @@ from unittest.mock import patch
 
 import pytest
 
-from apm_cli.utils.atomic_io import atomic_write_text
+from apm_cli.utils.atomic_io import atomic_write_text, write_text_lf
 
 
 class TestAtomicWriteText:
@@ -177,3 +177,41 @@ class TestAtomicWriteText:
                 atomic_write_text(target, "data")
 
         assert not target.exists()
+
+    # ------------------------------------------------------------------
+    # Deterministic LF line endings (cross-platform hash stability)
+    # ------------------------------------------------------------------
+
+    def test_crlf_normalized_to_lf(self, tmp_path: Path) -> None:
+        """CRLF input is written as LF so on-disk bytes are OS-independent."""
+        target = tmp_path / "crlf.txt"
+        atomic_write_text(target, "a\r\nb\r\nc")
+        assert target.read_bytes() == b"a\nb\nc"
+
+    def test_lf_input_unchanged(self, tmp_path: Path) -> None:
+        """LF input round-trips without gaining a carriage return."""
+        target = tmp_path / "lf.txt"
+        atomic_write_text(target, "a\nb\n")
+        assert target.read_bytes() == b"a\nb\n"
+
+
+class TestWriteTextLf:
+    """Tests for write_text_lf() (non-atomic, LF-normalizing writer)."""
+
+    def test_creates_file_with_lf(self, tmp_path: Path) -> None:
+        """Content is written and CRLF is normalized to LF."""
+        target = tmp_path / "out.md"
+        write_text_lf(target, "a\r\nb\r\n")
+        assert target.read_bytes() == b"a\nb\n"
+
+    def test_lf_input_unchanged(self, tmp_path: Path) -> None:
+        """LF-only input is left byte-for-byte intact."""
+        target = tmp_path / "out.md"
+        write_text_lf(target, "# H\n\ntext\n")
+        assert target.read_bytes() == b"# H\n\ntext\n"
+
+    def test_unicode_round_trips(self, tmp_path: Path) -> None:
+        """Non-ASCII content survives the UTF-8 + LF write."""
+        target = tmp_path / "u.md"
+        write_text_lf(target, "café ☕ 日本語\r\n")
+        assert target.read_text(encoding="utf-8") == "café ☕ 日本語\n"

--- a/tests/unit/utils/test_atomic_io.py
+++ b/tests/unit/utils/test_atomic_io.py
@@ -194,6 +194,12 @@ class TestAtomicWriteText:
         atomic_write_text(target, "a\nb\n")
         assert target.read_bytes() == b"a\nb\n"
 
+    def test_bare_cr_input_unchanged(self, tmp_path: Path) -> None:
+        """Bare CR round-trips; only CRLF pairs are normalized."""
+        target = tmp_path / "bare-cr.txt"
+        atomic_write_text(target, "a\rb\n")
+        assert target.read_bytes() == b"a\rb\n"
+
 
 class TestWriteTextLf:
     """Tests for write_text_lf() (non-atomic, LF-normalizing writer)."""
@@ -209,6 +215,12 @@ class TestWriteTextLf:
         target = tmp_path / "out.md"
         write_text_lf(target, "# H\n\ntext\n")
         assert target.read_bytes() == b"# H\n\ntext\n"
+
+    def test_bare_cr_input_unchanged(self, tmp_path: Path) -> None:
+        """Bare CR is not normalized so drift-normalizer semantics match."""
+        target = tmp_path / "bare-cr.md"
+        write_text_lf(target, "a\rb\n")
+        assert target.read_bytes() == b"a\rb\n"
 
     def test_unicode_round_trips(self, tmp_path: Path) -> None:
         """Non-ASCII content survives the UTF-8 + LF write."""


### PR DESCRIPTION
## TL;DR
Supersedes #1890 and preserves @aleguilloux's original fix for #1889 on a microsoft/apm branch so the merge conflicts can be resolved. Closes #1889.

## Credit
This PR is based on @aleguilloux's cross-platform LF normalization work from #1890. The original commits remain authored by @aleguilloux, and follow-up commits include co-author trailers for @aleguilloux and Copilot where appropriate.

## What changed
- Rebased/cherry-picked #1890 onto current `main` and resolved the CHANGELOG conflict.
- Centralized deployed text normalization through `apm_cli.utils.atomic_io` helpers.
- Routed remaining APM-written deployed text paths through LF-normalizing writes, including user root context output and UTF-8 text files from local bundles.
- Kept binary/non-UTF8 local bundle files byte-preserving via `shutil.copy2`.
- Added an integration regression trap proving CRLF source content deploys as LF and records the same hash as LF source content.
- Narrowed the CHANGELOG wording to APM-written deployed text files.

## Validation
- `uv run --extra dev pytest tests/integration/test_install_local_bundle_e2e.py::TestLocalBundleHashFormatCrossFlow tests/unit/utils/test_atomic_io.py::TestWriteTextLf tests/unit/integration/test_instruction_integrator.py::TestClaudeRulesIntegration::test_crlf_rule_file_rewritten_to_lf_not_adopted tests/unit/compilation/test_user_root_context.py -q` -> 29 passed.
- Mutation-break gate: deleting `normalize_crlf_to_lf` made `test_crlf_source_records_same_hash_as_lf_source` fail; guard restored.
- CI-mirror lint: ruff check, ruff format --check, YAML/file-length/relative_to guard equivalents, pylint R0801, and `scripts/lint-auth-signals.sh` all passed locally.

## External gate
The original #1890 has `license/cla` pending for @aleguilloux. This superseding PR may retain the same contributor CLA requirement because it preserves authorship; it must be resolved by the contributor before merge.
