### PR TITLE
fix(plugins): include repository-root primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Nested marketplace plugins now install agents and skills declared at the
+  repository root instead of silently omitting those primitives. (#2101)
 - `apm install host/org/repo/subpath#ref` on an unrecognised self-hosted FQDN
   no longer fails with a misleading "not accessible or doesn't exist" error;
   the failure reason now suggests setting `GITLAB_HOST` / `APM_GITLAB_HOSTS`

--- a/src/apm_cli/deps/github_downloader.py
+++ b/src/apm_cli/deps/github_downloader.py
@@ -1,6 +1,7 @@
 """GitHub package downloader for APM dependencies."""
 
 import contextlib
+import json
 import os
 import re
 import subprocess
@@ -1044,6 +1045,8 @@ class GitHubPackageDownloader:
         temp_clone_path: Path,
         subdir_path: str,
         ref: str | None = None,
+        *,
+        additional_paths: list[str] | None = None,
     ) -> bool:
         """Attempt sparse-checkout to download only a subdirectory (git 2.25+).
 
@@ -1075,7 +1078,13 @@ class GitHubPackageDownloader:
                 ["git", "init"],
                 ["git", "remote", "add", "origin", auth_url],
                 ["git", "sparse-checkout", "init", "--cone"],
-                ["git", "sparse-checkout", "set", subdir_path],
+                [
+                    "git",
+                    "sparse-checkout",
+                    "set",
+                    subdir_path,
+                    *(additional_paths or []),
+                ],
             ]
             fetch_cmd = ["git", "fetch", "origin"]
             fetch_cmd.append(ref or "HEAD")
@@ -1103,6 +1112,63 @@ class GitHubPackageDownloader:
         except Exception as e:
             _debug(f"Sparse-checkout failed: {e}")
             return False
+
+    def _plugin_sparse_paths(
+        self,
+        dep_ref: DependencyReference,
+        subdir_path: str,
+        ref: str | None,
+    ) -> list[str]:
+        """Return checkout paths for repository-level plugin artifacts."""
+        from ..utils.path_security import PathTraversalError, validate_path_segments
+        from .plugin_parser import _MAX_PLUGIN_JSON_BYTES
+
+        manifest_bytes = None
+        for relative_manifest in (
+            "plugin.json",
+            ".github/plugin/plugin.json",
+            ".claude-plugin/plugin.json",
+        ):
+            manifest_path = f"{subdir_path.rstrip('/')}/{relative_manifest}"
+            try:
+                manifest_bytes = self.download_raw_file(
+                    dep_ref,
+                    manifest_path,
+                    ref or "main",
+                )
+                break
+            except RuntimeError:
+                continue
+        if manifest_bytes is None or len(manifest_bytes) > _MAX_PLUGIN_JSON_BYTES:
+            return [subdir_path]
+        try:
+            manifest = json.loads(manifest_bytes)
+        except (UnicodeDecodeError, ValueError, RecursionError, MemoryError):
+            return [subdir_path]
+        if not isinstance(manifest, dict):
+            return [subdir_path]
+
+        paths = [subdir_path]
+        for component in ("agents", "skills"):
+            declared = manifest.get(component)
+            entries = declared if isinstance(declared, list) else [declared]
+            for entry in entries:
+                if not isinstance(entry, str) or not entry.strip():
+                    continue
+                raw = entry.strip().replace("\\", "/")
+                while raw.startswith("./"):
+                    raw = raw[2:]
+                raw = raw.rstrip("/")
+                try:
+                    validate_path_segments(raw, context=f"plugin {component} path")
+                except PathTraversalError:
+                    continue
+                source = Path(raw)
+                checkout_path = source.parent if source.suffix else source
+                checkout = checkout_path.as_posix()
+                if checkout not in ("", "."):
+                    paths.extend((checkout, f"{subdir_path.rstrip('/')}/{checkout}"))
+        return list(dict.fromkeys(paths))
 
     def download_subdirectory_package(
         self,
@@ -1138,6 +1204,13 @@ class GitHubPackageDownloader:
         # Use user-specified ref, or None to use repo's default branch
         ref = dep_ref.reference  # None if not specified
         subdir_path = dep_ref.virtual_path
+        is_nested_plugin = subdir_path.split("/", 1)[0] == "plugins"
+        sparse_paths = (
+            self._plugin_sparse_paths(dep_ref, subdir_path, ref)
+            if is_nested_plugin
+            else [subdir_path]
+        )
+        needs_repository_root = len(sparse_paths) > 1
         _perf_logger = getattr(self, "install_logger", None)
         _dep_display = str(dep_ref)
 
@@ -1184,7 +1257,7 @@ class GitHubPackageDownloader:
                     _resolved_sha_for_cache or ref,
                     locked_sha=_resolved_sha_for_cache,
                     env=self._git_env_dict(),
-                    sparse_paths=[subdir_path],
+                    sparse_paths=sparse_paths,
                 )
             except Exception:
                 # Cache miss or failure -- fall through to normal clone path.
@@ -1215,7 +1288,7 @@ class GitHubPackageDownloader:
                         _dep_display,
                         cache_state="persistent-hit",
                         sha_short=_sha_short,
-                        sparse_paths=[subdir_path],
+                        sparse_paths=sparse_paths or [],
                     )
                     _perf_logger.materialize_result(
                         sparse_applied=True,
@@ -1304,7 +1377,7 @@ class GitHubPackageDownloader:
                         # (subdir-agnostic) so multiple consumers
                         # requesting different subdirs of the same
                         # repo+SHA still share the object DB.
-                        sparse_paths=[subdir_path],
+                        sparse_paths=sparse_paths,
                     )
                 except Exception as e:
                     raise RuntimeError(
@@ -1329,7 +1402,21 @@ class GitHubPackageDownloader:
                     progress_obj.update(progress_task_id, completed=20, total=100)
 
                 # Phase 4 (#171): Try sparse-checkout first (git 2.25+), fall back to full clone
-                sparse_ok = self._try_sparse_checkout(dep_ref, sparse_clone_path, subdir_path, ref)
+                if needs_repository_root:
+                    sparse_ok = self._try_sparse_checkout(
+                        dep_ref,
+                        sparse_clone_path,
+                        subdir_path,
+                        ref,
+                        additional_paths=sparse_paths[1:],
+                    )
+                else:
+                    sparse_ok = self._try_sparse_checkout(
+                        dep_ref,
+                        sparse_clone_path,
+                        subdir_path,
+                        ref,
+                    )
 
                 if not sparse_ok:
                     # Full clone into a fresh subdirectory so we don't have to touch
@@ -1397,6 +1484,18 @@ class GitHubPackageDownloader:
 
             if not source_subdir.is_dir():
                 raise RuntimeError(f"Path '{subdir_path}' is not a directory")
+
+            if needs_repository_root:
+                from ..utils.helpers import find_plugin_json
+                from .plugin_parser import normalize_plugin_directory
+
+                plugin_json_path = find_plugin_json(source_subdir)
+                if plugin_json_path is not None:
+                    normalize_plugin_directory(
+                        source_subdir,
+                        plugin_json_path,
+                        repository_root=temp_clone_path,
+                    )
 
             # Create target directory
             target_path.mkdir(parents=True, exist_ok=True)

--- a/src/apm_cli/deps/github_downloader.py
+++ b/src/apm_cli/deps/github_downloader.py
@@ -11,7 +11,7 @@ import threading
 import time
 from collections.abc import Callable
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Union
 
 import git  # noqa: F401  -- re-exported; tests patch apm_cli.deps.github_downloader.git
@@ -1082,6 +1082,7 @@ class GitHubPackageDownloader:
                     "git",
                     "sparse-checkout",
                     "set",
+                    "--",
                     subdir_path,
                     *(additional_paths or []),
                 ],
@@ -1130,20 +1131,27 @@ class GitHubPackageDownloader:
             ".claude-plugin/plugin.json",
         ):
             manifest_path = f"{subdir_path.rstrip('/')}/{relative_manifest}"
+            _debug(f"Plugin manifest probe: {manifest_path}")
             try:
                 manifest_bytes = self.download_raw_file(
                     dep_ref,
                     manifest_path,
-                    ref or "main",
+                    ref or "HEAD",
                 )
+                _debug(f"Plugin manifest found: {manifest_path}")
                 break
             except RuntimeError:
                 continue
-        if manifest_bytes is None or len(manifest_bytes) > _MAX_PLUGIN_JSON_BYTES:
+        if manifest_bytes is None:
+            _debug(f"No plugin manifest found for {subdir_path}")
+            return [subdir_path]
+        if len(manifest_bytes) > _MAX_PLUGIN_JSON_BYTES:
+            _debug(f"Plugin manifest exceeds size limit for {subdir_path}")
             return [subdir_path]
         try:
             manifest = json.loads(manifest_bytes)
-        except (UnicodeDecodeError, ValueError, RecursionError, MemoryError):
+        except (UnicodeDecodeError, ValueError, RecursionError, MemoryError) as error:
+            _debug(f"Plugin manifest parse failed: {type(error).__name__}")
             return [subdir_path]
         if not isinstance(manifest, dict):
             return [subdir_path]
@@ -1159,6 +1167,12 @@ class GitHubPackageDownloader:
                 while raw.startswith("./"):
                     raw = raw[2:]
                 raw = raw.rstrip("/")
+                if (
+                    raw.startswith("-")
+                    or PurePosixPath(raw).is_absolute()
+                    or PureWindowsPath(raw).is_absolute()
+                ):
+                    continue
                 try:
                     validate_path_segments(raw, context=f"plugin {component} path")
                 except PathTraversalError:
@@ -1168,7 +1182,9 @@ class GitHubPackageDownloader:
                 checkout = checkout_path.as_posix()
                 if checkout not in ("", "."):
                     paths.extend((checkout, f"{subdir_path.rstrip('/')}/{checkout}"))
-        return list(dict.fromkeys(paths))
+        resolved_paths = list(dict.fromkeys(paths))
+        _debug(f"Plugin sparse paths: {resolved_paths}")
+        return resolved_paths
 
     def download_subdirectory_package(
         self,

--- a/src/apm_cli/deps/plugin_parser.py
+++ b/src/apm_cli/deps/plugin_parser.py
@@ -160,7 +160,12 @@ def parse_plugin_manifest(plugin_json_path: Path) -> dict[str, Any]:
     return manifest
 
 
-def normalize_plugin_directory(plugin_path: Path, plugin_json_path: Path | None = None) -> Path:
+def normalize_plugin_directory(
+    plugin_path: Path,
+    plugin_json_path: Path | None = None,
+    *,
+    repository_root: Path | None = None,
+) -> Path:
     """Normalize a Claude plugin directory into an APM package.
 
     Works with or without plugin.json.  When plugin.json is present it is
