### PR TITLE
test(produce): prove real pack-to-install artifact parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm pack` and local-bundle install now have a real binary parity contract,
+  and `apm audit --ci` no longer reports clean bundle deployments as orphaned. (#2215)
 - Preserve every enforceable policy field and strict denial across warm-cache reads (#2193).
   Cached inheritance chains no longer relabel stale strict parents as fresh or
   bypass inherited policy in `apm policy status` and executable approval.

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -259,6 +259,23 @@ if ! echo "$run_replay_body" | grep -q 'integrate_package_primitives(' \
     echo "[x] Audit replay must preserve locked skill subset intent"
     violations=$((violations + 1))
 fi
+local_bundle_marker_hits=$(
+    grep -rEn --include='*.py' \
+        '_LOCAL_BUNDLE_OWNER|active_owner.*["'\'']local-bundle["'\'']|["'\'']local-bundle["'\''].*active_owner|owners.*["'\'']local-bundle["'\'']' \
+        src/apm_cli \
+        | grep -v '^src/apm_cli/core/deployment_ledger.py:' \
+        | grep -v 'architecture-authority-exempt:' \
+        || true
+)
+if ! grep -q 'DeploymentLedgerCodec.record_local_bundle_files' \
+    src/apm_cli/install/local_bundle_handler.py \
+    || ! grep -q 'DeploymentLedgerCodec.local_bundle_paths' \
+    src/apm_cli/install/drift.py \
+    || [ -n "$local_bundle_marker_hits" ]; then
+    echo "[x] Local-bundle replay provenance must route through DeploymentLedgerCodec"
+    [ -n "$local_bundle_marker_hits" ] && echo "$local_bundle_marker_hits"
+    violations=$((violations + 1))
+fi
 dependency_field_owner="src/apm_cli/models/dependency/object_fields.py"
 dependency_parser="src/apm_cli/models/dependency/reference.py"
 dependency_field_duplicate_hits=$(

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -261,7 +261,7 @@ if ! echo "$run_replay_body" | grep -q 'integrate_package_primitives(' \
 fi
 local_bundle_marker_hits=$(
     grep -rEn --include='*.py' \
-        '_LOCAL_BUNDLE_OWNER|active_owner.*["'\'']local-bundle["'\'']|["'\'']local-bundle["'\''].*active_owner|owners.*["'\'']local-bundle["'\'']' \
+        "_LOCAL_BUNDLE_OWNER|active_owner.*[\"']local-bundle[\"']|[\"']local-bundle[\"'].*active_owner|owners.*[\"']local-bundle[\"']" \
         src/apm_cli \
         | grep -v '^src/apm_cli/core/deployment_ledger.py:' \
         | grep -v 'architecture-authority-exempt:' \

--- a/src/apm_cli/core/deployment_ledger.py
+++ b/src/apm_cli/core/deployment_ledger.py
@@ -31,6 +31,22 @@ _LEGACY_TARGET_PREFIXES = {
     ".opencode/": "opencode",
     ".agents/": "agents",
 }
+_LOCAL_BUNDLE_OWNER = "local-bundle"
+_SHA256_PREFIX = "sha256:"
+_LOWER_HEX = frozenset("0123456789abcdef")
+
+
+def _require_local_bundle_hash(path: str, content_hash: str | None) -> None:
+    """Reject imperative provenance without one canonical SHA-256 digest."""
+    digest = (
+        content_hash.removeprefix(_SHA256_PREFIX)
+        if isinstance(content_hash, str) and content_hash.startswith(_SHA256_PREFIX)
+        else ""
+    )
+    if len(digest) != 64 or any(character not in _LOWER_HEX for character in digest):
+        raise ValueError(
+            f"Local bundle deployment {path!r} requires a canonical sha256:<hex> content hash"
+        )
 
 
 class DeploymentLedgerCodec:
@@ -137,6 +153,7 @@ class DeploymentLedgerCodec:
         hashes: dict[str, str],
     ) -> None:
         """Update one compatibility ownership view and invalidate its projection."""
+        prior_bundle_paths = DeploymentLedgerCodec.local_bundle_paths(lockfile)
         if owner == ".":
             lockfile.local_deployed_files = list(files)
             lockfile.local_deployed_file_hashes = dict(hashes)
@@ -144,10 +161,46 @@ class DeploymentLedgerCodec:
             dependency = lockfile.dependencies[owner]
             dependency.deployed_files = list(files)
             dependency.deployed_file_hashes = dict(hashes)
-        lockfile.deployment_ledger = DeploymentLedger(records={})
-        lockfile._deployments_present = False
-        lockfile.deployment_ledger = DeploymentLedgerCodec.from_lockfile(lockfile)
-        lockfile._deployments_present = True
+        DeploymentLedgerCodec._rebuild_from_legacy(lockfile, prior_bundle_paths)
+
+    @staticmethod
+    def record_local_bundle_files(
+        lockfile: LockFile,
+        files: list[str],
+        hashes: dict[str, str],
+    ) -> None:
+        """Persist imperative bundle files without making them replayable source."""
+        prior_bundle_paths = DeploymentLedgerCodec.local_bundle_paths(lockfile)
+        for path in files:
+            _require_local_bundle_hash(path, hashes.get(path))
+        merged_files = sorted(set(lockfile.local_deployed_files).union(files))
+        merged_hashes = dict(lockfile.local_deployed_file_hashes)
+        merged_hashes.update(hashes)
+        DeploymentLedgerCodec.replace_legacy_owner(
+            lockfile,
+            ".",
+            merged_files,
+            merged_hashes,
+        )
+
+        DeploymentLedgerCodec._mark_local_bundle_paths(
+            lockfile,
+            prior_bundle_paths.union(files),
+        )
+        DeploymentLedgerCodec.apply_to_lockfile(lockfile.deployment_ledger, lockfile)
+
+    @staticmethod
+    def local_bundle_paths(lockfile: LockFile) -> frozenset[str]:
+        """Return paths whose active provenance is an imperative local bundle."""
+        ledger = DeploymentLedgerCodec.from_lockfile(lockfile)
+        paths: set[str] = set()
+        for record in ledger.records.values():
+            if record.active_owner != _LOCAL_BUNDLE_OWNER:
+                continue
+            path = DeploymentLedgerCodec._legacy_value(record.locator)
+            _require_local_bundle_hash(path, record.content_hash)
+            paths.add(path)
+        return frozenset(paths)
 
     @staticmethod
     def replace_mcp_target_servers(
@@ -159,10 +212,7 @@ class DeploymentLedgerCodec:
             runtime: list(servers) for runtime, servers in target_servers.items()
         }
         lockfile._mcp_target_servers_present = True
-        lockfile.deployment_ledger = DeploymentLedger(records={})
-        lockfile._deployments_present = False
-        lockfile.deployment_ledger = DeploymentLedgerCodec.from_lockfile(lockfile)
-        lockfile._deployments_present = True
+        DeploymentLedgerCodec.refresh_from_legacy(lockfile)
 
     @staticmethod
     def replace_context_local_files(context: Any, files: list[str]) -> None:
@@ -172,9 +222,87 @@ class DeploymentLedgerCodec:
     @staticmethod
     def refresh_from_legacy(lockfile: LockFile) -> None:
         """Rebuild canonical rows after a compatibility view mutates in place."""
+        prior_bundle_paths = DeploymentLedgerCodec.local_bundle_paths(lockfile)
+        DeploymentLedgerCodec._rebuild_from_legacy(lockfile, prior_bundle_paths)
+
+    @staticmethod
+    def invalidate_legacy_projection(lockfile: LockFile) -> None:
+        """Invalidate compatibility rows while preserving imperative provenance."""
+        prior_bundle_paths = DeploymentLedgerCodec.local_bundle_paths(lockfile)
+        lockfile.deployment_ledger = DeploymentLedger(records={})
+        lockfile._deployments_present = False
+        if prior_bundle_paths:
+            DeploymentLedgerCodec._rebuild_from_legacy(lockfile, prior_bundle_paths)
+
+    @staticmethod
+    def rename_local_deployed_path(
+        lockfile: LockFile,
+        old_value: str,
+        new_value: str,
+    ) -> None:
+        """Rename one local path while preserving imperative provenance."""
+        if old_value not in lockfile.local_deployed_files:
+            return
+        prior_bundle_paths = DeploymentLedgerCodec.local_bundle_paths(lockfile)
+        was_local_bundle = old_value in prior_bundle_paths
+        lockfile.local_deployed_files = [
+            value for value in lockfile.local_deployed_files if value != old_value
+        ]
+        if new_value not in lockfile.local_deployed_files:
+            lockfile.local_deployed_files.append(new_value)
+        if old_value in lockfile.local_deployed_file_hashes:
+            old_hash = lockfile.local_deployed_file_hashes.pop(old_value)
+            lockfile.local_deployed_file_hashes.setdefault(new_value, old_hash)
+        if was_local_bundle:
+            renamed_bundle_paths = (prior_bundle_paths - {old_value}) | {new_value}
+            DeploymentLedgerCodec._rebuild_from_legacy(
+                lockfile,
+                frozenset(renamed_bundle_paths),
+            )
+        else:
+            lockfile.deployment_ledger = DeploymentLedger(records={})
+            lockfile._deployments_present = False
+
+    @staticmethod
+    def _rebuild_from_legacy(
+        lockfile: LockFile,
+        prior_bundle_paths: frozenset[str],
+    ) -> None:
+        """Rebuild compatibility rows and restore surviving bundle provenance."""
         lockfile.deployment_ledger = DeploymentLedger(records={})
         lockfile._deployments_present = False
         lockfile.deployment_ledger = DeploymentLedgerCodec.from_lockfile(lockfile)
+        lockfile._deployments_present = True
+        surviving_paths = prior_bundle_paths.intersection(lockfile.local_deployed_files)
+        DeploymentLedgerCodec._mark_local_bundle_paths(lockfile, surviving_paths)
+
+    @staticmethod
+    def _mark_local_bundle_paths(
+        lockfile: LockFile,
+        bundle_paths: frozenset[str],
+    ) -> None:
+        """Mark existing ledger rows as hash-audited imperative bundle output."""
+        if not bundle_paths:
+            return
+        records = dict(lockfile.deployment_ledger.records)
+        marked_paths: set[str] = set()
+        for key, record in records.items():
+            path = DeploymentLedgerCodec._legacy_value(record.locator)
+            if path not in bundle_paths:
+                continue
+            _require_local_bundle_hash(path, record.content_hash)
+            owners = tuple(owner for owner in record.owners if owner != _LOCAL_BUNDLE_OWNER)
+            records[key] = DeploymentRecord(
+                locator=record.locator,
+                owners=(*owners, _LOCAL_BUNDLE_OWNER),
+                active_owner=_LOCAL_BUNDLE_OWNER,
+                content_hash=record.content_hash,
+            )
+            marked_paths.add(path)
+        missing = bundle_paths - marked_paths
+        if missing:
+            raise ValueError(f"Local bundle deployment rows are missing: {sorted(missing)}")
+        lockfile.deployment_ledger = DeploymentLedger(records=records)
         lockfile._deployments_present = True
 
     @staticmethod

--- a/src/apm_cli/deps/lockfile.py
+++ b/src/apm_cli/deps/lockfile.py
@@ -659,8 +659,9 @@ class LockFile:
         dep.deployed_files = _dedupe_preserving_order(dep.deployed_files)
         self.dependencies[dep.get_unique_key()] = dep
         if dep.deployed_files or dep.deployed_file_hashes:
-            self.deployment_ledger = DeploymentLedger(records={})
-            self._deployments_present = False
+            from ..core.deployment_ledger import DeploymentLedgerCodec
+
+            DeploymentLedgerCodec.invalidate_legacy_projection(self)
         if self.lockfile_version == "1" and (
             dep.source == "registry" or dep.constraint or dep.resolved_tag or dep.resolved_at
         ):
@@ -672,18 +673,9 @@ class LockFile:
 
     def rename_local_deployed_path(self, old_value: str, new_value: str) -> None:
         """Rename one locally deployed path and carry its content hash."""
-        if old_value not in self.local_deployed_files:
-            return
-        self.local_deployed_files = [
-            value for value in self.local_deployed_files if value != old_value
-        ]
-        if new_value not in self.local_deployed_files:
-            self.local_deployed_files.append(new_value)
-        if old_value in self.local_deployed_file_hashes:
-            old_hash = self.local_deployed_file_hashes.pop(old_value)
-            self.local_deployed_file_hashes.setdefault(new_value, old_hash)
-        self.deployment_ledger = DeploymentLedger(records={})
-        self._deployments_present = False
+        from ..core.deployment_ledger import DeploymentLedgerCodec
+
+        DeploymentLedgerCodec.rename_local_deployed_path(self, old_value, new_value)
 
     def has_dependency(self, key: str) -> bool:
         """Check if a dependency exists."""

--- a/src/apm_cli/install/drift.py
+++ b/src/apm_cli/install/drift.py
@@ -667,6 +667,25 @@ def diff_scratch_against_project(
     project_files = _walk_managed(project_root, governed)
     tracked = _collect_tracked_files(lockfile)
 
+    # Imperative local bundles have no authored source tree for replay. Their
+    # deployed bytes are already bound by local_deployed_file_hashes and the
+    # content-integrity check, so comparing them to an empty scratch projection
+    # would misclassify every clean bundle file as orphaned.
+    from apm_cli.core.deployment_ledger import DeploymentLedgerCodec
+
+    local_bundle_paths = DeploymentLedgerCodec.local_bundle_paths(lockfile)
+    if local_bundle_paths:
+        scratch_files = {
+            relative_path: path
+            for relative_path, path in scratch_files.items()
+            if relative_path not in local_bundle_paths
+        }
+        project_files = {
+            relative_path: path
+            for relative_path, path in project_files.items()
+            if relative_path not in local_bundle_paths
+        }
+
     # Canvas extensions are executable bundles that the drift replay does
     # not re-integrate (their integrator is intentionally omitted from the
     # replay bundle). Exclude their deploy prefixes from BOTH trees so a

--- a/src/apm_cli/install/drift.py
+++ b/src/apm_cli/install/drift.py
@@ -669,8 +669,9 @@ def diff_scratch_against_project(
 
     # Imperative local bundles have no authored source tree for replay. Their
     # deployed bytes are already bound by local_deployed_file_hashes and the
-    # content-integrity check, so comparing them to an empty scratch projection
-    # would misclassify every clean bundle file as orphaned.
+    # policy/ci_checks.py::_check_content_integrity check, so comparing them to
+    # an empty scratch projection would misclassify every clean bundle file as
+    # orphaned.
     from apm_cli.core.deployment_ledger import DeploymentLedgerCodec
 
     local_bundle_paths = DeploymentLedgerCodec.local_bundle_paths(lockfile)

--- a/src/apm_cli/install/local_bundle_handler.py
+++ b/src/apm_cli/install/local_bundle_handler.py
@@ -193,15 +193,9 @@ def install_local_bundle(
             migrate_lockfile_if_needed(project_root)
             lockfile_path = get_lockfile_path(project_root)
             lockfile = LockFile.read(lockfile_path) or LockFile()
-            existing = set(lockfile.local_deployed_files)
-            existing.update(deployed)
-            existing_hashes = dict(lockfile.local_deployed_file_hashes)
-            existing_hashes.update(deployed_hashes)
             from ..core.deployment_ledger import DeploymentLedgerCodec
 
-            DeploymentLedgerCodec.replace_legacy_owner(
-                lockfile, ".", sorted(existing), existing_hashes
-            )
+            DeploymentLedgerCodec.record_local_bundle_files(lockfile, deployed, deployed_hashes)
 
             # Auto-migrate legacy per-client skill paths (#737).
             # After deploying new .agents/skills/ files, detect and clean up

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import importlib.util
+import shutil
+import subprocess
 import sys
 from dataclasses import replace
 from pathlib import Path
@@ -61,6 +63,59 @@ def test_cleanup_current_claim_protection_has_single_owner() -> None:
     assert checker.analyze_path(root / "src/apm_cli/install/phases/cleanup.py") == []
     assert "scripts/check_cleanup_claim_owner.py" in guard
     assert "Cleanup current-claim protection must use DeploymentReconciler" in guard
+
+
+def test_local_bundle_replay_provenance_has_single_owner() -> None:
+    """Bundle persistence and drift exclusion must consume the deployment ledger."""
+    root = Path(__file__).parents[2]
+    handler = (root / "src/apm_cli/install/local_bundle_handler.py").read_text()
+    drift = (root / "src/apm_cli/install/drift.py").read_text()
+    guard = (root / "scripts/lint-architecture-boundaries.sh").read_text()
+
+    assert "DeploymentLedgerCodec.record_local_bundle_files" in handler
+    assert "DeploymentLedgerCodec.local_bundle_paths" in drift
+    assert "Local-bundle replay provenance must route through DeploymentLedgerCodec" in guard
+
+
+def test_local_bundle_owner_guard_rejects_parallel_marker_interpretation(
+    tmp_path: Path,
+) -> None:
+    """AC4 must reject a consumer that interprets the persisted marker itself."""
+    root = Path(__file__).parents[2]
+    sandbox = tmp_path / "repo"
+    shutil.copytree(
+        root,
+        sandbox,
+        ignore=shutil.ignore_patterns(
+            ".git",
+            ".venv",
+            ".pytest_cache",
+            "__pycache__",
+            "build",
+            "dist",
+            "node_modules",
+        ),
+    )
+    drift_path = sandbox / "src/apm_cli/install/drift.py"
+    with drift_path.open("a", encoding="utf-8") as handle:
+        handle.write(
+            "\n\ndef _parallel_bundle_owner(record):\n"
+            '    return record.active_owner != "local-bundle"\n'
+        )
+
+    result = subprocess.run(
+        ("bash", "scripts/lint-architecture-boundaries.sh"),
+        cwd=sandbox,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
+    )
+
+    assert result.returncode == 1
+    assert "Local-bundle replay provenance must route through DeploymentLedgerCodec" in (
+        result.stdout
+    )
 
 
 def _load_cleanup_claim_owner_checker(root: Path) -> ModuleType:

--- a/tests/integration/test_produce_consume_contract.py
+++ b/tests/integration/test_produce_consume_contract.py
@@ -341,6 +341,7 @@ def test_real_pack_output_matches_installed_artifacts_and_identity(
     assert set(bundle_rows) == expected_deployed
     assert {row["active_owner"] for row in bundle_rows.values()} == {"local-bundle"}
 
+    # Regression trap: a clean local-bundle install must not report orphaned drift.
     assert receipt.audit_report["passed"] is True
     assert receipt.audit_report["summary"] == {
         "total": len(receipt.audit_report["checks"]),

--- a/tests/integration/test_produce_consume_contract.py
+++ b/tests/integration/test_produce_consume_contract.py
@@ -204,7 +204,8 @@ def _run_produce_contract(
 
     source_after = ArtifactSnapshot.capture(source.root)
     producer_snapshot = ArtifactSnapshot.capture(producer.root)
-    bundle = producer.root / "build" / "produce-contract-producer-0.1.0"
+    producer_manifest = load_yaml(producer.manifest_path)
+    bundle = producer.root / "build" / f"{producer.name}-{producer_manifest['version']}"
     bundle_before_install = ArtifactSnapshot.capture(bundle)
     producer_observation = ScenarioObservation(
         source_inputs=producer_row.source_inputs,

--- a/tests/integration/test_produce_consume_contract.py
+++ b/tests/integration/test_produce_consume_contract.py
@@ -1,0 +1,381 @@
+"""Real-binary contract for selected artifacts across pack and local install."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from apm_cli.utils.yaml_io import load_yaml
+from tests.utils.apm_lifecycle_runner import ApmLifecycleRunner
+from tests.utils.artifact_snapshot import (
+    ArtifactSnapshot,
+    assert_paths_absent,
+    assert_paths_present,
+    assert_unchanged,
+)
+from tests.utils.isolated_apm_environment import IsolatedApmEnvironment
+from tests.utils.local_git_repository import LocalGitRepositoryFactory
+from tests.utils.local_package import LocalPackageFactory
+from tests.utils.scenario_rows import (
+    LifecycleAction,
+    ScenarioObservation,
+    ScenarioRow,
+)
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.requires_e2e_mode,
+    pytest.mark.requires_apm_binary,
+]
+
+_DECLARED_SKILLS = ("bare-skill", "productivity/grill-me")
+_EXPECTED_ARTIFACTS = frozenset(
+    {
+        "instructions/produce-rules.instructions.md",
+        "skills/bare-skill/SKILL.md",
+        "skills/grill-me/SKILL.md",
+    }
+)
+_EXCLUDED_SKILL = "internal-only"
+_AUDIT_ARGS = (
+    "audit",
+    "--ci",
+    "--no-policy",
+    "--format",
+    "json",
+    "--output",
+    "reports/audit.json",
+)
+
+
+@dataclass(frozen=True)
+class _ProduceContractReceipt:
+    """Captured command and filesystem evidence for one Produce lifecycle."""
+
+    producer_row: ScenarioRow
+    producer_observation: ScenarioObservation
+    consumer_row: ScenarioRow
+    consumer_observation: ScenarioObservation
+    producer_lock: dict[str, object]
+    bundle_lock: dict[str, object]
+    consumer_lock: dict[str, object]
+    audit_report: dict[str, object]
+
+
+def _artifact_hashes(
+    snapshot: ArtifactSnapshot,
+    prefixes: tuple[tuple[str, str], ...],
+) -> dict[str, str]:
+    """Project stage-specific paths onto canonical primitive-relative hashes."""
+    hashes: dict[str, str] = {}
+    for entry in snapshot.entries:
+        if entry.kind != "file" or entry.fingerprint is None:
+            continue
+        for stage_prefix, canonical_prefix in prefixes:
+            if not entry.relative_path.startswith(stage_prefix):
+                continue
+            canonical_path = canonical_prefix + entry.relative_path.removeprefix(stage_prefix)
+            if canonical_path in _EXPECTED_ARTIFACTS:
+                hashes[canonical_path] = entry.fingerprint
+            break
+    return hashes
+
+
+def _dependency(lockfile: dict[str, object]) -> dict[str, object]:
+    """Return the single dependency record persisted by the producer."""
+    dependencies = lockfile["dependencies"]
+    assert isinstance(dependencies, list)
+    assert len(dependencies) == 1
+    dependency = dependencies[0]
+    assert isinstance(dependency, dict)
+    return dependency
+
+
+def _run_produce_contract(
+    root: Path,
+    binary: Path,
+) -> _ProduceContractReceipt:
+    """Author, install, compile, pack, consume, and audit one local scenario."""
+    isolated = IsolatedApmEnvironment.create(root / "isolated", base_env=dict(os.environ))
+    environment = isolated.subprocess_env()
+
+    package_factory = LocalPackageFactory(isolated.package_root)
+    source = package_factory.create("produce-fixture", targets=("copilot",))
+    package_factory.add_skill(
+        source,
+        "bare-skill",
+        (
+            "---\n"
+            "name: bare-skill\n"
+            "description: Bare-name Produce contract skill\n"
+            "---\n"
+            "# Bare skill\n"
+        ),
+    )
+    package_factory.add_skill(
+        source,
+        "grill-me",
+        ("---\nname: grill-me\ndescription: Prefixed Produce contract skill\n---\n# Grill me\n"),
+    )
+    package_factory.add_skill(
+        source,
+        _EXCLUDED_SKILL,
+        (
+            "---\n"
+            f"name: {_EXCLUDED_SKILL}\n"
+            "description: Excluded Produce contract skill\n"
+            "---\n"
+            "# Internal only\n"
+        ),
+    )
+    package_factory.add_instruction(
+        source,
+        "produce-rules",
+        (
+            "---\n"
+            "applyTo: '**'\n"
+            "description: Produce contract compilation input\n"
+            "---\n"
+            "# Produce rules\n"
+        ),
+    )
+    source_before = ArtifactSnapshot.capture(source.root)
+
+    repository_factory = LocalGitRepositoryFactory(
+        isolated.repository_root,
+        env=environment,
+    )
+    repository = repository_factory.create("produce-fixture", source_tree=source.root)
+    commit = repository_factory.commit(repository, message="seed Produce fixture")
+    git_source = "git@gitlab.example.invalid:fixtures/produce-fixture.git"
+    subprocess.run(
+        (
+            "git",
+            "config",
+            "--global",
+            f"url.{repository.file_url}.insteadOf",
+            git_source,
+        ),
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+
+    project_factory = LocalPackageFactory(isolated.work_root)
+    producer = project_factory.create(
+        "produce-contract-producer",
+        dependencies=(
+            {
+                "git": git_source,
+                "type": "gitlab",
+                "ref": commit.sha,
+                "alias": source.name,
+                "skills": list(_DECLARED_SKILLS),
+            },
+        ),
+        targets=("copilot",),
+    )
+    producer_row = ScenarioRow(
+        id="produce-selected-artifacts",
+        source_inputs=(source.root, producer.manifest_path),
+        lifecycle_actions=(
+            LifecycleAction(("install", "--target", "copilot")),
+            LifecycleAction(("compile", "--target", "copilot", "--force-instructions")),
+            LifecycleAction(("pack", "--format", "plugin", "--offline")),
+        ),
+    )
+    runner = ApmLifecycleRunner((str(binary),), scenario_timeout_seconds=240)
+    producer_results = runner.run_sequence(
+        tuple(action.args for action in producer_row.lifecycle_actions),
+        expected_returncodes=tuple(
+            action.expected_returncode for action in producer_row.lifecycle_actions
+        ),
+        scenario_id=producer_row.id,
+        cwd=producer.root,
+        env=environment,
+    )
+
+    source_after = ArtifactSnapshot.capture(source.root)
+    producer_snapshot = ArtifactSnapshot.capture(producer.root)
+    bundle = producer.root / "build" / "produce-contract-producer-0.1.0"
+    bundle_before_install = ArtifactSnapshot.capture(bundle)
+    producer_observation = ScenarioObservation(
+        source_inputs=producer_row.source_inputs,
+        results=producer_results,
+        snapshots=(
+            source_before,
+            source_after,
+            producer_snapshot,
+            bundle_before_install,
+        ),
+    )
+
+    consumer = project_factory.create(
+        "produce-contract-consumer",
+        targets=("copilot",),
+    )
+    consumer_row = ScenarioRow(
+        id="consume-genuine-pack-output",
+        source_inputs=(bundle, consumer.manifest_path),
+        lifecycle_actions=(
+            LifecycleAction(("install", str(bundle), "--target", "copilot")),
+            LifecycleAction(_AUDIT_ARGS),
+        ),
+    )
+    consumer_results = runner.run_sequence(
+        tuple(action.args for action in consumer_row.lifecycle_actions),
+        expected_returncodes=tuple(
+            action.expected_returncode for action in consumer_row.lifecycle_actions
+        ),
+        scenario_id=consumer_row.id,
+        cwd=consumer.root,
+        env=environment,
+    )
+    bundle_after_install = ArtifactSnapshot.capture(bundle)
+    consumer_snapshot = ArtifactSnapshot.capture(consumer.root)
+    consumer_observation = ScenarioObservation(
+        source_inputs=consumer_row.source_inputs,
+        results=consumer_results,
+        snapshots=(bundle_before_install, bundle_after_install, consumer_snapshot),
+    )
+
+    return _ProduceContractReceipt(
+        producer_row=producer_row,
+        producer_observation=producer_observation,
+        consumer_row=consumer_row,
+        consumer_observation=consumer_observation,
+        producer_lock=load_yaml(producer.root / "apm.lock.yaml"),
+        bundle_lock=load_yaml(bundle / "apm.lock.yaml"),
+        consumer_lock=load_yaml(consumer.root / "apm.lock.yaml"),
+        audit_report=json.loads((consumer.root / "reports" / "audit.json").read_text()),
+    )
+
+
+def test_real_pack_output_matches_installed_artifacts_and_identity(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Selected bytes and subset identity survive every Produce boundary."""
+    receipt = _run_produce_contract(tmp_path, apm_binary_path)
+    source_before, source_after, producer_snapshot, bundle_snapshot = (
+        receipt.producer_observation.snapshots
+    )
+    bundle_before, bundle_after, consumer_snapshot = receipt.consumer_observation.snapshots
+
+    assert tuple(result.returncode for result in receipt.producer_observation.results) == (0, 0, 0)
+    assert tuple(result.returncode for result in receipt.consumer_observation.results) == (0, 0)
+    assert_unchanged(source_before, source_after)
+    assert_unchanged(bundle_before, bundle_after)
+    compiled = receipt.producer_row.source_inputs[1].parent / "AGENTS.md"
+    assert compiled.is_file()
+    assert "# Produce rules" in compiled.read_text(encoding="utf-8")
+
+    source_hashes = _artifact_hashes(
+        source_before,
+        (
+            ("skills/", "skills/"),
+            (".apm/instructions/", "instructions/"),
+        ),
+    )
+    producer_hashes = _artifact_hashes(
+        producer_snapshot,
+        (
+            (".agents/skills/", "skills/"),
+            (".github/instructions/", "instructions/"),
+        ),
+    )
+    bundle_hashes = _artifact_hashes(
+        bundle_snapshot,
+        (
+            ("skills/", "skills/"),
+            ("instructions/", "instructions/"),
+        ),
+    )
+    consumer_hashes = _artifact_hashes(
+        consumer_snapshot,
+        (
+            (".agents/skills/", "skills/"),
+            (".github/instructions/", "instructions/"),
+        ),
+    )
+    assert (
+        source_hashes
+        == producer_hashes
+        == bundle_hashes
+        == consumer_hashes
+        == {path: source_hashes[path] for path in _EXPECTED_ARTIFACTS}
+    )
+
+    assert _dependency(receipt.producer_lock)["skill_subset"] == list(_DECLARED_SKILLS)
+    assert _dependency(receipt.bundle_lock)["skill_subset"] == list(_DECLARED_SKILLS)
+    pack = receipt.bundle_lock["pack"]
+    assert isinstance(pack, dict)
+    bundle_file_hashes = pack["bundle_files"]
+    assert isinstance(bundle_file_hashes, dict)
+    assert {path: bundle_file_hashes[path] for path in _EXPECTED_ARTIFACTS} == bundle_hashes
+
+    expected_deployed = {
+        ".agents/skills/bare-skill/SKILL.md",
+        ".agents/skills/grill-me/SKILL.md",
+        ".github/instructions/produce-rules.instructions.md",
+    }
+    assert set(receipt.consumer_lock["local_deployed_files"]) == expected_deployed
+    deployed_hashes = receipt.consumer_lock["local_deployed_file_hashes"]
+    assert isinstance(deployed_hashes, dict)
+    assert set(deployed_hashes) == expected_deployed
+    assert all(str(value).startswith("sha256:") for value in deployed_hashes.values())
+    deployment_rows = receipt.consumer_lock["deployments"]
+    assert isinstance(deployment_rows, list)
+    bundle_rows = {
+        row["value"]: row
+        for row in deployment_rows
+        if isinstance(row, dict) and row.get("value") in expected_deployed
+    }
+    assert set(bundle_rows) == expected_deployed
+    assert {row["active_owner"] for row in bundle_rows.values()} == {"local-bundle"}
+
+    assert receipt.audit_report["passed"] is True
+    assert receipt.audit_report["summary"] == {
+        "total": len(receipt.audit_report["checks"]),
+        "passed": len(receipt.audit_report["checks"]),
+        "failed": 0,
+    }
+
+
+def test_excluded_skill_never_reaches_pack_or_consumer(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """A source skill outside the selected subset must not leak downstream."""
+    receipt = _run_produce_contract(tmp_path, apm_binary_path)
+    source_snapshot, _, producer_snapshot, bundle_snapshot = receipt.producer_observation.snapshots
+    consumer_snapshot = receipt.consumer_observation.snapshots[-1]
+
+    assert_paths_present(
+        source_snapshot,
+        {f"skills/{_EXCLUDED_SKILL}/SKILL.md"},
+    )
+    assert_paths_absent(
+        producer_snapshot,
+        {f".agents/skills/{_EXCLUDED_SKILL}/SKILL.md"},
+    )
+    assert_paths_absent(
+        bundle_snapshot,
+        {f"skills/{_EXCLUDED_SKILL}/SKILL.md"},
+    )
+    assert_paths_absent(
+        consumer_snapshot,
+        {f".agents/skills/{_EXCLUDED_SKILL}/SKILL.md"},
+    )
+    pack = receipt.bundle_lock["pack"]
+    assert isinstance(pack, dict)
+    bundle_files = pack["bundle_files"]
+    assert isinstance(bundle_files, dict)
+    assert set(bundle_files).isdisjoint({f"skills/{_EXCLUDED_SKILL}/SKILL.md"})

--- a/tests/quality/critical_suite.toml
+++ b/tests/quality/critical_suite.toml
@@ -19,3 +19,7 @@ marker = "component"
 [[modules]]
 path = "tests/integration/test_core_smoke.py"
 marker = "e2e"
+
+[[modules]]
+path = "tests/integration/test_produce_consume_contract.py"
+marker = "e2e"

--- a/tests/quality/test_test_taxonomy.py
+++ b/tests/quality/test_test_taxonomy.py
@@ -135,7 +135,7 @@ def test_tm001_behavioral_marker_definitions_match_spec() -> None:
 
 def test_tm002_manifest_is_finite_unique_and_existing() -> None:
     modules = _manifest_modules()
-    assert len(modules) == 5
+    assert len(modules) == 6
     paths = [entry["path"] for entry in modules]
     assert len(paths) == len(set(paths))
     assert {entry["marker"] for entry in modules} == BEHAVIORAL_MARKERS

--- a/tests/unit/core/test_deployment_state.py
+++ b/tests/unit/core/test_deployment_state.py
@@ -371,6 +371,97 @@ def test_legacy_import_and_dual_write_are_semantically_equivalent() -> None:
     assert rebuilt.is_semantically_equivalent(lockfile)
 
 
+def test_local_bundle_provenance_round_trips_beside_authored_local_files() -> None:
+    authored = ".github/instructions/authored.instructions.md"
+    bundled = ".agents/skills/bundled/SKILL.md"
+    lockfile = LockFile()
+    lockfile.local_deployed_files = [authored]
+    lockfile.local_deployed_file_hashes = {authored: "sha256:authored"}
+
+    DeploymentLedgerCodec.record_local_bundle_files(
+        lockfile,
+        [bundled],
+        {bundled: f"sha256:{'b' * 64}"},
+    )
+    rebuilt = LockFile.from_yaml(lockfile.to_yaml())
+
+    assert rebuilt.local_deployed_files == [bundled, authored]
+    assert rebuilt.local_deployed_file_hashes == {
+        bundled: f"sha256:{'b' * 64}",
+        authored: "sha256:authored",
+    }
+    assert DeploymentLedgerCodec.local_bundle_paths(rebuilt) == frozenset({bundled})
+    records = {
+        record.locator.value: record for record in rebuilt.deployment_ledger.records.values()
+    }
+    assert records[bundled].owners == (".", "local-bundle")
+    assert records[bundled].active_owner == "local-bundle"
+    assert records[authored].owners == (".",)
+    assert records[authored].active_owner == "."
+
+
+def test_local_bundle_provenance_survives_canonical_ledger_rebuilds() -> None:
+    bundled = ".agents/skills/bundled/SKILL.md"
+    sibling = ".agents/skills/sibling/SKILL.md"
+    renamed = ".agents/skills/renamed/SKILL.md"
+    lockfile = LockFile()
+    DeploymentLedgerCodec.record_local_bundle_files(
+        lockfile,
+        [bundled, sibling],
+        {
+            bundled: f"sha256:{'a' * 64}",
+            sibling: f"sha256:{'c' * 64}",
+        },
+    )
+
+    dependency = LockedDependency(
+        repo_url="owner/package",
+        deployed_files=[".github/agents/demo.agent.md"],
+        deployed_file_hashes={".github/agents/demo.agent.md": f"sha256:{'b' * 64}"},
+    )
+    lockfile.add_dependency(dependency)
+    DeploymentLedgerCodec.replace_mcp_target_servers(lockfile, {"vscode": ["demo"]})
+    DeploymentLedgerCodec.replace_legacy_owner(
+        lockfile,
+        dependency.get_unique_key(),
+        dependency.deployed_files,
+        dependency.deployed_file_hashes,
+    )
+    DeploymentLedgerCodec.refresh_from_legacy(lockfile)
+
+    assert DeploymentLedgerCodec.local_bundle_paths(lockfile) == frozenset({bundled, sibling})
+
+    lockfile.rename_local_deployed_path(bundled, renamed)
+
+    assert DeploymentLedgerCodec.local_bundle_paths(lockfile) == frozenset({renamed, sibling})
+    rebuilt = LockFile.from_yaml(lockfile.to_yaml())
+    assert DeploymentLedgerCodec.local_bundle_paths(rebuilt) == frozenset({renamed, sibling})
+
+
+def test_local_bundle_provenance_rejects_missing_or_malformed_hashes() -> None:
+    bundled = ".agents/skills/bundled/SKILL.md"
+    lockfile = LockFile()
+
+    with pytest.raises(ValueError, match="requires a canonical sha256"):
+        DeploymentLedgerCodec.record_local_bundle_files(lockfile, [bundled], {})
+
+    locator = _locator(bundled, target="agents")
+    lockfile.deployment_ledger = DeploymentLedger(
+        records={
+            locator.key: DeploymentRecord(
+                locator=locator,
+                owners=(".", "local-bundle"),
+                active_owner="local-bundle",
+                content_hash=None,
+            )
+        }
+    )
+    lockfile._deployments_present = True
+
+    with pytest.raises(ValueError, match="requires a canonical sha256"):
+        DeploymentLedgerCodec.local_bundle_paths(lockfile)
+
+
 def test_from_rows_preserves_hashless_legacy_ownership_row() -> None:
     rows = [
         {


### PR DESCRIPTION
# harden(produce): prove real pack-to-install artifact parity

## TL;DR

This adds a real-binary Produce contract that authors a hermetic package, installs
and compiles it, invokes `apm pack`, installs that genuine bundle into a fresh
consumer, and finishes with `apm audit --ci`. The contract compares portable
artifact paths and SHA-256 hashes across every stage, including a prefixed skill
subset and an excluded-skill negative twin. It also fixes the clean local-bundle
audit false positive exposed by the new scenario.

> [!NOTE]
> The product fix is limited to persisted local-bundle provenance and drift replay;
> pack traversal and attestation enforcement are unchanged.

## Problem (WHY)

- [x] The existing test named pack/install round-trip built its input with
  `_make_plugin_bundle`; it did not invoke `apm pack`, so producer and consumer
  projections could drift without the test noticing.
- [x] Pack tests covered exact artifact inclusion and provenance, but did not prove
  that the actual packed set equals the set deployed by supported local-bundle
  install.
- [x] The missing contract exposed a product defect: a clean bundle install wrote
  correct hashes, then `apm audit --ci` replayed those imperative files as authored
  source and reported every one as `orphaned`.
- [!] Fixing that defect outside the deployment-state authority would recreate the
  split this repository rejects: ["Every durable decision, vocabulary, outcome,
  write, or contract has exactly ONE canonical owner."](https://github.com/microsoft/apm/blob/5b20a65f219a1b68212c44cc872f72c2163e5764/.github/instructions/architecture.instructions.md#L17-L19)

Why these matter: Produce output must be predictable and auditable. P6 requires
["Behavior must be predictable, auditable, and explainable in plain
English."](https://github.com/microsoft/apm/blob/5b20a65f219a1b68212c44cc872f72c2163e5764/PRINCIPLES.md#L78-L83)

## Approach (WHAT)

| # | Fix | Principle | Source |
|---:|---|---|---|
| 1 | Exercise authored source through installed CLI boundaries and genuine pack output. | ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) | `tests/integration/test_produce_consume_contract.py` |
| 2 | Compare canonical relative artifact sets and content hashes, not ordering or mock calls. | ["agents pattern-match well against concrete structures"](https://agentskills.io/skill-creation/best-practices) | PR #2209 lifecycle utilities |
| 3 | Extend `DeploymentLedgerCodec` to own imperative bundle provenance. | ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) | Existing deployment-state owner |
| 4 | Guard both persistence and drift consumption with behavioral and AC4 mutation tests. | ["do the work, run a validator (a script, a reference checklist, or a self-check), fix any issues, and repeat until validation passes."](https://agentskills.io/skill-creation/best-practices) | Architecture boundary contract |

## Implementation (HOW)

| File | Intent |
|---|---|
| `tests/integration/test_produce_consume_contract.py` | Adds the two-scenario real-binary contract using `LocalPackageFactory`, `LocalGitRepositoryFactory`, `IsolatedApmEnvironment`, `ApmLifecycleRunner`, artifact snapshots, scenario rows, and `apm_binary_path`. |
| `src/apm_cli/core/deployment_ledger.py` | Persists hash-backed `local-bundle` ownership, preserves it across canonical rebuilds and path renames, and exposes the replay exclusion set. |
| `src/apm_cli/install/local_bundle_handler.py` | Routes bundle deployment persistence through `DeploymentLedgerCodec` instead of writing a generic local claim. |
| `src/apm_cli/install/drift.py` | Excludes only ledger-marked imperative paths from source replay; content-integrity remains authoritative for their bytes. |
| `src/apm_cli/deps/lockfile.py` | Delegates legacy projection invalidation and local path rename to the ledger owner without changing the YAML field shape. |
| `tests/unit/core/test_deployment_state.py` | Covers hash rejection, YAML round-trip, rebuild preservation, sibling-safe rename, and coexistence with authored local files. |
| `scripts/lint-architecture-boundaries.sh` | Extends AC4 to reject local-bundle marker interpretation outside the canonical owner. |
| `tests/integration/test_architecture_authorities.py` | Proves both consumers delegate and that alternate direct marker interpretation fails AC4. |
| `tests/quality/critical_suite.toml` | Enrolls the Produce contract as an `e2e` critical module. |
| `tests/quality/test_test_taxonomy.py` | Advances the finite critical-module count from seven to eight after merging the adjacent Consume contract. |
| `CHANGELOG.md` | Records the user outcome: clean local-bundle deployments no longer appear orphaned to CI audit. |

## Diagrams

Legend: dashed nodes are boundaries newly proven by the Produce contract; the
bundle directory itself is passed to the supported install path.

```mermaid
flowchart LR
    subgraph Author[Authored source]
        S[LocalPackageFactory]
        G[LocalGitRepositoryFactory]
    end
    subgraph Producer[Producer workspace]
        I[apm install]
        C[apm compile]
        P[apm pack plugin]
    end
    subgraph Consumer[Fresh consumer]
        B[Genuine bundle directory]
        L[apm install bundle]
        A[apm audit --ci]
    end
    S --> G
    G --> I
    I --> C
    C --> P
    P --> B
    B --> L
    L --> A
    classDef new stroke-dasharray: 5 5;
    class P,B,L,A new;
