### PR TITLE
fix(hooks): deploy self-contained hook scripts with siblings and package module type (closes #2023)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm install` now deploys hook script directories as self-contained
+  bundles for Claude-family targets, Copilot, and Kiro, so sibling
+  helper modules resolve at runtime. JavaScript and TypeScript hook
+  bundles also get a minimal module-type `package.json` sidecar, which
+  prevents a consumer repo's `type: module` from breaking CommonJS hooks.
+  (#2023)
 - `apm audit --help` now accurately describes the command's full scope:
   hidden Unicode scanning, drift detection, and lockfile/policy checks.
   The previous summary named only Unicode scanning and used the legacy

--- a/docs/src/content/docs/producer/author-primitives/hooks-and-commands.md
+++ b/docs/src/content/docs/producer/author-primitives/hooks-and-commands.md
@@ -86,14 +86,17 @@ file lives in `hooks/` or `.apm/hooks/`, a path like
 path is not doubled.
 
 When a hook command points at a script inside a package hook directory,
-APM deploys the hook source bundle for Claude-family targets, Copilot,
-and Kiro so sibling helper modules stay available at runtime. Root hook
-JSON descriptors, symlinks, and `.apm-pin` markers are not deployed. For
-JavaScript and TypeScript hook bundles, APM writes a minimal
-`package.json` beside the deployed scripts with the nearest source
-package's Node `type`; packages without an explicit `type` deploy as
-`commonjs` so the consumer repo's `package.json` cannot change hook
-module semantics. Shell-only bundles do not get a sidecar.
+APM deploys the hook source bundle so sibling helper modules stay
+available at runtime:
+
+- Claude-family merged targets (Claude, Cursor, Codex, Gemini,
+  Antigravity, and Windsurf), Copilot, and Kiro receive the same bundle.
+- Root hook JSON descriptors, symlinks, and `.apm-pin` markers are not
+  deployed.
+- JavaScript and TypeScript hook bundles get a minimal `package.json`
+  sidecar with the nearest source package's Node `type`; packages
+  without an explicit `type` deploy as `commonjs`, and shell-only
+  bundles do not get a sidecar.
 
 For multi-target packages, prefer simple hook filenames plus consumer
 per-dependency `targets:` in `dependencies.apm` to limit reach. If the

--- a/docs/src/content/docs/producer/author-primitives/hooks-and-commands.md
+++ b/docs/src/content/docs/producer/author-primitives/hooks-and-commands.md
@@ -85,6 +85,13 @@ file lives in `hooks/` or `.apm/hooks/`, a path like
 `./hooks/run-hook.sh` resolves from the package root so the deployed
 path is not doubled.
 
+When a hook command points at a script inside a package hook directory,
+APM deploys that whole hook directory so sibling helper modules stay
+available at runtime. It also writes a minimal `package.json` beside the
+deployed scripts with the source package's Node `type`; packages without
+an explicit `type` deploy as `commonjs` so the consumer repo's
+`package.json` cannot change hook module semantics.
+
 For multi-target packages, prefer simple hook filenames plus consumer
 per-dependency `targets:` in `dependencies.apm` to limit reach. If the
 same manifest stem is mirrored in both `hooks/` and `.apm/hooks/`, APM

--- a/docs/src/content/docs/producer/author-primitives/hooks-and-commands.md
+++ b/docs/src/content/docs/producer/author-primitives/hooks-and-commands.md
@@ -86,11 +86,14 @@ file lives in `hooks/` or `.apm/hooks/`, a path like
 path is not doubled.
 
 When a hook command points at a script inside a package hook directory,
-APM deploys that whole hook directory so sibling helper modules stay
-available at runtime. It also writes a minimal `package.json` beside the
-deployed scripts with the source package's Node `type`; packages without
-an explicit `type` deploy as `commonjs` so the consumer repo's
-`package.json` cannot change hook module semantics.
+APM deploys the hook source bundle for Claude-family targets, Copilot,
+and Kiro so sibling helper modules stay available at runtime. Root hook
+JSON descriptors, symlinks, and `.apm-pin` markers are not deployed. For
+JavaScript and TypeScript hook bundles, APM writes a minimal
+`package.json` beside the deployed scripts with the nearest source
+package's Node `type`; packages without an explicit `type` deploy as
+`commonjs` so the consumer repo's `package.json` cannot change hook
+module semantics. Shell-only bundles do not get a sidecar.
 
 For multi-target packages, prefer simple hook filenames plus consumer
 per-dependency `targets:` in `dependencies.apm` to limit reach. If the

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -128,8 +128,10 @@ hook action under `.kiro/hooks/`.
 
 When a hook command references a script inside `hooks/` or `.apm/hooks/`,
 APM deploys that hook source bundle so sibling helper files resolve at
-runtime. Root hook JSON descriptors, symlinks, and `.apm-pin` markers are
-not deployed. JavaScript and TypeScript hook bundles get a minimal
+runtime. Claude-family merged targets (Claude, Cursor, Codex, Gemini,
+Antigravity, and Windsurf), Copilot, and Kiro receive the same bundle.
+Root hook JSON descriptors, symlinks, and `.apm-pin` markers are not
+deployed. JavaScript and TypeScript hook bundles get a minimal
 `package.json` sidecar with the source package's Node `type` (defaulting
 to `commonjs`); shell-only bundles do not get a sidecar.
 

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -126,6 +126,13 @@ becomes `PostToolUse` in Claude) and rewrites path variables
 the correct target-specific form. Kiro materializes one JSON document per
 hook action under `.kiro/hooks/`.
 
