### PR TITLE
fix(policy): honor Govern cache TTL with bounded property coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Govern policy cache freshness now honors the effective policy's `cache.ttl`;
+  bounded property coverage protects all 39 enforceable fields, cold/warm parity,
+  canonical serialization, and last-good bytes after malformed refreshes. (#2235)
 - Marketplace packages emitted as remote URL or subdirectory sources now
   preserve the package host, path, and ref through `apm install`, fixing
   cross-host enterprise validation and self-hosted GitLab monorepo installs.

--- a/docs/src/content/docs/enterprise/governance-guide.md
+++ b/docs/src/content/docs/enterprise/governance-guide.md
@@ -87,7 +87,7 @@ The scope matrix below is the contract. Every row maps a security or operational
 | Manifest scripts policy | `manifest.scripts` | `scripts-policy` | `[i] audit-only` | Yes |
 | Explicit manifest includes | `manifest.require_explicit_includes` | `explicit-includes` | `[i] audit-only` | Yes |
 | Unmanaged files in governed dirs | `unmanaged_files.action`, `.directories` | `unmanaged-files` | `[i] audit-only` | Yes |
-| Cache TTL override | `policy.cache.ttl` | -- | `[!] parsed but not enforced` (cache reader uses hardcoded 1h) | -- |
+| Cache freshness | `cache.ttl` | -- | Honored -- the cache reader uses the cached effective policy's `cache.ttl` (default `3600` seconds); entries older than the 7-day `MAX_STALE_TTL` ceiling are never served | Same |
 | Transitive MCP trust (policy field) | `mcp.trust_transitive` | -- | `[!] parsed but not enforced` (gate is the `--trust-transitive-mcp` CLI flag) | -- |
 | Manifest content types | `manifest.content_types` | -- | `[!] parsed but not enforced` | -- |
 
@@ -311,6 +311,7 @@ When `apm install` returns exit code 0 and the effective org policy is in `enfor
 - Compilation targets that would be written match `compilation.target.allow` (when `enforce: true` on that field).
 - The fetched policy file matched any `policy.hash` pin in `apm.yml`. If the hash did not match, install failed closed regardless of `fetch_failure_default` -- hash-mismatch is unconditionally fail-closed in non-dry-run install paths. (`apm install --dry-run` logs the mismatch but does not exit non-zero -- see section 14 gap.)
 - The lockfile (`apm.lock.yaml`) was regenerated from the resolved, gated set.
+- Any cached policy used was current within the effective `cache.ttl` (default `3600` seconds), or -- if a refresh failed -- was within the 7-day stale ceiling (`MAX_STALE_TTL`) and a warning was logged naming the cache age.
 
 You are NOT guaranteed:
 
@@ -319,7 +320,6 @@ You are NOT guaranteed:
 - That the audit-only checks (`compilation-strategy`, `source-attribution`, `required-manifest-fields`, `scripts-policy`, `unmanaged-files`) passed. Run `apm audit --ci --policy <scope>` in CI for those.
 - That non-APM files in the repo conform to anything. APM only governs files it placed.
 - Anything about runtime behavior. APM is install-time only.
-- That a `policy.cache.ttl` shorter or longer than 1 hour took effect. The cache reader uses a hardcoded 1-hour TTL; the `policy.cache.ttl` field is parsed but not honored.
 
 ---
 
@@ -329,11 +329,13 @@ This section covers offline **policy** enforcement (the `apm-policy.yml` cache).
 
 **For air-gapped CI, run `apm audit --ci --policy ./vendored-policy.yml` as your gating check; do not rely on `apm install` enforcement.**
 
+Cache freshness follows the effective policy's `cache.ttl` (default `3600` seconds, i.e. 1 hour); the 7-day stale ceiling (`MAX_STALE_TTL`) is fixed and cannot be extended by policy. See [Cache and offline behaviour](../policy-reference/#9-cache-and-offline-behaviour) for the full mechanics.
+
 | Network state | Install gate | Install `--mcp` | `apm audit --ci --policy <file>` | `apm audit --ci` (auto-discovery) |
 |---|---|---|---|---|
 | Online | Discovers + enforces | Discovers + enforces | Loads from path, enforces | Discovers + enforces |
-| Cache fresh (< 1h) | Cache hit, enforces | Cache hit, enforces | n/a (file path skips cache) | Cache hit, enforces |
-| Cache stale (1h - 7d) | Refresh attempted; on fail, `cached_stale` outcome -- proceed with cached unless `policy.fetch_failure: block` | Same | n/a | Same |
+| Cache fresh (younger than effective `cache.ttl`, default 3600s) | Cache hit, enforces | Cache hit, enforces | n/a (file path skips cache) | Cache hit, enforces |
+| Cache stale (older than effective `cache.ttl`, within 7-day ceiling) | Refresh attempted; on fail, `cached_stale` outcome -- proceed with cached unless `policy.fetch_failure: block` | Same | n/a | Same |
 | Offline, cache > 7d | `cache_miss_fetch_fail` -- fail-OPEN by default; fail-closed only if `policy.fetch_failure_default: block` in `apm.yml` | Same | Loads from path, full enforce | Same as install -- also covers `no_git_remote` / `absent` / `empty` outcomes when `policy.fetch_failure_default: block` |
 
 Workarounds when the network is unreliable:
@@ -350,7 +352,7 @@ Workarounds when the network is unreliable:
 | Outcome | Default behavior | Override to fail-closed | Citation |
 |---|---|---|---|
 | Network failure (`cache_miss_fetch_fail`) | Fail-OPEN, log warning, install proceeds with no policy | `policy.fetch_failure_default: block` in `apm.yml` | [policy-reference#95-network-failure-semantics](../policy-reference/#95-network-failure-semantics) |
-| Cached stale (1h - 7d, refresh failed) | Warn and proceed with cached policy | `policy.fetch_failure: block` set in the cached policy itself | [policy-reference#95-network-failure-semantics](../policy-reference/#95-network-failure-semantics) |
+| Cached stale (past effective `cache.ttl`, within the 7-day ceiling; refresh failed) | Warn and proceed with cached policy | `policy.fetch_failure: block` set in the cached policy itself | [policy-reference#95-network-failure-semantics](../policy-reference/#95-network-failure-semantics) |
 | Malformed YAML (`malformed`) (org policy file) | Fail-OPEN by default | `policy.fetch_failure_default: block` | `policy/parser.py` |
 | **No policy resolved (`no_git_remote` / `absent` / `empty`)** | **Fail-OPEN, log warning** | `policy.fetch_failure_default: block` in `apm.yml` -- applies to BOTH `apm install` and `apm audit --ci` | [policy-reference#951-no-policy-outcomes](../policy-reference/#951-no-policy-outcomes-no_git_remote--absent--empty) |
 | Hash-mismatch (project pin vs fetched) | **Always fail-CLOSED** | n/a (cannot be relaxed) | [policy-reference#95-network-failure-semantics](../policy-reference/#95-network-failure-semantics) |
@@ -496,7 +498,6 @@ We publish this list because silent gaps are worse than known ones. Every item b
 
 These are the sharp edges. Plan around them; do not assume they are solved.
 
-- **`policy.cache.ttl` field is parsed but not honored.** The cache reader uses a hardcoded 1-hour TTL. Setting `policy.cache.ttl: 86400` in your policy will be silently ignored. Operational mitigation: do not rely on this field; assume 1-hour cache TTL universally.
 - **`mcp.trust_transitive` policy field is parsed but not enforced.** The transitive-MCP gate is the `--trust-transitive-mcp` CLI flag, NOT the policy field. Operational mitigation: govern transitive MCP trust through CI command lines and code review of workflow files, not through policy YAML.
 - **`manifest.content_types` field is parsed but no check enforces it.** Operational mitigation: do not advertise this field as a control to stakeholders.
 - **Audit-only checks are not enforced at install.** `compilation-strategy`, `source-attribution`, `required-manifest-fields`, `scripts-policy`, `explicit-includes`, and `unmanaged-files` only run under `apm audit --ci --policy <scope>`. Operational mitigation: make `apm audit --ci` a required status check in branch protection. Without that, these rules are advisory only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
     "mypy>=1.0.0",
     "jsonschema>=4.0.0",
     "pylint>=3.0.0",
+    "hypothesis>=6.0.0",
 ]
 build = [
     "pyinstaller>=6.0.0",

--- a/src/apm_cli/policy/discovery.py
+++ b/src/apm_cli/policy/discovery.py
@@ -1776,7 +1776,7 @@ def _detect_garbage(
 def _read_cache_entry(
     repo_ref: str,
     project_root: Path,
-    ttl: int = DEFAULT_CACHE_TTL,
+    ttl: int | None = None,
     *,
     expected_hash: str | None = None,
 ) -> _CacheEntry | None:
@@ -1792,6 +1792,9 @@ def _read_cache_entry(
     compared against it; a mismatch invalidates the cache entry so the
     caller falls through to a fresh fetch where the pin can be verified
     against authoritative bytes off the wire.
+
+    When *ttl* is omitted, staleness follows the cached effective policy's
+    ``cache.ttl``. Callers may pass an explicit TTL for diagnostics or tests.
     """
     cache_dir = _get_cache_dir(project_root)
     key = _cache_key(repo_ref)
@@ -1832,6 +1835,7 @@ def _read_cache_entry(
         # The sidecar preserves warnings from the authored cold input. Parser
         # warnings from canonical cache YAML are intentionally not user-facing.
         policy, _warnings = load_policy(policy_file)
+        effective_ttl = policy.cache.ttl if ttl is None else ttl
         cached_warnings = meta.get("warnings", [])
         if not isinstance(cached_warnings, list):
             cached_warnings = []
@@ -1848,7 +1852,7 @@ def _read_cache_entry(
             policy=policy,
             source=source,
             age_seconds=age,
-            stale=age > ttl,
+            stale=age > effective_ttl,
             chain_refs=meta.get("chain_refs", [repo_ref]),
             warnings=cached_warnings,
             fingerprint=meta.get("fingerprint", ""),
@@ -1861,11 +1865,12 @@ def _read_cache_entry(
 def _read_cache(
     repo_ref: str,
     project_root: Path,
-    ttl: int = DEFAULT_CACHE_TTL,
+    ttl: int | None = None,
 ) -> PolicyFetchResult | None:
     """Read policy from cache if still valid (within TTL).
 
     Legacy wrapper around ``_read_cache_entry`` for backward compatibility.
+    The cached effective policy's TTL applies unless *ttl* is explicit.
     Returns None if cache miss, expired, or past MAX_STALE_TTL.
     """
     entry = _read_cache_entry(repo_ref, project_root, ttl=ttl)

--- a/tests/unit/policy/test_policy_serialization_properties.py
+++ b/tests/unit/policy/test_policy_serialization_properties.py
@@ -1,0 +1,418 @@
+"""Bounded property tests for Govern policy serialization and cache behavior."""
+
+from __future__ import annotations
+
+import copy
+import dataclasses
+import tempfile
+from itertools import combinations
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+import yaml
+from hypothesis import given, seed, settings
+from hypothesis import strategies as st
+
+from apm_cli.policy import discovery
+from apm_cli.policy.inheritance import resolve_policy_chain
+from apm_cli.policy.parser import load_policy
+from apm_cli.policy.schema import ApmPolicy
+
+PROPERTY_SEED = 0xA9C2026
+PROPERTY_PROFILE = settings(
+    max_examples=24,
+    deadline=750,
+    database=None,
+    print_blob=True,
+)
+SINGLE_EXAMPLE_PROFILE = settings(
+    max_examples=1,
+    deadline=750,
+    database=None,
+    print_blob=True,
+)
+POLICY_URL = "https://policy.example.com/apm-policy.yml"
+PACKAGE_VALUES = (
+    "acme/alpha",
+    "acme/beta",
+    "contoso/security-*",
+    "github/*",
+    "microsoft/*",
+)
+TARGET_VALUES = ("claude", "copilot", "vscode")
+CONTENT_TYPE_VALUES = ("agents", "instructions", "prompts", "skills")
+PATH_VALUES = (".agents", ".github/instructions", ".github/prompts", ".github/skills")
+INVALID_CASES = (
+    ("enforcement", ("enforcement",), "invalid"),
+    ("fetch-failure", ("fetch_failure",), "off"),
+    ("cache-ttl", ("cache", "ttl"), 0),
+    ("dependency-resolution", ("dependencies", "require_resolution"), "relax"),
+    ("dependency-depth", ("dependencies", "max_depth"), -1),
+    ("manifest-scripts", ("manifest", "scripts"), "warn"),
+    ("unmanaged-action", ("unmanaged_files", "action"), "allow"),
+    ("audit-on-install", ("security", "audit", "on_install"), "allow"),
+    ("integrity-hashes", ("security", "integrity", "require_hashes"), "yes"),
+    ("executables-deny-all", ("executables", "deny_all"), "yes"),
+)
+
+
+def _non_empty_unique(
+    values: tuple[str, ...], *, max_size: int = 3
+) -> st.SearchStrategy[list[str]]:
+    """Return bounded non-empty unique lists from a stable finite vocabulary."""
+    candidates = tuple(
+        candidate
+        for size in range(1, min(len(values), max_size) + 1)
+        for candidate in combinations(values, size)
+    )
+    return st.sampled_from(candidates).map(list)
+
+
+@st.composite
+def enforceable_policy_data(draw: st.DrawFn) -> dict[str, Any]:
+    """Generate valid policies with every enforceable field set non-default."""
+    package_list = _non_empty_unique(PACKAGE_VALUES)
+    target_list = _non_empty_unique(TARGET_VALUES)
+    scanner_list = _non_empty_unique(("sarif", "skillspector"), max_size=2)
+    return {
+        "name": "govern-property-policy",
+        "version": "1.0.0",
+        "enforcement": draw(st.sampled_from(("block", "off"))),
+        "fetch_failure": "block",
+        "cache": {"ttl": draw(st.integers(min_value=1, max_value=3599))},
+        "dependencies": {
+            "allow": draw(package_list),
+            "deny": draw(package_list),
+            "require": draw(package_list),
+            "require_resolution": draw(st.sampled_from(("block", "policy-wins"))),
+            "max_depth": draw(st.integers(min_value=1, max_value=49)),
+            "require_pinned_constraint": True,
+        },
+        "mcp": {
+            "allow": draw(package_list),
+            "deny": draw(package_list),
+            "transport": {
+                "allow": draw(_non_empty_unique(("http", "sse", "stdio", "streamable-http")))
+            },
+            "self_defined": draw(st.sampled_from(("allow", "deny"))),
+            "trust_transitive": True,
+        },
+        "compilation": {
+            "target": {
+                "allow": draw(target_list),
+                "enforce": draw(st.sampled_from(TARGET_VALUES)),
+            },
+            "strategy": {
+                "enforce": draw(st.sampled_from(("distributed", "single-file"))),
+            },
+            "source_attribution": True,
+        },
+        "manifest": {
+            "required_fields": draw(
+                _non_empty_unique(("dependencies", "description", "name", "version"))
+            ),
+            "scripts": "deny",
+            "content_types": {
+                "allow": draw(_non_empty_unique(CONTENT_TYPE_VALUES)),
+            },
+            "require_explicit_includes": True,
+        },
+        "unmanaged_files": {
+            "action": draw(st.sampled_from(("deny", "warn"))),
+            "directories": draw(_non_empty_unique(PATH_VALUES)),
+            "exclude": draw(_non_empty_unique(("build/**", "dist/**", "tmp/**"))),
+        },
+        "registry_source": {
+            "require": draw(_non_empty_unique(("internal", "official", "trusted"))),
+            "allow_non_registry": False,
+        },
+        "security": {
+            "audit": {
+                "on_install": draw(st.sampled_from(("block", "off", "warn"))),
+                "external": draw(scanner_list),
+                "scanners": {
+                    "sarif": {"allow_args": draw(st.booleans())},
+                    "skillspector": {"allow_args": draw(st.booleans())},
+                },
+                "fail_on_drift": True,
+            },
+            "integrity": {"require_hashes": True},
+        },
+        "bin_deploy": {
+            "deny_all": True,
+            "deny": draw(package_list),
+        },
+        "executables": {
+            "deny_all": True,
+            "deny": draw(package_list),
+            "require": draw(package_list),
+            "recommend": draw(package_list),
+            "enforce": draw(package_list),
+        },
+        "future_govern_key": "preserve-authored-warning",
+    }
+
+
+def _policy_yaml(data: dict[str, Any]) -> str:
+    """Render generated policy input without relying on cache serialization."""
+    return yaml.safe_dump(data, default_flow_style=False, sort_keys=False)
+
+
+def _enforceable_fields(policy: ApmPolicy) -> dict[str, Any]:
+    """Project every current enforceable/cache field into a named observation."""
+    return {
+        "enforcement": policy.enforcement,
+        "fetch_failure": policy.fetch_failure,
+        "cache.ttl": policy.cache.ttl,
+        "dependencies.allow": policy.dependencies.allow,
+        "dependencies.deny": policy.dependencies.deny,
+        "dependencies.require": policy.dependencies.require,
+        "dependencies.require_resolution": policy.dependencies.require_resolution,
+        "dependencies.max_depth": policy.dependencies.max_depth,
+        "dependencies.require_pinned_constraint": policy.dependencies.require_pinned_constraint,
+        "mcp.allow": policy.mcp.allow,
+        "mcp.deny": policy.mcp.deny,
+        "mcp.transport.allow": policy.mcp.transport.allow,
+        "mcp.self_defined": policy.mcp.self_defined,
+        "mcp.trust_transitive": policy.mcp.trust_transitive,
+        "compilation.target.allow": policy.compilation.target.allow,
+        "compilation.target.enforce": policy.compilation.target.enforce,
+        "compilation.strategy.enforce": policy.compilation.strategy.enforce,
+        "compilation.source_attribution": policy.compilation.source_attribution,
+        "manifest.required_fields": policy.manifest.required_fields,
+        "manifest.scripts": policy.manifest.scripts,
+        "manifest.content_types": policy.manifest.content_types,
+        "manifest.require_explicit_includes": policy.manifest.require_explicit_includes,
+        "unmanaged_files.action": policy.unmanaged_files.action,
+        "unmanaged_files.directories": policy.unmanaged_files.directories,
+        "unmanaged_files.exclude": policy.unmanaged_files.exclude,
+        "registry_source.require": policy.registry_source.require,
+        "registry_source.allow_non_registry": policy.registry_source.allow_non_registry,
+        "security.audit.on_install": policy.security.audit.on_install,
+        "security.audit.external": policy.security.audit.external,
+        "security.audit.scanners": policy.security.audit.scanners,
+        "security.audit.fail_on_drift": policy.security.audit.fail_on_drift,
+        "security.integrity.require_hashes": policy.security.integrity.require_hashes,
+        "bin_deploy.deny_all": policy.bin_deploy.deny_all,
+        "bin_deploy.deny": policy.bin_deploy.deny,
+        "executables.deny_all": policy.executables.deny_all,
+        "executables.deny": policy.executables.deny,
+        "executables.require": policy.executables.require,
+        "executables.recommend": policy.executables.recommend,
+        "executables.enforce": policy.executables.enforce,
+    }
+
+
+def _schema_enforceable_field_paths(policy: ApmPolicy) -> set[str]:
+    """Return dataclass leaf paths, excluding non-enforceable policy metadata."""
+    paths: set[str] = set()
+
+    def visit(value: Any, prefix: str = "") -> None:
+        for field in dataclasses.fields(value):
+            path = f"{prefix}.{field.name}" if prefix else field.name
+            child = getattr(value, field.name)
+            if dataclasses.is_dataclass(child):
+                visit(child, path)
+            else:
+                paths.add(path)
+
+    visit(policy)
+    return paths - {"name", "version", "extends"}
+
+
+def _assert_cache_round_trip(policy: ApmPolicy) -> str:
+    """Assert field preservation and canonical idempotence through cache YAML."""
+    serialized = discovery._serialize_policy(policy)
+    reparsed, _ = load_policy(serialized)
+    assert _enforceable_fields(reparsed) == _enforceable_fields(policy), (
+        "cache round-trip changed enforceable fields"
+    )
+    assert discovery._serialize_policy(reparsed) == serialized
+    return serialized
+
+
+def _result_observation(result: discovery.PolicyFetchResult) -> tuple[Any, ...]:
+    """Return user-observable policy result data, excluding cache provenance."""
+    assert result.policy is not None
+    return (
+        _enforceable_fields(result.policy),
+        result.source,
+        result.error,
+        result.fetch_error,
+        result.outcome,
+        result.warnings,
+        result.raw_bytes_hash,
+    )
+
+
+def _cache_bytes(project_root: Path) -> dict[str, bytes]:
+    """Read one policy cache entry as a filename-to-bytes map."""
+    cache_dir = project_root / "apm_modules" / discovery.POLICY_CACHE_DIR
+    return {path.name: path.read_bytes() for path in sorted(cache_dir.iterdir())}
+
+
+def _set_nested(data: dict[str, Any], path: tuple[str, ...], value: Any) -> None:
+    """Replace one nested policy value in-place."""
+    target = data
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = value
+
+
+def _assert_policy_ttl_refreshes(data: dict[str, Any]) -> None:
+    """Assert a warm read refreshes immediately after the policy TTL."""
+    content = _policy_yaml(data)
+    response = SimpleNamespace(status_code=200, text=content, headers={})
+    ttl = data["cache"]["ttl"]
+    cached_at = 10_000.0
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        project_root = Path(temp_dir)
+        with patch("apm_cli.policy.discovery.requests.get", return_value=response) as request:
+            with patch("apm_cli.policy.discovery.time.time", return_value=cached_at):
+                cold = discovery._fetch_from_url(POLICY_URL, project_root)
+            with patch(
+                "apm_cli.policy.discovery.time.time",
+                return_value=cached_at + ttl + 1,
+            ):
+                refreshed = discovery._fetch_from_url(POLICY_URL, project_root)
+
+        assert request.call_count == 2, "policy cache TTL did not trigger refresh"
+        assert not cold.cached
+        assert not refreshed.cached
+        assert _result_observation(refreshed) == _result_observation(cold)
+
+
+@seed(PROPERTY_SEED)
+@PROPERTY_PROFILE
+@given(data=enforceable_policy_data())
+def test_effective_policy_cache_serialization_is_lossless_and_canonical(
+    data: dict[str, Any],
+) -> None:
+    """Parse -> effective policy -> cache YAML -> parse preserves all 39 fields."""
+    parsed, _ = load_policy(_policy_yaml(data))
+    effective = resolve_policy_chain([parsed])
+
+    assert set(_enforceable_fields(effective)) == _schema_enforceable_field_paths(effective)
+    assert len(_enforceable_fields(effective)) == 39
+    _assert_cache_round_trip(effective)
+
+
+@seed(PROPERTY_SEED)
+@PROPERTY_PROFILE
+@given(data=enforceable_policy_data())
+def test_cold_and_warm_policy_results_are_observationally_equivalent(
+    data: dict[str, Any],
+) -> None:
+    """A canonical warm-cache read preserves cold outcome and authored warnings."""
+    content = _policy_yaml(data)
+    response = SimpleNamespace(status_code=200, text=content, headers={})
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        project_root = Path(temp_dir)
+        with patch("apm_cli.policy.discovery.requests.get", return_value=response) as request:
+            cold = discovery._fetch_from_url(POLICY_URL, project_root)
+            warm = discovery._fetch_from_url(POLICY_URL, project_root)
+
+        assert request.call_count == 1
+        assert not cold.cached
+        assert warm.cached
+        assert _result_observation(warm) == _result_observation(cold)
+
+
+@seed(PROPERTY_SEED)
+@PROPERTY_PROFILE
+@given(data=enforceable_policy_data())
+def test_policy_cache_ttl_controls_when_warm_reads_refresh(
+    data: dict[str, Any],
+) -> None:
+    """A warm read refreshes immediately after the effective policy TTL."""
+    _assert_policy_ttl_refreshes(data)
+
+
+@seed(PROPERTY_SEED)
+@SINGLE_EXAMPLE_PROFILE
+@given(data=enforceable_policy_data())
+def test_cache_ttl_property_breaks_if_reader_uses_fixed_default(
+    data: dict[str, Any],
+) -> None:
+    """Negative twin: a fixed one-hour TTL must break the refresh property."""
+    original = discovery._read_cache_entry
+
+    def force_default_ttl(
+        repo_ref: str,
+        project_root: Path,
+        ttl: int | None = None,
+        *,
+        expected_hash: str | None = None,
+    ) -> Any:
+        del ttl
+        return original(
+            repo_ref,
+            project_root,
+            ttl=discovery.DEFAULT_CACHE_TTL,
+            expected_hash=expected_hash,
+        )
+
+    with patch("apm_cli.policy.discovery._read_cache_entry", side_effect=force_default_ttl):
+        with pytest.raises(AssertionError, match="policy cache TTL did not trigger refresh"):
+            _assert_policy_ttl_refreshes(data)
+
+
+@pytest.mark.parametrize(
+    ("_case_name", "path", "invalid_value"),
+    INVALID_CASES,
+    ids=[case[0] for case in INVALID_CASES],
+)
+@seed(PROPERTY_SEED)
+@SINGLE_EXAMPLE_PROFILE
+@given(valid_data=enforceable_policy_data())
+def test_invalid_refresh_fails_closed_and_preserves_last_good_cache(
+    _case_name: str,
+    path: tuple[str, ...],
+    invalid_value: Any,
+    valid_data: dict[str, Any],
+) -> None:
+    """Malformed refreshes never replace valid cached policy or metadata bytes."""
+    invalid_data = copy.deepcopy(valid_data)
+    _set_nested(invalid_data, path, invalid_value)
+    responses = [
+        SimpleNamespace(status_code=200, text=_policy_yaml(valid_data), headers={}),
+        SimpleNamespace(status_code=200, text=_policy_yaml(invalid_data), headers={}),
+    ]
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        project_root = Path(temp_dir)
+        with patch("apm_cli.policy.discovery.requests.get", side_effect=responses):
+            valid = discovery._fetch_from_url(POLICY_URL, project_root)
+            before = _cache_bytes(project_root)
+            invalid = discovery._fetch_from_url(POLICY_URL, project_root, no_cache=True)
+            after = _cache_bytes(project_root)
+
+    assert valid.policy is not None
+    assert invalid.policy is None
+    assert invalid.outcome == "malformed"
+    assert before == after
+
+
+@seed(PROPERTY_SEED)
+@SINGLE_EXAMPLE_PROFILE
+@given(data=enforceable_policy_data())
+def test_round_trip_property_breaks_when_serializer_omits_enforceable_field(
+    data: dict[str, Any],
+) -> None:
+    """Negative twin: deleting one serialized field must break the property."""
+    policy, _ = load_policy(_policy_yaml(data))
+    original = discovery._policy_to_dict
+
+    def omit_integrity_field(value: ApmPolicy) -> dict[str, Any]:
+        serialized = original(value)
+        del serialized["security"]["integrity"]["require_hashes"]
+        return serialized
+
+    with patch("apm_cli.policy.discovery._policy_to_dict", side_effect=omit_integrity_field):
+        with pytest.raises(AssertionError, match="cache round-trip changed enforceable fields"):
+            _assert_cache_round_trip(policy)

--- a/uv.lock
+++ b/uv.lock
@@ -218,8 +218,8 @@ dependencies = [
     { name = "ruamel-yaml" },
     { name = "toml" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "truststore" },
     { name = "tomlkit" },
+    { name = "truststore" },
     { name = "watchdog" },
     { name = "websockets" },
 ]
@@ -229,6 +229,7 @@ build = [
     { name = "pyinstaller" },
 ]
 dev = [
+    { name = "hypothesis" },
     { name = "jsonschema" },
     { name = "mypy" },
     { name = "pylint" },
@@ -245,6 +246,7 @@ requires-dist = [
     { name = "colorama", specifier = ">=0.4.6" },
     { name = "filelock", specifier = ">=3.12" },
     { name = "gitpython", specifier = ">=3.1.0" },
+    { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "llm", specifier = ">=0.28" },
     { name = "llm-github-models", specifier = ">=0.18.0" },
@@ -264,8 +266,8 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.0" },
     { name = "toml", specifier = ">=0.10.2" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=1.2.0" },
-    { name = "truststore", specifier = ">=0.10.0" },
     { name = "tomlkit", specifier = ">=0.13" },
+    { name = "truststore", specifier = ">=0.10.0" },
     { name = "watchdog", specifier = ">=3.0.0" },
     { name = "websockets", specifier = ">=12,<17" },
 ]
@@ -734,6 +736,75 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.156.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/83/8dbe89bdb8c6f25a7a52e7898af6d82fe35dfef08e5c702f6e33231ce6c6/hypothesis-6.156.6.tar.gz", hash = "sha256:96de02faefa3ce079873541da96f42595583bb001e8e4219294ed7d4501cc4cc", size = 476304, upload-time = "2026-07-10T20:56:49.96Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/dc/0c2a851f06c91d5ac9ef0f3b9615efc1ed650411d2eee23b6334f491c85e/hypothesis-6.156.6-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:caf6a93d011c10972da111c38ceb34ced20feaa8581e2b350c0655b022e27875", size = 747998, upload-time = "2026-07-10T20:56:16.311Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f8/59203ca978ab51595d12d6bc7e7a63300d7373431ab42ca3f1742e45db68/hypothesis-6.156.6-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:07f2bc9df1aeba80e12029c1618e2ee54abc440068c305d7075ffd6b85251843", size = 743073, upload-time = "2026-07-10T20:55:36.825Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d8/86a0023740434098d1b187a62bd5f99b198f098fb43e7fc58342283a8270/hypothesis-6.156.6-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7baca17f4803ad4aa151732326f3990baf54c3127df44aa872ac5bdf8a98a9a6", size = 1070169, upload-time = "2026-07-10T20:55:49.47Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/82/673453915fd0c67673f35a4876ba88f48c621335f293f3537d77b27d4286/hypothesis-6.156.6-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8083806645f84243aade727f4978185caaa0b7190af4318673999ee15fdbf424", size = 1121760, upload-time = "2026-07-10T20:55:53.502Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/c3/3a5557f52912f2fecc6ed59642dcf80dd8e89d0d9664502b68e23d66bf3d/hypothesis-6.156.6-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a922eedcd8618f9c2e17b79fa7b3f3f0b2df34e201958611cc3f0f46cca33c10", size = 1111440, upload-time = "2026-07-10T20:55:43.054Z" },
+    { url = "https://files.pythonhosted.org/packages/38/a6/ae636d4ca7f996a1ccb4b3d5997d949f1718fba52b01559b3ab53b237b3f/hypothesis-6.156.6-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5291bd33c4704d274d7c214d5c200e77f372a06644f5cbbe96dcbe53cb2fbf10", size = 1244944, upload-time = "2026-07-10T20:55:56.109Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/79/c425d22d734be0268ca60d120c6296299e4220a1783cb1a4cc76232807bb/hypothesis-6.156.6-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:55f3ec50161b4a95bae63bff2b5166e45935b493013d3be30ede279bf6192318", size = 1288808, upload-time = "2026-07-10T20:56:06.249Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/3a/cc9f479d22cbdd36ddfc55a978378eddadd183b09339ebdb81be33bb18e7/hypothesis-6.156.6-cp310-abi3-win32.whl", hash = "sha256:e96570ca5cdd9a5f2ff9e80a6fb2fd5420ebf33b833d7de5b09b6ebb26a3eb6c", size = 634868, upload-time = "2026-07-10T20:55:37.959Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/89/2008d287289841a936456cb13443ca89d88da6e4527d611d482e9544164d/hypothesis-6.156.6-cp310-abi3-win_amd64.whl", hash = "sha256:32710718c22fe8c5571464e898bb87d282837b02617d6ad68130abf7cb4843cb", size = 640382, upload-time = "2026-07-10T20:55:30.634Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/dc/b502504a972af7368b62e712268d310ffbc81d0ebfb31d5a9c60332a5063/hypothesis-6.156.6-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:afec0631a7a557acb50f665108b5d1d1123c21bc702d156a740db1cc33be4a7d", size = 749319, upload-time = "2026-07-10T20:55:35.708Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/a4867bc2b8b81d9b1648992fb7e4a732b3db480ff2d02df2c7b59189c812/hypothesis-6.156.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:583a658162ee7e1a82155e3f146932a3a2269030294f3c83f5cf52fcaa0562c3", size = 743969, upload-time = "2026-07-10T20:55:31.983Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/22/6ece4337e01c634594bb177009c049aa3133c151d9e397edccb6c3938567/hypothesis-6.156.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9600277defbfa769d8a6af264cbdff16294682c210c2d058ef39348fec16c0c", size = 1070874, upload-time = "2026-07-10T20:55:44.277Z" },
+    { url = "https://files.pythonhosted.org/packages/05/00/5820a3b1fe264b23770f77dbb3ac0f6fdadd21b640624791a05950f934da/hypothesis-6.156.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c7c3f067166bfc28b67f0042fc5fdcc87b3b58664da0c2f563fe544448b7ab3b", size = 1122191, upload-time = "2026-07-10T20:56:20.721Z" },
+    { url = "https://files.pythonhosted.org/packages/90/f8/0861ed15c96302577229334655e038e8c46e4b5b2a8cae971409a7e176e5/hypothesis-6.156.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f57842c1c5314839bdf4be5cff108589ff435cd7192c035dc48e6f14032915a5", size = 1246060, upload-time = "2026-07-10T20:55:41.834Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5c/63b60c6566eafac0b150f6acae5d1cbe0ed64dc294c863888eb87088a542/hypothesis-6.156.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c4a787c3af0035846034461792f2a62f1c43af850feb970a5b53a629d64b52fb", size = 1289510, upload-time = "2026-07-10T20:55:33.133Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4e/bfe57f182f51784549210903241057ae94784858117b965613089f5f89ad/hypothesis-6.156.6-cp310-cp310-win_amd64.whl", hash = "sha256:02accb187617ebaebb120da931f799a3cb0df7c38706f97f9d022441d4faf533", size = 640384, upload-time = "2026-07-10T20:56:26.939Z" },
+    { url = "https://files.pythonhosted.org/packages/13/64/e4a0796190d8089e85f06731e21fdddd7e8edd3a4e562101527a048e21c4/hypothesis-6.156.6-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:5baec7943a14d106e982121dd4f74cfc5ef45e37c17f94fe49338d3d1377f38c", size = 748988, upload-time = "2026-07-10T20:56:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a2/4a789b286cd2cced31992e1f683036b51dd6909b934ea007ffb43aa3a32f/hypothesis-6.156.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b5f519905ddeb10e23b8ba2c254541a5b1a8f146fe0551be94d972f4a77226f4", size = 743754, upload-time = "2026-07-10T20:56:09.113Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f7/3dd36c1c03d24ae3ffc3c5b0eca8cc4ae90c07abc320f76509eceb37019a/hypothesis-6.156.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c108655960b58ded3ca71b2dc5c69fb2ba7e9c723aeb6106facec3892d09087", size = 1070732, upload-time = "2026-07-10T20:56:28.738Z" },
+    { url = "https://files.pythonhosted.org/packages/57/51/befc4b816b471078034a875eb1ef69e0411ab84bcce582b4be173258785a/hypothesis-6.156.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7c8d37bebb6924729bc0bbf5852689df568842948abe4d93dd0ad3377adf76fa", size = 1121988, upload-time = "2026-07-10T20:56:07.676Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b7/a796f5e3e4b7cb911ff346008d49720296d1f4073490b8bc1cce6b3fbb07/hypothesis-6.156.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:74137bef6d502305c3648b2ed1a9bb4bc05fb1025e96b30a2c092204c40fe097", size = 1245596, upload-time = "2026-07-10T20:55:50.662Z" },
+    { url = "https://files.pythonhosted.org/packages/37/65/849c4cba44a6f6cc888fd931124429b24180234ccc4883abab8cad5fcfcb/hypothesis-6.156.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5e0afdf79cceed20fcf0a9fb80d4064a9b2b53d4d4eecbac0e21208a13f5a31b", size = 1289172, upload-time = "2026-07-10T20:55:58.915Z" },
+    { url = "https://files.pythonhosted.org/packages/13/03/7106a110df29eb631d66776e8aa8128f82f04a9dd2b6b22b612e6025e3a2/hypothesis-6.156.6-cp311-cp311-win_amd64.whl", hash = "sha256:84dc89caaf741a02f904ca7bd02b1af99650c75552868162290208aeecb70858", size = 640222, upload-time = "2026-07-10T20:56:10.396Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/45/9f009005b9c796f4a40424484ac7e70847bc088456fd940a937f96bb4b6d/hypothesis-6.156.6-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a2a728b514fceb81e3f0464508911d5220fd74dadc3270f859427a686b60c4cf", size = 748844, upload-time = "2026-07-10T20:56:38.036Z" },
+    { url = "https://files.pythonhosted.org/packages/02/2f/4d852bb8a9c73a68b18eca9b5b085285282122166e158f4d2a477639bfee/hypothesis-6.156.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7489b9a8f9df8227edd6c7cd8b9ccfab2483bab24da6a474c175973ca2294f58", size = 741936, upload-time = "2026-07-10T20:55:27.539Z" },
+    { url = "https://files.pythonhosted.org/packages/74/89/b9968070ae042f9bf3149bb6ba6399d5f28f452e0fb7f638cafc69ff0b9a/hypothesis-6.156.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42760873d6db1069d6edbaa355a61b9078a9950259efcfc72fc695741d7db7cd", size = 1069749, upload-time = "2026-07-10T20:56:43.017Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a9/753806f5292b40aeab1d269e408e3a7e85be3c0d88828fb78ab4a34d6626/hypothesis-6.156.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b4e66aaa7385538a5d617174d47c198ee807f06de99e282a67c6cb724c69340d", size = 1120983, upload-time = "2026-07-10T20:56:25.424Z" },
+    { url = "https://files.pythonhosted.org/packages/85/88/8386d064d680be27e936eba94f1448bc93ef6fa05473ee5034139f1c4284/hypothesis-6.156.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:08796b674c0b31a5dd4119b2173823390055921588d13eb77324e861b00fd7f8", size = 1243911, upload-time = "2026-07-10T20:55:54.799Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8c/7524c1e5279e7728eb47c99f2357cbc5f08ae92e9bce49bf50118b53f9c9/hypothesis-6.156.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4ca8cc26ea2d31d22cf7710e92951cfaa921f0f8aa1b6db33a5176335f583a4f", size = 1287806, upload-time = "2026-07-10T20:56:02.176Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/b3/c347ad913e1c5f2988956fe17826c0400b4ce470b973e6c248e97b6a0acf/hypothesis-6.156.6-cp312-cp312-win_amd64.whl", hash = "sha256:c3363d3fb8015594636689572510bb6090602d8e8e838a5693c2d52d3b5b09d8", size = 637679, upload-time = "2026-07-10T20:55:39.056Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5d/9583fe153573523dac27226c89e041a86ad4aeeae08c868160cbb93d39d2/hypothesis-6.156.6-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:59a8def90d9a5a9b67e1ac529e903a2363ceb6cf873c209da6b4284c5daab671", size = 749264, upload-time = "2026-07-10T20:56:46.118Z" },
+    { url = "https://files.pythonhosted.org/packages/86/35/e4113d06769b544f0fb77ffea9195b598b4c56a298905c21fd47c4eed388/hypothesis-6.156.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c574c3224563d730848bc5d1ef1683c4f83993400c0167899fe328f4bfcd4725", size = 742095, upload-time = "2026-07-10T20:56:41.412Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5c/a47666ede10384e8978722cade7ab96a42df71d2ab577317092d0fed7c8a/hypothesis-6.156.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01bb8270c46b3ef53b0c2d23ff613ea506d609d06f936d823ea57c58b66b05f7", size = 1069917, upload-time = "2026-07-10T20:56:04.845Z" },
+    { url = "https://files.pythonhosted.org/packages/79/93/75f6057dadd9dc0134f37c08d5d14d04d3cd7374debbcb0cc4569c6712f1/hypothesis-6.156.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d4ea6559c13606e13b645927f2e0906e52b5ac5d99b40d3abaaeb2e8c7ceeb75", size = 1121204, upload-time = "2026-07-10T20:55:52.008Z" },
+    { url = "https://files.pythonhosted.org/packages/62/87/308efef08bc60d1e673d035e8ca8e9663f4b6b3ba519c3cdebf6583c2b76/hypothesis-6.156.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2d47054d0230f0dd9b6868fc030126c7a6c25527144272ff376cc4e9c39f7540", size = 1244168, upload-time = "2026-07-10T20:55:40.288Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/66/de8fff5bd9a40a4056dafbe7f904887ef12632282bbbac90f1977c30dd3b/hypothesis-6.156.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:050c8c0815f88d47dd0875a92698d20d61639b7b721ee043a6d687c7f14ff7d8", size = 1288127, upload-time = "2026-07-10T20:56:00.541Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8d/794fb26e1fd3ff004978f8f18b7aa7e1c2270ba72e1f977b987a812064f8/hypothesis-6.156.6-cp313-cp313-win_amd64.whl", hash = "sha256:f0d73edab7b8a0051b3634f2d04d62b7e7282f8f274963b11188ee4957d672ef", size = 637954, upload-time = "2026-07-10T20:56:33.35Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/5b4b27984cb43c60e95f570b069660335dad34cb67f7d226017c5d35d31e/hypothesis-6.156.6-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:34a70a7b8226e34d658072d8fb81d03f97f0a75ceb536329a321b94ce2232fd6", size = 749312, upload-time = "2026-07-10T20:55:46.902Z" },
+    { url = "https://files.pythonhosted.org/packages/31/11/709cceffc28666c9d4cb75ffc6df5ce30db8c7dd5cc2c8b38a2fd837427f/hypothesis-6.156.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f1969646beead7d8cf6a2537d2765af89d73056e2cb218e7fae92b83802250a3", size = 742332, upload-time = "2026-07-10T20:56:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/84/52/cfc79b13d8dd3cd6de6b9df921c557efe8528a9c90a3a7cd93b37188d57e/hypothesis-6.156.6-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cbc2ec7b7d905e6b6ec1635f6340bfa52aaab718101c59f052bc012a6b486cd8", size = 1070109, upload-time = "2026-07-10T20:55:48.244Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/1da4def1f006b5ad01187ff96379e24c37439d659ec10c3e944c03436c0f/hypothesis-6.156.6-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9367ae25dfa6dc1af37904785e43c4f8fe1c4118cafdc2f06514154fbdd90992", size = 1121528, upload-time = "2026-07-10T20:56:39.665Z" },
+    { url = "https://files.pythonhosted.org/packages/68/47/744e4f5e3d635dea20dbedf3fa486e2a6fa5210e0a52a0d5c4da56babd84/hypothesis-6.156.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:455f09107ec07c78f2a83cb8fc19e23879c9d51cdc831de6f9cb6ec4059cb9af", size = 1244690, upload-time = "2026-07-10T20:56:31.854Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8a/42252fcd5e521d140dac532f29c2a13ca8f22908cb545ffdd64b5e225680/hypothesis-6.156.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c76634c45a3ceee4c4fdfed39aebd08b8b822ec8b0c556877ef82846fd777730", size = 1288519, upload-time = "2026-07-10T20:56:03.429Z" },
+    { url = "https://files.pythonhosted.org/packages/44/e7/176df9e47cf583d2b8d234b78c0aac3a47075ad5d147e60b2c21a1338bb1/hypothesis-6.156.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:eb7e9f8343bc6b948937e6ec12e6879ed25a17b53ceccbd2b84adadd3d511698", size = 586452, upload-time = "2026-07-10T20:56:22.285Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/75/2c8a0411bbe76429f3ae738ef9a00107201bf6146d9534350014ce369d98/hypothesis-6.156.6-cp314-cp314-win_amd64.whl", hash = "sha256:f9631cd604ae6032c3edf99160dc1b9e33873f2e52762246b24f07fb758652ae", size = 637774, upload-time = "2026-07-10T20:56:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/22/8115005e9aa72c8d63d90e9db5e0b8425fd8950fbc5d6e332805d4d32c9e/hypothesis-6.156.6-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:1f81163d36d3763b09ffaef7c3a71e88174ca3e6816201fca9d1d159f448fdb5", size = 747428, upload-time = "2026-07-10T20:56:44.611Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c2/66bfe9337f4a4b1f7754ee6d01d950280152a81d0d797e6c1d9eb0909750/hypothesis-6.156.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:556b905767e36147918634a64356aa05d8c956576f00aee01eb351678f193908", size = 740889, upload-time = "2026-07-10T20:55:57.656Z" },
+    { url = "https://files.pythonhosted.org/packages/95/3b/69f45af2d4f0950b7d1af3cdbdd800b88a6c2370331481eda79d6171fbe3/hypothesis-6.156.6-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3f2604b28d16d696aaaf4954d20f907b27e54034df98e64746a20c74c319f03", size = 1069270, upload-time = "2026-07-10T20:56:12.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/43/6b2549885da08f5e50ba34fb8e0d0a60b2f190ffd516fac220f8db5b5869/hypothesis-6.156.6-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffe012ad66dbe7b8e8ddef6f6992ab1b36719ea64430c2bf1ff7135521052a15", size = 1120409, upload-time = "2026-07-10T20:55:34.551Z" },
+    { url = "https://files.pythonhosted.org/packages/70/97/745c778c3eb29befa2367b1ded8437eecfbbe6932359d0f831275bc32170/hypothesis-6.156.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5bfa3c7b758f7278081c6bfec5f89b43c4eb075c0c9eb095323f7a9eb019b513", size = 1243111, upload-time = "2026-07-10T20:56:17.83Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/d7/c5ec6a442dc9b822f47064bda4b6d3e739dccdd1c5bf44c9a57fb6136830/hypothesis-6.156.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d0db1f4573800c618773622f03cb6533bb3377430ef938c9476ba10c39d22591", size = 1287262, upload-time = "2026-07-10T20:56:23.749Z" },
+    { url = "https://files.pythonhosted.org/packages/11/0c/c134d61710e14b68b010215dcf6bd57d2ec05cd169dff8bfab8fefc2d410/hypothesis-6.156.6-cp314-cp314t-win_amd64.whl", hash = "sha256:38cd0c4a7b9f809f1e23a4d15adfa9c5d99869b9afc327350a5e563350b78e48", size = 637862, upload-time = "2026-07-10T20:56:13.347Z" },
+    { url = "https://files.pythonhosted.org/packages/59/9c/b94f3a31665527b6181616b72990fcf8d6d5fa82b4187aab104ab5f548f0/hypothesis-6.156.6-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:8893b4da90e06828846c1b100c3414a7729d047a020d854c0899ae9339df0e70", size = 749575, upload-time = "2026-07-10T20:55:29.371Z" },
+    { url = "https://files.pythonhosted.org/packages/21/74/dcf695f79f526543ae5d0f8c1325508e9fe990a996c0e0853129a9a5d81d/hypothesis-6.156.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b7fc0b7df9b28d028e4cc295b2ac8fbbbc22e090a23382c92fff5e37696be74f", size = 744351, upload-time = "2026-07-10T20:56:36.46Z" },
+    { url = "https://files.pythonhosted.org/packages/11/d3/5bff4c55c6995a6c43f66ec8e5866b56e34f03837fd0be0e4922f3bab168/hypothesis-6.156.6-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38ed3178526382d392d04ad699ad7a2e53845e521a09d40f1cbbc1e1ff63ba48", size = 1070916, upload-time = "2026-07-10T20:56:19.256Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/af/5ed42117a69221ea118caaff933d8212039a0ac0bc15afa915635f13984c/hypothesis-6.156.6-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ad94e28aabf4db0d479297d43b8a2a01e7caaa9bdfccfdac7a4a3717e05b993", size = 1122625, upload-time = "2026-07-10T20:56:14.758Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d3/02499badc6e3f3e980941021edf5fd780c895d8d08c9015e78516340ed83/hypothesis-6.156.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:983a5cfd955994bffc7eb02976241f7a1f3c2d94dbc3389430c45858fa5c1ae0", size = 640823, upload-time = "2026-07-10T20:55:45.461Z" },
 ]
 
 [[package]]
@@ -1849,6 +1920,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# fix(policy): honor Govern cache TTL with bounded property coverage

## TL;DR

This PR adds a deterministic Hypothesis pilot around the stabilized Govern policy serialization and cache owner. The generated properties found a real defect: serialized `cache.ttl` values were preserved but warm-cache staleness always used a fixed one-hour default. The minimum fix makes cached effective policy TTL authoritative while preserving explicit diagnostic/test overrides.

> [!IMPORTANT]
> The pilot is intentionally bounded to Govern policy parsing, effective-policy serialization, and policy cache behavior; it does not touch resolver, marketplace, general cache, agent, critical-suite, or materialized Git-tree integrity surfaces.

## Problem (WHY)

- [x] A generated policy with `cache.ttl: 1` remained warm after its policy-defined TTL because `_read_cache_entry()` defaulted to `3600` before loading the cached policy.
- [x] Existing example tests did not prove that parse -> effective policy -> canonical cache YAML -> parse preserves every enforceable non-default field together.
- [x] Cold and warm reads lacked a generated observational-equivalence check covering outcomes, warnings, source, errors, and hashes.
- [!] Invalid refreshes had example coverage, but no bounded cross-field property proved malformed policy cannot replace last-good policy and metadata bytes.

Why these matter:

- ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) The pilot records a fixed seed, finite vocabularies, example cap, deadline, and disabled example database.
- ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) The fix stays inside the existing cache reader instead of creating a second policy authority.

## Approach (WHAT)

| # | Fix |
|---:|---|
| 1 | Generate valid policies whose 39 enforceable/cache leaves are all non-default, using finite vocabularies and bounded combinations. |
| 2 | Exercise the existing parser, inheritance resolver, serializer, URL fetch path, cache writer, and cache reader rather than a parallel model. |
| 3 | Make omitted reader TTL mean "use the cached effective policy's `cache.ttl`"; retain explicit TTL overrides. |
| 4 | Add negative twins that deliberately restore the fixed-hour bug or omit a serialized field and assert the properties break. |
| 5 | Align the enterprise governance guide with the now-enforced TTL contract. |

## Implementation (HOW)

| File | Intent and scope |
|---|---|
| [`src/apm_cli/policy/discovery.py`](https://github.com/microsoft/apm/blob/e5be6938dcca00e2c21bc58742e6ec21df5107c7/src/apm_cli/policy/discovery.py#L1776-L1877) | Changes the existing cache reader default from a pre-parse fixed TTL to the parsed cached effective policy TTL. Explicit TTL callers remain supported. |
| [`tests/unit/policy/test_policy_serialization_properties.py`](https://github.com/microsoft/apm/blob/e5be6938dcca00e2c21bc58742e6ec21df5107c7/tests/unit/policy/test_policy_serialization_properties.py#L1-L418) | Adds the bounded property strategies, 39-field schema drift check, canonical round trip, cold/warm parity, TTL regression, ten invalid combinations, byte-preservation checks, and two mutation twins. |
| [`pyproject.toml`](https://github.com/microsoft/apm/blob/e5be6938dcca00e2c21bc58742e6ec21df5107c7/pyproject.toml#L48-L58) | Adds Hypothesis only to the existing `dev` optional dependency surface. |
| [`uv.lock`](https://github.com/microsoft/apm/blob/e5be6938dcca00e2c21bc58742e6ec21df5107c7/uv.lock) | Locks Hypothesis 6.156.6 and its `sortedcontainers` dependency through `uv`; runtime dependencies are unchanged. |
| [`docs/src/content/docs/enterprise/governance-guide.md`](https://github.com/microsoft/apm/blob/e5be6938dcca00e2c21bc58742e6ec21df5107c7/docs/src/content/docs/enterprise/governance-guide.md#L80-L94) | Replaces stale fixed-hour/ignored-field statements with the effective-policy TTL behavior and keeps the seven-day hard ceiling explicit. |
| `CHANGELOG.md` | Records the policy TTL fix and bounded 39-field regression coverage under Unreleased / Fixed. |

## Diagrams

Legend: Dashed nodes are the new generated proof points; solid nodes are existing canonical Govern owners exercised by the pilot.

```mermaid
flowchart LR
    subgraph Generate[Bounded generation]
        G["valid non-default policy combinations"]
        I["ten invalid field combinations"]
    end
    subgraph Govern[Existing Govern owners]
        P["load_policy"]
        E["resolve_policy_chain"]
        S["_serialize_policy and _write_cache"]
        F["_fetch_from_url and _read_cache_entry"]
    end
    subgraph Observe[Metamorphic observations]
        O["all 39 enforceable fields preserved"]
        W["cold and warm outcomes match"]
        T["cache.ttl controls refresh"]
        B["last-good cache bytes unchanged"]
    end

    G --> P --> E --> S --> F
    I --> F
    F --> O
    F --> W
    F --> T
    F --> B
    classDef new stroke-dasharray: 5 5;
    class G,I,O,W,T,B new;
```

## Trade-offs

- **Bounded generation over exhaustive fuzzing.** Chose 24 examples, finite vocabularies, a 750 ms deadline, and seed `0xA9C2026`; rejected unbounded recursive inputs to keep runtime deterministic and CI-safe.
- **Development-only dependency over runtime coupling.** Chose the existing `dev` optional dependency group; rejected adding Hypothesis to production dependencies because it is test infrastructure only.
- **Existing owner over a new cache-policy layer.** Chose the minimum `_read_cache_entry()` fix; rejected a new abstraction or static architecture guard because authority did not move.
- **Mutation twins over coverage percentage.** Chose two explicit fault injections that prove the properties detect the TTL defect and a missing enforceable field.
- **Surgical scope over adjacent integrity work.** Resolver, marketplace, general cache, agent, critical-suite, and materialized Git-tree integrity files remain unchanged.

## Benefits

1. Every one of the current 39 enforceable/cache dataclass leaves is named and compared after canonical serialization.
2. Twenty-four deterministic examples per main property cover non-default values and valid combinations without a persistent Hypothesis database.
3. Ten malformed field combinations prove fail-closed outcomes and byte-for-byte preservation of the last-good cache entry.
4. Two negative twins prove the suite fails when the old fixed-hour behavior or a serializer field omission is reintroduced.
5. Steady-state property runs complete in 2.71-3.00 seconds of pytest time and 3.35-3.75 seconds wall time on the author machine.

## Validation

`uv run --extra dev pytest -q tests/unit/policy/test_policy_serialization_properties.py` repeated five times:

```text
run 1: 15 passed in 5.60s | wall 7.19s
run 2: 15 passed in 3.00s | wall 3.61s
run 3: 15 passed in 2.79s | wall 3.36s
run 4: 15 passed in 2.90s | wall 3.75s
run 5: 15 passed in 2.71s | wall 3.35s
```

<details><summary>Relevant policy, architecture, quality, lint, and audit evidence</summary>

`uv run --extra dev pytest -q tests/unit/policy tests/integration/test_policy_coverage.py tests/integration/test_policy_discovery_e2e.py tests/integration/test_policy_url_chain_parity.py tests/integration/test_policy_pinned_constraint_e2e.py tests/integration/test_policy_install_e2e.py`:

```text
1116 passed, 15 skipped, 1 xfailed, 63 subtests passed in 17.06s
```

`uv run --extra dev pytest -q tests/integration/test_architecture_*.py tests/quality`:

```text
97 passed in 174.53s (0:02:54)
```

`uv run --extra dev ruff check src/ tests/ && uv run --extra dev ruff format --check src/ tests/ && uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/ && bash scripts/lint-auth-signals.sh && bash scripts/lint-architecture-boundaries.sh`:

```text
All checks passed!
1528 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
[+] architecture boundary lint clean
```

`uv run --extra dev apm audit --ci`:

```text
[+] Replayed 7 package(s)
[+] No drift detected
[*] All 9 check(s) passed
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | A non-default Govern policy keeps every enforceable setting after effective-policy caching and reload | Governed by policy | `tests/unit/policy/test_policy_serialization_properties.py::test_effective_policy_cache_serialization_is_lossless_and_canonical` | unit |
| 2 | A warm policy read returns the same policy outcome and authored warnings as the cold network read | Governed by policy, DevX | `tests/unit/policy/test_policy_serialization_properties.py::test_cold_and_warm_policy_results_are_observationally_equivalent` | unit |
| 3 | A policy-defined cache TTL triggers refresh immediately after expiry instead of waiting one hour | Governed by policy | `tests/unit/policy/test_policy_serialization_properties.py::test_policy_cache_ttl_controls_when_warm_reads_refresh`<br/>`::test_cache_ttl_property_breaks_if_reader_uses_fixed_default` (regression trap for the generated RED counterexample; no linked issue) | unit |
| 4 | A malformed policy refresh fails closed without replacing last-good policy or metadata bytes | Secure by default, Governed by policy | `tests/unit/policy/test_policy_serialization_properties.py::test_invalid_refresh_fails_closed_and_preserves_last_good_cache` | unit |

## How to test

- [ ] Run the property module once; expect 15 passing tests and no Hypothesis health-check or deadline failures.
- [ ] Repeat the property module five times; expect the fixed seed and disabled database to produce stable passing runs.
- [ ] Temporarily force `_read_cache_entry(..., ttl=DEFAULT_CACHE_TTL)` in the TTL negative twin; expect the refresh property to raise its targeted assertion.
- [ ] Run the relevant policy suite; expect 1116 passes, 15 skips, one expected failure, and 63 passing subtests.
- [ ] Inspect the diff scope; expect only Govern policy discovery, its new property test, dev dependency metadata, lockfile, and the governance guide.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>