### PR TITLE
fix(hooks): scope merged-hook wipe to resolved targets, not all KNOWN_TARGETS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm uninstall` and `apm prune` no longer wipe still-installed dependencies'
+  merged hook entries out of a harness (e.g. `.cursor/hooks.json`) that was
+  dropped from a project's `targets:` list -- the hook wipe is now scoped to
+  the same resolved target set the rebuild step repopulates, so a narrowed
+  `targets:` no longer silently deletes a sibling package's hooks (and its
+  `apm-hooks.json` sidecar) in the now-undeclared harness. (closes #2250)
 - `apm prune` no longer leaves stale, executable hook entries behind for a
   removed package: it now reconciles merged hook ownership when it removes
   an orphaned package, clearing entries it contributed to

--- a/src/apm_cli/commands/uninstall/engine.py
+++ b/src/apm_cli/commands/uninstall/engine.py
@@ -635,11 +635,18 @@ def _sync_integrations_after_uninstall(
                 )
                 counts["prompts"] += result.get("files_removed", 0)
 
-    # Hooks (multi-target sync_integration handles all targets)
+    # Hooks: managed-file removal always scans every KNOWN_TARGETS prefix
+    # (safe -- it only ever deletes files already tracked as this
+    # package's own deployed_files). The merged-hook JSON wipe, in
+    # contrast, is scoped to `_resolved_targets` -- the SAME set the
+    # Phase 2 rebuild loop below iterates -- so a harness dropped from
+    # this project's `targets:` list is never wiped for packages that
+    # remain declared and installed (#2250).
     result = _integrators["hooks"].sync_integration(
         apm_package,
         project_root,
         managed_files=_buckets["hooks"] if _buckets else None,
+        targets=_resolved_targets,
     )
     counts["hooks"] = result.get("files_removed", 0)
 

--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -1877,27 +1877,32 @@ class HookIntegrator(BaseIntegrator):
         """Remove APM-managed hook files.
 
         Uses *managed_files* (relative paths) to surgically remove only
-        APM-tracked files.  Falls back to legacy ``*-apm.json`` glob when
-        *managed_files* is ``None``.
-
-        **Never** calls ``shutil.rmtree``.
-
+        APM-tracked files; falls back to legacy ``*-apm.json`` glob when
+        *managed_files* is ``None``. **Never** calls ``shutil.rmtree``.
         Also cleans APM entries from merged-hook JSON files via the
         ``_apm_source`` marker.
+
+        ``targets`` (#2250) scopes ONLY the merged-hook JSON cleanup below,
+        NOT the ``managed_files`` prefix guard (union of ``KNOWN_TARGETS``
+        + ``targets``): that guard defends against deleting outside a
+        recognized ``hooks/`` dir, and narrowing it would strand real
+        files deployed under a since-dropped target.
         """
         from .targets import KNOWN_TARGETS
 
         stats: dict[str, int] = {"files_removed": 0, "errors": 0}
 
-        # Derive hook prefixes dynamically from targets
-        source = targets if targets is not None else list(KNOWN_TARGETS.values())
-        hook_prefixes = []
-        for t in source:
-            if t.supports("hooks"):
-                sm = t.primitives["hooks"]
-                effective_root = sm.deploy_root or t.root_dir
-                hook_prefixes.append(f"{effective_root}/hooks/")
-        hook_prefix_tuple = tuple(hook_prefixes)
+        # Prefix guard: union of KNOWN_TARGETS + caller `targets`, never
+        # narrower than the unscoped default -- see docstring above.
+        guard_targets = list(KNOWN_TARGETS.values())
+        if targets is not None:
+            guard_targets = guard_targets + list(targets)
+        hook_prefixes = [
+            f"{(t.primitives['hooks'].deploy_root or t.root_dir)}/hooks/"
+            for t in guard_targets
+            if t.supports("hooks")
+        ]
+        hook_prefix_tuple = tuple(dict.fromkeys(hook_prefixes))
 
         if managed_files is not None:
             # Manifest-based removal -- only remove tracked files
@@ -1929,8 +1934,10 @@ class HookIntegrator(BaseIntegrator):
                     except Exception:
                         stats["errors"] += 1
 
-        # Clean APM entries from merged-hook JSON configs using external ownership.
-        for t in source:
+        # Clean APM entries from merged-hook JSON configs, scoped to
+        # `targets` when supplied -- matches the rebuild phase (#2250).
+        merge_source = targets if targets is not None else list(KNOWN_TARGETS.values())
+        for t in merge_source:
             config = _MERGE_HOOK_TARGETS.get(t.name)
             if config is not None:
                 json_path = project_root / t.root_dir / config.config_filename
@@ -1977,10 +1984,16 @@ class HookIntegrator(BaseIntegrator):
         reconcile, consistent with prune's existing per-package
         error-tolerant semantics.
 
-        Known boundary (shared with uninstall, tracked in #2250):
-        rebuilds only direct dependencies from ``get_all_apm_dependencies()``
-        -- a transitive dependency's merged hooks are wiped by the clear
-        phase above but never re-integrated here.
+        Target scope (#2250): the merged-hook JSON wipe below is scoped to
+        the SAME resolved ``targets`` the rebuild loop uses, so a harness
+        dropped from ``targets:`` (but still holding stale merged-hook
+        entries) is never wiped for still-declared, still-installed
+        packages while the rebuild silently skips repopulating it.
+
+        Known boundary (shared with uninstall, #2250): rebuilds only
+        direct dependencies from ``get_all_apm_dependencies()`` -- a
+        transitive dependency's merged hooks are wiped above but never
+        re-integrated here.
         """
         from apm_cli.constants import APM_MODULES_DIR
         from apm_cli.models.apm_package import build_installed_package_info
@@ -2000,15 +2013,11 @@ class HookIntegrator(BaseIntegrator):
         surviving_deps = list(apm_package.get_all_apm_dependencies())
 
         # Empty managed_files (not None) skips file-level deletion while
-        # still triggering the unconditional wipe of every _apm_source
-        # entry (and its ownership sidecar) across all KNOWN_TARGETS --
-        # see _clean_apm_entries_from_json. The narrower `targets` list
-        # resolved above is deliberately NOT passed here: doing so would
-        # make prune's wipe scope diverge from uninstall's identical
-        # call (both currently wipe all KNOWN_TARGETS by omitting
-        # targets=); that divergence is tracked as a shared-primitive
-        # fix in #2250, evaluated against all three callers together.
-        stats = self.sync_integration(apm_package, project_root, managed_files=set())
+        # still triggering the merged-hook JSON wipe, scoped to the same
+        # resolved `targets` the rebuild loop below uses (#2250).
+        stats = self.sync_integration(
+            apm_package, project_root, managed_files=set(), targets=targets
+        )
 
         for dep_ref in surviving_deps:
             pkg_info = build_installed_package_info(dep_ref, project_root / APM_MODULES_DIR)

--- a/tests/integration/test_hook_wipe_target_scope_e2e.py
+++ b/tests/integration/test_hook_wipe_target_scope_e2e.py
@@ -1,0 +1,475 @@
+"""Hermetic E2E coverage for #2250: hook wipe/rebuild target-scope symmetry.
+
+``HookIntegrator.sync_integration()`` is the shared "clear merged-hook
+JSON entries" primitive both ``apm uninstall`` (``_sync_integrations_after_
+uninstall`` in ``commands/uninstall/engine.py``) and ``apm prune``
+(``HookIntegrator.reconcile_after_removal``, added in #2249) call as the
+first half of a clear-then-rebuild transaction. Before this fix, the wipe
+half always covered every ``KNOWN_TARGETS`` entry (by omitting
+``targets=``), while the rebuild half only ever repopulated
+``resolve_targets(explicit_target=apm_package.canonical_targets or None)``
+-- the project's *currently declared* ``targets:`` list.
+
+If a project's ``targets:`` list is narrowed (e.g. ``[claude, cursor]`` ->
+``[claude]``) while a dependency stays installed and its old harness's
+merged-hook file (``.cursor/hooks.json``) still exists on disk, the next
+``apm uninstall`` or ``apm prune`` run wiped that harness's entire
+``_apm_source``-tagged entry set and deleted its ``apm-hooks.json``
+sidecar -- including entries for packages that are still declared and
+still installed -- because the rebuild phase never revisited that
+now-undeclared harness.
+
+The fix scopes the wipe to the SAME resolved target set the rebuild uses
+(see ``HookIntegrator.sync_integration``'s ``targets=`` parameter), for
+BOTH callers. These tests drive the REAL ``apm install``, ``apm
+uninstall``, and ``apm prune`` CLI commands end-to-end (Click
+``CliRunner``, no internals called directly except where a test
+specifically needs to prove an assertion is load-bearing), stubbing only
+the network download seam (``GitHubPackageDownloader.download_package``),
+matching the hermetic pattern already used by
+``tests/integration/test_prune_hook_reconciliation_e2e.py``.
+
+Matrix coverage is intentionally bounded to the two callers that share
+the defective primitive (``uninstall``, ``prune``) crossed with the two
+merge-hook schemas already established as semantically distinct in
+``test_prune_hook_reconciliation_e2e.py`` (Claude's schema-strict inline
+sidecar-only ownership vs Cursor's ``require_dir`` layout) -- a third
+caller or harness would not exercise new code, only repeat assertions.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from apm_cli.cli import cli
+from apm_cli.deps.github_downloader import GitHubPackageDownloader
+from apm_cli.models.apm_package import (
+    APMPackage,
+    GitReferenceType,
+    PackageInfo,
+    ResolvedReference,
+    clear_apm_yml_cache,
+)
+from apm_cli.models.dependency.reference import DependencyReference
+
+pytestmark = [pytest.mark.integration]
+
+_PATCH_UPDATES = "apm_cli.commands._helpers.check_for_updates"
+
+_TARGET_LAYOUT = {
+    "claude": (".claude/settings.json", ".claude/apm-hooks.json"),
+    "cursor": (".cursor/hooks.json", ".cursor/apm-hooks.json"),
+}
+
+# The two callers that route through HookIntegrator.sync_integration()'s
+# clear-then-rebuild transaction and shared the pre-fix scope asymmetry.
+_CALLERS = ["uninstall", "prune"]
+
+
+def _stub_download_package(hook_commands: dict[str, str]):
+    """Build a ``download_package`` stub that materializes a hooked fixture package."""
+
+    def _download(
+        _self: GitHubPackageDownloader,
+        repo_ref: object,
+        install_path: Path,
+        *_args: object,
+        **_kwargs: object,
+    ) -> PackageInfo:
+        dep_ref = (
+            repo_ref
+            if isinstance(repo_ref, DependencyReference)
+            else DependencyReference.parse(str(repo_ref))
+        )
+        install_path = Path(install_path)
+        install_path.mkdir(parents=True, exist_ok=True)
+        pkg_name = dep_ref.repo_url.rsplit("/", maxsplit=1)[-1]
+        (install_path / "apm.yml").write_text(
+            yaml.safe_dump(
+                {
+                    "name": pkg_name,
+                    "version": "1.0.0",
+                    "description": f"Hermetic target-scope fixture: {pkg_name}",
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+        command = hook_commands.get(dep_ref.repo_url)
+        if command is not None:
+            hooks_dir = install_path / ".apm" / "hooks"
+            hooks_dir.mkdir(parents=True, exist_ok=True)
+            (hooks_dir / "pre.json").write_text(
+                json.dumps(
+                    {
+                        "hooks": {
+                            "PreToolUse": [
+                                {
+                                    "matcher": "Bash",
+                                    "hooks": [{"type": "command", "command": command}],
+                                }
+                            ]
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+        package = APMPackage.from_apm_yml(install_path / "apm.yml")
+        return PackageInfo(
+            package=package,
+            install_path=install_path,
+            installed_at=datetime.now().isoformat(),
+            dependency_ref=dep_ref,
+            resolved_reference=ResolvedReference(
+                original_ref="main",
+                ref_type=GitReferenceType.BRANCH,
+                resolved_commit=None,
+                ref_name="main",
+            ),
+        )
+
+    return _download
+
+
+def _write_project(project: Path, dep_repo_urls: list[str], targets: list[str]) -> None:
+    project.mkdir(parents=True, exist_ok=True)
+    (project / "apm.yml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "hook-target-scope-consumer",
+                "version": "1.0.0",
+                "targets": targets,
+                "dependencies": {"apm": dep_repo_urls},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    clear_apm_yml_cache()
+
+
+def _narrow_targets(project: Path, targets: list[str]) -> None:
+    """Drop the project's declared ``targets:`` list to *targets*, keeping deps."""
+    manifest_path = project / "apm.yml"
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    manifest["targets"] = targets
+    manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
+    clear_apm_yml_cache()
+
+
+def _remove_dependency_from_manifest(project: Path, repo_url: str) -> None:
+    """Drop *repo_url* from apm.yml's declared deps, keeping any siblings."""
+    manifest_path = project / "apm.yml"
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    deps = manifest.get("dependencies", {}).get("apm", [])
+    manifest["dependencies"]["apm"] = [d for d in deps if d != repo_url]
+    manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
+    clear_apm_yml_cache()
+
+
+def _run_cli(project: Path, monkeypatch: pytest.MonkeyPatch, args: list[str]) -> object:
+    monkeypatch.chdir(project)
+    with patch(_PATCH_UPDATES, return_value=None):
+        return CliRunner().invoke(cli, args, catch_exceptions=False)
+
+
+def _run_install(
+    project: Path, monkeypatch: pytest.MonkeyPatch, hook_commands: dict[str, str]
+) -> object:
+    with patch.object(
+        GitHubPackageDownloader,
+        "download_package",
+        autospec=True,
+        side_effect=_stub_download_package(hook_commands),
+    ):
+        return _run_cli(project, monkeypatch, ["install", "--no-policy"])
+
+
+def _remove_package(
+    caller: str, project: Path, monkeypatch: pytest.MonkeyPatch, repo_url: str
+) -> object:
+    """Remove *repo_url* via the caller under test.
+
+    ``uninstall`` both edits apm.yml and removes the package in one CLI
+    call. ``prune`` requires the manifest edit to happen first (prune only
+    removes packages already absent from apm.yml).
+    """
+    if caller == "uninstall":
+        return _run_cli(project, monkeypatch, ["uninstall", repo_url])
+    if caller == "prune":
+        _remove_dependency_from_manifest(project, repo_url)
+        return _run_cli(project, monkeypatch, ["prune"])
+    raise ValueError(f"unknown caller: {caller}")
+
+
+def _read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _sidecar_sources(sidecar_path: Path) -> set[str]:
+    """Every _apm_source marker recorded anywhere in the sidecar file."""
+    if not sidecar_path.exists():
+        return set()
+    data = _read_json(sidecar_path)
+    sources: set[str] = set()
+    for entries in data.values():
+        if isinstance(entries, list):
+            for entry in entries:
+                if isinstance(entry, dict) and entry.get("_apm_source"):
+                    sources.add(entry["_apm_source"])
+    return sources
+
+
+def _pre_tool_use_commands(config_path: Path) -> list[str]:
+    if not config_path.exists():
+        return []
+    data = _read_json(config_path)
+    entries = data.get("hooks", {}).get("PreToolUse", [])
+    commands = []
+    for entry in entries:
+        for handler in entry.get("hooks", []):
+            if isinstance(handler, dict) and "command" in handler:
+                commands.append(handler["command"])
+    return commands
+
+
+def _install_two_packages_two_targets(project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Install pkg-a + pkg-b under [claude, cursor], both with merged hooks."""
+    _write_project(project, ["acme/pkg-a", "acme/pkg-b"], ["claude", "cursor"])
+    result = _run_install(
+        project,
+        monkeypatch,
+        {"acme/pkg-a": "./scripts/pkg-a-hook.sh", "acme/pkg-b": "./scripts/pkg-b-hook.sh"},
+    )
+    assert result.exit_code == 0, result.output
+
+
+@pytest.mark.parametrize("caller", _CALLERS)
+def test_narrowing_targets_preserves_sibling_hooks_in_dropped_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caller: str
+) -> None:
+    """RED (pre-fix): narrowing targets: then removing an unrelated package
+    wiped EVERY package's entries (including still-installed pkg-a's) from
+    the dropped harness (cursor), and deleted its ownership sidecar.
+
+    GREEN (post-fix): the still-declared, still-installed sibling's hooks
+    and manual/unowned entries in the now-undeclared harness survive,
+    because the wipe is scoped to the same resolved target set the
+    rebuild uses (the currently-declared [claude] only) -- cursor is
+    simply never touched by this operation.
+    """
+    project = tmp_path / f"proj-{caller}"
+    _install_two_packages_two_targets(project, monkeypatch)
+
+    cursor_settings = project / ".cursor" / "hooks.json"
+    cursor_sidecar = project / ".cursor" / "apm-hooks.json"
+    claude_settings = project / ".claude" / "settings.json"
+    claude_sidecar = project / ".claude" / "apm-hooks.json"
+    assert {"pkg-a", "pkg-b"} <= _sidecar_sources(cursor_sidecar), (
+        "precondition: both packages merged into cursor"
+    )
+    assert {"pkg-a", "pkg-b"} <= _sidecar_sources(claude_sidecar), (
+        "precondition: both packages merged into claude"
+    )
+
+    # Inject a manual, user-owned entry directly into cursor's native
+    # file -- never in the sidecar, so it carries no _apm_source marker.
+    # It must survive regardless of what happens to package-owned entries.
+    cursor_data = _read_json(cursor_settings)
+    cursor_data.setdefault("hooks", {}).setdefault("PreToolUse", []).append(
+        {"matcher": "Bash", "hooks": [{"type": "command", "command": "echo manual-cursor-hook"}]}
+    )
+    cursor_settings.write_text(json.dumps(cursor_data), encoding="utf-8")
+
+    # Narrow targets: [claude, cursor] -> [claude]. Both deps stay installed.
+    _narrow_targets(project, ["claude"])
+
+    result = _remove_package(caller, project, monkeypatch, "acme/pkg-b")
+    assert result.exit_code == 0, result.output
+
+    assert not (project / "apm_modules" / "acme" / "pkg-b").exists()
+    assert (project / "apm_modules" / "acme" / "pkg-a").is_dir(), (
+        "sibling package declared under the narrowed targets: must survive"
+    )
+
+    # The now-undeclared harness (cursor) must be untouched entirely: its
+    # config file, sidecar, package-owned entries (both packages), and the
+    # manual entry must all still be present exactly as before.
+    assert cursor_settings.exists(), "cursor config must not be deleted by a narrowed-away wipe"
+    assert cursor_sidecar.exists(), "cursor's ownership sidecar must survive"
+    assert {"pkg-a", "pkg-b"} <= _sidecar_sources(cursor_sidecar), (
+        "neither package's cursor hook entry may be lost when cursor is out of scope"
+    )
+    assert "echo manual-cursor-hook" in _pre_tool_use_commands(cursor_settings), (
+        "manual user-owned cursor hook must remain untouched"
+    )
+
+    # The currently-declared harness (claude) IS in scope: pkg-b's entry
+    # must be reconciled out, pkg-a's must survive.
+    claude_sources = _sidecar_sources(claude_sidecar)
+    assert "pkg-b" not in claude_sources, "removed package's claude hook entry must be gone"
+    assert "pkg-a" in claude_sources, "surviving sibling's claude hook entry must remain"
+    claude_commands = _pre_tool_use_commands(claude_settings)
+    assert "./scripts/pkg-a-hook.sh" in claude_commands
+    assert "./scripts/pkg-b-hook.sh" not in claude_commands
+
+
+@pytest.mark.parametrize("caller", _CALLERS)
+def test_negative_twin_without_narrowing_still_cleans_removed_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caller: str
+) -> None:
+    """Negative twin: without narrowing, both harnesses stay in scope.
+
+    Removing pkg-b while targets: still declares [claude, cursor] must
+    still reconcile pkg-b's entries out of BOTH harnesses (not just the
+    declared subset) -- this proves the fix does not regress the normal,
+    still-in-scope wipe/rebuild case into a silent no-op.
+    """
+    project = tmp_path / f"proj-negative-{caller}"
+    _install_two_packages_two_targets(project, monkeypatch)
+
+    cursor_sidecar = project / ".cursor" / "apm-hooks.json"
+    claude_sidecar = project / ".claude" / "apm-hooks.json"
+
+    result = _remove_package(caller, project, monkeypatch, "acme/pkg-b")
+    assert result.exit_code == 0, result.output
+
+    for sidecar, label in ((cursor_sidecar, "cursor"), (claude_sidecar, "claude")):
+        sources = _sidecar_sources(sidecar)
+        assert "pkg-b" not in sources, f"pkg-b's {label} entry must be reconciled when in scope"
+        assert "pkg-a" in sources, f"pkg-a's {label} entry must survive"
+
+
+@pytest.mark.parametrize("caller", _CALLERS)
+def test_target_scope_reconciliation_is_idempotent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caller: str
+) -> None:
+    """Running the same removal twice must not error or change state further."""
+    project = tmp_path / f"proj-idempotent-{caller}"
+    _install_two_packages_two_targets(project, monkeypatch)
+    _narrow_targets(project, ["claude"])
+
+    first = _remove_package(caller, project, monkeypatch, "acme/pkg-b")
+    assert first.exit_code == 0, first.output
+
+    cursor_sidecar = project / ".cursor" / "apm-hooks.json"
+    claude_settings = project / ".claude" / "settings.json"
+    claude_sidecar = project / ".claude" / "apm-hooks.json"
+    state_after_first = (
+        _read_json(claude_settings) if claude_settings.exists() else None,
+        cursor_sidecar.exists(),
+        _sidecar_sources(cursor_sidecar),
+        _sidecar_sources(claude_sidecar),
+    )
+
+    # Second run: uninstall re-invoking the same package is a no-op/error
+    # for `uninstall` (package already gone from apm.yml); prune with
+    # nothing orphaned is a no-op. Both must succeed without further
+    # mutating cursor or claude state.
+    if caller == "uninstall":
+        second = _run_cli(project, monkeypatch, ["prune"])
+    else:
+        second = _remove_package(caller, project, monkeypatch, "acme/pkg-b")
+    assert second.exit_code == 0, second.output
+
+    state_after_second = (
+        _read_json(claude_settings) if claude_settings.exists() else None,
+        cursor_sidecar.exists(),
+        _sidecar_sources(cursor_sidecar),
+        _sidecar_sources(claude_sidecar),
+    )
+    assert state_after_second == state_after_first, "second run must be a no-op"
+
+
+def test_zero_write_abort_before_destructive_wipe_on_prune(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Prune's reconcile computes targets/dependencies BEFORE the wipe.
+
+    If target resolution raises, nothing must be written -- a failed
+    resolution must never leave a committed wipe with no rebuild to
+    recover from (a zero-hook window until the next `apm install`).
+    """
+    project = tmp_path / "proj-zero-write"
+    _install_two_packages_two_targets(project, monkeypatch)
+
+    claude_settings = project / ".claude" / "settings.json"
+    claude_sidecar = project / ".claude" / "apm-hooks.json"
+    cursor_settings = project / ".cursor" / "hooks.json"
+    cursor_sidecar = project / ".cursor" / "apm-hooks.json"
+    before = {
+        p: _read_json(p) if p.exists() else None
+        for p in (claude_settings, claude_sidecar, cursor_settings, cursor_sidecar)
+    }
+
+    _remove_dependency_from_manifest(project, "acme/pkg-b")
+    with patch(
+        "apm_cli.integration.targets.resolve_targets",
+        side_effect=RuntimeError("simulated target resolution failure"),
+    ):
+        result = _run_cli(project, monkeypatch, ["prune"])
+
+    assert result.exit_code == 0, result.output
+    assert not (project / "apm_modules" / "acme" / "pkg-b").exists(), (
+        "package removal must still proceed even if hook reconciliation aborts"
+    )
+    after = {
+        p: _read_json(p) if p.exists() else None
+        for p in (claude_settings, claude_sidecar, cursor_settings, cursor_sidecar)
+    }
+    assert after == before, (
+        "a failed target resolution must abort before any wipe -- no merged-hook "
+        "file or sidecar may be touched"
+    )
+    assert "Hook reconciliation failed" in result.output
+
+
+def test_scope_symmetry_is_load_bearing_mutation_break(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mutation-break proof: neutering the targets= scope re-introduces #2250.
+
+    Simulates the exact pre-fix regression by forcing
+    ``HookIntegrator.sync_integration`` to ignore whatever ``targets`` its
+    caller passes (mirroring the old code path that always defaulted to
+    every ``KNOWN_TARGETS`` entry), then re-runs the narrowing scenario
+    from ``test_narrowing_targets_preserves_sibling_hooks_in_dropped_target``
+    and proves that assertion would fail against the neutered primitive --
+    confirming it is load-bearing, not vacuously true.
+    """
+    from apm_cli.integration.hook_integrator import HookIntegrator
+
+    project = tmp_path / "proj-mutation-break"
+    _install_two_packages_two_targets(project, monkeypatch)
+    _narrow_targets(project, ["claude"])
+
+    cursor_sidecar = project / ".cursor" / "apm-hooks.json"
+    assert {"pkg-a", "pkg-b"} <= _sidecar_sources(cursor_sidecar)
+
+    original_sync_integration = HookIntegrator.sync_integration
+
+    def _unscoped_sync_integration(self, apm_package, project_root, managed_files=None, **_kw):
+        # Drop whatever `targets` the caller supplied -- pre-#2250 behavior.
+        return original_sync_integration(
+            self, apm_package, project_root, managed_files=managed_files, targets=None
+        )
+
+    with patch.object(
+        HookIntegrator, "sync_integration", autospec=True, side_effect=_unscoped_sync_integration
+    ):
+        result = _remove_package("prune", project, monkeypatch, "acme/pkg-b")
+    assert result.exit_code == 0, result.output
+
+    assert "pkg-a" not in _sidecar_sources(cursor_sidecar), (
+        "with the targets= scope neutered (simulating the pre-#2250 unscoped "
+        "wipe), pkg-a's still-installed cursor hook entry must be gone -- "
+        "proving the real scoped call is what actually preserves it in "
+        "test_narrowing_targets_preserves_sibling_hooks_in_dropped_target"
+    )


### PR DESCRIPTION
# fix(hooks): scope merged-hook wipe to resolved targets, not all KNOWN_TARGETS

## TL;DR

`HookIntegrator.sync_integration()` wiped package-owned merged-hook entries across *every* supported harness, while the `apm uninstall` and `apm prune` rebuild steps that follow it only repopulate the project's currently-declared `targets:`. Narrowing `targets:` therefore silently deleted a still-installed sibling package's hooks (and its `apm-hooks.json` ownership sidecar) in the now-undeclared harness, with nothing left to restore them. `HookIntegrator` now scopes the merge-JSON wipe to the same resolved target set its own rebuild phase uses, so both callers stay symmetric by construction instead of by convention.

> [!NOTE]
> Closes #2250. Triaged via `apm-triage-panel` (ACCEPT, comment already posted on the issue) and reproduced empirically against both callers before any fix code was written.

apm-spec-waiver: restores the general reconcile-and-preserve hook contract already documented in reference/cli/prune.md and consumer/manage-dependencies.md ("entries owned by a pruned package are removed, while entries owned by packages that remain declared ... are preserved"); the docs establish this promise but do not separately name the `targets:`-narrowing trigger condition itself (confirmed via grep -- zero hits across prune.md/uninstall.md/manage-dependencies.md). This PR corrects an implementation bug against the already-documented general promise, adds no new normative behavior, so no new req-XXX spec anchor applies. (Rationale refined post-review-panel for precision -- see doc-writer verification below.)

## Problem (WHY)

- [x] `sync_integration()`'s merge-JSON cleanup loop iterated `KNOWN_TARGETS` unconditionally, deleting `_apm_source`-tagged entries (and the `apm-hooks.json` sidecar) from *every* harness regardless of what the caller had actually resolved for the project.
- [x] `uninstall/engine.py`'s `_sync_integrations_after_uninstall()` called `sync_integration()` without `targets=`, so its hook-wipe scope did not match the `_resolved_targets` the rest of that same function's rebuild loop iterates over (`src/apm_cli/commands/uninstall/engine.py:532,560`).
- [x] `HookIntegrator.reconcile_after_removal()` (the `apm prune` reconciliation path) called its internal `sync_integration()` the same unscoped way, while its own rebuild loop a few lines later iterated only the resolved `targets`.
- [!] Net effect: narrow a project's `targets:` list (e.g. drop `cursor`), then run `apm uninstall <pkg>` or `apm prune` -- a still-installed sibling package's `cursor` hooks vanish with no diagnostic, and no `apm install` rebuild path repopulates a target the project no longer declares.

Both callers independently reproduced the identical symptom against the same underlying method, confirming this was one shared defect in the owner, not two unrelated caller bugs.

## Approach (WHAT)

| # | Fix |
|---|-----|
| 1 | Decouple `sync_integration()`'s file-deletion prefix guard (kept as the union of `KNOWN_TARGETS` + caller `targets` -- a safety floor, never narrower than before) from a new `merge_source` variable that scopes the merged-hook JSON wipe to the caller-supplied `targets`, falling back to all `KNOWN_TARGETS` only when `targets` is `None`. |
| 2 | `reconcile_after_removal()` now passes `targets=targets` into its internal `sync_integration()` call (previously omitted). |
| 3 | `uninstall/engine.py`'s hooks call now passes `targets=_resolved_targets` (previously omitted). |

## Implementation (HOW)

- **`src/apm_cli/integration/hook_integrator.py`** -- the single canonical owner. `sync_integration()` builds `guard_targets` (union, wide-by-design) for the `managed_files` prefix check, and a separate `merge_source` (caller-scoped) for the `_clean_apm_entries_from_json` loop -- these are deliberately different widths for different reasons (file-deletion safety vs. hook-JSON symmetry with rebuild), not accidental drift. `reconcile_after_removal()` resolves `targets` and materializes `surviving_deps` *before* calling the destructive `sync_integration()`, so a `resolve_targets()` failure aborts with zero writes.
- **`src/apm_cli/commands/uninstall/engine.py`** -- `_sync_integrations_after_uninstall()` now threads the same `_resolved_targets` already used by its rebuild loop into the hooks call, closing the one remaining unscoped call site.
- **`tests/integration/test_hook_wipe_target_scope_e2e.py`** (new) -- 8 hermetic, CLI-driven tests (no network; stubbed `GitHubPackageDownloader.download_package`) parametrized across both callers.
- **`CHANGELOG.md`** -- one `Fixed` entry under `[Unreleased]`.

## Diagrams

Legend: how a target-narrowing project (drops `cursor` from `targets:`) flows through the now-symmetric wipe/rebuild pair inside `HookIntegrator`, for either caller.

```mermaid
flowchart TB
    A["apm uninstall / apm prune"] --> B["resolve_targets(project_root)\n-> _resolved_targets / targets"]
    B --> C{"resolve_targets raised?"}
    C -->|"yes"| Z["abort: zero writes\n(#2250 zero-write guarantee)"]
    C -->|"no"| D["sync_integration(targets=resolved)"]
    D --> E["guard_targets = union(KNOWN_TARGETS, resolved)\n[file-deletion prefix check -- stays wide]"]
    D --> F["merge_source = resolved\n[merge-JSON wipe -- scoped, the fix]"]
    F --> G["wipe _apm_source entries\nin each target in merge_source only"]
    E --> H["delete only managed_files\nunder a recognized hooks/ prefix"]
    G --> I["rebuild loop: re-integrate\nsurviving deps for target in resolved"]
    H --> I
    I --> J["cursor (dropped target): never wiped,\nnever rebuilt -- sibling hooks intact"]