+When a hook command references a script inside `hooks/` or `.apm/hooks/`,
+APM deploys that hook source bundle so sibling helper files resolve at
+runtime. Root hook JSON descriptors, symlinks, and `.apm-pin` markers are
+not deployed. JavaScript and TypeScript hook bundles get a minimal
+`package.json` sidecar with the source package's Node `type` (defaulting
+to `commonjs`); shell-only bundles do not get a sidecar.
+
 ### Hook command paths: project-scope stays repo-relative
 
 `apm install` (project-scope, no `-g`) keeps hook `command` paths

--- a/src/apm_cli/integration/hook_bundle.py
+++ b/src/apm_cli/integration/hook_bundle.py
@@ -5,9 +5,12 @@ import shutil
 from dataclasses import dataclass
 from pathlib import Path
 
+from apm_cli.install.cache_pin import MARKER_FILENAME
 from apm_cli.integration.base_integrator import BaseIntegrator
 from apm_cli.utils.path_security import ensure_path_within
 from apm_cli.utils.paths import portable_relpath
+
+_HOOK_SCRIPT_EXTENSIONS = {".js", ".mjs", ".cjs", ".ts"}
 
 
 @dataclass
@@ -80,6 +83,18 @@ def _same_text(path: Path, content: str) -> bool:
         return False
 
 
