### PR TITLE
fix(install): preserve ADO bearer auth scheme in semver resolver (#2150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   
 ### Fixed
 
+- Semver resolution now preserves each dependency's authentication scheme, so
+  Azure DevOps bearer credentials are used consistently for tag listing. (#2150)
 - Fresh checkouts with declared consumer targets no longer remain
   `apm audit --ci`-red for files those targets cannot restore: `apm install`
   now removes stale `deployed_files` entries outside the legitimate target

--- a/src/apm_cli/install/helpers/ref_reuse.py
+++ b/src/apm_cli/install/helpers/ref_reuse.py
@@ -32,14 +32,16 @@ def resolve_dep_auth(dep_ref: Any, auth_resolver: Any) -> tuple[str | None, str]
     """Resolve per-dependency authentication for use by ``git ls-remote``.
 
     Uses the same token and scheme the downstream clone will use. Best-effort:
-    on any failure the unauthenticated basic path remains and the downstream
-    clone surfaces the real auth error with its own diagnostic.
+    when no real token is resolved (or on any failure) the unauthenticated
+    basic path remains and the downstream clone surfaces the real auth error
+    with its own diagnostic. A ``bearer`` scheme is only forwarded alongside a
+    non-empty token, so a token-less context never triggers a bearer request.
     """
     if auth_resolver is None:
         return None, "basic"
     try:
         auth_ctx = auth_resolver.resolve_for_dep(dep_ref)
-        if auth_ctx is None:
+        if auth_ctx is None or not auth_ctx.token:
             return None, "basic"
         return auth_ctx.token, auth_ctx.auth_scheme
     except Exception:

--- a/src/apm_cli/install/helpers/ref_reuse.py
+++ b/src/apm_cli/install/helpers/ref_reuse.py
@@ -28,22 +28,22 @@ def _token_fingerprint(token: str | None) -> str | None:
     return "sha256:" + hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
 
 
-def resolve_dep_token(dep_ref: Any, auth_resolver: Any) -> str | None:
-    """Resolve the per-dep token via AuthResolver for use by ``git ls-remote``.
+def resolve_dep_auth(dep_ref: Any, auth_resolver: Any) -> tuple[str | None, str]:
+    """Resolve per-dependency authentication for use by ``git ls-remote``.
 
-    Uses the same credential source the downstream clone will use. Without
-    this threading, ls-remote on a private repo would rely on the host's git
-    credential helper (present on dev laptops, absent in CI). Best-effort:
-    on any failure the unauth path remains and the downstream clone surfaces
-    the real auth error with its own diagnostic.
+    Uses the same token and scheme the downstream clone will use. Best-effort:
+    on any failure the unauthenticated basic path remains and the downstream
+    clone surfaces the real auth error with its own diagnostic.
     """
     if auth_resolver is None:
-        return None
+        return None, "basic"
     try:
         auth_ctx = auth_resolver.resolve_for_dep(dep_ref)
-        return auth_ctx.token if auth_ctx is not None else None
+        if auth_ctx is None:
+            return None, "basic"
+        return auth_ctx.token, auth_ctx.auth_scheme
     except Exception:
-        return None
+        return None, "basic"
 
 
 def get_shared_ref_resolver(
@@ -51,13 +51,15 @@ def get_shared_ref_resolver(
     token: str | None,
     cache: dict[Any, Any] | None,
     lock: Any = None,
+    *,
+    auth_scheme: str = "basic",
 ) -> Any:
-    """Return a ``RefResolver`` for ``(host, token)``, reused across a run.
+    """Return a ``RefResolver`` for ``(host, token, auth_scheme)``, reused across a run.
 
     When ``cache`` is provided, resolvers are memoized so the second and
     later deps from a repo reuse the instance (and its ref cache). The cache
-    key is ``(normalized_host, fingerprint(token))`` -- a non-reversible token
-    fingerprint, never the raw PAT, so the credential is not exposed via the
+    key includes ``(normalized_host, fingerprint(token), auth_scheme)``. The
+    fingerprint is non-reversible and never stores the raw credential in the
     context object this cache lives on. ``host`` is normalized to ``None``
     meaning "use RefResolver default (github.com)", so a dep written with an
     explicit ``host='github.com'`` and one with no host collapse to the same
@@ -78,19 +80,19 @@ def get_shared_ref_resolver(
     canonical_host = host if host and host != _DEFAULT_HOST else None
 
     if cache is None:
-        return RefResolver(host=host, token=token)
+        return RefResolver(host=host, token=token, auth_scheme=auth_scheme)
 
-    key = (canonical_host, _token_fingerprint(token))
+    key = (canonical_host, _token_fingerprint(token), auth_scheme)
     if lock is not None:
         with lock:
             resolver = cache.get(key)
             if resolver is None:
-                resolver = RefResolver(host=host, token=token)
+                resolver = RefResolver(host=host, token=token, auth_scheme=auth_scheme)
                 cache[key] = resolver
             return resolver
 
     resolver = cache.get(key)
     if resolver is None:
-        resolver = RefResolver(host=host, token=token)
+        resolver = RefResolver(host=host, token=token, auth_scheme=auth_scheme)
         cache[key] = resolver
     return resolver

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -104,14 +104,12 @@ def _maybe_resolve_git_semver(
     ----
     When ``auth_resolver`` is supplied, the per-dep ``AuthContext`` is
     resolved before constructing :class:`RefResolver`; its token and
-    authentication scheme are forwarded to ``git ls-remote``. This mirrors
-    the auth path used by the clone step downstream, so a
-    private-repo semver dep that clones successfully also enumerates
-    its tags successfully in CI environments where ``GITHUB_APM_PAT`` /
-    ``ADO_APM_PAT`` are the only credential source (no system
-    credential helper available). Passing ``auth_resolver=None`` (the
-    legacy path) preserves the previous unauthenticated behaviour for
-    public repos and for callers that intentionally skip auth.
+    authentication scheme are forwarded to ``git ls-remote``, mirroring
+    the clone step downstream. A private-repo semver dep that clones
+    successfully then also enumerates its tags in CI environments where
+    ``GITHUB_APM_PAT`` / ``ADO_APM_PAT`` are the only credential source.
+    Passing ``auth_resolver=None`` preserves the previous unauthenticated
+    behaviour for public repos and callers that intentionally skip auth.
     """
     # Only git-source deps with a semver-range reference are eligible.
     if dep_ref.is_local:

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -103,9 +103,9 @@ def _maybe_resolve_git_semver(
     Auth
     ----
     When ``auth_resolver`` is supplied, the per-dep ``AuthContext`` is
-    resolved before constructing :class:`RefResolver` and its token is
-    embedded in the ``https://`` URL used by ``git ls-remote``. This
-    mirrors the auth path used by the clone step downstream, so a
+    resolved before constructing :class:`RefResolver`; its token and
+    authentication scheme are forwarded to ``git ls-remote``. This mirrors
+    the auth path used by the clone step downstream, so a
     private-repo semver dep that clones successfully also enumerates
     its tags successfully in CI environments where ``GITHUB_APM_PAT`` /
     ``ADO_APM_PAT`` are the only credential source (no system
@@ -157,14 +157,18 @@ def _maybe_resolve_git_semver(
     from apm_cli.deps.git_semver_resolver import GitSemverResolver
     from apm_cli.install.helpers.ref_reuse import (
         get_shared_ref_resolver,
-        resolve_dep_token,
+        resolve_dep_auth,
     )
 
-    # Reuse one RefResolver per (host, token) so same-repo deps share a
+    # Reuse one RefResolver per (host, token, scheme) so same-repo deps share a
     # single ls-remote tag listing (see helpers.ref_reuse for rationale).
-    token = resolve_dep_token(dep_ref, auth_resolver)
+    token, auth_scheme = resolve_dep_auth(dep_ref, auth_resolver)
     ref_resolver = get_shared_ref_resolver(
-        dep_ref.host, token, ref_resolver_cache, ref_resolver_cache_lock
+        dep_ref.host,
+        token,
+        ref_resolver_cache,
+        ref_resolver_cache_lock,
+        auth_scheme=auth_scheme,
     )
     resolver = GitSemverResolver(ref_resolver)
     return resolver.resolve(

--- a/src/apm_cli/marketplace/resolver.py
+++ b/src/apm_cli/marketplace/resolver.py
@@ -720,16 +720,20 @@ def resolve_plugin_source(
         raise ValueError(f"Plugin '{plugin.name}' has unsupported source type: '{source_type}'")
 
 
-def _extract_token(auth_resolver: object | None, host: str, org: str | None = None) -> str | None:
-    """Extract a token from the auth resolver for the given host."""
+def _extract_auth(
+    auth_resolver: object | None, host: str, org: str | None = None
+) -> tuple[str | None, str]:
+    """Extract the token and scheme from the auth resolver for the given host."""
     if auth_resolver is None:
-        return None
+        return None, "basic"
     try:
         ctx = auth_resolver.resolve(host, org=org)  # type: ignore[union-attr]
-        return ctx.token if ctx and ctx.token else None
+        if ctx is None:
+            return None, "basic"
+        return ctx.token, ctx.auth_scheme
     except Exception as exc:
-        logger.debug("Could not extract token for host '%s': %s", host, type(exc).__name__)
-        return None
+        logger.debug("Could not extract auth for host '%s': %s", host, type(exc).__name__)
+        return None, "basic"
 
 
 def resolve_marketplace_plugin(
@@ -929,7 +933,7 @@ def resolve_marketplace_plugin(
             from .version_resolver import resolve_version_constraint
 
             owner_repo = f"{source.owner}/{source.repo}"
-            token = _extract_token(auth_resolver, source.host, org=source.owner)
+            token, auth_scheme = _extract_auth(auth_resolver, source.host, org=source.owner)
             try:
                 tag_name, _sha = resolve_version_constraint(
                     plugin_name,
@@ -937,6 +941,7 @@ def resolve_marketplace_plugin(
                     version_spec,
                     host=source.host,
                     token=token,
+                    auth_scheme=auth_scheme,
                 )
                 canonical = f"{base}#{tag_name}"
                 logger.debug(

--- a/src/apm_cli/marketplace/resolver.py
+++ b/src/apm_cli/marketplace/resolver.py
@@ -728,7 +728,7 @@ def _extract_auth(
         return None, "basic"
     try:
         ctx = auth_resolver.resolve(host, org=org)  # type: ignore[union-attr]
-        if ctx is None:
+        if ctx is None or not ctx.token:
             return None, "basic"
         return ctx.token, ctx.auth_scheme
     except Exception as exc:

--- a/src/apm_cli/marketplace/version_resolver.py
+++ b/src/apm_cli/marketplace/version_resolver.py
@@ -54,6 +54,7 @@ def resolve_version_constraint(
     tag_pattern: str = DEFAULT_TAG_PATTERN,
     host: str | None = None,
     token: str | None = None,
+    auth_scheme: str = "basic",
 ) -> tuple[str, str]:
     """Resolve a semver range to the highest matching git tag.
 
@@ -70,6 +71,7 @@ def resolve_version_constraint(
             ``"{name}--v{version}"``.
         host: Git host for ``git ls-remote``. Defaults to github.com.
         token: Optional auth token for private repos.
+        auth_scheme: Authentication scheme from ``AuthContext``.
 
     Returns:
         ``(tag_name, commit_sha)`` of the highest matching version.
@@ -80,7 +82,7 @@ def resolve_version_constraint(
     pinned_pattern = tag_pattern.replace("{name}", plugin_name)
     tag_rx = build_tag_regex(pinned_pattern)
 
-    resolver = RefResolver(host=host, token=token)
+    resolver = RefResolver(host=host, token=token, auth_scheme=auth_scheme)
     try:
         refs = resolver.list_remote_refs(owner_repo)
     finally:

--- a/tests/unit/install/phases/test_resolve_ref_resolver_reuse.py
+++ b/tests/unit/install/phases/test_resolve_ref_resolver_reuse.py
@@ -15,6 +15,7 @@ from urllib.parse import urlparse
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "src"))
 
+from apm_cli.install.helpers.ref_reuse import resolve_dep_auth
 from apm_cli.install.phases.resolve import _maybe_resolve_git_semver
 from apm_cli.models.dependency.reference import DependencyReference
 
@@ -287,3 +288,33 @@ def test_semver_resolution_preserves_bearer_and_basic_auth_schemes():
         for key, value in github_kwargs["env"].items()
         if key.startswith("GIT_CONFIG_VALUE_") and value.startswith("Authorization:")
     }
+
+
+def test_resolve_dep_auth_falls_back_to_basic_when_token_missing():
+    """A token-less context must not forward a bearer scheme.
+
+    Forwarding ``auth_scheme="bearer"`` with an empty token would make
+    RefResolver attempt a bearer request on what is effectively the
+    unauthenticated public-repo path. The resolver must degrade to
+    ``(None, "basic")`` so the legacy best-effort behaviour is preserved.
+    """
+
+    class _NoTokenBearerResolver:
+        def resolve_for_dep(self, dep_ref):
+            return SimpleNamespace(token=None, auth_scheme="bearer")
+
+    class _EmptyTokenBearerResolver:
+        def resolve_for_dep(self, dep_ref):
+            return SimpleNamespace(token="", auth_scheme="bearer")
+
+    dep = DependencyReference(
+        host="dev.azure.com",
+        repo_url="example/project/_git/package",
+        reference="^1.0.0",
+        source="git",
+        explicit_scheme="https",
+    )
+
+    assert resolve_dep_auth(dep, _NoTokenBearerResolver()) == (None, "basic")
+    assert resolve_dep_auth(dep, _EmptyTokenBearerResolver()) == (None, "basic")
+    assert resolve_dep_auth(dep, None) == (None, "basic")

--- a/tests/unit/install/phases/test_resolve_ref_resolver_reuse.py
+++ b/tests/unit/install/phases/test_resolve_ref_resolver_reuse.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import os
 import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "..", "src"))
 
@@ -32,8 +34,8 @@ def _patched_resolver_env():
     made = []
 
     class _FakeRefResolver:
-        def __init__(self, *, host=None, token=None):
-            made.append((host, token))
+        def __init__(self, *, host=None, token=None, auth_scheme="basic"):
+            made.append((host, token, auth_scheme))
 
     fake_semver = MagicMock()
     fake_semver.return_value.resolve.return_value = "RESOLUTION"
@@ -102,12 +104,12 @@ def test_concurrent_same_repo_deps_share_one_resolver_under_lock():
     errors_lock = threading.Lock()
 
     class _SlowFakeRefResolver:
-        def __init__(self, *, host=None, token=None):
+        def __init__(self, *, host=None, token=None, auth_scheme="basic"):
             # Small delay to widen the construction window. With a working
             # lock only one thread ever reaches here; without it, several
             # would slip in during this sleep and append multiple entries.
             time.sleep(0.02)
-            made.append((host, token))
+            made.append((host, token, auth_scheme))
 
     fake_semver = MagicMock()
     fake_semver.return_value.resolve.return_value = "R"
@@ -187,8 +189,9 @@ def test_cache_key_does_not_contain_raw_token():
     cache: dict = {}
 
     class _FakeRefResolver:
-        def __init__(self, *, host=None, token=None):
+        def __init__(self, *, host=None, token=None, auth_scheme="basic"):
             self.token = token
+            self.auth_scheme = auth_scheme
 
     with patch("apm_cli.marketplace.ref_resolver.RefResolver", _FakeRefResolver):
         resolver = get_shared_ref_resolver("github.com", secret, cache)
@@ -202,3 +205,85 @@ def test_cache_key_does_not_contain_raw_token():
     with patch("apm_cli.marketplace.ref_resolver.RefResolver", _FakeRefResolver):
         get_shared_ref_resolver("github.com", "ghp_a_different_token_000000", cache)
     assert len(cache) == 2
+
+
+def test_cache_separates_basic_and_bearer_for_same_host_and_token():
+    """The scheme is part of resolver identity even when credentials match."""
+    from apm_cli.install.helpers.ref_reuse import get_shared_ref_resolver
+
+    class _FakeRefResolver:
+        def __init__(self, *, host=None, token=None, auth_scheme="basic"):
+            self.auth_scheme = auth_scheme
+
+    cache: dict = {}
+    with patch("apm_cli.marketplace.ref_resolver.RefResolver", _FakeRefResolver):
+        basic = get_shared_ref_resolver("dev.azure.com", "dummy", cache)
+        bearer = get_shared_ref_resolver("dev.azure.com", "dummy", cache, auth_scheme="bearer")
+
+    assert basic is not bearer
+    assert {basic.auth_scheme, bearer.auth_scheme} == {"basic", "bearer"}
+    assert len(cache) == 2
+
+
+def test_semver_resolution_preserves_bearer_and_basic_auth_schemes():
+    """Semver tag listing must use the complete per-dependency auth context."""
+    bearer_token = "dummy-ado-bearer"
+    basic_token = "dummy-github-basic"
+    calls = []
+
+    class _AuthResolver:
+        def resolve_for_dep(self, dep_ref):
+            if dep_ref.host == "dev.azure.com":
+                return SimpleNamespace(token=bearer_token, auth_scheme="bearer")
+            return SimpleNamespace(token=basic_token, auth_scheme="basic")
+
+    def _run(args, **kwargs):
+        calls.append((args, kwargs))
+        return SimpleNamespace(
+            returncode=0,
+            stdout=f"{'a' * 40}\trefs/tags/v1.0.0\n",
+            stderr="",
+        )
+
+    deps = [
+        DependencyReference(
+            host="dev.azure.com",
+            repo_url="example/project/_git/package",
+            reference="^1.0.0",
+            source="git",
+            explicit_scheme="https",
+        ),
+        DependencyReference(
+            host="github.com",
+            repo_url="example/package",
+            reference="^1.0.0",
+            source="git",
+            explicit_scheme="https",
+        ),
+    ]
+
+    cache = {}
+    with patch("apm_cli.marketplace.ref_resolver.subprocess.run", side_effect=_run):
+        for dep in deps:
+            _maybe_resolve_git_semver(
+                dep_ref=dep,
+                existing_lockfile=None,
+                update_refs=True,
+                auth_resolver=_AuthResolver(),
+                ref_resolver_cache=cache,
+            )
+
+    assert {resolver._auth_scheme for resolver in cache.values()} == {"basic", "bearer"}
+    ado_args, ado_kwargs = calls[0]
+    github_args, github_kwargs = calls[1]
+    ado_auth_values = {
+        value for key, value in ado_kwargs["env"].items() if key.startswith("GIT_CONFIG_VALUE_")
+    }
+    assert ado_auth_values == {f"Authorization: Bearer {bearer_token}"}
+    assert urlparse(ado_args[-1]).username is None
+    assert urlparse(github_args[-1]).password == basic_token
+    assert not {
+        value
+        for key, value in github_kwargs["env"].items()
+        if key.startswith("GIT_CONFIG_VALUE_") and value.startswith("Authorization:")
+    }

--- a/tests/unit/marketplace/test_version_resolver.py
+++ b/tests/unit/marketplace/test_version_resolver.py
@@ -113,7 +113,7 @@ class TestResolveVersionConstraint(unittest.TestCase):
         with self.assertRaises(NoMatchingVersionError):
             resolve_version_constraint("secrets-vault", "acme/plugins", "~1.0.0")
 
-    def test_passes_host_and_token(self, MockResolver):
+    def test_passes_host_token_and_auth_scheme(self, MockResolver):
         refs = _make_refs("1.0.0", plugin_name="my-plugin")
         MockResolver.return_value.list_remote_refs.return_value = refs
 
@@ -121,10 +121,15 @@ class TestResolveVersionConstraint(unittest.TestCase):
             "my-plugin",
             "owner/repo",
             "^1.0.0",
-            host="ghes.example.com",
-            token="ghp_secret",
+            host="dev.azure.com",
+            token="dummy-bearer",
+            auth_scheme="bearer",
         )
-        MockResolver.assert_called_once_with(host="ghes.example.com", token="ghp_secret")
+        MockResolver.assert_called_once_with(
+            host="dev.azure.com",
+            token="dummy-bearer",
+            auth_scheme="bearer",
+        )
 
     def test_resolver_closed_after_use(self, MockResolver):
         refs = _make_refs("1.0.0", plugin_name="my-plugin")


### PR DESCRIPTION
# fix(install): preserve ADO bearer auth scheme in semver resolver

## TL;DR

Semver resolution now forwards the complete resolved authentication metadata instead of dropping `AuthContext.auth_scheme`. Azure DevOps dependencies authenticated through Azure CLI therefore list tags with a Bearer header, while GitHub basic authentication remains unchanged.

> [!IMPORTANT]
> This closes the confirmed install/update failure in #2150 without changing credential resolution order or introducing a new auth boundary.

## Problem

- [x] `resolve_dep_token()` retained the token but discarded its scheme, so ADO bearer credentials reached `RefResolver` as Basic auth.
- [x] The failure occurred during `git ls-remote`, before the already-correct clone path could run.
- [!] Resolver cache identity omitted the scheme, allowing basic and bearer resolvers with the same host/token to be conflated.
- [!] The standalone marketplace version resolver had the same constructor omission.

Issue evidence: [#2150](https://github.com/microsoft/apm/issues/2150).

## Fix

| Area | Change |
|---|---|
| Install semver auth | Resolve and forward `(token, auth_scheme)` from the existing `AuthContext`. |
| Resolver reuse | Key the run-scoped cache by canonical host, token fingerprint, and auth scheme. |
| Marketplace versions | Forward the resolved scheme into `resolve_version_constraint()` and `RefResolver`. |
| Privacy | Keep raw credentials out of cache keys; only the existing truncated SHA-256 fingerprint is stored. |
| Regression coverage | Exercise ADO bearer and GitHub basic tag listing with dummy tokens and mocked subprocess I/O. |

## Implementation

- **`src/apm_cli/install/helpers/ref_reuse.py`** - Carries token and scheme together and includes the scheme in resolver identity.
- **`src/apm_cli/install/phases/resolve.py`** - Forwards both values into the shared semver resolver.
- **`src/apm_cli/marketplace/resolver.py`** - Extracts complete auth metadata for marketplace version constraints.
- **`src/apm_cli/marketplace/version_resolver.py`** - Passes `auth_scheme` to `RefResolver`.
- **Resolver tests** - Prove Bearer header injection, unchanged GitHub basic URL auth, cache separation, and marketplace constructor wiring.
- **`CHANGELOG.md`** - Records the fix under `[Unreleased]`.

## Diagram

Legend: dashed nodes are the propagation points changed by this PR; credential selection remains owned by `AuthResolver`.

```mermaid
flowchart LR
    A[AuthResolver] --> B[AuthContext]
    B --> C[resolve_dep_auth]
    C --> D[RefResolver cache key]
    D --> E[RefResolver]
    E --> F[git ls-remote]
    B --> G[marketplace version resolver]
    G --> E
    classDef new stroke-dasharray: 5 5;
    class C,D,G new;
```

## Trade-offs

- A small `(token, scheme)` pair is forwarded rather than passing `AuthContext` into transport code, preserving the existing AuthResolver-to-transport boundary.
- Authentication failures retain the prior best-effort fallback to unauthenticated basic behavior; this PR does not redesign error handling.

## Benefits

1. ADO semver dependencies using Azure CLI authentication send exactly one Bearer authorization header during tag listing.
2. GitHub basic dependencies continue embedding the dummy/basic credential in the HTTPS URL path used today.
3. Basic and bearer resolver instances cannot share a cache bucket for the same host and token.
4. Cache keys continue to exclude raw token values.

## Test

<details open><summary>Regression and resolver suites</summary>

```text
28 passed in 1.20s
49 passed, 18213 deselected in 6.12s
93 passed in 1.01s
1414 passed in 8.63s
```

</details>

<details><summary>CI lint mirror</summary>

```text
All checks passed!
1422 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
[+] CI source guards clean
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|---|---|---|---|
| 1 | `apm install` resolves an ADO semver dependency with Azure CLI bearer auth instead of downgrading it to Basic | Secure by default, Vendor-neutral, DevX | `tests/unit/install/phases/test_resolve_ref_resolver_reuse.py::test_semver_resolution_preserves_bearer_and_basic_auth_schemes` (regression-trap for #2150) | unit |
| 2 | GitHub semver dependencies continue using basic authentication | Vendor-neutral, DevX | `tests/unit/install/phases/test_resolve_ref_resolver_reuse.py::test_semver_resolution_preserves_bearer_and_basic_auth_schemes` | unit |
| 3 | Marketplace version constraints preserve an explicitly resolved bearer scheme | Vendor-neutral | `tests/unit/marketplace/test_version_resolver.py::TestResolveVersionConstraint::test_passes_host_token_and_auth_scheme` | unit |

## How to test

- [ ] Run `uv run --extra dev python -m pytest tests/unit/install/phases/test_resolve_ref_resolver_reuse.py tests/unit/marketplace/test_version_resolver.py -q`; expect 28 passing tests.
- [ ] Run `uv run --extra dev python -m pytest tests/unit -q -k "ref_reuse or refresolver or auth_scheme or version_resolver"`; expect 49 passing tests.
- [ ] Run `bash scripts/lint-auth-signals.sh`; expect `[+] auth-signal lint clean`.

apm-spec-waiver: propagates existing AuthContext.auth_scheme through the semver resolver; no new OpenAPM artifact or wire behavior.

Closes #2150

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
