### PR TITLE
fix(install): remove shared-root skill orphan on target narrowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Installing packages that share `.agents/skills` no longer leaves duplicate
   lockfile state or drops prior integrity information when APM must keep a file
   for a later retry. (#2283)
+- Narrowing a project's active targets (for example dropping Cursor back to
+  Claude only) now removes the shared-root skill copy that target deployed to
+  `.agents/skills/<name>/SKILL.md`, instead of leaving it on disk with no
+  lockfile ownership row. User-edited copies are still preserved, and a copy a
+  surviving target continues to claim is kept. `apm audit --ci` no longer
+  reports a clean bill of health while such an orphan lingers.
 - Copilot hooks installed with `apm install -g` now resolve from any working
   directory by writing absolute user-scope script commands, while project-scope
   hooks remain repo-relative for portability -- reported by @sproott, fixed by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.agents/skills/<name>/SKILL.md`, instead of leaving it on disk with no
   lockfile ownership row. User-edited copies are still preserved, and a copy a
   surviving target continues to claim is kept. `apm audit --ci` no longer
-  reports a clean bill of health while such an orphan lingers.
+  reports a clean bill of health while such an orphan lingers. (#2299)
 - Copilot hooks installed with `apm install -g` now resolve from any working
   directory by writing absolute user-scope script commands, while project-scope
   hooks remain repo-relative for portability -- reported by @sproott, fixed by

--- a/src/apm_cli/install/manifest_reconcile.py
+++ b/src/apm_cli/install/manifest_reconcile.py
@@ -425,6 +425,20 @@ def reconcile_deployed_block(  # noqa: PLR0913 -- deployed-state chokepoint wrap
         include_ledger=True,
     )
     dropped = set(prior_files) - set(files)
+    # Ledger-authoritative orphan detection. A prior value that HELD a ledger
+    # row, LOST it during reconciliation (its owning target went stale), yet
+    # still lingers in `files` -- a stale-cleanup retention re-inserts shared
+    # roots the active target cannot validate -- is a physical orphan. It never
+    # entered `dropped` (still present in `files`) so it would otherwise survive
+    # on disk with no manifest row. Route it through the SAME cleanup chokepoint
+    # so the validate / provenance / unlink gates decide its fate. This acts
+    # only on values that had a prior row (never on a ghost/no-row path), and
+    # excludes any value re-owned this run (`surviving`), so a shared root a
+    # concrete active target still claims is preserved.
+    if prior_ledger is not None:
+        prior_owned = {record.locator.value for record in prior_ledger.records.values()}
+        surviving = {record.locator.value for record in ledger.records.values()}
+        dropped |= (set(prior_files) & prior_owned) - surviving
     if not dropped:
         if include_ledger:
             return files, hashes, ledger
@@ -443,6 +457,14 @@ def reconcile_deployed_block(  # noqa: PLR0913 -- deployed-state chokepoint wrap
     )
     if on_cleanup is not None:
         on_cleanup(cleanup)
+    # Orphan candidates (unlike the classic dropped set) can still be present in
+    # `files`; a proven deletion must therefore also retract the value from the
+    # returned manifest and hashes so the lockfile row and disk state agree.
+    if cleanup.deleted:
+        deleted = set(cleanup.deleted)
+        files = [path for path in files if path not in deleted]
+        for path in deleted:
+            hashes.pop(path, None)
     for path in cleanup.retained:
         if path not in files:
             files.append(path)

--- a/tests/integration/test_shared_root_skill_contraction_e2e.py
+++ b/tests/integration/test_shared_root_skill_contraction_e2e.py
@@ -1,0 +1,177 @@
+"""End-to-end regression coverage for shared-root skill contraction.
+
+A skill deployed for a non-Claude target (e.g. Cursor) materializes into the
+shared ``.agents/skills/<name>/SKILL.md`` root, while the Claude target owns its
+private ``.claude/skills/<name>/SKILL.md`` copy. When the active target set
+narrows back to Claude only, the shared-root copy must be removed through the
+canonical cleanup chokepoint -- not left on disk after its lockfile/ledger
+ownership row has been reconciled away.
+
+This pins the fix for the shared-root physical orphan: previously the narrow
+install correctly dropped the ``.agents/skills`` ledger row (Cursor is no longer
+active/declared) yet the file lingered on disk because the reconciled value was
+never routed to :func:`remove_stale_deployed_files`. That left a physical orphan
+with no lockfile row, invisible to every manifest-driven audit gate.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+TIMEOUT = 180
+_SKILL_NAME = "scope"
+_CLAUDE_SKILL = Path(".claude/skills") / _SKILL_NAME / "SKILL.md"
+_SHARED_SKILL = Path(".agents/skills") / _SKILL_NAME / "SKILL.md"
+
+
+def _run(apm_binary_path: Path, cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run the installed CLI in *cwd* and capture its result."""
+    return subprocess.run(
+        [str(apm_binary_path), *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=TIMEOUT,
+        check=False,
+    )
+
+
+def _write_consumer(project: Path, targets: list[str]) -> None:
+    """Write a consumer manifest that depends on the adjacent fixture package."""
+    project.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "name": "shared-root-skill-contraction-consumer",
+        "version": "1.0.0",
+        "targets": targets,
+        "dependencies": {"apm": [{"path": "../lifecycle-package"}]},
+    }
+    (project / "apm.yml").write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
+
+
+def _write_lifecycle_package(package: Path) -> None:
+    """Write the local package whose skill materializes per target."""
+    package.mkdir(parents=True, exist_ok=True)
+    (package / "apm.yml").write_text(
+        """name: lifecycle-package
+version: 1.0.0
+description: Shared-root skill contraction fixture
+""",
+        encoding="utf-8",
+    )
+    skill_dir = package / ".apm" / "skills" / _SKILL_NAME
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(
+        """---
+name: scope
+description: Shared-root skill contraction fixture
+---
+# Scope skill
+This skill materializes into every active target's skill root.
+""",
+        encoding="utf-8",
+    )
+
+
+def _deployed_files(project: Path) -> list[str]:
+    """Return the fixture package's current lockfile paths."""
+    lockfile = yaml.safe_load((project / "apm.lock.yaml").read_text(encoding="utf-8"))
+    dependencies = lockfile.get("dependencies") or []
+    return list(dependencies[0].get("deployed_files") or [])
+
+
+@pytest.mark.integration
+def test_widen_then_narrow_removes_shared_root_skill_orphan(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Claude -> Claude+Cursor -> Claude removes the shared-root skill copy."""
+    workspace = tmp_path / "workspace"
+    consumer = workspace / "consumer"
+    package = workspace / "lifecycle-package"
+    _write_consumer(consumer, ["claude"])
+    _write_lifecycle_package(package)
+
+    initial = _run(apm_binary_path, consumer, "install", "--target", "claude", "--no-policy")
+    assert initial.returncode == 0, initial.stderr
+    assert (consumer / _CLAUDE_SKILL).is_file()
+    assert not (consumer / _SHARED_SKILL).exists()
+    claude_bytes = (consumer / _CLAUDE_SKILL).read_text(encoding="utf-8")
+
+    _write_consumer(consumer, ["claude", "cursor"])
+    widened = _run(
+        apm_binary_path,
+        consumer,
+        "install",
+        "--target",
+        "claude,cursor",
+        "--no-policy",
+    )
+    assert widened.returncode == 0, widened.stderr
+    assert (consumer / _CLAUDE_SKILL).is_file()
+    assert (consumer / _SHARED_SKILL).is_file()
+
+    _write_consumer(consumer, ["claude"])
+    narrowed = _run(apm_binary_path, consumer, "install", "--target", "claude", "--no-policy")
+    assert narrowed.returncode == 0, narrowed.stderr
+
+    # The shared-root skill copy for the dropped Cursor target is gone; the
+    # Claude-owned copy survives byte-for-byte.
+    assert not (consumer / _SHARED_SKILL).exists()
+    assert (consumer / _CLAUDE_SKILL).is_file()
+    assert (consumer / _CLAUDE_SKILL).read_text(encoding="utf-8") == claude_bytes
+
+    # No stale ledger/manifest row is left behind for the removed shared copy.
+    files = _deployed_files(consumer)
+    assert _CLAUDE_SKILL.as_posix() in files
+    assert _SHARED_SKILL.as_posix() not in files
+
+    # Prune is idempotent and leaves the reconciled state untouched.
+    pruned = _run(apm_binary_path, consumer, "prune")
+    assert pruned.returncode == 0, pruned.stderr
+    assert not (consumer / _SHARED_SKILL).exists()
+    assert (consumer / _CLAUDE_SKILL).is_file()
+
+    # The manifest-driven audit gate is clean -- no orphan blind spot remains.
+    audit = _run(apm_binary_path, consumer, "audit", "--ci", "--no-policy")
+    assert audit.returncode == 0, audit.stdout + audit.stderr
+
+
+@pytest.mark.integration
+def test_narrowing_preserves_a_user_edited_shared_root_skill(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """A user-edited shared-root skill survives the cleanup provenance gate."""
+    workspace = tmp_path / "workspace"
+    consumer = workspace / "consumer"
+    package = workspace / "lifecycle-package"
+    _write_consumer(consumer, ["claude", "cursor"])
+    _write_lifecycle_package(package)
+
+    initial = _run(
+        apm_binary_path,
+        consumer,
+        "install",
+        "--target",
+        "claude,cursor",
+        "--no-policy",
+    )
+    assert initial.returncode == 0, initial.stderr
+    shared = consumer / _SHARED_SKILL
+    original = shared.read_text(encoding="utf-8")
+    edited = original + "\n# User edit\n"
+    shared.write_text(edited, encoding="utf-8")
+
+    _write_consumer(consumer, ["claude"])
+    narrowed = _run(apm_binary_path, consumer, "install", "--target", "claude", "--no-policy")
+    assert narrowed.returncode == 0, narrowed.stderr
+
+    # The provenance gate refuses to delete user-modified bytes, and the row is
+    # retained so the surviving file stays covered by the audit gates.
+    assert (consumer / _CLAUDE_SKILL).is_file()
+    assert shared.read_text(encoding="utf-8") == edited
+    assert _SHARED_SKILL.as_posix() in _deployed_files(consumer)

--- a/tests/unit/install/phases/test_lockfile_union.py
+++ b/tests/unit/install/phases/test_lockfile_union.py
@@ -485,6 +485,205 @@ class TestCurrentInstallGovernance:
         assert files == [uri]
         assert hashes == {uri: original_hash}
 
+    def test_stale_owner_orphan_lingering_in_files_is_removed(self, tmp_path):
+        """A shared-root value that lost its ledger owner but lingers in the
+        current claim is a physical orphan and must be routed to cleanup.
+
+        This is the shared-root skill orphan: a prior Cursor-owned
+        ``.agents/skills/<s>/SKILL.md`` row is reconciled away on a narrow to
+        Claude, yet the file lingers in the current claim (a stale-cleanup
+        retention re-insertion). It must not survive as a rowless on-disk orphan.
+        """
+        from apm_cli.install.manifest_reconcile import reconcile_deployed_block
+        from apm_cli.utils.diagnostics import DiagnosticCollector
+
+        shared = ".agents/skills/scope/SKILL.md"
+        shared_path = tmp_path / shared
+        shared_path.parent.mkdir(parents=True)
+        shared_path.write_text("skill body", encoding="utf-8")
+        recorded = compute_file_hash(shared_path)
+        locator = DeploymentLocator(
+            kind=LocatorKind.PROJECT_RELATIVE,
+            target="cursor",
+            value=shared,
+            runtime=None,
+            scope="project",
+        )
+        ledger = DeploymentLedger(
+            records={
+                locator.key: DeploymentRecord(
+                    locator=locator,
+                    owners=("owner/pkg",),
+                    active_owner="owner/pkg",
+                    content_hash=recorded,
+                )
+            }
+        )
+
+        files, hashes = reconcile_deployed_block(
+            project_root=tmp_path,
+            dep_key="owner/pkg",
+            current_files=[shared],
+            current_hashes={shared: recorded},
+            prior_files=[shared],
+            prior_hashes={shared: recorded},
+            active_targets=[_known("claude")],
+            declared_targets=[_known("claude")],
+            diagnostics=DiagnosticCollector(),
+            prior_ledger=ledger,
+            cleanup_retained_hashes={shared: recorded},
+        )
+
+        assert shared not in files
+        assert shared not in hashes
+        assert not shared_path.exists()
+
+    def test_stale_orphan_preserved_when_another_active_target_still_owns(self, tmp_path):
+        """The shared-root value survives while a concrete active target claims it.
+
+        When Cursor stays active alongside Claude, the reconciled ledger keeps a
+        surviving record for the shared skill, so it must never be treated as an
+        orphan even though a prior row named Cursor as owner.
+        """
+        from apm_cli.install.manifest_reconcile import reconcile_deployed_block
+        from apm_cli.utils.diagnostics import DiagnosticCollector
+
+        shared = ".agents/skills/scope/SKILL.md"
+        shared_path = tmp_path / shared
+        shared_path.parent.mkdir(parents=True)
+        shared_path.write_text("skill body", encoding="utf-8")
+        recorded = compute_file_hash(shared_path)
+        locator = DeploymentLocator(
+            kind=LocatorKind.PROJECT_RELATIVE,
+            target="cursor",
+            value=shared,
+            runtime=None,
+            scope="project",
+        )
+        ledger = DeploymentLedger(
+            records={
+                locator.key: DeploymentRecord(
+                    locator=locator,
+                    owners=("owner/pkg",),
+                    active_owner="owner/pkg",
+                    content_hash=recorded,
+                )
+            }
+        )
+
+        files, _hashes = reconcile_deployed_block(
+            project_root=tmp_path,
+            dep_key="owner/pkg",
+            current_files=[shared],
+            current_hashes={shared: recorded},
+            prior_files=[shared],
+            prior_hashes={shared: recorded},
+            active_targets=[_known("claude"), _known("cursor")],
+            declared_targets=[_known("claude"), _known("cursor")],
+            diagnostics=DiagnosticCollector(),
+            prior_ledger=ledger,
+        )
+
+        assert shared in files
+        assert shared_path.exists()
+
+    def test_lingering_stale_orphan_preserves_user_edits(self, tmp_path):
+        """A user-modified lingering orphan is refused by the provenance gate.
+
+        The bytes differ from the recorded hash, so the cleanup chokepoint keeps
+        the file and its prior owner row is re-established -- no data loss, no
+        rowless orphan.
+        """
+        from apm_cli.install.manifest_reconcile import reconcile_deployed_block
+        from apm_cli.utils.diagnostics import DiagnosticCollector
+
+        shared = ".agents/skills/scope/SKILL.md"
+        shared_path = tmp_path / shared
+        shared_path.parent.mkdir(parents=True)
+        shared_path.write_text("user edit", encoding="utf-8")
+        recorded = "sha256:original"
+        locator = DeploymentLocator(
+            kind=LocatorKind.PROJECT_RELATIVE,
+            target="cursor",
+            value=shared,
+            runtime=None,
+            scope="project",
+        )
+        ledger = DeploymentLedger(
+            records={
+                locator.key: DeploymentRecord(
+                    locator=locator,
+                    owners=("owner/pkg",),
+                    active_owner="owner/pkg",
+                    content_hash=recorded,
+                )
+            }
+        )
+
+        files, hashes = reconcile_deployed_block(
+            project_root=tmp_path,
+            dep_key="owner/pkg",
+            current_files=[shared],
+            current_hashes={shared: recorded},
+            prior_files=[shared],
+            prior_hashes={shared: recorded},
+            active_targets=[_known("claude")],
+            declared_targets=[_known("claude")],
+            diagnostics=DiagnosticCollector(),
+            prior_ledger=ledger,
+            cleanup_retained_hashes={shared: recorded},
+        )
+
+        assert shared in files
+        assert hashes[shared] == recorded
+        assert shared_path.read_text(encoding="utf-8") == "user edit"
+
+    def test_lingering_stale_orphan_failed_cleanup_retains_row(self, tmp_path):
+        """A failed unlink fails closed: the lingering orphan keeps its row."""
+        from apm_cli.install.manifest_reconcile import reconcile_deployed_block
+        from apm_cli.utils.diagnostics import DiagnosticCollector
+
+        shared = ".agents/skills/scope/SKILL.md"
+        recorded = "sha256:original"
+        locator = DeploymentLocator(
+            kind=LocatorKind.PROJECT_RELATIVE,
+            target="cursor",
+            value=shared,
+            runtime=None,
+            scope="project",
+        )
+        ledger = DeploymentLedger(
+            records={
+                locator.key: DeploymentRecord(
+                    locator=locator,
+                    owners=("owner/pkg",),
+                    active_owner="owner/pkg",
+                    content_hash=recorded,
+                )
+            }
+        )
+
+        with patch(
+            "apm_cli.integration.cleanup.remove_stale_deployed_files",
+            return_value=CleanupResult(failed=[shared]),
+        ):
+            files, hashes = reconcile_deployed_block(
+                project_root=tmp_path,
+                dep_key="owner/pkg",
+                current_files=[shared],
+                current_hashes={shared: recorded},
+                prior_files=[shared],
+                prior_hashes={shared: recorded},
+                active_targets=[_known("claude")],
+                declared_targets=[_known("claude")],
+                diagnostics=DiagnosticCollector(),
+                prior_ledger=ledger,
+                cleanup_retained_hashes={shared: recorded},
+            )
+
+        assert shared in files
+        assert hashes[shared] == recorded
+
 
 class TestLocalDeployedFilesUnion:
     def test_copilot_app_install_preserves_prior_copilot_local_files(self):


### PR DESCRIPTION
## TL;DR

When a project's active targets widen then narrow (Claude → Claude+Cursor → Claude), the shared-root skill copy Cursor deployed to `.agents/skills/<name>/SKILL.md` was left on disk after its lockfile and deployment-ledger ownership row had been reconciled away — a physical orphan invisible to every manifest-driven `apm audit` gate. This routes that lost-ownership file through the existing `remove_stale_deployed_files` cleanup chokepoint, entirely inside the canonical `reconcile_deployed_block` contraction owner. User-edited copies and copies a surviving target still claims are preserved.

## Problem (WHY)

On a narrow install the reconciler correctly drops the `.agents/skills` ledger row (Cursor is no longer active or declared), yet the file survives on disk with **no** manifest row:

- The stale-cleanup phase validates retained files against the *active* target only; a shared root the active target cannot validate is retained and re-inserted into the current claim for a later retry.
- Back in `reconcile_deployed_block`, the value therefore still lingers in the reconciled `files` list, so the classic `dropped = prior_files - files` set **misses it** — it is never handed to the cleanup chokepoint.
- `apply_to_lockfile` then rebuilds `deployed_files` from the (correct) ledger, so the row vanishes while the file stays. The result is a rowless orphan, and `apm audit --ci` returns success because nothing in the manifest points at it.

This is the same defect shape the architecture guide names: a decision (physical removal) that must route through one owner but a sibling code path silently left the file behind. Anchor: ["the SAME decision was computed or enforced in more than one place, so a fix on one path silently missed a sibling path."](https://github.com/microsoft/apm/blob/main/.github/instructions/architecture.instructions.md)

## Approach (WHAT)

| Decision | Choice |
|---|---|
| Where to fix | Inside the existing `reconcile_deployed_block` chokepoint — the canonical target-scoped deployed-file contraction owner. No new authority. |
| How to detect the orphan | Ledger-authoritative: a value that **held** a prior ledger row, **lost** it, yet still lingers in `files`. Never acts on a ghost/no-row path. |
| How to delete | The same `remove_stale_deployed_files` three-gate chokepoint (validate / provenance / unlink). No path lists, no direct unlink, no `targets=None` broadening. |
| Safety | Exclude any value re-owned this run (`surviving`), so a shared root a concrete active target still claims — or a user-edited copy — is preserved. |

## Implementation (HOW)

**`src/apm_cli/install/manifest_reconcile.py`** — After `union_preserving`, compute `orphaned = (prior_files ∩ prior_owned) − surviving` from the prior and reconciled ledgers (comparing by `locator.value` only, never `.target`, so the `check_shared_target_contraction_owner.py` boundary guard stays green) and fold it into `dropped`. Because orphan candidates — unlike the classic dropped set — can still be present in `files`, a proven `cleanup.deleted` now also retracts the value from the returned `files`/`hashes` so the lockfile row and disk state agree. The existing user-edit / failed-unlink retention path is unchanged, so refusals still re-establish the prior owner row.

**`tests/integration/test_shared_root_skill_contraction_e2e.py`** (new) — Full Claude → Claude+Cursor → Claude lifecycle over a package with a real skill primitive, plus a user-edit-preserve twin.

**`tests/unit/install/phases/test_lockfile_union.py`** — Four hermetic `reconcile_deployed_block` twins: orphan removal, other-owner preserve, user-edit preserve, fail-closed on failed unlink.

**`CHANGELOG.md`** — One `Fixed` entry.

## Diagram

Legend: the reconcile chokepoint after this change; the boxed node is the NEW ledger-authoritative branch that feeds lost-ownership orphans into the same cleanup gate.

```mermaid
flowchart TD
    A["union_preserving: files + reconciled ledger"] --> B["dropped = prior_files minus files"]
    B --> C{"prior_ledger present?"}
    C -->|no| G{"dropped empty?"}
    C -->|yes| D["NEW: orphaned = prior_files and prior_owned, minus surviving"]
    D --> E["dropped = dropped or orphaned"]
    E --> G
    G -->|yes| H["return files, hashes"]
    G -->|no| I["remove_stale_deployed_files: validate / provenance / unlink"]
    I --> J["NEW: retract cleanup.deleted from files + hashes"]
    J --> K["re-add retained + owner row"]
    K --> H
    style D fill:#0d3b66,color:#ffffff
    style J fill:#0d3b66,color:#ffffff
