### PR TITLE
fix(update): reconcile MCP/LSP servers after apm update

### DIFF
--- a/docs/src/content/docs/reference/lockfile-spec.md
+++ b/docs/src/content/docs/reference/lockfile-spec.md
@@ -116,9 +116,9 @@ local_deployed_file_hashes:
 | `generated_at` | ISO 8601 string | yes | UTC timestamp of the last write. Ignored by equivalence checks. |
 | `apm_version` | string | no | APM CLI version that wrote the file. Diagnostic only. |
 | `dependencies` | list | yes | Resolved APM packages. See [per-entry fields](#per-entry-fields). |
-| `mcp_servers` | list of strings | no | Names of MCP servers declared in the manifest at install time. |
+| `mcp_servers` | list of strings | no | Names of MCP servers declared in the manifest as of the last install or update. |
 | `mcp_configs` | map | no | `server_name -> resolved config dict` baseline used to detect MCP drift. |
-| `lsp_servers` | list of strings | no | Names of LSP servers declared in the manifest at install time. |
+| `lsp_servers` | list of strings | no | Names of LSP servers declared in the manifest as of the last install or update. |
 | `lsp_configs` | map | no | `server_name -> resolved config dict` baseline used to detect LSP drift. |
 | `local_deployed_files` | list | no | Files this project itself contributes (sources its own primitives). See [self entry](#self-entry). |
 | `local_deployed_file_hashes` | map | no | `path -> sha256` for `local_deployed_files`. |

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -268,7 +268,9 @@ _APM_IMPORT_ERROR = None
 try:
     from ..deps.apm_resolver import APMDependencyResolver
     from ..deps.lockfile import LockFile, get_lockfile_path, migrate_lockfile_if_needed
-    from ..integration.mcp_integrator import MCPIntegrator
+    from ..integration.mcp_integrator import (
+        MCPIntegrator,  # noqa: F401 -- re-exported; tests patch commands.install.MCPIntegrator
+    )
     from ..models.apm_package import APMPackage, DependencyReference
 
     class _ScopedInstallDependencyResolver(APMDependencyResolver):
@@ -1845,122 +1847,44 @@ def _install_apm_packages(ctx, outcome):
 
         clear_apm_yml_cache()
 
-    # Collect transitive MCP dependencies from resolved APM packages
-    transitive_mcp = []
+    # -------------------------------------------------------------------------
+    # MCP integration (extracted to install/mcp/integration.py)
+    # -------------------------------------------------------------------------
+    from apm_cli.install.mcp import run_mcp_integration
+    from apm_cli.policy.install_preflight import PolicyBlockError
+
     from ..core.scope import get_modules_dir
 
     apm_modules_path = get_modules_dir(ctx.scope)
-    if should_install_mcp and apm_modules_path.exists():
-        lock_path = get_lockfile_path(ctx.apm_dir)
-        transitive_mcp = MCPIntegrator.collect_transitive(
-            apm_modules_path,
-            lock_path,
-            ctx.trust_transitive_mcp,
-            diagnostics=apm_diagnostics,
-        )
-        if transitive_mcp:
-            logger.verbose_detail(f"Collected {len(transitive_mcp)} transitive MCP dependency(ies)")
-            mcp_deps = MCPIntegrator.deduplicate(mcp_deps + transitive_mcp)
 
-    # allowExecutables MCP gate.
-    from ..security.executables import filter_mcp_by_allow_executables as _fmcp
-
-    mcp_deps = _fmcp(mcp_deps, getattr(apm_package, "allow_executables", None), logger)
-
-    # The pipeline gate phase (policy_gate.py) checks direct APM deps
-    # and direct MCP deps from apm.yml.  However, transitive MCP
-    # servers (discovered via collect_transitive above) are only known
-    # after APM packages are installed.  Run a second preflight
-    # against the *merged* MCP set (direct + transitive) BEFORE
-    # MCPIntegrator writes runtime configs.  On PolicyBlockError we
-    # abort the MCP write but leave already-installed APM packages
-    # in place (they were approved by the gate phase).
-    if should_install_mcp and mcp_deps:
-        from apm_cli.policy.install_preflight import (
-            PolicyBlockError as _TransitivePBE,
-        )
-        from apm_cli.policy.install_preflight import (
-            run_policy_preflight as _transitive_preflight,
-        )
-
-        try:
-            _transitive_preflight(
-                project_root=ctx.project_root,
-                mcp_deps=mcp_deps,
-                no_policy=ctx.no_policy,
-                logger=logger,
-                dry_run=False,
-            )
-        except _TransitivePBE:
-            logger.error(
-                "MCP server(s) blocked by org policy. "
-                "APM packages remain installed; MCP configs were NOT written."
-            )
-            logger.render_summary()
-            sys.exit(1)
-
-    mcp_count = 0
-    new_mcp_servers: builtins.set = builtins.set()
-    # Forward only the targets-key the user actually declared so parse_targets_field
-    # in the gate sees the same dict shape it sees from raw apm.yml. Including a
-    # `targets: None` placeholder when the user wrote `target:` (singular) would
-    # falsely trip the conflict-mutex check (see core.apm_yml.parse_targets_field).
-    # This restores parity with `apm install` for users on the modern `targets:`
-    # plural form -- without this, `targets:` was silently dropped at the call
-    # site and the gate fell back to permissive directory detection (#1335).
-    mcp_apm_config: dict = {"scripts": apm_package.scripts or {}}
-    if apm_package.targets is not None:
-        mcp_apm_config["targets"] = apm_package.targets
-    elif apm_package.target is not None:
-        mcp_apm_config["target"] = apm_package.target
-    if should_install_mcp and mcp_deps:
-        mcp_count = MCPIntegrator.install(
-            mcp_deps,
-            ctx.runtime,
-            ctx.exclude,
-            ctx.verbose,
-            stored_mcp_configs=old_mcp_configs,
-            apm_config=mcp_apm_config,
+    try:
+        mcp_count, mcp_apm_config = run_mcp_integration(
+            apm_package=apm_package,
+            mcp_deps=mcp_deps,
+            apm_modules_path=apm_modules_path,
+            lock_path=_lock_path,
+            old_mcp_servers=old_mcp_servers,
+            old_mcp_configs=old_mcp_configs,
             project_root=ctx.project_root,
             user_scope=(ctx.scope is InstallScope.USER),
-            explicit_target=ctx.target,
+            should_install=should_install_mcp,
+            logger=logger,
             diagnostics=apm_diagnostics,
+            runtime=ctx.runtime,
+            exclude=ctx.exclude,
+            trust_transitive_mcp=ctx.trust_transitive_mcp,
+            no_policy=ctx.no_policy,
+            verbose=ctx.verbose,
+            explicit_target=ctx.target,
             scope=ctx.scope,
         )
-        new_mcp_servers = MCPIntegrator.get_server_names(mcp_deps)
-        new_mcp_configs = MCPIntegrator.get_server_configs(mcp_deps)
-
-        # Remove stale MCP servers that are no longer needed
-        stale_servers = old_mcp_servers - new_mcp_servers
-        if stale_servers:
-            MCPIntegrator.remove_stale(
-                stale_servers,
-                ctx.runtime,
-                ctx.exclude,
-                project_root=ctx.project_root,
-                user_scope=(ctx.scope is InstallScope.USER),
-                scope=ctx.scope,
-            )
-
-        # Persist the new MCP server set and configs in the lockfile
-        MCPIntegrator.update_lockfile(new_mcp_servers, _lock_path, mcp_configs=new_mcp_configs)
-    elif should_install_mcp and not mcp_deps:
-        # No MCP deps at all -- remove any old APM-managed servers
-        if old_mcp_servers:
-            MCPIntegrator.remove_stale(
-                old_mcp_servers,
-                ctx.runtime,
-                ctx.exclude,
-                project_root=ctx.project_root,
-                user_scope=(ctx.scope is InstallScope.USER),
-                scope=ctx.scope,
-            )
-            MCPIntegrator.update_lockfile(builtins.set(), _lock_path, mcp_configs={})
-        logger.verbose_detail("No MCP dependencies found in apm.yml")
-    elif not should_install_mcp and old_mcp_servers:
-        # --only=apm: APM install regenerated the lockfile and dropped
-        # mcp_servers.  Restore the previous set so it is not lost.
-        MCPIntegrator.update_lockfile(old_mcp_servers, _lock_path, mcp_configs=old_mcp_configs)
+    except PolicyBlockError:
+        logger.error(
+            "MCP server(s) blocked by org policy. "
+            "APM packages remain installed; MCP configs were NOT written."
+        )
+        logger.render_summary()
+        sys.exit(1)
 
     # -------------------------------------------------------------------------
     # LSP integration (extracted to install/lsp/integration.py)

--- a/src/apm_cli/commands/update.py
+++ b/src/apm_cli/commands/update.py
@@ -82,6 +82,8 @@ from ._helpers import UnknownPackageError, _find_apm_yml, resolve_requested_pack
 
 if TYPE_CHECKING:
     from ..core.command_logger import CommandLogger
+    from ..core.scope import InstallScope
+    from ..deps.lockfile import LockFile
     from ..models.dependency.reference import DependencyReference
 
 
@@ -188,6 +190,83 @@ def _annotate_lockfile_revision_tags(project_root: Path, updates: list[RevisionP
             changed = True
     if changed:
         lockfile.save(lockfile_path)
+
+
+def _run_mcp_lsp_integration(
+    *,
+    scope: InstallScope,
+    project_root: Path,
+    existing_lock: LockFile | None,
+    lock_path: Path,
+    target: str | list[str] | None,
+    diagnostics: Any,
+    logger: InstallLogger,
+    verbose: bool,
+) -> None:
+    """Reconcile MCP and LSP servers against the current apm.yml.
+
+    ``apm update`` calls ``_install_apm_dependencies`` directly rather than
+    going through ``_install_apm_packages`` (see ``commands/install.py``),
+    so it must separately run the same MCP/LSP integration that helper
+    performs. Mirrors ``_install_apm_packages``'s ordering: clear the
+    apm.yml parse cache, re-parse the on-disk manifest (revision pins are
+    already applied by this point), then reconcile MCP and LSP servers.
+    """
+    from apm_cli.core.scope import InstallScope, get_modules_dir
+    from apm_cli.install.lsp import run_lsp_integration
+    from apm_cli.install.mcp import run_mcp_integration
+    from apm_cli.models.apm_package import APMPackage, clear_apm_yml_cache
+    from apm_cli.policy.install_preflight import PolicyBlockError
+
+    clear_apm_yml_cache()
+    apm_package = APMPackage.from_apm_yml(Path("apm.yml"))
+
+    old_mcp_servers: set = set()
+    old_mcp_configs: dict = {}
+    if existing_lock:
+        old_mcp_servers = set(existing_lock.mcp_servers)
+        old_mcp_configs = dict(existing_lock.mcp_configs)
+
+    apm_modules_path = get_modules_dir(scope)
+    user_scope = scope is InstallScope.USER
+
+    try:
+        _mcp_count, mcp_apm_config = run_mcp_integration(
+            apm_package=apm_package,
+            mcp_deps=apm_package.get_all_mcp_dependencies(),
+            apm_modules_path=apm_modules_path,
+            lock_path=lock_path,
+            old_mcp_servers=old_mcp_servers,
+            old_mcp_configs=old_mcp_configs,
+            project_root=project_root,
+            user_scope=user_scope,
+            should_install=True,
+            logger=logger,
+            diagnostics=diagnostics,
+            verbose=verbose,
+            explicit_target=target,
+            scope=scope,
+        )
+    except PolicyBlockError:
+        _rich_error(
+            "MCP server(s) blocked by org policy. "
+            "APM packages remain installed; MCP configs were NOT written."
+        )
+        logger.render_summary()
+        sys.exit(1)
+
+    run_lsp_integration(
+        apm_package=apm_package,
+        apm_modules_path=apm_modules_path,
+        lock_path=lock_path,
+        existing_lock=existing_lock,
+        project_root=project_root,
+        user_scope=user_scope,
+        should_install=True,
+        logger=logger,
+        diagnostics=diagnostics,
+        target_context=(mcp_apm_config, target, scope),
+    )
 
 
 @click.command(
@@ -527,6 +606,20 @@ def _run_dep_update(
 
         return _confirm_plan_application()
 
+    # Snapshot the pre-update lockfile's MCP/LSP state before
+    # ``_install_apm_dependencies`` regenerates it. The lockfile phase
+    # carries ``mcp_servers``/``mcp_configs`` forward unreconciled (see
+    # ``install/phases/lockfile.py::_preserve_existing_mcp_state``), so this
+    # is the correct "old" baseline for stale-server detection below. LSP
+    # fields have no such carry-forward, so they must be captured here too.
+    from apm_cli.core.scope import get_apm_dir, get_deploy_root
+    from apm_cli.deps.lockfile import LockFile, get_lockfile_path
+
+    _apm_dir = get_apm_dir(scope)
+    _mcp_lsp_project_root = get_deploy_root(scope)
+    _lock_path = get_lockfile_path(_apm_dir)
+    _existing_lock = LockFile.read(_lock_path)
+
     try:
         # Fire pre-update lifecycle scripts
         _fire_update_scripts(
@@ -586,6 +679,24 @@ def _run_dep_update(
             except Exception as e:
                 _rich_error(f"Failed to record revision-pin tags in apm.lock.yaml: {e}")
                 sys.exit(1)
+
+        try:
+            _run_mcp_lsp_integration(
+                scope=scope,
+                project_root=_mcp_lsp_project_root,
+                existing_lock=_existing_lock,
+                lock_path=_lock_path,
+                target=target,
+                diagnostics=getattr(result, "diagnostics", None),
+                logger=logger,
+                verbose=verbose,
+            )
+        except Exception as e:
+            _rich_error(f"Error reconciling MCP/LSP servers: {e}")
+            if not verbose:
+                _rich_info("Run with --verbose for detailed diagnostics.")
+            sys.exit(1)
+
         # Report the number of dependencies that actually changed (per the
         # plan), not the total tree re-materialized (result.installed_count).
         # The latter counts unchanged deps that were re-integrated, which

--- a/src/apm_cli/install/mcp/__init__.py
+++ b/src/apm_cli/install/mcp/__init__.py
@@ -12,7 +12,12 @@ Layout:
     command.py      ``run_mcp_install`` orchestrator
     conflicts.py    ``--mcp`` flag conflict matrix (E1-E15)
     entry.py        Pure ``apm.yml`` MCP entry builder (str | dict union)
+    integration.py  ``run_mcp_integration`` -- post-install MCP reconciliation
     registry.py     ``--registry`` validation, precedence, env override
     warnings.py     F5 SSRF + F7 shell-metachar install-time warnings
     writer.py       Idempotent ``apm.yml`` MCP entry persistence
 """
+
+from .integration import run_mcp_integration
+
+__all__ = ["run_mcp_integration"]

--- a/src/apm_cli/install/mcp/integration.py
+++ b/src/apm_cli/install/mcp/integration.py
@@ -1,0 +1,182 @@
+"""MCP server integration for the APM install pipeline.
+
+Mirrors the LSP integration pattern (see ``apm_cli.install.lsp.integration``)
+with runtime-neutral target selection.
+"""
+
+import builtins
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from apm_cli.models.apm_package import APMPackage
+
+
+def run_mcp_integration(  # noqa: PLR0913
+    *,
+    apm_package: "APMPackage",
+    mcp_deps: list,
+    apm_modules_path: Path,
+    lock_path: Path,
+    old_mcp_servers: builtins.set,
+    old_mcp_configs: builtins.dict,
+    project_root: Path,
+    user_scope: bool,
+    should_install: bool,
+    logger,
+    diagnostics=None,
+    runtime: str | None = None,
+    exclude: str | None = None,
+    trust_transitive_mcp: bool = False,
+    no_policy: bool = False,
+    verbose: bool = False,
+    explicit_target: str | list[str] | None = None,
+    scope=None,
+) -> tuple[int, dict]:
+    """Run MCP server integration after APM package installation.
+
+    Mirrors the LSP integration pattern:
+    1. Collect direct + transitive MCP deps
+    2. Deduplicate (first occurrence wins)
+    3. Filter by ``allowExecutables``
+    4. Enforce policy against the merged (direct + transitive) set
+    5. Install to each target's MCP config
+    6. Clean up stale servers
+    7. Update lockfile
+
+    Args:
+        apm_package: Root APM package with MCP deps.
+        mcp_deps: Direct MCP dependencies (pre-merge with transitive).
+        apm_modules_path: Path to apm_modules directory.
+        lock_path: Path to apm.lock.yaml.
+        old_mcp_servers: MCP server names from the lockfile before this run.
+        old_mcp_configs: MCP server configs from the lockfile before this run.
+        project_root: Project root directory.
+        user_scope: If True, write to user-scope runtime config paths.
+        should_install: Whether MCP integration should run.
+        logger: Install logger instance.
+        diagnostics: Optional DiagnosticCollector.
+        runtime: Optional runtime override.
+        exclude: Optional runtime exclusion.
+        trust_transitive_mcp: Auto-trust self-defined MCP servers declared by
+            transitive dependencies.
+        no_policy: Skip policy enforcement for the merged MCP set.
+        verbose: Show detailed installation information.
+        explicit_target: Explicit target selected by CLI or manifest.
+        scope: Optional InstallScope for user/project filtering.
+
+    Returns:
+        Tuple of ``(mcp_count, mcp_apm_config)``. ``mcp_apm_config`` is the
+        target-resolution metadata derived from *apm_package*, returned so
+        callers can forward it to :func:`apm_cli.install.lsp.run_lsp_integration`.
+
+    Raises:
+        apm_cli.policy.install_preflight.PolicyBlockError: When the merged
+            MCP set is blocked by org policy. Callers must catch this,
+            report the violation, and exit non-zero; already-installed APM
+            packages are left in place.
+    """
+    from apm_cli.integration.mcp_integrator import MCPIntegrator
+    from apm_cli.policy.install_preflight import run_policy_preflight
+
+    # Collect transitive MCP deps from installed packages
+    if should_install and apm_modules_path.exists():
+        transitive_mcp = MCPIntegrator.collect_transitive(
+            apm_modules_path,
+            lock_path,
+            trust_transitive_mcp,
+            diagnostics=diagnostics,
+        )
+        if transitive_mcp:
+            logger.verbose_detail(f"Collected {len(transitive_mcp)} transitive MCP dependency(ies)")
+            mcp_deps = MCPIntegrator.deduplicate(mcp_deps + transitive_mcp)
+
+    # allowExecutables MCP gate.
+    from apm_cli.security.executables import filter_mcp_by_allow_executables
+
+    mcp_deps = filter_mcp_by_allow_executables(
+        mcp_deps, getattr(apm_package, "allow_executables", None), logger
+    )
+
+    # The pipeline gate phase (policy_gate.py) checks direct APM deps
+    # and direct MCP deps from apm.yml.  However, transitive MCP
+    # servers (discovered via collect_transitive above) are only known
+    # after APM packages are installed.  Run a second preflight
+    # against the *merged* MCP set (direct + transitive) BEFORE
+    # MCPIntegrator writes runtime configs.  The caller is responsible
+    # for catching PolicyBlockError and aborting the MCP write while
+    # leaving already-installed APM packages in place.
+    if should_install and mcp_deps:
+        run_policy_preflight(
+            project_root=project_root,
+            mcp_deps=mcp_deps,
+            no_policy=no_policy,
+            logger=logger,
+            dry_run=False,
+        )
+
+    mcp_count = 0
+    new_mcp_servers: builtins.set = builtins.set()
+    # Forward only the targets-key the user actually declared so parse_targets_field
+    # in the gate sees the same dict shape it sees from raw apm.yml. Including a
+    # `targets: None` placeholder when the user wrote `target:` (singular) would
+    # falsely trip the conflict-mutex check (see core.apm_yml.parse_targets_field).
+    # This restores parity with `apm install` for users on the modern `targets:`
+    # plural form -- without this, `targets:` was silently dropped at the call
+    # site and the gate fell back to permissive directory detection (#1335).
+    mcp_apm_config: dict = {"scripts": apm_package.scripts or {}}
+    if apm_package.targets is not None:
+        mcp_apm_config["targets"] = apm_package.targets
+    elif apm_package.target is not None:
+        mcp_apm_config["target"] = apm_package.target
+
+    if should_install and mcp_deps:
+        mcp_count = MCPIntegrator.install(
+            mcp_deps,
+            runtime,
+            exclude,
+            verbose,
+            stored_mcp_configs=old_mcp_configs,
+            apm_config=mcp_apm_config,
+            project_root=project_root,
+            user_scope=user_scope,
+            explicit_target=explicit_target,
+            diagnostics=diagnostics,
+            scope=scope,
+        )
+        new_mcp_servers = MCPIntegrator.get_server_names(mcp_deps)
+        new_mcp_configs = MCPIntegrator.get_server_configs(mcp_deps)
+
+        # Remove stale MCP servers that are no longer needed
+        stale_servers = old_mcp_servers - new_mcp_servers
+        if stale_servers:
+            MCPIntegrator.remove_stale(
+                stale_servers,
+                runtime,
+                exclude,
+                project_root=project_root,
+                user_scope=user_scope,
+                scope=scope,
+            )
+
+        # Persist the new MCP server set and configs in the lockfile
+        MCPIntegrator.update_lockfile(new_mcp_servers, lock_path, mcp_configs=new_mcp_configs)
+    elif should_install and not mcp_deps:
+        # No MCP deps at all -- remove any old APM-managed servers
+        if old_mcp_servers:
+            MCPIntegrator.remove_stale(
+                old_mcp_servers,
+                runtime,
+                exclude,
+                project_root=project_root,
+                user_scope=user_scope,
+                scope=scope,
+            )
+            MCPIntegrator.update_lockfile(builtins.set(), lock_path, mcp_configs={})
+        logger.verbose_detail("No MCP dependencies found in apm.yml")
+    elif not should_install and old_mcp_servers:
+        # --only=apm: APM install regenerated the lockfile and dropped
+        # mcp_servers.  Restore the previous set so it is not lost.
+        MCPIntegrator.update_lockfile(old_mcp_servers, lock_path, mcp_configs=old_mcp_configs)
+
+    return mcp_count, mcp_apm_config

--- a/tests/integration/test_update_mcp_lsp_prune.py
+++ b/tests/integration/test_update_mcp_lsp_prune.py
@@ -1,0 +1,256 @@
+"""Integration tests: ``apm update`` reconciles MCP/LSP servers (#2077).
+
+``apm update`` calls ``_install_apm_dependencies`` directly instead of
+going through ``_install_apm_packages`` (see ``commands/install.py``), so it
+historically skipped the ``MCPIntegrator``/``LSPIntegrator`` reconciliation
+that runs after a normal ``apm install``. Two distinct failure modes:
+
+* MCP: the lockfile phase intentionally carries ``mcp_servers``/
+  ``mcp_configs`` forward unreconciled
+  (``install/phases/lockfile.py::_preserve_existing_mcp_state``), so without
+  a downstream reconcile step orphaned entries survive ``apm update``
+  indefinitely (the bug reported in #2077).
+* LSP: there is no equivalent carry-forward for ``lsp_servers``/
+  ``lsp_configs`` -- the lockfile builder always starts them empty -- so
+  without ``run_lsp_integration`` running, servers actually declared in
+  apm.yml never make it into the lockfile after ``apm update`` at all.
+
+Mirrors the mocking pattern from ``test_global_mcp_lockfile_e2e.py``:
+``GitHubPackageDownloader`` is stubbed so the resolver never touches the
+network, and a resolved-commit mismatch against the pre-seeded lockfile
+drives an "update" plan entry so ``apm update --yes`` proceeds past the
+consent gate.
+"""
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from apm_cli.deps.lockfile import LockedDependency, LockFile
+
+_OLD_SHA = "a" * 40
+_NEW_SHA = "b" * 40
+
+
+def _stub_downloader_for_lockfile(mock_dl_cls) -> None:
+    """Configure a patched ``GitHubPackageDownloader`` so the resolver
+    never touches the network and reports a commit change (``_NEW_SHA``)
+    against the pre-seeded lockfile's ``_OLD_SHA`` -- driving an "update"
+    plan entry so ``apm update --yes`` proceeds past the consent gate.
+    """
+    instance = mock_dl_cls.return_value
+    pkg_info = MagicMock()
+    pkg_info.resolved_reference.resolved_commit = _NEW_SHA
+    pkg_info.resolved_reference.ref_name = "main"
+    pkg_info.resolved_reference.is_branch = True
+    pkg_info.resolved_reference.is_tag = False
+    pkg_info.resolved_reference.is_sha = False
+    pkg_info.package_type.value = "apm_package"
+    pkg_info.package.name = "stub-package"
+    pkg_info.package.version = "0.0.0"
+    instance.download_package.return_value = pkg_info
+
+
+def _write_apm_yml(
+    path: Path,
+    *,
+    name: str = "test-project",
+    deps: list | None = None,
+    mcp: list | None = None,
+    lsp: list | None = None,
+) -> None:
+    data: dict = {"name": name, "version": "1.0.0", "dependencies": {"apm": deps or []}}
+    if mcp is not None:
+        data["dependencies"]["mcp"] = mcp
+    if lsp is not None:
+        data["dependencies"]["lsp"] = lsp
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.dump(data, default_flow_style=False), encoding="utf-8")
+
+
+def _make_pkg(apm_modules: Path, repo_url: str, *, name: str | None = None) -> None:
+    """Create a package directory with a minimal (no MCP/LSP) apm.yml."""
+    pkg_dir = apm_modules / repo_url
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+    _write_apm_yml(pkg_dir / "apm.yml", name=name or repo_url.split("/")[-1])
+
+
+def _seed_lockfile(
+    path: Path,
+    locked_deps: list,
+    *,
+    mcp_servers: list | None = None,
+    mcp_configs: dict | None = None,
+    lsp_servers: list | None = None,
+    lsp_configs: dict | None = None,
+) -> None:
+    lf = LockFile()
+    for dep in locked_deps:
+        lf.add_dependency(dep)
+    if mcp_servers:
+        lf.mcp_servers = mcp_servers
+    if mcp_configs:
+        lf.mcp_configs = mcp_configs
+    if lsp_servers:
+        lf.lsp_servers = lsp_servers
+    if lsp_configs:
+        lf.lsp_configs = lsp_configs
+    lf.write(path)
+
+
+def _seed_plain_dependency(path: Path, *, resolved_commit: str = _OLD_SHA) -> None:
+    """Seed a lockfile with a single ``acme/plain-pkg`` entry, no MCP/LSP."""
+    _seed_lockfile(
+        path,
+        [
+            LockedDependency(
+                repo_url="acme/plain-pkg",
+                depth=1,
+                resolved_by=None,
+                resolved_ref="main",
+                resolved_commit=resolved_commit,
+            ),
+        ],
+    )
+
+
+@pytest.fixture()
+def project(tmp_path, monkeypatch):
+    """Isolated project directory with ``apm_modules/`` prepared."""
+    (tmp_path / "apm_modules").mkdir()
+    monkeypatch.setenv("APM_E2E_TESTS", "1")
+    orig_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    yield tmp_path
+    os.chdir(orig_cwd)
+
+
+class TestUpdatePrunesOrphanedMCPServers:
+    """Regression for #2077: ``apm update`` must prune MCP servers no
+    longer declared anywhere in the dependency tree, not just carry them
+    forward from the previous lockfile."""
+
+    @patch("apm_cli.deps.github_downloader.GitHubPackageDownloader")
+    def test_apm_update_prunes_orphaned_mcp_server(self, mock_dl_cls, project):
+        """A manifest with no MCP deps must have previously-locked orphaned
+        MCP servers pruned from ``apm.lock.yaml`` after ``apm update --yes``."""
+        _stub_downloader_for_lockfile(mock_dl_cls)
+        apm_modules = project / "apm_modules"
+
+        # Root manifest depends on plain-pkg and declares no MCP servers
+        # (simulating a dependency that has dropped its MCP server).
+        _write_apm_yml(project / "apm.yml", deps=["acme/plain-pkg"])
+        _make_pkg(apm_modules, "acme/plain-pkg")
+
+        # Pre-seed the lockfile with an orphaned MCP server entry left over
+        # from a prior install, plus a resolved_commit that will differ
+        # from the mocked downloader's response so the update plan shows a
+        # change and proceeds past the consent gate.
+        _seed_lockfile(
+            project / "apm.lock.yaml",
+            [
+                LockedDependency(
+                    repo_url="acme/plain-pkg",
+                    depth=1,
+                    resolved_by=None,
+                    resolved_ref="main",
+                    resolved_commit=_OLD_SHA,
+                ),
+            ],
+            mcp_servers=["ghcr.io/acme/old-mcp-server"],
+            mcp_configs={"ghcr.io/acme/old-mcp-server": {"name": "ghcr.io/acme/old-mcp-server"}},
+        )
+
+        from apm_cli.cli import cli
+
+        result = CliRunner().invoke(cli, ["update", "--yes", "--target", "claude"])
+
+        assert result.exit_code == 0, f"CLI failed (exit {result.exit_code}):\n{result.output}"
+
+        updated_lock = LockFile.read(project / "apm.lock.yaml")
+        assert updated_lock is not None, "Lockfile missing after update"
+        assert updated_lock.mcp_servers == [], (
+            f"Expected orphaned MCP server to be pruned, got: {updated_lock.mcp_servers}"
+        )
+        assert updated_lock.mcp_configs == {}, (
+            f"Expected orphaned MCP config to be pruned, got: {updated_lock.mcp_configs}"
+        )
+
+    @patch("apm_cli.deps.github_downloader.GitHubPackageDownloader")
+    def test_apm_update_dry_run_does_not_touch_mcp_state(self, mock_dl_cls, project):
+        """``apm update --dry-run`` must not mutate MCP lockfile state."""
+        _stub_downloader_for_lockfile(mock_dl_cls)
+        apm_modules = project / "apm_modules"
+
+        _write_apm_yml(project / "apm.yml", deps=["acme/plain-pkg"])
+        _make_pkg(apm_modules, "acme/plain-pkg")
+        _seed_lockfile(
+            project / "apm.lock.yaml",
+            [
+                LockedDependency(
+                    repo_url="acme/plain-pkg",
+                    depth=1,
+                    resolved_by=None,
+                    resolved_ref="main",
+                    resolved_commit=_OLD_SHA,
+                ),
+            ],
+            mcp_servers=["ghcr.io/acme/old-mcp-server"],
+        )
+
+        from apm_cli.cli import cli
+
+        result = CliRunner().invoke(cli, ["update", "--dry-run"])
+
+        assert result.exit_code == 0, f"CLI failed (exit {result.exit_code}):\n{result.output}"
+
+        untouched_lock = LockFile.read(project / "apm.lock.yaml")
+        assert untouched_lock is not None
+        assert untouched_lock.mcp_servers == ["ghcr.io/acme/old-mcp-server"], (
+            f"Dry run must not prune MCP servers: got {untouched_lock.mcp_servers}"
+        )
+
+
+class TestUpdateRunsLSPIntegration:
+    """Regression for #2077's LSP parity decision: ``apm update`` must run
+    ``run_lsp_integration`` the same way ``apm install`` does, not just
+    ``run_mcp_integration``. Unlike MCP, the lockfile builder never carries
+    ``lsp_servers`` forward, so without this fix a declared LSP dependency
+    never reaches ``apm.lock.yaml`` via ``apm update`` at all."""
+
+    @patch("apm_cli.deps.github_downloader.GitHubPackageDownloader")
+    def test_apm_update_writes_declared_lsp_server_to_lockfile(self, mock_dl_cls, project):
+        """A manifest that declares an LSP server must have it recorded in
+        ``apm.lock.yaml`` after ``apm update --yes``."""
+        _stub_downloader_for_lockfile(mock_dl_cls)
+        apm_modules = project / "apm_modules"
+
+        _write_apm_yml(
+            project / "apm.yml",
+            deps=["acme/plain-pkg"],
+            lsp=[
+                {
+                    "name": "test-lsp",
+                    "command": "test-lsp-cmd",
+                    "extensionToLanguage": {".test": "test-lang"},
+                }
+            ],
+        )
+        _make_pkg(apm_modules, "acme/plain-pkg")
+        _seed_plain_dependency(project / "apm.lock.yaml")
+
+        from apm_cli.cli import cli
+
+        result = CliRunner().invoke(cli, ["update", "--yes", "--target", "claude"])
+
+        assert result.exit_code == 0, f"CLI failed (exit {result.exit_code}):\n{result.output}"
+
+        updated_lock = LockFile.read(project / "apm.lock.yaml")
+        assert updated_lock is not None, "Lockfile missing after update"
+        assert updated_lock.lsp_servers == ["test-lsp"], (
+            f"Expected declared LSP server to be recorded, got: {updated_lock.lsp_servers}"
+        )

--- a/tests/unit/install/test_mcp_integration_extraction.py
+++ b/tests/unit/install/test_mcp_integration_extraction.py
@@ -1,0 +1,246 @@
+"""Unit tests for ``run_mcp_integration`` extraction parity (#2077).
+
+``run_mcp_integration`` (``apm_cli.install.mcp.integration``) was extracted
+from the MCP block that used to live inline in
+``commands/install.py::_install_apm_packages`` so ``apm update`` could call
+the same reconciliation logic. These tests verify the extracted function
+preserves the original branch-by-branch behaviour:
+
+* ``install`` / ``remove_stale`` / ``update_lockfile`` wiring when MCP deps
+  are present.
+* Cleanup (``remove_stale`` + empty ``update_lockfile``) when the manifest
+  has no MCP deps but old servers exist.
+* ``--only=apm``-style restore (``should_install=False``) when old servers
+  exist.
+* ``PolicyBlockError`` propagates to the caller uncaught (the caller is
+  responsible for reporting + exiting), mirroring the
+  ``TestTransitiveMCPBlock`` behaviour in ``test_transitive_mcp_policy.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apm_cli.core.command_logger import InstallLogger
+from apm_cli.install.mcp import run_mcp_integration
+from apm_cli.models.dependency.mcp import MCPDependency
+from apm_cli.policy.discovery import PolicyFetchResult
+from apm_cli.policy.install_preflight import PolicyBlockError
+from apm_cli.policy.parser import load_policy
+
+FIXTURE_DIR = Path(__file__).resolve().parents[2] / "fixtures" / "policy"
+MCP_POLICY_FIXTURE = FIXTURE_DIR / "apm-policy-mcp.yml"
+
+_PATCH_TARGET = "apm_cli.integration.mcp_integrator.MCPIntegrator"
+
+
+def _make_apm_package(*, scripts=None, targets=None, target=None, allow_executables=None):
+    pkg = MagicMock()
+    pkg.scripts = scripts
+    pkg.targets = targets
+    pkg.target = target
+    pkg.allow_executables = allow_executables
+    return pkg
+
+
+def _make_logger() -> InstallLogger:
+    return InstallLogger(verbose=False)
+
+
+def _base_kwargs(**overrides):
+    kwargs = dict(
+        apm_package=_make_apm_package(),
+        mcp_deps=[],
+        apm_modules_path=Path("/nonexistent/apm_modules"),
+        lock_path=Path("/nonexistent/apm.lock.yaml"),
+        old_mcp_servers=set(),
+        old_mcp_configs={},
+        project_root=Path("/fake/project"),
+        user_scope=False,
+        should_install=True,
+        logger=_make_logger(),
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+class TestRunMcpIntegrationInstallBranch:
+    """``should_install=True`` and ``mcp_deps`` non-empty."""
+
+    @patch(_PATCH_TARGET)
+    def test_installs_and_updates_lockfile(self, mock_mcp):
+        dep = MCPDependency(name="io.github.acme/server", transport="stdio")
+        mock_mcp.deduplicate.side_effect = lambda x: x
+        mock_mcp.install.return_value = 1
+        mock_mcp.get_server_names.return_value = {"io.github.acme/server"}
+        mock_mcp.get_server_configs.return_value = {"io.github.acme/server": {"name": "x"}}
+
+        count, apm_config = run_mcp_integration(**_base_kwargs(mcp_deps=[dep]))
+
+        assert count == 1
+        assert apm_config == {"scripts": {}}
+        mock_mcp.install.assert_called_once()
+        installed_deps = mock_mcp.install.call_args.args[0]
+        assert installed_deps == [dep]
+        mock_mcp.update_lockfile.assert_called_once_with(
+            {"io.github.acme/server"},
+            Path("/nonexistent/apm.lock.yaml"),
+            mcp_configs={"io.github.acme/server": {"name": "x"}},
+        )
+        mock_mcp.remove_stale.assert_not_called()
+
+    @patch(_PATCH_TARGET)
+    def test_removes_stale_servers_no_longer_declared(self, mock_mcp):
+        dep = MCPDependency(name="io.github.acme/new-server", transport="stdio")
+        mock_mcp.deduplicate.side_effect = lambda x: x
+        mock_mcp.install.return_value = 1
+        mock_mcp.get_server_names.return_value = {"io.github.acme/new-server"}
+        mock_mcp.get_server_configs.return_value = {}
+
+        run_mcp_integration(
+            **_base_kwargs(
+                mcp_deps=[dep],
+                old_mcp_servers={"io.github.acme/orphan-server"},
+                old_mcp_configs={"io.github.acme/orphan-server": {"name": "orphan"}},
+            )
+        )
+
+        mock_mcp.remove_stale.assert_called_once()
+        stale_arg = mock_mcp.remove_stale.call_args.args[0]
+        assert stale_arg == {"io.github.acme/orphan-server"}
+
+    @patch(_PATCH_TARGET)
+    def test_forwards_apm_config_targets_key_when_declared(self, mock_mcp):
+        """#1335: only the targets-key the user actually declared is
+        forwarded, matching the original inline block's behaviour."""
+        dep = MCPDependency(name="io.github.acme/server", transport="stdio")
+        mock_mcp.deduplicate.side_effect = lambda x: x
+        mock_mcp.install.return_value = 1
+        mock_mcp.get_server_names.return_value = {"io.github.acme/server"}
+        mock_mcp.get_server_configs.return_value = {}
+
+        pkg = _make_apm_package(scripts={"build": "echo hi"}, targets=["claude", "copilot"])
+        _count, apm_config = run_mcp_integration(**_base_kwargs(apm_package=pkg, mcp_deps=[dep]))
+
+        assert apm_config == {"scripts": {"build": "echo hi"}, "targets": ["claude", "copilot"]}
+        install_kwargs = mock_mcp.install.call_args.kwargs
+        assert install_kwargs["apm_config"] == apm_config
+
+    @patch(_PATCH_TARGET)
+    def test_forwards_singular_target_key_when_declared(self, mock_mcp):
+        dep = MCPDependency(name="io.github.acme/server", transport="stdio")
+        mock_mcp.deduplicate.side_effect = lambda x: x
+        mock_mcp.install.return_value = 1
+        mock_mcp.get_server_names.return_value = {"io.github.acme/server"}
+        mock_mcp.get_server_configs.return_value = {}
+
+        pkg = _make_apm_package(target="claude")
+        _count, apm_config = run_mcp_integration(**_base_kwargs(apm_package=pkg, mcp_deps=[dep]))
+
+        assert apm_config == {"scripts": {}, "target": "claude"}
+        assert "targets" not in apm_config
+
+
+class TestRunMcpIntegrationEmptyDepsBranch:
+    """``should_install=True`` and ``mcp_deps`` empty."""
+
+    @patch(_PATCH_TARGET)
+    def test_no_deps_no_old_servers_is_a_noop(self, mock_mcp):
+        run_mcp_integration(**_base_kwargs(mcp_deps=[]))
+
+        mock_mcp.remove_stale.assert_not_called()
+        mock_mcp.update_lockfile.assert_not_called()
+        mock_mcp.install.assert_not_called()
+
+    @patch(_PATCH_TARGET)
+    def test_no_deps_with_old_servers_prunes_them(self, mock_mcp):
+        """Regression for #2077: orphaned servers must be removed and the
+        lockfile cleared even when the manifest declares zero MCP deps."""
+        count, _apm_config = run_mcp_integration(
+            **_base_kwargs(
+                mcp_deps=[],
+                old_mcp_servers={"io.github.acme/orphan"},
+                old_mcp_configs={"io.github.acme/orphan": {"name": "orphan"}},
+            )
+        )
+
+        assert count == 0
+        mock_mcp.remove_stale.assert_called_once()
+        assert mock_mcp.remove_stale.call_args.args[0] == {"io.github.acme/orphan"}
+        mock_mcp.update_lockfile.assert_called_once_with(
+            set(), Path("/nonexistent/apm.lock.yaml"), mcp_configs={}
+        )
+
+
+class TestRunMcpIntegrationRestoreBranch:
+    """``should_install=False`` (``--only=apm``-style)."""
+
+    @patch(_PATCH_TARGET)
+    def test_restores_old_servers_when_not_installing_mcp(self, mock_mcp):
+        run_mcp_integration(
+            **_base_kwargs(
+                mcp_deps=[],
+                should_install=False,
+                old_mcp_servers={"io.github.acme/kept"},
+                old_mcp_configs={"io.github.acme/kept": {"name": "kept"}},
+            )
+        )
+
+        mock_mcp.update_lockfile.assert_called_once_with(
+            {"io.github.acme/kept"},
+            Path("/nonexistent/apm.lock.yaml"),
+            mcp_configs={"io.github.acme/kept": {"name": "kept"}},
+        )
+        mock_mcp.install.assert_not_called()
+        mock_mcp.remove_stale.assert_not_called()
+
+    @patch(_PATCH_TARGET)
+    def test_no_op_when_not_installing_and_no_old_servers(self, mock_mcp):
+        run_mcp_integration(**_base_kwargs(mcp_deps=[], should_install=False))
+
+        mock_mcp.update_lockfile.assert_not_called()
+        mock_mcp.install.assert_not_called()
+
+
+class TestRunMcpIntegrationPolicyBlock:
+    """PolicyBlockError must propagate uncaught; the caller reports + exits."""
+
+    def _fetch_result(self):
+        policy, _warnings = load_policy(MCP_POLICY_FIXTURE)
+        return PolicyFetchResult(
+            policy=policy, source="org:test-org/.github", cached=False, outcome="found"
+        )
+
+    @patch(_PATCH_TARGET)
+    def test_policy_block_raises_and_does_not_call_install(self, mock_mcp):
+        mock_mcp.deduplicate.side_effect = lambda x: x
+        evil_dep = MCPDependency(name="io.github.untrusted/evil-transitive", transport="stdio")
+
+        with patch(
+            "apm_cli.policy.install_preflight.discover_policy_with_chain",
+            return_value=self._fetch_result(),
+        ):
+            with pytest.raises(PolicyBlockError):
+                run_mcp_integration(**_base_kwargs(mcp_deps=[evil_dep]))
+
+        mock_mcp.install.assert_not_called()
+        mock_mcp.update_lockfile.assert_not_called()
+
+    @patch(_PATCH_TARGET)
+    def test_no_policy_flag_skips_preflight_and_installs(self, mock_mcp):
+        mock_mcp.deduplicate.side_effect = lambda x: x
+        mock_mcp.install.return_value = 1
+        mock_mcp.get_server_names.return_value = {"io.github.untrusted/evil-transitive"}
+        mock_mcp.get_server_configs.return_value = {}
+        evil_dep = MCPDependency(name="io.github.untrusted/evil-transitive", transport="stdio")
+
+        with patch(
+            "apm_cli.policy.install_preflight.discover_policy_with_chain",
+            return_value=self._fetch_result(),
+        ):
+            run_mcp_integration(**_base_kwargs(mcp_deps=[evil_dep], no_policy=True))
+
+        mock_mcp.install.assert_called_once()


### PR DESCRIPTION
## Description

`apm update` never ran the MCP/LSP reconciliation that `apm install` performs: it calls `_install_apm_dependencies` directly, while `MCPIntegrator` / `run_lsp_integration` were only invoked from `_install_apm_packages`. Because the lockfile phase intentionally carries `mcp_servers` / `mcp_configs` forward unreconciled (`install/phases/lockfile.py::_preserve_existing_mcp_state`), MCP servers that dependencies no longer declare survived `apm update` indefinitely -- in `apm.lock.yaml` and in runtime configs (`.mcp.json` etc.). LSP had the same gap in the opposite direction: `lsp_servers` are not carried forward, so LSP servers never reached the lockfile via `apm update` at all.

Changes:

- Extract the MCP integration block from `commands/install.py::_install_apm_packages` into `install/mcp/integration.py::run_mcp_integration()`, mirroring the existing `install/lsp/integration.py::run_lsp_integration()`. The transitive-policy preflight now raises `PolicyBlockError` instead of calling `sys.exit(1)`; both callers catch it, report, and exit non-zero (no behaviour change for `apm install`).
- `apm update` now runs MCP **and** LSP integration after the consent gate -- only when the user accepted the plan (`--yes` or interactive confirm). It snapshots the old lockfile state before the pipeline regenerates it, re-parses the on-disk manifest after revision pins are applied, then reconciles (install -> remove stale -> update lockfile).
- `docs/reference/lockfile-spec.md`: `mcp_servers` / `lsp_servers` are now described as reflecting the manifest "as of the last install or update".

Security notes:

- `apm update` now writes and prunes runtime MCP/LSP configs the same way `apm install` does; `remove_stale` runs as a trust-hygiene step.
- The merged (direct + transitive) MCP set goes through the same policy preflight. `apm update` has no `--no-policy` / `--trust-transitive-mcp` flags, so both default to the stricter side, and `allowExecutables` gating now applies on update too.
- Dry-run, declined, and non-TTY runs touch nothing (covered by tests).

Known limitation: reconciliation only runs when a plan is applied. An `apm update` where nothing changed early-returns and leaves a pre-existing orphan in place until the next applied change (or an `apm install`); pruning without consent would contradict the command's "no changes applied" promise.

Out of scope: flag parity for `--runtime` / `--exclude` / `--trust-transitive-mcp` / `--no-policy` on `apm update`; `apm lock` (by design it resolves packages only).

Fixes #2077

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

`uv run pytest tests/unit tests/test_console.py`: 18153 passed. New tests: `tests/integration/test_update_mcp_lsp_prune.py` (update prunes an orphaned MCP server from the lockfile; dry-run leaves state untouched; a declared LSP server is recorded via update) and `tests/unit/install/test_mcp_integration_extraction.py` (extraction parity for every branch, including `PolicyBlockError` propagation). `ruff check` and `ruff format --check` pass.

## Spec conformance (OpenAPM v0.1)

If this PR changes behaviour that an OpenAPM v0.1 `req-XXX` covers,
confirm the three-step ritual (see CONTRIBUTING.md "Adding or
changing a normative requirement"):

- [ ] Spec edit: `docs/src/content/docs/specs/openapm-v0.1.md` updated
      (new/changed `<a id="req-XXX"></a>` anchor + prose + Appendix C
      row).
- [ ] Manifest edit: `docs/src/content/docs/specs/manifests/openapm-v0.1.requirements.yml`
      updated.
- [ ] Test edit: a `@pytest.mark.req("req-XXX")` test under
      `tests/spec_conformance/` added or extended.
- [ ] `CONFORMANCE.{md,json}` regenerated via
      `uv run --extra dev python -m tests.spec_conformance.gen_statement`
      and committed.
- [x] N/A -- this PR does not change OpenAPM-observable behaviour.


apm-spec-waiver: install/mcp/integration.py is a behaviour-preserving extraction of the MCP integration block from commands/install.py (apm install semantics unchanged); the update-side fix alters no req-covered behaviour (req-rs-011/012 untouched)