```

## Trade-offs

- **Use the supported directory bundle path.** Chose direct artifact snapshots and
  `apm install <bundle-dir>`; rejected test-owned archive extraction or another
  inventory helper.
- **Encode provenance in existing deployment rows.** Chose an owner marker with a
  mandatory canonical hash; rejected a new lockfile schema field and second state
  authority.
- **Separate replayability from integrity.** Chose to omit only marked imperative
  paths from source replay while retaining hash and presence checks; rejected
  suppressing drift for all local files.
- **Keep docs unchanged.** The classifier returned `no_change`: commands, flags,
  schema keys, and the documented local-bundle trust model are unchanged.

## Benefits

1. Three selected artifacts have identical canonical paths and hashes across
   source, producer deployment, pack output, and consumer deployment.
2. `productivity/grill-me` remains persisted while deploying and packing the
   normalized `grill-me` leaf.
3. One excluded source skill is absent from producer, bundle, bundle manifest, and
   consumer.
4. A clean genuine-bundle consumer now reaches a 9/9 passing CI audit without
   weakening hash drift detection.

## Validation

`apm audit --ci --no-policy --format json`:

```text
[>] Replaying install (cache-only)...
[+] Replayed 7 package(s)
[>] Diffing scratch vs working tree...
[+] No drift detected
{'total': 9, 'passed': 9, 'failed': 0}
```

<details><summary>Focused, unit, quality, mutation, and lint evidence</summary>

```text
Real built-binary Produce contract: 2 passed
Combined real built-binary Produce + Consume contracts: 5 passed
Complete unit suite: 18759 passed, 2 skipped, 21 xfailed, 88 subtests passed
Test architecture ratchets: 25 passed
Assertion ratchet: AQ001=5, AQ002=12
Exact-duplicate ratchet: 1039 files, 8 allowed duplicate groups
AC1-AC9: architecture boundary lint clean
Ruff check/format, R0801, auth boundary, YAML, file length, relative-path guards: clean

