### PR TITLE
fix(deps): normalize case-insensitive package identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub and package-registry references now normalize owner/repository casing
   before deriving identity, lock/cache keys, canonical strings, publish paths,
   and install directories, while unknown git hosts retain case-sensitive paths.
-  (closes #2073)
+  (closes #2073) (#2098)
 - `apm install host/org/repo/subpath#ref` on an unrecognised self-hosted FQDN
   no longer fails with a misleading "not accessible or doesn't exist" error;
   the failure reason now suggests setting `GITLAB_HOST` / `APM_GITLAB_HOSTS`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- GitHub and package-registry references now normalize owner/repository casing
-  before deriving identity, lock/cache keys, canonical strings, publish paths,
-  and install directories, while unknown git hosts retain case-sensitive paths.
-  (closes #2073) (#2098)
+- Installing the same GitHub or package-registry dependency with different
+  owner/repository casing no longer creates duplicate identities, lock/cache
+  keys, or install paths. Publish uses the same lowercase identity, while
+  unknown git hosts retain case-sensitive paths. (closes #2073) (#2098)
 - `apm install host/org/repo/subpath#ref` on an unrecognised self-hosted FQDN
   no longer fails with a misleading "not accessible or doesn't exist" error;
   the failure reason now suggests setting `GITLAB_HOST` / `APM_GITLAB_HOSTS`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- GitHub and package-registry references now normalize owner/repository casing
+  before deriving identity, lock/cache keys, canonical strings, publish paths,
+  and install directories, while unknown git hosts retain case-sensitive paths.
+  (closes #2073)
 - `apm install host/org/repo/subpath#ref` on an unrecognised self-hosted FQDN
   no longer fails with a misleading "not accessible or doesn't exist" error;
   the failure reason now suggests setting `GITLAB_HOST` / `APM_GITLAB_HOSTS`

--- a/docs/src/content/docs/consumer/manage-dependencies.md
+++ b/docs/src/content/docs/consumer/manage-dependencies.md
@@ -67,6 +67,11 @@ parser. The supported forms:
 | Registry shorthand | `owner/repo#^2.0.0` with a default registry configured | Routes dep through the default registry instead of git. Default may come from `apm.yml` or `~/.apm/config.json`. Requires `registries` experimental flag. |
 | Registry object form | `{ id: owner/repo, version: ^2.0.0 }` | Explicit registry dep. `registry:` optional when a default registry is configured. Requires `registries` experimental flag. |
 
+GitHub and package-registry owner/repository identifiers are normalized to
+lowercase before APM derives lock keys, cache identity, canonical strings, or
+`apm_modules/` paths. For example, `Owner/Repo` and `owner/repo` install as one
+package at `apm_modules/owner/repo`. Repository path casing is preserved for
+unknown git hosts because a self-hosted backend may be case-sensitive.
 
 Object form in YAML — three mutually exclusive keys select the variant
 (`git`, `path`, or `marketplace`):

--- a/docs/src/content/docs/reference/cli/publish.md
+++ b/docs/src/content/docs/reference/cli/publish.md
@@ -30,7 +30,7 @@ The project's `apm.yml` must declare a `registries:` block with at least one reg
 | Flag | Default | Description |
 |---|---|---|
 | `--registry NAME` | _(required when multiple registries configured)_ | Registry name from the `registries:` block. |
-| `--package OWNER/REPO` | _(required)_ | Package identity to publish as (e.g. `acme/my-skill`). |
+| `--package OWNER/REPO` | _(required)_ | Package identity to publish as (e.g. `acme/my-skill`). Owner and repository are normalized to lowercase. |
 | `--zip PATH` | auto-pack | Path to a pre-built `.zip`. Skips auto-pack. (renamed from `--tarball` in v0.20.0) |
 | `--dry-run` | off | Print what would be uploaded; do not call the registry. |
 | `--verbose`, `-v` | off | Show auto-pack details (archive path). |

--- a/docs/src/content/docs/reference/lockfile-spec.md
+++ b/docs/src/content/docs/reference/lockfile-spec.md
@@ -179,6 +179,11 @@ host (`host/owner/repo`), so `github.com/team/skills` and
 host casing cannot create duplicate keys. Registry-proxy entries keep the bare
 logical key because the proxy host is transport, not package identity.
 
+GitHub and package-registry owner/repository paths are lowercased before APM
+derives the key. Older mixed-case GitHub entries therefore serialize with the
+same key as new lowercase references. Repository path casing remains unchanged
+for unknown git hosts because those backends may be case-sensitive.
+
 ## Self entry
 
 A project that ships its own primitives (skills, agents, prompts under

--- a/packages/apm-guide/.apm/skills/apm-usage/commands.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/commands.md
@@ -24,6 +24,9 @@
 | `apm deps clean` | Clean dependency cache | `--dry-run`, `-y` skip confirm |
 | `apm deps update [PKGS...]` | Deprecated -- use `apm update` instead (now a strict superset). Update specific packages | `--verbose`, `--force`, `--target` (comma-separated), `--parallel-downloads N`, `-g/--global`, `--legacy-skill-paths` |
 
+`apm publish --package OWNER/REPO` normalizes the owner and repository to
+lowercase before constructing the package-registry path.
+
 ### Install validation chain (virtual subdirectory packages)
 
 `apm install` validates subdirectory packages (`owner/repo/path#ref`) before writing to `apm.yml` using the same credential chain as the actual install. See [Authentication > Install validation chain](../authentication/) for the full probe sequence and troubleshooting.

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -43,6 +43,12 @@ dependencies:
     - ../sibling-repo/my-package
 ```
 
+GitHub and package-registry owner/repository identifiers are normalized to
+lowercase before APM derives lock keys, cache identity, canonical strings, or
+`apm_modules/` paths. `Owner/Repo` and `owner/repo` therefore identify one
+package. Repository path casing is preserved for unknown git hosts because a
+self-hosted backend may be case-sensitive.
+
 **Local-path anchor rule:** a `local_path` declared INSIDE another local
 package is resolved relative to THAT package's own directory (npm/pip/cargo
 parity). Sibling layouts that resolve outside the consuming project root

--- a/src/apm_cli/commands/publish.py
+++ b/src/apm_cli/commands/publish.py
@@ -161,7 +161,14 @@ def _resolve_package_id(package_id: str) -> tuple[str, str]:
     raw = re.sub(r"^https?://[^/]+/", "", package_id).strip("/")
     parts = [p for p in raw.split("/") if p]
     if len(parts) >= 2:
-        return parts[-2], parts[-1]
+        from ..models.dependency.identity import normalize_package_repo_url
+
+        canonical = normalize_package_repo_url(
+            "/".join(parts[-2:]),
+            source="registry",
+        )
+        owner, repo = canonical.split("/", 1)
+        return owner, repo
     raise click.UsageError(
         f"--package must be in owner/repo form (got {package_id!r}).\n"
         "Example: --package acme/my-skill"

--- a/src/apm_cli/commands/publish.py
+++ b/src/apm_cli/commands/publish.py
@@ -17,6 +17,7 @@ import click
 
 from ..core.command_logger import CommandLogger
 from ..deps.registry.feature_gate import require_package_registry_enabled
+from ..models.dependency.identity import normalize_package_repo_url
 from ..utils.paths import portable_relpath
 
 _PUBLISH_HELP = """\
@@ -161,8 +162,6 @@ def _resolve_package_id(package_id: str) -> tuple[str, str]:
     raw = re.sub(r"^https?://[^/]+/", "", package_id).strip("/")
     parts = [p for p in raw.split("/") if p]
     if len(parts) >= 2:
-        from ..models.dependency.identity import normalize_package_repo_url
-
         canonical = normalize_package_repo_url(
             "/".join(parts[-2:]),
             source="registry",

--- a/src/apm_cli/deps/lockfile.py
+++ b/src/apm_cli/deps/lockfile.py
@@ -14,6 +14,7 @@ from typing import Any
 import yaml
 
 from ..models.apm_package import DependencyReference
+from ..models.dependency.identity import normalize_package_repo_url
 from ..models.dependency.reference import (
     build_canonical_dependency_string,
     build_dependency_unique_key,
@@ -137,6 +138,15 @@ class LockedDependency:
     # reading a lockfile written by a newer build doesn't silently drop
     # fields when it re-emits.
     _unknown_fields: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Normalize case-insensitive package identity when loading or creating locks."""
+        self.repo_url = normalize_package_repo_url(
+            self.repo_url,
+            host=self.host,
+            source=self.source,
+            registry_prefix=self.registry_prefix,
+        )
 
     def get_unique_key(self) -> str:
         """Returns unique key for this dependency."""

--- a/src/apm_cli/models/dependency/identity.py
+++ b/src/apm_cli/models/dependency/identity.py
@@ -9,6 +9,8 @@ without collapsing their distinct local-detection semantics.
 
 import re
 
+from ...utils.github_host import default_host, is_github_hostname
+
 # Allowed character set for a single repository path segment.
 #
 # ADO accepts spaces (project / repo names can contain them) but NOT tilde --
@@ -24,6 +26,34 @@ _ADO_PATH_SEGMENT_RE = r"^[a-zA-Z0-9._\- ]+$"
 _NON_ADO_PATH_SEGMENT_RE = r"^[a-zA-Z0-9._~-]+$"
 
 _RANGE_PREFIX_RE = re.compile(r"^(>=|<=|>|<|\^|~|=)")
+
+
+def normalize_package_repo_url(
+    repo_url: str,
+    *,
+    host: str | None = None,
+    source: str | None = None,
+    registry_prefix: str | None = None,
+    is_local: bool = False,
+    is_marketplace: bool = False,
+) -> str:
+    """Return the canonical repository path for package identity.
+
+    GitHub and package-registry identifiers are case-insensitive, so their
+    owner/repository path is lowercase at the model boundary. Unknown git
+    hosts retain their path casing because their repository semantics may be
+    case-sensitive.
+    """
+    if is_local or source == "local" or is_marketplace:
+        return repo_url
+
+    if source == "registry" or registry_prefix:
+        return repo_url.lower()
+
+    effective_host = host or default_host()
+    if effective_host.lower() == default_host().lower() or is_github_hostname(effective_host):
+        return repo_url.lower()
+    return repo_url
 
 
 def build_dependency_unique_key(

--- a/src/apm_cli/models/dependency/identity.py
+++ b/src/apm_cli/models/dependency/identity.py
@@ -5,6 +5,9 @@ file-length guardrail. These are pure, stateless helpers with no dependency on
 ``DependencyReference`` internals; both ``DependencyReference`` and
 ``LockedDependency`` reuse them so the two identity models share one body shape
 without collapsing their distinct local-detection semantics.
+
+``normalize_package_repo_url`` is the single casing-normalization boundary for
+package identity. Callers must not lowercase repository paths independently.
 """
 
 import re
@@ -50,8 +53,11 @@ def normalize_package_repo_url(
     if source == "registry" or registry_prefix:
         return repo_url.lower()
 
-    effective_host = host or default_host()
-    if effective_host.lower() == default_host().lower() or is_github_hostname(effective_host):
+    configured_default_host = default_host()
+    effective_host = host or configured_default_host
+    if effective_host.lower() == configured_default_host.lower() or is_github_hostname(
+        effective_host
+    ):
         return repo_url.lower()
     return repo_url
 

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -33,6 +33,7 @@ from .identity import (
     _path_segment_pattern,
     build_canonical_dependency_string,
     build_dependency_unique_key,
+    normalize_package_repo_url,
 )
 from .object_fields import (
     apply_optional_dependency_fields,
@@ -116,6 +117,17 @@ class DependencyReference:
     marketplace_name: str | None = None
     marketplace_plugin_name: str | None = None
     marketplace_version_spec: str | None = None
+
+    def __post_init__(self) -> None:
+        """Normalize case-insensitive package identity at the model boundary."""
+        self.repo_url = normalize_package_repo_url(
+            self.repo_url,
+            host=self.host,
+            source=self.source,
+            registry_prefix=self.artifactory_prefix,
+            is_local=self.is_local,
+            is_marketplace=self.is_marketplace,
+        )
 
     @property
     def ref_kind(self) -> str | None:

--- a/tests/integration/test_package_identity_case_install.py
+++ b/tests/integration/test_package_identity_case_install.py
@@ -1,0 +1,63 @@
+"""Integration coverage for case-insensitive GitHub package identity."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+from apm_cli.commands.install import _validate_and_add_packages_to_apm_yml
+from apm_cli.deps.apm_resolver import APMDependencyResolver
+from apm_cli.deps.lockfile import LockedDependency, LockFile
+from apm_cli.models.apm_package import APMPackage, clear_apm_yml_cache
+
+
+def test_mixed_case_install_resolves_once_without_collision(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Mixed-case install inputs converge before manifest and graph deduplication."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "apm.yml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "case-normalization-test",
+                "version": "1.0.0",
+                "dependencies": {"apm": []},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with patch("apm_cli.commands.install._validate_package_exists", return_value=True):
+        installed, _outcome = _validate_and_add_packages_to_apm_yml(
+            ["Owner/Example-Package", "owner/example-package"]
+        )
+
+    clear_apm_yml_cache()
+    package = APMPackage.from_apm_yml(tmp_path / "apm.yml")
+    dependencies = package.get_apm_dependencies()
+    graph = APMDependencyResolver(max_parallel=1).resolve_dependencies(tmp_path)
+    resolved = graph.flattened_dependencies.get_installation_list()
+    locked = LockedDependency.from_dependency_ref(
+        resolved[0],
+        resolved_commit="abc123",
+        depth=1,
+        resolved_by=None,
+    )
+    lockfile = LockFile()
+    lockfile.add_dependency(locked)
+    lock_path = tmp_path / "apm.lock.yaml"
+    lockfile.write(lock_path)
+    reloaded_lockfile = LockFile.read(lock_path)
+
+    assert installed == ["owner/example-package"]
+    assert [dependency.repo_url for dependency in dependencies] == ["owner/example-package"]
+    assert [dependency.get_unique_key() for dependency in resolved] == ["owner/example-package"]
+    assert resolved[0].get_install_path(tmp_path / "apm_modules") == (
+        tmp_path / "apm_modules" / "owner" / "example-package"
+    )
+    assert graph.flattened_dependencies.conflicts == []
+    assert list(reloaded_lockfile.dependencies) == ["owner/example-package"]
+    assert reloaded_lockfile.dependencies["owner/example-package"].repo_url == (
+        "owner/example-package"
+    )

--- a/tests/test_apm_package_models.py
+++ b/tests/test_apm_package_models.py
@@ -34,6 +34,39 @@ class TestDependencyReference:
         assert dep.reference is None
         assert dep.alias is None
 
+    def test_github_owner_repo_casing_has_one_identity(self):
+        """GitHub owner/repo casing must not create distinct package identities."""
+        mixed = DependencyReference.parse("Owner/Example-Package#v1.0.0")
+        lower = DependencyReference.parse("owner/example-package#v1.0.0")
+
+        assert mixed.repo_url == "owner/example-package"
+        assert mixed.get_identity() == lower.get_identity()
+        assert mixed.to_canonical() == lower.to_canonical()
+
+    def test_github_owner_repo_casing_has_one_dedup_key(self):
+        """GitHub owner/repo casing must not create distinct lock/dedup keys."""
+        mixed = DependencyReference.parse("https://github.com/Owner/Example-Package.git")
+        lower = DependencyReference.parse("owner/example-package")
+
+        assert mixed.get_unique_key() == lower.get_unique_key() == "owner/example-package"
+
+    def test_github_owner_repo_casing_has_one_install_path(self):
+        """GitHub owner/repo casing must not create distinct install directories."""
+        mixed = DependencyReference.parse("Owner/Example-Package")
+        lower = DependencyReference.parse("owner/example-package")
+        modules = Path("apm_modules")
+
+        assert mixed.get_install_path(modules) == lower.get_install_path(modules)
+        assert mixed.get_install_path(modules) == modules / "owner" / "example-package"
+
+    def test_generic_git_host_preserves_case_sensitive_repo_path(self):
+        """Unknown git hosts retain path casing because their semantics are unknown."""
+        mixed = DependencyReference.parse("https://git.example.com/Owner/Example-Package.git")
+        lower = DependencyReference.parse("https://git.example.com/owner/example-package.git")
+
+        assert mixed.repo_url == "Owner/Example-Package"
+        assert mixed.get_identity() != lower.get_identity()
+
     def test_parse_with_branch(self):
         """Test parsing with branch reference."""
         dep = DependencyReference.parse("user/repo#main")

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -32,6 +32,16 @@ class TestLockedDependency:
         dep = LockedDependency(repo_url="owner/repo", host="github.com")
         assert dep.get_unique_key() == "owner/repo"
 
+    def test_github_owner_repo_casing_migrates_to_one_lock_key(self):
+        mixed = LockedDependency.from_dict(
+            {"repo_url": "Owner/Example-Package", "host": "github.com"}
+        )
+        lower = LockedDependency(repo_url="owner/example-package", host="github.com")
+
+        assert mixed.repo_url == "owner/example-package"
+        assert mixed.get_unique_key() == lower.get_unique_key()
+        assert mixed.to_dict()["repo_url"] == "owner/example-package"
+
     def test_get_unique_key_includes_non_default_host(self):
         dep = LockedDependency(repo_url="team/skills", host="gitea.myorg.com")
         assert dep.get_unique_key() == "gitea.myorg.com/team/skills"

--- a/tests/unit/commands/test_publish_registry_archive.py
+++ b/tests/unit/commands/test_publish_registry_archive.py
@@ -184,6 +184,9 @@ class TestResolvePackageId:
     def test_bare_owner_repo(self) -> None:
         assert _resolve_package_id("acme/my-skill") == ("acme", "my-skill")
 
+    def test_package_identity_is_lowercase(self) -> None:
+        assert _resolve_package_id("Acme/My-Skill") == ("acme", "my-skill")
+
     def test_github_https_url_stripped(self) -> None:
         assert _resolve_package_id("https://github.com/acme/my-skill") == ("acme", "my-skill")
 

--- a/tests/unit/integration/test_skill_integrator.py
+++ b/tests/unit/integration/test_skill_integrator.py
@@ -1830,7 +1830,7 @@ Use this skill for comprehensive guidance.
         assert all(e.package != "humanizer" for e in entries), (
             "diagnostics.overwrite() was called with package=skill_name instead of package=current_key"
         )
-        assert any(e.package == "Serendeep/humanizer" for e in entries)
+        assert any(e.package == "serendeep/humanizer" for e in entries)
 
 
 # =============================================================================


### PR DESCRIPTION
# fix(deps): normalize case-insensitive package identity

## TL;DR

GitHub and package-registry owner/repository paths now become lowercase at a shared identity boundary. Mixed-case references therefore share canonical strings, lock/cache keys, publish paths, and install directories, while unknown git hosts retain their original path casing.

> [!NOTE]
> This closes #2073 and automatically rewrites legacy mixed-case GitHub lock entries on the next lockfile emission.

## Problem (WHY)

- [x] `Owner/example-package` and `owner/example-package` previously produced distinct identities, lock/cache keys, and `apm_modules/` paths, as reproduced in #2073.
- [x] `apm publish --package Owner/Repo` addressed a different case-sensitive registry URL path than install used for the same logical package.
- [!] Lowercasing every git URL would break unknown self-hosted backends whose repository paths may be case-sensitive.

The regression tests turn the issue contract into executable evidence: ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)

## Approach (WHAT)

| # | Fix | Principle | Source |
|---:|---|---|---|
| 1 | Centralize owner/repository normalization in one identity helper. | "Favor small, chainable primitives over monolithic frameworks." | [PROSE](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |
| 2 | Apply that boundary when dependency and lock models are created, and when registry publish IDs are parsed. | "Context arrives just-in-time, not just-in-case." | [PROSE](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |
| 3 | Preserve unknown-host repository casing and prove the exception. | "Add what the agent lacks, omit what it knows" | [Agent Skills](https://agentskills.io/skill-creation/best-practices) |

## Implementation (HOW)

| File | Change |
|---|---|
| `src/apm_cli/models/dependency/identity.py` | Adds the shared normalization policy: lowercase GitHub/default-host, registry, and registry-proxy identities; preserve local, unresolved marketplace, and unknown-host paths. |
| `src/apm_cli/models/dependency/reference.py` | Normalizes once in `DependencyReference.__post_init__`, before canonical, dedup, cache, display, and install-path consumers run. |
| `src/apm_cli/deps/lockfile.py` | Applies the same boundary to new and loaded `LockedDependency` values, migrating mixed-case GitHub lock entries on serialization. |
| `src/apm_cli/commands/publish.py` | Canonicalizes registry `OWNER/REPO` before constructing publish API paths. |
| `tests/test_apm_package_models.py` | Adds regression traps for identity, canonical form, dedup key, install path, and unknown-host case preservation. |
| `tests/test_lockfile.py` | Proves legacy mixed-case lock entries converge and serialize lowercase. |
| `tests/unit/commands/test_publish_registry_archive.py` | Proves publish package IDs use the same lowercase registry identity. |
| `tests/unit/integration/test_skill_integrator.py` | Updates the integration-level diagnostic contract to consume the normalized key. |
| `docs/src/content/docs/consumer/manage-dependencies.md` | Documents normalization and the unknown-host exception. |
| `packages/apm-guide/.apm/skills/apm-usage/dependencies.md` | Keeps the bundled dependency reference guidance synchronized. |
| `CHANGELOG.md` | Records the issue fix under Unreleased. |

## Diagrams

Legend: the dashed node is the new shared boundary; downstream consumers only receive its canonical result.

```mermaid
flowchart LR
    subgraph Inputs[Package identity inputs]
        I1[DependencyReference]
        I2[LockedDependency]
        I3[Registry publish ID]
    end
    subgraph Normalize[Identity boundary]
        N1[normalize_package_repo_url]
        N2{GitHub or registry?}
    end
    subgraph Outputs[Identity consumers]
        O1[Canonical string]
        O2[Lock and cache key]
        O3[Install and publish path]
    end
    I1 --> N1
    I2 --> N1
    I3 --> N1
    N1 --> N2
    N2 -->|yes| L1[Lowercase owner and repo]
    N2 -->|no| P1[Preserve repository path case]
    L1 --> O1
    L1 --> O2
    L1 --> O3
    P1 --> O1
    P1 --> O2
    P1 --> O3
    classDef new stroke-dasharray: 5 5;
    class N1 new;
```

## Trade-offs

- **Normalize at model construction, not at every consumer.** This prevents drift among canonical strings, lock/cache keys, and paths; repeated consumer-specific lowercasing was rejected.
- **Preserve unknown-host casing.** Universal lowercasing was rejected because generic Git servers can define case-sensitive repository paths.
- **Rewrite legacy values in place.** A lock schema bump was rejected because existing entries can be normalized safely when loaded and re-emitted.

## Benefits

1. Two GitHub references differing only by casing now produce exactly one identity and one lock/cache key.
2. The same pair now resolves to exactly one lowercase `apm_modules/owner/repo` directory.
3. Registry publish and install use the same lowercase owner/repository URL path.
4. Unknown self-hosted Git paths remain byte-for-byte case-preserving.

## Validation

`uv run --extra dev pytest <six casing regression tests> -q`:

```text
......                                                                   [100%]
6 passed in 2.11s
```

Mutation-break proof (replace both normalization returns with the unmodified input, then run the five normalization traps):

```text
mutation killed by regression tests
```

<details><summary>Full unit suite and CI lint mirror</summary>

`uv run --extra dev pytest tests/unit -q --tb=short`:

```text
18164 passed, 2 skipped, 21 xfailed, 19 warnings, 84 subtests passed in 164.33s (0:02:44)
```

CI lint mirror:

```text
All checks passed!
1410 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
YAML, file-length, and relative_to guards passed
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | Installing `Owner/Repo` and `owner/repo` creates one package identity, lock/cache key, and directory. | Governed by policy, DevX (pragmatic as npm) | `tests/test_apm_package_models.py::TestDependencyReference::test_github_owner_repo_casing_has_one_identity`<br/>`::test_github_owner_repo_casing_has_one_dedup_key`<br/>`::test_github_owner_repo_casing_has_one_install_path` (regression-trap for #2073) | unit |
| 2 | Loading an older mixed-case GitHub lock entry rewrites it to the canonical lowercase key. | Governed by policy | `tests/test_lockfile.py::TestLockedDependency::test_github_owner_repo_casing_migrates_to_one_lock_key` | unit |
| 3 | Publishing a mixed-case package ID addresses the same registry package that install resolves. | Governed by policy, DevX (pragmatic as npm) | `tests/unit/commands/test_publish_registry_archive.py::TestResolvePackageId::test_package_identity_is_lowercase` | unit |
| 4 | Installing from an unknown self-hosted Git server preserves its case-sensitive repository path. | Vendor-neutral | `tests/test_apm_package_models.py::TestDependencyReference::test_generic_git_host_preserves_case_sensitive_repo_path` | unit |
| 5 | Integrator diagnostics report the normalized current package key. | Multi-harness support, Governed by policy | `tests/unit/integration/test_skill_integrator.py::TestNativeSkillIntegration::test_native_skill_collision_diagnostic_package_is_current_key` | integration |

## How to test

- [ ] Run the six casing regression tests above; expect `6 passed`.
- [ ] Run `uv run --extra dev pytest tests/unit -q`; expect all unit tests to pass.
- [ ] Run the CI lint mirror; expect Ruff, duplication, auth, YAML, file-length, and relative-path guards to pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
