### PR TITLE
fix(prune): reconcile merged hook ownership after package removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm prune` now reconciles merged hook ownership when it removes an
+  orphaned package: entries it contributed to `.claude/settings.json`,
+  `.cursor/hooks.json`, and similar merge targets, plus their
+  `apm-hooks.json` ownership sidecars, are cleared while sibling packages'
+  and manually authored entries are preserved. (closes #2245)
 - `apm update` now automatically repairs a locked dependency whose
   materialized `apm_modules` cache is wholly absent -- including local
   filesystem dependencies -- without prompting for ref-change consent or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `apm prune` now reconciles merged hook ownership when it removes an
-  orphaned package: entries it contributed to `.claude/settings.json`,
-  `.cursor/hooks.json`, and similar merge targets, plus their
-  `apm-hooks.json` ownership sidecars, are cleared while sibling packages'
+- `apm prune` no longer leaves stale, executable hook entries behind for a
+  removed package: it now reconciles merged hook ownership when it removes
+  an orphaned package, clearing entries it contributed to
+  `.claude/settings.json`, `.cursor/hooks.json`, and similar merge targets
+  (plus their `apm-hooks.json` ownership sidecars), while sibling packages'
   and manually authored entries are preserved. (closes #2245)
 - `apm update` now automatically repairs a locked dependency whose
   materialized `apm_modules` cache is wholly absent -- including local

--- a/docs/src/content/docs/consumer/manage-dependencies.md
+++ b/docs/src/content/docs/consumer/manage-dependencies.md
@@ -307,9 +307,11 @@ apm prune             # delete orphaned packages from apm_modules/
 ```
 
 `apm prune` removes any directory in `apm_modules/` that no longer
-corresponds to a declared dependency. It does not touch your manifest,
-your lockfile entries are rewritten on the next `apm install`, and
-deployed files in `.github/`, `.claude/`, etc. are reconciled then too.
+corresponds to a declared dependency. It does not touch your manifest.
+Lockfile entries, deployed harness files (`.github/`, `.claude/`, etc.),
+and merged hook configuration owned by the pruned package are all
+reconciled immediately by `apm prune` itself -- no follow-up
+`apm install` is required.
 
 If you also want to refresh remaining deps to their latest versions or refs, see
 [Update and refresh](../update-and-refresh/).

--- a/docs/src/content/docs/reference/cli/prune.md
+++ b/docs/src/content/docs/reference/cli/prune.md
@@ -84,6 +84,10 @@ entries owned by a pruned package are removed, while entries owned by
 packages that remain declared -- and any manually authored entries -- are
 preserved and rewritten back. This orchestrates the same ownership-aware
 cleanup `apm uninstall` uses; it does not duplicate the filtering logic.
+Hook reconciliation is best-effort: a failure is logged as a warning but
+does not abort the run, since package and lockfile cleanup has already
+completed by that point. If reconciliation logs a warning, run `apm
+install` to rebuild hook configuration from the current dependency set.
 
 Notes:
 
@@ -105,6 +109,7 @@ Per-package removal failures are logged but do not abort the run; remaining orph
 ## Related
 
 - [`apm install`](../install/) -- install declared dependencies
