### PR TITLE
fix(install): adopt CRLF-source files against LF-deployed targets on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,15 +105,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Reinstalling a dependency whose source files carry CRLF line endings
-  (Windows text-mode checkout or `core.autocrlf`) now correctly adopts the
-  already-deployed LF file instead of re-integrating it every run and falsely
-  reporting it as freshly installed. The adopt check is deploy-mode aware:
-  LF-normalizing integrators (instruction/agent/prompt/command) compare the
-  on-disk target against the LF-normalized source, while byte-preserving
-  integrators (hook/canvas) keep exact raw-byte identity; a stale CRLF target
-  is still rewritten to LF rather than adopted. No-op installs now report
-  `(files unchanged)` on Windows as they already did on Linux/macOS. (#1916)
+- Reinstalling on Windows no longer falsely re-reports unchanged files as
+  freshly installed. A dependency whose source carries CRLF line endings
+  (text-mode checkout or `core.autocrlf`) now adopts the already-deployed LF
+  file, so no-op installs report `(files unchanged)` as they do on
+  Linux/macOS. (#1916)
 - `apm update` no longer shows a spurious update for registry semver deps already at the latest matching version. (#1897)
 - APM-written deployed text files now use LF line endings on every platform,
   so identical content no longer produces different

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,8 +108,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reinstalling a dependency whose source files carry CRLF line endings
   (Windows text-mode checkout or `core.autocrlf`) now correctly adopts the
   already-deployed LF file instead of re-integrating it every run and falsely
-  reporting it as freshly installed. The adopt check compares the on-disk
-  (LF) target against the LF-normalized source, so no-op installs report
+  reporting it as freshly installed. The adopt check is deploy-mode aware:
+  LF-normalizing integrators (instruction/agent/prompt/command) compare the
+  on-disk target against the LF-normalized source, while byte-preserving
+  integrators (hook/canvas) keep exact raw-byte identity; a stale CRLF target
+  is still rewritten to LF rather than adopted. No-op installs now report
   `(files unchanged)` on Windows as they already did on Linux/macOS. (#1916)
 - `apm update` no longer shows a spurious update for registry semver deps already at the latest matching version. (#1897)
 - APM-written deployed text files now use LF line endings on every platform,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reinstalling a dependency whose source files carry CRLF line endings
+  (Windows text-mode checkout or `core.autocrlf`) now correctly adopts the
+  already-deployed LF file instead of re-integrating it every run and falsely
+  reporting it as freshly installed. The adopt check compares the on-disk
+  (LF) target against the LF-normalized source, so no-op installs report
+  `(files unchanged)` on Windows as they already did on Linux/macOS. (#1916)
 - `apm update` no longer shows a spurious update for registry semver deps already at the latest matching version. (#1897)
 - APM-written deployed text files now use LF line endings on every platform,
   so identical content no longer produces different

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -399,7 +399,9 @@ class AgentIntegrator(BaseIntegrator):
                 continue
             rel_path = portable_relpath(target_path, project_root)
 
-            if self.try_adopt_identical(target_path, source_file, target_paths):
+            if self.try_adopt_identical(
+                target_path, source_file, target_paths, lf_normalized_deploy=True
+            ):
                 files_adopted += 1
             else:
                 if self.check_collision(
@@ -430,7 +432,9 @@ class AgentIntegrator(BaseIntegrator):
                         )
                     continue
                 claude_rel = portable_relpath(claude_path, project_root)
-                if self.try_adopt_identical(claude_path, source_file, target_paths):
+                if self.try_adopt_identical(
+                    claude_path, source_file, target_paths, lf_normalized_deploy=True
+                ):
                     files_adopted += 1
                 elif not self.check_collision(
                     claude_path, claude_rel, managed_files, force, diagnostics=diagnostics
@@ -456,7 +460,9 @@ class AgentIntegrator(BaseIntegrator):
                         )
                     continue
                 cursor_rel = portable_relpath(cursor_path, project_root)
-                if self.try_adopt_identical(cursor_path, source_file, target_paths):
+                if self.try_adopt_identical(
+                    cursor_path, source_file, target_paths, lf_normalized_deploy=True
+                ):
                     files_adopted += 1
                 elif not self.check_collision(
                     cursor_path, cursor_rel, managed_files, force, diagnostics=diagnostics

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -27,6 +27,9 @@ if TYPE_CHECKING:
 class AgentIntegrator(BaseIntegrator):
     """Handles integration of APM package agents into .github/agents/, .claude/agents/, and .cursor/agents/."""
 
+    # Deploys via write_text_lf -> compare adopt candidates in LF mode.
+    _LF_NORMALIZED_DEPLOY = True
+
     def find_agent_files(self, package_path: Path) -> list[Path]:
         """Find all .agent.md and .chatmode.md files in a package.
 

--- a/src/apm_cli/integration/base_integrator.py
+++ b/src/apm_cli/integration/base_integrator.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from apm_cli.compilation.link_resolver import UnifiedLinkResolver
 from apm_cli.primitives.discovery import discover_primitives
+from apm_cli.utils.atomic_io import normalize_crlf_to_lf
 from apm_cli.utils.console import _rich_warning
 
 
@@ -165,10 +166,20 @@ class BaseIntegrator:
 
     @staticmethod
     def is_content_identical_to_source(target_path: Path, source_path: Path) -> bool:
-        """Return True if *target_path* is byte-identical to *source_path*.
+        """Return True if *target_path* matches what APM would deploy from *source_path*.
 
         Used by non-skill integrators to silently *adopt* a pre-existing
         on-disk file that already matches what APM would deploy.
+
+        Deployed files are always written LF-normalized (``write_text_lf``),
+        so the on-disk *target* bytes are compared against the *LF-normalized*
+        source bytes -- not the raw source bytes. Without this normalization a
+        package whose source carries CRLF line endings (Windows text-mode
+        checkout, ``core.autocrlf``, or a text-mode write) would never match
+        the LF target, so every reinstall would needlessly re-integrate the
+        file and report it as freshly installed (apm#1916). Only the *source*
+        side is normalized: a stale CRLF *target* left by a pre-LF install
+        still mismatches and is rewritten to LF rather than adopted (apm#1889).
 
         Why this exists
         ---------------
@@ -194,12 +205,13 @@ class BaseIntegrator:
 
         Conservative by design
         ----------------------
-        Only fires for *byte-identical* matches. Format-transforming
-        targets (``codex_agent``, ``cursor_rules``, ``claude_rules``,
+        Only fires when the deployed bytes match the source content (modulo
+        CRLF->LF normalization). Format-transforming targets
+        (``codex_agent``, ``cursor_rules``, ``claude_rules``,
         ``windsurf_rules``, ``gemini_command``, ...) won't match -- they
         keep the existing skip behavior. This means we never silently
         adopt content that *might* have come from somewhere else; we only
-        adopt files that are demonstrably the package's own bytes already
+        adopt files that are demonstrably the package's own content already
         on disk.
 
         TOCTOU hardening
@@ -236,7 +248,21 @@ class BaseIntegrator:
                 # an optimisation; the user-authored skip path is the
                 # safe fallback.
                 return False
-            return target_bytes == source_bytes
+            # Compare the on-disk (LF) target against the LF-normalized
+            # source. A fast raw-byte equality covers the common case where
+            # source is already LF; the normalized comparison only runs when
+            # they differ (e.g. a CRLF source on Windows).
+            if target_bytes == source_bytes:
+                return True
+            try:
+                normalized_source = normalize_crlf_to_lf(source_bytes.decode("utf-8")).encode(
+                    "utf-8"
+                )
+            except UnicodeDecodeError:
+                # Binary or non-UTF-8 source: only a raw byte match (handled
+                # above) can adopt; otherwise fall through to skip/rewrite.
+                return False
+            return target_bytes == normalized_source
         except OSError:
             return False
 

--- a/src/apm_cli/integration/base_integrator.py
+++ b/src/apm_cli/integration/base_integrator.py
@@ -97,6 +97,15 @@ class BaseIntegrator:
     handled here.
     """
 
+    # Deploy-mode for the shared adopt predicate (:meth:`_check_adopt_or_skip`).
+    # ``False`` = byte-preserving identity (the safe default any future
+    # byte-preserving integrator inherits). Integrators that deploy via
+    # ``write_text_lf`` (instruction / command / agent) override this to
+    # ``True`` so a CRLF-source file already deployed as LF is adopted rather
+    # than churned. Making the mode an explicit, named class attribute keeps
+    # it out of a hardcoded literal buried inside the predicate.
+    _LF_NORMALIZED_DEPLOY = False
+
     def __init__(self):
         self.link_resolver: UnifiedLinkResolver | None = None
 
@@ -339,11 +348,16 @@ class BaseIntegrator:
         When adopting, *target_path* is appended to *target_paths* as a
         side effect so the caller's bookkeeping stays correct.
 
+        The adopt comparison runs in this integrator's deploy mode
+        (:attr:`_LF_NORMALIZED_DEPLOY`): LF-normalizing integrators compare
+        the on-disk target against the LF-normalized source, while
+        byte-preserving integrators compare raw bytes.
+
         Args:
             target_path: Destination path on disk.
             source_file: Source file to compare against; the file is adopted
-                when the on-disk target already matches the deployed (LF-
-                normalized) form of this source.
+                when the on-disk target already matches the deployed form of
+                this source.
             rel_path: Relative path string used for collision detection and
                 diagnostics.
             managed_files: Set of APM-managed relative paths; ``None`` means
@@ -354,12 +368,14 @@ class BaseIntegrator:
             target_paths: Mutable list; *target_path* is appended on adopt.
 
         Returns:
-            ``(skip, adopted)`` — when ``skip`` is ``True`` the caller must
+            ``(skip, adopted)`` -- when ``skip`` is ``True`` the caller must
             ``continue`` (or otherwise skip writing this file); ``adopted``
             is ``True`` only when the existing file already matched the
             deployed content and has been silently adopted.
         """
-        if self.is_content_identical_to_source(target_path, source_file, lf_normalized_deploy=True):
+        if self.is_content_identical_to_source(
+            target_path, source_file, lf_normalized_deploy=self._LF_NORMALIZED_DEPLOY
+        ):
             target_paths.append(target_path)
             return True, True
         if self.check_collision(

--- a/src/apm_cli/integration/base_integrator.py
+++ b/src/apm_cli/integration/base_integrator.py
@@ -165,21 +165,41 @@ class BaseIntegrator:
         return {p.replace("\\", "/") for p in managed_files}
 
     @staticmethod
-    def is_content_identical_to_source(target_path: Path, source_path: Path) -> bool:
+    def is_content_identical_to_source(
+        target_path: Path,
+        source_path: Path,
+        *,
+        lf_normalized_deploy: bool = False,
+    ) -> bool:
         """Return True if *target_path* matches what APM would deploy from *source_path*.
 
         Used by non-skill integrators to silently *adopt* a pre-existing
         on-disk file that already matches what APM would deploy.
 
-        Deployed files are always written LF-normalized (``write_text_lf``),
-        so the on-disk *target* bytes are compared against the *LF-normalized*
-        source bytes -- not the raw source bytes. Without this normalization a
-        package whose source carries CRLF line endings (Windows text-mode
-        checkout, ``core.autocrlf``, or a text-mode write) would never match
-        the LF target, so every reinstall would needlessly re-integrate the
-        file and report it as freshly installed (apm#1916). Only the *source*
-        side is normalized: a stale CRLF *target* left by a pre-LF install
-        still mismatches and is rewritten to LF rather than adopted (apm#1889).
+        The comparison depends on *how the calling integrator deploys*, which
+        the caller declares via ``lf_normalized_deploy``:
+
+        * ``lf_normalized_deploy=False`` (default) -- *byte-preserving*
+          deployers (the hook, kiro-hook, and canvas integrators copy the
+          source verbatim with ``shutil.copy2`` / ``shutil.copyfile``). The
+          deployed bytes equal the source bytes exactly, so "identical" is
+          raw byte identity.
+        * ``lf_normalized_deploy=True`` -- *LF-normalizing* deployers (the
+          agent, instruction, prompt, and command integrators write through
+          ``write_text_lf``). The deployed bytes equal the *LF-normalized*
+          source, so the on-disk *target* is identical iff it equals what
+          ``write_text_lf`` would write. Without this, a package whose source
+          carries CRLF line endings (Windows text-mode checkout,
+          ``core.autocrlf``, or a text-mode write) would never match the LF
+          target, so every reinstall would needlessly re-integrate the file
+          and report it as freshly installed (apm#1916).
+
+        In the LF-normalizing mode only the *source* side is normalized and
+        there is no raw-byte short-circuit: a stale CRLF *target* left by a
+        pre-LF install -- even one whose raw bytes happen to equal a CRLF
+        source on a ``core.autocrlf`` checkout -- still mismatches the LF
+        bytes ``write_text_lf`` would emit and is rewritten to LF rather than
+        adopted (apm#1889).
 
         Why this exists
         ---------------
@@ -248,37 +268,54 @@ class BaseIntegrator:
                 # an optimisation; the user-authored skip path is the
                 # safe fallback.
                 return False
-            # Compare the on-disk (LF) target against the LF-normalized
-            # source. A fast raw-byte equality covers the common case where
-            # source is already LF; the normalized comparison only runs when
-            # they differ (e.g. a CRLF source on Windows).
-            if target_bytes == source_bytes:
-                return True
+            if not lf_normalized_deploy:
+                # Byte-preserving deployer: deployed bytes equal source
+                # bytes verbatim, so "identical" is raw byte identity.
+                return target_bytes == source_bytes
+            # LF-normalizing deployer: the target is identical iff it equals
+            # what ``write_text_lf`` would write -- the LF-normalized source.
+            # No raw-byte short-circuit: a stale CRLF target whose raw bytes
+            # match a CRLF source must still be rewritten to LF, not adopted
+            # (apm#1889).
             try:
                 normalized_source = normalize_crlf_to_lf(source_bytes.decode("utf-8")).encode(
                     "utf-8"
                 )
             except UnicodeDecodeError:
-                # Binary or non-UTF-8 source: only a raw byte match (handled
-                # above) can adopt; otherwise fall through to skip/rewrite.
-                return False
+                # Non-UTF-8 source can't be line-normalized and
+                # ``write_text_lf`` could not have produced it; fall back to
+                # raw byte identity.
+                return target_bytes == source_bytes
             return target_bytes == normalized_source
         except OSError:
             return False
 
     @staticmethod
-    def try_adopt_identical(target_path: Path, source_path: Path, target_paths: list) -> bool:
-        """Adopt *target_path* when it is byte-identical to *source_path*.
+    def try_adopt_identical(
+        target_path: Path,
+        source_path: Path,
+        target_paths: list,
+        *,
+        lf_normalized_deploy: bool = False,
+    ) -> bool:
+        """Adopt *target_path* when it is identical to what would be deployed.
 
         Encapsulates the ``is_content_identical_to_source`` + append pattern
         so secondary call sites in agent/prompt/hook integrators share a
         single predicate call instead of repeating the three-line block.
 
+        ``lf_normalized_deploy`` is forwarded to
+        :meth:`is_content_identical_to_source`: LF-normalizing deployers
+        (agent, prompt) pass ``True``; byte-preserving deployers (hook,
+        kiro-hook) keep the ``False`` default.
+
         Returns ``True`` and appends *target_path* to *target_paths* when the
         files are identical; returns ``False`` and leaves *target_paths*
         unchanged otherwise.
         """
-        if BaseIntegrator.is_content_identical_to_source(target_path, source_path):
+        if BaseIntegrator.is_content_identical_to_source(
+            target_path, source_path, lf_normalized_deploy=lf_normalized_deploy
+        ):
             target_paths.append(target_path)
             return True
         return False
@@ -304,7 +341,9 @@ class BaseIntegrator:
 
         Args:
             target_path: Destination path on disk.
-            source_file: Source file to compare against for byte-identity.
+            source_file: Source file to compare against; the file is adopted
+                when the on-disk target already matches the deployed (LF-
+                normalized) form of this source.
             rel_path: Relative path string used for collision detection and
                 diagnostics.
             managed_files: Set of APM-managed relative paths; ``None`` means
@@ -317,10 +356,10 @@ class BaseIntegrator:
         Returns:
             ``(skip, adopted)`` — when ``skip`` is ``True`` the caller must
             ``continue`` (or otherwise skip writing this file); ``adopted``
-            is ``True`` only when the existing file was byte-identical and
-            has been silently adopted.
+            is ``True`` only when the existing file already matched the
+            deployed content and has been silently adopted.
         """
-        if self.is_content_identical_to_source(target_path, source_file):
+        if self.is_content_identical_to_source(target_path, source_file, lf_normalized_deploy=True):
             target_paths.append(target_path)
             return True, True
         if self.check_collision(

--- a/src/apm_cli/integration/command_integrator.py
+++ b/src/apm_cli/integration/command_integrator.py
@@ -145,6 +145,9 @@ class CommandIntegrator(BaseIntegrator):
     during package installation, following the same pattern as PromptIntegrator.
     """
 
+    # Deploys via write_text_lf -> compare adopt candidates in LF mode.
+    _LF_NORMALIZED_DEPLOY = True
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Track which (target_name) values have already received the

--- a/src/apm_cli/integration/instruction_integrator.py
+++ b/src/apm_cli/integration/instruction_integrator.py
@@ -36,6 +36,9 @@ class InstructionIntegrator(BaseIntegrator):
     * Gemini CLI: compile-only (GEMINI.md) -- no per-file rule deployment
     """
 
+    # Deploys via write_text_lf -> compare adopt candidates in LF mode.
+    _LF_NORMALIZED_DEPLOY = True
+
     # Map format_id -> converter method.  Built once at class load time;
     # avoids rebuilding the dict on every ``_render_instruction`` call.
     _FORMAT_CONVERTERS: ClassVar[dict[str, str]] = {

--- a/src/apm_cli/integration/prompt_integrator.py
+++ b/src/apm_cli/integration/prompt_integrator.py
@@ -302,7 +302,9 @@ class PromptIntegrator(BaseIntegrator):
                 continue
             rel_path = portable_relpath(target_path, project_root)
 
-            if self.try_adopt_identical(target_path, source_file, target_paths):
+            if self.try_adopt_identical(
+                target_path, source_file, target_paths, lf_normalized_deploy=True
+            ):
                 files_adopted += 1
                 continue
 

--- a/tests/unit/integration/test_content_identical_adopt.py
+++ b/tests/unit/integration/test_content_identical_adopt.py
@@ -80,6 +80,35 @@ class TestIsContentIdenticalToSource:
         b.write_bytes(b"different bytes\n")
         assert BaseIntegrator.is_content_identical_to_source(a, b) is False
 
+    def test_lf_target_adopts_crlf_source(self, tmp_path: Path) -> None:
+        """apm#1916: a CRLF source (Windows text write / autocrlf) must adopt
+        against the always-LF deployed target instead of re-integrating."""
+        target = tmp_path / "target"
+        source = tmp_path / "source"
+        target.write_bytes(b"# Fixture\nbody\n")
+        source.write_bytes(b"# Fixture\r\nbody\r\n")
+        assert BaseIntegrator.is_content_identical_to_source(target, source) is True
+
+    def test_stale_crlf_target_is_not_adopted(self, tmp_path: Path) -> None:
+        """apm#1889: a stale CRLF target left by a pre-LF install must NOT be
+        adopted; it should mismatch so the caller rewrites it to LF."""
+        target = tmp_path / "target"
+        source = tmp_path / "source"
+        target.write_bytes(b"# Fixture\r\nbody\r\n")
+        source.write_bytes(b"# Fixture\nbody\n")
+        assert BaseIntegrator.is_content_identical_to_source(target, source) is False
+
+    def test_non_utf8_source_only_raw_byte_match_adopts(self, tmp_path: Path) -> None:
+        """Binary/non-UTF-8 sources cannot be normalized: only an exact raw
+        byte match adopts; any difference falls through to skip/rewrite."""
+        target = tmp_path / "target"
+        source = tmp_path / "source"
+        target.write_bytes(b"\xff\xfe\x00bytes")
+        source.write_bytes(b"\xff\xfe\x00bytes")
+        assert BaseIntegrator.is_content_identical_to_source(target, source) is True
+        source.write_bytes(b"\xff\xfe\x00OTHER")
+        assert BaseIntegrator.is_content_identical_to_source(target, source) is False
+
     def test_target_missing_returns_false(self, tmp_path: Path) -> None:
         a = tmp_path / "missing"
         b = tmp_path / "present"

--- a/tests/unit/integration/test_content_identical_adopt.py
+++ b/tests/unit/integration/test_content_identical_adopt.py
@@ -80,34 +80,82 @@ class TestIsContentIdenticalToSource:
         b.write_bytes(b"different bytes\n")
         assert BaseIntegrator.is_content_identical_to_source(a, b) is False
 
-    def test_lf_target_adopts_crlf_source(self, tmp_path: Path) -> None:
-        """apm#1916: a CRLF source (Windows text write / autocrlf) must adopt
-        against the always-LF deployed target instead of re-integrating."""
+    def test_lf_normalized_deploy_adopts_crlf_source(self, tmp_path: Path) -> None:
+        """apm#1916: under an LF-normalizing deployer a CRLF source (Windows
+        text write / autocrlf) must adopt against the always-LF deployed
+        target instead of re-integrating."""
         target = tmp_path / "target"
         source = tmp_path / "source"
         target.write_bytes(b"# Fixture\nbody\n")
         source.write_bytes(b"# Fixture\r\nbody\r\n")
-        assert BaseIntegrator.is_content_identical_to_source(target, source) is True
+        assert (
+            BaseIntegrator.is_content_identical_to_source(target, source, lf_normalized_deploy=True)
+            is True
+        )
 
-    def test_stale_crlf_target_is_not_adopted(self, tmp_path: Path) -> None:
-        """apm#1889: a stale CRLF target left by a pre-LF install must NOT be
-        adopted; it should mismatch so the caller rewrites it to LF."""
+    def test_lf_normalized_deploy_stale_crlf_target_not_adopted(self, tmp_path: Path) -> None:
+        """apm#1889: under an LF-normalizing deployer a stale CRLF target left
+        by a pre-LF install must NOT be adopted against an LF source; it should
+        mismatch so the caller rewrites it to LF."""
         target = tmp_path / "target"
         source = tmp_path / "source"
         target.write_bytes(b"# Fixture\r\nbody\r\n")
         source.write_bytes(b"# Fixture\nbody\n")
+        assert (
+            BaseIntegrator.is_content_identical_to_source(target, source, lf_normalized_deploy=True)
+            is False
+        )
+
+    def test_lf_normalized_deploy_stale_crlf_target_with_crlf_source_not_adopted(
+        self, tmp_path: Path
+    ) -> None:
+        """apm#1889: the dangerous case -- a stale CRLF target whose raw bytes
+        equal a CRLF source (Windows checkout with ``core.autocrlf``) must
+        still NOT be adopted under an LF-normalizing deployer, because
+        ``write_text_lf`` would emit LF. There is deliberately no raw-byte
+        short-circuit that would wrongly adopt it."""
+        target = tmp_path / "target"
+        source = tmp_path / "source"
+        target.write_bytes(b"# Fixture\r\nbody\r\n")
+        source.write_bytes(b"# Fixture\r\nbody\r\n")
+        assert (
+            BaseIntegrator.is_content_identical_to_source(target, source, lf_normalized_deploy=True)
+            is False
+        )
+
+    def test_byte_preserving_deploy_requires_raw_identity(self, tmp_path: Path) -> None:
+        """Byte-preserving deployers (hook / kiro-hook / canvas copy the source
+        verbatim) must compare raw bytes: a CRLF source against an LF target is
+        NOT identical (the copy would write CRLF), but two CRLF files are."""
+        target = tmp_path / "target"
+        source = tmp_path / "source"
+        # CRLF source vs LF target -> byte-preserving copy would differ.
+        target.write_bytes(b"# Fixture\nbody\n")
+        source.write_bytes(b"# Fixture\r\nbody\r\n")
         assert BaseIntegrator.is_content_identical_to_source(target, source) is False
+        # Two raw-identical CRLF files -> adopt (no rewrite for byte copy).
+        target.write_bytes(b"# Fixture\r\nbody\r\n")
+        assert BaseIntegrator.is_content_identical_to_source(target, source) is True
 
     def test_non_utf8_source_only_raw_byte_match_adopts(self, tmp_path: Path) -> None:
-        """Binary/non-UTF-8 sources cannot be normalized: only an exact raw
-        byte match adopts; any difference falls through to skip/rewrite."""
+        """Binary/non-UTF-8 sources cannot be line-normalized: in both deploy
+        modes only an exact raw byte match adopts; any difference falls through
+        to skip/rewrite."""
         target = tmp_path / "target"
         source = tmp_path / "source"
         target.write_bytes(b"\xff\xfe\x00bytes")
         source.write_bytes(b"\xff\xfe\x00bytes")
         assert BaseIntegrator.is_content_identical_to_source(target, source) is True
+        assert (
+            BaseIntegrator.is_content_identical_to_source(target, source, lf_normalized_deploy=True)
+            is True
+        )
         source.write_bytes(b"\xff\xfe\x00OTHER")
         assert BaseIntegrator.is_content_identical_to_source(target, source) is False
+        assert (
+            BaseIntegrator.is_content_identical_to_source(target, source, lf_normalized_deploy=True)
+            is False
+        )
 
     def test_target_missing_returns_false(self, tmp_path: Path) -> None:
         a = tmp_path / "missing"
@@ -172,6 +220,39 @@ class TestInstructionIntegratorAdopt:
         )
         # Bytes preserved (no-op write or no write at all -- both acceptable).
         assert target.read_bytes() == body
+
+    def test_crlf_source_adopts_against_lf_target_when_managed_none(self, tmp_path: Path) -> None:
+        """apm#1916 end-to-end: a CRLF source (Windows text-mode checkout /
+        ``core.autocrlf``) against the LF target that ``write_text_lf`` already
+        deployed must be ADOPTED, not re-integrated.
+
+        Deterministically reproduces the Windows-only no-op-reinstall churn on
+        any OS by writing explicit CRLF source bytes. Guards
+        ``_check_adopt_or_skip(lf_normalized_deploy=True)``: drop that flag and
+        the CRLF source no longer matches the LF target, so the file is skipped
+        as user-authored and this test fails.
+        """
+        crlf_source = b"---\r\napplyTo: '**/*.py'\r\n---\r\n# Secure coding base\r\n"
+        lf_target = b"---\napplyTo: '**/*.py'\n---\n# Secure coding base\n"
+        _, target, pkg_info = self._build(tmp_path, crlf_source)
+        target.write_bytes(lf_target)  # what write_text_lf already deployed
+
+        result = InstructionIntegrator().integrate_instructions_for_target(
+            KNOWN_TARGETS["copilot"],
+            pkg_info,
+            tmp_path,
+            force=False,
+            managed_files=None,
+        )
+
+        assert target in result.target_paths, (
+            "CRLF source must adopt against the LF-deployed target so the file "
+            "is not endlessly re-integrated on Windows reinstalls (apm#1916)."
+        )
+        assert result.files_skipped == 0
+        assert result.files_integrated == 0, (
+            "Adopt must not re-report the file as freshly integrated."
+        )
 
     def test_divergent_pre_existing_file_is_still_skipped(self, tmp_path: Path) -> None:
         """User-authored content with different bytes keeps the existing

--- a/tests/unit/integration/test_content_identical_adopt.py
+++ b/tests/unit/integration/test_content_identical_adopt.py
@@ -171,6 +171,60 @@ class TestIsContentIdenticalToSource:
 
 
 # ---------------------------------------------------------------------------
+# try_adopt_identical -- deploy-mode contract for byte-preserving integrators
+# ---------------------------------------------------------------------------
+
+
+class TestTryAdoptIdenticalDeployMode:
+    """Pins the ``try_adopt_identical`` deploy-mode contract that the
+    byte-preserving integrators (hook / kiro-hook / canvas) depend on.
+
+    Those integrators call ``try_adopt_identical`` WITHOUT
+    ``lf_normalized_deploy`` and then deploy with ``shutil.copy2`` (verbatim),
+    so a CRLF source must NOT be adopted against an LF target -- a verbatim
+    copy would leave CRLF on disk and churn the lockfile. The LF-normalizing
+    integrators pass ``lf_normalized_deploy=True`` and DO adopt the same pair.
+    This pins the byte-preserving reject path at the wrapper that
+    ``hook_integrator`` actually calls, complementing the helper-level tests
+    on :meth:`is_content_identical_to_source`.
+    """
+
+    def test_byte_preserving_default_rejects_crlf_against_lf(self, tmp_path: Path) -> None:
+        target = tmp_path / "hook.sh"
+        source = tmp_path / "src.sh"
+        target.write_bytes(b"#!/bin/sh\necho hi\n")
+        source.write_bytes(b"#!/bin/sh\r\necho hi\r\n")
+        adopted: list[Path] = []
+        # Default mode is how hook_integrator calls it: no adopt, no append.
+        assert BaseIntegrator.try_adopt_identical(target, source, adopted) is False
+        assert adopted == []
+
+    def test_byte_preserving_default_adopts_raw_identical(self, tmp_path: Path) -> None:
+        target = tmp_path / "hook.sh"
+        source = tmp_path / "src.sh"
+        target.write_bytes(b"#!/bin/sh\r\necho hi\r\n")
+        source.write_bytes(b"#!/bin/sh\r\necho hi\r\n")
+        adopted: list[Path] = []
+        assert BaseIntegrator.try_adopt_identical(target, source, adopted) is True
+        assert adopted == [target]
+
+    def test_lf_normalized_flag_adopts_crlf_against_lf(self, tmp_path: Path) -> None:
+        """Contrast: the SAME CRLF-source/LF-target pair the byte-preserving
+        default rejects IS adopted when the caller opts into LF normalization
+        (instruction/agent/prompt/command)."""
+        target = tmp_path / "x.md"
+        source = tmp_path / "src.md"
+        target.write_bytes(b"# h\nbody\n")
+        source.write_bytes(b"# h\r\nbody\r\n")
+        adopted: list[Path] = []
+        assert (
+            BaseIntegrator.try_adopt_identical(target, source, adopted, lf_normalized_deploy=True)
+            is True
+        )
+        assert adopted == [target]
+
+
+# ---------------------------------------------------------------------------
 # Instruction integrator -- the user's reproducer (zava-storefront)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## TL;DR

Fixes the Windows-only CI failure in `test_second_noop_install_reports_no_changes_in_summary`. A no-op reinstall on Windows was re-integrating instruction files and reporting them as freshly installed instead of `(files unchanged)`.

## Problem (WHY)

PR #1913 made all deployed files LF-normalized on every platform (`write_text_lf`). But the shared adopt predicate `BaseIntegrator.is_content_identical_to_source` still compared **raw source bytes** against the on-disk target. On Windows, a package source file with CRLF line endings (text-mode checkout / `core.autocrlf`) never matched the always-LF deployed target, so:

- every reinstall re-integrated the file (`1 instruction(s) integrated`)
- the no-op summary never showed `(files unchanged)`

The rule-dir branch was already fixed for this in #1913; the identity path (`.github/instructions/`, agents, prompts, commands) was missed. This only manifests on Windows, where `\n` becomes `\r\n` in source files.

## Approach (WHAT)

Compare the on-disk (LF) target against the **LF-normalized source** instead of raw source bytes:

- A fast raw-byte equality still covers the common LF-source case.
- Only when they differ do we normalize the source (`normalize_crlf_to_lf`) and re-compare — so a CRLF source matches the LF target → adopt.
- Only the **source** side is normalized. A stale CRLF *target* left by a pre-LF install still mismatches and is rewritten to LF rather than adopted (preserves the apm#1889 intent).
- Non-UTF-8 / binary sources fall back to raw-byte-only matching.

## Validation evidence

- New regression tests in `test_content_identical_adopt.py` reproduce the Windows scenario on any OS via explicit byte writes (LF target + CRLF source → adopt; stale CRLF target → rewrite; non-UTF-8 handling).
- Local: `tests/unit/integration/`, `tests/unit/install/`, `tests/unit/test_content_hash.py` all pass (3429 passed).
- Lint chain green: ruff check, ruff format --check, pylint R0801, auth-signal lint.
- **The authoritative check is the Windows CI job in this PR** — the root cause is platform-specific and cannot be reproduced on macOS/Linux locally.

## How to test

```bash
uv run --extra dev pytest tests/unit/install/test_noop_summary.py tests/unit/integration/test_content_identical_adopt.py
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


apm-spec-waiver: bugfix restores intended LF/CRLF adopt idempotency from #1913; no new normative behaviour, deployed bytes unchanged.
