### PR TITLE
fix(deps): align integration throttle contracts

### DIFF
--- a/tests/integration/test_download_copilot_end_to_end.py
+++ b/tests/integration/test_download_copilot_end_to_end.py
@@ -56,6 +56,7 @@ from apm_cli.adapters.client.copilot import (
     _translate_env_placeholder,
 )
 from apm_cli.deps.download_strategies import DownloadDelegate
+from apm_cli.deps.github_rate_limit import GitHubThrottleError
 from apm_cli.models.dependency.reference import DependencyReference
 
 # ---------------------------------------------------------------------------
@@ -306,8 +307,10 @@ class TestResilientGet:
         assert result.status_code == 200
         mock_sleep.assert_called_once()
 
-    def test_ratelimit_remaining_low_logged(self, capsys: pytest.CaptureFixture) -> None:
-        """Low X-RateLimit-Remaining triggers debug log when APM_DEBUG set."""
+    def test_ratelimit_remaining_low_is_not_logged_by_transport(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A successful low-quota response is not a rendered throttle."""
         host = _make_host()
         delegate = DownloadDelegate(host)
         resp = _make_mock_response(200, headers={"X-RateLimit-Remaining": "5"})
@@ -317,7 +320,7 @@ class TestResilientGet:
         ):
             delegate.resilient_get("https://api.github.com/test", {}, max_retries=1)
         captured = capsys.readouterr()
-        assert "rate limit low" in captured.err
+        assert captured.err == ""
 
     def test_x_ratelimit_reset_header_used_for_wait(self) -> None:
         """X-RateLimit-Reset used to compute wait when Retry-After absent."""
@@ -970,8 +973,8 @@ class TestDownloadGithubFile:
 
         assert result == b"master content"
 
-    def test_rate_limit_error_message_without_token(self) -> None:
-        """Rate-limit error message instructs user to set GITHUB_APM_PAT."""
+    def test_confirmed_throttle_without_token_is_typed(self) -> None:
+        """A confirmed GitHub throttle retains its typed public contract."""
         host = _make_host(github_token=None)
         delegate = DownloadDelegate(host)
         dep = _make_dep_ref("owner/repo", host="github.com")
@@ -984,8 +987,11 @@ class TestDownloadGithubFile:
             patch.object(delegate, "try_raw_download", return_value=None),
             patch.object(host, "_resilient_get", return_value=rate_limited),
         ):
-            with pytest.raises(RuntimeError, match="rate limit"):
+            with pytest.raises(GitHubThrottleError) as exc_info:
                 delegate.download_github_file(dep, "apm.yml", ref="main")
+
+        assert str(exc_info.value) == "GitHub API throttle for github.com (HTTP 403)"
+        assert exc_info.value.throttle.signal == "remaining-zero"
 
     def test_network_error_wrapped_in_runtime_error(self) -> None:
         """ConnectionError is wrapped in RuntimeError."""

--- a/tests/integration/test_download_copilot_end_to_end.py
+++ b/tests/integration/test_download_copilot_end_to_end.py
@@ -993,6 +993,26 @@ class TestDownloadGithubFile:
         assert str(exc_info.value) == "GitHub API throttle for github.com (HTTP 403)"
         assert exc_info.value.throttle.signal == "remaining-zero"
 
+    def test_confirmed_throttle_with_token_is_typed(self) -> None:
+        """A confirmed throttle renders identically whether or not a token is set."""
+        host = _make_host(github_token="tok")
+        delegate = DownloadDelegate(host)
+        dep = _make_dep_ref("owner/repo", host="github.com")
+        host.auth_resolver.resolve.return_value = MagicMock(token="tok", source="env")
+        rate_limited = _make_mock_response(403, headers={"X-RateLimit-Remaining": "0"})
+        rate_limited_err = requests.exceptions.HTTPError(response=rate_limited)
+        rate_limited.raise_for_status.side_effect = rate_limited_err
+
+        with (
+            patch.object(delegate, "try_raw_download", return_value=None),
+            patch.object(host, "_resilient_get", return_value=rate_limited),
+        ):
+            with pytest.raises(GitHubThrottleError) as exc_info:
+                delegate.download_github_file(dep, "apm.yml", ref="main")
+
+        assert str(exc_info.value) == "GitHub API throttle for github.com (HTTP 403)"
+        assert exc_info.value.throttle.signal == "remaining-zero"
+
     def test_network_error_wrapped_in_runtime_error(self) -> None:
         """ConnectionError is wrapped in RuntimeError."""
         host = _make_host(github_token="tok")

--- a/tests/integration/test_download_strategies_phase3w5.py
+++ b/tests/integration/test_download_strategies_phase3w5.py
@@ -11,6 +11,7 @@ import pytest
 import requests
 
 from apm_cli.deps.download_strategies import DownloadDelegate
+from apm_cli.deps.github_rate_limit import GitHubThrottleError
 from apm_cli.models.apm_package import DependencyReference
 
 
@@ -775,7 +776,7 @@ class TestDownloadGithubFilePhase3W5:
             with pytest.raises(RuntimeError, match="HTTP 500"):
                 delegate.download_github_file(dep, "README.md", ref="main")
 
-    def test_rate_limit_error_without_token_uses_error_context(self) -> None:
+    def test_confirmed_throttle_without_token_is_typed(self) -> None:
         host = make_host(resolved_token=None)
         delegate = DownloadDelegate(host)
         dep = make_dep("owner/repo", host="github.com")
@@ -784,10 +785,13 @@ class TestDownloadGithubFilePhase3W5:
             headers={"X-RateLimit-Remaining": "0"},
         )
 
-        with pytest.raises(RuntimeError, match="Unauthenticated requests are limited"):
+        with pytest.raises(GitHubThrottleError) as exc_info:
             delegate.download_github_file(dep, "README.md")
 
-    def test_rate_limit_error_with_token_mentions_quota(self) -> None:
+        assert str(exc_info.value) == "GitHub API throttle for github.com (HTTP 403)"
+        assert exc_info.value.throttle.signal == "remaining-zero"
+
+    def test_confirmed_throttle_with_token_is_typed(self) -> None:
         host = make_host(resolved_token="gh-token")
         delegate = DownloadDelegate(host)
         dep = make_dep("owner/repo", host="github.com")
@@ -796,8 +800,11 @@ class TestDownloadGithubFilePhase3W5:
             headers={"X-RateLimit-Remaining": "0"},
         )
 
-        with pytest.raises(RuntimeError, match="rate-limit quota"):
+        with pytest.raises(GitHubThrottleError) as exc_info:
             delegate.download_github_file(dep, "README.md")
+
+        assert str(exc_info.value) == "GitHub API throttle for github.com (HTTP 403)"
+        assert exc_info.value.throttle.signal == "remaining-zero"
 
     def test_auth_failure_retries_without_auth_and_succeeds(self) -> None:
         host = make_host(resolved_token="gh-token")

--- a/tests/integration/test_download_strategies_selection.py
+++ b/tests/integration/test_download_strategies_selection.py
@@ -13,6 +13,7 @@ import pytest
 import requests
 
 from apm_cli.deps.download_strategies import DownloadDelegate
+from apm_cli.deps.github_rate_limit import GitHubThrottleError
 from apm_cli.models.apm_package import DependencyReference
 
 
@@ -824,7 +825,7 @@ class TestDownloadGithubFile:
             with pytest.raises(RuntimeError, match="HTTP 500"):
                 delegate.download_github_file(dep, "README.md", ref="main")
 
-    def test_rate_limit_error_without_token_uses_error_context(self) -> None:
+    def test_confirmed_throttle_without_token_is_typed(self) -> None:
         host = make_host(resolved_token=None)
         delegate = DownloadDelegate(host)
         dep = make_dep("owner/repo", host="github.com")
@@ -833,10 +834,13 @@ class TestDownloadGithubFile:
             headers={"X-RateLimit-Remaining": "0"},
         )
 
-        with pytest.raises(RuntimeError, match="Unauthenticated requests are limited"):
+        with pytest.raises(GitHubThrottleError) as exc_info:
             delegate.download_github_file(dep, "README.md")
 
-    def test_rate_limit_error_with_token_mentions_quota(self) -> None:
+        assert str(exc_info.value) == "GitHub API throttle for github.com (HTTP 403)"
+        assert exc_info.value.throttle.signal == "remaining-zero"
+
+    def test_confirmed_throttle_with_token_is_typed(self) -> None:
         host = make_host(resolved_token="gh-token")
         delegate = DownloadDelegate(host)
         dep = make_dep("owner/repo", host="github.com")
@@ -845,8 +849,11 @@ class TestDownloadGithubFile:
             headers={"X-RateLimit-Remaining": "0"},
         )
 
-        with pytest.raises(RuntimeError, match="rate-limit quota"):
+        with pytest.raises(GitHubThrottleError) as exc_info:
             delegate.download_github_file(dep, "README.md")
+
+        assert str(exc_info.value) == "GitHub API throttle for github.com (HTTP 403)"
+        assert exc_info.value.throttle.signal == "remaining-zero"
 
     def test_auth_failure_retries_without_auth_and_succeeds(self) -> None:
         host = make_host(resolved_token="gh-token")


### PR DESCRIPTION
# fix(deps): align integration throttle contracts

## TL;DR

Repair six packaged-G0 integration failures by asserting the existing
`GitHubThrottleError` public contract rather than retired generic rate-limit
phrases. Preserve the separate successful low-quota path as intentionally
silent transport behavior. No production downloader, credential-resolution,
or user-facing behavior changes.

> [!NOTE]
> The repair is based on packaged G0 run `29578118510`; it does not rerun that
> historical workflow.

## Problem (WHY)

- [x] The packaged run reported six failures because five integration nodes
  expected obsolete generic error narratives after a confirmed GitHub `403`
  throttle now raises the typed error.
- [x] The remaining node expected a debug warning for successful `200` low
  quota, although the transport intentionally leaves header interpretation to
  the canonical throttle classifier and produces no output.
- [!] Generic substring regexes did not prove the error type, safe rendered
  wording, or the classifier's `remaining-zero` signal.

Why these matter: the tests should encode the contract they need rather than
invent a parallel message authority: ["Add what the agent lacks, omit what it
knows"](https://agentskills.io/skill-creation/best-practices).

## Approach (WHAT)

| # | Fix |
|---|---|
| 1 | Replace generic `RuntimeError` regex expectations with `GitHubThrottleError`, exact safe text, and the `remaining-zero` classification signal. |
| 2 | Make the successful low-quota contract explicit: `resilient_get()` emits no stderr output for `200` plus remaining quota `5`. |
| 3 | Keep token-present and token-absent inputs as separate integration cases while asserting their shared typed-throttle outcome. |

## Implementation (HOW)

- **[`tests/integration/test_download_copilot_end_to_end.py`](https://github.com/microsoft/apm/blob/7a4dc8e7fb96991183e5ceb4675546c05058912d/tests/integration/test_download_copilot_end_to_end.py#L307-L995)** -- updates the low-quota test to prove silence and changes the no-token `403` case to assert the typed error plus exact rendered contract.
- **[`tests/integration/test_download_strategies_phase3w5.py`](https://github.com/microsoft/apm/blob/7a4dc8e7fb96991183e5ceb4675546c05058912d/tests/integration/test_download_strategies_phase3w5.py#L776-L809)** -- verifies the same typed `403` result for both token states without restoring retired quota copy.
- **[`tests/integration/test_download_strategies_selection.py`](https://github.com/microsoft/apm/blob/7a4dc8e7fb96991183e5ceb4675546c05058912d/tests/integration/test_download_strategies_selection.py#L825-L858)** -- mirrors the selection suite's token-state contracts against the canonical error type and signal.

## Diagrams

Legend: the changed assertions keep a successful low-quota response separate
from the confirmed-throttle path and consume the classifier-owned type.

```mermaid
flowchart LR
    R[GitHub response] --> Q{200 with low quota}
    Q -->|yes| S[No transport stderr]
    R --> T{403 with remaining zero}
    T -->|yes| E[GitHubThrottleError]
    E --> C[Exact type message and signal assertions]
    S --> C
    classDef new stroke-dasharray: 5 5;
    class C new;
```

## Trade-offs

- **Typed contract over retired advice text.** Chose exact type, message, and
  signal assertions; rejected broad `rate limit` matching because it would
  accept unrelated failures.
- **Silent low-quota response over a new warning.** Chose the existing
  classifier-owned distinction; rejected adding a second warning path because
  the current unit contract proves successful responses are not transport
  diagnostics.

## Benefits

1. All six packaged-G0 failures now test the canonical typed-throttle outcome.
2. Five cases reject a mutation that removes `API` from the rendered error.
3. The successful `200` low-quota case explicitly rejects unsolicited stderr.

## Validation

`uv run --extra dev pytest -q tests/integration/test_download_copilot_end_to_end.py tests/integration/test_download_strategies_phase3w5.py tests/integration/test_download_strategies_selection.py tests/unit/deps/test_github_rate_limit.py tests/unit/deps/test_github_throttle_fallback.py`:

```text
303 passed in 8.71s
```

`bash scripts/lint-architecture-boundaries.sh && uv run --extra dev pytest -q tests/integration/test_architecture_authorities.py`:

```text
[+] architecture boundary lint clean
51 passed in 1587.98s (0:26:27)
```

<details><summary>CI mirror and test-quality evidence</summary>

```text
ruff check: All checks passed!
ruff format: 1538 files already formatted
pylint R0801: Your code has been rated at 10.00/10
auth-signal lint: clean
CI YAML, file-length, and relative-path guards: passed
assertion-quality ratchet: AQ001=4, AQ002=12
exact test duplicate ratchet: 1052 files, 0 allowed duplicate group(s)
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|-------------------------|--------------|--------------------|------|
| 1 | A confirmed GitHub API throttle tells a package consumer exactly what failed without exposing response details, regardless of whether a token was supplied. | DevX (pragmatic as npm), Secure by default | `tests/integration/test_download_copilot_end_to_end.py::TestDownloadGithubFile::test_confirmed_throttle_without_token_is_typed` (regression-trap for packaged G0 run 29578118510)<br/>`tests/integration/test_download_strategies_phase3w5.py::TestDownloadGithubFilePhase3W5::test_confirmed_throttle_without_token_is_typed`<br/>`tests/integration/test_download_strategies_phase3w5.py::TestDownloadGithubFilePhase3W5::test_confirmed_throttle_with_token_is_typed`<br/>`tests/integration/test_download_strategies_selection.py::TestDownloadGithubFile::test_confirmed_throttle_without_token_is_typed`<br/>`tests/integration/test_download_strategies_selection.py::TestDownloadGithubFile::test_confirmed_throttle_with_token_is_typed` | integration |
| 2 | A successful GitHub request with low remaining quota completes without an unexpected transport warning. | DevX (pragmatic as npm) | `tests/integration/test_download_copilot_end_to_end.py::TestResilientGet::test_ratelimit_remaining_low_is_not_logged_by_transport` | integration |

## How to test

- [ ] Run the six repaired nodes from the focused pytest command above and
  observe `6 passed`.
- [ ] Change `GitHub API throttle` in `GitHubThrottleError` temporarily and run
  the five typed-throttle nodes; observe five assertion failures.
- [ ] Restore the message and run the full affected-suite command; observe
  `303 passed`.
- [ ] Run the architecture and CI-lint commands above; observe clean output.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
