### PR TITLE
test(consume): expand source/ref/cache matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm install` now re-resolves changed literal Git refs instead of silently
+  reusing an existing install path; a hermetic real-binary matrix covers
+  supported host forms, immutable refs, cache replay, and rollback. (#2219)
 - `apm pack` and local-bundle install now have a real binary parity contract,
   and `apm audit --ci` no longer reports clean bundle deployments as orphaned. (#2215)
 - Preserve every enforceable policy field and strict denial across warm-cache reads (#2193).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `apm install` now re-resolves changed literal Git refs instead of silently
-  reusing an existing install path; a hermetic real-binary matrix covers
-  supported host forms, immutable refs, cache replay, and rollback. (#2219)
+- Changing a literal Git ref in `apm.yml` no longer silently keeps old bytes;
+  `apm install` re-resolves the new ref and preserves the last good deployment
+  when the new ref is invalid. (#2219)
 - `apm pack` and local-bundle install now have a real binary parity contract,
   and `apm audit --ci` no longer reports clean bundle deployments as orphaned. (#2215)
 - Preserve every enforceable policy field and strict denial across warm-cache reads (#2193).

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -202,6 +202,21 @@ if ! grep -q \
     echo "[x] UnifiedLinkResolver must project source assets into the deployment frame"
     violations=$((violations + 1))
 fi
+ref_recheck_owner="src/apm_cli/drift.py"
+ref_recheck_consumers=(
+    src/apm_cli/deps/apm_resolver.py
+    src/apm_cli/install/phases/resolve.py
+)
+if ! grep -q '^def should_force_ref_recheck(' "$ref_recheck_owner" \
+    || ! grep -q 'should_force_ref_recheck(' "${ref_recheck_consumers[0]}" \
+    || ! grep -q 'should_force_ref_recheck(' "${ref_recheck_consumers[1]}" \
+    || grep -Eq '_force_semver_resolve|def should_force_ref_recheck' \
+        "${ref_recheck_consumers[@]}" \
+    || grep -rEq --include='*.py' --exclude='test_architecture_authorities.py' \
+        'def _force_semver_resolve|def should_force_ref_recheck' tests; then
+    echo "[x] Existing-path ref rechecks must use drift.py::should_force_ref_recheck"
+    violations=$((violations + 1))
+fi
 cleanup_claim_owner="src/apm_cli/install/phases/cleanup.py"
 cleanup_claim_output=$(python3 scripts/check_cleanup_claim_owner.py "$cleanup_claim_owner" 2>&1)
 cleanup_claim_status=$?

--- a/src/apm_cli/deps/apm_resolver.py
+++ b/src/apm_cli/deps/apm_resolver.py
@@ -9,7 +9,7 @@ from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 from pathlib import Path, PureWindowsPath
-from typing import Optional, Protocol
+from typing import TYPE_CHECKING, Optional, Protocol
 
 from ..models.apm_package import APMPackage, DependencyReference
 from ..utils.path_security import PathTraversalError, ensure_path_within, validate_path_segments
@@ -21,6 +21,9 @@ from .dependency_graph import (
     DependencyTree,
     FlatDependencyMap,
 )
+
+if TYPE_CHECKING:
+    from .lockfile import LockFile
 
 _logger = logging.getLogger(__name__)
 
@@ -81,6 +84,7 @@ class APMDependencyResolver:
         max_parallel: int | None = None,
         auth_resolver: object | None = None,
         update_refs: bool = False,
+        existing_lockfile: "LockFile | None" = None,
     ):
         """Initialize the resolver with maximum recursion depth.
 
@@ -104,12 +108,16 @@ class APMDependencyResolver:
                 install path already exists, at any depth -- see that
                 method's docstring for why this can't be scoped to direct
                 deps only.
+            existing_lockfile: Existing resolved dependency state used by the
+                canonical ref-drift owner to decide whether a plain install
+                must re-enter the download callback.
         """
         self.max_depth = max_depth
         self._apm_modules_dir: Path | None = apm_modules_dir
         self._project_root: Path | None = None
         self._download_callback = download_callback
         self._update_refs = update_refs
+        self._existing_lockfile = existing_lockfile
         # Whether ``download_callback`` accepts ``parent_pkg`` (added in #857).
         # Detected once via signature inspection so legacy callbacks that
         # predate the field still work without raising a silent TypeError
@@ -953,26 +961,18 @@ class APMDependencyResolver:
             return (item, None, exc)
 
     def _should_force_recheck(self, dep_ref: DependencyReference) -> bool:
-        """True when *dep_ref* must reach ``download_callback`` even though
-        its install path already exists on disk.
+        """Delegate existing-path recheck policy to the canonical drift owner."""
+        from apm_cli.drift import should_force_ref_recheck
 
-        ``download_callback`` (resolve.py) already has a
-        ``_force_semver_resolve`` fallthrough for this case, but this
-        method's caller (``_try_load_dependency_package``) only invokes the
-        callback when ``not install_path.exists()`` -- so that fallthrough
-        never fires for a dep whose path is already there. The existing
-        pre-purge (``_purge_cached_semver_paths_for_update``) works around
-        this for **direct** deps by deleting their install path up front,
-        but a transitive dep's path can't be pre-purged (its existence
-        isn't known until its parent's manifest is read, mid-resolution).
-        Widening this gate instead covers any depth uniformly. Mirrors
-        ``_force_semver_resolve`` exactly -- keep the two in sync.
-        """
-        return (
-            self._update_refs
-            and not dep_ref.is_local
-            and not getattr(dep_ref, "artifactory_prefix", None)
-            and getattr(dep_ref, "ref_kind", None) == "semver"
+        locked_dep = (
+            self._existing_lockfile.get_dependency(dep_ref.get_unique_key())
+            if self._existing_lockfile is not None
+            else None
+        )
+        return should_force_ref_recheck(
+            dep_ref,
+            locked_dep,
+            update_refs=self._update_refs,
         )
 
     def _try_load_dependency_package(

--- a/src/apm_cli/drift.py
+++ b/src/apm_cli/drift.py
@@ -171,6 +171,26 @@ def detect_ref_change(
     )
 
 
+def should_force_ref_recheck(
+    dep_ref: DependencyReference,
+    locked_dep: LockedDependency | None,
+    *,
+    update_refs: bool,
+) -> bool:
+    """Return whether an existing install path must reach the download owner.
+
+    This is the single gate shared by the dependency resolver and its download
+    callback. A normal install rechecks only manifest/lock drift. An explicit
+    update rechecks semver ranges so they can discover a newer matching tag,
+    while literal revision pins retain their dedicated update semantics.
+    """
+    if dep_ref.is_local or getattr(dep_ref, "artifactory_prefix", None):
+        return False
+    if update_refs:
+        return getattr(dep_ref, "ref_kind", None) == "semver"
+    return detect_ref_change(dep_ref, locked_dep, update_refs=False)
+
+
 # ---------------------------------------------------------------------------
 # Orphan drift
 # ---------------------------------------------------------------------------

--- a/src/apm_cli/drift.py
+++ b/src/apm_cli/drift.py
@@ -186,6 +186,8 @@ def should_force_ref_recheck(
     """
     if dep_ref.is_local or getattr(dep_ref, "artifactory_prefix", None):
         return False
+    if locked_dep is None:
+        return True
     if update_refs:
         return getattr(dep_ref, "ref_kind", None) == "semver"
     return detect_ref_change(dep_ref, locked_dep, update_refs=False)

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -459,9 +459,11 @@ def _resolve_dependencies(ctx: InstallContext, staging_session: ResolutionStagin
     existing_lockfile = ctx.existing_lockfile
     downloader = ctx.downloader
 
-    # Hoist drift helpers so download_callback avoids per-call sys.modules
-    # lookups and static analysis can see the dependency.
-    from apm_cli.drift import build_download_ref, detect_ref_change
+    from apm_cli.drift import (
+        build_download_ref,
+        detect_ref_change,
+        should_force_ref_recheck,
+    )
 
     verbose = ctx.verbose  # noqa: F841
 
@@ -480,18 +482,14 @@ def _resolve_dependencies(ctx: InstallContext, staging_session: ResolutionStagin
                 package's directory rather than the root consumer (#857).
         """
         install_path = dep_ref.get_install_path(modules_dir)
-        # Cache short-circuit: skip the rest of the callback when the
-        # install path already exists. Git semver deps under update still
-        # fall through to ``_maybe_resolve_git_semver`` and the full
-        # download callback.
+        # Cache reuse stays behind the canonical ref-drift owner.
         if install_path.exists():
-            _force_semver_resolve = (
-                update_refs
-                and not dep_ref.is_local
-                and not getattr(dep_ref, "artifactory_prefix", None)
-                and getattr(dep_ref, "ref_kind", None) == "semver"
+            _locked_for_recheck = (
+                existing_lockfile.get_dependency(dep_ref.get_unique_key())
+                if existing_lockfile
+                else None
             )
-            if not _force_semver_resolve:
+            if not should_force_ref_recheck(dep_ref, _locked_for_recheck, update_refs=update_refs):
                 return install_path
         staging_session.prepare_path(install_path)
         # F1 (#1116): surface a heartbeat BEFORE the network/copy work so
@@ -766,6 +764,7 @@ def _resolve_dependencies(ctx: InstallContext, staging_session: ResolutionStagin
         download_callback=download_callback,
         auth_resolver=ctx.auth_resolver,
         update_refs=update_refs,
+        existing_lockfile=existing_lockfile,
     )
 
     # Resolver reads ``<anchor>/apm.yml``. Preserve the original

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -372,6 +372,24 @@ def test_dependency_winner_selection_has_one_algorithm() -> None:
         assert duplicate not in source
 
 
+def test_existing_path_ref_rechecks_have_one_owner() -> None:
+    """Resolver gates must share the canonical ref-drift decision."""
+    root = Path(__file__).parents[2]
+    owner = (root / "src/apm_cli/drift.py").read_text()
+    resolver = (root / "src/apm_cli/deps/apm_resolver.py").read_text()
+    phase = (root / "src/apm_cli/install/phases/resolve.py").read_text()
+    legacy_test = (root / "tests/unit/test_install_update_refs.py").read_text()
+    guard = (root / "scripts/lint-architecture-boundaries.sh").read_text()
+
+    assert "def should_force_ref_recheck(" in owner
+    assert "should_force_ref_recheck(" in resolver
+    assert "should_force_ref_recheck(" in phase
+    assert "_force_semver_resolve" not in resolver
+    assert "_force_semver_resolve" not in phase
+    assert "def _force_semver_resolve" not in legacy_test
+    assert "Existing-path ref rechecks must use drift.py::should_force_ref_recheck" in guard
+
+
 def test_skill_subset_filtering_has_one_canonical_owner() -> None:
     """Install and pack must share one flattened skill-subset matcher."""
     root = Path(__file__).parents[2]

--- a/tests/integration/test_consume_source_ref_cache_matrix.py
+++ b/tests/integration/test_consume_source_ref_cache_matrix.py
@@ -1,0 +1,593 @@
+"""Real-binary Consume contracts across source, reference, and cache states.
+
+The package shape is intentionally fixed: one skill bundle, one skill, and the
+``copilot`` target. Remote-shaped URLs are rewritten by isolated Git config to
+one local bare origin. This proves public parsing, host classification,
+resolution, lock provenance, cache replay, deployment, audit, and update
+contracts without claiming remote authentication or host API coverage.
+
+Omitted candidates:
+
+* Local directories and GitLab SCP/HTTPS branch convergence are already proved
+  by ``test_real_consume_contracts.py``.
+* Direct ``file://`` dependency input is not supported by the public parser;
+  file transport is fixture infrastructure only.
+* Registry, marketplace, auth, policy, and primitive-shape variation are owned
+  by separate contracts.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from apm_cli.core.host_providers import classify_host_provider
+from apm_cli.utils.yaml_io import dump_yaml, load_yaml
+from tests.utils.apm_lifecycle_runner import ApmLifecycleRunner, CommandResult
+from tests.utils.artifact_snapshot import ArtifactSnapshot, assert_unchanged
+from tests.utils.isolated_apm_environment import IsolatedApmEnvironment
+from tests.utils.local_git_repository import (
+    GitCommit,
+    LocalGitRepository,
+    LocalGitRepositoryFactory,
+)
+from tests.utils.local_package import LocalPackageFactory
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.requires_apm_binary,
+]
+
+_AUDIT_ARGS = ("audit", "--ci", "--no-policy", "--format", "json")
+_INSTALL_ARGS = (
+    "install",
+    "--target",
+    "copilot",
+    "--no-policy",
+    "--parallel-downloads",
+    "0",
+)
+_LOCK_ARGS = (
+    "lock",
+    "--target",
+    "copilot",
+    "--no-policy",
+    "--parallel-downloads",
+    "0",
+)
+_UPDATE_ARGS = (
+    "update",
+    "--yes",
+    "--target",
+    "copilot",
+    "--parallel-downloads",
+    "0",
+)
+_SKILL_NAME = "source-ref-cache"
+_SKILL_PATH = Path(".agents") / "skills" / _SKILL_NAME / "SKILL.md"
+_REPO_NAME = "consume-matrix"
+
+
+@dataclass(frozen=True)
+class _MatrixRow:
+    id: str
+    source: str
+    rewrite_urls: tuple[str, ...]
+    expected_host: str
+    expected_kind: str
+    expected_repo: str
+    ref_selector: str
+    host_type: str | None = None
+    mode: str = "standard"
+    transition_source: str | None = None
+    transition_rewrite_urls: tuple[str, ...] = ()
+
+
+_ROWS = (
+    _MatrixRow(
+        id="github-https-full-sha",
+        source="https://github.com/acme/consume-matrix.git",
+        rewrite_urls=("https://github.com/acme/consume-matrix.git",),
+        expected_host="github.com",
+        expected_kind="github",
+        expected_repo="acme/consume-matrix",
+        ref_selector="first-sha",
+    ),
+    _MatrixRow(
+        id="github-scp-full-sha",
+        source="git@github.com:acme/consume-matrix.git",
+        rewrite_urls=("git@github.com:acme/consume-matrix.git",),
+        expected_host="github.com",
+        expected_kind="github",
+        expected_repo="acme/consume-matrix",
+        ref_selector="second-sha",
+    ),
+    _MatrixRow(
+        id="ghe-cloud-ssh-full-sha",
+        source="ssh://git@contoso.ghe.com/acme/consume-matrix.git",
+        rewrite_urls=("git@contoso.ghe.com:acme/consume-matrix.git",),
+        expected_host="contoso.ghe.com",
+        expected_kind="ghe_cloud",
+        expected_repo="acme/consume-matrix",
+        ref_selector="first-sha",
+    ),
+    _MatrixRow(
+        id="gitlab-ssh-semver-range",
+        source="ssh://git@gitlab.example.invalid/group/consume-matrix.git",
+        rewrite_urls=(
+            "git@gitlab.example.invalid:group/consume-matrix.git",
+            "https://gitlab.example.invalid/group/consume-matrix.git",
+        ),
+        expected_host="gitlab.example.invalid",
+        expected_kind="gitlab",
+        expected_repo="group/consume-matrix",
+        ref_selector="semver",
+        host_type="gitlab",
+    ),
+    _MatrixRow(
+        id="ado-https-literal-tag",
+        source="https://dev.azure.com/contoso/platform/_git/consume-matrix",
+        rewrite_urls=("https://dev.azure.com/contoso/platform/_git/consume-matrix",),
+        expected_host="dev.azure.com",
+        expected_kind="ado",
+        expected_repo="contoso/platform/consume-matrix",
+        ref_selector="tag",
+    ),
+    _MatrixRow(
+        id="ado-scp-full-sha",
+        source="git@dev.azure.com:contoso/platform/consume-matrix.git",
+        rewrite_urls=("git@ssh.dev.azure.com:v3/contoso/platform/consume-matrix",),
+        expected_host="dev.azure.com",
+        expected_kind="ado",
+        expected_repo="contoso/platform/consume-matrix",
+        ref_selector="second-sha",
+    ),
+    _MatrixRow(
+        id="github-https-warm-cache-only",
+        source="https://github.com/acme/consume-matrix.git",
+        rewrite_urls=("https://github.com/acme/consume-matrix.git",),
+        expected_host="github.com",
+        expected_kind="github",
+        expected_repo="acme/consume-matrix",
+        ref_selector="first-sha",
+        mode="warm-cache",
+    ),
+    _MatrixRow(
+        id="gitlab-source-ref-transition",
+        source="https://gitlab.example.invalid/group/consume-matrix.git",
+        rewrite_urls=("https://gitlab.example.invalid/group/consume-matrix.git",),
+        expected_host="gitlab.example.invalid",
+        expected_kind="gitlab",
+        expected_repo="group/consume-matrix",
+        ref_selector="first-sha",
+        host_type="gitlab",
+        mode="transition",
+        transition_source="git@gitlab.example.invalid:group/consume-matrix.git",
+        transition_rewrite_urls=("git@gitlab.example.invalid:group/consume-matrix.git",),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class _Scenario:
+    isolated: IsolatedApmEnvironment
+    environment: dict[str, str]
+    repositories: LocalGitRepositoryFactory
+    repository: LocalGitRepository
+    first_commit: GitCommit
+    second_commit: GitCommit
+    project_root: Path
+    initial_ref: str
+    expected_commit: GitCommit
+    expected_skill_bytes: bytes
+
+
+def _skill_document(marker: str) -> str:
+    return (
+        "---\n"
+        f"name: {_SKILL_NAME}\n"
+        "description: Consume source ref cache matrix skill\n"
+        "---\n"
+        f"# {marker}\n"
+    )
+
+
+def _configure_rewrites(
+    repository: LocalGitRepository,
+    urls: tuple[str, ...],
+    *,
+    environment: dict[str, str],
+) -> None:
+    for url in urls:
+        subprocess.run(
+            (
+                "git",
+                "config",
+                "--global",
+                "--add",
+                f"url.{repository.file_url}.insteadOf",
+                url,
+            ),
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+
+
+def _reference_for(
+    row: _MatrixRow,
+    first_commit: GitCommit,
+    second_commit: GitCommit,
+) -> tuple[str, GitCommit, bytes]:
+    if row.ref_selector == "first-sha":
+        return first_commit.sha, first_commit, _skill_document("version one").encode()
+    if row.ref_selector == "second-sha":
+        return second_commit.sha, second_commit, _skill_document("version two").encode()
+    if row.ref_selector == "tag":
+        return "v1.0.0", first_commit, _skill_document("version one").encode()
+    if row.ref_selector == "semver":
+        return "^1.0.0", second_commit, _skill_document("version two").encode()
+    raise AssertionError(f"Unknown ref selector: {row.ref_selector}")
+
+
+def _manifest_entry(row: _MatrixRow, source: str, reference: str) -> dict[str, str]:
+    entry = {"git": source, "ref": reference}
+    if row.host_type:
+        entry["type"] = row.host_type
+    return entry
+
+
+def _create_scenario(root: Path, row: _MatrixRow) -> _Scenario:
+    isolated = IsolatedApmEnvironment.create(root, base_env=dict(os.environ))
+    environment = isolated.subprocess_env()
+    packages = LocalPackageFactory(isolated.package_root)
+    bundle = packages.create(_REPO_NAME, targets=("copilot",))
+    skill_path = packages.add_skill(
+        bundle,
+        _SKILL_NAME,
+        _skill_document("version one"),
+    )
+
+    repositories = LocalGitRepositoryFactory(
+        isolated.repository_root,
+        env=environment,
+    )
+    repository = repositories.create(_REPO_NAME, source_tree=bundle.root)
+    first_commit = repositories.commit(repository, message="seed matrix bundle")
+    repositories.tag(repository, "v1.0.0", first_commit)
+
+    repository_skill = repository.worktree / skill_path.relative_to(bundle.root)
+    repository_skill.write_bytes(_skill_document("version two").encode())
+    second_commit = repositories.commit(repository, message="advance matrix bundle")
+    repositories.tag(repository, "v1.1.0", second_commit)
+
+    _configure_rewrites(
+        repository,
+        (*row.rewrite_urls, *row.transition_rewrite_urls),
+        environment=environment,
+    )
+    reference, expected_commit, expected_skill_bytes = _reference_for(
+        row,
+        first_commit,
+        second_commit,
+    )
+    consumer = LocalPackageFactory(isolated.work_root).create(
+        f"consumer-{row.id}",
+        dependencies=(_manifest_entry(row, row.source, reference),),
+        targets=("copilot",),
+    )
+    return _Scenario(
+        isolated=isolated,
+        environment=environment,
+        repositories=repositories,
+        repository=repository,
+        first_commit=first_commit,
+        second_commit=second_commit,
+        project_root=consumer.root,
+        initial_ref=reference,
+        expected_commit=expected_commit,
+        expected_skill_bytes=expected_skill_bytes,
+    )
+
+
+def _runner(apm_binary_path: Path) -> ApmLifecycleRunner:
+    return ApmLifecycleRunner(
+        (str(apm_binary_path),),
+        timeout_seconds=120,
+        scenario_timeout_seconds=360,
+    )
+
+
+def _assert_success(result: CommandResult) -> None:
+    assert result.returncode == 0, (
+        f"command={result.command!r}\nstdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+
+
+def _locked_dependency(project_root: Path) -> dict[str, object]:
+    lock = load_yaml(project_root / "apm.lock.yaml")
+    dependencies = lock["dependencies"]
+    assert len(dependencies) == 1
+    return dependencies[0]
+
+
+def _manifest_dependency(project_root: Path) -> dict[str, object]:
+    manifest = load_yaml(project_root / "apm.yml")
+    dependencies = manifest["dependencies"]["apm"]
+    assert len(dependencies) == 1
+    return dependencies[0]
+
+
+def _audit_payload(result: CommandResult) -> dict[str, object]:
+    payload = json.loads(result.stdout)
+    assert payload["passed"] is True
+    assert payload["summary"]["failed"] == 0
+    return payload
+
+
+def _update_plan_entries(output: str) -> list[str]:
+    return [
+        line.strip()
+        for line in output.splitlines()
+        if line.startswith("  [~] ") and line.strip() != "[~] updated"
+    ]
+
+
+def _assert_lock_provenance(
+    row: _MatrixRow,
+    scenario: _Scenario,
+    *,
+    expected_source: str,
+    expected_ref: str,
+    expected_commit: GitCommit,
+) -> dict[str, object]:
+    locked = _locked_dependency(scenario.project_root)
+    assert locked["host"] == row.expected_host
+    assert locked["repo_url"] == row.expected_repo
+    assert locked.get("source") is None
+    assert locked.get("host_type") == row.host_type
+    assert (
+        classify_host_provider(
+            str(locked["host"]),
+            host_type=locked.get("host_type"),
+        ).kind
+        == row.expected_kind
+    )
+    assert locked["resolved_commit"] == expected_commit.sha
+    if row.ref_selector == "semver" and expected_ref == scenario.initial_ref:
+        assert locked["constraint"] == "^1.0.0"
+        assert locked["resolved_tag"] == "v1.1.0"
+        assert locked["resolved_ref"] == "v1.1.0"
+        assert locked["version"] == "1.1.0"
+    else:
+        assert locked["resolved_ref"] == expected_ref
+    assert _manifest_dependency(scenario.project_root) == _manifest_entry(
+        row,
+        expected_source,
+        expected_ref,
+    )
+    return locked
+
+
+def _assert_deployment(
+    scenario: _Scenario,
+    *,
+    expected_skill_bytes: bytes,
+) -> None:
+    deployed = scenario.project_root / _SKILL_PATH
+    assert deployed.read_bytes() == expected_skill_bytes
+    locked = _locked_dependency(scenario.project_root)
+    deployed_path = _SKILL_PATH.as_posix()
+    assert deployed_path in locked["deployed_files"]
+    expected_hash = f"sha256:{hashlib.sha256(expected_skill_bytes).hexdigest()}"
+    assert locked["deployed_file_hashes"][deployed_path] == expected_hash
+    assert str(locked["content_hash"]).startswith("sha256:")
+
+
+def _run_initial_contract(
+    row: _MatrixRow,
+    scenario: _Scenario,
+    *,
+    apm_binary_path: Path,
+) -> None:
+    runner = _runner(apm_binary_path)
+    lock_result = runner.run(
+        _LOCK_ARGS,
+        scenario_id=f"{row.id}-cold-lock",
+        cwd=scenario.project_root,
+        env=scenario.environment,
+    )
+    _assert_success(lock_result)
+    assert not (scenario.project_root / _SKILL_PATH).exists()
+    _assert_lock_provenance(
+        row,
+        scenario,
+        expected_source=row.source,
+        expected_ref=scenario.initial_ref,
+        expected_commit=scenario.expected_commit,
+    )
+
+    install_result = runner.run(
+        _INSTALL_ARGS,
+        scenario_id=f"{row.id}-install",
+        cwd=scenario.project_root,
+        env=scenario.environment,
+    )
+    _assert_success(install_result)
+    _assert_deployment(
+        scenario,
+        expected_skill_bytes=scenario.expected_skill_bytes,
+    )
+
+    audit_result = runner.run(
+        _AUDIT_ARGS,
+        scenario_id=f"{row.id}-audit",
+        cwd=scenario.project_root,
+        env=scenario.environment,
+    )
+    _assert_success(audit_result)
+    _audit_payload(audit_result)
+
+
+def _assert_unchanged_convergence(
+    row: _MatrixRow,
+    scenario: _Scenario,
+    *,
+    apm_binary_path: Path,
+) -> None:
+    before = ArtifactSnapshot.capture(scenario.project_root)
+    if row.ref_selector in {"semver", "tag"}:
+        args = _UPDATE_ARGS
+        scenario_suffix = "unchanged-update"
+    else:
+        args = _INSTALL_ARGS
+        scenario_suffix = "unchanged-install"
+    result = _runner(apm_binary_path).run(
+        args,
+        scenario_id=f"{row.id}-{scenario_suffix}",
+        cwd=scenario.project_root,
+        env=scenario.environment,
+    )
+    _assert_success(result)
+    if row.ref_selector in {"semver", "tag"}:
+        output = result.stdout + result.stderr
+        assert _update_plan_entries(output) == []
+        assert "All dependencies already at their latest matching refs." in output
+    assert_unchanged(before, ArtifactSnapshot.capture(scenario.project_root))
+
+
+@pytest.mark.parametrize(
+    "row",
+    tuple(row for row in _ROWS if row.mode == "standard"),
+    ids=lambda row: row.id,
+)
+def test_immutable_source_ref_rows_resolve_deploy_audit_and_converge(
+    tmp_path: Path,
+    apm_binary_path: Path,
+    record_property: Callable[[str, object], None],
+    row: _MatrixRow,
+) -> None:
+    started = time.monotonic()
+    scenario = _create_scenario(tmp_path / row.id, row)
+    _run_initial_contract(row, scenario, apm_binary_path=apm_binary_path)
+    _assert_unchanged_convergence(row, scenario, apm_binary_path=apm_binary_path)
+    record_property("scenario_seconds", round(time.monotonic() - started, 3))
+
+
+def test_warm_cache_only_audit_replays_after_origin_becomes_unavailable(
+    tmp_path: Path,
+    apm_binary_path: Path,
+    record_property: Callable[[str, object], None],
+) -> None:
+    row = next(row for row in _ROWS if row.mode == "warm-cache")
+    started = time.monotonic()
+    scenario = _create_scenario(tmp_path / row.id, row)
+    _run_initial_contract(row, scenario, apm_binary_path=apm_binary_path)
+
+    offline_origin = scenario.repository.origin.with_name(
+        f"{scenario.repository.origin.name}.offline"
+    )
+    scenario.repository.origin.rename(offline_origin)
+    warm_audit = _runner(apm_binary_path).run(
+        _AUDIT_ARGS,
+        scenario_id=f"{row.id}-warm-cache-only-audit",
+        cwd=scenario.project_root,
+        env=scenario.environment,
+    )
+    _assert_success(warm_audit)
+    _audit_payload(warm_audit)
+    assert "[>] Replaying install (cache-only)..." in warm_audit.stderr
+    _assert_deployment(
+        scenario,
+        expected_skill_bytes=scenario.expected_skill_bytes,
+    )
+    record_property("scenario_seconds", round(time.monotonic() - started, 3))
+
+
+def test_source_ref_transition_applies_once_and_invalid_twin_preserves_state(
+    tmp_path: Path,
+    apm_binary_path: Path,
+    record_property: Callable[[str, object], None],
+) -> None:
+    row = next(row for row in _ROWS if row.mode == "transition")
+    assert row.transition_source is not None
+    started = time.monotonic()
+    scenario = _create_scenario(tmp_path / row.id, row)
+    _run_initial_contract(row, scenario, apm_binary_path=apm_binary_path)
+
+    manifest_path = scenario.project_root / "apm.yml"
+    manifest = load_yaml(manifest_path)
+    manifest["dependencies"]["apm"] = [
+        _manifest_entry(
+            row,
+            row.transition_source,
+            scenario.second_commit.sha,
+        )
+    ]
+    dump_yaml(manifest, manifest_path)
+
+    changed = _runner(apm_binary_path).run(
+        _INSTALL_ARGS,
+        scenario_id=f"{row.id}-changed",
+        cwd=scenario.project_root,
+        env=scenario.environment,
+    )
+    _assert_success(changed)
+    _assert_lock_provenance(
+        row,
+        scenario,
+        expected_source=row.transition_source,
+        expected_ref=scenario.second_commit.sha,
+        expected_commit=scenario.second_commit,
+    )
+    expected_skill_bytes = _skill_document("version two").encode()
+    _assert_deployment(
+        scenario,
+        expected_skill_bytes=expected_skill_bytes,
+    )
+    clean_audit = _runner(apm_binary_path).run(
+        _AUDIT_ARGS,
+        scenario_id=f"{row.id}-changed-audit",
+        cwd=scenario.project_root,
+        env=scenario.environment,
+    )
+    _assert_success(clean_audit)
+    _audit_payload(clean_audit)
+
+    converged = ArtifactSnapshot.capture(scenario.project_root)
+    unchanged = _runner(apm_binary_path).run(
+        _INSTALL_ARGS,
+        scenario_id=f"{row.id}-converged",
+        cwd=scenario.project_root,
+        env=scenario.environment,
+    )
+    _assert_success(unchanged)
+    assert_unchanged(converged, ArtifactSnapshot.capture(scenario.project_root))
+
+    lock_bytes = (scenario.project_root / "apm.lock.yaml").read_bytes()
+    deployed_bytes = (scenario.project_root / _SKILL_PATH).read_bytes()
+    invalid_commit = "f" * 40
+    manifest = load_yaml(manifest_path)
+    manifest["dependencies"]["apm"] = [_manifest_entry(row, row.transition_source, invalid_commit)]
+    dump_yaml(manifest, manifest_path)
+
+    invalid = _runner(apm_binary_path).run(
+        _INSTALL_ARGS,
+        scenario_id=f"{row.id}-invalid-ref",
+        cwd=scenario.project_root,
+        env=scenario.environment,
+    )
+    assert invalid.returncode == 1
+    assert (scenario.project_root / "apm.lock.yaml").read_bytes() == lock_bytes
+    assert (scenario.project_root / _SKILL_PATH).read_bytes() == deployed_bytes
+    record_property("scenario_seconds", round(time.monotonic() - started, 3))

--- a/tests/integration/test_consume_source_ref_cache_matrix.py
+++ b/tests/integration/test_consume_source_ref_cache_matrix.py
@@ -588,6 +588,9 @@ def test_source_ref_transition_applies_once_and_invalid_twin_preserves_state(
         env=scenario.environment,
     )
     assert invalid.returncode == 1
+    invalid_output = " ".join((invalid.stdout + invalid.stderr).split())
+    assert "Failed to download dependency" in invalid_output
+    assert "No install transaction changes were committed." in invalid_output
     assert (scenario.project_root / "apm.lock.yaml").read_bytes() == lock_bytes
     assert (scenario.project_root / _SKILL_PATH).read_bytes() == deployed_bytes
     record_property("scenario_seconds", round(time.monotonic() - started, 3))

--- a/tests/quality/critical_suite.toml
+++ b/tests/quality/critical_suite.toml
@@ -31,3 +31,7 @@ marker = "e2e"
 [[modules]]
 path = "tests/integration/test_real_consume_contracts.py"
 marker = "e2e"
+
+[[modules]]
+path = "tests/integration/test_consume_source_ref_cache_matrix.py"
+marker = "e2e"

--- a/tests/quality/test_test_taxonomy.py
+++ b/tests/quality/test_test_taxonomy.py
@@ -135,7 +135,7 @@ def test_tm001_behavioral_marker_definitions_match_spec() -> None:
 
 def test_tm002_manifest_is_finite_unique_and_existing() -> None:
     modules = _manifest_modules()
-    assert len(modules) == 8
+    assert len(modules) == 9
     paths = [entry["path"] for entry in modules]
     assert len(paths) == len(set(paths))
     assert {entry["marker"] for entry in modules} == BEHAVIORAL_MARKERS

--- a/tests/unit/deps/test_apm_resolver_edge_cases.py
+++ b/tests/unit/deps/test_apm_resolver_edge_cases.py
@@ -661,23 +661,22 @@ class TestShouldForceRecheck:
         ref.ref_kind = ref_kind
         return ref
 
-    def test_false_when_update_refs_is_false(self) -> None:
+    def test_true_without_lock_provenance_on_plain_install(self) -> None:
         resolver = APMDependencyResolver(update_refs=False)
-        assert resolver._should_force_recheck(self._dep()) is False
+        assert resolver._should_force_recheck(self._dep()) is True
 
     def test_true_for_semver_dep_when_update_refs_true(self) -> None:
         resolver = APMDependencyResolver(update_refs=True)
         assert resolver._should_force_recheck(self._dep()) is True
 
-    def test_false_for_literal_ref_kind(self) -> None:
-        """An exact/literal ref (e.g. a pinned tag) has nowhere else to
-        resolve to -- no point re-checking it."""
+    def test_true_without_lock_even_for_literal_ref(self) -> None:
+        """No lock provenance wins over literal-ref update optimization."""
         resolver = APMDependencyResolver(update_refs=True)
-        assert resolver._should_force_recheck(self._dep(ref_kind="literal")) is False
+        assert resolver._should_force_recheck(self._dep(ref_kind="literal")) is True
 
-    def test_false_for_none_ref_kind(self) -> None:
+    def test_true_without_lock_for_default_ref(self) -> None:
         resolver = APMDependencyResolver(update_refs=True)
-        assert resolver._should_force_recheck(self._dep(ref_kind=None)) is False
+        assert resolver._should_force_recheck(self._dep(ref_kind=None)) is True
 
     def test_false_for_local_dep(self) -> None:
         resolver = APMDependencyResolver(update_refs=True)
@@ -688,10 +687,9 @@ class TestShouldForceRecheck:
         assert resolver._should_force_recheck(self._dep(artifactory_prefix="proxy")) is False
 
     def test_default_constructor_is_update_refs_false(self) -> None:
-        """Callers that don't pass update_refs (e.g. plain apm install)
-        must not accidentally force re-checks."""
+        """A remote existing path without lock provenance must be rechecked."""
         resolver = APMDependencyResolver()
-        assert resolver._should_force_recheck(self._dep()) is False
+        assert resolver._should_force_recheck(self._dep()) is True
 
     def test_true_for_changed_literal_ref_on_plain_install(self) -> None:
         lockfile = LockFile()
@@ -761,9 +759,11 @@ class TestTryLoadDependencyPackageForceRecheck:
         assert len(call_log) == 1
         assert result is not None
 
-    def test_existing_path_skips_callback_when_update_refs_false(self, tmp_path: Path) -> None:
-        """Plain apm install (update_refs=False, the default) must not pay
-        the re-check cost -- this is the existing, unaffected fast path."""
+    def test_existing_path_without_lock_calls_callback_on_plain_install(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Plain install must not trust an existing path without provenance."""
         mods = tmp_path / "apm_modules"
         pkg_dir = mods / "org" / "pkg"
         pkg_dir.mkdir(parents=True)
@@ -781,7 +781,7 @@ class TestTryLoadDependencyPackageForceRecheck:
         )
         result = resolver._try_load_dependency_package(ref)
 
-        assert len(call_log) == 0
+        assert len(call_log) == 1
         assert result is not None
 
     def test_existing_path_calls_callback_for_changed_literal_ref(
@@ -816,11 +816,10 @@ class TestTryLoadDependencyPackageForceRecheck:
         assert resolver._try_load_dependency_package(ref) is not None
         assert calls == [ref]
 
-    def test_existing_path_skips_callback_for_literal_ref_even_with_update_refs(
+    def test_existing_path_without_lock_calls_callback_for_literal_ref(
         self, tmp_path: Path
     ) -> None:
-        """A dep pinned to a literal ref (not a semver range) has nothing to
-        re-resolve to -- re-checking it would be pure waste."""
+        """Missing provenance wins over literal-ref update optimization."""
         mods = tmp_path / "apm_modules"
         pkg_dir = mods / "org" / "pkg"
         pkg_dir.mkdir(parents=True)
@@ -839,5 +838,5 @@ class TestTryLoadDependencyPackageForceRecheck:
         )
         result = resolver._try_load_dependency_package(ref)
 
-        assert len(call_log) == 0
+        assert len(call_log) == 1
         assert result is not None

--- a/tests/unit/deps/test_apm_resolver_edge_cases.py
+++ b/tests/unit/deps/test_apm_resolver_edge_cases.py
@@ -28,6 +28,7 @@ import pytest
 import yaml
 
 from apm_cli.deps.apm_resolver import APMDependencyResolver
+from apm_cli.deps.lockfile import LockedDependency, LockFile
 from apm_cli.models.apm_package import DependencyReference
 
 # ---------------------------------------------------------------------------
@@ -649,10 +650,9 @@ class TestShouldForceRecheck:
     chance to run for a dep whose install path already exists on disk --
     the fix for transitive semver deps never being re-evaluated against the
     remote during ``apm update`` unless something *above* them in the tree
-    also happened to change. Mirrors download_callback's own
-    ``_force_semver_resolve`` predicate (see install/phases/resolve.py)
-    exactly -- kept in sync deliberately, since without this widened gate
-    that check is otherwise unreachable for any dep whose path exists."""
+    also happened to change. The method delegates to the same canonical drift
+    owner as ``download_callback`` so literal manifest ref changes also reach
+    the callback on a plain install."""
 
     def _dep(self, *, is_local=False, artifactory_prefix=None, ref_kind="semver"):
         ref = MagicMock()
@@ -692,6 +692,34 @@ class TestShouldForceRecheck:
         must not accidentally force re-checks."""
         resolver = APMDependencyResolver()
         assert resolver._should_force_recheck(self._dep()) is False
+
+    def test_true_for_changed_literal_ref_on_plain_install(self) -> None:
+        lockfile = LockFile()
+        lockfile.add_dependency(
+            LockedDependency(
+                repo_url="org/pkg",
+                resolved_ref="a" * 40,
+                resolved_commit="a" * 40,
+            )
+        )
+        resolver = APMDependencyResolver(existing_lockfile=lockfile)
+        dep = DependencyReference(repo_url="org/pkg", reference="b" * 40)
+
+        assert resolver._should_force_recheck(dep) is True
+
+    def test_false_for_unchanged_literal_ref_on_plain_install(self) -> None:
+        lockfile = LockFile()
+        lockfile.add_dependency(
+            LockedDependency(
+                repo_url="org/pkg",
+                resolved_ref="a" * 40,
+                resolved_commit="a" * 40,
+            )
+        )
+        resolver = APMDependencyResolver(existing_lockfile=lockfile)
+        dep = DependencyReference(repo_url="org/pkg", reference="a" * 40)
+
+        assert resolver._should_force_recheck(dep) is False
 
 
 class TestTryLoadDependencyPackageForceRecheck:
@@ -755,6 +783,38 @@ class TestTryLoadDependencyPackageForceRecheck:
 
         assert len(call_log) == 0
         assert result is not None
+
+    def test_existing_path_calls_callback_for_changed_literal_ref(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        mods = tmp_path / "apm_modules"
+        pkg_dir = mods / "org" / "pkg"
+        pkg_dir.mkdir(parents=True)
+        (pkg_dir / "apm.yml").write_text("name: pkg\nversion: 1.0.0\n")
+        lockfile = LockFile()
+        lockfile.add_dependency(
+            LockedDependency(
+                repo_url="org/pkg",
+                resolved_ref="a" * 40,
+                resolved_commit="a" * 40,
+            )
+        )
+        calls: list[DependencyReference] = []
+
+        def cb(dep_ref, modules_dir, parent_chain="", parent_pkg=None):
+            calls.append(dep_ref)
+            return pkg_dir
+
+        ref = DependencyReference(repo_url="org/pkg", reference="b" * 40)
+        resolver = APMDependencyResolver(
+            apm_modules_dir=mods,
+            download_callback=cb,
+            existing_lockfile=lockfile,
+        )
+
+        assert resolver._try_load_dependency_package(ref) is not None
+        assert calls == [ref]
 
     def test_existing_path_skips_callback_for_literal_ref_even_with_update_refs(
         self, tmp_path: Path

--- a/tests/unit/test_install_update_refs.py
+++ b/tests/unit/test_install_update_refs.py
@@ -11,8 +11,11 @@ Covers two code paths fixed in issue #548:
    short-circuit the download.  Only lockfile_match (SHA comparison) may skip.
 """
 
+from types import SimpleNamespace
+
 import pytest
 
+from apm_cli.drift import should_force_ref_recheck
 from apm_cli.install.phases._skip_logic import (
     _compute_skip_download,
     _should_use_locked_ref,
@@ -330,31 +333,29 @@ class TestAlreadyResolvedSkipLogic:
 
 
 # ===========================================================================
-# TestForceSemverResolve -- BFS callback early-return guard
+# TestForceRefRecheck -- BFS callback early-return guard
 # ===========================================================================
 
 
-def _force_semver_resolve(
+def _recheck_dep(
     *,
-    update_refs: bool,
     is_local: bool,
-    source: str | None,
     artifactory_prefix: str | None,
     ref_kind: str | None,
-) -> bool:
-    """Mirror of the _force_semver_resolve expression in download_callback.
+) -> SimpleNamespace:
+    """Build the minimal dependency shape consumed by the canonical owner."""
+    return SimpleNamespace(
+        is_local=is_local,
+        artifactory_prefix=artifactory_prefix,
+        ref_kind=ref_kind,
+    )
 
-    Kept in sync with resolve.py so that any change to the production
-    condition surfaces here as a test failure.
-    """
-    return update_refs and not is_local and not artifactory_prefix and ref_kind == "semver"
 
-
-class TestForceSemverResolve:
-    """BFS download_callback must re-resolve semver deps on --update.
+class TestForceRefRecheck:
+    """BFS download callback must re-resolve semver deps on update.
 
     When install_path exists the callback short-circuits UNLESS
-    _force_semver_resolve is True.  Regression guard for the bug where
+    ``should_force_ref_recheck`` is true. Regression guard for the bug where
     registry deps with semver constraints were excluded from re-resolution,
     causing 'apm update' to silently keep the old version even when a newer
     one satisfying the range was available.
@@ -363,12 +364,14 @@ class TestForceSemverResolve:
     def test_registry_semver_forces_resolve_on_update(self) -> None:
         """Registry dep with ^1.0.0 must re-resolve when update_refs=True."""
         assert (
-            _force_semver_resolve(
+            should_force_ref_recheck(
+                _recheck_dep(
+                    is_local=False,
+                    artifactory_prefix=None,
+                    ref_kind="semver",
+                ),
+                None,
                 update_refs=True,
-                is_local=False,
-                source="registry",
-                artifactory_prefix=None,
-                ref_kind="semver",
             )
             is True
         )
@@ -376,12 +379,14 @@ class TestForceSemverResolve:
     def test_registry_semver_no_force_on_normal_install(self) -> None:
         """Registry semver dep must NOT re-resolve on a plain install."""
         assert (
-            _force_semver_resolve(
+            should_force_ref_recheck(
+                _recheck_dep(
+                    is_local=False,
+                    artifactory_prefix=None,
+                    ref_kind="semver",
+                ),
+                None,
                 update_refs=False,
-                is_local=False,
-                source="registry",
-                artifactory_prefix=None,
-                ref_kind="semver",
             )
             is False
         )
@@ -389,12 +394,14 @@ class TestForceSemverResolve:
     def test_git_semver_forces_resolve_on_update(self) -> None:
         """Git-source semver dep continues to re-resolve (pre-existing behavior)."""
         assert (
-            _force_semver_resolve(
+            should_force_ref_recheck(
+                _recheck_dep(
+                    is_local=False,
+                    artifactory_prefix=None,
+                    ref_kind="semver",
+                ),
+                None,
                 update_refs=True,
-                is_local=False,
-                source=None,
-                artifactory_prefix=None,
-                ref_kind="semver",
             )
             is True
         )
@@ -402,12 +409,14 @@ class TestForceSemverResolve:
     def test_registry_literal_ref_no_force(self) -> None:
         """Registry dep with a literal ref (e.g. 'stable') is never force-resolved."""
         assert (
-            _force_semver_resolve(
+            should_force_ref_recheck(
+                _recheck_dep(
+                    is_local=False,
+                    artifactory_prefix=None,
+                    ref_kind="literal",
+                ),
+                None,
                 update_refs=True,
-                is_local=False,
-                source="registry",
-                artifactory_prefix=None,
-                ref_kind="literal",
             )
             is False
         )
@@ -415,12 +424,14 @@ class TestForceSemverResolve:
     def test_local_dep_never_force_resolved(self) -> None:
         """Local deps are excluded regardless of ref_kind."""
         assert (
-            _force_semver_resolve(
+            should_force_ref_recheck(
+                _recheck_dep(
+                    is_local=True,
+                    artifactory_prefix=None,
+                    ref_kind="semver",
+                ),
+                None,
                 update_refs=True,
-                is_local=True,
-                source=None,
-                artifactory_prefix=None,
-                ref_kind="semver",
             )
             is False
         )
@@ -428,12 +439,14 @@ class TestForceSemverResolve:
     def test_artifactory_dep_never_force_resolved(self) -> None:
         """Artifactory-proxied deps are excluded regardless of ref_kind."""
         assert (
-            _force_semver_resolve(
+            should_force_ref_recheck(
+                _recheck_dep(
+                    is_local=False,
+                    artifactory_prefix="artifactory/github",
+                    ref_kind="semver",
+                ),
+                None,
                 update_refs=True,
-                is_local=False,
-                source=None,
-                artifactory_prefix="artifactory/github",
-                ref_kind="semver",
             )
             is False
         )

--- a/tests/unit/test_install_update_refs.py
+++ b/tests/unit/test_install_update_refs.py
@@ -377,7 +377,7 @@ class TestForceRefRecheck:
         )
 
     def test_registry_semver_no_force_on_normal_install(self) -> None:
-        """Registry semver dep must NOT re-resolve on a plain install."""
+        """A dependency without lock provenance must re-resolve on plain install."""
         assert (
             should_force_ref_recheck(
                 _recheck_dep(
@@ -388,7 +388,7 @@ class TestForceRefRecheck:
                 None,
                 update_refs=False,
             )
-            is False
+            is True
         )
 
     def test_git_semver_forces_resolve_on_update(self) -> None:
@@ -415,7 +415,7 @@ class TestForceRefRecheck:
                     artifactory_prefix=None,
                     ref_kind="literal",
                 ),
-                None,
+                SimpleNamespace(),
                 update_refs=True,
             )
             is False


### PR DESCRIPTION
# fix(consume): expand source/ref/cache contracts

## TL;DR

Adds an eight-row, real-binary Consume matrix across GitHub, GHE Cloud,
GitLab, and Azure DevOps source forms; full-SHA, literal-tag, and semver
references; cold resolution; warm cache-only audit; convergence; transition;
and invalid-ref rollback. The matrix exposed and fixes a bug where
`apm install` silently reused existing package bytes after a manifest changed
from one literal ref to another.

> [!NOTE]
> Hermetic URL rewriting proves parser, host-classification, Git transport,
> lock, cache, deployment, and audit behavior. It does not claim remote auth
> or provider API coverage.
>
> `apm-spec-waiver: resolver cache-gate repair restores existing literal-ref reconciliation; no new normative surface.`

## Problem (WHY)

- [x] PR #2212 proves additive subsets and GitLab branch convergence, but not
  variation across supported source, immutable-ref, and cache states.
- [x] The new transition scenario reproduced a concrete failure: changing a
  GitLab dependency from HTTPS at SHA A to SCP at SHA B returned success while
  retaining SHA A in `apm.lock.yaml` and deployed bytes.
- [!] The resolver and download callback independently decided whether an
  existing install path could skip resolution, so the canonical ref-drift
  decision was unreachable on this path.

Why these matter: scenario claims should be backed by execution because
["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/).
The repair also follows
["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)
by extending the existing drift owner instead of adding a resolver authority.

## Approach (WHAT)

| # | Fix | Principle |
|---:|---|---|
| 1 | Add one finite, parametrized real-binary matrix with a fixed one-skill package and `copilot` target. | ["agents pattern-match well against concrete structures"](https://agentskills.io/skill-creation/best-practices) |
| 2 | Route both existing-path gates through `drift.py::should_force_ref_recheck`. | One durable decision, one owner |
| 3 | Enroll the module in the finite critical suite and guard against reintroducing mirrored predicates. | Executable architecture contract |

## Implementation (HOW)

| File | Change |
|---|---|
| `tests/integration/test_consume_source_ref_cache_matrix.py` | Adds eight hermetic rows using `apm_binary_path`, lifecycle utilities, local Git origins, exact lock/deployment assertions, timing properties, and a positive/negative transition twin. |
| `src/apm_cli/drift.py` | Adds the single existing-path recheck decision, composing the established `detect_ref_change` owner. |
| `src/apm_cli/deps/apm_resolver.py` | Supplies lockfile provenance to the resolver and delegates its early gate to the shared owner. |
| `src/apm_cli/install/phases/resolve.py` | Routes the download callback's cache gate through the same owner; no second ref predicate remains. |
| `scripts/lint-architecture-boundaries.sh` | Adds an AC4 guard requiring both consumers to call the owner and rejecting duplicate definitions. |
| `tests/integration/test_architecture_authorities.py` | Makes that owner/consumer/static-guard relationship executable. |
| `tests/unit/deps/test_apm_resolver_edge_cases.py` | Covers changed and unchanged literal refs, including callback reachability with an existing install path. |
| `tests/unit/test_install_update_refs.py` | Removes the old mirrored semver predicate and tests the canonical helper directly. |
| `tests/quality/critical_suite.toml` | Adds the new module as `e2e` while preserving existing Consume and Produce entries. |
| `tests/quality/test_test_taxonomy.py` | Advances the finite manifest count from eight to nine. |
| `CHANGELOG.md` | Records the user-visible literal-ref reuse fix and matrix coverage under Unreleased/Fixed. |

## Diagrams

Legend: the dashed node is the new shared decision; reviewers should verify
that both resolver gates reach it before existing bytes are reused.

```mermaid
flowchart LR
    subgraph Inputs[Durable inputs]
        M[apm.yml ref]
        L[apm.lock.yaml provenance]
        C[existing install path]
    end
    subgraph Decision[Canonical drift decision]
        R[should_force_ref_recheck]:::new
        D[detect_ref_change]
    end
    subgraph Outcomes[Install outcome]
        K[reuse locked bytes]
        F[resolve and download manifest ref]
        W[write lock and deploy]
    end
    M --> R
    L --> R
    C --> R
    R --> D
    R -->|unchanged| K
    R -->|changed| F
    F --> W
    classDef new stroke-dasharray: 5 5;
    class R new;
