### PR TITLE
fix(deps): render logical local dep keys in deps list/tree; refresh stale v0.25.0 release tests

### DIFF
--- a/src/apm_cli/commands/deps/cli.py
+++ b/src/apm_cli/commands/deps/cli.py
@@ -60,19 +60,18 @@ def _deps_list_source_label(
     return "github"
 
 
-def _dep_display_name(dep) -> str:
+def _dep_display_name(dep: LockedDependency) -> str:
     """Get display name for a locked dependency (key@version).
 
-    Local deps render their declared ``local_path`` (``../pkg``) instead of the
-    lockfile unique key. For anchored transitive local deps the unique key is an
+    Local deps render a logical, portable identity instead of the lockfile
+    unique key. For anchored transitive local deps the unique key is an
     absolute ``local:/...`` slot (see build_dependency_unique_key), which would
-    leak the host filesystem path into user-facing tree output. The declared
-    relative path is the logical, portable identity the user typed.
+    leak the host filesystem path into user-facing tree output. Prefer the
+    declared relative ``local_path`` (``../pkg``); fall back to the logical
+    ``repo_url`` (``_local/pkg``) if the path is absent. Remote deps keep their
+    canonical unique key.
     """
-    if getattr(dep, "source", None) == "local" and getattr(dep, "local_path", None):
-        key = dep.local_path
-    else:
-        key = dep.get_unique_key()
+    key = (dep.local_path or dep.repo_url) if dep.source == "local" else dep.get_unique_key()
     version = (
         dep.version
         or (dep.resolved_commit[:7] if dep.resolved_commit else None)
@@ -301,11 +300,12 @@ def _resolve_scope_deps(apm_dir, logger, insecure_only=False):
     installed_packages = []
     orphaned_packages = []
     for candidate, org_repo_name, has_apm_yml, _has_skill_md in scanned_candidates:
+        # Local transitive deps are scanned at their physical hash slot
+        # (``_local/<hash>/pkg``); report and orphan-check against the
+        # logical lockfile key (``_local/pkg``) instead of leaking the slot.
+        # Resolve before the try so a read failure warns with the logical name.
+        logical_name = physical_to_logical.get(org_repo_name, org_repo_name)
         try:
-            # Local transitive deps are scanned at their physical hash slot
-            # (``_local/<hash>/pkg``); report and orphan-check against the
-            # logical lockfile key (``_local/pkg``) instead of leaking the slot.
-            logical_name = physical_to_logical.get(org_repo_name, org_repo_name)
             version = "unknown"
             if has_apm_yml:
                 package = APMPackage.from_apm_yml(candidate / APM_YML_FILENAME)
@@ -336,7 +336,7 @@ def _resolve_scope_deps(apm_dir, logger, insecure_only=False):
                 }
             )
         except Exception as e:
-            logger.warning(f"Failed to read package {org_repo_name}: {e}")
+            logger.warning(f"Failed to read package {logical_name}: {e}")
 
     if insecure_only:
         installed_packages = [pkg for pkg in installed_packages if pkg["is_insecure"]]

