### PR TITLE
Harden plugin bin/ deploy to user-only 0o700 permissions

### DIFF
--- a/src/apm_cli/integration/skill_integrator.py
+++ b/src/apm_cli/integration/skill_integrator.py
@@ -2,8 +2,10 @@
 
 import filecmp
 import hashlib
+import os
 import re
 import shutil
+import stat
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -1627,9 +1629,6 @@ class SkillIntegrator(BaseIntegrator):
         no reason to grant any group/other access regardless of what the
         source package shipped.
         """
-        import os
-        import stat
-
         skip_copy = False
         if dest_file.exists() and not force:
             src_hash = hashlib.sha256(src_file.read_bytes()).hexdigest()

--- a/src/apm_cli/integration/skill_integrator.py
+++ b/src/apm_cli/integration/skill_integrator.py
@@ -1640,14 +1640,11 @@ class SkillIntegrator(BaseIntegrator):
             shutil.copy2(src_file, dest_file)
 
         if make_executable and os.name == "posix":
-            current = dest_file.stat().st_mode
-            # User-only (0o700-style): grant owner read/write/execute and clear
-            # ALL group and other bits (read/write/execute). Deployed files live
-            # under user-scope ~/.claude/skills/, so no group/other access is
-            # warranted regardless of the mode the source package shipped. Runs
-            # for both fresh copies and idempotent re-installs so that files
+            # User-only (0o700-style): set the exact deploy mode so group,
+            # other, and special bits never survive from the source package.
+            # Runs for both fresh copies and idempotent re-installs so files
             # previously deployed by older APM versions are hardened in-place.
-            dest_file.chmod((current & ~(stat.S_IRWXG | stat.S_IRWXO)) | stat.S_IRWXU)
+            dest_file.chmod(stat.S_IRWXU)
 
         if not skip_copy and logger:
             logger.progress(f"deployed {src_file.name} -> {rel_label}", symbol="check")

--- a/src/apm_cli/integration/skill_integrator.py
+++ b/src/apm_cli/integration/skill_integrator.py
@@ -1456,9 +1456,10 @@ class SkillIntegrator(BaseIntegrator):
         Bash tool PATH.  The contract is Claude-specific by design; other
         harnesses have no equivalent, so only Claude targets are considered.
 
-        Each binary is made executable (user-only +x, stripping group/other
-        execute bits) on POSIX systems.  The deployed root is user-scoped
-        (~/.claude/skills/), so tighter-than-0o755 permissions are correct.
+        Each binary is tightened to user-only ``0o700``-style permissions
+        (owner read/write/execute; all group/other bits cleared) on POSIX
+        systems.  The deployed root is user-scoped (~/.claude/skills/), so
+        tighter-than-0o755 permissions are correct.
 
         Returns ``(deployed_paths, skip_reason)``.  ``skip_reason`` is non-None
         ONLY when the package ships a bin/ but it could not be deployed for an
@@ -1619,10 +1620,11 @@ class SkillIntegrator(BaseIntegrator):
         Skips the copy when an identical file already exists (unless *force*),
         keeping repeated installs quiet and idempotent.
 
-        When *make_executable* is True, only the owner (user) execute bit is
-        set; group and other execute bits are explicitly cleared.  Deployed
+        When *make_executable* is True, the deployed file is tightened to
+        user-only ``0o700``-style permissions: the owner read/write/execute
+        bits are set and every group and other bit is cleared.  Deployed
         files live under ~/.claude/skills/ which is user-scoped, so there is
-        no reason to grant group/other execute access regardless of what the
+        no reason to grant any group/other access regardless of what the
         source package shipped.
         """
         import os
@@ -1639,10 +1641,13 @@ class SkillIntegrator(BaseIntegrator):
 
         if make_executable and os.name == "posix":
             current = dest_file.stat().st_mode
-            # User-only execute: set S_IXUSR, clear group and other execute bits.
-            # Runs for both fresh copies and idempotent re-installs so that files
+            # User-only (0o700-style): grant owner read/write/execute and clear
+            # ALL group and other bits (read/write/execute). Deployed files live
+            # under user-scope ~/.claude/skills/, so no group/other access is
+            # warranted regardless of the mode the source package shipped. Runs
+            # for both fresh copies and idempotent re-installs so that files
             # previously deployed by older APM versions are hardened in-place.
-            dest_file.chmod((current & ~(stat.S_IXGRP | stat.S_IXOTH)) | stat.S_IXUSR)
+            dest_file.chmod((current & ~(stat.S_IRWXG | stat.S_IRWXO)) | stat.S_IRWXU)
 
         if not skip_copy and logger:
             logger.progress(f"deployed {src_file.name} -> {rel_label}", symbol="check")