+def _is_root_hook_descriptor(
+    source_file: Path, source_root: Path, descriptor_files: set[Path]
+) -> bool:
+    """Return True for root-level hook manifests that should not deploy."""
+    if source_file in descriptor_files:
+        return True
+    if source_file.parent != source_root or source_file.suffix.lower() != ".json":
+        return False
+    stem = source_file.stem.lower()
+    return stem == "hooks" or stem.startswith("hooks-") or stem.endswith("-hooks")
+
+
 def copy_deployed_hook_bundle(
     integrator: BaseIntegrator,
     *,
@@ -91,11 +106,14 @@ def copy_deployed_hook_bundle(
     force: bool,
     diagnostics=None,
     target_paths: list[Path],
+    hook_descriptor_files: set[Path] | None = None,
 ) -> HookBundleCopyResult:
     """Copy each referenced script's whole hooks root and module type."""
     result = HookBundleCopyResult()
     source_target_roots: dict[tuple[Path, Path], str] = {}
+    root_has_js_hook: dict[tuple[Path, Path], bool] = {}
     command_target_rels = {target_rel for _source_file, target_rel in scripts}
+    descriptor_files = hook_descriptor_files or set()
 
     for source_file, target_rel in scripts:
         target_script = project_root / target_rel
@@ -109,15 +127,23 @@ def copy_deployed_hook_bundle(
             package_path,
             source_root,
         )
+        root_has_js_hook.setdefault((source_root, target_root), False)
 
     copy_plan: dict[str, Path] = {}
     for source_root, target_root in source_target_roots:
         for source_file in sorted(source_root.rglob("*")):
-            if not source_file.is_file() or source_file.name == "package.json":
+            if (
+                source_file.is_symlink()
+                or not source_file.is_file()
+                or source_file.name in {"package.json", MARKER_FILENAME}
+                or _is_root_hook_descriptor(source_file, source_root, descriptor_files)
+            ):
                 continue
             source_rel = source_file.relative_to(source_root)
             target_file = target_root / source_rel
             copy_plan[portable_relpath(target_file, project_root)] = source_file
+            if source_file.suffix.lower() in _HOOK_SCRIPT_EXTENSIONS:
+                root_has_js_hook[(source_root, target_root)] = True
 
     for target_rel, source_file in copy_plan.items():
         target_file = project_root / target_rel
@@ -141,6 +167,8 @@ def copy_deployed_hook_bundle(
         target_paths.append(target_file)
 
     for (_source_root, target_root), module_type in source_target_roots.items():
+        if not root_has_js_hook.get((_source_root, target_root), False):
+            continue
         target_file = target_root / "package.json"
         target_rel = portable_relpath(target_file, project_root)
         ensure_path_within(target_file, project_root)

--- a/src/apm_cli/integration/hook_bundle.py
+++ b/src/apm_cli/integration/hook_bundle.py
@@ -1,0 +1,163 @@
+"""Helpers for deploying hook script bundles."""
+
+import json
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from apm_cli.integration.base_integrator import BaseIntegrator
+from apm_cli.utils.path_security import ensure_path_within
+from apm_cli.utils.paths import portable_relpath
+
+
+@dataclass
+class HookBundleCopyResult:
+    """Counters for deployed hook bundle file copies."""
+
+    scripts_copied: int = 0
+    files_adopted: int = 0
+
+
+def _hook_source_root(
+    package_path: Path,
+    hook_file_dir: Path | None,
+    source_file: Path,
+) -> Path:
+    """Return the hooks directory that should deploy with a script."""
+    candidates: list[Path] = []
+    if hook_file_dir is not None:
+        candidates.append(hook_file_dir)
+    candidates.extend((package_path / "hooks", package_path / ".apm" / "hooks"))
+
+    seen: set[Path] = set()
+    for candidate in candidates:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        try:
+            source_file.relative_to(candidate)
+        except ValueError:
+            continue
+        return candidate
+    return source_file.parent
+
+
+def _target_root_for_hook_source(
+    target_script: Path,
+    source_file: Path,
+    source_root: Path,
+) -> Path:
+    """Return the deployed directory corresponding to a source hooks root."""
+    source_rel = source_file.relative_to(source_root)
+    target_root = target_script
+    for _part in source_rel.parts:
+        target_root = target_root.parent
+    return target_root
+
+
+def _hook_module_type(package_path: Path, hook_source_root: Path) -> str:
+    """Return the Node module type that governs a source hooks root."""
+    current = hook_source_root
+    while True:
+        package_json = current / "package.json"
+        if package_json.exists():
+            try:
+                data = json.loads(package_json.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                return "commonjs"
+            package_type = data.get("type") if isinstance(data, dict) else None
+            return package_type if package_type in {"commonjs", "module"} else "commonjs"
+        if current in (package_path, current.parent):
+            return "commonjs"
+        current = current.parent
+
+
+def _same_text(path: Path, content: str) -> bool:
+    """Return True when path already contains content."""
+    try:
+        return path.read_text(encoding="utf-8") == content
+    except OSError:
+        return False
+
+
+def copy_deployed_hook_bundle(
+    integrator: BaseIntegrator,
+    *,
+    package_path: Path,
+    hook_file_dir: Path | None,
+    project_root: Path,
+    scripts: list[tuple[Path, str]],
+    managed_files: set | None,
+    force: bool,
+    diagnostics=None,
+    target_paths: list[Path],
+) -> HookBundleCopyResult:
+    """Copy each referenced script's whole hooks root and module type."""
+    result = HookBundleCopyResult()
+    source_target_roots: dict[tuple[Path, Path], str] = {}
+    command_target_rels = {target_rel for _source_file, target_rel in scripts}
+
+    for source_file, target_rel in scripts:
+        target_script = project_root / target_rel
+        source_root = _hook_source_root(package_path, hook_file_dir, source_file)
+        target_root = _target_root_for_hook_source(
+            target_script,
+            source_file,
+            source_root,
+        )
+        source_target_roots[(source_root, target_root)] = _hook_module_type(
+            package_path,
+            source_root,
+        )
+
+    copy_plan: dict[str, Path] = {}
+    for source_root, target_root in source_target_roots:
+        for source_file in sorted(source_root.rglob("*")):
+            if not source_file.is_file() or source_file.name == "package.json":
+                continue
+            source_rel = source_file.relative_to(source_root)
+            target_file = target_root / source_rel
+            copy_plan[portable_relpath(target_file, project_root)] = source_file
+
+    for target_rel, source_file in copy_plan.items():
+        target_file = project_root / target_rel
+        ensure_path_within(target_file, project_root)
+        if integrator.try_adopt_identical(target_file, source_file, target_paths):
+            if target_rel in command_target_rels:
+                result.files_adopted += 1
+            continue
+        if integrator.check_collision(
+            target_file,
+            target_rel,
+            managed_files,
+            force,
+            diagnostics=diagnostics,
+        ):
+            continue
+        target_file.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_file, target_file)
+        if target_rel in command_target_rels:
+            result.scripts_copied += 1
+        target_paths.append(target_file)
+
+    for (_source_root, target_root), module_type in source_target_roots.items():
+        target_file = target_root / "package.json"
+        target_rel = portable_relpath(target_file, project_root)
+        ensure_path_within(target_file, project_root)
+        content = json.dumps({"type": module_type}, indent=2, sort_keys=True) + "\n"
+        if target_file.exists() and _same_text(target_file, content):
+            target_paths.append(target_file)
+            continue
+        if integrator.check_collision(
+            target_file,
+            target_rel,
+            managed_files,
+            force,
+            diagnostics=diagnostics,
+        ):
+            continue
+        target_file.parent.mkdir(parents=True, exist_ok=True)
+        target_file.write_text(content, encoding="utf-8")
+        target_paths.append(target_file)
+
+    return result

--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -1309,6 +1309,7 @@ class HookIntegrator(BaseIntegrator):
                 force=force,
                 diagnostics=diagnostics,
                 target_paths=target_paths,
+                hook_descriptor_files=set(hook_files),
             )
             scripts_copied += copy_result.scripts_copied
             scripts_adopted += copy_result.files_adopted
@@ -1656,6 +1657,7 @@ class HookIntegrator(BaseIntegrator):
                 force=force,
                 diagnostics=diagnostics,
                 target_paths=target_paths,
+                hook_descriptor_files=set(hook_files),
             )
             scripts_copied += copy_result.scripts_copied
             scripts_adopted += copy_result.files_adopted

--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -47,7 +47,6 @@ Script path handling:
 import json
 import logging
 import re
-import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -55,6 +54,7 @@ from typing import Any
 import yaml
 
 from apm_cli.integration.base_integrator import BaseIntegrator, IntegrationResult
+from apm_cli.integration.hook_bundle import copy_deployed_hook_bundle
 from apm_cli.integration.hook_file_routing import filter_hook_files_for_target
 from apm_cli.utils.console import _rich_warning
 from apm_cli.utils.path_security import (
@@ -1299,21 +1299,19 @@ class HookIntegrator(BaseIntegrator):
                 )
             )
 
