### PR TITLE
harden(ci): require hermetic lifecycle smoke subset on pull-request CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,8 +357,31 @@ jobs:
   # merge queue. This job closes that gap for the subset that is both
   # hermetic and fast enough for the PR-time critical path.
   #
-  # Why these five targets specifically
-  # ------------------------------------
+  # Declarative selection via a registered pytest marker
+  # -----------------------------------------------------
+  # The family is selected by `-m lifecycle_smoke`, not by an explicit
+  # file/node-id list. `@pytest.mark.lifecycle_smoke` (registered in
+  # pyproject.toml's [tool.pytest.ini_options] markers, enforced by
+  # --strict-markers) is applied at the module level to
+  # test_install_content_hash_roundtrip.py, test_policy_pinned_constraint_e2e.py,
+  # test_virtual_claude_skill_lock_convergence.py, and
+  # test_virtual_package_lifecycle_matrix.py, and at the function level to
+  # ONLY test_architecture_authorities.py::test_ado_lock_coordinates_have_single_owner
+  # (the exact #2226 AC14 static guard pinning that ADO coordinates are
+  # derived by DependencyReference and never persisted in the lockfile --
+  # the file's other 32 tests are deliberately unmarked; four of them shell
+  # out to a subprocess pytest run (~30s each) and would blow the time
+  # budget without adding coverage for this PR's regressions).
+  #
+  # This is the load-bearing reason for marker-based selection over an
+  # explicit-path list: if every `lifecycle_smoke` mark were ever stripped
+  # (accidentally or via a bad merge), `-m lifecycle_smoke` collects zero
+  # tests and pytest exits 5 ("no tests collected") -- a hard, structural
+  # CI failure, not a silent no-op. An explicit path list degrades instead:
+  # a dropped/renamed target just quietly shrinks what runs.
+  #
+  # Why these four modules + one function, Consume/Produce/Govern coverage
+  # ------------------------------------------------------------------------
   #   - test_install_content_hash_roundtrip.py, test_policy_pinned_constraint_e2e.py:
   #     already-curated `component`-tier Consume/Govern contracts from
   #     critical_suite.toml; no built binary, no network.
@@ -369,13 +392,9 @@ jobs:
   #     regression test (install/lock/frozen-install/update/audit matrix for
   #     virtual + manifestless packages). Not in critical_suite.toml (it
   #     carries only `pytest.mark.integration`, not a taxonomy behavioral
-  #     marker), so no manifest change is needed to target it.
+  #     marker), so no manifest change is needed to mark it.
   #   - test_architecture_authorities.py::test_ado_lock_coordinates_have_single_owner:
-  #     the exact #2226 AC14 static guard pinning that ADO coordinates are
-  #     derived by DependencyReference and never persisted in the lockfile.
-  #     The other 32 tests in that file are excluded here: four of them
-  #     shell out to a subprocess pytest run (~30s each) and would blow the
-  #     time budget without adding coverage for this PR's regressions.
+  #     see above.
   #
   # #2238 (bounded best-effort ref-lookup retries) is intentionally NOT
   # duplicated here: its regression coverage
@@ -385,8 +404,9 @@ jobs:
   #
   # Why this stays hermetic, network-free, and credential-free
   # ------------------------------------------------------------
-  # None of the five targets carry requires_apm_binary, requires_github_token,
-  # requires_ado_pat, or any other network/credential precondition marker.
+  # None of the twelve tests this marker currently collects carry
+  # requires_apm_binary, requires_github_token, requires_ado_pat, or any
+  # other network/credential precondition marker.
   # tests/utils/isolated_apm_environment.py's socket guard denies ALL
   # AF_INET/AF_INET6 use (including loopback) inside the subprocess these
   # tests drive; git remotes are rewritten to local bare repos via
@@ -394,18 +414,33 @@ jobs:
   # GITHUB_APM_PAT/ADO_APM_PAT env, so it is structurally unable to depend on
   # credentials.
   #
+  # Why `tests/integration` as the collection root, not `tests/`
+  # ----------------------------------------------------------------
+  # Bounding collection to tests/integration keeps `-m lifecycle_smoke` from
+  # ever silently picking up a same-named marker use added under
+  # tests/unit or tests/quality in the future; it also keeps collection
+  # cost proportional to the directory that actually owns this family.
+  #
   # Why timeout-minutes: 3
   # ------------------------
-  # Measured cold wall time for this exact target list is ~13s bare pytest
-  # (stable across repeated runs); with checkout + setup-python + setup-uv +
-  # `uv sync --extra dev` overhead (~45-50s, per the comparable
-  # Test Architecture Ratchets job), total job wall time is projected at
-  # ~60s. 3 minutes gives ample runner-variance headroom while still failing
-  # fast and loud if this suite ever regresses toward materially slower
-  # (e.g. an accidental real network call retrying under the hood).
+  # Before this refactor (explicit 5-target list), measured cold wall time
+  # was ~16-19s bare pytest. After moving to marker-based selection over
+  # the full tests/integration/ directory (299 files), measured cold wall
+  # time is ~18-27s bare pytest -- the marker scan adds a real but bounded
+  # +2 to +8s of collection overhead versus enumerating five paths
+  # directly. With checkout + setup-python + setup-uv + `uv sync --extra
+  # dev` overhead (~45-50s, per the comparable Test Architecture Ratchets
+  # job), total job wall time is projected at ~63-70s -- still within the
+  # 60-90s target with adequate headroom. 3 minutes gives ample
+  # runner-variance headroom while still failing fast and loud if this
+  # suite ever regresses toward materially slower (e.g. an accidental real
+  # network call retrying under the hood, or the marker family silently
+  # growing unbounded).
   #
-  # tests/quality/test_ci_topology.py guards this job's name, target list,
-  # timeout, and required-check membership against silent drift.
+  # tests/quality/test_ci_topology.py guards this job's name, the marker's
+  # registration, the command's use of --strict-markers/-m/bounded root,
+  # required-check membership, and that the marker family is non-empty
+  # right now -- against silent drift.
   lifecycle-smoke:
     name: Lifecycle Smoke (Linux)
     runs-on: ubuntu-24.04
@@ -431,9 +466,5 @@ jobs:
 
     - name: Run required lifecycle smoke subset
       run: |
-        uv run --extra dev pytest -p no:cacheprovider -q \
-          tests/integration/test_install_content_hash_roundtrip.py \
-          tests/integration/test_policy_pinned_constraint_e2e.py \
-          tests/integration/test_virtual_claude_skill_lock_convergence.py \
-          tests/integration/test_virtual_package_lifecycle_matrix.py \
-          tests/integration/test_architecture_authorities.py::test_ado_lock_coordinates_have_single_owner
+        uv run --extra dev pytest -p no:cacheprovider -q --strict-markers \
+          -m lifecycle_smoke tests/integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,3 +342,98 @@ jobs:
       # .agents/skills/ content could silently diverge from source (#1716).
       - name: apm audit --ci
         run: uv run apm audit --ci
+
+  # Promotes the smallest stable hermetic slice of the real Consume/Produce/
+  # Govern lifecycle contracts to a PR-time required check. Tier 1.
+  #
+  # Why this job exists
+  # --------------------
+  # Every module under tests/integration/ -- including the curated
+  # producer/consumer/govern contracts in tests/quality/critical_suite.toml
+  # and the regression coverage added by #2226 (ADO lock coordinate
+  # preservation) and #2240 (virtual/manifestless lifecycle convergence) --
+  # only ran on merge_group (ci-integration.yml), never as a required PR
+  # check. A revert of either fix could sit un-caught until a PR reached the
+  # merge queue. This job closes that gap for the subset that is both
+  # hermetic and fast enough for the PR-time critical path.
+  #
+  # Why these five targets specifically
+  # ------------------------------------
+  #   - test_install_content_hash_roundtrip.py, test_policy_pinned_constraint_e2e.py:
+  #     already-curated `component`-tier Consume/Govern contracts from
+  #     critical_suite.toml; no built binary, no network.
+  #   - test_virtual_claude_skill_lock_convergence.py: `component`-tier
+  #     Produce/Consume lock-convergence contract from critical_suite.toml,
+  #     directly adjacent to the #2226 ADO lock-coordinate fix.
+  #   - test_virtual_package_lifecycle_matrix.py: the direct #2240
+  #     regression test (install/lock/frozen-install/update/audit matrix for
+  #     virtual + manifestless packages). Not in critical_suite.toml (it
+  #     carries only `pytest.mark.integration`, not a taxonomy behavioral
+  #     marker), so no manifest change is needed to target it.
+  #   - test_architecture_authorities.py::test_ado_lock_coordinates_have_single_owner:
+  #     the exact #2226 AC14 static guard pinning that ADO coordinates are
+  #     derived by DependencyReference and never persisted in the lockfile.
+  #     The other 32 tests in that file are excluded here: four of them
+  #     shell out to a subprocess pytest run (~30s each) and would blow the
+  #     time budget without adding coverage for this PR's regressions.
+  #
+  # #2238 (bounded best-effort ref-lookup retries) is intentionally NOT
+  # duplicated here: its regression coverage
+  # (tests/unit/deps/test_download_strategies_phase3.py,
+  # tests/unit/deps/test_git_reference_resolver.py) is unit-level and
+  # already required today via build-and-test-shard.
+  #
+  # Why this stays hermetic, network-free, and credential-free
+  # ------------------------------------------------------------
+  # None of the five targets carry requires_apm_binary, requires_github_token,
+  # requires_ado_pat, or any other network/credential precondition marker.
+  # tests/utils/isolated_apm_environment.py's socket guard denies ALL
+  # AF_INET/AF_INET6 use (including loopback) inside the subprocess these
+  # tests drive; git remotes are rewritten to local bare repos via
+  # `git config url.<path>.insteadOf`. This job declares no `secrets:` and no
+  # GITHUB_APM_PAT/ADO_APM_PAT env, so it is structurally unable to depend on
+  # credentials.
+  #
+  # Why timeout-minutes: 3
+  # ------------------------
+  # Measured cold wall time for this exact target list is ~13s bare pytest
+  # (stable across repeated runs); with checkout + setup-python + setup-uv +
+  # `uv sync --extra dev` overhead (~45-50s, per the comparable
+  # Test Architecture Ratchets job), total job wall time is projected at
+  # ~60s. 3 minutes gives ample runner-variance headroom while still failing
+  # fast and loud if this suite ever regresses toward materially slower
+  # (e.g. an accidental real network call retrying under the hood).
+  #
+  # tests/quality/test_ci_topology.py guards this job's name, target list,
+  # timeout, and required-check membership against silent drift.
+  lifecycle-smoke:
+    name: Lifecycle Smoke (Linux)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 3
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ env.PYTHON_VERSION }}
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        enable-cache: true
+
+    - name: Install dependencies
+      run: uv sync --extra dev
+
+    - name: Run required lifecycle smoke subset
+      run: |
+        uv run --extra dev pytest -p no:cacheprovider -q \
+          tests/integration/test_install_content_hash_roundtrip.py \
+          tests/integration/test_policy_pinned_constraint_e2e.py \
+          tests/integration/test_virtual_claude_skill_lock_convergence.py \
+          tests/integration/test_virtual_package_lifecycle_matrix.py \
+          tests/integration/test_architecture_authorities.py::test_ado_lock_coordinates_have_single_owner

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -126,7 +126,13 @@ jobs:
           # allocation latency on the critical path.
           # merge_group context: Coverage Combine IS required, so the
           # global 80% floor blocks the actual merge.
