### PR TITLE
feat(install): allow dynamic override of package versions via env vars or version.env

### DIFF
--- a/src/apm_cli/cli.py
+++ b/src/apm_cli/cli.py
@@ -329,8 +329,31 @@ def _configure_encoding() -> None:
             _warn_encoding_issue(current_cp)
 
 
+def _load_version_env() -> None:
+    """Load config overrides from version.env if it exists in current directory."""
+    import os
+
+    env_file = "version.env"
+    if os.path.exists(env_file):
+        try:
+            with open(env_file, "r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line or line.startswith("#"):
+                        continue
+                    if "=" in line:
+                        key, val = line.split("=", 1)
+                        key = key.strip()
+                        val = val.strip().strip('"').strip("'")
+                        if key:
+                            os.environ[key] = val
+        except Exception:
+            pass
+
+
 def main():
     """Main entry point for the CLI."""
+    _load_version_env()
     _configure_logging()  # honours APM_LOG_LEVEL env var; --verbose upgrades in cli()
     _configure_encoding()
     try:

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -112,7 +112,23 @@ class DependencyReference:
     marketplace_plugin_name: str | None = None
     marketplace_version_spec: str | None = None
 
+    def __post_init__(self) -> None:
+        import os
+        import re
+
+        if self.repo_url:
+            # Extract repository name (last part of repo_url path)
+            repo_name = self.repo_url.split("/")[-1]
+            # Replace non-alphanumeric characters with underscore and uppercase
+            safe_name = re.sub(r"[^a-zA-Z0-9_]", "_", repo_name).upper()
+            override_env = f"APM_{safe_name}"
+            if override_env in os.environ:
+                val = os.environ[override_env]
+                if val:
+                    self.reference = val
+
     @property
+
     def ref_kind(self) -> str | None:
         """Classify ``reference`` for routing purposes.
 

--- a/tests/test_apm_package_models.py
+++ b/tests/test_apm_package_models.py
@@ -27,6 +27,48 @@ from src.apm_cli.models.apm_package import (
 class TestDependencyReference:
     """Test DependencyReference parsing and functionality."""
 
+    def test_override_version_via_environment_variable(self, monkeypatch):
+        """Test that environment variables override dependency references dynamically."""
+        monkeypatch.setenv("APM_OH_MY_OPENAGENT", "v2.0.0")
+        dep = DependencyReference.parse("owner/oh-my-openagent#v1.0.0")
+        assert dep.reference == "v2.0.0"
+
+        # Also test that it works even if no reference was originally specified
+        dep2 = DependencyReference.parse("owner/oh-my-openagent")
+        assert dep2.reference == "v2.0.0"
+
+        # Also test with hyphens and non-alphanumeric characters
+        monkeypatch.setenv("APM_MY_DASHED_REPO", "v3.0.0")
+        dep3 = DependencyReference.parse("owner/my-dashed-repo")
+        assert dep3.reference == "v3.0.0"
+
+    def test_load_version_env_file(self, tmp_path, monkeypatch):
+        """Test that _load_version_env reads version.env and sets environment variables."""
+        from apm_cli.cli import _load_version_env
+
+        # Change current working directory to temp path
+        monkeypatch.chdir(tmp_path)
+
+        env_content = (
+            "# This is a comment\n"
+            "APM_OH_MY_OPENAGENT=v4.0.0\n"
+            "APM_NEXUS = v2.5.0\n"
+        )
+
+        env_file = tmp_path / "version.env"
+        env_file.write_text(env_content, encoding="utf-8")
+
+        # Run loading function
+        _load_version_env()
+
+        import os
+        assert os.environ.get("APM_OH_MY_OPENAGENT") == "v4.0.0"
+        assert os.environ.get("APM_NEXUS") == "v2.5.0"
+
+        # Clean up environment variables
+        monkeypatch.delenv("APM_OH_MY_OPENAGENT", raising=False)
+        monkeypatch.delenv("APM_NEXUS", raising=False)
+
     def test_parse_simple_repo(self):
         """Test parsing simple user/repo format."""
         dep = DependencyReference.parse("user/repo")


### PR DESCRIPTION
This PR introduces a mechanism to dynamically override package versions via environment variables prefixed with `APM_` (e.g. `APM_OH_MY_OPENAGENT=v2.0.0`) or by placing them inside a local `version.env` file.

### Changes
- Add `_load_version_env()` to `apm_cli/cli.py` to parse environment variables from `version.env` if it exists in the current directory on start.
- Add a `__post_init__` method to `DependencyReference` to override `self.reference` when a matching environment variable `APM_<LIBRARY_NAME>` is found.
- Add unit tests for both environment variable override and `version.env` parsing.