### PR TITLE
perf(resolve): share one RefResolver per repo so ls-remote runs once per repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `apm install` now issues a single `git ls-remote` call per repository when
   resolving multiple semver git dependencies from the same remote, reducing
   network round-trips for monorepos with many shared-origin semver deps. (#1975)
+- `apm outdated` now dedupes `git ls-remote` across locked dependencies that
+  share one upstream repository (e.g. several virtual-subdirectory packages
+  from the same monorepo), issuing one listing per repo per run instead of one
+  per dependency. The cache is per-invocation, so a newer upstream ref is still
+  detected on the next run. (#1975)
 
 ## [0.23.1] - 2026-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.git` path now install successfully over anonymous HTTPS; `apm install` no
   longer drops the suffix. (#1995)
 
+### Performance
+
+- `apm install` now issues a single `git ls-remote` call per repository when
+  resolving multiple semver git dependencies from the same remote, reducing
+  network round-trips for monorepos with many shared-origin semver deps. (#1975)
+
 ## [0.23.1] - 2026-06-29
 
 ### Fixed

--- a/src/apm_cli/commands/outdated.py
+++ b/src/apm_cli/commands/outdated.py
@@ -519,6 +519,14 @@ def outdated(global_, verbose, parallel_checks):
 
         registry_ctx = load_registry_outdated_context(project_root, lockfile)
 
+    # Dedupe redundant ``git ls-remote`` across same-repo deps for the span
+    # of this invocation (e.g. many virtual-subdirectory packages from one
+    # monorepo). Mirrors the install-path RefResolver reuse (#1975); fresh
+    # per run, so a newer upstream ref is still seen on the next invocation.
+    from ..deps.outdated_ref_cache import OutdatedRefCache
+
+    downloader = OutdatedRefCache(downloader)
+
     # Check deps with progress feedback and optional parallelism
     rows = _check_deps_with_progress(
         checkable, downloader, verbose, parallel_checks, logger, registry_ctx

--- a/src/apm_cli/deps/outdated_ref_cache.py
+++ b/src/apm_cli/deps/outdated_ref_cache.py
@@ -1,0 +1,107 @@
+"""Per-invocation ``git ls-remote`` dedup for ``apm outdated``.
+
+``apm outdated`` checks every locked dependency against its upstream by
+calling ``downloader.list_remote_refs`` / ``list_remote_tag_refs``, each of
+which issues a fresh ``git ls-remote`` (see
+:class:`apm_cli.deps.git_reference_resolver.GitReferenceResolver`). When
+several locked deps share one upstream repo -- e.g. multiple virtual
+subdirectory packages carved out of the same monorepo -- that is one
+redundant ``ls-remote`` per dep for identical output.
+
+This wrapper collapses those redundant round-trips to one per
+(repo-identity, ref-family) within a single ``apm outdated`` invocation. It
+is the ``outdated``-surface analogue of the install-path RefResolver reuse
+in :mod:`apm_cli.install.helpers.ref_reuse`, extending the dedup so the
+optimization is pervasive across install and outdated.
+
+Correctness: the cache is built fresh per invocation and never persisted, so
+a newer upstream ref pushed between two ``apm outdated`` runs is still seen
+on the next run. Within one run every same-repo dep observes one consistent
+ls-remote snapshot, which cannot make ``outdated`` miss a newer upstream ref
+(the snapshot is the freshest listing of this run). Failures are not cached,
+preserving the per-dep ``unknown`` degradation of the un-wrapped path.
+
+Auth-lens: the cache key is the repo *identity* (host, repo_url, port,
+insecure-transport, ref-family) -- never a token. Two deps from one repo
+resolve the same credential via ``AuthResolver`` and the same upstream refs,
+so identity alone is a sufficient and non-secret key.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..models.dependency.reference import DependencyReference
+    from ..models.dependency.types import RemoteRef
+
+
+def _identity_key(dep_ref: DependencyReference, include_heads: bool) -> tuple:
+    """Return a non-secret cache key for *dep_ref*'s ls-remote listing.
+
+    ``include_heads`` distinguishes the tags+branches listing
+    (``list_remote_refs``) from the tags-only listing
+    (``list_remote_tag_refs``): the two return different ref sets and must
+    not share a bucket. No token is part of the key -- see module docstring.
+    """
+    return (
+        dep_ref.host or "",
+        dep_ref.repo_url or "",
+        getattr(dep_ref, "port", None),
+        bool(getattr(dep_ref, "is_insecure", False)),
+        include_heads,
+    )
+
+
+class OutdatedRefCache:
+    """Thread-safe, per-invocation ``ls-remote`` dedup around a downloader.
+
+    Wraps a ``GitHubPackageDownloader`` so the two ref-listing methods used
+    by ``apm outdated`` memoize their result per repo identity while every
+    other attribute/method delegates to the wrapped downloader unchanged.
+    Concurrent first-touches for the same key coalesce under a per-key lock
+    so the parallel ``-j`` path still issues exactly one ``ls-remote``.
+    """
+
+    def __init__(self, downloader: Any) -> None:
+        self._downloader = downloader
+        self._results: dict[tuple, list[RemoteRef]] = {}
+        self._key_locks: dict[tuple, threading.Lock] = {}
+        self._master_lock = threading.Lock()
+
+    def __getattr__(self, name: str) -> Any:
+        # Delegate everything not overridden here (registry/marketplace paths,
+        # tiered-resolver wiring, etc.) to the wrapped downloader untouched.
+        return getattr(self._downloader, name)
+
+    def list_remote_refs(self, dep_ref: DependencyReference) -> list[RemoteRef]:
+        return self._cached(dep_ref, include_heads=True)
+
+    def list_remote_tag_refs(self, dep_ref: DependencyReference) -> list[RemoteRef]:
+        return self._cached(dep_ref, include_heads=False)
+
+    def _cached(self, dep_ref: DependencyReference, *, include_heads: bool) -> list[RemoteRef]:
+        key = _identity_key(dep_ref, include_heads)
+        with self._master_lock:
+            cached = self._results.get(key)
+            if cached is not None:
+                return cached
+            key_lock = self._key_locks.get(key)
+            if key_lock is None:
+                key_lock = threading.Lock()
+                self._key_locks[key] = key_lock
+        # Compute outside the master lock (so distinct repos fetch in
+        # parallel) but under a per-key lock (so same-repo first-touches
+        # coalesce to one ls-remote). Failures propagate uncached, matching
+        # the un-wrapped per-dep 'unknown' degradation.
+        with key_lock:
+            cached = self._results.get(key)
+            if cached is not None:
+                return cached
+            if include_heads:
+                refs = self._downloader.list_remote_refs(dep_ref)
+            else:
+                refs = self._downloader.list_remote_tag_refs(dep_ref)
+            self._results[key] = refs
+            return refs

--- a/src/apm_cli/install/context.py
+++ b/src/apm_cli/install/context.py
@@ -121,6 +121,11 @@ class InstallContext:
     # consumed by install/sources.py to plumb the resolution into the
     # lockfile via InstalledPackage.git_semver_resolution.
     git_semver_resolutions: dict[str, Any] = field(default_factory=dict)
+    # Run-scoped cache of RefResolver instances keyed by (host, token) so
+    # semver deps sharing an upstream repo reuse one ``git ls-remote`` tag
+    # listing (RefResolver memoizes per instance) instead of one per dep.
+    # Populated lazily in _maybe_resolve_git_semver during the resolve phase.
+    ref_resolver_cache: dict[Any, Any] = field(default_factory=dict)
     managed_files: set[str] = field(default_factory=set)
 
     # ------------------------------------------------------------------

--- a/src/apm_cli/install/context.py
+++ b/src/apm_cli/install/context.py
@@ -121,11 +121,11 @@ class InstallContext:
     # consumed by install/sources.py to plumb the resolution into the
     # lockfile via InstalledPackage.git_semver_resolution.
     git_semver_resolutions: dict[str, Any] = field(default_factory=dict)
-    # Run-scoped cache of RefResolver instances keyed by (host, token) so
-    # semver deps sharing an upstream repo reuse one ``git ls-remote`` tag
+    # Run-scoped cache of RefResolver instances keyed by (host, token-fingerprint)
+    # so semver deps sharing an upstream repo reuse one ``git ls-remote`` tag
     # listing (RefResolver memoizes per instance) instead of one per dep.
     # Populated lazily in _maybe_resolve_git_semver during the resolve phase.
-    ref_resolver_cache: dict[Any, Any] = field(default_factory=dict)
+    ref_resolver_cache: dict[tuple[str | None, str | None], Any] = field(default_factory=dict)
     managed_files: set[str] = field(default_factory=set)
 
     # ------------------------------------------------------------------

--- a/src/apm_cli/install/helpers/ref_reuse.py
+++ b/src/apm_cli/install/helpers/ref_reuse.py
@@ -53,7 +53,10 @@ def get_shared_ref_resolver(
     if cache is None:
         return RefResolver(host=host, token=token)
 
-    key = (host, token)
+    import hashlib
+
+    token_key = None if token is None else hashlib.sha256(token.encode("utf-8")).digest()
+    key = (host, token_key)
     if lock is not None:
         with lock:
             resolver = cache.get(key)

--- a/src/apm_cli/install/helpers/ref_reuse.py
+++ b/src/apm_cli/install/helpers/ref_reuse.py
@@ -1,0 +1,69 @@
+"""Run-scoped RefResolver reuse for semver resolution.
+
+Extracted from :mod:`apm_cli.install.phases.resolve` to keep that phase
+module within its LOC budget (see
+``tests/unit/install/test_architecture_invariants.py``).
+
+Multiple semver deps from the same upstream repo should share one
+``RefResolver`` so its per-instance ``git ls-remote`` tag listing is fetched
+once per repo instead of once per dep.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def resolve_dep_token(dep_ref: Any, auth_resolver: Any) -> str | None:
+    """Resolve the per-dep token via AuthResolver for use by ``git ls-remote``.
+
+    Uses the same credential source the downstream clone will use. Without
+    this threading, ls-remote on a private repo would rely on the host's git
+    credential helper (present on dev laptops, absent in CI). Best-effort:
+    on any failure the unauth path remains and the downstream clone surfaces
+    the real auth error with its own diagnostic.
+    """
+    if auth_resolver is None:
+        return None
+    try:
+        auth_ctx = auth_resolver.resolve_for_dep(dep_ref)
+        return auth_ctx.token if auth_ctx is not None else None
+    except Exception:
+        return None
+
+
+def get_shared_ref_resolver(
+    host: str | None,
+    token: str | None,
+    cache: dict[Any, Any] | None,
+    lock: Any = None,
+) -> Any:
+    """Return a ``RefResolver`` for ``(host, token)``, reused across a run.
+
+    When ``cache`` is provided, resolvers are memoized by ``(host, token)``
+    so the second and later deps from a repo reuse the instance (and its
+    ref cache). When ``lock`` is also provided, the get-or-create runs under
+    it -- required because the BFS download callback runs on a worker pool,
+    where unguarded concurrent first-touches would each build a resolver and
+    defeat the dedup. ``cache=None`` (the default caller behavior) builds a
+    fresh resolver per call, preserving the legacy one-per-dep path.
+    """
+    from apm_cli.marketplace.ref_resolver import RefResolver
+
+    if cache is None:
+        return RefResolver(host=host, token=token)
+
+    key = (host, token)
+    if lock is not None:
+        with lock:
+            resolver = cache.get(key)
+            if resolver is None:
+                resolver = RefResolver(host=host, token=token)
+                cache[key] = resolver
+            return resolver
+
+    resolver = cache.get(key)
+    if resolver is None:
+        resolver = RefResolver(host=host, token=token)
+        cache[key] = resolver
+    return resolver

--- a/src/apm_cli/install/helpers/ref_reuse.py
+++ b/src/apm_cli/install/helpers/ref_reuse.py
@@ -11,7 +11,21 @@ once per repo instead of once per dep.
 
 from __future__ import annotations
 
+import hashlib
 from typing import Any
+
+
+def _token_fingerprint(token: str | None) -> str | None:
+    """Return a non-reversible fingerprint of ``token`` for use as a cache key.
+
+    The cache lives on ``InstallContext``; keying by the raw PAT would leak
+    the credential into any ``repr(ctx)`` / debug dump / dict-key trace. A
+    truncated SHA-256 keeps distinct tokens in distinct buckets without
+    storing the secret. ``None`` (unauthenticated) maps to ``None``.
+    """
+    if token is None:
+        return None
+    return "sha256:" + hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
 
 
 def resolve_dep_token(dep_ref: Any, auth_resolver: Any) -> str | None:
@@ -40,23 +54,23 @@ def get_shared_ref_resolver(
 ) -> Any:
     """Return a ``RefResolver`` for ``(host, token)``, reused across a run.
 
-    When ``cache`` is provided, resolvers are memoized by ``(host, token)``
-    so the second and later deps from a repo reuse the instance (and its
-    ref cache). When ``lock`` is also provided, the get-or-create runs under
-    it -- required because the BFS download callback runs on a worker pool,
-    where unguarded concurrent first-touches would each build a resolver and
-    defeat the dedup. ``cache=None`` (the default caller behavior) builds a
-    fresh resolver per call, preserving the legacy one-per-dep path.
+    When ``cache`` is provided, resolvers are memoized so the second and
+    later deps from a repo reuse the instance (and its ref cache). The cache
+    key is ``(host, fingerprint(token))`` -- a non-reversible token
+    fingerprint, never the raw PAT, so the credential is not exposed via the
+    context object this cache lives on. When ``lock`` is also provided, the
+    get-or-create runs under it -- required because the BFS download callback
+    runs on a worker pool, where unguarded concurrent first-touches would
+    each build a resolver and defeat the dedup. ``cache=None`` (the default
+    caller behavior) builds a fresh resolver per call, preserving the legacy
+    one-per-dep path.
     """
     from apm_cli.marketplace.ref_resolver import RefResolver
 
     if cache is None:
         return RefResolver(host=host, token=token)
 
-    import hashlib
-
-    token_key = None if token is None else hashlib.sha256(token.encode("utf-8")).digest()
-    key = (host, token_key)
+    key = (host, _token_fingerprint(token))
     if lock is not None:
         with lock:
             resolver = cache.get(key)

--- a/src/apm_cli/install/helpers/ref_reuse.py
+++ b/src/apm_cli/install/helpers/ref_reuse.py
@@ -56,21 +56,31 @@ def get_shared_ref_resolver(
 
     When ``cache`` is provided, resolvers are memoized so the second and
     later deps from a repo reuse the instance (and its ref cache). The cache
-    key is ``(host, fingerprint(token))`` -- a non-reversible token
+    key is ``(normalized_host, fingerprint(token))`` -- a non-reversible token
     fingerprint, never the raw PAT, so the credential is not exposed via the
-    context object this cache lives on. When ``lock`` is also provided, the
-    get-or-create runs under it -- required because the BFS download callback
-    runs on a worker pool, where unguarded concurrent first-touches would
-    each build a resolver and defeat the dedup. ``cache=None`` (the default
-    caller behavior) builds a fresh resolver per call, preserving the legacy
-    one-per-dep path.
+    context object this cache lives on. ``host`` is normalized to ``None``
+    meaning "use RefResolver default (github.com)", so a dep written with an
+    explicit ``host='github.com'`` and one with no host collapse to the same
+    cache bucket. When ``lock`` is also provided, the get-or-create runs under
+    it -- required because the BFS download callback runs on a worker pool,
+    where unguarded concurrent first-touches would each build a resolver and
+    defeat the dedup. ``cache=None`` (the default caller behavior) builds a
+    fresh resolver per call, preserving the legacy one-per-dep path. Token
+    rotation mid-run is intentionally unsupported: once a resolver is cached,
+    its embedded token is fixed for the lifetime of the run (APM installs are
+    short-lived; tokens do not rotate mid-process).
     """
     from apm_cli.marketplace.ref_resolver import RefResolver
+
+    # Normalize the default github.com host so deps that omit host and deps
+    # that spell out 'github.com' explicitly share the same cache bucket.
+    _DEFAULT_HOST = "github.com"
+    canonical_host = host if host and host != _DEFAULT_HOST else None
 
     if cache is None:
         return RefResolver(host=host, token=token)
 
-    key = (host, _token_fingerprint(token))
+    key = (canonical_host, _token_fingerprint(token))
     if lock is not None:
         with lock:
             resolver = cache.get(key)

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -79,6 +79,8 @@ def _maybe_resolve_git_semver(
     existing_lockfile,
     update_refs: bool,
     auth_resolver=None,
+    ref_resolver_cache=None,
+    ref_resolver_cache_lock=None,
 ):
     """Resolve a git-source semver-range ``ref:`` to a concrete tag.
 
@@ -152,24 +154,17 @@ def _maybe_resolve_git_semver(
 
     # Fresh resolution: call git ls-remote and pick the highest matching tag.
     from apm_cli.deps.git_semver_resolver import GitSemverResolver
-    from apm_cli.marketplace.ref_resolver import RefResolver
+    from apm_cli.install.helpers.ref_reuse import (
+        get_shared_ref_resolver,
+        resolve_dep_token,
+    )
 
-    # Resolve the per-dep token via AuthResolver so ls-remote uses the
-    # same credential source the downstream clone will use. Without this
-    # threading, ls-remote on a private repo would rely on the host's
-    # git credential helper (present on dev laptops, absent in CI).
-    token: str | None = None
-    if auth_resolver is not None:
-        try:
-            auth_ctx = auth_resolver.resolve_for_dep(dep_ref)
-            token = auth_ctx.token if auth_ctx is not None else None
-        except Exception:
-            # Auth lookup is best-effort here: if it fails the unauth path
-            # remains, the downstream clone will surface the real auth
-            # error with its own actionable diagnostic.
-            token = None
-
-    ref_resolver = RefResolver(host=dep_ref.host, token=token)
+    # Reuse one RefResolver per (host, token) so same-repo deps share a
+    # single ls-remote tag listing (see helpers.ref_reuse for rationale).
+    token = resolve_dep_token(dep_ref, auth_resolver)
+    ref_resolver = get_shared_ref_resolver(
+        dep_ref.host, token, ref_resolver_cache, ref_resolver_cache_lock
+    )
     resolver = GitSemverResolver(ref_resolver)
     return resolver.resolve(
         owner_repo=owner_repo,
@@ -643,6 +638,8 @@ def _resolve_dependencies(ctx: InstallContext) -> None:
                 existing_lockfile=existing_lockfile,
                 update_refs=update_refs,
                 auth_resolver=ctx.auth_resolver,
+                ref_resolver_cache=ctx.ref_resolver_cache,
+                ref_resolver_cache_lock=callback_lock,
             )
             if _semver_resolution is not None:
                 with callback_lock:

--- a/tests/unit/deps/test_outdated_ref_cache.py
+++ b/tests/unit/deps/test_outdated_ref_cache.py
@@ -1,0 +1,264 @@
+"""Tests for per-invocation ``ls-remote`` dedup in ``apm outdated``.
+
+Two axes are exercised:
+
+1. **Dedup (the optimization).** Multiple locked deps sharing one upstream
+   repo issue exactly one ``git ls-remote`` per ref-family, both directly on
+   :class:`OutdatedRefCache` and end-to-end through ``apm outdated``. Each
+   dedup assertion is written to *fail* if the wrapper were removed (the raw
+   per-dep path issues one ls-remote per dep).
+2. **Correctness (no degradation).** Distinct repos never share a cached
+   listing, tag-only and tags+branches families never collide, failures are
+   not cached, and ``apm outdated`` still reports accurate
+   up-to-date/outdated status for same-repo deps -- a stale cache must never
+   surface a false "up to date".
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "src"))
+
+from apm_cli.deps.outdated_ref_cache import OutdatedRefCache, _identity_key
+from apm_cli.models.dependency.reference import DependencyReference
+from apm_cli.models.dependency.types import GitReferenceType, RemoteRef
+
+
+def _dep(repo_url: str = "owner/repo", host=None, virtual_path=None) -> DependencyReference:
+    return DependencyReference(
+        repo_url=repo_url,
+        reference="v1.0.0",
+        host=host,
+        virtual_path=virtual_path,
+        is_virtual=bool(virtual_path),
+    )
+
+
+def _tag(name: str, sha: str = "abc123") -> RemoteRef:
+    return RemoteRef(name=name, ref_type=GitReferenceType.TAG, commit_sha=sha)
+
+
+# ---------------------------------------------------------------------------
+# Dedup on OutdatedRefCache directly
+# ---------------------------------------------------------------------------
+def test_same_repo_deps_issue_one_ls_remote():
+    """Three same-repo (different-subdir) deps -> one underlying ls-remote.
+
+    Traps the regression: the un-wrapped downloader lists refs once per dep,
+    so this asserts call_count == 1 (not 3).
+    """
+    inner = MagicMock()
+    inner.list_remote_refs.return_value = [_tag("v1.0.0")]
+    cache = OutdatedRefCache(inner)
+
+    deps = [
+        _dep(virtual_path="packages/a"),
+        _dep(virtual_path="packages/b"),
+        _dep(virtual_path="packages/c"),
+    ]
+    results = [cache.list_remote_refs(d) for d in deps]
+
+    assert inner.list_remote_refs.call_count == 1
+    # Every caller still gets the correct refs back.
+    assert all(r == [_tag("v1.0.0")] for r in results)
+
+
+def test_distinct_repos_each_fetch():
+    """Different repos must not share a cached listing (no cross-repo bleed)."""
+    inner = MagicMock()
+    inner.list_remote_refs.side_effect = [[_tag("v1.0.0")], [_tag("v2.0.0")]]
+    cache = OutdatedRefCache(inner)
+
+    a = cache.list_remote_refs(_dep("owner/alpha"))
+    b = cache.list_remote_refs(_dep("owner/beta"))
+
+    assert inner.list_remote_refs.call_count == 2
+    assert a == [_tag("v1.0.0")]
+    assert b == [_tag("v2.0.0")]
+
+
+def test_distinct_hosts_each_fetch():
+    """Same repo path on different hosts are distinct upstreams."""
+    inner = MagicMock()
+    inner.list_remote_refs.side_effect = [[_tag("v1.0.0")], [_tag("v9.9.9")]]
+    cache = OutdatedRefCache(inner)
+
+    cache.list_remote_refs(_dep("owner/repo", host=None))
+    cache.list_remote_refs(_dep("owner/repo", host="example.com"))
+
+    assert inner.list_remote_refs.call_count == 2
+
+
+def test_tag_family_and_heads_family_do_not_collide():
+    """tags-only and tags+branches are different listings; both fetched once."""
+    inner = MagicMock()
+    inner.list_remote_refs.return_value = [_tag("v1.0.0")]
+    inner.list_remote_tag_refs.return_value = [_tag("v1.0.0")]
+    cache = OutdatedRefCache(inner)
+
+    cache.list_remote_refs(_dep())
+    cache.list_remote_refs(_dep(virtual_path="packages/b"))
+    cache.list_remote_tag_refs(_dep())
+    cache.list_remote_tag_refs(_dep(virtual_path="packages/b"))
+
+    assert inner.list_remote_refs.call_count == 1
+    assert inner.list_remote_tag_refs.call_count == 1
+
+
+def test_failures_are_not_cached():
+    """A raised ls-remote must not poison the cache (per-dep unknown preserved)."""
+    inner = MagicMock()
+    inner.list_remote_refs.side_effect = [RuntimeError("boom"), [_tag("v1.0.0")]]
+    cache = OutdatedRefCache(inner)
+
+    try:
+        cache.list_remote_refs(_dep())
+        raise AssertionError("expected RuntimeError")
+    except RuntimeError:
+        pass
+
+    # Second attempt for the same repo re-fetches (failure was not cached).
+    assert cache.list_remote_refs(_dep()) == [_tag("v1.0.0")]
+    assert inner.list_remote_refs.call_count == 2
+
+
+def test_delegates_unknown_attributes_to_wrapped_downloader():
+    """Non-ref methods/attrs pass through untouched (registry/marketplace paths)."""
+    inner = MagicMock()
+    inner.persistent_git_cache = "sentinel"
+    inner.some_method.return_value = 42
+    cache = OutdatedRefCache(inner)
+
+    assert cache.persistent_git_cache == "sentinel"
+    assert cache.some_method() == 42
+
+
+def test_identity_key_contains_no_token():
+    """Auth-lens: the cache key is repo identity, never a credential."""
+    secret = "ghp_SUPERSECRETTOKENVALUE1234567890"
+    dep = _dep()
+    dep.token = secret  # even if a token rode along, it must not enter the key
+    key = _identity_key(dep, include_heads=True)
+    assert secret not in repr(key)
+
+
+def test_concurrent_same_repo_coalesces_to_one_fetch():
+    """Parallel first-touches for one repo issue exactly one ls-remote."""
+    import time
+
+    n_threads = 8
+    calls: list[int] = []
+    calls_lock = threading.Lock()
+    barrier = threading.Barrier(n_threads)
+    errors: list[BaseException] = []
+
+    class _SlowInner:
+        def list_remote_refs(self, dep_ref):
+            # Widen the fetch window so an unlocked implementation would let
+            # several threads in and record multiple calls.
+            time.sleep(0.02)
+            with calls_lock:
+                calls.append(1)
+            return [_tag("v1.0.0")]
+
+        def list_remote_tag_refs(self, dep_ref):  # pragma: no cover - unused here
+            return []
+
+    cache = OutdatedRefCache(_SlowInner())
+
+    def worker(i):
+        try:
+            barrier.wait(timeout=5)
+            cache.list_remote_refs(_dep(virtual_path=f"packages/p{i}"))
+        except BaseException as exc:  # surfaced on main thread
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert not any(t.is_alive() for t in threads), "worker thread(s) did not terminate"
+    assert not errors, f"worker thread(s) raised: {errors!r}"
+    assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through ``apm outdated``: dedup AND correctness preserved
+# ---------------------------------------------------------------------------
+_PATCH_LOCKFILE = "apm_cli.deps.lockfile.LockFile"
+_PATCH_GET_LOCKFILE_PATH = "apm_cli.deps.lockfile.get_lockfile_path"
+_PATCH_MIGRATE = "apm_cli.deps.lockfile.migrate_lockfile_if_needed"
+_PATCH_DOWNLOADER = "apm_cli.deps.github_downloader.GitHubPackageDownloader"
+_PATCH_AUTH = "apm_cli.core.auth.AuthResolver"
+_PATCH_GET_APM_DIR = "apm_cli.core.scope.get_apm_dir"
+
+
+def _locked(repo_url, virtual_path, resolved_ref):
+    from apm_cli.deps.lockfile import LockedDependency
+
+    return LockedDependency(
+        repo_url=repo_url,
+        resolved_ref=resolved_ref,
+        resolved_commit="deadbee",
+        virtual_path=virtual_path,
+        is_virtual=True,
+    )
+
+
+def _make_lockfile(deps_dict):
+    from apm_cli.deps.lockfile import LockFile
+
+    lf = LockFile()
+    lf.dependencies = deps_dict
+    return lf
+
+
+def test_outdated_command_dedupes_and_preserves_correctness(tmp_path):
+    """Two same-repo virtual deps -> one ls-remote, and outdated stays accurate.
+
+    Locked at v1.0.0 while upstream's highest tag is v2.0.0: both rows must
+    report ``outdated`` (a stale/misapplied cache would wrongly say
+    ``up-to-date``), while the shared upstream is listed exactly once.
+    """
+    from click.testing import CliRunner
+
+    from apm_cli.cli import cli
+
+    deps = {
+        "org/mono#packages/a": _locked("org/mono", "packages/a", "v1.0.0"),
+        "org/mono#packages/b": _locked("org/mono", "packages/b", "v1.0.0"),
+    }
+
+    inner = MagicMock()
+    # Same upstream repo -> one listing; highest tag is v2.0.0 (newer).
+    inner.list_remote_refs.return_value = [_tag("v1.0.0"), _tag("v2.0.0")]
+
+    cwd = os.getcwd()
+    with (
+        patch(_PATCH_MIGRATE),
+        patch(_PATCH_GET_LOCKFILE_PATH, return_value=tmp_path / "apm.lock.yaml"),
+        patch(_PATCH_GET_APM_DIR, return_value=tmp_path),
+        patch(_PATCH_LOCKFILE) as mock_lf_cls,
+        patch(_PATCH_DOWNLOADER, return_value=inner),
+        patch(_PATCH_AUTH),
+    ):
+        mock_lf_cls.read.return_value = _make_lockfile(deps)
+        try:
+            os.chdir(tmp_path)
+            # -j 0 => sequential, so the dedup count is deterministic.
+            result = CliRunner().invoke(cli, ["outdated", "-j", "0"])
+        finally:
+            os.chdir(cwd)
+
+    assert result.exit_code == 0, result.output
+    # Dedup: one shared upstream listed exactly once (would be 2 un-wrapped).
+    assert inner.list_remote_refs.call_count == 1
+    # Correctness: both same-repo deps still reported outdated (v1 -> v2).
+    assert "outdated" in result.output.lower()
+    assert "up-to-date" not in result.output.lower()

--- a/tests/unit/install/phases/test_resolve_ref_resolver_reuse.py
+++ b/tests/unit/install/phases/test_resolve_ref_resolver_reuse.py
@@ -95,8 +95,11 @@ def test_concurrent_same_repo_deps_share_one_resolver_under_lock():
     import threading
     import time
 
+    n_threads = 8
     made = []
-    all_started = threading.Barrier(8)
+    all_started = threading.Barrier(n_threads)
+    errors: list[BaseException] = []
+    errors_lock = threading.Lock()
 
     class _SlowFakeRefResolver:
         def __init__(self, *, host=None, token=None):
@@ -113,26 +116,36 @@ def test_concurrent_same_repo_deps_share_one_resolver_under_lock():
 
     def worker(i):
         # Release all threads at once so they contend on the cache together.
-        all_started.wait(timeout=5)
-        _maybe_resolve_git_semver(
-            dep_ref=_semver_dep("owner/repo", f"packages/p{i}"),
-            existing_lockfile=None,
-            update_refs=False,
-            ref_resolver_cache=cache,
-            ref_resolver_cache_lock=lock,
-        )
+        # Capture any exception so a failure inside a worker thread surfaces
+        # as a test failure instead of a lost/warning-only thread error.
+        try:
+            all_started.wait(timeout=5)
+            _maybe_resolve_git_semver(
+                dep_ref=_semver_dep("owner/repo", f"packages/p{i}"),
+                existing_lockfile=None,
+                update_refs=False,
+                ref_resolver_cache=cache,
+                ref_resolver_cache_lock=lock,
+            )
+        except BaseException as exc:  # re-raised on the main thread
+            with errors_lock:
+                errors.append(exc)
 
     with (
         patch("apm_cli.marketplace.ref_resolver.RefResolver", _SlowFakeRefResolver),
         patch("apm_cli.deps.git_semver_resolver.GitSemverResolver", fake_semver),
     ):
-        threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(n_threads)]
         for t in threads:
             t.start()
         for t in threads:
             t.join(timeout=10)
 
-    # Exactly one resolver despite 8 concurrent first-touches.
+    # Every worker must have terminated (no hang / deadlock).
+    assert not any(t.is_alive() for t in threads), "worker thread(s) did not terminate"
+    # Any exception raised inside a worker must fail the test, not be swallowed.
+    assert not errors, f"worker thread(s) raised: {errors!r}"
+    # Exactly one resolver despite n concurrent first-touches.
     assert len(made) == 1
     assert len(cache) == 1
 
@@ -163,4 +176,29 @@ def test_distinct_hosts_get_distinct_resolvers():
             )
     # Different host -> different cache key -> two resolvers.
     assert len(made) == 2
+    assert len(cache) == 2
+
+
+def test_cache_key_does_not_contain_raw_token():
+    """The raw PAT must never appear in a cache key (leak prevention)."""
+    from apm_cli.install.helpers.ref_reuse import get_shared_ref_resolver
+
+    secret = "ghp_SUPERSECRETTOKENVALUE1234567890"
+    cache: dict = {}
+
+    class _FakeRefResolver:
+        def __init__(self, *, host=None, token=None):
+            self.token = token
+
+    with patch("apm_cli.marketplace.ref_resolver.RefResolver", _FakeRefResolver):
+        resolver = get_shared_ref_resolver("github.com", secret, cache)
+
+    # The resolver still receives the real token (auth works)...
+    assert resolver.token == secret
+    # ...but no cache key exposes it.
+    for key in cache:
+        assert secret not in repr(key)
+    # Distinct tokens still map to distinct buckets.
+    with patch("apm_cli.marketplace.ref_resolver.RefResolver", _FakeRefResolver):
+        get_shared_ref_resolver("github.com", "ghp_a_different_token_000000", cache)
     assert len(cache) == 2

--- a/tests/unit/install/phases/test_resolve_ref_resolver_reuse.py
+++ b/tests/unit/install/phases/test_resolve_ref_resolver_reuse.py
@@ -1,0 +1,166 @@
+"""Unit tests for run-scoped RefResolver reuse in ``_maybe_resolve_git_semver``.
+
+Multiple semver deps that resolve against the same upstream repo should share
+one ``RefResolver`` instance (and therefore one ``git ls-remote`` tag listing)
+instead of constructing a fresh resolver -- and a fresh ls-remote -- per dep.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "src"))
+
+from apm_cli.install.phases.resolve import _maybe_resolve_git_semver
+from apm_cli.models.dependency.reference import DependencyReference
+
+
+def _semver_dep(repo_url: str, virtual_path: str) -> DependencyReference:
+    """A git-source semver-range dep (ref_kind == 'semver')."""
+    return DependencyReference(
+        repo_url=repo_url,
+        reference=">=0.0.1",
+        virtual_path=virtual_path,
+        is_virtual=True,
+    )
+
+
+def _patched_resolver_env():
+    """Patch RefResolver (counting ctor) + GitSemverResolver (no-op resolve)."""
+    made = []
+
+    class _FakeRefResolver:
+        def __init__(self, *, host=None, token=None):
+            made.append((host, token))
+
+    fake_semver = MagicMock()
+    fake_semver.return_value.resolve.return_value = "RESOLUTION"
+    return made, _FakeRefResolver, fake_semver
+
+
+def test_same_repo_deps_share_one_ref_resolver():
+    made, fake_ref, fake_semver = _patched_resolver_env()
+    cache: dict = {}
+    deps = [
+        _semver_dep("owner/repo", "packages/a"),
+        _semver_dep("owner/repo", "packages/b"),
+        _semver_dep("owner/repo", "packages/c"),
+    ]
+    with (
+        patch("apm_cli.marketplace.ref_resolver.RefResolver", fake_ref),
+        patch("apm_cli.deps.git_semver_resolver.GitSemverResolver", fake_semver),
+    ):
+        for d in deps:
+            _maybe_resolve_git_semver(
+                dep_ref=d,
+                existing_lockfile=None,
+                update_refs=False,
+                ref_resolver_cache=cache,
+            )
+    # Three deps, same (host, token) -> exactly one RefResolver constructed.
+    assert len(made) == 1
+    assert len(cache) == 1
+
+
+def test_no_cache_constructs_one_resolver_per_dep():
+    """Default (cache=None) preserves the legacy one-resolver-per-dep path."""
+    made, fake_ref, fake_semver = _patched_resolver_env()
+    deps = [
+        _semver_dep("owner/repo", "packages/a"),
+        _semver_dep("owner/repo", "packages/b"),
+    ]
+    with (
+        patch("apm_cli.marketplace.ref_resolver.RefResolver", fake_ref),
+        patch("apm_cli.deps.git_semver_resolver.GitSemverResolver", fake_semver),
+    ):
+        for d in deps:
+            _maybe_resolve_git_semver(
+                dep_ref=d,
+                existing_lockfile=None,
+                update_refs=False,
+                ref_resolver_cache=None,
+            )
+    assert len(made) == 2
+
+
+def test_concurrent_same_repo_deps_share_one_resolver_under_lock():
+    """Under a lock, parallel first-touch resolves still build one resolver.
+
+    Mirrors the level-batched worker pool: many threads call
+    _maybe_resolve_git_semver for the same (host, token) at once. With the
+    lock threaded through, exactly one RefResolver is constructed.
+    """
+    import threading
+    import time
+
+    made = []
+    all_started = threading.Barrier(8)
+
+    class _SlowFakeRefResolver:
+        def __init__(self, *, host=None, token=None):
+            # Small delay to widen the construction window. With a working
+            # lock only one thread ever reaches here; without it, several
+            # would slip in during this sleep and append multiple entries.
+            time.sleep(0.02)
+            made.append((host, token))
+
+    fake_semver = MagicMock()
+    fake_semver.return_value.resolve.return_value = "R"
+    cache: dict = {}
+    lock = threading.Lock()
+
+    def worker(i):
+        # Release all threads at once so they contend on the cache together.
+        all_started.wait(timeout=5)
+        _maybe_resolve_git_semver(
+            dep_ref=_semver_dep("owner/repo", f"packages/p{i}"),
+            existing_lockfile=None,
+            update_refs=False,
+            ref_resolver_cache=cache,
+            ref_resolver_cache_lock=lock,
+        )
+
+    with (
+        patch("apm_cli.marketplace.ref_resolver.RefResolver", _SlowFakeRefResolver),
+        patch("apm_cli.deps.git_semver_resolver.GitSemverResolver", fake_semver),
+    ):
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+    # Exactly one resolver despite 8 concurrent first-touches.
+    assert len(made) == 1
+    assert len(cache) == 1
+
+
+def test_distinct_hosts_get_distinct_resolvers():
+    made, fake_ref, fake_semver = _patched_resolver_env()
+    cache: dict = {}
+    deps = [
+        _semver_dep("owner/repo", "packages/a"),  # host defaults
+        DependencyReference(
+            repo_url="owner/repo",
+            reference=">=0.0.1",
+            virtual_path="packages/b",
+            is_virtual=True,
+            host="example.com",
+        ),
+    ]
+    with (
+        patch("apm_cli.marketplace.ref_resolver.RefResolver", fake_ref),
+        patch("apm_cli.deps.git_semver_resolver.GitSemverResolver", fake_semver),
+    ):
+        for d in deps:
+            _maybe_resolve_git_semver(
+                dep_ref=d,
+                existing_lockfile=None,
+                update_refs=False,
+                ref_resolver_cache=cache,
+            )
+    # Different host -> different cache key -> two resolvers.
+    assert len(made) == 2
+    assert len(cache) == 2


### PR DESCRIPTION
## Description

`_maybe_resolve_git_semver` constructed a **fresh `RefResolver` for every semver dep**. Each `RefResolver` memoizes its `git ls-remote --tags --heads` per instance, so N deps from the **same** upstream repo each ran their own identical `ls-remote` — redundant network and a git subprocess per dep. On a manifest sourced mostly from one monorepo this is the dominant cold-resolve cost.

This PR threads a **run-scoped `RefResolver` cache** (keyed by `(host, token)`) on `InstallContext` and reuses the instance across deps, so the second and later deps from a repo hit the in-memory tag cache instead of re-running `ls-remote`. Because the BFS download callback runs on a worker pool, the get-or-create is guarded by the existing callback lock — otherwise concurrent first-touches would each build a resolver and defeat the dedup.

**Measured end-to-end:** 5 same-repo semver deps dropped from **5 real `ls-remote` subprocesses to 1**.

The token resolution and shared-resolver logic live in `install/helpers/ref_reuse.py` so `phases/resolve.py` stays within its per-module LOC budget (`test_architecture_invariants`). Callers that pass no cache (the default) keep the prior one-resolver-per-dep behavior.

Fixes # (issue)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

Added unit tests for same-repo reuse, the no-cache fallback, distinct-host separation, and concurrent first-touch under the lock. Full `tests/unit/install` + `tests/unit/deps` suites pass (2877 passed).

## Spec conformance (OpenAPM v0.1)

- [x] N/A -- this PR does not change OpenAPM-observable behaviour.