-          EXPECTED_CHECKS: ${{ github.event_name == 'merge_group' && 'Build & Test Shard 1 (Linux),Build & Test Shard 2 (Linux),Coverage Combine (Linux),APM Self-Check,NOTICE Drift Check,Build (Linux),Smoke Test (Linux),Integration Tests (Linux),Release Validation (Linux)' || 'Build & Test Shard 1 (Linux),Build & Test Shard 2 (Linux),APM Self-Check,NOTICE Drift Check' }}
+          # Lifecycle Smoke (Linux) is required in BOTH contexts: it's a
+          # hermetic, ~60s ci.yml job (runs on pull_request AND merge_group,
+          # same as APM Self-Check / NOTICE Drift Check), promoting the
+          # smallest stable subset of the real Consume/Produce/Govern
+          # lifecycle contracts -- including the direct #2226/#2240
+          # regression tests -- onto the PR-time critical path.
+          EXPECTED_CHECKS: ${{ github.event_name == 'merge_group' && 'Build & Test Shard 1 (Linux),Build & Test Shard 2 (Linux),Coverage Combine (Linux),APM Self-Check,NOTICE Drift Check,Lifecycle Smoke (Linux),Build (Linux),Smoke Test (Linux),Integration Tests (Linux),Release Validation (Linux)' || 'Build & Test Shard 1 (Linux),Build & Test Shard 2 (Linux),APM Self-Check,NOTICE Drift Check,Lifecycle Smoke (Linux)' }}
           # Poll budget: ci-integration.yml chains Build -> Smoke ->
           # Integration (timeout 20m) -> Release Validation (timeout 20m).
           # Theoretical worst case ~50m; observed today ~5m end-to-end.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- A hermetic ~60s `Lifecycle Smoke (Linux)` check is now required at PR time
