### PR TITLE
fix(cli): point version-check hint to apm self-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed startup version-check hint to reference `apm self-update` instead
+  of the deprecated `apm update` command. (by @syf2211; closes #1939) (#1943)
 - `apm outdated` tag-pattern matching for monorepo virtual subdirectory
   dependencies now derives the `{name}` segment from the `virtual_path`
   basename (e.g., `packages/my-pkg` -> `my-pkg`), aligning with `apm update`

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ curl -sSL https://aka.ms/apm-unix | sh
 irm https://aka.ms/apm-windows | iex
 ```
 
-Native release binaries are published for macOS, Linux, and Windows x86_64. `apm update` reuses the matching platform installer.
+Native release binaries are published for macOS, Linux, and Windows x86_64. `apm self-update` reuses the matching platform installer.
 
 <details>
 <summary>Other install methods</summary>

--- a/src/apm_cli/update_policy.py
+++ b/src/apm_cli/update_policy.py
@@ -46,5 +46,5 @@ def get_self_update_disabled_message() -> str:
 def get_update_hint_message() -> str:
     """Return the update hint used in startup notifications."""
     if is_self_update_enabled():
-        return "Run apm update to upgrade"
+        return "Run apm self-update to upgrade"
     return get_self_update_disabled_message()

--- a/tests/integration/test_utils_logic_phase4w3.py
+++ b/tests/integration/test_utils_logic_phase4w3.py
@@ -286,7 +286,7 @@ class TestUpdatePolicy:
 
         with patch.object(policy, "SELF_UPDATE_ENABLED", True):
             hint = policy.get_update_hint_message()
-        assert "apm update" in hint
+        assert "apm self-update" in hint
 
     def test_get_update_hint_disabled(self) -> None:
         import apm_cli.update_policy as policy

--- a/tests/integration/test_version_notification.py
+++ b/tests/integration/test_version_notification.py
@@ -30,7 +30,7 @@ class TestVersionNotificationIntegration(unittest.TestCase):
             # Check that update notification appears in output
             self.assertIn("A new version", result.output)
             self.assertIn("0.7.0", result.output)
-            self.assertIn("apm update", result.output)
+            self.assertIn("apm self-update", result.output)
 
     @patch("apm_cli.commands._helpers.check_for_updates")
     def test_no_notification_when_up_to_date(self, mock_check):
@@ -45,7 +45,7 @@ class TestVersionNotificationIntegration(unittest.TestCase):
 
             # Check that update notification does NOT appear
             self.assertNotIn("A new version", result.output)
-            self.assertNotIn("apm update", result.output)
+            self.assertNotIn("apm self-update", result.output)
 
     @patch("apm_cli.commands._helpers.check_for_updates")
     def test_notification_does_not_block_command(self, mock_check):

--- a/tests/unit/test_update_policy.py
+++ b/tests/unit/test_update_policy.py
@@ -156,10 +156,10 @@ class TestGetSelfUpdateDisabledMessage:
 class TestGetUpdateHintMessage:
     """Tests for get_update_hint_message()."""
 
-    def test_returns_run_apm_update_when_enabled(self) -> None:
+    def test_returns_run_apm_self_update_when_enabled(self) -> None:
         with patch.object(policy_mod, "SELF_UPDATE_ENABLED", True):
             result = get_update_hint_message()
-        assert result == "Run apm update to upgrade"
+        assert result == "Run apm self-update to upgrade"
 
     def test_returns_disabled_message_when_disabled(self) -> None:
         custom = "Use your package manager to update."


### PR DESCRIPTION
## Description

When APM detects a newer CLI release at startup, the notification hint now
suggests `apm self-update` instead of the deprecated `apm update` command.
Following the old hint sent users to a command that immediately warned about
its own deprecation.

Fixes #1939

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

Updated existing unit and integration tests that assert the startup hint text.

## Spec conformance (OpenAPM v0.1)

- [ ] Spec edit: `docs/src/content/docs/specs/openapm-v0.1.md` updated
- [ ] Manifest edit: `docs/src/content/docs/specs/manifests/openapm-v0.1.requirements.yml` updated
- [ ] Test edit: a `@pytest.mark.req("req-XXX")` test under `tests/spec_conformance/` added or extended.
- [ ] `CONFORMANCE.{md,json}` regenerated
- [x] N/A -- this PR does not change OpenAPM-observable behaviour.