```

## Trade-offs

- **Scope the wipe, keep the file-delete guard wide.** Narrowing the `managed_files` prefix guard itself (instead of adding a separate `merge_source`) would have been a smaller diff, but it risks stranding real deployed files under a since-dropped target if a future caller passes a narrower `targets` for file cleanup than it intends for hook-JSON cleanup. Keeping the guard unconditionally wide and only scoping `merge_source` removes that coupling.
- **Fix at the owner, not the callers.** Both `uninstall/engine.py` and `reconcile_after_removal()` needed one added `targets=` argument each; no caller-specific hook-filtering logic was introduced, preserving the existing single-owner discipline in `HookIntegrator`.
- **`SkillIntegrator` hypothesis empirically rejected, not filed.** The original draft of this section speculated `SkillIntegrator` had "an analogous un-decoupled prefix guard, same shape as this bug." Direct code review during the live-PR review panel (`src/apm_cli/integration/skill_integrator.py:1686-1760`) disproves this: `SkillIntegrator.sync_integration()` has no merged-JSON-wipe phase at all -- it is pure file-deletion filtered by a *single* `source` variable (`targets` or all `KNOWN_TARGETS`), so there is no wide-guard-vs-narrow-merge split to decouple in the first place, and `uninstall/engine.py` already passes it the correctly-scoped `_resolved_targets` in the normal case. No follow-up issue filed for this -- rejected with evidence, per the review panel's python-architect and orchestrator verification.
- **Transitive-dependency hook orphaning is a pre-existing, separate boundary -- now tracked.** `reconcile_after_removal()` only rebuilds direct dependencies (`get_all_apm_dependencies()`); a transitive dependency's merged hooks are wiped but not re-integrated. Documented in the method's own docstring as a known boundary shared with `uninstall`, not introduced or worsened by this change, but absent from every public doc page. Filed as #2254 rather than left as a PR-body-only mention.
- **Stale dropped-target hook entries have zero user-visible diagnostic -- now tracked.** Post-fix, a removed package's own hooks in a dropped-target harness become permanently stale with no signal to the user (not a regression -- pre-fix ALL hooks in that harness were destroyed, which is strictly worse). Raised by devx-ux-expert during the live-PR review panel; filed as #2253.
- **`tests/integration` as a whole hangs on a full-directory run** (9+ minutes, no progress) on an apparently unrelated live-network-adjacent test; not investigated further here since it predates this change and the new file itself runs in under 2 seconds in isolation.
- **Spec-waiver, not a new req-XXX anchor.** The `Spec conformance gate` (Mode B detector) flags this file as an OpenAPM critical path. Filed a `apm-spec-waiver:` (see NOTE above) rather than a new spec requirement, since the corrected behavior already matches the promise documented in `prune.md`/`manage-dependencies.md` -- this is a conformance fix, not new normative behavior.

## Benefits

1. A project that narrows `targets:` no longer loses a still-installed sibling's hooks in the dropped harness -- verified for both `apm uninstall` and `apm prune` via the RED/GREEN evidence below.
2. Manually authored (non-`_apm_source`) hook entries continue to survive reconciliation in all paths, unchanged by this fix (confirmed by supply-chain-security review, below).
3. Zero-write-on-resolve-failure is now a tested regression guard, not just an implicit ordering accident.
4. One canonical owner (`HookIntegrator`) for target-scope decisions; no caller re-implements hook-filtering logic.

## Live-PR Review Panel (docs-sync / apm-strategy / apm-review-panel)

> [!NOTE]
> The hosted `apm-review-panel` and `docs-sync` gh-aw workflows are currently broken repo-wide ("No authentication information found" from the `copilot` engine -- pre-existing, tracked in #2169, unrelated to this diff). Rather than skip the mandated live-PR artifacts, the orchestrator manually executed the full 9-persona panel fan-out + CEO synthesis via direct sub-agent dispatch against this PR's actual diff, and independently re-verified docs-sync claims by reading the doc pages directly (see below). `apm-strategy` has no hosted workflow at all (skill-only); it was invoked directly.

**Panel composition:** cli-logging-expert (inactive, no CLI surface), oss-growth-hacker (inactive, no growth surface), auth-expert (inactive, no auth surface), performance-expert (inactive, no perf surface), devx-ux-expert (active), python-architect (active), supply-chain-security-expert (active), test-coverage-expert (active), doc-writer (active) -- synthesized by apm-ceo.

**CEO headline:** "Restores the multi-harness hook-preservation contract by scoping the destructive wipe phase to only resolved targets, closing a silent data-loss regression on prune/uninstall with narrowed targets."

**Ship recommendation:** `ship_with_followups` -- all nine panelists converge, no blocking findings, no inter-persona dissent on the fix itself. Two follow-ups filed as tracking issues (not code changes, preserving this PR's bounded scope); one hypothesis explicitly rejected with evidence; one PR-body wording tightened.

### Seven verification questions -- answered with evidence

1. **Install already passes a symmetric target set, so uninstall/prune are the complete affected caller set?** Confirmed by full-codebase grep: `HookIntegrator.sync_integration` has exactly 2 external callers (`reconcile_after_removal` for `apm prune`, `uninstall/engine.py` for `apm uninstall`), both fixed. `apm install` never calls this method at all -- it only ever uses the additive `integrate_hooks_for_target` (confirmed independently by supply-chain-security-expert).
2. **Can the `guard_targets`/`merge_source` split preserve stale owned JSON incorrectly, or delete unrelated/manual entries?** No, on both counts. `test_negative_twin_without_narrowing_still_cleans_removed_target` (lines 324-348) proves normal in-scope wipes are not regressed into no-ops. `test_narrowing_targets_preserves_sibling_hooks_in_dropped_target` (lines 254-322) proves a manually authored, non-`_apm_source` entry (injected lines 282-289) survives untouched (asserted line 310-311), while the in-scope harness still correctly cleans the removed package (lines 316-321). `_clean_apm_entries_from_json` filters only on the `_apm_source` marker, so manual entries can never be deleted by this code path.
3. **Zero-write resolution failure and diagnostics?** `test_zero_write_abort_before_destructive_wipe_on_prune` (lines 391-431) snapshots all 4 hook files before/after a simulated `resolve_targets()` failure and asserts byte-for-byte equality (zero writes) plus asserts the diagnostic `"Hook reconciliation failed"` appears in CLI output. Scoped to the `prune` caller since that's the only caller where target resolution happens inside the destructive-call chain; `uninstall` resolves targets at a higher level before entering hook sync, so it is not at equivalent risk.
4. **Supply-chain implications of silently losing enforcement hooks?** Closed for both callers. `apm install` cannot trigger the wipe path (only additive integration). The zero-write-abort test prevents any resolve-failure-induced partial-wipe window. Stale entries left in a dropped target are inert (meaningful only to a harness no longer declared) and self-heal automatically if the target is ever re-added.
5. **Spec-waiver rationale accuracy?** Verbatim-accurate as a paraphrase of the *general* preserve-declared-packages contract in `prune.md` (lines 83-85) and `manage-dependencies.md` (line 312), confirmed by direct doc read. However, no doc page separately names the specific `targets:`-narrowing trigger scenario (confirmed via grep, zero hits) -- the waiver text above has been reworded to reflect this precisely, per doc-writer's finding.
6. **Should the 2096-line `hook_integrator.py` extract a canonical target-scope helper?** No. python-architect grepped every other integrator (`SkillIntegrator`, `CommandIntegrator`, `AgentIntegrator`, `InstructionIntegrator`, `PromptIntegrator`) and confirmed none share `HookIntegrator`'s dual-scope (guard-vs-merge) pattern -- `HookIntegrator` is uniquely the only integrator with a merged-JSON ownership model. Extraction would be premature abstraction with zero cross-integrator reuse pressure.
7. **Transitive-dependency and SkillIntegrator observations: filed or rejected with evidence?** Transitive-dependency hook-orphaning boundary is confirmed real (stated in the method's own docstring) and undocumented in any public page -- **filed as #2254**. The SkillIntegrator hypothesis is **explicitly rejected with evidence**: direct code read of `skill_integrator.py:1686-1760` shows it has no merged-JSON-wipe phase at all (pure file-deletion via a single `source` variable), so the dual-scope bug pattern is structurally impossible there -- no issue filed; the PR body's Trade-offs section above has been corrected to remove the unsupported claim. A third, panel-originated finding (devx-ux-expert: stale dropped-target hook entries have zero user-visible diagnostic) is **filed as #2253**.

## Validation

**RED (fix reverted, base commit's `hook_integrator.py`/`engine.py` checked out over the new tests):**

```
tests/integration/test_hook_wipe_target_scope_e2e.py::test_narrowing_targets_preserves_sibling_hooks_in_dropped_target[uninstall] FAILED
tests/integration/test_hook_wipe_target_scope_e2e.py::test_narrowing_targets_preserves_sibling_hooks_in_dropped_target[prune] FAILED
E   AssertionError: cursor's ownership sidecar must survive
    assert False
     +  where False = exists()
