### PR TITLE
fix(mcp): purge APM-managed MCP servers from dropped targets on contraction (#2149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   
 ### Fixed
 
+- Contracting the active target set now removes APM-managed MCP server
+  entries from dropped targets while preserving user-authored servers and
+  unrelated native config. (#2149)
 - Fresh checkouts with declared consumer targets no longer remain
   `apm audit --ci`-red for files those targets cannot restore: `apm install`
   now removes stale `deployed_files` entries outside the legitimate target

--- a/docs/src/content/docs/consumer/install-mcp-servers.md
+++ b/docs/src/content/docs/consumer/install-mcp-servers.md
@@ -128,6 +128,10 @@ the gate took effect:
 [i] Skipped MCP config for claude, codex  (active targets: copilot)
 ```
 
+On reinstall, removing a previously configured target also removes the
+APM-managed server entries from that target's native config. User-authored
+servers and unrelated JSON or TOML settings remain unchanged.
+
 This single rule replaces two older ones that used to coexist:
 
 - A "directory opt-in" carve-out for Cursor / Gemini / OpenCode -- now

--- a/docs/src/content/docs/reference/lockfile-spec.md
+++ b/docs/src/content/docs/reference/lockfile-spec.md
@@ -99,6 +99,12 @@ mcp_configs:
   transitive-server:
     type: stdio
     command: local-server
+mcp_target_servers:
+  codex:
+    - github
+  copilot:
+    - github
+    - transitive-server
 mcp_config_provenance:
   transitive-server: local-package
 lsp_servers:
@@ -124,6 +130,7 @@ local_deployed_file_hashes:
 | `dependencies` | list | yes | Resolved APM packages. See [per-entry fields](#per-entry-fields). |
 | `mcp_servers` | list of strings | no | Names of MCP servers managed as of the last install or update, including transitively contributed servers. |
 | `mcp_configs` | map | no | `server_name -> resolved config dict` baseline used to detect MCP drift. |
+| `mcp_target_servers` | map of string lists | no | `target -> server names` for MCP entries APM successfully wrote. Reinstall uses this ownership record to remove only APM-managed entries when a target is dropped. |
 | `mcp_config_provenance` | map | no | `server_name -> declaring package` for transitively contributed MCP servers. Used by `config-consistency` to distinguish transitive entries from orphans. |
 | `lsp_servers` | list of strings | no | Names of LSP servers declared in the manifest as of the last install or update. |
 | `lsp_configs` | map | no | `server_name -> resolved config dict` baseline used to detect LSP drift. |

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -1749,12 +1749,14 @@ def _install_apm_packages(ctx, outcome):
     old_mcp_servers: builtins.set = builtins.set()
     old_mcp_configs: builtins.dict = {}
     old_mcp_provenance: builtins.dict = {}
+    old_mcp_target_servers: builtins.dict = {}
     _lock_path = get_lockfile_path(ctx.apm_dir)
     _existing_lock = LockFile.read(_lock_path)
     if _existing_lock:
         old_mcp_servers = builtins.set(_existing_lock.mcp_servers)
         old_mcp_configs = builtins.dict(_existing_lock.mcp_configs)
         old_mcp_provenance = builtins.dict(_existing_lock.mcp_config_provenance)
+        old_mcp_target_servers = builtins.dict(_existing_lock.mcp_target_servers)
 
     # Enter the APM install path when there are deps, local .apm/ primitives
     # (#714), OR orphan deps in the lockfile to clean up (manifest emptied).
@@ -1875,6 +1877,7 @@ def _install_apm_packages(ctx, outcome):
             old_mcp_servers=old_mcp_servers,
             old_mcp_configs=old_mcp_configs,
             old_mcp_provenance=old_mcp_provenance,
+            old_mcp_target_servers=old_mcp_target_servers,
             project_root=ctx.project_root,
             user_scope=(ctx.scope is InstallScope.USER),
             should_install=should_install_mcp,

--- a/src/apm_cli/commands/update.py
+++ b/src/apm_cli/commands/update.py
@@ -224,10 +224,12 @@ def _run_mcp_lsp_integration(
     old_mcp_servers: set = set()
     old_mcp_configs: dict = {}
     old_mcp_provenance: dict = {}
+    old_mcp_target_servers: dict = {}
     if existing_lock:
         old_mcp_servers = set(existing_lock.mcp_servers)
         old_mcp_configs = dict(existing_lock.mcp_configs)
         old_mcp_provenance = dict(existing_lock.mcp_config_provenance)
+        old_mcp_target_servers = dict(existing_lock.mcp_target_servers)
 
     apm_modules_path = get_modules_dir(scope)
     user_scope = scope is InstallScope.USER
@@ -241,6 +243,7 @@ def _run_mcp_lsp_integration(
             old_mcp_servers=old_mcp_servers,
             old_mcp_configs=old_mcp_configs,
             old_mcp_provenance=old_mcp_provenance,
+            old_mcp_target_servers=old_mcp_target_servers,
             project_root=project_root,
             user_scope=user_scope,
             should_install=True,

--- a/src/apm_cli/deps/lockfile.py
+++ b/src/apm_cli/deps/lockfile.py
@@ -547,6 +547,7 @@ class LockFile:
     dependencies: dict[str, LockedDependency] = field(default_factory=dict)
     mcp_servers: list[str] = field(default_factory=list)
     mcp_configs: dict[str, dict] = field(default_factory=dict)
+    mcp_target_servers: dict[str, list[str]] = field(default_factory=dict)
     # Provenance for transitively-contributed MCP servers: name -> declaring
     # package identity. Only servers NOT declared in the root manifest's mcp:
     # block appear here (absent == direct, mirroring the dependency-side
@@ -635,6 +636,11 @@ class LockFile:
                 data["mcp_servers"] = sorted(self.mcp_servers)
             if self.mcp_configs:
                 data["mcp_configs"] = dict(sorted(self.mcp_configs.items()))
+            if self.mcp_target_servers:
+                data["mcp_target_servers"] = {
+                    target: sorted(servers)
+                    for target, servers in sorted(self.mcp_target_servers.items())
+                }
             if self.mcp_config_provenance:
                 data["mcp_config_provenance"] = dict(sorted(self.mcp_config_provenance.items()))
             if self.lsp_servers:
@@ -677,6 +683,10 @@ class LockFile:
             lock.add_dependency(LockedDependency.from_dict(dep_data))
         lock.mcp_servers = list(data.get("mcp_servers", []))
         lock.mcp_configs = dict(data.get("mcp_configs") or {})
+        lock.mcp_target_servers = {
+            target: list(servers)
+            for target, servers in (data.get("mcp_target_servers") or {}).items()
+        }
         lock.mcp_config_provenance = dict(data.get("mcp_config_provenance") or {})
         lock.lsp_servers = list(data.get("lsp_servers", []))
         lock.lsp_configs = dict(data.get("lsp_configs") or {})
@@ -832,6 +842,8 @@ class LockFile:
         if sorted(self.mcp_servers) != sorted(other.mcp_servers):
             return False
         if self.mcp_configs != other.mcp_configs:
+            return False
+        if self.mcp_target_servers != other.mcp_target_servers:
             return False
         if self.mcp_config_provenance != other.mcp_config_provenance:
             return False

--- a/src/apm_cli/install/mcp/integration.py
+++ b/src/apm_cli/install/mcp/integration.py
@@ -21,6 +21,7 @@ def run_mcp_integration(  # noqa: PLR0913
     old_mcp_servers: builtins.set,
     old_mcp_configs: builtins.dict,
     old_mcp_provenance: builtins.dict,
+    old_mcp_target_servers: builtins.dict | None = None,
     project_root: Path,
     user_scope: bool,
     should_install: bool,
@@ -54,6 +55,7 @@ def run_mcp_integration(  # noqa: PLR0913
         old_mcp_configs: MCP server configs from the lockfile before this run.
         old_mcp_provenance: Transitive MCP provenance from the lockfile before
             this run.
+        old_mcp_target_servers: APM-owned server names previously written per target.
         project_root: Project root directory.
         user_scope: If True, write to user-scope runtime config paths.
         should_install: Whether MCP integration should run.
@@ -134,6 +136,10 @@ def run_mcp_integration(  # noqa: PLR0913
         mcp_apm_config["target"] = apm_package.target
 
     if should_install and mcp_deps:
+        old_mcp_target_servers = old_mcp_target_servers or {}
+        managed_target_servers = {
+            target: builtins.set(servers) for target, servers in old_mcp_target_servers.items()
+        }
         mcp_count = MCPIntegrator.install(
             mcp_deps,
             runtime,
@@ -146,10 +152,22 @@ def run_mcp_integration(  # noqa: PLR0913
             explicit_target=explicit_target,
             diagnostics=diagnostics,
             scope=scope,
+            managed_target_servers=managed_target_servers,
         )
         new_mcp_servers = MCPIntegrator.get_server_names(mcp_deps)
         new_mcp_configs = MCPIntegrator.get_server_configs(mcp_deps)
         new_mcp_provenance = MCPIntegrator.get_server_provenance(mcp_deps)
+
+        for removed_target in sorted(
+            builtins.set(old_mcp_target_servers) - builtins.set(managed_target_servers)
+        ):
+            MCPIntegrator.remove_stale(
+                builtins.set(old_mcp_target_servers[removed_target]),
+                runtime=removed_target,
+                project_root=project_root,
+                user_scope=user_scope,
+                scope=scope,
+            )
 
         # Remove stale MCP servers that are no longer needed
         stale_servers = old_mcp_servers - new_mcp_servers
@@ -168,6 +186,7 @@ def run_mcp_integration(  # noqa: PLR0913
             new_mcp_servers,
             lock_path,
             mcp_configs=new_mcp_configs,
+            mcp_target_servers=managed_target_servers,
             mcp_config_provenance=new_mcp_provenance,
         )
     elif should_install and not mcp_deps:
@@ -182,7 +201,11 @@ def run_mcp_integration(  # noqa: PLR0913
                 scope=scope,
             )
             MCPIntegrator.update_lockfile(
-                builtins.set(), lock_path, mcp_configs={}, mcp_config_provenance={}
+                builtins.set(),
+                lock_path,
+                mcp_configs={},
+                mcp_target_servers={},
+                mcp_config_provenance={},
             )
         logger.verbose_detail("No MCP dependencies found in apm.yml")
     elif not should_install and old_mcp_servers:
@@ -192,6 +215,7 @@ def run_mcp_integration(  # noqa: PLR0913
             old_mcp_servers,
             lock_path,
             mcp_configs=old_mcp_configs,
+            mcp_target_servers=old_mcp_target_servers,
             mcp_config_provenance=old_mcp_provenance,
         )
 

--- a/src/apm_cli/integration/mcp_integrator.py
+++ b/src/apm_cli/integration/mcp_integrator.py
@@ -808,6 +808,7 @@ class MCPIntegrator:
         lock_path: Path | None = None,
         *,
         mcp_configs: builtins.dict | None = None,
+        mcp_target_servers: builtins.dict | None = None,
         mcp_config_provenance: builtins.dict | None = None,
     ) -> None:
         """Update the lockfile with the current set of APM-managed MCP server names.
@@ -820,6 +821,7 @@ class MCPIntegrator:
             lock_path: Path to the lockfile.  Defaults to ``apm.lock.yaml`` in CWD.
             mcp_configs: Keyword-only.  When provided, overwrites ``mcp_configs``
                          in the lockfile (used for drift-detection baseline).
+            mcp_target_servers: Keyword-only. Per-target APM-owned server names.
             mcp_config_provenance: Keyword-only.  When provided, overwrites
                          ``mcp_config_provenance`` (name -> declaring package for
                          transitively-contributed servers). Passed in lockstep
@@ -838,6 +840,12 @@ class MCPIntegrator:
             lockfile.mcp_servers = sorted(mcp_server_names)
             if mcp_configs is not None:
                 lockfile.mcp_configs = mcp_configs
+            if mcp_target_servers is not None:
+                lockfile.mcp_target_servers = {
+                    target: sorted(servers)
+                    for target, servers in sorted(mcp_target_servers.items())
+                    if servers
+                }
             if mcp_config_provenance is not None:
                 lockfile.mcp_config_provenance = mcp_config_provenance
             # Invariant: provenance only carries entries that still have a live
@@ -1214,6 +1222,7 @@ class MCPIntegrator:
         logger=None,
         diagnostics=None,
         scope=None,
+        managed_target_servers: builtins.dict | None = None,
     ) -> int:
         """Install MCP dependencies.
 
@@ -1234,6 +1243,9 @@ class MCPIntegrator:
             scope: InstallScope (PROJECT or USER). When USER, only
                 runtimes whose adapter declares ``supports_user_scope``
                 are targeted; workspace-only runtimes are skipped.
+            managed_target_servers: Mutable per-target ownership state. Existing
+                entries are reconciled to active targets and successful writes
+                are recorded in place.
 
         Returns:
             Number of MCP servers newly configured or updated.
@@ -1253,4 +1265,5 @@ class MCPIntegrator:
             logger=logger,
             diagnostics=diagnostics,
             scope=scope,
+            managed_target_servers=managed_target_servers,
         )

--- a/src/apm_cli/integration/mcp_integrator_install.py
+++ b/src/apm_cli/integration/mcp_integrator_install.py
@@ -32,6 +32,7 @@ def _install_registry_group(
     verbose: bool,
     console: Any,
     logger: Any,
+    managed_target_servers: dict[str, set[str]] | None,
 ) -> int:
     """Process one group of registry deps through a single ``MCPServerOperations`` instance.
 
@@ -161,6 +162,7 @@ def _install_registry_group(
                         logger=logger,
                     ):
                         any_ok = True
+                        _record_managed_server(managed_target_servers, rt, dep)
 
                 if any_ok:
                     if console:
@@ -182,6 +184,16 @@ def _install_registry_group(
                     logger.error(f"{dep} -- failed for all runtimes")
 
     return configured_count
+
+
+def _record_managed_server(
+    managed_target_servers: dict[str, set[str]] | None,
+    runtime: str,
+    server_name: str,
+) -> None:
+    """Record a server only after APM successfully writes its target config."""
+    if managed_target_servers is not None:
+        managed_target_servers.setdefault(runtime, set()).add(server_name)
 
 
 def _hermes_runtime_opted_in() -> bool:
@@ -496,6 +508,7 @@ def _install_self_defined_deps(
     verbose: bool,
     console,
     logger,
+    managed_target_servers: dict[str, set[str]] | None,
 ) -> int:
     """Install self-defined (``registry: false``) MCP deps for all target runtimes.
 
@@ -585,6 +598,7 @@ def _install_self_defined_deps(
                 logger=logger,
             ):
                 any_ok = True
+                _record_managed_server(managed_target_servers, rt, dep.name)
 
         if any_ok:
             if console:
@@ -644,6 +658,7 @@ def run_mcp_install(
     logger=None,
     diagnostics=None,
     scope: InstallScope | None = None,
+    managed_target_servers: dict[str, set[str]] | None = None,
 ) -> int:
     """Install MCP dependencies.
 
@@ -665,6 +680,7 @@ def run_mcp_install(
         scope: InstallScope (PROJECT or USER). When USER, only
             runtimes whose adapter declares ``supports_user_scope``
             are targeted; workspace-only runtimes are skipped.
+        managed_target_servers: Mutable per-target APM ownership state.
 
     Returns:
         Number of MCP servers newly configured or updated.
@@ -742,6 +758,19 @@ def run_mcp_install(
     if target_runtimes is None:
         return 0
 
+    if managed_target_servers is not None:
+        active_targets = set(target_runtimes)
+        current_names = {
+            dep.name if hasattr(dep, "name") else dep
+            for dep in mcp_deps
+            if isinstance(dep, str) or hasattr(dep, "name")
+        }
+        for target in list(managed_target_servers):
+            if target not in active_targets:
+                del managed_target_servers[target]
+            else:
+                managed_target_servers[target].intersection_update(current_names)
+
     # Use the new registry operations module for better server detection
     configured_count = 0
 
@@ -782,6 +811,7 @@ def run_mcp_install(
                     verbose=verbose,
                     console=console,
                     logger=logger,
+                    managed_target_servers=managed_target_servers,
                 )
 
         except ImportError:
@@ -802,6 +832,7 @@ def run_mcp_install(
             verbose=verbose,
             console=console,
             logger=logger,
+            managed_target_servers=managed_target_servers,
         )
 
     # Close the panel

--- a/tests/integration/test_mcp_install_flow.py
+++ b/tests/integration/test_mcp_install_flow.py
@@ -12,6 +12,7 @@ import json
 from unittest.mock import MagicMock, patch
 
 import pytest
+import tomlkit
 import yaml
 from click.testing import CliRunner
 
@@ -92,6 +93,71 @@ def test_install_restores_dev_mcp_dependencies_to_lockfile_and_config(tmp_path, 
     assert lockfile is not None
     assert lockfile.mcp_servers == ["dev-server"]
     assert lockfile.mcp_configs["dev-server"]["command"] == "python"
+
+
+def test_install_target_contraction_removes_only_apm_managed_mcp_servers(tmp_path, monkeypatch):
+    """Reinstalling with fewer targets purges APM-owned entries from dropped targets."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    LockFile().write(tmp_path / "apm.lock.yaml")
+    manifest = {
+        "name": "mcp-target-contraction",
+        "version": "0.0.1",
+        "targets": ["copilot", "codex"],
+        "dependencies": {
+            "mcp": [
+                {
+                    "name": "apm-managed",
+                    "registry": False,
+                    "transport": "stdio",
+                    "command": "echo",
+                    "args": ["managed"],
+                }
+            ]
+        },
+    }
+    (tmp_path / "apm.yml").write_text(yaml.safe_dump(manifest), encoding="utf-8")
+    codex_config = tmp_path / ".codex" / "config.toml"
+    codex_config.parent.mkdir()
+    codex_config.write_text(
+        "[projects.'c:\\src\\project']\n"
+        'trust_level = "trusted"\n'
+        "\n"
+        "[mcp_servers.user-authored]\n"
+        'command = "user-command"\n',
+        encoding="utf-8",
+    )
+
+    broad = CliRunner().invoke(
+        cli,
+        ["install", "--target", "copilot,codex", "--no-policy"],
+    )
+    assert broad.exit_code == 0, broad.output
+    broad_config = tomlkit.parse(codex_config.read_text(encoding="utf-8"))
+    assert broad_config["mcp_servers"]["apm-managed"]["command"] == "echo"
+    broad_lock = LockFile.read(tmp_path / "apm.lock.yaml")
+    assert broad_lock is not None
+    assert broad_lock.mcp_target_servers == {
+        "codex": ["apm-managed"],
+        "vscode": ["apm-managed"],
+    }
+
+    manifest["targets"] = ["copilot"]
+    (tmp_path / "apm.yml").write_text(yaml.safe_dump(manifest), encoding="utf-8")
+    contracted = CliRunner().invoke(
+        cli,
+        ["install", "--target", "copilot", "--no-policy"],
+    )
+
+    assert contracted.exit_code == 0, contracted.output
+    updated_text = codex_config.read_text(encoding="utf-8")
+    updated = tomlkit.parse(updated_text)
+    assert "apm-managed" not in updated["mcp_servers"]
+    assert updated["mcp_servers"]["user-authored"]["command"] == "user-command"
+    assert updated["projects"][r"c:\src\project"]["trust_level"] == "trusted"
+    contracted_lock = LockFile.read(tmp_path / "apm.lock.yaml")
+    assert contracted_lock is not None
+    assert contracted_lock.mcp_target_servers == {"copilot": ["apm-managed"]}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/install/test_mcp_integration_extraction.py
+++ b/tests/unit/install/test_mcp_integration_extraction.py
@@ -59,6 +59,7 @@ def _base_kwargs(**overrides):
         old_mcp_servers=set(),
         old_mcp_configs={},
         old_mcp_provenance={},
+        old_mcp_target_servers={},
         project_root=Path("/fake/project"),
         user_scope=False,
         should_install=True,
@@ -95,6 +96,7 @@ class TestRunMcpIntegrationInstallBranch:
             {"io.github.acme/server"},
             Path("/nonexistent/apm.lock.yaml"),
             mcp_configs={"io.github.acme/server": {"name": "x"}},
+            mcp_target_servers={},
             mcp_config_provenance={"io.github.acme/server": "io.github.acme/package"},
         )
         mock_mcp.remove_stale.assert_not_called()
@@ -189,6 +191,7 @@ class TestRunMcpIntegrationEmptyDepsBranch:
             set(),
             Path("/nonexistent/apm.lock.yaml"),
             mcp_configs={},
+            mcp_target_servers={},
             mcp_config_provenance={},
         )
 
@@ -205,6 +208,7 @@ class TestRunMcpIntegrationRestoreBranch:
                 old_mcp_servers={"io.github.acme/kept"},
                 old_mcp_configs={"io.github.acme/kept": {"name": "kept"}},
                 old_mcp_provenance={"io.github.acme/kept": "io.github.acme/pkg"},
+                old_mcp_target_servers={"copilot": ["io.github.acme/kept"]},
             )
         )
 
@@ -212,6 +216,7 @@ class TestRunMcpIntegrationRestoreBranch:
             {"io.github.acme/kept"},
             Path("/nonexistent/apm.lock.yaml"),
             mcp_configs={"io.github.acme/kept": {"name": "kept"}},
+            mcp_target_servers={"copilot": ["io.github.acme/kept"]},
             mcp_config_provenance={"io.github.acme/kept": "io.github.acme/pkg"},
         )
         mock_mcp.install.assert_not_called()


### PR DESCRIPTION
## Problem

When an install contracts its active target set, MCP cleanup only visits active runtimes. APM-managed servers therefore remain stranded in native configs for targets that were removed.

## Fix

- Record successful MCP writes as per-target ownership in `apm.lock.yaml`.
- Reconcile that ownership against the active runtime set on reinstall.
- Dispatch existing native JSON, TOML, and Claude cleanup helpers for removed targets.
- Remove only server names recorded as APM-managed, preserving user-authored servers, Codex literal path keys, and unrelated native settings.
- Document the lockfile ownership field and contraction behavior.

## Test

- Added an end-to-end regression that installs across Copilot and Codex, contracts to Copilot, and verifies the Codex APM-managed entry is removed while a user-authored server and literal Windows path key remain.
- `uv run --extra dev python -m pytest tests/integration/test_mcp_install_flow.py -q` - 28 passed.
- `uv run --extra dev python -m pytest tests/unit -k mcp -q` - 1430 passed, 1 skipped.
- Ruff check/format, pylint R0801, source guards, and `scripts/lint-auth-signals.sh` passed.

Closes #2149

apm-spec-waiver: lifecycle cleanup of APM-owned MCP entries on target contraction; native schemas unchanged, no new OpenAPM artifact or wire behavior.