### PR TITLE
test: add finite taxonomy and quality ratchets

### DIFF
--- a/.apm/instructions/tests.instructions.md
+++ b/.apm/instructions/tests.instructions.md
@@ -112,13 +112,26 @@ production code must follow (see
 
 The integration suite uses **declarative gating** via pytest markers,
 not per-file orchestrator enumeration. Adding a new integration test
-is two steps.
+does not require editing `scripts/test-integration.sh`.
+
+### Three independent marker axes
+
+Markers compose across three axes:
+
+| Axis | Question | Markers |
+|---|---|---|
+| Behavioral | What boundary does the test cross? | `unit`, `component`, `e2e` |
+| Scheduling | When is the test selected? | `integration`, `slow`, `benchmark`, `live` |
+| Prerequisite | What environment must exist? | `requires_*` |
+
+`live` is both an opt-in scheduling marker and an external-service
+prerequisite. Behavioral markers do not replace prerequisite markers.
 
 ### Procedure
 
 1. Drop the file under `tests/integration/test_<feature>.py`.
-2. At the top of the module, declare the runtime / network / E2E
-   prerequisites as a single `pytestmark`:
+2. At the top of the module, declare any scheduling and prerequisite
+   markers as a single `pytestmark`:
 
    ```python
    import pytest
@@ -135,10 +148,10 @@ That is it. The orchestrator (`scripts/test-integration.sh`) and the
 CI integration job collect everything under `tests/integration/` in
 a single `pytest` invocation; markers are honored automatically.
 
-### Marker selection
+### Prerequisite selection
 
-Pick the marker that matches the **strongest** prerequisite the test
-has. The full registry lives in `pyproject.toml` under
+Declare every prerequisite the test needs. The full registry lives in
+`pyproject.toml` under
 `[tool.pytest.ini_options].markers` and is documented (with the
 opt-in commands) in
 [`docs/src/content/docs/contributing/integration-testing.md`](../../docs/src/content/docs/contributing/integration-testing.md).
@@ -157,6 +170,50 @@ Quick map for the common cases:
 Need a marker that does not exist yet? Register it in
 `pyproject.toml` AND add a row to the docs registry table in the
 same PR. Both must stay in sync.
+
+### Behavioral classification for the critical suite
+
+| Marker | Definition |
+|---|---|
+| `unit` | Pure logic with no filesystem and no CLI |
+| `component` | In-process behavior that touches a filesystem or one command boundary |
+| `e2e` | A real installed CLI crossing at least one command boundary |
+
+`pyproject.toml` owns these definitions.
+`tests/quality/critical_suite.toml` owns the finite classified module set.
+Directory names and filename suffixes are not behavioral evidence. For
+example, `test_policy_pinned_constraint_e2e.py` is `component` because it uses
+Click in-process; `test_core_smoke.py` is `e2e` because it invokes an installed
+binary through subprocess boundaries.
+
+To extend the finite manifest:
+
+1. Confirm every test in the module crosses the same behavioral boundary.
+2. Add the literal module path and marker to `critical_suite.toml`.
+3. Add the module-level behavioral `pytestmark`; preserve independent
+   scheduling and prerequisite markers.
+4. If the filename suggests a different boundary, document why behavior wins.
+5. Run the taxonomy and quality contracts:
+
+```bash
+uv run --extra dev pytest -p no:cacheprovider -q tests/quality
+uv run --frozen python scripts/check_test_assertions.py
+uv run --frozen python scripts/check_exact_test_duplicates.py
+```
+
+Baseline updates may only tighten reductions. A new duplicate or assertion
+violation must be fixed, not accepted by an updater:
+
+```bash
+uv run --frozen python scripts/check_test_assertions.py --update-baseline
+uv run --frozen python scripts/check_exact_test_duplicates.py --update-baseline
+```
+
+Provisional mode is CI-only and permitted only while a pull request is a draft.
+Contributor commands, ready pull requests, merge queue runs, and final
+validation are strict and reject `provisional` metadata. Do not pass the
+internal provisional flag manually; remove the metadata after remeasurement
+and review.
 
 ### Anti-patterns (will land as `recommended` findings on review)
 

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -112,13 +112,26 @@ production code must follow (see
 
 The integration suite uses **declarative gating** via pytest markers,
 not per-file orchestrator enumeration. Adding a new integration test
-is two steps.
+does not require editing `scripts/test-integration.sh`.
+
+### Three independent marker axes
+
+Markers compose across three axes:
+
+| Axis | Question | Markers |
+|---|---|---|
+| Behavioral | What boundary does the test cross? | `unit`, `component`, `e2e` |
+| Scheduling | When is the test selected? | `integration`, `slow`, `benchmark`, `live` |
+| Prerequisite | What environment must exist? | `requires_*` |
+
+`live` is both an opt-in scheduling marker and an external-service
+prerequisite. Behavioral markers do not replace prerequisite markers.
 
 ### Procedure
 
 1. Drop the file under `tests/integration/test_<feature>.py`.
-2. At the top of the module, declare the runtime / network / E2E
-   prerequisites as a single `pytestmark`:
+2. At the top of the module, declare any scheduling and prerequisite
+   markers as a single `pytestmark`:
 
    ```python
    import pytest
@@ -135,10 +148,10 @@ That is it. The orchestrator (`scripts/test-integration.sh`) and the
 CI integration job collect everything under `tests/integration/` in
 a single `pytest` invocation; markers are honored automatically.
 
-### Marker selection
+### Prerequisite selection
 
-Pick the marker that matches the **strongest** prerequisite the test
-has. The full registry lives in `pyproject.toml` under
+Declare every prerequisite the test needs. The full registry lives in
+`pyproject.toml` under
 `[tool.pytest.ini_options].markers` and is documented (with the
 opt-in commands) in
 [`docs/src/content/docs/contributing/integration-testing.md`](../../docs/src/content/docs/contributing/integration-testing.md).
@@ -157,6 +170,50 @@ Quick map for the common cases:
 Need a marker that does not exist yet? Register it in
 `pyproject.toml` AND add a row to the docs registry table in the
 same PR. Both must stay in sync.
+
+### Behavioral classification for the critical suite
+
+| Marker | Definition |
+|---|---|
+| `unit` | Pure logic with no filesystem and no CLI |
+| `component` | In-process behavior that touches a filesystem or one command boundary |
+| `e2e` | A real installed CLI crossing at least one command boundary |
+
+`pyproject.toml` owns these definitions.
+`tests/quality/critical_suite.toml` owns the finite classified module set.
+Directory names and filename suffixes are not behavioral evidence. For
+example, `test_policy_pinned_constraint_e2e.py` is `component` because it uses
+Click in-process; `test_core_smoke.py` is `e2e` because it invokes an installed
+binary through subprocess boundaries.
+
+To extend the finite manifest:
+
+1. Confirm every test in the module crosses the same behavioral boundary.
+2. Add the literal module path and marker to `critical_suite.toml`.
+3. Add the module-level behavioral `pytestmark`; preserve independent
+   scheduling and prerequisite markers.
+4. If the filename suggests a different boundary, document why behavior wins.
+5. Run the taxonomy and quality contracts:
+
+```bash
+uv run --extra dev pytest -p no:cacheprovider -q tests/quality
+uv run --frozen python scripts/check_test_assertions.py
+uv run --frozen python scripts/check_exact_test_duplicates.py
+```
+
+Baseline updates may only tighten reductions. A new duplicate or assertion
+violation must be fixed, not accepted by an updater:
+
+```bash
+uv run --frozen python scripts/check_test_assertions.py --update-baseline
+uv run --frozen python scripts/check_exact_test_duplicates.py --update-baseline
+```
+
+Provisional mode is CI-only and permitted only while a pull request is a draft.
+Contributor commands, ready pull requests, merge queue runs, and final
+validation are strict and reject `provisional` metadata. Do not pass the
+internal provisional flag manually; remove the metadata after remeasurement
+and review.
 
 ### Anti-patterns (will land as `recommended` findings on review)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,37 @@ jobs:
     - name: Lint - architecture authority boundaries
       run: bash scripts/lint-architecture-boundaries.sh
 
+  test-architecture:
+    name: Test Architecture Ratchets
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
+
+    - name: Run ratchet contract tests
+      env:
+        APM_ALLOW_PROVISIONAL_BASELINES: ${{ github.event_name == 'pull_request' && github.event.pull_request.draft == true && '1' || '0' }}
+      run: |
+        uv run --extra dev pytest -p no:cacheprovider -q \
+          tests/unit/scripts/test_check_test_assertions.py \
+          tests/unit/scripts/test_check_exact_test_duplicates.py \
+          tests/quality/test_test_taxonomy.py \
+          tests/quality/test_quality_baselines.py \
+          tests/quality/test_ci_topology.py
+
   # Linux-only for PR feedback. Full platform matrix (incl. macOS + Windows) runs post-merge in build-release.yml.
   #
   # Two-way sharded with pytest-split, mirroring the pattern proven in

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -2853,7 +2853,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:b527ccaecf0e92f74d300fc9027f1bc49bb43d8ddcdd36338c1556fcde0d8b2d
+  content_hash: sha256:ba0d1f1003960beb7a469d35ef724641f902841b4cb07049600c691b8c66afe4
 local_deployed_files:
 - .agents/skills/apm-spec-guardian
 - .agents/skills/apm-spec-guardian/SKILL.md
@@ -3288,4 +3288,4 @@ local_deployed_file_hashes:
   .github/instructions/integrators.instructions.md: sha256:19919cbd04031a8a09be8aa0860aa941640b8313df74439e7bfac31310aa1b13
   .github/instructions/linting.instructions.md: sha256:8d31137f18842570bef6c93f8396587ac691e5fc973988bd865b008b0983f90d
   .github/instructions/python.instructions.md: sha256:8acd2bb824eb8d70a1977dfef309a5a122b49320d22222dd8d3544ca08712bca
-  .github/instructions/tests.instructions.md: sha256:b527ccaecf0e92f74d300fc9027f1bc49bb43d8ddcdd36338c1556fcde0d8b2d
+  .github/instructions/tests.instructions.md: sha256:ba0d1f1003960beb7a469d35ef724641f902841b4cb07049600c691b8c66afe4

--- a/docs/src/content/docs/contributing/integration-testing.md
+++ b/docs/src/content/docs/contributing/integration-testing.md
@@ -64,6 +64,61 @@ invocation is silent rather than red: every test is collected and
 reported as `SKIPPED` with a one-line reason, so you can see exactly
 what is missing and why.
 
+### Three marker axes
+
+Pytest markers compose across independent axes:
+
+| Axis | Question | Markers |
+| --- | --- | --- |
+| Behavioral | What boundary does the test cross? | `unit`, `component`, `e2e` |
+| Scheduling | When is the test selected? | `integration`, `slow`, `benchmark`, `live` |
+| Prerequisite | What environment must exist? | `requires_*` |
+
+`live` is both an opt-in scheduling marker and an external-service
+prerequisite. Behavioral markers do not replace prerequisite markers.
+
+The behavioral definitions are:
+
+| Marker | Definition |
+| --- | --- |
+| `unit` | Pure logic with no filesystem and no CLI |
+| `component` | In-process behavior that touches a filesystem or one command boundary |
+| `e2e` | A real installed CLI crossing at least one command boundary |
+
+`pyproject.toml` owns these definitions, while
+`tests/quality/critical_suite.toml` owns the finite classified module set.
+Directory names and `_e2e.py` suffixes are not proof of behavior.
+`test_policy_pinned_constraint_e2e.py` is `component` because it uses Click
+in-process; `test_core_smoke.py` is `e2e` because it invokes an installed
+binary through subprocess boundaries.
+
+To extend the manifest:
+
+1. Confirm the whole module has one behavioral boundary.
+2. Add its literal path and marker to `critical_suite.toml`.
+3. Add the module-level behavioral `pytestmark`, preserving any scheduling and
+   prerequisite markers.
+4. Document why behavior wins if the filename suggests another boundary.
+5. Run the contracts:
+
+```bash
+uv run --extra dev pytest -p no:cacheprovider -q tests/quality
+uv run --frozen python scripts/check_test_assertions.py
+uv run --frozen python scripts/check_exact_test_duplicates.py
+```
+
+The assertion and exact-duplicate baseline updaters only accept reductions.
+
+```bash
+uv run --frozen python scripts/check_test_assertions.py --update-baseline
+uv run --frozen python scripts/check_exact_test_duplicates.py --update-baseline
+```
+
+Provisional mode is CI-only and allowed only on draft pull requests.
+Contributor commands, ready pull requests, merge queue runs, and final
+validation are strict. Do not pass the internal provisional flag manually;
+remove `provisional` metadata after remeasurement and review.
+
 ### Common invocations
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,9 @@ exclude_lines = [
 [tool.pytest.ini_options]
 addopts = "-m 'not benchmark and not live'"
 markers = [
+    "unit: pure logic with no filesystem and no CLI",
+    "component: in-process behavior that touches a filesystem or one command boundary",
+    "e2e: a real installed CLI crossing at least one command boundary",
     "integration: marks tests as integration tests that may require network access",
     "live: marks tests that hit real GitHub repos (requires network + optional GITHUB_TOKEN)",
     "slow: marks tests as slow running tests",

--- a/scripts/check_exact_test_duplicates.py
+++ b/scripts/check_exact_test_duplicates.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Prevent growth in proven raw-byte-identical Python test modules."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+from ratchet_baseline import (
+    BaselineError,
+    load_baseline,
+    validate_provisional,
+    write_baseline,
+)
+from test_file_inventory import tracked_python_paths
+
+ALGORITHM = "sha256-bytes-v1"
+SCOPE = ["tests/**/test_*.py", "tests/**/*_test.py"]
+
+
+def test_modules(root: Path, scope: list[str]) -> list[Path]:
+    """Return contained, non-symlink tracked test modules for the scope."""
+    return tracked_python_paths(root, scope=tuple(scope))
+
+
+def duplicate_groups(root: Path, modules: list[Path]) -> dict[str, set[str]]:
+    """Group scoped test modules by SHA-256 of their unmodified bytes."""
+    by_hash: dict[str, set[str]] = defaultdict(set)
+    for path in modules:
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        by_hash[digest].add(path.relative_to(root).as_posix())
+    return {digest: paths for digest, paths in by_hash.items() if len(paths) > 1}
+
+
+def compare(
+    observed: dict[str, set[str]],
+    allowed: dict[str, set[str]],
+) -> tuple[list[str], list[str]]:
+    """Return new-debt and reduction diagnostics for exact groups."""
+    growth: list[str] = []
+    stale: list[str] = []
+    for digest, paths in sorted(observed.items()):
+        ceiling = allowed.get(digest)
+        if ceiling is None:
+            listed = "\n".join(f"  - {path}" for path in sorted(paths))
+            growth.append(
+                f"new exact duplicate group {digest}:\n{listed}\n"
+                "  Remediation: make each test module meaningfully distinct; "
+                "do not expand the baseline."
+            )
+        elif not paths <= ceiling:
+            added = sorted(paths - ceiling)
+            listed = "\n".join(f"  - {path}" for path in added)
+            growth.append(
+                f"exact duplicate group {digest} added tracked path(s):\n"
+                f"{listed}\n"
+                "  Remediation: remove or differentiate the added copy; "
+                "do not expand the baseline."
+            )
+    for digest, paths in sorted(allowed.items()):
+        current = observed.get(digest, set())
+        if current != paths and current <= paths:
+            stale.append(
+                f"exact duplicate group {digest} reduced: {sorted(paths)} -> {sorted(current)}"
+            )
+    return growth, stale
+
+
+def main(argv: list[str] | None = None) -> int:  # noqa: PLR0911
+    """Check the baseline, or tighten it when only reductions are observed."""
+    parser = argparse.ArgumentParser(
+        description="Check exact raw-byte test duplicate no-growth ceilings."
+    )
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--baseline", type=Path)
+    parser.add_argument("--update-baseline", action="store_true")
+    parser.add_argument(
+        "--allow-provisional",
+        action="store_true",
+        help="Allow explicitly provisional metadata during non-final checks.",
+    )
+    args = parser.parse_args(argv)
+
+    root = args.root.resolve()
+    baseline = (
+        args.baseline.resolve()
+        if args.baseline is not None
+        else root / "tests" / "quality" / "exact_test_duplicates.json"
+    )
+    try:
+        payload = load_baseline(baseline, label="exact-duplicate")
+        provisional = validate_provisional(
+            payload,
+            baseline,
+            allow=args.allow_provisional,
+            label="exact-duplicate",
+        )
+    except BaselineError as error:
+        print(f"[x] {error}", file=sys.stderr)
+        return 2
+    required_keys = {"algorithm", "duplicate_groups", "schema_version", "scope"}
+    allowed_keys = required_keys | {"provisional"}
+    if not required_keys <= set(payload) or not set(payload) <= allowed_keys:
+        print(
+            "[x] invalid exact-duplicate baseline: unexpected object shape",
+            file=sys.stderr,
+        )
+        return 2
+    if payload["schema_version"] != 1 or payload["algorithm"] != ALGORITHM:
+        print(
+            "[x] invalid exact-duplicate baseline: unsupported schema or algorithm",
+            file=sys.stderr,
+        )
+        return 2
+    if payload["scope"] != SCOPE:
+        print(
+            "[x] invalid exact-duplicate baseline: scope must remain exact",
+            file=sys.stderr,
+        )
+        return 2
+
+    raw_groups = payload["duplicate_groups"]
+    if not isinstance(raw_groups, list):
+        print(
+            "[x] invalid exact-duplicate baseline: duplicate_groups must be a list",
+            file=sys.stderr,
+        )
+        return 2
+    allowed: dict[str, set[str]] = {}
+    seen_paths: set[str] = set()
+    for group in raw_groups:
+        if not isinstance(group, dict) or set(group) != {"paths", "sha256"}:
+            print(
+                "[x] invalid exact-duplicate baseline: malformed group",
+                file=sys.stderr,
+            )
+            return 2
+        digest = group["sha256"]
+        paths = group["paths"]
+        if not isinstance(digest, str) or re.fullmatch(r"[0-9a-f]{64}", digest) is None:
+            print(
+                "[x] invalid exact-duplicate baseline: malformed sha256",
+                file=sys.stderr,
+            )
+            return 2
+        if (
+            not isinstance(paths, list)
+            or len(paths) < 2
+            or any(not isinstance(path, str) or not path for path in paths)
+            or paths != sorted(set(paths))
+        ):
+            print(
+                "[x] invalid exact-duplicate baseline: paths must be sorted and unique",
+                file=sys.stderr,
+            )
+            return 2
+        if digest in allowed or seen_paths.intersection(paths):
+            print(
+                "[x] invalid exact-duplicate baseline: repeated digest or path",
+                file=sys.stderr,
+            )
+            return 2
+        allowed[digest] = set(paths)
+        seen_paths.update(paths)
+
+    try:
+        modules = test_modules(root, payload["scope"])
+        observed = duplicate_groups(root, modules)
+    except (OSError, UnicodeError, ValueError) as error:
+        print(f"[x] exact-duplicate scan failed: {error}", file=sys.stderr)
+        return 2
+    growth, stale = compare(observed, allowed)
+    if growth:
+        for diagnostic in growth:
+            print(f"[x] {diagnostic}", file=sys.stderr)
+        if args.update_baseline:
+            print(
+                "[x] refusing to update exact-duplicate baseline with new debt; "
+                "fix the listed copies instead",
+                file=sys.stderr,
+            )
+        return 1
+    if stale and not args.update_baseline:
+        for diagnostic in stale:
+            print(f"[x] {diagnostic}", file=sys.stderr)
+        command = "uv run --frozen python scripts/check_exact_test_duplicates.py --update-baseline"
+        print(
+            "[x] exact-duplicate baseline is stale after resolved copies. "
+            f"Review the reductions, then run '{command}'.",
+            file=sys.stderr,
+        )
+        return 1
+    if stale:
+        removed_groups = len(set(allowed) - set(observed))
+        removed_paths = sum(len(paths) for paths in allowed.values()) - sum(
+            len(paths) for paths in observed.values()
+        )
+        updated_groups = [
+            {"paths": sorted(paths), "sha256": digest} for digest, paths in sorted(observed.items())
+        ]
+        updated: dict[str, object] = {
+            "algorithm": ALGORITHM,
+            "duplicate_groups": updated_groups,
+            "schema_version": 1,
+            "scope": SCOPE,
+        }
+        if provisional is not None:
+            updated["provisional"] = provisional
+        try:
+            write_baseline(
+                baseline,
+                updated,
+                label="exact-duplicate",
+            )
+        except BaselineError as error:
+            print(f"[x] {error}", file=sys.stderr)
+            return 2
+        print(
+            "[+] updated exact-duplicate baseline: removed "
+            f"{removed_groups} resolved group(s) and "
+            f"{removed_paths} stale path entr{'y' if removed_paths == 1 else 'ies'}"
+        )
+    elif args.update_baseline:
+        print("[i] exact-duplicate baseline already current; no update written")
+
+    print(
+        f"[+] exact test duplicate ratchet clean: {len(modules)} files, "
+        f"{len(observed)} allowed duplicate group(s)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_test_assertions.py
+++ b/scripts/check_test_assertions.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Enforce bounded no-growth ceilings for two assertion-quality forms."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+from ratchet_baseline import (
+    BaselineError,
+    load_baseline,
+    validate_provisional,
+    write_baseline,
+)
+from test_file_inventory import tracked_python_paths
+
+RULE_AQ001 = "AQ001_constant_assertion"
+RULE_AQ002 = "AQ002_broad_pytest_raises"
+RULES = (RULE_AQ001, RULE_AQ002)
+
+
+def scan(root: Path) -> dict[str, dict[str, list[int]]]:
+    """Locate only AQ001 constant assertions and AQ002 broad pytest.raises."""
+    observed: dict[str, defaultdict[str, list[int]]] = {rule: defaultdict(list) for rule in RULES}
+    for path in tracked_python_paths(
+        root,
+        scope=("tests/*.py", "tests/**/*.py"),
+    ):
+        relative = path.relative_to(root).as_posix()
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=relative)
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Assert)
+                and isinstance(node.test, ast.Constant)
+                and (node.test.value is True or node.test.value is False or node.test.value is None)
+            ):
+                observed[RULE_AQ001][relative].append(node.lineno)
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "raises"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "pytest"
+                and node.args
+                and isinstance(node.args[0], ast.Name)
+                and node.args[0].id in {"Exception", "BaseException"}
+            ):
+                observed[RULE_AQ002][relative].append(node.lineno)
+    return {
+        rule: {path: sorted(lines) for path, lines in sorted(observed[rule].items())}
+        for rule in RULES
+    }
+
+
+def compare(
+    observed: dict[str, dict[str, list[int]]],
+    allowed: dict[str, dict[str, int]],
+) -> tuple[list[str], list[str]]:
+    """Return growth and stale-reduction diagnostics."""
+    growth: list[str] = []
+    stale: list[str] = []
+    for rule in RULES:
+        paths = set(observed[rule]) | set(allowed[rule])
+        for path in sorted(paths):
+            lines = observed[rule].get(path, [])
+            current = len(lines)
+            ceiling = allowed[rule].get(path, 0)
+            if current > ceiling:
+                if rule == RULE_AQ001:
+                    problem = "constant assertion does not test behavior"
+                    remedy = "replace it with an assertion over observed output or state"
+                else:
+                    problem = "pytest.raises catches Exception or BaseException"
+                    remedy = "assert the narrow exception type raised by this scenario"
+                locations = ", ".join(f"{path}:{line}" for line in lines)
+                growth.append(
+                    f"{locations}: {rule}: {problem} "
+                    f"(observed {current}, allowed {ceiling}); {remedy}"
+                )
+            elif current < ceiling:
+                stale.append(f"{path}: {rule} reduced to {current} from {ceiling}")
+    return growth, stale
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Check the baseline, or tighten it when only reductions are observed."""
+    parser = argparse.ArgumentParser(
+        description="Check AQ001/AQ002 assertion-quality no-growth ceilings."
+    )
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--baseline", type=Path)
+    parser.add_argument("--update-baseline", action="store_true")
+    parser.add_argument(
+        "--allow-provisional",
+        action="store_true",
+        help="Allow explicitly provisional metadata during non-final checks.",
+    )
+    args = parser.parse_args(argv)
+
+    root = args.root.resolve()
+    baseline = (
+        args.baseline.resolve()
+        if args.baseline is not None
+        else root / "tests" / "quality" / "assertion_quality_baseline.json"
+    )
+    try:
+        payload = load_baseline(baseline, label="assertion-quality")
+        provisional = validate_provisional(
+            payload,
+            baseline,
+            allow=args.allow_provisional,
+            label="assertion-quality",
+        )
+    except BaselineError as error:
+        print(f"[x] {error}", file=sys.stderr)
+        return 2
+    required_keys = {"schema_version", "rules"}
+    allowed_keys = required_keys | {"provisional"}
+    if not required_keys <= set(payload) or not set(payload) <= allowed_keys:
+        print(
+            "[x] invalid assertion-quality baseline: unexpected object shape",
+            file=sys.stderr,
+        )
+        return 2
+    if payload["schema_version"] != 1:
+        print(
+            "[x] invalid assertion-quality baseline: schema_version must be 1",
+            file=sys.stderr,
+        )
+        return 2
+
+    raw_rules = payload["rules"]
+    if not isinstance(raw_rules, dict) or set(raw_rules) != set(RULES):
+        print(
+            "[x] invalid assertion-quality baseline: both named rules are required",
+            file=sys.stderr,
+        )
+        return 2
+    allowed: dict[str, dict[str, int]] = {}
+    for rule in RULES:
+        by_path = raw_rules[rule]
+        if not isinstance(by_path, dict):
+            print(
+                f"[x] invalid assertion-quality baseline: {rule} must be an object",
+                file=sys.stderr,
+            )
+            return 2
+        normalized: dict[str, int] = {}
+        for path, count in by_path.items():
+            if not isinstance(path, str) or not path or type(count) is not int or count < 0:
+                print(
+                    f"[x] invalid assertion-quality baseline: bad count in {rule}",
+                    file=sys.stderr,
+                )
+                return 2
+            normalized[path] = count
+        allowed[rule] = normalized
+
+    try:
+        observed = scan(root)
+    except (OSError, UnicodeError, SyntaxError, ValueError) as error:
+        print(f"[x] assertion-quality scan failed: {error}", file=sys.stderr)
+        return 2
+    growth, stale = compare(observed, allowed)
+    if growth:
+        for diagnostic in growth:
+            print(f"[x] {diagnostic}", file=sys.stderr)
+        if args.update_baseline:
+            print(
+                "[x] refusing to update assertion baseline with new debt; "
+                "fix the listed assertions instead",
+                file=sys.stderr,
+            )
+        return 1
+    if stale and not args.update_baseline:
+        for diagnostic in stale:
+            print(f"[x] {diagnostic}", file=sys.stderr)
+        command = "uv run --frozen python scripts/check_test_assertions.py --update-baseline"
+        print(
+            "[x] assertion baseline is stale after resolved findings. "
+            f"Review the reductions, then run '{command}'.",
+            file=sys.stderr,
+        )
+        return 1
+    if stale:
+        reductions = sum(
+            allowed[rule].get(path, 0) - len(observed[rule].get(path, []))
+            for rule in RULES
+            for path in allowed[rule]
+        )
+        updated_rules = {
+            rule: {path: len(lines) for path, lines in observed[rule].items()} for rule in RULES
+        }
+        updated: dict[str, object] = {
+            "schema_version": 1,
+            "rules": updated_rules,
+        }
+        if provisional is not None:
+            updated["provisional"] = provisional
+        try:
+            write_baseline(
+                baseline,
+                updated,
+                label="assertion",
+            )
+        except BaselineError as error:
+            print(f"[x] {error}", file=sys.stderr)
+            return 2
+        print(
+            f"[+] updated assertion-quality baseline: removed {reductions} resolved occurrence(s)"
+        )
+    elif args.update_baseline:
+        print("[i] assertion-quality baseline already current; no update written")
+
+    aq001_total = sum(len(lines) for lines in observed[RULE_AQ001].values())
+    aq002_total = sum(len(lines) for lines in observed[RULE_AQ002].values())
+    print(f"[+] assertion-quality ratchet clean: AQ001={aq001_total}, AQ002={aq002_total}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_test_contract_authorities.py
+++ b/scripts/check_test_contract_authorities.py
@@ -27,6 +27,25 @@ LOCAL_BINARY_FACADES = {
     "apm_binary",
     "apm_command",
 }
+TEST_FILE_INVENTORY_OWNER = Path("scripts/test_file_inventory.py")
+RATCHET_BASELINE_OWNER = Path("scripts/ratchet_baseline.py")
+# Manual allowlist: every new ratchet consumer must enroll here for AC9.
+RATCHET_AUTHORITY_CONSUMERS = {
+    Path("scripts/check_test_assertions.py"): (
+        "from test_file_inventory import tracked_python_paths",
+        "from ratchet_baseline import",
+    ),
+    Path("scripts/check_exact_test_duplicates.py"): (
+        "from test_file_inventory import tracked_python_paths",
+        "from ratchet_baseline import",
+    ),
+    Path("tests/quality/repository_python_inventory.py"): (
+        "from scripts.test_file_inventory import tracked_python_paths",
+    ),
+    Path("tests/quality/test_ci_topology.py"): (
+        "from scripts.test_file_inventory import is_test_module_path",
+    ),
+}
 
 
 def _python_files(root: Path, locations: tuple[str, ...]) -> list[Path]:
@@ -916,11 +935,53 @@ def find_rendered_parity_violations(root: Path) -> list[str]:
     return sorted(set(diagnostics))
 
 
+def find_ratchet_authority_violations(root: Path) -> list[str]:
+    """Require ratchet consumers to route through shared file/baseline owners."""
+    diagnostics: list[str] = []
+    for owner in (TEST_FILE_INVENTORY_OWNER, RATCHET_BASELINE_OWNER):
+        if not (root / owner).is_file():
+            diagnostics.append(f"[x] missing ratchet authority owner: {owner}")
+
+    for relative, required_imports in RATCHET_AUTHORITY_CONSUMERS.items():
+        path = root / relative
+        if not path.is_file():
+            diagnostics.append(f"[x] missing ratchet authority consumer: {relative}")
+            continue
+        text = path.read_text(encoding="utf-8")
+        for required_import in required_imports:
+            if required_import not in text:
+                diagnostics.append(
+                    f"[x] {relative} must consume ratchet authority: {required_import}"
+                )
+
+    local_inventory_shapes = {
+        Path("scripts/check_test_assertions.py"): (
+            'rglob("*.py")',
+            '"ls-files"',
+        ),
+        Path("scripts/check_exact_test_duplicates.py"): ('"ls-files"',),
+        Path("tests/quality/repository_python_inventory.py"): ('"ls-files"',),
+    }
+    for relative, forbidden_shapes in local_inventory_shapes.items():
+        path = root / relative
+        if not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8")
+        for forbidden in forbidden_shapes:
+            if forbidden in text:
+                diagnostics.append(
+                    f"[x] duplicate tracked Python inventory in {relative}: "
+                    f"{forbidden}; owner is {TEST_FILE_INVENTORY_OWNER}"
+                )
+    return sorted(diagnostics)
+
+
 def check(root: Path) -> list[str]:
     """Return all canonical-owner violations for the repository."""
     return [
         *find_binary_selection_violations(root),
         *find_rendered_parity_violations(root),
+        *find_ratchet_authority_violations(root),
     ]
 
 

--- a/scripts/ratchet_baseline.py
+++ b/scripts/ratchet_baseline.py
@@ -1,0 +1,72 @@
+"""Shared JSON baseline lifecycle for bounded test-quality ratchets."""
+
+from __future__ import annotations
+
+import json
+from json import JSONDecodeError
+from pathlib import Path
+
+PROVISIONAL_KEYS = {"basis_commit", "required_follow_up"}
+
+
+class BaselineError(ValueError):
+    """Raised when a ratchet baseline cannot be trusted or updated."""
+
+
+def load_baseline(path: Path, *, label: str) -> dict[str, object]:
+    """Load one baseline as a JSON object with consistent errors."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (
+        FileNotFoundError,
+        IsADirectoryError,
+        PermissionError,
+        JSONDecodeError,
+    ) as error:
+        raise BaselineError(f"invalid {label} baseline {path}: {error}") from error
+    if not isinstance(payload, dict):
+        raise BaselineError(f"invalid {label} baseline: root must be an object")
+    return payload
+
+
+def validate_provisional(
+    payload: dict[str, object],
+    path: Path,
+    *,
+    allow: bool,
+    label: str,
+) -> dict[str, str] | None:
+    """Validate provisional metadata and enforce final mode."""
+    provisional = payload.get("provisional")
+    if provisional is not None and (
+        not isinstance(provisional, dict)
+        or set(provisional) != PROVISIONAL_KEYS
+        or not all(isinstance(value, str) and value for value in provisional.values())
+    ):
+        raise BaselineError(f"invalid {label} baseline: malformed provisional metadata")
+    if provisional is not None and not allow:
+        raise BaselineError(
+            f"provisional baseline is not allowed in final mode: {path}. "
+            "Remeasure and remove provisional metadata before final validation; "
+            "use --allow-provisional only for explicitly provisional checks."
+        )
+    return provisional
+
+
+def write_baseline(
+    path: Path,
+    payload: dict[str, object],
+    *,
+    label: str,
+) -> None:
+    """Atomically write canonical sorted JSON."""
+    temporary = path.with_name(f".{path.name}.tmp")
+    try:
+        temporary.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    except OSError as error:
+        temporary.unlink(missing_ok=True)
+        raise BaselineError(f"failed to update {label} baseline: {error}") from error

