### PR TITLE
fix(utils): keep .git suffix on anonymous HTTPS clone URLs (closes #1995)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `apm audit --ci` no longer reports phantom drift for root-local hook files
   when audit replay writes into a scratch project root. (#1980)
 
+- `apm install` no longer fails for dependencies on git hosts that serve
+  smart-HTTP only at the `.git` path without redirecting the bare path
+  (e.g. GitBucket): the anonymous HTTPS clone URL builder now keeps the
+  `.git` suffix, matching the token, SSH, and plain-HTTP builders. (#1995)
+
 ## [0.23.1] - 2026-06-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   environment for Claude Code and Codex instead of being written verbatim.
   (#1966)
 
-- `apm install` no longer fails for dependencies on git hosts that serve
-  smart-HTTP only at the `.git` path without redirecting the bare path
-  (e.g. GitBucket): the anonymous HTTPS clone URL builder now keeps the
-  `.git` suffix, matching the token, SSH, and plain-HTTP builders. (#1995)
+- `apm install` no longer fails on self-hosted git hosts such as GitBucket
+  that require the `.git` URL suffix; anonymous HTTPS clone URLs now match
+  the token, SSH, and plain-HTTP builders. (#1995)
 
 ## [0.23.1] - 2026-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   environment for Claude Code and Codex instead of being written verbatim.
   (#1966)
 
-- `apm install` no longer drops the `.git` suffix from anonymous HTTPS
-  dependencies, fixing self-hosted git hosts such as GitBucket that require
-  the suffixed clone URL. (#1995)
+- Self-hosted git hosts such as GitBucket that serve smart-HTTP only at the
+  `.git` path now install successfully over anonymous HTTPS; `apm install` no
+  longer drops the suffix. (#1995)
 
 ## [0.23.1] - 2026-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   environment for Claude Code and Codex instead of being written verbatim.
   (#1966)
 
-- `apm install` no longer fails on self-hosted git hosts such as GitBucket
-  that require the `.git` URL suffix; anonymous HTTPS clone URLs now match
-  the token, SSH, and plain-HTTP builders. (#1995)
+- `apm install` no longer drops the `.git` suffix from anonymous HTTPS
+  dependencies, fixing self-hosted git hosts such as GitBucket that require
+  the suffixed clone URL. (#1995)
 
 ## [0.23.1] - 2026-06-29
 

--- a/src/apm_cli/marketplace/ref_resolver.py
+++ b/src/apm_cli/marketplace/ref_resolver.py
@@ -207,8 +207,6 @@ class RefResolver:
                 raise OfflineMissError(package="", remote=owner_repo)
 
             url = build_https_clone_url(self._host, owner_repo, token=self._token)
-            if not url.endswith(".git"):
-                url += ".git"
             env = {**os.environ, "GIT_TERMINAL_PROMPT": "0", "GIT_ASKPASS": "echo"}
             try:
                 result = subprocess.run(
@@ -284,8 +282,6 @@ class RefResolver:
             When the ref does not exist or the subprocess fails.
         """
         url = build_https_clone_url(self._host, owner_repo, token=self._token)
-        if not url.endswith(".git"):
-            url += ".git"
         env = {**os.environ, "GIT_TERMINAL_PROMPT": "0", "GIT_ASKPASS": "echo"}
         try:
             result = subprocess.run(

--- a/src/apm_cli/utils/github_host.py
+++ b/src/apm_cli/utils/github_host.py
@@ -379,7 +379,11 @@ def build_https_clone_url(
     if token:
         # Use x-access-token format which is compatible with GitHub Enterprise and GH Actions
         return f"https://x-access-token:{token}@{netloc}/{repo_ref}.git"
-    return f"https://{netloc}/{repo_ref}"
+    # Keep the .git suffix on the anonymous form too: hosts like GitBucket
+    # serve smart-HTTP only at the .git path (no redirect), while GitHub /
+    # GitLab / Bitbucket / Gitea accept both. This also keeps parity with
+    # the token, SSH, and plain-HTTP builders, which all emit .git.
+    return f"https://{netloc}/{repo_ref}.git"
 
 
 def build_gitlab_https_clone_url(

--- a/src/apm_cli/utils/github_host.py
+++ b/src/apm_cli/utils/github_host.py
@@ -372,6 +372,8 @@ def build_https_clone_url(
 
     ``port`` is embedded in the netloc (``host:port``) when set so custom
     HTTPS ports (e.g. self-hosted Git servers on 8443) are preserved.
+    Returned URLs always carry the ``.git`` suffix, matching SSH and plain-HTTP
+    builders.
 
     Note: callers must avoid logging raw token-bearing URLs.
     """

--- a/src/apm_cli/utils/github_host.py
+++ b/src/apm_cli/utils/github_host.py
@@ -372,8 +372,8 @@ def build_https_clone_url(
 
     ``port`` is embedded in the netloc (``host:port``) when set so custom
     HTTPS ports (e.g. self-hosted Git servers on 8443) are preserved.
-    Returned URLs always carry the ``.git`` suffix, matching SSH and plain-HTTP
-    builders.
+    Returned Git-family URLs always carry the ``.git`` suffix, matching SSH,
+    plain-HTTP, and GitLab builders.
 
     Note: callers must avoid logging raw token-bearing URLs.
     """

--- a/tests/integration/test_anonymous_https_git_suffix_e2e.py
+++ b/tests/integration/test_anonymous_https_git_suffix_e2e.py
@@ -1,0 +1,146 @@
+"""Hermetic e2e regression coverage for anonymous generic HTTPS clone URLs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
+
+from apm_cli.core.token_manager import GitHubTokenManager
+from apm_cli.deps.github_downloader import GitHubPackageDownloader
+from apm_cli.models.apm_package import (
+    APMPackage,
+    GitReferenceType,
+    ResolvedReference,
+    clear_apm_yml_cache,
+)
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.requires_e2e_mode,
+]
+
+
+class _FakeGit:
+    """Minimal GitPython ``repo.git`` stand-in used by downloader cleanup."""
+
+    def clear_cache(self) -> None:
+        """Match the GitPython cleanup surface."""
+
+
+class _FakeRepo:
+    """Minimal GitPython repo stand-in returned by the fake clone."""
+
+    git = _FakeGit()
+
+    def close(self) -> None:
+        """Match the GitPython cleanup surface."""
+
+
+def _write_manifest(project: Path) -> Path:
+    """Write an apm.yml that keeps a .git suffix in user input."""
+    apm_yml = project / "apm.yml"
+    apm_yml.write_text(
+        "\n".join(
+            [
+                "name: gitbucket-repro",
+                "version: '1.0.0'",
+                "dependencies:",
+                "  apm:",
+                "    - git: https://gitbucket.example.com/owner/repo.git",
+                "      ref: main",
+                "    ",
+                "  mcp: []",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return apm_yml
+
+
+def _resolved_main() -> ResolvedReference:
+    """Return a deterministic branch resolution with no network access."""
+    return ResolvedReference(
+        original_ref="main",
+        ref_name="main",
+        ref_type=GitReferenceType.BRANCH,
+        resolved_commit="a" * 40,
+    )
+
+
+def test_generic_anonymous_https_clone_url_keeps_git_suffix_end_to_end(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A GitBucket-style generic HTTPS dependency clones with /owner/repo.git."""
+    for name in (
+        "GITHUB_APM_PAT",
+        "GITHUB_TOKEN",
+        "GH_TOKEN",
+        "ADO_APM_PAT",
+        "GITLAB_APM_PAT",
+        "GITLAB_TOKEN",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setattr(
+        GitHubTokenManager,
+        "resolve_credential_from_git",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        GitHubTokenManager,
+        "resolve_credential_from_gh_cli",
+        lambda *args, **kwargs: None,
+    )
+
+    clear_apm_yml_cache()
+    apm_yml = _write_manifest(tmp_path)
+    package = APMPackage.from_apm_yml(apm_yml)
+    dep_ref = package.get_apm_dependencies()[0]
+    captured: dict[str, object] = {}
+
+    def fake_clone_from(
+        url: str,
+        target: Path,
+        *,
+        env: dict[str, str] | None = None,
+        progress: object | None = None,
+        **kwargs: object,
+    ) -> _FakeRepo:
+        """Capture the clone URL and materialise a valid package."""
+        captured["url"] = url
+        captured["env"] = env or {}
+        captured["kwargs"] = kwargs
+        target.mkdir(parents=True, exist_ok=True)
+        skill_dir = target / ".apm" / "skills" / "demo"
+        skill_dir.mkdir(parents=True)
+        (target / "apm.yml").write_text(
+            "name: cloned-gitbucket-package\nversion: '1.0.0'\n",
+            encoding="utf-8",
+        )
+        (skill_dir / "SKILL.md").write_text("# Demo\n", encoding="utf-8")
+        return _FakeRepo()
+
+    monkeypatch.setattr("apm_cli.deps.github_downloader.Repo.clone_from", fake_clone_from)
+    monkeypatch.setattr(
+        GitHubPackageDownloader,
+        "resolve_git_reference",
+        lambda self, repo_ref: _resolved_main(),
+    )
+
+    downloader = GitHubPackageDownloader()
+    result = downloader.download_package(dep_ref, tmp_path / "apm_modules" / "owner" / "repo")
+
+    clone_url = captured["url"]
+    assert isinstance(clone_url, str)
+    parsed = urlparse(clone_url)
+    assert parsed.scheme == "https"
+    assert parsed.hostname == "gitbucket.example.com"
+    assert parsed.username is None
+    assert parsed.password is None
+    assert parsed.path == "/owner/repo.git"
+    assert captured["kwargs"] == {"depth": 1, "branch": "main"}
+    assert result.package.name == "cloned-gitbucket-package"

--- a/tests/integration/test_runtime_smoke.py
+++ b/tests/integration/test_runtime_smoke.py
@@ -16,6 +16,7 @@ import pytest
 
 pytestmark = [
     pytest.mark.requires_e2e_mode,
+    pytest.mark.requires_network_integration,
     # Mutates os.environ["HOME"]; must be serialized on a single xdist worker.
     # Requires --dist loadgroup in the xdist invocation (the only
     # scheduler that honors xdist_group); without it the marker is

--- a/tests/integration/test_skill_bundle_live.py
+++ b/tests/integration/test_skill_bundle_live.py
@@ -26,7 +26,10 @@ import yaml
 # Markers and skip gates
 # ---------------------------------------------------------------------------
 
-pytestmark = pytest.mark.live
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.requires_network_integration,
+]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_github_downloader_token_precedence.py
+++ b/tests/test_github_downloader_token_precedence.py
@@ -74,7 +74,7 @@ class TestGitHubDownloaderTokenPrecedence:
 
             # Build URL should work for public repos
             public_url = downloader._build_repo_url("octocat/Hello-World", use_ssh=False)
-            expected_public = f"https://{github_host.default_host()}/octocat/Hello-World"
+            expected_public = f"https://{github_host.default_host()}/octocat/Hello-World.git"
             assert public_url == expected_public
 
     def test_private_repo_url_building_with_token(self):

--- a/tests/unit/deps/test_host_backends.py
+++ b/tests/unit/deps/test_host_backends.py
@@ -128,9 +128,9 @@ class TestGitHubFamilyCloneUrls:
     def test_https_no_token(self):
         backend = GitHubBackend(host_info=_info("github.com", "github"))
         url = backend.build_clone_https_url(_dep_ref(), token=None)
-        # build_https_clone_url omits the ".git" suffix on the unauthenticated
-        # path (preserved behavior from main).
-        assert url == "https://github.com/owner/repo"
+        # The unauthenticated path keeps the ".git" suffix, same as the token,
+        # SSH, and plain-HTTP builders (#1995).
+        assert url == "https://github.com/owner/repo.git"
 
     def test_https_with_token(self):
         backend = GitHubBackend(host_info=_info("github.com", "github"))
@@ -165,7 +165,7 @@ class TestGitHubFamilyCloneUrls:
     def test_ghe_cloud_https(self):
         backend = GHECloudBackend(host_info=_info("octo.ghe.com", "ghe_cloud"))
         url = backend.build_clone_https_url(_dep_ref(host="octo.ghe.com"), token=None)
-        assert url == "https://octo.ghe.com/owner/repo"
+        assert url == "https://octo.ghe.com/owner/repo.git"
 
     def test_https_with_custom_port(self):
         backend = GitHubBackend(host_info=_info("github.com", "github"))

--- a/tests/unit/deps/test_host_backends.py
+++ b/tests/unit/deps/test_host_backends.py
@@ -315,6 +315,7 @@ class TestGenericGitBackend:
         assert "some_token" not in url
         assert parsed.username is None and parsed.password is None
         assert parsed.hostname == "gitea.example.com"
+        assert parsed.path == "/owner/repo.git"
 
     def test_ssh_url(self):
         backend = GenericGitBackend(host_info=_info("gitea.example.com", "generic"))

--- a/tests/unit/test_auth_scoping.py
+++ b/tests/unit/test_auth_scoping.py
@@ -141,7 +141,7 @@ class TestBuildRepoUrlTokenScoping:
             url = dl._build_repo_url("acme/rules", use_ssh=False, dep_ref=dep)
         assert "ghp_SHOULD_NOT_LEAK" not in url
         assert "oauth2" not in url
-        assert url == "https://gitlab.com/acme/rules"
+        assert url == "https://gitlab.com/acme/rules.git"
 
     def test_bitbucket_does_not_get_github_token(self):
         dl = _make_downloader(github_token="ghp_TESTTOKEN")

--- a/tests/unit/test_generic_git_urls.py
+++ b/tests/unit/test_generic_git_urls.py
@@ -358,7 +358,7 @@ class TestCloneURLBuilding:
 
     def test_gitlab_https_clone_url(self):
         url = build_https_clone_url("gitlab.com", "acme/repo")
-        assert url == "https://gitlab.com/acme/repo"
+        assert url == "https://gitlab.com/acme/repo.git"
 
     def test_gitlab_https_clone_url_with_token(self):
         url = build_https_clone_url("gitlab.com", "acme/repo", token="glpat-xxx")
@@ -366,7 +366,7 @@ class TestCloneURLBuilding:
 
     def test_bitbucket_https_clone_url(self):
         url = build_https_clone_url("bitbucket.org", "acme/repo")
-        assert url == "https://bitbucket.org/acme/repo"
+        assert url == "https://bitbucket.org/acme/repo.git"
 
     def test_gitlab_ssh_clone_url(self):
         url = build_ssh_url("gitlab.com", "acme/repo")
@@ -391,7 +391,7 @@ class TestCloneURLBuilding:
 
     def test_https_clone_url_with_custom_port(self):
         url = build_https_clone_url("bitbucket.domain.ext", "team/repo", port=8443)
-        assert url == "https://bitbucket.domain.ext:8443/team/repo"
+        assert url == "https://bitbucket.domain.ext:8443/team/repo.git"
 
     def test_ssh_clone_url_with_custom_user(self):
         """Custom SSH usernames (e.g. EMU accounts) are preserved in the SCP shorthand."""


### PR DESCRIPTION
# Branch: fix/anonymous-https-git-suffix
# Commit: fix(utils): keep .git suffix on anonymous HTTPS clone URLs (closes #1995)

## Description

`build_https_clone_url` re-appends the `.git` suffix (stripped during
dependency parsing) on the token-bearing branch but not on the anonymous
branch. Generic hosts never embed tokens — auth is delegated to git
credential helpers — so they always receive the suffix-less URL. Hosts that
serve smart-HTTP only at the `.git` path without redirecting the bare path
(GitBucket) therefore fail on every `apm install`, and there is no
manifest-side workaround because the parser strips an explicitly written
`.git` before the builder runs.

This PR appends `.git` on the anonymous branch, restoring parity with the
token, SSH (`build_ssh_url`), and plain-HTTP (`build_clone_http_url`)
builders. All supported hosts (GitHub, GHE Cloud/Server, GitLab, Bitbucket,
Gitea) accept the suffixed form, so the change is backward-compatible.

Supporting evidence that the asymmetry was accidental: the marketplace ref
resolver was already compensating locally with
`if not url.endswith(".git"): url += ".git"` after calling the builder
(`git ls-remote` needs the suffix on GitHub too). Those two now-redundant
guards are removed so the invariant lives in the builder alone.

Six test expectations that asserted the suffix-less form are updated, plus
a CHANGELOG entry.

Known non-blocking follow-up (intentionally out of scope): with
`credential.useHttpPath=true`, the credential-fill probe in
`token_manager.py` sends `path=owner/repo` while git itself now requests
`path=owner/repo.git`; multi-account helper setups may want the fill path
suffixed for exact parity. Default helper matching is host-only, so the
common case is unaffected.

Fixes #1995

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally — verified against a real GitBucket 4.x instance:
  stock 0.23.1 fails with `git clone ... exit code(128)` on the suffix-less
  URL; with this patch the same manifest installs successfully over plain
  HTTPS with credential-helper auth (no `insteadOf` rewrites).
- [x] All existing tests pass (`pytest tests/unit tests/test_console.py`
  CI-equivalent scope; `ruff check` / `ruff format --check` silent).
- [x] Updated tests: `tests/unit/test_generic_git_urls.py` (3),
  `tests/unit/deps/test_host_backends.py` (2),
  `tests/test_github_downloader_token_precedence.py` (1) — expectations now
  assert the suffixed form.

## Spec conformance (OpenAPM v0.1)

- [x] N/A -- this PR does not change OpenAPM-observable behaviour.
  (`src/apm_cli/utils/` is outside the Mode B critical-path allowlist; no
  `req-XXX` anchor covers clone-URL construction.)
