### PR TITLE
test(auth): add Windows SSH passphrase evidence fixture

### DIFF
--- a/.github/workflows/windows-ssh-passphrase-repro.yml
+++ b/.github/workflows/windows-ssh-passphrase-repro.yml
@@ -1,0 +1,85 @@
+name: Windows SSH Passphrase Reproduction
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/windows-ssh-passphrase-repro.yml'
+      - 'scripts/windows/test-ssh-passphrase-fixture.ps1'
+      - 'src/apm_cli/deps/**'
+      - 'src/apm_cli/install/**'
+      - 'src/apm_cli/core/auth.py'
+      - 'src/apm_cli/core/token_manager.py'
+      - 'build/apm.spec'
+      - 'scripts/windows/build-binary.ps1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-ssh-passphrase-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  windows-ssh-passphrase:
+    name: Windows SSH passphrase contract
+    runs-on: windows-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Verify fixture-only baseline
+        shell: pwsh
+        run: |
+          $baseline = "796e229805ade19244683f0a1e70ec534ce4fb85"
+          git merge-base --is-ancestor $baseline HEAD
+          if ($LASTEXITCODE -ne 0) {
+            throw "Required baseline $baseline is not an ancestor of HEAD"
+          }
+          $allowed = @(
+            ".github/workflows/windows-ssh-passphrase-repro.yml",
+            "scripts/windows/test-ssh-passphrase-fixture.ps1"
+          )
+          $changed = @(git diff --name-only "$baseline..HEAD")
+          $unexpected = @($changed | Where-Object { $allowed -notcontains $_ })
+          if ($unexpected.Count -gt 0) {
+            throw "Evidence lane contains non-fixture changes: $($unexpected -join ', ')"
+          }
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install build dependencies
+        run: uv sync --extra dev --extra build
+
+      - name: Build packaged Windows CLI
+        shell: pwsh
+        run: uv run pwsh scripts/windows/build-binary.ps1
+
+      - name: Exercise encrypted SSH key boundary
+        shell: pwsh
+        run: >-
+          ./scripts/windows/test-ssh-passphrase-fixture.ps1
+          -ApmBinary ./dist/apm-windows-x86_64/apm.exe
+          -EvidenceDirectory ./ssh-passphrase-evidence
+
+      - name: Upload process evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-ssh-passphrase-evidence
+          path: ./ssh-passphrase-evidence
+          if-no-files-found: error
+          retention-days: 14

--- a/scripts/windows/test-ssh-passphrase-fixture.ps1
+++ b/scripts/windows/test-ssh-passphrase-fixture.ps1
@@ -1094,7 +1094,7 @@ Match Group administrators
 
     foreach ($sensitiveValue in @($passphrase, $wrongPassphrase)) {
         foreach ($file in Get-ChildItem -Path $EvidenceDirectory -File -Recurse) {
-            $evidenceContent = [string](Get-Content -Path $file.FullName -Raw)
+            $evidenceContent = [System.IO.File]::ReadAllText($file.FullName)
             if ($evidenceContent.Contains($sensitiveValue)) {
                 throw "Ephemeral passphrase leaked into evidence file: $($file.FullName)"
             }

--- a/scripts/windows/test-ssh-passphrase-fixture.ps1
+++ b/scripts/windows/test-ssh-passphrase-fixture.ps1
@@ -338,14 +338,14 @@ function New-ScenarioEnvironment {
         $environment[[string]$entry.Key] = [string]$entry.Value
     }
 
-    $home = Join-Path $ScenarioRoot "home"
+    $homeRoot = Join-Path $ScenarioRoot "home"
     $config = Join-Path $ScenarioRoot "config"
     $cache = Join-Path $ScenarioRoot "cache"
     $temp = Join-Path $ScenarioRoot "temp"
-    foreach ($path in @($home, $config, $cache, $temp)) {
+    foreach ($path in @($homeRoot, $config, $cache, $temp)) {
         New-Item -ItemType Directory -Path $path -Force | Out-Null
     }
-    $updateCache = Join-Path $home "AppData\Local\apm\cache"
+    $updateCache = Join-Path $homeRoot "AppData\Local\apm\cache"
     New-Item -ItemType Directory -Path $updateCache -Force | Out-Null
     New-Item -ItemType File -Path (Join-Path $updateCache "last_version_check") -Force | Out-Null
 
@@ -374,9 +374,9 @@ function New-ScenarioEnvironment {
         "NumberOfPasswordPrompts=1"
     ) -join " "
 
-    $environment["HOME"] = $home
-    $environment["USERPROFILE"] = $home
-    $environment["LOCALAPPDATA"] = Join-Path $home "AppData\Local"
+    $environment["HOME"] = $homeRoot
+    $environment["USERPROFILE"] = $homeRoot
+    $environment["LOCALAPPDATA"] = Join-Path $homeRoot "AppData\Local"
     $environment["XDG_CONFIG_HOME"] = $config
     $environment["XDG_CACHE_HOME"] = $cache
     $environment["APM_HOME"] = $config

--- a/scripts/windows/test-ssh-passphrase-fixture.ps1
+++ b/scripts/windows/test-ssh-passphrase-fixture.ps1
@@ -253,6 +253,16 @@ function Get-TraceReceipt {
             }
         }
     )
+    $processExits = @(
+        $events | Where-Object {
+            $_.event -eq "exit"
+        } | ForEach-Object {
+            [pscustomobject]@{
+                sid = [string]$_.sid
+                exit_code = [int]$_.code
+            }
+        }
+    )
     $safeEnvironmentNames = @(
         "GIT_TERMINAL_PROMPT",
         "GIT_ASKPASS",
@@ -300,6 +310,7 @@ function Get-TraceReceipt {
             }
         )
         child_exits = $transportExits
+        process_exits = $processExits
         environment = $environmentEvents
     }
 }
@@ -493,13 +504,14 @@ targets:
     Write-Utf8Text -Path $stdoutPath -Content $process.stdout
     Write-Utf8Text -Path $stderrPath -Content $process.stderr
 
-    $skillPath = Join-Path $projectRoot ".github\skills\ssh-passphrase-fixture\SKILL.md"
+    $skillPath = Join-Path $projectRoot ".agents\skills\ssh-passphrase-fixture\SKILL.md"
     $lockPath = Join-Path $projectRoot "apm.lock.yaml"
     $actualSuccess = -not $process.timed_out -and $process.exit_code -eq 0
     $skillInstalled = Test-Path $skillPath
     $lockWritten = Test-Path $lockPath
     $askpassReceipt = @(Get-AskpassReceipt -AskpassLog $askpassLogPath)
     $traceReceipt = Get-TraceReceipt -TracePath $tracePath
+    $sshLogContent = [string](Get-Content -Path $sshLogPath -Raw)
     $skillMatches = $false
     if ($skillInstalled) {
         $skillMatches = (Get-Content -Path $skillPath -Raw).Contains($ExpectedSkillMarker)
@@ -524,6 +536,7 @@ targets:
         }
         askpass_invocation_count = $askpassReceipt.Count
         askpass_invocations = $askpassReceipt
+        ssh_agent_socket_unavailable = $sshLogContent.Contains("unable to connect to pipe")
         git_trace = $traceReceipt
         skill_installed = $skillInstalled
         skill_marker_matches = $skillMatches
@@ -672,7 +685,7 @@ type invocation struct {
     SshAskpass         string   `json:"ssh_askpass"`
     SshAskpassRequire  string   `json:"ssh_askpass_require"`
     Display            string   `json:"display"`
-    SshAuthSockPresent bool     `json:"ssh_auth_sock_present"`
+    SshAuthSock         string   `json:"ssh_auth_sock"`
     ResponsePresent    bool     `json:"response_present"`
 }
 
@@ -685,7 +698,7 @@ func main() {
         SshAskpass:         os.Getenv("SSH_ASKPASS"),
         SshAskpassRequire:  os.Getenv("SSH_ASKPASS_REQUIRE"),
         Display:            os.Getenv("DISPLAY"),
-        SshAuthSockPresent: os.Getenv("SSH_AUTH_SOCK") != "",
+        SshAuthSock:        os.Getenv("SSH_AUTH_SOCK"),
         ResponsePresent:    responsePresent,
     }
     logPath := os.Getenv("APM_SSH_FIXTURE_ASKPASS_LOG")