```

## Trade-offs

- **Ledger-authoritative, not filesystem scan.** Detection is driven by prior-vs-reconciled ledger values, not an unbounded directory walk — it only ever considers files a prior install recorded. Rejected: a standalone audit filesystem scan, which would be a second ownership model.
- **Acts only on a row that existed and was removed.** A user-created file that never had a ledger row (e.g. the existing `test_widen_then_narrow_removes_dropped_cursor_instruction` fixture) is left untouched — "never trust a ghost/no-row path alone".
- **Fixes both call sites at once.** The change lives in the shared chokepoint, so both `_attach_deployed_files` and `reconcile_target_deployed_files` benefit; whichever runs first deletes, the second is idempotent.

## Benefits

1. No rowless physical orphan after a target narrows — disk and lockfile agree.
2. `apm audit --ci` no longer reports a clean bill of health while an orphan lingers.
3. Zero data loss: user-edited shared bytes are preserved and keep their owner row.
4. A shared root a surviving concrete target still claims is preserved.
5. Deletion stays inside the audited three-gate cleanup chokepoint — no new destructive path.

## Validation

Canonical lint chain, focused regressions, and the #2283/#2295 contract suites are green. `[source-identity]` in `test_hermetic_lifecycle_foundation.py` fails **identically on clean `main`** (verified by reverting this diff) and is unrelated to this change.

<details><summary>Lint + focused + contract suites</summary>

```
$ ruff check src/ tests/            -> All checks passed!
$ ruff format --check src/ tests/   -> 1546 files already formatted
$ pylint --enable=R0801 ...         -> 10.00/10
$ scripts/lint-auth-signals.sh      -> [+] auth-signal lint clean
$ scripts/lint-architecture-boundaries.sh -> [+] architecture boundary lint clean
$ scripts/check_shared_target_contraction_owner.py     -> exit 0
$ scripts/check_target_instruction_contraction_owner.py -> exit 0

