### PR TITLE
fix(deps): canonicalize virtual package manifest bytes

### DIFF
--- a/src/apm_cli/deps/github_downloader.py
+++ b/src/apm_cli/deps/github_downloader.py
@@ -29,6 +29,7 @@ from ..models.apm_package import (
     ResolvedReference,
     validate_apm_package,
 )
+from ..utils.atomic_io import atomic_write_text
 from ..utils.console import (
     _rich_warning,  # noqa: F401  -- re-exported; tests patch github_downloader._rich_warning
 )
@@ -1001,7 +1002,7 @@ class GitHubPackageDownloader:
         apm_yml_content = yaml_to_str(apm_yml_data)
 
         apm_yml_path = target_path / "apm.yml"
-        apm_yml_path.write_text(apm_yml_content, encoding="utf-8")
+        atomic_write_text(apm_yml_path, apm_yml_content)
 
         # Create APMPackage object
         package = APMPackage(

--- a/tests/integration/test_install_content_hash_roundtrip.py
+++ b/tests/integration/test_install_content_hash_roundtrip.py
@@ -8,6 +8,8 @@ re-download unchanged on-disk bytes.
 
 from __future__ import annotations
 
+import json
+import shutil
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -25,10 +27,14 @@ from apm_cli.models.apm_package import (
     ResolvedReference,
 )
 from apm_cli.models.dependency.reference import DependencyReference
+from apm_cli.utils.content_hash import compute_package_hash
 
 pytestmark = pytest.mark.component
 
 _PATCH_UPDATES = "apm_cli.commands._helpers.check_for_updates"
+_VIRTUAL_COMMIT = "a" * 40
+_VIRTUAL_DEPENDENCY = "acme/fixture/instructions/fixture.instructions.md#" + _VIRTUAL_COMMIT
+_VIRTUAL_SOURCE = b"# Fixture\nsame payload\n"
 
 
 class _ContentHashOnlyDownloader:
@@ -101,10 +107,52 @@ def _run_install(runner: CliRunner, project: Path, monkeypatch: pytest.MonkeyPat
         return runner.invoke(cli, ["install"], catch_exceptions=False)
 
 
+def _run_command(
+    runner: CliRunner,
+    project: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    args: list[str],
+) -> object:
+    monkeypatch.chdir(project)
+    with patch(_PATCH_UPDATES, return_value=None):
+        return runner.invoke(cli, args, catch_exceptions=False)
+
+
 def _locked_dep(project: Path) -> dict:
     lockfile = yaml.safe_load((project / "apm.lock.yaml").read_text(encoding="utf-8"))
     deps = lockfile.get("dependencies") or []
     return next(dep for dep in deps if dep.get("repo_url") == "acme/fixture-pkg")
+
+
+def _write_virtual_project(project: Path) -> None:
+    project.mkdir(parents=True, exist_ok=True)
+    (project / ".github").mkdir()
+    (project / ".github" / "copilot-instructions.md").write_text(
+        "# Project\n",
+        encoding="utf-8",
+    )
+    (project / "apm.yml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "virtual-hash-roundtrip",
+                "version": "1.0.0",
+                "target": "copilot",
+                "dependencies": {"apm": [_VIRTUAL_DEPENDENCY], "mcp": []},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _locked_virtual_dep(project: Path) -> dict:
+    lockfile = yaml.safe_load((project / "apm.lock.yaml").read_text(encoding="utf-8"))
+    deps = lockfile.get("dependencies") or []
+    return next(
+        dep
+        for dep in deps
+        if dep.get("repo_url") == "acme/fixture"
+        and dep.get("virtual_path") == "instructions/fixture.instructions.md"
+    )
 
 
 def test_no_resolved_commit_content_hash_reuses_on_disk_package(
@@ -139,3 +187,113 @@ def test_no_resolved_commit_content_hash_reuses_on_disk_package(
     second = _run_install(runner, project, monkeypatch)
     assert second.exit_code == 0, second.output
     assert downloader.calls == 1
+
+
+def test_virtual_lock_replays_across_synthetic_manifest_newline_domains(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A lock made in an LF domain installs and audits in a CRLF domain."""
+    project = tmp_path / "virtual-project"
+    _write_virtual_project(project)
+    newline_domain = {"value": "lf"}
+    original_write_text = Path.write_text
+
+    def write_with_platform_newlines(
+        path,
+        data,
+        encoding=None,
+        errors=None,
+        newline=None,
+    ):
+        if path.name == "apm.yml" and "apm_modules" in path.parts:
+            canonical = data.replace("\r\n", "\n")
+            data = (
+                canonical.replace("\n", "\r\n") if newline_domain["value"] == "crlf" else canonical
+            )
+            newline = ""
+        return original_write_text(
+            path,
+            data,
+            encoding=encoding,
+            errors=errors,
+            newline=newline,
+        )
+
+    from apm_cli.deps import github_downloader as _ghd
+
+    monkeypatch.setattr(Path, "write_text", write_with_platform_newlines)
+    monkeypatch.setattr(
+        _ghd.GitHubPackageDownloader,
+        "validate_virtual_package_exists",
+        lambda self, *args, **kwargs: True,
+    )
+    monkeypatch.setattr(
+        _ghd.GitHubPackageDownloader,
+        "_resolve_commit_sha_for_ref",
+        lambda self, dep_ref, ref: _VIRTUAL_COMMIT,
+    )
+    monkeypatch.setattr(
+        _ghd.GitHubPackageDownloader,
+        "download_raw_file",
+        lambda self, dep_ref, file_path, ref: _VIRTUAL_SOURCE,
+    )
+
+    runner = CliRunner()
+    locked = _run_command(
+        runner,
+        project,
+        monkeypatch,
+        [
+            "lock",
+            "--target",
+            "copilot",
+            "--no-policy",
+            "--parallel-downloads",
+            "0",
+        ],
+    )
+    assert locked.exit_code == 0, locked.output
+    lf_locked_hash = _locked_virtual_dep(project)["content_hash"]
+
+    dep_ref = DependencyReference.parse(_VIRTUAL_DEPENDENCY)
+    install_path = dep_ref.get_install_path(project / "apm_modules")
+    assert install_path.is_dir()
+    assert b"\r\n" not in (install_path / "apm.yml").read_bytes()
+
+    shutil.rmtree(install_path)
+    newline_domain["value"] = "crlf"
+    installed = _run_command(
+        runner,
+        project,
+        monkeypatch,
+        [
+            "install",
+            "--target",
+            "copilot",
+            "--no-policy",
+            "--parallel-downloads",
+            "0",
+        ],
+    )
+    assert installed.exit_code == 0, installed.output
+
+    installed_manifest = (install_path / "apm.yml").read_bytes()
+    assert b"\r\n" not in installed_manifest
+    converged_hash = _locked_virtual_dep(project)["content_hash"]
+    assert converged_hash == lf_locked_hash
+    assert compute_package_hash(install_path) == converged_hash
+
+    audited = _run_command(
+        runner,
+        project,
+        monkeypatch,
+        ["audit", "--ci", "--no-policy", "--format", "json"],
+    )
+    assert audited.exit_code == 0, audited.output
+    json_start = audited.output.find("{")
+    assert json_start >= 0, audited.output
+    audit_payload = json.loads(audited.output[json_start:])
+    assert audit_payload["passed"] is True
+    checks = {check["name"]: check for check in audit_payload["checks"]}
+    assert checks["content-integrity"]["passed"] is True

--- a/tests/quality/test_test_taxonomy.py
+++ b/tests/quality/test_test_taxonomy.py
@@ -135,7 +135,7 @@ def test_tm001_behavioral_marker_definitions_match_spec() -> None:
 
 def test_tm002_manifest_is_finite_unique_and_existing() -> None:
     modules = _manifest_modules()
-    assert len(modules) == 9
+    assert len(modules) == 10
     paths = [entry["path"] for entry in modules]
     assert len(paths) == len(set(paths))
     assert {entry["marker"] for entry in modules} == BEHAVIORAL_MARKERS

--- a/tests/test_github_downloader.py
+++ b/tests/test_github_downloader.py
@@ -1838,6 +1838,81 @@ class TestVirtualFilePackageYamlGeneration:
         parsed = yaml.safe_load(content)
         assert parsed["description"] == "A simple agent without special chars"
 
+    def test_synthetic_manifest_is_canonical_before_package_hash(self, tmp_path):
+        """Synthetic metadata is LF-stable while source bytes stay hash-visible."""
+        from apm_cli.utils.content_hash import compute_package_hash
+
+        source_bytes = b"# Fixture\nsame payload\n"
+        original_write_text = Path.write_text
+
+        def materialize(
+            label: str,
+            newline_domain: str,
+            content: bytes = source_bytes,
+        ) -> tuple[str, bytes, bytes]:
+            target_path = tmp_path / label
+            dep_ref = self._make_dep_ref("instructions/fixture.instructions.md")
+            downloader = GitHubPackageDownloader()
+
+            def write_with_platform_newlines(
+                path,
+                data,
+                encoding=None,
+                errors=None,
+                newline=None,
+            ):
+                canonical = data.replace("\r\n", "\n")
+                rendered = (
+                    canonical.replace("\n", "\r\n") if newline_domain == "crlf" else canonical
+                )
+                return original_write_text(
+                    path,
+                    rendered,
+                    encoding=encoding,
+                    errors=errors,
+                    newline="",
+                )
+
+            with (
+                patch.object(
+                    downloader,
+                    "_resolve_commit_sha_for_ref",
+                    return_value="a" * 40,
+                ),
+                patch.object(downloader, "download_raw_file", return_value=content),
+                patch.object(Path, "write_text", new=write_with_platform_newlines),
+            ):
+                downloader.download_virtual_file_package(dep_ref, target_path)
+
+            return (
+                compute_package_hash(target_path),
+                (target_path / "apm.yml").read_bytes(),
+                (target_path / ".apm" / "instructions" / "fixture.instructions.md").read_bytes(),
+            )
+
+        lf_hash, lf_manifest, lf_source = materialize("lf", "lf")
+        crlf_hash, crlf_manifest, crlf_source = materialize("crlf", "crlf")
+
+        assert lf_source == crlf_source == source_bytes
+        assert b"\r\n" not in lf_manifest
+        assert crlf_manifest == lf_manifest
+        assert crlf_hash == lf_hash
+
+        changed_hash, _, _ = materialize(
+            "changed-content",
+            "lf",
+            b"# Fixture\nchanged payload\n",
+        )
+        assert changed_hash != lf_hash
+
+        user_crlf_hash, _, user_crlf_source = materialize(
+            "user-crlf",
+            "lf",
+            source_bytes.replace(b"\n", b"\r\n"),
+        )
+        assert user_crlf_source != lf_source
+        assert user_crlf_hash != lf_hash
+
 
 class TestRefExistsViaLsRemote:
     """Tests for ``_clone_with_fallback``'s auth path so validation


### PR DESCRIPTION
# fix(deps): canonicalize virtual package manifest bytes

## TL;DR

Virtual single-file packages now write their synthetic `apm.yml` through APM's canonical LF atomic writer before the raw package-tree hash is computed. Equivalent LF and CRLF newline domains therefore converge on one lock hash, while downloaded user-authored bytes remain byte-sensitive. This closes #2187 without broadening normalization inside `compute_package_hash`.

> [!NOTE]
> The regression suite simulates LF and CRLF text-write domains hermetically. It does not claim execution on a hosted Windows runner.

## Problem (WHY)

- [x] The synthetic virtual-package manifest used `Path.write_text`, allowing host text-mode newline translation to change generated bytes.
- [x] `compute_package_hash` correctly hashes every package file as raw bytes, so the generated manifest difference became a lockfile integrity mismatch even when the pinned source bytes were identical.
- [!] Normalizing all text inside the raw package hash would hide byte changes in user-authored package content and expand the integrity-domain change beyond #2187.

The fix keeps evidence deterministic at its owner boundary: ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) It also remains surgical by reusing an existing primitive: ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)

## Approach (WHAT)

| # | Fix | Principle |
|---:|---|---|
| 1 | Route synthetic `apm.yml` writes through `atomic_write_text`. | ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |
| 2 | Keep `compute_package_hash` unchanged and raw-byte sensitive. | ["Add what the agent lacks, omit what it knows"](https://agentskills.io/skill-creation/best-practices) |
| 3 | Prove the owner contract and a real lock/install/audit replay with hermetic newline domains. | ["agents pattern-match well against concrete structures"](https://agentskills.io/skill-creation/best-practices) |

## Implementation (HOW)

- **[`src/apm_cli/deps/github_downloader.py`](https://github.com/microsoft/apm/blob/cc0e23faa5becc2e8dcca3b3df758be2276a96f7/src/apm_cli/deps/github_downloader.py#L995-L1008)** - the virtual-file materializer still serializes through `yaml_to_str`, but now commits the generated manifest with the existing LF-normalizing atomic writer.
- **[`tests/test_github_downloader.py`](https://github.com/microsoft/apm/blob/cc0e23faa5becc2e8dcca3b3df758be2276a96f7/tests/test_github_downloader.py#L1841-L1915)** - adds the owner-level metamorphic contract: newline-only synthetic metadata converges, real content mutations diverge, and source CRLF remains hash-visible.
- **[`tests/integration/test_install_content_hash_roundtrip.py`](https://github.com/microsoft/apm/blob/cc0e23faa5becc2e8dcca3b3df758be2276a96f7/tests/integration/test_install_content_hash_roundtrip.py#L192-L304)** - adds a component scenario that creates a lock in an LF domain, forces fresh materialization in a CRLF domain, installs against the original lock, asserts hash convergence, and runs audit.
- **[`tests/quality/test_test_taxonomy.py`](https://github.com/microsoft/apm/blob/fe9446917c04f0734c4b3a4692869406d06d7da8/tests/quality/test_test_taxonomy.py#L136-L142)** - aligns the finite critical-suite count with the 10 entries already committed on the base branch, restoring the exact architecture-ratchet job.

## Diagrams

Legend: the dashed stage is the only production behavior changed; raw source bytes and raw tree hashing retain their existing contracts.

```mermaid
flowchart LR
    subgraph Materialize[Virtual package materialization]
        S[Downloaded source bytes]
        W[write_bytes]
        Y[yaml_to_str]
        A[atomic_write_text]:::new
    end
    subgraph Integrity[Integrity domain]
        T[Materialized package tree]
        H[compute_package_hash]
        L[apm.lock.yaml content_hash]
    end
    S --> W
    W --> T
    Y --> A
    A --> T
    T --> H
    H --> L
    classDef new stroke-dasharray: 5 5;
    class A new;
```

## Trade-offs

- **Canonicalize at generation, not hashing.** Chose the synthetic-manifest owner; rejected generic text normalization in `compute_package_hash` because user-authored bytes must remain integrity-visible.
- **Reuse the atomic writer.** Chose `atomic_write_text`; rejected a local `newline=""` write because it would duplicate the canonical LF and crash-safety decision.
- **No new architecture guard.** The owner did not move or split; this patch removes a bypass of the existing atomic-I/O owner, and AC1-AC9 remain clean.
- **No hosted-Windows claim.** The tests model newline domains deterministically on the current host. Hosted Windows evidence remains the post-merge platform matrix's responsibility.
- **Repair inherited ratchet parity.** Chose the one-line expected-count alignment; rejected leaving the PR with a known red architecture job inherited from current `main`.

## Benefits

1. Two materialized trees that differ only by the legacy synthetic-manifest newline domain produce one identical `sha256:` package hash.
2. A lock produced in the LF domain installs successfully after forced fresh materialization in the CRLF domain.
3. A real source-content mutation still changes the package hash.
4. User-authored LF and CRLF byte sequences still produce different package hashes.
5. The lock/install flow converges and `content-integrity` audit passes.

## Validation

`uv run apm audit --ci --no-policy --format json`:

```text
[+] No drift detected
"passed": true
"summary": {"total": 9, "passed": 9, "failed": 0}
```

`uv run --extra dev pytest -q tests/test_github_downloader.py::TestVirtualFilePackageYamlGeneration tests/integration/test_install_content_hash_roundtrip.py`:

```text
6 passed in 1.57s
```

`uv run pytest tests/unit tests/test_console.py tests/red_team -n 2 --dist worksteal --no-cov -q`:

```text
19042 passed, 2 skipped, 21 xfailed, 86 subtests passed
```

<details><summary>Lint, architecture, mutation, and ratchet evidence</summary>

```text
Ruff lint: pass
Ruff format: pass
YAML I/O safety: pass
File length guard: pass
portable_relpath guard: pass
pylint R0801: pass
auth boundary: pass
architecture boundaries AC1-AC9: pass

Mutation: restoring Path.write_text made both new contracts fail with distinct LF/CRLF hashes.

check_test_assertions.py: pass
check_exact_test_duplicates.py: pass
check_test_contract_authorities.py: pass
tests/unit/utils/test_atomic_io.py: 18 passed
Test Architecture Ratchets: 52 passed
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | The same pinned virtual file keeps one lock hash when generated metadata crosses LF and CRLF newline domains. | Portability by manifest, Secure by default, Governed by policy | `tests/test_github_downloader.py::TestVirtualFilePackageYamlGeneration::test_synthetic_manifest_is_canonical_before_package_hash` (regression-trap for #2187) | unit |
| 2 | A lock created in one newline domain installs and audits after fresh materialization in the other domain. | Portability by manifest, Secure by default, Governed by policy, DevX | `tests/integration/test_install_content_hash_roundtrip.py::test_virtual_lock_replays_across_synthetic_manifest_newline_domains` (regression-trap for #2187) | integration |
| 3 | Changing downloaded source bytes still changes the package integrity hash. | Secure by default | `tests/test_github_downloader.py::TestVirtualFilePackageYamlGeneration::test_synthetic_manifest_is_canonical_before_package_hash` | unit |

## How to test

- [ ] Run the focused six-test command above; expect all tests to pass.
- [ ] Replace `atomic_write_text` with the prior `Path.write_text` call; expect both #2187 regression contracts to fail.
- [ ] Restore `atomic_write_text` and run the lint mirror; expect Ruff, R0801, auth, and AC1-AC9 to pass.
- [ ] Run the exact architecture-ratchet pytest selection; expect 52 tests to pass.
- [ ] Run `uv run apm audit --ci --no-policy --format json`; expect 9/9 checks to pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
