### PR TITLE
fix(install): prune lockfile when all dependencies are removed from manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed `apm install` lockfile pruning when all `apm.yml` dependencies are
+  removed, so stale `apm.lock.yaml` entries no longer survive. (by @nadav-y)
+  (#1926)
 - Fixed spurious version-range diffs for cached transitive registry
   dependencies during `apm update`. (by @nadav-y) (#1921)
 

--- a/src/apm_cli/install/phases/lockfile.py
+++ b/src/apm_cli/install/phases/lockfile.py
@@ -67,7 +67,11 @@ class LockfileBuilder:
 
     def build_and_save(self) -> None:
         """Assemble lockfile from ctx state and write it (no-op when nothing was installed)."""
-        if not self.ctx.installed_packages and not self.ctx.lockfile_only:
+        if (
+            not self.ctx.installed_packages
+            and not self.ctx.lockfile_only
+            and not self._has_orphan_lockfile_entries()
+        ):
             # Even with nothing newly installed, a pre-existing
             # lockfile may need its cache pin markers refreshed --
             # e.g. user upgraded APM and their cache pre-dates the
@@ -79,6 +83,12 @@ class LockfileBuilder:
             # promise is to always materialise an ``apm.lock.yaml`` (an
             # empty one for a depless project), mirroring
             # ``cargo generate-lockfile``.
+            #
+            # We also fall through when the existing lockfile records deps
+            # that the manifest no longer declares (orphans): removing every
+            # dependency leaves installed_packages empty, but the lockfile
+            # must still be pruned to match apm.yml (see
+            # ``_has_orphan_lockfile_entries``).
             self._sync_cache_pin_markers_from_disk()
             return
         try:
@@ -136,6 +146,24 @@ class LockfileBuilder:
             self._handle_failure(e)
 
     # -- private helpers (verbatim from original inline block) ----------
+
+    def _has_orphan_lockfile_entries(self) -> bool:
+        """True when the existing lockfile records apm deps no longer intended.
+
+        Guards the "nothing installed" early-return: when every apm dependency
+        is removed from the manifest, ``installed_packages`` is empty, yet the
+        lockfile still lists the dropped deps. Falling through lets the normal
+        prune path (``_merge_existing``) rebuild a lockfile that matches the
+        manifest. Skipped for partial (``only_packages``) installs, which
+        intentionally preserve unlisted entries.
+        """
+        existing = self.ctx.existing_lockfile
+        if existing is None or self.ctx.only_packages:
+            return False
+        from apm_cli.deps.lockfile import _SELF_KEY
+
+        intended = self.ctx.intended_dep_keys or set()
+        return any(key != _SELF_KEY and key not in intended for key in existing.dependencies)
 
     def _attach_deployed_files(self, lockfile: LockFile) -> None:
         """Attach per-dependency deployed-file manifests, unioning targets.

--- a/tests/unit/install/phases/test_lockfile_orphan_prune.py
+++ b/tests/unit/install/phases/test_lockfile_orphan_prune.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from apm_cli.deps.lockfile import LockedDependency, LockFile
+from apm_cli.install.context import InstallContext
 from apm_cli.install.phases.lockfile import LockfileBuilder
 
 
@@ -76,3 +77,21 @@ class TestHasOrphanLockfileEntries:
         lf.dependencies[_SELF_KEY] = LockedDependency(repo_url=_SELF_KEY, resolved_ref="")
         ctx = _ctx(existing_lockfile=lf, intended_dep_keys=set())
         assert LockfileBuilder(ctx)._has_orphan_lockfile_entries() is False
+
+    def test_build_and_save_prunes_orphans_when_manifest_is_empty(self, tmp_path) -> None:
+        existing = _existing_with("acme/pkg")
+        lockfile_path = tmp_path / "apm.lock.yaml"
+        existing.write(lockfile_path)
+        ctx = InstallContext(
+            project_root=tmp_path,
+            apm_dir=tmp_path,
+            installed_packages=[],
+            existing_lockfile=existing,
+            intended_dep_keys=set(),
+        )
+
+        LockfileBuilder(ctx).build_and_save()
+
+        written = LockFile.read(lockfile_path)
+        assert written is not None
+        assert written.get_package_dependencies() == []

--- a/tests/unit/install/phases/test_lockfile_orphan_prune.py
+++ b/tests/unit/install/phases/test_lockfile_orphan_prune.py
@@ -1,0 +1,78 @@
+"""Regression traps for orphan-pruning the lockfile on a depless manifest.
+
+When every apm dependency is removed from ``apm.yml``, ``installed_packages``
+is empty, so ``LockfileBuilder.build_and_save`` used to early-return before the
+orphan-prune path (``_merge_existing``) ran -- leaving the lockfile listing deps
+the manifest no longer declares. ``_has_orphan_lockfile_entries`` guards that
+early-return so the builder falls through and rebuilds a lockfile matching the
+manifest. Partial (``only_packages``) installs must still preserve unlisted
+entries, so the guard is suppressed for them.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from apm_cli.deps.lockfile import LockedDependency, LockFile
+from apm_cli.install.phases.lockfile import LockfileBuilder
+
+
+def _existing_with(*repo_urls: str) -> LockFile:
+    lf = LockFile()
+    for url in repo_urls:
+        lf.add_dependency(LockedDependency(repo_url=url, resolved_ref="1.0.0"))
+    return lf
+
+
+def _ctx(*, existing_lockfile, intended_dep_keys, only_packages=None):
+    return SimpleNamespace(
+        existing_lockfile=existing_lockfile,
+        intended_dep_keys=set(intended_dep_keys),
+        only_packages=only_packages,
+    )
+
+
+class TestHasOrphanLockfileEntries:
+    def test_orphan_detected_when_manifest_emptied(self) -> None:
+        ctx = _ctx(
+            existing_lockfile=_existing_with("acme/pkg"),
+            intended_dep_keys=set(),  # manifest now declares nothing
+        )
+        assert LockfileBuilder(ctx)._has_orphan_lockfile_entries() is True
+
+    def test_no_orphan_when_all_entries_intended(self) -> None:
+        ctx = _ctx(
+            existing_lockfile=_existing_with("acme/pkg", "acme/other"),
+            intended_dep_keys={"acme/pkg", "acme/other"},
+        )
+        assert LockfileBuilder(ctx)._has_orphan_lockfile_entries() is False
+
+    def test_partial_orphan_detected(self) -> None:
+        ctx = _ctx(
+            existing_lockfile=_existing_with("acme/pkg", "acme/dropped"),
+            intended_dep_keys={"acme/pkg"},
+        )
+        assert LockfileBuilder(ctx)._has_orphan_lockfile_entries() is True
+
+    def test_only_packages_install_never_reports_orphans(self) -> None:
+        # Partial install intentionally preserves unlisted entries.
+        ctx = _ctx(
+            existing_lockfile=_existing_with("acme/pkg"),
+            intended_dep_keys=set(),
+            only_packages=["acme/pkg"],
+        )
+        assert LockfileBuilder(ctx)._has_orphan_lockfile_entries() is False
+
+    def test_no_existing_lockfile_has_no_orphans(self) -> None:
+        ctx = _ctx(existing_lockfile=None, intended_dep_keys=set())
+        assert LockfileBuilder(ctx)._has_orphan_lockfile_entries() is False
+
+    def test_self_key_is_not_treated_as_orphan(self) -> None:
+        # The "." self-entry (local deployed files) is not a manifest dep and
+        # must never trip the orphan guard on its own.
+        from apm_cli.deps.lockfile import _SELF_KEY
+
+        lf = LockFile()
+        lf.dependencies[_SELF_KEY] = LockedDependency(repo_url=_SELF_KEY, resolved_ref="")
+        ctx = _ctx(existing_lockfile=lf, intended_dep_keys=set())
+        assert LockfileBuilder(ctx)._has_orphan_lockfile_entries() is False


### PR DESCRIPTION
## Summary

Removing **every** apm dependency from `apm.yml` (leaving `apm: []`) cleans the deployed files but leaves the lockfile listing the dropped dependencies. The committed `apm.lock.yaml` then claims deps the manifest no longer declares.

Reproduced on a clean project:

```console
$ apm install        # apm.yml declares one dep (-> 3 with transitives)
$ grep -c repo_url apm.lock.yaml
3
# edit apm.yml: dependencies.apm: []
$ apm install
[i] Cleaned 4 files from packages no longer in apm.yml
$ grep -c repo_url apm.lock.yaml
3      # <-- stale; should be 0
```

## Root cause

`LockfileBuilder.build_and_save` early-returns when `installed_packages` is empty:

```python
if not self.ctx.installed_packages and not self.ctx.lockfile_only:
    self._sync_cache_pin_markers_from_disk()
    return
```

Emptying the manifest leaves `installed_packages` empty, so this returns before the orphan-prune path (`_merge_existing`, which already drops entries not in `intended_dep_keys`) can run. Partial removal (drop one of several deps) was unaffected, because `installed_packages` was non-empty and the full path ran.

## Fix

Guard the early-return with `_has_orphan_lockfile_entries()`: fall through to the rebuild/prune path when the existing lockfile records apm deps the manifest no longer declares. The fall-through reuses the existing prune + MCP/local-state-preservation logic unchanged.

- Suppressed for `only_packages` installs (partial install intentionally preserves unlisted entries).
- Ignores the `.` self-entry (local deployed files), which is not a manifest dep.
- No-op installs with deps still present do not churn the lockfile (verified: `generated_at` unchanged across a cached re-install).

## Behavior

| Scenario | Before | After |
|---|---|---|
| Remove all deps (`apm: []`), reinstall | lockfile keeps stale entries | lockfile pruned to `dependencies: []` |
| Remove one of several deps | pruned correctly | pruned correctly (unchanged) |
| Cached no-op install | no churn | no churn (unchanged) |

## Tests

`tests/unit/install/phases/test_lockfile_orphan_prune.py` -- 6 cases on `_has_orphan_lockfile_entries`: orphan detected on emptied manifest, partial orphan, no orphan when all intended, `only_packages` suppression, no existing lockfile, and `.` self-entry exclusion.

Verified live against a JFrog registry (registry deps) and `microsoft/apm-sample-package` (git deps) -- the desync and fix reproduce identically for both sources, confirming this is a general install-path fix, not source-specific.

apm-spec-waiver: lockfile-correctness fix -- prunes orphaned entries on a depless manifest so the lockfile matches apm.yml; reuses the existing prune path, no new normative behavior