### PR TITLE
fix(deps): accept custom port in shorthand so apm.yml entries re-parse

### DIFF
--- a/docs/src/content/docs/consumer/private-and-org-packages.md
+++ b/docs/src/content/docs/consumer/private-and-org-packages.md
@@ -33,9 +33,11 @@ dependencies:
 ```
 
 Use shorthand when the host follows owner/repo (or ADO's
-org/project/repo). Use the object form for custom ports, non-standard
-schemes, or deep GitLab subgroups shorthand cannot disambiguate. Full
-grammar: `DependencyReference.parse` in
+org/project/repo). HTTPS shorthand also accepts
+`host:PORT/owner/repo`; when authoring `apm.yml` by hand, prefer a full
+URL or object form for custom ports so the transport is explicit. Use
+the object form for non-standard schemes or deep GitLab subgroups
+shorthand cannot disambiguate. Full grammar: `DependencyReference.parse` in
 `src/apm_cli/models/dependency/reference.py`.
 
 ## GitHub.com private repos
@@ -131,8 +133,8 @@ dependencies:
 
 ## Custom ports and self-hosted git
 
-Use the object form for non-default ports. Use `ssh://` -- SCP
-shorthand (`git@host:path`) cannot carry a port:
+For SSH, use `ssh://` -- SCP shorthand (`git@host:path`) cannot carry a
+port. For HTTPS, prefer the full URL or object form:
 
 ```yaml
 dependencies:
@@ -142,6 +144,11 @@ dependencies:
     - git: https://git.acme.internal:8443/team/standards.git
       ref: v1.2.0
 ```
+
+After `apm install`, APM writes this HTTPS dependency in `apm.yml` as
+`git.acme.internal:8443/team/standards#v1.2.0`. This scheme-free
+shorthand preserves the custom port and is valid input on subsequent
+runs.
 
 APM does not fall back across protocols by default. If you need the
 legacy same-port fallback, pass `--allow-protocol-fallback` or set

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -355,18 +355,21 @@ Grammar (ABNF-style):
 ```
 dependency      = url_form / shorthand_form / local_path_form
 url_form        = ("https://" / "http://" / "ssh://git@" / "git@") clone-url
-shorthand_form  = [host "/"] owner "/" repo ["/" virtual_path] ["#" ref]
+shorthand_form  = [host [":" port] "/"] owner "/" repo ["/" virtual_path] ["#" ref]
 local_path_form = ("./" / "../" / "/" / "~/" / ".\\" / "..\\" / "~\\") path
 ```
 
+The `host:port` shorthand resolves as HTTPS. SSH custom ports require the
+`ssh://` URL form.
+
 When a default registry is configured - via `registries.default` in `apm.yml` or `registry.<name>.default true` in `~/.apm/config.json` - plain `shorthand_form` entries with a `#<selector>` route through that registry instead of Git.
 
-`clone-url` MAY include a `:port` segment on `https://`, `http://`, and `ssh://git@` forms (e.g. `ssh://git@host:7999/owner/repo.git`). The SCP shorthand `git@host:path` cannot carry a port - `:` is the path separator in that form. When a port is present, APM preserves it across all clone attempts: the SSH attempt uses `ssh://host:PORT/...` and the HTTPS fallback uses `https://host:PORT/...` (same port on both protocols).
+`clone-url` MAY include a `:port` segment on `https://`, `http://`, and `ssh://git@` forms (e.g. `ssh://git@host:7999/owner/repo.git`). The SCP shorthand `git@host:path` cannot carry a port - `:` is the path separator in that form. When a port is present, APM preserves it across all clone attempts: the SSH attempt uses `ssh://host:PORT/...` and the HTTPS fallback uses `https://host:PORT/...` (same port on both protocols). For HTTPS custom-port dependencies, APM writes the scheme-free shorthand `host:PORT/owner/repo[#ref]` to `apm.yml` and can parse that form on the next run. The shorthand port `:443` normalizes to no port.
 
 | Segment | Required | Pattern | Description |
 |---|---|---|---|
 | `host` | OPTIONAL | FQDN (e.g. `gitlab.com`) | Git host. Defaults to `github.com`. |
-| `port` | OPTIONAL | `1`-`65535` | Non-default port on `ssh://`, `https://`, `http://` clone URLs. Not expressible in SCP shorthand. |
+| `port` | OPTIONAL | `1`-`65535` | Non-default port on `ssh://`, `https://`, `http://` clone URLs. Also accepted in HTTPS shorthand as `host:PORT/owner/repo`; `:443` normalizes to no port. Not expressible in SCP shorthand. |
 | `owner/repo` | REQUIRED | 2+ path segments of `[a-zA-Z0-9._~-]+` on non-Azure-DevOps hosts; `[a-zA-Z0-9._\- ]+` (allows spaces, not tilde) on Azure DevOps | Repository path. GitHub uses exactly 2 segments. Non-GitHub hosts MAY use nested groups (e.g. `gitlab.com/group/sub/repo`). Tilde supports Bitbucket Data Center personal-repo segments (`/scm/~user/repo.git`) and Sourcehut `~user` paths. |
 | `virtual_path` | OPTIONAL | Path segments after repo | Subdirectory or file within the repo. See Section 4.1.3. |
 | `ref` | OPTIONAL | Branch, tag, or commit SHA | Git reference. Commit SHAs matched by `^[a-f0-9]{7,40}$`. Semver tags matched by `^v?\d+\.\d+\.\d+`. |
