### PR TITLE
fix(deps): bound best-effort ref lookup retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Best-effort commits API lookups now fall through promptly to Git when
+  rate-limited, avoiding multi-minute dependency resolution stalls -- by
+  @danielmeppiel (#2238).
 - Govern policy cache freshness now honors the effective policy's `cache.ttl`;
   bounded property coverage protects all 39 enforceable fields, cold/warm parity,
   canonical serialization, and last-good bytes after malformed refreshes. (#2235)

--- a/src/apm_cli/deps/download_strategies.py
+++ b/src/apm_cli/deps/download_strategies.py
@@ -134,7 +134,7 @@ class DownloadDelegate:
             url: Request URL
             headers: HTTP headers
             timeout: Request timeout in seconds
-            max_retries: Maximum retry attempts for transient failures
+            max_retries: Maximum total attempts, including the initial request
             stream: Whether to stream the response body instead of buffering it
 
         Returns:
@@ -177,13 +177,18 @@ class DownloadDelegate:
                             wait = min(2**attempt, 30) * (0.5 + random.random())  # noqa: S311
                     else:
                         wait = min(2**attempt, 30) * (0.5 + random.random())  # noqa: S311
-                    _debug(
-                        f"Rate limited ({response.status_code}), retry in "
-                        f"{wait:.1f}s (attempt {attempt + 1}/{max_retries})"
-                    )
                     if attempt < max_retries - 1:
+                        _debug(
+                            f"Rate limited ({response.status_code}), retry in "
+                            f"{wait:.1f}s (attempt {attempt + 1}/{max_retries})"
+                        )
                         _close_response(response, "rate-limit retry")
                         time.sleep(wait)
+                    else:
+                        _debug(
+                            f"Rate limited ({response.status_code}), no retries left "
+                            f"(attempt {attempt + 1}/{max_retries})"
+                        )
                     continue
 
                 # Log rate limit proximity

--- a/src/apm_cli/deps/download_strategies.py
+++ b/src/apm_cli/deps/download_strategies.py
@@ -183,7 +183,7 @@ class DownloadDelegate:
                     )
                     if attempt < max_retries - 1:
                         _close_response(response, "rate-limit retry")
-                    time.sleep(wait)
+                        time.sleep(wait)
                     continue
 
                 # Log rate limit proximity

--- a/src/apm_cli/deps/git_reference_resolver.py
+++ b/src/apm_cli/deps/git_reference_resolver.py
@@ -319,6 +319,7 @@ class GitReferenceResolver:
             headers["Authorization"] = f"token {token}"
 
         try:
+            # L2/L3 own fallback, so this optional metadata tier gets one total attempt.
             response = host._resilient_get(api_url, headers=headers, timeout=10, max_retries=1)
             if response.status_code != 200:
                 return None

--- a/src/apm_cli/deps/git_reference_resolver.py
+++ b/src/apm_cli/deps/git_reference_resolver.py
@@ -44,6 +44,8 @@ from ..utils.github_host import (
 )
 
 if TYPE_CHECKING:
+    import requests
+
     from ..core.auth import AuthResolver
     from .transport_selection import ProtocolPreference, TransportSelector
 
@@ -85,7 +87,13 @@ class _DownloaderContext(Protocol):
     ) -> str: ...
     def _clone_with_fallback(self, *args, **kwargs): ...
     def _sanitize_git_error(self, error_message: str) -> str: ...
-    def _resilient_get(self, url: str, headers: dict, timeout: int = ...): ...
+    def _resilient_get(
+        self,
+        url: str,
+        headers: dict[str, str],
+        timeout: int = ...,
+        max_retries: int = ...,
+    ) -> requests.Response: ...
     def _parse_ls_remote_output(self, output: str) -> list[RemoteRef]: ...
     def _sort_remote_refs(self, refs: list[RemoteRef]) -> list[RemoteRef]: ...
     def _parse_artifactory_base_url(self) -> tuple | None: ...