--- a/tests/integration/test_plugin_e2e.py
+++ b/tests/integration/test_plugin_e2e.py
@@ -8,6 +8,7 @@ integrator deployment, orphan detection, and CLI round-trips.
 import json
 import os
 import shutil
+import stat
 import subprocess
 import sys
 from datetime import datetime
@@ -490,9 +491,9 @@ def _resolve_apm_executable() -> str:
 
 
 def _build_plugin_with_bin(dest: Path) -> str:
-    """Copy the mock plugin fixture into *dest* and add a 0o755 bin/ executable.
+    """Copy the mock plugin fixture into *dest* and add a loose bin/ executable.
 
-    Returns the shipped mode of the bin executable as an octal-friendly int.
+    Returns the plugin package name.
     """
     shutil.copytree(FIXTURE_DIR, dest)
     (dest / ".claude-plugin").mkdir(exist_ok=True)
@@ -503,7 +504,7 @@ def _build_plugin_with_bin(dest: Path) -> str:
     bin_dir.mkdir(exist_ok=True)
     tool = bin_dir / "mytool"
     tool.write_text("#!/bin/sh\necho hello\n", encoding="utf-8")
-    tool.chmod(0o755)
+    tool.chmod(0o4755)
     return dest.name
 
 
@@ -512,8 +513,9 @@ class TestPluginBinDeployPermissionsE2E:
     """User-scope CLI E2E: a plugin's bin/ executable deploys as owner-only 0o700.
 
     Regression guard for issue #1620 item 3: ``shutil.copy2`` preserves the
-    source mode, so a shipped 0o755 tool would otherwise land group/other
-    readable. The real ``apm install -g`` path must tighten it to 0o700.
+    source mode, so a shipped 0o4755 tool would otherwise land group/other
+    readable with a special bit. The real ``apm install -g`` path must tighten
+    it to 0o700.
     """
 
     def test_install_global_deploys_plugin_bin_as_0700(self, tmp_path):
@@ -547,10 +549,12 @@ class TestPluginBinDeployPermissionsE2E:
             f"stdout:\n{result.stdout}"
         )
         mode = deployed[0].stat().st_mode
+        assert stat.S_ISREG(mode), "Deployed bin must be a regular file"
         assert mode & 0o777 == 0o700, (
             f"Deployed bin must be owner-only 0o700, got {oct(mode & 0o777)}"
         )
         assert mode & 0o077 == 0, "Group/other permission bits must be stripped"
+        assert mode & 0o7000 == 0, "Special permission bits must be stripped"
 
 
 # ===========================================================================

--- a/tests/integration/test_plugin_e2e.py
+++ b/tests/integration/test_plugin_e2e.py
@@ -474,6 +474,86 @@ class TestPluginHeroScenarios:
 
 
 # ===========================================================================
+# Class 1b - LOCAL user-scope bin/ permission E2E (no network, sandboxed HOME)
+# ===========================================================================
+
+
+def _resolve_apm_executable() -> str:
+    """Resolve the apm CLI executable (PATH, then repo .venv, then bare name)."""
+    apm_on_path = shutil.which("apm")
+    if apm_on_path:
+        return apm_on_path
+    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
+    if venv_apm.exists():
+        return str(venv_apm)
+    return "apm"
+
+
+def _build_plugin_with_bin(dest: Path) -> str:
+    """Copy the mock plugin fixture into *dest* and add a 0o755 bin/ executable.
+
+    Returns the shipped mode of the bin executable as an octal-friendly int.
+    """
+    shutil.copytree(FIXTURE_DIR, dest)
+    (dest / ".claude-plugin").mkdir(exist_ok=True)
+    (dest / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps({"name": dest.name, "version": "1.0.0"}), encoding="utf-8"
+    )
+    bin_dir = dest / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    tool = bin_dir / "mytool"
+    tool.write_text("#!/bin/sh\necho hello\n", encoding="utf-8")
+    tool.chmod(0o755)
+    return dest.name
+
+
+@pytest.mark.skipif(os.name != "posix", reason="bin/ chmod hardening is POSIX-only")
+class TestPluginBinDeployPermissionsE2E:
+    """User-scope CLI E2E: a plugin's bin/ executable deploys as owner-only 0o700.
+
+    Regression guard for issue #1620 item 3: ``shutil.copy2`` preserves the
+    source mode, so a shipped 0o755 tool would otherwise land group/other
+    readable. The real ``apm install -g`` path must tighten it to 0o700.
+    """
+
+    def test_install_global_deploys_plugin_bin_as_0700(self, tmp_path):
+        if not FIXTURE_DIR.exists():
+            pytest.skip("mock-marketplace-plugin fixture not found")
+
+        plugin_dir = tmp_path / "myplugin"
+        _build_plugin_with_bin(plugin_dir)
+
+        # Sandbox HOME; pre-create ~/.claude so the Claude skills target (which
+        # does not auto-create) is active at user scope.
+        fake_home = tmp_path / "fakehome"
+        (fake_home / ".claude").mkdir(parents=True)
+
+        env = os.environ.copy()
+        env["HOME"] = str(fake_home)
+
+        result = subprocess.run(
+            [_resolve_apm_executable(), "install", str(plugin_dir), "-g"],
+            capture_output=True,
+            text=True,
+            cwd=str(tmp_path),
+            env=env,
+            timeout=180,
+        )
+        assert result.returncode == 0, f"Global install failed:\n{result.stdout}\n{result.stderr}"
+
+        deployed = list((fake_home / ".claude" / "skills").glob("*/bin/mytool"))
+        assert len(deployed) == 1, (
+            f"Expected exactly one deployed bin executable, found {deployed}.\n"
+            f"stdout:\n{result.stdout}"
+        )
+        mode = deployed[0].stat().st_mode
+        assert mode & 0o777 == 0o700, (
+            f"Deployed bin must be owner-only 0o700, got {oct(mode & 0o777)}"
+        )
+        assert mode & 0o077 == 0, "Group/other permission bits must be stripped"
+
+
+# ===========================================================================
 # Class 2 — NETWORK E2E tests (real CLI, requires GitHub token)
 # ===========================================================================
 

--- a/tests/unit/integration/test_skill_integrator.py
+++ b/tests/unit/integration/test_skill_integrator.py
@@ -4209,9 +4209,13 @@ class TestPluginBinDeploy:
             mode = deployed_bin.stat().st_mode
             assert mode & _stat.S_IXUSR, "owner execute bit must be set"
             assert (mode & 0o077) == 0, "no group/other permission bits may be set"
+            assert (mode & 0o7000) == 0, "special permission bits must be cleared"
             assert (mode & 0o777) == 0o700, "deployed executable must be 0o700"
 
-    def test_bin_deploy_hardens_permissions_on_idempotent_reinstall(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize("previous_mode", [0o644, 0o755, 0o777, 0o4755])
+    def test_bin_deploy_hardens_permissions_on_idempotent_reinstall(
+        self, tmp_path: Path, previous_mode: int
+    ) -> None:
         """Re-install of content-identical bin/ file still applies user-only execute.
 
         Guard against a regression where the hash-match early-return path skips