-            # Copy referenced scripts (individual file tracking)
-            for source_file, target_rel in scripts:
-                target_script = project_root / target_rel
-                ensure_path_within(target_script, project_root)
-                if self.try_adopt_identical(target_script, source_file, target_paths):
-                    scripts_adopted += 1
-                    continue
-                if self.check_collision(
-                    target_script, target_rel, managed_files, force, diagnostics=diagnostics
-                ):
-                    continue
-                target_script.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(source_file, target_script)
-                scripts_copied += 1
-                target_paths.append(target_script)
+            copy_result = copy_deployed_hook_bundle(
+                self,
+                package_path=package_info.install_path,
+                hook_file_dir=hook_file.parent,
+                project_root=project_root,
+                scripts=scripts,
+                managed_files=managed_files,
+                force=force,
+                diagnostics=diagnostics,
+                target_paths=target_paths,
+            )
+            scripts_copied += copy_result.scripts_copied
+            scripts_adopted += copy_result.files_adopted
 
         return HookIntegrationResult(
             files_integrated=hooks_integrated,
@@ -1648,25 +1646,19 @@ class HookIntegrator(BaseIntegrator):
                     config.target_key,
                 )
 
-            # Copy referenced scripts
-            for source_file, target_rel in scripts:
-                target_script = project_root / target_rel
-                ensure_path_within(target_script, project_root)
-                if self.try_adopt_identical(target_script, source_file, target_paths):
-                    scripts_adopted += 1
-                    continue
-                if self.check_collision(
-                    target_script,
-                    target_rel,
-                    managed_files,
-                    force,
-                    diagnostics=diagnostics,
-                ):
-                    continue
-                target_script.parent.mkdir(parents=True, exist_ok=True)
-                shutil.copy2(source_file, target_script)
-                scripts_copied += 1
-                target_paths.append(target_script)
+            copy_result = copy_deployed_hook_bundle(
+                self,
+                package_path=package_info.install_path,
+                hook_file_dir=hook_file.parent,
+                project_root=project_root,
+                scripts=scripts,
+                managed_files=managed_files,
+                force=force,
+                diagnostics=diagnostics,
+                target_paths=target_paths,
+            )
+            scripts_copied += copy_result.scripts_copied
+            scripts_adopted += copy_result.files_adopted
 
         # Write JSON config back
         # Don't track the config file in target_paths -- it's a shared

--- a/src/apm_cli/integration/kiro_hook_integrator.py
+++ b/src/apm_cli/integration/kiro_hook_integrator.py
@@ -10,10 +10,10 @@ from __future__ import annotations
 import json
 import os
 import re
