### PR TITLE
refactor(cowork): DRY internal hot-path cleanup (closes #922)

### DIFF
--- a/src/apm_cli/integration/skill_integrator.py
+++ b/src/apm_cli/integration/skill_integrator.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 
 from apm_cli.integration.base_integrator import BaseIntegrator
+from apm_cli.integration.targets import TargetProfile
 
 
 def _build_copy_ignore(
@@ -439,6 +440,20 @@ class SkillIntegrator(BaseIntegrator):
         # map so that same-manifest collisions are detected before the lockfile is written.
         self._native_skill_session_owners: dict[str, str] = {}
 
+    @staticmethod
+    def _target_skills_root(target: TargetProfile, project_root: Path) -> Path:
+        """Return the target skills root for static and dynamic-root targets."""
+        if target.resolved_deploy_root is not None:
+            return target.deploy_path(project_root)
+        skills_mapping = target.primitives["skills"]
+        effective_root = skills_mapping.deploy_root or target.root_dir
+        return project_root / effective_root / "skills"
+
+    @staticmethod
+    def _target_skill_dir(target: TargetProfile, project_root: Path, skill_name: str) -> Path:
+        """Return the concrete directory for a deployed skill."""
+        return SkillIntegrator._target_skills_root(target, project_root) / skill_name
+
     def find_instruction_files(self, package_path: Path) -> list[Path]:
         """Find all instruction files in a package.
 
@@ -831,13 +846,7 @@ class SkillIntegrator(BaseIntegrator):
                 continue
 
             is_primary = idx == 0  # first active target owns diagnostics
-            skills_mapping = target.primitives["skills"]
-            # Dynamic-root targets (cowork): use resolved_deploy_root.
-            if target.resolved_deploy_root is not None:
-                target_skills_root = target.resolved_deploy_root
-            else:
-                effective_root = skills_mapping.deploy_root or target.root_dir
-                target_skills_root = project_root / effective_root / "skills"
+            target_skills_root = self._target_skills_root(target, project_root)
 
             # Dedup: skip if same resolved skills root already processed.
             resolved_root = target_skills_root.resolve()
@@ -973,12 +982,8 @@ class SkillIntegrator(BaseIntegrator):
 
             is_primary = idx == 0  # first active target owns diagnostics
             skills_mapping = target.primitives["skills"]
-            # Dynamic-root targets (cowork): use resolved_deploy_root.
-            if target.resolved_deploy_root is not None:
-                target_skill_dir = target.resolved_deploy_root / skill_name
-            else:
-                effective_root = skills_mapping.deploy_root or target.root_dir
-                target_skill_dir = project_root / effective_root / "skills" / skill_name
+            effective_root = skills_mapping.deploy_root or target.root_dir
+            target_skill_dir = self._target_skill_dir(target, project_root, skill_name)
 
             # Security: validate name + containment + symlink rejection.
             from apm_cli.utils.path_security import (
@@ -1071,11 +1076,8 @@ class SkillIntegrator(BaseIntegrator):
             if is_primary:
                 files_copied = sum(1 for _ in target_skill_dir.rglob("*") if _.is_file())
 
-            # Promote sub-skills for this target
-            if target.resolved_deploy_root is not None:
-                target_skills_root = target.resolved_deploy_root
-            else:
-                target_skills_root = project_root / effective_root / "skills"
+            # Promote sub-skills for this target.
+            target_skills_root = self._target_skills_root(target, project_root)
             _, sub_deployed = self._promote_sub_skills(
                 sub_skills_dir,
                 target_skills_root,

--- a/src/apm_cli/integration/skill_integrator.py
+++ b/src/apm_cli/integration/skill_integrator.py
@@ -983,6 +983,7 @@ class SkillIntegrator(BaseIntegrator):
 
             is_primary = idx == 0  # first active target owns diagnostics
             skills_mapping = target.primitives["skills"]
+            # Static targets still need the effective root for the containment guard below.
             effective_root = skills_mapping.deploy_root or target.root_dir
             target_skill_dir = self._target_skill_dir(target, project_root, skill_name)
 

--- a/tests/unit/integration/test_skill_integrator_hermetic.py
+++ b/tests/unit/integration/test_skill_integrator_hermetic.py
@@ -63,6 +63,11 @@ def _make_target(
     target.root_dir = root_dir
     target.auto_create = auto_create
     target.resolved_deploy_root = resolved_deploy_root
+    target.deploy_path = MagicMock(
+        side_effect=lambda project_root, *parts: (
+            resolved_deploy_root if resolved_deploy_root is not None else project_root / root_dir
+        ).joinpath(*parts)
+    )
     prim = MagicMock()
     mapping = MagicMock()
     mapping.deploy_root = deploy_root

--- a/tests/unit/integration/test_skill_integrator_phase3w4.py
+++ b/tests/unit/integration/test_skill_integrator_phase3w4.py
@@ -63,6 +63,11 @@ def _make_target(
     target.root_dir = root_dir
     target.auto_create = auto_create
     target.resolved_deploy_root = resolved_deploy_root
+    target.deploy_path = MagicMock(
+        side_effect=lambda project_root, *parts: (
+            resolved_deploy_root if resolved_deploy_root is not None else project_root / root_dir
+        ).joinpath(*parts)
+    )
     prim = MagicMock()
     mapping = MagicMock()
     mapping.deploy_root = deploy_root


### PR DESCRIPTION
# refactor(cowork): DRY internal hot-path cleanup

## TL;DR

This is the item-1-only refactor accepted for #922: `SkillIntegrator` no longer open-codes the cowork dynamic-root branch at the three identified call sites. The change is behavior-preserving and keeps static target `deploy_root` handling intact. Closes #922 under the maintainer's accepted scope.

> [!NOTE]
> Scope is intentionally limited to issue item 1: routing skill deployment paths through the target deploy-path abstraction. Items 2 and 3 remain out of scope per the Board comment.

## Problem (WHY)

- [x] Issue #922 item 1 identified three `SkillIntegrator` call sites that repeated `if target.resolved_deploy_root is not None` instead of using the target abstraction.
- [x] The maintainer acceptance narrowed the work to "scoped to item 1 only" and required "no public CLI/manifest surface change".
- [!] Repeating the dynamic-root branch makes future cowork path changes easier to miss in hot skill deployment paths.

## Approach (WHAT)

| # | Fix |
|---|-----|
| 1 | Add one internal helper for resolving the target skills root. |
| 2 | Add one internal helper for resolving a concrete native skill directory. |
| 3 | Replace the three item-1 dynamic-root branches with those helpers, which route cowork roots through `TargetProfile.deploy_path()`. |
| 4 | Update the existing target test doubles so they model the deploy-path accessor now used by the implementation. |

## Implementation (HOW)

- **`src/apm_cli/integration/skill_integrator.py`** -- adds `_target_skills_root()` and `_target_skill_dir()` and uses them in the three item-1 call sites: standalone sub-skill promotion, native skill directory deployment, and native sub-skill promotion. Static targets still use `skills_mapping.deploy_root or target.root_dir`, preserving existing Copilot/Cursor/OpenCode `.agents/skills` behavior.
- **`tests/unit/integration/test_skill_integrator_hermetic.py`** -- teaches the local `_make_target()` mock to expose `deploy_path()` so the dedup tests exercise the same internal accessor shape.
- **`tests/unit/integration/test_skill_integrator_phase3w4.py`** -- mirrors the same mock update in the duplicate coverage fixture.

## Diagrams

Legend: the diagram shows the three repeated cowork branches collapsing into two internal helpers while cowork roots continue through `TargetProfile.deploy_path()`.

```mermaid
flowchart LR
    subgraph Before[Before]
        B1[standalone sub-skill path]
        B2[native skill path]
        B3[native sub-skill promotion]
        B4[inline resolved_deploy_root branches]
    end
    subgraph After[After]
        A1[_target_skills_root]:::new
        A2[_target_skill_dir]:::new
        A3[TargetProfile.deploy_path]
    end
    B1 --> A1
    B2 --> A2
    B3 --> A1
    A1 --> A3
    A2 --> A1
    classDef new stroke-dasharray: 5 5;
    class A1,A2 new;
```

## Trade-offs

- **Helper extraction instead of broader target API change.** Chose a local `SkillIntegrator` helper; rejected changing `TargetProfile.deploy_path()` semantics because item 1 is a bounded internal tidy.
- **No behavior tests added.** This is a pure refactor; existing cowork and skill-integrator tests already cover the affected paths, and the only test changes keep mocks aligned with the production accessor.
- **Items 2 and 3 left untouched.** The maintainer explicitly scoped this PR to item 1 only.

## Benefits

1. Reduces three open-coded cowork dynamic-root branches to one helper path.
2. Keeps cowork deployment rooted through `TargetProfile.deploy_path()` for the accepted item-1 sites.
3. Preserves static `deploy_root` behavior for existing non-cowork skill targets.
4. Leaves public CLI flags, manifest schema, and user-visible output unchanged.

## Validation

Baseline before refactor:

```console
$ uv run --extra dev pytest tests/ -k cowork -q
224 skipped, 28664 deselected in 28.95s

$ uv run --extra dev pytest tests/unit/integration/test_skill_integrator_cowork.py -q
6 passed in 1.53s
```

After refactor:

```console
$ uv run --extra dev pytest tests/ -k cowork -q
224 skipped, 28664 deselected in 9.05s

$ uv run --extra dev pytest tests/unit/integration/test_skill_integrator_cowork.py -q
6 passed in 0.79s

$ uv run --extra dev pytest tests/unit/integration/test_skill_integrator.py tests/unit/integration/test_skill_integrator_hermetic.py tests/unit/integration/test_skill_integrator_phase3w4.py -q
280 passed in 4.36s

$ uv run --extra dev pytest tests/ -q
exit 0
```

Lint:

```console
$ uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/ && uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/ && bash scripts/lint-auth-signals.sh
All checks passed!
1315 files already formatted

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

[*] Rule A: get_bearer_provider boundary (any reference)
[*] Rule B: git ls-remote auth-delegated annotation
[+] auth-signal lint clean
```

Additional CI lint guards (YAML I/O, file length, raw `str(relative_to(...))`) were run with BSD-compatible local equivalents and exited 0.

### Scenario Evidence

Skipped: pure internal refactor with no observable behavior change.

## How to test

- [ ] Run `uv run --extra dev pytest tests/unit/integration/test_skill_integrator_cowork.py -q` and expect 6 passing tests.
- [ ] Run `uv run --extra dev pytest tests/unit/integration/test_skill_integrator.py tests/unit/integration/test_skill_integrator_hermetic.py tests/unit/integration/test_skill_integrator_phase3w4.py -q` and expect 280 passing tests.
- [ ] Run the lint chain above and expect ruff, format, pylint R0801, and auth-signal checks to pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
