### PR TITLE
fix: retain dev dependencies (supersedes #2042, closes #2033)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `apm prune`, `apm audit --ci` orphan detection, and the lockfile-exists
+  check now include `devDependencies.apm` entries, fixing false orphan
+  reports, spurious CI failures, and a misleading message for dev-only
+  projects. (#2042, closes #2033)
+
 ## [0.24.0] - 2026-07-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the failure reason now suggests setting `GITLAB_HOST` / `APM_GITLAB_HOSTS`
   if the target is a self-hosted GitLab instance, or using an explicit
   `git:` + `path:` entry in `apm.yml` otherwise. (by @rrazvd; closes #2066) (#2074)
-- `apm prune`, `apm audit --ci` orphan detection, and the lockfile-exists
-  check now include `devDependencies.apm` entries, fixing false orphan
-  reports, spurious CI failures, and a misleading message for dev-only
-  projects. (#2042, closes #2033)
+- Dev dependencies are no longer removed by `apm prune`, reported as orphans
+  by `apm audit --ci`, or omitted from lockfile and MCP config checks. This
+  includes `devDependencies.apm` and applicable `devDependencies.mcp` entries.
+  (by @sergio-sisternes-epam; #2102, supersedes #2042, closes #2033)
 
 ## [0.24.0] - 2026-07-05
 

--- a/docs/src/content/docs/reference/baseline-checks.md
+++ b/docs/src/content/docs/reference/baseline-checks.md
@@ -90,7 +90,7 @@ the [policy schema](./policy-schema/).
 
 ### `config-consistency`
 
-- **What it verifies.** That MCP server configs derived from `apm.yml` match the `mcp_configs` baseline stored in the lockfile.
+- **What it verifies.** That MCP server configs derived from both `dependencies.mcp` and `devDependencies.mcp` in `apm.yml` match the `mcp_configs` baseline stored in the lockfile.
 - **Fails when.** A server's resolved config differs from the lockfile, a server is in the lockfile but not the manifest, or a server is in the manifest but not the lockfile.
 - **Remediation.** Run `apm install` to reconcile the MCP configuration.
 

--- a/docs/src/content/docs/reference/baseline-checks.md
+++ b/docs/src/content/docs/reference/baseline-checks.md
@@ -59,14 +59,14 @@ the [policy schema](./policy-schema/).
 
 ### `lockfile-exists`
 
-- **What it verifies.** That `apm.lock.yaml` is present whenever the project has APM or MCP dependencies, or whenever an existing lockfile records local content under the synthesized self-entry.
-- **Fails when.** `apm.yml` declares dependencies but no lockfile is on disk.
+- **What it verifies.** That `apm.lock.yaml` is present whenever the project has APM or MCP dependencies (including `devDependencies`), or whenever an existing lockfile records local content under the synthesized self-entry.
+- **Fails when.** `apm.yml` declares dependencies (production or dev) but no lockfile is on disk.
 - **Effect.** Subsequent checks are skipped (the lockfile is required input).
 - **Remediation.** Run `apm install` to generate `apm.lock.yaml` and commit it.
 
 ### `ref-consistency`
 
-- **What it verifies.** That every dependency's `reference` in `apm.yml` matches the `resolved_ref` recorded in the lockfile.
+- **What it verifies.** That every dependency's `reference` in `apm.yml` (both `dependencies.apm` and `devDependencies.apm`) matches the `resolved_ref` recorded in the lockfile.
 - **Fails when.** A manifest ref differs from the lockfile entry, or the manifest declares a dependency that is missing from the lockfile.
 - **Remediation.** Run `apm install` so the lockfile re-resolves to the manifest, then commit `apm.lock.yaml`.
 
@@ -78,7 +78,7 @@ the [policy schema](./policy-schema/).
 
 ### `no-orphaned-packages`
 
-- **What it verifies.** That every dependency in the lockfile is still declared in `apm.yml`. The synthesized self-entry is excluded.
+- **What it verifies.** That every dependency in the lockfile is still declared in `apm.yml` (in either `dependencies.apm` or `devDependencies.apm`). The synthesized self-entry is excluded.
 - **Fails when.** The lockfile holds a package that the manifest no longer lists.
 - **Remediation.** Run `apm install` to prune the orphan, then commit `apm.lock.yaml`.
 

--- a/docs/src/content/docs/reference/cli/prune.md
+++ b/docs/src/content/docs/reference/cli/prune.md
@@ -21,11 +21,11 @@ apm prune [--dry-run]
 
 `apm prune` reconciles three states:
 
-1. Packages declared in `apm.yml`
+1. Packages declared in `apm.yml` (both `dependencies.apm` and `devDependencies.apm`)
 2. Packages installed under `apm_modules/`
 3. Packages recorded in `apm.lock.yaml` with their `deployed_files`
 
-Anything installed but no longer declared is **orphaned**. `apm prune` removes the orphan's directory under `apm_modules/`, deletes every file the orphan deployed into your harness directories (using the `deployed_files` manifest in the lockfile), removes the entry from `apm.lock.yaml`, and cleans up empty parent directories.
+Anything installed but not declared in either dependency list is **orphaned**. `apm prune` removes the orphan's directory under `apm_modules/`, deletes every file the orphan deployed into your harness directories (using the `deployed_files` manifest in the lockfile), removes the entry from `apm.lock.yaml`, and cleans up empty parent directories.
 
 If `apm_modules/` does not exist, the command exits cleanly with nothing to do. If `apm.yml` is missing, it exits with an error.
 

--- a/src/apm_cli/commands/_helpers.py
+++ b/src/apm_cli/commands/_helpers.py
@@ -308,7 +308,7 @@ def _check_orphaned_packages():
             from ..models.apm_package import APMPackage
 
             apm_package = APMPackage.from_apm_yml(Path(APM_YML_FILENAME))
-            declared_deps = apm_package.get_apm_dependencies()
+            declared_deps = apm_package.get_all_apm_dependencies()
             lockfile = LockFile.read(get_lockfile_path(Path.cwd()))
             expected = _build_expected_install_paths(declared_deps, lockfile, apm_modules_dir)
         except Exception:

--- a/src/apm_cli/commands/prune.py
+++ b/src/apm_cli/commands/prune.py
@@ -52,7 +52,7 @@ def prune(ctx, dry_run):
         # Build expected vs installed using shared helpers
         try:
             apm_package = APMPackage.from_apm_yml(Path(APM_YML_FILENAME))
-            declared_deps = apm_package.get_apm_dependencies()
+            declared_deps = apm_package.get_all_apm_dependencies()
             lockfile = LockFile.read(get_lockfile_path(Path.cwd()))
             expected_installed = _build_expected_install_paths(
                 declared_deps, lockfile, apm_modules_dir

--- a/src/apm_cli/models/apm_package.py
+++ b/src/apm_cli/models/apm_package.py
@@ -550,6 +550,14 @@ class APMPackage:
             if isinstance(dep, MCPDependency)
         ]
 
+    def get_all_apm_dependencies(self) -> list[DependencyReference]:
+        """Get production and dev APM dependencies in manifest order."""
+        return self.get_apm_dependencies() + self.get_dev_apm_dependencies()
+
+    def has_any_apm_dependencies(self) -> bool:
+        """Check if this package has any APM dependencies (prod or dev)."""
+        return bool(self.get_apm_dependencies() or self.get_dev_apm_dependencies())
+
     def get_all_mcp_dependencies(self) -> list["MCPDependency"]:
         """Get production and dev MCP dependencies in manifest order."""
         return self.get_mcp_dependencies() + self.get_dev_mcp_dependencies()

--- a/src/apm_cli/policy/ci_checks.py
+++ b/src/apm_cli/policy/ci_checks.py
@@ -53,7 +53,7 @@ def _check_lockfile_exists(
             message="No apm.yml found -- nothing to check",
         )
 
-    has_deps = manifest.has_apm_dependencies() or bool(manifest.get_mcp_dependencies())
+    has_deps = manifest.has_any_apm_dependencies() or bool(manifest.get_mcp_dependencies())
     lockfile_path = get_lockfile_path(project_root)
 
     # Local-only repos may declare no remote/MCP deps but still have a
@@ -98,7 +98,7 @@ def _check_ref_consistency(
     from ..drift import detect_ref_change
 
     mismatches: list[str] = []
-    for dep_ref in manifest.get_apm_dependencies():
+    for dep_ref in manifest.get_all_apm_dependencies():
         key = dep_ref.get_unique_key()
         locked_dep = lock.get_dependency(key)
         if locked_dep is None:
@@ -167,7 +167,7 @@ def _check_no_orphans(
     sub-package's manifest, not the root manifest, so the root manifest
     cannot make them go away by editing its ``dependencies.apm`` list.
     """
-    manifest_keys = {dep.get_unique_key() for dep in manifest.get_apm_dependencies()}
+    manifest_keys = {dep.get_unique_key() for dep in manifest.get_all_apm_dependencies()}
     orphaned = [
         dep_key
         for dep_key, locked_dep in lock.dependencies.items()
@@ -195,7 +195,7 @@ def _check_skill_subset_consistency(
 ) -> CheckResult:
     """Verify lockfile skill_subset matches manifest skills: for each entry."""
     mismatches: list[str] = []
-    for dep_ref in manifest.get_apm_dependencies():
+    for dep_ref in manifest.get_all_apm_dependencies():
         key = dep_ref.get_unique_key()
         locked_dep = lock.get_dependency(key)
         if locked_dep is None:

--- a/src/apm_cli/policy/ci_checks.py
+++ b/src/apm_cli/policy/ci_checks.py
@@ -53,7 +53,7 @@ def _check_lockfile_exists(
             message="No apm.yml found -- nothing to check",
         )
 
-    has_deps = manifest.has_any_apm_dependencies() or bool(manifest.get_mcp_dependencies())
+    has_deps = manifest.has_any_apm_dependencies() or bool(manifest.get_all_mcp_dependencies())
     lockfile_path = get_lockfile_path(project_root)
 
     # Local-only repos may declare no remote/MCP deps but still have a
@@ -165,7 +165,7 @@ def _check_no_orphans(
     Only DIRECT dependencies (``depth == 1`` / no ``resolved_by``) are
     candidates for orphan detection. Transitive deps belong to a
     sub-package's manifest, not the root manifest, so the root manifest
-    cannot make them go away by editing its ``dependencies.apm`` list.
+    cannot make them go away by editing its dependency lists.
     """
     manifest_keys = {dep.get_unique_key() for dep in manifest.get_all_apm_dependencies()}
     orphaned = [

--- a/src/apm_cli/policy/ci_checks.py
+++ b/src/apm_cli/policy/ci_checks.py
@@ -234,7 +234,7 @@ def _check_config_consistency(
     from ..drift import detect_config_drift
     from ..integration.mcp_integrator import MCPIntegrator
 
-    mcp_deps = manifest.get_mcp_dependencies()
+    mcp_deps = manifest.get_all_mcp_dependencies()
     current_configs = MCPIntegrator.get_server_configs(mcp_deps)
     stored_configs = lock.mcp_configs or {}
 

--- a/tests/integration/test_dev_dependency_orphan_e2e.py
+++ b/tests/integration/test_dev_dependency_orphan_e2e.py
@@ -1,0 +1,74 @@
+"""End-to-end regression coverage for dev dependency orphan detection."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from apm_cli.deps.lockfile import LockFile
+
+CLI = [sys.executable, "-m", "apm_cli.cli"]
+TIMEOUT = 180
+
+
+def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run the APM CLI in *cwd* and return the completed subprocess."""
+    return subprocess.run(
+        CLI + list(args),
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=TIMEOUT,
+        check=False,
+    )
+
+
+@pytest.mark.integration
+def test_dev_dependency_survives_audit_and_prune(tmp_path: Path) -> None:
+    """A clean install must not classify its dev dependency as orphaned."""
+    package = tmp_path / "dev-package"
+    package.mkdir()
+    (package / "apm.yml").write_text(
+        yaml.safe_dump({"name": "dev-package", "version": "1.0.0"}),
+        encoding="utf-8",
+    )
+
+    project = tmp_path / "consumer"
+    project.mkdir()
+    (project / "apm.yml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "consumer",
+                "version": "1.0.0",
+                "target": "copilot",
+                "devDependencies": {"apm": [{"path": "../dev-package"}]},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    install = _run(project, "install")
+    assert install.returncode == 0, (
+        f"install stdout:\n{install.stdout}\ninstall stderr:\n{install.stderr}"
+    )
+
+    installed_package = project / "apm_modules" / "_local" / "dev-package"
+    assert installed_package.is_dir()
+    lockfile = LockFile.read(project / "apm.lock.yaml")
+    assert lockfile is not None
+    assert len(lockfile.dependencies) == 1
+    locked_dependency = next(iter(lockfile.dependencies.values()))
+    assert locked_dependency.is_dev is True
+
+    audit = _run(project, "audit", "--ci")
+    assert audit.returncode == 0, f"audit stdout:\n{audit.stdout}\naudit stderr:\n{audit.stderr}"
+
+    prune = _run(project, "prune")
+    assert prune.returncode == 0, f"prune stdout:\n{prune.stdout}\nprune stderr:\n{prune.stderr}"
+    assert installed_package.is_dir(), (
+        "apm prune removed a package declared under devDependencies.apm"
+    )

--- a/tests/unit/test_command_helpers.py
+++ b/tests/unit/test_command_helpers.py
@@ -448,6 +448,27 @@ class TestCheckOrphanedPackagesSubdirectoryAncestor:
         orphaned = _check_orphaned_packages()
         assert orphaned == [], f"Whole-repo package should not be orphaned; got: {orphaned}"
 
+    def test_dev_dependency_not_orphaned(self, tmp_path, monkeypatch):
+        """A package declared only as a dev dependency is not orphaned."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "apm.yml").write_text(
+            "name: test\n"
+            "version: 1.0.0\n"
+            "devDependencies:\n"
+            "  apm:\n"
+            "    - github.example.com/org/dev-package\n",
+            encoding="utf-8",
+        )
+
+        pkg_dir = tmp_path / "apm_modules" / "org" / "dev-package"
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / "apm.yml").write_text(
+            "name: dev-package\nversion: 1.0.0\n",
+            encoding="utf-8",
+        )
+
+        assert _check_orphaned_packages() == []
+
     def test_whole_repo_with_unrelated_orphan(self, tmp_path, monkeypatch):
         """Whole-repo dep is fine; an unrelated stale package IS orphaned."""
         monkeypatch.chdir(tmp_path)

--- a/tests/unit/test_dev_dependencies.py
+++ b/tests/unit/test_dev_dependencies.py
@@ -537,8 +537,33 @@ class TestOrphanDetectionIncludesDevDeps:
         manifest.has_apm_dependencies.return_value = False
         manifest.has_any_apm_dependencies.return_value = True
         manifest.get_mcp_dependencies.return_value = []
+        manifest.get_all_mcp_dependencies.return_value = []
 
         # No lockfile on disk -- should say "lockfile missing", not "no deps"
         result = _check_lockfile_exists(tmp_path, manifest)
         assert result.passed is False
         assert "missing" in result.message.lower()
+
+    def test_check_ref_consistency_detects_dev_dep_mismatch(self) -> None:
+        """_check_ref_consistency should detect ref mismatches in dev deps."""
+        from apm_cli.policy.ci_checks import _check_ref_consistency
+
+        dev_dep = DependencyReference(repo_url="owner/dev-pkg", reference="v2.0")
+        manifest = MagicMock(spec=APMPackage)
+        manifest.get_apm_dependencies.return_value = []
+        manifest.get_dev_apm_dependencies.return_value = [dev_dep]
+        manifest.get_all_apm_dependencies.return_value = APMPackage.get_all_apm_dependencies(
+            manifest
+        )
+
+        lock = MagicMock(spec=LockFile)
+        lock.get_dependency.return_value = LockedDependency(
+            repo_url="owner/dev-pkg",
+            is_dev=True,
+            resolved_ref="v1.0",
+            resolved_by=None,
+        )
+
+        result = _check_ref_consistency(manifest, lock)
+        assert result.passed is False
+        assert "ref mismatch" in result.message.lower()

--- a/tests/unit/test_dev_dependencies.py
+++ b/tests/unit/test_dev_dependencies.py
@@ -447,3 +447,98 @@ class TestValidateAndAddDevDeps:
             data = yaml.safe_load(f)
         assert "org/prod-pkg" in data["dependencies"]["apm"]
         assert "devDependencies" not in data
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for #2033: devDependencies visible to orphan detection
+# ---------------------------------------------------------------------------
+
+
+class TestGetAllApmDependencies:
+    """Tests for APMPackage.get_all_apm_dependencies() and has_any_apm_dependencies()."""
+
+    def test_returns_union_of_prod_and_dev(self) -> None:
+        """get_all_apm_dependencies returns both prod and dev deps."""
+        pkg = MagicMock(spec=APMPackage)
+        prod_dep = DependencyReference(repo_url="owner/prod-pkg")
+        dev_dep = DependencyReference(repo_url="owner/dev-pkg")
+        pkg.get_apm_dependencies.return_value = [prod_dep]
+        pkg.get_dev_apm_dependencies.return_value = [dev_dep]
+        # Call the real method on the mock
+        result = APMPackage.get_all_apm_dependencies(pkg)
+        assert result == [prod_dep, dev_dep]
+
+    def test_returns_only_prod_when_no_dev(self) -> None:
+        """get_all_apm_dependencies returns prod-only when no dev deps exist."""
+        pkg = MagicMock(spec=APMPackage)
+        prod_dep = DependencyReference(repo_url="owner/prod-pkg")
+        pkg.get_apm_dependencies.return_value = [prod_dep]
+        pkg.get_dev_apm_dependencies.return_value = []
+        result = APMPackage.get_all_apm_dependencies(pkg)
+        assert result == [prod_dep]
+
+    def test_returns_only_dev_when_no_prod(self) -> None:
+        """get_all_apm_dependencies returns dev-only when no prod deps exist."""
+        pkg = MagicMock(spec=APMPackage)
+        dev_dep = DependencyReference(repo_url="owner/dev-pkg")
+        pkg.get_apm_dependencies.return_value = []
+        pkg.get_dev_apm_dependencies.return_value = [dev_dep]
+        result = APMPackage.get_all_apm_dependencies(pkg)
+        assert result == [dev_dep]
+
+    def test_has_any_true_for_dev_only(self) -> None:
+        """has_any_apm_dependencies returns True when only dev deps exist."""
+        pkg = MagicMock(spec=APMPackage)
+        pkg.get_apm_dependencies.return_value = []
+        pkg.get_dev_apm_dependencies.return_value = [DependencyReference(repo_url="owner/dev-pkg")]
+        result = APMPackage.has_any_apm_dependencies(pkg)
+        assert result is True
+
+    def test_has_any_false_when_empty(self) -> None:
+        """has_any_apm_dependencies returns False when no deps at all."""
+        pkg = MagicMock(spec=APMPackage)
+        pkg.get_apm_dependencies.return_value = []
+        pkg.get_dev_apm_dependencies.return_value = []
+        result = APMPackage.has_any_apm_dependencies(pkg)
+        assert result is False
+
+
+class TestOrphanDetectionIncludesDevDeps:
+    """Regression tests for #2033: orphan detection must include devDependencies."""
+
+    def test_check_no_orphans_passes_for_dev_dep(self) -> None:
+        """_check_no_orphans should not flag a dev dependency as orphaned."""
+        from apm_cli.policy.ci_checks import _check_no_orphans
+
+        manifest = MagicMock(spec=APMPackage)
+        manifest.get_apm_dependencies.return_value = []
+        manifest.get_dev_apm_dependencies.return_value = [
+            DependencyReference(repo_url="owner/dev-pkg")
+        ]
+        manifest.get_all_apm_dependencies.return_value = APMPackage.get_all_apm_dependencies(
+            manifest
+        )
+
+        lock = MagicMock(spec=LockFile)
+        lock.dependencies = {
+            "owner/dev-pkg": LockedDependency(
+                repo_url="owner/dev-pkg", is_dev=True, resolved_by=None
+            ),
+        }
+
+        result = _check_no_orphans(manifest, lock)
+        assert result.passed is True
+
+    def test_check_lockfile_exists_recognises_dev_only_deps(self, tmp_path) -> None:
+        """_check_lockfile_exists should not say 'no dependencies' for dev-only projects."""
+        from apm_cli.policy.ci_checks import _check_lockfile_exists
+
+        manifest = MagicMock(spec=APMPackage)
+        manifest.has_apm_dependencies.return_value = False
+        manifest.has_any_apm_dependencies.return_value = True
+        manifest.get_mcp_dependencies.return_value = []
+
+        # No lockfile on disk -- should say "lockfile missing", not "no deps"
+        result = _check_lockfile_exists(tmp_path, manifest)
+        assert result.passed is False
+        assert "missing" in result.message.lower()

--- a/tests/unit/test_prune_command.py
+++ b/tests/unit/test_prune_command.py
@@ -466,3 +466,31 @@ dependencies:
             result = self.runner.invoke(cli, ["prune"])
             assert result.exit_code == 0
             assert not orphan_dir.exists()
+
+    # ------------------------------------------------------------------
+    # Regression: devDependencies must not be pruned (#2033)
+    # ------------------------------------------------------------------
+
+    def test_prune_keeps_dev_dependency_packages(self):
+        """Regression #2033: prune must not remove devDependencies.apm packages."""
+        apm_yml_with_dev_dep = (
+            "name: test-project\n"
+            "version: 1.0.0\n"
+            "dependencies:\n"
+            "  apm:\n"
+            "    - declared-org/prod-pkg\n"
+            "  mcp: []\n"
+            "devDependencies:\n"
+            "  apm:\n"
+            "    - dev-org/dev-pkg\n"
+        )
+        with self._chdir_tmp() as tmp:
+            (tmp / "apm.yml").write_text(apm_yml_with_dev_dep)
+            prod_dir = _make_package_dir(tmp, "declared-org", "prod-pkg")
+            dev_dir = _make_package_dir(tmp, "dev-org", "dev-pkg")
+            orphan_dir = _make_package_dir(tmp, "orphan-org", "orphan-repo")
+            result = self.runner.invoke(cli, ["prune"])
+            assert result.exit_code == 0
+            assert prod_dir.exists(), "Prod dependency must remain"
+            assert dev_dir.exists(), "Dev dependency must remain"
+            assert not orphan_dir.exists(), "Orphaned package must be removed"

--- a/tests/unit/test_skill_subset_persistence.py
+++ b/tests/unit/test_skill_subset_persistence.py
@@ -445,6 +445,8 @@ class TestSkillSubsetConsistencyCheck:
         """Create a manifest mock with given dep_refs."""
         manifest = Mock()
         manifest.get_apm_dependencies.return_value = deps
+        manifest.get_dev_apm_dependencies.return_value = []
+        manifest.get_all_apm_dependencies.return_value = deps
         return manifest
 
     def _make_lock_mock(self, locked_deps):


### PR DESCRIPTION
# fix(dependencies): keep dev dependencies through audit and prune

## TL;DR

Dependencies declared under `devDependencies.apm` now participate in every declared-dependency check used by install cleanup, `apm audit --ci`, and `apm prune`. This supersedes #2042 with an end-to-end regression test that runs the real install, audit, and prune commands and proves the installed dev package survives.

> [!IMPORTANT]
> Supersedes #2042, preserves @sergio-sisternes-epam's commits and authorship, and closes #2033.

## Problem (WHY)

- [x] `apm install` installed a local dev dependency, but `apm audit --ci` then classified its lockfile entry as orphaned.
- [x] `apm prune` deleted the same package even though it remained declared in `apm.yml`.
- [x] Dev-only projects could be reported as having no dependencies, so lockfile enforcement was skipped.
- [!] Unit tests covered individual helpers, but not the user-visible command chain that exposed #2033.

The observed behavior and reproduction are documented in [#2033](https://github.com/microsoft/apm/issues/2033). The end-to-end proof follows the project testing rule that cross-module behavior needs an integration scenario, while keeping the implementation surgical: ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/).

## Approach (WHAT)

| # | Fix | Principle | Source |
|---:|---|---|---|
| 1 | Add one model API that combines production and dev APM dependencies. | Governed by policy | [#2033](https://github.com/microsoft/apm/issues/2033) |
| 2 | Route prune, orphan, lockfile, ref, and skill-subset checks through the combined view. | DevX (pragmatic as npm) | [#2033](https://github.com/microsoft/apm/issues/2033) |
| 3 | Exercise install -> audit -> prune in a hermetic subprocess test. | ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) | `tests/integration/test_dev_dependency_orphan_e2e.py` |
| 4 | Document the corrected contract and add release notes. | OSS / community-driven | `CHANGELOG.md` and reference docs |

## Implementation (HOW)

| File | Intent |
|---|---|
| `src/apm_cli/models/apm_package.py` | Adds combined production-plus-dev APM dependency queries. |
| `src/apm_cli/commands/_helpers.py` | Includes dev declarations in the shared on-disk orphan scan. |
| `src/apm_cli/commands/prune.py` | Builds the expected install set from both dependency buckets. |
| `src/apm_cli/policy/ci_checks.py` | Applies the combined APM and MCP views across lockfile, ref, orphan, subset, and config checks. |
| `tests/integration/test_dev_dependency_orphan_e2e.py` | Runs a real local dev install, CI audit, and prune, then verifies the package and `is_dev` lock metadata. |
| `tests/unit/test_dev_dependencies.py` | Covers combined model queries and CI-policy behavior for dev-only manifests. |
| `tests/unit/test_prune_command.py` | Adds a focused destructive-command regression trap. |
| `tests/unit/test_skill_subset_persistence.py` | Keeps manifest mocks aligned with the combined dependency API. |
| `docs/src/content/docs/reference/baseline-checks.md` | States that CI baseline checks include dev dependencies. |
| `docs/src/content/docs/reference/cli/prune.md` | States that declared dev dependencies are retained. |
| `CHANGELOG.md` | Records the user-visible fix under Unreleased. |

## Diagrams

Legend: the dashed node is the new end-to-end proof; the shared manifest view is the production behavior corrected by this branch.

```mermaid
flowchart LR
    subgraph Manifest[Manifest]
        P[dependencies.apm]
        D[devDependencies.apm]
    end
    subgraph Model[APMPackage]
        A[get_all_apm_dependencies]
    end
    subgraph Commands[Command checks]
        I[install]
        U[audit --ci]
        R[prune]
    end
    subgraph Proof[Regression proof]
        E[test_dev_dependency_survives_audit_and_prune]
    end
    P --> A
    D --> A
    A --> U
    A --> R
    I --> E
    U --> E
    R --> E
    classDef new stroke-dasharray: 5 5;
    class E new;
```

## Trade-offs

- **Combined view instead of duplicating merges at call sites.** Chose model-level helpers; rejected repeated production-plus-dev concatenation because a single contract is harder to narrow accidentally.
- **Hermetic local package instead of network installation.** Chose a sibling path dependency; rejected live GitHub access so the regression proof is deterministic and credential-free.
- **Real subprocesses instead of command mocks.** Chose slower boundary coverage; rejected mocking install/audit/prune because the bug existed between those boundaries.
- **No production-only prune mode.** Preserved current npm-like behavior; a future omit-dev option would be a separate product decision.

## Benefits

1. A package declared only in `devDependencies.apm` remains installed after `apm prune`.
2. `apm audit --ci` exits zero immediately after a clean dev-only install.
3. The generated lockfile retains exactly one direct dependency with `is_dev: true` in the regression scenario.
4. One integration test now fails if prune regresses to the production-only getter.

## Validation

`uv run --extra dev pytest -q tests/integration/test_dev_dependency_orphan_e2e.py tests/unit/test_dev_dependencies.py tests/unit/test_prune_command.py`:

```
........................................................                 [100%]
56 passed in 2.88s
```

<details><summary>Full lint mirror</summary>

`uv run --extra dev ruff check src/ tests/`:

```
All checks passed!
```

`uv run --extra dev ruff format --check src/ tests/`:

```
1411 files already formatted
```

`uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/`:

```
Your code has been rated at 10.00/10
```

`bash scripts/lint-auth-signals.sh`:

```
[+] auth-signal lint clean
```

</details>

### Mutation-break evidence

With `prune.py` temporarily changed back from `get_all_apm_dependencies()` to `get_apm_dependencies()`, the new integration test failed at the final survival assertion:

```
AssertionError: apm prune removed a package declared under devDependencies.apm
1 failed
```

The production guard was restored and the test passed again.

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | A clean dev-only install passes `apm audit --ci` and survives `apm prune`. | Governed by policy, DevX | `tests/integration/test_dev_dependency_orphan_e2e.py::test_dev_dependency_survives_audit_and_prune` (regression-trap for #2033) | e2e |
| 2 | CI ref consistency rejects a mismatched ref for a dev dependency. | Secure by default, Governed by policy | `tests/unit/test_dev_dependencies.py::TestOrphanDetectionIncludesDevDeps::test_check_ref_consistency_detects_dev_dep_mismatch` | unit |
| 3 | Prune removes a real orphan while retaining declared production and dev packages. | DevX | `tests/unit/test_prune_command.py::TestPruneCommand::test_prune_keeps_dev_dependency_packages` | unit |

## How to test

- [ ] Run the targeted 56-test command above and observe all tests pass.
- [ ] Temporarily narrow `prune.py` to `get_apm_dependencies()` and observe the end-to-end test fail at the package-survival assertion.
- [ ] Restore `get_all_apm_dependencies()` and observe the end-to-end test pass.
- [ ] Run the full lint mirror and observe silent/green results.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
