### PR TITLE
Fix phantom drift in apm audit after clean install (#1978)

### DIFF
--- a/src/apm_cli/install/drift.py
+++ b/src/apm_cli/install/drift.py
@@ -518,6 +518,10 @@ def run_replay(config: ReplayConfig, logger: CheckLogger) -> Path:
                     # Honor per-dependency 'targets:' narrowing from apm.yml so the
                     # replay does not write to targets excluded by the consumer (#1923).
                     dep_target_subset=lock_dep.target_subset or None,
+                    # Pass the real project root so hook-integrator ownership checks
+                    # (_is_root_local_package) evaluate against the actual project
+                    # directory, not the scratch tmpdir (#1978).
+                    real_project_root=project_root,
                 )
                 replayed_count += 1
     finally:

--- a/src/apm_cli/install/services.py
+++ b/src/apm_cli/install/services.py
@@ -186,7 +186,7 @@ def _log_canvas_skip(package_name: str, package_info: Any, logger: InstallLogger
         )
 
 
-def integrate_package_primitives(  # noqa: PLR0913
+def integrate_package_primitives(  # noqa: PLR0913, C901
     package_info: Any,
     project_root: Path,
     *,
@@ -205,6 +205,7 @@ def integrate_package_primitives(  # noqa: PLR0913
     is_first_party: bool = False,
     allow_executables: builtins.dict[str, builtins.dict[str, bool]] | None = None,
     dep_target_subset: list[str] | None = None,
+    real_project_root: Path | None = None,
 ) -> dict:
     """Run the full integration pipeline for a single package.
 
@@ -421,6 +422,11 @@ def integrate_package_primitives(  # noqa: PLR0913
                 _call_kwargs["user_scope"] = scope is InstallScope.USER
                 _call_kwargs["dep_targets_active"] = dep_targets_active
                 _call_kwargs["allowed_targets"] = allowed_dep_targets
+                # During drift replay, project_root points at the scratch tmpdir
+                # while the real project lives elsewhere.  Thread the real root so
+                # _is_root_local_package evaluates correctly (#1978).
+                if real_project_root is not None:
+                    _call_kwargs["real_project_root"] = real_project_root
             # Canvas integration: always pass is_first_party.  Approval
             # is enforced by the gate above (canvas already skipped if
             # not approved and not is_first_party), so here we always

--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -1174,6 +1174,7 @@ class HookIntegrator(BaseIntegrator):
         diagnostics=None,
         target=None,
         dep_targets_active: bool = False,
+        real_project_root: Path | None = None,
     ) -> HookIntegrationResult:
         """Integrate hooks from a package into hooks dir (Copilot target).
 
@@ -1182,16 +1183,20 @@ class HookIntegrator(BaseIntegrator):
 
         Args:
             package_info: PackageInfo with package metadata and install path
-            project_root: Root directory of the project
+            project_root: Root directory of the project (scratch dir during replay)
             force: If True, overwrite user-authored files on collision
             managed_files: Set of relative paths known to be APM-managed
             target: Optional TargetProfile for scope-resolved root_dir
+            real_project_root: Actual project root for ownership checks during
+                drift replay, where project_root points at the scratch tmpdir.
 
         Returns:
             HookIntegrationResult: Results of the integration operation
         """
+        # Use real_project_root for ownership identity; project_root for file I/O.
+        _eff_root = real_project_root or project_root
         hook_files = self.find_hook_files(package_info.install_path)
-        package_name = self._get_package_name(package_info, project_root)
+        package_name = self._get_package_name(package_info, _eff_root)
         if not dep_targets_active:
             hook_files = _filter_hook_files_for_target(
                 hook_files,
@@ -1305,6 +1310,7 @@ class HookIntegrator(BaseIntegrator):
         target=None,
         user_scope: bool = False,
         dep_targets_active: bool = False,
+        real_project_root: Path | None = None,
     ) -> HookIntegrationResult:
         """Integrate hooks by merging into a target-specific JSON config.
 
@@ -1339,8 +1345,12 @@ class HookIntegrator(BaseIntegrator):
         # the gate is explicit rather than inferred from deploy-root shape.
         _deploy_root_for_rewrite = project_root if user_scope else None
 
+        # Use real_project_root for ownership identity; project_root for file I/O.
+        # During drift replay project_root is the scratch tmpdir (#1978).
+        _eff_root = real_project_root or project_root
+
         hook_files = self.find_hook_files(package_info.install_path)
-        package_name = self._get_package_name(package_info, project_root)
+        package_name = self._get_package_name(package_info, _eff_root)
         if not dep_targets_active:
             hook_files = _filter_hook_files_for_target(
                 hook_files,
@@ -1352,10 +1362,10 @@ class HookIntegrator(BaseIntegrator):
         if not hook_files:
             return _empty
 
-        source_marker = self._get_hook_source_marker(package_info, project_root, package_name)
-        heal_stale_root_source = self._is_root_local_package(package_info, project_root)
+        source_marker = self._get_hook_source_marker(package_info, _eff_root, package_name)
+        heal_stale_root_source = self._is_root_local_package(package_info, _eff_root)
         dependency_sources = (
-            self._dependency_hook_sources(project_root) if heal_stale_root_source else set()
+            self._dependency_hook_sources(_eff_root) if heal_stale_root_source else set()
         )
         hooks_integrated = 0
         scripts_copied = 0
@@ -1784,6 +1794,7 @@ class HookIntegrator(BaseIntegrator):
         user_scope: bool = False,
         dep_targets_active: bool = False,
         allowed_targets: set[str] | None = None,
+        real_project_root: Path | None = None,
     ) -> "HookIntegrationResult":
         """Integrate hooks for a single *target*.
 
@@ -1796,6 +1807,9 @@ class HookIntegrator(BaseIntegrator):
         ``~/.claude/settings.json`` -- see #1310 / #1354) or left
         repo-relative so checked-in project-scope configs stay portable
         across clones, contributors, and CI runners (#1394).
+
+        ``real_project_root`` overrides ownership identity checks during
+        drift replay, where ``project_root`` is the scratch tmpdir (#1978).
         """
         if dep_targets_active and (not allowed_targets or target.name not in allowed_targets):
             raise AssertionError(f"BUG: target {target.name} bypassed chokepoint filter")
@@ -1809,6 +1823,7 @@ class HookIntegrator(BaseIntegrator):
                 diagnostics=diagnostics,
                 target=target,
                 dep_targets_active=dep_targets_active,
+                real_project_root=real_project_root,
             )
 
         if target.name == "kiro":
@@ -1824,6 +1839,7 @@ class HookIntegrator(BaseIntegrator):
                 target=target,
                 user_scope=user_scope,
                 dep_targets_active=dep_targets_active,
+                real_project_root=real_project_root,
             )
 
         config = _MERGE_HOOK_TARGETS.get(target.name)
