### PR TITLE
fix(update): report changed-dependency count, not re-materialized tree size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed `apm install` lockfile pruning when all `apm.yml` dependencies are
   removed, so stale `apm.lock.yaml` entries no longer survive. (by @nadav-y)
   (#1926)
+- Fixed `apm update` final summary counts so unchanged re-materialized
+  dependencies are not reported as updated. (by @nadav-y) (#1927)
 - Fixed spurious version-range diffs for cached transitive registry
   dependencies during `apm update`. (by @nadav-y) (#1921)
 

--- a/src/apm_cli/commands/update.py
+++ b/src/apm_cli/commands/update.py
@@ -576,16 +576,26 @@ def _run_dep_update(
             except Exception as e:
                 _rich_error(f"Failed to record revision-pin tags in apm.lock.yaml: {e}")
                 sys.exit(1)
+        # Report the number of dependencies that actually changed (per the
+        # plan), not the total tree re-materialized (result.installed_count).
+        # The latter counts unchanged deps that were re-integrated, which
+        # contradicts the "N updated" line the plan just printed.
+        # installed_count is still the guard for whether anything materialized:
+        # a proceeded run that installed nothing reports the no-op outcome even
+        # if the plan predicted changes.
         installed = getattr(result, "installed_count", 0)
-        if installed and revision_pin_updates:
+        changed = len(plan.changed_entries)
+        applied = bool(installed) and changed > 0
+        if applied and revision_pin_updates:
             count = len(revision_pin_updates)
-            dep_noun = "dependency" if installed == 1 else "dependencies"
+            dep_noun = "dependency" if changed == 1 else "dependencies"
             pin_noun = "pin" if count == 1 else "pins"
             _rich_success(
-                f"Updated {installed} APM {dep_noun} and {count} revision {pin_noun} in apm.yml."
+                f"Updated {changed} APM {dep_noun} and {count} revision {pin_noun} in apm.yml."
             )
-        elif installed:
-            _rich_success(f"Updated {installed} APM dependencies.")
+        elif applied:
+            dep_noun = "dependency" if changed == 1 else "dependencies"
+            _rich_success(f"Updated {changed} APM {dep_noun}.")
         elif revision_pin_updates:
             count = len(revision_pin_updates)
             noun = "pin" if count == 1 else "pins"

--- a/src/apm_cli/commands/update.py
+++ b/src/apm_cli/commands/update.py
@@ -586,15 +586,14 @@ def _run_dep_update(
         installed = getattr(result, "installed_count", 0)
         changed = len(plan.changed_entries)
         applied = bool(installed) and changed > 0
+        dep_noun = "dependency" if changed == 1 else "dependencies"
         if applied and revision_pin_updates:
             count = len(revision_pin_updates)
-            dep_noun = "dependency" if changed == 1 else "dependencies"
             pin_noun = "pin" if count == 1 else "pins"
             _rich_success(
                 f"Updated {changed} APM {dep_noun} and {count} revision {pin_noun} in apm.yml."
             )
         elif applied:
-            dep_noun = "dependency" if changed == 1 else "dependencies"
             _rich_success(f"Updated {changed} APM {dep_noun}.")
         elif revision_pin_updates:
             count = len(revision_pin_updates)

--- a/tests/unit/commands/test_update_command.py
+++ b/tests/unit/commands/test_update_command.py
@@ -931,6 +931,61 @@ class TestUpdatePlanStatePaths:
             assert result.exit_code == 0, result.output
             assert "no dependency changes were applied" in result.output.lower()
 
+    def test_summary_reports_plan_changed_count_not_install_count(self, runner, tmp_path) -> None:
+        """Summary reflects the plan's changed count, not the re-materialized tree.
+
+        Regression: a single-dep change in a multi-dep tree printed "Updated 3
+        APM dependencies" (installed_count, the whole tree) -- contradicting the
+        plan's "1 updated" line. The summary must report the changed count.
+        """
+        with runner.isolated_filesystem(temp_dir=tmp_path):
+            _make_apm_yml(Path.cwd())
+
+            def fake_install(_apm, **kwargs):
+                from apm_cli.models.results import InstallResult
+
+                plan = UpdatePlan(
+                    entries=(
+                        PlanEntry(
+                            dep_key="o/r",
+                            action="update",
+                            display_name="o/r",
+                            old_resolved_ref="1.1.0",
+                            new_resolved_ref="1.3.0",
+                        ),
+                        PlanEntry(
+                            dep_key="o/t1",
+                            action="unchanged",
+                            display_name="o/t1",
+                            old_resolved_ref="1.0.0",
+                            new_resolved_ref="1.0.0",
+                        ),
+                        PlanEntry(
+                            dep_key="o/t2",
+                            action="unchanged",
+                            display_name="o/t2",
+                            old_resolved_ref="1.0.0",
+                            new_resolved_ref="1.0.0",
+                        ),
+                    )
+                )
+                kwargs["plan_callback"](plan)
+                # Whole 3-dep tree re-materialized, but only one changed.
+                return InstallResult(installed_count=3)
+
+            with (
+                _patch(
+                    "apm_cli.commands.install._install_apm_dependencies",
+                    side_effect=fake_install,
+                ),
+                _patch("apm_cli.commands.update._stdin_is_tty", return_value=True),
+                _patch("apm_cli.commands.update.click.confirm", return_value=True),
+            ):
+                result = runner.invoke(cli, ["update"])
+            assert result.exit_code == 0, result.output
+            assert "Updated 1 APM dependency." in result.output
+            assert "Updated 3" not in result.output
+
 
 # -----------------------------------------------------------------------------
 # apm update -- superset flags from issue #1525:


### PR DESCRIPTION
## Summary

The summary line printed after `apm update` overstates how many dependencies were updated. It uses `result.installed_count` -- the whole tree re-materialized, including unchanged transitives -- so a single-dependency change in a multi-dep tree prints **"Updated 3 APM dependencies"** while the plan the user just approved said **"1 updated"**.

Observed against a registry project (`packages-skills -> artifactory-instructions -> jfrog-instructions`) where only the direct dep changed:

```console
$ apm update --yes
  [~] jfrog/packages-skills
      ref: 1.1.0 -> 1.3.0
  1 updated                        # <-- plan: 1
  ...
Updated 3 APM dependencies.        # <-- summary: 3  (contradicts the plan)
```

## Fix

Report the plan's changed count (`len(plan.changed_entries)`) instead of `installed_count`.

`installed_count` is kept as the guard for whether anything materialized: a proceeded run that installed nothing still reports the no-op outcome even if the plan predicted changes (preserves the existing `test_proceeded_zero_installed_reports_no_dependency_changes` behavior). Also pluralizes the dependency noun, which was always "dependencies" (so a single change previously read "Updated 1 APM dependencies").

| Scenario (changed / installed / pins) | Before | After |
|---|---|---|
| 1 / 3 / 0 (one dep changed in a 3-dep tree) | "Updated 3 APM dependencies." | "Updated 1 APM dependency." |
| 1 / 1 / 1 | "Updated 1 APM dependency and 1 revision pin..." | unchanged |
| 0 / 0 / 1 (revision-pin only) | "Updated 1 revision pin..." | unchanged |
| 1 / 0 / 0 (proceeded, nothing materialized) | "No dependency changes were applied." | unchanged |

## Tests

- New `test_summary_reports_plan_changed_count_not_install_count`: 1 update + 2 unchanged in the plan, `installed_count=3` -> asserts "Updated 1 APM dependency." and not "Updated 3".
- All existing `test_update_command.py` cases pass (101 total across update + plan suites).

Found while smoke-testing registry updates, but the fix is general (not registry-specific) -- it applies to any multi-dependency `apm update`.

apm-spec-waiver: corrects an over-counted summary line to match the rendered plan; no change to resolution, download, or lockfile behavior