### PR TITLE
chore: release v0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,44 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.1] - 2026-07-10
+
 ### Fixed
 
-- Sub-skill and native-skill ownership tracking now keys on the full
-  dependency identity (`owner/repo`) instead of the last path segment.
-  Two different packages that happen to share a repo/leaf name (e.g. two
-  orgs each publishing a `shared-skill` or `utils` repo) were previously
-  treated as the same owner, silently suppressing the cross-package
-  collision warning exactly when it mattered -- an unrelated package
-  could overwrite another's skill with no signal. `apm install --force`
-  now correctly reports the collision regardless of dependency source
-  (registry or git), and the lockfile no longer records both packages as
-  owning the same deployed file after a collision. (by @nadav-y) (#2052)
-- Codex MCP installs and stale-server cleanup now preserve literal-quoted
-  Windows path keys such as `C:\Users\me\Documents\Playground` in `config.toml`
-  instead of rejecting or corrupting other projects and per-path preferences.
-  (closes #2075) (#2100)
-- `apm audit --ci` no longer raises false `config-consistency` failures in
-  monorepos whose local-path sub-packages contribute MCP servers. Transitively
-  contributed servers now carry lockfile provenance and are exempt from the
-  orphan check. (#2084)
+- Skill ownership tracking now keys on the full `owner/repo` identity, so
+  packages with the same leaf name no longer suppress collision warnings or
+  claim the same deployed files. (by @nadav-y, #2052)
+- Repeated `apm install` runs now preserve existing LSP server and config state
+  before lockfile comparison, avoiding no-op rewrites caused only by
+  `generated_at`. (by @paul-ww, closes #2078, #2079)
+- OpenAPM v0.1 now defines deterministic Antigravity glob frontmatter and
+  limits `AGENTS.md` deduplication to resolved instruction files, preventing
+  unrelated rule files from suppressing instructions. (#2087)
+- Codex MCP installs and stale-server cleanup now preserve literal Windows
+  path keys in `config.toml` instead of rejecting or corrupting per-project
+  preferences. (closes #2075, #2100)
+- `apm audit --ci` no longer reports transitive MCP servers from local-path
+  sub-packages as orphaned configs. (by @edenfunf, closes #2081, #2084)
 - In-repository plugins from SSH-registered GitLab and generic git
-  marketplaces no longer rewrite to HTTPS; generated `git:` and `path:`
-  dependencies keep using existing SSH keys. (#2091)
-- Installing the same GitHub or package-registry dependency with different
-  owner/repository casing no longer creates duplicate identities, lock/cache
-  keys, or install paths. Publish uses the same lowercase identity, while
-  unknown git hosts retain case-sensitive paths. (closes #2073) (#2098)
+  marketplaces now preserve SSH transport in generated `git:` and `path:`
+  dependencies. (#2091)
+- GitHub and package-registry dependency identities are now case-insensitive,
+  preventing duplicate lock, cache, and install paths while preserving
+  case-sensitive paths for unknown git hosts. (closes #2073, #2098)
 - `apm deps tree` no longer repeats same-repository virtual packages, keeping
   large monorepo dependency trees accurate and scannable. (#2093)
-- `apm install host/org/repo/subpath#ref` on an unrecognised self-hosted FQDN
-  no longer fails with a misleading "not accessible or doesn't exist" error;
-  the failure reason now suggests setting `GITLAB_HOST` / `APM_GITLAB_HOSTS`
-  if the target is a self-hosted GitLab instance, or using an explicit
-  `git:` + `path:` entry in `apm.yml` otherwise. (by @rrazvd; closes #2066) (#2074)
-- Dev dependencies are no longer removed by `apm prune`, reported as orphans
-  by `apm audit --ci`, or omitted from lockfile and MCP config checks. This
-  includes `devDependencies.apm` and applicable `devDependencies.mcp` entries.
-  (by @sergio-sisternes-epam; #2102, supersedes #2042, closes #2033)
+- Claude user-scope MCP installs now honor `CLAUDE_CONFIG_DIR`, with
+  `~/.claude.json` retained as the fallback. (closes #2060, #2096)
+- Dev dependencies now survive `apm prune`, pass `apm audit --ci`, and remain
+  represented in lockfile and MCP config checks. (by @sergio-sisternes-epam,
+  closes #2033, #2102; supersedes #2042)
+- `apm deps list` now matches local transitive dependencies by their canonical
+  install path instead of incorrectly reporting valid packages as orphaned.
+  (closes #2068, #2099)
+- Failed installs from unrecognized self-hosted GitLab hosts now suggest
+  `GITLAB_HOST`, `APM_GITLAB_HOSTS`, or an explicit `git:` plus `path:` entry.
+  (by @rrazvd, closes #2066, #2074)
+- `apm update` now reconciles MCP and LSP servers after an accepted plan,
+  removing stale runtime config and recording newly declared servers.
+  (by @cffnpwr, closes #2077, #2085)
 
 ## [0.24.0] - 2026-07-05
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apm-cli"
-version = "0.24.0"
+version = "0.24.1"
 description = "MCP configuration tool"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/unit/install/test_mcp_integration_extraction.py
+++ b/tests/unit/install/test_mcp_integration_extraction.py
@@ -72,7 +72,7 @@ class TestRunMcpIntegrationInstallBranch:
     """``should_install=True`` and ``mcp_deps`` non-empty."""
 
     @patch(_PATCH_TARGET)
-    def test_installs_and_updates_lockfile(self, mock_mcp):
+    def test_installs_and_updates_lockfile(self, mock_mcp, tmp_path: Path):
         dep = MCPDependency(name="io.github.acme/server", transport="stdio")
         mock_mcp.deduplicate.side_effect = lambda x: x
         mock_mcp.install.return_value = 1
@@ -82,7 +82,9 @@ class TestRunMcpIntegrationInstallBranch:
             "io.github.acme/server": "io.github.acme/package"
         }
 
-        count, apm_config = run_mcp_integration(**_base_kwargs(mcp_deps=[dep]))
+        count, apm_config = run_mcp_integration(
+            **_base_kwargs(mcp_deps=[dep], project_root=tmp_path)
+        )
 
         assert count == 1
         assert apm_config == {"scripts": {}}
@@ -98,7 +100,7 @@ class TestRunMcpIntegrationInstallBranch:
         mock_mcp.remove_stale.assert_not_called()
 
     @patch(_PATCH_TARGET)
-    def test_removes_stale_servers_no_longer_declared(self, mock_mcp):
+    def test_removes_stale_servers_no_longer_declared(self, mock_mcp, tmp_path: Path):
         dep = MCPDependency(name="io.github.acme/new-server", transport="stdio")
         mock_mcp.deduplicate.side_effect = lambda x: x
         mock_mcp.install.return_value = 1
@@ -111,6 +113,7 @@ class TestRunMcpIntegrationInstallBranch:
                 mcp_deps=[dep],
                 old_mcp_servers={"io.github.acme/orphan-server"},
                 old_mcp_configs={"io.github.acme/orphan-server": {"name": "orphan"}},
+                project_root=tmp_path,
             )
         )
 
@@ -119,7 +122,7 @@ class TestRunMcpIntegrationInstallBranch:
         assert stale_arg == {"io.github.acme/orphan-server"}
 
     @patch(_PATCH_TARGET)
-    def test_forwards_apm_config_targets_key_when_declared(self, mock_mcp):
+    def test_forwards_apm_config_targets_key_when_declared(self, mock_mcp, tmp_path: Path):
         """#1335: only the targets-key the user actually declared is
         forwarded, matching the original inline block's behaviour."""
         dep = MCPDependency(name="io.github.acme/server", transport="stdio")
@@ -130,14 +133,16 @@ class TestRunMcpIntegrationInstallBranch:
         mock_mcp.get_server_provenance.return_value = {}
 
         pkg = _make_apm_package(scripts={"build": "echo hi"}, targets=["claude", "copilot"])
-        _count, apm_config = run_mcp_integration(**_base_kwargs(apm_package=pkg, mcp_deps=[dep]))
+        _count, apm_config = run_mcp_integration(
+            **_base_kwargs(apm_package=pkg, mcp_deps=[dep], project_root=tmp_path)
+        )
 
         assert apm_config == {"scripts": {"build": "echo hi"}, "targets": ["claude", "copilot"]}
         install_kwargs = mock_mcp.install.call_args.kwargs
         assert install_kwargs["apm_config"] == apm_config
 
     @patch(_PATCH_TARGET)
-    def test_forwards_singular_target_key_when_declared(self, mock_mcp):
+    def test_forwards_singular_target_key_when_declared(self, mock_mcp, tmp_path: Path):
         dep = MCPDependency(name="io.github.acme/server", transport="stdio")
         mock_mcp.deduplicate.side_effect = lambda x: x
         mock_mcp.install.return_value = 1
@@ -146,7 +151,9 @@ class TestRunMcpIntegrationInstallBranch:
         mock_mcp.get_server_provenance.return_value = {}
 
         pkg = _make_apm_package(target="claude")
-        _count, apm_config = run_mcp_integration(**_base_kwargs(apm_package=pkg, mcp_deps=[dep]))
+        _count, apm_config = run_mcp_integration(
+            **_base_kwargs(apm_package=pkg, mcp_deps=[dep], project_root=tmp_path)
+        )
 
         assert apm_config == {"scripts": {}, "target": "claude"}
         assert "targets" not in apm_config

--- a/uv.lock
+++ b/uv.lock
@@ -201,7 +201,7 @@ wheels = [
 
 [[package]]
 name = "apm-cli"
-version = "0.24.0"
+version = "0.24.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
# ship(release): prepare v0.24.1

## TL;DR

Cut release 0.24.1 as a PATCH from 0.24.0. This moves the approved
`[Unreleased]` notes into a dated release section and keeps
`pyproject.toml` and `uv.lock` on the same version. It also repairs four
Windows unit tests that passed a nonexistent subprocess working directory.

> [!IMPORTANT]
> Merging this PR does not publish the release. Tagging `v0.24.1` remains the
> explicit post-merge gate that triggers the release workflow.

## Problem (WHY)

- [x] The 13 user-facing fixes merged since `v0.24.0` still live under
  `[Unreleased]`.
- [x] The project metadata and lockfile still identify the package as
  `0.24.0`.
- [!] Release automation must not run before the release-preparation diff is
  reviewed and merged.
- [x] The Windows unit job cannot reach packaging while MCP integration tests
  use a nonexistent POSIX-shaped `project_root`.

The repository's changelog contract requires released versions to use
`## [X.Y.Z] - YYYY-MM-DD`, while the release workflow requires a later,
human-controlled `v`-prefixed tag.

## Approach (WHAT)

| # | Fix |
|---:|---|
| 1 | Move the approved release notes to `[0.24.1] - 2026-07-10`, leaving an empty `[Unreleased]` placeholder. |
| 2 | Set the package version to `0.24.1` in `pyproject.toml`. |
| 3 | Regenerate `uv.lock` so its editable `apm-cli` package entry also reports `0.24.1`. |
| 4 | Stop before tagging; publication remains a post-merge operator action. |
| 5 | Give the four default-policy MCP integration tests a real pytest temporary project root on every OS. |

## Implementation (HOW)

| File | Change |
|---|---|
| `CHANGELOG.md` | Consolidates one concise "so what" entry for each user-facing PR, preserves external contributor attribution, and dates the PATCH release. Internal workflow-only PR #2040 is excluded. |
| `pyproject.toml` | Bumps `[project].version` from `0.24.0` to `0.24.1`. |
| `uv.lock` | Refreshes the root editable package entry to `0.24.1`; dependency resolution is otherwise unchanged. |
| `tests/unit/install/test_mcp_integration_extraction.py` | Uses `tmp_path` for the four tests that enter policy discovery, avoiding Windows `NotADirectoryError` without changing production behavior. |

## Diagrams

Legend: the dashed nodes are the release artifacts updated by this PR; tagging
stays outside the PR as the human-gated publication trigger.

```mermaid
flowchart LR
    subgraph Prepare[Release PR]
        C[CHANGELOG 0.24.1]
        P[pyproject version 0.24.1]
        U[uv.lock version 0.24.1]
    end
    subgraph Publish[Post-merge]
        T[tag v0.24.1]
        R[release workflow]
    end
    C --> T
    P --> T
    U --> T
    T --> R
    classDef new stroke-dasharray: 5 5;
    class C,P,U new;
```

## Trade-offs

- **PATCH instead of MINOR.** Chose `0.24.1` because every user-facing change
  repairs an existing surface; rejected `0.25.0` because the cycle adds no new
  command, feature flag, schema, contract surface, resolution mode, adapter,
  or BREAKING change.
- **One release note per user-facing PR.** Chose concise user outcomes;
  rejected internal implementation detail and workflow-only churn.
- **No Scenario Evidence table.** This is a pure release metadata/version bump
  plus a test-harness portability repair with no product behavior change.
  Existing product scenario coverage is unchanged.

## Benefits

1. `CHANGELOG.md`, `pyproject.toml`, and `uv.lock` agree on version `0.24.1`.
2. All 13 user-facing PRs since `v0.24.0` have one release-note entry.
3. External contributors remain credited in the shipped changelog.
4. Publication cannot begin until a maintainer merges this PR and creates the
   `v0.24.1` tag.
5. The Windows unit job can complete the MCP integration tests instead of
   failing on an invalid subprocess working directory.

## Why PATCH (0.24.1), not MINOR (0.25.0)

Semver rubric Row 7 applies: all remaining changes are bug fixes, a contract
clarification, docs, or internal work. No BREAKING marker or new public surface
was introduced.

## Validation

`.agents/skills/cut-release/scripts/verify-lint-mirror.sh`:

```text
ruff check                     PASS
ruff format --check            PASS
pylint R0801 duplication       PASS
auth-signals boundary          PASS
[+] all lint-mirror checks PASSED
```

`uv run --extra dev pytest -q tests/unit tests/test_console.py`:

```text
18205 passed, 2 skipped, 21 xfailed, 19 warnings, 84 subtests passed
```

Manual release test build on the PR head:

```text
Build & Test (windows-latest, x86_64, windows, apm-windows-x86_64)  PASS
```

https://github.com/microsoft/apm/actions/runs/29080835382/job/86323043773

### Scenario Evidence

Omitted because the added test-harness repair changes no product behavior; it
only replaces an invalid fixture path with pytest's real temporary directory.

## How to test

- [ ] Confirm `CHANGELOG.md` contains an empty `[Unreleased]` heading followed
  by `[0.24.1] - 2026-07-10`.
- [ ] Confirm `pyproject.toml` reports `version = "0.24.1"`.
- [ ] Confirm the root `apm-cli` package entry in `uv.lock` reports
  `version = "0.24.1"`.
- [ ] Run `.agents/skills/cut-release/scripts/verify-lint-mirror.sh` and expect
  all four checks to pass.
- [ ] Run `uv run --extra dev pytest -q tests/unit tests/test_console.py` and
  expect the full unit suite to pass, including on Windows.

## Post-merge

Tag `v0.24.1` to trigger the release workflow:

```bash
git tag v0.24.1
git push origin v0.24.1
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>