```

## Trade-offs

- **Hermetic rewrites over live providers.** Chose local bare origins and Git
  `insteadOf`; rejected network/token fixtures because this PR proves source
  syntax and lifecycle behavior, not remote auth or API semantics.
- **Finite matrix over combinatorial coverage.** Chose eight load-bearing rows;
  rejected Cartesian expansion to keep runtime bounded.
- **Existing drift owner over resolver-local logic.** Chose one shared decision;
  rejected another cache/ref helper and added a static guard against regression.
- **Intentional omissions.** Local-directory and GitLab branch convergence
  remain in #2212; direct `file://` dependency input is unsupported; primitive
  shape, policy, registry, marketplace, and auth variation remain separate.

## Benefits

1. Eight real-binary rows now cover four canonical host families, three ref
   classes, cold/warm cache states, convergence, transition, and rollback.
2. A literal ref change can no longer return success while retaining stale lock
   provenance and deployed bytes.
3. Two runtime consumers now share one ref-recheck owner, with unit,
   architecture, static, and mutation guards.
4. The full matrix runs in about 75 seconds locally without network or tokens.

## Validation

`apm audit --ci --format json`:

```text
"summary": {
  "total": 9,
  "passed": 9,
  "failed": 0
}
```

<details><summary>Focused, lifecycle, quality, and mutation evidence</summary>