+- [`apm uninstall`](../uninstall/) -- remove a declared dependency (shares this command's hook-reconciliation owner)
 - [`apm list`](../list/) -- inspect what is installed
 - [Lockfile spec](../../lockfile-spec/) -- `deployed_files` schema
 - [Package anatomy](../../../concepts/package-anatomy/) -- what gets deployed where

--- a/docs/src/content/docs/reference/cli/prune.md
+++ b/docs/src/content/docs/reference/cli/prune.md
@@ -77,6 +77,14 @@ For each orphaned package, `apm prune`:
 4. Cleans up empty parent directories under both `apm_modules/` and the harness deploy roots.
 5. Deletes `apm.lock.yaml` if pruning leaves it with zero dependencies.
 
+After processing all orphaned packages, `apm prune` also reconciles merged
+hook configuration (`.claude/settings.json`, `.cursor/hooks.json`, and
+similar merge targets, plus their `apm-hooks.json` ownership sidecars):
+entries owned by a pruned package are removed, while entries owned by
+packages that remain declared -- and any manually authored entries -- are
+preserved and rewritten back. This orchestrates the same ownership-aware
+cleanup `apm uninstall` uses; it does not duplicate the filtering logic.
+
 Notes:
 
 - Packages that share an install root with a still-declared sibling subdirectory dependency are not falsely protected by ancestor expansion. The check uses lockfile membership (with `apm.yml` fallback) to identify genuine standalone packages.

--- a/src/apm_cli/commands/prune.py
+++ b/src/apm_cli/commands/prune.py
@@ -165,12 +165,28 @@ def prune(ctx, dry_run):
             # apm.yml is not mutated by prune (orphaned packages are, by
             # definition, already absent from it), so the manifest parsed
             # at the top of this command still reflects the desired state.
+            #
+            # Best-effort: package/lockfile pruning has already committed
+            # by this point, so a reconciliation failure is a warning
+            # (not an error) -- it does not roll back or fail the command.
             try:
                 from ..integration.hook_integrator import HookIntegrator
 
-                HookIntegrator().reconcile_after_removal(apm_package, project_root)
+                hook_stats = HookIntegrator().reconcile_after_removal(apm_package, project_root)
+                hook_errors = hook_stats.get("errors", 0)
+                if hook_errors:
+                    logger.warning(
+                        f"Hook reconciliation incomplete for {hook_errors} "
+                        "dependency(ies) -- some hook entries may be stale. "
+                        "Run 'apm install' to rebuild hook configuration."
+                    )
+                else:
+                    logger.progress("+ Reconciled merged hook ownership for pruned package(s)")
             except Exception as e:
-                logger.error(f"Failed to reconcile hook integrations: {e}")
+                logger.warning(
+                    f"Hook reconciliation failed: {e}. Some hook entries may be "
+                    "stale -- run 'apm install' to rebuild hook configuration."
+                )
 
         # Final summary
         if removed_count > 0:

--- a/src/apm_cli/commands/prune.py
+++ b/src/apm_cli/commands/prune.py
@@ -157,6 +157,21 @@ def prune(ctx, dry_run):
                 except Exception:
                     pass
 
+            # Reconcile merged-hook ownership (settings.json / hooks.json
+            # entries and their apm-hooks.json sidecars) for the packages
+            # just pruned. This delegates to the same canonical
+            # clear-then-rebuild owner `apm uninstall` already uses --
+            # prune must not reimplement hook-entry filtering itself.
+            # apm.yml is not mutated by prune (orphaned packages are, by
+            # definition, already absent from it), so the manifest parsed
+            # at the top of this command still reflects the desired state.
+            try:
+                from ..integration.hook_integrator import HookIntegrator
+
+                HookIntegrator().reconcile_after_removal(apm_package, project_root)
+            except Exception as e:
+                logger.error(f"Failed to reconcile hook integrations: {e}")
+
         # Final summary
         if removed_count > 0:
             logger.success(f"Pruned {removed_count} orphaned package(s)")

--- a/src/apm_cli/commands/uninstall/engine.py
+++ b/src/apm_cli/commands/uninstall/engine.py
@@ -484,7 +484,7 @@ def _sync_integrations_after_uninstall(
     from ...integration.base_integrator import BaseIntegrator
     from ...integration.dispatch import get_dispatch_table
     from ...integration.targets import resolve_targets
-    from ...models.apm_package import PackageInfo, validate_apm_package
+    from ...models.apm_package import build_installed_package_info
     from ...primitives.discovery import clear_discovery_cache
 
     # Phase 2 re-integration walks the on-disk primitive set after Phase 1
@@ -654,20 +654,9 @@ def _sync_integrations_after_uninstall(
         dep_ref = dep if hasattr(dep, "repo_url") else None
         if not dep_ref:
             continue
-        install_path = dep_ref.get_install_path(Path(APM_MODULES_DIR))
-        if not install_path.exists():
+        pkg_info = build_installed_package_info(dep_ref, Path(APM_MODULES_DIR))
+        if pkg_info is None:
             continue
-
-        result = validate_apm_package(install_path)
-        pkg = result.package if result and result.package else None
-        if not pkg:
-            continue
-        pkg_info = PackageInfo(
-            package=pkg,
-            install_path=install_path,
-            dependency_ref=dep_ref,
-            package_type=result.package_type if result else None,
-        )
         dep_key = dep_ref.get_unique_key()
         deployed_files = package_deployed_files.setdefault(dep_key, [])
 

--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -1943,6 +1943,71 @@ class HookIntegrator(BaseIntegrator):
 
         return stats
 
+    def reconcile_after_removal(
+        self,
+        apm_package,
+        project_root: Path,
+        *,
+        user_scope: bool = False,
+    ) -> dict:
+        """Reconcile merged-hook ownership after packages leave apm.yml.
+
+        ``_clean_apm_entries_from_json`` (invoked by ``sync_integration``)
+        strips *every* ``_apm_source``-tagged entry from a merge target's
+        JSON file and deletes its ownership sidecar unconditionally -- it
+        has no notion of "this package only". A caller that wants to drop
+        one package's hooks therefore cannot call ``sync_integration``
+        alone without also erasing entries owned by packages that remain
+        declared: it must wipe, then rebuild from what is still installed.
+
+        This mirrors the "clear + rebuild" pattern
+        ``apm uninstall`` already uses (see
+        ``_sync_integrations_after_uninstall`` in
+        ``commands/uninstall/engine.py``), scoped to hooks only, so
+        callers such as ``apm prune`` orchestrate the existing
+        ownership-aware cleanup instead of reimplementing hook filtering.
+
+        Uses ``get_all_apm_dependencies()`` (prod + dev) rather than
+        uninstall's prod-only dependency set, matching ``apm prune``'s
+        own orphan-detection scope (prune already treats dev deps as
+        first-class for removal purposes).
+
+        Best-effort by design: a re-integration failure for one
+        dependency is logged and skipped rather than aborting the
+        reconcile, consistent with prune's existing per-package
+        error-tolerant semantics.
+        """
+        from apm_cli.constants import APM_MODULES_DIR
+        from apm_cli.models.apm_package import build_installed_package_info
+
+        from .targets import resolve_targets
+
+        stats = self.sync_integration(apm_package, project_root, managed_files=set())
+
+        config_target = list(apm_package.canonical_targets)
+        targets = resolve_targets(
+            project_root, user_scope=user_scope, explicit_target=config_target or None
+        )
+
+        for dep_ref in apm_package.get_all_apm_dependencies():
+            pkg_info = build_installed_package_info(dep_ref, project_root / APM_MODULES_DIR)
+            if pkg_info is None:
+                continue
+
+            try:
+                for target in targets:
+                    self.integrate_hooks_for_target(
+                        target, pkg_info, project_root, user_scope=user_scope
+                    )
+            except Exception as e:
+                stats["errors"] = stats.get("errors", 0) + 1
+                pkg_id = (
+                    dep_ref.get_identity() if hasattr(dep_ref, "get_identity") else str(dep_ref)
+                )
+                _log.warning("Best-effort hook re-integration skipped for %s: %s", pkg_id, e)
+
+        return stats
+
     @staticmethod
     def _clean_apm_entries_from_json(
         json_path: Path,

--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -1976,20 +1976,41 @@ class HookIntegrator(BaseIntegrator):
         dependency is logged and skipped rather than aborting the
         reconcile, consistent with prune's existing per-package
         error-tolerant semantics.
+
+        Known boundary (shared with uninstall, tracked in #2250):
+        rebuilds only direct dependencies from ``get_all_apm_dependencies()``
+        -- a transitive dependency's merged hooks are wiped by the clear
+        phase above but never re-integrated here.
         """
         from apm_cli.constants import APM_MODULES_DIR
         from apm_cli.models.apm_package import build_installed_package_info
 
         from .targets import resolve_targets
 
-        stats = self.sync_integration(apm_package, project_root, managed_files=set())
-
+        # Resolve targets and materialize the dependency list BEFORE the
+        # destructive wipe below. If either raises (malformed target
+        # config, bad dependency data), we abort with nothing written
+        # instead of committing a wipe we can never rebuild from -- a
+        # zero-hook window for every still-declared package would
+        # otherwise persist until the next `apm install`.
         config_target = list(apm_package.canonical_targets)
         targets = resolve_targets(
             project_root, user_scope=user_scope, explicit_target=config_target or None
         )
+        surviving_deps = list(apm_package.get_all_apm_dependencies())
 
-        for dep_ref in apm_package.get_all_apm_dependencies():
+        # Empty managed_files (not None) skips file-level deletion while
+        # still triggering the unconditional wipe of every _apm_source
+        # entry (and its ownership sidecar) across all KNOWN_TARGETS --
+        # see _clean_apm_entries_from_json. The narrower `targets` list
+        # resolved above is deliberately NOT passed here: doing so would
+        # make prune's wipe scope diverge from uninstall's identical
+        # call (both currently wipe all KNOWN_TARGETS by omitting
+        # targets=); that divergence is tracked as a shared-primitive
+        # fix in #2250, evaluated against all three callers together.
+        stats = self.sync_integration(apm_package, project_root, managed_files=set())
+
+        for dep_ref in surviving_deps:
             pkg_info = build_installed_package_info(dep_ref, project_root / APM_MODULES_DIR)
             if pkg_info is None:
                 continue

--- a/src/apm_cli/models/apm_package.py
+++ b/src/apm_cli/models/apm_package.py
@@ -776,7 +776,7 @@ class PackageInfo:
 
 def build_installed_package_info(
     dep_ref: DependencyReference, apm_modules_dir: Path
-) -> "PackageInfo | None":
+) -> PackageInfo | None:
     """Build a ``PackageInfo`` for a dependency that is still installed on disk.
 
     Shared by callers that re-integrate primitives from remaining

--- a/src/apm_cli/models/apm_package.py
+++ b/src/apm_cli/models/apm_package.py
@@ -772,3 +772,33 @@ class PackageInfo:
             return True
 
         return False
+
+
+def build_installed_package_info(
+    dep_ref: DependencyReference, apm_modules_dir: Path
+) -> "PackageInfo | None":
+    """Build a ``PackageInfo`` for a dependency that is still installed on disk.
+
+    Shared by callers that re-integrate primitives from remaining
+    dependencies after some other package is removed -- e.g. ``apm
+    uninstall``'s post-removal re-sync and ``apm prune``'s hook
+    reconciliation (see ``HookIntegrator.reconcile_after_removal``).
+    Returns ``None`` when the dependency's install directory is missing
+    or fails manifest validation, so callers can skip it rather than
+    fail the broader re-integration pass.
+    """
+    install_path = dep_ref.get_install_path(apm_modules_dir)
+    if not install_path.exists():
+        return None
+
+    result = validate_apm_package(install_path)
+    package = result.package if result and result.package else None
+    if not package:
+        return None
+
+    return PackageInfo(
+        package=package,
+        install_path=install_path,
+        dependency_ref=dep_ref,
+        package_type=result.package_type if result else None,
+    )

--- a/tests/integration/test_prune_hook_reconciliation_e2e.py
+++ b/tests/integration/test_prune_hook_reconciliation_e2e.py
@@ -1,0 +1,434 @@
+"""Hermetic E2E coverage for #2245: prune must reconcile merged hook ownership.
+
+``apm prune`` removes orphaned package directories and their lockfile
+``deployed_files``, but historically never touched merged-hook JSON files
+(``.claude/settings.json``, ``.cursor/hooks.json``) or their
+``apm-hooks.json`` ownership sidecars. This left dead ``_apm_source``
+entries behind after a package was dropped from ``apm.yml`` and pruned,
+so harnesses like Claude Code kept firing hooks that pointed at deleted
+scripts.
+
+``apm uninstall`` already solves this correctly via
+``HookIntegrator.sync_integration()`` + a full re-integration pass over
+whatever remains declared and installed (see
+``_sync_integrations_after_uninstall`` in
+``commands/uninstall/engine.py``). These tests drive the REAL ``apm
+install`` and ``apm prune`` CLI commands end-to-end (Click ``CliRunner``,
+no internals called directly) and stub only the network download seam
+(``GitHubPackageDownloader.download_package``), matching the hermetic
+pattern already used by
+``tests/integration/test_install_content_hash_roundtrip.py`` and
+``tests/integration/test_frozen_host_qualified_git_e2e.py``.
+
+Matrix coverage is intentionally bounded to two merge targets (Claude,
+Cursor) rather than every harness in ``_MERGE_HOOK_TARGETS`` -- both use
+the same schema-strict sidecar-ownership code path, so a third harness
+would not exercise new code, only repeat the assertions.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from apm_cli.cli import cli
+from apm_cli.deps.github_downloader import GitHubPackageDownloader
+from apm_cli.models.apm_package import (
+    APMPackage,
+    GitReferenceType,
+    PackageInfo,
+    ResolvedReference,
+    clear_apm_yml_cache,
+)
+from apm_cli.models.dependency.reference import DependencyReference
+
+pytestmark = [pytest.mark.integration]
+
+_PATCH_UPDATES = "apm_cli.commands._helpers.check_for_updates"
+
+# Per-merge-target on-disk layout: config file + its ownership sidecar.
+# Both targets are schema-strict (ownership lives only in the sidecar,
+# never inline in the native file) -- see hook_integrator._MERGE_HOOK_TARGETS.
+_TARGET_LAYOUT = {
+    "claude": (".claude/settings.json", ".claude/apm-hooks.json"),
+    "cursor": (".cursor/hooks.json", ".cursor/apm-hooks.json"),
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_package_cache() -> None:
+    clear_apm_yml_cache()
+    yield
+    clear_apm_yml_cache()
+
+
+def _stub_download_package(hook_commands: dict[str, str]):
+    """Build a ``download_package`` stub that materializes a hooked fixture package.
+
+    *hook_commands* maps a dependency's ``repo_url`` (e.g. ``"acme/pkg-a"``)
+    to the shell command its lone ``PreToolUse`` hook should run. Packages
+    with no entry in the map are still materialized but ship no hooks --
+    used to prove prune's *own* package/script removal still works
+    unconditionally.
+    """
+
+    def _download(
+        _self: GitHubPackageDownloader,
+        repo_ref: object,
+        install_path: Path,
+        *_args: object,
+        **_kwargs: object,
+    ) -> PackageInfo:
+        dep_ref = (
+            repo_ref
+            if isinstance(repo_ref, DependencyReference)
+            else DependencyReference.parse(str(repo_ref))
+        )
+        install_path = Path(install_path)
+        install_path.mkdir(parents=True, exist_ok=True)
+        pkg_name = dep_ref.repo_url.rsplit("/", maxsplit=1)[-1]
+        (install_path / "apm.yml").write_text(
+            yaml.safe_dump(
+                {
+                    "name": pkg_name,
+                    "version": "1.0.0",
+                    "description": f"Hermetic prune-reconciliation fixture: {pkg_name}",
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+        command = hook_commands.get(dep_ref.repo_url)
+        if command is not None:
+            hooks_dir = install_path / ".apm" / "hooks"
+            hooks_dir.mkdir(parents=True, exist_ok=True)
+            (hooks_dir / "pre.json").write_text(
+                json.dumps(
+                    {
+                        "hooks": {
+                            "PreToolUse": [
+                                {
+                                    "matcher": "Bash",
+                                    "hooks": [{"type": "command", "command": command}],
+                                }
+                            ]
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+        package = APMPackage.from_apm_yml(install_path / "apm.yml")
+        return PackageInfo(
+            package=package,
+            install_path=install_path,
+            installed_at=datetime.now().isoformat(),
+            dependency_ref=dep_ref,
+            resolved_reference=ResolvedReference(
+                original_ref="main",
+                ref_type=GitReferenceType.BRANCH,
+                resolved_commit=None,
+                ref_name="main",
+            ),
+        )
+
+    return _download
+
+
+def _write_project(project: Path, dep_repo_urls: list[str], targets: list[str]) -> None:
+    project.mkdir(parents=True, exist_ok=True)
+    (project / "apm.yml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "prune-hook-reconciliation-consumer",
+                "version": "1.0.0",
+                "targets": targets,
+                "dependencies": {"apm": dep_repo_urls},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _remove_dependency(project: Path, repo_url: str) -> None:
+    """Drop *repo_url* from apm.yml's declared deps, keeping any siblings."""
+    manifest_path = project / "apm.yml"
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    deps = manifest.get("dependencies", {}).get("apm", [])
+    manifest["dependencies"]["apm"] = [d for d in deps if d != repo_url]
+    manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
+    clear_apm_yml_cache()
+
+
+def _run_cli(project: Path, monkeypatch: pytest.MonkeyPatch, args: list[str]) -> object:
+    monkeypatch.chdir(project)
+    with patch(_PATCH_UPDATES, return_value=None):
+        return CliRunner().invoke(cli, args, catch_exceptions=False)
+
+
+def _run_install(
+    project: Path, monkeypatch: pytest.MonkeyPatch, hook_commands: dict[str, str]
+) -> object:
+    with patch.object(
+        GitHubPackageDownloader,
+        "download_package",
+        autospec=True,
+        side_effect=_stub_download_package(hook_commands),
+    ):
+        return _run_cli(project, monkeypatch, ["install", "--no-policy"])
+
+
+def _run_prune(project: Path, monkeypatch: pytest.MonkeyPatch, *, dry_run: bool = False) -> object:
+    args = ["prune", "--dry-run"] if dry_run else ["prune"]
+    return _run_cli(project, monkeypatch, args)
+
+
+def _read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _sidecar_sources(sidecar_path: Path) -> set[str]:
+    """Every _apm_source marker recorded anywhere in the sidecar file."""
+    if not sidecar_path.exists():
+        return set()
+    data = _read_json(sidecar_path)
+    sources: set[str] = set()
+    for entries in data.values():
+        if isinstance(entries, list):
+            for entry in entries:
+                if isinstance(entry, dict) and entry.get("_apm_source"):
+                    sources.add(entry["_apm_source"])
+    return sources
+
+
+def _pre_tool_use_commands(settings_path: Path) -> list[str]:
+    if not settings_path.exists():
+        return []
+    data = _read_json(settings_path)
+    entries = data.get("hooks", {}).get("PreToolUse", [])
+    commands = []
+    for entry in entries:
+        for handler in entry.get("hooks", []):
+            if isinstance(handler, dict) and "command" in handler:
+                commands.append(handler["command"])
+    return commands
+
+
+@pytest.mark.parametrize("target", ["claude", "cursor"], ids=["claude", "cursor"])
+def test_prune_removes_merged_hook_entries_and_sidecar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, target: str
+) -> None:
+    """RED (pre-fix): prune left merged hook entries + sidecar markers behind.
+
+    GREEN (post-fix): pruning an orphaned package's directory and lockfile
+    entry also reconciles the merged hook config and its ownership sidecar
+    for the target the project declares.
+    """
+    settings_rel, sidecar_rel = _TARGET_LAYOUT[target]
+    project = tmp_path / f"proj-{target}"
+    _write_project(project, ["acme/pkg-a"], [target])
+
+    install_result = _run_install(project, monkeypatch, {"acme/pkg-a": "./scripts/pkg-a-hook.sh"})
+    assert install_result.exit_code == 0, install_result.output
+
+    package_dir = project / "apm_modules" / "acme" / "pkg-a"
+    assert package_dir.is_dir(), "precondition: package installed"
+    settings_path = project / settings_rel
+    sidecar_path = project / sidecar_rel
+    assert "pkg-a" in _sidecar_sources(sidecar_path), (
+        f"precondition: pkg-a hook entry merged into {sidecar_rel}"
+    )
+
+    _remove_dependency(project, "acme/pkg-a")
+    prune_result = _run_prune(project, monkeypatch)
+    assert prune_result.exit_code == 0, prune_result.output
+
+    assert not package_dir.exists(), "orphaned package directory must be removed"
+    assert "pkg-a" not in _sidecar_sources(sidecar_path), (
+        f"pkg-a's merged hook entry must be reconciled out of {sidecar_rel}"
+    )
+    assert "./scripts/pkg-a-hook.sh" not in _pre_tool_use_commands(settings_path), (
+        f"pkg-a's dead hook command must no longer appear in {settings_rel}"
+    )
+
+
+def test_prune_preserves_sibling_hooks_and_manual_entries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Negative twin: reconciliation must be scoped, not a blind wipe.
+
+    ``_clean_apm_entries_from_json`` strips every ``_apm_source``-tagged
+    entry unconditionally and deletes the whole sidecar. A naive prune ->
+    sync_integration() call would therefore also erase the still-declared
+    sibling package's hooks and would not distinguish package-owned
+    entries from a user's own manual hook -- both would be regressions.
+    """
+    project = tmp_path / "proj-siblings"
+    _write_project(project, ["acme/pkg-a", "acme/pkg-b"], ["claude"])
+
+    install_result = _run_install(
+        project,
+        monkeypatch,
+        {"acme/pkg-a": "./scripts/pkg-a-hook.sh", "acme/pkg-b": "./scripts/pkg-b-hook.sh"},
+    )
+    assert install_result.exit_code == 0, install_result.output
+
+    settings_path = project / ".claude" / "settings.json"
+    sidecar_path = project / ".claude" / "apm-hooks.json"
+    assert {"pkg-a", "pkg-b"} <= _sidecar_sources(sidecar_path)
+
+    # Inject a manual, user-owned entry directly into the native file --
+    # never in the sidecar, so it carries no _apm_source marker.
+    settings_data = _read_json(settings_path)
+    settings_data.setdefault("hooks", {}).setdefault("PreToolUse", []).append(
+        {
+            "matcher": "Bash",
+            "hooks": [{"type": "command", "command": "echo manual-user-hook"}],
+        }
+    )
+    settings_path.write_text(json.dumps(settings_data), encoding="utf-8")
+
+    _remove_dependency(project, "acme/pkg-a")
+    prune_result = _run_prune(project, monkeypatch)
+    assert prune_result.exit_code == 0, prune_result.output
+
+    assert not (project / "apm_modules" / "acme" / "pkg-a").exists()
+    assert (project / "apm_modules" / "acme" / "pkg-b").is_dir(), (
+        "sibling package declared in apm.yml must survive prune"
+    )
+
+    remaining_sources = _sidecar_sources(sidecar_path)
+    assert "pkg-a" not in remaining_sources, "pruned package's hook entry must be gone"
+    assert "pkg-b" in remaining_sources, (
+        "sibling package's hook entry must survive scoped reconciliation"
+    )
+    commands = _pre_tool_use_commands(settings_path)
+    assert "./scripts/pkg-b-hook.sh" in commands, "sibling's hook command must remain"
+    assert "echo manual-user-hook" in commands, "manual user-owned hook must remain untouched"
+    assert "./scripts/pkg-a-hook.sh" not in commands, "pruned package's hook command must be gone"
+
+
+def test_prune_hook_reconciliation_is_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Running prune twice in a row must not error or change state further."""
+    project = tmp_path / "proj-idempotent"
+    _write_project(project, ["acme/pkg-a"], ["claude"])
+    install_result = _run_install(project, monkeypatch, {"acme/pkg-a": "./scripts/pkg-a-hook.sh"})
+    assert install_result.exit_code == 0, install_result.output
+
+    _remove_dependency(project, "acme/pkg-a")
+    first = _run_prune(project, monkeypatch)
+    assert first.exit_code == 0, first.output
+
+    settings_path = project / ".claude" / "settings.json"
+    sidecar_path = project / ".claude" / "apm-hooks.json"
+    state_after_first = (
+        _read_json(settings_path) if settings_path.exists() else None,
+        sidecar_path.exists(),
+    )
+
+    second = _run_prune(project, monkeypatch)
+    assert second.exit_code == 0, second.output
+    state_after_second = (
+        _read_json(settings_path) if settings_path.exists() else None,
+        sidecar_path.exists(),
+    )
+    assert state_after_second == state_after_first, "second prune run must be a no-op"
+
+
+def test_prune_dry_run_does_not_touch_hook_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--dry-run`` must leave merged hook config and sidecar untouched."""
+    project = tmp_path / "proj-dry-run"
+    _write_project(project, ["acme/pkg-a"], ["claude"])
+    install_result = _run_install(project, monkeypatch, {"acme/pkg-a": "./scripts/pkg-a-hook.sh"})
+    assert install_result.exit_code == 0, install_result.output
+
+    settings_path = project / ".claude" / "settings.json"
+    sidecar_path = project / ".claude" / "apm-hooks.json"
+    before_settings = _read_json(settings_path)
+    before_sidecar = _read_json(sidecar_path)
+
+    _remove_dependency(project, "acme/pkg-a")
+    dry_run_result = _run_prune(project, monkeypatch, dry_run=True)
+    assert dry_run_result.exit_code == 0, dry_run_result.output
+
+    assert (project / "apm_modules" / "acme" / "pkg-a").is_dir(), (
+        "dry-run must not remove the package directory"
+    )
+    assert _read_json(settings_path) == before_settings, "dry-run must not touch merged config"
+    assert _read_json(sidecar_path) == before_sidecar, "dry-run must not touch the sidecar"
+
+
+def test_prune_hook_reconciliation_failure_does_not_abort_package_removal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Partial-failure semantics: a reconcile error must not roll back removal.
+
+    This mirrors prune's existing per-step error tolerance (a failed
+    ``safe_rmtree`` or lockfile write is logged, not fatal) -- a hook
+    reconciliation failure must behave the same way, not crash the whole
+    command or leave the package directory in place.
+    """
+    project = tmp_path / "proj-partial-failure"
+    _write_project(project, ["acme/pkg-a"], ["claude"])
+    install_result = _run_install(project, monkeypatch, {"acme/pkg-a": "./scripts/pkg-a-hook.sh"})
+    assert install_result.exit_code == 0, install_result.output
+
+    _remove_dependency(project, "acme/pkg-a")
+    with patch(
+        "apm_cli.integration.hook_integrator.HookIntegrator.reconcile_after_removal",
+        side_effect=RuntimeError("simulated reconciliation failure"),
+    ):
+        prune_result = _run_prune(project, monkeypatch)
+
+    assert prune_result.exit_code == 0, prune_result.output
+    assert not (project / "apm_modules" / "acme" / "pkg-a").exists(), (
+        "package removal must not be rolled back by a reconciliation failure"
+    )
+
+
+def test_prune_orchestration_call_is_load_bearing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mutation-break proof: neutering prune's call to the reconcile owner
+    must re-introduce the exact #2245 symptom (dead merged hook entry).
+
+    This does not edit source; it simulates the mutation an accidental
+    revert of the orchestration call would cause (a no-op reconcile) and
+    proves ``test_prune_removes_merged_hook_entries_and_sidecar`` would
+    fail against it -- confirming that assertion is load-bearing rather
+    than vacuously true.
+    """
+    project = tmp_path / "proj-mutation-break"
+    _write_project(project, ["acme/pkg-a"], ["claude"])
+    install_result = _run_install(project, monkeypatch, {"acme/pkg-a": "./scripts/pkg-a-hook.sh"})
+    assert install_result.exit_code == 0, install_result.output
+
+    sidecar_path = project / ".claude" / "apm-hooks.json"
+    assert "pkg-a" in _sidecar_sources(sidecar_path)
+
+    _remove_dependency(project, "acme/pkg-a")
+    with patch(
+        "apm_cli.integration.hook_integrator.HookIntegrator.reconcile_after_removal",
+        return_value={"files_removed": 0, "errors": 0},
+    ) as neutered_reconcile:
+        prune_result = _run_prune(project, monkeypatch)
+        assert neutered_reconcile.called, (
+            "prune must still call the reconcile owner even when neutered"
+        )
+    assert prune_result.exit_code == 0, prune_result.output
+    assert "pkg-a" in _sidecar_sources(sidecar_path), (
+        "with the reconcile call neutered (simulating its removal), the "
+        "stale hook entry must still be present -- proving the real call "
+        "is what actually cleans it in "
+        "test_prune_removes_merged_hook_entries_and_sidecar"
+    )

--- a/tests/integration/test_prune_hook_reconciliation_e2e.py
+++ b/tests/integration/test_prune_hook_reconciliation_e2e.py
@@ -394,6 +394,10 @@ def test_prune_hook_reconciliation_failure_does_not_abort_package_removal(
     assert not (project / "apm_modules" / "acme" / "pkg-a").exists(), (
         "package removal must not be rolled back by a reconciliation failure"
     )
+    assert "Hook reconciliation failed" in prune_result.output, (
+        "a failed reconciliation must surface a user-visible diagnostic, not "
+        "fail silently -- users need to know hook entries may be stale"
+    )
 
 
 def test_prune_orchestration_call_is_load_bearing(


### PR DESCRIPTION
> [!NOTE]
> **Ready for maintainer review and merge.** Automation was prohibited from merging this PR; that restriction does not apply to a maintainer after review. Closes #2245.

apm-spec-waiver: hook integration has zero existing OpenAPM v0.1 requirements coverage (no prune/hook req rows in the manifest); this is a bounded bug fix restoring prune's existing directory/lockfile cleanup contract to also cover hooks, not a net-new capability, and originating a full req-XXX anchor + manifest + conformance-test triple for the hook-integration surface is separate spec-authoring work deferred to its own PR.

## TL;DR

`apm prune` deleted orphaned package directories and their lockfile `deployed_files` entries but left every merged hook entry that package had contributed -- plus its `apm-hooks.json` ownership sidecar -- behind in `.claude/settings.json`, `.cursor/hooks.json`, and the other merge targets. Harnesses kept firing hooks that pointed at scripts that no longer existed. `HookIntegrator.reconcile_after_removal()` now orchestrates the same clear-then-rebuild pattern `apm uninstall` already uses, so prune stops duplicating and starts reusing the canonical ownership-cleanup owner.

## Problem (WHY)

- [x] `apm prune` removes `apm_modules/<pkg>` and the lockfile's `deployed_files` for that package, but never touches merged-hook config -- confirmed by reading `src/apm_cli/commands/prune.py` before this change: no call into `HookIntegrator` anywhere in the orphan-removal path.
- [x] `_apm_source`-tagged entries in `.claude/settings.json` / `.cursor/hooks.json` and the `apm-hooks.json` ownership sidecar survive the package directory being deleted, so the merge target still references a script path under a directory `apm prune` just removed.
- [!] `HookIntegrator._clean_apm_entries_from_json()` is a "clear everything" primitive, not a per-package one -- any fix that calls it directly (instead of clear-then-rebuild) would silently wipe hooks owned by packages that were *not* pruned.

Why these matter: `apm uninstall` already solved exactly this shape of problem via `_sync_integrations_after_uninstall()` in `src/apm_cli/commands/uninstall/engine.py` -- prune reimplementing hook filtering instead of reusing that owner would create a second, divergent source of truth for "who owns this merged hook entry," which is the architecture smell the repo's canonical-owner discipline (`.github/instructions/architecture.instructions.md`) exists to prevent.

## Approach (WHAT)

| # | Fix |
|---|-----|
| 1 | Add `HookIntegrator.reconcile_after_removal()`: wipe all merged-hook entries/sidecars for the project (`sync_integration(managed_files=set())`), then rebuild from whatever dependencies are still declared in `apm.yml` *and* still installed on disk. |
| 2 | Wire `prune.py` to call it once, inside the existing `if pruned_keys:` block, non-fatally (matches prune's existing per-step error-tolerance pattern). |
| 3 | Extract the duplicated "resolve install path -> validate -> build `PackageInfo`" block (shared by uninstall's re-integration loop and the new reconcile path) into `build_installed_package_info()` in `models/apm_package.py`, so both owners call one implementation instead of two copies drifting apart. |

## Implementation (HOW)

- **`src/apm_cli/integration/hook_integrator.py`** -- New `reconcile_after_removal(apm_package, project_root)` method, placed between `sync_integration()` and `_clean_apm_entries_from_json()`. Clears every merge target's `_apm_source` entries and sidecar, then re-integrates hooks for each of `get_all_apm_dependencies()` (prod + dev -- intentionally broader than uninstall's prod-only scope, matching prune's own scope) that is still installed. Per-dependency re-integration failures are caught and logged (`_log.warning`), never abort the loop.
- **`src/apm_cli/commands/prune.py`** -- One `try`/`except` block calling `HookIntegrator().reconcile_after_removal(apm_package, project_root)` after the lockfile write, before the summary is printed. A reconciliation failure is logged via `logger.warning(...)` (severity aligned with the non-fatal contract, after review-panel fold -- see below) with an actionable recovery hint (`run 'apm install' to rebuild hook configuration`), and does not fail the prune command -- directory/lockfile pruning has already committed by this point, so hook reconciliation failing here is a best-effort cleanup step, not a transactional one. A happy-path progress line and a partial-failure warning (keyed off the returned error count) make the step visible on every outcome.
- **`src/apm_cli/models/apm_package.py`** -- New `build_installed_package_info(dep_ref, apm_modules_dir) -> PackageInfo | None`, the shared "resolve + validate + construct" helper. References the module's already-imported `validate_apm_package` (not a fresh local import) so existing tests that monkeypatch `apm_cli.models.apm_package.validate_apm_package` still intercept it.
- **`src/apm_cli/commands/uninstall/engine.py`** -- `_sync_integrations_after_uninstall()` now calls `build_installed_package_info()` instead of inlining the same construction logic (net -14/+6 lines). No behavior change for uninstall; this is the dedup side of the fix, required by the repo's `pylint R0801` duplication guard.
- **`docs/src/content/docs/reference/cli/prune.md`** -- One new paragraph documenting that prune now reconciles merged hook configuration and sidecars, scoped to package-owned entries only.
- **`CHANGELOG.md`** -- One `Fixed` entry under `[Unreleased]`.
- **`tests/integration/test_prune_hook_reconciliation_e2e.py`** -- New hermetic end-to-end suite (see Validation).

## Diagrams

Legend: what `apm prune` does today (directory + lockfile cleanup) versus the new reconciliation step it now triggers on the `HookIntegrator`; the highlighted region is entirely new.

```mermaid
sequenceDiagram
    participant U as apm prune
    participant L as apm.lock.yaml
    participant HI as HookIntegrator
    participant CFG as .claude/settings.json (+ siblings)
    participant SC as apm-hooks.json sidecar

    U->>L: diff manifest vs deployed_files -> pruned_keys
    U->>U: delete orphan apm_modules/<pkg> dirs
    U->>L: write lockfile without pruned entries
    rect rgb(255, 247, 200)
        Note over U,HI: NEW: reconcile_after_removal()
        U->>HI: reconcile_after_removal(apm_package, project_root)
        HI->>CFG: sync_integration(managed_files=set()) -> wipe all _apm_source entries
        HI->>SC: delete ownership sidecar
        HI->>HI: get_all_apm_dependencies() still declared + installed
        loop for each surviving dependency
            HI->>CFG: integrate_hooks_for_target() -> rebuild that package's entries
            HI->>SC: rewrite ownership sidecar
        end
    end
    Note over CFG,SC: Manual entries untouched -- siblings restored -- orphan gone
```

## Trade-offs

- **Clear-then-rebuild, not selective delete.** `_clean_apm_entries_from_json()` has no per-package granularity, so a surgical "delete just this package's entries" fix isn't available without rewriting that primitive (out of scope -- it's shared with uninstall and install). Rejected in favor of reusing the existing wipe-and-rebuild contract `apm uninstall` already relies on, keeping one behavior for "something in the dependency graph changed."
- **Best-effort, not transactional.** If `reconcile_after_removal()` raises for one dependency, the exception is logged and swallowed rather than rolling back the already-completed directory/lockfile pruning -- consistent with prune's existing per-step tolerance (dry-run and directory-removal failures are handled the same way elsewhere in `prune.py`).
- **Upgrade-time stale-hook gap: already handled, out of scope here.** The mandate asked me to check whether hooks can go stale when a package is *upgraded* rather than removed. `hook_integrator.py`'s per-target merged-hook integration already does an idempotent upsert keyed by `source_marker` (see the `cleared_events` logic around `integrate_hooks_for_target`, fixed for microsoft/apm#708): every `apm install`/`apm update` re-run for a package clears that package's own prior entries before appending its fresh ones. That already prevents stale hooks surviving an in-place upgrade. It is orthogonal to this PR's removal-time gap, needs no code change, and is documented here rather than silently assumed.
- **Dev dependencies included, unlike uninstall's prod-only scope.** `reconcile_after_removal()` iterates `get_all_apm_dependencies()` (prod + dev) because prune's own orphan-detection already spans both; narrowing it to prod-only would leave dev-dependency hooks unreconciled after a dev dependency is pruned.
- **Known, pre-existing, shared gap deferred rather than fixed here: #2250.** Review surfaced that `sync_integration`'s wipe phase scans *all* `KNOWN_TARGETS`, while the rebuild phase in both `reconcile_after_removal()` and the existing `_sync_integrations_after_uninstall()` only re-populates `canonical_targets`-scoped targets -- so narrowing a project's `targets:` list while a dependency stays installed can silently drop a still-declared package's hooks for the now-undeclared harness. Confirmed via diff that this exact asymmetry already exists in `uninstall/engine.py` on `main` (this PR's change there is dedup-only); `reconcile_after_removal()` faithfully mirrors the existing pattern rather than introducing a new one. Filed as its own follow-up because it's a shared-primitive fix (`sync_integration`, used by install/uninstall/prune) that needs evaluation against all three callers, not a single-command fix.
- **No new OpenAPM req-ID for hook integration (see waiver above).** The `Spec conformance gate` (Mode B detector) flags `hook_integrator.py` as a normative critical path; hooks/prune have no existing spec coverage to extend, so full spec authorship is left to a dedicated follow-up rather than folded into this bug-fix PR.

## Benefits

1. `apm prune` no longer leaves dangling hook references to deleted scripts -- verified by the new e2e suite asserting the merged config and sidecar are empty of the removed package's entries after a real `apm prune` run.
2. Sibling packages' and manually authored hook entries are provably untouched by the same run (negative twin in the same suite).
3. Zero hook-filtering logic duplicated in `prune.py` -- it is a 15-line orchestration call, not a reimplementation.
4. `pylint R0801` duplication guard stays green after adding a second caller of the "resolve install path -> PackageInfo" pattern, because it's now one shared function instead of two copies.

## Validation

<details><summary>Full CI-mirror lint chain</summary>

```
$ uv run --extra dev ruff check src/ tests/
All checks passed!

$ uv run --extra dev ruff format --check src/ tests/
1538 files already formatted

$ uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ bash scripts/lint-auth-signals.sh
[*] Rule A: get_bearer_provider boundary (any reference)
[*] Rule B: git ls-remote auth-delegated annotation
[+] auth-signal lint clean
```

</details>

**TDD RED -> GREEN** (`git stash` the product-code diff, keep the new tests):

```
RED  (product code stashed): 5 of 7 tests fail
GREEN (product code restored): 7 passed in 1.05s
```

<details><summary>GREEN run -- exact node IDs and timing</summary>

```
$ uv run pytest tests/integration/test_prune_hook_reconciliation_e2e.py -v
tests/integration/test_prune_hook_reconciliation_e2e.py::test_prune_removes_merged_hook_entries_and_sidecar[claude] PASSED [ 14%]
tests/integration/test_prune_hook_reconciliation_e2e.py::test_prune_removes_merged_hook_entries_and_sidecar[cursor] PASSED [ 28%]
tests/integration/test_prune_hook_reconciliation_e2e.py::test_prune_preserves_sibling_hooks_and_manual_entries PASSED [ 42%]
tests/integration/test_prune_hook_reconciliation_e2e.py::test_prune_hook_reconciliation_is_idempotent PASSED [ 57%]
tests/integration/test_prune_hook_reconciliation_e2e.py::test_prune_dry_run_does_not_touch_hook_files PASSED [ 71%]
tests/integration/test_prune_hook_reconciliation_e2e.py::test_prune_hook_reconciliation_failure_does_not_abort_package_removal PASSED [ 85%]
tests/integration/test_prune_hook_reconciliation_e2e.py::test_prune_orchestration_call_is_load_bearing PASSED [100%]

7 passed in 1.05s
```

</details>

<details><summary>Bounded regression run: prune + hook + uninstall (1417 passed)</summary>

```
$ uv run pytest tests/unit tests/integration -k "prune or hook or uninstall" -q
1 failed, 1417 passed, 16 skipped, 28173 deselected in 40.92s

FAILED tests/integration/test_tls_frozen_hook.py::test_user_override_still_wins_under_frozen_hook
```

That single failure is `ssl.SSLContext.__module__` global-state pollution from `truststore` in an unrelated TLS test (matched by `-k hook` only because of the word "runtime_hook" in the test file name -- nothing to do with `hook_integrator.py`). Confirmed pre-existing and order-dependent: reruns green standalone.

```
$ uv run pytest tests/integration/test_tls_frozen_hook.py -q
6 passed in 2.19s
```

</details>

Full `tests/unit tests/test_console.py tests/integration` was also run twice in this branch's development; all failures found there were independently confirmed pre-existing (deterministic on `main` too, e.g. `test_ado_ref_resolution_fallback.py`) or network-dependent (this sandbox has no outbound git access), and none touch `hook_integrator.py`, `commands/prune.py`, `commands/uninstall/engine.py`, or `models/apm_package.py`.

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|--------------------------|---------------|---------------------|------|
| 1 | Removing a dependency and running `apm prune` deletes that package's merged hook entries from `.claude/settings.json` and `.cursor/hooks.json`, plus its `apm-hooks.json` sidecar marker. | Secure by default / Multi-harness | `tests/integration/test_prune_hook_reconciliation_e2e.py::test_prune_removes_merged_hook_entries_and_sidecar[claude]`, `[cursor]` | integration (e2e, real CLI) |
| 2 | Pruning one package never removes a sibling package's hooks or a manually authored (non-APM) hook entry in the same merge target. | Secure by default / DevX | `tests/integration/test_prune_hook_reconciliation_e2e.py::test_prune_preserves_sibling_hooks_and_manual_entries` | integration (e2e) |
| 3 | Running `apm prune` twice in a row after the same removal is a no-op the second time (no error, no duplicate reconciliation). | DevX | `tests/integration/test_prune_hook_reconciliation_e2e.py::test_prune_hook_reconciliation_is_idempotent` | integration (e2e) |
| 4 | `apm prune --dry-run` never touches hook config or sidecar files. | Secure by default | `tests/integration/test_prune_hook_reconciliation_e2e.py::test_prune_dry_run_does_not_touch_hook_files` | integration (e2e) |
| 5 | If hook reconciliation itself fails, package/lockfile pruning still completes (best-effort, non-transactional). | DevX | `tests/integration/test_prune_hook_reconciliation_e2e.py::test_prune_hook_reconciliation_failure_does_not_abort_package_removal` | integration (e2e) |
| 6 | The `prune.py` -> `reconcile_after_removal()` call site is load-bearing: neutering it leaves stale hook entries behind (mutation-break proof). | Vendor-neutral (canonical-owner discipline) | `tests/integration/test_prune_hook_reconciliation_e2e.py::test_prune_orchestration_call_is_load_bearing` | integration (e2e, monkeypatched owner) |

## Review panel advisory (fold applied)

A full 7-persona `apm-review-panel` (python-architect, cli-logging-expert,
devx-ux-expert, supply-chain-security-expert, test-coverage-expert,
doc-writer, oss-growth-hacker) plus the `docs-sync` classifier and an
`apm-strategy` check were run against this PR's head. All in-scope
findings were folded; nothing required a design change.

**Folded:**
- Non-fatal reconciliation failure now logs `logger.warning(...)` with a
  recovery hint (`run 'apm install' to rebuild hook configuration`)
  instead of `logger.error(...)` -- 3 lenses (cli-logging, devx-ux,
  test-coverage) independently flagged the prior severity as
  over-signaling a step that does not fail the command.
- Success and partial-failure outcomes are now both visible in console
  output (previously only failure was, and even then only via the
  outer `try/except`, not from inside `reconcile_after_removal` itself).
- `reconcile_after_removal()` now resolves targets and materializes the
  dependency list *before* the destructive wipe, so a resolution
  failure aborts with zero writes instead of wiping every package's
  hooks with none rebuilt (supply-chain-security finding; local to
  this new caller, does not touch uninstall's code).
- New test assertion: the failure-path e2e test now asserts the
  user-visible warning string appears in `apm prune`'s output, not just
  that removal wasn't rolled back (test-coverage finding).
- `prune.md` now states reconciliation is best-effort/non-fatal and
  links back to `apm uninstall` (doc-writer finding).
- `manage-dependencies.md` had a genuine, PR-author-missed drift: it
  claimed lockfile/hook reconciliation happens on the *next*
  `apm install` -- both now happen immediately inside `apm prune`
  itself. Fixed (docs-sync classifier finding).
- `CHANGELOG.md` entry reframed to lead with the user-visible symptom
  (stale executable hooks) rather than the mechanism (growth-hacker
  nit).
- Two nits folded: dropped unnecessary string-quoting on
  `build_installed_package_info`'s return type; added inline comments
  explaining the `managed_files=set()` wipe idiom and the
  transitive-dependency rebuild boundary.

**Explicitly declined (documented, not silently dropped):**
- python-architect suggested scoping `reconcile_after_removal()`'s wipe
  call to `canonical_targets` (narrower than today's "all
  `KNOWN_TARGETS`" default). Confirmed `apm uninstall`'s identical
  `sync_integration()` call has the exact same asymmetry today.
  Narrowing only the new prune caller would create a *new* divergence
  between the two canonical-owner call sites -- the opposite of what
  this PR is trying to uphold. Left for #2250, which is scoped to fix
  the shared `sync_integration` primitive consistently for every
  caller at once.
- Transitive-dependency rebuild gap (security finding) confirmed
  pre-existing in uninstall too (`engine.py`, prod-only direct-dep
  loop) -- documented inline rather than fixed here, same #2250
  rationale.

7/7 hermetic e2e tests still green after the fold (1.08s). Full
CI-mirror lint chain re-verified clean. See commit `aaac9d83e1` for the
exact diff.

## How to test

- [ ] `git checkout danielmeppiel-fix-prune-hook-cleanup && uv run pytest tests/integration/test_prune_hook_reconciliation_e2e.py -v` -> 7 passed.
- [ ] Materialize a package with a merged Claude hook (`apm install`), remove it from `apm.yml`, run `apm prune` -> confirm `.claude/settings.json`'s `_apm_source` entry and the `apm-hooks.json` sidecar marker for that package are gone.
- [ ] Repeat with a second, un-pruned package present -> confirm its hook entries survive.
- [ ] `uv run pytest tests/unit tests/integration -k "prune or hook or uninstall" -q` -> 1417 passed (pre-existing unrelated TLS flake aside).
- [ ] Run the CI-mirror lint chain (ruff check, ruff format --check, pylint R0801, `scripts/lint-auth-signals.sh`) -> all green.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