--- a/scripts/test_file_inventory.py
+++ b/scripts/test_file_inventory.py
@@ -1,0 +1,56 @@
+"""Canonical tracked Python file inventory for test-quality ratchets."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def tracked_python_paths(
+    root: Path,
+    *,
+    scope: tuple[str, ...] = (),
+) -> list[Path]:
+    """Return contained, non-symlink tracked Python paths for `scope`."""
+    root = root.resolve()
+    git = shutil.which("git")
+    if git is None:
+        raise ValueError("git executable not found")
+    pathspecs = [f":(glob){pattern}" for pattern in scope]
+    result = subprocess.run(  # noqa: S603 - fixed git operation, no shell
+        [git, "-C", str(root), "ls-files", "-z", "--", *pathspecs],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode("utf-8", errors="replace").strip()
+        raise ValueError(f"git ls-files failed: {detail}")
+
+    paths: list[Path] = []
+    for relative_text in result.stdout.decode("utf-8").split("\0"):
+        if not relative_text or not relative_text.endswith(".py"):
+            continue
+        relative = Path(relative_text)
+        if relative.is_absolute() or ".." in relative.parts:
+            raise ValueError(f"tracked Python path escapes repository: {relative_text}")
+        path = root / relative
+        resolved = path.resolve(strict=True)
+        try:
+            resolved.relative_to(root)
+        except ValueError as error:
+            raise ValueError(
+                f"tracked Python path resolves outside repository: {relative_text}"
+            ) from error
+        if path.is_symlink():
+            raise ValueError(f"tracked Python path is a symlink: {relative_text}")
+        if not path.is_file():
+            raise ValueError(f"tracked Python path is not a regular file: {relative_text}")
+        paths.append(path)
+    return sorted(paths)
+
+
+def is_test_module_path(path: str | Path) -> bool:
+    """Return whether a path matches either pytest module naming convention."""
+    name = Path(path).name
+    return name.startswith("test_") or name.endswith("_test.py")

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -439,6 +439,16 @@ def test_executable_test_contracts_have_one_canonical_owner() -> None:
     assert checker.check(root) == []
 
 
+def test_quality_ratchets_route_through_shared_authorities() -> None:
+    """Ratchet file discovery and baseline writes must have one owner each."""
+    root = Path(__file__).parents[2]
+    guard = (root / "scripts/lint-architecture-boundaries.sh").read_text()
+    checker = _load_test_contract_checker(root)
+
+    assert "check_test_contract_authorities.py" in guard
+    assert checker.find_ratchet_authority_violations(root) == []
+
+
 def test_windows_owner_row_stays_synced_source_deployed_and_lockfile() -> None:
     """The new owner-table row must not silently drop on the next deploy.
 