```text
8 passed in 74.48s
18 passed, 2 skipped in 175.79s
160 passed in 192.38s
163 passed, 2 skipped in 154.20s (post-panel)
52 passed in 48.51s
[+] assertion-quality ratchet clean: AQ001=5, AQ002=12
[+] exact test duplicate ratchet clean: 1039 files, 8 allowed duplicate group(s)
[+] architecture boundary lint clean

Mutation: should_force_ref_recheck(..., update_refs=False) -> False
2 failed in 3.80s
Restored implementation
2 passed in 5.26s
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | Install immutable dependencies from GitHub HTTPS/SCP, GHE Cloud SSH, and ADO HTTPS/SCP; lock and deployed bytes identify the selected commit. | Vendor-neutral, Governed by policy | `tests/integration/test_consume_source_ref_cache_matrix.py::test_immutable_source_ref_rows_resolve_deploy_audit_and_converge` | e2e |
| 2 | Resolve a GitLab semver range to the highest matching tag and an ADO literal tag to its immutable commit. | Vendor-neutral, DevX | `tests/integration/test_consume_source_ref_cache_matrix.py::test_immutable_source_ref_rows_resolve_deploy_audit_and_converge` | e2e |
| 3 | Run cache-only audit after the rewritten origin disappears; deployed state remains verifiable without network. | Secure by default, Governed by policy | `tests/integration/test_consume_source_ref_cache_matrix.py::test_warm_cache_only_audit_replays_after_origin_becomes_unavailable` | e2e |
| 4 | Change one dependency from GitLab HTTPS/SHA A to SCP/SHA B; install updates once, converges, and an invalid SHA fails without mutating the last good lock or deployment. | Secure by default, DevX | `tests/integration/test_consume_source_ref_cache_matrix.py::test_source_ref_transition_applies_once_and_invalid_twin_preserves_state` (regression trap discovered by this matrix) | e2e |
| 5 | Re-running install for full SHAs and update for tag/range refs produces no artifact changes when upstream state is unchanged. | DevX, Governed by policy | `tests/integration/test_consume_source_ref_cache_matrix.py::test_immutable_source_ref_rows_resolve_deploy_audit_and_converge` | e2e |

## How to test

- [ ] Set `APM_BINARY_PATH` to the built executable and run the matrix module;
  expect eight passes and no network/token prerequisite.
- [ ] Run `test_real_consume_contracts.py`, `test_produce_consume_contract.py`,
  and `test_hermetic_lifecycle_foundation.py`; existing contracts stay green.
- [ ] Run `tests/quality` and both strict ratchet scripts; the nine-module
  manifest remains finite, unique, and classified.
- [ ] Run the CI lint mirror plus `scripts/lint-architecture-boundaries.sh`;
  AC1-AC9 and duplication checks stay green.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