@@ -311,7 +319,7 @@ class GitReferenceResolver:
             headers["Authorization"] = f"token {token}"
 
         try:
-            response = host._resilient_get(api_url, headers=headers, timeout=10)
+            response = host._resilient_get(api_url, headers=headers, timeout=10, max_retries=1)
             if response.status_code != 200:
                 return None
             body = (response.text or "").strip()

--- a/src/apm_cli/deps/tiered_ref_resolver.py
+++ b/src/apm_cli/deps/tiered_ref_resolver.py
@@ -154,9 +154,10 @@ class L1CommitsAPI:
     Delegates to :meth:`GitReferenceResolver.resolve_commit_sha_for_ref` --
     the cheap-path helper that already dispatches through
     ``host_backends.build_commits_api_url`` and ``host._resilient_get``,
-    inheriting that helper's auth + retry behavior. Returns ``None`` for
-    hosts whose backend has no cheap commits endpoint (e.g. ADO today);
-    the caller then falls through to L2/L3.
+    inheriting that helper's auth behavior. The optional metadata lookup
+    makes one HTTP attempt so rate limiting cannot delay L2/L3 fallback.
+    Returns ``None`` for hosts whose backend has no cheap commits endpoint
+    (e.g. ADO today); the caller then falls through to L2/L3.
 
     Future: an explicit :class:`HttpCache` ETag pass could be added here
     for unauthenticated requests (the underlying helper does not yet

--- a/tests/unit/deps/test_download_strategies_phase3.py
+++ b/tests/unit/deps/test_download_strategies_phase3.py
@@ -227,15 +227,22 @@ class TestResilientGet:
         assert result is forbidden_resp
         assert mock_get.call_count == 1
 
-    def test_rate_limit_exhausts_retries_returns_last_response(self) -> None:
+    def test_rate_limit_exhausts_retries_returns_last_response(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         """If every attempt is rate-limited, the last rate-limit response is returned."""
         rate_resp = _fake_response(429, b"rate", headers={"Retry-After": "0.001"})
         with (
             patch("requests.get", return_value=rate_resp),
-            patch("time.sleep"),
+            patch("time.sleep") as mock_sleep,
+            patch.dict("os.environ", {"APM_DEBUG": "1"}),
         ):
             result = self.delegate.resilient_get("https://example.com", {}, max_retries=2)
         assert result is rate_resp
+        assert mock_sleep.call_count == 1
+        captured = capsys.readouterr()
+        assert captured.err.count("retry in") == 1
+        assert "no retries left (attempt 2/2)" in captured.err
 
     def test_retry_after_invalid_falls_back_to_backoff(self) -> None:
         """Non-numeric Retry-After header falls back to exponential back-off."""

--- a/tests/unit/deps/test_git_reference_resolver.py
+++ b/tests/unit/deps/test_git_reference_resolver.py
@@ -120,6 +120,9 @@ def _loopback_http_stub(
     responses: list[tuple[int, dict[str, str], bytes]],
 ) -> Iterator[tuple[types.SimpleNamespace, str]]:
     """Serve deterministic HTTP responses from loopback."""
+    if not responses:
+        raise ValueError("responses must not be empty")
+
     state = types.SimpleNamespace(hits=0)
 
     class Handler(BaseHTTPRequestHandler):

--- a/tests/unit/deps/test_git_reference_resolver.py
+++ b/tests/unit/deps/test_git_reference_resolver.py
@@ -14,7 +14,11 @@ from __future__ import annotations
 
 import os
 import sys
+import threading
 import types
+from collections.abc import Iterator
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -23,6 +27,7 @@ from git.exc import GitCommandError
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "src"))
 
 from apm_cli.deps.git_reference_resolver import GitReferenceResolver
