### PR TITLE
fix(mcp): clarify install help forwarded options

### DIFF
--- a/docs/src/content/docs/reference/cli/mcp.md
+++ b/docs/src/content/docs/reference/cli/mcp.md
@@ -89,7 +89,7 @@ apm mcp install fetch -- npx -y @modelcontextprotocol/server-fetch
 apm mcp install api --transport http --url https://example.com/mcp
 ```
 
-Common forwarded options (see `apm install --help` for the full
+Forwarded install options (see `apm install --help` for the full
 list):
 
 | Flag | Description |

--- a/src/apm_cli/commands/mcp.py
+++ b/src/apm_cli/commands/mcp.py
@@ -89,18 +89,16 @@ def mcp():
         "Add an MCP server to apm.yml. Alias for 'apm install --mcp'.\n\n"
         "Examples:\n\n"
         "  apm mcp install fetch -- npx -y @modelcontextprotocol/server-fetch\n\n"
-        "  apm mcp install api --transport http --url https://example.com/mcp"
-    ),
-    epilog=(
+        "  apm mcp install api --transport http --url https://example.com/mcp\n\n"
         "\b\n"
-        "Common options (see 'apm install --help' for full list):\n"
+        "Forwarded install options (see 'apm install --help' for the full list):\n"
         "  --transport [stdio|http|sse|streamable-http]\n"
         "  --url URL           Server URL for remote transports\n"
         "  --env KEY=VALUE     Environment variable (repeatable)\n"
         "  --header KEY=VALUE  HTTP header (repeatable)\n"
         "  --registry URL      Custom registry URL\n"
         "  --mcp-version VER   Pin registry entry to a specific version\n"
-        "  --dev / --dry-run / --force / --verbose / --no-policy\n"
+        "  --dev / --dry-run / --force / --verbose / --no-policy"
     ),
 )
 @click.argument("name", required=True)

--- a/tests/integration/test_commands_mcp_flow.py
+++ b/tests/integration/test_commands_mcp_flow.py
@@ -121,6 +121,12 @@ class TestMcpGroupHelp:
         runner = CliRunner()
         result = runner.invoke(mcp, ["install", "--help"])
         assert result.exit_code == 0
+        description, options = result.output.split("Options:", 1)
+        assert "Forwarded install options" in description
+        assert "--transport [stdio|http|sse|streamable-http]" in description
+        assert "--mcp-version VER" in description
+        assert "Common options" not in options
+        assert "--transport [stdio|http|sse|streamable-http]" not in options
 
 
 class TestMcpSearch:

--- a/tests/integration/test_commands_mcp_phase3c.py
+++ b/tests/integration/test_commands_mcp_phase3c.py
@@ -121,6 +121,12 @@ class TestMcpGroupHelp:
         runner = CliRunner()
         result = runner.invoke(mcp, ["install", "--help"])
         assert result.exit_code == 0
+        description, options = result.output.split("Options:", 1)
+        assert "Forwarded install options" in description
+        assert "--transport [stdio|http|sse|streamable-http]" in description
+        assert "--mcp-version VER" in description
+        assert "Common options" not in options
+        assert "--transport [stdio|http|sse|streamable-http]" not in options
 
 
 class TestMcpSearch:


### PR DESCRIPTION
﻿## Summary

Part of #2006.

- move the forwarded `apm install --mcp` option summary into the `apm mcp install` command description instead of rendering it after the `Options:` section
- rename the note to "Forwarded install options" so it is clear these flags are forwarded, not Click-registered on the alias command
- add regression assertions in both MCP command test suites so forwarded options stay out of the Click `Options:` section

## Validation

- `.venv\Scripts\python.exe -m pytest tests\integration\test_commands_mcp_phase3c.py::TestMcpGroupHelp::test_mcp_install_help tests\integration\test_commands_mcp_flow.py::TestMcpGroupHelp::test_mcp_install_help -q`
- `.venv\Scripts\python.exe -m pytest tests\integration\test_commands_mcp_phase3c.py tests\integration\test_commands_mcp_flow.py -q`
- `.venv\Scripts\python.exe -m pytest tests\unit\test_cli_consistency.py -q`
- `.venv\Scripts\python.exe -m ruff check src\apm_cli\commands\mcp.py tests\integration\test_commands_mcp_phase3c.py tests\integration\test_commands_mcp_flow.py`
- `.venv\Scripts\python.exe -m ruff format --check src\apm_cli\commands\mcp.py tests\integration\test_commands_mcp_phase3c.py tests\integration\test_commands_mcp_flow.py`
- `.venv\Scripts\apm.exe mcp install --help`
- `git diff --check origin/main...HEAD`