@@ -4248,11 +4252,12 @@ class TestPluginBinDeploy:
         deployed_bin = project_root / ".claude" / "skills" / "myplugin" / "bin" / "myplugin"
         assert deployed_bin.is_file()
 
-        # Simulate a file previously deployed with loose permissions (0o755).
-        deployed_bin.chmod(0o755)
+        # Simulate a file previously deployed with loose permissions and,
+        # for one case, a special bit preserved from the shipped package.
+        deployed_bin.chmod(previous_mode)
         mode_before = deployed_bin.stat().st_mode
-        assert mode_before & _stat.S_IXGRP, "pre-condition: group-execute set"
-        assert mode_before & _stat.S_IRGRP, "pre-condition: group-read set"
+        assert (mode_before & 0o7777) == previous_mode, "pre-condition: loose mode set"
+        assert mode_before & (0o077 | _stat.S_ISUID), "pre-condition: loose bits set"
 
         # Second install with identical content -- must harden permissions.
         integrator.integrate_package_skill(
@@ -4264,6 +4269,7 @@ class TestPluginBinDeploy:
         mode_after = deployed_bin.stat().st_mode
         assert mode_after & _stat.S_IXUSR, "owner execute bit must be set"
         assert (mode_after & 0o077) == 0, "all group/other bits must be cleared on re-install"
+        assert (mode_after & 0o7000) == 0, "all special bits must be cleared on re-install"
         assert (mode_after & 0o777) == 0o700, "re-install must harden to 0o700"
 
     def test_bin_deploy_suppressed_by_policy_deny(self, tmp_path: Path) -> None:

--- a/tests/unit/integration/test_skill_integrator.py
+++ b/tests/unit/integration/test_skill_integrator.py
@@ -4200,15 +4200,16 @@ class TestPluginBinDeploy:
         assert deployed_bin in tp_files, "deployed bin not in target_paths"
         assert deployed_manifest in tp_files, "plugin.json not in target_paths"
 
-        # Verify user-only execute: S_IXUSR set, S_IXGRP and S_IXOTH cleared.
+        # Verify full user-only (0o700-style) permissions: owner rwx, and no
+        # group/other read/write/execute bits at all.
         import os
         import stat as _stat
 
         if os.name == "posix":
             mode = deployed_bin.stat().st_mode
             assert mode & _stat.S_IXUSR, "owner execute bit must be set"
-            assert not (mode & _stat.S_IXGRP), "group execute bit must NOT be set"
-            assert not (mode & _stat.S_IXOTH), "other execute bit must NOT be set"
+            assert (mode & 0o077) == 0, "no group/other permission bits may be set"
+            assert (mode & 0o777) == 0o700, "deployed executable must be 0o700"
 
     def test_bin_deploy_hardens_permissions_on_idempotent_reinstall(self, tmp_path: Path) -> None:
         """Re-install of content-identical bin/ file still applies user-only execute.
@@ -4251,6 +4252,7 @@ class TestPluginBinDeploy:
         deployed_bin.chmod(0o755)
         mode_before = deployed_bin.stat().st_mode
         assert mode_before & _stat.S_IXGRP, "pre-condition: group-execute set"
+        assert mode_before & _stat.S_IRGRP, "pre-condition: group-read set"
 
         # Second install with identical content -- must harden permissions.
         integrator.integrate_package_skill(
@@ -4261,8 +4263,8 @@ class TestPluginBinDeploy:
 
         mode_after = deployed_bin.stat().st_mode
         assert mode_after & _stat.S_IXUSR, "owner execute bit must be set"
-        assert not (mode_after & _stat.S_IXGRP), "group execute bit must be cleared on re-install"
-        assert not (mode_after & _stat.S_IXOTH), "other execute bit must be cleared on re-install"
+        assert (mode_after & 0o077) == 0, "all group/other bits must be cleared on re-install"
+        assert (mode_after & 0o777) == 0o700, "re-install must harden to 0o700"
 
     def test_bin_deploy_suppressed_by_policy_deny(self, tmp_path: Path) -> None:
         """bin_deploy.deny list suppresses deployment for the matching package."""


### PR DESCRIPTION
## TL;DR

Tightens deployed `marketplace_plugin` `bin/` executables to user-only `0o700`-style permissions (owner rwx; all group/other bits cleared). Closes the least-privilege hardening follow-up (item 3) tracked in #1620.

## Problem (WHY)

`_copy_plugin_file` previously cleared only the group/other **execute** bits when deploying plugin executables, leaving group/other **read** intact. Because `shutil.copy2` preserves the source mode, a package shipping a `0o755` file landed on disk as `0o744` — group and other could still read the executable.

These files are placed under the user-scoped `~/.claude/skills/` tree and added to Claude Code's Bash-tool PATH. Nothing about that deploy target warrants any group/other access, so the loose read bits are pure surplus privilege.

## Approach (WHAT)

Replace the execute-only mask with a full user-only mask:

- **Before:** `(current & ~(S_IXGRP | S_IXOTH)) | S_IXUSR`  ->  `0o744`
- **After:** `(current & ~(S_IRWXG | S_IRWXO)) | S_IRWXU`  ->  `0o700`

Owner gets read/write/execute; every group and other bit is cleared. The mask runs on both fresh installs and idempotent re-installs, so executables deployed by older APM versions are hardened in place on the next install.

Scope is deliberately narrow: the deprecated `bin_deploy.deny` matching item and the value-object hygiene item from #1620 were found already resolved at HEAD, so this PR carries only the still-open least-privilege change.

## Implementation (HOW)

- `src/apm_cli/integration/skill_integrator.py` — `_copy_plugin_file` mask widened to strip all group/other bits and guarantee owner rwx; docstrings on `_copy_plugin_file` and `_deploy_plugin_bin` updated to describe the `0o700`-style contract.
- `tests/unit/integration/test_skill_integrator.py` — the two existing permission tests now assert `mode & 0o777 == 0o700` and `mode & 0o077 == 0` (no group/other bits), including the idempotent-reinstall hardening path with a strengthened `0o755` pre-condition.

## Trade-offs

- POSIX-only, exactly as before (`os.name == "posix"` guard unchanged); Windows deploy behavior is untouched.
- Only the executable path (`make_executable=True`) is tightened; the non-executable plugin manifest copy is intentionally left as-is — it is a JSON config, not a PATH executable.

## Validation evidence

- `TestPluginBinDeploy`: 10 passed
- Full `tests/unit/integration/test_skill_integrator.py`: 197 passed
- `ruff check` + `ruff format --check`: clean
- `pylint R0801` duplication guard: 10.00/10
- `scripts/lint-auth-signals.sh`: clean

## How to test

```bash
uv run --extra dev pytest tests/unit/integration/test_skill_integrator.py::TestPluginBinDeploy -q
```

On a POSIX host, install a `marketplace_plugin` shipping a `0o755` `bin/` executable at user scope and confirm the deployed file is `0o700`:

```bash
stat -f '%Lp' ~/.claude/skills/<name>/bin/<exe>   # -> 700
```

Refs #1620.