@@ -893,30 +906,30 @@ Match Group administrators
                     "Scenario $($receipt.id): Git did not record the configured Windows OpenSSH child"
                 )
             } else {
-                $missingChildExits = @(
-                    $openSshChildren | Where-Object { $null -eq $_.exit_code }
-                )
-                if ($missingChildExits.Count -gt 0) {
-                    $assertionFailures.Add(
-                        "Scenario $($receipt.id): one or more OpenSSH children have no Trace2 exit"
-                    )
-                }
                 $sshExitCodes = @(
                     $openSshChildren | Where-Object { $null -ne $_.exit_code } |
                         ForEach-Object { [int]$_.exit_code }
                 )
-                if ($receipt.expected_success -and @($sshExitCodes | Where-Object { $_ -ne 0 }).Count -gt 0) {
-                    $assertionFailures.Add(
-                        "Scenario $($receipt.id): a successful case recorded a failed OpenSSH child"
+                if ($receipt.expected_success) {
+                    if ($sshExitCodes.Count -ne $openSshChildren.Count) {
+                        $assertionFailures.Add(
+                            "Scenario $($receipt.id): successful OpenSSH child has no Trace2 exit"
+                        )
+                    }
+                    if (@($sshExitCodes | Where-Object { $_ -ne 0 }).Count -gt 0) {
+                        $assertionFailures.Add(
+                            "Scenario $($receipt.id): a successful case recorded a failed OpenSSH child"
+                        )
+                    }
+                } else {
+                    $failedGitExits = @(
+                        $receipt.git_trace.process_exits | Where-Object { $_.exit_code -ne 0 }
                     )
-                }
-                if (
-                    -not $receipt.expected_success -and
-                    @($sshExitCodes | Where-Object { $_ -ne 0 }).Count -eq 0
-                ) {
-                    $assertionFailures.Add(
-                        "Scenario $($receipt.id): negative case recorded no failed OpenSSH child"
-                    )
+                    if ($failedGitExits.Count -eq 0) {
+                        $assertionFailures.Add(
+                            "Scenario $($receipt.id): negative case recorded no failed Git exit"
+                        )
+                    }
                 }
             }
         }
@@ -949,6 +962,11 @@ Match Group administrators
         if ($traceEnvironment.ContainsKey("SSH_AUTH_SOCK")) {
             $assertionFailures.Add(
                 "Scenario $($receipt.id): SSH agent state leaked into the Git child"
+            )
+        }
+        if (-not $receipt.ssh_agent_socket_unavailable) {
+            $assertionFailures.Add(
+                "Scenario $($receipt.id): OpenSSH did not prove its default agent pipe unavailable"
             )
         }
         $expectsAskpassEnvironment = $receipt.id -ne "unencrypted-positive"
@@ -1015,9 +1033,12 @@ Match Group administrators
                     "Scenario $($receipt.id): askpass child did not inherit the fixture DISPLAY"
                 )
             }
