### PR TITLE
fix: Sanitise marketplace name to kebab-case in output mappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Marketplace names containing dots, underscores, or other non-kebab-case
-  characters (e.g. `my.marketplace`) are now normalized to kebab-case in the
-  generated `marketplace.json` `name` field, so the Copilot App no longer
-  rejects them with a "name must be kebab-case" validation error. Internal
-  resolution, registry lookups, and the Codex `interface.displayName` keep the
-  original name. (#2008)
+- `apm pack` now produces a `marketplace.json` the Copilot App accepts even
+  when your manifest `name` contains dots, underscores, or other non-kebab-case
+  characters (e.g. `my.marketplace`): the emitted `name` field is normalized to
+  kebab-case, and `apm pack` prints a warning naming the original and emitted
+  values when a rewrite occurs. Internal resolution, registry lookups, and the
+  Codex `interface.displayName` keep the original name. (#2008)
 
 - `apm audit --ci` no longer reports phantom drift for root-local hook files
   when audit replay writes into a scratch project root. (#1980)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Marketplace names containing dots, underscores, or other non-kebab-case
+  characters (e.g. `my.marketplace`) are now normalized to kebab-case in the
+  generated `marketplace.json` `name` field, so the Copilot App no longer
+  rejects them with a "name must be kebab-case" validation error. Internal
+  resolution, registry lookups, and the Codex `interface.displayName` keep the
+  original name. (#2008)
+
 - `apm audit --ci` no longer reports phantom drift for root-local hook files
   when audit replay writes into a scratch project root. (#1980)
 

--- a/docs/src/content/docs/producer/publish-to-a-marketplace.md
+++ b/docs/src/content/docs/producer/publish-to-a-marketplace.md
@@ -117,11 +117,13 @@ marketplace:
 
 The key in `apm.yml` is `packages:`. It becomes `plugins:` in the
 compiled `marketplace.json`. Alongside that rename, `apm pack` normalises
-the top-level `name` to kebab-case in the compiled output (see the
-[schema reference](../../reference/manifest-schema/#72-block-fields)) --
-lowercase letters, digits, and hyphens only -- so the Copilot App accepts
-it; the raw name is preserved for internal resolution and, for Codex, as
-`interface.displayName`. Strict schema: unknown keys raise an error, never
+the top-level `name` to kebab-case in the compiled output -- lowercase
+letters, digits, and hyphens only -- so the Copilot App accepts it (see the
+[schema reference](../../reference/manifest-schema/#72-block-fields)). The
+raw name is preserved for internal resolution and, for Codex, as
+`interface.displayName`. When a rewrite occurs, `apm pack` prints a warning
+showing both the original and emitted name. Strict schema: unknown keys
+raise an error, never
 silently ignored.
 
 Use `sourceBase` when packages live under the same enterprise git base.

--- a/docs/src/content/docs/producer/publish-to-a-marketplace.md
+++ b/docs/src/content/docs/producer/publish-to-a-marketplace.md
@@ -116,9 +116,13 @@ marketplace:
 ```
 
 The key in `apm.yml` is `packages:`. It becomes `plugins:` in the
-compiled `marketplace.json` -- that rename is the only structural
-transform `apm pack` performs. Strict schema: unknown keys raise an
-error, never silently ignored.
+compiled `marketplace.json`. Alongside that rename, `apm pack` normalises
+the top-level `name` to kebab-case in the compiled output (see the
+[schema reference](../../reference/manifest-schema/#72-block-fields)) --
+lowercase letters, digits, and hyphens only -- so the Copilot App accepts
+it; the raw name is preserved for internal resolution and, for Codex, as
+`interface.displayName`. Strict schema: unknown keys raise an error, never
+silently ignored.
 
 Use `sourceBase` when packages live under the same enterprise git base.
 The base may target any supported host -- GitHub.com, GitHub Enterprise,

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -806,7 +806,7 @@ Overrides exist for the rare case where the published marketplace identity diffe
 
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `name` | `string` | OPTIONAL (override) | inherited | Override of top-level `name`. |
+| `name` | `string` | OPTIONAL (override) | inherited | Override of top-level `name`. Normalised to kebab-case (lowercase, non-alphanumeric -> hyphen) in the compiled `marketplace.json` for Copilot App compatibility; the raw value is retained internally and, for Codex, as `interface.displayName`. |
 | `description` | `string` | OPTIONAL (override) | inherited | Override of top-level `description`. |
 | `version` | `string` | OPTIONAL (override) | inherited | Override of top-level `version`. Validated as semver. |
 | `owner` | `Owner` | REQUIRED | -- | Marketplace publisher identity. See Section 7.3. |

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -82,7 +82,7 @@ Newly initialised projects (`apm init`) are scaffolded by the CLI; see [`apm ini
 |---|---|
 | **Type** | `string` |
 | **Required** | MUST be present |
-| **Description** | Package identifier. Free-form string (no pattern enforced at parse time). Convention: alphanumeric, dots, hyphens, underscores. |
+| **Description** | Package identifier. Free-form string (no pattern enforced at parse time). Convention: alphanumeric, dots, hyphens, underscores. Normalised to kebab-case in the compiled `marketplace.json` -- see [7.2](#72-block-fields). |
 
 ### 3.2. `version`
 

--- a/src/apm_cli/marketplace/output_mappers.py
+++ b/src/apm_cli/marketplace/output_mappers.py
@@ -16,6 +16,9 @@ from typing import TYPE_CHECKING, Any
 from .diagnostics import BuildDiagnostic
 from .errors import BuildError
 
+_RE_NON_ALNUM = re.compile(r"[^a-z0-9]")
+_RE_MULTI_DASH = re.compile(r"-{2,}")
+
 
 def sanitize_marketplace_name(name: str) -> str:
     """Normalize a marketplace name to kebab-case for Copilot App compatibility.
@@ -32,11 +35,14 @@ def sanitize_marketplace_name(name: str) -> str:
 
     Note: this is a *display/identity* sanitizer for the emitted JSON only.
     It is distinct from ``client._sanitize_cache_name`` (path-safety for
-    on-disk cache keys); do not use this helper for filesystem paths.
+    on-disk cache keys); do not use this helper for filesystem paths.  The
+    mapping is intentionally many-to-one (``my.pkg`` and ``my_pkg`` both map
+    to ``my-pkg``); do not use it for identity disambiguation or registry-key
+    deduplication.
     """
     result = name.lower()
-    result = re.sub(r"[^a-z0-9]", "-", result)
-    result = re.sub(r"-{2,}", "-", result)
+    result = _RE_NON_ALNUM.sub("-", result)
+    result = _RE_MULTI_DASH.sub("-", result)
     result = result.strip("-")
     return result or "marketplace"
 
@@ -48,8 +54,8 @@ def _sanitized_name_with_diagnostic(config_name: str) -> tuple[str, list[BuildDi
     empty.  When sanitisation actually rewrites the name, a single
     ``warning``-level ``BuildDiagnostic`` is emitted so the user sees that the
     value landing in ``marketplace.json`` differs from what they configured and
-    can rename ``marketplace.yml`` to silence it.  Shared by both output
-    mappers so the message and level stay consistent.
+    can rename it in their marketplace config to silence it.  Shared by both
+    output mappers so the message and level stay consistent.
     """
     sanitized = sanitize_marketplace_name(config_name)
     diagnostics: list[BuildDiagnostic] = []
@@ -60,7 +66,7 @@ def _sanitized_name_with_diagnostic(config_name: str) -> tuple[str, list[BuildDi
                 message=(
                     f"[!] Marketplace name '{config_name}' is not kebab-case -- "
                     f"emitted as '{sanitized}' in marketplace.json for Copilot App "
-                    f"compatibility. Rename it in marketplace.yml to silence this."
+                    f"compatibility. Rename it in your marketplace config to silence this."
                 ),
             )
         )

--- a/src/apm_cli/marketplace/output_mappers.py
+++ b/src/apm_cli/marketplace/output_mappers.py
@@ -7,6 +7,7 @@ these classes own format-specific field mapping.
 
 from __future__ import annotations
 
+import re
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -14,6 +15,25 @@ from typing import TYPE_CHECKING, Any
 
 from .diagnostics import BuildDiagnostic
 from .errors import BuildError
+
+
+def sanitise_marketplace_name(name: str) -> str:
+    """Convert a marketplace name to kebab-case for Copilot App compatibility.
+
+    Repo names like ``my.marketplace`` or ``My_Package`` are valid on GitHub
+    but rejected by the Copilot App which requires kebab-case
+    (lowercase letters, digits, and hyphens only).
+
+    The conversion lowercases the input, replaces every non-alphanumeric
+    character with a hyphen, collapses consecutive hyphens, and strips
+    leading/trailing hyphens.
+    """
+    result = name.lower()
+    result = re.sub(r"[^a-z0-9]", "-", result)
+    result = re.sub(r"-{2,}", "-", result)
+    result = result.strip("-")
+    return result or "marketplace"
+
 
 if TYPE_CHECKING:
     from .builder import ResolvedPackage
@@ -61,7 +81,7 @@ class ClaudeMarketplaceMapper(MarketplaceOutputMapper):
         entry_by_name: dict[str, PackageEntry] = {e.name: e for e in config.packages}
 
         doc: dict[str, Any] = OrderedDict()
-        doc["name"] = config.name
+        doc["name"] = sanitise_marketplace_name(config.name)
         if config.description_overridden and config.description:
             doc["description"] = config.description
         if config.version_overridden and config.version:
@@ -236,7 +256,8 @@ class CodexMarketplaceMapper(MarketplaceOutputMapper):
         entry_by_name: dict[str, PackageEntry] = {e.name: e for e in config.packages}
 
         doc: dict[str, Any] = OrderedDict()
-        doc["name"] = config.name
+        sanitised = sanitise_marketplace_name(config.name)
+        doc["name"] = sanitised
         doc["interface"] = OrderedDict({"displayName": config.name})
 
         plugins: list[dict[str, Any]] = []

--- a/src/apm_cli/marketplace/output_mappers.py
+++ b/src/apm_cli/marketplace/output_mappers.py
@@ -17,12 +17,14 @@ from .diagnostics import BuildDiagnostic
 from .errors import BuildError
 
 
-def sanitise_marketplace_name(name: str) -> str:
-    """Convert a marketplace name to kebab-case for Copilot App compatibility.
+def sanitize_marketplace_name(name: str) -> str:
+    """Normalize a marketplace name to kebab-case for Copilot App compatibility.
 
-    Repo names like ``my.marketplace`` or ``My_Package`` are valid on GitHub
-    but rejected by the Copilot App which requires kebab-case
-    (lowercase letters, digits, and hyphens only).
+    Marketplace names like ``my.marketplace`` or ``My_Package`` are valid
+    identifiers on GitHub but rejected by the Copilot App which requires
+    kebab-case (lowercase letters, digits, and hyphens only).  This is an
+    output-boundary normalization -- the original name is preserved for
+    internal lookups and display purposes.
 
     The conversion lowercases the input, replaces every non-alphanumeric
     character with a hyphen, collapses consecutive hyphens, and strips
@@ -81,7 +83,7 @@ class ClaudeMarketplaceMapper(MarketplaceOutputMapper):
         entry_by_name: dict[str, PackageEntry] = {e.name: e for e in config.packages}
 
         doc: dict[str, Any] = OrderedDict()
-        doc["name"] = sanitise_marketplace_name(config.name)
+        doc["name"] = sanitize_marketplace_name(config.name)
         if config.description_overridden and config.description:
             doc["description"] = config.description
         if config.version_overridden and config.version:
@@ -256,8 +258,8 @@ class CodexMarketplaceMapper(MarketplaceOutputMapper):
         entry_by_name: dict[str, PackageEntry] = {e.name: e for e in config.packages}
 
         doc: dict[str, Any] = OrderedDict()
-        sanitised = sanitise_marketplace_name(config.name)
-        doc["name"] = sanitised
+        sanitized = sanitize_marketplace_name(config.name)
+        doc["name"] = sanitized
         doc["interface"] = OrderedDict({"displayName": config.name})
 
         plugins: list[dict[str, Any]] = []

--- a/src/apm_cli/marketplace/output_mappers.py
+++ b/src/apm_cli/marketplace/output_mappers.py
@@ -29,12 +29,42 @@ def sanitize_marketplace_name(name: str) -> str:
     The conversion lowercases the input, replaces every non-alphanumeric
     character with a hyphen, collapses consecutive hyphens, and strips
     leading/trailing hyphens.
+
+    Note: this is a *display/identity* sanitizer for the emitted JSON only.
+    It is distinct from ``client._sanitize_cache_name`` (path-safety for
+    on-disk cache keys); do not use this helper for filesystem paths.
     """
     result = name.lower()
     result = re.sub(r"[^a-z0-9]", "-", result)
     result = re.sub(r"-{2,}", "-", result)
     result = result.strip("-")
     return result or "marketplace"
+
+
+def _sanitized_name_with_diagnostic(config_name: str) -> tuple[str, list[BuildDiagnostic]]:
+    """Return the sanitized marketplace name and any diagnostic it warrants.
+
+    When the configured name is already kebab-case the diagnostic list is
+    empty.  When sanitisation actually rewrites the name, a single
+    ``warning``-level ``BuildDiagnostic`` is emitted so the user sees that the
+    value landing in ``marketplace.json`` differs from what they configured and
+    can rename ``marketplace.yml`` to silence it.  Shared by both output
+    mappers so the message and level stay consistent.
+    """
+    sanitized = sanitize_marketplace_name(config_name)
+    diagnostics: list[BuildDiagnostic] = []
+    if sanitized != config_name:
+        diagnostics.append(
+            BuildDiagnostic(
+                level="warning",
+                message=(
+                    f"[!] Marketplace name '{config_name}' is not kebab-case -- "
+                    f"emitted as '{sanitized}' in marketplace.json for Copilot App "
+                    f"compatibility. Rename it in marketplace.yml to silence this."
+                ),
+            )
+        )
+    return sanitized, diagnostics
 
 
 if TYPE_CHECKING:
@@ -83,7 +113,8 @@ class ClaudeMarketplaceMapper(MarketplaceOutputMapper):
         entry_by_name: dict[str, PackageEntry] = {e.name: e for e in config.packages}
 
         doc: dict[str, Any] = OrderedDict()
-        doc["name"] = sanitize_marketplace_name(config.name)
+        sanitized_name, name_diagnostics = _sanitized_name_with_diagnostic(config.name)
+        doc["name"] = sanitized_name
         if config.description_overridden and config.description:
             doc["description"] = config.description
         if config.version_overridden and config.version:
@@ -101,7 +132,7 @@ class ClaudeMarketplaceMapper(MarketplaceOutputMapper):
         plugin_root = config.metadata.get("pluginRoot", "")
         strip_count = 0
         override_count = 0
-        diagnostics: list[BuildDiagnostic] = []
+        diagnostics: list[BuildDiagnostic] = list(name_diagnostics)
         plugins: list[dict[str, Any]] = []
 
         for pkg in resolved:
@@ -258,7 +289,7 @@ class CodexMarketplaceMapper(MarketplaceOutputMapper):
         entry_by_name: dict[str, PackageEntry] = {e.name: e for e in config.packages}
 
         doc: dict[str, Any] = OrderedDict()
-        sanitized = sanitize_marketplace_name(config.name)
+        sanitized, name_diagnostics = _sanitized_name_with_diagnostic(config.name)
         doc["name"] = sanitized
         doc["interface"] = OrderedDict({"displayName": config.name})
 
@@ -285,7 +316,7 @@ class CodexMarketplaceMapper(MarketplaceOutputMapper):
             plugins.append(plugin)
 
         doc["plugins"] = plugins
-        return MapperResult(doc)
+        return MapperResult(doc, (), tuple(name_diagnostics))
 
 
 MARKETPLACE_OUTPUT_MAPPERS: dict[str, MarketplaceOutputMapper] = {

--- a/tests/integration/marketplace/test_name_sanitisation_e2e.py
+++ b/tests/integration/marketplace/test_name_sanitisation_e2e.py
@@ -92,6 +92,39 @@ class TestClaudeOutputSanitisesName:
         plugin_names = {p["name"] for p in data["plugins"]}
         assert plugin_names == {"code-reviewer", "test-generator"}
 
+    def test_rewrite_emits_warning_diagnostic(self, tmp_path: Path, mock_ref_resolver):
+        """When the name is rewritten the build surfaces a warning diagnostic."""
+        _write_yml(tmp_path, NON_KEBAB_YML)
+
+        builder = MarketplaceBuilder(tmp_path / "marketplace.yml")
+        report = builder.build()
+
+        name_diags = [
+            d
+            for d in report.diagnostics
+            if d.level == "warning" and RAW_NAME in d.message and EXPECTED_NAME in d.message
+        ]
+        assert name_diags, "expected a warning diagnostic naming the old and new name"
+
+    def test_kebab_name_emits_no_diagnostic(self, tmp_path: Path, mock_ref_resolver):
+        """An already-kebab-case name must not trigger the rewrite warning."""
+        _write_yml(tmp_path, NON_KEBAB_YML.replace(RAW_NAME, "already-kebab"))
+
+        builder = MarketplaceBuilder(tmp_path / "marketplace.yml")
+        report = builder.build()
+
+        assert not [d for d in report.diagnostics if "not kebab-case" in d.message]
+
+    def test_all_special_name_falls_back(self, tmp_path: Path, mock_ref_resolver):
+        """A name of only special characters falls back to the literal 'marketplace'."""
+        _write_yml(tmp_path, NON_KEBAB_YML.replace(RAW_NAME, "..."))
+
+        builder = MarketplaceBuilder(tmp_path / "marketplace.yml")
+        builder.build()
+
+        data = json.loads((tmp_path / "marketplace.json").read_text(encoding="utf-8"))
+        assert data["name"] == "marketplace"
+
 
 class TestCodexOutputSanitisesName:
     """The Codex document must sanitise ``name`` but preserve the display name."""

--- a/tests/integration/marketplace/test_name_sanitisation_e2e.py
+++ b/tests/integration/marketplace/test_name_sanitisation_e2e.py
@@ -1,0 +1,108 @@
+"""End-to-end integration tests for marketplace name sanitisation.
+
+Strategy
+--------
+The unit suite (``tests/unit/marketplace/test_name_sanitisation.py``) proves
+``sanitize_marketplace_name`` in isolation.  These tests provide the empirical
+proof that the sanitisation actually reaches the on-disk artefact: they write a
+real ``marketplace.yml`` whose ``name`` is NOT kebab-case, run the full build
+pipeline (load -> resolve -> compose -> write), and assert against the produced
+JSON documents for BOTH output mappers (Claude and Codex).
+
+``RefResolver.list_remote_refs`` is patched via ``mock_ref_resolver`` so no
+network calls are made; every assertion is against real file-system / composed
+output produced by the pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from apm_cli.marketplace.builder import MarketplaceBuilder
+
+from .conftest import run_cli  # noqa: F401
+
+# A marketplace name that GitHub accepts as a repo/manifest identifier but the
+# Copilot App rejects: contains an uppercase letter, a dot, and an underscore.
+RAW_NAME = "My.Marketplace_Name"
+EXPECTED_NAME = "my-marketplace-name"
+
+NON_KEBAB_YML = f"""\
+name: {RAW_NAME}
+description: Marketplace with a non-kebab-case name
+version: 1.0.0
+owner:
+  name: Test Org
+  email: test@example.com
+  url: https://example.com
+metadata:
+  pluginRoot: plugins
+  category: testing
+packages:
+  - name: code-reviewer
+    description: Automated code review assistant
+    source: acme/code-reviewer
+    version: "^2.0.0"
+    category: tools
+    tags:
+      - review
+      - quality
+  - name: test-generator
+    description: Test generation tool
+    source: acme/test-generator
+    version: "^1.0.0"
+    subdir: src/plugin
+    category: tools
+    tags:
+      - testing
+"""
+
+
+def _write_yml(tmp_path: Path, content: str) -> Path:
+    p = tmp_path / "marketplace.yml"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+class TestClaudeOutputSanitisesName:
+    """The Claude marketplace.json written to disk must carry a kebab-case name."""
+
+    def test_written_json_name_is_kebab_case(self, tmp_path: Path, mock_ref_resolver):
+        """A non-kebab config name is normalised in the emitted marketplace.json."""
+        _write_yml(tmp_path, NON_KEBAB_YML)
+
+        builder = MarketplaceBuilder(tmp_path / "marketplace.yml")
+        builder.build()
+
+        out_path = tmp_path / "marketplace.json"
+        assert out_path.exists(), "marketplace.json was not produced"
+        data = json.loads(out_path.read_text(encoding="utf-8"))
+
+        assert data["name"] == EXPECTED_NAME
+
+    def test_internal_package_names_untouched(self, tmp_path: Path, mock_ref_resolver):
+        """Sanitisation is scoped to the top-level name -- plugin names are verbatim."""
+        _write_yml(tmp_path, NON_KEBAB_YML)
+
+        builder = MarketplaceBuilder(tmp_path / "marketplace.yml")
+        builder.build()
+
+        data = json.loads((tmp_path / "marketplace.json").read_text(encoding="utf-8"))
+        plugin_names = {p["name"] for p in data["plugins"]}
+        assert plugin_names == {"code-reviewer", "test-generator"}
+
+
+class TestCodexOutputSanitisesName:
+    """The Codex document must sanitise ``name`` but preserve the display name."""
+
+    def test_codex_name_sanitised_display_name_preserved(self, tmp_path: Path, mock_ref_resolver):
+        """Codex ``name`` is kebab-case while ``interface.displayName`` keeps the raw name."""
+        _write_yml(tmp_path, NON_KEBAB_YML)
+
+        builder = MarketplaceBuilder(tmp_path / "marketplace.yml")
+        result = builder.resolve()
+        doc, _warnings = builder.compose_codex_marketplace_json(list(result.entries))
+
+        assert doc["name"] == EXPECTED_NAME
+        assert doc["interface"]["displayName"] == RAW_NAME

--- a/tests/unit/marketplace/test_name_sanitisation.py
+++ b/tests/unit/marketplace/test_name_sanitisation.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import pytest
 
-from apm_cli.marketplace.output_mappers import sanitise_marketplace_name
+from apm_cli.marketplace.output_mappers import sanitize_marketplace_name
 
 
-class TestSanitiseMarketplaceName:
-    """Verify sanitise_marketplace_name produces valid kebab-case output."""
+class TestSanitizeMarketplaceName:
+    """Verify sanitize_marketplace_name produces valid kebab-case output."""
 
     @pytest.mark.parametrize(
         ("raw", "expected"),
@@ -29,13 +29,13 @@ class TestSanitiseMarketplaceName:
         ],
     )
     def test_converts_to_kebab_case(self, raw: str, expected: str) -> None:
-        assert sanitise_marketplace_name(raw) == expected
+        assert sanitize_marketplace_name(raw) == expected
 
     def test_empty_string_returns_fallback(self) -> None:
-        assert sanitise_marketplace_name("") == "marketplace"
+        assert sanitize_marketplace_name("") == "marketplace"
 
     def test_only_special_chars_returns_fallback(self) -> None:
-        assert sanitise_marketplace_name("...") == "marketplace"
+        assert sanitize_marketplace_name("...") == "marketplace"
 
     def test_already_kebab_case_unchanged(self) -> None:
-        assert sanitise_marketplace_name("my-marketplace") == "my-marketplace"
+        assert sanitize_marketplace_name("my-marketplace") == "my-marketplace"

--- a/tests/unit/marketplace/test_name_sanitisation.py
+++ b/tests/unit/marketplace/test_name_sanitisation.py
@@ -1,0 +1,41 @@
+"""Tests for marketplace name sanitisation in output mappers."""
+
+from __future__ import annotations
+
+import pytest
+
+from apm_cli.marketplace.output_mappers import sanitise_marketplace_name
+
+
+class TestSanitiseMarketplaceName:
+    """Verify sanitise_marketplace_name produces valid kebab-case output."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("my.marketplace", "my-marketplace"),
+            ("My_Package", "my-package"),
+            ("Already-Valid", "already-valid"),
+            ("kebab-case-name", "kebab-case-name"),
+            ("dots.and_underscores.mixed", "dots-and-underscores-mixed"),
+            ("UPPER", "upper"),
+            ("with  spaces", "with-spaces"),
+            ("multi...dots", "multi-dots"),
+            ("--leading-trailing--", "leading-trailing"),
+            ("name123", "name123"),
+            ("a", "a"),
+            ("org/my.marketplace", "org-my-marketplace"),
+            ("special!@#chars", "special-chars"),
+        ],
+    )
+    def test_converts_to_kebab_case(self, raw: str, expected: str) -> None:
+        assert sanitise_marketplace_name(raw) == expected
+
+    def test_empty_string_returns_fallback(self) -> None:
+        assert sanitise_marketplace_name("") == "marketplace"
+
+    def test_only_special_chars_returns_fallback(self) -> None:
+        assert sanitise_marketplace_name("...") == "marketplace"
+
+    def test_already_kebab_case_unchanged(self) -> None:
+        assert sanitise_marketplace_name("my-marketplace") == "my-marketplace"


### PR DESCRIPTION
## Description

Repository names containing dots, underscores, or other non-kebab-case characters (e.g. `my.marketplace`) flow into `marketplace.json` verbatim. The Copilot App rejects these with a validation error: "name Marketplace name must be kebab-case (letters, numbers, and hyphens)".

Since we cannot control how users name their repositories, this PR adds a `sanitise_marketplace_name()` function that converts names to kebab-case at the output boundary -- when composing `marketplace.json`. The function lowercases, replaces non-alphanumeric characters with hyphens, collapses consecutive hyphens, and strips leading/trailing hyphens.

Applied in both `ClaudeMarketplaceMapper` and `CodexMarketplaceMapper`. Internal resolution, registry lookups, and install flows remain untouched -- the original name is preserved everywhere except the consumer-facing JSON `"name"` field. The Codex `displayName` also keeps the original for human readability.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass (1409 marketplace unit tests)
- [x] Added tests for new functionality (`tests/unit/marketplace/test_name_sanitisation.py` -- 16 parametrised cases covering dots, underscores, spaces, slashes, special characters, mixed case, edge cases, and fallback behaviour)

## Spec conformance (OpenAPM v0.1)

- [x] N/A -- this PR does not change OpenAPM-observable behaviour.