### PR TITLE
fix(install): carry forward mcp_target_servers to stop generated_at churn

### DIFF
--- a/src/apm_cli/install/phases/lockfile.py
+++ b/src/apm_cli/install/phases/lockfile.py
@@ -427,6 +427,20 @@ class LockfileBuilder:
             lockfile.mcp_config_provenance = copy.deepcopy(
                 self.ctx.existing_lockfile.mcp_config_provenance
             )
+            # Also carry forward mcp_target_servers (and its ledger rows) via
+            # the same codec path MCPIntegrator itself uses. Without this, the
+            # freshly-built lockfile always starts with mcp_target_servers={},
+            # which reads as a real change against the on-disk file and forces
+            # an extra write here -- MCPIntegrator then has to correct it
+            # with a second write of its own, churning generated_at twice per
+            # install even when nothing changed (issue #2297).
+            if self.ctx.existing_lockfile.mcp_target_servers:
+                from apm_cli.core.deployment_ledger import DeploymentLedgerCodec
+
+                DeploymentLedgerCodec.replace_mcp_target_servers(
+                    lockfile,
+                    copy.deepcopy(self.ctx.existing_lockfile.mcp_target_servers),
+                )
             if self.ctx.logger:
                 self.ctx.logger.verbose_detail(
                     "MCP state unchanged -- carrying forward "

--- a/tests/unit/install/test_mcp_lockfile_determinism.py
+++ b/tests/unit/install/test_mcp_lockfile_determinism.py
@@ -109,6 +109,8 @@ def _run_lockfile_phase_and_mcp_persist(
     project_root: Path,
     package: APMPackage,
     instant: datetime,
+    *,
+    mcp_target_servers: dict[str, list[str]] | None = None,
 ) -> None:
     lock_path = get_lockfile_path(project_root)
     dep_ref = package.get_apm_dependencies()[0]
@@ -138,6 +140,7 @@ def _run_lockfile_phase_and_mcp_persist(
             MCPIntegrator.get_server_names(mcp_deps),
             lock_path,
             mcp_configs=MCPIntegrator.get_server_configs(mcp_deps),
+            mcp_target_servers=mcp_target_servers,
         )
 
 
@@ -262,6 +265,35 @@ def test_unchanged_mcp_dependencies_do_not_rewrite_lockfile(tmp_path: Path) -> N
     assert second_lock is not None
 
     assert second_lock.generated_at == first_lock.generated_at
+    assert second_bytes == first_bytes
+
+
+def test_unchanged_mcp_target_servers_do_not_rewrite_lockfile(tmp_path: Path) -> None:
+    """Regression for #2297: a populated mcp_target_servers must not churn generated_at."""
+    package = _write_manifest_with_mcp(tmp_path)
+    first_instant = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    second_instant = datetime(2026, 1, 1, 0, 1, 0, tzinfo=timezone.utc)
+    target_servers = {"claude": ["atlassian"]}
+
+    _run_lockfile_phase_and_mcp_persist(
+        tmp_path, package, first_instant, mcp_target_servers=target_servers
+    )
+    lock_path = get_lockfile_path(tmp_path)
+    first_bytes = lock_path.read_bytes()
+    first_lock = LockFile.read(lock_path)
+    assert first_lock is not None
+    assert first_lock.generated_at == first_instant.isoformat()
+    assert first_lock.mcp_target_servers == target_servers
+
+    _run_lockfile_phase_and_mcp_persist(
+        tmp_path, package, second_instant, mcp_target_servers=target_servers
+    )
+    second_bytes = lock_path.read_bytes()
+    second_lock = LockFile.read(lock_path)
+    assert second_lock is not None
+
+    assert second_lock.generated_at == first_lock.generated_at
+    assert second_lock.mcp_target_servers == target_servers
     assert second_bytes == first_bytes
 
 


### PR DESCRIPTION
## Description

`apm install` rewrote `apm.lock.yaml` (diff only in `generated_at`) on every run, even when nothing changed, whenever the project had an MCP server deployed to a target.

Root cause: `LockfileBuilder._preserve_existing_mcp_state` (`src/apm_cli/install/phases/lockfile.py`) carried `mcp_servers`, `mcp_configs`, and `mcp_config_provenance` forward from the on-disk lockfile, but not `mcp_target_servers`. The freshly-built lockfile therefore always started from `mcp_target_servers={}`, which looked like a real change against the on-disk file and forced a write in `_write_if_changed`. `MCPIntegrator.update_lockfile` then ran right after, re-detected the correct `mcp_target_servers`, and had to correct it with a *second* write. Both writes stamp a fresh `generated_at`, so every install produced a diff-only-in-timestamp change even though the final content was correct.

Fix: carry `mcp_target_servers` forward too, through the same `DeploymentLedgerCodec.replace_mcp_target_servers` path `MCPIntegrator` already uses, so the first write starts from consistent state and both writes become true no-ops when nothing changed.

Confirmed via a hermetic end-to-end repro (local-path deps + several GitLab-shorthand virtual/subpath deps + one self-defined `registry: false` HTTP MCP server, matching the shape reported in #2297): before the fix, a second back-to-back `apm install` rewrote the lockfile twice and changed `generated_at`; after the fix, zero writes occur on the no-op reinstall.

Fixes #2297

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

Details:
- Added `test_unchanged_mcp_target_servers_do_not_rewrite_lockfile` to `tests/unit/install/test_mcp_lockfile_determinism.py`, which fails on `main` and passes with this fix.
- `tests/unit/install/`, `tests/unit/deps/`, `tests/test_lockfile.py`, `tests/unit/core/` — 4404 passed, 4 pre-existing failures unrelated to this change (reproduced identically on `main` without this patch; multi-harness-detection/registry-import tests, not lockfile-related).
- `tests/integration/test_global_mcp_lockfile_e2e.py`, `tests/unit/integration/test_mcp_config_view.py`, `tests/unit/deps/test_lockfile_deployment_paths.py`, `tests/unit/deps/test_lockfile_consumer_contract.py`, `tests/unit/deps/test_lockfile_git_semver.py` — 40 passed.
- `ruff check` on changed files — clean.

## Spec conformance (OpenAPM v0.1)

This PR does not add or change a normative requirement -- it fixes a **Mode A silent regression** against an existing one. [req-lk-005](https://github.com/microsoft/apm/blob/main/docs/src/content/docs/specs/openapm-v0.1.md#L1042) already states: *"A no-op install operation MUST NOT rewrite a lockfile whose only changed fields would be [`generated_at`, `apm_version`]."* Per CONTRIBUTING.md's Mode A guidance ("a code change in `src/apm_cli/**` breaks an assertion bound to a `req-XXX`... fix the code, do not touch the spec"), no spec/manifest edit is needed here.

Note: the existing `@pytest.mark.req("req-lk-005")` test in `tests/spec_conformance/test_lockfile_reqs.py` only checks schema shape and the canonical-ordering clause of req-lk-005 -- it does not exercise the no-op-rewrite behavioral clause end-to-end, which is how this regression shipped in 0.25.0 without being caught. Happy to follow up with a behavioral `req-lk-005` spec-conformance test (mirroring the new unit test) in a separate PR if maintainers want that gap closed -- flagging it here rather than bundling it into this bug-fix PR.

- [ ] Spec edit: `docs/src/content/docs/specs/openapm-v0.1.md` updated (new/changed `<a id="req-XXX"></a>` anchor + prose + Appendix C row).
- [ ] Manifest edit: `docs/src/content/docs/specs/manifests/openapm-v0.1.requirements.yml` updated.
- [ ] Test edit: a `@pytest.mark.req("req-XXX")` test under `tests/spec_conformance/` added or extended.
- [ ] `CONFORMANCE.{md,json}` regenerated via `uv run --extra dev python -m tests.spec_conformance.gen_statement` and committed.
- [x] N/A -- this PR does not change OpenAPM-observable behaviour (it restores conformance with existing req-lk-005; no new requirement, no spec text change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
