### PR TITLE
Fix duplicate H1 in generated CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   named target instead of only the last suffix target, so one deprecated
   filename-routed manifest can still reach both Claude Code and Codex during the
   migration window. (by @garyj) (#2021)
+- Generated `CLAUDE.md` now uses a single H1 title with nested H2/H3 sections,
+  fixing duplicate top-level headings in Claude Code. (#2014)
 - `apm audit --ci` no longer reports phantom drift for root-local hook files
   when audit replay writes into a scratch project root. (#1980)
 - Self-defined stdio MCP env placeholders now resolve from the install process

--- a/src/apm_cli/compilation/claude_formatter.py
+++ b/src/apm_cli/compilation/claude_formatter.py
@@ -302,7 +302,7 @@ class ClaudeFormatter:
 
         # Dependencies section (only for root CLAUDE.md)
         if placement.dependencies:
-            sections.append("# Dependencies")
+            sections.append("## Dependencies")
             for dep in placement.dependencies:
                 sections.append(dep)
             sections.append("")
@@ -311,7 +311,7 @@ class ClaudeFormatter:
         if placement.is_root:
             constitution = read_constitution(self.source_dir)
             if constitution:
-                sections.append("# Constitution")
+                sections.append("## Constitution")
                 sections.append("")
                 sections.append(constitution.strip())
                 sections.append("")

--- a/src/apm_cli/compilation/claude_formatter.py
+++ b/src/apm_cli/compilation/claude_formatter.py
@@ -329,6 +329,7 @@ class ClaudeFormatter:
                     placement.instructions,
                     placement.source_attribution,
                     self.source_dir,
+                    section_heading_prefix="###",
                 )
             )
 

--- a/src/apm_cli/compilation/claude_formatter.py
+++ b/src/apm_cli/compilation/claude_formatter.py
@@ -321,7 +321,7 @@ class ClaudeFormatter:
         # `apm install`, since Claude Code reads both locations and would see
         # duplicate content.
         if placement.instructions and not skip_instructions:
-            sections.append("# Project Standards")
+            sections.append("## Project Standards")
             sections.append("")
 
             sections.extend(

--- a/src/apm_cli/compilation/template_builder.py
+++ b/src/apm_cli/compilation/template_builder.py
@@ -25,14 +25,15 @@ def render_instructions_block(
     *,
     base_dir: Path,
     emit_instruction: Callable[[Instruction], list[str]],
-    global_heading: str = GLOBAL_INSTRUCTIONS_HEADING,
+    section_heading_prefix: str = "##",
+    global_heading: str | None = None,
 ) -> list[str]:
     """Render the body lines of an instructions section.
 
     Renders global instructions (those with no ``applyTo`` pattern) under a
     single ``global_heading`` block, then renders pattern-scoped instructions
-    grouped under ``## Files matching `<pattern>``` headings (sorted by
-    pattern). Within each group, instructions are sorted by file path
+    grouped under ``{section_heading_prefix} Files matching `<pattern>```
+    headings (sorted by pattern). Within each group, instructions are sorted by file path
     relative to ``base_dir`` for deterministic output.
 
     The caller controls per-instruction emission via ``emit_instruction`` so
@@ -45,7 +46,11 @@ def render_instructions_block(
             instruction. Typically the source-attribution comment, the
             instruction body, and a trailing blank line. Empty-content
             instructions are filtered out before this is invoked.
-        global_heading: Heading line for the global section.
+        section_heading_prefix: Markdown heading prefix used for instruction
+            groups. The default keeps AGENTS.md groups at H2; callers that
+            wrap instructions under an H2 parent can pass ``"###"``.
+        global_heading: Optional explicit heading line for global instructions.
+            When omitted, the heading is derived from ``section_heading_prefix``.
 
     Returns:
         Lines that the caller will join. Empty list when ``instructions`` is
@@ -55,6 +60,7 @@ def render_instructions_block(
         return []
 
     sections: list[str] = []
+    global_heading = global_heading or f"{section_heading_prefix} Global Instructions"
 
     def _sort_key(inst: Instruction) -> str:
         return portable_relpath(inst.file_path, base_dir)
@@ -75,7 +81,7 @@ def render_instructions_block(
                 sections.extend(emit_instruction(instruction))
 
     for pattern, pattern_instructions in sorted(pattern_groups.items()):
-        sections.append(f"## Files matching `{pattern}`")
+        sections.append(f"{section_heading_prefix} Files matching `{pattern}`")
         sections.append("")
         for instruction in sorted(pattern_instructions, key=_sort_key):
             if instruction.content.strip():
@@ -88,6 +94,8 @@ def build_attributed_instructions(
     instructions: list[Instruction],
     source_attribution: dict | None,
     base_dir: Path,
+    *,
+    section_heading_prefix: str = "##",
 ) -> list[str]:
     """Render an instructions block with optional source-attribution comments.
 
@@ -102,6 +110,8 @@ def build_attributed_instructions(
             When provided, each instruction is prefixed with a
             ``<!-- Source: <label> <rel_path> -->`` comment.
         base_dir: Directory used as anchor for stable sort keys.
+        section_heading_prefix: Markdown heading prefix used for instruction
+            groups.
 
     Returns:
         Lines ready to be joined or extended into a parent ``sections`` list.
@@ -121,6 +131,7 @@ def build_attributed_instructions(
         instructions,
         base_dir=base_dir,
         emit_instruction=_emit,
+        section_heading_prefix=section_heading_prefix,
     )
 
 

--- a/tests/integration/test_compile_claude_single_h1.py
+++ b/tests/integration/test_compile_claude_single_h1.py
@@ -1,0 +1,42 @@
+"""Regression coverage for CLAUDE.md heading structure."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from apm_cli.cli import cli
+
+
+def _h1_lines(path: Path) -> list[str]:
+    return [line for line in path.read_text(encoding="utf-8").splitlines() if line.startswith("# ")]
+
+
+def test_compile_claude_project_standards_is_not_duplicate_h1(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CLAUDE.md keeps Project Standards below the file title."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "apm.yml").write_text(
+        "name: single-h1-repro\nversion: 1.0.0\ntargets:\n  - claude\n  - codex\n",
+        encoding="utf-8",
+    )
+
+    instructions_dir = tmp_path / ".apm" / "instructions"
+    instructions_dir.mkdir(parents=True)
+    (instructions_dir / "style.instructions.md").write_text(
+        "---\ndescription: Style rule\napplyTo: '**/*.py'\n---\nUse type hints for Python code.\n",
+        encoding="utf-8",
+    )
+
+    result = CliRunner().invoke(cli, ["compile", "--no-links"], catch_exceptions=False)
+
+    assert result.exit_code == 0, result.output
+    assert _h1_lines(tmp_path / "CLAUDE.md") == ["# CLAUDE.md"]
+    assert _h1_lines(tmp_path / "AGENTS.md") == ["# AGENTS.md"]
+
+    claude_lines = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8").splitlines()
+    assert "## Project Standards" in claude_lines
+    assert "# Project Standards" not in claude_lines

--- a/tests/integration/test_compile_claude_single_h1.py
+++ b/tests/integration/test_compile_claude_single_h1.py
@@ -52,6 +52,8 @@ def test_compile_claude_project_standards_is_not_duplicate_h1(
     assert "## Dependencies" in claude_lines
     assert "## Constitution" in claude_lines
     assert "## Project Standards" in claude_lines
+    assert "### Files matching `**/*.py`" in claude_lines
     assert "# Dependencies" not in claude_lines
     assert "# Constitution" not in claude_lines
     assert "# Project Standards" not in claude_lines
+    assert "## Files matching `**/*.py`" not in claude_lines

--- a/tests/integration/test_compile_claude_single_h1.py
+++ b/tests/integration/test_compile_claude_single_h1.py
@@ -31,6 +31,17 @@ def test_compile_claude_project_standards_is_not_duplicate_h1(
         encoding="utf-8",
     )
 
+    memory_dir = tmp_path / ".specify" / "memory"
+    memory_dir.mkdir(parents=True)
+    (memory_dir / "constitution.md").write_text(
+        "Be helpful and accurate.\n",
+        encoding="utf-8",
+    )
+
+    dep_dir = tmp_path / "apm_modules" / "owner" / "package"
+    dep_dir.mkdir(parents=True)
+    (dep_dir / "CLAUDE.md").write_text("# dep\n", encoding="utf-8")
+
     result = CliRunner().invoke(cli, ["compile", "--no-links"], catch_exceptions=False)
 
     assert result.exit_code == 0, result.output
@@ -38,5 +49,9 @@ def test_compile_claude_project_standards_is_not_duplicate_h1(
     assert _h1_lines(tmp_path / "AGENTS.md") == ["# AGENTS.md"]
 
     claude_lines = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8").splitlines()
+    assert "## Dependencies" in claude_lines
+    assert "## Constitution" in claude_lines
     assert "## Project Standards" in claude_lines
+    assert "# Dependencies" not in claude_lines
+    assert "# Constitution" not in claude_lines
     assert "# Project Standards" not in claude_lines

--- a/tests/integration/test_install_compile_claude_dedup_e2e.py
+++ b/tests/integration/test_install_compile_claude_dedup_e2e.py
@@ -120,7 +120,7 @@ def test_install_then_compile_skips_duplicated_instructions(project_with_instruc
         # The PR's contract: when .claude/rules/ is populated, the
         # "Project Standards" instructions section is omitted from
         # CLAUDE.md to keep Claude's context window lean.
-        assert "# Project Standards" not in body, (
+        assert "Project Standards" not in body, (
             "CLAUDE.md must NOT carry the duplicated instructions "
             "section after install populated .claude/rules/. "
             "Body was:\n" + body
@@ -188,7 +188,7 @@ def test_compile_alone_then_compile_again_skips_on_second_run(project_with_instr
     claude_md = proj / "CLAUDE.md"
     if claude_md.exists():
         body = claude_md.read_text(encoding="utf-8")
-        assert "# Project Standards" not in body, (
+        assert "Project Standards" not in body, (
             "Second compile must dedup against its own previously-emitted "
             ".claude/rules/ files. Body was:\n" + body
         )

--- a/tests/unit/compilation/test_agents_compiler_coverage.py
+++ b/tests/unit/compilation/test_agents_compiler_coverage.py
@@ -708,7 +708,7 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         self.assertTrue(result.success)
         claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
         self.assertTrue(claude_md.exists())
-        self.assertIn("# Project Standards", claude_md.read_text())
+        self.assertIn("## Project Standards", claude_md.read_text())
 
     def test_instructions_skipped_with_populated_rules_dir(self):
         """With .claude/rules/ containing .md files, instructions are skipped."""
@@ -738,7 +738,7 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
         self.assertTrue(claude_md.exists())
         content = claude_md.read_text()
-        self.assertIn("# Project Standards", content)
+        self.assertIn("## Project Standards", content)
 
     def test_instructions_not_skipped_with_non_md_files_in_rules_dir(self):
         """Non-.md files in .claude/rules/ do not trigger instruction skipping."""
@@ -755,7 +755,7 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
         self.assertTrue(claude_md.exists())
         content = claude_md.read_text()
-        self.assertIn("# Project Standards", content)
+        self.assertIn("## Project Standards", content)
 
     def test_skip_instructions_dry_run(self):
         """Dry-run respects skip_instructions when .claude/rules/ is populated."""
@@ -840,7 +840,7 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
             # Instructions should NOT be skipped (symlink escapes project root)
             claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
             self.assertTrue(claude_md.exists())
-            self.assertIn("# Project Standards", claude_md.read_text())
+            self.assertIn("## Project Standards", claude_md.read_text())
         finally:
             shutil.rmtree(external_dir, ignore_errors=True)
 

--- a/tests/unit/compilation/test_claude_formatter.py
+++ b/tests/unit/compilation/test_claude_formatter.py
@@ -65,7 +65,7 @@ class TestFormatDistributed:
     def temp_project(self):
         """Create a temporary project directory."""
         temp_dir = tempfile.mkdtemp()
-        yield Path(temp_dir)
+        yield Path(temp_dir).resolve()
         shutil.rmtree(temp_dir, ignore_errors=True)
 
     @pytest.fixture
@@ -136,8 +136,8 @@ class TestFormatDistributed:
         content = result.content_map[temp_project / "CLAUDE.md"]
 
         # Check pattern grouping
-        assert "## Files matching `**/*.py`" in content
-        assert "## Files matching `**/*.js`" in content
+        assert "### Files matching `**/*.py`" in content
+        assert "### Files matching `**/*.js`" in content
         assert "Use type hints and follow PEP 8." in content
         assert "Use ES6+ features." in content
 
@@ -190,6 +190,8 @@ class TestFormatDistributed:
         assert "## Dependencies" in lines
         assert "## Constitution" in lines
         assert "## Project Standards" in lines
+        assert "### Files matching `**/*.py`" in lines
+        assert "## Files matching `**/*.py`" not in lines
 
     def test_format_includes_source_attribution(self, temp_project, sample_primitives):
         """Test that source attribution comments are included."""

--- a/tests/unit/compilation/test_claude_formatter.py
+++ b/tests/unit/compilation/test_claude_formatter.py
@@ -164,6 +164,33 @@ class TestFormatDistributed:
         assert "## Project Standards" in content.splitlines()
         assert "# Project Standards" not in content.splitlines()
 
+    def test_generated_claude_sections_keep_single_h1(self, temp_project, sample_primitives):
+        """Generated CLAUDE.md section headings must stay below the file title."""
+        from apm_cli.compilation.constitution import clear_constitution_cache
+
+        memory_dir = temp_project / ".specify" / "memory"
+        memory_dir.mkdir(parents=True)
+        (memory_dir / "constitution.md").write_text("Be helpful and accurate.")
+
+        dep_dir = temp_project / "apm_modules" / "owner" / "package"
+        dep_dir.mkdir(parents=True)
+        (dep_dir / "CLAUDE.md").write_text("# dep")
+
+        clear_constitution_cache()
+        formatter = ClaudeFormatter(str(temp_project))
+
+        placement_map = {temp_project: list(sample_primitives.instructions)}
+        result = formatter.format_distributed(sample_primitives, placement_map)
+
+        content = result.content_map[temp_project / "CLAUDE.md"]
+        lines = content.splitlines()
+        h1_lines = [line for line in lines if line.startswith("# ")]
+
+        assert h1_lines == ["# CLAUDE.md"]
+        assert "## Dependencies" in lines
+        assert "## Constitution" in lines
+        assert "## Project Standards" in lines
+
     def test_format_includes_source_attribution(self, temp_project, sample_primitives):
         """Test that source attribution comments are included."""
         formatter = ClaudeFormatter(str(temp_project))
@@ -213,7 +240,7 @@ class TestFormatDistributed:
         """Test formatting with constitution file."""
         # Create constitution file
         constitution_file = temp_project / "CONSTITUTION.md"
-        constitution_file.write_text("# Constitution\n\nBe helpful and accurate.")
+        constitution_file.write_text("Be helpful and accurate.")
 
         formatter = ClaudeFormatter(str(temp_project))
         primitives = PrimitiveCollection()
@@ -224,7 +251,7 @@ class TestFormatDistributed:
         assert result.success
         if result.content_map:
             content = list(result.content_map.values())[0]  # noqa: RUF015
-            assert "# Constitution" in content
+            assert "## Constitution" in content.splitlines()
             assert "Be helpful and accurate." in content
 
 
@@ -283,7 +310,7 @@ class TestDependenciesImportSyntax:
         # Check @import syntax
         assert "@apm_modules/owner1/package1/CLAUDE.md" in content
         assert "@apm_modules/owner2/package2/CLAUDE.md" in content
-        assert "# Dependencies" in content
+        assert "## Dependencies" in content.splitlines()
 
     def test_dependencies_are_sorted(self, temp_project_with_deps):
         """Test that dependencies are sorted alphabetically."""
@@ -591,7 +618,7 @@ class TestSkipInstructions:
         assert result.success
         assert len(result.content_map) == 1
         content = result.content_map[temp_project / "CLAUDE.md"]
-        assert "# Constitution" in content
+        assert "## Constitution" in content.splitlines()
         assert "Always be helpful." in content
         assert "Project Standards" not in content
 
@@ -611,7 +638,7 @@ class TestSkipInstructions:
         assert result.success
         assert len(result.content_map) == 1
         content = result.content_map[temp_project / "CLAUDE.md"]
-        assert "# Dependencies" in content
+        assert "## Dependencies" in content.splitlines()
         assert "@apm_modules/owner/package/CLAUDE.md" in content
         assert "Project Standards" not in content
 
@@ -674,5 +701,5 @@ class TestSkipInstructions:
         assert len(result.placements) == 1
         assert result.placements[0].is_root is True
         content = next(iter(result.content_map.values()))
-        assert "# Dependencies" in content
+        assert "## Dependencies" in content.splitlines()
         assert "Project Standards" not in content

--- a/tests/unit/compilation/test_claude_formatter.py
+++ b/tests/unit/compilation/test_claude_formatter.py
@@ -149,7 +149,20 @@ class TestFormatDistributed:
         result = formatter.format_distributed(sample_primitives, placement_map)
 
         content = result.content_map[temp_project / "CLAUDE.md"]
-        assert "# Project Standards" in content
+        assert "## Project Standards" in content
+
+    def test_project_standards_is_not_second_h1(self, temp_project, sample_primitives):
+        """Project Standards must sit below the CLAUDE.md title."""
+        formatter = ClaudeFormatter(str(temp_project))
+
+        placement_map = {temp_project: list(sample_primitives.instructions)}
+        result = formatter.format_distributed(sample_primitives, placement_map)
+
+        content = result.content_map[temp_project / "CLAUDE.md"]
+        h1_lines = [line for line in content.splitlines() if line.startswith("# ")]
+        assert h1_lines == ["# CLAUDE.md"]
+        assert "## Project Standards" in content.splitlines()
+        assert "# Project Standards" not in content.splitlines()
 
     def test_format_includes_source_attribution(self, temp_project, sample_primitives):
         """Test that source attribution comments are included."""
@@ -580,7 +593,7 @@ class TestSkipInstructions:
         content = result.content_map[temp_project / "CLAUDE.md"]
         assert "# Constitution" in content
         assert "Always be helpful." in content
-        assert "# Project Standards" not in content
+        assert "Project Standards" not in content
 
     def test_skip_instructions_preserves_dependencies(self, temp_project, sample_primitives):
         """When skip_instructions is True, dependencies are still included."""
@@ -600,7 +613,7 @@ class TestSkipInstructions:
         content = result.content_map[temp_project / "CLAUDE.md"]
         assert "# Dependencies" in content
         assert "@apm_modules/owner/package/CLAUDE.md" in content
-        assert "# Project Standards" not in content
+        assert "Project Standards" not in content
 
     def test_skip_instructions_omits_subdirectory_files(self, temp_project, sample_primitives):
         """When skip_instructions is True, subdirectory CLAUDE.md files are not generated."""
@@ -639,7 +652,7 @@ class TestSkipInstructions:
         assert result.success
         assert len(result.content_map) == 1
         content = result.content_map[temp_project / "CLAUDE.md"]
-        assert "# Project Standards" in content
+        assert "## Project Standards" in content
         assert "Use type hints and follow PEP 8." in content
 
     def test_is_root_flag_used_for_skip_filtering(self, temp_project, sample_primitives):
@@ -662,4 +675,4 @@ class TestSkipInstructions:
         assert result.placements[0].is_root is True
         content = next(iter(result.content_map.values()))
         assert "# Dependencies" in content
-        assert "# Project Standards" not in content
+        assert "Project Standards" not in content

--- a/tests/unit/compilation/test_compile_no_dedup_flag.py
+++ b/tests/unit/compilation/test_compile_no_dedup_flag.py
@@ -126,11 +126,11 @@ class TestNoDedupSkipsDeduplicationLogic:
             config={"skip_instructions": True},
         )
         for content in result.content_map.values():
-            assert "# Project Standards" not in content
+            assert "Project Standards" not in content
 
     def test_with_no_dedup_instructions_are_included(self, project_with_rules):
         """When no_dedup=True the compiler forces skip_instructions=False even
-        when .claude/rules/ is populated, so '# Project Standards' appears in
+        when .claude/rules/ is populated, so Project Standards appears in
         CLAUDE.md."""
         tmp_path, primitives = project_with_rules
 
@@ -160,7 +160,7 @@ class TestNoDedupSkipsDeduplicationLogic:
             "CLAUDE.md must be created even with .claude/rules/ populated when no_dedup=True"
         )
         body = claude_md.read_text(encoding="utf-8")
-        assert "# Project Standards" in body, (
+        assert "## Project Standards" in body, (
             "With no_dedup=True, instructions section must be present in CLAUDE.md "
             "even when .claude/rules/ is pre-populated. Got:\n" + body
         )

--- a/tests/unit/compilation/test_global_instructions_1072.py
+++ b/tests/unit/compilation/test_global_instructions_1072.py
@@ -348,8 +348,8 @@ class TestClaudeFormatterIncludesGlobals:
         content = result.content_map[claude_path]
         assert "GLOBAL_BODY" in content
         assert "SCOPED_BODY" in content
-        # Project Standards top-level header still present, with global heading nested.
-        assert "# Project Standards" in content
+        # Project Standards groups Claude instructions below the CLAUDE.md title.
+        assert "## Project Standards" in content
         assert GLOBAL_INSTRUCTIONS_HEADING in content
         assert content.index("GLOBAL_BODY") < content.index("SCOPED_BODY")
 

--- a/tests/unit/compilation/test_global_instructions_1072.py
+++ b/tests/unit/compilation/test_global_instructions_1072.py
@@ -350,7 +350,7 @@ class TestClaudeFormatterIncludesGlobals:
         assert "SCOPED_BODY" in content
         # Project Standards groups Claude instructions below the CLAUDE.md title.
         assert "## Project Standards" in content
-        assert GLOBAL_INSTRUCTIONS_HEADING in content
+        assert "### Global Instructions" in content
         assert content.index("GLOBAL_BODY") < content.index("SCOPED_BODY")
 
     def test_only_globals_emits_general_section_only(self, tmp_path):
@@ -364,7 +364,7 @@ class TestClaudeFormatterIncludesGlobals:
         content = result.content_map[tmp_path / "CLAUDE.md"]
 
         assert "ONLY" in content
-        assert GLOBAL_INSTRUCTIONS_HEADING in content
+        assert "### Global Instructions" in content
         assert "## Files matching" not in content
 
 

--- a/tests/unit/compilation/test_stale_claude_md_cleanup_1729.py
+++ b/tests/unit/compilation/test_stale_claude_md_cleanup_1729.py
@@ -490,7 +490,7 @@ class TestNoDedupPreventsRemoval:
             "--no-dedup must produce a CLAUDE.md; stale-removal must not fire"
         )
         body = (tmp_path / "CLAUDE.md").read_text(encoding="utf-8")
-        assert "# Project Standards" in body or "global guidance" in body.lower(), (
+        assert "## Project Standards" in body or "global guidance" in body.lower(), (
             "--no-dedup CLAUDE.md must contain instruction content"
         )
 


### PR DESCRIPTION
## Summary
- Demote generated Claude `Dependencies`, `Constitution`, and `Project Standards` section headings from H1 to H2 so APM-generated `CLAUDE.md` keeps `# CLAUDE.md` as the only top-level heading.
- Extend the CLI regression to cover dependencies + constitution + instructions in the same generated `CLAUDE.md`.
- Tighten existing Claude formatter assertions so tests check exact heading levels instead of substring matches.

Closes #2014

## Local validation
- Shepherd follow-up: instruction groups now render as H3 under `## Project Standards`; mutation-break gate reverted the Dependencies demotion and `tests/integration/test_compile_claude_single_h1.py` failed as expected, then passed after restore.
- Reproduced before the patch with a temporary `apm compile --no-links` project: `CLAUDE_H1=# CLAUDE.md | # Project Standards`, `AGENTS_H1=# AGENTS.md`.
- Rechecked after the original patch: `CLAUDE_H1=# CLAUDE.md`, `CLAUDE_HEADINGS=# CLAUDE.md | ## Project Standards | ### Files matching **/*.py`, `AGENTS_H1=# AGENTS.md`.
- Follow-up smoke with instructions + dependency import + constitution: `CLAUDE_H1=# CLAUDE.md`, `CLAUDE_H2=## Dependencies | ## Constitution | ## Project Standards`, `CLAUDE_H3=### Files matching **`, `AGENTS_H1=# AGENTS.md`.
- `uv run --extra dev pytest tests/unit/compilation/test_claude_formatter.py tests/integration/test_compile_claude_single_h1.py tests/unit/compilation/test_compile_no_dedup_flag.py tests/unit/compilation/test_global_instructions_1072.py tests/unit/compilation/test_agents_compiler_coverage.py tests/unit/compilation/test_stale_claude_md_cleanup_1729.py tests/integration/test_install_compile_claude_dedup_e2e.py -q` -> 136 passed, 1 skipped; one Windows subprocess reader GBK warning, no test failures.
- `uv run --extra dev ruff check src/apm_cli/compilation/claude_formatter.py tests/unit/compilation/test_claude_formatter.py tests/integration/test_compile_claude_single_h1.py` -> passed.
- `uv run --extra dev ruff format --check src/apm_cli/compilation/claude_formatter.py tests/unit/compilation/test_claude_formatter.py tests/integration/test_compile_claude_single_h1.py` -> passed.
- `git diff --check` -> passed.