### PR TITLE
fix(hooks): rename Copilot hook events to camelCase during merge (closes #1977)

### DIFF
--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -117,6 +117,23 @@ class _MergeHookConfig:
 # Copilot (camelCase) or Claude (PascalCase) names; targets that use
 # different conventions get their events renamed during merge.
 _HOOK_EVENT_MAP: dict[str, dict[str, str]] = {
+    "copilot": {
+        # Claude PascalCase -> Copilot camelCase
+        "PreToolUse": "preToolUse",
+        "preToolUse": "preToolUse",
+        "PostToolUse": "postToolUse",
+        "postToolUse": "postToolUse",
+        "UserPromptSubmit": "userPromptSubmit",
+        "userPromptSubmit": "userPromptSubmit",
+        "Stop": "stop",
+        "stop": "stop",
+        "AgentStop": "agentStop",
+        "agentStop": "agentStop",
+        "PreTaskExecution": "preTaskExecution",
+        "preTaskExecution": "preTaskExecution",
+        "PostTaskExecution": "postTaskExecution",
+        "postTaskExecution": "postTaskExecution",
+    },
     "claude": {
         # Copilot camelCase -> Claude PascalCase
         "preToolUse": "PreToolUse",
@@ -1245,7 +1262,19 @@ class HookIntegrator(BaseIntegrator):
             ):
                 continue
 
-            _emit_hook_event_diagnostics(list(rewritten.get("hooks", {}).keys()), "copilot", {})
+            hooks = rewritten.get("hooks", {})
+            event_map = _HOOK_EVENT_MAP.get("copilot", {})
+            _emit_hook_event_diagnostics(list(hooks.keys()), "copilot", event_map)
+            if isinstance(hooks, dict):
+                renamed_hooks = {}
+                for raw_event_name, entries in hooks.items():
+                    event_name = event_map.get(raw_event_name, raw_event_name)
+                    if event_name in renamed_hooks and isinstance(renamed_hooks[event_name], list):
+                        if isinstance(entries, list):
+                            renamed_hooks[event_name].extend(entries)
+                            continue
+                    renamed_hooks[event_name] = entries
+                rewritten["hooks"] = renamed_hooks
 
             # Write rewritten JSON
             with open(target_path, "w", encoding="utf-8") as f:

--- a/tests/integration/test_hook_integrator_copilot_casing_e2e.py
+++ b/tests/integration/test_hook_integrator_copilot_casing_e2e.py
@@ -1,0 +1,156 @@
+"""Hermetic install-path proof for Copilot hook event casing."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from apm_cli.install.services import IntegratorBundle, integrate_package_primitives
+from apm_cli.integration.hook_integrator import HookIntegrator
+from apm_cli.integration.skill_integrator import SkillIntegrator
+from apm_cli.integration.targets import KNOWN_TARGETS
+from apm_cli.models.apm_package import APMPackage, PackageInfo
+from apm_cli.utils.diagnostics import DiagnosticCollector
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep any accidental home-scoped writes inside the pytest temp tree."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+
+def _hook_entry(command: str) -> dict[str, Any]:
+    """Return a hook matcher entry using the native nested hook shape."""
+    return {"hooks": [{"type": "command", "command": command}]}
+
+
+def _make_hook_package(
+    tmp_path: Path,
+    hooks: dict[str, list[dict[str, Any]]],
+    *,
+    name: str = "hook-casing-proof",
+) -> PackageInfo:
+    """Create a local package layout containing one .apm/hooks JSON file."""
+    package_root = tmp_path / "apm_modules" / "local" / name
+    hooks_dir = package_root / ".apm" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (hooks_dir / "hooks.json").write_text(
+        json.dumps({"hooks": hooks}, indent=2),
+        encoding="utf-8",
+    )
+
+    package = APMPackage(name=name, version="1.0.0", source=f"local/{name}")
+    return PackageInfo(package=package, install_path=package_root)
+
+
+def _integrate_package_hooks(
+    package_info: PackageInfo,
+    project_root: Path,
+    *,
+    target_name: str,
+) -> dict[str, Any]:
+    """Run the install service dispatch that invokes HookIntegrator for a target."""
+    return integrate_package_primitives(
+        package_info,
+        project_root,
+        targets=[KNOWN_TARGETS[target_name]],
+        integrators=IntegratorBundle(
+            prompt=None,
+            agent=None,
+            skill=SkillIntegrator(),
+            instruction=None,
+            command=None,
+            hook=HookIntegrator(),
+        ),
+        force=False,
+        managed_files=set(),
+        diagnostics=DiagnosticCollector(),
+        package_name=package_info.package.name,
+    )
+
+
+def _read_copilot_hooks_config(project_root: Path, package_name: str) -> dict[str, Any]:
+    """Read the actual Copilot hook JSON written under .github/hooks."""
+    config_path = project_root / ".github" / "hooks" / f"{package_name}-hooks.json"
+    assert config_path.exists()
+    return json.loads(config_path.read_text(encoding="utf-8"))
+
+
+def test_copilot_install_writes_only_camel_case_hook_events(tmp_path: Path) -> None:
+    """Copilot hook integration rewrites Claude-style events to camelCase on disk."""
+    project_root = tmp_path / "project"
+    (project_root / ".github").mkdir(parents=True)
+    (project_root / ".github" / "copilot-instructions.md").write_text(
+        "# Copilot instructions\n",
+        encoding="utf-8",
+    )
+    package_info = _make_hook_package(
+        tmp_path,
+        {
+            "PreToolUse": [_hook_entry("echo pre")],
+            "PostToolUse": [_hook_entry("echo post")],
+            "UserPromptSubmit": [_hook_entry("echo prompt")],
+            "Stop": [_hook_entry("echo stop")],
+        },
+    )
+
+    result = _integrate_package_hooks(package_info, project_root, target_name="copilot")
+
+    assert result["hooks"] == 1
+    config = _read_copilot_hooks_config(project_root, package_info.package.name)
+    hooks = config["hooks"]
+    assert set(hooks) == {"preToolUse", "postToolUse", "userPromptSubmit", "stop"}
+    assert {"PreToolUse", "PostToolUse", "UserPromptSubmit", "Stop"}.isdisjoint(hooks)
+
+
+def test_copilot_install_merges_duplicate_event_aliases(tmp_path: Path) -> None:
+    """Copilot hook integration unions PascalCase and camelCase alias entries."""
+    project_root = tmp_path / "project"
+    (project_root / ".github").mkdir(parents=True)
+    (project_root / ".github" / "copilot-instructions.md").write_text(
+        "# Copilot instructions\n",
+        encoding="utf-8",
+    )
+    package_info = _make_hook_package(
+        tmp_path,
+        {
+            "PreToolUse": [_hook_entry("echo pascal")],
+            "preToolUse": [_hook_entry("echo camel")],
+        },
+    )
+
+    result = _integrate_package_hooks(package_info, project_root, target_name="copilot")
+
+    assert result["hooks"] == 1
+    config = _read_copilot_hooks_config(project_root, package_info.package.name)
+    hooks = config["hooks"]
+    assert set(hooks) == {"preToolUse"}
+    commands = [entry["hooks"][0]["command"] for entry in hooks["preToolUse"]]
+    assert commands == ["echo pascal", "echo camel"]
+
+
+def test_claude_install_preserves_pascal_case_hook_events(tmp_path: Path) -> None:
+    """Claude hook integration keeps PascalCase events in settings.json."""
+    project_root = tmp_path / "project"
+    (project_root / ".claude").mkdir(parents=True)
+    package_info = _make_hook_package(
+        tmp_path,
+        {
+            "PreToolUse": [_hook_entry("echo pre")],
+            "PostToolUse": [_hook_entry("echo post")],
+            "Stop": [_hook_entry("echo stop")],
+        },
+    )
+
+    result = _integrate_package_hooks(package_info, project_root, target_name="claude")
+
+    assert result["hooks"] == 1
+    settings = json.loads((project_root / ".claude" / "settings.json").read_text(encoding="utf-8"))
+    assert set(settings["hooks"]) == {"PreToolUse", "PostToolUse", "Stop"}

--- a/tests/unit/integration/test_hook_integrator.py
+++ b/tests/unit/integration/test_hook_integrator.py
@@ -269,7 +269,7 @@ class TestVSCodeIntegration:
 
         # Verify rewritten paths
         data = json.loads(target_json.read_text())
-        cmd = data["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+        cmd = data["hooks"]["preToolUse"][0]["hooks"][0]["command"]
         assert "${CLAUDE_PLUGIN_ROOT}" not in cmd
         assert ".github/hooks/scripts/hookify/hooks/pretooluse.py" in cmd
         assert cmd.startswith("python3 ")
@@ -338,7 +338,7 @@ class TestVSCodeIntegration:
 
         target_json = temp_project / ".github" / "hooks" / "ralph-loop-hooks.json"
         data = json.loads(target_json.read_text())
-        cmd = data["hooks"]["Stop"][0]["hooks"][0]["command"]
+        cmd = data["hooks"]["stop"][0]["hooks"][0]["command"]
         assert "ralph-loop" in cmd
         assert "stop-hook.sh" in cmd
 
@@ -404,7 +404,7 @@ class TestVSCodeIntegration:
 
         target_json = temp_project / ".github" / "hooks" / "format-pkg-format.json"
         data = json.loads(target_json.read_text())
-        cmd = data["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+        cmd = data["hooks"]["preToolUse"][0]["hooks"][0]["command"]
         assert cmd == "npx prettier --check ."
 
     def test_invalid_json_skipped(self, temp_project):
@@ -2341,7 +2341,7 @@ class TestScriptPathRewriting:
         # Verify the rewritten command points to the bundled script
         target_json = temp_project / ".github" / "hooks" / "lint-hooks-hooks.json"
         data = json.loads(target_json.read_text())
-        cmd = data["hooks"]["PostToolUse"][0]["hooks"][0]["command"]
+        cmd = data["hooks"]["postToolUse"][0]["hooks"][0]["command"]
         assert ".github/hooks/scripts/lint-hooks/scripts/lint.sh" in cmd
         assert "./" not in cmd
 

--- a/tests/unit/integration/test_hook_integrator_defect_regression.py
+++ b/tests/unit/integration/test_hook_integrator_defect_regression.py
@@ -98,6 +98,34 @@ def test_copilot_hook_path_no_doubling(tmp_path: Path) -> None:
     ).exists()
 
 
+def test_copilot_renames_claude_tool_events_to_camel_case(tmp_path: Path, caplog, capsys) -> None:
+    project = tmp_path / "project"
+    package_path = tmp_path / "superpowers"
+    hooks_dir = package_path / ".apm" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (hooks_dir / "hooks.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [{"hooks": [{"type": "command", "command": "echo pre"}]}],
+                    "PostToolUse": [{"hooks": [{"type": "command", "command": "echo post"}]}],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    HookIntegrator().integrate_package_hooks(_package_info(package_path), project)
+
+    output = json.loads(
+        (project / ".github" / "hooks" / "superpowers-hooks.json").read_text(encoding="utf-8")
+    )
+    assert set(output["hooks"]) == {"preToolUse", "postToolUse"}
+    captured = capsys.readouterr()
+    assert "may not be recognized" not in captured.out
+    assert "hook event casing mismatch" not in caplog.text
+
+
 def test_claude_hook_script_path_no_doubling(tmp_path: Path) -> None:
     project = tmp_path / "project"
     package_path = tmp_path / "superpowers"

--- a/tests/unit/integration/test_hook_integrator_defect_regression.py
+++ b/tests/unit/integration/test_hook_integrator_defect_regression.py
@@ -126,6 +126,33 @@ def test_copilot_renames_claude_tool_events_to_camel_case(tmp_path: Path, caplog
     assert "hook event casing mismatch" not in caplog.text
 
 
+def test_copilot_merges_duplicate_event_aliases_to_camel_case(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    package_path = tmp_path / "superpowers"
+    hooks_dir = package_path / ".apm" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (hooks_dir / "hooks.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [{"hooks": [{"type": "command", "command": "echo pascal"}]}],
+                    "preToolUse": [{"hooks": [{"type": "command", "command": "echo camel"}]}],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    HookIntegrator().integrate_package_hooks(_package_info(package_path), project)
+
+    output = json.loads(
+        (project / ".github" / "hooks" / "superpowers-hooks.json").read_text(encoding="utf-8")
+    )
+    assert set(output["hooks"]) == {"preToolUse"}
+    commands = [entry["hooks"][0]["command"] for entry in output["hooks"]["preToolUse"]]
+    assert commands == ["echo pascal", "echo camel"]
+
+
 def test_claude_hook_script_path_no_doubling(tmp_path: Path) -> None:
     project = tmp_path / "project"
     package_path = tmp_path / "superpowers"

--- a/tests/unit/test_install_hook_transparency.py
+++ b/tests/unit/test_install_hook_transparency.py
@@ -116,7 +116,7 @@ def test_display_payloads_reflect_rewritten_paths_vscode(tmp_path):
     # Verify actions are present
     assert len(payload["actions"]) >= 1
     action = payload["actions"][0]
-    assert action["event"] == "PreToolUse"
+    assert action["event"] == "preToolUse"
     # Summary must reference the rewritten path, not the template variable
     assert "${CLAUDE_PLUGIN_ROOT}" not in action["summary"]
     assert ".github" in action["summary"]


### PR DESCRIPTION
Root cause: Copilot declared camelCase hook casing but had no _HOOK_EVENT_MAP entry, and the Copilot deploy path passed an empty event map while writing hook JSON unchanged. Claude-shape events such as PreToolUse and PostToolUse were deployed as-is and triggered casing mismatch warnings.

Fix:
- Add Copilot event aliases that normalize Claude/PascalCase hook names to Copilot camelCase names.
- Apply the Copilot event map before writing .github/hooks payloads, while using the same map for diagnostics.
- Add a regression test proving PreToolUse and PostToolUse become preToolUse and postToolUse with no casing mismatch warning.
- Add a regression test proving duplicate PascalCase/camelCase aliases merge under the same Copilot event without dropping hook entries.

apm-spec-waiver: This PR fixes Copilot hook event casing during target merge only; it does not change the OpenAPM specification artifact or conformance fixtures.

How to test:
- uv run --extra dev pytest tests/unit/integration/test_hook_integrator_defect_regression.py::test_copilot_renames_claude_tool_events_to_camel_case -q
- uv run --extra dev pytest tests/unit/integration/test_hook_integrator_defect_regression.py::test_copilot_merges_duplicate_event_aliases_to_camel_case -q
- Mutation-break gate: temporarily removed the Copilot map entry and confirmed the regression test failed with PostToolUse/PreToolUse still present and a casing warning.
- Mutation-break gate: temporarily removed the duplicate-alias merge branch and confirmed the alias-merge regression test failed with only the camelCase entry preserved.
- uv run --extra dev pytest tests/unit/test_install_hook_transparency.py::test_display_payloads_reflect_rewritten_paths_vscode tests/unit/integration/test_hook_integrator_defect_regression.py::test_copilot_renames_claude_tool_events_to_camel_case tests/unit/integration/test_hook_integrator_defect_regression.py::test_copilot_merges_duplicate_event_aliases_to_camel_case -q
- uv run --extra dev pytest tests/unit/integration/test_hook_integrator.py tests/unit/integration/test_hook_diagnostics.py tests/unit/integration/test_hook_integrator_defect_regression.py tests/unit/integration/test_hook_naked_format.py tests/unit/integration/test_hook_target_selection.py tests/unit/integration/test_hook_target_deprecation.py tests/unit/integration/test_hook_integrator_issue1892.py -q
- uv run --extra dev pytest tests/ -k "hook" -q
- uv run --extra dev ruff check src/ tests/ --fix && uv run --extra dev ruff check src/ tests/
- uv run --extra dev ruff format src/ tests/ && uv run --extra dev ruff format --check src/ tests/
- uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/
- bash scripts/lint-auth-signals.sh

Closes #1977