### PR TITLE
fix: clear remediation for passphrase-protected SSH key failures (closes #1976)

### DIFF
--- a/src/apm_cli/deps/bare_cache.py
+++ b/src/apm_cli/deps/bare_cache.py
@@ -765,7 +765,7 @@ def _ssh_key_auth_diagnostic(
     return (
         " SSH key authentication failed while APM ran git non-interactively. "
         "Verify that the key is available to SSH. For a passphrase-protected key, "
-        "Load the key into ssh-agent before running APM: start ssh-agent if needed, "
+        "load the key into ssh-agent before running APM: start ssh-agent if needed, "
         "then run 'ssh-add <key-file>' (or 'ssh-add' for the default key). "
         "In CI, load a dedicated deploy key non-interactively, or switch the "
         "dependency to token-backed HTTPS. APM does not open an interactive "

--- a/src/apm_cli/deps/bare_cache.py
+++ b/src/apm_cli/deps/bare_cache.py
@@ -765,7 +765,8 @@ def _ssh_key_auth_diagnostic(
     return (
         " SSH key authentication failed while APM ran git non-interactively. "
         "Verify that the key is available to SSH. For a passphrase-protected key, "
-        "unlock it before running APM (for example, with 'ssh-add <key-file>'). "
+        "Load the key into ssh-agent before running APM: start ssh-agent if needed, "
+        "then run 'ssh-add <key-file>' (or 'ssh-add' for the default key). "
         "In CI, load a dedicated deploy key non-interactively, or switch the "
         "dependency to token-backed HTTPS. APM does not open an interactive "
         "passphrase prompt during clone."

--- a/tests/unit/deps/test_bare_cache_clone_failure.py
+++ b/tests/unit/deps/test_bare_cache_clone_failure.py
@@ -77,7 +77,7 @@ def test_clone_failure_message_explains_passphrase_protected_ssh_key() -> None:
     )
 
     assert "SSH key authentication failed" in message
-    assert "Load the key into ssh-agent" in message
+    assert "load the key into ssh-agent" in message
     assert "ssh-add <key-file>" in message
     assert "start ssh-agent" in message
     assert "Verify that the key is available to SSH" in message
@@ -94,7 +94,7 @@ def test_clone_failure_message_explains_explicit_ssh_publickey_failure() -> None
     )
 
     assert "SSH key authentication failed" in message
-    assert "Load the key into ssh-agent" in message
+    assert "load the key into ssh-agent" in message
     assert "ssh-add <key-file>" in message
     assert "start ssh-agent" in message
     assert "token-backed HTTPS" in message

--- a/tests/unit/deps/test_bare_cache_clone_failure.py
+++ b/tests/unit/deps/test_bare_cache_clone_failure.py
@@ -77,7 +77,9 @@ def test_clone_failure_message_explains_passphrase_protected_ssh_key() -> None:
     )
 
     assert "SSH key authentication failed" in message
+    assert "Load the key into ssh-agent" in message
     assert "ssh-add <key-file>" in message
+    assert "start ssh-agent" in message
     assert "Verify that the key is available to SSH" in message
     assert "dedicated deploy key" in message
     assert "token-backed HTTPS" in message
@@ -92,7 +94,9 @@ def test_clone_failure_message_explains_explicit_ssh_publickey_failure() -> None
     )
 
     assert "SSH key authentication failed" in message
+    assert "Load the key into ssh-agent" in message
     assert "ssh-add <key-file>" in message
+    assert "start ssh-agent" in message
     assert "token-backed HTTPS" in message
 
 


### PR DESCRIPTION
## Context

Closes #1976. SSH clone failures caused by a passphrase-protected key that is not loaded into ssh-agent currently fail under APM's non-interactive git execution model.

## Scope note

This is intentionally a bounded diagnostic fix for the needs-design issue. It does not implement interactive passphrase prompting, platform credential-helper integration, macOS keychain behavior, Windows credential manager behavior, or Linux ssh-agent orchestration. The deferred design question is whether and how APM should ever support interactive SSH passphrase prompting across platforms.

## What changed

- Extended the existing SSH key auth diagnostic in `bare_cache._ssh_key_auth_diagnostic`.
- The message now explicitly tells users to load the key into ssh-agent, start ssh-agent if needed, and run `ssh-add <key-file>` or `ssh-add` before `apm install`.
- Added regression assertions for the locked-key SSH failure diagnostic.

## How to test

- `uv run --extra dev pytest tests/unit/deps/test_bare_cache_clone_failure.py -q`
- Mutation-break: reverting the new ssh-agent guidance made `test_clone_failure_message_explains_passphrase_protected_ssh_key` fail as expected.
- `uv run --extra dev pytest tests/ -k "ssh or auth or clone or diagnostic" -q`
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- `uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/`
- `bash scripts/lint-auth-signals.sh`
