### PR TITLE
fix(audit): honor locked skill subsets during replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `apm update` now converges for git-source semver dependencies already at
   their locked tag instead of reporting a spurious update on every run. Branch
   dependencies remain unaffected. (by @srobroek, #2165)
+- `apm audit` no longer reports drift for skills intentionally excluded by a
+  dependency's `skills:` subset filter. (#2177)
 - `apm update` now re-checks a transitive dependency's own semver range
   against the remote at any depth, not just for direct dependencies.
   Previously, `download_callback` only ran for a dependency whose install

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -151,6 +151,28 @@ if ! grep -A25 'if plugin.registry:' src/apm_cli/marketplace/resolver.py \
     echo "[x] Marketplace registry intent must create a registry dependency"
     violations=$((violations + 1))
 fi
+lockfile_to_ref_body=$(awk '
+    /^    def to_dependency_ref\(/ {flag=1}
+    flag && /^    def / && !/to_dependency_ref/ {exit}
+    flag && /^class / {exit}
+    flag {print}
+' src/apm_cli/deps/lockfile.py)
+if ! echo "$lockfile_to_ref_body" | grep -q 'DependencyReference(' \
+    || ! echo "$lockfile_to_ref_body" | grep 'skill_subset=' | grep -q 'self\.skill_subset'; then
+    echo "[x] LockedDependency.to_dependency_ref must reconstruct skill_subset from self.skill_subset"
+    violations=$((violations + 1))
+fi
+run_replay_body=$(awk '
+    /^def run_replay\(/ {flag=1}
+    flag && /^def / && !/run_replay/ {exit}
+    flag {print}
+' src/apm_cli/install/drift.py)
+if ! echo "$run_replay_body" | grep -q 'integrate_package_primitives(' \
+    || ! echo "$run_replay_body" | grep 'skill_subset=' \
+        | grep -q 'package_info\.dependency_ref\.skill_subset'; then
+    echo "[x] Audit replay must preserve locked skill subset intent"
+    violations=$((violations + 1))
+fi
 
 echo "[*] AC5: process-wide I/O boundaries"
 check_pattern \

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -157,8 +157,13 @@ lockfile_to_ref_body=$(awk '
     flag && /^class / {exit}
     flag {print}
 ' src/apm_cli/deps/lockfile.py)
+# Checked as two separate function-scoped greps (rather than requiring both
+# the keyword and the owner attribute on one physical line) so that ruff/
+# manual formatting wrapping the ``skill_subset=`` expression across lines
+# does not produce a false positive.
 if ! echo "$lockfile_to_ref_body" | grep -q 'DependencyReference(' \
-    || ! echo "$lockfile_to_ref_body" | grep 'skill_subset=' | grep -q 'self\.skill_subset'; then
+    || ! echo "$lockfile_to_ref_body" | grep -q 'skill_subset=' \
+    || ! echo "$lockfile_to_ref_body" | grep -q 'self\.skill_subset'; then
     echo "[x] LockedDependency.to_dependency_ref must reconstruct skill_subset from self.skill_subset"
     violations=$((violations + 1))
 fi
@@ -167,9 +172,12 @@ run_replay_body=$(awk '
     flag && /^def / && !/run_replay/ {exit}
     flag {print}
 ' src/apm_cli/install/drift.py)
+# Same rationale as the lockfile guard above: keyword and owner attribute
+# are checked as independent function-scoped greps so multiline formatting
+# of the ``skill_subset=`` expression is still accepted.
 if ! echo "$run_replay_body" | grep -q 'integrate_package_primitives(' \
-    || ! echo "$run_replay_body" | grep 'skill_subset=' \
-        | grep -q 'package_info\.dependency_ref\.skill_subset'; then
+    || ! echo "$run_replay_body" | grep -q 'skill_subset=' \
+    || ! echo "$run_replay_body" | grep -q 'package_info\.dependency_ref\.skill_subset'; then
     echo "[x] Audit replay must preserve locked skill subset intent"
     violations=$((violations + 1))
 fi

--- a/src/apm_cli/deps/lockfile.py
+++ b/src/apm_cli/deps/lockfile.py
@@ -615,6 +615,7 @@ class LockedDependency:
             is_insecure=self.is_insecure,
             allow_insecure=self.allow_insecure,
             source=self.source,
+            skill_subset=sorted(self.skill_subset) if self.skill_subset else None,
             target_subset=sorted(self.target_subset) if self.target_subset else None,
         )
 

--- a/src/apm_cli/install/drift.py
+++ b/src/apm_cli/install/drift.py
@@ -519,7 +519,7 @@ def run_replay(config: ReplayConfig, logger: CheckLogger) -> Path:
                     package_name=dep_key,
                     logger=None,
                     scope=None,
-                    skill_subset=None,
+                    skill_subset=tuple(package_info.dependency_ref.skill_subset or ()) or None,
                     ctx=None,
                     scratch_root=scratch_root,
                     # Honor per-dependency 'targets:' narrowing from apm.yml so the

--- a/tests/integration/test_architecture_intent_guards.py
+++ b/tests/integration/test_architecture_intent_guards.py
@@ -2,8 +2,121 @@
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 from unittest.mock import MagicMock
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_LINT_SCRIPT = _REPO_ROOT / "scripts" / "lint-architecture-boundaries.sh"
+
+
+def _find_function(tree: ast.AST, name: str) -> ast.FunctionDef:
+    """Locate a (possibly nested/method) function definition by name."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"function {name!r} not found")
+
+
+def _find_call(func: ast.FunctionDef, callee_name: str) -> ast.Call:
+    """Locate a direct call to ``callee_name(...)`` inside ``func``'s body."""
+    for node in ast.walk(func):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == callee_name
+        ):
+            return node
+    raise AssertionError(f"no call to {callee_name}(...) found inside {func.name}")
+
+
+def _keyword_value(call: ast.Call, keyword: str) -> ast.expr:
+    for kw in call.keywords:
+        if kw.arg == keyword:
+            return kw.value
+    raise AssertionError(f"call to {call.func.id} has no keyword {keyword!r}")  # type: ignore[union-attr]
+
+
+def _attribute_path(node: ast.AST) -> str | None:
+    """Reconstruct a dotted attribute path, e.g. ``self.skill_subset``.
+
+    Returns ``None`` if the node is not a plain ``Name``/``Attribute`` chain.
+    """
+    parts: list[str] = []
+    current = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if isinstance(current, ast.Name):
+        parts.append(current.id)
+        return ".".join(reversed(parts))
+    return None
+
+
+def _expression_depends_on(expr: ast.expr, expected_path: str) -> bool:
+    """True if any attribute access inside ``expr`` resolves to ``expected_path``."""
+    for node in ast.walk(expr):
+        if isinstance(node, ast.Attribute) and node.attr == expected_path.rsplit(".", 1)[-1]:
+            if _attribute_path(node) == expected_path:
+                return True
+    return False
+
+
+def test_locked_dependency_reconstructs_persisted_skill_subset() -> None:
+    """LockedDependency.to_dependency_ref() must forward the persisted subset.
+
+    The lockfile is the sole persisted record of a consumer's ``--skill``
+    selection. If ``to_dependency_ref()`` stopped forwarding
+    ``self.skill_subset`` into the reconstructed ``DependencyReference``
+    (e.g. hardcoding ``None`` or a constant), every downstream consumer --
+    including audit replay -- would silently lose the narrowing and drift
+    would go undetected.
+    """
+    source_path = _REPO_ROOT / "src" / "apm_cli" / "deps" / "lockfile.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+
+    method = _find_function(tree, "to_dependency_ref")
+    call = _find_call(method, "DependencyReference")
+    value = _keyword_value(call, "skill_subset")
+
+    assert _expression_depends_on(value, "self.skill_subset"), (
+        "to_dependency_ref()'s DependencyReference(...) call must pass "
+        "skill_subset derived from self.skill_subset, not a constant"
+    )
+
+
+def test_audit_replay_forwards_locked_skill_subset_without_interpreting_it() -> None:
+    """run_replay() must forward, not reinterpret, the locked skill subset.
+
+    ``integrate_package_primitives`` is the canonical owner of skill-subset
+    filtering during install/replay. ``run_replay`` must pass through
+    ``package_info.dependency_ref.skill_subset`` untouched (no recomputation,
+    no dropping to ``None``) so the replay pipeline enforces exactly what was
+    locked -- not a value re-derived at replay time.
+    """
+    source_path = _REPO_ROOT / "src" / "apm_cli" / "install" / "drift.py"
+    tree = ast.parse(source_path.read_text(encoding="utf-8"))
+
+    func = _find_function(tree, "run_replay")
+    call = _find_call(func, "integrate_package_primitives")
+    value = _keyword_value(call, "skill_subset")
+
+    assert _expression_depends_on(value, "package_info.dependency_ref.skill_subset"), (
+        "run_replay()'s integrate_package_primitives(...) call must pass "
+        "skill_subset derived from package_info.dependency_ref.skill_subset"
+    )
+
+
+def test_static_boundary_guard_covers_replay_skill_subset_authority() -> None:
+    """The static lint script must guard both propagation edges above.
+
+    A behavioral/AST regression test alone can be deleted or weakened by a
+    future change; the architecture-boundary lint script is the second,
+    independent guardrail required by the single-canonical-owner discipline
+    (see .github/instructions/architecture.instructions.md, AC4).
+    """
+    lint_source = _LINT_SCRIPT.read_text(encoding="utf-8")
+    assert "Audit replay must preserve locked skill subset intent" in lint_source
 
 
 def test_incompatible_refs_survive_to_conflict_selection(tmp_path: Path) -> None:

--- a/tests/integration/test_architecture_intent_guards.py
+++ b/tests/integration/test_architecture_intent_guards.py
@@ -65,6 +65,13 @@ def _expression_depends_on(expr: ast.expr, expected_path: str) -> bool:
 def test_locked_dependency_reconstructs_persisted_skill_subset() -> None:
     """LockedDependency.to_dependency_ref() must forward the persisted subset.
 
+    This is a structural *routing* guard: it asserts, at the source level,
+    that ``self.skill_subset`` is the value threaded into the reconstructed
+    ``DependencyReference(...)`` call. It does not exercise runtime
+    behavior -- ``tests/unit/install/test_drift.py::
+    test_run_replay_threads_locked_skill_subset`` owns the runtime symptom
+    coverage (an actual replay producing the correctly filtered primitives).
+
     The lockfile is the sole persisted record of a consumer's ``--skill``
     selection. If ``to_dependency_ref()`` stopped forwarding
     ``self.skill_subset`` into the reconstructed ``DependencyReference``
@@ -88,6 +95,11 @@ def test_locked_dependency_reconstructs_persisted_skill_subset() -> None:
 def test_audit_replay_forwards_locked_skill_subset_without_interpreting_it() -> None:
     """run_replay() must forward, not reinterpret, the locked skill subset.
 
+    Like the guard above, this is a structural *routing* guard operating on
+    the AST, not a runtime behavior test: ``tests/unit/install/
+    test_drift.py::test_run_replay_threads_locked_skill_subset`` owns the
+    runtime symptom coverage for an actual replay run.
+
     ``integrate_package_primitives`` is the canonical owner of skill-subset
     filtering during install/replay. ``run_replay`` must pass through
     ``package_info.dependency_ref.skill_subset`` untouched (no recomputation,
@@ -110,12 +122,21 @@ def test_audit_replay_forwards_locked_skill_subset_without_interpreting_it() -> 
 def test_static_boundary_guard_covers_replay_skill_subset_authority() -> None:
     """The static lint script must guard both propagation edges above.
 
-    A behavioral/AST regression test alone can be deleted or weakened by a
-    future change; the architecture-boundary lint script is the second,
-    independent guardrail required by the single-canonical-owner discipline
-    (see .github/instructions/architecture.instructions.md, AC4).
+    This meta-test does not itself re-derive runtime behavior; it only
+    confirms the two independent, function-scoped static guards below exist
+    in the lint script. Both AST tests above are structural routing guards
+    and the lint script is the second, independent guardrail required by
+    the single-canonical-owner discipline (see
+    .github/instructions/architecture.instructions.md, AC4). A
+    behavioral/AST regression test alone can be deleted or weakened by a
+    future change, so both guards -- lockfile-side reconstruction and
+    replay-side forwarding -- must be present in the script.
     """
     lint_source = _LINT_SCRIPT.read_text(encoding="utf-8")
+    assert (
+        "LockedDependency.to_dependency_ref must reconstruct skill_subset "
+        "from self.skill_subset" in lint_source
+    )
     assert "Audit replay must preserve locked skill subset intent" in lint_source
 
 

--- a/tests/integration/test_drift_check.py
+++ b/tests/integration/test_drift_check.py
@@ -411,6 +411,41 @@ class TestSectionBRegressions:
         combined = (result.stdout or "") + (result.stderr or "")
         assert "Drift detected" not in combined
 
+    def test_b5_skill_subset_excludes_unselected_skills_from_drift(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression: audit replay must honor a dependency's skill subset."""
+        project = _make_apm_project(tmp_path)
+        bundle = tmp_path / "skill-bundle"
+        for name in ("grill-me", "grilling", "unselected"):
+            skill_dir = bundle / "skills" / name
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_bytes(
+                f"---\nname: {name}\ndescription: Test skill {name}.\n---\n".encode()
+            )
+        (bundle / "apm.yml").write_bytes(b"name: skill-bundle\nversion: 1.0.0\n")
+
+        monkeypatch.chdir(project)
+        install_result = CliRunner().invoke(
+            cli,
+            [
+                "install",
+                str(bundle),
+                "--skill",
+                "grill-me",
+                "--skill",
+                "grilling",
+            ],
+            catch_exceptions=False,
+        )
+        assert install_result.exit_code == 0, install_result.output
+        assert not (project / ".agents" / "skills" / "unselected").exists()
+
+        audit_result = _audit(project, monkeypatch, "--ci", "-f", "json")
+
+        assert audit_result.exit_code == 0, audit_result.output
+        assert _drift_paths(audit_result.stdout) == []
+
 
 # ---------------------------------------------------------------------------
 # Section C -- edge cases

--- a/tests/unit/install/test_drift.py
+++ b/tests/unit/install/test_drift.py
@@ -12,6 +12,7 @@ Covers:
 from __future__ import annotations
 
 import dataclasses
+from pathlib import Path
 
 import pytest
 
@@ -549,3 +550,75 @@ def test_run_replay_threads_dep_target_subset(monkeypatch, tmp_path):
     assert call["dep_target_subset"] == ["claude"], (
         f"dep_target_subset should be ['claude'], got {call['dep_target_subset']}"
     )
+
+
+def test_run_replay_threads_locked_skill_subset(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Replay must preserve the locked skill subset through dependency reconstruction."""
+    from apm_cli.install.drift import run_replay
+
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    (project_root / "apm.yml").write_text(
+        "name: test-project\ntarget: copilot\n",
+        encoding="utf-8",
+    )
+
+    lock = LockFile()
+    lock.add_dependency(
+        LockedDependency(
+            repo_url="./skill-bundle",
+            source="local",
+            local_path="./skill-bundle",
+            resolved_commit=None,
+            skill_subset=[
+                "productivity/grill-me",
+                "productivity/grilling",
+            ],
+        )
+    )
+    (project_root / "skill-bundle").mkdir()
+    lockfile_path = project_root / "apm.lock.yaml"
+    lock.write(lockfile_path)
+
+    captured: list[dict[str, object]] = []
+
+    def _spy_integrate(*args: object, **kwargs: object) -> dict[str, list[str]]:
+        package_info = args[0]
+        captured.append(
+            {
+                "dependency_ref_skill_subset": package_info.dependency_ref.skill_subset,
+                "skill_subset": kwargs.get("skill_subset"),
+            }
+        )
+        return {"deployed_files": []}
+
+    monkeypatch.setattr(
+        "apm_cli.install.services.integrate_package_primitives",
+        _spy_integrate,
+    )
+
+    run_replay(
+        ReplayConfig(
+            project_root=project_root,
+            lockfile_path=lockfile_path,
+            targets=None,
+            cache_only=True,
+        ),
+        CheckLogger(verbose=False),
+    )
+
+    assert captured == [
+        {
+            "dependency_ref_skill_subset": [
+                "productivity/grill-me",
+                "productivity/grilling",
+            ],
+            "skill_subset": (
+                "productivity/grill-me",
+                "productivity/grilling",
+            ),
+        }
+    ]


### PR DESCRIPTION
# fix(audit): honor locked skill subsets during replay

## TL;DR

`apm audit` now reconstructs and replays each dependency's locked skill subset instead of integrating every upstream skill into the scratch tree. This removes false `unintegrated` drift findings for skills that the consumer intentionally excluded. Regression coverage proves both the propagation boundary and the full install-to-audit scenario.

> [!IMPORTANT]
> Closes #2172.

## Problem (WHY)

- [x] A clean filtered install could make `apm audit --ci` report an excluded upstream skill as `unintegrated`, despite the contract that ["It should not report drift for skills from the upstream vendor repo that were intentionally excluded by the subset filter"](https://github.com/microsoft/apm/issues/2172).
- [x] `LockedDependency.to_dependency_ref()` reconstructed `target_subset` but dropped `skill_subset`; `run_replay()` then explicitly passed `skill_subset=None` to integration.
- [!] The lockfile reference says [`skill_subset` is "the sorted subset of skill names the manifest selected"](https://github.com/microsoft/apm/blob/4633dbd505175aba7a0d829c44710edd0e15e5b4/docs/src/content/docs/reference/lockfile-spec.md#L158-L161), so replaying all skills contradicted the persisted audit input.

Why this matters: a deterministic audit gate must reproduce the selected install, not a broader package state. ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)

## Approach (WHAT)

| # | Fix |
|---|---|
| 1 | Preserve `skill_subset` when reconstructing a `DependencyReference` from a lock entry. |
| 2 | Pass that reconstructed subset into the existing integration service during drift replay. |
| 3 | Pin the contract at both the replay boundary and the install-to-audit CLI boundary. |

## Implementation (HOW)

| File | Change |
|---|---|
| [`src/apm_cli/deps/lockfile.py`](https://github.com/microsoft/apm/blob/9af1b1bcc77edf964071f57a019cdb745ea4babe/src/apm_cli/deps/lockfile.py#L588-L620) | `to_dependency_ref()` now carries the sorted locked skill selection, matching its existing target-subset reconstruction. |
| [`src/apm_cli/install/drift.py`](https://github.com/microsoft/apm/blob/9af1b1bcc77edf964071f57a019cdb745ea4babe/src/apm_cli/install/drift.py#L499-L523) | `run_replay()` converts the reconstructed selection to the tuple expected by `integrate_package_primitives`; an empty lock selection remains `None` and continues to mean all skills. |
| [`tests/unit/install/test_drift.py`](https://github.com/microsoft/apm/blob/9af1b1bcc77edf964071f57a019cdb745ea4babe/tests/unit/install/test_drift.py#L553-L624) | Adds a focused lock-to-replay propagation trap using two path-qualified skill selections. |
| [`tests/integration/test_drift_check.py`](https://github.com/microsoft/apm/blob/9af1b1bcc77edf964071f57a019cdb745ea4babe/tests/integration/test_drift_check.py#L415-L451) | Installs two of three local bundle skills, audits the clean project, and asserts the excluded skill does not produce drift. |

## Diagrams

Legend: dashed nodes are the two propagation points changed by this PR; the existing skill filter remains the canonical selection mechanism.

```mermaid
flowchart LR
    subgraph Lock[Locked dependency]
        L[apm.lock.yaml]
        D["LockedDependency.to_dependency_ref()"]
    end
    subgraph Replay[Audit replay]
        R["drift.run_replay()"]
        I[integrate_package_primitives]
    end
    subgraph Filter[Skill integration]
        S[SkillIntegrator subset filter]
        O[Scratch expected files]
    end
    L --> D
    D --> R
    R --> I
    I --> S
    S --> O
    classDef new stroke-dasharray: 5 5;
    class D,R new;
```

## Trade-offs

- **Reuse the reconstructed dependency reference.** Chose the existing semantic carrier; rejected a drift-only lock-list parser because it would create a second propagation path.
- **Keep the lockfile schema unchanged.** Chose to fix consumption of the existing `skill_subset`; rejected a migration because persisted data was already correct.
- **Test both seam and behavior.** The unit test isolates field propagation while the integration test pays the higher setup cost to prove the user-visible audit exit code and finding set.

## Benefits

1. A clean two-of-three skill install now yields audit exit code `0` instead of one false drift finding.
2. Reconstructed dependency references retain both subset dimensions: `skill_subset` and `target_subset`.
3. The regression test fails with the exact excluded path when either production propagation step is removed.

## Validation

### Mutation-break evidence

With the production fix removed:

`uv run --extra dev pytest tests/integration/test_drift_check.py::TestSectionBRegressions::test_b5_skill_subset_excludes_unselected_skills_from_drift -q`

```text
E       AssertionError: assert 1 == 0
E       "message": "drift detected: 1 file(s): .agents/skills/unselected/SKILL.md"
1 failed in 1.80s
```

After restoring the fix:

```text
.                                                                        [100%]
1 passed in 1.29s
```

The focused propagation test also passed:

`uv run --extra dev pytest tests/unit/install/test_drift.py::test_run_replay_threads_locked_skill_subset -q`

```text
.                                                                        [100%]
1 passed in 0.35s
```

<details><summary>Relevant suite output (216 tests)</summary>

`uv run --extra dev pytest tests/unit/install/test_drift.py tests/unit/test_skill_subset_persistence.py tests/unit/test_dep_targets_persistence.py tests/test_lockfile.py tests/integration/test_drift_check.py -q`

```text
........................................................................ [ 33%]
........................................................................ [ 66%]
........................................................................ [100%]
216 passed in 5.33s
```

</details>

<details><summary>Canonical lint mirror</summary>

The full mirror exited `0` with quiet output:

- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- YAML I/O, 2100-line, and raw `str(relative_to())` guards
- `uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/`
- `bash scripts/lint-auth-signals.sh`
- `bash scripts/lint-architecture-boundaries.sh`

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|---|---|---|---|
| 1 | Install only selected skills from a bundle, then run `apm audit --ci`; excluded skills do not appear as drift. | Governed by policy, Portability by manifest, DevX (pragmatic as npm) | `tests/integration/test_drift_check.py::TestSectionBRegressions::test_b5_skill_subset_excludes_unselected_skills_from_drift` (regression-trap for #2172)<br/>`tests/unit/install/test_drift.py::test_run_replay_threads_locked_skill_subset` | integration + unit |

## How to test

- [ ] Run the new integration regression and confirm it passes with exit code `0`:

  ```bash
  uv run --extra dev pytest tests/integration/test_drift_check.py::TestSectionBRegressions::test_b5_skill_subset_excludes_unselected_skills_from_drift -q
  ```

- [ ] Remove the `skill_subset` forwarding in `run_replay()` and confirm the test reports `.agents/skills/unselected/SKILL.md` as `unintegrated`.
- [ ] Restore the forwarding and run the relevant suite; confirm all 216 tests pass:

  ```bash
  uv run --extra dev pytest tests/unit/install/test_drift.py tests/unit/test_skill_subset_persistence.py tests/unit/test_dep_targets_persistence.py tests/test_lockfile.py tests/integration/test_drift_check.py -q
  ```

- [ ] Run the canonical lint mirror; confirm every command and guard exits `0`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