@@ -394,6 +397,7 @@ dependencies:
     # Custom ports (e.g. Bitbucket Datacenter, self-hosted GitLab)
     - ssh://git@bitbucket.example.com:7999/project/repo.git
     - https://git.internal:8443/team/repo.git
+    - git.internal:8443/team/repo#main        # HTTPS shorthand: accepted and written by APM
 
     # Virtual packages
     - ComposioHQ/awesome-claude-skills/brand-guidelines   # subdirectory

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -76,6 +76,10 @@ fallback enabled with `--allow-protocol-fallback`).
 - Use the `ssh://` form to specify an SSH port
   (e.g. `ssh://git@host:7999/owner/repo.git`). The SCP shorthand
   `git@host:path` **cannot** carry a port -- the `:` is the path separator.
+- For HTTPS, prefer a full URL or object form when entering a custom port.
+  APM may write the dependency to `apm.yml` as
+  `host:PORT/owner/repo[#ref]`; the parser accepts this shorthand and
+  normalizes `:443` to no port.
 - A non-`git` SSH user is honored when present in the dep URL
   (e.g. `myuser@host:owner/repo.git` or `ssh://myuser@host/owner/repo.git`),
   useful for EMU accounts or servers where the SSH login is not `git`.
@@ -83,8 +87,9 @@ fallback enabled with `--allow-protocol-fallback`).
   percent-encoded userinfo is rejected. The user is presentation-only and
   not part of dependency identity (does not perturb lockfile dedup).
 - The lockfile records `port: <int>` (1-65535) only when a non-default port
-  is set. Port is a transport detail, not part of the package identity --
-  the same repo reachable on different ports dedupes to one entry.
+  is set. Manifest identity includes `host:port`, while the lockfile dedup
+  key uses `host/repo`; the same repository reached through different
+  ports maps to one lockfile key.
 
 ## Transport selection (SSH vs HTTPS)
 

--- a/src/apm_cli/models/dependency/identity.py
+++ b/src/apm_cli/models/dependency/identity.py
@@ -29,6 +29,21 @@ _ADO_PATH_SEGMENT_RE = r"^[a-zA-Z0-9._\- ]+$"
 _NON_ADO_PATH_SEGMENT_RE = r"^[a-zA-Z0-9._~-]+$"
 
 _RANGE_PREFIX_RE = re.compile(r"^(>=|<=|>|<|\^|~|=)")