Mutation 1: exact-only pack filtering drops skills/grill-me/SKILL.md -> contract fails
Mutation 2: generic local ownership makes audit report 3 orphaned files -> contract fails
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|:---:|
| 1 | Author selected primitives, compile, pack, install the genuine bundle, and audit with identical bytes at every stage | Portability by manifest, Governed by policy, DevX | `tests/integration/test_produce_consume_contract.py::test_real_pack_output_matches_installed_artifacts_and_identity` | e2e |
| 2 | Exclude one skill from `skills:` and it never appears in pack output or the consumer | Secure by default, Portability by manifest | `tests/integration/test_produce_consume_contract.py::test_excluded_skill_never_reaches_pack_or_consumer` | e2e |
| 3 | Audit a clean local-bundle install without false `orphaned` drift | Governed by policy, Secure by default | `tests/integration/test_produce_consume_contract.py::test_real_pack_output_matches_installed_artifacts_and_identity` (regression-trap for the defect uncovered here) | e2e |
| 4 | Reject hashless bundle provenance and preserve valid markers across lockfile rebuilds | Secure by default, Governed by policy | `tests/unit/core/test_deployment_state.py::test_local_bundle_provenance_rejects_missing_or_malformed_hashes`<br/>`tests/unit/core/test_deployment_state.py::test_local_bundle_provenance_survives_canonical_ledger_rebuilds` | unit |

## How to test

- [ ] Build the binary, set `APM_BINARY_PATH`, and run the Produce contract; expect
  two passing e2e tests.
- [ ] Run `tests/unit/core/test_deployment_state.py`; expect provenance, rebuild,
  and rename cases to pass.
- [ ] Run `tests/integration/test_architecture_authorities.py`; expect the AC4
  routing and mutation guards to pass.
- [ ] Run the quality ratchets and CI lint mirror; expect all gates to exit zero.
- [ ] Run `apm audit --ci --no-policy --format json`; expect `passed: true`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
