### PR TITLE
fix(audit): surface ref-consistency before deployment-ledger-owners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `apm audit --ci` now surfaces the safe remediation when a lockfile's source
+  identity is tampered. A rewritten dependency `host`/`repo_url` trips both the
+  external `ref-consistency` check (remedy `apm install --update`, which
+  re-resolves from the trusted manifest) and the internal
+  `deployment-ledger-owners` check (remedy `apm prune`, which would reconcile
+  ownership toward the tampered lockfile). Under the default fail-fast the
+  runner now reports `ref-consistency` first, so operators get the
+  manifest-driven fix instead of the attacker-entrenching one. Genuine
+  departed-owner detection is unchanged. (#2300)
 - Project-scope installs for Gemini, Codex, OpenCode, and experimental Hermes now prompt users to run `apm compile` when dependency instructions need root context compilation, instead of silently leaving those instructions unapplied -- by @sergio-sisternes-epam (closes #2057; supersedes #2115) (#2293).
 - Removing a dependency and running `apm prune` now fully cleans its deployment
   ownership records while preserving shared deployments and user-edited files.

--- a/docs/src/content/docs/enterprise/enforce-in-ci.md
+++ b/docs/src/content/docs/enterprise/enforce-in-ci.md
@@ -21,7 +21,7 @@ apm audit --ci
 ```
 
 One command. It runs the nine baseline lockfile checks
-(`lockfile-exists`, `deployment-ledger-owners`, `ref-consistency`,
+(`lockfile-exists`, `ref-consistency`, `deployment-ledger-owners`,
 `deployed-files-present`, `no-orphaned-packages`, `skill-subset-consistency`,
 `config-consistency`, `content-integrity`, `includes-consent`), the
 install-replay drift check, and -- if an `apm-policy.yml` is discovered --

--- a/docs/src/content/docs/reference/baseline-checks.md
+++ b/docs/src/content/docs/reference/baseline-checks.md
@@ -32,8 +32,8 @@ first failure to skip expensive I/O.
 |---|---|---|---|
 | `manifest-parse` | block | `ci_checks.py` | only when `apm.yml` cannot be parsed |
 | `lockfile-exists` | block | `ci_checks.py` | yes |
-| `deployment-ledger-owners` | block | `ci_checks.py` | yes |
 | `ref-consistency` | block | `ci_checks.py` | yes |
+| `deployment-ledger-owners` | block | `ci_checks.py` | yes |
 | `deployed-files-present` | block | `ci_checks.py` | yes |
 | `no-orphaned-packages` | block | `ci_checks.py` | yes |
 | `skill-subset-consistency` | block | `ci_checks.py` | yes |
@@ -65,6 +65,19 @@ the [policy schema](../policy-schema/).
 - **Effect.** Subsequent checks are skipped (the lockfile is required input).
 - **Remediation.** Run `apm install` to generate `apm.lock.yaml` and commit it.
 
+### `ref-consistency`
+
+- **What it verifies.** That every dependency's `reference` in `apm.yml` (both `dependencies.apm` and `devDependencies.apm`) matches the `resolved_ref` recorded in the lockfile.
+- **Fails when.** A manifest ref differs from the lockfile entry, or the manifest declares a dependency that is missing from the lockfile.
+- **Remediation.** Run `apm install` so the lockfile re-resolves to the manifest, then commit `apm.lock.yaml`.
+- **Runs before `deployment-ledger-owners`.** This external manifest-versus-lockfile
+  identity check is evaluated ahead of the internal ledger-owner check on purpose.
+  A source-identity tamper (a rewritten dependency `host`/`repo_url` in the lockfile)
+  trips both, but only `ref-consistency` points at the safe fix -- re-resolving from
+  the trusted manifest via `apm install --update`. The ledger-owner remedy (`apm prune`)
+  reconciles ownership toward the *current* lockfile, so it must never be the surfaced
+  cause when the manifest and lockfile disagree about a dependency's identity.
+
 ### `deployment-ledger-owners`
 
 - **What it verifies.** That every canonical `deployments` row's `owners` and
@@ -83,12 +96,6 @@ the [policy schema](../policy-schema/).
   the stale ownership metadata; it does not delete files based on a ghost
   row alone. See [`apm prune`](../cli/prune/#canonical-deployment-ownership)
   and [Lockfile spec](../lockfile-spec/#canonical-deployment-rows).
-
-### `ref-consistency`
-
-- **What it verifies.** That every dependency's `reference` in `apm.yml` (both `dependencies.apm` and `devDependencies.apm`) matches the `resolved_ref` recorded in the lockfile.
-- **Fails when.** A manifest ref differs from the lockfile entry, or the manifest declares a dependency that is missing from the lockfile.
-- **Remediation.** Run `apm install` so the lockfile re-resolves to the manifest, then commit `apm.lock.yaml`.
 
 ### `deployed-files-present`
 
@@ -142,7 +149,7 @@ the [policy schema](../policy-schema/).
 
 ## Run order and fail-fast
 
-The aggregate runner in `run_baseline_checks` evaluates checks in this order: `manifest-parse` (only when `apm.yml` is unparseable), `lockfile-exists`, `deployment-ledger-owners`, `ref-consistency`, `deployed-files-present`, `no-orphaned-packages`, `skill-subset-consistency`, `config-consistency`, `content-integrity`, `includes-consent`. Drift is invoked separately by the audit command after the baseline batch.
+The aggregate runner in `run_baseline_checks` evaluates checks in this order: `manifest-parse` (only when `apm.yml` is unparseable), `lockfile-exists`, `ref-consistency`, `deployment-ledger-owners`, `deployed-files-present`, `no-orphaned-packages`, `skill-subset-consistency`, `config-consistency`, `content-integrity`, `includes-consent`. Drift is invoked separately by the audit command after the baseline batch.
 
 With fail-fast on (the default), the runner stops at the first failing check. `apm audit --ci --no-fail-fast` evaluates every check so the report lists every problem at once.
 

--- a/docs/src/content/docs/reference/baseline-checks.md
+++ b/docs/src/content/docs/reference/baseline-checks.md
@@ -69,7 +69,11 @@ the [policy schema](../policy-schema/).
 
 - **What it verifies.** That every dependency's `reference` in `apm.yml` (both `dependencies.apm` and `devDependencies.apm`) matches the `resolved_ref` recorded in the lockfile.
 - **Fails when.** A manifest ref differs from the lockfile entry, or the manifest declares a dependency that is missing from the lockfile.
-- **Remediation.** Run `apm install` so the lockfile re-resolves to the manifest, then commit `apm.lock.yaml`.
+- **Remediation.** Run the command named in the check message -- `apm install`
+  for a first resolution, or `apm install --update` when the lockfile already
+  resolved the dependency and must be refreshed (the source-identity rewrite and
+  commit-pin mismatch cases) -- so the lockfile re-resolves to the manifest, then
+  commit `apm.lock.yaml`.
 - **Runs before `deployment-ledger-owners`.** This external manifest-versus-lockfile
   identity check is evaluated ahead of the internal ledger-owner check on purpose.
   A source-identity tamper (a rewritten dependency `host`/`repo_url` in the lockfile)

--- a/docs/src/content/docs/reference/baseline-checks.md
+++ b/docs/src/content/docs/reference/baseline-checks.md
@@ -69,11 +69,11 @@ the [policy schema](../policy-schema/).
 
 - **What it verifies.** That every dependency's `reference` in `apm.yml` (both `dependencies.apm` and `devDependencies.apm`) matches the `resolved_ref` recorded in the lockfile.
 - **Fails when.** A manifest ref differs from the lockfile entry, or the manifest declares a dependency that is missing from the lockfile.
-- **Remediation.** Run the command named in the check message -- `apm install`
-  for a first resolution, or `apm install --update` when the lockfile already
-  resolved the dependency and must be refreshed (the source-identity rewrite and
-  commit-pin mismatch cases) -- so the lockfile re-resolves to the manifest, then
-  commit `apm.lock.yaml`.
+- **Remediation.** Run the command the check message names: `apm install --update`
+  when the lockfile already holds a resolution that must be refreshed or re-keyed
+  (the source-identity rewrite and commit-pin mismatch cases), or plain `apm install`
+  for a first resolution -- so the lockfile re-resolves to the manifest, then commit
+  `apm.lock.yaml`.
 - **Runs before `deployment-ledger-owners`.** This external manifest-versus-lockfile
   identity check is evaluated ahead of the internal ledger-owner check on purpose.
   A source-identity tamper (a rewritten dependency `host`/`repo_url` in the lockfile)

--- a/packages/apm-guide/.apm/skills/apm-usage/governance.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/governance.md
@@ -353,8 +353,8 @@ Deny is evaluated first. Empty allow list permits all (except denied).
 These checks run without a policy file:
 
 - `lockfile-exists` -- apm.lock.yaml present
-- `deployment-ledger-owners` -- every canonical deployment owner and active owner resolves to a current dependency, `.`, or `local-bundle`
 - `ref-consistency` -- dependency refs match lockfile
+- `deployment-ledger-owners` -- every canonical deployment owner and active owner resolves to a current dependency, `.`, or `local-bundle`
 - `deployed-files-present` -- all deployed files exist
 - `no-orphaned-packages` -- no packages in lockfile absent from manifest
 - `skill-subset-consistency` -- selected skill subsets match the lockfile

--- a/src/apm_cli/policy/ci_checks.py
+++ b/src/apm_cli/policy/ci_checks.py
@@ -680,12 +680,24 @@ def run_baseline_checks(
         result.checks.append(check)
         return fail_fast and not check.passed
 
-    # Check 2: Canonical deployment owner references
-    if _run(_check_deployment_ledger_owners(lock)):
+    # Check 2: Ref consistency (external manifest <-> lockfile identity)
+    #
+    # External-boundary identity checks MUST surface before internal
+    # reconciliation checks (Check 3, deployment-ledger-owners) because the
+    # latter's remedy assumes the lockfile's identity claims are legitimate.
+    # A source-identity tamper (attacker rewrites a dependency's host/repo_url)
+    # trips both: ref-consistency ("not found in lockfile" -> re-resolve from the
+    # trusted manifest via 'apm install --update') and deployment-ledger-owners
+    # (stale owner -> 'apm prune'). Under fail-fast the first failing check wins,
+    # and 'apm prune' on a tampered lockfile would reconcile ownership toward the
+    # attacker source, so ref-consistency -- the safe, manifest-driven remedy --
+    # must be evaluated first. The ledger-owner check still owns the genuine
+    # departed-owner case (req-pl-016), where ref-consistency passes.
+    if _run(_check_ref_consistency(manifest, lock)):
         return result
 
-    # Check 3: Ref consistency
-    if _run(_check_ref_consistency(manifest, lock)):
+    # Check 3: Canonical deployment owner references
+    if _run(_check_deployment_ledger_owners(lock)):
         return result
 
     # Check 4: Deployed files present

--- a/tests/unit/policy/test_ci_checks.py
+++ b/tests/unit/policy/test_ci_checks.py
@@ -862,6 +862,109 @@ class TestRunBaselineChecks:
         assert len(result.failed_checks) >= 2
 
 
+class TestExternalBeforeInternalCheckOrdering:
+    """Ordering contract: the external manifest<->lockfile identity check
+    (``ref-consistency``) MUST surface before the internal ledger-owner
+    integrity check (``deployment-ledger-owners``).
+
+    Regression guard for the #2292 -> source-identity failure: a
+    source-identity lockfile tamper (attacker rewrites a dependency's
+    host/repo_url) trips BOTH checks, but their remedies diverge --
+    ref-consistency says ``apm install --update`` (re-resolve from the
+    trusted manifest, restoring the legitimate source) while
+    deployment-ledger-owners says ``apm prune`` (reconcile ownership
+    toward the CURRENT/tampered lockfile, which would entrench the
+    attacker). Under fail-fast the first failing check wins, so
+    ref-consistency must be evaluated first. This test locks that order
+    so a future check insertion cannot silently swap the reported cause
+    and its remediation again.
+    """
+
+    _LEGIT_KEY = "gitlab.example.invalid/group/fixture-source-identity"
+
+    def _write_source_identity_tamper(self, project: Path) -> None:
+        """Manifest declares the legitimate source; the lockfile has been
+        source-identity tampered (host/repo_url rewritten to an attacker
+        key) while the persisted deployment ledger still owns the
+        legitimate key -- so both checks fire."""
+        _write_apm_yml(project, deps=[self._LEGIT_KEY])
+        _write_lockfile(
+            project,
+            textwrap.dedent(f"""\
+                lockfile_version: '1'
+                generated_at: '2025-01-01T00:00:00Z'
+                dependencies:
+                  - repo_url: attacker/other
+                    host: attacker.invalid
+                    host_type: gitlab
+                    resolved_ref: '{"0" * 40}'
+                    resolved_commit: '{"0" * 40}'
+                    version: 0.1.0
+                    package_type: skill_bundle
+                deployments:
+                  - kind: project-relative
+                    target: copilot
+                    value: .github/instructions/fixture.instructions.md
+                    runtime: null
+                    scope: project
+                    owners:
+                      - {self._LEGIT_KEY}
+                    active_owner: {self._LEGIT_KEY}
+                    content_hash: sha256:{"a" * 64}
+            """),
+        )
+
+    def test_source_identity_tamper_surfaces_ref_consistency_under_fail_fast(self, tmp_path):
+        self._write_source_identity_tamper(tmp_path)
+        result = run_baseline_checks(tmp_path, fail_fast=True)
+        assert not result.passed
+        # Fail-fast must report the external-boundary cause with the safe
+        # ``apm install --update`` remedy, never the ledger-owner cause
+        # (whose ``apm prune`` remedy would entrench the attacker source).
+        assert len(result.failed_checks) == 1
+        assert result.failed_checks[0].name == "ref-consistency"
+        assert "apm install --update" in result.failed_checks[0].message
+
+    def test_ref_consistency_precedes_deployment_ledger_owners(self, tmp_path):
+        self._write_source_identity_tamper(tmp_path)
+        result = run_baseline_checks(tmp_path, fail_fast=False)
+        names = [check.name for check in result.checks]
+        assert "ref-consistency" in names
+        assert "deployment-ledger-owners" in names
+        assert names.index("ref-consistency") < names.index("deployment-ledger-owners")
+        # Both are genuine failures in this dual-cause tamper.
+        failed = {c.name for c in result.failed_checks}
+        assert {"ref-consistency", "deployment-ledger-owners"} <= failed
+
+    def test_genuine_ghost_owner_still_reported_after_reorder(self, tmp_path):
+        """Reordering must NOT weaken ghost-owner detection: when the
+        manifest declares no deps (ref-consistency passes) but a stale
+        ledger owner does not resolve, deployment-ledger-owners still
+        fires. This is req-pl-016's genuine departed-owner domain."""
+        _write_apm_yml(tmp_path)
+        _write_lockfile(
+            tmp_path,
+            textwrap.dedent(f"""\
+                lockfile_version: '1'
+                generated_at: '2025-01-01T00:00:00Z'
+                dependencies: []
+                deployments:
+                  - kind: project-relative
+                    target: claude
+                    value: .claude/rules/ghost.md
+                    runtime: null
+                    scope: project
+                    owners:
+                      - removed/beta
+                    active_owner: removed/beta
+                    content_hash: sha256:{"a" * 64}
+            """),
+        )
+        result = run_baseline_checks(tmp_path, fail_fast=True)
+        assert not result.passed
+        assert result.failed_checks[0].name == "deployment-ledger-owners"
+
+
 # -- Serialization -------------------------------------------------
 
 


### PR DESCRIPTION
## TL;DR

A source-identity lockfile tamper trips two baseline checks at once, but under the default fail-fast the runner surfaced the wrong one — `deployment-ledger-owners`, whose remedy (`apm prune`) reconciles ownership *toward the tampered lockfile* and entrenches the attacker source. This PR reorders `run_baseline_checks` so the external manifest↔lockfile identity check (`ref-consistency`, safe remedy `apm install --update`) is evaluated before the internal ledger-owner check. A new ordering contract test locks the cause + remediation so a future check insertion cannot silently swap them again.

## Problem (WHY)

The integration oracle `test_generated_artifact_tampering_reports_cause_and_recovers[source-identity]` fails deterministically on clean `main`: it expects failed-check set `{ref-consistency}` but gets `{deployment-ledger-owners}`.

- The `source-identity` tamper rewrites lockfile `dependencies[0].host` → `attacker.invalid` and `repo_url` → `attacker/other`, while the persisted `deployments:` ledger owners stay on the legitimate `gitlab.example.invalid/...` key. This is a genuine **dual-cause** tamper: the manifest dep is no longer found in the lockfile (`ref-consistency` fires) **and** the ledger owner no longer resolves (`deployment-ledger-owners` fires).
- PR #2292 inserted `deployment-ledger-owners` as Check 2 *ahead* of `ref-consistency` (Check 3) and did not update this test (the test file predates #2292, last touched by #2230).
- `apm audit --ci` defaults `fail_fast=True`, so only the first failing check surfaces — masking `ref-consistency`.
- The reported cause dictates the remediation, and the two remedies diverge in safety. Grounding the fix in behavior rather than the green checkmark follows PROSE: ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)

> [!WARNING]
> `deployment-ledger-owners` remediation is `apm prune`, which reconciles ownership toward the **current** (tampered) lockfile — laundering the attacker's rewritten source. `ref-consistency` remediation is `apm install --update`, which re-resolves from the **trusted manifest**. Surfacing the ledger-owner cause for a source-identity attack hands the operator a dangerous fix.

## Approach (WHAT)

| Decision | Choice |
|---|---|
| Which cause should surface first | `ref-consistency` — external manifest↔lockfile identity boundary |
| Why | Its remedy (`apm install --update`) is manifest-driven and safe; the ledger-owner remedy (`apm prune`) trusts the tampered lockfile |
| Genuine departed-owner case (req-pl-016) | Unaffected: empty/consistent deps → `ref-consistency` passes → `deployment-ledger-owners` still fires and is reported |
| Rejected: update the oracle to expect `{deployment-ledger-owners}` | Would bless the unsafe remediation as canonical |
| Rejected: report both (a `--full` mode) | Out of scope; fail-fast contract is the shipped default. Noted as possible follow-up |

## Implementation (HOW)

- **`src/apm_cli/policy/ci_checks.py`** — In `run_baseline_checks`, swapped Check 2 and Check 3 so `_check_ref_consistency` precedes `_check_deployment_ledger_owners`, with a multi-line comment documenting the external-boundary-before-internal-reconciliation rationale and the `apm prune` safety argument. No check IDs, messages, or aggregation semantics changed.
- **`tests/unit/policy/test_ci_checks.py`** — Added `TestExternalBeforeInternalCheckOrdering` (3 tests): fail-fast surfaces `ref-consistency` with the `apm install --update` remedy; `ref-consistency` index precedes `deployment-ledger-owners` and both are genuine failures under `--no-fail-fast`; a pure ghost-owner lockfile (empty deps) still reports `deployment-ledger-owners` after the reorder.
- **Docs** — `reference/baseline-checks.md`, `enterprise/enforce-in-ci.md`, and `packages/apm-guide/.apm/skills/apm-usage/governance.md` updated to the new run order, with a note on why `ref-consistency` runs first.

## Diagram

Legend: the check pipeline before and after the reorder, for a source-identity tamper under fail-fast (red = surfaced cause + its remediation).

```mermaid
flowchart LR
    subgraph before["Before (#2292 order)"]
        B1["lockfile-exists"] --> B2["deployment-ledger-owners"]
        B2 -->|"FAIL: apm prune (entrenches attacker)"| BStop["fail-fast stops"]
        B2 -.->|masked| B3["ref-consistency"]
    end
    subgraph after["After (this PR)"]
        A1["lockfile-exists"] --> A2["ref-consistency"]
        A2 -->|"FAIL: apm install --update (safe)"| AStop["fail-fast stops"]
        A2 -.->|not reached under fail-fast| A3["deployment-ledger-owners"]
    end
    class B2 bad
    class A2 good
    classDef bad fill:#ffd6d6,stroke:#c00
    classDef good fill:#d6f5d6,stroke:#0a0
```

## Trade-offs

- **Fail-fast still reports a single cause.** For the dual-cause tamper only `ref-consistency` surfaces; the operator re-runs after `apm install --update` and any residual ledger issue then surfaces. `--no-fail-fast` already reports both. A dedicated "report every root cause at once" mode is a possible follow-up, not shipped here.
- **Reorder is behavior-visible** to anyone asserting exact check order; the new contract test plus updated docs make the order an intentional, tested contract rather than an accident of insertion.

## Benefits

1. Source-identity tampering now yields the **safe** remediation (`apm install --update`) instead of the attacker-entrenching `apm prune`.
2. The failing merge-group integration node passes without weakening req-pl-016 ghost-owner detection.
3. A mutation-breaking ordering contract test prevents silent regression when future checks are inserted.
4. Check-order documentation matches code across three surfaces (reference, enterprise, guide skill).

## Validation

Canonical lint chain, contract tests, the full integration oracle, and the fail-fast regression all green on head `24f93da71c`.

<details><summary>Lint chain + focused tests</summary>

```
$ uv run --extra dev ruff check src/ tests/
All checks passed!
$ uv run --extra dev ruff format --check src/ tests/
1545 files already formatted
$ uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/
Your code has been rated at 10.00/10
$ bash scripts/lint-auth-signals.sh
[+] auth-signal lint clean

$ uv run --extra dev pytest tests/integration/test_hermetic_lifecycle_foundation.py::test_generated_artifact_tampering_reports_cause_and_recovers \
    tests/unit/policy/test_ci_checks.py::TestExternalBeforeInternalCheckOrdering \
    tests/unit/policy/test_ci_checks.py::TestRunBaselineChecks::test_fail_fast_stops_after_first_failure
9 passed
```
</details>

### Scenario evidence

| User-promise scenario | Test that proves it | APM principle |
|---|---|---|
| Source-identity tamper reports the safe manifest-driven fix | `TestExternalBeforeInternalCheckOrdering::test_source_identity_tamper_surfaces_ref_consistency_under_fail_fast` | Trustworthy governance: the reported cause must not hand the operator an unsafe remedy |
| Genuine departed-owner (ghost) still hard-fails | `test_genuine_ghost_owner_still_reported_after_reorder` + `tests/spec_conformance/test_policy_reqs.py::test_deployment_ledger_owner_is_hard_integrity_failure` | req-pl-016 ledger-owner integrity preserved |
| Tampered artifact reports cause and recovers | `test_generated_artifact_tampering_reports_cause_and_recovers[source-identity]` | Audit detects tampering and a documented remedy restores a clean audit |

## How to test

- [ ] `uv run --extra dev pytest "tests/integration/test_hermetic_lifecycle_foundation.py::test_generated_artifact_tampering_reports_cause_and_recovers[source-identity]"` — passes.
- [ ] `uv run --extra dev pytest tests/unit/policy/test_ci_checks.py::TestExternalBeforeInternalCheckOrdering` — 3 pass.
- [ ] `git revert --no-commit HEAD -- src/apm_cli/policy/ci_checks.py` (mutation check): the two ordering tests go RED, confirming they trap the regression.
- [ ] `uv run --extra dev pytest tests/spec_conformance/test_policy_reqs.py::test_deployment_ledger_owner_is_hard_integrity_failure` — still passes (req-pl-016 intact).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>