### PR TITLE
fix(integration): make MCP target resolution honor declared apm.yml targets

### DIFF
--- a/src/apm_cli/integration/mcp_integrator_install.py
+++ b/src/apm_cli/integration/mcp_integrator_install.py
@@ -388,20 +388,6 @@ def _resolve_target_runtimes(
     """
     from apm_cli.integration.mcp_integrator import MCPIntegrator
 
-    project_root_path = Path(project_root) if project_root is not None else Path.cwd()
-
-    if apm_config is None:
-        try:
-            apm_yml = project_root_path / "apm.yml"
-            if apm_yml.exists():
-                from apm_cli.utils.yaml_io import load_yaml
-
-                apm_config = load_yaml(apm_yml)
-        except Exception:
-            apm_config = None
-
-    declared_targets = _declared_manifest_target_runtimes(apm_config)
-
     if runtime:
         # Single runtime mode - skip auto-discovery entirely.
         logger.progress(f"Targeting specific runtime: {runtime}")
@@ -415,85 +401,113 @@ def _resolve_target_runtimes(
         )
         runtime_label = "runtime" if len(target_runtimes) == 1 else "runtimes"
         logger.progress(f"Targeting specific {runtime_label}: {', '.join(target_runtimes)}")
-    elif declared_targets is not None:
-        # apm.yml declares `targets:` explicitly -- that is the deterministic,
-        # committed source of truth for MCP ownership too. Using it instead of
-        # local-machine runtime auto-discovery keeps `mcp_target_servers` (and
-        # the deployment ledger `runtime` field) byte-identical across
-        # developers with different harnesses installed, instead of each
-        # `apm install` "stealing" MCP ownership toward whatever the current
-        # machine happens to have (issue #2298).
-        target_runtimes = declared_targets
-        runtime_label = "runtime" if len(target_runtimes) == 1 else "runtimes"
-        logger.progress(
-            f"Targeting declared {runtime_label} from apm.yml: {', '.join(target_runtimes)}"
-        )
     else:
-        # Step 1: Get all installed runtimes on the system
-        installed_runtimes = _discover_installed_runtimes(project_root_path, user_scope=user_scope)
+        # Manifest loading/parsing (and the user-facing warnings
+        # parse_targets_field can emit, e.g. legacy `targets: [all]`) is
+        # deferred to this branch -- irrelevant, and wasted filesystem I/O,
+        # whenever the caller already pinned a runtime/target explicitly.
+        project_root_path = Path(project_root) if project_root is not None else Path.cwd()
 
-        # Step 2: Get runtimes referenced in apm.yml scripts
-        script_runtimes = MCPIntegrator._detect_runtimes(
-            apm_config.get("scripts", {}) if apm_config else {}
-        )
+        if apm_config is None:
+            try:
+                apm_yml = project_root_path / "apm.yml"
+                if apm_yml.exists():
+                    from apm_cli.utils.yaml_io import load_yaml
 
-        # Step 3: Target runtimes BOTH installed AND referenced in scripts
-        if script_runtimes:
-            target_runtimes = [rt for rt in installed_runtimes if rt in script_runtimes]
+                    apm_config = load_yaml(apm_yml)
+            except Exception:
+                apm_config = None
 
-            if verbose:
-                if console:
-                    console.print(f"|  [cyan]{STATUS_SYMBOLS['info']}  Runtime Detection[/cyan]")
-                    console.print(f"|     +- Installed: {', '.join(installed_runtimes)}")
-                    console.print(f"|     +- Used in scripts: {', '.join(script_runtimes)}")
-                    if target_runtimes:
-                        console.print(
-                            f"|     +- Target: {', '.join(target_runtimes)} "
-                            f"(available + used in scripts)"
-                        )
-                    console.print("|")
-                else:
-                    logger.verbose_detail(f"Installed runtimes: {', '.join(installed_runtimes)}")
-                    logger.verbose_detail(f"Script runtimes: {', '.join(script_runtimes)}")
-                    if target_runtimes:
-                        logger.verbose_detail(f"Target runtimes: {', '.join(target_runtimes)}")
-
-            if not target_runtimes:
-                logger.warning("Scripts reference runtimes that are not installed")
-                logger.progress("Install missing runtimes with: apm runtime setup <runtime>")
-        else:
-            target_runtimes = installed_runtimes
-            if target_runtimes:
-                if verbose:
-                    logger.verbose_detail(
-                        f"No scripts detected, using all installed runtimes: "
-                        f"{', '.join(target_runtimes)}"
-                    )
-            else:
-                logger.warning("No MCP-compatible runtimes installed")
-                logger.progress("Install a runtime with: apm runtime setup copilot")
-
-        # Surface auto-detected runtimes in non-verbose plain-logger mode so
-        # users get a signal about what `apm install --mcp` is targeting --
-        # notably the machine-scoped JetBrains (intellij) runtime, which is
-        # detected globally once the plugin is installed anywhere on the host.
-        if target_runtimes and not verbose and console is None:
-            logger.progress(f"Detected runtimes: {', '.join(target_runtimes)}")
-
-        # Apply exclusions
-        if exclude:
-            target_runtimes = [r for r in target_runtimes if r != exclude]
-        # All runtimes excluded  -- nothing to configure
-        if not target_runtimes and installed_runtimes:
-            logger.warning(
-                f"All installed runtimes excluded (--exclude {exclude}), skipping MCP configuration"
+        declared_targets = _declared_manifest_target_runtimes(apm_config)
+        if declared_targets is not None:
+            # apm.yml declares `targets:` explicitly -- that is the deterministic,
+            # committed source of truth for MCP ownership too. Using it instead of
+            # local-machine runtime auto-discovery keeps `mcp_target_servers` (and
+            # the deployment ledger `runtime` field) byte-identical across
+            # developers with different harnesses installed, instead of each
+            # `apm install` "stealing" MCP ownership toward whatever the current
+            # machine happens to have (issue #2298).
+            target_runtimes = declared_targets
+            runtime_label = "runtime" if len(target_runtimes) == 1 else "runtimes"
+            logger.progress(
+                f"Targeting declared {runtime_label} from apm.yml: {', '.join(target_runtimes)}"
             )
-            return None
+            if exclude:
+                target_runtimes = [r for r in target_runtimes if r != exclude]
+                if not target_runtimes:
+                    logger.warning(
+                        f"All declared targets excluded (--exclude {exclude}), "
+                        "skipping MCP configuration"
+                    )
+                    return None
+        else:
+            # Step 1: Get all installed runtimes on the system
+            installed_runtimes = _discover_installed_runtimes(
+                project_root_path, user_scope=user_scope
+            )
 
-        # Fall back to VS Code only if no runtimes are installed at all
-        if not target_runtimes and not installed_runtimes:
-            target_runtimes = ["vscode"]
-            logger.progress("No runtimes installed, using VS Code as fallback")
+            # Step 2: Get runtimes referenced in apm.yml scripts
+            script_runtimes = MCPIntegrator._detect_runtimes(
+                apm_config.get("scripts", {}) if apm_config else {}
+            )
+
+            # Step 3: Target runtimes BOTH installed AND referenced in scripts
+            if script_runtimes:
+                target_runtimes = [rt for rt in installed_runtimes if rt in script_runtimes]
+
+                if verbose:
+                    if console:
+                        console.print(f"|  [cyan]{STATUS_SYMBOLS['info']}  Runtime Detection[/cyan]")
+                        console.print(f"|     +- Installed: {', '.join(installed_runtimes)}")
+                        console.print(f"|     +- Used in scripts: {', '.join(script_runtimes)}")
+                        if target_runtimes:
+                            console.print(
+                                f"|     +- Target: {', '.join(target_runtimes)} "
+                                f"(available + used in scripts)"
+                            )
+                        console.print("|")
+                    else:
+                        logger.verbose_detail(f"Installed runtimes: {', '.join(installed_runtimes)}")
+                        logger.verbose_detail(f"Script runtimes: {', '.join(script_runtimes)}")
+                        if target_runtimes:
+                            logger.verbose_detail(f"Target runtimes: {', '.join(target_runtimes)}")
+
+                if not target_runtimes:
+                    logger.warning("Scripts reference runtimes that are not installed")
+                    logger.progress("Install missing runtimes with: apm runtime setup <runtime>")
+            else:
+                target_runtimes = installed_runtimes
+                if target_runtimes:
+                    if verbose:
+                        logger.verbose_detail(
+                            f"No scripts detected, using all installed runtimes: "
+                            f"{', '.join(target_runtimes)}"
+                        )
+                else:
+                    logger.warning("No MCP-compatible runtimes installed")
+                    logger.progress("Install a runtime with: apm runtime setup copilot")
+
+            # Surface auto-detected runtimes in non-verbose plain-logger mode so
+            # users get a signal about what `apm install --mcp` is targeting --
+            # notably the machine-scoped JetBrains (intellij) runtime, which is
+            # detected globally once the plugin is installed anywhere on the host.
+            if target_runtimes and not verbose and console is None:
+                logger.progress(f"Detected runtimes: {', '.join(target_runtimes)}")
+
+            # Apply exclusions
+            if exclude:
+                target_runtimes = [r for r in target_runtimes if r != exclude]
+            # All runtimes excluded  -- nothing to configure
+            if not target_runtimes and installed_runtimes:
+                logger.warning(
+                    f"All installed runtimes excluded (--exclude {exclude}), skipping MCP configuration"
+                )
+                return None
+
+            # Fall back to VS Code only if no runtimes are installed at all
+            if not target_runtimes and not installed_runtimes:
+                target_runtimes = ["vscode"]
+                logger.progress("No runtimes installed, using VS Code as fallback")
 
     # Codex MCP is project-scoped: only configure it when Codex is an
     # active project target (silent skip, same as Cursor/OpenCode/Gemini).

--- a/src/apm_cli/integration/mcp_integrator_install.py
+++ b/src/apm_cli/integration/mcp_integrator_install.py
@@ -335,6 +335,39 @@ def _discover_installed_runtimes_fallback(
     return installed_runtimes
 
 
+def _declared_manifest_target_runtimes(apm_config: dict | None) -> list[str] | None:
+    """Return apm.yml's declared ``targets:`` as canonical runtime names.
+
+    Delegates to :func:`apm_cli.core.apm_yml.parse_targets_field`, the same
+    parser the v2 file-deployment target resolver and
+    :meth:`MCPIntegrator._gate_project_scoped_runtimes` both use, so a
+    manifest-declared target list is interpreted identically everywhere
+    (including folding the legacy ``all`` value back to auto-detect).
+
+    Returns ``None`` when the manifest does not restrict targets (no
+    ``targets:``/``target:`` key, or legacy ``all``) so the caller falls
+    back to local-machine runtime auto-discovery. Malformed declarations
+    (conflicting keys, empty list, unknown name) also return ``None`` here;
+    auto-discovery proceeds and ``_gate_project_scoped_runtimes`` -- which
+    re-parses the same field -- is left as the single place that renders
+    the fail-closed error to the user.
+    """
+    if not apm_config:
+        return None
+    from apm_cli.core.apm_yml import (
+        ConflictingTargetsError,
+        EmptyTargetsListError,
+        UnknownTargetError,
+        parse_targets_field,
+    )
+
+    try:
+        parsed = parse_targets_field(apm_config)
+    except (ConflictingTargetsError, EmptyTargetsListError, UnknownTargetError):
+        return None
+    return parsed or None
+
+
 def _resolve_target_runtimes(
     runtime: str | None,
     exclude: str | None,
@@ -355,6 +388,20 @@ def _resolve_target_runtimes(
     """
     from apm_cli.integration.mcp_integrator import MCPIntegrator
 
+    project_root_path = Path(project_root) if project_root is not None else Path.cwd()
+
+    if apm_config is None:
+        try:
+            apm_yml = project_root_path / "apm.yml"
+            if apm_yml.exists():
+                from apm_cli.utils.yaml_io import load_yaml
+
+                apm_config = load_yaml(apm_yml)
+        except Exception:
+            apm_config = None
+
+    declared_targets = _declared_manifest_target_runtimes(apm_config)
+
     if runtime:
         # Single runtime mode - skip auto-discovery entirely.
         logger.progress(f"Targeting specific runtime: {runtime}")
@@ -368,19 +415,20 @@ def _resolve_target_runtimes(
         )
         runtime_label = "runtime" if len(target_runtimes) == 1 else "runtimes"
         logger.progress(f"Targeting specific {runtime_label}: {', '.join(target_runtimes)}")
+    elif declared_targets is not None:
+        # apm.yml declares `targets:` explicitly -- that is the deterministic,
+        # committed source of truth for MCP ownership too. Using it instead of
+        # local-machine runtime auto-discovery keeps `mcp_target_servers` (and
+        # the deployment ledger `runtime` field) byte-identical across
+        # developers with different harnesses installed, instead of each
+        # `apm install` "stealing" MCP ownership toward whatever the current
+        # machine happens to have (issue #2298).
+        target_runtimes = declared_targets
+        runtime_label = "runtime" if len(target_runtimes) == 1 else "runtimes"
+        logger.progress(
+            f"Targeting declared {runtime_label} from apm.yml: {', '.join(target_runtimes)}"
+        )
     else:
-        project_root_path = Path(project_root) if project_root is not None else Path.cwd()
-
-        if apm_config is None:
-            try:
-                apm_yml = project_root_path / "apm.yml"
-                if apm_yml.exists():
-                    from apm_cli.utils.yaml_io import load_yaml
-
-                    apm_config = load_yaml(apm_yml)
-            except Exception:
-                apm_config = None
-
         # Step 1: Get all installed runtimes on the system
         installed_runtimes = _discover_installed_runtimes(project_root_path, user_scope=user_scope)
 

--- a/tests/unit/integration/test_mcp_integrator.py
+++ b/tests/unit/integration/test_mcp_integrator.py
@@ -755,12 +755,53 @@ class TestInstallProjectRootDetection:
     def test_install_uses_explicit_project_root_for_workspace_runtime_detection(
         self, _which, mock_mgr_cls, mock_install_rt, mock_ops_cls, tmp_path
     ):
+        # A single, unambiguous directory signal in `nested` (none in
+        # `tmp_path`/cwd) isolates what this test asserts: auto-detection
+        # (and the active-targets gate it feeds) probes the explicit
+        # `project_root`, not `Path.cwd()`. apm.yml declares no `targets:`
+        # here -- a manifest-declared value now resolves MCP ownership
+        # deterministically from the declaration itself (issue #2298) and
+        # would bypass the auto-detection this test exercises; see
+        # `test_declared_targets_override_local_runtime_detection` below for
+        # that path.
         nested = tmp_path / "nested-project"
         (nested / ".cursor").mkdir(parents=True)
-        (nested / ".opencode").mkdir()
-        (nested / ".vscode").mkdir()
-        # Copilot's project profile detects on `.github/` (targets.py:330);
-        # without it the active-targets gate would drop vscode here.
+
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.is_runtime_available.return_value = False
+        mock_install_rt.return_value = True
+
+        mock_ops = mock_ops_cls.return_value
+        mock_ops.validate_servers_exist.return_value = (["test/server"], [])
+        mock_ops.check_servers_needing_installation.return_value = ["test/server"]
+        mock_ops.batch_fetch_server_info.return_value = {"test/server": {}}
+        mock_ops.collect_environment_variables.return_value = {}
+        mock_ops.collect_runtime_variables.return_value = {}
+
+        with patch("apm_cli.integration.mcp_integrator.Path.cwd", return_value=tmp_path):
+            MCPIntegrator.install(
+                mcp_deps=["test/server"],
+                project_root=nested,
+            )
+
+        called_runtimes = {call.args[0] for call in mock_install_rt.call_args_list}
+        assert called_runtimes == {"cursor"}
+
+    @patch("apm_cli.registry.operations.MCPServerOperations")
+    @patch("apm_cli.integration.mcp_integrator.MCPIntegrator._install_for_runtime")
+    @patch("apm_cli.runtime.manager.RuntimeManager")
+    @patch("apm_cli.integration.mcp_integrator.shutil.which", return_value=None)
+    def test_declared_targets_override_local_runtime_detection(
+        self, _which, mock_mgr_cls, mock_install_rt, mock_ops_cls, tmp_path
+    ):
+        """Regression for #2298: declared `targets:` must not gain undeclared runtimes.
+
+        `.vscode/` exists on disk (as it would on one developer's machine
+        but not another's) but is NOT declared, so it must not be
+        targeted even though it would otherwise be auto-detected.
+        """
+        nested = tmp_path / "nested-project"
+        (nested / ".vscode").mkdir(parents=True)
         (nested / ".github").mkdir()
 
         mock_mgr = mock_mgr_cls.return_value
@@ -778,19 +819,12 @@ class TestInstallProjectRootDetection:
             MCPIntegrator.install(
                 mcp_deps=["test/server"],
                 project_root=nested,
-                # Declare every target the multi-signal nested project
-                # supports. Without this, the strict resolver raises
-                # AmbiguousHarnessError on >=2 signals (cursor, opencode,
-                # copilot from .github/) and the gate fails closed -- which
-                # is correct UX in production but obscures what THIS test
-                # is asserting (workspace project_root resolution).
                 apm_config={"targets": ["copilot", "cursor", "opencode"]},
             )
 
         called_runtimes = {call.args[0] for call in mock_install_rt.call_args_list}
-        assert "vscode" in called_runtimes
-        assert "cursor" in called_runtimes
-        assert "opencode" in called_runtimes
+        assert called_runtimes == {"copilot", "cursor", "opencode"}
+        assert "vscode" not in called_runtimes
 
 
 # ===========================================================================

--- a/tests/unit/integration/test_mcp_integrator.py
+++ b/tests/unit/integration/test_mcp_integrator.py
@@ -826,6 +826,39 @@ class TestInstallProjectRootDetection:
         assert called_runtimes == {"copilot", "cursor", "opencode"}
         assert "vscode" not in called_runtimes
 
+    @patch("apm_cli.registry.operations.MCPServerOperations")
+    @patch("apm_cli.integration.mcp_integrator.MCPIntegrator._install_for_runtime")
+    @patch("apm_cli.runtime.manager.RuntimeManager")
+    @patch("apm_cli.integration.mcp_integrator.shutil.which", return_value=None)
+    def test_exclude_applies_to_declared_targets(
+        self, _which, mock_mgr_cls, mock_install_rt, mock_ops_cls, tmp_path
+    ):
+        """Regression: --exclude must still drop a runtime from a declared `targets:` list."""
+        nested = tmp_path / "nested-project"
+        nested.mkdir()
+
+        mock_mgr = mock_mgr_cls.return_value
+        mock_mgr.is_runtime_available.return_value = False
+        mock_install_rt.return_value = True
+
+        mock_ops = mock_ops_cls.return_value
+        mock_ops.validate_servers_exist.return_value = (["test/server"], [])
+        mock_ops.check_servers_needing_installation.return_value = ["test/server"]
+        mock_ops.batch_fetch_server_info.return_value = {"test/server": {}}
+        mock_ops.collect_environment_variables.return_value = {}
+        mock_ops.collect_runtime_variables.return_value = {}
+
+        with patch("apm_cli.integration.mcp_integrator.Path.cwd", return_value=tmp_path):
+            MCPIntegrator.install(
+                mcp_deps=["test/server"],
+                exclude="cursor",
+                project_root=nested,
+                apm_config={"targets": ["copilot", "cursor"]},
+            )
+
+        called_runtimes = {call.args[0] for call in mock_install_rt.call_args_list}
+        assert called_runtimes == {"copilot"}
+
 
 # ===========================================================================
 # MCPIntegrator.remove_stale - copilot


### PR DESCRIPTION
## Description

Fixes #2298: the committed `apm.lock.yaml` recorded MCP server ownership (`deployments[].runtime`, the top-level `mcp_target_servers` map) based on which AI harnesses happen to be installed on the **local machine**, even when `apm.yml` declared an explicit `targets:` list. Two developers with different local harnesses (e.g. one with only GitHub Copilot/VS Code, one with only Claude Code) would each "steal" MCP ownership toward their own machine's detected runtimes, producing recurring, meaningless merge conflicts on the committed lockfile -- even though both declared the same `targets: [claude, copilot]`.

Root cause: the rest of the install pipeline (instruction/skill deployment, via `install/phases/targets.py`) already treats a declared `targets:` field as the deterministic source of truth, falling back to local-machine directory-signal detection only when nothing is declared. MCP integration had its own, separate target-resolution path (`_resolve_target_runtimes` in `src/apm_cli/integration/mcp_integrator_install.py`) that never consulted the manifest at all -- it only ever auto-detected installed runtimes (`_discover_installed_runtimes` + script-reference intersection), with `apm.yml`'s `targets:` only used *afterward*, as a subtractive filter (`MCPIntegrator._gate_project_scoped_runtimes`) that can drop auto-detected runtimes but can never add back a declared one the local machine doesn't happen to have installed.

Fix: add a `targets:`-aware branch to `_resolve_target_runtimes`, checked *before* the local-machine auto-detect fallback (same priority order as `--target` CLI flag > `--runtime` > auto-detect, just inserted between explicit CLI target and auto-detect). It delegates to `apm_cli.core.apm_yml.parse_targets_field` -- the exact same parser `install/phases/targets.py` and `MCPIntegrator._gate_project_scoped_runtimes` already use -- so a declared target list is interpreted identically everywhere in the pipeline (including folding the legacy `all` value back to auto-detect, same as elsewhere).

Verified end-to-end with a hermetic two-"machine" repro (same `apm.yml` with `targets: [claude, copilot]`, one machine with only a `.vscode/` signal, the other with only a `.claude/` signal): before the fix, machine A wrote `mcp_target_servers: {claude: [...], vscode: [...]}` and machine B wrote `{claude: [...]}` -- genuinely different. After the fix, both produce byte-identical `{claude: [...], copilot: [...]}`.

Fixes #2298

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

Details:
- Added `test_declared_targets_override_local_runtime_detection` to `tests/unit/integration/test_mcp_integrator.py` (fails on `main`, passes with this fix): declared `targets: [copilot, cursor, opencode]` must not gain an undeclared `vscode` runtime just because `.vscode/` happens to exist locally.
- Updated `test_install_uses_explicit_project_root_for_workspace_runtime_detection` in the same file: its prior setup relied on a declared-`targets:` `apm_config` purely to dodge `AmbiguousHarnessError` from the (unrelated) active-targets gate, which incidentally exercised auto-detection with multiple directory signals. Since declared targets now bypass auto-detection entirely, I narrowed it to a single unambiguous directory signal so it keeps testing what it says it tests (explicit `project_root` is used for local-machine auto-detection, not `Path.cwd()`), and added the new test above to cover the declared-targets path it used to (incidentally, not intentionally) touch.
- `tests/unit/integration/test_mcp_integrator.py`, `tests/unit/install/test_mcp_integrator_install_flow.py`, `tests/unit/install/test_mcp_integrator_install_phase3.py`, `tests/unit/integration/test_targets.py`, `tests/unit/integration/test_copilot_cowork_target.py`, `tests/unit/integration/test_data_driven_dispatch.py`, `tests/unit/integration/test_copilot_app_target.py`, `tests/unit/integration/test_scope_integration.py`, `tests/unit/test_global_mcp_scope.py` -- 350 passed, 4 pre-existing failures unrelated to this change (reproduced identically on `main` without this patch; environment-specific: this machine has both Copilot and Claude signals present, tripping the pre-existing ambiguity gate in two tests, plus two unrelated registry-import-error tests).
- `ruff check` on changed files -- clean.

## Spec conformance (OpenAPM v0.1)

- [ ] Spec edit: `docs/src/content/docs/specs/openapm-v0.1.md` updated (new/changed `<a id="req-XXX"></a>` anchor + prose + Appendix C row).
- [ ] Manifest edit: `docs/src/content/docs/specs/manifests/openapm-v0.1.requirements.yml` updated.
- [ ] Test edit: a `@pytest.mark.req("req-XXX")` test under `tests/spec_conformance/` added or extended.
- [ ] `CONFORMANCE.{md,json}` regenerated via `uv run --extra dev python -m tests.spec_conformance.gen_statement` and committed.
- [x] N/A -- see waiver below.

I checked and there is no existing `req-XXX` in the spec covering MCP target/runtime determinism (unlike #2297's fix, which was a regression against the already-normative `req-lk-005`). This PR's `src/apm_cli/integration/mcp_integrator_install.py` diff is 38 substantive lines under a critical path, so the local Mode B detector fires without a waiver. Rather than bundle ad hoc spec authorship into a bug-fix PR, I'm opting for the documented waiver and flagging that a new normative requirement (something like "a conforming consumer MUST resolve MCP server target ownership from a declared `targets:` field when present, before falling back to local-machine harness detection, so two consumers on the same commit produce identical `mcp_target_servers`/deployment-ledger MCP rows") would be a good follow-up for a maintainer or a dedicated PR to author properly, including the Appendix C row and a real `tests/spec_conformance/` assertion.

apm-spec-waiver: bug fix restoring apm.yml targets: determinism for MCP; no existing req-XXX covers MCP target resolution, proposing new requirement as a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
