### PR TITLE
fix(audit): preserve dependency link paths during replay

### DIFF
--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -119,6 +119,20 @@ if [ "$winner_selector_calls" -ne 3 ]; then
     violations=$((violations + 1))
 fi
 check_pattern \
+    "Dependency deployment-frame mapping belongs to UnifiedLinkResolver" \
+    'deployment_package_root' \
+    $(find src/apm_cli -name '*.py' \
+        ! -path 'src/apm_cli/models/apm_package.py' \
+        ! -path 'src/apm_cli/integration/base_integrator.py' \
+        ! -path 'src/apm_cli/compilation/link_resolver.py' \
+        ! -path 'src/apm_cli/install/drift.py')
+if ! grep -q \
+    'candidate_in_deployment = ctx.deployment_package_root / package_relative' \
+    src/apm_cli/compilation/link_resolver.py; then
+    echo "[x] UnifiedLinkResolver must project source assets into the deployment frame"
+    violations=$((violations + 1))
+fi
+check_pattern \
     "Resolver queue dedup must preserve ref constraints" \
     'queued_keys.*get_unique_key|get_unique_key.*queued_keys' \
     src/apm_cli/deps/apm_resolver.py

--- a/src/apm_cli/compilation/link_resolver.py
+++ b/src/apm_cli/compilation/link_resolver.py
@@ -523,12 +523,15 @@ class UnifiedLinkResolver:
 
         candidate_in_deployment = candidate
         if ctx.deployment_package_root is not None:
+            # Source containment is already enforced above. This projection only
+            # changes emitted link text; it does not access the deployment path.
             try:
                 package_relative = candidate.relative_to(source_package_root)
                 candidate_in_deployment = ctx.deployment_package_root / package_relative
             except (OSError, ValueError):
                 return None
         elif not candidate.is_relative_to(ctx.base_dir):
+            # Legacy replay callers project source-relative assets under base_dir.
             try:
                 package_relative = candidate.relative_to(source_package_root)
                 candidate_in_deployment = ctx.base_dir / package_relative

--- a/src/apm_cli/compilation/link_resolver.py
+++ b/src/apm_cli/compilation/link_resolver.py
@@ -46,6 +46,9 @@ class LinkResolutionContext:
     # stay inside this subtree already resolve after copy and should remain
     # portable bundle-local links.
     preserved_source_root: Path | None = None
+    # Source package projected into the deployment output frame. Audit replay
+    # points this at scratch while package_root remains the real source tree.
+    deployment_package_root: Path | None = None
 
 
 class UnifiedLinkResolver:
@@ -76,6 +79,7 @@ class UnifiedLinkResolver:
         # rewriting (#1147). None for compile / legacy callers disables
         # the generalization safely.
         self.package_root: Path | None = None
