### PR TITLE
feat(copilot): support local MCP config in .mcp.json and global via -g flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm install --mcp NAME --target copilot` now writes project-scoped Copilot
+  CLI MCP configuration to `.mcp.json`; use `-g` / `--global` to keep writing
+  `~/.copilot/mcp-config.json`. Stale MCP cleanup now follows the same scope.
 - `apm pack` now produces a `marketplace.json` the Copilot App accepts even
   when your manifest `name` contains dots, underscores, or other non-kebab-case
   characters (e.g. `my.marketplace`): the emitted `name` field is normalized to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `apm install --mcp NAME --target copilot` now writes project-scoped Copilot
   CLI MCP configuration to `.mcp.json`; use `-g` / `--global` to keep writing
-  `~/.copilot/mcp-config.json`. Stale MCP cleanup now follows the same scope.
+  `~/.copilot/mcp-config.json`. Stale MCP cleanup now follows the same scope. (#2015)
 - `apm pack` now produces a `marketplace.json` the Copilot App accepts even
   when your manifest `name` contains dots, underscores, or other non-kebab-case
   characters (e.g. `my.marketplace`): the emitted `name` field is normalized to

--- a/docs/src/content/docs/consumer/install-mcp-servers.md
+++ b/docs/src/content/docs/consumer/install-mcp-servers.md
@@ -100,7 +100,7 @@ for the full required-vs-optional runtime config rule.
 
 | Harness | File | Scope | Format |
 |---|---|---|---|
-| GitHub Copilot CLI | `~/.copilot/mcp-config.json` | global | JSON `mcpServers` |
+| GitHub Copilot CLI | `.mcp.json` (project) or `~/.copilot/mcp-config.json` (`-g`) | both | JSON `mcpServers` |
 | VS Code (Copilot) | `.vscode/mcp.json` | project | JSON `servers` |
 | Claude Code | `.mcp.json` (project) or `~/.claude.json` (`-g`) | both | JSON `mcpServers` |
 | Cursor | `.cursor/mcp.json` | project (only if `.cursor/` exists) | JSON `mcpServers` |
@@ -111,6 +111,12 @@ for the full required-vs-optional runtime config rule.
 | Windsurf | `~/.codeium/windsurf/mcp_config.json` | global | JSON `mcpServers` |
 | Kiro IDE | `.kiro/settings/mcp.json` (project, only if `.kiro/` exists) or `~/.kiro/settings/mcp.json` (`-g`) | both | JSON `mcpServers` |
 | JetBrains Copilot | OS-specific `mcp.json` under the GitHub Copilot user config directory | global | JSON `servers` |
+
+For Copilot CLI project scope, APM writes `.mcp.json` directly with the
+same `mcpServers` key Copilot CLI reads. If you are moving a hand-written
+VS Code MCP file to Copilot CLI, GitHub's migration guidance is to copy
+`.vscode/mcp.json` into `.mcp.json` while remapping the top-level
+`servers` key to `mcpServers`.
 
 ## How `targets:` gates which configs get written
 

--- a/docs/src/content/docs/producer/author-primitives/mcp-as-primitive.md
+++ b/docs/src/content/docs/producer/author-primitives/mcp-as-primitive.md
@@ -31,9 +31,9 @@ materialises them at install time into the harness-specific config
 file (see the per-harness map in
 [Install MCP servers](../../consumer/install-mcp-servers/#what-apm-install-writes-to-disk)).
 
-You declare once. At project scope, APM writes `.vscode/mcp.json`,
-`.cursor/mcp.json`, `.mcp.json` for Claude, `.codex/config.toml`, and the
-rest -- whichever harnesses the consumer has.
+You declare once. At project scope, APM writes `.mcp.json` for Copilot CLI
+and Claude Code, `.vscode/mcp.json` for VS Code, `.cursor/mcp.json`,
+`.codex/config.toml`, and the rest -- whichever harnesses the consumer has.
 
 ## The `mcp:` schema
 

--- a/src/apm_cli/adapters/client/copilot.py
+++ b/src/apm_cli/adapters/client/copilot.py
@@ -1,8 +1,9 @@
 """GitHub Copilot CLI implementation of MCP client adapter.
 
-This adapter implements the Copilot CLI-specific handling of MCP server configuration,
-targeting the global ~/.copilot/mcp-config.json file as specified in the MCP installation
-architecture specification.
+Project scope writes ``.mcp.json`` at the project root using Copilot CLI's
+workspace MCP schema (top-level ``mcpServers``). User scope writes
+``~/.copilot/mcp-config.json``. Both scopes use the same Copilot CLI
+``mcpServers`` entry shape.
 """
 
 import json
@@ -36,9 +37,9 @@ from .base import (
 class CopilotClientAdapter(MCPClientAdapter):
     """Copilot CLI implementation of MCP client adapter.
 
-    This adapter handles Copilot CLI-specific configuration for MCP servers using
-    a global ~/.copilot/mcp-config.json file, following the JSON format for
-    MCP server configuration.
+    Project installs write ``<project_root>/.mcp.json`` so servers are scoped
+    to the repository. User-scope installs (``-g`` / ``--global``) keep the
+    existing Copilot CLI user config path, ``~/.copilot/mcp-config.json``.
     """
 
     supports_user_scope: bool = True
@@ -103,14 +104,22 @@ class CopilotClientAdapter(MCPClientAdapter):
         self.registry_client = SimpleRegistryClient(registry_url)
         self.registry_integration = RegistryIntegration(registry_url)
 
+    def _project_mcp_path(self) -> Path:
+        return self.project_root / ".mcp.json"
+
+    def _user_mcp_path(self) -> Path:
+        return Path.home() / ".copilot" / "mcp-config.json"
+
     def get_config_path(self):
         """Get the path to the Copilot CLI MCP configuration file.
 
         Returns:
-            str: Path to ~/.copilot/mcp-config.json
+            str: Project ``.mcp.json`` by default, or
+            ``~/.copilot/mcp-config.json`` for user scope.
         """
-        copilot_dir = Path.home() / ".copilot"
-        return str(copilot_dir / "mcp-config.json")
+        if self.user_scope:
+            return str(self._user_mcp_path())
+        return str(self._project_mcp_path())
 
     def update_config(self, config_updates):
         """Update the Copilot CLI MCP configuration.

--- a/src/apm_cli/adapters/client/copilot.py
+++ b/src/apm_cli/adapters/client/copilot.py
@@ -142,8 +142,9 @@ class CopilotClientAdapter(MCPClientAdapter):
         # Ensure directory exists
         config_path.parent.mkdir(parents=True, exist_ok=True)
 
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             json.dump(current_config, f, indent=2)
+        os.chmod(config_path, 0o600)
 
     def get_current_config(self):
         """Get the current Copilot CLI MCP configuration.
@@ -157,7 +158,7 @@ class CopilotClientAdapter(MCPClientAdapter):
             return {}
 
         try:
-            with open(config_path) as f:
+            with open(config_path, encoding="utf-8") as f:
                 return json.load(f)
         except (OSError, json.JSONDecodeError):
             return {}

--- a/src/apm_cli/integration/mcp_integrator.py
+++ b/src/apm_cli/integration/mcp_integrator.py
@@ -623,11 +623,22 @@ class MCPIntegrator:
             )
 
         if "copilot" in target_runtimes:
+            from apm_cli.factory import ClientFactory
+
+            copilot_user_scope = user_scope or scope is InstallScope.USER
+            copilot_cfg = Path(
+                ClientFactory.create_client(
+                    "copilot",
+                    project_root=project_root_path,
+                    user_scope=copilot_user_scope,
+                ).get_config_path()
+            )
+            copilot_label = "Copilot CLI user config" if copilot_user_scope else ".mcp.json"
             _clean_json_mcp_config(
-                Path.home() / ".copilot" / "mcp-config.json",
+                copilot_cfg,
                 expanded_stale,
                 logger,
-                "Copilot CLI config",
+                copilot_label,
                 use_rich=True,
             )
 

--- a/tests/integration/test_mcp_env_var_copilot_e2e.py
+++ b/tests/integration/test_mcp_env_var_copilot_e2e.py
@@ -3,7 +3,7 @@ must contain ``${VAR}`` runtime placeholders for env-var references in
 apm.yml -- never the literal value resolved at install time.
 
 This exercises the full pipeline:
-    apm.yml  ->  apm install --target copilot  ->  ~/.copilot/mcp-config.json
+    apm.yml  ->  apm install --target copilot  ->  <project>/.mcp.json
 
 The unit tests in tests/unit/test_copilot_adapter.py cover translation in
 isolation; this test pins the integration boundary so plaintext secrets
@@ -75,9 +75,8 @@ class TestMcpEnvVarHeadersCopilot:
         # copilot/vscode runtime detection chain.
         (project_dir / ".github").mkdir()
 
-        # Isolated HOME so we don't touch the developer's real
-        # ~/.copilot/mcp-config.json. The Copilot adapter uses
-        # ``Path.home() / ".copilot"``.
+        # Isolated HOME so user-scope config is never touched.
+        # Project-scope Copilot writes to project_dir/.mcp.json.
         fake_home = tmp_path / "home"
         fake_home.mkdir()
 
@@ -120,9 +119,9 @@ class TestMcpEnvVarHeadersCopilot:
             f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
         )
 
-        mcp_config = fake_home / ".copilot" / "mcp-config.json"
+        mcp_config = project_dir / ".mcp.json"
         assert mcp_config.exists(), (
-            f"Expected ~/.copilot/mcp-config.json to exist after install.\n"
+            f"Expected .mcp.json to exist after install.\n"
             f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
         )
 
@@ -209,9 +208,9 @@ class TestMcpEnvVarHeadersCopilot:
             f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
         )
 
-        mcp_config = fake_home / ".copilot" / "mcp-config.json"
+        mcp_config = project_dir / ".mcp.json"
         assert mcp_config.exists(), (
-            f"Expected ~/.copilot/mcp-config.json to exist after install.\n"
+            f"Expected .mcp.json to exist after install.\n"
             f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
         )
 

--- a/tests/integration/test_mcp_env_var_copilot_e2e.py
+++ b/tests/integration/test_mcp_env_var_copilot_e2e.py
@@ -1,4 +1,4 @@
-"""End-to-end regression guard for #1152: Copilot CLI's mcp-config.json
+"""End-to-end regression guard for #1152: Copilot CLI's .mcp.json
 must contain ``${VAR}`` runtime placeholders for env-var references in
 apm.yml -- never the literal value resolved at install time.
 
@@ -59,14 +59,14 @@ def _write_apm_yml(project_dir, mcp_servers):
 
 
 class TestMcpEnvVarHeadersCopilot:
-    """#1152 regression: Copilot mcp-config.json must contain ``${VAR}``
+    """#1152 regression: Copilot .mcp.json must contain ``${VAR}``
     runtime placeholders for env-var references in apm.yml. The literal
     values from the installer's environment must NEVER appear on disk.
     """
 
     def test_self_defined_http_server_translates_env_vars_not_resolves(self, tmp_path, apm_command):
         """``${VAR}`` and ``${env:VAR}`` syntaxes in apm.yml headers must
-        land in mcp-config.json as ``${VAR}`` (Copilot CLI's native runtime
+        land in .mcp.json as ``${VAR}`` (Copilot CLI's native runtime
         substitution syntax). No host env values may leak into the file.
         """
         project_dir = tmp_path / "project"
@@ -128,7 +128,7 @@ class TestMcpEnvVarHeadersCopilot:
         config = json.loads(mcp_config.read_text(encoding="utf-8"))
         servers = config.get("mcpServers") or {}
         assert len(servers) == 1, (
-            f"Expected 1 server in mcp-config.json, got: {list(servers.keys())}"
+            f"Expected 1 server in .mcp.json, got: {list(servers.keys())}"
         )
         server = next(iter(servers.values()))
         headers = server.get("headers") or {}
@@ -145,7 +145,7 @@ class TestMcpEnvVarHeadersCopilot:
         # CRITICAL: no plaintext secret may appear anywhere in the file.
         full_text = mcp_config.read_text(encoding="utf-8")
         assert "should-not-appear-in-copilot-json" not in full_text, (
-            "Copilot mcp-config.json leaked the literal env value -- "
+            "Copilot .mcp.json leaked the literal env value -- "
             "the install-time translation regressed and secrets are now "
             "baked to disk.\n"
             f"File contents:\n{full_text}"
@@ -153,7 +153,7 @@ class TestMcpEnvVarHeadersCopilot:
 
     def test_self_defined_stdio_server_translates_env_vars_in_args(self, tmp_path, apm_command):
         """Self-defined stdio server with env-var placeholders in BOTH the
-        ``env`` block and ``args`` list must land in mcp-config.json with
+        ``env`` block and ``args`` list must land in .mcp.json with
         ``${VAR}`` runtime placeholders. Closes the integration-tier gap
         flagged by test-coverage review for the ``_raw_stdio`` branch of
         ``_format_server_config`` and the supply-chain regression where
@@ -217,7 +217,7 @@ class TestMcpEnvVarHeadersCopilot:
         config = json.loads(mcp_config.read_text(encoding="utf-8"))
         servers = config.get("mcpServers") or {}
         assert len(servers) == 1, (
-            f"Expected 1 server in mcp-config.json, got: {list(servers.keys())}"
+            f"Expected 1 server in .mcp.json, got: {list(servers.keys())}"
         )
         server = next(iter(servers.values()))
 

--- a/tests/unit/integration/test_mcp_integrator.py
+++ b/tests/unit/integration/test_mcp_integrator.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 
 import pytest
 
+from apm_cli.core.scope import InstallScope
 from apm_cli.integration.mcp_integrator import MCPIntegrator, _is_vscode_available
 from apm_cli.models.dependency.mcp import MCPDependency
 
@@ -718,25 +719,64 @@ class TestInstallProjectRootDetection:
 
 
 class TestRemoveStaleCopilot:
-    def _write_copilot_mcp(self, home: Path, servers: dict) -> Path:
+    def _write_project_copilot_mcp(self, root: Path, servers: dict) -> Path:
+        root.mkdir(parents=True, exist_ok=True)
+        cfg = root / ".mcp.json"
+        cfg.write_text(json.dumps({"mcpServers": servers}), encoding="utf-8")
+        return cfg
+
+    def _write_user_copilot_mcp(self, home: Path, servers: dict) -> Path:
         copilot_dir = home / ".copilot"
         copilot_dir.mkdir(parents=True, exist_ok=True)
         cfg = copilot_dir / "mcp-config.json"
         cfg.write_text(json.dumps({"mcpServers": servers}), encoding="utf-8")
         return cfg
 
-    def test_removes_stale_from_copilot(self, tmp_path):
-        cfg = self._write_copilot_mcp(tmp_path, {"old": {}, "keep": {}})
+    def test_removes_stale_from_project_copilot_mcp_json(self, tmp_path):
+        cfg = self._write_project_copilot_mcp(tmp_path, {"old": {}, "keep": {}})
 
-        with (
-            patch("apm_cli.integration.mcp_integrator.Path.cwd", return_value=tmp_path),
-            patch("pathlib.Path.home", return_value=tmp_path),
-        ):
-            MCPIntegrator.remove_stale({"old"}, runtime="copilot")
+        MCPIntegrator.remove_stale(
+            {"old"},
+            runtime="copilot",
+            project_root=tmp_path,
+            scope=InstallScope.PROJECT,
+        )
 
         remaining = json.loads(cfg.read_text())
         assert "old" not in remaining["mcpServers"]
         assert "keep" in remaining["mcpServers"]
+
+    def test_removes_stale_from_user_copilot_mcp_config(self, tmp_path):
+        cfg = self._write_user_copilot_mcp(tmp_path, {"old": {}, "keep": {}})
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            MCPIntegrator.remove_stale(
+                {"old"},
+                runtime="copilot",
+                project_root=tmp_path / "project",
+                scope=InstallScope.USER,
+            )
+
+        remaining = json.loads(cfg.read_text())
+        assert "old" not in remaining["mcpServers"]
+        assert "keep" in remaining["mcpServers"]
+
+    def test_project_cleanup_does_not_touch_user_copilot_config(self, tmp_path):
+        project_cfg = self._write_project_copilot_mcp(tmp_path / "project", {"old": {}})
+        user_cfg = self._write_user_copilot_mcp(tmp_path / "home", {"old": {}})
+        user_raw = user_cfg.read_text(encoding="utf-8")
+
+        with patch.object(Path, "home", return_value=tmp_path / "home"):
+            MCPIntegrator.remove_stale(
+                {"old"},
+                runtime="copilot",
+                project_root=tmp_path / "project",
+                scope=InstallScope.PROJECT,
+            )
+
+        project_remaining = json.loads(project_cfg.read_text(encoding="utf-8"))
+        assert "old" not in project_remaining["mcpServers"]
+        assert user_cfg.read_text(encoding="utf-8") == user_raw
 
 
 # ===========================================================================

--- a/tests/unit/test_copilot_adapter.py
+++ b/tests/unit/test_copilot_adapter.py
@@ -5,9 +5,94 @@ import os
 import shutil
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from apm_cli.adapters.client.copilot import CopilotClientAdapter
+
+
+class TestCopilotClientAdapterScope(unittest.TestCase):
+    """Project and user scope path routing for Copilot MCP config."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.home = self.root / "home"
+        self.home_patcher = patch.object(Path, "home", return_value=self.home)
+        self.home_patcher.start()
+        self.registry_patcher = patch("apm_cli.adapters.client.copilot.SimpleRegistryClient")
+        self.registry_patcher.start()
+        self.integration_patcher = patch("apm_cli.adapters.client.copilot.RegistryIntegration")
+        self.integration_patcher.start()
+
+    def tearDown(self) -> None:
+        self.integration_patcher.stop()
+        self.registry_patcher.stop()
+        self.home_patcher.stop()
+        self.tmp.cleanup()
+
+    def test_project_scope_config_path_uses_project_mcp_json(self) -> None:
+        adapter = CopilotClientAdapter(project_root=self.root)
+
+        self.assertEqual(Path(adapter.get_config_path()), self.root / ".mcp.json")
+
+    def test_user_scope_config_path_uses_copilot_user_config(self) -> None:
+        adapter = CopilotClientAdapter(project_root=self.root, user_scope=True)
+
+        self.assertEqual(
+            Path(adapter.get_config_path()),
+            self.home / ".copilot" / "mcp-config.json",
+        )
+
+    def test_project_get_current_config_reads_project_mcp_json(self) -> None:
+        expected = {"mcpServers": {"project": {"command": "python"}}}
+        (self.root / ".mcp.json").write_text(json.dumps(expected), encoding="utf-8")
+        adapter = CopilotClientAdapter(project_root=self.root)
+
+        self.assertEqual(adapter.get_current_config(), expected)
+
+    def test_user_get_current_config_reads_copilot_user_config(self) -> None:
+        expected = {"mcpServers": {"user": {"command": "node"}}}
+        user_path = self.home / ".copilot" / "mcp-config.json"
+        user_path.parent.mkdir(parents=True)
+        user_path.write_text(json.dumps(expected), encoding="utf-8")
+        adapter = CopilotClientAdapter(project_root=self.root, user_scope=True)
+
+        self.assertEqual(adapter.get_current_config(), expected)
+
+    def test_project_update_config_creates_project_mcp_json(self) -> None:
+        adapter = CopilotClientAdapter(project_root=self.root)
+
+        adapter.update_config({"srv": {"command": "node", "args": ["server.js"]}})
+
+        mcp_path = self.root / ".mcp.json"
+        self.assertTrue(mcp_path.exists())
+        data = json.loads(mcp_path.read_text(encoding="utf-8"))
+        self.assertEqual(data["mcpServers"]["srv"]["command"], "node")
+
+    def test_project_update_config_preserves_existing_servers(self) -> None:
+        mcp_path = self.root / ".mcp.json"
+        mcp_path.write_text(
+            json.dumps({"mcpServers": {"keep": {"command": "python"}}}),
+            encoding="utf-8",
+        )
+        adapter = CopilotClientAdapter(project_root=self.root)
+
+        adapter.update_config({"new": {"command": "node"}})
+
+        data = json.loads(mcp_path.read_text(encoding="utf-8"))
+        self.assertIn("keep", data["mcpServers"])
+        self.assertIn("new", data["mcpServers"])
+
+    def test_user_update_config_keeps_existing_user_path_behavior(self) -> None:
+        adapter = CopilotClientAdapter(project_root=self.root, user_scope=True)
+
+        adapter.update_config({"srv": {"command": "node"}})
+
+        user_path = self.home / ".copilot" / "mcp-config.json"
+        self.assertTrue(user_path.exists())
+        data = json.loads(user_path.read_text(encoding="utf-8"))
+        self.assertIn("srv", data["mcpServers"])
 
 
 class TestCopilotRemoteTransportValidation(unittest.TestCase):

--- a/tests/unit/test_copilot_adapter_compatibility.py
+++ b/tests/unit/test_copilot_adapter_compatibility.py
@@ -27,6 +27,7 @@ import json
 import os
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 from apm_cli.adapters.client.copilot import (
@@ -100,11 +101,20 @@ class TestModuleLevelHelpers(unittest.TestCase):
 
 
 class TestGetConfigPath(unittest.TestCase):
-    def test_returns_path_under_home_copilot(self) -> None:
-        adapter = _make_adapter()
-        config_path = adapter.get_config_path()
-        self.assertIn(".copilot", config_path)
-        self.assertTrue(config_path.endswith("mcp-config.json"))
+    def test_project_scope_returns_project_mcp_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            adapter = _make_adapter(project_root=tmp)
+            config_path = Path(adapter.get_config_path())
+
+        self.assertEqual(config_path, Path(tmp) / ".mcp.json")
+
+    def test_user_scope_returns_home_copilot_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            adapter = _make_adapter(project_root=tmp, user_scope=True)
+            with patch.object(Path, "home", return_value=Path(tmp) / "home"):
+                config_path = Path(adapter.get_config_path())
+
+        self.assertEqual(config_path, Path(tmp) / "home" / ".copilot" / "mcp-config.json")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_copilot_adapter_phase3.py
+++ b/tests/unit/test_copilot_adapter_phase3.py
@@ -27,6 +27,7 @@ import json
 import os
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 from apm_cli.adapters.client.copilot import (
@@ -100,11 +101,20 @@ class TestModuleLevelHelpers(unittest.TestCase):
 
 
 class TestGetConfigPath(unittest.TestCase):
-    def test_returns_path_under_home_copilot(self) -> None:
-        adapter = _make_adapter()
-        config_path = adapter.get_config_path()
-        self.assertIn(".copilot", config_path)
-        self.assertTrue(config_path.endswith("mcp-config.json"))
+    def test_project_scope_returns_project_mcp_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            adapter = _make_adapter(project_root=tmp)
+            config_path = Path(adapter.get_config_path())
+
+        self.assertEqual(config_path, Path(tmp) / ".mcp.json")
+
+    def test_user_scope_returns_home_copilot_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            adapter = _make_adapter(project_root=tmp, user_scope=True)
+            with patch.object(Path, "home", return_value=Path(tmp) / "home"):
+                config_path = Path(adapter.get_config_path())
+
+        self.assertEqual(config_path, Path(tmp) / "home" / ".copilot" / "mcp-config.json")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
feat(copilot): support local MCP config in .mcp.json and global via -g flag

## TL;DR

This PR resolves outdated MCP configuration handling for GitHub Copilot by aligning with the official migration guide. It introduces support for project-local `.mcp.json` configurations and scopes the previous default to a global context accessible via the `-g` flag.

## Problem (WHY)

- The GitHub Copilot CLI adapter did not support the newly recommended `.mcp.json` local configuration file.
- We must provide deterministic behavior across environments. As noted in Agent Skills: ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/).
- Configuration needed to correctly separate project-local settings from user-global settings.

## Approach (WHAT)

- Update `CopilotClientAdapter` path resolution to return `.mcp.json` for the project scope and `~/.copilot/mcp-config.json` for the user scope.
- Propagate the scope (`InstallScope.PROJECT` vs `InstallScope.USER`) through the `MCPIntegrator`.
- Update relevant docs and add test coverage for path resolution.

## Implementation (HOW)

| File | Change |
| --- | --- |
| `src/apm_cli/adapters/client/copilot.py` | Overhauled configuration pathing based on `user_scope` boolean flag. |
| `src/apm_cli/integration/mcp_integrator.py` | Added scope propagation. |
| `CHANGELOG.md` & `docs/**/*.md` | Documented the new `-g` flag and local `.mcp.json` standard. |
| `tests/**/*.py` | Validated that both scopes return correct paths and do not overwrite each other. |

## Diagrams

The updated configuration resolution path:

```mermaid
flowchart LR
    A["CopilotClientAdapter"] -->|Project Scope| B[".mcp.json"]
    A -->|User Scope (-g)| C["~/.copilot/mcp-config.json"]
