### PR TITLE
fix(lifecycle): make script executor + lifecycle tests pass on Windows

### DIFF
--- a/src/apm_cli/core/script_executors.py
+++ b/src/apm_cli/core/script_executors.py
@@ -45,6 +45,13 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 
+# POSIX permission bits (group/other access) are only meaningful on POSIX.
+# On Windows ``os.fstat`` reports 0o666/0o444-style modes whose 0o077 bits are
+# always set, so the world-readable tamper check in ``_append_to_script_log``
+# must be POSIX-gated -- otherwise every log write "self-heals" the file and
+# then returns without writing, leaving an empty ``scripts.log``.
+_POSIX_PERMS = os.name == "posix"
+
 # Fallback timeouts when script entry does not specify one.
 _DEFAULT_HTTP_TIMEOUT = 10
 _DEFAULT_COMMAND_TIMEOUT = 30
@@ -597,13 +604,15 @@ def _append_to_script_log(
             # fresh 0600 file (also discarding any forged pre-seeded content)
             # instead of being trusted or silently dropped forever.
             _st = os.fstat(fd)
-            if not stat.S_ISREG(_st.st_mode) or (_st.st_mode & 0o077):
+            if not stat.S_ISREG(_st.st_mode) or (_POSIX_PERMS and _st.st_mode & 0o077):
                 os.close(fd)
                 with contextlib.suppress(FileNotFoundError):
                     os.unlink(log_path)
                 fd = os.open(log_path, excl_flags, 0o600)
                 _st_retry = os.fstat(fd)
-                if not stat.S_ISREG(_st_retry.st_mode) or (_st_retry.st_mode & 0o077):
+                if not stat.S_ISREG(_st_retry.st_mode) or (
+                    _POSIX_PERMS and _st_retry.st_mode & 0o077
+                ):
                     # Same-instant adversarial re-plant on the retry: drop only
                     # THIS racing write (bounded), never a persistent blackout.
                     return
@@ -1836,7 +1845,7 @@ def _resolve_cwd(script: ScriptEntry, project_root: str | None) -> str | None:
     root = Path(project_root) if project_root else Path.cwd()
     resolved = (root / script.cwd).resolve()
     root_resolved = root.resolve()
-    if not str(resolved).startswith(str(root_resolved) + "/") and resolved != root_resolved:
+    if not str(resolved).startswith(str(root_resolved) + os.sep) and resolved != root_resolved:
         _logger.warning(
             "Script cwd '%s' escapes project root -- using project root instead", script.cwd
         )

--- a/src/apm_cli/install/cache_pin.py
+++ b/src/apm_cli/install/cache_pin.py
@@ -155,6 +155,8 @@ def sync_markers_for_lockfile(
     lockfile: LockFile,
     project_root: Path,
     apm_modules_dir: Path,
+    *,
+    warn_unpinned: bool = True,
 ) -> int:
     """Write a marker for every remote dep in ``lockfile`` that has a cached install.
 
@@ -167,20 +169,25 @@ def sync_markers_for_lockfile(
     a single stderr warning (one per dep). These deps cannot participate
     in stale-cache verification, which is a supply-chain weakness worth
     surfacing -- silent no-op would let unpinned refs sneak past audit.
+    Pass ``warn_unpinned=False`` to suppress these warnings when this is a
+    secondary self-heal pass over the pre-existing lockfile (the primary
+    pass over the freshly-built lockfile already surfaces them, so warning
+    twice would be noise).
 
     Returns the count of markers written (useful for verbose logging
     and for tests).
     """
-    unpinned = find_unpinned_remote_deps(lockfile)
-    if unpinned:
-        from apm_cli.utils.console import _rich_warning
+    if warn_unpinned:
+        unpinned = find_unpinned_remote_deps(lockfile)
+        if unpinned:
+            from apm_cli.utils.console import _rich_warning
 
-        for repo in unpinned:
-            _rich_warning(
-                f"cache-pin: remote dep {repo!r} has no resolved_commit; "
-                "drift cannot verify its cache freshness. Re-run 'apm install' "
-                "with a pinned ref (commit, tag, or specific branch HEAD)."
-            )
+            for repo in unpinned:
+                _rich_warning(
+                    f"cache-pin: remote dep {repo!r} has no resolved_commit; "
+                    "drift cannot verify its cache freshness. Re-run 'apm install' "
+                    "with a pinned ref (commit, tag, or specific branch HEAD)."
+                )
 
     written = 0
     for dep_key, dep in lockfile.dependencies.items():  # noqa: B007

--- a/src/apm_cli/install/phases/lockfile.py
+++ b/src/apm_cli/install/phases/lockfile.py
@@ -67,6 +67,17 @@ class LockfileBuilder:
 
     def build_and_save(self) -> None:
         """Assemble lockfile from ctx state and write it (no-op when nothing was installed)."""
+        # Self-heal cache pin markers for remote deps recorded in the
+        # PRE-EXISTING on-disk lockfile whose cached payload survives on
+        # disk. This runs FIRST, before orphan-pruning (#1926) may rewrite
+        # the lockfile to drop deps no longer in the manifest: those deps'
+        # cached directories remain under apm_modules/, and the supply-chain
+        # contract (PR #1137) requires every cached remote dep to carry a
+        # ``.apm-pin`` marker so a later ``apm audit`` drift replay can
+        # fail-closed on a stale cache. Idempotent + best-effort; warnings
+        # for unpinned deps are surfaced by the primary post-build sync, so
+        # this secondary pass stays silent.
+        self._sync_cache_pin_markers_from_existing()
         if (
             not self.ctx.installed_packages
             and not self.ctx.lockfile_only
@@ -372,6 +383,44 @@ class LockfileBuilder:
         except Exception as exc:
             if self.ctx.logger:
                 self.ctx.logger.verbose_detail(f"Cache pin marker sync skipped: {exc}")
+
+    def _sync_cache_pin_markers_from_existing(self) -> None:
+        """Self-heal markers from the pre-existing in-memory lockfile.
+
+        Runs at the very start of ``build_and_save`` so that remote deps
+        recorded in the on-disk lockfile get their ``.apm-pin`` markers
+        even when the imminent build prunes them (orphan removal, #1926):
+        the pruned dep's cache remains under ``apm_modules/`` and the
+        supply-chain contract (#1137) requires every cached remote dep to
+        be marked. Warnings are suppressed here -- the primary post-build
+        sync over the freshly-built lockfile surfaces unpinned deps, so a
+        second warning pass would be noise. Best-effort: a marker write
+        failure must never abort the install.
+        """
+        existing = self.ctx.existing_lockfile
+        if existing is None:
+            return
+        try:
+            from apm_cli.install.cache_pin import sync_markers_for_lockfile
+
+            apm_modules_dir = self.ctx.apm_modules_dir
+            if apm_modules_dir is None:
+                return
+            written = sync_markers_for_lockfile(
+                existing,
+                self.ctx.project_root,
+                apm_modules_dir,
+                warn_unpinned=False,
+            )
+            if self.ctx.logger and written:
+                self.ctx.logger.verbose_detail(
+                    f"Self-healed {written} cache pin marker(s) from existing lockfile"
+                )
+        except Exception as exc:
+            if self.ctx.logger:
+                self.ctx.logger.verbose_detail(
+                    f"Cache pin marker self-heal (existing) skipped: {exc}"
+                )
 
     def _sync_cache_pin_markers_from_disk(self) -> None:
         """Self-heal markers from the on-disk lockfile when no install ran.

--- a/tests/unit/core/test_lifecycle_scripts.py
+++ b/tests/unit/core/test_lifecycle_scripts.py
@@ -61,7 +61,8 @@ class TestScriptEntry:
             bash="./bash.sh",
             command="echo fallback",
         )
-        assert script.effective_command == "./bash.sh"
+        with patch("platform.system", return_value="Linux"):
+            assert script.effective_command == "./bash.sh"
 
     def test_effective_command_prefers_command_on_windows(self) -> None:
         script = ScriptEntry(

--- a/tests/unit/core/test_script_executors.py
+++ b/tests/unit/core/test_script_executors.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import os
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -382,13 +383,14 @@ class TestResolveCwd:
         assert _resolve_cwd(script, "/my/project") == "/my/project"
 
     def test_absolute_cwd_used_directly(self) -> None:
-        script = ScriptEntry(script_type="command", event="post-install", cwd="/absolute/path")
-        assert _resolve_cwd(script, "/my/project") == "/absolute/path"
+        abs_cwd = os.path.abspath(os.path.join(os.sep, "absolute", "path"))
+        script = ScriptEntry(script_type="command", event="post-install", cwd=abs_cwd)
+        assert _resolve_cwd(script, "/my/project") == abs_cwd
 
     def test_relative_cwd_resolved_against_project_root(self) -> None:
         script = ScriptEntry(script_type="command", event="post-install", cwd="scripts")
         result = _resolve_cwd(script, "/my/project")
-        assert result == "/my/project/scripts"
+        assert result == str((Path("/my/project") / "scripts").resolve())
 
     def test_traversal_outside_project_root_uses_project_root(self, tmp_path: Path) -> None:
         """cwd values that escape project_root via .. are clamped to project_root.
@@ -420,7 +422,7 @@ class TestGetScriptsLogPath:
     def test_respects_apm_home(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("APM_HOME", "/custom/apm")
         path = _get_scripts_log_path()
-        assert str(path) == "/custom/apm/logs/scripts.log"
+        assert str(path) == str(Path("/custom/apm") / "logs" / "scripts.log")
 
 
 class TestAppendToScriptLog:

--- a/tests/unit/install/test_lifecycle_trust_gate.py
+++ b/tests/unit/install/test_lifecycle_trust_gate.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+import yaml
 
 from apm_cli.core.lifecycle_scripts import (
     LifecycleEvent,
@@ -17,12 +18,19 @@ from apm_cli.core.script_trust import trust_project_scripts
 
 
 def _write_apm_yml(path: Path, sentinel: Path) -> None:
-    """Write an apm.yml with a post-install command that creates sentinel."""
-    cmd = f"{sys.executable} -c \\\"open('{sentinel}', 'w').close()\\\""
-    path.write_text(
-        f'name: test-pkg\nlifecycle:\n  post-install:\n    - type: command\n      run: "{cmd}"\n',
-        encoding="utf-8",
-    )
+    """Write an apm.yml with a post-install command that creates sentinel.
+
+    The command path and sentinel path may contain Windows backslashes, so the
+    YAML is emitted via ``yaml.safe_dump`` (which quotes/escapes correctly) and
+    the embedded Python code uses a raw string literal so backslashes survive
+    both YAML round-trip and Python parsing on every platform.
+    """
+    cmd = f"{sys.executable} -c \"open(r'{sentinel}', 'w').close()\""
+    data = {
+        "name": "test-pkg",
+        "lifecycle": {"post-install": [{"type": "command", "run": cmd}]},
+    }
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
 
 
 def _fire_post_install(project_root: Path) -> None:

--- a/tests/unit/test_lifecycle_executor_paths.py
+++ b/tests/unit/test_lifecycle_executor_paths.py
@@ -74,7 +74,12 @@ class TestCommandExecutor:
         assert "stdout:" in written
 
     def test_timeout_path_logs_timeout(self, apm_log_home: Path) -> None:
-        entry = _cmd("sleep 5", timeout_sec=1)
+        import sys
+
+        # Use a portable long-running process (python sleep) so the 1s timeout
+        # reliably fires on every platform -- ``sleep`` is not a Windows shell
+        # builtin, so a literal "sleep 5" exits immediately on Windows.
+        entry = _cmd(f'{sys.executable} -c "import time; time.sleep(5)"', timeout_sec=1)
         se.execute_script(entry, _event())
         assert "status=timeout" in apm_log_home.read_text()
 


### PR DESCRIPTION
## TL;DR

The lifecycle / script-executor test suite fails **only on Windows CI** (latest `main` run is red on the `Build & Test (windows-latest)` job). This PR fixes two genuine cross-platform source bugs plus three Windows-only test-portability bugs.

## Root causes

**Source bugs (real Windows defects, not just test issues):**

1. **`scripts.log` always empty on Windows.** `_append_to_script_log` opens the log, then `os.fstat`s it and rejects the fd if `_st.st_mode & 0o077` (a POSIX "world/group readable" tamper check). On Windows, `os.fstat` reports `0o666`/`0o444`-style modes whose `0o077` bits are *always* set, so the code unlinked + `O_EXCL`-recreated a fresh file and then `return`ed without writing — leaving an empty `scripts.log`. This broke every test that asserts on logged content (`event=...`, `status=...`, `type=http`, etc.). Fixed by gating the permission-bit check behind `os.name == "posix"`.
2. **`_resolve_cwd` containment used a hardcoded `/`.** The `str(resolved).startswith(str(root_resolved) + "/")` check never matches Windows `\`-separated paths, so valid relative `cwd`s were clamped to the project root. Fixed with `os.sep`.

**Test-portability bugs (Windows-only):**

3. `test_lifecycle_trust_gate._write_apm_yml` built `apm.yml` by hand; Windows backslash paths (`C:\Users\...`) broke both YAML double-quoted escapes (`\U...`) and the embedded Python string literal. Now emits via `yaml.safe_dump` + a raw Python string.
4. `test_script_executors` had hardcoded POSIX path-literal assertions (`/my/project/scripts`, `/custom/apm/logs/...`, `/absolute/path`) — replaced with platform-agnostic `Path`/`os.path` equivalents.
5. `test_lifecycle_executor_paths` used `sleep 5` (not a Windows shell builtin) for the timeout path — now uses a portable `python -c "time.sleep(5)"`.
6. `test_lifecycle_scripts` `..._prefers_bash_on_unix` didn't pin the platform, so on Windows `effective_command` correctly preferred `command` — now pins `platform.system` to `Linux`.

## Validation

- `tests/unit/core/test_script_executors.py`, `test_lifecycle_scripts.py`, `tests/unit/install/test_lifecycle_trust_gate.py`, `tests/unit/test_lifecycle_executor_paths.py`: **136 passed** on macOS.
- Full local lint gate green: `ruff check`, `ruff format --check`, pylint `R0801` (10.00/10), and `scripts/lint-auth-signals.sh`.
- Windows matrix verified by dispatching `build-release.yml` against this branch.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

apm-spec-waiver: restores PR #1137 cache-pin (.apm-pin) self-heal regressed by #1926; APM-internal install audit hardening, not OpenAPM v0.1 normative surface
