### PR TITLE
fix(hooks): deploy hook script runtime context

### DIFF
--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -49,7 +49,7 @@ import logging
 import re
 import shutil
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 import yaml
@@ -465,6 +465,145 @@ def _resolve_relative_hook_script(
         if candidate.exists() and candidate.is_file():
             return candidate
     return last_candidate
+
+
+def _same_file_or_path(left: Path, right: Path) -> bool:
+    """Return True when two paths identify the same file or path string."""
+    try:
+        return left.samefile(right)
+    except OSError:
+        try:
+            return left.resolve() == right.resolve()
+        except (OSError, RuntimeError):
+            return left == right
+
+
+def _nearest_package_json_for_script(source_file: Path, package_path: Path) -> Path | None:
+    """Find the package scope that controls a deployed hook script."""
+    try:
+        package_root = package_path.resolve()
+        current = ensure_path_within(source_file.parent, package_path).resolve()
+    except (OSError, RuntimeError, PathTraversalError):
+        return None
+
+    while True:
+        package_json = current / "package.json"
+        if package_json.is_file() and not package_json.is_symlink():
+            return package_json
+        if current == package_root:
+            return None
+        parent = current.parent
+        if parent == current:
+            return None
+        try:
+            current.relative_to(package_root)
+        except ValueError:
+            return None
+        current = parent
+
+
+def _target_child_path(target_parent: PurePosixPath, relative_child: Path) -> str:
+    """Build a forward-slash target path for a copied runtime file."""
+    return (target_parent / relative_child.as_posix()).as_posix()
+
+
+def _hook_runtime_source_root(source_file: Path, package_path: Path) -> Path:
+    """Return the package subtree that should travel with a hook entrypoint."""
+    try:
+        rel_source = source_file.relative_to(package_path)
+    except ValueError:
+        return source_file.parent
+    if rel_source.parts and rel_source.parts[0] in {"hooks", "scripts"}:
+        return package_path / rel_source.parts[0]
+    return source_file.parent
+
+
+def _hook_runtime_target_root(
+    source_file: Path,
+    target_rel: str,
+    runtime_source_root: Path,
+) -> PurePosixPath:
+    """Return the target subtree corresponding to ``runtime_source_root``."""
+    target_path = PurePosixPath(target_rel)
+    try:
+        source_child = source_file.relative_to(runtime_source_root)
+    except ValueError:
+        return target_path.parent
+    child_parts = source_child.parts
+    if not child_parts or len(target_path.parts) <= len(child_parts):
+        return target_path.parent
+    return PurePosixPath(*target_path.parts[: -len(child_parts)])
+
+
+def _iter_hook_runtime_files(
+    source_file: Path,
+    target_rel: str,
+    package_path: Path,
+    hook_file: Path,
+) -> list[tuple[Path, str]]:
+    """Return files needed to run a deployed hook entry script.
+
+    Hook packages often keep small CommonJS helper modules next to, or
+    one directory above, the command entrypoint.  Copying only the
+    entrypoint leaves relative ``require("./helper")`` imports broken;
+    copying the nearest package scope preserves the source package's
+    ``type`` semantics inside consumer projects that use a different
+    module system.
+    """
+    source_dir = _hook_runtime_source_root(source_file, package_path)
+    target_root = _hook_runtime_target_root(source_file, target_rel, source_dir)
+    runtime_files: list[tuple[Path, str]] = []
+
+    try:
+        ensure_path_within(source_dir, package_path)
+    except PathTraversalError:
+        return [(source_file, target_rel)]
+
+    try:
+        candidates = sorted(source_dir.rglob("*"), key=lambda p: p.as_posix())
+    except OSError:
+        candidates = [source_file]
+
+    for candidate in candidates:
+        try:
+            if candidate.is_symlink() or not candidate.is_file():
+                continue
+            ensure_path_within(candidate, package_path)
+        except (OSError, RuntimeError, PathTraversalError):
+            continue
+        if _same_file_or_path(candidate, hook_file):
+            continue
+        try:
+            rel_child = candidate.relative_to(source_dir)
+        except ValueError:
+            continue
+        runtime_files.append((candidate, _target_child_path(target_root, rel_child)))
+
+    package_json = _nearest_package_json_for_script(source_file, package_path)
+    if package_json is not None:
+        runtime_files.append((package_json, (target_root / "package.json").as_posix()))
+
+    if not runtime_files:
+        runtime_files.append((source_file, target_rel))
+    return runtime_files
+
+
+def _expand_hook_runtime_scripts(
+    scripts: list[tuple[Path, str]],
+    package_path: Path,
+    hook_file: Path,
+) -> list[tuple[Path, str]]:
+    """Expand command entrypoints into copy targets for their runtime context."""
+    seen_targets: dict[str, Path] = {}
+    for source_file, target_rel in scripts:
+        for runtime_source, runtime_target in _iter_hook_runtime_files(
+            source_file,
+            target_rel,
+            package_path,
+            hook_file,
+        ):
+            seen_targets.setdefault(runtime_target, runtime_source)
+    return [(source, target) for target, source in seen_targets.items()]
 
 
 class HookIntegrator(BaseIntegrator):
@@ -1257,6 +1396,7 @@ class HookIntegrator(BaseIntegrator):
                 hook_file_dir=hook_file.parent,
                 root_dir=root_dir,
             )
