### PR TITLE
fix(tests): stub package name/version in MCP lockfile integration mocks

### DIFF
--- a/tests/integration/test_global_mcp_lockfile_e2e.py
+++ b/tests/integration/test_global_mcp_lockfile_e2e.py
@@ -36,6 +36,8 @@ def _stub_downloader_for_lockfile(mock_dl_cls) -> None:
     pkg_info.resolved_reference.is_tag = False
     pkg_info.resolved_reference.is_sha = False
     pkg_info.package_type.value = "apm_package"
+    pkg_info.package.name = "stub-package"
+    pkg_info.package.version = "0.0.0"
     instance.download_package.return_value = pkg_info
 
 

--- a/tests/integration/test_selective_install_mcp.py
+++ b/tests/integration/test_selective_install_mcp.py
@@ -39,6 +39,8 @@ def _stub_downloader_for_lockfile(mock_dl_cls) -> None:
     pkg_info.resolved_reference.is_tag = False
     pkg_info.resolved_reference.is_sha = False
     pkg_info.package_type.value = "apm_package"
+    pkg_info.package.name = "stub-package"
+    pkg_info.package.version = "0.0.0"
     instance.download_package.return_value = pkg_info
 
 


### PR DESCRIPTION
## TL;DR

Stub `package.name` / `package.version` on the mocked downloader in two MCP lockfile integration test helpers so the v0.22.0 release CI goes green.

## Problem (WHY)

The release run for `v0.22.0` ([run 28221238903](https://github.com/microsoft/apm/actions/runs/28221238903)) failed on **Build & Validate (macOS x86_64 / arm64)** and **Integration Tests (ubuntu-24.04)** with 9 failing tests across:

- `tests/integration/test_selective_install_mcp.py` (7)
- `tests/integration/test_global_mcp_lockfile_e2e.py` (2)

The #1904 lockfile feature now records the installed package name and version by reading `package_info.package.name` / `package_info.package.version` in `src/apm_cli/install/sources.py`. In these tests the downloader is mocked via a shared `_stub_downloader_for_lockfile` helper that stubbed `resolved_reference` but not `package.name` / `.version`. Those attributes therefore returned unserializable `MagicMock`s, so lockfile YAML generation raised `cannot represent an object, <MagicMock ...package.name>` and the install exited non-zero.

## Approach (WHAT)

Add two lines to each helper to stub a real string name and version on the mock. This is a **test-only** fix -- production code is correct (`Package.name` / `.version` are strings in real runs); no `str()` coercion was added to `sources.py`.

## Validation evidence

- The 9 previously-failing tests pass locally: `pytest tests/integration/test_selective_install_mcp.py tests/integration/test_global_mcp_lockfile_e2e.py` -> 10 passed.
- Lint mirror green (ruff check, ruff format --check, pylint R0801, auth-signals).

## How to test

```
uv run --extra dev pytest tests/integration/test_selective_install_mcp.py tests/integration/test_global_mcp_lockfile_e2e.py -q
```
