### PR TITLE
[FEATURE] Support local MCP config for Copilot CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `apm install --mcp NAME --target copilot` now writes project-scoped Copilot
+  CLI MCP configuration to `.mcp.json`; use `-g` / `--global` to keep writing
+  `~/.copilot/mcp-config.json`. Stale MCP cleanup now follows the same scope. (#2048)
+
 ## [0.24.1] - 2026-07-10
 
 ### Fixed
@@ -91,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   universal instructions. (by @WilliamK112, #1993)
 
 ### Fixed
+
 
 - `apm install` no longer aborts with a false "package not accessible" error
   when GitHub's API rate limit (primary 60/hr or secondary concurrency) throttles

--- a/docs/src/content/docs/consumer/install-mcp-servers.md
+++ b/docs/src/content/docs/consumer/install-mcp-servers.md
@@ -100,7 +100,7 @@ for the full required-vs-optional runtime config rule.
 
 | Harness | File | Scope | Format |
 |---|---|---|---|
-| GitHub Copilot CLI | `~/.copilot/mcp-config.json` | global | JSON `mcpServers` |
+| GitHub Copilot CLI | `.mcp.json` (project) or `~/.copilot/mcp-config.json` (`-g`) | both | JSON `mcpServers` |
 | VS Code (Copilot) | `.vscode/mcp.json` | project | JSON `servers` |
 | Claude Code | `.mcp.json` (project) or `$CLAUDE_CONFIG_DIR/.claude.json` (`-g`; unset/blank: `~/.claude.json`) | both | JSON `mcpServers` |
 | Cursor | `.cursor/mcp.json` | project (only if `.cursor/` exists) | JSON `mcpServers` |
@@ -111,6 +111,12 @@ for the full required-vs-optional runtime config rule.
 | Windsurf | `~/.codeium/windsurf/mcp_config.json` | global | JSON `mcpServers` |
 | Kiro IDE | `.kiro/settings/mcp.json` (project, only if `.kiro/` exists) or `~/.kiro/settings/mcp.json` (`-g`) | both | JSON `mcpServers` |
 | JetBrains Copilot | OS-specific `mcp.json` under the GitHub Copilot user config directory | global | JSON `servers` |
+
+For Copilot CLI project scope, APM writes `.mcp.json` directly with the
+same `mcpServers` key Copilot CLI reads. If you are moving a hand-written
+VS Code MCP file to Copilot CLI, GitHub's migration guidance is to copy
+`.vscode/mcp.json` into `.mcp.json` while remapping the top-level
+`servers` key to `mcpServers`.
 
 ## How `targets:` gates which configs get written
 

--- a/docs/src/content/docs/producer/author-primitives/mcp-as-primitive.md
+++ b/docs/src/content/docs/producer/author-primitives/mcp-as-primitive.md
@@ -31,9 +31,9 @@ materialises them at install time into the harness-specific config
 file (see the per-harness map in
 [Install MCP servers](../../consumer/install-mcp-servers/#what-apm-install-writes-to-disk)).
 
-You declare once. At project scope, APM writes `.vscode/mcp.json`,
-`.cursor/mcp.json`, `.mcp.json` for Claude, `.codex/config.toml`, and the
-rest -- whichever harnesses the consumer has.
+You declare once. At project scope, APM writes `.mcp.json` for Copilot CLI
+and Claude Code, `.vscode/mcp.json` for VS Code, `.cursor/mcp.json`,
+`.codex/config.toml`, and the rest -- whichever harnesses the consumer has.
 
 ## The `mcp:` schema
 

--- a/src/apm_cli/adapters/client/copilot.py
+++ b/src/apm_cli/adapters/client/copilot.py
@@ -1,8 +1,9 @@
 """GitHub Copilot CLI implementation of MCP client adapter.
 
-This adapter implements the Copilot CLI-specific handling of MCP server configuration,
-targeting the global ~/.copilot/mcp-config.json file as specified in the MCP installation
-architecture specification.
+Project scope writes ``.mcp.json`` at the project root using Copilot CLI's
+workspace MCP schema (top-level ``mcpServers``). User scope writes
+``~/.copilot/mcp-config.json``. Both scopes use the same Copilot CLI
+``mcpServers`` entry shape.
 """
 
 import json
@@ -36,9 +37,9 @@ from .base import (
 class CopilotClientAdapter(MCPClientAdapter):
     """Copilot CLI implementation of MCP client adapter.
 
-    This adapter handles Copilot CLI-specific configuration for MCP servers using
-    a global ~/.copilot/mcp-config.json file, following the JSON format for
-    MCP server configuration.
+    Project installs write ``<project_root>/.mcp.json`` so servers are scoped
+    to the repository. User-scope installs (``-g`` / ``--global``) keep the
+    existing Copilot CLI user config path, ``~/.copilot/mcp-config.json``.
     """
 
     supports_user_scope: bool = True
@@ -103,14 +104,22 @@ class CopilotClientAdapter(MCPClientAdapter):
         self.registry_client = SimpleRegistryClient(registry_url)
         self.registry_integration = RegistryIntegration(registry_url)
 
+    def _project_mcp_path(self) -> Path:
+        return self.project_root / ".mcp.json"
+
+    def _user_mcp_path(self) -> Path:
+        return Path.home() / ".copilot" / "mcp-config.json"
+
     def get_config_path(self):
         """Get the path to the Copilot CLI MCP configuration file.
 
         Returns:
-            str: Path to ~/.copilot/mcp-config.json
+            str: Project ``.mcp.json`` by default, or
+            ``~/.copilot/mcp-config.json`` for user scope.
         """
-        copilot_dir = Path.home() / ".copilot"
-        return str(copilot_dir / "mcp-config.json")
+        if self.user_scope:
+            return str(self._user_mcp_path())
+        return str(self._project_mcp_path())
 
     def update_config(self, config_updates):
         """Update the Copilot CLI MCP configuration.
@@ -133,8 +142,9 @@ class CopilotClientAdapter(MCPClientAdapter):
         # Ensure directory exists
         config_path.parent.mkdir(parents=True, exist_ok=True)
 
-        with open(config_path, "w") as f:
+        with open(config_path, "w", encoding="utf-8") as f:
             json.dump(current_config, f, indent=2)
+        os.chmod(config_path, 0o600)
 
     def get_current_config(self):
         """Get the current Copilot CLI MCP configuration.
@@ -148,7 +158,7 @@ class CopilotClientAdapter(MCPClientAdapter):
             return {}
 
         try:
-            with open(config_path) as f:
+            with open(config_path, encoding="utf-8") as f:
                 return json.load(f)
         except (OSError, json.JSONDecodeError):
             return {}

--- a/src/apm_cli/integration/mcp_integrator.py
+++ b/src/apm_cli/integration/mcp_integrator.py
@@ -610,6 +610,7 @@ class MCPIntegrator:
         from apm_cli.core.scope import InstallScope
 
         if scope is InstallScope.USER:
+            user_scope = True
             from apm_cli.factory import ClientFactory as _CF
 
             supported = builtins.set()
@@ -620,6 +621,8 @@ class MCPIntegrator:
                 except ValueError:
                     pass
             target_runtimes = supported
+        elif scope is InstallScope.PROJECT:
+            user_scope = False
 
         # Claude Code: when scope is unspecified, fail safely toward the project
         # config only -- never touch ~/.claude.json on the user's behalf without
@@ -654,11 +657,21 @@ class MCPIntegrator:
             )
 
         if "copilot" in target_runtimes:
+            from apm_cli.factory import ClientFactory
+
+            copilot_cfg = Path(
+                ClientFactory.create_client(
+                    "copilot",
+                    project_root=project_root_path,
+                    user_scope=user_scope,
+                ).get_config_path()
+            )
+            copilot_label = "Copilot CLI user config" if user_scope else ".mcp.json"
             _clean_json_mcp_config(
-                Path.home() / ".copilot" / "mcp-config.json",
+                copilot_cfg,
                 expanded_stale,
                 logger,
-                "Copilot CLI config",
+                copilot_label,
                 use_rich=True,
             )
 
@@ -711,7 +724,7 @@ class MCPIntegrator:
                 ClientFactory.create_client(
                     "kiro",
                     project_root=project_root_path,
-                    user_scope=user_scope or scope is InstallScope.USER,
+                    user_scope=user_scope,
                 ).get_config_path()
             )
             _clean_json_mcp_config(

--- a/src/apm_cli/runtime/copilot_runtime.py
+++ b/src/apm_cli/runtime/copilot_runtime.py
@@ -118,8 +118,16 @@ class CopilotRuntime(RuntimeAdapter):
             version = version_result.stdout.strip() if version_result.returncode == 0 else "unknown"
 
             # Check for MCP configuration
-            mcp_config_path = Path.home() / ".copilot" / "mcp-config.json"
+            mcp_config_path = self.get_mcp_config_path()
             mcp_configured = mcp_config_path.exists()
+
+            if mcp_config_path.name in (".mcp.json", "mcp.json"):
+                if mcp_config_path.parent.name == ".github":
+                    config_label = ".github/mcp.json"
+                else:
+                    config_label = ".mcp.json"
+            else:
+                config_label = "~/.copilot/mcp-config.json"
 
             return {
                 "name": "copilot",
@@ -128,7 +136,7 @@ class CopilotRuntime(RuntimeAdapter):
                 "capabilities": {
                     "model_execution": True,
                     "mcp_servers": "native_support" if mcp_configured else "manual_setup_required",
-                    "configuration": "~/.copilot/mcp-config.json",
+                    "configuration": config_label,
                     "interactive_mode": True,
                     "background_processes": True,
                     "file_operations": True,
@@ -163,8 +171,17 @@ class CopilotRuntime(RuntimeAdapter):
         """Get the path to the MCP configuration file.
 
         Returns:
-            Path: Path to the MCP configuration file
+            Path: Path to the MCP configuration file (prioritizes workspace config)
         """
+        cwd = Path.cwd()
+        cwd_mcp = cwd / ".mcp.json"
+        if cwd_mcp.is_file():
+            return cwd_mcp
+
+        cwd_github_mcp = cwd / ".github" / "mcp.json"
+        if cwd_github_mcp.is_file():
+            return cwd_github_mcp
+
         return Path.home() / ".copilot" / "mcp-config.json"
 
     def is_mcp_configured(self) -> bool:
@@ -188,7 +205,10 @@ class CopilotRuntime(RuntimeAdapter):
         try:
             with open(mcp_config_path, encoding="utf-8") as f:
                 config = json.load(f)
-                return config.get("servers", {})
+                if not isinstance(config, dict):
+                    return {}
+                val = config.get("mcpServers", config.get("servers", {}))
+                return val if isinstance(val, dict) else {}
         except Exception as e:
             return {"error": f"Failed to read MCP configuration: {e}"}
 

--- a/tests/integration/test_integration_runtime_coverage.py
+++ b/tests/integration/test_integration_runtime_coverage.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 import urllib.parse
 from pathlib import Path
 from typing import Any
@@ -705,6 +706,8 @@ class TestCopilotAppWsHelpers:
 
     def test_token_file_mode_ok_missing_file_returns_false(self, tmp_path: Path) -> None:
         """Missing file returns False."""
+        if os.name == "nt":
+            pytest.skip("POSIX-only test")
         from apm_cli.integration.copilot_app_ws import _token_file_mode_ok
 
         assert _token_file_mode_ok(tmp_path / "nonexistent") is False
@@ -1373,7 +1376,7 @@ class TestStreamSubprocessOutput:
         """Normal command returns lines and zero exit code."""
         from apm_cli.runtime.base import _stream_subprocess_output
 
-        output, rc = _stream_subprocess_output(["echo", "hello"])
+        output, rc = _stream_subprocess_output([sys.executable, "-c", "print('hello')"])
         assert rc == 0
         assert any("hello" in line for line in output)
 
@@ -1381,7 +1384,7 @@ class TestStreamSubprocessOutput:
         """Failing command returns non-zero return code."""
         from apm_cli.runtime.base import _stream_subprocess_output
 
-        _, rc = _stream_subprocess_output(["false"])
+        _, rc = _stream_subprocess_output([sys.executable, "-c", "import sys; sys.exit(1)"])
         assert rc != 0
 
     def test_timeout_kills_process(self) -> None:

--- a/tests/integration/test_mcp_env_var_copilot_e2e.py
+++ b/tests/integration/test_mcp_env_var_copilot_e2e.py
@@ -1,9 +1,9 @@
-"""End-to-end regression guard for #1152: Copilot CLI's mcp-config.json
+"""End-to-end regression guard for #1152: Copilot CLI's .mcp.json
 must contain ``${VAR}`` runtime placeholders for env-var references in
 apm.yml -- never the literal value resolved at install time.
 
 This exercises the full pipeline:
-    apm.yml  ->  apm install --target copilot  ->  ~/.copilot/mcp-config.json
+    apm.yml  ->  apm install --target copilot  ->  <project>/.mcp.json
 
 The unit tests in tests/unit/test_copilot_adapter.py cover translation in
 isolation; this test pins the integration boundary so plaintext secrets
@@ -59,14 +59,14 @@ def _write_apm_yml(project_dir, mcp_servers):
 
 
 class TestMcpEnvVarHeadersCopilot:
-    """#1152 regression: Copilot mcp-config.json must contain ``${VAR}``
+    """#1152 regression: Copilot .mcp.json must contain ``${VAR}``
     runtime placeholders for env-var references in apm.yml. The literal
     values from the installer's environment must NEVER appear on disk.
     """
 
     def test_self_defined_http_server_translates_env_vars_not_resolves(self, tmp_path, apm_command):
         """``${VAR}`` and ``${env:VAR}`` syntaxes in apm.yml headers must
-        land in mcp-config.json as ``${VAR}`` (Copilot CLI's native runtime
+        land in .mcp.json as ``${VAR}`` (Copilot CLI's native runtime
         substitution syntax). No host env values may leak into the file.
         """
         project_dir = tmp_path / "project"
@@ -75,9 +75,8 @@ class TestMcpEnvVarHeadersCopilot:
         # copilot/vscode runtime detection chain.
         (project_dir / ".github").mkdir()
 
-        # Isolated HOME so we don't touch the developer's real
-        # ~/.copilot/mcp-config.json. The Copilot adapter uses
-        # ``Path.home() / ".copilot"``.
+        # Isolated HOME so user-scope config is never touched.
+        # Project-scope Copilot writes to project_dir/.mcp.json.
         fake_home = tmp_path / "home"
         fake_home.mkdir()
 
@@ -120,16 +119,16 @@ class TestMcpEnvVarHeadersCopilot:
             f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
         )
 
-        mcp_config = fake_home / ".copilot" / "mcp-config.json"
+        mcp_config = project_dir / ".mcp.json"
         assert mcp_config.exists(), (
-            f"Expected ~/.copilot/mcp-config.json to exist after install.\n"
+            f"Expected .mcp.json to exist after install.\n"
             f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
         )
 
         config = json.loads(mcp_config.read_text(encoding="utf-8"))
         servers = config.get("mcpServers") or {}
         assert len(servers) == 1, (
-            f"Expected 1 server in mcp-config.json, got: {list(servers.keys())}"
+            f"Expected 1 server in .mcp.json, got: {list(servers.keys())}"
         )
         server = next(iter(servers.values()))
         headers = server.get("headers") or {}
@@ -146,7 +145,7 @@ class TestMcpEnvVarHeadersCopilot:
         # CRITICAL: no plaintext secret may appear anywhere in the file.
         full_text = mcp_config.read_text(encoding="utf-8")
         assert "should-not-appear-in-copilot-json" not in full_text, (
-            "Copilot mcp-config.json leaked the literal env value -- "
+            "Copilot .mcp.json leaked the literal env value -- "
             "the install-time translation regressed and secrets are now "
             "baked to disk.\n"
             f"File contents:\n{full_text}"
@@ -154,7 +153,7 @@ class TestMcpEnvVarHeadersCopilot:
 
     def test_self_defined_stdio_server_translates_env_vars_in_args(self, tmp_path, apm_command):
         """Self-defined stdio server with env-var placeholders in BOTH the
-        ``env`` block and ``args`` list must land in mcp-config.json with
+        ``env`` block and ``args`` list must land in .mcp.json with
         ``${VAR}`` runtime placeholders. Closes the integration-tier gap
         flagged by test-coverage review for the ``_raw_stdio`` branch of
         ``_format_server_config`` and the supply-chain regression where
@@ -209,16 +208,16 @@ class TestMcpEnvVarHeadersCopilot:
             f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
         )
 
-        mcp_config = fake_home / ".copilot" / "mcp-config.json"
+        mcp_config = project_dir / ".mcp.json"
         assert mcp_config.exists(), (
-            f"Expected ~/.copilot/mcp-config.json to exist after install.\n"
+            f"Expected .mcp.json to exist after install.\n"
             f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
         )
 
         config = json.loads(mcp_config.read_text(encoding="utf-8"))
         servers = config.get("mcpServers") or {}
         assert len(servers) == 1, (
-            f"Expected 1 server in mcp-config.json, got: {list(servers.keys())}"
+            f"Expected 1 server in .mcp.json, got: {list(servers.keys())}"
         )
         server = next(iter(servers.values()))
 

--- a/tests/unit/integration/test_mcp_integrator.py
+++ b/tests/unit/integration/test_mcp_integrator.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 
 import pytest
 
+from apm_cli.core.scope import InstallScope
 from apm_cli.integration.mcp_integrator import MCPIntegrator, _is_vscode_available
 from apm_cli.models.dependency.mcp import MCPDependency
 
@@ -799,25 +800,64 @@ class TestInstallProjectRootDetection:
 
 
 class TestRemoveStaleCopilot:
-    def _write_copilot_mcp(self, home: Path, servers: dict) -> Path:
+    def _write_project_copilot_mcp(self, root: Path, servers: dict) -> Path:
+        root.mkdir(parents=True, exist_ok=True)
+        cfg = root / ".mcp.json"
+        cfg.write_text(json.dumps({"mcpServers": servers}), encoding="utf-8")
+        return cfg
+
+    def _write_user_copilot_mcp(self, home: Path, servers: dict) -> Path:
         copilot_dir = home / ".copilot"
         copilot_dir.mkdir(parents=True, exist_ok=True)
         cfg = copilot_dir / "mcp-config.json"
         cfg.write_text(json.dumps({"mcpServers": servers}), encoding="utf-8")
         return cfg
 
-    def test_removes_stale_from_copilot(self, tmp_path):
-        cfg = self._write_copilot_mcp(tmp_path, {"old": {}, "keep": {}})
+    def test_removes_stale_from_project_copilot_mcp_json(self, tmp_path):
+        cfg = self._write_project_copilot_mcp(tmp_path, {"old": {}, "keep": {}})
 
-        with (
-            patch("apm_cli.integration.mcp_integrator.Path.cwd", return_value=tmp_path),
-            patch("pathlib.Path.home", return_value=tmp_path),
-        ):
-            MCPIntegrator.remove_stale({"old"}, runtime="copilot")
+        MCPIntegrator.remove_stale(
+            {"old"},
+            runtime="copilot",
+            project_root=tmp_path,
+            scope=InstallScope.PROJECT,
+        )
 
         remaining = json.loads(cfg.read_text())
         assert "old" not in remaining["mcpServers"]
         assert "keep" in remaining["mcpServers"]
+
+    def test_removes_stale_from_user_copilot_mcp_config(self, tmp_path):
+        cfg = self._write_user_copilot_mcp(tmp_path, {"old": {}, "keep": {}})
+
+        with patch.object(Path, "home", return_value=tmp_path):
+            MCPIntegrator.remove_stale(
+                {"old"},
+                runtime="copilot",
+                project_root=tmp_path / "project",
+                scope=InstallScope.USER,
+            )
+
+        remaining = json.loads(cfg.read_text())
+        assert "old" not in remaining["mcpServers"]
+        assert "keep" in remaining["mcpServers"]
+
+    def test_project_cleanup_does_not_touch_user_copilot_config(self, tmp_path):
+        project_cfg = self._write_project_copilot_mcp(tmp_path / "project", {"old": {}})
+        user_cfg = self._write_user_copilot_mcp(tmp_path / "home", {"old": {}})
+        user_raw = user_cfg.read_text(encoding="utf-8")
+
+        with patch.object(Path, "home", return_value=tmp_path / "home"):
+            MCPIntegrator.remove_stale(
+                {"old"},
+                runtime="copilot",
+                project_root=tmp_path / "project",
+                scope=InstallScope.PROJECT,
+            )
+
+        project_remaining = json.loads(project_cfg.read_text(encoding="utf-8"))
+        assert "old" not in project_remaining["mcpServers"]
+        assert user_cfg.read_text(encoding="utf-8") == user_raw
 
 
 # ===========================================================================

--- a/tests/unit/test_copilot_adapter.py
+++ b/tests/unit/test_copilot_adapter.py
@@ -5,9 +5,94 @@ import os
 import shutil
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from apm_cli.adapters.client.copilot import CopilotClientAdapter
+
+
+class TestCopilotClientAdapterScope(unittest.TestCase):
+    """Project and user scope path routing for Copilot MCP config."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.home = self.root / "home"
+        self.home_patcher = patch.object(Path, "home", return_value=self.home)
+        self.home_patcher.start()
+        self.registry_patcher = patch("apm_cli.adapters.client.copilot.SimpleRegistryClient")
+        self.registry_patcher.start()
+        self.integration_patcher = patch("apm_cli.adapters.client.copilot.RegistryIntegration")
+        self.integration_patcher.start()
+
+    def tearDown(self) -> None:
+        self.integration_patcher.stop()
+        self.registry_patcher.stop()
+        self.home_patcher.stop()
+        self.tmp.cleanup()
+
+    def test_project_scope_config_path_uses_project_mcp_json(self) -> None:
+        adapter = CopilotClientAdapter(project_root=self.root)
+
+        self.assertEqual(Path(adapter.get_config_path()), self.root / ".mcp.json")
+
+    def test_user_scope_config_path_uses_copilot_user_config(self) -> None:
+        adapter = CopilotClientAdapter(project_root=self.root, user_scope=True)
+
+        self.assertEqual(
+            Path(adapter.get_config_path()),
+            self.home / ".copilot" / "mcp-config.json",
+        )
+
+    def test_project_get_current_config_reads_project_mcp_json(self) -> None:
+        expected = {"mcpServers": {"project": {"command": "python"}}}
+        (self.root / ".mcp.json").write_text(json.dumps(expected), encoding="utf-8")
+        adapter = CopilotClientAdapter(project_root=self.root)
+
+        self.assertEqual(adapter.get_current_config(), expected)
+
+    def test_user_get_current_config_reads_copilot_user_config(self) -> None:
+        expected = {"mcpServers": {"user": {"command": "node"}}}
+        user_path = self.home / ".copilot" / "mcp-config.json"
+        user_path.parent.mkdir(parents=True)
+        user_path.write_text(json.dumps(expected), encoding="utf-8")
+        adapter = CopilotClientAdapter(project_root=self.root, user_scope=True)
+
+        self.assertEqual(adapter.get_current_config(), expected)
+
+    def test_project_update_config_creates_project_mcp_json(self) -> None:
+        adapter = CopilotClientAdapter(project_root=self.root)
+
+        adapter.update_config({"srv": {"command": "node", "args": ["server.js"]}})
+
+        mcp_path = self.root / ".mcp.json"
+        self.assertTrue(mcp_path.exists())
+        data = json.loads(mcp_path.read_text(encoding="utf-8"))
+        self.assertEqual(data["mcpServers"]["srv"]["command"], "node")
+
+    def test_project_update_config_preserves_existing_servers(self) -> None:
+        mcp_path = self.root / ".mcp.json"
+        mcp_path.write_text(
+            json.dumps({"mcpServers": {"keep": {"command": "python"}}}),
+            encoding="utf-8",
+        )
+        adapter = CopilotClientAdapter(project_root=self.root)
+
+        adapter.update_config({"new": {"command": "node"}})
+
+        data = json.loads(mcp_path.read_text(encoding="utf-8"))
+        self.assertIn("keep", data["mcpServers"])
+        self.assertIn("new", data["mcpServers"])
+
+    def test_user_update_config_keeps_existing_user_path_behavior(self) -> None:
+        adapter = CopilotClientAdapter(project_root=self.root, user_scope=True)
+
+        adapter.update_config({"srv": {"command": "node"}})
+
+        user_path = self.home / ".copilot" / "mcp-config.json"
+        self.assertTrue(user_path.exists())
+        data = json.loads(user_path.read_text(encoding="utf-8"))
+        self.assertIn("srv", data["mcpServers"])
 
 
 class TestCopilotRemoteTransportValidation(unittest.TestCase):

--- a/tests/unit/test_copilot_adapter_compatibility.py
+++ b/tests/unit/test_copilot_adapter_compatibility.py
@@ -27,6 +27,7 @@ import json
 import os
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 from apm_cli.adapters.client.copilot import (
@@ -100,11 +101,20 @@ class TestModuleLevelHelpers(unittest.TestCase):
 
 
 class TestGetConfigPath(unittest.TestCase):
-    def test_returns_path_under_home_copilot(self) -> None:
-        adapter = _make_adapter()
-        config_path = adapter.get_config_path()
-        self.assertIn(".copilot", config_path)
-        self.assertTrue(config_path.endswith("mcp-config.json"))
+    def test_project_scope_returns_project_mcp_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            adapter = _make_adapter(project_root=tmp)
+            config_path = Path(adapter.get_config_path())
+
+        self.assertEqual(config_path, Path(tmp) / ".mcp.json")
+
+    def test_user_scope_returns_home_copilot_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            adapter = _make_adapter(project_root=tmp, user_scope=True)
+            with patch.object(Path, "home", return_value=Path(tmp) / "home"):
+                config_path = Path(adapter.get_config_path())
+
+        self.assertEqual(config_path, Path(tmp) / "home" / ".copilot" / "mcp-config.json")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_copilot_adapter_phase3.py
+++ b/tests/unit/test_copilot_adapter_phase3.py
@@ -27,6 +27,7 @@ import json
 import os
 import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import patch
 
 from apm_cli.adapters.client.copilot import (
@@ -100,11 +101,20 @@ class TestModuleLevelHelpers(unittest.TestCase):
 
 
 class TestGetConfigPath(unittest.TestCase):
-    def test_returns_path_under_home_copilot(self) -> None:
-        adapter = _make_adapter()
-        config_path = adapter.get_config_path()
-        self.assertIn(".copilot", config_path)
-        self.assertTrue(config_path.endswith("mcp-config.json"))
+    def test_project_scope_returns_project_mcp_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            adapter = _make_adapter(project_root=tmp)
+            config_path = Path(adapter.get_config_path())
+
+        self.assertEqual(config_path, Path(tmp) / ".mcp.json")
+
+    def test_user_scope_returns_home_copilot_config(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            adapter = _make_adapter(project_root=tmp, user_scope=True)
+            with patch.object(Path, "home", return_value=Path(tmp) / "home"):
+                config_path = Path(adapter.get_config_path())
+
+        self.assertEqual(config_path, Path(tmp) / "home" / ".copilot" / "mcp-config.json")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_copilot_runtime.py
+++ b/tests/unit/test_copilot_runtime.py
@@ -1,5 +1,6 @@
 """Test Copilot Runtime."""
 
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
@@ -51,7 +52,21 @@ class TestCopilotRuntime:
             mock_subprocess.return_value = mock_result
 
             runtime = CopilotRuntime()
-            info = runtime.get_runtime_info()
+
+            # Test case 1: Local .mcp.json config path
+            with patch.object(runtime, "get_mcp_config_path", return_value=Path("/workspace/.mcp.json")):
+                info = runtime.get_runtime_info()
+                assert info["capabilities"]["configuration"] == ".mcp.json"
+
+            # Test case 2: Local .github/mcp.json config path
+            with patch.object(runtime, "get_mcp_config_path", return_value=Path("/workspace/.github/mcp.json")):
+                info = runtime.get_runtime_info()
+                assert info["capabilities"]["configuration"] == ".github/mcp.json"
+
+            # Test case 3: Global fallback config path
+            with patch.object(runtime, "get_mcp_config_path", return_value=Path("/home/user/.copilot/mcp-config.json")):
+                info = runtime.get_runtime_info()
+                assert info["capabilities"]["configuration"] == "~/.copilot/mcp-config.json"
 
             assert info["name"] == "copilot"
             assert info["type"] == "copilot_cli"
@@ -68,13 +83,40 @@ class TestCopilotRuntime:
             assert "copilot-default" in models
             assert models["copilot-default"]["provider"] == "github-copilot"
 
-    def test_get_mcp_config_path(self):
+    def test_get_mcp_config_path(self, tmp_path):
         """Test getting MCP configuration path."""
         with patch.object(CopilotRuntime, "is_available", return_value=True):
             runtime = CopilotRuntime()
-            config_path = runtime.get_mcp_config_path()
 
-            assert config_path.as_posix().endswith(".copilot/mcp-config.json")
+            # Setup mock directories
+            mock_cwd = tmp_path / "workspace"
+            mock_cwd.mkdir()
+            mock_home = tmp_path / "home"
+            mock_home.mkdir()
+            mock_copilot = mock_home / ".copilot"
+            mock_copilot.mkdir()
+
+            with (
+                patch("pathlib.Path.cwd", return_value=mock_cwd),
+                patch("pathlib.Path.home", return_value=mock_home),
+            ):
+                # 1. Global fallback (no workspace config)
+                config_path = runtime.get_mcp_config_path()
+                assert config_path.as_posix().endswith(".copilot/mcp-config.json")
+
+                # 2. .github/mcp.json exists
+                mock_github = mock_cwd / ".github"
+                mock_github.mkdir()
+                (mock_github / "mcp.json").touch()
+                config_path = runtime.get_mcp_config_path()
+                assert config_path.name == "mcp.json"
+                assert ".github" in config_path.parts
+
+                # 3. .mcp.json exists (highest priority)
+                (mock_cwd / ".mcp.json").touch()
+                config_path = runtime.get_mcp_config_path()
+                assert config_path.name == ".mcp.json"
+                assert ".github" not in config_path.parts
 
     def test_execute_prompt_basic(self):
         """Test basic prompt execution."""
@@ -181,3 +223,54 @@ class TestMcpConfigUtf8RoundTrip:
 
         assert "demo-cafe" in got
         assert got["demo-cafe"]["description"] == "\u4e2d\u6587 description -- cafe"
+
+    def test_get_mcp_servers_reads_mcp_servers_key(self, tmp_path):
+        """Test reading MCP config supports the mcpServers key used in .mcp.json."""
+        import json as _json
+
+        mcp_path = tmp_path / "mcp.json"
+        servers = {
+            "mcpServers": {
+                "workspace-server": {
+                    "command": "node",
+                    "args": ["server.js"],
+                }
+            }
+        }
+        mcp_path.write_bytes(_json.dumps(servers).encode("utf-8"))
+
+        with patch.object(CopilotRuntime, "is_available", return_value=True):
+            runtime = CopilotRuntime()
+            with patch.object(CopilotRuntime, "get_mcp_config_path", return_value=mcp_path):
+                got = runtime.get_mcp_servers()
+
+        assert "workspace-server" in got
+
+    def test_get_mcp_servers_handles_non_dict(self, tmp_path):
+        """Test that get_mcp_servers returns an empty dict if servers is a list or non-dict."""
+        import json as _json
+
+        mcp_path = tmp_path / "mcp.json"
+        servers = {"mcpServers": ["not", "a", "dict"]}
+        mcp_path.write_bytes(_json.dumps(servers).encode("utf-8"))
+
+        with patch.object(CopilotRuntime, "is_available", return_value=True):
+            runtime = CopilotRuntime()
+            with patch.object(CopilotRuntime, "get_mcp_config_path", return_value=mcp_path):
+                got = runtime.get_mcp_servers()
+
+        assert got == {}
+
+    def test_get_mcp_servers_handles_malformed_config_root(self, tmp_path):
+        """Test that get_mcp_servers returns an empty dict if the root is not a dict."""
+        import json as _json
+
+        mcp_path = tmp_path / "mcp.json"
+        mcp_path.write_bytes(_json.dumps(["root", "is", "list"]).encode("utf-8"))
+
+        with patch.object(CopilotRuntime, "is_available", return_value=True):
+            runtime = CopilotRuntime()
+            with patch.object(CopilotRuntime, "get_mcp_config_path", return_value=mcp_path):
+                got = runtime.get_mcp_servers()
+
+        assert got == {}

--- a/tests/unit/test_mcp_lifecycle_e2e.py
+++ b/tests/unit/test_mcp_lifecycle_e2e.py
@@ -761,7 +761,7 @@ class TestStaleCleanupKeyNormalization:
         )
 
         stale = {"io.github.github/github-mcp-server"}
-        MCPIntegrator.remove_stale(stale, runtime="copilot")
+        MCPIntegrator.remove_stale(stale, runtime="copilot", user_scope=True)
 
         result = json.loads(copilot_config.read_text())
         assert "github-mcp-server" not in result["mcpServers"]
@@ -796,7 +796,7 @@ class TestStaleCleanupKeyNormalization:
         )
 
         stale = {"acme-kb"}
-        MCPIntegrator.remove_stale(stale, runtime="copilot")
+        MCPIntegrator.remove_stale(stale, runtime="copilot", user_scope=True)
 
         result = json.loads(copilot_config.read_text())
         assert "acme-kb" not in result["mcpServers"]


### PR DESCRIPTION
## Description

This PR enables workspace-level MCP configuration for the GitHub Copilot CLI integration, bringing it into parity with other harnesses like `claude` and `codex`.
I've created PR before trying to adress this problem, though it was rejected I'd like to try again. It seems it is mostly lack of clarity in official Copilot docs, that do not describe this behaiour in main configuration documentation for MCP (https://docs.github.com/en/copilot/how-tos/copilot-cli/use-copilot-cli/overview#add-an-mcp-server), this is only described on another subpage (https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference#mcp-server-loading-priority).

Related feature request: https://github.com/microsoft/apm/issues/2047
Still hope to make a contribution, rather than attempt some workarounds locally.

### Background
In the GitHub Copilot CLI, MCP configuration is loaded with the following priority, as per the [official documentation](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-command-reference#mcp-server-loading-priority):
1. Project-local `.mcp.json`
2. Project-local `.github/mcp.json`
3. User-global `~/.copilot/mcp-config.json`

### The Problem
Previously (as discussed in #2015), the adapter successfully created a project-local config, but the APM CLI's `CopilotRuntime` *read-path* remained hardcoded to only look at the global `~/.copilot/mcp-config.json`. This mismatch caused the runtime to fail discovering locally installed tools during execution. Furthermore, when reading `.mcp.json`, the schema usually places servers inside the `"mcpServers"` key instead of the older `"servers"` key.

### The Solution & Changes Made
To fully support Copilot's intended configuration loading priority and fix the runtime-read path mismatch, this PR updates `CopilotRuntime` to:
1. First check the current working directory for `.mcp.json`.
2. Then check the current working directory for `.github/mcp.json`.
3. Finally, fall back to the global `~/.copilot/mcp-config.json`.
4. When reading the JSON file, correctly fall back to the `"mcpServers"` key if `"servers"` is not present.

The `-g` / `--global` flag is now correctly supported for explicit user-scope installations.

**Note on Critical Paths:** The changes involve `src/apm_cli/runtime/` which is a critical path. The commits include the `apm-spec-waiver` trailer to account for this change.

Fixes #2047

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

## Spec conformance (OpenAPM v0.1)

If this PR changes behaviour that an OpenAPM v0.1 `req-XXX` covers,
confirm the three-step ritual (see CONTRIBUTING.md "Adding or
changing a normative requirement"):

- [ ] Spec edit: `docs/src/content/docs/specs/openapm-v0.1.md` updated
      (new/changed `<a id="req-XXX"></a>` anchor + prose + Appendix C
      row).
- [ ] Manifest edit: `docs/src/content/docs/specs/manifest.json` updated.
- [ ] Test edit: `tests/fixtures/spec-conformance/` updated.
- [ ] CONFORMANCE.{md,json} regenerated via `make spec-conformance`.
- [x] N/A -- this PR does not change OpenAPM-observable behaviour.
