### PR TITLE
Fix devDependencies invisible to orphan detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `apm prune`, `apm audit --ci` orphan detection, and the lockfile-exists
+  check now include `devDependencies.apm` entries, fixing false orphan
+  reports, spurious CI failures, and a misleading message for dev-only
+  projects. (#2042, closes #2033)
+
 ## [0.24.0] - 2026-07-05
 
 ### Added

--- a/docs/src/content/docs/reference/baseline-checks.md
+++ b/docs/src/content/docs/reference/baseline-checks.md
@@ -59,14 +59,14 @@ the [policy schema](./policy-schema/).
 
 ### `lockfile-exists`
 
-- **What it verifies.** That `apm.lock.yaml` is present whenever the project has APM or MCP dependencies, or whenever an existing lockfile records local content under the synthesized self-entry.
-- **Fails when.** `apm.yml` declares dependencies but no lockfile is on disk.
+- **What it verifies.** That `apm.lock.yaml` is present whenever the project has APM or MCP dependencies (including `devDependencies`), or whenever an existing lockfile records local content under the synthesized self-entry.
+- **Fails when.** `apm.yml` declares dependencies (production or dev) but no lockfile is on disk.
 - **Effect.** Subsequent checks are skipped (the lockfile is required input).
 - **Remediation.** Run `apm install` to generate `apm.lock.yaml` and commit it.
 
 ### `ref-consistency`
 
-- **What it verifies.** That every dependency's `reference` in `apm.yml` matches the `resolved_ref` recorded in the lockfile.
+- **What it verifies.** That every dependency's `reference` in `apm.yml` (both `dependencies.apm` and `devDependencies.apm`) matches the `resolved_ref` recorded in the lockfile.
 - **Fails when.** A manifest ref differs from the lockfile entry, or the manifest declares a dependency that is missing from the lockfile.
 - **Remediation.** Run `apm install` so the lockfile re-resolves to the manifest, then commit `apm.lock.yaml`.
 
@@ -78,7 +78,7 @@ the [policy schema](./policy-schema/).
 
 ### `no-orphaned-packages`
 
-- **What it verifies.** That every dependency in the lockfile is still declared in `apm.yml`. The synthesized self-entry is excluded.
+- **What it verifies.** That every dependency in the lockfile is still declared in `apm.yml` (in either `dependencies.apm` or `devDependencies.apm`). The synthesized self-entry is excluded.
 - **Fails when.** The lockfile holds a package that the manifest no longer lists.
 - **Remediation.** Run `apm install` to prune the orphan, then commit `apm.lock.yaml`.
 

--- a/docs/src/content/docs/reference/cli/prune.md
+++ b/docs/src/content/docs/reference/cli/prune.md
@@ -21,11 +21,11 @@ apm prune [--dry-run]
 
 `apm prune` reconciles three states:
 
-1. Packages declared in `apm.yml`
+1. Packages declared in `apm.yml` (both `dependencies.apm` and `devDependencies.apm`)
 2. Packages installed under `apm_modules/`
 3. Packages recorded in `apm.lock.yaml` with their `deployed_files`
 
-Anything installed but no longer declared is **orphaned**. `apm prune` removes the orphan's directory under `apm_modules/`, deletes every file the orphan deployed into your harness directories (using the `deployed_files` manifest in the lockfile), removes the entry from `apm.lock.yaml`, and cleans up empty parent directories.
+Anything installed but not declared in either dependency list is **orphaned**. `apm prune` removes the orphan's directory under `apm_modules/`, deletes every file the orphan deployed into your harness directories (using the `deployed_files` manifest in the lockfile), removes the entry from `apm.lock.yaml`, and cleans up empty parent directories.
 
 If `apm_modules/` does not exist, the command exits cleanly with nothing to do. If `apm.yml` is missing, it exits with an error.
 

--- a/src/apm_cli/commands/_helpers.py
+++ b/src/apm_cli/commands/_helpers.py
@@ -308,7 +308,7 @@ def _check_orphaned_packages():
             from ..models.apm_package import APMPackage
 
             apm_package = APMPackage.from_apm_yml(Path(APM_YML_FILENAME))
-            declared_deps = apm_package.get_apm_dependencies()
+            declared_deps = apm_package.get_all_apm_dependencies()
             lockfile = LockFile.read(get_lockfile_path(Path.cwd()))
             expected = _build_expected_install_paths(declared_deps, lockfile, apm_modules_dir)
         except Exception:

--- a/src/apm_cli/commands/prune.py
+++ b/src/apm_cli/commands/prune.py
@@ -52,7 +52,7 @@ def prune(ctx, dry_run):
         # Build expected vs installed using shared helpers
         try:
             apm_package = APMPackage.from_apm_yml(Path(APM_YML_FILENAME))
-            declared_deps = apm_package.get_apm_dependencies()
+            declared_deps = apm_package.get_all_apm_dependencies()
             lockfile = LockFile.read(get_lockfile_path(Path.cwd()))
             expected_installed = _build_expected_install_paths(
                 declared_deps, lockfile, apm_modules_dir

--- a/src/apm_cli/models/apm_package.py
+++ b/src/apm_cli/models/apm_package.py
@@ -550,6 +550,14 @@ class APMPackage:
             if isinstance(dep, MCPDependency)
         ]
 
+    def get_all_apm_dependencies(self) -> list[DependencyReference]:
+        """Get production and dev APM dependencies in manifest order."""
+        return self.get_apm_dependencies() + self.get_dev_apm_dependencies()
+
+    def has_any_apm_dependencies(self) -> bool:
+        """Check if this package has any APM dependencies (prod or dev)."""
+        return bool(self.get_apm_dependencies() or self.get_dev_apm_dependencies())
+
     def get_all_mcp_dependencies(self) -> list["MCPDependency"]:
         """Get production and dev MCP dependencies in manifest order."""
         return self.get_mcp_dependencies() + self.get_dev_mcp_dependencies()

--- a/src/apm_cli/policy/ci_checks.py
+++ b/src/apm_cli/policy/ci_checks.py
@@ -53,7 +53,7 @@ def _check_lockfile_exists(
             message="No apm.yml found -- nothing to check",
         )
 
-    has_deps = manifest.has_apm_dependencies() or bool(manifest.get_mcp_dependencies())
+    has_deps = manifest.has_any_apm_dependencies() or bool(manifest.get_mcp_dependencies())
     lockfile_path = get_lockfile_path(project_root)
 
     # Local-only repos may declare no remote/MCP deps but still have a
@@ -98,7 +98,7 @@ def _check_ref_consistency(
     from ..drift import detect_ref_change
 
     mismatches: list[str] = []
-    for dep_ref in manifest.get_apm_dependencies():
+    for dep_ref in manifest.get_all_apm_dependencies():
         key = dep_ref.get_unique_key()
         locked_dep = lock.get_dependency(key)
         if locked_dep is None:
@@ -167,7 +167,7 @@ def _check_no_orphans(
     sub-package's manifest, not the root manifest, so the root manifest
     cannot make them go away by editing its ``dependencies.apm`` list.
     """
-    manifest_keys = {dep.get_unique_key() for dep in manifest.get_apm_dependencies()}
+    manifest_keys = {dep.get_unique_key() for dep in manifest.get_all_apm_dependencies()}
     orphaned = [
         dep_key
         for dep_key, locked_dep in lock.dependencies.items()
@@ -195,7 +195,7 @@ def _check_skill_subset_consistency(
 ) -> CheckResult:
     """Verify lockfile skill_subset matches manifest skills: for each entry."""
     mismatches: list[str] = []
-    for dep_ref in manifest.get_apm_dependencies():
+    for dep_ref in manifest.get_all_apm_dependencies():
         key = dep_ref.get_unique_key()
         locked_dep = lock.get_dependency(key)
         if locked_dep is None:

--- a/src/apm_cli/policy/ci_checks.py
+++ b/src/apm_cli/policy/ci_checks.py
@@ -53,7 +53,7 @@ def _check_lockfile_exists(
             message="No apm.yml found -- nothing to check",
         )
 
-    has_deps = manifest.has_any_apm_dependencies() or bool(manifest.get_mcp_dependencies())
+    has_deps = manifest.has_any_apm_dependencies() or bool(manifest.get_all_mcp_dependencies())
     lockfile_path = get_lockfile_path(project_root)
 
     # Local-only repos may declare no remote/MCP deps but still have a
@@ -165,7 +165,7 @@ def _check_no_orphans(
     Only DIRECT dependencies (``depth == 1`` / no ``resolved_by``) are
     candidates for orphan detection. Transitive deps belong to a
     sub-package's manifest, not the root manifest, so the root manifest
-    cannot make them go away by editing its ``dependencies.apm`` list.
+    cannot make them go away by editing its dependency lists.
     """
     manifest_keys = {dep.get_unique_key() for dep in manifest.get_all_apm_dependencies()}
     orphaned = [

--- a/src/apm_cli/policy/ci_checks.py
+++ b/src/apm_cli/policy/ci_checks.py
@@ -234,7 +234,7 @@ def _check_config_consistency(
     from ..drift import detect_config_drift
     from ..integration.mcp_integrator import MCPIntegrator
 
-    mcp_deps = manifest.get_mcp_dependencies()
+    mcp_deps = manifest.get_all_mcp_dependencies()
     current_configs = MCPIntegrator.get_server_configs(mcp_deps)
     stored_configs = lock.mcp_configs or {}
 

--- a/tests/unit/test_dev_dependencies.py
+++ b/tests/unit/test_dev_dependencies.py
@@ -537,8 +537,33 @@ class TestOrphanDetectionIncludesDevDeps:
         manifest.has_apm_dependencies.return_value = False
         manifest.has_any_apm_dependencies.return_value = True
         manifest.get_mcp_dependencies.return_value = []
+        manifest.get_all_mcp_dependencies.return_value = []
 
         # No lockfile on disk -- should say "lockfile missing", not "no deps"
         result = _check_lockfile_exists(tmp_path, manifest)
         assert result.passed is False
         assert "missing" in result.message.lower()
+
+    def test_check_ref_consistency_detects_dev_dep_mismatch(self) -> None:
+        """_check_ref_consistency should detect ref mismatches in dev deps."""
+        from apm_cli.policy.ci_checks import _check_ref_consistency
+
+        dev_dep = DependencyReference(repo_url="owner/dev-pkg", reference="v2.0")
+        manifest = MagicMock(spec=APMPackage)
+        manifest.get_apm_dependencies.return_value = []
+        manifest.get_dev_apm_dependencies.return_value = [dev_dep]
+        manifest.get_all_apm_dependencies.return_value = APMPackage.get_all_apm_dependencies(
+            manifest
+        )
+
+        lock = MagicMock(spec=LockFile)
+        lock.get_dependency.return_value = LockedDependency(
+            repo_url="owner/dev-pkg",
+            is_dev=True,
+            resolved_ref="v1.0",
+            resolved_by=None,
+        )
+
+        result = _check_ref_consistency(manifest, lock)
+        assert result.passed is False
+        assert "ref mismatch" in result.message.lower()

--- a/tests/unit/test_dev_dependencies.py
+++ b/tests/unit/test_dev_dependencies.py
@@ -447,3 +447,98 @@ class TestValidateAndAddDevDeps:
             data = yaml.safe_load(f)
         assert "org/prod-pkg" in data["dependencies"]["apm"]
         assert "devDependencies" not in data
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for #2033: devDependencies visible to orphan detection
+# ---------------------------------------------------------------------------
+
+
+class TestGetAllApmDependencies:
+    """Tests for APMPackage.get_all_apm_dependencies() and has_any_apm_dependencies()."""
+
+    def test_returns_union_of_prod_and_dev(self) -> None:
+        """get_all_apm_dependencies returns both prod and dev deps."""
+        pkg = MagicMock(spec=APMPackage)
+        prod_dep = DependencyReference(repo_url="owner/prod-pkg")
+        dev_dep = DependencyReference(repo_url="owner/dev-pkg")
+        pkg.get_apm_dependencies.return_value = [prod_dep]
+        pkg.get_dev_apm_dependencies.return_value = [dev_dep]
+        # Call the real method on the mock
+        result = APMPackage.get_all_apm_dependencies(pkg)
+        assert result == [prod_dep, dev_dep]
+
+    def test_returns_only_prod_when_no_dev(self) -> None:
+        """get_all_apm_dependencies returns prod-only when no dev deps exist."""
+        pkg = MagicMock(spec=APMPackage)
+        prod_dep = DependencyReference(repo_url="owner/prod-pkg")
+        pkg.get_apm_dependencies.return_value = [prod_dep]
+        pkg.get_dev_apm_dependencies.return_value = []
+        result = APMPackage.get_all_apm_dependencies(pkg)
+        assert result == [prod_dep]
+
+    def test_returns_only_dev_when_no_prod(self) -> None:
+        """get_all_apm_dependencies returns dev-only when no prod deps exist."""
+        pkg = MagicMock(spec=APMPackage)
+        dev_dep = DependencyReference(repo_url="owner/dev-pkg")
+        pkg.get_apm_dependencies.return_value = []
+        pkg.get_dev_apm_dependencies.return_value = [dev_dep]
+        result = APMPackage.get_all_apm_dependencies(pkg)
+        assert result == [dev_dep]
+
+    def test_has_any_true_for_dev_only(self) -> None:
+        """has_any_apm_dependencies returns True when only dev deps exist."""
+        pkg = MagicMock(spec=APMPackage)
+        pkg.get_apm_dependencies.return_value = []
+        pkg.get_dev_apm_dependencies.return_value = [DependencyReference(repo_url="owner/dev-pkg")]
+        result = APMPackage.has_any_apm_dependencies(pkg)
+        assert result is True
+
+    def test_has_any_false_when_empty(self) -> None:
+        """has_any_apm_dependencies returns False when no deps at all."""
+        pkg = MagicMock(spec=APMPackage)
+        pkg.get_apm_dependencies.return_value = []
+        pkg.get_dev_apm_dependencies.return_value = []
+        result = APMPackage.has_any_apm_dependencies(pkg)
+        assert result is False
+
+
+class TestOrphanDetectionIncludesDevDeps:
+    """Regression tests for #2033: orphan detection must include devDependencies."""
+
+    def test_check_no_orphans_passes_for_dev_dep(self) -> None:
+        """_check_no_orphans should not flag a dev dependency as orphaned."""
+        from apm_cli.policy.ci_checks import _check_no_orphans
+
+        manifest = MagicMock(spec=APMPackage)
+        manifest.get_apm_dependencies.return_value = []
+        manifest.get_dev_apm_dependencies.return_value = [
+            DependencyReference(repo_url="owner/dev-pkg")
+        ]
+        manifest.get_all_apm_dependencies.return_value = APMPackage.get_all_apm_dependencies(
+            manifest
+        )
+
+        lock = MagicMock(spec=LockFile)
+        lock.dependencies = {
+            "owner/dev-pkg": LockedDependency(
+                repo_url="owner/dev-pkg", is_dev=True, resolved_by=None
+            ),
+        }
+
+        result = _check_no_orphans(manifest, lock)
+        assert result.passed is True
+
+    def test_check_lockfile_exists_recognises_dev_only_deps(self, tmp_path) -> None:
+        """_check_lockfile_exists should not say 'no dependencies' for dev-only projects."""
+        from apm_cli.policy.ci_checks import _check_lockfile_exists
+
+        manifest = MagicMock(spec=APMPackage)
+        manifest.has_apm_dependencies.return_value = False
+        manifest.has_any_apm_dependencies.return_value = True
+        manifest.get_mcp_dependencies.return_value = []
+
+        # No lockfile on disk -- should say "lockfile missing", not "no deps"
+        result = _check_lockfile_exists(tmp_path, manifest)
+        assert result.passed is False
+        assert "missing" in result.message.lower()

--- a/tests/unit/test_prune_command.py
+++ b/tests/unit/test_prune_command.py
@@ -466,3 +466,31 @@ dependencies:
             result = self.runner.invoke(cli, ["prune"])
             assert result.exit_code == 0
             assert not orphan_dir.exists()
+
+    # ------------------------------------------------------------------
+    # Regression: devDependencies must not be pruned (#2033)
+    # ------------------------------------------------------------------
+
+    def test_prune_keeps_dev_dependency_packages(self):
+        """Regression #2033: prune must not remove devDependencies.apm packages."""
+        apm_yml_with_dev_dep = (
+            "name: test-project\n"
+            "version: 1.0.0\n"
+            "dependencies:\n"
+            "  apm:\n"
+            "    - declared-org/prod-pkg\n"
+            "  mcp: []\n"
+            "devDependencies:\n"
+            "  apm:\n"
+            "    - dev-org/dev-pkg\n"
+        )
+        with self._chdir_tmp() as tmp:
+            (tmp / "apm.yml").write_text(apm_yml_with_dev_dep)
+            prod_dir = _make_package_dir(tmp, "declared-org", "prod-pkg")
+            dev_dir = _make_package_dir(tmp, "dev-org", "dev-pkg")
+            orphan_dir = _make_package_dir(tmp, "orphan-org", "orphan-repo")
+            result = self.runner.invoke(cli, ["prune"])
+            assert result.exit_code == 0
+            assert prod_dir.exists(), "Prod dependency must remain"
+            assert dev_dir.exists(), "Dev dependency must remain"
+            assert not orphan_dir.exists(), "Orphaned package must be removed"

--- a/tests/unit/test_skill_subset_persistence.py
+++ b/tests/unit/test_skill_subset_persistence.py
@@ -445,6 +445,8 @@ class TestSkillSubsetConsistencyCheck:
         """Create a manifest mock with given dep_refs."""
         manifest = Mock()
         manifest.get_apm_dependencies.return_value = deps
+        manifest.get_dev_apm_dependencies.return_value = []
+        manifest.get_all_apm_dependencies.return_value = deps
         return manifest
 
     def _make_lock_mock(self, locked_deps):


### PR DESCRIPTION
## Description

`APMPackage.get_apm_dependencies()` returns only production dependencies, but
prune, orphan-check, and CI audit paths use it as the sole source of "declared
deps". Any package installed via `devDependencies.apm` is therefore treated as
orphaned -- `apm prune` deletes it, `apm audit --ci` fails the
`no-orphaned-packages` check, and dev-only projects get a misleading "No
dependencies declared" message.

The fix adds `get_all_apm_dependencies()` and `has_any_apm_dependencies()` to
`APMPackage` (mirroring the existing `get_all_mcp_dependencies()` pattern), then
updates the five call sites that only consulted the production bucket:

- **`commands/prune.py`**: dev deps no longer pruned as orphans
- **`commands/_helpers.py`**: `_check_orphaned_packages` includes dev deps
- **`policy/ci_checks.py`**: `_check_lockfile_exists`, `_check_no_orphans`,
  `_check_ref_consistency`, and `_check_skill_subset_consistency` all now
  include dev deps in the declared-dependency set

Fixes: #2033

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

Eight regression tests added to `tests/unit/test_dev_dependencies.py`:
- `get_all_apm_dependencies()` returns union of prod + dev
- `has_any_apm_dependencies()` returns True for dev-only packages
- `_check_no_orphans` passes when dep is dev-only
- `_check_lockfile_exists` recognises dev-only deps as "has dependencies"

Full suite: 18150 passed, lint chain green.

## Spec conformance (OpenAPM v0.1)

- [x] N/A -- this PR does not change OpenAPM-observable behaviour.