### PR TITLE
ci(release): mint GitHub App token for Homebrew tap dispatch

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -785,10 +785,30 @@ jobs:
           echo "Linux x86_64 SHA: $LINUX_X86_64_SHA"
           echo "Linux ARM64 SHA: $LINUX_ARM64_SHA"
 
+      # Mint a short-lived (1h) GitHub App installation token scoped to the
+      # tap repo. App installation tokens are NOT personal access tokens, so
+      # they are exempt from the 'Microsoft Open Source' enterprise policy that
+      # forbids fine-grained PATs with a lifetime > 8 days. This removes the
+      # unsustainable 8-day PAT-rotation treadmill that previously broke this
+      # job. Requires two org/repo secrets, set once, that never expire:
+      #   HOMEBREW_TAP_APP_ID          -- the GitHub App's numeric App ID
+      #   HOMEBREW_TAP_APP_PRIVATE_KEY -- the App's PEM private key
+      # The App must be installed on microsoft/homebrew-apm with
+      # Repository permissions: Contents = Read and write (repository_dispatch
+      # is delivered on the target repo's Contents write scope).
+      - name: Mint Homebrew tap installation token
+        id: tap-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.HOMEBREW_TAP_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: microsoft
+          repositories: homebrew-apm
+
       - name: Trigger Homebrew tap repository update
         uses: peter-evans/repository-dispatch@v3
         with:
-          token: ${{ secrets.GH_PKG_PAT }}
+          token: ${{ steps.tap-token.outputs.token }}
           repository: microsoft/homebrew-apm
           event-type: formula-update
           client-payload: |


### PR DESCRIPTION
## TL;DR

Switch the release pipeline's Homebrew-tap update from a fine-grained PAT to a short-lived **GitHub App installation token**, so the job stops breaking every 8 days under the org's PAT-lifetime policy.

## Problem (WHY)

The `update-homebrew` job sends a `repository_dispatch` to `microsoft/homebrew-apm` using `secrets.GH_PKG_PAT` (a fine-grained PAT). During the v0.24.0 release the step failed hard:

```
The 'Microsoft Open Source' enterprise forbids access via a fine-grained
personal access tokens if the token's lifetime is greater than 8 days
```

So the token can live at most 8 days -- meaning a maintainer would have to rotate the secret **every week** or the Homebrew formula silently stops updating on release. That is not sustainable.

`GH_PKG_PAT` is referenced **only** in this one step, so swapping it is fully isolated.

## Approach (WHAT)

Mint a **GitHub App installation token** at job time and hand it to the dispatch step instead of the PAT.

Installation tokens:
- are **not** personal access tokens, so the enterprise PAT-lifetime policy does not apply;
- auto-expire after ~1 hour (minted fresh each run -- least privilege);
- are backed by an App **private key that never expires**, so there is nothing to rotate on a schedule.

This mirrors the pattern already trusted in this repo -- the gh-aw workflows (`pr-review-panel`, `triage-panel`, `docs-sync`) already use `actions/create-github-app-token`.

## Implementation (HOW)

- Added a `Mint Homebrew tap installation token` step (`actions/create-github-app-token@v3`) scoped to `owner: microsoft`, `repositories: homebrew-apm`.
- Repointed the `repository-dispatch` step's `token:` from `secrets.GH_PKG_PAT` to `steps.tap-token.outputs.token`.
- No behavior change to the payload, checksums, or triggering conditions.

```mermaid
flowchart LR
    A[create-release + publish-pypi] --> B[Mint App token<br/>~1h, auto-expires]
    B --> C[repository_dispatch<br/>-> microsoft/homebrew-apm]
    C --> D[Tap formula bumped]
```

## Required one-time maintainer setup

This PR is inert until two secrets exist on `microsoft/apm` (they never expire, set once):

| Secret | Value |
| --- | --- |
| `HOMEBREW_TAP_APP_ID` | The GitHub App's numeric App ID |
| `HOMEBREW_TAP_APP_PRIVATE_KEY` | The App's PEM private key |

The App must be **installed on `microsoft/homebrew-apm`** with Repository permission **Contents: Read and write** (the scope `repository_dispatch` is delivered under). `GH_PKG_PAT` can be deleted afterward.

## Trade-offs

- Requires standing up (or reusing) a GitHub App + installing it on the tap repo -- a one-time cost that buys permanent freedom from rotation.
- Alternative considered: a self-contained polling workflow **inside** `microsoft/homebrew-apm` that reads the latest `microsoft/apm` release with its own `GITHUB_TOKEN` and needs **zero** cross-repo secrets. Strongest long-term option, but it lives in the tap repo, out of scope for this PR. See PR discussion.

## Validation evidence

| Check | Status |
| --- | --- |
| YAML parse (`yaml.safe_load`) | [+] valid |
| Scope of change | [+] single step; `GH_PKG_PAT` used nowhere else |
| End-to-end dispatch | Requires the secrets above; will validate on the next tagged release |

## How to test

1. Create the GitHub App + install on `microsoft/homebrew-apm` (Contents: RW); add the two secrets.
2. Cut the next release tag (or re-run the `update-homebrew` job of an existing tagged run).
3. Confirm the token step succeeds and the tap repo receives the `formula-update` dispatch.
