### PR TITLE
test(outdated): isolate parallel fixtures

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -66,6 +66,10 @@ def _reset_console_state():
     """
     from apm_cli.utils.console import _reset_console
 
+    # ``rich._console`` is Rich's process-global default console (the one
+    # ``rich.get_console()``/``rich.print`` lazily create). Nulling it forces
+    # a fresh real console next call. The attribute has lived at this name
+    # since Rich 10.0; the project pins ``rich>=13.0.0`` (verified on 15.x).
     _reset_console()
     rich._console = None
     yield

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -24,6 +24,7 @@ from functools import lru_cache
 from pathlib import Path
 
 import pytest
+import rich
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
@@ -47,7 +48,7 @@ def _integration_process_cwd_guard():
 
 @pytest.fixture(autouse=True)
 def _reset_console_state():
-    """Reset the console singleton after each test.
+    """Reset APM and Rich console singletons before and after each test.
 
     Several commands (e.g. ``pack --json``) call
     ``set_console_stderr(True)`` to route rich/click output to stderr.
@@ -56,14 +57,20 @@ def _reset_console_state():
     tests see empty stdout because ``click.echo(..., err=True)``
     silently diverts output.
 
-    This fixture is a safety net -- it yields first (so the test runs
-    with whatever state it sets up) and unconditionally resets
-    afterwards.
+    Tests that initialize Rich's process-global console while its
+    ``Console`` class is patched can also leave a ``MagicMock`` clock
+    behind. Rich progress then compares mock timestamps in later tests.
+
+    This fixture resets both singletons before and after each test so an
+    xdist worker cannot carry console state across test boundaries.
     """
-    yield
     from apm_cli.utils.console import _reset_console
 
     _reset_console()
+    rich._console = None
+    yield
+    _reset_console()
+    rich._console = None
     try:
         os.getcwd()
     except (FileNotFoundError, OSError):

--- a/tests/integration/test_wave6_outdated_view_coverage.py
+++ b/tests/integration/test_wave6_outdated_view_coverage.py
@@ -22,10 +22,12 @@ from typing import Never
 from unittest.mock import MagicMock, patch
 
 import pytest
+import rich
 from click.testing import CliRunner
 
 from apm_cli.cli import cli
 from apm_cli.models.dependency.types import GitReferenceType, RemoteRef
+from tests.integration.conftest import _reset_console_state
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -563,6 +565,19 @@ class TestOutdatedSequential:
 
 class TestOutdatedParallel:
     """Multiple deps trigger the parallel code path."""
+
+    def test_console_guard_resets_rich_singleton_before_and_after(self) -> None:
+        """The integration guard isolates Rich's process-global console."""
+        guard = _reset_console_state.__wrapped__()
+        rich._console = MagicMock()
+
+        next(guard)
+        assert rich._console is None
+
+        rich._console = MagicMock()
+        with pytest.raises(StopIteration):
+            next(guard)
+        assert rich._console is None
 
     def test_multiple_deps_parallel(
         self, runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/integration/test_wave6_outdated_view_coverage.py
+++ b/tests/integration/test_wave6_outdated_view_coverage.py
@@ -18,7 +18,7 @@ Target modules
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Never
+from typing import NoReturn
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -660,7 +660,7 @@ class TestOutdatedParallel:
             f"    resolved_commit: {sha}\n",
         )
 
