### PR TITLE
[BUG] Make dependency resolution transactional so a corrected cyclic graph resumes without manual apm_modules deletion

### DIFF
--- a/docs/src/content/docs/troubleshooting/install-failures.md
+++ b/docs/src/content/docs/troubleshooting/install-failures.md
@@ -220,6 +220,8 @@ apm install
 
 The cache short-circuits already-downloaded packages and the integrate phase overwrites partially-deployed files.
 
+If resolution rejects a cyclic dependency graph, fix the package manifests and run `apm install` again. APM rolls back only the package snapshots staged by the rejected resolution, so no manual `apm_modules/` deletion is required.
+
 If files in `apm_modules/` or under target harness directories look corrupt, force a fresh deploy by combining cache bypass with overwrite:
 
 ```bash

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -24,11 +24,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from apm_cli.install.helpers.ref_seed import seed_ref_resolver_from_lockfile
+from apm_cli.install.resolution_staging import transactional_resolution
 from apm_cli.models.apm_package import GitReferenceType, ResolvedReference
 from apm_cli.utils.short_sha import format_short_sha
 
 if TYPE_CHECKING:
     from apm_cli.install.context import InstallContext
+    from apm_cli.install.resolution_staging import ResolutionStagingSession
     from apm_cli.models.dependency.reference import DependencyReference
 
 _logger = logging.getLogger(__name__)
@@ -374,13 +376,9 @@ def _fail_on_resolution_errors(ctx: InstallContext, dependency_graph) -> None:
     raise RuntimeError(f"Dependency resolution failed: {joined_errors}")
 
 
-def _resolve_dependencies(ctx: InstallContext) -> None:
-    """Run ``APMDependencyResolver``, handle errors; populate ``ctx.deps_to_install`` and ``ctx.dependency_graph``.
-
-    Also wires the download callback (which handles transitive package fetching),
-    builds ``ctx.dep_base_dirs``, writes ancillary state to ``ctx``, and cleans up
-    the shared clone cache.
-    """
+@transactional_resolution
+def _resolve_dependencies(ctx: InstallContext, staging_session: ResolutionStagingSession) -> None:
+    """Resolve dependencies and populate the resolution fields on ``ctx``."""
     import threading as _threading
 
     from apm_cli.core.scope import InstallScope
@@ -499,6 +497,7 @@ def _resolve_dependencies(ctx: InstallContext) -> None:
             )
             if not _force_semver_resolve:
                 return install_path
+        staging_session.prepare_path(install_path)
         # F1 (#1116): surface a heartbeat BEFORE the network/copy work so
         # users see the install advancing past silent transitive lookups.
         # Under F7's parallel BFS this callback may run on a worker

--- a/src/apm_cli/install/resolution_staging.py
+++ b/src/apm_cli/install/resolution_staging.py
@@ -1,0 +1,80 @@
+"""Rollback-scoped staging for dependency resolution writes."""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from collections.abc import Callable
+from functools import wraps
+from pathlib import Path
+from typing import Any
+
+from apm_cli.utils.path_security import ensure_path_within, safe_rmtree
+
+
+class ResolutionStagingSession:
+    """Track paths mutated during resolution and restore them on failure."""
+
+    def __init__(self, apm_modules_dir: Path) -> None:
+        """Create an empty staging session rooted below ``apm_modules``."""
+        self._modules_dir = apm_modules_dir
+        self._staging_root = apm_modules_dir / ".apm-resolution-staging" / uuid.uuid4().hex
+        self._backups: dict[Path, Path | None] = {}
+        self._lock = threading.Lock()
+
+    def prepare_path(self, path: Path) -> None:
+        """Record *path* and preserve its pre-resolution contents if present."""
+        resolved = ensure_path_within(path, self._modules_dir)
+        with self._lock:
+            if resolved in self._backups:
+                return
+            backup: Path | None = None
+            if resolved.exists():
+                relative = resolved.relative_to(self._modules_dir.resolve())
+                backup = self._staging_root / relative
+                backup.parent.mkdir(parents=True, exist_ok=True)
+                resolved.replace(backup)
+            self._backups[resolved] = backup
+
+    def commit(self) -> None:
+        """Discard preserved pre-resolution contents after successful validation."""
+        self._remove_staging_root()
+        self._backups.clear()
+
+    def rollback(self) -> None:
+        """Remove session-created paths and restore every replaced path."""
+        with self._lock:
+            for path, backup in reversed(self._backups.items()):
+                if path.exists():
+                    safe_rmtree(path, self._modules_dir)
+                if backup is not None and backup.exists():
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    backup.replace(path)
+            self._remove_staging_root()
+            self._backups.clear()
+
+    def _remove_staging_root(self) -> None:
+        if self._staging_root.exists():
+            safe_rmtree(self._staging_root, self._modules_dir)
+        staging_parent = self._staging_root.parent
+        if staging_parent.exists() and not any(staging_parent.iterdir()):
+            staging_parent.rmdir()
+
+
+ResolveFunction = Callable[[Any, ResolutionStagingSession], None]
+
+
+def transactional_resolution(resolve: ResolveFunction) -> Callable[[Any], None]:
+    """Wrap a resolve operation in a rollback-scoped staging session."""
+
+    @wraps(resolve)
+    def wrapped(ctx: Any) -> None:
+        session = ResolutionStagingSession(ctx.apm_modules_dir)
+        try:
+            resolve(ctx, session)
+        except BaseException:
+            session.rollback()
+            raise
+        session.commit()
+
+    return wrapped

--- a/src/apm_cli/install/resolution_staging.py
+++ b/src/apm_cli/install/resolution_staging.py
@@ -30,7 +30,8 @@ class ResolutionStagingSession:
                 return
             backup: Path | None = None
             if resolved.exists():
-                relative = resolved.relative_to(self._modules_dir.resolve())
+                resolved_base = ensure_path_within(self._modules_dir, self._modules_dir)
+                relative = resolved.relative_to(resolved_base)
                 backup = self._staging_root / relative
                 backup.parent.mkdir(parents=True, exist_ok=True)
                 resolved.replace(backup)

--- a/tests/unit/install/test_resolution_transactionality.py
+++ b/tests/unit/install/test_resolution_transactionality.py
@@ -1,0 +1,96 @@
+"""Regression coverage for transactional dependency resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from apm_cli.cli import cli
+from apm_cli.install.resolution_staging import ResolutionStagingSession
+from apm_cli.models.apm_package import clear_apm_yml_cache
+
+
+def _write_package(path: Path, name: str, dependency: str | None = None) -> None:
+    """Write a local package and one Copilot instruction."""
+    path.mkdir(parents=True, exist_ok=True)
+    dependency_block = ""
+    if dependency is not None:
+        dependency_block = f"dependencies:\n  apm:\n    - path: {dependency}\n"
+    (path / "apm.yml").write_text(
+        f"name: {name}\nversion: 1.0.0\n{dependency_block}",
+        encoding="ascii",
+    )
+    instructions = path / ".apm" / "instructions"
+    instructions.mkdir(parents=True, exist_ok=True)
+    (instructions / f"{name}.instructions.md").write_text(
+        f"# {name}\n",
+        encoding="ascii",
+    )
+
+
+def test_resolution_rollback_restores_replaced_cache_path(tmp_path: Path) -> None:
+    """Rollback must restore a valid cache entry replaced by this attempt."""
+    modules = tmp_path / "apm_modules"
+    package = modules / "_local" / "package-a"
+    package.mkdir(parents=True)
+    marker = package / "marker.txt"
+    marker.write_text("original", encoding="ascii")
+    session = ResolutionStagingSession(modules)
+
+    session.prepare_path(package)
+    package.mkdir(parents=True)
+    marker.write_text("replacement", encoding="ascii")
+    session.rollback()
+
+    assert marker.read_text(encoding="ascii") == "original"
+    assert not (modules / ".apm-resolution-staging").exists()
+
+
+def test_corrected_local_cycle_resumes_without_manual_cache_deletion(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """A rejected local cycle must not leave snapshots that poison the retry."""
+    workspace = tmp_path / "workspace"
+    project = workspace / "project"
+    package_a = workspace / "package-a"
+    package_b = workspace / "package-b"
+    home = workspace / "home"
+    project.mkdir(parents=True)
+    home.mkdir()
+    (project / ".github").mkdir()
+    (project / "apm.yml").write_text(
+        "name: consumer\nversion: 1.0.0\ndependencies:\n  apm:\n    - path: ../package-a\n",
+        encoding="ascii",
+    )
+    _write_package(package_a, "package-a", "../package-b")
+    _write_package(package_b, "package-b", "../package-a")
+
+    monkeypatch.chdir(project)
+    monkeypatch.setenv("HOME", str(home))
+    runner = CliRunner()
+
+    rejected = runner.invoke(
+        cli,
+        ["install", "--target", "copilot", "--verbose"],
+        catch_exceptions=True,
+    )
+
+    assert rejected.exit_code != 0, rejected.output
+    modules = project / "apm_modules"
+    assert not (modules / "_local" / "package-a").exists()
+    assert not (modules / "_local" / "package-b").exists()
+    assert not (project / "apm.lock.yaml").exists()
+
+    _write_package(package_b, "package-b")
+    clear_apm_yml_cache()
+    resumed = runner.invoke(
+        cli,
+        ["install", "--target", "copilot", "--verbose"],
+        catch_exceptions=True,
+    )
+
+    assert resumed.exit_code == 0, resumed.output
+    assert (project / "apm.lock.yaml").is_file()
+    assert (project / ".github" / "instructions" / "package-a.instructions.md").is_file()

--- a/tests/unit/install/test_resolution_transactionality.py
+++ b/tests/unit/install/test_resolution_transactionality.py
@@ -78,6 +78,7 @@ def test_corrected_local_cycle_resumes_without_manual_cache_deletion(
     )
 
     assert rejected.exit_code != 0, rejected.output
+    assert "Circular dependencies detected" in rejected.output
     modules = project / "apm_modules"
     assert not (modules / "_local" / "package-a").exists()
     assert not (modules / "_local" / "package-b").exists()


### PR DESCRIPTION
# fix(install): make dependency resolution transactional

## TL;DR

A failed cyclic dependency resolution now rolls back only the `apm_modules/` paths staged or replaced by that attempt. After the user fixes the source graph, a normal `apm install` succeeds without manually deleting `apm_modules/`, while valid pre-existing cache entries remain protected.

> [!NOTE]
> Fixes #2140. This deliberately does not use a blanket delete-all recovery path.

## Problem (WHY)

- [x] A two-node local cycle correctly exited 1, but left both package snapshots in `apm_modules/`.
- [x] After the source cycle was fixed, the stale snapshots remained authoritative and the next install still exited 1.
- [x] Recovery required `rm -rf apm_modules`, discarding unrelated valid cache entries.
- [!] This violated P6: ["Behavior must be predictable, auditable, and explainable in plain English."](https://github.com/microsoft/apm/blob/main/PRINCIPLES.md#p6----reliability-over-magic)
- [!] A delete-all fix would violate P4: ["No bug fix, hardening, security patch, or refactor lands if it makes those commands harder, slower, more verbose, or more confusing for a new user."](https://github.com/microsoft/apm/blob/main/PRINCIPLES.md#p4----ux-is-the-floor-not-a-trade)

## Approach (WHAT)

| # | Fix | Principle |
|---|---|---|
| 1 | Register every package path before resolution mutates it. | P6 - Reliability over magic |
| 2 | Move replaced content to a session-unique backup and record newly created paths. | Non-destructive, rollback-scoped staging |
| 3 | Commit only after graph validation; on any resolution exception, remove only session-created content and restore backups. | P4 - UX is the floor, not a trade |
| 4 | Keep the staging layer below target adapters and independent of package source type. | P3 - Vendor neutral by construction |

## Implementation (HOW)

| File | Change |
|---|---|
| `src/apm_cli/install/resolution_staging.py` | Adds the thread-safe `ResolutionStagingSession` and transaction decorator. Existing paths are atomically moved to session backups; rollback restores them in reverse order. |
| `src/apm_cli/install/phases/resolve.py` | Wraps dependency resolution in the staging transaction and registers a path only after cache reuse has been ruled out. |
| `tests/unit/install/test_resolution_transactionality.py` | Reproduces #2140 through the real CLI, proves failed resolution is clean, then fixes the source and proves retry succeeds. Also verifies replaced cache content is restored. |
| `docs/src/content/docs/troubleshooting/install-failures.md` | Documents that cyclic-graph retries no longer require manual `apm_modules/` deletion. |

## Diagram

Legend: dashed nodes are the new transaction boundary around existing resolution and validation.

```mermaid
flowchart LR
    S[Source manifests] --> P[Prepare touched path]
    P --> M[Materialize package snapshot]
    M --> V{Graph valid}
    V -->|yes| C[Discard session backups]
    V -->|no| R[Remove new snapshots and restore backups]
    R --> X[Correct source and retry]
    classDef new stroke-dasharray: 5 5;
    class P,C,R new;
