### PR TITLE
fix(marketplace): preserve ADO URL and bearer auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Azure DevOps marketplace checks now preserve suffix-free `/_git/<repo>` URLs
+  and pass Azure CLI bearer authentication through to `git ls-remote`. (closes #2119)
+
 ## [0.24.1] - 2026-07-10
 
 ### Fixed

--- a/docs/src/content/docs/getting-started/authentication.md
+++ b/docs/src/content/docs/getting-started/authentication.md
@@ -223,6 +223,10 @@ apm install dev.azure.com/myorg/myproject/myrepo
 2. AAD bearer via `az account get-access-token` if `az` is installed and signed in
 3. Otherwise: auth-failed error with guidance for both paths
 
+`apm marketplace check` uses this same chain for an ADO `marketplace.sourceBase`.
+Azure CLI credentials are passed to `git ls-remote` as a bearer Authorization
+header, never embedded in the repository URL.
+
 **Stale-PAT fallback:** if `ADO_APM_PAT` is set but rejected (HTTP 401), APM silently retries with the `az` bearer and emits:
 
 ```

--- a/docs/src/content/docs/reference/cli/marketplace.md
+++ b/docs/src/content/docs/reference/cli/marketplace.md
@@ -193,7 +193,8 @@ Fold a legacy `marketplace.yml` into the `marketplace:` block of
 Validate the schema of the authoring config and verify that every
 package entry resolves to a reachable git ref. For an Azure DevOps `sourceBase`
 ending in `/_git`, package names are appended without a `.git` suffix. The check
-uses `ADO_APM_PAT`, then the Azure CLI bearer fallback, just like installation.
+uses `ADO_APM_PAT` when it is set. Otherwise, it uses the Azure CLI bearer
+credential when `az` is installed and signed in.
 
 | Flag | Description |
 |---|---|

--- a/docs/src/content/docs/reference/cli/marketplace.md
+++ b/docs/src/content/docs/reference/cli/marketplace.md
@@ -191,7 +191,9 @@ Fold a legacy `marketplace.yml` into the `marketplace:` block of
 ### `apm marketplace check`
 
 Validate the schema of the authoring config and verify that every
-package entry resolves to a reachable git ref.
+package entry resolves to a reachable git ref. For an Azure DevOps `sourceBase`
+ending in `/_git`, package names are appended without a `.git` suffix. The check
+uses `ADO_APM_PAT`, then the Azure CLI bearer fallback, just like installation.
 
 | Flag | Description |
 |---|---|

--- a/packages/apm-guide/.apm/skills/apm-usage/authentication.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/authentication.md
@@ -88,9 +88,9 @@ apm install dev.azure.com/org/project/_git/repo
 ```
 
 ADO paths use the 3-segment format: `org/project/repo`. Auth is always required.
-`apm marketplace check` preserves this auth mode for ADO `sourceBase` entries:
-Azure CLI tokens are injected into `git ls-remote` as bearer headers and are not
-embedded in clone URLs.
+`apm marketplace check` uses this same credential chain. See
+[Marketplace source bases](package-authoring.md#marketplace-source-bases) for
+ADO marketplace URL authoring.
 
 **Finding your tenant ID:** visit `https://dev.azure.com/{org}/_settings/organizationAad`,
 or run `az login` and inspect `az account show --query tenantId -o tsv`.

--- a/packages/apm-guide/.apm/skills/apm-usage/authentication.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/authentication.md
@@ -88,6 +88,9 @@ apm install dev.azure.com/org/project/_git/repo
 ```
 
 ADO paths use the 3-segment format: `org/project/repo`. Auth is always required.
+`apm marketplace check` preserves this auth mode for ADO `sourceBase` entries:
+Azure CLI tokens are injected into `git ls-remote` as bearer headers and are not
+embedded in clone URLs.
 
 **Finding your tenant ID:** visit `https://dev.azure.com/{org}/_settings/organizationAad`,
 or run `az login` and inspect `az account show --query tenantId -o tsv`.

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -43,11 +43,6 @@ dependencies:
     - ../sibling-repo/my-package
 ```
 
-For an Azure DevOps marketplace, use
-`sourceBase: https://dev.azure.com/org/project/_git` and a relative package
-`source`. APM appends the repository name without adding `.git`, matching the
-ADO clone URL contract.
-
 GitHub and package-registry owner/repository identifiers are normalized to
 lowercase before APM derives lock keys, cache identity, canonical strings, or
 `apm_modules/` paths. `Owner/Repo` and `owner/repo` therefore identify one

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -43,6 +43,11 @@ dependencies:
     - ../sibling-repo/my-package
 ```
 
+For an Azure DevOps marketplace, use
+`sourceBase: https://dev.azure.com/org/project/_git` and a relative package
+`source`. APM appends the repository name without adding `.git`, matching the
+ADO clone URL contract.
+
 GitHub and package-registry owner/repository identifiers are normalized to
 lowercase before APM derives lock keys, cache identity, canonical strings, or
 `apm_modules/` paths. `Owner/Repo` and `owner/repo` therefore identify one

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -482,7 +482,9 @@ Section 7.5 is canonical for the full validation and override rules.
 The base may target any supported host -- GitHub.com, GitHub Enterprise,
 self-hosted GitLab, or Azure DevOps. For Azure DevOps, use a
 `https://dev.azure.com/{org}/{project}/_git` base; the `dev.azure.com` host is
-preserved through to the consumer and authenticated with `ADO_APM_PAT`:
+preserved through to the consumer. APM appends each repository name without a
+`.git` suffix. Authentication uses `ADO_APM_PAT` when set, or an Azure CLI
+bearer credential when the PAT is unset and `az` is signed in:
 
 ```yaml
 marketplace:

--- a/src/apm_cli/commands/marketplace/check.py
+++ b/src/apm_cli/commands/marketplace/check.py
@@ -9,11 +9,12 @@ from typing import TYPE_CHECKING
 import click
 
 from ...core.command_logger import CommandLogger
-from ...marketplace.auth_helpers import resolve_token_for_host
+from ...marketplace.auth_helpers import resolve_auth_for_host
 from ...marketplace.errors import GitLsRemoteError, OfflineMissError
 from ...marketplace.ref_resolver import RefResolver
 from ...marketplace.semver import satisfies_range
 from ...marketplace.yml_schema import PackageEntry, split_source_base
+from ...utils.github_host import is_azure_devops_hostname
 from . import (
     _CheckResult,
     _extract_tag_versions,
@@ -92,13 +93,18 @@ def check(offline, verbose):
                     from ...core.auth import AuthResolver
 
                     auth_resolver = AuthResolver()
-                token = resolve_token_for_host(
+                auth = resolve_auth_for_host(
                     host,
                     offline=offline,
                     org=org,
                     auth_resolver=auth_resolver,
                 )
-                resolvers[key] = RefResolver(offline=offline, host=host, token=token)
+                resolvers[key] = RefResolver(
+                    offline=offline,
+                    host=host,
+                    token=auth.token if auth else None,
+                    auth_scheme=auth.auth_scheme if auth else "basic",
+                )
         return resolvers[key]
 
     results = []
@@ -122,7 +128,10 @@ def check(offline, verbose):
             try:
                 # Resolve each entry against its effective host + composed path.
                 host, owner_repo, org = _entry_coordinates(entry, source_base)
-                remote_label = f"https://{host}/{owner_repo}.git" if host else owner_repo
+                if host and is_azure_devops_hostname(host):
+                    remote_label = f"https://{host}/{owner_repo}"
+                else:
+                    remote_label = f"https://{host}/{owner_repo}.git" if host else owner_repo
                 logger.verbose_detail(
                     f"Resolving {entry.name} via {host or 'default host'}: {remote_label}"
                 )

--- a/src/apm_cli/marketplace/auth_helpers.py
+++ b/src/apm_cli/marketplace/auth_helpers.py
@@ -14,9 +14,35 @@ import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ..core.auth import AuthResolver
+    from ..core.auth import AuthContext, AuthResolver
 
 logger = logging.getLogger(__name__)
+
+
+def resolve_auth_for_host(
+    host: str,
+    *,
+    offline: bool = False,
+    org: str | None = None,
+    auth_resolver: AuthResolver | None = None,
+) -> AuthContext | None:
+    """Resolve and preserve the complete auth context for *host*."""
+    if offline:
+        return None
+    try:
+        if auth_resolver is None:
+            from ..core.auth import AuthResolver  # lazy import to avoid cycles
+
+            resolver = AuthResolver()
+        else:
+            resolver = auth_resolver
+        ctx = resolver.resolve(host) if org is None else resolver.resolve(host, org=org)
+        if ctx.token:
+            logger.debug("Resolved token for host %s (source=%s)", host, ctx.source)
+            return ctx
+    except Exception:
+        logger.debug("Could not resolve token for host %s", host, exc_info=True)
+    return None
 
 
 def resolve_token_for_host(
@@ -35,19 +61,10 @@ def resolve_token_for_host(
     Pass *auth_resolver* to reuse a cached resolver across many calls;
     otherwise a fresh one is created per call.
     """
-    if offline:
-        return None
-    try:
-        if auth_resolver is None:
-            from ..core.auth import AuthResolver  # lazy import to avoid cycles
-
-            resolver = AuthResolver()
-        else:
-            resolver = auth_resolver
-        ctx = resolver.resolve(host) if org is None else resolver.resolve(host, org=org)
-        if ctx.token:
-            logger.debug("Resolved token for host %s (source=%s)", host, ctx.source)
-            return ctx.token
-    except Exception:
-        logger.debug("Could not resolve token for host %s", host, exc_info=True)
-    return None
+    ctx = resolve_auth_for_host(
+        host,
+        offline=offline,
+        org=org,
+        auth_resolver=auth_resolver,
+    )
+    return ctx.token if ctx is not None else None

--- a/src/apm_cli/marketplace/builder.py
+++ b/src/apm_cli/marketplace/builder.py
@@ -29,14 +29,14 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from ..core.auth import HostInfo
+    from ..core.auth import AuthContext, HostInfo
 
 from ..utils.github_host import default_host
 from ..utils.path_security import ensure_path_within
 from ..utils.yaml_io import load_yaml_str
 from ._io import atomic_write
 from ._shared import iter_semver_tags
-from .auth_helpers import resolve_token_for_host
+from .auth_helpers import resolve_auth_for_host, resolve_token_for_host
 from .diagnostics import BuildDiagnostic
 from .errors import (
     BuildError,
@@ -452,21 +452,39 @@ class MarketplaceBuilder:
             cached = self._host_resolvers.get(key)
             if cached is not None:
                 return cached
-            token = self._resolve_token_for_host(resolved_host, org=org)
+            auth = self._resolve_auth_for_host(resolved_host, org=org)
             logger.debug(
                 "Creating per-host RefResolver for %s (org=%s, token=%s)",
                 resolved_host,
                 org or "none",
-                "set" if token else "unset",
+                "set" if auth else "unset",
             )
             resolver = RefResolver(
                 timeout_seconds=self._options.timeout_seconds,
                 offline=self._options.offline,
                 host=resolved_host,
-                token=token,
+                token=auth.token if auth else None,
+                auth_scheme=auth.auth_scheme if auth else "basic",
             )
             self._host_resolvers[key] = resolver
             return resolver
+
+    def _resolve_auth_for_host(self, host: str, *, org: str | None = None) -> AuthContext | None:
+        """Resolve the complete auth context for marketplace git operations."""
+        if self._options.offline:
+            return None
+        from ..core.auth import AuthResolver  # lazy import
+
+        resolver = self._auth_resolver
+        if resolver is None:
+            resolver = AuthResolver()
+            self._auth_resolver = resolver
+        return resolve_auth_for_host(
+            host,
+            offline=self._options.offline,
+            org=org,
+            auth_resolver=resolver,
+        )
 
     def _resolve_token_for_host(self, host: str, *, org: str | None = None) -> str | None:
         """Resolve an auth token for *host* via the shared marketplace helper."""

--- a/src/apm_cli/marketplace/builder.py
+++ b/src/apm_cli/marketplace/builder.py
@@ -36,7 +36,7 @@ from ..utils.path_security import ensure_path_within
 from ..utils.yaml_io import load_yaml_str
 from ._io import atomic_write
 from ._shared import iter_semver_tags
-from .auth_helpers import resolve_auth_for_host, resolve_token_for_host
+from .auth_helpers import resolve_auth_for_host
 from .diagnostics import BuildDiagnostic
 from .errors import (
     BuildError,
@@ -488,20 +488,8 @@ class MarketplaceBuilder:
 
     def _resolve_token_for_host(self, host: str, *, org: str | None = None) -> str | None:
         """Resolve an auth token for *host* via the shared marketplace helper."""
-        if self._options.offline:
-            return None
-        from ..core.auth import AuthResolver  # lazy import
-
-        resolver = self._auth_resolver
-        if resolver is None:
-            resolver = AuthResolver()
-            self._auth_resolver = resolver
-        return resolve_token_for_host(
-            host,
-            offline=self._options.offline,
-            org=org,
-            auth_resolver=resolver,
-        )
+        auth = self._resolve_auth_for_host(host, org=org)
+        return auth.token if auth else None
 
     def _ensure_auth(self) -> None:
         """Lazily resolve host classification and GitHub token.

--- a/src/apm_cli/marketplace/ref_resolver.py
+++ b/src/apm_cli/marketplace/ref_resolver.py
@@ -23,7 +23,12 @@ import threading
 import time
 from dataclasses import dataclass
 
-from ..utils.github_host import build_https_clone_url, default_host
+from ..utils.github_host import (
+    build_ado_bearer_git_env,
+    build_https_clone_url,
+    default_host,
+    is_azure_devops_hostname,
+)
 from ._git_utils import redact_token as _redact_token
 from .errors import GitLsRemoteError, OfflineMissError
 from .git_stderr import translate_git_stderr
@@ -137,9 +142,10 @@ class RefResolver:
         When ``True`` (default), stderr from failed ``git`` calls is
         classified via ``translate_git_stderr``.
     token:
-        Optional GitHub PAT to embed in the ``https://`` URL.  When set
-        the URL uses ``x-access-token`` authentication; when ``None``
-        (default) git runs unauthenticated.
+        Optional PAT or bearer credential. Basic credentials are embedded in
+        the URL; ADO bearer credentials are sent through ``http.extraheader``.
+    auth_scheme:
+        ``"basic"`` (default) or ``"bearer"`` from ``AuthContext``.
     """
 
     def __init__(
@@ -150,12 +156,14 @@ class RefResolver:
         stderr_translator_enabled: bool = True,
         host: str | None = None,
         token: str | None = None,
+        auth_scheme: str = "basic",
     ) -> None:
         self._timeout = timeout_seconds
         self._offline = offline
         self._stderr_translator = stderr_translator_enabled
         self._host: str = host or default_host() or "github.com"
         self._token: str | None = token
+        self._auth_scheme = auth_scheme
         self._cache = RefCache()
         self._lock = threading.Lock()
         # Per-remote locks to serialise calls to the same remote while
@@ -172,6 +180,22 @@ class RefResolver:
             if owner_repo not in self._remote_locks:
                 self._remote_locks[owner_repo] = threading.Lock()
             return self._remote_locks[owner_repo]
+
+    def _git_url_and_env(self, owner_repo: str) -> tuple[str, dict[str, str]]:
+        """Build the remote URL and auth environment for one git operation."""
+        requested_bearer = self._auth_scheme == "bearer"
+        bearer = requested_bearer and is_azure_devops_hostname(self._host)
+        token = None if requested_bearer else self._token
+        if is_azure_devops_hostname(self._host):
+            credentials = f"x-access-token:{token}@" if token else ""
+            url = f"https://{credentials}{self._host}/{owner_repo}"
+        else:
+            url = build_https_clone_url(self._host, owner_repo, token=token)
+        env = {**os.environ, "GIT_TERMINAL_PROMPT": "0", "GIT_ASKPASS": "echo"}
+        if bearer and self._token:
+            env.pop("GIT_TOKEN", None)
+            env.update(build_ado_bearer_git_env(self._token))
+        return url, env
 
     def list_remote_refs(self, owner_repo: str) -> list[RemoteRef]:
         """Fetch all tags and heads from the configured Git host.
@@ -206,8 +230,7 @@ class RefResolver:
             if self._offline:
                 raise OfflineMissError(package="", remote=owner_repo)
 
-            url = build_https_clone_url(self._host, owner_repo, token=self._token)
-            env = {**os.environ, "GIT_TERMINAL_PROMPT": "0", "GIT_ASKPASS": "echo"}
+            url, env = self._git_url_and_env(owner_repo)
             try:
                 result = subprocess.run(
                     ["git", "ls-remote", "--tags", "--heads", url],
@@ -281,8 +304,7 @@ class RefResolver:
         GitLsRemoteError
             When the ref does not exist or the subprocess fails.
         """
-        url = build_https_clone_url(self._host, owner_repo, token=self._token)
-        env = {**os.environ, "GIT_TERMINAL_PROMPT": "0", "GIT_ASKPASS": "echo"}
+        url, env = self._git_url_and_env(owner_repo)
         try:
             result = subprocess.run(
                 ["git", "ls-remote", url, ref],

--- a/src/apm_cli/marketplace/ref_resolver.py
+++ b/src/apm_cli/marketplace/ref_resolver.py
@@ -16,6 +16,7 @@ Security notes
 
 from __future__ import annotations
 
+import base64
 import os
 import re
 import subprocess
@@ -25,6 +26,7 @@ from dataclasses import dataclass
 
 from ..utils.github_host import (
     build_ado_bearer_git_env,
+    build_authorization_header_git_env,
     build_https_clone_url,
     default_host,
     is_azure_devops_hostname,
@@ -186,18 +188,24 @@ class RefResolver:
         requested_bearer = self._auth_scheme == "bearer"
         ado_host = is_azure_devops_hostname(self._host)
         if requested_bearer and not ado_host:
-            raise ValueError(f"Bearer authentication is not supported for host {self._host}")
+            raise GitLsRemoteError(
+                package="",
+                summary=f"Bearer authentication is not supported for host '{self._host}'.",
+                hint="Use bearer authentication only with an Azure DevOps host.",
+            )
         bearer = requested_bearer and ado_host
         token = None if requested_bearer else self._token
         if ado_host:
-            credentials = f"x-access-token:{token}@" if token else ""
-            url = f"https://{credentials}{self._host}/{owner_repo}"
+            url = f"https://{self._host}/{owner_repo}"
         else:
             url = build_https_clone_url(self._host, owner_repo, token=token)
         env = {**os.environ, "GIT_TERMINAL_PROMPT": "0", "GIT_ASKPASS": "echo"}
         if bearer and self._token:
             env.pop("GIT_TOKEN", None)
             env.update(build_ado_bearer_git_env(self._token))
+        elif ado_host and token:
+            credential = base64.b64encode(f":{token}".encode()).decode()
+            env.update(build_authorization_header_git_env("Basic", credential))
         return url, env
 
     def list_remote_refs(self, owner_repo: str) -> list[RemoteRef]:

--- a/src/apm_cli/marketplace/ref_resolver.py
+++ b/src/apm_cli/marketplace/ref_resolver.py
@@ -194,17 +194,17 @@ class RefResolver:
                 hint="Use bearer authentication only with an Azure DevOps host.",
             )
         bearer = requested_bearer and ado_host
-        token = None if requested_bearer else self._token
+        url_token = None if requested_bearer else self._token
         if ado_host:
             url = f"https://{self._host}/{owner_repo}"
         else:
-            url = build_https_clone_url(self._host, owner_repo, token=token)
+            url = build_https_clone_url(self._host, owner_repo, token=url_token)
         env = {**os.environ, "GIT_TERMINAL_PROMPT": "0", "GIT_ASKPASS": "echo"}
         if bearer and self._token:
             env.pop("GIT_TOKEN", None)
             env.update(build_ado_bearer_git_env(self._token))
-        elif ado_host and token:
-            credential = base64.b64encode(f":{token}".encode()).decode()
+        elif ado_host and url_token:
+            credential = base64.b64encode(f":{url_token}".encode()).decode()
             env.update(build_authorization_header_git_env("Basic", credential))
         return url, env
 

--- a/src/apm_cli/marketplace/ref_resolver.py
+++ b/src/apm_cli/marketplace/ref_resolver.py
@@ -184,9 +184,12 @@ class RefResolver:
     def _git_url_and_env(self, owner_repo: str) -> tuple[str, dict[str, str]]:
         """Build the remote URL and auth environment for one git operation."""
         requested_bearer = self._auth_scheme == "bearer"
-        bearer = requested_bearer and is_azure_devops_hostname(self._host)
+        ado_host = is_azure_devops_hostname(self._host)
+        if requested_bearer and not ado_host:
+            raise ValueError(f"Bearer authentication is not supported for host {self._host}")
+        bearer = requested_bearer and ado_host
         token = None if requested_bearer else self._token
-        if is_azure_devops_hostname(self._host):
+        if ado_host:
             credentials = f"x-access-token:{token}@" if token else ""
             url = f"https://{credentials}{self._host}/{owner_repo}"
         else:

--- a/tests/integration/test_ado_marketplace_check_auth.py
+++ b/tests/integration/test_ado_marketplace_check_auth.py
@@ -1,0 +1,75 @@
+"""Hermetic end-to-end coverage for ADO marketplace source resolution."""
+
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+from urllib.parse import urlparse
+
+from click.testing import CliRunner
+
+from apm_cli.commands.marketplace import marketplace
+from apm_cli.core.auth import AuthResolver
+
+
+def test_marketplace_check_uses_ado_url_and_bearer_auth(monkeypatch, tmp_path) -> None:
+    """The CLI checks an ADO sourceBase with its exact URL and bearer header."""
+    bearer = "test-ado-bearer"
+    sha = "a" * 40
+    (tmp_path / "apm.yml").write_text(
+        """\
+name: ado-marketplace
+description: ADO marketplace regression
+version: 1.0.0
+marketplace:
+  owner:
+    name: Contoso
+  sourceBase: https://dev.azure.com/contoso/platform/_git
+  packages:
+    - name: my-package
+      source: my-package
+      ref: main
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        AuthResolver,
+        "resolve",
+        lambda _self, host, org=None: SimpleNamespace(
+            token=bearer,
+            source="AAD_BEARER_AZ_CLI",
+            auth_scheme="bearer",
+        ),
+    )
+
+    def fake_git(command, **kwargs):
+        parsed = urlparse(command[-1])
+        assert parsed.scheme == "https"
+        assert parsed.hostname == "dev.azure.com"
+        assert parsed.path == "/contoso/platform/_git/my-package"
+        assert parsed.username is None
+        env = kwargs["env"]
+        assert env["GIT_CONFIG_COUNT"] == "1"
+        assert env["GIT_CONFIG_KEY_0"] == "http.extraheader"
+        assert env["GIT_CONFIG_VALUE_0"] == f"Authorization: Bearer {bearer}"
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=f"{sha}\trefs/heads/main\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr("apm_cli.marketplace.ref_resolver.subprocess.run", fake_git)
+
+    result = CliRunner().invoke(marketplace, ["check", "--verbose"])
+
+    assert result.exit_code == 0, result.output
+    printed_urls = [
+        urlparse(token.rstrip(":"))
+        for token in result.output.split()
+        if token.startswith("https://")
+    ]
+    assert [(url.scheme, url.hostname, url.path) for url in printed_urls] == [
+        ("https", "dev.azure.com", "/contoso/platform/_git/my-package")
+    ]

--- a/tests/integration/test_ado_marketplace_e2e.py
+++ b/tests/integration/test_ado_marketplace_e2e.py
@@ -60,7 +60,7 @@ class _RecordingAuthResolver:
 
     def resolve(self, host: str, org: str | None = None):
         self.calls.append((host, org))
-        return SimpleNamespace(token="ado-secret-token", source="ADO_APM_PAT")
+        return SimpleNamespace(token="ado-secret-token", source="ADO_APM_PAT", auth_scheme="basic")
 
 
 def _write_ado_marketplace(tmp_path: Path) -> Path:

--- a/tests/unit/commands/test_marketplace_check.py
+++ b/tests/unit/commands/test_marketplace_check.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import textwrap
 from pathlib import Path  # noqa: F401
+from types import SimpleNamespace
 from unittest.mock import ANY, MagicMock, patch
 
 import pytest
@@ -549,7 +550,10 @@ class TestCheckRefHeadsPrefix:
 
 
 class TestCheckPerHostResolution:
-    @patch("apm_cli.commands.marketplace.check.resolve_token_for_host", return_value="glpat-xyz")
+    @patch(
+        "apm_cli.commands.marketplace.check.resolve_auth_for_host",
+        return_value=SimpleNamespace(token="glpat-xyz", auth_scheme="basic"),
+    )
     @patch("apm_cli.commands.marketplace.check.RefResolver")
     @patch("apm_cli.commands.marketplace.check._load_config_or_exit")
     def test_sourcebase_entry_composes_and_uses_host_token(
@@ -588,12 +592,18 @@ class TestCheckPerHostResolution:
         )
         # resolver bound to that host with that token
         MockResolver.assert_called_once_with(
-            offline=False, host="gitlab.example.com", token="glpat-xyz"
+            offline=False,
+            host="gitlab.example.com",
+            token="glpat-xyz",
+            auth_scheme="basic",
         )
         # ls-remote runs against the composed nested path
         mock_inst.list_remote_refs.assert_called_once_with("group/sub/team/project/my-package")
 
-    @patch("apm_cli.commands.marketplace.check.resolve_token_for_host", return_value="ghp-tok")
+    @patch(
+        "apm_cli.commands.marketplace.check.resolve_auth_for_host",
+        return_value=SimpleNamespace(token="ghp-tok", auth_scheme="basic"),
+    )
     @patch("apm_cli.commands.marketplace.check.RefResolver")
     @patch("apm_cli.commands.marketplace.check._load_config_or_exit")
     def test_host_prefixed_override_uses_that_host(
@@ -629,10 +639,12 @@ class TestCheckPerHostResolution:
         # host-prefixed override carries no sourceBase org hint (org=None),
         # matching the builder's _remote_source_coordinates
         mock_token.assert_called_once_with("github.com", offline=False, org=None, auth_resolver=ANY)
-        MockResolver.assert_called_once_with(offline=False, host="github.com", token="ghp-tok")
+        MockResolver.assert_called_once_with(
+            offline=False, host="github.com", token="ghp-tok", auth_scheme="basic"
+        )
         mock_inst.list_remote_refs.assert_called_once_with("owner/repo")
 
-    @patch("apm_cli.commands.marketplace.check.resolve_token_for_host")
+    @patch("apm_cli.commands.marketplace.check.resolve_auth_for_host")
     @patch("apm_cli.commands.marketplace.check.RefResolver")
     @patch("apm_cli.commands.marketplace.check._load_config_or_exit")
     def test_local_entry_makes_zero_ls_remote_calls(

--- a/tests/unit/marketplace/test_auth_helpers.py
+++ b/tests/unit/marketplace/test_auth_helpers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from apm_cli.marketplace.auth_helpers import resolve_token_for_host
+from apm_cli.marketplace.auth_helpers import resolve_auth_for_host, resolve_token_for_host
 
 
 def test_resolve_token_for_host_offline_returns_none_without_resolver() -> None:
@@ -29,6 +29,27 @@ def test_resolve_token_for_host_returns_token_from_supplied_resolver() -> None:
 
     assert token == "glpat-token"
     resolver.resolve.assert_called_once_with("gitlab.example.com", org="group")
+
+
+def test_resolve_auth_for_host_preserves_bearer_scheme() -> None:
+    """The context-preserving helper returns the resolver result unchanged."""
+    resolver = MagicMock()
+    context = SimpleNamespace(
+        token="ado-bearer",
+        source="AAD_BEARER_AZ_CLI",
+        auth_scheme="bearer",
+    )
+    resolver.resolve.return_value = context
+
+    resolved = resolve_auth_for_host(
+        "dev.azure.com",
+        org="contoso",
+        auth_resolver=resolver,
+    )
+
+    assert resolved is context
+    assert resolved.auth_scheme == "bearer"
+    resolver.resolve.assert_called_once_with("dev.azure.com", org="contoso")
 
 
 def test_resolve_token_for_host_returns_none_when_resolver_raises() -> None:

--- a/tests/unit/marketplace/test_builder.py
+++ b/tests/unit/marketplace/test_builder.py
@@ -1291,7 +1291,30 @@ class TestGetResolverForHostTokenIsolation:
         resolver = builder._get_resolver_for_host("ghe.example.com")
         assert resolver._host == "ghe.example.com"
         assert resolver._token == "ghs_ghe_specific_token"
+        assert resolver._auth_scheme == "basic"
         fake_auth.resolve.assert_called_once_with("ghe.example.com")
+
+    def test_ado_bearer_auth_scheme_reaches_resolver(self, tmp_path: Path) -> None:
+        """ADO bearer contexts retain their scheme for header injection."""
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        yml_path = _write_yml(tmp_path, _BASIC_YML)
+        builder = MarketplaceBuilder(yml_path, BuildOptions(offline=False))
+        fake_auth = MagicMock()
+        fake_auth.resolve.return_value = SimpleNamespace(
+            token="ado_bearer_token",
+            source="AAD_BEARER_AZ_CLI",
+            auth_scheme="bearer",
+        )
+        builder._auth_resolver = fake_auth
+
+        resolver = builder._get_resolver_for_host("dev.azure.com", org="contoso")
+
+        assert resolver._host == "dev.azure.com"
+        assert resolver._token == "ado_bearer_token"
+        assert resolver._auth_scheme == "bearer"
+        fake_auth.resolve.assert_called_once_with("dev.azure.com", org="contoso")
 
     def test_per_host_resolver_is_cached(self, tmp_path: Path) -> None:
         """Repeated lookups for the same host return the same instance."""

--- a/tests/unit/marketplace/test_marketplace_source_base.py
+++ b/tests/unit/marketplace/test_marketplace_source_base.py
@@ -45,7 +45,7 @@ class _RecordingAuthResolver:
 
     def resolve(self, host: str, org: str | None = None):
         self.calls.append((host, org))
-        return SimpleNamespace(token="token", source="test-auth")
+        return SimpleNamespace(token="token", source="test-auth", auth_scheme="basic")
 
 
 def _write(path: Path, content: str) -> Path:

--- a/tests/unit/marketplace/test_ref_resolver.py
+++ b/tests/unit/marketplace/test_ref_resolver.py
@@ -599,3 +599,17 @@ class TestRefResolverTokenInjection:
             assert parsed.hostname == "corp.ghe.com"
             assert parsed.username == "x-access-token"
             assert parsed.path.endswith(".git")
+
+    def test_bearer_auth_rejects_non_ado_host(self) -> None:
+        """Bearer credentials never silently downgrade on unsupported hosts."""
+        resolver = RefResolver(
+            host="gitlab.example.com",
+            token="bearer_token",
+            auth_scheme="bearer",
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=r"Bearer authentication is not supported for host gitlab\.example\.com",
+        ):
+            resolver.list_remote_refs("owner/repo")

--- a/tests/unit/marketplace/test_ref_resolver.py
+++ b/tests/unit/marketplace/test_ref_resolver.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import subprocess
 import time
 import urllib.parse
@@ -609,7 +610,24 @@ class TestRefResolverTokenInjection:
         )
 
         with pytest.raises(
-            ValueError,
-            match=r"Bearer authentication is not supported for host gitlab\.example\.com",
+            GitLsRemoteError,
+            match=r"Bearer authentication is not supported for host 'gitlab\.example\.com'",
         ):
             resolver.list_remote_refs("owner/repo")
+
+    def test_ado_pat_uses_basic_header_without_url_credentials(self) -> None:
+        """ADO PATs stay out of the process-visible remote URL."""
+        resolver = RefResolver(host="dev.azure.com", token="ado_pat")
+        with patch("apm_cli.marketplace.ref_resolver.subprocess.run") as mock_run:
+            mock_run.return_value = _make_completed("aaaa" * 10 + "\trefs/heads/main\n")
+
+            resolver.list_remote_refs("contoso/platform/_git/repo")
+
+        command = mock_run.call_args.args[0]
+        parsed = urllib.parse.urlparse(command[-1])
+        assert parsed.hostname == "dev.azure.com"
+        assert parsed.username is None
+        env = mock_run.call_args.kwargs["env"]
+        assert env["GIT_CONFIG_KEY_0"] == "http.extraheader"
+        expected = base64.b64encode(b":ado_pat").decode()
+        assert env["GIT_CONFIG_VALUE_0"] == f"Authorization: Basic {expected}"


### PR DESCRIPTION
# fix(marketplace): preserve Azure DevOps URL and bearer auth

## TL;DR

Azure DevOps marketplace checks now use the suffix-free `/_git/<repo>` URL that ADO accepts. Marketplace resolution also preserves `AuthContext.auth_scheme`, so Azure CLI credentials reach `git ls-remote` as a bearer header instead of being treated like a PAT.

> [!NOTE]
> Fixes #2119 with a hermetic CLI-level regression test covering both failures in one flow.

## Problem (WHY)

- [x] `apm marketplace check` appended `.git` to ADO `sourceBase` repositories, making ADO resolve a different repository name ([reported failure](https://github.com/microsoft/apm/issues/2119)).
- [x] Marketplace auth reduced `AuthContext` to a token string, discarding the bearer scheme before `git ls-remote` ([reported failure](https://github.com/microsoft/apm/issues/2119)).
- [!] Verbose output described the same invalid `.git` endpoint ([reported output](https://github.com/microsoft/apm/issues/2119)).

## Approach (WHAT)

| # | Fix |
|---:|---|
| 1 | Preserve the complete host auth context through marketplace check and pack resolution. |
| 2 | Build ADO marketplace git URLs without `.git`; retain suffix behavior for other hosts. |
| 3 | Inject ADO bearer credentials with git's `http.extraheader` environment configuration. |
| 4 | Pin the user-visible command flow with a hermetic end-to-end test. |

## Implementation (HOW)

| Area | Change |
|---|---|
| `marketplace/auth_helpers.py` | Adds context-preserving auth resolution while retaining the token-only helper. |
| `marketplace/ref_resolver.py` | Selects host-correct URLs and bearer-safe environments for both ref-listing paths. |
| `commands/marketplace/check.py` | Carries `auth_scheme` into `RefResolver` and prints the suffix-free ADO endpoint. |
| `marketplace/builder.py` | Applies the same auth context to pack-time per-host resolvers. |
| Tests | Exercises CLI loading, source composition, auth routing, URL parsing, bearer injection, and ref parsing. |
| Docs | Updates Starlight, the bundled usage guide, and changelog. |

## Diagrams

Legend: dashed stages are corrected by this PR; the bearer never enters the URL.

```mermaid
flowchart LR
    M["apm.yml sourceBase"] --> C["marketplace check"]
    C --> A["AuthResolver context"]
    A --> R["RefResolver"]
    R --> U["ADO URL without .git"]
    R --> H["Bearer http.extraheader"]
    U --> G["git ls-remote"]
    H --> G
    classDef new stroke-dasharray: 5 5;
    class A,U,H new;
```

## Trade-offs

- **Context preservation over scheme inference.** The resolver receives `auth_scheme`; it does not guess from token contents.
- **Host-specific URL behavior over changing the shared generic builder.** Other git hosts retain `.git` compatibility.
- **Hermetic boundary over live ADO coverage.** Only AuthResolver's result and the external git process are replaced.
- **Unrelated failure left untouched.** The complete suite exposed an existing local-package ownership failure; cleanup semantics are outside #2119.

## Benefits

1. ADO `sourceBase` resolves exactly to `/org/project/_git/repo`, checked with `urllib.parse`.
2. Azure CLI credentials reach git as one bearer header and never appear in the URL.
3. Verbose output reports the same suffix-free endpoint sent to git.
4. URL and auth mutations independently break the regression test.

## Validation

Regression test before and after the fix:

```text
RED:   1 failed in 3.21s
GREEN: 1 passed in 0.34s
```

Mutation-break evidence after independently changing the production URL and auth guards, then restoring them:

```text
MUTATION_RESULTS url=1 auth=1
RESTORED: 1 passed in 0.32s
```

Relevant ADO integration and marketplace unit suites:

```text
229 passed in 4.51s
```

Canonical lint gate:

```text
All checks passed!
1418 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
YAML, file-length, and relative_to guards clean
```

<details><summary>Complete integration-suite evidence</summary>

`bash scripts/test-integration.sh` collected the entire integration directory:

```text
10204 passed, 172 skipped, 16 deselected, 2 xfailed, 2 failed
```

The ADO fixture failure was corrected and passes in the targeted ADO integration run. The remaining failure reproduces independently in unchanged code: `tests/integration/test_intra_package_cleanup.py::TestCrossPackageSharedFileCleanup::test_shared_file_survives_when_other_package_still_deploys_it`.

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | `apm marketplace check` succeeds for an ADO `sourceBase` while signed in through Azure CLI | Secure by default, Vendor-neutral, DevX | `tests/integration/test_ado_marketplace_check_auth.py::test_marketplace_check_uses_ado_url_and_bearer_auth` (regression-trap for #2119) | e2e |
| 2 | ADO marketplace authoring and consumption remains host-preserving | Vendor-neutral | `tests/integration/test_ado_marketplace_e2e.py` | integration |

## How to test

- [ ] Run `uv run --extra dev pytest tests/integration/test_ado_marketplace_check_auth.py -q`; expect one pass without network.
- [ ] Run the relevant marketplace unit suites; expect 229 passes.
- [ ] Run the canonical lint chain; expect ruff, formatter, R0801, and auth-signal checks to pass.
- [ ] With an ADO marketplace and `az login`, run `apm marketplace check --verbose`; expect a suffix-free URL and successful ref check.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