+        self.deployment_package_root: Path | None = None
 
     def register_contexts(self, primitives) -> None:
         """Build registry of all available context files.
@@ -138,6 +142,7 @@ class UnifiedLinkResolver:
             package_root=self.package_root,
             enable_asset_rewrite=self.package_root is not None,
             preserved_source_root=preserved_source_root,
+            deployment_package_root=self.deployment_package_root,
         )
 
         return self._rewrite_markdown_links(content, ctx)
@@ -511,33 +516,27 @@ class UnifiedLinkResolver:
                 pass
 
         try:
-            ensure_path_within(candidate, ctx.package_root)
-        except PathTraversalError:
+            source_package_root = ctx.package_root.resolve()
+            ensure_path_within(candidate, source_package_root)
+        except (OSError, ValueError, PathTraversalError):
             return None
 
-        # Replay-frame translation (#1182): during audit-replay of a
-        # self-package, ``ctx.base_dir`` is the scratch tmpdir but
-        # ``ctx.package_root`` (and therefore ``candidate``) still points
-        # at the real project tree. Computing ``relpath`` directly would
-        # produce a tmpdir-traversal link (e.g. ``../../../../Users/...``)
-        # that diverges from what real install writes to disk, causing
-        # spurious drift. Detect the cross-frame case (candidate outside
-        # base_dir) and re-anchor the target onto package_root so the
-        # rewrite mirrors the install-time output.
-        relpath_anchor = ctx.target_location
-        try:
-            candidate_in_base = candidate.is_relative_to(ctx.base_dir)
-        except (OSError, ValueError):
-            candidate_in_base = True
-        if not candidate_in_base:
+        candidate_in_deployment = candidate
+        if ctx.deployment_package_root is not None:
             try:
-                target_rel = ctx.target_location.relative_to(ctx.base_dir)
-                relpath_anchor = ctx.package_root / target_rel
+                package_relative = candidate.relative_to(source_package_root)
+                candidate_in_deployment = ctx.deployment_package_root / package_relative
             except (OSError, ValueError):
-                relpath_anchor = ctx.target_location
+                return None
+        elif not candidate.is_relative_to(ctx.base_dir):
+            try:
+                package_relative = candidate.relative_to(source_package_root)
+                candidate_in_deployment = ctx.base_dir / package_relative
+            except (OSError, ValueError):
+                return None
 
         try:
-            relative_path = os.path.relpath(candidate, relpath_anchor)
+            relative_path = os.path.relpath(candidate_in_deployment, ctx.target_location)
         except (OSError, ValueError):
             return None
 

--- a/src/apm_cli/install/drift.py
+++ b/src/apm_cli/install/drift.py
@@ -494,6 +494,11 @@ def run_replay(config: ReplayConfig, logger: CheckLogger) -> Path:
                 package_info = _build_package_info(lock_dep, install_path)
                 if lock_dep.local_path == _SELF_KEY:
                     package_info.root_local_project_root = project_root
+                    package_info.deployment_package_root = scratch_root
+                else:
+                    package_info.deployment_package_root = (
+                        lock_dep.to_dependency_ref().get_install_path(scratch_root / "apm_modules")
+                    )
                 dep_key = lock_dep.get_unique_key()
 
                 integrate_package_primitives(

--- a/src/apm_cli/integration/base_integrator.py
+++ b/src/apm_cli/integration/base_integrator.py
@@ -751,6 +751,9 @@ class BaseIntegrator:
             if install_path.resolve() != home_root.resolve() and install_path.is_dir():
                 if narrowed_local or (len(scan_roots) == 1 and scan_roots[0] == install_path):
                     self.link_resolver.package_root = Path(install_path)
+                    self.link_resolver.deployment_package_root = Path(
+                        getattr(package_info, "deployment_package_root", None) or install_path
+                    )
         except Exception:
             self.link_resolver = None
 

--- a/src/apm_cli/integration/base_integrator.py
+++ b/src/apm_cli/integration/base_integrator.py
@@ -752,7 +752,7 @@ class BaseIntegrator:
                 if narrowed_local or (len(scan_roots) == 1 and scan_roots[0] == install_path):
                     self.link_resolver.package_root = Path(install_path)
                     self.link_resolver.deployment_package_root = Path(
-                        getattr(package_info, "deployment_package_root", None) or install_path
+                        package_info.deployment_package_root or install_path
                     )
         except Exception:
             self.link_resolver = None

--- a/src/apm_cli/models/apm_package.py
+++ b/src/apm_cli/models/apm_package.py
@@ -729,6 +729,7 @@ class PackageInfo:
     )
     package_type: PackageType | None = None  # APM_PACKAGE, CLAUDE_SKILL, or HYBRID
     root_local_project_root: Path | None = None
+    deployment_package_root: Path | None = None  # Source root in the deployment output frame
 
     def get_canonical_dependency_string(self) -> str:
         """Get the canonical dependency string for this package.

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -217,3 +217,13 @@ def test_tls_injection_has_one_canonical_authority() -> None:
 
     assert "TLS trust injection belongs to canonical owners" in guard
     assert duplicate_owners == []