+from apm_cli.deps.github_downloader import GitHubPackageDownloader
 from apm_cli.deps.transport_selection import (
     NoOpInsteadOfResolver,
     ProtocolPreference,
@@ -110,6 +115,38 @@ def _ctx(
     return host
 
 
+@contextmanager
+def _loopback_http_stub(
+    responses: list[tuple[int, dict[str, str], bytes]],
+) -> Iterator[tuple[types.SimpleNamespace, str]]:
+    """Serve deterministic HTTP responses from loopback."""
+    state = types.SimpleNamespace(hits=0)
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            index = min(state.hits, len(responses) - 1)
+            status, headers, body = responses[index]
+            state.hits += 1
+            self.send_response(status)
+            for name, value in headers.items():
+                self.send_header(name, value)
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield state, f"http://127.0.0.1:{server.server_port}/commit/main"
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+        server.server_close()
+
+
 # ---------------------------------------------------------------------------
 # resolve_commit_sha_for_ref
 # ---------------------------------------------------------------------------
@@ -176,6 +213,59 @@ class TestResolveCommitShaForRef:
         resolver = GitReferenceResolver(host)
         # Use a generic-host dep -- generic backend returns None for commits API
         assert resolver.resolve_commit_sha_for_ref(_dep(host="git.example.com"), "main") is None
+
+    def test_best_effort_rate_limit_falls_through_without_retry_wait(self):
+        """The optional commits-API tier must not stall the git fallback."""
+        downloader = GitHubPackageDownloader()
+        dep = _dep(host="github.com", reference="main")
+        responses = [
+            (
+                403,
+                {"X-RateLimit-Remaining": "0", "Retry-After": "60"},
+                b"rate limited",
+            )
+        ]
+
+        with (
+            _loopback_http_stub(responses) as (server, api_url),
+            patch(
+                "apm_cli.deps.host_backends.backend_for",
+                return_value=types.SimpleNamespace(
+                    build_commits_api_url=lambda dep_ref, ref: api_url
+                ),
+            ),
+            patch.object(
+                downloader.auth_resolver,
+                "resolve",
+                return_value=types.SimpleNamespace(token=None),
+            ),
+            patch("apm_cli.deps.download_strategies.time.sleep") as sleep,
+        ):
+            result = downloader._refs.resolve_commit_sha_for_ref(dep, "main")
+
+        assert result is None
+        assert server.hits == 1
+        sleep.assert_not_called()
+
+    def test_primary_http_transient_rate_limit_still_retries(self):
+        """Primary HTTP work keeps the shared transient retry policy."""
+        downloader = GitHubPackageDownloader()
+        sha = b"deadbeef" + (b"0" * 32)
+        responses = [
+            (429, {"Retry-After": "0.01"}, b"rate limited"),
+            (200, {}, sha),
+        ]
+
+        with (
+            _loopback_http_stub(responses) as (server, api_url),
+            patch("apm_cli.deps.download_strategies.time.sleep") as sleep,
+        ):
+            response = downloader._resilient_get(api_url, {}, timeout=1)
+
+        assert response.status_code == 200
+        assert response.content == sha
+        assert server.hits == 2
+        sleep.assert_called_once_with(0.01)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# fix(deps): bound best-effort ref lookup retries

## TL;DR

The optional GitHub commit-SHA lookup now makes one HTTP attempt and falls through immediately when rate-limited instead of inheriting the primary-download retry budget. The shared retry owner also stops sleeping after its final attempt, while primary HTTP operations continue to honor transient `Retry-After` responses. This removes the 120-second resolver stall exposed while validating merged PR #2229 without changing its SSH transport behavior.

> [!NOTE]
> This is a focused follow-up to #2229; it does not change protocol selection, authentication resolution, documented CLI surfaces, or dependency formats.

apm-spec-waiver: Internal retry-budget correction with no OpenAPM manifest or resolver contract changes.

## Problem (WHY)

- [x] A loopback production-path reproduction returned `403` with `X-RateLimit-Remaining: 0` and `Retry-After: 60`; the best-effort commit lookup made 3 HTTP requests and requested sleeps of `[60.0, 60.0, 60.0]` before returning `None`.
- [x] `DownloadDelegate.resilient_get()` slept after the final rate-limit attempt even though no subsequent retry could occur.
- [x] `GitReferenceResolver.resolve_commit_sha_for_ref()` inherited the default 3-attempt budget even though the tier is optional and has Git fallbacks.
- [!] The shared retry policy is intentional for primary downloads, so a global reduction would trade a latency bug for transient install failures.

The fix stays at the existing owner boundaries because ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) The loopback regression turns the observed symptom into deterministic evidence: ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)

