### PR TITLE
fix(marketplace): preserve registered SSH transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Marketplace plugins inside SSH-registered repositories now preserve SSH in
+  generated `git:` plus `path:` dependencies instead of rewriting to HTTPS.
+  (#2091)
 - `apm install host/org/repo/subpath#ref` on an unrecognised self-hosted FQDN
   no longer fails with a misleading "not accessible or doesn't exist" error;
   the failure reason now suggests setting `GITLAB_HOST` / `APM_GITLAB_HOSTS`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Marketplace plugins inside SSH-registered repositories now preserve SSH in
-  generated `git:` plus `path:` dependencies instead of rewriting to HTTPS.
-  (#2091)
+- SSH-registered marketplace installs no longer rewrite to HTTPS; generated
+  `git:` and `path:` dependencies keep using existing SSH keys. (#2091)
 - `apm install host/org/repo/subpath#ref` on an unrecognised self-hosted FQDN
   no longer fails with a misleading "not accessible or doesn't exist" error;
   the failure reason now suggests setting `GITLAB_HOST` / `APM_GITLAB_HOSTS`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- SSH-registered marketplace installs no longer rewrite to HTTPS; generated
-  `git:` and `path:` dependencies keep using existing SSH keys. (#2091)
+- In-repository plugins from SSH-registered GitLab and generic git
+  marketplaces no longer rewrite to HTTPS; generated `git:` and `path:`
+  dependencies keep using existing SSH keys. (#2091)
 - `apm install host/org/repo/subpath#ref` on an unrecognised self-hosted FQDN
   no longer fails with a misleading "not accessible or doesn't exist" error;
   the failure reason now suggests setting `GITLAB_HOST` / `APM_GITLAB_HOSTS`

--- a/docs/src/content/docs/consumer/authentication.md
+++ b/docs/src/content/docs/consumer/authentication.md
@@ -57,11 +57,6 @@ where the REST API is restricted or returns 410 -- if `git clone` works, so
 does `apm install`. For self-hosted hosts, explicit `git:` / SSH URLs carry
 the host in the dependency. Set `GITLAB_HOST` (or `APM_GITLAB_HOSTS`) only
 when you want bare-host or shorthand forms to classify as GitLab.
-Marketplace plugins inside a repository also keep the consumer-selected
-registration transport in their generated `git:` plus `path:` dependency.
-An SSH registration therefore continues to use existing SSH keys instead of
-being rewritten to HTTPS.
-
 If you need to fall back to the GitLab REST API (for environments where git
 transport is not available), set `GITLAB_APM_PAT`:
 
@@ -106,6 +101,14 @@ apm install                                             # APM picks up the cache
 There is no APM-specific env var for these hosts by design: if you can `git clone`, APM can install. Configure your credential helper once (`git credential-manager`, Keychain, libsecret, plain-text store -- whatever your shell uses) and `apm install` follows the same path git already trusts.
 
 For non-interactive environments (CI, devcontainers), set the credential through your CI's secret store and configure `git config --global credential.helper store` against a runtime-injected `~/.git-credentials` file.
+
+## Marketplace transport
+
+If you registered a git-backed marketplace with an SSH URL, plugins
+installed from that repository keep using SSH. APM preserves the
+registration transport in the generated `git:` and `path:` dependency
+instead of rewriting it to HTTPS. See
+[Installing from marketplaces](../installing-from-marketplaces/#supported-marketplace-sources).
 
 ## Going further
 

--- a/docs/src/content/docs/consumer/authentication.md
+++ b/docs/src/content/docs/consumer/authentication.md
@@ -57,6 +57,10 @@ where the REST API is restricted or returns 410 -- if `git clone` works, so
 does `apm install`. For self-hosted hosts, explicit `git:` / SSH URLs carry
 the host in the dependency. Set `GITLAB_HOST` (or `APM_GITLAB_HOSTS`) only
 when you want bare-host or shorthand forms to classify as GitLab.
+Marketplace plugins inside a repository also keep the consumer-selected
+registration transport in their generated `git:` plus `path:` dependency.
+An SSH registration therefore continues to use existing SSH keys instead of
+being rewritten to HTTPS.
 
 If you need to fall back to the GitLab REST API (for environments where git
 transport is not available), set `GITLAB_APM_PAT`:

--- a/docs/src/content/docs/consumer/authentication.md
+++ b/docs/src/content/docs/consumer/authentication.md
@@ -104,11 +104,11 @@ For non-interactive environments (CI, devcontainers), set the credential through
 
 ## Marketplace transport
 
-If you registered a git-backed marketplace with an SSH URL, plugins
-installed from that repository keep using SSH. APM preserves the
-registration transport in the generated `git:` and `path:` dependency
-instead of rewriting it to HTTPS. See
-[Installing from marketplaces](../installing-from-marketplaces/#supported-marketplace-sources).
+For in-repository plugins from GitLab and generic git marketplaces, an SSH
+registration stays SSH when APM generates the concrete `git:` and `path:`
+dependency. Existing SSH keys keep working instead of the dependency being
+rewritten to HTTPS. See
+[Installing from marketplaces](../installing-from-marketplaces/#local-and-self-hosted-marketplaces).
 
 ## Going further
 

--- a/docs/src/content/docs/consumer/installing-from-marketplaces.md
+++ b/docs/src/content/docs/consumer/installing-from-marketplaces.md
@@ -93,7 +93,7 @@ browse / install / update workflow works against:
 - **SSH URLs** -- `git@gitea.example.com:org/repo.git`. The host
   is extracted, classified, and routed through the matching fetcher.
   In-repository plugins keep this consumer-selected SSH transport when
-  APM writes their concrete `git:` plus `path:` entry to `apm.yml`.
+  APM writes their concrete `git:` and `path:` entry to `apm.yml`.
   HTTPS registrations likewise remain HTTPS.
 
 :::note[Hosted JSON is public HTTPS]

--- a/docs/src/content/docs/consumer/installing-from-marketplaces.md
+++ b/docs/src/content/docs/consumer/installing-from-marketplaces.md
@@ -92,9 +92,10 @@ browse / install / update workflow works against:
   Gitea, Bitbucket Server, and self-hosted git servers.
 - **SSH URLs** -- `git@gitea.example.com:org/repo.git`. The host
   is extracted, classified, and routed through the matching fetcher.
-  In-repository plugins keep this consumer-selected SSH transport when
-  APM writes their concrete `git:` and `path:` entry to `apm.yml`.
-  HTTPS registrations likewise remain HTTPS.
+  For in-repository plugins from GitLab and generic git marketplaces, APM
+  keeps this consumer-selected SSH transport when it writes their concrete
+  `git:` and `path:` entry to `apm.yml`. HTTPS registrations likewise remain
+  HTTPS.
 
 :::note[Hosted JSON is public HTTPS]
 Hosted `marketplace.json` URLs are public HTTPS sources: APM does not

--- a/docs/src/content/docs/consumer/installing-from-marketplaces.md
+++ b/docs/src/content/docs/consumer/installing-from-marketplaces.md
@@ -92,6 +92,9 @@ browse / install / update workflow works against:
   Gitea, Bitbucket Server, and self-hosted git servers.
 - **SSH URLs** -- `git@gitea.example.com:org/repo.git`. The host
   is extracted, classified, and routed through the matching fetcher.
+  In-repository plugins keep this consumer-selected SSH transport when
+  APM writes their concrete `git:` plus `path:` entry to `apm.yml`.
+  HTTPS registrations likewise remain HTTPS.
 
 :::note[Hosted JSON is public HTTPS]
 Hosted `marketplace.json` URLs are public HTTPS sources: APM does not

--- a/packages/apm-guide/.apm/skills/apm-usage/authentication.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/authentication.md
@@ -120,6 +120,11 @@ GitLab instances where the API returns 410 (disabled) no longer fail. Explicit
 `APM_GITLAB_HOSTS`) only when bare-host or shorthand forms should classify as
 GitLab.
 
+For marketplace plugins inside the registered repository, APM preserves the
+consumer-selected marketplace transport in the generated `git:` plus `path:`
+dependency. SSH registrations therefore continue to use SSH keys instead of
+being rewritten to HTTPS.
+
 If git transport is unavailable, `GITLAB_APM_PAT` is the fallback:
 
 ```bash

--- a/packages/apm-guide/.apm/skills/apm-usage/authentication.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/authentication.md
@@ -18,6 +18,13 @@ APM checks the active `gh` CLI account before invoking OS credential helpers. Th
 
 For multi-account Git Credential Manager setups, see the [Multi-account Git Credential Manager](https://microsoft.github.io/apm/getting-started/authentication/#multi-account-git-credential-manager) section in the main authentication guide.
 
+## Marketplace transport
+
+If a git-backed marketplace was registered with an SSH URL, plugins installed
+from that repository keep using SSH. APM preserves the registration transport
+in the generated `git:` and `path:` dependency instead of rewriting it to
+HTTPS.
+
 ## GitLab hosts
 
 `gitlab.com` is detected automatically. For self-managed GitLab, set
@@ -119,11 +126,6 @@ GitLab instances where the API returns 410 (disabled) no longer fail. Explicit
 `git:` / SSH URLs carry the host in the dependency; set `GITLAB_HOST` (or
 `APM_GITLAB_HOSTS`) only when bare-host or shorthand forms should classify as
 GitLab.
-
-For marketplace plugins inside the registered repository, APM preserves the
-consumer-selected marketplace transport in the generated `git:` plus `path:`
-dependency. SSH registrations therefore continue to use SSH keys instead of
-being rewritten to HTTPS.
 
 If git transport is unavailable, `GITLAB_APM_PAT` is the fallback:
 

--- a/packages/apm-guide/.apm/skills/apm-usage/authentication.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/authentication.md
@@ -20,10 +20,10 @@ For multi-account Git Credential Manager setups, see the [Multi-account Git Cred
 
 ## Marketplace transport
 
-If a git-backed marketplace was registered with an SSH URL, plugins installed
-from that repository keep using SSH. APM preserves the registration transport
-in the generated `git:` and `path:` dependency instead of rewriting it to
-HTTPS.
+For in-repository plugins from GitLab and generic git marketplaces, an SSH
+registration stays SSH when APM generates the concrete `git:` and `path:`
+dependency. Existing SSH keys keep working instead of the dependency being
+rewritten to HTTPS.
 
 ## GitLab hosts
 

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -94,9 +94,9 @@ across protocols.
 
 A failed clone fails loudly, naming the URL and the protocol attempted.
 Explicit URL schemes are honored exactly.
-This includes marketplace installs: an in-repository plugin resolved from a
-consumer-registered SSH marketplace is persisted as SSH `git:` and `path:`;
-an HTTPS registration remains HTTPS.
+This includes in-repository plugins from GitLab and generic git marketplaces:
+an SSH registration is persisted as SSH `git:` and `path:`; an HTTPS
+registration remains HTTPS.
 
 Force the initial protocol for shorthand:
 

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -94,6 +94,9 @@ across protocols.
 
 A failed clone fails loudly, naming the URL and the protocol attempted.
 Explicit URL schemes are honored exactly.
+This includes marketplace installs: an in-repository plugin resolved from a
+consumer-registered SSH marketplace is persisted as SSH `git:` plus `path:`;
+an HTTPS registration remains HTTPS.
 
 Force the initial protocol for shorthand:
 

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -95,7 +95,7 @@ across protocols.
 A failed clone fails loudly, naming the URL and the protocol attempted.
 Explicit URL schemes are honored exactly.
 This includes marketplace installs: an in-repository plugin resolved from a
-consumer-registered SSH marketplace is persisted as SSH `git:` plus `path:`;
+consumer-registered SSH marketplace is persisted as SSH `git:` and `path:`;
 an HTTPS registration remains HTTPS.
 
 Force the initial protocol for shorthand:

--- a/src/apm_cli/install/package_resolution.py
+++ b/src/apm_cli/install/package_resolution.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 from typing import Any
 
 from apm_cli.install.gitlab_resolver import _GITLAB_DIRECT_SHORTHAND_UNRESOLVED
+from apm_cli.utils.github_host import build_ssh_url
 
 GIT_PARENT_USER_SCOPE_ERROR = (
     "git: parent dependencies are not supported at user scope. "
@@ -22,7 +23,15 @@ GIT_PARENT_USER_SCOPE_ERROR = (
 
 def dependency_reference_to_yaml_entry(dep_ref: Any) -> dict:
     """Serialize a structured dependency reference for ``apm.yml`` storage."""
-    entry = {"git": dep_ref.to_github_url()}
+    git_url = dep_ref.to_github_url()
+    if dep_ref.explicit_scheme == "ssh":
+        git_url = build_ssh_url(
+            dep_ref.host,
+            dep_ref.repo_url,
+            port=dep_ref.port,
+            user=dep_ref.ssh_user or "git",
+        )
+    entry = {"git": git_url}
     if dep_ref.virtual_path:
         entry["path"] = dep_ref.virtual_path
     if dep_ref.reference:

--- a/tests/integration/test_marketplace_ssh_install_e2e.py
+++ b/tests/integration/test_marketplace_ssh_install_e2e.py
@@ -1,0 +1,85 @@
+"""End-to-end coverage for SSH marketplace dependency persistence."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from apm_cli.cli import cli
+from apm_cli.marketplace.models import (
+    MarketplaceManifest,
+    MarketplacePlugin,
+    MarketplaceSource,
+)
+from apm_cli.models.apm_package import clear_apm_yml_cache
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(autouse=True)
+def _clear_manifest_cache() -> None:
+    """Keep manifest parsing isolated around the CLI invocation."""
+    clear_apm_yml_cache()
+    yield
+    clear_apm_yml_cache()
+
+
+def test_ssh_marketplace_url_reaches_dependency_install_unchanged(tmp_path, monkeypatch) -> None:
+    """An SSH registration survives persistence, reload, and install dispatch."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("APM_PROGRESS", "never")
+    (tmp_path / "apm.yml").write_text(
+        "name: ssh-marketplace-consumer\nversion: 1.0.0\n",
+        encoding="utf-8",
+    )
+    source = MarketplaceSource(
+        name="apm-reg",
+        url="git@gitlab.mycompany.com:team/packages/toolkit.git",
+    )
+    manifest = MarketplaceManifest(
+        name="apm-reg",
+        plugins=(
+            MarketplacePlugin(
+                name="some-skill",
+                source="skills/some-skill",
+            ),
+        ),
+    )
+    install_result = SimpleNamespace(installed_count=1, diagnostics=None)
+
+    with (
+        patch("apm_cli.commands._helpers.check_for_updates", return_value=None),
+        patch(
+            "apm_cli.marketplace.resolver.get_marketplace_by_name",
+            return_value=source,
+        ),
+        patch(
+            "apm_cli.marketplace.resolver.fetch_or_cache",
+            return_value=manifest,
+        ),
+        patch("apm_cli.commands.install._validate_package_exists", return_value=True),
+        patch(
+            "apm_cli.commands.install._install_apm_dependencies",
+            return_value=install_result,
+        ) as install_dependencies,
+    ):
+        result = CliRunner().invoke(
+            cli,
+            ["install", "some-skill@apm-reg", "--only=apm", "--no-policy"],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0, result.output
+    install_dependencies.assert_called_once()
+    loaded_package = install_dependencies.call_args.args[0]
+    loaded_dependencies = loaded_package.get_apm_dependencies()
+    assert len(loaded_dependencies) == 1
+    dependency = loaded_dependencies[0]
+    assert dependency.explicit_scheme == "ssh"
+    assert dependency.ssh_user == "git"
+    assert dependency.host == "gitlab.mycompany.com"
+    assert dependency.repo_url == "team/packages/toolkit"
+    assert dependency.virtual_path == "skills/some-skill"

--- a/tests/unit/marketplace/test_marketplace_resolver.py
+++ b/tests/unit/marketplace/test_marketplace_resolver.py
@@ -1,9 +1,12 @@
 """Tests for marketplace resolver -- regex and source type resolution."""
 
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 import pytest
 
+from apm_cli.cache.url_normalize import normalize_repo_url
+from apm_cli.install.package_resolution import dependency_reference_to_yaml_entry
 from apm_cli.marketplace.models import (
     MarketplaceManifest,
     MarketplacePlugin,
@@ -543,6 +546,29 @@ class TestResolveMarketplacePluginGitLabMonorepo:
         assert dep.virtual_path == "registry/optimize-prompt"
         assert dep.is_virtual is True
         assert dep.to_canonical() == canonical
+
+    @patch("apm_cli.marketplace.resolver.fetch_or_cache")
+    @patch("apm_cli.marketplace.resolver.get_marketplace_by_name")
+    def test_ssh_registration_is_preserved_in_serialized_dependency(self, mock_get, mock_fetch):
+        source = MarketplaceSource(
+            name="apm-reg",
+            url="git@gitlab.mycompany.com:team/packages/toolkit.git",
+        )
+        plugin = MarketplacePlugin(name="some-skill", source="skills/some-skill")
+        mock_get.return_value = source
+        mock_fetch.return_value = self._manifest_with_plugin(plugin)
+
+        resolution = resolve_marketplace_plugin("some-skill", "apm-reg")
+        dep = resolution.dependency_reference
+        assert dep is not None
+
+        entry = dependency_reference_to_yaml_entry(dep)
+        parsed = urlparse(normalize_repo_url(entry["git"]))
+        assert parsed.scheme == "ssh"
+        assert parsed.username == "git"
+        assert parsed.hostname == "gitlab.mycompany.com"
+        assert parsed.path == "/team/packages/toolkit"
+        assert entry["path"] == "skills/some-skill"
 
     @patch("apm_cli.marketplace.resolver.fetch_or_cache")
     @patch("apm_cli.marketplace.resolver.get_marketplace_by_name")


### PR DESCRIPTION
# fix(marketplace): preserve registered SSH transport

## TL;DR

Marketplace subpath installs now preserve the transport selected when the consumer registered the marketplace. SSH registrations produce SSH `git:` plus `path:` entries in `apm.yml`; HTTPS behavior and strict protocol-fallback boundaries remain unchanged.

> [!NOTE]
> Closes #2063.

## Problem (WHY)

- [x] `resolve_marketplace_plugin` retained SSH on its structured `DependencyReference`, but `dependency_reference_to_yaml_entry` always called the HTTPS-oriented `to_github_url()` serializer.
- [x] SSH-key-only environments therefore received an explicit HTTPS dependency that failed unless unsafe cross-protocol fallback was enabled.
- [!] The reporter observed that ["every install still pays for one guaranteed-failing HTTPS round-trip first"](https://github.com/microsoft/apm/issues/2063) when using the fallback workaround.

The consumer typed the marketplace registration URL. Preserving that transport stays within the existing consumer-controlled trust boundary and does not trust transport instructions from third-party marketplace package metadata.

## Approach (WHAT)

- Detect an already-parsed explicit SSH scheme only at structured dependency serialization.
- Rebuild the SSH clone URL with the existing validated host, port, repository, and SSH user fields.
- Leave HTTPS serialization and protocol fallback behavior untouched.
- Document marketplace transport preservation in consumer and bundled APM usage guidance.

## Implementation (HOW)

- **`src/apm_cli/install/package_resolution.py`** -- serializes explicit SSH references with the existing `build_ssh_url` helper while retaining the current serializer for all other schemes.
- **`tests/unit/marketplace/test_marketplace_resolver.py`** -- reproduces issue #2063 from an SCP-form `MarketplaceSource` through subpath resolution and YAML-entry serialization.
- **`docs/src/content/docs/consumer/authentication.md`** -- explains that SSH marketplace registration continues to use existing SSH keys.
- **`docs/src/content/docs/consumer/installing-from-marketplaces.md`** -- documents transport preservation for generated marketplace dependencies.
- **`packages/apm-guide/.apm/skills/apm-usage/authentication.md`** -- keeps bundled auth guidance aligned with the consumer docs.
- **`packages/apm-guide/.apm/skills/apm-usage/dependencies.md`** -- adds the marketplace case to explicit transport selection.
- **`CHANGELOG.md`** -- records the fix under Unreleased.

## Diagrams

Legend: The dashed nodes are the serialization behavior changed by this PR; marketplace resolution and trust classification remain unchanged.

```mermaid
flowchart LR
    R[MarketplaceSource SSH URL] --> P[resolve_marketplace_plugin]
    P --> D[DependencyReference explicit_scheme ssh]
    D --> S[dependency_reference_to_yaml_entry]
    S --> Y[apm.yml git plus path]
    classDef new stroke-dasharray: 5 5;
    class S,Y new;
```

## Trade-offs

- **Narrow serialization fix.** This does not change `DependencyReference.to_github_url()` globally, avoiding unrelated clone URL behavior changes.
- **No protocol fallback expansion.** Only references already marked `explicit_scheme == "ssh"` are serialized as SSH; third-party package sources cannot opt a consumer into ambient SSH through this change.
- **Existing URL shape.** The shared `build_ssh_url` helper emits SCP form without a port and `ssh://` with a port, preserving existing validated SSH-user rules.

## Benefits

1. SSH-registered marketplace subpath installs write one usable SSH dependency instead of a guaranteed-failing HTTPS attempt.
2. HTTPS-registered marketplaces continue to produce HTTPS dependencies.
3. Strict protocol selection remains the default; `--allow-protocol-fallback` is not enabled or broadened.
4. Documentation and the bundled APM usage skill describe the same transport contract as the implementation.

## Validation

<details open><summary>Regression and relevant suites (185 tests)</summary>

`uv run --extra dev pytest tests/unit/install/test_package_resolution_persistence.py tests/unit/marketplace/test_marketplace_resolver.py tests/integration/test_install_marketplace_phase4w3.py -q`:

```text
185 passed in 1.41s
```

</details>

<details><summary>Mutation-break proof</summary>

```text
Mutation: change the explicit SSH serialization predicate so it does not run.
Result: regression test failed with AssertionError: assert 'https' == 'ssh'.
MUTATION KILLED
```

</details>

<details><summary>Full lint mirror</summary>

CI-mirror lint chain:

```text
uv run --extra dev ruff check src/ tests/
All checks passed!
uv run --extra dev ruff format --check src/ tests/
1410 files already formatted
uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/
Your code has been rated at 10.00/10
bash scripts/lint-auth-signals.sh
[+] auth-signal lint clean
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|-------------------------|--------------|--------------------|------|
| 1 | Register a GitLab or generic git marketplace with an SCP SSH URL, install an in-repository plugin, and keep SSH through manifest persistence, reload, and install dispatch | Secure by default, Vendor-neutral, DevX | `tests/integration/test_marketplace_ssh_install_e2e.py::test_ssh_marketplace_url_reaches_dependency_install_unchanged` (regression-trap for #2063) | integration-with-fixtures |
| 2 | Serialize an SSH-resolved marketplace dependency without rewriting its scheme, user, host, repository, or path | Secure by default, Vendor-neutral | `tests/unit/marketplace/test_marketplace_resolver.py::TestResolveMarketplacePluginGitLabMonorepo::test_ssh_registration_is_preserved_in_serialized_dependency` | unit |

## How to test

- [ ] Register a marketplace with `git@gitlab.mycompany.com:team/packages/toolkit.git`.
- [ ] Install an in-repository plugin such as `some-skill@my-marketplace`.
- [ ] Confirm `apm.yml` contains the same SSH repository under `git:` and the plugin subdirectory under `path:`.
- [ ] Repeat with an HTTPS marketplace and confirm the generated dependency remains HTTPS.

Closes #2063

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

