### PR TITLE
test(hooks): promote target-scope uninstall smoke

### DIFF
--- a/tests/integration/test_hook_wipe_target_scope_e2e.py
+++ b/tests/integration/test_hook_wipe_target_scope_e2e.py
@@ -251,7 +251,13 @@ def _install_two_packages_two_targets(project: Path, monkeypatch: pytest.MonkeyP
     assert result.exit_code == 0, result.output
 
 
-@pytest.mark.parametrize("caller", _CALLERS)
+@pytest.mark.parametrize(
+    "caller",
+    [
+        pytest.param("uninstall", marks=pytest.mark.lifecycle_smoke),
+        "prune",
+    ],
+)
 def test_narrowing_targets_preserves_sibling_hooks_in_dropped_target(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caller: str
 ) -> None:


### PR DESCRIPTION
# harden(hooks): promote target-scope uninstall smoke

## TL;DR

Promote exactly one hermetic regression node from the #2252 hook target-scope suite into the required `lifecycle_smoke` family. The selected `uninstall` case proves that narrowing a project from `claude,cursor` to `claude` does not wipe the dropped Cursor harness while rebuilding surviving hooks. After additively merging the Windows CI repair from `main`, it still passed and still failed when the #2252 `targets=_resolved_targets` production fix was temporarily removed.

> [!NOTE]
> The existing marker-driven workflow and its three-minute ceiling are unchanged; the family grows from 13 to 14 collected nodes.

## Problem (WHY)

- [x] #2252 fixed an uninstall path that could erase a still-installed sibling's merged Cursor hooks and ownership sidecar after the project narrowed its declared targets.
- [x] The regression suite was hermetic and load-bearing, but its core uninstall proof was not part of the required PR-time lifecycle family.
- [!] Marking the full module would add prune twins, negative twins, idempotency, zero-write, and mutation-only paths rather than the one behavior required to trap the defect.

Why this matters: ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) The `lifecycle_smoke` contract stays declarative: [`ci.yml`](https://github.com/microsoft/apm/blob/9fdc2f04d694f63704512d056ffb11fe29cfcbd7/.github/workflows/ci.yml) selects `-m lifecycle_smoke`, not test paths or a count.

## Approach (WHAT)

| # | Fix |
|---|-----|
| 1 | Mark only `test_narrowing_targets_preserves_sibling_hooks_in_dropped_target[uninstall]`. |
| 2 | Leave the `prune` parameter and every other module node unmarked. |
| 3 | Retain CI's marker selection and `timeout-minutes: 3` without topology-test changes. |

## Implementation (HOW)

- **[`tests/integration/test_hook_wipe_target_scope_e2e.py`](https://github.com/microsoft/apm/blob/91a354027862efde03271aebd7b2c5b91e6069e8/tests/integration/test_hook_wipe_target_scope_e2e.py#L254-L265)** -- converts the parameter source into a narrow list and attaches `lifecycle_smoke` only to `uninstall`. The surrounding assertions remain the owner of manual-entry, sibling-package, dropped-target, and in-scope reconciliation behavior.

## Diagrams

Legend: the dashed node is the new required-selection edge; the test still exercises the production target-scope transaction unchanged.

```mermaid
flowchart LR
    M["apm.yml targets: claude,cursor"] --> N["targets narrowed to claude"]
    N --> U["apm uninstall pkg-b"]
    U --> S["sync_integration targets=_resolved_targets"]
    S --> C["Cursor remains untouched"]
    S --> R["Claude rebuild preserves pkg-a"]
    T["uninstall regression node"] --> U
    classDef new stroke-dasharray: 5 5;
    class T new;
```

## Trade-offs

- **One uninstall parameter.** Chose the shared defect's original caller; rejected marking both caller parameters to keep the added required coverage to one node.
- **Existing test fixture.** Chose the established two-target, two-package fixture; rejected a new duplicate test file because it would repeat the manual-entry and sibling assertions already present.
- **No workflow edit.** Chose marker membership only; rejected count assertions or explicit node enumeration because the family is intentionally declarative.

## Benefits

1. Required PR CI now includes one additional hermetic target-scope regression node.
2. The selected node proves all four relevant observations: dropped Cursor config and sidecar persist, manual Cursor content persists, sibling `pkg-a` persists, and in-scope Claude removes `pkg-b`.
3. The mutation proof fails at the Cursor-sidecar preservation assertion when `targets=_resolved_targets` is removed.
4. The promoted family remains under its existing three-minute ceiling in local measurement.

## Validation

Superseding receipt after merging Windows hotfix `9fdc2f04d694f63704512d056ffb11fe29cfcbd7`:

```text
base=9fdc2f04d694f63704512d056ffb11fe29cfcbd7
head=91a354027862efde03271aebd7b2c5b91e6069e8
1 passed in 15.73s
```

Mutation proof after temporarily removing `targets=_resolved_targets` from `commands/uninstall/engine.py`, then restoring the line:

```text
FAILED ...[uninstall]
AssertionError: cursor's ownership sidecar must survive
1 failed in 28.15s
```

<details><summary>Refreshed promoted-family and semantic-contract checks</summary>

```text
14 passed, 10626 deselected in 27.13s
real 42.50

23 passed in 46.35s
[nested plugin-autoload isolation] 1 passed in 10.12s
[+] assertion-quality ratchet clean: AQ001=5, AQ002=12
[+] exact test duplicate ratchet clean: 1060 files, 8 allowed duplicate group(s)

All checks passed!
1542 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
```

</details>

Hosted exact-head timing: CI run [`29516545950`](https://github.com/microsoft/apm/actions/runs/29516545950) passed at `91a354027862efde03271aebd7b2c5b91e6069e8`; `Lifecycle Smoke (Linux)` completed in 38 seconds, below the 44-second baseline. The unchanged `timeout-minutes: 3` ceiling retains 142 seconds of headroom. Exact-head CI checks, including `Lint`, both Linux build-and-test shards, `Lifecycle Smoke (Linux)`, `Test Architecture Ratchets`, `Windows Compatibility Gate`, `APM Self-Check`, CodeQL, and `gate`, are successful. The merged Windows repair itself passed the exact full Windows command with 18,930 passed, 77 skipped, and 21 xfailed.

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|-------------------------|--------------|--------------------|------|
| 1 | After narrowing a project to Claude, `apm uninstall` keeps a still-installed sibling's Cursor hooks, Cursor sidecar, and manual Cursor hook intact. | Multi-harness support, DevX (pragmatic as npm) | `tests/integration/test_hook_wipe_target_scope_e2e.py::test_narrowing_targets_preserves_sibling_hooks_in_dropped_target[uninstall]` (regression-trap for #2250) | e2e |
| 2 | In the declared Claude target, `apm uninstall` removes the uninstalled package's hook and retains the sibling package's hook. | Multi-harness support | `tests/integration/test_hook_wipe_target_scope_e2e.py::test_narrowing_targets_preserves_sibling_hooks_in_dropped_target[uninstall]` | e2e |

## How to test

- [ ] Run `uv run --extra dev pytest --strict-markers -q tests/integration/test_hook_wipe_target_scope_e2e.py::test_narrowing_targets_preserves_sibling_hooks_in_dropped_target[uninstall]` and observe one passing node.
- [ ] Run `uv run --extra dev pytest -p no:cacheprovider -q --strict-markers -m lifecycle_smoke tests/integration` and observe the promoted node in the marker family.
- [ ] Temporarily remove `targets=_resolved_targets` from `src/apm_cli/commands/uninstall/engine.py`, rerun the selected node, and observe the Cursor-sidecar assertion fail; restore the line afterward.
- [ ] Confirm `.github/workflows/ci.yml` still runs `-m lifecycle_smoke tests/integration` with `timeout-minutes: 3`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