2 failed, 6 passed in 5.71s
```

**GREEN (fix restored):**

```
8 passed in 1.75s
```

**Repeated-run stability (5x back-to-back) of the core repro node, candidate for later `lifecycle_smoke` promotion once that marker lands** (no `lifecycle_smoke` mechanism exists yet in this repo as of this PR -- confirmed via repo-wide search -- so nothing is wired into CI here; this is timing evidence for that future promotion):

```
run 1: 2 passed in 1.34s (slowest case 0.22s)
run 2: 2 passed in 2.75s (slowest case 0.84s)
run 3: 2 passed in 2.64s (slowest case 0.49s)
run 4: 2 passed in 1.19s (slowest case 0.20s)
run 5: 2 passed in 1.89s (slowest case 0.51s)
```

<details><summary>Full canonical lint mirror (all seven CI Lint-job checks)</summary>

```
$ uv run --extra dev ruff check src/ tests/
All checks passed!

$ uv run --extra dev ruff format --check src/ tests/
1542 files already formatted

$ uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

$ bash scripts/lint-auth-signals.sh
[+] auth-signal lint clean

$ bash scripts/lint-architecture-boundaries.sh
AC1-AC14: all pass (no new static boundary guard required -- fix to an
existing owner's logic, not introduction of a new split-authority owner)

File-length guardrail (MAX_LINES=2100): hook_integrator.py at 2096 lines
(under cap; baseline was 2087 before this fix's condensed docstrings)

relative_to raw-pattern guard: 0 hits in src/apm_cli/
```

</details>

<details><summary>Full CI-mirrored test gate (pytest tests/unit tests/test_console.py tests/red_team)</summary>

```
tests/unit: 19000 passed, 2 skipped, 21 xfailed
tests/test_console.py + tests/red_team: 280 passed
Test Architecture Ratchets job's 5 files: 52 passed
7-file targeted regression suite around hook_integrator/uninstall/prune: 225 passed
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|--------------------------|--------------|---------------------|------|
| 1 | Narrowing a project's `targets:` list does not delete a still-installed sibling package's hooks (or its ownership sidecar) from the now-undeclared harness, on `apm uninstall` | Multi-harness / Secure by default | `tests/integration/test_hook_wipe_target_scope_e2e.py::test_narrowing_targets_preserves_sibling_hooks_in_dropped_target[uninstall]` | integration |
| 2 | Same promise, for `apm prune` | Multi-harness / Secure by default | `test_hook_wipe_target_scope_e2e.py::test_narrowing_targets_preserves_sibling_hooks_in_dropped_target[prune]` | integration |
| 3 | A manually authored (non-APM) hook entry in a dropped target is never touched, for either caller | Secure by default | `test_hook_wipe_target_scope_e2e.py::test_narrowing_targets_preserves_sibling_hooks_in_dropped_target[uninstall\|prune]` (manual-entry assertion) | integration |
| 4 | Without narrowing, a removed package's own hooks in a still-declared target are still cleaned (fix does not over-preserve) | Secure by default | `test_hook_wipe_target_scope_e2e.py::test_negative_twin_without_narrowing_still_cleans_removed_target[uninstall\|prune]` | integration |
| 5 | Running the same command twice yields identical hook state (no accumulation, no double-delete) | DevX | `test_hook_wipe_target_scope_e2e.py::test_target_scope_reconciliation_is_idempotent[uninstall\|prune]` | integration |
| 6 | A `resolve_targets()` failure during `apm prune` aborts before any destructive wipe, with a diagnostic | Secure by default / DevX | `test_hook_wipe_target_scope_e2e.py::test_zero_write_abort_before_destructive_wipe_on_prune` | integration |
| 7 | The scoped-`targets` behavior is load-bearing, not a vacuous assertion | Secure by default | `test_hook_wipe_target_scope_e2e.py::test_scope_symmetry_is_load_bearing_mutation_break` | integration (mutation-break) |

## How to test

- [ ] Checkout this branch, run `uv run --extra dev pytest tests/integration/test_hook_wipe_target_scope_e2e.py -v` -> 8 passed.
- [ ] `git checkout HEAD~1 -- src/apm_cli/integration/hook_integrator.py src/apm_cli/commands/uninstall/engine.py`, re-run the same command -> 2 failed (RED, reproducing #2250), then `git checkout HEAD -- <same two files>` to restore.
- [ ] Manually: create a project with two deps installing hooks into both `.claude` and `.cursor`, narrow `apm.yml`'s `targets:` to drop `cursor`, run `apm prune` or `apm uninstall <one dep>` -> confirm `.cursor/hooks.json` and `.cursor/apm-hooks.json` still contain the surviving package's entries.
- [ ] Run the full lint mirror per `.apm/instructions/linting.instructions.md` -> all seven checks green.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
