### PR TITLE
feat(view): route 'view versions' to the registry when a default is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `apm view <package> versions` now routes to the configured default registry for
+  plain shorthands (e.g., `acme/web-skills`) when a default registry is configured,
+  matching `apm install` routing behavior. Added `--registry [NAME]` for explicit
+  registry control: bare `--registry` uses the lockfile entry or configured default;
+  `--registry NAME` forces a named registry. Use a full git URL to force the git path
+  when a default registry is configured. (by @nadav-y) (#1938)
+
 ### Removed
 
 - Removed legacy `.chatmode.md` primitive format and `chatmodes/` subdirectory

--- a/docs/src/content/docs/reference/cli/view.md
+++ b/docs/src/content/docs/reference/cli/view.md
@@ -38,7 +38,7 @@ Output includes: name, version, description, author, source, install path, lockf
 
 Lists available versions for the package. Calls the remote -- requires network access.
 
-For git packages, output is a table with name, type (`tag` or `branch`), and short commit SHA. For installed registry packages, `apm view` reads the lockfile source and queries the configured registry, then prints version and published timestamp columns. Private git repositories require `GITHUB_APM_PAT`; private registries use the registry token configured for that registry (see [authentication](../../../consumer/authentication/)).
+For git packages, output is a table with name, type (`tag` or `branch`), and short commit SHA. For registry packages, output is a version and published-timestamp table. Registry packages are identified by three signals checked in order: (1) the `--registry [NAME]` flag forces the registry path; (2) a `source: registry` entry in `apm.lock.yaml` routes the package to the registry that installed it; (3) a configured default registry causes plain shorthands (e.g., `owner/repo`) to route to the registry even without a lockfile entry -- use a full git URL to override this. Private git repositories require `GITHUB_APM_PAT`; private registries use the registry token configured for that registry (see [authentication](../../../consumer/authentication/)).
 
 ## Arguments
 

--- a/docs/src/content/docs/reference/cli/view.md
+++ b/docs/src/content/docs/reference/cli/view.md
@@ -20,7 +20,7 @@ apm view PACKAGE [FIELD] [OPTIONS]
 `apm view` has two modes, selected by the optional `FIELD` argument:
 
 - **No field** -- read installed package metadata from `apm_modules/` (or `~/.apm/apm_modules/` with `-g`). Local-only; the package must be installed.
-- **`versions` field** -- query available versions. Git packages list remote tags and branches without requiring a local install. Registry packages list version and published-timestamp columns. Registry routing uses the first matching signal: (1) `--registry [NAME]` flag, (2) `apm.lock.yaml` records the package as a registry dependency, (3) a default registry is configured and the package reference is a plain shorthand (e.g., `owner/repo`). Use a full git URL to force the git path when a default registry is configured.
+- **`versions` field** -- query available versions. Git packages list remote tags and branches without requiring a local install. Registry packages list version and published-timestamp columns. See the `apm view <package> versions` subcommand below for the full registry-routing precedence and escape-hatch details.
 
 When `PACKAGE` matches the `NAME@MARKETPLACE` pattern, `apm view` resolves the plugin against the marketplace manifest and prints its entry (name, version, description, source, tags) instead of a Git repository view. This applies whether or not `versions` is passed.
 

--- a/docs/src/content/docs/reference/cli/view.md
+++ b/docs/src/content/docs/reference/cli/view.md
@@ -20,7 +20,7 @@ apm view PACKAGE [FIELD] [OPTIONS]
 `apm view` has two modes, selected by the optional `FIELD` argument:
 
 - **No field** -- read installed package metadata from `apm_modules/` (or `~/.apm/apm_modules/` with `-g`). Local-only; the package must be installed.
-- **`versions` field** -- query available versions. Git packages list remote tags and branches without requiring a local install. Installed registry packages are detected from `apm.lock.yaml` and list registry versions instead.
+- **`versions` field** -- query available versions. Git packages list remote tags and branches without requiring a local install. Registry packages list version and published-timestamp columns. Registry routing uses the first matching signal: (1) `--registry [NAME]` flag, (2) `apm.lock.yaml` records the package as a registry dependency, (3) a default registry is configured and the package reference is a plain shorthand (e.g., `owner/repo`). Use a full git URL to force the git path when a default registry is configured.
 
 When `PACKAGE` matches the `NAME@MARKETPLACE` pattern, `apm view` resolves the plugin against the marketplace manifest and prints its entry (name, version, description, source, tags) instead of a Git repository view. This applies whether or not `versions` is passed.
 
@@ -49,9 +49,10 @@ For git packages, output is a table with name, type (`tag` or `branch`), and sho
 
 ## Options
 
-| Option           | Description                                  |
-| ---------------- | -------------------------------------------- |
-| `-g`, `--global` | Inspect a package installed in user scope (`~/.apm/apm_modules/`) |
+| Option              | Description                                  |
+| ------------------- | -------------------------------------------- |
+| `-g`, `--global`    | Inspect a package installed in user scope (`~/.apm/apm_modules/`) |
+| `--registry [NAME]` | List versions from a registry. Omit a value to use the lockfile entry or configured default; provide `NAME` to force a specific named registry. Only valid with the `versions` field. |
 
 ## Examples
 
@@ -77,6 +78,24 @@ List registry versions for an installed registry package:
 
 ```bash
 apm view acme/web-skills versions
+```
+
+List versions from the configured default registry (for an unlocked shorthand):
+
+```bash
+apm view acme/web-skills versions --registry
+```
+
+List versions from a specific named registry:
+
+```bash
+apm view acme/web-skills versions --registry my-registry
+```
+
+Force the git path even when a default registry is configured:
+
+```bash
+apm view https://github.com/acme/web-skills versions
 ```
 
 Inspect a package installed at user scope:

--- a/packages/apm-guide/.apm/skills/apm-usage/commands.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/commands.md
@@ -18,7 +18,7 @@
 | `apm deps tree` | Show dependency tree | -- |
 | `apm deps why PKG` | Explain why a package is installed (walks lockfile bottom-up to direct deps; analogue of `npm why` / `yarn why`) | `-g` global, `--json` |
 | `apm find <PATH>` | Trace a deployed file back to the package(s) that contributed it (inverse of install; reads `apm.lock.yaml` only) | `--source` show OCI/git/local origin, `--path` show full why-chain (same as `apm deps why`) |
-| `apm view PKG [FIELD]` | View package details, git refs, or registry versions | `-g` global, `FIELD=versions` |
+| `apm view PKG [FIELD]` | View package details, git refs, or registry versions | `-g` global, `FIELD=versions`, `--registry [NAME]` forces registry path for versions |
 | `apm outdated` | Check locked deps via SHA/semver comparison; patterned per-package tags are auto-detected; full-SHA pins compare against the latest annotated semver tag | `-g` global, `-v` verbose, `-j N` parallel checks |
 | `apm deps info PKG` | Alias for `apm view PKG` local metadata | -- |
 | `apm deps clean` | Clean dependency cache | `--dry-run`, `-y` skip confirm |

--- a/src/apm_cli/commands/view.py
+++ b/src/apm_cli/commands/view.py
@@ -340,8 +340,15 @@ def _display_registry_versions(
     package: str,
     dep_ref: DependencyReference,
     logger: CommandLogger,
+    registry_name: str | None = None,
 ) -> None:
-    """List available versions from the configured registry for a registry dep."""
+    """List available versions from the configured registry for a registry dep.
+
+    *registry_name* forces a specific registry by name (from the merged
+    registries map), bypassing the lockfile/default resolution below. An empty
+    string or ``None`` falls back to the lockfile's recorded registry, then the
+    configured default.
+    """
     from ..deps.registry.auth import resolve_for_url
     from ..deps.registry.client import RegistryClient, RegistryError
     from ..deps.registry.config_loader import resolve_effective_registries
@@ -372,28 +379,39 @@ def _display_registry_versions(
     if registries is None:
         registries = {}
 
+    # An explicit --registry NAME forces that registry, bypassing lockfile and
+    # default resolution.
+    explicit = registry_name or None
+    registry_url = None
+    if explicit:
+        registry_url = registries.get(explicit)
+        if not registry_url:
+            known = ", ".join(sorted(registries)) or "none configured"
+            logger.error(f"Registry '{explicit}' is not configured (known: {known})")
+            sys.exit(1)
+
     # Prefer resolved_url from lockfile: it names the exact registry used for
     # this dep and works for non-default registries without any extra lookup.
-    registry_url = None
-    try:
-        from ..deps.lockfile import LockFile, get_lockfile_path
+    if registry_url is None:
+        try:
+            from ..deps.lockfile import LockFile, get_lockfile_path
 
-        lf_path = get_lockfile_path(Path("."))
-        lf = LockFile.read(lf_path)
-        if lf:
-            locked = lf.dependencies.get(package)
-            if locked is None:
-                for key, d in lf.dependencies.items():
-                    if package in key or key.endswith(f"/{package}"):
-                        locked = d
-                        break
-            if locked and locked.resolved_url:
-                sep = "/v1/packages/"
-                idx = locked.resolved_url.find(sep)
-                if idx != -1:
-                    registry_url = locked.resolved_url[:idx]
-    except Exception:
-        pass
+            lf_path = get_lockfile_path(Path("."))
+            lf = LockFile.read(lf_path)
+            if lf:
+                locked = lf.dependencies.get(package)
+                if locked is None:
+                    for key, d in lf.dependencies.items():
+                        if package in key or key.endswith(f"/{package}"):
+                            locked = d
+                            break
+                if locked and locked.resolved_url:
+                    sep = "/v1/packages/"
+                    idx = locked.resolved_url.find(sep)
+                    if idx != -1:
+                        registry_url = locked.resolved_url[:idx]
+        except Exception:
+            pass
 
     if registry_url is None:
         if not default_registry:
@@ -443,10 +461,47 @@ def _display_registry_versions(
             click.echo(f"{entry.version:<20} {entry.published_at:<30}")
 
 
+def _is_explicit_git_form(package: str) -> bool:
+    """True when *package* is an explicit git reference (URL or SCP form).
+
+    Such references always route to the git path even when a default registry
+    is configured -- they are the escape hatch for viewing git versions,
+    mirroring the ``- git:`` manifest form.
+    """
+    p = package.strip().lower()
+    return "://" in p or p.startswith("git@")
+
+
+def _effective_default_registry(project_root: Path) -> str | None:
+    """Return the effective default registry name (config.json + project apm.yml).
+
+    Returns ``None`` when no default registry is configured or the registry
+    feature is unavailable. Best-effort: any parsing/gate error is treated as
+    "no default" so version lookups fall back to git.
+    """
+    from ..deps.registry.config_loader import resolve_effective_registries
+
+    project_registries = None
+    project_default = None
+    try:
+        apm_yml = project_root / "apm.yml"
+        if apm_yml.is_file():
+            from ..models.apm_package import APMPackage
+
+            pkg = APMPackage.from_apm_yml(apm_yml)
+            project_registries = pkg.registries
+            project_default = pkg.default_registry
+        _, default_registry = resolve_effective_registries(project_registries, project_default)
+    except Exception:
+        return None
+    return default_registry
+
+
 def display_versions(
     package: str,
     logger: CommandLogger,
     project_root: Path | None = None,
+    registry: str | None = None,
 ) -> None:
     """Query and display available remote versions (tags/branches).
 
@@ -460,9 +515,19 @@ def display_versions(
     marketplace manifest is fetched instead and the plugin's marketplace
     metadata is displayed.
 
-    *project_root* is used only to detect registry deps via the lockfile.
-    Pass ``None`` (e.g. for ``--global``) to skip lockfile detection and
-    go straight to the git path.
+    Registry routing (highest precedence first):
+
+    1. ``registry`` is not ``None`` -- ``--registry`` was passed: force the
+       registry path. A non-empty value names the registry; ``""`` uses the
+       lockfile/default. An explicit git URL still overrides nothing here --
+       the flag wins.
+    2. The lockfile records the package as ``source: registry``.
+    3. A default registry is configured and *package* is a plain shorthand
+       (not an explicit git URL) -- mirrors how ``apm install`` routes
+       shorthand to the default registry.
+
+    Otherwise the git path is used. *project_root* scopes the lockfile and
+    apm.yml lookups; pass ``None`` (``--global``) to read from the cwd.
     """
     # -- Marketplace path: NAME@MARKETPLACE --
     from ..marketplace.resolver import parse_marketplace_ref
@@ -480,7 +545,12 @@ def display_versions(
         logger.error(f"Invalid package reference '{package}': {exc}")
         sys.exit(1)
 
-    # Detect registry dep via lockfile and route to registry API.
+    # (1) Explicit --registry forces the registry path.
+    if registry is not None:
+        _display_registry_versions(package, dep_ref, logger, registry_name=registry or None)
+        return
+
+    # (2) Detect registry dep via lockfile and route to registry API.
     # Only consult the lockfile when we have a project root with an apm.yml;
     # this prevents mis-routing when the user is outside an APM project or
     # running with --global (project_root=None).
@@ -490,6 +560,14 @@ def display_versions(
         if _locked_source == "registry":
             _display_registry_versions(package, dep_ref, logger)
             return
+
+    # (3) No lockfile signal, but a default registry is configured and the
+    # reference is a plain shorthand -- consult the registry, mirroring how
+    # `apm install` routes unscoped shorthands to the default registry. An
+    # explicit git URL is the escape hatch to force the git path below.
+    if not _is_explicit_git_form(package) and _effective_default_registry(_pr):
+        _display_registry_versions(package, dep_ref, logger)
+        return
 
     try:
         downloader = GitHubPackageDownloader(auth_resolver=AuthResolver())
@@ -550,9 +628,12 @@ _VIEW_HELP = (
     "    versions    List available remote tags and branches\n\n"
     "\b\n"
     "Examples:\n"
-    "    apm view org/repo                # Local metadata\n"
-    "    apm view org/repo versions       # Remote tags/branches\n"
-    "    apm view org/repo -g             # From user scope"
+    "    apm view org/repo                       # Local metadata\n"
+    "    apm view org/repo versions              # Remote tags/branches (or registry)\n"
+    "    apm view org/repo versions --registry   # From the default registry\n"
+    "    apm view org/repo versions --registry myreg  # From a named registry\n"
+    "    apm view https://github.com/org/repo versions  # Force the git path\n"
+    "    apm view org/repo -g                    # From user scope"
 )
 
 
@@ -571,7 +652,17 @@ _VIEW_HELP = (
     default=False,
     help="Inspect package from user scope (~/.apm/)",
 )
-def view(package: str, field: str | None, global_: bool):
+@click.option(
+    "--registry",
+    "registry",
+    is_flag=False,
+    flag_value="",
+    default=None,
+    metavar="[NAME]",
+    help="List versions from a registry (bare to use the default, or name one). "
+    "Use a full git URL to force the git path instead.",
+)
+def view(package: str, field: str | None, global_: bool, registry: str | None):
     """View package metadata or list remote versions."""
     from ..core.scope import InstallScope, get_apm_dir
 
@@ -585,7 +676,12 @@ def view(package: str, field: str | None, global_: bool):
             sys.exit(1)
 
         if field == "versions":
-            display_versions(package, logger, project_root=None if global_ else Path("."))
+            display_versions(
+                package,
+                logger,
+                project_root=None if global_ else Path("."),
+                registry=registry,
+            )
             return
 
     # --- marketplace ref without explicit field -> show versions ---

--- a/src/apm_cli/commands/view.py
+++ b/src/apm_cli/commands/view.py
@@ -476,6 +476,8 @@ def _is_explicit_git_form(package: str) -> bool:
     (``owner/repo`` with an optional ``#ref``) has neither in that segment.
     """
     p = package.strip()
+    if p.startswith("./") or p.startswith("../") or p.startswith("/"):
+        return True
     if "://" in p or p.lower().endswith(".git"):
         return True
     head = p.split("/", 1)[0]
@@ -586,9 +588,14 @@ def display_versions(
     # reference is a plain shorthand -- consult the registry, mirroring how
     # `apm install` routes unscoped shorthands to the default registry. An
     # explicit git URL is the escape hatch to force the git path below.
-    if not _is_explicit_git_form(package) and _effective_default_registry(_pr):
-        _display_registry_versions(package, dep_ref, logger)
-        return
+    if not _is_explicit_git_form(package):
+        _default_reg = _effective_default_registry(_pr)
+        if _default_reg:
+            logger.info(
+                f"Routing to registry '{_default_reg}' (use a git URL to force the git path)"
+            )
+            _display_registry_versions(package, dep_ref, logger, registry_name=_default_reg)
+            return
 
     try:
         downloader = GitHubPackageDownloader(auth_resolver=AuthResolver())

--- a/src/apm_cli/commands/view.py
+++ b/src/apm_cli/commands/view.py
@@ -462,14 +462,24 @@ def _display_registry_versions(
 
 
 def _is_explicit_git_form(package: str) -> bool:
-    """True when *package* is an explicit git reference (URL or SCP form).
+    """True when *package* is an explicit git reference (URL, SCP, or .git).
 
     Such references always route to the git path even when a default registry
     is configured -- they are the escape hatch for viewing git versions,
     mirroring the ``- git:`` manifest form.
+
+    Covers transport-scheme URLs (``https://``, ``ssh://``, ``git://``),
+    ``.git`` suffixes, and SCP-style ``user@host:path`` refs for ANY user
+    (not just ``git@``) -- ``DependencyReference.parse`` accepts arbitrary SSH
+    usernames, so the SCP check looks for ``@`` and ``:`` in the segment before
+    the first ``/`` rather than a literal ``git@`` prefix. A bare shorthand
+    (``owner/repo`` with an optional ``#ref``) has neither in that segment.
     """
-    p = package.strip().lower()
-    return "://" in p or p.startswith("git@")
+    p = package.strip()
+    if "://" in p or p.lower().endswith(".git"):
+        return True
+    head = p.split("/", 1)[0]
+    return "@" in head and ":" in head
 
 
 def _effective_default_registry(project_root: Path) -> str | None:
@@ -478,8 +488,19 @@ def _effective_default_registry(project_root: Path) -> str | None:
     Returns ``None`` when no default registry is configured or the registry
     feature is unavailable. Best-effort: any parsing/gate error is treated as
     "no default" so version lookups fall back to git.
+
+    Honors the registries experimental feature gate, mirroring
+    ``install/registry_wiring.get_effective_default_registry`` -- when registries
+    are disabled, shorthand routing must not silently use a config.json default.
     """
     from ..deps.registry.config_loader import resolve_effective_registries
+    from ..deps.registry.feature_gate import is_package_registry_enabled
+
+    try:
+        if not is_package_registry_enabled():
+            return None
+    except Exception:
+        return None
 
     project_registries = None
     project_default = None

--- a/src/apm_cli/commands/view.py
+++ b/src/apm_cli/commands/view.py
@@ -696,6 +696,10 @@ def view(package: str, field: str | None, global_: bool, registry: str | None):
 
     logger = CommandLogger("view")
 
+    # Warn if --registry is supplied without the versions field (flag is ignored).
+    if registry is not None and field != "versions":
+        logger.warning("--registry is only valid with the versions field; flag ignored")
+
     # --- field validation (before any I/O) ---
     if field is not None:
         if field not in VALID_FIELDS:

--- a/tests/integration/test_view_coverage.py
+++ b/tests/integration/test_view_coverage.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from click.testing import CliRunner
 
+from apm_cli.cli import cli
 from apm_cli.commands.view import (
     _lookup_lockfile_ref,
     resolve_package_path,
@@ -163,3 +166,64 @@ class TestLookupLockfileRef:
 
             assert ref == ""
             assert commit == ""
+
+
+class TestViewVersionsRegistryRouting:
+    """Integration tests for the --registry CLI surface.
+
+    These tests exercise the real Click-decorated ``view`` command with a
+    real ``apm.yml`` fixture on disk.  Only external I/O is mocked:
+    ``resolve_effective_registries``, ``resolve_for_url``, and
+    ``RegistryClient``.  This verifies that the ``--registry NAME`` flag
+    routes through ``_display_registry_versions`` and renders the
+    version/published-timestamp table, and that ``--registry UNKNOWN``
+    exits 1 with an informative error message.
+    """
+
+    def test_registry_flag_routes_to_named_registry(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--registry NAME routes to the named registry and prints version data."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "apm.yml").write_text("name: test-project\nversion: 1.0.0\n")
+
+        mock_entry = SimpleNamespace(version="2.3.0", published_at="2024-06-01")
+
+        with (
+            patch(
+                "apm_cli.deps.registry.config_loader.resolve_effective_registries",
+                return_value=({"my-registry": "https://example.com/r"}, "my-registry"),
+            ),
+            patch("apm_cli.deps.registry.auth.resolve_for_url", return_value=None),
+            patch("apm_cli.deps.registry.client.RegistryClient") as mock_cls,
+        ):
+            mock_cls.return_value.list_versions.return_value = [mock_entry]
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                ["view", "acme/web-skills", "versions", "--registry", "my-registry"],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "2.3.0" in result.output
+
+    def test_registry_flag_unknown_name_exits_one(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--registry UNKNOWN exits 1 and names the missing registry."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "apm.yml").write_text("name: test-project\nversion: 1.0.0\n")
+
+        with patch(
+            "apm_cli.deps.registry.config_loader.resolve_effective_registries",
+            return_value=({"known-reg": "https://example.com/r"}, "known-reg"),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli,
+                ["view", "acme/web-skills", "versions", "--registry", "unknown-name"],
+            )
+
+        assert result.exit_code == 1
+        assert "unknown-name" in result.output
+        assert "not configured" in result.output

--- a/tests/unit/test_view_command.py
+++ b/tests/unit/test_view_command.py
@@ -298,6 +298,50 @@ class TestViewCommand(_InfoCmdBase):
         assert mock_reg.call_args.kwargs.get("registry_name") == "myreg"
         mock_gh.return_value.list_remote_refs.assert_not_called()
 
+    def test_view_versions_bare_registry_flag_forces_registry(self):
+        """Bare --registry (no NAME) parses as an empty value and forces the registry.
+
+        Guards against Click option drift (e.g. --registry accidentally becoming
+        value-required). registry_name is passed as None so the lockfile/default
+        registry is used.
+        """
+        with self._chdir_tmp() as tmp:
+            (tmp / "apm.yml").write_text("name: testproject\nversion: 1.0.0\n")
+            with (
+                patch("apm_cli.commands.view._display_registry_versions") as mock_reg,
+                patch("apm_cli.commands.view.GitHubPackageDownloader") as mock_gh,
+            ):
+                result = self.runner.invoke(cli, ["view", "myorg/myrepo", "versions", "--registry"])
+        assert result.exit_code == 0
+        mock_reg.assert_called_once()
+        # "" (bare flag) is normalized to None -> use lockfile/default registry.
+        assert mock_reg.call_args.kwargs.get("registry_name") is None
+        mock_gh.return_value.list_remote_refs.assert_not_called()
+
+    def test_view_versions_scp_git_ref_forces_git_even_with_default_registry(self):
+        """An SCP-style git ref (arbitrary user) routes to git, not the registry."""
+        with self._chdir_tmp() as tmp:
+            (tmp / "apm.yml").write_text("name: testproject\nversion: 1.0.0\n")
+            with (
+                patch(
+                    "apm_cli.commands.view._lookup_lockfile_ref",
+                    return_value=("", "", ""),
+                ),
+                patch(
+                    "apm_cli.commands.view._effective_default_registry",
+                    return_value="jfrog-demo",
+                ),
+                patch("apm_cli.commands.view._display_registry_versions") as mock_reg,
+                patch("apm_cli.commands.view.GitHubPackageDownloader") as mock_gh,
+            ):
+                mock_gh.return_value.list_remote_refs.return_value = []
+                result = self.runner.invoke(
+                    cli, ["view", "alice@github.com:myorg/myrepo", "versions"]
+                )
+        assert result.exit_code == 0
+        mock_reg.assert_not_called()
+        mock_gh.return_value.list_remote_refs.assert_called_once()
+
     def test_view_versions_explicit_git_url_forces_git_even_with_default_registry(self):
         """A full git URL routes to git even when a default registry is configured."""
         with self._chdir_tmp() as tmp:
@@ -795,3 +839,48 @@ class TestViewMarketplaceNoField(_InfoCmdBase):
 
         assert result.exit_code == 0
         assert "1.0.0" in result.output
+
+
+class TestEffectiveDefaultRegistry:
+    """_effective_default_registry honors the registries feature gate."""
+
+    def test_returns_none_when_registry_feature_disabled(self, tmp_path) -> None:
+        """A config.json default must not route view->registry when registries are off.
+
+        Mirrors install/registry_wiring.get_effective_default_registry, which
+        short-circuits to None when is_package_registry_enabled() is False.
+        """
+        from apm_cli.commands.view import _effective_default_registry
+
+        with (
+            patch(
+                "apm_cli.deps.registry.feature_gate.is_package_registry_enabled",
+                return_value=False,
+            ),
+            patch(
+                "apm_cli.deps.registry.config_loader.resolve_effective_registries",
+                return_value=({"jfrog-demo": "https://example/r"}, "jfrog-demo"),
+            ) as mock_resolve,
+        ):
+            result = _effective_default_registry(tmp_path)
+
+        assert result is None
+        # Gate short-circuits before any registry resolution happens.
+        mock_resolve.assert_not_called()
+
+    def test_returns_default_when_enabled(self, tmp_path) -> None:
+        from apm_cli.commands.view import _effective_default_registry
+
+        with (
+            patch(
+                "apm_cli.deps.registry.feature_gate.is_package_registry_enabled",
+                return_value=True,
+            ),
+            patch(
+                "apm_cli.deps.registry.config_loader.resolve_effective_registries",
+                return_value=({"jfrog-demo": "https://example/r"}, "jfrog-demo"),
+            ),
+        ):
+            result = _effective_default_registry(tmp_path)
+
+        assert result == "jfrog-demo"

--- a/tests/unit/test_view_command.py
+++ b/tests/unit/test_view_command.py
@@ -899,3 +899,111 @@ class TestEffectiveDefaultRegistry:
             result = _effective_default_registry(tmp_path)
 
         assert result == "jfrog-demo"
+
+
+class TestDisplayRegistryVersions:
+    """Direct tests for _display_registry_versions error and output paths."""
+
+    runner = CliRunner()
+
+    def test_unknown_registry_name_exits_with_error(self, tmp_path) -> None:
+        """An explicit --registry NAME that does not exist in config exits 1."""
+        from apm_cli.commands.view import _display_registry_versions
+        from apm_cli.core.command_logger import CommandLogger
+        from apm_cli.models.dependency.reference import DependencyReference
+
+        dep_ref = DependencyReference.parse("acme/web-skills")
+        logger = CommandLogger("test")
+
+        with (
+            patch(
+                "apm_cli.deps.registry.config_loader.resolve_effective_registries",
+                return_value=({"known-reg": "https://known.example"}, "known-reg"),
+            ),
+            pytest.raises(SystemExit, match=r"1"),
+        ):
+            _display_registry_versions(
+                dep_ref.repo_url, dep_ref, logger, registry_name="no-such-reg"
+            )
+
+    def test_no_registry_configured_exits_with_error(self, tmp_path) -> None:
+        """When no registry is configured at all, _display_registry_versions exits 1."""
+        from apm_cli.commands.view import _display_registry_versions
+        from apm_cli.core.command_logger import CommandLogger
+        from apm_cli.models.dependency.reference import DependencyReference
+
+        dep_ref = DependencyReference.parse("acme/web-skills")
+        logger = CommandLogger("test")
+
+        with (
+            patch(
+                "apm_cli.deps.registry.config_loader.resolve_effective_registries",
+                return_value=(None, None),
+            ),
+            patch(
+                "apm_cli.deps.lockfile.LockFile.read",
+                return_value=None,
+            ),
+            pytest.raises(SystemExit, match=r"1"),
+        ):
+            _display_registry_versions("acme/web-skills", dep_ref, logger, registry_name=None)
+
+    def test_registry_client_error_exits_with_error(self) -> None:
+        """RegistryError from the client is caught and exits 1."""
+        from apm_cli.commands.view import _display_registry_versions
+        from apm_cli.core.command_logger import CommandLogger
+        from apm_cli.deps.registry.client import RegistryError
+        from apm_cli.models.dependency.reference import DependencyReference
+
+        dep_ref = DependencyReference.parse("acme/web-skills")
+        logger = CommandLogger("test")
+
+        with (
+            patch(
+                "apm_cli.deps.registry.config_loader.resolve_effective_registries",
+                return_value=({"my-reg": "https://reg.example"}, "my-reg"),
+            ),
+            patch(
+                "apm_cli.deps.registry.auth.resolve_for_url",
+                return_value=None,
+            ),
+            patch(
+                "apm_cli.deps.registry.client.RegistryClient.list_versions",
+                side_effect=RegistryError("connection refused"),
+            ),
+            pytest.raises(SystemExit, match=r"1"),
+        ):
+            _display_registry_versions("acme/web-skills", dep_ref, logger, registry_name=None)
+
+    def test_happy_path_returns_versions(self) -> None:
+        """Happy path: RegistryClient returns versions and the function returns normally."""
+        from apm_cli.commands.view import _display_registry_versions
+        from apm_cli.core.command_logger import CommandLogger
+        from apm_cli.models.dependency.reference import DependencyReference
+
+        dep_ref = DependencyReference.parse("acme/web-skills")
+        logger = CommandLogger("test")
+
+        version_entry = MagicMock()
+        version_entry.version = "1.2.3"
+        version_entry.published_at = "2025-01-01T00:00:00Z"
+
+        with (
+            patch(
+                "apm_cli.deps.registry.config_loader.resolve_effective_registries",
+                return_value=({"my-reg": "https://reg.example"}, "my-reg"),
+            ),
+            patch(
+                "apm_cli.deps.registry.auth.resolve_for_url",
+                return_value=None,
+            ),
+            patch(
+                "apm_cli.deps.registry.client.RegistryClient.list_versions",
+                return_value=[version_entry],
+            ),
+            patch("rich.console.Console") as mock_console_cls,
+        ):
+            mock_console = MagicMock()
+            mock_console_cls.return_value = mock_console
+            # Should not raise or exit
+            _display_registry_versions("acme/web-skills", dep_ref, logger, registry_name=None)

--- a/tests/unit/test_view_command.py
+++ b/tests/unit/test_view_command.py
@@ -235,6 +235,93 @@ class TestViewCommand(_InfoCmdBase):
         mock_reg.assert_called_once()
         mock_gh.return_value.list_remote_refs.assert_not_called()
 
+    def test_view_versions_routes_unlocked_shorthand_to_default_registry(self):
+        """No lockfile signal, but a default registry is configured -> registry API.
+
+        Mirrors how ``apm install`` routes an unscoped shorthand to the default
+        registry. Without this the unlocked shorthand fell through to git.
+        """
+        with self._chdir_tmp() as tmp:
+            (tmp / "apm.yml").write_text("name: testproject\nversion: 1.0.0\n")
+            with (
+                patch(
+                    "apm_cli.commands.view._lookup_lockfile_ref",
+                    return_value=("", "", ""),  # not in lockfile
+                ),
+                patch(
+                    "apm_cli.commands.view._effective_default_registry",
+                    return_value="jfrog-demo",
+                ),
+                patch("apm_cli.commands.view._display_registry_versions") as mock_reg,
+                patch("apm_cli.commands.view.GitHubPackageDownloader") as mock_gh,
+            ):
+                result = self.runner.invoke(cli, ["view", "myorg/myrepo", "versions"])
+        assert result.exit_code == 0
+        mock_reg.assert_called_once()
+        mock_gh.return_value.list_remote_refs.assert_not_called()
+
+    def test_view_versions_unlocked_shorthand_no_default_uses_git(self):
+        """No lockfile signal and no default registry -> git path (keeps git working)."""
+        with self._chdir_tmp() as tmp:
+            (tmp / "apm.yml").write_text("name: testproject\nversion: 1.0.0\n")
+            with (
+                patch(
+                    "apm_cli.commands.view._lookup_lockfile_ref",
+                    return_value=("", "", ""),
+                ),
+                patch(
+                    "apm_cli.commands.view._effective_default_registry",
+                    return_value=None,
+                ),
+                patch("apm_cli.commands.view._display_registry_versions") as mock_reg,
+                patch("apm_cli.commands.view.GitHubPackageDownloader") as mock_gh,
+            ):
+                mock_gh.return_value.list_remote_refs.return_value = []
+                result = self.runner.invoke(cli, ["view", "myorg/myrepo", "versions"])
+        assert result.exit_code == 0
+        mock_reg.assert_not_called()
+        mock_gh.return_value.list_remote_refs.assert_called_once()
+
+    def test_view_versions_explicit_registry_flag_forces_registry(self):
+        """--registry NAME forces the registry path and passes the name through."""
+        with self._chdir_tmp() as tmp:
+            (tmp / "apm.yml").write_text("name: testproject\nversion: 1.0.0\n")
+            with (
+                patch("apm_cli.commands.view._display_registry_versions") as mock_reg,
+                patch("apm_cli.commands.view.GitHubPackageDownloader") as mock_gh,
+            ):
+                result = self.runner.invoke(
+                    cli, ["view", "myorg/myrepo", "versions", "--registry", "myreg"]
+                )
+        assert result.exit_code == 0
+        mock_reg.assert_called_once()
+        assert mock_reg.call_args.kwargs.get("registry_name") == "myreg"
+        mock_gh.return_value.list_remote_refs.assert_not_called()
+
+    def test_view_versions_explicit_git_url_forces_git_even_with_default_registry(self):
+        """A full git URL routes to git even when a default registry is configured."""
+        with self._chdir_tmp() as tmp:
+            (tmp / "apm.yml").write_text("name: testproject\nversion: 1.0.0\n")
+            with (
+                patch(
+                    "apm_cli.commands.view._lookup_lockfile_ref",
+                    return_value=("", "", ""),
+                ),
+                patch(
+                    "apm_cli.commands.view._effective_default_registry",
+                    return_value="jfrog-demo",
+                ),
+                patch("apm_cli.commands.view._display_registry_versions") as mock_reg,
+                patch("apm_cli.commands.view.GitHubPackageDownloader") as mock_gh,
+            ):
+                mock_gh.return_value.list_remote_refs.return_value = []
+                result = self.runner.invoke(
+                    cli, ["view", "https://github.com/myorg/myrepo", "versions"]
+                )
+        assert result.exit_code == 0
+        mock_reg.assert_not_called()
+        mock_gh.return_value.list_remote_refs.assert_called_once()
+
     # -- invalid field ----------------------------------------------------
 
     def test_view_invalid_field(self):

--- a/tests/unit/test_view_command.py
+++ b/tests/unit/test_view_command.py
@@ -342,6 +342,21 @@ class TestViewCommand(_InfoCmdBase):
         mock_reg.assert_not_called()
         mock_gh.return_value.list_remote_refs.assert_called_once()
 
+    def test_view_versions_unknown_registry_name_exits_with_error(self):
+        """--registry UNKNOWN exits 1 and names the missing registry in the error message."""
+        with self._chdir_tmp() as tmp:
+            (tmp / "apm.yml").write_text("name: testproject\nversion: 1.0.0\n")
+            with patch(
+                "apm_cli.deps.registry.config_loader.resolve_effective_registries",
+                return_value=({"known-registry": "https://example.com/r"}, "known-registry"),
+            ):
+                result = self.runner.invoke(
+                    cli, ["view", "myorg/myrepo", "versions", "--registry", "nonexistent"]
+                )
+        assert result.exit_code == 1
+        assert "nonexistent" in result.output
+        assert "not configured" in result.output
+
     def test_view_versions_explicit_git_url_forces_git_even_with_default_registry(self):
         """A full git URL routes to git even when a default registry is configured."""
         with self._chdir_tmp() as tmp:


### PR DESCRIPTION
## Summary

`apm view <pkg> versions` decided registry-vs-git **only** from the lockfile, so an *unlocked* shorthand fell through to `git ls-remote` even when a default registry was configured. That contradicts `apm install`, which already routes unscoped shorthands to the default registry:

```console
# default registry configured; package not yet installed
$ apm view jfrog/packages-skills versions
[x] Failed to list versions ... Authentication failed for list refs on github.com.   # before
```

It now consults the default registry for unlocked shorthands, and adds an explicit `--registry [NAME]` override.

## Routing precedence (`display_versions`)

1. **`--registry [NAME]`** -- force the registry path. Bare uses the lockfile/default; a value names a specific registry (clear error if unknown).
2. **Lockfile** records the package as `source: registry` (existing behavior).
3. **Default registry configured + plain shorthand** -- consult the registry, mirroring `apm install`. An explicit git URL (`https://github.com/...`) stays on the git path.
4. Otherwise -- git.

A full git URL is the escape hatch to force git when a default registry is set (the `view` analog of the `- git:` manifest form).

## Why this is low-risk

All paths here are **read-only** -- no install, no resolution, no lockfile mutation. This is the read-only sibling of the deferred default-registry-vs-git-transitives discussion, without any of that risk. `_display_registry_versions` already resolved the default registry for unlocked packages (it just wasn't reached); this wires the routing and adds explicit name support.

## Behavior

| Invocation (default registry configured) | Before | After |
|---|---|---|
| `view org/repo versions` (unlocked shorthand) | git ls-remote (404/auth fail) | default registry |
| `view org/repo versions` (locked as registry) | registry | registry (unchanged) |
| `view org/repo versions --registry` | n/a (flag new) | default registry |
| `view org/repo versions --registry NAME` | n/a | named registry (error if unknown) |
| `view https://github.com/org/repo versions` | git | git (escape hatch) |
| no default registry configured | git | git (unchanged) |

## Tests

4 new cases in `tests/unit/test_view_command.py`: default-registry routing for unlocked shorthand, no-default-still-git, `--registry NAME` forces + threads the name, and git-URL-forces-git. 331 view/registry tests pass; ruff clean. Verified live against a JFrog registry (unlocked listing, named registry, unknown-name error, git escape).

apm-spec-waiver: read-only display routing -- makes `view versions` consult the configured default registry consistently with `install`; no install, resolution, or lockfile behavior changes