### PR TITLE
fix(claude): honor CLAUDE_CONFIG_DIR for user MCP config

### DIFF
--- a/docs/src/content/docs/consumer/install-mcp-servers.md
+++ b/docs/src/content/docs/consumer/install-mcp-servers.md
@@ -102,7 +102,7 @@ for the full required-vs-optional runtime config rule.
 |---|---|---|---|
 | GitHub Copilot CLI | `~/.copilot/mcp-config.json` | global | JSON `mcpServers` |
 | VS Code (Copilot) | `.vscode/mcp.json` | project | JSON `servers` |
-| Claude Code | `.mcp.json` (project) or `~/.claude.json` (`-g`) | both | JSON `mcpServers` |
+| Claude Code | `.mcp.json` (project) or `$CLAUDE_CONFIG_DIR/.claude.json` (`-g`, when set; otherwise `~/.claude.json`) | both | JSON `mcpServers` |
 | Cursor | `.cursor/mcp.json` | project (only if `.cursor/` exists) | JSON `mcpServers` |
 | Codex CLI | `.codex/config.toml` (project, only if `.codex/` exists) or `$CODEX_HOME/config.toml` (`-g`, when non-blank; otherwise `~/.codex/config.toml`) | both | TOML `[mcp_servers.*]` |
 | Gemini CLI | `.gemini/settings.json` (project, only if `.gemini/` exists) or `~/.gemini/settings.json` (`-g`) | both | JSON `mcpServers` |