+            scripts = _expand_hook_runtime_scripts(scripts, package_info.install_path, hook_file)
 
             # Generate target filename (clean, no -apm suffix)
             stem = hook_file.stem
@@ -1482,6 +1622,7 @@ class HookIntegrator(BaseIntegrator):
                 root_dir=root_dir,
                 deploy_root=_deploy_root_for_rewrite,
             )
+            scripts = _expand_hook_runtime_scripts(scripts, package_info.install_path, hook_file)
 
             # Merge hooks into config (additive)
             hooks = rewritten.get("hooks", {})

--- a/tests/integration/test_hook_script_runtime_deployment_e2e.py
+++ b/tests/integration/test_hook_script_runtime_deployment_e2e.py
@@ -1,0 +1,146 @@
+"""Runtime proof for deployed hook scripts that require local siblings."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from apm_cli.integration.hook_integrator import HookIntegrator
+from apm_cli.models.apm_package import APMPackage, PackageInfo
+
+pytestmark = pytest.mark.integration
+
+
+def _node_binary() -> str:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node is required to execute deployed JavaScript hook scripts")
+    return node
+
+
+def _package_info(package_root: Path) -> PackageInfo:
+    package = APMPackage(
+        name="ponytail",
+        version="1.0.0",
+        source="DietrichGebert/ponytail",
+    )
+    return PackageInfo(package=package, install_path=package_root)
+
+
+def _seed_ponytail_runtime_package(project_root: Path, hook_payload: dict) -> PackageInfo:
+    package_root = project_root / "apm_modules" / "DietrichGebert" / "ponytail"
+    hooks_dir = package_root / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (package_root / "package.json").write_text(
+        json.dumps({"name": "ponytail", "type": "commonjs"}) + "\n",
+        encoding="utf-8",
+    )
+    (hooks_dir / "hooks.json").write_text(json.dumps(hook_payload, indent=2), encoding="utf-8")
+    (hooks_dir / "ponytail-activate.js").write_text(
+        "const config = require('./ponytail-config');\nprocess.stdout.write(config.message);\n",
+        encoding="utf-8",
+    )
+    (hooks_dir / "ponytail-config.js").write_text(
+        "module.exports = { message: 'PONYTAIL MODE ACTIVE' };\n",
+        encoding="utf-8",
+    )
+    return _package_info(package_root)
+
+
+def _assert_deployed_hook_runs(project_root: Path, deployed_script: Path) -> None:
+    assert deployed_script.exists()
+    assert (deployed_script.parent / "ponytail-config.js").exists()
+    assert (
+        json.loads((deployed_script.parent / "package.json").read_text(encoding="utf-8"))["type"]
+        == "commonjs"
+    )
+
+    completed = subprocess.run(
+        [_node_binary(), str(deployed_script)],
+        cwd=project_root,
+        input="{}\n",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout == "PONYTAIL MODE ACTIVE"
+
+
+def test_copilot_deployed_hook_runs_with_sibling_modules_and_package_scope(
+    tmp_path: Path,
+) -> None:
+    """Copilot hook copies must be runnable inside a type=module consumer project."""
+    project_root = tmp_path / "project"
+    (project_root / ".github").mkdir(parents=True)
+    (project_root / ".github" / "copilot-instructions.md").write_text(
+        "# Copilot instructions\n",
+        encoding="utf-8",
+    )
+    (project_root / "package.json").write_text('{"type":"module"}\n', encoding="utf-8")
+    package_info = _seed_ponytail_runtime_package(
+        project_root,
+        {
+            "hooks": {
+                "preToolUse": [
+                    {
+                        "type": "command",
+                        "bash": "node ${PLUGIN_ROOT}/hooks/ponytail-activate.js",
+                    }
+                ]
+            }
+        },
+    )
+
+    result = HookIntegrator().integrate_package_hooks(package_info, project_root)
+
+    assert result.scripts_copied >= 3
+    _assert_deployed_hook_runs(
+        project_root,
+        project_root
+        / ".github"
+        / "hooks"
+        / "scripts"
+        / "ponytail"
+        / "hooks"
+        / "ponytail-activate.js",
+    )
+
+
+def test_claude_deployed_hook_runs_with_sibling_modules_and_package_scope(
+    tmp_path: Path,
+) -> None:
+    """Merged Claude hooks use the same deployed runtime context."""
+    project_root = tmp_path / "project"
+    (project_root / ".claude").mkdir(parents=True)
+    (project_root / "package.json").write_text('{"type":"module"}\n', encoding="utf-8")
+    package_info = _seed_ponytail_runtime_package(
+        project_root,
+        {
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js",
+                            }
+                        ]
+                    }
+                ]
+            }
+        },
+    )
+
+    result = HookIntegrator().integrate_package_hooks_claude(package_info, project_root)
+
+    assert result.scripts_copied >= 3
+    _assert_deployed_hook_runs(
+        project_root,
+        project_root / ".claude" / "hooks" / "ponytail" / "hooks" / "ponytail-activate.js",
+    )


### PR DESCRIPTION
## Summary

- Expands deployed hook script copies from only the command entrypoint to the entrypoint runtime subtree, so required sibling modules like `./ponytail-config` are present after install.
- Copies the nearest source `package.json` into the deployed hook runtime directory so hook scripts keep the package module semantics instead of inheriting the consumer project's `package.json` `type`.
- Adds a Node-backed regression for both Copilot and Claude deployments in a consumer project with `type=module`, proving the deployed CommonJS hook can run and load its sibling module.

Closes #2023.

## Preflight

- #2023 was open, unassigned, and had no comments before implementation and again immediately before push.
- Duplicate PR search for #2023 / hook script crash / sibling modules / ponytail runtime / package.json module type terms returned no open PRs immediately before push.

## Validation

- `uv run --extra dev pytest tests/integration/test_hook_script_runtime_deployment_e2e.py -q` (2 passed)
- `uv run --extra dev pytest tests/unit/integration/test_hook_integrator.py tests/integration/test_hook_script_runtime_deployment_e2e.py tests/integration/test_hook_routing_combined_manifest_e2e.py tests/integration/test_hook_integrator_copilot_casing_e2e.py tests/integration/test_integrators_hooks_execution.py tests/integration/test_integrators_hooks_phase3c.py -q` (444 passed)
- `uv run --extra dev ruff check src tests`
- `uv run --extra dev ruff format --check src tests`
- `git diff --check`
- `uv run --extra dev pytest -q` was also attempted; this repo's default marker configuration skipped 29592 tests and deselected 173, so the targeted hook suite above is the relevant behavior evidence.