@@ -174,6 +179,8 @@ def normalize_plugin_directory(plugin_path: Path, plugin_json_path: Path | None 
     Args:
         plugin_path: Root of the plugin directory.
         plugin_json_path: Optional path to plugin.json (may be None).
+        repository_root: Optional checkout root for manifest paths shared by
+            nested plugins in a monorepo.
 
     Returns:
         Path: Path to the generated apm.yml.
@@ -190,10 +197,19 @@ def normalize_plugin_directory(plugin_path: Path, plugin_json_path: Path | None 
     if "name" not in manifest or not manifest["name"]:
         manifest["name"] = plugin_path.name
 
-    return synthesize_apm_yml_from_plugin(plugin_path, manifest)
+    return synthesize_apm_yml_from_plugin(
+        plugin_path,
+        manifest,
+        repository_root=repository_root,
+    )
 
 
-def synthesize_apm_yml_from_plugin(plugin_path: Path, manifest: dict[str, Any]) -> Path:
+def synthesize_apm_yml_from_plugin(
+    plugin_path: Path,
+    manifest: dict[str, Any],
+    *,
+    repository_root: Path | None = None,
+) -> Path:
     """Synthesize apm.yml from plugin metadata.
 
     Maps the plugin's agents/, skills/, commands/, hooks/ directories and
@@ -210,6 +226,8 @@ def synthesize_apm_yml_from_plugin(plugin_path: Path, manifest: dict[str, Any]) 
         plugin_path: Path to the plugin directory.
         manifest: Plugin metadata dict (only `name` is required; all other
                   fields are optional and default gracefully).
+        repository_root: Optional checkout root for manifest paths shared by
+            nested plugins in a monorepo.
 
     Returns:
         Path: Path to the generated apm.yml.
@@ -222,7 +240,12 @@ def synthesize_apm_yml_from_plugin(plugin_path: Path, manifest: dict[str, Any]) 
     apm_dir.mkdir(exist_ok=True)
 
     # Map plugin structure into .apm/ subdirectories
-    _map_plugin_artifacts(plugin_path, apm_dir, manifest)
+    _map_plugin_artifacts(
+        plugin_path,
+        apm_dir,
+        manifest,
+        repository_root=repository_root,
+    )
 
     # Extract MCP servers from plugin and convert to dependency format
     mcp_servers = _extract_mcp_servers(plugin_path, manifest)
@@ -630,7 +653,11 @@ def _lsp_servers_to_apm_deps(servers: dict[str, Any], plugin_path: Path) -> list
 
 
 def _map_plugin_artifacts(
-    plugin_path: Path, apm_dir: Path, manifest: dict[str, Any] | None = None
+    plugin_path: Path,
+    apm_dir: Path,
+    manifest: dict[str, Any] | None = None,
+    *,
+    repository_root: Path | None = None,
 ) -> None:
     """Map plugin artifacts to .apm/ subdirectories and copy pass-through files.
 
@@ -652,6 +679,8 @@ def _map_plugin_artifacts(
         plugin_path: Root of the plugin directory.
         apm_dir: Path to the .apm/ directory.
         manifest: Optional plugin.json metadata; used for custom component paths.
+        repository_root: Optional checkout root for manifest paths shared by
+            nested plugins in a monorepo.
     """
     if manifest is None:
         manifest = {}
@@ -661,33 +690,40 @@ def _map_plugin_artifacts(
     # Resolve source paths  -- use manifest arrays if present, else defaults.
     # Custom paths may be directories OR individual files.
     #
-    # Security: every manifest-controlled path is verified to resolve
-    # inside *plugin_path* before it is copied.  Without this guard, a
+    # Security: every manifest-controlled path is verified to resolve inside
+    # its trusted package or repository root before it is copied. Without this guard, a
     # malicious plugin could set ``"commands": "/etc/passwd"`` or
     # ``"agents": ["../../host"]`` and trick ``apm install`` into copying
     # arbitrary host files into the project's ``.apm/`` tree (and from
     # there into ``.github/prompts/`` via auto-integration).
     def _resolve_sources(component: str, default_dir: str):
         """Return list of existing source paths (dirs or files) for a component."""
+
+        def _resolve_custom_path(raw: str) -> tuple[Path, Path]:
+            local = plugin_path / raw
+            if local.exists() or repository_root is None:
+                return local, plugin_path
+            return repository_root / raw, repository_root
+
         custom = manifest.get(component)
         if isinstance(custom, list):
             paths = []
             for p in custom:
                 raw = str(p)
-                src = plugin_path / raw
+                src, source_root = _resolve_custom_path(raw)
                 if (
                     src.exists()
                     and not src.is_symlink()
-                    and _is_within_plugin(src, plugin_path, component=component)
+                    and _is_within_plugin(src, source_root, component=component)
                 ):
                     paths.append(src)
             return paths
         elif isinstance(custom, str):
-            src = plugin_path / custom
+            src, source_root = _resolve_custom_path(custom)
             if (
                 src.exists()
                 and not src.is_symlink()
-                and _is_within_plugin(src, plugin_path, component=component)
+                and _is_within_plugin(src, source_root, component=component)
             ):
                 return [src]
             return []

--- a/tests/integration/test_plugin_e2e.py
+++ b/tests/integration/test_plugin_e2e.py
@@ -16,12 +16,14 @@ from pathlib import Path
 
 import pytest
 
+from apm_cli.deps.github_downloader import GitHubPackageDownloader
 from apm_cli.integration.agent_integrator import AgentIntegrator
 from apm_cli.integration.command_integrator import CommandIntegrator
 from apm_cli.integration.prompt_integrator import PromptIntegrator
 from apm_cli.integration.skill_integrator import SkillIntegrator
 from apm_cli.models.apm_package import (
     APMPackage,
+    DependencyReference,
     GitReferenceType,
     PackageInfo,
     PackageType,
@@ -114,6 +116,45 @@ def _write_local_skill_package(skill_dir: Path) -> None:
     (skill_content / "SKILL.md").write_text("# Review and Refactor\n")
 
 
+class _LocalGitPackageDownloader(GitHubPackageDownloader):
+    """Exercise the production downloader against a real local git remote."""
+
+    def __init__(self, origin: Path) -> None:
+        super().__init__()
+        self._local_origin = origin
+
+    def _build_repo_url(
+        self,
+        repo_ref: str,
+        use_ssh: bool = False,
+        dep_ref: DependencyReference | None = None,
+        token: str | None = None,
+        auth_scheme: str = "basic",
+    ) -> str:
+        """Return the local fixture remote instead of a hosted forge URL."""
+        del repo_ref, use_ssh, dep_ref, token, auth_scheme
+        return self._local_origin.as_uri()
+
+    def download_raw_file(
+        self,
+        dep_ref: DependencyReference,
+        file_path: str,
+        ref: str = "main",
+        verbose_callback=None,
+    ) -> bytes:
+        """Read a manifest from the same real git ref used by sparse checkout."""
+        del dep_ref, verbose_callback
+        result = subprocess.run(
+            ["git", "show", f"{ref}:{file_path}"],
+            cwd=self._local_origin,
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(result.stderr.decode(errors="replace"))
+        return result.stdout
+
+
 # ===========================================================================
 # Class 1 — LOCAL tests (no network, uses mock fixture)
 # ===========================================================================
@@ -121,6 +162,70 @@ def _write_local_skill_package(skill_dir: Path) -> None:
 
 class TestPluginHeroScenarios:
     """Local hero-scenario tests using the mock-marketplace-plugin fixture."""
+
+    def test_nested_plugin_installs_and_deploys_repository_root_primitives(self, tmp_path):
+        """Install an awesome-copilot-style plugin from a real local git remote."""
+        origin = tmp_path / "awesome-copilot"
+        origin.mkdir()
+        subprocess.run(["git", "init", "-b", "trunk"], cwd=origin, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "apm-tests@example.invalid"],
+            cwd=origin,
+            check=True,
+        )
+        subprocess.run(["git", "config", "user.name", "APM Tests"], cwd=origin, check=True)
+
+        plugin = origin / "plugins" / "frontend-web-dev"
+        manifest_dir = plugin / ".github" / "plugin"
+        manifest_dir.mkdir(parents=True)
+        (manifest_dir / "plugin.json").write_text(
+            json.dumps(
+                {
+                    "name": "frontend-web-dev",
+                    "version": "1.0.0",
+                    "description": "Awesome Copilot style fixture",
+                    "agents": ["./agents/frontend.agent.md"],
+                    "skills": ["./skills/browser-testing/"],
+                }
+            )
+        )
+        agent = origin / "agents" / "frontend.agent.md"
+        agent.parent.mkdir()
+        agent.write_text("# Frontend Agent\n")
+        skill = origin / "skills" / "browser-testing"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("# Browser Testing\n")
+        subprocess.run(["git", "add", "."], cwd=origin, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Add awesome-copilot fixture"],
+            cwd=origin,
+            check=True,
+            capture_output=True,
+        )
+
+        downloader = _LocalGitPackageDownloader(origin)
+        dependency = DependencyReference.parse("github/awesome-copilot/plugins/frontend-web-dev")
+        installed = tmp_path / "apm_modules" / "github" / "awesome-copilot"
+        package_info = downloader.download_subdirectory_package(dependency, installed)
+
+        assert (installed / ".apm" / "agents" / "frontend.agent.md").read_text() == (
+            "# Frontend Agent\n"
+        )
+        assert (
+            installed / ".apm" / "skills" / "browser-testing" / "SKILL.md"
+        ).read_text() == "# Browser Testing\n"
+
+        project = tmp_path / "project"
+        project.mkdir()
+        AgentIntegrator().integrate_package_agents(package_info, project)
+        SkillIntegrator().integrate_package_skill(package_info, project)
+
+        assert (project / ".github" / "agents" / "frontend.agent.md").read_text() == (
+            "# Frontend Agent\n"
+        )
+        assert (
+            project / ".agents" / "skills" / "browser-testing" / "SKILL.md"
+        ).read_text() == "# Browser Testing\n"
 
     # ---- Test 1: Full lifecycle -----------------------------------------
 

--- a/tests/test_github_downloader.py
+++ b/tests/test_github_downloader.py
@@ -1258,6 +1258,73 @@ class TestDownloadSubdirectoryPackageWindowsCleanup:
         # owner/repo/skills/test-pkg → virtual subdirectory reference
         return DependencyReference.parse("owner/repo/skills/test-pkg")
 
+    def test_nested_plugin_copies_repository_root_agents_and_skills(self, tmp_path):
+        downloader = GitHubPackageDownloader()
+        dep = DependencyReference.parse("github/awesome-copilot/plugins/frontend-web-dev")
+        target = tmp_path / "out"
+
+        manifest = (
+            b'{"name":"frontend-web-dev",'
+            b'"agents":["./agents/frontend.agent.md"],'
+            b'"skills":["./skills/browser-testing/"]}'
+        )
+
+        def fake_download_raw(_dep, path, _ref):
+            if path.endswith(".github/plugin/plugin.json"):
+                return manifest
+            raise RuntimeError("not found")
+
+        def fake_sparse(
+            _dep,
+            clone_path,
+            _subdir,
+            _ref,
+            *,
+            additional_paths=None,
+        ):
+            plugin = clone_path / "plugins" / "frontend-web-dev"
+            manifest_dir = plugin / ".github" / "plugin"
+            manifest_dir.mkdir(parents=True)
+            (manifest_dir / "plugin.json").write_bytes(manifest)
+            if not additional_paths:
+                return True
+            agent = clone_path / "agents" / "frontend.agent.md"
+            agent.parent.mkdir()
+            agent.write_text("# Frontend agent")
+            skill = clone_path / "skills" / "browser-testing"
+            skill.mkdir(parents=True)
+            (skill / "SKILL.md").write_text("# Browser testing")
+            return True
+
+        def fake_clone(_url, clone_path, **_kwargs):
+            fake_sparse(dep, clone_path, dep.virtual_path, dep.reference)
+
+        fake_repo = MagicMock()
+        fake_repo.head.commit.hexsha = "abc1234"
+        validation = MagicMock(
+            is_valid=True,
+            errors=[],
+            package=APMPackage(name="frontend-web-dev", version="1.0.0"),
+        )
+
+        with (
+            patch.object(downloader, "download_raw_file", side_effect=fake_download_raw),
+            patch.object(downloader, "_try_sparse_checkout", side_effect=fake_sparse),
+            patch.object(downloader, "_clone_with_fallback", side_effect=fake_clone),
+            patch("apm_cli.deps.github_downloader.Repo", return_value=fake_repo),
+            patch("apm_cli.deps.github_downloader._close_repo"),
+            patch(
+                "apm_cli.deps.github_downloader.validate_apm_package",
+                return_value=validation,
+            ),
+        ):
+            downloader.download_subdirectory_package(dep, target)
+
+        assert (target / ".apm" / "agents" / "frontend.agent.md").read_text() == "# Frontend agent"
+        assert (
+            target / ".apm" / "skills" / "browser-testing" / "SKILL.md"
+        ).read_text() == "# Browser testing"
+
     def test_sparse_checkout_success_closes_sha_repo_before_rmtree(self, tmp_path):
         """When sparse checkout succeeds the SHA-capture Repo is closed before _rmtree."""
         from apm_cli.deps.github_downloader import _close_repo  # noqa

--- a/tests/test_github_downloader.py
+++ b/tests/test_github_downloader.py
@@ -1,6 +1,7 @@
 """Tests for GitHub package downloader."""
 
 import contextlib
+import json
 import os
 import shutil
 import stat
@@ -1324,6 +1325,59 @@ class TestDownloadSubdirectoryPackageWindowsCleanup:
         assert (
             target / ".apm" / "skills" / "browser-testing" / "SKILL.md"
         ).read_text() == "# Browser testing"
+
+    def test_plugin_sparse_paths_rejects_unsafe_manifest_paths(self):
+        downloader = GitHubPackageDownloader()
+        dep = DependencyReference.parse("github/awesome-copilot/plugins/frontend-web-dev")
+        manifest = json.dumps(
+            {
+                "agents": [
+                    "../../outside.agent.md",
+                    "/etc/passwd",
+                    r"C:\Windows\secret.agent.md",
+                    "--stdin",
+                ],
+                "skills": ["./skills/browser-testing/"],
+            }
+        ).encode()
+
+        with patch.object(downloader, "download_raw_file", return_value=manifest):
+            paths = downloader._plugin_sparse_paths(
+                dep,
+                "plugins/frontend-web-dev",
+                "main",
+            )
+
+        assert paths == [
+            "plugins/frontend-web-dev",
+            "skills/browser-testing",
+            "plugins/frontend-web-dev/skills/browser-testing",
+        ]
+
+    def test_plugin_sparse_paths_uses_remote_head_when_ref_is_unset(self):
+        downloader = GitHubPackageDownloader()
+        dep = DependencyReference.parse("github/awesome-copilot/plugins/frontend-web-dev")
+        refs = []
+
+        def fake_download_raw(_dep, path, ref):
+            refs.append(ref)
+            if path.endswith(".github/plugin/plugin.json"):
+                return b'{"agents":["./agents/frontend.agent.md"]}'
+            raise RuntimeError("not found")
+
+        with patch.object(downloader, "download_raw_file", side_effect=fake_download_raw):
+            paths = downloader._plugin_sparse_paths(
+                dep,
+                "plugins/frontend-web-dev",
+                None,
+            )
+
+        assert refs == ["HEAD", "HEAD"]
+        assert paths == [
+            "plugins/frontend-web-dev",
+            "agents",
+            "plugins/frontend-web-dev/agents",
+        ]
 
     def test_sparse_checkout_success_closes_sha_repo_before_rmtree(self, tmp_path):
         """When sparse checkout succeeds the SHA-capture Repo is closed before _rmtree."""

--- a/tests/unit/test_plugin_parser.py
+++ b/tests/unit/test_plugin_parser.py
@@ -111,6 +111,35 @@ class TestParsePluginManifest:
 
 
 class TestMapPluginArtifacts:
+    def test_map_repository_root_artifacts_for_nested_plugin(self, tmp_path):
+        repo_root = tmp_path / "repo"
+        plugin_dir = repo_root / "plugins" / "frontend-web-dev"
+        plugin_dir.mkdir(parents=True)
+        agent = repo_root / "agents" / "frontend.agent.md"
+        agent.parent.mkdir()
+        agent.write_text("# Frontend agent")
+        skill = repo_root / "skills" / "browser-testing"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("# Browser testing")
+        manifest = {
+            "agents": ["./agents/frontend.agent.md"],
+            "skills": ["./skills/browser-testing/"],
+        }
+
+        apm_dir = plugin_dir / ".apm"
+        apm_dir.mkdir()
+        _map_plugin_artifacts(
+            plugin_dir,
+            apm_dir,
+            manifest,
+            repository_root=repo_root,
+        )
+
+        assert (apm_dir / "agents" / "frontend.agent.md").read_text() == "# Frontend agent"
+        assert (
+            apm_dir / "skills" / "browser-testing" / "SKILL.md"
+        ).read_text() == "# Browser testing"
+
     def test_map_agents_directory(self, tmp_path):
         plugin_dir = tmp_path / "plugin"
         plugin_dir.mkdir()


### PR DESCRIPTION
# fix(plugins): include repository-root primitives for nested marketplace plugins

## TL;DR

Nested marketplace plugins now install agents and skills declared outside their plugin subdirectory. The downloader discovers those manifest paths before sparse checkout, and the plugin normalizer resolves missing local artifacts against the trusted repository checkout root. This closes #2039 without expanding checkout to the entire repository.

> [!NOTE]
> The fallback applies only while normalizing nested `plugins/...` packages and retains path-containment and symlink checks.

## Problem (WHY)

- [x] `frontend-web-dev@awesome-copilot` installed successfully but omitted agents and skills declared by its plugin manifest ([#2039](https://github.com/microsoft/apm/issues/2039)).
- [x] Subdirectory sparse checkout fetched only `plugins/frontend-web-dev`, while the manifest's `./agents/...` and `./skills/...` references pointed at repository-root directories.
- [!] Normalization had no repository-root context after extraction, so absent plugin-local paths were silently skipped.

The fix makes the install result verifiable at the filesystem boundary: ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)

## Approach (WHAT)

1. Probe supported plugin manifest locations before checking out a nested plugin.
2. Add declared agent and skill paths to the sparse checkout, including both repository-root and plugin-relative candidates.
3. Normalize while the checkout root is available, preferring plugin-local artifacts and falling back to repository-root artifacts only when needed.
4. Keep existing traversal, containment, and symlink protections at the copy boundary.
5. Add unit and cross-module regression traps for the awesome-copilot layout.

## Implementation (HOW)

| File | Change |
|---|---|
| `src/apm_cli/deps/github_downloader.py` | Reads bounded plugin metadata, derives safe sparse paths, carries them through cached and direct checkout flows, and normalizes nested plugins before extraction. |
| `src/apm_cli/deps/plugin_parser.py` | Threads an optional repository root through normalization and uses it only when a declared plugin-local artifact does not exist. |
| `tests/test_github_downloader.py` | Exercises manifest probing, expanded sparse checkout, normalization, and final `.apm` materialization through the downloader boundary. |
| `tests/unit/test_plugin_parser.py` | Verifies repository-root agent files and skill directories map into a nested plugin's `.apm` tree. |

## Diagrams

Legend: The dashed stages are new; review the local-first branch before the repository-root fallback.

```mermaid
flowchart LR
    subgraph Discover[Discover]
        D1[Probe nested plugin manifest]
        D2[Derive agent and skill paths]
    end
    subgraph Checkout[Checkout]
        C1[Sparse checkout plugin paths]
    end
    subgraph Normalize[Normalize]
        N1{Plugin-local artifact exists}
        N2[Copy plugin-local artifact]
        N3[Resolve within repository root]
        N4[Write normalized .apm tree]
    end
    D1 --> D2
    D2 --> C1
    C1 --> N1
    N1 -->|Yes| N2
    N1 -->|No| N3
    N2 --> N4
    N3 --> N4
    classDef new stroke-dasharray: 5 5;
    class D1,D2,C1,N3 new;
```

## Trade-offs

- **Manifest probe instead of full checkout.** Chose up to three bounded raw-file probes and targeted sparse paths; rejected unconditional full-repository checkout because large plugin repositories made installs impractically slow.
- **Local-first resolution instead of repository-root-first resolution.** Chose existing plugin-local behavior as the precedence rule; rejected overriding a valid local artifact with a repository sibling.
- **Both path interpretations in sparse checkout.** Chose repository-root and plugin-relative candidates because plugin ecosystems use both layouts; rejected inferring semantics from path spelling alone.
- **No documentation change.** This restores the existing plugin-install contract and does not add a command, flag, or manifest format.

## Benefits

1. The #2039 layout produces both `.apm/agents/frontend.agent.md` and `.apm/skills/browser-testing/SKILL.md`.
2. Sparse checkout remains targeted to the plugin plus declared primitive paths rather than cloning the entire repository worktree.
3. Existing plugin-local agent and skill declarations retain precedence.
4. Traversal, out-of-root, and symlink sources remain excluded by the existing copy boundary.

## Validation

Mutation check after forcing `needs_repository_root = False`:

```
FAILED tests/integration/test_plugin_e2e.py::TestPluginHeroScenarios::test_nested_plugin_installs_and_deploys_repository_root_primitives
1 failed in 0.75s
Mutation correctly killed; guard restored; test passed
```

<details><summary>Canonical lint mirror and focused test output</summary>

`uv run --extra dev ruff check src/ tests/`:

```
All checks passed!
```

`uv run --extra dev ruff format --check src/ tests/`:

```
1410 files already formatted
```

YAML I/O, 2100-line file-length, and raw `str(relative_to())` guards:

```
(exit 0; no violations)
```

`uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/`:

```
Your code has been rated at 10.00/10
```

`bash scripts/lint-auth-signals.sh`:

```
[*] Rule A: get_bearer_provider boundary (any reference)
[*] Rule B: git ls-remote auth-delegated annotation
[+] auth-signal lint clean
```

`uv run --extra dev pytest tests/unit/test_plugin_parser.py tests/test_github_downloader.py::TestDownloadSubdirectoryPackageWindowsCleanup tests/integration/test_plugin_e2e.py::TestPluginHeroScenarios::test_nested_plugin_installs_and_deploys_repository_root_primitives -q`:

```
........................................................................ [ 78%]
....................                                                     [100%]
92 passed in 1.06s
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|---|---|---|---|
| 1 | Installing a nested marketplace plugin deploys agents and skills stored at repository root | Portability by manifest, DevX, OSS / community-driven | `tests/integration/test_plugin_e2e.py::TestPluginHeroScenarios::test_nested_plugin_installs_and_deploys_repository_root_primitives` (real local git remote, production downloader and integrators) | integration-with-fixtures |
| 2 | A nested plugin's repository-root primitive declarations normalize into its `.apm` package | Portability by manifest | `tests/unit/test_plugin_parser.py::TestMapPluginArtifacts::test_map_repository_root_artifacts_for_nested_plugin` | unit |
| 3 | Manifest-controlled sparse paths reject traversal, absolute, Windows, and option-like values | Secure by default | `tests/test_github_downloader.py::TestDownloadSubdirectoryPackageWindowsCleanup::test_plugin_sparse_paths_rejects_unsafe_manifest_paths` | unit |

## How to test

- [ ] Initialize an APM project and register the `github/awesome-copilot` marketplace.
- [ ] Run `apm install frontend-web-dev@awesome-copilot` and expect a successful install.
- [ ] Inspect the installed package's `.apm/agents` and `.apm/skills` directories and expect declared repository-root primitives to be present.
- [ ] Run the focused pytest command above and expect 92 passing tests.
- [ ] Run the canonical lint mirror and expect no diagnostics.

Closes #2039

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

