### PR TITLE
fix(mcp): resolve self-defined stdio env ${VAR} placeholders at install time (closes #1963)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `apm audit --ci` no longer reports phantom drift for root-local hook files
   when audit replay writes into a scratch project root. (#1980)
+- Self-defined stdio MCP env placeholders now resolve from the install process
+  environment for Claude Code and Codex. (#1966)
 
 ## [0.23.1] - 2026-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `apm audit --ci` no longer reports phantom drift for root-local hook files
   when audit replay writes into a scratch project root. (#1980)
 - Self-defined stdio MCP env placeholders now resolve from the install process
-  environment for Claude Code and Codex. (#1966)
+  environment for Claude Code and Codex instead of being written verbatim.
+  (#1966)
 
 ## [0.23.1] - 2026-06-29
 

--- a/docs/src/content/docs/producer/author-primitives/mcp-as-primitive.md
+++ b/docs/src/content/docs/producer/author-primitives/mcp-as-primitive.md
@@ -114,12 +114,13 @@ shipped. Do not embed tokens. Two patterns work:
 ```
 
 Headers and env values are never shell-expanded by APM. For harnesses
-that support runtime env placeholders, APM preserves the placeholder so
-the harness resolves it when the server starts or the request is made.
-For harnesses that require literal values, APM resolves `${VAR}` from
-the install process environment and leaves unresolved placeholders
-unchanged. Keep the real secret in the consumer's environment (or their
-secret manager).
+that support runtime env placeholders (for example VS Code and Kiro),
+APM preserves the placeholder so the harness resolves it when the
+server starts or the request is made. For harnesses that require
+literal values (for example Claude Code and Codex self-defined stdio
+env), APM resolves `${VAR}` from the install process environment and
+leaves unresolved placeholders unchanged. Keep the real secret in the
+consumer's environment (or their secret manager).
 
 The `github-mcp-server` is a special case: APM injects an
 `Authorization: Bearer <token>` header automatically when it writes

--- a/docs/src/content/docs/producer/author-primitives/mcp-as-primitive.md
+++ b/docs/src/content/docs/producer/author-primitives/mcp-as-primitive.md
@@ -96,7 +96,7 @@ Treat `apm.yml` like `package.json`: it is committed, reviewed, and
 shipped. Do not embed tokens. Two patterns work:
 
 ```yaml
-# Env-var indirection -- the harness expands at runtime
+# Env-var indirection -- resolved by APM or the harness per target
 - name: linear
   registry: false
   transport: http
@@ -118,9 +118,10 @@ that support runtime env placeholders (for example VS Code and Kiro),
 APM preserves the placeholder so the harness resolves it when the
 server starts or the request is made. For harnesses that require
 literal values (for example Claude Code and Codex self-defined stdio
-env), APM resolves `${VAR}` from the install process environment and
-leaves unresolved placeholders unchanged. Keep the real secret in the
-consumer's environment (or their secret manager).
+env), APM resolves `${VAR}` from the install process environment,
+prompts during interactive installs when possible, and leaves unresolved
+placeholders unchanged in non-interactive installs. Keep the real secret
+in the consumer's environment (or their secret manager).
 
 The `github-mcp-server` is a special case: APM injects an
 `Authorization: Bearer <token>` header automatically when it writes
@@ -131,7 +132,7 @@ When a registry server marks an env/input variable optional, APM does
 not generate a prompt or runtime config entry unless a value is already
 available. See the
 [manifest schema reference](../../reference/manifest-schema/#424-variable-references-in-headers-and-env)
-for the canonical required-vs-optional rule.
+for the canonical per-target and required-vs-optional rules.
 
 ## Direct vs transitive: the trust boundary
 

--- a/docs/src/content/docs/producer/author-primitives/mcp-as-primitive.md
+++ b/docs/src/content/docs/producer/author-primitives/mcp-as-primitive.md
@@ -104,7 +104,7 @@ shipped. Do not embed tokens. Two patterns work:
   headers:
     Authorization: "Bearer ${LINEAR_TOKEN}"
 
-# Stdio env -- value passed verbatim; use ${VAR} for indirection
+# Stdio env -- use ${VAR} for indirection from the installer environment
 - name: my-internal
   registry: false
   transport: stdio
@@ -113,9 +113,13 @@ shipped. Do not embed tokens. Two patterns work:
     API_TOKEN: "${MY_API_TOKEN}"
 ```
 
-Headers and env values are not shell-expanded by APM -- the harness
-does that when it spawns the server or makes the request. Keep the
-real secret in the consumer's environment (or their secret manager).
+Headers and env values are never shell-expanded by APM. For harnesses
+that support runtime env placeholders, APM preserves the placeholder so
+the harness resolves it when the server starts or the request is made.
+For harnesses that require literal values, APM resolves `${VAR}` from
+the install process environment and leaves unresolved placeholders
+unchanged. Keep the real secret in the consumer's environment (or their
+secret manager).
 
 The `github-mcp-server` is a special case: APM injects an
 `Authorization: Bearer <token>` header automatically when it writes

--- a/docs/src/content/docs/producer/author-primitives/mcp-as-primitive.md
+++ b/docs/src/content/docs/producer/author-primitives/mcp-as-primitive.md
@@ -119,9 +119,9 @@ APM preserves the placeholder so the harness resolves it when the
 server starts or the request is made. For harnesses that require
 literal values (for example Claude Code and Codex self-defined stdio
 env), APM resolves `${VAR}` from the install process environment,
-prompts during interactive installs when possible, and leaves unresolved
-placeholders unchanged in non-interactive installs. Keep the real secret
-in the consumer's environment (or their secret manager).
+prompts interactively when the terminal is attached, and leaves
+unresolved placeholders unchanged in non-interactive installs. Keep the
+real secret in the consumer's environment (or their secret manager).
 
 The `github-mcp-server` is a special case: APM injects an
 `Authorization: Bearer <token>` header automatically when it writes

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -369,7 +369,8 @@ dependencies:
         #                            and resolved at runtime.
         #                            Kiro: preserved as ${VAR} and resolved at runtime.
         #                            Cursor/Windsurf/OpenCode/Claude/Gemini: resolved at install time.
-        #                            Codex: passed through unchanged.
+        #                            Codex remote headers: passed through unchanged.
+        #                            Codex self-defined stdio env: resolved at install time.
         #   ${input:<id>}         -> VS Code prompts user at runtime
         #   <VAR>                 -> deprecated; auto-translated, emits a warning
         # Registry-declared optional env/input fields are omitted when unset;

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -369,8 +369,7 @@ dependencies:
         #                            and resolved at runtime.
         #                            Kiro: preserved as ${VAR} and resolved at runtime.
         #                            Cursor/Windsurf/OpenCode/Claude/Gemini: resolved at install time.
-        #                            Codex remote headers: passed through unchanged.
-        #                            Codex self-defined stdio env: resolved at install time.
+        #                            Codex: resolved at install time.
         #   ${input:<id>}         -> VS Code prompts user at runtime
         #   <VAR>                 -> deprecated; auto-translated, emits a warning
         # Registry-declared optional env/input fields are omitted when unset;

--- a/src/apm_cli/integration/mcp_integrator_install.py
+++ b/src/apm_cli/integration/mcp_integrator_install.py
@@ -543,9 +543,10 @@ def _install_self_defined_deps(
         is_update = dep.name in servers_to_update
         synthetic_info = MCPIntegrator._build_self_defined_info(dep)
         self_defined_cache = {dep.name: synthetic_info}
-        self_defined_env = dep.env or {}
-
         transport_label = dep.transport or "stdio"
+        # Stdio env values live in _raw_stdio and must be resolved by the
+        # adapter pipeline, not reused as env_overrides that shadow os.environ.
+        self_defined_env = {} if transport_label == "stdio" else dep.env or {}
         action_text = "Updating" if is_update else "Configuring"
         if console:
             console.print(

--- a/src/apm_cli/integration/mcp_integrator_install.py
+++ b/src/apm_cli/integration/mcp_integrator_install.py
@@ -544,8 +544,8 @@ def _install_self_defined_deps(
         synthetic_info = MCPIntegrator._build_self_defined_info(dep)
         self_defined_cache = {dep.name: synthetic_info}
         transport_label = dep.transport or "stdio"
-        # Stdio env values live in _raw_stdio and must be resolved by the
-        # adapter pipeline, not reused as env_overrides that shadow os.environ.
+        # Stdio env values live in _raw_stdio from _build_self_defined_info
+        # and resolve in the adapter pipeline, not via env_overrides.
         self_defined_env = {} if transport_label == "stdio" else dep.env or {}
         action_text = "Updating" if is_update else "Configuring"
         if console:

--- a/src/apm_cli/integration/mcp_integrator_install.py
+++ b/src/apm_cli/integration/mcp_integrator_install.py
@@ -544,8 +544,9 @@ def _install_self_defined_deps(
         synthetic_info = MCPIntegrator._build_self_defined_info(dep)
         self_defined_cache = {dep.name: synthetic_info}
         transport_label = dep.transport or "stdio"
-        # Stdio env values live in _raw_stdio from _build_self_defined_info
-        # and resolve in the adapter pipeline, not via env_overrides.
+        # Stdio env values live in _raw_stdio and resolve in the adapter
+        # pipeline; env_overrides would shadow os.environ with the raw
+        # placeholder string.
         self_defined_env = {} if transport_label == "stdio" else dep.env or {}
         action_text = "Updating" if is_update else "Configuring"
         if console:

--- a/tests/integration/test_mcp_stdio_env_resolution_e2e.py
+++ b/tests/integration/test_mcp_stdio_env_resolution_e2e.py
@@ -1,0 +1,123 @@
+"""E2E guard for self-defined stdio MCP env placeholder resolution."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import toml
+import yaml
+
+pytestmark = pytest.mark.xdist_group(name="home_env")
+
+
+@pytest.fixture
+def apm_command() -> str:
+    """Return the APM executable used by this integration test."""
+    apm_on_path = shutil.which("apm")
+    if apm_on_path:
+        return apm_on_path
+    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
+    if venv_apm.exists():
+        return str(venv_apm)
+    return "apm"
+
+
+def _write_apm_yml(project_dir: Path) -> None:
+    config = {
+        "name": "mcp-stdio-env-resolution-e2e",
+        "version": "0.0.0",
+        "dependencies": {
+            "apm": [],
+            "mcp": [
+                {
+                    "name": "env-demo",
+                    "registry": False,
+                    "transport": "stdio",
+                    "command": "npx",
+                    "args": ["-y", "example-mcp"],
+                    "env": {
+                        "APM_STDIO_E2E_TOKEN": "${APM_STDIO_E2E_TOKEN}",
+                        "APM_STDIO_E2E_UNSET_TOKEN": "${APM_STDIO_E2E_UNSET_TOKEN}",
+                        "LITERAL_VALUE": "literal-value",
+                    },
+                }
+            ],
+        },
+    }
+    (project_dir / "apm.yml").write_text(yaml.safe_dump(config), encoding="utf-8")
+
+
+def _run_install(
+    apm_command: str, project_dir: Path, runtime: str, verbose: bool
+) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    env["APM_NON_INTERACTIVE"] = "1"
+    args = [apm_command, "install"]
+    if verbose:
+        args.append("--verbose")
+    args.extend(["--only", "mcp", "--runtime", runtime, "--target", runtime])
+    return subprocess.run(
+        args,
+        cwd=project_dir,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+    )
+
+
+def _env_block(project_dir: Path, runtime: str) -> dict[str, str]:
+    if runtime == "claude":
+        config = json.loads((project_dir / ".mcp.json").read_text(encoding="utf-8"))
+        return config["mcpServers"]["env-demo"]["env"]
+    config = toml.load(project_dir / ".codex" / "config.toml")
+    return config["mcp_servers"]["env-demo"]["env"]
+
+
+@pytest.mark.parametrize(
+    ("runtime", "signal_dir"),
+    [
+        ("claude", ".claude"),
+        ("codex", ".codex"),
+    ],
+)
+@pytest.mark.parametrize("verbose", [False, True], ids=["default-output", "verbose-output"])
+def test_self_defined_stdio_env_placeholders_resolve_from_process_env_e2e(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    apm_command: str,
+    runtime: str,
+    signal_dir: str,
+    verbose: bool,
+) -> None:
+    """Real install writes process-env values for self-defined stdio env."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / signal_dir).mkdir()
+    _write_apm_yml(project_dir)
+
+    secret_value = "stdio-e2e-secret-value=canary"
+    monkeypatch.setenv("APM_STDIO_E2E_TOKEN", secret_value)
+    monkeypatch.delenv("APM_STDIO_E2E_UNSET_TOKEN", raising=False)
+
+    result = _run_install(apm_command, project_dir, runtime, verbose)
+
+    assert result.returncode == 0, (
+        f"apm install failed (rc={result.returncode}).\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+
+    env_block = _env_block(project_dir, runtime)
+    assert env_block["APM_STDIO_E2E_TOKEN"] == secret_value
+    assert env_block["APM_STDIO_E2E_TOKEN"] != "${APM_STDIO_E2E_TOKEN}"
+    assert env_block["APM_STDIO_E2E_UNSET_TOKEN"] == "${APM_STDIO_E2E_UNSET_TOKEN}"
+    assert env_block["LITERAL_VALUE"] == "literal-value"
+
+    observed_output = f"{result.stdout}\n{result.stderr}"
+    assert secret_value not in observed_output

--- a/tests/unit/install/test_mcp_integrator_install_flow.py
+++ b/tests/unit/install/test_mcp_integrator_install_flow.py
@@ -21,9 +21,12 @@ Covers branches not hit by existing MCP tests:
 from __future__ import annotations
 
 import contextlib
+import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+import toml
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -308,6 +311,56 @@ class TestRunMcpInstallSelfDefined:
             run_mcp_install([sd_dep], runtime="copilot", logger=logger)
 
         # Function reached without crash is the assertion
+
+    @pytest.mark.parametrize(
+        ("runtime", "signal_dir", "config_relpath"),
+        [
+            ("claude", ".claude", ".mcp.json"),
+            ("codex", ".codex", ".codex/config.toml"),
+        ],
+    )
+    def test_self_defined_stdio_env_placeholders_resolve_from_process_env(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        runtime: str,
+        signal_dir: str,
+        config_relpath: str,
+    ) -> None:
+        from apm_cli.integration.mcp_integrator_install import run_mcp_install
+        from apm_cli.models.dependency.mcp import MCPDependency
+
+        (tmp_path / signal_dir).mkdir()
+        monkeypatch.setenv("MY_TOKEN", "repro-secret-not-a-real-token")
+        dep = MCPDependency(
+            name="env-demo",
+            registry=False,
+            transport="stdio",
+            command="npx",
+            args=["-y", "example-mcp"],
+            env={
+                "MY_TOKEN": "${MY_TOKEN}",
+                "LITERAL_VALUE": "literal-value",
+            },
+        )
+
+        result = run_mcp_install(
+            [dep],
+            runtime=runtime,
+            project_root=tmp_path,
+            logger=MagicMock(),
+        )
+
+        assert result == 1
+        config_path = tmp_path / config_relpath
+        if runtime == "claude":
+            env_block = json.loads(config_path.read_text(encoding="utf-8"))["mcpServers"][
+                "env-demo"
+            ]["env"]
+        else:
+            env_block = toml.load(config_path)["mcp_servers"]["env-demo"]["env"]
+        assert env_block["MY_TOKEN"] == "repro-secret-not-a-real-token"
+        assert env_block["LITERAL_VALUE"] == "literal-value"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/install/test_mcp_integrator_install_flow.py
+++ b/tests/unit/install/test_mcp_integrator_install_flow.py
@@ -362,6 +362,38 @@ class TestRunMcpInstallSelfDefined:
         assert env_block["MY_TOKEN"] == "repro-secret-not-a-real-token"
         assert env_block["LITERAL_VALUE"] == "literal-value"
 
+    def test_self_defined_non_stdio_env_remains_env_overrides(self) -> None:
+        from apm_cli.integration.mcp_integrator import MCPIntegrator
+        from apm_cli.integration.mcp_integrator_install import run_mcp_install
+        from apm_cli.models.dependency.mcp import MCPDependency
+
+        dep = MCPDependency(
+            name="http-demo",
+            registry=False,
+            transport="http",
+            url="https://example.test/mcp",
+            env={"HTTP_TOKEN": "${HTTP_TOKEN}"},
+        )
+
+        with (
+            patch(
+                "apm_cli.integration.mcp_integrator_install._resolve_target_runtimes",
+                return_value=["claude"],
+            ),
+            patch("apm_cli.integration.mcp_integrator._get_console", return_value=None),
+            patch.object(
+                MCPIntegrator,
+                "_check_self_defined_servers_needing_installation",
+                return_value={"http-demo"},
+            ),
+            patch.object(MCPIntegrator, "_install_for_runtime", return_value=True) as install_mock,
+        ):
+            result = run_mcp_install([dep], runtime="claude", logger=MagicMock())
+
+        assert result == 1
+        install_mock.assert_called_once()
+        assert install_mock.call_args.args[2] == {"HTTP_TOKEN": "${HTTP_TOKEN}"}
+
 
 # ---------------------------------------------------------------------------
 # plain strings treated as registry deps


### PR DESCRIPTION
## Why

Self-defined MCP transports were inconsistent: HTTP headers already resolved `${VAR}` placeholders from the install process environment for literal-only harnesses, but self-defined stdio `env` values were passed back as `env_overrides`, causing the authored placeholder to shadow the real process environment. That made Claude Code and Codex write `${VAR}` verbatim and break authenticated servers, a P6 reliability issue.

## What changed

- Stopped passing self-defined stdio `env` blocks as `env_overrides`; the adapter now resolves `_raw_stdio.env` through the same placeholder pipeline used by headers.
- Added a regression test that installs the same self-defined stdio server into Claude Code and Codex and asserts `${MY_TOKEN}` resolves while literal env values remain unchanged.
- Updated docs, the APM usage guide, and the changelog entry for the clarified behavior.

## How to test

Exact repro:

```bash
rm -rf .scratch-1963
mkdir -p .scratch-1963/.claude .scratch-1963/.codex
cat > .scratch-1963/apm.yml <<'YAML'
name: repro-1963
version: 0.0.0
dependencies:
  mcp:
    - name: env-demo
      registry: false
      transport: stdio
      command: npx
      args: ["-y", "example-mcp"]
      env:
        MY_TOKEN: "${MY_TOKEN}"
        LITERAL_VALUE: "literal-value"
    - name: http-demo
      registry: false
      transport: http
      url: https://example.com/mcp
      headers:
        X-Token: "${MY_TOKEN}"
YAML
cd .scratch-1963
MY_TOKEN="repro-secret-not-a-real-token" uv run --project .. apm install --only mcp --target claude
cat .mcp.json
MY_TOKEN="repro-secret-not-a-real-token" uv run --project .. apm install --only mcp --target codex
cat .codex/config.toml
```

Validation run:

```bash
uv run --extra dev pytest tests/unit/install/test_mcp_integrator_install_flow.py::TestRunMcpInstallSelfDefined::test_self_defined_stdio_env_placeholders_resolve_from_process_env -q
uv run --extra dev pytest tests/unit/install/test_mcp_integrator_install_flow.py tests/unit/test_claude_mcp.py tests/unit/test_codex_adapter_phase3.py tests/test_codex_empty_string_and_defaults.py -q
uv run --extra dev ruff check src/ tests/
uv run --extra dev ruff format --check src/ tests/
```

Mutation-break gate: removed `self_defined_env = {} if transport_label == "stdio" else dep.env or {}` and restored `self_defined_env = dep.env or {}`; the new regression test failed for both Claude and Codex with `${MY_TOKEN}` written verbatim (`failed_without_guard=true`).

Closes #1963
