### PR TITLE
fix(deps): match local transitive dependencies by install path

### DIFF
--- a/src/apm_cli/commands/deps/cli.py
+++ b/src/apm_cli/commands/deps/cli.py
@@ -156,13 +156,14 @@ def _resolve_scope_deps(apm_dir, logger, insecure_only=False):
         if lockfile_path.exists():
             lockfile = LockFile.read(lockfile_path)
             for dep in lockfile.dependencies.values():
-                # Orphan / source matching is host-blind: it compares against
-                # the apm.yml-derived keys above and the host-blind apm_modules/
-                # filesystem layout. get_unique_key() is the host-qualified
-                # lockfile dedup key (#773) and must NOT be used here, or a
-                # non-default-host dep never matches its installed directory
-                # (it would be wrongly flagged orphaned and lose its Source).
-                dep_key = dep.get_canonical_dependency_string()
+                # Match the host-blind apm_modules/ layout. Local dependency
+                # identity retains its source-relative path, so derive its key
+                # from the canonical install path instead.
+                if dep.source == "local":
+                    install_path = dep.to_dependency_ref().get_install_path(apm_modules_path)
+                    dep_key = install_path.relative_to(apm_modules_path).as_posix()
+                else:
+                    dep_key = dep.get_canonical_dependency_string()
                 if dep_key and dep_key not in declared_sources:
                     declared_sources[dep_key] = _deps_list_source_label(
                         dep.host,

--- a/tests/integration/test_wave6_deps_cli_coverage.py
+++ b/tests/integration/test_wave6_deps_cli_coverage.py
@@ -679,6 +679,33 @@ class TestResolveScopeDepsEdgeCases:
         assert result.exit_code == 0
         assert "local-pkg" in result.output
 
+    def test_local_transitive_dependency_matches_installed_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A locked local transitive package matches its installed path."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "apm.yml").write_text(_APM_YML_SIMPLE)
+        lockfile_content = dedent("""\
+            lockfile_version: "1"
+            dependencies:
+              - repo_url: _local/sub-package
+                name: sub-package
+                source: local
+                local_path: ../sub-package
+                depth: 2
+                resolved_by: _local/parent-package
+        """)
+        (tmp_path / "apm.lock.yaml").write_text(lockfile_content)
+        modules = tmp_path / "apm_modules"
+        _make_pkg(modules, "_local", "sub-package")
+
+        result = CliRunner().invoke(cli, ["deps", "list"])
+
+        assert result.exit_code == 0, result.output
+        assert "_local/sub-package" in result.output
+        assert "local" in result.output
+        assert "orphaned package(s) found" not in result.output
+
     def test_modules_dir_with_dotfile_dirs_skipped(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/test_deps_list_tree_info.py
+++ b/tests/unit/test_deps_list_tree_info.py
@@ -185,6 +185,31 @@ class TestDepsListCommand(_DepsCmdBase):
         # match against unrelated 'orphan' substrings in future output).
         assert "orphaned package(s) found" in result.output
 
+    def test_list_does_not_orphan_local_transitive_dependency(self):
+        """A locked local transitive dep is keyed by its canonical install path."""
+        with self._chdir_tmp() as tmp:
+            self._make_package(tmp, "_local", "sub-package")
+            (tmp / "apm.lock.yaml").write_text(
+                'lockfile_version: "1"\n'
+                "generated_at: '2026-01-01T00:00:00+00:00'\n"
+                "dependencies:\n"
+                "  - repo_url: _local/sub-package\n"
+                "    name: sub-package\n"
+                "    source: local\n"
+                "    local_path: ../sub-package\n"
+                "    depth: 2\n"
+                "    resolved_by: _local/package\n",
+                encoding="utf-8",
+            )
+
+            with patch("apm_cli.core.scope.get_apm_dir", return_value=tmp), _force_rich_fallback():
+                result = self.runner.invoke(cli, ["deps", "list"])
+
+        assert result.exit_code == 0, result.output
+        assert "_local/sub-package" in result.output
+        assert "local" in result.output
+        assert "orphaned package(s) found" not in result.output
+
     def test_list_version_shown(self):
         """Version from apm.yml should appear in fallback text output."""
         with self._chdir_tmp() as tmp:


### PR DESCRIPTION
# fix(deps): match local transitive dependencies by install path

## TL;DR

`apm deps list` now identifies lockfile-recorded local transitive dependencies by their canonical `apm_modules` install path. This prevents a real `_local/sub-package` install from being reported as orphaned when its source-relative lockfile path is `../sub-package`, bringing list output back into agreement with prune.

> [!NOTE]
> Closes #2068. The lockfile schema and CLI surface are unchanged.

## Problem (WHY)

- [x] `apm deps list` keyed a local lock entry as `../sub-package`, while the filesystem scan keyed the installed dependency as `_local/sub-package`.
- [x] The mismatch displayed a legitimate depth-2 dependency as orphaned even though `apm prune --dry-run` correctly considered the same tree clean.
- [!] Contradictory dependency inventory erodes the user-facing CLI contract. This regression test turns that probabilistic diagnosis into ["verifiable action"](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/).

## Approach (WHAT)

| # | Fix | Principle | Source |
|---:|---|---|---|
| 1 | For local lock entries, reconstruct the dependency reference and derive the key from `get_install_path()`. | "Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action." | [PROSE](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |
| 2 | Keep the existing canonical dependency string for remote entries, limiting the behavior change to the failing local case. | "Favor small, chainable primitives over monolithic frameworks." | [PROSE](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |
| 3 | Exercise the complete `apm deps list` command with a real lockfile and installed package fixture. | "agents pattern-match well against concrete structures" | [Agent Skills](https://agentskills.io/skill-creation/best-practices) |

## Implementation (HOW)

| File | Change |
|---|---|
| [`src/apm_cli/commands/deps/cli.py`](https://github.com/microsoft/apm/blob/2c5cb125ccde3b5652fedfda9a733df59a2b2397/src/apm_cli/commands/deps/cli.py#L153-L174) | Uses the existing `LockedDependency.to_dependency_ref()` and `DependencyReference.get_install_path()` helpers for local entries, then converts the result to the same POSIX-relative key produced by the filesystem scan. Remote keying is untouched. |
| [`tests/unit/test_deps_list_tree_info.py`](https://github.com/microsoft/apm/blob/2c5cb125ccde3b5652fedfda9a733df59a2b2397/tests/unit/test_deps_list_tree_info.py#L188-L212) | Adds a user-facing regression fixture with `local_path: ../sub-package`, `depth: 2`, and the installed `_local/sub-package` directory. |

## Diagrams

Legend: the dashed node is the corrected key derivation; both paths now converge on `_local/sub-package`.

```mermaid
flowchart LR
    subgraph Lockfile[Lockfile inventory]
        L1["local_path: ../sub-package"]
        L2["to_dependency_ref and get_install_path"]:::new
        L3["_local/sub-package"]
    end
    subgraph Filesystem[Installed inventory]
        F1["apm_modules/_local/sub-package"]
        F2["_local/sub-package"]
    end
    subgraph Compare[Orphan check]
        C1["keys match"]
        C2["source: local"]
    end
    L1 --> L2
    L2 --> L3
    F1 --> F2
    L3 --> C1
    F2 --> C1
    C1 --> C2
    classDef new stroke-dasharray: 5 5;
    class L2 new;
```

## Trade-offs

- **Special-case local lock entries.** Chose install-path derivation only for `source == "local"`; rejected changing remote keying because the existing host-blind behavior already covers those packages and carries prior compatibility constraints.
- **Reuse the security-aware path helper.** Chose `get_install_path()` over manual `_local/<name>` construction so validation and path containment remain centralized.
- **No documentation or schema edits.** The public command, flags, lockfile fields, and intended orphan semantics do not change; this patch restores existing behavior.

## Benefits

1. A lockfile-recorded local transitive dependency appears once as `_local/sub-package` with source `local`.
2. The command emits zero orphan warnings for the reproduced valid dependency tree.
3. Removing the install-path branch makes the regression test fail with the original one-orphan warning.
4. Existing dependency list and orphan/prune suites remain green: 62 tests pass.

## Validation

`uv run --extra dev pytest -q tests/unit/test_deps_list_tree_info.py tests/unit/test_prune_command.py tests/unit/test_orphan_announce_parity.py tests/unit/install/phases/test_lockfile_orphan_prune.py`:

```text
..............................................................           [100%]
62 passed in 1.78s
```

<details><summary>Mutation-break proof</summary>

With the local install-path branch temporarily replaced by the original canonical-string lookup:

```text
FAILED tests/unit/test_deps_list_tree_info.py::TestDepsListCommand::test_list_does_not_orphan_local_transitive_dependency
E       AssertionError: assert 'orphaned package(s) found' not in result.output
1 failed in 1.11s
```

</details>

<details><summary>Full CI lint mirror</summary>

`uv run --extra dev ruff check src/ tests/`:

```text
All checks passed!
```

`uv run --extra dev ruff format --check src/ tests/`:

```text
1410 files already formatted
```

YAML I/O, 2100-line, and raw `str(relative_to())` guardrails:

```text
Portable CI guards passed
```

`uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/`:

```text
Your code has been rated at 10.00/10
```

`bash scripts/lint-auth-signals.sh`:

```text
[+] auth-signal lint clean
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | `apm deps list` does not label a lockfile-recorded local transitive dependency as orphaned | Governed by policy, DevX (pragmatic as npm) | `tests/unit/test_deps_list_tree_info.py::TestDepsListCommand::test_list_does_not_orphan_local_transitive_dependency` (regression-trap for #2068) | unit |

## How to test

- [ ] Create `apm_modules/_local/sub-package/apm.yml` and a depth-2 local lock entry whose `local_path` is `../sub-package`.
- [ ] Run `apm deps list` and confirm `_local/sub-package` is shown with source `local`.
- [ ] Confirm the output contains no `orphaned package(s) found` warning.
- [ ] Run the four-suite pytest command above and confirm all 62 tests pass.
- [ ] Run the CI lint mirror and confirm every gate exits 0.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