$ pytest tests/integration/test_shared_root_skill_contraction_e2e.py -> 2 passed
$ pytest tests/unit/install/phases/test_lockfile_union.py            -> 32 passed
$ pytest test_target_instruction_contraction_e2e.py \
         test_hook_target_contraction_reconciliation.py \
         test_check_{target_instruction,shared_target}_contraction_owner.py \
         test_cleanup_phase.py test_lockfile_orphan_prune.py \
         test_lockfile_cross_package_reconcile.py            -> 58 passed
$ pytest tests/spec_conformance/test_lockfile_reqs.py + ledger/cleanup -> 448 passed
$ pytest tests/integration/test_architecture_authorities.py -> 80 passed
```
</details>

### Scenario Evidence

| User-promise scenario | Proven by | APM principle |
|---|---|---|
| Narrowing targets removes the dropped target's shared-root skill copy | `test_shared_root_skill_contraction_e2e.py::test_widen_then_narrow_removes_shared_root_skill_orphan` | Reproducible, deterministic deploy state |
| A user-edited shared-root skill is never deleted | `...::test_narrowing_preserves_a_user_edited_shared_root_skill` + `test_lingering_stale_orphan_preserves_user_edits` | Fail-safe, no data loss |
| A shared root a surviving target still claims is kept | `test_stale_orphan_preserved_when_another_active_target_still_owns` | Correct target attribution |
| A failed unlink fails closed | `test_lingering_stale_orphan_failed_cleanup_retains_row` | Refuse rather than proceed |

<details><summary>Mutation-break evidence</summary>

- Remove the orphan-detection block → e2e + `test_stale_owner_orphan_lingering_in_files_is_removed` RED.
- Remove the `− surviving` safety exclusion → `test_stale_orphan_preserved_when_another_active_target_still_owns` RED (would delete a still-owned file).
- Remove the `cleanup.deleted` retraction → `test_stale_owner_orphan_lingering_in_files_is_removed` RED (row/disk disagree).
- Restore → all four twins GREEN.
</details>

## How to test

- [ ] Build/point `APM_BINARY_PATH` at the CLI under test.
- [ ] `APM_E2E_TESTS=1 pytest tests/integration/test_shared_root_skill_contraction_e2e.py`
- [ ] `pytest tests/unit/install/phases/test_lockfile_union.py`
- [ ] Manually: install a skill package for `claude,cursor`, then re-install for `claude` only; confirm `.agents/skills/<name>/SKILL.md` is gone, `.claude/skills/<name>/SKILL.md` remains, and `apm audit --ci` passes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
