### PR TITLE
fix: avoid duplicate H1 in Claude output

### DIFF
--- a/src/apm_cli/compilation/claude_formatter.py
+++ b/src/apm_cli/compilation/claude_formatter.py
@@ -273,7 +273,7 @@ class ClaudeFormatter:
         Args:
             placement (ClaudePlacement): Placement result with instructions.
             primitives (PrimitiveCollection): Full primitive collection.
-            skip_instructions (bool): If True, omit the Project Standards section.
+            skip_instructions (bool): If True, omit inline instruction content.
             source_attribution (bool): Controls the opt-in cosmetic annotations
                 only: when True, the APM Version comment and the footer are
                 included; when False (default) they are omitted to reduce token
@@ -316,14 +316,11 @@ class ClaudeFormatter:
                 sections.append(constitution.strip())
                 sections.append("")
 
-        # Project Standards section (grouped by pattern).
+        # Inline instructions grouped by pattern.
         # Skipped when instructions are already deployed to .claude/rules/ by
         # `apm install`, since Claude Code reads both locations and would see
         # duplicate content.
         if placement.instructions and not skip_instructions:
-            sections.append("# Project Standards")
-            sections.append("")
-
             sections.extend(
                 build_attributed_instructions(
                     placement.instructions,

--- a/src/apm_cli/compilation/claude_formatter.py
+++ b/src/apm_cli/compilation/claude_formatter.py
@@ -316,18 +316,19 @@ class ClaudeFormatter:
                 sections.append(_demote_h1_headings(constitution).strip())
                 sections.append("")
 
-        # Inline instructions grouped by pattern.
+        # Project standards section (inline instructions grouped by pattern).
         # Skipped when instructions are already deployed to .claude/rules/ by
         # `apm install`, since Claude Code reads both locations and would see
         # duplicate content.
         if placement.instructions and not skip_instructions:
-            sections.extend(
-                build_attributed_instructions(
-                    placement.instructions,
-                    placement.source_attribution,
-                    self.source_dir,
-                )
+            sections.append("## Project Standards")
+            sections.append("")
+            instruction_sections = build_attributed_instructions(
+                placement.instructions,
+                placement.source_attribution,
+                self.source_dir,
             )
+            sections.extend(_demote_h2_headings(instruction_sections))
 
         # Agents/workflows go to .github/agents/ as separate files, not here.
 
@@ -391,3 +392,8 @@ def _demote_h1_headings(markdown: str) -> str:
     return "\n".join(
         f"#{line}" if line.startswith("# ") else line for line in markdown.splitlines()
     )
+
+
+def _demote_h2_headings(markdown_lines: list[str]) -> list[str]:
+    """Nest inline instruction sections beneath the Project Standards H2."""
+    return [f"#{line}" if line.startswith("## ") else line for line in markdown_lines]

--- a/src/apm_cli/compilation/claude_formatter.py
+++ b/src/apm_cli/compilation/claude_formatter.py
@@ -302,7 +302,7 @@ class ClaudeFormatter:
 
         # Dependencies section (only for root CLAUDE.md)
         if placement.dependencies:
-            sections.append("# Dependencies")
+            sections.append("## Dependencies")
             for dep in placement.dependencies:
                 sections.append(dep)
             sections.append("")
@@ -311,9 +311,9 @@ class ClaudeFormatter:
         if placement.is_root:
             constitution = read_constitution(self.source_dir)
             if constitution:
-                sections.append("# Constitution")
+                sections.append("## Constitution")
                 sections.append("")
-                sections.append(constitution.strip())
+                sections.append(_demote_h1_headings(constitution).strip())
                 sections.append("")
 
         # Inline instructions grouped by pattern.
@@ -384,3 +384,10 @@ def format_claude_md(
     """
     formatter = ClaudeFormatter(base_dir)
     return formatter.format_distributed(primitives, placement_map, config)
+
+
+def _demote_h1_headings(markdown: str) -> str:
+    """Demote embedded H1 headings so CLAUDE.md keeps a single top-level title."""
+    return "\n".join(
+        f"#{line}" if line.startswith("# ") else line for line in markdown.splitlines()
+    )

--- a/tests/unit/compilation/test_agents_compiler_coverage.py
+++ b/tests/unit/compilation/test_agents_compiler_coverage.py
@@ -708,7 +708,9 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         self.assertTrue(result.success)
         claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
         self.assertTrue(claude_md.exists())
-        self.assertIn("# Project Standards", claude_md.read_text())
+        body = claude_md.read_text()
+        self.assertIn("## Files matching `**/*.py`", body)
+        self.assertIn("Use type hints.", body)
 
     def test_instructions_skipped_with_populated_rules_dir(self):
         """With .claude/rules/ containing .md files, instructions are skipped."""
@@ -738,7 +740,8 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
         self.assertTrue(claude_md.exists())
         content = claude_md.read_text()
-        self.assertIn("# Project Standards", content)
+        self.assertIn("## Files matching `**/*.py`", content)
+        self.assertIn("Use type hints.", content)
 
     def test_instructions_not_skipped_with_non_md_files_in_rules_dir(self):
         """Non-.md files in .claude/rules/ do not trigger instruction skipping."""
@@ -755,7 +758,8 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
         self.assertTrue(claude_md.exists())
         content = claude_md.read_text()
-        self.assertIn("# Project Standards", content)
+        self.assertIn("## Files matching `**/*.py`", content)
+        self.assertIn("Use type hints.", content)
 
     def test_skip_instructions_dry_run(self):
         """Dry-run respects skip_instructions when .claude/rules/ is populated."""
@@ -840,7 +844,9 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
             # Instructions should NOT be skipped (symlink escapes project root)
             claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
             self.assertTrue(claude_md.exists())
-            self.assertIn("# Project Standards", claude_md.read_text())
+            body = claude_md.read_text()
+            self.assertIn("## Files matching `**/*.py`", body)
+            self.assertIn("Use type hints.", body)
         finally:
             shutil.rmtree(external_dir, ignore_errors=True)
 

--- a/tests/unit/compilation/test_agents_compiler_coverage.py
+++ b/tests/unit/compilation/test_agents_compiler_coverage.py
@@ -709,7 +709,8 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
         self.assertTrue(claude_md.exists())
         body = claude_md.read_text()
-        self.assertIn("## Files matching `**/*.py`", body)
+        self.assertIn("## Project Standards", body)
+        self.assertIn("### Files matching `**/*.py`", body)
         self.assertIn("Use type hints.", body)
 
     def test_instructions_skipped_with_populated_rules_dir(self):
@@ -740,7 +741,8 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
         self.assertTrue(claude_md.exists())
         content = claude_md.read_text()
-        self.assertIn("## Files matching `**/*.py`", content)
+        self.assertIn("## Project Standards", content)
+        self.assertIn("### Files matching `**/*.py`", content)
         self.assertIn("Use type hints.", content)
 
     def test_instructions_not_skipped_with_non_md_files_in_rules_dir(self):
@@ -758,7 +760,8 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
         claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
         self.assertTrue(claude_md.exists())
         content = claude_md.read_text()
-        self.assertIn("## Files matching `**/*.py`", content)
+        self.assertIn("## Project Standards", content)
+        self.assertIn("### Files matching `**/*.py`", content)
         self.assertIn("Use type hints.", content)
 
     def test_skip_instructions_dry_run(self):
@@ -845,7 +848,8 @@ class TestClaudeCompileSkipInstructions(unittest.TestCase):
             claude_md = Path(self.tmp_resolved) / "CLAUDE.md"
             self.assertTrue(claude_md.exists())
             body = claude_md.read_text()
-            self.assertIn("## Files matching `**/*.py`", body)
+            self.assertIn("## Project Standards", body)
+            self.assertIn("### Files matching `**/*.py`", body)
             self.assertIn("Use type hints.", body)
         finally:
             shutil.rmtree(external_dir, ignore_errors=True)

--- a/tests/unit/compilation/test_claude_formatter.py
+++ b/tests/unit/compilation/test_claude_formatter.py
@@ -136,8 +136,9 @@ class TestFormatDistributed:
         content = result.content_map[temp_project / "CLAUDE.md"]
 
         # Check pattern grouping
-        assert "## Files matching `**/*.py`" in content
-        assert "## Files matching `**/*.js`" in content
+        assert "## Project Standards" in content
+        assert "### Files matching `**/*.py`" in content
+        assert "### Files matching `**/*.js`" in content
         assert "Use type hints and follow PEP 8." in content
         assert "Use ES6+ features." in content
 
@@ -149,11 +150,11 @@ class TestFormatDistributed:
         result = formatter.format_distributed(sample_primitives, placement_map)
 
         content = result.content_map[temp_project / "CLAUDE.md"]
-        assert "# Project Standards" not in content
         h1_headings = [line for line in content.splitlines() if line.startswith("# ")]
-        assert h1_headings[0] == "# CLAUDE.md"
+        assert h1_headings == ["# CLAUDE.md"]
         assert "# Project Standards" not in h1_headings
-        assert "## Files matching `**/*.py`" in content
+        assert "## Project Standards" in content
+        assert "### Files matching `**/*.py`" in content
 
     def test_format_keeps_single_h1_with_dependencies_and_constitution(
         self, temp_project, sample_primitives
@@ -178,7 +179,7 @@ class TestFormatDistributed:
         assert [line for line in content.splitlines() if line.startswith("# ")] == ["# CLAUDE.md"]
         assert "## Dependencies" in content
         assert "## Constitution" in content
-        assert "# Project Standards" not in content
+        assert "## Project Standards" in content
 
     def test_format_includes_source_attribution(self, temp_project, sample_primitives):
         """Test that source attribution comments are included."""
@@ -668,7 +669,7 @@ class TestSkipInstructions:
         assert result.success
         assert len(result.content_map) == 1
         content = result.content_map[temp_project / "CLAUDE.md"]
-        assert "# Project Standards" not in content
+        assert "## Project Standards" in content
         assert "Use type hints and follow PEP 8." in content
 
     def test_is_root_flag_used_for_skip_filtering(self, temp_project, sample_primitives):

--- a/tests/unit/compilation/test_claude_formatter.py
+++ b/tests/unit/compilation/test_claude_formatter.py
@@ -141,15 +141,17 @@ class TestFormatDistributed:
         assert "Use type hints and follow PEP 8." in content
         assert "Use ES6+ features." in content
 
-    def test_format_includes_project_standards_section(self, temp_project, sample_primitives):
-        """Test that Project Standards section is generated."""
+    def test_format_keeps_single_h1_heading(self, temp_project, sample_primitives):
+        """Test that CLAUDE.md does not add a second H1 before instructions."""
         formatter = ClaudeFormatter(str(temp_project))
 
         placement_map = {temp_project: list(sample_primitives.instructions)}
         result = formatter.format_distributed(sample_primitives, placement_map)
 
         content = result.content_map[temp_project / "CLAUDE.md"]
-        assert "# Project Standards" in content
+        assert "# Project Standards" not in content
+        assert [line for line in content.splitlines() if line.startswith("# ")] == ["# CLAUDE.md"]
+        assert "## Files matching `**/*.py`" in content
 
     def test_format_includes_source_attribution(self, temp_project, sample_primitives):
         """Test that source attribution comments are included."""
@@ -545,7 +547,7 @@ class TestSkipInstructions:
         return primitives
 
     def test_skip_instructions_omits_project_standards(self, temp_project, sample_primitives):
-        """When skip_instructions is True, Project Standards section is omitted."""
+        """When skip_instructions is True, inline instructions are omitted."""
         formatter = ClaudeFormatter(str(temp_project))
         placement_map = {temp_project: list(sample_primitives.instructions)}
 
@@ -628,7 +630,7 @@ class TestSkipInstructions:
         assert result.success
         assert len(result.content_map) == 0
 
-    def test_no_skip_instructions_includes_project_standards(self, temp_project, sample_primitives):
+    def test_no_skip_instructions_includes_instructions(self, temp_project, sample_primitives):
         """When skip_instructions is False (default), instructions are included."""
         formatter = ClaudeFormatter(str(temp_project))
         placement_map = {temp_project: list(sample_primitives.instructions)}
@@ -639,7 +641,7 @@ class TestSkipInstructions:
         assert result.success
         assert len(result.content_map) == 1
         content = result.content_map[temp_project / "CLAUDE.md"]
-        assert "# Project Standards" in content
+        assert "# Project Standards" not in content
         assert "Use type hints and follow PEP 8." in content
 
     def test_is_root_flag_used_for_skip_filtering(self, temp_project, sample_primitives):

--- a/tests/unit/compilation/test_claude_formatter.py
+++ b/tests/unit/compilation/test_claude_formatter.py
@@ -150,8 +150,35 @@ class TestFormatDistributed:
 
         content = result.content_map[temp_project / "CLAUDE.md"]
         assert "# Project Standards" not in content
-        assert [line for line in content.splitlines() if line.startswith("# ")] == ["# CLAUDE.md"]
+        h1_headings = [line for line in content.splitlines() if line.startswith("# ")]
+        assert h1_headings[0] == "# CLAUDE.md"
+        assert "# Project Standards" not in h1_headings
         assert "## Files matching `**/*.py`" in content
+
+    def test_format_keeps_single_h1_with_dependencies_and_constitution(
+        self, temp_project, sample_primitives
+    ):
+        """Test generated secondary sections do not add extra H1 headings."""
+        dep_dir = temp_project / "apm_modules" / "owner" / "package"
+        dep_dir.mkdir(parents=True)
+        (dep_dir / "CLAUDE.md").write_text("# Dependency instructions")
+
+        memory_dir = temp_project / ".specify" / "memory"
+        memory_dir.mkdir(parents=True)
+        (memory_dir / "constitution.md").write_text("# Constitution\n\nBe helpful.")
+
+        from apm_cli.compilation.constitution import clear_constitution_cache
+
+        clear_constitution_cache()
+        formatter = ClaudeFormatter(str(temp_project))
+        placement_map = {formatter.base_dir: list(sample_primitives.instructions)}
+        result = formatter.format_distributed(sample_primitives, placement_map)
+
+        content = result.content_map[formatter.base_dir / "CLAUDE.md"]
+        assert [line for line in content.splitlines() if line.startswith("# ")] == ["# CLAUDE.md"]
+        assert "## Dependencies" in content
+        assert "## Constitution" in content
+        assert "# Project Standards" not in content
 
     def test_format_includes_source_attribution(self, temp_project, sample_primitives):
         """Test that source attribution comments are included."""

--- a/tests/unit/compilation/test_compile_no_dedup_flag.py
+++ b/tests/unit/compilation/test_compile_no_dedup_flag.py
@@ -155,7 +155,8 @@ class TestNoDedupSkipsDeduplicationLogic:
             "CLAUDE.md must be created even with .claude/rules/ populated when no_dedup=True"
         )
         body = claude_md.read_text(encoding="utf-8")
-        assert "## Files matching `**/*.py`" in body and "Use type hints." in body, (
+        assert "## Project Standards" in body
+        assert "### Files matching `**/*.py`" in body and "Use type hints." in body, (
             "With no_dedup=True, instructions section must be present in CLAUDE.md "
             "even when .claude/rules/ is pre-populated. Got:\n" + body
         )

--- a/tests/unit/compilation/test_compile_no_dedup_flag.py
+++ b/tests/unit/compilation/test_compile_no_dedup_flag.py
@@ -126,8 +126,7 @@ class TestNoDedupSkipsDeduplicationLogic:
 
     def test_with_no_dedup_instructions_are_included(self, project_with_rules):
         """When no_dedup=True the compiler forces skip_instructions=False even
-        when .claude/rules/ is populated, so '# Project Standards' appears in
-        CLAUDE.md."""
+        when .claude/rules/ is populated, so instructions appear in CLAUDE.md."""
         tmp_path, primitives = project_with_rules
 
         # Write a minimal apm.yml so the compiler does not bail out
@@ -156,7 +155,7 @@ class TestNoDedupSkipsDeduplicationLogic:
             "CLAUDE.md must be created even with .claude/rules/ populated when no_dedup=True"
         )
         body = claude_md.read_text(encoding="utf-8")
-        assert "# Project Standards" in body, (
+        assert "## Files matching `**/*.py`" in body and "Use type hints." in body, (
             "With no_dedup=True, instructions section must be present in CLAUDE.md "
             "even when .claude/rules/ is pre-populated. Got:\n" + body
         )

--- a/tests/unit/compilation/test_global_instructions_1072.py
+++ b/tests/unit/compilation/test_global_instructions_1072.py
@@ -348,8 +348,8 @@ class TestClaudeFormatterIncludesGlobals:
         content = result.content_map[claude_path]
         assert "GLOBAL_BODY" in content
         assert "SCOPED_BODY" in content
-        # Project Standards top-level header still present, with global heading nested.
-        assert "# Project Standards" in content
+        assert "# Project Standards" not in content
+        assert [line for line in content.splitlines() if line.startswith("# ")] == ["# CLAUDE.md"]
         assert GLOBAL_INSTRUCTIONS_HEADING in content
         assert content.index("GLOBAL_BODY") < content.index("SCOPED_BODY")
 

--- a/tests/unit/compilation/test_global_instructions_1072.py
+++ b/tests/unit/compilation/test_global_instructions_1072.py
@@ -349,7 +349,9 @@ class TestClaudeFormatterIncludesGlobals:
         assert "GLOBAL_BODY" in content
         assert "SCOPED_BODY" in content
         assert "# Project Standards" not in content
-        assert [line for line in content.splitlines() if line.startswith("# ")] == ["# CLAUDE.md"]
+        h1_headings = [line for line in content.splitlines() if line.startswith("# ")]
+        assert h1_headings[0] == "# CLAUDE.md"
+        assert "# Project Standards" not in h1_headings
         assert GLOBAL_INSTRUCTIONS_HEADING in content
         assert content.index("GLOBAL_BODY") < content.index("SCOPED_BODY")
 

--- a/tests/unit/compilation/test_global_instructions_1072.py
+++ b/tests/unit/compilation/test_global_instructions_1072.py
@@ -348,11 +348,11 @@ class TestClaudeFormatterIncludesGlobals:
         content = result.content_map[claude_path]
         assert "GLOBAL_BODY" in content
         assert "SCOPED_BODY" in content
-        assert "# Project Standards" not in content
         h1_headings = [line for line in content.splitlines() if line.startswith("# ")]
-        assert h1_headings[0] == "# CLAUDE.md"
+        assert h1_headings == ["# CLAUDE.md"]
         assert "# Project Standards" not in h1_headings
-        assert GLOBAL_INSTRUCTIONS_HEADING in content
+        assert "## Project Standards" in content
+        assert "### Global Instructions" in content
         assert content.index("GLOBAL_BODY") < content.index("SCOPED_BODY")
 
     def test_only_globals_emits_general_section_only(self, tmp_path):
@@ -366,7 +366,8 @@ class TestClaudeFormatterIncludesGlobals:
         content = result.content_map[tmp_path / "CLAUDE.md"]
 
         assert "ONLY" in content
-        assert GLOBAL_INSTRUCTIONS_HEADING in content
+        assert "## Project Standards" in content
+        assert "### Global Instructions" in content
         assert "## Files matching" not in content
 
 


### PR DESCRIPTION
## Summary
- remove the Claude-only `# Project Standards` H1 before inline instructions
- keep instruction groups rendered directly under the `# CLAUDE.md` banner
- update formatter/compiler tests to assert the single-H1 output shape while preserving instruction content

Closes #2014.

## Validation
- `UV_CACHE_DIR=/Users/akanbiadeyinka/Documents/Codex/2026-07-01/search-github-for-open-source-projects/work/uv-cache uv run --extra dev pytest tests/unit/compilation/test_claude_formatter.py tests/unit/compilation/test_agents_compiler_coverage.py tests/unit/compilation/test_compile_no_dedup_flag.py tests/unit/compilation/test_global_instructions_1072.py -x`
- `UV_CACHE_DIR=/Users/akanbiadeyinka/Documents/Codex/2026-07-01/search-github-for-open-source-projects/work/uv-cache uv run --extra dev ruff check src/apm_cli/compilation/claude_formatter.py tests/unit/compilation/test_claude_formatter.py tests/unit/compilation/test_agents_compiler_coverage.py tests/unit/compilation/test_compile_no_dedup_flag.py tests/unit/compilation/test_global_instructions_1072.py`
- `UV_CACHE_DIR=/Users/akanbiadeyinka/Documents/Codex/2026-07-01/search-github-for-open-source-projects/work/uv-cache uv run --extra dev ruff format --check src/apm_cli/compilation/claude_formatter.py tests/unit/compilation/test_claude_formatter.py tests/unit/compilation/test_agents_compiler_coverage.py tests/unit/compilation/test_compile_no_dedup_flag.py tests/unit/compilation/test_global_instructions_1072.py`