### PR TITLE
fix(deps): harden local-dep display against Windows repo_url leak and over-eager hash stripping

### DIFF
--- a/src/apm_cli/commands/deps/cli.py
+++ b/src/apm_cli/commands/deps/cli.py
@@ -93,6 +93,20 @@ def _logical_local_display(physical_name: str) -> str:
     return physical_name
 
 
+def _local_basename(path: str) -> str:
+    """Cross-platform basename of a local dependency path.
+
+    A Windows-form path parsed on POSIX (``C:\\packages\\pkg``) is opaque to
+    ``PurePosixPath`` -- the backslashes are ordinary characters, so ``.name``
+    returns the whole string and the drive leaks. Route drive/UNC/backslash
+    paths through ``PureWindowsPath`` and everything else through
+    ``PurePosixPath`` so the leaf name is recovered on either host.
+    """
+    if "\\" in path or PureWindowsPath(path).drive:
+        return PureWindowsPath(path).name
+    return PurePosixPath(path).name
+
+
 def _dep_display_name(dep: LockedDependency) -> str:
     """Get display name for a locked dependency (key@version).
 
@@ -100,16 +114,20 @@ def _dep_display_name(dep: LockedDependency) -> str:
     unique key. For anchored transitive local deps the unique key is an
     absolute ``local:/...`` slot (see build_dependency_unique_key), which would
     leak the host filesystem path into user-facing tree output. Prefer the
-    declared relative ``local_path`` (``../pkg``); fall back to the logical
-    ``repo_url`` (``_local/pkg``) when the path is absent or itself absolute
-    (``/Users/...``, ``~/...``, ``C:\\...``). Remote deps keep their canonical
-    unique key.
+    declared relative ``local_path`` (``../pkg``). For an absolute declared path
+    (``/Users/...``, ``~/...``, ``C:\\...``) derive a hash-free logical
+    ``_local/<basename>`` from ``local_path`` -- never the ``repo_url``, which a
+    Windows-form path can pollute with the drive and backslashes
+    (``_local/C:\\packages\\pkg``). Fall back to ``repo_url`` only when
+    ``local_path`` is absent. Remote deps keep their canonical unique key.
     """
     if dep.source == "local":
-        if dep.local_path and not _is_absolute_local_path(dep.local_path):
-            key = dep.local_path
-        else:
+        if not dep.local_path:
             key = dep.repo_url