@@ -147,7 +147,9 @@ declare one in `apm.yml`. (#1335)
 
 `apm install -g --mcp NAME` routes the write to each runtime's
 user-scope MCP config (for example, Copilot CLI to
-`~/.copilot/mcp-config.json`, Claude Code to `~/.claude.json`, Codex CLI to
+`~/.copilot/mcp-config.json`, Claude Code to
+`$CLAUDE_CONFIG_DIR/.claude.json` when `CLAUDE_CONFIG_DIR` is set to a
+non-whitespace value or `~/.claude.json` otherwise, Codex CLI to
 `$CODEX_HOME/config.toml` when `CODEX_HOME` is set to a non-whitespace value or `~/.codex/config.toml` otherwise, Gemini CLI to `~/.gemini/settings.json`, Antigravity CLI to `~/.gemini/config/mcp_config.json`, Windsurf to
 `~/.codeium/windsurf/mcp_config.json`, Kiro to `~/.kiro/settings/mcp.json`,
 and JetBrains Copilot to its OS-specific user config). When the

--- a/docs/src/content/docs/consumer/install-mcp-servers.md
+++ b/docs/src/content/docs/consumer/install-mcp-servers.md
@@ -102,7 +102,7 @@ for the full required-vs-optional runtime config rule.
 |---|---|---|---|
 | GitHub Copilot CLI | `~/.copilot/mcp-config.json` | global | JSON `mcpServers` |
 | VS Code (Copilot) | `.vscode/mcp.json` | project | JSON `servers` |
-| Claude Code | `.mcp.json` (project) or `$CLAUDE_CONFIG_DIR/.claude.json` (`-g`, when set to an absolute path; otherwise `~/.claude.json`) | both | JSON `mcpServers` |
+| Claude Code | `.mcp.json` (project) or `$CLAUDE_CONFIG_DIR/.claude.json` (`-g`; unset/blank: `~/.claude.json`) | both | JSON `mcpServers` |
 | Cursor | `.cursor/mcp.json` | project (only if `.cursor/` exists) | JSON `mcpServers` |
 | Codex CLI | `.codex/config.toml` (project, only if `.codex/` exists) or `$CODEX_HOME/config.toml` (`-g`, when non-blank; otherwise `~/.codex/config.toml`) | both | TOML `[mcp_servers.*]` |
 | Gemini CLI | `.gemini/settings.json` (project, only if `.gemini/` exists) or `~/.gemini/settings.json` (`-g`) | both | JSON `mcpServers` |
@@ -149,7 +149,8 @@ declare one in `apm.yml`. (#1335)
 user-scope MCP config (for example, Copilot CLI to
 `~/.copilot/mcp-config.json`, Claude Code to
 `$CLAUDE_CONFIG_DIR/.claude.json` when `CLAUDE_CONFIG_DIR` is set to a
-non-whitespace absolute path or `~/.claude.json` otherwise, Codex CLI to
+non-whitespace absolute path. Unset or blank values use `~/.claude.json`;
+relative values are rejected. Codex CLI writes to
 `$CODEX_HOME/config.toml` when `CODEX_HOME` is set to a non-whitespace value or `~/.codex/config.toml` otherwise, Gemini CLI to `~/.gemini/settings.json`, Antigravity CLI to `~/.gemini/config/mcp_config.json`, Windsurf to
 `~/.codeium/windsurf/mcp_config.json`, Kiro to `~/.kiro/settings/mcp.json`,
 and JetBrains Copilot to its OS-specific user config). When the

--- a/docs/src/content/docs/consumer/install-mcp-servers.md
+++ b/docs/src/content/docs/consumer/install-mcp-servers.md
@@ -102,7 +102,7 @@ for the full required-vs-optional runtime config rule.
 |---|---|---|---|
 | GitHub Copilot CLI | `~/.copilot/mcp-config.json` | global | JSON `mcpServers` |
 | VS Code (Copilot) | `.vscode/mcp.json` | project | JSON `servers` |
-| Claude Code | `.mcp.json` (project) or `$CLAUDE_CONFIG_DIR/.claude.json` (`-g`, when set; otherwise `~/.claude.json`) | both | JSON `mcpServers` |
+| Claude Code | `.mcp.json` (project) or `$CLAUDE_CONFIG_DIR/.claude.json` (`-g`, when set to an absolute path; otherwise `~/.claude.json`) | both | JSON `mcpServers` |
 | Cursor | `.cursor/mcp.json` | project (only if `.cursor/` exists) | JSON `mcpServers` |
 | Codex CLI | `.codex/config.toml` (project, only if `.codex/` exists) or `$CODEX_HOME/config.toml` (`-g`, when non-blank; otherwise `~/.codex/config.toml`) | both | TOML `[mcp_servers.*]` |
 | Gemini CLI | `.gemini/settings.json` (project, only if `.gemini/` exists) or `~/.gemini/settings.json` (`-g`) | both | JSON `mcpServers` |
@@ -149,7 +149,7 @@ declare one in `apm.yml`. (#1335)
 user-scope MCP config (for example, Copilot CLI to
 `~/.copilot/mcp-config.json`, Claude Code to
 `$CLAUDE_CONFIG_DIR/.claude.json` when `CLAUDE_CONFIG_DIR` is set to a
-non-whitespace value or `~/.claude.json` otherwise, Codex CLI to
+non-whitespace absolute path or `~/.claude.json` otherwise, Codex CLI to
 `$CODEX_HOME/config.toml` when `CODEX_HOME` is set to a non-whitespace value or `~/.codex/config.toml` otherwise, Gemini CLI to `~/.gemini/settings.json`, Antigravity CLI to `~/.gemini/config/mcp_config.json`, Windsurf to
 `~/.codeium/windsurf/mcp_config.json`, Kiro to `~/.kiro/settings/mcp.json`,
 and JetBrains Copilot to its OS-specific user config). When the

--- a/docs/src/content/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/reference/environment-variables.md
@@ -75,7 +75,7 @@ Controls how APM clones packages from Git hosts. These settings can also be pers
 | `APM_BROAD_FETCH_DEPTH` | Maximum commit depth used by the bare-cache broad fetch when resolving git refs. | `50` | Integer-like string; tune for very deep histories where ref resolution misses. |
 | `XDG_CACHE_HOME` | Standard XDG base-directory variable APM consults when `APM_CACHE_DIR` is unset (Linux / macOS). | unset | Honoured per the XDG spec. |
 | `LOCALAPPDATA` | Standard Windows variable APM consults when `APM_CACHE_DIR` is unset. | OS-provided | Used to derive the default Windows cache path. |
-| `CLAUDE_CONFIG_DIR` | Override the user-scope destination Claude reads for skills, agents, and MCP config. | Claude default | User-scope MCP servers are written to `$CLAUDE_CONFIG_DIR/.claude.json`; when unset or blank, APM uses `~/.claude.json`. |
+| `CLAUDE_CONFIG_DIR` | Override the user-scope destination Claude reads for skills, agents, and MCP config. | Claude default | Must be absolute. User-scope MCP servers are written to `$CLAUDE_CONFIG_DIR/.claude.json`; when unset or blank, APM uses `~/.claude.json`. |
 
 ## Policy
 

--- a/docs/src/content/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/reference/environment-variables.md
@@ -75,7 +75,7 @@ Controls how APM clones packages from Git hosts. These settings can also be pers
 | `APM_BROAD_FETCH_DEPTH` | Maximum commit depth used by the bare-cache broad fetch when resolving git refs. | `50` | Integer-like string; tune for very deep histories where ref resolution misses. |
 | `XDG_CACHE_HOME` | Standard XDG base-directory variable APM consults when `APM_CACHE_DIR` is unset (Linux / macOS). | unset | Honoured per the XDG spec. |
 | `LOCALAPPDATA` | Standard Windows variable APM consults when `APM_CACHE_DIR` is unset. | OS-provided | Used to derive the default Windows cache path. |
-| `CLAUDE_CONFIG_DIR` | Override the user-scope destination Claude reads for skills, agents, and MCP config. | Claude default | Must be absolute. User-scope MCP servers are written to `$CLAUDE_CONFIG_DIR/.claude.json`; when unset or blank, APM uses `~/.claude.json`. |
+| `CLAUDE_CONFIG_DIR` | Override the user-scope destination Claude reads for skills, agents, and MCP config. | Claude default | For MCP config, nonblank values must be absolute. User-scope MCP servers are written to `$CLAUDE_CONFIG_DIR/.claude.json`; when unset or blank, APM uses `~/.claude.json`. |
 
 ## Policy
 

--- a/docs/src/content/docs/reference/environment-variables.md
+++ b/docs/src/content/docs/reference/environment-variables.md
@@ -75,7 +75,7 @@ Controls how APM clones packages from Git hosts. These settings can also be pers
 | `APM_BROAD_FETCH_DEPTH` | Maximum commit depth used by the bare-cache broad fetch when resolving git refs. | `50` | Integer-like string; tune for very deep histories where ref resolution misses. |
 | `XDG_CACHE_HOME` | Standard XDG base-directory variable APM consults when `APM_CACHE_DIR` is unset (Linux / macOS). | unset | Honoured per the XDG spec. |
 | `LOCALAPPDATA` | Standard Windows variable APM consults when `APM_CACHE_DIR` is unset. | OS-provided | Used to derive the default Windows cache path. |
-| `CLAUDE_CONFIG_DIR` | Override the destination Claude reads for skills / agents. | Claude default | Read by the Claude integration target. |
+| `CLAUDE_CONFIG_DIR` | Override the user-scope destination Claude reads for skills, agents, and MCP config. | Claude default | User-scope MCP servers are written to `$CLAUDE_CONFIG_DIR/.claude.json`; when unset or blank, APM uses `~/.claude.json`. |
 
 ## Policy
 

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -419,7 +419,8 @@ dependencies:
 
 At user scope, Claude MCP entries are written to
 `$CLAUDE_CONFIG_DIR/.claude.json` when `CLAUDE_CONFIG_DIR` is set to a
-non-whitespace absolute path, or `~/.claude.json` otherwise.
+non-whitespace absolute path. Unset or blank values use `~/.claude.json`;
+relative values are rejected.
 
 ## LSP dependency formats
 

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -417,6 +417,10 @@ dependencies:
         callbackPort: 3118
 ```
 
+At user scope, Claude MCP entries are written to
+`$CLAUDE_CONFIG_DIR/.claude.json` when `CLAUDE_CONFIG_DIR` is set to a
+non-whitespace value, or `~/.claude.json` otherwise.
+
 ## LSP dependency formats
 
 LSP (Language Server Protocol) servers give supported runtimes real-time

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -419,7 +419,7 @@ dependencies:
 
 At user scope, Claude MCP entries are written to
 `$CLAUDE_CONFIG_DIR/.claude.json` when `CLAUDE_CONFIG_DIR` is set to a
-non-whitespace value, or `~/.claude.json` otherwise.
+non-whitespace absolute path, or `~/.claude.json` otherwise.
 
 ## LSP dependency formats
 

--- a/src/apm_cli/adapters/client/claude.py
+++ b/src/apm_cli/adapters/client/claude.py
@@ -151,8 +151,8 @@ class ClaudeClientAdapter(CopilotClientAdapter):
             config_path = Path(config_dir).expanduser()
             if not config_path.is_absolute():
                 raise PathTraversalError(
-                    "CLAUDE_CONFIG_DIR is set to a non-absolute path; cannot locate "
-                    "the Claude Code configuration directory."
+                    "CLAUDE_CONFIG_DIR must be an absolute path for user-scope MCP "
+                    "config; set an absolute path or unset it to use ~/.claude.json."
                 )
             return config_path.resolve(strict=False) / ".claude.json"
         return Path.home() / ".claude.json"

--- a/src/apm_cli/adapters/client/claude.py
+++ b/src/apm_cli/adapters/client/claude.py
@@ -20,12 +20,16 @@ See https://code.claude.com/docs/en/mcp
 """
 
 import json
+import logging
 import os
 from pathlib import Path
 
 from ...utils.atomic_io import atomic_write_text
 from ...utils.console import _rich_error, _rich_success, _rich_warning
+from ...utils.path_security import PathTraversalError
 from .copilot import CopilotClientAdapter
+
+_log = logging.getLogger(__name__)
 
 
 class ClaudeClientAdapter(CopilotClientAdapter):
@@ -144,7 +148,13 @@ class ClaudeClientAdapter(CopilotClientAdapter):
     def _user_claude_json_path(self) -> Path:
         config_dir = os.environ.get("CLAUDE_CONFIG_DIR", "").strip()
         if config_dir:
-            return Path(config_dir).expanduser() / ".claude.json"
+            config_path = Path(config_dir).expanduser()
+            if not config_path.is_absolute():
+                raise PathTraversalError(
+                    "CLAUDE_CONFIG_DIR is set to a non-absolute path; cannot locate "
+                    "the Claude Code configuration directory."
+                )
+            return config_path.resolve(strict=False) / ".claude.json"
         return Path.home() / ".claude.json"
 
     def _should_write_project(self) -> bool:
@@ -210,6 +220,7 @@ class ClaudeClientAdapter(CopilotClientAdapter):
             payload = json.dumps(data, indent=2) + "\n"
             path.parent.mkdir(parents=True, exist_ok=True)
             atomic_write_text(path, payload, new_file_mode=0o600)
+            _log.debug("Claude user-scope MCP config written to %s", path)
             return True
         except OSError:
             return False

--- a/src/apm_cli/adapters/client/claude.py
+++ b/src/apm_cli/adapters/client/claude.py
@@ -4,11 +4,11 @@ Project scope: ``.mcp.json`` at the project root with top-level ``mcpServers``
 (``--scope project`` in Claude Code). Writes are opt-in when ``.claude/`` exists,
 mirroring the Cursor/OpenCode directory-presence convention.
 
-User scope: top-level ``mcpServers`` in ``~/.claude.json`` (``--scope user``).
-Writes are atomic and create the file with ``0o600`` permissions on first
-write so the shared Claude Code config is not silently truncated by a
-concurrent writer and cannot leak any embedded OAuth state to other users
-on a multi-user host.
+User scope: top-level ``mcpServers`` in ``$CLAUDE_CONFIG_DIR/.claude.json``
+when configured, otherwise ``~/.claude.json`` (``--scope user``). Writes are
+atomic and create the file with ``0o600`` permissions on first write so the
+shared Claude Code config is not silently truncated by a concurrent writer
+and cannot leak any embedded OAuth state to other users on a multi-user host.
 
 Local scope (Claude Code's third scope -- the default for ``claude mcp add``,
 storing per-project private config under ``~/.claude.json -> projects.<abs_path>
@@ -20,6 +20,7 @@ See https://code.claude.com/docs/en/mcp
 """
 
 import json
+import os
 from pathlib import Path
 
 from ...utils.atomic_io import atomic_write_text
@@ -141,6 +142,9 @@ class ClaudeClientAdapter(CopilotClientAdapter):
         return self.project_root / ".mcp.json"
 
     def _user_claude_json_path(self) -> Path:
+        config_dir = os.environ.get("CLAUDE_CONFIG_DIR", "").strip()
+        if config_dir:
+            return Path(config_dir).expanduser() / ".claude.json"
         return Path.home() / ".claude.json"
 
     def _should_write_project(self) -> bool:

--- a/tests/integration/test_claude_mcp_schema_fidelity.py
+++ b/tests/integration/test_claude_mcp_schema_fidelity.py
@@ -30,6 +30,7 @@ Coverage matrix:
 from __future__ import annotations
 
 import json
+import os
 import tempfile
 from pathlib import Path
 from unittest import mock
@@ -113,10 +114,13 @@ class TestClaudeUserScopeSchemaFidelity:
             "apm_cli.adapters.client.claude.Path.home",
             return_value=self.fake_home,
         )
+        self._config_dir_patch = mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": ""})
         self._home_patch.start()
+        self._config_dir_patch.start()
         self.adapter = ClaudeClientAdapter(project_root=str(self.root), user_scope=True)
 
     def teardown_method(self):
+        self._config_dir_patch.stop()
         self._home_patch.stop()
         self._tmp.cleanup()
 

--- a/tests/integration/test_mcp_targets_gating_e2e.py
+++ b/tests/integration/test_mcp_targets_gating_e2e.py
@@ -78,6 +78,31 @@ def _codex_mcp_path(project: Path) -> Path:
 
 
 class TestMCPTargetsGatingE2E:
+    def test_user_scope_claude_install_honors_claude_config_dir(self, tmp_path, monkeypatch):
+        project = tmp_path / "project"
+        project.mkdir()
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        config_dir = tmp_path / "relocated-claude"
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+
+        installed = MCPIntegrator.install(
+            [_make_stdio_dep("relocated-claude-mcp")],
+            runtime="claude",
+            project_root=project,
+            user_scope=True,
+            explicit_target="claude",
+        )
+
+        relocated_config = config_dir / ".claude.json"
+        default_config = fake_home / ".claude.json"
+        assert installed == 1
+        assert relocated_config.is_file()
+        data = json.loads(relocated_config.read_text(encoding="utf-8"))
+        assert data["mcpServers"]["relocated-claude-mcp"]["command"] == "echo"
+        assert not default_config.exists()
+
     def test_targets_whitelist_copilot_suppresses_foreign_writes(
         self, tmp_path, capsys, monkeypatch
     ):

--- a/tests/unit/test_claude_mcp.py
+++ b/tests/unit/test_claude_mcp.py
@@ -13,6 +13,7 @@ import pytest
 from apm_cli.adapters.client.claude import ClaudeClientAdapter
 from apm_cli.core.scope import InstallScope
 from apm_cli.factory import ClientFactory
+from apm_cli.utils.path_security import PathTraversalError
 
 
 class TestClaudeClientFactory(unittest.TestCase):
@@ -226,8 +227,13 @@ class TestClaudeClientAdapterUser(unittest.TestCase):
         with patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": str(config_dir)}):
             self.assertEqual(
                 Path(self.adapter.get_config_path()),
-                config_dir / ".claude.json",
+                config_dir.resolve() / ".claude.json",
             )
+
+    def test_get_config_path_rejects_relative_claude_config_dir(self):
+        with patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": "../custom-claude"}):
+            with self.assertRaises(PathTraversalError):
+                self.adapter.get_config_path()
 
     def test_new_user_claude_json_created_with_0600_perms(self):
         """New ~/.claude.json must be created with 0o600 to avoid leaking OAuth state."""

--- a/tests/unit/test_claude_mcp.py
+++ b/tests/unit/test_claude_mcp.py
@@ -201,9 +201,12 @@ class TestClaudeClientAdapterUser(unittest.TestCase):
         self.claude_json = self.home / ".claude.json"
         self.adapter = ClaudeClientAdapter(user_scope=True)
         self._home = patch.object(Path, "home", return_value=self.home)
+        self._config_dir = patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": ""})
         self._home.start()
+        self._config_dir.start()
 
     def tearDown(self):
+        self._config_dir.stop()
         self._home.stop()
         self.tmp.cleanup()
 
@@ -217,6 +220,14 @@ class TestClaudeClientAdapterUser(unittest.TestCase):
         self.assertIn("projects", data)
         self.assertIn("x", data["mcpServers"])
         self.assertIn("y", data["mcpServers"])
+
+    def test_get_config_path_honors_claude_config_dir(self):
+        config_dir = self.home / "custom-claude"
+        with patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": str(config_dir)}):
+            self.assertEqual(
+                Path(self.adapter.get_config_path()),
+                config_dir / ".claude.json",
+            )
 
     def test_new_user_claude_json_created_with_0600_perms(self):
         """New ~/.claude.json must be created with 0o600 to avoid leaking OAuth state."""


### PR DESCRIPTION
# fix(claude): honor CLAUDE_CONFIG_DIR for user MCP config

## TL;DR

Claude user-scope MCP writes now follow `CLAUDE_CONFIG_DIR` when it is set and non-blank, falling back to `~/.claude.json` otherwise. This keeps `apm install -g --mcp` aligned with the file Claude Code actually reads and closes #2060.

> [!NOTE]
> Project-scope behavior remains unchanged: Claude MCP entries still go to `.mcp.json`.

## Problem (WHY)

- [x] `ClaudeClientAdapter(user_scope=True)` hardcoded `~/.claude.json`, even when Claude Code was configured to read `$CLAUDE_CONFIG_DIR/.claude.json`.
- [x] Global MCP installs could report success while writing a file Claude Code did not read.
- [!] Other Claude user-scope primitives already honored `CLAUDE_CONFIG_DIR`, so MCP routing diverged from the target's established behavior.

Issue #2060 captures the observed contract: user-scope MCP servers should be written to `$CLAUDE_CONFIG_DIR/.claude.json` when configured, with the existing home-directory fallback preserved.

## Approach (WHAT)

| # | Fix |
|---|---|
| 1 | Resolve the Claude user config root from a trimmed `CLAUDE_CONFIG_DIR`. |
| 2 | Preserve `~/.claude.json` for unset or whitespace-only values. |
| 3 | Add a regression test that exercises the adapter's public config-path result. |
| 4 | Update user-facing MCP and environment-variable guidance. |

## Implementation (HOW)

| File | Change |
|---|---|
| `src/apm_cli/adapters/client/claude.py` | `_user_claude_json_path()` now requires an absolute non-blank `CLAUDE_CONFIG_DIR`, normalizes it, and logs the resolved write path; all existing read, write, and merge paths continue through this helper. |
| `tests/unit/test_claude_mcp.py` | Adds path-resolution and relative-path rejection coverage. |
| `tests/integration/test_mcp_targets_gating_e2e.py` | Exercises a real user-scope MCP install and proves the relocated file is written without leaking to the home fallback. |
| `docs/src/content/docs/consumer/install-mcp-servers.md` | Documents the Claude global MCP destination and fallback. |
| `docs/src/content/docs/reference/environment-variables.md` | Extends the variable contract to include user-scope MCP config. |
| `packages/apm-guide/.apm/skills/apm-usage/dependencies.md` | Mirrors the MCP destination guidance in the bundled usage skill. |

## Diagrams

Legend: The dashed node is the new environment-aware destination selected before the existing Claude MCP write path runs.

```mermaid
flowchart LR
    E[CLAUDE_CONFIG_DIR] --> Q{Non-blank value}
    Q -->|yes| C[Config directory .claude.json]
    Q -->|no| H[Home directory .claude.json]
    C --> W[Existing Claude MCP read and write path]
    H --> W
    classDef new stroke-dasharray: 5 5;
    class C new;
```

## Trade-offs

- **Local resolution over cross-module reuse.** The adapter reads the environment directly instead of coupling MCP config writes to the broader deployment-target resolver; this is the smallest sibling-consistent fix.
- **Dynamic lookup over constructor caching.** The helper resolves the variable when the path is requested, preserving current adapter behavior and making environment-scoped tests deterministic.
- **No CHANGELOG entry.** The fix is documented in the directly affected reference and bundled usage guidance; release maintainers can consolidate the final release note.

## Benefits

1. A non-blank `CLAUDE_CONFIG_DIR` produces exactly one expected user MCP destination: `$CLAUDE_CONFIG_DIR/.claude.json`.
2. Unset and blank values retain the existing `~/.claude.json` destination.
3. Reads, merges, stale checks, and writes share the corrected helper without separate routing logic.
4. The regression test fails when the environment lookup is removed or renamed.

## Validation

`uv run --extra dev pytest tests/unit/test_claude_mcp.py -q`:

```
29 passed, 4 subtests passed in 0.84s
```

`uv run --extra dev pytest tests/unit/test_claude_mcp.py tests/integration/test_claude_mcp_schema_fidelity.py tests/integration/test_mcp_targets_gating_e2e.py -q`:

```
46 passed, 4 subtests passed in 3.34s
```

<details><summary>Canonical lint mirror</summary>

```
All checks passed!
1410 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
All CI grep guardrails passed
```

</details>

Mutation-break proof replaced `CLAUDE_CONFIG_DIR` with `CLAUDE_CONFIG_DIR_MUTANT`; `test_user_scope_claude_install_honors_claude_config_dir` failed because the relocated file was absent, then passed after restoration.

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|---|---|---|---|
| 1 | Set `CLAUDE_CONFIG_DIR`, then install Claude MCP servers globally; APM writes that directory's `.claude.json` and not the home fallback. | Portability by manifest, Multi-harness support, DevX | `tests/integration/test_mcp_targets_gating_e2e.py::TestMCPTargetsGatingE2E::test_user_scope_claude_install_honors_claude_config_dir` (regression-trap for #2060) | integration-with-fixtures |

## How to test

- [ ] Set `CLAUDE_CONFIG_DIR` to a scratch directory and instantiate `ClaudeClientAdapter(user_scope=True)`; `get_config_path()` should end in that directory's `.claude.json`.
- [ ] Unset `CLAUDE_CONFIG_DIR`; the same call should return `~/.claude.json`.
- [ ] Run the Claude MCP unit and integration suites; all tests and subtests should pass.
- [ ] Run the canonical lint mirror; every gate should exit zero.

Closes #2060

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

