### PR TITLE
fix(audit): stable _apm_source marker in audit replay (closes #1978)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `apm audit --ci` no longer reports phantom drift for root-local hook files
+  when audit replay writes into a scratch project root. (#1980)
+
 ## [0.23.1] - 2026-06-29
 
 ### Fixed

--- a/src/apm_cli/install/drift.py
+++ b/src/apm_cli/install/drift.py
@@ -492,6 +492,8 @@ def run_replay(config: ReplayConfig, logger: CheckLogger) -> Path:
                     )
 
                 package_info = _build_package_info(lock_dep, install_path)
+                if lock_dep.local_path == _SELF_KEY:
+                    package_info.root_local_project_root = project_root
                 dep_key = lock_dep.get_unique_key()
 
                 integrate_package_primitives(

--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -886,12 +886,18 @@ class HookIntegrator(BaseIntegrator):
         return rewritten, unique_scripts
 
     @staticmethod
+    def _root_local_identity_root(package_info, project_root: Path | None) -> Path | None:
+        """Return the project root used to identify root-local packages."""
+        return getattr(package_info, "root_local_project_root", None) or project_root
+
+    @staticmethod
     def _is_root_local_package(package_info, project_root: Path | None) -> bool:
         """Return True when *package_info* represents the project's own .apm content."""
-        if project_root is None:
+        identity_root = HookIntegrator._root_local_identity_root(package_info, project_root)
+        if identity_root is None:
             return False
         try:
-            return Path(package_info.install_path).resolve() == Path(project_root).resolve()
+            return Path(package_info.install_path).resolve() == Path(identity_root).resolve()
         except (OSError, RuntimeError):
             return False
 
@@ -951,7 +957,8 @@ class HookIntegrator(BaseIntegrator):
             str: Package name used as hook source marker and script namespace
         """
         if self._is_root_local_package(package_info, project_root):
-            return HookIntegrator._get_root_local_package_name(package_info, Path(project_root))
+            identity_root = HookIntegrator._root_local_identity_root(package_info, project_root)
+            return HookIntegrator._get_root_local_package_name(package_info, Path(identity_root))
         return package_info.install_path.name
 
     @staticmethod

--- a/src/apm_cli/models/apm_package.py
+++ b/src/apm_cli/models/apm_package.py
@@ -585,6 +585,7 @@ class PackageInfo:
         None  # Original dependency reference for canonical string
     )
     package_type: PackageType | None = None  # APM_PACKAGE, CLAUDE_SKILL, or HYBRID
+    root_local_project_root: Path | None = None
 
     def get_canonical_dependency_string(self) -> str:
         """Get the canonical dependency string for this package.

--- a/tests/integration/test_audit_root_local_hook_replay_e2e.py
+++ b/tests/integration/test_audit_root_local_hook_replay_e2e.py
@@ -1,0 +1,113 @@
+"""End-to-end audit replay proof for root-local hook source markers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from apm_cli.cli import cli
+from apm_cli.deps.lockfile import LockFile, get_lockfile_path
+from apm_cli.install.drift import (
+    CheckLogger,
+    ReplayConfig,
+    diff_scratch_against_project,
+    run_replay,
+)
+from apm_cli.integration.targets import resolve_targets
+
+
+def _write_root_local_codex_hook_project(project: Path) -> None:
+    """Create a project whose own .apm directory ships a Codex hook."""
+    project.mkdir()
+    (project / "apm.yml").write_bytes(b"name: apm-bugs\nversion: 0.0.0\ntargets:\n  - codex\n")
+    (project / ".codex").mkdir()
+    hooks_dir = project / ".apm" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    skill_dir = project / ".apm" / "skills" / "proof-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_bytes(
+        b"---\n"
+        b"name: proof-skill\n"
+        b"description: Local skill that makes the install lockfile track root content.\n"
+        b"---\n"
+        b"# Proof skill\n"
+    )
+    (hooks_dir / "pre.json").write_bytes(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "echo apm-managed",
+                                }
+                            ],
+                        }
+                    ]
+                }
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+        + b"\n"
+    )
+
+
+def _install(project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run the real install command in-process."""
+    monkeypatch.chdir(project)
+    result = CliRunner().invoke(cli, ["install"], catch_exceptions=False)
+    assert result.exit_code == 0, (
+        f"apm install failed: exit={result.exit_code}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+def _codex_marker(root: Path) -> str:
+    """Return the first APM ownership marker from Codex hooks.json."""
+    hooks_path = root / ".codex" / "hooks.json"
+    data = json.loads(hooks_path.read_text(encoding="utf-8"))
+    entries = data["hooks"]["PreToolUse"]
+    assert len(entries) == 1
+    marker = entries[0]["_apm_source"]
+    assert isinstance(marker, str)
+    return marker
+
+
+@pytest.mark.integration
+def test_audit_replay_preserves_root_local_hook_marker_without_phantom_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Install then replay-audit a root-local hook without marker drift."""
+    project = tmp_path / "apm-bugs"
+    _write_root_local_codex_hook_project(project)
+    _install(project, monkeypatch)
+
+    installed_marker = _codex_marker(project)
+    lockfile_path = get_lockfile_path(project)
+    lockfile = LockFile.read(lockfile_path)
+    assert lockfile is not None
+
+    scratch_root = run_replay(
+        ReplayConfig(
+            project_root=project,
+            lockfile_path=lockfile_path,
+            targets=frozenset({"codex"}),
+        ),
+        CheckLogger(verbose=False),
+    )
+    replay_marker = _codex_marker(scratch_root)
+
+    assert installed_marker == "_local/apm-bugs"
+    assert replay_marker == installed_marker
+    assert replay_marker != "apm-bugs"
+
+    targets = resolve_targets(project, explicit_target=["codex"])
+    findings = diff_scratch_against_project(scratch_root, project, lockfile, targets)
+    assert findings == []

--- a/tests/unit/install/test_drift_detection.py
+++ b/tests/unit/install/test_drift_detection.py
@@ -46,7 +46,9 @@ from apm_cli.install.drift import (
     render_drift,
     render_drift_json,
     render_drift_text,
+    run_replay,
 )
+from apm_cli.integration.hook_integrator import HookIntegrator
 
 # ---------------------------------------------------------------------------
 # _assert_scratch_bound
@@ -123,6 +125,43 @@ class TestCheckLogger:
         logger.scratch_root(tmp_path)
         captured = capsys.readouterr()
         assert str(tmp_path) in captured.err
+
+
+def test_run_replay_preserves_root_local_hook_marker_identity(tmp_path: Path) -> None:
+    """Self package hook markers must stay stable when replay writes to scratch."""
+    project = tmp_path / "apm-bugs"
+    project.mkdir()
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    (project / "apm.yml").write_text("name: apm-bugs\nversion: 0.0.0\n", encoding="utf-8")
+    lockfile_path = project / "apm.lock.yaml"
+    LockFile(local_deployed_files=[".codex/hooks.json"]).write(lockfile_path)
+    captured: dict[str, object] = {}
+
+    def fake_integrate_package_primitives(package_info, replay_root, **_kwargs):
+        hook_integrator = HookIntegrator()
+        package_name = hook_integrator._get_package_name(package_info, replay_root)
+        captured["marker"] = hook_integrator._get_hook_source_marker(
+            package_info, replay_root, package_name
+        )
+        captured["replay_root"] = replay_root
+        return {"deployed_files": []}
+
+    with (
+        patch("apm_cli.install.drift._make_scratch_root", return_value=scratch),
+        patch(
+            "apm_cli.install.services.integrate_package_primitives",
+            side_effect=fake_integrate_package_primitives,
+        ),
+    ):
+        returned_scratch = run_replay(
+            ReplayConfig(project_root=project, lockfile_path=lockfile_path),
+            CheckLogger(verbose=False),
+        )
+
+    assert returned_scratch == scratch
+    assert captured["replay_root"] == scratch
+    assert captured["marker"] == "_local/apm-bugs"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

Audit replay redirects writes to a scratch project root. For the synthetic self package, HookIntegrator compared package_info.install_path against that scratch root, so replay classified the root package as a dependency and stamped bare _apm_source markers like apm-bugs. A real install compared against the original project root and stamped _local/apm-bugs, so freshly installed hook files appeared modified.

## Fix

Preserve the original project root on the self-package PackageInfo during replay and have HookIntegrator use that identity root for root-local marker decisions. This keeps _apm_source ownership drift detectable for genuinely foreign files while removing the scratch-root false positive.

## How to test

- uv run --extra dev pytest tests/unit/install/test_drift_detection.py::test_run_replay_preserves_root_local_hook_marker_identity -q
- uv run --extra dev pytest tests/unit/install/test_drift_detection.py tests/unit/integration/test_hook_integrator.py -q
- uv run --extra dev pytest tests/ -k 'audit or drift or hook' -q
- uv run --extra dev ruff check src/ tests/ >/dev/null && uv run --extra dev ruff format --check src/ tests/ >/dev/null && uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/ >/dev/null && bash scripts/lint-auth-signals.sh >/dev/null

Closes #1978