--- a/tests/integration/test_core_smoke.py
+++ b/tests/integration/test_core_smoke.py
@@ -47,6 +47,7 @@ from pathlib import Path
 import pytest
 
 pytestmark = [
+    pytest.mark.e2e,
     pytest.mark.requires_e2e_mode,
     pytest.mark.requires_apm_binary,
 ]

--- a/tests/integration/test_install_content_hash_roundtrip.py
+++ b/tests/integration/test_install_content_hash_roundtrip.py
@@ -26,6 +26,8 @@ from apm_cli.models.apm_package import (
 )
 from apm_cli.models.dependency.reference import DependencyReference
 
+pytestmark = pytest.mark.component
+
 _PATCH_UPDATES = "apm_cli.commands._helpers.check_for_updates"
 
 

--- a/tests/integration/test_marker_registry_sync.py
+++ b/tests/integration/test_marker_registry_sync.py
@@ -85,10 +85,11 @@ def _conftest_marker_names() -> set[str]:
 
 
 def _gating_markers_in_pyproject() -> set[str]:
-    """Subset of pyproject markers that gate execution (requires_* + live).
+    """Return only execution prerequisites wired into the skip registry.
 
-    ``integration``, ``slow``, ``benchmark`` are taxonomy markers, not
-    gates, and are intentionally excluded from the docs registry.
+    Behavioral markers (unit/component/e2e) and pure scheduling markers
+    (integration/slow/benchmark) are not environment gates. ``live`` is both
+    opt-in scheduling and an external-service gate.
     """
     names = _pyproject_marker_names()
     return {n for n in names if n.startswith("requires_") or n == "live"}

--- a/tests/integration/test_policy_pinned_constraint_e2e.py
+++ b/tests/integration/test_policy_pinned_constraint_e2e.py
@@ -17,6 +17,8 @@ from click.testing import CliRunner
 from apm_cli.policy.discovery import PolicyFetchResult
 from apm_cli.policy.schema import ApmPolicy, DependencyPolicy
 
+pytestmark = pytest.mark.component
+
 _PATCH_DISCOVER_GATE = "apm_cli.policy.discovery.discover_policy_with_chain"
 _PATCH_DISCOVER_PREFLIGHT = "apm_cli.policy.install_preflight.discover_policy_with_chain"
 _PATCH_UPDATES = "apm_cli.commands._helpers.check_for_updates"

--- a/tests/quality/assertion_quality_baseline.json
+++ b/tests/quality/assertion_quality_baseline.json
@@ -1,0 +1,20 @@
+{
+  "rules": {
+    "AQ001_constant_assertion": {
+      "tests/integration/test_integrators_end_to_end.py": 1,
+      "tests/integration/test_integrators_phase3.py": 1,
+      "tests/red_team/http/test_header_injection.py": 1,
+      "tests/unit/compilation/test_compile_cli_phase3.py": 1,
+      "tests/unit/compilation/test_compile_cli_surface.py": 1
+    },
+    "AQ002_broad_pytest_raises": {
+      "tests/integration/test_download_strategies_phase3w5.py": 1,
+      "tests/integration/test_download_strategies_selection.py": 1,
+      "tests/unit/deps/test_shared_clone_cache.py": 1,
+      "tests/unit/install/test_mcp_registry_module.py": 6,
+      "tests/unit/registry/test_resolver.py": 2,
+      "tests/unit/registry/test_resolver_e2e_http.py": 1
+    }
+  },
+  "schema_version": 1
+}

--- a/tests/quality/conftest.py
+++ b/tests/quality/conftest.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.quality.repository_python_inventory import (
+    PythonModuleFacts,
+    tracked_python_inventory,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture(scope="session")
+def repository_python_inventory() -> dict[str, PythonModuleFacts]:
+    """Share one tracked Python AST inventory across quality contracts."""
+    return tracked_python_inventory(REPO_ROOT)

--- a/tests/quality/critical_suite.toml
+++ b/tests/quality/critical_suite.toml
@@ -1,0 +1,21 @@
+schema_version = 1
+
+[[modules]]
+path = "tests/unit/core/test_install_audit.py"
+marker = "unit"
+
+[[modules]]
+path = "tests/unit/deps/test_lockfile_git_semver.py"
+marker = "unit"
+
+[[modules]]
+path = "tests/integration/test_install_content_hash_roundtrip.py"
+marker = "component"
+
+[[modules]]
+path = "tests/integration/test_policy_pinned_constraint_e2e.py"
+marker = "component"
+
+[[modules]]
+path = "tests/integration/test_core_smoke.py"
+marker = "e2e"

--- a/tests/quality/exact_test_duplicates.json
+++ b/tests/quality/exact_test_duplicates.json
@@ -1,0 +1,66 @@
+{
+  "algorithm": "sha256-bytes-v1",
+  "duplicate_groups": [
+    {
+      "paths": [
+        "tests/integration/test_deps_resolver_phase3b.py",
+        "tests/integration/test_deps_resolver_resolution.py"
+      ],
+      "sha256": "228e15b22951f92a6b91f278be05b58775b4f0b3671060259719f15ce0f70726"
+    },
+    {
+      "paths": [
+        "tests/unit/test_output_formatters_phase3.py",
+        "tests/unit/test_output_formatters_rendering.py"
+      ],
+      "sha256": "403ac8e70abd0546fcf212de19c77c6d451b351ffd00ddc98fb77469372a2ea7"
+    },
+    {
+      "paths": [
+        "tests/integration/test_mcp_integrator_characterisation.py",
+        "tests/integration/test_mcp_integrator_phase3w5.py"
+      ],
+      "sha256": "608d378e361fa7b91b5ae307cefbc36d30c77a7a43394860bed518416c760d5a"
+    },
+    {
+      "paths": [
+        "tests/integration/test_commands_mcp_flow.py",
+        "tests/integration/test_commands_mcp_phase3c.py"
+      ],
+      "sha256": "90abcd6c6ac4d79f1bfce4a236cb1ab74346089401ee891921cfafa389a2cf45"
+    },
+    {
+      "paths": [
+        "tests/integration/test_uninstall_policy_pack_flow.py",
+        "tests/integration/test_uninstall_policy_pack_phase3.py"
+      ],
+      "sha256": "a80fc52b42decf8ae8dcf3b78a45b1cc0c9f6e554eb0c9848b8e6dcd58d1dc1c"
+    },
+    {
+      "paths": [
+        "tests/integration/test_command_integrator_hermetic.py",
+        "tests/integration/test_command_integrator_phase3w5.py"
+      ],
+      "sha256": "b9917ef5c16f8d2e3587fe635baca0dd08ce56bbc6914c5ef2917443f69600a3"
+    },
+    {
+      "paths": [
+        "tests/integration/test_yml_schema_phase3w5.py",
+        "tests/integration/test_yml_schema_validation.py"
+      ],
+      "sha256": "dedfae8f8c7d10355d2042afe89a55190a3a0a22eafdb4d30d7d3e2d9a437e22"
+    },
+    {
+      "paths": [
+        "tests/integration/test_validation_phase3w5.py",
+        "tests/integration/test_validation_rules.py"
+      ],
+      "sha256": "f85beaf48104869412c0189e7f0eef9cf6c2eb368b9efb198e94bc05f75dda24"
+    }
+  ],
+  "schema_version": 1,
+  "scope": [
+    "tests/**/test_*.py",
+    "tests/**/*_test.py"
+  ]
+}

--- a/tests/quality/repository_python_inventory.py
+++ b/tests/quality/repository_python_inventory.py
@@ -1,0 +1,59 @@
+"""Build one tracked Python AST inventory for quality topology tests."""
+
+from __future__ import annotations
+
+import ast
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+
+from scripts.test_file_inventory import tracked_python_paths
+
+SCOPE_MARKER = "RATCHET_TEST_SCOPE"
+INVENTORY_CALLS: Counter[Path] = Counter()
+
+
+@dataclass(frozen=True)
+class PythonModuleFacts:
+    """Static facts consumed by bounded quality ownership checks."""
+
+    string_literals: frozenset[str]
+    ratchet_scope: str | None
+
+
+def tracked_python_inventory(root: Path) -> dict[str, PythonModuleFacts]:
+    """Parse every tracked Python file once without caching across roots."""
+    root = root.resolve()
+    INVENTORY_CALLS[root] += 1
+
+    inventory: dict[str, PythonModuleFacts] = {}
+    for path in tracked_python_paths(root):
+        relative = path.relative_to(root)
+        relative_text = relative.as_posix()
+        tree = ast.parse(
+            path.read_text(encoding="utf-8"),
+            filename=relative_text,
+        )
+        scope_values = {
+            node.value.value
+            for node in tree.body
+            if isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == SCOPE_MARKER
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        }
+        if len(scope_values) > 1:
+            raise RuntimeError(
+                f"multiple {SCOPE_MARKER} values in {relative_text}: {sorted(scope_values)}"
+            )
+        inventory[relative.as_posix()] = PythonModuleFacts(
+            string_literals=frozenset(
+                node.value
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Constant) and isinstance(node.value, str)
+            ),
+            ratchet_scope=next(iter(scope_values), None),
+        )
+    return inventory

--- a/tests/quality/taxonomy_inventory_plugin.py
+++ b/tests/quality/taxonomy_inventory_plugin.py
@@ -1,0 +1,29 @@
+"""Emit one repository-wide node and behavioral-marker inventory."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+BEHAVIORAL_MARKERS = frozenset({"unit", "component", "e2e"})
+OUTPUT_ENV = "APM_TAXONOMY_INVENTORY"
+
+
+def pytest_collection_finish(session: pytest.Session) -> None:
+    """Write the collected node IDs and their behavioral markers once."""
+    output = os.environ.get(OUTPUT_ENV)
+    if output is None:
+        raise pytest.UsageError(f"{OUTPUT_ENV} must name the inventory output")
+    inventory = {
+        item.nodeid: sorted(
+            marker.name for marker in item.iter_markers() if marker.name in BEHAVIORAL_MARKERS
+        )
+        for item in session.items
+    }
+    Path(output).write_text(
+        json.dumps(inventory, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )

--- a/tests/quality/test_ci_topology.py
+++ b/tests/quality/test_ci_topology.py
@@ -1,0 +1,318 @@
+from __future__ import annotations
+
+import subprocess
+from collections import Counter
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from scripts.test_file_inventory import is_test_module_path
+from tests.quality.repository_python_inventory import (
+    INVENTORY_CALLS,
+    PythonModuleFacts,
+    tracked_python_inventory,
+)
+from tests.workflow_contracts import (
+    WorkflowNode,
+    load_workflow,
+    shell_commands,
+    workflow_job,
+    workflow_step,
+)
+
+RATCHET_TEST_SCOPE = "repository"
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RATCHET_JOB = "test-architecture"
+RATCHET_CHECK = "Test Architecture Ratchets"
+ALLOW_PROVISIONAL_KEY = "APM_ALLOW_PROVISIONAL_BASELINES"
+DRAFT_PROVISIONAL_GUARD = (
+    "${{ github.event_name == 'pull_request' && "
+    "github.event.pull_request.draft == true && '1' || '0' }}"
+)
+REPOSITORY_SCOPE = "repository"
+FIXTURE_SCOPE = "fixture"
+REPOSITORY_ROOT = "tests/quality"
+FIXTURE_ROOT = "tests/unit/scripts"
+REQUIRED_SHARD_CHECKS = (
+    "Build & Test Shard 1 (Linux)",
+    "Build & Test Shard 2 (Linux)",
+)
+REQUIRED_SHARD_ROOTS = (
+    "tests/unit",
+    "tests/test_console.py",
+    "tests/red_team",
+)
+
+
+def _run_steps(job: WorkflowNode) -> list[WorkflowNode]:
+    steps = job.get("steps")
+    if not isinstance(steps, list):
+        return []
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def _pytest_targets(job: WorkflowNode) -> tuple[str, ...]:
+    targets: list[str] = []
+    for step in _run_steps(job):
+        run = step.get("run")
+        if not isinstance(run, str) or "pytest" not in run:
+            continue
+        for tokens in shell_commands(step):
+            if "pytest" not in tokens:
+                continue
+            pytest_index = tokens.index("pytest")
+            targets.extend(
+                token for token in tokens[pytest_index + 1 :] if token.startswith("tests/")
+            )
+    return tuple(targets)
+
+
+def _ratchet_test_inventory(
+    python_inventory: dict[str, PythonModuleFacts],
+) -> dict[str, str]:
+    return {
+        path: facts.ratchet_scope
+        for path, facts in python_inventory.items()
+        if is_test_module_path(path) and facts.ratchet_scope is not None
+    }
+
+
+def _assert_ci_provisional_guard(
+    ci: WorkflowNode,
+) -> None:
+    jobs = ci["jobs"]
+    assert isinstance(jobs, dict)
+    bindings: list[tuple[str, str, object]] = []
+    for job_name, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        for step in _run_steps(job):
+            env = step.get("env")
+            if isinstance(env, dict) and ALLOW_PROVISIONAL_KEY in env:
+                bindings.append(
+                    (
+                        job_name,
+                        str(step.get("name", "")),
+                        env[ALLOW_PROVISIONAL_KEY],
+                    )
+                )
+            run = step.get("run")
+            if isinstance(run, str):
+                assert "--allow-provisional" not in run
+                assert f"{ALLOW_PROVISIONAL_KEY}=1" not in run
+
+    expected = [
+        (
+            RATCHET_JOB,
+            "Run ratchet contract tests",
+            DRAFT_PROVISIONAL_GUARD,
+        )
+    ]
+    assert bindings == expected
+
+
+def _assert_ci_test_targets(
+    ci: WorkflowNode,
+    inventory: dict[str, str],
+) -> None:
+    repository_modules = {path for path, scope in inventory.items() if scope == REPOSITORY_SCOPE}
+    fixture_modules = {path for path, scope in inventory.items() if scope == FIXTURE_SCOPE}
+    ratchet = workflow_job(ci, RATCHET_JOB)
+    expected_ratchet_targets = Counter({path: 1 for path in repository_modules | fixture_modules})
+    assert Counter(_pytest_targets(ratchet)) == expected_ratchet_targets
+
+    required_shard = workflow_job(ci, "build-and-test-shard")
+    assert _pytest_targets(required_shard) == REQUIRED_SHARD_ROOTS
+
+
+def _assert_topology(root: Path, inventory: dict[str, str]) -> None:
+    repository_modules = {path for path, scope in inventory.items() if scope == REPOSITORY_SCOPE}
+    fixture_modules = {path for path, scope in inventory.items() if scope == FIXTURE_SCOPE}
+    unknown_scopes = {
+        path: scope
+        for path, scope in inventory.items()
+        if scope not in {REPOSITORY_SCOPE, FIXTURE_SCOPE}
+    }
+    assert unknown_scopes == {}
+    assert repository_modules
+    assert all(path.startswith(f"{REPOSITORY_ROOT}/") for path in repository_modules), (
+        f"repository-state ratchet tests must live under {REPOSITORY_ROOT}: "
+        f"{sorted(repository_modules)}"
+    )
+    assert fixture_modules
+    assert all(path.startswith(f"{FIXTURE_ROOT}/") for path in fixture_modules), (
+        f"fixture-only ratchet tests must live under {FIXTURE_ROOT}: {sorted(fixture_modules)}"
+    )
+
+    workflows = root / ".github" / "workflows"
+    ci = load_workflow(workflows / "ci.yml")
+    ratchet = workflow_job(ci, RATCHET_JOB)
+    assert ratchet["name"] == RATCHET_CHECK
+    _assert_ci_test_targets(ci, inventory)
+
+    merge_gate = load_workflow(workflows / "merge-gate.yml")
+    gate = workflow_job(merge_gate, "gate")
+    wait_step = workflow_step(gate, "Wait for all required checks")
+    expected_checks = wait_step["env"]["EXPECTED_CHECKS"]
+    assert isinstance(expected_checks, str)
+    assert RATCHET_CHECK not in expected_checks
+    for required_check in REQUIRED_SHARD_CHECKS:
+        assert required_check in expected_checks
+
+    ratchet_callers: list[tuple[str, str]] = []
+    for workflow_path in sorted(workflows.glob("*.yml")):
+        workflow = load_workflow(workflow_path)
+        workflow_jobs = workflow.get("jobs")
+        if not isinstance(workflow_jobs, dict):
+            continue
+        for job_name, job in workflow_jobs.items():
+            if not isinstance(job, dict):
+                continue
+            if repository_modules.intersection(_pytest_targets(job)):
+                ratchet_callers.append((workflow_path.name, job_name))
+    assert ratchet_callers == [("ci.yml", RATCHET_JOB)]
+
+
+@pytest.fixture(scope="module")
+def repository_inventory(
+    repository_python_inventory: dict[str, PythonModuleFacts],
+) -> dict[str, str]:
+    return _ratchet_test_inventory(repository_python_inventory)
+
+
+def test_test_architecture_ratchets_remain_non_required(
+    repository_inventory: dict[str, str],
+) -> None:
+    _assert_topology(REPO_ROOT, repository_inventory)
+
+
+def test_repository_ratchet_inventory_is_collected_once(
+    repository_inventory: dict[str, str],
+) -> None:
+    assert repository_inventory
+    assert INVENTORY_CALLS[REPO_ROOT.resolve()] == 1
+
+
+def test_provisional_ci_opt_in_is_draft_guarded() -> None:
+    ci = load_workflow(REPO_ROOT / ".github" / "workflows" / "ci.yml")
+    _assert_ci_provisional_guard(ci)
+
+
+def test_relocated_repository_contract_fails_topology(tmp_path: Path) -> None:
+    source = REPO_ROOT / "tests" / "quality" / "test_quality_baselines.py"
+    relocated = tmp_path / "tests" / "unit" / "example_test.py"
+    relocated.parent.mkdir(parents=True)
+    relocated.write_text(
+        source.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "add", "tests"], check=True)
+    temp_inventory = _ratchet_test_inventory(tracked_python_inventory(tmp_path))
+
+    with pytest.raises(
+        AssertionError,
+        match="repository-state ratchet tests must live under tests/quality",
+    ):
+        _assert_topology(
+            tmp_path,
+            temp_inventory,
+        )
+
+
+def test_relocated_fixture_contract_fails_topology(tmp_path: Path) -> None:
+    source = REPO_ROOT / "tests" / "unit" / "scripts" / "test_check_test_assertions.py"
+    relocated = tmp_path / "tests" / "quality" / "example_test.py"
+    relocated.parent.mkdir(parents=True)
+    relocated.write_text(
+        source.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+    repository_contract = tmp_path / "tests" / "quality" / "test_repository.py"
+    repository_contract.write_text(
+        'RATCHET_TEST_SCOPE = "repository"\n',
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "add", "tests"], check=True)
+    temp_inventory = _ratchet_test_inventory(tracked_python_inventory(tmp_path))
+
+    with pytest.raises(
+        AssertionError,
+        match="fixture-only ratchet tests must live under tests/unit/scripts",
+    ):
+        _assert_topology(
+            tmp_path,
+            temp_inventory,
+        )
+
+
+@pytest.fixture
+def provisional_ci() -> WorkflowNode:
+    return deepcopy(load_workflow(REPO_ROOT / ".github" / "workflows" / "ci.yml"))
+
+
+def _ratchet_step(ci: WorkflowNode) -> WorkflowNode:
+    return workflow_step(
+        workflow_job(ci, RATCHET_JOB),
+        "Run ratchet contract tests",
+    )
+
+
+def test_unconditional_provisional_opt_in_fails(
+    provisional_ci: WorkflowNode,
+) -> None:
+    _ratchet_step(provisional_ci)["env"][ALLOW_PROVISIONAL_KEY] = "1"
+
+    with pytest.raises(AssertionError):
+        _assert_ci_provisional_guard(provisional_ci)
+
+
+def test_required_shard_provisional_opt_in_fails(
+    provisional_ci: WorkflowNode,
+) -> None:
+    shard_step = _run_steps(workflow_job(provisional_ci, "build-and-test-shard"))[0]
+    shard_step["env"] = {ALLOW_PROVISIONAL_KEY: DRAFT_PROVISIONAL_GUARD}
+
+    with pytest.raises(AssertionError):
+        _assert_ci_provisional_guard(provisional_ci)
+
+
+def test_non_draft_provisional_condition_fails(
+    provisional_ci: WorkflowNode,
+) -> None:
+    _ratchet_step(provisional_ci)["env"][ALLOW_PROVISIONAL_KEY] = (
+        "${{ github.event_name == 'pull_request' && "
+        "github.event.pull_request.draft == false && '1' || '0' }}"
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_ci_provisional_guard(provisional_ci)
+
+
+def test_merge_group_provisional_acceptance_fails(
+    provisional_ci: WorkflowNode,
+) -> None:
+    _ratchet_step(provisional_ci)["env"][ALLOW_PROVISIONAL_KEY] = (
+        "${{ github.event_name == 'merge_group' && '1' || '0' }}"
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_ci_provisional_guard(provisional_ci)
+
+
+def test_duplicate_ratchet_target_fails(
+    provisional_ci: WorkflowNode,
+    repository_inventory: dict[str, str],
+) -> None:
+    step = _ratchet_step(provisional_ci)
+    target = "tests/quality/test_quality_baselines.py"
+    step["run"] = step["run"].replace(target, f"{target} {target}")
+
+    with pytest.raises(AssertionError):
+        _assert_ci_test_targets(
+            provisional_ci,
+            repository_inventory,
+        )

--- a/tests/quality/test_quality_baselines.py
+++ b/tests/quality/test_quality_baselines.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+from scripts.test_file_inventory import is_test_module_path
+from tests.quality.repository_python_inventory import PythonModuleFacts
+
+RATCHET_TEST_SCOPE = "repository"
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+QUALITY_DIR = REPO_ROOT / "tests" / "quality"
+CHECKERS = (
+    (
+        REPO_ROOT / "scripts" / "check_test_assertions.py",
+        QUALITY_DIR / "assertion_quality_baseline.json",
+        "[+] assertion-quality ratchet clean: AQ001=5, AQ002=12\n",
+    ),
+    (
+        REPO_ROOT / "scripts" / "check_exact_test_duplicates.py",
+        QUALITY_DIR / "exact_test_duplicates.json",
+        (
+            "[+] exact test duplicate ratchet clean: "
+            "{module_count} files, 8 allowed duplicate group(s)\n"
+        ),
+    ),
+)
+ALLOW_PROVISIONAL_ENV = "APM_ALLOW_PROVISIONAL_BASELINES"
+
+
+def _assert_provisional_mode(
+    *,
+    provisional: bool,
+    env_value: str | None,
+) -> None:
+    assert env_value in {None, "0", "1"}
+    if provisional:
+        assert env_value == "1"
+
+
+def test_repository_quality_baselines_are_scanned_once(
+    monkeypatch: pytest.MonkeyPatch,
+    repository_python_inventory: dict[str, PythonModuleFacts],
+) -> None:
+    invocations: Counter[Path] = Counter()
+    real_run = subprocess.run
+    module_count = sum(
+        path.startswith("tests/") and is_test_module_path(path)
+        for path in repository_python_inventory
+    )
+
+    def tracked_run(
+        command: list[str],
+        **kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        script = Path(command[1])
+        if script in {entry[0] for entry in CHECKERS}:
+            invocations[script] += 1
+        return real_run(command, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", tracked_run)
+    for script, baseline, expected in CHECKERS:
+        payload = json.loads(baseline.read_text(encoding="utf-8"))
+        command = [sys.executable, str(script)]
+        if "provisional" in payload:
+            assert os.environ.get(ALLOW_PROVISIONAL_ENV) == "1"
+            command.append("--allow-provisional")
+
+        result = subprocess.run(
+            command,
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert result.stdout == expected.format(module_count=module_count)
+        assert result.stderr == ""
+        assert baseline.is_file()
+
+    assert invocations == Counter({script: 1 for script, _baseline, _expected in CHECKERS})
+
+
+def test_repository_baseline_finalization_state_is_consistent() -> None:
+    states = {
+        baseline: "provisional" in json.loads(baseline.read_text(encoding="utf-8"))
+        for _script, baseline, _expected in CHECKERS
+    }
+    assert len(set(states.values())) == 1, (
+        f"repository quality baselines have mixed finalization state: {states}"
+    )
+    provisional = next(iter(states.values()))
+    _assert_provisional_mode(
+        provisional=provisional,
+        env_value=os.environ.get(ALLOW_PROVISIONAL_ENV),
+    )
+
+
+@pytest.mark.parametrize(
+    ("provisional", "env_value", "passes"),
+    [
+        (True, "0", False),
+        (True, "1", True),
+        (False, "1", True),
+        (False, "0", True),
+    ],
+)
+def test_provisional_mode_implication(
+    provisional: bool,
+    env_value: str,
+    passes: bool,
+) -> None:
+    if passes:
+        _assert_provisional_mode(
+            provisional=provisional,
+            env_value=env_value,
+        )
+        return
+
+    with pytest.raises(AssertionError):
+        _assert_provisional_mode(
+            provisional=provisional,
+            env_value=env_value,
+        )

--- a/tests/quality/test_quality_baselines.py
+++ b/tests/quality/test_quality_baselines.py
@@ -103,6 +103,71 @@ def test_repository_baseline_finalization_state_is_consistent() -> None:
     )
 
 
+def test_duplicate_checker_reports_new_tracked_module_count(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "repo"
+    tests = root / "tests"
+    tests.mkdir(parents=True)
+    baseline = root / "baseline.json"
+    baseline.write_text(
+        json.dumps(
+            {
+                "algorithm": "sha256-bytes-v1",
+                "duplicate_groups": [],
+                "schema_version": 1,
+                "scope": [
+                    "tests/**/test_*.py",
+                    "tests/**/*_test.py",
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+
+    first = tests / "test_first.py"
+    first.write_text("def test_first():\n    assert 1 == 1\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(root), "add", "tests"], check=True)
+    first_result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "check_exact_test_duplicates.py"),
+            "--root",
+            str(root),
+            "--baseline",
+            str(baseline),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    second = tests / "second_test.py"
+    second.write_text("def test_second():\n    assert 2 == 2\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(root), "add", "tests"], check=True)
+    second_result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "check_exact_test_duplicates.py"),
+            "--root",
+            str(root),
+            "--baseline",
+            str(baseline),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert first_result.returncode == 0
+    assert "1 files, 0 allowed duplicate group(s)" in first_result.stdout
+    assert second_result.returncode == 0
+    assert "2 files, 0 allowed duplicate group(s)" in second_result.stdout
+
+
 @pytest.mark.parametrize(
     ("provisional", "env_value", "passes"),
     [

--- a/tests/quality/test_test_taxonomy.py
+++ b/tests/quality/test_test_taxonomy.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import tomllib
+
+from tests.quality.repository_python_inventory import (
+    PythonModuleFacts,
+    tracked_python_inventory,
+)
+
+RATCHET_TEST_SCOPE = "repository"
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+MANIFEST = REPO_ROOT / "tests" / "quality" / "critical_suite.toml"
+DOCS = REPO_ROOT / "docs" / "src" / "content" / "docs" / "contributing" / "integration-testing.md"
+APM_INSTRUCTIONS = REPO_ROOT / ".apm" / "instructions" / "tests.instructions.md"
+GITHUB_INSTRUCTIONS = REPO_ROOT / ".github" / "instructions" / "tests.instructions.md"
+EXPECTED_MARKERS = {
+    "unit": "pure logic with no filesystem and no CLI",
+    "component": ("in-process behavior that touches a filesystem or one command boundary"),
+    "e2e": "a real installed CLI crossing at least one command boundary",
+}
+BEHAVIORAL_MARKERS = frozenset(EXPECTED_MARKERS)
+INVENTORY_PLUGIN = "tests.quality.taxonomy_inventory_plugin"
+
+
+def _declared_markers() -> dict[str, str]:
+    with PYPROJECT.open("rb") as handle:
+        data = tomllib.load(handle)
+    entries = data["tool"]["pytest"]["ini_options"]["markers"]
+    declared: dict[str, str] = {}
+    for entry in entries:
+        name, separator, description = entry.partition(":")
+        if separator:
+            declared[name.strip()] = description.strip()
+    return declared
+
+
+def _manifest_modules(manifest: Path = MANIFEST) -> list[dict[str, str]]:
+    with manifest.open("rb") as handle:
+        data = tomllib.load(handle)
+    modules = data.get("modules")
+    assert data == {"schema_version": 1, "modules": modules}
+    assert isinstance(modules, list)
+
+    normalized: list[dict[str, str]] = []
+    for entry in modules:
+        assert isinstance(entry, dict)
+        assert set(entry) == {"path", "marker"}
+        path = entry["path"]
+        marker = entry["marker"]
+        assert isinstance(path, str)
+        assert isinstance(marker, str)
+        normalized.append({"path": path, "marker": marker})
+    return normalized
+
+
+def _documented_marker_definitions(path: Path) -> dict[str, str]:
+    definitions: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        cells = [cell.strip() for cell in line.split("|")]
+        if len(cells) < 4:
+            continue
+        marker = cells[1].strip("`")
+        if marker in EXPECTED_MARKERS:
+            definition = cells[2].rstrip(".")
+            definitions[marker] = definition[:1].lower() + definition[1:]
+    return definitions
+
+
+def _collect_inventory(root: Path, output: Path) -> dict[str, list[str]]:
+    env = os.environ.copy()
+    env["APM_TAXONOMY_INVENTORY"] = str(output)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-p",
+            "no:cacheprovider",
+            "-p",
+            INVENTORY_PLUGIN,
+            "--collect-only",
+            "-q",
+            "tests",
+        ],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    data = json.loads(output.read_text(encoding="utf-8"))
+    assert isinstance(data, dict)
+    return data
+
+
+def _assert_behavioral_marker_scope(
+    manifest: Path,
+    inventory: dict[str, list[str]],
+) -> None:
+    modules = _manifest_modules(manifest)
+    manifest_paths = {entry["path"] for entry in modules}
+    manifest_nodes = {nodeid for nodeid in inventory if nodeid.split("::", 1)[0] in manifest_paths}
+    globally_marked_nodes = {
+        nodeid for nodeid, markers in inventory.items() if BEHAVIORAL_MARKERS.intersection(markers)
+    }
+    extras = sorted(globally_marked_nodes - manifest_nodes)
+    missing = sorted(manifest_nodes - globally_marked_nodes)
+    assert extras == [], f"behavioral markers outside critical manifest: {extras}"
+    assert missing == [], f"manifest nodes missing behavioral markers: {missing}"
+
+
+@pytest.fixture(scope="module")
+def marker_inventory(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> dict[str, list[str]]:
+    output = tmp_path_factory.mktemp("taxonomy") / "inventory.json"
+    return _collect_inventory(REPO_ROOT, output)
+
+
+def test_tm001_behavioral_marker_definitions_match_spec() -> None:
+    declared = _declared_markers()
+    actual = {marker: declared.get(marker) for marker in EXPECTED_MARKERS}
+    assert actual == EXPECTED_MARKERS
+
+
+def test_tm002_manifest_is_finite_unique_and_existing() -> None:
+    modules = _manifest_modules()
+    assert len(modules) == 5
+    paths = [entry["path"] for entry in modules]
+    assert len(paths) == len(set(paths))
+    assert {entry["marker"] for entry in modules} == BEHAVIORAL_MARKERS
+    missing = [path for path in paths if not (REPO_ROOT / path).is_file()]
+    assert missing == []
+
+
+def _assert_manifest_is_only_module_list(
+    python_inventory: dict[str, PythonModuleFacts],
+) -> None:
+    manifest_paths = {entry["path"] for entry in _manifest_modules()}
+    duplicated_literals = {
+        path: sorted(facts.string_literals.intersection(manifest_paths))
+        for path, facts in python_inventory.items()
+        if facts.string_literals.intersection(manifest_paths)
+    }
+
+    assert duplicated_literals == {}, (
+        f"critical module paths must be declared only in critical_suite.toml: {duplicated_literals}"
+    )
+
+
+def test_tm002_manifest_is_the_only_critical_module_list(
+    repository_python_inventory: dict[str, PythonModuleFacts],
+) -> None:
+    _assert_manifest_is_only_module_list(repository_python_inventory)
+
+
+def test_tm002_manifest_literal_outside_quality_fails(tmp_path: Path) -> None:
+    manifest_path = next(iter(entry["path"] for entry in _manifest_modules()))
+    duplicate = tmp_path / "scripts" / "duplicate_authority.py"
+    duplicate.parent.mkdir(parents=True)
+    duplicate.write_text(
+        f"DUPLICATE_MODULE = {manifest_path!r}\n",
+        encoding="utf-8",
+    )
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "add", "scripts"], check=True)
+
+    with pytest.raises(
+        AssertionError,
+        match="critical module paths must be declared only",
+    ):
+        _assert_manifest_is_only_module_list(tracked_python_inventory(tmp_path))
+
+
+def test_tm003_each_manifest_module_has_exactly_its_declared_marker(
+    marker_inventory: dict[str, list[str]],
+) -> None:
+    modules = _manifest_modules()
+    for entry in modules:
+        module_nodes = {
+            nodeid: markers
+            for nodeid, markers in marker_inventory.items()
+            if nodeid.split("::", 1)[0] == entry["path"]
+        }
+        assert module_nodes
+        for markers in module_nodes.values():
+            assert BEHAVIORAL_MARKERS.intersection(markers) == {entry["marker"]}
+
+
+def test_tm004_behavioral_markers_are_not_used_outside_manifest(
+    marker_inventory: dict[str, list[str]],
+) -> None:
+    _assert_behavioral_marker_scope(MANIFEST, marker_inventory)
+
+
+def test_tm004_rejects_an_unmanifested_behavioral_marker(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    tests = root / "tests"
+    quality = tests / "quality"
+    quality.mkdir(parents=True)
+    (tests / "test_manifested.py").write_text(
+        "def test_manifested():\n    assert 1 == 1\n",
+        encoding="utf-8",
+    )
+    (tests / "test_unmanifested.py").write_text(
+        "def test_unmanifested():\n    assert 1 == 1\n",
+        encoding="utf-8",
+    )
+    manifest = quality / "critical_suite.toml"
+    manifest.write_text(
+        'schema_version = 1\n[[modules]]\npath = "tests/test_manifested.py"\nmarker = "unit"\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        AssertionError,
+        match="behavioral markers outside critical manifest",
+    ):
+        _assert_behavioral_marker_scope(
+            manifest,
+            {
+                "tests/test_manifested.py::test_manifested": ["unit"],
+                "tests/test_unmanifested.py::test_unmanifested": ["e2e"],
+            },
+        )
+
+
+def test_tm005_behavioral_marker_prose_mirrors_canonical_definitions() -> None:
+    assert APM_INSTRUCTIONS.read_bytes() == GITHUB_INSTRUCTIONS.read_bytes()
+    for path in (APM_INSTRUCTIONS, GITHUB_INSTRUCTIONS, DOCS):
+        assert _documented_marker_definitions(path) == EXPECTED_MARKERS
+        text = path.read_text(encoding="utf-8")
+        assert "uv run --frozen python scripts/check_test_assertions.py" in text
+        assert "uv run --frozen python scripts/check_exact_test_duplicates.py" in text
+        assert "--allow-provisional" not in text

--- a/tests/unit/core/test_install_audit.py
+++ b/tests/unit/core/test_install_audit.py
@@ -20,6 +20,8 @@ from apm_cli.core.install_audit import (
     resolve_install_audit_mode,
 )
 
+pytestmark = pytest.mark.unit
+
 
 class TestResolveInstallAuditMode:
     """Precedence ladder: flag master switch > policy floor > CLI > config."""

--- a/tests/unit/deps/test_lockfile_git_semver.py
+++ b/tests/unit/deps/test_lockfile_git_semver.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import pytest
+
 from apm_cli.deps.git_semver_resolver import GitSemverResolution
 from apm_cli.deps.installed_package import InstalledPackage
 from apm_cli.deps.lockfile import LockedDependency, LockFile
 from apm_cli.models.dependency.reference import DependencyReference
+
+pytestmark = pytest.mark.unit
 
 
 def _make_dep_ref(repo_url: str = "acme/some-skills", reference: str = "^1.2.0"):

--- a/tests/unit/scripts/test_check_exact_test_duplicates.py
+++ b/tests/unit/scripts/test_check_exact_test_duplicates.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+RATCHET_TEST_SCOPE = "fixture"
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "check_exact_test_duplicates.py"
+
+
+def _run(root: Path, baseline: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--root",
+            str(root),
+            "--baseline",
+            str(baseline),
+            *extra,
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _payload(groups: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "algorithm": "sha256-bytes-v1",
+        "duplicate_groups": groups,
+        "schema_version": 1,
+        "scope": ["tests/**/test_*.py", "tests/**/*_test.py"],
+    }
+
+
+def _write_baseline(path: Path, groups: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(_payload(groups), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_bytes(root: Path, name: str, content: bytes) -> Path:
+    path = root / "tests" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
+
+
+def _track_tests(root: Path) -> None:
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    subprocess.run(["git", "-C", str(root), "add", "tests"], check=True)
+
+
+def test_new_exact_pair_fails(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    content = b"def test_value():\n    assert 1 == 1\n"
+    _write_bytes(root, "test_a.py", content)
+    _write_bytes(root, "test_b.py", content)
+    _track_tests(root)
+    baseline = root / "baseline.json"
+    _write_baseline(baseline, [])
+    digest = hashlib.sha256(content).hexdigest()
+
+    result = _run(root, baseline)
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert f"new exact duplicate group {digest}" in result.stderr
+    assert "  - tests/test_a.py" in result.stderr
+    assert "  - tests/test_b.py" in result.stderr
+    assert "make each test module meaningfully distinct" in result.stderr
+
+
+def test_near_duplicate_pair_passes(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    _write_bytes(root, "test_a.py", b"def test_value():\n    assert 1 == 1\n")
+    _write_bytes(root, "test_b.py", b"def test_value():\n    assert 1 == 2\n")
+    _track_tests(root)
+    baseline = root / "baseline.json"
+    _write_baseline(baseline, [])
+
+    result = _run(root, baseline)
+
+    assert result.returncode == 0
+
+
+def test_crlf_and_lf_are_not_exact_duplicates(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    _write_bytes(root, "test_lf.py", b"def test_value():\n    assert 1 == 1\n")
+    _write_bytes(
+        root,
+        "test_crlf.py",
+        b"def test_value():\r\n    assert 1 == 1\r\n",
+    )
+    _track_tests(root)
+    baseline = root / "baseline.json"
+    _write_baseline(baseline, [])
+
+    result = _run(root, baseline)
+
+    assert result.returncode == 0
+
+
+def test_third_copy_exceeds_pair_baseline(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    content = b"def test_value():\n    assert 1 == 1\n"
+    digest = hashlib.sha256(content).hexdigest()
+    for name in ("test_a.py", "test_b.py", "test_c.py"):
+        _write_bytes(root, name, content)
+    _track_tests(root)
+    baseline = root / "baseline.json"
+    _write_baseline(
+        baseline,
+        [
+            {
+                "paths": ["tests/test_a.py", "tests/test_b.py"],
+                "sha256": digest,
+            }
+        ],
+    )
+
+    result = _run(root, baseline)
+
+    assert result.returncode == 1
+    assert f"exact duplicate group {digest} added tracked path(s)" in result.stderr
+    assert "  - tests/test_c.py" in result.stderr
+    assert "remove or differentiate the added copy" in result.stderr
+
+
+def test_update_refuses_existing_group_growth_without_writing(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "repo"
+    content = b"def test_value():\n    assert 1 == 1\n"
+    digest = hashlib.sha256(content).hexdigest()
+    for name in ("test_a.py", "test_b.py", "test_c.py"):
+        _write_bytes(root, name, content)
+    _track_tests(root)
+    baseline = root / "baseline.json"
+    _write_baseline(
+        baseline,
+        [
+            {
+                "paths": ["tests/test_a.py", "tests/test_b.py"],
+                "sha256": digest,
+            }
+        ],
+    )
+    before = baseline.read_bytes()
+
+    result = _run(root, baseline, "--update-baseline")
+
+    assert result.returncode == 1
+    assert "added tracked path(s)" in result.stderr
+    assert "refusing to update exact-duplicate baseline with new debt" in result.stderr
+    assert baseline.read_bytes() == before
+
+
+def test_update_refuses_growth_without_writing(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    content = b"def test_value():\n    assert 1 == 1\n"
+    _write_bytes(root, "test_a.py", content)
+    _write_bytes(root, "test_b.py", content)
+    _track_tests(root)
+    baseline = root / "baseline.json"
+    _write_baseline(baseline, [])
+    before = baseline.read_bytes()
+
+    result = _run(root, baseline, "--update-baseline")
+
+    assert result.returncode == 1
+    assert "refusing to update exact-duplicate baseline with new debt" in result.stderr
+    assert baseline.read_bytes() == before
+
+
+def test_reduction_requires_baseline_tightening(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    content = b"def test_value():\n    assert 1 == 1\n"
+    digest = hashlib.sha256(content).hexdigest()
+    _write_bytes(root, "test_a.py", content)
+    _track_tests(root)
+    baseline = root / "baseline.json"
+    _write_baseline(
+        baseline,
+        [
+            {
+                "paths": ["tests/test_a.py", "tests/test_b.py"],
+                "sha256": digest,
+            }
+        ],
+    )
+
+    stale = _run(root, baseline)
+    updated = _run(root, baseline, "--update-baseline")
+
+    assert stale.returncode == 1
+    assert f"exact duplicate group {digest} reduced:" in stale.stderr
+    assert (
+        "uv run --frozen python scripts/check_exact_test_duplicates.py --update-baseline"
+    ) in stale.stderr
+    assert updated.returncode == 0
+    assert (
+        "[+] updated exact-duplicate baseline: removed 1 resolved group(s) and 2 stale path entries"
+    ) in updated.stdout
+    assert json.loads(baseline.read_text(encoding="utf-8")) == _payload([])
+
+
+def test_malformed_digest_fails_closed(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    baseline = root / "baseline.json"
+    _write_baseline(
+        baseline,
+        [
+            {
+                "paths": ["tests/test_a.py", "tests/test_b.py"],
+                "sha256": ("c7f0b529522a2a44e5436097426a694e361ff3c42f03fb5d7ccdef6a7792"),
+            }
+        ],
+    )
+
+    result = _run(root, baseline)
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert "[x]" in result.stderr
+
+
+def test_tracked_symlink_inside_root_fails_closed(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    target = _write_bytes(
+        root,
+        "fixture.py",
+        b"def test_value():\n    assert 1 == 1\n",
+    )
+    link = root / "tests" / "test_link.py"
+    try:
+        link.symlink_to(target.name)
+    except OSError as error:
+        pytest.skip(f"symlink creation unavailable: {error}")
+    _track_tests(root)
+    baseline = root / "baseline.json"
+    _write_baseline(baseline, [])
+
+    result = _run(root, baseline)
+
+    assert result.returncode == 2
+    assert "tracked Python path is a symlink: tests/test_link.py" in result.stderr
+
+
+def test_symlink_outside_root_fails_containment_check(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    tests = root / "tests"
+    tests.mkdir(parents=True)
+    outside = tmp_path / "outside.py"
+    outside.write_bytes(b"def test_value():\n    assert 1 == 1\n")
+    link = tests / "test_escape.py"
+    try:
+        link.symlink_to(outside)
+    except OSError as error:
+        pytest.skip(f"symlink creation unavailable: {error}")
+    _track_tests(root)
+    baseline = root / "baseline.json"
+    _write_baseline(baseline, [])
+
+    result = _run(root, baseline)
+
+    assert result.returncode == 2
+    assert "tracked Python path resolves outside repository" in result.stderr
+
+
+def test_worktree_edits_are_hashed_without_staging(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    first = b"def test_value():\n    assert 1 == 1\n"
+    _write_bytes(root, "test_a.py", first)
+    second = _write_bytes(root, "test_b.py", b"def test_value():\n    assert 2 == 2\n")
+    _track_tests(root)
+    second.write_bytes(first)
+    baseline = root / "baseline.json"
+    _write_baseline(baseline, [])
+
+    result = _run(root, baseline)
+
+    assert result.returncode == 1
+    assert "new exact duplicate group" in result.stderr
+
+
+def test_untracked_duplicate_is_out_of_scope(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    content = b"def test_value():\n    assert 1 == 1\n"
+    _write_bytes(root, "test_tracked.py", content)
+    _track_tests(root)
+    _write_bytes(root, "test_untracked.py", content)
+    baseline = root / "baseline.json"
+    _write_baseline(baseline, [])
+
+    result = _run(root, baseline)
+
+    assert result.returncode == 0
+    assert "1 files, 0 allowed duplicate group(s)" in result.stdout
+
+
+def test_provisional_baseline_requires_explicit_allow(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    _write_bytes(root, "test_tracked.py", b"def test_value():\n    assert 1 == 1\n")
+    _track_tests(root)
+    baseline = root / "baseline.json"
+    payload = _payload([])
+    payload["provisional"] = {
+        "basis_commit": "abc123",
+        "required_follow_up": "remeasure",
+    }
+    baseline.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    final = _run(root, baseline)
+    provisional = _run(root, baseline, "--allow-provisional")
+    payload = json.loads(baseline.read_text(encoding="utf-8"))
+    del payload["provisional"]
+    baseline.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    finalized = _run(root, baseline)
+
+    assert final.returncode == 2
+    assert "provisional baseline is not allowed in final mode" in final.stderr
+    assert provisional.returncode == 0
+    assert provisional.stderr == ""
+    assert finalized.returncode == 0
+    assert finalized.stderr == ""

--- a/tests/unit/scripts/test_check_test_assertions.py
+++ b/tests/unit/scripts/test_check_test_assertions.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+RATCHET_TEST_SCOPE = "fixture"
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "check_test_assertions.py"
+RULE_AQ001 = "AQ001_constant_assertion"
+RULE_AQ002 = "AQ002_broad_pytest_raises"
+EMPTY_RULES = {RULE_AQ001: {}, RULE_AQ002: {}}
+
+
+def _run(root: Path, baseline: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--root",
+            str(root),
+            "--baseline",
+            str(baseline),
+            *extra,
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _write_baseline(path: Path, rules: dict[str, dict[str, int]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {"schema_version": 1, "rules": rules},
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_test(root: Path, source: str, name: str = "test_sample.py") -> Path:
+    path = root / "tests" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(source, encoding="utf-8")
+    _track_tests(root)
+    return path
+
+
+def _track_tests(root: Path) -> None:
+    subprocess.run(["git", "init", "-q", str(root)], check=True)
+    subprocess.run(["git", "-C", str(root), "add", "tests"], check=True)
+
+
+def test_aq001_new_constant_assertion_fails(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    _write_test(root, "def test_sample():\n    assert True\n")
+    baseline = root / "baseline.json"
+    _write_baseline(baseline, EMPTY_RULES)
+
+    result = _run(root, baseline)
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert "tests/test_sample.py:2" in result.stderr
+    assert RULE_AQ001 in result.stderr
+    assert "replace it with an assertion over observed output or state" in result.stderr
+
+
+def test_aq002_new_broad_raises_fails(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    _write_test(
+        root,
+        "import pytest\n"
+        "def test_sample():\n"
+        "    with pytest.raises(Exception, match='boom'):\n"
+        "        raise Exception('boom')\n",
+    )
+    baseline = root / "baseline.json"
+    _write_baseline(baseline, EMPTY_RULES)
+
+    result = _run(root, baseline)
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert "tests/test_sample.py:3" in result.stderr
+    assert RULE_AQ002 in result.stderr
+    assert "assert the narrow exception type" in result.stderr
+
+
+def test_specific_exception_raises_is_allowed(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    _write_test(
+        root,
+        "import pytest\n"
+        "def test_sample():\n"
+        "    with pytest.raises(ValueError):\n"
+        "        raise ValueError\n",
+    )
+    baseline = root / "baseline.json"
+    _write_baseline(baseline, EMPTY_RULES)
+
+    result = _run(root, baseline)
+
+    assert result.returncode == 0
+
+
+def test_numeric_constants_are_not_aq001(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    _write_test(
+        root,
+        "def test_zero():\n    assert 0\ndef test_one():\n    assert 1\n",
+    )
+    baseline = root / "baseline.json"
+    _write_baseline(baseline, EMPTY_RULES)
+
+    result = _run(root, baseline)
+
+    assert result.returncode == 0
+
+
+def test_new_file_debt_fails_against_zero_default(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    _write_test(root, "def test_sample():\n    assert None\n", "test_new_debt.py")
+    baseline = root / "baseline.json"
+    _write_baseline(baseline, EMPTY_RULES)
+
+    result = _run(root, baseline)
+
+    assert result.returncode == 1
+    assert "tests/test_new_debt.py:2" in result.stderr
+
+
+def test_reduction_is_stale_until_baseline_is_tightened(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    _write_test(root, "def test_sample():\n    assert 1 == 1\n")
+    baseline = root / "baseline.json"
+    _write_baseline(
+        baseline,
+        {
+            RULE_AQ001: {"tests/test_sample.py": 1},
+            RULE_AQ002: {},
+        },
+    )
+
+    result = _run(root, baseline)
+
+    assert result.returncode == 1
+    assert f"tests/test_sample.py: {RULE_AQ001} reduced to 0 from 1" in result.stderr
+    assert (
+        "uv run --frozen python scripts/check_test_assertions.py --update-baseline"
+    ) in result.stderr
+
+
+def test_update_refuses_growth_without_writing(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    _write_test(root, "def test_sample():\n    assert False\n")
+    baseline = root / "baseline.json"
+    _write_baseline(baseline, EMPTY_RULES)
+    before = baseline.read_bytes()
+
+    result = _run(root, baseline, "--update-baseline")
+
+    assert result.returncode == 1
+    assert "refusing to update assertion baseline with new debt" in result.stderr
+    assert baseline.read_bytes() == before
+
+
+def test_update_refuses_existing_count_growth_without_writing(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "repo"
+    _write_test(
+        root,
+        "def test_first():\n    assert True\ndef test_second():\n    assert False\n",
+    )
+    _track_tests(root)
+    baseline = root / "baseline.json"
+    _write_baseline(
+        baseline,
+        {
+            RULE_AQ001: {"tests/test_sample.py": 1},
+            RULE_AQ002: {},
+        },
+    )
+    before = baseline.read_bytes()
+
+    result = _run(root, baseline, "--update-baseline")
+
+    assert result.returncode == 1
+    assert "observed 2, allowed 1" in result.stderr
+    assert "refusing to update assertion baseline with new debt" in result.stderr
+    assert baseline.read_bytes() == before
+
+
+def test_tracked_symlink_inside_root_fails_closed(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    target = _write_test(root, "def test_sample():\n    assert True\n", "fixture.py")
+    link = root / "tests" / "test_link.py"
+    try:
+        link.symlink_to(target.name)
+    except OSError as error:
+        pytest.skip(f"symlink creation unavailable: {error}")
+    _track_tests(root)
+    baseline = root / "baseline.json"
+    _write_baseline(baseline, EMPTY_RULES)
+
+    result = _run(root, baseline)
+
+    assert result.returncode == 2
+    assert "tracked Python path is a symlink: tests/test_link.py" in result.stderr
+
+
+def test_symlink_outside_root_fails_containment_check(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    tests = root / "tests"
+    tests.mkdir(parents=True)
+    outside = tmp_path / "outside.py"
+    outside.write_text("def test_sample():\n    assert True\n", encoding="utf-8")
+    link = tests / "test_escape.py"
+    try:
+        link.symlink_to(outside)
+    except OSError as error:
+        pytest.skip(f"symlink creation unavailable: {error}")
+    _track_tests(root)
+    baseline = root / "baseline.json"
+    _write_baseline(baseline, EMPTY_RULES)
+
+    result = _run(root, baseline)
+
+    assert result.returncode == 2
+    assert "tracked Python path resolves outside repository" in result.stderr
+
+
+def test_update_writes_reduced_canonical_baseline(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    _write_test(root, "def test_sample():\n    assert 1 == 1\n")
+    baseline = root / "baseline.json"
+    _write_baseline(
+        baseline,
+        {
+            RULE_AQ001: {"tests/test_sample.py": 1},
+            RULE_AQ002: {},
+        },
+    )
+    expected = (
+        json.dumps(
+            {"schema_version": 1, "rules": EMPTY_RULES},
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode()
+
+    result = _run(root, baseline, "--update-baseline")
+
+    assert result.returncode == 0
+    assert (
+        "[+] updated assertion-quality baseline: removed 1 resolved occurrence(s)" in result.stdout
+    )
+    assert baseline.read_bytes() == expected
+
+
+def test_malformed_baseline_fails_closed(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    _write_test(root, "def test_sample():\n    assert 1 == 1\n")
+    baseline = root / "baseline.json"
+    baseline.write_text("{not-json", encoding="utf-8")
+
+    result = _run(root, baseline)
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert "[x]" in result.stderr
+
+
+def test_structurally_invalid_baseline_fails_closed(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    _write_test(root, "def test_sample():\n    assert 1 == 1\n")
+    baseline = root / "baseline.json"
+    invalid_payloads = [
+        {"schema_version": 2, "rules": EMPTY_RULES},
+        {"schema_version": 1, "rules": {RULE_AQ001: {}}},
+        {
+            "schema_version": 1,
+            "rules": {RULE_AQ001: {"tests/test_sample.py": -1}, RULE_AQ002: {}},
+        },
+        {
+            "schema_version": 1,
+            "rules": {
+                RULE_AQ001: {"tests/test_sample.py": "1"},
+                RULE_AQ002: {},
+            },
+        },
+    ]
+
+    for payload in invalid_payloads:
+        baseline.write_text(json.dumps(payload), encoding="utf-8")
+        result = _run(root, baseline)
+        assert result.returncode == 2
+        assert result.stdout == ""
+        assert "[x]" in result.stderr
+
+
+def test_provisional_baseline_requires_explicit_allow(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    _write_test(root, "def test_sample():\n    assert 1 == 1\n")
+    baseline = root / "baseline.json"
+    baseline.write_text(
+        json.dumps(
+            {
+                "provisional": {
+                    "basis_commit": "abc123",
+                    "required_follow_up": "remeasure",
+                },
+                "rules": EMPTY_RULES,
+                "schema_version": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    final = _run(root, baseline)
+    provisional = _run(root, baseline, "--allow-provisional")
+    payload = json.loads(baseline.read_text(encoding="utf-8"))
+    del payload["provisional"]
+    baseline.write_text(json.dumps(payload), encoding="utf-8")
+    finalized = _run(root, baseline)
+
+    assert final.returncode == 2
+    assert "provisional baseline is not allowed in final mode" in final.stderr
+    assert provisional.returncode == 0
+    assert provisional.stderr == ""
+    assert finalized.returncode == 0
+    assert finalized.stderr == ""

--- a/tests/unit/scripts/test_check_test_contract_authorities.py
+++ b/tests/unit/scripts/test_check_test_contract_authorities.py
@@ -105,6 +105,46 @@ def test_binary_fixture_delegation_is_allowed(tmp_path: Path) -> None:
     assert _load_checker().find_binary_selection_violations(tmp_path) == []
 
 
+def _write_ratchet_authority_stubs(root: Path) -> None:
+    files = {
+        "scripts/test_file_inventory.py": "",
+        "scripts/ratchet_baseline.py": "",
+        "scripts/check_test_assertions.py": (
+            "from test_file_inventory import tracked_python_paths\n"
+            "from ratchet_baseline import load_baseline\n"
+        ),
+        "scripts/check_exact_test_duplicates.py": (
+            "from test_file_inventory import tracked_python_paths\n"
+            "from ratchet_baseline import load_baseline\n"
+        ),
+        "tests/quality/repository_python_inventory.py": (
+            "from scripts.test_file_inventory import tracked_python_paths\n"
+        ),
+        "tests/quality/test_ci_topology.py": (
+            "from scripts.test_file_inventory import is_test_module_path\n"
+        ),
+    }
+    for relative, content in files.items():
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+
+
+def test_ratchet_consumers_must_import_inventory_owner(tmp_path: Path) -> None:
+    """Removing canonical inventory routing must fail the authority checker."""
+    _write_ratchet_authority_stubs(tmp_path)
+    consumer = tmp_path / "scripts" / "check_test_assertions.py"
+    consumer.write_text(
+        'from ratchet_baseline import load_baseline\nfiles = root.rglob("*.py")\n',
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_ratchet_authority_violations(tmp_path)
+
+    assert any("must consume ratchet authority" in item for item in violations)
+    assert any("duplicate tracked Python inventory" in item for item in violations)
+
+
 def test_implicit_lifecycle_runner_selection_is_rejected(tmp_path: Path) -> None:
     """Deleting the lifecycle-runner detector must fail independently."""
     _write_owner_stubs(tmp_path)

--- a/tests/unit/scripts/test_check_test_contract_authorities.py
+++ b/tests/unit/scripts/test_check_test_contract_authorities.py
@@ -130,19 +130,64 @@ def _write_ratchet_authority_stubs(root: Path) -> None:
         path.write_text(content, encoding="utf-8")
 
 
-def test_ratchet_consumers_must_import_inventory_owner(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    ("relative", "replacement"),
+    [
+        (
+            "scripts/check_test_assertions.py",
+            "from ratchet_baseline import load_baseline\n",
+        ),
+        (
+            "scripts/check_exact_test_duplicates.py",
+            "from ratchet_baseline import load_baseline\n",
+        ),
+        ("tests/quality/repository_python_inventory.py", ""),
+        ("tests/quality/test_ci_topology.py", ""),
+    ],
+)
+def test_ratchet_consumers_must_import_inventory_owner(
+    tmp_path: Path,
+    relative: str,
+    replacement: str,
+) -> None:
     """Removing canonical inventory routing must fail the authority checker."""
     _write_ratchet_authority_stubs(tmp_path)
-    consumer = tmp_path / "scripts" / "check_test_assertions.py"
+    consumer = tmp_path / relative
     consumer.write_text(
-        'from ratchet_baseline import load_baseline\nfiles = root.rglob("*.py")\n',
+        replacement,
         encoding="utf-8",
     )
 
     violations = _load_checker().find_ratchet_authority_violations(tmp_path)
 
     assert any("must consume ratchet authority" in item for item in violations)
-    assert any("duplicate tracked Python inventory" in item for item in violations)
+
+
+@pytest.mark.parametrize(
+    "relative",
+    [
+        "scripts/check_test_assertions.py",
+        "scripts/check_exact_test_duplicates.py",
+    ],
+)
+def test_ratchet_consumers_must_import_baseline_owner(
+    tmp_path: Path,
+    relative: str,
+) -> None:
+    """Removing shared baseline lifecycle routing must fail AC9."""
+    _write_ratchet_authority_stubs(tmp_path)
+    consumer = tmp_path / relative
+    consumer.write_text(
+        "from test_file_inventory import tracked_python_paths\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_ratchet_authority_violations(tmp_path)
+
+    assert any(
+        f"{relative} must consume ratchet authority: from ratchet_baseline import" in item
+        for item in violations
+    )
 
 
 def test_implicit_lifecycle_runner_selection_is_rejected(tmp_path: Path) -> None:


### PR DESCRIPTION
# harden(test-architecture): add finite taxonomy and quality ratchets

## TL;DR

This PR gives five critical test modules an explicit `unit` / `component` /
`e2e` taxonomy and adds focused no-growth ratchets for two assertion forms and
raw-byte-identical test files. The checks run as a visible, non-required CI
signal, with static topology tests proving they stay outside required shards.

## Problem (WHY)

- [x] The critical suite had no finite file-level owner for behavioral
  classification. A literal manifest gives reviewers a stable shape because
  ["agents pattern-match well against concrete structures"](https://agentskills.io/skill-creation/best-practices).
- [x] Exact duplicate files and the two accepted assertion-quality forms had
  observations but no automated no-growth contract. Checked-in baselines add
  only the project-specific evidence the checker needs:
  ["Add what the agent lacks, omit what it knows"](https://agentskills.io/skill-creation/best-practices).
- [!] A broad analyzer would turn bounded ratchets into a policy framework.
  The implementation stays on two named AST forms and raw-byte hashes because
  ["Overly comprehensive skills can hurt more than they help"](https://agentskills.io/skill-creation/best-practices).

## Approach (WHAT)

| # | Fix | Principle |
|---:|---|---|
| 1 | Make one five-module TOML manifest own the classified suite. | ["agents pattern-match well against concrete structures"](https://agentskills.io/skill-creation/best-practices) |
| 2 | Count only AQ001 constant assertions and AQ002 broad `pytest.raises`. | ["Add what the agent lacks, omit what it knows"](https://agentskills.io/skill-creation/best-practices) |
| 3 | Hash unmodified bytes and reject only new groups or added members. | ["Be prescriptive when operations are fragile"](https://agentskills.io/skill-creation/best-practices) |
| 4 | Publish one informational CI job without editing the required merge gate. | ["Provide defaults, not menus"](https://agentskills.io/skill-creation/best-practices) |

## Implementation (HOW)

| Files | Intent and scope |
|---|---|
| `pyproject.toml`, `tests/quality/critical_suite.toml`, `tests/quality/test_test_taxonomy.py`, `tests/quality/repository_python_inventory.py`, `tests/quality/taxonomy_inventory_plugin.py` | Register the definitions, make TOML the sole module authority, scan all tracked Python for duplicate path literals, and share one tracked AST inventory across topology checks. |
| `tests/unit/core/test_install_audit.py`, `tests/unit/deps/test_lockfile_git_semver.py` | Classify the two pure-logic modules as `unit`. |
| `tests/integration/test_install_content_hash_roundtrip.py`, `tests/integration/test_policy_pinned_constraint_e2e.py` | Classify the two in-process filesystem / command-boundary modules as `component`. |
| `tests/integration/test_core_smoke.py` | Add `e2e` while preserving the independent binary and E2E-mode prerequisites. |
| `scripts/test_file_inventory.py`, `scripts/ratchet_baseline.py`, both checker scripts, and their unit tests | Share tracked/symlink-contained file discovery and JSON baseline lifecycle; report actionable failures and refuse all debt growth during updates. |
| `tests/quality/assertion_quality_baseline.json`, `tests/quality/exact_test_duplicates.json` | Record the final merged-main measurements: AQ001=5, AQ002=12, 1036 files, and 8 exact groups / 16 occurrences. |
| `.github/workflows/ci.yml`, `tests/quality/test_ci_topology.py`, `tests/quality/test_quality_baselines.py` | Enforce semantic test placement and exact pytest roots, run each repository scanner once, and permit provisional mode only for draft pull-request events. |
| `.apm/instructions/tests.instructions.md`, `.github/instructions/tests.instructions.md`, `docs/src/content/docs/contributing/integration-testing.md` | Document three marker axes, the manifest checklist, frozen strict updater commands, and draft-CI-only provisional behavior; keep instruction mirrors byte-identical. |
| `apm.lock.yaml` | Refresh the self-managed instruction content hash so `apm audit --ci` verifies the updated mirror. |
| `tests/integration/test_marker_registry_sync.py` | Clarify that behavioral and scheduling markers are not environment gates; registry logic is unchanged. |

## Diagrams

Legend: dashed nodes are the new manifest, ratchets, and informational CI path.

```mermaid
flowchart LR
    subgraph Taxonomy[Finite taxonomy]
        P["pyproject markers"]
        M["critical_suite.toml"]
        T["test_test_taxonomy.py"]
        P --> T
        M --> T
    end
    subgraph Quality[Bounded quality checks]
        S["Tracked Python test modules"]
        A["check_test_assertions.py"]
        D["check_exact_test_duplicates.py"]
        AB["assertion baseline"]
        DB["duplicate baseline"]
        S --> A
        S -->|"contained non-symlink paths"| D
        AB --> A
        DB --> D
    end
    T --> J["Test Architecture Ratchets"]
    A --> J
    D --> J
    J --> I["Informational PR signal"]
    R["Required test shards"] --> U["tests/unit only"]
    U -.->|"does not collect"| J
    classDef new stroke-dasharray: 5 5;
    class M,T,A,D,J,I new;
```

## Trade-offs

- **Finite manifest, not repository-wide reclassification.** Chose five
  behaviorally uniform modules; rejected directory-derived or mass-applied
  labels because filenames and locations are not behavioral proof.
- **Two named AST forms, not a generic analyzer.** Chose direct `ast.walk`
  checks for AQ001/AQ002; rejected visitors, similarity engines, control-flow
  analysis, and deletion recommendations.
- **Tracked paths with worktree bytes, not Git blobs or filesystem discovery.**
  Chose `git ls-files` once for identity and `read_bytes()` for local-edit
  visibility; rejected untracked files, symlinks, normalization, and blob-only
  hashing.
- **Reduction-only updates, not debt approval.** Chose atomic tightening only;
  rejected force, bootstrap-growth, or approve flags.
- **Permanent draft guard, not metadata-coupled workflow edits.** The one guarded
  binding remains after finalization; ready PRs, merge groups, and other events
  always run strict mode.
- **Contributor scenario evidence included.** This changes test-authoring and
  CI behavior, so the pure-refactor skip clause does not apply.

## Benefits

1. Exactly five critical modules are selected by one and only one behavioral
   marker.
2. New AQ001/AQ002 occurrences default to a ceiling of zero and fail.
3. A new exact duplicate pair or third member fails, while one-byte and
   CRLF/LF differences remain allowed.
4. Baseline reductions fail stale until tightened, while final validation
   rejects any remaining `provisional` metadata.
5. PRs receive a visible signal without changing the required `gate` topology.

## Diff shape

The contaminated branch was `+13,327/-2,736` across 166 files. Reconstructing
from current main removed merged predecessor commits, duplicated #2198 history,
the merge commit, and all inherited internal planning/report artifacts.

| Area | Files | Additions | Deletions |
|---|---:|---:|---:|
| Repository-state quality contracts and baselines | 9 | 972 | 0 |
| Hermetic checker and authority mutations | 3 | 770 | 0 |
| Ratchet and authority implementation | 5 | 652 | 0 |
| Contributor guidance and integrity metadata | 4 | 183 | 14 |
| CI and architecture topology | 2 | 41 | 0 |
| Finite taxonomy declarations and markers | 7 | 18 | 3 |
| **Corrected total** | **30** | **2,636** | **17** |

The largest files are adversarial contract suites
(`test_check_test_assertions.py` +343,
`test_check_exact_test_duplicates.py` +342,
`test_ci_topology.py` +318) and the two bounded scanners (+238/+225).

## Validation

`uv run --extra dev pytest -p no:cacheprovider -q tests/quality tests/unit/scripts/test_check_test_assertions.py tests/unit/scripts/test_check_exact_test_duplicates.py tests/unit/scripts/test_check_test_contract_authorities.py tests/integration/test_architecture_authorities.py`:

```text
129 passed in 45.87s
```

`uv run --frozen python scripts/check_test_assertions.py && uv run --frozen python scripts/check_exact_test_duplicates.py`:

```text
[+] assertion-quality ratchet clean: AQ001=5, AQ002=12
[+] exact test duplicate ratchet clean: 1036 files, 8 allowed duplicate group(s)
```

`uv run apm audit --ci`:

```text
[*] All 9 check(s) passed
```

<details><summary>Required suite and lint evidence</summary>

`uv run pytest tests/unit tests/test_console.py tests/red_team -n 2 --dist worksteal`:

```text
19033 passed, 2 skipped, 21 xfailed, 19 warnings in 122.36s (0:02:02)
```

CI lint mirror:

```text
All checks passed!
1517 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
[+] architecture boundary lint clean (AC1-AC9)
```

The YAML I/O, file-length, and raw `str(relative_to())` guards produced no
violations. The terminal APM panel recommends `ship_now` on exact head
`c972b37212849908b2ea34dff682cdbc37823f79`. Copilot's only comment
references the removed pre-rewrite head and is classified NOT-LEGIT.

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | A contributor classifies a critical test once and collection selects it under exactly that behavior boundary. | OSS / community-driven | `tests/quality/test_test_taxonomy.py::test_tm003_each_manifest_module_has_exactly_its_declared_marker` | integration |
| 2 | Repository-state quality checks stay physically isolated and informational while required shards retain exact roots. | Governed by policy | `tests/quality/test_ci_topology.py::test_test_architecture_ratchets_remain_non_required`<br/>`tests/quality/test_ci_topology.py::test_relocated_repository_contract_fails_topology`<br/>`tests/quality/test_ci_topology.py::test_duplicate_ratchet_target_fails` | integration |
| 3 | A contributor adding constant assertions or broad exception catches receives a focused failure without expanding the analyzer. | OSS / community-driven | `tests/unit/scripts/test_check_test_assertions.py::test_aq001_new_constant_assertion_fails`<br/>`tests/unit/scripts/test_check_test_assertions.py::test_aq002_new_broad_raises_fails` | unit |
| 4 | A tracked byte-identical copy fails, while untracked files, near duplicates, and line-ending differences remain outside exact-duplicate debt. | OSS / community-driven, Secure by default | `tests/unit/scripts/test_check_exact_test_duplicates.py::test_new_exact_pair_fails`<br/>`tests/unit/scripts/test_check_exact_test_duplicates.py::test_untracked_duplicate_is_out_of_scope`<br/>`tests/unit/scripts/test_check_exact_test_duplicates.py::test_crlf_and_lf_are_not_exact_duplicates` | unit |
| 5 | A tracked symlink cannot escape the repository or hide outside bytes in the duplicate scan. | Secure by default | `tests/unit/scripts/test_check_exact_test_duplicates.py::test_tracked_symlink_inside_root_fails_closed`<br/>`tests/unit/scripts/test_check_exact_test_duplicates.py::test_symlink_outside_root_fails_containment_check` | unit |
| 6 | Final validation cannot pass with provisional metadata, then succeeds after that metadata is removed. | Governed by policy | `tests/unit/scripts/test_check_test_assertions.py::test_provisional_baseline_requires_explicit_allow`<br/>`tests/unit/scripts/test_check_exact_test_duplicates.py::test_provisional_baseline_requires_explicit_allow` | unit |
| 7 | Provisional mode is available only to draft pull-request CI; ready, merge-group, and other events remain strict. | Governed by policy | `tests/quality/test_ci_topology.py::test_provisional_ci_opt_in_is_draft_guarded`<br/>`tests/quality/test_ci_topology.py::test_unconditional_provisional_opt_in_fails`<br/>`tests/quality/test_ci_topology.py::test_merge_group_provisional_acceptance_fails` | integration |
| 8 | Both pytest filename conventions and all tracked Python locations participate in topology and sole-owner checks without repeated repository parsing. | OSS / community-driven, Governed by policy | `tests/quality/test_ci_topology.py::test_relocated_repository_contract_fails_topology`<br/>`tests/quality/test_ci_topology.py::test_repository_ratchet_inventory_is_collected_once`<br/>`tests/quality/test_test_taxonomy.py::test_tm002_manifest_literal_outside_quality_fails` | integration |

## How to test

- [ ] Run the focused contract command; observe 129 passing contracts.
- [ ] Run both strict checker commands; observe AQ001=5, AQ002=12, 1036 tracked files, and 8 groups.
- [ ] Add a normal tracked test module; observe the dynamic count adjust without editing a golden literal.
- [ ] Add and stage `assert True` in a temporary test fixture; observe AQ001 growth fail against zero.
- [ ] Inspect CI; observe `Test Architecture Ratchets` separately and required shards unchanged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>