-import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from apm_cli.integration.hook_bundle import copy_deployed_hook_bundle
 from apm_cli.integration.hook_integrator import (
     _HOOK_EVENT_MAP,
     HookIntegrationResult,
@@ -210,34 +210,29 @@ def _display_payload(
 def _copy_scripts(
     integrator: HookIntegrator,
     scripts,
+    package_path: Path,
+    hook_file_dir: Path,
     project_root: Path,
     managed_files,
     force: bool,
     diagnostics,
     target_paths: list[Path],
+    hook_descriptor_files: set[Path],
 ) -> tuple[int, int]:
     """Copy Kiro hook scripts and return copied/adopted counts."""
-    scripts_copied = 0
-    scripts_adopted = 0
-    for source_file, target_rel in scripts:
-        target_script = project_root / target_rel
-        ensure_path_within(target_script, project_root)
-        if integrator.try_adopt_identical(target_script, source_file, target_paths):
-            scripts_adopted += 1
-            continue
-        if integrator.check_collision(
-            target_script,
-            target_rel,
-            managed_files,
-            force,
-            diagnostics=diagnostics,
-        ):
-            continue
-        target_script.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(source_file, target_script)
-        scripts_copied += 1
-        target_paths.append(target_script)
-    return scripts_copied, scripts_adopted
+    copy_result = copy_deployed_hook_bundle(
+        integrator,
+        package_path=package_path,
+        hook_file_dir=hook_file_dir,
+        project_root=project_root,
+        scripts=scripts,
+        managed_files=managed_files,
+        force=force,
+        diagnostics=diagnostics,
+        target_paths=target_paths,
+        hook_descriptor_files=hook_descriptor_files,
+    )
+    return copy_result.scripts_copied, copy_result.files_adopted
 
 
 def integrate_kiro_hooks(
@@ -314,7 +309,16 @@ def integrate_kiro_hooks(
         files_skipped += skipped
         files_adopted += adopted
         copied, adopted_scripts = _copy_scripts(
-            integrator, scripts, project_root, managed_files, force, diagnostics, target_paths
+            integrator,
+            scripts,
+            package_info.install_path,
+            hook_file.parent,
+            project_root,
+            managed_files,
+            force,
+            diagnostics,
+            target_paths,
+            set(hook_files),
         )
         scripts_copied += copied
         scripts_adopted += adopted_scripts

--- a/tests/unit/integration/test_hook_integrator_defect_regression.py
+++ b/tests/unit/integration/test_hook_integrator_defect_regression.py
@@ -170,3 +170,64 @@ def test_claude_hook_script_path_no_doubling(tmp_path: Path) -> None:
     command = settings["hooks"]["SessionStart"][0]["hooks"][0]["command"]
     assert command == ".claude/hooks/superpowers/hooks/run-hook.cmd start"
     assert (project / ".claude" / "hooks" / "superpowers" / "hooks" / "run-hook.cmd").exists()
+
+
+def _setup_commonjs_hook_package(
+    tmp_path: Path, target_manifest: str = "hooks.json"
+) -> PackageInfo:
+    package_path = tmp_path / "ponytail"
+    hooks_dir = package_path / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (package_path / "package.json").write_text(
+        json.dumps({"type": "commonjs"}),
+        encoding="utf-8",
+    )
+    (hooks_dir / "ponytail.js").write_text(
+        "const config = require('./ponytail-config');\nconsole.log(config.message);\n",
+        encoding="utf-8",
+    )
+    (hooks_dir / "ponytail-config.js").write_text(
+        "module.exports = { message: 'ok' };\n",
+        encoding="utf-8",
+    )
+    (hooks_dir / target_manifest).write_text(
+        json.dumps(_session_start_hook("${CLAUDE_PLUGIN_ROOT}/hooks/ponytail.js session-start")),
+        encoding="utf-8",
+    )
+    return _package_info(package_path, "ponytail")
+
+
+def test_claude_deploys_hook_directory_siblings_and_package_module_type(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "package.json").write_text(json.dumps({"type": "module"}), encoding="utf-8")
+    pkg_info = _setup_commonjs_hook_package(tmp_path)
+
+    HookIntegrator().integrate_package_hooks_claude(pkg_info, project)
+
+    deployed_script = project / ".claude" / "hooks" / "ponytail" / "hooks" / "ponytail.js"
+    deployed_package_json = deployed_script.parent / "package.json"
+    assert deployed_script.exists()
+    assert (deployed_script.parent / "ponytail-config.js").exists()
+    assert json.loads(deployed_package_json.read_text(encoding="utf-8")) == {"type": "commonjs"}
+
+
+def test_copilot_deploys_hook_directory_siblings_and_package_module_type(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / "package.json").write_text(json.dumps({"type": "module"}), encoding="utf-8")
+    pkg_info = _setup_commonjs_hook_package(tmp_path, "hooks-copilot.json")
+
+    HookIntegrator().integrate_package_hooks(pkg_info, project)
+
+    deployed_script = (
+        project / ".github" / "hooks" / "scripts" / "ponytail" / "hooks" / "ponytail.js"
+    )
+    deployed_package_json = deployed_script.parent / "package.json"
+    assert deployed_script.exists()
+    assert (deployed_script.parent / "ponytail-config.js").exists()
+    assert json.loads(deployed_package_json.read_text(encoding="utf-8")) == {"type": "commonjs"}

--- a/tests/unit/integration/test_hook_integrator_defect_regression.py
+++ b/tests/unit/integration/test_hook_integrator_defect_regression.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from apm_cli.integration.hook_integrator import HookIntegrator
 from apm_cli.models.apm_package import APMPackage, PackageInfo
 
@@ -178,16 +180,23 @@ def _setup_commonjs_hook_package(
     package_path = tmp_path / "ponytail"
     hooks_dir = package_path / "hooks"
     hooks_dir.mkdir(parents=True)
+    (hooks_dir / "lib").mkdir()
     (package_path / "package.json").write_text(
         json.dumps({"type": "commonjs"}),
         encoding="utf-8",
     )
     (hooks_dir / "ponytail.js").write_text(
-        "const config = require('./ponytail-config');\nconsole.log(config.message);\n",
+        "const config = require('./ponytail-config');\n"
+        "const helper = require('./lib/helper');\n"
+        "console.log(config.message, helper.message);\n",
         encoding="utf-8",
     )
     (hooks_dir / "ponytail-config.js").write_text(
         "module.exports = { message: 'ok' };\n",
+        encoding="utf-8",
+    )
+    (hooks_dir / "lib" / "helper.js").write_text(
+        "module.exports = { message: 'nested' };\n",
         encoding="utf-8",
     )
     (hooks_dir / target_manifest).write_text(
@@ -205,13 +214,18 @@ def test_claude_deploys_hook_directory_siblings_and_package_module_type(
     (project / "package.json").write_text(json.dumps({"type": "module"}), encoding="utf-8")
     pkg_info = _setup_commonjs_hook_package(tmp_path)
 
-    HookIntegrator().integrate_package_hooks_claude(pkg_info, project)
+    result = HookIntegrator().integrate_package_hooks_claude(pkg_info, project)
 
     deployed_script = project / ".claude" / "hooks" / "ponytail" / "hooks" / "ponytail.js"
     deployed_package_json = deployed_script.parent / "package.json"
     assert deployed_script.exists()
     assert (deployed_script.parent / "ponytail-config.js").exists()
+    assert (deployed_script.parent / "lib" / "helper.js").exists()
     assert json.loads(deployed_package_json.read_text(encoding="utf-8")) == {"type": "commonjs"}
+    assert deployed_script in result.target_paths
+    assert (deployed_script.parent / "ponytail-config.js") in result.target_paths
+    assert (deployed_script.parent / "lib" / "helper.js") in result.target_paths
+    assert deployed_package_json in result.target_paths
 
 
 def test_copilot_deploys_hook_directory_siblings_and_package_module_type(
@@ -222,7 +236,7 @@ def test_copilot_deploys_hook_directory_siblings_and_package_module_type(
     (project / "package.json").write_text(json.dumps({"type": "module"}), encoding="utf-8")
     pkg_info = _setup_commonjs_hook_package(tmp_path, "hooks-copilot.json")
 
-    HookIntegrator().integrate_package_hooks(pkg_info, project)
+    result = HookIntegrator().integrate_package_hooks(pkg_info, project)
 
     deployed_script = (
         project / ".github" / "hooks" / "scripts" / "ponytail" / "hooks" / "ponytail.js"
@@ -230,4 +244,107 @@ def test_copilot_deploys_hook_directory_siblings_and_package_module_type(
     deployed_package_json = deployed_script.parent / "package.json"
     assert deployed_script.exists()
     assert (deployed_script.parent / "ponytail-config.js").exists()
+    assert (deployed_script.parent / "lib" / "helper.js").exists()
     assert json.loads(deployed_package_json.read_text(encoding="utf-8")) == {"type": "commonjs"}
+    assert deployed_script in result.target_paths
+    assert (deployed_script.parent / "ponytail-config.js") in result.target_paths
+    assert (deployed_script.parent / "lib" / "helper.js") in result.target_paths
+    assert deployed_package_json in result.target_paths
+
+
+def test_hook_bundle_defaults_sidecar_to_commonjs_without_package_type(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    package_path = tmp_path / "defaulttype"
+    hooks_dir = package_path / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (hooks_dir / "entry.js").write_text("console.log('ok');\n", encoding="utf-8")
+    (hooks_dir / "hooks.json").write_text(
+        json.dumps(_session_start_hook("${CLAUDE_PLUGIN_ROOT}/hooks/entry.js")),
+        encoding="utf-8",
+    )
+
+    HookIntegrator().integrate_package_hooks_claude(
+        _package_info(package_path, "defaulttype"), project
+    )
+
+    deployed_package_json = project / ".claude" / "hooks" / "defaulttype" / "hooks" / "package.json"
+    assert json.loads(deployed_package_json.read_text(encoding="utf-8")) == {"type": "commonjs"}
+
+
+def test_hook_bundle_does_not_deploy_root_hook_descriptor_manifest(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    pkg_info = _setup_commonjs_hook_package(tmp_path)
+
+    HookIntegrator().integrate_package_hooks_claude(pkg_info, project)
+
+    deployed_root = project / ".claude" / "hooks" / "ponytail" / "hooks"
+    assert not (deployed_root / "hooks.json").exists()
+
+
+def test_hook_bundle_skips_package_sidecar_for_shell_only_hooks(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    package_path = tmp_path / "shellhooks"
+    hooks_dir = package_path / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (hooks_dir / "run.sh").write_text("#!/bin/sh\necho ok\n", encoding="utf-8")
+    (hooks_dir / "hooks.json").write_text(
+        json.dumps(_session_start_hook("${CLAUDE_PLUGIN_ROOT}/hooks/run.sh")),
+        encoding="utf-8",
+    )
+
+    HookIntegrator().integrate_package_hooks_claude(
+        _package_info(package_path, "shellhooks"), project
+    )
+
+    deployed_root = project / ".claude" / "hooks" / "shellhooks" / "hooks"
+    assert (deployed_root / "run.sh").exists()
+    assert not (deployed_root / "package.json").exists()
+
+
+def test_hook_bundle_excludes_symlinks(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    package_path = tmp_path / "linkhooks"
+    hooks_dir = package_path / "hooks"
+    hooks_dir.mkdir(parents=True)
+    outside_file = tmp_path / "outside-secret.js"
+    outside_file.write_text("module.exports = 'secret';\n", encoding="utf-8")
+    (hooks_dir / "entry.js").write_text("require('./linked-secret');\n", encoding="utf-8")
+    try:
+        (hooks_dir / "linked-secret.js").symlink_to(outside_file)
+    except OSError as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+    (hooks_dir / "hooks.json").write_text(
+        json.dumps(_session_start_hook("${CLAUDE_PLUGIN_ROOT}/hooks/entry.js")),
+        encoding="utf-8",
+    )
+
+    HookIntegrator().integrate_package_hooks_claude(
+        _package_info(package_path, "linkhooks"), project
+    )
+
+    deployed_root = project / ".claude" / "hooks" / "linkhooks" / "hooks"
+    assert (deployed_root / "entry.js").exists()
+    assert not (deployed_root / "linked-secret.js").exists()
+
+
+def test_hook_bundle_stale_sibling_removed_from_target_paths(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    project.mkdir()
+    pkg_info = _setup_commonjs_hook_package(tmp_path)
+    integrator = HookIntegrator()
+
+    result = integrator.integrate_package_hooks_claude(pkg_info, project)
+    stale_sibling = project / ".claude" / "hooks" / "ponytail" / "hooks" / "ponytail-config.js"
+    assert stale_sibling in result.target_paths
+    managed_files = {path.relative_to(project).as_posix() for path in result.target_paths}
+
+    sync_result = integrator.sync_integration(None, project, managed_files=managed_files)
+
+    assert sync_result["files_removed"] >= 4
+    assert not stale_sibling.exists()

--- a/tests/unit/integration/test_kiro_target.py
+++ b/tests/unit/integration/test_kiro_target.py
@@ -250,6 +250,65 @@ def test_kiro_hooks_expand_each_apm_hook_to_individual_json(tmp_path: Path) -> N
     assert (tmp_path / ".kiro" / "hooks" / "hookify" / "hooks" / "prompt.py").exists()
 
 
+def test_kiro_deploys_hook_directory_siblings_and_package_module_type(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".kiro").mkdir()
+    package_dir = tmp_path / "ponytail"
+    hooks_dir = package_dir / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (package_dir / "package.json").write_text(
+        json.dumps({"type": "commonjs"}),
+        encoding="utf-8",
+    )
+    (hooks_dir / "ponytail.js").write_text(
+        "const config = require('./ponytail-config');\nconsole.log(config.message);\n",
+        encoding="utf-8",
+    )
+    (hooks_dir / "ponytail-config.js").write_text(
+        "module.exports = { message: 'ok' };\n",
+        encoding="utf-8",
+    )
+    (hooks_dir / "hooks.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "node ${PLUGIN_ROOT}/hooks/ponytail.js",
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = HookIntegrator().integrate_hooks_for_target(
+        KNOWN_TARGETS["kiro"],
+        _make_package_info(package_dir, "ponytail"),
+        tmp_path,
+    )
+
+    deployed_root = tmp_path / ".kiro" / "hooks" / "ponytail" / "hooks"
+    deployed_script = deployed_root / "ponytail.js"
+    deployed_sibling = deployed_root / "ponytail-config.js"
+    deployed_package_json = deployed_root / "package.json"
+    assert result.files_integrated == 1
+    assert result.scripts_copied == 1
+    assert deployed_script.exists()
+    assert deployed_sibling.exists()
+    assert json.loads(deployed_package_json.read_text(encoding="utf-8")) == {"type": "commonjs"}
+    assert deployed_script in result.target_paths
+    assert deployed_sibling in result.target_paths
+    assert deployed_package_json in result.target_paths
+
+
 def test_kiro_hooks_convert_prompt_actions_to_ask_agent(tmp_path: Path) -> None:
     (tmp_path / ".kiro").mkdir()
     package_dir = tmp_path / "prompt-hooks"


### PR DESCRIPTION
fix(hooks): deploy hook bundles self-contained

## TL;DR

Hook installs now deploy the hook script bundle, not only the entry script, for Claude-family targets, Copilot, and Kiro. JavaScript and TypeScript bundles get a minimal module-type sidecar so consumer repos with `type: module` cannot hijack CommonJS hooks. The fold also excludes hook descriptor manifests, symlinks, and `.apm-pin` markers, and adds regression traps for bundle parity, stale cleanup, and shell-only behavior.

> [!NOTE]
> Closes #2023. Direction A (self-contained deploy) was chosen over runtime references into `apm_modules/` because installed hook configs must stay portable after clone and in user-scope installs.

apm-spec-waiver: Hook bundle copying fixes existing hook primitive deployment semantics; it adds no new OpenAPM manifest, lockfile, registry, or policy field.

## Problem (WHY)

- [x] Hook entry scripts could deploy without sibling modules, so a package that worked in its source tree failed after `apm install` when it used `require('./helper')` or `import './helper'`.
- [x] CommonJS hook scripts could run under a consumer repo's `type: module` unless APM wrote a nearer module-type boundary beside the deployed scripts.
- [x] Kiro still used the old single-file copy path, so the same hook package could work for Claude/Copilot and fail for Kiro.
- [x] Root hook descriptor JSON files and symlinks were eligible for deployment because the bundle copy loop only excluded `package.json`.
- [!] Tests proved two happy paths, but not the lockfile/stale-cleanup contract, shell-only sidecar skip, descriptor exclusion, symlink exclusion, nested subdirs, or Kiro parity.

Why these matter: the fix needs deterministic evidence because PROSE says, ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) The implementation stays small and shared because PROSE says, ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) The PR body uses a concrete scenario table because Agent Skills says, ["agents pattern-match well against concrete structures"](https://agentskills.io/skill-creation/best-practices).

## Approach (WHAT)

| # | Fix | Principle | Source |
|---|-----|-----------|--------|
| 1 | Share one bundle-copy helper across Copilot, Claude-family merged targets, and Kiro. | "Favor small, chainable primitives over monolithic frameworks." | PROSE |
| 2 | Copy regular hook bundle files recursively while excluding hook descriptor manifests, symlinks, `.apm-pin`, and source `package.json`. | "Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action." | PROSE |
| 3 | Write a minimal `package.json` sidecar only for JS/TS bundles; resolve `type` from source, defaulting to `commonjs`. | "Context arrives just-in-time, not just-in-case." | PROSE |
| 4 | Add regression traps for target parity, stale cleanup, nested subdirs, descriptors, symlinks, shell-only bundles, and default module type. | "agents pattern-match well against concrete structures" | Agent Skills |

## Implementation (HOW)

- **`src/apm_cli/integration/hook_bundle.py`** -- Adds the shared bundle deploy helper. It resolves the hook source root, preserves relative paths, skips non-content files, writes a minimal JS/TS-only sidecar, and appends every deployed file to `target_paths` so lockfile cleanup keeps working.
- **`src/apm_cli/integration/hook_integrator.py`** -- Routes Copilot and Claude-family merged targets through the helper and passes the discovered hook descriptor set so parse-time manifests do not deploy as runtime scripts.
- **`src/apm_cli/integration/kiro_hook_integrator.py`** -- Replaces Kiro's old single-file copy loop with the same helper, keeping Kiro's generated JSON documents while adding sibling files and sidecar parity.
- **`tests/unit/integration/test_hook_integrator_defect_regression.py`** and **`tests/unit/integration/test_kiro_target.py`** -- Add regression traps for the bug class, including mutation-checked descriptor, symlink, shell-only, nested, target_paths, stale cleanup, default sidecar, and Kiro scenarios.
- **Docs and release notes** -- Update the hook authoring docs, the APM usage skill resource, and the Unreleased changelog entry to describe the final behavior, including the Claude-family merged target set, without over-promising.

## Diagrams

Legend: The new bundle helper sits between hook command rewriting and target_paths/cleanup bookkeeping.

```mermaid
flowchart LR
    subgraph Parse[Parse hook descriptors]
        H1[find hook JSON files]
        H2[rewrite hook commands]
    end
    subgraph Deploy[Deploy bundle]
        B1[resolve hook source root]:::new
        B2[copy regular files]:::new
        B3[write JS or TS sidecar]:::new
    end
    subgraph Track[Track cleanup]
        T1[target_paths]
        T2[lockfile deployed_files]
    end
    H1 --> H2
    H2 --> B1
    B1 --> B2
    B2 --> B3
    B2 --> T1
    B3 --> T1
    T1 --> T2
    classDef new stroke-dasharray: 5 5;
    class B1,B2,B3 new;
```

Legend: All hook targets now converge on the same script-bundle deployment path.

```mermaid
flowchart LR
    C[Copilot hook integrator]
    M[Claude-family merged targets]
    K[Kiro hook integrator]
    B[copy_deployed_hook_bundle]:::new
    O[deployed scripts, siblings, optional sidecar]
    C --> B
    M --> B
    K --> B
    B --> O
    classDef new stroke-dasharray: 5 5;
    class B new;
```

## Trade-offs

- **Self-contained deploy over runtime `apm_modules/` references.** Chose Direction A so committed hook configs keep working after clone and in user scope; rejected Direction B because it depends on an install cache path that is not a stable runtime contract.
- **Copy the hook source bundle, not a deep dependency graph.** The helper preserves files under `hooks/` or `.apm/hooks/`; node_modules, cross-dir require graph walking, binary hook policy, and tree-shaking stay out of scope.
- **Minimal sidecar over copying package metadata.** A one-field `package.json` protects module semantics without dragging source package scripts, dependencies, or unrelated metadata into consumer repos.
- **Spec waiver over new OpenAPM requirement.** This changes APM's deployment implementation for existing hook primitives; it does not introduce a new manifest, lockfile, registry, or policy contract.

## Benefits

1. Claude-family targets, Copilot, and Kiro now deploy sibling helper files alongside hook entry scripts.
2. CommonJS JS hooks are shielded from consumer repos that declare `type: module`.
3. Shell-only hook bundles no longer receive noisy Node sidecars.
4. Root hook descriptor JSON files, symlinks, and `.apm-pin` markers are excluded from runtime deploy directories.
5. Deployed siblings and sidecars enter `target_paths`, so stale cleanup removes them through the existing lockfile path.

## Validation

`PATH="$HOME/.local/bin:$PATH" uv run --extra dev pytest`:

```
29539 skipped, 173 deselected in 12.25s
```

`PATH="$HOME/.local/bin:$PATH" uv run --extra dev pytest tests/unit/integration/test_hook_integrator_defect_regression.py tests/unit/integration/test_kiro_target.py -q`:

```
23 passed in 1.22s
```

`PATH="$HOME/.local/bin:$PATH" uv run --extra dev ruff check src/ tests/ --quiet && PATH="$HOME/.local/bin:$PATH" uv run --extra dev ruff format --check src/ tests/ --quiet`:

```
(no output; exit 0)
```

Full lint mirror:

```
full_lint_contract_ok
```

CI after latest push (`b47c72358`):

```
APM Self-Check pass; Build & Test Shard 1 (Linux) pass; Build & Test Shard 2 (Linux) pass; Coverage Combine (Linux) pass; Lint pass; PR Binary Smoke (Linux) pass; Spec conformance gate pass; CodeQL pass; NOTICE Drift Check pass; build pass; gate pass; license/cla pass; deploy skipped.
```

<details><summary>Mutation-break evidence</summary>

```
descriptor_mutation_status=1
shell_sidecar_mutation_status=1
symlink_mutation_status=1
nested_mutation_status=1
target_paths_mutation_status=1
kiro_mutation_status=1
default_commonjs_mutation_status=1
```

Each mutation removed the production guard named by the test, the test failed, and the guard was restored.

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|------------------------|--------------|--------------------|------|
| 1 | Claude-family hooks with sibling JS modules keep running after install. | Portability by manifest, DevX | `tests/unit/integration/test_hook_integrator_defect_regression.py::test_claude_deploys_hook_directory_siblings_and_package_module_type` (regression-trap for #2023) | integration |
| 2 | Copilot hooks with sibling JS modules keep running after install. | Multi-harness support, DevX | `tests/unit/integration/test_hook_integrator_defect_regression.py::test_copilot_deploys_hook_directory_siblings_and_package_module_type` (regression-trap for #2023) | integration |
| 3 | Kiro hooks get the same sibling and sidecar deployment behavior. | Multi-harness support, Vendor-neutral | `tests/unit/integration/test_kiro_target.py::test_kiro_deploys_hook_directory_siblings_and_package_module_type` | integration |
| 4 | Shell-only bundles stay shell-only and do not receive a Node sidecar. | DevX | `tests/unit/integration/test_hook_integrator_defect_regression.py::test_hook_bundle_skips_package_sidecar_for_shell_only_hooks` | integration |
| 5 | Descriptor JSONs, symlinks, and stale sibling files do not leak into managed runtime state. | Secure by default, Governed by policy | `test_hook_bundle_does_not_deploy_root_hook_descriptor_manifest`; `test_hook_bundle_excludes_symlinks`; `test_hook_bundle_stale_sibling_removed_from_target_paths` | integration |

## How to test

- [ ] Run `PATH="$HOME/.local/bin:$PATH" uv run --extra dev pytest tests/unit/integration/test_hook_integrator_defect_regression.py tests/unit/integration/test_kiro_target.py -q` -> expect `23 passed`.
- [ ] Run `PATH="$HOME/.local/bin:$PATH" uv run --extra dev pytest` -> expect the full local suite to complete with exit 0.
- [ ] Run the lint mirror from `.apm/instructions/linting.instructions.md` -> expect exit 0.
- [ ] Inspect a fixture install output for Claude/Copilot/Kiro -> expect entry script, sibling helper, and JS/TS sidecar in the target script dir.
- [ ] Inspect a shell-only fixture -> expect no deployed `package.json` sidecar.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