+        elif _is_absolute_local_path(dep.local_path):
+            key = f"_local/{_local_basename(dep.local_path)}"
+        else:
+            key = dep.local_path
     else:
         key = dep.get_unique_key()
     version = (
@@ -344,10 +362,15 @@ def _resolve_scope_deps(apm_dir, logger, insecure_only=False):
         # (``_local/<hash>/pkg``); report and orphan-check against the
         # logical lockfile key (``_local/pkg``) instead of leaking the slot.
         # A genuinely orphaned slot has no lockfile entry, so it stays keyed by
-        # its raw physical identity for correct detection -- but its displayed
-        # name is always the hash-free logical form.
+        # its raw physical identity for correct detection -- and only then is
+        # its displayed name reduced to the hash-free logical form.
         logical_name = physical_to_logical.get(org_repo_name, org_repo_name)
-        display_name = _logical_local_display(logical_name)
+        is_orphaned = logical_name not in declared_with_ancestors
+        # Hash-stripping is reserved for a CONFIRMED orphan: a slot with no
+        # lockfile mapping to a logical key. A declared/mapped slot keeps its
+        # logical name verbatim so a legitimately hashed logical identity
+        # (``_local/<12hex>/pkg``) is not corrupted into ``_local/pkg``.
+        display_name = _logical_local_display(logical_name) if is_orphaned else logical_name
         try:
             version = "unknown"
             if has_apm_yml:
@@ -355,7 +378,6 @@ def _resolve_scope_deps(apm_dir, logger, insecure_only=False):
                 version = package.version or "unknown"
             primitives = _count_primitives(candidate)
 
-            is_orphaned = logical_name not in declared_with_ancestors
             if is_orphaned:
                 orphaned_packages.append(display_name)
 

--- a/tests/unit/commands/test_deps_cli_helpers.py
+++ b/tests/unit/commands/test_deps_cli_helpers.py
@@ -137,6 +137,31 @@ class TestDepDisplayNameLocal:
         assert result == "_local/pkg@latest"
         assert "~" not in result
 
+    def test_local_dep_windows_path_repo_url_pollution_renders_clean_basename(self):
+        """A Windows-form path parsed on POSIX leaves the drive and backslashes
+        embedded in ``repo_url`` (``_local/C:\\packages\\pkg``). Falling back to
+        that polluted ``repo_url`` would leak host structure, so the display must
+        derive a clean cross-platform basename from ``local_path`` instead.
+
+        Exercises the real parse -> LockedDependency -> display chain.
+        """
+        from apm_cli.deps.lockfile import LockedDependency
+        from apm_cli.models.dependency.reference import DependencyReference
+
+        ref = DependencyReference.parse(r"C:\packages\pkg")
+        # Guard the precondition: repo_url is genuinely polluted by the parse.
+        assert "C:" in ref.repo_url
+        dep = LockedDependency(
+            repo_url=ref.repo_url,
+            source="local",
+            local_path=ref.local_path,
+            version="1.0.0",
+        )
+        result = _dep_display_name(dep)
+        assert result == "_local/pkg@1.0.0"
+        assert "C:" not in result
+        assert "\\" not in result
+
 
 # ---------------------------------------------------------------------------
 # _resolve_scope_deps - filesystem paths
@@ -259,6 +284,45 @@ class TestResolveScopeDepsOrphanHashSlot:
         # The raw physical hash slot must never surface in user-facing output.
         for name in names + orphaned:
             assert _HASH_SLOT not in name
+
+
+class TestResolveScopeDepsDeclaredHashSlot:
+    """Hash-stripping is a *last resort* reserved for confirmed unmapped
+    orphans. A declared/locked local slot whose logical key legitimately looks
+    like ``_local/<12hex>/pkg`` must be preserved verbatim -- stripping it would
+    corrupt a real identity and mask a mapped dependency as if it were orphaned.
+    """
+
+    def test_declared_hashed_local_slot_is_preserved_not_stripped(self, tmp_path):
+        from apm_cli.deps.lockfile import LockedDependency, LockFile, get_lockfile_path
+
+        modules_dir = tmp_path / APM_MODULES_DIR
+        slot = modules_dir / "_local" / _HASH_SLOT / "pkg"
+        slot.mkdir(parents=True)
+        (slot / APM_YML_FILENAME).write_text("name: pkg\nversion: 1.0.0\n")
+
+        # Declare the slot in the lockfile with a 3-part hashed logical
+        # ``repo_url``. Its install slot maps elsewhere (``_local/pkg``), so the
+        # scanned slot stays UNMAPPED yet DECLARED -> not an orphan.
+        lockfile = LockFile()
+        lockfile.add_dependency(
+            LockedDependency(
+                repo_url=f"_local/{_HASH_SLOT}/pkg",
+                source="local",
+                local_path="../pkg",
+                version="1.0.0",
+            )
+        )
+        lockfile.write(get_lockfile_path(tmp_path))
+
+        installed, orphaned = _resolve_scope_deps(tmp_path, _make_logger())
+
+        assert installed is not None
+        names = [package["name"] for package in installed]
+        # Declared, non-orphan slot: logical name is preserved verbatim.
+        assert names == [f"_local/{_HASH_SLOT}/pkg"]
+        assert orphaned == []
+        assert installed[0]["is_orphaned"] is False
 
 
 class TestResolveScopeDepsReadFailure:


### PR DESCRIPTION
## TL;DR

Two verified pre-merge follow-ups to the v0.25.0 local-dependency display hardening (PR #2173, now merged). Both leaked or corrupted the user-facing local-dependency identity in `apm deps list`/`tree` output. Fixed TDD-first; no behavior change for the common relative-path case.

## Problem (WHY)

PR #2173 hardened local-dep display but two edge cases still leak/corrupt identity:

1. **Windows-path `repo_url` pollution.** A Windows-form declared path parsed on POSIX (`C:\packages\pkg`) leaves the drive letter and backslashes embedded in the parsed `repo_url` (`_local/C:\packages\pkg`), because `PurePosixPath("C:\\...").name` treats backslashes as ordinary characters. `_dep_display_name` fell back to that polluted `repo_url` for absolute paths, leaking host filesystem structure into user-facing output.

2. **Over-eager orphan hash stripping.** `_resolve_scope_deps` stripped the hash segment from *every* scanned `_local/<12hex>/pkg` slot name. A legitimately declared/mapped slot whose logical key happens to look hashed was corrupted into `_local/pkg` and masked, instead of being reported under its true logical identity.

## Approach (WHAT)

1. Derive a hash-free `_local/<basename>` from `local_path` for absolute declared paths, via a new `_local_basename` helper that routes drive/UNC/backslash paths through `PureWindowsPath` and everything else through `PurePosixPath`. Relative `local_path` stays verbatim; a missing `local_path` still falls back to `repo_url`. `get_unique_key` is still never called for local deps.

2. Gate the hash-strip in the scan loop on a **confirmed orphan** (a slot with no lockfile mapping to a logical key). Declared/mapped slots keep their logical name verbatim. Orphan *detection* still runs on the raw physical identity, so detection accuracy is unchanged.

## Implementation (HOW)

- `src/apm_cli/commands/deps/cli.py`: add `_local_basename`; rework `_dep_display_name` local branch; compute `is_orphaned` before the scan `try` and apply `_logical_local_display` only when orphaned.
- `tests/unit/commands/test_deps_cli_helpers.py`: real `DependencyReference.parse(r"C:\packages\pkg") -> LockedDependency -> _dep_display_name` regression (asserts no drive/backslashes); declared-hashed-slot preservation test (asserts `_local/<12hex>/pkg` is preserved, not orphaned). Both were RED before the fix.

## Trade-offs

Detection intentionally uses `PureWindowsPath` heuristics (backslash or drive) rather than importing the heavier path resolver -- keeps this a bounded release patch with no new cross-cutting abstraction.

## Validation evidence

| Check | Result |
| --- | --- |
| New RED->GREEN unit tests | 2 new, RED confirmed then GREEN |
| `test_deps_cli_helpers.py` | 25 passed |
| Related deps modules (local_deps, deps_utils, list_tree_info, wave6, deps_cli_coverage) | 282 passed |
| `test_transitive_chain_e2e.py` (binary shim) | 4 passed |
| ruff check / ruff format --check | clean |
| auth-signals lint | clean |
| pylint R0801 | 10.00/10 |
| ASCII-only additions | verified |

## How to test

```
uv run --extra dev pytest tests/unit/commands/test_deps_cli_helpers.py -q
```

Does not merge or move any tags.