### PR TITLE
fix(quality): correct duplicate group count

### DIFF
--- a/tests/quality/test_quality_baselines.py
+++ b/tests/quality/test_quality_baselines.py
@@ -27,7 +27,7 @@ CHECKERS = (
         QUALITY_DIR / "exact_test_duplicates.json",
         (
             "[+] exact test duplicate ratchet clean: "
-            "{module_count} files, 7 allowed duplicate group(s)\n"
+            "{module_count} files, 6 allowed duplicate group(s)\n"
         ),
     ),
 )


### PR DESCRIPTION
# fix(quality): align duplicate ratchet oracle with the canonical baseline

## TL;DR

This updates the repository-quality test oracle from 7 to 6 allowed exact-test
duplicate groups. The canonical baseline and scanner already agree on 6 after
the merged test deletions in #2263 and #2264; only the hardcoded expected
stdout was stale, causing current `main` to fail its quality ratchet.

> [!IMPORTANT]
> This is a one-file, one-line semantic correction. It does not change the
> canonical JSON baseline, scanner logic, or production behavior.

## Problem (WHY)

- [x] On exact `main` commit `e06a26508212ae48aedf202b2e86f587011bbdb2`,
  `test_repository_quality_baselines_are_scanned_once` expected 7 duplicate
  groups while the checker emitted 6.
- [x] The mismatch made the post-merge repository-quality gate fail even
  though `tests/quality/exact_test_duplicates.json` and
  `scripts/check_exact_test_duplicates.py` agreed.
- [!] Leaving the stale assertion in place would make a tightened duplicate
  baseline indistinguishable from a scanner regression.

The correction is grounded in the observed command output and follows the
execution-first guidance to
["Run the skill against real tasks, then feed the results — all of them, not just failures — back into the creation process."](https://agentskills.io/skill-creation/best-practices)

## Approach (WHAT)

| # | Fix | Principle | Source |
|---:|---|---|---|
| 1 | Change the expected duplicate-group count from 7 to 6. | ["Effective skills are grounded in real expertise."](https://agentskills.io/skill-creation/best-practices) | Reproduced scanner output on exact `main` |
| 2 | Preserve the canonical JSON and scanner implementation unchanged. | ["Add what the agent lacks, omit what it knows"](https://agentskills.io/skill-creation/best-practices) | One-file diff |

## Implementation (HOW)

- **[`tests/quality/test_quality_baselines.py`](https://github.com/microsoft/apm/blob/74dae05d4fe850713e5bf586342e38abe243c51d/tests/quality/test_quality_baselines.py#L29-L30)** -
  updates only the expected stdout count for the exact-test duplicate checker.
  The baseline data, checker algorithm, and unrelated quality assertions remain
  untouched.

## Diagrams

Legend: the dashed oracle node is the only changed artifact; it now matches the
canonical checker's measured output.

```mermaid
flowchart LR
    C["check_exact_test_duplicates.py"] -->|"reports 6 allowed groups"| O["test_quality_baselines.py expected output"]
    O --> A["stdout assertion passes"]
    classDef new stroke-dasharray: 5 5;
    class O new;
```

## Trade-offs

- **Correct the derived oracle, not the canonical owners.** Chose the one-line
  expected-output update; rejected changing the JSON baseline or scanner
  because both independently report 6.
- **Keep this test-only hotfix out of docs and the changelog.** Chose a bounded
  CI repair; rejected broader documentation edits because no CLI, format,
  policy, or user workflow changed.

## Benefits

1. Restores the focused quality-ratchet test from 1 failure to 1 pass.
2. Restores all 39 tests under `tests/quality`.
3. Preserves a tighter canonical allowance of 6 duplicate groups without
   weakening the checker.

## Validation

Exact-main RED reproduction:

<details><summary>Focused failure before the correction</summary>

```text
F                                                                        [100%]
=================================== FAILURES ===================================
______________ test_repository_quality_baselines_are_scanned_once ______________

>           assert result.stdout == expected.format(module_count=module_count)
E           AssertionError: assert '[+] exact te...te group(s)\n' == '[+] exact te...te group(s)\n'
E
E             Skipping 42 identical leading characters in diff, use -v to show
E             - 60 files, 7 allowed duplicate group(s)
E             ?           ^
E             + 60 files, 6 allowed duplicate group(s)
E             ?           ^

tests/quality/test_quality_baselines.py:84: AssertionError
=========================== short test summary info ============================
FAILED tests/quality/test_quality_baselines.py::test_repository_quality_baselines_are_scanned_once
1 failed, 38 deselected in 19.90s
```

</details>

`uv run --extra dev pytest -q tests/quality -k repository_quality_baselines_are_scanned_once`:

```text
.                                                                        [100%]
1 passed, 38 deselected in 15.91s
```

`uv run --extra dev pytest -p no:cacheprovider -q tests/quality`:

```text
.......................................                                  [100%]
39 passed in 123.22s (0:02:03)
```

`uv run --frozen python scripts/check_exact_test_duplicates.py`:

```text
[+] exact test duplicate ratchet clean: 1060 files, 6 allowed duplicate group(s)
```

`bash scripts/lint-architecture-boundaries.sh`:

```text
[*] AC1: canonical capability authorities
[*] AC2: validate-before-mutate boundaries
[*] AC3: outcome and policy enforcement authorities
[*] AC4: declared-intent preservation
[*] AC5: process-wide I/O boundaries
[*] AC6: neutral IR and schema contracts
[*] AC7: concurrency and deadline safety
[*] AC8: Windows installer authorities
[*] AC9: executable test contract authorities
[*] AC10: marketplace source parsing authority
[*] AC11: Git repository cache identity authority
[*] AC12: diagnostic printable-ASCII authority
[*] AC13: Git ref transport selection authority
[*] AC14: ADO lock-coordinate authority
[+] architecture boundary lint clean
```

Canonical lint mirror:

```text
All checks passed!
1543 files already formatted
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
[+] auth-signal lint clean
[+] architecture boundary lint clean
```

<details><summary>Mutation proof: restoring 7 reproduces RED</summary>

```text
FAILED tests/quality/test_quality_baselines.py::test_repository_quality_baselines_are_scanned_once
1 failed, 38 deselected in 30.76s
[+] mutation reproduced RED with exit 1
```

The mutation was restored to 6 before commit.

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | Repository quality checks pass when the measured duplicate allowance matches the canonical baseline. | OSS / community-driven | `tests/quality/test_quality_baselines.py::test_repository_quality_baselines_are_scanned_once` (regression trap for the post-merge failure) | integration |

## How to test

- [ ] Check out this branch and run the focused test; observe 1 pass.
- [ ] Run all of `tests/quality`; observe 39 passes.
- [ ] Run `scripts/check_exact_test_duplicates.py`; observe 6 allowed groups.
- [ ] Temporarily change the expected count to 7; observe the focused test fail,
  then restore 6.
- [ ] Run the lint mirror and architecture-boundary script; observe exit 0.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
