### PR TITLE
fix(docs): enable GFM table rendering in Starlight docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed startup version-check hint to reference `apm self-update` instead
   of the deprecated `apm update` command. (by @syf2211; closes #1939) (#1943)
+- Fixed GFM table rendering in the documentation site by enabling `markdown.gfm` in the Astro
+  config, restoring pipe tables, strikethrough, and task-list support for all `.mdx` content.
+  (by @syf2211; closes #1940) (#1944)
 - `apm outdated` tag-pattern matching for monorepo virtual subdirectory
   dependencies now derives the `{name}` segment from the `virtual_path`
   basename (e.g., `packages/my-pkg` -> `my-pkg`), aligning with `apm update`

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -10,6 +10,9 @@ import mermaid from 'astro-mermaid';
 export default defineConfig({
 	site: 'https://microsoft.github.io',
 	base: '/apm/',
+	markdown: {
+		gfm: true,
+	},
 	trailingSlash: 'always',
 	prefetch: {
 		prefetchAll: true,


### PR DESCRIPTION
## Summary

Enable GFM (GitHub Flavored Markdown) in the Astro docs config so pipe tables render correctly across the site.

## Motivation

Fixes #1940. GFM tables (e.g. the "What to commit" section on the quickstart page) were rendering as raw pipe text instead of HTML tables. This is a known regression with Astro 6.4 + Starlight 0.38.x where `markdown.gfm` is no longer enabled by default.

## Changes

- Add `markdown: { gfm: true }` to `docs/astro.config.mjs`
- Restores GFM table, strikethrough, and task-list support for all `.mdx` content files

## Tests

- `cd docs && npm ci && npm run build` — passed (122 pages built, all internal links valid)
- Verified `dist/quickstart/index.html` now contains a proper `<table>` element for the "What to commit" section

## Notes

This is the minimal workaround for the current Starlight 0.38.4 pin. A follow-up Starlight upgrade to 0.40.0+ (which includes the canonical fix in withastro/starlight#3923) can be done separately to avoid broader dependency churn in this PR.