### PR TITLE
fix(pack): emit category in Claude marketplace output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Preserve every enforceable policy field and strict denial across warm-cache reads (#2193).
   Cached inheritance chains no longer relabel stale strict parents as fresh or
   bypass inherited policy in `apm policy status` and executable approval.
+- `apm pack` now emits the `category` field in the Claude marketplace output
+  (`.claude-plugin/marketplace.json`) when a package sets it, matching the
+  Anthropic marketplace schema and the existing Codex output. It stays optional
+  (omitted when unset). Previously `category` was silently stripped from the
+  Claude output even though the `apm.yml` schema accepts and validates it.
+  (closes #2188)
 - `apm pack` now matches source-relative skill selectors such as
   `productivity/grill-me` against flattened deployed skill names. (closes
   #2171; #2176)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Anthropic marketplace schema and the existing Codex output. It stays optional
   (omitted when unset). Previously `category` was silently stripped from the
   Claude output even though the `apm.yml` schema accepts and validates it.
-  (closes #2188)
+  -- by @mbeacom (closes #2188)
 - `apm pack` now matches source-relative skill selectors such as
   `productivity/grill-me` against flattened deployed skill names. (closes
   #2171; #2176)

--- a/docs/src/content/docs/producer/publish-to-a-marketplace.md
+++ b/docs/src/content/docs/producer/publish-to-a-marketplace.md
@@ -193,7 +193,8 @@ form (`outputs: [claude, codex]`) still parses with a deprecation
 warning. When `codex` is selected, every package must define
 `category`. Codex output maps local entries to `source: local`,
 remote entries to `source: url`, and remote subdirectory entries to
-`source: git-subdir`.
+`source: git-subdir`. Claude output also emits `category` on any
+package where it is set, even though only `codex` requires it.
 
 ## Build
 

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -899,6 +899,7 @@ Each entry MUST be a mapping. Unknown keys are rejected.
 | `author` | `string` or `object` | OPTIONAL | Either a non-empty string (treated as `name`) or an object with `name` (REQUIRED), `email`, `url`. |
 | `license` | `string` | OPTIONAL | Pass-through (SPDX identifier). |
 | `repository` | `string` | OPTIONAL | Pass-through. |
+| `category` | `string` | Conditional | Pass-through to `marketplace.json` for both the Claude and Codex outputs when set. REQUIRED when `marketplace.outputs` includes `codex`. |
 
 Remote packages MUST declare at least one of `version` or `ref`. Local packages (sources beginning with `./`) skip git resolution and have no version requirement.
 

--- a/src/apm_cli/marketplace/output_mappers.py
+++ b/src/apm_cli/marketplace/output_mappers.py
@@ -203,6 +203,8 @@ class ClaudeMarketplaceMapper(MarketplaceOutputMapper):
                 plugin["repository"] = entry.repository
             if pkg.tags:
                 plugin["tags"] = list(pkg.tags)
+            if entry and entry.category:
+                plugin["category"] = entry.category
             if is_local and entry.homepage:
                 plugin["homepage"] = entry.homepage
 

--- a/src/apm_cli/marketplace/yml_schema.py
+++ b/src/apm_cli/marketplace/yml_schema.py
@@ -349,8 +349,8 @@ class PackageEntry:
     author: Mapping[str, str] | None = None
     license: str | None = None
     repository: str | None = None
-    # Marketplace category metadata. Emitted only by output formats that
-    # consume categories, currently Codex repo marketplace output.
+    # Marketplace category metadata. Emitted by both the Claude and Codex
+    # outputs when present; the Codex output additionally requires it.
     category: str | None = None
     # Derived (set by loader, not by user)
     is_local: bool = False
@@ -945,8 +945,8 @@ def _parse_package_entry(
             raise MarketplaceYmlError(f"'packages[{index}].repository' must be a non-empty string")
         repository = repository.strip()
 
-    # Optional marketplace category. Claude output strips this; Codex output
-    # requires and emits it.
+    # Optional marketplace category. Emitted by both the Claude and Codex
+    # outputs when set; the Codex output additionally requires it.
     category: str | None = None
     raw_category = raw.get("category")
     if raw_category is not None:

--- a/tests/integration/test_marketplace_builder_hermetic.py
+++ b/tests/integration/test_marketplace_builder_hermetic.py
@@ -1030,6 +1030,50 @@ class TestBuildPipeline:
         assert source["source"] == "url"
         assert source["url"] == "https://gitlab.example.com/platform/marketplaces/team/tool"
 
+    def test_build_writes_category_to_claude_output_on_disk(self, tmp_path):
+        """On-disk regression trap for issue #2188: a real ``builder.build()``
+        run (no mocked resolve/write_output) must write ``category`` into the
+        WRITTEN Claude ``marketplace.json`` for a package that sets it, and
+        omit the key entirely for a sibling package that doesn't -- the exact
+        promise ``ClaudeMarketplaceMapper.compose()`` now keeps."""
+        apm_yml = tmp_path / "apm.yml"
+        apm_yml.write_text(
+            yaml.safe_dump(
+                {
+                    "name": "category-marketplace",
+                    "description": "Category on-disk marketplace",
+                    "version": "1.0.0",
+                    "marketplace": {
+                        "owner": {"name": "ACME"},
+                        "claude": {"output": "marketplace.json"},
+                        "packages": [
+                            {
+                                "name": "with-category",
+                                "source": "./packages/with-category",
+                                "version": "1.0.0",
+                                "category": "retrieval",
+                            },
+                            {
+                                "name": "without-category",
+                                "source": "./packages/without-category",
+                                "version": "1.0.0",
+                            },
+                        ],
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        builder = MarketplaceBuilder(apm_yml, options=BuildOptions(offline=True))
+
+        report = builder.build()
+
+        assert report.primary_output.errors == ()
+        output = json.loads((tmp_path / "marketplace.json").read_text(encoding="utf-8"))
+        plugins = {p["name"]: p for p in output["plugins"]}
+        assert plugins["with-category"]["category"] == "retrieval"
+        assert "category" not in plugins["without-category"]
+
     def test_build_calls_resolve_and_write_output(self, tmp_path):
         yml = _make_marketplace_yml_file(tmp_path)
         builder = MarketplaceBuilder(yml)

--- a/tests/unit/marketplace/test_local_path_compose.py
+++ b/tests/unit/marketplace/test_local_path_compose.py
@@ -81,7 +81,86 @@ def test_compose_emits_local_source_as_string(
     assert plugin["description"] == "A locally vendored tool."
     assert plugin["version"] == "0.1.0"
     assert plugin["homepage"] == "https://example.com/local-tool"
-    assert "category" not in plugin
+    assert plugin["category"] == "Productivity"
+
+
+def test_compose_claude_emits_category_for_local_and_remote_when_set(tmp_path: Path) -> None:
+    """``category`` is a supported Anthropic marketplace field -- the Claude
+    output must carry it for both local and remote packages when set, mirroring
+    ``tags``/``author``/``license``/``repository``.
+    """
+    _write(
+        tmp_path / "apm.yml",
+        """\
+        name: catdemo
+        description: A project.
+        version: 1.0.0
+        marketplace:
+          owner:
+            name: ACME
+          packages:
+            - name: local-tool
+              source: ./packages/local-tool
+              version: 0.1.0
+              category: retrieval
+            - name: remote-tool
+              source: acme/remote-tool
+              ref: v1.0.0
+              category: developer-tools
+        """,
+    )
+    config = load_marketplace_config(tmp_path)
+    builder = MarketplaceBuilder.from_config(config, tmp_path, BuildOptions(offline=True))
+    local_entry = next(p for p in config.packages if p.is_local)
+    remote_entry = next(p for p in config.packages if p.name == "remote-tool")
+    resolved = [
+        builder._resolve_entry(local_entry),
+        # Construct the remote resolved shape directly; this test is about
+        # category composition, not git ref resolution.
+        ResolvedPackage(
+            name=remote_entry.name,
+            source_repo=remote_entry.source,
+            subdir=remote_entry.subdir,
+            ref="v1.0.0",
+            sha="a" * 40,
+            requested_version=None,
+            tags=(),
+            is_prerelease=False,
+        ),
+    ]
+    doc = builder.compose_marketplace_json(resolved)
+
+    plugins = {p["name"]: p for p in doc["plugins"]}
+    assert plugins["local-tool"]["category"] == "retrieval"
+    assert plugins["remote-tool"]["category"] == "developer-tools"
+
+
+def test_compose_claude_omits_category_when_unset(tmp_path: Path) -> None:
+    """``category`` stays optional -- when a package omits it the Claude output
+    emits no ``category`` key.
+    """
+    _write(
+        tmp_path / "apm.yml",
+        """\
+        name: catdemo
+        description: A project.
+        version: 1.0.0
+        marketplace:
+          owner:
+            name: ACME
+          packages:
+            - name: local-tool
+              source: ./packages/local-tool
+              version: 0.1.0
+        """,
+    )
+    config = load_marketplace_config(tmp_path)
+    builder = MarketplaceBuilder.from_config(config, tmp_path, BuildOptions(offline=True))
+    local_entry = next(p for p in config.packages if p.is_local)
+    resolved = [builder._resolve_entry(local_entry)]
+    doc = builder.compose_marketplace_json(resolved)
+
+    assert "category" not in doc["plugins"][0]
 
 
 def test_compose_codex_marketplace_includes_local_and_remote_plugins(tmp_path: Path) -> None:


### PR DESCRIPTION
# fix(pack): emit `category` in Claude marketplace output

## TL;DR

`apm pack` silently dropped the `category` field from the Claude marketplace output (`.claude-plugin/marketplace.json`) while emitting it for Codex — even though `category` is a documented Anthropic marketplace-specific plugin-entry field and APM's own `apm.yml` schema already accepts and validates it. This PR maps `category` into each Claude plugin entry when set (both local and remote packages), keeps it optional, and updates the two stale "Claude output strips this" comments.

> [!NOTE]
> Fixes #2188. Scoped to `category` only — no other field-mapping behavior changes.

## Problem (WHY)

- [x] `ClaudeMarketplaceMapper.compose()` emitted `name`, `description`, `version`, `author`, `license`, `repository`, `tags`, `homepage`, and `source`, but never `category` — so a category set in `apm.yml` never reached `.claude-plugin/marketplace.json`.
- [x] The `apm.yml` schema already accepts and validates `category` (`_PACKAGE_ENTRY_KEYS` includes it; `_parse_package_entry` validates it), so authors could set a field that the Claude output then discarded.
- [!] Single-source-of-truth producers (`apm.yml` → `apm pack` → `.claude-plugin/marketplace.json`) had to hand-edit the generated file to keep a category-tagged Claude marketplace, defeating the point of generating it.

Why these matter: the Claude output otherwise targets the Anthropic marketplace schema byte-for-byte, and per the [Claude Code plugin-marketplace docs](https://code.claude.com/docs/en/plugin-marketplaces#plugin-entries) each plugin entry may include `"source, category, tags, strict, and relevance"`. Stripping a documented, schema-accepted field diverges from that target.

## Approach (WHAT)

| # | Fix (and why, if non-obvious) |
|---|-------------------------------|
| 1 | Emit `category` in `ClaudeMarketplaceMapper.compose()` when `entry.category` is set, following the existing conditional-field pattern used for `author`/`license`/`repository`/`tags`. |
| 2 | Place the new branch before the local-only `homepage` block so it applies to **both** local and remote packages (category is package metadata, unlike `homepage`). |
| 3 | Update two now-stale comments in `yml_schema.py` that claimed the Claude output strips `category`. |

## Implementation (HOW)

- **`src/apm_cli/marketplace/output_mappers.py`** — added `if entry and entry.category: plugin["category"] = entry.category` in `ClaudeMarketplaceMapper.compose()`, positioned right after the `tags` block and before the `is_local`-gated `homepage` block. This ordering is deliberate: it runs on the shared (local + remote) path, keeps `category` adjacent to `tags` in field order, and stays optional (no key when unset). The Codex mapper is untouched — it still requires and emits `category`.
- **`src/apm_cli/marketplace/yml_schema.py`** — comment-only: the `PackageEntry.category` docstring comment and the `_parse_package_entry` comment no longer say "Claude output strips this"; they now state both outputs emit it and Codex additionally requires it. No parsing/validation logic changed.
- **`tests/unit/marketplace/test_local_path_compose.py`** — flipped the existing `assert "category" not in plugin` (which asserted the old strip) to assert the value now appears, and added two focused tests covering local + remote (present) and omitted-when-unset.
- **`CHANGELOG.md`** — added an `[Unreleased] → Fixed` entry, mirroring sibling `apm pack` fixes.

## Diagrams

Legend: per-package field emission inside `ClaudeMarketplaceMapper.compose()`; look at the highlighted `category` node — it sits on the shared path (local **and** remote), unlike the local-only `homepage`.

```mermaid
flowchart TD
    pkg["resolved package (local or remote)"] --> common["emit name, description, version,<br/>author, license, repository, tags"]
    common --> cat{"entry.category set?"}
    cat -->|yes| emitcat["emit category -- NEW: shared local + remote path"]
    cat -->|no| skip["omit category key"]
    emitcat --> hp{"is_local AND homepage set?"}
    skip --> hp
    hp -->|yes| emithp["emit homepage (local only)"]
    hp -->|no| src["emit source (string if local, object if remote)"]
    emithp --> src
```

## Trade-offs

- **Placement next to `tags`, not last.** Chose to slot `category` between `tags` and `homepage` so package-metadata fields stay grouped and it lands on the shared local/remote path; rejected appending it after `source` (would split it from sibling metadata and read as an afterthought).
- **Comment-only change in `yml_schema.py`.** The parser already accepted `category`; only the outdated "strips this" narrative needed correcting. No validation surface moved.
- **Codex behavior deliberately unchanged.** Codex still *requires* `category` and raises when it is missing; this PR only stops the Claude output from discarding it.

## Benefits

1. `apm pack` produces a Claude `marketplace.json` whose `category` matches what the author declared in `apm.yml` — no hand-editing of the generated file.
2. Field parity between the Claude and Codex outputs for `category` (both emit when set).
3. Zero new required fields: unset `category` is omitted, so existing manifests and outputs are byte-identical.

## Validation

`apm pack --offline` on the issue's exact dual-output repro (both `claude` and `codex` outputs, package `a` with `category: retrieval`):

```
[*] Built marketplace.json [claude] (1 package(s)) -> out/claude-marketplace.json
[*] Built marketplace.json [codex] (1 package(s)) -> out/codex-marketplace.json
```

Both outputs now contain `category` (the issue reported Claude = no match):

```
$ grep -c '"category"' out/claude-marketplace.json   # -> 1  (was 0 before this PR)
$ grep -c '"category"' out/codex-marketplace.json    # -> 1
```

Claude output plugin entry (verbatim):

```json
{
  "name": "a",
  "description": "demo package",
  "version": "1.0.0",
  "category": "retrieval",
  "source": "./plugins/a"
}
```

<details><summary>Lint contract (all seven checks green) + full marketplace test run</summary>

```
$ uv run --extra dev ruff check src/ tests/
All checks passed!
$ uv run --extra dev ruff format --check src/ tests/
1488 files already formatted
$ uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/
Your code has been rated at 10.00/10
$ bash scripts/lint-auth-signals.sh
[+] auth-signal lint clean

$ uv run --extra dev python -m pytest tests/unit/marketplace tests/integration/test_marketplace_builder_phase3w4.py tests/integration/test_marketplace_builder_hermetic.py tests/integration/marketplace -q
1622 passed, 7 skipped in 11.69s
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|------------------------|--------------|--------------------|------|
| 1 | Author sets `category` in `apm.yml`; `apm pack` carries it into the Claude `marketplace.json` for both local and remote packages. | Vendor-neutral / Multi-harness | `tests/unit/marketplace/test_local_path_compose.py::test_compose_claude_emits_category_for_local_and_remote_when_set` | unit |
| 2 | Author omits `category`; the Claude output emits no `category` key (stays optional, no output churn). | DevX | `tests/unit/marketplace/test_local_path_compose.py::test_compose_claude_omits_category_when_unset` | unit |
| 3 | A local package with `category` set surfaces it alongside `homepage`/`tags` in the Claude entry. | Vendor-neutral | `tests/unit/marketplace/test_local_path_compose.py::test_compose_emits_local_source_as_string` | unit |

## How to test

- [ ] Create an `apm.yml` with `outputs: {claude: {}, codex: {}}` and a package that sets `category:` → run `apm pack --offline`.
- [ ] `grep '"category"' <claude output>` → the field is present with the declared value.
- [ ] `grep '"category"' <codex output>` → still present (unchanged behavior).
- [ ] Remove `category` from the package, re-run `apm pack --offline` → no `category` key in either output.
- [ ] `uv run --extra dev python -m pytest tests/unit/marketplace/test_local_path_compose.py` → all green.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