+
+
+def test_link_resolver_owns_dependency_deployment_frame_mapping() -> None:
+    """Dependency asset links must use the canonical resolver frame mapping."""
+    root = Path(__file__).parents[2]
+    source = (root / "src/apm_cli/compilation/link_resolver.py").read_text()
+    guard = (root / "scripts/lint-architecture-boundaries.sh").read_text()
+
+    assert "candidate_in_deployment = ctx.deployment_package_root / package_relative" in source
+    assert "Dependency deployment-frame mapping belongs to UnifiedLinkResolver" in guard

--- a/tests/integration/test_audit_dependency_skill_links_e2e.py
+++ b/tests/integration/test_audit_dependency_skill_links_e2e.py
@@ -1,0 +1,87 @@
+"""End-to-end audit replay coverage for dependency skill links."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+CLI = [sys.executable, "-m", "apm_cli.cli"]
+TIMEOUT = 180
+
+
+def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run the APM CLI in *cwd* and return the completed subprocess."""
+    return subprocess.run(
+        CLI + list(args),
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=TIMEOUT,
+        check=False,
+    )
+
+
+def _write_project(project: Path) -> None:
+    """Create a project with a nested local dependency skill."""
+    project.mkdir()
+    (project / ".claude").mkdir()
+    (project / "apm.yml").write_text(
+        """name: dependency-link-consumer
+version: 1.0.0
+target: claude
+dependencies:
+  apm:
+    - path: ./package
+""",
+        encoding="utf-8",
+    )
+
+    package = project / "package"
+    package.mkdir()
+    (package / "apm.yml").write_text(
+        """name: linked-skill-package
+version: 1.0.0
+description: Dependency skill link audit proof
+author: Test
+""",
+        encoding="utf-8",
+    )
+    (package / "MANIFESTO.md").write_text("# Manifesto\n", encoding="utf-8")
+    skill = package / ".apm" / "skills" / "demo" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text(
+        """---
+name: demo
+description: Dependency skill with a package-root link
+---
+# Demo
+
+See [the manifesto](../../../MANIFESTO.md).
+""",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.integration
+def test_audit_is_clean_after_installing_dependency_skill_with_relative_link(
+    tmp_path: Path,
+) -> None:
+    """Replay must preserve the install-time dependency path in skill links."""
+    project = tmp_path / "project"
+    _write_project(project)
+
+    install = _run(project, "install")
+    assert install.returncode == 0, (
+        f"install stdout:\n{install.stdout}\ninstall stderr:\n{install.stderr}"
+    )
+
+    deployed = project / ".claude" / "skills" / "demo" / "SKILL.md"
+    assert "../../../apm_modules/_local/package/MANIFESTO.md" in deployed.read_text(
+        encoding="utf-8"
+    )
+
+    audit = _run(project, "audit", "--ci", "--no-policy")
+    assert audit.returncode == 0, f"audit stdout:\n{audit.stdout}\naudit stderr:\n{audit.stderr}"

--- a/tests/unit/compilation/test_link_resolver.py
+++ b/tests/unit/compilation/test_link_resolver.py
@@ -796,6 +796,28 @@ class TestReplayFrameTranslation:
         assert "tmp" not in result
         assert "real_repo/MANIFESTO.md" not in result
 
+    def test_dependency_replay_uses_deployment_package_root(self, tmp_path):
+        """Dependency replay must retain its canonical scratch install path."""
+        source_root = tmp_path / "source_package"
+        source_dir = source_root / ".apm" / "skills" / "demo"
+        source_dir.mkdir(parents=True)
+        (source_root / "MANIFESTO.md").write_text("# Manifesto", encoding="utf-8")
+        source_file = source_dir / "SKILL.md"
+        source_file.write_text("placeholder", encoding="utf-8")
+
+        scratch_root = tmp_path / "scratch"
+        target_file = scratch_root / ".claude" / "skills" / "demo" / "SKILL.md"
+        target_file.parent.mkdir(parents=True)
+
+        resolver = UnifiedLinkResolver(scratch_root)
+        resolver.package_root = source_root
+        resolver.deployment_package_root = scratch_root / "apm_modules" / "_local" / "package"
+
+        content = "See [the manifesto](../../../MANIFESTO.md)."
+        result = resolver.resolve_links_for_installation(content, source_file, target_file)
+
+        assert "[the manifesto](../../../apm_modules/_local/package/MANIFESTO.md)" in result
+
     def test_normal_install_self_package_unchanged(self, tmp_path):
         """Sanity: normal install (base_dir == package_root parent) still
         rewrites correctly and the replay-frame branch does not regress it.


### PR DESCRIPTION
# fix(audit): preserve dependency link paths during replay

## TL;DR

Audit replay now projects package-relative link targets into the same canonical
package installation frame used by `apm install`. A clean install of a nested
local dependency skill no longer reports false `modified` drift. The change
keeps path validation on the real source tree and changes only relative-link
rendering in the scratch replay frame.

> [!NOTE]
> Closes #2154. The regression test exercises the full install-to-audit round
> trip and was mutation-checked against the removed frame handoff.

## Problem (WHY)

- [x] A dependency skill linking to its package `MANIFESTO.md` was rewritten to
  `../../../apm_modules/_local/package/MANIFESTO.md` by install but to
  `../../../MANIFESTO.md` by audit replay.
- [x] The byte mismatch made `apm audit --ci` exit non-zero immediately after a
  successful clean install, as reproduced in
  [#2154](https://github.com/microsoft/apm/issues/2154).
- [x] The replay-frame correction for self-package content treated every
  out-of-scratch candidate as though its package root were the project root.
- [!] Re-deriving dependency placement inside the link resolver would split the
  install-path decision from `DependencyReference.get_install_path()`.

The frame decision now has one concrete representation; agents and reviewers
can follow it because
["agents pattern-match well against concrete structures"](https://agentskills.io/skill-creation/best-practices).

## Approach (WHAT)

1. Carry a package root projected into the current deployment output frame,
   instead of inferring a project ancestor from a source path.
2. Ask the existing `DependencyReference.get_install_path()` authority for each
   dependency's scratch-frame location rather than duplicating known layout
   rules, following ["Add what the agent lacks, omit what it knows"](https://agentskills.io/skill-creation/best-practices).
3. Keep `UnifiedLinkResolver` as the only owner that maps a validated source
   candidate into that deployment frame before computing `relpath`.
4. Lock the ownership boundary with both an end-to-end regression and a static
   architecture guard.

## Implementation (HOW)

| File | Surgical change |
|---|---|
| `src/apm_cli/models/apm_package.py` | Adds optional `deployment_package_root` metadata to `PackageInfo`; ordinary installs continue to default to `install_path`. |
| `src/apm_cli/install/drift.py` | Projects self content to `scratch_root` and dependencies through canonical `get_install_path(scratch_root / "apm_modules")`. |
| `src/apm_cli/integration/base_integrator.py` | Hands the projected root to the shared link resolver for every file-level integrator. |
| `src/apm_cli/compilation/link_resolver.py` | Validates against the real source package, maps the relative candidate into the deployment frame, then renders the target-relative link. |
| `scripts/lint-architecture-boundaries.sh` | Prevents a second deployment-frame mapper and verifies the resolver keeps the projection step. |
| `tests/integration/test_architecture_authorities.py` | Proves the static guard and canonical mapping remain connected. |
| `tests/integration/test_audit_dependency_skill_links_e2e.py` | Installs a nested local dependency skill, verifies the installed link, and requires immediate audit success. |

No CLI syntax, manifest schema, lockfile schema, or documented user contract
changes, so no documentation or README update is needed.

## Diagrams

Legend: the dashed nodes are the new frame metadata and canonical projection;
source validation still happens against the real package.

```mermaid
flowchart LR
    subgraph Source[Source frame]
        S1[Real dependency package]
        S2[Validated package-relative candidate]
    end
    subgraph Replay[Audit replay frame]
        R1[DependencyReference.get_install_path]
        R2[deployment_package_root]
    end
    subgraph Resolve[UnifiedLinkResolver]
        L1[Project candidate into deployment frame]
        L2[Compute link from scratch target]
    end
    S1 --> S2
    R1 --> R2
    S2 --> L1
    R2 --> L1
    L1 --> L2
    classDef new stroke-dasharray: 5 5;
    class R2,L1 new;
```

## Trade-offs

- **Explicit frame metadata over path inference.** Chose a `PackageInfo` field;
  rejected searching ancestors for `apm_modules` because local dependencies may
  originate outside that tree.
- **Canonical path owner over replay-specific naming logic.** Chose
  `DependencyReference.get_install_path()`; rejected rebuilding `_local`,
  virtual, and host-specific layouts in `drift.py`.
- **End-to-end regression over helper-only coverage.** Chose a hermetic CLI
  round trip; rejected a unit-only assertion because the defect spans lockfile
  materialization, integration, link rewriting, and drift comparison.
- **Compatibility fallback retained.** Direct resolver callers that set only
  `package_root` keep the self-package behavior covered by the existing #1182
  tests; production integrators use the explicit frame.

## Benefits

1. A nested dependency skill with a package-root Markdown link passes
   `apm audit --ci` immediately after install.
2. The replayed link preserves the full
   `apm_modules/_local/package/MANIFESTO.md` segment byte-for-byte.
3. One integration regression fails when the frame handoff is removed and
   passes when restored.
4. One static boundary check prevents deployment-frame mapping from spreading
   beyond the canonical resolver path.

## Validation

`uv run --extra dev pytest tests/integration/test_audit_dependency_skill_links_e2e.py -q`:

```
.                                                                        [100%]
1 passed in 1.76s
```

<details><summary>Relevant regression suite (451 tests)</summary>

`uv run --extra dev pytest tests/unit/compilation/test_link_resolver.py tests/unit/compilation/test_link_resolver_resolution.py tests/unit/compilation/test_link_resolver_phase3.py tests/unit/install/test_drift.py tests/unit/install/test_drift_phase3.py tests/unit/integration/test_skill_integrator.py tests/integration/test_audit_dependency_skill_links_e2e.py tests/integration/test_architecture_authorities.py -q`:

```
451 passed in 3.89s
```

</details>

<details><summary>Mutation-break proof</summary>

With the `BaseIntegrator` frame handoff temporarily removed, the regression
trap produced this expected result before the correction was restored:

```
FAILED tests/integration/test_audit_dependency_skill_links_e2e.py::test_audit_is_clean_after_installing_dependency_skill_with_relative_link
1 failed in 2.11s
mutation break confirmed
```

</details>

Full canonical lint mirror, including Ruff, YAML I/O, file length,
`relative_to`, pylint R0801, auth, and architecture boundaries:

```
canonical lint mirror: PASS
```

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|---|---|---|---|
| 1 | Install a dependency skill with a package-relative Markdown link, then run `apm audit --ci`; the clean install remains clean | Governed by policy, DevX (pragmatic as npm) | `tests/integration/test_audit_dependency_skill_links_e2e.py::test_audit_is_clean_after_installing_dependency_skill_with_relative_link` (regression-trap for #2154) | e2e |
| 2 | Existing self-package replay links continue to resolve against the project root | Portability by manifest, Governed by policy | `tests/unit/compilation/test_link_resolver.py::TestReplayFrameTranslation` | unit |
| 3 | Dependency deployment-frame mapping remains owned by the shared resolver | Governed by policy, OSS / community-driven | `tests/integration/test_architecture_authorities.py::test_link_resolver_owns_dependency_deployment_frame_mapping` | integration |

## How to test

- [ ] Run the new e2e test; expect one passing test and no drift finding.
- [ ] Inspect the fixture's deployed skill assertion; expect the link to retain
  `../../../apm_modules/_local/package/MANIFESTO.md`.
- [ ] Run `tests/unit/compilation/test_link_resolver.py`; expect the existing
  self-package replay cases to remain green.
- [ ] Run `bash scripts/lint-architecture-boundaries.sh`; expect
  `[+] architecture boundary lint clean`.
- [ ] Run the canonical lint mirror; expect every command to exit zero.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
