### PR TITLE
fix(ci): raise packaged Unix integration timeout

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -442,7 +442,7 @@ jobs:
         run: |
           chmod +x scripts/test-integration.sh
           uv run ./scripts/test-integration.sh
-        timeout-minutes: 20
+        timeout-minutes: 30
 
       - name: Run integration tests (Windows)
         if: matrix.platform == 'windows'

--- a/tests/unit/test_platform_contract_workflow.py
+++ b/tests/unit/test_platform_contract_workflow.py
@@ -105,6 +105,14 @@ def _assert_windows_installer_step(workflow: dict) -> None:
     assert "--tb=short" in tokens
 
 
+def _assert_standalone_integration_timeouts(workflow: dict) -> None:
+    job = workflow_job(workflow, "integration-tests")
+    unix_step = workflow_step(job, "Run integration tests (Unix)")
+    windows_step = workflow_step(job, "Run integration tests (Windows)")
+    assert unix_step.get("timeout-minutes") == 30
+    assert windows_step.get("timeout-minutes") == 20
+
+
 def test_macos_jobs_run_non_shell_binary_startup_after_build() -> None:
     """Both macOS jobs execute the exact generated artifact before upload."""
     _assert_macos_startup_steps(_workflow())
@@ -113,6 +121,37 @@ def test_macos_jobs_run_non_shell_binary_startup_after_build() -> None:
 def test_windows_installer_contract_is_windows_only_and_tokenless() -> None:
     """The Windows E2E has exact gating and no effective repository token."""
     _assert_windows_installer_step(_workflow())
+
+
+def test_standalone_integration_timeouts_are_platform_specific() -> None:
+    """Standalone Unix has headroom while Windows retains its proven bound."""
+    _assert_standalone_integration_timeouts(_workflow())
+
+
+def test_unix_integration_twenty_minute_timeout_mutation_is_rejected() -> None:
+    """The prior Unix timeout cannot satisfy the packaged timing contract."""
+    workflow = deepcopy(_workflow())
+    unix_step = workflow_step(
+        workflow_job(workflow, "integration-tests"),
+        "Run integration tests (Unix)",
+    )
+    unix_step["timeout-minutes"] = 20
+
+    with pytest.raises(AssertionError):
+        _assert_standalone_integration_timeouts(workflow)
+
+
+def test_missing_unix_integration_timeout_mutation_is_rejected() -> None:
+    """Removing the Unix timeout cannot silently make the step unbounded."""
+    workflow = deepcopy(_workflow())
+    unix_step = workflow_step(
+        workflow_job(workflow, "integration-tests"),
+        "Run integration tests (Unix)",
+    )
+    del unix_step["timeout-minutes"]
+
+    with pytest.raises(AssertionError):
+        _assert_standalone_integration_timeouts(workflow)
 
 
 @pytest.mark.parametrize("scope", ("workflow", "job", "step"))


### PR DESCRIPTION
# fix(ci): raise the packaged Unix integration timeout

## TL;DR

Raise only the standalone packaged Unix integration step timeout from 20 to 30 minutes. The failing G0 run completed all 10,324 Linux x64 tests in 19:26 and emitted the release-readiness marker before GitHub terminated the step at exactly 20 minutes. A semantic contract now fixes Unix at 30 minutes, keeps Windows at 20, and rejects both the prior Unix value and a missing Unix timeout.

> [!IMPORTANT]
> Human merge only. Do not dispatch packaged G0 until this PR is merged and the coordinator approves the run.

## Problem (WHY)

