### PR TITLE
fix(plugin-bin): harden deploy permissions and deny matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Marketplace plugin `bin/` deployment now hardens POSIX executable copies to
+  user-only `0o700` permissions and normalizes legacy `bin_deploy.deny` GitHub
+  forms before matching. -- by @WilliamK112 (#1971)
 - `apm audit --help` now accurately describes the command's full scope:
   hidden Unicode scanning, drift detection, and lockfile/policy checks.
   The previous summary named only Unicode scanning and used the legacy

--- a/docs/src/content/docs/producer/repo-shapes.md
+++ b/docs/src/content/docs/producer/repo-shapes.md
@@ -207,8 +207,8 @@ Claude Code skills target. Authoring rules:
 
 - Deploy is **user-scope only**. A project-scope install (without `-g`)
   skips `bin/` and prints a hint to re-run with `-g`.
-- APM sets **user-only execute** on deployed files (owner +x; group and
-  other execute bits are cleared). Do not rely on a specific umask.
+- APM tightens deployed executable files to **`0o700` on POSIX systems**.
+  Do not rely on source-file permissions or a specific umask.
 - Deployed executables sit on Claude Code's `PATH` and are invoked
   **without per-call confirmation**. Treat them as trusted code: keep
   them minimal, audited, and free of network side effects you would not

--- a/docs/src/content/docs/reference/policy-schema.md
+++ b/docs/src/content/docs/reference/policy-schema.md
@@ -463,7 +463,7 @@ This realizes Claude Code's "skills-directory plugin" contract: a folder under a
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `deny_all` | `bool` | `false` | When `true`, suppresses bin/ deployment for every `marketplace_plugin` package, regardless of individual `deny` entries. |
-| `deny` | `list<string>` | `[]` | Package canonical strings whose bin/ executables must not be deployed. Entries are normalized before matching, so `MyOrg/MyPlugin`, `github.com/myorg/myplugin`, and `https://github.com/myorg/myplugin.git` all match `myorg/myplugin`. |
+| `deny` | `list<string>` | `[]` | Package identities whose bin/ executables must not be deployed. Entries are normalized before matching, so `MyOrg/MyPlugin`, `github.com/myorg/myplugin`, and `https://github.com/myorg/myplugin.git` all match `myorg/myplugin`. |
 
 ```yaml
 bin_deploy:

--- a/docs/src/content/docs/reference/policy-schema.md
+++ b/docs/src/content/docs/reference/policy-schema.md
@@ -454,7 +454,7 @@ deny).
 
 This realizes Claude Code's "skills-directory plugin" contract: a folder under a skills directory that contains `.claude-plugin/plugin.json` loads as `<name>@skills-dir`, and its root `bin/` is added to the Bash tool's `PATH`. The package's `.claude-plugin/plugin.json` is required for Claude to load the folder as a plugin; APM copies it alongside `bin/` when the package ships one. The contract is Claude-specific, so deployment only targets Claude. Restart Claude Code (or run `/reload-plugins`) after install for new executables to be picked up.
 
-**Security note:** deployed executables are made executable (user-only execute bit; group and other execute bits are cleared) and placed on Claude Code's `PATH`, so Claude can invoke them without further confirmation. By default, APM mirrors npm's trust model: installing a package implies trusting its declared artifacts, including executables. Use this field to opt out globally or per-package in enterprise environments.
+**Security note:** deployed executables are tightened to `0o700` on POSIX systems and placed on Claude Code's `PATH`, so Claude can invoke them without further confirmation. By default, APM mirrors npm's trust model: installing a package implies trusting its declared artifacts, including executables. Use this field to opt out globally or per-package in enterprise environments.
 
 **Scope:** bin/ deployment only activates for global (`-g`, user-scope) installs. Project-scope installs do not deploy executables.
 
@@ -463,7 +463,7 @@ This realizes Claude Code's "skills-directory plugin" contract: a folder under a
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `deny_all` | `bool` | `false` | When `true`, suppresses bin/ deployment for every `marketplace_plugin` package, regardless of individual `deny` entries. |
-| `deny` | `list<string>` | `[]` | Package canonical strings whose bin/ executables must not be deployed. Entries are matched case-sensitively; copy each string verbatim from `apm deps list` (e.g. `myorg/myplugin`). |
+| `deny` | `list<string>` | `[]` | Package canonical strings whose bin/ executables must not be deployed. Entries are normalized before matching, so `MyOrg/MyPlugin`, `github.com/myorg/myplugin`, and `https://github.com/myorg/myplugin.git` all match `myorg/myplugin`. |
 
 ```yaml
 bin_deploy:

--- a/src/apm_cli/integration/skill_integrator.py
+++ b/src/apm_cli/integration/skill_integrator.py
@@ -1534,7 +1534,10 @@ class SkillIntegrator(BaseIntegrator):
         bd_policy = policy.bin_deploy
         if bd_policy is None:
             return False
+        from apm_cli.security.executables import normalize_bin_deploy_deny_key
+
         canonical = package_info.get_canonical_dependency_string()
+        normalized_canonical = normalize_bin_deploy_deny_key(canonical)
         if bd_policy.deny_all:
             if logger:
                 logger.progress(
@@ -1542,7 +1545,8 @@ class SkillIntegrator(BaseIntegrator):
                     symbol="info",
                 )
             return True
-        if canonical in bd_policy.deny:
+        deny_entries = {normalize_bin_deploy_deny_key(entry) for entry in bd_policy.deny}
+        if normalized_canonical in deny_entries:
             if logger:
                 logger.progress(
                     f"bin_deploy.deny: skipping bin deploy for {canonical}",

--- a/src/apm_cli/policy/schema.py
+++ b/src/apm_cli/policy/schema.py
@@ -229,8 +229,9 @@ class BinDeployPolicy:
     ``deny_all``: when ``True``, bin/ deployment is suppressed for all
     marketplace_plugin packages regardless of the ``deny`` list.
 
-    ``deny``: package canonical dependency strings (e.g. ``owner/repo``)
-    whose bin/ executables must NOT be deployed. Matched as exact strings.
+    ``deny``: package identities whose bin/ executables must NOT be
+    deployed. Entries normalize common GitHub forms (case, ``.git`` suffix,
+    and ``github.com/`` prefix) before matching.
     """
 
     deny_all: bool = False

--- a/src/apm_cli/security/executables.py
+++ b/src/apm_cli/security/executables.py
@@ -225,6 +225,20 @@ def _strip_version(package_key: str) -> str:
     return package_key.split("#", 1)[0]
 
 
+def normalize_bin_deploy_deny_key(value: object) -> str:
+    """Normalize package identity for legacy ``bin_deploy.deny`` matching."""
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    try:
+        from apm_cli.models.apm_package import DependencyReference
+
+        raw = DependencyReference.parse(raw).get_canonical_dependency_string()
+    except ValueError:
+        raw = raw.removesuffix(".git")
+    return raw.rstrip("/").lower()
+
+
 def _map_grants(
     grant_map: dict[str, dict[str, bool]] | None,
     package_key: str,
@@ -271,8 +285,13 @@ def _org_denies(ctx: ExecTrustContext, name: str, exec_type: str) -> tuple[bool,
         return True, LAYER_ORG_DENY_ALL
     if _deny_glob_match(name, ctx.org_deny):
         return True, LAYER_ORG_DENY
-    if exec_type == EXEC_TYPE_BIN and _deny_glob_match(name, ctx.org_bin_deny):
-        return True, LAYER_ORG_DENY
+    if exec_type == EXEC_TYPE_BIN:
+        normalized_name = normalize_bin_deploy_deny_key(name)
+        normalized_bin_deny = frozenset(
+            normalize_bin_deploy_deny_key(pattern) for pattern in ctx.org_bin_deny
+        )
+        if _deny_glob_match(normalized_name, normalized_bin_deny):
+            return True, LAYER_ORG_DENY
     return False, None
 
 
@@ -1092,7 +1111,10 @@ def build_exec_trust_context(
         bin_deploy = getattr(policy, "bin_deploy", None)
         if bin_deploy is not None:
             org_bin_deny_all = bool(getattr(bin_deploy, "deny_all", False))
-            org_bin_deny = frozenset(getattr(bin_deploy, "deny", ()) or ())
+            org_bin_deny = frozenset(
+                normalize_bin_deploy_deny_key(entry)
+                for entry in (getattr(bin_deploy, "deny", ()) or ())
+            )
             org_signal = org_signal or org_bin_deny_all or bool(org_bin_deny)
 
     gate_enabled = project_executables_gate_enabled(data) or org_signal

--- a/src/apm_cli/security/executables.py
+++ b/src/apm_cli/security/executables.py
@@ -226,7 +226,7 @@ def _strip_version(package_key: str) -> str:
 
 
 def normalize_bin_deploy_deny_key(value: object) -> str:
-    """Normalize package identity for legacy ``bin_deploy.deny`` matching."""
+    """Normalize package identity for ``bin_deploy.deny`` storage and lookup."""
     raw = str(value or "").strip()
     if not raw:
         return ""
@@ -287,10 +287,7 @@ def _org_denies(ctx: ExecTrustContext, name: str, exec_type: str) -> tuple[bool,
         return True, LAYER_ORG_DENY
     if exec_type == EXEC_TYPE_BIN:
         normalized_name = normalize_bin_deploy_deny_key(name)
-        normalized_bin_deny = frozenset(
-            normalize_bin_deploy_deny_key(pattern) for pattern in ctx.org_bin_deny
-        )
-        if _deny_glob_match(normalized_name, normalized_bin_deny):
+        if _deny_glob_match(normalized_name, ctx.org_bin_deny):
             return True, LAYER_ORG_DENY
     return False, None
 

--- a/tests/integration/test_plugin_bin_deploy_hardening.py
+++ b/tests/integration/test_plugin_bin_deploy_hardening.py
@@ -1,0 +1,96 @@
+"""Integration coverage for marketplace plugin bin/ deployment hardening."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from apm_cli.core.scope import InstallScope
+from apm_cli.integration.skill_integrator import SkillIntegrator
+from apm_cli.models.apm_package import PackageInfo, PackageType, validate_apm_package
+from apm_cli.policy.schema import ApmPolicy, BinDeployPolicy
+
+pytestmark = pytest.mark.skipif(os.name != "posix", reason="POSIX mode hardening only")
+
+
+def _write_marketplace_plugin(package_dir: Path, *, manifest_name: str) -> tuple[PackageInfo, Path]:
+    """Create and validate a real marketplace plugin fixture with one bin file."""
+    package_dir.mkdir(parents=True)
+    (package_dir / "plugin.json").write_text(
+        f'{{"name": "{manifest_name}", "version": "1.0.0"}}',
+        encoding="utf-8",
+    )
+    plugin_manifest_dir = package_dir / ".claude-plugin"
+    plugin_manifest_dir.mkdir()
+    (plugin_manifest_dir / "plugin.json").write_text(
+        f'{{"name": "{manifest_name}"}}',
+        encoding="utf-8",
+    )
+    bin_dir = package_dir / "bin"
+    bin_dir.mkdir()
+    source_bin = bin_dir / "tool"
+    source_bin.write_text("#!/bin/sh\necho plugin\n", encoding="utf-8")
+    source_bin.chmod(0o777)
+
+    validation = validate_apm_package(package_dir)
+    assert not validation.errors
+    assert validation.package is not None
+    assert validation.package_type is PackageType.MARKETPLACE_PLUGIN
+    return (
+        PackageInfo(
+            package=validation.package,
+            install_path=package_dir,
+            package_type=validation.package_type,
+        ),
+        source_bin,
+    )
+
+
+def test_plugin_bin_deploy_hardens_mode_and_honors_normalized_legacy_deny(
+    tmp_path: Path,
+) -> None:
+    """Real plugin deploy path chmods bins to 0o700 and normalizes legacy denies."""
+    project_root = tmp_path / "home"
+    project_root.mkdir()
+    (project_root / ".claude").mkdir()
+
+    integrator = SkillIntegrator()
+    allowed_info, allowed_source_bin = _write_marketplace_plugin(
+        tmp_path / "packages" / "loose-tool",
+        manifest_name="MyOwner/LooseTool",
+    )
+
+    assert stat.S_IMODE(allowed_source_bin.stat().st_mode) == 0o777
+    allowed = integrator.integrate_package_skill(
+        allowed_info,
+        project_root,
+        scope=InstallScope.USER,
+    )
+
+    deployed_bin = project_root / ".claude" / "skills" / "loose-tool" / "bin" / "tool"
+    assert allowed.bin_deployed == 2
+    assert deployed_bin.is_file()
+    assert stat.S_IMODE(deployed_bin.stat().st_mode) == 0o700
+
+    denied_info, denied_source_bin = _write_marketplace_plugin(
+        tmp_path / "packages" / "denied-tool",
+        manifest_name="MyOwner/MyPlugin",
+    )
+    policy = ApmPolicy(
+        bin_deploy=BinDeployPolicy(deny=("https://github.com/myowner/myplugin.git",))
+    )
+
+    assert stat.S_IMODE(denied_source_bin.stat().st_mode) == 0o777
+    denied = integrator.integrate_package_skill(
+        denied_info,
+        project_root,
+        scope=InstallScope.USER,
+        policy=policy,
+    )
+
+    denied_bin = project_root / ".claude" / "skills" / "denied-tool" / "bin" / "tool"
+    assert denied.bin_deployed == 0
+    assert not denied_bin.exists()

--- a/tests/unit/integration/test_skill_integrator.py
+++ b/tests/unit/integration/test_skill_integrator.py
@@ -4169,6 +4169,11 @@ class TestPluginBinDeploy:
         bin_dir = pkg_dir / "bin"
         bin_dir.mkdir()
         (bin_dir / "myplugin").write_text("#!/bin/sh\necho hello\n")
+        import os
+        import stat as _stat
+
+        if os.name == "posix":
+            (bin_dir / "myplugin").chmod(0o777)
         plugin_manifest_dir = pkg_dir / ".claude-plugin"
         plugin_manifest_dir.mkdir()
         (plugin_manifest_dir / "plugin.json").write_text('{"name": "myplugin"}')
@@ -4202,15 +4207,9 @@ class TestPluginBinDeploy:
 
         # Verify full user-only (0o700-style) permissions: owner rwx, and no
         # group/other read/write/execute bits at all.
-        import os
-        import stat as _stat
-
         if os.name == "posix":
             mode = deployed_bin.stat().st_mode
-            assert mode & _stat.S_IXUSR, "owner execute bit must be set"
-            assert (mode & 0o077) == 0, "no group/other permission bits may be set"
-            assert (mode & 0o7000) == 0, "special permission bits must be cleared"
-            assert (mode & 0o777) == 0o700, "deployed executable must be 0o700"
+            assert _stat.S_IMODE(mode) == 0o700, "deployed bin permissions must be 0o700"
 
     @pytest.mark.parametrize("previous_mode", [0o644, 0o755, 0o777, 0o4755])
     def test_bin_deploy_hardens_permissions_on_idempotent_reinstall(
@@ -4256,7 +4255,7 @@ class TestPluginBinDeploy:
         # for one case, a special bit preserved from the shipped package.
         deployed_bin.chmod(previous_mode)
         mode_before = deployed_bin.stat().st_mode
-        assert (mode_before & 0o7777) == previous_mode, "pre-condition: loose mode set"
+        assert _stat.S_IMODE(mode_before) == previous_mode, "pre-condition: loose mode set"
         assert mode_before & (0o077 | _stat.S_ISUID), "pre-condition: loose bits set"
 
         # Second install with identical content -- must harden permissions.
@@ -4267,10 +4266,7 @@ class TestPluginBinDeploy:
         )
 
         mode_after = deployed_bin.stat().st_mode
-        assert mode_after & _stat.S_IXUSR, "owner execute bit must be set"
-        assert (mode_after & 0o077) == 0, "all group/other bits must be cleared on re-install"
-        assert (mode_after & 0o7000) == 0, "all special bits must be cleared on re-install"
-        assert (mode_after & 0o777) == 0o700, "re-install must harden to 0o700"
+        assert _stat.S_IMODE(mode_after) == 0o700, "re-install must harden permissions to 0o700"
 
     def test_bin_deploy_suppressed_by_policy_deny(self, tmp_path: Path) -> None:
         """bin_deploy.deny list suppresses deployment for the matching package."""
@@ -4301,6 +4297,38 @@ class TestPluginBinDeploy:
 
         deployed_bin = project_root / ".claude" / "skills" / "myplugin" / "bin" / "myplugin"
         assert not deployed_bin.exists(), "bin/myplugin should NOT be deployed when in deny list"
+        assert result.skill_created is False
+
+    def test_bin_deploy_deny_normalizes_case_and_github_prefix(self, tmp_path: Path) -> None:
+        """bin_deploy.deny accepts common GitHub URL/prefix forms."""
+        from apm_cli.core.scope import InstallScope
+        from apm_cli.policy.schema import ApmPolicy, BinDeployPolicy
+
+        project_root = tmp_path / "home"
+        project_root.mkdir()
+        (project_root / ".claude").mkdir()
+
+        pkg_dir = tmp_path / "apm_modules" / "myplugin"
+        pkg_dir.mkdir(parents=True)
+        bin_dir = pkg_dir / "bin"
+        bin_dir.mkdir()
+        (bin_dir / "myplugin").write_text("#!/bin/sh\necho hello\n")
+
+        pkg_info = self._make_plugin_package(pkg_dir, pkg_name="MyOwner/MyPlugin")
+        policy = ApmPolicy(
+            bin_deploy=BinDeployPolicy(deny=("https://github.com/myowner/myplugin.git",))
+        )
+
+        integrator = SkillIntegrator()
+        result = integrator.integrate_package_skill(
+            pkg_info,
+            project_root,
+            scope=InstallScope.USER,
+            policy=policy,
+        )
+
+        deployed_bin = project_root / ".claude" / "skills" / "myplugin" / "bin" / "myplugin"
+        assert not deployed_bin.exists(), "normalized bin_deploy.deny should suppress deployment"
         assert result.skill_created is False
 
     def test_bin_deploy_suppressed_by_deny_all(self, tmp_path: Path) -> None:

--- a/tests/unit/security/test_exec_vocab_unification.py
+++ b/tests/unit/security/test_exec_vocab_unification.py
@@ -98,7 +98,7 @@ class TestBuildExecTrustContext:
     def test_legacy_bin_deploy_maps_to_bin_deny(self, tmp_path, monkeypatch):
         monkeypatch.setattr(ex, "_user_config_file", lambda: tmp_path / "c.json")
         monkeypatch.setattr(ex, "_legacy_approvals_path", lambda: tmp_path / "a.yml")
-        policy = ApmPolicy(bin_deploy=BinDeployPolicy(deny=("bad/pkg",)))
+        policy = ApmPolicy(bin_deploy=BinDeployPolicy(deny=("https://github.com/BAD/PKG.git",)))
         ctx = build_exec_trust_context(policy=policy, project_data={})
         assert "bad/pkg" in ctx.org_bin_deny
 

--- a/tests/unit/security/test_resolve_exec_decision.py
+++ b/tests/unit/security/test_resolve_exec_decision.py
@@ -89,8 +89,8 @@ class TestRow1OrgDeny:
         d_hooks = resolve_exec_decision(ctx, PKG, EXEC_TYPE_HOOKS)
         assert d_hooks.deciding_layer != LAYER_ORG_DENY_ALL
 
-    def test_legacy_bin_deploy_denies_normalized_github_url(self):
-        ctx = _ctx(org_bin_deny=frozenset({"https://github.com/OWNER/REPO.git"}))
+    def test_legacy_bin_deploy_denies_normalized_name(self):
+        ctx = _ctx(org_bin_deny=frozenset({"owner/repo"}))
         d = resolve_exec_decision(ctx, PKG, EXEC_TYPE_BIN)
         assert d.allowed is False
         assert d.deciding_layer == LAYER_ORG_DENY

--- a/tests/unit/security/test_resolve_exec_decision.py
+++ b/tests/unit/security/test_resolve_exec_decision.py
@@ -89,6 +89,12 @@ class TestRow1OrgDeny:
         d_hooks = resolve_exec_decision(ctx, PKG, EXEC_TYPE_HOOKS)
         assert d_hooks.deciding_layer != LAYER_ORG_DENY_ALL
 
+    def test_legacy_bin_deploy_denies_normalized_github_url(self):
+        ctx = _ctx(org_bin_deny=frozenset({"https://github.com/OWNER/REPO.git"}))
+        d = resolve_exec_decision(ctx, PKG, EXEC_TYPE_BIN)
+        assert d.allowed is False
+        assert d.deciding_layer == LAYER_ORG_DENY
+
 
 class TestRow2UserDeny:
     def test_user_deny_denies(self):


### PR DESCRIPTION
## Summary

Addresses bounded follow-ups from #1620 for marketplace plugin `bin/` deployment:

- tighten deployed POSIX `bin/` executables to `0o700` instead of preserving source group/other read/write bits from `copy2`
- normalize legacy `bin_deploy.deny` package identities before matching so common GitHub forms such as `github.com/Owner/Repo` and `https://github.com/owner/repo.git` match the host-blind canonical package key
- apply the same normalization in both the executable trust gate and the final bin deploy policy check
- update producer/policy docs to match the new behavior

This intentionally does not take on the larger opt-in/first-deploy consent redesign or TargetProfile plugin-bin contract abstraction from #1620.

## Tests

- `PYTHONPATH=src .\.venv\Scripts\python.exe -m pytest tests/unit/integration/test_skill_integrator.py -k bin_deploy -q`
- `PYTHONPATH=src .\.venv\Scripts\python.exe -m pytest tests/unit/security/test_resolve_exec_decision.py tests/unit/security/test_exec_vocab_unification.py -q`
- `.\.venv\Scripts\ruff.exe check src/apm_cli/integration/skill_integrator.py src/apm_cli/security/executables.py tests/unit/integration/test_skill_integrator.py tests/unit/security/test_resolve_exec_decision.py tests/unit/security/test_exec_vocab_unification.py`
- `.\.venv\Scripts\ruff.exe format --check src/apm_cli/integration/skill_integrator.py src/apm_cli/security/executables.py tests/unit/integration/test_skill_integrator.py tests/unit/security/test_resolve_exec_decision.py tests/unit/security/test_exec_vocab_unification.py`

Refs #1620