-            if ($invocation.ssh_auth_sock_present) {
+            if (
+                -not [string]::IsNullOrEmpty($invocation.ssh_auth_sock) -and
+                $invocation.ssh_auth_sock -ne '\\.\pipe\openssh-ssh-agent'
+            ) {
                 $assertionFailures.Add(
-                    "Scenario $($receipt.id): askpass child inherited SSH agent state"
+                    "Scenario $($receipt.id): askpass child inherited unexpected SSH agent state"
                 )
             }
             if (-not $invocation.response_present) {
@@ -1073,7 +1094,8 @@ Match Group administrators
 
     foreach ($sensitiveValue in @($passphrase, $wrongPassphrase)) {
         foreach ($file in Get-ChildItem -Path $EvidenceDirectory -File -Recurse) {
-            if ((Get-Content -Path $file.FullName -Raw).Contains($sensitiveValue)) {
+            $evidenceContent = [string](Get-Content -Path $file.FullName -Raw)
+            if ($evidenceContent.Contains($sensitiveValue)) {
                 throw "Ephemeral passphrase leaked into evidence file: $($file.FullName)"
             }
         }

--- a/scripts/windows/test-ssh-passphrase-fixture.ps1
+++ b/scripts/windows/test-ssh-passphrase-fixture.ps1
@@ -1,0 +1,1094 @@
+# Hermetic Windows reproduction contract for encrypted SSH private keys.
+#
+# This script exercises a packaged APM binary through real Git and Windows
+# OpenSSH processes. It creates only ephemeral keys and loopback services.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ApmBinary,
+
+    [string]$EvidenceDirectory = (Join-Path $PWD "ssh-passphrase-evidence")
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$EvidenceDirectory = [System.IO.Path]::GetFullPath($EvidenceDirectory, $PWD.Path)
+
+function Write-Info {
+    param([string]$Message)
+    Write-Host "[i] $Message"
+}
+
+function Write-Success {
+    param([string]$Message)
+    Write-Host "[+] $Message"
+}
+
+function Assert-Condition {
+    param(
+        [bool]$Condition,
+        [string]$Message
+    )
+    if (-not $Condition) {
+        throw $Message
+    }
+    Write-Success $Message
+}
+
+function ConvertTo-ForwardSlashPath {
+    param([string]$Path)
+    return $Path.Replace("\", "/")
+}
+
+function Invoke-CapturedProcess {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [string[]]$ArgumentList = @(),
+
+        [string]$WorkingDirectory = $PWD.Path,
+
+        [System.Collections.IDictionary]$Environment,
+
+        [int]$TimeoutSeconds = 60
+    )
+
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $FilePath
+    $startInfo.WorkingDirectory = $WorkingDirectory
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    foreach ($argument in $ArgumentList) {
+        $startInfo.ArgumentList.Add($argument)
+    }
+
+    if ($null -ne $Environment) {
+        $startInfo.Environment.Clear()
+        foreach ($entry in $Environment.GetEnumerator()) {
+            if ($null -ne $entry.Value) {
+                $startInfo.Environment[[string]$entry.Key] = [string]$entry.Value
+            }
+        }
+    }
+
+    $process = [System.Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    $startedAt = [DateTimeOffset]::UtcNow
+    if (-not $process.Start()) {
+        throw "Failed to start process: $FilePath"
+    }
+
+    $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+    $stderrTask = $process.StandardError.ReadToEndAsync()
+    $timedOut = -not $process.WaitForExit($TimeoutSeconds * 1000)
+    if ($timedOut) {
+        try {
+            $process.Kill($true)
+        } catch {
+            if (-not $process.HasExited) {
+                throw
+            }
+        }
+        $process.WaitForExit()
+    }
+    $process.WaitForExit()
+    $finishedAt = [DateTimeOffset]::UtcNow
+
+    return [pscustomobject]@{
+        file_path = $FilePath
+        arguments = @($ArgumentList)
+        working_directory = $WorkingDirectory
+        exit_code = $process.ExitCode
+        stdout = $stdoutTask.GetAwaiter().GetResult()
+        stderr = $stderrTask.GetAwaiter().GetResult()
+        started_at = $startedAt.ToString("o")
+        finished_at = $finishedAt.ToString("o")
+        duration_ms = [math]::Round(($finishedAt - $startedAt).TotalMilliseconds)
+        timed_out = $timedOut
+        timeout_seconds = $TimeoutSeconds
+    }
+}
+
+function Invoke-CheckedProcess {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [string[]]$ArgumentList = @(),
+
+        [string]$WorkingDirectory = $PWD.Path,
+
+        [System.Collections.IDictionary]$Environment,
+
+        [int]$TimeoutSeconds = 60
+    )
+
+    $result = Invoke-CapturedProcess `
+        -FilePath $FilePath `
+        -ArgumentList $ArgumentList `
+        -WorkingDirectory $WorkingDirectory `
+        -Environment $Environment `
+        -TimeoutSeconds $TimeoutSeconds
+    if ($result.timed_out -or $result.exit_code -ne 0) {
+        throw (
+            "Process failed (exit={0}, timed_out={1}): {2}`nstdout:`n{3}`nstderr:`n{4}" -f
+            $result.exit_code,
+            $result.timed_out,
+            $FilePath,
+            $result.stdout,
+            $result.stderr
+        )
+    }
+    return $result
+}
+
+function Get-CleanEnvironment {
+    $environment = [ordered]@{}
+    foreach ($entry in [Environment]::GetEnvironmentVariables().GetEnumerator()) {
+        $environment[[string]$entry.Key] = [string]$entry.Value
+    }
+
+    $removeNames = @(
+        "ADO_APM_PAT",
+        "COPILOT_GITHUB_TOKEN",
+        "GH_ENTERPRISE_TOKEN",
+        "GH_TOKEN",
+        "GITHUB_APM_PAT",
+        "GITHUB_COPILOT_PAT",
+        "GITHUB_ENTERPRISE_TOKEN",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "GITHUB_TOKEN",
+        "GIT_ASKPASS",
+        "GIT_CONFIG_COUNT",
+        "GIT_CONFIG_PARAMETERS",
+        "GIT_HTTP_EXTRAHEADER",
+        "GIT_SSH",
+        "GIT_SSH_COMMAND",
+        "SSH_AGENT_PID",
+        "SSH_ASKPASS",
+        "SSH_ASKPASS_REQUIRE",
+        "SSH_AUTH_SOCK"
+    )
+    foreach ($name in $removeNames) {
+        $environment.Remove($name)
+    }
+    foreach ($name in @($environment.Keys)) {
+        if (
+            $name -like "GITHUB_APM_PAT_*" -or
+            $name -like "GIT_CONFIG_KEY_*" -or
+            $name -like "GIT_CONFIG_VALUE_*"
+        ) {
+            $environment.Remove($name)
+        }
+    }
+    return $environment
+}
+
+function Write-Utf8Text {
+    param(
+        [string]$Path,
+        [string]$Content
+    )
+    [System.IO.File]::WriteAllText(
+        $Path,
+        $Content,
+        [System.Text.UTF8Encoding]::new($false)
+    )
+}
+
+function Wait-ForLoopbackPort {
+    param(
+        [int]$Port,
+        [int]$TimeoutSeconds = 20
+    )
+
+    $deadline = [DateTimeOffset]::UtcNow.AddSeconds($TimeoutSeconds)
+    while ([DateTimeOffset]::UtcNow -lt $deadline) {
+        $client = [System.Net.Sockets.TcpClient]::new()
+        try {
+            $connectTask = $client.ConnectAsync("127.0.0.1", $Port)
+            if ($connectTask.Wait(500) -and $client.Connected) {
+                return
+            }
+        } catch {
+            Start-Sleep -Milliseconds 250
+        } finally {
+            $client.Dispose()
+        }
+    }
+    throw "Windows OpenSSH did not listen on 127.0.0.1:$Port"
+}
+
+function Get-TraceReceipt {
+    param([string]$TracePath)
+
+    $events = @()
+    if (Test-Path $TracePath) {
+        foreach ($line in Get-Content -Path $TracePath) {
+            if (-not [string]::IsNullOrWhiteSpace($line)) {
+                $events += $line | ConvertFrom-Json
+            }
+        }
+    }
+
+    $transportStarts = @(
+        $events | Where-Object {
+            $_.event -eq "child_start" -and
+            [string]$_.child_class -like "transport/*"
+        }
+    )
+    $transportExits = @(
+        $events | Where-Object {
+            $_.event -eq "child_exit"
+        } | ForEach-Object {
+            [pscustomobject]@{
+                sid = [string]$_.sid
+                child_id = [int]$_.child_id
+                pid = [int]$_.pid
+                exit_code = [int]$_.code
+            }
+        }
+    )
+    $safeEnvironmentNames = @(
+        "GIT_TERMINAL_PROMPT",
+        "GIT_ASKPASS",
+        "SSH_ASKPASS",
+        "SSH_ASKPASS_REQUIRE",
+        "DISPLAY",
+        "SSH_AUTH_SOCK",
+        "GIT_SSH_COMMAND"
+    )
+    $environmentEvents = @(
+        $events | Where-Object {
+            $_.event -eq "def_param" -and
+            $safeEnvironmentNames -contains [string]$_.param
+        } | ForEach-Object {
+            [pscustomobject]@{
+                parameter = [string]$_.param
+                value = [string]$_.value
+            }
+        }
+    )
+
+    return [pscustomobject]@{
+        event_count = $events.Count
+        git_start_commands = @(
+            $events | Where-Object { $_.event -eq "start" } | ForEach-Object {
+                @($_.argv)
+            }
+        )
+        transport_children = @(
+            $transportStarts | ForEach-Object {
+                $start = $_
+                $matchingExit = $transportExits | Where-Object {
+                    $_.sid -eq [string]$start.sid -and
+                    $_.child_id -eq [int]$start.child_id
+                } | Select-Object -First 1
+                [pscustomobject]@{
+                    sid = [string]$start.sid
+                    child_id = [int]$start.child_id
+                    child_class = [string]$start.child_class
+                    use_shell = [bool]$start.use_shell
+                    argv = @($start.argv)
+                    pid = if ($null -ne $matchingExit) { $matchingExit.pid } else { $null }
+                    exit_code = if ($null -ne $matchingExit) { $matchingExit.exit_code } else { $null }
+                }
+            }
+        )
+        child_exits = $transportExits
+        environment = $environmentEvents
+    }
+}
+
+function Get-AskpassReceipt {
+    param([string]$AskpassLog)
+
+    if (-not (Test-Path $AskpassLog)) {
+        return @()
+    }
+    return @(
+        Get-Content -Path $AskpassLog | Where-Object {
+            -not [string]::IsNullOrWhiteSpace($_)
+        } | ForEach-Object {
+            $_ | ConvertFrom-Json
+        }
+    )
+}
+
+function New-ScenarioEnvironment {
+    param(
+        [System.Collections.IDictionary]$BaseEnvironment,
+        [string]$ScenarioRoot,
+        [string]$IdentityPath,
+        [string]$KnownHostsPath,
+        [string]$SshPath,
+        [string]$SshLogPath,
+        [string]$TracePath,
+        [string]$AskpassPath,
+        [string]$AskpassLogPath,
+        [string]$AskpassResponse
+    )
+
+    $environment = [ordered]@{}
+    foreach ($entry in $BaseEnvironment.GetEnumerator()) {
+        $environment[[string]$entry.Key] = [string]$entry.Value
+    }
+
+    $home = Join-Path $ScenarioRoot "home"
+    $config = Join-Path $ScenarioRoot "config"
+    $cache = Join-Path $ScenarioRoot "cache"
+    $temp = Join-Path $ScenarioRoot "temp"
+    foreach ($path in @($home, $config, $cache, $temp)) {
+        New-Item -ItemType Directory -Path $path -Force | Out-Null
+    }
+    $updateCache = Join-Path $home "AppData\Local\apm\cache"
+    New-Item -ItemType Directory -Path $updateCache -Force | Out-Null
+    New-Item -ItemType File -Path (Join-Path $updateCache "last_version_check") -Force | Out-Null
+
+    $sshCommand = @(
+        (ConvertTo-ForwardSlashPath $SshPath),
+        "-vvv",
+        "-E",
+        (ConvertTo-ForwardSlashPath $SshLogPath),
+        "-i",
+        (ConvertTo-ForwardSlashPath $IdentityPath),
+        "-o",
+        "IdentitiesOnly=yes",
+        "-o",
+        "StrictHostKeyChecking=yes",
+        "-o",
+        "UserKnownHostsFile=$(ConvertTo-ForwardSlashPath $KnownHostsPath)",
+        "-o",
+        "PreferredAuthentications=publickey",
+        "-o",
+        "PasswordAuthentication=no",
+        "-o",
+        "KbdInteractiveAuthentication=no",
+        "-o",
+        "ConnectTimeout=5",
+        "-o",
+        "NumberOfPasswordPrompts=1"
+    ) -join " "
+
+    $environment["HOME"] = $home
+    $environment["USERPROFILE"] = $home
+    $environment["LOCALAPPDATA"] = Join-Path $home "AppData\Local"
+    $environment["XDG_CONFIG_HOME"] = $config
+    $environment["XDG_CACHE_HOME"] = $cache
+    $environment["APM_HOME"] = $config
+    $environment["APM_CACHE_DIR"] = $cache
+    $environment["APM_TEMP_DIR"] = $temp
+    $environment["TEMP"] = $temp
+    $environment["TMP"] = $temp
+    $environment["APM_NO_CACHE"] = "1"
+    $environment["APM_TIERED_RESOLVER"] = "0"
+    $environment["APM_PROGRESS"] = "never"
+    $environment["APM_GIT_PROTOCOL"] = "ssh"
+    $environment["APM_ALLOW_PROTOCOL_FALLBACK"] = "0"
+    $environment["CI"] = "1"
+    $environment["GIT_CONFIG_NOSYSTEM"] = "1"
+    $environment["GIT_CONFIG_SYSTEM"] = "NUL"
+    $environment["GIT_CONFIG_GLOBAL"] = (ConvertTo-ForwardSlashPath (Join-Path $ScenarioRoot "empty.gitconfig"))
+    $environment["GIT_SSH_COMMAND"] = $sshCommand
+    $environment["GIT_TRACE2_EVENT"] = (ConvertTo-ForwardSlashPath $TracePath)
+    $environment["GIT_TRACE2_ENV_VARS"] = (
+        "GIT_TERMINAL_PROMPT,GIT_ASKPASS,SSH_ASKPASS," +
+        "SSH_ASKPASS_REQUIRE,DISPLAY,SSH_AUTH_SOCK,GIT_SSH_COMMAND"
+    )
+    $environment["HTTP_PROXY"] = "http://127.0.0.1:9"
+    $environment["HTTPS_PROXY"] = "http://127.0.0.1:9"
+    $environment["ALL_PROXY"] = "http://127.0.0.1:9"
+    $environment["NO_PROXY"] = "127.0.0.1,localhost"
+    $environment["SSH_ASKPASS_REQUIRE"] = "force"
+    $environment["DISPLAY"] = "apm-fixture:0"
+    Write-Utf8Text -Path $environment["GIT_CONFIG_GLOBAL"] -Content ""
+
+    if (-not [string]::IsNullOrWhiteSpace($AskpassPath)) {
+        $environment["SSH_ASKPASS"] = (ConvertTo-ForwardSlashPath $AskpassPath)
+        $environment["APM_SSH_FIXTURE_ASKPASS_LOG"] = $AskpassLogPath
+    } else {
+        $environment.Remove("SSH_ASKPASS")
+        $environment.Remove("APM_SSH_FIXTURE_ASKPASS_LOG")
+    }
+    if (-not [string]::IsNullOrEmpty($AskpassResponse)) {
+        $environment["APM_SSH_FIXTURE_RESPONSE"] = $AskpassResponse
+    } else {
+        $environment.Remove("APM_SSH_FIXTURE_RESPONSE")
+    }
+    return $environment
+}
+
+function Invoke-Scenario {
+    param(
+        [string]$Id,
+        [bool]$ExpectedSuccess,
+        [string]$IdentityPath,
+        [string]$RemoteUrl,
+        [string]$ExpectedSkillMarker,
+        [string]$ApmPath,
+        [string]$Root,
+        [string]$EvidenceRoot,
+        [System.Collections.IDictionary]$BaseEnvironment,
+        [string]$KnownHostsPath,
+        [string]$SshPath,
+        [string]$AskpassPath,
+        [string]$AskpassResponse
+    )
+
+    $scenarioRoot = Join-Path $Root $Id
+    $projectRoot = Join-Path $scenarioRoot "project"
+    $scenarioEvidence = Join-Path $EvidenceRoot $Id
+    New-Item -ItemType Directory -Path $projectRoot -Force | Out-Null
+    New-Item -ItemType Directory -Path $scenarioEvidence -Force | Out-Null
+
+    $tracePath = Join-Path $scenarioEvidence "git-trace.json"
+    $sshLogPath = Join-Path $scenarioEvidence "ssh-client.log"
+    $askpassLogPath = Join-Path $scenarioEvidence "askpass.jsonl"
+    $stdoutPath = Join-Path $scenarioEvidence "apm.stdout.txt"
+    $stderrPath = Join-Path $scenarioEvidence "apm.stderr.txt"
+    $manifestPath = Join-Path $projectRoot "apm.yml"
+    $manifest = @"
+name: consumer-$Id
+version: 1.0.0
+description: Windows encrypted SSH fixture consumer
+dependencies:
+  apm:
+    - git: "$RemoteUrl"
+      ref: main
+targets:
+  - copilot
+"@
+    Write-Utf8Text -Path $manifestPath -Content $manifest
+
+    $environment = New-ScenarioEnvironment `
+        -BaseEnvironment $BaseEnvironment `
+        -ScenarioRoot $scenarioRoot `
+        -IdentityPath $IdentityPath `
+        -KnownHostsPath $KnownHostsPath `
+        -SshPath $SshPath `
+        -SshLogPath $sshLogPath `
+        -TracePath $tracePath `
+        -AskpassPath $AskpassPath `
+        -AskpassLogPath $askpassLogPath `
+        -AskpassResponse $AskpassResponse
+
+    Write-Info "Running scenario $Id through packaged APM"
+    $process = Invoke-CapturedProcess `
+        -FilePath $ApmPath `
+        -ArgumentList @(
+            "install",
+            "--target",
+            "copilot",
+            "--no-policy",
+            "--parallel-downloads",
+            "0"
+        ) `
+        -WorkingDirectory $projectRoot `
+        -Environment $environment `
+        -TimeoutSeconds 120
+    Write-Utf8Text -Path $stdoutPath -Content $process.stdout
+    Write-Utf8Text -Path $stderrPath -Content $process.stderr
+
+    $skillPath = Join-Path $projectRoot ".github\skills\ssh-passphrase-fixture\SKILL.md"
+    $lockPath = Join-Path $projectRoot "apm.lock.yaml"
+    $actualSuccess = -not $process.timed_out -and $process.exit_code -eq 0
+    $skillInstalled = Test-Path $skillPath
+    $lockWritten = Test-Path $lockPath
+    $askpassReceipt = Get-AskpassReceipt -AskpassLog $askpassLogPath
+    $traceReceipt = Get-TraceReceipt -TracePath $tracePath
+    $skillMatches = $false
+    if ($skillInstalled) {
+        $skillMatches = (Get-Content -Path $skillPath -Raw).Contains($ExpectedSkillMarker)
+    }
+
+    $receipt = [pscustomobject]@{
+        id = $Id
+        expected_success = $ExpectedSuccess
+        actual_success = $actualSuccess
+        expectation_met = $actualSuccess -eq $ExpectedSuccess
+        apm_process = $process
+        environment_contract = [pscustomobject]@{
+            git_ssh_command = [string]$environment["GIT_SSH_COMMAND"]
+            ssh_askpass_present = $environment.Contains("SSH_ASKPASS")
+            ssh_askpass_require = [string]$environment["SSH_ASKPASS_REQUIRE"]
+            display = [string]$environment["DISPLAY"]
+            ssh_auth_sock_present = $environment.Contains("SSH_AUTH_SOCK")
+            git_terminal_prompt_input = $environment.Contains("GIT_TERMINAL_PROMPT")
+            git_askpass_input = $environment.Contains("GIT_ASKPASS")
+            all_proxy = [string]$environment["ALL_PROXY"]
+            no_proxy = [string]$environment["NO_PROXY"]
+        }
+        askpass_invocation_count = $askpassReceipt.Count
+        askpass_invocations = $askpassReceipt
+        git_trace = $traceReceipt
+        skill_installed = $skillInstalled
+        skill_marker_matches = $skillMatches
+        lock_written = $lockWritten
+    }
+    Write-Utf8Text `
+        -Path (Join-Path $scenarioEvidence "receipt.json") `
+        -Content ($receipt | ConvertTo-Json -Depth 20)
+    return $receipt
+}
+
+$root = Join-Path $env:RUNNER_TEMP ("apm-ssh-passphrase-" + [guid]::NewGuid().ToString("N"))
+$keysRoot = Join-Path $root "keys"
+$sourceRoot = Join-Path $root "source"
+$bareRoot = Join-Path $root "ssh-passphrase-fixture.git"
+$serverCommandLog = Join-Path $EvidenceDirectory "server-commands.log"
+$askpassSource = Join-Path $root "askpass.go"
+$askpassExe = Join-Path $root "askpass.exe"
+$knownHosts = Join-Path $root "known_hosts"
+$encryptedKey = Join-Path $keysRoot "id_ed25519_encrypted"
+$plainKey = Join-Path $keysRoot "id_ed25519_plain"
+$passphrase = "apm-" + [guid]::NewGuid().ToString("N")
+$wrongPassphrase = "wrong-" + [guid]::NewGuid().ToString("N")
+$port = 22222
+$expectedSkillMarker = "windows-ssh-passphrase-fixture"
+$programDataSsh = Join-Path $env:ProgramData "ssh"
+$sshdConfig = Join-Path $programDataSsh "sshd_config"
+$authorizedKeys = Join-Path $programDataSsh "administrators_authorized_keys"
+$sshdLogRoot = Join-Path $programDataSsh "logs"
+$sshdLogDestination = Join-Path $EvidenceDirectory "sshd"
+$sshdService = $null
+$initialServiceStatus = $null
+$initialServiceStartType = $null
+$originalSshdConfig = $null
+$originalAuthorizedKeys = $null
+$sshdConfigExisted = Test-Path $sshdConfig
+$authorizedKeysExisted = Test-Path $authorizedKeys
+$assertionFailures = [System.Collections.Generic.List[string]]::new()
+
+try {
+    New-Item -ItemType Directory -Path $root -Force | Out-Null
+    New-Item -ItemType Directory -Path $keysRoot -Force | Out-Null
+    if (Test-Path $EvidenceDirectory) {
+        Remove-Item -Path $EvidenceDirectory -Recurse -Force
+    }
+    New-Item -ItemType Directory -Path $EvidenceDirectory -Force | Out-Null
+
+    $apmPath = (Resolve-Path $ApmBinary).Path
+    $gitPath = (Get-Command git.exe -ErrorAction Stop).Source
+    $goPath = (Get-Command go.exe -ErrorAction Stop).Source
+    $sshPath = Join-Path $env:WINDIR "System32\OpenSSH\ssh.exe"
+    $sshKeygenPath = Join-Path $env:WINDIR "System32\OpenSSH\ssh-keygen.exe"
+    $sshKeyscanPath = Join-Path $env:WINDIR "System32\OpenSSH\ssh-keyscan.exe"
+    $sshdPath = Join-Path $env:WINDIR "System32\OpenSSH\sshd.exe"
+    foreach ($requiredPath in @(
+        $apmPath,
+        $gitPath,
+        $goPath,
+        $sshPath,
+        $sshKeygenPath,
+        $sshKeyscanPath,
+        $sshdPath
+    )) {
+        Assert-Condition (Test-Path $requiredPath -PathType Leaf) "Required executable exists: $requiredPath"
+    }
+    Assert-Condition ($apmPath.EndsWith("apm.exe")) "Fixture uses a packaged apm.exe"
+    Assert-Condition (-not ($root -match "\s")) "Ephemeral fixture path contains no whitespace"
+
+    $principal = [Security.Principal.WindowsPrincipal]::new(
+        [Security.Principal.WindowsIdentity]::GetCurrent()
+    )
+    Assert-Condition (
+        $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    ) "Hosted runner account is an administrator"
+
+    $baseEnvironment = Get-CleanEnvironment
+    $gitVersion = Invoke-CheckedProcess -FilePath $gitPath -ArgumentList @("--version")
+    $sshVersion = Invoke-CheckedProcess -FilePath $sshPath -ArgumentList @("-V")
+    $sshdVersion = Invoke-CheckedProcess -FilePath $sshdPath -ArgumentList @("-V")
+    $apmVersion = Invoke-CheckedProcess -FilePath $apmPath -ArgumentList @("--version")
+
+    Write-Info "Creating ephemeral Git package and bare origin"
+    New-Item -ItemType Directory -Path (Join-Path $sourceRoot "skills\ssh-passphrase-fixture") -Force |
+        Out-Null
+    Write-Utf8Text -Path (Join-Path $sourceRoot "apm.yml") -Content @"
+name: ssh-passphrase-fixture
+version: 1.0.0
+description: Hermetic Windows SSH passphrase fixture
+targets:
+  - copilot
+"@
+    Write-Utf8Text `
+        -Path (Join-Path $sourceRoot "skills\ssh-passphrase-fixture\SKILL.md") `
+        -Content @"
+---
+name: ssh-passphrase-fixture
+description: Hermetic Windows SSH passphrase fixture
+---
+# $expectedSkillMarker
+"@
+    Invoke-CheckedProcess -FilePath $gitPath -ArgumentList @("init", "-b", "main") -WorkingDirectory $sourceRoot |
+        Out-Null
+    Invoke-CheckedProcess -FilePath $gitPath -ArgumentList @("config", "user.name", "APM Fixture") -WorkingDirectory $sourceRoot |
+        Out-Null
+    Invoke-CheckedProcess -FilePath $gitPath -ArgumentList @("config", "user.email", "fixture@invalid.example") -WorkingDirectory $sourceRoot |
+        Out-Null
+    Invoke-CheckedProcess -FilePath $gitPath -ArgumentList @("add", ".") -WorkingDirectory $sourceRoot |
+        Out-Null
+    Invoke-CheckedProcess -FilePath $gitPath -ArgumentList @("commit", "-m", "seed fixture") -WorkingDirectory $sourceRoot |
+        Out-Null
+    Invoke-CheckedProcess -FilePath $gitPath -ArgumentList @("clone", "--bare", $sourceRoot, $bareRoot) |
+        Out-Null
+    $fixtureCommit = (
+        Invoke-CheckedProcess -FilePath $gitPath -ArgumentList @("-C", $sourceRoot, "rev-parse", "HEAD")
+    ).stdout.Trim()
+
+    Write-Info "Generating one encrypted and one unencrypted private key"
+    Invoke-CheckedProcess `
+        -FilePath $sshKeygenPath `
+        -ArgumentList @("-q", "-t", "ed25519", "-N", $passphrase, "-f", $encryptedKey) |
+        Out-Null
+    Invoke-CheckedProcess `
+        -FilePath $sshKeygenPath `
+        -ArgumentList @("-q", "-t", "ed25519", "-N", "", "-f", $plainKey) |
+        Out-Null
+    $encryptedFingerprint = (
+        Invoke-CheckedProcess -FilePath $sshKeygenPath -ArgumentList @("-lf", "$encryptedKey.pub")
+    ).stdout.Trim()
+    $plainFingerprint = (
+        Invoke-CheckedProcess -FilePath $sshKeygenPath -ArgumentList @("-lf", "$plainKey.pub")
+    ).stdout.Trim()
+
+    $askpassProgram = @'
+package main
+
+import (
+    "encoding/json"
+    "fmt"
+    "os"
+)
+
+type invocation struct {
+    Arguments          []string `json:"arguments"`
+    GitTerminalPrompt  string   `json:"git_terminal_prompt"`
+    GitAskpass         string   `json:"git_askpass"`
+    SshAskpass         string   `json:"ssh_askpass"`
+    SshAskpassRequire  string   `json:"ssh_askpass_require"`
+    Display            string   `json:"display"`
+    SshAuthSockPresent bool     `json:"ssh_auth_sock_present"`
+    ResponsePresent    bool     `json:"response_present"`
+}
+
+func main() {
+    response, responsePresent := os.LookupEnv("APM_SSH_FIXTURE_RESPONSE")
+    record := invocation{
+        Arguments:          os.Args[1:],
+        GitTerminalPrompt:  os.Getenv("GIT_TERMINAL_PROMPT"),
+        GitAskpass:         os.Getenv("GIT_ASKPASS"),
+        SshAskpass:         os.Getenv("SSH_ASKPASS"),
+        SshAskpassRequire:  os.Getenv("SSH_ASKPASS_REQUIRE"),
+        Display:            os.Getenv("DISPLAY"),
+        SshAuthSockPresent: os.Getenv("SSH_AUTH_SOCK") != "",
+        ResponsePresent:    responsePresent,
+    }
+    logPath := os.Getenv("APM_SSH_FIXTURE_ASKPASS_LOG")
+    if logPath != "" {
+        logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
+        if err != nil {
+            os.Exit(3)
+        }
+        encoder := json.NewEncoder(logFile)
+        if err := encoder.Encode(record); err != nil {
+            logFile.Close()
+            os.Exit(4)
+        }
+        if err := logFile.Close(); err != nil {
+            os.Exit(5)
+        }
+    }
+    if !responsePresent {
+        os.Exit(2)
+    }
+    fmt.Fprintln(os.Stdout, response)
+}
+'@
+    Write-Utf8Text -Path $askpassSource -Content $askpassProgram
+    Invoke-CheckedProcess `
+        -FilePath $goPath `
+        -ArgumentList @("build", "-trimpath", "-ldflags=-s -w", "-o", $askpassExe, $askpassSource) `
+        -WorkingDirectory $root `
+        -Environment $baseEnvironment `
+        -TimeoutSeconds 120 |
+        Out-Null
+
+    Write-Info "Configuring Windows OpenSSH on loopback only"
+    $sshdService = Get-Service -Name sshd -ErrorAction Stop
+    $initialServiceStatus = $sshdService.Status
+    $initialServiceStartType = $sshdService.StartType
+    if ($sshdService.Status -eq "Running") {
+        Stop-Service -Name sshd -Force
+    }
+    Set-Service -Name sshd -StartupType Manual
+    New-Item -ItemType Directory -Path $programDataSsh -Force | Out-Null
+    if ($sshdConfigExisted) {
+        $originalSshdConfig = [System.IO.File]::ReadAllBytes($sshdConfig)
+    }
+    if ($authorizedKeysExisted) {
+        $originalAuthorizedKeys = [System.IO.File]::ReadAllBytes($authorizedKeys)
+    }
+
+    Invoke-CheckedProcess -FilePath $sshKeygenPath -ArgumentList @("-A") | Out-Null
+    $serveCommand = Join-Path $root "serve-git.cmd"
+    $gitForward = ConvertTo-ForwardSlashPath $gitPath
+    $bareForward = ConvertTo-ForwardSlashPath $bareRoot
+    $serverLogForward = ConvertTo-ForwardSlashPath $serverCommandLog
+    Write-Utf8Text -Path $serveCommand -Content @"
+@echo off
+echo %SSH_ORIGINAL_COMMAND%>>"$serverLogForward"
+"$gitForward" upload-pack "$bareForward"
+"@
+    $serveCommandForward = ConvertTo-ForwardSlashPath $serveCommand
+    $keyOptions = (
+        'command="' + $serveCommandForward +
+        '",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding '
+    )
+    $authorizedContent = @(
+        $keyOptions + (Get-Content -Path "$encryptedKey.pub" -Raw).Trim(),
+        $keyOptions + (Get-Content -Path "$plainKey.pub" -Raw).Trim()
+    ) -join "`n"
+    Write-Utf8Text -Path $authorizedKeys -Content ($authorizedContent + "`n")
+    & icacls.exe $authorizedKeys /inheritance:r /grant "Administrators:F" /grant "SYSTEM:F" | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to secure administrators_authorized_keys"
+    }
+
+    $runnerUser = $env:USERNAME.ToLowerInvariant()
+    $sshdConfiguration = @"
+Port $port
+ListenAddress 127.0.0.1
+PubkeyAuthentication yes
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+PermitEmptyPasswords no
+AllowUsers $runnerUser
+AuthorizedKeysFile __PROGRAMDATA__/ssh/administrators_authorized_keys
+LogLevel DEBUG3
+SyslogFacility LOCAL0
+Subsystem sftp sftp-server.exe
+Match Group administrators
+    AuthorizedKeysFile __PROGRAMDATA__/ssh/administrators_authorized_keys
+"@
+    Write-Utf8Text -Path $sshdConfig -Content $sshdConfiguration
+    Invoke-CheckedProcess -FilePath $sshdPath -ArgumentList @("-t", "-f", $sshdConfig) | Out-Null
+    Start-Service -Name sshd
+    Wait-ForLoopbackPort -Port $port
+
+    $keyscan = Invoke-CheckedProcess `
+        -FilePath $sshKeyscanPath `
+        -ArgumentList @("-p", [string]$port, "127.0.0.1")
+    Write-Utf8Text -Path $knownHosts -Content $keyscan.stdout
+    Assert-Condition (-not [string]::IsNullOrWhiteSpace($keyscan.stdout)) "Loopback SSH host key was captured"
+
+    $remoteUrl = "ssh://${runnerUser}@127.0.0.1:${port}/fixture/ssh-passphrase-fixture.git"
+    $scenarioDefinitions = @(
+        [pscustomobject]@{
+            id = "unencrypted-positive"
+            expected_success = $true
+            identity = $plainKey
+            askpass = ""
+            response = ""
+        },
+        [pscustomobject]@{
+            id = "encrypted-correct"
+            expected_success = $true
+            identity = $encryptedKey
+            askpass = $askpassExe
+            response = $passphrase
+        },
+        [pscustomobject]@{
+            id = "encrypted-wrong"
+            expected_success = $false
+            identity = $encryptedKey
+            askpass = $askpassExe
+            response = $wrongPassphrase
+        },
+        [pscustomobject]@{
+            id = "encrypted-missing"
+            expected_success = $false
+            identity = $encryptedKey
+            askpass = (Join-Path $root "missing-askpass.exe")
+            response = ""
+        }
+    )
+
+    $scenarioReceipts = @()
+    foreach ($scenario in $scenarioDefinitions) {
+        $receipt = Invoke-Scenario `
+            -Id $scenario.id `
+            -ExpectedSuccess $scenario.expected_success `
+            -IdentityPath $scenario.identity `
+            -RemoteUrl $remoteUrl `
+            -ExpectedSkillMarker $expectedSkillMarker `
+            -ApmPath $apmPath `
+            -Root $root `
+            -EvidenceRoot $EvidenceDirectory `
+            -BaseEnvironment $baseEnvironment `
+            -KnownHostsPath $knownHosts `
+            -SshPath $sshPath `
+            -AskpassPath $scenario.askpass `
+            -AskpassResponse $scenario.response
+        $scenarioReceipts += $receipt
+    }
+
+    foreach ($receipt in $scenarioReceipts) {
+        if ($receipt.apm_process.timed_out) {
+            $assertionFailures.Add(
+                "Scenario $($receipt.id): packaged APM timed out after " +
+                "$($receipt.apm_process.timeout_seconds) seconds"
+            )
+        }
+        if (-not $receipt.expectation_met) {
+            $assertionFailures.Add(
+                "Scenario {0}: expected_success={1}, exit_code={2}" -f
+                $receipt.id,
+                $receipt.expected_success,
+                $receipt.apm_process.exit_code
+            )
+        }
+        if ($receipt.git_trace.transport_children.Count -eq 0) {
+            $assertionFailures.Add("Scenario $($receipt.id): no Git SSH transport child recorded")
+        } else {
+            $expectedSshPath = ConvertTo-ForwardSlashPath $sshPath
+            $openSshChildren = @(
+                $receipt.git_trace.transport_children | Where-Object {
+                    $_.child_class -eq "transport/ssh" -and
+                    ((@($_.argv) -join " ") -replace "\\", "/").Contains($expectedSshPath)
+                }
+            )
+            if ($openSshChildren.Count -eq 0) {
+                $assertionFailures.Add(
+                    "Scenario $($receipt.id): Git did not record the configured Windows OpenSSH child"
+                )
+            } else {
+                $missingChildExits = @(
+                    $openSshChildren | Where-Object { $null -eq $_.exit_code }
+                )
+                if ($missingChildExits.Count -gt 0) {
+                    $assertionFailures.Add(
+                        "Scenario $($receipt.id): one or more OpenSSH children have no Trace2 exit"
+                    )
+                }
+                $sshExitCodes = @(
+                    $openSshChildren | Where-Object { $null -ne $_.exit_code } |
+                        ForEach-Object { [int]$_.exit_code }
+                )
+                if ($receipt.expected_success -and @($sshExitCodes | Where-Object { $_ -ne 0 }).Count -gt 0) {
+                    $assertionFailures.Add(
+                        "Scenario $($receipt.id): a successful case recorded a failed OpenSSH child"
+                    )
+                }
+                if (
+                    -not $receipt.expected_success -and
+                    @($sshExitCodes | Where-Object { $_ -ne 0 }).Count -eq 0
+                ) {
+                    $assertionFailures.Add(
+                        "Scenario $($receipt.id): negative case recorded no failed OpenSSH child"
+                    )
+                }
+            }
+        }
+        $traceEnvironment = @{}
+        foreach ($entry in $receipt.git_trace.environment) {
+            $traceEnvironment[[string]$entry.parameter] = [string]$entry.value
+        }
+        foreach ($expectedPair in @{
+            "GIT_TERMINAL_PROMPT" = "0"
+            "SSH_ASKPASS_REQUIRE" = "force"
+            "DISPLAY" = "apm-fixture:0"
+        }.GetEnumerator()) {
+            if ($traceEnvironment[[string]$expectedPair.Key] -ne [string]$expectedPair.Value) {
+                $assertionFailures.Add(
+                    "Scenario $($receipt.id): Trace2 did not record " +
+                    "$($expectedPair.Key)=$($expectedPair.Value)"
+                )
+            }
+        }
+        if (-not $traceEnvironment.ContainsKey("GIT_SSH_COMMAND")) {
+            $assertionFailures.Add(
+                "Scenario $($receipt.id): Trace2 did not record GIT_SSH_COMMAND"
+            )
+        }
+        if ($traceEnvironment.ContainsKey("GIT_ASKPASS")) {
+            $assertionFailures.Add(
+                "Scenario $($receipt.id): generic SSH child unexpectedly retained GIT_ASKPASS"
+            )
+        }
+        if ($traceEnvironment.ContainsKey("SSH_AUTH_SOCK")) {
+            $assertionFailures.Add(
+                "Scenario $($receipt.id): SSH agent state leaked into the Git child"
+            )
+        }
+        $expectsAskpassEnvironment = $receipt.id -ne "unencrypted-positive"
+        if ($traceEnvironment.ContainsKey("SSH_ASKPASS") -ne $expectsAskpassEnvironment) {
+            $assertionFailures.Add(
+                "Scenario $($receipt.id): Trace2 SSH_ASKPASS presence did not match the case"
+            )
+        }
+        if ($receipt.expected_success) {
+            if (-not $receipt.skill_installed) {
+                $assertionFailures.Add("Scenario $($receipt.id): expected skill was not installed")
+            }
+            if (-not $receipt.skill_marker_matches) {
+                $assertionFailures.Add("Scenario $($receipt.id): installed skill marker did not match")
+            }
+            if (-not $receipt.lock_written) {
+                $assertionFailures.Add("Scenario $($receipt.id): expected lockfile was not written")
+            }
+        } else {
+            if ($receipt.skill_installed) {
+                $assertionFailures.Add("Scenario $($receipt.id): failed install materialized a skill")
+            }
+            if ($receipt.lock_written) {
+                $assertionFailures.Add("Scenario $($receipt.id): failed install wrote a lockfile")
+            }
+        }
+    }
+
+    $plainReceipt = $scenarioReceipts | Where-Object { $_.id -eq "unencrypted-positive" }
+    $correctReceipt = $scenarioReceipts | Where-Object { $_.id -eq "encrypted-correct" }
+    $wrongReceipt = $scenarioReceipts | Where-Object { $_.id -eq "encrypted-wrong" }
+    $missingReceipt = $scenarioReceipts | Where-Object { $_.id -eq "encrypted-missing" }
+    if ($plainReceipt.askpass_invocation_count -ne 0) {
+        $assertionFailures.Add("Unencrypted positive unexpectedly invoked askpass")
+    }
+    if ($correctReceipt.askpass_invocation_count -lt 1) {
+        $assertionFailures.Add("Encrypted correct case did not invoke askpass")
+    }
+    if ($wrongReceipt.askpass_invocation_count -lt 1) {
+        $assertionFailures.Add("Encrypted wrong case did not invoke askpass")
+    }
+    if ($missingReceipt.askpass_invocation_count -ne 0) {
+        $assertionFailures.Add("Encrypted missing case unexpectedly produced an askpass receipt")
+    }
+    foreach ($receipt in @($correctReceipt, $wrongReceipt)) {
+        foreach ($invocation in $receipt.askpass_invocations) {
+            if ($invocation.git_terminal_prompt -ne "0") {
+                $assertionFailures.Add(
+                    "Scenario $($receipt.id): askpass child did not inherit GIT_TERMINAL_PROMPT=0"
+                )
+            }
+            if (-not [string]::IsNullOrEmpty($invocation.git_askpass)) {
+                $assertionFailures.Add(
+                    "Scenario $($receipt.id): askpass child unexpectedly inherited GIT_ASKPASS"
+                )
+            }
+            if ($invocation.ssh_askpass_require -ne "force") {
+                $assertionFailures.Add(
+                    "Scenario $($receipt.id): askpass child did not inherit SSH_ASKPASS_REQUIRE=force"
+                )
+            }
+            if ($invocation.display -ne "apm-fixture:0") {
+                $assertionFailures.Add(
+                    "Scenario $($receipt.id): askpass child did not inherit the fixture DISPLAY"
+                )
+            }
+            if ($invocation.ssh_auth_sock_present) {
+                $assertionFailures.Add(
+                    "Scenario $($receipt.id): askpass child inherited SSH agent state"
+                )
+            }
+            if (-not $invocation.response_present) {
+                $assertionFailures.Add(
+                    "Scenario $($receipt.id): askpass child had no ephemeral response"
+                )
+            }
+            if ((@($invocation.arguments) -join " ") -notmatch "(?i)passphrase") {
+                $assertionFailures.Add(
+                    "Scenario $($receipt.id): askpass invocation was not a key passphrase prompt"
+                )
+            }
+        }
+    }
+
+    $summary = [pscustomobject]@{
+        issue = 1976
+        source_head = (Invoke-CheckedProcess -FilePath $gitPath -ArgumentList @("rev-parse", "HEAD")).stdout.Trim()
+        fixture_commit = $fixtureCommit
+        platform = [pscustomobject]@{
+            os = [System.Runtime.InteropServices.RuntimeInformation]::OSDescription
+            architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+            powershell = $PSVersionTable.PSVersion.ToString()
+        }
+        packaged_apm = [pscustomobject]@{
+            path = $apmPath
+            sha256 = (Get-FileHash -Path $apmPath -Algorithm SHA256).Hash.ToLowerInvariant()
+            version_stdout = $apmVersion.stdout.Trim()
+            version_stderr = $apmVersion.stderr.Trim()
+        }
+        tools = [pscustomobject]@{
+            git_path = $gitPath
+            git_version = $gitVersion.stdout.Trim()
+            ssh_path = $sshPath
+            ssh_version = ($sshVersion.stderr + $sshVersion.stdout).Trim()
+            sshd_path = $sshdPath
+            sshd_version = ($sshdVersion.stderr + $sshdVersion.stdout).Trim()
+        }
+        boundary = [pscustomobject]@{
+            address = "127.0.0.1"
+            port = $port
+            remote_url = $remoteUrl
+            encrypted_key_fingerprint = $encryptedFingerprint
+            unencrypted_key_fingerprint = $plainFingerprint
+            stored_credentials = $false
+            external_git_remote = $false
+        }
+        scenarios = $scenarioReceipts
+        assertion_failures = @($assertionFailures)
+    }
+    $summaryPath = Join-Path $EvidenceDirectory "summary.json"
+    Write-Utf8Text -Path $summaryPath -Content ($summary | ConvertTo-Json -Depth 25)
+
+    foreach ($sensitiveValue in @($passphrase, $wrongPassphrase)) {
+        foreach ($file in Get-ChildItem -Path $EvidenceDirectory -File -Recurse) {
+            if ((Get-Content -Path $file.FullName -Raw).Contains($sensitiveValue)) {
+                throw "Ephemeral passphrase leaked into evidence file: $($file.FullName)"
+            }
+        }
+    }
+
+    if ($assertionFailures.Count -gt 0) {
+        throw (
+            "Windows SSH passphrase contract failed:`n- " +
+            ($assertionFailures -join "`n- ")
+        )
+    }
+    Write-Success "Windows SSH passphrase contract passed all four scenarios"
+} finally {
+    if ($null -ne $sshdService) {
+        try {
+            Stop-Service -Name sshd -Force -ErrorAction SilentlyContinue
+            if ($sshdConfigExisted) {
+                [System.IO.File]::WriteAllBytes($sshdConfig, $originalSshdConfig)
+            } else {
+                Remove-Item -Path $sshdConfig -Force -ErrorAction SilentlyContinue
+            }
+            if ($authorizedKeysExisted) {
+                [System.IO.File]::WriteAllBytes($authorizedKeys, $originalAuthorizedKeys)
+            } else {
+                Remove-Item -Path $authorizedKeys -Force -ErrorAction SilentlyContinue
+            }
+            if ($initialServiceStatus -eq "Running") {
+                Start-Service -Name sshd
+            }
+            if ($null -ne $initialServiceStartType) {
+                Set-Service -Name sshd -StartupType $initialServiceStartType
+            }
+        } catch {
+            Write-Host "[!] Failed to restore Windows OpenSSH state: $($_.Exception.Message)"
+        }
+    }
+    if (Test-Path $sshdLogRoot) {
+        New-Item -ItemType Directory -Path $sshdLogDestination -Force | Out-Null
+        Copy-Item -Path (Join-Path $sshdLogRoot "*") -Destination $sshdLogDestination -Force -ErrorAction SilentlyContinue
+    }
+    if (Test-Path $root) {
+        Remove-Item -Path $root -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/windows/test-ssh-passphrase-fixture.ps1
+++ b/scripts/windows/test-ssh-passphrase-fixture.ps1
@@ -498,7 +498,7 @@ targets:
     $actualSuccess = -not $process.timed_out -and $process.exit_code -eq 0
     $skillInstalled = Test-Path $skillPath
     $lockWritten = Test-Path $lockPath
-    $askpassReceipt = Get-AskpassReceipt -AskpassLog $askpassLogPath
+    $askpassReceipt = @(Get-AskpassReceipt -AskpassLog $askpassLogPath)
     $traceReceipt = Get-TraceReceipt -TracePath $tracePath
     $skillMatches = $false
     if ($skillInstalled) {
@@ -749,11 +749,10 @@ echo %SSH_ORIGINAL_COMMAND%>>"$serverLogForward"
         'command="' + $serveCommandForward +
         '",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding '
     )
-    $authorizedContent = @(
-        $keyOptions + (Get-Content -Path "$encryptedKey.pub" -Raw).Trim(),
-        $keyOptions + (Get-Content -Path "$plainKey.pub" -Raw).Trim()
-    ) -join "`n"
-    Write-Utf8Text -Path $authorizedKeys -Content ($authorizedContent + "`n")
+    $encryptedAuthorizedKey = $keyOptions + (Get-Content -Path "$encryptedKey.pub" -Raw).Trim()
+    $plainAuthorizedKey = $keyOptions + (Get-Content -Path "$plainKey.pub" -Raw).Trim()
+    $authorizedContent = $encryptedAuthorizedKey + "`n" + $plainAuthorizedKey + "`n"
+    Write-Utf8Text -Path $authorizedKeys -Content $authorizedContent
     & icacls.exe $authorizedKeys /inheritance:r /grant "Administrators:F" /grant "SYSTEM:F" | Out-Null
     if ($LASTEXITCODE -ne 0) {
         throw "Failed to secure administrators_authorized_keys"
@@ -787,6 +786,33 @@ Match Group administrators
     Assert-Condition (-not [string]::IsNullOrWhiteSpace($keyscan.stdout)) "Loopback SSH host key was captured"
 
     $remoteUrl = "ssh://${runnerUser}@127.0.0.1:${port}/fixture/ssh-passphrase-fixture.git"
+    $preflightRoot = Join-Path $root "git-preflight"
+    $preflightEvidence = Join-Path $EvidenceDirectory "git-preflight"
+    New-Item -ItemType Directory -Path $preflightEvidence -Force | Out-Null
+    $preflightEnvironment = New-ScenarioEnvironment `
+        -BaseEnvironment $baseEnvironment `
+        -ScenarioRoot $preflightRoot `
+        -IdentityPath $plainKey `
+        -KnownHostsPath $knownHosts `
+        -SshPath $sshPath `
+        -SshLogPath (Join-Path $preflightEvidence "ssh-client.log") `
+        -TracePath (Join-Path $preflightEvidence "git-trace.json") `
+        -AskpassPath "" `
+        -AskpassLogPath "" `
+        -AskpassResponse ""
+    $preflightEnvironment["GIT_TERMINAL_PROMPT"] = "0"
+    $gitPreflight = Invoke-CheckedProcess `
+        -FilePath $gitPath `
+        -ArgumentList @("ls-remote", $remoteUrl, "refs/heads/main") `
+        -WorkingDirectory $preflightRoot `
+        -Environment $preflightEnvironment
+    Write-Utf8Text `
+        -Path (Join-Path $preflightEvidence "receipt.json") `
+        -Content ($gitPreflight | ConvertTo-Json -Depth 10)
+    Assert-Condition (
+        $gitPreflight.stdout.Contains($fixtureCommit)
+    ) "Direct unencrypted Git/OpenSSH preflight reached the fixture commit"
+
     $scenarioDefinitions = @(
         [pscustomobject]@{
             id = "unencrypted-positive"


### PR DESCRIPTION
# test(auth): add Windows SSH passphrase evidence fixture

## TL;DR

This draft adds a hosted Windows evidence contract for issue #1976 without changing APM product behavior. It builds the packaged `apm.exe`, serves an ephemeral package through loopback Windows OpenSSH, and runs encrypted-correct, unencrypted, wrong-passphrase, and missing-passphrase cases through real Git processes. Hosted run [`29469702438`](https://github.com/microsoft/apm/actions/runs/29469702438) passed all four expectations: the reported failure did not reproduce when Windows OpenSSH received the correct response through `SSH_ASKPASS`.

> [!IMPORTANT]
> Evidence baseline: `796e229805ade19244683f0a1e70ec534ce4fb85`; exact evidence head: `f7c9d0e23e9800f06ce2792306ac316fca6970ba`. This is a fixture-only evidence draft. Never merge it from this lane.

## Problem (WHY)

- [x] Issue #1976 reports that Windows installs work with an unencrypted SSH key but fail when the key has a passphrase.
- [x] The issue's original log ended in a port-22 timeout, so it did not isolate passphrase prompting from network reachability.
- [x] Existing coverage does not cross packaged APM, Git for Windows, Windows OpenSSH, an encrypted key, and passphrase handling in one boundary.
- [!] A source-only or mocked test could report the expected environment while missing frozen-process or Windows child-process behavior.

Why this matters: ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) The fixture uses concrete process and artifact receipts because ["agents pattern-match well against concrete structures"](https://agentskills.io/skill-creation/best-practices).

## Approach (WHAT)

| # | Fixture decision | Evidence produced |
|---:|---|---|
| 1 | Build the repository's packaged Windows CLI | Binary path, SHA-256, version, and source head |
| 2 | Bind Windows `sshd` to `127.0.0.1:22222` | Server logs, host key, forced `git upload-pack` command |
| 3 | Generate encrypted and unencrypted Ed25519 keys at runtime | Public fingerprints only; private material is deleted |
| 4 | Prove the server with direct unencrypted `git ls-remote` | Independent Git/OpenSSH receipt before packaged APM runs |
| 5 | Run four isolated APM installs | APM stdout/stderr/exit, Trace2 child argv/env/exit, SSH logs, askpass receipts |
| 6 | Fail on expectation drift or secret leakage | Contract result with artifact upload preserved by `if: always()` |

## Implementation (HOW)

| File | Change |
|---|---|
| [`.github/workflows/windows-ssh-passphrase-repro.yml`](https://github.com/microsoft/apm/blob/f7c9d0e23e9800f06ce2792306ac316fca6970ba/.github/workflows/windows-ssh-passphrase-repro.yml) | Adds a non-required `windows-latest` PR/manual workflow. Checkout is pinned to the PR head, credentials are not persisted, and the workflow rejects any diff beyond the two fixture files relative to the required baseline. |
| [`scripts/windows/test-ssh-passphrase-fixture.ps1`](https://github.com/microsoft/apm/blob/f7c9d0e23e9800f06ce2792306ac316fca6970ba/scripts/windows/test-ssh-passphrase-fixture.ps1) | Creates the local Git/SSH boundary, ephemeral keys and askpass executable, preflights the server, runs all four packaged-CLI scenarios, captures process evidence, scans artifacts for passphrase leakage, restores `sshd`, and removes private material. |

No product module, documentation claim, `critical_suite.toml`, or TM002 metadata changes in this lane.

## Diagrams

Legend: the boxed sequence is the new hosted evidence path; the askpass branch runs only for encrypted-key cases.

```mermaid
sequenceDiagram
    participant W as windows-latest job
    participant A as packaged apm.exe
    participant G as Git for Windows
    participant S as Windows OpenSSH client
    participant Q as ephemeral askpass.exe
    participant D as loopback sshd
    participant R as git upload-pack

    rect rgb(255, 247, 200)
        W->>A: apm install
        A->>G: resolve and clone SSH dependency
        G->>S: transport/ssh child
        alt encrypted private key
            S->>Q: request key passphrase
            Q-->>S: ephemeral response
        else unencrypted private key
            S->>S: decrypt not required
        end
        S->>D: public-key auth on 127.0.0.1
        D->>R: forced upload-pack command
        R-->>D: package objects
        D-->>S: SSH stream and exit
        S-->>G: transport exit
        G-->>A: install result
    end
    Note over W,R: No external Git remote, stored credential, or mocked process boundary
```

## Trade-offs

- **Hosted Windows instead of cross-platform emulation.** Chose the actual Windows Server/OpenSSH/Git stack; rejected Linux or mocked subprocess evidence because it cannot reproduce Windows process inheritance.
- **Generated askpass executable instead of a checked-in credential helper.** Chose a tiny runtime-built fixture that reads one ephemeral environment value; rejected stored passphrases and reusable product abstractions. This proves noninteractive askpass behavior, not a human-facing ConPTY prompt.
- **Loopback `sshd` instead of a private repository.** Chose a forced local `git upload-pack`; rejected external network, repository credentials, and a third-party SSH server.
- **Dedicated draft workflow instead of a required gate.** Chose an isolated evidence check; rejected merge-gate enrollment until the root cause and long-term matrix are known.
- **No product fix from a GREEN receipt.** The encrypted-correct case passed, so this lane records the non-reproduction instead of inventing a change.

## Benefits

1. Four explicit controls distinguish server reachability, key encryption, wrong passphrase, and missing askpass behavior.
2. Successful SSH children record argv and exit `0`; failed clones truthfully record Git exit `128` even though Git for Windows omits the SSH `child_exit` event on that path.
3. Every askpass invocation records safe prompt/environment metadata without recording its response.
4. The evidence artifact excludes private keys and fails if either ephemeral passphrase appears in any uploaded file.
5. A later lane can distinguish a direct interactive-console gap from the working noninteractive askpass path before touching product code.

## Validation

`uv run --extra dev pytest -q tests/quality/test_ci_topology.py tests/unit/test_platform_contract_workflow.py tests/unit/test_build_spec.py`:

```text
39 passed in 6.38s
```

`uv run --extra dev pytest -p no:cacheprovider -q tests/quality`:

```text
25 passed in 20.48s
```

<details><summary>Lint and quality ratchets</summary>

```text
ruff check: passed
ruff format --check: 1533 files already formatted
pylint R0801: 10.00/10
[+] auth-signal lint clean
[+] assertion-quality ratchet clean: AQ001=5, AQ002=12
[+] exact test duplicate ratchet clean: 1052 files, 8 allowed duplicate groups
PowerShell parser: passed
Workflow YAML parser: passed
Printable ASCII check: passed
```

</details>

> [!NOTE]
> Hosted Windows run [`29469702438`](https://github.com/microsoft/apm/actions/runs/29469702438) passed on `windows-latest`. Packaged APM was `0.25.0` (`SHA-256 5d657991888a44a90245ff05f91dc22f4382e8d3dce6d3e5775ded96753dabee`), Git was `2.55.0.windows.2`, and Windows OpenSSH was `9.5p2`.

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test proving it | Type |
|---:|---|---|---|:---:|
| 1 | `apm install` succeeds with an unencrypted SSH private key | Vendor-neutral, DevX | `scripts/windows/test-ssh-passphrase-fixture.ps1` - `unencrypted-positive` | e2e |
| 2 | `apm install` succeeds when askpass supplies the correct encrypted-key passphrase | Secure by default, Vendor-neutral, DevX | `scripts/windows/test-ssh-passphrase-fixture.ps1` - `encrypted-correct` (regression-trap for #1976) | e2e |
| 3 | `apm install` fails closed when askpass supplies a wrong passphrase | Secure by default, Governed by policy | `scripts/windows/test-ssh-passphrase-fixture.ps1` - `encrypted-wrong` | e2e |
| 4 | `apm install` fails closed without a usable passphrase helper | Secure by default, Governed by policy | `scripts/windows/test-ssh-passphrase-fixture.ps1` - `encrypted-missing` | e2e |

### Hosted receipt

| Scenario | APM exit | Askpass calls | Git/SSH evidence | Result |
|---|---:|---:|---|---|
| `unencrypted-positive` | `0` | `0` | Three SSH transports exited `0`; skill and lockfile written | PASS |
| `encrypted-correct` | `0` | `3` | Three passphrase prompts and three SSH transports exited `0`; skill and lockfile written | PASS |
| `encrypted-wrong` | `1` | `1` | Git clone exited `128`; no skill or lockfile written | PASS |
| `encrypted-missing` | `1` | `0` | Git clone exited `128`; no skill or lockfile written | PASS |

Trace2 recorded `GIT_TERMINAL_PROMPT=0`, `SSH_ASKPASS_REQUIRE=force`, the fixture `DISPLAY`, and the exact `GIT_SSH_COMMAND`. `GIT_ASKPASS` and input `SSH_AUTH_SOCK` were absent. Windows OpenSSH supplied its built-in `\\.\pipe\openssh-ssh-agent` value to the askpass child, but the pipe was unavailable and no agent credential was used. The 28-file uploaded artifact contains no private-key-like file; the runtime passphrase leak scan passed.

**Classification:** #1976 did not reproduce in this noninteractive askpass-backed Windows boundary. Do not create a product-fix session from this receipt. If direct interactive PowerShell prompting remains a requirement, stack a fixture-only ConPTY/console scenario on `f7c9d0e23e`; create a product-fix lane only if that narrower boundary turns RED.

## How to test

- [x] Confirm the workflow checked out `f7c9d0e23e` and accepted only the two fixture files over baseline `796e229805`.
- [x] Confirm all four scenarios executed through packaged APM and the local Git/OpenSSH boundary.
- [x] Inspect `summary.json`, per-scenario receipts, Trace2 logs, SSH logs, and askpass JSONL from run `29469702438`.
- [x] Confirm every repository check, including the hosted Windows contract, is green.
- [ ] Never merge this evidence draft from this lane.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>