### PR TITLE
fix(hooks): route combined hook manifests to every named target (closes #2020)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   kebab-case, and `apm pack` prints a warning naming the original and emitted
   values when a rewrite occurs. Internal resolution, registry lookups, and the
   Codex `interface.displayName` keep the original name. (#2008)
+- Combined hook manifests such as `claude-codex-hooks.json` now deploy to every
+  named target instead of only the last suffix target, so one deprecated
+  filename-routed manifest can still reach both Claude Code and Codex during the
+  migration window. by @garyj (#2021)
 
 - `apm audit --ci` no longer reports phantom drift for root-local hook files
   when audit replay writes into a scratch project root. (#1980)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Combined hook manifests such as `claude-codex-hooks.json` now deploy to every
   named target instead of only the last suffix target, so one deprecated
   filename-routed manifest can still reach both Claude Code and Codex during the
-  migration window. by @garyj (#2021)
-
+  migration window. (by @garyj) (#2021)
 - `apm audit --ci` no longer reports phantom drift for root-local hook files
   when audit replay writes into a scratch project root. (#1980)
 - Self-defined stdio MCP env placeholders now resolve from the install process

--- a/docs/src/content/docs/producer/author-primitives/hooks-and-commands.md
+++ b/docs/src/content/docs/producer/author-primitives/hooks-and-commands.md
@@ -105,6 +105,8 @@ window and warns at install time.
 
 Before: name the manifest `my-pkg-codex-hooks.json`. After: keep
 `hooks.json` generic and let the consumer set `targets: [codex]`.
+Combined deprecated stems such as `claude-codex-hooks.json` route to every
+named target token during the migration window.
 :::
 
 Supported targets and where the integrator writes:

--- a/docs/src/content/docs/producer/author-primitives/hooks-and-commands.md
+++ b/docs/src/content/docs/producer/author-primitives/hooks-and-commands.md
@@ -107,6 +107,9 @@ Before: name the manifest `my-pkg-codex-hooks.json`. After: keep
 `hooks.json` generic and let the consumer set `targets: [codex]`.
 Combined deprecated stems such as `claude-codex-hooks.json` route to every
 named target token during the migration window.
+Stems with target tokens outside the trailing target suffix (for example
+`codex-launch-hooks.json`) fall back to universal or suffix routing and print a
+warning naming the ignored token.
 :::
 
 Supported targets and where the integrator writes:

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -113,6 +113,8 @@ dependencies:
 
 Before: encode the target in a filename such as `my-pkg-codex-hooks.json`.
 After: keep hook filenames generic and let the consumer set `targets: [codex]`.
+Combined deprecated stems such as `claude-codex-hooks.json` route to every
+named target token during the migration window.
 
 During the deprecation window, existing suffix-named hook files still
 route to their matching harness and emit an install-time warning. Once a

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -115,6 +115,9 @@ Before: encode the target in a filename such as `my-pkg-codex-hooks.json`.
 After: keep hook filenames generic and let the consumer set `targets: [codex]`.
 Combined deprecated stems such as `claude-codex-hooks.json` route to every
 named target token during the migration window.
+Stems with target tokens outside the trailing target suffix (for example
+`codex-launch-hooks.json`) fall back to universal or suffix routing and print a
+warning naming the ignored token.
 
 During the deprecation window, existing suffix-named hook files still
 route to their matching harness and emit an install-time warning. Once a

--- a/src/apm_cli/integration/hook_file_routing.py
+++ b/src/apm_cli/integration/hook_file_routing.py
@@ -33,15 +33,15 @@ def filter_hook_files_for_target(
     universal: list[Path] = []
     for hook_file in hook_files:
         allowed_targets = _hook_file_allowed_targets(hook_file)
+        _warn_unresolved_target_tokens_if_needed(
+            warned_packages,
+            warning_key,
+            package_name,
+            package_identity,
+            hook_file.name,
+            _hook_file_unresolved_target_tokens(hook_file),
+        )
         if allowed_targets is None:
-            _warn_unresolved_target_tokens_if_needed(
-                warned_packages,
-                warning_key,
-                package_name,
-                package_identity,
-                hook_file.name,
-                _hook_file_unresolved_target_tokens(hook_file),
-            )
             universal.append(hook_file)
         elif target_key in allowed_targets:
             _warn_if_needed(
@@ -70,16 +70,15 @@ def _hook_file_allowed_targets(hook_file: Path) -> set[str] | None:
 
     if stem_lower.endswith("-hooks"):
         segments = stem_lower[: -len("-hooks")].split("-")
-        per_segment = [_HOOK_FILE_TARGET_TOKENS.get(segment) for segment in segments]
         suffix_targets = _target_suffix_segments(segments)
         if len(suffix_targets) >= 2:
             # Combined manifest (e.g. claude-codex-hooks): union of every
             # target suffix token, so the file is selected for each.
             return _union_target_sets(suffix_targets)
-        if per_segment and per_segment[-1]:
+        if suffix_targets:
             # `<token>-hooks` or `*-<token>-hooks`: route by the final target
             # token. Earlier non-target segments are descriptive prefixes.
-            return per_segment[-1]
+            return suffix_targets[0]
 
     return None
 
@@ -105,14 +104,14 @@ def _union_target_sets(target_sets: list[set[str]]) -> set[str]:
 
 
 def _hook_file_unresolved_target_tokens(hook_file: Path) -> list[str]:
-    """Return known target tokens from stems that still resolve universal."""
+    """Return known target tokens ignored by suffix-based filename routing."""
     stem_lower = hook_file.stem.lower()
     if not stem_lower.endswith("-hooks"):
         return []
     segments = stem_lower[: -len("-hooks")].split("-")
-    if _target_suffix_segments(segments):
-        return []
-    return sorted({segment for segment in segments if segment in _HOOK_FILE_TARGET_TOKENS})
+    suffix_count = len(_target_suffix_segments(segments))
+    ignored_segments = segments[: len(segments) - suffix_count] if suffix_count else segments
+    return sorted({segment for segment in ignored_segments if segment in _HOOK_FILE_TARGET_TOKENS})
 
 
 def _warn_if_needed(
@@ -197,10 +196,11 @@ def _unresolved_filename_routing_warning(
     pkg_label = package_name or package_identity or "<owner/repo>"
     return (
         f"{pkg_label}: hook filename routing could not resolve '{hook_filename}'.\n"
-        f"    The stem contains target token(s) [{tokens_csv}] but does not end\n"
-        "    with a recognized target suffix, so APM treats it as universal.\n"
-        "    Rename the file to '<prefix>-<target>-hooks.json' or prefer\n"
-        "    per-dependency targets: [...] in apm.yml."
+        f"    The stem contains target token(s) [{tokens_csv}] outside the trailing\n"
+        "    target suffix, so APM ignores those token(s) and uses the suffix\n"
+        "    match or universal fallback. Rename the file to\n"
+        "    '<prefix>-<target>-hooks.json' or prefer per-dependency\n"
+        "    targets: [...] in apm.yml."
     )
 
 

--- a/src/apm_cli/integration/hook_file_routing.py
+++ b/src/apm_cli/integration/hook_file_routing.py
@@ -53,12 +53,26 @@ def _hook_file_allowed_targets(hook_file: Path) -> set[str] | None:
     """Return explicit targets for a hook file, or None for universal files."""
     stem_lower = hook_file.stem.lower()
     for token, allowed_targets in _HOOK_FILE_TARGET_TOKENS.items():
-        if (
-            stem_lower == f"{token}-hooks"
-            or stem_lower.endswith(f"-{token}-hooks")
-            or stem_lower == f"hooks-{token}"
-        ):
+        if stem_lower == f"hooks-{token}":
             return allowed_targets
+
+    if stem_lower.endswith("-hooks"):
+        segments = stem_lower[: -len("-hooks")].split("-")
+        per_segment = [_HOOK_FILE_TARGET_TOKENS.get(segment) for segment in segments]
+        if segments and all(per_segment):
+            # Combined manifest (e.g. claude-codex-hooks): union of every
+            # token's allowed targets, so the file is selected for each.
+            matched: set[str] = set()
+            for segment_targets in per_segment:
+                if segment_targets is not None:
+                    matched |= segment_targets
+            return matched
+        if per_segment and per_segment[-1]:
+            # `<token>-hooks` or `*-<token>-hooks`: route by the last segment
+            # so descriptive prefixes (e.g. pre-claude-launch-hooks) don't
+            # accidentally match a token that isn't actually the target.
+            return per_segment[-1]
+
     return None
 
 

--- a/src/apm_cli/integration/hook_file_routing.py
+++ b/src/apm_cli/integration/hook_file_routing.py
@@ -34,6 +34,14 @@ def filter_hook_files_for_target(
     for hook_file in hook_files:
         allowed_targets = _hook_file_allowed_targets(hook_file)
         if allowed_targets is None:
+            _warn_unresolved_target_tokens_if_needed(
+                warned_packages,
+                warning_key,
+                package_name,
+                package_identity,
+                hook_file.name,
+                _hook_file_unresolved_target_tokens(hook_file),
+            )
             universal.append(hook_file)
         elif target_key in allowed_targets:
             _warn_if_needed(
@@ -50,7 +58,11 @@ def filter_hook_files_for_target(
 
 
 def _hook_file_allowed_targets(hook_file: Path) -> set[str] | None:
-    """Return explicit targets for a hook file, or None for universal files."""
+    """Return explicit targets for a hook file, or None for universal files.
+
+    Filename routing is a deprecated package-authoring convenience, not an
+    authorization boundary. Unknown stems intentionally stay universal.
+    """
     stem_lower = hook_file.stem.lower()
     for token, allowed_targets in _HOOK_FILE_TARGET_TOKENS.items():
         if stem_lower == f"hooks-{token}":
@@ -59,21 +71,48 @@ def _hook_file_allowed_targets(hook_file: Path) -> set[str] | None:
     if stem_lower.endswith("-hooks"):
         segments = stem_lower[: -len("-hooks")].split("-")
         per_segment = [_HOOK_FILE_TARGET_TOKENS.get(segment) for segment in segments]
-        if segments and all(per_segment):
+        suffix_targets = _target_suffix_segments(segments)
+        if len(suffix_targets) >= 2:
             # Combined manifest (e.g. claude-codex-hooks): union of every
-            # token's allowed targets, so the file is selected for each.
-            matched: set[str] = set()
-            for segment_targets in per_segment:
-                if segment_targets is not None:
-                    matched |= segment_targets
-            return matched
+            # target suffix token, so the file is selected for each.
+            return _union_target_sets(suffix_targets)
         if per_segment and per_segment[-1]:
-            # `<token>-hooks` or `*-<token>-hooks`: route by the last segment
-            # so descriptive prefixes (e.g. pre-claude-launch-hooks) don't
-            # accidentally match a token that isn't actually the target.
+            # `<token>-hooks` or `*-<token>-hooks`: route by the final target
+            # token. Earlier non-target segments are descriptive prefixes.
             return per_segment[-1]
 
     return None
+
+
+def _target_suffix_segments(segments: list[str]) -> list[set[str]]:
+    """Return contiguous target-token matches at the end of a stem."""
+    suffix: list[set[str]] = []
+    for segment in reversed(segments):
+        segment_targets = _HOOK_FILE_TARGET_TOKENS.get(segment)
+        if segment_targets is None:
+            break
+        suffix.append(segment_targets)
+    suffix.reverse()
+    return suffix
+
+
+def _union_target_sets(target_sets: list[set[str]]) -> set[str]:
+    """Return the union of target sets while preserving simple caller logic."""
+    matched: set[str] = set()
+    for segment_targets in target_sets:
+        matched |= segment_targets
+    return matched
+
+
+def _hook_file_unresolved_target_tokens(hook_file: Path) -> list[str]:
+    """Return known target tokens from stems that still resolve universal."""
+    stem_lower = hook_file.stem.lower()
+    if not stem_lower.endswith("-hooks"):
+        return []
+    segments = stem_lower[: -len("-hooks")].split("-")
+    if _target_suffix_segments(segments):
+        return []
+    return sorted({segment for segment in segments if segment in _HOOK_FILE_TARGET_TOKENS})
 
 
 def _warn_if_needed(
@@ -99,6 +138,32 @@ def _warn_if_needed(
     warned_packages.add(warning_key)
 
 
+def _warn_unresolved_target_tokens_if_needed(
+    warned_packages: set[str] | None,
+    warning_key: str,
+    package_name: str,
+    package_identity: str,
+    hook_filename: str,
+    token_names: list[str],
+) -> None:
+    """Emit a warning when a target-looking filename falls back to universal."""
+    if warned_packages is None or not token_names:
+        return
+    unresolved_key = f"{warning_key}:unresolved:{hook_filename.lower()}"
+    if unresolved_key in warned_packages:
+        return
+    _rich_warning(
+        _unresolved_filename_routing_warning(
+            package_name,
+            package_identity,
+            hook_filename,
+            token_names,
+        ),
+        symbol="warning",
+    )
+    warned_packages.add(unresolved_key)
+
+
 def _deprecated_filename_routing_warning(
     package_name: str,
     package_identity: str,
@@ -118,6 +183,24 @@ def _deprecated_filename_routing_warning(
         f"        targets: [{targets_csv}]\n"
         "\n"
         "    See: https://microsoft.github.io/apm/reference/manifest-schema/#412-object-form"
+    )
+
+
+def _unresolved_filename_routing_warning(
+    package_name: str,
+    package_identity: str,
+    hook_filename: str,
+    token_names: list[str],
+) -> str:
+    """Return the warning for target-looking stems treated as universal."""
+    tokens_csv = ", ".join(token_names)
+    pkg_label = package_name or package_identity or "<owner/repo>"
+    return (
+        f"{pkg_label}: hook filename routing could not resolve '{hook_filename}'.\n"
+        f"    The stem contains target token(s) [{tokens_csv}] but does not end\n"
+        "    with a recognized target suffix, so APM treats it as universal.\n"
+        "    Rename the file to '<prefix>-<target>-hooks.json' or prefer\n"
+        "    per-dependency targets: [...] in apm.yml."
     )
 
 

--- a/tests/integration/test_hook_routing_combined_manifest_e2e.py
+++ b/tests/integration/test_hook_routing_combined_manifest_e2e.py
@@ -1,0 +1,172 @@
+"""Hermetic install-path proof for combined multi-target hook manifest routing."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from apm_cli.install.services import IntegratorBundle, integrate_package_primitives
+from apm_cli.integration.hook_integrator import HookIntegrator
+from apm_cli.integration.skill_integrator import SkillIntegrator
+from apm_cli.integration.targets import KNOWN_TARGETS
+from apm_cli.models.apm_package import APMPackage, PackageInfo
+from apm_cli.utils.diagnostics import DiagnosticCollector
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep any accidental home-scoped writes inside the pytest temp tree."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+
+_UNIVERSAL_COPILOT_SHAPE_HOOKS = {
+    "sessionStart": [
+        {"type": "command", "bash": "node a.js", "powershell": "node a.js", "timeoutSec": 5}
+    ]
+}
+
+_CLAUDE_SHAPE_HOOKS = {
+    "SessionStart": [
+        {
+            "matcher": "startup",
+            "hooks": [{"type": "command", "command": "node a.js", "timeout": 5}],
+        }
+    ],
+    "SubagentStart": [{"hooks": [{"type": "command", "command": "node b.js", "timeout": 5}]}],
+}
+
+_COPILOT_SHAPE_HOOKS = {
+    "sessionStart": [
+        {"type": "command", "bash": "node a.js", "powershell": "node a.js", "timeoutSec": 5}
+    ]
+}
+
+
+def _make_ponytail_package(tmp_path: Path, *, name: str = "ponytail") -> PackageInfo:
+    """Build a package fixture shaped like the DietrichGebert/ponytail package.
+
+    A universal Copilot-shaped hooks.json sits alongside a Claude-shaped
+    combined manifest and a dedicated Copilot manifest, mirroring the
+    real-world layout that triggered issue routing hooks-codex/-claude
+    combined stems only to the last token.
+    """
+    package_root = tmp_path / "apm_modules" / "local" / name
+    apm_hooks_dir = package_root / ".apm" / "hooks"
+    apm_hooks_dir.mkdir(parents=True)
+    (apm_hooks_dir / "hooks.json").write_text(
+        json.dumps({"hooks": _UNIVERSAL_COPILOT_SHAPE_HOOKS}, indent=2),
+        encoding="utf-8",
+    )
+
+    hooks_dir = package_root / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (hooks_dir / "claude-codex-hooks.json").write_text(
+        json.dumps({"hooks": _CLAUDE_SHAPE_HOOKS}, indent=2),
+        encoding="utf-8",
+    )
+    (hooks_dir / "copilot-hooks.json").write_text(
+        json.dumps({"hooks": _COPILOT_SHAPE_HOOKS}, indent=2),
+        encoding="utf-8",
+    )
+
+    package = APMPackage(name=name, version="1.0.0", source=f"DietrichGebert/{name}")
+    return PackageInfo(package=package, install_path=package_root)
+
+
+def _integrate_package_hooks(
+    package_info: PackageInfo,
+    project_root: Path,
+    *,
+    target_name: str,
+) -> dict[str, Any]:
+    """Run the install service dispatch that invokes HookIntegrator for a target."""
+    return integrate_package_primitives(
+        package_info,
+        project_root,
+        targets=[KNOWN_TARGETS[target_name]],
+        integrators=IntegratorBundle(
+            prompt=None,
+            agent=None,
+            skill=SkillIntegrator(),
+            instruction=None,
+            command=None,
+            hook=HookIntegrator(),
+        ),
+        force=False,
+        managed_files=set(),
+        diagnostics=DiagnosticCollector(),
+        package_name=package_info.package.name,
+    )
+
+
+def test_claude_target_gets_combined_manifest_not_universal_copilot_fallback(
+    tmp_path: Path,
+) -> None:
+    """The combined claude-codex-hooks.json manifest must win over the universal file.
+
+    Before the fix, a `claude-codex-hooks.json` manifest routed only to codex
+    (matching the trailing `-codex-hooks` token), so the claude target had no
+    target-specific file, fell back to the universal (Copilot-shaped)
+    hooks.json, and Copilot field names leaked into .claude/settings.json.
+    """
+    project_root = tmp_path / "project"
+    (project_root / ".claude").mkdir(parents=True)
+    package_info = _make_ponytail_package(tmp_path)
+
+    result = _integrate_package_hooks(package_info, project_root, target_name="claude")
+
+    assert result["hooks"] == 1
+    settings = json.loads((project_root / ".claude" / "settings.json").read_text(encoding="utf-8"))
+    hooks = settings["hooks"]
+    assert set(hooks) == {"SessionStart", "SubagentStart"}
+
+    raw = json.dumps(hooks)
+    assert "sessionStart" not in raw
+    assert "bash" not in raw
+    assert "powershell" not in raw
+    assert "timeoutSec" not in raw
+
+    for entries in hooks.values():
+        for entry in entries:
+            assert "hooks" in entry
+
+
+def test_copilot_target_still_deploys_its_own_manifest(tmp_path: Path) -> None:
+    """The dedicated copilot-hooks.json file keeps deploying for the copilot target."""
+    project_root = tmp_path / "project"
+    (project_root / ".github").mkdir(parents=True)
+    (project_root / ".github" / "copilot-instructions.md").write_text(
+        "# Copilot instructions\n",
+        encoding="utf-8",
+    )
+    package_info = _make_ponytail_package(tmp_path)
+
+    result = _integrate_package_hooks(package_info, project_root, target_name="copilot")
+
+    assert result["hooks"] == 1
+    config_path = (
+        project_root / ".github" / "hooks" / f"{package_info.package.name}-copilot-hooks.json"
+    )
+    assert config_path.exists()
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    assert set(config["hooks"]) == {"sessionStart"}
+
+
+def test_codex_target_still_gets_the_combined_manifest(tmp_path: Path) -> None:
+    """The combined claude-codex-hooks.json manifest also deploys for the codex target."""
+    project_root = tmp_path / "project"
+    (project_root / ".codex").mkdir(parents=True)
+    package_info = _make_ponytail_package(tmp_path)
+
+    result = _integrate_package_hooks(package_info, project_root, target_name="codex")
+
+    assert result["hooks"] == 1
+    settings = json.loads((project_root / ".codex" / "hooks.json").read_text(encoding="utf-8"))
+    assert set(settings["hooks"]) == {"SessionStart", "SubagentStart"}

--- a/tests/integration/test_hook_routing_combined_manifest_e2e.py
+++ b/tests/integration/test_hook_routing_combined_manifest_e2e.py
@@ -87,10 +87,19 @@ def _integrate_package_hooks(
     target_name: str,
 ) -> dict[str, Any]:
     """Run the install service dispatch that invokes HookIntegrator for a target."""
+    return _integrate_package_hooks_for_targets(package_info, project_root, [target_name])
+
+
+def _integrate_package_hooks_for_targets(
+    package_info: PackageInfo,
+    project_root: Path,
+    target_names: list[str],
+) -> dict[str, Any]:
+    """Run the install service dispatch for multiple targets in one pass."""
     return integrate_package_primitives(
         package_info,
         project_root,
-        targets=[KNOWN_TARGETS[target_name]],
+        targets=[KNOWN_TARGETS[target_name] for target_name in target_names],
         integrators=IntegratorBundle(
             prompt=None,
             agent=None,
@@ -170,3 +179,29 @@ def test_codex_target_still_gets_the_combined_manifest(tmp_path: Path) -> None:
     assert result["hooks"] == 1
     settings = json.loads((project_root / ".codex" / "hooks.json").read_text(encoding="utf-8"))
     assert set(settings["hooks"]) == {"SessionStart", "SubagentStart"}
+
+
+def test_combined_manifest_deploys_to_all_named_targets_in_one_install_pass(
+    tmp_path: Path,
+) -> None:
+    """One install pass deploys a combined manifest to every named target."""
+    project_root = tmp_path / "project"
+    (project_root / ".claude").mkdir(parents=True)
+    (project_root / ".codex").mkdir(parents=True)
+    package_info = _make_ponytail_package(tmp_path)
+
+    result = _integrate_package_hooks_for_targets(
+        package_info,
+        project_root,
+        ["claude", "codex"],
+    )
+
+    assert result["hooks"] == 2
+    claude_settings = json.loads(
+        (project_root / ".claude" / "settings.json").read_text(encoding="utf-8")
+    )
+    codex_settings = json.loads(
+        (project_root / ".codex" / "hooks.json").read_text(encoding="utf-8")
+    )
+    assert set(claude_settings["hooks"]) == {"SessionStart", "SubagentStart"}
+    assert set(codex_settings["hooks"]) == {"SessionStart", "SubagentStart"}

--- a/tests/unit/integration/test_hook_file_routing_combined_stems.py
+++ b/tests/unit/integration/test_hook_file_routing_combined_stems.py
@@ -59,4 +59,39 @@ def test_unknown_suffix_with_known_token_warns_before_universal_fallback(
     assert "hook filename routing could not resolve" in output
     assert "claude-launch-hooks.json" in output
     assert "contains target token(s) [claude]" in output
-    assert "treats it as universal" in output
+    assert "universal fallback" in output
+
+
+def test_known_token_outside_target_suffix_warns_when_routed_to_last_token(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mixed = tmp_path / "claude-approval-codex-hooks.json"
+    warned_packages: set[str] = set()
+
+    assert [
+        p.name
+        for p in filter_hook_files_for_target(
+            [mixed],
+            "codex",
+            package_name="ponytail",
+            package_identity="DietrichGebert/ponytail",
+            warned_packages=warned_packages,
+        )
+    ] == [mixed.name]
+    assert (
+        filter_hook_files_for_target(
+            [mixed],
+            "claude",
+            package_name="ponytail",
+            package_identity="DietrichGebert/ponytail",
+            warned_packages=warned_packages,
+        )
+        == []
+    )
+
+    output = capsys.readouterr().out
+    assert "hook filename routing could not resolve" in output
+    assert "claude-approval-codex-hooks.json" in output
+    assert "contains target token(s) [claude]" in output
+    assert "uses the suffix" in output

--- a/tests/unit/integration/test_hook_file_routing_combined_stems.py
+++ b/tests/unit/integration/test_hook_file_routing_combined_stems.py
@@ -16,6 +16,7 @@ from apm_cli.integration.hook_file_routing import (
     "stem, expected",
     [
         ("claude-codex-hooks", {"claude", "codex"}),
+        ("internal-claude-codex-hooks", {"claude", "codex"}),
         ("copilot-hooks", {"copilot", "vscode"}),
         ("my-copilot-hooks", {"copilot", "vscode"}),
         ("pre-claude-launch-hooks", None),
@@ -37,3 +38,25 @@ def test_combined_manifest_selected_for_all_its_targets_and_not_others(tmp_path:
     assert [p.name for p in filter_hook_files_for_target([combined], "claude")] == [combined.name]
     assert [p.name for p in filter_hook_files_for_target([combined], "codex")] == [combined.name]
     assert filter_hook_files_for_target([combined], "copilot") == []
+
+
+def test_unknown_suffix_with_known_token_warns_before_universal_fallback(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mixed = tmp_path / "claude-launch-hooks.json"
+    warned_packages: set[str] = set()
+
+    assert filter_hook_files_for_target(
+        [mixed],
+        "codex",
+        package_name="ponytail",
+        package_identity="DietrichGebert/ponytail",
+        warned_packages=warned_packages,
+    ) == [mixed]
+
+    output = capsys.readouterr().out
+    assert "hook filename routing could not resolve" in output
+    assert "claude-launch-hooks.json" in output
+    assert "contains target token(s) [claude]" in output
+    assert "treats it as universal" in output

--- a/tests/unit/integration/test_hook_file_routing_combined_stems.py
+++ b/tests/unit/integration/test_hook_file_routing_combined_stems.py
@@ -1,0 +1,39 @@
+"""Tests for combined multi-target hook manifest stem routing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from apm_cli.integration.hook_file_routing import (
+    _hook_file_allowed_targets,
+    filter_hook_files_for_target,
+)
+
+
+@pytest.mark.parametrize(
+    "stem, expected",
+    [
+        ("claude-codex-hooks", {"claude", "codex"}),
+        ("copilot-hooks", {"copilot", "vscode"}),
+        ("my-copilot-hooks", {"copilot", "vscode"}),
+        ("pre-claude-launch-hooks", None),
+        ("ponytail-hooks", None),
+        ("hooks-claude", {"claude"}),
+        ("hooks", None),
+        ("copilot-vscode-hooks", {"copilot", "vscode"}),
+    ],
+)
+def test_hook_file_allowed_targets(tmp_path: Path, stem: str, expected: set[str] | None) -> None:
+    hook_file = tmp_path / f"{stem}.json"
+
+    assert _hook_file_allowed_targets(hook_file) == expected
+
+
+def test_combined_manifest_selected_for_all_its_targets_and_not_others(tmp_path: Path) -> None:
+    combined = tmp_path / "claude-codex-hooks.json"
+
+    assert [p.name for p in filter_hook_files_for_target([combined], "claude")] == [combined.name]
+    assert [p.name for p in filter_hook_files_for_target([combined], "codex")] == [combined.name]
+    assert filter_hook_files_for_target([combined], "copilot") == []


### PR DESCRIPTION
Root cause: `_hook_file_allowed_targets()` recognized only single-token stems (`<token>-hooks`, `*-<token>-hooks`, `hooks-<token>`). A combined manifest such as `claude-codex-hooks.json` matched only via `endswith("-codex-hooks")` and routed to codex alone. The claude target then fell back to the universal `.apm/hooks/hooks.json`, which plugin normalization generates from the first `plugin.json` found (`.github/plugin/` outranks `.claude-plugin/`), so Copilot-schema hooks (camelCase events, `bash`/`powershell`/`timeoutSec`, no matcher nesting) landed in `.claude/settings.json` and Claude Code silently ignored them. Observed in the wild with `apm install DietrichGebert/ponytail -t claude`.

Fix:

- Route combined deprecated hook stems such as `claude-codex-hooks` to the union of their trailing target tokens.
- Keep single-token stems and non-token stems compatible with existing behavior.
- Warn when a target-looking stem has target tokens outside the trailing suffix, because those tokens are ignored and routing falls back to the suffix or universal behavior.
- Add unit coverage for the stem routing table and a hermetic e2e test proving a ponytail-shaped package deploys a combined manifest to every named target in one install pass.
- Add docs and CHANGELOG notes for the migration-window behavior.

apm-spec-waiver: filename-based hook routing is outside the current OpenAPM v0.1 conformance surface (same rationale as #1902).

### Scenario Evidence

| Scenario | Principle | Evidence |
|---|---|---|
| `claude-codex-hooks.json` deploys to Claude and Codex in one install pass. | multi-harness-support | `tests/integration/test_hook_routing_combined_manifest_e2e.py::test_combined_manifest_deploys_to_all_named_targets_in_one_install_pass` |
| Claude receives the Claude-shaped combined manifest instead of the universal Copilot-shaped fallback. | multi-harness-support | `tests/integration/test_hook_routing_combined_manifest_e2e.py::test_claude_target_gets_combined_manifest_not_universal_copilot_fallback` |
| Prefixed combined stems still route to every trailing named target token. | devx | `tests/unit/integration/test_hook_file_routing_combined_stems.py::test_hook_file_allowed_targets` |
| Target tokens outside the trailing suffix warn before fallback routing. | devx | `tests/unit/integration/test_hook_file_routing_combined_stems.py::test_known_token_outside_target_suffix_warns_when_routed_to_last_token` |

How to test:

- `uv run --extra dev pytest tests/unit/integration/test_hook_file_routing_combined_stems.py tests/integration/test_hook_routing_combined_manifest_e2e.py -q`
- Regressions: `uv run --extra dev pytest tests/integration/test_hook_integrator_copilot_casing_e2e.py tests/unit/integration/test_hook_integrator_issue1892.py -q`
- Full local suite: `uv run --extra dev pytest -q` (`29466 skipped, 173 deselected in 14.59s` in this worktree; integration tests are marker-gated by default)
- Mutation-break gate: disabling the combined suffix union made `test_combined_manifest_deploys_to_all_named_targets_in_one_install_pass` fail with Claude receiving `sessionStart`; disabling unresolved-token warnings made both warning tests fail; guards restored.
- Real package: `apm install DietrichGebert/ponytail -t claude` from this branch writes `SessionStart`/`SubagentStart`/`UserPromptSubmit` with matcher/hooks nesting and no Copilot field names.

Note: this fixes manifest selection only. ponytail's hook scripts can still fail at runtime because deployed entry scripts are copied without their `require()`d sibling files and inherit the consumer project's `package.json` module type; filing separately.

Closes #2020