### PR TITLE
test(lifecycle): add shared state substrate

### DIFF
--- a/tests/integration/test_lifecycle_state_snapshot_contract.py
+++ b/tests/integration/test_lifecycle_state_snapshot_contract.py
@@ -112,12 +112,12 @@ def test_capture_preserves_raw_bytes_and_canonical_semantics(tmp_path: Path) -> 
     assert tuple(record.locator.key for record in snapshot.deployment_records) == tuple(
         sorted((file_record.locator.key, uri_record.locator.key))
     )
-    assert snapshot.mcp_state_json == (
+    assert snapshot.mcp_state_bytes == (
         b'{"configs":{"fixture-mcp":{"command":"fixture-mcp","label":"'
         b'\\u03bb","name":"fixture-mcp","transport":"stdio"}},'
         b'"provenance":{},"servers":["fixture-mcp"],"target_servers":{}}'
     )
-    assert snapshot.lsp_state_json == (
+    assert snapshot.lsp_state_bytes == (
         b'{"configs":{"fixture-lsp":{"command":"fixture-lsp",'
         b'"extensionToLanguage":{".py":"python"},"name":"fixture-lsp"}},'
         b'"servers":["fixture-lsp"]}'
@@ -130,7 +130,8 @@ def test_capture_preserves_raw_bytes_and_canonical_semantics(tmp_path: Path) -> 
         b'{"servers":{"fixture-mcp":{"label":"\xcf\x80"}}}\n'
     )
     assert snapshot.file("AGENTS.md").roles == frozenset({"compiled"})
-    assert snapshot.file("copilot-app-db://workflows/dynamic-row") is None
+    with pytest.raises(KeyError, match="not tracked"):
+        snapshot.file("copilot-app-db://workflows/dynamic-row")
     assert tuple(file.relative_path for file in snapshot.files) == tuple(
         sorted(file.relative_path for file in snapshot.files)
     )
@@ -169,7 +170,7 @@ def test_semantic_state_reflects_deployment_and_config_changes(tmp_path: Path) -
 
     assert before.deployment_records == ()
     assert after.deployment_records == (record,)
-    assert before.mcp_state_json != after.mcp_state_json
+    assert before.mcp_state_bytes != after.mcp_state_bytes
     assert before.semantic_bytes != after.semantic_bytes
 
 
@@ -245,7 +246,7 @@ def test_capture_rejects_symlinked_ancestor_and_workspace_root(tmp_path: Path) -
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     (workspace / ".claude").symlink_to(outside, target_is_directory=True)
-    with pytest.raises(ValueError, match="symlinked lifecycle snapshot path"):
+    with pytest.raises(ValueError, match="outside workspace"):
         LifecycleStateSnapshot.capture(workspace, targets=("claude",))
 
     linked_workspace = tmp_path / "linked-workspace"
@@ -260,6 +261,22 @@ def test_capture_rejects_unknown_targets(tmp_path: Path) -> None:
 
     with pytest.raises(KeyError, match="not-a-target"):
         LifecycleStateSnapshot.capture(workspace, targets=("not-a-target",))
+
+
+def test_capture_rejects_target_relative_deployment_without_bounded_root(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    record = _record(
+        kind=LocatorKind.TARGET_RELATIVE,
+        target="claude",
+        value="rules/external.md",
+    )
+    _write_lock(workspace, (record,))
+
+    with pytest.raises(ValueError, match="target-relative"):
+        LifecycleStateSnapshot.capture(workspace, targets=("claude",))
 
 
 def test_capture_accepts_catalog_target_without_file_profile(tmp_path: Path) -> None:
@@ -289,6 +306,19 @@ def test_capture_marks_target_generated_file_as_compiled(tmp_path: Path) -> None
     assert snapshot.file(".github/copilot-instructions.md").roles == frozenset({"compiled"})
 
 
+def test_compiled_discovery_requires_a_file_target(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "AGENTS.md").write_bytes(b"# Compiled\n")
+
+    semantic_only = LifecycleStateSnapshot.capture(workspace)
+    with pytest.raises(KeyError, match="not tracked"):
+        semantic_only.file("AGENTS.md")
+
+    with_compiled = LifecycleStateSnapshot.capture(workspace, targets=("claude",))
+    assert with_compiled.file("AGENTS.md").roles == frozenset({"compiled"})
+
+
 def test_capture_reports_directory_kind_for_role_path(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     config_directory = workspace / ".custom/config.json"
@@ -303,3 +333,35 @@ def test_capture_reports_directory_kind_for_role_path(tmp_path: Path) -> None:
     assert state.kind == "directory"
     assert state.content is None
     assert state.sha256 is None
+
+
+def test_capture_reads_legacy_lock_when_canonical_lockfile_is_absent(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    lock = LockFile(generated_at="2026-01-01T00:00:00+00:00")
+    lock.write(workspace / "apm.lock")
+
+    snapshot = LifecycleStateSnapshot.capture(workspace)
+
+    assert not (workspace / "apm.lock.yaml").exists()
+    assert snapshot.lockfile_bytes == (workspace / "apm.lock").read_bytes()
+
+
+def test_capture_rejects_windows_drive_and_file_ancestor_paths(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    with pytest.raises(ValueError, match="relative POSIX"):
+        LifecycleStateSnapshot.capture(
+            workspace,
+            config_paths=(PurePosixPath("C:/outside/config.json"),),
+        )
+
+    (workspace / ".custom").write_bytes(b"not-a-directory")
+    with pytest.raises(ValueError, match="not a directory"):
+        LifecycleStateSnapshot.capture(
+            workspace,
+            config_paths=(PurePosixPath(".custom/config.json"),),
+        )

--- a/tests/integration/test_lifecycle_state_snapshot_contract.py
+++ b/tests/integration/test_lifecycle_state_snapshot_contract.py
@@ -11,7 +11,7 @@ from apm_cli.core.deployment_state import (
     LocatorKind,
 )
 from apm_cli.deps.lockfile import LockFile
-from tests.utils.lifecycle_state import LifecycleStateSnapshot
+from tests.utils.lifecycle_state import LifecycleStateRoot, LifecycleStateSnapshot
 
 
 def _record(
@@ -20,13 +20,14 @@ def _record(
     target: str,
     value: str,
     content_hash: str | None = None,
+    scope: str = "project",
 ) -> DeploymentRecord:
     locator = DeploymentLocator(
         kind=kind,
         target=target,
         value=value,
         runtime=None,
-        scope="project",
+        scope=scope,
     )
     return DeploymentRecord(
         locator=locator,
@@ -246,7 +247,7 @@ def test_capture_rejects_symlinked_ancestor_and_workspace_root(tmp_path: Path) -
     workspace = tmp_path / "workspace"
     workspace.mkdir()
     (workspace / ".claude").symlink_to(outside, target_is_directory=True)
-    with pytest.raises(ValueError, match="outside workspace"):
+    with pytest.raises(ValueError, match="outside bounded root"):
         LifecycleStateSnapshot.capture(workspace, targets=("claude",))
 
     linked_workspace = tmp_path / "linked-workspace"
@@ -277,6 +278,206 @@ def test_capture_rejects_target_relative_deployment_without_bounded_root(
 
     with pytest.raises(ValueError, match="target-relative"):
         LifecycleStateSnapshot.capture(workspace, targets=("claude",))
+
+
+def test_capture_reads_two_bounded_roots_without_relative_path_collisions(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    claude_root = tmp_path / "claude-home"
+    cursor_root = tmp_path / "cursor-home"
+    claude_root.mkdir()
+    cursor_root.mkdir()
+    (claude_root / "settings.json").write_bytes(b'{"client":"claude"}\n')
+    (cursor_root / "settings.json").write_bytes(b'{"client":"cursor"}\n')
+    claude_script = claude_root / "hooks/fixture/check.py"
+    claude_script.parent.mkdir(parents=True)
+    claude_script.write_bytes(b"print('bounded')\n")
+    records = (
+        _record(
+            kind=LocatorKind.TARGET_RELATIVE,
+            target="claude",
+            scope="user",
+            value="hooks/fixture/check.py",
+            content_hash="sha256:script",
+        ),
+        _record(
+            kind=LocatorKind.TARGET_RELATIVE,
+            target="cursor",
+            scope="user",
+            value="rules/missing.mdc",
+        ),
+        _record(
+            kind=LocatorKind.URI,
+            target="copilot-app",
+            scope="user",
+            value="copilot-app-db://workflows/external",
+        ),
+    )
+    _write_lock(workspace, records)
+    roots = (
+        LifecycleStateRoot(
+            root_id="claude-user",
+            target="claude",
+            scope="user",
+            path=claude_root,
+            config_paths=(PurePosixPath("settings.json"),),
+        ),
+        LifecycleStateRoot(
+            root_id="cursor-user",
+            target="cursor",
+            scope="user",
+            path=cursor_root,
+            config_paths=(
+                PurePosixPath("settings.json"),
+                PurePosixPath("rules/missing.mdc"),
+            ),
+        ),
+    )
+
+    snapshot = LifecycleStateSnapshot.capture(workspace, external_roots=roots)
+
+    claude_config = snapshot.file("settings.json", root_id="claude-user")
+    cursor_config = snapshot.file("settings.json", root_id="cursor-user")
+    script = snapshot.file("hooks/fixture/check.py", root_id="claude-user")
+    missing = snapshot.file("rules/missing.mdc", root_id="cursor-user")
+    assert claude_config.root_id == "claude-user"
+    assert claude_config.root_path == claude_root
+    assert claude_config.content == b'{"client":"claude"}\n'
+    assert cursor_config.root_id == "cursor-user"
+    assert cursor_config.root_path == cursor_root
+    assert cursor_config.content == b'{"client":"cursor"}\n'
+    assert script.roles == frozenset({"deployment"})
+    assert script.content == b"print('bounded')\n"
+    assert missing.kind == "missing"
+    assert missing.roles == frozenset({"config", "deployment"})
+    assert tuple((file.root_id, file.relative_path) for file in snapshot.files) == tuple(
+        sorted((file.root_id, file.relative_path) for file in snapshot.files)
+    )
+    with pytest.raises(KeyError, match="unknown-root"):
+        snapshot.file("settings.json", root_id="unknown-root")
+    with pytest.raises(KeyError, match="not tracked"):
+        snapshot.file("copilot-app-db://workflows/external", root_id="claude-user")
+
+
+def test_bounded_roots_fail_closed_before_outside_reads(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    root = tmp_path / "user-root"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    outside_file = outside / "secret.json"
+    outside_file.write_bytes(b'{"secret":"unchanged"}\n')
+    (root / "linked.json").symlink_to(outside_file)
+    _write_lock(
+        workspace,
+        (
+            _record(
+                kind=LocatorKind.TARGET_RELATIVE,
+                target="claude",
+                scope="user",
+                value="linked.json",
+            ),
+        ),
+    )
+    bounded = LifecycleStateRoot(
+        root_id="claude-user",
+        target="claude",
+        scope="user",
+        path=root,
+        config_paths=(PurePosixPath("linked.json"),),
+    )
+
+    snapshot = LifecycleStateSnapshot.capture(workspace, external_roots=(bounded,))
+
+    linked = snapshot.file("linked.json", root_id="claude-user")
+    assert linked.kind == "symlink"
+    assert linked.content is None
+    assert linked.link_target == str(outside_file)
+    assert outside_file.read_bytes() == b'{"secret":"unchanged"}\n'
+
+    linked_directory = root / "escape"
+    linked_directory.symlink_to(outside, target_is_directory=True)
+    escaping = LifecycleStateRoot(
+        root_id="claude-user",
+        target="claude",
+        scope="user",
+        path=root,
+        config_paths=(PurePosixPath("escape/secret.json"),),
+    )
+    with pytest.raises(ValueError, match="outside bounded root"):
+        LifecycleStateSnapshot.capture(workspace, external_roots=(escaping,))
+    assert outside_file.read_bytes() == b'{"secret":"unchanged"}\n'
+
+
+def test_bounded_root_identity_and_path_collisions_are_rejected(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    nested = first / "nested"
+    nested.mkdir()
+
+    duplicate_id = (
+        LifecycleStateRoot("same", "claude", "user", first),
+        LifecycleStateRoot("same", "cursor", "user", second),
+    )
+    duplicate_owner = (
+        LifecycleStateRoot("first", "claude", "user", first),
+        LifecycleStateRoot("second", "claude", "user", second),
+    )
+    duplicate_path = (
+        LifecycleStateRoot("first", "claude", "user", first),
+        LifecycleStateRoot("second", "cursor", "user", first),
+    )
+    nested_path = (
+        LifecycleStateRoot("first", "claude", "user", first),
+        LifecycleStateRoot("second", "cursor", "user", nested),
+    )
+    for roots, message in (
+        (duplicate_id, "root_id"),
+        (duplicate_owner, "target/scope"),
+        (duplicate_path, "overlap"),
+        (nested_path, "overlap"),
+    ):
+        with pytest.raises(ValueError, match=message):
+            LifecycleStateSnapshot.capture(workspace, external_roots=roots)
+
+    with pytest.raises(ValueError, match="reserved"):
+        LifecycleStateSnapshot.capture(
+            workspace,
+            external_roots=(LifecycleStateRoot("workspace", "claude", "user", first),),
+        )
+    with pytest.raises(ValueError, match="traversal sequence"):
+        LifecycleStateSnapshot.capture(
+            workspace,
+            external_roots=(
+                LifecycleStateRoot(
+                    "claude-user",
+                    "claude",
+                    "user",
+                    first,
+                    config_paths=(PurePosixPath("../outside"),),
+                ),
+            ),
+        )
+    with pytest.raises(ValueError, match="overlap"):
+        LifecycleStateSnapshot.capture(
+            workspace,
+            external_roots=(LifecycleStateRoot("claude-user", "claude", "user", workspace),),
+        )
+
+    linked_root = tmp_path / "linked-root"
+    linked_root.symlink_to(first, target_is_directory=True)
+    with pytest.raises(ValueError, match="must not be a symlink"):
+        LifecycleStateSnapshot.capture(
+            workspace,
+            external_roots=(LifecycleStateRoot("claude-user", "claude", "user", linked_root),),
+        )
 
 
 def test_capture_accepts_catalog_target_without_file_profile(tmp_path: Path) -> None:

--- a/tests/integration/test_lifecycle_state_snapshot_contract.py
+++ b/tests/integration/test_lifecycle_state_snapshot_contract.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+from apm_cli.core.deployment_state import (
+    DeploymentLedger,
+    DeploymentLocator,
+    DeploymentRecord,
+    LocatorKind,
+)
+from apm_cli.deps.lockfile import LockFile
+from tests.utils.lifecycle_state import LifecycleStateSnapshot
+
+
+def _record(
+    *,
+    kind: LocatorKind,
+    target: str,
+    value: str,
+    content_hash: str | None = None,
+) -> DeploymentRecord:
+    locator = DeploymentLocator(
+        kind=kind,
+        target=target,
+        value=value,
+        runtime=None,
+        scope="project",
+    )
+    return DeploymentRecord(
+        locator=locator,
+        owners=("fixture",),
+        active_owner="fixture",
+        content_hash=content_hash,
+    )
+
+
+def _write_lock(
+    workspace: Path,
+    records: tuple[DeploymentRecord, ...],
+    *,
+    generated_at: str = "2026-01-01T00:00:00+00:00",
+    mcp_label: str = "\u03bb",
+) -> None:
+    lock = LockFile(generated_at=generated_at)
+    lock.deployment_ledger = DeploymentLedger(
+        records={record.locator.key: record for record in records}
+    )
+    lock._deployments_present = True
+    lock.mcp_servers = ["fixture-mcp"]
+    lock.mcp_configs = {
+        "fixture-mcp": {
+            "name": "fixture-mcp",
+            "transport": "stdio",
+            "command": "fixture-mcp",
+            "label": mcp_label,
+        }
+    }
+    lock.lsp_servers = ["fixture-lsp"]
+    lock.lsp_configs = {
+        "fixture-lsp": {
+            "name": "fixture-lsp",
+            "command": "fixture-lsp",
+            "extensionToLanguage": {".py": "python"},
+        }
+    }
+    lock.write(workspace / "apm.lock.yaml")
+
+
+def test_capture_preserves_raw_bytes_and_canonical_semantics(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    manifest = b'name: fixture\nversion: 0.1.0\ndescription: "\\u03bb"\n'
+    (workspace / "apm.yml").write_bytes(manifest)
+    deployed = workspace / ".agents/skills/review/SKILL.md"
+    deployed.parent.mkdir(parents=True)
+    deployed_bytes = b"---\nname: review\n---\n# \xcf\x80\n"
+    deployed.write_bytes(deployed_bytes)
+    (workspace / "AGENTS.md").write_bytes(b"# Compiled\n")
+    hook_config = workspace / ".claude/settings.json"
+    hook_config.parent.mkdir(parents=True)
+    hook_config.write_bytes(b'{"hooks":{"PreToolUse":[]}}\n')
+    (workspace / ".claude/apm-hooks.json").write_bytes(
+        b'{"PreToolUse":[{"_apm_source":"fixture"}]}\n'
+    )
+    config = workspace / ".vscode/mcp.json"
+    config.parent.mkdir(parents=True)
+    config.write_bytes(b'{"servers":{"fixture-mcp":{"label":"\xcf\x80"}}}\n')
+
+    file_record = _record(
+        kind=LocatorKind.PROJECT_RELATIVE,
+        target="agents",
+        value=".agents/skills/review/SKILL.md",
+        content_hash="sha256:fixture",
+    )
+    uri_record = _record(
+        kind=LocatorKind.URI,
+        target="copilot-app",
+        value="copilot-app-db://workflows/dynamic-row",
+    )
+    _write_lock(workspace, (uri_record, file_record))
+
+    snapshot = LifecycleStateSnapshot.capture(
+        workspace,
+        targets=("claude",),
+        config_paths=(PurePosixPath(".vscode/mcp.json"),),
+    )
+
+    assert snapshot.manifest_bytes == manifest
+    assert snapshot.lockfile_bytes == (workspace / "apm.lock.yaml").read_bytes()
+    assert tuple(record.locator.key for record in snapshot.deployment_records) == tuple(
+        sorted((file_record.locator.key, uri_record.locator.key))
+    )
+    assert snapshot.mcp_state_json == (
+        b'{"configs":{"fixture-mcp":{"command":"fixture-mcp","label":"'
+        b'\\u03bb","name":"fixture-mcp","transport":"stdio"}},'
+        b'"provenance":{},"servers":["fixture-mcp"],"target_servers":{}}'
+    )
+    assert snapshot.lsp_state_json == (
+        b'{"configs":{"fixture-lsp":{"command":"fixture-lsp",'
+        b'"extensionToLanguage":{".py":"python"},"name":"fixture-lsp"}},'
+        b'"servers":["fixture-lsp"]}'
+    )
+    assert snapshot.file(".agents/skills/review/SKILL.md").content == deployed_bytes
+    assert snapshot.file(".agents/skills/review/SKILL.md").roles == frozenset({"deployment"})
+    assert snapshot.file(".claude/settings.json").roles == frozenset({"config", "hook-config"})
+    assert snapshot.file(".claude/apm-hooks.json").roles == frozenset({"config", "hook-sidecar"})
+    assert snapshot.file(".vscode/mcp.json").content == (
+        b'{"servers":{"fixture-mcp":{"label":"\xcf\x80"}}}\n'
+    )
+    assert snapshot.file("AGENTS.md").roles == frozenset({"compiled"})
+    assert snapshot.file("copilot-app-db://workflows/dynamic-row") is None
+    assert tuple(file.relative_path for file in snapshot.files) == tuple(
+        sorted(file.relative_path for file in snapshot.files)
+    )
+
+
+def test_semantic_state_ignores_yaml_formatting_and_generated_time(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "apm.yml").write_bytes(b"name: fixture\nversion: 0.1.0\n")
+    _write_lock(workspace, ())
+    before = LifecycleStateSnapshot.capture(workspace)
+
+    (workspace / "apm.yml").write_bytes(b"{version: 0.1.0, name: fixture}\n")
+    _write_lock(workspace, (), generated_at="2026-02-02T00:00:00+00:00")
+    after = LifecycleStateSnapshot.capture(workspace)
+
+    assert before.manifest_bytes != after.manifest_bytes
+    assert before.lockfile_bytes != after.lockfile_bytes
+    assert before.semantic_bytes == after.semantic_bytes
+
+
+def test_semantic_state_reflects_deployment_and_config_changes(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "apm.yml").write_bytes(b"name: fixture\nversion: 0.1.0\n")
+    _write_lock(workspace, ())
+    before = LifecycleStateSnapshot.capture(workspace)
+
+    record = _record(
+        kind=LocatorKind.PROJECT_RELATIVE,
+        target="copilot",
+        value=".github/instructions/rules.instructions.md",
+    )
+    _write_lock(workspace, (record,), mcp_label="changed")
+    after = LifecycleStateSnapshot.capture(workspace)
+
+    assert before.deployment_records == ()
+    assert after.deployment_records == (record,)
+    assert before.mcp_state_json != after.mcp_state_json
+    assert before.semantic_bytes != after.semantic_bytes
+
+
+def test_missing_state_and_missing_deployment_are_explicit(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    missing_record = _record(
+        kind=LocatorKind.PROJECT_RELATIVE,
+        target="copilot",
+        value=".github/instructions/missing.instructions.md",
+    )
+    _write_lock(workspace, (missing_record,))
+
+    snapshot = LifecycleStateSnapshot.capture(workspace)
+
+    assert snapshot.manifest_bytes is None
+    assert snapshot.lockfile_bytes is not None
+    missing = snapshot.file(".github/instructions/missing.instructions.md")
+    assert missing.kind == "missing"
+    assert missing.content is None
+    assert missing.sha256 is None
+    assert missing.roles == frozenset({"deployment"})
+
+    empty = LifecycleStateSnapshot.capture(tmp_path / "absent-workspace")
+    assert empty.manifest_bytes is None
+    assert empty.lockfile_bytes is None
+    assert empty.deployment_records == ()
+    assert empty.files == ()
+
+
+def test_capture_rejects_traversal_and_never_follows_workspace_symlinks(
+    tmp_path: Path,
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside.bin"
+    outside.write_bytes(b"do-not-read")
+    linked = workspace / "linked.bin"
+    linked.symlink_to(outside)
+    record = _record(
+        kind=LocatorKind.PROJECT_RELATIVE,
+        target="copilot",
+        value="linked.bin",
+    )
+    _write_lock(workspace, (record,))
+
+    with pytest.raises(ValueError, match="traversal sequence"):
+        LifecycleStateSnapshot.capture(
+            workspace,
+            config_paths=(PurePosixPath("../outside.bin"),),
+        )
+
+    snapshot = LifecycleStateSnapshot.capture(workspace)
+    state = snapshot.file("linked.bin")
+    assert state.kind == "symlink"
+    assert state.content is None
+    assert state.link_target == str(outside)
+    assert outside.read_bytes() == b"do-not-read"
+
+    linked_manifest_workspace = tmp_path / "linked-manifest-workspace"
+    linked_manifest_workspace.mkdir()
+    (linked_manifest_workspace / "apm.yml").symlink_to(outside)
+    with pytest.raises(ValueError, match="regular file"):
+        LifecycleStateSnapshot.capture(linked_manifest_workspace)
+    assert outside.read_bytes() == b"do-not-read"
+
+
+def test_capture_rejects_symlinked_ancestor_and_workspace_root(tmp_path: Path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "settings.json").write_bytes(b'{"outside":true}\n')
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / ".claude").symlink_to(outside, target_is_directory=True)
+    with pytest.raises(ValueError, match="symlinked lifecycle snapshot path"):
+        LifecycleStateSnapshot.capture(workspace, targets=("claude",))
+
+    linked_workspace = tmp_path / "linked-workspace"
+    linked_workspace.symlink_to(outside, target_is_directory=True)
+    with pytest.raises(ValueError, match="root must not be a symlink"):
+        LifecycleStateSnapshot.capture(linked_workspace)
+
+
+def test_capture_rejects_unknown_targets(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    with pytest.raises(KeyError, match="not-a-target"):
+        LifecycleStateSnapshot.capture(workspace, targets=("not-a-target",))
+
+
+def test_capture_accepts_catalog_target_without_file_profile(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config = workspace / ".idea/mcp.json"
+    config.parent.mkdir()
+    config.write_bytes(b'{"servers":{}}\n')
+
+    snapshot = LifecycleStateSnapshot.capture(
+        workspace,
+        targets=("intellij",),
+        config_paths=(PurePosixPath(".idea/mcp.json"),),
+    )
+
+    assert snapshot.file(".idea/mcp.json").roles == frozenset({"config"})
+
+
+def test_capture_marks_target_generated_file_as_compiled(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    generated = workspace / ".github/copilot-instructions.md"
+    generated.parent.mkdir(parents=True)
+    generated.write_bytes(b"# Generated instructions\n")
+
+    snapshot = LifecycleStateSnapshot.capture(workspace, targets=("copilot",))
+
+    assert snapshot.file(".github/copilot-instructions.md").roles == frozenset({"compiled"})
+
+
+def test_capture_reports_directory_kind_for_role_path(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    config_directory = workspace / ".custom/config.json"
+    config_directory.mkdir(parents=True)
+
+    snapshot = LifecycleStateSnapshot.capture(
+        workspace,
+        config_paths=(PurePosixPath(".custom/config.json"),),
+    )
+
+    state = snapshot.file(".custom/config.json")
+    assert state.kind == "directory"
+    assert state.content is None
+    assert state.sha256 is None

--- a/tests/integration/test_local_git_repository_factory_contract.py
+++ b/tests/integration/test_local_git_repository_factory_contract.py
@@ -214,6 +214,165 @@ def test_relative_root_resolves_once_at_the_intended_location(
     assert remote_main.stdout.split()[0] == commit.sha
 
 
+@pytest.mark.parametrize("remote_suffix", ("", ".git"))
+def test_install_url_rewrite_is_isolated_and_resolves_bare_and_git_forms(
+    tmp_path: Path,
+    remote_suffix: str,
+) -> None:
+    environment = _git_environment(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+    environment["HOME"] = str(home)
+    environment["USERPROFILE"] = str(home)
+    factory = LocalGitRepositoryFactory(
+        tmp_path / "repositories",
+        env=environment,
+    )
+    repository = factory.create("package")
+    (repository.worktree / "apm.yml").write_text(
+        "name: package\nversion: 0.1.0\n",
+        encoding="utf-8",
+    )
+    commit = factory.commit(repository, message="seed")
+    remote_base = "https://github.example.invalid/acme/package"
+
+    remote_forms = factory.install_url_rewrite(
+        repository,
+        f"{remote_base}{remote_suffix}",
+    )
+    assert factory.install_url_rewrite(repository, remote_base) == remote_forms
+
+    assert remote_forms == (remote_base, f"{remote_base}.git")
+    key = f"url.{repository.file_url}/.insteadOf"
+    configured = _run_git(
+        "config",
+        "--file",
+        environment["GIT_CONFIG_GLOBAL"],
+        "--get-all",
+        key,
+        environment=environment,
+    )
+    assert configured.stdout.splitlines() == list(remote_forms)
+    assert not (home / ".gitconfig").exists()
+
+    for remote_form in remote_forms:
+        resolved = _run_git(
+            "ls-remote",
+            remote_form,
+            "refs/heads/main",
+            environment=environment,
+        )
+        assert resolved.stdout.split()[0] == commit.sha
+
+    adjacent = factory.create("package.git-fork")
+    (adjacent.worktree / "apm.yml").write_text(
+        "name: adjacent\nversion: 0.1.0\n",
+        encoding="utf-8",
+    )
+    factory.commit(adjacent, message="seed adjacent")
+    adjacent_remote = _run_git(
+        "ls-remote",
+        f"{remote_base}.git-fork.git",
+        "refs/heads/main",
+        environment=environment,
+        check=False,
+    )
+    assert adjacent_remote.returncode != 0
+
+
+def test_install_url_rewrite_rejects_unsafe_inputs_before_config_mutation(
+    tmp_path: Path,
+) -> None:
+    environment = _git_environment(tmp_path)
+    home = tmp_path / "home"
+    home.mkdir()
+    environment["HOME"] = str(home)
+    environment["USERPROFILE"] = str(home)
+    factory = LocalGitRepositoryFactory(
+        tmp_path / "repositories",
+        env=environment,
+    )
+    repository = factory.create("package")
+    global_config = Path(environment["GIT_CONFIG_GLOBAL"])
+    original_global = global_config.read_bytes()
+
+    for remote_url in (
+        "",
+        " https://github.example.invalid/acme/package",
+        "file:///tmp/package.git",
+        "https://token@github.example.invalid/acme/package.git",
+        "https://github.example.invalid/acme/package?ref=main",
+        "https://github.example.invalid/acme/package#main",
+        "https://github.example.invalid/acme/../package",
+        "https://github.example.invalid/acme/package/",
+    ):
+        with pytest.raises(ValueError):
+            factory.install_url_rewrite(repository, remote_url)
+    assert global_config.read_bytes() == original_global
+    assert not (home / ".gitconfig").exists()
+
+    forged = LocalGitRepository(
+        origin=repository.origin,
+        worktree=repository.worktree,
+    )
+    with pytest.raises(ValueError, match="not owned"):
+        factory.install_url_rewrite(
+            forged,
+            "https://github.example.invalid/acme/package",
+        )
+    assert global_config.read_bytes() == original_global
+    assert not (home / ".gitconfig").exists()
+
+    outside_config = tmp_path / "outside.gitconfig"
+    outside_config.write_bytes(b"[safe]\n\tvalue = unchanged\n")
+    global_config.unlink()
+    global_config.symlink_to(outside_config)
+    with pytest.raises(ValueError, match="symlinked fixture Git config"):
+        factory.install_url_rewrite(
+            repository,
+            "https://github.example.invalid/acme/package",
+        )
+    assert outside_config.read_bytes() == b"[safe]\n\tvalue = unchanged\n"
+    assert not (home / ".gitconfig").exists()
+
+
+def test_install_url_rewrite_requires_bounded_fixture_git_config(tmp_path: Path) -> None:
+    scenario = tmp_path / "scenario"
+    scenario.mkdir()
+    home = scenario / "home"
+    home.mkdir()
+    environment = _git_environment(tmp_path)
+    environment["HOME"] = str(home)
+    environment["USERPROFILE"] = str(home)
+    outside_config = Path(environment["GIT_CONFIG_GLOBAL"])
+    original_config = outside_config.read_bytes()
+    factory = LocalGitRepositoryFactory(
+        scenario / "repositories",
+        env=environment,
+    )
+    repository = factory.create("package")
+
+    with pytest.raises(ValueError, match="outside the allowed base"):
+        factory.install_url_rewrite(
+            repository,
+            "https://github.example.invalid/acme/package",
+        )
+    assert outside_config.read_bytes() == original_config
+
+    isolated_environment = _git_environment(scenario)
+    isolated_environment.pop("GIT_CONFIG_NOSYSTEM")
+    unguarded_factory = LocalGitRepositoryFactory(
+        scenario / "unguarded-repositories",
+        env=isolated_environment,
+    )
+    unguarded_repository = unguarded_factory.create("package")
+    with pytest.raises(ValueError, match="GIT_CONFIG_NOSYSTEM=1"):
+        unguarded_factory.install_url_rewrite(
+            unguarded_repository,
+            "https://github.example.invalid/acme/package",
+        )
+
+
 def test_same_source_sequence_produces_deterministic_commit(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_local_package_factory_contract.py
+++ b/tests/integration/test_local_package_factory_contract.py
@@ -837,8 +837,11 @@ def test_config_dependency_validation_is_transactional(tmp_path: Path) -> None:
             "invalid-lsp",
             lsp_dependencies=({"name": "invalid", "command": "fixture-lsp"},),
         )
+    with pytest.raises(TypeError, match="strings or mappings"):
+        factory.create("invalid-mcp-type", mcp_dependencies=(42,))
     assert not (tmp_path / "packages/invalid-mcp").exists()
     assert not (tmp_path / "packages/invalid-lsp").exists()
+    assert not (tmp_path / "packages/invalid-mcp-type").exists()
 
 
 def test_lifecycle_sources_accept_mcp_and_lsp_string_references(tmp_path: Path) -> None:

--- a/tests/integration/test_local_package_factory_contract.py
+++ b/tests/integration/test_local_package_factory_contract.py
@@ -848,6 +848,28 @@ def test_config_dependency_validation_is_transactional(tmp_path: Path) -> None:
     assert not (tmp_path / "packages/invalid-mcp-type").exists()
 
 
+def test_config_dependency_round_trip_guards_reject_loss_and_semantic_drift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    entry = {
+        "name": "fixture-mcp",
+        "registry": False,
+        "transport": "stdio",
+        "command": "fixture-mcp",
+    }
+
+    monkeypatch.setattr("tests.utils.local_package.load_yaml_str", lambda _text: None)
+    with pytest.raises(ValueError, match="did not survive YAML serialization"):
+        LocalPackageFactory._validate_config_dependencies((entry,), kind="MCP")
+
+    monkeypatch.setattr(
+        "tests.utils.local_package.load_yaml_str",
+        lambda _text: {"dependency": {"name": "different-server"}},
+    )
+    with pytest.raises(ValueError, match="failed semantic round-trip validation"):
+        LocalPackageFactory._validate_config_dependencies((entry,), kind="MCP")
+
+
 def test_lifecycle_sources_accept_mcp_and_lsp_string_references(tmp_path: Path) -> None:
     factory = LocalPackageFactory(tmp_path / "packages")
     package = factory.create(

--- a/tests/integration/test_local_package_factory_contract.py
+++ b/tests/integration/test_local_package_factory_contract.py
@@ -3,6 +3,7 @@ from pathlib import Path, PurePosixPath
 import pytest
 
 from apm_cli.core.errors import UnknownTargetError
+from apm_cli.models.apm_package import APMPackage
 from apm_cli.models.dependency import DependencyReference
 from apm_cli.utils.yaml_io import dump_yaml, load_yaml
 from tests.utils.local_package import LocalPackage, LocalPackageFactory
@@ -680,3 +681,182 @@ def test_product_output_paths_are_rejected(tmp_path: Path) -> None:
         ".claude",
     ):
         assert not (package.root / forbidden).exists()
+
+
+def test_lifecycle_sources_cover_all_deploy_categories_and_config_dependencies(
+    tmp_path: Path,
+) -> None:
+    factory = LocalPackageFactory(tmp_path / "packages")
+    package = factory.create(
+        "lifecycle-source",
+        targets=("copilot", "claude"),
+        mcp_dependencies=(
+            {
+                "name": "fixture-mcp",
+                "registry": False,
+                "transport": "stdio",
+                "command": "fixture-mcp",
+                "args": ["--stdio"],
+            },
+        ),
+        lsp_dependencies=(
+            {
+                "name": "fixture-lsp",
+                "command": "fixture-lsp",
+                "extensionToLanguage": {".py": "python"},
+            },
+        ),
+    )
+
+    skill = factory.add_skill(package, "review", "# Review\n")
+    agent = factory.add_agent(package, "helper", "---\ndescription: Helper\n---\n# Helper\n")
+    prompt = factory.add_prompt(
+        package,
+        "summarize",
+        "---\ndescription: Summarize\n---\nSummarize this repository.\n",
+    )
+    command = factory.add_command(
+        package,
+        "check",
+        "---\ndescription: Check\n---\nCheck this repository.\n",
+    )
+    instruction = factory.add_instruction(
+        package,
+        "rules",
+        "---\ndescription: Rules\n---\n# Rules\n",
+    )
+    hook = factory.add_hook(
+        package,
+        "lifecycle",
+        {"hooks": {"PreToolUse": [{"command": "python scripts/check.py"}]}},
+    )
+    canvas = factory.add_canvas(
+        package,
+        "inspector",
+        "export default { activate() {} };\n",
+        assets={
+            PurePosixPath("ui/config.json"): b'{"label":"\\u03bb"}\n',
+            PurePosixPath("ui/icon.bin"): b"\x00\xff",
+        },
+    )
+
+    assert skill == package.root / "skills/review/SKILL.md"
+    assert agent == package.root / ".apm/agents/helper.agent.md"
+    assert prompt == package.root / ".apm/prompts/summarize.prompt.md"
+    assert command == package.root / ".apm/prompts/check.prompt.md"
+    assert instruction == package.root / ".apm/instructions/rules.instructions.md"
+    assert hook == package.root / ".apm/hooks/lifecycle.json"
+    assert canvas == package.root / ".apm/extensions/inspector"
+    assert hook.read_bytes() == (
+        b'{\n  "hooks": {\n    "PreToolUse": [\n'
+        b'      {\n        "command": "python scripts/check.py"\n'
+        b"      }\n    ]\n  }\n}\n"
+    )
+    assert (canvas / "extension.mjs").read_bytes() == (b"export default { activate() {} };\n")
+    assert (canvas / "ui/config.json").read_bytes() == b'{"label":"\\u03bb"}\n'
+    assert (canvas / "ui/icon.bin").read_bytes() == b"\x00\xff"
+
+    parsed = APMPackage.from_apm_yml(package.manifest_path)
+    assert parsed.dependencies is not None
+    assert [dependency.to_dict() for dependency in parsed.dependencies["mcp"]] == [
+        {
+            "name": "fixture-mcp",
+            "transport": "stdio",
+            "args": ["--stdio"],
+            "registry": False,
+            "command": "fixture-mcp",
+        }
+    ]
+    assert [dependency.to_dict() for dependency in parsed.dependencies["lsp"]] == [
+        {
+            "name": "fixture-lsp",
+            "command": "fixture-lsp",
+            "extensionToLanguage": {".py": "python"},
+        }
+    ]
+
+
+def test_lifecycle_source_authors_reject_traversal_and_symlink_escape(
+    tmp_path: Path,
+) -> None:
+    factory = LocalPackageFactory(tmp_path / "packages")
+    package = factory.create("lifecycle-source")
+
+    with pytest.raises(ValueError, match="traversal sequence"):
+        factory.add_prompt(package, "../outside", "prompt")
+    with pytest.raises(ValueError, match="traversal sequence"):
+        factory.add_command(package, "../outside", "command")
+    with pytest.raises(ValueError, match="traversal sequence"):
+        factory.add_hook(package, "../outside", {"hooks": {}})
+    with pytest.raises(ValueError, match="traversal sequence"):
+        factory.add_canvas(package, "../outside", "export default {};\n")
+    with pytest.raises(ValueError, match="traversal sequence"):
+        factory.add_canvas(
+            package,
+            "safe",
+            "export default {};\n",
+            assets={PurePosixPath("../outside.bin"): b"outside"},
+        )
+    with pytest.raises(TypeError, match="contents must be bytes"):
+        factory.add_canvas(
+            package,
+            "invalid-content",
+            "export default {};\n",
+            assets={PurePosixPath("asset.txt"): "not-bytes"},
+        )
+    assert not (tmp_path / "outside").exists()
+    assert not (tmp_path / "outside.bin").exists()
+    assert not (package.root / ".apm/extensions/invalid-content").exists()
+
+    outside = tmp_path / "outside-extensions"
+    outside.mkdir()
+    extensions = package.root / ".apm/extensions"
+    extensions.parent.mkdir(parents=True)
+    extensions.symlink_to(outside, target_is_directory=True)
+    with pytest.raises(ValueError, match=r"outside|symlink"):
+        factory.add_canvas(package, "escaped", "export default {};\n")
+    assert not (outside / "escaped").exists()
+
+
+def test_config_dependency_validation_is_transactional(tmp_path: Path) -> None:
+    factory = LocalPackageFactory(tmp_path / "packages")
+
+    with pytest.raises(ValueError, match="requires 'command'"):
+        factory.create(
+            "invalid-mcp",
+            mcp_dependencies=(
+                {
+                    "name": "invalid",
+                    "registry": False,
+                    "transport": "stdio",
+                },
+            ),
+        )
+    with pytest.raises(ValueError, match="requires 'extensionToLanguage'"):
+        factory.create(
+            "invalid-lsp",
+            lsp_dependencies=({"name": "invalid", "command": "fixture-lsp"},),
+        )
+    assert not (tmp_path / "packages/invalid-mcp").exists()
+    assert not (tmp_path / "packages/invalid-lsp").exists()
+
+
+def test_lifecycle_sources_accept_mcp_and_lsp_string_references(tmp_path: Path) -> None:
+    factory = LocalPackageFactory(tmp_path / "packages")
+    package = factory.create(
+        "registry-config-source",
+        mcp_dependencies=("io.github.acme/fixture-mcp",),
+        lsp_dependencies=("fixture-lsp",),
+    )
+
+    parsed = APMPackage.from_apm_yml(package.manifest_path)
+
+    assert parsed.dependencies is not None
+    assert [dependency.name for dependency in parsed.dependencies["mcp"]] == [
+        "io.github.acme/fixture-mcp"
+    ]
+    assert [dependency.name for dependency in parsed.dependencies["lsp"]] == ["fixture-lsp"]
+    assert load_yaml(package.manifest_path)["dependencies"] == {
+        "mcp": ["io.github.acme/fixture-mcp"],
+        "lsp": ["fixture-lsp"],
+    }

--- a/tests/integration/test_local_package_factory_contract.py
+++ b/tests/integration/test_local_package_factory_contract.py
@@ -1,3 +1,5 @@
+import json
+import os
 from pathlib import Path, PurePosixPath
 
 import pytest
@@ -865,3 +867,200 @@ def test_lifecycle_sources_accept_mcp_and_lsp_string_references(tmp_path: Path) 
         "mcp": ["io.github.acme/fixture-mcp"],
         "lsp": ["fixture-lsp"],
     }
+
+
+def test_hook_assets_are_bounded_source_files_with_executable_intent(
+    tmp_path: Path,
+) -> None:
+    factory = LocalPackageFactory(tmp_path / "packages")
+    package = factory.create("hook-source")
+    hook_document = {
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "command": "python ./lifecycle/scripts/check.py",
+                }
+            ]
+        }
+    }
+    hook = factory.add_hook(package, "lifecycle", hook_document)
+
+    script = factory.add_hook_asset(
+        package,
+        "lifecycle",
+        PurePosixPath("scripts/check.py"),
+        "print('hook')\n",
+        executable=True,
+    )
+    binary = factory.add_hook_asset(
+        package,
+        "lifecycle",
+        PurePosixPath("assets/payload.bin"),
+        b"\x00\xffhook\n",
+    )
+
+    assert hook == package.root / ".apm/hooks/lifecycle.json"
+    assert script == package.root / ".apm/hooks/lifecycle/scripts/check.py"
+    assert binary == package.root / ".apm/hooks/lifecycle/assets/payload.bin"
+    assert script.read_bytes() == b"print('hook')\n"
+    assert binary.read_bytes() == b"\x00\xffhook\n"
+    if os.name != "nt":
+        assert script.stat().st_mode & 0o111 == 0o111
+        assert binary.stat().st_mode & 0o111 == 0
+    assert json.loads(hook.read_text(encoding="utf-8")) == hook_document
+
+
+def test_hook_assets_reject_escape_replacement_and_foreign_packages(
+    tmp_path: Path,
+) -> None:
+    factory = LocalPackageFactory(tmp_path / "packages")
+    package = factory.create("hook-source")
+    hook = factory.add_hook(package, "lifecycle", {"hooks": {}})
+    hook_bytes = hook.read_bytes()
+
+    for relative_path in (
+        PurePosixPath("."),
+        PurePosixPath("../lifecycle.json"),
+        PurePosixPath("/outside.py"),
+        PurePosixPath(r"..\outside.py"),
+        PurePosixPath("%252e%252e/outside.py"),
+    ):
+        with pytest.raises(ValueError):
+            factory.add_hook_asset(
+                package,
+                "lifecycle",
+                relative_path,
+                b"outside",
+            )
+    with pytest.raises(TypeError, match="text or bytes"):
+        factory.add_hook_asset(
+            package,
+            "lifecycle",
+            PurePosixPath("scripts/check.py"),
+            object(),
+        )
+    assert hook.read_bytes() == hook_bytes
+    assert not (tmp_path / "outside.py").exists()
+
+    without_descriptor = factory.create("missing-hook")
+    with pytest.raises(ValueError, match="descriptor"):
+        factory.add_hook_asset(
+            without_descriptor,
+            "lifecycle",
+            PurePosixPath("scripts/check.py"),
+            b"missing",
+        )
+
+    foreign_factory = LocalPackageFactory(tmp_path / "foreign")
+    foreign = foreign_factory.create("foreign")
+    foreign_factory.add_hook(foreign, "lifecycle", {"hooks": {}})
+    with pytest.raises(ValueError, match="not owned"):
+        factory.add_hook_asset(
+            foreign,
+            "lifecycle",
+            PurePosixPath("scripts/check.py"),
+            b"foreign",
+        )
+
+    outside = tmp_path / "outside-assets"
+    outside.mkdir()
+    asset_root = package.root / ".apm/hooks/lifecycle"
+    asset_root.symlink_to(outside, target_is_directory=True)
+    with pytest.raises(ValueError, match=r"outside|symlink"):
+        factory.add_hook_asset(
+            package,
+            "lifecycle",
+            PurePosixPath("scripts/check.py"),
+            b"escaped",
+        )
+    assert not (outside / "scripts/check.py").exists()
+
+
+def test_manifest_transitions_preserve_unrelated_sections_and_are_idempotent(
+    tmp_path: Path,
+) -> None:
+    factory = LocalPackageFactory(tmp_path / "packages")
+    package = factory.create(
+        "consumer",
+        mcp_dependencies=("io.github.acme/server",),
+    )
+    manifest = load_yaml(package.manifest_path)
+    manifest["compilation"] = {"output": "AGENTS.md"}
+    manifest["allowExecutables"] = {"acme/hooks#v1": {"hooks": True}}
+    dump_yaml(manifest, package.manifest_path)
+    dependencies = (
+        "acme/first#v1.0.0",
+        {
+            "git": "https://gitlab.example.invalid/acme/second.git",
+            "type": "gitlab",
+            "ref": "main",
+            "alias": "second",
+        },
+    )
+
+    factory.set_targets(package, ("copilot", "claude"))
+    factory.replace_apm_dependencies(package, dependencies)
+    first_bytes = package.manifest_path.read_bytes()
+    factory.set_targets(package, ("copilot", "claude"))
+    factory.replace_apm_dependencies(package, dependencies)
+
+    transitioned = load_yaml(package.manifest_path)
+    assert package.manifest_path.read_bytes() == first_bytes
+    assert transitioned["targets"] == ["copilot", "claude"]
+    assert transitioned["dependencies"] == {
+        "apm": list(dependencies),
+        "mcp": ["io.github.acme/server"],
+    }
+    assert transitioned["compilation"] == {"output": "AGENTS.md"}
+    assert transitioned["allowExecutables"] == {"acme/hooks#v1": {"hooks": True}}
+
+    identity_equivalent = "https://github.com/acme/first.git#v9.9.9"
+    assert factory.remove_apm_dependency(package, identity_equivalent) is True
+    removed_bytes = package.manifest_path.read_bytes()
+    assert factory.remove_apm_dependency(package, identity_equivalent) is False
+    assert package.manifest_path.read_bytes() == removed_bytes
+    assert load_yaml(package.manifest_path)["dependencies"]["apm"] == [dependencies[1]]
+
+    factory.replace_apm_dependencies(package, ())
+    factory.set_targets(package, ())
+    contracted = load_yaml(package.manifest_path)
+    assert contracted["dependencies"] == {"mcp": ["io.github.acme/server"]}
+    assert "targets" not in contracted
+    assert contracted["compilation"] == {"output": "AGENTS.md"}
+
+
+def test_manifest_transitions_reject_invalid_inputs_without_partial_write(
+    tmp_path: Path,
+) -> None:
+    factory = LocalPackageFactory(tmp_path / "packages")
+    package = factory.create(
+        "consumer",
+        dependencies=("acme/original#v1.0.0",),
+        targets=("copilot",),
+    )
+    original = package.manifest_path.read_bytes()
+
+    with pytest.raises(UnknownTargetError, match="Unknown target"):
+        factory.set_targets(package, ("not-a-target",))
+    with pytest.raises(ValueError, match="Unsupported field"):
+        factory.replace_apm_dependencies(
+            package,
+            (
+                {
+                    "git": "acme/repository",
+                    "resolved_commit": "a" * 40,
+                },
+            ),
+        )
+    with pytest.raises(TypeError, match="strings or mappings"):
+        factory.remove_apm_dependency(package, 42)
+    assert package.manifest_path.read_bytes() == original
+
+    foreign_factory = LocalPackageFactory(tmp_path / "foreign")
+    foreign = foreign_factory.create("foreign")
+    with pytest.raises(ValueError, match="not owned"):
+        factory.set_targets(foreign, ("copilot",))
+    with pytest.raises(ValueError, match="not owned"):
+        factory.replace_apm_dependencies(foreign, ())
+    with pytest.raises(ValueError, match="not owned"):
+        factory.remove_apm_dependency(foreign, "acme/original#v1.0.0")

--- a/tests/integration/test_local_package_factory_contract.py
+++ b/tests/integration/test_local_package_factory_contract.py
@@ -821,6 +821,8 @@ def test_lifecycle_source_authors_reject_traversal_and_symlink_escape(
 def test_config_dependency_validation_is_transactional(tmp_path: Path) -> None:
     factory = LocalPackageFactory(tmp_path / "packages")
 
+    with pytest.raises(ValueError, match="Unsupported config dependency kind"):
+        factory._validate_config_dependencies((), kind="mcp")
     with pytest.raises(ValueError, match="requires 'command'"):
         factory.create(
             "invalid-mcp",

--- a/tests/utils/artifact_snapshot.py
+++ b/tests/utils/artifact_snapshot.py
@@ -1,4 +1,8 @@
-"""Read-only snapshots and assertions for filesystem artifact tests."""
+"""Read-only snapshots and assertions for filesystem artifact tests.
+
+For lifecycle-aware manifest, lock, config, and deployment state, use
+``LifecycleStateSnapshot`` instead.
+"""
 
 from __future__ import annotations
 

--- a/tests/utils/lifecycle_state.py
+++ b/tests/utils/lifecycle_state.py
@@ -16,6 +16,7 @@ from typing import Literal, TypeAlias
 
 from apm_cli.core.deployment_ledger import DeploymentLedgerCodec
 from apm_cli.core.deployment_state import DeploymentRecord, LocatorKind
+from apm_cli.core.scope import InstallScope
 from apm_cli.core.target_catalog import get_target_capability
 from apm_cli.deps.lockfile import LEGACY_LOCKFILE_NAME, LOCKFILE_NAME, LockFile
 from apm_cli.integration.hook_integrator import _APM_HOOKS_SIDECAR
@@ -37,12 +38,26 @@ LifecycleFileRole: TypeAlias = Literal[
     "compiled",
 ]
 _COMPILED_NAMES = frozenset({"AGENTS.md", "CLAUDE.md", "GEMINI.md"})
+_WORKSPACE_ROOT_ID = "workspace"
+
+
+@dataclass(frozen=True)
+class LifecycleStateRoot:
+    """One caller-bounded external target root and selected native configs."""
+
+    root_id: str
+    target: str
+    scope: str
+    path: Path
+    config_paths: tuple[PurePosixPath, ...] = ()
 
 
 @dataclass(frozen=True)
 class LifecycleFileState:
-    """Exact bytes and classification for one workspace-contained path."""
+    """Exact bytes and classification for one explicitly bounded root path."""
 
+    root_id: str
+    root_path: Path
     relative_path: str
     kind: LifecycleFileKind
     roles: frozenset[LifecycleFileRole]
@@ -61,6 +76,7 @@ class LifecycleStateSnapshot:
     """
 
     workspace_root: Path
+    external_roots: tuple[LifecycleStateRoot, ...]
     manifest_bytes: bytes | None
     lockfile_bytes: bytes | None
     deployment_records: tuple[DeploymentRecord, ...]
@@ -76,8 +92,9 @@ class LifecycleStateSnapshot:
         *,
         targets: Sequence[str] = (),
         config_paths: Sequence[PurePosixPath] = (),
+        external_roots: Sequence[LifecycleStateRoot] = (),
     ) -> LifecycleStateSnapshot:
-        """Capture deterministic durable state without reading outside the workspace."""
+        """Capture deterministic durable state from explicit non-overlapping roots."""
         root = workspace_root.absolute()
         if root.is_symlink():
             raise ValueError(f"Lifecycle workspace root must not be a symlink: {root}")
@@ -89,9 +106,20 @@ class LifecycleStateSnapshot:
             if profile is not None:
                 profiles.append(profile)
 
+        normalized_roots = _validate_external_roots(root, external_roots)
+        root_paths = {
+            _WORKSPACE_ROOT_ID: root,
+            **{external.root_id: external.path for external in normalized_roots},
+        }
+        roots_by_owner = {
+            (external.target, external.scope): external for external in normalized_roots
+        }
         if not root.exists():
+            if normalized_roots:
+                raise ValueError("Lifecycle workspace root must exist when external roots are used")
             return cls(
                 workspace_root=root,
+                external_roots=(),
                 manifest_bytes=None,
                 lockfile_bytes=None,
                 deployment_records=(),
@@ -127,48 +155,100 @@ class LifecycleStateSnapshot:
             if lock is not None
             else ()
         )
-        target_relative = tuple(
-            record.locator.key
-            for record in records
-            if record.locator.kind is LocatorKind.TARGET_RELATIVE
-        )
-        if target_relative:
-            raise ValueError(
-                "Lifecycle snapshots require explicit bounded roots for "
-                f"target-relative deployments: {sorted(target_relative)}"
-            )
         mcp_state = _mcp_state(lock)
         lsp_state = _lsp_state(lock)
 
-        roles_by_path: dict[str, set[LifecycleFileRole]] = {}
+        roles_by_path: dict[tuple[str, str], set[LifecycleFileRole]] = {}
         for record in records:
             if record.locator.kind is LocatorKind.PROJECT_RELATIVE:
                 _add_role(
                     roles_by_path,
+                    _WORKSPACE_ROOT_ID,
+                    record.locator.value,
+                    "deployment",
+                )
+            elif record.locator.kind is LocatorKind.TARGET_RELATIVE:
+                external = roots_by_owner.get((record.locator.target, record.locator.scope))
+                if external is None:
+                    raise ValueError(
+                        "Lifecycle snapshot has no bounded root for target-relative "
+                        f"deployment {record.locator.key!r}"
+                    )
+                _add_role(
+                    roles_by_path,
+                    external.root_id,
                     record.locator.value,
                     "deployment",
                 )
         for relative_path in config_paths:
-            _add_role(roles_by_path, relative_path.as_posix(), "config")
+            _add_role(
+                roles_by_path,
+                _WORKSPACE_ROOT_ID,
+                relative_path.as_posix(),
+                "config",
+            )
+        for external in normalized_roots:
+            for relative_path in external.config_paths:
+                _add_role(
+                    roles_by_path,
+                    external.root_id,
+                    relative_path.as_posix(),
+                    "config",
+                )
         for profile in profiles:
             if profile.hooks_config_display:
                 hook_path = PurePosixPath(profile.hooks_config_display)
-                _add_role(roles_by_path, hook_path.as_posix(), "config")
-                _add_role(roles_by_path, hook_path.as_posix(), "hook-config")
+                _add_role(
+                    roles_by_path,
+                    _WORKSPACE_ROOT_ID,
+                    hook_path.as_posix(),
+                    "config",
+                )
+                _add_role(
+                    roles_by_path,
+                    _WORKSPACE_ROOT_ID,
+                    hook_path.as_posix(),
+                    "hook-config",
+                )
                 sidecar = hook_path.parent / _APM_HOOKS_SIDECAR
-                _add_role(roles_by_path, sidecar.as_posix(), "config")
-                _add_role(roles_by_path, sidecar.as_posix(), "hook-sidecar")
+                _add_role(
+                    roles_by_path,
+                    _WORKSPACE_ROOT_ID,
+                    sidecar.as_posix(),
+                    "config",
+                )
+                _add_role(
+                    roles_by_path,
+                    _WORKSPACE_ROOT_ID,
+                    sidecar.as_posix(),
+                    "hook-sidecar",
+                )
             for generated in profile.generated_files:
                 relative = PurePosixPath(profile.root_dir) / generated
-                _add_role(roles_by_path, relative.as_posix(), "compiled")
+                _add_role(
+                    roles_by_path,
+                    _WORKSPACE_ROOT_ID,
+                    relative.as_posix(),
+                    "compiled",
+                )
 
         if profiles:
             for relative_path in _compiled_paths(root):
-                _add_role(roles_by_path, relative_path, "compiled")
+                _add_role(
+                    roles_by_path,
+                    _WORKSPACE_ROOT_ID,
+                    relative_path,
+                    "compiled",
+                )
 
         files = tuple(
-            _capture_file(root, relative_path, frozenset(roles_by_path[relative_path]))
-            for relative_path in sorted(roles_by_path)
+            _capture_file(
+                root_paths[root_id],
+                root_id,
+                relative_path,
+                frozenset(roles_by_path[(root_id, relative_path)]),
+            )
+            for root_id, relative_path in sorted(roles_by_path)
         )
         manifest_semantic = (
             load_yaml_str(manifest_bytes.decode("utf-8")) if manifest_bytes is not None else None
@@ -180,6 +260,7 @@ class LifecycleStateSnapshot:
                 "lock": lock_semantic,
                 "files": [
                     {
+                        "root_id": file.root_id,
                         "path": file.relative_path,
                         "kind": file.kind,
                         "roles": sorted(file.roles),
@@ -192,6 +273,7 @@ class LifecycleStateSnapshot:
         )
         return cls(
             workspace_root=root,
+            external_roots=normalized_roots,
             manifest_bytes=manifest_bytes,
             lockfile_bytes=lockfile_bytes,
             deployment_records=records,
@@ -201,35 +283,42 @@ class LifecycleStateSnapshot:
             semantic_bytes=semantic_bytes,
         )
 
-    def file(self, relative_path: str) -> LifecycleFileState:
+    def file(
+        self,
+        relative_path: str,
+        *,
+        root_id: str = _WORKSPACE_ROOT_ID,
+    ) -> LifecycleFileState:
         """Return a tracked file state, failing clearly for untracked paths."""
+        known_roots = {_WORKSPACE_ROOT_ID, *(root.root_id for root in self.external_roots)}
+        if root_id not in known_roots:
+            raise KeyError(f"Unknown lifecycle snapshot root_id {root_id!r}")
         for file in self.files:
-            if file.relative_path == relative_path:
+            if file.root_id == root_id and file.relative_path == relative_path:
                 return file
-        tracked = ", ".join(file.relative_path for file in self.files) or "<none>"
+        tracked = (
+            ", ".join(file.relative_path for file in self.files if file.root_id == root_id)
+            or "<none>"
+        )
         raise KeyError(
-            f"Lifecycle snapshot path {relative_path!r} is not tracked; tracked paths: {tracked}"
+            f"Lifecycle snapshot path {relative_path!r} is not tracked in "
+            f"root {root_id!r}; tracked paths: {tracked}"
         )
 
 
 def _add_role(
-    roles_by_path: dict[str, set[LifecycleFileRole]],
+    roles_by_path: dict[tuple[str, str], set[LifecycleFileRole]],
+    root_id: str,
     relative_path: str,
     role: LifecycleFileRole,
 ) -> None:
-    validate_path_segments(
-        relative_path,
-        context="lifecycle snapshot path",
-        reject_empty=True,
-    )
-    path = PurePosixPath(relative_path)
-    if path.is_absolute() or "\\" in relative_path or PureWindowsPath(relative_path).drive:
-        raise ValueError(f"Lifecycle snapshot path must be relative POSIX: {relative_path}")
-    roles_by_path.setdefault(path.as_posix(), set()).add(role)
+    path = _validate_relative_state_path(relative_path)
+    roles_by_path.setdefault((root_id, path.as_posix()), set()).add(role)
 
 
 def _capture_file(
     root: Path,
+    root_id: str,
     relative_path: str,
     roles: frozenset[LifecycleFileRole],
 ) -> LifecycleFileState:
@@ -237,11 +326,15 @@ def _capture_file(
     try:
         ensure_path_within(path.parent, root)
     except PathTraversalError as exc:
-        raise ValueError(f"Refusing lifecycle snapshot path outside workspace: {path}") from exc
+        raise ValueError(
+            f"Refusing lifecycle snapshot path outside bounded root {root_id!r}: {path}"
+        ) from exc
     try:
         metadata = path.lstat()
     except FileNotFoundError:
         return LifecycleFileState(
+            root_id=root_id,
+            root_path=root,
             relative_path=relative_path,
             kind="missing",
             roles=roles,
@@ -252,6 +345,8 @@ def _capture_file(
         raise ValueError(f"Lifecycle snapshot path ancestor is not a directory: {path}") from exc
     if stat.S_ISLNK(metadata.st_mode):
         return LifecycleFileState(
+            root_id=root_id,
+            root_path=root,
             relative_path=relative_path,
             kind="symlink",
             roles=roles,
@@ -261,6 +356,8 @@ def _capture_file(
         )
     if stat.S_ISDIR(metadata.st_mode):
         return LifecycleFileState(
+            root_id=root_id,
+            root_path=root,
             relative_path=relative_path,
             kind="directory",
             roles=roles,
@@ -271,12 +368,83 @@ def _capture_file(
         raise ValueError(f"Unsupported lifecycle snapshot file type: {path}")
     content = path.read_bytes()
     return LifecycleFileState(
+        root_id=root_id,
+        root_path=root,
         relative_path=relative_path,
         kind="file",
         roles=roles,
         content=content,
         sha256=hashlib.sha256(content).hexdigest(),
     )
+
+
+def _validate_external_roots(
+    workspace_root: Path,
+    external_roots: Sequence[LifecycleStateRoot],
+) -> tuple[LifecycleStateRoot, ...]:
+    normalized: list[LifecycleStateRoot] = []
+    root_ids: set[str] = set()
+    owners: set[tuple[str, str]] = set()
+    bounded_paths = [workspace_root.resolve()]
+    for external in external_roots:
+        validate_path_segments(
+            external.root_id,
+            context="lifecycle root_id",
+            reject_empty=True,
+        )
+        if external.root_id == _WORKSPACE_ROOT_ID:
+            raise ValueError(f"Lifecycle root_id {_WORKSPACE_ROOT_ID!r} is reserved")
+        if external.root_id in root_ids:
+            raise ValueError(f"Duplicate lifecycle root_id: {external.root_id!r}")
+        capability = get_target_capability(external.target)
+        if capability.name != external.target:
+            raise ValueError(f"Lifecycle state root target must be canonical: {external.target!r}")
+        scope = InstallScope(external.scope).value
+        owner = (external.target, scope)
+        if owner in owners:
+            raise ValueError(
+                f"Duplicate lifecycle target/scope root: {external.target!r}/{scope!r}"
+            )
+        path = external.path.absolute()
+        if path.is_symlink():
+            raise ValueError(f"Lifecycle external root must not be a symlink: {path}")
+        if not path.is_dir():
+            raise ValueError(f"Lifecycle external root must be a directory: {path}")
+        resolved = path.resolve()
+        for bounded in bounded_paths:
+            if (
+                resolved == bounded
+                or resolved.is_relative_to(bounded)
+                or bounded.is_relative_to(resolved)
+            ):
+                raise ValueError(f"Lifecycle state roots overlap: {resolved} and {bounded}")
+        for config_path in external.config_paths:
+            _validate_relative_state_path(config_path.as_posix())
+        normalized.append(
+            LifecycleStateRoot(
+                root_id=external.root_id,
+                target=external.target,
+                scope=scope,
+                path=resolved,
+                config_paths=tuple(external.config_paths),
+            )
+        )
+        root_ids.add(external.root_id)
+        owners.add(owner)
+        bounded_paths.append(resolved)
+    return tuple(sorted(normalized, key=lambda root: root.root_id))
+
+
+def _validate_relative_state_path(relative_path: str) -> PurePosixPath:
+    validate_path_segments(
+        relative_path,
+        context="lifecycle snapshot path",
+        reject_empty=True,
+    )
+    path = PurePosixPath(relative_path)
+    if path.is_absolute() or "\\" in relative_path or PureWindowsPath(relative_path).drive:
+        raise ValueError(f"Lifecycle snapshot path must be relative POSIX: {relative_path}")
+    return path
 
 
 def _read_optional_file(path: Path) -> bytes | None:

--- a/tests/utils/lifecycle_state.py
+++ b/tests/utils/lifecycle_state.py
@@ -466,6 +466,7 @@ def _lockfile_path(root: Path) -> Path | None:
 
 
 def _compiled_paths(root: Path) -> tuple[str, ...]:
+    """Find distributed context outputs across the full selected workspace."""
     paths: list[str] = []
     for directory, dirnames, filenames in os.walk(root, followlinks=False):
         directory_path = Path(directory)

--- a/tests/utils/lifecycle_state.py
+++ b/tests/utils/lifecycle_state.py
@@ -1,0 +1,351 @@
+"""Exact and semantic snapshots of one evolving lifecycle workspace."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Literal, TypeAlias
+
+from apm_cli.core.deployment_ledger import DeploymentLedgerCodec
+from apm_cli.core.deployment_state import DeploymentRecord, LocatorKind
+from apm_cli.core.target_catalog import get_target_capability
+from apm_cli.deps.lockfile import LEGACY_LOCKFILE_NAME, LOCKFILE_NAME, LockFile
+from apm_cli.integration.hook_integrator import _APM_HOOKS_SIDECAR
+from apm_cli.integration.targets import KNOWN_TARGETS
+from apm_cli.utils.path_security import validate_path_segments
+from apm_cli.utils.paths import portable_relpath
+from apm_cli.utils.yaml_io import load_yaml_str
+
+LifecycleFileKind: TypeAlias = Literal["missing", "file", "directory", "symlink"]
+LifecycleFileRole: TypeAlias = Literal[
+    "deployment",
+    "config",
+    "hook-config",
+    "hook-sidecar",
+    "compiled",
+]
+_COMPILED_NAMES = frozenset({"AGENTS.md", "CLAUDE.md", "GEMINI.md"})
+
+
+@dataclass(frozen=True)
+class LifecycleFileState:
+    """Exact bytes and classification for one workspace-contained path."""
+
+    relative_path: str
+    kind: LifecycleFileKind
+    roles: frozenset[LifecycleFileRole]
+    content: bytes | None
+    sha256: str | None
+    link_target: str | None = None
+
+
+@dataclass(frozen=True)
+class LifecycleStateSnapshot:
+    """Immutable exact and semantic state for a lifecycle workspace.
+
+    Raw manifest, lockfile, and materialized file bytes prove byte-idempotency.
+    ``semantic_bytes`` removes YAML presentation and lock generation time while
+    preserving canonical deployment, MCP, LSP, and file-content state.
+    """
+
+    workspace_root: Path
+    manifest_bytes: bytes | None
+    lockfile_bytes: bytes | None
+    deployment_records: tuple[DeploymentRecord, ...]
+    mcp_state_json: bytes
+    lsp_state_json: bytes
+    files: tuple[LifecycleFileState, ...]
+    semantic_bytes: bytes
+
+    @classmethod
+    def capture(
+        cls,
+        workspace_root: Path,
+        *,
+        targets: Sequence[str] = (),
+        config_paths: Sequence[PurePosixPath] = (),
+    ) -> LifecycleStateSnapshot:
+        """Capture deterministic durable state without reading outside the workspace."""
+        root = workspace_root.absolute()
+        if root.is_symlink():
+            raise ValueError(f"Lifecycle workspace root must not be a symlink: {root}")
+
+        profiles = []
+        for target in targets:
+            capability = get_target_capability(target)
+            profile = KNOWN_TARGETS.get(capability.name)
+            if profile is not None:
+                profiles.append(profile)
+
+        if not root.exists():
+            return cls(
+                workspace_root=root,
+                manifest_bytes=None,
+                lockfile_bytes=None,
+                deployment_records=(),
+                mcp_state_json=_canonical_json_bytes(_empty_mcp_state()),
+                lsp_state_json=_canonical_json_bytes(_empty_lsp_state()),
+                files=(),
+                semantic_bytes=_canonical_json_bytes(
+                    {
+                        "manifest": None,
+                        "lock": None,
+                        "files": [],
+                    }
+                ),
+            )
+        if not root.is_dir():
+            raise ValueError(f"Lifecycle workspace root must be a directory: {root}")
+
+        manifest_bytes = _read_optional_file(root / "apm.yml")
+        lock_path = _lockfile_path(root)
+        lockfile_bytes = _read_optional_file(lock_path) if lock_path is not None else None
+        lock = (
+            LockFile.from_yaml(lockfile_bytes.decode("utf-8"))
+            if lockfile_bytes is not None
+            else None
+        )
+        records = (
+            tuple(
+                record
+                for _key, record in sorted(
+                    lock.deployment_ledger.records.items(),
+                )
+            )
+            if lock is not None
+            else ()
+        )
+        mcp_state = _mcp_state(lock)
+        lsp_state = _lsp_state(lock)
+
+        roles_by_path: dict[str, set[LifecycleFileRole]] = {}
+        for record in records:
+            if record.locator.kind is LocatorKind.PROJECT_RELATIVE:
+                _add_role(
+                    roles_by_path,
+                    record.locator.value,
+                    "deployment",
+                )
+        for relative_path in config_paths:
+            _add_role(roles_by_path, relative_path.as_posix(), "config")
+        for profile in profiles:
+            if profile.hooks_config_display:
+                hook_path = PurePosixPath(profile.hooks_config_display)
+                _add_role(roles_by_path, hook_path.as_posix(), "config")
+                _add_role(roles_by_path, hook_path.as_posix(), "hook-config")
+                sidecar = hook_path.parent / _APM_HOOKS_SIDECAR
+                _add_role(roles_by_path, sidecar.as_posix(), "config")
+                _add_role(roles_by_path, sidecar.as_posix(), "hook-sidecar")
+            for generated in profile.generated_files:
+                relative = PurePosixPath(profile.root_dir) / generated
+                _add_role(roles_by_path, relative.as_posix(), "compiled")
+
+        for relative_path in _compiled_paths(root):
+            _add_role(roles_by_path, relative_path, "compiled")
+
+        files = tuple(
+            _capture_file(root, relative_path, frozenset(roles_by_path[relative_path]))
+            for relative_path in sorted(roles_by_path)
+        )
+        manifest_semantic = (
+            load_yaml_str(manifest_bytes.decode("utf-8")) if manifest_bytes is not None else None
+        )
+        lock_semantic = _lock_semantic(lock)
+        semantic_bytes = _canonical_json_bytes(
+            {
+                "manifest": manifest_semantic,
+                "lock": lock_semantic,
+                "files": [
+                    {
+                        "path": file.relative_path,
+                        "kind": file.kind,
+                        "roles": sorted(file.roles),
+                        "sha256": file.sha256,
+                        "link_target": file.link_target,
+                    }
+                    for file in files
+                ],
+            }
+        )
+        return cls(
+            workspace_root=root,
+            manifest_bytes=manifest_bytes,
+            lockfile_bytes=lockfile_bytes,
+            deployment_records=records,
+            mcp_state_json=_canonical_json_bytes(mcp_state),
+            lsp_state_json=_canonical_json_bytes(lsp_state),
+            files=files,
+            semantic_bytes=semantic_bytes,
+        )
+
+    def file(self, relative_path: str) -> LifecycleFileState | None:
+        """Return one captured file state by portable workspace-relative path."""
+        return next(
+            (file for file in self.files if file.relative_path == relative_path),
+            None,
+        )
+
+
+def _add_role(
+    roles_by_path: dict[str, set[LifecycleFileRole]],
+    relative_path: str,
+    role: LifecycleFileRole,
+) -> None:
+    validate_path_segments(
+        relative_path,
+        context="lifecycle snapshot path",
+        reject_empty=True,
+    )
+    path = PurePosixPath(relative_path)
+    if path.is_absolute() or "\\" in relative_path:
+        raise ValueError(f"Lifecycle snapshot path must be relative POSIX: {relative_path}")
+    roles_by_path.setdefault(path.as_posix(), set()).add(role)
+
+
+def _capture_file(
+    root: Path,
+    relative_path: str,
+    roles: frozenset[LifecycleFileRole],
+) -> LifecycleFileState:
+    path = root.joinpath(*PurePosixPath(relative_path).parts)
+    _reject_symlink_ancestors(path, root)
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return LifecycleFileState(
+            relative_path=relative_path,
+            kind="missing",
+            roles=roles,
+            content=None,
+            sha256=None,
+        )
+    if stat.S_ISLNK(metadata.st_mode):
+        return LifecycleFileState(
+            relative_path=relative_path,
+            kind="symlink",
+            roles=roles,
+            content=None,
+            sha256=None,
+            link_target=os.readlink(path),
+        )
+    if stat.S_ISDIR(metadata.st_mode):
+        return LifecycleFileState(
+            relative_path=relative_path,
+            kind="directory",
+            roles=roles,
+            content=None,
+            sha256=None,
+        )
+    if not stat.S_ISREG(metadata.st_mode):
+        raise ValueError(f"Unsupported lifecycle snapshot file type: {path}")
+    content = path.read_bytes()
+    return LifecycleFileState(
+        relative_path=relative_path,
+        kind="file",
+        roles=roles,
+        content=content,
+        sha256=hashlib.sha256(content).hexdigest(),
+    )
+
+
+def _reject_symlink_ancestors(path: Path, root: Path) -> None:
+    current = root
+    relative = path.relative_to(root)
+    for part in relative.parts[:-1]:
+        current /= part
+        if current.is_symlink():
+            raise ValueError(f"Refusing symlinked lifecycle snapshot path: {current}")
+
+
+def _read_optional_file(path: Path) -> bytes | None:
+    if path.is_symlink():
+        raise ValueError(f"Lifecycle state file must be a regular file: {path}")
+    if not path.exists():
+        return None
+    if not path.is_file():
+        raise ValueError(f"Lifecycle state file must be a regular file: {path}")
+    return path.read_bytes()
+
+
+def _lockfile_path(root: Path) -> Path | None:
+    current = root / LOCKFILE_NAME
+    if current.exists() or current.is_symlink():
+        return current
+    legacy = root / LEGACY_LOCKFILE_NAME
+    return legacy if legacy.exists() or legacy.is_symlink() else None
+
+
+def _compiled_paths(root: Path) -> tuple[str, ...]:
+    paths: list[str] = []
+    for directory, dirnames, filenames in os.walk(root, followlinks=False):
+        directory_path = Path(directory)
+        dirnames[:] = [name for name in dirnames if not (directory_path / name).is_symlink()]
+        for filename in filenames:
+            if filename in _COMPILED_NAMES:
+                paths.append(portable_relpath(directory_path / filename, root))
+    return tuple(sorted(paths))
+
+
+def _empty_mcp_state() -> dict[str, object]:
+    return {
+        "servers": [],
+        "configs": {},
+        "target_servers": {},
+        "provenance": {},
+    }
+
+
+def _mcp_state(lock: LockFile | None) -> dict[str, object]:
+    if lock is None:
+        return _empty_mcp_state()
+    return {
+        "servers": sorted(lock.mcp_servers),
+        "configs": dict(sorted(lock.mcp_configs.items())),
+        "target_servers": {
+            target: sorted(servers) for target, servers in sorted(lock.mcp_target_servers.items())
+        },
+        "provenance": dict(sorted(lock.mcp_config_provenance.items())),
+    }
+
+
+def _empty_lsp_state() -> dict[str, object]:
+    return {"servers": [], "configs": {}}
+
+
+def _lsp_state(lock: LockFile | None) -> dict[str, object]:
+    if lock is None:
+        return _empty_lsp_state()
+    return {
+        "servers": sorted(lock.lsp_servers),
+        "configs": dict(sorted(lock.lsp_configs.items())),
+    }
+
+
+def _lock_semantic(lock: LockFile | None) -> Mapping[str, object] | None:
+    if lock is None:
+        return None
+    dependencies = [dependency.to_dict() for dependency in lock.get_package_dependencies()]
+    return {
+        "lockfile_version": lock.lockfile_version,
+        "apm_version": lock.apm_version,
+        "dependencies": dependencies,
+        "deployments": DeploymentLedgerCodec.rows(lock.deployment_ledger),
+        "mcp": _mcp_state(lock),
+        "lsp": _lsp_state(lock),
+        "local_deployed_files": sorted(lock.local_deployed_files),
+        "local_deployed_file_hashes": dict(sorted(lock.local_deployed_file_hashes.items())),
+    }
+
+
+def _canonical_json_bytes(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        ensure_ascii=True,
+        separators=(",", ":"),
+    ).encode("ascii")

--- a/tests/utils/lifecycle_state.py
+++ b/tests/utils/lifecycle_state.py
@@ -1,4 +1,7 @@
-"""Exact and semantic snapshots of one evolving lifecycle workspace."""
+"""Exact and semantic snapshots of one evolving lifecycle workspace.
+
+For generic whole-tree hashing and diffs, use ``ArtifactSnapshot`` instead.
+"""
 
 from __future__ import annotations
 
@@ -8,7 +11,7 @@ import os
 import stat
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Literal, TypeAlias
 
 from apm_cli.core.deployment_ledger import DeploymentLedgerCodec
@@ -17,7 +20,11 @@ from apm_cli.core.target_catalog import get_target_capability
 from apm_cli.deps.lockfile import LEGACY_LOCKFILE_NAME, LOCKFILE_NAME, LockFile
 from apm_cli.integration.hook_integrator import _APM_HOOKS_SIDECAR
 from apm_cli.integration.targets import KNOWN_TARGETS
-from apm_cli.utils.path_security import validate_path_segments
+from apm_cli.utils.path_security import (
+    PathTraversalError,
+    ensure_path_within,
+    validate_path_segments,
+)
 from apm_cli.utils.paths import portable_relpath
 from apm_cli.utils.yaml_io import load_yaml_str
 
@@ -57,8 +64,8 @@ class LifecycleStateSnapshot:
     manifest_bytes: bytes | None
     lockfile_bytes: bytes | None
     deployment_records: tuple[DeploymentRecord, ...]
-    mcp_state_json: bytes
-    lsp_state_json: bytes
+    mcp_state_bytes: bytes
+    lsp_state_bytes: bytes
     files: tuple[LifecycleFileState, ...]
     semantic_bytes: bytes
 
@@ -88,8 +95,8 @@ class LifecycleStateSnapshot:
                 manifest_bytes=None,
                 lockfile_bytes=None,
                 deployment_records=(),
-                mcp_state_json=_canonical_json_bytes(_empty_mcp_state()),
-                lsp_state_json=_canonical_json_bytes(_empty_lsp_state()),
+                mcp_state_bytes=_canonical_json_bytes(_empty_mcp_state()),
+                lsp_state_bytes=_canonical_json_bytes(_empty_lsp_state()),
                 files=(),
                 semantic_bytes=_canonical_json_bytes(
                     {
@@ -120,6 +127,16 @@ class LifecycleStateSnapshot:
             if lock is not None
             else ()
         )
+        target_relative = tuple(
+            record.locator.key
+            for record in records
+            if record.locator.kind is LocatorKind.TARGET_RELATIVE
+        )
+        if target_relative:
+            raise ValueError(
+                "Lifecycle snapshots require explicit bounded roots for "
+                f"target-relative deployments: {sorted(target_relative)}"
+            )
         mcp_state = _mcp_state(lock)
         lsp_state = _lsp_state(lock)
 
@@ -145,8 +162,9 @@ class LifecycleStateSnapshot:
                 relative = PurePosixPath(profile.root_dir) / generated
                 _add_role(roles_by_path, relative.as_posix(), "compiled")
 
-        for relative_path in _compiled_paths(root):
-            _add_role(roles_by_path, relative_path, "compiled")
+        if profiles:
+            for relative_path in _compiled_paths(root):
+                _add_role(roles_by_path, relative_path, "compiled")
 
         files = tuple(
             _capture_file(root, relative_path, frozenset(roles_by_path[relative_path]))
@@ -177,17 +195,20 @@ class LifecycleStateSnapshot:
             manifest_bytes=manifest_bytes,
             lockfile_bytes=lockfile_bytes,
             deployment_records=records,
-            mcp_state_json=_canonical_json_bytes(mcp_state),
-            lsp_state_json=_canonical_json_bytes(lsp_state),
+            mcp_state_bytes=_canonical_json_bytes(mcp_state),
+            lsp_state_bytes=_canonical_json_bytes(lsp_state),
             files=files,
             semantic_bytes=semantic_bytes,
         )
 
-    def file(self, relative_path: str) -> LifecycleFileState | None:
-        """Return one captured file state by portable workspace-relative path."""
-        return next(
-            (file for file in self.files if file.relative_path == relative_path),
-            None,
+    def file(self, relative_path: str) -> LifecycleFileState:
+        """Return a tracked file state, failing clearly for untracked paths."""
+        for file in self.files:
+            if file.relative_path == relative_path:
+                return file
+        tracked = ", ".join(file.relative_path for file in self.files) or "<none>"
+        raise KeyError(
+            f"Lifecycle snapshot path {relative_path!r} is not tracked; tracked paths: {tracked}"
         )
 
 
@@ -202,7 +223,7 @@ def _add_role(
         reject_empty=True,
     )
     path = PurePosixPath(relative_path)
-    if path.is_absolute() or "\\" in relative_path:
+    if path.is_absolute() or "\\" in relative_path or PureWindowsPath(relative_path).drive:
         raise ValueError(f"Lifecycle snapshot path must be relative POSIX: {relative_path}")
     roles_by_path.setdefault(path.as_posix(), set()).add(role)
 
@@ -213,7 +234,10 @@ def _capture_file(
     roles: frozenset[LifecycleFileRole],
 ) -> LifecycleFileState:
     path = root.joinpath(*PurePosixPath(relative_path).parts)
-    _reject_symlink_ancestors(path, root)
+    try:
+        ensure_path_within(path.parent, root)
+    except PathTraversalError as exc:
+        raise ValueError(f"Refusing lifecycle snapshot path outside workspace: {path}") from exc
     try:
         metadata = path.lstat()
     except FileNotFoundError:
@@ -224,6 +248,8 @@ def _capture_file(
             content=None,
             sha256=None,
         )
+    except NotADirectoryError as exc:
+        raise ValueError(f"Lifecycle snapshot path ancestor is not a directory: {path}") from exc
     if stat.S_ISLNK(metadata.st_mode):
         return LifecycleFileState(
             relative_path=relative_path,
@@ -251,15 +277,6 @@ def _capture_file(
         content=content,
         sha256=hashlib.sha256(content).hexdigest(),
     )
-
-
-def _reject_symlink_ancestors(path: Path, root: Path) -> None:
-    current = root
-    relative = path.relative_to(root)
-    for part in relative.parts[:-1]:
-        current /= part
-        if current.is_symlink():
-            raise ValueError(f"Refusing symlinked lifecycle snapshot path: {current}")
 
 
 def _read_optional_file(path: Path) -> bytes | None:

--- a/tests/utils/local_git_repository.py
+++ b/tests/utils/local_git_repository.py
@@ -6,6 +6,7 @@ import time
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.parse import urlsplit
 
 from apm_cli.utils.path_security import ensure_path_within, validate_path_segments
 
@@ -154,11 +155,59 @@ class LocalGitRepositoryFactory:
             cwd=repository.worktree,
         )
 
+    def install_url_rewrite(
+        self,
+        repository: LocalGitRepository,
+        remote_url: str,
+    ) -> tuple[str, str]:
+        """Route bare and ``.git`` HTTP(S) forms to an owned local repository.
+
+        Rewrites are written only to the explicit fixture global config. The
+        local replacement ends in ``/`` so Git's prefix matching cannot append
+        an adjacent remote suffix onto a sibling fixture repository path.
+        """
+        repository = self._owned_repository(repository)
+        remote_forms = self._remote_url_forms(remote_url)
+        config_path = self._fixture_git_config_path()
+        rewrite_base = f"{repository.file_url}/"
+        key = f"url.{rewrite_base}.insteadOf"
+        configured = self._run(
+            (
+                "git",
+                "config",
+                "--file",
+                str(config_path),
+                "--get-all",
+                key,
+            ),
+            cwd=self._root,
+            check=False,
+        )
+        # Fixture setup is single-writer; serial dedup keeps repeated calls idempotent.
+        existing = set(configured.stdout.splitlines())
+        for remote_form in remote_forms:
+            if remote_form in existing:
+                continue
+            self._run(
+                (
+                    "git",
+                    "config",
+                    "--file",
+                    str(config_path),
+                    "--add",
+                    key,
+                    remote_form,
+                ),
+                cwd=self._root,
+            )
+        return remote_forms
+
     def _run(
         self,
         command: tuple[str, ...],
         *,
         cwd: Path,
+        check: bool = True,
     ) -> subprocess.CompletedProcess[str]:
         timeout_seconds = self._timeout_seconds
         if self._deadline is not None:
@@ -172,9 +221,58 @@ class LocalGitRepositoryFactory:
             env=self._env,
             capture_output=True,
             text=True,
-            check=True,
+            check=check,
             timeout=timeout_seconds,
         )
+
+    @staticmethod
+    def _remote_url_forms(remote_url: str) -> tuple[str, str]:
+        if not remote_url or remote_url.strip() != remote_url:
+            raise ValueError("Remote URL must be a non-empty string without surrounding whitespace")
+        parsed = urlsplit(remote_url)
+        if parsed.scheme not in {"http", "https"} or parsed.hostname is None:
+            raise ValueError("Remote URL must use an HTTP(S) production host")
+        if parsed.username is not None or parsed.password is not None:
+            raise ValueError("Remote URL must not contain credentials")
+        if parsed.query or parsed.fragment:
+            raise ValueError("Remote URL must not contain a query or fragment")
+        if parsed.path.endswith("/"):
+            raise ValueError("Remote URL must identify a repository, not a directory")
+        path = parsed.path.lstrip("/")
+        validate_path_segments(path, context="remote repository URL", reject_empty=True)
+        if len(path.split("/")) < 2:
+            raise ValueError("Remote URL must include an owner and repository path")
+        bare = remote_url.removesuffix(".git")
+        if bare.endswith("/"):
+            raise ValueError("Remote URL must include a repository name before .git")
+        return bare, f"{bare}.git"
+
+    def _fixture_git_config_path(self) -> Path:
+        """Return the explicit config after anchoring it to fixture ``HOME``."""
+        if self._env.get("GIT_CONFIG_NOSYSTEM") != "1":
+            raise ValueError("Fixture Git rewrites require GIT_CONFIG_NOSYSTEM=1")
+        raw_global = self._env.get("GIT_CONFIG_GLOBAL")
+        raw_home = self._env.get("HOME")
+        if not raw_global or not raw_home:
+            raise ValueError("Fixture Git rewrites require explicit GIT_CONFIG_GLOBAL and HOME")
+        global_config = Path(raw_global)
+        home = Path(raw_home)
+        if not global_config.is_absolute() or not home.is_absolute():
+            raise ValueError("Fixture Git config and HOME paths must be absolute")
+        if home.is_symlink() or not home.is_dir():
+            raise ValueError(f"Fixture HOME must be a non-symlink directory: {home}")
+        fixture_root = home.parent
+        ensure_path_within(self._root, fixture_root)
+        if global_config.is_symlink():
+            raise ValueError(f"Refusing symlinked fixture Git config: {global_config}")
+        ensure_path_within(global_config, fixture_root)
+        if not global_config.parent.is_dir():
+            raise ValueError(
+                f"Fixture Git config parent must be a directory: {global_config.parent}"
+            )
+        if global_config.exists() and not global_config.is_file():
+            raise ValueError(f"Fixture Git config must be a regular file: {global_config}")
+        return global_config
 
     def _owned_repository(self, repository: LocalGitRepository) -> LocalGitRepository:
         if self._repositories.get(id(repository)) is not repository:

--- a/tests/utils/local_package.py
+++ b/tests/utils/local_package.py
@@ -18,7 +18,6 @@ from apm_cli.utils.path_security import ensure_path_within, validate_path_segmen
 from apm_cli.utils.yaml_io import dump_yaml, load_yaml, load_yaml_str, yaml_to_str
 
 DependencyInput: TypeAlias = str | Mapping[str, object]
-ConfigDependencyInput: TypeAlias = str | Mapping[str, object]
 _MANIFEST_LAYOUT = "manifest"
 _POLICY_LAYOUT = "policy"
 _SKILL_LAYOUT = "skill"
@@ -40,7 +39,12 @@ class LocalPackage:
 
 
 class LocalPackageFactory:
-    """Author realistic package source inputs without product-generated output."""
+    """Author realistic package source inputs without product-generated output.
+
+    Create a package, then add source primitives through the category-specific
+    ``add_*`` methods. Lifecycle scenarios can commit ``package.root`` with
+    ``LocalGitRepositoryFactory`` and run commands through ``ApmLifecycleRunner``.
+    """
 
     def __init__(self, root: Path) -> None:
         """Create a factory rooted at the package source directory."""
@@ -54,8 +58,8 @@ class LocalPackageFactory:
         *,
         version: str = "0.1.0",
         dependencies: Sequence[DependencyInput] = (),
-        mcp_dependencies: Sequence[ConfigDependencyInput] = (),
-        lsp_dependencies: Sequence[ConfigDependencyInput] = (),
+        mcp_dependencies: Sequence[DependencyInput] = (),
+        lsp_dependencies: Sequence[DependencyInput] = (),
         targets: Sequence[str] = (),
     ) -> LocalPackage:
         """Create a package source directory and its manifest."""
@@ -141,7 +145,7 @@ class LocalPackageFactory:
         return self._add_prompt_source(package, name, content, kind="prompt")
 
     def add_command(self, package: LocalPackage, name: str, content: str) -> Path:
-        """Author a prompt source transformed by command-capable targets."""
+        """Author a ``.apm/prompts/*.prompt.md`` source for command targets."""
         return self._add_prompt_source(package, name, content, kind="command")
 
     def add_hook(
@@ -173,7 +177,11 @@ class LocalPackageFactory:
         *,
         assets: Mapping[PurePosixPath, bytes] | None = None,
     ) -> Path:
-        """Author an executable canvas bundle and optional exact-byte assets."""
+        """Author a canvas bundle and return its directory, not its entry file.
+
+        Canvas names deliberately delegate to the production integrator's
+        validator so tests cannot drift from the executable deployment surface.
+        """
         self._validate_segment(name, "canvas")
         CanvasIntegrator._validate_canvas_name(name)
         bundle_path = PurePosixPath(".apm") / "extensions" / name
@@ -424,7 +432,7 @@ class LocalPackageFactory:
 
     @staticmethod
     def _validate_config_dependencies(
-        dependencies: Sequence[ConfigDependencyInput],
+        dependencies: Sequence[DependencyInput],
         *,
         kind: str,
     ) -> list[str | dict[str, object]]:

--- a/tests/utils/local_package.py
+++ b/tests/utils/local_package.py
@@ -141,7 +141,7 @@ class LocalPackageFactory:
         return self._write_text(path, content)
 
     def add_prompt(self, package: LocalPackage, name: str, content: str) -> Path:
-        """Author a prompt source consumed by prompt-capable targets."""
+        """Author a ``.apm/prompts/*.prompt.md`` source with prompt intent."""
         return self._add_prompt_source(package, name, content, kind="prompt")
 
     def add_command(self, package: LocalPackage, name: str, content: str) -> Path:
@@ -214,6 +214,8 @@ class LocalPackageFactory:
 
         Canvas names deliberately delegate to the production integrator's
         validator so tests cannot drift from the executable deployment surface.
+        Canvas assets are intentionally supplied in one validated mapping;
+        unlike hook scripts, they do not need incremental authoring.
         """
         self._validate_segment(name, "canvas")
         CanvasIntegrator._validate_canvas_name(name)
@@ -374,7 +376,7 @@ class LocalPackageFactory:
         package: LocalPackage,
         dependency: DependencyInput,
     ) -> bool:
-        """Remove the first semantically matching APM dependency."""
+        """Remove one canonical identity match, or return False without writing."""
         manifest_path, manifest = self._load_manifest(package)
         validated = self._validate_dependencies((dependency,))
         expected = self._parse_dependency(validated[0])

--- a/tests/utils/local_package.py
+++ b/tests/utils/local_package.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -11,16 +12,21 @@ from typing import TypeAlias
 import yaml
 
 from apm_cli.core.apm_yml import parse_targets_field
-from apm_cli.models.dependency import DependencyReference
+from apm_cli.integration.canvas_integrator import CanvasIntegrator
+from apm_cli.models.dependency import DependencyReference, LSPDependency, MCPDependency
 from apm_cli.utils.path_security import ensure_path_within, validate_path_segments
 from apm_cli.utils.yaml_io import dump_yaml, load_yaml, load_yaml_str, yaml_to_str
 
 DependencyInput: TypeAlias = str | Mapping[str, object]
+ConfigDependencyInput: TypeAlias = str | Mapping[str, object]
 _MANIFEST_LAYOUT = "manifest"
 _POLICY_LAYOUT = "policy"
 _SKILL_LAYOUT = "skill"
 _AGENT_LAYOUT = "agent"
 _INSTRUCTION_LAYOUT = "instruction"
+_PROMPT_LAYOUT = "prompt"
+_HOOK_LAYOUT = "hook"
+_CANVAS_LAYOUT = "canvas"
 _PRIMITIVE_LAYOUTS = frozenset({_SKILL_LAYOUT, _AGENT_LAYOUT, _INSTRUCTION_LAYOUT})
 
 
@@ -48,6 +54,8 @@ class LocalPackageFactory:
         *,
         version: str = "0.1.0",
         dependencies: Sequence[DependencyInput] = (),
+        mcp_dependencies: Sequence[ConfigDependencyInput] = (),
+        lsp_dependencies: Sequence[ConfigDependencyInput] = (),
         targets: Sequence[str] = (),
     ) -> LocalPackage:
         """Create a package source directory and its manifest."""
@@ -56,6 +64,14 @@ class LocalPackageFactory:
         package_root = self._root / name
         ensure_path_within(package_root, self._root)
         validated_dependencies = self._validate_dependencies(dependencies)
+        validated_mcp = self._validate_config_dependencies(
+            mcp_dependencies,
+            kind="MCP",
+        )
+        validated_lsp = self._validate_config_dependencies(
+            lsp_dependencies,
+            kind="LSP",
+        )
         validated_targets = parse_targets_field({"targets": list(targets)}) if targets else []
         package_root.mkdir(parents=True, exist_ok=False)
         manifest_path = self._validated_source_path(
@@ -69,8 +85,15 @@ class LocalPackageFactory:
             "description": f"Hermetic test package {name}",
             "author": "APM Test",
         }
+        dependency_block: dict[str, object] = {}
         if validated_dependencies:
-            manifest["dependencies"] = {"apm": validated_dependencies}
+            dependency_block["apm"] = validated_dependencies
+        if validated_mcp:
+            dependency_block["mcp"] = validated_mcp
+        if validated_lsp:
+            dependency_block["lsp"] = validated_lsp
+        if dependency_block:
+            manifest["dependencies"] = dependency_block
         if validated_targets:
             manifest["targets"] = validated_targets
         dump_yaml(manifest, manifest_path)
@@ -112,6 +135,73 @@ class LocalPackageFactory:
             frozenset({_INSTRUCTION_LAYOUT}),
         )
         return self._write_text(path, content)
+
+    def add_prompt(self, package: LocalPackage, name: str, content: str) -> Path:
+        """Author a prompt source consumed by prompt-capable targets."""
+        return self._add_prompt_source(package, name, content, kind="prompt")
+
+    def add_command(self, package: LocalPackage, name: str, content: str) -> Path:
+        """Author a prompt source transformed by command-capable targets."""
+        return self._add_prompt_source(package, name, content, kind="command")
+
+    def add_hook(
+        self,
+        package: LocalPackage,
+        name: str,
+        document: Mapping[str, object],
+    ) -> Path:
+        """Author one declarative hook document using canonical JSON text."""
+        self._validate_segment(name, "hook")
+        path = self._source_path(
+            package,
+            PurePosixPath(".apm") / "hooks" / f"{name}.json",
+            frozenset({_HOOK_LAYOUT}),
+        )
+        content = json.dumps(
+            dict(document),
+            indent=2,
+            sort_keys=True,
+            ensure_ascii=True,
+        )
+        return self._write_text(path, f"{content}\n")
+
+    def add_canvas(
+        self,
+        package: LocalPackage,
+        name: str,
+        extension: str,
+        *,
+        assets: Mapping[PurePosixPath, bytes] | None = None,
+    ) -> Path:
+        """Author an executable canvas bundle and optional exact-byte assets."""
+        self._validate_segment(name, "canvas")
+        CanvasIntegrator._validate_canvas_name(name)
+        bundle_path = PurePosixPath(".apm") / "extensions" / name
+        marker_path = self._source_path(
+            package,
+            bundle_path / "extension.mjs",
+            frozenset({_CANVAS_LAYOUT}),
+        )
+        validated_assets: list[tuple[Path, bytes]] = []
+        for relative_path, content in (assets or {}).items():
+            if not isinstance(relative_path, PurePosixPath):
+                raise TypeError("Canvas asset paths must be PurePosixPath instances")
+            if not isinstance(content, bytes):
+                raise TypeError("Canvas asset contents must be bytes")
+            if relative_path == PurePosixPath("extension.mjs"):
+                raise ValueError("Canvas assets must not replace extension.mjs")
+            asset_path = self._source_path(
+                package,
+                bundle_path / relative_path,
+                frozenset({_CANVAS_LAYOUT}),
+            )
+            validated_assets.append((asset_path, content))
+
+        self._write_text(marker_path, extension)
+        for asset_path, content in validated_assets:
+            asset_path.parent.mkdir(parents=True, exist_ok=True)
+            asset_path.write_bytes(content)
+        return marker_path.parent
 
     def add_relative_dependency(
         self,
@@ -206,6 +296,22 @@ class LocalPackageFactory:
             frozenset({_MANIFEST_LAYOUT}),
         )
 
+    def _add_prompt_source(
+        self,
+        package: LocalPackage,
+        name: str,
+        content: str,
+        *,
+        kind: str,
+    ) -> Path:
+        self._validate_segment(name, kind)
+        path = self._source_path(
+            package,
+            PurePosixPath(".apm") / "prompts" / f"{name}.prompt.md",
+            frozenset({_PROMPT_LAYOUT}),
+        )
+        return self._write_text(path, content)
+
     def _owned_package(self, package: LocalPackage) -> LocalPackage:
         if self._packages.get(id(package)) is not package:
             raise ValueError("Local package is not owned by this factory")
@@ -247,6 +353,8 @@ class LocalPackageFactory:
             return _POLICY_LAYOUT
         if len(parts) >= 3 and parts[0] == "skills":
             return _SKILL_LAYOUT
+        if len(parts) >= 4 and parts[:2] == (".apm", "extensions"):
+            return _CANVAS_LAYOUT
         if len(parts) != 3:
             return None
         if (
@@ -261,6 +369,14 @@ class LocalPackageFactory:
             and parts[2] != ".instructions.md"
         ):
             return _INSTRUCTION_LAYOUT
+        if (
+            parts[:2] == (".apm", "prompts")
+            and parts[2].endswith(".prompt.md")
+            and parts[2] != ".prompt.md"
+        ):
+            return _PROMPT_LAYOUT
+        if parts[:2] == (".apm", "hooks") and parts[2].endswith(".json") and parts[2] != ".json":
+            return _HOOK_LAYOUT
         return None
 
     @staticmethod
@@ -303,6 +419,47 @@ class LocalPackageFactory:
                 reparsed = DependencyReference.parse_from_dict(roundtrip_entry)
             if reparsed != dependency:
                 raise ValueError("Dependency source form failed semantic round-trip validation")
+            validated.append(source_entry)
+        return validated
+
+    @staticmethod
+    def _validate_config_dependencies(
+        dependencies: Sequence[ConfigDependencyInput],
+        *,
+        kind: str,
+    ) -> list[str | dict[str, object]]:
+        model = MCPDependency if kind == "MCP" else LSPDependency
+        validated: list[str | dict[str, object]] = []
+        for entry in dependencies:
+            if isinstance(entry, str):
+                source_entry: str | dict[str, object] = entry
+                dependency = model.from_string(entry)
+            elif isinstance(entry, Mapping):
+                source_entry = dict(entry)
+                dependency = model.from_dict(source_entry)
+            else:
+                raise TypeError(f"{kind} dependency entries must be strings or mappings")
+
+            roundtrip_document = load_yaml_str(yaml_to_str({"dependency": source_entry}))
+            if not isinstance(roundtrip_document, dict):
+                raise ValueError(
+                    f"{kind} dependency source form did not survive YAML serialization"
+                )
+            roundtrip_entry = roundtrip_document.get("dependency")
+            if isinstance(source_entry, str):
+                if not isinstance(roundtrip_entry, str):
+                    raise ValueError(f"{kind} dependency string did not survive YAML serialization")
+                reparsed = model.from_string(roundtrip_entry)
+            else:
+                if not isinstance(roundtrip_entry, dict):
+                    raise ValueError(
+                        f"{kind} dependency mapping did not survive YAML serialization"
+                    )
+                reparsed = model.from_dict(roundtrip_entry)
+            if reparsed.to_dict() != dependency.to_dict():
+                raise ValueError(
+                    f"{kind} dependency source form failed semantic round-trip validation"
+                )
             validated.append(source_entry)
         return validated
 

--- a/tests/utils/local_package.py
+++ b/tests/utils/local_package.py
@@ -169,6 +169,39 @@ class LocalPackageFactory:
         )
         return self._write_text(path, f"{content}\n")
 
+    def add_hook_asset(
+        self,
+        package: LocalPackage,
+        hook_name: str,
+        relative_path: PurePosixPath,
+        content: str | bytes,
+        *,
+        executable: bool = False,
+    ) -> Path:
+        """Author a file below one hook descriptor's relative source subtree."""
+        self._validate_segment(hook_name, "hook")
+        if not isinstance(relative_path, PurePosixPath):
+            raise TypeError("Hook asset paths must be PurePosixPath instances")
+        if not isinstance(content, (str, bytes)):
+            raise TypeError("Hook asset contents must be text or bytes")
+        descriptor = self._source_path(
+            package,
+            PurePosixPath(".apm") / "hooks" / f"{hook_name}.json",
+            frozenset({_HOOK_LAYOUT}),
+        )
+        if descriptor.is_symlink() or not descriptor.is_file():
+            raise ValueError(f"Hook descriptor must exist before its assets: {descriptor}")
+        path = self._source_path(
+            package,
+            PurePosixPath(".apm") / "hooks" / hook_name / relative_path,
+            frozenset({_HOOK_LAYOUT}),
+        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(content.encode("utf-8") if isinstance(content, str) else content)
+        if executable:
+            path.chmod(path.stat().st_mode | 0o111)
+        return path
+
     def add_canvas(
         self,
         package: LocalPackage,
@@ -287,6 +320,89 @@ class LocalPackageFactory:
         dump_yaml(dict(policy), path)
         return path
 
+    def set_targets(
+        self,
+        package: LocalPackage,
+        targets: Sequence[str],
+    ) -> None:
+        """Replace canonical manifest targets while preserving other sections."""
+        manifest_path, manifest = self._load_manifest(package)
+        validated = parse_targets_field({"targets": list(targets)}) if targets else []
+        if validated:
+            if manifest.get("targets") == validated:
+                return
+            manifest["targets"] = validated
+        elif "targets" in manifest:
+            manifest.pop("targets")
+        else:
+            return
+        dump_yaml(manifest, manifest_path)
+
+    def replace_apm_dependencies(
+        self,
+        package: LocalPackage,
+        dependencies: Sequence[DependencyInput],
+    ) -> None:
+        """Replace only ``dependencies.apm`` using canonical source validation."""
+        manifest_path, manifest = self._load_manifest(package)
+        validated = self._validate_dependencies(dependencies)
+        dependency_block = manifest.get("dependencies")
+        if dependency_block is None:
+            dependency_block = {}
+        if not isinstance(dependency_block, dict):
+            raise ValueError(f"Invalid dependencies mapping: {manifest_path}")
+        current = dependency_block.get("apm")
+        if current is not None and not isinstance(current, list):
+            raise ValueError(f"Invalid APM dependencies list: {manifest_path}")
+        if validated:
+            if current == validated:
+                return
+            dependency_block["apm"] = validated
+            manifest["dependencies"] = dependency_block
+        elif "apm" in dependency_block:
+            dependency_block.pop("apm")
+            if dependency_block:
+                manifest["dependencies"] = dependency_block
+            else:
+                manifest.pop("dependencies", None)
+        else:
+            return
+        dump_yaml(manifest, manifest_path)
+
+    def remove_apm_dependency(
+        self,
+        package: LocalPackage,
+        dependency: DependencyInput,
+    ) -> bool:
+        """Remove the first semantically matching APM dependency."""
+        manifest_path, manifest = self._load_manifest(package)
+        validated = self._validate_dependencies((dependency,))
+        expected = self._parse_dependency(validated[0])
+        expected_identity = expected.get_identity()
+        dependency_block = manifest.get("dependencies")
+        if dependency_block is None:
+            return False
+        if not isinstance(dependency_block, dict):
+            raise ValueError(f"Invalid dependencies mapping: {manifest_path}")
+        current = dependency_block.get("apm")
+        if current is None:
+            return False
+        if not isinstance(current, list):
+            raise ValueError(f"Invalid APM dependencies list: {manifest_path}")
+        for index, entry in enumerate(current):
+            if self._parse_dependency(entry).get_identity() != expected_identity:
+                continue
+            updated = [*current[:index], *current[index + 1 :]]
+            if updated:
+                dependency_block["apm"] = updated
+            else:
+                dependency_block.pop("apm")
+                if not dependency_block:
+                    manifest.pop("dependencies", None)
+            dump_yaml(manifest, manifest_path)
+            return True
+        return False
+
     def _source_path(
         self,
         package: LocalPackage,
@@ -303,6 +419,16 @@ class LocalPackageFactory:
             PurePosixPath("apm.yml"),
             frozenset({_MANIFEST_LAYOUT}),
         )
+
+    def _load_manifest(self, package: LocalPackage) -> tuple[Path, dict[str, object]]:
+        manifest_path = self._manifest_path(package)
+        try:
+            manifest = load_yaml(manifest_path)
+        except yaml.YAMLError as exc:
+            raise ValueError(f"Invalid manifest YAML: {manifest_path}") from exc
+        if not isinstance(manifest, dict):
+            raise ValueError(f"Invalid manifest mapping: {manifest_path}")
+        return manifest_path, manifest
 
     def _add_prompt_source(
         self,
@@ -363,6 +489,8 @@ class LocalPackageFactory:
             return _SKILL_LAYOUT
         if len(parts) >= 4 and parts[:2] == (".apm", "extensions"):
             return _CANVAS_LAYOUT
+        if len(parts) >= 4 and parts[:2] == (".apm", "hooks") and not parts[2].endswith(".json"):
+            return _HOOK_LAYOUT
         if len(parts) != 3:
             return None
         if (
@@ -429,6 +557,14 @@ class LocalPackageFactory:
                 raise ValueError("Dependency source form failed semantic round-trip validation")
             validated.append(source_entry)
         return validated
+
+    @staticmethod
+    def _parse_dependency(entry: object) -> DependencyReference:
+        if isinstance(entry, str):
+            return DependencyReference.parse(entry)
+        if isinstance(entry, Mapping):
+            return DependencyReference.parse_from_dict(dict(entry))
+        raise TypeError("APM dependency entries must be strings or mappings")
 
     @staticmethod
     def _validate_config_dependencies(

--- a/tests/utils/local_package.py
+++ b/tests/utils/local_package.py
@@ -436,7 +436,12 @@ class LocalPackageFactory:
         *,
         kind: str,
     ) -> list[str | dict[str, object]]:
-        model = MCPDependency if kind == "MCP" else LSPDependency
+        if kind == "MCP":
+            model = MCPDependency
+        elif kind == "LSP":
+            model = LSPDependency
+        else:
+            raise ValueError(f"Unsupported config dependency kind: {kind}")
         validated: list[str | dict[str, object]] = []
         for entry in dependencies:
             if isinstance(entry, str):


### PR DESCRIPTION
# add(test): provide shared lifecycle state substrate

## TL;DR

This adds the test-only foundation for the lifecycle-contract wave: realistic package/hook authoring and transitions, isolated local-Git transport, and deterministic multi-root durable-state snapshots. Later PRs can drive real commands and assert project/user-scope bytes or semantic convergence without fabricating package metadata, reimplementing lockfile serialization, reading ambient HOME, or reaching a production Git host. Production source and user-facing behavior are unchanged.

> [!IMPORTANT]
> This PR is independently mergeable foundation only. It adds no lifecycle scenarios, workflow gates, production fixes, or legacy-test deletion.

## Problem (WHY)

- [x] The existing package factory covered skills, agents, and instructions, but later lifecycle lanes also need prompts, commands, hooks, canvases, and declarative MCP/LSP inputs.
- [x] Generic filesystem snapshots preserve hashes, but they do not expose raw manifest/lock bytes, canonical deployment records, config state, hook sidecars, or compiled-output roles as one durable-state contract.
- [x] Marketplace/plugin rows need production-shaped Git URLs, but repeated inline `git config` subprocess blocks make hermetic rewrites easy to drift.
- [!] Repeating those details in each scenario PR would create parallel test vocabularies and serializer drift.

These gaps matter because ["agents pattern-match well against concrete structures"](https://agentskills.io/skill-creation/best-practices), while ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) The foundation therefore composes existing production codecs and test runners instead of fabricating state.

## Approach (WHAT)

| # | Fix | Principle |
|---:|---|---|
| 1 | Extend `LocalPackageFactory` with source-only authors for every deploy category and validated MCP/LSP manifest entries. | ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |
| 2 | Add `LifecycleStateSnapshot` for raw bytes, canonical lock/ledger semantics, and workspace-contained materialized state. | ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |
| 3 | Add one owned-repository URL rewrite that writes only a bounded fixture Git config and contains Git prefix matching inside the local bare repository. | ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |
| 4 | Bind user-scope target-relative rows and selected configs through explicit, non-overlapping `LifecycleStateRoot` values. | ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |
| 5 | Author hook scripts/assets only below their descriptor-owned `.apm/hooks/<name>/` subtree. | ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |
| 6 | Replace/remove targets and APM dependencies through production validators while preserving unrelated manifest sections. | ["agents pattern-match well against concrete structures"](https://agentskills.io/skill-creation/best-practices) |
| 7 | Prove malicious paths, root collisions, missing files, non-ASCII bytes, idempotency, semantic changes, and adjacent Git prefixes. | ["do the work, run a validator (a script, a reference checklist, or a self-check), fix any issues, and repeat until validation passes."](https://agentskills.io/skill-creation/best-practices) |

## Implementation (HOW)

| File | Change |
|---|---|
| `tests/utils/local_package.py` | Extends the existing canonical factory with seven categories, hook assets, MCP/LSP declarations, and owned target/APM dependency transitions through production validators. |
| `tests/utils/lifecycle_state.py` | Adds immutable root/file/snapshot values. It delegates lock parsing and deployment rows to production owners, then binds external files only through caller-supplied target/scope roots. |
| `tests/utils/artifact_snapshot.py` | Cross-references the lifecycle-aware oracle so later lanes choose the domain snapshot instead of creating a third overlapping helper. |
| `tests/utils/local_git_repository.py` | Adds `install_url_rewrite()`: validates an owned local repository and HTTP(S) remote, derives bare/`.git` forms, writes only the scenario-bounded `GIT_CONFIG_GLOBAL`, and uses a trailing-slash local base so Git prefix suffixes cannot reach sibling fixtures. |
| `tests/integration/test_local_package_factory_contract.py` | Covers all seven deploy categories, exact source layouts/bytes, mapping and string config dependencies, transactional rejection, symlink/traversal boundaries, hook assets, and manifest transitions. |
| `tests/integration/test_lifecycle_state_snapshot_contract.py` | Covers raw and semantic state, dynamic URI rows, project plus multiple external roots, duplicate relative names, target-relative rows, missing/directory states, and every symlink/root collision boundary. |
| `tests/integration/test_local_git_repository_factory_contract.py` | Proves both URL forms with real `git ls-remote`, idempotent config, untouched HOME config, adjacent-prefix containment, and validation-before-mutation. |

### Public test API

```python
factory = LocalPackageFactory(package_root)
package = factory.create(
    "fixture",
    dependencies=({"path": "../shared", "alias": "shared"},),
    mcp_dependencies=({"name": "mcp", "registry": False,
                       "transport": "stdio", "command": "mcp"},),
    lsp_dependencies=({"name": "lsp", "command": "lsp",
                       "extensionToLanguage": {".py": "python"}},),
    targets=("copilot", "claude"),
)

factory.add_skill(package, "review", skill_text)
factory.add_agent(package, "helper", agent_text)
factory.add_prompt(package, "summarize", prompt_text)
factory.add_command(package, "check", command_text)
factory.add_instruction(package, "rules", instruction_text)
factory.add_hook(package, "lifecycle", hook_mapping)
factory.add_hook_asset(
    package, "lifecycle", PurePosixPath("scripts/check.py"),
    "print('hook')\n", executable=True,
)
factory.add_canvas(package, "inspector", extension_mjs, assets=asset_bytes)
factory.set_targets(package, ("copilot", "claude"))
factory.replace_apm_dependencies(package, dependencies)
factory.remove_apm_dependency(package, identity_equivalent_dependency)
```

The existing local-Git and command owners remain unchanged:

```python
repository_factory = LocalGitRepositoryFactory(
    repository_root,
    env=environment,
    deadline=deadline,
)
repository = repository_factory.create("fixture", source_tree=package.root)
remote_forms = repository_factory.install_url_rewrite(
    repository,
    "https://github.example.invalid/acme/fixture.git",
)

results = ApmLifecycleRunner((str(apm_binary_path),)).run_sequence(
    commands,
    expected_returncodes=expected_returncodes,
    scenario_id="required-lifecycle",
    cwd=consumer.root,
    env=environment,
)
```

Capture exact or semantic invariants from project and user roots:

```python
state = LifecycleStateSnapshot.capture(
    consumer.root,
    targets=("copilot", "claude"),
    config_paths=(PurePosixPath(".vscode/mcp.json"),),
    external_roots=(
        LifecycleStateRoot(
            root_id="claude-user",
            target="claude",
            scope="user",
            path=isolated.home / ".claude",
            config_paths=(PurePosixPath("settings.json"),),
        ),
    ),
)

assert state.manifest_bytes == expected_manifest_bytes
assert state.lockfile_bytes == expected_lockfile_bytes
assert state.deployment_records == expected_records
assert state.mcp_state_bytes == expected_mcp_state
assert state.lsp_state_bytes == expected_lsp_state
assert state.file(".agents/skills/review/SKILL.md").content == expected_skill
assert state.file("settings.json", root_id="claude-user").content == expected_user_config
assert before.semantic_bytes == after.semantic_bytes
```

## Diagram

Legend: later scenario PRs author real source and run real commands; the snapshot reads project and explicit user roots through canonical owners.

```mermaid
flowchart LR
    subgraph Author[Author source]
        LPF[LocalPackageFactory]
        SRC[Local package tree]
    end
    subgraph Execute[Execute lifecycle]
        GIT[LocalGitRepositoryFactory]
        CFG[Bounded fixture Git config]
        RUN[ApmLifecycleRunner]
        WS[Evolving workspace]
    end
    subgraph Observe[Observe durable state]
        LOCK[LockFile and DeploymentLedgerCodec]
        ROOTS[Explicit target roots]
        SNAP[LifecycleStateSnapshot]
        ASSERT[Exact or semantic assertions]
    end
    LPF --> SRC
    SRC --> GIT
    GIT --> CFG
    CFG --> GIT
    GIT --> RUN
    RUN --> WS
    WS --> LOCK
    WS --> SNAP
    ROOTS --> SNAP
    LOCK --> SNAP
    SNAP --> ASSERT
    classDef new stroke-dasharray: 5 5;
    class LPF,ROOTS,SNAP new;
```

## Trade-offs

- **Extend existing owners, not add lane-local builders.** Package, Git, runner, and snapshot responsibilities remain separate and composable.
- **Store raw bytes and canonical semantic bytes.** Raw bytes prove idempotency; canonical JSON prevents formatting-only YAML churn from appearing semantic.
- **Bound all state I/O.** Project files use the workspace root; user/target files require explicit non-overlapping `(root_id, target, scope, path)` values; URL rewrites write only scenario-bounded `GIT_CONFIG_GLOBAL`.
- **Keep source intent separate from expected deployment.** Hook assets live beneath their descriptor, while target mapping and script rewriting remain production-owned.
- **Expose substrate without migrating scenarios.** Downstream command chains consume this PR after coordinator acceptance.

## Benefits

1. Seven deploy categories, hook scripts/assets, and manifest transitions share one source-authoring vocabulary.
2. Exact state exposes manifest, lock, deployment records, MCP/LSP state, and root-qualified filesystem bytes in one capture.
3. Project and multiple user target roots can contain duplicate relative names without collisions or ambient HOME reads.
4. Bare and `.git` remotes resolve locally, while adjacent prefixes cannot resolve to sibling fixtures.
5. Invalid roots, paths, generated fields, foreign packages, and semantic round-trip drift fail before mutation.
6. The diff remains test-only: seven files changed and no `src/` modifications.

## Validation

`uv run --extra dev pytest -q tests/integration/test_local_package_factory_contract.py tests/integration/test_lifecycle_state_snapshot_contract.py tests/integration/test_local_git_repository_factory_contract.py`:

```text
..........................................                               [100%]
42 passed in 5.13s
```

<details><summary>Repository gates</summary>

`uv run --extra dev pytest -q tests/unit tests/test_console.py tests/red_team`:

```text
19292 passed, 2 skipped, 21 xfailed, 19 warnings, 88 subtests passed in 190.97s (0:03:10)
```

`uv run --extra dev pytest -p no:cacheprovider -q tests/quality` plus assertion and duplicate ratchets:

```text
37 passed in 33.72s
[+] assertion-quality ratchet clean: AQ001=5, AQ002=12
[+] exact test duplicate ratchet clean: 1062 files, 8 allowed duplicate group(s)
```

Architecture/helper contracts:

```text
108 passed in 135.81s (0:02:15)
```

Full lint mirror:

```text
All checks passed!
1545 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
[+] architecture boundary lint clean
```

Docs impact classifier:

```json
{"verdict":"no_change","confidence":"high","source":"L0","scope_pages":[]}
```

</details>

### Scenario Evidence

| # | Scenario (test-author promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | A lifecycle test can author every deploy category plus MCP/LSP declarations from a real source tree. | Portability by manifest, Multi-harness support | `tests/integration/test_local_package_factory_contract.py::test_lifecycle_sources_cover_all_deploy_categories_and_config_dependencies` | integration |
| 2 | A lifecycle test can distinguish byte-only churn from a real deployment/config state change. | Governed by policy, DevX | `tests/integration/test_lifecycle_state_snapshot_contract.py::test_semantic_state_ignores_yaml_formatting_and_generated_time`<br/>`::test_semantic_state_reflects_deployment_and_config_changes` | integration |
| 3 | Malicious paths cannot make the shared helpers read or write outside their declared roots. | Secure by default | `tests/integration/test_lifecycle_state_snapshot_contract.py::test_bounded_roots_fail_closed_before_outside_reads`<br/>`::test_bounded_root_identity_and_path_collisions_are_rejected` | integration |
| 4 | A production-shaped marketplace Git URL resolves locally without touching host Git state or capturing an adjacent repository prefix. | Secure by default, Vendor-neutral, DevX | `tests/integration/test_local_git_repository_factory_contract.py::test_install_url_rewrite_is_isolated_and_resolves_bare_and_git_forms` | integration |
| 5 | Project and two user target roots can contain the same relative config name without identity or byte collisions. | Secure by default, Multi-harness support | `tests/integration/test_lifecycle_state_snapshot_contract.py::test_capture_reads_two_bounded_roots_without_relative_path_collisions` | integration |
| 6 | A hook descriptor can reference portable text/binary scripts without letting assets replace or escape its source subtree. | Secure by default, Portability by manifest | `tests/integration/test_local_package_factory_contract.py::test_hook_assets_are_bounded_source_files_with_executable_intent`<br/>`::test_hook_assets_reject_escape_replacement_and_foreign_packages` | integration |
| 7 | Lifecycle tests can widen/narrow targets and replace/remove dependencies without losing unrelated manifest sections or accepting generated fields. | Governed by policy, DevX | `tests/integration/test_local_package_factory_contract.py::test_manifest_transitions_preserve_unrelated_sections_and_are_idempotent`<br/>`::test_manifest_transitions_reject_invalid_inputs_without_partial_write` | integration |

## How to test

- [ ] Run the package/state/local-Git contracts (42 tests); expect all to pass.
- [ ] Capture project plus two user roots before/after drift; expect root-qualified bytes, semantic changes, and fail-closed escapes.
- [ ] Author a hook script and mutate targets/dependencies twice; expect canonical source paths and byte-idempotent manifests.
- [ ] Exercise bare and `.git` production URLs; expect the owned local SHA, while an adjacent prefix fails.
- [ ] Run the lint, quality, architecture, and required-test commands above; expect zero failures.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>