```

## Trade-offs

- Chose per-path backup and rollback over deleting all of `apm_modules/`; unrelated valid cache entries are preserved.
- Chose same-filesystem sibling staging under `apm_modules/` over copying the full cache; path replacement stays atomic without cache-sized copy cost.
- Kept package materialization unchanged; authenticated-source resolution, content-hash checks, and valid cache short-circuits retain their existing behavior.
- The transaction covers resolution writes, not later deployment phases; this is the narrow owner locus for #2140.

## Benefits

1. A rejected two-node cycle leaves neither newly staged package snapshot behind.
2. Fixing the source graph allows the next plain install to exit 0 and write the lockfile.
3. Copilot instructions deploy on the retry without manual cache deletion.
4. A pre-existing path replaced during a failed attempt is restored in the regression test.

## Validation

### Scenario evidence

| # | Scenario (user promise) | Principle(s) | Test proving it | Type |
|---|---|---|---|---|
| 1 | Fix a rejected local dependency cycle and rerun install without deleting `apm_modules/`; install succeeds. | DevX, Governed by policy | `tests/unit/install/test_resolution_transactionality.py::test_corrected_local_cycle_resumes_without_manual_cache_deletion` (regression-trap for #2140) | integration |
| 2 | A failed resolution that replaces a valid cache path restores the original content. | Secure by default, Governed by policy | `tests/unit/install/test_resolution_transactionality.py::test_resolution_rollback_restores_replaced_cache_path` | unit |

<details><summary>Test and lint evidence</summary>

Base regression run before production changes:

```text
1 failed in 5.33s
```

Regression after the fix:

```text
2 passed
```

Targeted install suite:

```text
1787 passed in 28.21s
```

CI lint mirror:

```text
All checks passed!
1424 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
YAML, file-length, and relative_to guards passed
```

</details>

## How to test

- [ ] Create local packages A and B where A depends on B and B depends on A; run `apm install --target copilot --verbose` and expect exit 1 with no A/B snapshots retained.
- [ ] Remove B's dependency on A without deleting `apm_modules/`.
- [ ] Run the same install command and expect exit 0.
- [ ] Confirm `apm.lock.yaml` and `.github/instructions/package-a.instructions.md` exist.

Fixes #2140

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