- [x] [Packaged G0 run 29557731517](https://github.com/microsoft/apm/actions/runs/29557731517) passed all five build jobs, Windows integration, Linux arm64 integration, and both macOS jobs; Linux x64 then reported `10324 passed ... in 1166.82s (0:19:26)` and `Ready for release validation!` before GitHub reported `timed out after 20 minutes`.
- [!] [Corroborating run 29558190428](https://github.com/microsoft/apm/actions/runs/29558190428) passed Linux x64 at 18:19 under the same cap, confirming that healthy runtime sits too close to the boundary.
- [!] The prior workflow had no semantic regression trap for the platform-specific timeout values. The contract follows the validation-loop pattern: ["do the work, run a validator (a script, a reference checklist, or a self-check), fix any issues, and repeat until validation passes."](https://agentskills.io/skill-creation/best-practices#validation-loops)

The evidence isolates a timeout-boundary defect in the standalone Unix step, not a test or wrapper failure.

## Approach (WHAT)

1. Raise only `integration-tests` -> `Run integration tests (Unix)` from 20 to 30 minutes.
2. Preserve the standalone Windows timeout at 20 minutes and leave macOS integration and all release-validation timeouts unchanged.
3. Add one positive semantic contract plus two negative mutation twins. Exact values are appropriate because ["Be prescriptive when operations are fragile, consistency matters, or a specific sequence must be followed"](https://agentskills.io/skill-creation/best-practices#match-specificity-to-fragility).

## Implementation (HOW)

| File | Change |
|---|---|
| [`.github/workflows/build-release.yml`](https://github.com/microsoft/apm/blob/f2c362c950d8e0ef500dcea689adad80402b0032/.github/workflows/build-release.yml#L436-L456) | Gives the standalone Unix integration wrapper 30 minutes while retaining the Windows step's 20-minute bound. No other workflow step changes. |
| [`tests/unit/test_platform_contract_workflow.py`](https://github.com/microsoft/apm/blob/f2c362c950d8e0ef500dcea689adad80402b0032/tests/unit/test_platform_contract_workflow.py#L108-L159) | Requires Unix exactly 30 and Windows exactly 20, then proves Unix `20` and a missing Unix timeout are rejected. |

## Diagrams

Legend: the dashed Unix node is the only changed workflow behavior; the Windows branch remains fixed at 20 minutes.

```mermaid
flowchart LR
    J[integration-tests matrix] --> P{matrix.platform}
    P -->|"not windows"| U["Run integration tests (Unix)<br/>timeout-minutes: 30"]
    P -->|"windows"| W["Run integration tests (Windows)<br/>timeout-minutes: 20"]
    classDef new stroke-dasharray: 5 5;
    class U new;
```

## Trade-offs

- **Bounded headroom over an unbounded step.** Chose 30 minutes rather than removing the timeout; this adds ten minutes for observed variance while retaining a finite failure bound.
- **Surgical platform scope over timeout normalization.** Chose to leave Windows, macOS, and release-validation values unchanged because the observed failure is confined to standalone Unix integration.
- **Human-gated validation over immediate dispatch.** Chose to freeze after CI is green and mergeable; packaged G0 remains a post-merge, coordinator-approved action.

## Benefits

1. The affected Unix step gains 10 minutes of headroom beyond the exact 20-minute failure boundary.
2. One workflow value changes; Windows remains exactly 20 and unrelated timeout surfaces remain untouched.
3. Three semantic tests lock the positive platform contract and both requested Unix mutation failures.

## Validation

<details open><summary>Observed packaged-run evidence</summary>

`gh run view 29557731517 --repo microsoft/apm --job 87814611188 --log`:

```text
=== 10324 passed, 65 skipped, 16 deselected, 2 xfailed in 1166.82s (0:19:26) ===
##[error]The action 'Run integration tests (Unix)' has timed out after 20 minutes.
```

`gh run view 29558190428 --repo microsoft/apm --job 87826312423 --log`:

```text
=== 10330 passed, 65 skipped, 16 deselected, 2 xfailed in 1099.86s (0:18:19) ===
```

</details>

<details><summary>TDD and workflow-quality evidence</summary>

Focused RED before the workflow edit:

```text
FAILED tests/unit/test_platform_contract_workflow.py::test_standalone_integration_timeouts_are_platform_specific
1 failed, 20 passed in 4.76s
```

Focused GREEN after the workflow edit:

```text
.....................                                                    [100%]
21 passed in 2.83s
```

Workflow-quality tests:

```text
....................................                                     [100%]
36 passed in 71.05s (0:01:11)
```

Changed-test Ruff checks:

```text
All checks passed!
1 file already formatted
```

</details>

<details><summary>CI-mirror lint evidence</summary>

```text
All checks passed!
1545 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
[+] architecture boundary lint clean
YAML and portable-relative-path guards passed
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|---|---|---|---|
| 1 | A healthy packaged Unix integration run can finish near the prior 20-minute boundary and hand off to release validation instead of being killed after reporting success. | Governed by policy | `tests/unit/test_platform_contract_workflow.py::test_standalone_integration_timeouts_are_platform_specific` (regression trap for run 29557731517)<br/>`tests/unit/test_platform_contract_workflow.py::test_unix_integration_twenty_minute_timeout_mutation_is_rejected`<br/>`tests/unit/test_platform_contract_workflow.py::test_missing_unix_integration_timeout_mutation_is_rejected` | unit |

## How to test

- [ ] Run `uv run --extra dev pytest -q tests/unit/test_platform_contract_workflow.py`; expect 21 passing tests.
- [ ] Run `uv run --extra dev pytest -q tests/quality/test_ci_topology.py tests/unit/test_windows_compat_gate_workflow.py`; expect 36 passing tests.
- [ ] Run `uv run --extra dev ruff check tests/unit/test_platform_contract_workflow.py && uv run --extra dev ruff format --check tests/unit/test_platform_contract_workflow.py`; expect no diagnostics.
- [ ] Inspect the workflow diff; expect only Unix `timeout-minutes: 30`, with Windows still `20`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
