### PR TITLE
fix(deps): preserve local identity display boundaries

### DIFF
--- a/src/apm_cli/commands/deps/cli.py
+++ b/src/apm_cli/commands/deps/cli.py
@@ -79,6 +79,17 @@ def _is_absolute_local_path(path: str) -> bool:
     return PurePosixPath(path).is_absolute() or PureWindowsPath(path).is_absolute()
 
 
+def _absolute_local_display(path: str, fallback: str) -> str:
+    """Return a portable logical name for an absolute local dependency."""
+    windows_path = PureWindowsPath(path)
+    parsed_path = (
+        windows_path
+        if windows_path.is_absolute() or path.startswith("~\\")
+        else PurePosixPath(path)
+    )
+    return f"_local/{parsed_path.name}" if parsed_path.name else fallback
+
+
 def _logical_local_display(physical_name: str) -> str:
     """Strip the physical hash segment from an unmapped local slot.
 
@@ -108,6 +119,8 @@ def _dep_display_name(dep: LockedDependency) -> str:
     if dep.source == "local":
         if dep.local_path and not _is_absolute_local_path(dep.local_path):
             key = dep.local_path
+        elif dep.local_path:
+            key = _absolute_local_display(dep.local_path, dep.repo_url)
         else:
             key = dep.repo_url
     else:
@@ -344,10 +357,12 @@ def _resolve_scope_deps(apm_dir, logger, insecure_only=False):
         # (``_local/<hash>/pkg``); report and orphan-check against the
         # logical lockfile key (``_local/pkg``) instead of leaking the slot.
         # A genuinely orphaned slot has no lockfile entry, so it stays keyed by
-        # its raw physical identity for correct detection -- but its displayed
-        # name is always the hash-free logical form.
+        # its raw physical identity for correct detection. Only confirmed
+        # orphans have their physical hash redacted; declared remote identities
+        # that happen to match the slot shape remain unchanged.
         logical_name = physical_to_logical.get(org_repo_name, org_repo_name)
-        display_name = _logical_local_display(logical_name)
+        is_orphaned = logical_name not in declared_with_ancestors
+        display_name = _logical_local_display(logical_name) if is_orphaned else logical_name
         try:
             version = "unknown"
             if has_apm_yml:
@@ -355,7 +370,6 @@ def _resolve_scope_deps(apm_dir, logger, insecure_only=False):
                 version = package.version or "unknown"
             primitives = _count_primitives(candidate)
 
-            is_orphaned = logical_name not in declared_with_ancestors
             if is_orphaned:
                 orphaned_packages.append(display_name)
 

--- a/tests/unit/commands/test_deps_cli_helpers.py
+++ b/tests/unit/commands/test_deps_cli_helpers.py
@@ -19,6 +19,8 @@ from apm_cli.commands.deps.cli import (
     _resolve_scope_deps,
 )
 from apm_cli.constants import APM_MODULES_DIR, APM_YML_FILENAME, SKILL_MD_FILENAME
+from apm_cli.deps.lockfile import LockedDependency, LockFile, get_lockfile_path
+from apm_cli.models.dependency.reference import DependencyReference
 
 # ---------------------------------------------------------------------------
 # _format_primitive_counts
@@ -126,6 +128,22 @@ class TestDepDisplayNameLocal:
         """A Windows-absolute declared path must never leak the host filesystem."""
         dep = _make_local_dep(local_path=r"C:\Users\alice\pkg", repo_url="_local/pkg")
         result = _dep_display_name(dep)
+        assert result == "_local/pkg@latest"
+        assert "C:" not in result
+        assert "\\" not in result
+
+    def test_parsed_windows_absolute_path_renders_cross_platform_logical_name(self):
+        """Display derives a safe name even when parsed on a non-Windows host."""
+        dep_ref = DependencyReference.parse(r"C:\Users\alice\pkg")
+        dep = LockedDependency.from_dependency_ref(
+            dep_ref,
+            resolved_commit=None,
+            depth=0,
+            resolved_by=None,
+        )
+
+        result = _dep_display_name(dep)
+
         assert result == "_local/pkg@latest"
         assert "C:" not in result
         assert "\\" not in result
@@ -259,6 +277,22 @@ class TestResolveScopeDepsOrphanHashSlot:
         # The raw physical hash slot must never surface in user-facing output.
         for name in names + orphaned:
             assert _HASH_SLOT not in name
+
+    def test_declared_remote_hash_shaped_identity_is_not_redacted(self, tmp_path):
+        remote_name = f"_local/{_HASH_SLOT}/pkg"
+        modules_dir = tmp_path / APM_MODULES_DIR
+        package_dir = modules_dir / remote_name
+        package_dir.mkdir(parents=True)
+        (package_dir / APM_YML_FILENAME).write_text("name: pkg\nversion: 1.0.0\n")
+
+        dep = LockedDependency(repo_url=remote_name, resolved_commit="a" * 40)
+        LockFile(dependencies={dep.get_unique_key(): dep}).write(get_lockfile_path(tmp_path))
+
+        installed, orphaned = _resolve_scope_deps(tmp_path, _make_logger())
+
+        assert installed is not None
+        assert [package["name"] for package in installed] == [remote_name]
+        assert orphaned == []
 
 
 class TestResolveScopeDepsReadFailure:


### PR DESCRIPTION
# fix(deps): preserve local identity display boundaries

## TL;DR

This follow-up closes two display edge cases found after #2173 merged: Windows absolute local paths parsed on a POSIX host could still reach `deps tree`, and a declared remote identity shaped like a local hash slot could be shortened incorrectly. The patch derives absolute-local labels from the declared path's cross-platform basename and limits hash redaction to confirmed orphan slots.

> [!IMPORTANT]
> This is a narrow release-recovery follow-up on top of merged PR #2173; it does not change local dependency storage, resolution, or lockfile identity.

## Problem (WHY)

- [x] A real `DependencyReference.parse(r"C:\Users\alice\pkg")` to `LockedDependency` flow rendered `_local/C:\Users\alice\pkg@latest` on POSIX instead of `_local/pkg@latest`.
- [x] `_logical_local_display()` ran before orphan status was known, so a declared remote identity such as `_local/abcdef123456/pkg` was displayed as `_local/pkg`.
- [!] Both cases sit on user-visible `apm deps list/tree` output added in #2173, so they must preserve logical identity without exposing host-specific paths.

The two regression tests were added first and failed with the exact outputs above. That keeps the follow-up grounded in ["deterministic tool execution transforms probabilistic generation into verifiable action"](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/).

## Approach (WHAT)

| # | Fix |
|---:|---|
| 1 | For absolute local paths, derive `_local/<basename>` with `PureWindowsPath` or `PurePosixPath`; keep relative paths and missing-path fallbacks unchanged. |
| 2 | Determine orphan status from the raw logical identity before display redaction. |
| 3 | Strip `_local/<12-hex>/` only for confirmed unmapped orphan slots; preserve declared remote identities byte-for-byte. |
| 4 | Lock both boundaries with real parser, lockfile, and filesystem regression cases. |

## Implementation (HOW)

- **`src/apm_cli/commands/deps/cli.py`** - adds a small absolute-local display helper and moves the orphan predicate ahead of display-name selection. Physical identity remains the authority for orphan detection; only the rendered orphan label is sanitized.
- **`tests/unit/commands/test_deps_cli_helpers.py`** - adds a parser-to-lock-to-display Windows regression and a real lockfile/filesystem case proving that a declared remote hash-shaped identity is neither orphaned nor shortened.

## Diagrams

Legend: the dashed nodes are the two rendering decisions introduced by this follow-up; storage and lockfile identity stay unchanged.

```mermaid
flowchart LR
    subgraph Inputs[Inputs]
        L[Locked dependency]
        S[Scanned package identity]
    end
    subgraph Decide[Decide]
        A{Absolute local path}
        O{Confirmed orphan}
    end
    subgraph Render[Render]
        B["_local/basename"]:::new
        K[Declared logical identity]
        H["Hash-free orphan name"]:::new
    end
    L --> A
    A -->|yes| B
    A -->|no| K
    S --> O
    O -->|yes| H
    O -->|no| K
    classDef new stroke-dasharray: 5 5;
```

## Trade-offs

- **Sanitize at the display boundary.** Chose a narrow renderer fix; rejected a release-blocking parser/install-path refactor because storage and resolution are already correct for supported host-native paths.
- **Gate redaction on orphan status.** Chose identity-preserving conditional redaction; rejected unconditional shape-based rewriting because a valid declared remote name can match the physical-slot pattern.

## Benefits

1. A Windows absolute local declaration renders one portable label, `_local/pkg`, on POSIX and Windows hosts.
2. A declared remote identity matching `_local/<12-hex>/pkg` retains all three path segments and remains non-orphaned.
3. Existing true orphan slots still render without their physical 12-character hash.

## Validation

`uv run --extra dev pytest -q tests/unit/commands/test_deps_cli_helpers.py`:

```text
.........................                                                [100%]
25 passed in 0.61s
```

`APM_RUN_INTEGRATION_TESTS=1 APM_E2E_TESTS=1 uv run --extra dev pytest -q tests/integration/test_transitive_chain_e2e.py`:

```text
....                                                                     [100%]
4 passed in 4.95s
```

<details><summary>Broader command and lint evidence</summary>

`uv run --extra dev pytest -q tests/unit/commands -k deps`:

```text
........................................................................ [ 41%]
........................................................................ [ 83%]
.............................                                            [100%]
173 passed, 938 deselected in 2.14s
```

CI lint mirror:

```text
All checks passed!
1468 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
[+] architecture boundary lint clean
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | `apm deps tree` never prints a Windows host path when a local dependency was parsed on POSIX | Secure by default, DevX | `tests/unit/commands/test_deps_cli_helpers.py::TestDepDisplayNameLocal::test_parsed_windows_absolute_path_renders_cross_platform_logical_name` (regression trap for #2173 follow-up) | unit |
| 2 | A declared remote package whose name resembles a local hash slot keeps its full identity and is not marked orphaned | Governed by policy, Vendor-neutral | `tests/unit/commands/test_deps_cli_helpers.py::TestResolveScopeDepsOrphanHashSlot::test_declared_remote_hash_shaped_identity_is_not_redacted` (regression trap for #2173 follow-up) | unit |
| 3 | Transitive local dependencies still use logical names while physical parent-scoped slots remain collision-safe | DevX, Governed by policy | `tests/integration/test_transitive_chain_e2e.py::test_deps_commands_follow_full_lock_graph_and_ignore_embedded_manifests` | integration |

## How to test

- [ ] Run the helper test file; expect 25 passing tests.
- [ ] Run the transitive-chain integration file with both E2E environment flags; expect 4 passing tests.
- [ ] Inspect `apm deps list` and `apm deps tree` for a transitive local chain; expect no `local:/`, absolute host path, or `_local/<12-hex>/` orphan hash in user-facing output.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