--- a/src/apm_cli/commands/deps/cli.py
+++ b/src/apm_cli/commands/deps/cli.py
@@ -61,8 +61,18 @@ def _deps_list_source_label(
 
 
 def _dep_display_name(dep) -> str:
-    """Get display name for a locked dependency (key@version)."""
-    key = dep.get_unique_key()
+    """Get display name for a locked dependency (key@version).
+
+    Local deps render their declared ``local_path`` (``../pkg``) instead of the
+    lockfile unique key. For anchored transitive local deps the unique key is an
+    absolute ``local:/...`` slot (see build_dependency_unique_key), which would
+    leak the host filesystem path into user-facing tree output. The declared
+    relative path is the logical, portable identity the user typed.
+    """
+    if getattr(dep, "source", None) == "local" and getattr(dep, "local_path", None):
+        key = dep.local_path
+    else:
+        key = dep.get_unique_key()
     version = (
         dep.version
         or (dep.resolved_commit[:7] if dep.resolved_commit else None)
@@ -209,18 +219,26 @@ def _resolve_scope_deps(apm_dir, logger, insecure_only=False):
     except Exception:
         pass  # Continue without orphan detection if apm.yml parsing fails
 
-    # Also load lockfile deps to avoid false orphan flags on transitive deps
+    # Also load lockfile deps to avoid false orphan flags on transitive deps.
+    # Local transitive deps are installed into hashed physical slots
+    # (``_local/<hash>/pkg``) to prevent sibling collisions (#2155), but their
+    # logical identity is the un-hashed lockfile ``repo_url`` (``_local/pkg``).
+    # Key orphan/insecure state on the logical id and remember each physical
+    # slot -> logical id so the scan below can report the logical name instead
+    # of leaking the hash slot into user-facing output.
+    physical_to_logical: dict[str, str] = {}
     try:
         lockfile_path = get_lockfile_path(apm_dir)
         if lockfile_path.exists():
             lockfile = LockFile.read(lockfile_path)
             for dep in lockfile.dependencies.values():
-                # Match the host-blind apm_modules/ layout. Local dependency
-                # identity retains its source-relative path, so derive its key
-                # from the canonical install path instead.
+                # Local deps: key on the logical lockfile identity
+                # (``repo_url``) and map the physical install slot back to it.
                 if dep.source == "local":
                     install_path = dep.to_dependency_ref().get_install_path(apm_modules_path)
-                    dep_key = install_path.relative_to(apm_modules_path).as_posix()
+                    physical_key = install_path.relative_to(apm_modules_path).as_posix()
+                    dep_key = dep.repo_url
+                    physical_to_logical[physical_key] = dep_key
                 else:
                     dep_key = dep.get_canonical_dependency_string()
                 if dep_key and dep_key not in declared_sources:
@@ -284,24 +302,28 @@ def _resolve_scope_deps(apm_dir, logger, insecure_only=False):
     orphaned_packages = []
     for candidate, org_repo_name, has_apm_yml, _has_skill_md in scanned_candidates:
         try:
+            # Local transitive deps are scanned at their physical hash slot
+            # (``_local/<hash>/pkg``); report and orphan-check against the
+            # logical lockfile key (``_local/pkg``) instead of leaking the slot.
+            logical_name = physical_to_logical.get(org_repo_name, org_repo_name)
             version = "unknown"
             if has_apm_yml:
                 package = APMPackage.from_apm_yml(candidate / APM_YML_FILENAME)
                 version = package.version or "unknown"
             primitives = _count_primitives(candidate)
 
-            is_orphaned = org_repo_name not in declared_with_ancestors
+            is_orphaned = logical_name not in declared_with_ancestors
             if is_orphaned:
-                orphaned_packages.append(org_repo_name)
+                orphaned_packages.append(logical_name)
 
-            locked_dep = insecure_lock_deps.get(org_repo_name)
+            locked_dep = insecure_lock_deps.get(logical_name)
             installed_packages.append(
                 {
-                    "name": org_repo_name,
+                    "name": logical_name,
                     "version": version,
                     "source": "orphaned"
                     if is_orphaned
-                    else declared_sources.get(org_repo_name, "github"),
+                    else declared_sources.get(logical_name, "github"),
                     "primitives": primitives,
                     "path": str(candidate),
                     "is_orphaned": is_orphaned,

--- a/src/apm_cli/commands/deps/cli.py
+++ b/src/apm_cli/commands/deps/cli.py
@@ -1,9 +1,10 @@
 """APM dependency management CLI commands."""
 
+import re
 import shutil
 import sys
 from collections.abc import Iterator
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 import click
 
@@ -60,6 +61,38 @@ def _deps_list_source_label(
     return "github"
 
 
+_LOCAL_HASH_SLOT_RE = re.compile(r"^(_local)/[0-9a-f]{12}/(.+)$")
+
+
+def _is_absolute_local_path(path: str) -> bool:
+    """True if a declared local path embeds host filesystem structure.
+
+    Absolute POSIX paths (``/Users/...``), home-relative paths (``~/...``), and
+    Windows drive/UNC paths (``C:\\...``, ``\\\\server\\share``) all leak the
+    author's machine layout and must not reach user-facing output. Relative
+    declared paths (``../pkg``, ``./packages/foo``) are portable and safe.
+    """
+    if not path:
+        return False
+    if path.startswith("~"):
+        return True
+    return PurePosixPath(path).is_absolute() or PureWindowsPath(path).is_absolute()
+
+
+def _logical_local_display(physical_name: str) -> str:
+    """Strip the physical hash segment from an unmapped local slot.
+
+    Orphaned local transitive slots (``_local/<12hex>/pkg``) have no lockfile
+    entry, so ``physical_to_logical`` cannot resolve them. Orphan *detection*
+    keeps the raw physical identity, but the name shown to the user must be the
+    hash-free logical form (``_local/pkg``). Non-local names pass through.
+    """
+    match = _LOCAL_HASH_SLOT_RE.match(physical_name)
+    if match:
+        return f"{match.group(1)}/{match.group(2)}"
+    return physical_name
+
+
 def _dep_display_name(dep: LockedDependency) -> str:
     """Get display name for a locked dependency (key@version).
 
@@ -68,10 +101,17 @@ def _dep_display_name(dep: LockedDependency) -> str:
     absolute ``local:/...`` slot (see build_dependency_unique_key), which would
     leak the host filesystem path into user-facing tree output. Prefer the
     declared relative ``local_path`` (``../pkg``); fall back to the logical
-    ``repo_url`` (``_local/pkg``) if the path is absent. Remote deps keep their
-    canonical unique key.
+    ``repo_url`` (``_local/pkg``) when the path is absent or itself absolute
+    (``/Users/...``, ``~/...``, ``C:\\...``). Remote deps keep their canonical
+    unique key.
     """
-    key = (dep.local_path or dep.repo_url) if dep.source == "local" else dep.get_unique_key()
+    if dep.source == "local":
+        if dep.local_path and not _is_absolute_local_path(dep.local_path):
+            key = dep.local_path
+        else:
+            key = dep.repo_url
+    else:
+        key = dep.get_unique_key()
     version = (
         dep.version
         or (dep.resolved_commit[:7] if dep.resolved_commit else None)
@@ -303,8 +343,11 @@ def _resolve_scope_deps(apm_dir, logger, insecure_only=False):
         # Local transitive deps are scanned at their physical hash slot
         # (``_local/<hash>/pkg``); report and orphan-check against the
         # logical lockfile key (``_local/pkg``) instead of leaking the slot.
-        # Resolve before the try so a read failure warns with the logical name.
+        # A genuinely orphaned slot has no lockfile entry, so it stays keyed by
+        # its raw physical identity for correct detection -- but its displayed
+        # name is always the hash-free logical form.
         logical_name = physical_to_logical.get(org_repo_name, org_repo_name)
+        display_name = _logical_local_display(logical_name)
         try:
             version = "unknown"
             if has_apm_yml:
@@ -314,12 +357,12 @@ def _resolve_scope_deps(apm_dir, logger, insecure_only=False):
 
             is_orphaned = logical_name not in declared_with_ancestors
             if is_orphaned:
-                orphaned_packages.append(logical_name)
+                orphaned_packages.append(display_name)
 
             locked_dep = insecure_lock_deps.get(logical_name)
             installed_packages.append(
                 {
-                    "name": logical_name,
+                    "name": display_name,
                     "version": version,
                     "source": "orphaned"
                     if is_orphaned
@@ -335,8 +378,13 @@ def _resolve_scope_deps(apm_dir, logger, insecure_only=False):
                     ),
                 }
             )
-        except Exception as e:
-            logger.warning(f"Failed to read package {logical_name}: {e}")
+        except Exception:
+            # The raised error (e.g. malformed-YAML ValueError) embeds the
+            # absolute apm.yml path; never forward it. Emit a stable, actionable
+            # public warning keyed on the hash-free display name.
+            logger.warning(
+                f"Failed to inspect package {display_name}. Check its package files and rerun."
+            )
 
     if insecure_only:
         installed_packages = [pkg for pkg in installed_packages if pkg["is_insecure"]]

--- a/tests/integration/test_dep_url_parsing_e2e.py
+++ b/tests/integration/test_dep_url_parsing_e2e.py
@@ -141,7 +141,7 @@ class TestDiscoverPolicyWithChainEMUEndToEnd:
         _git_init_with_remote(tmp_path, "enterprise-user@github.com:contoso/some-app.git")
         _write_minimal_apm_yml(tmp_path)
 
-        sentinel = PolicyFetchResult(outcome="absent", source="org:contoso/.github")
+        sentinel = PolicyFetchResult(outcome="absent", source="org:contoso/.github-private")
 
         with patch(
             "apm_cli.policy.discovery._fetch_from_repo", return_value=sentinel
@@ -150,11 +150,11 @@ class TestDiscoverPolicyWithChainEMUEndToEnd:
 
         # The regression guard for #1159 is the ROUTING: discovery reached
         # _fetch_from_repo (proves SCP_LIKE_RE matched and the org was
-        # extracted) and the FIRST candidate it tried was contoso/.github.
+        # extracted) and the FIRST candidate it tried was contoso/.github-private.
         assert mock_fetch.call_count >= 1
         first_call_repo_ref = mock_fetch.call_args_list[0].args[0]
-        assert first_call_repo_ref == "contoso/.github"
-        # Cascading discovery (#1830) tries .github -> .apm -> _apm. With every
+        assert first_call_repo_ref == "contoso/.github-private"
+        # Cascading discovery (#1830) tries .github-private -> .github -> .apm -> _apm. With every
         # candidate mocked absent, the cascade exhausts and returns a fresh
         # terminal "absent" result -- it does NOT propagate the per-candidate
         # sentinel object. The org-routing assertion above is the real guard.

--- a/tests/integration/test_pack_apm_provenance_e2e.py
+++ b/tests/integration/test_pack_apm_provenance_e2e.py
@@ -174,7 +174,8 @@ def test_apm_pack_rejects_tampered_file_in_deployed_directory(tmp_path: Path) ->
     _write_apm_yml(project)
     _write_deployed_skill(project, "alpha", "deployed alpha")
     skill_dir = project / ".github" / "skills" / "alpha"
-    # Hash the contained files, but list the DIRECTORY in deployed_files.
+    # Production-realistic shape: real installs list the directory entry AND
+    # every contained file in deployed_files, with per-child hashes.
     file_rels = [
         (skill_dir / "SKILL.md").relative_to(project).as_posix(),
         (skill_dir / "notes.md").relative_to(project).as_posix(),
@@ -185,7 +186,7 @@ def test_apm_pack_rejects_tampered_file_in_deployed_directory(tmp_path: Path) ->
         resolved_commit="abc123",
         depth=1,
         package_type="skill_bundle",
-        deployed_files=[skill_dir.relative_to(project).as_posix() + "/"],
+        deployed_files=[skill_dir.relative_to(project).as_posix() + "/", *file_rels],
         deployed_file_hashes=hashes,
     )
     _write_lockfile(project, dep)
@@ -255,7 +256,7 @@ def test_apm_pack_directory_symlink_does_not_escape(tmp_path: Path) -> None:
         resolved_commit="abc123",
         depth=1,
         package_type="skill_bundle",
-        deployed_files=[skill_dir.relative_to(project).as_posix() + "/"],
+        deployed_files=[skill_dir.relative_to(project).as_posix() + "/", *deployed],
         deployed_file_hashes={rel: compute_file_hash(project / rel) for rel in deployed},
     )
     _write_lockfile(project, dep)

--- a/tests/integration/test_plugin_e2e.py
+++ b/tests/integration/test_plugin_e2e.py
@@ -598,7 +598,10 @@ def temp_project(tmp_path):
 class TestPluginNetworkE2E:
     """Network E2E tests — real CLI installs from GitHub."""
 
-    PLUGIN_REF = "github/awesome-copilot/plugins/context-engineering"
+    PLUGIN_REF = "github/awesome-copilot/plugins/context-engineering#marketplace"
+    # On-disk / logical key form: the ``#marketplace`` ref suffix is stripped
+    # from the install path (see DependencyReference.get_install_path).
+    PLUGIN_PATH = "github/awesome-copilot/plugins/context-engineering"
 
     # ---- Test 1: install real plugin ------------------------------------
 
@@ -617,7 +620,7 @@ class TestPluginNetworkE2E:
         )
 
         # Installed directory exists
-        pkg_path = temp_project / "apm_modules" / self.PLUGIN_REF
+        pkg_path = temp_project / "apm_modules" / self.PLUGIN_PATH
         assert pkg_path.is_dir(), f"Expected {pkg_path} to exist"
 
         # apm.yml synthesized
@@ -716,7 +719,7 @@ class TestPluginNetworkE2E:
         )
 
         # Both packages installed
-        assert (temp_project / "apm_modules" / self.PLUGIN_REF).is_dir()
+        assert (temp_project / "apm_modules" / self.PLUGIN_PATH).is_dir()
         review_path = (
             temp_project
             / "apm_modules"
@@ -754,7 +757,7 @@ class TestPluginNetworkE2E:
             cwd=str(temp_project),
             timeout=300,
         )
-        pkg_path = temp_project / "apm_modules" / self.PLUGIN_REF
+        pkg_path = temp_project / "apm_modules" / self.PLUGIN_PATH
         assert pkg_path.is_dir(), "Plugin must be installed before uninstall test"
 
         # Uninstall
@@ -893,7 +896,7 @@ class TestPluginNetworkE2E:
         )
         assert r.returncode == 0, f"Install failed:\n{r.stderr}"
 
-        pkg_path = temp_project / "apm_modules" / self.PLUGIN_REF
+        pkg_path = temp_project / "apm_modules" / self.PLUGIN_PATH
         assert pkg_path.is_dir(), "Plugin must be installed before prune test"
 
         # Remove the plugin from apm.yml (simulate user edit)
@@ -1010,5 +1013,5 @@ class TestPluginNetworkE2E:
         )
 
         # Package should still be on disk
-        pkg_path = temp_project / "apm_modules" / self.PLUGIN_REF
+        pkg_path = temp_project / "apm_modules" / self.PLUGIN_PATH
         assert pkg_path.is_dir(), "Plugin should still be present after reinstall"

--- a/tests/integration/test_transitive_chain_e2e.py
+++ b/tests/integration/test_transitive_chain_e2e.py
@@ -245,14 +245,20 @@ def test_deps_commands_follow_full_lock_graph_and_ignore_embedded_manifests(
     for embedded_name in embedded_names:
         assert embedded_name not in tree_output
 
-    # Negative guard (regression for the v0.25.0 leak): neither the physical
-    # hashed slot (``_local/<12-hex>/``) nor an absolute ``local:/<path>`` host
-    # slot may surface in user-facing list/tree output. Bounded regex, no
-    # host-specific matching.
+    # Negative guard (regression for the v0.25.0 leak): user-facing list/tree
+    # output must never surface a physical hashed slot (``_local/<12-hex>/``),
+    # an absolute ``local:/<path>`` unique-key slot, or any host-absolute path.
+    # The workspace root is the ground truth for "an absolute path that would
+    # leak" -- checking it (plus a bounded Windows-drive regex) stays generic
+    # without brittle host-specific matching.
     hash_slot = re.compile(r"_local/[0-9a-f]{12}/")
+    windows_abs = re.compile(r"[A-Za-z]:\\")
+    workspace_root = str(deep_chain_workspace)
     for label, output in (("deps list", list_output), ("deps tree", tree_output)):
         assert not hash_slot.search(output), f"{label} leaked a hashed slot:\n{output}"
         assert "local:/" not in output, f"{label} leaked an absolute local slot:\n{output}"
+        assert workspace_root not in output, f"{label} leaked an absolute host path:\n{output}"
+        assert not windows_abs.search(output), f"{label} leaked a Windows-absolute path:\n{output}"
 
     pruned = subprocess.run(
         [apm_command, "prune"],

--- a/tests/integration/test_transitive_chain_e2e.py
+++ b/tests/integration/test_transitive_chain_e2e.py
@@ -255,8 +255,17 @@ def test_deps_commands_follow_full_lock_graph_and_ignore_embedded_manifests(
     prune_output = pruned.stdout + pruned.stderr
     for embedded_name in embedded_names:
         assert embedded_name not in prune_output
-    for package_name in package_names:
-        assert (consumer / "apm_modules" / "_local" / package_name / "apm.yml").is_file()
+    # Direct dep (depth-1) lands in a flat ``_local/pkg`` slot; transitive
+    # local deps are materialised in parent-scoped hashed slots
+    # (``_local/<hash>/pkg``) per #2155, so locate them by glob the same way
+    # test_three_level_apm_chain_resolves_all_levels does.
+    modules_local = consumer / "apm_modules" / "_local"
+    assert (modules_local / package_names[0] / "apm.yml").is_file()
+    for package_name in package_names[1:]:
+        matches = list(modules_local.glob(f"*/{package_name}/apm.yml"))
+        assert len(matches) == 1, (
+            f"Transitive package {package_name} not materialised in its parent-scoped slot"
+        )
     assert (
         consumer
         / "apm_modules"

--- a/tests/integration/test_transitive_chain_e2e.py
+++ b/tests/integration/test_transitive_chain_e2e.py
@@ -7,6 +7,7 @@ still flowing through the same resolver/lockfile/integration code that
 remote APM deps use.
 """
 
+import re
 import shutil
 import subprocess
 from itertools import pairwise
@@ -243,6 +244,15 @@ def test_deps_commands_follow_full_lock_graph_and_ignore_embedded_manifests(
     assert all(left < right for left, right in pairwise(key_columns))
     for embedded_name in embedded_names:
         assert embedded_name not in tree_output
+
+    # Negative guard (regression for the v0.25.0 leak): neither the physical
+    # hashed slot (``_local/<12-hex>/``) nor an absolute ``local:/<path>`` host
+    # slot may surface in user-facing list/tree output. Bounded regex, no
+    # host-specific matching.
+    hash_slot = re.compile(r"_local/[0-9a-f]{12}/")
+    for label, output in (("deps list", list_output), ("deps tree", tree_output)):
+        assert not hash_slot.search(output), f"{label} leaked a hashed slot:\n{output}"
+        assert "local:/" not in output, f"{label} leaked an absolute local slot:\n{output}"
 
     pruned = subprocess.run(
         [apm_command, "prune"],

--- a/tests/unit/commands/test_deps_cli_helpers.py
+++ b/tests/unit/commands/test_deps_cli_helpers.py
@@ -114,6 +114,29 @@ class TestDepDisplayNameLocal:
         assert "local:/" not in result
         dep.get_unique_key.assert_not_called()
 
+    def test_local_dep_with_posix_absolute_path_renders_logical_repo_url(self):
+        """A POSIX-absolute declared path must never leak the host filesystem."""
+        dep = _make_local_dep(local_path="/Users/alice/pkg", repo_url="_local/pkg")
+        result = _dep_display_name(dep)
+        assert result == "_local/pkg@latest"
+        assert "/Users/" not in result
+        assert result.startswith("_local/")
+
+    def test_local_dep_with_windows_absolute_path_renders_logical_repo_url(self):
+        """A Windows-absolute declared path must never leak the host filesystem."""
+        dep = _make_local_dep(local_path=r"C:\Users\alice\pkg", repo_url="_local/pkg")
+        result = _dep_display_name(dep)
+        assert result == "_local/pkg@latest"
+        assert "C:" not in result
+        assert "\\" not in result
+
+    def test_local_dep_with_home_prefixed_path_renders_logical_repo_url(self):
+        """A ``~``-prefixed declared path embeds home structure; render logical."""
+        dep = _make_local_dep(local_path="~/pkg", repo_url="_local/pkg")
+        result = _dep_display_name(dep)
+        assert result == "_local/pkg@latest"
+        assert "~" not in result
+
 
 # ---------------------------------------------------------------------------
 # _resolve_scope_deps - filesystem paths
@@ -205,3 +228,64 @@ class TestResolveScopeDepsWithPackages:
         assert installed is not None
         assert [package["name"] for package in installed] == ["_local/package"]
         assert orphaned == ["_local/package"]
+
+
+# ---------------------------------------------------------------------------
+# _resolve_scope_deps - hash-slot / read-failure leak guards
+# ---------------------------------------------------------------------------
+
+_HASH_SLOT = "abcdef123456"
+
+
+class TestResolveScopeDepsOrphanHashSlot:
+    """A genuinely orphaned physical slot (``_local/<12hex>/pkg``) has no
+    lockfile entry to map back to. It must still be detected as orphaned, but
+    its user-facing name must be the hash-free logical form (``_local/pkg``).
+    """
+
+    def test_orphan_hashed_slot_is_orphaned_and_shows_no_hash(self, tmp_path):
+        modules_dir = tmp_path / APM_MODULES_DIR
+        slot = modules_dir / "_local" / _HASH_SLOT / "pkg"
+        slot.mkdir(parents=True)
+        (slot / APM_YML_FILENAME).write_text("name: pkg\nversion: 1.0.0\n")
+        # No apm.yml declaration and no lockfile -> genuinely orphaned.
+
+        installed, orphaned = _resolve_scope_deps(tmp_path, _make_logger())
+
+        assert installed is not None
+        names = [package["name"] for package in installed]
+        assert names == ["_local/pkg"]
+        assert orphaned == ["_local/pkg"]
+        # The raw physical hash slot must never surface in user-facing output.
+        for name in names + orphaned:
+            assert _HASH_SLOT not in name
+
+
+class TestResolveScopeDepsReadFailure:
+    """A malformed package apm.yml makes ``APMPackage.from_apm_yml`` raise a
+    ``ValueError`` embedding the absolute apm.yml path. The read-failure
+    warning must not leak that path (or a hash slot); it must identify the
+    package by its hash-free logical name and stay actionable.
+    """
+
+    def test_malformed_apm_yml_warning_excludes_path_and_hash(self, tmp_path):
+        modules_dir = tmp_path / APM_MODULES_DIR
+        slot = modules_dir / "_local" / "pkg"
+        slot.mkdir(parents=True)
+        # Invalid YAML: unbalanced bracket -> yaml.YAMLError -> ValueError(path).
+        (slot / APM_YML_FILENAME).write_text("name: [unterminated\nversion: 1.0.0\n")
+
+        logger = _make_logger()
+        installed, _orphaned = _resolve_scope_deps(tmp_path, logger)
+
+        assert installed is not None
+        warnings = [call.args[0] for call in logger.warning.call_args_list if call.args]
+        read_failures = [w for w in warnings if "inspect package" in w or "read package" in w]
+        assert read_failures, f"expected a read-failure warning, got: {warnings}"
+        message = read_failures[0]
+        # Must identify the package by its logical name...
+        assert "_local/pkg" in message
+        # ...and must NOT leak the absolute apm.yml path or a hash slot.
+        assert str(tmp_path) not in message
+        assert APM_YML_FILENAME not in message
+        assert _HASH_SLOT not in message

--- a/tests/unit/commands/test_deps_cli_helpers.py
+++ b/tests/unit/commands/test_deps_cli_helpers.py
@@ -84,6 +84,37 @@ class TestDepDisplayName:
         assert _dep_display_name(dep) == "owner/repo@2.0.0"
 
 
+def _make_local_dep(local_path=None, repo_url="_local/pkg", version=None):
+    """Local dep whose unique key would leak an absolute host slot."""
+    dep = MagicMock()
+    dep.source = "local"
+    dep.local_path = local_path
+    dep.repo_url = repo_url
+    dep.version = version
+    dep.resolved_commit = None
+    dep.resolved_ref = None
+    # The anchored unique key is an absolute ``local:/...`` slot the display
+    # must never surface for a local dep.
+    dep.get_unique_key.return_value = "local:/abs/host/path/pkg"
+    return dep
+
+
+class TestDepDisplayNameLocal:
+    def test_local_dep_uses_local_path_when_present(self):
+        dep = _make_local_dep(local_path="../pkg-depth-2")
+        result = _dep_display_name(dep)
+        assert result == "../pkg-depth-2@latest"
+        assert "local:/" not in result
+        dep.get_unique_key.assert_not_called()
+
+    def test_local_dep_falls_back_to_logical_repo_url_when_path_missing(self):
+        dep = _make_local_dep(local_path=None, repo_url="_local/pkg-depth-2")
+        result = _dep_display_name(dep)
+        assert result == "_local/pkg-depth-2@latest"
+        assert "local:/" not in result
+        dep.get_unique_key.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # _resolve_scope_deps - filesystem paths
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
fix(deps): render logical local dep keys in deps list/tree; refresh stale v0.25.0 release tests

## TL;DR

The v0.25.0 release integration suite ([run 29184076146](https://github.com/microsoft/apm/actions/runs/29184076146)) went red with 13 failures across four independent root causes. Exactly one is a production bug: `apm deps list` and `apm deps tree` leak physical, parent-scoped install slots for transitive **local** dependencies instead of their logical lockfile identity. This PR fixes that display regression and regrounds three stale test fixtures that drifted behind intentional prior changes (#2058, #2155, and upstream `awesome-copilot`). No production behavior other than local-dep display changes; physical hashed storage, remote behavior, and lockfile keys are untouched.

## Problem (WHY)

Thirteen failures, one production bug, three stale tests:

- **Production regression (`deps list`/`deps tree`)**: for a local transitive chain, `apm deps list` printed `_local/<12-char-hash>/pkg-depth-N` and `apm deps tree` printed `local:/abs/host/path/pkg-depth-N`. Both leak the parent-scoped physical slot (introduced by #2155 to avoid sibling collisions) and, in the tree case, the **absolute host filesystem path** into user-facing output. The logical identity the user typed is `../pkg-depth-N` (lockfile `repo_url` `_local/pkg-depth-N`).
- **Stale policy test**: `test_emu_ssh_remote_routes_to_correct_org_policy_repo` asserted the first policy candidate is `contoso/.github`, but #2058 intentionally made `.github-private` first in the cascade.
- **Stale pack fixture**: two `test_pack_apm_provenance_e2e` cases built a lockfile shape no real install produces -- a skill **directory** in `deployed_files` with per-**child** hashes. #2155's deployment ledger rebuilds hashes only for paths present in `deployed_files`, so the fixture never exercised the intended path.
- **Drifted plugin fixture**: `test_plugin_e2e` installed `github/awesome-copilot/plugins/context-engineering` from default `main`, which upstream has since reduced to a thin stub whose manifest declares absent component paths. APM correctly fails closed (#2103/#2155); the assembled plugin now lives on the upstream `marketplace` branch.

The user-facing leak is the one that matters: the CLI's job is to show the logical graph the user declared, not internal storage. Grounding output in the declared identity keeps the surface honest, consistent with PROSE's ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)

## Approach (WHAT)

| Root cause | Kind | Change |
|---|---|---|
| #4 deps list/tree leak | **production** | Map physical install slot -> logical lockfile key in `_resolve_scope_deps`; render `local_path` in `_dep_display_name` |
| #1 policy cascade | test | Assert `.github-private` first; update cascade comments |
| #2 pack ledger shape | test | List directory entry **plus** every contained file in `deployed_files` |
| #3 plugin ref | test | Point ref at `...context-engineering#marketplace`; add ref-stripped path constant |

## Implementation (HOW)

**`src/apm_cli/commands/deps/cli.py`** (only production file). `_resolve_scope_deps` now builds a `physical_to_logical` map while reading the lockfile: for each `source == "local"` dep it records `install_path.relative_to(apm_modules) -> dep.repo_url` (logical). The scan loop resolves each scanned candidate's name through that map, so locked-membership, orphan detection, insecure lookup, and the reported `name` all key on the logical `_local/pkg`, never the hash slot. `_dep_display_name` renders a local dep's declared `local_path` (`../pkg`) instead of `get_unique_key()`, which for anchored transitive local deps is an absolute `local:/...` slot. Hashed physical storage, remote deps, and lockfile keys are unchanged.

**`tests/integration/test_dep_url_parsing_e2e.py`** -- assertion and cascade comments updated to `.github-private -> .github -> .apm -> _apm`. Production source untouched.

**`tests/integration/test_pack_apm_provenance_e2e.py`** -- both the tamper and directory-symlink-escape cases now set `deployed_files=[skill_dir + "/", *file_rels]`, matching a real install. Fail-closed verification (`verify_attested_file`) is unchanged.

**`tests/integration/test_plugin_e2e.py`** -- `PLUGIN_REF` gains the `#marketplace` suffix; a new ref-stripped `PLUGIN_PATH` constant backs the five on-disk path assertions (the ref suffix is stripped from the install path by `DependencyReference.get_install_path`).

**`tests/integration/test_transitive_chain_e2e.py`** -- the post-prune assertion expected a flat `_local/pkg/apm.yml` for transitive deps; it now globs the hashed slot exactly as the sibling `test_three_level_apm_chain_resolves_all_levels` already does.

## Diagram

Legend: how a scanned physical slot is resolved to the logical name that `deps list` reports, after this fix.

```mermaid
flowchart LR
    A["scan apm_modules/<br/>_local/&lt;hash&gt;/pkg-depth-2"] --> B{"source == local?<br/>(lockfile)"}
    B -->|yes| C["physical_to_logical<br/>&lt;hash&gt;/pkg-depth-2 → _local/pkg-depth-2"]
    B -->|no| D["canonical string<br/>owner/repo"]
    C --> E["report logical name<br/>_local/pkg-depth-2"]
    D --> E
    E --> F["orphan check · insecure lookup · display"]
```

## Trade-offs

- **Display-only fix, storage unchanged.** I deliberately did **not** touch `get_install_path`'s hashing. #2155 hashes physical slots to prevent sibling collisions; that is correct and the task scope preserves it. The logical/physical split is intentional -- the fix reconciles the *view*, not the *storage*.
- **Scope crept from `_resolve_scope_deps` to `_dep_display_name`.** The traced root cause named only `deps list`. Testing showed `deps tree` leaked the same class of value (absolute `local:/...`), so the one-line `_dep_display_name` change is included to make the tree logical too. Both live in the same file and the same conceptual fix.
- **Test-only corrections for #1/#2 and the extra prune assertion in #4.** These reground expectations behind prior intentional changes; production source is not weakened (policy cascade, fail-closed pack verification, and component validation all preserved).

## Benefits

1. `apm deps list` and `apm deps tree` show the logical dependency the user declared (`_local/pkg`, `../pkg`) for local chains of any depth.
2. No host absolute path (`local:/Users/...`) leaks into CLI output.
3. The release integration suite's four root causes are resolved without relaxing any security or validation boundary.
4. Pack and plugin fixtures now exercise production-realistic shapes, so they will catch real regressions instead of drifting.

## Validation

> [!NOTE]
> Local `main` in this worktree is stale; the branch is exactly one commit on top of `origin/main` (`3880677f`, the v0.25.0 release commit). The PR diff is 5 files.

<details><summary>Focused failing tests (the four root causes) -- all green</summary>

```
$ APM_RUN_INTEGRATION_TESTS=1 APM_E2E_TESTS=1 pytest \
    test_dep_url_parsing_e2e.py::...::test_emu_ssh_remote_routes_to_correct_org_policy_repo \
    test_pack_apm_provenance_e2e.py::test_apm_pack_rejects_tampered_file_in_deployed_directory \
    test_pack_apm_provenance_e2e.py::test_apm_pack_directory_symlink_does_not_escape \
    test_transitive_chain_e2e.py::test_deps_commands_follow_full_lock_graph_and_ignore_embedded_manifests
4 passed
```
</details>

<details><summary>Full relevant test files + broader deps coverage</summary>

```
$ pytest test_dep_url_parsing_e2e.py test_pack_apm_provenance_e2e.py test_transitive_chain_e2e.py
23 passed

$ pytest tests/unit/deps tests/unit/commands tests/unit/test_deps*.py \
    tests/unit/test_local_deps.py tests/unit/test_transitive_deps.py tests/unit/test_prune_command.py ...
2510 passed

$ APM_RUN_INTEGRATION_TESTS=1 APM_E2E_TESTS=1 pytest \
    test_wave6_deps_cli_coverage.py test_apm_dependencies.py
89 passed, 15 skipped
```
</details>

<details><summary>Plugin ref -- real network install from #marketplace (token available)</summary>

```
$ GITHUB_APM_PAT=*** APM_RUN_INTEGRATION_TESTS=1 pytest \
    test_plugin_e2e.py::TestPluginNetworkE2E::test_install_real_plugin \
    test_plugin_e2e.py::TestPluginNetworkE2E::test_deps_tree_shows_plugin
2 passed
```

Branch/tree verified live before editing: `marketplace` exists (`4ce0b479`), `plugins/context-engineering` contains `agents/` and `skills/`.
</details>

<details><summary>Lint mirror (canonical contract) -- all green</summary>

```
$ ruff check src/ tests/                                  # All checks passed!
$ ruff format --check src/ tests/                         # 1468 files already formatted
$ pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/
                                                          # 10.00/10, exit 0
$ bash scripts/lint-auth-signals.sh                       # [+] auth-signal lint clean
# relative_to guard: clean (uses .as_posix(), not str())
# file-length guard: deps/cli.py = 1060 lines (< 2100)
# yaml-io guard: no yaml.dump in changed file
```
</details>

### Scenario Evidence

| User-promise scenario | Proving test | APM principle |
|---|---|---|
| `deps list` shows the logical graph for a local transitive chain | `test_transitive_chain_e2e.py::test_deps_commands_follow_full_lock_graph_and_ignore_embedded_manifests` (list assertion) | Honest, legible operating surface |
| `deps tree` shows declared refs, no host path leak | same test (tree assertion) | Honest, legible operating surface |
| Transitive local deps materialise in their parent-scoped slot after prune | same test (glob assertion) | Collision-safe storage (#2155) |
| Policy discovery tries `.github-private` first | `test_emu_ssh_remote_routes_to_correct_org_policy_repo` | Org policy precedence (#2058) |
| Pack rejects a tampered file in a deployed directory | `test_apm_pack_rejects_tampered_file_in_deployed_directory` | Fail-closed provenance |
| Plugin install fails closed on absent components; succeeds on assembled ref | `TestPluginNetworkE2E::test_install_real_plugin` | Component validation (#2103/#2155) |

## How to test

- [ ] Build a local `../pkg-a -> ../pkg-b -> ../pkg-c` chain and `apm install ../pkg-a`.
- [ ] Run `apm deps list`; confirm names read `_local/pkg-b`, `_local/pkg-c` (no hash prefix).
- [ ] Run `apm deps tree`; confirm rows read `../pkg-b`, `../pkg-c` (no `local:/abs/path`).
- [ ] Run the four focused tests above with `APM_RUN_INTEGRATION_TESTS=1 APM_E2E_TESTS=1`.
- [ ] Run the lint mirror; confirm all checks green.

<details><summary>Panel review follow-up (commit <code>7733c8ac3</code>)</summary>

Folded four in-scope panel findings on this branch:

1. **No hash leak in warnings** - `_resolve_scope_deps` scan-loop exception
   warning emits the logical name (resolved before the `try`), so a package
   read failure cannot surface `_local/<hash>/pkg`.
2. **Typed, safe display** - `_dep_display_name(dep: LockedDependency)` drops
   `getattr` for direct attribute access; local deps prefer `local_path`, else
   the logical `repo_url`, never the absolute `local:/` unique-key slot.
3. **Focused unit coverage** - `test_deps_cli_helpers.py`: local_path present
   renders the relative path; local_path absent falls back to `repo_url`. Both
   assert `local:/` never appears and `get_unique_key()` is not consulted.
4. **Negative integration guards** - bounded-regex assertions that neither
   `_local/<12-hex>/` nor `local:/` appears in `deps list`/`deps tree` output.

```console
$ pytest tests/unit/commands/test_deps_cli_helpers.py            # 18 passed
$ APM_RUN_INTEGRATION_TESTS=1 APM_E2E_TESTS=1 \
    pytest tests/integration/test_transitive_chain_e2e.py        # 4 passed
$ pytest tests/unit/commands/ -k deps                            # 166 passed
# lint mirror: ruff check + format clean, pylint R0801 10.00/10, auth-signals clean
```

The repeated network-E2E setup redesign is intentionally deferred; tracked
separately after the release.
</details>

<details><summary>Pre-merge review round 2 (commit <code>b668d6141</code>)</summary>

Three reachable residual leaks in `deps list`, each fixed TDD (RED first):

1. **Absolute local_path** - `_dep_display_name` rendered any truthy
   `local_path`, leaking `/Users/...`, `~/...`, `C:\...`. New display-only
   `_is_absolute_local_path` (PurePosixPath + PureWindowsPath + `~`) keeps
   relative declared paths, falls back to logical `repo_url` for absolute.
2. **True orphan physical slot** - a `_local/<12hex>/pkg` left after its
   lockfile entry is removed has no mapping. Orphan *detection* keeps the raw
   physical identity; new `_logical_local_display` strips the hash for the
   *displayed* name (`_local/pkg`).
3. **Read-failure exception** - the malformed-YAML `ValueError` embeds the
   absolute apm.yml path. The scan-loop warning no longer forwards the
   exception; it emits a stable public message keyed on the hash-free name.

Integration negative guard strengthened to reject any host-absolute path
(workspace root + bounded Windows-drive regex), not just `local:/`.

```console
$ pytest tests/unit/commands/test_deps_cli_helpers.py            # 23 passed (5 new)
$ APM_RUN_INTEGRATION_TESTS=1 APM_E2E_TESTS=1 \
    pytest test_transitive_chain_e2e.py test_dep_url_parsing_e2e.py \
           test_pack_apm_provenance_e2e.py                        # 46 passed
$ pytest tests/unit/ -k "deps or lockfile or display"            # 2418 passed
$ pytest tests/integration/ -k "deps_list or deps_tree or transitive or local_install"
                                                                  # 93 passed, 4 skipped
# lint mirror: ruff check + format clean, pylint R0801 10.00/10, auth-signals clean
```

Remote behavior and physical hashed storage unchanged.
</details>

> [!IMPORTANT]
> Remote CI has not yet run on this branch; the "green" claims above are the **local** lint/test mirror only. Do not treat CI as green until the PR checks complete. Merge, tag moves, and release re-trigger are intentionally left to the maintainer.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