-  (`ci.yml`, gated via `merge-gate.yml`), covering the smallest stable subset
-  of the real Consume/Produce/Govern lifecycle contracts: install
-  content-hash roundtrip, policy pinned-constraint enforcement, virtual-skill
-  lock convergence, the virtual/manifestless lifecycle matrix (#2240), and
-  the ADO lock-coordinate ownership guard (#2226). No built binary, network,
-  or credentials required; `tests/quality/test_ci_topology.py` guards the
-  job's targets, timeout, and required-check membership against drift.
-  (#2247)
+- Pull requests now run a ~60s hermetic `Lifecycle Smoke (Linux)` check that
+  validates core install, lock-convergence, and policy-enforcement contracts
+  at PR time instead of only in the merge queue -- no network, credentials, or
+  built binary required (#2247).
 - Object-form Git dependencies now reject unsupported keys instead of silently
   ignoring them; use `ref` rather than `version`, and omit inert `name` fields
   from `git: parent`. CI audit also rejects full-SHA pins whose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the ADO lock-coordinate ownership guard (#2226). No built binary, network,
   or credentials required; `tests/quality/test_ci_topology.py` guards the
   job's targets, timeout, and required-check membership against drift.
+  (#2247)
 - Object-form Git dependencies now reject unsupported keys instead of silently
   ignoring them; use `ref` rather than `version`, and omit inert `name` fields
   from `git: parent`. CI audit also rejects full-SHA pins whose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Pull requests now run a ~60s hermetic `Lifecycle Smoke (Linux)` check that
-  validates core install, lock-convergence, and policy-enforcement contracts
-  at PR time instead of only in the merge queue -- no network, credentials, or
-  built binary required (#2247).
+- Pull requests now run a ~65-70s hermetic `Lifecycle Smoke (Linux)` check,
+  selected declaratively via a registered `lifecycle_smoke` pytest marker,
+  that validates core install, lock-convergence, and policy-enforcement
+  contracts at PR time instead of only in the merge queue -- no network,
+  credentials, or built binary required (#2247).
 - Object-form Git dependencies now reject unsupported keys instead of silently
   ignoring them; use `ref` rather than `version`, and omit inert `name` fields
   from `git: parent`. CI audit also rejects full-SHA pins whose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- A hermetic ~60s `Lifecycle Smoke (Linux)` check is now required at PR time
+  (`ci.yml`, gated via `merge-gate.yml`), covering the smallest stable subset
+  of the real Consume/Produce/Govern lifecycle contracts: install
+  content-hash roundtrip, policy pinned-constraint enforcement, virtual-skill
+  lock convergence, the virtual/manifestless lifecycle matrix (#2240), and
+  the ADO lock-coordinate ownership guard (#2226). No built binary, network,
+  or credentials required; `tests/quality/test_ci_topology.py` guards the
+  job's targets, timeout, and required-check membership against drift.
 - Object-form Git dependencies now reject unsupported keys instead of silently
   ignoring them; use `ref` rather than `version`, and omit inert `name` fields
   from `git: parent`. CI audit also rejects full-SHA pins whose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pull requests now run a ~65-70s hermetic `Lifecycle Smoke (Linux)` check,
   selected declaratively via a registered `lifecycle_smoke` pytest marker,
-  that validates core install, lock-convergence, and policy-enforcement
-  contracts at PR time instead of only in the merge queue -- no network,
-  credentials, or built binary required (#2247).
+  that validates core install, lock-convergence, policy-enforcement, and
+  prune-time hook-reconciliation contracts at PR time instead of only in
+  the merge queue -- no network, credentials, or built binary required
+  (#2247).
 - Object-form Git dependencies now reject unsupported keys instead of silently
   ignoring them; use `ref` rather than `version`, and omit inert `name` fields
   from `git: parent`. CI audit also rejects full-SHA pins whose

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,10 +150,11 @@ What this means for contributors:
 
 - You don't need to keep your branch up to date with `main` manually.
 - The fast unit + build checks (Tier 1) run on every push to your PR.
-- A hermetic ~60s Lifecycle Smoke check also runs on every push, validating
-  core install/lock-convergence/policy-enforcement contracts -- no network,
-  credentials, or built binary required, so you get real regression
-  feedback before the queue instead of only after.
+- A hermetic ~65-70s Lifecycle Smoke check also runs on every push, validating
+  core install/lock-convergence/policy-enforcement contracts via a declarative
+  `lifecycle_smoke` pytest marker -- no network, credentials, or built binary
+  required, so you get real regression feedback before the queue instead of
+  only after.
 - The full integration suite (Tier 2) only runs once your PR is in the queue,
   not on every WIP push.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,6 +150,10 @@ What this means for contributors:
 
 - You don't need to keep your branch up to date with `main` manually.
 - The fast unit + build checks (Tier 1) run on every push to your PR.
+- A hermetic ~60s Lifecycle Smoke check also runs on every push, validating
+  core install/lock-convergence/policy-enforcement contracts -- no network,
+  credentials, or built binary required, so you get real regression
+  feedback before the queue instead of only after.
 - The full integration suite (Tier 2) only runs once your PR is in the queue,
   not on every WIP push.
 

--- a/docs/src/content/docs/contributing/integration-testing.md
+++ b/docs/src/content/docs/contributing/integration-testing.md
@@ -33,6 +33,13 @@ APM uses a tiered approach to integration testing:
 - **Duration**: ~10-15 minutes per platform (with 20-minute timeout)  
 - **Trigger**: merge queue integration workflow, plus tag, schedule, and manual promotion runs
 
+### 3. **Lifecycle Smoke** (PR-time required check)
+- **Location**: `tests/integration/test_install_content_hash_roundtrip.py`, `test_policy_pinned_constraint_e2e.py`, `test_virtual_claude_skill_lock_convergence.py`, `test_virtual_package_lifecycle_matrix.py`, and `test_architecture_authorities.py::test_ado_lock_coordinates_have_single_owner`
+- **Purpose**: Promote the smallest stable, hermetic slice of the real Consume/Produce/Govern lifecycle contracts onto the PR-time critical path, so a regression in install/lock/audit convergence or ADO lock-coordinate handling fails the PR instead of only surfacing once a change reaches the merge queue
+- **Scope**: install content-hash roundtrip, policy pinned-constraint enforcement, virtual-skill lock convergence, the virtual/manifestless lifecycle matrix, and the ADO lock-coordinate ownership guard -- no built binary, no network, no credentials
+- **Duration**: ~60s job wall time (hard 3-minute timeout)
+- **Trigger**: every pull request and merge queue run (`ci.yml`'s `lifecycle-smoke` job, required via `merge-gate.yml`)
+
 ## Running Tests Locally
 
 Integration tests live under `tests/integration/` and run via `pytest`
@@ -248,7 +255,7 @@ environment end-to-end; for local iteration prefer the direct
 ### GitHub Actions Workflow
 
 **On PR and merge queue:**
-1. PR-time unit checks run first; merge queue adds Linux smoke, integration, and release-validation gates.
+1. PR-time unit checks and the hermetic Lifecycle Smoke gate run first; merge queue adds Linux smoke, integration, and release-validation gates.
 
 **On version tag releases:**
 1. Unit tests + Smoke tests

--- a/docs/src/content/docs/contributing/integration-testing.md
+++ b/docs/src/content/docs/contributing/integration-testing.md
@@ -34,20 +34,17 @@ APM uses a tiered approach to integration testing:
 - **Trigger**: merge queue integration workflow, plus tag, schedule, and manual promotion runs
 
 ### 3. **Lifecycle Smoke** (PR-time required check)
-- **Location**: all under `tests/integration/` -- `test_install_content_hash_roundtrip.py`, `test_policy_pinned_constraint_e2e.py`, `test_virtual_claude_skill_lock_convergence.py`, `test_virtual_package_lifecycle_matrix.py`, and `test_architecture_authorities.py::test_ado_lock_coordinates_have_single_owner`
+- **Location**: selected declaratively via the registered `lifecycle_smoke` pytest marker, applied to all of `tests/integration/test_install_content_hash_roundtrip.py`, `test_policy_pinned_constraint_e2e.py`, `test_virtual_claude_skill_lock_convergence.py`, `test_virtual_package_lifecycle_matrix.py` (module-level), and to only `test_architecture_authorities.py::test_ado_lock_coordinates_have_single_owner` (function-level -- the file's other tests are not part of this family)
 - **Purpose**: Promote the smallest stable, hermetic slice of the real Consume/Produce/Govern lifecycle contracts onto the PR-time critical path, so a regression in install/lock/audit convergence or ADO lock-coordinate handling fails the PR instead of only surfacing once a change reaches the merge queue
 - **Scope**: install content-hash roundtrip, policy pinned-constraint enforcement, virtual-skill lock convergence, the virtual/manifestless lifecycle matrix, and the ADO lock-coordinate ownership guard -- no built binary, no network, no credentials
-- **Duration**: ~60s job wall time (hard 3-minute timeout)
+- **Duration**: ~65-70s job wall time (hard 3-minute timeout)
 - **Trigger**: every pull request and merge queue run (`ci.yml`'s `lifecycle-smoke` job, required via `merge-gate.yml`)
-- **Drift guard**: `tests/quality/test_ci_topology.py` pins this job's exact targets, timeout, hermeticity (no credentials at job- or step-level `env`, no credential expressions in `run:`/`with:`), and required-check membership -- editing the job's targets without updating that guard fails CI
+- **Selection mechanism**: `pytest --strict-markers -m lifecycle_smoke tests/integration` -- declarative, not an explicit file/node-id list. If every `@pytest.mark.lifecycle_smoke` mark were ever removed, the marker family collects zero tests and pytest exits code 5 ("no tests collected"), failing the job loudly rather than silently shrinking. The marker is registered in `pyproject.toml`'s `[tool.pytest.ini_options]` markers list; `--strict-markers` rejects any typo'd or unregistered mark used as a decorator.
+- **Drift guard**: `tests/quality/test_ci_topology.py` pins the marker's registration, the command's use of `--strict-markers`/`-m lifecycle_smoke`/the bounded `tests/integration` root, hermeticity (no credentials at job- or step-level `env`, no credential expressions in `run:`/`with:`), required-check membership, and that the marker family collects a non-empty set of tests right now -- editing the job without updating that guard fails CI
 - **Run it locally** (the exact command CI runs):
   ```bash
-  uv run --extra dev pytest -p no:cacheprovider -q \
-    tests/integration/test_install_content_hash_roundtrip.py \
-    tests/integration/test_policy_pinned_constraint_e2e.py \
-    tests/integration/test_virtual_claude_skill_lock_convergence.py \
-    tests/integration/test_virtual_package_lifecycle_matrix.py \
-    "tests/integration/test_architecture_authorities.py::test_ado_lock_coordinates_have_single_owner"
+  uv run --extra dev pytest -p no:cacheprovider -q --strict-markers \
+    -m lifecycle_smoke tests/integration
   ```
 
 ## Running Tests Locally
@@ -90,9 +87,14 @@ Pytest markers compose across independent axes:
 | Behavioral | What boundary does the test cross? | `unit`, `component`, `e2e` |
 | Scheduling | When is the test selected? | `integration`, `slow`, `benchmark`, `live` |
 | Prerequisite | What environment must exist? | `requires_*` |
+| CI-selection | Is this test part of a named required CI gate? | `lifecycle_smoke` |
 
 `live` is both an opt-in scheduling marker and an external-service
 prerequisite. Behavioral markers do not replace prerequisite markers.
+`lifecycle_smoke` is orthogonal to all three: it does not describe a
+test's boundary, scheduling, or precondition, only that
+`ci.yml`'s required `lifecycle-smoke` job selects it via
+`-m lifecycle_smoke` (see Tier 3 above for the full rationale).
 
 The behavioral definitions are:
 
@@ -390,7 +392,7 @@ Promotion integration tests run on:
 ### Lifecycle Smoke Failures
 - These tests are hermetic -- no credentials, no built binary, no network (a real socket attempt raises `OSError`, it does not hang or retry). A failure is a genuine regression, not an environment issue.
 - Run the exact CI command from the "Run it locally" block under Tier 3 above to reproduce.
-- If the failure is about the CI job's shape (wrong target list, timeout, or required-check wiring) rather than test logic, check `tests/quality/test_ci_topology.py` -- that guard pins the job's contract and its own failure message will point at what drifted.
+- If the failure is about the CI job's shape (marker not registered, wrong `-m`/`--strict-markers` invocation, unbounded root, timeout, empty marker family, or required-check wiring) rather than test logic, check `tests/quality/test_ci_topology.py` -- that guard pins the job's contract and its own failure message will point at what drifted.
 - For hanging issues: Check command transformation in script runner (codex expects prompt content, not file paths)
 
 ## Adding New Tests

--- a/docs/src/content/docs/contributing/integration-testing.md
+++ b/docs/src/content/docs/contributing/integration-testing.md
@@ -34,11 +34,21 @@ APM uses a tiered approach to integration testing:
 - **Trigger**: merge queue integration workflow, plus tag, schedule, and manual promotion runs
 
 ### 3. **Lifecycle Smoke** (PR-time required check)
-- **Location**: `tests/integration/test_install_content_hash_roundtrip.py`, `test_policy_pinned_constraint_e2e.py`, `test_virtual_claude_skill_lock_convergence.py`, `test_virtual_package_lifecycle_matrix.py`, and `test_architecture_authorities.py::test_ado_lock_coordinates_have_single_owner`
+- **Location**: all under `tests/integration/` -- `test_install_content_hash_roundtrip.py`, `test_policy_pinned_constraint_e2e.py`, `test_virtual_claude_skill_lock_convergence.py`, `test_virtual_package_lifecycle_matrix.py`, and `test_architecture_authorities.py::test_ado_lock_coordinates_have_single_owner`
 - **Purpose**: Promote the smallest stable, hermetic slice of the real Consume/Produce/Govern lifecycle contracts onto the PR-time critical path, so a regression in install/lock/audit convergence or ADO lock-coordinate handling fails the PR instead of only surfacing once a change reaches the merge queue
 - **Scope**: install content-hash roundtrip, policy pinned-constraint enforcement, virtual-skill lock convergence, the virtual/manifestless lifecycle matrix, and the ADO lock-coordinate ownership guard -- no built binary, no network, no credentials
 - **Duration**: ~60s job wall time (hard 3-minute timeout)
 - **Trigger**: every pull request and merge queue run (`ci.yml`'s `lifecycle-smoke` job, required via `merge-gate.yml`)
+- **Drift guard**: `tests/quality/test_ci_topology.py` pins this job's exact targets, timeout, hermeticity (no credentials at job- or step-level `env`, no credential expressions in `run:`/`with:`), and required-check membership -- editing the job's targets without updating that guard fails CI
+- **Run it locally** (the exact command CI runs):
+  ```bash
+  uv run --extra dev pytest -p no:cacheprovider -q \
+    tests/integration/test_install_content_hash_roundtrip.py \
+    tests/integration/test_policy_pinned_constraint_e2e.py \
+    tests/integration/test_virtual_claude_skill_lock_convergence.py \
+    tests/integration/test_virtual_package_lifecycle_matrix.py \
+    "tests/integration/test_architecture_authorities.py::test_ado_lock_coordinates_have_single_owner"
+  ```
 
 ## Running Tests Locally
 
@@ -332,6 +342,14 @@ Promotion integration tests run on:
 - ✅ Binary artifacts work across platforms
 - ✅ Release pipeline integrity (GitHub Release → PyPI)
 
+### Lifecycle Smoke Verifies:
+- Install content-hash roundtrip (Consume contract)
+- Virtual-skill lock convergence (Produce contract, adjacent to the #2226 ADO lock-coordinate fix)
+- Policy pinned-constraint enforcement (Govern contract)
+- The virtual/manifestless lifecycle matrix: install, lock, frozen-install, update, and audit stay consistent (the direct #2240 regression)
+- The ADO lock-coordinate single-owner guard (the direct #2226 regression)
+- No network, no credentials, no built binary required for any of the above
+
 ## Benefits
 
 ### **Speed vs Confidence Balance**
@@ -368,6 +386,11 @@ Promotion integration tests run on:
 - Check GitHub Models API availability
 - Review actual vs expected output
 - Test locally with same environment
+
+### Lifecycle Smoke Failures
+- These tests are hermetic -- no credentials, no built binary, no network (a real socket attempt raises `OSError`, it does not hang or retry). A failure is a genuine regression, not an environment issue.
+- Run the exact CI command from the "Run it locally" block under Tier 3 above to reproduce.
+- If the failure is about the CI job's shape (wrong target list, timeout, or required-check wiring) rather than test logic, check `tests/quality/test_ci_topology.py` -- that guard pins the job's contract and its own failure message will point at what drifted.
 - For hanging issues: Check command transformation in script runner (codex expects prompt content, not file paths)
 
 ## Adding New Tests

--- a/docs/src/content/docs/contributing/integration-testing.md
+++ b/docs/src/content/docs/contributing/integration-testing.md
@@ -34,9 +34,9 @@ APM uses a tiered approach to integration testing:
 - **Trigger**: merge queue integration workflow, plus tag, schedule, and manual promotion runs
 
 ### 3. **Lifecycle Smoke** (PR-time required check)
-- **Location**: selected declaratively via the registered `lifecycle_smoke` pytest marker, applied to all of `tests/integration/test_install_content_hash_roundtrip.py`, `test_policy_pinned_constraint_e2e.py`, `test_virtual_claude_skill_lock_convergence.py`, `test_virtual_package_lifecycle_matrix.py` (module-level), and to only `test_architecture_authorities.py::test_ado_lock_coordinates_have_single_owner` (function-level -- the file's other tests are not part of this family)
-- **Purpose**: Promote the smallest stable, hermetic slice of the real Consume/Produce/Govern lifecycle contracts onto the PR-time critical path, so a regression in install/lock/audit convergence or ADO lock-coordinate handling fails the PR instead of only surfacing once a change reaches the merge queue
-- **Scope**: install content-hash roundtrip, policy pinned-constraint enforcement, virtual-skill lock convergence, the virtual/manifestless lifecycle matrix, and the ADO lock-coordinate ownership guard -- no built binary, no network, no credentials
+- **Location**: selected declaratively via the registered `lifecycle_smoke` pytest marker, applied to all of `tests/integration/test_install_content_hash_roundtrip.py`, `test_policy_pinned_constraint_e2e.py`, `test_virtual_claude_skill_lock_convergence.py`, `test_virtual_package_lifecycle_matrix.py` (module-level), to only `test_architecture_authorities.py::test_ado_lock_coordinates_have_single_owner` (function-level -- the file's other tests are not part of this family), and to only the `[claude]` parametrization of `test_prune_hook_reconciliation_e2e.py::test_prune_removes_merged_hook_entries_and_sidecar` (the sibling `[cursor]` parametrization is deliberately excluded)
+- **Purpose**: Promote the smallest stable, hermetic slice of the real Consume/Produce/Govern lifecycle contracts onto the PR-time critical path, so a regression in install/lock/audit convergence, ADO lock-coordinate handling, or prune-time hook reconciliation fails the PR instead of only surfacing once a change reaches the merge queue
+- **Scope**: install content-hash roundtrip, policy pinned-constraint enforcement, virtual-skill lock convergence, the virtual/manifestless lifecycle matrix, the ADO lock-coordinate ownership guard, and prune's merged-hook/sidecar reconciliation -- no built binary, no network, no credentials
 - **Duration**: ~65-70s job wall time (hard 3-minute timeout)
 - **Trigger**: every pull request and merge queue run (`ci.yml`'s `lifecycle-smoke` job, required via `merge-gate.yml`)
 - **Selection mechanism**: `pytest --strict-markers -m lifecycle_smoke tests/integration` -- declarative, not an explicit file/node-id list. If every `@pytest.mark.lifecycle_smoke` mark were ever removed, the marker family collects zero tests and pytest exits code 5 ("no tests collected"), failing the job loudly rather than silently shrinking. The marker is registered in `pyproject.toml`'s `[tool.pytest.ini_options]` markers list; `--strict-markers` rejects any typo'd or unregistered mark used as a decorator.
@@ -350,6 +350,7 @@ Promotion integration tests run on:
 - Policy pinned-constraint enforcement (Govern contract)
 - The virtual/manifestless lifecycle matrix: install, lock, frozen-install, update, and audit stay consistent (the direct #2240 regression)
 - The ADO lock-coordinate single-owner guard (the direct #2226 regression)
+- Prune's merged-hook and ownership-sidecar reconciliation for the `claude` target (the direct #2249 regression -- an orphaned package's merged hook entries and sidecar markers must be cleaned up, not left pointing at deleted scripts)
 - No network, no credentials, no built binary required for any of the above
 
 ## Benefits

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,4 +214,5 @@ markers = [
     "requires_runtime_llm: requires llm runtime installed",
     "requires_inference: requires APM_RUN_INFERENCE_TESTS=1 + model API access",
     "req: binds a test to one or more OpenAPM req-XXX ids (spec-conformance suite)",
+    "lifecycle_smoke: promoted to the required PR-time Lifecycle Smoke (Linux) job -- see ci.yml's lifecycle-smoke job and docs/src/content/docs/contributing/integration-testing.md",
 ]

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -52,6 +52,7 @@ def test_object_git_dependency_fields_have_single_owner() -> None:
     assert "Object-form Git dependency fields must come from the product parser" in guard
 
 
+@pytest.mark.lifecycle_smoke
 def test_ado_lock_coordinates_have_single_owner() -> None:
     """AC14 derives ADO coordinates without provider-specific lock fields."""
     import inspect

--- a/tests/integration/test_install_content_hash_roundtrip.py
+++ b/tests/integration/test_install_content_hash_roundtrip.py
@@ -29,7 +29,7 @@ from apm_cli.models.apm_package import (
 from apm_cli.models.dependency.reference import DependencyReference
 from apm_cli.utils.content_hash import compute_package_hash
 
-pytestmark = pytest.mark.component
+pytestmark = [pytest.mark.component, pytest.mark.lifecycle_smoke]
 
 _PATCH_UPDATES = "apm_cli.commands._helpers.check_for_updates"
 _VIRTUAL_COMMIT = "a" * 40

--- a/tests/integration/test_policy_pinned_constraint_e2e.py
+++ b/tests/integration/test_policy_pinned_constraint_e2e.py
@@ -17,7 +17,7 @@ from click.testing import CliRunner
 from apm_cli.policy.discovery import PolicyFetchResult
 from apm_cli.policy.schema import ApmPolicy, DependencyPolicy
 
-pytestmark = pytest.mark.component
+pytestmark = [pytest.mark.component, pytest.mark.lifecycle_smoke]
 
 _PATCH_DISCOVER_GATE = "apm_cli.policy.discovery.discover_policy_with_chain"
 _PATCH_DISCOVER_PREFLIGHT = "apm_cli.policy.install_preflight.discover_policy_with_chain"

--- a/tests/integration/test_prune_hook_reconciliation_e2e.py
+++ b/tests/integration/test_prune_hook_reconciliation_e2e.py
@@ -220,7 +220,11 @@ def _pre_tool_use_commands(settings_path: Path) -> list[str]:
     return commands
 
 
-@pytest.mark.parametrize("target", ["claude", "cursor"], ids=["claude", "cursor"])
+@pytest.mark.parametrize(
+    "target",
+    [pytest.param("claude", marks=pytest.mark.lifecycle_smoke), "cursor"],
+    ids=["claude", "cursor"],
+)
 def test_prune_removes_merged_hook_entries_and_sidecar(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, target: str
 ) -> None:

--- a/tests/integration/test_virtual_claude_skill_lock_convergence.py
+++ b/tests/integration/test_virtual_claude_skill_lock_convergence.py
@@ -20,7 +20,7 @@ from tests.utils.isolated_apm_environment import IsolatedApmEnvironment
 from tests.utils.local_git_repository import LocalGitRepository, LocalGitRepositoryFactory
 from tests.utils.local_package import LocalPackageFactory
 
-pytestmark = [pytest.mark.integration, pytest.mark.component]
+pytestmark = [pytest.mark.integration, pytest.mark.component, pytest.mark.lifecycle_smoke]
 
 _REMOTE = "ssh://git@gitlab.example.invalid/acme/skill-repo.git"
 _REWRITE_URLS = (

--- a/tests/integration/test_virtual_package_lifecycle_matrix.py
+++ b/tests/integration/test_virtual_package_lifecycle_matrix.py
@@ -29,7 +29,7 @@ from tests.utils.local_git_repository import LocalGitRepository, LocalGitReposit
 from tests.utils.local_package import LocalPackageFactory
 from tests.utils.scenario_rows import LifecycleAction, ScenarioRow
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.lifecycle_smoke]
 
 _REPO_NAME = "virtual-lifecycle"
 _SKILL_NAME = "auth"

--- a/tests/quality/test_ci_topology.py
+++ b/tests/quality/test_ci_topology.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from pathlib import Path
 
 import pytest
+import tomllib
 
 from scripts.test_file_inventory import is_test_module_path
 from tests.quality.repository_python_inventory import (
@@ -44,6 +45,44 @@ REQUIRED_SHARD_ROOTS = (
     "tests/test_console.py",
     "tests/red_team",
 )
+
+# Lifecycle Smoke (Linux): the smallest stable hermetic subset of the real
+# Consume/Produce/Govern lifecycle contracts, promoted to a PR-time required
+# check. See ci.yml's lifecycle-smoke job comment for full rationale;
+# targets directly pin the #2226 (ADO lock coordinates) and #2240 (virtual
+# lifecycle convergence) regressions plus the `component`-marked (hermetic,
+# no built binary) contracts already curated in critical_suite.toml.
+LIFECYCLE_SMOKE_JOB = "lifecycle-smoke"
+LIFECYCLE_SMOKE_CHECK = "Lifecycle Smoke (Linux)"
+LIFECYCLE_SMOKE_RUN_STEP = "Run required lifecycle smoke subset"
+LIFECYCLE_SMOKE_MAX_TIMEOUT_MINUTES = 5
+MANIFEST = REPO_ROOT / "tests" / "quality" / "critical_suite.toml"
+# The two direct regression targets are NOT in critical_suite.toml (only
+# `pytest.mark.integration`, not a taxonomy behavioral marker), so no
+# manifest change is needed and no literal-duplication conflict exists.
+LIFECYCLE_SMOKE_DIRECT_TARGETS = (
+    "tests/integration/test_virtual_package_lifecycle_matrix.py",
+    "tests/integration/test_architecture_authorities.py::"
+    "test_ado_lock_coordinates_have_single_owner",
+)
+
+
+def _manifest_component_targets() -> tuple[str, ...]:
+    """The `component`-marked hermetic modules curated in
+    critical_suite.toml, in manifest declaration order.
+
+    Read dynamically rather than hardcoded as literals: TM002 in
+    tests/quality/test_test_taxonomy.py enforces that critical_suite.toml
+    is the sole place manifest module paths may be declared, so any
+    literal duplicate here would fail that guard.
+    """
+    with MANIFEST.open("rb") as handle:
+        data = tomllib.load(handle)
+    return tuple(entry["path"] for entry in data["modules"] if entry["marker"] == "component")
+
+
+LIFECYCLE_SMOKE_TARGETS = _manifest_component_targets() + LIFECYCLE_SMOKE_DIRECT_TARGETS
+FORBIDDEN_CREDENTIAL_ENV = ("GITHUB_APM_PAT", "ADO_APM_PAT", "GITHUB_TOKEN")
 
 
 def _run_steps(job: WorkflowNode) -> list[WorkflowNode]:
@@ -316,3 +355,118 @@ def test_duplicate_ratchet_target_fails(
             provisional_ci,
             repository_inventory,
         )
+
+
+def _assert_lifecycle_smoke_targets(job: WorkflowNode) -> None:
+    assert _pytest_targets(job) == LIFECYCLE_SMOKE_TARGETS
+
+
+def _assert_lifecycle_smoke_hermetic(job: WorkflowNode) -> None:
+    assert "secrets" not in job
+    for step in _run_steps(job):
+        env = step.get("env")
+        if isinstance(env, dict):
+            for key in FORBIDDEN_CREDENTIAL_ENV:
+                assert key not in env, f"lifecycle-smoke step must not bind {key}"
+        run = step.get("run")
+        if isinstance(run, str):
+            for key in FORBIDDEN_CREDENTIAL_ENV:
+                assert key not in run, f"lifecycle-smoke step must not reference {key}"
+
+
+def _assert_lifecycle_smoke_required(merge_gate: WorkflowNode) -> None:
+    gate = workflow_job(merge_gate, "gate")
+    wait_step = workflow_step(gate, "Wait for all required checks")
+    expected_checks = wait_step["env"]["EXPECTED_CHECKS"]
+    assert isinstance(expected_checks, str)
+    assert LIFECYCLE_SMOKE_CHECK in expected_checks
+
+
+def test_lifecycle_smoke_is_required_and_hermetic() -> None:
+    """Pins the new PR-time gate: exact targets, bounded timeout, no
+    credentials, and required-check membership. This is the positive half
+    of the guard -- the mutation tests below prove it actually catches
+    drift rather than trivially passing."""
+    ci = load_workflow(REPO_ROOT / ".github" / "workflows" / "ci.yml")
+    job = workflow_job(ci, LIFECYCLE_SMOKE_JOB)
+    assert job["name"] == LIFECYCLE_SMOKE_CHECK
+    assert job["runs-on"] == "ubuntu-24.04"
+
+    timeout = job.get("timeout-minutes")
+    assert isinstance(timeout, int)
+    assert 0 < timeout <= LIFECYCLE_SMOKE_MAX_TIMEOUT_MINUTES, (
+        "lifecycle-smoke must keep a hard, tight timeout so a regression "
+        "toward slowness (e.g. an accidental network retry loop) fails "
+        "fast and loud rather than silently eating the PR-time budget"
+    )
+
+    _assert_lifecycle_smoke_targets(job)
+    _assert_lifecycle_smoke_hermetic(job)
+
+    merge_gate = load_workflow(REPO_ROOT / ".github" / "workflows" / "merge-gate.yml")
+    _assert_lifecycle_smoke_required(merge_gate)
+
+
+@pytest.fixture
+def provisional_lifecycle_job(provisional_ci: WorkflowNode) -> WorkflowNode:
+    return workflow_job(provisional_ci, LIFECYCLE_SMOKE_JOB)
+
+
+def test_lifecycle_smoke_dropped_target_fails(
+    provisional_lifecycle_job: WorkflowNode,
+) -> None:
+    """Proves the guard fails if a load-bearing regression target (here,
+    the direct #2240 lifecycle-matrix regression test) is silently
+    removed from the required job."""
+    step = workflow_step(provisional_lifecycle_job, LIFECYCLE_SMOKE_RUN_STEP)
+    target = LIFECYCLE_SMOKE_DIRECT_TARGETS[0]
+    assert target in step["run"]
+    step["run"] = step["run"].replace(target, "")
+
+    with pytest.raises(AssertionError):
+        _assert_lifecycle_smoke_targets(provisional_lifecycle_job)
+
+
+def test_lifecycle_smoke_inverted_ac14_target_fails(
+    provisional_lifecycle_job: WorkflowNode,
+) -> None:
+    """Proves the guard fails if the direct #2226 AC14 static guard
+    node-id is swapped for a different (non-equivalent) node-id -- i.e.
+    the check would still run *a* test, but not the one that actually
+    pins the regression."""
+    step = workflow_step(provisional_lifecycle_job, LIFECYCLE_SMOKE_RUN_STEP)
+    step["run"] = step["run"].replace(
+        "test_ado_lock_coordinates_have_single_owner",
+        "test_something_unrelated",
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_lifecycle_smoke_targets(provisional_lifecycle_job)
+
+
+def test_lifecycle_smoke_credential_env_fails(
+    provisional_lifecycle_job: WorkflowNode,
+) -> None:
+    """Proves the guard fails if this job is ever wired to a credential,
+    which would break the hermetic/no-credentials contract the PR-time
+    critical path depends on."""
+    step = workflow_step(provisional_lifecycle_job, LIFECYCLE_SMOKE_RUN_STEP)
+    step["env"] = {"GITHUB_APM_PAT": "${{ secrets.GITHUB_APM_PAT }}"}
+
+    with pytest.raises(AssertionError):
+        _assert_lifecycle_smoke_hermetic(provisional_lifecycle_job)
+
+
+def test_lifecycle_smoke_removed_from_expected_checks_fails() -> None:
+    """Proves the guard fails if Lifecycle Smoke is dropped from
+    merge-gate's EXPECTED_CHECKS -- i.e. the job could exist and pass
+    while silently no longer blocking merges."""
+    merge_gate = deepcopy(load_workflow(REPO_ROOT / ".github" / "workflows" / "merge-gate.yml"))
+    gate = workflow_job(merge_gate, "gate")
+    wait_step = workflow_step(gate, "Wait for all required checks")
+    wait_step["env"]["EXPECTED_CHECKS"] = wait_step["env"]["EXPECTED_CHECKS"].replace(
+        LIFECYCLE_SMOKE_CHECK, "REMOVED"
+    )
+
+    with pytest.raises(AssertionError):
+        _assert_lifecycle_smoke_required(merge_gate)

--- a/tests/quality/test_ci_topology.py
+++ b/tests/quality/test_ci_topology.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from collections import Counter
 from copy import deepcopy
 from pathlib import Path
@@ -48,44 +49,42 @@ REQUIRED_SHARD_ROOTS = (
 
 # Lifecycle Smoke (Linux): the smallest stable hermetic subset of the real
 # Consume/Produce/Govern lifecycle contracts, promoted to a PR-time required
-# check. See ci.yml's lifecycle-smoke job comment for full rationale;
-# targets directly pin the #2226 (ADO lock coordinates) and #2240 (virtual
-# lifecycle convergence) regressions plus the `component`-marked (hermetic,
-# no built binary) contracts already curated in critical_suite.toml.
+# check. See ci.yml's lifecycle-smoke job comment for full rationale.
+#
+# Selection is declarative via the `lifecycle_smoke` pytest marker (see
+# pyproject.toml's [tool.pytest.ini_options].markers), not an explicit
+# file/node-id list. The marker is applied at the source: module-level
+# `pytestmark` on the four lifecycle-contract modules, and a single
+# function-level `@pytest.mark.lifecycle_smoke` on the one #2226 AC14
+# static guard inside test_architecture_authorities.py (that module's
+# other 32 tests are deliberately NOT marked). This intentionally means
+# no target list lives here or in any other test constant/manifest --
+# the marker registration + a live collection count are the only source
+# of truth, so a maintainer adding/removing a lifecycle_smoke-marked test
+# anywhere under tests/integration changes the required job's scope
+# without ever touching this file or ci.yml.
 LIFECYCLE_SMOKE_JOB = "lifecycle-smoke"
 LIFECYCLE_SMOKE_CHECK = "Lifecycle Smoke (Linux)"
 LIFECYCLE_SMOKE_RUN_STEP = "Run required lifecycle smoke subset"
 LIFECYCLE_SMOKE_MAX_TIMEOUT_MINUTES = 5
-MANIFEST = REPO_ROOT / "tests" / "quality" / "critical_suite.toml"
-# The two direct regression targets are NOT in critical_suite.toml (only
-# `pytest.mark.integration`, not a taxonomy behavioral marker), so no
-# manifest change is needed and no literal-duplication conflict exists.
-LIFECYCLE_SMOKE_DIRECT_TARGETS = (
-    "tests/integration/test_virtual_package_lifecycle_matrix.py",
-    "tests/integration/test_architecture_authorities.py::"
-    "test_ado_lock_coordinates_have_single_owner",
-)
-
-
-def _manifest_component_targets() -> tuple[str, ...]:
-    """The `component`-marked hermetic modules curated in
-    critical_suite.toml, in manifest declaration order.
-
-    Read dynamically rather than hardcoded as literals: TM002 in
-    tests/quality/test_test_taxonomy.py enforces that critical_suite.toml
-    is the sole place manifest module paths may be declared, so any
-    literal duplicate here would fail that guard.
-    """
-    with MANIFEST.open("rb") as handle:
-        data = tomllib.load(handle)
-    return tuple(entry["path"] for entry in data["modules"] if entry["marker"] == "component")
-
-
-LIFECYCLE_SMOKE_TARGETS = _manifest_component_targets() + LIFECYCLE_SMOKE_DIRECT_TARGETS
+LIFECYCLE_SMOKE_MARKER = "lifecycle_smoke"
+LIFECYCLE_SMOKE_ROOT = "tests/integration"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
 FORBIDDEN_CREDENTIAL_ENV = ("GITHUB_APM_PAT", "ADO_APM_PAT", "GITHUB_TOKEN")
 # Covers the `${{ github.token }}` context alias, which does not contain any
 # FORBIDDEN_CREDENTIAL_ENV substring but resolves to the same automatic token.
 FORBIDDEN_CREDENTIAL_EXPRESSIONS = (*FORBIDDEN_CREDENTIAL_ENV, "github.token")
+
+
+def _pytest_ini_markers() -> list[str]:
+    """The registered marker declarations from
+    [tool.pytest.ini_options].markers in pyproject.toml -- the single
+    canonical place pytest markers are declared in this repo."""
+    with PYPROJECT.open("rb") as handle:
+        data = tomllib.load(handle)
+    markers = data["tool"]["pytest"]["ini_options"]["markers"]
+    assert isinstance(markers, list)
+    return markers
 
 
 def _run_steps(job: WorkflowNode) -> list[WorkflowNode]:
@@ -360,8 +359,53 @@ def test_duplicate_ratchet_target_fails(
         )
 
 
-def _assert_lifecycle_smoke_targets(job: WorkflowNode) -> None:
-    assert _pytest_targets(job) == LIFECYCLE_SMOKE_TARGETS
+def _assert_lifecycle_smoke_marker_registered(markers: list[str]) -> None:
+    """The `lifecycle_smoke` marker must be registered in pyproject.toml's
+    canonical markers list. The CI invocation's `--strict-markers` flag
+    turns an unregistered marker into a hard collection error, so this is
+    a load-bearing prerequisite for the job to run at all -- not cosmetic
+    documentation."""
+    assert any(marker.startswith(f"{LIFECYCLE_SMOKE_MARKER}:") for marker in markers), (
+        f"{LIFECYCLE_SMOKE_MARKER} marker must be registered in "
+        "pyproject.toml's [tool.pytest.ini_options].markers so "
+        "--strict-markers does not reject it"
+    )
+
+
+def _assert_lifecycle_smoke_command(job: WorkflowNode) -> None:
+    """The run step must select declaratively via the `lifecycle_smoke`
+    marker expression, pass `--strict-markers`, and bound collection to
+    `tests/integration` -- never the bare `tests` root or full repo.
+    Dropping the marker expression (or widening the root) would silently
+    make this job re-run the entire integration suite inside the PR-time
+    critical path, duplicating ci-integration.yml's merge_group-only job
+    rather than staying the smallest stable hermetic subset."""
+    step = workflow_step(job, LIFECYCLE_SMOKE_RUN_STEP)
+    for tokens in shell_commands(step):
+        if "pytest" not in tokens:
+            continue
+        assert "--strict-markers" in tokens, (
+            "lifecycle-smoke must pass --strict-markers so an unregistered "
+            "or typo'd marker name fails loudly instead of silently "
+            "selecting zero tests"
+        )
+        assert "-m" in tokens, (
+            "lifecycle-smoke must select tests declaratively via a marker "
+            "expression (-m), not explicit file/node-id targets"
+        )
+        marker_index = tokens.index("-m")
+        assert marker_index + 1 < len(tokens), "lifecycle-smoke's -m flag is missing its value"
+        assert tokens[marker_index + 1] == LIFECYCLE_SMOKE_MARKER, (
+            f"lifecycle-smoke's -m expression must be exactly {LIFECYCLE_SMOKE_MARKER!r}, "
+            f"got {tokens[marker_index + 1]!r}"
+        )
+        targets = [token for token in tokens if token.startswith("tests/")]
+        assert targets == [LIFECYCLE_SMOKE_ROOT], (
+            f"lifecycle-smoke must bound collection to exactly {LIFECYCLE_SMOKE_ROOT!r} "
+            f"(never the full repo or bare tests/) -- got {targets!r}"
+        )
+        return
+    raise AssertionError("lifecycle-smoke run step contains no pytest invocation")
 
 
 def _assert_lifecycle_smoke_hermetic(job: WorkflowNode) -> None:
@@ -406,11 +450,57 @@ def _assert_lifecycle_smoke_required(merge_gate: WorkflowNode) -> None:
     assert LIFECYCLE_SMOKE_CHECK in expected_checks
 
 
+def _assert_marker_collection_non_empty(marker: str) -> None:
+    """Runs a real `--collect-only` subprocess for the given marker
+    expression and asserts pytest's exit code is 0, not 5 ("no tests
+    collected"). Parameterized so the mutation test below can prove a
+    marker guaranteed to match zero tests is caught by the exact same
+    code path the real check exercises."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-p",
+            "no:cacheprovider",
+            "-q",
+            "--collect-only",
+            "--strict-markers",
+            "-m",
+            marker,
+            LIFECYCLE_SMOKE_ROOT,
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"marker {marker!r} family must not be empty -- pytest exit "
+        f"code {result.returncode} (5 == no tests collected):\n{result.stdout}\n{result.stderr}"
+    )
+    assert "collected" in result.stdout, f"expected a collection summary, got: {result.stdout}"
+
+
+def _assert_lifecycle_smoke_collection_non_empty() -> None:
+    """Proves the marker-based family is non-empty right now: a real
+    `--collect-only` subprocess run against the exact CI invocation. If
+    every `@pytest.mark.lifecycle_smoke` were stripped from the four
+    modules and the AC14 function, pytest would exit 5 ("no tests
+    collected") -- exactly what the CI job itself would do, per
+    test_lifecycle_smoke_marker_family_empty_fails below."""
+    _assert_marker_collection_non_empty(LIFECYCLE_SMOKE_MARKER)
+
+
 def test_lifecycle_smoke_is_required_and_hermetic() -> None:
-    """Pins the new PR-time gate: exact targets, bounded timeout, no
-    credentials, and required-check membership. This is the positive half
-    of the guard -- the mutation tests below prove it actually catches
-    drift rather than trivially passing."""
+    """Pins the new PR-time gate as a semantic contract, not an exact
+    target list: the marker is registered, the command selects
+    declaratively via that marker within a bounded root, the job stays
+    hermetic and required, and the marker family actually collects tests
+    right now. This is the positive half of the guard -- the mutation
+    tests below prove it actually catches drift rather than trivially
+    passing."""
     ci = load_workflow(REPO_ROOT / ".github" / "workflows" / "ci.yml")
     job = workflow_job(ci, LIFECYCLE_SMOKE_JOB)
     assert job["name"] == LIFECYCLE_SMOKE_CHECK
@@ -424,8 +514,10 @@ def test_lifecycle_smoke_is_required_and_hermetic() -> None:
         "fast and loud rather than silently eating the PR-time budget"
     )
 
-    _assert_lifecycle_smoke_targets(job)
+    _assert_lifecycle_smoke_marker_registered(_pytest_ini_markers())
+    _assert_lifecycle_smoke_command(job)
     _assert_lifecycle_smoke_hermetic(job)
+    _assert_lifecycle_smoke_collection_non_empty()
 
     merge_gate = load_workflow(REPO_ROOT / ".github" / "workflows" / "merge-gate.yml")
     _assert_lifecycle_smoke_required(merge_gate)
@@ -436,36 +528,84 @@ def provisional_lifecycle_job(provisional_ci: WorkflowNode) -> WorkflowNode:
     return workflow_job(provisional_ci, LIFECYCLE_SMOKE_JOB)
 
 
-def test_lifecycle_smoke_dropped_target_fails(
+def test_lifecycle_smoke_marker_expression_dropped_fails(
     provisional_lifecycle_job: WorkflowNode,
 ) -> None:
-    """Proves the guard fails if a load-bearing regression target (here,
-    the direct #2240 lifecycle-matrix regression test) is silently
-    removed from the required job."""
+    """Proves the guard fails if the `-m lifecycle_smoke` marker
+    expression is silently dropped -- without it, this job would
+    silently re-run the ENTIRE tests/integration suite inside the
+    PR-time critical path, duplicating ci-integration.yml's
+    merge_group-only job and blowing the 60-90s time budget."""
     step = workflow_step(provisional_lifecycle_job, LIFECYCLE_SMOKE_RUN_STEP)
-    target = LIFECYCLE_SMOKE_DIRECT_TARGETS[0]
-    assert target in step["run"]
-    step["run"] = step["run"].replace(target, "")
+    step["run"] = step["run"].replace("-m lifecycle_smoke ", "")
 
     with pytest.raises(AssertionError):
-        _assert_lifecycle_smoke_targets(provisional_lifecycle_job)
+        _assert_lifecycle_smoke_command(provisional_lifecycle_job)
 
 
-def test_lifecycle_smoke_inverted_ac14_target_fails(
+def test_lifecycle_smoke_wrong_marker_expression_fails(
     provisional_lifecycle_job: WorkflowNode,
 ) -> None:
-    """Proves the guard fails if the direct #2226 AC14 static guard
-    node-id is swapped for a different (non-equivalent) node-id -- i.e.
-    the check would still run *a* test, but not the one that actually
-    pins the regression."""
+    """Proves the guard fails if the marker expression is swapped for a
+    different, broader, pre-existing marker (e.g. `integration`) --
+    which would still select *some* tests but silently change this job's
+    curated scope away from the lifecycle_smoke family."""
     step = workflow_step(provisional_lifecycle_job, LIFECYCLE_SMOKE_RUN_STEP)
-    step["run"] = step["run"].replace(
-        "test_ado_lock_coordinates_have_single_owner",
-        "test_something_unrelated",
-    )
+    step["run"] = step["run"].replace("lifecycle_smoke", "integration")
 
     with pytest.raises(AssertionError):
-        _assert_lifecycle_smoke_targets(provisional_lifecycle_job)
+        _assert_lifecycle_smoke_command(provisional_lifecycle_job)
+
+
+def test_lifecycle_smoke_unbounded_root_fails(
+    provisional_lifecycle_job: WorkflowNode,
+) -> None:
+    """Proves the guard fails if the collection root is silently widened
+    from tests/integration to the full tests/ tree -- even with the
+    marker expression intact, collecting over the entire suite adds
+    unbounded, unbudgeted collection overhead to every PR."""
+    step = workflow_step(provisional_lifecycle_job, LIFECYCLE_SMOKE_RUN_STEP)
+    step["run"] = step["run"].replace("tests/integration", "tests")
+
+    with pytest.raises(AssertionError):
+        _assert_lifecycle_smoke_command(provisional_lifecycle_job)
+
+
+def test_lifecycle_smoke_strict_markers_flag_dropped_fails(
+    provisional_lifecycle_job: WorkflowNode,
+) -> None:
+    """Proves the guard fails if --strict-markers is silently dropped
+    from the invocation -- without it, a future typo in the marker name
+    would silently collect zero tests (or the wrong tests) instead of
+    erroring loudly at collection time."""
+    step = workflow_step(provisional_lifecycle_job, LIFECYCLE_SMOKE_RUN_STEP)
+    step["run"] = step["run"].replace("--strict-markers ", "")
+
+    with pytest.raises(AssertionError):
+        _assert_lifecycle_smoke_command(provisional_lifecycle_job)
+
+
+def test_lifecycle_smoke_marker_not_registered_fails() -> None:
+    """Proves the guard fails if the lifecycle_smoke marker is silently
+    dropped from pyproject.toml's registered markers list -- the state
+    that would make --strict-markers reject every
+    @pytest.mark.lifecycle_smoke decorator at collection time."""
+    markers = [m for m in _pytest_ini_markers() if not m.startswith(f"{LIFECYCLE_SMOKE_MARKER}:")]
+
+    with pytest.raises(AssertionError):
+        _assert_lifecycle_smoke_marker_registered(markers)
+
+
+def test_lifecycle_smoke_marker_family_empty_fails() -> None:
+    """Proves the collection-non-empty check would fail loudly (pytest
+    exit code 5, "no tests collected") if the lifecycle_smoke family ever
+    became empty -- e.g. if every @pytest.mark.lifecycle_smoke were
+    stripped from the four modules and the AC14 function. Exercises the
+    exact same subprocess code path as
+    _assert_lifecycle_smoke_collection_non_empty, with a marker name
+    guaranteed to match zero tests today."""
+    with pytest.raises(AssertionError):
+        _assert_marker_collection_non_empty("lifecycle_smoke_nonexistent_probe_marker")
 
 
 def test_lifecycle_smoke_credential_env_fails(

--- a/tests/quality/test_ci_topology.py
+++ b/tests/quality/test_ci_topology.py
@@ -83,6 +83,9 @@ def _manifest_component_targets() -> tuple[str, ...]:
 
 LIFECYCLE_SMOKE_TARGETS = _manifest_component_targets() + LIFECYCLE_SMOKE_DIRECT_TARGETS
 FORBIDDEN_CREDENTIAL_ENV = ("GITHUB_APM_PAT", "ADO_APM_PAT", "GITHUB_TOKEN")
+# Covers the `${{ github.token }}` context alias, which does not contain any
+# FORBIDDEN_CREDENTIAL_ENV substring but resolves to the same automatic token.
+FORBIDDEN_CREDENTIAL_EXPRESSIONS = (*FORBIDDEN_CREDENTIAL_ENV, "github.token")
 
 
 def _run_steps(job: WorkflowNode) -> list[WorkflowNode]:
@@ -363,6 +366,16 @@ def _assert_lifecycle_smoke_targets(job: WorkflowNode) -> None:
 
 def _assert_lifecycle_smoke_hermetic(job: WorkflowNode) -> None:
     assert "secrets" not in job
+
+    # Job-level `env:` is inherited by every step in GitHub Actions, so a
+    # credential bound there would bypass a step-only check (panel review
+    # of #2247: python-architect, supply-chain-security-expert, and
+    # test-coverage-expert independently found and proved this gap).
+    job_env = job.get("env")
+    if isinstance(job_env, dict):
+        for key in FORBIDDEN_CREDENTIAL_ENV:
+            assert key not in job_env, f"lifecycle-smoke job-level env must not bind {key}"
+
     for step in _run_steps(job):
         env = step.get("env")
         if isinstance(env, dict):
@@ -372,6 +385,17 @@ def _assert_lifecycle_smoke_hermetic(job: WorkflowNode) -> None:
         if isinstance(run, str):
             for key in FORBIDDEN_CREDENTIAL_ENV:
                 assert key not in run, f"lifecycle-smoke step must not reference {key}"
+        # `with:` values can smuggle a credential expression (e.g. a
+        # checkout `token:` input) past the env/run-only checks above.
+        with_block = step.get("with")
+        if isinstance(with_block, dict):
+            for value in with_block.values():
+                if not isinstance(value, str):
+                    continue
+                for key in FORBIDDEN_CREDENTIAL_EXPRESSIONS:
+                    assert key not in value, (
+                        f"lifecycle-smoke step `with:` must not reference {key}"
+                    )
 
 
 def _assert_lifecycle_smoke_required(merge_gate: WorkflowNode) -> None:
@@ -452,6 +476,50 @@ def test_lifecycle_smoke_credential_env_fails(
     critical path depends on."""
     step = workflow_step(provisional_lifecycle_job, LIFECYCLE_SMOKE_RUN_STEP)
     step["env"] = {"GITHUB_APM_PAT": "${{ secrets.GITHUB_APM_PAT }}"}
+
+    with pytest.raises(AssertionError):
+        _assert_lifecycle_smoke_hermetic(provisional_lifecycle_job)
+
+
+def test_lifecycle_smoke_job_level_credential_env_fails(
+    provisional_lifecycle_job: WorkflowNode,
+) -> None:
+    """Proves the guard fails if a credential is bound at job-level `env:`
+    rather than step-level -- job-level env is inherited by every step in
+    GitHub Actions, so this is a distinct injection vector from the
+    step-level case above, not a duplicate of it. Panel review of #2247
+    found this gap independently in three lenses (architecture, supply
+    chain security, test coverage) and it was empirically confirmed:
+    without this fix, the same mutation on `job["env"]` passed silently."""
+    provisional_lifecycle_job["env"] = {"GITHUB_APM_PAT": "${{ secrets.GITHUB_APM_PAT }}"}
+
+    with pytest.raises(AssertionError):
+        _assert_lifecycle_smoke_hermetic(provisional_lifecycle_job)
+
+
+def test_lifecycle_smoke_with_block_credential_fails(
+    provisional_lifecycle_job: WorkflowNode,
+) -> None:
+    """Proves the guard fails if a credential expression is smuggled
+    through a step's `with:` block (e.g. an actions/checkout `token:`
+    input) instead of `env:`/`run:` -- a third distinct injection vector
+    flagged by the supply-chain-security-expert panelist."""
+    step = workflow_step(provisional_lifecycle_job, LIFECYCLE_SMOKE_RUN_STEP)
+    step["with"] = {"token": "${{ secrets.GITHUB_APM_PAT }}"}
+
+    with pytest.raises(AssertionError):
+        _assert_lifecycle_smoke_hermetic(provisional_lifecycle_job)
+
+
+def test_lifecycle_smoke_github_token_expression_alias_fails(
+    provisional_lifecycle_job: WorkflowNode,
+) -> None:
+    """Proves the guard catches the `${{ github.token }}` context alias,
+    which resolves to the same automatic GITHUB_TOKEN but does not
+    contain the `GITHUB_TOKEN` substring FORBIDDEN_CREDENTIAL_ENV alone
+    would catch."""
+    step = workflow_step(provisional_lifecycle_job, LIFECYCLE_SMOKE_RUN_STEP)
+    step["with"] = {"token": "${{ github.token }}"}
 
     with pytest.raises(AssertionError):
         _assert_lifecycle_smoke_hermetic(provisional_lifecycle_job)


### PR DESCRIPTION
tests/integration/** -- including the curated Consume/Produce/Govern lifecycle contracts and the direct regression tests for #2226 (ADO lock coordinates) and #2240 (virtual lifecycle convergence) -- currently only runs on merge_group, never at PR time. This PR adds a new required Lifecycle Smoke (Linux) job that runs the smallest stable, fully hermetic subset of that suite (13 tests, ~17-18s bare pytest locally / 14.75s on hosted CI at the marker-refactor head, ~44s measured job wall time at the current head) as a PR-time gate, selected declaratively via a registered `lifecycle_smoke` pytest marker, and adds a self-guarding topology test so the wiring itself cannot silently drift.

> [!NOTE]
> Pure CI/test-topology + docs change. No src/apm_cli/** changes. The mutation pilot (#2241) stays nightly/manual -- not touched here.

## Problem (WHY)

- [x] ci-integration.yml, the only workflow that runs tests/integration/**, triggers **only** on merge_group -- a PR can revert a merged fix and every existing PR-time check stays green until the PR reaches the merge queue.
- [x] The repo already curates exactly this concept -- tests/quality/critical_suite.toml, a manifest of "Consume/Produce/Govern lifecycle contract" modules -- but the manifest has no CI-gating role today; it is referenced only by a taxonomy test and docs.
- [x] The direct regression coverage for #2226 (test_architecture_authorities.py::test_ado_lock_coordinates_have_single_owner) and #2240 (test_virtual_package_lifecycle_matrix.py) is hermetic and fast, but sits behind the same merge-queue-only gate as the 15-minute golden-scenario e2e suite.
- [!] Nothing enforces that a future edit to ci.yml or merge-gate.yml can't quietly drop this coverage once it exists -- addressed here with a mutation-tested topology guard, not just the tests themselves.
- [x] (Maintainer follow-up) An explicit file/node-id target list degrades silently: a dropped or renamed path just shrinks what runs, with no structural signal. A registered pytest marker makes "family emptied" a hard, loud failure -- pytest exit code 5 ("no tests collected") -- instead of a quiet no-op.
- [x] (Maintainer follow-up, post-#2249) `apm prune`'s merged-hook/sidecar reconciliation (closes #2245, PR #2249) is a real Consume-lifecycle regression class -- an orphaned package's hook entries silently surviving removal -- that the marker mechanism can now absorb with zero workflow edit, once #2249 merged.

## Approach (WHAT)

| # | Fix |
|---|-----|
| 1 | Add lifecycle-smoke job (Lifecycle Smoke (Linux)) to ci.yml: declarative `pytest --strict-markers -m lifecycle_smoke tests/integration`, timeout-minutes: 3, no secrets. |
| 2 | Add Lifecycle Smoke (Linux) to both branches of merge-gate.yml's EXPECTED_CHECKS ternary. |
| 3 | Register `lifecycle_smoke` in pyproject.toml's pytest markers list; mark the four lifecycle modules at module level, only the AC14 function in test_architecture_authorities.py, and (post-#2249) only the `[claude]` parametrization of the prune-hook reconciliation test. |
| 4 | Extend tests/quality/test_ci_topology.py with a positive guard + 11 mutation/negative tests proving the wiring itself is self-guarding, using semantic contracts (marker registered, command shape, non-empty collection) instead of an exact target-list equality check. |
| 5 | Update docs/.../integration-testing.md, CONTRIBUTING.md, and CHANGELOG.md. |

## Implementation (HOW)

- **.github/workflows/ci.yml** -- lifecycle-smoke job, placed after apm-self-check. Run step: `uv run --extra dev pytest -p no:cacheprovider -q --strict-markers -m lifecycle_smoke tests/integration`. The job's rationale comment now explains the marker mechanism, why these four modules, one function, and (post-#2249) one parametrized test case are marked, and the measured before/after timing. **This file required zero edit for the #2249 prune-hook promotion** -- confirmed via `git diff` showing no change to the lifecycle-smoke job section between the marker-refactor head and this head; the marker-driven command auto-picked up the newly-marked test.
- **pyproject.toml** -- registers `lifecycle_smoke` in `[tool.pytest.ini_options].markers`, the single existing canonical marker registry (no new manifest constant added).
- **Marked modules** -- `test_install_content_hash_roundtrip.py`, `test_policy_pinned_constraint_e2e.py`, `test_virtual_claude_skill_lock_convergence.py` (all component-marked in critical_suite.toml), and `test_virtual_package_lifecycle_matrix.py` (direct #2240 regression) all carry `pytest.mark.lifecycle_smoke` at module level (added to their existing `pytestmark` list). Only `test_architecture_authorities.py::test_ado_lock_coordinates_have_single_owner` (direct #2226 AC14 static guard) carries a function-level `@pytest.mark.lifecycle_smoke` decorator -- the file's other 32 tests remain unmarked, per the maintainer's explicit "do not mark unrelated tests" instruction. **Post-#2249:** `test_prune_hook_reconciliation_e2e.py::test_prune_removes_merged_hook_entries_and_sidecar` carries the mark scoped to only its `claude` parametrization, via `pytest.param("claude", marks=pytest.mark.lifecycle_smoke)` inside the existing `@pytest.mark.parametrize` decorator -- the sibling `[cursor]` parametrization and the file's other five tests remain unmarked.
- **.github/workflows/merge-gate.yml** -- unchanged from the prior round: Lifecycle Smoke (Linux) in EXPECTED_CHECKS for both the pull_request and merge_group branches.
- **tests/quality/test_ci_topology.py** -- replaced the exact-target-list assertion and its two target-based mutation tests with semantic contracts: marker registered (read from pyproject.toml's existing markers list via a new `_pytest_ini_markers()` helper -- not a new manifest), command uses `--strict-markers` + `-m lifecycle_smoke` + the bounded `tests/integration` root (token-level check on the exact invocation), job stays required and hermetic (unchanged assertions), and the marker family collects a non-empty set of tests right now (a real `--collect-only` subprocess check). Six new mutation tests prove each contract is load-bearing: dropped `-m` expression, wrong marker string, unbounded root, dropped `--strict-markers`, unregistered marker name, and an empty marker family (pytest exit 5). The four pre-existing hermeticity/required-check mutation tests (job-level env credential, `with:`-block credential, `github.token` alias, dropped from EXPECTED_CHECKS) are retained unchanged -- they remain valid regardless of the selection mechanism.
- **docs/.../integration-testing.md** -- Tier 3 section rewritten to describe marker-based selection (the "Location" bullet now names the marker, the "Selection mechanism" bullet explains the exit-5 empty-family behavior); added a `CI-selection` row to the marker-axes table naming `lifecycle_smoke` as a fourth, orthogonal axis.
- **CONTRIBUTING.md** -- contributor-facing CI-tier summary now names the `lifecycle_smoke` marker and the updated ~65-70s timing.
- **CHANGELOG.md** -- Unreleased entry updated to mention the marker-based selection and the updated timing.

## Diagrams

Legend: PR-time critical path today ends at merge-gate's existing four checks; Lifecycle Smoke (dashed = new) joins that gate, while the 4-way integration shard and the rest of ci-integration.yml remain merge-queue-only. (Unchanged from the prior round -- this refactor only changed *how* the job selects its tests, not its position in the topology.)

```mermaid
flowchart LR
    subgraph PRTime["PR-time required checks (ci.yml)"]
        S1[Build and Test Shard 1]
        S2[Build and Test Shard 2]
        ASC[APM Self-Check]
        NDC[NOTICE Drift Check]
        LS["Lifecycle Smoke<br/>(-m lifecycle_smoke)"]:::new
    end
    subgraph MergeQueue["merge_group only (ci-integration.yml)"]
        BLD[Build Linux]
        SMK[Smoke Test]
        INT[Integration Tests 4-way shard]
        REL[Release Validation]
    end
    PR[Pull request opened] --> S1
    PR --> S2
    PR --> ASC
    PR --> NDC
    PR --> LS
    S1 --> GATE[merge-gate EXPECTED_CHECKS]
    S2 --> GATE
    ASC --> GATE
    NDC --> GATE
    LS --> GATE
    GATE -->|queued| BLD --> SMK --> INT --> REL
    classDef new stroke-dasharray: 5 5;
    class LS new;
```

## Trade-offs

- **Marker-based selection, superseding the prior explicit-path-list trade-off.** A maintainer follow-up asked for a registered `@pytest.mark.lifecycle_smoke` marker instead of the initial explicit-path-list design, so that an emptied family fails loudly (pytest exit 5) rather than a path list silently shrinking. This is the design this PR now ships.
- **Marker-based collection scans all of `tests/integration/` (299 files) to resolve `-m lifecycle_smoke`, not five explicit paths.** Measured overhead: local bare-pytest time went from ~16-19s (explicit paths) to ~18-19.5s (marker, after the noise settled across 8 total repeated runs); the real hosted-CI run measured pytest at 14.75s and the full job at 31s wall time -- both comfortably inside the 60-90s target and the 3-minute hard ceiling.
- **#2238 deliberately not duplicated here.** Its regression coverage is unit-level and already required via the existing shards.
- **4th and 5th targets stay outside critical_suite.toml; the 6th (prune-hook) does too.** All three carry only `pytest.mark.integration`/`pytest.mark.lifecycle_smoke`, not a taxonomy behavioral marker, so no manifest edit was needed for any of them -- keeping this PR the sole owner of critical-suite/taxonomy/workflow-promotion surfaces.
- **test_architecture_authorities.py's other 32 tests excluded/unmarked.** Four of them shell out to a subprocess pytest run (~30s each); including them would roughly double the job's wall time for no additional regression coverage relevant to this PR.
- **No ci-integration.yml changes.** The 4-way integration shard keeps its full scope and no `-m` filter, so all `lifecycle_smoke`-marked tests continue to run there unaffected; some overlap with the new PR-time job is expected and fine.
- **No new manifest/target-list constant.** `_pytest_ini_markers()` reads pyproject.toml's pre-existing, already-canonical `[tool.pytest.ini_options].markers` list -- not a parallel list of file paths.

## Benefits

1. A PR that reverts the #2226 or #2240 fix now fails at PR time (proven below, re-verified against the final marker-based mechanism), not after reaching the merge queue.
2. Zero new flake/cost surface: hermetic, no network, no credentials, no built binary -- ~31s measured total job wall time on real hosted CI (well inside the 60-90s target).
3. CI wiring itself is now regression-tested with semantic, not exact-target, contracts: test_ci_topology.py fails if the marker is unregistered, the command's shape drifts (missing `--strict-markers`, wrong `-m` expression, unbounded root), the job's timeout/required-check membership drifts, or the marker family becomes empty -- 12 tests (1 positive + 11 mutation) total, up from 8. These assertions are count-agnostic by design, so growing the marker family from 12 to 13 tests (the #2249 prune-hook promotion) required zero change to this file.
4. The empty-family failure mode is structural, not a maintained assertion: if every `lifecycle_smoke` mark were ever accidentally stripped, pytest itself exits code 5 ("no tests collected") and the required job goes red -- no bespoke check has to remember to catch that case.

## Validation

actionlint on both changed workflows: clean, no output (re-verified at final head).

Canonical lint mirror (re-verified at final head 954b56383d): ruff check (All checks passed!), ruff format --check (clean), pylint R0801 (10.00/10), lint-auth-signals.sh (clean), lint-architecture-boundaries.sh (all 14 AC guards clean, including AC14).

<details><summary>Timing: before (explicit paths) vs marker refactor vs prune-hook promotion (12 -> 13 tests) -- local + real hosted CI</summary>

```
BEFORE (explicit 5-target list, local, 3 repeats):
  run 1: 12 passed, pytest 16.16s, real 16.67s
  run 2: 12 passed, pytest 18.40s, real 19.01s
  run 3: 12 passed, pytest 17.02s, real 17.31s

MARKER REFACTOR (marker-based -m lifecycle_smoke tests/integration, local, 8 total repeats):
  runs 1-5 (initial):  pytest 17.67s-24.73s, real 18.88s-27.03s (one noisy outlier)
  runs 6-8 (re-check): pytest 17.73s-18.42s, real 19.44s-19.55s (settled/stable)

MARKER REFACTOR, real hosted GitHub Actions CI at head 954b56383d:
  pytest-reported: "12 passed, 10613 deselected in 14.75s"
  Lifecycle Smoke (Linux) job total wall time: 31s

PRUNE-HOOK PROMOTION (13 tests, after merging origin/main + #2249, local, 3 repeats):
  run 1: 13 passed, 17.90s
  run 2: 13 passed, 16.58s
  run 3: 13 passed, 16.52s

PRUNE-HOOK PROMOTION, real hosted GitHub Actions CI at final head 0b7bd060c0:
  Lifecycle Smoke (Linux) job total wall time: 44s
```

Net effect: adding the 13th test (prune-hook `[claude]`) did not measurably change local bare-pytest wall time (16.5-17.9s, within the same noise band as the 12-test 17.7-18.4s settled baseline) since the added test's own execution cost is small relative to marker-scan overhead already paid for scanning `tests/integration/`. The hosted job's total wall time (44s, including checkout/setup-python/setup-uv/uv sync/pytest) remains well inside the 60-90s target and the 3-minute (`timeout-minutes: 3`) hard ceiling, with no ceiling change needed.

</details>

<details><summary>Marker/target parity proof (marker refactor) + additive-promotion proof (prune-hook)</summary>

`pytest --collect-only -m lifecycle_smoke tests/integration` collected the exact same 12 test IDs as the prior explicit 5-path/node-id list at the marker-refactor head -- confirmed via a direct diff of collected test IDs before removing the old invocation.

Post-#2249, the same collect-only command now returns exactly 13 IDs: the prior 12 plus `test_prune_hook_reconciliation_e2e.py::test_prune_removes_merged_hook_entries_and_sidecar[claude]`. The sibling `[cursor]` parametrization is confirmed absent from the collected set -- verified with a scoped collect-only run against just that file (`1/7 tests collected (6 deselected)`, the 1 being exactly `[claude]`).

</details>

<details><summary>Empty-family failure proof (the marker's core design requirement, unaffected by the prune-hook promotion)</summary>

```
$ uv run --extra dev pytest -p no:cacheprovider -q --strict-markers \
    -m 'lifecycle_smoke and nonexistent_marker_xyz_never_registered' tests/integration
10625 deselected in 4.20s
$ echo $?
5
```

Exit code 5 ("no tests collected") is pytest's own structural signal -- if every `@pytest.mark.lifecycle_smoke` were ever stripped, the required CI job goes red without any bespoke assertion having to detect it. `--strict-markers` does not validate `-m` expression tokens (it only rejects unregistered markers used as `@pytest.mark.xxx` decorators at collection time); a nonexistent name inside a `-m` filter is legal syntax that simply matches zero tests, which is exactly the mechanism this proof and the corresponding `test_lifecycle_smoke_marker_family_empty_fails` mutation test rely on.

</details>

<details><summary>Full topology + taxonomy + architecture-authorities suite (67 passed, unaffected by the prune-hook promotion since these are semantic/count-agnostic contracts)</summary>

```
67 passed in 203.95s (0:03:23)
```

(tests/quality/test_ci_topology.py + tests/quality/test_test_taxonomy.py + tests/integration/test_architecture_authorities.py -- none of it is on the required PR-time critical path. No topology assertion needed updating for the prune-hook promotion: the guard's contracts are marker-registration/command-shape/non-empty-collection checks, not an exact test count.)

</details>

<details><summary>Failure-injection proof: the gate fails if the load-bearing fix is reverted/inverted (re-run against the final marker-based mechanism, including a new #2249 proof, then fully restored)</summary>

**#2240** -- reverted src/apm_cli/commands/update.py to its pre-fix (77953cc99f) content, ran the exact final `-m lifecycle_smoke` command:

```
FAILED tests/integration/test_virtual_package_lifecycle_matrix.py::test_virtual_package_lifecycle_matrix[content-drift-pinned-virtual-file]
AssertionError: assert 'Restored dependency cache without changing refs.' in '...[+] All dependencies already at their latest matching refs.\n'
1 failed, 11 passed, 10613 deselected in 17.82s
```

**#2226** -- reverted lockfile.py to pre-fix (796e229805) content, ran the exact final `-m lifecycle_smoke` command scoped to the AC14 file:

```
FAILED tests/integration/test_architecture_authorities.py::test_ado_lock_coordinates_have_single_owner
AssertionError: assert 'with_derived_provider_coordinates' in '...def to_dependency_ref(self) -> DependencyReference: ...'
1 failed, 36 deselected in 0.54s
```

**#2249 (new)** -- reverted prune.py, hook_integrator.py, uninstall/engine.py, and apm_package.py to their pre-#2249 content (`git apply -R` of the PR's own production-code diff), ran the exact final `-m lifecycle_smoke` command:

```
FAILED tests/integration/test_prune_hook_reconciliation_e2e.py::test_prune_removes_merged_hook_entries_and_sidecar[claude]
AssertionError: pkg-a's merged hook entry must be reconciled out of .claude/apm-hooks.json
assert 'pkg-a' not in {'pkg-a'}
1 failed, 12 passed, 10619 deselected in 26.55s
```

All three reverts restored to HEAD immediately after; `git status --short` confirmed a clean tree each time, and the full 13-test suite re-passed afterward.

</details>


### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|------------------------|--------------|--------------------|------|
| 1 | A PR that reintroduces the #2226 ADO lock-coordinate bug (persisting provider-specific fields instead of deriving them) fails CI before it can be merged | Governed by policy, Secure by default | tests/integration/test_architecture_authorities.py::test_ado_lock_coordinates_have_single_owner (`@pytest.mark.lifecycle_smoke`, regression-trap for #2226) | integration |
| 2 | A PR that reintroduces the #2240 virtual/manifestless lifecycle-drift bug (dependency cache not repaired without changing refs) fails CI before it can be merged | Governed by policy | tests/integration/test_virtual_package_lifecycle_matrix.py (module `pytestmark` includes `lifecycle_smoke`, regression-trap for #2240) | integration |
| 3 | Install content-hash roundtrip, policy pinned-constraint enforcement, and virtual-skill lock convergence -- the curated component-marked lifecycle contracts -- are enforced pre-merge, not only once a PR reaches the merge queue | Governed by policy, DevX | tests/integration/test_install_content_hash_roundtrip.py, tests/integration/test_policy_pinned_constraint_e2e.py, tests/integration/test_virtual_claude_skill_lock_convergence.py (all `lifecycle_smoke`-marked) | integration |
| 4 | The Lifecycle Smoke job's marker registration, command shape (`--strict-markers`/`-m lifecycle_smoke`/bounded root), timeout, required-check membership, and non-empty collection cannot silently drift without a test noticing -- including job-level env, `with:`-block, `github.token`-alias credential injection, and an emptied marker family | Governed by policy, Secure by default, OSS / community-driven | tests/quality/test_ci_topology.py::test_lifecycle_smoke_is_required_and_hermetic + 11 mutation tests | unit |
| 5 | A PR that reintroduces the #2249 prune-hook bug (orphaned package removal leaving merged hook entries and ownership sidecars behind) fails CI before it can be merged -- scoped to exactly the `claude` target, not the `cursor` sibling | Governed by policy, Secure by default | tests/integration/test_prune_hook_reconciliation_e2e.py::test_prune_removes_merged_hook_entries_and_sidecar[claude] (`pytest.param(..., marks=pytest.mark.lifecycle_smoke)`, regression-trap for #2249) | integration |

## How to test

- [ ] Open this PR against main and confirm Lifecycle Smoke (Linux) appears as a new required check alongside the existing Windows Compatibility Gate and the rest of the PR-time gates.
- [ ] `git log --oneline origin/main..HEAD` -> 6 commits ahead of the current main tip, 13 files changed (adds a merge commit for origin/main plus the prune-hook promotion commit: test marker addition, CHANGELOG, and docs).
- [ ] `uv run --extra dev pytest -p no:cacheprovider -q --strict-markers -m lifecycle_smoke tests/integration` -> 13 passed.
- [ ] `uv run --extra dev pytest -p no:cacheprovider -q tests/quality/test_ci_topology.py tests/quality/test_test_taxonomy.py` -> 30 passed (unaffected by the prune-hook promotion).
- [ ] Confirm the job actually runs and passes on the PR's own CI run (already verified: 44s, pass, at final head 0b7bd060c0).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

