### PR TITLE
fix(manifest): fold legacy 'all' in targets to auto-detect with a deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `apm deps list` renders non-ASCII package names. Repeated
   `apm runtime setup llm` completes without TLS recursion, and first-party CI
   and release environments resolve exactly from `uv.lock`. (#2264)
+- Legacy manifests that declared `targets: [all]` are no longer hard-rejected;
+  APM treats the field as omitted with a deprecation warning, restoring
+  installability for packages published before the canonical target catalog
+  migration. (closes #2271) -- by @kotalab (#2272)
 - `apm uninstall` and `apm prune` no longer wipe still-installed dependencies'
   merged hook entries out of a harness (e.g. `.cursor/hooks.json`) that was
   dropped from a project's `targets:` list -- the hook wipe is now scoped to

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -149,6 +149,8 @@ actionable nudge (the authoring path only).
 
 Controls which output targets are generated during compilation, installation, and packing. Accepts a single string or a YAML list. Unknown values MUST raise a parse error at load time, naming the offending token.
 
+**Deprecated: `all`.** Manifests published before the canonical target catalog could declare `all`, meaning "no restriction". The value is deprecated: parsers treat a field containing `all` as if the field were omitted (auto-detect / `--target` decide; any sibling targets listed alongside `all` are ignored, though they are still validated) and emit a deprecation warning once per run. Remove the field to keep this behavior permanently — `all` will become a hard parse error in a future release.
+
 When `target:` is omitted, APM auto-detects targets from folder presence (`.github/`, `.claude/`, `.codex/`, `.gemini/`, `.opencode/`, `.windsurf/`, `.kiro/`). Auto-detection applies only when `target:` is unset; once set, the field is authoritative.
 
 ```yaml

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -149,7 +149,7 @@ actionable nudge (the authoring path only).
 
 Controls which output targets are generated during compilation, installation, and packing. Accepts a single string or a YAML list. Unknown values MUST raise a parse error at load time, naming the offending token.
 
-**Deprecated: `all`.** Manifests published before the canonical target catalog could declare `all`, meaning "no restriction". The value is deprecated: parsers treat a field containing `all` as if the field were omitted (auto-detect / `--target` decide; any sibling targets listed alongside `all` are ignored, though they are still validated) and emit a deprecation warning once per run. Remove the field to keep this behavior permanently — `all` will become a hard parse error in a future release.
+**Deprecated: `all`.** Manifests published before the canonical target catalog could declare `all`, meaning "no restriction". The value is deprecated: parsers treat a field containing `all` as if the field were omitted (auto-detect / `--target` decide; any sibling targets listed alongside `all` are ignored, though they are still validated) and emit a deprecation warning once per run. Remove the field to keep this behavior permanently; `all` will become a hard parse error in a future release.
 
 When `target:` is omitted, APM auto-detects targets from folder presence (`.github/`, `.claude/`, `.codex/`, `.gemini/`, `.opencode/`, `.windsurf/`, `.kiro/`). Auto-detection applies only when `target:` is unset; once set, the field is authoritative.
 

--- a/src/apm_cli/core/apm_yml.py
+++ b/src/apm_cli/core/apm_yml.py
@@ -34,6 +34,7 @@ CANONICAL_TARGETS: frozenset[str] = manifest_target_names()
 # once per process. Hard rejection returns after a deprecation window.
 
 _legacy_all_warned: bool = False
+_LEGACY_ALL_TARGET_NAME = "all"
 
 
 def _reset_legacy_all_warning() -> None:
@@ -50,9 +51,9 @@ def _fold_legacy_all(tokens: list[str]) -> tuple[list[str], bool]:
     emit the warning via :func:`_warn_legacy_all_once`, so a manifest that
     still hard-fails on a sibling token does not consume the warning latch.
     """
-    if "all" not in tokens:
+    if _LEGACY_ALL_TARGET_NAME not in tokens:
         return tokens, False
-    return [t for t in tokens if t != "all"], True
+    return [t for t in tokens if t != _LEGACY_ALL_TARGET_NAME], True
 
 
 def _warn_legacy_all_once() -> None:
@@ -69,11 +70,10 @@ def _warn_legacy_all_once() -> None:
     from apm_cli.utils.console import _rich_warning
 
     _rich_warning(
-        "'all' in apm.yml targets is deprecated -- treating the field as "
-        "omitted so --target / auto-detect decide (its legacy meaning; any "
-        "sibling targets listed alongside 'all' are ignored). Remove the "
-        "field from the manifest; 'all' will become a hard error in a "
-        "future release.",
+        "'all' in apm.yml targets is deprecated and will become a hard "
+        "error in a future release. APM is treating the field as omitted "
+        "for this install so --target / auto-detect decide. If you "
+        "maintain this package, remove 'all' from the manifest.",
         symbol="warning",
     )
 
@@ -84,6 +84,16 @@ def _validate_canonical(tokens: list[str]) -> None:
         capability = TARGET_CAPABILITIES.get(token)
         if capability is None or capability.experimental_flag is not None or capability.mcp_only:
             raise UnknownTargetError(render_unknown_target_error(token, sorted(CANONICAL_TARGETS)))
+
+
+def _validate_and_fold_legacy_all(tokens: list[str]) -> list[str]:
+    """Validate tokens and fold legacy 'all' to the omitted-field behavior."""
+    tokens, folded = _fold_legacy_all(tokens)
+    _validate_canonical(tokens)
+    if folded:
+        _warn_legacy_all_once()
+        return []
+    return tokens
 
 
 def parse_targets_field(yaml_data: dict) -> list[str]:
@@ -122,12 +132,7 @@ def parse_targets_field(yaml_data: dict) -> list[str]:
             # Single value under targets: key, treat as one-element list
             raw = [str(raw)]
         tokens = [str(t).strip() for t in raw if str(t).strip()]
-        tokens, folded = _fold_legacy_all(tokens)
-        _validate_canonical(tokens)
-        if folded:
-            _warn_legacy_all_once()
-            return []
-        return tokens
+        return _validate_and_fold_legacy_all(tokens)
 
     if has_target:
         raw = yaml_data["target"]
@@ -140,23 +145,13 @@ def parse_targets_field(yaml_data: dict) -> list[str]:
             tokens = [str(t).strip() for t in raw if str(t).strip()]
             if not tokens:
                 return []
-            tokens, folded = _fold_legacy_all(tokens)
-            _validate_canonical(tokens)
-            if folded:
-                _warn_legacy_all_once()
-                return []
-            return tokens
+            return _validate_and_fold_legacy_all(tokens)
         raw_str = str(raw).strip()
         if not raw_str:
             return []
         # CSV sugar: "claude,copilot" -> ['claude', 'copilot']
         tokens = [t.strip() for t in raw_str.split(",") if t.strip()]
-        tokens, folded = _fold_legacy_all(tokens)
-        _validate_canonical(tokens)
-        if folded:
-            _warn_legacy_all_once()
-            return []
-        return tokens
+        return _validate_and_fold_legacy_all(tokens)
 
     # Neither key present
     return []

--- a/src/apm_cli/core/apm_yml.py
+++ b/src/apm_cli/core/apm_yml.py
@@ -25,6 +25,58 @@ from apm_cli.core.target_catalog import TARGET_CAPABILITIES, manifest_target_nam
 # Canonical target names accepted by APM.
 CANONICAL_TARGETS: frozenset[str] = manifest_target_names()
 
+# --- Legacy 'all' migration bridge (#2271) ---------------------------------
+# 'all' predates the canonical catalog (#1154): manifests published before
+# 0.25.0 could legally declare `targets: [all]`, meaning "no restriction".
+# The catalog keeps 'all' flag-only by design, but already-published tags
+# cannot be re-validated, so the parser folds the token to the
+# field-omitted behavior (fall through to --target / auto-detect) and warns
+# once per process. Hard rejection returns after a deprecation window.
+
+_legacy_all_warned: bool = False
+
+
+def _reset_legacy_all_warning() -> None:
+    """Test hook: re-arm the once-per-process legacy 'all' warning."""
+    global _legacy_all_warned
+    _legacy_all_warned = False
+
+
+def _fold_legacy_all(tokens: list[str]) -> tuple[list[str], bool]:
+    """Split the legacy 'all' token out of *tokens*.
+
+    Returns ``(remaining_tokens, folded)`` where *folded* is True when the
+    token was present. Callers validate the remainder first and only then
+    emit the warning via :func:`_warn_legacy_all_once`, so a manifest that
+    still hard-fails on a sibling token does not consume the warning latch.
+    """
+    if "all" not in tokens:
+        return tokens, False
+    return [t for t in tokens if t != "all"], True
+
+
+def _warn_legacy_all_once() -> None:
+    """Emit the legacy 'all' deprecation warning at most once per process.
+
+    Dependency graphs can contain many affected manifests; one warning is
+    enough. The unlocked check-then-set is a benign race: a concurrent
+    parse can at worst duplicate the warning, never suppress it.
+    """
+    global _legacy_all_warned
+    if _legacy_all_warned:
+        return
+    _legacy_all_warned = True
+    from apm_cli.utils.console import _rich_warning
+
+    _rich_warning(
+        "'all' in apm.yml targets is deprecated -- treating the field as "
+        "omitted so --target / auto-detect decide (its legacy meaning; any "
+        "sibling targets listed alongside 'all' are ignored). Remove the "
+        "field from the manifest; 'all' will become a hard error in a "
+        "future release.",
+        symbol="warning",
+    )
+
 
 def _validate_canonical(tokens: list[str]) -> None:
     """Validate every token is in CANONICAL_TARGETS. Raises UnknownTargetError."""
@@ -70,7 +122,11 @@ def parse_targets_field(yaml_data: dict) -> list[str]:
             # Single value under targets: key, treat as one-element list
             raw = [str(raw)]
         tokens = [str(t).strip() for t in raw if str(t).strip()]
+        tokens, folded = _fold_legacy_all(tokens)
         _validate_canonical(tokens)
+        if folded:
+            _warn_legacy_all_once()
+            return []
         return tokens
 
     if has_target:
@@ -84,14 +140,22 @@ def parse_targets_field(yaml_data: dict) -> list[str]:
             tokens = [str(t).strip() for t in raw if str(t).strip()]
             if not tokens:
                 return []
+            tokens, folded = _fold_legacy_all(tokens)
             _validate_canonical(tokens)
+            if folded:
+                _warn_legacy_all_once()
+                return []
             return tokens
         raw_str = str(raw).strip()
         if not raw_str:
             return []
         # CSV sugar: "claude,copilot" -> ['claude', 'copilot']
         tokens = [t.strip() for t in raw_str.split(",") if t.strip()]
+        tokens, folded = _fold_legacy_all(tokens)
         _validate_canonical(tokens)
+        if folded:
+            _warn_legacy_all_once()
+            return []
         return tokens
 
     # Neither key present

--- a/src/apm_cli/models/apm_package.py
+++ b/src/apm_cli/models/apm_package.py
@@ -565,8 +565,9 @@ class APMPackage:
             )
             canonical_targets = ()
         elif "targets" in data:
-            targets_value = parse_targets_field(data)
-            canonical_targets = tuple(targets_value)
+            parsed_targets = parse_targets_field(data)
+            targets_value = parsed_targets or None
+            canonical_targets = tuple(parsed_targets)
         else:
             target_value = parse_target_field(
                 data.get("target"),

--- a/tests/integration/test_drift_check.py
+++ b/tests/integration/test_drift_check.py
@@ -411,7 +411,30 @@ class TestSectionBRegressions:
         combined = (result.stdout or "") + (result.stderr or "")
         assert "Drift detected" not in combined
 
-    def test_b5_skill_subset_excludes_unselected_skills_from_drift(
+    def test_b5_install_legacy_all_targets_uses_explicit_target(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression: `targets: [all]` no longer blocks install (#2271)."""
+        from apm_cli.core.apm_yml import _reset_legacy_all_warning
+
+        project = _make_apm_project(tmp_path, target=None)
+        manifest = {"name": "legacy-all-fixture", "version": "1.0.0", "targets": ["all"]}
+        (project / "apm.yml").write_bytes(yaml.safe_dump(manifest).encode("utf-8"))
+
+        _reset_legacy_all_warning()
+        monkeypatch.chdir(project)
+        result = CliRunner().invoke(
+            cli,
+            ["install", "--target", "copilot"],
+            catch_exceptions=False,
+        )
+
+        combined = (result.stdout or "") + (result.stderr or "")
+        assert result.exit_code == 0, combined
+        assert "deprecated" in combined
+        assert (project / ".github" / "instructions" / "rules.instructions.md").exists()
+
+    def test_b6_skill_subset_excludes_unselected_skills_from_drift(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Regression: audit replay must honor a dependency's skill subset."""

--- a/tests/unit/core/test_target_resolution_v2.py
+++ b/tests/unit/core/test_target_resolution_v2.py
@@ -315,10 +315,60 @@ def test_target_singular_with_yaml_list_non_string_coerced():
         parse_targets_field({"target": [42]})
 
 
-def test_target_singular_with_all_token_in_list_rejected():
-    """'all' is a CLI flag-only meta-target; must not validate inside YAML."""
+def test_target_singular_with_all_token_folds_to_auto_detect():
+    """Legacy 'all' folds the field to auto-detect (deprecation bridge, #2271).
+
+    'all' stays a CLI flag-only meta-target by design, but manifests
+    published before the canonical catalog (#1154) carry it inside
+    already-released tags. The parser treats such a field as omitted
+    (fall through to --target / auto-detect) instead of hard-failing,
+    until the deprecation window closes.
+    """
+    from apm_cli.core.apm_yml import _reset_legacy_all_warning
+
+    _reset_legacy_all_warning()
+    assert parse_targets_field({"target": ["all", "claude"]}) == []
+
+
+def test_targets_plural_with_all_folds_to_auto_detect(capsys):
+    """`targets: [all]` returns [] and warns once per process."""
+    from apm_cli.core.apm_yml import _reset_legacy_all_warning
+
+    _reset_legacy_all_warning()
+    assert parse_targets_field({"targets": ["all"]}) == []
+    out = capsys.readouterr()
+    combined = out.out + out.err
+    assert "deprecated" in combined
+    # Second parse in the same process stays silent (once-per-process guard).
+    assert parse_targets_field({"targets": ["all"]}) == []
+    out = capsys.readouterr()
+    assert "deprecated" not in (out.out + out.err)
+
+
+def test_target_csv_with_all_folds_to_auto_detect():
+    """CSV sugar containing 'all' folds the whole field to auto-detect."""
+    from apm_cli.core.apm_yml import _reset_legacy_all_warning
+
+    _reset_legacy_all_warning()
+    assert parse_targets_field({"target": "all"}) == []
+    assert parse_targets_field({"target": "all,claude"}) == []
+
+
+def test_targets_with_all_still_validates_siblings(capsys):
+    """Unknown sibling tokens are still rejected even when 'all' folds.
+
+    The hard-failing manifest must not consume the once-per-process
+    warning latch: a later valid legacy manifest still warns.
+    """
+    from apm_cli.core.apm_yml import _reset_legacy_all_warning
+
+    _reset_legacy_all_warning()
     with pytest.raises(UnknownTargetError):
-        parse_targets_field({"target": ["all", "claude"]})
+        parse_targets_field({"targets": ["all", "nonsense"]})
+    capsys.readouterr()
+    assert parse_targets_field({"targets": ["all"]}) == []
+    out = capsys.readouterr()
+    assert "deprecated" in (out.out + out.err)
 
 
 def test_target_singular_with_yaml_list_preserves_duplicates():

--- a/tests/unit/core/test_target_resolution_v2.py
+++ b/tests/unit/core/test_target_resolution_v2.py
@@ -327,6 +327,7 @@ def test_target_singular_with_all_token_folds_to_auto_detect():
     from apm_cli.core.apm_yml import _reset_legacy_all_warning
 
     _reset_legacy_all_warning()
+    # Mutation guard: deleting the legacy-all fold makes this raise UnknownTargetError.
     assert parse_targets_field({"target": ["all", "claude"]}) == []
 
 


### PR DESCRIPTION
## TL;DR

Manifests published before the canonical catalog could legally declare `targets: [all]` ("no restriction"). Since 0.25.0 the token is a hard error, retroactively breaking every published tag of such packages with no consumer-side workaround. This PR keeps `all` flag-only as designed, but bridges legacy manifests: the parser folds the token to the field-omitted behavior (fall through to `--target` / auto-detect) and warns once per process. Closes #2271.

## Problem

- `parse_targets_field` validates manifest tokens against `CANONICAL_TARGETS`, which excludes `all` — deliberately (`test_target_singular_with_all_token_in_list_rejected`: *"'all' is a CLI flag-only meta-target"*).
- But the manifest value never had a deprecation window of its own: the 0.12.3 deprecation covered the CLI flag; no release warned about manifests, and the value lives inside already-published tags that cannot be re-validated.
- Consumers hit `Unknown target 'all'` at install and cannot override it: `--target claude` does not bypass the manifest validation. The only fix is publisher re-release of every affected version.

## Approach

Treat legacy `all` exactly as its historical meaning: **no restriction = the field was never there.** The parser folds the token to `[]` (auto-detect fall-through), preserving the flag-only design as the end state — hard rejection can return once the deprecation window closes. This mirrors the project's established bridges for `marketplace.outputs` list form (#1324) and `executables.deny[bin]` (#1875), and the `agents` alias warning in `install/phases/targets.py`.

Notably, folding to auto-detect is *narrower* than the CLI `--target all` expansion (all known targets): a legacy manifest can never force primitives into harness directories the consumer doesn't have.

## Implementation

- `src/apm_cli/core/apm_yml.py`: `_fold_legacy_all()` splits the token out in all three sugar branches (plural list / singular list / CSV). Sibling tokens are **still validated** (`targets: [all, bogus]` keeps failing closed), and the once-per-process warning (`_warn_legacy_all_once()`) fires only after validation passes, so a hard-failing manifest does not consume the warning latch. `reset_legacy_all_warning()` is the test hook.
- `tests/unit/core/test_target_resolution_v2.py`: the flag-only rejection test becomes the bridge test (documenting why), plus coverage for plural/CSV folding, once-per-process warning, sibling validation, and latch preservation.

## Validation

- `uv run pytest tests/unit tests/test_console.py`: **19016 passed**, 2 skipped, 21 xfailed
- `ruff check` / `ruff format --check`: clean
- Adversarial review with the `supply-chain-security-expert` persona (per CONTRIBUTING, mandatory for manifest-evaluation changes): **no blocking findings** — fold verified observationally identical to field-omitted across all `parse_targets_field` callers (`drift.py`, `manifest_reconcile.py`, `install/phases/targets.py`); no contradiction with `enterprise/security.md` (policy preflight and transitive-MCP gates apply unchanged to the resolved target set)
- Real-world repro: an affected private marketplace package (`targets: [all]`, published pre-0.25.0) fails on 0.25.0 and parses cleanly with this branch

## Known follow-ups (kept out of scope)

- The once-per-process warning names no manifest; per-manifest attribution would help spot a compromised update that *adds* `all` to widen deployment. Worth pairing with the eventual hard-removal.
- The singular `target:` model-attribute fallback path in `install/phases/targets.py` / `models/apm_package.py` still passes a raw `all` through the v1 parser — pre-existing asymmetry to fold into the same removal.

## How to test

```bash
printf 'name: t\nversion: 0.0.1\ntargets:\n- all\n' > /tmp/apm-all/apm.yml  # plus a SKILL.md
apm install /tmp/apm-all --target claude --dry-run   # 0.25.0: Unknown target 'all' / this branch: warns + proceeds
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)