### PR TITLE
harden(contracts): add platform and rendered documentation evidence

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -76,9 +76,8 @@ jobs:
         shell: pwsh
         env:
           APM_E2E_TESTS: "1"
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >-
-          uv run pytest
+          uv run --frozen pytest
           tests/integration/test_windows_installer_launchers.py
           -vv -ra --tb=short
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -193,10 +193,11 @@ jobs:
         env:
           APM_E2E_TESTS: "1"
           APM_BINARY_PATH: ${{ github.workspace }}/dist/apm-darwin-x86_64/apm
-        run: >-
-          uv run pytest
-          tests/integration/test_core_smoke.py::TestBinaryStartup::test_apm_version_runs
-          -vv -ra --tb=short
+        run: |
+          test -x "$APM_BINARY_PATH"
+          uv run --frozen pytest \
+            tests/integration/test_core_smoke.py::TestBinaryStartup::test_apm_version_runs \
+            -vv -ra --tb=short
 
       - name: Upload binary as workflow artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -77,8 +77,10 @@ jobs:
         env:
           APM_E2E_TESTS: "1"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          uv run pytest tests/integration/test_windows_installer_launchers.py -q
+        run: >-
+          uv run pytest
+          tests/integration/test_windows_installer_launchers.py
+          -vv -ra --tb=short
 
       # Unit tests run on every push for fast platform-regression signal.
       # Smoke is intentionally NOT included here: it duplicates ci-integration.yml's
@@ -186,6 +188,15 @@ jobs:
         run: |
           chmod +x scripts/build-binary.sh
           uv run ./scripts/build-binary.sh
+
+      - name: Test macOS non-shell binary startup
+        env:
+          APM_E2E_TESTS: "1"
+          APM_BINARY_PATH: ${{ github.workspace }}/dist/apm-darwin-x86_64/apm
+        run: >-
+          uv run pytest
+          tests/integration/test_core_smoke.py::TestBinaryStartup::test_apm_version_runs
+          -vv -ra --tb=short
 
       - name: Upload binary as workflow artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,12 @@ on:
   release:
     types: [published]
   pull_request:
-    paths: ['docs/**']
+    paths:
+      - 'docs/**'
+      - 'src/apm_cli/cli.py'
+      - 'scripts/check_cli_docs.py'
+      - 'tests/unit/test_cli_docs_contract.py'
+      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 permissions:
@@ -45,13 +50,36 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'docs/package-lock.json'
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install Python test dependencies
+        run: uv sync --extra dev
+
       - name: Install dependencies
         working-directory: ./docs
         run: npm ci
 
+      - name: Test generated-link checker
+        working-directory: ./docs
+        run: npm run test:links
+
+      - name: Test CLI registry contract
+        run: uv run pytest tests/unit/test_cli_docs_contract.py -q
+
       - name: Build documentation
         working-directory: ./docs
         run: npm run build
+
+      - name: Check CLI registry against rendered pages
+        run: uv run python scripts/check_cli_docs.py docs/dist
 
       - name: Verify schema $id reachability
         # Asserts every JSON Schema's declared $id URL resolves to a

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,7 @@ on:
     paths:
       - 'docs/**'
       - 'src/apm_cli/cli.py'
+      - 'src/apm_cli/commands/**'
       - 'scripts/check_cli_docs.py'
       - 'tests/unit/test_cli_docs_contract.py'
       - '.github/workflows/docs.yml'
@@ -29,8 +30,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: "pages-${{ github.ref }}"
@@ -61,7 +60,7 @@ jobs:
           enable-cache: true
 
       - name: Install Python test dependencies
-        run: uv sync --extra dev
+        run: uv sync --frozen --extra dev
 
       - name: Install dependencies
         working-directory: ./docs
@@ -72,14 +71,14 @@ jobs:
         run: npm run test:links
 
       - name: Test CLI registry contract
-        run: uv run pytest tests/unit/test_cli_docs_contract.py -q
+        run: uv run --frozen pytest tests/unit/test_cli_docs_contract.py -q
 
       - name: Build documentation
         working-directory: ./docs
         run: npm run build
 
       - name: Check CLI registry against rendered pages
-        run: uv run python scripts/check_cli_docs.py docs/dist
+        run: uv run --frozen python scripts/check_cli_docs.py docs/dist
 
       - name: Verify schema $id reachability
         # Asserts every JSON Schema's declared $id URL resolves to a

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,7 @@ on:
       - 'src/apm_cli/commands/**'
       - 'scripts/check_cli_docs.py'
       - 'tests/unit/test_cli_docs_contract.py'
+      - 'tests/integration/test_cli_docs_contract.py'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 
@@ -71,7 +72,11 @@ jobs:
         run: npm run test:links
 
       - name: Test CLI registry contract
-        run: uv run --frozen pytest tests/unit/test_cli_docs_contract.py -q
+        run: >-
+          uv run --frozen pytest
+          tests/unit/test_cli_docs_contract.py
+          tests/integration/test_cli_docs_contract.py
+          -q
 
       - name: Build documentation
         working-directory: ./docs

--- a/docs/scripts/check-links.test.mjs
+++ b/docs/scripts/check-links.test.mjs
@@ -198,9 +198,10 @@ test('CLI exits 0 with no output errors when all links resolve', () => {
 	}
 });
 
-test('CLI exits non-zero with actionable diagnostics when a link is broken', () => {
+test('CLI exits non-zero with actionable diagnostics when a rendered target page is missing', () => {
 	const dist = makeFixtureDist({
-		'enterprise/registry-proxy/index.html': '<a href="../troubleshooting/ssl-issues/">SSL</a>',
+		'enterprise/registry-proxy/index.html':
+			'<a href="../../troubleshooting/ssl-issues/">SSL</a>',
 	});
 	try {
 		let threw = false;
@@ -211,10 +212,10 @@ test('CLI exits non-zero with actionable diagnostics when a link is broken', () 
 			assert.notEqual(error.status, 0);
 			const combined = `${error.stdout || ''}${error.stderr || ''}`;
 			assert.match(combined, /registry-proxy/);
-			assert.match(combined, /\.\.\/troubleshooting\/ssl-issues\//);
-			assert.match(combined, /\/apm\/enterprise\/troubleshooting\/ssl-issues\//);
+			assert.match(combined, /\.\.\/\.\.\/troubleshooting\/ssl-issues\//);
+			assert.match(combined, /\/apm\/troubleshooting\/ssl-issues\//);
 		}
-		assert.ok(threw, 'expected CLI to exit with a non-zero status');
+		assert.ok(threw, 'expected a missing rendered target page to fail');
 	} finally {
 		cleanup(dist);
 	}

--- a/docs/src/content/docs/contributing/development-guide.md
+++ b/docs/src/content/docs/contributing/development-guide.md
@@ -136,7 +136,9 @@ This is optional -- CI is the authoritative gate. The pre-commit hook rev may la
 
 If your changes affect how users interact with the project, update the documentation accordingly.
 Public top-level CLI commands and rendered reference pages are a matched contract. When you add,
-remove, or rename a command, update `docs/src/content/docs/reference/cli/<command>.md`, then run:
+remove, or rename a command, create, remove, or rename its matching page under
+`docs/src/content/docs/reference/cli/` and update the command table in
+`docs/src/content/docs/reference/index.md`, then run:
 
 ```bash
 npm --prefix docs run build

--- a/docs/src/content/docs/contributing/development-guide.md
+++ b/docs/src/content/docs/contributing/development-guide.md
@@ -135,6 +135,13 @@ This is optional -- CI is the authoritative gate. The pre-commit hook rev may la
 ## Documentation
 
 If your changes affect how users interact with the project, update the documentation accordingly.
+Public top-level CLI commands and rendered reference pages are a matched contract. When you add,
+remove, or rename a command, update `docs/src/content/docs/reference/cli/<command>.md`, then run:
+
+```bash
+npm --prefix docs run build
+uv run --frozen python scripts/check_cli_docs.py docs/dist
+```
 
 ## License
 

--- a/scripts/check_cli_docs.py
+++ b/scripts/check_cli_docs.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Compare public top-level Click commands with rendered CLI reference pages."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import click
+
+from apm_cli.cli import cli
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_DIST = REPO_ROOT / "docs" / "dist"
+
+
+def public_top_level_commands(group: click.Group) -> set[str]:
+    """Return visible top-level names from Click's live command registry."""
+    return {name for name, command in group.commands.items() if not command.hidden}
+
+
+def rendered_cli_reference_pages(dist_dir: Path) -> set[str]:
+    """Return one-level CLI pages emitted by the Astro build."""
+    cli_dir = dist_dir / "reference" / "cli"
+    if not cli_dir.is_dir():
+        raise FileNotFoundError(f"rendered CLI directory not found: {cli_dir}")
+
+    return {
+        child.name
+        for child in cli_dir.iterdir()
+        if child.is_dir() and (child / "index.html").is_file()
+    }
+
+
+def registry_docs_mismatches(
+    group: click.Group,
+    dist_dir: Path,
+) -> tuple[list[str], list[str]]:
+    """Return missing rendered pages and rendered pages without commands."""
+    commands = public_top_level_commands(group)
+    pages = rendered_cli_reference_pages(dist_dir)
+    return sorted(commands - pages), sorted(pages - commands)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Validate the repository CLI registry against one rendered dist tree."""
+    parser = argparse.ArgumentParser(
+        description="Check public CLI commands against rendered reference pages."
+    )
+    parser.add_argument(
+        "dist_dir",
+        nargs="?",
+        type=Path,
+        default=DEFAULT_DIST,
+        help="Astro output directory (default: docs/dist)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        missing_pages, orphan_pages = registry_docs_mismatches(
+            cli,
+            args.dist_dir,
+        )
+    except FileNotFoundError as error:
+        print(f"[x] {error}")
+        return 1
+
+    if missing_pages or orphan_pages:
+        print("[x] CLI registry/rendered documentation mismatch:")
+        if missing_pages:
+            print("  executable commands missing rendered pages: " + ", ".join(missing_pages))
+        if orphan_pages:
+            print("  rendered pages missing executable commands: " + ", ".join(orphan_pages))
+        return 1
+
+    command_count = len(public_top_level_commands(cli))
+    print(f"[+] {command_count} public CLI commands match {command_count} rendered pages.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_cli_docs.py
+++ b/scripts/check_cli_docs.py
@@ -15,6 +15,21 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_DIST = REPO_ROOT / "docs" / "dist"
 
 
+def recovery_guidance(dist_dir: Path, *, mismatch: bool) -> str:
+    """Return root-safe recovery guidance for the selected output tree."""
+    if dist_dir.resolve() == DEFAULT_DIST.resolve():
+        rebuild = "rebuild with 'npm --prefix docs run build'"
+    else:
+        rebuild = f"rebuild the rendered docs at '{dist_dir}'"
+    if mismatch:
+        action = f"Add or remove the matching CLI reference page, {rebuild}"
+    else:
+        action = rebuild[0].upper() + rebuild[1:]
+    return (
+        f"[i] {action}, then rerun 'uv run --frozen python scripts/check_cli_docs.py {dist_dir}'."
+    )
+
+
 def public_top_level_commands(group: click.Group) -> set[str]:
     """Return visible top-level names from Click's live command registry."""
     return {name for name, command in group.commands.items() if not command.hidden}
@@ -64,11 +79,7 @@ def main(argv: list[str] | None = None) -> int:
         )
     except FileNotFoundError as error:
         print(f"[x] {error}", file=sys.stderr)
-        print(
-            "[i] Rebuild docs with 'npm --prefix docs run build', then rerun "
-            f"'uv run --frozen python scripts/check_cli_docs.py {args.dist_dir}'.",
-            file=sys.stderr,
-        )
+        print(recovery_guidance(args.dist_dir, mismatch=False), file=sys.stderr)
         return 1
 
     if missing_pages or orphan_pages:
@@ -83,12 +94,7 @@ def main(argv: list[str] | None = None) -> int:
                 "  rendered pages missing executable commands: " + ", ".join(orphan_pages),
                 file=sys.stderr,
             )
-        print(
-            "[i] Add or remove the matching CLI reference page, rebuild with "
-            "'npm --prefix docs run build', then rerun "
-            f"'uv run --frozen python scripts/check_cli_docs.py {args.dist_dir}'.",
-            file=sys.stderr,
-        )
+        print(recovery_guidance(args.dist_dir, mismatch=True), file=sys.stderr)
         return 1
 
     command_count = len(public_top_level_commands(cli))

--- a/scripts/check_cli_docs.py
+++ b/scripts/check_cli_docs.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 
 import click
@@ -62,15 +63,32 @@ def main(argv: list[str] | None = None) -> int:
             args.dist_dir,
         )
     except FileNotFoundError as error:
-        print(f"[x] {error}")
+        print(f"[x] {error}", file=sys.stderr)
+        print(
+            "[i] Rebuild docs with 'cd docs && npm run build', then rerun "
+            f"'uv run --frozen python scripts/check_cli_docs.py {args.dist_dir}'.",
+            file=sys.stderr,
+        )
         return 1
 
     if missing_pages or orphan_pages:
-        print("[x] CLI registry/rendered documentation mismatch:")
+        print("[x] CLI registry/rendered documentation mismatch:", file=sys.stderr)
         if missing_pages:
-            print("  executable commands missing rendered pages: " + ", ".join(missing_pages))
+            print(
+                "  executable commands missing rendered pages: " + ", ".join(missing_pages),
+                file=sys.stderr,
+            )
         if orphan_pages:
-            print("  rendered pages missing executable commands: " + ", ".join(orphan_pages))
+            print(
+                "  rendered pages missing executable commands: " + ", ".join(orphan_pages),
+                file=sys.stderr,
+            )
+        print(
+            "[i] Add or remove the matching CLI reference page, rebuild with "
+            "'cd docs && npm run build', then rerun "
+            f"'uv run --frozen python scripts/check_cli_docs.py {args.dist_dir}'.",
+            file=sys.stderr,
+        )
         return 1
 
     command_count = len(public_top_level_commands(cli))

--- a/scripts/check_cli_docs.py
+++ b/scripts/check_cli_docs.py
@@ -65,7 +65,7 @@ def main(argv: list[str] | None = None) -> int:
     except FileNotFoundError as error:
         print(f"[x] {error}", file=sys.stderr)
         print(
-            "[i] Rebuild docs with 'cd docs && npm run build', then rerun "
+            "[i] Rebuild docs with 'npm --prefix docs run build', then rerun "
             f"'uv run --frozen python scripts/check_cli_docs.py {args.dist_dir}'.",
             file=sys.stderr,
         )
@@ -85,7 +85,7 @@ def main(argv: list[str] | None = None) -> int:
             )
         print(
             "[i] Add or remove the matching CLI reference page, rebuild with "
-            "'cd docs && npm run build', then rerun "
+            "'npm --prefix docs run build', then rerun "
             f"'uv run --frozen python scripts/check_cli_docs.py {args.dist_dir}'.",
             file=sys.stderr,
         )

--- a/scripts/check_test_contract_authorities.py
+++ b/scripts/check_test_contract_authorities.py
@@ -420,22 +420,45 @@ def _list_literal_values(node: ast.AST) -> list[str | None]:
 
 def _assignment_command_values(
     tree: ast.AST,
-) -> tuple[dict[str, list[str | None]], dict[str, str]]:
-    lists: dict[str, list[str | None]] = {}
-    strings: dict[str, str] = {}
+    scope_by_node: dict[int, ast.AST],
+) -> tuple[
+    dict[int, dict[str, list[str | None]]],
+    dict[int, dict[str, str]],
+]:
+    assignments: dict[int, list[tuple[list[str], ast.AST]]] = {}
     for node in ast.walk(tree):
         if not isinstance(node, (ast.Assign, ast.AnnAssign)) or node.value is None:
             continue
         targets = node.targets if isinstance(node, ast.Assign) else [node.target]
         names = [name for target in targets for name in _bound_names(target)]
-        list_value = _list_literal_values(node.value)
-        string_value = _literal_string(node.value)
-        for name in names:
-            if list_value:
-                lists[name] = list_value
-            elif string_value is not None:
-                strings[name] = string_value
-    return lists, strings
+        scope = scope_by_node.get(id(node), tree)
+        assignments.setdefault(id(scope), []).append((names, node.value))
+
+    lists_by_scope: dict[int, dict[str, list[str | None]]] = {}
+    strings_by_scope: dict[int, dict[str, str]] = {}
+    for scope_id, scoped_assignments in assignments.items():
+        lists: dict[str, list[str | None]] = {}
+        strings: dict[str, str] = {}
+        for _ in range(len(scoped_assignments) + 1):
+            changed = False
+            for names, value in scoped_assignments:
+                list_value = _list_literal_values(value)
+                string_value = _literal_string(value)
+                if isinstance(value, ast.Name):
+                    list_value = lists.get(value.id, [])
+                    string_value = strings.get(value.id)
+                for name in names:
+                    if list_value and lists.get(name) != list_value:
+                        lists[name] = list_value
+                        changed = True
+                    elif string_value is not None and strings.get(name) != string_value:
+                        strings[name] = string_value
+                        changed = True
+            if not changed:
+                break
+        lists_by_scope[scope_id] = lists
+        strings_by_scope[scope_id] = strings
+    return lists_by_scope, strings_by_scope
 
 
 def _shell_enabled(call: ast.Call) -> bool:
@@ -449,7 +472,10 @@ def _shell_enabled(call: ast.Call) -> bool:
 
 def _direct_apm_subprocess_lines(tree: ast.AST) -> list[int]:
     bindings_by_scope, scope_by_node = _scope_binding_maps(tree)
-    assigned_lists, assigned_strings = _assignment_command_values(tree)
+    lists_by_scope, strings_by_scope = _assignment_command_values(
+        tree,
+        scope_by_node,
+    )
     lines: set[int] = set()
     for node in ast.walk(tree):
         if isinstance(node, (ast.List, ast.Tuple)):
@@ -486,6 +512,9 @@ def _direct_apm_subprocess_lines(tree: ast.AST) -> list[int]:
         if not isinstance(node, ast.Call) or not node.args:
             continue
         scope = scope_by_node.get(id(node), tree)
+        scope_id = id(scope)
+        assigned_lists = lists_by_scope.get(scope_id, {})
+        assigned_strings = strings_by_scope.get(scope_id, {})
         if not _is_subprocess_call(
             node,
             bindings_by_scope.get(id(scope), {}),

--- a/scripts/check_test_contract_authorities.py
+++ b/scripts/check_test_contract_authorities.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Guard canonical owners for integration binaries and rendered CLI parity."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BINARY_OWNER = Path("tests/integration/conftest.py")
+PARITY_OWNER = Path("scripts/check_cli_docs.py")
+
+
+def _python_files(root: Path, locations: tuple[str, ...]) -> list[Path]:
+    files: list[Path] = []
+    for location in locations:
+        base = root / location
+        if base.is_file():
+            files.append(base)
+        elif base.is_dir():
+            files.extend(base.rglob("*.py"))
+    return sorted(path for path in files if path.is_file())
+
+
+def _function_nodes(tree: ast.AST) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    return [
+        node for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+
+
+def _attribute_name(node: ast.AST) -> str | None:
+    parts: list[str] = []
+    current = node
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if isinstance(current, ast.Name):
+        parts.append(current.id)
+        return ".".join(reversed(parts))
+    return None
+
+
+def _string_values(node: ast.AST) -> set[str]:
+    return {
+        child.value
+        for child in ast.walk(node)
+        if isinstance(child, ast.Constant) and isinstance(child.value, str)
+    }
+
+
+def _calls_named(node: ast.AST, names: set[str]) -> bool:
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call):
+            continue
+        called = _attribute_name(child.func)
+        if called is not None and called in names:
+            return True
+    return False
+
+
+def _binary_duplicate_reason(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> str | None:
+    strings = _string_values(function)
+    reads_binary_env = "APM_BINARY_PATH" in strings and _calls_named(
+        function,
+        {"os.environ.get", "os.getenv"},
+    )
+    discovers_path_binary = _calls_named(function, {"shutil.which"}) and "apm" in strings
+    discovers_venv_binary = ".venv" in strings and "apm" in strings
+
+    if function.name == "_resolve_apm_binary":
+        return "defines a second _resolve_apm_binary helper"
+    if reads_binary_env and (discovers_path_binary or discovers_venv_binary):
+        return "combines APM_BINARY_PATH reading with local/PATH fallback discovery"
+    return None
+
+
+def find_binary_selection_violations(root: Path) -> list[str]:
+    """Find integration-test functions that reimplement binary selection."""
+    diagnostics: list[str] = []
+    owner = root / BINARY_OWNER
+    if not owner.is_file() or "def _resolve_apm_binary(" not in owner.read_text(encoding="utf-8"):
+        diagnostics.append(f"[x] {BINARY_OWNER} must define _resolve_apm_binary")
+
+    for path in _python_files(root, ("tests",)):
+        if path == owner:
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError) as error:
+            diagnostics.append(f"[x] cannot inspect {path.relative_to(root)}: {error}")
+            continue
+        for function in _function_nodes(tree):
+            reason = _binary_duplicate_reason(function)
+            if reason is not None:
+                relative = path.relative_to(root).as_posix()
+                diagnostics.append(
+                    f"[x] duplicate integration binary selection: "
+                    f"{relative}:{function.lineno} {function.name} {reason}"
+                )
+    return sorted(diagnostics)
+
+
+def _has_visible_registry_projection(tree: ast.AST) -> bool:
+    has_commands_items = False
+    has_hidden_filter = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            called = _attribute_name(node.func)
+            if called is not None and called.endswith(".commands.items"):
+                has_commands_items = True
+        if isinstance(node, ast.Attribute) and node.attr == "hidden":
+            has_hidden_filter = True
+    return has_commands_items and has_hidden_filter
+
+
+def _has_rendered_page_projection(tree: ast.AST) -> bool:
+    strings = _string_values(tree)
+    has_iterdir = any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "iterdir"
+        for node in ast.walk(tree)
+    )
+    return has_iterdir and {"reference", "cli", "index.html"}.issubset(strings)
+
+
+def _has_bidirectional_set_difference(tree: ast.AST) -> bool:
+    return (
+        sum(isinstance(node, ast.BinOp) and isinstance(node.op, ast.Sub) for node in ast.walk(tree))
+        >= 2
+    )
+
+
+def find_rendered_parity_violations(root: Path) -> list[str]:
+    """Find modules outside the checker that recompute rendered CLI parity."""
+    diagnostics: list[str] = []
+    owner = root / PARITY_OWNER
+    owner_source = owner.read_text(encoding="utf-8") if owner.is_file() else ""
+    required = (
+        "def public_top_level_commands(",
+        "def rendered_cli_reference_pages(",
+        "def registry_docs_mismatches(",
+    )
+    if any(token not in owner_source for token in required):
+        diagnostics.append(f"[x] {PARITY_OWNER} must own all rendered parity projections")
+
+    for path in _python_files(root, ("src/apm_cli", "scripts")):
+        if path == owner:
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError) as error:
+            diagnostics.append(f"[x] cannot inspect {path.relative_to(root)}: {error}")
+            continue
+        roles = (
+            _has_visible_registry_projection(tree),
+            _has_rendered_page_projection(tree),
+            _has_bidirectional_set_difference(tree),
+        )
+        if sum(roles) >= 2:
+            relative = path.relative_to(root).as_posix()
+            diagnostics.append(
+                f"[x] duplicate rendered CLI parity computation: {relative} "
+                "must delegate to scripts/check_cli_docs.py"
+            )
+    return sorted(diagnostics)
+
+
+def check(root: Path) -> list[str]:
+    """Return all canonical-owner violations for the repository."""
+    return [
+        *find_binary_selection_violations(root),
+        *find_rendered_parity_violations(root),
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=REPO_ROOT)
+    args = parser.parse_args(argv)
+    diagnostics = check(args.root.resolve())
+    for diagnostic in diagnostics:
+        print(diagnostic)
+    if diagnostics:
+        print(f"[x] {len(diagnostics)} test contract authority violation(s) found")
+        return 1
+    print("[+] test contract authority check clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_test_contract_authorities.py
+++ b/scripts/check_test_contract_authorities.py
@@ -75,6 +75,18 @@ def _resolve_binding(node: ast.AST, bindings: dict[str, str]) -> str | None:
     return None
 
 
+def _scope_nodes(body: list[ast.stmt]) -> list[ast.AST]:
+    nodes: list[ast.AST] = []
+    stack: list[ast.AST] = list(reversed(body))
+    while stack:
+        node = stack.pop()
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        nodes.append(node)
+        stack.extend(reversed(list(ast.iter_child_nodes(node))))
+    return nodes
+
+
 def _scope_binding_maps(
     tree: ast.Module,
 ) -> tuple[dict[int, dict[str, str]], dict[int, ast.AST]]:
@@ -87,6 +99,7 @@ def _scope_binding_maps(
             if isinstance(scope, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef))
             else []
         )
+        scope_nodes = _scope_nodes(body)
         bindings = dict(inherited)
         if isinstance(scope, (ast.FunctionDef, ast.AsyncFunctionDef)):
             local_names = {
@@ -99,9 +112,7 @@ def _scope_binding_maps(
             }
             local_names.update(
                 name
-                for statement in body
-                if not isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
-                for child in ast.walk(statement)
+                for child in scope_nodes
                 if isinstance(child, (ast.Assign, ast.AnnAssign, ast.NamedExpr))
                 for target in (child.targets if isinstance(child, ast.Assign) else [child.target])
                 for name in _bound_names(target)
@@ -109,7 +120,7 @@ def _scope_binding_maps(
             for name in local_names:
                 bindings.pop(name, None)
 
-        for statement in body:
+        for statement in scope_nodes:
             if isinstance(statement, ast.Import):
                 for alias in statement.names:
                     if alias.name in {"os", "shutil", "subprocess", "sys"}:
@@ -122,9 +133,9 @@ def _scope_binding_maps(
                 for alias in statement.names:
                     bindings[alias.asname or alias.name] = f"{statement.module}.{alias.name}"
 
-        for _ in range(len(body) + 1):
+        for _ in range(len(scope_nodes) + 1):
             changed = False
-            for statement in body:
+            for statement in scope_nodes:
                 if not isinstance(statement, (ast.Assign, ast.AnnAssign)):
                     continue
                 value = statement.value

--- a/scripts/check_test_contract_authorities.py
+++ b/scripts/check_test_contract_authorities.py
@@ -461,6 +461,38 @@ def _assignment_command_values(
     return lists_by_scope, strings_by_scope
 
 
+def _scope_parent_map(tree: ast.Module) -> dict[int, ast.AST]:
+    parents = {child: node for node in ast.walk(tree) for child in ast.iter_child_nodes(node)}
+    scope_parents: dict[int, ast.AST] = {}
+    for scope in (
+        node for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ):
+        parent = parents.get(scope)
+        while parent is not None and not isinstance(
+            parent,
+            (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef),
+        ):
+            parent = parents.get(parent)
+        if parent is not None:
+            scope_parents[id(scope)] = parent
+    return scope_parents
+
+
+def _scoped_value(
+    name: str,
+    scope: ast.AST,
+    values_by_scope: dict[int, dict[str, object]],
+    scope_parents: dict[int, ast.AST],
+) -> object | None:
+    current: ast.AST | None = scope
+    while current is not None:
+        values = values_by_scope.get(id(current), {})
+        if name in values:
+            return values[name]
+        current = scope_parents.get(id(current))
+    return None
+
+
 def _shell_enabled(call: ast.Call) -> bool:
     return any(
         keyword.arg == "shell"
@@ -472,6 +504,7 @@ def _shell_enabled(call: ast.Call) -> bool:
 
 def _direct_apm_subprocess_lines(tree: ast.AST) -> list[int]:
     bindings_by_scope, scope_by_node = _scope_binding_maps(tree)
+    scope_parents = _scope_parent_map(tree)
     lists_by_scope, strings_by_scope = _assignment_command_values(
         tree,
         scope_by_node,
@@ -512,9 +545,6 @@ def _direct_apm_subprocess_lines(tree: ast.AST) -> list[int]:
         if not isinstance(node, ast.Call) or not node.args:
             continue
         scope = scope_by_node.get(id(node), tree)
-        scope_id = id(scope)
-        assigned_lists = lists_by_scope.get(scope_id, {})
-        assigned_strings = strings_by_scope.get(scope_id, {})
         if not _is_subprocess_call(
             node,
             bindings_by_scope.get(id(scope), {}),
@@ -523,13 +553,26 @@ def _direct_apm_subprocess_lines(tree: ast.AST) -> list[int]:
         command = node.args[0]
         values = _list_literal_values(command)
         if not values and isinstance(command, ast.Name):
-            values = assigned_lists.get(command.id, [])
+            inherited_list = _scoped_value(
+                command.id,
+                scope,
+                lists_by_scope,
+                scope_parents,
+            )
+            values = inherited_list if isinstance(inherited_list, list) else []
         if values and values[0] in APM_EXECUTABLE_NAMES:
             lines.add(node.lineno)
         if _shell_enabled(node):
             shell_command = _literal_string(command)
             if shell_command is None and isinstance(command, ast.Name):
-                shell_command = assigned_strings.get(command.id)
+                inherited_string = _scoped_value(
+                    command.id,
+                    scope,
+                    strings_by_scope,
+                    scope_parents,
+                )
+                if isinstance(inherited_string, str):
+                    shell_command = inherited_string
             if shell_command is not None:
                 try:
                     shell_tokens = shlex.split(shell_command, posix=True)

--- a/scripts/check_test_contract_authorities.py
+++ b/scripts/check_test_contract_authorities.py
@@ -122,6 +122,13 @@ def _list_literal_values(node: ast.AST) -> list[str | None]:
     return [_literal_string(element) for element in node.elts]
 
 
+def _is_subprocess_execution(call: ast.Call) -> bool:
+    return _attribute_name(call.func) in {
+        "subprocess.Popen",
+        "subprocess.run",
+    }
+
+
 def _standalone_binary_selector_lines(tree: ast.AST) -> list[int]:
     lines: set[int] = set()
     for node in ast.walk(tree):
@@ -143,7 +150,7 @@ def _standalone_binary_selector_lines(tree: ast.AST) -> list[int]:
             value for child in ast.walk(function) if (value := _literal_string(child)) is not None
         }
         runs_subprocess = any(
-            isinstance(child, ast.Call) and _attribute_name(child.func) == "subprocess.run"
+            isinstance(child, ast.Call) and _is_subprocess_execution(child)
             for child in ast.walk(function)
         )
         if runs_subprocess and {"apm", "./apm", "./dist/apm"}.issubset(strings):
@@ -157,7 +164,7 @@ def _standalone_binary_selector_lines(tree: ast.AST) -> list[int]:
                 and _literal_string(call.args[0]) == "apm"
             ):
                 lines.add(call.lineno)
-            if _attribute_name(call.func) != "subprocess.run" or not call.args:
+            if not _is_subprocess_execution(call) or not call.args:
                 continue
             command = _list_literal_values(call.args[0])
             if command and command[0] == "apm":

--- a/scripts/check_test_contract_authorities.py
+++ b/scripts/check_test_contract_authorities.py
@@ -103,6 +103,19 @@ def _venv_binary_fallback_lines(tree: ast.AST) -> list[int]:
     return sorted(lines)
 
 
+def _path_binary_fallback_lines(tree: ast.AST) -> list[int]:
+    return sorted(
+        {
+            node.lineno
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and _attribute_name(node.func) == "shutil.which"
+            and bool(node.args)
+            and _literal_string(node.args[0]) == "apm"
+        }
+    )
+
+
 def _defined_functions(tree: ast.AST) -> set[str]:
     return {
         node.name for node in tree.body if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
@@ -143,12 +156,16 @@ def find_binary_selection_violations(root: Path) -> list[str]:
                 f"[x] direct APM_BINARY_PATH read outside {BINARY_OWNER}: "
                 f"{relative}:{line}; consume the apm_binary_path fixture"
             )
-        if env_read_lines:
-            for line in _venv_binary_fallback_lines(tree):
-                diagnostics.append(
-                    f"[x] direct .venv apm fallback outside {BINARY_OWNER}: "
-                    f"{relative}:{line}; consume the apm_binary_path fixture"
-                )
+        for line in _venv_binary_fallback_lines(tree):
+            diagnostics.append(
+                f"[x] direct .venv apm fallback outside {BINARY_OWNER}: "
+                f"{relative}:{line}; consume the apm_binary_path fixture"
+            )
+        for line in _path_binary_fallback_lines(tree):
+            diagnostics.append(
+                f"[x] direct shutil.which('apm') fallback outside {BINARY_OWNER}: "
+                f"{relative}:{line}; consume the apm_binary_path fixture"
+            )
         if path.parent == integration_root and "_resolve_apm_binary" in _defined_functions(tree):
             diagnostics.append(
                 f"[x] duplicate _resolve_apm_binary definition: {relative}; owner is {BINARY_OWNER}"

--- a/scripts/check_test_contract_authorities.py
+++ b/scripts/check_test_contract_authorities.py
@@ -124,6 +124,18 @@ def _list_literal_values(node: ast.AST) -> list[str | None]:
 
 def _standalone_binary_selector_lines(tree: ast.AST) -> list[int]:
     lines: set[int] = set()
+    for node in ast.walk(tree):
+        command = _list_literal_values(node)
+        if any(
+            command[index : index + 2]
+            in (
+                ["-m", "apm_cli"],
+                ["-m", "apm_cli.cli"],
+            )
+            for index in range(len(command))
+        ):
+            lines.add(node.lineno)
+
     for function in ast.walk(tree):
         if not isinstance(function, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue

--- a/scripts/check_test_contract_authorities.py
+++ b/scripts/check_test_contract_authorities.py
@@ -60,14 +60,27 @@ def _calls_named(node: ast.AST, names: set[str]) -> bool:
     return False
 
 
+def _reads_binary_path_environment(
+    function: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> bool:
+    if "APM_BINARY_PATH" not in _string_values(function):
+        return False
+    if _calls_named(function, {"os.environ.get", "os.getenv"}):
+        return True
+    return any(
+        isinstance(node, ast.Subscript)
+        and _attribute_name(node.value) == "os.environ"
+        and isinstance(node.slice, ast.Constant)
+        and node.slice.value == "APM_BINARY_PATH"
+        for node in ast.walk(function)
+    )
+
+
 def _binary_duplicate_reason(
     function: ast.FunctionDef | ast.AsyncFunctionDef,
 ) -> str | None:
     strings = _string_values(function)
-    reads_binary_env = "APM_BINARY_PATH" in strings and _calls_named(
-        function,
-        {"os.environ.get", "os.getenv"},
-    )
+    reads_binary_env = _reads_binary_path_environment(function)
     discovers_path_binary = _calls_named(function, {"shutil.which"}) and "apm" in strings
     discovers_venv_binary = ".venv" in strings and "apm" in strings
 

--- a/scripts/check_test_contract_authorities.py
+++ b/scripts/check_test_contract_authorities.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import shlex
 import sys
 from pathlib import Path
 
@@ -57,66 +58,150 @@ def _literal_string(node: ast.AST) -> str | None:
     return None
 
 
-def _direct_binary_env_read_lines(tree: ast.AST) -> list[int]:
-    os_aliases = {"os"}
-    environ_aliases: set[str] = set()
-    getenv_aliases: set[str] = set()
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            os_aliases.update(
-                alias.asname or alias.name for alias in node.names if alias.name == "os"
-            )
-        elif isinstance(node, ast.ImportFrom) and node.module == "os":
-            for alias in node.names:
-                local_name = alias.asname or alias.name
-                if alias.name == "environ":
-                    environ_aliases.add(local_name)
-                elif alias.name == "getenv":
-                    getenv_aliases.add(local_name)
+def _bound_names(node: ast.AST) -> set[str]:
+    if isinstance(node, ast.Name):
+        return {node.id}
+    if isinstance(node, (ast.List, ast.Tuple)):
+        return {name for element in node.elts for name in _bound_names(element)}
+    return set()
 
+
+def _resolve_binding(node: ast.AST, bindings: dict[str, str]) -> str | None:
+    if isinstance(node, ast.Name):
+        return bindings.get(node.id)
+    if isinstance(node, ast.Attribute):
+        base = _resolve_binding(node.value, bindings)
+        return f"{base}.{node.attr}" if base is not None else None
+    return None
+
+
+def _scope_binding_maps(
+    tree: ast.Module,
+) -> tuple[dict[int, dict[str, str]], dict[int, ast.AST]]:
+    bindings_by_scope: dict[int, dict[str, str]] = {}
+    scope_by_node: dict[int, ast.AST] = {}
+
+    def map_scope(scope: ast.AST, inherited: dict[str, str]) -> None:
+        body = (
+            scope.body
+            if isinstance(scope, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef))
+            else []
+        )
+        bindings = dict(inherited)
+        if isinstance(scope, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            local_names = {
+                argument.arg
+                for argument in (
+                    *scope.args.posonlyargs,
+                    *scope.args.args,
+                    *scope.args.kwonlyargs,
+                )
+            }
+            local_names.update(
+                name
+                for statement in body
+                if not isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+                for child in ast.walk(statement)
+                if isinstance(child, (ast.Assign, ast.AnnAssign, ast.NamedExpr))
+                for target in (child.targets if isinstance(child, ast.Assign) else [child.target])
+                for name in _bound_names(target)
+            )
+            for name in local_names:
+                bindings.pop(name, None)
+
+        for statement in body:
+            if isinstance(statement, ast.Import):
+                for alias in statement.names:
+                    if alias.name in {"os", "shutil", "sys"}:
+                        bindings[alias.asname or alias.name] = alias.name
+            elif isinstance(statement, ast.ImportFrom) and statement.module in {
+                "os",
+                "shutil",
+            }:
+                for alias in statement.names:
+                    bindings[alias.asname or alias.name] = f"{statement.module}.{alias.name}"
+
+        for _ in range(len(body) + 1):
+            changed = False
+            for statement in body:
+                if not isinstance(statement, (ast.Assign, ast.AnnAssign)):
+                    continue
+                value = statement.value
+                if value is None:
+                    continue
+                resolved = _resolve_binding(value, bindings)
+                targets = (
+                    statement.targets if isinstance(statement, ast.Assign) else [statement.target]
+                )
+                for target in targets:
+                    for name in _bound_names(target):
+                        if resolved is None:
+                            bindings.pop(name, None)
+                        elif bindings.get(name) != resolved:
+                            bindings[name] = resolved
+                            changed = True
+            if not changed:
+                break
+
+        bindings_by_scope[id(scope)] = bindings
+
+        def mark(node: ast.AST) -> None:
+            scope_by_node[id(node)] = scope
+            for child in ast.iter_child_nodes(node):
+                if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    map_scope(child, bindings)
+                elif isinstance(child, ast.ClassDef):
+                    for nested in child.body:
+                        if isinstance(nested, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                            map_scope(nested, bindings)
+                else:
+                    mark(child)
+
+        for statement in body:
+            if isinstance(statement, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                map_scope(statement, bindings)
+            elif isinstance(statement, ast.ClassDef):
+                for nested in statement.body:
+                    if isinstance(nested, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                        map_scope(nested, bindings)
+            else:
+                mark(statement)
+
+    map_scope(tree, {})
+    return bindings_by_scope, scope_by_node
+
+
+def _direct_binary_env_read_lines(tree: ast.AST) -> list[int]:
+    bindings_by_scope, scope_by_node = _scope_binding_maps(tree)
     lines: set[int] = set()
     for node in ast.walk(tree):
+        scope = scope_by_node.get(id(node), tree)
+        bindings = bindings_by_scope.get(id(scope), {})
         if isinstance(node, ast.Call) and node.args:
-            called = _attribute_name(node.func)
+            called = _resolve_binding(node.func, bindings)
             reads_variable = _literal_string(node.args[0]) == "APM_BINARY_PATH"
-            if reads_variable and (
-                called in getenv_aliases
-                or any(
-                    called in {f"{alias}.getenv", f"{alias}.environ.get"} for alias in os_aliases
-                )
-                or any(called == f"{alias}.get" for alias in environ_aliases)
-            ):
+            if reads_variable and called in {"os.environ.get", "os.getenv"}:
                 lines.add(node.lineno)
         elif isinstance(node, ast.Subscript) and _literal_string(node.slice) == "APM_BINARY_PATH":
-            target = _attribute_name(node.value)
-            if target in environ_aliases or any(
-                target == f"{alias}.environ" for alias in os_aliases
-            ):
+            if _resolve_binding(node.value, bindings) == "os.environ":
                 lines.add(node.lineno)
     return sorted(lines)
 
 
 def _direct_binary_path_lookup_lines(tree: ast.AST) -> list[int]:
-    shutil_aliases: set[str] = set()
-    which_aliases: set[str] = set()
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            shutil_aliases.update(
-                alias.asname or alias.name for alias in node.names if alias.name == "shutil"
-            )
-        elif isinstance(node, ast.ImportFrom) and node.module == "shutil":
-            which_aliases.update(
-                alias.asname or alias.name for alias in node.names if alias.name == "which"
-            )
-
+    bindings_by_scope, scope_by_node = _scope_binding_maps(tree)
     lines: set[int] = set()
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call) or not node.args:
             continue
-        called = _attribute_name(node.func)
+        scope = scope_by_node.get(id(node), tree)
+        called = _resolve_binding(
+            node.func,
+            bindings_by_scope.get(id(scope), {}),
+        )
         if _literal_string(node.args[0]) not in APM_EXECUTABLE_NAMES:
             continue
-        if called in which_aliases or any(called == f"{alias}.which" for alias in shutil_aliases):
+        if called == "shutil.which":
             lines.add(node.lineno)
     return sorted(lines)
 
@@ -177,6 +262,8 @@ def _venv_binary_fallback_lines(tree: ast.AST) -> list[int]:
         return called in {
             "Path",
             "PurePath",
+            "PurePosixPath",
+            "PureWindowsPath",
             "join",
             "joinpath",
         }
@@ -224,15 +311,59 @@ def _python_sibling_binary_lines(tree: ast.AST) -> list[int]:
         }
         if any(f"{alias}.executable" in names for alias in sys_aliases):
             lines.add(node.lineno)
+    known = _assignment_string_tokens(tree)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.BinOp):
+            continue
+        tokens = _expression_string_tokens(node, known)
+        names = {
+            _attribute_name(child) for child in ast.walk(node) if isinstance(child, ast.Attribute)
+        }
+        if tokens.intersection(APM_EXECUTABLE_NAMES) and any(
+            name is not None and name.endswith(".executable") for name in names
+        ):
+            lines.add(node.lineno)
     return sorted(lines)
 
 
 def _local_binary_facade_lines(tree: ast.AST) -> list[int]:
     lines: set[int] = set()
-    for node in tree.body:
+
+    def returns_binary_value(
+        function: ast.FunctionDef | ast.AsyncFunctionDef,
+    ) -> bool:
+        tainted = {"apm_binary_path"}
+        for _ in range(len(function.body) + 1):
+            changed = False
+            for child in ast.walk(function):
+                if not isinstance(child, (ast.Assign, ast.AnnAssign)):
+                    continue
+                value = child.value
+                if value is None or not any(
+                    isinstance(node, ast.Name) and node.id in tainted for node in ast.walk(value)
+                ):
+                    continue
+                targets = child.targets if isinstance(child, ast.Assign) else [child.target]
+                for target in targets:
+                    for name in _bound_names(target):
+                        if name not in tainted:
+                            tainted.add(name)
+                            changed = True
+            if not changed:
+                break
+        return any(
+            isinstance(child, ast.Return)
+            and child.value is not None
+            and any(
+                isinstance(node, ast.Name) and node.id in tainted for node in ast.walk(child.value)
+            )
+            for child in ast.walk(function)
+        )
+
+    for node in ast.walk(tree):
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
-        if node.name in LOCAL_BINARY_FACADES:
+        if node.name in {*LOCAL_BINARY_FACADES, "_resolve_apm_binary", "apm_binary_path"}:
             lines.add(node.lineno)
             continue
         fixture = any(
@@ -251,25 +382,7 @@ def _local_binary_facade_lines(tree: ast.AST) -> list[int]:
                 *node.args.kwonlyargs,
             )
         }
-        executable_body = [
-            statement
-            for statement in node.body
-            if not (
-                isinstance(statement, ast.Expr)
-                and isinstance(statement.value, ast.Constant)
-                and isinstance(statement.value.value, str)
-            )
-        ]
-        forwards_fixture = (
-            len(executable_body) == 1
-            and isinstance(executable_body[0], ast.Return)
-            and executable_body[0].value is not None
-            and any(
-                isinstance(child, ast.Name) and child.id == "apm_binary_path"
-                for child in ast.walk(executable_body[0].value)
-            )
-        )
-        if fixture and "apm_binary_path" in parameter_names and forwards_fixture:
+        if fixture and "apm_binary_path" in parameter_names and returns_binary_value(node):
             lines.add(node.lineno)
     return sorted(lines)
 
@@ -316,8 +429,38 @@ def _list_literal_values(node: ast.AST) -> list[str | None]:
     return [_literal_string(element) for element in node.elts]
 
 
+def _assignment_command_values(
+    tree: ast.AST,
+) -> tuple[dict[str, list[str | None]], dict[str, str]]:
+    lists: dict[str, list[str | None]] = {}
+    strings: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)) or node.value is None:
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        names = [name for target in targets for name in _bound_names(target)]
+        list_value = _list_literal_values(node.value)
+        string_value = _literal_string(node.value)
+        for name in names:
+            if list_value:
+                lists[name] = list_value
+            elif string_value is not None:
+                strings[name] = string_value
+    return lists, strings
+
+
+def _shell_enabled(call: ast.Call) -> bool:
+    return any(
+        keyword.arg == "shell"
+        and isinstance(keyword.value, ast.Constant)
+        and keyword.value.value is True
+        for keyword in call.keywords
+    )
+
+
 def _direct_apm_subprocess_lines(tree: ast.AST) -> list[int]:
     module_aliases, call_aliases = _subprocess_aliases(tree)
+    assigned_lists, assigned_strings = _assignment_command_values(tree)
     lines: set[int] = set()
     for node in ast.walk(tree):
         if isinstance(node, (ast.List, ast.Tuple)):
@@ -357,8 +500,21 @@ def _direct_apm_subprocess_lines(tree: ast.AST) -> list[int]:
             continue
         command = node.args[0]
         values = _list_literal_values(command)
+        if not values and isinstance(command, ast.Name):
+            values = assigned_lists.get(command.id, [])
         if values and values[0] in APM_EXECUTABLE_NAMES:
             lines.add(node.lineno)
+        if _shell_enabled(node):
+            shell_command = _literal_string(command)
+            if shell_command is None and isinstance(command, ast.Name):
+                shell_command = assigned_strings.get(command.id)
+            if shell_command is not None:
+                try:
+                    shell_tokens = shlex.split(shell_command, posix=True)
+                except ValueError:
+                    shell_tokens = []
+                if shell_tokens and shell_tokens[0] in APM_EXECUTABLE_NAMES:
+                    lines.add(node.lineno)
         noncanonical_names = {
             child.id
             for child in ast.walk(command)

--- a/scripts/check_test_contract_authorities.py
+++ b/scripts/check_test_contract_authorities.py
@@ -116,6 +116,48 @@ def _path_binary_fallback_lines(tree: ast.AST) -> list[int]:
     )
 
 
+def _list_literal_values(node: ast.AST) -> list[str | None]:
+    if not isinstance(node, (ast.List, ast.Tuple)):
+        return []
+    return [_literal_string(element) for element in node.elts]
+
+
+def _standalone_binary_selector_lines(tree: ast.AST) -> list[int]:
+    lines: set[int] = set()
+    for function in ast.walk(tree):
+        if not isinstance(function, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        strings = {
+            value for child in ast.walk(function) if (value := _literal_string(child)) is not None
+        }
+        runs_subprocess = any(
+            isinstance(child, ast.Call) and _attribute_name(child.func) == "subprocess.run"
+            for child in ast.walk(function)
+        )
+        if runs_subprocess and {"apm", "./apm", "./dist/apm"}.issubset(strings):
+            lines.add(function.lineno)
+
+        for call in (child for child in ast.walk(function) if isinstance(child, ast.Call)):
+            if (
+                isinstance(call.func, ast.Attribute)
+                and call.func.attr == "with_name"
+                and bool(call.args)
+                and _literal_string(call.args[0]) == "apm"
+            ):
+                lines.add(call.lineno)
+            if _attribute_name(call.func) != "subprocess.run" or not call.args:
+                continue
+            command = _list_literal_values(call.args[0])
+            if command and command[0] == "apm":
+                lines.add(call.lineno)
+            compact = [value for value in command if value is not None]
+            if any(
+                compact[index : index + 3] == ["uv", "run", "apm"] for index in range(len(compact))
+            ):
+                lines.add(call.lineno)
+    return sorted(lines)
+
+
 def _defined_functions(tree: ast.AST) -> set[str]:
     return {
         node.name for node in tree.body if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
@@ -164,6 +206,11 @@ def find_binary_selection_violations(root: Path) -> list[str]:
         for line in _path_binary_fallback_lines(tree):
             diagnostics.append(
                 f"[x] direct shutil.which('apm') fallback outside {BINARY_OWNER}: "
+                f"{relative}:{line}; consume the apm_binary_path fixture"
+            )
+        for line in _standalone_binary_selector_lines(tree):
+            diagnostics.append(
+                f"[x] standalone APM subprocess selector outside {BINARY_OWNER}: "
                 f"{relative}:{line}; consume the apm_binary_path fixture"
             )
         if path.parent == integration_root and "_resolve_apm_binary" in _defined_functions(tree):

--- a/scripts/check_test_contract_authorities.py
+++ b/scripts/check_test_contract_authorities.py
@@ -90,6 +90,19 @@ def _direct_binary_env_read_lines(tree: ast.AST) -> list[int]:
     return sorted(lines)
 
 
+def _venv_binary_fallback_lines(tree: ast.AST) -> list[int]:
+    lines: set[int] = set()
+    for function in ast.walk(tree):
+        if not isinstance(function, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        strings = {
+            value for child in ast.walk(function) if (value := _literal_string(child)) is not None
+        }
+        if ".venv" in strings and "apm" in strings:
+            lines.add(function.lineno)
+    return sorted(lines)
+
+
 def _defined_functions(tree: ast.AST) -> set[str]:
     return {
         node.name for node in tree.body if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
@@ -124,11 +137,18 @@ def find_binary_selection_violations(root: Path) -> list[str]:
         if tree is None:
             continue
         relative = path.relative_to(root).as_posix()
-        for line in _direct_binary_env_read_lines(tree):
+        env_read_lines = _direct_binary_env_read_lines(tree)
+        for line in env_read_lines:
             diagnostics.append(
                 f"[x] direct APM_BINARY_PATH read outside {BINARY_OWNER}: "
                 f"{relative}:{line}; consume the apm_binary_path fixture"
             )
+        if env_read_lines:
+            for line in _venv_binary_fallback_lines(tree):
+                diagnostics.append(
+                    f"[x] direct .venv apm fallback outside {BINARY_OWNER}: "
+                    f"{relative}:{line}; consume the apm_binary_path fixture"
+                )
         if path.parent == integration_root and "_resolve_apm_binary" in _defined_functions(tree):
             diagnostics.append(
                 f"[x] duplicate _resolve_apm_binary definition: {relative}; owner is {BINARY_OWNER}"

--- a/scripts/check_test_contract_authorities.py
+++ b/scripts/check_test_contract_authorities.py
@@ -344,7 +344,12 @@ def _direct_apm_subprocess_lines(tree: ast.AST) -> list[int]:
                     for attribute in attributes
                 )
             )
-            if runs_python_module or runs_uv_apm:
+            runs_bare_uv_apm = len(values) >= 3 and values[:3] == [
+                "uv",
+                "run",
+                "apm",
+            ]
+            if runs_python_module or runs_uv_apm or runs_bare_uv_apm:
                 lines.add(node.lineno)
         if not isinstance(node, ast.Call) or not node.args:
             continue
@@ -369,49 +374,7 @@ def _direct_apm_subprocess_lines(tree: ast.AST) -> list[int]:
         }
         if noncanonical_names:
             lines.add(node.lineno)
-    return sorted(lines)
-
-
-def _path_binary_fallback_lines(tree: ast.AST) -> list[int]:
-    return sorted(
-        {
-            node.lineno
-            for node in ast.walk(tree)
-            if isinstance(node, ast.Call)
-            and _attribute_name(node.func) == "shutil.which"
-            and bool(node.args)
-            and _literal_string(node.args[0]) == "apm"
-        }
-    )
-
-
-def _list_literal_values(node: ast.AST) -> list[str | None]:
-    if not isinstance(node, (ast.List, ast.Tuple)):
-        return []
-    return [_literal_string(element) for element in node.elts]
-
-
-def _is_subprocess_execution(call: ast.Call) -> bool:
-    return _attribute_name(call.func) in {
-        "subprocess.Popen",
-        "subprocess.run",
-    }
-
-
-def _standalone_binary_selector_lines(tree: ast.AST) -> list[int]:
-    lines: set[int] = set()
-    for node in ast.walk(tree):
-        command = _list_literal_values(node)
-        if any(
-            command[index : index + 2]
-            in (
-                ["-m", "apm_cli"],
-                ["-m", "apm_cli.cli"],
-            )
-            for index in range(len(command))
-        ):
-            lines.add(node.lineno)
-
+    module_aliases, call_aliases = _subprocess_aliases(tree)
     for function in ast.walk(tree):
         if not isinstance(function, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
@@ -419,30 +382,11 @@ def _standalone_binary_selector_lines(tree: ast.AST) -> list[int]:
             value for child in ast.walk(function) if (value := _literal_string(child)) is not None
         }
         runs_subprocess = any(
-            isinstance(child, ast.Call) and _is_subprocess_execution(child)
+            isinstance(child, ast.Call) and _is_subprocess_call(child, module_aliases, call_aliases)
             for child in ast.walk(function)
         )
         if runs_subprocess and {"apm", "./apm", "./dist/apm"}.issubset(strings):
             lines.add(function.lineno)
-
-        for call in (child for child in ast.walk(function) if isinstance(child, ast.Call)):
-            if (
-                isinstance(call.func, ast.Attribute)
-                and call.func.attr == "with_name"
-                and bool(call.args)
-                and _literal_string(call.args[0]) == "apm"
-            ):
-                lines.add(call.lineno)
-            if not _is_subprocess_execution(call) or not call.args:
-                continue
-            command = _list_literal_values(call.args[0])
-            if command and command[0] == "apm":
-                lines.add(call.lineno)
-            compact = [value for value in command if value is not None]
-            if any(
-                compact[index : index + 3] == ["uv", "run", "apm"] for index in range(len(compact))
-            ):
-                lines.add(call.lineno)
     return sorted(lines)
 
 

--- a/scripts/check_test_contract_authorities.py
+++ b/scripts/check_test_contract_authorities.py
@@ -55,7 +55,7 @@ def _direct_binary_env_read_lines(tree: ast.AST) -> list[int]:
     os_aliases = {"os"}
     environ_aliases: set[str] = set()
     getenv_aliases: set[str] = set()
-    for node in tree.body:
+    for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             os_aliases.update(
                 alias.asname or alias.name for alias in node.names if alias.name == "os"
@@ -186,6 +186,21 @@ def _registry_projection_lines(tree: ast.AST) -> list[int]:
         )
         if projects_commands and filters_hidden:
             lines.add(node.lineno)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.For):
+            continue
+        projects_commands = isinstance(node.iter, ast.Call) and _is_commands_items(node.iter)
+        filters_hidden = any(
+            isinstance(child, ast.Attribute) and child.attr == "hidden" for child in ast.walk(node)
+        )
+        collects_names = any(
+            isinstance(child, ast.Call)
+            and isinstance(child.func, ast.Attribute)
+            and child.func.attr in {"add", "append", "update"}
+            for child in ast.walk(node)
+        )
+        if projects_commands and filters_hidden and collects_names:
+            lines.add(node.lineno)
     return sorted(lines)
 
 
@@ -193,17 +208,39 @@ def _path_string_segments(node: ast.AST) -> set[str]:
     return {value for child in ast.walk(node) if (value := _literal_string(child)) is not None}
 
 
+def _path_segments(node: ast.AST, known: dict[str, set[str]]) -> set[str]:
+    segments = _path_string_segments(node)
+    segments.update(
+        segment
+        for child in ast.walk(node)
+        if isinstance(child, ast.Name)
+        for segment in known.get(child.id, set())
+    )
+    return segments
+
+
 def _rendered_cli_path_names(tree: ast.AST) -> set[str]:
-    names: set[str] = set()
+    assignments: list[tuple[list[str], ast.AST]] = []
     for node in ast.walk(tree):
-        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
-            continue
-        value = node.value
-        if value is None or not {"reference", "cli"}.issubset(_path_string_segments(value)):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)) or node.value is None:
             continue
         targets = node.targets if isinstance(node, ast.Assign) else [node.target]
-        names.update(target.id for target in targets if isinstance(target, ast.Name))
-    return names
+        names = [target.id for target in targets if isinstance(target, ast.Name)]
+        if names:
+            assignments.append((names, node.value))
+
+    known: dict[str, set[str]] = {}
+    for _ in range(len(assignments) + 1):
+        changed = False
+        for names, value in assignments:
+            segments = _path_segments(value, known)
+            for name in names:
+                if not segments.issubset(known.get(name, set())):
+                    known.setdefault(name, set()).update(segments)
+                    changed = True
+        if not changed:
+            break
+    return {name for name, segments in known.items() if {"reference", "cli"}.issubset(segments)}
 
 
 def _rendered_inventory_lines(tree: ast.AST) -> list[int]:

--- a/scripts/check_test_contract_authorities.py
+++ b/scripts/check_test_contract_authorities.py
@@ -617,6 +617,48 @@ def _direct_apm_subprocess_lines(tree: ast.AST) -> list[int]:
     return sorted(lines)
 
 
+def _implicit_lifecycle_runner_lines(tree: ast.AST) -> list[int]:
+    """Find lifecycle runners that would choose an APM executable locally."""
+    runner_aliases: set[str] = set()
+    module_aliases: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == ("tests.utils.apm_lifecycle_runner"):
+            runner_aliases.update(
+                alias.asname or alias.name
+                for alias in node.names
+                if alias.name == "ApmLifecycleRunner"
+            )
+        elif isinstance(node, ast.Import):
+            module_aliases.update(
+                alias.asname or alias.name
+                for alias in node.names
+                if alias.name == "tests.utils.apm_lifecycle_runner"
+            )
+
+    lines: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        called = _attribute_name(node.func)
+        if called not in runner_aliases and not any(
+            called == f"{alias}.ApmLifecycleRunner" for alias in module_aliases
+        ):
+            continue
+        command_keyword = next(
+            (keyword.value for keyword in node.keywords if keyword.arg == "command"),
+            None,
+        )
+        implicit = not node.args and command_keyword is None
+        explicit_none = (
+            bool(node.args)
+            and isinstance(node.args[0], ast.Constant)
+            and node.args[0].value is None
+        ) or (isinstance(command_keyword, ast.Constant) and command_keyword.value is None)
+        if implicit or explicit_none:
+            lines.add(node.lineno)
+    return sorted(lines)
+
+
 def _defined_functions(tree: ast.AST) -> set[str]:
     return {
         node.name for node in tree.body if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
@@ -681,6 +723,11 @@ def find_binary_selection_violations(root: Path) -> list[str]:
             diagnostics.append(
                 f"[x] direct apm subprocess selection outside {BINARY_OWNER}: "
                 f"{relative}:{line}; inject apm_binary_path directly"
+            )
+        for line in _implicit_lifecycle_runner_lines(tree):
+            diagnostics.append(
+                f"[x] implicit lifecycle runner APM selection outside {BINARY_OWNER}: "
+                f"{relative}:{line}; pass apm_binary_path as the runner command"
             )
         if path.parent == integration_root and "_resolve_apm_binary" in _defined_functions(tree):
             diagnostics.append(

--- a/scripts/check_test_contract_authorities.py
+++ b/scripts/check_test_contract_authorities.py
@@ -112,11 +112,12 @@ def _scope_binding_maps(
         for statement in body:
             if isinstance(statement, ast.Import):
                 for alias in statement.names:
-                    if alias.name in {"os", "shutil", "sys"}:
+                    if alias.name in {"os", "shutil", "subprocess", "sys"}:
                         bindings[alias.asname or alias.name] = alias.name
             elif isinstance(statement, ast.ImportFrom) and statement.module in {
                 "os",
                 "shutil",
+                "subprocess",
             }:
                 for alias in statement.names:
                     bindings[alias.asname or alias.name] = f"{statement.module}.{alias.name}"
@@ -387,40 +388,17 @@ def _local_binary_facade_lines(tree: ast.AST) -> list[int]:
     return sorted(lines)
 
 
-def _subprocess_aliases(tree: ast.AST) -> tuple[set[str], set[str]]:
-    module_aliases: set[str] = set()
-    call_aliases: set[str] = set()
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Import):
-            module_aliases.update(
-                alias.asname or alias.name for alias in node.names if alias.name == "subprocess"
-            )
-        elif isinstance(node, ast.ImportFrom) and node.module == "subprocess":
-            call_aliases.update(
-                alias.asname or alias.name
-                for alias in node.names
-                if alias.name in {"Popen", "call", "check_call", "check_output", "run"}
-            )
-    return module_aliases, call_aliases
-
-
 def _is_subprocess_call(
     node: ast.Call,
-    module_aliases: set[str],
-    call_aliases: set[str],
+    bindings: dict[str, str],
 ) -> bool:
-    called = _attribute_name(node.func)
-    return called in call_aliases or any(
-        called
-        in {
-            f"{alias}.Popen",
-            f"{alias}.call",
-            f"{alias}.check_call",
-            f"{alias}.check_output",
-            f"{alias}.run",
-        }
-        for alias in module_aliases
-    )
+    return _resolve_binding(node.func, bindings) in {
+        "subprocess.Popen",
+        "subprocess.call",
+        "subprocess.check_call",
+        "subprocess.check_output",
+        "subprocess.run",
+    }
 
 
 def _list_literal_values(node: ast.AST) -> list[str | None]:
@@ -459,7 +437,7 @@ def _shell_enabled(call: ast.Call) -> bool:
 
 
 def _direct_apm_subprocess_lines(tree: ast.AST) -> list[int]:
-    module_aliases, call_aliases = _subprocess_aliases(tree)
+    bindings_by_scope, scope_by_node = _scope_binding_maps(tree)
     assigned_lists, assigned_strings = _assignment_command_values(tree)
     lines: set[int] = set()
     for node in ast.walk(tree):
@@ -496,7 +474,11 @@ def _direct_apm_subprocess_lines(tree: ast.AST) -> list[int]:
                 lines.add(node.lineno)
         if not isinstance(node, ast.Call) or not node.args:
             continue
-        if not _is_subprocess_call(node, module_aliases, call_aliases):
+        scope = scope_by_node.get(id(node), tree)
+        if not _is_subprocess_call(
+            node,
+            bindings_by_scope.get(id(scope), {}),
+        ):
             continue
         command = node.args[0]
         values = _list_literal_values(command)
@@ -530,7 +512,6 @@ def _direct_apm_subprocess_lines(tree: ast.AST) -> list[int]:
         }
         if noncanonical_names:
             lines.add(node.lineno)
-    module_aliases, call_aliases = _subprocess_aliases(tree)
     for function in ast.walk(tree):
         if not isinstance(function, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
@@ -538,7 +519,14 @@ def _direct_apm_subprocess_lines(tree: ast.AST) -> list[int]:
             value for child in ast.walk(function) if (value := _literal_string(child)) is not None
         }
         runs_subprocess = any(
-            isinstance(child, ast.Call) and _is_subprocess_call(child, module_aliases, call_aliases)
+            isinstance(child, ast.Call)
+            and _is_subprocess_call(
+                child,
+                bindings_by_scope.get(
+                    id(scope_by_node.get(id(child), tree)),
+                    {},
+                ),
+            )
             for child in ast.walk(function)
         )
         if runs_subprocess and {"apm", "./apm", "./dist/apm"}.issubset(strings):

--- a/scripts/check_test_contract_authorities.py
+++ b/scripts/check_test_contract_authorities.py
@@ -930,9 +930,14 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     diagnostics = check(args.root.resolve())
     for diagnostic in diagnostics:
-        print(diagnostic)
+        print(diagnostic, file=sys.stderr)
     if diagnostics:
-        print(f"[x] {len(diagnostics)} test contract authority violation(s) found")
+        count = len(diagnostics)
+        label = "violation" if count == 1 else "violations"
+        print(
+            f"[x] {count} test contract authority {label} found",
+            file=sys.stderr,
+        )
         return 1
     print("[+] test contract authority check clean")
     return 0

--- a/scripts/check_test_contract_authorities.py
+++ b/scripts/check_test_contract_authorities.py
@@ -20,6 +20,12 @@ PARITY_OWNER_FUNCTIONS = {
     *PARITY_INTERNALS,
     PARITY_FACADE,
 }
+APM_EXECUTABLE_NAMES = {"apm", "apm.cmd", "apm.exe"}
+LOCAL_BINARY_FACADES = {
+    "_resolve_apm_executable",
+    "apm_binary",
+    "apm_command",
+}
 
 
 def _python_files(root: Path, locations: tuple[str, ...]) -> list[Path]:
@@ -90,16 +96,279 @@ def _direct_binary_env_read_lines(tree: ast.AST) -> list[int]:
     return sorted(lines)
 
 
-def _venv_binary_fallback_lines(tree: ast.AST) -> list[int]:
+def _direct_binary_path_lookup_lines(tree: ast.AST) -> list[int]:
+    shutil_aliases: set[str] = set()
+    which_aliases: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            shutil_aliases.update(
+                alias.asname or alias.name for alias in node.names if alias.name == "shutil"
+            )
+        elif isinstance(node, ast.ImportFrom) and node.module == "shutil":
+            which_aliases.update(
+                alias.asname or alias.name for alias in node.names if alias.name == "which"
+            )
+
     lines: set[int] = set()
-    for function in ast.walk(tree):
-        if not isinstance(function, (ast.FunctionDef, ast.AsyncFunctionDef)):
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not node.args:
             continue
-        strings = {
-            value for child in ast.walk(function) if (value := _literal_string(child)) is not None
+        called = _attribute_name(node.func)
+        if _literal_string(node.args[0]) not in APM_EXECUTABLE_NAMES:
+            continue
+        if called in which_aliases or any(called == f"{alias}.which" for alias in shutil_aliases):
+            lines.add(node.lineno)
+    return sorted(lines)
+
+
+def _assignment_string_tokens(tree: ast.AST) -> dict[str, set[str]]:
+    assignments: list[tuple[list[str], ast.AST]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)) or node.value is None:
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        names = [target.id for target in targets if isinstance(target, ast.Name)]
+        if names:
+            assignments.append((names, node.value))
+
+    known: dict[str, set[str]] = {}
+    for _ in range(len(assignments) + 1):
+        changed = False
+        for names, value in assignments:
+            tokens = _expression_string_tokens(value, known)
+            for name in names:
+                if not tokens.issubset(known.get(name, set())):
+                    known.setdefault(name, set()).update(tokens)
+                    changed = True
+        if not changed:
+            break
+    return known
+
+
+def _expression_string_tokens(
+    node: ast.AST,
+    known: dict[str, set[str]],
+) -> set[str]:
+    tokens: set[str] = set()
+    for child in ast.walk(node):
+        value = _literal_string(child)
+        if value is not None:
+            tokens.update(part.casefold() for part in value.replace("\\", "/").split("/") if part)
+        elif isinstance(child, ast.Name):
+            tokens.update(known.get(child.id, set()))
+    return tokens
+
+
+def _venv_binary_fallback_lines(tree: ast.AST) -> list[int]:
+    known = _assignment_string_tokens(tree)
+    parents = {child: node for node in ast.walk(tree) for child in ast.iter_child_nodes(node)}
+
+    def is_path_construction(node: ast.AST) -> bool:
+        if isinstance(node, ast.BinOp):
+            return isinstance(node.op, ast.Div)
+        if not isinstance(node, ast.Call):
+            return False
+        if isinstance(node.func, ast.Attribute):
+            called = node.func.attr
+        elif isinstance(node.func, ast.Name):
+            called = node.func.id
+        else:
+            return False
+        return called in {
+            "Path",
+            "PurePath",
+            "join",
+            "joinpath",
         }
-        if ".venv" in strings and "apm" in strings:
-            lines.add(function.lineno)
+
+    lines: set[int] = set()
+    for node in ast.walk(tree):
+        if not is_path_construction(node):
+            continue
+        if any(is_path_construction(ancestor) for ancestor in _ancestors(node, parents)):
+            continue
+        tokens = _expression_string_tokens(node, known)
+        if ".venv" in tokens and tokens.intersection(APM_EXECUTABLE_NAMES):
+            lines.add(node.lineno)
+    return sorted(lines)
+
+
+def _ancestors(node: ast.AST, parents: dict[ast.AST, ast.AST]) -> list[ast.AST]:
+    ancestors: list[ast.AST] = []
+    while node in parents:
+        node = parents[node]
+        ancestors.append(node)
+    return ancestors
+
+
+def _python_sibling_binary_lines(tree: ast.AST) -> list[int]:
+    sys_aliases: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            sys_aliases.update(
+                alias.asname or alias.name for alias in node.names if alias.name == "sys"
+            )
+
+    lines: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        if not isinstance(node.func, ast.Attribute) or node.func.attr != "with_name":
+            continue
+        if _literal_string(node.args[0]) not in APM_EXECUTABLE_NAMES:
+            continue
+        names = {
+            _attribute_name(child)
+            for child in ast.walk(node.func.value)
+            if isinstance(child, ast.Attribute)
+        }
+        if any(f"{alias}.executable" in names for alias in sys_aliases):
+            lines.add(node.lineno)
+    return sorted(lines)
+
+
+def _local_binary_facade_lines(tree: ast.AST) -> list[int]:
+    lines: set[int] = set()
+    for node in tree.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name in LOCAL_BINARY_FACADES:
+            lines.add(node.lineno)
+            continue
+        fixture = any(
+            (_attribute_name(decorator) or "").endswith(".fixture")
+            or (
+                isinstance(decorator, ast.Call)
+                and (_attribute_name(decorator.func) or "").endswith(".fixture")
+            )
+            for decorator in node.decorator_list
+        )
+        parameter_names = {
+            argument.arg
+            for argument in (
+                *node.args.posonlyargs,
+                *node.args.args,
+                *node.args.kwonlyargs,
+            )
+        }
+        executable_body = [
+            statement
+            for statement in node.body
+            if not (
+                isinstance(statement, ast.Expr)
+                and isinstance(statement.value, ast.Constant)
+                and isinstance(statement.value.value, str)
+            )
+        ]
+        forwards_fixture = (
+            len(executable_body) == 1
+            and isinstance(executable_body[0], ast.Return)
+            and executable_body[0].value is not None
+            and any(
+                isinstance(child, ast.Name) and child.id == "apm_binary_path"
+                for child in ast.walk(executable_body[0].value)
+            )
+        )
+        if fixture and "apm_binary_path" in parameter_names and forwards_fixture:
+            lines.add(node.lineno)
+    return sorted(lines)
+
+
+def _subprocess_aliases(tree: ast.AST) -> tuple[set[str], set[str]]:
+    module_aliases: set[str] = set()
+    call_aliases: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            module_aliases.update(
+                alias.asname or alias.name for alias in node.names if alias.name == "subprocess"
+            )
+        elif isinstance(node, ast.ImportFrom) and node.module == "subprocess":
+            call_aliases.update(
+                alias.asname or alias.name
+                for alias in node.names
+                if alias.name in {"Popen", "call", "check_call", "check_output", "run"}
+            )
+    return module_aliases, call_aliases
+
+
+def _is_subprocess_call(
+    node: ast.Call,
+    module_aliases: set[str],
+    call_aliases: set[str],
+) -> bool:
+    called = _attribute_name(node.func)
+    return called in call_aliases or any(
+        called
+        in {
+            f"{alias}.Popen",
+            f"{alias}.call",
+            f"{alias}.check_call",
+            f"{alias}.check_output",
+            f"{alias}.run",
+        }
+        for alias in module_aliases
+    )
+
+
+def _list_literal_values(node: ast.AST) -> list[str | None]:
+    if not isinstance(node, (ast.List, ast.Tuple)):
+        return []
+    return [_literal_string(element) for element in node.elts]
+
+
+def _direct_apm_subprocess_lines(tree: ast.AST) -> list[int]:
+    module_aliases, call_aliases = _subprocess_aliases(tree)
+    lines: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.List, ast.Tuple)):
+            values = _list_literal_values(node)
+            attributes = {
+                _attribute_name(child)
+                for child in ast.walk(node)
+                if isinstance(child, ast.Attribute)
+            }
+            runs_python_module = (
+                len(values) >= 3
+                and values[1] == "-m"
+                and values[2] in {"apm_cli", "apm_cli.cli"}
+                and any(
+                    attribute is not None and attribute.endswith(".executable")
+                    for attribute in attributes
+                )
+            )
+            runs_uv_apm = (
+                len(values) >= 5
+                and values[1:5] == ["-m", "uv", "run", "apm"]
+                and any(
+                    attribute is not None and attribute.endswith(".executable")
+                    for attribute in attributes
+                )
+            )
+            if runs_python_module or runs_uv_apm:
+                lines.add(node.lineno)
+        if not isinstance(node, ast.Call) or not node.args:
+            continue
+        if not _is_subprocess_call(node, module_aliases, call_aliases):
+            continue
+        command = node.args[0]
+        values = _list_literal_values(command)
+        if values and values[0] in APM_EXECUTABLE_NAMES:
+            lines.add(node.lineno)
+        noncanonical_names = {
+            child.id
+            for child in ast.walk(command)
+            if isinstance(child, ast.Name)
+            and child.id
+            in {
+                "apm_bin",
+                "apm_binary",
+                "apm_command",
+                "apm_executable",
+                "apm_path",
+            }
+        }
+        if noncanonical_names:
+            lines.add(node.lineno)
     return sorted(lines)
 
 
@@ -217,20 +486,30 @@ def find_binary_selection_violations(root: Path) -> list[str]:
                 f"[x] direct APM_BINARY_PATH read outside {BINARY_OWNER}: "
                 f"{relative}:{line}; consume the apm_binary_path fixture"
             )
+        for line in _direct_binary_path_lookup_lines(tree):
+            diagnostics.append(
+                f"[x] direct PATH lookup for apm outside {BINARY_OWNER}: "
+                f"{relative}:{line}; consume the apm_binary_path fixture"
+            )
         for line in _venv_binary_fallback_lines(tree):
             diagnostics.append(
                 f"[x] direct .venv apm fallback outside {BINARY_OWNER}: "
                 f"{relative}:{line}; consume the apm_binary_path fixture"
             )
-        for line in _path_binary_fallback_lines(tree):
+        for line in _python_sibling_binary_lines(tree):
             diagnostics.append(
-                f"[x] direct shutil.which('apm') fallback outside {BINARY_OWNER}: "
+                f"[x] interpreter-relative apm selection outside {BINARY_OWNER}: "
                 f"{relative}:{line}; consume the apm_binary_path fixture"
             )
-        for line in _standalone_binary_selector_lines(tree):
+        for line in _local_binary_facade_lines(tree):
             diagnostics.append(
-                f"[x] standalone APM subprocess selector outside {BINARY_OWNER}: "
-                f"{relative}:{line}; consume the apm_binary_path fixture"
+                f"[x] local apm binary fixture or facade outside {BINARY_OWNER}: "
+                f"{relative}:{line}; inject apm_binary_path directly"
+            )
+        for line in _direct_apm_subprocess_lines(tree):
+            diagnostics.append(
+                f"[x] direct apm subprocess selection outside {BINARY_OWNER}: "
+                f"{relative}:{line}; inject apm_binary_path directly"
             )
         if path.parent == integration_root and "_resolve_apm_binary" in _defined_functions(tree):
             diagnostics.append(

--- a/scripts/check_test_contract_authorities.py
+++ b/scripts/check_test_contract_authorities.py
@@ -11,6 +11,15 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 BINARY_OWNER = Path("tests/integration/conftest.py")
 PARITY_OWNER = Path("scripts/check_cli_docs.py")
+PARITY_FACADE = "registry_docs_mismatches"
+PARITY_INTERNALS = {
+    "public_top_level_commands",
+    "rendered_cli_reference_pages",
+}
+PARITY_OWNER_FUNCTIONS = {
+    *PARITY_INTERNALS,
+    PARITY_FACADE,
+}
 
 
 def _python_files(root: Path, locations: tuple[str, ...]) -> list[Path]:
@@ -22,12 +31,6 @@ def _python_files(root: Path, locations: tuple[str, ...]) -> list[Path]:
         elif base.is_dir():
             files.extend(base.rglob("*.py"))
     return sorted(path for path in files if path.is_file())
-
-
-def _function_nodes(tree: ast.AST) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
-    return [
-        node for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-    ]
 
 
 def _attribute_name(node: ast.AST) -> str | None:
@@ -42,145 +45,210 @@ def _attribute_name(node: ast.AST) -> str | None:
     return None
 
 
-def _string_values(node: ast.AST) -> set[str]:
-    return {
-        child.value
-        for child in ast.walk(node)
-        if isinstance(child, ast.Constant) and isinstance(child.value, str)
-    }
-
-
-def _calls_named(node: ast.AST, names: set[str]) -> bool:
-    for child in ast.walk(node):
-        if not isinstance(child, ast.Call):
-            continue
-        called = _attribute_name(child.func)
-        if called is not None and called in names:
-            return True
-    return False
-
-
-def _reads_binary_path_environment(
-    function: ast.FunctionDef | ast.AsyncFunctionDef,
-) -> bool:
-    if "APM_BINARY_PATH" not in _string_values(function):
-        return False
-    if _calls_named(function, {"os.environ.get", "os.getenv"}):
-        return True
-    return any(
-        isinstance(node, ast.Subscript)
-        and _attribute_name(node.value) == "os.environ"
-        and isinstance(node.slice, ast.Constant)
-        and node.slice.value == "APM_BINARY_PATH"
-        for node in ast.walk(function)
-    )
-
-
-def _binary_duplicate_reason(
-    function: ast.FunctionDef | ast.AsyncFunctionDef,
-) -> str | None:
-    strings = _string_values(function)
-    reads_binary_env = _reads_binary_path_environment(function)
-    discovers_path_binary = _calls_named(function, {"shutil.which"}) and "apm" in strings
-    discovers_venv_binary = ".venv" in strings and "apm" in strings
-
-    if function.name == "_resolve_apm_binary":
-        return "defines a second _resolve_apm_binary helper"
-    if reads_binary_env and (discovers_path_binary or discovers_venv_binary):
-        return "combines APM_BINARY_PATH reading with local/PATH fallback discovery"
+def _literal_string(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
     return None
 
 
+def _is_environment_get(call: ast.Call, variable: str) -> bool:
+    called = _attribute_name(call.func)
+    return (
+        called in {"os.environ.get", "os.getenv"}
+        and bool(call.args)
+        and _literal_string(call.args[0]) == variable
+    )
+
+
+def _is_environment_subscript(node: ast.Subscript, variable: str) -> bool:
+    return _attribute_name(node.value) == "os.environ" and _literal_string(node.slice) == variable
+
+
+def _direct_binary_env_read_lines(tree: ast.AST) -> list[int]:
+    lines: set[int] = set()
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Call) and _is_environment_get(node, "APM_BINARY_PATH")) or (
+            isinstance(node, ast.Subscript) and _is_environment_subscript(node, "APM_BINARY_PATH")
+        ):
+            lines.add(node.lineno)
+    return sorted(lines)
+
+
+def _defined_functions(tree: ast.AST) -> set[str]:
+    return {
+        node.name for node in tree.body if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def _parse(path: Path, root: Path) -> tuple[ast.Module | None, str | None]:
+    try:
+        return ast.parse(path.read_text(encoding="utf-8")), None
+    except (OSError, SyntaxError) as error:
+        return None, f"[x] cannot inspect {path.relative_to(root)}: {error}"
+
+
 def find_binary_selection_violations(root: Path) -> list[str]:
-    """Find integration-test functions that reimplement binary selection."""
+    """Reject every direct integration-test read outside the canonical owner."""
     diagnostics: list[str] = []
     owner = root / BINARY_OWNER
-    if not owner.is_file() or "def _resolve_apm_binary(" not in owner.read_text(encoding="utf-8"):
+    owner_tree, owner_error = _parse(owner, root)
+    if owner_error is not None:
+        diagnostics.append(owner_error)
+    elif owner_tree is None or "_resolve_apm_binary" not in _defined_functions(owner_tree):
         diagnostics.append(f"[x] {BINARY_OWNER} must define _resolve_apm_binary")
 
-    for path in _python_files(root, ("tests",)):
+    integration_root = root / "tests" / "integration"
+    for path in _python_files(root, ("tests/integration",)):
         if path == owner:
             continue
-        try:
-            tree = ast.parse(path.read_text(encoding="utf-8"))
-        except (OSError, SyntaxError) as error:
-            diagnostics.append(f"[x] cannot inspect {path.relative_to(root)}: {error}")
+        tree, error = _parse(path, root)
+        if error is not None:
+            diagnostics.append(error)
             continue
-        for function in _function_nodes(tree):
-            reason = _binary_duplicate_reason(function)
-            if reason is not None:
-                relative = path.relative_to(root).as_posix()
-                diagnostics.append(
-                    f"[x] duplicate integration binary selection: "
-                    f"{relative}:{function.lineno} {function.name} {reason}"
-                )
+        if tree is None:
+            continue
+        relative = path.relative_to(root).as_posix()
+        for line in _direct_binary_env_read_lines(tree):
+            diagnostics.append(
+                f"[x] direct APM_BINARY_PATH read outside {BINARY_OWNER}: "
+                f"{relative}:{line}; consume the apm_binary_path fixture"
+            )
+        if path.parent == integration_root and "_resolve_apm_binary" in _defined_functions(tree):
+            diagnostics.append(
+                f"[x] duplicate _resolve_apm_binary definition: {relative}; owner is {BINARY_OWNER}"
+            )
     return sorted(diagnostics)
 
 
-def _has_visible_registry_projection(tree: ast.AST) -> bool:
-    has_commands_items = False
-    has_hidden_filter = False
+def _parity_import_violations(tree: ast.AST, relative: str) -> list[str]:
+    diagnostics: list[str] = []
     for node in ast.walk(tree):
-        if isinstance(node, ast.Call):
-            called = _attribute_name(node.func)
-            if called is not None and called.endswith(".commands.items"):
-                has_commands_items = True
-        if isinstance(node, ast.Attribute) and node.attr == "hidden":
-            has_hidden_filter = True
-    return has_commands_items and has_hidden_filter
+        if isinstance(node, ast.ImportFrom) and node.module == "scripts.check_cli_docs":
+            for alias in node.names:
+                if alias.name in PARITY_INTERNALS:
+                    diagnostics.append(
+                        f"[x] internal rendered parity projection imported: "
+                        f"{relative}:{node.lineno} {alias.name}; "
+                        f"consume {PARITY_FACADE}"
+                    )
+        elif isinstance(node, ast.ImportFrom) and node.module == "scripts":
+            for alias in node.names:
+                if alias.name == "check_cli_docs":
+                    diagnostics.append(
+                        f"[x] rendered parity module imported directly: "
+                        f"{relative}:{node.lineno}; import {PARITY_FACADE} only"
+                    )
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "scripts.check_cli_docs":
+                    diagnostics.append(
+                        f"[x] rendered parity module imported directly: "
+                        f"{relative}:{node.lineno}; import {PARITY_FACADE} only"
+                    )
+    return diagnostics
 
 
-def _has_rendered_page_projection(tree: ast.AST) -> bool:
-    strings = _string_values(tree)
-    has_iterdir = any(
-        isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Attribute)
-        and node.func.attr == "iterdir"
-        for node in ast.walk(tree)
-    )
-    return has_iterdir and {"reference", "cli", "index.html"}.issubset(strings)
+def _is_commands_items(call: ast.Call) -> bool:
+    called = _attribute_name(call.func)
+    return called is not None and called.endswith(".commands.items")
 
 
-def _has_bidirectional_set_difference(tree: ast.AST) -> bool:
-    return (
-        sum(isinstance(node, ast.BinOp) and isinstance(node.op, ast.Sub) for node in ast.walk(tree))
-        >= 2
-    )
+def _registry_projection_lines(tree: ast.AST) -> list[int]:
+    lines: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and _is_commands_items(node):
+            lines.add(node.lineno)
+    return sorted(lines)
+
+
+def _path_string_segments(node: ast.AST) -> set[str]:
+    return {value for child in ast.walk(node) if (value := _literal_string(child)) is not None}
+
+
+def _rendered_cli_path_names(tree: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        value = node.value
+        if value is None or not {"reference", "cli"}.issubset(_path_string_segments(value)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        names.update(target.id for target in targets if isinstance(target, ast.Name))
+    return names
+
+
+def _rendered_inventory_lines(tree: ast.AST) -> list[int]:
+    lines: set[int] = set()
+    rendered_path_names = _rendered_cli_path_names(tree)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not isinstance(node.func, ast.Attribute) or node.func.attr not in {
+            "glob",
+            "iterdir",
+            "rglob",
+        }:
+            continue
+        parent = node.func.value
+        if {"reference", "cli"}.issubset(_path_string_segments(parent)) or (
+            isinstance(parent, ast.Name) and parent.id in rendered_path_names
+        ):
+            lines.add(node.lineno)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.BinOp) or not isinstance(node.op, ast.Div):
+            continue
+        if "index.html" not in _path_string_segments(node):
+            continue
+        if any(
+            isinstance(child, ast.Call)
+            and isinstance(child.func, ast.Attribute)
+            and child.func.attr in {"is_file", "exists"}
+            for child in ast.walk(node)
+        ):
+            lines.add(node.lineno)
+    return sorted(lines)
+
+
+def _owner_definition_violations(root: Path) -> list[str]:
+    owner = root / PARITY_OWNER
+    tree, error = _parse(owner, root)
+    if error is not None:
+        return [error]
+    if tree is None:
+        return [f"[x] cannot inspect {PARITY_OWNER}"]
+    missing = sorted(PARITY_OWNER_FUNCTIONS - _defined_functions(tree))
+    return [
+        f"[x] {PARITY_OWNER} must define rendered parity owner function: {name}" for name in missing
+    ]
 
 
 def find_rendered_parity_violations(root: Path) -> list[str]:
-    """Find modules outside the checker that recompute rendered CLI parity."""
-    diagnostics: list[str] = []
+    """Enforce facade-only consumers and unique registry/page projections."""
+    diagnostics = _owner_definition_violations(root)
     owner = root / PARITY_OWNER
-    owner_source = owner.read_text(encoding="utf-8") if owner.is_file() else ""
-    required = (
-        "def public_top_level_commands(",
-        "def rendered_cli_reference_pages(",
-        "def registry_docs_mismatches(",
-    )
-    if any(token not in owner_source for token in required):
-        diagnostics.append(f"[x] {PARITY_OWNER} must own all rendered parity projections")
-
-    for path in _python_files(root, ("src/apm_cli", "scripts")):
+    for path in _python_files(root, ("src/apm_cli", "scripts", "tests")):
         if path == owner:
             continue
-        try:
-            tree = ast.parse(path.read_text(encoding="utf-8"))
-        except (OSError, SyntaxError) as error:
-            diagnostics.append(f"[x] cannot inspect {path.relative_to(root)}: {error}")
+        tree, error = _parse(path, root)
+        if error is not None:
+            diagnostics.append(error)
             continue
-        roles = (
-            _has_visible_registry_projection(tree),
-            _has_rendered_page_projection(tree),
-            _has_bidirectional_set_difference(tree),
-        )
-        if sum(roles) >= 2:
-            relative = path.relative_to(root).as_posix()
+        if tree is None:
+            continue
+        relative = path.relative_to(root).as_posix()
+        diagnostics.extend(_parity_import_violations(tree, relative))
+        for line in _registry_projection_lines(tree):
             diagnostics.append(
-                f"[x] duplicate rendered CLI parity computation: {relative} "
-                "must delegate to scripts/check_cli_docs.py"
+                f"[x] direct Click command registry projection: {relative}:{line}; "
+                f"consume {PARITY_FACADE}"
             )
-    return sorted(diagnostics)
+        for line in _rendered_inventory_lines(tree):
+            diagnostics.append(
+                f"[x] direct rendered CLI route inventory: {relative}:{line}; "
+                f"consume {PARITY_FACADE}"
+            )
+    return sorted(set(diagnostics))
 
 
 def check(root: Path) -> list[str]:

--- a/scripts/check_test_contract_authorities.py
+++ b/scripts/check_test_contract_authorities.py
@@ -51,26 +51,42 @@ def _literal_string(node: ast.AST) -> str | None:
     return None
 
 
-def _is_environment_get(call: ast.Call, variable: str) -> bool:
-    called = _attribute_name(call.func)
-    return (
-        called in {"os.environ.get", "os.getenv"}
-        and bool(call.args)
-        and _literal_string(call.args[0]) == variable
-    )
-
-
-def _is_environment_subscript(node: ast.Subscript, variable: str) -> bool:
-    return _attribute_name(node.value) == "os.environ" and _literal_string(node.slice) == variable
-
-
 def _direct_binary_env_read_lines(tree: ast.AST) -> list[int]:
+    os_aliases = {"os"}
+    environ_aliases: set[str] = set()
+    getenv_aliases: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            os_aliases.update(
+                alias.asname or alias.name for alias in node.names if alias.name == "os"
+            )
+        elif isinstance(node, ast.ImportFrom) and node.module == "os":
+            for alias in node.names:
+                local_name = alias.asname or alias.name
+                if alias.name == "environ":
+                    environ_aliases.add(local_name)
+                elif alias.name == "getenv":
+                    getenv_aliases.add(local_name)
+
     lines: set[int] = set()
     for node in ast.walk(tree):
-        if (isinstance(node, ast.Call) and _is_environment_get(node, "APM_BINARY_PATH")) or (
-            isinstance(node, ast.Subscript) and _is_environment_subscript(node, "APM_BINARY_PATH")
-        ):
-            lines.add(node.lineno)
+        if isinstance(node, ast.Call) and node.args:
+            called = _attribute_name(node.func)
+            reads_variable = _literal_string(node.args[0]) == "APM_BINARY_PATH"
+            if reads_variable and (
+                called in getenv_aliases
+                or any(
+                    called in {f"{alias}.getenv", f"{alias}.environ.get"} for alias in os_aliases
+                )
+                or any(called == f"{alias}.get" for alias in environ_aliases)
+            ):
+                lines.add(node.lineno)
+        elif isinstance(node, ast.Subscript) and _literal_string(node.slice) == "APM_BINARY_PATH":
+            target = _attribute_name(node.value)
+            if target in environ_aliases or any(
+                target == f"{alias}.environ" for alias in os_aliases
+            ):
+                lines.add(node.lineno)
     return sorted(lines)
 
 
@@ -156,7 +172,19 @@ def _is_commands_items(call: ast.Call) -> bool:
 def _registry_projection_lines(tree: ast.AST) -> list[int]:
     lines: set[int] = set()
     for node in ast.walk(tree):
-        if isinstance(node, ast.Call) and _is_commands_items(node):
+        if not isinstance(
+            node,
+            (ast.DictComp, ast.GeneratorExp, ast.ListComp, ast.SetComp),
+        ):
+            continue
+        projects_commands = any(
+            isinstance(generator.iter, ast.Call) and _is_commands_items(generator.iter)
+            for generator in node.generators
+        )
+        filters_hidden = any(
+            isinstance(child, ast.Attribute) and child.attr == "hidden" for child in ast.walk(node)
+        )
+        if projects_commands and filters_hidden:
             lines.add(node.lineno)
     return sorted(lines)
 

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -356,6 +356,15 @@ if [ "$windows_owner_status" -ne 0 ]; then
     violations=$((violations + 1))
 fi
 
+echo "[*] AC9: executable test contract authorities"
+test_contract_output=$(python3 scripts/check_test_contract_authorities.py --root "$ROOT" 2>&1)
+test_contract_status=$?
+if [ "$test_contract_status" -ne 0 ]; then
+    echo "[x] Integration binary selection and rendered CLI parity require canonical owners"
+    echo "$test_contract_output"
+    violations=$((violations + 1))
+fi
+
 if [ "$violations" -gt 0 ]; then
     echo "[x] $violations architecture boundary rule(s) failed"
     exit 1

--- a/scripts/windows/test-install-script.ps1
+++ b/scripts/windows/test-install-script.ps1
@@ -278,6 +278,69 @@ function New-IsolatedPrefix {
     return @{ Root = $root; BinDir = $binDir; TmpDir = $tmpDir }
 }
 
+function Assert-MissingStableExecutableFailsForNativeProcess {
+    param(
+        [Parameter(Mandatory = $true)][string]$CurrentDir,
+        [Parameter(Mandatory = $true)][string]$BinDir,
+        [Parameter(Mandatory = $true)][string]$WorkingDir
+    )
+
+    $stableExe = Join-Path $CurrentDir "apm.exe"
+    $cmdShim = Join-Path $BinDir "apm.cmd"
+    $disabledCurrent = "$CurrentDir.pr6-disabled"
+    $savedPath = $env:Path
+    $savedLaunchCwd = $env:APM_LAUNCH_TEST_CWD
+    $pythonExe = (Get-Command python -ErrorAction Stop).Source
+
+    Assert-True (Test-Path $stableExe) "Negative twin starts with stable apm.exe"
+    Assert-True (Test-Path $cmdShim) "Negative twin keeps apm.cmd available"
+
+    try {
+        Move-Item -Path $CurrentDir -Destination $disabledCurrent
+        Assert-True (-not (Test-Path $stableExe)) "Stable apm.exe is absent during negative twin"
+        Assert-True (Test-Path $cmdShim) "apm.cmd remains during negative twin"
+        $env:Path = "$CurrentDir;$BinDir"
+        $env:APM_LAUNCH_TEST_CWD = $WorkingDir
+
+        $pythonScript = @'
+import os
+import subprocess
+import sys
+
+try:
+    subprocess.run(
+        ["apm", "--version"],
+        cwd=os.environ["APM_LAUNCH_TEST_CWD"],
+    )
+except FileNotFoundError:
+    print("missing stable executable rejected")
+    sys.exit(0)
+
+print("bare apm unexpectedly resolved", file=sys.stderr)
+sys.exit(1)
+'@
+        $pythonOutput = & $pythonExe -c $pythonScript 2>&1
+        $pythonExit = $LASTEXITCODE
+        if ($pythonExit -ne 0) {
+            throw "Python subprocess unexpectedly resolved missing stable apm.exe (got $pythonExit; output: $pythonOutput)"
+        }
+        if (($pythonOutput | Out-String) -notmatch "missing stable executable rejected") {
+            throw "Python subprocess did not record FileNotFoundError (output: $pythonOutput)"
+        }
+        Write-Success "Python subprocess rejects missing stable apm.exe"
+    } finally {
+        $env:Path = $savedPath
+        if ($null -ne $savedLaunchCwd) {
+            $env:APM_LAUNCH_TEST_CWD = $savedLaunchCwd
+        } else {
+            Remove-Item Env:APM_LAUNCH_TEST_CWD -ErrorAction SilentlyContinue
+        }
+        if (Test-Path $disabledCurrent) {
+            Move-Item -Path $disabledCurrent -Destination $CurrentDir
+        }
+    }
+}
+
 # ---------------------------------------------------------------------------
 # Test 3: End-to-end install into an isolated prefix (fresh install path).
 # ---------------------------------------------------------------------------
@@ -367,6 +430,11 @@ sys.exit(result.returncode)
                 $pythonExit = $LASTEXITCODE
                 Assert-True ($pythonExit -eq 0) "Python subprocess resolves bare apm (got $pythonExit; output: $pythonOutput)"
                 Assert-True (($pythonOutput | Out-String) -match [regex]::Escape($PinnedVersion.TrimStart("v"))) "Python subprocess reports $PinnedVersion"
+
+                Assert-MissingStableExecutableFailsForNativeProcess `
+                    -CurrentDir $currentDir `
+                    -BinDir $prefix.BinDir `
+                    -WorkingDir $prefix.Root
 
                 $bash = Get-Command bash -ErrorAction SilentlyContinue
                 if ($bash) {

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -158,7 +158,8 @@ def _resolve_apm_binary() -> Path | None:
     """Resolve the apm binary used by integration tests.
 
     Resolution order (prefers the build under test over a system install):
-      1. ``APM_BINARY_PATH`` env var (CI sets this after the build step).
+      1. ``APM_BINARY_PATH`` env var (CI sets this after the build step). When
+         set, this path is authoritative and invalid values fail closed.
       2. ``./dist/<platform>/apm`` (local build convention).
       3. ``shutil.which("apm")`` lookup on ``PATH``.
 
@@ -169,8 +170,17 @@ def _resolve_apm_binary() -> Path | None:
     env_path = os.environ.get("APM_BINARY_PATH")
     if env_path:
         candidate = Path(env_path)
-        if candidate.is_file():
-            return candidate.resolve()
+        if not candidate.is_file():
+            raise RuntimeError(
+                f"APM_BINARY_PATH does not exist or is not a file: {candidate}. "
+                "Build the expected artifact or correct APM_BINARY_PATH."
+            )
+        if not os.access(candidate, os.X_OK):
+            raise RuntimeError(
+                f"APM_BINARY_PATH is not executable: {candidate}. "
+                "Make the expected artifact executable and rerun the test."
+            )
+        return candidate.resolve()
 
     local = _local_dist_apm_binary()
     if local is not None:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -168,7 +168,12 @@ def _resolve_apm_binary() -> Path | None:
     contributor is trying to validate.
     """
     env_path = os.environ.get("APM_BINARY_PATH")
-    if env_path:
+    if env_path is not None:
+        if not env_path:
+            raise pytest.UsageError(
+                "APM_BINARY_PATH is set but empty. "
+                "Set it to the expected executable or remove the variable."
+            )
         candidate = Path(env_path)
         if not candidate.is_file():
             raise pytest.UsageError(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -171,12 +171,12 @@ def _resolve_apm_binary() -> Path | None:
     if env_path:
         candidate = Path(env_path)
         if not candidate.is_file():
-            raise RuntimeError(
+            raise pytest.UsageError(
                 f"APM_BINARY_PATH does not exist or is not a file: {candidate}. "
                 "Build the expected artifact or correct APM_BINARY_PATH."
             )
         if not os.access(candidate, os.X_OK):
-            raise RuntimeError(
+            raise pytest.UsageError(
                 f"APM_BINARY_PATH is not executable: {candidate}. "
                 "Make the expected artifact executable and rerun the test."
             )

--- a/tests/integration/marketplace/conftest.py
+++ b/tests/integration/marketplace/conftest.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import json
 import os
 import subprocess
-import sys
 from pathlib import Path
 from typing import List, Optional  # noqa: F401, UP035
 from unittest.mock import MagicMock, patch  # noqa: F401
@@ -282,12 +281,13 @@ def live_marketplace_repo() -> str:
 
 
 def run_cli(
+    apm_binary_path: Path,
     args: list[str],
     cwd: Path | None = None,
     env: dict | None = None,
     timeout: int = 60,
 ) -> subprocess.CompletedProcess:
-    """Invoke ``uv run apm <args>`` via subprocess.
+    """Invoke the canonical APM executable via subprocess.
 
     The subprocess inherits a curated env containing PATH and HOME.
     Additional env vars can be passed via *env*; they are merged on top.
@@ -328,11 +328,7 @@ def run_cli(
     if env:
         base_env.update(env)
 
-    cmd = [sys.executable, "-m", "uv", "run", "apm"] + args  # noqa: RUF005
-    # Prefer the project-local uv wrapper if available
-    uv_bin = _project_uv_bin()
-    if uv_bin:
-        cmd = [uv_bin, "run", "apm"] + args  # noqa: RUF005
+    cmd = [str(apm_binary_path), *args]
 
     return subprocess.run(
         cmd,

--- a/tests/integration/marketplace/conftest.py
+++ b/tests/integration/marketplace/conftest.py
@@ -194,9 +194,9 @@ def mock_ref_resolver():
 
     Usage in tests::
 
-        def test_something(mkt_repo_root, mock_ref_resolver):
+        def test_something(mkt_repo_root, mock_ref_resolver, apm_binary_path):
             # mock_ref_resolver.list_remote_refs is already patched
-            result = run_cli(["marketplace", "build"], cwd=mkt_repo_root)
+            result = run_cli(apm_binary_path, ["marketplace", "build"], cwd=mkt_repo_root)
             assert result.returncode == 0
     """
     with patch(
@@ -287,7 +287,7 @@ def run_cli(
     env: dict | None = None,
     timeout: int = 60,
 ) -> subprocess.CompletedProcess:
-    """Invoke the canonical APM executable via subprocess.
+    """Invoke the canonical integration APM executable via subprocess.
 
     The subprocess inherits a curated env containing PATH and HOME.
     Additional env vars can be passed via *env*; they are merged on top.
@@ -328,20 +328,11 @@ def run_cli(
     if env:
         base_env.update(env)
 
-    cmd = [str(apm_binary_path), *args]
-
     return subprocess.run(
-        cmd,
+        [str(apm_binary_path), *args],
         cwd=str(cwd) if cwd else str(_PROJECT_ROOT),
         capture_output=True,
         text=True,
         timeout=timeout,
         env=base_env,
     )
-
-
-def _project_uv_bin() -> str | None:
-    """Return path to uv if it is on PATH, else None."""
-    import shutil
-
-    return shutil.which("uv")

--- a/tests/integration/marketplace/test_build_integration.py
+++ b/tests/integration/marketplace/test_build_integration.py
@@ -265,21 +265,12 @@ class TestBuildCLI:
         result = run_cli(apm_binary_path, ["marketplace", "build"], cwd=tmp_path)
         assert result.returncode == 2
 
-    def test_dry_run_flag_present(
-        self,
-        tmp_path: Path,
-        mock_ref_resolver,
-        apm_binary_path: Path,
-    ):
+    def test_dry_run_flag_present(self, tmp_path: Path, mock_ref_resolver, apm_binary_path: Path):
         """The removed `apm marketplace build` accepts --dry-run without
         crashing on unknown args; exit is the deprecation code (2) and
         there is no Python traceback."""
         _write_yml(tmp_path, MINIMAL_YML)
-        result = run_cli(
-            apm_binary_path,
-            ["marketplace", "build", "--dry-run"],
-            cwd=tmp_path,
-        )
+        result = run_cli(apm_binary_path, ["marketplace", "build", "--dry-run"], cwd=tmp_path)
         assert result.returncode == 2
         assert "Traceback" not in result.stderr
         combined = result.stdout + result.stderr

--- a/tests/integration/marketplace/test_build_integration.py
+++ b/tests/integration/marketplace/test_build_integration.py
@@ -255,27 +255,36 @@ class TestBuildErrorPaths:
 class TestBuildCLI:
     """Tests that invoke `apm marketplace build` via subprocess."""
 
-    def test_missing_yml_exits_1(self, tmp_path: Path):
+    def test_missing_yml_exits_1(self, tmp_path: Path, apm_binary_path: Path):
         """`apm marketplace build` was removed; the stub exits 2 with a
         deprecation message that points users at `apm pack`."""
-        result = run_cli(["marketplace", "build"], cwd=tmp_path)
+        result = run_cli(apm_binary_path, ["marketplace", "build"], cwd=tmp_path)
         assert result.returncode == 2
         combined = result.stdout + result.stderr
         assert "removed" in combined.lower()
         assert "apm pack" in combined
 
-    def test_schema_error_exits_2(self, tmp_path: Path):
+    def test_schema_error_exits_2(self, tmp_path: Path, apm_binary_path: Path):
         """Malformed marketplace.yml must exit 2."""
         (tmp_path / "marketplace.yml").write_text("name: [\nbad: yaml\n", encoding="utf-8")
-        result = run_cli(["marketplace", "build"], cwd=tmp_path)
+        result = run_cli(apm_binary_path, ["marketplace", "build"], cwd=tmp_path)
         assert result.returncode == 2
 
-    def test_dry_run_flag_present(self, tmp_path: Path, mock_ref_resolver):
+    def test_dry_run_flag_present(
+        self,
+        tmp_path: Path,
+        mock_ref_resolver,
+        apm_binary_path: Path,
+    ):
         """The removed `apm marketplace build` accepts --dry-run without
         crashing on unknown args; exit is the deprecation code (2) and
         there is no Python traceback."""
         _write_yml(tmp_path, MINIMAL_YML)
-        result = run_cli(["marketplace", "build", "--dry-run"], cwd=tmp_path)
+        result = run_cli(
+            apm_binary_path,
+            ["marketplace", "build", "--dry-run"],
+            cwd=tmp_path,
+        )
         assert result.returncode == 2
         assert "Traceback" not in result.stderr
         combined = result.stdout + result.stderr

--- a/tests/integration/marketplace/test_build_integration.py
+++ b/tests/integration/marketplace/test_build_integration.py
@@ -25,7 +25,6 @@ from apm_cli.marketplace.yml_schema import load_marketplace_yml  # noqa: F401
 from .conftest import (
     GOLDEN_YML,
     MINIMAL_YML,
-    _project_uv_bin,
     run_cli,
 )
 
@@ -248,10 +247,6 @@ class TestBuildErrorPaths:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(
-    not _project_uv_bin(),
-    reason="uv not found on PATH; skipping subprocess CLI tests",
-)
 class TestBuildCLI:
     """Tests that invoke `apm marketplace build` via subprocess."""
 

--- a/tests/integration/marketplace/test_live_e2e.py
+++ b/tests/integration/marketplace/test_live_e2e.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import json
 import re
-from pathlib import Path  # noqa: F401
+from pathlib import Path
 
 import pytest
 
@@ -60,12 +60,17 @@ packages:
 class TestLiveBuild:
     """Live build test: resolves real tags and writes marketplace.json."""
 
-    def test_live_build_succeeds(self, live_marketplace_repo, tmp_path):
+    def test_live_build_succeeds(
+        self,
+        live_marketplace_repo,
+        tmp_path,
+        apm_binary_path: Path,
+    ):
         """Build with a real remote must exit 0 and produce marketplace.json."""
         yml_path = tmp_path / "marketplace.yml"
         yml_path.write_text(_live_yml(live_marketplace_repo), encoding="utf-8")
 
-        result = run_cli(["marketplace", "build"], cwd=tmp_path, timeout=120)
+        result = run_cli(apm_binary_path, ["marketplace", "build"], cwd=tmp_path, timeout=120)
 
         assert result.returncode == 0, (
             f"build exited {result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
@@ -74,12 +79,17 @@ class TestLiveBuild:
         out_path = tmp_path / "marketplace.json"
         assert out_path.exists(), "marketplace.json was not produced"
 
-    def test_live_build_resolves_sha(self, live_marketplace_repo, tmp_path):
+    def test_live_build_resolves_sha(
+        self,
+        live_marketplace_repo,
+        tmp_path,
+        apm_binary_path: Path,
+    ):
         """All plugins in the produced marketplace.json must have a 40-char SHA."""
         yml_path = tmp_path / "marketplace.yml"
         yml_path.write_text(_live_yml(live_marketplace_repo), encoding="utf-8")
 
-        result = run_cli(["marketplace", "build"], cwd=tmp_path, timeout=120)
+        result = run_cli(apm_binary_path, ["marketplace", "build"], cwd=tmp_path, timeout=120)
         if result.returncode != 0:
             pytest.skip(
                 f"Build failed (possible: no v1.x tags on {live_marketplace_repo}). "
@@ -98,23 +108,33 @@ class TestLiveBuild:
 class TestLiveOutdated:
     """Live outdated test: reports upgrades in correct format."""
 
-    def test_live_outdated_exits_zero(self, live_marketplace_repo, tmp_path):
+    def test_live_outdated_exits_zero(
+        self,
+        live_marketplace_repo,
+        tmp_path,
+        apm_binary_path: Path,
+    ):
         """outdated always exits 0 (informational command)."""
         yml_path = tmp_path / "marketplace.yml"
         yml_path.write_text(_live_yml(live_marketplace_repo), encoding="utf-8")
 
-        result = run_cli(["marketplace", "outdated"], cwd=tmp_path, timeout=120)
+        result = run_cli(apm_binary_path, ["marketplace", "outdated"], cwd=tmp_path, timeout=120)
 
         assert result.returncode == 0, (
             f"outdated exited {result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
         )
 
-    def test_live_outdated_output_contains_package_name(self, live_marketplace_repo, tmp_path):
+    def test_live_outdated_output_contains_package_name(
+        self,
+        live_marketplace_repo,
+        tmp_path,
+        apm_binary_path: Path,
+    ):
         """Output must contain the package name from the yml."""
         yml_path = tmp_path / "marketplace.yml"
         yml_path.write_text(_live_yml(live_marketplace_repo), encoding="utf-8")
 
-        result = run_cli(["marketplace", "outdated"], cwd=tmp_path, timeout=120)
+        result = run_cli(apm_binary_path, ["marketplace", "outdated"], cwd=tmp_path, timeout=120)
 
         assert "live-plugin" in result.stdout or "live-plugin" in result.stderr, (
             "Expected package name 'live-plugin' to appear in outdated output"
@@ -124,12 +144,17 @@ class TestLiveOutdated:
 class TestLiveCheck:
     """Live check test: all entries must be reachable."""
 
-    def test_live_check_exits_zero(self, live_marketplace_repo, tmp_path):
+    def test_live_check_exits_zero(
+        self,
+        live_marketplace_repo,
+        tmp_path,
+        apm_binary_path: Path,
+    ):
         """check must exit 0 when all entries resolve against the live remote."""
         yml_path = tmp_path / "marketplace.yml"
         yml_path.write_text(_live_yml(live_marketplace_repo), encoding="utf-8")
 
-        result = run_cli(["marketplace", "check"], cwd=tmp_path, timeout=120)
+        result = run_cli(apm_binary_path, ["marketplace", "check"], cwd=tmp_path, timeout=120)
 
         assert result.returncode in (0, 1), (
             f"check exited {result.returncode} (unexpected)\n"
@@ -148,23 +173,33 @@ class TestLiveCheck:
 class TestLiveDoctor:
     """Live doctor test: git + network checks should pass in CI with network."""
 
-    def test_live_doctor_exits_zero(self, live_marketplace_repo, tmp_path):
+    def test_live_doctor_exits_zero(
+        self,
+        live_marketplace_repo,
+        tmp_path,
+        apm_binary_path: Path,
+    ):
         """doctor must exit 0 when git is available and github.com is reachable."""
         # Place a valid marketplace.yml so the yml check is informational-pass
         yml_path = tmp_path / "marketplace.yml"
         yml_path.write_text(_live_yml(live_marketplace_repo), encoding="utf-8")
 
-        result = run_cli(["marketplace", "doctor"], cwd=tmp_path, timeout=30)
+        result = run_cli(apm_binary_path, ["marketplace", "doctor"], cwd=tmp_path, timeout=30)
 
         assert result.returncode == 0, (
             f"doctor exited {result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
         )
 
-    def test_live_doctor_mentions_git(self, live_marketplace_repo, tmp_path):
+    def test_live_doctor_mentions_git(
+        self,
+        live_marketplace_repo,
+        tmp_path,
+        apm_binary_path: Path,
+    ):
         """doctor output must mention the git check."""
         yml_path = tmp_path / "marketplace.yml"
         yml_path.write_text(_live_yml(live_marketplace_repo), encoding="utf-8")
 
-        result = run_cli(["marketplace", "doctor"], cwd=tmp_path, timeout=30)
+        result = run_cli(apm_binary_path, ["marketplace", "doctor"], cwd=tmp_path, timeout=30)
 
         assert "git" in (result.stdout + result.stderr).lower()

--- a/tests/integration/marketplace/test_live_e2e.py
+++ b/tests/integration/marketplace/test_live_e2e.py
@@ -60,12 +60,7 @@ packages:
 class TestLiveBuild:
     """Live build test: resolves real tags and writes marketplace.json."""
 
-    def test_live_build_succeeds(
-        self,
-        live_marketplace_repo,
-        tmp_path,
-        apm_binary_path: Path,
-    ):
+    def test_live_build_succeeds(self, live_marketplace_repo, tmp_path, apm_binary_path: Path):
         """Build with a real remote must exit 0 and produce marketplace.json."""
         yml_path = tmp_path / "marketplace.yml"
         yml_path.write_text(_live_yml(live_marketplace_repo), encoding="utf-8")
@@ -79,12 +74,7 @@ class TestLiveBuild:
         out_path = tmp_path / "marketplace.json"
         assert out_path.exists(), "marketplace.json was not produced"
 
-    def test_live_build_resolves_sha(
-        self,
-        live_marketplace_repo,
-        tmp_path,
-        apm_binary_path: Path,
-    ):
+    def test_live_build_resolves_sha(self, live_marketplace_repo, tmp_path, apm_binary_path: Path):
         """All plugins in the produced marketplace.json must have a 40-char SHA."""
         yml_path = tmp_path / "marketplace.yml"
         yml_path.write_text(_live_yml(live_marketplace_repo), encoding="utf-8")
@@ -108,12 +98,7 @@ class TestLiveBuild:
 class TestLiveOutdated:
     """Live outdated test: reports upgrades in correct format."""
 
-    def test_live_outdated_exits_zero(
-        self,
-        live_marketplace_repo,
-        tmp_path,
-        apm_binary_path: Path,
-    ):
+    def test_live_outdated_exits_zero(self, live_marketplace_repo, tmp_path, apm_binary_path: Path):
         """outdated always exits 0 (informational command)."""
         yml_path = tmp_path / "marketplace.yml"
         yml_path.write_text(_live_yml(live_marketplace_repo), encoding="utf-8")
@@ -125,10 +110,7 @@ class TestLiveOutdated:
         )
 
     def test_live_outdated_output_contains_package_name(
-        self,
-        live_marketplace_repo,
-        tmp_path,
-        apm_binary_path: Path,
+        self, live_marketplace_repo, tmp_path, apm_binary_path: Path
     ):
         """Output must contain the package name from the yml."""
         yml_path = tmp_path / "marketplace.yml"
@@ -144,12 +126,7 @@ class TestLiveOutdated:
 class TestLiveCheck:
     """Live check test: all entries must be reachable."""
 
-    def test_live_check_exits_zero(
-        self,
-        live_marketplace_repo,
-        tmp_path,
-        apm_binary_path: Path,
-    ):
+    def test_live_check_exits_zero(self, live_marketplace_repo, tmp_path, apm_binary_path: Path):
         """check must exit 0 when all entries resolve against the live remote."""
         yml_path = tmp_path / "marketplace.yml"
         yml_path.write_text(_live_yml(live_marketplace_repo), encoding="utf-8")
@@ -173,12 +150,7 @@ class TestLiveCheck:
 class TestLiveDoctor:
     """Live doctor test: git + network checks should pass in CI with network."""
 
-    def test_live_doctor_exits_zero(
-        self,
-        live_marketplace_repo,
-        tmp_path,
-        apm_binary_path: Path,
-    ):
+    def test_live_doctor_exits_zero(self, live_marketplace_repo, tmp_path, apm_binary_path: Path):
         """doctor must exit 0 when git is available and github.com is reachable."""
         # Place a valid marketplace.yml so the yml check is informational-pass
         yml_path = tmp_path / "marketplace.yml"
@@ -190,12 +162,7 @@ class TestLiveDoctor:
             f"doctor exited {result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
         )
 
-    def test_live_doctor_mentions_git(
-        self,
-        live_marketplace_repo,
-        tmp_path,
-        apm_binary_path: Path,
-    ):
+    def test_live_doctor_mentions_git(self, live_marketplace_repo, tmp_path, apm_binary_path: Path):
         """doctor output must mention the git check."""
         yml_path = tmp_path / "marketplace.yml"
         yml_path.write_text(_live_yml(live_marketplace_repo), encoding="utf-8")

--- a/tests/integration/test_ado_bearer_e2e.py
+++ b/tests/integration/test_ado_bearer_e2e.py
@@ -27,7 +27,6 @@ import os
 import shlex
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
@@ -67,21 +66,17 @@ pytestmark = pytest.mark.requires_ado_bearer
 
 
 def run_apm(
-    cmd: str, cwd: Path, env_overrides: dict, timeout: int = 90
+    apm_binary_path: Path,
+    cmd: str,
+    cwd: Path,
+    env_overrides: dict,
+    timeout: int = 90,
 ) -> subprocess.CompletedProcess:
     """Run apm with a controlled env dict.
 
     env_overrides is merged into a copy of os.environ; values of None DELETE
     that key from the merged env.
     """
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        apm_path = apm_on_path
-    elif sys.platform == "win32":
-        apm_path = str(Path(__file__).parent.parent.parent / ".venv" / "Scripts" / "apm.exe")
-    else:
-        apm_path = str(Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm")
-
     env = {**os.environ}
     for k, v in env_overrides.items():
         if v is None:
@@ -92,7 +87,7 @@ def run_apm(
     return subprocess.run(
         # B4 #852: list-form (shell=False) avoids command injection via
         # CI-supplied repo names that may contain shell metacharacters.
-        [apm_path, *shlex.split(cmd)],
+        [str(apm_binary_path), *shlex.split(cmd)],
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -161,11 +156,12 @@ EXPECTED_PATH_PARTS = _expected_path_parts_from_repo(ADO_TEST_REPO)
 class TestBearerOnly:
     """Install an ADO package with NO ADO_APM_PAT set; bearer is the only path."""
 
-    def test_install_via_bearer_only(self, tmp_path):
+    def test_install_via_bearer_only(self, tmp_path, apm_binary_path: Path):
         project_dir = tmp_path / "bearer-only"
         _init_project(project_dir)
 
         result = run_apm(
+            apm_binary_path,
             f'install --only apm "{ADO_TEST_REPO}"',
             project_dir,
             env_overrides={"ADO_APM_PAT": None},
@@ -185,12 +181,13 @@ class TestBearerOnly:
         )
         assert installed.exists(), f"Expected {installed} to exist after bearer install"
 
-    def test_verbose_shows_bearer_source(self, tmp_path):
+    def test_verbose_shows_bearer_source(self, tmp_path, apm_binary_path: Path):
         """apm install --verbose should reveal 'bearer from az cli' as the token source."""
         project_dir = tmp_path / "bearer-verbose"
         _init_project(project_dir)
 
         result = run_apm(
+            apm_binary_path,
             f'install --only apm --verbose "{ADO_TEST_REPO}"',
             project_dir,
             env_overrides={"ADO_APM_PAT": None},
@@ -209,7 +206,7 @@ class TestBearerOnly:
 class TestStalePatFallback:
     """A bogus PAT triggers 401, then bearer fallback succeeds with a [!] warning."""
 
-    def test_bogus_pat_falls_back_to_bearer(self, tmp_path):
+    def test_bogus_pat_falls_back_to_bearer(self, tmp_path, apm_binary_path: Path):
         project_dir = tmp_path / "stale-pat"
         _init_project(project_dir)
 
@@ -217,6 +214,7 @@ class TestStalePatFallback:
         bogus = "x" * 52
 
         result = run_apm(
+            apm_binary_path,
             f'install --only apm "{ADO_TEST_REPO}"',
             project_dir,
             env_overrides={"ADO_APM_PAT": bogus},
@@ -271,12 +269,13 @@ class TestPatRegression:
         not os.getenv("ADO_APM_PAT"),
         reason="ADO_APM_PAT not set; regression test requires real PAT",
     )
-    def test_pat_install_unchanged(self, tmp_path):
+    def test_pat_install_unchanged(self, tmp_path, apm_binary_path: Path):
         project_dir = tmp_path / "pat-regress"
         _init_project(project_dir)
 
         # Use the user's real PAT as-is
         result = run_apm(
+            apm_binary_path,
             f'install --only apm "{ADO_TEST_REPO}"',
             project_dir,
             env_overrides={},
@@ -303,12 +302,13 @@ class TestPatRegression:
 class TestIssue1015BearerInstallRegression:
     """#1015 bug repro: bearer-only install (no PAT) should succeed."""
 
-    def test_bearer_only_install_succeeds(self, tmp_path):
+    def test_bearer_only_install_succeeds(self, tmp_path, apm_binary_path: Path):
         """With ADO_APM_PAT deleted, install via az cli bearer should work."""
         project_dir = tmp_path / "issue-1015-repro"
         _init_project(project_dir)
 
         result = run_apm(
+            apm_binary_path,
             f'install --only apm "{ADO_TEST_REPO}"',
             project_dir,
             env_overrides={"ADO_APM_PAT": None},
@@ -332,7 +332,7 @@ class TestIssue1015BearerInstallRegression:
 class TestIssue1015DiagnosticOnAuthFailure:
     """#1015: auth failure surfaces actionable diagnostics, not legacy wording."""
 
-    def test_bogus_pat_no_az_shows_diagnostic(self, tmp_path):
+    def test_bogus_pat_no_az_shows_diagnostic(self, tmp_path, apm_binary_path: Path):
         """With a bogus PAT and az NOT available, stderr shows diagnostics."""
         project_dir = tmp_path / "issue-1015-diag"
         _init_project(project_dir)
@@ -341,6 +341,7 @@ class TestIssue1015DiagnosticOnAuthFailure:
         # vars so az-cli bearer is unavailable for fallback.
         bogus = "x" * 52
         result = run_apm(
+            apm_binary_path,
             f'install --only apm "{ADO_TEST_REPO}"',
             project_dir,
             env_overrides={
@@ -375,7 +376,7 @@ class TestIssue1015DiagnosticOnAuthFailure:
 class TestIssue1015UpdatePreflightAbort:
     """#1015: apm install --update aborts cleanly on auth failure."""
 
-    def test_update_aborts_no_files_modified(self, tmp_path):
+    def test_update_aborts_no_files_modified(self, tmp_path, apm_binary_path: Path):
         """--update with no auth must exit non-zero and not modify files."""
         import hashlib
 
@@ -394,6 +395,7 @@ class TestIssue1015UpdatePreflightAbort:
         # Use a made-up ADO repo that the bearer cannot access
         # and suppress all auth so it fails cleanly.
         result = run_apm(
+            apm_binary_path,
             'install --only apm --update "dev.azure.com/nonexistent-org-xyzzy/fake/_git/fake"',
             project_dir,
             env_overrides={
@@ -436,11 +438,12 @@ class TestIssue1015PatRegressionExplicit:
         not os.getenv("ADO_APM_PAT"),
         reason="ADO_APM_PAT not set; PAT regression test requires real PAT",
     )
-    def test_pat_still_works_after_bearer_fix(self, tmp_path):
+    def test_pat_still_works_after_bearer_fix(self, tmp_path, apm_binary_path: Path):
         project_dir = tmp_path / "issue-1015-pat"
         _init_project(project_dir)
 
         result = run_apm(
+            apm_binary_path,
             f'install --only apm "{ADO_TEST_REPO}"',
             project_dir,
             env_overrides={},  # Use real PAT from env

--- a/tests/integration/test_ado_e2e.py
+++ b/tests/integration/test_ado_e2e.py
@@ -8,9 +8,8 @@ Skip these tests if ADO_APM_PAT is not available.
 """
 
 import os
-import shutil
+import shlex
 import subprocess
-import sys
 import tempfile  # noqa: F401
 from pathlib import Path
 
@@ -21,22 +20,15 @@ import yaml
 pytestmark = pytest.mark.requires_ado_pat
 
 
-def run_apm_command(cmd: str, cwd: Path, timeout: int = 60) -> subprocess.CompletedProcess:
+def run_apm_command(
+    apm_binary_path: Path,
+    cmd: str,
+    cwd: Path,
+    timeout: int = 60,
+) -> subprocess.CompletedProcess:
     """Run an APM CLI command and return the result."""
-    # Prefer binary on PATH (CI uses the PR artifact there)
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        apm_path = apm_on_path
-    # Fallback to local dev venv
-    elif sys.platform == "win32":
-        apm_path = Path(__file__).parent.parent.parent / ".venv" / "Scripts" / "apm.exe"
-    else:
-        apm_path = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-
-    full_cmd = f"{apm_path} {cmd}"
     result = subprocess.run(
-        full_cmd,
-        shell=True,
+        [str(apm_binary_path), *shlex.split(cmd)],
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -54,7 +46,7 @@ class TestADOInstall:
     # Test ADO repository - must be accessible with ADO_APM_PAT
     ADO_TEST_REPO = "dev.azure.com/dmeppiel-org/market-js-app/_git/compliance-rules"
 
-    def test_install_ado_package(self, tmp_path):
+    def test_install_ado_package(self, tmp_path, apm_binary_path: Path):
         """Install a real ADO package and verify directory structure."""
         project_dir = tmp_path / "test-project"
         project_dir.mkdir()
@@ -73,7 +65,11 @@ class TestADOInstall:
         )
 
         # Install ADO package
-        result = run_apm_command(f'install "{self.ADO_TEST_REPO}"', project_dir)
+        result = run_apm_command(
+            apm_binary_path,
+            f'install "{self.ADO_TEST_REPO}"',
+            project_dir,
+        )
         assert result.returncode == 0, f"Install failed: {result.stderr}"
 
         # Verify 3-level directory structure
@@ -93,7 +89,7 @@ class TestADODepsAndPrune:
 
     ADO_TEST_REPO = "dev.azure.com/dmeppiel-org/market-js-app/_git/compliance-rules"
 
-    def test_deps_list_shows_correct_path(self, tmp_path):
+    def test_deps_list_shows_correct_path(self, tmp_path, apm_binary_path: Path):
         """deps list should show full 3-level path for ADO packages."""
         project_dir = tmp_path / "test-project"
         project_dir.mkdir()
@@ -111,10 +107,10 @@ class TestADODepsAndPrune:
             )
         )
 
-        run_apm_command("install", project_dir, timeout=120)
+        run_apm_command(apm_binary_path, "install", project_dir, timeout=120)
 
         # Run deps list
-        result = run_apm_command("deps list", project_dir)
+        result = run_apm_command(apm_binary_path, "deps list", project_dir)
         assert result.returncode == 0, f"deps list failed: {result.stderr}"
 
         # Should show 3-level path (may be truncated with ...) and azure-devops source
@@ -122,7 +118,7 @@ class TestADODepsAndPrune:
         assert "azure-devops" in result.stdout
         assert "orphaned" not in result.stdout.lower()
 
-    def test_prune_no_false_positives(self, tmp_path):
+    def test_prune_no_false_positives(self, tmp_path, apm_binary_path: Path):
         """prune should not flag properly installed ADO packages as orphaned."""
         project_dir = tmp_path / "test-project"
         project_dir.mkdir()
@@ -140,10 +136,10 @@ class TestADODepsAndPrune:
             )
         )
 
-        run_apm_command("install", project_dir, timeout=120)
+        run_apm_command(apm_binary_path, "install", project_dir, timeout=120)
 
         # Run prune --dry-run
-        result = run_apm_command("prune --dry-run", project_dir)
+        result = run_apm_command(apm_binary_path, "prune --dry-run", project_dir)
         assert result.returncode == 0, f"prune failed: {result.stderr}"
 
         # Should report clean
@@ -155,7 +151,7 @@ class TestADOCompile:
 
     ADO_TEST_REPO = "dev.azure.com/dmeppiel-org/market-js-app/_git/compliance-rules"
 
-    def test_compile_generates_agents_md(self, tmp_path):
+    def test_compile_generates_agents_md(self, tmp_path, apm_binary_path: Path):
         """Compile should keep ADO Copilot instructions outside AGENTS.md."""
         project_dir = tmp_path / "test-project"
         project_dir.mkdir()
@@ -173,10 +169,10 @@ class TestADOCompile:
             )
         )
 
-        run_apm_command("install", project_dir, timeout=120)
+        run_apm_command(apm_binary_path, "install", project_dir, timeout=120)
 
         # Run compile
-        result = run_apm_command("compile --verbose", project_dir)
+        result = run_apm_command(apm_binary_path, "compile --verbose", project_dir)
         assert result.returncode == 0, f"compile failed: {result.stderr}"
 
         # Should not show orphan warnings
@@ -200,7 +196,7 @@ class TestADOVirtualPackage:
         "dev.azure.com/dmeppiel-org/market-js-app/_git/compliance-rules/gdpr-assessment.prompt.md"
     )
 
-    def test_install_virtual_package(self, tmp_path):
+    def test_install_virtual_package(self, tmp_path, apm_binary_path: Path):
         """Install a single file (virtual package) from ADO repo."""
         project_dir = tmp_path / "test-project"
         project_dir.mkdir()
@@ -219,7 +215,12 @@ class TestADOVirtualPackage:
         )
 
         # Install virtual package
-        result = run_apm_command(f'install "{self.ADO_VIRTUAL_PACKAGE}"', project_dir, timeout=120)
+        result = run_apm_command(
+            apm_binary_path,
+            f'install "{self.ADO_VIRTUAL_PACKAGE}"',
+            project_dir,
+            timeout=120,
+        )
         assert result.returncode == 0, f"Install failed: {result.stderr}"
 
         # Verify 3-level virtual package path
@@ -230,7 +231,7 @@ class TestADOVirtualPackage:
         )
         assert expected_path.exists(), f"Expected virtual package path not found: {expected_path}"
 
-    def test_virtual_package_not_orphaned(self, tmp_path):
+    def test_virtual_package_not_orphaned(self, tmp_path, apm_binary_path: Path):
         """Virtual packages should not be flagged as orphaned."""
         project_dir = tmp_path / "test-project"
         project_dir.mkdir()
@@ -248,14 +249,14 @@ class TestADOVirtualPackage:
             )
         )
 
-        run_apm_command("install", project_dir, timeout=120)
+        run_apm_command(apm_binary_path, "install", project_dir, timeout=120)
 
         # deps list should show it correctly
-        result = run_apm_command("deps list", project_dir)
+        result = run_apm_command(apm_binary_path, "deps list", project_dir)
         assert "orphaned" not in result.stdout.lower() or "0 orphan" in result.stdout.lower()
 
         # prune should report clean
-        result = run_apm_command("prune --dry-run", project_dir)
+        result = run_apm_command(apm_binary_path, "prune --dry-run", project_dir)
         assert "No orphaned packages found" in result.stdout or "clean" in result.stdout.lower()
 
 
@@ -265,7 +266,7 @@ class TestMixedDependencies:
     GITHUB_PACKAGE = "microsoft/apm-sample-package"
     ADO_PACKAGE = "dev.azure.com/dmeppiel-org/market-js-app/_git/compliance-rules"
 
-    def test_mixed_install(self, tmp_path):
+    def test_mixed_install(self, tmp_path, apm_binary_path: Path):
         """Both GitHub and ADO packages should install correctly."""
         project_dir = tmp_path / "test-project"
         project_dir.mkdir()
@@ -284,7 +285,7 @@ class TestMixedDependencies:
         )
 
         # Install all
-        result = run_apm_command("install", project_dir, timeout=180)
+        result = run_apm_command(apm_binary_path, "install", project_dir, timeout=180)
         assert result.returncode == 0, f"Install failed: {result.stderr}"
 
         # Verify both structures
@@ -298,7 +299,7 @@ class TestMixedDependencies:
         ado_path = apm_modules / "dmeppiel-org" / "market-js-app" / "compliance-rules"
         assert ado_path.exists(), f"ADO package not found: {ado_path}"
 
-    def test_mixed_deps_list(self, tmp_path):
+    def test_mixed_deps_list(self, tmp_path, apm_binary_path: Path):
         """deps list should show correct sources for mixed dependencies."""
         project_dir = tmp_path / "test-project"
         project_dir.mkdir()
@@ -316,10 +317,10 @@ class TestMixedDependencies:
             )
         )
 
-        run_apm_command("install", project_dir, timeout=180)
+        run_apm_command(apm_binary_path, "install", project_dir, timeout=180)
 
         # deps list should show both correctly
-        result = run_apm_command("deps list", project_dir)
+        result = run_apm_command(apm_binary_path, "deps list", project_dir)
         assert result.returncode == 0
 
         # Check sources are correct
@@ -331,7 +332,7 @@ class TestMixedDependencies:
         # Either no orphan warning or explicitly 0 orphaned
         assert "orphaned" not in lines or "0 orphan" in lines
 
-    def test_mixed_prune_no_false_positives(self, tmp_path):
+    def test_mixed_prune_no_false_positives(self, tmp_path, apm_binary_path: Path):
         """prune should handle both GitHub and ADO packages correctly."""
         project_dir = tmp_path / "test-project"
         project_dir.mkdir()
@@ -349,9 +350,9 @@ class TestMixedDependencies:
             )
         )
 
-        run_apm_command("install", project_dir, timeout=180)
+        run_apm_command(apm_binary_path, "install", project_dir, timeout=180)
 
         # prune should report clean
-        result = run_apm_command("prune --dry-run", project_dir)
+        result = run_apm_command(apm_binary_path, "prune --dry-run", project_dir)
         assert result.returncode == 0
         assert "No orphaned packages found" in result.stdout or "clean" in result.stdout.lower()

--- a/tests/integration/test_ado_e2e.py
+++ b/tests/integration/test_ado_e2e.py
@@ -21,10 +21,7 @@ pytestmark = pytest.mark.requires_ado_pat
 
 
 def run_apm_command(
-    apm_binary_path: Path,
-    cmd: str,
-    cwd: Path,
-    timeout: int = 60,
+    apm_binary_path: Path, cmd: str, cwd: Path, timeout: int = 60
 ) -> subprocess.CompletedProcess:
     """Run an APM CLI command and return the result."""
     result = subprocess.run(
@@ -65,11 +62,7 @@ class TestADOInstall:
         )
 
         # Install ADO package
-        result = run_apm_command(
-            apm_binary_path,
-            f'install "{self.ADO_TEST_REPO}"',
-            project_dir,
-        )
+        result = run_apm_command(apm_binary_path, f'install "{self.ADO_TEST_REPO}"', project_dir)
         assert result.returncode == 0, f"Install failed: {result.stderr}"
 
         # Verify 3-level directory structure
@@ -216,10 +209,7 @@ class TestADOVirtualPackage:
 
         # Install virtual package
         result = run_apm_command(
-            apm_binary_path,
-            f'install "{self.ADO_VIRTUAL_PACKAGE}"',
-            project_dir,
-            timeout=120,
+            apm_binary_path, f'install "{self.ADO_VIRTUAL_PACKAGE}"', project_dir, timeout=120
         )
         assert result.returncode == 0, f"Install failed: {result.stderr}"
 

--- a/tests/integration/test_apm_lifecycle_runner_contract.py
+++ b/tests/integration/test_apm_lifecycle_runner_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import os
 import subprocess
 import sys
@@ -12,28 +13,27 @@ import pytest
 from tests.utils.apm_lifecycle_runner import ApmLifecycleRunner, CommandResult
 
 
-def test_default_runner_executes_apm_console_script(tmp_path: Path) -> None:
-    result = ApmLifecycleRunner().run(
+def test_runner_executes_injected_apm_binary(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    result = ApmLifecycleRunner((str(apm_binary_path),)).run(
         ("--help",),
         cwd=tmp_path,
         env=os.environ,
     )
 
-    assert result.command == ("apm", "--help")
+    assert result.command == (str(apm_binary_path), "--help")
     assert result.returncode == 0
     assert "Usage: apm [OPTIONS] COMMAND [ARGS]..." in result.stdout
     assert "Agent Package Manager (APM)" in result.stdout
     assert result.cwd == tmp_path
 
 
-def test_explicit_command_can_execute_source_module(tmp_path: Path) -> None:
-    runner = ApmLifecycleRunner((sys.executable, "-m", "apm_cli.cli"))
+def test_runner_requires_explicit_command() -> None:
+    command = inspect.signature(ApmLifecycleRunner).parameters["command"]
 
-    result = runner.run(("--help",), cwd=tmp_path, env=os.environ)
-
-    assert result.command == (sys.executable, "-m", "apm_cli.cli", "--help")
-    assert result.returncode == 0
-    assert "Usage: python -m apm_cli.cli [OPTIONS] COMMAND [ARGS]..." in result.stdout
+    assert command.default is inspect.Parameter.empty
 
 
 def test_runner_passes_explicit_cwd_and_environment(tmp_path: Path) -> None:
@@ -129,8 +129,12 @@ def test_run_sequence_enforces_one_scenario_deadline(tmp_path: Path) -> None:
 
 def test_expired_scenario_deadline_reports_context_before_spawn(
     tmp_path: Path,
+    apm_binary_path: Path,
 ) -> None:
-    runner = ApmLifecycleRunner(scenario_timeout_seconds=0)
+    runner = ApmLifecycleRunner(
+        (str(apm_binary_path),),
+        scenario_timeout_seconds=0,
+    )
 
     with pytest.raises(subprocess.TimeoutExpired) as exc_info:
         runner.run_sequence(
@@ -144,7 +148,7 @@ def test_expired_scenario_deadline_reports_context_before_spawn(
     assert str(exc_info.value) == (
         "scenario='already-expired'\n"
         f"cwd={str(tmp_path)!r}\n"
-        "command=('apm', '--help')\n"
+        f"command={(str(apm_binary_path), '--help')!r}\n"
         "budget_seconds=0\n"
         "stdout=''\n"
         "stderr=''"
@@ -248,7 +252,7 @@ def test_run_sequence_stops_at_first_unexpected_result_with_evidence(
 
 
 def test_run_sequence_rejects_misaligned_expectations(tmp_path: Path) -> None:
-    runner = ApmLifecycleRunner()
+    runner = ApmLifecycleRunner(("unused",))
 
     with pytest.raises(ValueError, match="equal length"):
         runner.run_sequence(

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -112,6 +112,18 @@ def _load_windows_stable_path_checker(root: Path) -> ModuleType:
     return module
 
 
+def _load_test_contract_checker(root: Path) -> ModuleType:
+    """Import the single scanner for executable test contract owners."""
+    module_name = "check_test_contract_authorities"
+    script_path = root / "scripts" / f"{module_name}.py"
+    spec = importlib.util.spec_from_file_location(module_name, script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_plural_targets_drive_bundle_filtering(tmp_path: Path) -> None:
     """The canonical manifest target list must control bundle packing."""
     from apm_cli.bundle.packer import pack_bundle
@@ -410,6 +422,19 @@ def test_windows_stable_executable_path_has_one_canonical_owner() -> None:
     assert "check_windows_stable_path_owner.py" in guard
 
     checker = _load_windows_stable_path_checker(root)
+
+    assert checker.check(root) == []
+
+
+def test_executable_test_contracts_have_one_canonical_owner() -> None:
+    """Binary selection and rendered parity must use their canonical helpers."""
+    root = Path(__file__).parents[2]
+    guard = (root / "scripts/lint-architecture-boundaries.sh").read_text()
+
+    assert "Integration binary selection and rendered CLI parity require canonical owners" in guard
+    assert "check_test_contract_authorities.py" in guard
+
+    checker = _load_test_contract_checker(root)
 
     assert checker.check(root) == []
 

--- a/tests/integration/test_audit_dependency_skill_links_e2e.py
+++ b/tests/integration/test_audit_dependency_skill_links_e2e.py
@@ -10,11 +10,7 @@ import pytest
 TIMEOUT = 180
 
 
-def _run(
-    apm_binary_path: Path,
-    cwd: Path,
-    *args: str,
-) -> subprocess.CompletedProcess[str]:
+def _run(apm_binary_path: Path, cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
     """Run the APM CLI in *cwd* and return the completed subprocess."""
     return subprocess.run(
         [str(apm_binary_path), *args],

--- a/tests/integration/test_audit_dependency_skill_links_e2e.py
+++ b/tests/integration/test_audit_dependency_skill_links_e2e.py
@@ -3,19 +3,21 @@
 from __future__ import annotations
 
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
 
-CLI = [sys.executable, "-m", "apm_cli.cli"]
 TIMEOUT = 180
 
 
-def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+def _run(
+    apm_binary_path: Path,
+    cwd: Path,
+    *args: str,
+) -> subprocess.CompletedProcess[str]:
     """Run the APM CLI in *cwd* and return the completed subprocess."""
     return subprocess.run(
-        CLI + list(args),
+        [str(apm_binary_path), *args],
         cwd=str(cwd),
         capture_output=True,
         text=True,
@@ -68,12 +70,13 @@ See [the manifesto](../../../MANIFESTO.md).
 @pytest.mark.integration
 def test_audit_is_clean_after_installing_dependency_skill_with_relative_link(
     tmp_path: Path,
+    apm_binary_path: Path,
 ) -> None:
     """Replay must preserve the install-time dependency path in skill links."""
     project = tmp_path / "project"
     _write_project(project)
 
-    install = _run(project, "install")
+    install = _run(apm_binary_path, project, "install")
     assert install.returncode == 0, (
         f"install stdout:\n{install.stdout}\ninstall stderr:\n{install.stderr}"
     )
@@ -83,5 +86,5 @@ def test_audit_is_clean_after_installing_dependency_skill_with_relative_link(
         encoding="utf-8"
     )
 
-    audit = _run(project, "audit", "--ci", "--no-policy")
+    audit = _run(apm_binary_path, project, "audit", "--ci", "--no-policy")
     assert audit.returncode == 0, f"audit stdout:\n{audit.stdout}\naudit stderr:\n{audit.stderr}"

--- a/tests/integration/test_auto_install_e2e.py
+++ b/tests/integration/test_auto_install_e2e.py
@@ -111,11 +111,7 @@ author: test
                 else:
                     raise
 
-    def test_auto_install_virtual_prompt_first_run(
-        self,
-        temp_e2e_home,
-        apm_binary_path: Path,
-    ):
+    def test_auto_install_virtual_prompt_first_run(self, temp_e2e_home, apm_binary_path: Path):
         """Test auto-install on first run with virtual package reference.
 
         This is the exact README hero scenario:
@@ -137,12 +133,15 @@ author: test
         env["HOME"] = temp_e2e_home
 
         # Run the exact README command with streaming output monitoring
-        process = _start_apm(
-            apm_binary_path,
+        process = subprocess.Popen(
             [
+                str(apm_binary_path),
                 "run",
                 "github/awesome-copilot/skills/architecture-blueprint-generator",
             ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
             cwd=self.test_dir,
             env=env,
         )
@@ -203,11 +202,7 @@ author: test
 
         print(f"[+] Auto-install successful: {package_path}")
 
-    def test_auto_install_uses_cache_on_second_run(
-        self,
-        temp_e2e_home,
-        apm_binary_path: Path,
-    ):
+    def test_auto_install_uses_cache_on_second_run(self, temp_e2e_home, apm_binary_path: Path):
         """Test that second run uses cached package (no re-download).
 
         Expected behavior:
@@ -220,12 +215,15 @@ author: test
         env["HOME"] = temp_e2e_home
 
         # First run - install with early termination
-        process = _start_apm(
-            apm_binary_path,
+        process = subprocess.Popen(
             [
+                str(apm_binary_path),
                 "run",
                 "github/awesome-copilot/skills/architecture-blueprint-generator",
             ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
             cwd=self.test_dir,
             env=env,
         )
@@ -255,12 +253,15 @@ author: test
         assert package_path.exists(), "Package should exist after first run"
 
         # Second run - should use cache with early termination
-        process = _start_apm(
-            apm_binary_path,
+        process = subprocess.Popen(
             [
+                str(apm_binary_path),
                 "run",
                 "github/awesome-copilot/skills/architecture-blueprint-generator",
             ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
             cwd=self.test_dir,
             env=env,
         )
@@ -291,11 +292,7 @@ author: test
 
         print("[+] Second run used cached package (no re-download)")
 
-    def test_simple_name_works_after_install(
-        self,
-        temp_e2e_home,
-        apm_binary_path: Path,
-    ):
+    def test_simple_name_works_after_install(self, temp_e2e_home, apm_binary_path: Path):
         """Test that simple name works after package is installed.
 
         Expected behavior:
@@ -308,12 +305,15 @@ author: test
         env["HOME"] = temp_e2e_home
 
         # First install with full path - early termination
-        process = _start_apm(
-            apm_binary_path,
+        process = subprocess.Popen(
             [
+                str(apm_binary_path),
                 "run",
                 "github/awesome-copilot/skills/architecture-blueprint-generator",
             ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
             cwd=self.test_dir,
             env=env,
         )
@@ -333,9 +333,11 @@ author: test
             process.stdout.close()
 
         # Run with simple name - early termination
-        process = _start_apm(
-            apm_binary_path,
-            ["run", "architecture-blueprint-generator"],
+        process = subprocess.Popen(
+            [str(apm_binary_path), "run", "architecture-blueprint-generator"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
             cwd=self.test_dir,
             env=env,
         )
@@ -365,11 +367,7 @@ author: test
 
         print("[+] Simple name works after installation")
 
-    def test_auto_install_with_qualified_path(
-        self,
-        temp_e2e_home,
-        apm_binary_path: Path,
-    ):
+    def test_auto_install_with_qualified_path(self, temp_e2e_home, apm_binary_path: Path):
         """Test auto-install works with qualified path format.
 
         Tests both formats:
@@ -381,12 +379,15 @@ author: test
         env["HOME"] = temp_e2e_home
 
         # Test with qualified path (without .prompt.md extension) - early termination
-        process = _start_apm(
-            apm_binary_path,
+        process = subprocess.Popen(
             [
+                str(apm_binary_path),
                 "run",
                 "github/awesome-copilot/skills/architecture-blueprint-generator",
             ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
             cwd=self.test_dir,
             env=env,
         )

--- a/tests/integration/test_auto_install_e2e.py
+++ b/tests/integration/test_auto_install_e2e.py
@@ -133,15 +133,12 @@ author: test
         env["HOME"] = temp_e2e_home
 
         # Run the exact README command with streaming output monitoring
-        process = subprocess.Popen(
+        process = _start_apm(
+            apm_binary_path,
             [
-                str(apm_binary_path),
                 "run",
                 "github/awesome-copilot/skills/architecture-blueprint-generator",
             ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
             cwd=self.test_dir,
             env=env,
         )
@@ -215,15 +212,12 @@ author: test
         env["HOME"] = temp_e2e_home
 
         # First run - install with early termination
-        process = subprocess.Popen(
+        process = _start_apm(
+            apm_binary_path,
             [
-                str(apm_binary_path),
                 "run",
                 "github/awesome-copilot/skills/architecture-blueprint-generator",
             ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
             cwd=self.test_dir,
             env=env,
         )
@@ -253,15 +247,12 @@ author: test
         assert package_path.exists(), "Package should exist after first run"
 
         # Second run - should use cache with early termination
-        process = subprocess.Popen(
+        process = _start_apm(
+            apm_binary_path,
             [
-                str(apm_binary_path),
                 "run",
                 "github/awesome-copilot/skills/architecture-blueprint-generator",
             ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
             cwd=self.test_dir,
             env=env,
         )
@@ -305,15 +296,12 @@ author: test
         env["HOME"] = temp_e2e_home
 
         # First install with full path - early termination
-        process = subprocess.Popen(
+        process = _start_apm(
+            apm_binary_path,
             [
-                str(apm_binary_path),
                 "run",
                 "github/awesome-copilot/skills/architecture-blueprint-generator",
             ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
             cwd=self.test_dir,
             env=env,
         )
@@ -333,11 +321,9 @@ author: test
             process.stdout.close()
 
         # Run with simple name - early termination
-        process = subprocess.Popen(
-            [str(apm_binary_path), "run", "architecture-blueprint-generator"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
+        process = _start_apm(
+            apm_binary_path,
+            ["run", "architecture-blueprint-generator"],
             cwd=self.test_dir,
             env=env,
         )
@@ -379,15 +365,12 @@ author: test
         env["HOME"] = temp_e2e_home
 
         # Test with qualified path (without .prompt.md extension) - early termination
-        process = subprocess.Popen(
+        process = _start_apm(
+            apm_binary_path,
             [
-                str(apm_binary_path),
                 "run",
                 "github/awesome-copilot/skills/architecture-blueprint-generator",
             ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
             cwd=self.test_dir,
             env=env,
         )

--- a/tests/integration/test_auto_install_e2e.py
+++ b/tests/integration/test_auto_install_e2e.py
@@ -25,12 +25,31 @@ E2E_MODE = os.environ.get("APM_E2E_TESTS", "").lower() in ("1", "true", "yes")
 
 pytestmark = [
     pytest.mark.requires_e2e_mode,
+    pytest.mark.requires_apm_binary,
     # Mutates os.environ["HOME"]; must be serialized on a single xdist worker.
     # Requires --dist loadgroup in the xdist invocation (the only
     # scheduler that honors xdist_group); without it the marker is
     # silently ignored and tests would race on global env state.
     pytest.mark.xdist_group(name="home_env"),
 ]
+
+
+def _start_apm(
+    apm_binary_path: Path,
+    args: list[str],
+    *,
+    cwd: str,
+    env: dict[str, str],
+) -> subprocess.Popen[str]:
+    """Start the injected APM executable with streaming output."""
+    return subprocess.Popen(
+        [str(apm_binary_path), *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        cwd=cwd,
+        env=env,
+    )
 
 
 @pytest.fixture(scope="module")
@@ -92,7 +111,11 @@ author: test
                 else:
                     raise
 
-    def test_auto_install_virtual_prompt_first_run(self, temp_e2e_home):
+    def test_auto_install_virtual_prompt_first_run(
+        self,
+        temp_e2e_home,
+        apm_binary_path: Path,
+    ):
         """Test auto-install on first run with virtual package reference.
 
         This is the exact README hero scenario:
@@ -114,11 +137,12 @@ author: test
         env["HOME"] = temp_e2e_home
 
         # Run the exact README command with streaming output monitoring
-        process = subprocess.Popen(
-            ["apm", "run", "github/awesome-copilot/skills/architecture-blueprint-generator"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
+        process = _start_apm(
+            apm_binary_path,
+            [
+                "run",
+                "github/awesome-copilot/skills/architecture-blueprint-generator",
+            ],
             cwd=self.test_dir,
             env=env,
         )
@@ -179,7 +203,11 @@ author: test
 
         print(f"[+] Auto-install successful: {package_path}")
 
-    def test_auto_install_uses_cache_on_second_run(self, temp_e2e_home):
+    def test_auto_install_uses_cache_on_second_run(
+        self,
+        temp_e2e_home,
+        apm_binary_path: Path,
+    ):
         """Test that second run uses cached package (no re-download).
 
         Expected behavior:
@@ -192,11 +220,12 @@ author: test
         env["HOME"] = temp_e2e_home
 
         # First run - install with early termination
-        process = subprocess.Popen(
-            ["apm", "run", "github/awesome-copilot/skills/architecture-blueprint-generator"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
+        process = _start_apm(
+            apm_binary_path,
+            [
+                "run",
+                "github/awesome-copilot/skills/architecture-blueprint-generator",
+            ],
             cwd=self.test_dir,
             env=env,
         )
@@ -226,11 +255,12 @@ author: test
         assert package_path.exists(), "Package should exist after first run"
 
         # Second run - should use cache with early termination
-        process = subprocess.Popen(
-            ["apm", "run", "github/awesome-copilot/skills/architecture-blueprint-generator"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
+        process = _start_apm(
+            apm_binary_path,
+            [
+                "run",
+                "github/awesome-copilot/skills/architecture-blueprint-generator",
+            ],
             cwd=self.test_dir,
             env=env,
         )
@@ -261,7 +291,11 @@ author: test
 
         print("[+] Second run used cached package (no re-download)")
 
-    def test_simple_name_works_after_install(self, temp_e2e_home):
+    def test_simple_name_works_after_install(
+        self,
+        temp_e2e_home,
+        apm_binary_path: Path,
+    ):
         """Test that simple name works after package is installed.
 
         Expected behavior:
@@ -274,11 +308,12 @@ author: test
         env["HOME"] = temp_e2e_home
 
         # First install with full path - early termination
-        process = subprocess.Popen(
-            ["apm", "run", "github/awesome-copilot/skills/architecture-blueprint-generator"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
+        process = _start_apm(
+            apm_binary_path,
+            [
+                "run",
+                "github/awesome-copilot/skills/architecture-blueprint-generator",
+            ],
             cwd=self.test_dir,
             env=env,
         )
@@ -298,11 +333,9 @@ author: test
             process.stdout.close()
 
         # Run with simple name - early termination
-        process = subprocess.Popen(
-            ["apm", "run", "architecture-blueprint-generator"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
+        process = _start_apm(
+            apm_binary_path,
+            ["run", "architecture-blueprint-generator"],
             cwd=self.test_dir,
             env=env,
         )
@@ -332,7 +365,11 @@ author: test
 
         print("[+] Simple name works after installation")
 
-    def test_auto_install_with_qualified_path(self, temp_e2e_home):
+    def test_auto_install_with_qualified_path(
+        self,
+        temp_e2e_home,
+        apm_binary_path: Path,
+    ):
         """Test auto-install works with qualified path format.
 
         Tests both formats:
@@ -344,11 +381,12 @@ author: test
         env["HOME"] = temp_e2e_home
 
         # Test with qualified path (without .prompt.md extension) - early termination
-        process = subprocess.Popen(
-            ["apm", "run", "github/awesome-copilot/skills/architecture-blueprint-generator"],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
+        process = _start_apm(
+            apm_binary_path,
+            [
+                "run",
+                "github/awesome-copilot/skills/architecture-blueprint-generator",
+            ],
             cwd=self.test_dir,
             env=env,
         )

--- a/tests/integration/test_cache_lockfile_parity.py
+++ b/tests/integration/test_cache_lockfile_parity.py
@@ -33,11 +33,6 @@ pytestmark = pytest.mark.requires_github_token
 
 
 @pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    return str(apm_binary_path)
-
-
-@pytest.fixture
 def project_with_apm(tmp_path: Path) -> Path:
     """Minimal APM project with one stable APM dep for parity checks."""
     project = tmp_path / "parity-test"
@@ -108,7 +103,7 @@ def _clone_project(template: Path, dest: Path) -> Path:
 
 
 def test_lockfile_byte_identical_across_cache_regimes(
-    apm_command: str,
+    apm_binary_path: str,
     project_with_apm: Path,
     tmp_path: Path,
 ) -> None:
@@ -124,7 +119,7 @@ def test_lockfile_byte_identical_across_cache_regimes(
     # Run A: cold cache
     project_a = _clone_project(project_with_apm, tmp_path / "run-a")
     _run_install(
-        apm_command,
+        apm_binary_path,
         project_a,
         env_overrides={"APM_CACHE_DIR": str(cache_dir), "CI": "1"},
     )
@@ -133,7 +128,7 @@ def test_lockfile_byte_identical_across_cache_regimes(
     # Run B: warm cache (same APM_CACHE_DIR retained, fresh project tree)
     project_b = _clone_project(project_with_apm, tmp_path / "run-b")
     _run_install(
-        apm_command,
+        apm_binary_path,
         project_b,
         env_overrides={"APM_CACHE_DIR": str(cache_dir), "CI": "1"},
     )
@@ -142,7 +137,7 @@ def test_lockfile_byte_identical_across_cache_regimes(
     # Run C: cache disabled (fresh project tree)
     project_c = _clone_project(project_with_apm, tmp_path / "run-c")
     _run_install(
-        apm_command,
+        apm_binary_path,
         project_c,
         env_overrides={"APM_NO_CACHE": "1", "CI": "1"},
     )

--- a/tests/integration/test_cache_lockfile_parity.py
+++ b/tests/integration/test_cache_lockfile_parity.py
@@ -33,14 +33,8 @@ pytestmark = pytest.mark.requires_github_token
 
 
 @pytest.fixture
-def apm_command() -> str:
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    return str(apm_binary_path)
 
 
 @pytest.fixture

--- a/tests/integration/test_cli_docs_contract.py
+++ b/tests/integration/test_cli_docs_contract.py
@@ -1,0 +1,73 @@
+"""Subprocess contracts for the rendered CLI documentation checker."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from apm_cli.cli import cli
+from scripts.check_cli_docs import public_top_level_commands
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECKER = ROOT / "scripts" / "check_cli_docs.py"
+
+
+def _render_page(dist: Path, name: str) -> None:
+    page = dist / "reference" / "cli" / name / "index.html"
+    page.parent.mkdir(parents=True, exist_ok=True)
+    page.write_text("<p>rendered</p>\n", encoding="utf-8")
+
+
+def _render_public_pages(dist: Path, *, omit: set[str] | None = None) -> None:
+    omitted = omit or set()
+    for name in public_top_level_commands(cli) - omitted:
+        _render_page(dist, name)
+
+
+def _run_checker(dist: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER), str(dist)],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_checker_cli_reports_missing_rendered_page_on_stderr(tmp_path: Path) -> None:
+    """A missing page exits 1, names the command, and explains recovery."""
+    _render_public_pages(tmp_path, omit={"doctor"})
+
+    result = _run_checker(tmp_path)
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert "executable commands missing rendered pages: doctor" in result.stderr
+    assert "npm run build" in result.stderr
+    assert "scripts/check_cli_docs.py" in result.stderr
+
+
+def test_checker_cli_reports_orphan_rendered_page_on_stderr(tmp_path: Path) -> None:
+    """An orphan page exits 1, names the route, and explains recovery."""
+    _render_public_pages(tmp_path)
+    _render_page(tmp_path, "not-a-command")
+
+    result = _run_checker(tmp_path)
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert "rendered pages missing executable commands: not-a-command" in result.stderr
+    assert "npm run build" in result.stderr
+    assert "scripts/check_cli_docs.py" in result.stderr
+
+
+def test_checker_cli_reserves_stdout_for_success(tmp_path: Path) -> None:
+    """A matching rendered tree emits only successful evidence on stdout."""
+    _render_public_pages(tmp_path)
+
+    result = _run_checker(tmp_path)
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert "public CLI commands match" in result.stdout

--- a/tests/integration/test_cli_docs_contract.py
+++ b/tests/integration/test_cli_docs_contract.py
@@ -47,8 +47,8 @@ def _run_checker(dist: Path) -> subprocess.CompletedProcess[str]:
 
 def _rerun_guidance(dist: Path) -> str:
     return (
-        "[i] Add or remove the matching CLI reference page, rebuild with "
-        "'npm --prefix docs run build', then rerun "
+        "[i] Add or remove the matching CLI reference page, "
+        f"rebuild the rendered docs at '{dist}', then rerun "
         f"'uv run --frozen python scripts/check_cli_docs.py {dist}'.\n"
     )
 
@@ -93,7 +93,7 @@ def test_checker_cli_reports_missing_rendered_directory_on_stderr(tmp_path: Path
     assert result.stdout == ""
     assert result.stderr == (
         f"[x] rendered CLI directory not found: {cli_dir}\n"
-        "[i] Rebuild docs with 'npm --prefix docs run build', then rerun "
+        f"[i] Rebuild the rendered docs at '{tmp_path}', then rerun "
         f"'uv run --frozen python scripts/check_cli_docs.py {tmp_path}'.\n"
     )
 

--- a/tests/integration/test_cli_docs_contract.py
+++ b/tests/integration/test_cli_docs_contract.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 
 from apm_cli.cli import cli
-from scripts.check_cli_docs import public_top_level_commands
+from scripts.check_cli_docs import registry_docs_mismatches
 
 ROOT = Path(__file__).resolve().parents[2]
 CHECKER = ROOT / "scripts" / "check_cli_docs.py"
@@ -19,10 +19,20 @@ def _render_page(dist: Path, name: str) -> None:
     page.write_text("<p>rendered</p>\n", encoding="utf-8")
 
 
-def _render_public_pages(dist: Path, *, omit: set[str] | None = None) -> None:
+def _public_command_names(dist: Path) -> set[str]:
+    cli_dir = dist / "reference" / "cli"
+    cli_dir.mkdir(parents=True, exist_ok=True)
+    missing, orphan = registry_docs_mismatches(cli, dist)
+    assert orphan == []
+    return set(missing)
+
+
+def _render_public_pages(dist: Path, *, omit: set[str] | None = None) -> set[str]:
     omitted = omit or set()
-    for name in public_top_level_commands(cli) - omitted:
+    public = _public_command_names(dist)
+    for name in public - omitted:
         _render_page(dist, name)
+    return public
 
 
 def _run_checker(dist: Path) -> subprocess.CompletedProcess[str]:
@@ -90,13 +100,13 @@ def test_checker_cli_reports_missing_rendered_directory_on_stderr(tmp_path: Path
 
 def test_checker_cli_reserves_stdout_for_success(tmp_path: Path) -> None:
     """A matching rendered tree emits only successful evidence on stdout."""
-    _render_public_pages(tmp_path)
+    public = _render_public_pages(tmp_path)
 
     result = _run_checker(tmp_path)
 
     assert result.returncode == 0
     assert result.stderr == ""
-    command_count = len(public_top_level_commands(cli))
+    command_count = len(public)
     assert result.stdout == (
         f"[+] {command_count} public CLI commands match {command_count} rendered pages.\n"
     )

--- a/tests/integration/test_cli_docs_contract.py
+++ b/tests/integration/test_cli_docs_contract.py
@@ -35,6 +35,14 @@ def _run_checker(dist: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _rerun_guidance(dist: Path) -> str:
+    return (
+        "[i] Add or remove the matching CLI reference page, rebuild with "
+        "'npm --prefix docs run build', then rerun "
+        f"'uv run --frozen python scripts/check_cli_docs.py {dist}'.\n"
+    )
+
+
 def test_checker_cli_reports_missing_rendered_page_on_stderr(tmp_path: Path) -> None:
     """A missing page exits 1, names the command, and explains recovery."""
     _render_public_pages(tmp_path, omit={"doctor"})
@@ -43,9 +51,11 @@ def test_checker_cli_reports_missing_rendered_page_on_stderr(tmp_path: Path) -> 
 
     assert result.returncode == 1
     assert result.stdout == ""
-    assert "executable commands missing rendered pages: doctor" in result.stderr
-    assert "npm run build" in result.stderr
-    assert "scripts/check_cli_docs.py" in result.stderr
+    assert result.stderr == (
+        "[x] CLI registry/rendered documentation mismatch:\n"
+        "  executable commands missing rendered pages: doctor\n"
+        f"{_rerun_guidance(tmp_path)}"
+    )
 
 
 def test_checker_cli_reports_orphan_rendered_page_on_stderr(tmp_path: Path) -> None:
@@ -57,9 +67,25 @@ def test_checker_cli_reports_orphan_rendered_page_on_stderr(tmp_path: Path) -> N
 
     assert result.returncode == 1
     assert result.stdout == ""
-    assert "rendered pages missing executable commands: not-a-command" in result.stderr
-    assert "npm run build" in result.stderr
-    assert "scripts/check_cli_docs.py" in result.stderr
+    assert result.stderr == (
+        "[x] CLI registry/rendered documentation mismatch:\n"
+        "  rendered pages missing executable commands: not-a-command\n"
+        f"{_rerun_guidance(tmp_path)}"
+    )
+
+
+def test_checker_cli_reports_missing_rendered_directory_on_stderr(tmp_path: Path) -> None:
+    """A missing build tree exits 1 with root-safe build and rerun commands."""
+    result = _run_checker(tmp_path)
+    cli_dir = tmp_path / "reference" / "cli"
+
+    assert result.returncode == 1
+    assert result.stdout == ""
+    assert result.stderr == (
+        f"[x] rendered CLI directory not found: {cli_dir}\n"
+        "[i] Rebuild docs with 'npm --prefix docs run build', then rerun "
+        f"'uv run --frozen python scripts/check_cli_docs.py {tmp_path}'.\n"
+    )
 
 
 def test_checker_cli_reserves_stdout_for_success(tmp_path: Path) -> None:
@@ -70,4 +96,7 @@ def test_checker_cli_reserves_stdout_for_success(tmp_path: Path) -> None:
 
     assert result.returncode == 0
     assert result.stderr == ""
-    assert "public CLI commands match" in result.stdout
+    command_count = len(public_top_level_commands(cli))
+    assert result.stdout == (
+        f"[+] {command_count} public CLI commands match {command_count} rendered pages.\n"
+    )

--- a/tests/integration/test_compile_constitution_injection.py
+++ b/tests/integration/test_compile_constitution_injection.py
@@ -6,11 +6,7 @@ from pathlib import Path
 from ..utils.constitution_fixtures import DEFAULT_CONSTITUTION, temp_project_with_constitution
 
 
-def run_cli(
-    apm_binary_path: Path,
-    cwd: Path,
-    *args: str,
-) -> subprocess.CompletedProcess:
+def run_cli(apm_binary_path: Path, cwd: Path, *args: str) -> subprocess.CompletedProcess:
     return subprocess.run(
         [str(apm_binary_path), "compile", "--single-agents", *args],
         cwd=str(cwd),

--- a/tests/integration/test_compile_constitution_injection.py
+++ b/tests/integration/test_compile_constitution_injection.py
@@ -1,25 +1,31 @@
 from __future__ import annotations
 
 import subprocess
-import sys
 from pathlib import Path
 
 from ..utils.constitution_fixtures import DEFAULT_CONSTITUTION, temp_project_with_constitution
 
-CLI = [sys.executable, "-m", "apm_cli.cli", "compile", "--single-agents"]
 
-
-def run_cli(cwd: Path, *args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(CLI + list(args), cwd=str(cwd), capture_output=True, text=True)
+def run_cli(
+    apm_binary_path: Path,
+    cwd: Path,
+    *args: str,
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [str(apm_binary_path), "compile", "--single-agents", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+    )
 
 
 def read_agents(cwd: Path) -> str:
     return (cwd / "AGENTS.md").read_text(encoding="utf-8")
 
 
-def test_injects_block_when_constitution_present():
+def test_injects_block_when_constitution_present(apm_binary_path: Path):
     with temp_project_with_constitution(constitution_text=DEFAULT_CONSTITUTION) as proj:
-        result = run_cli(proj)
+        result = run_cli(apm_binary_path, proj)
         assert result.returncode == 0, result.stderr
         content = read_agents(proj)
         lines = content.splitlines()
@@ -52,13 +58,13 @@ def test_injects_block_when_constitution_present():
         assert hash_line.startswith("hash:"), "Hash line missing after constitution begin"
 
 
-def test_header_then_block_ordering_idempotent():
+def test_header_then_block_ordering_idempotent(apm_binary_path: Path):
     """Ensure ordering (header -> block -> body) remains stable across runs."""
     with temp_project_with_constitution(constitution_text=DEFAULT_CONSTITUTION) as proj:
-        r1 = run_cli(proj)
+        r1 = run_cli(apm_binary_path, proj)
         assert r1.returncode == 0
         first = read_agents(proj).splitlines()
-        r2 = run_cli(proj)
+        r2 = run_cli(apm_binary_path, proj)
         assert r2.returncode == 0
         second = read_agents(proj).splitlines()
         assert first == second
@@ -74,40 +80,40 @@ def test_header_then_block_ordering_idempotent():
         assert begin_positions[0] > 2, "Constitution block unexpectedly before header metadata"
 
 
-def test_idempotent_when_no_changes():
+def test_idempotent_when_no_changes(apm_binary_path: Path):
     with temp_project_with_constitution(constitution_text=DEFAULT_CONSTITUTION) as proj:
-        r1 = run_cli(proj)
+        r1 = run_cli(apm_binary_path, proj)
         assert r1.returncode == 0
         first = read_agents(proj)
-        r2 = run_cli(proj)
+        r2 = run_cli(apm_binary_path, proj)
         assert r2.returncode == 0
         second = read_agents(proj)
         assert first == second
 
 
-def test_updates_when_constitution_changes():
+def test_updates_when_constitution_changes(apm_binary_path: Path):
     with temp_project_with_constitution(constitution_text=DEFAULT_CONSTITUTION) as proj:
-        run_cli(proj)
+        run_cli(apm_binary_path, proj)
         original = read_agents(proj)
         # Modify constitution
         (proj / ".specify" / "memory" / "constitution.md").write_text(
             DEFAULT_CONSTITUTION + "\nNew Principle X\n", encoding="utf-8"
         )
-        run_cli(proj)
+        run_cli(apm_binary_path, proj)
         updated = read_agents(proj)
         assert original != updated
         assert "New Principle X" in updated
 
 
-def test_skips_with_flag_no_constitution():
+def test_skips_with_flag_no_constitution(apm_binary_path: Path):
     with temp_project_with_constitution(constitution_text=DEFAULT_CONSTITUTION) as proj:
         # First compile to create file with block
-        run_cli(proj)
+        run_cli(apm_binary_path, proj)
         first = read_agents(proj)
         assert "<!-- SPEC-KIT CONSTITUTION: BEGIN -->" in first
 
         # Re-run with skip flag
-        run_cli(proj, "--no-constitution")
+        run_cli(apm_binary_path, proj, "--no-constitution")
         second = read_agents(proj)
 
         # Constitution block should be removed when --no-constitution flag is used
@@ -116,16 +122,16 @@ def test_skips_with_flag_no_constitution():
         assert "# AGENTS.md" in second
 
 
-def test_creates_agents_md_if_missing():
+def test_creates_agents_md_if_missing(apm_binary_path: Path):
     with temp_project_with_constitution(constitution_text=DEFAULT_CONSTITUTION) as proj:
         assert not (proj / "AGENTS.md").exists()
-        run_cli(proj)
+        run_cli(apm_binary_path, proj)
         assert (proj / "AGENTS.md").exists()
 
 
-def test_no_failure_if_constitution_absent():
+def test_no_failure_if_constitution_absent(apm_binary_path: Path):
     with temp_project_with_constitution(constitution_text=None) as proj:
-        result = run_cli(proj)
+        result = run_cli(apm_binary_path, proj)
         # When no constitution and no APM content exist, CLI should exit with error
         assert result.returncode == 1
         # Should not create AGENTS.md

--- a/tests/integration/test_compile_copilot_root_instructions.py
+++ b/tests/integration/test_compile_copilot_root_instructions.py
@@ -20,8 +20,7 @@ def run_cli(apm_binary_path: Path, cwd: Path) -> subprocess.CompletedProcess:
 
 
 def test_compile_emits_copilot_root_instructions_and_is_idempotent(
-    tmp_path: Path,
-    apm_binary_path: Path,
+    tmp_path: Path, apm_binary_path: Path
 ):
     (tmp_path / "apm.yml").write_text("name: test-project\nversion: 0.1.0\n", encoding="utf-8")
     instructions_dir = tmp_path / ".apm" / "instructions"
@@ -49,8 +48,7 @@ def test_compile_emits_copilot_root_instructions_and_is_idempotent(
 
 
 def test_compile_removes_stale_root_file_when_only_scoped_rules_remain(
-    tmp_path: Path,
-    apm_binary_path: Path,
+    tmp_path: Path, apm_binary_path: Path
 ):
     (tmp_path / "apm.yml").write_text("name: test-project\nversion: 0.1.0\n", encoding="utf-8")
     instructions_dir = tmp_path / ".apm" / "instructions"

--- a/tests/integration/test_compile_copilot_root_instructions.py
+++ b/tests/integration/test_compile_copilot_root_instructions.py
@@ -1,17 +1,28 @@
 from __future__ import annotations
 
 import subprocess
-import sys
 from pathlib import Path
 
-CLI = [sys.executable, "-m", "apm_cli.cli", "compile", "--target", "copilot", "--single-agents"]
+
+def run_cli(apm_binary_path: Path, cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            str(apm_binary_path),
+            "compile",
+            "--target",
+            "copilot",
+            "--single-agents",
+        ],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+    )
 
 
-def run_cli(cwd: Path) -> subprocess.CompletedProcess:
-    return subprocess.run(CLI, cwd=str(cwd), capture_output=True, text=True)
-
-
-def test_compile_emits_copilot_root_instructions_and_is_idempotent(tmp_path: Path):
+def test_compile_emits_copilot_root_instructions_and_is_idempotent(
+    tmp_path: Path,
+    apm_binary_path: Path,
+):
     (tmp_path / "apm.yml").write_text("name: test-project\nversion: 0.1.0\n", encoding="utf-8")
     instructions_dir = tmp_path / ".apm" / "instructions"
     instructions_dir.mkdir(parents=True)
@@ -20,7 +31,7 @@ def test_compile_emits_copilot_root_instructions_and_is_idempotent(tmp_path: Pat
         encoding="utf-8",
     )
 
-    first = run_cli(tmp_path)
+    first = run_cli(apm_binary_path, tmp_path)
     assert first.returncode == 0, first.stderr or first.stdout
 
     copilot_root = tmp_path / ".github" / "copilot-instructions.md"
@@ -30,14 +41,17 @@ def test_compile_emits_copilot_root_instructions_and_is_idempotent(tmp_path: Pat
     assert "# Contributing" in first_content
     assert "Run focused tests first." in first_content
 
-    second = run_cli(tmp_path)
+    second = run_cli(apm_binary_path, tmp_path)
     assert second.returncode == 0, second.stderr or second.stdout
     second_content = copilot_root.read_text(encoding="utf-8")
 
     assert first_content == second_content
 
 
-def test_compile_removes_stale_root_file_when_only_scoped_rules_remain(tmp_path: Path):
+def test_compile_removes_stale_root_file_when_only_scoped_rules_remain(
+    tmp_path: Path,
+    apm_binary_path: Path,
+):
     (tmp_path / "apm.yml").write_text("name: test-project\nversion: 0.1.0\n", encoding="utf-8")
     instructions_dir = tmp_path / ".apm" / "instructions"
     instructions_dir.mkdir(parents=True)
@@ -47,7 +61,7 @@ def test_compile_removes_stale_root_file_when_only_scoped_rules_remain(tmp_path:
         "---\ndescription: Contributing guide\n---\n\n# Contributing\n\nRun focused tests first.\n",
         encoding="utf-8",
     )
-    first = run_cli(tmp_path)
+    first = run_cli(apm_binary_path, tmp_path)
     assert first.returncode == 0, first.stderr or first.stdout
 
     copilot_root = tmp_path / ".github" / "copilot-instructions.md"
@@ -57,7 +71,7 @@ def test_compile_removes_stale_root_file_when_only_scoped_rules_remain(tmp_path:
         '---\napplyTo: "**/*.py"\ndescription: Python guide\n---\n\nUse type hints.\n',
         encoding="utf-8",
     )
-    second = run_cli(tmp_path)
+    second = run_cli(apm_binary_path, tmp_path)
     assert second.returncode == 0, second.stderr or second.stdout
 
     assert not copilot_root.exists()

--- a/tests/integration/test_compile_permission_denied.py
+++ b/tests/integration/test_compile_permission_denied.py
@@ -9,13 +9,11 @@ import pytest
 
 from ..utils.constitution_fixtures import DEFAULT_CONSTITUTION, temp_project_with_constitution
 
-CLI = [sys.executable, "-m", "apm_cli.cli", "compile", "--single-agents"]
-
 
 @pytest.mark.skipif(
     sys.platform == "win32", reason="Windows handles read-only directories differently"
 )
-def test_permission_denied_graceful(tmp_path: Path):
+def test_permission_denied_graceful(tmp_path: Path, apm_binary_path: Path):
     # Use temp project with constitution to force write
     with temp_project_with_constitution(constitution_text=DEFAULT_CONSTITUTION) as proj:
         agents = Path(proj) / "AGENTS.md"
@@ -27,7 +25,12 @@ def test_permission_denied_graceful(tmp_path: Path):
         proj_path.chmod(stat.S_IREAD | stat.S_IEXEC)  # read + execute only, no write
 
         try:
-            proc = subprocess.run(CLI, cwd=str(proj), capture_output=True, text=True)
+            proc = subprocess.run(
+                [str(apm_binary_path), "compile", "--single-agents"],
+                cwd=str(proj),
+                capture_output=True,
+                text=True,
+            )
             # Expect non-zero exit due to write failure
             assert proc.returncode != 0
             combined = proc.stdout + proc.stderr

--- a/tests/integration/test_compile_root_redirect_e2e.py
+++ b/tests/integration/test_compile_root_redirect_e2e.py
@@ -22,10 +22,7 @@ Two invariants are load-bearing:
 from __future__ import annotations
 
 import subprocess
-import sys
 from pathlib import Path
-
-_COMPILE = [sys.executable, "-m", "apm_cli.cli", "compile"]
 
 
 def _make_project(root: Path) -> None:
@@ -39,19 +36,29 @@ def _make_project(root: Path) -> None:
     )
 
 
-def _run(args: list[str], cwd: Path) -> subprocess.CompletedProcess:
-    return subprocess.run([*_COMPILE, *args], cwd=str(cwd), capture_output=True, text=True)
+def _run(
+    apm_binary_path: Path,
+    args: list[str],
+    cwd: Path,
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [str(apm_binary_path), "compile", *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+    )
 
 
 def test_root_redirect_is_byte_identical_and_keeps_sources_in_pwd(
     tmp_path: Path,
+    apm_binary_path: Path,
 ) -> None:
     src = tmp_path / "src"
     src.mkdir()
     _make_project(src)
 
     # Baseline: plain compile writes AGENTS.md into the source tree.
-    baseline = _run([], cwd=src)
+    baseline = _run(apm_binary_path, [], cwd=src)
     assert baseline.returncode == 0, baseline.stderr or baseline.stdout
     baseline_agents = src / "AGENTS.md"
     assert baseline_agents.exists(), "baseline compile did not emit AGENTS.md"
@@ -61,7 +68,7 @@ def test_root_redirect_is_byte_identical_and_keeps_sources_in_pwd(
     # --root: sources still read from ``src`` ($PWD), writes land in deploy.
     deploy = tmp_path / "deploy"
     deploy.mkdir()
-    redirected = _run(["--root", str(deploy)], cwd=src)
+    redirected = _run(apm_binary_path, ["--root", str(deploy)], cwd=src)
     assert redirected.returncode == 0, redirected.stderr or redirected.stdout
 
     # Source tree stays clean -- no artifact leaked back into $PWD.
@@ -76,7 +83,10 @@ def test_root_redirect_is_byte_identical_and_keeps_sources_in_pwd(
     )
 
 
-def test_root_override_does_not_leak_into_next_invocation(tmp_path: Path) -> None:
+def test_root_override_does_not_leak_into_next_invocation(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
     src = tmp_path / "src"
     src.mkdir()
     _make_project(src)
@@ -84,7 +94,7 @@ def test_root_override_does_not_leak_into_next_invocation(tmp_path: Path) -> Non
     deploy = tmp_path / "deploy"
     deploy.mkdir()
 
-    first = _run(["--root", str(deploy)], cwd=src)
+    first = _run(apm_binary_path, ["--root", str(deploy)], cwd=src)
     assert first.returncode == 0, first.stderr or first.stdout
     assert (deploy / "AGENTS.md").exists()
     assert not (src / "AGENTS.md").exists()
@@ -92,7 +102,7 @@ def test_root_override_does_not_leak_into_next_invocation(tmp_path: Path) -> Non
     # A subsequent plain compile (separate process, but the override is a
     # process-global so this also guards the in-process unwind contract)
     # must once again write into $PWD, not the previous deploy root.
-    second = _run([], cwd=src)
+    second = _run(apm_binary_path, [], cwd=src)
     assert second.returncode == 0, second.stderr or second.stdout
     assert (src / "AGENTS.md").exists(), (
         "plain compile after --root failed to write into $PWD -- "

--- a/tests/integration/test_compile_root_redirect_e2e.py
+++ b/tests/integration/test_compile_root_redirect_e2e.py
@@ -36,11 +36,7 @@ def _make_project(root: Path) -> None:
     )
 
 
-def _run(
-    apm_binary_path: Path,
-    args: list[str],
-    cwd: Path,
-) -> subprocess.CompletedProcess:
+def _run(apm_binary_path: Path, args: list[str], cwd: Path) -> subprocess.CompletedProcess:
     return subprocess.run(
         [str(apm_binary_path), "compile", *args],
         cwd=str(cwd),
@@ -50,8 +46,7 @@ def _run(
 
 
 def test_root_redirect_is_byte_identical_and_keeps_sources_in_pwd(
-    tmp_path: Path,
-    apm_binary_path: Path,
+    tmp_path: Path, apm_binary_path: Path
 ) -> None:
     src = tmp_path / "src"
     src.mkdir()
@@ -84,8 +79,7 @@ def test_root_redirect_is_byte_identical_and_keeps_sources_in_pwd(
 
 
 def test_root_override_does_not_leak_into_next_invocation(
-    tmp_path: Path,
-    apm_binary_path: Path,
+    tmp_path: Path, apm_binary_path: Path
 ) -> None:
     src = tmp_path / "src"
     src.mkdir()

--- a/tests/integration/test_core_smoke.py
+++ b/tests/integration/test_core_smoke.py
@@ -41,6 +41,7 @@ Markers
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
@@ -122,6 +123,11 @@ class TestBinaryStartup:
         smoke or integration check would also fail; failing fast
         here saves merge-queue minutes.
         """
+        configured_path = os.environ.get("APM_BINARY_PATH")
+        if configured_path:
+            assert apm_binary_path == Path(configured_path).resolve(), (
+                "APM_BINARY_PATH must select the exact generated artifact"
+            )
         result = _run_apm(apm_binary_path, ["--version"], cwd=tmp_path)
         assert result.returncode == 0, (
             f"apm --version failed (rc={result.returncode})\nstderr:\n{result.stderr}"

--- a/tests/integration/test_core_smoke.py
+++ b/tests/integration/test_core_smoke.py
@@ -41,7 +41,6 @@ Markers
 
 from __future__ import annotations
 
-import os
 import subprocess
 from pathlib import Path
 
@@ -123,11 +122,6 @@ class TestBinaryStartup:
         smoke or integration check would also fail; failing fast
         here saves merge-queue minutes.
         """
-        configured_path = os.environ.get("APM_BINARY_PATH")
-        if configured_path:
-            assert apm_binary_path == Path(configured_path).resolve(), (
-                "APM_BINARY_PATH must select the exact generated artifact"
-            )
         result = _run_apm(apm_binary_path, ["--version"], cwd=tmp_path)
         assert result.returncode == 0, (
             f"apm --version failed (rc={result.returncode})\nstderr:\n{result.stderr}"

--- a/tests/integration/test_cursor_mcp_schema_fidelity.py
+++ b/tests/integration/test_cursor_mcp_schema_fidelity.py
@@ -12,7 +12,6 @@ Regression guard for #844.
 
 import json
 import os
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -21,14 +20,8 @@ import yaml
 
 
 @pytest.fixture
-def apm_command():
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    return str(apm_binary_path)
 
 
 def _write_apm_yml(project_dir: Path, mcp_servers: list[dict]) -> None:

--- a/tests/integration/test_cursor_mcp_schema_fidelity.py
+++ b/tests/integration/test_cursor_mcp_schema_fidelity.py
@@ -19,11 +19,6 @@ import pytest
 import yaml
 
 
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    return str(apm_binary_path)
-
-
 def _write_apm_yml(project_dir: Path, mcp_servers: list[dict]) -> None:
     config = {
         "name": "cursor-schema-fidelity-e2e",
@@ -51,7 +46,7 @@ def _assert_no_copilot_fields(server_config: dict, label: str) -> None:
 class TestCursorStdioSchemaFidelity:
     """Verify stdio MCP servers produce Cursor-native schema on disk."""
 
-    def test_stdio_server_emits_type_stdio(self, tmp_path, apm_command):
+    def test_stdio_server_emits_type_stdio(self, tmp_path, apm_binary_path):
         project_dir = tmp_path / "project"
         project_dir.mkdir()
         (project_dir / ".cursor").mkdir()
@@ -76,7 +71,7 @@ class TestCursorStdioSchemaFidelity:
         env["MY_VAR"] = "my-value"
 
         result = subprocess.run(
-            [apm_command, "install", "--target", "cursor"],
+            [apm_binary_path, "install", "--target", "cursor"],
             cwd=project_dir,
             env=env,
             capture_output=True,
@@ -108,7 +103,7 @@ class TestCursorStdioSchemaFidelity:
 class TestCursorHttpSchemaFidelity:
     """Verify HTTP MCP servers produce Cursor-native schema on disk."""
 
-    def test_http_server_emits_type_http(self, tmp_path, apm_command):
+    def test_http_server_emits_type_http(self, tmp_path, apm_binary_path):
         project_dir = tmp_path / "project"
         project_dir.mkdir()
         (project_dir / ".cursor").mkdir()
@@ -131,7 +126,7 @@ class TestCursorHttpSchemaFidelity:
         env["APM_NON_INTERACTIVE"] = "1"
 
         result = subprocess.run(
-            [apm_command, "install", "--target", "cursor"],
+            [apm_binary_path, "install", "--target", "cursor"],
             cwd=project_dir,
             env=env,
             capture_output=True,

--- a/tests/integration/test_deployed_files_e2e.py
+++ b/tests/integration/test_deployed_files_e2e.py
@@ -14,19 +14,12 @@ Requires network access and GITHUB_TOKEN/GITHUB_APM_PAT for GitHub API.
 
 import json  # noqa: F401
 import subprocess
-from pathlib import Path
 
 import pytest
 import yaml
 
 # Skip all tests if no GitHub token is available
 pytestmark = pytest.mark.requires_github_token
-
-
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
 
 
 @pytest.fixture
@@ -53,10 +46,10 @@ def temp_project(tmp_path):
     return project_dir
 
 
-def _run_apm(apm_command, args, cwd, timeout=120):
+def _run_apm(apm_binary_path, args, cwd, timeout=120):
     """Run an apm CLI command and return the result."""
     return subprocess.run(
-        [apm_command] + args,  # noqa: RUF005
+        [apm_binary_path] + args,  # noqa: RUF005
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -98,9 +91,11 @@ def _get_locked_dep(lockfile, key):
 class TestCleanFilenames:
     """Verify installed files use clean names (no -apm suffix)."""
 
-    def test_prompts_have_clean_names(self, temp_project, apm_command):
+    def test_prompts_have_clean_names(self, temp_project, apm_binary_path):
         """Prompts should be deployed without -apm suffix."""
-        result = _run_apm(apm_command, ["install", "microsoft/apm-sample-package"], temp_project)
+        result = _run_apm(
+            apm_binary_path, ["install", "microsoft/apm-sample-package"], temp_project
+        )
         assert result.returncode == 0, f"Install failed: {result.stderr}\n{result.stdout}"
 
         prompts_dir = temp_project / ".github" / "prompts"
@@ -109,9 +104,11 @@ class TestCleanFilenames:
             for f in prompt_files:
                 assert "-apm.prompt.md" not in f.name, f"Prompt {f.name} still uses -apm suffix"
 
-    def test_agents_have_clean_names(self, temp_project, apm_command):
+    def test_agents_have_clean_names(self, temp_project, apm_binary_path):
         """Agents should be deployed without -apm suffix."""
-        result = _run_apm(apm_command, ["install", "microsoft/apm-sample-package"], temp_project)
+        result = _run_apm(
+            apm_binary_path, ["install", "microsoft/apm-sample-package"], temp_project
+        )
         assert result.returncode == 0, f"Install failed: {result.stderr}\n{result.stdout}"
 
         agents_dir = temp_project / ".github" / "agents"
@@ -129,9 +126,11 @@ class TestCleanFilenames:
 class TestDeployedFilesInLockfile:
     """Verify deployed_files are recorded in apm.lock after install."""
 
-    def test_lockfile_has_deployed_files_after_install(self, temp_project, apm_command):
+    def test_lockfile_has_deployed_files_after_install(self, temp_project, apm_binary_path):
         """apm.lock should contain deployed_files for each installed package."""
-        result = _run_apm(apm_command, ["install", "microsoft/apm-sample-package"], temp_project)
+        result = _run_apm(
+            apm_binary_path, ["install", "microsoft/apm-sample-package"], temp_project
+        )
         assert result.returncode == 0, f"Install failed: {result.stderr}\n{result.stdout}"
 
         lockfile = _read_lockfile(temp_project)
@@ -142,9 +141,11 @@ class TestDeployedFilesInLockfile:
         assert "deployed_files" in dep, "deployed_files key missing from lockfile entry"
         assert len(dep["deployed_files"]) > 0, "deployed_files list is empty"
 
-    def test_deployed_files_point_to_existing_files(self, temp_project, apm_command):
+    def test_deployed_files_point_to_existing_files(self, temp_project, apm_binary_path):
         """Every path in deployed_files should exist on disk after install."""
-        result = _run_apm(apm_command, ["install", "microsoft/apm-sample-package"], temp_project)
+        result = _run_apm(
+            apm_binary_path, ["install", "microsoft/apm-sample-package"], temp_project
+        )
         assert result.returncode == 0, f"Install failed: {result.stderr}\n{result.stdout}"
 
         lockfile = _read_lockfile(temp_project)
@@ -155,7 +156,7 @@ class TestDeployedFilesInLockfile:
             full_path = temp_project / rel_path
             assert full_path.exists(), f"Deployed file {rel_path} does not exist on disk"
 
-    def test_deployed_files_are_under_known_target_roots(self, temp_project, apm_command):
+    def test_deployed_files_are_under_known_target_roots(self, temp_project, apm_binary_path):
         """deployed_files must land under one of the known target roots.
 
         Plugin-style packages whose primitives include skills also deploy a
@@ -165,7 +166,9 @@ class TestDeployedFilesInLockfile:
         so the assertion must allow ``.agents/`` alongside ``.github/``
         and ``.claude/``.
         """
-        result = _run_apm(apm_command, ["install", "microsoft/apm-sample-package"], temp_project)
+        result = _run_apm(
+            apm_binary_path, ["install", "microsoft/apm-sample-package"], temp_project
+        )
         assert result.returncode == 0, f"Install failed: {result.stderr}\n{result.stdout}"
 
         lockfile = _read_lockfile(temp_project)
@@ -178,9 +181,11 @@ class TestDeployedFilesInLockfile:
                 f"Deployed file {rel_path} is not under any of {allowed_roots}"
             )
 
-    def test_deployed_files_have_clean_names_in_lockfile(self, temp_project, apm_command):
+    def test_deployed_files_have_clean_names_in_lockfile(self, temp_project, apm_binary_path):
         """deployed_files paths in lockfile should use clean names (no -apm suffix)."""
-        result = _run_apm(apm_command, ["install", "microsoft/apm-sample-package"], temp_project)
+        result = _run_apm(
+            apm_binary_path, ["install", "microsoft/apm-sample-package"], temp_project
+        )
         assert result.returncode == 0, f"Install failed: {result.stderr}\n{result.stdout}"
 
         lockfile = _read_lockfile(temp_project)
@@ -190,10 +195,10 @@ class TestDeployedFilesInLockfile:
         for rel_path in dep["deployed_files"]:
             assert "-apm." not in rel_path, f"Deployed file path {rel_path} still uses -apm suffix"
 
-    def test_skill_deployed_files_tracked(self, temp_project, apm_command):
+    def test_skill_deployed_files_tracked(self, temp_project, apm_binary_path):
         """Skill packages should have deployed_files entries for .agents/skills/."""
         result = _run_apm(
-            apm_command,
+            apm_binary_path,
             ["install", "anthropics/skills/skills/brand-guidelines"],
             temp_project,
         )
@@ -232,10 +237,12 @@ class TestDeployedFilesInLockfile:
 class TestCollisionDetection:
     """Test that user-authored files are not overwritten on re-install."""
 
-    def test_user_file_not_overwritten_on_reinstall(self, temp_project, apm_command):
+    def test_user_file_not_overwritten_on_reinstall(self, temp_project, apm_binary_path):
         """Pre-existing user-authored file should be preserved on re-install."""
         # First install to get the package
-        result = _run_apm(apm_command, ["install", "microsoft/apm-sample-package"], temp_project)
+        result = _run_apm(
+            apm_binary_path, ["install", "microsoft/apm-sample-package"], temp_project
+        )
         assert result.returncode == 0, f"First install failed: {result.stderr}\n{result.stdout}"
 
         # Find a deployed prompt file
@@ -259,7 +266,9 @@ class TestCollisionDetection:
         target_file.write_text(user_content)
 
         # Re-install (should detect collision and skip)
-        result2 = _run_apm(apm_command, ["install", "microsoft/apm-sample-package"], temp_project)
+        result2 = _run_apm(
+            apm_binary_path, ["install", "microsoft/apm-sample-package"], temp_project
+        )
         assert result2.returncode == 0, f"Re-install failed: {result2.stderr}\n{result2.stdout}"
 
         # User content should be preserved
@@ -267,10 +276,12 @@ class TestCollisionDetection:
             "User-authored file was overwritten during re-install"
         )
 
-    def test_force_flag_overwrites_collision(self, temp_project, apm_command):
+    def test_force_flag_overwrites_collision(self, temp_project, apm_binary_path):
         """--force should overwrite even user-authored files."""
         # First install
-        result = _run_apm(apm_command, ["install", "microsoft/apm-sample-package"], temp_project)
+        result = _run_apm(
+            apm_binary_path, ["install", "microsoft/apm-sample-package"], temp_project
+        )
         assert result.returncode == 0
 
         prompts_dir = temp_project / ".github" / "prompts"
@@ -292,7 +303,7 @@ class TestCollisionDetection:
 
         # Re-install with --force
         result2 = _run_apm(
-            apm_command,
+            apm_binary_path,
             ["install", "microsoft/apm-sample-package", "--force"],
             temp_project,
         )
@@ -312,10 +323,12 @@ class TestCollisionDetection:
 class TestReinstallPreservesManifest:
     """Verify that re-install updates deployed_files correctly."""
 
-    def test_reinstall_same_package_updates_lockfile(self, temp_project, apm_command):
+    def test_reinstall_same_package_updates_lockfile(self, temp_project, apm_binary_path):
         """Re-installing the same package should keep deployed_files in lockfile."""
         # First install
-        result1 = _run_apm(apm_command, ["install", "microsoft/apm-sample-package"], temp_project)
+        result1 = _run_apm(
+            apm_binary_path, ["install", "microsoft/apm-sample-package"], temp_project
+        )
         assert result1.returncode == 0
 
         lockfile1 = _read_lockfile(temp_project)
@@ -323,7 +336,7 @@ class TestReinstallPreservesManifest:
         files1 = dep1.get("deployed_files", []) if dep1 else []
 
         # Second install
-        result2 = _run_apm(apm_command, ["install"], temp_project)
+        result2 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result2.returncode == 0
 
         lockfile2 = _read_lockfile(temp_project)
@@ -344,10 +357,12 @@ class TestReinstallPreservesManifest:
 class TestPruneDeployedFiles:
     """Verify that prune removes deployed files for pruned packages."""
 
-    def test_prune_removes_deployed_files(self, temp_project, apm_command):
+    def test_prune_removes_deployed_files(self, temp_project, apm_binary_path):
         """After removing a package from apm.yml and pruning, deployed files should be cleaned."""
         # Install a package
-        result = _run_apm(apm_command, ["install", "microsoft/apm-sample-package"], temp_project)
+        result = _run_apm(
+            apm_binary_path, ["install", "microsoft/apm-sample-package"], temp_project
+        )
         assert result.returncode == 0, f"Install failed: {result.stderr}\n{result.stdout}"
 
         # Read deployed files before prune
@@ -372,7 +387,7 @@ class TestPruneDeployedFiles:
         )
 
         # Run prune
-        result2 = _run_apm(apm_command, ["prune"], temp_project)
+        result2 = _run_apm(apm_binary_path, ["prune"], temp_project)
         assert result2.returncode == 0, f"Prune failed: {result2.stderr}\n{result2.stdout}"
 
         # Verify deployed files were cleaned up
@@ -380,10 +395,12 @@ class TestPruneDeployedFiles:
             full_path = temp_project / rel_path
             assert not full_path.exists(), f"Deployed file {rel_path} was not cleaned up by prune"
 
-    def test_prune_removes_package_from_lockfile(self, temp_project, apm_command):
+    def test_prune_removes_package_from_lockfile(self, temp_project, apm_binary_path):
         """After prune, the pruned package should not be in apm.lock."""
         # Install
-        result = _run_apm(apm_command, ["install", "microsoft/apm-sample-package"], temp_project)
+        result = _run_apm(
+            apm_binary_path, ["install", "microsoft/apm-sample-package"], temp_project
+        )
         assert result.returncode == 0
 
         # Remove from apm.yml
@@ -391,7 +408,7 @@ class TestPruneDeployedFiles:
         apm_yml.write_text("name: deployed-files-test\nversion: 1.0.0\ndependencies:\n  apm: []\n")
 
         # Prune
-        result2 = _run_apm(apm_command, ["prune"], temp_project)
+        result2 = _run_apm(apm_binary_path, ["prune"], temp_project)
         assert result2.returncode == 0
 
         # Lockfile should not have the pruned package
@@ -409,10 +426,12 @@ class TestPruneDeployedFiles:
 class TestUninstallDeployedFiles:
     """Verify that uninstall removes deployed files for the package."""
 
-    def test_uninstall_removes_deployed_files(self, temp_project, apm_command):
+    def test_uninstall_removes_deployed_files(self, temp_project, apm_binary_path):
         """Uninstalling a package should clean up its deployed files."""
         # Install
-        result = _run_apm(apm_command, ["install", "microsoft/apm-sample-package"], temp_project)
+        result = _run_apm(
+            apm_binary_path, ["install", "microsoft/apm-sample-package"], temp_project
+        )
         assert result.returncode == 0, f"Install failed: {result.stderr}\n{result.stdout}"
 
         # Record deployed files
@@ -425,7 +444,9 @@ class TestUninstallDeployedFiles:
         existing_before = [f for f in deployed if (temp_project / f).exists()]
 
         # Uninstall
-        result2 = _run_apm(apm_command, ["uninstall", "microsoft/apm-sample-package"], temp_project)
+        result2 = _run_apm(
+            apm_binary_path, ["uninstall", "microsoft/apm-sample-package"], temp_project
+        )
         assert result2.returncode == 0, f"Uninstall failed: {result2.stderr}\n{result2.stdout}"
 
         # Deployed files should be cleaned
@@ -435,17 +456,21 @@ class TestUninstallDeployedFiles:
                 f"Deployed file {rel_path} was not cleaned up by uninstall"
             )
 
-    def test_uninstall_removes_package_dir(self, temp_project, apm_command):
+    def test_uninstall_removes_package_dir(self, temp_project, apm_binary_path):
         """Uninstalling should remove the package from apm_modules/."""
         # Install
-        result = _run_apm(apm_command, ["install", "microsoft/apm-sample-package"], temp_project)
+        result = _run_apm(
+            apm_binary_path, ["install", "microsoft/apm-sample-package"], temp_project
+        )
         assert result.returncode == 0
 
         pkg_dir = temp_project / "apm_modules" / "microsoft" / "apm-sample-package"
         assert pkg_dir.exists(), "Package not installed"
 
         # Uninstall
-        result2 = _run_apm(apm_command, ["uninstall", "microsoft/apm-sample-package"], temp_project)
+        result2 = _run_apm(
+            apm_binary_path, ["uninstall", "microsoft/apm-sample-package"], temp_project
+        )
         assert result2.returncode == 0
 
         assert not pkg_dir.exists(), "Package dir not removed after uninstall"

--- a/tests/integration/test_deployed_files_e2e.py
+++ b/tests/integration/test_deployed_files_e2e.py
@@ -13,7 +13,6 @@ Requires network access and GITHUB_TOKEN/GITHUB_APM_PAT for GitHub API.
 """
 
 import json  # noqa: F401
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -25,15 +24,9 @@ pytestmark = pytest.mark.requires_github_token
 
 
 @pytest.fixture
-def apm_command():
-    """Get the path to the APM CLI executable."""
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 @pytest.fixture

--- a/tests/integration/test_deps_update_e2e.py
+++ b/tests/integration/test_deps_update_e2e.py
@@ -15,7 +15,6 @@ Uses real packages from GitHub:
 """
 
 import os
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -33,15 +32,9 @@ NEWER_REF = "main"
 
 
 @pytest.fixture
-def apm_command():
-    """Get the path to the APM CLI executable."""
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 @pytest.fixture

--- a/tests/integration/test_deps_update_e2e.py
+++ b/tests/integration/test_deps_update_e2e.py
@@ -16,7 +16,6 @@ Uses real packages from GitHub:
 
 import os
 import subprocess
-from pathlib import Path
 
 import pytest
 import yaml
@@ -29,12 +28,6 @@ SAMPLE_GIT_URL = "https://github.com/microsoft/apm-sample-package.git"
 # Initial commit of microsoft/apm-sample-package (older than current main).
 OLD_SHA = "318a8439"
 NEWER_REF = "main"
-
-
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
 
 
 @pytest.fixture
@@ -65,10 +58,10 @@ def _env_with_home(fake_home):
     return env
 
 
-def _run_apm(apm_command, args, cwd, env=None, timeout=180):
+def _run_apm(apm_binary_path, args, cwd, env=None, timeout=180):
     """Run an apm CLI command and return the result."""
     return subprocess.run(
-        [apm_command] + args,  # noqa: RUF005
+        [apm_binary_path] + args,  # noqa: RUF005
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -116,11 +109,11 @@ def _get_locked_dep(lockfile, repo_url):
 # ---------------------------------------------------------------------------
 
 
-def test_deps_update_all_packages_bumps_lockfile_sha(temp_project, apm_command):
+def test_deps_update_all_packages_bumps_lockfile_sha(temp_project, apm_binary_path):
     """`apm deps update` (no args) re-resolves refs and bumps the lockfile SHA."""
     # Step 1: install pinned to an older commit SHA.
     _write_apm_yml(temp_project, [{"git": SAMPLE_GIT_URL, "ref": OLD_SHA}])
-    result1 = _run_apm(apm_command, ["install"], temp_project)
+    result1 = _run_apm(apm_binary_path, ["install"], temp_project)
     assert result1.returncode == 0, (
         f"Initial install failed:\nSTDOUT: {result1.stdout}\nSTDERR: {result1.stderr}"
     )
@@ -136,7 +129,7 @@ def test_deps_update_all_packages_bumps_lockfile_sha(temp_project, apm_command):
     _write_apm_yml(temp_project, [{"git": SAMPLE_GIT_URL, "ref": NEWER_REF}])
 
     # Step 3: run `apm deps update` with no positional args.
-    result2 = _run_apm(apm_command, ["deps", "update"], temp_project)
+    result2 = _run_apm(apm_binary_path, ["deps", "update"], temp_project)
     assert result2.returncode == 0, (
         f"deps update failed:\nSTDOUT: {result2.stdout}\nSTDERR: {result2.stderr}"
     )
@@ -163,7 +156,7 @@ def test_deps_update_all_packages_bumps_lockfile_sha(temp_project, apm_command):
 # ---------------------------------------------------------------------------
 
 
-def test_deps_update_single_package_selective(temp_project, apm_command):
+def test_deps_update_single_package_selective(temp_project, apm_binary_path):
     """`apm deps update <pkg>` should accept the selective filter and succeed.
 
     With two packages installed, requesting an update for one must succeed and
@@ -176,7 +169,7 @@ def test_deps_update_single_package_selective(temp_project, apm_command):
             "github/awesome-copilot/skills/aspire",
         ],
     )
-    result1 = _run_apm(apm_command, ["install"], temp_project)
+    result1 = _run_apm(apm_binary_path, ["install"], temp_project)
     assert result1.returncode == 0, (
         f"Initial install failed:\nSTDOUT: {result1.stdout}\nSTDERR: {result1.stderr}"
     )
@@ -195,7 +188,7 @@ def test_deps_update_single_package_selective(temp_project, apm_command):
     )
 
     result2 = _run_apm(
-        apm_command,
+        apm_binary_path,
         ["deps", "update", SAMPLE_REPO_URL],
         temp_project,
     )
@@ -218,7 +211,7 @@ def test_deps_update_single_package_selective(temp_project, apm_command):
 # ---------------------------------------------------------------------------
 
 
-def test_deps_update_global_user_scope(tmp_path, fake_home, apm_command):
+def test_deps_update_global_user_scope(tmp_path, fake_home, apm_binary_path):
     """`apm deps update -g` must update ~/.apm/apm.lock.yaml, not cwd lockfile.
 
     Regression guard: a historical bug deployed silently to the project even
@@ -255,7 +248,7 @@ def test_deps_update_global_user_scope(tmp_path, fake_home, apm_command):
     work_dir.mkdir()
 
     # Step 1: install -g to populate ~/.apm/apm.lock.yaml.
-    result1 = _run_apm(apm_command, ["install", "-g"], work_dir, env=env)
+    result1 = _run_apm(apm_binary_path, ["install", "-g"], work_dir, env=env)
     assert result1.returncode == 0, (
         f"Global install failed:\nSTDOUT: {result1.stdout}\nSTDERR: {result1.stderr}"
     )
@@ -270,7 +263,7 @@ def test_deps_update_global_user_scope(tmp_path, fake_home, apm_command):
     _write_user_manifest(NEWER_REF)
 
     # Step 3: run `apm deps update -g` from a directory with no project.
-    result2 = _run_apm(apm_command, ["deps", "update", "-g"], work_dir, env=env)
+    result2 = _run_apm(apm_binary_path, ["deps", "update", "-g"], work_dir, env=env)
     assert result2.returncode == 0, (
         f"deps update -g failed:\nSTDOUT: {result2.stdout}\nSTDERR: {result2.stderr}"
     )
@@ -300,16 +293,16 @@ def test_deps_update_global_user_scope(tmp_path, fake_home, apm_command):
 # ---------------------------------------------------------------------------
 
 
-def test_deps_update_unknown_package_errors(temp_project, apm_command):
+def test_deps_update_unknown_package_errors(temp_project, apm_binary_path):
     """`apm deps update <unknown>` should exit non-zero with a helpful error."""
     _write_apm_yml(temp_project, [SAMPLE_REPO_URL])
-    result_install = _run_apm(apm_command, ["install"], temp_project)
+    result_install = _run_apm(apm_binary_path, ["install"], temp_project)
     assert result_install.returncode == 0, (
         f"Initial install failed:\nSTDOUT: {result_install.stdout}\nSTDERR: {result_install.stderr}"
     )
 
     result = _run_apm(
-        apm_command,
+        apm_binary_path,
         ["deps", "update", "some/nonexistent-package"],
         temp_project,
     )

--- a/tests/integration/test_dev_dependency_orphan_e2e.py
+++ b/tests/integration/test_dev_dependency_orphan_e2e.py
@@ -13,11 +13,7 @@ from apm_cli.deps.lockfile import LockFile
 TIMEOUT = 180
 
 
-def _run(
-    apm_binary_path: Path,
-    cwd: Path,
-    *args: str,
-) -> subprocess.CompletedProcess[str]:
+def _run(apm_binary_path: Path, cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
     """Run the APM CLI in *cwd* and return the completed subprocess."""
     return subprocess.run(
         [str(apm_binary_path), *args],
@@ -30,10 +26,7 @@ def _run(
 
 
 @pytest.mark.integration
-def test_dev_dependency_survives_audit_and_prune(
-    tmp_path: Path,
-    apm_binary_path: Path,
-) -> None:
+def test_dev_dependency_survives_audit_and_prune(tmp_path: Path, apm_binary_path: Path) -> None:
     """A clean install must not classify its dev dependency as orphaned."""
     package = tmp_path / "dev-package"
     package.mkdir()

--- a/tests/integration/test_dev_dependency_orphan_e2e.py
+++ b/tests/integration/test_dev_dependency_orphan_e2e.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
@@ -11,14 +10,17 @@ import yaml
 
 from apm_cli.deps.lockfile import LockFile
 
-CLI = [sys.executable, "-m", "apm_cli.cli"]
 TIMEOUT = 180
 
 
-def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+def _run(
+    apm_binary_path: Path,
+    cwd: Path,
+    *args: str,
+) -> subprocess.CompletedProcess[str]:
     """Run the APM CLI in *cwd* and return the completed subprocess."""
     return subprocess.run(
-        CLI + list(args),
+        [str(apm_binary_path), *args],
         cwd=str(cwd),
         capture_output=True,
         text=True,
@@ -28,7 +30,10 @@ def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
 
 
 @pytest.mark.integration
-def test_dev_dependency_survives_audit_and_prune(tmp_path: Path) -> None:
+def test_dev_dependency_survives_audit_and_prune(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
     """A clean install must not classify its dev dependency as orphaned."""
     package = tmp_path / "dev-package"
     package.mkdir()
@@ -51,7 +56,7 @@ def test_dev_dependency_survives_audit_and_prune(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    install = _run(project, "install")
+    install = _run(apm_binary_path, project, "install")
     assert install.returncode == 0, (
         f"install stdout:\n{install.stdout}\ninstall stderr:\n{install.stderr}"
     )
@@ -64,10 +69,10 @@ def test_dev_dependency_survives_audit_and_prune(tmp_path: Path) -> None:
     locked_dependency = next(iter(lockfile.dependencies.values()))
     assert locked_dependency.is_dev is True
 
-    audit = _run(project, "audit", "--ci")
+    audit = _run(apm_binary_path, project, "audit", "--ci")
     assert audit.returncode == 0, f"audit stdout:\n{audit.stdout}\naudit stderr:\n{audit.stderr}"
 
-    prune = _run(project, "prune")
+    prune = _run(apm_binary_path, project, "prune")
     assert prune.returncode == 0, f"prune stdout:\n{prune.stdout}\nprune stderr:\n{prune.stderr}"
     assert installed_package.is_dir(), (
         "apm prune removed a package declared under devDependencies.apm"

--- a/tests/integration/test_diff_aware_install_e2e.py
+++ b/tests/integration/test_diff_aware_install_e2e.py
@@ -11,7 +11,6 @@ Uses real packages from GitHub:
   - microsoft/apm-sample-package (deployed prompts, agents, etc.)
 """
 
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -23,15 +22,9 @@ pytestmark = pytest.mark.requires_github_token
 
 
 @pytest.fixture
-def apm_command():
-    """Get the path to the APM CLI executable."""
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 @pytest.fixture

--- a/tests/integration/test_diff_aware_install_e2e.py
+++ b/tests/integration/test_diff_aware_install_e2e.py
@@ -12,19 +12,12 @@ Uses real packages from GitHub:
 """
 
 import subprocess
-from pathlib import Path
 
 import pytest
 import yaml
 
 # Skip all tests if no GitHub token is available
 pytestmark = pytest.mark.requires_github_token
-
-
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
 
 
 @pytest.fixture
@@ -36,10 +29,10 @@ def temp_project(tmp_path):
     return project_dir
 
 
-def _run_apm(apm_command, args, cwd, timeout=180):
+def _run_apm(apm_binary_path, args, cwd, timeout=180):
     """Run an apm CLI command and return the result."""
     return subprocess.run(
-        [apm_command] + args,  # noqa: RUF005
+        [apm_binary_path] + args,  # noqa: RUF005
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -107,11 +100,11 @@ class TestPackageRemovedFromManifest:
     """When a package is removed from apm.yml, apm install should clean up
     its deployed files and remove it from the lockfile."""
 
-    def test_removed_package_files_cleaned_on_install(self, temp_project, apm_command):
+    def test_removed_package_files_cleaned_on_install(self, temp_project, apm_binary_path):
         """Files deployed by a removed package disappear on the next apm install."""
         # -- Step 1: install the package --
         _write_apm_yml(temp_project, ["microsoft/apm-sample-package"])
-        result1 = _run_apm(apm_command, ["install"], temp_project)
+        result1 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result1.returncode == 0, (
             f"Initial install failed:\nSTDOUT: {result1.stdout}\nSTDERR: {result1.stderr}"
         )
@@ -128,7 +121,7 @@ class TestPackageRemovedFromManifest:
         _write_apm_yml(temp_project, [])
 
         # -- Step 4: run apm install (no packages) — should detect orphan --
-        result2 = _run_apm(apm_command, ["install", "--only=apm"], temp_project)
+        result2 = _run_apm(apm_binary_path, ["install", "--only=apm"], temp_project)
         assert result2.returncode == 0, (
             f"Install after removal failed:\nSTDOUT: {result2.stdout}\nSTDERR: {result2.stderr}"
         )
@@ -140,11 +133,13 @@ class TestPackageRemovedFromManifest:
                 f"Orphaned file {rel_path} was NOT cleaned up by apm install"
             )
 
-    def test_removed_package_absent_from_lockfile_after_install(self, temp_project, apm_command):
+    def test_removed_package_absent_from_lockfile_after_install(
+        self, temp_project, apm_binary_path
+    ):
         """After removing a package from apm.yml, apm install removes it from lockfile."""
         # -- Install --
         _write_apm_yml(temp_project, ["microsoft/apm-sample-package"])
-        result1 = _run_apm(apm_command, ["install"], temp_project)
+        result1 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result1.returncode == 0, (
             f"Initial install failed:\nSTDOUT: {result1.stdout}\nSTDERR: {result1.stderr}"
         )
@@ -153,7 +148,7 @@ class TestPackageRemovedFromManifest:
         _write_apm_yml(temp_project, [])
 
         # -- Re-install --
-        result2 = _run_apm(apm_command, ["install", "--only=apm"], temp_project)
+        result2 = _run_apm(apm_binary_path, ["install", "--only=apm"], temp_project)
         assert result2.returncode == 0, (
             f"Install after removal failed:\nSTDOUT: {result2.stdout}\nSTDERR: {result2.stderr}"
         )
@@ -164,7 +159,7 @@ class TestPackageRemovedFromManifest:
             dep_after = _get_locked_dep(lockfile_after, "microsoft/apm-sample-package")
             assert dep_after is None, "Removed package still present in apm.lock after apm install"
 
-    def test_remaining_package_unaffected_by_removal(self, temp_project, apm_command):
+    def test_remaining_package_unaffected_by_removal(self, temp_project, apm_binary_path):
         """Files from packages still in the manifest are untouched."""
         # -- Install two packages --
         _write_apm_yml(
@@ -174,7 +169,7 @@ class TestPackageRemovedFromManifest:
                 "github/awesome-copilot/skills/aspire",
             ],
         )
-        result1 = _run_apm(apm_command, ["install"], temp_project)
+        result1 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result1.returncode == 0, (
             f"Initial install failed:\nSTDOUT: {result1.stdout}\nSTDERR: {result1.stderr}"
         )
@@ -186,7 +181,7 @@ class TestPackageRemovedFromManifest:
 
         # -- Remove only apm-sample-package --
         _write_apm_yml(temp_project, ["github/awesome-copilot/skills/aspire"])
-        result2 = _run_apm(apm_command, ["install", "--only=apm"], temp_project)
+        result2 = _run_apm(apm_binary_path, ["install", "--only=apm"], temp_project)
         assert result2.returncode == 0, (
             f"Second install failed:\nSTDOUT: {result2.stdout}\nSTDERR: {result2.stderr}"
         )
@@ -207,13 +202,13 @@ class TestPackageRemovedFromManifest:
 class TestPackageRefChangedInManifest:
     """When the ref in apm.yml changes, apm install re-downloads without --update."""
 
-    def test_ref_change_triggers_re_download(self, temp_project, apm_command):
+    def test_ref_change_triggers_re_download(self, temp_project, apm_binary_path):
         """Changing the ref in apm.yml from one value to another causes re-download."""
         # -- Step 1: install with an explicit commit-pinned ref --
         # We install first without a ref (using default branch), so the lockfile
         # records the resolved_ref as the default branch or latest commit.
         _write_apm_yml(temp_project, ["microsoft/apm-sample-package"])
-        result1 = _run_apm(apm_command, ["install"], temp_project)
+        result1 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result1.returncode == 0, (
             f"Initial install failed:\nSTDOUT: {result1.stdout}\nSTDERR: {result1.stderr}"
         )
@@ -235,7 +230,7 @@ class TestPackageRefChangedInManifest:
         )
 
         # -- Step 3: run install WITHOUT --update --
-        result2 = _run_apm(apm_command, ["install", "--only=apm"], temp_project)
+        result2 = _run_apm(apm_binary_path, ["install", "--only=apm"], temp_project)
         assert result2.returncode == 0, (
             f"Install with changed ref failed:\nSTDOUT: {result2.stdout}\nSTDERR: {result2.stderr}"
         )
@@ -255,11 +250,11 @@ class TestPackageRefChangedInManifest:
             "Package directory disappeared after re-download for ref change"
         )
 
-    def test_no_ref_change_does_not_re_download(self, temp_project, apm_command):
+    def test_no_ref_change_does_not_re_download(self, temp_project, apm_binary_path):
         """Without a ref change, apm install uses the lockfile SHA (idempotent)."""
         # -- Install --
         _write_apm_yml(temp_project, ["microsoft/apm-sample-package"])
-        result1 = _run_apm(apm_command, ["install"], temp_project)
+        result1 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result1.returncode == 0, (
             f"Initial install failed:\nSTDOUT: {result1.stdout}\nSTDERR: {result1.stderr}"
         )
@@ -269,7 +264,7 @@ class TestPackageRefChangedInManifest:
         commit_before = dep1.get("resolved_commit") if dep1 else None
 
         # -- Re-install without changing the ref --
-        result2 = _run_apm(apm_command, ["install", "--only=apm"], temp_project)
+        result2 = _run_apm(apm_binary_path, ["install", "--only=apm"], temp_project)
         assert result2.returncode == 0, (
             f"Re-install failed:\nSTDOUT: {result2.stdout}\nSTDERR: {result2.stderr}"
         )
@@ -293,11 +288,11 @@ class TestPackageRefChangedInManifest:
 class TestFullInstallIdempotent:
     """Running apm install multiple times without manifest changes is safe."""
 
-    def test_repeated_install_does_not_remove_files(self, temp_project, apm_command):
+    def test_repeated_install_does_not_remove_files(self, temp_project, apm_binary_path):
         """Repeated apm install with same manifest preserves deployed files."""
         _write_apm_yml(temp_project, ["microsoft/apm-sample-package"])
 
-        result1 = _run_apm(apm_command, ["install"], temp_project)
+        result1 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result1.returncode == 0, (
             f"First install failed:\nSTDOUT: {result1.stdout}\nSTDERR: {result1.stderr}"
         )
@@ -306,7 +301,7 @@ class TestFullInstallIdempotent:
         dep1 = _get_locked_dep(lockfile1, "microsoft/apm-sample-package")
         files_before = dep1.get("deployed_files", []) if dep1 else []
 
-        result2 = _run_apm(apm_command, ["install"], temp_project)
+        result2 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result2.returncode == 0, (
             f"Second install failed:\nSTDOUT: {result2.stdout}\nSTDERR: {result2.stderr}"
         )
@@ -396,7 +391,7 @@ class TestBranchRefDriftRegression:
     content_hash, and the on-disk content.
     """
 
-    def test_branch_ref_picks_up_upstream_advance(self, temp_project, apm_command):
+    def test_branch_ref_picks_up_upstream_advance(self, temp_project, apm_binary_path):
         """Lockfile SHA != current branch HEAD -> plain ``apm install``
         re-downloads and updates the lockfile to the current HEAD."""
         # -- Step 1: install with ref=main, lockfile records current HEAD --
@@ -404,7 +399,7 @@ class TestBranchRefDriftRegression:
             temp_project,
             [{"git": f"https://github.com/{FIXTURE_REPO}.git", "ref": "main"}],
         )
-        result1 = _run_apm(apm_command, ["install"], temp_project)
+        result1 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result1.returncode == 0, (
             f"Initial install failed:\nSTDOUT: {result1.stdout}\nSTDERR: {result1.stderr}"
         )
@@ -424,7 +419,7 @@ class TestBranchRefDriftRegression:
         )
 
         # -- Step 3: plain ``apm install`` with NO --update flag --
-        result2 = _run_apm(apm_command, ["install"], temp_project)
+        result2 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result2.returncode == 0, (
             f"Second install failed:\nSTDOUT: {result2.stdout}\nSTDERR: {result2.stderr}"
         )
@@ -441,7 +436,7 @@ class TestBranchRefDriftRegression:
             f"got {dep2['resolved_commit']}"
         )
 
-    def test_self_heal_recovers_buggy_version_lockfile(self, temp_project, apm_command):
+    def test_self_heal_recovers_buggy_version_lockfile(self, temp_project, apm_binary_path):
         """Lockfile generated by APM <= 0.12.2 with a stale resolved_commit
         and matching disk content (the corrupted state)
         triggers the version-gated self-heal on next plain install."""
@@ -450,7 +445,7 @@ class TestBranchRefDriftRegression:
             temp_project,
             [{"git": f"https://github.com/{FIXTURE_REPO}.git", "ref": "main"}],
         )
-        result1 = _run_apm(apm_command, ["install"], temp_project)
+        result1 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result1.returncode == 0, (
             f"Initial install failed:\nSTDOUT: {result1.stdout}\nSTDERR: {result1.stderr}"
         )
@@ -465,7 +460,7 @@ class TestBranchRefDriftRegression:
         )
 
         # -- Step 3: plain install -- self-heal should fire --
-        result2 = _run_apm(apm_command, ["install"], temp_project)
+        result2 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result2.returncode == 0, (
             f"Self-heal install failed:\nSTDOUT: {result2.stdout}\nSTDERR: {result2.stderr}"
         )
@@ -487,14 +482,14 @@ class TestBranchRefDriftRegression:
         # because the re-download produces identical bytes. On the
         # released version (post 0.12.2) self-heal will not re-fire at
         # all. Either way, install must converge to the same state.
-        result3 = _run_apm(apm_command, ["install"], temp_project)
+        result3 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result3.returncode == 0
         lockfile3 = _read_lockfile(temp_project)
         dep3 = _get_locked_dep(lockfile3, FIXTURE_REPO)
         assert dep3["resolved_commit"] == dep2["resolved_commit"]
         assert dep3["content_hash"] == dep2["content_hash"]
 
-    def test_virtual_package_branch_ref_drift_recovers(self, temp_project, apm_command):
+    def test_virtual_package_branch_ref_drift_recovers(self, temp_project, apm_binary_path):
         """Reported reproduction shape: virtual package
         (path: virtual-pkg) with ref: main. Branch drift on a virtual
         package always falls back to content-hash matching (install_path
@@ -509,7 +504,7 @@ class TestBranchRefDriftRegression:
                 }
             ],
         )
-        result1 = _run_apm(apm_command, ["install"], temp_project)
+        result1 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result1.returncode == 0, (
             f"Initial install failed:\nSTDOUT: {result1.stdout}\nSTDERR: {result1.stderr}"
         )
@@ -524,7 +519,7 @@ class TestBranchRefDriftRegression:
         _rewrite_lockfile_resolved_commit(
             temp_project, "apm-update-repro", new_commit=KNOWN_OLD_COMMIT
         )
-        result2 = _run_apm(apm_command, ["install"], temp_project)
+        result2 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result2.returncode == 0, (
             f"Second install failed:\nSTDOUT: {result2.stdout}\nSTDERR: {result2.stderr}"
         )
@@ -537,7 +532,9 @@ class TestBranchRefDriftRegression:
         )
         assert dep2["resolved_commit"] == head_sha
 
-    def test_corrupted_state_self_heal_does_not_trip_supply_chain(self, temp_project, apm_command):
+    def test_corrupted_state_self_heal_does_not_trip_supply_chain(
+        self, temp_project, apm_binary_path
+    ):
         """Reproduce the EXACT corrupted state and verify the
         self-heal completes without tripping the supply-chain hard-block.
 
@@ -561,7 +558,7 @@ class TestBranchRefDriftRegression:
             temp_project,
             [{"git": f"https://github.com/{FIXTURE_REPO}.git", "ref": KNOWN_OLD_COMMIT}],
         )
-        result1 = _run_apm(apm_command, ["install"], temp_project)
+        result1 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result1.returncode == 0, (
             f"Initial pinned install failed:\nSTDOUT: {result1.stdout}\nSTDERR: {result1.stderr}"
         )
@@ -612,7 +609,7 @@ class TestBranchRefDriftRegression:
 
         # -- Step 5: plain ``apm install``. Self-heal must fire AND the
         # supply-chain hard-block must NOT abort the install. --
-        result2 = _run_apm(apm_command, ["install"], temp_project)
+        result2 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result2.returncode == 0, (
             "Self-heal aborted -- likely tripped the supply-chain hard-block "
             f"because expected_hash_change_deps plumbing is missing.\n"

--- a/tests/integration/test_global_install_e2e.py
+++ b/tests/integration/test_global_install_e2e.py
@@ -15,7 +15,6 @@ Requires network access and GITHUB_TOKEN/GITHUB_APM_PAT for GitHub API.
 import os
 import subprocess
 import sys
-from pathlib import Path
 
 import pytest
 import yaml
@@ -24,12 +23,6 @@ pytestmark = pytest.mark.requires_github_token
 
 
 SAMPLE_PKG = "microsoft/apm-sample-package"
-
-
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
 
 
 @pytest.fixture
@@ -48,9 +41,9 @@ def _env_with_home(fake_home):
     return env
 
 
-def _run_apm(apm_command, args, cwd, fake_home, timeout=180):
+def _run_apm(apm_binary_path, args, cwd, fake_home, timeout=180):
     return subprocess.run(
-        [apm_command] + args,  # noqa: RUF005
+        [apm_binary_path] + args,  # noqa: RUF005
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -110,13 +103,13 @@ class TestGlobalInstallDeploysRealPackage:
     """Verify `apm install -g` actually deploys primitive files under ~/.apm/."""
 
     def test_install_global_deploys_real_package_to_user_scope(
-        self, apm_command, fake_home, tmp_path
+        self, apm_binary_path, fake_home, tmp_path
     ):
         _write_user_manifest(fake_home, [SAMPLE_PKG])
         work_dir = tmp_path / "workdir"
         work_dir.mkdir()
 
-        result = _run_apm(apm_command, ["install", "-g"], work_dir, fake_home)
+        result = _run_apm(apm_binary_path, ["install", "-g"], work_dir, fake_home)
         assert result.returncode == 0, (
             f"global install failed:\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
         )
@@ -139,12 +132,12 @@ class TestGlobalInstallDeploysRealPackage:
         assert not (work_dir / "apm.lock.yaml").exists(), "lockfile leaked into cwd"
         assert not (work_dir / "apm_modules").exists(), "apm_modules leaked into cwd"
 
-    def test_uninstall_global_removes_deployed_files(self, apm_command, fake_home, tmp_path):
+    def test_uninstall_global_removes_deployed_files(self, apm_binary_path, fake_home, tmp_path):
         _write_user_manifest(fake_home, [SAMPLE_PKG])
         work_dir = tmp_path / "workdir"
         work_dir.mkdir()
 
-        install_result = _run_apm(apm_command, ["install", "-g"], work_dir, fake_home)
+        install_result = _run_apm(apm_binary_path, ["install", "-g"], work_dir, fake_home)
         assert install_result.returncode == 0, (
             f"setup install failed:\nSTDOUT: {install_result.stdout}\n"
             f"STDERR: {install_result.stderr}"
@@ -158,7 +151,7 @@ class TestGlobalInstallDeploysRealPackage:
             pytest.skip("Sample package deployed no files; nothing to verify removal of")
 
         uninstall_result = _run_apm(
-            apm_command,
+            apm_binary_path,
             ["uninstall", SAMPLE_PKG, "-g"],
             work_dir,
             fake_home,
@@ -189,13 +182,13 @@ class TestGlobalInstallDeploysRealPackage:
             )
 
     def test_install_global_then_project_install_does_not_collide(
-        self, apm_command, fake_home, tmp_path
+        self, apm_binary_path, fake_home, tmp_path
     ):
         # Install globally first.
         _write_user_manifest(fake_home, [SAMPLE_PKG])
         global_workdir = tmp_path / "global-workdir"
         global_workdir.mkdir()
-        global_result = _run_apm(apm_command, ["install", "-g"], global_workdir, fake_home)
+        global_result = _run_apm(apm_binary_path, ["install", "-g"], global_workdir, fake_home)
         assert global_result.returncode == 0, (
             f"global install failed:\nSTDOUT: {global_result.stdout}\n"
             f"STDERR: {global_result.stderr}"
@@ -222,7 +215,7 @@ class TestGlobalInstallDeploysRealPackage:
             encoding="utf-8",
         )
 
-        local_result = _run_apm(apm_command, ["install"], project_dir, fake_home)
+        local_result = _run_apm(apm_binary_path, ["install"], project_dir, fake_home)
         assert local_result.returncode == 0, (
             f"project install failed:\nSTDOUT: {local_result.stdout}\nSTDERR: {local_result.stderr}"
         )

--- a/tests/integration/test_global_install_e2e.py
+++ b/tests/integration/test_global_install_e2e.py
@@ -13,7 +13,6 @@ Requires network access and GITHUB_TOKEN/GITHUB_APM_PAT for GitHub API.
 """
 
 import os
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -28,15 +27,9 @@ SAMPLE_PKG = "microsoft/apm-sample-package"
 
 
 @pytest.fixture
-def apm_command():
-    """Resolve the apm CLI executable."""
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 @pytest.fixture

--- a/tests/integration/test_global_scope_e2e.py
+++ b/tests/integration/test_global_scope_e2e.py
@@ -16,7 +16,6 @@ resolution, and CLI output using local fixtures only.
 import json
 import os
 import platform  # noqa: F401
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -32,15 +31,9 @@ pytestmark = pytest.mark.requires_apm_binary
 
 
 @pytest.fixture
-def apm_command():
-    """Get the path to the APM CLI executable."""
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 @pytest.fixture

--- a/tests/integration/test_global_scope_e2e.py
+++ b/tests/integration/test_global_scope_e2e.py
@@ -31,12 +31,6 @@ pytestmark = pytest.mark.requires_apm_binary
 
 
 @pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
-
-
-@pytest.fixture
 def fake_home(tmp_path):
     """Create an isolated home directory for user-scope tests.
 
@@ -61,10 +55,10 @@ def _env_with_home(fake_home):
     return env
 
 
-def _run_apm(apm_command, args, cwd, fake_home, timeout=60):
+def _run_apm(apm_binary_path, args, cwd, fake_home, timeout=60):
     """Run an apm CLI command with an overridden home directory."""
     return subprocess.run(
-        [apm_command] + args,  # noqa: RUF005
+        [apm_binary_path] + args,  # noqa: RUF005
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -111,34 +105,34 @@ def local_package(tmp_path):
 class TestGlobalDirectoryCreation:
     """Verify that --global creates ~/.apm/ and its children."""
 
-    def test_global_flag_creates_apm_dir(self, apm_command, fake_home):
+    def test_global_flag_creates_apm_dir(self, apm_binary_path, fake_home):
         """apm install --global should create ~/.apm/ even when the command
         ultimately fails (e.g. no manifest and no packages)."""
-        result = _run_apm(apm_command, ["install", "--global"], fake_home, fake_home)
+        result = _run_apm(apm_binary_path, ["install", "--global"], fake_home, fake_home)
 
         apm_dir = fake_home / ".apm"
         assert apm_dir.is_dir(), (
             f"~/.apm/ not created. stdout: {result.stdout}\nstderr: {result.stderr}"
         )
 
-    def test_global_flag_creates_modules_subdir(self, apm_command, fake_home):
+    def test_global_flag_creates_modules_subdir(self, apm_binary_path, fake_home):
         """apm install --global should create ~/.apm/apm_modules/."""
-        _run_apm(apm_command, ["install", "--global"], fake_home, fake_home)
+        _run_apm(apm_binary_path, ["install", "--global"], fake_home, fake_home)
 
         modules = fake_home / ".apm" / "apm_modules"
         assert modules.is_dir(), "~/.apm/apm_modules/ not created"
 
-    def test_short_flag_g_creates_apm_dir(self, apm_command, fake_home):
+    def test_short_flag_g_creates_apm_dir(self, apm_binary_path, fake_home):
         """-g short flag should behave identically to --global."""
-        _run_apm(apm_command, ["install", "-g"], fake_home, fake_home)
+        _run_apm(apm_binary_path, ["install", "-g"], fake_home, fake_home)
 
         assert (fake_home / ".apm").is_dir(), "-g did not create ~/.apm/"
         assert (fake_home / ".apm" / "apm_modules").is_dir()
 
-    def test_directory_creation_is_idempotent(self, apm_command, fake_home):
+    def test_directory_creation_is_idempotent(self, apm_binary_path, fake_home):
         """Running --global twice should not raise or corrupt the directory."""
-        _run_apm(apm_command, ["install", "--global"], fake_home, fake_home)
-        _run_apm(apm_command, ["install", "--global"], fake_home, fake_home)
+        _run_apm(apm_binary_path, ["install", "--global"], fake_home, fake_home)
+        _run_apm(apm_binary_path, ["install", "--global"], fake_home, fake_home)
 
         assert (fake_home / ".apm").is_dir()
         assert (fake_home / ".apm" / "apm_modules").is_dir()
@@ -152,21 +146,21 @@ class TestGlobalDirectoryCreation:
 class TestGlobalScopeOutput:
     """Verify CLI output when using --global."""
 
-    def test_shows_user_scope_info(self, apm_command, fake_home):
+    def test_shows_user_scope_info(self, apm_binary_path, fake_home):
         """Install --global should display user scope info message."""
-        result = _run_apm(apm_command, ["install", "--global"], fake_home, fake_home)
+        result = _run_apm(apm_binary_path, ["install", "--global"], fake_home, fake_home)
         combined = result.stdout + result.stderr
         assert "user scope" in combined.lower() or "~/.apm/" in combined, (
             f"Missing scope info in output: {combined}"
         )
 
-    def test_warns_about_unsupported_targets(self, apm_command, fake_home):
+    def test_warns_about_unsupported_targets(self, apm_binary_path, fake_home):
         """Install --global should warn about targets that lack user-scope support."""
-        result = _run_apm(apm_command, ["install", "--global"], fake_home, fake_home)
+        result = _run_apm(apm_binary_path, ["install", "--global"], fake_home, fake_home)
         combined = result.stdout + result.stderr
         assert "cursor" in combined.lower(), f"Missing cursor warning in output: {combined}"
 
-    def test_uninstall_global_shows_scope_info(self, apm_command, fake_home):
+    def test_uninstall_global_shows_scope_info(self, apm_binary_path, fake_home):
         """Uninstall --global should mention user scope in output."""
         # Create a minimal manifest so uninstall doesn't fail on missing apm.yml
         apm_dir = fake_home / ".apm"
@@ -182,7 +176,7 @@ class TestGlobalScopeOutput:
         )
 
         result = _run_apm(
-            apm_command,
+            apm_binary_path,
             ["uninstall", "--global", "test/pkg"],
             fake_home,
             fake_home,
@@ -201,9 +195,9 @@ class TestGlobalScopeOutput:
 class TestGlobalErrorHandling:
     """Verify error paths for --global installs."""
 
-    def test_no_manifest_no_packages_errors(self, apm_command, fake_home):
+    def test_no_manifest_no_packages_errors(self, apm_binary_path, fake_home):
         """--global without packages and without ~/.apm/apm.yml should fail."""
-        result = _run_apm(apm_command, ["install", "--global"], fake_home, fake_home)
+        result = _run_apm(apm_binary_path, ["install", "--global"], fake_home, fake_home)
         assert result.returncode != 0
         combined = result.stdout + result.stderr
         # The error message includes the full path which may be line-wrapped
@@ -212,10 +206,10 @@ class TestGlobalErrorHandling:
             f"Error should mention missing manifest: {combined}"
         )
 
-    def test_uninstall_global_no_manifest_errors(self, apm_command, fake_home):
+    def test_uninstall_global_no_manifest_errors(self, apm_binary_path, fake_home):
         """Uninstall --global without ~/.apm/apm.yml should fail."""
         result = _run_apm(
-            apm_command,
+            apm_binary_path,
             ["uninstall", "--global", "test/pkg"],
             fake_home,
             fake_home,
@@ -235,10 +229,10 @@ class TestGlobalErrorHandling:
 class TestGlobalManifestPlacement:
     """Verify that manifest/lockfile are written under ~/.apm/."""
 
-    def test_auto_bootstrap_creates_user_manifest(self, apm_command, fake_home, local_package):
+    def test_auto_bootstrap_creates_user_manifest(self, apm_binary_path, fake_home, local_package):
         """Installing a local package with --global auto-creates ~/.apm/apm.yml."""
         result = _run_apm(
-            apm_command,
+            apm_binary_path,
             ["install", "--global", str(local_package)],
             fake_home,
             fake_home,
@@ -277,13 +271,13 @@ class TestGlobalManifestPlacement:
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
 
-    def test_user_manifest_does_not_pollute_cwd(self, apm_command, fake_home, local_package):
+    def test_user_manifest_does_not_pollute_cwd(self, apm_binary_path, fake_home, local_package):
         """--global must not create apm.yml in the working directory."""
         work_dir = fake_home / "workdir"
         work_dir.mkdir()
 
         _run_apm(
-            apm_command,
+            apm_binary_path,
             ["install", "--global", str(local_package)],
             work_dir,
             fake_home,
@@ -293,13 +287,13 @@ class TestGlobalManifestPlacement:
             "apm.yml was incorrectly created in the working directory"
         )
 
-    def test_lockfile_placed_under_user_dir(self, apm_command, fake_home, local_package):
+    def test_lockfile_placed_under_user_dir(self, apm_binary_path, fake_home, local_package):
         """Lockfile should be created under ~/.apm/, not in the working directory."""
         work_dir = fake_home / "workdir"
         work_dir.mkdir()
 
         result = _run_apm(  # noqa: F841
-            apm_command,
+            apm_binary_path,
             ["install", "--global", str(local_package)],
             work_dir,
             fake_home,
@@ -329,7 +323,7 @@ class TestGlobalManifestPlacement:
 class TestCrossPlatformPaths:
     """Verify path resolution works on the current platform."""
 
-    def test_home_based_paths_are_absolute(self, apm_command, fake_home):
+    def test_home_based_paths_are_absolute(self, apm_binary_path, fake_home):
         """All user-scope paths should resolve to absolute paths."""
         from unittest.mock import patch
 
@@ -355,7 +349,7 @@ class TestCrossPlatformPaths:
                     f"{fn.__name__}(USER) returned non-absolute path: {result}"
                 )
 
-    def test_forward_slash_paths_on_all_platforms(self, apm_command, fake_home):
+    def test_forward_slash_paths_on_all_platforms(self, apm_binary_path, fake_home):
         """User-scope paths should use forward slashes (POSIX) when
         stored as strings, matching the lockfile convention."""
         from unittest.mock import patch
@@ -389,13 +383,13 @@ class TestCrossPlatformPaths:
 class TestGlobalGeminiScope:
     """Verify user-scope install/uninstall deploys to ~/.gemini/."""
 
-    def test_global_install_creates_gemini_dirs(self, apm_command, fake_home, local_package):
+    def test_global_install_creates_gemini_dirs(self, apm_binary_path, fake_home, local_package):
         """--global should deploy primitives to ~/.gemini/ when .gemini/ exists."""
         gemini_dir = fake_home / ".gemini"
         gemini_dir.mkdir()
 
         result = _run_apm(
-            apm_command,
+            apm_binary_path,
             ["install", "--global", str(local_package)],
             fake_home,
             fake_home,
@@ -403,13 +397,13 @@ class TestGlobalGeminiScope:
         combined = result.stdout + result.stderr
         assert "gemini" in combined.lower(), f"Gemini not mentioned in output: {combined}"
 
-    def test_global_install_mentions_gemini_full_support(self, apm_command, fake_home):
+    def test_global_install_mentions_gemini_full_support(self, apm_binary_path, fake_home):
         """--global output should list gemini as fully supported."""
         gemini_dir = fake_home / ".gemini"
         gemini_dir.mkdir()
 
         result = _run_apm(
-            apm_command,
+            apm_binary_path,
             ["install", "--global"],
             fake_home,
             fake_home,
@@ -417,20 +411,20 @@ class TestGlobalGeminiScope:
         combined = result.stdout + result.stderr
         assert "gemini" in combined.lower(), f"Gemini not in scope support message: {combined}"
 
-    def test_global_uninstall_runs_in_user_scope(self, apm_command, fake_home, local_package):
+    def test_global_uninstall_runs_in_user_scope(self, apm_binary_path, fake_home, local_package):
         """Uninstall --global with .gemini/ present operates in user scope."""
         gemini_dir = fake_home / ".gemini"
         gemini_dir.mkdir()
 
         _run_apm(
-            apm_command,
+            apm_binary_path,
             ["install", "--global", str(local_package)],
             fake_home,
             fake_home,
         )
 
         result = _run_apm(
-            apm_command,
+            apm_binary_path,
             ["uninstall", "--global", "local-pkg"],
             fake_home,
             fake_home,
@@ -442,7 +436,7 @@ class TestGlobalGeminiScope:
 class TestGlobalUninstallLifecycle:
     """Test uninstall --global removes packages from user-scope metadata."""
 
-    def test_uninstall_removes_package_from_user_manifest(self, apm_command, fake_home):
+    def test_uninstall_removes_package_from_user_manifest(self, apm_binary_path, fake_home):
         """Uninstall --global should remove the package entry from ~/.apm/apm.yml."""
         apm_dir = fake_home / ".apm"
         apm_dir.mkdir(parents=True, exist_ok=True)
@@ -461,7 +455,7 @@ class TestGlobalUninstallLifecycle:
         )
 
         result = _run_apm(
-            apm_command,
+            apm_binary_path,
             ["uninstall", "--global", "test/pkg-to-remove"],
             fake_home,
             fake_home,
@@ -474,7 +468,7 @@ class TestGlobalUninstallLifecycle:
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
 
-    def test_uninstall_global_package_not_found_warns(self, apm_command, fake_home):
+    def test_uninstall_global_package_not_found_warns(self, apm_binary_path, fake_home):
         """Uninstalling a package that is not in the manifest should warn."""
         apm_dir = fake_home / ".apm"
         apm_dir.mkdir(parents=True, exist_ok=True)
@@ -492,7 +486,7 @@ class TestGlobalUninstallLifecycle:
         )
 
         result = _run_apm(
-            apm_command,
+            apm_binary_path,
             ["uninstall", "--global", "nonexistent/pkg"],
             fake_home,
             fake_home,
@@ -552,13 +546,13 @@ class TestGlobalHookIntegrationNakedFormat:
     """
 
     def test_claude_settings_receives_naked_stop_entry(
-        self, apm_command, fake_home, naked_hook_package
+        self, apm_binary_path, fake_home, naked_hook_package
     ):
         """``~/.claude/settings.json`` must carry the Stop entry after global install."""
         (fake_home / ".claude").mkdir()
 
         result = _run_apm(
-            apm_command,
+            apm_binary_path,
             ["install", "--global", str(naked_hook_package)],
             fake_home,
             fake_home,
@@ -577,7 +571,9 @@ class TestGlobalHookIntegrationNakedFormat:
             f"Stop event missing from ~/.claude/settings.json: {settings['hooks']!r}"
         )
 
-    def test_integrated_counter_does_not_lie_on_empty_merge(self, apm_command, fake_home, tmp_path):
+    def test_integrated_counter_does_not_lie_on_empty_merge(
+        self, apm_binary_path, fake_home, tmp_path
+    ):
         """A hook file whose events are all empty must NOT bump the counter.
 
         Companion regression for #1499: the user-facing summary line
@@ -597,7 +593,7 @@ class TestGlobalHookIntegrationNakedFormat:
         (fake_home / ".claude").mkdir()
 
         result = _run_apm(
-            apm_command,
+            apm_binary_path,
             ["install", "--global", str(pkg)],
             fake_home,
             fake_home,

--- a/tests/integration/test_golden_scenario_e2e.py
+++ b/tests/integration/test_golden_scenario_e2e.py
@@ -150,25 +150,9 @@ def temp_e2e_home():
 
 
 @pytest.fixture(scope="module")
-def apm_binary():
-    """Get path to APM binary for testing."""
-    # Try to find APM binary in common locations
-    possible_paths = [
-        "apm",  # In PATH
-        "./apm",  # Local directory
-        "./dist/apm",  # Build directory
-        Path(__file__).parent.parent.parent / "dist" / "apm",  # Relative to test
-    ]
-
-    for path in possible_paths:
-        try:
-            result = subprocess.run([str(path), "--version"], capture_output=True, text=True)
-            if result.returncode == 0:
-                return str(path)
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            continue
-
-    pytest.skip("APM binary not found. Build it first with: python -m build")
+def apm_binary(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 class TestGoldenScenarioE2E:

--- a/tests/integration/test_golden_scenario_e2e.py
+++ b/tests/integration/test_golden_scenario_e2e.py
@@ -149,12 +149,6 @@ def temp_e2e_home():
             del os.environ["HOME"]
 
 
-@pytest.fixture(scope="module")
-def apm_binary(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
-
-
 class TestGoldenScenarioE2E:
     """End-to-end tests for the exact README hero quick start scenario."""
 
@@ -162,7 +156,7 @@ class TestGoldenScenarioE2E:
         not PRIMARY_TOKEN,
         reason="GitHub token (GITHUB_APM_PAT or GITHUB_TOKEN) required for E2E tests",
     )
-    def test_complete_golden_scenario_copilot(self, temp_e2e_home, apm_binary):
+    def test_complete_golden_scenario_copilot(self, temp_e2e_home, apm_binary_path):
         """Test the complete hero quick start from README using Copilot CLI runtime.
 
         Validates the exact 6-step flow:
@@ -178,7 +172,9 @@ class TestGoldenScenarioE2E:
         print("\n=== Step 2: Set up your GitHub PAT and an Agent CLI ===")
         print("GitHub token: ✓ (set via environment - GITHUB_APM_PAT preferred)")
         print("Installing Copilot CLI runtime...")
-        result = run_command(f"{apm_binary} runtime setup copilot", timeout=300, show_output=True)
+        result = run_command(
+            f"{apm_binary_path} runtime setup copilot", timeout=300, show_output=True
+        )
         assert result.returncode == 0, f"Runtime setup failed: {result.stderr}"
 
         # Verify copilot is available and GitHub configuration was created
@@ -212,7 +208,7 @@ class TestGoldenScenarioE2E:
 
             print("\n=== Step 3: Transform your project with AI-Native structure ===")
             result = run_command(
-                f"{apm_binary} init my-ai-native-project --yes --target copilot",
+                f"{apm_binary_path} init my-ai-native-project --yes --target copilot",
                 cwd=project_workspace,
                 show_output=True,
             )
@@ -291,7 +287,7 @@ Basic instructions for E2E testing.
 
             # Step 4: Compile Agent Primitives for any coding agent (equivalent to: apm compile)
             print("\n=== Step 4: Compile Agent Primitives for any coding agent ===")
-            result = run_command(f"{apm_binary} compile", cwd=project_dir, show_output=True)
+            result = run_command(f"{apm_binary_path} compile", cwd=project_dir, show_output=True)
             assert result.returncode == 0, f"Agent Primitives compilation failed: {result.stderr}"
 
             # Verify agents.md was generated
@@ -312,7 +308,7 @@ Basic instructions for E2E testing.
             # Leave ado_org unset to avoid connecting to real organization
 
             result = run_command(
-                f"{apm_binary} install", cwd=project_dir, show_output=True, env=env
+                f"{apm_binary_path} install", cwd=project_dir, show_output=True, env=env
             )
             assert result.returncode == 0, f"Dependency install failed: {result.stderr}"
 
@@ -337,7 +333,7 @@ Basic instructions for E2E testing.
                 env["COPILOT_GITHUB_TOKEN"] = os.environ["GITHUB_TOKEN"]
 
             # Run with real-time output streaming (using 'start' script which calls Copilot CLI)
-            cmd = f'{apm_binary} run start --param name="developer"'
+            cmd = f'{apm_binary_path} run start --param name="developer"'
             print(f"Executing: {cmd}")
 
             try:
@@ -414,7 +410,7 @@ Basic instructions for E2E testing.
         not PRIMARY_TOKEN,
         reason="GitHub token (GITHUB_APM_PAT or GITHUB_TOKEN) required for E2E tests",
     )
-    def test_complete_golden_scenario_codex(self, temp_e2e_home, apm_binary):
+    def test_complete_golden_scenario_codex(self, temp_e2e_home, apm_binary_path):
         """Test the complete golden scenario using Codex CLI runtime.
 
         This test uses the 'debug' script which actually calls Codex CLI.
@@ -422,7 +418,9 @@ Basic instructions for E2E testing.
 
         # Step 1: Setup Codex runtime
         print("\n=== Setting up Codex CLI runtime ===")
-        result = run_command(f"{apm_binary} runtime setup codex", timeout=300, show_output=True)
+        result = run_command(
+            f"{apm_binary_path} runtime setup codex", timeout=300, show_output=True
+        )
         assert result.returncode == 0, f"Codex runtime setup failed: {result.stderr}"
 
         # Verify codex is available and GitHub configuration was created
@@ -447,7 +445,7 @@ Basic instructions for E2E testing.
 
             print("\n=== Initializing Codex test project ===")
             result = run_command(
-                f"{apm_binary} init my-ai-native-project-codex --yes --target copilot",
+                f"{apm_binary_path} init my-ai-native-project-codex --yes --target copilot",
                 cwd=project_workspace,
             )
             assert result.returncode == 0, f"Project init failed: {result.stderr}"
@@ -501,7 +499,7 @@ Instructions for Codex E2E testing.
 
             # Step 3: Compile Agent Primitives
             print("\n=== Compiling Agent Primitives ===")
-            result = run_command(f"{apm_binary} compile", cwd=project_dir)
+            result = run_command(f"{apm_binary_path} compile", cwd=project_dir)
             assert result.returncode == 0, f"Compilation failed: {result.stderr}"
 
             # Step 4: Install dependencies
@@ -512,7 +510,7 @@ Instructions for Codex E2E testing.
             env["ado_domain"] = "core"  # Limit to core domain only
             env["HOME"] = temp_e2e_home
 
-            result = run_command(f"{apm_binary} install", cwd=project_dir, env=env)
+            result = run_command(f"{apm_binary_path} install", cwd=project_dir, env=env)
             assert result.returncode == 0, f"Dependency install failed: {result.stderr}"
 
             # Step 5: Run with Codex CLI (equivalent to: apm run debug --param name="<YourGitHubHandle>")
@@ -524,7 +522,7 @@ Instructions for Codex E2E testing.
             env["HOME"] = temp_e2e_home
 
             # Run the Codex command with proper environment (use 'debug' script which calls Codex CLI)
-            cmd = f'{apm_binary} run debug --param name="developer"'
+            cmd = f'{apm_binary_path} run debug --param name="developer"'
             process = subprocess.Popen(
                 cmd,
                 shell=True,
@@ -573,12 +571,12 @@ Instructions for Codex E2E testing.
         not PRIMARY_TOKEN,
         reason="GitHub token (GITHUB_APM_PAT or GITHUB_TOKEN) required for E2E tests",
     )
-    def test_complete_golden_scenario_llm(self, temp_e2e_home, apm_binary):
+    def test_complete_golden_scenario_llm(self, temp_e2e_home, apm_binary_path):
         """Test the complete golden scenario using LLM runtime."""
 
         # Step 1: Setup LLM runtime (equivalent to: apm runtime setup llm)
         print("\\n=== Setting up LLM runtime ===")
-        result = run_command(f"{apm_binary} runtime setup llm", timeout=300)
+        result = run_command(f"{apm_binary_path} runtime setup llm", timeout=300)
         assert result.returncode == 0, f"LLM runtime setup failed: {result.stderr}"
 
         # Verify LLM is available
@@ -598,7 +596,7 @@ Instructions for Codex E2E testing.
 
             print("\\n=== Initializing LLM test project ===")
             result = run_command(
-                f"{apm_binary} init my-ai-native-project-llm --yes --target copilot",
+                f"{apm_binary_path} init my-ai-native-project-llm --yes --target copilot",
                 cwd=project_workspace,
             )
             assert result.returncode == 0, f"Project init failed: {result.stderr}"
@@ -652,7 +650,7 @@ Instructions for LLM E2E testing.
 
             # Step 3: Compile Agent Primitives
             print("\\n=== Compiling Agent Primitives ===")
-            result = run_command(f"{apm_binary} compile", cwd=project_dir)
+            result = run_command(f"{apm_binary_path} compile", cwd=project_dir)
             assert result.returncode == 0, f"Compilation failed: {result.stderr}"
 
             # Step 4: Install dependencies
@@ -663,7 +661,7 @@ Instructions for LLM E2E testing.
             env["ado_domain"] = "core"  # Limit to core domain only
             env["HOME"] = temp_e2e_home
 
-            result = run_command(f"{apm_binary} install", cwd=project_dir, env=env)
+            result = run_command(f"{apm_binary_path} install", cwd=project_dir, env=env)
             assert result.returncode == 0, f"Dependency install failed: {result.stderr}"
 
             # Step 5: Run with LLM runtime (equivalent to: apm run llm --param name="<YourGitHubHandle>")
@@ -680,7 +678,7 @@ Instructions for LLM E2E testing.
                     env["GITHUB_MODELS_KEY"] = github_token
 
             # Run the LLM command with proper environment (use 'llm' script, not 'start')
-            cmd = f'{apm_binary} run llm --param name="developer"'
+            cmd = f'{apm_binary_path} run llm --param name="developer"'
             process = subprocess.Popen(
                 cmd,
                 shell=True,
@@ -716,7 +714,7 @@ Instructions for LLM E2E testing.
         not PRIMARY_TOKEN,
         reason="GitHub token (GITHUB_APM_PAT or GITHUB_TOKEN) required for E2E tests",
     )
-    def test_complete_golden_scenario_gemini(self, temp_e2e_home, apm_binary):
+    def test_complete_golden_scenario_gemini(self, temp_e2e_home, apm_binary_path):
         """Test the complete golden scenario using Gemini CLI runtime.
 
         This test uses the 'review' script which calls Gemini CLI.
@@ -726,7 +724,9 @@ Instructions for LLM E2E testing.
 
         # Step 1: Setup Gemini runtime (npm install -g @google/gemini-cli)
         print("\n=== Setting up Gemini CLI runtime ===")
-        result = run_command(f"{apm_binary} runtime setup gemini", timeout=300, show_output=True)
+        result = run_command(
+            f"{apm_binary_path} runtime setup gemini", timeout=300, show_output=True
+        )
         assert result.returncode == 0, f"Gemini runtime setup failed: {result.stderr}"
 
         # Verify gemini is available (npm global install, not in ~/.apm/runtimes)
@@ -755,7 +755,7 @@ Instructions for LLM E2E testing.
 
             print("\n=== Initializing Gemini test project ===")
             result = run_command(
-                f"{apm_binary} init my-ai-native-project-gemini --yes --target copilot",
+                f"{apm_binary_path} init my-ai-native-project-gemini --yes --target copilot",
                 cwd=project_workspace,
             )
             assert result.returncode == 0, f"Project init failed: {result.stderr}"
@@ -810,7 +810,7 @@ Instructions for Gemini CLI E2E testing.
 
             # Step 3: Compile Agent Primitives
             print("\n=== Compiling Agent Primitives ===")
-            result = run_command(f"{apm_binary} compile", cwd=project_dir)
+            result = run_command(f"{apm_binary_path} compile", cwd=project_dir)
             assert result.returncode == 0, f"Compilation failed: {result.stderr}"
 
             # Step 4: Install dependencies (targets gemini since .gemini/ exists)
@@ -818,7 +818,7 @@ Instructions for Gemini CLI E2E testing.
             env = os.environ.copy()
             env["HOME"] = temp_e2e_home
 
-            result = run_command(f"{apm_binary} install", cwd=project_dir, env=env)
+            result = run_command(f"{apm_binary_path} install", cwd=project_dir, env=env)
             assert result.returncode == 0, f"Dependency install failed: {result.stderr}"
 
             # Step 5: Run with Gemini CLI
@@ -827,7 +827,7 @@ Instructions for Gemini CLI E2E testing.
             env["HOME"] = temp_e2e_home
             env["GEMINI_CLI_TRUST_WORKSPACE"] = "true"
 
-            cmd = f'{apm_binary} run review --param name="developer"'
+            cmd = f'{apm_binary_path} run review --param name="developer"'
             process = subprocess.Popen(
                 cmd,
                 shell=True,
@@ -873,10 +873,10 @@ Instructions for Gemini CLI E2E testing.
                         f"Gemini CLI execution failed with return code {return_code}: {full_output}"
                     )
 
-    def test_runtime_list_command(self, temp_e2e_home, apm_binary):
+    def test_runtime_list_command(self, temp_e2e_home, apm_binary_path):
         """Test that APM can list installed runtimes."""
         print("\\n=== Testing runtime list command ===")
-        result = run_command(f"{apm_binary} runtime list")
+        result = run_command(f"{apm_binary_path} runtime list")
 
         # Should succeed even if no runtimes installed
         assert result.returncode == 0, f"Runtime list failed: {result.stderr}"
@@ -889,17 +889,17 @@ Instructions for Gemini CLI E2E testing.
 
         print(f"Runtime list output: {result.stdout}")
 
-    def test_apm_version_and_help(self, apm_binary):
+    def test_apm_version_and_help(self, apm_binary_path):
         """Test basic APM CLI functionality."""
         print("\\n=== Testing APM CLI basics ===")
 
         # Test version
-        result = run_command(f"{apm_binary} --version")
+        result = run_command(f"{apm_binary_path} --version")
         assert result.returncode == 0, f"Version command failed: {result.stderr}"
         assert result.stdout.strip(), "Version output is empty"
 
         # Test help
-        result = run_command(f"{apm_binary} --help")
+        result = run_command(f"{apm_binary_path} --help")
         assert result.returncode == 0, f"Help command failed: {result.stderr}"
         assert "usage:" in result.stdout.lower() or "apm" in result.stdout.lower(), (
             "Help output doesn't look correct"
@@ -907,7 +907,7 @@ Instructions for Gemini CLI E2E testing.
 
         print(f"APM version: {result.stdout}")
 
-    def test_init_command_minimal_mode(self, temp_e2e_home, apm_binary):
+    def test_init_command_minimal_mode(self, temp_e2e_home, apm_binary_path):
         """Test apm init command in minimal mode (new behavior)."""
         print("\\n=== Testing APM init command (minimal mode) ===")
 
@@ -916,7 +916,7 @@ Instructions for Gemini CLI E2E testing.
 
             # Test apm init
             result = run_command(
-                f"{apm_binary} init template-test-project --yes --target copilot",
+                f"{apm_binary_path} init template-test-project --yes --target copilot",
                 cwd=workspace,
                 show_output=True,
             )
@@ -940,17 +940,17 @@ Instructions for Gemini CLI E2E testing.
 class TestRuntimeInteroperability:
     """Test that both runtimes can be installed and work together."""
 
-    def test_dual_runtime_installation(self, temp_e2e_home, apm_binary):
+    def test_dual_runtime_installation(self, temp_e2e_home, apm_binary_path):
         """Test installing both runtimes in the same environment."""
 
         # Install Codex
         print("\\n=== Installing Codex runtime ===")
-        result = run_command(f"{apm_binary} runtime setup codex", timeout=300)
+        result = run_command(f"{apm_binary_path} runtime setup codex", timeout=300)
         assert result.returncode == 0, f"Codex setup failed: {result.stderr}"
 
         # Install LLM
         print("\\n=== Installing LLM runtime ===")
-        result = run_command(f"{apm_binary} runtime setup llm", timeout=300)
+        result = run_command(f"{apm_binary_path} runtime setup llm", timeout=300)
         assert result.returncode == 0, f"LLM setup failed: {result.stderr}"
 
         # Verify both are available
@@ -959,7 +959,7 @@ class TestRuntimeInteroperability:
         assert (runtime_dir / "llm").exists(), "LLM not found after dual install"
 
         # Test runtime list shows both
-        result = run_command(f"{apm_binary} runtime list")
+        result = run_command(f"{apm_binary_path} runtime list")
         assert result.returncode == 0, f"Runtime list failed: {result.stderr}"
 
         output = result.stdout.lower()  # noqa: F841

--- a/tests/integration/test_guardrailing_hero_e2e.py
+++ b/tests/integration/test_guardrailing_hero_e2e.py
@@ -87,24 +87,9 @@ def run_command(
 
 
 @pytest.fixture(scope="module")
-def apm_binary():
-    """Get path to APM binary for testing."""
-    possible_paths = [
-        "apm",
-        "./apm",
-        "./dist/apm",
-        Path(__file__).parent.parent.parent / "dist" / "apm",
-    ]
-
-    for path in possible_paths:
-        try:
-            result = subprocess.run([str(path), "--version"], capture_output=True, text=True)
-            if result.returncode == 0:
-                return str(path)
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            continue
-
-    pytest.skip("APM binary not found. Build it first with: python -m build")
+def apm_binary(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 class TestGuardrailingHeroScenario:

--- a/tests/integration/test_guardrailing_hero_e2e.py
+++ b/tests/integration/test_guardrailing_hero_e2e.py
@@ -86,17 +86,11 @@ def run_command(
         pytest.fail(f"Command failed: {cmd}\nStdout: {e.stdout}\nStderr: {e.stderr}")
 
 
-@pytest.fixture(scope="module")
-def apm_binary(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
-
-
 class TestGuardrailingHeroScenario:
     """Test README Hero Scenario 2: 2-Minute Guardrailing"""
 
     @pytest.mark.skipif(not PRIMARY_TOKEN, reason="GitHub token required for E2E tests")
-    def test_2_minute_guardrailing_flow(self, apm_binary):
+    def test_2_minute_guardrailing_flow(self, apm_binary_path):
         """Test the exact 2-minute guardrailing flow from README.
 
         Validates:
@@ -111,7 +105,7 @@ class TestGuardrailingHeroScenario:
             # Step 1: apm init my-project
             print("\n=== Step 1: apm init my-project ===")
             result = run_command(
-                f"{apm_binary} init my-project --yes --target copilot",
+                f"{apm_binary_path} init my-project --yes --target copilot",
                 cwd=workspace,
                 show_output=True,
             )
@@ -127,7 +121,7 @@ class TestGuardrailingHeroScenario:
             print("\n=== Step 2: apm install microsoft/apm-sample-package ===")
             env = os.environ.copy()
             result = run_command(
-                f"{apm_binary} install microsoft/apm-sample-package",
+                f"{apm_binary_path} install microsoft/apm-sample-package",
                 cwd=project_dir,
                 show_output=True,
                 env=env,
@@ -146,7 +140,7 @@ class TestGuardrailingHeroScenario:
                 "\n=== Step 3: apm install github/awesome-copilot/instructions/code-review-generic.instructions.md ==="
             )
             result = run_command(
-                f"{apm_binary} install github/awesome-copilot/instructions/code-review-generic.instructions.md",
+                f"{apm_binary_path} install github/awesome-copilot/instructions/code-review-generic.instructions.md",
                 cwd=project_dir,
                 show_output=True,
                 env=env,
@@ -169,7 +163,7 @@ class TestGuardrailingHeroScenario:
 
             # Step 4: apm compile
             print("\n=== Step 4: apm compile ===")
-            result = run_command(f"{apm_binary} compile", cwd=project_dir, show_output=True)
+            result = run_command(f"{apm_binary_path} compile", cwd=project_dir, show_output=True)
             assert result.returncode == 0, f"Compilation failed: {result.stderr}"
 
             # Copilot compile suppresses empty AGENTS.md shells when installed
@@ -211,7 +205,7 @@ class TestGuardrailingHeroScenario:
             # Use early termination pattern - we only need to verify prompt starts correctly
             # Don't wait for full Copilot CLI execution (takes minutes)
             process = subprocess.Popen(
-                f"{apm_binary} run design-review",
+                f"{apm_binary_path} run design-review",
                 shell=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,

--- a/tests/integration/test_hermetic_lifecycle_foundation.py
+++ b/tests/integration/test_hermetic_lifecycle_foundation.py
@@ -66,6 +66,7 @@ def _run_lifecycle_scenario(
     root: Path,
     scenario_id: str,
     *,
+    apm_binary_path: Path,
     base_env: dict[str, str],
 ) -> _LifecycleReceipt:
     scenario_deadline = time.monotonic() + _SCENARIO_TIMEOUT_SECONDS
@@ -153,10 +154,11 @@ def _run_lifecycle_scenario(
     )
 
     results = ApmLifecycleRunner(
+        (str(apm_binary_path),),
         scenario_timeout_seconds=max(
             0.001,
             scenario_deadline - time.monotonic(),
-        )
+        ),
     ).run_sequence(
         tuple(action.args for action in row.lifecycle_actions),
         expected_returncodes=tuple(action.expected_returncode for action in row.lifecycle_actions),
@@ -299,6 +301,7 @@ def test_concurrent_real_lifecycles_are_worker_isolated(
     tmp_path: Path,
     worker_id: str,
     batch: str,
+    apm_binary_path: Path,
 ) -> None:
     parent_environment = dict(os.environ)
     poisoned_environment = {
@@ -319,6 +322,7 @@ def test_concurrent_real_lifecycles_are_worker_isolated(
                 _run_lifecycle_scenario,
                 scenario_parent / scenario_id,
                 scenario_id,
+                apm_binary_path=apm_binary_path,
                 base_env=poisoned_environment,
             )
             for scenario_id in scenario_ids
@@ -358,11 +362,13 @@ def test_concurrent_real_lifecycles_are_worker_isolated(
 def test_generated_artifact_tampering_reports_cause_and_recovers(
     tmp_path: Path,
     mutation: str,
+    apm_binary_path: Path,
 ) -> None:
     scenario_id = mutation
     receipt = _run_lifecycle_scenario(
         tmp_path / scenario_id,
         scenario_id,
+        apm_binary_path=apm_binary_path,
         base_env=dict(os.environ),
     )
     _assert_lifecycle_receipt(receipt)
@@ -392,10 +398,11 @@ def test_generated_artifact_tampering_reports_cause_and_recovers(
         dump_yaml(lock, lock_path)
 
     runner = ApmLifecycleRunner(
+        (str(apm_binary_path),),
         scenario_timeout_seconds=max(
             0.001,
             receipt.scenario_deadline - time.monotonic(),
-        )
+        ),
     )
     environment = receipt.isolated.subprocess_env()
     if mutation == "content-hash":

--- a/tests/integration/test_hook_root_source_drift_e2e.py
+++ b/tests/integration/test_hook_root_source_drift_e2e.py
@@ -10,16 +10,22 @@ from __future__ import annotations
 
 import json
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
 
-CLI = [sys.executable, "-m", "apm_cli.cli"]
 
-
-def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(CLI + list(args), cwd=str(cwd), capture_output=True, text=True)
+def _run(
+    apm_binary_path: Path,
+    cwd: Path,
+    *args: str,
+) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [str(apm_binary_path), *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+    )
 
 
 # Per-target on-disk layout descriptors:
@@ -121,6 +127,7 @@ def test_root_hook_source_drift_heals_on_reinstall(
     settings_rel: str,
     sidecar_rel: str | None,
     event_key: str,
+    apm_binary_path: Path,
 ) -> None:
     """After a checkout rename, a second `apm install` heals stale source markers.
 
@@ -155,7 +162,7 @@ def test_root_hook_source_drift_heals_on_reinstall(
     )
 
     # First install: produces target-shaped entries marked `_local/myapp`.
-    first = _run(project, "install")
+    first = _run(apm_binary_path, project, "install")
     assert first.returncode == 0, first.stderr or first.stdout
     assert _load_sources(project, settings_rel, sidecar_rel, event_key) == ["_local/myapp"], (
         "First install must produce a single _local/myapp entry; "
@@ -184,7 +191,7 @@ def test_root_hook_source_drift_heals_on_reinstall(
     settings_path.write_text(json.dumps(settings_data), encoding="utf-8")
 
     # Second install: must heal the stale marker without touching the user-owned entry.
-    second = _run(project, "install")
+    second = _run(apm_binary_path, project, "install")
     assert second.returncode == 0, second.stderr or second.stdout
 
     sources = _load_sources(project, settings_rel, sidecar_rel, event_key)

--- a/tests/integration/test_hook_root_source_drift_e2e.py
+++ b/tests/integration/test_hook_root_source_drift_e2e.py
@@ -124,7 +124,6 @@ def test_root_hook_source_drift_heals_on_reinstall(
     settings_rel: str,
     sidecar_rel: str | None,
     event_key: str,
-    apm_binary_path: Path,
 ) -> None:
     """After a checkout rename, a second `apm install` heals stale source markers.
 

--- a/tests/integration/test_hook_root_source_drift_e2e.py
+++ b/tests/integration/test_hook_root_source_drift_e2e.py
@@ -15,11 +15,7 @@ from pathlib import Path
 import pytest
 
 
-def _run(
-    apm_binary_path: Path,
-    cwd: Path,
-    *args: str,
-) -> subprocess.CompletedProcess:
+def _run(apm_binary_path: Path, cwd: Path, *args: str) -> subprocess.CompletedProcess:
     return subprocess.run(
         [str(apm_binary_path), *args],
         cwd=str(cwd),
@@ -123,6 +119,7 @@ def _rewrite_source(
 @pytest.mark.parametrize("target, settings_rel, sidecar_rel, event_key", _HARNESS_CASES)
 def test_root_hook_source_drift_heals_on_reinstall(
     tmp_path: Path,
+    apm_binary_path: Path,
     target: str,
     settings_rel: str,
     sidecar_rel: str | None,

--- a/tests/integration/test_install_compile_antigravity_dedup_e2e.py
+++ b/tests/integration/test_install_compile_antigravity_dedup_e2e.py
@@ -38,11 +38,7 @@ EXPECTED_RULE = (
 INSTRUCTION_SENTINEL = "Use type hints everywhere."
 
 
-def _run(
-    apm_binary_path: Path,
-    cwd: Path,
-    *args: str,
-) -> subprocess.CompletedProcess:
+def _run(apm_binary_path: Path, cwd: Path, *args: str) -> subprocess.CompletedProcess:
     return subprocess.run(
         [str(apm_binary_path), *args],
         cwd=str(cwd),
@@ -97,13 +93,7 @@ def test_install_then_compile_dedups_only_expected_antigravity_rule(
     if agents_md.exists():
         agents_md.unlink()
 
-    unrelated_res = _run(
-        apm_binary_path,
-        proj,
-        "compile",
-        "--target",
-        "antigravity",
-    )
+    unrelated_res = _run(apm_binary_path, proj, "compile", "--target", "antigravity")
     assert unrelated_res.returncode == 0, (
         f"unrelated compile stdout:\n{unrelated_res.stdout}\n"
         f"unrelated compile stderr:\n{unrelated_res.stderr}"

--- a/tests/integration/test_install_compile_antigravity_dedup_e2e.py
+++ b/tests/integration/test_install_compile_antigravity_dedup_e2e.py
@@ -10,12 +10,9 @@ file in the rules directory must not trigger that deduplication.
 from __future__ import annotations
 
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
-
-CLI = [sys.executable, "-m", "apm_cli.cli"]
 
 APM_YML = """name: test-antigravity-dedup
 version: 1.0.0
@@ -41,9 +38,13 @@ EXPECTED_RULE = (
 INSTRUCTION_SENTINEL = "Use type hints everywhere."
 
 
-def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+def _run(
+    apm_binary_path: Path,
+    cwd: Path,
+    *args: str,
+) -> subprocess.CompletedProcess:
     return subprocess.run(
-        CLI + list(args),
+        [str(apm_binary_path), *args],
         cwd=str(cwd),
         capture_output=True,
         text=True,
@@ -66,11 +67,12 @@ def project_with_instruction(tmp_path: Path) -> Path:
 @pytest.mark.integration
 def test_install_then_compile_dedups_only_expected_antigravity_rule(
     project_with_instruction: Path,
+    apm_binary_path: Path,
 ) -> None:
     """Real install+compile proves Antigravity rule frontmatter and dedup."""
     proj = project_with_instruction
 
-    install_res = _run(proj, "install", "--target", "antigravity")
+    install_res = _run(apm_binary_path, proj, "install", "--target", "antigravity")
     assert install_res.returncode == 0, (
         f"install stdout:\n{install_res.stdout}\ninstall stderr:\n{install_res.stderr}"
     )
@@ -79,7 +81,7 @@ def test_install_then_compile_dedups_only_expected_antigravity_rule(
     rule_file = rules_dir / "style.md"
     assert rule_file.read_text(encoding="utf-8") == EXPECTED_RULE
 
-    dedup_res = _run(proj, "compile", "--target", "antigravity")
+    dedup_res = _run(apm_binary_path, proj, "compile", "--target", "antigravity")
     assert dedup_res.returncode == 0, (
         f"dedup compile stdout:\n{dedup_res.stdout}\ndedup compile stderr:\n{dedup_res.stderr}"
     )
@@ -95,7 +97,13 @@ def test_install_then_compile_dedups_only_expected_antigravity_rule(
     if agents_md.exists():
         agents_md.unlink()
 
-    unrelated_res = _run(proj, "compile", "--target", "antigravity")
+    unrelated_res = _run(
+        apm_binary_path,
+        proj,
+        "compile",
+        "--target",
+        "antigravity",
+    )
     assert unrelated_res.returncode == 0, (
         f"unrelated compile stdout:\n{unrelated_res.stdout}\n"
         f"unrelated compile stderr:\n{unrelated_res.stderr}"

--- a/tests/integration/test_install_compile_claude_dedup_e2e.py
+++ b/tests/integration/test_install_compile_claude_dedup_e2e.py
@@ -20,16 +20,12 @@ full code path, not just the formatter unit.
 from __future__ import annotations
 
 import subprocess
-import sys
 import tempfile
 from pathlib import Path
 
 import pytest
 
 from apm_cli.compilation.constitution import clear_constitution_cache
-
-CLI = [sys.executable, "-m", "apm_cli.cli"]
-
 
 # ---------------------------------------------------------------------------
 # Module-level cache isolation
@@ -68,9 +64,13 @@ INSTRUCTION_BODY = (
 )
 
 
-def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+def _run(
+    apm_binary_path: Path,
+    cwd: Path,
+    *args: str,
+) -> subprocess.CompletedProcess:
     return subprocess.run(
-        CLI + list(args),
+        [str(apm_binary_path), *args],
         cwd=str(cwd),
         capture_output=True,
         text=True,
@@ -90,14 +90,17 @@ def project_with_instruction():
 
 
 @pytest.mark.integration
-def test_install_then_compile_skips_duplicated_instructions(project_with_instruction):
+def test_install_then_compile_skips_duplicated_instructions(
+    project_with_instruction,
+    apm_binary_path: Path,
+):
     """After install populates .claude/rules/, compile must drop the
     instructions section from CLAUDE.md. Pre-PR-#1146 the section was
     duplicated into both files on every compile.
     """
     proj = project_with_instruction
 
-    install_res = _run(proj, "install", "--target", "claude")
+    install_res = _run(apm_binary_path, proj, "install", "--target", "claude")
     assert install_res.returncode == 0, (
         f"install stdout:\n{install_res.stdout}\ninstall stderr:\n{install_res.stderr}"
     )
@@ -109,7 +112,7 @@ def test_install_then_compile_skips_duplicated_instructions(project_with_instruc
     rule_files = sorted(rules_dir.glob("*.md"))
     assert rule_files, "install must emit at least one *.md rule file"
 
-    compile_res = _run(proj, "compile", "--target", "claude")
+    compile_res = _run(apm_binary_path, proj, "compile", "--target", "claude")
     assert compile_res.returncode == 0, (
         f"compile stdout:\n{compile_res.stdout}\ncompile stderr:\n{compile_res.stderr}"
     )
@@ -128,7 +131,10 @@ def test_install_then_compile_skips_duplicated_instructions(project_with_instruc
 
 
 @pytest.mark.integration
-def test_clean_flag_removes_stale_apm_generated_claude_md(project_with_instruction):
+def test_clean_flag_removes_stale_apm_generated_claude_md(
+    project_with_instruction,
+    apm_binary_path: Path,
+):
     """apm compile --target claude --clean must remove a stale APM-generated
     CLAUDE.md when .claude/rules/ is already populated.
 
@@ -150,7 +156,14 @@ def test_clean_flag_removes_stale_apm_generated_claude_md(project_with_instructi
         encoding="utf-8",
     )
 
-    compile_res = _run(proj, "compile", "--target", "claude", "--clean")
+    compile_res = _run(
+        apm_binary_path,
+        proj,
+        "compile",
+        "--target",
+        "claude",
+        "--clean",
+    )
     assert compile_res.returncode == 0, (
         f"compile --clean stdout:\n{compile_res.stdout}\n"
         f"compile --clean stderr:\n{compile_res.stderr}"
@@ -164,7 +177,10 @@ def test_clean_flag_removes_stale_apm_generated_claude_md(project_with_instructi
 
 
 @pytest.mark.integration
-def test_compile_alone_then_compile_again_skips_on_second_run(project_with_instruction):
+def test_compile_alone_then_compile_again_skips_on_second_run(
+    project_with_instruction,
+    apm_binary_path: Path,
+):
     """`apm compile` itself also writes per-file rules into
     ``.claude/rules/``; running it twice must trigger the dedup on the
     second pass even if `apm install` was never invoked. Locks in the
@@ -172,7 +188,7 @@ def test_compile_alone_then_compile_again_skips_on_second_run(project_with_instr
     """
     proj = project_with_instruction
 
-    first = _run(proj, "compile", "--target", "claude")
+    first = _run(apm_binary_path, proj, "compile", "--target", "claude")
     assert first.returncode == 0, first.stderr
 
     rules_dir = proj / ".claude" / "rules"
@@ -182,7 +198,7 @@ def test_compile_alone_then_compile_again_skips_on_second_run(project_with_instr
             "build; install->compile path is covered by the sibling test"
         )
 
-    second = _run(proj, "compile", "--target", "claude")
+    second = _run(apm_binary_path, proj, "compile", "--target", "claude")
     assert second.returncode == 0, second.stderr
 
     claude_md = proj / "CLAUDE.md"

--- a/tests/integration/test_install_compile_claude_dedup_e2e.py
+++ b/tests/integration/test_install_compile_claude_dedup_e2e.py
@@ -64,11 +64,7 @@ INSTRUCTION_BODY = (
 )
 
 
-def _run(
-    apm_binary_path: Path,
-    cwd: Path,
-    *args: str,
-) -> subprocess.CompletedProcess:
+def _run(apm_binary_path: Path, cwd: Path, *args: str) -> subprocess.CompletedProcess:
     return subprocess.run(
         [str(apm_binary_path), *args],
         cwd=str(cwd),
@@ -91,8 +87,7 @@ def project_with_instruction():
 
 @pytest.mark.integration
 def test_install_then_compile_skips_duplicated_instructions(
-    project_with_instruction,
-    apm_binary_path: Path,
+    project_with_instruction, apm_binary_path: Path
 ):
     """After install populates .claude/rules/, compile must drop the
     instructions section from CLAUDE.md. Pre-PR-#1146 the section was
@@ -132,8 +127,7 @@ def test_install_then_compile_skips_duplicated_instructions(
 
 @pytest.mark.integration
 def test_clean_flag_removes_stale_apm_generated_claude_md(
-    project_with_instruction,
-    apm_binary_path: Path,
+    project_with_instruction, apm_binary_path: Path
 ):
     """apm compile --target claude --clean must remove a stale APM-generated
     CLAUDE.md when .claude/rules/ is already populated.
@@ -156,14 +150,7 @@ def test_clean_flag_removes_stale_apm_generated_claude_md(
         encoding="utf-8",
     )
 
-    compile_res = _run(
-        apm_binary_path,
-        proj,
-        "compile",
-        "--target",
-        "claude",
-        "--clean",
-    )
+    compile_res = _run(apm_binary_path, proj, "compile", "--target", "claude", "--clean")
     assert compile_res.returncode == 0, (
         f"compile --clean stdout:\n{compile_res.stdout}\n"
         f"compile --clean stderr:\n{compile_res.stderr}"
@@ -178,8 +165,7 @@ def test_clean_flag_removes_stale_apm_generated_claude_md(
 
 @pytest.mark.integration
 def test_compile_alone_then_compile_again_skips_on_second_run(
-    project_with_instruction,
-    apm_binary_path: Path,
+    project_with_instruction, apm_binary_path: Path
 ):
     """`apm compile` itself also writes per-file rules into
     ``.claude/rules/``; running it twice must trigger the dedup on the

--- a/tests/integration/test_install_compile_copilot_dedup_e2e.py
+++ b/tests/integration/test_install_compile_copilot_dedup_e2e.py
@@ -44,11 +44,7 @@ INSTRUCTION_BODY = (
 INSTRUCTION_SENTINEL = "Use type hints everywhere."
 
 
-def _run(
-    apm_binary_path: Path,
-    cwd: Path,
-    *args: str,
-) -> subprocess.CompletedProcess:
+def _run(apm_binary_path: Path, cwd: Path, *args: str) -> subprocess.CompletedProcess:
     return subprocess.run(
         [str(apm_binary_path), *args],
         cwd=str(cwd),
@@ -71,8 +67,7 @@ def project_with_instruction():
 
 @pytest.mark.integration
 def test_install_then_compile_skips_duplicated_instructions(
-    project_with_instruction,
-    apm_binary_path: Path,
+    project_with_instruction, apm_binary_path: Path
 ):
     """After install populates .github/instructions/, compile must drop the
     instructions content from AGENTS.md. Pre-fix, the content was duplicated
@@ -107,8 +102,7 @@ def test_install_then_compile_skips_duplicated_instructions(
 
 @pytest.mark.integration
 def test_compile_without_github_instructions_includes_content(
-    project_with_instruction,
-    apm_binary_path: Path,
+    project_with_instruction, apm_binary_path: Path
 ):
     """Without .github/instructions/ populated, compile should include
     instruction content in AGENTS.md (the non-dedup baseline).

--- a/tests/integration/test_install_compile_copilot_dedup_e2e.py
+++ b/tests/integration/test_install_compile_copilot_dedup_e2e.py
@@ -19,13 +19,10 @@ code path, not just the unit logic.
 from __future__ import annotations
 
 import subprocess
-import sys
 import tempfile
 from pathlib import Path
 
 import pytest
-
-CLI = [sys.executable, "-m", "apm_cli.cli"]
 
 APM_YML = """name: test-copilot-dedup
 version: 1.0.0
@@ -47,9 +44,13 @@ INSTRUCTION_BODY = (
 INSTRUCTION_SENTINEL = "Use type hints everywhere."
 
 
-def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess:
+def _run(
+    apm_binary_path: Path,
+    cwd: Path,
+    *args: str,
+) -> subprocess.CompletedProcess:
     return subprocess.run(
-        CLI + list(args),
+        [str(apm_binary_path), *args],
         cwd=str(cwd),
         capture_output=True,
         text=True,
@@ -69,14 +70,17 @@ def project_with_instruction():
 
 
 @pytest.mark.integration
-def test_install_then_compile_skips_duplicated_instructions(project_with_instruction):
+def test_install_then_compile_skips_duplicated_instructions(
+    project_with_instruction,
+    apm_binary_path: Path,
+):
     """After install populates .github/instructions/, compile must drop the
     instructions content from AGENTS.md. Pre-fix, the content was duplicated
     into both files on every compile.
     """
     proj = project_with_instruction
 
-    install_res = _run(proj, "install", "--target", "copilot")
+    install_res = _run(apm_binary_path, proj, "install", "--target", "copilot")
     assert install_res.returncode == 0, (
         f"install stdout:\n{install_res.stdout}\ninstall stderr:\n{install_res.stderr}"
     )
@@ -88,7 +92,7 @@ def test_install_then_compile_skips_duplicated_instructions(project_with_instruc
     instr_files = sorted(instructions_dir.glob("*.md"))
     assert instr_files, "install must emit at least one *.md instructions file"
 
-    compile_res = _run(proj, "compile", "--target", "agents")
+    compile_res = _run(apm_binary_path, proj, "compile", "--target", "agents")
     assert compile_res.returncode == 0, (
         f"compile stdout:\n{compile_res.stdout}\ncompile stderr:\n{compile_res.stderr}"
     )
@@ -102,13 +106,16 @@ def test_install_then_compile_skips_duplicated_instructions(project_with_instruc
 
 
 @pytest.mark.integration
-def test_compile_without_github_instructions_includes_content(project_with_instruction):
+def test_compile_without_github_instructions_includes_content(
+    project_with_instruction,
+    apm_binary_path: Path,
+):
     """Without .github/instructions/ populated, compile should include
     instruction content in AGENTS.md (the non-dedup baseline).
     """
     proj = project_with_instruction
 
-    compile_res = _run(proj, "compile", "--target", "agents")
+    compile_res = _run(apm_binary_path, proj, "compile", "--target", "agents")
     assert compile_res.returncode == 0, (
         f"compile stdout:\n{compile_res.stdout}\ncompile stderr:\n{compile_res.stderr}"
     )

--- a/tests/integration/test_install_dry_run_e2e.py
+++ b/tests/integration/test_install_dry_run_e2e.py
@@ -10,18 +10,11 @@ GITHUB_APM_PAT or GITHUB_TOKEN for API access.
 """
 
 import subprocess
-from pathlib import Path
 
 import pytest
 import yaml
 
 pytestmark = pytest.mark.requires_github_token
-
-
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
 
 
 @pytest.fixture
@@ -35,9 +28,9 @@ def temp_project(tmp_path):
     return project_dir
 
 
-def _run_apm(apm_command, args, cwd, timeout=180):
+def _run_apm(apm_binary_path, args, cwd, timeout=180):
     return subprocess.run(
-        [apm_command] + args,  # noqa: RUF005
+        [apm_binary_path] + args,  # noqa: RUF005
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -73,12 +66,12 @@ class TestInstallDryRunE2E:
     """End-to-end coverage for `apm install --dry-run`."""
 
     def test_install_dry_run_lists_apm_dependencies_without_changes(
-        self, temp_project, apm_command
+        self, temp_project, apm_binary_path
     ):
         """Dry-run prints the preview banner, lists the APM dep, and writes nothing."""
         _write_apm_yml(temp_project, ["microsoft/apm-sample-package"])
 
-        result = _run_apm(apm_command, ["install", "--dry-run"], temp_project)
+        result = _run_apm(apm_binary_path, ["install", "--dry-run"], temp_project)
         assert result.returncode == 0, (
             f"Dry-run failed:\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
         )
@@ -93,7 +86,7 @@ class TestInstallDryRunE2E:
 
         _assert_no_install_artifacts(temp_project)
 
-    def test_install_dry_run_with_only_packages_filter(self, temp_project, apm_command):
+    def test_install_dry_run_with_only_packages_filter(self, temp_project, apm_binary_path):
         """`--only=apm` suppresses MCP-dependency listing in the dry-run preview."""
         _write_apm_yml(
             temp_project,
@@ -101,7 +94,7 @@ class TestInstallDryRunE2E:
             mcp_packages=["io.github.github/github-mcp-server"],
         )
 
-        result = _run_apm(apm_command, ["install", "--dry-run", "--only=apm"], temp_project)
+        result = _run_apm(apm_binary_path, ["install", "--dry-run", "--only=apm"], temp_project)
         assert result.returncode == 0, (
             f"Filtered dry-run failed:\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
         )
@@ -117,11 +110,11 @@ class TestInstallDryRunE2E:
 
         _assert_no_install_artifacts(temp_project)
 
-    def test_install_dry_run_previews_orphan_removals(self, temp_project, apm_command):
+    def test_install_dry_run_previews_orphan_removals(self, temp_project, apm_binary_path):
         """After a real install, removing the dep + dry-run reports orphan files
         and keeps them on disk (the orphan-preview NameError regression test)."""
         _write_apm_yml(temp_project, ["microsoft/apm-sample-package"])
-        real = _run_apm(apm_command, ["install"], temp_project)
+        real = _run_apm(apm_binary_path, ["install"], temp_project)
         assert real.returncode == 0, (
             f"Initial install failed:\nSTDOUT: {real.stdout}\nSTDERR: {real.stderr}"
         )
@@ -143,7 +136,7 @@ class TestInstallDryRunE2E:
 
         _write_apm_yml(temp_project, [])
 
-        result = _run_apm(apm_command, ["install", "--dry-run"], temp_project)
+        result = _run_apm(apm_binary_path, ["install", "--dry-run"], temp_project)
         assert result.returncode == 0, (
             f"Orphan dry-run failed:\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
         )

--- a/tests/integration/test_install_dry_run_e2e.py
+++ b/tests/integration/test_install_dry_run_e2e.py
@@ -9,7 +9,6 @@ Uses the real `microsoft/apm-sample-package` from GitHub. Requires
 GITHUB_APM_PAT or GITHUB_TOKEN for API access.
 """
 
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -20,15 +19,9 @@ pytestmark = pytest.mark.requires_github_token
 
 
 @pytest.fixture
-def apm_command():
-    """Path to the APM CLI executable (PATH first, then venv fallback)."""
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 @pytest.fixture

--- a/tests/integration/test_install_root_redirect_e2e.py
+++ b/tests/integration/test_install_root_redirect_e2e.py
@@ -37,8 +37,7 @@ def _make_local_dep(pkg: Path) -> None:
 
 
 def test_install_root_resolves_sources_from_pwd_and_writes_under_root(
-    tmp_path: Path,
-    apm_binary_path: Path,
+    tmp_path: Path, apm_binary_path: Path
 ) -> None:
     pkg = tmp_path / "pkg"
     _make_local_dep(pkg)

--- a/tests/integration/test_install_root_redirect_e2e.py
+++ b/tests/integration/test_install_root_redirect_e2e.py
@@ -20,10 +20,7 @@ git, no registry.
 from __future__ import annotations
 
 import subprocess
-import sys
 from pathlib import Path
-
-_INSTALL = [sys.executable, "-m", "apm_cli.cli", "install"]
 
 
 def _make_local_dep(pkg: Path) -> None:
@@ -41,6 +38,7 @@ def _make_local_dep(pkg: Path) -> None:
 
 def test_install_root_resolves_sources_from_pwd_and_writes_under_root(
     tmp_path: Path,
+    apm_binary_path: Path,
 ) -> None:
     pkg = tmp_path / "pkg"
     _make_local_dep(pkg)
@@ -61,7 +59,14 @@ def test_install_root_resolves_sources_from_pwd_and_writes_under_root(
     deploy.mkdir()
 
     result = subprocess.run(
-        [*_INSTALL, "--root", str(deploy), "--target", "copilot"],
+        [
+            str(apm_binary_path),
+            "install",
+            "--root",
+            str(deploy),
+            "--target",
+            "copilot",
+        ],
         cwd=str(consumer),
         capture_output=True,
         text=True,

--- a/tests/integration/test_install_verbose_redaction_e2e.py
+++ b/tests/integration/test_install_verbose_redaction_e2e.py
@@ -13,7 +13,6 @@ GITHUB_TOKEN to be configured in CI.
 """
 
 import os
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -27,15 +26,9 @@ CANARY_CORE = "BOGUS_REDACTION_CANARY_DO_NOT_LEAK"
 
 
 @pytest.fixture
-def apm_command():
-    """Get the path to the APM CLI executable."""
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 @pytest.fixture

--- a/tests/integration/test_install_verbose_redaction_e2e.py
+++ b/tests/integration/test_install_verbose_redaction_e2e.py
@@ -14,7 +14,6 @@ GITHUB_TOKEN to be configured in CI.
 
 import os
 import subprocess
-from pathlib import Path
 
 import pytest
 import yaml
@@ -23,12 +22,6 @@ pytestmark = pytest.mark.requires_apm_binary
 
 CANARY = "github_pat_BOGUS_REDACTION_CANARY_DO_NOT_LEAK"
 CANARY_CORE = "BOGUS_REDACTION_CANARY_DO_NOT_LEAK"
-
-
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
 
 
 @pytest.fixture
@@ -52,9 +45,9 @@ def _bogus_env():
     return env
 
 
-def _run_apm_with_env(apm_command, args, cwd, env, timeout=60):
+def _run_apm_with_env(apm_binary_path, args, cwd, env, timeout=60):
     return subprocess.run(
-        [apm_command] + args,  # noqa: RUF005
+        [apm_binary_path] + args,  # noqa: RUF005
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -101,14 +94,14 @@ def _assert_install_failed(result):
 class TestVerboseInstallTokenRedaction:
     """Regression guard for PR #764 -- verbose install must redact tokens."""
 
-    def test_verbose_install_does_not_leak_token_on_404_repo(self, temp_project, apm_command):
+    def test_verbose_install_does_not_leak_token_on_404_repo(self, temp_project, apm_binary_path):
         """API-probe path: nonexistent shorthand repo ref, auth fails."""
         _write_apm_yml(
             temp_project,
             ["microsoft/this-repo-definitely-does-not-exist-xyz123"],
         )
         result = _run_apm_with_env(
-            apm_command,
+            apm_binary_path,
             ["install", "--verbose"],
             temp_project,
             _bogus_env(),
@@ -116,14 +109,14 @@ class TestVerboseInstallTokenRedaction:
         _assert_install_failed(result)
         _assert_no_canary(result)
 
-    def test_verbose_install_does_not_leak_token_in_url_form(self, temp_project, apm_command):
+    def test_verbose_install_does_not_leak_token_in_url_form(self, temp_project, apm_binary_path):
         """URL-probe path: explicit git+https URL, auth fails."""
         _write_apm_yml(
             temp_project,
             [{"git": "https://github.com/microsoft/this-also-does-not-exist-xyz789.git"}],
         )
         result = _run_apm_with_env(
-            apm_command,
+            apm_binary_path,
             ["install", "--verbose"],
             temp_project,
             _bogus_env(),

--- a/tests/integration/test_intellij_target.py
+++ b/tests/integration/test_intellij_target.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -43,21 +42,9 @@ _BASE_ENV: dict[str, str] = {"APM_E2E_TESTS": "1"}
 
 
 @pytest.fixture()
-def apm_command() -> str:
-    """Return the APM executable used by the end-to-end test."""
-    executable_name = "apm.exe" if sys.platform == "win32" else "apm"
-    venv_apm = (
-        Path(__file__).parents[2]
-        / ".venv"
-        / ("Scripts" if sys.platform == "win32" else "bin")
-        / executable_name
-    )
-    if venv_apm.exists():
-        return str(venv_apm)
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    pytest.fail("APM executable not found in the project virtualenv or PATH")
+def apm_command(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 @pytest.fixture()

--- a/tests/integration/test_intellij_target.py
+++ b/tests/integration/test_intellij_target.py
@@ -42,12 +42,6 @@ _BASE_ENV: dict[str, str] = {"APM_E2E_TESTS": "1"}
 
 
 @pytest.fixture()
-def apm_command(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
-
-
-@pytest.fixture()
 def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Isolated home directory wired into every APM config lookup."""
     home = tmp_path / "home"
@@ -153,7 +147,7 @@ class TestIntelliJCliE2E:
     def test_mcp_install_respects_composed_target_set(
         self,
         tmp_path: Path,
-        apm_command: str,
+        apm_binary_path: str,
         target: str,
         expect_claude: bool,
     ) -> None:
@@ -180,7 +174,7 @@ class TestIntelliJCliE2E:
 
         result = subprocess.run(
             [
-                apm_command,
+                apm_binary_path,
                 "install",
                 "--mcp",
                 "test-http-server",

--- a/tests/integration/test_intra_package_cleanup.py
+++ b/tests/integration/test_intra_package_cleanup.py
@@ -9,18 +9,11 @@ and do not require GITHUB_APM_PAT / GITHUB_TOKEN.
 """
 
 import subprocess
-from pathlib import Path
 
 import pytest
 import yaml
 
 pytestmark = pytest.mark.requires_apm_binary
-
-
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
 
 
 @pytest.fixture
@@ -52,10 +45,10 @@ def local_pkg_root(tmp_path):
     return pkg
 
 
-def _run_apm(apm_command, args, cwd, timeout=180):
+def _run_apm(apm_binary_path, args, cwd, timeout=180):
     """Run an apm CLI command and return the result."""
     return subprocess.run(
-        [apm_command] + args,  # noqa: RUF005
+        [apm_binary_path] + args,  # noqa: RUF005
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -163,14 +156,14 @@ class TestNestedPackagePrune:
     """End-to-end regression coverage for nested package ownership."""
 
     def test_prune_preserves_nested_content_then_removes_whole_parent(
-        self, temp_project, apm_command, tmp_path
+        self, temp_project, apm_binary_path, tmp_path
     ):
         """Prune protects a declared parent, then removes all of it once orphaned."""
         parent = _make_local_nested_package(tmp_path, "parent-pkg")
         unrelated = _make_local_nested_package(tmp_path, "unrelated-pkg")
         _write_apm_yml_local_packages(temp_project, [parent, unrelated])
 
-        installed = _run_apm(apm_command, ["install"], temp_project)
+        installed = _run_apm(apm_binary_path, ["install"], temp_project)
         assert installed.returncode == 0, (
             f"Install failed:\nSTDOUT: {installed.stdout}\nSTDERR: {installed.stderr}"
         )
@@ -182,14 +175,14 @@ class TestNestedPackagePrune:
         assert nested_payload.is_file()
         assert unrelated_payload.is_file()
 
-        updated = _run_apm(apm_command, ["update", "--yes"], temp_project)
+        updated = _run_apm(apm_binary_path, ["update", "--yes"], temp_project)
         assert updated.returncode == 0, (
             f"Update failed:\nSTDOUT: {updated.stdout}\nSTDERR: {updated.stderr}"
         )
         assert nested_payload.is_file(), "Update removed nested package content"
         assert unrelated_payload.is_file(), "Update removed unrelated package content"
 
-        kept = _run_apm(apm_command, ["prune"], temp_project)
+        kept = _run_apm(apm_binary_path, ["prune"], temp_project)
         assert kept.returncode == 0, (
             f"Initial prune failed:\nSTDOUT: {kept.stdout}\nSTDERR: {kept.stderr}"
         )
@@ -197,7 +190,7 @@ class TestNestedPackagePrune:
         assert unrelated_payload.is_file(), "Unrelated package content was pruned"
 
         _write_apm_yml_local_packages(temp_project, [unrelated])
-        removed = _run_apm(apm_command, ["prune"], temp_project)
+        removed = _run_apm(apm_binary_path, ["prune"], temp_project)
         assert removed.returncode == 0, (
             f"Orphan prune failed:\nSTDOUT: {removed.stdout}\nSTDERR: {removed.stderr}"
         )
@@ -210,12 +203,12 @@ class TestFileRenamedWithinPackage:
     """Regression tests for issue #666: renaming a file inside a still-present
     package must delete the stale deployed artifacts on the next apm install."""
 
-    def test_renamed_file_cleanup_on_install(self, temp_project, apm_command, local_pkg_root):
+    def test_renamed_file_cleanup_on_install(self, temp_project, apm_binary_path, local_pkg_root):
         """Rename a source primitive, re-install, assert old files gone and
         lockfile deployed_files no longer lists the stale paths."""
         # -- Step 1: initial install --
         _write_apm_yml_local(temp_project, local_pkg_root)
-        result1 = _run_apm(apm_command, ["install"], temp_project)
+        result1 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result1.returncode == 0, (
             f"Initial install failed:\nSTDOUT: {result1.stdout}\nSTDERR: {result1.stderr}"
         )
@@ -236,7 +229,7 @@ class TestFileRenamedWithinPackage:
         src.rename(new)
 
         # -- Step 3: re-install --
-        result2 = _run_apm(apm_command, ["install"], temp_project)
+        result2 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result2.returncode == 0, (
             f"Re-install failed:\nSTDOUT: {result2.stdout}\nSTDERR: {result2.stderr}"
         )
@@ -257,7 +250,9 @@ class TestFileRenamedWithinPackage:
                 f"Stale path {stale} still in lockfile deployed_files after cleanup"
             )
 
-    def test_partial_install_cleans_renamed_file(self, temp_project, apm_command, local_pkg_root):
+    def test_partial_install_cleans_renamed_file(
+        self, temp_project, apm_binary_path, local_pkg_root
+    ):
         """`apm install --only=apm` on a package with a renamed file still cleans up.
 
         Verifies that partial installs clean files for the packages they touch
@@ -265,7 +260,7 @@ class TestFileRenamedWithinPackage:
         no-ops on partial installs."""
         # -- Step 1: initial install --
         _write_apm_yml_local(temp_project, local_pkg_root)
-        result1 = _run_apm(apm_command, ["install"], temp_project)
+        result1 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result1.returncode == 0, f"Initial install failed: {result1.stderr}"
 
         lockfile_before = _read_lockfile(temp_project)
@@ -282,7 +277,7 @@ class TestFileRenamedWithinPackage:
         src.rename(new)
 
         # -- Step 3: partial install --
-        result2 = _run_apm(apm_command, ["install", "--only=apm"], temp_project)
+        result2 = _run_apm(apm_binary_path, ["install", "--only=apm"], temp_project)
         assert result2.returncode == 0, f"Partial re-install failed: {result2.stderr}"
 
         # -- Step 4: old deployed files must be gone --
@@ -306,7 +301,7 @@ class TestCrossPackageSharedFileCleanup:
     """Regression tests for issue #1831 across real local-path packages."""
 
     def test_shared_file_survives_when_other_package_still_deploys_it(
-        self, temp_project, apm_command, tmp_path
+        self, temp_project, apm_binary_path, tmp_path
     ):
         """If pkg-a drops a shared prompt, pkg-b's deployed copy survives."""
         shared_body = "---\ndescription: shared\n---\nshared\n"
@@ -325,7 +320,7 @@ class TestCrossPackageSharedFileCleanup:
         )
         _write_apm_yml_local_packages(temp_project, [pkg_a, pkg_b])
 
-        result1 = _run_apm(apm_command, ["install"], temp_project)
+        result1 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result1.returncode == 0, (
             f"Initial install failed:\nSTDOUT: {result1.stdout}\nSTDERR: {result1.stderr}"
         )
@@ -349,7 +344,7 @@ class TestCrossPackageSharedFileCleanup:
         (pkg_a / ".apm" / "prompts" / "shared.prompt.md").unlink()
         (pkg_a / ".apm" / "prompts" / "only-a.prompt.md").unlink()
 
-        result2 = _run_apm(apm_command, ["install"], temp_project)
+        result2 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result2.returncode == 0, (
             f"Re-install failed:\nSTDOUT: {result2.stdout}\nSTDERR: {result2.stderr}"
         )

--- a/tests/integration/test_intra_package_cleanup.py
+++ b/tests/integration/test_intra_package_cleanup.py
@@ -8,7 +8,6 @@ Uses a throwaway local-path package fixture so these tests are fully local
 and do not require GITHUB_APM_PAT / GITHUB_TOKEN.
 """
 
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -19,15 +18,9 @@ pytestmark = pytest.mark.requires_apm_binary
 
 
 @pytest.fixture
-def apm_command():
-    """Path to the APM CLI executable."""
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 @pytest.fixture

--- a/tests/integration/test_link_rewrite_e2e.py
+++ b/tests/integration/test_link_rewrite_e2e.py
@@ -45,12 +45,6 @@ pytestmark = pytest.mark.requires_apm_binary
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
-
-
 def _write(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     # write_bytes (not write_text) keeps newlines as \n on Windows;
@@ -81,9 +75,9 @@ def _make_consumer(root: Path, *, targets: list[str] | None = None) -> Path:
     return consumer
 
 
-def _run_install(apm_bin: str, consumer: Path, *args: str) -> subprocess.CompletedProcess:
+def _run_install(apm_binary_path: Path, consumer: Path, *args: str) -> subprocess.CompletedProcess:
     return subprocess.run(
-        [apm_bin, "install", *args],
+        [str(apm_binary_path), "install", *args],
         cwd=consumer,
         capture_output=True,
         text=True,
@@ -122,10 +116,10 @@ class TestInstructionSiblingLinkRewriting:
         consumer = _make_consumer(ws)
         return consumer, producer
 
-    def test_link_rewritten_and_resolves_on_disk(self, workspace, apm_command):
+    def test_link_rewritten_and_resolves_on_disk(self, workspace, apm_binary_path):
         consumer, producer = workspace
 
-        result = _run_install(apm_command, consumer, str(producer))
+        result = _run_install(apm_binary_path, consumer, str(producer))
         assert result.returncode == 0, f"Install failed:\n{result.stderr}\n{result.stdout}"
 
         deployed = consumer / ".github" / "instructions" / "foo.instructions.md"
@@ -168,9 +162,9 @@ class TestPromptSiblingLinkRewriting:
         consumer = _make_consumer(ws)
         return consumer, producer
 
-    def test_prompt_link_rewritten_and_resolves(self, workspace, apm_command):
+    def test_prompt_link_rewritten_and_resolves(self, workspace, apm_binary_path):
         consumer, producer = workspace
-        result = _run_install(apm_command, consumer, str(producer))
+        result = _run_install(apm_binary_path, consumer, str(producer))
         assert result.returncode == 0, f"Install failed:\n{result.stderr}\n{result.stdout}"
 
         deployed = consumer / ".github" / "prompts" / "review.prompt.md"
@@ -213,9 +207,9 @@ class TestMixedLinkTypes:
         consumer = _make_consumer(ws)
         return consumer, producer
 
-    def test_only_relative_in_package_links_rewritten(self, workspace, apm_command):
+    def test_only_relative_in_package_links_rewritten(self, workspace, apm_binary_path):
         consumer, producer = workspace
-        result = _run_install(apm_command, consumer, str(producer))
+        result = _run_install(apm_binary_path, consumer, str(producer))
         assert result.returncode == 0, f"Install failed:\n{result.stderr}\n{result.stdout}"
 
         deployed = consumer / ".github" / "instructions" / "many.instructions.md"
@@ -269,9 +263,9 @@ class TestEscapeOutsidePackagePreserved:
         consumer = _make_consumer(ws)
         return consumer, producer, ws
 
-    def test_escape_link_preserved_verbatim(self, workspace, apm_command):
+    def test_escape_link_preserved_verbatim(self, workspace, apm_binary_path):
         consumer, producer, _ = workspace
-        result = _run_install(apm_command, consumer, str(producer))
+        result = _run_install(apm_binary_path, consumer, str(producer))
         assert result.returncode == 0, f"Install failed:\n{result.stderr}\n{result.stdout}"
 
         deployed = consumer / ".github" / "instructions" / "escape.instructions.md"
@@ -329,9 +323,9 @@ class TestSkillBundleInternalLinkUnchanged:
         (consumer / ".agents").mkdir()
         return consumer, producer
 
-    def test_in_bundle_link_resolves_after_install(self, workspace, apm_command):
+    def test_in_bundle_link_resolves_after_install(self, workspace, apm_binary_path):
         consumer, producer = workspace
-        result = _run_install(apm_command, consumer, str(producer))
+        result = _run_install(apm_binary_path, consumer, str(producer))
         assert result.returncode == 0, f"Install failed:\n{result.stderr}\n{result.stdout}"
 
         # Skills under the copilot target deploy under .agents/skills/<name>/
@@ -358,9 +352,9 @@ class TestSkillBundleInternalLinkUnchanged:
         )
         assert resolved.read_text(encoding="utf-8").startswith("# Reference")
 
-    def test_outbound_skill_links_rewritten_to_apm_modules(self, workspace, apm_command):
+    def test_outbound_skill_links_rewritten_to_apm_modules(self, workspace, apm_binary_path):
         consumer, producer = workspace
-        result = _run_install(apm_command, consumer, str(producer))
+        result = _run_install(apm_binary_path, consumer, str(producer))
         assert result.returncode == 0, f"Install failed:\n{result.stderr}\n{result.stdout}"
 
         deployed_skills = [
@@ -418,9 +412,9 @@ class TestMultiTargetLinkRewriting:
         (consumer / ".claude").mkdir()
         return consumer, producer
 
-    def test_both_targets_resolve(self, workspace, apm_command):
+    def test_both_targets_resolve(self, workspace, apm_binary_path):
         consumer, producer = workspace
-        result = _run_install(apm_command, consumer, str(producer))
+        result = _run_install(apm_binary_path, consumer, str(producer))
         assert result.returncode == 0, f"Install failed:\n{result.stderr}\n{result.stdout}"
 
         # Find every deployed copy of the instruction across targets,

--- a/tests/integration/test_link_rewrite_e2e.py
+++ b/tests/integration/test_link_rewrite_e2e.py
@@ -32,7 +32,6 @@ safe to run in CI without tokens.
 from __future__ import annotations
 
 import re
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -47,15 +46,9 @@ pytestmark = pytest.mark.requires_apm_binary
 
 
 @pytest.fixture
-def apm_command():
-    """Resolve the ``apm`` binary the same way other local-install tests do."""
-    on_path = shutil.which("apm")
-    if on_path:
-        return on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 def _write(path: Path, content: str) -> None:

--- a/tests/integration/test_local_content_audit.py
+++ b/tests/integration/test_local_content_audit.py
@@ -29,12 +29,6 @@ pytestmark = pytest.mark.requires_apm_binary
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
-
-
 def _write_manifest(project: Path, *, includes=None) -> None:
     """Write a minimal apm.yml. ``includes`` may be None, 'auto', or a list."""
     data = {
@@ -73,10 +67,10 @@ def _make_project(tmp_path: Path, *, includes=None) -> Path:
     return project
 
 
-def _run_apm(apm_command: str, args, cwd: Path):
+def _run_apm(apm_binary_path: str, args, cwd: Path):
     """Invoke the apm CLI and return CompletedProcess."""
     return subprocess.run(
-        [apm_command, *args],
+        [apm_binary_path, *args],
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -84,8 +78,8 @@ def _run_apm(apm_command: str, args, cwd: Path):
     )
 
 
-def _install(apm_command: str, project: Path):
-    result = _run_apm(apm_command, ["install"], project)
+def _install(apm_binary_path: str, project: Path):
+    result = _run_apm(apm_binary_path, ["install"], project)
     assert result.returncode == 0, (
         f"apm install failed (exit {result.returncode}):\n"
         f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
@@ -93,13 +87,13 @@ def _install(apm_command: str, project: Path):
     return result
 
 
-def _audit_json(apm_command: str, project: Path, extra_args=()):
+def _audit_json(apm_binary_path: str, project: Path, extra_args=()):
     """Run ``apm audit --ci -f json`` and return (exit_code, parsed_json)."""
     args = ["audit", "--ci", "--no-policy", "-f", "json", *extra_args]
     if "--policy" in extra_args:
         # When policy is provided, drop --no-policy so the override wins.
         args = ["audit", "--ci", "-f", "json", *extra_args]
-    result = _run_apm(apm_command, args, project)
+    result = _run_apm(apm_binary_path, args, project)
     # JSON output is on stdout; tolerate trailing log lines.
     payload = None
     try:
@@ -133,10 +127,10 @@ def _check(payload: dict, name: str) -> dict:
 class TestLocalContentAudit:
     """End-to-end coverage for issue #887 close-the-gap behavior."""
 
-    def test_install_records_self_entry(self, tmp_path, apm_command):
+    def test_install_records_self_entry(self, tmp_path, apm_binary_path):
         """Test A: ``apm install`` records local files + hashes in lockfile."""
         project = _make_project(tmp_path)
-        _install(apm_command, project)
+        _install(apm_binary_path, project)
 
         lock_path = project / "apm.lock.yaml"
         assert lock_path.exists(), "apm.lock.yaml not created by install"
@@ -165,12 +159,12 @@ class TestLocalContentAudit:
             f"hash not sha256-prefixed: {hashes[instr_keys[0]]!r}"
         )
 
-    def test_audit_passes_clean_install(self, tmp_path, apm_command):
+    def test_audit_passes_clean_install(self, tmp_path, apm_binary_path):
         """Test B: clean install passes audit; consent advisory present."""
         project = _make_project(tmp_path)  # no includes: declared
-        _install(apm_command, project)
+        _install(apm_binary_path, project)
 
-        exit_code, payload, _ = _audit_json(apm_command, project)
+        exit_code, payload, _ = _audit_json(apm_binary_path, project)
         assert exit_code == 0, f"audit --ci failed on clean install: {payload}"
         assert payload["passed"] is True
 
@@ -189,10 +183,10 @@ class TestLocalContentAudit:
             f"got: {consent['message']!r}"
         )
 
-    def test_audit_detects_drift(self, tmp_path, apm_command):
+    def test_audit_detects_drift(self, tmp_path, apm_binary_path):
         """Test C: hand-edit a deployed file -> hash-drift detected."""
         project = _make_project(tmp_path)
-        _install(apm_command, project)
+        _install(apm_binary_path, project)
 
         # Tamper with the deployed copy under .github/.
         deployed_instr = project / ".github" / "instructions" / "bar.instructions.md"
@@ -200,7 +194,7 @@ class TestLocalContentAudit:
         with open(deployed_instr, "a") as f:
             f.write("\nTAMPERED\n")
 
-        exit_code, payload, result = _audit_json(apm_command, project)
+        exit_code, payload, result = _audit_json(apm_binary_path, project)
         assert exit_code != 0, (
             f"audit --ci should fail on drift but passed: {payload}\nSTDERR: {result.stderr}"
         )
@@ -214,7 +208,7 @@ class TestLocalContentAudit:
             f"path of modified file not surfaced: {haystack!r}"
         )
 
-    def test_audit_passes_when_deployed_file_has_crlf(self, tmp_path, apm_command):
+    def test_audit_passes_when_deployed_file_has_crlf(self, tmp_path, apm_binary_path):
         """Test F (issue #1952): a deployed file whose only post-install
         change is LF -> CRLF must NOT be flagged as content drift.
 
@@ -226,7 +220,7 @@ class TestLocalContentAudit:
         identical content and pass.
         """
         project = _make_project(tmp_path)
-        _install(apm_command, project)
+        _install(apm_binary_path, project)
 
         deployed_instr = project / ".github" / "instructions" / "bar.instructions.md"
         assert deployed_instr.exists(), f"target file missing post-install: {deployed_instr}"
@@ -238,7 +232,7 @@ class TestLocalContentAudit:
         assert crlf != original, "rewrite did not change any line endings"
         deployed_instr.write_bytes(crlf)
 
-        exit_code, payload, result = _audit_json(apm_command, project)
+        exit_code, payload, result = _audit_json(apm_binary_path, project)
         assert exit_code == 0, (
             f"audit --ci should pass on a CRLF-only difference but failed: {payload}\n"
             f"STDERR: {result.stderr}"
@@ -248,13 +242,13 @@ class TestLocalContentAudit:
             f"content-integrity false-flagged a CRLF-only change (issue #1952): {ci}"
         )
 
-    def test_audit_passes_with_explicit_includes(self, tmp_path, apm_command):
+    def test_audit_passes_with_explicit_includes(self, tmp_path, apm_binary_path):
         """Test D: declaring ``includes:`` removes the consent advisory."""
         # Use 'auto' first.
         project = _make_project(tmp_path, includes="auto")
-        _install(apm_command, project)
+        _install(apm_binary_path, project)
 
-        exit_code, payload, _ = _audit_json(apm_command, project)
+        exit_code, payload, _ = _audit_json(apm_binary_path, project)
         assert exit_code == 0, f"audit failed unexpectedly: {payload}"
 
         consent = _check(payload, "includes-consent")
@@ -271,15 +265,15 @@ class TestLocalContentAudit:
                 ".apm/instructions/bar.instructions.md",
             ],
         )
-        exit_code2, payload2, _ = _audit_json(apm_command, project)
+        exit_code2, payload2, _ = _audit_json(apm_binary_path, project)
         assert exit_code2 == 0, f"audit failed with explicit list: {payload2}"
         consent2 = _check(payload2, "includes-consent")
         assert "[!]" not in consent2["message"]
 
-    def test_policy_blocks_undeclared_includes(self, tmp_path, apm_command):
+    def test_policy_blocks_undeclared_includes(self, tmp_path, apm_binary_path):
         """Test E: ``require_explicit_includes`` blocks ``includes: auto``."""
         project = _make_project(tmp_path, includes="auto")
-        _install(apm_command, project)
+        _install(apm_binary_path, project)
 
         # Local policy file -- pass via --policy <path>.
         policy_path = project / "apm-policy.yml"
@@ -295,7 +289,7 @@ class TestLocalContentAudit:
         )
 
         exit_code, payload, result = _audit_json(
-            apm_command, project, extra_args=["--policy", str(policy_path)]
+            apm_binary_path, project, extra_args=["--policy", str(policy_path)]
         )
         assert exit_code != 0, (
             f"policy should have blocked includes: auto but passed:\n"

--- a/tests/integration/test_local_content_audit.py
+++ b/tests/integration/test_local_content_audit.py
@@ -16,7 +16,6 @@ project on disk and ``apm`` invoked via subprocess.  Verifies:
 """
 
 import json
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -31,15 +30,9 @@ pytestmark = pytest.mark.requires_apm_binary
 
 
 @pytest.fixture
-def apm_command():
-    """Resolve the ``apm`` CLI executable for subprocess invocation."""
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 def _write_manifest(project: Path, *, includes=None) -> None:

--- a/tests/integration/test_local_install.py
+++ b/tests/integration/test_local_install.py
@@ -5,7 +5,6 @@ These tests create real file structures and invoke CLI commands via subprocess.
 """
 
 import os  # noqa: F401
-import shutil
 import subprocess
 import sys  # noqa: F401
 import tempfile  # noqa: F401
@@ -22,15 +21,9 @@ pytestmark = pytest.mark.requires_apm_binary
 
 
 @pytest.fixture
-def apm_command():
-    """Get the path to the APM CLI executable."""
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 @pytest.fixture

--- a/tests/integration/test_local_install.py
+++ b/tests/integration/test_local_install.py
@@ -8,7 +8,6 @@ import os  # noqa: F401
 import subprocess
 import sys  # noqa: F401
 import tempfile  # noqa: F401
-from pathlib import Path
 
 import pytest
 import yaml
@@ -18,12 +17,6 @@ pytestmark = pytest.mark.requires_apm_binary
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
 
 
 @pytest.fixture
@@ -117,11 +110,11 @@ def temp_workspace(tmp_path):
 class TestLocalInstall:
     """Test `apm install ./local/path` workflow."""
 
-    def test_install_local_package_relative_path(self, temp_workspace, apm_command):
+    def test_install_local_package_relative_path(self, temp_workspace, apm_binary_path):
         """Install a local package using a relative path."""
         consumer = temp_workspace / "consumer"
         result = subprocess.run(
-            [apm_command, "install", "../packages/local-skills"],
+            [apm_binary_path, "install", "../packages/local-skills"],
             cwd=consumer,
             capture_output=True,
             text=True,
@@ -150,12 +143,12 @@ class TestLocalInstall:
         # Local deps have source: local
         assert any(d.get("source") == "local" for d in deps), f"No local source in lockfile: {deps}"
 
-    def test_install_local_package_absolute_path(self, temp_workspace, apm_command):
+    def test_install_local_package_absolute_path(self, temp_workspace, apm_binary_path):
         """Install a local package using an absolute path."""
         consumer = temp_workspace / "consumer"
         abs_path = str(temp_workspace / "packages" / "local-skills")
         result = subprocess.run(
-            [apm_command, "install", abs_path],
+            [apm_binary_path, "install", abs_path],
             cwd=consumer,
             capture_output=True,
             text=True,
@@ -169,11 +162,11 @@ class TestLocalInstall:
         apm_deps = data.get("dependencies", {}).get("apm", [])
         assert abs_path in apm_deps
 
-    def test_install_local_deploys_instructions(self, temp_workspace, apm_command):
+    def test_install_local_deploys_instructions(self, temp_workspace, apm_binary_path):
         """Verify that instructions from a local package are deployed to .github/instructions/."""
         consumer = temp_workspace / "consumer"
         result = subprocess.run(
-            [apm_command, "install", "../packages/local-skills"],
+            [apm_binary_path, "install", "../packages/local-skills"],
             cwd=consumer,
             capture_output=True,
             text=True,
@@ -188,11 +181,11 @@ class TestLocalInstall:
             f"Instructions not deployed. Files in .github/: {all_files}\nstdout: {result.stdout}"
         )
 
-    def test_install_local_package_no_manifest_fails(self, temp_workspace, apm_command):
+    def test_install_local_package_no_manifest_fails(self, temp_workspace, apm_binary_path):
         """Installing a path with no apm.yml or SKILL.md should fail gracefully."""
         consumer = temp_workspace / "consumer"
         result = subprocess.run(
-            [apm_command, "install", "../packages/no-manifest"],
+            [apm_binary_path, "install", "../packages/no-manifest"],
             cwd=consumer,
             capture_output=True,
             text=True,
@@ -207,11 +200,11 @@ class TestLocalInstall:
             or "failed validation" in combined.lower()
         ), f"Expected failure message. stdout: {result.stdout}, stderr: {result.stderr}"
 
-    def test_install_nonexistent_local_path_fails(self, temp_workspace, apm_command):
+    def test_install_nonexistent_local_path_fails(self, temp_workspace, apm_binary_path):
         """Installing a non-existent path should fail."""
         consumer = temp_workspace / "consumer"
         result = subprocess.run(
-            [apm_command, "install", "./does-not-exist"],
+            [apm_binary_path, "install", "./does-not-exist"],
             cwd=consumer,
             capture_output=True,
             text=True,
@@ -225,7 +218,7 @@ class TestLocalInstall:
             or "failed validation" in combined.lower()
         )
 
-    def test_install_local_from_apm_yml(self, temp_workspace, apm_command):
+    def test_install_local_from_apm_yml(self, temp_workspace, apm_binary_path):
         """Install local deps declared in apm.yml (bare `apm install`)."""
         consumer = temp_workspace / "consumer"
 
@@ -243,7 +236,7 @@ class TestLocalInstall:
         )
 
         result = subprocess.run(
-            [apm_command, "install"],
+            [apm_binary_path, "install"],
             cwd=consumer,
             capture_output=True,
             text=True,
@@ -255,13 +248,13 @@ class TestLocalInstall:
         install_dir = consumer / "apm_modules" / "_local" / "local-skills"
         assert install_dir.exists()
 
-    def test_reinstall_copies_fresh(self, temp_workspace, apm_command):
+    def test_reinstall_copies_fresh(self, temp_workspace, apm_binary_path):
         """Re-running `apm install` on local deps should re-copy (no SHA to cache)."""
         consumer = temp_workspace / "consumer"
 
         # First install
         subprocess.run(
-            [apm_command, "install", "../packages/local-skills"],
+            [apm_binary_path, "install", "../packages/local-skills"],
             cwd=consumer,
             capture_output=True,
             text=True,
@@ -283,7 +276,7 @@ class TestLocalInstall:
 
         # Re-install
         result = subprocess.run(
-            [apm_command, "install"],
+            [apm_binary_path, "install"],
             cwd=consumer,
             capture_output=True,
             text=True,
@@ -307,13 +300,13 @@ class TestLocalInstall:
 class TestLocalUninstall:
     """Test `apm uninstall ./local/path` workflow."""
 
-    def test_uninstall_local_package(self, temp_workspace, apm_command):
+    def test_uninstall_local_package(self, temp_workspace, apm_binary_path):
         """Uninstall a previously installed local package."""
         consumer = temp_workspace / "consumer"
 
         # Install first
         subprocess.run(
-            [apm_command, "install", "../packages/local-skills"],
+            [apm_binary_path, "install", "../packages/local-skills"],
             cwd=consumer,
             capture_output=True,
             text=True,
@@ -325,7 +318,7 @@ class TestLocalUninstall:
 
         # Uninstall
         result = subprocess.run(
-            [apm_command, "uninstall", "../packages/local-skills"],
+            [apm_binary_path, "uninstall", "../packages/local-skills"],
             cwd=consumer,
             capture_output=True,
             text=True,
@@ -346,13 +339,13 @@ class TestLocalUninstall:
 class TestLocalDeps:
     """Test `apm deps` with local dependencies."""
 
-    def test_deps_shows_local_packages(self, temp_workspace, apm_command):
+    def test_deps_shows_local_packages(self, temp_workspace, apm_binary_path):
         """The `apm deps list` command should list local dependencies."""
         consumer = temp_workspace / "consumer"
 
         # Install a local package
         subprocess.run(
-            [apm_command, "install", "../packages/local-skills"],
+            [apm_binary_path, "install", "../packages/local-skills"],
             cwd=consumer,
             capture_output=True,
             text=True,
@@ -360,7 +353,7 @@ class TestLocalDeps:
         )
 
         result = subprocess.run(
-            [apm_command, "deps", "list"],
+            [apm_binary_path, "deps", "list"],
             cwd=consumer,
             capture_output=True,
             text=True,
@@ -377,7 +370,7 @@ class TestLocalDeps:
 class TestLocalPackMixed:
     """Test that `apm pack` rejects local deps."""
 
-    def test_pack_rejects_with_local_deps(self, temp_workspace, apm_command):
+    def test_pack_rejects_with_local_deps(self, temp_workspace, apm_binary_path):
         """apm pack should refuse when apm.yml has local deps."""
         consumer = temp_workspace / "consumer"
 
@@ -409,7 +402,7 @@ class TestLocalPackMixed:
         _lock.write(consumer / "apm.lock.yaml")
 
         result = subprocess.run(
-            [apm_command, "pack"],
+            [apm_binary_path, "pack"],
             cwd=consumer,
             capture_output=True,
             text=True,
@@ -454,7 +447,7 @@ class TestRootProjectPrimitives:
         (project / ".claude" / "rules").mkdir(parents=True)
         return project
 
-    def test_root_apm_primitives_deployed_with_no_deps(self, tmp_path, apm_command):
+    def test_root_apm_primitives_deployed_with_no_deps(self, tmp_path, apm_binary_path):
         """root apm.yml with no deps + root .apm/ -> rules deployed.
 
         Before the fix, apm install returned early with nothing to install
@@ -463,7 +456,7 @@ class TestRootProjectPrimitives:
         project = self._make_project(tmp_path)
 
         result = subprocess.run(
-            [apm_command, "install"],
+            [apm_binary_path, "install"],
             cwd=project,
             capture_output=True,
             text=True,
@@ -478,7 +471,7 @@ class TestRootProjectPrimitives:
         )
         assert "Local Rules" in deployed.read_text()
 
-    def test_root_apm_primitives_deployed_alongside_external_dep(self, tmp_path, apm_command):
+    def test_root_apm_primitives_deployed_alongside_external_dep(self, tmp_path, apm_binary_path):
         """root apm.yml with external dep + root .apm/ -> both rule sets deployed.
 
         This is the exact scenario from #714: external dependencies in apm.yml
@@ -504,7 +497,7 @@ class TestRootProjectPrimitives:
         project = self._make_project(tmp_path, apm_deps=["../ext-pkg"])
 
         result = subprocess.run(
-            [apm_command, "install"],
+            [apm_binary_path, "install"],
             cwd=project,
             capture_output=True,
             text=True,
@@ -521,7 +514,7 @@ class TestRootProjectPrimitives:
             f"External dep rule NOT deployed. Files: {deployed_names}\nOutput:\n{combined}"
         )
 
-    def test_workaround_sub_package_still_works(self, tmp_path, apm_command):
+    def test_workaround_sub_package_still_works(self, tmp_path, apm_binary_path):
         """Old ./agent/apm.yml workaround continues to work (regression guard)."""
         project = tmp_path / "project"
         project.mkdir()
@@ -554,7 +547,7 @@ class TestRootProjectPrimitives:
         (project / ".claude" / "rules").mkdir(parents=True)
 
         result = subprocess.run(
-            [apm_command, "install"],
+            [apm_binary_path, "install"],
             cwd=project,
             capture_output=True,
             text=True,
@@ -566,13 +559,13 @@ class TestRootProjectPrimitives:
             f"Sub-package rules NOT deployed.\nOutput:\n{combined}"
         )
 
-    def test_root_apm_primitives_idempotent(self, tmp_path, apm_command):
+    def test_root_apm_primitives_idempotent(self, tmp_path, apm_binary_path):
         """Running apm install twice with root .apm/ is idempotent."""
         project = self._make_project(tmp_path)
 
         for run in range(2):
             result = subprocess.run(
-                [apm_command, "install"],
+                [apm_binary_path, "install"],
                 cwd=project,
                 capture_output=True,
                 text=True,
@@ -582,7 +575,7 @@ class TestRootProjectPrimitives:
 
         assert (project / ".claude" / "rules" / "local-rules.md").exists()
 
-    def test_root_apm_hooks_deployed(self, tmp_path, apm_command):
+    def test_root_apm_hooks_deployed(self, tmp_path, apm_binary_path):
         """root .apm/hooks/ is detected and integrated (not just instructions).
 
         Guards the _ROOT_PRIM_SUBDIRS list: a project that only has .apm/hooks/
@@ -610,7 +603,7 @@ class TestRootProjectPrimitives:
         (project / ".claude").mkdir(parents=True)
 
         result = subprocess.run(
-            [apm_command, "install"],
+            [apm_binary_path, "install"],
             cwd=project,
             capture_output=True,
             text=True,
@@ -625,7 +618,7 @@ class TestRootProjectPrimitives:
             f"have triggered early return.\nOutput:\n{combined}"
         )
 
-    def test_root_skill_md_detected(self, tmp_path, apm_command):
+    def test_root_skill_md_detected(self, tmp_path, apm_binary_path):
         """A root SKILL.md alone triggers the integration path.
 
         Guards the (project_root / "SKILL.md").exists() branch in the
@@ -648,7 +641,7 @@ class TestRootProjectPrimitives:
         (project / ".claude").mkdir(parents=True)
 
         result = subprocess.run(
-            [apm_command, "install"],
+            [apm_binary_path, "install"],
             cwd=project,
             capture_output=True,
             text=True,
@@ -665,13 +658,13 @@ class TestRootProjectPrimitives:
 class TestLocalMixedWithRemote:
     """Test mixing local and remote dependencies."""
 
-    def test_install_local_alongside_remote_in_apm_yml(self, temp_workspace, apm_command):
+    def test_install_local_alongside_remote_in_apm_yml(self, temp_workspace, apm_binary_path):
         """Both local and remote deps in apm.yml should install correctly."""
         consumer = temp_workspace / "consumer"
 
         # First install local
         result = subprocess.run(
-            [apm_command, "install", "../packages/local-skills"],
+            [apm_binary_path, "install", "../packages/local-skills"],
             cwd=consumer,
             capture_output=True,
             text=True,

--- a/tests/integration/test_local_path_dependency_targets_e2e.py
+++ b/tests/integration/test_local_path_dependency_targets_e2e.py
@@ -10,13 +10,11 @@ dependency scoped to Copilot never deploys its instructions to Claude.
 from __future__ import annotations
 
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
 import yaml
 
-CLI = [sys.executable, "-m", "apm_cli.cli"]
 TIMEOUT = 180
 
 DEPENDENCY_INSTRUCTION = """---
@@ -29,10 +27,14 @@ This instruction must deploy only to Copilot.
 DEPENDENCY_SENTINEL = "This instruction must deploy only to Copilot."
 
 
-def _run(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+def _run(
+    apm_binary_path: Path,
+    cwd: Path,
+    *args: str,
+) -> subprocess.CompletedProcess[str]:
     """Run the APM CLI in *cwd* and return the completed subprocess."""
     return subprocess.run(
-        CLI + list(args),
+        [str(apm_binary_path), *args],
         cwd=str(cwd),
         capture_output=True,
         text=True,
@@ -95,11 +97,18 @@ def local_path_targets_workspace(tmp_path: Path) -> Path:
 @pytest.mark.integration
 def test_path_dependency_targets_deploy_only_to_declared_target(
     local_path_targets_workspace: Path,
+    apm_binary_path: Path,
 ) -> None:
     """A path dependency with targets: [copilot] must not deploy to Claude."""
     consumer = local_path_targets_workspace
 
-    install_res = _run(consumer, "install", "--target", "copilot,claude")
+    install_res = _run(
+        apm_binary_path,
+        consumer,
+        "install",
+        "--target",
+        "copilot,claude",
+    )
     assert install_res.returncode == 0, (
         f"install stdout:\n{install_res.stdout}\ninstall stderr:\n{install_res.stderr}"
     )
@@ -110,7 +119,13 @@ def test_path_dependency_targets_deploy_only_to_declared_target(
         f"and replay. Lockfile dependencies: {locked_deps}"
     )
 
-    compile_res = _run(consumer, "compile", "--target", "copilot,claude")
+    compile_res = _run(
+        apm_binary_path,
+        consumer,
+        "compile",
+        "--target",
+        "copilot,claude",
+    )
     assert compile_res.returncode == 0, (
         f"compile stdout:\n{compile_res.stdout}\ncompile stderr:\n{compile_res.stderr}"
     )

--- a/tests/integration/test_local_path_dependency_targets_e2e.py
+++ b/tests/integration/test_local_path_dependency_targets_e2e.py
@@ -27,11 +27,7 @@ This instruction must deploy only to Copilot.
 DEPENDENCY_SENTINEL = "This instruction must deploy only to Copilot."
 
 
-def _run(
-    apm_binary_path: Path,
-    cwd: Path,
-    *args: str,
-) -> subprocess.CompletedProcess[str]:
+def _run(apm_binary_path: Path, cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
     """Run the APM CLI in *cwd* and return the completed subprocess."""
     return subprocess.run(
         [str(apm_binary_path), *args],
@@ -102,13 +98,7 @@ def test_path_dependency_targets_deploy_only_to_declared_target(
     """A path dependency with targets: [copilot] must not deploy to Claude."""
     consumer = local_path_targets_workspace
 
-    install_res = _run(
-        apm_binary_path,
-        consumer,
-        "install",
-        "--target",
-        "copilot,claude",
-    )
+    install_res = _run(apm_binary_path, consumer, "install", "--target", "copilot,claude")
     assert install_res.returncode == 0, (
         f"install stdout:\n{install_res.stdout}\ninstall stderr:\n{install_res.stderr}"
     )
@@ -119,13 +109,7 @@ def test_path_dependency_targets_deploy_only_to_declared_target(
         f"and replay. Lockfile dependencies: {locked_deps}"
     )
 
-    compile_res = _run(
-        apm_binary_path,
-        consumer,
-        "compile",
-        "--target",
-        "copilot,claude",
-    )
+    compile_res = _run(apm_binary_path, consumer, "compile", "--target", "copilot,claude")
     assert compile_res.returncode == 0, (
         f"compile stdout:\n{compile_res.stdout}\ncompile stderr:\n{compile_res.stderr}"
     )

--- a/tests/integration/test_lock_e2e.py
+++ b/tests/integration/test_lock_e2e.py
@@ -17,7 +17,6 @@ dependencies are used wherever a real dependency is needed.
 
 from __future__ import annotations
 
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -33,14 +32,8 @@ pytestmark = pytest.mark.requires_apm_binary
 
 
 @pytest.fixture
-def apm_command() -> str:
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    return str(apm_binary_path)
 
 
 def _run_apm(

--- a/tests/integration/test_lock_e2e.py
+++ b/tests/integration/test_lock_e2e.py
@@ -31,19 +31,14 @@ pytestmark = pytest.mark.requires_apm_binary
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    return str(apm_binary_path)
-
-
 def _run_apm(
-    apm_command: str,
+    apm_binary_path: str,
     args: list[str],
     cwd: Path,
     timeout: int = 60,
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        [apm_command, *args],
+        [apm_binary_path, *args],
         cwd=str(cwd),
         capture_output=True,
         text=True,
@@ -88,7 +83,7 @@ def _make_local_package(pkg_dir: Path, name: str) -> None:
 
 class TestLockEmptyDeps:
     def test_no_deps_creates_lockfile_and_exits_zero(
-        self, apm_command: str, tmp_path: Path
+        self, apm_binary_path: str, tmp_path: Path
     ) -> None:
         """A project with no dependencies should produce apm.lock.yaml and
         exit 0 -- the core promise of the lockfile-only path."""
@@ -96,7 +91,7 @@ class TestLockEmptyDeps:
         project.mkdir()
         _write_apm_yml(project)
 
-        result = _run_apm(apm_command, ["lock"], project)
+        result = _run_apm(apm_binary_path, ["lock"], project)
 
         assert result.returncode == 0, (
             f"apm lock exited {result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
@@ -104,13 +99,13 @@ class TestLockEmptyDeps:
         lockfile = project / "apm.lock.yaml"
         assert lockfile.exists(), "apm.lock.yaml must be created even with no dependencies"
 
-    def test_no_deps_lockfile_is_valid_yaml(self, apm_command: str, tmp_path: Path) -> None:
+    def test_no_deps_lockfile_is_valid_yaml(self, apm_binary_path: str, tmp_path: Path) -> None:
         """The produced lockfile must be parseable YAML."""
         project = tmp_path / "project"
         project.mkdir()
         _write_apm_yml(project)
 
-        _run_apm(apm_command, ["lock"], project)
+        _run_apm(apm_binary_path, ["lock"], project)
 
         lockfile = project / "apm.lock.yaml"
         content = lockfile.read_text(encoding="utf-8")
@@ -120,7 +115,7 @@ class TestLockEmptyDeps:
 
 class TestLockLocalDep:
     def test_local_dep_writes_lockfile_without_deploying(
-        self, apm_command: str, tmp_path: Path
+        self, apm_binary_path: str, tmp_path: Path
     ) -> None:
         """apm lock with a local-path dep must write the lockfile but NOT
         copy any files to .github/, .agents/, or similar harness dirs."""
@@ -132,7 +127,7 @@ class TestLockLocalDep:
 
         _write_apm_yml(project, deps=[str(pkg_dir)])
 
-        result = _run_apm(apm_command, ["lock"], project)
+        result = _run_apm(apm_binary_path, ["lock"], project)
 
         assert result.returncode == 0, (
             f"apm lock exited {result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
@@ -150,7 +145,9 @@ class TestLockLocalDep:
             "apm lock must NOT deploy files to .agents/ -- only the lockfile should be written"
         )
 
-    def test_local_dep_lockfile_records_dependency(self, apm_command: str, tmp_path: Path) -> None:
+    def test_local_dep_lockfile_records_dependency(
+        self, apm_binary_path: str, tmp_path: Path
+    ) -> None:
         """The lockfile written by apm lock must record the local dependency."""
         project = tmp_path / "project"
         project.mkdir()
@@ -159,7 +156,7 @@ class TestLockLocalDep:
         _make_local_package(pkg_dir, "my-skills")
 
         _write_apm_yml(project, deps=[str(pkg_dir)])
-        _run_apm(apm_command, ["lock"], project)
+        _run_apm(apm_binary_path, ["lock"], project)
 
         lockfile = project / "apm.lock.yaml"
         content = lockfile.read_text(encoding="utf-8")
@@ -168,7 +165,7 @@ class TestLockLocalDep:
         deps = parsed.get("dependencies", {})
         assert len(deps) > 0, "lockfile must record at least one dependency entry for the local dep"
 
-    def test_lock_is_idempotent(self, apm_command: str, tmp_path: Path) -> None:
+    def test_lock_is_idempotent(self, apm_binary_path: str, tmp_path: Path) -> None:
         """Running apm lock twice with unchanged deps produces the same lockfile."""
         project = tmp_path / "project"
         project.mkdir()
@@ -177,10 +174,10 @@ class TestLockLocalDep:
         _make_local_package(pkg_dir, "my-skills")
         _write_apm_yml(project, deps=[str(pkg_dir)])
 
-        _run_apm(apm_command, ["lock"], project)
+        _run_apm(apm_binary_path, ["lock"], project)
         first = (project / "apm.lock.yaml").read_text(encoding="utf-8")
 
-        _run_apm(apm_command, ["lock"], project)
+        _run_apm(apm_binary_path, ["lock"], project)
         second = (project / "apm.lock.yaml").read_text(encoding="utf-8")
 
         assert first == second, "apm lock must be idempotent -- same lockfile on second run"

--- a/tests/integration/test_marketplace_e2e.py
+++ b/tests/integration/test_marketplace_e2e.py
@@ -19,7 +19,6 @@ which is a plain APM package, not a marketplace).
 
 import json
 import os
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -32,15 +31,9 @@ SAMPLE_MARKETPLACE_NAME = "test-mkt"
 
 
 @pytest.fixture
-def apm_command():
-    """Resolve the apm CLI executable (PATH first, then local venv)."""
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 @pytest.fixture

--- a/tests/integration/test_marketplace_e2e.py
+++ b/tests/integration/test_marketplace_e2e.py
@@ -21,19 +21,12 @@ import json
 import os
 import subprocess
 import sys
-from pathlib import Path
 
 import pytest
 
 pytestmark = pytest.mark.requires_apm_binary
 
 SAMPLE_MARKETPLACE_NAME = "test-mkt"
-
-
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
 
 
 @pytest.fixture
@@ -52,9 +45,9 @@ def _env_with_home(fake_home):
     return env
 
 
-def _run_apm(apm_command, args, fake_home, cwd=None, timeout=60):
+def _run_apm(apm_binary_path, args, fake_home, cwd=None, timeout=60):
     return subprocess.run(
-        [apm_command] + args,  # noqa: RUF005
+        [apm_binary_path] + args,  # noqa: RUF005
         cwd=str(cwd) if cwd else None,
         capture_output=True,
         text=True,
@@ -74,11 +67,11 @@ def _seed_marketplace(
     (apm_dir / "marketplaces.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
 
-def test_marketplace_list_shows_seeded_entry(apm_command, fake_home):
+def test_marketplace_list_shows_seeded_entry(apm_binary_path, fake_home):
     """`apm marketplace list` surfaces entries persisted in the registry."""
     _seed_marketplace(fake_home)
 
-    result = _run_apm(apm_command, ["marketplace", "list"], fake_home)
+    result = _run_apm(apm_binary_path, ["marketplace", "list"], fake_home)
 
     assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
     combined = result.stdout + result.stderr
@@ -86,10 +79,10 @@ def test_marketplace_list_shows_seeded_entry(apm_command, fake_home):
     assert "acme-org/plugin-marketplace" in combined
 
 
-def test_marketplace_add_rejects_invalid_format(apm_command, fake_home):
+def test_marketplace_add_rejects_invalid_format(apm_binary_path, fake_home):
     """`apm marketplace add` validates OWNER/REPO format without hitting the
     network (validation happens before the GitHub fetch)."""
-    result = _run_apm(apm_command, ["marketplace", "add", "not-a-valid-repo"], fake_home)
+    result = _run_apm(apm_binary_path, ["marketplace", "add", "not-a-valid-repo"], fake_home)
 
     assert result.returncode != 0
     combined = result.stdout + result.stderr
@@ -102,12 +95,12 @@ def test_marketplace_add_rejects_invalid_format(apm_command, fake_home):
         assert data.get("marketplaces", []) == []
 
 
-def test_marketplace_remove_clears_entry(apm_command, fake_home):
+def test_marketplace_remove_clears_entry(apm_binary_path, fake_home):
     """`apm marketplace remove --yes` deletes the entry from the registry."""
     _seed_marketplace(fake_home)
 
     remove_result = _run_apm(
-        apm_command,
+        apm_binary_path,
         ["marketplace", "remove", SAMPLE_MARKETPLACE_NAME, "--yes"],
         fake_home,
     )
@@ -115,7 +108,7 @@ def test_marketplace_remove_clears_entry(apm_command, fake_home):
         f"stdout={remove_result.stdout!r}\nstderr={remove_result.stderr!r}"
     )
 
-    list_result = _run_apm(apm_command, ["marketplace", "list"], fake_home)
+    list_result = _run_apm(apm_binary_path, ["marketplace", "list"], fake_home)
     assert list_result.returncode == 0
     combined = list_result.stdout + list_result.stderr
     assert SAMPLE_MARKETPLACE_NAME not in combined

--- a/tests/integration/test_mcp_env_var_copilot_e2e.py
+++ b/tests/integration/test_mcp_env_var_copilot_e2e.py
@@ -19,7 +19,6 @@ the Copilot translation accidentally bleeds into Cursor.
 import json
 import os
 import subprocess
-from pathlib import Path
 
 import pytest
 import yaml
@@ -33,11 +32,6 @@ pytestmark = [
     # silently ignored and tests would race on global env state.
     pytest.mark.xdist_group(name="home_env"),
 ]
-
-
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    return str(apm_binary_path)
 
 
 def _write_apm_yml(project_dir, mcp_servers):
@@ -57,7 +51,9 @@ class TestMcpEnvVarHeadersCopilot:
     values from the installer's environment must NEVER appear on disk.
     """
 
-    def test_self_defined_http_server_translates_env_vars_not_resolves(self, tmp_path, apm_command):
+    def test_self_defined_http_server_translates_env_vars_not_resolves(
+        self, tmp_path, apm_binary_path
+    ):
         """``${VAR}`` and ``${env:VAR}`` syntaxes in apm.yml headers must
         land in mcp-config.json as ``${VAR}`` (Copilot CLI's native runtime
         substitution syntax). No host env values may leak into the file.
@@ -100,7 +96,7 @@ class TestMcpEnvVarHeadersCopilot:
         env["APM_NON_INTERACTIVE"] = "1"
 
         result = subprocess.run(
-            [apm_command, "install", "--target", "copilot"],
+            [apm_binary_path, "install", "--target", "copilot"],
             cwd=project_dir,
             capture_output=True,
             text=True,
@@ -145,7 +141,7 @@ class TestMcpEnvVarHeadersCopilot:
             f"File contents:\n{full_text}"
         )
 
-    def test_self_defined_stdio_server_translates_env_vars_in_args(self, tmp_path, apm_command):
+    def test_self_defined_stdio_server_translates_env_vars_in_args(self, tmp_path, apm_binary_path):
         """Self-defined stdio server with env-var placeholders in BOTH the
         ``env`` block and ``args`` list must land in mcp-config.json with
         ``${VAR}`` runtime placeholders. Closes the integration-tier gap
@@ -189,7 +185,7 @@ class TestMcpEnvVarHeadersCopilot:
         env["APM_NON_INTERACTIVE"] = "1"
 
         result = subprocess.run(
-            [apm_command, "install", "--target", "copilot"],
+            [apm_binary_path, "install", "--target", "copilot"],
             cwd=project_dir,
             capture_output=True,
             text=True,
@@ -261,7 +257,7 @@ class TestMcpEnvVarHeadersCursor:
     a way that breaks Cursor.
     """
 
-    def test_cursor_still_resolves_env_vars_to_literal(self, tmp_path, apm_command):
+    def test_cursor_still_resolves_env_vars_to_literal(self, tmp_path, apm_binary_path):
         project_dir = tmp_path / "project"
         project_dir.mkdir()
         # Cursor target signal.
@@ -288,7 +284,7 @@ class TestMcpEnvVarHeadersCursor:
         env["APM_NON_INTERACTIVE"] = "1"
 
         result = subprocess.run(
-            [apm_command, "install", "--target", "cursor"],
+            [apm_binary_path, "install", "--target", "cursor"],
             cwd=project_dir,
             capture_output=True,
             text=True,

--- a/tests/integration/test_mcp_env_var_copilot_e2e.py
+++ b/tests/integration/test_mcp_env_var_copilot_e2e.py
@@ -18,7 +18,6 @@ the Copilot translation accidentally bleeds into Cursor.
 
 import json
 import os
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -37,14 +36,8 @@ pytestmark = [
 
 
 @pytest.fixture
-def apm_command():
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    return str(apm_binary_path)
 
 
 def _write_apm_yml(project_dir, mcp_servers):

--- a/tests/integration/test_mcp_env_var_headers_e2e.py
+++ b/tests/integration/test_mcp_env_var_headers_e2e.py
@@ -13,7 +13,6 @@ regress when adapter wiring changes.
 
 import json
 import os
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -22,14 +21,8 @@ import yaml
 
 
 @pytest.fixture
-def apm_command():
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    return str(apm_binary_path)
 
 
 @pytest.fixture

--- a/tests/integration/test_mcp_env_var_headers_e2e.py
+++ b/tests/integration/test_mcp_env_var_headers_e2e.py
@@ -14,15 +14,9 @@ regress when adapter wiring changes.
 import json
 import os
 import subprocess
-from pathlib import Path
 
 import pytest
 import yaml
-
-
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    return str(apm_binary_path)
 
 
 @pytest.fixture
@@ -50,7 +44,7 @@ class TestMcpEnvVarHeadersVSCode:
     for both ${VAR} and ${env:VAR} header syntaxes from apm.yml."""
 
     def test_self_defined_http_server_translates_both_env_var_syntaxes(
-        self, temp_project, apm_command
+        self, temp_project, apm_binary_path
     ):
         """Both bare ${VAR} and explicit ${env:VAR} in apm.yml headers must
         land in mcp.json as ${env:VAR} (the syntax VS Code resolves at
@@ -81,7 +75,7 @@ class TestMcpEnvVarHeadersVSCode:
         env["APM_NON_INTERACTIVE"] = "1"
 
         result = subprocess.run(
-            [apm_command, "install", "--target", "vscode"],
+            [apm_binary_path, "install", "--target", "vscode"],
             cwd=temp_project,
             capture_output=True,
             text=True,

--- a/tests/integration/test_mcp_registry_e2e.py
+++ b/tests/integration/test_mcp_registry_e2e.py
@@ -159,21 +159,15 @@ def temp_e2e_home():
             del os.environ["HOME"]
 
 
-@pytest.fixture(scope="module")
-def apm_binary(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
-
-
 class TestMCPRegistryE2E:
     """E2E tests for MCP registry functionality."""
 
-    def test_mcp_search_command(self, temp_e2e_home, apm_binary):
+    def test_mcp_search_command(self, temp_e2e_home, apm_binary_path):
         """Test MCP registry search functionality."""
         print("\n=== Testing MCP Registry Search ===")
 
         # Test search for GitHub MCP server (retry on transient registry outage)
-        result = run_mcp_command_with_retry(f"{apm_binary} mcp search github", timeout=30)
+        result = run_mcp_command_with_retry(f"{apm_binary_path} mcp search github", timeout=30)
 
         # Verify output contains expected results
         output = result.stdout.lower()
@@ -184,12 +178,12 @@ class TestMCPRegistryE2E:
 
         # Test search with limit (retry on transient registry outage)
         result = run_mcp_command_with_retry(
-            f"{apm_binary} mcp search filesystem --limit 3", timeout=30
+            f"{apm_binary_path} mcp search filesystem --limit 3", timeout=30
         )
 
         print("[OK] MCP search with limit works")
 
-    def test_mcp_show_command(self, temp_e2e_home, apm_binary):
+    def test_mcp_show_command(self, temp_e2e_home, apm_binary_path):
         """Test MCP registry server details functionality."""
         print("\n=== Testing MCP Registry Show ===")
 
@@ -198,7 +192,9 @@ class TestMCPRegistryE2E:
         # the CLI surfaces that as "Could not reach MCP registry" -- retry on
         # that exact marker rather than treating it as a product regression.
         github_server = "io.github.github/github-mcp-server"
-        result = run_mcp_command_with_retry(f"{apm_binary} mcp show {github_server}", timeout=30)
+        result = run_mcp_command_with_retry(
+            f"{apm_binary_path} mcp show {github_server}", timeout=30
+        )
 
         # Verify output contains server details
         output = result.stdout.lower()
@@ -215,13 +211,13 @@ class TestMCPRegistryE2E:
         not _is_registry_healthy(),
         reason="GitHub MCP server configured as remote-only (no packages) - skipping installation tests",
     )
-    def test_registry_installation_with_codex(self, temp_e2e_home, apm_binary):
+    def test_registry_installation_with_codex(self, temp_e2e_home, apm_binary_path):
         """Test complete registry-based installation flow with Codex runtime."""
         print("\n=== Testing Registry Installation with Codex ===")
 
         # Step 1: Set up Codex runtime
         print("Setting up Codex runtime...")
-        result = run_command(f"{apm_binary} runtime setup codex", timeout=300)
+        result = run_command(f"{apm_binary_path} runtime setup codex", timeout=300)
         assert result.returncode == 0, f"Codex setup failed: {result.stderr}"
 
         # Verify codex config was created
@@ -234,7 +230,7 @@ class TestMCPRegistryE2E:
 
             print("Creating project with MCP dependencies...")
             result = run_command(
-                f"{apm_binary} init registry-test-project --yes --target copilot",
+                f"{apm_binary_path} init registry-test-project --yes --target copilot",
                 cwd=project_workspace,
             )
             assert result.returncode == 0, f"Project init failed: {result.stderr}"
@@ -280,7 +276,7 @@ class TestMCPRegistryE2E:
             env_input = "\n\n\n\n\n"  # Empty for most optional environment variables
 
             result = run_command(
-                f"{apm_binary} install", cwd=project_dir, input_text=env_input, timeout=180
+                f"{apm_binary_path} install", cwd=project_dir, input_text=env_input, timeout=180
             )
 
             # Installation should succeed even with some empty environment variables
@@ -351,12 +347,12 @@ class TestMCPRegistryE2E:
         not _is_registry_healthy(),
         reason="GitHub MCP server configured as remote-only (no packages) - skipping installation tests",
     )
-    def test_empty_string_handling_e2e(self, temp_e2e_home, apm_binary):
+    def test_empty_string_handling_e2e(self, temp_e2e_home, apm_binary_path):
         """Test end-to-end empty string and defaults handling during installation."""
         print("\n=== Testing Empty String and Defaults Handling ===")
 
         # Set up a runtime first
-        result = run_command(f"{apm_binary} runtime setup codex", timeout=300)
+        result = run_command(f"{apm_binary_path} runtime setup codex", timeout=300)
         if result.returncode != 0:
             pytest.skip("Codex setup failed, skipping empty string test")
 
@@ -364,7 +360,8 @@ class TestMCPRegistryE2E:
             project_dir = Path(project_workspace) / "empty-string-test"
 
             result = run_command(
-                f"{apm_binary} init empty-string-test --yes --target copilot", cwd=project_workspace
+                f"{apm_binary_path} init empty-string-test --yes --target copilot",
+                cwd=project_workspace,
             )
             assert result.returncode == 0, f"Project init failed: {result.stderr}"
 
@@ -402,7 +399,7 @@ class TestMCPRegistryE2E:
             env_input = "\n\n\n\n\n"  # Empty inputs for optional variables
 
             result = run_command(
-                f"{apm_binary} install --runtime copilot",
+                f"{apm_binary_path} install --runtime copilot",
                 cwd=project_dir,
                 input_text=env_input,
                 timeout=120,
@@ -466,12 +463,12 @@ class TestMCPRegistryE2E:
                 print("[WARN] Copilot configuration not created (binary may not be available)")
                 # This is OK for testing - we're validating the adapter logic
 
-    def test_empty_string_handling_e2e(self, temp_e2e_home, apm_binary):  # noqa: F811
+    def test_empty_string_handling_e2e(self, temp_e2e_home, apm_binary_path):  # noqa: F811
         """Test end-to-end empty string and defaults handling during installation."""
         print("\n=== Testing Empty String and Defaults Handling ===")
 
         # Set up a runtime first
-        result = run_command(f"{apm_binary} runtime setup codex", timeout=300)
+        result = run_command(f"{apm_binary_path} runtime setup codex", timeout=300)
         if result.returncode != 0:
             pytest.skip("Codex setup failed, skipping empty string test")
 
@@ -479,7 +476,8 @@ class TestMCPRegistryE2E:
             project_dir = Path(project_workspace) / "empty-string-test"
 
             result = run_command(
-                f"{apm_binary} init empty-string-test --yes --target copilot", cwd=project_workspace
+                f"{apm_binary_path} init empty-string-test --yes --target copilot",
+                cwd=project_workspace,
             )
             assert result.returncode == 0, f"Project init failed: {result.stderr}"
 
@@ -502,7 +500,7 @@ class TestMCPRegistryE2E:
             env_input = "\n   \n\n\n\n"  # Empty/whitespace for optional vars
 
             result = run_command(
-                f"{apm_binary} install", cwd=project_dir, input_text=env_input, timeout=120
+                f"{apm_binary_path} install", cwd=project_dir, input_text=env_input, timeout=120
             )
 
             # Check the configuration to see how empty strings were handled
@@ -535,12 +533,12 @@ class TestMCPRegistryE2E:
         not _is_registry_healthy(),
         reason="GitHub MCP server configured as remote-only (no packages) - skipping installation tests",
     )
-    def test_cross_adapter_consistency(self, temp_e2e_home, apm_binary):
+    def test_cross_adapter_consistency(self, temp_e2e_home, apm_binary_path):
         """Test that Codex adapter handles MCP server installation consistently."""
         print("\n=== Testing Codex Adapter Consistency ===")
 
         # Set up Codex runtime
-        result = run_command(f"{apm_binary} runtime setup codex", timeout=300)
+        result = run_command(f"{apm_binary_path} runtime setup codex", timeout=300)
         if result.returncode != 0:
             pytest.skip("Codex setup failed, skipping consistency test")
 
@@ -548,7 +546,8 @@ class TestMCPRegistryE2E:
             project_dir = Path(project_workspace) / "consistency-test"
 
             result = run_command(
-                f"{apm_binary} init consistency-test --yes --target copilot", cwd=project_workspace
+                f"{apm_binary_path} init consistency-test --yes --target copilot",
+                cwd=project_workspace,
             )
             assert result.returncode == 0, f"Project init failed: {result.stderr}"
 
@@ -571,7 +570,7 @@ class TestMCPRegistryE2E:
             env_input = "\n\n\n\n\n"  # Empty for optional vars
 
             result = run_command(
-                f"{apm_binary} install", cwd=project_dir, input_text=env_input, timeout=180
+                f"{apm_binary_path} install", cwd=project_dir, input_text=env_input, timeout=180
             )
 
             # Check Codex configuration
@@ -602,12 +601,12 @@ class TestMCPRegistryE2E:
         not _is_registry_healthy(),
         reason="GitHub MCP server configured as remote-only (no packages) - skipping installation tests",
     )
-    def test_duplication_prevention_e2e(self, temp_e2e_home, apm_binary):
+    def test_duplication_prevention_e2e(self, temp_e2e_home, apm_binary_path):
         """Test that repeated installations don't create duplicate entries."""
         print("\n=== Testing Duplication Prevention ===")
 
         # Set up runtime
-        result = run_command(f"{apm_binary} runtime setup codex", timeout=300)
+        result = run_command(f"{apm_binary_path} runtime setup codex", timeout=300)
         if result.returncode != 0:
             pytest.skip("Codex setup failed, skipping duplication test")
 
@@ -615,7 +614,8 @@ class TestMCPRegistryE2E:
             project_dir = Path(project_workspace) / "duplication-test"
 
             result = run_command(
-                f"{apm_binary} init duplication-test --yes --target copilot", cwd=project_workspace
+                f"{apm_binary_path} init duplication-test --yes --target copilot",
+                cwd=project_workspace,
             )
             assert result.returncode == 0, f"Project init failed: {result.stderr}"
 
@@ -636,14 +636,14 @@ class TestMCPRegistryE2E:
             env_input = "test-token\n\n\n\n\n"  # token + empty for optional vars
 
             result1 = run_command(  # noqa: F841
-                f"{apm_binary} install", cwd=project_dir, input_text=env_input, timeout=120
+                f"{apm_binary_path} install", cwd=project_dir, input_text=env_input, timeout=120
             )
 
             # Second installation (should detect existing and skip)
             print("Running second installation (should skip duplicates)...")
 
             result2 = run_command(
-                f"{apm_binary} install", cwd=project_dir, input_text=env_input, timeout=120
+                f"{apm_binary_path} install", cwd=project_dir, input_text=env_input, timeout=120
             )
 
             # Verify no duplication in output

--- a/tests/integration/test_mcp_registry_e2e.py
+++ b/tests/integration/test_mcp_registry_e2e.py
@@ -160,25 +160,9 @@ def temp_e2e_home():
 
 
 @pytest.fixture(scope="module")
-def apm_binary():
-    """Get path to APM binary for testing."""
-    # Try to find APM binary in common locations
-    possible_paths = [
-        "apm",  # In PATH
-        "./apm",  # Local directory
-        "./dist/apm",  # Build directory
-        Path(__file__).parent.parent.parent / "dist" / "apm",  # Relative to test
-    ]
-
-    for path in possible_paths:
-        try:
-            result = subprocess.run([str(path), "--version"], capture_output=True, text=True)
-            if result.returncode == 0:
-                return str(path)
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            continue
-
-    pytest.skip("APM binary not found. Build it first with: python -m build")
+def apm_binary(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 class TestMCPRegistryE2E:

--- a/tests/integration/test_mcp_stdio_env_resolution_e2e.py
+++ b/tests/integration/test_mcp_stdio_env_resolution_e2e.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -16,15 +15,9 @@ pytestmark = pytest.mark.xdist_group(name="home_env")
 
 
 @pytest.fixture
-def apm_command() -> str:
-    """Return the APM executable used by this integration test."""
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 def _write_apm_yml(project_dir: Path) -> None:

--- a/tests/integration/test_mcp_stdio_env_resolution_e2e.py
+++ b/tests/integration/test_mcp_stdio_env_resolution_e2e.py
@@ -14,12 +14,6 @@ import yaml
 pytestmark = pytest.mark.xdist_group(name="home_env")
 
 
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
-
-
 def _write_apm_yml(project_dir: Path) -> None:
     config = {
         "name": "mcp-stdio-env-resolution-e2e",
@@ -46,12 +40,12 @@ def _write_apm_yml(project_dir: Path) -> None:
 
 
 def _run_install(
-    apm_command: str, project_dir: Path, runtime: str, verbose: bool
+    apm_binary_path: str, project_dir: Path, runtime: str, verbose: bool
 ) -> subprocess.CompletedProcess:
     env = os.environ.copy()
     env["GIT_TERMINAL_PROMPT"] = "0"
     env["APM_NON_INTERACTIVE"] = "1"
-    args = [apm_command, "install"]
+    args = [apm_binary_path, "install"]
     if verbose:
         args.append("--verbose")
     args.extend(["--only", "mcp", "--runtime", runtime, "--target", runtime])
@@ -84,7 +78,7 @@ def _env_block(project_dir: Path, runtime: str) -> dict[str, str]:
 def test_self_defined_stdio_env_placeholders_resolve_from_process_env_e2e(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    apm_command: str,
+    apm_binary_path: str,
     runtime: str,
     signal_dir: str,
     verbose: bool,
@@ -99,7 +93,7 @@ def test_self_defined_stdio_env_placeholders_resolve_from_process_env_e2e(
     monkeypatch.setenv("APM_STDIO_E2E_TOKEN", secret_value)
     monkeypatch.delenv("APM_STDIO_E2E_UNSET_TOKEN", raising=False)
 
-    result = _run_install(apm_command, project_dir, runtime, verbose)
+    result = _run_install(apm_binary_path, project_dir, runtime, verbose)
 
     assert result.returncode == 0, (
         f"apm install failed (rc={result.returncode}).\n"

--- a/tests/integration/test_mixed_deps.py
+++ b/tests/integration/test_mixed_deps.py
@@ -6,7 +6,6 @@ as dependencies, and that both types work correctly together.
 These tests require network access to GitHub.
 """
 
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -41,17 +40,9 @@ dependencies:
 
 
 @pytest.fixture
-def apm_command():
-    """Get the path to the APM CLI executable."""
-    # Prefer binary on PATH (CI uses the PR artifact there)
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    # Fallback to local dev venv
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 class TestMixedDependencyInstall:

--- a/tests/integration/test_mixed_deps.py
+++ b/tests/integration/test_mixed_deps.py
@@ -7,7 +7,6 @@ These tests require network access to GitHub.
 """
 
 import subprocess
-from pathlib import Path
 
 import pytest
 
@@ -39,20 +38,14 @@ dependencies:
     return project_dir
 
 
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
-
-
 class TestMixedDependencyInstall:
     """Test installing both APM packages and Claude Skills."""
 
-    def test_install_apm_package_and_claude_skill(self, temp_project, apm_command):
+    def test_install_apm_package_and_claude_skill(self, temp_project, apm_binary_path):
         """Install an APM package and a Claude Skill in the same project."""
         # Install APM package first
         result1 = subprocess.run(
-            [apm_command, "install", "microsoft/apm-sample-package"],
+            [apm_binary_path, "install", "microsoft/apm-sample-package"],
             cwd=temp_project,
             capture_output=True,
             text=True,
@@ -65,7 +58,7 @@ class TestMixedDependencyInstall:
 
         # Install Claude Skill
         result2 = subprocess.run(
-            [apm_command, "install", "anthropics/skills/skills/brand-guidelines"],
+            [apm_binary_path, "install", "anthropics/skills/skills/brand-guidelines"],
             cwd=temp_project,
             capture_output=True,
             text=True,
@@ -82,18 +75,18 @@ class TestMixedDependencyInstall:
         assert apm_package_path.exists(), "APM package not installed"
         assert skill_path.exists(), "Claude Skill not installed"
 
-    def test_apm_yml_contains_both_dependency_types(self, temp_project, apm_command):
+    def test_apm_yml_contains_both_dependency_types(self, temp_project, apm_binary_path):
         """Verify apm.yml lists both APM packages and Claude Skills."""
         # Install both
         subprocess.run(
-            [apm_command, "install", "microsoft/apm-sample-package"],
+            [apm_binary_path, "install", "microsoft/apm-sample-package"],
             cwd=temp_project,
             capture_output=True,
             text=True,
             timeout=120,
         )
         subprocess.run(
-            [apm_command, "install", "anthropics/skills/skills/brand-guidelines"],
+            [apm_binary_path, "install", "anthropics/skills/skills/brand-guidelines"],
             cwd=temp_project,
             capture_output=True,
             text=True,
@@ -114,11 +107,11 @@ class TestMixedDependencyInstall:
 class TestMixedDependencyCompile:
     """Test compiling projects with mixed dependencies."""
 
-    def test_compile_with_mixed_deps_generates_agents_md(self, temp_project, apm_command):
+    def test_compile_with_mixed_deps_generates_agents_md(self, temp_project, apm_binary_path):
         """Compile should keep Copilot instructions outside AGENTS.md."""
         # Install Claude Skill (most likely to succeed)
         subprocess.run(
-            [apm_command, "install", "anthropics/skills/skills/brand-guidelines"],
+            [apm_binary_path, "install", "anthropics/skills/skills/brand-guidelines"],
             cwd=temp_project,
             capture_output=True,
             text=True,
@@ -139,7 +132,11 @@ This is a test.
 
         # Run compile
         result = subprocess.run(
-            [apm_command, "compile"], cwd=temp_project, capture_output=True, text=True, timeout=60
+            [apm_binary_path, "compile"],
+            cwd=temp_project,
+            capture_output=True,
+            text=True,
+            timeout=60,
         )
 
         assert result.returncode == 0, f"Compile failed: {result.stderr}"
@@ -156,11 +153,11 @@ This is a test.
         skill_integrated = temp_project / ".agents" / "skills" / "brand-guidelines" / "SKILL.md"
         assert skill_integrated.exists(), "Skill not integrated to .agents/skills/"
 
-    def test_compile_output_mentions_sources(self, temp_project, apm_command):
+    def test_compile_output_mentions_sources(self, temp_project, apm_binary_path):
         """Compile output should mention different source types."""
         # Install skill
         subprocess.run(
-            [apm_command, "install", "anthropics/skills/skills/brand-guidelines"],
+            [apm_binary_path, "install", "anthropics/skills/skills/brand-guidelines"],
             cwd=temp_project,
             capture_output=True,
             text=True,
@@ -169,7 +166,7 @@ This is a test.
 
         # Run compile with verbose
         result = subprocess.run(
-            [apm_command, "compile", "--verbose"],
+            [apm_binary_path, "compile", "--verbose"],
             cwd=temp_project,
             capture_output=True,
             text=True,
@@ -183,10 +180,10 @@ This is a test.
 class TestDependencyTypeDetection:
     """Test that dependency types are correctly detected."""
 
-    def test_apm_package_has_apm_yml(self, temp_project, apm_command):
+    def test_apm_package_has_apm_yml(self, temp_project, apm_binary_path):
         """APM packages have apm.yml at root."""
         result = subprocess.run(
-            [apm_command, "install", "microsoft/apm-sample-package"],
+            [apm_binary_path, "install", "microsoft/apm-sample-package"],
             cwd=temp_project,
             capture_output=True,
             text=True,
@@ -199,10 +196,10 @@ class TestDependencyTypeDetection:
         pkg_path = temp_project / "apm_modules" / "microsoft" / "apm-sample-package"
         assert (pkg_path / "apm.yml").exists(), "APM package missing apm.yml"
 
-    def test_claude_skill_has_skill_md(self, temp_project, apm_command):
+    def test_claude_skill_has_skill_md(self, temp_project, apm_binary_path):
         """Claude Skills have SKILL.md at root."""
         subprocess.run(
-            [apm_command, "install", "anthropics/skills/skills/brand-guidelines"],
+            [apm_binary_path, "install", "anthropics/skills/skills/brand-guidelines"],
             cwd=temp_project,
             capture_output=True,
             text=True,
@@ -214,10 +211,10 @@ class TestDependencyTypeDetection:
         )
         assert (skill_path / "SKILL.md").exists(), "Claude Skill missing SKILL.md"
 
-    def test_skill_gets_integrated_to_github_skills(self, temp_project, apm_command):
+    def test_skill_gets_integrated_to_github_skills(self, temp_project, apm_binary_path):
         """Claude Skills get integrated to .agents/skills/ directory."""
         subprocess.run(
-            [apm_command, "install", "anthropics/skills/skills/brand-guidelines"],
+            [apm_binary_path, "install", "anthropics/skills/skills/brand-guidelines"],
             cwd=temp_project,
             capture_output=True,
             text=True,

--- a/tests/integration/test_pack_apm_provenance_e2e.py
+++ b/tests/integration/test_pack_apm_provenance_e2e.py
@@ -12,7 +12,6 @@ escape the project root into the bundle.
 
 import os
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
@@ -84,7 +83,10 @@ def _write_lockfile(project: Path, dep: LockedDependency) -> None:
 
 
 def _run_pack_apm(
-    project: Path, target: str | None = None, output_name: str = "build"
+    apm_binary_path: Path,
+    project: Path,
+    target: str | None = None,
+    output_name: str = "build",
 ) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     for name in ("GITHUB_TOKEN", "GITHUB_APM_PAT", "ADO_APM_PAT"):
@@ -93,9 +95,7 @@ def _run_pack_apm(
     home.mkdir(exist_ok=True)
     env.update({"APM_E2E_TESTS": "1", "HOME": str(home), "PYTHONUTF8": "1"})
     args = [
-        sys.executable,
-        "-m",
-        "apm_cli.cli",
+        str(apm_binary_path),
         "pack",
         "--format",
         "apm",
@@ -119,7 +119,10 @@ def _bundle_dir(project: Path, output_name: str = "build") -> Path:
     return project / output_name / "apm-provenance-e2e-1.0.0"
 
 
-def test_apm_pack_accepts_matching_deployed_file(tmp_path: Path) -> None:
+def test_apm_pack_accepts_matching_deployed_file(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
     """Untampered deployed files pack cleanly (guards against false positives)."""
     project = tmp_path / "project"
     project.mkdir()
@@ -127,7 +130,7 @@ def test_apm_pack_accepts_matching_deployed_file(tmp_path: Path) -> None:
     deployed = _write_deployed_skill(project, "alpha", "deployed alpha")
     _write_lockfile(project, _dep_with_hashes(project, deployed))
 
-    result = _run_pack_apm(project)
+    result = _run_pack_apm(apm_binary_path, project)
 
     assert result.returncode == 0, result.stdout + result.stderr
     bundle = _bundle_dir(project)
@@ -136,7 +139,10 @@ def test_apm_pack_accepts_matching_deployed_file(tmp_path: Path) -> None:
     ) == "deployed alpha"
 
 
-def test_apm_pack_rejects_tampered_deployed_file(tmp_path: Path) -> None:
+def test_apm_pack_rejects_tampered_deployed_file(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
     """A deployed file tampered after install must fail the pack loudly.
 
     This is the RED-without-fix / GREEN-with-fix provenance gate for the
@@ -154,7 +160,7 @@ def test_apm_pack_rejects_tampered_deployed_file(tmp_path: Path) -> None:
         "tampered payload", encoding="utf-8"
     )
 
-    result = _run_pack_apm(project)
+    result = _run_pack_apm(apm_binary_path, project)
 
     combined = result.stdout + result.stderr
     assert result.returncode != 0, combined
@@ -163,7 +169,10 @@ def test_apm_pack_rejects_tampered_deployed_file(tmp_path: Path) -> None:
     assert not packed.exists() or packed.read_text(encoding="utf-8") != "tampered payload"
 
 
-def test_apm_pack_rejects_tampered_file_in_deployed_directory(tmp_path: Path) -> None:
+def test_apm_pack_rejects_tampered_file_in_deployed_directory(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
     """A tampered file inside a deployed *directory* entry also fails loud.
 
     Directory entries are copied via copytree; the provenance walk verifies
@@ -193,14 +202,17 @@ def test_apm_pack_rejects_tampered_file_in_deployed_directory(tmp_path: Path) ->
 
     (skill_dir / "notes.md").write_text("tampered notes", encoding="utf-8")
 
-    result = _run_pack_apm(project)
+    result = _run_pack_apm(apm_binary_path, project)
 
     combined = result.stdout + result.stderr
     assert result.returncode != 0, combined
     assert "does not match the hash recorded in apm.lock.yaml" in combined
 
 
-def test_apm_pack_cross_target_mapped_file_no_false_positive(tmp_path: Path) -> None:
+def test_apm_pack_cross_target_mapped_file_no_false_positive(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
     """Cross-target mapped files verify against the on-disk key, not bundle key.
 
     Files deployed under ``.github/skills/`` are hashed against their on-disk
@@ -215,7 +227,7 @@ def test_apm_pack_cross_target_mapped_file_no_false_positive(tmp_path: Path) -> 
     deployed = _write_deployed_skill(project, "alpha", "deployed alpha")
     _write_lockfile(project, _dep_with_hashes(project, deployed))
 
-    result = _run_pack_apm(project, target="claude")
+    result = _run_pack_apm(apm_binary_path, project, target="claude")
 
     assert result.returncode == 0, result.stdout + result.stderr
     bundle = _bundle_dir(project)
@@ -225,7 +237,10 @@ def test_apm_pack_cross_target_mapped_file_no_false_positive(tmp_path: Path) -> 
     ) == "deployed alpha"
 
 
-def test_apm_pack_directory_symlink_does_not_escape(tmp_path: Path) -> None:
+def test_apm_pack_directory_symlink_does_not_escape(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
     """A directory symlink inside a deployed dir must not leak external bytes.
 
     Defense-in-depth: the copytree ignore filter drops symlinks and the
@@ -261,7 +276,7 @@ def test_apm_pack_directory_symlink_does_not_escape(tmp_path: Path) -> None:
     )
     _write_lockfile(project, dep)
 
-    result = _run_pack_apm(project)
+    result = _run_pack_apm(apm_binary_path, project)
 
     # Two acceptable outcomes prove the same invariant across Python versions:
     #  (a) pack succeeds and the symlinked secret simply never lands (rglob

--- a/tests/integration/test_pack_apm_provenance_e2e.py
+++ b/tests/integration/test_pack_apm_provenance_e2e.py
@@ -119,10 +119,7 @@ def _bundle_dir(project: Path, output_name: str = "build") -> Path:
     return project / output_name / "apm-provenance-e2e-1.0.0"
 
 
-def test_apm_pack_accepts_matching_deployed_file(
-    tmp_path: Path,
-    apm_binary_path: Path,
-) -> None:
+def test_apm_pack_accepts_matching_deployed_file(tmp_path: Path, apm_binary_path: Path) -> None:
     """Untampered deployed files pack cleanly (guards against false positives)."""
     project = tmp_path / "project"
     project.mkdir()
@@ -139,10 +136,7 @@ def test_apm_pack_accepts_matching_deployed_file(
     ) == "deployed alpha"
 
 
-def test_apm_pack_rejects_tampered_deployed_file(
-    tmp_path: Path,
-    apm_binary_path: Path,
-) -> None:
+def test_apm_pack_rejects_tampered_deployed_file(tmp_path: Path, apm_binary_path: Path) -> None:
     """A deployed file tampered after install must fail the pack loudly.
 
     This is the RED-without-fix / GREEN-with-fix provenance gate for the
@@ -170,8 +164,7 @@ def test_apm_pack_rejects_tampered_deployed_file(
 
 
 def test_apm_pack_rejects_tampered_file_in_deployed_directory(
-    tmp_path: Path,
-    apm_binary_path: Path,
+    tmp_path: Path, apm_binary_path: Path
 ) -> None:
     """A tampered file inside a deployed *directory* entry also fails loud.
 
@@ -210,8 +203,7 @@ def test_apm_pack_rejects_tampered_file_in_deployed_directory(
 
 
 def test_apm_pack_cross_target_mapped_file_no_false_positive(
-    tmp_path: Path,
-    apm_binary_path: Path,
+    tmp_path: Path, apm_binary_path: Path
 ) -> None:
     """Cross-target mapped files verify against the on-disk key, not bundle key.
 
@@ -237,10 +229,7 @@ def test_apm_pack_cross_target_mapped_file_no_false_positive(
     ) == "deployed alpha"
 
 
-def test_apm_pack_directory_symlink_does_not_escape(
-    tmp_path: Path,
-    apm_binary_path: Path,
-) -> None:
+def test_apm_pack_directory_symlink_does_not_escape(tmp_path: Path, apm_binary_path: Path) -> None:
     """A directory symlink inside a deployed dir must not leak external bytes.
 
     Defense-in-depth: the copytree ignore filter drops symlinks and the

--- a/tests/integration/test_pack_root_skills_e2e.py
+++ b/tests/integration/test_pack_root_skills_e2e.py
@@ -6,11 +6,7 @@ import subprocess
 from pathlib import Path
 
 
-def _run_apm(
-    apm_binary_path: Path,
-    project: Path,
-    *args: str,
-) -> subprocess.CompletedProcess[str]:
+def _run_apm(apm_binary_path: Path, project: Path, *args: str) -> subprocess.CompletedProcess[str]:
     """Run the installed APM CLI in a project directory."""
     return subprocess.run(
         [str(apm_binary_path), *args],
@@ -22,10 +18,7 @@ def _run_apm(
     )
 
 
-def test_pack_auto_includes_only_apm_authored_skills(
-    tmp_path: Path,
-    apm_binary_path: Path,
-) -> None:
+def test_pack_auto_includes_only_apm_authored_skills(tmp_path: Path, apm_binary_path: Path) -> None:
     """The real pack command must not treat a root skills directory as publishable."""
     project = tmp_path / "project"
     project.mkdir()
@@ -64,8 +57,7 @@ def test_pack_auto_includes_only_apm_authored_skills(
 
 
 def test_init_then_pack_preserves_native_claude_skill(
-    tmp_path: Path,
-    apm_binary_path: Path,
+    tmp_path: Path, apm_binary_path: Path
 ) -> None:
     """Init must not make a native Claude root skill disappear from pack."""
     project = tmp_path / "native-plugin"

--- a/tests/integration/test_pack_root_skills_e2e.py
+++ b/tests/integration/test_pack_root_skills_e2e.py
@@ -3,15 +3,17 @@
 from __future__ import annotations
 
 import subprocess
-import sys
 from pathlib import Path
 
 
-def _run_apm(project: Path, *args: str) -> subprocess.CompletedProcess[str]:
+def _run_apm(
+    apm_binary_path: Path,
+    project: Path,
+    *args: str,
+) -> subprocess.CompletedProcess[str]:
     """Run the installed APM CLI in a project directory."""
-    apm_executable = Path(sys.executable).with_name("apm")
     return subprocess.run(
-        [str(apm_executable), *args],
+        [str(apm_binary_path), *args],
         cwd=project,
         capture_output=True,
         text=True,
@@ -20,7 +22,10 @@ def _run_apm(project: Path, *args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def test_pack_auto_includes_only_apm_authored_skills(tmp_path: Path) -> None:
+def test_pack_auto_includes_only_apm_authored_skills(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
     """The real pack command must not treat a root skills directory as publishable."""
     project = tmp_path / "project"
     project.mkdir()
@@ -44,7 +49,7 @@ def test_pack_auto_includes_only_apm_authored_skills(tmp_path: Path) -> None:
     local_skill.mkdir(parents=True)
     (local_skill / "SKILL.md").write_text("# Work in progress\n", encoding="utf-8")
 
-    result = _run_apm(project, "pack")
+    result = _run_apm(apm_binary_path, project, "pack")
 
     assert result.returncode == 0, (
         f"apm pack failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
@@ -58,14 +63,17 @@ def test_pack_auto_includes_only_apm_authored_skills(tmp_path: Path) -> None:
     assert "remove skills/ to silence this warning." in output
 
 
-def test_init_then_pack_preserves_native_claude_skill(tmp_path: Path) -> None:
+def test_init_then_pack_preserves_native_claude_skill(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
     """Init must not make a native Claude root skill disappear from pack."""
     project = tmp_path / "native-plugin"
     skill = project / "skills" / "published"
     skill.mkdir(parents=True)
     (skill / "SKILL.md").write_text("# Published\n", encoding="utf-8")
 
-    init_result = _run_apm(project, "init", "--yes")
+    init_result = _run_apm(apm_binary_path, project, "init", "--yes")
 
     assert init_result.returncode == 0, init_result.stderr
     assert not (project / ".apm").exists()
@@ -74,7 +82,7 @@ def test_init_then_pack_preserves_native_claude_skill(tmp_path: Path) -> None:
     assert "Found plugin-native sources at the project root: skills/." in init_output
     assert "They remain included by apm pack." in init_output
 
-    pack_result = _run_apm(project, "pack")
+    pack_result = _run_apm(apm_binary_path, project, "pack")
 
     assert pack_result.returncode == 0, pack_result.stderr
     bundles = [path for path in (project / "build").iterdir() if path.is_dir()]

--- a/tests/integration/test_pack_unpack_e2e.py
+++ b/tests/integration/test_pack_unpack_e2e.py
@@ -5,7 +5,6 @@ Round-trip tests: install -> pack -> install bundle -> verify files match.
 Requires network access and GITHUB_TOKEN/GITHUB_APM_PAT for GitHub API.
 """
 
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -15,15 +14,9 @@ pytestmark = pytest.mark.requires_github_token
 
 
 @pytest.fixture
-def apm_command():
-    """Get the path to the APM CLI executable."""
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 @pytest.fixture

--- a/tests/integration/test_pack_unpack_e2e.py
+++ b/tests/integration/test_pack_unpack_e2e.py
@@ -6,17 +6,10 @@ Requires network access and GITHUB_TOKEN/GITHUB_APM_PAT for GitHub API.
 """
 
 import subprocess
-from pathlib import Path
 
 import pytest
 
 pytestmark = pytest.mark.requires_github_token
-
-
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
 
 
 @pytest.fixture
@@ -40,10 +33,10 @@ def temp_project(tmp_path):
     return project_dir
 
 
-def _run_apm(apm_command, args, cwd, timeout=120):
+def _run_apm(apm_binary_path, args, cwd, timeout=120):
     """Run an apm CLI command and return the result."""
     return subprocess.run(
-        [apm_command] + args,  # noqa: RUF005
+        [apm_binary_path] + args,  # noqa: RUF005
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -52,7 +45,7 @@ def _run_apm(apm_command, args, cwd, timeout=120):
 
 
 class TestPackUnpackE2E:
-    def test_full_round_trip(self, apm_command, temp_project, tmp_path):
+    def test_full_round_trip(self, apm_binary_path, temp_project, tmp_path):
         """Install -> pack --archive -> install <bundle> in fresh dir -> files match.
 
         Note: ``apm unpack`` was deprecated in favor of ``apm install <bundle-path>``
@@ -62,12 +55,12 @@ class TestPackUnpackE2E:
         round-trip uses the supported ``apm install <archive>`` flow instead.
         """
         # 1. Install
-        result = _run_apm(apm_command, ["install"], cwd=temp_project)
+        result = _run_apm(apm_binary_path, ["install"], cwd=temp_project)
         assert result.returncode == 0, f"install failed: {result.stderr}"
         assert (temp_project / "apm.lock.yaml").exists()
 
         # 2. Pack
-        result = _run_apm(apm_command, ["pack", "--archive"], cwd=temp_project)
+        result = _run_apm(apm_binary_path, ["pack", "--archive"], cwd=temp_project)
         assert result.returncode == 0, f"pack failed: {result.stderr}"
 
         build_dir = temp_project / "build"
@@ -82,7 +75,7 @@ class TestPackUnpackE2E:
         (consumer / ".github" / "copilot-instructions.md").write_text("# test\n")
         archive = archives[0]
 
-        result = _run_apm(apm_command, ["install", str(archive)], cwd=consumer)
+        result = _run_apm(apm_binary_path, ["install", str(archive)], cwd=consumer)
         assert result.returncode == 0, (
             f"bundle install failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
         )
@@ -90,12 +83,12 @@ class TestPackUnpackE2E:
         # 4. Verify .github/ files are present
         assert (consumer / ".github").exists(), ".github/ missing after bundle install"
 
-    def test_pack_dry_run_no_side_effects(self, apm_command, temp_project):
+    def test_pack_dry_run_no_side_effects(self, apm_binary_path, temp_project):
         """Dry run should not create any files."""
-        result = _run_apm(apm_command, ["install"], cwd=temp_project)
+        result = _run_apm(apm_binary_path, ["install"], cwd=temp_project)
         assert result.returncode == 0
 
-        result = _run_apm(apm_command, ["pack", "--dry-run"], cwd=temp_project)
+        result = _run_apm(apm_binary_path, ["pack", "--dry-run"], cwd=temp_project)
         assert result.returncode == 0
 
         assert not (temp_project / "build").exists()

--- a/tests/integration/test_plugin_e2e.py
+++ b/tests/integration/test_plugin_e2e.py
@@ -479,17 +479,6 @@ class TestPluginHeroScenarios:
 # ===========================================================================
 
 
-def _resolve_apm_executable() -> str:
-    """Resolve the apm CLI executable (PATH, then repo .venv, then bare name)."""
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
-
-
 def _build_plugin_with_bin(dest: Path) -> str:
     """Copy the mock plugin fixture into *dest* and add a loose bin/ executable.
 
@@ -518,7 +507,11 @@ class TestPluginBinDeployPermissionsE2E:
     it to 0o700.
     """
 
-    def test_install_global_deploys_plugin_bin_as_0700(self, tmp_path):
+    def test_install_global_deploys_plugin_bin_as_0700(
+        self,
+        tmp_path: Path,
+        apm_binary_path: Path,
+    ) -> None:
         if not FIXTURE_DIR.exists():
             pytest.skip("mock-marketplace-plugin fixture not found")
 
@@ -534,7 +527,7 @@ class TestPluginBinDeployPermissionsE2E:
         env["HOME"] = str(fake_home)
 
         result = subprocess.run(
-            [_resolve_apm_executable(), "install", str(plugin_dir), "-g"],
+            [str(apm_binary_path), "install", str(plugin_dir), "-g"],
             capture_output=True,
             text=True,
             cwd=str(tmp_path),
@@ -565,15 +558,9 @@ pytestmark_network = pytest.mark.requires_github_token
 
 
 @pytest.fixture
-def apm_command():
-    """Get the path to the APM CLI executable."""
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 @pytest.fixture

--- a/tests/integration/test_plugin_e2e.py
+++ b/tests/integration/test_plugin_e2e.py
@@ -38,11 +38,11 @@ FIXTURE_DIR = Path(__file__).parent.parent / "fixtures" / "mock-marketplace-plug
 
 
 def _run_apm_command(
-    apm_command: str, args: list[str], cwd: Path, timeout: int = 120
+    apm_binary_path: str, args: list[str], cwd: Path, timeout: int = 120
 ) -> subprocess.CompletedProcess[str]:
     """Run the real APM CLI in a project directory."""
     return subprocess.run(
-        [apm_command, *args],
+        [apm_binary_path, *args],
         capture_output=True,
         text=True,
         cwd=str(cwd),
@@ -419,7 +419,7 @@ class TestPluginHeroScenarios:
 
     @pytest.mark.requires_apm_binary
     def test_local_plugin_uninstall_after_sequential_skill_install_cleans_deployed_files(
-        self, apm_command, tmp_path
+        self, apm_binary_path, tmp_path
     ):
         """Sequential CLI installs must retain plugin deployed_files for uninstall cleanup."""
         import yaml as yaml_lib
@@ -443,13 +443,13 @@ class TestPluginHeroScenarios:
         (project / ".github" / "copilot-instructions.md").write_text("# test\n")
 
         plugin_install = _run_apm_command(
-            apm_command, ["install", str(plugin_dir)], project, timeout=120
+            apm_binary_path, ["install", str(plugin_dir)], project, timeout=120
         )
         assert plugin_install.returncode == 0, (
             f"Plugin install failed:\n{plugin_install.stdout}\n{plugin_install.stderr}"
         )
         skill_install = _run_apm_command(
-            apm_command, ["install", str(skill_dir)], project, timeout=120
+            apm_binary_path, ["install", str(skill_dir)], project, timeout=120
         )
         assert skill_install.returncode == 0, (
             f"Skill install failed:\n{skill_install.stdout}\n{skill_install.stderr}"
@@ -464,7 +464,7 @@ class TestPluginHeroScenarios:
         assert project / ".github" / "agents" / "test-agent.agent.md" in deployed_paths
 
         uninstall = _run_apm_command(
-            apm_command, ["uninstall", str(plugin_dir)], project, timeout=60
+            apm_binary_path, ["uninstall", str(plugin_dir)], project, timeout=60
         )
         assert uninstall.returncode == 0, (
             f"Uninstall failed:\n{uninstall.stdout}\n{uninstall.stderr}"
@@ -507,11 +507,7 @@ class TestPluginBinDeployPermissionsE2E:
     it to 0o700.
     """
 
-    def test_install_global_deploys_plugin_bin_as_0700(
-        self,
-        tmp_path: Path,
-        apm_binary_path: Path,
-    ) -> None:
+    def test_install_global_deploys_plugin_bin_as_0700(self, tmp_path, apm_binary_path: Path):
         if not FIXTURE_DIR.exists():
             pytest.skip("mock-marketplace-plugin fixture not found")
 
@@ -558,12 +554,6 @@ pytestmark_network = pytest.mark.requires_github_token
 
 
 @pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
-
-
-@pytest.fixture
 def temp_project(tmp_path):
     """Create a temporary APM project."""
     project_dir = tmp_path / "e2e-project"
@@ -592,10 +582,10 @@ class TestPluginNetworkE2E:
 
     # ---- Test 1: install real plugin ------------------------------------
 
-    def test_install_real_plugin(self, apm_command, temp_project):
+    def test_install_real_plugin(self, apm_binary_path, temp_project):
         """Install a real plugin from GitHub, verify artifacts on disk."""
         result = subprocess.run(
-            [apm_command, "install", self.PLUGIN_REF, "--verbose"],
+            [apm_binary_path, "install", self.PLUGIN_REF, "--verbose"],
             capture_output=True,
             text=True,
             cwd=str(temp_project),
@@ -624,11 +614,11 @@ class TestPluginNetworkE2E:
 
     # ---- Test 2: deps list — no false orphans ---------------------------
 
-    def test_deps_list_no_false_orphans(self, apm_command, temp_project):
+    def test_deps_list_no_false_orphans(self, apm_binary_path, temp_project):
         """After install, deps list should show the plugin without orphan warnings."""
         # Install first
         subprocess.run(
-            [apm_command, "install", self.PLUGIN_REF, "--verbose"],
+            [apm_binary_path, "install", self.PLUGIN_REF, "--verbose"],
             capture_output=True,
             text=True,
             cwd=str(temp_project),
@@ -636,7 +626,7 @@ class TestPluginNetworkE2E:
         )
 
         result = subprocess.run(
-            [apm_command, "deps", "list"],
+            [apm_binary_path, "deps", "list"],
             capture_output=True,
             text=True,
             cwd=str(temp_project),
@@ -653,10 +643,10 @@ class TestPluginNetworkE2E:
 
     # ---- Test 3: deps tree shows plugin ---------------------------------
 
-    def test_deps_tree_shows_plugin(self, apm_command, temp_project):
+    def test_deps_tree_shows_plugin(self, apm_binary_path, temp_project):
         """deps tree output should contain the plugin reference."""
         subprocess.run(
-            [apm_command, "install", self.PLUGIN_REF, "--verbose"],
+            [apm_binary_path, "install", self.PLUGIN_REF, "--verbose"],
             capture_output=True,
             text=True,
             cwd=str(temp_project),
@@ -664,7 +654,7 @@ class TestPluginNetworkE2E:
         )
 
         result = subprocess.run(
-            [apm_command, "deps", "tree"],
+            [apm_binary_path, "deps", "tree"],
             capture_output=True,
             text=True,
             cwd=str(temp_project),
@@ -681,7 +671,7 @@ class TestPluginNetworkE2E:
 
     # ---- Test 4: mixed dependencies (plugin + skill) --------------------
 
-    def test_install_mixed_dependencies(self, apm_command, temp_project):
+    def test_install_mixed_dependencies(self, apm_binary_path, temp_project):
         """Install a plugin AND a regular skill together."""
         apm_yml = temp_project / "apm.yml"
         apm_yml.write_text(
@@ -694,7 +684,7 @@ class TestPluginNetworkE2E:
         )
 
         result = subprocess.run(
-            [apm_command, "install", "--verbose"],
+            [apm_binary_path, "install", "--verbose"],
             capture_output=True,
             text=True,
             cwd=str(temp_project),
@@ -723,7 +713,7 @@ class TestPluginNetworkE2E:
 
         # deps list — no orphans
         list_result = subprocess.run(
-            [apm_command, "deps", "list"],
+            [apm_binary_path, "deps", "list"],
             capture_output=True,
             text=True,
             cwd=str(temp_project),
@@ -734,11 +724,11 @@ class TestPluginNetworkE2E:
 
     # ---- Test 5: uninstall plugin ---------------------------------------
 
-    def test_uninstall_plugin(self, apm_command, temp_project):
+    def test_uninstall_plugin(self, apm_binary_path, temp_project):
         """Uninstall a plugin — directory and scattered files cleaned up."""
         # Install first
         subprocess.run(
-            [apm_command, "install", self.PLUGIN_REF, "--verbose"],
+            [apm_binary_path, "install", self.PLUGIN_REF, "--verbose"],
             capture_output=True,
             text=True,
             cwd=str(temp_project),
@@ -749,7 +739,7 @@ class TestPluginNetworkE2E:
 
         # Uninstall
         result = subprocess.run(
-            [apm_command, "uninstall", self.PLUGIN_REF],
+            [apm_binary_path, "uninstall", self.PLUGIN_REF],
             capture_output=True,
             text=True,
             cwd=str(temp_project),
@@ -765,13 +755,13 @@ class TestPluginNetworkE2E:
 
     # ---- Test 6: lockfile preserved on sequential installs ---------------
 
-    def test_lockfile_preserved_on_sequential_install(self, apm_command, temp_project):
+    def test_lockfile_preserved_on_sequential_install(self, apm_binary_path, temp_project):
         """Installing packages one at a time must preserve previous lockfile entries."""
         skill_ref = "github/awesome-copilot/skills/review-and-refactor"
 
         # Install plugin
         r1 = subprocess.run(
-            [apm_command, "install", self.PLUGIN_REF],
+            [apm_binary_path, "install", self.PLUGIN_REF],
             capture_output=True,
             text=True,
             cwd=str(temp_project),
@@ -781,7 +771,7 @@ class TestPluginNetworkE2E:
 
         # Install skill separately
         r2 = subprocess.run(
-            [apm_command, "install", skill_ref],
+            [apm_binary_path, "install", skill_ref],
             capture_output=True,
             text=True,
             cwd=str(temp_project),
@@ -807,7 +797,7 @@ class TestPluginNetworkE2E:
 
         # deps tree should show both
         tree = subprocess.run(
-            [apm_command, "deps", "tree"],
+            [apm_binary_path, "deps", "tree"],
             capture_output=True,
             text=True,
             cwd=str(temp_project),
@@ -821,7 +811,7 @@ class TestPluginNetworkE2E:
         # Verify cleanup for the files that were actually deployed instead of
         # hard-coding that it must currently contain an agent primitive.
         r3 = subprocess.run(
-            [apm_command, "uninstall", self.PLUGIN_REF],
+            [apm_binary_path, "uninstall", self.PLUGIN_REF],
             capture_output=True,
             text=True,
             cwd=str(temp_project),
@@ -838,11 +828,11 @@ class TestPluginNetworkE2E:
 
     # ---- Test 7: compile includes plugin primitives ---------------------
 
-    def test_compile_includes_plugin_primitives(self, apm_command, temp_project):
+    def test_compile_includes_plugin_primitives(self, apm_binary_path, temp_project):
         """apm compile should include primitives from a normalized plugin."""
         # Install the plugin
         r = subprocess.run(
-            [apm_command, "install", self.PLUGIN_REF, "--verbose"],
+            [apm_binary_path, "install", self.PLUGIN_REF, "--verbose"],
             capture_output=True,
             text=True,
             cwd=str(temp_project),
@@ -852,7 +842,7 @@ class TestPluginNetworkE2E:
 
         # Compile
         result = subprocess.run(
-            [apm_command, "compile"],
+            [apm_binary_path, "compile"],
             capture_output=True,
             text=True,
             cwd=str(temp_project),
@@ -871,11 +861,11 @@ class TestPluginNetworkE2E:
 
     # ---- Test 8: prune removes orphaned plugin --------------------------
 
-    def test_prune_removes_orphaned_plugin(self, apm_command, temp_project):
+    def test_prune_removes_orphaned_plugin(self, apm_binary_path, temp_project):
         """apm prune should remove a plugin no longer in apm.yml."""
         # Install the plugin
         r = subprocess.run(
-            [apm_command, "install", self.PLUGIN_REF, "--verbose"],
+            [apm_binary_path, "install", self.PLUGIN_REF, "--verbose"],
             capture_output=True,
             text=True,
             cwd=str(temp_project),
@@ -898,7 +888,7 @@ class TestPluginNetworkE2E:
 
         # Prune should detect and remove the orphan
         result = subprocess.run(
-            [apm_command, "prune"],
+            [apm_binary_path, "prune"],
             capture_output=True,
             text=True,
             cwd=str(temp_project),
@@ -913,10 +903,10 @@ class TestPluginNetworkE2E:
 
     # ---- Test 9: install counter reports plugin -------------------------
 
-    def test_install_counter_includes_plugin(self, apm_command, temp_project):
+    def test_install_counter_includes_plugin(self, apm_binary_path, temp_project):
         """apm install output should count plugin as an installed dependency."""
         result = subprocess.run(
-            [apm_command, "install", self.PLUGIN_REF],
+            [apm_binary_path, "install", self.PLUGIN_REF],
             capture_output=True,
             text=True,
             cwd=str(temp_project),
@@ -932,10 +922,10 @@ class TestPluginNetworkE2E:
 
     # ---- Test 10: lockfile records package_type -------------------------
 
-    def test_lockfile_records_package_type(self, apm_command, temp_project):
+    def test_lockfile_records_package_type(self, apm_binary_path, temp_project):
         """Lockfile should record package_type for plugin dependencies."""
         result = subprocess.run(
-            [apm_command, "install", self.PLUGIN_REF],
+            [apm_binary_path, "install", self.PLUGIN_REF],
             capture_output=True,
             text=True,
             cwd=str(temp_project),
@@ -966,11 +956,11 @@ class TestPluginNetworkE2E:
 
     # ---- Test 11: idempotent reinstall ----------------------------------
 
-    def test_idempotent_reinstall(self, apm_command, temp_project):
+    def test_idempotent_reinstall(self, apm_binary_path, temp_project):
         """Running apm install twice should be safe and produce identical results."""
         # First install
         r1 = subprocess.run(
-            [apm_command, "install", self.PLUGIN_REF],
+            [apm_binary_path, "install", self.PLUGIN_REF],
             capture_output=True,
             text=True,
             cwd=str(temp_project),
@@ -985,7 +975,7 @@ class TestPluginNetworkE2E:
 
         # Second install (should use cache)
         r2 = subprocess.run(
-            [apm_command, "install", self.PLUGIN_REF],
+            [apm_binary_path, "install", self.PLUGIN_REF],
             capture_output=True,
             text=True,
             cwd=str(temp_project),

--- a/tests/integration/test_plugin_skill_subset_pack_e2e.py
+++ b/tests/integration/test_plugin_skill_subset_pack_e2e.py
@@ -93,9 +93,7 @@ def _write_cached_hooks(project: Path, hook_event: str) -> None:
 
 
 def _run_pack(
-    apm_binary_path: Path,
-    project: Path,
-    output_name: str = "build",
+    apm_binary_path: Path, project: Path, output_name: str = "build"
 ) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     for name in ("GITHUB_TOKEN", "GITHUB_APM_PAT", "ADO_APM_PAT"):
@@ -181,8 +179,7 @@ def test_pack_plugin_uses_deployed_skill_subset_and_survives_missing_cache(
 
 
 def test_pack_plugin_excludes_unattested_cache_hooks_and_mcp(
-    tmp_path: Path,
-    apm_binary_path: Path,
+    tmp_path: Path, apm_binary_path: Path
 ) -> None:
     """Provenance guarantee: unattested apm_modules content is never packed.
 
@@ -229,10 +226,7 @@ def test_pack_plugin_excludes_unattested_cache_hooks_and_mcp(
     assert not (bundle_dir / "skills" / "zeta").exists(), "unattested cache skill leaked"
 
 
-def test_pack_plugin_rejects_unsafe_deployed_paths(
-    tmp_path: Path,
-    apm_binary_path: Path,
-) -> None:
+def test_pack_plugin_rejects_unsafe_deployed_paths(tmp_path: Path, apm_binary_path: Path) -> None:
     """apm pack must reject unsafe deployed_files paths before copying."""
     project = tmp_path / "project"
     project.mkdir()
@@ -290,8 +284,7 @@ def test_pack_plugin_fails_when_dep_has_cache_but_no_deployed_files(
 
 
 def test_pack_plugin_warns_when_dep_hooks_mcp_config_dropped(
-    tmp_path: Path,
-    apm_binary_path: Path,
+    tmp_path: Path, apm_binary_path: Path
 ) -> None:
     """A hooks/MCP-config-only dep is skipped cleanly but warns loudly (#2013).
 

--- a/tests/integration/test_plugin_skill_subset_pack_e2e.py
+++ b/tests/integration/test_plugin_skill_subset_pack_e2e.py
@@ -4,7 +4,6 @@ import json
 import os
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
@@ -93,7 +92,11 @@ def _write_cached_hooks(project: Path, hook_event: str) -> None:
     )
 
 
-def _run_pack(project: Path, output_name: str = "build") -> subprocess.CompletedProcess[str]:
+def _run_pack(
+    apm_binary_path: Path,
+    project: Path,
+    output_name: str = "build",
+) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     for name in ("GITHUB_TOKEN", "GITHUB_APM_PAT", "ADO_APM_PAT"):
         env.pop(name, None)
@@ -108,9 +111,7 @@ def _run_pack(project: Path, output_name: str = "build") -> subprocess.Completed
     )
     return subprocess.run(
         [
-            sys.executable,
-            "-m",
-            "apm_cli.cli",
+            str(apm_binary_path),
             "pack",
             "--format",
             "plugin",
@@ -140,6 +141,7 @@ def _assert_only_subset_skills(bundle_dir: Path) -> None:
 
 def test_pack_plugin_uses_deployed_skill_subset_and_survives_missing_cache(
     tmp_path: Path,
+    apm_binary_path: Path,
 ) -> None:
     """apm pack must export the installed subset, not raw apm_modules."""
     project = tmp_path / "project"
@@ -164,7 +166,7 @@ def test_pack_plugin_uses_deployed_skill_subset_and_survives_missing_cache(
     for skill in ("alpha", "beta", "gamma"):
         _write_cached_skill(project, skill, f"raw cache {skill}")
 
-    result = _run_pack(project)
+    result = _run_pack(apm_binary_path, project)
 
     assert result.returncode == 0, result.stderr
     _assert_only_subset_skills(_bundle_dir(project))
@@ -172,13 +174,16 @@ def test_pack_plugin_uses_deployed_skill_subset_and_survives_missing_cache(
     shutil.rmtree(project / "apm_modules")
     shutil.rmtree(project / "build")
 
-    result_without_cache = _run_pack(project)
+    result_without_cache = _run_pack(apm_binary_path, project)
 
     assert result_without_cache.returncode == 0, result_without_cache.stderr
     _assert_only_subset_skills(_bundle_dir(project))
 
 
-def test_pack_plugin_excludes_unattested_cache_hooks_and_mcp(tmp_path: Path) -> None:
+def test_pack_plugin_excludes_unattested_cache_hooks_and_mcp(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
     """Provenance guarantee: unattested apm_modules content is never packed.
 
     The dependency has an attested skill subset (alpha, beta), but its
@@ -212,7 +217,7 @@ def test_pack_plugin_excludes_unattested_cache_hooks_and_mcp(tmp_path: Path) -> 
     # An unattested extra skill in the cache, too.
     _write_cached_skill(project, "zeta", "raw cache zeta")
 
-    result = _run_pack(project)
+    result = _run_pack(apm_binary_path, project)
 
     assert result.returncode == 0, result.stderr
     bundle_dir = _bundle_dir(project)
@@ -224,7 +229,10 @@ def test_pack_plugin_excludes_unattested_cache_hooks_and_mcp(tmp_path: Path) -> 
     assert not (bundle_dir / "skills" / "zeta").exists(), "unattested cache skill leaked"
 
 
-def test_pack_plugin_rejects_unsafe_deployed_paths(tmp_path: Path) -> None:
+def test_pack_plugin_rejects_unsafe_deployed_paths(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
     """apm pack must reject unsafe deployed_files paths before copying."""
     project = tmp_path / "project"
     project.mkdir()
@@ -241,7 +249,7 @@ def test_pack_plugin_rejects_unsafe_deployed_paths(tmp_path: Path) -> None:
         ),
     )
 
-    result = _run_pack(project)
+    result = _run_pack(apm_binary_path, project)
 
     assert result.returncode != 0
     combined_output = result.stdout + result.stderr
@@ -250,6 +258,7 @@ def test_pack_plugin_rejects_unsafe_deployed_paths(tmp_path: Path) -> None:
 
 def test_pack_plugin_fails_when_dep_has_cache_but_no_deployed_files(
     tmp_path: Path,
+    apm_binary_path: Path,
 ) -> None:
     """A dep with cached primitives but no attested deployed_files fails loud.
 
@@ -271,7 +280,7 @@ def test_pack_plugin_fails_when_dep_has_cache_but_no_deployed_files(
     )
     _write_cached_skill(project, "legacy", "legacy cache skill")
 
-    result = _run_pack(project)
+    result = _run_pack(apm_binary_path, project)
 
     assert result.returncode != 0
     combined_output = result.stdout + result.stderr
@@ -280,7 +289,10 @@ def test_pack_plugin_fails_when_dep_has_cache_but_no_deployed_files(
     )
 
 
-def test_pack_plugin_warns_when_dep_hooks_mcp_config_dropped(tmp_path: Path) -> None:
+def test_pack_plugin_warns_when_dep_hooks_mcp_config_dropped(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
     """A hooks/MCP-config-only dep is skipped cleanly but warns loudly (#2013).
 
     The dependency records NO deployed_files (its only cached content is
@@ -306,7 +318,7 @@ def test_pack_plugin_warns_when_dep_hooks_mcp_config_dropped(tmp_path: Path) -> 
     _write_cached_mcp(project, "leaked-server")
     _write_cached_hooks(project, "preCommit")
 
-    result = _run_pack(project)
+    result = _run_pack(apm_binary_path, project)
 
     assert result.returncode == 0, result.stderr
     combined_output = result.stdout + result.stderr

--- a/tests/integration/test_silent_adopt_existing_files_e2e.py
+++ b/tests/integration/test_silent_adopt_existing_files_e2e.py
@@ -21,7 +21,6 @@ Requires network access and GITHUB_TOKEN/GITHUB_APM_PAT for GitHub API.
 """
 
 import subprocess
-from pathlib import Path
 
 import pytest
 import yaml
@@ -30,12 +29,6 @@ pytestmark = [
     pytest.mark.requires_github_token,
     pytest.mark.requires_apm_binary,
 ]
-
-
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test binary selection unchanged."""
-    return str(apm_binary_path)
 
 
 @pytest.fixture
@@ -55,9 +48,9 @@ def temp_project(tmp_path):
     return project_dir
 
 
-def _run_apm(apm_command, args, cwd, timeout=120):
+def _run_apm(apm_binary_path, args, cwd, timeout=120):
     return subprocess.run(
-        [apm_command] + args,  # noqa: RUF005
+        [apm_binary_path] + args,  # noqa: RUF005
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -87,7 +80,7 @@ class TestSilentAdoptOfExistingFiles:
     """Catch-22: degraded lockfile + identical files on disk -> must self-heal."""
 
     def test_reinstall_with_wiped_lockfile_repopulates_deployed_files(
-        self, temp_project, apm_command
+        self, temp_project, apm_binary_path
     ):
         """The exact zava-storefront reproducer.
 
@@ -103,7 +96,9 @@ class TestSilentAdoptOfExistingFiles:
         deployed_files, which would then trip
         ``required-packages-deployed`` policy.
         """
-        result1 = _run_apm(apm_command, ["install", "microsoft/apm-sample-package"], temp_project)
+        result1 = _run_apm(
+            apm_binary_path, ["install", "microsoft/apm-sample-package"], temp_project
+        )
         assert result1.returncode == 0, (
             f"First install failed:\nstderr={result1.stderr}\nstdout={result1.stdout}"
         )
@@ -125,7 +120,7 @@ class TestSilentAdoptOfExistingFiles:
         (temp_project / "apm.lock.yaml").unlink()
 
         # Re-install. Files are still on disk, byte-identical to package source.
-        result2 = _run_apm(apm_command, ["install"], temp_project)
+        result2 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result2.returncode == 0, (
             f"Re-install failed:\nstderr={result2.stderr}\nstdout={result2.stdout}"
         )
@@ -147,7 +142,9 @@ class TestSilentAdoptOfExistingFiles:
                 f"Adopt path must not modify on-disk bytes: {f} changed."
             )
 
-    def test_required_packages_deployed_passes_after_lockfile_wipe(self, temp_project, apm_command):
+    def test_required_packages_deployed_passes_after_lockfile_wipe(
+        self, temp_project, apm_binary_path
+    ):
         """End-to-end: with adopt in place, ``apm audit`` (which runs the
         same ``required-packages-deployed`` check the policy gate uses)
         passes after a lockfile wipe + re-install -- proving the catch-22
@@ -160,7 +157,7 @@ class TestSilentAdoptOfExistingFiles:
         full pipeline now self-heals.
         """
         # Initial install
-        r1 = _run_apm(apm_command, ["install", "microsoft/apm-sample-package"], temp_project)
+        r1 = _run_apm(apm_binary_path, ["install", "microsoft/apm-sample-package"], temp_project)
         assert r1.returncode == 0, f"first install: {r1.stderr}\n{r1.stdout}"
 
         # Wipe lockfile -- degraded state
@@ -170,7 +167,7 @@ class TestSilentAdoptOfExistingFiles:
         # exercise just the integrator/lockfile path. (The fix lives in
         # the integrator; --no-policy keeps this test independent of the
         # current org policy fixtures.)
-        r2 = _run_apm(apm_command, ["install", "--no-policy"], temp_project)
+        r2 = _run_apm(apm_binary_path, ["install", "--no-policy"], temp_project)
         assert r2.returncode == 0, f"re-install: {r2.stderr}\n{r2.stdout}"
 
         lock2 = _read_lockfile(temp_project)
@@ -185,7 +182,7 @@ class TestSilentAdoptOfExistingFiles:
         # Third run: full policy gate, no --no-policy flag. Proves the
         # pipeline fully self-heals and the required-packages-deployed
         # check passes because deployed_files was repopulated in run 2.
-        r3 = _run_apm(apm_command, ["install"], temp_project)
+        r3 = _run_apm(apm_binary_path, ["install"], temp_project)
         assert r3.returncode == 0, (
             "Third install (with policy) must succeed -- catch-22 is broken. "
             f"stderr: {r3.stderr}\nstdout: {r3.stdout}"

--- a/tests/integration/test_silent_adopt_existing_files_e2e.py
+++ b/tests/integration/test_silent_adopt_existing_files_e2e.py
@@ -20,55 +20,22 @@ catch-22.
 Requires network access and GITHUB_TOKEN/GITHUB_APM_PAT for GitHub API.
 """
 
-import shutil
 import subprocess
 from pathlib import Path
 
 import pytest
 import yaml
 
-pytestmark = pytest.mark.requires_github_token
+pytestmark = [
+    pytest.mark.requires_github_token,
+    pytest.mark.requires_apm_binary,
+]
 
 
 @pytest.fixture
-def apm_command():
-    """Resolve an apm binary that is wired to *this* checkout's source.
-
-    The repo binary (homebrew/system ``apm``) may be a stable release that
-    predates the fix under test, which would silently make this regression
-    test pass against unfixed code. Prefer the CI-built artifact or a
-    venv-installed editable binary so the test exercises the in-repo
-    apm_cli source.
-
-    Resolution order:
-      1. ``APM_TEST_BINARY`` env override (explicit per-test pin).
-      2. ``APM_BINARY_PATH`` env (CI sets this after the build step;
-         shared with ``apm_binary_path`` fixture in ``conftest.py``).
-      3. Repo-local ``.venv/bin/apm`` (this worktree).
-      4. Sibling ``../awd-cli/.venv/bin/apm`` (shared dev venv pointing
-         at this worktree via ``pip install -e .``).
-      5. ``apm`` on PATH (last resort; may be stale).
-    """
-    import os
-
-    for env_var in ("APM_TEST_BINARY", "APM_BINARY_PATH"):
-        override = os.environ.get(env_var)
-        if override and Path(override).exists():
-            return override
-
-    repo_root = Path(__file__).parent.parent.parent
-    candidates = [
-        repo_root / ".venv" / "bin" / "apm",
-        repo_root.parent / "awd-cli" / ".venv" / "bin" / "apm",
-    ]
-    for candidate in candidates:
-        if candidate.exists():
-            return str(candidate)
-
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test binary selection unchanged."""
+    return str(apm_binary_path)
 
 
 @pytest.fixture

--- a/tests/integration/test_skill_bundle_live.py
+++ b/tests/integration/test_skill_bundle_live.py
@@ -57,16 +57,9 @@ LIVE_REPOS = [
 
 
 @pytest.fixture
-def apm_command():
-    """Resolve the apm CLI executable (PATH first, then local venv)."""
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    # Fallback: run as module
-    return None
+def apm_command(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 @pytest.fixture

--- a/tests/integration/test_skill_bundle_live.py
+++ b/tests/integration/test_skill_bundle_live.py
@@ -114,10 +114,7 @@ def _env_with_home(fake_home):
 
 def _run_apm(apm_command, args, cwd, fake_home, timeout=180):
     """Run apm CLI with isolated HOME."""
-    if apm_command:  # noqa: SIM108
-        cmd = [apm_command] + args  # noqa: RUF005
-    else:
-        cmd = [sys.executable, "-m", "apm_cli"] + args  # noqa: RUF005
+    cmd = [apm_command, *args]
     return subprocess.run(
         cmd,
         cwd=cwd,

--- a/tests/integration/test_skill_bundle_live.py
+++ b/tests/integration/test_skill_bundle_live.py
@@ -17,7 +17,6 @@ import os
 import shutil
 import subprocess
 import sys
-from pathlib import Path
 
 import pytest
 import yaml
@@ -54,12 +53,6 @@ LIVE_REPOS = [
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
 
 
 @pytest.fixture
@@ -112,11 +105,10 @@ def _env_with_home(fake_home):
     return env
 
 
-def _run_apm(apm_command, args, cwd, fake_home, timeout=180):
+def _run_apm(apm_binary_path, args, cwd, fake_home, timeout=180):
     """Run apm CLI with isolated HOME."""
-    cmd = [apm_command, *args]
     return subprocess.run(
-        cmd,
+        [str(apm_binary_path), *args],
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -178,13 +170,13 @@ def _count_deployed_skills(project_root):
     ids=[r[0] for r in LIVE_REPOS],
 )
 def test_live_install_classifies_and_succeeds(
-    tmp_path, apm_command, fake_home, repo, expected_type, min_skills, is_plugin
+    tmp_path, apm_binary_path, fake_home, repo, expected_type, min_skills, is_plugin
 ):
     """Install a real repo and validate classification + deployment."""
     work_dir = tmp_path / "project"
     work_dir.mkdir()
 
-    result = _run_apm(apm_command, ["install", repo, "--verbose"], work_dir, fake_home)
+    result = _run_apm(apm_binary_path, ["install", repo, "--verbose"], work_dir, fake_home)
     assert result.returncode == 0, (
         f"apm install {repo} failed (exit {result.returncode}):\n"
         f"STDOUT:\n{result.stdout[-2000:]}\n"
@@ -226,7 +218,7 @@ def test_live_install_classifies_and_succeeds(
 
 
 @pytest.mark.live
-def test_live_skill_subset_selection(tmp_path, apm_command, fake_home):
+def test_live_skill_subset_selection(tmp_path, apm_binary_path, fake_home):
     """Install a single skill from vercel-labs/agent-skills (6-skill bundle).
 
     Picks one known skill name and asserts only that skill is deployed.
@@ -239,7 +231,7 @@ def test_live_skill_subset_selection(tmp_path, apm_command, fake_home):
     target_skill = "deploy-to-vercel"
 
     result = _run_apm(
-        apm_command,
+        apm_binary_path,
         ["install", "vercel-labs/agent-skills", "--skill", target_skill, "--verbose"],
         work_dir,
         fake_home,
@@ -281,7 +273,7 @@ def test_live_skill_subset_selection(tmp_path, apm_command, fake_home):
 
 
 @pytest.mark.live
-def test_live_skill_flag_on_non_bundle_deploys_normally(tmp_path, apm_command, fake_home):
+def test_live_skill_flag_on_non_bundle_deploys_normally(tmp_path, apm_binary_path, fake_home):
     """--skill on a MARKETPLACE_PLUGIN that ships .apm/skills/ should still
     deploy those skills normally -- the --skill filter only applies to
     SKILL_BUNDLE packages with a root skills/ directory.
@@ -293,7 +285,7 @@ def test_live_skill_flag_on_non_bundle_deploys_normally(tmp_path, apm_command, f
     work_dir.mkdir()
 
     result = _run_apm(
-        apm_command,
+        apm_binary_path,
         ["install", "pbakaus/impeccable", "--skill", "nonexistent", "--verbose"],
         work_dir,
         fake_home,
@@ -348,14 +340,14 @@ def _get_manifest_entry(manifest, repo):
 
 
 @pytest.mark.live
-def test_skill_subset_persists_to_apm_yml(tmp_path, apm_command, fake_home):
+def test_skill_subset_persists_to_apm_yml(tmp_path, apm_binary_path, fake_home):
     """--skill <name> persists skills: field in apm.yml after install."""
     work_dir = tmp_path / "project"
     work_dir.mkdir()
 
     target_skill = "deploy-to-vercel"
     result = _run_apm(
-        apm_command,
+        apm_binary_path,
         ["install", "vercel-labs/agent-skills", "--skill", target_skill, "--verbose"],
         work_dir,
         fake_home,
@@ -377,14 +369,14 @@ def test_skill_subset_persists_to_apm_yml(tmp_path, apm_command, fake_home):
 
 
 @pytest.mark.live
-def test_skill_subset_persists_to_lockfile(tmp_path, apm_command, fake_home):
+def test_skill_subset_persists_to_lockfile(tmp_path, apm_binary_path, fake_home):
     """--skill <name> persists skill_subset in apm.lock.yaml."""
     work_dir = tmp_path / "project"
     work_dir.mkdir()
 
     target_skill = "deploy-to-vercel"
     result = _run_apm(
-        apm_command,
+        apm_binary_path,
         ["install", "vercel-labs/agent-skills", "--skill", target_skill, "--verbose"],
         work_dir,
         fake_home,
@@ -405,7 +397,7 @@ def test_skill_subset_persists_to_lockfile(tmp_path, apm_command, fake_home):
 
 
 @pytest.mark.live
-def test_bare_reinstall_respects_persisted_subset(tmp_path, apm_command, fake_home):
+def test_bare_reinstall_respects_persisted_subset(tmp_path, apm_binary_path, fake_home):
     """Bare `apm install` after --skill respects persisted skills: selection."""
     work_dir = tmp_path / "project"
     work_dir.mkdir()
@@ -414,7 +406,7 @@ def test_bare_reinstall_respects_persisted_subset(tmp_path, apm_command, fake_ho
 
     # First install with --skill
     result = _run_apm(
-        apm_command,
+        apm_binary_path,
         ["install", "vercel-labs/agent-skills", "--skill", target_skill, "--verbose"],
         work_dir,
         fake_home,
@@ -431,7 +423,7 @@ def test_bare_reinstall_respects_persisted_subset(tmp_path, apm_command, fake_ho
 
     # Re-install bare (no --skill flag)
     result = _run_apm(
-        apm_command,
+        apm_binary_path,
         ["install", "--verbose"],
         work_dir,
         fake_home,
@@ -451,7 +443,7 @@ def test_bare_reinstall_respects_persisted_subset(tmp_path, apm_command, fake_ho
 
 
 @pytest.mark.live
-def test_star_sentinel_clears_subset(tmp_path, apm_command, fake_home):
+def test_star_sentinel_clears_subset(tmp_path, apm_binary_path, fake_home):
     """--skill '*' clears persisted skills: selection and installs all."""
     work_dir = tmp_path / "project"
     work_dir.mkdir()
@@ -460,7 +452,7 @@ def test_star_sentinel_clears_subset(tmp_path, apm_command, fake_home):
 
     # First install with --skill to persist subset
     result = _run_apm(
-        apm_command,
+        apm_binary_path,
         ["install", "vercel-labs/agent-skills", "--skill", target_skill, "--verbose"],
         work_dir,
         fake_home,
@@ -476,7 +468,7 @@ def test_star_sentinel_clears_subset(tmp_path, apm_command, fake_home):
 
     # Now install with --skill '*' to clear
     result = _run_apm(
-        apm_command,
+        apm_binary_path,
         ["install", "vercel-labs/agent-skills", "--skill", "*", "--verbose"],
         work_dir,
         fake_home,
@@ -498,14 +490,14 @@ def test_star_sentinel_clears_subset(tmp_path, apm_command, fake_home):
 
 
 @pytest.mark.live
-def test_skill_flag_on_non_bundle_warns_and_does_not_persist(tmp_path, apm_command, fake_home):
+def test_skill_flag_on_non_bundle_warns_and_does_not_persist(tmp_path, apm_binary_path, fake_home):
     """--skill on a non-SKILL_BUNDLE warns and does NOT persist skills:."""
     work_dir = tmp_path / "project"
     work_dir.mkdir()
 
     # obra/superpowers is a MARKETPLACE_PLUGIN
     result = _run_apm(
-        apm_command,
+        apm_binary_path,
         ["install", "obra/superpowers", "--skill", "fake-skill", "--verbose"],
         work_dir,
         fake_home,
@@ -539,7 +531,7 @@ def test_skill_flag_on_non_bundle_warns_and_does_not_persist(tmp_path, apm_comma
 
 
 @pytest.mark.live
-def test_audit_detects_lockfile_drift(tmp_path, apm_command, fake_home):
+def test_audit_detects_lockfile_drift(tmp_path, apm_binary_path, fake_home):
     """apm audit --ci detects lockfile drift when skills: changes after install."""
     work_dir = tmp_path / "project"
     work_dir.mkdir()
@@ -548,7 +540,7 @@ def test_audit_detects_lockfile_drift(tmp_path, apm_command, fake_home):
 
     # Install with --skill to get consistent state
     result = _run_apm(
-        apm_command,
+        apm_binary_path,
         ["install", "vercel-labs/agent-skills", "--skill", target_skill, "--verbose"],
         work_dir,
         fake_home,
@@ -557,7 +549,7 @@ def test_audit_detects_lockfile_drift(tmp_path, apm_command, fake_home):
 
     # Verify audit passes in consistent state
     result = _run_apm(
-        apm_command,
+        apm_binary_path,
         ["audit", "--ci"],
         work_dir,
         fake_home,
@@ -580,7 +572,7 @@ def test_audit_detects_lockfile_drift(tmp_path, apm_command, fake_home):
 
     # Audit should now detect drift
     result = _run_apm(
-        apm_command,
+        apm_binary_path,
         ["audit", "--ci"],
         work_dir,
         fake_home,

--- a/tests/integration/test_skill_install.py
+++ b/tests/integration/test_skill_install.py
@@ -7,7 +7,6 @@ These tests require network access to GitHub.
 """
 
 import subprocess
-from pathlib import Path
 
 import pytest
 
@@ -39,20 +38,14 @@ dependencies:
     return project_dir
 
 
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
-
-
 class TestSimpleClaudeSkillInstall:
     """Test installing a simple Claude Skill (SKILL.md only)."""
 
-    def test_install_brand_guidelines_skill(self, temp_project, apm_command):
+    def test_install_brand_guidelines_skill(self, temp_project, apm_binary_path):
         """Install brand-guidelines skill from anthropics/skills."""
         # Install the skill
         result = subprocess.run(
-            [apm_command, "install", "anthropics/skills/skills/brand-guidelines", "--verbose"],
+            [apm_binary_path, "install", "anthropics/skills/skills/brand-guidelines", "--verbose"],
             cwd=temp_project,
             capture_output=True,
             text=True,
@@ -76,11 +69,11 @@ class TestSimpleClaudeSkillInstall:
         skill_integrated = temp_project / ".agents" / "skills" / "brand-guidelines" / "SKILL.md"
         assert skill_integrated.exists(), "Skill not integrated to .agents/skills/"
 
-    def test_install_skill_updates_apm_yml(self, temp_project, apm_command):
+    def test_install_skill_updates_apm_yml(self, temp_project, apm_binary_path):
         """Verify the skill is added to project's apm.yml."""
         # Install the skill
         subprocess.run(
-            [apm_command, "install", "anthropics/skills/skills/brand-guidelines"],
+            [apm_binary_path, "install", "anthropics/skills/skills/brand-guidelines"],
             cwd=temp_project,
             capture_output=True,
             text=True,
@@ -94,10 +87,10 @@ class TestSimpleClaudeSkillInstall:
         # Verify dependency was added
         assert "anthropics/skills/skills/brand-guidelines" in content
 
-    def test_skill_detection_in_output(self, temp_project, apm_command):
+    def test_skill_detection_in_output(self, temp_project, apm_binary_path):
         """Verify CLI output shows skill integration message."""
         result = subprocess.run(
-            [apm_command, "install", "anthropics/skills/skills/brand-guidelines", "--verbose"],
+            [apm_binary_path, "install", "anthropics/skills/skills/brand-guidelines", "--verbose"],
             cwd=temp_project,
             capture_output=True,
             text=True,
@@ -115,10 +108,10 @@ class TestSimpleClaudeSkillInstall:
 class TestClaudeSkillWithResources:
     """Test installing Claude Skills with bundled resources."""
 
-    def test_install_skill_with_scripts(self, temp_project, apm_command):
+    def test_install_skill_with_scripts(self, temp_project, apm_binary_path):
         """Install skill-creator which has scripts/ folder."""
         result = subprocess.run(
-            [apm_command, "install", "anthropics/skills/skills/skill-creator", "--verbose"],
+            [apm_binary_path, "install", "anthropics/skills/skills/skill-creator", "--verbose"],
             cwd=temp_project,
             capture_output=True,
             text=True,
@@ -144,10 +137,10 @@ class TestClaudeSkillWithResources:
         skill_integrated = temp_project / ".agents" / "skills" / "skill-creator" / "SKILL.md"
         assert skill_integrated.exists(), "Skill not integrated to .agents/skills/"
 
-    def test_resources_stay_in_apm_modules(self, temp_project, apm_command):
+    def test_resources_stay_in_apm_modules(self, temp_project, apm_binary_path):
         """Verify bundled resources stay in apm_modules, not copied to .github/."""
         subprocess.run(
-            [apm_command, "install", "anthropics/skills/skills/skill-creator", "--verbose"],
+            [apm_binary_path, "install", "anthropics/skills/skills/skill-creator", "--verbose"],
             cwd=temp_project,
             capture_output=True,
             text=True,
@@ -170,13 +163,13 @@ class TestClaudeSkillWithResources:
 class TestSkillInstallIdempotency:
     """Test that skill installation is idempotent."""
 
-    def test_reinstall_same_skill_is_idempotent(self, temp_project, apm_command):
+    def test_reinstall_same_skill_is_idempotent(self, temp_project, apm_binary_path):
         """Installing the same skill twice should work without errors."""
         skill_ref = "anthropics/skills/skills/brand-guidelines"
 
         # First install
         result1 = subprocess.run(
-            [apm_command, "install", skill_ref],
+            [apm_binary_path, "install", skill_ref],
             cwd=temp_project,
             capture_output=True,
             text=True,
@@ -186,7 +179,7 @@ class TestSkillInstallIdempotency:
 
         # Second install (should succeed, possibly from cache)
         result2 = subprocess.run(
-            [apm_command, "install", skill_ref],
+            [apm_binary_path, "install", skill_ref],
             cwd=temp_project,
             capture_output=True,
             text=True,
@@ -198,7 +191,7 @@ class TestSkillInstallIdempotency:
         skill_integrated = temp_project / ".agents" / "skills" / "brand-guidelines" / "SKILL.md"
         assert skill_integrated.exists()
 
-    def test_reinstall_does_not_leak_apm_pin_to_deploy_targets(self, temp_project, apm_command):
+    def test_reinstall_does_not_leak_apm_pin_to_deploy_targets(self, temp_project, apm_binary_path):
         """Installing a skill twice must not copy .apm-pin into deploy targets.
 
         Regression test for https://github.com/microsoft/apm/issues/1150.
@@ -212,7 +205,7 @@ class TestSkillInstallIdempotency:
         skill_ref = "anthropics/skills/skills/brand-guidelines"
 
         result1 = subprocess.run(
-            [apm_command, "install", skill_ref],
+            [apm_binary_path, "install", skill_ref],
             cwd=temp_project,
             capture_output=True,
             text=True,
@@ -221,7 +214,7 @@ class TestSkillInstallIdempotency:
         assert result1.returncode == 0, f"First install failed: {result1.stderr}"
 
         result2 = subprocess.run(
-            [apm_command, "install", skill_ref],
+            [apm_binary_path, "install", skill_ref],
             cwd=temp_project,
             capture_output=True,
             text=True,
@@ -249,7 +242,7 @@ class TestSkillInstallIdempotency:
 class TestSkillInstallWithoutVSCodeTarget:
     """Test skill installation when VSCode is not the target."""
 
-    def test_skill_install_without_github_folder(self, tmp_path, apm_command):
+    def test_skill_install_without_github_folder(self, tmp_path, apm_binary_path):
         """Skill installs but no agent.md generated without .github/ folder."""
         project_dir = tmp_path / "no-vscode-project"
         project_dir.mkdir()
@@ -265,7 +258,7 @@ dependencies:
 
         # Install skill
         result = subprocess.run(
-            [apm_command, "install", "anthropics/skills/skills/brand-guidelines"],
+            [apm_binary_path, "install", "anthropics/skills/skills/brand-guidelines"],
             cwd=project_dir,
             capture_output=True,
             text=True,

--- a/tests/integration/test_skill_install.py
+++ b/tests/integration/test_skill_install.py
@@ -6,7 +6,6 @@ including simple skills and skills with bundled resources.
 These tests require network access to GitHub.
 """
 
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -41,17 +40,9 @@ dependencies:
 
 
 @pytest.fixture
-def apm_command():
-    """Get the path to the APM CLI executable."""
-    # Prefer binary on PATH (CI uses the PR artifact there)
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    # Fallback to local dev venv
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 class TestSimpleClaudeSkillInstall:

--- a/tests/integration/test_skill_integration.py
+++ b/tests/integration/test_skill_integration.py
@@ -7,7 +7,6 @@ and that compile does not modify skill files.
 These tests require network access to GitHub.
 """
 
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -45,17 +44,9 @@ dependencies:
 
 
 @pytest.fixture
-def apm_command():
-    """Get the path to the APM CLI executable."""
-    # Prefer binary on PATH (CI uses the PR artifact there)
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    # Fallback to local dev venv
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 class TestSkillInstallIntegration:

--- a/tests/integration/test_skill_integration.py
+++ b/tests/integration/test_skill_integration.py
@@ -8,7 +8,6 @@ These tests require network access to GitHub.
 """
 
 import subprocess
-from pathlib import Path
 
 import pytest
 
@@ -43,20 +42,14 @@ dependencies:
     return project_dir
 
 
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
-
-
 class TestSkillInstallIntegration:
     """Test SKILL.md integration at install time."""
 
-    def test_install_integrates_skill(self, temp_project, apm_command):
+    def test_install_integrates_skill(self, temp_project, apm_binary_path):
         """Install should integrate SKILL.md to .agents/skills/ when VSCode is target."""
         # Install skill
         result = subprocess.run(
-            [apm_command, "install", "anthropics/skills/skills/brand-guidelines"],
+            [apm_binary_path, "install", "anthropics/skills/skills/brand-guidelines"],
             cwd=temp_project,
             capture_output=True,
             text=True,
@@ -71,11 +64,11 @@ class TestSkillInstallIntegration:
             "Skill should be integrated to .agents/skills/ at install time"
         )
 
-    def test_install_preserves_skill_content(self, temp_project, apm_command):
+    def test_install_preserves_skill_content(self, temp_project, apm_binary_path):
         """Integrated skill should preserve the original SKILL.md content."""
         # Install skill
         result = subprocess.run(
-            [apm_command, "install", "anthropics/skills/skills/brand-guidelines"],
+            [apm_binary_path, "install", "anthropics/skills/skills/brand-guidelines"],
             cwd=temp_project,
             capture_output=True,
             text=True,
@@ -104,11 +97,11 @@ class TestSkillInstallIntegration:
         # The content should be preserved
         assert skill_content == integrated_content, "Integrated skill content should match original"
 
-    def test_install_creates_correct_structure(self, temp_project, apm_command):
+    def test_install_creates_correct_structure(self, temp_project, apm_binary_path):
         """Integrated skill should have SKILL.md in .agents/skills/{name}/."""
         # Install skill
         result = subprocess.run(
-            [apm_command, "install", "anthropics/skills/skills/brand-guidelines"],
+            [apm_binary_path, "install", "anthropics/skills/skills/brand-guidelines"],
             cwd=temp_project,
             capture_output=True,
             text=True,
@@ -126,11 +119,11 @@ class TestSkillInstallIntegration:
 class TestCompileSkipsSkills:
     """Test that compile does NOT modify or generate files from skills."""
 
-    def test_compile_does_not_modify_skills(self, temp_project, apm_command):
+    def test_compile_does_not_modify_skills(self, temp_project, apm_binary_path):
         """Compile should not modify skill files already integrated."""
         # Install skill (this integrates the skill)
         result = subprocess.run(
-            [apm_command, "install", "anthropics/skills/skills/brand-guidelines"],
+            [apm_binary_path, "install", "anthropics/skills/skills/brand-guidelines"],
             cwd=temp_project,
             capture_output=True,
             text=True,
@@ -146,7 +139,11 @@ class TestCompileSkipsSkills:
 
         # Run compile
         subprocess.run(
-            [apm_command, "compile"], cwd=temp_project, capture_output=True, text=True, timeout=60
+            [apm_binary_path, "compile"],
+            cwd=temp_project,
+            capture_output=True,
+            text=True,
+            timeout=60,
         )
 
         # Skill file should not be modified by compile
@@ -157,7 +154,7 @@ class TestCompileSkipsSkills:
 class TestMultipleSkillsInstall:
     """Test install with multiple skills."""
 
-    def test_multiple_skills_create_multiple_integrations(self, temp_project, apm_command):
+    def test_multiple_skills_create_multiple_integrations(self, temp_project, apm_binary_path):
         """Each installed skill should be integrated to .agents/skills/."""
         skills = [
             "anthropics/skills/skills/brand-guidelines",
@@ -166,7 +163,7 @@ class TestMultipleSkillsInstall:
 
         for skill in skills:
             result = subprocess.run(
-                [apm_command, "install", skill],
+                [apm_binary_path, "install", skill],
                 cwd=temp_project,
                 capture_output=True,
                 text=True,
@@ -185,10 +182,10 @@ class TestMultipleSkillsInstall:
 class TestSkillNaming:
     """Test that skill directory naming conventions are correct."""
 
-    def test_skill_name_matches_directory(self, temp_project, apm_command):
+    def test_skill_name_matches_directory(self, temp_project, apm_binary_path):
         """Skill directory name should match the skill name."""
         subprocess.run(
-            [apm_command, "install", "anthropics/skills/skills/brand-guidelines"],
+            [apm_binary_path, "install", "anthropics/skills/skills/brand-guidelines"],
             cwd=temp_project,
             capture_output=True,
             text=True,
@@ -200,10 +197,10 @@ class TestSkillNaming:
         assert skill_dir.exists(), "Skill directory should match skill name"
         assert (skill_dir / "SKILL.md").exists(), "SKILL.md should be in skill directory"
 
-    def test_skill_name_in_content(self, temp_project, apm_command):
+    def test_skill_name_in_content(self, temp_project, apm_binary_path):
         """Integrated SKILL.md should have content."""
         subprocess.run(
-            [apm_command, "install", "anthropics/skills/skills/brand-guidelines"],
+            [apm_binary_path, "install", "anthropics/skills/skills/brand-guidelines"],
             cwd=temp_project,
             capture_output=True,
             text=True,

--- a/tests/integration/test_target_resolution_e2e.py
+++ b/tests/integration/test_target_resolution_e2e.py
@@ -334,11 +334,7 @@ def test_s12_empty_repo_errors_no_silent_copilot(tmp_path):
     reason="#650 global copilot path resolution; handled by three-guard collapse",
     strict=False,
 )
-def test_s13_global_copilot_no_silent_skip(
-    tmp_path,
-    monkeypatch,
-    apm_binary_path: Path,
-):
+def test_s13_global_copilot_no_silent_skip(tmp_path, monkeypatch, apm_binary_path: Path):
     """S13: Closes #650 - 'apm install -g --target copilot' must not silently skip."""
     project = _setup(tmp_path, "s13_global_copilot")
     fakehome = tmp_path / "fakehome"
@@ -349,13 +345,7 @@ def test_s13_global_copilot_no_silent_skip(
     for var in ("APM_TARGET", "APM_CONFIG", "APM_HOME"):
         env.pop(var, None)
     result = subprocess.run(
-        [
-            str(apm_binary_path),
-            "install",
-            "-g",
-            "--target",
-            "copilot",
-        ],
+        [str(apm_binary_path), "install", "-g", "--target", "copilot"],
         cwd=project,
         env=env,
         capture_output=True,

--- a/tests/integration/test_target_resolution_e2e.py
+++ b/tests/integration/test_target_resolution_e2e.py
@@ -27,7 +27,6 @@ import os
 import re
 import shutil
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
@@ -335,7 +334,11 @@ def test_s12_empty_repo_errors_no_silent_copilot(tmp_path):
     reason="#650 global copilot path resolution; handled by three-guard collapse",
     strict=False,
 )
-def test_s13_global_copilot_no_silent_skip(tmp_path, monkeypatch):
+def test_s13_global_copilot_no_silent_skip(
+    tmp_path,
+    monkeypatch,
+    apm_binary_path: Path,
+):
     """S13: Closes #650 - 'apm install -g --target copilot' must not silently skip."""
     project = _setup(tmp_path, "s13_global_copilot")
     fakehome = tmp_path / "fakehome"
@@ -346,7 +349,13 @@ def test_s13_global_copilot_no_silent_skip(tmp_path, monkeypatch):
     for var in ("APM_TARGET", "APM_CONFIG", "APM_HOME"):
         env.pop(var, None)
     result = subprocess.run(
-        [sys.executable, "-m", "apm_cli", "install", "-g", "--target", "copilot"],
+        [
+            str(apm_binary_path),
+            "install",
+            "-g",
+            "--target",
+            "copilot",
+        ],
         cwd=project,
         env=env,
         capture_output=True,

--- a/tests/integration/test_transitive_chain_e2e.py
+++ b/tests/integration/test_transitive_chain_e2e.py
@@ -21,12 +21,6 @@ TIMEOUT = 180
 DEEP_CHAIN_LENGTH = 8
 
 
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    """Use the canonical integration-test executable."""
-    return str(apm_binary_path)
-
-
 def _write_pkg(pkg_dir: Path, name: str, deps: list, primitive_name: str) -> None:
     """Create a minimal APM package with one instructions primitive."""
     pkg_dir.mkdir(parents=True)
@@ -135,12 +129,12 @@ def _deps_by_name(lockfile: dict) -> dict:
     return out
 
 
-def test_three_level_apm_chain_resolves_all_levels(chain_workspace, apm_command):
+def test_three_level_apm_chain_resolves_all_levels(chain_workspace, apm_binary_path):
     """A->B->C chain installs all three packages and records the dep graph."""
     consumer = chain_workspace / "consumer"
 
     result = subprocess.run(
-        [apm_command, "install", "../pkg-a"],
+        [apm_binary_path, "install", "../pkg-a"],
         cwd=consumer,
         capture_output=True,
         text=True,
@@ -181,7 +175,7 @@ def test_three_level_apm_chain_resolves_all_levels(chain_workspace, apm_command)
 
 def test_deps_commands_follow_full_lock_graph_and_ignore_embedded_manifests(
     deep_chain_workspace: Path,
-    apm_command: str,
+    apm_binary_path: str,
 ) -> None:
     """CLI inventory follows every resolved edge but ignores parent-owned manifests."""
     consumer = deep_chain_workspace / "consumer"
@@ -191,7 +185,7 @@ def test_deps_commands_follow_full_lock_graph_and_ignore_embedded_manifests(
     embedded_names = ("embedded-shallow", "embedded-deep")
 
     installed = subprocess.run(
-        [apm_command, "install", f"../{package_names[0]}"],
+        [apm_binary_path, "install", f"../{package_names[0]}"],
         cwd=consumer,
         capture_output=True,
         text=True,
@@ -207,7 +201,7 @@ def test_deps_commands_follow_full_lock_graph_and_ignore_embedded_manifests(
         assert locked[key].get("resolved_by") in (expected_parent, "")
 
     listed = subprocess.run(
-        [apm_command, "deps", "list"],
+        [apm_binary_path, "deps", "list"],
         cwd=consumer,
         capture_output=True,
         text=True,
@@ -222,7 +216,7 @@ def test_deps_commands_follow_full_lock_graph_and_ignore_embedded_manifests(
     assert "orphaned package(s) found" not in list_output
 
     tree = subprocess.run(
-        [apm_command, "deps", "tree"],
+        [apm_binary_path, "deps", "tree"],
         cwd=consumer,
         capture_output=True,
         text=True,
@@ -254,7 +248,7 @@ def test_deps_commands_follow_full_lock_graph_and_ignore_embedded_manifests(
         assert not windows_abs.search(output), f"{label} leaked a Windows-absolute path:\n{output}"
 
     pruned = subprocess.run(
-        [apm_command, "prune"],
+        [apm_binary_path, "prune"],
         cwd=consumer,
         capture_output=True,
         text=True,
@@ -297,12 +291,12 @@ def test_deps_commands_follow_full_lock_graph_and_ignore_embedded_manifests(
     ).is_file()
 
 
-def test_three_level_chain_uninstall_root_cascades(chain_workspace, apm_command):
+def test_three_level_chain_uninstall_root_cascades(chain_workspace, apm_binary_path):
     """Uninstalling the root drops orphaned transitive deps and their primitives."""
     consumer = chain_workspace / "consumer"
 
     install = subprocess.run(
-        [apm_command, "install", "../pkg-a"],
+        [apm_binary_path, "install", "../pkg-a"],
         cwd=consumer,
         capture_output=True,
         text=True,
@@ -311,7 +305,7 @@ def test_three_level_chain_uninstall_root_cascades(chain_workspace, apm_command)
     assert install.returncode == 0, f"Install failed: {install.stderr}"
 
     uninstall = subprocess.run(
-        [apm_command, "uninstall", "../pkg-a"],
+        [apm_binary_path, "uninstall", "../pkg-a"],
         cwd=consumer,
         capture_output=True,
         text=True,
@@ -342,7 +336,7 @@ def test_three_level_chain_uninstall_root_cascades(chain_workspace, apm_command)
         assert not (deployed / fname).exists(), f"Primitive {fname} survived cascade uninstall"
 
 
-def test_asymmetric_layout_anchors_on_declaring_pkg(tmp_path, apm_command):
+def test_asymmetric_layout_anchors_on_declaring_pkg(tmp_path, apm_binary_path):
     """Regression for #857: a transitive ../sibling resolves against the
     DECLARING package's directory, not the consumer's project root.
 
@@ -377,7 +371,7 @@ def test_asymmetric_layout_anchors_on_declaring_pkg(tmp_path, apm_command):
     )
 
     result = subprocess.run(
-        [apm_command, "install"],
+        [apm_binary_path, "install"],
         cwd=consumer,
         capture_output=True,
         text=True,

--- a/tests/integration/test_transitive_chain_e2e.py
+++ b/tests/integration/test_transitive_chain_e2e.py
@@ -8,7 +8,6 @@ remote APM deps use.
 """
 
 import re
-import shutil
 import subprocess
 from itertools import pairwise
 from pathlib import Path
@@ -23,15 +22,9 @@ DEEP_CHAIN_LENGTH = 8
 
 
 @pytest.fixture
-def apm_command():
-    """Resolve the APM CLI executable (PATH or local venv)."""
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    """Use the canonical integration-test executable."""
+    return str(apm_binary_path)
 
 
 def _write_pkg(pkg_dir: Path, name: str, deps: list, primitive_name: str) -> None:

--- a/tests/integration/test_transitive_mcp_audit_e2e.py
+++ b/tests/integration/test_transitive_mcp_audit_e2e.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import subprocess
-import sys
 from pathlib import Path
 
 import pytest
@@ -12,14 +11,17 @@ import yaml
 
 pytestmark = pytest.mark.integration
 
-CLI = [sys.executable, "-m", "apm_cli.cli"]
 TIMEOUT = 180
 
 
-def _run(project: Path, *args: str) -> subprocess.CompletedProcess[str]:
+def _run(
+    apm_binary_path: Path,
+    project: Path,
+    *args: str,
+) -> subprocess.CompletedProcess[str]:
     """Run the APM CLI in the fixture project."""
     return subprocess.run(
-        [*CLI, *args],
+        [str(apm_binary_path), *args],
         cwd=project,
         capture_output=True,
         text=True,
@@ -62,11 +64,15 @@ dependencies:
     return project
 
 
-def test_ci_audit_tracks_current_transitive_mcp_source(tmp_path: Path) -> None:
+def test_ci_audit_tracks_current_transitive_mcp_source(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
     """Audit accepts installed transitive MCP, then rejects its removal."""
     project = _write_workspace(tmp_path)
 
     install = _run(
+        apm_binary_path,
         project,
         "install",
         "--force",
@@ -81,7 +87,15 @@ def test_ci_audit_tracks_current_transitive_mcp_source(tmp_path: Path) -> None:
     lock_data = yaml.safe_load((project / "apm.lock.yaml").read_text(encoding="utf-8"))
     assert lock_data["mcp_config_provenance"] == {"shadcn": "agent-config"}
 
-    audit = _run(project, "audit", "--ci", "--no-policy", "-f", "json")
+    audit = _run(
+        apm_binary_path,
+        project,
+        "audit",
+        "--ci",
+        "--no-policy",
+        "-f",
+        "json",
+    )
     assert audit.returncode == 0, f"audit stdout:\n{audit.stdout}\naudit stderr:\n{audit.stderr}"
     payload = json.loads(audit.stdout)
     config_check = next(
@@ -96,6 +110,7 @@ def test_ci_audit_tracks_current_transitive_mcp_source(tmp_path: Path) -> None:
     )
 
     changed_audit = _run(
+        apm_binary_path,
         project,
         "audit",
         "--ci",

--- a/tests/integration/test_transitive_mcp_audit_e2e.py
+++ b/tests/integration/test_transitive_mcp_audit_e2e.py
@@ -14,11 +14,7 @@ pytestmark = pytest.mark.integration
 TIMEOUT = 180
 
 
-def _run(
-    apm_binary_path: Path,
-    project: Path,
-    *args: str,
-) -> subprocess.CompletedProcess[str]:
+def _run(apm_binary_path: Path, project: Path, *args: str) -> subprocess.CompletedProcess[str]:
     """Run the APM CLI in the fixture project."""
     return subprocess.run(
         [str(apm_binary_path), *args],
@@ -65,8 +61,7 @@ dependencies:
 
 
 def test_ci_audit_tracks_current_transitive_mcp_source(
-    tmp_path: Path,
-    apm_binary_path: Path,
+    tmp_path: Path, apm_binary_path: Path
 ) -> None:
     """Audit accepts installed transitive MCP, then rejects its removal."""
     project = _write_workspace(tmp_path)
@@ -87,15 +82,7 @@ def test_ci_audit_tracks_current_transitive_mcp_source(
     lock_data = yaml.safe_load((project / "apm.lock.yaml").read_text(encoding="utf-8"))
     assert lock_data["mcp_config_provenance"] == {"shadcn": "agent-config"}
 
-    audit = _run(
-        apm_binary_path,
-        project,
-        "audit",
-        "--ci",
-        "--no-policy",
-        "-f",
-        "json",
-    )
+    audit = _run(apm_binary_path, project, "audit", "--ci", "--no-policy", "-f", "json")
     assert audit.returncode == 0, f"audit stdout:\n{audit.stdout}\naudit stderr:\n{audit.stderr}"
     payload = json.loads(audit.stdout)
     config_check = next(

--- a/tests/integration/test_uninstall_dry_run_e2e.py
+++ b/tests/integration/test_uninstall_dry_run_e2e.py
@@ -7,7 +7,6 @@ Requires network access and GITHUB_TOKEN/GITHUB_APM_PAT for GitHub API.
 Uses the real microsoft/apm-sample-package.
 """
 
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -21,14 +20,8 @@ pytestmark = [
 
 
 @pytest.fixture
-def apm_command():
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    return str(apm_binary_path)
 
 
 @pytest.fixture

--- a/tests/integration/test_uninstall_dry_run_e2e.py
+++ b/tests/integration/test_uninstall_dry_run_e2e.py
@@ -8,7 +8,6 @@ Uses the real microsoft/apm-sample-package.
 """
 
 import subprocess
-from pathlib import Path
 
 import pytest
 import yaml
@@ -20,11 +19,6 @@ pytestmark = [
 
 
 @pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    return str(apm_binary_path)
-
-
-@pytest.fixture
 def temp_project(tmp_path):
     project_dir = tmp_path / "uninstall-dry-run-test"
     project_dir.mkdir()
@@ -33,9 +27,9 @@ def temp_project(tmp_path):
     return project_dir
 
 
-def _run_apm(apm_command, args, cwd, timeout=180):
+def _run_apm(apm_binary_path, args, cwd, timeout=180):
     return subprocess.run(
-        [apm_command] + args,  # noqa: RUF005
+        [apm_binary_path] + args,  # noqa: RUF005
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -66,10 +60,10 @@ def _snapshot_files(project_dir):
 SAMPLE_PKG = "microsoft/apm-sample-package#main"
 
 
-def test_uninstall_dry_run_lists_files_without_removing(apm_command, temp_project):
+def test_uninstall_dry_run_lists_files_without_removing(apm_binary_path, temp_project):
     _write_apm_yml(temp_project, [SAMPLE_PKG])
 
-    install = _run_apm(apm_command, ["install"], temp_project)
+    install = _run_apm(apm_binary_path, ["install"], temp_project)
     assert install.returncode == 0, f"install failed: {install.stderr}\n{install.stdout}"
 
     apm_yml_before = (temp_project / "apm.yml").read_text(encoding="utf-8")
@@ -80,7 +74,7 @@ def test_uninstall_dry_run_lists_files_without_removing(apm_command, temp_projec
     files_before = _snapshot_files(temp_project)
 
     result = _run_apm(
-        apm_command,
+        apm_binary_path,
         ["uninstall", "microsoft/apm-sample-package", "--dry-run"],
         temp_project,
     )
@@ -100,17 +94,17 @@ def test_uninstall_dry_run_lists_files_without_removing(apm_command, temp_projec
     assert "apm-sample-package" in lock_path.read_text(encoding="utf-8")
 
 
-def test_uninstall_dry_run_with_unknown_package(apm_command, temp_project):
+def test_uninstall_dry_run_with_unknown_package(apm_binary_path, temp_project):
     _write_apm_yml(temp_project, [SAMPLE_PKG])
 
-    install = _run_apm(apm_command, ["install"], temp_project)
+    install = _run_apm(apm_binary_path, ["install"], temp_project)
     assert install.returncode == 0, f"install failed: {install.stderr}\n{install.stdout}"
 
     files_before = _snapshot_files(temp_project)
     apm_yml_before = (temp_project / "apm.yml").read_text(encoding="utf-8")
 
     result = _run_apm(
-        apm_command,
+        apm_binary_path,
         ["uninstall", "some/nonexistent", "--dry-run"],
         temp_project,
     )

--- a/tests/integration/test_uninstall_marketplace.py
+++ b/tests/integration/test_uninstall_marketplace.py
@@ -8,7 +8,6 @@ Does **not** require a GitHub token -- the lockfile is pre-seeded so the
 offline Stage 1 resolution path is exercised exclusively.
 """
 
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -24,14 +23,8 @@ pytestmark = [pytest.mark.requires_apm_binary]
 
 
 @pytest.fixture
-def apm_command():
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    return str(apm_binary_path)
 
 
 def _run_apm(apm_command, args, cwd, timeout=60):

--- a/tests/integration/test_uninstall_marketplace.py
+++ b/tests/integration/test_uninstall_marketplace.py
@@ -22,14 +22,9 @@ pytestmark = [pytest.mark.requires_apm_binary]
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    return str(apm_binary_path)
-
-
-def _run_apm(apm_command, args, cwd, timeout=60):
+def _run_apm(apm_binary_path, args, cwd, timeout=60):
     return subprocess.run(
-        [apm_command] + args,  # noqa: RUF005
+        [apm_binary_path] + args,  # noqa: RUF005
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -81,7 +76,7 @@ def _seed_project(project_dir: Path, canonical: str, marketplace_name: str, plug
 # ---------------------------------------------------------------------------
 
 
-def test_uninstall_marketplace_notation_via_lockfile(apm_command, tmp_path):
+def test_uninstall_marketplace_notation_via_lockfile(apm_binary_path, tmp_path):
     """``apm uninstall name@marketplace`` resolves via lockfile and removes the package."""
     project = tmp_path / "project"
     project.mkdir()
@@ -92,7 +87,7 @@ def test_uninstall_marketplace_notation_via_lockfile(apm_command, tmp_path):
     _seed_project(project, canonical, marketplace_name, plugin_name)
 
     result = _run_apm(
-        apm_command,
+        apm_binary_path,
         ["uninstall", f"{plugin_name}@{marketplace_name}"],
         project,
     )
@@ -114,7 +109,7 @@ def test_uninstall_marketplace_notation_via_lockfile(apm_command, tmp_path):
     assert not pkg_dir.exists(), f"Expected {pkg_dir} to be removed"
 
 
-def test_uninstall_marketplace_dry_run_no_changes(apm_command, tmp_path):
+def test_uninstall_marketplace_dry_run_no_changes(apm_binary_path, tmp_path):
     """``apm uninstall name@marketplace --dry-run`` resolves but does not mutate disk."""
     project = tmp_path / "project"
     project.mkdir()
@@ -123,7 +118,7 @@ def test_uninstall_marketplace_dry_run_no_changes(apm_command, tmp_path):
     _seed_project(project, canonical, "official", "my-plugin")
 
     result = _run_apm(
-        apm_command,
+        apm_binary_path,
         ["uninstall", "my-plugin@official", "--dry-run"],
         project,
     )
@@ -145,7 +140,7 @@ def test_uninstall_marketplace_dry_run_no_changes(apm_command, tmp_path):
     assert pkg_dir.exists(), "Expected apm_modules to be untouched after dry-run"
 
 
-def test_uninstall_marketplace_dry_run_no_lockfile_warns(apm_command, tmp_path):
+def test_uninstall_marketplace_dry_run_no_lockfile_warns(apm_binary_path, tmp_path):
     """``apm uninstall name@marketplace --dry-run`` without a lockfile warns and skips.
 
     Stage 1 (lockfile lookup) finds nothing because no lockfile exists, and Stage 2
@@ -166,7 +161,7 @@ def test_uninstall_marketplace_dry_run_no_lockfile_warns(apm_command, tmp_path):
     # Deliberately do NOT seed apm.lock.yaml -- this is the no-lockfile path.
 
     result = _run_apm(
-        apm_command,
+        apm_binary_path,
         ["uninstall", "my-plugin@official", "--dry-run"],
         project,
     )

--- a/tests/integration/test_uninstall_multi_e2e.py
+++ b/tests/integration/test_uninstall_multi_e2e.py
@@ -11,7 +11,6 @@ Uses two real public APM packages from GitHub:
 """
 
 import subprocess
-from pathlib import Path
 
 import pytest
 import yaml
@@ -27,11 +26,6 @@ PKG_B = "github/awesome-copilot/skills/aspire"
 
 
 @pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    return str(apm_binary_path)
-
-
-@pytest.fixture
 def temp_project(tmp_path):
     project_dir = tmp_path / "uninstall-multi-test"
     project_dir.mkdir()
@@ -40,9 +34,9 @@ def temp_project(tmp_path):
     return project_dir
 
 
-def _run_apm(apm_command, args, cwd, timeout=180):
+def _run_apm(apm_binary_path, args, cwd, timeout=180):
     return subprocess.run(
-        [apm_command] + args,  # noqa: RUF005
+        [apm_binary_path] + args,  # noqa: RUF005
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -98,9 +92,9 @@ def _deployed_files_for(lockfile, repo_substr):
 class TestUninstallMultiplePackages:
     """Verify that `apm uninstall pkg1 pkg2` removes both in a single command."""
 
-    def test_uninstall_multiple_packages_in_one_command(self, temp_project, apm_command):
+    def test_uninstall_multiple_packages_in_one_command(self, temp_project, apm_binary_path):
         _write_apm_yml(temp_project, [PKG_A, PKG_B])
-        result_install = _run_apm(apm_command, ["install"], temp_project)
+        result_install = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result_install.returncode == 0, (
             f"Install failed:\nSTDOUT: {result_install.stdout}\nSTDERR: {result_install.stderr}"
         )
@@ -119,7 +113,7 @@ class TestUninstallMultiplePackages:
         if not files_a_before or not files_b_before:
             pytest.skip("One of the packages deployed no files; cannot verify cleanup")
 
-        result_un = _run_apm(apm_command, ["uninstall", PKG_A, PKG_B], temp_project)
+        result_un = _run_apm(apm_binary_path, ["uninstall", PKG_A, PKG_B], temp_project)
         assert result_un.returncode == 0, (
             f"Uninstall failed:\nSTDOUT: {result_un.stdout}\nSTDERR: {result_un.stderr}"
         )
@@ -149,16 +143,16 @@ class TestUninstallMultiplePackages:
                 f"Deployed file {rel_path} not cleaned up by multi-uninstall"
             )
 
-    def test_uninstall_partial_unknown_continues_safely(self, temp_project, apm_command):
+    def test_uninstall_partial_unknown_continues_safely(self, temp_project, apm_binary_path):
         """Engine warns on unknown package but still removes the known one (exit 0)."""
         _write_apm_yml(temp_project, [PKG_A])
-        result_install = _run_apm(apm_command, ["install"], temp_project)
+        result_install = _run_apm(apm_binary_path, ["install"], temp_project)
         assert result_install.returncode == 0, (
             f"Install failed:\nSTDOUT: {result_install.stdout}\nSTDERR: {result_install.stderr}"
         )
 
         result_un = _run_apm(
-            apm_command,
+            apm_binary_path,
             ["uninstall", PKG_A, "some/unknown-pkg-xyz789"],
             temp_project,
         )

--- a/tests/integration/test_uninstall_multi_e2e.py
+++ b/tests/integration/test_uninstall_multi_e2e.py
@@ -10,7 +10,6 @@ Uses two real public APM packages from GitHub:
   - github/awesome-copilot/skills/aspire
 """
 
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -28,14 +27,8 @@ PKG_B = "github/awesome-copilot/skills/aspire"
 
 
 @pytest.fixture
-def apm_command():
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    return str(apm_binary_path)
 
 
 @pytest.fixture

--- a/tests/integration/test_update_e2e.py
+++ b/tests/integration/test_update_e2e.py
@@ -19,7 +19,6 @@ or GITHUB_TOKEN.
 from __future__ import annotations
 
 import os
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -34,14 +33,8 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.fixture
-def apm_command():
-    apm_on_path = shutil.which("apm")
-    if apm_on_path:
-        return apm_on_path
-    venv_apm = Path(__file__).parent.parent.parent / ".venv" / "bin" / "apm"
-    if venv_apm.exists():
-        return str(venv_apm)
-    return "apm"
+def apm_command(apm_binary_path: Path) -> str:
+    return str(apm_binary_path)
 
 
 @pytest.fixture

--- a/tests/integration/test_update_e2e.py
+++ b/tests/integration/test_update_e2e.py
@@ -33,11 +33,6 @@ pytestmark = pytest.mark.skipif(
 
 
 @pytest.fixture
-def apm_command(apm_binary_path: Path) -> str:
-    return str(apm_binary_path)
-
-
-@pytest.fixture
 def temp_project(tmp_path):
     project_dir = tmp_path / "update-test"
     project_dir.mkdir()
@@ -47,9 +42,9 @@ def temp_project(tmp_path):
     return project_dir
 
 
-def _run_apm(apm_command, args, cwd, timeout=180, stdin_input=None):
+def _run_apm(apm_binary_path, args, cwd, timeout=180, stdin_input=None):
     return subprocess.run(
-        [apm_command] + args,  # noqa: RUF005
+        [apm_binary_path] + args,  # noqa: RUF005
         cwd=cwd,
         capture_output=True,
         text=True,
@@ -70,11 +65,11 @@ def _write_apm_yml(project_dir: Path, apm_packages: list[str]) -> None:
 
 
 class TestUpdateE2E:
-    def test_update_dry_run_writes_nothing(self, temp_project, apm_command):
+    def test_update_dry_run_writes_nothing(self, temp_project, apm_binary_path):
         """`apm update --dry-run` prints a plan and writes no artifacts."""
         _write_apm_yml(temp_project, ["microsoft/apm-sample-package"])
 
-        result = _run_apm(apm_command, ["update", "--dry-run"], temp_project)
+        result = _run_apm(apm_binary_path, ["update", "--dry-run"], temp_project)
 
         assert result.returncode == 0, (
             f"Dry-run failed:\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
@@ -82,18 +77,18 @@ class TestUpdateE2E:
         assert "Dry run" in result.stdout or "plan" in result.stdout.lower()
         assert not (temp_project / "apm.lock.yaml").exists()
 
-    def test_update_after_install_no_changes_short_circuits(self, temp_project, apm_command):
+    def test_update_after_install_no_changes_short_circuits(self, temp_project, apm_binary_path):
         """After `apm install`, a follow-up `apm update --yes` with no
         manifest changes should report all-up-to-date and not fail."""
         _write_apm_yml(temp_project, ["microsoft/apm-sample-package"])
 
-        first = _run_apm(apm_command, ["install"], temp_project)
+        first = _run_apm(apm_binary_path, ["install"], temp_project)
         assert first.returncode == 0, (
             f"Initial install failed:\nSTDOUT: {first.stdout}\nSTDERR: {first.stderr}"
         )
         assert (temp_project / "apm.lock.yaml").exists()
 
-        result = _run_apm(apm_command, ["update", "--yes"], temp_project)
+        result = _run_apm(apm_binary_path, ["update", "--yes"], temp_project)
 
         assert result.returncode == 0, (
             f"Update failed:\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
@@ -101,32 +96,32 @@ class TestUpdateE2E:
 
 
 class TestFrozenE2E:
-    def test_frozen_succeeds_against_in_sync_lockfile(self, temp_project, apm_command):
+    def test_frozen_succeeds_against_in_sync_lockfile(self, temp_project, apm_binary_path):
         _write_apm_yml(temp_project, ["microsoft/apm-sample-package"])
 
-        first = _run_apm(apm_command, ["install"], temp_project)
+        first = _run_apm(apm_binary_path, ["install"], temp_project)
         assert first.returncode == 0, first.stderr
 
         # Re-run with --frozen on the same manifest+lockfile.
-        result = _run_apm(apm_command, ["install", "--frozen"], temp_project)
+        result = _run_apm(apm_binary_path, ["install", "--frozen"], temp_project)
 
         assert result.returncode == 0, (
             f"Frozen install failed on in-sync project:\n{result.stdout}\n{result.stderr}"
         )
 
-    def test_frozen_fails_when_lockfile_missing(self, temp_project, apm_command):
+    def test_frozen_fails_when_lockfile_missing(self, temp_project, apm_binary_path):
         _write_apm_yml(temp_project, ["microsoft/apm-sample-package"])
 
-        result = _run_apm(apm_command, ["install", "--frozen"], temp_project)
+        result = _run_apm(apm_binary_path, ["install", "--frozen"], temp_project)
 
         assert result.returncode != 0
         combined = result.stdout + result.stderr
         assert "frozen" in combined.lower() or "lock" in combined.lower()
 
-    def test_frozen_fails_when_manifest_adds_undeclared_dep(self, temp_project, apm_command):
+    def test_frozen_fails_when_manifest_adds_undeclared_dep(self, temp_project, apm_binary_path):
         """Lockfile present but manifest gained a dep that isn't in lock -> fail."""
         _write_apm_yml(temp_project, ["microsoft/apm-sample-package"])
-        first = _run_apm(apm_command, ["install"], temp_project)
+        first = _run_apm(apm_binary_path, ["install"], temp_project)
         assert first.returncode == 0, first.stderr
 
         _write_apm_yml(
@@ -134,16 +129,16 @@ class TestFrozenE2E:
             ["microsoft/apm-sample-package", "microsoft/some-other-not-in-lock"],
         )
 
-        result = _run_apm(apm_command, ["install", "--frozen"], temp_project)
+        result = _run_apm(apm_binary_path, ["install", "--frozen"], temp_project)
 
         assert result.returncode != 0
         combined = result.stdout + result.stderr
         assert "out of sync" in combined.lower() or "missing" in combined.lower()
 
-    def test_frozen_with_update_is_rejected(self, temp_project, apm_command):
+    def test_frozen_with_update_is_rejected(self, temp_project, apm_binary_path):
         _write_apm_yml(temp_project, ["microsoft/apm-sample-package"])
 
-        result = _run_apm(apm_command, ["install", "--frozen", "--update"], temp_project)
+        result = _run_apm(apm_binary_path, ["install", "--frozen", "--update"], temp_project)
 
         assert result.returncode != 0
         combined = result.stdout + result.stderr
@@ -166,7 +161,7 @@ class TestUpdateInteractiveDecline:
         sys.platform.startswith("win"),
         reason="pty.openpty is POSIX-only; decline path is covered by unit tests on Windows",
     )
-    def test_decline_at_prompt_leaves_lockfile_untouched(self, temp_project, apm_command):
+    def test_decline_at_prompt_leaves_lockfile_untouched(self, temp_project, apm_binary_path):
         """``apm update`` with TTY stdin and 'n' answer mutates nothing.
 
         Sequence:
@@ -183,7 +178,7 @@ class TestUpdateInteractiveDecline:
            state (the decline path performed no on-disk mutation).
         """
         _write_apm_yml(temp_project, ["microsoft/apm-sample-package"])
-        first = _run_apm(apm_command, ["install"], temp_project)
+        first = _run_apm(apm_binary_path, ["install"], temp_project)
         assert first.returncode == 0, first.stderr
 
         lockfile = temp_project / "apm.lock.yaml"
@@ -197,7 +192,7 @@ class TestUpdateInteractiveDecline:
         )
 
         rc, output = _run_apm_with_pty(
-            apm_command,
+            apm_binary_path,
             ["update"],
             cwd=temp_project,
             stdin_text="n\n",
@@ -231,7 +226,7 @@ def _write_apm_yml_with_ref(project_dir: Path, package: str, *, ref: str) -> Non
 
 
 def _run_apm_with_pty(
-    apm_command: str,
+    apm_binary_path: str,
     args: list[str],
     *,
     cwd: Path,
@@ -253,7 +248,7 @@ def _run_apm_with_pty(
     master_fd, slave_fd = pty.openpty()
     try:
         proc = subprocess.Popen(
-            [apm_command, *args],
+            [apm_binary_path, *args],
             cwd=str(cwd),
             stdin=slave_fd,
             stdout=slave_fd,

--- a/tests/unit/scripts/test_check_test_contract_authorities.py
+++ b/tests/unit/scripts/test_check_test_contract_authorities.py
@@ -44,6 +44,9 @@ def _write_owner_stubs(root: Path) -> None:
         "import os\ndef choose():\n    return os.environ['APM_BINARY_PATH']\n",
         "from os import environ\ndef choose():\n    return environ.get('APM_BINARY_PATH')\n",
         "from os import environ as env\ndef choose():\n    return env['APM_BINARY_PATH']\n",
+        "def choose():\n"
+        "    import os as nested_os\n"
+        "    return nested_os.environ.get('APM_BINARY_PATH')\n",
     ),
 )
 def test_any_direct_binary_environment_read_is_rejected(
@@ -153,6 +156,26 @@ def test_unrelated_recursive_registry_walk_is_allowed(tmp_path: Path) -> None:
     assert _load_checker().find_rendered_parity_violations(tmp_path) == []
 
 
+def test_loop_based_registry_projection_is_rejected(tmp_path: Path) -> None:
+    """A loop that builds the public command set is still a projection."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "scripts" / "loop_projection.py"
+    duplicate.write_text(
+        "def project(group):\n"
+        "    result = set()\n"
+        "    for name, command in group.commands.items():\n"
+        "        if not command.hidden:\n"
+        "            result.add(name)\n"
+        "    return result\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_rendered_parity_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "direct Click command registry projection" in violations[0]
+
+
 def test_direct_rendered_inventory_is_rejected_with_imported_registry(
     tmp_path: Path,
 ) -> None:
@@ -172,6 +195,24 @@ def test_direct_rendered_inventory_is_rejected_with_imported_registry(
 
     assert len(violations) >= 2
     assert any("internal rendered parity projection imported" in item for item in violations)
+    assert any("direct rendered CLI route inventory" in item for item in violations)
+
+
+def test_split_path_rendered_inventory_is_rejected(tmp_path: Path) -> None:
+    """Splitting reference/cli across assignments cannot evade ownership."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "scripts" / "split_page_projection.py"
+    duplicate.write_text(
+        "def project(dist):\n"
+        "    base = dist / 'reference'\n"
+        "    cli_dir = base / 'cli'\n"
+        "    return {child.name for child in cli_dir.iterdir() "
+        "if (child / 'index.html').is_file()}\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_rendered_parity_violations(tmp_path)
+
     assert any("direct rendered CLI route inventory" in item for item in violations)
 
 
@@ -230,3 +271,26 @@ def test_rendered_parity_facade_delegation_is_allowed(tmp_path: Path) -> None:
     )
 
     assert _load_checker().find_rendered_parity_violations(tmp_path) == []
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "import scripts.check_cli_docs\n",
+        "from scripts import check_cli_docs\n",
+    ),
+)
+def test_direct_parity_module_import_is_rejected(
+    tmp_path: Path,
+    source: str,
+) -> None:
+    """Direct module imports cannot bypass facade-only consumption."""
+    _write_owner_stubs(tmp_path)
+    consumer = tmp_path / "tests" / "consumer.py"
+    consumer.parent.mkdir(exist_ok=True)
+    consumer.write_text(source, encoding="utf-8")
+
+    violations = _load_checker().find_rendered_parity_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "rendered parity module imported directly" in violations[0]

--- a/tests/unit/scripts/test_check_test_contract_authorities.py
+++ b/tests/unit/scripts/test_check_test_contract_authorities.py
@@ -39,8 +39,11 @@ def _write_owner_stubs(root: Path) -> None:
     "source",
     (
         "import os\ndef renamed():\n    return os.environ.get('APM_BINARY_PATH') or 'apm'\n",
+        "import os as _os\ndef renamed():\n    return _os.environ.get('APM_BINARY_PATH')\n",
         "import os\ndef choose():\n    return os.getenv('APM_BINARY_PATH')\n",
         "import os\ndef choose():\n    return os.environ['APM_BINARY_PATH']\n",
+        "from os import environ\ndef choose():\n    return environ.get('APM_BINARY_PATH')\n",
+        "from os import environ as env\ndef choose():\n    return env['APM_BINARY_PATH']\n",
     ),
 )
 def test_any_direct_binary_environment_read_is_rejected(
@@ -133,6 +136,21 @@ def test_direct_registry_projection_is_rejected_without_comparison(tmp_path: Pat
 
     assert len(violations) == 1
     assert "direct Click command registry projection" in violations[0]
+
+
+def test_unrelated_recursive_registry_walk_is_allowed(tmp_path: Path) -> None:
+    """A recursive help audit is not a rendered parity projection."""
+    _write_owner_stubs(tmp_path)
+    consumer = tmp_path / "tests" / "help_audit.py"
+    consumer.parent.mkdir(exist_ok=True)
+    consumer.write_text(
+        "def walk(group):\n"
+        "    for name, command in group.commands.items():\n"
+        "        yield name, command\n",
+        encoding="utf-8",
+    )
+
+    assert _load_checker().find_rendered_parity_violations(tmp_path) == []
 
 
 def test_direct_rendered_inventory_is_rejected_with_imported_registry(

--- a/tests/unit/scripts/test_check_test_contract_authorities.py
+++ b/tests/unit/scripts/test_check_test_contract_authorities.py
@@ -44,6 +44,7 @@ def _write_owner_stubs(root: Path) -> None:
         "import os\ndef choose():\n    return os.environ['APM_BINARY_PATH']\n",
         "from os import environ\ndef choose():\n    return environ.get('APM_BINARY_PATH')\n",
         "from os import environ as env\ndef choose():\n    return env['APM_BINARY_PATH']\n",
+        "import os\ndef choose():\n    env = os.environ\n    return env.get('APM_BINARY_PATH')\n",
         "def choose():\n"
         "    import os as nested_os\n"
         "    return nested_os.environ.get('APM_BINARY_PATH')\n",
@@ -121,6 +122,42 @@ def test_aliased_path_lookup_is_rejected(tmp_path: Path) -> None:
     assert "direct PATH lookup for apm" in violations[0]
 
 
+def test_assigned_path_lookup_alias_is_rejected(tmp_path: Path) -> None:
+    """A simple assignment alias must preserve shutil.which authority."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "tests" / "integration" / "path_assignment.py"
+    duplicate.write_text(
+        "import shutil\nlocate = shutil.which\ndef choose():\n    return locate('apm')\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_binary_selection_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "direct PATH lookup for apm" in violations[0]
+
+
+def test_shadowed_shutil_binding_does_not_duplicate_diagnostics(tmp_path: Path) -> None:
+    """Parameter/local shadowing must not inherit the outer import binding."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "tests" / "integration" / "shadowed.py"
+    duplicate.write_text(
+        "import shutil\n"
+        "outer = shutil.which('apm')\n"
+        "def parameter_shadow(shutil):\n"
+        "    return shutil.which('apm')\n"
+        "def local_shadow():\n"
+        "    shutil = object()\n"
+        "    return shutil.which('apm')\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_binary_selection_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "direct PATH lookup for apm" in violations[0]
+
+
 def test_venv_fallback_without_env_or_which_is_rejected(tmp_path: Path) -> None:
     """Deleting the .venv detector must fail independently."""
     _write_owner_stubs(tmp_path)
@@ -144,6 +181,8 @@ def test_venv_fallback_without_env_or_which_is_rejected(tmp_path: Path) -> None:
     (
         "Path('.venv', 'bin', 'apm')",
         "Path('.venv').joinpath('Scripts', 'apm.exe')",
+        "PurePosixPath('.venv', 'bin', 'apm')",
+        "PureWindowsPath('.venv', 'Scripts', 'apm.exe')",
         "os.path.join('.venv', 'bin', 'apm')",
     ),
 )
@@ -155,7 +194,9 @@ def test_standalone_venv_constructor_forms_are_rejected(
     _write_owner_stubs(tmp_path)
     duplicate = tmp_path / "tests" / "integration" / "venv_constructor.py"
     duplicate.write_text(
-        f"import os\nfrom pathlib import Path\ndef choose():\n    return {selector}\n",
+        "import os\n"
+        "from pathlib import Path, PurePosixPath, PureWindowsPath\n"
+        f"def choose():\n    return {selector}\n",
         encoding="utf-8",
     )
 
@@ -215,11 +256,31 @@ def test_interpreter_relative_apm_selector_is_rejected(tmp_path: Path) -> None:
     assert "interpreter-relative apm selection" in violations[0]
 
 
+def test_interpreter_parent_apm_selector_is_rejected(tmp_path: Path) -> None:
+    """Parent-directory construction from sys.executable is still selection."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "tests" / "integration" / "parent_duplicate.py"
+    duplicate.write_text(
+        "import sys\n"
+        "from pathlib import Path\n"
+        "def choose():\n"
+        "    return Path(sys.executable).parent / 'apm'\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_binary_selection_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "interpreter-relative apm selection" in violations[0]
+
+
 @pytest.mark.parametrize(
     "source",
     (
         "import subprocess\nsubprocess.run(['apm', '--version'])\n",
         "import subprocess\nsubprocess.Popen(['apm', '--version'])\n",
+        "import subprocess\nsubprocess.run('apm --version', shell=True)\n",
+        "import subprocess\ncommand = 'apm --version'\nsubprocess.run(command, shell=True)\n",
         "import subprocess\nsubprocess.run(['uv', 'run', 'apm'])\n",
         "import subprocess, sys\nsubprocess.run([sys.executable, '-m', 'apm_cli'])\n",
         "import subprocess, sys\nsubprocess.run([sys.executable, '-m', 'uv', 'run', 'apm'])\n",
@@ -277,6 +338,46 @@ def test_fixture_forwarding_facade_is_rejected(tmp_path: Path) -> None:
 
     assert len(violations) == 1
     assert "local apm binary fixture or facade" in violations[0]
+
+
+def test_multistatement_forwarding_fixture_is_rejected(tmp_path: Path) -> None:
+    """Extra statements cannot disguise a duplicate forwarding fixture."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "tests" / "integration" / "facade.py"
+    duplicate.write_text(
+        "import pytest\n"
+        "@pytest.fixture\n"
+        "def binary(apm_binary_path):\n"
+        "    selected = str(apm_binary_path)\n"
+        "    return selected\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_binary_selection_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "local apm binary fixture or facade" in violations[0]
+
+
+def test_nested_binary_owner_definitions_are_rejected(tmp_path: Path) -> None:
+    """Resolver and fixture ownership cannot hide in nested scopes."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "tests" / "integration" / "nested.py"
+    duplicate.write_text(
+        "import pytest\n"
+        "def outer():\n"
+        "    def _resolve_apm_binary():\n"
+        "        return None\n"
+        "    @pytest.fixture\n"
+        "    def apm_binary_path():\n"
+        "        return None\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_binary_selection_violations(tmp_path)
+
+    assert any("local apm binary fixture or facade" in item for item in violations)
+    assert len(violations) >= 2
 
 
 def test_renamed_binary_resolver_is_rejected(tmp_path: Path) -> None:

--- a/tests/unit/scripts/test_check_test_contract_authorities.py
+++ b/tests/unit/scripts/test_check_test_contract_authorities.py
@@ -69,6 +69,25 @@ def test_binary_fixture_delegation_is_allowed(tmp_path: Path) -> None:
     assert _load_checker().find_binary_selection_violations(tmp_path) == []
 
 
+def test_binary_environment_subscript_fallback_is_rejected(tmp_path: Path) -> None:
+    """Subscript syntax must not evade the binary-selection boundary."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "tests" / "integration" / "subscript_duplicate.py"
+    duplicate.write_text(
+        "import os\n"
+        "import shutil\n"
+        "def apm_command():\n"
+        "    configured = os.environ['APM_BINARY_PATH']\n"
+        "    return configured or shutil.which('apm')\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_binary_selection_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "duplicate integration binary selection" in violations[0]
+
+
 def test_known_rendered_parity_reimplementation_is_rejected(tmp_path: Path) -> None:
     """A second registry/page set comparison must trip the boundary."""
     _write_owner_stubs(tmp_path)

--- a/tests/unit/scripts/test_check_test_contract_authorities.py
+++ b/tests/unit/scripts/test_check_test_contract_authorities.py
@@ -201,6 +201,7 @@ def test_venv_fallback_without_env_or_which_is_rejected(tmp_path: Path) -> None:
     "selector",
     (
         "Path('.venv', 'bin', 'apm')",
+        "PurePath('.venv', 'bin', 'apm')",
         "Path('.venv').joinpath('Scripts', 'apm.exe')",
         "PurePosixPath('.venv', 'bin', 'apm')",
         "PureWindowsPath('.venv', 'Scripts', 'apm.exe')",
@@ -216,7 +217,7 @@ def test_standalone_venv_constructor_forms_are_rejected(
     duplicate = tmp_path / "tests" / "integration" / "venv_constructor.py"
     duplicate.write_text(
         "import os\n"
-        "from pathlib import Path, PurePosixPath, PureWindowsPath\n"
+        "from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath\n"
         f"def choose():\n    return {selector}\n",
         encoding="utf-8",
     )

--- a/tests/unit/scripts/test_check_test_contract_authorities.py
+++ b/tests/unit/scripts/test_check_test_contract_authorities.py
@@ -347,6 +347,62 @@ def test_shadowed_subprocess_binding_does_not_duplicate_diagnostics(
     assert "direct apm subprocess selection" in violations[0]
 
 
+@pytest.mark.parametrize(
+    "source",
+    (
+        "import shutil\n"
+        "def choose(flag):\n"
+        "    if flag:\n"
+        "        locate = shutil.which\n"
+        "    else:\n"
+        "        locate = shutil.which\n"
+        "    return locate('apm')\n",
+        "import os\n"
+        "def choose(items):\n"
+        "    for _ in items:\n"
+        "        env = os.environ\n"
+        "    return env.get('APM_BINARY_PATH')\n",
+        "import subprocess\n"
+        "def choose():\n"
+        "    try:\n"
+        "        runner = subprocess\n"
+        "    finally:\n"
+        "        pass\n"
+        "    return runner.run(['apm', '--version'])\n",
+    ),
+)
+def test_nested_control_flow_aliases_are_rejected(
+    tmp_path: Path,
+    source: str,
+) -> None:
+    """Aliases assigned inside compound statements retain their authority."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "tests" / "integration" / "nested_alias.py"
+    duplicate.write_text(source, encoding="utf-8")
+
+    violations = _load_checker().find_binary_selection_violations(tmp_path)
+
+    assert len(violations) == 1
+
+
+def test_command_assignment_does_not_leak_between_scopes(tmp_path: Path) -> None:
+    """Common command variable names remain isolated per function."""
+    _write_owner_stubs(tmp_path)
+    consumer = tmp_path / "tests" / "integration" / "commands.py"
+    consumer.write_text(
+        "import subprocess\n"
+        "def unrelated_tool():\n"
+        "    command = ['ls', '-la']\n"
+        "    return subprocess.run(command)\n"
+        "def apm_data_only():\n"
+        "    command = ['apm', '--version']\n"
+        "    return command\n",
+        encoding="utf-8",
+    )
+
+    assert _load_checker().find_binary_selection_violations(tmp_path) == []
+
+
 def test_probe_list_selector_is_rejected(tmp_path: Path) -> None:
     """Probe-loop selection must use the canonical fixture."""
     _write_owner_stubs(tmp_path)

--- a/tests/unit/scripts/test_check_test_contract_authorities.py
+++ b/tests/unit/scripts/test_check_test_contract_authorities.py
@@ -124,6 +124,38 @@ def test_path_fallback_without_venv_is_rejected(tmp_path: Path) -> None:
     assert "direct shutil.which('apm') fallback" in violations[0]
 
 
+@pytest.mark.parametrize(
+    "source",
+    (
+        "import subprocess\ndef run():\n    return subprocess.run(['apm', '--version'])\n",
+        "import subprocess\ndef run():\n"
+        "    return subprocess.run(['uv', 'run', 'apm', '--version'])\n",
+        "import subprocess\nimport sys\nfrom pathlib import Path\n"
+        "def run():\n"
+        "    executable = Path(sys.executable).with_name('apm')\n"
+        "    return subprocess.run([str(executable), '--version'])\n",
+        "import subprocess\ndef probe():\n"
+        "    possible = ['apm', './apm', './dist/apm']\n"
+        "    for path in possible:\n"
+        "        result = subprocess.run([path, '--version'])\n"
+        "        if result.returncode == 0:\n"
+        "            return path\n",
+    ),
+)
+def test_standalone_binary_selector_shapes_are_rejected(
+    tmp_path: Path,
+    source: str,
+) -> None:
+    """Known bare, uv, sibling, and probe selectors must stay retired."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "tests" / "integration" / "selector.py"
+    duplicate.write_text(source, encoding="utf-8")
+
+    violations = _load_checker().find_binary_selection_violations(tmp_path)
+
+    assert any("standalone APM subprocess selector" in item for item in violations)
+
+
 def test_renamed_binary_resolver_is_rejected(tmp_path: Path) -> None:
     """A renamed resolver still fails because it reads the owned variable."""
     _write_owner_stubs(tmp_path)

--- a/tests/unit/scripts/test_check_test_contract_authorities.py
+++ b/tests/unit/scripts/test_check_test_contract_authorities.py
@@ -158,6 +158,27 @@ def test_shadowed_shutil_binding_does_not_duplicate_diagnostics(tmp_path: Path) 
     assert "direct PATH lookup for apm" in violations[0]
 
 
+def test_shadowed_os_binding_does_not_duplicate_diagnostics(tmp_path: Path) -> None:
+    """Only the genuine outer os binding may own an environment read."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "tests" / "integration" / "shadowed_os.py"
+    duplicate.write_text(
+        "import os\n"
+        "outer = os.getenv('APM_BINARY_PATH')\n"
+        "def parameter_shadow(os):\n"
+        "    return os.getenv('APM_BINARY_PATH')\n"
+        "def local_shadow():\n"
+        "    os = object()\n"
+        "    return os.getenv('APM_BINARY_PATH')\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_binary_selection_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "direct APM_BINARY_PATH read" in violations[0]
+
+
 def test_venv_fallback_without_env_or_which_is_rejected(tmp_path: Path) -> None:
     """Deleting the .venv detector must fail independently."""
     _write_owner_stubs(tmp_path)
@@ -281,6 +302,7 @@ def test_interpreter_parent_apm_selector_is_rejected(tmp_path: Path) -> None:
         "import subprocess\nsubprocess.Popen(['apm', '--version'])\n",
         "import subprocess\nsubprocess.run('apm --version', shell=True)\n",
         "import subprocess\ncommand = 'apm --version'\nsubprocess.run(command, shell=True)\n",
+        "import subprocess\ncommand = ['apm', '--version']\nsubprocess.run(command)\n",
         "import subprocess\nsubprocess.run(['uv', 'run', 'apm'])\n",
         "import subprocess, sys\nsubprocess.run([sys.executable, '-m', 'apm_cli'])\n",
         "import subprocess, sys\nsubprocess.run([sys.executable, '-m', 'uv', 'run', 'apm'])\n",
@@ -294,6 +316,29 @@ def test_direct_subprocess_selection_is_rejected(
     _write_owner_stubs(tmp_path)
     duplicate = tmp_path / "tests" / "integration" / "launcher_duplicate.py"
     duplicate.write_text(source, encoding="utf-8")
+
+    violations = _load_checker().find_binary_selection_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "direct apm subprocess selection" in violations[0]
+
+
+def test_shadowed_subprocess_binding_does_not_duplicate_diagnostics(
+    tmp_path: Path,
+) -> None:
+    """Only the genuine imported subprocess binding may launch APM."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "tests" / "integration" / "shadowed_subprocess.py"
+    duplicate.write_text(
+        "import subprocess\n"
+        "outer = subprocess.run(['apm', '--version'])\n"
+        "def parameter_shadow(subprocess):\n"
+        "    return subprocess.run(['apm', '--version'])\n"
+        "def local_shadow():\n"
+        "    subprocess = object()\n"
+        "    return subprocess.run(['apm', '--version'])\n",
+        encoding="utf-8",
+    )
 
     violations = _load_checker().find_binary_selection_violations(tmp_path)
 

--- a/tests/unit/scripts/test_check_test_contract_authorities.py
+++ b/tests/unit/scripts/test_check_test_contract_authorities.py
@@ -128,6 +128,7 @@ def test_path_fallback_without_venv_is_rejected(tmp_path: Path) -> None:
     "source",
     (
         "import subprocess\ndef run():\n    return subprocess.run(['apm', '--version'])\n",
+        "import subprocess\ndef run():\n    return subprocess.Popen(['apm', '--version'])\n",
         "import subprocess\ndef run():\n"
         "    return subprocess.run(['uv', 'run', 'apm', '--version'])\n",
         "import subprocess\nimport sys\ndef run():\n"

--- a/tests/unit/scripts/test_check_test_contract_authorities.py
+++ b/tests/unit/scripts/test_check_test_contract_authorities.py
@@ -35,6 +35,34 @@ def _write_owner_stubs(root: Path) -> None:
     )
 
 
+def test_checker_main_reserves_stdout_for_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    checker = _load_checker()
+    monkeypatch.setattr(checker, "check", lambda _root: [])
+
+    assert checker.main(["--root", str(tmp_path)]) == 0
+    captured = capsys.readouterr()
+    assert captured.out == "[+] test contract authority check clean\n"
+    assert captured.err == ""
+
+
+def test_checker_main_routes_failures_to_stderr(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    checker = _load_checker()
+    monkeypatch.setattr(checker, "check", lambda _root: ["[x] duplicate owner"])
+
+    assert checker.main(["--root", str(tmp_path)]) == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ("[x] duplicate owner\n[x] 1 test contract authority violation found\n")
+
+
 @pytest.mark.parametrize(
     "source",
     (

--- a/tests/unit/scripts/test_check_test_contract_authorities.py
+++ b/tests/unit/scripts/test_check_test_contract_authorities.py
@@ -1,0 +1,104 @@
+"""Mutation-style tests for test contract authority boundaries."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_checker() -> ModuleType:
+    root = Path(__file__).resolve().parents[3]
+    path = root / "scripts" / "check_test_contract_authorities.py"
+    spec = importlib.util.spec_from_file_location("check_test_contract_authorities", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_owner_stubs(root: Path) -> None:
+    binary_owner = root / "tests" / "integration" / "conftest.py"
+    binary_owner.parent.mkdir(parents=True)
+    binary_owner.write_text("def _resolve_apm_binary():\n    return None\n", encoding="utf-8")
+    parity_owner = root / "scripts" / "check_cli_docs.py"
+    parity_owner.parent.mkdir(parents=True)
+    parity_owner.write_text(
+        "def public_top_level_commands():\n    pass\n"
+        "def rendered_cli_reference_pages():\n    pass\n"
+        "def registry_docs_mismatches():\n    pass\n",
+        encoding="utf-8",
+    )
+
+
+def test_known_binary_fallback_chain_is_rejected(tmp_path: Path) -> None:
+    """The retired silent-adopt resolver shape must trip the boundary."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "tests" / "integration" / "duplicate.py"
+    duplicate.write_text(
+        "import os\n"
+        "import shutil\n"
+        "from pathlib import Path\n"
+        "def apm_command():\n"
+        "    for env_var in ('APM_TEST_BINARY', 'APM_BINARY_PATH'):\n"
+        "        override = os.environ.get(env_var)\n"
+        "        if override and Path(override).exists():\n"
+        "            return override\n"
+        "    candidate = Path('.venv') / 'bin' / 'apm'\n"
+        "    return str(candidate) if candidate.exists() else shutil.which('apm')\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_binary_selection_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "duplicate integration binary selection" in violations[0]
+
+
+def test_binary_fixture_delegation_is_allowed(tmp_path: Path) -> None:
+    """A consumer accepting the canonical fixture is not a second owner."""
+    _write_owner_stubs(tmp_path)
+    consumer = tmp_path / "tests" / "integration" / "consumer.py"
+    consumer.write_text(
+        "def apm_command(apm_binary_path):\n    return str(apm_binary_path)\n",
+        encoding="utf-8",
+    )
+
+    assert _load_checker().find_binary_selection_violations(tmp_path) == []
+
+
+def test_known_rendered_parity_reimplementation_is_rejected(tmp_path: Path) -> None:
+    """A second registry/page set comparison must trip the boundary."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "scripts" / "duplicate_parity.py"
+    duplicate.write_text(
+        "def duplicate(group, dist):\n"
+        "    commands = {name for name, command in group.commands.items() "
+        "if not command.hidden}\n"
+        "    cli_dir = dist / 'reference' / 'cli'\n"
+        "    pages = {child.name for child in cli_dir.iterdir() "
+        "if (child / 'index.html').is_file()}\n"
+        "    return sorted(commands - pages), sorted(pages - commands)\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_rendered_parity_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "duplicate rendered CLI parity computation" in violations[0]
+
+
+def test_rendered_parity_helper_delegation_is_allowed(tmp_path: Path) -> None:
+    """A consumer importing the canonical comparison is not a second owner."""
+    _write_owner_stubs(tmp_path)
+    consumer = tmp_path / "scripts" / "consumer.py"
+    consumer.write_text(
+        "from scripts.check_cli_docs import registry_docs_mismatches\n"
+        "def check(group, dist):\n"
+        "    return registry_docs_mismatches(group, dist)\n",
+        encoding="utf-8",
+    )
+
+    assert _load_checker().find_rendered_parity_violations(tmp_path) == []

--- a/tests/unit/scripts/test_check_test_contract_authorities.py
+++ b/tests/unit/scripts/test_check_test_contract_authorities.py
@@ -96,20 +96,32 @@ def test_venv_fallback_without_which_is_rejected(tmp_path: Path) -> None:
     _write_owner_stubs(tmp_path)
     duplicate = tmp_path / "tests" / "integration" / "venv_duplicate.py"
     duplicate.write_text(
-        "import os\n"
         "from pathlib import Path\n"
         "def choose():\n"
-        "    configured = os.getenv('APM_BINARY_PATH')\n"
         "    candidate = Path('.venv') / 'bin' / 'apm'\n"
-        "    return configured or (str(candidate) if candidate.exists() else None)\n",
+        "    return str(candidate) if candidate.exists() else None\n",
         encoding="utf-8",
     )
 
     violations = _load_checker().find_binary_selection_violations(tmp_path)
 
-    assert len(violations) == 2
-    assert any("direct APM_BINARY_PATH read" in item for item in violations)
-    assert any("direct .venv apm fallback" in item for item in violations)
+    assert len(violations) == 1
+    assert "direct .venv apm fallback" in violations[0]
+
+
+def test_path_fallback_without_venv_is_rejected(tmp_path: Path) -> None:
+    """PATH selection is distinct from local virtualenv selection."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "tests" / "integration" / "path_duplicate.py"
+    duplicate.write_text(
+        "import shutil\ndef choose():\n    return shutil.which('apm')\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_binary_selection_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "direct shutil.which('apm') fallback" in violations[0]
 
 
 def test_renamed_binary_resolver_is_rejected(tmp_path: Path) -> None:

--- a/tests/unit/scripts/test_check_test_contract_authorities.py
+++ b/tests/unit/scripts/test_check_test_contract_authorities.py
@@ -516,6 +516,23 @@ def test_nested_binary_owner_definitions_are_rejected(tmp_path: Path) -> None:
     assert len(violations) >= 2
 
 
+def test_nested_integration_files_are_scanned_recursively(tmp_path: Path) -> None:
+    """Replacing rglob with top-level glob must miss this violation and fail."""
+    _write_owner_stubs(tmp_path)
+    nested = tmp_path / "tests" / "integration" / "nested" / "consumer.py"
+    nested.parent.mkdir()
+    nested.write_text(
+        "import os\ndef choose():\n    return os.getenv('APM_BINARY_PATH')\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_binary_selection_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "nested/consumer.py" in violations[0]
+    assert "direct APM_BINARY_PATH read" in violations[0]
+
+
 def test_renamed_binary_resolver_is_rejected(tmp_path: Path) -> None:
     """A renamed resolver still fails because it reads the owned variable."""
     _write_owner_stubs(tmp_path)

--- a/tests/unit/scripts/test_check_test_contract_authorities.py
+++ b/tests/unit/scripts/test_check_test_contract_authorities.py
@@ -130,6 +130,8 @@ def test_path_fallback_without_venv_is_rejected(tmp_path: Path) -> None:
         "import subprocess\ndef run():\n    return subprocess.run(['apm', '--version'])\n",
         "import subprocess\ndef run():\n"
         "    return subprocess.run(['uv', 'run', 'apm', '--version'])\n",
+        "import subprocess\nimport sys\ndef run():\n"
+        "    return subprocess.run([sys.executable, '-m', 'apm_cli', '--version'])\n",
         "import subprocess\nimport sys\nfrom pathlib import Path\n"
         "def run():\n"
         "    executable = Path(sys.executable).with_name('apm')\n"
@@ -146,7 +148,7 @@ def test_standalone_binary_selector_shapes_are_rejected(
     tmp_path: Path,
     source: str,
 ) -> None:
-    """Known bare, uv, sibling, and probe selectors must stay retired."""
+    """Known bare, uv, source-module, sibling, and probe selectors stay retired."""
     _write_owner_stubs(tmp_path)
     duplicate = tmp_path / "tests" / "integration" / "selector.py"
     duplicate.write_text(source, encoding="utf-8")

--- a/tests/unit/scripts/test_check_test_contract_authorities.py
+++ b/tests/unit/scripts/test_check_test_contract_authorities.py
@@ -77,6 +77,37 @@ def test_binary_fixture_delegation_is_allowed(tmp_path: Path) -> None:
     assert _load_checker().find_binary_selection_violations(tmp_path) == []
 
 
+def test_implicit_lifecycle_runner_selection_is_rejected(tmp_path: Path) -> None:
+    """Deleting the lifecycle-runner detector must fail independently."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "tests" / "integration" / "lifecycle_duplicate.py"
+    duplicate.write_text(
+        "from tests.utils.apm_lifecycle_runner import ApmLifecycleRunner\n"
+        "def run():\n"
+        "    return ApmLifecycleRunner(timeout_seconds=30)\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_binary_selection_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "implicit lifecycle runner APM selection" in violations[0]
+
+
+def test_lifecycle_runner_fixture_delegation_is_allowed(tmp_path: Path) -> None:
+    """An explicit fixture-backed runner command remains a consumer."""
+    _write_owner_stubs(tmp_path)
+    consumer = tmp_path / "tests" / "integration" / "lifecycle_consumer.py"
+    consumer.write_text(
+        "from tests.utils.apm_lifecycle_runner import ApmLifecycleRunner\n"
+        "def run(apm_binary_path):\n"
+        "    return ApmLifecycleRunner((str(apm_binary_path),))\n",
+        encoding="utf-8",
+    )
+
+    assert _load_checker().find_binary_selection_violations(tmp_path) == []
+
+
 def test_direct_os_getenv_binary_read_is_rejected(tmp_path: Path) -> None:
     """Deleting the os.getenv detector must fail independently."""
     _write_owner_stubs(tmp_path)

--- a/tests/unit/scripts/test_check_test_contract_authorities.py
+++ b/tests/unit/scripts/test_check_test_contract_authorities.py
@@ -76,6 +76,42 @@ def test_binary_fixture_delegation_is_allowed(tmp_path: Path) -> None:
     assert _load_checker().find_binary_selection_violations(tmp_path) == []
 
 
+def test_direct_os_getenv_binary_read_is_rejected(tmp_path: Path) -> None:
+    """Deleting the os.getenv detector must fail independently."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "tests" / "integration" / "getenv_duplicate.py"
+    duplicate.write_text(
+        "import os\ndef choose():\n    return os.getenv('APM_BINARY_PATH')\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_binary_selection_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "direct APM_BINARY_PATH read" in violations[0]
+
+
+def test_venv_fallback_without_which_is_rejected(tmp_path: Path) -> None:
+    """Deleting the .venv detector must fail independently of PATH lookup."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "tests" / "integration" / "venv_duplicate.py"
+    duplicate.write_text(
+        "import os\n"
+        "from pathlib import Path\n"
+        "def choose():\n"
+        "    configured = os.getenv('APM_BINARY_PATH')\n"
+        "    candidate = Path('.venv') / 'bin' / 'apm'\n"
+        "    return configured or (str(candidate) if candidate.exists() else None)\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_binary_selection_violations(tmp_path)
+
+    assert len(violations) == 2
+    assert any("direct APM_BINARY_PATH read" in item for item in violations)
+    assert any("direct .venv apm fallback" in item for item in violations)
+
+
 def test_renamed_binary_resolver_is_rejected(tmp_path: Path) -> None:
     """A renamed resolver still fails because it reads the owned variable."""
     _write_owner_stubs(tmp_path)

--- a/tests/unit/scripts/test_check_test_contract_authorities.py
+++ b/tests/unit/scripts/test_check_test_contract_authorities.py
@@ -304,6 +304,7 @@ def test_interpreter_parent_apm_selector_is_rejected(tmp_path: Path) -> None:
         "import subprocess\nsubprocess.run('apm --version', shell=True)\n",
         "import subprocess\ncommand = 'apm --version'\nsubprocess.run(command, shell=True)\n",
         "import subprocess\ncommand = ['apm', '--version']\nsubprocess.run(command)\n",
+        "import subprocess\ncommand = ['apm', '--version']\nsubprocess.Popen(command)\n",
         "import subprocess\nsubprocess.run(['uv', 'run', 'apm'])\n",
         "import subprocess, sys\nsubprocess.run([sys.executable, '-m', 'apm_cli'])\n",
         "import subprocess, sys\nsubprocess.run([sys.executable, '-m', 'uv', 'run', 'apm'])\n",

--- a/tests/unit/scripts/test_check_test_contract_authorities.py
+++ b/tests/unit/scripts/test_check_test_contract_authorities.py
@@ -1,4 +1,4 @@
-"""Mutation-style tests for test contract authority boundaries."""
+"""Adversarial tests for test contract authority boundaries."""
 
 from __future__ import annotations
 
@@ -6,6 +6,8 @@ import importlib.util
 import sys
 from pathlib import Path
 from types import ModuleType
+
+import pytest
 
 
 def _load_checker() -> ModuleType:
@@ -33,28 +35,27 @@ def _write_owner_stubs(root: Path) -> None:
     )
 
 
-def test_known_binary_fallback_chain_is_rejected(tmp_path: Path) -> None:
-    """The retired silent-adopt resolver shape must trip the boundary."""
+@pytest.mark.parametrize(
+    "source",
+    (
+        "import os\ndef renamed():\n    return os.environ.get('APM_BINARY_PATH') or 'apm'\n",
+        "import os\ndef choose():\n    return os.getenv('APM_BINARY_PATH')\n",
+        "import os\ndef choose():\n    return os.environ['APM_BINARY_PATH']\n",
+    ),
+)
+def test_any_direct_binary_environment_read_is_rejected(
+    tmp_path: Path,
+    source: str,
+) -> None:
+    """Names and fallback syntax cannot evade canonical binary selection."""
     _write_owner_stubs(tmp_path)
     duplicate = tmp_path / "tests" / "integration" / "duplicate.py"
-    duplicate.write_text(
-        "import os\n"
-        "import shutil\n"
-        "from pathlib import Path\n"
-        "def apm_command():\n"
-        "    for env_var in ('APM_TEST_BINARY', 'APM_BINARY_PATH'):\n"
-        "        override = os.environ.get(env_var)\n"
-        "        if override and Path(override).exists():\n"
-        "            return override\n"
-        "    candidate = Path('.venv') / 'bin' / 'apm'\n"
-        "    return str(candidate) if candidate.exists() else shutil.which('apm')\n",
-        encoding="utf-8",
-    )
+    duplicate.write_text(source, encoding="utf-8")
 
     violations = _load_checker().find_binary_selection_violations(tmp_path)
 
     assert len(violations) == 1
-    assert "duplicate integration binary selection" in violations[0]
+    assert "direct APM_BINARY_PATH read" in violations[0]
 
 
 def test_binary_fixture_delegation_is_allowed(tmp_path: Path) -> None:
@@ -69,50 +70,140 @@ def test_binary_fixture_delegation_is_allowed(tmp_path: Path) -> None:
     assert _load_checker().find_binary_selection_violations(tmp_path) == []
 
 
-def test_binary_environment_subscript_fallback_is_rejected(tmp_path: Path) -> None:
-    """Subscript syntax must not evade the binary-selection boundary."""
+def test_renamed_binary_resolver_is_rejected(tmp_path: Path) -> None:
+    """A renamed resolver still fails because it reads the owned variable."""
     _write_owner_stubs(tmp_path)
-    duplicate = tmp_path / "tests" / "integration" / "subscript_duplicate.py"
+    duplicate = tmp_path / "tests" / "integration" / "renamed.py"
     duplicate.write_text(
-        "import os\n"
-        "import shutil\n"
-        "def apm_command():\n"
-        "    configured = os.environ['APM_BINARY_PATH']\n"
-        "    return configured or shutil.which('apm')\n",
+        "import os\ndef resolve_tool():\n    return os.environ.get('APM_BINARY_PATH')\n",
         encoding="utf-8",
     )
 
     violations = _load_checker().find_binary_selection_violations(tmp_path)
 
     assert len(violations) == 1
-    assert "duplicate integration binary selection" in violations[0]
+    assert "direct APM_BINARY_PATH read" in violations[0]
 
 
-def test_known_rendered_parity_reimplementation_is_rejected(tmp_path: Path) -> None:
-    """A second registry/page set comparison must trip the boundary."""
+def test_comment_only_parity_owner_definitions_are_rejected(tmp_path: Path) -> None:
+    """Owner presence must come from AST definitions, not comments."""
     _write_owner_stubs(tmp_path)
-    duplicate = tmp_path / "scripts" / "duplicate_parity.py"
-    duplicate.write_text(
-        "def duplicate(group, dist):\n"
-        "    commands = {name for name, command in group.commands.items() "
-        "if not command.hidden}\n"
-        "    cli_dir = dist / 'reference' / 'cli'\n"
-        "    pages = {child.name for child in cli_dir.iterdir() "
-        "if (child / 'index.html').is_file()}\n"
-        "    return sorted(commands - pages), sorted(pages - commands)\n",
+    owner = tmp_path / "scripts" / "check_cli_docs.py"
+    owner.write_text(
+        "# def public_top_level_commands():\n"
+        "# def rendered_cli_reference_pages():\n"
+        "# def registry_docs_mismatches():\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_rendered_parity_violations(tmp_path)
+
+    assert len(violations) == 3
+    assert all("must define rendered parity owner function" in item for item in violations)
+
+
+def test_internal_projection_import_is_rejected(tmp_path: Path) -> None:
+    """External consumers may import only the parity facade."""
+    _write_owner_stubs(tmp_path)
+    consumer = tmp_path / "tests" / "consumer.py"
+    consumer.parent.mkdir(exist_ok=True)
+    consumer.write_text(
+        "from scripts.check_cli_docs import public_top_level_commands\n",
         encoding="utf-8",
     )
 
     violations = _load_checker().find_rendered_parity_violations(tmp_path)
 
     assert len(violations) == 1
-    assert "duplicate rendered CLI parity computation" in violations[0]
+    assert "internal rendered parity projection imported" in violations[0]
 
 
-def test_rendered_parity_helper_delegation_is_allowed(tmp_path: Path) -> None:
-    """A consumer importing the canonical comparison is not a second owner."""
+def test_direct_registry_projection_is_rejected_without_comparison(tmp_path: Path) -> None:
+    """Registry projection alone is owned, independent of set-difference syntax."""
     _write_owner_stubs(tmp_path)
-    consumer = tmp_path / "scripts" / "consumer.py"
+    duplicate = tmp_path / "scripts" / "registry_projection.py"
+    duplicate.write_text(
+        "def renamed(group):\n"
+        "    return {name for name, command in group.commands.items() "
+        "if not command.hidden}\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_rendered_parity_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "direct Click command registry projection" in violations[0]
+
+
+def test_direct_rendered_inventory_is_rejected_with_imported_registry(
+    tmp_path: Path,
+) -> None:
+    """Importing one side cannot permit recomputing the other side."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "scripts" / "page_projection.py"
+    duplicate.write_text(
+        "from scripts.check_cli_docs import public_top_level_commands\n"
+        "def renamed(dist):\n"
+        "    cli_dir = dist / 'reference' / 'cli'\n"
+        "    return {child.name for child in cli_dir.iterdir() "
+        "if (child / 'index.html').is_file()}\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_rendered_parity_violations(tmp_path)
+
+    assert len(violations) >= 2
+    assert any("internal rendered parity projection imported" in item for item in violations)
+    assert any("direct rendered CLI route inventory" in item for item in violations)
+
+
+def test_direct_registry_projection_is_rejected_with_imported_pages(
+    tmp_path: Path,
+) -> None:
+    """Importing page projection cannot permit recomputing the registry side."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "scripts" / "registry_projection.py"
+    duplicate.write_text(
+        "from scripts.check_cli_docs import rendered_cli_reference_pages\n"
+        "def renamed(group):\n"
+        "    return {name for name, command in group.commands.items() "
+        "if not command.hidden}\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_rendered_parity_violations(tmp_path)
+
+    assert len(violations) == 2
+    assert any("internal rendered parity projection imported" in item for item in violations)
+    assert any("direct Click command registry projection" in item for item in violations)
+
+
+def test_set_difference_parity_reimplementation_is_rejected(tmp_path: Path) -> None:
+    """Method-form set differences cannot evade projection ownership."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "scripts" / "difference_parity.py"
+    duplicate.write_text(
+        "def compare(group, dist):\n"
+        "    commands = {name for name, command in group.commands.items() "
+        "if not command.hidden}\n"
+        "    cli_dir = dist / 'reference' / 'cli'\n"
+        "    pages = {child.name for child in cli_dir.iterdir() "
+        "if (child / 'index.html').is_file()}\n"
+        "    return commands.difference(pages), pages.difference(commands)\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_rendered_parity_violations(tmp_path)
+
+    assert any("direct Click command registry projection" in item for item in violations)
+    assert any("direct rendered CLI route inventory" in item for item in violations)
+
+
+def test_rendered_parity_facade_delegation_is_allowed(tmp_path: Path) -> None:
+    """Consumers may import and call the canonical comparison facade."""
+    _write_owner_stubs(tmp_path)
+    consumer = tmp_path / "tests" / "consumer.py"
+    consumer.parent.mkdir(exist_ok=True)
     consumer.write_text(
         "from scripts.check_cli_docs import registry_docs_mismatches\n"
         "def check(group, dist):\n"

--- a/tests/unit/scripts/test_check_test_contract_authorities.py
+++ b/tests/unit/scripts/test_check_test_contract_authorities.py
@@ -403,6 +403,40 @@ def test_command_assignment_does_not_leak_between_scopes(tmp_path: Path) -> None
     assert _load_checker().find_binary_selection_violations(tmp_path) == []
 
 
+@pytest.mark.parametrize(
+    "source",
+    (
+        "import subprocess\n"
+        "command = ['apm', '--version']\n"
+        "def run_it():\n"
+        "    return subprocess.run(command)\n",
+        "import subprocess\n"
+        "def outer():\n"
+        "    command = ['apm', '--version']\n"
+        "    def inner():\n"
+        "        return subprocess.run(command)\n"
+        "    return inner()\n",
+        "import subprocess\n"
+        "command = 'apm --version'\n"
+        "def run_it():\n"
+        "    return subprocess.run(command, shell=True)\n",
+    ),
+)
+def test_command_assignment_inherits_into_nested_scopes(
+    tmp_path: Path,
+    source: str,
+) -> None:
+    """Module and closure command values remain visible to child scopes."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "tests" / "integration" / "inherited_command.py"
+    duplicate.write_text(source, encoding="utf-8")
+
+    violations = _load_checker().find_binary_selection_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "direct apm subprocess selection" in violations[0]
+
+
 def test_probe_list_selector_is_rejected(tmp_path: Path) -> None:
     """Probe-loop selection must use the canonical fixture."""
     _write_owner_stubs(tmp_path)

--- a/tests/unit/scripts/test_check_test_contract_authorities.py
+++ b/tests/unit/scripts/test_check_test_contract_authorities.py
@@ -219,6 +219,8 @@ def test_interpreter_relative_apm_selector_is_rejected(tmp_path: Path) -> None:
     "source",
     (
         "import subprocess\nsubprocess.run(['apm', '--version'])\n",
+        "import subprocess\nsubprocess.Popen(['apm', '--version'])\n",
+        "import subprocess\nsubprocess.run(['uv', 'run', 'apm'])\n",
         "import subprocess, sys\nsubprocess.run([sys.executable, '-m', 'apm_cli'])\n",
         "import subprocess, sys\nsubprocess.run([sys.executable, '-m', 'uv', 'run', 'apm'])\n",
     ),
@@ -231,6 +233,27 @@ def test_direct_subprocess_selection_is_rejected(
     _write_owner_stubs(tmp_path)
     duplicate = tmp_path / "tests" / "integration" / "launcher_duplicate.py"
     duplicate.write_text(source, encoding="utf-8")
+
+    violations = _load_checker().find_binary_selection_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "direct apm subprocess selection" in violations[0]
+
+
+def test_probe_list_selector_is_rejected(tmp_path: Path) -> None:
+    """Probe-loop selection must use the canonical fixture."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "tests" / "integration" / "probe_duplicate.py"
+    duplicate.write_text(
+        "import subprocess\n"
+        "def probe():\n"
+        "    possible = ['apm', './apm', './dist/apm']\n"
+        "    for path in possible:\n"
+        "        result = subprocess.run([path, '--version'])\n"
+        "        if result.returncode == 0:\n"
+        "            return path\n",
+        encoding="utf-8",
+    )
 
     violations = _load_checker().find_binary_selection_violations(tmp_path)
 

--- a/tests/unit/scripts/test_check_test_contract_authorities.py
+++ b/tests/unit/scripts/test_check_test_contract_authorities.py
@@ -69,7 +69,7 @@ def test_binary_fixture_delegation_is_allowed(tmp_path: Path) -> None:
     _write_owner_stubs(tmp_path)
     consumer = tmp_path / "tests" / "integration" / "consumer.py"
     consumer.write_text(
-        "def apm_command(apm_binary_path):\n    return str(apm_binary_path)\n",
+        "def run_command(apm_binary_path):\n    return str(apm_binary_path)\n",
         encoding="utf-8",
     )
 
@@ -91,8 +91,38 @@ def test_direct_os_getenv_binary_read_is_rejected(tmp_path: Path) -> None:
     assert "direct APM_BINARY_PATH read" in violations[0]
 
 
-def test_venv_fallback_without_which_is_rejected(tmp_path: Path) -> None:
-    """Deleting the .venv detector must fail independently of PATH lookup."""
+def test_path_lookup_without_env_or_venv_is_rejected(tmp_path: Path) -> None:
+    """Deleting the PATH detector must fail independently."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "tests" / "integration" / "path_duplicate.py"
+    duplicate.write_text(
+        "import shutil\ndef choose():\n    return shutil.which('apm')\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_binary_selection_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "direct PATH lookup for apm" in violations[0]
+
+
+def test_aliased_path_lookup_is_rejected(tmp_path: Path) -> None:
+    """Import aliases cannot evade the PATH selector boundary."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "tests" / "integration" / "path_alias_duplicate.py"
+    duplicate.write_text(
+        "from shutil import which as locate\ndef choose():\n    return locate('apm')\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_binary_selection_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "direct PATH lookup for apm" in violations[0]
+
+
+def test_venv_fallback_without_env_or_which_is_rejected(tmp_path: Path) -> None:
+    """Deleting the .venv detector must fail independently."""
     _write_owner_stubs(tmp_path)
     duplicate = tmp_path / "tests" / "integration" / "venv_duplicate.py"
     duplicate.write_text(
@@ -109,54 +139,121 @@ def test_venv_fallback_without_which_is_rejected(tmp_path: Path) -> None:
     assert "direct .venv apm fallback" in violations[0]
 
 
-def test_path_fallback_without_venv_is_rejected(tmp_path: Path) -> None:
-    """PATH selection is distinct from local virtualenv selection."""
+@pytest.mark.parametrize(
+    "selector",
+    (
+        "Path('.venv', 'bin', 'apm')",
+        "Path('.venv').joinpath('Scripts', 'apm.exe')",
+        "os.path.join('.venv', 'bin', 'apm')",
+    ),
+)
+def test_standalone_venv_constructor_forms_are_rejected(
+    tmp_path: Path,
+    selector: str,
+) -> None:
+    """Every path-construction form is rejected without another selector."""
     _write_owner_stubs(tmp_path)
-    duplicate = tmp_path / "tests" / "integration" / "path_duplicate.py"
+    duplicate = tmp_path / "tests" / "integration" / "venv_constructor.py"
     duplicate.write_text(
-        "import shutil\ndef choose():\n    return shutil.which('apm')\n",
+        f"import os\nfrom pathlib import Path\ndef choose():\n    return {selector}\n",
         encoding="utf-8",
     )
 
     violations = _load_checker().find_binary_selection_violations(tmp_path)
 
     assert len(violations) == 1
-    assert "direct shutil.which('apm') fallback" in violations[0]
+    assert "direct .venv apm fallback" in violations[0]
+
+
+def test_venv_fallback_used_by_subprocess_is_reported_once(tmp_path: Path) -> None:
+    """The selector owns one diagnostic; subprocess options must not duplicate it."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "tests" / "integration" / "venv_subprocess.py"
+    duplicate.write_text(
+        "import subprocess\nfrom pathlib import Path\n"
+        "apm_path = Path('.venv') / 'bin' / 'apm'\n"
+        "subprocess.run([str(apm_path), '--encoding', 'utf-8'])\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_binary_selection_violations(tmp_path)
+
+    assert len(violations) == 2
+    assert sum("direct .venv apm fallback" in item for item in violations) == 1
+    assert sum("direct apm subprocess selection" in item for item in violations) == 1
+
+
+def test_unrelated_tool_lookup_is_allowed(tmp_path: Path) -> None:
+    """The binary boundary must preserve discovery for non-APM tools."""
+    _write_owner_stubs(tmp_path)
+    consumer = tmp_path / "tests" / "integration" / "tools.py"
+    consumer.write_text(
+        "import shutil\n"
+        "def tools():\n"
+        "    return shutil.which('az'), shutil.which('uv'), shutil.which('git')\n",
+        encoding="utf-8",
+    )
+
+    assert _load_checker().find_binary_selection_violations(tmp_path) == []
+
+
+def test_interpreter_relative_apm_selector_is_rejected(tmp_path: Path) -> None:
+    """Deleting the interpreter-sibling detector must fail independently."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "tests" / "integration" / "sibling_duplicate.py"
+    duplicate.write_text(
+        "import sys\n"
+        "from pathlib import Path\n"
+        "def choose():\n"
+        "    return Path(sys.executable).with_name('apm')\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_binary_selection_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "interpreter-relative apm selection" in violations[0]
 
 
 @pytest.mark.parametrize(
     "source",
     (
-        "import subprocess\ndef run():\n    return subprocess.run(['apm', '--version'])\n",
-        "import subprocess\ndef run():\n    return subprocess.Popen(['apm', '--version'])\n",
-        "import subprocess\ndef run():\n"
-        "    return subprocess.run(['uv', 'run', 'apm', '--version'])\n",
-        "import subprocess\nimport sys\ndef run():\n"
-        "    return subprocess.run([sys.executable, '-m', 'apm_cli', '--version'])\n",
-        "import subprocess\nimport sys\nfrom pathlib import Path\n"
-        "def run():\n"
-        "    executable = Path(sys.executable).with_name('apm')\n"
-        "    return subprocess.run([str(executable), '--version'])\n",
-        "import subprocess\ndef probe():\n"
-        "    possible = ['apm', './apm', './dist/apm']\n"
-        "    for path in possible:\n"
-        "        result = subprocess.run([path, '--version'])\n"
-        "        if result.returncode == 0:\n"
-        "            return path\n",
+        "import subprocess\nsubprocess.run(['apm', '--version'])\n",
+        "import subprocess, sys\nsubprocess.run([sys.executable, '-m', 'apm_cli'])\n",
+        "import subprocess, sys\nsubprocess.run([sys.executable, '-m', 'uv', 'run', 'apm'])\n",
     ),
 )
-def test_standalone_binary_selector_shapes_are_rejected(
+def test_direct_subprocess_selection_is_rejected(
     tmp_path: Path,
     source: str,
 ) -> None:
-    """Known bare, uv, source-module, sibling, and probe selectors stay retired."""
+    """Each direct launcher syntax independently requires the fixture."""
     _write_owner_stubs(tmp_path)
-    duplicate = tmp_path / "tests" / "integration" / "selector.py"
+    duplicate = tmp_path / "tests" / "integration" / "launcher_duplicate.py"
     duplicate.write_text(source, encoding="utf-8")
 
     violations = _load_checker().find_binary_selection_violations(tmp_path)
 
-    assert any("standalone APM subprocess selector" in item for item in violations)
+    assert len(violations) == 1
+    assert "direct apm subprocess selection" in violations[0]
+
+
+def test_fixture_forwarding_facade_is_rejected(tmp_path: Path) -> None:
+    """Consumers must inject the canonical fixture without another fixture."""
+    _write_owner_stubs(tmp_path)
+    duplicate = tmp_path / "tests" / "integration" / "facade.py"
+    duplicate.write_text(
+        "import pytest\n"
+        "@pytest.fixture\n"
+        "def binary(apm_binary_path):\n"
+        "    return str(apm_binary_path)\n",
+        encoding="utf-8",
+    )
+
+    violations = _load_checker().find_binary_selection_violations(tmp_path)
+
+    assert len(violations) == 1
+    assert "local apm binary fixture or facade" in violations[0]
 
 
 def test_renamed_binary_resolver_is_rejected(tmp_path: Path) -> None:

--- a/tests/unit/test_cli_consistency.py
+++ b/tests/unit/test_cli_consistency.py
@@ -11,10 +11,7 @@ from apm_cli.output.script_formatters import ScriptExecutionFormatter
 
 def _walk_commands(group: click.Group, prefix: tuple[str, ...] = ()):
     """Yield (path_tuple, command) for every command reachable under group."""
-    context = click.Context(group)
-    for name in group.list_commands(context):
-        cmd = group.get_command(context, name)
-        assert cmd is not None
+    for name, cmd in group.commands.items():
         path = (*prefix, name)
         yield path, cmd
         if isinstance(cmd, click.Group):

--- a/tests/unit/test_cli_consistency.py
+++ b/tests/unit/test_cli_consistency.py
@@ -11,7 +11,10 @@ from apm_cli.output.script_formatters import ScriptExecutionFormatter
 
 def _walk_commands(group: click.Group, prefix: tuple[str, ...] = ()):
     """Yield (path_tuple, command) for every command reachable under group."""
-    for name, cmd in group.commands.items():
+    context = click.Context(group)
+    for name in group.list_commands(context):
+        cmd = group.get_command(context, name)
+        assert cmd is not None
         path = (*prefix, name)
         yield path, cmd
         if isinstance(cmd, click.Group):

--- a/tests/unit/test_cli_docs_contract.py
+++ b/tests/unit/test_cli_docs_contract.py
@@ -1,31 +1,80 @@
-"""Contracts keeping public top-level CLI commands discoverable in the docs."""
+"""Contracts keeping the public CLI registry aligned with rendered docs."""
 
 from pathlib import Path
 
 from apm_cli.cli import cli
+from scripts.check_cli_docs import (
+    public_top_level_commands,
+    registry_docs_mismatches,
+)
 
 REPO_ROOT = Path(__file__).parents[2]
 CLI_REFERENCE_DIR = REPO_ROOT / "docs" / "src" / "content" / "docs" / "reference" / "cli"
 REFERENCE_INDEX = CLI_REFERENCE_DIR.parent / "index.md"
 
 
-def _public_command_names() -> set[str]:
-    """Return the public top-level command names registered with Click."""
-    return {name for name, command in cli.commands.items() if not command.hidden}
+def _render_page(dist: Path, name: str) -> None:
+    page = dist / "reference" / "cli" / name / "index.html"
+    page.parent.mkdir(parents=True, exist_ok=True)
+    page.write_text("<p>rendered</p>\n", encoding="utf-8")
 
 
-def test_public_commands_have_reference_pages() -> None:
-    """Require one CLI reference page for every public top-level command."""
-    documented_commands = {path.stem for path in CLI_REFERENCE_DIR.glob("*.md")}
-
-    assert _public_command_names() <= documented_commands
+def _render_public_pages(dist: Path, *, omit: set[str] | None = None) -> None:
+    omitted = omit or set()
+    for name in public_top_level_commands(cli) - omitted:
+        _render_page(dist, name)
 
 
 def test_public_commands_are_linked_from_reference_index() -> None:
-    """Require the reference landing page to link every public command."""
+    """Keep source-level landing-page discoverability separate from rendering."""
     index = REFERENCE_INDEX.read_text(encoding="utf-8")
-    linked_commands = {
-        name for name in _public_command_names() if f"[`{name}`](./cli/{name}/)" in index
-    }
+    public = public_top_level_commands(cli)
+    linked = {name for name in public if f"[`{name}`](./cli/{name}/)" in index}
 
-    assert linked_commands == _public_command_names()
+    assert linked == public
+
+
+def test_hidden_alias_does_not_require_rendered_page(tmp_path: Path) -> None:
+    """The hidden info alias must not create a second documentation contract."""
+    _render_public_pages(tmp_path)
+
+    missing_pages, orphan_pages = registry_docs_mismatches(cli, tmp_path)
+
+    assert "info" not in public_top_level_commands(cli)
+    assert missing_pages == []
+    assert orphan_pages == []
+
+
+def test_nested_subcommands_share_the_top_level_group_page(tmp_path: Path) -> None:
+    """Nested rendered directories do not imply recursive command-page parity."""
+    _render_public_pages(tmp_path)
+    nested = tmp_path / "reference" / "cli" / "deps" / "tree" / "index.html"
+    nested.parent.mkdir(parents=True)
+    nested.write_text("<p>nested</p>\n", encoding="utf-8")
+
+    missing_pages, orphan_pages = registry_docs_mismatches(cli, tmp_path)
+
+    assert missing_pages == []
+    assert orphan_pages == []
+
+
+def test_registered_command_without_rendered_page_fails(tmp_path: Path) -> None:
+    """Removing one rendered page must identify its executable command."""
+    assert "doctor" in public_top_level_commands(cli)
+    _render_public_pages(tmp_path, omit={"doctor"})
+
+    missing_pages, orphan_pages = registry_docs_mismatches(cli, tmp_path)
+
+    assert missing_pages == ["doctor"]
+    assert orphan_pages == []
+
+
+def test_rendered_page_without_registered_command_fails(tmp_path: Path) -> None:
+    """Adding one rendered page must identify its missing executable."""
+    _render_public_pages(tmp_path)
+    _render_page(tmp_path, "not-a-command")
+
+    missing_pages, orphan_pages = registry_docs_mismatches(cli, tmp_path)
+
+    assert missing_pages == []
+    assert orphan_pages == ["not-a-command"]

--- a/tests/unit/test_cli_docs_contract.py
+++ b/tests/unit/test_cli_docs_contract.py
@@ -3,10 +3,7 @@
 from pathlib import Path
 
 from apm_cli.cli import cli
-from scripts.check_cli_docs import (
-    public_top_level_commands,
-    registry_docs_mismatches,
-)
+from scripts.check_cli_docs import registry_docs_mismatches
 
 REPO_ROOT = Path(__file__).parents[2]
 CLI_REFERENCE_DIR = REPO_ROOT / "docs" / "src" / "content" / "docs" / "reference" / "cli"
@@ -19,16 +16,26 @@ def _render_page(dist: Path, name: str) -> None:
     page.write_text("<p>rendered</p>\n", encoding="utf-8")
 
 
-def _render_public_pages(dist: Path, *, omit: set[str] | None = None) -> None:
+def _public_command_names(dist: Path) -> set[str]:
+    cli_dir = dist / "reference" / "cli"
+    cli_dir.mkdir(parents=True, exist_ok=True)
+    missing, orphan = registry_docs_mismatches(cli, dist)
+    assert orphan == []
+    return set(missing)
+
+
+def _render_public_pages(dist: Path, *, omit: set[str] | None = None) -> set[str]:
     omitted = omit or set()
-    for name in public_top_level_commands(cli) - omitted:
+    public = _public_command_names(dist)
+    for name in public - omitted:
         _render_page(dist, name)
+    return public
 
 
-def test_public_commands_are_linked_from_reference_index() -> None:
+def test_public_commands_are_linked_from_reference_index(tmp_path: Path) -> None:
     """Keep source-level landing-page discoverability separate from rendering."""
     index = REFERENCE_INDEX.read_text(encoding="utf-8")
-    public = public_top_level_commands(cli)
+    public = _public_command_names(tmp_path)
     linked = {name for name in public if f"[`{name}`](./cli/{name}/)" in index}
 
     assert linked == public
@@ -36,11 +43,11 @@ def test_public_commands_are_linked_from_reference_index() -> None:
 
 def test_hidden_alias_does_not_require_rendered_page(tmp_path: Path) -> None:
     """The hidden info alias must not create a second documentation contract."""
-    _render_public_pages(tmp_path)
+    public = _render_public_pages(tmp_path)
 
     missing_pages, orphan_pages = registry_docs_mismatches(cli, tmp_path)
 
-    assert "info" not in public_top_level_commands(cli)
+    assert "info" not in public
     assert missing_pages == []
     assert orphan_pages == []
 
@@ -60,11 +67,11 @@ def test_nested_subcommands_share_the_top_level_group_page(tmp_path: Path) -> No
 
 def test_registered_command_without_rendered_page_fails(tmp_path: Path) -> None:
     """Removing one rendered page must identify its executable command."""
-    assert "doctor" in public_top_level_commands(cli)
-    _render_public_pages(tmp_path, omit={"doctor"})
+    public = _render_public_pages(tmp_path, omit={"doctor"})
 
     missing_pages, orphan_pages = registry_docs_mismatches(cli, tmp_path)
 
+    assert "doctor" in public
     assert missing_pages == ["doctor"]
     assert orphan_pages == []
 

--- a/tests/unit/test_cli_docs_contract.py
+++ b/tests/unit/test_cli_docs_contract.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 from apm_cli.cli import cli
-from scripts.check_cli_docs import registry_docs_mismatches
+from scripts.check_cli_docs import DEFAULT_DIST, recovery_guidance, registry_docs_mismatches
 
 REPO_ROOT = Path(__file__).parents[2]
 CLI_REFERENCE_DIR = REPO_ROOT / "docs" / "src" / "content" / "docs" / "reference" / "cli"
@@ -85,3 +85,12 @@ def test_rendered_page_without_registered_command_fails(tmp_path: Path) -> None:
 
     assert missing_pages == []
     assert orphan_pages == ["not-a-command"]
+
+
+def test_default_dist_recovery_guidance_uses_root_safe_build_command() -> None:
+    """The repository output keeps an executable build-and-rerun sequence."""
+    assert recovery_guidance(DEFAULT_DIST, mismatch=True) == (
+        "[i] Add or remove the matching CLI reference page, "
+        "rebuild with 'npm --prefix docs run build', then rerun "
+        f"'uv run --frozen python scripts/check_cli_docs.py {DEFAULT_DIST}'."
+    )

--- a/tests/unit/test_docs_contract_workflow.py
+++ b/tests/unit/test_docs_contract_workflow.py
@@ -22,6 +22,7 @@ def test_docs_contract_runs_for_every_cli_registration_owner() -> None:
     assert "'src/apm_cli/commands/**'" in pull_request
     assert "'scripts/check_cli_docs.py'" in pull_request
     assert "'tests/unit/test_cli_docs_contract.py'" in pull_request
+    assert "'tests/integration/test_cli_docs_contract.py'" in pull_request
 
 
 def test_docs_build_has_read_only_permissions() -> None:
@@ -46,5 +47,7 @@ def test_docs_python_operations_are_frozen() -> None:
     build_job = workflow[workflow.index("  build:") : workflow.index("  deploy:")]
 
     assert "uv sync --frozen --extra dev" in build_job
-    assert "uv run --frozen pytest tests/unit/test_cli_docs_contract.py -q" in build_job
+    assert "tests/unit/test_cli_docs_contract.py" in build_job
+    assert "tests/integration/test_cli_docs_contract.py" in build_job
+    assert "uv run --frozen pytest" in build_job
     assert "uv run --frozen python scripts/check_cli_docs.py docs/dist" in build_job

--- a/tests/unit/test_docs_contract_workflow.py
+++ b/tests/unit/test_docs_contract_workflow.py
@@ -1,53 +1,103 @@
-"""Static ownership and least-privilege contracts for the docs workflow."""
+"""Semantic ownership and least-privilege contracts for the docs workflow."""
 
+from __future__ import annotations
+
+from copy import deepcopy
 from pathlib import Path
+
+import pytest
+
+from tests.workflow_contracts import (
+    assert_unconditional,
+    load_workflow,
+    shell_tokens,
+    workflow_job,
+    workflow_step,
+)
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github" / "workflows" / "docs.yml"
+UNIT_CONTRACT = "tests/unit/test_cli_docs_contract.py"
+SUBPROCESS_CONTRACT = "tests/integration/test_cli_docs_contract.py"
 
 
-def _workflow() -> str:
-    return WORKFLOW.read_text(encoding="utf-8")
+def _workflow() -> dict:
+    return load_workflow(WORKFLOW)
+
+
+def _assert_checker_test_step(workflow: dict) -> None:
+    build = workflow_job(workflow, "build")
+    step = workflow_step(build, "Test CLI registry contract")
+    assert_unconditional(build, label="docs build job")
+    assert_unconditional(step, label="CLI registry contract step")
+    tokens = shell_tokens(step)
+    assert tokens[:4] == ["uv", "run", "--frozen", "pytest"]
+    assert UNIT_CONTRACT in tokens
+    assert SUBPROCESS_CONTRACT in tokens
 
 
 def test_docs_contract_runs_for_every_cli_registration_owner() -> None:
     """Command names and visibility cannot change without scheduling parity."""
     workflow = _workflow()
-    pull_request = workflow[
-        workflow.index("  pull_request:") : workflow.index("  workflow_dispatch:")
-    ]
+    triggers = workflow["on"]["pull_request"]["paths"]
 
-    assert "'docs/**'" in pull_request
-    assert "'src/apm_cli/cli.py'" in pull_request
-    assert "'src/apm_cli/commands/**'" in pull_request
-    assert "'scripts/check_cli_docs.py'" in pull_request
-    assert "'tests/unit/test_cli_docs_contract.py'" in pull_request
-    assert "'tests/integration/test_cli_docs_contract.py'" in pull_request
+    assert set(triggers) >= {
+        "docs/**",
+        "src/apm_cli/cli.py",
+        "src/apm_cli/commands/**",
+        "scripts/check_cli_docs.py",
+        UNIT_CONTRACT,
+        SUBPROCESS_CONTRACT,
+    }
 
 
 def test_docs_build_has_read_only_permissions() -> None:
     """Pages write and OIDC minting belong only to the deploy job."""
     workflow = _workflow()
-    top_level = workflow[workflow.index("permissions:") : workflow.index("concurrency:")]
-    build_job = workflow[workflow.index("  build:") : workflow.index("  deploy:")]
-    deploy_job = workflow[workflow.index("  deploy:") :]
+    build = workflow_job(workflow, "build")
+    deploy = workflow_job(workflow, "deploy")
 
-    assert "contents: read" in top_level
-    assert "pages: write" not in top_level
-    assert "id-token: write" not in top_level
-    assert "pages: write" not in build_job
-    assert "id-token: write" not in build_job
-    assert "pages: write" in deploy_job
-    assert "id-token: write" in deploy_job
+    assert workflow["permissions"] == {"contents": "read"}
+    assert "permissions" not in build
+    assert deploy["permissions"] == {
+        "pages": "write",
+        "id-token": "write",
+    }
 
 
 def test_docs_python_operations_are_frozen() -> None:
     """The docs owner must consume the reviewed lock without mutation."""
     workflow = _workflow()
-    build_job = workflow[workflow.index("  build:") : workflow.index("  deploy:")]
+    build = workflow_job(workflow, "build")
+    install = workflow_step(build, "Install Python test dependencies")
+    checker = workflow_step(build, "Check CLI registry against rendered pages")
 
-    assert "uv sync --frozen --extra dev" in build_job
-    assert "tests/unit/test_cli_docs_contract.py" in build_job
-    assert "tests/integration/test_cli_docs_contract.py" in build_job
-    assert "uv run --frozen pytest" in build_job
-    assert "uv run --frozen python scripts/check_cli_docs.py docs/dist" in build_job
+    assert shell_tokens(install) == ["uv", "sync", "--frozen", "--extra", "dev"]
+    _assert_checker_test_step(workflow)
+    assert shell_tokens(checker) == [
+        "uv",
+        "run",
+        "--frozen",
+        "python",
+        "scripts/check_cli_docs.py",
+        "docs/dist",
+    ]
+
+
+@pytest.mark.parametrize("mutation", ("step-disabled", "unit-omitted", "subprocess-commented"))
+def test_docs_checker_step_mutations_are_rejected(mutation: str) -> None:
+    """Disabled, omitted, or commented contract execution must fail."""
+    workflow = deepcopy(_workflow())
+    step = workflow_step(workflow_job(workflow, "build"), "Test CLI registry contract")
+    if mutation == "step-disabled":
+        step["if"] = False
+    elif mutation == "unit-omitted":
+        step["run"] = step["run"].replace(UNIT_CONTRACT, "")
+    else:
+        step["run"] = step["run"].replace(
+            SUBPROCESS_CONTRACT,
+            f"# {SUBPROCESS_CONTRACT}",
+        )
+
+    with pytest.raises(AssertionError):
+        _assert_checker_test_step(workflow)

--- a/tests/unit/test_docs_contract_workflow.py
+++ b/tests/unit/test_docs_contract_workflow.py
@@ -1,0 +1,50 @@
+"""Static ownership and least-privilege contracts for the docs workflow."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "docs.yml"
+
+
+def _workflow() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_docs_contract_runs_for_every_cli_registration_owner() -> None:
+    """Command names and visibility cannot change without scheduling parity."""
+    workflow = _workflow()
+    pull_request = workflow[
+        workflow.index("  pull_request:") : workflow.index("  workflow_dispatch:")
+    ]
+
+    assert "'docs/**'" in pull_request
+    assert "'src/apm_cli/cli.py'" in pull_request
+    assert "'src/apm_cli/commands/**'" in pull_request
+    assert "'scripts/check_cli_docs.py'" in pull_request
+    assert "'tests/unit/test_cli_docs_contract.py'" in pull_request
+
+
+def test_docs_build_has_read_only_permissions() -> None:
+    """Pages write and OIDC minting belong only to the deploy job."""
+    workflow = _workflow()
+    top_level = workflow[workflow.index("permissions:") : workflow.index("concurrency:")]
+    build_job = workflow[workflow.index("  build:") : workflow.index("  deploy:")]
+    deploy_job = workflow[workflow.index("  deploy:") :]
+
+    assert "contents: read" in top_level
+    assert "pages: write" not in top_level
+    assert "id-token: write" not in top_level
+    assert "pages: write" not in build_job
+    assert "id-token: write" not in build_job
+    assert "pages: write" in deploy_job
+    assert "id-token: write" in deploy_job
+
+
+def test_docs_python_operations_are_frozen() -> None:
+    """The docs owner must consume the reviewed lock without mutation."""
+    workflow = _workflow()
+    build_job = workflow[workflow.index("  build:") : workflow.index("  deploy:")]
+
+    assert "uv sync --frozen --extra dev" in build_job
+    assert "uv run --frozen pytest tests/unit/test_cli_docs_contract.py -q" in build_job
+    assert "uv run --frozen python scripts/check_cli_docs.py docs/dist" in build_job

--- a/tests/unit/test_integration_binary_path_contract.py
+++ b/tests/unit/test_integration_binary_path_contract.py
@@ -49,6 +49,22 @@ def test_missing_explicit_binary_path_fails_without_fallback(
         integration_conftest._resolve_apm_binary()
 
 
+def test_empty_explicit_binary_path_fails_without_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A present empty configuration must not enable fallback discovery."""
+    fallback = tmp_path / "fallback-apm"
+    fallback.write_text("#!/bin/sh\n", encoding="utf-8")
+    fallback.chmod(0o755)
+    monkeypatch.setenv("APM_BINARY_PATH", "")
+    monkeypatch.setattr(integration_conftest, "_local_dist_apm_binary", lambda: fallback)
+    monkeypatch.setattr(integration_conftest.shutil, "which", lambda _name: str(fallback))
+
+    with pytest.raises(pytest.UsageError, match=r"APM_BINARY_PATH is set but empty"):
+        integration_conftest._resolve_apm_binary()
+
+
 def test_non_executable_explicit_binary_path_fails_without_fallback(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_integration_binary_path_contract.py
+++ b/tests/unit/test_integration_binary_path_contract.py
@@ -8,11 +8,8 @@ from pathlib import Path
 import pytest
 
 from tests.integration import conftest as integration_conftest
-from tests.integration import (
-    test_ado_e2e,
-    test_auto_install_e2e,
-    test_plugin_e2e,
-)
+from tests.integration import test_ado_e2e, test_plugin_skill_subset_pack_e2e
+from tests.integration.marketplace import conftest as marketplace_conftest
 
 
 @pytest.fixture(autouse=True)
@@ -174,67 +171,25 @@ def test_non_executable_explicit_binary_path_fails_without_fallback(
         integration_conftest._resolve_apm_binary()
 
 
-def test_ado_consumer_executes_injected_binary(
+def test_representative_subprocess_consumers_launch_injected_binary(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The ADO helper must launch the injected validated executable."""
-    configured = tmp_path / "configured-apm"
-    captured: list[list[str]] = []
+    """Real consumer helpers must put the injected executable in argv[0]."""
+    injected = tmp_path / "canonical-apm"
+    commands: list[list[str]] = []
 
-    def fake_run(args: list[str], **_kwargs) -> subprocess.CompletedProcess[str]:
-        captured.append(args)
-        return subprocess.CompletedProcess(args, 0, "", "")
+    def capture_run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, "", "")
 
-    monkeypatch.setattr(test_ado_e2e.subprocess, "run", fake_run)
+    monkeypatch.setattr(subprocess, "run", capture_run)
 
-    test_ado_e2e.run_apm_command(configured, "--version", tmp_path)
+    test_ado_e2e.run_apm_command(injected, "install owner/package", tmp_path)
+    test_plugin_skill_subset_pack_e2e._run_pack(injected, tmp_path)
+    marketplace_conftest.run_cli(injected, ["marketplace", "build"], cwd=tmp_path)
 
-    assert captured == [[str(configured), "--version"]]
-
-
-def test_plugin_consumer_executes_injected_binary(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The plugin fixture and helper must preserve the injected executable."""
-    configured = tmp_path / "configured-apm"
-    captured: list[list[str]] = []
-
-    def fake_run(args: list[str], **_kwargs) -> subprocess.CompletedProcess[str]:
-        captured.append(args)
-        return subprocess.CompletedProcess(args, 0, "", "")
-
-    monkeypatch.setattr(test_plugin_e2e.subprocess, "run", fake_run)
-    command = test_plugin_e2e.apm_command.__wrapped__(configured)
-
-    test_plugin_e2e._run_apm_command(command, ["--version"], tmp_path)
-
-    assert captured == [[str(configured), "--version"]]
-
-
-def test_auto_install_consumer_executes_injected_binary(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The streaming auto-install helper must launch the injected artifact."""
-    configured = tmp_path / "configured-apm"
-    captured: list[list[str]] = []
-
-    class FakeProcess:
-        pass
-
-    def fake_popen(args: list[str], **_kwargs) -> FakeProcess:
-        captured.append(args)
-        return FakeProcess()
-
-    monkeypatch.setattr(test_auto_install_e2e.subprocess, "Popen", fake_popen)
-
-    test_auto_install_e2e._start_apm(
-        configured,
-        ["--version"],
-        cwd=str(tmp_path),
-        env={},
-    )
-
-    assert captured == [[str(configured), "--version"]]
+    assert [command[0] for command in commands] == [str(injected)] * 3
+    assert commands[0][1:] == ["install", "owner/package"]
+    assert commands[1][1:3] == ["pack", "--format"]
+    assert commands[2][1:] == ["marketplace", "build"]

--- a/tests/unit/test_integration_binary_path_contract.py
+++ b/tests/unit/test_integration_binary_path_contract.py
@@ -68,15 +68,40 @@ def test_empty_explicit_binary_path_fails_without_fallback(
         integration_conftest._resolve_apm_binary()
 
 
-def test_silent_adopt_consumer_rejects_empty_explicit_binary(
+@pytest.mark.parametrize(
+    ("configured_kind", "expected_error"),
+    (
+        ("empty", "APM_BINARY_PATH is set but empty."),
+        ("missing", "APM_BINARY_PATH does not exist or is not a file:"),
+        pytest.param(
+            "non-executable",
+            "APM_BINARY_PATH is not executable:",
+            marks=pytest.mark.skipif(
+                os.name == "nt",
+                reason="Windows os.access(X_OK) does not model executable bits",
+            ),
+        ),
+    ),
+)
+def test_silent_adopt_consumer_rejects_invalid_explicit_binary(
     tmp_path: Path,
+    configured_kind: str,
+    expected_error: str,
 ) -> None:
-    """The silent-adopt E2E must fail through the canonical resolver."""
+    """The silent-adopt E2E must inherit every canonical failure mode."""
     fallback = tmp_path / "apm"
     fallback.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
     fallback.chmod(0o755)
     env = os.environ.copy()
-    env["APM_BINARY_PATH"] = ""
+    if configured_kind == "empty":
+        env["APM_BINARY_PATH"] = ""
+    elif configured_kind == "missing":
+        env["APM_BINARY_PATH"] = str(tmp_path / "missing-apm")
+    else:
+        configured = tmp_path / "configured-apm"
+        configured.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        configured.chmod(0o644)
+        env["APM_BINARY_PATH"] = str(configured)
     env["GITHUB_APM_PAT"] = "test-token"
     env["PATH"] = f"{tmp_path}{os.pathsep}{env.get('PATH', '')}"
 
@@ -98,7 +123,7 @@ def test_silent_adopt_consumer_rejects_empty_explicit_binary(
 
     combined = result.stdout + result.stderr
     assert result.returncode != 0
-    assert "ERROR: APM_BINARY_PATH is set but empty." in combined
+    assert f"ERROR: {expected_error}" in combined
     assert "INTERNALERROR" not in combined
 
 

--- a/tests/unit/test_integration_binary_path_contract.py
+++ b/tests/unit/test_integration_binary_path_contract.py
@@ -45,7 +45,7 @@ def test_missing_explicit_binary_path_fails_without_fallback(
     monkeypatch.setattr(integration_conftest, "_local_dist_apm_binary", lambda: fallback)
     monkeypatch.setattr(integration_conftest.shutil, "which", lambda _name: str(fallback))
 
-    with pytest.raises(RuntimeError, match=r"APM_BINARY_PATH does not exist"):
+    with pytest.raises(pytest.UsageError, match=r"APM_BINARY_PATH does not exist"):
         integration_conftest._resolve_apm_binary()
 
 
@@ -64,5 +64,5 @@ def test_non_executable_explicit_binary_path_fails_without_fallback(
     monkeypatch.setattr(integration_conftest.shutil, "which", lambda _name: str(fallback))
     monkeypatch.setattr(integration_conftest.os, "access", lambda _path, _mode: False)
 
-    with pytest.raises(RuntimeError, match=r"APM_BINARY_PATH is not executable"):
+    with pytest.raises(pytest.UsageError, match=r"APM_BINARY_PATH is not executable"):
         integration_conftest._resolve_apm_binary()

--- a/tests/unit/test_integration_binary_path_contract.py
+++ b/tests/unit/test_integration_binary_path_contract.py
@@ -8,7 +8,11 @@ from pathlib import Path
 import pytest
 
 from tests.integration import conftest as integration_conftest
-from tests.integration import test_ado_e2e, test_plugin_skill_subset_pack_e2e
+from tests.integration import (
+    test_ado_e2e,
+    test_auto_install_e2e,
+    test_plugin_skill_subset_pack_e2e,
+)
 from tests.integration.marketplace import conftest as marketplace_conftest
 
 
@@ -193,3 +197,30 @@ def test_representative_subprocess_consumers_launch_injected_binary(
     assert commands[0][1:] == ["install", "owner/package"]
     assert commands[1][1:3] == ["pack", "--format"]
     assert commands[2][1:] == ["marketplace", "build"]
+
+
+def test_auto_install_popen_launches_injected_binary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The streaming helper must put the injected artifact in argv[0]."""
+    injected = tmp_path / "canonical-apm"
+    commands: list[list[str]] = []
+
+    class FakeProcess:
+        pass
+
+    def capture_popen(command: list[str], **_kwargs: object) -> FakeProcess:
+        commands.append(command)
+        return FakeProcess()
+
+    monkeypatch.setattr(test_auto_install_e2e.subprocess, "Popen", capture_popen)
+
+    test_auto_install_e2e._start_apm(
+        injected,
+        ["--version"],
+        cwd=str(tmp_path),
+        env={},
+    )
+
+    assert commands == [[str(injected), "--version"]]

--- a/tests/unit/test_integration_binary_path_contract.py
+++ b/tests/unit/test_integration_binary_path_contract.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from tests.integration import conftest as integration_conftest
+from tests.integration import test_ado_e2e, test_plugin_e2e
 
 
 @pytest.fixture(autouse=True)
@@ -167,3 +168,42 @@ def test_non_executable_explicit_binary_path_fails_without_fallback(
 
     with pytest.raises(pytest.UsageError, match=r"APM_BINARY_PATH is not executable"):
         integration_conftest._resolve_apm_binary()
+
+
+def test_ado_consumer_executes_injected_binary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The ADO helper must launch the injected validated executable."""
+    configured = tmp_path / "configured-apm"
+    captured: list[list[str]] = []
+
+    def fake_run(args: list[str], **_kwargs) -> subprocess.CompletedProcess[str]:
+        captured.append(args)
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(test_ado_e2e.subprocess, "run", fake_run)
+
+    test_ado_e2e.run_apm_command(configured, "--version", tmp_path)
+
+    assert captured == [[str(configured), "--version"]]
+
+
+def test_plugin_consumer_executes_injected_binary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The plugin fixture and helper must preserve the injected executable."""
+    configured = tmp_path / "configured-apm"
+    captured: list[list[str]] = []
+
+    def fake_run(args: list[str], **_kwargs) -> subprocess.CompletedProcess[str]:
+        captured.append(args)
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(test_plugin_e2e.subprocess, "run", fake_run)
+    command = test_plugin_e2e.apm_command.__wrapped__(configured)
+
+    test_plugin_e2e._run_apm_command(command, ["--version"], tmp_path)
+
+    assert captured == [[str(configured), "--version"]]

--- a/tests/unit/test_integration_binary_path_contract.py
+++ b/tests/unit/test_integration_binary_path_contract.py
@@ -1,5 +1,8 @@
 """Contracts for authoritative integration-test binary selection."""
 
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -63,6 +66,40 @@ def test_empty_explicit_binary_path_fails_without_fallback(
 
     with pytest.raises(pytest.UsageError, match=r"APM_BINARY_PATH is set but empty"):
         integration_conftest._resolve_apm_binary()
+
+
+def test_silent_adopt_consumer_rejects_empty_explicit_binary(
+    tmp_path: Path,
+) -> None:
+    """The silent-adopt E2E must fail through the canonical resolver."""
+    fallback = tmp_path / "apm"
+    fallback.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fallback.chmod(0o755)
+    env = os.environ.copy()
+    env["APM_BINARY_PATH"] = ""
+    env["GITHUB_APM_PAT"] = "test-token"
+    env["PATH"] = f"{tmp_path}{os.pathsep}{env.get('PATH', '')}"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "--collect-only",
+            "-q",
+            "tests/integration/test_silent_adopt_existing_files_e2e.py",
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    combined = result.stdout + result.stderr
+    assert result.returncode != 0
+    assert "ERROR: APM_BINARY_PATH is set but empty." in combined
+    assert "INTERNALERROR" not in combined
 
 
 def test_non_executable_explicit_binary_path_fails_without_fallback(

--- a/tests/unit/test_integration_binary_path_contract.py
+++ b/tests/unit/test_integration_binary_path_contract.py
@@ -52,6 +52,24 @@ def test_missing_explicit_binary_path_fails_without_fallback(
         integration_conftest._resolve_apm_binary()
 
 
+def test_directory_explicit_binary_path_fails_without_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An existing directory must not satisfy the executable-file contract."""
+    configured = tmp_path / "configured-apm"
+    configured.mkdir()
+    fallback = tmp_path / "fallback-apm"
+    fallback.write_text("#!/bin/sh\n", encoding="utf-8")
+    fallback.chmod(0o755)
+    monkeypatch.setenv("APM_BINARY_PATH", str(configured))
+    monkeypatch.setattr(integration_conftest, "_local_dist_apm_binary", lambda: fallback)
+    monkeypatch.setattr(integration_conftest.shutil, "which", lambda _name: str(fallback))
+
+    with pytest.raises(pytest.UsageError, match=r"APM_BINARY_PATH does not exist or is not a file"):
+        integration_conftest._resolve_apm_binary()
+
+
 def test_empty_explicit_binary_path_fails_without_fallback(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_integration_binary_path_contract.py
+++ b/tests/unit/test_integration_binary_path_contract.py
@@ -91,6 +91,7 @@ def test_empty_explicit_binary_path_fails_without_fallback(
     (
         ("empty", "APM_BINARY_PATH is set but empty."),
         ("missing", "APM_BINARY_PATH does not exist or is not a file:"),
+        ("directory", "APM_BINARY_PATH does not exist or is not a file:"),
         pytest.param(
             "non-executable",
             "APM_BINARY_PATH is not executable:",
@@ -115,6 +116,10 @@ def test_silent_adopt_consumer_rejects_invalid_explicit_binary(
         env["APM_BINARY_PATH"] = ""
     elif configured_kind == "missing":
         env["APM_BINARY_PATH"] = str(tmp_path / "missing-apm")
+    elif configured_kind == "directory":
+        configured = tmp_path / "configured-apm"
+        configured.mkdir()
+        env["APM_BINARY_PATH"] = str(configured)
     else:
         configured = tmp_path / "configured-apm"
         configured.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")

--- a/tests/unit/test_integration_binary_path_contract.py
+++ b/tests/unit/test_integration_binary_path_contract.py
@@ -1,0 +1,68 @@
+"""Contracts for authoritative integration-test binary selection."""
+
+from pathlib import Path
+
+import pytest
+
+from tests.integration import conftest as integration_conftest
+
+
+@pytest.fixture(autouse=True)
+def _clear_binary_resolution_cache() -> None:
+    integration_conftest._resolve_apm_binary.cache_clear()
+    yield
+    integration_conftest._resolve_apm_binary.cache_clear()
+
+
+def test_explicit_binary_path_is_authoritative(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit executable must win over local and PATH fallbacks."""
+    configured = tmp_path / "configured-apm"
+    configured.write_text("#!/bin/sh\n", encoding="utf-8")
+    configured.chmod(0o755)
+    fallback = tmp_path / "fallback-apm"
+    fallback.write_text("#!/bin/sh\n", encoding="utf-8")
+    fallback.chmod(0o755)
+    monkeypatch.setenv("APM_BINARY_PATH", str(configured))
+    monkeypatch.setattr(integration_conftest, "_local_dist_apm_binary", lambda: fallback)
+    monkeypatch.setattr(integration_conftest.shutil, "which", lambda _name: str(fallback))
+
+    assert integration_conftest._resolve_apm_binary() == configured.resolve()
+
+
+def test_missing_explicit_binary_path_fails_without_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing configured artifact must not fall back to another binary."""
+    missing = tmp_path / "missing-apm"
+    fallback = tmp_path / "fallback-apm"
+    fallback.write_text("#!/bin/sh\n", encoding="utf-8")
+    fallback.chmod(0o755)
+    monkeypatch.setenv("APM_BINARY_PATH", str(missing))
+    monkeypatch.setattr(integration_conftest, "_local_dist_apm_binary", lambda: fallback)
+    monkeypatch.setattr(integration_conftest.shutil, "which", lambda _name: str(fallback))
+
+    with pytest.raises(RuntimeError, match=r"APM_BINARY_PATH does not exist"):
+        integration_conftest._resolve_apm_binary()
+
+
+def test_non_executable_explicit_binary_path_fails_without_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-executable configured artifact must not fall back to PATH."""
+    configured = tmp_path / "configured-apm"
+    configured.write_text("not executable\n", encoding="utf-8")
+    fallback = tmp_path / "fallback-apm"
+    fallback.write_text("#!/bin/sh\n", encoding="utf-8")
+    fallback.chmod(0o755)
+    monkeypatch.setenv("APM_BINARY_PATH", str(configured))
+    monkeypatch.setattr(integration_conftest, "_local_dist_apm_binary", lambda: fallback)
+    monkeypatch.setattr(integration_conftest.shutil, "which", lambda _name: str(fallback))
+    monkeypatch.setattr(integration_conftest.os, "access", lambda _path, _mode: False)
+
+    with pytest.raises(RuntimeError, match=r"APM_BINARY_PATH is not executable"):
+        integration_conftest._resolve_apm_binary()

--- a/tests/unit/test_integration_binary_path_contract.py
+++ b/tests/unit/test_integration_binary_path_contract.py
@@ -8,7 +8,11 @@ from pathlib import Path
 import pytest
 
 from tests.integration import conftest as integration_conftest
-from tests.integration import test_ado_e2e, test_plugin_e2e
+from tests.integration import (
+    test_ado_e2e,
+    test_auto_install_e2e,
+    test_plugin_e2e,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -205,5 +209,32 @@ def test_plugin_consumer_executes_injected_binary(
     command = test_plugin_e2e.apm_command.__wrapped__(configured)
 
     test_plugin_e2e._run_apm_command(command, ["--version"], tmp_path)
+
+    assert captured == [[str(configured), "--version"]]
+
+
+def test_auto_install_consumer_executes_injected_binary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The streaming auto-install helper must launch the injected artifact."""
+    configured = tmp_path / "configured-apm"
+    captured: list[list[str]] = []
+
+    class FakeProcess:
+        pass
+
+    def fake_popen(args: list[str], **_kwargs) -> FakeProcess:
+        captured.append(args)
+        return FakeProcess()
+
+    monkeypatch.setattr(test_auto_install_e2e.subprocess, "Popen", fake_popen)
+
+    test_auto_install_e2e._start_apm(
+        configured,
+        ["--version"],
+        cwd=str(tmp_path),
+        env={},
+    )
 
     assert captured == [[str(configured), "--version"]]

--- a/tests/unit/test_platform_contract_workflow.py
+++ b/tests/unit/test_platform_contract_workflow.py
@@ -8,9 +8,11 @@ from pathlib import Path
 import pytest
 
 from tests.workflow_contracts import (
+    assert_exact_command,
     assert_unconditional,
     effective_env,
     load_workflow,
+    shell_commands,
     shell_tokens,
     workflow_job,
     workflow_step,
@@ -39,7 +41,20 @@ def _assert_macos_startup_step(workflow: dict) -> None:
     }
     tokens = shell_tokens(step)
     assert tokens[:3] == ["test", "-x", "$APM_BINARY_PATH"]
-    assert MACOS_TEST_ID in tokens
+    assert_exact_command(
+        shell_commands(step),
+        [
+            "uv",
+            "run",
+            "--frozen",
+            "pytest",
+            MACOS_TEST_ID,
+            "-vv",
+            "-ra",
+            "--tb=short",
+        ],
+        label="macOS Intel startup step",
+    )
     assert workflow_step_index(job, "Build binary") < workflow_step_index(
         job,
         "Test macOS non-shell binary startup",
@@ -104,6 +119,22 @@ def test_macos_disabled_mutations_are_rejected(scope: str) -> None:
     job = workflow_job(workflow, "build-and-validate-macos-intel")
     step = workflow_step(job, "Test macOS non-shell binary startup")
     {"job": job, "step": step}[scope]["if"] = False
+
+    with pytest.raises(AssertionError):
+        _assert_macos_startup_step(workflow)
+
+
+def test_macos_echo_replacement_mutation_is_rejected() -> None:
+    """An echo cannot replace the exact frozen pytest invocation."""
+    workflow = deepcopy(_workflow())
+    step = workflow_step(
+        workflow_job(workflow, "build-and-validate-macos-intel"),
+        "Test macOS non-shell binary startup",
+    )
+    step["run"] = (
+        'test -x "$APM_BINARY_PATH"\n'
+        f"echo uv run --frozen pytest {MACOS_TEST_ID} -vv -ra --tb=short\n"
+    )
 
     with pytest.raises(AssertionError):
         _assert_macos_startup_step(workflow)

--- a/tests/unit/test_platform_contract_workflow.py
+++ b/tests/unit/test_platform_contract_workflow.py
@@ -14,14 +14,8 @@ def test_macos_intel_runs_non_shell_binary_startup_after_build() -> None:
     intel_job = workflow[intel_start:arm_start]
 
     build_step = "      - name: Build binary"
-    test_id = (
-        "tests/integration/test_core_smoke.py::"
-        "TestBinaryStartup::test_apm_version_runs"
-    )
-    binary_path = (
-        "APM_BINARY_PATH: "
-        "${{ github.workspace }}/dist/apm-darwin-x86_64/apm"
-    )
+    test_id = "tests/integration/test_core_smoke.py::TestBinaryStartup::test_apm_version_runs"
+    binary_path = "APM_BINARY_PATH: ${{ github.workspace }}/dist/apm-darwin-x86_64/apm"
 
     assert test_id in intel_job
     assert binary_path in intel_job

--- a/tests/unit/test_platform_contract_workflow.py
+++ b/tests/unit/test_platform_contract_workflow.py
@@ -21,6 +21,11 @@ def test_macos_intel_runs_non_shell_binary_startup_after_build() -> None:
     assert binary_path in intel_job
     assert 'APM_E2E_TESTS: "1"' in intel_job
     assert intel_job.index(build_step) < intel_job.index(test_id)
+    command_start = intel_job.index("      - name: Test macOS non-shell binary startup")
+    command = intel_job[command_start : command_start + 500]
+    assert 'test -x "$APM_BINARY_PATH"' in command
+    assert "uv run --frozen pytest" in command
+    assert command.index('test -x "$APM_BINARY_PATH"') < command.index(test_id)
     assert "matrix:" not in intel_job
 
 

--- a/tests/unit/test_platform_contract_workflow.py
+++ b/tests/unit/test_platform_contract_workflow.py
@@ -1,0 +1,44 @@
+"""Static contracts for hosted PR6 platform evidence."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "build-release.yml"
+
+
+def test_macos_intel_runs_non_shell_binary_startup_after_build() -> None:
+    """The Intel job must execute the existing list-form binary startup test."""
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    intel_start = workflow.index("  build-and-validate-macos-intel:")
+    arm_start = workflow.index("  build-and-validate-macos-arm:")
+    intel_job = workflow[intel_start:arm_start]
+
+    build_step = "      - name: Build binary"
+    test_id = (
+        "tests/integration/test_core_smoke.py::"
+        "TestBinaryStartup::test_apm_version_runs"
+    )
+    binary_path = (
+        "APM_BINARY_PATH: "
+        "${{ github.workspace }}/dist/apm-darwin-x86_64/apm"
+    )
+
+    assert test_id in intel_job
+    assert binary_path in intel_job
+    assert 'APM_E2E_TESTS: "1"' in intel_job
+    assert intel_job.index(build_step) < intel_job.index(test_id)
+    assert "matrix:" not in intel_job
+
+
+def test_windows_installer_contract_reports_its_exact_test_id() -> None:
+    """The hosted Windows log must distinguish a pass from a skip."""
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+    windows_start = workflow.index("  build-and-test:")
+    intel_start = workflow.index("  build-and-validate-macos-intel:")
+    build_job = workflow[windows_start:intel_start]
+
+    test_id = "tests/integration/test_windows_installer_launchers.py"
+    assert test_id in build_job
+    command_start = build_job.index(test_id)
+    command = build_job[command_start : command_start + 160]
+    assert "-vv -ra --tb=short" in command

--- a/tests/unit/test_platform_contract_workflow.py
+++ b/tests/unit/test_platform_contract_workflow.py
@@ -30,7 +30,7 @@ def test_macos_intel_runs_non_shell_binary_startup_after_build() -> None:
 
 
 def test_windows_installer_contract_reports_its_exact_test_id() -> None:
-    """The hosted Windows log must distinguish a pass from a skip."""
+    """The hosted Windows log is exact, frozen, and does not expose a token."""
     workflow = WORKFLOW.read_text(encoding="utf-8")
     windows_start = workflow.index("  build-and-test:")
     intel_start = workflow.index("  build-and-validate-macos-intel:")
@@ -41,3 +41,9 @@ def test_windows_installer_contract_reports_its_exact_test_id() -> None:
     command_start = build_job.index(test_id)
     command = build_job[command_start : command_start + 160]
     assert "-vv -ra --tb=short" in command
+    installer_step_start = build_job.index("      - name: Test install.ps1 end-to-end (Windows)")
+    installer_step_end = build_job.index("      - name: Run unit tests", installer_step_start)
+    installer_step = build_job[installer_step_start:installer_step_end]
+    assert "uv run --frozen pytest" in installer_step
+    assert 'APM_E2E_TESTS: "1"' in installer_step
+    assert "GITHUB_TOKEN:" not in installer_step

--- a/tests/unit/test_platform_contract_workflow.py
+++ b/tests/unit/test_platform_contract_workflow.py
@@ -35,6 +35,7 @@ def _assert_macos_startup_step(workflow: dict) -> None:
     assert_unconditional(job, label="macOS Intel job")
     assert_unconditional(step, label="macOS Intel startup step")
     assert job["runs-on"] == "macos-15-intel"
+    assert effective_env(workflow, job, step).get("GITHUB_TOKEN") is None
     assert step["env"] == {
         "APM_E2E_TESTS": "1",
         "APM_BINARY_PATH": "${{ github.workspace }}/dist/apm-darwin-x86_64/apm",
@@ -97,6 +98,20 @@ def test_windows_token_scope_mutations_are_rejected(scope: str) -> None:
 
     with pytest.raises(AssertionError):
         _assert_windows_installer_step(workflow)
+
+
+@pytest.mark.parametrize("scope", ("workflow", "job", "step"))
+def test_macos_token_scope_mutations_are_rejected(scope: str) -> None:
+    """A token inherited from any Actions scope must fail the macOS contract."""
+    workflow = deepcopy(_workflow())
+    job = workflow_job(workflow, "build-and-validate-macos-intel")
+    step = workflow_step(job, "Test macOS non-shell binary startup")
+    {"workflow": workflow, "job": job, "step": step}[scope].setdefault("env", {})[
+        "GITHUB_TOKEN"
+    ] = "secret"
+
+    with pytest.raises(AssertionError):
+        _assert_macos_startup_step(workflow)
 
 
 def test_windows_linux_gate_mutation_is_rejected() -> None:

--- a/tests/unit/test_platform_contract_workflow.py
+++ b/tests/unit/test_platform_contract_workflow.py
@@ -1,49 +1,109 @@
-"""Static contracts for hosted PR6 platform evidence."""
+"""Semantic contracts for hosted PR6 platform evidence."""
 
+from __future__ import annotations
+
+from copy import deepcopy
 from pathlib import Path
+
+import pytest
+
+from tests.workflow_contracts import (
+    assert_unconditional,
+    effective_env,
+    load_workflow,
+    shell_tokens,
+    workflow_job,
+    workflow_step,
+    workflow_step_index,
+)
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github" / "workflows" / "build-release.yml"
+MACOS_TEST_ID = "tests/integration/test_core_smoke.py::TestBinaryStartup::test_apm_version_runs"
+WINDOWS_TEST_ID = "tests/integration/test_windows_installer_launchers.py"
+
+
+def _workflow() -> dict:
+    return load_workflow(WORKFLOW)
+
+
+def _assert_macos_startup_step(workflow: dict) -> None:
+    job = workflow_job(workflow, "build-and-validate-macos-intel")
+    step = workflow_step(job, "Test macOS non-shell binary startup")
+    assert_unconditional(job, label="macOS Intel job")
+    assert_unconditional(step, label="macOS Intel startup step")
+    assert job["runs-on"] == "macos-15-intel"
+    assert step["env"] == {
+        "APM_E2E_TESTS": "1",
+        "APM_BINARY_PATH": "${{ github.workspace }}/dist/apm-darwin-x86_64/apm",
+    }
+    tokens = shell_tokens(step)
+    assert tokens[:3] == ["test", "-x", "$APM_BINARY_PATH"]
+    assert MACOS_TEST_ID in tokens
+    assert workflow_step_index(job, "Build binary") < workflow_step_index(
+        job,
+        "Test macOS non-shell binary startup",
+    )
+
+
+def _assert_windows_installer_step(workflow: dict) -> None:
+    job = workflow_job(workflow, "build-and-test")
+    step = workflow_step(job, "Test install.ps1 end-to-end (Windows)")
+    assert step.get("if") == "matrix.platform == 'windows'"
+    assert effective_env(workflow, job, step).get("GITHUB_TOKEN") is None
+    assert step["env"] == {"APM_E2E_TESTS": "1"}
+    tokens = shell_tokens(step)
+    assert tokens[:4] == ["uv", "run", "--frozen", "pytest"]
+    assert WINDOWS_TEST_ID in tokens
+    assert "-vv" in tokens
+    assert "-ra" in tokens
+    assert "--tb=short" in tokens
 
 
 def test_macos_intel_runs_non_shell_binary_startup_after_build() -> None:
-    """The Intel job must execute the existing list-form binary startup test."""
-    workflow = WORKFLOW.read_text(encoding="utf-8")
-    intel_start = workflow.index("  build-and-validate-macos-intel:")
-    arm_start = workflow.index("  build-and-validate-macos-arm:")
-    intel_job = workflow[intel_start:arm_start]
-
-    build_step = "      - name: Build binary"
-    test_id = "tests/integration/test_core_smoke.py::TestBinaryStartup::test_apm_version_runs"
-    binary_path = "APM_BINARY_PATH: ${{ github.workspace }}/dist/apm-darwin-x86_64/apm"
-
-    assert test_id in intel_job
-    assert binary_path in intel_job
-    assert 'APM_E2E_TESTS: "1"' in intel_job
-    assert intel_job.index(build_step) < intel_job.index(test_id)
-    command_start = intel_job.index("      - name: Test macOS non-shell binary startup")
-    command = intel_job[command_start : command_start + 500]
-    assert 'test -x "$APM_BINARY_PATH"' in command
-    assert "uv run --frozen pytest" in command
-    assert command.index('test -x "$APM_BINARY_PATH"') < command.index(test_id)
-    assert "matrix:" not in intel_job
+    """The Intel job executes the exact generated artifact unconditionally."""
+    _assert_macos_startup_step(_workflow())
 
 
-def test_windows_installer_contract_reports_its_exact_test_id() -> None:
-    """The hosted Windows log is exact, frozen, and does not expose a token."""
-    workflow = WORKFLOW.read_text(encoding="utf-8")
-    windows_start = workflow.index("  build-and-test:")
-    intel_start = workflow.index("  build-and-validate-macos-intel:")
-    build_job = workflow[windows_start:intel_start]
+def test_windows_installer_contract_is_windows_only_and_tokenless() -> None:
+    """The Windows E2E has exact gating and no effective repository token."""
+    _assert_windows_installer_step(_workflow())
 
-    test_id = "tests/integration/test_windows_installer_launchers.py"
-    assert test_id in build_job
-    command_start = build_job.index(test_id)
-    command = build_job[command_start : command_start + 160]
-    assert "-vv -ra --tb=short" in command
-    installer_step_start = build_job.index("      - name: Test install.ps1 end-to-end (Windows)")
-    installer_step_end = build_job.index("      - name: Run unit tests", installer_step_start)
-    installer_step = build_job[installer_step_start:installer_step_end]
-    assert "uv run --frozen pytest" in installer_step
-    assert 'APM_E2E_TESTS: "1"' in installer_step
-    assert "GITHUB_TOKEN:" not in installer_step
+
+@pytest.mark.parametrize("scope", ("workflow", "job", "step"))
+def test_windows_token_scope_mutations_are_rejected(scope: str) -> None:
+    """A token inherited from any Actions scope must fail the contract."""
+    workflow = deepcopy(_workflow())
+    job = workflow_job(workflow, "build-and-test")
+    step = workflow_step(job, "Test install.ps1 end-to-end (Windows)")
+    {"workflow": workflow, "job": job, "step": step}[scope].setdefault("env", {})[
+        "GITHUB_TOKEN"
+    ] = "secret"
+
+    with pytest.raises(AssertionError):
+        _assert_windows_installer_step(workflow)
+
+
+def test_windows_linux_gate_mutation_is_rejected() -> None:
+    """A Linux condition cannot satisfy the Windows-only platform contract."""
+    workflow = deepcopy(_workflow())
+    step = workflow_step(
+        workflow_job(workflow, "build-and-test"),
+        "Test install.ps1 end-to-end (Windows)",
+    )
+    step["if"] = "matrix.platform == 'linux'"
+
+    with pytest.raises(AssertionError):
+        _assert_windows_installer_step(workflow)
+
+
+@pytest.mark.parametrize("scope", ("job", "step"))
+def test_macos_disabled_mutations_are_rejected(scope: str) -> None:
+    """The Intel startup evidence cannot be disabled at job or step scope."""
+    workflow = deepcopy(_workflow())
+    job = workflow_job(workflow, "build-and-validate-macos-intel")
+    step = workflow_step(job, "Test macOS non-shell binary startup")
+    {"job": job, "step": step}[scope]["if"] = False
+
+    with pytest.raises(AssertionError):
+        _assert_macos_startup_step(workflow)

--- a/tests/unit/test_windows_installer_launchers.py
+++ b/tests/unit/test_windows_installer_launchers.py
@@ -43,9 +43,7 @@ def test_windows_installer_e2e_covers_bare_subprocess_resolution() -> None:
 
 def test_windows_installer_e2e_covers_missing_stable_executable_negative_twin() -> None:
     """The native-process proof must fail when only the cmd shim remains."""
-    test_script = (ROOT / "scripts/windows/test-install-script.ps1").read_text(
-        encoding="utf-8"
-    )
+    test_script = (ROOT / "scripts/windows/test-install-script.ps1").read_text(encoding="utf-8")
 
     helper_name = "Assert-MissingStableExecutableFailsForNativeProcess"
     assert f"function {helper_name}" in test_script

--- a/tests/unit/test_windows_installer_launchers.py
+++ b/tests/unit/test_windows_installer_launchers.py
@@ -41,6 +41,33 @@ def test_windows_installer_e2e_covers_bare_subprocess_resolution() -> None:
     assert "Stable executable directory precedes command shim directory in user PATH" in test_script
 
 
+def test_windows_installer_e2e_covers_missing_stable_executable_negative_twin() -> None:
+    """The native-process proof must fail when only the cmd shim remains."""
+    test_script = (ROOT / "scripts/windows/test-install-script.ps1").read_text(
+        encoding="utf-8"
+    )
+
+    helper_name = "Assert-MissingStableExecutableFailsForNativeProcess"
+    assert f"function {helper_name}" in test_script
+
+    helper_start = test_script.index(f"function {helper_name}")
+    helper_end = test_script.index(
+        "# ---------------------------------------------------------------------------",
+        helper_start,
+    )
+    helper = test_script[helper_start:helper_end]
+    assert 'Join-Path $BinDir "apm.cmd"' in helper
+    assert '["apm", "--version"],' in helper
+    assert 'cwd=os.environ["APM_LAUNCH_TEST_CWD"]' in helper
+    assert "except FileNotFoundError:" in helper
+    assert '$env:Path = "$CurrentDir;$BinDir"' in helper
+    assert 'throw "Python subprocess unexpectedly resolved' in helper
+
+    e2e_start = test_script.index("function Test-EndToEndInstall")
+    e2e_end = test_script.index("function Test-NonJunctionCollision")
+    assert helper_name in test_script[e2e_start:e2e_end]
+
+
 def test_windows_installer_e2e_covers_non_junction_collision() -> None:
     """The Windows release gate must prove collision failures preserve data."""
     test_script = (ROOT / "scripts/windows/test-install-script.ps1").read_text(encoding="utf-8")

--- a/tests/utils/apm_lifecycle_runner.py
+++ b/tests/utils/apm_lifecycle_runner.py
@@ -51,19 +51,19 @@ class _LifecycleTimeoutExpired(subprocess.TimeoutExpired):
 class ApmLifecycleRunner:
     """Run an APM entry point with explicit process inputs and captured evidence.
 
-    The default resolves the development environment's ``apm`` console script.
-    Pass an explicit command tuple to exercise a source module or packaged
-    standalone binary instead.
+    Integration tests pass the command selected by the canonical
+    ``apm_binary_path`` fixture. Tests for runner mechanics may instead pass an
+    unrelated explicit command such as the current Python interpreter.
     """
 
     def __init__(
         self,
-        command: Sequence[str] | None = None,
+        command: Sequence[str],
         *,
         timeout_seconds: float = 120.0,
         scenario_timeout_seconds: float = 300.0,
     ) -> None:
-        self._command = tuple(command or ("apm",))
+        self._command = tuple(command)
         self._timeout_seconds = timeout_seconds
         self._scenario_timeout_seconds = scenario_timeout_seconds
 

--- a/tests/workflow_contracts.py
+++ b/tests/workflow_contracts.py
@@ -1,0 +1,80 @@
+"""Shared semantic helpers for GitHub Actions workflow contracts."""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+WorkflowNode = dict[str, Any]
+
+
+def load_workflow(path: Path) -> WorkflowNode:
+    """Parse a workflow while normalizing YAML 1.1's boolean ``on`` key."""
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise AssertionError(f"workflow root must be a mapping: {path}")
+    if True in loaded and "on" not in loaded:
+        loaded["on"] = loaded.pop(True)
+    return loaded
+
+
+def workflow_job(workflow: WorkflowNode, name: str) -> WorkflowNode:
+    """Return one named job mapping."""
+    jobs = workflow.get("jobs")
+    if not isinstance(jobs, dict) or not isinstance(jobs.get(name), dict):
+        raise AssertionError(f"workflow job not found: {name}")
+    return jobs[name]
+
+
+def workflow_step(job: WorkflowNode, name: str) -> WorkflowNode:
+    """Return one named step mapping."""
+    steps = job.get("steps")
+    if not isinstance(steps, list):
+        raise AssertionError("workflow job steps must be a list")
+    matches = [step for step in steps if isinstance(step, dict) and step.get("name") == name]
+    if len(matches) != 1:
+        raise AssertionError(f"expected exactly one workflow step named {name!r}")
+    return matches[0]
+
+
+def workflow_step_index(job: WorkflowNode, name: str) -> int:
+    """Return the list index of one named step."""
+    steps = job.get("steps")
+    if not isinstance(steps, list):
+        raise AssertionError("workflow job steps must be a list")
+    for index, step in enumerate(steps):
+        if isinstance(step, dict) and step.get("name") == name:
+            return index
+    raise AssertionError(f"workflow step not found: {name}")
+
+
+def effective_env(
+    workflow: WorkflowNode,
+    job: WorkflowNode,
+    step: WorkflowNode,
+) -> dict[str, Any]:
+    """Merge workflow, job, and step environments using Actions precedence."""
+    merged: dict[str, Any] = {}
+    for node in (workflow, job, step):
+        env = node.get("env", {})
+        if not isinstance(env, dict):
+            raise AssertionError("workflow env must be a mapping")
+        merged.update(env)
+    return merged
+
+
+def shell_tokens(step: WorkflowNode) -> list[str]:
+    """Tokenize a run step while treating commented commands as absent."""
+    command = step.get("run")
+    if not isinstance(command, str):
+        raise AssertionError("workflow step must contain a run command")
+    return shlex.split(command, comments=True, posix=True)
+
+
+def assert_unconditional(node: WorkflowNode, *, label: str) -> None:
+    """Require a job or step to have no conditional gate."""
+    if "if" in node:
+        raise AssertionError(f"{label} must be unconditional, got if={node['if']!r}")

--- a/tests/workflow_contracts.py
+++ b/tests/workflow_contracts.py
@@ -68,10 +68,31 @@ def effective_env(
 
 def shell_tokens(step: WorkflowNode) -> list[str]:
     """Tokenize a run step while treating commented commands as absent."""
+    return [token for command in shell_commands(step) for token in command]
+
+
+def shell_commands(step: WorkflowNode) -> list[list[str]]:
+    """Tokenize each shell command after joining line continuations."""
     command = step.get("run")
     if not isinstance(command, str):
         raise AssertionError("workflow step must contain a run command")
-    return shlex.split(command, comments=True, posix=True)
+    logical = command.replace("\\\n", " ")
+    return [
+        tokens
+        for line in logical.splitlines()
+        if (tokens := shlex.split(line, comments=True, posix=True))
+    ]
+
+
+def assert_exact_command(
+    commands: list[list[str]],
+    expected: list[str],
+    *,
+    label: str,
+) -> None:
+    """Require one complete shell command to match exactly."""
+    if expected not in commands:
+        raise AssertionError(f"{label} must contain exact command: {expected!r}")
 
 
 def assert_unconditional(node: WorkflowNode, *, label: str) -> None:


### PR DESCRIPTION
# harden(contracts): prove platform startup and rendered docs parity

## TL;DR

This PR adds executable evidence for Windows launcher loss, macOS Intel startup, rendered-link targets, and Click registry-to-rendered-page parity. It also makes `tests/integration/conftest.py::apm_binary_path` the only integration-test APM executable selector and guards that ownership with AC9. The branch is rebased linearly onto the lifecycle foundation from #2209.

> [!IMPORTANT]
> Exact head `10b7e65a55591508f7206708a1b2151bddbb5a28` is green in hosted CI. The PR is ready for human review and is not merged.

## Problem (WHY)

- [x] An explicit `APM_BINARY_PATH` could be empty, missing, a directory, or non-executable and silently fall back to a different binary.
- [x] Integration modules independently selected APM through `PATH`, `.venv`, source-module, bare-command, and interpreter-relative launchers.
- [x] Windows and macOS workflows lacked exact contract evidence for the generated executables under review.
- [x] Source CLI registration could drift from rendered reference pages without failing the docs-owner workflow.
- [!] Workflow-level Pages/OIDC permissions and a Windows step token exposed more authority than validation required.

These contracts keep the scope on project-specific failure modes by following ["Add what the agent lacks, omit what it knows"](https://agentskills.io/skill-creation/best-practices). Their concrete tests also follow ["agents pattern-match well against concrete structures"](https://agentskills.io/skill-creation/best-practices).

## Approach (WHAT)

| # | Fix |
|---:|---|
| 1 | Treat configured binary presence as authoritative and fail closed on every invalid value. |
| 2 | Inject one validated `apm_binary_path` into every integration subprocess consumer. |
| 3 | Enforce sole ownership with syntax-aware AC9 detectors and independent mutation traps. |
| 4 | Compare the live Click registry with rendered Astro routes through one parity facade. |
| 5 | Run exact Windows, macOS, link, and CLI-doc contracts in their owning workflows. |
| 6 | Narrow token and deployment permissions to the jobs and steps that require them. |

## Implementation (HOW)

| Surface | Intent |
|---|---|
| `.github/workflows/build-release.yml` and `scripts/windows/test-install-script.ps1` | Run the exact generated macOS binary, prove the missing-stable-Windows-executable negative twin, and keep downloaded Windows binaries tokenless. |
| `.github/workflows/docs.yml` and `tests/workflow_contracts.py` | Trigger on CLI registration changes, run frozen contract suites unconditionally, and keep Pages/OIDC permissions deploy-only. |
| `scripts/check_cli_docs.py` | Own Click-registry and rendered-route projection, reserve stdout for success, and give output-tree-correct recovery guidance. |
| `tests/integration/conftest.py` | Own environment, local artifact, and final `PATH` resolution once; reject invalid explicit paths without fallback. |
| `scripts/check_test_contract_authorities.py` and `scripts/lint-architecture-boundaries.sh` | Add AC9 for environment reads, aliases, `.venv` constructors, interpreter paths, subprocess commands, lifecycle runners, and parity-facade bypasses. |
| `tests/integration/**` | Replace local executable selection with direct canonical fixture injection while preserving scenario-specific arguments and bounded environments. |
| `tests/unit/**` and `tests/integration/test_architecture_authorities.py` | Pin recursive discovery, scope/shadow behavior, PurePath forms, run/Popen propagation, workflow semantics, and stream contracts. |
| `docs/src/content/docs/contributing/development-guide.md` | Document the command-page and reference-index contribution contract with local build/parity commands. |

## Diagrams

Legend: the upper path is the only allowed executable decision; the lower path prevents a second owner from entering the integration tree.

```mermaid
flowchart LR
    subgraph Select[Canonical selection]
        E[APM_BINARY_PATH] --> R[conftest resolver]
        D[generated dist artifact] --> R
        P[PATH fallback] --> R
        R --> F[apm_binary_path fixture]
    end
    subgraph Consume[Integration execution]
        F --> C[subprocess consumers]
        C --> X[argv zero is validated artifact]
    end
    subgraph Guard[AC9 authority boundary]
        T[recursive integration tree] --> A[AST authority checker]
        A --> G1[environment and PATH]
        A --> G2[venv and interpreter paths]
        A --> G3[run, Popen, and lifecycle runner]
        A --> G4[rendered parity facade]
    end
    classDef new stroke-dasharray: 5 5;
    class F,A,G1,G2,G3,G4 new;
```

## Trade-offs

- **Fail closed instead of silently recovering.** Explicit binary configuration is an assertion about the artifact under test, not a hint.
- **AST checks instead of broad grep.** The larger checker distinguishes real selection from unrelated `git`, `uv`, and `az` discovery.
- **Direct fixture injection instead of forwarding fixtures.** Compatibility aliases would preserve another owner-shaped facade.
- **Keep scenario runners local.** Binary choice is centralized; test-specific arguments, environments, and timeout behavior remain near each scenario.
- **No CHANGELOG or README entry.** The PR changes test and CI evidence rather than released CLI behavior; release communication remains release-cut scope.

## Benefits

1. One canonical executable decision feeds every inventoried integration APM subprocess.
2. AC9 scans recursively and rejects environment, path, command, fixture, and parity reimplementations.
3. The docs workflow proves 33 public commands match 33 rendered pages.
4. The docs build proves 909 generated relative links resolve across 123 pages.
5. Hosted CI validates the final SHA through lint, both Linux shards, coverage combine, binary smoke, self-check, docs, CodeQL, and merge status.

## Validation

`uv run --extra dev pytest -q tests/unit/scripts/test_check_test_contract_authorities.py tests/unit/test_integration_binary_path_contract.py tests/integration/test_architecture_authorities.py`:

```text
99 passed in 24.10s
```

`uv run python scripts/check_test_contract_authorities.py && bash scripts/lint-architecture-boundaries.sh`:

```text
[+] test contract authority check clean
[*] AC1: canonical capability authorities
[*] AC2: validate-before-mutate boundaries
[*] AC3: outcome and policy enforcement authorities
[*] AC4: declared-intent preservation
[*] AC5: process-wide I/O boundaries
[*] AC6: neutral IR and schema contracts
[*] AC7: concurrency and deadline safety
[*] AC8: Windows installer authorities
[*] AC9: executable test contract authorities
[+] architecture boundary lint clean
```

<details><summary>Rendered docs, lint, and hosted exact-head receipts</summary>

```text
[+] 33 public CLI commands match 33 rendered pages.
[+] Checked 909 relative link(s) across generated pages. No broken relative links found.
[build] 123 page(s) built
ruff check: All checks passed!
ruff format: 1509 files already formatted
pylint R0801: 10.00/10
auth-signal lint: clean
```

```text
APM Self-Check                 pass
Analyze (actions)              pass
Analyze (python)               pass
Build & Test Shard 1 (Linux)   pass
Build & Test Shard 2 (Linux)   pass
Coverage Combine (Linux)       pass
Lint                           pass
NOTICE Drift Check             pass
PR Binary Smoke (Linux)        pass
Deploy Docs / build            pass
Merge Gate                     pass
license/cla                    pass
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | Native Windows callers stop resolving APM when the stable executable is missing | DevX, Secure by default | `tests/unit/test_windows_installer_launchers.py::test_windows_installer_e2e_covers_missing_stable_executable_negative_twin` | static + e2e |
| 2 | Invalid configured artifacts never fall back to another executable | DevX, Secure by default | `tests/unit/test_integration_binary_path_contract.py` | unit + integration |
| 3 | Every integration subprocess receives the same validated APM path | Governed by policy, DevX | `tests/integration/test_architecture_authorities.py::test_executable_test_contracts_have_one_canonical_owner` | integration |
| 4 | macOS Intel executes the exact generated binary without inheriting a repository token | Secure by default, DevX | `tests/unit/test_platform_contract_workflow.py` | static + hosted e2e |
| 5 | A missing rendered target or CLI page fails with the exact broken name and recovery path | OSS, DevX | `docs/scripts/check-links.test.mjs`<br/>`tests/integration/test_cli_docs_contract.py` | unit + integration |
| 6 | Docs validation is read-only while deployment alone receives Pages/OIDC authority | Secure by default, Governed by policy | `tests/unit/test_docs_contract_workflow.py` | static |

## How to test

- [ ] Run `uv run python scripts/check_test_contract_authorities.py`; expect `[+] test contract authority check clean`.
- [ ] Run the 99-test authority command above; expect all tests to pass.
- [ ] Run `npm --prefix docs run build`; expect 123 pages and no broken links.
- [ ] Run `uv run --frozen python scripts/check_cli_docs.py docs/dist`; expect `33` commands and pages.
- [ ] Inspect checks for exact head `10b7e65a55591508f7206708a1b2151bddbb5a28`; expect all required checks green.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>