### PR TITLE
fix(update): treat cached transitive registry deps as unchanged in update plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed spurious version-range diffs for cached transitive registry
+  dependencies during `apm update`. (by @nadav-y) (#1921)
+
 ## [0.22.0] - 2026-06-26
 
 ### Added

--- a/src/apm_cli/install/plan.py
+++ b/src/apm_cli/install/plan.py
@@ -196,6 +196,10 @@ def build_update_plan(
         seen_keys.add(key)
         old = old_entries.get(key)
         new_ref, new_commit = _extract_new_ref_and_commit(dep)
+        # Unannotated registry dep (cached, not re-downloaded): no concrete
+        # version was resolved this run, so treat the locked value as current.
+        if new_ref is None and old is not None and getattr(dep, "source", None) == "registry":
+            new_ref = old.resolved_ref
 
         if old is None:
             plan_entries.append(
@@ -280,6 +284,11 @@ def _extract_new_ref_and_commit(dep: DependencyReference) -> tuple[str | None, s
     """
     resolved = getattr(dep, "resolved_reference", None)
     if resolved is None:
+        # Registry deps identify by resolved version, not the manifest range.
+        # Return None so the caller can fall back to the locked concrete version
+        # rather than treating the range as a ref change.
+        if getattr(dep, "source", None) == "registry":
+            return (None, None)
         return (getattr(dep, "reference", None), None)
     new_ref = (
         getattr(resolved, "ref_name", None)

--- a/src/apm_cli/install/plan.py
+++ b/src/apm_cli/install/plan.py
@@ -198,7 +198,15 @@ def build_update_plan(
         new_ref, new_commit = _extract_new_ref_and_commit(dep)
         # Unannotated registry dep (cached, not re-downloaded): no concrete
         # version was resolved this run, so treat the locked value as current.
-        if new_ref is None and old is not None and getattr(dep, "source", None) == "registry":
+        # Require the locked entry to also be registry-sourced -- otherwise a
+        # dep that transitions sources (e.g. git -> registry) while keeping the
+        # same key would be masked as unchanged.
+        if (
+            new_ref is None
+            and old is not None
+            and getattr(dep, "source", None) == "registry"
+            and old.source == "registry"
+        ):
             new_ref = old.resolved_ref
 
         if old is None:

--- a/tests/unit/install/test_plan.py
+++ b/tests/unit/install/test_plan.py
@@ -142,6 +142,71 @@ class TestBuildUpdatePlan:
 
         assert plan.entries == ()
 
+    def test_unannotated_registry_dep_is_unchanged_not_range_diff(self):
+        """A cached registry dep with no fresh resolution must stay 'unchanged'.
+
+        Regression: on ``apm update``, only direct semver deps get their cache
+        purged and re-resolved, so transitive registry deps are NOT re-downloaded
+        and never receive a ``resolved_reference`` annotation. The plan must fall
+        back to the locked concrete version (``1.0.0``) rather than the manifest
+        range (``^1.0.0``), which would otherwise render as a spurious
+        ``1.0.0 -> ^1.0.0`` update.
+        """
+        lock = _new_lockfile()
+        locked = LockedDependency(
+            repo_url="acme/transitive",
+            resolved_ref="1.0.0",
+            resolved_commit=None,
+            depth=2,
+            source="registry",
+            version="1.0.0",
+        )
+        lock.add_dependency(locked)
+
+        # Cached transitive: source=registry, range reference, NO annotation.
+        dep = DependencyReference(repo_url="acme/transitive", reference="^1.0.0", source="registry")
+        assert getattr(dep, "resolved_reference", None) is None
+
+        plan = build_update_plan(lock, [dep])
+
+        assert plan.has_changes is False
+        entry = plan.entries[0]
+        assert entry.action == "unchanged"
+        assert entry.new_resolved_ref == "1.0.0"
+
+    def test_annotated_registry_dep_still_shows_real_version_change(self):
+        """A re-resolved registry dep with a new version must still show as update.
+
+        Guards that the unchanged fallback above does not mask genuine updates:
+        when the resolver re-downloads a registry dep it annotates a concrete
+        ``resolved_reference``, and a higher version must surface as a change.
+        """
+        lock = _new_lockfile()
+        lock.add_dependency(
+            LockedDependency(
+                repo_url="acme/direct",
+                resolved_ref="1.1.0",
+                resolved_commit=None,
+                depth=1,
+                source="registry",
+                version="1.1.0",
+            )
+        )
+        dep = DependencyReference(repo_url="acme/direct", reference="^1.0.0", source="registry")
+        dep.resolved_reference = ResolvedReference(
+            original_ref="^1.0.0",
+            ref_type=GitReferenceType.TAG,
+            ref_name="1.3.0",
+        )
+
+        plan = build_update_plan(lock, [dep])
+
+        assert plan.has_changes is True
+        entry = plan.entries[0]
+        assert entry.action == "update"
+        assert entry.old_resolved_ref == "1.1.0"
+        assert entry.new_resolved_ref == "1.3.0"
+
 
 # -----------------------------------------------------------------------------
 # render_plan_text

--- a/tests/unit/install/test_plan.py
+++ b/tests/unit/install/test_plan.py
@@ -207,6 +207,34 @@ class TestBuildUpdatePlan:
         assert entry.old_resolved_ref == "1.1.0"
         assert entry.new_resolved_ref == "1.3.0"
 
+    def test_source_transition_to_registry_is_not_masked_as_unchanged(self):
+        """A git -> registry source change under the same key is a real change.
+
+        The unannotated-registry fallback must not borrow the locked ref when the
+        locked entry is git-sourced; otherwise a dependency that transitions
+        sources while keeping the same key would be masked as unchanged.
+        """
+        lock = _new_lockfile()
+        lock.add_dependency(
+            LockedDependency(
+                repo_url="acme/moved",
+                resolved_ref="v1.0.0",
+                resolved_commit="a" * 40,
+                depth=1,
+                source=None,  # git-sourced lock (None == git)
+            )
+        )
+        # Now resolved as a registry dep, but unannotated (no resolved_reference).
+        dep = DependencyReference(repo_url="acme/moved", reference="^1.0.0", source="registry")
+        assert getattr(dep, "resolved_reference", None) is None
+
+        plan = build_update_plan(lock, [dep])
+
+        entry = plan.entries[0]
+        # The git lock's ref must not be borrowed; this is a real change.
+        assert entry.new_resolved_ref != "v1.0.0"
+        assert entry.action == "update"
+
 
 # -----------------------------------------------------------------------------
 # render_plan_text


### PR DESCRIPTION
## Summary

`apm update` on a project with **transitive registry dependencies** misreports them as updated (`1.0.0 -> ^1.0.0`) even when nothing changed. This is not cosmetic -- the false classification flips `UpdatePlan.has_changes`, which gates control flow in `update.py`:

- In **CI / non-interactive shells**, a no-op `apm update` exits **non-zero** ("Cannot prompt for confirmation in non-interactive shell") instead of succeeding as a clean no-op.
- **Interactively**, it prompts the user to confirm a no-op and, if accepted, performs a needless re-resolve / re-integrate pass.

The lockfile end-state was always correct (no corruption) -- only the plan classification was wrong.

## Root cause

On `apm update`, only *direct* semver deps get their on-disk cache purged and re-resolved (`_purge_cached_semver_paths_for_update` is scoped to direct deps by design). So `_annotate_registry_dep_ref` runs for direct deps but **not** for cached transitive registry deps, which are never re-downloaded.

With no `resolved_reference` annotation, `_extract_new_ref_and_commit` fell back to `dep_ref.reference` -- the manifest range (`^1.0.0`). That mismatched the locked concrete version (`1.0.0`) and rendered a spurious `1.0.0 -> ^1.0.0` update.

The bug surfaced once #1908 correctly started storing the resolved version (`1.0.0`) in `resolved_ref` instead of the range -- before that, the comparison was `^1.0.0` vs `^1.0.0` and happened to match.

## Fix

- `_extract_new_ref_and_commit` returns `None` for an unannotated registry dep (the manifest range is not a ref).
- `build_update_plan` falls back to the locked concrete version for an already-locked registry dep with no fresh resolution.

A re-resolved registry dep still carries its `resolved_reference` annotation, so **genuine version bumps continue to show as updates** -- verified by test and live run.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| No-op `apm update`, non-interactive (CI) | exit 1, "Cannot prompt for confirmation" | exit 0, "All dependencies already at their latest matching refs." |
| No-op `apm update` plan output | "2 updated", `1.0.0 -> ^1.0.0` | clean no-op |
| Genuine direct-dep bump (`1.1.0 -> 1.3.0`) | shown as update | still shown as update |

## Tests

Two regression tests in `tests/unit/install/test_plan.py`:

- `test_unannotated_registry_dep_is_unchanged_not_range_diff` -- cached transitive registry dep stays `unchanged`, falls back to locked `1.0.0`.
- `test_annotated_registry_dep_still_shows_real_version_change` -- re-resolved registry dep with a new version still surfaces as `update` (guards against masking real updates).

Verified live against a JFrog registry with a `packages-skills -> artifactory-instructions -> jfrog-instructions` transitive chain. 19/19 plan tests pass, ruff clean.

apm-spec-waiver: display/plan-classification correctness fix for transitive registry deps -- restores expected no-op semantics for `apm update`; no new normative behavior introduced