+_DEFAULT_SCHEME_PORTS: dict[str, int] = {"https": 443, "http": 80, "ssh": 22}
+
+
+def _split_shorthand_host_port(host_segment: str) -> tuple[str, int | None]:
+    """Split and validate the host segment used by DependencyReference shorthand."""
+    if ":" not in host_segment:
+        return host_segment, None
+    host, _, raw_port = host_segment.rpartition(":")
+    error = f"Invalid shorthand port '{raw_port}'. Expected an integer from 1 to 65535"
+    if not host or not re.fullmatch(r"[0-9]{1,5}", raw_port):
+        raise ValueError(error)
+    port = int(raw_port)
+    if not 1 <= port <= 65535:
+        raise ValueError(error)
+    return host, None if port == _DEFAULT_SCHEME_PORTS["https"] else port
 
 
 def normalize_package_repo_url(

--- a/src/apm_cli/models/dependency/identity.py
+++ b/src/apm_cli/models/dependency/identity.py
@@ -37,7 +37,7 @@ def _split_shorthand_host_port(host_segment: str) -> tuple[str, int | None]:
     if ":" not in host_segment:
         return host_segment, None
     host, _, raw_port = host_segment.rpartition(":")
-    error = f"Invalid shorthand port '{raw_port}'. Expected an integer from 1 to 65535"
+    error = "Invalid shorthand port. Expected an integer from 1 to 65535"
     if not host or not re.fullmatch(r"[0-9]{1,5}", raw_port):
         raise ValueError(error)
     port = int(raw_port)

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -26,11 +26,13 @@ from ...utils.path_security import (
 )
 from ..validation import InvalidVirtualPackageExtensionError
 from .identity import (
+    _DEFAULT_SCHEME_PORTS,
     _NON_ADO_PATH_SEGMENT_RE,
     InvalidSemverRangeError,
     _is_valid_registry_semver_range,
     _looks_like_invalid_semver_range,
     _path_segment_pattern,
+    _split_shorthand_host_port,
     build_canonical_dependency_string,
     build_dependency_unique_key,
     normalize_package_repo_url,
@@ -43,13 +45,6 @@ from .object_fields import (
     reject_unknown_git_fields,
 )
 from .types import VirtualPackageType
-
-# Identity/semver helpers re-exported from .identity for back-compat imports.
-# Default ports per URI scheme -- used to normalise away redundant
-# explicit ports (e.g. https://host:443/...) so that lockfile keys
-# and error messages stay consistent regardless of how the user
-# spelled the URL.
-_DEFAULT_SCHEME_PORTS: dict[str, int] = {"https": 443, "http": 80, "ssh": 22}
 
 _REF_VERSION_SUFFIX_RE = re.compile(r"^v?\d+(?:\.\d+)*(?:[-+][A-Za-z0-9][A-Za-z0-9._-]*)?$")
 
@@ -1523,8 +1518,7 @@ class DependencyReference:
         Validates path components before returning.
 
         Returns:
-            ``(parsed_url, host, port)`` -- *port* is the custom port split off
-            the leading ``host:port`` segment, or ``None``.
+            ``(parsed_url, host, port)`` with any custom shorthand port.
         """
         parts = repo_url.split("/")
 
@@ -1532,20 +1526,7 @@ class DependencyReference:
             git_idx = parts.index("_git")
             parts = parts[:git_idx] + parts[git_idx + 1 :]
 
-        # Accept a custom port on the leading host segment
-        # (``git.example.com:8443/owner/repo``). to_canonical()/get_identity()
-        # emit this form for non-default-port HTTPS deps, so parse() must be
-        # able to read back what APM itself wrote (#2203).
-        port = None
-        if parts and ":" in parts[0]:
-            maybe_host, _, maybe_port = parts[0].rpartition(":")
-            if maybe_host and maybe_port.isdigit() and 1 <= int(maybe_port) <= 65535:
-                parsed_port = int(maybe_port)
-                parts = [maybe_host, *parts[1:]]
-                # Drop a redundant HTTPS default port for canonical consistency
-                # with the URL-form parser (https://host:443 -> port None).
-                if parsed_port != _DEFAULT_SCHEME_PORTS.get("https"):
-                    port = parsed_port
+        parts[0], port = _split_shorthand_host_port(parts[0])
 
         if len(parts) >= 3 and is_supported_git_host(parts[0]):
             host = parts[0]

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -1523,13 +1523,29 @@ class DependencyReference:
         Validates path components before returning.
 
         Returns:
-            ``(parsed_url, host)``
+            ``(parsed_url, host, port)`` -- *port* is the custom port split off
+            the leading ``host:port`` segment, or ``None``.
         """
         parts = repo_url.split("/")
 
         if "_git" in parts:
             git_idx = parts.index("_git")
             parts = parts[:git_idx] + parts[git_idx + 1 :]
+
+        # Accept a custom port on the leading host segment
+        # (``git.example.com:8443/owner/repo``). to_canonical()/get_identity()
+        # emit this form for non-default-port HTTPS deps, so parse() must be
+        # able to read back what APM itself wrote (#2203).
+        port = None
+        if parts and ":" in parts[0]:
+            maybe_host, _, maybe_port = parts[0].rpartition(":")
+            if maybe_host and maybe_port.isdigit() and 1 <= int(maybe_port) <= 65535:
+                parsed_port = int(maybe_port)
+                parts = [maybe_host, *parts[1:]]
+                # Drop a redundant HTTPS default port for canonical consistency
+                # with the URL-form parser (https://host:443 -> port None).
+                if parsed_port != _DEFAULT_SCHEME_PORTS.get("https"):
+                    port = parsed_port
 
         if len(parts) >= 3 and is_supported_git_host(parts[0]):
             host = parts[0]
@@ -1597,7 +1613,7 @@ class DependencyReference:
         github_url = urllib.parse.urljoin(f"https://{host}/", quoted_repo)
         parsed_url = urllib.parse.urlparse(github_url)
 
-        return parsed_url, host
+        return parsed_url, host, port
 
     @classmethod
     def _validate_url_repo_path(cls, parsed_url) -> tuple[str, str | None]:
@@ -1773,7 +1789,7 @@ class DependencyReference:
             if port == _DEFAULT_SCHEME_PORTS.get(scheme):
                 port = None
         else:
-            parsed_url, host = cls._resolve_shorthand_to_parsed_url(repo_url, host)
+            parsed_url, host, port = cls._resolve_shorthand_to_parsed_url(repo_url, host)
 
         repo_url, url_virtual_path = cls._validate_url_repo_path(parsed_url)
 

--- a/tests/integration/test_consume_source_ref_cache_matrix.py
+++ b/tests/integration/test_consume_source_ref_cache_matrix.py
@@ -26,10 +26,12 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import urlparse
 
 import pytest
 
 from apm_cli.core.host_providers import classify_host_provider
+from apm_cli.models.dependency import DependencyReference
 from apm_cli.utils.yaml_io import dump_yaml, load_yaml
 from tests.utils.apm_lifecycle_runner import ApmLifecycleRunner, CommandResult
 from tests.utils.artifact_snapshot import ArtifactSnapshot, assert_unchanged
@@ -89,6 +91,7 @@ class _MatrixRow:
     mode: str = "standard"
     transition_source: str | None = None
     transition_rewrite_urls: tuple[str, ...] = ()
+    expected_port: int | None = None
 
 
 _ROWS = (
@@ -173,6 +176,35 @@ _ROWS = (
         transition_source="git@gitlab.example.invalid:group/consume-matrix.git",
         transition_rewrite_urls=("git@gitlab.example.invalid:group/consume-matrix.git",),
     ),
+    _MatrixRow(
+        id="generic-https-default-port-persistence",
+        source="https://git.example.invalid:443/acme/consume-matrix.git",
+        rewrite_urls=(
+            "https://git.example.invalid:443/acme/consume-matrix.git",
+            "https://git.example.invalid/acme/consume-matrix.git",
+            "https://git.example.invalid/acme/consume-matrix",
+            "git@git.example.invalid:acme/consume-matrix.git",
+        ),
+        expected_host="git.example.invalid",
+        expected_kind="generic",
+        expected_repo="acme/consume-matrix",
+        ref_selector="first-sha",
+        mode="port-persistence",
+    ),
+    _MatrixRow(
+        id="generic-https-custom-port-persistence",
+        source="https://git.example.invalid:8443/acme/consume-matrix.git",
+        rewrite_urls=(
+            "https://git.example.invalid:8443/acme/consume-matrix.git",
+            "https://git.example.invalid:8443/acme/consume-matrix",
+        ),
+        expected_host="git.example.invalid",
+        expected_kind="generic",
+        expected_repo="acme/consume-matrix",
+        ref_selector="second-sha",
+        mode="port-persistence",
+        expected_port=8443,
+    ),
 )
 
 
@@ -205,23 +237,31 @@ def _configure_rewrites(
     urls: tuple[str, ...],
     *,
     environment: dict[str, str],
+    include_home_config: bool = False,
 ) -> None:
+    # Generic-host preflight drops GIT_CONFIG_GLOBAL, while clone keeps it.
+    # Port rows therefore need rewrites in both isolated global locations.
+    home_gitconfig = Path(environment["HOME"]) / ".gitconfig"
     for url in urls:
-        subprocess.run(
-            (
-                "git",
-                "config",
-                "--global",
-                "--add",
-                f"url.{repository.file_url}.insteadOf",
-                url,
-            ),
-            env=environment,
-            capture_output=True,
-            text=True,
-            check=True,
-            timeout=30,
-        )
+        config_locations = [("--global",)]
+        if include_home_config:
+            config_locations.append(("--file", str(home_gitconfig)))
+        for config_args in config_locations:
+            subprocess.run(
+                (
+                    "git",
+                    "config",
+                    *config_args,
+                    "--add",
+                    f"url.{repository.file_url}.insteadOf",
+                    url,
+                ),
+                env=environment,
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=30,
+            )
 
 
 def _reference_for(
@@ -275,15 +315,19 @@ def _create_scenario(root: Path, row: _MatrixRow) -> _Scenario:
         repository,
         (*row.rewrite_urls, *row.transition_rewrite_urls),
         environment=environment,
+        include_home_config=row.mode == "port-persistence",
     )
     reference, expected_commit, expected_skill_bytes = _reference_for(
         row,
         first_commit,
         second_commit,
     )
+    dependencies = (
+        () if row.mode == "port-persistence" else (_manifest_entry(row, row.source, reference),)
+    )
     consumer = LocalPackageFactory(isolated.work_root).create(
         f"consumer-{row.id}",
-        dependencies=(_manifest_entry(row, row.source, reference),),
+        dependencies=dependencies,
         targets=("copilot",),
     )
     return _Scenario(
@@ -594,3 +638,107 @@ def test_source_ref_transition_applies_once_and_invalid_twin_preserves_state(
     assert (scenario.project_root / "apm.lock.yaml").read_bytes() == lock_bytes
     assert (scenario.project_root / _SKILL_PATH).read_bytes() == deployed_bytes
     record_property("scenario_seconds", round(time.monotonic() - started, 3))
+
+
+@pytest.mark.parametrize(
+    "row",
+    tuple(row for row in _ROWS if row.mode == "port-persistence"),
+    ids=lambda row: row.id,
+)
+def test_cli_manifest_port_rows_reparse_to_backend_url(
+    tmp_path: Path,
+    apm_binary_path: Path,
+    record_property: Callable[[str, object], None],
+    row: _MatrixRow,
+) -> None:
+    """Public install writes a shorthand that re-parses to the same backend."""
+    started = time.monotonic()
+    scenario = _create_scenario(tmp_path / row.id, row)
+    source_with_ref = f"{row.source}#{scenario.initial_ref}"
+    first_install = _runner(apm_binary_path).run(
+        (*_INSTALL_ARGS, source_with_ref),
+        scenario_id=f"{row.id}-public-install",
+        cwd=scenario.project_root,
+        env=scenario.environment,
+    )
+    _assert_success(first_install)
+    _assert_deployment(
+        scenario,
+        expected_skill_bytes=scenario.expected_skill_bytes,
+    )
+
+    persisted = load_yaml(scenario.project_root / "apm.yml")["dependencies"]["apm"]
+    assert len(persisted) == 1
+    assert isinstance(persisted[0], str)
+    reparsed = DependencyReference.parse(persisted[0])
+    backend_url = urlparse(reparsed.to_clone_url())
+    assert (
+        backend_url.scheme,
+        backend_url.hostname,
+        backend_url.port,
+        backend_url.path,
+    ) == ("https", row.expected_host, row.expected_port, f"/{row.expected_repo}")
+    assert reparsed.reference == scenario.initial_ref
+
+    manifest_reparse = _runner(apm_binary_path).run(
+        _INSTALL_ARGS,
+        scenario_id=f"{row.id}-manifest-reparse",
+        cwd=scenario.project_root,
+        env=scenario.environment,
+    )
+    _assert_success(manifest_reparse)
+    locked = _locked_dependency(scenario.project_root)
+    assert locked["host"] == row.expected_host
+    assert locked["repo_url"] == row.expected_repo
+    assert locked.get("port") == row.expected_port
+    assert locked["resolved_ref"] == scenario.initial_ref
+    assert locked["resolved_commit"] == scenario.expected_commit.sha
+    assert _manifest_dependency(scenario.project_root) == persisted[0]
+    record_property("scenario_seconds", round(time.monotonic() - started, 3))
+
+
+def test_cli_custom_port_negative_twins_preserve_last_good_state(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Malformed and insecure twins fail without changing installed state."""
+    row = next(row for row in _ROWS if row.id == "generic-https-custom-port-persistence")
+    scenario = _create_scenario(tmp_path / row.id, row)
+    source_with_ref = f"{row.source}#{scenario.initial_ref}"
+    installed = _runner(apm_binary_path).run(
+        (*_INSTALL_ARGS, source_with_ref),
+        scenario_id=f"{row.id}-seed-last-good",
+        cwd=scenario.project_root,
+        env=scenario.environment,
+    )
+    _assert_success(installed)
+
+    invalid_sources = (
+        (
+            "malformed-port",
+            f"https://git.example.invalid:70000/acme/consume-matrix.git#{scenario.initial_ref}",
+            "Port out of range",
+        ),
+        (
+            "malformed-shorthand-port",
+            f"git.example.invalid:70000/acme/consume-matrix#{scenario.initial_ref}",
+            "Invalid shorthand port",
+        ),
+        (
+            "insecure-transport",
+            f"http://git.example.invalid:8080/acme/consume-matrix.git#{scenario.initial_ref}",
+            "--allow-insecure",
+        ),
+    )
+    for scenario_suffix, invalid_source, expected_message in invalid_sources:
+        last_good = ArtifactSnapshot.capture(scenario.project_root)
+        invalid = _runner(apm_binary_path).run(
+            (*_INSTALL_ARGS, invalid_source),
+            scenario_id=f"{row.id}-{scenario_suffix}",
+            cwd=scenario.project_root,
+            env=scenario.environment,
+        )
+        assert invalid.returncode == 1
+        output = " ".join((invalid.stdout + invalid.stderr).split())
+        assert expected_message in output
+        assert_unchanged(last_good, ArtifactSnapshot.capture(scenario.project_root))

--- a/tests/unit/test_canonicalization.py
+++ b/tests/unit/test_canonicalization.py
@@ -811,7 +811,7 @@ class TestHttpInsecureDeps:
         assert http_dep.get_identity() == https_dep.get_identity()
 
 
-# ── HTTPS custom-port shorthand round-trip (#2203) ───────────────────────────
+# HTTPS custom-port shorthand round-trip (#2203)
 
 
 class TestHttpsCustomPortShorthand:
@@ -831,13 +831,20 @@ class TestHttpsCustomPortShorthand:
         assert dep.repo_url == "owner/repo"
 
     def test_apm_yml_entry_round_trips(self):
-        """parse -> to_apm_yml_entry -> parse preserves host and port (#2203)."""
+        """Manifest write/reparse preserves the backend HTTPS URL (#2203)."""
         dep = DependencyReference.parse("https://git.example.com:8443/owner/repo")
         entry = dep.to_apm_yml_entry()
         assert entry == "git.example.com:8443/owner/repo"
         reparsed = DependencyReference.parse(entry)
         assert reparsed.host == "git.example.com"
         assert reparsed.port == 8443
+        backend_url = urlparse(reparsed.to_clone_url())
+        assert (
+            backend_url.scheme,
+            backend_url.hostname,
+            backend_url.port,
+            backend_url.path,
+        ) == ("https", "git.example.com", 8443, "/owner/repo")
         # Serialization is idempotent: what APM writes, it can read and rewrite.
         assert reparsed.to_canonical() == entry
 
@@ -860,6 +867,18 @@ class TestHttpsCustomPortShorthand:
         dep = DependencyReference.parse("git.example.com:443/owner/repo")
         assert dep.port is None
         assert dep.to_canonical() == "git.example.com/owner/repo"
+        backend_url = urlparse(dep.to_clone_url())
+        assert (backend_url.scheme, backend_url.hostname, backend_url.port) == (
+            "https",
+            "git.example.com",
+            None,
+        )
+
+    @pytest.mark.parametrize("port", ["", "0", "65536", "not-a-port"])
+    def test_malformed_shorthand_port_is_rejected(self, port):
+        """Malformed ports cannot be reinterpreted as a different dependency."""
+        with pytest.raises(ValueError, match=r"Invalid shorthand port"):
+            DependencyReference.parse(f"git.example.com:{port}/owner/repo")
 
     def test_plain_shorthand_has_no_port(self):
         """Portless shorthand is unaffected by the port-splitting branch."""

--- a/tests/unit/test_canonicalization.py
+++ b/tests/unit/test_canonicalization.py
@@ -809,3 +809,59 @@ class TestHttpInsecureDeps:
         https_dep = DependencyReference.parse("https://gitlab.com/owner/repo.git")
         # Identity includes host but not scheme, so they are the same package
         assert http_dep.get_identity() == https_dep.get_identity()
+
+
+# ── HTTPS custom-port shorthand round-trip (#2203) ───────────────────────────
+
+
+class TestHttpsCustomPortShorthand:
+    """The apm.yml entry APM writes for a custom-port HTTPS dep must re-parse.
+
+    to_canonical()/get_identity() emit the scheme-free ``host:port/owner/repo``
+    form for a non-default-port HTTPS dependency. Before the fix the shorthand
+    parser rejected that form, so any command re-reading apm.yml failed on an
+    entry APM itself wrote.
+    """
+
+    def test_shorthand_with_custom_port_parses(self):
+        """Bare ``host:port/owner/repo`` restores host and port."""
+        dep = DependencyReference.parse("git.example.com:8443/owner/repo")
+        assert dep.host == "git.example.com"
+        assert dep.port == 8443
+        assert dep.repo_url == "owner/repo"
+
+    def test_apm_yml_entry_round_trips(self):
+        """parse -> to_apm_yml_entry -> parse preserves host and port (#2203)."""
+        dep = DependencyReference.parse("https://git.example.com:8443/owner/repo")
+        entry = dep.to_apm_yml_entry()
+        assert entry == "git.example.com:8443/owner/repo"
+        reparsed = DependencyReference.parse(entry)
+        assert reparsed.host == "git.example.com"
+        assert reparsed.port == 8443
+        # Serialization is idempotent: what APM writes, it can read and rewrite.
+        assert reparsed.to_canonical() == entry
+
+    def test_identity_round_trips(self):
+        """get_identity() (uninstall/dedup key) also re-parses with its port."""
+        dep = DependencyReference.parse("https://git.example.com:8443/owner/repo")
+        reparsed = DependencyReference.parse(dep.get_identity())
+        assert reparsed.port == 8443
+        assert reparsed.get_identity() == dep.get_identity()
+
+    def test_shorthand_with_ref_and_custom_port(self):
+        """A trailing ``#ref`` still parses alongside a custom port."""
+        dep = DependencyReference.parse("git.example.com:8443/owner/repo#v1.0")
+        assert dep.host == "git.example.com"
+        assert dep.port == 8443
+        assert dep.reference == "v1.0"
+
+    def test_redundant_https_default_port_is_normalized(self):
+        """``host:443`` normalizes to no port, matching the URL-form parser."""
+        dep = DependencyReference.parse("git.example.com:443/owner/repo")
+        assert dep.port is None
+        assert dep.to_canonical() == "git.example.com/owner/repo"
+
+    def test_plain_shorthand_has_no_port(self):
+        """Portless shorthand is unaffected by the port-splitting branch."""
+        assert DependencyReference.parse("owner/repo").port is None
+        assert DependencyReference.parse("github.com/owner/repo").port is None

--- a/tests/unit/test_canonicalization.py
+++ b/tests/unit/test_canonicalization.py
@@ -880,6 +880,18 @@ class TestHttpsCustomPortShorthand:
         with pytest.raises(ValueError, match=r"Invalid shorthand port"):
             DependencyReference.parse(f"git.example.com:{port}/owner/repo")
 
+    def test_non_ascii_shorthand_port_error_is_printable_ascii(self):
+        """Untrusted port text cannot escape into the rendered parser error."""
+        with pytest.raises(ValueError) as exc_info:
+            DependencyReference.parse("git.example.com:\U0001f680/owner/repo")
+
+        message = str(exc_info.value)
+        assert (message, message.isascii(), message.isprintable()) == (
+            "Invalid shorthand port. Expected an integer from 1 to 65535",
+            True,
+            True,
+        )
+
     def test_plain_shorthand_has_no_port(self):
         """Portless shorthand is unaffected by the port-splitting branch."""
         assert DependencyReference.parse("owner/repo").port is None


### PR DESCRIPTION
# fix(deps): accept HTTPS custom-port shorthand on manifest reparse

## TL;DR

Installing an HTTPS Git dependency on a custom port succeeded, but APM wrote
`host:port/owner/repo` to `apm.yml` and then rejected that same entry on the
next read. This extends the existing `DependencyReference` parser authority,
proves the complete CLI write/reparse/backend contract, and documents the
persisted form without changing HTTP behavior already fixed by #2210. Malformed
non-ASCII port text is rejected without being echoed into CLI-visible errors.

> [!NOTE]
> Fixes #2203. The contributor's original commit remains authored by
> @atulya-singh; the maintainer fold-in is a separate commit.

## Problem (WHY)

- [x] `apm install https://git.example.com:8443/owner/repo` preserved port
  `8443`, but serialized the dependency as `git.example.com:8443/owner/repo`.
- [x] `_resolve_shorthand_to_parsed_url()` treated the leading `host:port`
  segment as neither a supported host nor bare `owner/repo`, so later install,
  update, resolve, or uninstall reads failed on APM's own output.
- [x] The parser and serializer disagreed on the canonical grammar described in
  [issue #2203](https://github.com/microsoft/apm/issues/2203).
- [x] A malformed non-ASCII shorthand port was interpolated into a `ValueError`
  that can reach CLI output, violating
  ["All source code files and CLI output strings must stay within **printable ASCII** (U+0020–U+007E)."](https://github.com/microsoft/apm/blob/33e1006d4078002893dc9e87ca489f4935e9386a/.github/instructions/encoding.instructions.md#L8-L18)
- [!] Without a lifecycle contract, a unit-only fix could preserve parsing while
  still dropping the port before backend URL or lockfile construction.

Why these matter: APM's architecture requires
["Every durable decision, vocabulary, outcome, write, or contract has exactly ONE canonical owner."](https://github.com/microsoft/apm/blob/33e1006d4078002893dc9e87ca489f4935e9386a/.github/instructions/architecture.instructions.md#L15-L19)
The change therefore extends `DependencyReference` instead of adding another
host/port parser. The documentation follows
["Add what the agent lacks, omit what it knows"](https://agentskills.io/skill-creation/best-practices)
by explaining only the non-obvious APM-written shorthand.

## Approach (WHAT)

| # | Fix |
|---|---|
| 1 | Split and validate an optional port from the leading shorthand host segment, bounded to ASCII digits and `1..65535`. |
| 2 | Normalize shorthand `:443` exactly like `https://host:443`; preserve custom ports such as `:8443`. |
| 3 | Route the parsed port through `DependencyReference` to manifest identity, clone URL, and structured lock state. |
| 4 | Extend the existing source/ref/cache critical contract with standard/custom rows and malformed/insecure last-good-state twins. |
| 5 | Align the manifest reference, consumer guide, and bundled APM usage guidance with the implemented grammar. |
| 6 | Keep malformed-port errors actionable and printable without echoing untrusted port text. |

## Implementation (HOW)

| File | Change |
|---|---|
| `src/apm_cli/models/dependency/reference.py` | Keeps shorthand grammar ownership in `_resolve_shorthand_to_parsed_url()` and threads its port result through the existing parse path. |
| `src/apm_cli/models/dependency/identity.py` | Holds the private, one-caller bounded host-segment validator and emits a constant printable-ASCII malformed-port error without exposing raw input. |
| `tests/unit/test_canonicalization.py` | Covers custom/default ports, refs, malformed values, manifest and identity round trips, parsed backend URL components, and printable malformed-input errors. |
| `tests/integration/test_consume_source_ref_cache_matrix.py` | Adds `:443` and `:8443` public CLI rows plus malformed URL, malformed shorthand, insecure transport, and last-good-state assertions. |
| `docs/src/content/docs/reference/manifest-schema.md` | Adds `[":" port]` to shorthand ABNF and documents HTTPS-only shorthand normalization. |
| `docs/src/content/docs/consumer/private-and-org-packages.md` | Recommends explicit HTTPS input while explaining the scheme-free form APM writes and rereads. |
| `packages/apm-guide/.apm/skills/apm-usage/dependencies.md` | Aligns custom-port and manifest-versus-lockfile identity guidance. |

## Diagrams

Legend: follow the value from explicit user input through the new shorthand
parse stage to the same HTTPS backend endpoint.

```mermaid
flowchart LR
    subgraph Input[Public CLI input]
        I1["https://git.example.com:8443/owner/repo"]
    end
    subgraph Write[Manifest write]
        W1["git.example.com:8443/owner/repo"]
    end
    subgraph Parse[DependencyReference parse]
        P1["split host and bounded port"]:::new
        P2["normalize port 443"]
    end
    subgraph Resolve[Backend state]
        R1["https://git.example.com:8443/owner/repo"]
        R2["lockfile port: 8443"]
    end
    I1 --> W1
    W1 --> P1
    P1 --> P2
    P2 --> R1
    P2 --> R2
    classDef new stroke-dasharray: 5 5;
    class P1 new;
```

## Trade-offs

- **Keep one parser owner.** Chose a private scalar validator called only by
  `DependencyReference`; rejected a second host/port parser or transport branch.
- **No new static architecture check.** This is an owner extension, not a new
  owner or split-authority repair; behavioral regression and mutation evidence
  are sufficient for this classification.
- **Reuse the existing critical surface.** Added rows to the declared
  source/ref/cache matrix; rejected a standalone `critical_suite.toml` row and
  duplicate HTTP coverage.
- **Prefer explicit authored input.** Full HTTPS URLs remain the documented
  recommendation; scheme-free shorthand is documented because APM writes it.
- **Do not echo malformed input.** Chose one constant actionable error; rejected
  sanitizing or repeating the raw port because untrusted non-ASCII text must not
  reach CLI output.

## Benefits

1. A custom port survives `apm install` -> `apm.yml` -> reparse -> HTTPS clone
   URL with the same host, port, path, and ref.
2. Both standard HTTPS port `443` and custom port `8443` have real-binary
   lifecycle rows.
3. Three failure variants preserve the last-good project snapshot: malformed
   URL port, malformed shorthand port, and insecure HTTP transport.
4. Removing custom-port preservation makes the regression trap fail with
   `assert None == 8443`.
5. Restoring the raw malformed-port echo makes the printable-output regression
   fail with `message.isascii() == False`.

## Validation

`uv run --extra dev ruff check src/ tests/` and
`uv run --extra dev ruff format --check src/ tests/`:

```text
All checks passed!
1527 files already formatted
```

Relevant unit and real-binary lifecycle tests, excluding the two proven
clean-main ADO failures:

```text
........................................................................ [ 65%]
......................................                                   [100%]
110 passed, 2 deselected in 45.02s
```

Test-quality contracts:

```text
25 passed in 18.89s
[+] assertion-quality ratchet clean: AQ001=5, AQ002=12
[+] exact test duplicate ratchet clean: 1046 files, 8 allowed duplicate group(s)
```

`uv run apm audit --ci`:

```text
[*] All 9 check(s) passed
```

Exact-head hosted workflows:

```text
33e1006d4078002893dc9e87ca489f4935e9386a
CI, CodeQL, Merge Gate, Spec conformance, NOTICE Drift Check, Deploy Docs: success
```

Mutation break:

```text
E       AssertionError: assert None == 8443
1 failed in 1.47s
E       assert ("Invalid shorthand port '🚀'...", False, True) == (..., True, True)
1 failed in 0.51s
```

Both guards were restored before the green runs above.

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|---|---|---|---|
| 1 | Installing an HTTPS dependency on port 8443 writes a manifest entry that the next install resolves to the same endpoint | Portability by manifest, Vendor-neutral, DevX | `tests/integration/test_consume_source_ref_cache_matrix.py::test_cli_manifest_port_rows_reparse_to_backend_url[generic-https-custom-port-persistence]` (regression-trap for #2203) | e2e |
| 2 | Explicit HTTPS port 443 normalizes without changing the backend endpoint | Portability by manifest, Governed by policy | `tests/integration/test_consume_source_ref_cache_matrix.py::test_cli_manifest_port_rows_reparse_to_backend_url[generic-https-default-port-persistence]` | e2e |
| 3 | Malformed custom ports and insecure HTTP fail without changing installed files or lock state | Secure by default, DevX | `tests/integration/test_consume_source_ref_cache_matrix.py::test_cli_custom_port_negative_twins_preserve_last_good_state` | e2e |
| 4 | APM-written custom-port shorthand reparses to an HTTPS URL with the original host, port, and path | Portability by manifest, Vendor-neutral | `tests/unit/test_canonicalization.py::TestHttpsCustomPortShorthand::test_apm_yml_entry_round_trips` (regression-trap for #2203) | unit |
| 5 | A malformed non-ASCII shorthand port fails with an actionable error that any supported terminal can print | Secure by default, DevX | `tests/unit/test_canonicalization.py::TestHttpsCustomPortShorthand::test_non_ascii_shorthand_port_error_is_printable_ascii` (regression-trap for coordinator review) | unit |

## How to test

- [ ] Run `uv run pytest tests/unit/test_canonicalization.py::TestHttpsCustomPortShorthand -q`; expect 11 passing cases.
- [ ] Set `APM_BINARY_PATH` to the built CLI and run the two `port-persistence` matrix rows; expect both manifest reparses to preserve backend URL components.
- [ ] Run `test_cli_custom_port_negative_twins_preserve_last_good_state`; expect all malformed/insecure commands to return 1 and leave the snapshot unchanged.
- [ ] Run the canonical lint chain plus `bash scripts/lint-architecture-boundaries.sh`; expect exit 0.
- [ ] Run `uv run apm audit --ci`; expect all nine checks to pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>