-        def _raise_check_error(*_args: object, **_kwargs: object) -> Never:
+        def _raise_check_error(*_args: object, **_kwargs: object) -> NoReturn:
             raise TypeError("'<' not supported between MagicMock and MagicMock")
 
         with patch(

--- a/tests/integration/test_wave6_outdated_view_coverage.py
+++ b/tests/integration/test_wave6_outdated_view_coverage.py
@@ -17,15 +17,15 @@ Target modules
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
+from typing import Never
 from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
 
 from apm_cli.cli import cli
-from apm_cli.models.dependency.types import GitReferenceType
+from apm_cli.models.dependency.types import GitReferenceType, RemoteRef
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -50,16 +50,9 @@ dependencies:
 """
 
 
-def _make_remote_ref(name: str, ref_type: GitReferenceType, sha: str):
-    """Create a minimal RemoteRef-like object."""
-
-    @dataclass
-    class _Ref:
-        name: str
-        ref_type: GitReferenceType
-        commit_sha: str
-
-    return _Ref(name=name, ref_type=ref_type, commit_sha=sha)
+def _make_remote_ref(name: str, ref_type: GitReferenceType, sha: str) -> RemoteRef:
+    """Create a production-shaped remote reference."""
+    return RemoteRef(name=name, ref_type=ref_type, commit_sha=sha)
 
 
 def _write_lockfile(tmp_path: Path, deps_yaml: str) -> None:
@@ -589,9 +582,12 @@ class TestOutdatedParallel:
 
         branch_ref = _make_remote_ref("main", GitReferenceType.BRANCH, sha)
 
+        def _list_remote_refs(_downloader: object, _dep_ref: object) -> list[RemoteRef]:
+            return [branch_ref]
+
         with patch(
             "apm_cli.deps.github_downloader.GitHubPackageDownloader.list_remote_refs",
-            return_value=[branch_ref],
+            new=_list_remote_refs,
         ):
             result = runner.invoke(cli, ["outdated", "-j", "2"])
 
@@ -615,13 +611,12 @@ class TestOutdatedParallel:
             f"    resolved_commit: {new_sha}\n",
         )
 
-        def _side_effect(dep_ref):
-            sha = new_sha
-            return [_make_remote_ref("main", GitReferenceType.BRANCH, sha)]
+        def _list_remote_refs(_downloader: object, _dep_ref: object) -> list[RemoteRef]:
+            return [_make_remote_ref("main", GitReferenceType.BRANCH, new_sha)]
 
         with patch(
             "apm_cli.deps.github_downloader.GitHubPackageDownloader.list_remote_refs",
-            side_effect=_side_effect,
+            new=_list_remote_refs,
         ):
             result = runner.invoke(cli, ["outdated"])
 
@@ -650,9 +645,12 @@ class TestOutdatedParallel:
             f"    resolved_commit: {sha}\n",
         )
 
+        def _raise_check_error(*_args: object, **_kwargs: object) -> Never:
+            raise TypeError("'<' not supported between MagicMock and MagicMock")
+
         with patch(
             "apm_cli.commands.outdated._check_one_dep",
-            side_effect=TypeError("'<' not supported between MagicMock and MagicMock"),
+            new=_raise_check_error,
         ):
             result = runner.invoke(cli, ["outdated", "-j", "2"])
 


### PR DESCRIPTION
# fix(tests): isolate parallel outdated fixtures

## TL;DR

This repairs the three deterministic macOS arm64 `TestOutdatedParallel` failures from G0 run 29578118510. The integration guard now clears Rich's process-global console before and after every test, preventing a leaked `MagicMock` clock from reaching production progress comparisons; parallel seams also use real `RemoteRef` values and plain typed callables.

> [!NOTE]
> Production ordering, exception handling, and CLI assertions are unchanged.

## Problem (WHY)

- [x] G0 run 29578118510 failed all three `TestOutdatedParallel` nodes with `TypeError("'<' not supported between instances of 'MagicMock' and 'MagicMock'")`.
- [x] An earlier integration test could initialize Rich's process-global console while patched; later progress updates then evaluated `ProgressSample.timestamp < old_sample_time` with two `MagicMock` clock values.
- [x] The integration console guard reset APM's singleton only after each test, leaving Rich's singleton live across xdist worker boundaries.
- [x] The parallel fixtures also patched functions called from `ThreadPoolExecutor` workers with shared mocks instead of plain typed callables.
- [!] The module-local remote-reference helper duplicated the shape of `RemoteRef` instead of constructing the production type.

This matters because deterministic execution should ground generated test state in real values: ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)

## Approach (WHAT)

| # | Fix | Principle |
|---:|---|---|
| 1 | Reset both APM and Rich console singletons before and after every integration test. | ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |
| 2 | Construct the production `RemoteRef` dataclass in the shared fixture helper. | ["Add what the agent lacks, omit what it knows"](https://agentskills.io/skill-creation/best-practices) |
| 3 | Patch thread-invoked methods with plain typed functions via `new=`, not shared mocks. | ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |

## Implementation (HOW)

- **[`tests/integration/conftest.py`](https://github.com/microsoft/apm/blob/16e8bbbc058a4b51bb680a4a4d81023776faeda9/tests/integration/conftest.py#L49-L76)** - resets APM and Rich console singletons on both sides of every integration test, so a worker begins with a real Rich clock and cannot leak console state forward.
- **[`tests/integration/test_wave6_outdated_view_coverage.py`](https://github.com/microsoft/apm/blob/16e8bbbc058a4b51bb680a4a4d81023776faeda9/tests/integration/test_wave6_outdated_view_coverage.py#L53-L670)** - adds the pre/post singleton regression trap, replaces the local look-alike dataclass with `RemoteRef`, and replaces the three thread-shared mock patches with typed functions. No production files, CLI behavior, ordering logic, skips, xfails, or existing assertions changed.

## Diagrams

Legend: the dashed isolation stages are the changed boundary; the production Rich comparison and parallel path remain intact.

```mermaid
flowchart LR
    subgraph Prior[Prior integration test]
        L1[Leaked mock console]
    end
    subgraph Guard[Autouse console guard]
        G1[Pre-test reset]
        G2[Post-test reset]
    end
    subgraph Production[Production path]
        P1[ThreadPoolExecutor]
        P2[Real Rich clock]
        P3[Ordered result rows]
    end
    L1 --> G1
    G1 --> P1
    P1 --> P2
    P2 --> P3
    P3 --> G2
    classDef new stroke-dasharray: 5 5;
    class G1,G2 new;
```

## Trade-offs

- **Private Rich singleton reset in test infrastructure.** The guard assigns `rich._console = None`; this is intentionally confined to integration-test isolation and avoids changing production console ownership.
- **Plain callables over mock call tracking.** This gives up `MagicMock` call metadata in these three tests; the assertions are outcome-based, so call tracking adds no signal.
- **Fixture repair over production accommodation.** Production sorting was left unchanged; skipping, xfail, catching `TypeError`, or weakening assertions would hide an untruthful fixture rather than repair it.

## Benefits

1. All three G0-failing nodes complete with exit code 0 using truthful remote-reference values.
2. Five reversed-order repetitions pass without cross-test leakage.
3. A deliberately poisoned Rich singleton is cleared before the three nodes execute.
4. The full 52-test containing module passes with the CI `-n 2 --dist loadgroup` scheduler.

## Validation

`pytest` order matrix on Python 3.12.10:

```text
individual: 1 passed; 1 passed; 1 passed
together: 3 passed
reversed order, repeated 5 times: 3 passed each run
containing module with -n 2 --dist loadgroup: 52 passed
```

Regression-trap mutation break:

```text
before guard fix: 1 failed
after guard fix: 1 passed
poisoned Rich singleton probe: 3 passed
```

<details><summary>Lint and test-quality gates</summary>

```text
ruff check: All checks passed!
ruff format --check: 1538 files already formatted
pylint R0801: 10.00/10
auth-signal lint: clean
architecture boundary lint: clean
portable YAML, file-length, and relative-path guards: passed
assertion-quality ratchet: clean
exact test duplicate ratchet: clean
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | `apm outdated` checks multiple dependencies in parallel without inherited console-state failures | DevX (pragmatic as npm) | `tests/integration/test_wave6_outdated_view_coverage.py::TestOutdatedParallel::test_console_guard_resets_rich_singleton_before_and_after`<br/>`::test_multiple_deps_parallel`<br/>`::test_multiple_deps_some_outdated`<br/>`::test_multiple_deps_one_check_errors_degrades` (regression trap for G0 run 29578118510) | integration |

## How to test

- [ ] Run each `TestOutdatedParallel` node separately; each should pass.
- [ ] Run the three nodes together and in reverse order; all should pass.
- [ ] Repeat the reversed order five times; every run should report `3 passed`.
- [ ] Run the containing module with `-n 2 --dist loadgroup`; it should report `52 passed`.
- [ ] Run the full CI lint mirror; every gate should exit 0.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