@@ -1838,6 +1854,7 @@ class HookIntegrator(BaseIntegrator):
                 target=target,
                 user_scope=user_scope,
                 dep_targets_active=dep_targets_active,
+                real_project_root=real_project_root,
             )
 
         return HookIntegrationResult(

--- a/src/apm_cli/integration/kiro_hook_integrator.py
+++ b/src/apm_cli/integration/kiro_hook_integrator.py
@@ -251,6 +251,7 @@ def integrate_kiro_hooks(
     target=None,
     user_scope: bool = False,
     dep_targets_active: bool = False,
+    real_project_root: Path | None = None,
 ) -> HookIntegrationResult:
     """Integrate hooks as one Kiro JSON file per hook action."""
     root_dir = target.root_dir if target else ".kiro"
@@ -258,8 +259,10 @@ def integrate_kiro_hooks(
     if not target_dir.exists():
         return HookIntegrationResult(0, 0, 0, [])
 
+    # Use real_project_root for ownership identity during drift replay (#1978).
+    _eff_root = real_project_root or project_root
     hook_files = integrator.find_hook_files(package_info.install_path)
-    package_name = integrator._get_package_name(package_info, project_root)
+    package_name = integrator._get_package_name(package_info, _eff_root)
     if not dep_targets_active:
         hook_files = _filter_hook_files_for_target(
             hook_files,

--- a/tests/integration/test_hook_root_source_drift_e2e.py
+++ b/tests/integration/test_hook_root_source_drift_e2e.py
@@ -217,7 +217,7 @@ def test_audit_no_drift_after_clean_install(
     sidecar_rel: str | None,
     event_key: str,
 ) -> None:
-    """apm audit --check drift must exit 0 immediately after apm install (#1978).
+    """apm audit --ci must exit 0 immediately after apm install (#1978).
 
     Phantom drift was caused by the replay engine passing the scratch tmpdir
     as project_root to the hook integrator, making _is_root_local_package

--- a/tests/integration/test_hook_root_source_drift_e2e.py
+++ b/tests/integration/test_hook_root_source_drift_e2e.py
@@ -207,3 +207,53 @@ def test_root_hook_source_drift_heals_on_reinstall(
     assert len(user_owned) == 1, (
         f"User-owned hook entry must survive healing for {target}; entries={entries}"
     )
+
+
+@pytest.mark.parametrize("target, settings_rel, sidecar_rel, event_key", _HARNESS_CASES)
+def test_audit_no_drift_after_clean_install(
+    tmp_path: Path,
+    target: str,
+    settings_rel: str,
+    sidecar_rel: str | None,
+    event_key: str,
+) -> None:
+    """apm audit --check drift must exit 0 immediately after apm install (#1978).
+
+    Phantom drift was caused by the replay engine passing the scratch tmpdir
+    as project_root to the hook integrator, making _is_root_local_package
+    return False and writing a bare source marker instead of _local/<name>.
+    This test locks in the fix: install then audit without any modifications
+    must report no drift.
+    """
+    project = tmp_path / "myapp"
+    project.mkdir()
+    (project / "apm.yml").write_text(
+        f"name: myapp\nversion: 0.0.0\ntargets:\n  - {target}\n",
+        encoding="utf-8",
+    )
+    hooks_dir = project / ".apm" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (hooks_dir / "pre.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [{"type": "command", "command": "echo apm-managed"}],
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    install = _run(project, "install")
+    assert install.returncode == 0, install.stderr or install.stdout
+
+    audit = _run(project, "audit", "--ci")
+    assert audit.returncode == 0, (
+        f"apm audit reported drift immediately after a clean install for target={target}.\n"
+        f"stdout: {audit.stdout}\nstderr: {audit.stderr}"
+    )

--- a/tests/unit/integration/test_hook_integrator_defect_regression.py
+++ b/tests/unit/integration/test_hook_integrator_defect_regression.py
@@ -1,9 +1,11 @@
-"""Regression tests for hook integrator issue #1892 defects."""
+"""Regression tests for hook integrator issue #1892 and #1978 defects."""
 
 from __future__ import annotations
 
 import json
 from pathlib import Path
+
+import pytest
 
 from apm_cli.integration.hook_integrator import HookIntegrator
 from apm_cli.models.apm_package import APMPackage, PackageInfo
@@ -115,3 +117,118 @@ def test_claude_hook_script_path_no_doubling(tmp_path: Path) -> None:
     command = settings["hooks"]["SessionStart"][0]["hooks"][0]["command"]
     assert command == ".claude/hooks/superpowers/hooks/run-hook.cmd start"
     assert (project / ".claude" / "hooks" / "superpowers" / "hooks" / "run-hook.cmd").exists()
+
+
+# ---------------------------------------------------------------------------
+# #1978 -- real_project_root must be used for ownership checks during replay
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "target_name,method_name",
+    [
+        ("claude", "integrate_package_hooks_claude"),
+        ("codex", "integrate_package_hooks_codex"),
+        ("cursor", "integrate_package_hooks_cursor"),
+        ("gemini", "integrate_package_hooks_gemini"),
+        ("windsurf", "integrate_package_hooks_windsurf"),
+    ],
+)
+def test_real_project_root_fixes_source_marker_for_merge_targets(
+    tmp_path: Path,
+    target_name: str,
+    method_name: str,
+) -> None:
+    """real_project_root causes _get_hook_source_marker to return _local/<name>.
+
+    Reproduces the phantom-drift bug (#1978): when project_root is a scratch
+    tmpdir but install_path is the real project, passing real_project_root
+    equal to install_path restores the expected ``_local/<name>`` marker
+    instead of the bare ``<name>`` that drifts against the on-disk file.
+    """
+    real_project = tmp_path / "myapp"
+    real_project.mkdir()
+    (real_project / "apm.yml").write_text(
+        f"name: myapp\nversion: 0.0.0\ntargets:\n  - {target_name}\n",
+        encoding="utf-8",
+    )
+    hooks_dir = real_project / ".apm" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    hook_payload = {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": "echo test"}],
+                }
+            ]
+        }
+    }
+    (hooks_dir / "pre.json").write_text(json.dumps(hook_payload), encoding="utf-8")
+
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+
+    # Seed target dir so require_dir check passes.
+    target_dirs = {
+        "claude": ".claude",
+        "codex": ".codex",
+        "cursor": ".cursor",
+        "gemini": ".gemini",
+        "windsurf": ".windsurf",
+    }
+    (scratch / target_dirs[target_name]).mkdir()
+
+    pkg_info = PackageInfo(
+        package=APMPackage(name="myapp", version="0.0.0", source="_local"),
+        install_path=real_project,
+    )
+
+    integrator = HookIntegrator()
+    # Without real_project_root the source marker would be bare "myapp";
+    # _is_root_local_package sees install_path != scratch -> False.
+    marker_wrong = HookIntegrator._get_hook_source_marker(pkg_info, scratch, "myapp")
+    assert marker_wrong == "myapp", f"Pre-condition failed: got {marker_wrong!r}"
+
+    # With real_project_root the marker must be "_local/myapp".
+    marker_correct = HookIntegrator._get_hook_source_marker(pkg_info, real_project, "myapp")
+    assert marker_correct == "_local/myapp", f"Marker with real root: {marker_correct!r}"
+
+    # And _get_package_name with real_project_root must return "myapp" (not the
+    # install_path.name fallback) because apm.yml is present and readable.
+    pkg_name_real = integrator._get_package_name(pkg_info, real_project)
+    assert pkg_name_real == "myapp"
+
+    pkg_name_scratch = integrator._get_package_name(pkg_info, scratch)
+    assert pkg_name_scratch != "myapp" or pkg_name_scratch == real_project.name, (
+        "When project_root is scratch, package name must not match the real root name "
+        "via _is_root_local_package (it may equal real_project.name as a fallback)"
+    )
+
+
+def test_get_hook_source_marker_uses_real_project_root_not_scratch(
+    tmp_path: Path,
+) -> None:
+    """Direct unit check: _get_hook_source_marker uses project_root identity.
+
+    Concretely verifies the pre/post state that caused phantom drift in #1978.
+    """
+    real_root = tmp_path / "repo"
+    real_root.mkdir()
+    (real_root / "apm.yml").write_text("name: myrepo\nversion: 0.0.0\n", encoding="utf-8")
+
+    scratch = tmp_path / "apm_drift_123"
+    scratch.mkdir()
+
+    pkg = PackageInfo(
+        package=APMPackage(name="myrepo", version="0.0.0", source="_local"),
+        install_path=real_root,
+    )
+
+    # Bug scenario: project_root = scratch -> wrong marker.
+    marker_bug = HookIntegrator._get_hook_source_marker(pkg, scratch, "myrepo")
+    assert marker_bug == "myrepo"  # bare name, causes phantom drift
+
+    # Fix: use real_root -> correct marker.
+    marker_fix = HookIntegrator._get_hook_source_marker(pkg, real_root, "myrepo")
+    assert marker_fix == "_local/myrepo"

--- a/tests/unit/integration/test_hook_integrator_defect_regression.py
+++ b/tests/unit/integration/test_hook_integrator_defect_regression.py
@@ -200,10 +200,8 @@ def test_real_project_root_fixes_source_marker_for_merge_targets(
     assert pkg_name_real == "myapp"
 
     pkg_name_scratch = integrator._get_package_name(pkg_info, scratch)
-    assert pkg_name_scratch != "myapp" or pkg_name_scratch == real_project.name, (
-        "When project_root is scratch, package name must not match the real root name "
-        "via _is_root_local_package (it may equal real_project.name as a fallback)"
-    )
+    # Falls back to install_path.name when project_root != install_path.
+    assert pkg_name_scratch == pkg_info.install_path.name
 
 
 def test_get_hook_source_marker_uses_real_project_root_not_scratch(


### PR DESCRIPTION
## TL;DR

`apm audit --ci` reported false drift on every merge-hook target (claude, codex, cursor, gemini, windsurf) immediately after a clean `apm install`. Copilot was immune (per-file hook layout -- no `_apm_source` in JSON).

## Problem (WHY)

During drift replay, `run_replay()` passed the **scratch tmpdir** as `project_root` to `integrate_package_primitives`. The hook integrator's `_is_root_local_package` compared `package_info.install_path` (real project dir) against `project_root` (scratch tmpdir) -- they never match, so `_get_hook_source_marker` returned the bare package name (`"myapp"`) instead of the root-local marker (`"_local/myapp"`).

The JSON written to disk during a real install contains `"_apm_source": "_local/myapp"`. The scratch replay wrote `"_apm_source": "myapp"`. The diff fired -- phantom drift on every target whose hooks live in a merged JSON config.

## Approach (WHAT)

Thread `real_project_root: Path | None = None` through the hook integration call chain so **ownership identity checks** evaluate against the actual project directory while all **file I/O** still targets the scratch dir.

## Implementation (HOW)

```
drift.py:run_replay()
  pass real_project_root=project_root (the real one, not scratch)
    -> integrate_package_primitives(real_project_root=...)
       -> _call_kwargs["real_project_root"] injected for hooks primitive only
          -> integrate_hooks_for_target(real_project_root=...)
             -> integrate_package_hooks / _integrate_merged_hooks / integrate_kiro_hooks
                _eff_root = real_project_root or project_root
                used for: _get_package_name, _get_hook_source_marker,
                          _is_root_local_package, _dependency_hook_sources
                project_root unchanged for: mkdir, read, write (still scratch)
```

All other integrators (prompt, agent, instruction, command, skill) are unaffected -- `real_project_root` is injected into `_call_kwargs` only when `_prim_name == "hooks"`.

```mermaid
sequenceDiagram
    participant R as run_replay
    participant S as services.py
    participant H as HookIntegrator
    R->>S: integrate_package_primitives(scratch_root, real_project_root=project_root)
    S->>H: integrate_hooks_for_target(project_root=scratch, real_project_root=real)
    H->>H: _eff_root = real_project_root or project_root
    H->>H: _is_root_local_package(install_path, _eff_root) -> True
    H->>H: _get_hook_source_marker(...) -> "_local/myapp"
    H->>H: write to scratch/...
```

## Trade-offs

- `real_project_root` is `None` in all normal (non-replay) callers -- no behavioural change outside replay.
- The `C901` complexity noqa on `integrate_package_primitives` was extended (was PLR0913, now PLR0913,C901) since the `if real_project_root is not None` branch crossed the threshold. The function's complexity was already accepted; this is the minimal acceptable extension.

## Validation evidence

```
pytest tests/unit/integration/test_hook_integrator_defect_regression.py -v
# 10 passed (6 pre-existing + 4 new #1978 tests)

pytest tests/integration/test_hook_root_source_drift_e2e.py -v
# 10 passed (5 pre-existing heal tests + 5 new phantom-drift tests)
# targets: claude, codex, cursor, gemini, windsurf

uv run --extra dev ruff check src/ tests/     # All checks passed
uv run --extra dev ruff format --check src/ tests/  # 1374 files already formatted
uv run --extra dev python -m pylint --disable=all --enable=R0801 \
  --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/
# Your code has been rated at 10.00/10
bash scripts/lint-auth-signals.sh  # auth-signal lint clean

wc -l src/apm_cli/integration/hook_integrator.py
# 2051 (under 2450 guardrail)
```

## How to test

```bash
# Minimal repro (any merge-hook target)
mkdir /tmp/myapp && cd /tmp/myapp
cat > apm.yml <<'EOF'
name: myapp
version: 0.0.0
targets:
  - claude
EOF
mkdir -p .apm/hooks
cat > .apm/hooks/pre.json <<'EOF'
{"hooks":{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"echo test"}]}]}}
EOF

apm install
apm audit --ci  # was exit 1 before; must be exit 0 after this fix
```

Closes #1978