### PR TITLE
fix(yaml): preserve apm.yml comments on manifest update (closes #2000)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm install` and `apm uninstall` no longer strip comments from `apm.yml`
+  while updating dependency entries. (#2012)
 - `apm pack` now produces a `marketplace.json` the Copilot App accepts even
   when your manifest `name` contains dots, underscores, or other non-kebab-case
   characters (e.g. `my.marketplace`): the emitted `name` field is normalized to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `apm install` and `apm uninstall` no longer strip comments from `apm.yml`
-  while updating dependency entries. (#2012)
+  while updating dependency entries, so inline annotations and section notes
+  survive dependency updates. (#2012)
 - `apm pack` now produces a `marketplace.json` the Copilot App accepts even
   when your manifest `name` contains dots, underscores, or other non-kebab-case
   characters (e.g. `my.marketplace`): the emitted `name` field is normalized to

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -609,9 +609,9 @@ def _merge_packages_into_yml(
 
     # Write back to apm.yml
     try:
-        from ..utils.yaml_io import dump_yaml
+        from ..utils.yaml_io import dump_yaml_roundtrip
 
-        dump_yaml(data, apm_yml_path)
+        dump_yaml_roundtrip(data, apm_yml_path)
         if logger:
             logger.success(
                 f"Updated {APM_YML_FILENAME} with {len(validated_packages)} new package(s)"
@@ -660,9 +660,9 @@ def _validate_and_add_packages_to_apm_yml(
 
     # Read current apm.yml
     try:
-        from ..utils.yaml_io import load_yaml
+        from ..utils.yaml_io import load_yaml_roundtrip
 
-        data = load_yaml(apm_yml_path) or {}
+        data = load_yaml_roundtrip(apm_yml_path) or {}
     except Exception as e:
         if logger:
             logger.error(f"Failed to read {APM_YML_FILENAME}: {e}")

--- a/src/apm_cli/commands/uninstall/cli.py
+++ b/src/apm_cli/commands/uninstall/cli.py
@@ -95,11 +95,11 @@ def uninstall(ctx, packages, dry_run, verbose, global_):
         )
 
         # Read current apm.yml
-        from ...utils.yaml_io import dump_yaml, load_yaml
+        from ...utils.yaml_io import dump_yaml_roundtrip, load_yaml_roundtrip
 
         apm_yml_path = manifest_path
         try:
-            data = load_yaml(apm_yml_path) or {}
+            data = load_yaml_roundtrip(apm_yml_path) or {}
         except Exception as e:
             logger.error(f"Failed to read {apm_yml_path}: {e}")
             sys.exit(1)
@@ -166,7 +166,7 @@ def uninstall(ctx, packages, dry_run, verbose, global_):
             if not data["devDependencies"] and not had_dev_section:
                 del data["devDependencies"]
         try:
-            dump_yaml(data, apm_yml_path)
+            dump_yaml_roundtrip(data, apm_yml_path)
             logger.success(f"Updated {apm_yml_path} (removed {len(packages_to_remove)} package(s))")
         except Exception as e:
             logger.error(f"Failed to write {apm_yml_path}: {e}")

--- a/src/apm_cli/install/package_resolution.py
+++ b/src/apm_cli/install/package_resolution.py
@@ -370,9 +370,9 @@ def persist_dependency_list_if_changed(
         return
     data[dep_section]["apm"] = current_deps
     try:
-        from apm_cli.utils.yaml_io import dump_yaml
+        from apm_cli.utils.yaml_io import dump_yaml_roundtrip
 
-        dump_yaml(data, apm_yml_path)
+        dump_yaml_roundtrip(data, apm_yml_path)
         if logger:
             logger.success(f"Updated {apm_yml_filename} dependency entries")
     except Exception as e:

--- a/src/apm_cli/utils/yaml_io.py
+++ b/src/apm_cli/utils/yaml_io.py
@@ -7,14 +7,17 @@ default file encoding is cp1252, not UTF-8.
 
 Public API::
 
-    load_yaml(path)        -- read a .yml/.yaml file -> dict | None
-    dump_yaml(data, path)  -- write dict -> .yml/.yaml file
-    yaml_to_str(data)      -- serialize dict -> YAML string
+    load_yaml(path)                 -- read a .yml/.yaml file -> dict | None
+    dump_yaml(data, path)           -- write dict -> .yml/.yaml file
+    load_yaml_roundtrip(path)       -- read YAML while preserving comments
+    dump_yaml_roundtrip(data, path) -- write round-trip YAML data
+    yaml_to_str(data)               -- serialize dict -> YAML string
 """
 
 import os
 import secrets
 from contextlib import suppress
+from io import StringIO
 from pathlib import Path
 from typing import Any
 
@@ -283,6 +286,51 @@ def load_yaml_str(text: str) -> dict[str, Any] | None:
     on malformed, over-budget, huge-int, or deeply-nested input.
     """
     return _bounded_load(text)
+
+
+def _roundtrip_yaml() -> Any:
+    """Return a configured ruamel.yaml round-trip parser."""
+    from ruamel.yaml import YAML
+
+    rt = YAML(typ="rt")
+    rt.preserve_quotes = True
+    rt.indent(mapping=2, sequence=4, offset=2)
+    return rt
+
+
+def _raise_as_pyyaml_error(exc: Exception) -> None:
+    """Normalize ruamel parser failures to the yaml.YAMLError family."""
+    from ruamel.yaml import YAMLError as RuamelYAMLError
+
+    if isinstance(exc, RuamelYAMLError):
+        raise yaml.YAMLError(f"round-trip YAML parse failed: {exc}") from exc
+    raise exc
+
+
+def load_yaml_roundtrip(path: str | Path) -> Any:
+    """Load YAML while preserving comments and formatting metadata.
+
+    The document is first parsed by the bounded PyYAML loader so the manifest
+    update paths keep the same alias and merge-key safety budget as
+    :func:`load_yaml`. The original text is then parsed with ruamel.yaml
+    round-trip mode so callers can mutate the returned object and write it back
+    without stripping comments.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+    _bounded_load(text)
+    try:
+        return _roundtrip_yaml().load(text)
+    except Exception as exc:
+        _raise_as_pyyaml_error(exc)
+
+
+def dump_yaml_roundtrip(data: Any, path: str | Path) -> None:
+    """Write ruamel round-trip YAML data with explicit UTF-8 encoding."""
+    stream = StringIO()
+    _roundtrip_yaml().dump(data, stream)
+    text = stream.getvalue()
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(text)
 
 
 class _BoundedYAMLHandler(_FrontmatterYAMLHandler):

--- a/src/apm_cli/utils/yaml_io.py
+++ b/src/apm_cli/utils/yaml_io.py
@@ -19,7 +19,7 @@ import secrets
 from contextlib import suppress
 from io import StringIO
 from pathlib import Path
-from typing import Any
+from typing import Any, NoReturn
 
 import yaml
 from frontmatter.default_handlers import YAMLHandler as _FrontmatterYAMLHandler
@@ -291,19 +291,29 @@ def load_yaml_str(text: str) -> dict[str, Any] | None:
 def _roundtrip_yaml() -> Any:
     """Return a configured ruamel.yaml round-trip parser."""
     from ruamel.yaml import YAML
+    from ruamel.yaml.constructor import ConstructorError
+
+    def reject_python_tag(_constructor: Any, tag_suffix: str, node: Any) -> NoReturn:
+        raise ConstructorError(
+            None,
+            None,
+            f"forbidden Python YAML tag: {tag_suffix}",
+            node.start_mark,
+        )
 
     rt = YAML(typ="rt")
+    rt.Constructor.add_multi_constructor("tag:yaml.org,2002:python/", reject_python_tag)
     rt.preserve_quotes = True
     rt.indent(mapping=2, sequence=4, offset=2)
     return rt
 
 
-def _raise_as_pyyaml_error(exc: Exception) -> None:
+def _raise_as_pyyaml_error(exc: Exception) -> NoReturn:
     """Normalize ruamel parser failures to the yaml.YAMLError family."""
     from ruamel.yaml import YAMLError as RuamelYAMLError
 
     if isinstance(exc, RuamelYAMLError):
-        raise yaml.YAMLError(f"round-trip YAML parse failed: {exc}") from exc
+        raise yaml.YAMLError(f"YAML parse failed: {exc}") from exc
     raise exc
 
 

--- a/src/apm_cli/utils/yaml_io.py
+++ b/src/apm_cli/utils/yaml_io.py
@@ -302,6 +302,8 @@ def _roundtrip_yaml() -> Any:
         )
 
     rt = YAML(typ="rt")
+    # Class-level constructor registration is intentional: every round-trip
+    # YAML instance in this process should reject unsafe Python tags.
     rt.Constructor.add_multi_constructor("tag:yaml.org,2002:python/", reject_python_tag)
     rt.preserve_quotes = True
     rt.indent(mapping=2, sequence=4, offset=2)
@@ -337,7 +339,10 @@ def load_yaml_roundtrip(path: str | Path) -> Any:
 def dump_yaml_roundtrip(data: Any, path: str | Path) -> None:
     """Write ruamel round-trip YAML data with explicit UTF-8 encoding."""
     stream = StringIO()
-    _roundtrip_yaml().dump(data, stream)
+    try:
+        _roundtrip_yaml().dump(data, stream)
+    except Exception as exc:
+        _raise_as_pyyaml_error(exc)
     text = stream.getvalue()
     with open(path, "w", encoding="utf-8") as fh:
         fh.write(text)

--- a/tests/integration/test_manifest_comments_e2e.py
+++ b/tests/integration/test_manifest_comments_e2e.py
@@ -1,0 +1,81 @@
+"""E2E regression test for comment-preserving apm.yml rewrites."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from apm_cli.cli import cli
+from apm_cli.models.apm_package import clear_apm_yml_cache
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.requires_e2e_mode,
+]
+
+_PATCH_UPDATES = "apm_cli.commands._helpers.check_for_updates"
+
+
+@pytest.fixture(autouse=True)
+def _clear_manifest_cache() -> None:
+    """Keep manifest parsing isolated across CLI invocations."""
+    clear_apm_yml_cache()
+    yield
+    clear_apm_yml_cache()
+
+
+def test_install_preserves_manifest_comments_and_formatting(tmp_path, monkeypatch) -> None:
+    """Running real ``apm install`` keeps comments and formatting in apm.yml."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("APM_PROGRESS", "never")
+    manifest = tmp_path / "apm.yml"
+    manifest.write_text(
+        """\
+# project intent: keep this manifest annotated
+name: comment-roundtrip
+version: "1.0.0"
+
+dependencies:
+  # APM dependency notes must survive installs
+  apm:
+    - "owner/existing-skill" # inline package note
+  mcp: []  # compact MCP list stays compact
+targets:
+  # target comment remains attached
+  - copilot
+""",
+        encoding="utf-8",
+    )
+
+    install_result = SimpleNamespace(installed_count=1, diagnostics=None)
+    runner = CliRunner()
+
+    with (
+        patch(_PATCH_UPDATES, return_value=None),
+        patch("apm_cli.commands.install._validate_package_exists", return_value=True),
+        patch("apm_cli.commands.install._install_apm_dependencies", return_value=install_result),
+    ):
+        result = runner.invoke(
+            cli,
+            ["install", "owner/new-skill", "--only=apm", "--no-policy"],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0, result.output
+    rendered = manifest.read_text(encoding="utf-8")
+    parsed = yaml.safe_load(rendered)
+
+    assert parsed["dependencies"]["apm"] == [
+        "owner/existing-skill",
+        "owner/new-skill",
+    ]
+    assert "# project intent: keep this manifest annotated" in rendered
+    assert 'version: "1.0.0"' in rendered
+    assert "  # APM dependency notes must survive installs" in rendered
+    assert '    - "owner/existing-skill" # inline package note' in rendered
+    assert "  mcp: []  # compact MCP list stays compact" in rendered
+    assert "  # target comment remains attached" in rendered

--- a/tests/integration/test_runtime_smoke.py
+++ b/tests/integration/test_runtime_smoke.py
@@ -16,6 +16,7 @@ import pytest
 
 pytestmark = [
     pytest.mark.requires_e2e_mode,
+    pytest.mark.requires_network_integration,
     # Mutates os.environ["HOME"]; must be serialized on a single xdist worker.
     # Requires --dist loadgroup in the xdist invocation (the only
     # scheduler that honors xdist_group); without it the marker is

--- a/tests/integration/test_skill_bundle_live.py
+++ b/tests/integration/test_skill_bundle_live.py
@@ -26,7 +26,10 @@ import yaml
 # Markers and skip gates
 # ---------------------------------------------------------------------------
 
-pytestmark = pytest.mark.live
+pytestmark = [
+    pytest.mark.live,
+    pytest.mark.requires_network_integration,
+]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/commands/test_install_context_and_resolution.py
+++ b/tests/unit/commands/test_install_context_and_resolution.py
@@ -251,7 +251,7 @@ class TestMergePackagesIntoYml:
         data = {"dependencies": {"apm": ["existing/pkg"]}}
         current_deps = data["dependencies"]["apm"]
 
-        with patch("apm_cli.utils.yaml_io.dump_yaml") as mock_dump:
+        with patch("apm_cli.utils.yaml_io.dump_yaml_roundtrip") as mock_dump:
             _merge_packages_into_yml(
                 ["new/pkg"],
                 {},
@@ -273,7 +273,7 @@ class TestMergePackagesIntoYml:
         current_deps = data["dependencies"]["apm"]
         apm_yml_entries = {"owner/repo": {"repo": "owner/repo", "ref": "main"}}
 
-        with patch("apm_cli.utils.yaml_io.dump_yaml"):
+        with patch("apm_cli.utils.yaml_io.dump_yaml_roundtrip"):
             _merge_packages_into_yml(
                 ["owner/repo"],
                 apm_yml_entries,
@@ -292,7 +292,7 @@ class TestMergePackagesIntoYml:
         data = {"dependencies": {"apm": []}}
         current_deps = data["dependencies"]["apm"]
 
-        with patch("apm_cli.utils.yaml_io.dump_yaml", side_effect=Exception("disk full")):
+        with patch("apm_cli.utils.yaml_io.dump_yaml_roundtrip", side_effect=Exception("disk full")):
             with pytest.raises(SystemExit) as exc_info:
                 _merge_packages_into_yml(
                     ["owner/repo"],
@@ -312,7 +312,7 @@ class TestMergePackagesIntoYml:
         data = {"devDependencies": {"apm": []}}
         current_deps = data["devDependencies"]["apm"]
 
-        with patch("apm_cli.utils.yaml_io.dump_yaml"):
+        with patch("apm_cli.utils.yaml_io.dump_yaml_roundtrip"):
             _merge_packages_into_yml(
                 ["owner/repo"],
                 {},
@@ -420,6 +420,48 @@ class TestValidateAndAddPackagesToApmYml:
                         manifest_path=apm_yml,
                     )
         assert validated == []
+
+    def test_manifest_update_preserves_comments(self, tmp_path: Path) -> None:
+        from apm_cli.commands.install import _validate_and_add_packages_to_apm_yml
+
+        apm_yml = tmp_path / "apm.yml"
+        apm_yml.write_text(
+            "# project comment\n"
+            "name: project\n"
+            "# dependency section comment\n"
+            "dependencies: # dependencies inline comment\n"
+            "  # apm list comment\n"
+            "  apm:\n"
+            "    - existing/pkg # existing dependency comment\n",
+            encoding="utf-8",
+        )
+        logger = _make_install_logger()
+        logger.validation_summary.return_value = True
+
+        with patch("apm_cli.commands.install._check_package_conflicts", return_value=set()):
+            with patch("apm_cli.commands.install._resolve_package_references") as mock_resolve:
+                mock_resolve.return_value = (
+                    [("new/pkg", False)],
+                    [],
+                    ["new/pkg"],
+                    {},
+                    {},
+                    False,
+                )
+                validated, _outcome = _validate_and_add_packages_to_apm_yml(
+                    ["new/pkg"],
+                    logger=logger,
+                    manifest_path=apm_yml,
+                )
+
+        text = apm_yml.read_text(encoding="utf-8")
+        assert validated == ["new/pkg"]
+        assert "# project comment" in text
+        assert "# dependency section comment" in text
+        assert "# dependencies inline comment" in text
+        assert "# apm list comment" in text
+        assert "# existing dependency comment" in text
+        assert "new/pkg" in text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/commands/test_install_error_handling.py
+++ b/tests/unit/commands/test_install_error_handling.py
@@ -182,7 +182,7 @@ class TestValidateAndAddPackagesWriteError:
                 ),
             ),
             patch(
-                "apm_cli.utils.yaml_io.dump_yaml",
+                "apm_cli.utils.yaml_io.dump_yaml_roundtrip",
                 side_effect=OSError("write fail"),
             ),
         ):
@@ -213,7 +213,7 @@ class TestValidateAndAddPackagesWriteError:
                     False,
                 ),
             ),
-            patch("apm_cli.utils.yaml_io.dump_yaml", side_effect=OSError("write fail")),
+            patch("apm_cli.utils.yaml_io.dump_yaml_roundtrip", side_effect=OSError("write fail")),
         ):
             with pytest.raises(SystemExit) as exc_info:
                 _validate_and_add_packages_to_apm_yml(

--- a/tests/unit/commands/test_install_phase3.py
+++ b/tests/unit/commands/test_install_phase3.py
@@ -252,7 +252,7 @@ class TestMergePackagesIntoYml:
         data = {"dependencies": {"apm": ["existing/pkg"]}}
         current_deps = data["dependencies"]["apm"]
 
-        with patch("apm_cli.utils.yaml_io.dump_yaml") as mock_dump:
+        with patch("apm_cli.utils.yaml_io.dump_yaml_roundtrip") as mock_dump:
             _merge_packages_into_yml(
                 ["new/pkg"],
                 {},
@@ -274,7 +274,7 @@ class TestMergePackagesIntoYml:
         current_deps = data["dependencies"]["apm"]
         apm_yml_entries = {"owner/repo": {"repo": "owner/repo", "ref": "main"}}
 
-        with patch("apm_cli.utils.yaml_io.dump_yaml"):
+        with patch("apm_cli.utils.yaml_io.dump_yaml_roundtrip"):
             _merge_packages_into_yml(
                 ["owner/repo"],
                 apm_yml_entries,
@@ -293,7 +293,7 @@ class TestMergePackagesIntoYml:
         data = {"dependencies": {"apm": []}}
         current_deps = data["dependencies"]["apm"]
 
-        with patch("apm_cli.utils.yaml_io.dump_yaml", side_effect=Exception("disk full")):
+        with patch("apm_cli.utils.yaml_io.dump_yaml_roundtrip", side_effect=Exception("disk full")):
             with pytest.raises(SystemExit) as exc_info:
                 _merge_packages_into_yml(
                     ["owner/repo"],
@@ -313,7 +313,7 @@ class TestMergePackagesIntoYml:
         data = {"devDependencies": {"apm": []}}
         current_deps = data["devDependencies"]["apm"]
 
-        with patch("apm_cli.utils.yaml_io.dump_yaml"):
+        with patch("apm_cli.utils.yaml_io.dump_yaml_roundtrip"):
             _merge_packages_into_yml(
                 ["owner/repo"],
                 {},

--- a/tests/unit/commands/test_install_phase3w4.py
+++ b/tests/unit/commands/test_install_phase3w4.py
@@ -182,7 +182,7 @@ class TestValidateAndAddPackagesWriteError:
                 ),
             ),
             patch(
-                "apm_cli.utils.yaml_io.dump_yaml",
+                "apm_cli.utils.yaml_io.dump_yaml_roundtrip",
                 side_effect=OSError("write fail"),
             ),
         ):
@@ -213,7 +213,7 @@ class TestValidateAndAddPackagesWriteError:
                     False,
                 ),
             ),
-            patch("apm_cli.utils.yaml_io.dump_yaml", side_effect=OSError("write fail")),
+            patch("apm_cli.utils.yaml_io.dump_yaml_roundtrip", side_effect=OSError("write fail")),
         ):
             with pytest.raises(SystemExit) as exc_info:
                 _validate_and_add_packages_to_apm_yml(

--- a/tests/unit/install/test_package_resolution_persistence.py
+++ b/tests/unit/install/test_package_resolution_persistence.py
@@ -13,7 +13,7 @@ def test_persist_dependency_list_reports_generic_manifest_update():
     data = {"dependencies": {"apm": []}}
     current_deps = ["danielmeppiel/genesis#v0.4.0"]
 
-    with patch("apm_cli.utils.yaml_io.dump_yaml") as dump_yaml:
+    with patch("apm_cli.utils.yaml_io.dump_yaml_roundtrip") as dump_yaml_roundtrip:
         persist_dependency_list_if_changed(
             dependencies_changed=True,
             data=data,
@@ -26,5 +26,5 @@ def test_persist_dependency_list_reports_generic_manifest_update():
             sys_exit=Mock(),
         )
 
-    dump_yaml.assert_called_once_with(data, "apm.yml")
+    dump_yaml_roundtrip.assert_called_once_with(data, "apm.yml")
     logger.success.assert_called_once_with("Updated apm.yml dependency entries")

--- a/tests/unit/test_uninstall_dev_dependencies.py
+++ b/tests/unit/test_uninstall_dev_dependencies.py
@@ -105,3 +105,32 @@ class TestUninstallDevDependencies:
         assert result.exit_code == 0, result.output
         data = _read_apm_yml(tmp_path)
         assert "devDependencies" not in data
+
+    def test_uninstall_preserves_manifest_comments(self, tmp_path: Path, monkeypatch) -> None:
+        """Removing a package must not strip existing apm.yml comments."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "apm.yml").write_text(
+            "# project comment\n"
+            "name: test-project\n"
+            "# dependency section comment\n"
+            "dependencies: # dependencies inline comment\n"
+            "  # apm list comment\n"
+            "  apm:\n"
+            "    - microsoft/apm-sample-package # removed package comment\n"
+            "    - acme/keep-prod # kept package comment\n",
+            encoding="utf-8",
+        )
+
+        from apm_cli.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["uninstall", "microsoft/apm-sample-package"])
+
+        assert result.exit_code == 0, result.output
+        text = (tmp_path / "apm.yml").read_text(encoding="utf-8")
+        assert "# project comment" in text
+        assert "# dependency section comment" in text
+        assert "# dependencies inline comment" in text
+        assert "# apm list comment" in text
+        assert "# kept package comment" in text
+        assert "microsoft/apm-sample-package" not in text

--- a/tests/unit/test_yaml_io.py
+++ b/tests/unit/test_yaml_io.py
@@ -4,11 +4,15 @@ import io
 
 import pytest
 import yaml
+from ruamel.yaml import YAMLError as RuamelYAMLError
 
 from apm_cli.utils.yaml_io import (
+    _roundtrip_yaml,
     dump_yaml,
+    dump_yaml_roundtrip,
     load_frontmatter,
     load_yaml,
+    load_yaml_roundtrip,
     load_yaml_str,
     yaml_to_str,
 )
@@ -208,6 +212,45 @@ class TestLoadYamlStr:
         data = load_yaml_str(doc)
         assert data["use1"] == {"x": 1}
         assert data["use2"] == {"x": 1}
+
+
+class TestLoadYamlRoundtrip:
+    """Tests for comment-preserving YAML round-trip helpers."""
+
+    def test_roundtrip_preserves_comments(self, tmp_path):
+        """A load/mutate/dump cycle preserves existing comments."""
+        p = tmp_path / "apm.yml"
+        p.write_text(
+            "# project note\nname: demo\n# deps note\ndependencies: []\n", encoding="utf-8"
+        )
+
+        data = load_yaml_roundtrip(p)
+        data["dependencies"].append("github:owner/new-skill@v1")
+        dump_yaml_roundtrip(data, p)
+
+        rendered = p.read_text(encoding="utf-8")
+        assert "# project note" in rendered
+        assert "# deps note" in rendered
+        assert "github:owner/new-skill@v1" in rendered
+
+    def test_alias_expansion_bomb_fails_closed(self, tmp_path):
+        """The round-trip path keeps the bounded-loader expansion guard."""
+        p = tmp_path / "apm.yml"
+        lines = ["l0: &l0 [x]"]
+        prev = "l0"
+        for i in range(1, 25):
+            cur = f"l{i}"
+            lines.append(f"{cur}: &{cur} [*{prev}, *{prev}]")
+            prev = cur
+        p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        with pytest.raises(yaml.YAMLError):
+            load_yaml_roundtrip(p)
+
+    def test_roundtrip_parser_rejects_python_tags(self):
+        """The ruamel layer also fails closed on unsafe Python tags."""
+        with pytest.raises(RuamelYAMLError):
+            _roundtrip_yaml().load("x: !!python/name:os.system ''\n")
 
 
 class TestLoadFrontmatter:


### PR DESCRIPTION
Why: apm install and apm uninstall rewrote apm.yml through PyYAML, which dropped user comments during dependency updates. What: route apm.yml manifest update reads and writes through the existing ruamel.yaml dependency in bounded round-trip helpers, preserving comments while keeping the existing YAML safety pre-parse. How to test: uv run --extra dev pytest tests/unit/commands/test_install_context_and_resolution.py::TestValidateAndAddPackagesToApmYml::test_manifest_update_preserves_comments tests/unit/test_uninstall_dev_dependencies.py::TestUninstallDevDependencies::test_uninstall_preserves_manifest_comments -q; uv run --extra dev pytest tests/unit -k "yaml or install or uninstall or manifest" -q; uv run --extra dev ruff check src/ tests/ --quiet; uv run --extra dev ruff format --check src/ tests/ --quiet; uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/. Closes #2000.