### PR TITLE
test(consume): add real lifecycle contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `apm update` now converges for git-source semver dependencies already at
   their locked tag instead of reporting a spurious update on every run. Branch
   dependencies remain unaffected. (by @srobroek, #2165)
+- `apm update` now resolves branch tips before rendering the plan, so unchanged branches converge without repeated installs while real tip advances remain visible. (#2212)
 - `apm audit` no longer reports drift for skills intentionally excluded by a
   dependency's `skills:` subset filter. (#2177)
 - `apm update` now re-checks a transitive dependency's own semver range

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `apm pack` now matches source-relative skill selectors such as
   `productivity/grill-me` against flattened deployed skill names. (closes
   #2171; #2176)
-- `apm update` now converges for git-source semver dependencies already at
-  their locked tag instead of reporting a spurious update on every run. Branch
-  dependencies remain unaffected. (by @srobroek, #2165)
-- `apm update` now resolves branch tips before rendering the plan, so unchanged branches converge without repeated installs while real tip advances remain visible. (#2212)
+- `apm update` now converges for unchanged Git dependencies: semver dependencies already at their locked tag no longer report spurious updates (by @srobroek, #2165), and branch dependencies at the same tip no longer produce a plan or reinstall while real tip advances remain visible (#2212).
 - `apm audit` no longer reports drift for skills intentionally excluded by a
   dependency's `skills:` subset filter. (#2177)
 - `apm update` now re-checks a transitive dependency's own semver range

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -260,10 +260,10 @@ if ! echo "$run_replay_body" | grep -q 'integrate_package_primitives(' \
     violations=$((violations + 1))
 fi
 update_plan_ref_body=$(awk '
-    /^def _annotate_update_plan_refs\(/ {flag=1}
-    flag && /^def / && !/_annotate_update_plan_refs/ {exit}
+    /^def annotate_update_plan_refs\(/ {flag=1}
+    flag && /^def / && !/annotate_update_plan_refs/ {exit}
     flag {print}
-' src/apm_cli/install/phases/resolve.py)
+' src/apm_cli/install/helpers/ref_reuse.py)
 if ! echo "$update_plan_ref_body" | grep -q 'downloader\.resolve_git_reference(dep_ref)' \
     || ! echo "$update_plan_ref_body" | grep -q 'dep_ref\.resolved_reference = resolved'; then
     echo "[x] Cached update planning must resolve refs through the downloader owner"

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -259,6 +259,16 @@ if ! echo "$run_replay_body" | grep -q 'integrate_package_primitives(' \
     echo "[x] Audit replay must preserve locked skill subset intent"
     violations=$((violations + 1))
 fi
+update_plan_ref_body=$(awk '
+    /^def _annotate_update_plan_refs\(/ {flag=1}
+    flag && /^def / && !/_annotate_update_plan_refs/ {exit}
+    flag {print}
+' src/apm_cli/install/phases/resolve.py)
+if ! echo "$update_plan_ref_body" | grep -q 'downloader\.resolve_git_reference(dep_ref)' \
+    || ! echo "$update_plan_ref_body" | grep -q 'dep_ref\.resolved_reference = resolved'; then
+    echo "[x] Cached update planning must resolve refs through the downloader owner"
+    violations=$((violations + 1))
+fi
 dependency_field_owner="src/apm_cli/models/dependency/object_fields.py"
 dependency_parser="src/apm_cli/models/dependency/reference.py"
 dependency_field_duplicate_hits=$(

--- a/src/apm_cli/install/helpers/ref_reuse.py
+++ b/src/apm_cli/install/helpers/ref_reuse.py
@@ -1,4 +1,4 @@
-"""Run-scoped RefResolver reuse for semver resolution.
+"""Run-scoped Git reference resolution helpers.
 
 Extracted from :mod:`apm_cli.install.phases.resolve` to keep that phase
 module within its LOC budget (see
@@ -12,7 +12,11 @@ once per repo instead of once per dep.
 from __future__ import annotations
 
 import hashlib
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from apm_cli.deps.github_downloader import GitHubPackageDownloader
+    from apm_cli.models.dependency.reference import DependencyReference
 
 
 def _token_fingerprint(token: str | None) -> str | None:
@@ -117,3 +121,25 @@ def get_shared_ref_resolver(
         resolver = RefResolver(**resolver_kwargs)
         cache[key] = resolver
     return resolver
+
+
+def annotate_update_plan_refs(
+    deps_to_install: list[DependencyReference],
+    downloader: GitHubPackageDownloader,
+    *,
+    update_refs: bool,
+) -> list[DependencyReference]:
+    """Resolve Git refs needed by the update plan through the downloader owner."""
+    if not update_refs:
+        return deps_to_install
+    for dep_ref in deps_to_install:
+        if (
+            getattr(dep_ref, "resolved_reference", None) is not None
+            or dep_ref.is_local
+            or getattr(dep_ref, "source", None) == "registry"
+            or getattr(dep_ref, "artifactory_prefix", None)
+        ):
+            continue
+        resolved = downloader.resolve_git_reference(dep_ref)
+        dep_ref.resolved_reference = resolved
+    return deps_to_install

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import builtins
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from apm_cli.install.helpers.ref_seed import seed_ref_resolver_from_lockfile
 from apm_cli.install.transaction import resolution_for_context
@@ -368,6 +368,28 @@ def _annotate_registry_dep_ref(dep_ref, registry_resolver) -> None:
     )
 
 
+def _annotate_update_plan_refs(
+    deps_to_install: list[DependencyReference],
+    downloader: Any,
+    *,
+    update_refs: bool,
+) -> list[DependencyReference]:
+    """Resolve Git refs needed by the update plan through the downloader owner."""
+    if not update_refs:
+        return deps_to_install
+    for dep_ref in deps_to_install:
+        if (
+            getattr(dep_ref, "resolved_reference", None) is not None
+            or dep_ref.is_local
+            or getattr(dep_ref, "source", None) == "registry"
+            or getattr(dep_ref, "artifactory_prefix", None)
+        ):
+            continue
+        resolved = downloader.resolve_git_reference(dep_ref)
+        dep_ref.resolved_reference = resolved
+    return deps_to_install
+
+
 def _fail_on_resolution_errors(ctx: InstallContext, dependency_graph) -> None:
     """Raise when the resolver recorded fatal dependency-resolution errors."""
     if not dependency_graph.resolution_errors:
@@ -480,16 +502,9 @@ def _resolve_dependencies(ctx: InstallContext, staging_session: ResolutionStagin
         """
         install_path = dep_ref.get_install_path(modules_dir)
         # Cache short-circuit: skip the rest of the callback when the
-        # install path already exists. Exception: for git-source semver
-        # deps under ``--update`` / ``--refresh`` (``update_refs=True``),
-        # fall through so ``_maybe_resolve_git_semver`` re-runs
-        # ``git ls-remote`` and the lockfile gets rewritten with the
-        # latest matching tag. Matches npm/cargo/bundler: ``--update``
-        # is the explicit re-resolve trigger and must not be swallowed
-        # by the on-disk cache (Bug 1 fix on #1496). The downstream
-        # ``downloader.download_package`` rmtrees and re-clones the
-        # install path when the resolved tag changes, so refetching is
-        # safe.
+        # install path already exists. Git semver deps under update still
+        # fall through to ``_maybe_resolve_git_semver`` and the full
+        # download callback.
         if install_path.exists():
             _force_semver_resolve = (
                 update_refs
@@ -691,6 +706,7 @@ def _resolve_dependencies(ctx: InstallContext, staging_session: ResolutionStagin
             # Capture resolved commit SHA for lockfile
             resolved_sha = None
             if result and hasattr(result, "resolved_reference") and result.resolved_reference:
+                dep_ref.resolved_reference = result.resolved_reference
                 resolved_sha = result.resolved_reference.resolved_commit
             callback_downloaded_value = resolved_sha
             with callback_lock:
@@ -846,7 +862,11 @@ def _resolve_dependencies(ctx: InstallContext, staging_session: ResolutionStagin
         allow_insecure_hosts=ctx.allow_insecure_hosts,
     )
 
-    ctx.deps_to_install = deps_to_install
+    ctx.deps_to_install = _annotate_update_plan_refs(
+        deps_to_install,
+        downloader,
+        update_refs=update_refs,
+    )
 
     # ------------------------------------------------------------------
     # 7.5 Build dep_key -> parent source_path map for transitive locals

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import builtins
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from apm_cli.install.helpers.ref_seed import seed_ref_resolver_from_lockfile
 from apm_cli.install.transaction import resolution_for_context
@@ -29,6 +29,7 @@ from apm_cli.models.apm_package import GitReferenceType, ResolvedReference
 from apm_cli.utils.short_sha import format_short_sha
 
 if TYPE_CHECKING:
+    from apm_cli.deps.github_downloader import GitHubPackageDownloader
     from apm_cli.install.context import InstallContext
     from apm_cli.install.resolution_staging import ResolutionStagingSession
     from apm_cli.models.dependency.reference import DependencyReference
@@ -370,7 +371,7 @@ def _annotate_registry_dep_ref(dep_ref, registry_resolver) -> None:
 
 def _annotate_update_plan_refs(
     deps_to_install: list[DependencyReference],
-    downloader: Any,
+    downloader: GitHubPackageDownloader,
     *,
     update_refs: bool,
 ) -> list[DependencyReference]:
@@ -706,6 +707,9 @@ def _resolve_dependencies(ctx: InstallContext, staging_session: ResolutionStagin
             # Capture resolved commit SHA for lockfile
             resolved_sha = None
             if result and hasattr(result, "resolved_reference") and result.resolved_reference:
+                # Pre-plan resolution may have populated this carrier already.
+                # The download result wins so lock state stays tied to the
+                # materialized bytes; the tiered resolver makes re-resolution cheap.
                 dep_ref.resolved_reference = result.resolved_reference
                 resolved_sha = result.resolved_reference.resolved_commit
             callback_downloaded_value = resolved_sha

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -23,13 +23,13 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from apm_cli.install.helpers.ref_reuse import annotate_update_plan_refs
 from apm_cli.install.helpers.ref_seed import seed_ref_resolver_from_lockfile
 from apm_cli.install.transaction import resolution_for_context
 from apm_cli.models.apm_package import GitReferenceType, ResolvedReference
 from apm_cli.utils.short_sha import format_short_sha
 
 if TYPE_CHECKING:
-    from apm_cli.deps.github_downloader import GitHubPackageDownloader
     from apm_cli.install.context import InstallContext
     from apm_cli.install.resolution_staging import ResolutionStagingSession
     from apm_cli.models.dependency.reference import DependencyReference
@@ -369,28 +369,6 @@ def _annotate_registry_dep_ref(dep_ref, registry_resolver) -> None:
     )
 
 
-def _annotate_update_plan_refs(
-    deps_to_install: list[DependencyReference],
-    downloader: GitHubPackageDownloader,
-    *,
-    update_refs: bool,
-) -> list[DependencyReference]:
-    """Resolve Git refs needed by the update plan through the downloader owner."""
-    if not update_refs:
-        return deps_to_install
-    for dep_ref in deps_to_install:
-        if (
-            getattr(dep_ref, "resolved_reference", None) is not None
-            or dep_ref.is_local
-            or getattr(dep_ref, "source", None) == "registry"
-            or getattr(dep_ref, "artifactory_prefix", None)
-        ):
-            continue
-        resolved = downloader.resolve_git_reference(dep_ref)
-        dep_ref.resolved_reference = resolved
-    return deps_to_install
-
-
 def _fail_on_resolution_errors(ctx: InstallContext, dependency_graph) -> None:
     """Raise when the resolver recorded fatal dependency-resolution errors."""
     if not dependency_graph.resolution_errors:
@@ -707,9 +685,7 @@ def _resolve_dependencies(ctx: InstallContext, staging_session: ResolutionStagin
             # Capture resolved commit SHA for lockfile
             resolved_sha = None
             if result and hasattr(result, "resolved_reference") and result.resolved_reference:
-                # Pre-plan resolution may have populated this carrier already.
-                # The download result wins so lock state stays tied to the
-                # materialized bytes; the tiered resolver makes re-resolution cheap.
+                # Download wins over cached pre-plan state; tiered re-resolution is cheap.
                 dep_ref.resolved_reference = result.resolved_reference
                 resolved_sha = result.resolved_reference.resolved_commit
             callback_downloaded_value = resolved_sha
@@ -866,7 +842,7 @@ def _resolve_dependencies(ctx: InstallContext, staging_session: ResolutionStagin
         allow_insecure_hosts=ctx.allow_insecure_hosts,
     )
 
-    ctx.deps_to_install = _annotate_update_plan_refs(
+    ctx.deps_to_install = annotate_update_plan_refs(
         deps_to_install,
         downloader,
         update_refs=update_refs,

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -332,6 +332,16 @@ def test_skill_subset_filtering_has_one_canonical_owner() -> None:
     assert "def _skill_subset_name_filter" not in integrator
 
 
+def test_cached_update_resolution_stays_with_downloader_owner() -> None:
+    """Cached branch planning must reuse the production ref resolver."""
+    root = Path(__file__).parents[2]
+    resolve = (root / "src/apm_cli/install/phases/resolve.py").read_text()
+    guard = (root / "scripts/lint-architecture-boundaries.sh").read_text()
+
+    assert "resolved = downloader.resolve_git_reference(dep_ref)" in resolve
+    assert "Cached update planning must resolve refs through the downloader owner" in guard
+
+
 def test_skill_subset_ast_checker_is_wired_into_the_boundary_guard() -> None:
     """The Bash guard must invoke the semantic AST checker, not only grep.
 

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -335,10 +335,10 @@ def test_skill_subset_filtering_has_one_canonical_owner() -> None:
 def test_cached_update_resolution_stays_with_downloader_owner() -> None:
     """Cached branch planning must reuse the production ref resolver."""
     root = Path(__file__).parents[2]
-    resolve = (root / "src/apm_cli/install/phases/resolve.py").read_text()
+    ref_reuse = (root / "src/apm_cli/install/helpers/ref_reuse.py").read_text()
     guard = (root / "scripts/lint-architecture-boundaries.sh").read_text()
 
-    assert "resolved = downloader.resolve_git_reference(dep_ref)" in resolve
+    assert "resolved = downloader.resolve_git_reference(dep_ref)" in ref_reuse
     assert "Cached update planning must resolve refs through the downloader owner" in guard
 
 

--- a/tests/integration/test_real_consume_contracts.py
+++ b/tests/integration/test_real_consume_contracts.py
@@ -1,0 +1,353 @@
+"""Real command contracts for the Consume lifecycle promise."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from apm_cli.utils.yaml_io import load_yaml
+from tests.utils.apm_lifecycle_runner import ApmLifecycleRunner, CommandResult
+from tests.utils.artifact_snapshot import (
+    ArtifactSnapshot,
+    assert_paths_absent,
+    assert_paths_present,
+    assert_unchanged,
+)
+from tests.utils.isolated_apm_environment import IsolatedApmEnvironment
+from tests.utils.local_git_repository import (
+    GitCommit,
+    LocalGitRepository,
+    LocalGitRepositoryFactory,
+)
+from tests.utils.local_package import LocalPackageFactory
+from tests.utils.scenario_rows import LifecycleAction, ScenarioObservation, ScenarioRow
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.requires_apm_binary,
+]
+
+_AUDIT_ARGS = ("audit", "--ci", "--no-policy", "--format", "json")
+
+
+@dataclass(frozen=True)
+class _GitConsumerFixture:
+    """Real package, repository, and consumer state for one scenario."""
+
+    isolated: IsolatedApmEnvironment
+    environment: dict[str, str]
+    repositories: LocalGitRepositoryFactory
+    repository: LocalGitRepository
+    initial_commit: GitCommit
+    git_source: str
+    project_root: Path
+
+
+def _skill_document(name: str, marker: str) -> str:
+    """Return one valid skill document with observable content."""
+    return f"---\nname: {name}\ndescription: Consume contract skill {name}\n---\n# {marker}\n"
+
+
+def _configure_local_source_rewrite(
+    git_source: str,
+    repository: LocalGitRepository,
+    *,
+    environment: dict[str, str],
+) -> None:
+    """Route one production-shaped source through the local bare origin."""
+    subprocess.run(
+        (
+            "git",
+            "config",
+            "--global",
+            f"url.{repository.file_url}.insteadOf",
+            git_source,
+        ),
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+
+
+def _create_git_consumer(
+    root: Path,
+    *,
+    git_source: str,
+    declare_dependency: bool = True,
+) -> _GitConsumerFixture:
+    """Create a three-skill package and consumer backed by real local Git."""
+    isolated = IsolatedApmEnvironment.create(root, base_env=dict(os.environ))
+    environment = isolated.subprocess_env()
+    package_factory = LocalPackageFactory(isolated.package_root)
+    bundle = package_factory.create("consume-bundle", targets=("copilot",))
+    for skill in ("alpha", "beta", "gamma"):
+        package_factory.add_skill(
+            bundle,
+            skill,
+            _skill_document(skill, f"{skill} version one"),
+        )
+
+    repositories = LocalGitRepositoryFactory(
+        isolated.repository_root,
+        env=environment,
+    )
+    repository = repositories.create("consume-bundle", source_tree=bundle.root)
+    initial_commit = repositories.commit(repository, message="seed consume bundle")
+    _configure_local_source_rewrite(
+        git_source,
+        repository,
+        environment=environment,
+    )
+
+    consumer = LocalPackageFactory(isolated.work_root).create(
+        "consume-project",
+        dependencies=(
+            (
+                {
+                    "git": git_source,
+                    "type": "gitlab",
+                    "ref": "main",
+                },
+            )
+            if declare_dependency
+            else ()
+        ),
+        targets=("copilot",),
+    )
+    return _GitConsumerFixture(
+        isolated=isolated,
+        environment=environment,
+        repositories=repositories,
+        repository=repository,
+        initial_commit=initial_commit,
+        git_source=git_source,
+        project_root=consumer.root,
+    )
+
+
+def _runner(apm_binary_path: Path) -> ApmLifecycleRunner:
+    """Return the canonical real-binary lifecycle runner."""
+    return ApmLifecycleRunner(
+        (str(apm_binary_path),),
+        timeout_seconds=120,
+        scenario_timeout_seconds=300,
+    )
+
+
+def _locked_dependency(project_root: Path) -> dict[str, object]:
+    """Read the single dependency from persisted lock state."""
+    lock = load_yaml(project_root / "apm.lock.yaml")
+    dependencies = lock["dependencies"]
+    assert len(dependencies) == 1
+    return dependencies[0]
+
+
+def _manifest_dependency(project_root: Path) -> dict[str, object]:
+    """Read the single dependency from persisted manifest state."""
+    manifest = load_yaml(project_root / "apm.yml")
+    dependencies = manifest["dependencies"]["apm"]
+    assert len(dependencies) == 1
+    return dependencies[0]
+
+
+def _audit_payload(result: CommandResult) -> dict[str, object]:
+    """Parse and validate one real audit command result."""
+    payload = json.loads(result.stdout)
+    assert payload["passed"] is True
+    assert payload["summary"]["failed"] == 0
+    return payload
+
+
+def _update_plan_entries(output: str) -> list[str]:
+    """Return rendered dependency rows without counting the plan legend."""
+    return [
+        line.strip()
+        for line in output.splitlines()
+        if line.startswith("  [~] ") and line.strip() != "[~] updated"
+    ]
+
+
+def test_filtered_install_and_additive_subset_remain_audit_clean(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Install A then B without losing A across manifest, lock, or audit."""
+    fixture = _create_git_consumer(
+        tmp_path / "additive-subset",
+        git_source="git@gitlab.example.invalid:group/consume-bundle.git",
+        declare_dependency=False,
+    )
+    bundle_path = str(fixture.repository.worktree)
+    row = ScenarioRow(
+        id="filtered-additive-subset",
+        source_inputs=(fixture.repository.origin,),
+        lifecycle_actions=(
+            LifecycleAction(
+                (
+                    "install",
+                    bundle_path,
+                    "--skill",
+                    "alpha",
+                    "--target",
+                    "copilot",
+                    "--no-policy",
+                )
+            ),
+            LifecycleAction(_AUDIT_ARGS),
+        ),
+    )
+    results = _runner(apm_binary_path).run_sequence(
+        tuple(action.args for action in row.lifecycle_actions),
+        expected_returncodes=tuple(action.expected_returncode for action in row.lifecycle_actions),
+        scenario_id=row.id,
+        cwd=fixture.project_root,
+        env=fixture.environment,
+    )
+    first_snapshot = ArtifactSnapshot.capture(fixture.project_root)
+    observation = ScenarioObservation(
+        source_inputs=row.source_inputs,
+        results=results,
+        snapshots=(first_snapshot,),
+    )
+
+    assert observation.results[0].stdout
+    first_lock = _locked_dependency(fixture.project_root)
+    assert first_lock["source"] == "local"
+    assert first_lock["skill_subset"] == ["alpha"]
+    assert _manifest_dependency(fixture.project_root)["skills"] == ["alpha"]
+    assert_paths_present(
+        first_snapshot,
+        {
+            "apm.lock.yaml",
+            ".agents/skills/alpha/SKILL.md",
+        },
+    )
+    assert_paths_absent(
+        first_snapshot,
+        {
+            ".agents/skills/beta/SKILL.md",
+            ".agents/skills/gamma/SKILL.md",
+        },
+    )
+    _audit_payload(observation.results[1])
+    alpha_bytes = (fixture.project_root / ".agents" / "skills" / "alpha" / "SKILL.md").read_bytes()
+
+    second_install, second_audit = _runner(apm_binary_path).run_sequence(
+        (
+            (
+                "install",
+                bundle_path,
+                "--skill",
+                "beta",
+                "--target",
+                "copilot",
+                "--no-policy",
+            ),
+            _AUDIT_ARGS,
+        ),
+        expected_returncodes=(0, 0),
+        scenario_id="additive-subset-second-install",
+        cwd=fixture.project_root,
+        env=fixture.environment,
+    )
+    second_snapshot = ArtifactSnapshot.capture(fixture.project_root)
+
+    assert second_install.stdout
+    second_lock = _locked_dependency(fixture.project_root)
+    assert second_lock["source"] == "local"
+    assert second_lock["skill_subset"] == ["alpha", "beta"]
+    assert _manifest_dependency(fixture.project_root)["skills"] == ["alpha", "beta"]
+    assert_paths_present(
+        second_snapshot,
+        {
+            ".agents/skills/alpha/SKILL.md",
+            ".agents/skills/beta/SKILL.md",
+        },
+    )
+    assert_paths_absent(
+        second_snapshot,
+        {".agents/skills/gamma/SKILL.md"},
+    )
+    assert (
+        fixture.project_root / ".agents" / "skills" / "alpha" / "SKILL.md"
+    ).read_bytes() == alpha_bytes
+    _audit_payload(second_audit)
+
+
+@pytest.mark.parametrize(
+    "git_source",
+    (
+        "git@gitlab.example.invalid:group/consume-bundle.git",
+        "https://gitlab.example.invalid/group/consume-bundle.git",
+    ),
+    ids=("scp-source", "https-source"),
+)
+def test_update_observes_branch_advance_then_converges(
+    tmp_path: Path,
+    apm_binary_path: Path,
+    git_source: str,
+) -> None:
+    """A real branch advance changes once; the next update has zero effect."""
+    fixture = _create_git_consumer(
+        tmp_path / git_source.split(":", maxsplit=1)[0].replace("/", "-"),
+        git_source=git_source,
+    )
+    runner = _runner(apm_binary_path)
+    install = runner.run(
+        ("install", "--target", "copilot", "--no-policy"),
+        scenario_id="update-convergence-install",
+        cwd=fixture.project_root,
+        env=fixture.environment,
+    )
+    assert install.returncode == 0, install.stderr
+    initial_lock = _locked_dependency(fixture.project_root)
+    assert initial_lock["resolved_commit"] == fixture.initial_commit.sha
+
+    skill_path = fixture.repository.worktree / "skills" / "alpha" / "SKILL.md"
+    skill_path.write_text(
+        _skill_document("alpha", "alpha version two"),
+        encoding="utf-8",
+    )
+    advanced_commit = fixture.repositories.commit(
+        fixture.repository,
+        message="advance consume bundle",
+    )
+
+    changed = runner.run(
+        ("update", "--yes", "--target", "copilot"),
+        scenario_id="update-observes-branch-advance",
+        cwd=fixture.project_root,
+        env=fixture.environment,
+    )
+    assert changed.returncode == 0, changed.stderr
+    changed_output = changed.stdout + changed.stderr
+    assert _update_plan_entries(changed_output) == ["[~] group/consume-bundle"]
+    assert "1 updated" in changed_output
+    updated_lock = _locked_dependency(fixture.project_root)
+    assert updated_lock["resolved_commit"] == advanced_commit.sha
+    assert updated_lock["resolved_commit"] != fixture.initial_commit.sha
+    assert "alpha version two" in (
+        fixture.project_root / ".agents" / "skills" / "alpha" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    after_changed_update = ArtifactSnapshot.capture(fixture.project_root)
+
+    unchanged = runner.run(
+        ("update", "--yes", "--target", "copilot"),
+        scenario_id="update-converges",
+        cwd=fixture.project_root,
+        env=fixture.environment,
+    )
+    assert unchanged.returncode == 0, unchanged.stderr
+    unchanged_output = unchanged.stdout + unchanged.stderr
+    assert _update_plan_entries(unchanged_output) == []
+    assert "All dependencies already at their latest matching refs." in unchanged_output
+    after_unchanged_update = ArtifactSnapshot.capture(fixture.project_root)
+    assert_unchanged(after_changed_update, after_unchanged_update)
+    assert _locked_dependency(fixture.project_root)["resolved_commit"] == advanced_commit.sha

--- a/tests/quality/critical_suite.toml
+++ b/tests/quality/critical_suite.toml
@@ -9,6 +9,10 @@ path = "tests/unit/deps/test_lockfile_git_semver.py"
 marker = "unit"
 
 [[modules]]
+path = "tests/unit/deps/test_lockfile_consumer_contract.py"
+marker = "unit"
+
+[[modules]]
 path = "tests/integration/test_install_content_hash_roundtrip.py"
 marker = "component"
 
@@ -18,4 +22,8 @@ marker = "component"
 
 [[modules]]
 path = "tests/integration/test_core_smoke.py"
+marker = "e2e"
+
+[[modules]]
+path = "tests/integration/test_real_consume_contracts.py"
 marker = "e2e"

--- a/tests/quality/test_test_taxonomy.py
+++ b/tests/quality/test_test_taxonomy.py
@@ -135,7 +135,7 @@ def test_tm001_behavioral_marker_definitions_match_spec() -> None:
 
 def test_tm002_manifest_is_finite_unique_and_existing() -> None:
     modules = _manifest_modules()
-    assert len(modules) == 5
+    assert len(modules) == 7
     paths = [entry["path"] for entry in modules]
     assert len(paths) == len(set(paths))
     assert {entry["marker"] for entry in modules} == BEHAVIORAL_MARKERS

--- a/tests/unit/deps/test_lockfile_consumer_contract.py
+++ b/tests/unit/deps/test_lockfile_consumer_contract.py
@@ -1,0 +1,164 @@
+"""Load-bearing contracts for dependency lock-state consumers."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from dataclasses import fields
+
+import pytest
+
+from apm_cli.deps.lockfile import LockedDependency, LockFile
+
+pytestmark = pytest.mark.unit
+
+_LOCKED_DEPENDENCY_VALUES = {
+    "repo_url": "group/consume-contract",
+    "host": "gitlab.example.invalid",
+    "host_type": "gitlab",
+    "port": 2222,
+    "registry_prefix": "registry/git",
+    "resolved_commit": "a" * 40,
+    "resolved_ref": "main",
+    "version": "1.2.3",
+    "virtual_path": "skills/alpha",
+    "is_virtual": True,
+    "depth": 2,
+    "resolved_by": "group/parent",
+    "package_type": "skill_bundle",
+    "deployed_files": [".agents/skills/alpha/SKILL.md"],
+    "deployed_file_hashes": {
+        ".agents/skills/alpha/SKILL.md": f"sha256:{'b' * 64}",
+    },
+    "source": "registry",
+    "local_path": "../consume-contract",
+    "declaring_parent": "group/parent",
+    "anchored_local_path": "/workspace/consume-contract",
+    "content_hash": f"sha256:{'c' * 64}",
+    "is_dev": True,
+    "discovered_via": "fixture-marketplace",
+    "marketplace_plugin_name": "fixture-plugin",
+    "source_url": "https://registry.example.invalid/fixture.json",
+    "source_digest": f"sha256:{'d' * 64}",
+    "is_insecure": True,
+    "allow_insecure": True,
+    "skill_subset": ["alpha", "beta"],
+    "target_subset": ["copilot"],
+    "resolved_url": "https://registry.example.invalid/consume-contract.tgz",
+    "resolved_hash": f"sha256:{'e' * 64}",
+    "constraint": "^1.0.0",
+    "resolved_tag": "v1.2.3",
+    "resolved_at": "2026-01-01T00:00:00+00:00",
+    "declared_license": "MIT",
+    "exec_status": "deployed",
+    "name": "consume-contract",
+    "_unknown_fields": {"future_consumer_field": {"enabled": True}},
+}
+
+_RECONSTRUCTED_LOCK_FIELDS = {
+    "repo_url",
+    "host",
+    "host_type",
+    "port",
+    "registry_prefix",
+    "resolved_ref",
+    "version",
+    "virtual_path",
+    "is_virtual",
+    "source",
+    "local_path",
+    "declaring_parent",
+    "anchored_local_path",
+    "is_insecure",
+    "allow_insecure",
+    "skill_subset",
+    "target_subset",
+}
+
+
+def _locked_fields_read_by_reconstruction() -> set[str]:
+    """Return owner fields consumed by ``to_dependency_ref``."""
+    source = textwrap.dedent(inspect.getsource(LockedDependency.to_dependency_ref))
+    tree = ast.parse(source)
+    return {
+        node.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "self"
+    }
+
+
+def test_every_locked_dependency_field_survives_yaml_round_trip() -> None:
+    """Every declared lock field must be populated and survive real YAML."""
+    declared_fields = {field.name for field in fields(LockedDependency)}
+    assert set(_LOCKED_DEPENDENCY_VALUES) == declared_fields
+
+    dependency = LockedDependency(**_LOCKED_DEPENDENCY_VALUES)
+    lockfile = LockFile(generated_at="2026-01-01T00:00:00+00:00")
+    lockfile.add_dependency(dependency)
+
+    restored = LockFile.from_yaml(lockfile.to_yaml())
+
+    assert restored.get_dependency(dependency.get_unique_key()) == dependency
+
+
+def test_reconstruction_declares_and_preserves_every_consumed_lock_field() -> None:
+    """The lock owner must reconstruct every field its consumer reads."""
+    assert _locked_fields_read_by_reconstruction() == _RECONSTRUCTED_LOCK_FIELDS
+
+    dependency = LockedDependency(
+        repo_url="group/consume-contract",
+        host="gitlab.example.invalid",
+        host_type="gitlab",
+        port=2222,
+        registry_prefix="registry/git",
+        resolved_ref="main",
+        version="1.2.3",
+        virtual_path="skills/alpha",
+        is_virtual=True,
+        source="local",
+        local_path="../consume-contract",
+        declaring_parent="group/parent",
+        anchored_local_path="/workspace/consume-contract",
+        is_insecure=True,
+        allow_insecure=True,
+        skill_subset=["beta", "alpha"],
+        target_subset=["copilot"],
+    )
+
+    reconstructed = dependency.to_dependency_ref()
+
+    assert reconstructed.repo_url == dependency.repo_url
+    assert reconstructed.host == dependency.host
+    assert reconstructed.host_type == dependency.host_type
+    assert reconstructed.port == dependency.port
+    assert reconstructed.artifactory_prefix == dependency.registry_prefix
+    assert reconstructed.reference == dependency.resolved_ref
+    assert reconstructed.virtual_path == dependency.virtual_path
+    assert reconstructed.is_virtual is dependency.is_virtual
+    assert reconstructed.source == dependency.source
+    assert reconstructed.is_local is True
+    assert reconstructed.local_path == dependency.local_path
+    assert reconstructed.declaring_parent == dependency.declaring_parent
+    assert reconstructed.anchored_local_path == dependency.anchored_local_path
+    assert reconstructed.is_insecure is dependency.is_insecure
+    assert reconstructed.allow_insecure is dependency.allow_insecure
+    assert reconstructed.skill_subset == ["alpha", "beta"]
+    assert reconstructed.target_subset == ["copilot"]
+
+
+def test_registry_reconstruction_uses_locked_exact_version() -> None:
+    """Registry consumers must use the locked version, not the input range."""
+    dependency = LockedDependency(
+        repo_url="group/consume-contract",
+        source="registry",
+        resolved_ref="resolved-range-value",
+        version="1.2.3",
+    )
+
+    reconstructed = dependency.to_dependency_ref()
+
+    assert reconstructed.source == "registry"
+    assert reconstructed.reference == "1.2.3"


### PR DESCRIPTION
# add(consume): prove real lifecycle contracts

## TL;DR

This PR replaces indirect Consume confidence with real command contracts across
manifest, resolution, lock state, installation, audit, and update. The contracts
also exposed and fix a branch-update convergence bug: unchanged branch tips no
longer produce a non-empty update plan or repeat installation effects.

> [!NOTE]
> Every Git scenario is hermetic: real local bare repositories, no network, and
> no credentials.

apm-spec-waiver: Restores existing branch update idempotency without extending OpenAPM behavior.

## Problem (WHY)

- [x] `LockedDependency` had field-by-field tests, but no contract requiring
  every declared field to survive one real YAML round trip.
- [x] Filtered install, persisted subset state, deployed bytes, and audit replay
  were not proven together through the installed CLI.
- [x] A branch dependency with an unchanged tip still rendered one update on
  every `apm update --yes`; its resolved commit was available through the
  downloader but not attached to the plan input.
- [!] Additive subset behavior was covered below the full
  install-to-audit boundary.

These are reliability seams. APM P6 requires that
["Behavior must be predictable, auditable, and explainable in plain English."](https://github.com/microsoft/apm/blob/bf76cd629a4fd895053054f6296f6d5cad7b0162/PRINCIPLES.md#L78-L83)
The test shape uses concrete contracts because
["agents pattern-match well against concrete structures"](https://agentskills.io/skill-creation/best-practices).

## Approach (WHAT)

| # | Fix | Principle |
|---:|---|---|
| 1 | Enumerate every `LockedDependency` dataclass field and round-trip a fully populated record through `LockFile` YAML. | Governed by policy |
| 2 | Exercise filtered and additive subset installs through the canonical binary, local package, local Git, snapshot, and audit owners. | Portability by manifest, DevX |
| 3 | Resolve update-plan Git refs through `GitHubPackageDownloader.resolve_git_reference` and attach its existing `ResolvedReference` carrier. | Vendor-neutral, Governed by policy |
| 4 | Add static AC9 evidence so the update plan cannot silently fork Git ref resolution. | Governed by policy |

## Implementation (HOW)

| File | Intent |
|---|---|
| `src/apm_cli/install/helpers/ref_reuse.py` | Owns update-plan annotation through the existing downloader ref-resolution API. |
| `src/apm_cli/install/phases/resolve.py` | Routes flattened dependencies through the helper before planning and preserves authoritative download results on the same carrier. |
| `tests/unit/deps/test_lockfile_consumer_contract.py` | Requires all `LockedDependency` fields to survive YAML and introspects `to_dependency_ref` so newly consumed fields force expectation updates. |
| `tests/integration/test_real_consume_contracts.py` | Runs filtered/additive install and branch-update convergence against real local state through `apm_binary_path`. |
| `scripts/lint-architecture-boundaries.sh` | Adds the static downloader-owner boundary for update-plan ref resolution. |
| `tests/integration/test_architecture_authorities.py` | Proves the static boundary is wired to the production resolver. |
| `tests/quality/critical_suite.toml` | Adds both contract modules to the finite critical-suite manifest. |
| `tests/quality/test_test_taxonomy.py` | Advances the explicit finite manifest count from five to seven modules. |
| `CHANGELOG.md` | Records the branch-update convergence fix under Unreleased. |

## Diagrams

Legend: the dashed node is the new seam that carries the authoritative Git
commit from the existing resolver into planning.

```mermaid
flowchart LR
    subgraph Inputs[Production inputs]
        M[apm.yml]
        G[Local Git origin]
        O[Existing lock]
    end
    subgraph Resolve[Resolve]
        R[Dependency resolver]
        D[GitHubPackageDownloader]
        A[ResolvedReference annotation]
    end
    subgraph Consume[Consume]
        P[Update plan]
        I[Install]
        L[Persisted lock]
        U[Audit and next update]
    end
    M --> R
    G --> D
    O --> P
    R --> D
    D --> A
    A --> P
    P --> I
    I --> L
    L --> U
    classDef new stroke-dasharray: 5 5;
    class A new;
```

## Trade-offs

- **Use real subprocess contracts, not more mocks.** The e2e module is slower
  than unit tests, but it proves persisted bytes and command exit codes across
  the seams that historically escaped.
- **Reuse the downloader owner, not a new Git probe.** This keeps host,
  transport, auth, cache, and ref vocabulary in one production authority.
- **Keep the matrix bounded.** SCP-shaped and HTTPS-shaped Git sources cover
  representative URL forms; no generalized fixture framework or host matrix
  was added.
- **Do not expand bare `--skill`.** Subset tests use the documented positional
  install flow; the PR deliberately avoids introducing new CLI semantics.

## Benefits

1. All 38 declared `LockedDependency` fields are covered by one complete YAML
   reconstruction contract.
2. Four Consume promises are mapped to three real-binary scenarios and three
   field/reconstruction unit contracts.
3. Two unchanged updates now produce zero rendered plan entries and a
   byte-identical project snapshot across both Git source forms.
4. A real branch-tip advance remains observable in the plan, deployed skill
   bytes, and persisted commit SHA.

## Validation

`uv run --extra dev pytest -q <affected suites>`:

```text
1440 passed in 180.40s (0:03:00)
```

`APM_BINARY_PATH="$PWD/.venv/bin/apm" uv run --extra dev pytest -q tests/integration/test_real_consume_contracts.py`:

```text
3 passed in 28.39s
```

<details><summary>Lint, architecture, quality, mutation, and audit evidence</summary>

`ruff`, pylint duplication, auth boundaries, and AC1-AC9:

```text
All checks passed!
1519 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
[+] architecture boundary lint clean
```

Test-quality ratchets:

```text
[+] assertion-quality ratchet clean: AQ001=5, AQ002=12
[+] exact test duplicate ratchet clean: 1036 files, 8 allowed duplicate group(s)
52 passed in 58.05s
```

Mutation breaks:

```text
1 failed, 1 passed in 0.62s
1 failed in 15.67s
```

`uv run apm audit --ci`:

```text
[+] No drift detected
[*] All 9 check(s) passed
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|:---:|
| 1 | Every dependency fact read from the lock survives write, read, and reconstruction. | Governed by policy, Secure by default | `tests/unit/deps/test_lockfile_consumer_contract.py` | unit |
| 2 | Installing only skill A persists the same subset in the manifest and lock, deploys only A, and audits cleanly. | Portability by manifest, Governed by policy | `tests/integration/test_real_consume_contracts.py::test_filtered_install_and_additive_subset_remain_audit_clean` | e2e |
| 3 | Installing skill A and then skill B keeps A, adds B, excludes unselected skills, and remains audit-clean. | DevX, Governed by policy | `tests/integration/test_real_consume_contracts.py::test_filtered_install_and_additive_subset_remain_audit_clean` | e2e |
| 4 | A real branch advance updates once; the next unchanged update has zero plan entries and zero filesystem effect. | DevX, Vendor-neutral, Governed by policy | `tests/integration/test_real_consume_contracts.py::test_update_observes_branch_advance_then_converges` | e2e |

## How to test

- [ ] Run `uv sync --extra dev`; confirm `.venv/bin/apm` is executable.
- [ ] Set `APM_BINARY_PATH="$PWD/.venv/bin/apm"` and run
  `pytest -q tests/integration/test_real_consume_contracts.py`; expect 3 passes.
- [ ] Run `pytest -q tests/unit/deps/test_lockfile_consumer_contract.py`;
  expect 3 passes.
- [ ] Run `bash scripts/lint-architecture-boundaries.sh`; expect AC1-AC9 clean.
- [ ] Run `uv run apm audit --ci`; expect all checks to pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