## Approach (WHAT)

| # | Fix | Principle |
|---:|---|---|
| 1 | Request `max_retries=1` only for the optional commit-SHA API lookup. | ["Add what the agent lacks, omit what it knows"](https://agentskills.io/skill-creation/best-practices) |
| 2 | Sleep only when another rate-limit attempt will actually run. | ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |
| 3 | Exercise the real resolver-to-HTTP path with a loopback stub and retain a transient-retry twin. | ["agents pattern-match well against concrete structures"](https://agentskills.io/skill-creation/best-practices) |

## Implementation (HOW)

| File | Change |
|---|---|
| [`src/apm_cli/deps/download_strategies.py`](https://github.com/microsoft/apm/blob/danielmeppiel-fix-tiered-resolver-backoff/src/apm_cli/deps/download_strategies.py#L163-L192) | Keeps rate-limit response classification and wait calculation unchanged, but runs `sleep()` only between attempts and reports final-attempt fallthrough truthfully in debug mode. |
| [`src/apm_cli/deps/git_reference_resolver.py`](https://github.com/microsoft/apm/blob/danielmeppiel-fix-tiered-resolver-backoff/src/apm_cli/deps/git_reference_resolver.py#L267-L330) | Extends the downloader protocol signature and gives the optional commits-API lookup a one-attempt budget. Auth still resolves through `AuthResolver`; non-200 responses still return `None`. |
| [`src/apm_cli/deps/tiered_ref_resolver.py`](https://github.com/microsoft/apm/blob/danielmeppiel-fix-tiered-resolver-backoff/src/apm_cli/deps/tiered_ref_resolver.py#L151-L165) | Documents the intentional one-attempt L1 policy before Git-backed L2/L3 fallback. |
| [`tests/unit/deps/test_git_reference_resolver.py`](https://github.com/microsoft/apm/blob/danielmeppiel-fix-tiered-resolver-backoff/tests/unit/deps/test_git_reference_resolver.py#L118-L269) | Adds a deterministic loopback server, the rate-limit regression trap, and a transient `429 -> 200` twin for the primary retry path. |
| [`tests/unit/deps/test_download_strategies_phase3.py`](https://github.com/microsoft/apm/blob/danielmeppiel-fix-tiered-resolver-backoff/tests/unit/deps/test_download_strategies_phase3.py#L230-L250) | Directly asserts that exhausted retries sleep only between attempts and emit truthful debug text. |
| [`CHANGELOG.md`](https://github.com/microsoft/apm/blob/danielmeppiel-fix-tiered-resolver-backoff/CHANGELOG.md#L21-L28) | Records the user-visible latency fix under Unreleased/Fixed. |

## Diagrams

Legend: the highlighted exchange is the changed best-effort path; reviewers should verify that rate limiting falls through to Git without weakening the primary retry owner.

```mermaid
sequenceDiagram
    participant I as Install resolver
    participant T as TieredRefResolver
    participant C as Commits API tier
    participant H as DownloadDelegate
    participant G as Git fallback

    I->>T: resolve named ref
    T->>C: try L1
    rect rgb(255, 247, 200)
        C->>H: GET with max_retries 1
        H-->>C: 403 rate limited
        Note over H: No final-attempt sleep
        C-->>T: None
    end
    T->>G: continue to L2 or L3
    G-->>T: resolved commit
    T-->>I: ResolvedReference
```

## Trade-offs

- **Per-call budget instead of a new policy abstraction.** Chose the existing `max_retries` seam; rejected a new enum or retry-policy class because this is the only best-effort call site.
- **Primary retries remain enabled.** Chose one attempt only for commits metadata; rejected changing the shared default of 3 because downloads without a fallback still need transient recovery.
- **Final-attempt sleep fixed centrally.** Chose to guard the owner rather than special-case the resolver because sleeping before returning can never help any caller.
- **No documentation change.** The PR adds no flag, output, authentication order, or dependency format; the existing tier and auth documentation remains accurate.

## Benefits

1. A rate-limited best-effort commit lookup performs 1 HTTP request and 0 waits instead of 3 requests and up to 180 seconds of requested sleep.
2. A primary transient `429` still performs a second request after exactly 1 `Retry-After` wait.
3. Both relevant mutations are killed independently: inherited retry budget fails on hit count, and final-attempt sleep fails on sleep count.
4. Existing SSH resolver contracts remain green across 145 focused tests.

## Validation

Pre-fix loopback reproduction:

```text
{'result': None, 'http_hits': 3, 'requested_sleeps': [60.0, 60.0, 60.0]}
```

Focused resolver and retry tests:

```text
186 passed in 2.68s
```

Exact CI unit set:

```text
19157 passed, 2 skipped, 21 xfailed, 19 warnings, 86 subtests passed in 219.48s
```

Resolver, auth, and architecture integrations:

```text
119 passed, 31 skipped in 160.37s
```

SSH resolver contracts:

```text
145 passed in 1.89s
```

<details><summary>Quality, conformance, audit, and lint evidence</summary>

`uv run --extra dev pytest -p no:cacheprovider -q tests/quality`:

```text
25 passed in 39.44s
[+] assertion-quality ratchet clean: AQ001=5, AQ002=12
[+] exact test duplicate ratchet clean: 1052 files, 8 allowed duplicate group(s)
```

Spec conformance:

```text
[+] orphan_check OK: 100 requirements aligned across anchors / manifest / Appendix C / pytest markers
Mode B waiver: internal retry-budget correction with no OpenAPM manifest or resolver contract changes.
140 passed, 2 skipped in 29.78s
```

`uv run apm audit --ci`:

```text
[*] All 9 check(s) passed
```

Canonical lint:

```text
All checks passed!
1533 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
[+] architecture boundary lint clean
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | A rate-limited optional metadata lookup does not hold up dependency resolution before Git fallback. | DevX (pragmatic as npm), Vendor-neutral | `tests/unit/deps/test_git_reference_resolver.py::TestResolveCommitShaForRef::test_best_effort_rate_limit_falls_through_without_retry_wait` (regression-trap for the #2229 follow-up) | integration |
| 2 | Primary HTTP work still recovers from a transient rate limit after honoring `Retry-After`. | DevX (pragmatic as npm), Secure by default | `tests/unit/deps/test_git_reference_resolver.py::TestResolveCommitShaForRef::test_primary_http_transient_rate_limit_still_retries` | integration |
| 3 | SSH ref enumeration still avoids token auth and protocol fallback. | Secure by default, Vendor-neutral | `tests/unit/deps/test_git_reference_resolver.py::TestListRemoteRefs::test_ssh_preference_selects_ssh_without_token_auth`<br/>`tests/unit/deps/test_git_semver_resolver.py` | unit |

## How to test

- [ ] Run `uv run --extra dev pytest -q tests/unit/deps/test_git_reference_resolver.py` and observe both loopback scenarios pass.
- [ ] Temporarily remove `max_retries=1`; the regression trap should fail with 3 HTTP hits.
- [ ] Temporarily move `sleep(wait)` outside the final-attempt guard; the regression trap should fail with one 60-second sleep request.
- [ ] Run `uv run --extra dev pytest -q tests/unit/deps/test_download_strategies_phase3.py` and observe exactly one sleep and one `retry in` diagnostic across two exhausted attempts.
- [ ] Run `uv run --extra dev pytest -q tests/unit/deps/test_git_semver_resolver.py tests/unit/deps/test_tiered_ref_resolver.py` and observe the SSH/tiered contracts remain green.
- [ ] Run the canonical lint chain and observe the auth and AC1-AC13 architecture guards pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>