### PR TITLE
fix(ci): restore Windows unit reliability

### DIFF
--- a/src/apm_cli/utils/git_env.py
+++ b/src/apm_cli/utils/git_env.py
@@ -24,9 +24,8 @@ import shutil
 
 from apm_cli.utils.subprocess_env import external_process_env
 
-# Module-level cached git executable path (resolved once per process)
+# Module-level cached git executable path (successful resolutions only).
 _git_executable: str | None = None
-_git_resolved: bool = False
 
 # Variables that represent ambient git state -- strip these to avoid
 # biasing APM's git operations when invoked from within another repo
@@ -52,9 +51,11 @@ _STRIP_GIT_VARS: frozenset[str] = frozenset(
 
 
 def get_git_executable() -> str:
-    """Return the path to the git executable (cached after first lookup).
+    """Return the path to the git executable (cached after a successful lookup).
 
     Uses ``shutil.which("git")`` to locate git on PATH.
+    Failed lookups are not cached because PATH can change within a
+    long-lived process.
 
     Returns:
         Absolute or relative path to the git binary.
@@ -62,21 +63,16 @@ def get_git_executable() -> str:
     Raises:
         FileNotFoundError: If git is not found on PATH.
     """
-    global _git_executable, _git_resolved
-    if _git_resolved:
-        if _git_executable is None:
-            raise FileNotFoundError(
-                "git executable not found on PATH. "
-                "Please install git: https://git-scm.com/downloads"
-            )
+    global _git_executable
+    if _git_executable is not None:
         return _git_executable
 
-    _git_executable = shutil.which("git")
-    _git_resolved = True
-    if _git_executable is None:
+    resolved = shutil.which("git")
+    if resolved is None:
         raise FileNotFoundError(
             "git executable not found on PATH. Please install git: https://git-scm.com/downloads"
         )
+    _git_executable = resolved
     return _git_executable
 
 
@@ -96,9 +92,8 @@ def git_subprocess_env() -> dict[str, str]:
 
 def reset_git_cache() -> None:
     """Reset the cached git executable (for testing purposes only)."""
-    global _git_executable, _git_resolved
+    global _git_executable
     _git_executable = None
-    _git_resolved = False
 
 
 def git_long_paths_args() -> list[str]:

--- a/tests/unit/cache/test_git_env.py
+++ b/tests/unit/cache/test_git_env.py
@@ -49,15 +49,14 @@ class TestGetGitExecutable:
         with pytest.raises(FileNotFoundError, match=r"git executable not found"):
             get_git_executable()
 
-    @patch("shutil.which", return_value=None)
-    def test_cached_failure(self, mock_which) -> None:
-        """Once git is determined missing, subsequent calls raise immediately."""
+    @patch("shutil.which", side_effect=[None, "/usr/bin/git"])
+    def test_transient_failure_does_not_poison_later_resolution(self, mock_which) -> None:
+        """A transient PATH miss raises but remains retryable."""
         with pytest.raises(FileNotFoundError):
             get_git_executable()
-        # Second call should also raise without calling which again
-        with pytest.raises(FileNotFoundError):
-            get_git_executable()
-        mock_which.assert_called_once()
+
+        assert get_git_executable() == "/usr/bin/git"
+        assert mock_which.call_count == 2
 
 
 class TestGitSubprocessEnv:

--- a/tests/unit/test_protocol_fallback_warning.py
+++ b/tests/unit/test_protocol_fallback_warning.py
@@ -383,6 +383,7 @@ class TestConcurrentFallbackWarning:
         import shutil
         import threading
 
+        original_environment = dict(os.environ)
         dl = _make_downloader()
         dl._allow_fallback = True
 
@@ -403,48 +404,49 @@ class TestConcurrentFallbackWarning:
         errors_lock = threading.Lock()
 
         def _worker():
-            with (
-                patch.dict(os.environ, {}, clear=True),
-                patch(
-                    "apm_cli.core.token_manager.GitHubTokenManager.resolve_credential_from_git",
-                    return_value=None,
-                ),
-                patch("apm_cli.deps.github_downloader.Repo") as MockRepo,
-                patch(
-                    "apm_cli.deps.github_downloader._rich_warning",
-                    side_effect=_capture,
-                ),
-            ):
-                MockRepo.clone_from.side_effect = _fake_clone
-                try:
-                    barrier.wait(timeout=10)
-                except threading.BrokenBarrierError as exc:
-                    with errors_lock:
-                        worker_errors.append(exc)
-                    return
-                target = Path(tempfile.mkdtemp())
-                try:
-                    dl._clone_with_fallback(dep.repo_url, target, dep_ref=dep)
-                except (RuntimeError, GitCommandError):
-                    pass
-                finally:
-                    shutil.rmtree(target, ignore_errors=True)
+            try:
+                barrier.wait(timeout=10)
+            except threading.BrokenBarrierError as exc:
+                with errors_lock:
+                    worker_errors.append(exc)
+                return
+            target = Path(tempfile.mkdtemp())
+            try:
+                dl._clone_with_fallback(dep.repo_url, target, dep_ref=dep)
+            except (RuntimeError, GitCommandError):
+                pass
+            finally:
+                shutil.rmtree(target, ignore_errors=True)
 
-        threads = [threading.Thread(target=_worker) for _ in range(4)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join(timeout=10)
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch(
+                "apm_cli.core.token_manager.GitHubTokenManager.resolve_credential_from_git",
+                return_value=None,
+            ),
+            patch("apm_cli.deps.github_downloader.Repo") as MockRepo,
+            patch(
+                "apm_cli.deps.github_downloader._rich_warning",
+                side_effect=_capture,
+            ),
+        ):
+            MockRepo.clone_from.side_effect = _fake_clone
+            threads = [threading.Thread(target=_worker) for _ in range(4)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=10)
 
-        assert not worker_errors, (
-            f"Worker(s) failed to reach the barrier within the timeout "
-            f"(barrier broken or slow start): {worker_errors}"
-        )
-        for t in threads:
-            assert not t.is_alive(), (
-                f"Thread {t.name!r} is still alive after join(timeout=10); "
-                "the worker may have hung inside _clone_with_fallback"
+            assert not worker_errors, (
+                f"Worker(s) failed to reach the barrier within the timeout "
+                f"(barrier broken or slow start): {worker_errors}"
             )
+            for t in threads:
+                assert not t.is_alive(), (
+                    f"Thread {t.name!r} is still alive after join(timeout=10); "
+                    "the worker may have hung inside _clone_with_fallback"
+                )
+        assert dict(os.environ) == original_environment
 
         port_warnings = [msg for msg, sym in captured if "Custom port" in msg]
         assert len(port_warnings) == 1, (

--- a/tests/unit/test_windows_compat_gate_workflow.py
+++ b/tests/unit/test_windows_compat_gate_workflow.py
@@ -40,6 +40,7 @@ from tests.workflow_contracts import (
 ROOT = Path(__file__).resolve().parents[2]
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 MERGE_GATE_WORKFLOW = ROOT / ".github" / "workflows" / "merge-gate.yml"
+_COLLECTION_ENV_BASELINE = os.environ.copy()
 
 GATE_JOB = "windows-compat-gate"
 GATE_CHECK_NAME = "Windows Compatibility Gate"
@@ -121,7 +122,7 @@ def _positional_test_paths(args: list[str]) -> list[str]:
 
 def _collect_gate_family(args: list[str]) -> subprocess.CompletedProcess[str]:
     """Collect the declared gate family without loading unrelated plugins."""
-    collection_env = os.environ.copy()
+    collection_env = _COLLECTION_ENV_BASELINE.copy()
     collection_env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
     return subprocess.run(
         [sys.executable, "-m", "pytest", "-p", "no:cacheprovider", "--collect-only", "-q", *args],
@@ -234,6 +235,7 @@ def test_nested_collection_disables_plugin_autoload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Nested collection must not import unrelated third-party plugins."""
+    expected_path = os.environ.get("PATH")
     captured_env: dict[str, str] | None = None
 
     def fake_run(
@@ -251,12 +253,13 @@ def test_nested_collection_disables_plugin_autoload(
         )
 
     monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.delenv("PATH", raising=False)
 
     _collect_gate_family(["-m", GATE_MARKER, "tests/unit"])
 
     assert captured_env is not None
     assert captured_env.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD") == "1"
-    assert captured_env.get("PATH") == os.environ.get("PATH")
+    assert captured_env.get("PATH") == expected_path
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_windows_compat_gate_workflow.py
+++ b/tests/unit/test_windows_compat_gate_workflow.py
@@ -21,6 +21,7 @@ need to change every time a test gains or loses the marker.
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 import sys
@@ -118,6 +119,21 @@ def _positional_test_paths(args: list[str]) -> list[str]:
     return positional
 
 
+def _collect_gate_family(args: list[str]) -> subprocess.CompletedProcess[str]:
+    """Collect the declared gate family without loading unrelated plugins."""
+    collection_env = os.environ.copy()
+    collection_env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", "-p", "no:cacheprovider", "--collect-only", "-q", *args],
+        cwd=ROOT,
+        env=collection_env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+
+
 def test_windows_compat_gate_runs_on_windows_with_bounded_timeout() -> None:
     job = workflow_job(_ci_workflow(), GATE_JOB)
     assert job["name"] == GATE_CHECK_NAME
@@ -200,15 +216,7 @@ def test_windows_compat_gate_marker_selects_nonempty_bounded_family() -> None:
     job = workflow_job(_ci_workflow(), GATE_JOB)
     step = workflow_step(job, GATE_STEP)
     args = _gate_pytest_args(step)
-
-    result = subprocess.run(
-        [sys.executable, "-m", "pytest", "-p", "no:cacheprovider", "--collect-only", "-q", *args],
-        cwd=ROOT,
-        capture_output=True,
-        text=True,
-        timeout=120,
-        check=False,
-    )
+    result = _collect_gate_family(args)
     assert result.returncode == 0, (
         f"collection failed for the gate's own declared invocation "
         f"(args={args!r}):\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
@@ -220,6 +228,35 @@ def test_windows_compat_gate_marker_selects_nonempty_bounded_family() -> None:
         f"expected a non-empty, bounded {GATE_MARKER!r} contract family "
         f"(1..{MAX_BOUNDED_FAMILY_SIZE}), got {collected}"
     )
+
+
+def test_nested_collection_disables_plugin_autoload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nested collection must not import unrelated third-party plugins."""
+    captured_env: dict[str, str] | None = None
+
+    def fake_run(
+        command: list[str],
+        **kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal captured_env
+        env = kwargs.get("env")
+        captured_env = env if isinstance(env, dict) else None
+        return subprocess.CompletedProcess(
+            command,
+            returncode=0,
+            stdout="1 test collected\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    _collect_gate_family(["-m", GATE_MARKER, "tests/unit"])
+
+    assert captured_env is not None
+    assert captured_env.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD") == "1"
+    assert captured_env.get("PATH") == os.environ.get("PATH")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# fix(ci): restore Windows unit reliability

## TL;DR

The Windows full-unit job leaked an empty process environment from a threaded
test, which removed `PATH` and Windows socket/DLL state for later tests. This PR
moves process-global patches outside the worker threads, prevents transient Git
lookup misses from becoming process-lifetime false negatives, and gives the
nested topology collector a clean baseline environment with plugin autoload
disabled.

> [!IMPORTANT]
> The original failure is preserved in
> [run 29505541953, job 87645211116](https://github.com/microsoft/apm/actions/runs/29505541953/job/87645211116);
> the corrected head is `b431acfd0a53d45649cb6a8c249e08d4b95a96cf`.

## Problem (WHY)

- [x] Four worker threads each entered
  `patch.dict(os.environ, {}, clear=True)`. Out-of-order restoration left the
  xdist worker environment as `{}`, so 15 owner-gate fixtures could not resolve
  installed Git.
- [x] The same empty environment reached a nested `pytest --collect-only`
  process. Missing Windows process state made `asyncio` fail while importing
  `_overlapped` with `WinError 10106`.
- [!] `get_git_executable()` cached a failed lookup permanently, amplifying one
  transient miss across every later Git caller in the process.

The fix follows the PROSE requirement that
["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)
and keeps the change as small, independent primitives rather than weakening the
parallel test contract.

## Approach (WHAT)

| # | Fix | Principle |
|---:|---|---|
| 1 | Scope `os.environ` and shared mock patches once around the concurrent workload, never once per thread. | ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |
| 2 | Cache only successful Git executable resolutions; leave misses retryable. | ["Add what the agent lacks, omit what it knows"](https://agentskills.io/skill-creation/best-practices) |
| 3 | Spawn nested collection from a collection-time environment snapshot and disable third-party plugin autoload. | ["agents pattern-match well against concrete structures"](https://agentskills.io/skill-creation/best-practices) |

## Implementation (HOW)

| File | Surgical change |
|---|---|
| [`src/apm_cli/utils/git_env.py`](https://github.com/microsoft/apm/blob/b431acfd0a53d45649cb6a8c249e08d4b95a96cf/src/apm_cli/utils/git_env.py#L27-L96) | Removes the negative-cache sentinel while preserving `get_git_executable()` as the single Git resolution owner and retaining successful-path caching. |
| [`tests/unit/cache/test_git_env.py`](https://github.com/microsoft/apm/blob/b431acfd0a53d45649cb6a8c249e08d4b95a96cf/tests/unit/cache/test_git_env.py#L24-L61) | Replaces the old cached-failure expectation with a transient miss -> later success regression trap. |
| [`tests/unit/test_protocol_fallback_warning.py`](https://github.com/microsoft/apm/blob/b431acfd0a53d45649cb6a8c249e08d4b95a96cf/tests/unit/test_protocol_fallback_warning.py#L378-L456) | Runs only the production fallback calls concurrently; process-global patches now have one deterministic owner and the test asserts full environment restoration. |
| [`tests/unit/test_windows_compat_gate_workflow.py`](https://github.com/microsoft/apm/blob/b431acfd0a53d45649cb6a8c249e08d4b95a96cf/tests/unit/test_windows_compat_gate_workflow.py#L39-L265) | Preserves the real non-empty/bounded marker collection while isolating its child process from runtime worker mutations and unrelated plugins. |

## Diagrams

Legend: the highlighted block shows the new single-owner patch scope and the two
later consumers that now receive a restored environment.

```mermaid
sequenceDiagram
    participant W as pytest xdist worker
    participant E as os.environ
    participant T as four fallback threads
    participant G as get_git_executable
    participant C as nested pytest collector

    rect rgb(255, 247, 200)
        W->>E: enter one process-global patch scope
        W->>T: start concurrent fallback calls
        T-->>W: join all threads
        W->>E: exit once and restore baseline
        W->>G: resolve installed Git
        G-->>W: cache successful path
        W->>C: collect with baseline env and autoload disabled
        C-->>W: return bounded marker count
    end
```

## Trade-offs

- **Retry misses, cache successes.** Chose recovery from a changing `PATH`;
  rejected permanent negative caching. A process with permanently missing Git
  may repeat `shutil.which`, but callers still fail closed immediately.
- **Freeze the collector environment at module collection.** Chose deterministic
  topology validation; rejected inheriting arbitrary mutations from earlier
  tests. This helper is test infrastructure, not a general subprocess API.
- **Keep full xdist and semantic collection.** Rejected retries, exclusions,
  lower parallelism, broad skips, and file enumeration because they would hide
  the ordering defect rather than remove it.
- **Rollback risk is narrow but direct.** Reverting the patch-scope change
  reintroduces the empty-worker environment; runtime behavior outside Git
  miss caching is unchanged.

## Benefits

1. Converts the observed Windows result from 15 owner-gate setup errors plus one
   nested collection failure to `18,930 passed` on a hosted Windows runner.
2. Three independent hosted repetitions show zero recurrence of either
   `git executable not found` or `WinError 10106`.
3. The focused Windows contract family remains bounded at 76 tests, below the
   existing ceiling of 200.
4. Linux x86_64, macOS x86_64, and macOS arm64 unit steps all pass on the same
   corrected commit.

## Validation

### RED evidence

`test_transient_failure_does_not_poison_later_resolution` before the resolver fix:

```text
FileNotFoundError: git executable not found on PATH.
```

`test_concurrent_fallback_warning_emitted_once` before moving the patch scope:

```text
AssertionError: assert {} == { ... 57 environment entries ... }
```

`test_nested_collection_disables_plugin_autoload` before the baseline snapshot:

```text
AssertionError: assert None == '<original PATH>'
```

### GREEN evidence

`uv run --extra dev pytest -q tests/unit/cache/test_git_env.py tests/unit/test_protocol_fallback_warning.py tests/unit/test_shepherd_owner_touch_gate.py tests/unit/test_windows_compat_gate_workflow.py -n auto --dist worksteal`

```text
57 passed in 8.08s
```

`uv run --extra dev pytest -p no:cacheprovider -v -m windows_compat tests/unit`

```text
76 passed, 18951 deselected in 10.88s
```

<details><summary>Hosted repetition and cross-platform evidence</summary>

| Run / job | Exact full Windows unit step | Incident signatures |
|---|---|---|
| [29512630437 / 87669651553](https://github.com/microsoft/apm/actions/runs/29512630437/job/87669651553) | `18,930 passed, 77 skipped, 21 xfailed` | none |
| [29512623436 / 87669626228](https://github.com/microsoft/apm/actions/runs/29512623436/job/87669626228) | 18,929 passed; stopped only on pre-existing policy Hypothesis deadline | none |
| [29512615554 / 87669602893](https://github.com/microsoft/apm/actions/runs/29512615554/job/87669602893) | 18,929 passed; stopped only on pre-existing policy Hypothesis deadline | none |

Cross-platform unit steps at the same head:

- [Linux x86_64 passed](https://github.com/microsoft/apm/actions/runs/29512630437/job/87669651521)
- [macOS x86_64 passed](https://github.com/microsoft/apm/actions/runs/29512630437/job/87669651532)
- [macOS arm64 passed](https://github.com/microsoft/apm/actions/runs/29512630437/job/87669651713)

</details>

`ruff`, duplication, auth, architecture, and test-quality gates:

```text
All checks passed!
1542 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
[+] architecture boundary lint clean
37 passed
assertion-quality ratchet clean: AQ001=5, AQ002=12
exact test duplicate ratchet clean: 1060 files, 8 allowed duplicate group(s)
```

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | A temporary Git lookup miss does not make installed Git unavailable for the rest of the process. | DevX, Vendor-neutral | `tests/unit/cache/test_git_env.py::TestGetGitExecutable::test_transient_failure_does_not_poison_later_resolution` (regression trap) | unit |
| 2 | The full parallel Windows suite cannot erase process environment state while testing concurrent fallback warnings. | DevX, OSS / community-driven | `tests/unit/test_protocol_fallback_warning.py::TestConcurrentFallbackWarning::test_concurrent_fallback_warning_emitted_once` (regression trap) | unit |
| 3 | The Windows compatibility gate proves a real bounded family without inheriting mutated worker state or unrelated plugins. | Governed by policy, OSS / community-driven | `tests/unit/test_windows_compat_gate_workflow.py::test_nested_collection_disables_plugin_autoload`<br/>`tests/unit/test_windows_compat_gate_workflow.py::test_windows_compat_gate_marker_selects_nonempty_bounded_family` | unit |

## How to test

- [ ] Run the 57-test focused worksteal command; expect all tests to pass.
- [ ] Run `pytest -m windows_compat tests/unit`; expect exactly a non-empty family
  no larger than 200 (currently 76).
- [ ] Dispatch `build-release.yml` on this branch; expect the Windows full-unit
  step to report no Git owner-gate errors and no `WinError 10106`.
- [ ] Run the canonical lint and test-quality chains; expect no diagnostics.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
