### PR TITLE
docs: Fix Compile page link to Instructions

### DIFF
--- a/docs/src/content/docs/producer/compile.md
+++ b/docs/src/content/docs/producer/compile.md
@@ -31,7 +31,7 @@ apm compile
 ```
 
 Concretely, that command rolls your `instructions/*.instructions.md`
-(see [Instructions](../../author-primitives/instructions-and-agents/#instructions))
+(see [Instructions](author-primitives/instructions-and-agents/#instructions))
 into the native rules surface each target expects:
 
 - `AGENTS.md` -- the cross-harness root context file. Copilot, Codex,

--- a/docs/src/content/docs/producer/compile.md
+++ b/docs/src/content/docs/producer/compile.md
@@ -31,7 +31,7 @@ apm compile
 ```
 
 Concretely, that command rolls your `instructions/*.instructions.md`
-(see [Instructions](../../author-primitives/instructions-and-agents/#1-instructions))
+(see [Instructions](../../author-primitives/instructions-and-agents/#instructions))
 into the native rules surface each target expects:
 
 - `AGENTS.md` -- the cross-harness root context file. Copilot, Codex,

--- a/docs/src/content/docs/producer/compile.md
+++ b/docs/src/content/docs/producer/compile.md
@@ -31,7 +31,7 @@ apm compile
 ```
 
 Concretely, that command rolls your `instructions/*.instructions.md`
-(see [Instructions](../author-primitives/instructions-and-agents/#1-instructions))
+(see [Instructions](../../author-primitives/instructions-and-agents/#1-instructions))
 into the native rules surface each target expects:
 
 - `AGENTS.md` -- the cross-harness root context file. Copilot, Codex,


### PR DESCRIPTION
## Description

The APM Compile page has a broken link out to provide more context on instructions.

<img width="1316" height="554" alt="image" src="https://github.com/user-attachments/assets/5d1750b2-f8d1-48d7-a8e2-7e83d714a481" />

-----

<img width="831" height="414" alt="image" src="https://github.com/user-attachments/assets/4fc90716-1c57-47d3-a1ce-4a0a2f53f061" />

The correct page is one folder higher up, hence this fix.

<img width="817" height="284" alt="image" src="https://github.com/user-attachments/assets/d1b537af-2f56-41ce-9d90-b755e1c0f770" />



Fixes # (issue)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Maintenance / refactor

## Testing

n/a

- [ ] Tested locally
- [ ] All existing tests pass
- [ ] Added tests for new functionality (if applicable)

## Spec conformance (OpenAPM v0.1)

If this PR changes behaviour that an OpenAPM v0.1 `req-XXX` covers,
confirm the three-step ritual (see CONTRIBUTING.md "Adding or
changing a normative requirement"):

- [ ] Spec edit: `docs/src/content/docs/specs/openapm-v0.1.md` updated
      (new/changed `<a id="req-XXX"></a>` anchor + prose + Appendix C
      row).
- [ ] Manifest edit: `docs/src/content/docs/specs/manifests/openapm-v0.1.requirements.yml`
      updated.
- [ ] Test edit: a `@pytest.mark.req("req-XXX")` test under
      `tests/spec_conformance/` added or extended.
- [ ] `CONFORMANCE.{md,json}` regenerated via
      `uv run --extra dev python -m tests.spec_conformance.gen_statement`
      and committed.
- [x] N/A -- this PR does not change OpenAPM-observable behaviour.
