### PR TITLE
fix(install): exclude self-entry from dry-run orphan preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `apm install --dry-run` no longer lists the project's own `includes: auto`
+  self-managed files under "Files that would be removed"; the orphan preview
+  now excludes the synthesized lockfile self-entry, matching the real install
+  which never removes them. (by @mia106dev, #2069)
+
 ## [0.26.0] - 2026-07-18
 
 ### Added

--- a/src/apm_cli/drift.py
+++ b/src/apm_cli/drift.py
@@ -224,10 +224,19 @@ def detect_orphans(
         are no longer in the manifest.  The caller is responsible for actually
         removing the files.
     """
+    from apm_cli.deps.lockfile import _SELF_KEY
+
     orphaned: builtins.set = builtins.set()
     if only_packages or not existing_lockfile:
         return orphaned
     for dep_key, dep in existing_lockfile.dependencies.items():
+        # The synthesized self-entry (key ".") holds the project's own
+        # includes:auto content, which the real install always re-deploys
+        # (never removes). It can never appear in the manifest-derived
+        # intended set, so skip it to avoid over-counting self-includes as
+        # removals in the dry-run preview.
+        if dep_key == _SELF_KEY:
+            continue
         if dep_key not in intended_dep_keys:
             orphaned.update(dep.deployed_files)
     return orphaned

--- a/tests/unit/test_drift_detection.py
+++ b/tests/unit/test_drift_detection.py
@@ -214,6 +214,55 @@ class TestDetectOrphans(unittest.TestCase):
         result = detect_orphans(lf, set(), only_packages=None)
         self.assertEqual(result, {"a.md"})
 
+    def test_self_entry_never_orphaned(self):
+        """The synthesized self-entry (key ".") must never be reported as orphan.
+
+        from_yaml() injects a virtual ``_SELF_KEY`` dependency carrying the
+        project's own includes:auto content. That key can never appear in the
+        manifest-derived intended set, and the real install re-deploys it
+        (drift.py replay guards ``local_path == _SELF_KEY``). Reporting it here
+        over-counts self-includes as removals in the dry-run preview.
+        """
+        from apm_cli.deps.lockfile import _SELF_KEY
+
+        self_dep = _LockedDep(
+            repo_url="<self>",
+            source="local",
+            local_path=_SELF_KEY,
+            deployed_files=["self_a.md", "self_b.md"],
+        )
+        orphan = _LockedDep(repo_url="owner/gone", deployed_files=["gone.md"])
+        lf = _LockFile(dependencies={_SELF_KEY: self_dep, "owner/gone": orphan})
+        result = detect_orphans(lf, set(), only_packages=[])
+        # Only the genuinely dropped package is an orphan; self-includes are not.
+        self.assertEqual(result, {"gone.md"})
+
+    def test_self_include_survives_real_from_yaml_roundtrip(self):
+        """End-to-end guard using the real LockFile.from_yaml synthesis.
+
+        The stub-based test above could drift from how from_yaml actually
+        synthesizes the self-entry. This exercises the real parse -> detect
+        path so a change to either side (self-key value, synthesis shape)
+        that reintroduces the dry-run false alarm fails here. from_yaml is a
+        pure string parse -- no I/O.
+        """
+        from apm_cli.deps.lockfile import LockFile
+
+        lock = LockFile.from_yaml(
+            "lockfile_version: '2'\n"
+            "generated_at: ''\n"
+            "dependencies:\n"
+            "  - repo_url: owner/kept\n"
+            "    source: git\n"
+            "    deployed_files: ['.apm/x.md']\n"
+            "local_deployed_files:\n"
+            "  - .claude/skills/self/SKILL.md\n"
+        )
+        # Manifest now empty -> only the real dropped package is an orphan;
+        # the synthesized self-entry's includes are never reported.
+        result = detect_orphans(lock, set(), only_packages=[])
+        self.assertEqual(result, {".apm/x.md"})
+
 
 # ---------------------------------------------------------------------------
 # detect_config_drift


### PR DESCRIPTION
## TL;DR

`apm install --dry-run` falsely lists the project's **own** `includes: auto`
self-managed files under **"Files that would be removed (packages no longer in
apm.yml)"**. The real install never removes them — this is a dry-run *preview*
bug only. The fix makes the orphan preview skip the synthesized lockfile
self-entry, so the preview matches actual install behaviour.

## Problem

For a project using `includes: auto`, `LockFile.from_yaml` synthesizes a
virtual dependency keyed by `_SELF_KEY` (`"."`) from the flat
`local_deployed_files` field, to unify traversal across real dependencies and
the project's own local content (`src/apm_cli/deps/lockfile.py`, `from_yaml`).

`detect_orphans` (`src/apm_cli/drift.py`) walks **every** entry in
`existing_lockfile.dependencies` and flags any key not present in the
manifest-derived `intended_dep_keys` as orphaned:

```python
for dep_key, dep in existing_lockfile.dependencies.items():
    if dep_key not in intended_dep_keys:
        orphaned.update(dep.deployed_files)
```

The synthesized `_SELF_KEY` (`"."`) can **never** appear in `intended_dep_keys`
(it is not a manifest dependency), so on a full install every self-include was
reported as an orphan to be removed.

This is preview-only over-reporting. The real paths are already correct and
were never affected:

- Replay guards the self-entry to **re-deploy** it, not remove it —
  `src/apm_cli/install/drift.py:481,495` (`if lock_dep.local_path == _SELF_KEY`).
- The cleanup phase independently skips it —
  `src/apm_cli/install/phases/cleanup.py:79` (`if _orphan_key == _SELF_KEY`).

`detect_orphans`' only non-test caller is the dry-run preview renderer
(`src/apm_cli/install/presentation/dry_run.py:70`), which confirms the blast
radius is the preview text alone.

## Approach

Skip `_SELF_KEY` inside `detect_orphans`. Orphan-ness is a property the
function itself owns, so the guard belongs here — next to the sibling guards
already present in the real cleanup/replay paths — rather than filtered at the
single caller. Synthesis stays in `from_yaml` because other consumers rely on
the self-entry existing.

## Implementation

```diff
+    from apm_cli.deps.lockfile import _SELF_KEY
+
     orphaned: builtins.set = builtins.set()
     if only_packages or not existing_lockfile:
         return orphaned
     for dep_key, dep in existing_lockfile.dependencies.items():
+        # The synthesized self-entry (key ".") holds the project's own
+        # includes:auto content, which the real install always re-deploys
+        # (never removes). It can never appear in the manifest-derived
+        # intended set, so skip it to avoid over-counting self-includes as
+        # removals in the dry-run preview.
+        if dep_key == _SELF_KEY:
+            continue
         if dep_key not in intended_dep_keys:
             orphaned.update(dep.deployed_files)
     return orphaned
```

The `_SELF_KEY` import is function-scoped, matching the codebase's established
lazy-import idiom for the `drift` ↔ `lockfile` cycle.

## Validation

- New unit tests in `tests/unit/test_drift_detection.py`:
  - `test_self_entry_never_orphaned` — a stub lockfile with a self-entry plus a
    genuinely dropped package: only the dropped package's files are returned.
  - `test_self_include_survives_real_from_yaml_roundtrip` — exercises the
    **real** `LockFile.from_yaml` synthesis → `detect_orphans` path, so a future
    change to either the self-key value or the synthesis shape that reintroduces
    the false alarm fails here.
- Red→green confirmed: `test_self_entry_never_orphaned` fails on `main`
  (`self_a.md`/`self_b.md` wrongly returned), passes with the fix.
- End-to-end check against the real parse path: with the manifest emptied, only
  a genuinely dropped package's file is reported; self-includes
  (`.claude/skills/...`) no longer appear.
- Blast-radius unit suites green (`test_drift_detection`, `test_install_update`,
  `tests/unit/install/`): 1831 passed.
- Lint clean: `ruff check` + `ruff format --check` on the changed files.

## How to test

```bash
uv run pytest tests/unit/test_drift_detection.py -q
```

Or reproduce the original symptom: in a project that uses `includes: auto` with
a committed `apm.lock.yaml`, run `apm install --dry-run` — before this change
the project's own deployed files are listed under "Files that would be
removed"; after, they are not.

## Scope notes

- `src/apm_cli/drift.py` is not under the OpenAPM Mode-B critical-path allowlist
  (`tests/spec_conformance/critical_paths.txt`), so no spec anchor/manifest/
  marker or `apm-spec-waiver:` is required.
- Out of scope (noted by review): the `dep_key == _SELF_KEY` idiom now appears
  in several consumers; a `LockFile.real_dependencies()` accessor to DRY it is a
  separate refactor.
