### PR TITLE
fix(install): actionable hint when self-hosted GitLab host swallows subpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `apm install host/org/repo/subpath#ref` on an unrecognised self-hosted FQDN
+  no longer fails with a misleading "not accessible or doesn't exist" error.
+  The failure reason now explains that the whole path was folded into a
+  single repository path and suggests setting `GITLAB_HOST` /
+  `APM_GITLAB_HOSTS` if the target is a self-hosted GitLab instance, or using
+  an explicit `git:` + `path:` entry in `apm.yml` otherwise. (by @rrazvd,
+  closes #2066)
+
 ## [0.24.0] - 2026-07-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `apm install host/org/repo/subpath#ref` on an unrecognised self-hosted FQDN
-  no longer fails with a misleading "not accessible or doesn't exist" error.
-  The failure reason now explains that the whole path was folded into a
-  single repository path and suggests setting `GITLAB_HOST` /
-  `APM_GITLAB_HOSTS` if the target is a self-hosted GitLab instance, or using
-  an explicit `git:` + `path:` entry in `apm.yml` otherwise. (by @rrazvd,
-  closes #2066)
+  no longer fails with a misleading "not accessible or doesn't exist" error;
+  the failure reason now suggests setting `GITLAB_HOST` / `APM_GITLAB_HOSTS`
+  if the target is a self-hosted GitLab instance, or using an explicit
+  `git:` + `path:` entry in `apm.yml` otherwise. (by @rrazvd; closes #2066) (#2074)
 
 ## [0.24.0] - 2026-07-05
 

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -85,6 +85,7 @@ from apm_cli.install.services import (
 # level name lookup -- keeping it co-located means @patch on this module
 # intercepts those calls without test changes.
 from apm_cli.install.validation import (
+    _generic_host_ambiguous_subpath_hint,
     _local_path_failure_reason,
     _local_path_no_markers_hint,  # noqa: F401 -- re-exported; test_architecture_invariants checks importability
     _validate_package_exists,
@@ -544,6 +545,8 @@ def _resolve_package_references(
                 _marketplace_provenance[identity] = marketplace_provenance
         else:
             reason = _local_path_failure_reason(dep_ref)
+            if not reason:
+                reason = _generic_host_ambiguous_subpath_hint(dep_ref)
             if not reason:
                 # Round-4 panel fix (devx-ux): name the four-step probe
                 # chain explicitly when the validator exhausted it

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -80,12 +80,11 @@ from apm_cli.install.services import (
 
 # Re-export validation leaf helpers so that existing test patches like
 # @patch("apm_cli.commands.install._validate_package_exists") keep working.
-# _validate_and_add_packages_to_apm_yml stays here (not moved) because it
-# calls _validate_package_exists and _local_path_failure_reason via module-
-# level name lookup -- keeping it co-located means @patch on this module
-# intercepts those calls without test changes.
+# _validate_and_add_packages_to_apm_yml stays co-located (module lookup keeps @patch working).
 from apm_cli.install.validation import (
-    _generic_host_ambiguous_subpath_hint,
+    _generic_host_ambiguous_subpath_hint as _ambiguous_subpath_hint,
+)
+from apm_cli.install.validation import (
     _local_path_failure_reason,
     _local_path_no_markers_hint,  # noqa: F401 -- re-exported; test_architecture_invariants checks importability
     _validate_package_exists,
@@ -544,9 +543,7 @@ def _resolve_package_references(
             if marketplace_provenance:
                 _marketplace_provenance[identity] = marketplace_provenance
         else:
-            reason = _local_path_failure_reason(dep_ref)
-            if not reason:
-                reason = _generic_host_ambiguous_subpath_hint(dep_ref)
+            reason = _local_path_failure_reason(dep_ref) or _ambiguous_subpath_hint(dep_ref)
             if not reason:
                 # Round-4 panel fix (devx-ux): name the four-step probe
                 # chain explicitly when the validator exhausted it

--- a/src/apm_cli/install/validation.py
+++ b/src/apm_cli/install/validation.py
@@ -152,7 +152,7 @@ def _local_path_failure_reason(dep_ref):
     return "no apm.yml, SKILL.md, or plugin.json found"
 
 
-def _generic_host_ambiguous_subpath_hint(dep_ref):
+def _generic_host_ambiguous_subpath_hint(dep_ref) -> str | None:
     """Return an actionable hint when an unrecognised FQDN swallowed a subpath.
 
     Mirrors GHES (``GITHUB_HOST``): a self-hosted GitLab instance is only
@@ -170,7 +170,8 @@ def _generic_host_ambiguous_subpath_hint(dep_ref):
         return None
     if is_github_hostname(host) or dep_ref.is_azure_devops() or is_gitlab_hostname(host):
         return None
-    if len(dep_ref.repo_url.split("/")) <= 2:
+    segments = [seg for seg in dep_ref.repo_url.split("/") if seg]
+    if len(segments) <= 2:
         return None
     return (
         f"'{host}' was treated as a single repository path "

--- a/src/apm_cli/install/validation.py
+++ b/src/apm_cli/install/validation.py
@@ -21,6 +21,9 @@ _local_path_failure_reason
     Return a human-readable reason when a local-path dep fails validation.
 _local_path_no_markers_hint
     Scan a local directory for nested installable packages and hint the user.
+_generic_host_ambiguous_subpath_hint
+    Return a GITLAB_HOST/APM_GITLAB_HOSTS hint when an unrecognised FQDN
+    swallowed a subpath into a single (non-existent) repo path.
 """
 
 import re
@@ -29,7 +32,12 @@ from pathlib import Path
 import requests
 
 from ..utils.console import _rich_echo, _rich_info, _rich_warning
-from ..utils.github_host import default_host, is_ado_auth_failure_signal
+from ..utils.github_host import (
+    default_host,
+    is_ado_auth_failure_signal,
+    is_github_hostname,
+    is_gitlab_hostname,
+)
 from .errors import AuthenticationError
 
 # ---------------------------------------------------------------------------
@@ -142,6 +150,37 @@ def _local_path_failure_reason(dep_ref):
         return "path is not a directory"
     # Directory exists but has no package markers
     return "no apm.yml, SKILL.md, or plugin.json found"
+
+
+def _generic_host_ambiguous_subpath_hint(dep_ref):
+    """Return an actionable hint when an unrecognised FQDN swallowed a subpath.
+
+    Mirrors GHES (``GITHUB_HOST``): a self-hosted GitLab instance is only
+    classified as GitLab-class -- which enables the repo/subpath boundary
+    probe for nested groups -- once the user points ``GITLAB_HOST`` or
+    ``APM_GITLAB_HOSTS`` at it (issue #2066). Without that, parse-time
+    detection has no way to know where the repo ends and the subpath
+    begins, so it folds the whole remaining path into ``repo_url``, which
+    then fails validation as a single (non-existent) repository. Surface
+    *why* instead of a bare "not accessible" so the user knows to
+    configure the host rather than suspect a permissions problem.
+    """
+    host = dep_ref.host
+    if not host or dep_ref.is_local or dep_ref.is_virtual:
+        return None
+    if is_github_hostname(host) or dep_ref.is_azure_devops() or is_gitlab_hostname(host):
+        return None
+    if len(dep_ref.repo_url.split("/")) <= 2:
+        return None
+    return (
+        f"'{host}' was treated as a single repository path "
+        f"('{dep_ref.repo_url}') because it isn't recognised as GitHub, "
+        f"Azure DevOps, or GitLab. If this is a self-hosted GitLab instance, "
+        f"set GITLAB_HOST={host} (or add it to the comma-separated "
+        f"APM_GITLAB_HOSTS) and re-run to enable repo/subpath resolution for "
+        f"nested groups. Otherwise, use an explicit 'git:' + 'path:' entry "
+        f"in apm.yml."
+    )
 
 
 def _local_path_no_markers_hint(local_dir, logger=None):

--- a/tests/unit/install/test_validation_error_handling.py
+++ b/tests/unit/install/test_validation_error_handling.py
@@ -275,7 +275,6 @@ class TestGenericHostAmbiguousSubpathHint:
         assert reason is not None
         assert "GITLAB_HOST=gitlab.company.com" in reason
         assert "APM_GITLAB_HOSTS" in reason
-        assert "gitlab.company.com" in reason
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/install/test_validation_error_handling.py
+++ b/tests/unit/install/test_validation_error_handling.py
@@ -7,6 +7,10 @@ Covers branches not hit by existing validation tests:
 * ``_log_tls_failure`` -- non-verbose and verbose branches
 * ``_local_path_failure_reason`` -- all branches (non-local, not-exists,
   not-dir, no-markers)
+* ``_generic_host_ambiguous_subpath_hint`` -- unrecognised FQDN with an
+  ambiguous multi-segment repo path (issue #2066), and the guard branches
+  that suppress the hint (local, virtual, GitHub, ADO, GitLab-recognised,
+  two-segment repo path)
 * ``_local_path_no_markers_hint`` -- no found, with logger, without logger,
   > 5 items
 * ``_validate_package_exists`` -- local exists with apm.yml, with SKILL.md,
@@ -168,6 +172,101 @@ class TestLocalPathFailureReason:
         reason = _local_path_failure_reason(dep)
         assert reason is not None
         assert "apm.yml" in reason or "SKILL.md" in reason
+
+
+# ---------------------------------------------------------------------------
+# _generic_host_ambiguous_subpath_hint
+# ---------------------------------------------------------------------------
+
+
+class TestGenericHostAmbiguousSubpathHint:
+    """Issue #2066: an unrecognised self-hosted FQDN silently swallows a
+    monorepo subpath into ``repo_url`` instead of splitting it, then fails
+    validation with a misleading "not accessible" error. This hint should
+    fire only for that exact shape and point the user at GITLAB_HOST /
+    APM_GITLAB_HOSTS instead.
+    """
+
+    def _dep(self, **overrides):
+        dep = MagicMock()
+        dep.host = "gitlab.company.com"
+        dep.is_local = False
+        dep.is_virtual = False
+        dep.is_azure_devops.return_value = False
+        dep.repo_url = "my-org/my-monorepo/primitives/skills/my-skill"
+        for key, value in overrides.items():
+            setattr(dep, key, value)
+        return dep
+
+    def test_no_host_returns_none(self, monkeypatch) -> None:
+        from apm_cli.install.validation import _generic_host_ambiguous_subpath_hint
+
+        monkeypatch.delenv("GITLAB_HOST", raising=False)
+        monkeypatch.delenv("APM_GITLAB_HOSTS", raising=False)
+        assert _generic_host_ambiguous_subpath_hint(self._dep(host=None)) is None
+
+    def test_local_dep_returns_none(self, monkeypatch) -> None:
+        from apm_cli.install.validation import _generic_host_ambiguous_subpath_hint
+
+        monkeypatch.delenv("GITLAB_HOST", raising=False)
+        monkeypatch.delenv("APM_GITLAB_HOSTS", raising=False)
+        assert _generic_host_ambiguous_subpath_hint(self._dep(is_local=True)) is None
+
+    def test_virtual_dep_returns_none(self, monkeypatch) -> None:
+        from apm_cli.install.validation import _generic_host_ambiguous_subpath_hint
+
+        monkeypatch.delenv("GITLAB_HOST", raising=False)
+        monkeypatch.delenv("APM_GITLAB_HOSTS", raising=False)
+        assert _generic_host_ambiguous_subpath_hint(self._dep(is_virtual=True)) is None
+
+    def test_github_host_returns_none(self, monkeypatch) -> None:
+        from apm_cli.install.validation import _generic_host_ambiguous_subpath_hint
+
+        monkeypatch.delenv("GITLAB_HOST", raising=False)
+        monkeypatch.delenv("APM_GITLAB_HOSTS", raising=False)
+        assert _generic_host_ambiguous_subpath_hint(self._dep(host="github.com")) is None
+
+    def test_ado_host_returns_none(self, monkeypatch) -> None:
+        from apm_cli.install.validation import _generic_host_ambiguous_subpath_hint
+
+        monkeypatch.delenv("GITLAB_HOST", raising=False)
+        monkeypatch.delenv("APM_GITLAB_HOSTS", raising=False)
+        dep = self._dep(host="dev.azure.com")
+        dep.is_azure_devops.return_value = True
+        assert _generic_host_ambiguous_subpath_hint(dep) is None
+
+    def test_gitlab_com_returns_none(self, monkeypatch) -> None:
+        from apm_cli.install.validation import _generic_host_ambiguous_subpath_hint
+
+        monkeypatch.delenv("GITLAB_HOST", raising=False)
+        monkeypatch.delenv("APM_GITLAB_HOSTS", raising=False)
+        assert _generic_host_ambiguous_subpath_hint(self._dep(host="gitlab.com")) is None
+
+    def test_selfhosted_host_already_registered_via_env_returns_none(self, monkeypatch) -> None:
+        from apm_cli.install.validation import _generic_host_ambiguous_subpath_hint
+
+        monkeypatch.setenv("GITLAB_HOST", "gitlab.company.com")
+        monkeypatch.delenv("APM_GITLAB_HOSTS", raising=False)
+        assert _generic_host_ambiguous_subpath_hint(self._dep()) is None
+
+    def test_two_segment_repo_path_returns_none(self, monkeypatch) -> None:
+        """A plain owner/repo on a generic host isn't ambiguous -- don't hint."""
+        from apm_cli.install.validation import _generic_host_ambiguous_subpath_hint
+
+        monkeypatch.delenv("GITLAB_HOST", raising=False)
+        monkeypatch.delenv("APM_GITLAB_HOSTS", raising=False)
+        assert _generic_host_ambiguous_subpath_hint(self._dep(repo_url="owner/repo")) is None
+
+    def test_unrecognised_selfhosted_ambiguous_path_returns_hint(self, monkeypatch) -> None:
+        from apm_cli.install.validation import _generic_host_ambiguous_subpath_hint
+
+        monkeypatch.delenv("GITLAB_HOST", raising=False)
+        monkeypatch.delenv("APM_GITLAB_HOSTS", raising=False)
+        reason = _generic_host_ambiguous_subpath_hint(self._dep())
+        assert reason is not None
+        assert "GITLAB_HOST=gitlab.company.com" in reason
+        assert "APM_GITLAB_HOSTS" in reason
+        assert "gitlab.company.com" in reason
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/install/test_validation_error_handling.py
+++ b/tests/unit/install/test_validation_error_handling.py
@@ -257,6 +257,15 @@ class TestGenericHostAmbiguousSubpathHint:
         monkeypatch.delenv("APM_GITLAB_HOSTS", raising=False)
         assert _generic_host_ambiguous_subpath_hint(self._dep(repo_url="owner/repo")) is None
 
+    def test_two_segment_repo_path_with_trailing_slash_returns_none(self, monkeypatch) -> None:
+        """Empty segments from a trailing/double slash must not inflate the count."""
+        from apm_cli.install.validation import _generic_host_ambiguous_subpath_hint
+
+        monkeypatch.delenv("GITLAB_HOST", raising=False)
+        monkeypatch.delenv("APM_GITLAB_HOSTS", raising=False)
+        assert _generic_host_ambiguous_subpath_hint(self._dep(repo_url="owner/repo/")) is None
+        assert _generic_host_ambiguous_subpath_hint(self._dep(repo_url="owner//repo")) is None
+
     def test_unrecognised_selfhosted_ambiguous_path_returns_hint(self, monkeypatch) -> None:
         from apm_cli.install.validation import _generic_host_ambiguous_subpath_hint
 

--- a/tests/unit/test_install_command.py
+++ b/tests/unit/test_install_command.py
@@ -470,6 +470,28 @@ class TestValidationFailureReasonMessages:
             # user is already in verbose mode.
             assert "run with --verbose for the full probe log" not in output
 
+    @patch("apm_cli.commands.install._validate_package_exists", return_value=False)
+    def test_selfhosted_gitlab_like_host_hints_gitlab_host_env(self, mock_validate, monkeypatch):
+        """Issue #2066: an unrecognised self-hosted FQDN with a multi-segment
+        path is folded into a single (non-existent) repo path at parse time.
+        The failure reason should point at GITLAB_HOST/APM_GITLAB_HOSTS
+        instead of the generic "not accessible" message.
+        """
+        monkeypatch.delenv("GITLAB_HOST", raising=False)
+        monkeypatch.delenv("APM_GITLAB_HOSTS", raising=False)
+        with self._chdir_tmp():
+            Path("apm.yml").write_text("name: test\ndependencies:\n  apm: []\n  mcp: []\n")
+            result = self.runner.invoke(
+                cli,
+                [
+                    "install",
+                    "gitlab.company.com/my-org/my-monorepo/primitives/skills/my-skill#v1.0.0",
+                ],
+            )
+            output = " ".join(result.output.split())
+            assert "GITLAB_HOST=gitlab.company.com" in output
+            assert "APM_GITLAB_HOSTS" in output
+
     @patch(
         "apm_cli.core.token_manager.GitHubTokenManager.resolve_credential_from_git",
         return_value=None,


### PR DESCRIPTION
## Description

`apm install <fqdn>/org/repo/subpath#ref` only splits `repo` from `subpath` on hosts already recognised as GitLab-class: literally `gitlab.com`, or a host explicitly declared via `GITLAB_HOST` / `APM_GITLAB_HOSTS`. When the host is an *unrecognised* self-hosted GitLab FQDN (the common case: a company GitLab that the user hasn't told APM about yet), the whole remaining path is folded into `repo_url` at parse time -- there's no ambiguous-boundary probing to fall back on, because that probe itself requires the host to already be GitLab-classified. The resulting `git ls-remote` then fails against a bogus repo path, and the user sees:

```
[x] gitlab.company.com/my-org/my-monorepo/primitives/skills/my-skill -- not accessible or doesn't exist
```

which reads like a permissions/network problem, not a missing-config one.

Fixes #2066.

### Investigation note

The issue as filed reproduces with `gitlab.com` in the example, and cites PR #1684's "gitlab.com excluded" comment as the root cause. I verified end-to-end (including against the real `gitlab.com` host, and against the exact `apm==0.23.1` build cited in the issue) that the `gitlab.com` case already works correctly today -- that exclusion is in the *GHES*-specific host-detection branch, which is deliberately not the code path GitLab uses (GitLab has its own dedicated boundary-probe resolver, `install/gitlab_resolver.py`, already covered by `tests/unit/install/test_gitlab_resolver.py`).

The actual reproducible gap is **self-hosted GitLab without `GITLAB_HOST`/`APM_GITLAB_HOSTS` configured** -- confirmed end-to-end against a real self-hosted instance (`gitlab.gnome.org`) both before and after this change.

## Approach

Rather than trying to auto-detect arbitrary self-hosted FQDNs as GitLab-class (higher risk: APM can't safely guess an unknown host's namespace-depth convention), this keeps the existing GHES-style opt-in model (`GITHUB_HOST` already works the same way for GitHub Enterprise) and fixes the UX gap: when a generic, unrecognised host fails validation with an ambiguous multi-segment path, the error message now explains *why* and points at the fix.

Before:
```
[x] gitlab.company.com/my-org/my-monorepo/primitives/skills/my-skill -- not accessible or doesn't exist -- run with --verbose for auth details
```

After:
```
[x] gitlab.company.com/my-org/my-monorepo/primitives/skills/my-skill -- 'gitlab.company.com' was treated as a single repository path ('my-org/my-monorepo/primitives/skills/my-skill') because it isn't recognised as GitHub, Azure DevOps, or GitLab. If this is a self-hosted GitLab instance, set GITLAB_HOST=gitlab.company.com (or add it to the comma-separated APM_GITLAB_HOSTS) and re-run to enable repo/subpath resolution for nested groups. Otherwise, use an explicit 'git:' + 'path:' entry in apm.yml.
```

## Implementation

- `src/apm_cli/install/validation.py`: new `_generic_host_ambiguous_subpath_hint(dep_ref)`, following the existing `_local_path_failure_reason` pattern. Fires only when: the dep isn't local/virtual, the host isn't GitHub/ADO/GitLab-recognised, and `repo_url` has more than 2 path segments (i.e. genuinely ambiguous -- a plain `owner/repo` on a generic host is unaffected).
- `src/apm_cli/commands/install.py`: wires the new helper into the existing failure-reason chain in `_resolve_package_references`, ahead of the generic "not accessible" fallback.
- Tests: unit coverage for the helper's guard branches (local, virtual, GitHub, ADO, `gitlab.com`, env-registered self-hosted host, two-segment path) plus one CLI-level test asserting the hint text end-to-end through `apm install`.
- `CHANGELOG.md`: `[Unreleased] / Fixed` entry crediting this fix to #2066.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally, including live end-to-end runs against a real self-hosted GitLab instance (`gitlab.gnome.org`) reproducing the failure before this change and confirming the fix after, plus the `GITLAB_HOST`-configured success path
- [x] All existing tests pass (`uv run pytest tests/unit tests/test_console.py`; the small number of pre-existing failures in `test_install_target_copilot_app_e2e.py`, `test_install_target_copilot_cowork_e2e.py`, `test_mcp_integrator_install_flow.py`/`test_mcp_integrator_install_phase3.py`, and two terminal-width-sensitive assertions in `test_install_command.py` reproduce identically on `main` without this change)
- [x] Added tests for new functionality
- [x] `ruff check` / `ruff format --check` clean

## Spec conformance (OpenAPM v0.1)

- [x] N/A -- this PR does not change OpenAPM-observable behaviour (no change to what resolves/installs; only the diagnostic text on an existing failure path changes).

apm-spec-waiver: error-message-only change, no install/resolution behavior delta

## How to test

```bash
# Without GITLAB_HOST/APM_GITLAB_HOSTS set:
apm install "gitlab.gnome.org/GNOME/gnome-shell/data#main" --dry-run
# -> actionable hint mentioning GITLAB_HOST=gitlab.gnome.org

# With the host registered:
GITLAB_HOST=gitlab.gnome.org apm install "gitlab.gnome.org/GNOME/gnome-shell/data#main" --dry-run
# -> resolves successfully
```
