### PR TITLE
Fix CLI consistency report gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Think `package.json`, `requirements.txt`, or `Cargo.toml` — but for AI agent c
 
 GitHub Copilot · Claude Code · Cursor · OpenCode · Codex · Gemini · Windsurf · Kiro
 
-**[Documentation](https://microsoft.github.io/apm/)** · **[Quick Start](https://microsoft.github.io/apm/getting-started/quick-start/)** · **[CLI Reference](https://microsoft.github.io/apm/reference/cli-commands/)** · **[Roadmap](https://github.com/orgs/microsoft/projects/2304)**
+**[Documentation](https://microsoft.github.io/apm/)** · **[Quick Start](https://microsoft.github.io/apm/getting-started/quick-start/)** · **[CLI Reference](https://microsoft.github.io/apm/reference/cli/)** · **[Roadmap](https://github.com/orgs/microsoft/projects/2304)**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Think `package.json`, `requirements.txt`, or `Cargo.toml` — but for AI agent c
 
 GitHub Copilot · Claude Code · Cursor · OpenCode · Codex · Gemini · Windsurf · Kiro
 
-**[Documentation](https://microsoft.github.io/apm/)** · **[Quick Start](https://microsoft.github.io/apm/getting-started/quick-start/)** · **[CLI Reference](https://microsoft.github.io/apm/reference/cli/)** · **[Roadmap](https://github.com/orgs/microsoft/projects/2304)**
+**[Documentation](https://microsoft.github.io/apm/)** · **[Quick Start](https://microsoft.github.io/apm/getting-started/quick-start/)** · **[CLI Reference](https://microsoft.github.io/apm/reference/#cli-commands)** · **[Roadmap](https://github.com/orgs/microsoft/projects/2304)**
 
 ---
 

--- a/docs/src/content/docs/reference/cli/deps.md
+++ b/docs/src/content/docs/reference/cli/deps.md
@@ -125,7 +125,7 @@ apm deps clean [OPTIONS]
 | Option | Description |
 |---|---|
 | `--dry-run` | Show what would be removed without removing. |
-| `-y, --yes` | Skip the confirmation prompt (for CI and scripts). |
+| `-y, --yes` | Skip the confirmation prompt. |
 
 ## Examples
 

--- a/docs/src/content/docs/reference/cli/doctor.md
+++ b/docs/src/content/docs/reference/cli/doctor.md
@@ -1,0 +1,67 @@
+---
+title: apm doctor
+description: Run local environment diagnostics for git, GitHub reachability, auth, marketplace config, and executable trust.
+sidebar:
+  order: 11
+---
+
+Run a bounded pass/fail diagnostic table for the local APM environment.
+
+## Synopsis
+
+```bash
+apm doctor [OPTIONS]
+```
+
+## Description
+
+`apm doctor` is the first command to run when an install works on one machine but fails on another, or when CI cannot reproduce a local APM workflow. It checks the core tools and network path APM depends on, then reports a single exit code suitable for scripts.
+
+The command currently covers:
+
+| Check | Type | What it validates |
+|---|---|---|
+| `git` | critical | `git --version` succeeds and returns before the timeout. |
+| `network` | critical | Git can reach `https://github.com/git/git.git` with `ls-remote`. |
+| `auth` | informational | A GitHub token is available through APM's auth resolver. |
+| `marketplace config` | informational | An `apm.yml` `marketplace:` block or legacy `marketplace.yml`, when present, parses successfully. |
+| `format coverage` | informational | Marketplace output formats are configured when marketplace authoring config is present. |
+| `duplicate names` | informational | Marketplace package names do not collide. |
+| `version alignment` | informational | Local marketplace packages align with the configured versioning strategy. |
+| `executable trust` | informational | Local executable approvals are not shadowed by an org policy deny. |
+
+Critical checks determine the exit code. Informational checks explain drift or missing optional setup without failing the command.
+
+## Options
+
+| Flag | Default | Description |
+|---|---|---|
+| `-v`, `--verbose` | off | Show detailed output for each diagnostic check. |
+
+## Examples
+
+Run the quick table:
+
+```bash
+apm doctor
+```
+
+Show detailed context:
+
+```bash
+apm doctor --verbose
+```
+
+## Exit Codes
+
+| Code | Meaning |
+|---|---|
+| `0` | All critical checks passed. |
+| `1` | At least one critical check failed. |
+
+## Related
+
+- [`apm config`](../config/) -- inspect active APM configuration.
+- [`apm cache`](../cache/) -- inspect and clean the local cache.
+- [`apm runtime`](../runtime/) -- inspect runtime installation state.
+- [`apm policy explain`](../policy/) -- inspect executable-trust decisions for a package.

--- a/docs/src/content/docs/reference/cli/init.md
+++ b/docs/src/content/docs/reference/cli/init.md
@@ -32,7 +32,7 @@ and [`apm marketplace init`](../marketplace/) instead.
 
 | Flag | Default | Description |
 |---|---|---|
-| `-y`, `--yes` | off | Skip interactive prompts; use auto-detected defaults. Overwrites an existing `apm.yml` without confirmation. |
+| `-y`, `--yes` | off | Skip interactive prompts (use auto-detected defaults). Overwrites an existing `apm.yml` without confirmation. |
 | `--plugin` | off | **Deprecated.** Use [`apm plugin init`](../plugin/) instead. Scaffold a plugin authoring project: also writes `plugin.json` and adds a `devDependencies` block to `apm.yml`. Plugin name must be kebab-case, max 64 chars. |
 | `--marketplace` | off | **Deprecated.** Use [`apm marketplace init`](../marketplace/) instead. Append a `marketplace:` authoring block to `apm.yml`. See [Publish to a marketplace](../../../producer/publish-to-a-marketplace/). |
 | `--target` | (prompt) | Comma-separated target list. Skips the interactive target prompt and writes targets directly. Valid values include `copilot`, `claude`, `cursor`, `opencode`, `codex`, `gemini`, `antigravity`, `windsurf`, `kiro`, `agent-skills`, and `all`. |

--- a/docs/src/content/docs/reference/index.md
+++ b/docs/src/content/docs/reference/index.md
@@ -13,13 +13,14 @@ Per-command pages live under [`reference/cli/`](./cli/install/). Grouped by life
 
 | Phase                  | Commands                                                                         |
 |------------------------|----------------------------------------------------------------------------------|
-| Project setup          | [`init`](./cli/init/), [`install`](./cli/install/), [`update`](./cli/update/), [`uninstall`](./cli/uninstall/) |
-| Inspect and audit      | [`view`](./cli/view/), [`deps`](./cli/deps/), [`outdated`](./cli/outdated/), [`list`](./cli/list/), [`audit`](./cli/audit/) |
+| Project setup          | [`init`](./cli/init/), [`install`](./cli/install/), [`lock`](./cli/lock/), [`update`](./cli/update/), [`uninstall`](./cli/uninstall/) |
+| Inspect and audit      | [`view`](./cli/view/), [`find`](./cli/find/), [`deps`](./cli/deps/), [`outdated`](./cli/outdated/), [`list`](./cli/list/), [`audit`](./cli/audit/) |
 | Compile and integrate  | [`compile`](./cli/compile/), [`prune`](./cli/prune/), [`targets`](./cli/targets/), [`runtime`](./cli/runtime/) |
 | Cache and config       | [`cache`](./cli/cache/), [`config`](./cli/config/)                               |
 | Run scripts            | [`run`](./cli/run/)                                                              |
-| Author and distribute  | [`pack`](./cli/pack/), [`unpack`](./cli/unpack/), [`preview`](./cli/preview/), [`marketplace`](./cli/marketplace/), [`search`](./cli/search/) |
-| Governance             | [`policy`](./cli/policy/), [`mcp`](./cli/mcp/)                                   |
+| Author and distribute  | [`pack`](./cli/pack/), [`unpack`](./cli/unpack/), [`plugin`](./cli/plugin/), [`publish`](./cli/publish/), [`preview`](./cli/preview/), [`marketplace`](./cli/marketplace/), [`search`](./cli/search/) |
+| Governance             | [`approve`](./cli/approve/) / [`deny`](./cli/approve/), [`lifecycle`](./cli/lifecycle/), [`policy`](./cli/policy/), [`mcp`](./cli/mcp/) |
+| Diagnostics and utility | [`doctor`](./cli/doctor/), [`self-update`](./cli/self-update/)                   |
 | Experimental           | [`experimental`](./cli/experimental/)                                            |
 
 ## Schemas and specifications

--- a/src/apm_cli/commands/config.py
+++ b/src/apm_cli/commands/config.py
@@ -482,7 +482,9 @@ def set(key, value):  # noqa: F811
         )
 
 
-@config.command(help="Get a configuration value")
+@config.command(
+    help="Get a configuration value (omit KEY to list all settable keys with effective values)"
+)
 @click.argument("key", required=False)
 def get(key):
     """Get a configuration value or show all configuration.

--- a/src/apm_cli/commands/deps/cli.py
+++ b/src/apm_cli/commands/deps/cli.py
@@ -669,7 +669,7 @@ def tree(global_):
 @click.option(
     "--dry-run", is_flag=True, default=False, help="Show what would be removed without removing"
 )
-@click.option("--yes", "-y", is_flag=True, default=False, help="Skip confirmation prompt")
+@click.option("--yes", "-y", is_flag=True, default=False, help="Skip the confirmation prompt")
 def clean(dry_run: bool, yes: bool):
     """Remove entire apm_modules/ directory."""
     logger = CommandLogger("deps-clean")

--- a/src/apm_cli/commands/init.py
+++ b/src/apm_cli/commands/init.py
@@ -64,7 +64,7 @@ _PROMPT_TARGETS_ORDERED: list[str] = [
 @click.command(help="Initialize a new APM project")
 @click.argument("project_name", required=False)
 @click.option(
-    "--yes", "-y", is_flag=True, help="Skip interactive prompts and use auto-detected defaults"
+    "--yes", "-y", is_flag=True, help="Skip interactive prompts (use auto-detected defaults)"
 )
 @click.option(
     "--plugin",

--- a/src/apm_cli/commands/pack.py
+++ b/src/apm_cli/commands/pack.py
@@ -728,6 +728,7 @@ def _render_marketplace_catalog(logger, written: list[tuple[str | None, Path]]) 
         "[Deprecated] Extract an APM bundle into the current project. "
         "Use 'apm install <bundle-path>' instead -- this command will be removed in a future release."
     ),
+    short_help="[Deprecated] Use 'apm install <bundle-path>' instead.",
 )
 @click.argument("bundle_path", type=click.Path(exists=True))
 @click.option(

--- a/tests/integration/test_wave4_cli_commands_coverage.py
+++ b/tests/integration/test_wave4_cli_commands_coverage.py
@@ -267,6 +267,13 @@ class TestConfigCommand:
         result = self.runner.invoke(cli, ["config", "get", "auto-integrate"])
         assert result.exit_code == 0
 
+    def test_config_get_help_describes_no_argument_listing(self, tmp_path: Path) -> None:
+        """``config get --help`` documents the no-argument list-all behavior."""
+        os.chdir(tmp_path)
+        result = self.runner.invoke(cli, ["config", "get", "--help"])
+        assert result.exit_code == 0
+        assert "omit KEY to list all settable keys" in result.output
+
 
 # ====== Experimental Command Tests ======
 

--- a/tests/integration/test_wave6_init_pack_coverage.py
+++ b/tests/integration/test_wave6_init_pack_coverage.py
@@ -412,6 +412,13 @@ class TestInitPluginNameValidation:
 class TestPackBasic:
     """Basic pack invocations with a skill project."""
 
+    def test_top_level_help_names_unpack_replacement(self, runner):
+        """Top-level command list names the replacement for deprecated unpack."""
+        result = runner.invoke(cli, ["--help"])
+        assert result.exit_code == 0, result.output
+        assert "unpack" in result.output
+        assert "apm install <bundle-path>" in result.output
+
     def test_pack_skill_project(self, runner, tmp_path, monkeypatch):
         """apm pack in a skill project produces output files."""
         monkeypatch.chdir(tmp_path)


### PR DESCRIPTION
## Summary

Fixes #1968.

- add the missing `apm doctor` CLI reference page and link it from the reference index
- add missing existing commands to the reference index and fix the README CLI reference URL
- clarify `config get`, `deps clean --yes`, `init --yes`, and deprecated `unpack` help text
- add CLI help regression coverage for `config get --help` and the top-level `unpack` replacement summary

## Verification

- `uv run pytest tests/integration/test_wave4_cli_commands_coverage.py::TestConfigCommand tests/integration/test_wave6_deps_cli_coverage.py::TestDepsClean tests/integration/test_wave6_init_pack_coverage.py::TestInitBasic tests/integration/test_wave6_init_pack_coverage.py::TestPackBasic -q`
- `uv run ruff check src/apm_cli/commands/config.py src/apm_cli/commands/deps/cli.py src/apm_cli/commands/init.py src/apm_cli/commands/pack.py tests/integration/test_wave4_cli_commands_coverage.py tests/integration/test_wave6_init_pack_coverage.py`
- `uv run ruff format --check src/apm_cli/commands/config.py src/apm_cli/commands/deps/cli.py src/apm_cli/commands/init.py src/apm_cli/commands/pack.py tests/integration/test_wave4_cli_commands_coverage.py tests/integration/test_wave6_init_pack_coverage.py`
- `uv run apm --help`
- `uv run apm config get --help`
- `uv run apm deps clean --help`
- `uv run apm init --help`
- `uv run apm doctor --help`
- `git diff --check`
- `cd docs && npm ci && npm run build` (passes; existing Astro/Vite warnings only, internal links valid)

Signed-off-by: WilliamK112 <WilliamK112@users.noreply.github.com>