### PR TITLE
perf(compile): fast-path universal applyTo matching

### DIFF
--- a/src/apm_cli/compilation/context_optimizer.py
+++ b/src/apm_cli/compilation/context_optimizer.py
@@ -580,7 +580,7 @@ class ContextOptimizer:
         Returns:
             List[Path]: Mathematically optimal placement(s).
         """
-        pattern = instruction.apply_to
+        pattern = instruction.apply_to.strip()
 
         # Find all directories with matching files
         matching_directories = self._find_matching_directories(pattern)
@@ -801,11 +801,12 @@ class ContextOptimizer:
         if pattern in self._pattern_cache:
             return self._pattern_cache[pattern]
 
-        if pattern.strip() == "**":
+        normalized_pattern = pattern.strip()
+        if normalized_pattern == "**":
             matching_dirs = set(self._directory_cache)
             for analysis in self._directory_cache.values():
-                analysis.pattern_matches[pattern] = analysis.total_files
-            self._pattern_cache[pattern] = matching_dirs
+                analysis.pattern_matches[normalized_pattern] = analysis.total_files
+            self._pattern_cache[normalized_pattern] = matching_dirs
             return matching_dirs
 
         matching_dirs: builtins.set[Path] = set()

--- a/src/apm_cli/compilation/context_optimizer.py
+++ b/src/apm_cli/compilation/context_optimizer.py
@@ -801,6 +801,13 @@ class ContextOptimizer:
         if pattern in self._pattern_cache:
             return self._pattern_cache[pattern]
 
+        if pattern.strip() == "**":
+            matching_dirs = set(self._directory_cache)
+            for analysis in self._directory_cache.values():
+                analysis.pattern_matches[pattern] = analysis.total_files
+            self._pattern_cache[pattern] = matching_dirs
+            return matching_dirs
+
         matching_dirs: builtins.set[Path] = set()
 
         # Use the reliable approach for all patterns

--- a/src/apm_cli/compilation/context_optimizer.py
+++ b/src/apm_cli/compilation/context_optimizer.py
@@ -1293,7 +1293,9 @@ class ContextOptimizer:
         if not instruction.apply_to:
             return True  # Global instructions are always relevant
 
-        pattern = instruction.apply_to
+        pattern = instruction.apply_to.strip()
+        if not pattern:
+            return True
 
         # Resolve working directory to handle path inconsistencies
         try:

--- a/tests/integration/test_compile_universal_apply_to_fastpath_e2e.py
+++ b/tests/integration/test_compile_universal_apply_to_fastpath_e2e.py
@@ -1,0 +1,140 @@
+"""E2E coverage for universal applyTo fast-path placement."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from apm_cli.cli import cli
+from apm_cli.compilation.context_optimizer import ContextOptimizer
+
+UNIVERSAL_SENTINEL = "Universal fast path sentinel."
+EXPLICIT_SENTINEL = "Explicit all files sentinel."
+
+
+def _write_project_file(project_root: Path, relative_path: str, content: str = "x\n") -> None:
+    path = project_root / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _relative_directory_set(project_root: Path, directories: set[Path]) -> set[str]:
+    return {path.relative_to(project_root).as_posix() or "." for path in directories}
+
+
+def _build_project(project_root: Path) -> set[str]:
+    (project_root / "apm.yml").write_text(
+        "name: universal-fastpath-e2e\nversion: 0.1.0\ntarget: agents\n",
+        encoding="utf-8",
+    )
+    instructions_dir = project_root / ".apm" / "instructions"
+    instructions_dir.mkdir(parents=True)
+    (instructions_dir / "universal.instructions.md").write_text(
+        "---\n"
+        "description: Universal placement rule\n"
+        'applyTo: "  **  "\n'
+        "---\n\n"
+        f"{UNIVERSAL_SENTINEL}\n",
+        encoding="utf-8",
+    )
+    (instructions_dir / "explicit-all.instructions.md").write_text(
+        "---\n"
+        "description: Explicit all-files placement rule\n"
+        'applyTo: "**/*"\n'
+        "---\n\n"
+        f"{EXPLICIT_SENTINEL}\n",
+        encoding="utf-8",
+    )
+
+    expected_directories = {
+        ".",
+        "docs",
+        "src",
+        "src/pkg",
+        "tests",
+    }
+    _write_project_file(project_root, "docs/readme.md")
+    _write_project_file(project_root, "src/app.py")
+    _write_project_file(project_root, "src/pkg/mod.py")
+    _write_project_file(project_root, "tests/test_app.py")
+    (project_root / "empty").mkdir()
+    return expected_directories
+
+
+def test_compile_agents_universal_apply_to_fast_path_preserves_match_set(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Real compile must use the ``**`` fast path without changing matches."""
+    project_root = tmp_path
+    expected_directories = _build_project(project_root)
+    optimizer_instances: list[ContextOptimizer] = []
+    universal_match_sets: list[set[str]] = []
+    explicit_match_sets: list[set[str]] = []
+    universal_file_match_calls: list[str] = []
+
+    original_init = ContextOptimizer.__init__
+    original_find = ContextOptimizer._find_matching_directories
+    original_file_matches = ContextOptimizer._file_matches_pattern
+
+    def spy_init(self: ContextOptimizer, *args, **kwargs) -> None:
+        original_init(self, *args, **kwargs)
+        optimizer_instances.append(self)
+
+    def spy_find(self: ContextOptimizer, pattern: str) -> set[Path]:
+        result = original_find(self, pattern)
+        relative_result = _relative_directory_set(project_root, result)
+        if pattern.strip() == "**":
+            universal_match_sets.append(relative_result)
+        elif pattern == "**/*":
+            explicit_match_sets.append(relative_result)
+        return result
+
+    def spy_file_matches(self: ContextOptimizer, file_path: Path, pattern: str) -> bool:
+        if pattern.strip() == "**":
+            universal_file_match_calls.append(file_path.name)
+        return original_file_matches(self, file_path, pattern)
+
+    monkeypatch.chdir(project_root)
+    with (
+        patch.object(ContextOptimizer, "__init__", spy_init),
+        patch.object(ContextOptimizer, "_find_matching_directories", spy_find),
+        patch.object(ContextOptimizer, "_file_matches_pattern", spy_file_matches),
+    ):
+        result = CliRunner().invoke(
+            cli,
+            ["compile", "--target", "agents"],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0, result.output
+    assert optimizer_instances, "compile must construct the real context optimizer"
+    assert universal_match_sets == [expected_directories]
+    assert explicit_match_sets == [expected_directories]
+    assert universal_match_sets[0] == explicit_match_sets[0]
+    assert not universal_file_match_calls, (
+        "padded applyTo '**' must not fall back to per-file matching during "
+        "compile display or inheritance analysis"
+    )
+
+    optimizer = optimizer_instances[-1]
+    assert _relative_directory_set(project_root, optimizer._pattern_cache["**"]) == (
+        expected_directories
+    )
+    assert "  **  " not in optimizer._pattern_cache
+    assert optimizer._optimization_decisions[0].matching_directories == len(expected_directories)
+    assert optimizer._optimization_decisions[1].matching_directories == len(expected_directories)
+
+    for directory, analysis in optimizer._directory_cache.items():
+        relative_dir = directory.relative_to(project_root).as_posix() or "."
+        assert relative_dir in expected_directories
+        assert analysis.pattern_matches["**"] == analysis.total_files
+        assert "  **  " not in analysis.pattern_matches
+
+    agents_md = project_root / "AGENTS.md"
+    assert agents_md.exists()
+    agents_content = agents_md.read_text(encoding="utf-8")
+    assert UNIVERSAL_SENTINEL in agents_content
+    assert EXPLICIT_SENTINEL in agents_content

--- a/tests/unit/compilation/test_context_optimizer_cache_and_placement.py
+++ b/tests/unit/compilation/test_context_optimizer_cache_and_placement.py
@@ -84,6 +84,43 @@ class TestCachedGlobUsesFileList:
         assert not any(m.startswith("node_modules") for m in matches)
 
 
+class TestUniversalApplyToFastPath:
+    """Regression coverage for universal ``applyTo: "**"`` placement."""
+
+    def test_universal_apply_to_reuses_directory_analysis(self, tmp_path: Path) -> None:
+        for i in range(30):
+            _touch(tmp_path, f"pkg{i}/file.txt")
+        (tmp_path / "empty").mkdir()
+
+        optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        instruction = Instruction(
+            name="global-standards",
+            file_path=Path("global.instructions.md"),
+            description="Global coding standards",
+            apply_to="**",
+            content="Global standards",
+        )
+
+        with (
+            patch.object(
+                optimizer,
+                "_file_matches_pattern",
+                wraps=optimizer._file_matches_pattern,
+            ) as file_match_spy,
+            patch.object(optimizer, "_cached_glob", wraps=optimizer._cached_glob) as glob_spy,
+        ):
+            result = optimizer.optimize_instruction_placement([instruction])
+
+        assert list(result) == [tmp_path]
+        assert optimizer._optimization_decisions[0].matching_directories == 30
+        assert file_match_spy.call_count == 0
+        assert glob_spy.call_count == 0
+        assert "**" in optimizer._pattern_cache
+        for directory, analysis in optimizer._directory_cache.items():
+            assert directory in optimizer._pattern_cache["**"]
+            assert analysis.pattern_matches["**"] == analysis.total_files
+
+
 class TestSelectivePlacementNonRootLCA:
     """Regression test for medium-distribution placement at a non-root LCA.
 

--- a/tests/unit/compilation/test_context_optimizer_cache_and_placement.py
+++ b/tests/unit/compilation/test_context_optimizer_cache_and_placement.py
@@ -93,11 +93,12 @@ class TestUniversalApplyToFastPath:
         (tmp_path / "empty").mkdir()
 
         optimizer = ContextOptimizer(base_dir=str(tmp_path))
+        expected_directories = {tmp_path / f"pkg{i}" for i in range(30)}
         instruction = Instruction(
             name="global-standards",
             file_path=Path("global.instructions.md"),
             description="Global coding standards",
-            apply_to="**",
+            apply_to=" ** ",
             content="Global standards",
         )
 
@@ -115,10 +116,12 @@ class TestUniversalApplyToFastPath:
         assert optimizer._optimization_decisions[0].matching_directories == 30
         assert file_match_spy.call_count == 0
         assert glob_spy.call_count == 0
-        assert "**" in optimizer._pattern_cache
+        assert optimizer._pattern_cache["**"] == expected_directories
+        assert " ** " not in optimizer._pattern_cache
         for directory, analysis in optimizer._directory_cache.items():
             assert directory in optimizer._pattern_cache["**"]
             assert analysis.pattern_matches["**"] == analysis.total_files
+            assert " ** " not in analysis.pattern_matches
 
 
 class TestSelectivePlacementNonRootLCA:


### PR DESCRIPTION
## Summary
- Fast-path exact universal `**` matching in `ContextOptimizer._find_matching_directories()` by reusing the already-built directory analysis cache.
- Preserve placement statistics by recording each cached directory's full file count under the `**` pattern.
- Add regression coverage proving universal matching no longer calls per-file glob matching while preserving root placement.

Closes #1988

## Local validation
- Baseline repro before the patch on 500 one-file directories: root placement, `matching_dirs=500`, `_file_matches_pattern` called 500 times.
- After the patch on the same repro: root placement, `matching_dirs=500`, `_file_matches_pattern` called 0 times.
- `$env:PYTHONPATH=(Resolve-Path src).Path; ..\microsoft-apm\.venv\Scripts\python.exe -m pytest tests\unit\compilation\test_context_optimizer_cache_and_placement.py -q` -> 5 passed.
- `$env:PYTHONPATH=(Resolve-Path src).Path; ..\microsoft-apm\.venv\Scripts\python.exe -m pytest tests\unit\compilation -q` -> 1206 passed.
- `..\microsoft-apm\.venv\Scripts\ruff.exe check src\apm_cli\compilation\context_optimizer.py tests\unit\compilation\test_context_optimizer_cache_and_placement.py` -> passed.
- `..\microsoft-apm\.venv\Scripts\ruff.exe format --check src\apm_cli\compilation\context_optimizer.py tests\unit\compilation\test_context_optimizer_cache_and_placement.py` -> passed.
- `git diff --check` -> passed.