### PR TITLE
test(quality): synchronize the finite critical-suite count

### DIFF
--- a/tests/quality/test_test_taxonomy.py
+++ b/tests/quality/test_test_taxonomy.py
@@ -135,7 +135,7 @@ def test_tm001_behavioral_marker_definitions_match_spec() -> None:
 
 def test_tm002_manifest_is_finite_unique_and_existing() -> None:
     modules = _manifest_modules()
-    assert len(modules) == 11
+    assert len(modules) == 12
     paths = [entry["path"] for entry in modules]
     assert len(paths) == len(set(paths))
     assert {entry["marker"] for entry in modules} == BEHAVIORAL_MARKERS


### PR DESCRIPTION
# fix(quality): synchronize the finite critical-suite count

## TL;DR

Updates the TM002 finite-manifest assertion from 11 to 12 so it matches the 12 entries already present in `tests/quality/critical_suite.toml` on `main`. This restores the Test Architecture Ratchets job without weakening the finite, uniqueness, marker, or file-existence checks.

> [!IMPORTANT]
> This is a one-line test-manifest synchronization against `main` at `bf2a12b9190a822ab5e9279b4dccf00dcbbd991d`.

## Problem (WHY)

- [x] Untouched `main` fails `test_tm002_manifest_is_finite_unique_and_existing` with `AssertionError: assert 12 == 11`.
- [x] The stale count makes every dependent PR fail the required Test Architecture Ratchets job even though all 12 manifest entries are finite, unique, classified, and present.
- [!] The ratchet must remain explicit rather than deriving the expected count from the manifest itself. ["Be prescriptive when operations are fragile, consistency matters, or a specific sequence must be followed."](https://agentskills.io/skill-creation/best-practices)

## Approach (WHAT)

| # | Fix | Principle | Source |
|---:|---|---|---|
| 1 | Change only the finite expected count from 11 to 12. | "Be prescriptive when operations are fragile, consistency matters, or a specific sequence must be followed." | [Agent Skills](https://agentskills.io/skill-creation/best-practices) |
| 2 | Preserve all uniqueness, marker-set, and file-existence assertions. | "The pattern is: do the work, run a validator (a script, a reference checklist, or a self-check), fix any issues, and repeat until validation passes." | [Agent Skills](https://agentskills.io/skill-creation/best-practices) |

## Implementation (HOW)

- **`tests/quality/test_test_taxonomy.py`** — synchronizes TM002's literal finite count with the 12-entry canonical manifest. No production code, manifest entries, markers, quality thresholds, documentation, or changelog content changes.

## Diagrams

Legend: The manifest remains the canonical finite list; this PR updates only the stale expected-count node that gates the existing quality checks.

```mermaid
flowchart LR
    M["critical_suite.toml<br/>12 modules"]
    P["_manifest_modules"]
    C["TM002 expected count = 12"]
    R["uniqueness, markers, files"]
    G["Test Architecture Ratchets"]
    M --> P
    P --> C
    C --> R
    R --> G
    classDef new stroke-dasharray: 5 5;
    class C new;
```

## Trade-offs

- **Keep a literal count.** Chose updating 11 to 12; rejected deriving the value from the manifest because that would weaken the finite ratchet and stop catching unreviewed manifest growth.
- **Keep the hotfix bounded.** Chose no docs or changelog entry; rejected unrelated edits because this changes only an internal quality-test expectation and no user-facing behavior.

## Benefits

1. The exact TM002 regression changes from 1 failure to 1 pass.
2. All 25 tests under `tests/quality` pass against the 12-entry manifest.
3. The required architecture-ratchet path can complete without relaxing any quality assertion.

## Validation

<details><summary>RED on untouched main</summary>

`uv run --extra dev pytest -p no:cacheprovider -q tests/quality/test_test_taxonomy.py::test_tm002_manifest_is_finite_unique_and_existing`:

```text
F                                                                        [100%]
=================================== FAILURES ===================================
______________ test_tm002_manifest_is_finite_unique_and_existing _______________

    def test_tm002_manifest_is_finite_unique_and_existing() -> None:
        modules = _manifest_modules()
>       assert len(modules) == 11
E       AssertionError: assert 12 == 11

tests/quality/test_test_taxonomy.py:138: AssertionError
=========================== short test summary info ============================
FAILED tests/quality/test_test_taxonomy.py::test_tm002_manifest_is_finite_unique_and_existing
1 failed in 5.90s
```

</details>

`uv run --extra dev pytest -p no:cacheprovider -q tests/quality/test_test_taxonomy.py::test_tm002_manifest_is_finite_unique_and_existing`:

```text
.                                                                        [100%]
1 passed in 2.53s
```

`uv run --extra dev pytest -p no:cacheprovider -q tests/quality`:

```text
.........................                                                [100%]
25 passed in 66.10s (0:01:06)
```

`uv run --frozen python scripts/check_test_assertions.py`:

```text
[+] assertion-quality ratchet clean: AQ001=5, AQ002=12
```

`uv run --frozen python scripts/check_exact_test_duplicates.py`:

```text
[+] exact test duplicate ratchet clean: 1043 files, 8 allowed duplicate group(s)
```

<details><summary>Full CI lint mirror</summary>

`uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/ && uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/ && bash scripts/lint-auth-signals.sh`:

```text
All checks passed!
1524 files already formatted

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

[*] Rule A: get_bearer_provider boundary (any reference)
[*] Rule B: git ls-remote auth-delegated annotation
[+] auth-signal lint clean
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | Contributors can add a reviewed critical-suite module without an unrelated stale count blocking every dependent PR. | OSS / community-driven | `tests/quality/test_test_taxonomy.py::test_tm002_manifest_is_finite_unique_and_existing` (regression-trap for the merge-order break) | unit |

## How to test

- [ ] Check out this head and run the exact TM002 test; observe `1 passed`.
- [ ] Run `uv run --extra dev pytest -p no:cacheprovider -q tests/quality`; observe `25 passed`.
- [ ] Run both test-quality ratchet scripts; observe each reports a clean ratchet.
- [ ] Confirm the diff changes only `assert len(modules) == 11` to `assert len(modules) == 12`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
