### PR TITLE
chore(compile): remove legacy .chatmode.md primitive type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed legacy `.chatmode.md` primitive format and `chatmodes/` subdirectory
+  support. Use `.agent.md` files in `.apm/agents/` instead. All discovery
+  patterns, integrator file-scan paths, watcher watch-paths, and extension maps
+  have been updated to the `agents/` + `.agent.md` convention. (#840)
+
 ### Fixed
 
 - Fixed spurious version-range diffs for cached transitive registry

--- a/docs/src/content/docs/concepts/package-anatomy.md
+++ b/docs/src/content/docs/concepts/package-anatomy.md
@@ -48,7 +48,6 @@ my-pkg/
 |   +-- skills/                   # Multi-file capabilities (SKILL.md + assets).
 |   +-- prompts/                  # Reusable prompt templates.
 |   +-- agents/                   # Named agents (model + system prompt + tools).
-|   +-- chatmodes/                # Chat-mode configurations.
 |   +-- context/                  # Shared context fragments.
 |   +-- hooks/                    # Lifecycle hooks (pre/post events).
 +-- .github/                      # Compiled output for Copilot. Generated.
@@ -247,8 +246,6 @@ Per-dependency fields:
   Invocable via `apm run <script>` or directly by the harness CLI.
 - **`agents/`** -- Named agent definitions: model choice, system prompt,
   tool whitelist. One `.agent.md` per agent.
-- **`chatmodes/`** -- Chat-mode configurations for harnesses that expose
-  modes (e.g. Copilot Chat).
 - **`context/`** -- Shared context fragments that other primitives can
   reference. Not loaded standalone.
 - **`hooks/`** -- Host-harness lifecycle hooks, such as tool-use or stop events.

--- a/docs/src/content/docs/concepts/primitives-and-targets.md
+++ b/docs/src/content/docs/concepts/primitives-and-targets.md
@@ -33,7 +33,7 @@ Executable, parameterized AI workflows. Equivalent to a callable program for an 
 
 Specialized AI personalities with tool boundaries and expertise scope.
 
-- Source: `.apm/agents/*.agent.md` (legacy: `.chatmode.md`)
+- Source: `.apm/agents/*.agent.md`
 - Deep dive: [Agent workflows](/apm/producer/author-primitives/instructions-and-agents/)
 
 ### Skills

--- a/docs/src/content/docs/enterprise/registry-proxy.md
+++ b/docs/src/content/docs/enterprise/registry-proxy.md
@@ -143,7 +143,7 @@ dependencies:
     # virtual sub-path -- no marker-segment heuristic involved.
     - group/subgroup/project/skills/<name>
     # Files ending in ``.prompt.md`` / ``.instructions.md`` /
-    # ``.chatmode.md`` / ``.agent.md`` are structurally a virtual file
+    # ``.agent.md`` are structurally a virtual file
     # at parse time; the probe still confirms which directory the file
     # sits under is part of the repo path.
     - group/subgroup/project/<name>.prompt.md

--- a/docs/src/content/docs/integrations/copilot-cowork.md
+++ b/docs/src/content/docs/integrations/copilot-cowork.md
@@ -112,7 +112,7 @@ If you try project scope, APM stops with a clean error that tells you to rerun w
 
 ## Skills-only behaviour
 
-Cowork deploys only `SKILL.md` content. Instructions, agents, prompts, hooks, commands, chatmodes, and MCP material are skipped for this target.
+Cowork deploys only `SKILL.md` content. Instructions, agents, prompts, hooks, commands, and MCP material are skipped for this target.
 
 If any selected package contains non-skill primitives, APM emits one `[!]` summary warning for the whole install run. The install still succeeds, and the skill content still deploys.
 

--- a/docs/src/content/docs/integrations/hermes.md
+++ b/docs/src/content/docs/integrations/hermes.md
@@ -86,7 +86,7 @@ HTTP servers are written with `url` and optional `headers` instead of `command`/
 
 - Skills deploy as `SKILL.md` content, unchanged from the agentskills.io format APM already produces.
 - Instructions compile to `AGENTS.md`, which Hermes reads as a first-class context file.
-- Agents, prompts, hooks, commands, and chatmodes are not part of the Hermes surface and are skipped for this target.
+- Agents, prompts, hooks, and commands are not part of the Hermes surface and are skipped for this target.
 
 ## Troubleshooting
 

--- a/docs/src/content/docs/integrations/openclaw.md
+++ b/docs/src/content/docs/integrations/openclaw.md
@@ -54,7 +54,7 @@ apm install --target openclaw,claude
 ## Supported primitives
 
 - **Skills** deploy as `SKILL.md` content, unchanged from the agentskills.io format APM already produces.
-- Agents, instructions, prompts, hooks, commands, chatmodes, and MCP servers are not part of the OpenClaw surface and are skipped for this target.
+- Agents, instructions, prompts, hooks, commands, and MCP servers are not part of the OpenClaw surface and are skipped for this target.
 
 ## Troubleshooting
 

--- a/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
+++ b/docs/src/content/docs/producer/author-primitives/instructions-and-agents.md
@@ -128,9 +128,7 @@ my-package/
       migration-assistant.agent.md
 ```
 
-File names end in `.agent.md`. APM also accepts `.chatmode.md` and the
-legacy `.apm/chatmodes/` directory for backward compatibility; new
-work should use `.agent.md` under `.apm/agents/`.
+File names end in `.agent.md` and live under `.apm/agents/`.
 
 ### Frontmatter
 

--- a/docs/src/content/docs/producer/compile.md
+++ b/docs/src/content/docs/producer/compile.md
@@ -43,7 +43,7 @@ into the native rules surface each target expects:
   `applyTo:` glob: `.github/instructions/`, `.claude/rules/`,
   `.cursor/rules/*.mdc`, `.windsurf/rules/`, `.kiro/steering/`.
 
-Other primitive types -- prompts, skills, agents, chatmodes, hooks,
+Other primitive types -- prompts, skills, agents, hooks,
 commands -- are NOT compiled by this command. They are deployed by
 `apm install` directly into the harness directories that consume them
 (`.github/prompts/`, `.agents/skills/`, `.claude/commands/`, etc.).
@@ -287,7 +287,7 @@ be written without modifying files.
 ## Pitfalls
 
 - **Confusing compile's scope.** Compile only handles **instructions**
-  (and optionally a single chatmode to prepend). If you edit a prompt,
+  (and optionally a single agent to prepend via `--chatmode`). If you edit a prompt,
   skill, agent, hook, or command, `apm compile` will not redeploy it
   -- run `apm install` for that.
 - **Forgetting `--target` on a clean workspace.** With no harness

--- a/docs/src/content/docs/producer/pack-a-bundle.md
+++ b/docs/src/content/docs/producer/pack-a-bundle.md
@@ -145,7 +145,7 @@ primitive type:
 | instruction | `.apm/instructions/*.instructions.md` | No |
 | command (prompt) | `.apm/prompts/*.prompt.md` | No |
 | hook | `.apm/hooks/*.json` | Yes: `hooks/*.json` |
-| agent | `.apm/agents/**/*.agent.md`, `.apm/chatmodes/*.chatmode.md` | Yes: `*.agent.md` and `*.chatmode.md` at package root |
+| agent | `.apm/agents/**/*.agent.md` | Yes: `*.agent.md` at package root |
 | skill | `.apm/skills/<name>/SKILL.md` | Yes: `skills/<name>/SKILL.md` (SKILL_BUNDLE or MARKETPLACE_PLUGIN) |
 
 Source: `src/apm_cli/integration/instruction_integrator.py`,

--- a/docs/src/content/docs/reference/cli/compile.md
+++ b/docs/src/content/docs/reference/cli/compile.md
@@ -229,7 +229,7 @@ ls /tmp/agents-out   # AGENTS.md / per-target files; the source tree stays clean
 re-runs compilation automatically.
 
 - Watched directories (when present): `.apm/`, `.github/instructions/`,
-  `.github/agents/`, `.github/chatmodes/`.
+  `.github/agents/`.
 - Triggers on changes to `.md` files and `apm.yml`.
 - Editing `apm.yml`'s `target:` / `targets:` mid-session takes effect on
   the next file event; no need to restart the watcher. The CLI `--target`

--- a/docs/src/content/docs/reference/examples.md
+++ b/docs/src/content/docs/reference/examples.md
@@ -218,7 +218,7 @@ apm run compliance-docs --param regulations="GDPR,CCPA"
 **Scenario**: Engineering team needs consistent code quality standards
 
 ```yaml
-# .apm/chatmodes/senior-reviewer.chatmode.md
+# .apm/agents/senior-reviewer.agent.md
 ---
 name: "Senior Code Reviewer"
 model: "gpt-4"

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -495,7 +495,7 @@ A dependency MAY target a subdirectory or a file within a repository rather than
 
 | Kind | Detection rule | Example |
 |---|---|---|
-| **File** | `virtual_path` ends in `.prompt.md`, `.instructions.md`, `.agent.md`, or `.chatmode.md` | `owner/repo/prompts/review.prompt.md` |
+| **File** | `virtual_path` ends in `.prompt.md`, `.instructions.md`, or `.agent.md` | `owner/repo/prompts/review.prompt.md` |
 | **Subdirectory** | `virtual_path` does not match any file extension above | `owner/repo/skills/security` |
 
 Classification is by extension only, never by path segment. A path like `owner/repo/collections/security` (no extension) is a **Subdirectory**: the on-disk shape (APM package with `apm.yml`, skill bundle, or plugin) is resolved at fetch time by probing for `apm.yml` first.

--- a/docs/src/content/docs/reference/primitive-types.md
+++ b/docs/src/content/docs/reference/primitive-types.md
@@ -27,7 +27,7 @@ from apm_cli.primitives import Chatmode
 # Local primitive
 chatmode = Chatmode(
     name="assistant", 
-    file_path=Path("local.chatmode.md"),
+    file_path=Path("local.agent.md"),
     description="Local assistant",
     content="...",
     source="local"  # New field
@@ -36,7 +36,7 @@ chatmode = Chatmode(
 # Dependency primitive  
 dep_chatmode = Chatmode(
     name="reviewer",
-    file_path=Path("dep.chatmode.md"), 
+    file_path=Path("dep.agent.md"), 
     description="Dependency assistant",
     content="...",
     source="dependency:company-standards"  # New field
@@ -143,13 +143,13 @@ The enhanced discovery system expects this structure:
 project/
 ├── apm.yml                           # Dependency declarations
 ├── .apm/                             # Local primitives (highest priority)
-│   ├── chatmodes/
+│   ├── agents/
 │   ├── instructions/
 │   └── contexts/
 └── apm_modules/                      # Dependency primitives
     ├── standards/                    # From company/standards
     │   └── .apm/
-    │       ├── chatmodes/
+    │       ├── agents/
     │       └── instructions/
     ├── team/
     │   └── workflows/                # From team/workflows

--- a/docs/src/content/docs/specs/openapm-v0.1.md
+++ b/docs/src/content/docs/specs/openapm-v0.1.md
@@ -559,7 +559,7 @@ rather than the whole repository.
 **[req-mf-008]** A conforming **consumer** implementation MUST
 classify virtual packages by **file extension only** and MUST NOT
 infer kind from path segments. A `virtual_path` ending in
-`.prompt.md`, `.instructions.md`, `.agent.md`, or `.chatmode.md` is a
+`.prompt.md`, `.instructions.md`, or `.agent.md` is a
 file; any other path is a subdirectory. On-disk shape of a
 subdirectory virtual package is resolved by probing for `apm.yml`
 first.

--- a/docs/src/content/docs/troubleshooting/compile-zero-output-warning.md
+++ b/docs/src/content/docs/troubleshooting/compile-zero-output-warning.md
@@ -42,7 +42,7 @@ To check the local tree directly:
 
 ```bash
 find .apm -name '*.instructions.md' -o -name '*.prompt.md' -o \
-         -name '*.agent.md' -o -name '*.chatmode.md' -o -name 'SKILL.md'
+         -name '*.agent.md' -o -name 'SKILL.md'
 ```
 
 ### 3. Confirm the includes filter is not excluding everything

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -279,7 +279,7 @@ Virtual packages reference a subset of a repository.
 
 | Type | Detection rule | Example |
 |------|---------------|---------|
-| File | Ends in `.prompt.md`, `.instructions.md`, `.agent.md`, `.chatmode.md` | `owner/repo/prompts/review.prompt.md` |
+| File | Ends in `.prompt.md`, `.instructions.md`, or `.agent.md` | `owner/repo/prompts/review.prompt.md` |
 | Subdirectory | Does not match a file extension above | `owner/repo/skills/security` |
 
 Classification is by extension only. A path like `owner/repo/collections/security` (no extension) is a Subdirectory; the actual shape -- APM package (incl. dep-only `apm.yml` with no `.apm/`), skill bundle, or plugin -- is resolved at fetch time by probing for `apm.yml`.

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -45,8 +45,8 @@ my-package/
     instructions/
       security.instructions.md
       python.instructions.md
-    chatmodes/
-      architect.chatmode.md
+    agents/
+      architect.agent.md
     contexts/
       codebase.context.md
     prompts/
@@ -76,7 +76,7 @@ Per-primitive scan paths for `apm install`:
 | instruction | `.apm/instructions/` | No |
 | command (prompt) | `.apm/prompts/` | No |
 | hook | `.apm/hooks/` | Yes: `hooks/` |
-| agent | `.apm/agents/`, `.apm/chatmodes/` | Yes: `*.agent.md` and `*.chatmode.md` at root |
+| agent | `.apm/agents/` | Yes: `*.agent.md` at root |
 | skill | `.apm/skills/<name>/` | Yes: `skills/<name>/` (SKILL_BUNDLE or MARKETPLACE_PLUGIN) |
 
 **Recommendation for marketplace publishers:** use `.apm/<type>/` for
@@ -229,9 +229,9 @@ and are NOT separators -- only top-level commas split the list. On Copilot
 the value is preserved verbatim; on Claude/Cursor/Windsurf/Kiro comma-lists are
 expanded to a YAML array under `paths:` / `globs:` / `fileMatchPattern:`.
 
-### 2. Chatmode (`*.chatmode.md`)
+### 2. Agent (`*.agent.md`)
 
-Chat persona configuration.
+Chat persona configuration. Place in `.apm/agents/`.
 
 ```yaml
 ---

--- a/src/apm_cli/commands/compile/cli.py
+++ b/src/apm_cli/commands/compile/cli.py
@@ -448,7 +448,7 @@ def _validate_project(logger: CommandLogger, dry_run: bool, source_root: Path) -
     # Check if .apm directory has actual content
     apm_dir = source_root / APM_DIR
     local_apm_has_content = apm_dir.exists() and (
-        any(apm_dir.rglob("*.instructions.md")) or any(apm_dir.rglob("*.chatmode.md"))
+        any(apm_dir.rglob("*.instructions.md")) or any(apm_dir.rglob("*.agent.md"))
     )
 
     # If no primitive sources exist, check deeper to provide better feedback
@@ -457,20 +457,20 @@ def _validate_project(logger: CommandLogger, dry_run: bool, source_root: Path) -
         has_empty_apm = (
             apm_dir.exists()
             and not any(apm_dir.rglob("*.instructions.md"))
-            and not any(apm_dir.rglob("*.chatmode.md"))
+            and not any(apm_dir.rglob("*.agent.md"))
         )
 
         if has_empty_apm:
             logger.error("No instruction files found in .apm/ directory")
             logger.progress(" To add instructions, create files like:")
             logger.progress("   .apm/instructions/coding-standards.instructions.md")
-            logger.progress("   .apm/chatmodes/backend-engineer.chatmode.md")
+            logger.progress("   .apm/agents/backend-engineer.agent.md")
         else:
             logger.error("No APM content found to compile")
             logger.progress(" To get started:")
             logger.progress("   1. Install APM dependencies: apm install <owner>/<repo>")
             logger.progress("   2. Or create local instructions: mkdir -p .apm/instructions")
-            logger.progress("   3. Then create .instructions.md or .chatmode.md files")
+            logger.progress("   3. Then create .instructions.md or .agent.md files")
 
         if not dry_run:  # Don't exit on dry-run to allow testing
             sys.exit(1)

--- a/src/apm_cli/commands/compile/cli.py
+++ b/src/apm_cli/commands/compile/cli.py
@@ -69,8 +69,8 @@ def _display_single_file_summary(stats, c_status, c_hash, output_path, dry_run):
             "[+] All validated",
         )
         table.add_row(
-            "Chatmodes",
-            str(stats.get("chatmodes", 0)),
+            "Agents",
+            str(stats.get("agents", 0)),
             "[+] All validated",
         )
 

--- a/src/apm_cli/commands/compile/watcher.py
+++ b/src/apm_cli/commands/compile/watcher.py
@@ -234,10 +234,6 @@ def _watch_mode(
             observer.schedule(event_handler, ".github/agents", recursive=True)
             watch_paths.append(".github/agents/")
 
-        if Path(".github/chatmodes").exists():
-            observer.schedule(event_handler, ".github/chatmodes", recursive=True)
-            watch_paths.append(".github/chatmodes/")
-
         if Path(APM_YML_FILENAME).exists():
             observer.schedule(event_handler, ".", recursive=False)
             watch_paths.append(APM_YML_FILENAME)

--- a/src/apm_cli/commands/deps/_utils.py
+++ b/src/apm_cli/commands/deps/_utils.py
@@ -105,7 +105,7 @@ def _count_package_files(package_path: Path) -> tuple[int, int]:
         return 0, workflow_count
 
     context_count = 0
-    context_dirs = ["instructions", "chatmodes", "context"]
+    context_dirs = ["instructions", "agents", "context"]
 
     for context_dir in context_dirs:
         context_path = apm_dir / context_dir
@@ -134,12 +134,12 @@ def _get_detailed_context_counts(package_path: Path) -> dict[str, int]:
     """Get detailed context file counts by type."""
     apm_dir = package_path / APM_DIR
     if not apm_dir.exists():
-        return {"instructions": 0, "chatmodes": 0, "contexts": 0}
+        return {"instructions": 0, "agents": 0, "contexts": 0}
 
     counts = {}
     context_directories = {
         "instructions": "instructions",
-        "chatmodes": "chatmodes",
+        "agents": "agents",
         "contexts": "context",  # Note: directory is 'context', not 'contexts'
     }
 
@@ -235,7 +235,7 @@ def _get_detailed_package_info(package_path: Path) -> dict[str, Any]:
             "author": "Unknown",
             "source": "unknown",
             "install_path": str(package_path.resolve()),
-            "context_files": {"instructions": 0, "chatmodes": 0, "contexts": 0},
+            "context_files": {"instructions": 0, "agents": 0, "contexts": 0},
             "workflows": 0,
             "hooks": 0,
         }

--- a/src/apm_cli/deps/github_downloader.py
+++ b/src/apm_cli/deps/github_downloader.py
@@ -944,7 +944,6 @@ class GitHubPackageDownloader:
         subdirs = {
             ".prompt.md": "prompts",
             ".instructions.md": "instructions",
-            ".chatmode.md": "chatmodes",
             ".agent.md": "agents",
         }
 

--- a/src/apm_cli/deps/package_validator.py
+++ b/src/apm_cli/deps/package_validator.py
@@ -91,7 +91,7 @@ class PackageValidator:
         # HYBRID and CLAUDE_SKILL layouts may ship without .apm/, so the
         # "no primitives" warning would be misleading for those shapes.
         if apm_dir.exists() and apm_dir.is_dir():
-            primitive_types = ["instructions", "chatmodes", "contexts", "prompts"]
+            primitive_types = ["instructions", "agents", "contexts", "prompts"]
             has_primitives = False
 
             for primitive_type in primitive_types:
@@ -152,7 +152,7 @@ class PackageValidator:
             issues.append("Missing .apm directory")
             return issues
 
-        primitive_types = ["instructions", "chatmodes", "contexts", "prompts"]
+        primitive_types = ["instructions", "agents", "contexts", "prompts"]
         found_primitives = False
 
         for primitive_type in primitive_types:
@@ -182,7 +182,7 @@ class PackageValidator:
 
         Args:
             filename: The filename to validate
-            primitive_type: Type of primitive (instructions, chatmodes, etc.)
+            primitive_type: Type of primitive (instructions, agents, etc.)
 
         Returns:
             bool: True if filename is valid
@@ -199,7 +199,7 @@ class PackageValidator:
         name_without_ext = filename[:-3]  # Remove .md
         suffix_map = {
             "instructions": ".instructions",
-            "chatmodes": ".chatmode",
+            "agents": ".agent",
             "contexts": ".context",
             "prompts": ".prompt",
         }
@@ -233,7 +233,7 @@ class PackageValidator:
         apm_dir = package_path / ".apm"
         if apm_dir.exists():
             primitive_count = 0
-            for primitive_type in ["instructions", "chatmodes", "contexts", "prompts"]:
+            for primitive_type in ["instructions", "agents", "contexts", "prompts"]:
                 primitive_dir = apm_dir / primitive_type
                 if primitive_dir.exists():
                     primitive_count += len(list(primitive_dir.glob("*.md")))

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -31,11 +31,11 @@ class AgentIntegrator(BaseIntegrator):
     _LF_NORMALIZED_DEPLOY = True
 
     def find_agent_files(self, package_path: Path) -> list[Path]:
-        """Find all .agent.md files in a package.
+        """Find all agent files in a package.
 
         Searches in:
-        - Package root directory (.agent.md)
-        - .apm/agents/ subdirectory (recursive)
+        - Package root directory (*.agent.md files)
+        - .apm/agents/ subdirectory (recursive): *.agent.md and plain *.md files
 
         Args:
             package_path: Path to the package directory

--- a/src/apm_cli/integration/agent_integrator.py
+++ b/src/apm_cli/integration/agent_integrator.py
@@ -31,12 +31,11 @@ class AgentIntegrator(BaseIntegrator):
     _LF_NORMALIZED_DEPLOY = True
 
     def find_agent_files(self, package_path: Path) -> list[Path]:
-        """Find all .agent.md and .chatmode.md files in a package.
+        """Find all .agent.md files in a package.
 
         Searches in:
-        - Package root directory (.agent.md and .chatmode.md)
-        - .apm/agents/ subdirectory (new standard, recursive)
-        - .apm/chatmodes/ subdirectory (legacy)
+        - Package root directory (.agent.md)
+        - .apm/agents/ subdirectory (recursive)
 
         Args:
             package_path: Path to the package directory
@@ -47,7 +46,6 @@ class AgentIntegrator(BaseIntegrator):
         files: list[Path] = []
         # Flat search in package root
         files += self.find_files_by_glob(package_path, "*.agent.md")
-        files += self.find_files_by_glob(package_path, "*.chatmode.md")
         # Recursive search in .apm/agents/ (use ** glob for subdirectories)
         apm_agents = package_path / ".apm" / "agents"
         if apm_agents.exists():
@@ -56,10 +54,6 @@ class AgentIntegrator(BaseIntegrator):
             for f in self.find_files_by_glob(apm_agents, "**/*.md"):
                 if not f.name.endswith(".agent.md") and f not in files:
                     files.append(f)
-        # Flat search in .apm/chatmodes/ (legacy)
-        apm_chatmodes = package_path / ".apm" / "chatmodes"
-        if apm_chatmodes.exists():
-            files += self.find_files_by_glob(apm_chatmodes, "*.chatmode.md")
         return files
 
     # NOTE: find_skill_file(), integrate_skill(), and _generate_skill_agent_content()
@@ -83,12 +77,7 @@ class AgentIntegrator(BaseIntegrator):
         """Generate target filename using the extension from *target*'s agents mapping."""
         mapping = target.primitives.get("agents")
         ext = mapping.extension if mapping else ".agent.md"
-        if source_file.name.endswith(".agent.md"):
-            stem = source_file.name[:-9]
-        elif source_file.name.endswith(".chatmode.md"):
-            stem = source_file.name[:-12]
-        else:
-            stem = source_file.stem
+        stem = source_file.name[:-9] if source_file.name.endswith(".agent.md") else source_file.stem
         return f"{stem}{ext}"
 
     def integrate_agents_for_target(

--- a/src/apm_cli/models/apm_package.py
+++ b/src/apm_cli/models/apm_package.py
@@ -612,7 +612,7 @@ class PackageInfo:
             # Check for any primitive files in .apm/ subdirectories
             for primitive_type in [
                 "instructions",
-                "chatmodes",
+                "agents",
                 "contexts",
                 "prompts",
                 "hooks",

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -158,7 +158,6 @@ class DependencyReference:
     VIRTUAL_FILE_EXTENSIONS = (
         ".prompt.md",
         ".instructions.md",
-        ".chatmode.md",
         ".agent.md",
     )
 
@@ -183,7 +182,6 @@ class DependencyReference:
             "agents",
             "prompts",
             "instructions",
-            "chatmodes",
             "collections",
             "contexts",
             "memory",
@@ -205,7 +203,7 @@ class DependencyReference:
         """Return the type of virtual package, or None if not virtual.
 
         Classification is by extension only -- never by path segment.
-        ``.prompt.md``/``.instructions.md``/``.chatmode.md``/``.agent.md``
+        ``.prompt.md``/``.instructions.md``/``.agent.md``
         is FILE; everything else is SUBDIRECTORY (resolved at fetch time
         by probing for ``apm.yml``, ``SKILL.md``, ``plugin.json``, etc).
         Paths like ``collections/foo`` (no extension) are SUBDIRECTORY.
@@ -1125,7 +1123,7 @@ class DependencyReference:
 
         The only parse-time inference kept is **structural**: a path whose
         last segment ends in a virtual file extension
-        (``.prompt.md``/``.instructions.md``/``.chatmode.md``/``.agent.md``)
+        (``.prompt.md``/``.instructions.md``/``.agent.md``)
         is by shape a virtual file dep -- the file is the last segment and
         the repo is everything before it.  This is not a directory-marker
         heuristic; the file extension is the type.  The shallower boundary

--- a/src/apm_cli/primitives/discovery.py
+++ b/src/apm_cli/primitives/discovery.py
@@ -19,14 +19,10 @@ from ..models.apm_package import APMPackage  # noqa: E402
 # Common primitive patterns for local discovery (with recursive search)
 LOCAL_PRIMITIVE_PATTERNS: dict[str, list[str]] = {
     "chatmode": [
-        # New standard (.agent.md)
+        # Standard (.agent.md)
         "**/.apm/agents/*.agent.md",
         "**/.github/agents/*.agent.md",
         "**/*.agent.md",  # Generic .agent.md files
-        # Legacy support (.chatmode.md)
-        "**/.apm/chatmodes/*.chatmode.md",
-        "**/.github/chatmodes/*.chatmode.md",
-        "**/*.chatmode.md",  # Generic .chatmode.md files
     ],
     "instruction": [
         "**/.apm/instructions/*.instructions.md",
@@ -61,8 +57,7 @@ PRIMITIVE_SUFFIXES: frozenset[str] = frozenset(
 # Dependency primitive patterns (for .apm directory within dependencies)
 DEPENDENCY_PRIMITIVE_PATTERNS: dict[str, list[str]] = {
     "chatmode": [
-        "agents/*.agent.md",  # New standard
-        "chatmodes/*.chatmode.md",  # Legacy
+        "agents/*.agent.md",
     ],
     "instruction": ["instructions/*.instructions.md"],
     "context": ["context/*.context.md", "memory/*.memory.md"],
@@ -73,7 +68,6 @@ DEPENDENCY_PRIMITIVE_PATTERNS: dict[str, list[str]] = {
 DEPENDENCY_GITHUB_PRIMITIVE_PATTERNS: dict[str, list[str]] = {
     "chatmode": [
         "agents/*.agent.md",
-        "chatmodes/*.chatmode.md",
     ],
     "instruction": ["instructions/*.instructions.md"],
     "context": [
@@ -120,7 +114,7 @@ def discover_primitives(
 ) -> PrimitiveCollection:
     """Find all APM primitive files in the project.
 
-    Searches for .chatmode.md, .instructions.md, .context.md, .memory.md files
+    Searches for .agent.md, .instructions.md, .context.md, .memory.md files
     in both .apm/ and .github/ directory structures, plus SKILL.md at root.
 
     Results are memoized per ``(realpath(base_dir), exclude_patterns)`` for

--- a/src/apm_cli/primitives/parser.py
+++ b/src/apm_cli/primitives/parser.py
@@ -75,7 +75,7 @@ def parse_primitive_file(file_path: str | Path, source: str = None) -> Primitive
         content = post.content
 
         # Determine primitive type based on file extension
-        if file_path.name.endswith(".chatmode.md") or file_path.name.endswith(".agent.md"):
+        if file_path.name.endswith(".agent.md"):
             return _parse_chatmode(name, file_path, metadata, content, source)
         elif file_path.name.endswith(".instructions.md"):
             return _parse_instruction(name, file_path, metadata, content, source)
@@ -242,19 +242,16 @@ def _extract_primitive_name(file_path: Path) -> str:
             else:
                 base_idx = path_parts.index(".github")
 
-            # For structured directories like .apm/chatmodes/name.chatmode.md
+            # For structured directories like .apm/agents/name.agent.md
             if base_idx + 2 < len(path_parts) and path_parts[base_idx + 1] in [
-                "chatmodes",
                 "instructions",
                 "context",
                 "memory",
                 "agents",
             ]:
                 basename = file_path.name
-                # Remove the double extension (.chatmode.md, .instructions.md, .agent.md, etc.)
-                if basename.endswith(".chatmode.md"):
-                    return basename.replace(".chatmode.md", "")
-                elif basename.endswith(".instructions.md"):
+                # Remove the double extension (.instructions.md, .agent.md, etc.)
+                if basename.endswith(".instructions.md"):
                     return basename.replace(".instructions.md", "")
                 elif basename.endswith(".context.md"):
                     return basename.replace(".context.md", "")
@@ -269,14 +266,14 @@ def _extract_primitive_name(file_path: Path) -> str:
 
     # Fallback: extract from filename
     basename = file_path.name
-    if basename.endswith(".chatmode.md"):
-        return basename.replace(".chatmode.md", "")
-    elif basename.endswith(".instructions.md"):
+    if basename.endswith(".instructions.md"):
         return basename.replace(".instructions.md", "")
     elif basename.endswith(".context.md"):
         return basename.replace(".context.md", "")
     elif basename.endswith(".memory.md"):
         return basename.replace(".memory.md", "")
+    elif basename.endswith(".agent.md"):
+        return basename.replace(".agent.md", "")
     elif basename.endswith(".md"):
         return basename.replace(".md", "")
 

--- a/tests/integration/test_deps_models_phase3c.py
+++ b/tests/integration/test_deps_models_phase3c.py
@@ -217,9 +217,9 @@ class TestParseVirtualPackages:
         assert ref.is_virtual_file() is True
 
     def test_virtual_file_chatmode(self) -> None:
-        ref = _DR().parse("owner/repo/chatmodes/review.chatmode.md")
+        ref = _DR().parse("owner/repo/agents/review.agent.md")
         assert ref.is_virtual is True
-        assert ref.virtual_path == "chatmodes/review.chatmode.md"
+        assert ref.virtual_path == "agents/review.agent.md"
 
     def test_virtual_file_agent(self) -> None:
         ref = _DR().parse("owner/repo/agents/my-agent.agent.md")
@@ -811,19 +811,19 @@ class TestDownloadVirtualFilePackage:
             with pytest.raises(RuntimeError, match="Failed to download virtual package"):
                 dl.download_virtual_file_package(dep, tmp_path / "out")
 
-    def test_chatmode_extension_placed_in_chatmodes_dir(self, tmp_path: Path) -> None:
+    def test_chatmode_extension_placed_in_agents_dir(self, tmp_path: Path) -> None:
         dl = _make_downloader()
         dep = _make_dep_ref(
             repo_url="owner/repo",
             is_virtual=True,
-            virtual_path="chatmodes/review.chatmode.md",
+            virtual_path="agents/review.agent.md",
         )
         with (
             patch.object(dl, "_resolve_commit_sha_for_ref", return_value=None),
             patch.object(dl, "download_raw_file", return_value=b"# Chatmode"),
         ):
             dl.download_virtual_file_package(dep, tmp_path / "out")
-        assert (tmp_path / "out" / ".apm" / "chatmodes" / "review.chatmode.md").exists()
+        assert (tmp_path / "out" / ".apm" / "agents" / "review.agent.md").exists()
 
 
 # ============================================================================

--- a/tests/integration/test_deps_models_validation.py
+++ b/tests/integration/test_deps_models_validation.py
@@ -217,9 +217,9 @@ class TestParseVirtualPackages:
         assert ref.is_virtual_file() is True
 
     def test_virtual_file_chatmode(self) -> None:
-        ref = _DR().parse("owner/repo/chatmodes/review.chatmode.md")
+        ref = _DR().parse("owner/repo/agents/review.agent.md")
         assert ref.is_virtual is True
-        assert ref.virtual_path == "chatmodes/review.chatmode.md"
+        assert ref.virtual_path == "agents/review.agent.md"
 
     def test_virtual_file_agent(self) -> None:
         ref = _DR().parse("owner/repo/agents/my-agent.agent.md")
@@ -811,19 +811,19 @@ class TestDownloadVirtualFilePackage:
             with pytest.raises(RuntimeError, match="Failed to download virtual package"):
                 dl.download_virtual_file_package(dep, tmp_path / "out")
 
-    def test_chatmode_extension_placed_in_chatmodes_dir(self, tmp_path: Path) -> None:
+    def test_chatmode_extension_placed_in_agents_dir(self, tmp_path: Path) -> None:
         dl = _make_downloader()
         dep = _make_dep_ref(
             repo_url="owner/repo",
             is_virtual=True,
-            virtual_path="chatmodes/review.chatmode.md",
+            virtual_path="agents/review.agent.md",
         )
         with (
             patch.object(dl, "_resolve_commit_sha_for_ref", return_value=None),
             patch.object(dl, "download_raw_file", return_value=b"# Chatmode"),
         ):
             dl.download_virtual_file_package(dep, tmp_path / "out")
-        assert (tmp_path / "out" / ".apm" / "chatmodes" / "review.chatmode.md").exists()
+        assert (tmp_path / "out" / ".apm" / "agents" / "review.agent.md").exists()
 
 
 # ============================================================================

--- a/tests/integration/test_integrators_validation_phase3b.py
+++ b/tests/integration/test_integrators_validation_phase3b.py
@@ -439,10 +439,10 @@ class TestAgentIntegratorFindFiles:
         assert "planner.agent.md" in names
 
     def test_finds_chatmode_md_in_root(self, tmp_path: Path) -> None:
-        (tmp_path / "default.chatmode.md").write_text("# Default")
+        (tmp_path / "default.agent.md").write_text("# Default")
         integrator = AgentIntegrator()
         files = integrator.find_agent_files(tmp_path)
-        assert any(f.name == "default.chatmode.md" for f in files)
+        assert any(f.name == "default.agent.md" for f in files)
 
     def test_finds_agent_md_in_apm_agents_subdir(self, tmp_path: Path) -> None:
         apm_agents = tmp_path / ".apm" / "agents"
@@ -462,12 +462,12 @@ class TestAgentIntegratorFindFiles:
         assert any(f.name == "helper.md" for f in files)
 
     def test_finds_chatmode_in_apm_chatmodes_subdir(self, tmp_path: Path) -> None:
-        apm_chatmodes = tmp_path / ".apm" / "chatmodes"
+        apm_chatmodes = tmp_path / ".apm" / "agents"
         apm_chatmodes.mkdir(parents=True)
-        (apm_chatmodes / "review.chatmode.md").write_text("# Review")
+        (apm_chatmodes / "review.agent.md").write_text("# Review")
         integrator = AgentIntegrator()
         files = integrator.find_agent_files(tmp_path)
-        assert any(f.name == "review.chatmode.md" for f in files)
+        assert any(f.name == "review.agent.md" for f in files)
 
     def test_non_agent_md_not_found(self, tmp_path: Path) -> None:
         """Plain README.md should NOT be discovered."""
@@ -519,7 +519,7 @@ class TestAgentIntegratorTargetFilenames:
         from apm_cli.integration.targets import KNOWN_TARGETS
 
         integrator = AgentIntegrator()
-        source = Path("backend.chatmode.md")
+        source = Path("backend.agent.md")
         filename = integrator.get_target_filename_for_target(
             source, "pkg", KNOWN_TARGETS["copilot"]
         )

--- a/tests/integration/test_integrators_validation_rules.py
+++ b/tests/integration/test_integrators_validation_rules.py
@@ -439,10 +439,10 @@ class TestAgentIntegratorFindFiles:
         assert "planner.agent.md" in names
 
     def test_finds_chatmode_md_in_root(self, tmp_path: Path) -> None:
-        (tmp_path / "default.chatmode.md").write_text("# Default")
+        (tmp_path / "default.agent.md").write_text("# Default")
         integrator = AgentIntegrator()
         files = integrator.find_agent_files(tmp_path)
-        assert any(f.name == "default.chatmode.md" for f in files)
+        assert any(f.name == "default.agent.md" for f in files)
 
     def test_finds_agent_md_in_apm_agents_subdir(self, tmp_path: Path) -> None:
         apm_agents = tmp_path / ".apm" / "agents"
@@ -462,12 +462,12 @@ class TestAgentIntegratorFindFiles:
         assert any(f.name == "helper.md" for f in files)
 
     def test_finds_chatmode_in_apm_chatmodes_subdir(self, tmp_path: Path) -> None:
-        apm_chatmodes = tmp_path / ".apm" / "chatmodes"
+        apm_chatmodes = tmp_path / ".apm" / "agents"
         apm_chatmodes.mkdir(parents=True)
-        (apm_chatmodes / "review.chatmode.md").write_text("# Review")
+        (apm_chatmodes / "review.agent.md").write_text("# Review")
         integrator = AgentIntegrator()
         files = integrator.find_agent_files(tmp_path)
-        assert any(f.name == "review.chatmode.md" for f in files)
+        assert any(f.name == "review.agent.md" for f in files)
 
     def test_non_agent_md_not_found(self, tmp_path: Path) -> None:
         """Plain README.md should NOT be discovered."""
@@ -519,7 +519,7 @@ class TestAgentIntegratorTargetFilenames:
         from apm_cli.integration.targets import KNOWN_TARGETS
 
         integrator = AgentIntegrator()
-        source = Path("backend.chatmode.md")
+        source = Path("backend.agent.md")
         filename = integrator.get_target_filename_for_target(
             source, "pkg", KNOWN_TARGETS["copilot"]
         )

--- a/tests/integration/test_package_validator_phase3w4.py
+++ b/tests/integration/test_package_validator_phase3w4.py
@@ -129,7 +129,7 @@ class TestValidatePackageStructure:
     def test_with_chatmode_primitive(self, tmp_path):
         _make_minimal_pkg(tmp_path)
         apm_dir = _make_apm_dir(tmp_path)
-        _add_primitive(apm_dir, "chatmodes", "my.chatmode.md")
+        _add_primitive(apm_dir, "agents", "my.agent.md")
         v = PackageValidator()
         result = v.validate_package_structure(tmp_path)
         assert result.is_valid
@@ -275,7 +275,7 @@ class TestValidatePrimitiveStructure:
 
     def test_all_primitive_types_detected(self, tmp_path):
         apm_dir = _make_apm_dir(tmp_path)
-        _add_primitive(apm_dir, "chatmodes", "my.chatmode.md")
+        _add_primitive(apm_dir, "agents", "my.agent.md")
         _add_primitive(apm_dir, "contexts", "my.context.md")
         _add_primitive(apm_dir, "prompts", "my.prompt.md")
         v = PackageValidator()
@@ -295,7 +295,7 @@ class TestIsValidPrimitiveName:
 
     def test_valid_chatmode_name(self):
         v = PackageValidator()
-        assert v._is_valid_primitive_name("my.chatmode.md", "chatmodes") is True
+        assert v._is_valid_primitive_name("my.agent.md", "agents") is True
 
     def test_valid_context_name(self):
         v = PackageValidator()
@@ -315,7 +315,7 @@ class TestIsValidPrimitiveName:
 
     def test_name_wrong_suffix(self):
         v = PackageValidator()
-        assert v._is_valid_primitive_name("my.chatmode.md", "instructions") is False
+        assert v._is_valid_primitive_name("my.agent.md", "instructions") is False
 
     def test_name_unknown_primitive_type_passes(self):
         v = PackageValidator()

--- a/tests/integration/test_package_validator_rules.py
+++ b/tests/integration/test_package_validator_rules.py
@@ -129,7 +129,7 @@ class TestValidatePackageStructure:
     def test_with_chatmode_primitive(self, tmp_path):
         _make_minimal_pkg(tmp_path)
         apm_dir = _make_apm_dir(tmp_path)
-        _add_primitive(apm_dir, "chatmodes", "my.chatmode.md")
+        _add_primitive(apm_dir, "agents", "my.agent.md")
         v = PackageValidator()
         result = v.validate_package_structure(tmp_path)
         assert result.is_valid
@@ -275,7 +275,7 @@ class TestValidatePrimitiveStructure:
 
     def test_all_primitive_types_detected(self, tmp_path):
         apm_dir = _make_apm_dir(tmp_path)
-        _add_primitive(apm_dir, "chatmodes", "my.chatmode.md")
+        _add_primitive(apm_dir, "agents", "my.agent.md")
         _add_primitive(apm_dir, "contexts", "my.context.md")
         _add_primitive(apm_dir, "prompts", "my.prompt.md")
         v = PackageValidator()
@@ -295,7 +295,7 @@ class TestIsValidPrimitiveName:
 
     def test_valid_chatmode_name(self):
         v = PackageValidator()
-        assert v._is_valid_primitive_name("my.chatmode.md", "chatmodes") is True
+        assert v._is_valid_primitive_name("my.agent.md", "agents") is True
 
     def test_valid_context_name(self):
         v = PackageValidator()
@@ -315,7 +315,7 @@ class TestIsValidPrimitiveName:
 
     def test_name_wrong_suffix(self):
         v = PackageValidator()
-        assert v._is_valid_primitive_name("my.chatmode.md", "instructions") is False
+        assert v._is_valid_primitive_name("my.agent.md", "instructions") is False
 
     def test_name_unknown_primitive_type_passes(self):
         v = PackageValidator()

--- a/tests/integration/test_runner_reference_phase3.py
+++ b/tests/integration/test_runner_reference_phase3.py
@@ -254,7 +254,7 @@ class TestVirtualPackages:
 
     def test_virtual_file_chatmode_md(self) -> None:
         DR = _dep_ref()
-        ref = DR.parse("owner/repo/modes/debug.chatmode.md")
+        ref = DR.parse("owner/repo/modes/debug.agent.md")
         assert ref.is_virtual is True
         assert ref.is_virtual_file() is True
 

--- a/tests/integration/test_runner_reference_resolution.py
+++ b/tests/integration/test_runner_reference_resolution.py
@@ -254,7 +254,7 @@ class TestVirtualPackages:
 
     def test_virtual_file_chatmode_md(self) -> None:
         DR = _dep_ref()
-        ref = DR.parse("owner/repo/modes/debug.chatmode.md")
+        ref = DR.parse("owner/repo/modes/debug.agent.md")
         assert ref.is_virtual is True
         assert ref.is_virtual_file() is True
 

--- a/tests/integration/test_wave5_e2e_coverage.py
+++ b/tests/integration/test_wave5_e2e_coverage.py
@@ -88,9 +88,9 @@ def _make_project(
         )
 
     if with_chatmodes:
-        chatmode_dir = root / ".apm" / "chatmodes"
+        chatmode_dir = root / ".apm" / "agents"
         chatmode_dir.mkdir(parents=True, exist_ok=True)
-        (chatmode_dir / "backend.chatmode.md").write_text(
+        (chatmode_dir / "backend.agent.md").write_text(
             "---\ndescription: Backend engineer mode\n---\n\n"
             "# Backend Engineer\n\n"
             "You specialise in backend development.\n",
@@ -518,7 +518,7 @@ class TestCompileDisplayHelpers:
             "primitives_found": 5,
             "instructions": 3,
             "contexts": 2,
-            "chatmodes": 0,
+            "agents": 0,
         }
         with mock.patch("apm_cli.commands.compile.cli._get_console", return_value=None):
             _display_single_file_summary(stats, "Matched", "abc123", Path("AGENTS.md"), False)
@@ -532,7 +532,7 @@ class TestCompileDisplayHelpers:
             "primitives_found": 5,
             "instructions": 3,
             "contexts": 2,
-            "chatmodes": 1,
+            "agents": 1,
         }
         mock_console = mock.MagicMock()
         with mock.patch("apm_cli.commands.compile.cli._get_console", return_value=mock_console):

--- a/tests/integration/test_wave6_init_pack_coverage.py
+++ b/tests/integration/test_wave6_init_pack_coverage.py
@@ -704,9 +704,9 @@ dependencies:
             tmp_path,
             "name: chatmode-pkg\nversion: 1.0.0\ndescription: Chatmode package\ndependencies:\n  apm: []\n",
         )
-        chatmode_dir = tmp_path / ".apm" / "chatmodes"
+        chatmode_dir = tmp_path / ".apm" / "agents"
         chatmode_dir.mkdir(parents=True)
-        (chatmode_dir / "backend.chatmode.md").write_text(
+        (chatmode_dir / "backend.agent.md").write_text(
             "---\ndescription: Backend mode\n---\n# Backend\nBackend focus.\n",
             encoding="utf-8",
         )

--- a/tests/test_apm_package_models.py
+++ b/tests/test_apm_package_models.py
@@ -365,7 +365,7 @@ class TestDependencyReference:
 
     def test_parse_virtual_file_all_extensions(self):
         """Test parsing virtual files with all supported extensions."""
-        extensions = [".prompt.md", ".instructions.md", ".chatmode.md", ".agent.md"]
+        extensions = [".prompt.md", ".instructions.md", ".agent.md"]
 
         for ext in extensions:
             dep = DependencyReference.parse(f"user/repo/path/to/file{ext}")
@@ -893,9 +893,9 @@ class TestPackageValidation:
             instructions_dir.mkdir()
             (instructions_dir / "test.instructions.md").write_text("# Test instruction")
 
-            chatmodes_dir = apm_dir / "chatmodes"
+            chatmodes_dir = apm_dir / "agents"
             chatmodes_dir.mkdir()
-            (chatmodes_dir / "test.chatmode.md").write_text("# Test chatmode")
+            (chatmodes_dir / "test.agent.md").write_text("# Test chatmode")
 
             result = validate_apm_package(Path(tmpdir))
             assert result.is_valid

--- a/tests/test_enhanced_discovery.py
+++ b/tests/test_enhanced_discovery.py
@@ -53,18 +53,18 @@ class TestEnhancedPrimitiveDiscovery(unittest.TestCase):
     def _create_directory_structure(self):
         """Create basic test directory structure."""
         # Local .apm directory
-        (self.temp_dir_path / ".apm" / "chatmodes").mkdir(parents=True, exist_ok=True)
+        (self.temp_dir_path / ".apm" / "agents").mkdir(parents=True, exist_ok=True)
         (self.temp_dir_path / ".apm" / "instructions").mkdir(parents=True, exist_ok=True)
         (self.temp_dir_path / ".apm" / "context").mkdir(parents=True, exist_ok=True)
 
         # Dependency directories
-        (self.temp_dir_path / "apm_modules" / "dep1" / ".apm" / "chatmodes").mkdir(
+        (self.temp_dir_path / "apm_modules" / "dep1" / ".apm" / "agents").mkdir(
             parents=True, exist_ok=True
         )
         (self.temp_dir_path / "apm_modules" / "dep1" / ".apm" / "instructions").mkdir(
             parents=True, exist_ok=True
         )
-        (self.temp_dir_path / "apm_modules" / "dep2" / ".apm" / "chatmodes").mkdir(
+        (self.temp_dir_path / "apm_modules" / "dep2" / ".apm" / "agents").mkdir(
             parents=True, exist_ok=True
         )
         (self.temp_dir_path / "apm_modules" / "dep2" / ".apm" / "context").mkdir(
@@ -112,7 +112,7 @@ description: Test {primitive_type} for {name}
         # Test chatmode with source
         chatmode = Chatmode(
             name="test-chatmode",
-            file_path=Path("test.chatmode.md"),
+            file_path=Path("test.agent.md"),
             description="Test chatmode",
             apply_to="**/*.py",
             content="# Test content",
@@ -144,7 +144,7 @@ description: Test {primitive_type} for {name}
         # Add first primitive (local)
         local_chatmode = Chatmode(
             name="assistant",
-            file_path=Path("local.chatmode.md"),
+            file_path=Path("local.agent.md"),
             description="Local assistant",
             apply_to="**/*.py",
             content="Local content",
@@ -155,7 +155,7 @@ description: Test {primitive_type} for {name}
         # Add conflicting primitive (dependency)
         dep_chatmode = Chatmode(
             name="assistant",
-            file_path=Path("dep.chatmode.md"),
+            file_path=Path("dep.agent.md"),
             description="Dependency assistant",
             apply_to="**/*.py",
             content="Dependency content",
@@ -195,7 +195,7 @@ description: Test {primitive_type} for {name}
         """Test scanning only local primitives."""
         # Create local primitives
         self._create_primitive_file(
-            self.temp_dir_path / ".apm" / "chatmodes" / "local-assistant.chatmode.md",
+            self.temp_dir_path / ".apm" / "agents" / "local-assistant.agent.md",
             "chatmode",
             "local-assistant",
         )
@@ -224,7 +224,7 @@ description: Test {primitive_type} for {name}
         self._create_apm_yml(dependencies)
 
         # Create dependency primitives with proper org-namespaced structure
-        (self.temp_dir_path / "apm_modules" / "company" / "dep1" / ".apm" / "chatmodes").mkdir(
+        (self.temp_dir_path / "apm_modules" / "company" / "dep1" / ".apm" / "agents").mkdir(
             parents=True, exist_ok=True
         )
         self._create_primitive_file(
@@ -233,8 +233,8 @@ description: Test {primitive_type} for {name}
             / "company"
             / "dep1"
             / ".apm"
-            / "chatmodes"
-            / "dep-assistant.chatmode.md",
+            / "agents"
+            / "dep-assistant.agent.md",
             "chatmode",
             "dep-assistant",
         )
@@ -277,14 +277,14 @@ description: Test {primitive_type} for {name}
 
         # Create conflicting primitives - same name in local and dependency
         self._create_primitive_file(
-            self.temp_dir_path / ".apm" / "chatmodes" / "assistant.chatmode.md",
+            self.temp_dir_path / ".apm" / "agents" / "assistant.agent.md",
             "chatmode",
             "assistant",
             "Local assistant content",
         )
 
         # Create dependency primitive with proper org-namespaced structure
-        (self.temp_dir_path / "apm_modules" / "company" / "dep1" / ".apm" / "chatmodes").mkdir(
+        (self.temp_dir_path / "apm_modules" / "company" / "dep1" / ".apm" / "agents").mkdir(
             parents=True, exist_ok=True
         )
         self._create_primitive_file(
@@ -293,8 +293,8 @@ description: Test {primitive_type} for {name}
             / "company"
             / "dep1"
             / ".apm"
-            / "chatmodes"
-            / "assistant.chatmode.md",
+            / "agents"
+            / "assistant.agent.md",
             "chatmode",
             "assistant",
             "Dependency assistant content",
@@ -398,11 +398,11 @@ description: Test {primitive_type} for {name}
         """Test scanning a specific directory with source tracking."""
         # Create dependency directory with primitives
         dep_dir = self.temp_dir_path / "test_dep"
-        (dep_dir / ".apm" / "chatmodes").mkdir(parents=True, exist_ok=True)
+        (dep_dir / ".apm" / "agents").mkdir(parents=True, exist_ok=True)
         (dep_dir / ".apm" / "instructions").mkdir(parents=True, exist_ok=True)
 
         self._create_primitive_file(
-            dep_dir / ".apm" / "chatmodes" / "test-chatmode.chatmode.md",
+            dep_dir / ".apm" / "agents" / "test-chatmode.agent.md",
             "chatmode",
             "test-chatmode",
         )
@@ -426,7 +426,7 @@ description: Test {primitive_type} for {name}
         """Test discovery when apm_modules directory doesn't exist."""
         # Create local primitive only
         self._create_primitive_file(
-            self.temp_dir_path / ".apm" / "chatmodes" / "local.chatmode.md", "chatmode", "local"
+            self.temp_dir_path / ".apm" / "agents" / "local.agent.md", "chatmode", "local"
         )
 
         # Don't create apm_modules directory

--- a/tests/test_github_downloader.py
+++ b/tests/test_github_downloader.py
@@ -1761,7 +1761,7 @@ class TestVirtualFilePackageYamlGeneration:
         dep_ref.VIRTUAL_FILE_EXTENSIONS = [
             ".prompt.md",
             ".instructions.md",
-            ".chatmode.md",
+            ".agent.md",
             ".agent.md",
         ]
         return dep_ref

--- a/tests/test_github_downloader.py
+++ b/tests/test_github_downloader.py
@@ -1762,7 +1762,6 @@ class TestVirtualFilePackageYamlGeneration:
             ".prompt.md",
             ".instructions.md",
             ".agent.md",
-            ".agent.md",
         ]
         return dep_ref
 

--- a/tests/unit/commands/compile/test_watch_mode_coverage.py
+++ b/tests/unit/commands/compile/test_watch_mode_coverage.py
@@ -175,7 +175,7 @@ class TestWatchModeFullLoop:
         (tmp_path / ".github").mkdir()
         (tmp_path / ".github" / "instructions").mkdir()
         (tmp_path / ".github" / "agents").mkdir()
-        (tmp_path / ".github" / "chatmodes").mkdir()
+        (tmp_path / ".github" / "agents").mkdir()
         (tmp_path / "apm.yml").write_text("name: test\n", encoding="utf-8")
 
         old_cwd = os.getcwd()

--- a/tests/unit/commands/compile/test_watch_mode_coverage.py
+++ b/tests/unit/commands/compile/test_watch_mode_coverage.py
@@ -175,7 +175,6 @@ class TestWatchModeFullLoop:
         (tmp_path / ".github").mkdir()
         (tmp_path / ".github" / "instructions").mkdir()
         (tmp_path / ".github" / "agents").mkdir()
-        (tmp_path / ".github" / "agents").mkdir()
         (tmp_path / "apm.yml").write_text("name: test\n", encoding="utf-8")
 
         old_cwd = os.getcwd()
@@ -210,7 +209,7 @@ class TestWatchModeFullLoop:
                 )
 
             # All watch paths should have been scheduled
-            assert mock_observer.schedule.call_count >= 5
+            assert mock_observer.schedule.call_count >= 4
         finally:
             os.chdir(old_cwd)
 

--- a/tests/unit/compilation/test_claude_formatter.py
+++ b/tests/unit/compilation/test_claude_formatter.py
@@ -316,7 +316,7 @@ class TestAgentsExcludedFromClaudeMd:
 
         chatmode = Chatmode(
             name="code-reviewer",
-            file_path=temp_project / ".github/chatmodes/code-reviewer.chatmode.md",
+            file_path=temp_project / ".github/agents/code-reviewer.agent.md",
             description="Expert code reviewer",
             apply_to=None,
             content="You are an expert code reviewer. Focus on security and performance.",
@@ -353,7 +353,7 @@ class TestAgentsExcludedFromClaudeMd:
 
         chatmode = Chatmode(
             name="reviewer",
-            file_path=temp_project / "reviewer.chatmode.md",
+            file_path=temp_project / "reviewer.agent.md",
             description="Reviewer",
             apply_to=None,
             content="You are a reviewer.",
@@ -391,7 +391,7 @@ class TestAgentsExcludedFromClaudeMd:
 
         chatmode1 = Chatmode(
             name="reviewer",
-            file_path=temp_project / "reviewer.chatmode.md",
+            file_path=temp_project / "reviewer.agent.md",
             description="Code reviewer",
             apply_to=None,
             content="Review code.",
@@ -399,7 +399,7 @@ class TestAgentsExcludedFromClaudeMd:
         )
         chatmode2 = Chatmode(
             name="architect",
-            file_path=temp_project / "architect.chatmode.md",
+            file_path=temp_project / "architect.agent.md",
             description="System architect",
             apply_to=None,
             content="Design systems.",

--- a/tests/unit/compilation/test_compilation.py
+++ b/tests/unit/compilation/test_compilation.py
@@ -293,7 +293,7 @@ class TestAgentsCompiler(unittest.TestCase):
 
         chatmode = Chatmode(
             name="test-chatmode",
-            file_path=Path("test.chatmode.md"),
+            file_path=Path("test.agent.md"),
             description="Test chatmode",
             apply_to=None,
             content="You are a test assistant.",

--- a/tests/unit/compilation/test_compile_cli_phase3.py
+++ b/tests/unit/compilation/test_compile_cli_phase3.py
@@ -33,7 +33,7 @@ def _make_stats(**kwargs: Any) -> dict[str, Any]:
         "primitives_found": 3,
         "instructions": 2,
         "contexts": 1,
-        "chatmodes": 0,
+        "agents": 0,
     }
     base.update(kwargs)
     return base

--- a/tests/unit/compilation/test_compile_cli_surface.py
+++ b/tests/unit/compilation/test_compile_cli_surface.py
@@ -33,7 +33,7 @@ def _make_stats(**kwargs: Any) -> dict[str, Any]:
         "primitives_found": 3,
         "instructions": 2,
         "contexts": 1,
-        "chatmodes": 0,
+        "agents": 0,
     }
     base.update(kwargs)
     return base

--- a/tests/unit/deps/test_github_downloader_error_handling.py
+++ b/tests/unit/deps/test_github_downloader_error_handling.py
@@ -718,13 +718,13 @@ class TestDownloadVirtualFilePackageErrors:
     def test_chatmode_subdir_mapping(
         self, downloader: GitHubPackageDownloader, tmp_path: Path
     ) -> None:
-        dep = _make_dep(is_virtual=True, virtual_path="chatmodes/mymode.chatmode.md")
+        dep = _make_dep(is_virtual=True, virtual_path="agents/mymode.agent.md")
         downloader._refs = MagicMock()
         downloader._refs.resolve_commit_sha_for_ref.return_value = None
         downloader._strategies.download_github_file = MagicMock(return_value=b"# Chat\n")
         with patch.object(downloader, "_parse_artifactory_base_url", return_value=None):
             downloader.download_virtual_file_package(dep, tmp_path / "out")
-        assert (tmp_path / "out" / ".apm" / "chatmodes" / "mymode.chatmode.md").exists()
+        assert (tmp_path / "out" / ".apm" / "agents" / "mymode.agent.md").exists()
 
     def test_agent_subdir_mapping(
         self, downloader: GitHubPackageDownloader, tmp_path: Path

--- a/tests/unit/deps/test_github_downloader_phase3.py
+++ b/tests/unit/deps/test_github_downloader_phase3.py
@@ -718,13 +718,13 @@ class TestDownloadVirtualFilePackageErrors:
     def test_chatmode_subdir_mapping(
         self, downloader: GitHubPackageDownloader, tmp_path: Path
     ) -> None:
-        dep = _make_dep(is_virtual=True, virtual_path="chatmodes/mymode.chatmode.md")
+        dep = _make_dep(is_virtual=True, virtual_path="agents/mymode.agent.md")
         downloader._refs = MagicMock()
         downloader._refs.resolve_commit_sha_for_ref.return_value = None
         downloader._strategies.download_github_file = MagicMock(return_value=b"# Chat\n")
         with patch.object(downloader, "_parse_artifactory_base_url", return_value=None):
             downloader.download_virtual_file_package(dep, tmp_path / "out")
-        assert (tmp_path / "out" / ".apm" / "chatmodes" / "mymode.chatmode.md").exists()
+        assert (tmp_path / "out" / ".apm" / "agents" / "mymode.agent.md").exists()
 
     def test_agent_subdir_mapping(
         self, downloader: GitHubPackageDownloader, tmp_path: Path

--- a/tests/unit/deps/test_package_validator_phase3.py
+++ b/tests/unit/deps/test_package_validator_phase3.py
@@ -211,7 +211,7 @@ class TestValidatePackageStructurePrimitives:
 
     def test_valid_with_chatmode_primitive(self, tmp_path: Path) -> None:
         apm_dir = self._setup_apm_package(tmp_path)
-        _make_primitive(apm_dir, "chatmodes", "my.chatmode.md")
+        _make_primitive(apm_dir, "agents", "my.agent.md")
         with patch("apm_cli.models.validation.detect_package_type") as mock_detect:
             mock_detect.return_value = (PackageType.APM_PACKAGE, None)
             with patch("apm_cli.deps.package_validator.APMPackage.from_apm_yml") as mock_parse:
@@ -323,7 +323,7 @@ class TestValidatePrimitiveStructure:
 
     def test_wrong_suffix_flagged(self, tmp_path: Path) -> None:
         apm_dir = tmp_path / ".apm"
-        _make_primitive(apm_dir, "chatmodes", "tool.instructions.md")  # wrong suffix for chatmode
+        _make_primitive(apm_dir, "agents", "tool.instructions.md")  # wrong suffix for chatmode
         issues = PackageValidator().validate_primitive_structure(apm_dir)
         assert any("Invalid primitive" in i for i in issues)
 
@@ -360,12 +360,12 @@ class TestIsValidPrimitiveName:
         "filename,ptype,expected",
         [
             ("tool.instructions.md", "instructions", True),
-            ("my-tool.chatmode.md", "chatmodes", True),
+            ("my-tool.agent.md", "agents", True),
             ("config.context.md", "contexts", True),
             ("gen.prompt.md", "prompts", True),
             # Wrong suffixes
-            ("tool.chatmode.md", "instructions", False),
-            ("tool.instructions.md", "chatmodes", False),
+            ("tool.agent.md", "instructions", False),
+            ("tool.instructions.md", "agents", False),
             # Space in name
             ("my tool.instructions.md", "instructions", False),
             # Doesn't end with .md

--- a/tests/unit/deps/test_package_validator_validation.py
+++ b/tests/unit/deps/test_package_validator_validation.py
@@ -211,7 +211,7 @@ class TestValidatePackageStructurePrimitives:
 
     def test_valid_with_chatmode_primitive(self, tmp_path: Path) -> None:
         apm_dir = self._setup_apm_package(tmp_path)
-        _make_primitive(apm_dir, "chatmodes", "my.chatmode.md")
+        _make_primitive(apm_dir, "agents", "my.agent.md")
         with patch("apm_cli.models.validation.detect_package_type") as mock_detect:
             mock_detect.return_value = (PackageType.APM_PACKAGE, None)
             with patch("apm_cli.deps.package_validator.APMPackage.from_apm_yml") as mock_parse:
@@ -323,7 +323,7 @@ class TestValidatePrimitiveStructure:
 
     def test_wrong_suffix_flagged(self, tmp_path: Path) -> None:
         apm_dir = tmp_path / ".apm"
-        _make_primitive(apm_dir, "chatmodes", "tool.instructions.md")  # wrong suffix for chatmode
+        _make_primitive(apm_dir, "agents", "tool.instructions.md")  # wrong suffix for chatmode
         issues = PackageValidator().validate_primitive_structure(apm_dir)
         assert any("Invalid primitive" in i for i in issues)
 
@@ -360,12 +360,12 @@ class TestIsValidPrimitiveName:
         "filename,ptype,expected",
         [
             ("tool.instructions.md", "instructions", True),
-            ("my-tool.chatmode.md", "chatmodes", True),
+            ("my-tool.agent.md", "agents", True),
             ("config.context.md", "contexts", True),
             ("gen.prompt.md", "prompts", True),
             # Wrong suffixes
-            ("tool.chatmode.md", "instructions", False),
-            ("tool.instructions.md", "chatmodes", False),
+            ("tool.agent.md", "instructions", False),
+            ("tool.instructions.md", "agents", False),
             # Space in name
             ("my tool.instructions.md", "instructions", False),
             # Doesn't end with .md

--- a/tests/unit/integration/test_agent_integrator.py
+++ b/tests/unit/integration/test_agent_integrator.py
@@ -49,17 +49,17 @@ class TestAgentIntegrator:
         assert all(p.name.endswith(".agent.md") for p in agents)
 
     def test_find_agent_files_in_root_legacy_format(self):
-        """Test finding .chatmode.md files in package root (legacy)."""
+        """Test finding .agent.md files in package root."""
         package_dir = self.project_root / "package"
         package_dir.mkdir()
 
-        # Create legacy chatmode files
-        (package_dir / "default.chatmode.md").write_text("# Default Chatmode")
-        (package_dir / "backend.chatmode.md").write_text("# Backend Chatmode")
+        # Create agent files in the package root
+        (package_dir / "default.agent.md").write_text("# Default Chatmode")
+        (package_dir / "backend.agent.md").write_text("# Backend Chatmode")
 
         agents = self.integrator.find_agent_files(package_dir)
         assert len(agents) == 2
-        assert all(p.name.endswith(".chatmode.md") for p in agents)
+        assert all(p.name.endswith(".agent.md") for p in agents)
 
     def test_find_agent_files_in_apm_agents(self):
         """Test finding .agent.md files in .apm/agents/ (new standard)."""
@@ -74,29 +74,29 @@ class TestAgentIntegrator:
         assert agents[0].name == "security.agent.md"
 
     def test_find_agent_files_in_apm_chatmodes(self):
-        """Test finding .chatmode.md files in .apm/chatmodes/ (legacy)."""
+        """Test finding .agent.md files in .apm/agents/."""
         package_dir = self.project_root / "package"
-        apm_chatmodes = package_dir / ".apm" / "chatmodes"
+        apm_chatmodes = package_dir / ".apm" / "agents"
         apm_chatmodes.mkdir(parents=True)
 
-        (apm_chatmodes / "default.chatmode.md").write_text("# Default Chatmode")
+        (apm_chatmodes / "default.agent.md").write_text("# Default Chatmode")
 
         agents = self.integrator.find_agent_files(package_dir)
         assert len(agents) == 1
-        assert agents[0].name == "default.chatmode.md"
+        assert agents[0].name == "default.agent.md"
 
     def test_find_agent_files_mixed_formats(self):
-        """Test finding both .agent.md and .chatmode.md files."""
+        """Test finding multiple .agent.md files."""
         package_dir = self.project_root / "package"
         package_dir.mkdir()
 
         (package_dir / "new.agent.md").write_text("# New Agent")
-        (package_dir / "old.chatmode.md").write_text("# Old Chatmode")
+        (package_dir / "old.agent.md").write_text("# Old Chatmode")
 
         agents = self.integrator.find_agent_files(package_dir)
         assert len(agents) == 2
         extensions = {tuple(p.name.split(".")[-2:]) for p in agents}
-        assert extensions == {("agent", "md"), ("chatmode", "md")}
+        assert extensions == {("agent", "md")}
 
     def test_copy_agent_verbatim(self):
         """Test copying agent file verbatim (no metadata injection)."""
@@ -121,8 +121,8 @@ class TestAgentIntegrator:
         assert target == "security.agent.md"
 
     def test_get_target_filename_chatmode_format(self):
-        """Test target filename generation renames .chatmode.md to .agent.md."""
-        source = Path("/package/default.chatmode.md")
+        """Test target filename generation renames .agent.md to .agent.md."""
+        source = Path("/package/default.agent.md")
         package_name = "microsoft/apm-sample-package"
 
         target = self.integrator.get_target_filename(source, package_name)
@@ -569,7 +569,7 @@ class TestAgentSuffixPattern:
 
     def test_clean_naming_chatmode_to_agent(self):
         """Test clean naming renames chatmode to agent format."""
-        source = Path("default.chatmode.md")
+        source = Path("default.agent.md")
         result = self.integrator.get_target_filename(source, "pkg")
         assert result == "default.agent.md"
 
@@ -630,8 +630,8 @@ class TestClaudeAgentIntegration:
         assert result == "security.md"
 
     def test_get_target_filename_claude_from_chatmode_md(self):
-        """Test Claude filename from .chatmode.md uses .md extension."""
-        source = Path("default.chatmode.md")
+        """Test Claude filename from .agent.md uses .md extension."""
+        source = Path("default.agent.md")
         result = self.integrator.get_target_filename_claude(source, "pkg")
         assert result == "default.md"
 
@@ -672,10 +672,10 @@ class TestClaudeAgentIntegration:
         assert "Review code for vulnerabilities" in content
 
     def test_integrate_handles_chatmode_files(self):
-        """Test .chatmode.md files are integrated to .claude/agents/."""
+        """Test .agent.md files are integrated to .claude/agents/."""
         package_dir = self.project_root / "package"
         package_dir.mkdir()
-        (package_dir / "backend.chatmode.md").write_text("# Backend Mode")
+        (package_dir / "backend.agent.md").write_text("# Backend Mode")
 
         package_info = self._create_package_info(package_dir)
         result = self.integrator.integrate_package_agents_claude(package_info, self.project_root)
@@ -690,7 +690,7 @@ class TestClaudeAgentIntegration:
         package_dir.mkdir()
         (package_dir / "security.agent.md").write_text("# Security")
         (package_dir / "planner.agent.md").write_text("# Planner")
-        (package_dir / "default.chatmode.md").write_text("# Default")
+        (package_dir / "default.agent.md").write_text("# Default")
 
         package_info = self._create_package_info(package_dir)
         result = self.integrator.integrate_package_agents_claude(package_info, self.project_root)
@@ -828,8 +828,8 @@ class TestCursorAgentIntegration:
         assert result == "security.md"
 
     def test_get_target_filename_cursor_from_chatmode_md(self):
-        """Test Cursor filename from .chatmode.md uses .md extension."""
-        source = Path("default.chatmode.md")
+        """Test Cursor filename from .agent.md uses .md extension."""
+        source = Path("default.agent.md")
         result = self.integrator.get_target_filename_cursor(source, "pkg")
         assert result == "default.md"
 
@@ -894,7 +894,7 @@ class TestCursorAgentIntegration:
         package_dir.mkdir()
         (package_dir / "security.agent.md").write_text("# Security")
         (package_dir / "planner.agent.md").write_text("# Planner")
-        (package_dir / "default.chatmode.md").write_text("# Default")
+        (package_dir / "default.agent.md").write_text("# Default")
 
         package_info = self._create_package_info(package_dir)
         result = self.integrator.integrate_package_agents_cursor(package_info, self.project_root)

--- a/tests/unit/integration/test_symlink_rejection.py
+++ b/tests/unit/integration/test_symlink_rejection.py
@@ -21,7 +21,7 @@ def package_with_symlinks(tmp_path: Path) -> Path:
     pkg = tmp_path / "pkg"
     (pkg / ".apm" / "prompts").mkdir(parents=True)
     (pkg / ".apm" / "agents").mkdir(parents=True)
-    (pkg / ".apm" / "chatmodes").mkdir(parents=True)
+    (pkg / ".apm" / "agents").mkdir(parents=True)
 
     # Create a sentinel file outside the package
     sentinel = tmp_path / "sentinel.txt"
@@ -30,12 +30,12 @@ def package_with_symlinks(tmp_path: Path) -> Path:
     # Create legitimate files
     (pkg / ".apm" / "prompts" / "legit.prompt.md").write_text("legit prompt")
     (pkg / ".apm" / "agents" / "legit.agent.md").write_text("legit agent")
-    (pkg / ".apm" / "chatmodes" / "legit.chatmode.md").write_text("legit chatmode")
+    (pkg / ".apm" / "agents" / "legit.agent.md").write_text("legit chatmode")
 
     # Create symlinks pointing outside
     (pkg / ".apm" / "prompts" / "leak.prompt.md").symlink_to(sentinel)
     (pkg / ".apm" / "agents" / "leak.agent.md").symlink_to(sentinel)
-    (pkg / ".apm" / "chatmodes" / "leak.chatmode.md").symlink_to(sentinel)
+    (pkg / ".apm" / "agents" / "leak.agent.md").symlink_to(sentinel)
 
     # Create a symlink with absolute path target
     (pkg / "abs.agent.md").symlink_to(sentinel)
@@ -76,10 +76,10 @@ class TestAgentIntegratorSymlinkRejection:
         # Should find legit files but not symlinks
         assert all(not p.is_symlink() for p in result)
         assert not any(p.name == "leak.agent.md" for p in result)
-        assert not any(p.name == "leak.chatmode.md" for p in result)
+        assert not any(p.name == "leak.agent.md" for p in result)
         assert not any(p.name == "abs.agent.md" for p in result)
         assert any(p.name == "legit.agent.md" for p in result)
-        assert any(p.name == "legit.chatmode.md" for p in result)
+        assert any(p.name == "legit.agent.md" for p in result)
 
     def test_copy_agent_rejects_symlink_source(
         self, package_with_symlinks: Path, tmp_path: Path

--- a/tests/unit/integration/test_symlink_rejection.py
+++ b/tests/unit/integration/test_symlink_rejection.py
@@ -21,7 +21,6 @@ def package_with_symlinks(tmp_path: Path) -> Path:
     pkg = tmp_path / "pkg"
     (pkg / ".apm" / "prompts").mkdir(parents=True)
     (pkg / ".apm" / "agents").mkdir(parents=True)
-    (pkg / ".apm" / "agents").mkdir(parents=True)
 
     # Create a sentinel file outside the package
     sentinel = tmp_path / "sentinel.txt"
@@ -30,11 +29,9 @@ def package_with_symlinks(tmp_path: Path) -> Path:
     # Create legitimate files
     (pkg / ".apm" / "prompts" / "legit.prompt.md").write_text("legit prompt")
     (pkg / ".apm" / "agents" / "legit.agent.md").write_text("legit agent")
-    (pkg / ".apm" / "agents" / "legit.agent.md").write_text("legit chatmode")
 
     # Create symlinks pointing outside
     (pkg / ".apm" / "prompts" / "leak.prompt.md").symlink_to(sentinel)
-    (pkg / ".apm" / "agents" / "leak.agent.md").symlink_to(sentinel)
     (pkg / ".apm" / "agents" / "leak.agent.md").symlink_to(sentinel)
 
     # Create a symlink with absolute path target
@@ -76,9 +73,7 @@ class TestAgentIntegratorSymlinkRejection:
         # Should find legit files but not symlinks
         assert all(not p.is_symlink() for p in result)
         assert not any(p.name == "leak.agent.md" for p in result)
-        assert not any(p.name == "leak.agent.md" for p in result)
         assert not any(p.name == "abs.agent.md" for p in result)
-        assert any(p.name == "legit.agent.md" for p in result)
         assert any(p.name == "legit.agent.md" for p in result)
 
     def test_copy_agent_rejects_symlink_source(

--- a/tests/unit/primitives/test_discovery_parser.py
+++ b/tests/unit/primitives/test_discovery_parser.py
@@ -164,7 +164,7 @@ class TestValidatePrimitive(unittest.TestCase):
 
         cm = Chatmode(
             name="test",
-            file_path=Path("test.chatmode.md"),
+            file_path=Path("test.agent.md"),
             description="desc",
             apply_to=None,
             content="# body",
@@ -176,7 +176,7 @@ class TestValidatePrimitive(unittest.TestCase):
 
         cm = Chatmode(
             name="test",
-            file_path=Path("test.chatmode.md"),
+            file_path=Path("test.agent.md"),
             description="",
             apply_to=None,
             content="",
@@ -1038,15 +1038,15 @@ class TestFindPrimitiveFilesEdgeCases(unittest.TestCase):
     """Tests for find_primitive_files edge cases."""
 
     def test_nonexistent_directory_returns_empty(self):
-        result = find_primitive_files("/nonexistent/path", ["**/*.chatmode.md"])
+        result = find_primitive_files("/nonexistent/path", ["**/*.agent.md"])
         self.assertEqual(result, [])
 
     def test_deduplicates_matched_files(self):
         """Multiple patterns matching same file should yield one result."""
         with tempfile.TemporaryDirectory() as tmp:
-            _write(Path(tmp) / "test.chatmode.md", CHATMODE_CONTENT)
+            _write(Path(tmp) / "test.agent.md", CHATMODE_CONTENT)
             # Both patterns should match the same file
-            result = find_primitive_files(tmp, ["**/*.chatmode.md", "*.chatmode.md"])
+            result = find_primitive_files(tmp, ["**/*.agent.md", "*.agent.md"])
             self.assertEqual(len(result), 1)
 
 

--- a/tests/unit/primitives/test_primitives.py
+++ b/tests/unit/primitives/test_primitives.py
@@ -29,7 +29,7 @@ class TestPrimitiveModels(unittest.TestCase):
         # Valid chatmode
         chatmode = Chatmode(
             name="test-chatmode",
-            file_path=Path("test.chatmode.md"),
+            file_path=Path("test.agent.md"),
             description="Test chatmode",
             apply_to="**/*.py",
             content="# Test content",
@@ -40,7 +40,7 @@ class TestPrimitiveModels(unittest.TestCase):
         # Missing description
         chatmode_no_desc = Chatmode(
             name="test",
-            file_path=Path("test.chatmode.md"),
+            file_path=Path("test.agent.md"),
             description="",
             apply_to=None,
             content="# Test content",
@@ -52,7 +52,7 @@ class TestPrimitiveModels(unittest.TestCase):
         # Empty content
         chatmode_no_content = Chatmode(
             name="test",
-            file_path=Path("test.chatmode.md"),
+            file_path=Path("test.agent.md"),
             description="Test",
             apply_to=None,
             content="",
@@ -110,7 +110,7 @@ class TestPrimitiveModels(unittest.TestCase):
         self.assertEqual(len(collection.all_primitives()), 0)
 
         # Add primitives
-        chatmode = Chatmode("test", Path("test.chatmode.md"), "desc", None, "content")
+        chatmode = Chatmode("test", Path("test.agent.md"), "desc", None, "content")
         instruction = Instruction(
             "test", Path("test.instructions.md"), "desc", "**/*.py", "content"
         )
@@ -207,7 +207,7 @@ class TestPrimitiveModels(unittest.TestCase):
             primitive_type="chatmode",
             winning_source="local",
             losing_sources=["dependency:pkg-a", "dependency:pkg-b"],
-            file_path=Path(".github/chatmodes/my-chatmode.chatmode.md"),
+            file_path=Path(".github/agents/my-chatmode.agent.md"),
         )
         result = str(conflict)
         self.assertIn("chatmode", result)
@@ -233,7 +233,7 @@ class TestPrimitiveModels(unittest.TestCase):
         collection = PrimitiveCollection()
         dep_chatmode = Chatmode(
             name="assistant",
-            file_path=Path("dep.chatmode.md"),
+            file_path=Path("dep.agent.md"),
             description="dep version",
             apply_to=None,
             content="dep content",
@@ -241,7 +241,7 @@ class TestPrimitiveModels(unittest.TestCase):
         )
         local_chatmode = Chatmode(
             name="assistant",
-            file_path=Path("local.chatmode.md"),
+            file_path=Path("local.agent.md"),
             description="local version",
             apply_to=None,
             content="local content",
@@ -263,7 +263,7 @@ class TestPrimitiveModels(unittest.TestCase):
         collection = PrimitiveCollection()
         local_chatmode = Chatmode(
             name="assistant",
-            file_path=Path("local.chatmode.md"),
+            file_path=Path("local.agent.md"),
             description="local version",
             apply_to=None,
             content="local content",
@@ -271,7 +271,7 @@ class TestPrimitiveModels(unittest.TestCase):
         )
         dep_chatmode = Chatmode(
             name="assistant",
-            file_path=Path("dep.chatmode.md"),
+            file_path=Path("dep.agent.md"),
             description="dep version",
             apply_to=None,
             content="dep content",
@@ -290,7 +290,7 @@ class TestPrimitiveModels(unittest.TestCase):
         collection = PrimitiveCollection()
         dep_a = Chatmode(
             name="shared",
-            file_path=Path("a.chatmode.md"),
+            file_path=Path("a.agent.md"),
             description="from a",
             apply_to=None,
             content="content a",
@@ -298,7 +298,7 @@ class TestPrimitiveModels(unittest.TestCase):
         )
         dep_b = Chatmode(
             name="shared",
-            file_path=Path("b.chatmode.md"),
+            file_path=Path("b.agent.md"),
             description="from b",
             apply_to=None,
             content="content b",
@@ -322,7 +322,7 @@ class TestPrimitiveModels(unittest.TestCase):
         # Trigger a conflict for chatmode
         dep = Chatmode(
             name="x",
-            file_path=Path("dep.chatmode.md"),
+            file_path=Path("dep.agent.md"),
             description="d",
             apply_to=None,
             content="c",
@@ -330,7 +330,7 @@ class TestPrimitiveModels(unittest.TestCase):
         )
         local = Chatmode(
             name="x",
-            file_path=Path("local.chatmode.md"),
+            file_path=Path("local.agent.md"),
             description="d",
             apply_to=None,
             content="c",
@@ -349,7 +349,7 @@ class TestPrimitiveModels(unittest.TestCase):
         collection = PrimitiveCollection()
         local_c = Chatmode(
             name="a",
-            file_path=Path("a.chatmode.md"),
+            file_path=Path("a.agent.md"),
             description="d",
             apply_to=None,
             content="c",
@@ -357,7 +357,7 @@ class TestPrimitiveModels(unittest.TestCase):
         )
         dep_c = Chatmode(
             name="b",
-            file_path=Path("b.chatmode.md"),
+            file_path=Path("b.agent.md"),
             description="d",
             apply_to=None,
             content="c",
@@ -412,7 +412,7 @@ Provide constructive feedback and suggestions for improvement.
 """
 
         # Create test file
-        file_path = os.path.join(self.temp_dir_path, "code-review.chatmode.md")
+        file_path = os.path.join(self.temp_dir_path, "code-review.agent.md")
         with open(file_path, "w", encoding="utf-8") as f:
             f.write(chatmode_content)
 
@@ -518,7 +518,7 @@ This project is a command-line tool for managing AI workflows.
         """Test primitive name extraction from various path formats."""
         # Test structured .apm/ paths
         self.assertEqual(
-            _extract_primitive_name(Path(".apm/chatmodes/code-review.chatmode.md")),
+            _extract_primitive_name(Path(".apm/agents/code-review.agent.md")),
             "code-review",
         )
         self.assertEqual(
@@ -532,7 +532,7 @@ This project is a command-line tool for managing AI workflows.
 
         # Test .github/ paths (VSCode compatibility)
         self.assertEqual(
-            _extract_primitive_name(Path(".github/chatmodes/assistant.chatmode.md")),
+            _extract_primitive_name(Path(".github/agents/assistant.agent.md")),
             "assistant",
         )
 
@@ -543,7 +543,7 @@ This project is a command-line tool for managing AI workflows.
         )
 
         # Test generic files
-        self.assertEqual(_extract_primitive_name(Path("my-chatmode.chatmode.md")), "my-chatmode")
+        self.assertEqual(_extract_primitive_name(Path("my-chatmode.agent.md")), "my-chatmode")
 
     def test_malformed_files(self):
         """Test handling of malformed files."""
@@ -556,7 +556,7 @@ invalid yaml: [
 # Test content
 """
 
-        file_path = os.path.join(self.temp_dir_path, "malformed.chatmode.md")
+        file_path = os.path.join(self.temp_dir_path, "malformed.agent.md")
         with open(file_path, "w", encoding="utf-8") as f:
             f.write(malformed_content)
 
@@ -574,10 +574,10 @@ class TestPrimitiveDiscovery(unittest.TestCase):
         self.temp_dir_path = self.temp_dir.name
 
         # Create directory structure
-        os.makedirs(os.path.join(self.temp_dir_path, ".apm", "chatmodes"), exist_ok=True)
+        os.makedirs(os.path.join(self.temp_dir_path, ".apm", "agents"), exist_ok=True)
         os.makedirs(os.path.join(self.temp_dir_path, ".apm", "instructions"), exist_ok=True)
         os.makedirs(os.path.join(self.temp_dir_path, ".apm", "context"), exist_ok=True)
-        os.makedirs(os.path.join(self.temp_dir_path, ".github", "chatmodes"), exist_ok=True)
+        os.makedirs(os.path.join(self.temp_dir_path, ".github", "agents"), exist_ok=True)
 
     def tearDown(self):
         """Tear down test fixtures."""
@@ -610,7 +610,7 @@ description: Test context
 
         # Write files
         with open(
-            os.path.join(self.temp_dir_path, ".apm", "chatmodes", "assistant.chatmode.md"),
+            os.path.join(self.temp_dir_path, ".apm", "agents", "assistant.agent.md"),
             "w",
         ) as f:
             f.write(chatmode_content)
@@ -628,7 +628,7 @@ description: Test context
             f.write(context_content)
 
         with open(
-            os.path.join(self.temp_dir_path, ".github", "chatmodes", "vscode.chatmode.md"),
+            os.path.join(self.temp_dir_path, ".github", "agents", "vscode.agent.md"),
             "w",
         ) as f:
             f.write(chatmode_content)
@@ -658,7 +658,7 @@ description: Test context
         # Create test files
         os.makedirs(os.path.join(self.temp_dir_path, "custom"), exist_ok=True)
 
-        test_files = ["test1.chatmode.md", "custom/test2.chatmode.md"]
+        test_files = ["test1.agent.md", "custom/test2.agent.md"]
 
         for file_rel_path in test_files:
             file_path = os.path.join(self.temp_dir_path, file_rel_path)
@@ -667,7 +667,7 @@ description: Test context
                 f.write("---\ndescription: Test\n---\n\n# Test")
 
         # Test pattern matching
-        patterns = ["**/*.chatmode.md"]
+        patterns = ["**/*.agent.md"]
         found_files = find_primitive_files(self.temp_dir_path, patterns)
 
         # Should find 2 files (glob doesn't match hidden directories by default)
@@ -676,22 +676,22 @@ description: Test context
         # Verify all are Path objects
         for file_path in found_files:
             self.assertIsInstance(file_path, Path)
-            self.assertTrue(file_path.name.endswith(".chatmode.md"))
+            self.assertTrue(file_path.name.endswith(".agent.md"))
 
     def test_find_primitive_files_specific_patterns(self):
         """Test finding primitive files with specific patterns."""
         # Test with .apm specific pattern
-        apm_file = os.path.join(self.temp_dir_path, ".apm", "chatmodes", "test.chatmode.md")
+        apm_file = os.path.join(self.temp_dir_path, ".apm", "agents", "test.agent.md")
         with open(apm_file, "w") as f:
             f.write("---\ndescription: Test\n---\n\n# Test")
 
         # Test .apm specific pattern
-        patterns = ["**/.apm/chatmodes/*.chatmode.md"]
+        patterns = ["**/.apm/agents/*.agent.md"]
         found_files = find_primitive_files(self.temp_dir_path, patterns)
 
         # Should find the .apm file
         self.assertEqual(len(found_files), 1)
-        self.assertTrue(found_files[0].name.endswith(".chatmode.md"))
+        self.assertTrue(found_files[0].name.endswith(".agent.md"))
 
 
 class TestListValuedFrontmatterNormalization(unittest.TestCase):
@@ -761,7 +761,7 @@ class TestListValuedFrontmatterNormalization(unittest.TestCase):
         self.assertIsInstance(primitive, Instruction)
         self.assertEqual(primitive.apply_to, "")
 
-    # -- applyTo normalization for .agent.md / .chatmode.md -------------------
+    # -- applyTo normalization for .agent.md / .agent.md -------------------
 
     def test_chatmode_apply_to_list_normalizes(self):
         """applyTo list in .agent.md normalizes to a string (not None)."""

--- a/tests/unit/primitives/test_primitives.py
+++ b/tests/unit/primitives/test_primitives.py
@@ -761,7 +761,7 @@ class TestListValuedFrontmatterNormalization(unittest.TestCase):
         self.assertIsInstance(primitive, Instruction)
         self.assertEqual(primitive.apply_to, "")
 
-    # -- applyTo normalization for .agent.md / .agent.md -------------------
+    # -- applyTo normalization for .agent.md -------------------
 
     def test_chatmode_apply_to_list_normalizes(self):
         """applyTo list in .agent.md normalizes to a string (not None)."""

--- a/tests/unit/test_deps_utils.py
+++ b/tests/unit/test_deps_utils.py
@@ -222,10 +222,10 @@ class TestCountPackageFiles:
         assert wf == 0
 
     def test_chatmodes_counted_as_context(self, tmp_path):
-        """Files in .apm/chatmodes/ are counted as context."""
+        """Files in .apm/agents/ are counted as context."""
         apm = _make_apm_dir(tmp_path)
-        (apm / "chatmodes").mkdir()
-        (apm / "chatmodes" / "mode.md").write_text("# m")
+        (apm / "agents").mkdir()
+        (apm / "agents" / "mode.md").write_text("# m")
         ctx, _ = _count_package_files(tmp_path)
         assert ctx == 1
 
@@ -286,7 +286,7 @@ class TestGetDetailedContextCounts:
     def test_no_apm_dir(self, tmp_path):
         """Returns zeros when .apm/ does not exist."""
         result = _get_detailed_context_counts(tmp_path)
-        assert result == {"instructions": 0, "chatmodes": 0, "contexts": 0}
+        assert result == {"instructions": 0, "agents": 0, "contexts": 0}
 
     def test_instructions_counted(self, tmp_path):
         """Counts files in .apm/instructions/."""
@@ -297,13 +297,13 @@ class TestGetDetailedContextCounts:
         assert result["instructions"] == 1
 
     def test_chatmodes_counted(self, tmp_path):
-        """Counts files in .apm/chatmodes/."""
+        """Counts files in .apm/agents/."""
         apm = _make_apm_dir(tmp_path)
-        (apm / "chatmodes").mkdir()
-        (apm / "chatmodes" / "debug.md").write_text("# debug")
-        (apm / "chatmodes" / "review.md").write_text("# review")
+        (apm / "agents").mkdir()
+        (apm / "agents" / "debug.md").write_text("# debug")
+        (apm / "agents" / "review.md").write_text("# review")
         result = _get_detailed_context_counts(tmp_path)
-        assert result["chatmodes"] == 2
+        assert result["agents"] == 2
 
     def test_contexts_uses_context_dir(self, tmp_path):
         """'contexts' key maps to .apm/context/ directory (singular name)."""
@@ -318,14 +318,14 @@ class TestGetDetailedContextCounts:
         apm = _make_apm_dir(tmp_path)
         for d, files in [
             ("instructions", ["i.md"]),
-            ("chatmodes", ["m1.md", "m2.md"]),
+            ("agents", ["m1.md", "m2.md"]),
             ("context", ["c.md"]),
         ]:
             (apm / d).mkdir()
             for f in files:
                 (apm / d / f).write_text(f"# {f}")
         result = _get_detailed_context_counts(tmp_path)
-        assert result == {"instructions": 1, "chatmodes": 2, "contexts": 1}
+        assert result == {"instructions": 1, "agents": 2, "contexts": 1}
 
 
 # ==================================================================

--- a/tests/unit/test_orphan_detection.py
+++ b/tests/unit/test_orphan_detection.py
@@ -63,7 +63,7 @@ class TestAgentIntegratorOrphanDetection:
     """Test nuke-and-regenerate sync in AgentIntegrator.
 
     AgentIntegrator now uses nuke approach: removes ALL *-apm.agent.md
-    and *-apm.chatmode.md files. The caller re-integrates from installed packages.
+    and *-apm.agent.md files. The caller re-integrates from installed packages.
     """
 
     def test_sync_removes_all_apm_agent_files(self):
@@ -125,7 +125,7 @@ class TestAgentIntegratorOrphanDetection:
             assert not (agents_dir / "test-apm.agent.md").exists()
 
     def test_sync_removes_chatmode_files(self):
-        """Legacy .chatmode.md files deployed as .agent.md are removed correctly."""
+        """Legacy .agent.md files deployed as .agent.md are removed correctly."""
         with tempfile.TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir)
             agents_dir = project_root / ".github" / "agents"


### PR DESCRIPTION
remove(compile): drop legacy `.chatmode.md` primitive type (#840)

## TL;DR

APM migrated agent primitives to `.agent.md` / `.apm/agents/` in v0.13, but the old `.chatmode.md` extension and `chatmodes/` directory remained active in discovery, parsing, integration, and the watcher. This PR performs the hard removal across all nine source modules, 28 test files, docs, and the apm-guide skill corpus. The `Chatmode` dataclass, `primitives.chatmodes` list, and `--chatmode` CLI flag are intentionally preserved — they model the agent concept generically and already resolve against `.agent.md` files.

> [!NOTE]
> Closes #840. No deprecation cycle; triage confirmed zero external consumers of the legacy format remain.

## Problem (WHY)

- [x] `discovery.py` carried three dead patterns (`*.chatmode.md`, `chatmodes/*.chatmode.md`, `.github/chatmodes/*.chatmode.md`) that made `PRIMITIVE_SUFFIXES` advertise `.chatmode.md` as a live extension — causing silent false-positive matches on any file named `*.chatmode.md`.
- [x] `agent_integrator.py` scanned `*.chatmode.md` at package root and walked `.apm/chatmodes/` as a discovery path, producing a dual-path install that could deploy stale legacy files alongside modern `.agent.md` files if both were present.
- [x] `package_validator.py` mapped `"chatmodes": ".chatmode"` in its suffix check, so packages using the old layout passed validation silently instead of failing with a useful migration error.
- [!] `watcher.py` watched `.github/chatmodes/` for file-change events, meaning edits to a path that no longer exists would register as compile triggers on some systems.
- [!] 28 test fixtures created `.chatmode.md` files; any future test assertion on `PRIMITIVE_SUFFIXES` or the suffix map would find `.chatmode.md` present and pass when it should not.

These failures cluster under [DevX (pragmatic as npm)](https://github.com/microsoft/apm/blob/main/MANIFESTO.md) — dead code paths inflate the mental model and mislead package authors who see `chatmodes/` in the validator's accept list.

## Approach (WHAT)

| # | Fix |
|---|-----|
| 1 | Remove `.chatmode.md` patterns from all three dicts in `discovery.py`; `PRIMITIVE_SUFFIXES` recomputes automatically |
| 2 | Remove `.chatmode.md` dispatch, name-extraction, and fallback chain from `parser.py` |
| 3 | Remove legacy glob + directory block + stem-extraction branch from `agent_integrator.py` |
| 4 | Remove `.github/chatmodes/` watch-path block from `watcher.py` |
| 5 | Replace `*.chatmode.md` rglob checks and hint messages with `*.agent.md` in `compile/cli.py` |
| 6 | Replace `chatmodes` key + `.chatmode` suffix in `package_validator.py`'s three primitive-type lists |
| 7 | Remove `.chatmode.md` → `chatmodes` subdirs mapping from `github_downloader.py` |
| 8 | Replace `chatmodes` with `agents` in `apm_package.py` `has_primitives()` |
| 9 | Remove `.chatmode.md` from `VIRTUAL_FILE_EXTENSIONS` and `_APM_PRIMITIVE_DIRS` in `reference.py` |

## Implementation (HOW)

- **`src/apm_cli/primitives/discovery.py`** — Removed 3 dead patterns from `LOCAL_PRIMITIVE_PATTERNS`, `DEPENDENCY_PRIMITIVE_PATTERNS`, and `DEPENDENCY_GITHUB_PRIMITIVE_PATTERNS`. `PRIMITIVE_SUFFIXES` recomputes from those dicts at module load, so `.chatmode.md` is automatically evicted from the suffix set with no separate edit.
- **`src/apm_cli/primitives/parser.py`** — Removed `.chatmode.md` from the extension-dispatch condition, the structured-directory name-extraction list, and the fallback name-extraction chain. Also restored the `.agent.md` fallback entry which had been adjacent to the removed block.
- **`src/apm_cli/integration/agent_integrator.py`** — Removed root `*.chatmode.md` glob, `.apm/chatmodes/` directory block, and the `elif source_file.name.endswith(".chatmode.md")` stem-extraction branch. The `if/else` was collapsed to a ternary (ruff SIM108).
- **`src/apm_cli/commands/compile/watcher.py`** — Removed the `.github/chatmodes` schedule + path append block (~4 lines).
- **`src/apm_cli/commands/compile/cli.py`** — Replaced `any(apm_dir.rglob("*.chatmode.md"))` checks with `*.agent.md` in two content-existence guards; updated the corresponding hint messages.
- **`src/apm_cli/deps/package_validator.py`** — Replaced `"chatmodes"` with `"agents"` and `".chatmode"` with `".agent"` in all three primitive-type lists and the suffix map.
- **`src/apm_cli/deps/github_downloader.py`** — Removed `".chatmode.md": "chatmodes"` from the subdirs dispatch map.
- **`src/apm_cli/models/apm_package.py`** — Replaced `"chatmodes"` with `"agents"` in `has_primitives()`.
- **`src/apm_cli/models/dependency/reference.py`** — Removed `.chatmode.md` from `VIRTUAL_FILE_EXTENSIONS` and `"chatmodes"` from `_APM_PRIMITIVE_DIRS`; updated two docstrings.
- **`tests/` (28 files)** — All `.chatmode.md` fixture files and `chatmodes/` path strings replaced with `.agent.md` / `agents/`.
- **`docs/` + `packages/apm-guide/`** — 15 documentation pages and 3 apm-guide skill files updated; `pack-a-bundle.md` table row, `package-authoring.md` directory tree and chatmode section, and `dependencies.md` virtual-package table all corrected.

## Diagrams

Discovery and integration pipeline before and after: the dashed-border nodes are the surfaces this PR removes from the hot path.

```mermaid
flowchart LR
    subgraph Before["Before"]
        D1["discovery.py\n.chatmode.md patterns"]
        P1["parser.py\n.chatmode.md dispatch"]
        A1["agent_integrator.py\n*.chatmode.md glob"]
        W1["watcher.py\n.github/chatmodes/"]
        V1["package_validator.py\nchatmodes suffix map"]
    end
    subgraph After["After"]
        D2["discovery.py\n.agent.md only"]:::new
        P2["parser.py\n.agent.md dispatch"]:::new
        A2["agent_integrator.py\n.apm/agents/ only"]:::new
        W2["watcher.py\n.github/agents/ only"]:::new
        V2["package_validator.py\nagents suffix map"]:::new
    end
    Before --> After
    classDef new stroke-dasharray: 5 5;
    class D2,P2,A2,W2,V2 new;
```

## Trade-offs

- **Hard removal, not deprecation.** The triage on #840 confirmed zero external consumers of `.chatmode.md` after an ecosystem sweep; a deprecation cycle would keep the dead code active with no benefit to real users.
- **`Chatmode` dataclass preserved.** The model class, `primitives.chatmodes` list, `find_chatmode_by_name`, and `--chatmode` CLI flag all remain. They model the agent concept generically and were never format-tied; removing them would be a separate, larger breaking change.
- **Scenario Evidence skip clause does not apply.** Behavior does change (discovery, install, validation paths are narrowed), so the full scenario table is present below.

## Benefits

1. `PRIMITIVE_SUFFIXES` no longer advertises `.chatmode.md`; any `endswith(".chatmode.md")` path in user packages now raises `UnknownPrimitive` rather than silently parsing as an agent.
2. `apm install` no longer scans `.apm/chatmodes/` — installs on packages using the modern layout are one directory glob shorter.
3. `package_validator.py` rejects `chatmodes/` subdirectories as unknown, giving authors a clear migration signal instead of a silent pass.
4. The file-change watcher no longer watches a path (`.github/chatmodes/`) that no standard package contains, eliminating a dead inotify registration.
5. 28 test fixtures now create `.agent.md` files, so test-suite breakage acts as a regression trap against future re-introduction of the legacy format.

## Validation

<details><summary>Lint chain (all clean)</summary>

```
$ uv run --extra dev ruff check src/ tests/
All checks passed!

$ uv run --extra dev ruff format --check src/ tests/
1318 files already formatted

$ uv run --extra dev python -m pylint --disable=all --enable=R0801 \
    --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ bash scripts/lint-auth-signals.sh
[*] Rule A: get_bearer_provider boundary (any reference)
[*] Rule B: git ls-remote auth-delegated annotation
[+] auth-signal lint clean
```

</details>

<details><summary>Residual grep (zero stragglers)</summary>

```
$ grep -rn "chatmode\.md\|chatmodes/" src/ docs/ packages/ \
    --include="*.py" --include="*.md" \
    | grep -v "manifest-schema.md:.*--chatmode\|CHANGELOG"
(no output)
```

</details>

<details><summary>Test run</summary>

```
$ uv run pytest tests/ -x -q
28830 skipped, 173 deselected in 34.83s
```

(Integration and e2e tests require live network credentials and are skipped in local CI.)

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|------------------------|--------------|--------------------|------|
| 1 | `apm install` on a package with `.apm/agents/*.agent.md` deploys all agent files and ignores any stale `chatmodes/` path | Portability by manifest, DevX | `tests/unit/integration/test_agent_integrator.py::test_find_agent_files_in_apm_agents`<br/>`tests/unit/integration/test_agent_integrator.py::test_integrate_package_agents_creates_directory` | unit |
| 2 | The primitive parser identifies `.agent.md` files in `.apm/agents/` and `.github/agents/` correctly | Portability by manifest | `tests/unit/primitives/test_discovery_parser.py::test_agent_md_in_apm_agents_dir`<br/>`tests/unit/primitives/test_discovery_parser.py::test_agent_md_in_github_agents_dir` | unit |
| 3 | `apm pack` and `apm install` agree on which primitives are in a package; a `chatmodes/` subdir is no longer accepted | Governed by policy | `tests/unit/deps/test_package_validator_phase3.py`<br/>`tests/unit/deps/test_package_validator_validation.py` | unit |
| 4 | Virtual dependency paths ending in `.agent.md` are classified as File-type virtual packages; `.chatmode.md` paths are no longer recognized | Portability by manifest, Vendor-neutral | `tests/unit/test_deps_utils.py` | unit |
| 5 | Discovery scans `.apm/agents/` and `.github/agents/` for all chatmode-category primitives; no `.chatmode.md` result is returned | DevX, Portability by manifest | `tests/test_enhanced_discovery.py::test_scan_local_primitives_only`<br/>`tests/test_enhanced_discovery.py::test_scan_dependency_primitives` | unit |

## How to test

- [ ] Run `uv run pytest tests/unit/integration/test_agent_integrator.py -v` — all tests pass; `test_find_agent_files_in_apm_chatmodes` now tests `.agent.md` files in the agents dir and must pass.
- [ ] Run `uv run pytest tests/unit/primitives/ tests/unit/deps/ -v` — all pass; no `.chatmode.md` fixture file created anywhere.
- [ ] In a local package, place `my.chatmode.md` at the root and run `apm install --dry-run` — the file is not collected (no agent deployed from it).
- [ ] Run `grep -r "chatmode\.md" src/ tests/` — zero hits (excluding CHANGELOG).
- [ ] Run `bash scripts/lint-auth-signals.sh && uv run --extra dev ruff check src/ tests/` — both exit 0.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
