### PR TITLE
fix: honor per-dep targets and plural `targets:` in audit drift replay

### DIFF
--- a/src/apm_cli/install/drift.py
+++ b/src/apm_cli/install/drift.py
@@ -371,11 +371,14 @@ def _filter_targets(all_targets, names: frozenset[str] | None):
 
 
 def _read_apm_yml_target(project_root: Path):
-    """Return the ``target:`` field from ``apm.yml`` if present, else ``None``.
+    """Return the explicit target list from ``apm.yml`` if declared, else ``None``.
 
-    This lets ``run_replay`` reproduce the SAME target set the install
-    pipeline used, instead of falling back to directory auto-detection
-    that misses targets whose deployment directories are still empty.
+    Handles both the singular ``target:`` and plural ``targets:`` forms so
+    that the replay uses the same target set the install pipeline used.
+    Without this, a project with ``targets: [claude, codex]`` (no copilot)
+    that also has a ``.github/`` directory for unrelated CI workflows would
+    have copilot auto-detected during replay, producing false
+    ``unintegrated`` findings for ``.github/instructions/`` (#1924).
     """
     apm_yml = project_root / "apm.yml"
     if not apm_yml.exists():
@@ -389,13 +392,13 @@ def _read_apm_yml_target(project_root: Path):
         # than crashing the replay; the caller still surfaces a useful
         # error elsewhere if the project is truly broken.
         return None
-    raw = data.get("target")
-    if raw is None:
-        return None
+    # parse_targets_field handles both 'target:' (singular) and 'targets:'
+    # (plural list) and validates the tokens against the canonical set.
     try:
-        from apm_cli.core.target_detection import parse_target_field
+        from apm_cli.core.apm_yml import parse_targets_field
 
-        return parse_target_field(raw, source_path=apm_yml)
+        tokens = parse_targets_field(data)
+        return tokens if tokens else None
     except Exception:
         return None
 
@@ -509,6 +512,9 @@ def run_replay(config: ReplayConfig, logger: CheckLogger) -> Path:
                     skill_subset=None,
                     ctx=None,
                     scratch_root=scratch_root,
+                    # Honor per-dependency 'targets:' narrowing from apm.yml so the
+                    # replay does not write to targets excluded by the consumer (#1923).
+                    dep_target_subset=lock_dep.target_subset or None,
                 )
                 replayed_count += 1
     finally:

--- a/tests/unit/install/test_drift.py
+++ b/tests/unit/install/test_drift.py
@@ -471,3 +471,60 @@ def test_run_replay_wraps_loop_with_readonly_guard(monkeypatch, tmp_path):
         run_replay(config, logger)
 
     assert "leaked.md" in str(exc_info.value) or "created:" in str(exc_info.value)
+
+
+def test_run_replay_threads_dep_target_subset(monkeypatch, tmp_path):
+    """run_replay must pass dep_target_subset from the lockfile to integrate_package_primitives.
+
+    A dependency narrowed to ``targets: [claude]`` in apm.yml stores
+    ``target_subset: [claude]`` in the lockfile.  The replay must forward
+    this list so the per-dependency target filter applies -- otherwise
+    copilot-governed paths (e.g. ``.agents/skills/``) are written to
+    scratch even though the dep was never installed there, producing
+    false ``unintegrated`` drift (#1923).
+    """
+    from apm_cli.deps.lockfile import LockedDependency, LockFile
+    from apm_cli.install.drift import CheckLogger, ReplayConfig, run_replay
+
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    (project_root / ".github").mkdir()  # simulate unrelated .github/ dir
+
+    # Use a local dep whose path resolves to the project root itself so
+    # _materialize_install_path does not need network or apm_modules cache.
+    lock = LockFile()
+    dep = LockedDependency(
+        repo_url="./my-skill",
+        source="local",
+        local_path="./my-skill",
+        resolved_commit=None,
+        target_subset=["claude"],
+    )
+    lock.add_dependency(dep)
+    # Create the local package dir so path resolution succeeds.
+    (project_root / "my-skill").mkdir()
+    lockfile_path = project_root / "apm.lock.yaml"
+    lock.write(lockfile_path)
+
+    captured: list = []
+
+    def _spy_integrate(*args, **kwargs):
+        captured.append(kwargs.get("dep_target_subset"))
+        return {"deployed_files": []}
+
+    monkeypatch.setattr(
+        "apm_cli.install.services.integrate_package_primitives",
+        _spy_integrate,
+    )
+
+    config = ReplayConfig(
+        project_root=project_root,
+        lockfile_path=lockfile_path,
+        targets=None,
+        cache_only=True,
+    )
+    logger = CheckLogger(verbose=False)
+    run_replay(config, logger)
+
+    assert len(captured) >= 1, "integrate_package_primitives was not called"
+    assert captured[0] == ["claude"], f"dep_target_subset should be ['claude'], got {captured[0]}"

--- a/tests/unit/install/test_drift.py
+++ b/tests/unit/install/test_drift.py
@@ -488,9 +488,14 @@ def test_run_replay_threads_dep_target_subset(monkeypatch, tmp_path):
 
     project_root = tmp_path / "proj"
     project_root.mkdir()
-    (project_root / ".github").mkdir()  # simulate unrelated .github/ dir
+    # Explicit apm.yml with targets: [claude, copilot] makes target resolution
+    # deterministic (not directory-based) and matches the real bug scenario where
+    # a copilot target is active but the dep is narrowed to claude only.
+    (project_root / "apm.yml").write_text(
+        "name: test-project\ntargets:\n  - claude\n  - copilot\n", encoding="utf-8"
+    )
 
-    # Use a local dep whose path resolves to the project root itself so
+    # Use a local dep whose path resolves under project_root so
     # _materialize_install_path does not need network or apm_modules cache.
     lock = LockFile()
     dep = LockedDependency(
@@ -509,7 +514,15 @@ def test_run_replay_threads_dep_target_subset(monkeypatch, tmp_path):
     captured: list = []
 
     def _spy_integrate(*args, **kwargs):
-        captured.append(kwargs.get("dep_target_subset"))
+        # Capture both the resolved targets list and dep_target_subset so the
+        # test confirms (a) the full target set includes copilot (subset is
+        # meaningful) and (b) dep_target_subset is passed through correctly.
+        captured.append(
+            {
+                "target_names": sorted(t.name for t in kwargs.get("targets", [])),
+                "dep_target_subset": kwargs.get("dep_target_subset"),
+            }
+        )
         return {"deployed_files": []}
 
     monkeypatch.setattr(
@@ -527,4 +540,12 @@ def test_run_replay_threads_dep_target_subset(monkeypatch, tmp_path):
     run_replay(config, logger)
 
     assert len(captured) >= 1, "integrate_package_primitives was not called"
-    assert captured[0] == ["claude"], f"dep_target_subset should be ['claude'], got {captured[0]}"
+    call = captured[0]
+    # The resolved target set must include both claude and copilot so the
+    # dep_target_subset=['claude'] actually narrows integration.
+    assert "copilot" in call["target_names"], (
+        f"expected copilot in resolved targets, got {call['target_names']}"
+    )
+    assert call["dep_target_subset"] == ["claude"], (
+        f"dep_target_subset should be ['claude'], got {call['dep_target_subset']}"
+    )

--- a/tests/unit/install/test_drift_detection.py
+++ b/tests/unit/install/test_drift_detection.py
@@ -294,16 +294,24 @@ class TestReadApmYmlTarget:
         result = _read_apm_yml_target(tmp_path)
         assert result is None
 
-    def test_apm_yml_with_target_returns_value(self, tmp_path: Path) -> None:
+    def test_apm_yml_with_singular_target_returns_list(self, tmp_path: Path) -> None:
+        # Singular 'target: copilot' form -- returns a one-element list.
         (tmp_path / "apm.yml").write_text("name: pkg\ntarget: copilot\n", encoding="utf-8")
-        with patch("apm_cli.core.target_detection.parse_target_field", return_value="copilot"):
-            result = _read_apm_yml_target(tmp_path)
-        assert result == "copilot"
+        result = _read_apm_yml_target(tmp_path)
+        assert result == ["copilot"]
 
-    def test_parse_target_field_exception_returns_none(self, tmp_path: Path) -> None:
-        (tmp_path / "apm.yml").write_text("name: pkg\ntarget: invalid\n", encoding="utf-8")
+    def test_apm_yml_with_targets_list_returns_list(self, tmp_path: Path) -> None:
+        # Plural 'targets: [claude, codex]' form -- both tokens returned (#1924).
+        (tmp_path / "apm.yml").write_text(
+            "name: pkg\ntargets:\n  - claude\n  - codex\n", encoding="utf-8"
+        )
+        result = _read_apm_yml_target(tmp_path)
+        assert result == ["claude", "codex"]
+
+    def test_parse_targets_field_exception_returns_none(self, tmp_path: Path) -> None:
+        (tmp_path / "apm.yml").write_text("name: pkg\ntarget: copilot\n", encoding="utf-8")
         with patch(
-            "apm_cli.core.target_detection.parse_target_field",
+            "apm_cli.core.apm_yml.parse_targets_field",
             side_effect=ValueError("bad"),
         ):
             result = _read_apm_yml_target(tmp_path)

--- a/tests/unit/install/test_drift_phase3.py
+++ b/tests/unit/install/test_drift_phase3.py
@@ -277,16 +277,16 @@ class TestReadApmYmlTarget:
         result = _read_apm_yml_target(tmp_path)
         assert result is None
 
-    def test_apm_yml_with_target_returns_value(self, tmp_path: Path) -> None:
+    def test_apm_yml_with_singular_target_returns_list(self, tmp_path: Path) -> None:
+        # Singular 'target: copilot' form -- returns a one-element list.
         (tmp_path / "apm.yml").write_text("name: pkg\ntarget: copilot\n", encoding="utf-8")
-        with patch("apm_cli.core.target_detection.parse_target_field", return_value="copilot"):
-            result = _read_apm_yml_target(tmp_path)
-        assert result == "copilot"
+        result = _read_apm_yml_target(tmp_path)
+        assert result == ["copilot"]
 
-    def test_parse_target_field_exception_returns_none(self, tmp_path: Path) -> None:
-        (tmp_path / "apm.yml").write_text("name: pkg\ntarget: invalid\n", encoding="utf-8")
+    def test_parse_targets_field_exception_returns_none(self, tmp_path: Path) -> None:
+        (tmp_path / "apm.yml").write_text("name: pkg\ntarget: copilot\n", encoding="utf-8")
         with patch(
-            "apm_cli.core.target_detection.parse_target_field",
+            "apm_cli.core.apm_yml.parse_targets_field",
             side_effect=ValueError("bad"),
         ):
             result = _read_apm_yml_target(tmp_path)


### PR DESCRIPTION
## TL;DR

Two false-positive `unintegrated` drift bugs in `apm audit --ci` fixed
in a single, minimal change to `src/apm_cli/install/drift.py`.

---

## Problem (WHY)

### #1923 -- per-dependency `targets:` not honored in replay

`apm install` correctly narrows deployment for a dependency declared with
`targets: [claude]` in `apm.yml` -- only `.claude/skills/` is written.
The lockfile stores `target_subset: [claude]` on the locked entry.

However, `run_replay` called `integrate_package_primitives` **without**
`dep_target_subset`, so the replay ran copilot primitives into
`.agents/skills/` in scratch even though the dep was scoped to claude.
`diff_scratch_against_project` then found `.agents/skills/<dep>/SKILL.md`
in scratch but not in the project and reported false `unintegrated` drift.

### #1924 -- plural `targets:` field ignored during replay

`_read_apm_yml_target` read `data.get("target")` (singular) and passed
it to `parse_target_field`.  A project with `targets: [claude, codex]`
(plural list form, no copilot) returns `None` from the old lookup, so
`resolve_targets` fell through to directory-based auto-detection.  With
`.github/` present for unrelated CI workflows, copilot was auto-detected,
and the replay wrote `.github/instructions/local.instructions.md` into
scratch.  The project tree had no such file, yielding false
`unintegrated` drift.

---

## Approach (WHAT)

Two surgical fixes, both in `src/apm_cli/install/drift.py`:

1. **Pass `dep_target_subset` in `run_replay`** -- thread
   `lock_dep.target_subset or None` into `integrate_package_primitives`
   so the per-dependency target filter that already works at install time
   is applied identically during replay.

2. **Use `parse_targets_field` in `_read_apm_yml_target`** -- replace the
   hand-rolled `data.get("target")` + `parse_target_field` path with
   `parse_targets_field` from `core/apm_yml.py`, which already handles
   both `target:` (singular) and `targets:` (plural list) forms and
   validates tokens against the canonical set.

---

## Implementation (HOW)

```diff
# src/apm_cli/install/drift.py

# Fix #1924: _read_apm_yml_target
-    raw = data.get("target")
-    if raw is None:
-        return None
-    try:
-        from apm_cli.core.target_detection import parse_target_field
-        return parse_target_field(raw, source_path=apm_yml)
-    except Exception:
-        return None
+    try:
+        from apm_cli.core.apm_yml import parse_targets_field
+        tokens = parse_targets_field(data)
+        return tokens if tokens else None
+    except Exception:
+        return None

# Fix #1923: run_replay
+    dep_target_subset=lock_dep.target_subset or None,
```

No CLI surface change. No new dependencies. No docs change required
(the `targets:` per-dependency semantics are already documented and
the fix restores intended behavior).

---

## Architecture

```mermaid
flowchart TD
    A[apm audit --ci] --> B[_check_drift]
    B --> C[run_replay]
    C --> D[_read_apm_yml_target]
    D --> |"parse_targets_field (both forms)"| E[resolve_targets with explicit_target]
    C --> F[integrate_package_primitives]
    F --> |"dep_target_subset=lock_dep.target_subset"| G[filter_targets_for_dependency]
    G --> H[Write to scratch only for allowed targets]
    B --> I[diff_scratch_against_project]
    I --> J[No false unintegrated findings]
```

```mermaid
sequenceDiagram
    participant Audit as apm audit --ci
    participant Replay as run_replay
    participant Parse as _read_apm_yml_target
    participant Integrate as integrate_package_primitives
    participant Filter as filter_targets_for_dependency

    Audit->>Replay: run_replay(config)
    Replay->>Parse: _read_apm_yml_target(project_root)
    Note over Parse: parse_targets_field handles<br/>target: and targets: (#1924)
    Parse-->>Replay: ["claude", "codex"]
    Replay->>Integrate: ...dep_target_subset=["claude"]
    Note over Integrate: filter_targets_for_dependency<br/>narrows to claude only (#1923)
    Integrate-->>Replay: scratch written to .claude/ only
    Replay-->>Audit: scratch_root
    Note over Audit: diff finds no phantom .agents/ entries
```

---

## Trade-offs

- `_read_apm_yml_target` now returns `list[str]` instead of `str | None`.
  `resolve_targets(explicit_target=...)` already accepts a list, so no
  downstream change is needed.  Updated tests reflect the new return type.
- Using `parse_targets_field` means an invalid token in `targets:` now
  raises inside `_read_apm_yml_target`'s `except Exception` guard and
  falls back to auto-detect (same safe fallback as before).

---

## Validation evidence

```
uv run --extra dev pytest tests/unit/install/test_drift.py \
  tests/unit/install/test_drift_detection.py \
  tests/unit/install/test_drift_phase3.py -q
# 1688 passed

uv run --extra dev ruff check src/ tests/ && \
  uv run --extra dev ruff format --check src/ tests/ && \
  uv run --extra dev python -m pylint --disable=all --enable=R0801 \
    --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/ && \
  bash scripts/lint-auth-signals.sh
# All clean / 10.00/10
```

---

## How to test

1. Create a project with `targets: [claude, codex]` and a `.github/`
   directory (no copilot target).
2. Install any package that contains instruction primitives.
3. Run `apm audit --ci` -- should report no drift (was false
   `unintegrated` for `.github/instructions/` before this fix).

For #1923:
1. Add a dep with `targets: [claude]` in `apm.yml`.
2. Install (`apm install`) -- only `.claude/skills/` is written.
3. Run `apm audit --ci` -- should report no drift (was false
   `unintegrated` for `.agents/skills/<dep>/SKILL.md` before this fix).

Closes #1923
Closes #1924