```

## Trade-offs

- **Breaking Change for Default Behavior**: Users who relied on the previous behavior for global configuration must now explicitly pass the `-g` flag if they are outside a project directory. 

## Benefits

1. Enables native, standard-compliant project-level MCP configurations.
2. Directly aligns with the VS Code `mcp.json` migration guide.
3. Cleanly separates workspace config from user config, preventing accidental bleed.

## Validation

<details><summary>Test Output</summary>

```
============================= test session starts =============================
platform win32 -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
collected 378 items

tests\unit\test_copilot_adapter.py ..................................... [  9%]
..................                                                       [ 14%]
tests\unit\test_copilot_adapter_compatibility.py ....................... [ 20%]
........................................................................ [ 39%]
.................                                                        [ 44%]
tests\unit\test_copilot_adapter_phase3.py .............................. [ 52%]
........................................................................ [ 71%]
..........                                                               [ 73%]
tests\unit\integration\test_mcp_integrator.py .......................... [ 80%]
........................................................................ [ 99%]
.                                                                        [100%]

============================ 378 passed in 15.91s =============================
```

</details>

## How to test

- [ ] Run `apm install` within a project directory and verify `.mcp.json` is updated.
- [ ] Run `apm install -g` outside a project directory and verify `~/.copilot/mcp-config.json` is updated.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
