### PR TITLE
fix(install): preserve MCP target mappings (supersedes #2301, closes #2297)

### DIFF
--- a/.apm/instructions/architecture.instructions.md
+++ b/.apm/instructions/architecture.instructions.md
@@ -79,6 +79,10 @@ The scripts/lint-architecture-boundaries.sh check is wired into CI (the
 Lint job) alongside the auth-signal guard. Treat a new authority the
 same way: give it a guard line.
 
+Static boundary checks use bounded AST inspection and do not trace alias
+dataflow such as `view = lock.field; view.clear()`. Behavioral regression
+tests and code review remain the guard for those indirect mutations.
+
 ## Review lens
 
 When reviewing or authoring a change, ask: "Does this compute or

--- a/.github/instructions/architecture.instructions.md
+++ b/.github/instructions/architecture.instructions.md
@@ -79,6 +79,10 @@ The scripts/lint-architecture-boundaries.sh check is wired into CI (the
 Lint job) alongside the auth-signal guard. Treat a new authority the
 same way: give it a guard line.
 
+Static boundary checks use bounded AST inspection and do not trace alias
+dataflow such as `view = lock.field; view.clear()`. Behavioral regression
+tests and code review remain the guard for those indirect mutations.
+
 ## Review lens
 
 When reviewing or authoring a change, ask: "Does this compute or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stale. The matching `openapm-v0.1.md` frozen-install requirement now covers
   MCP state and all durable writes. (by @edenfunf, #2390; fixes #2373)
 
+- Repeated `apm install` runs with unchanged self-defined MCP dependencies and
+  explicit target mappings now preserve `generated_at`, deployment ownership,
+  and `mcp_target_servers`, leaving `apm.lock.yaml` byte-identical instead of
+  rewriting it. (#2306)
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview
   now excludes the synthesized lockfile self-entry, matching the real install
@@ -106,11 +110,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   @sergio-sisternes-epam. (#2294)
 - Narrowing active targets now removes shared-root skill copies owned only by a
   dropped target while preserving user edits and surviving ownership. (#2299)
-- Repeated `apm install` runs with unchanged self-defined MCP dependencies and
-  explicit target mappings now preserve `generated_at`, deployment ownership,
-  and `mcp_target_servers`, leaving `apm.lock.yaml` byte-identical instead of
-  rewriting it. One bounded hermetic regression joins the PR-time lifecycle
-  gate. (#2306)
 - Installing packages that share `.agents/skills` no longer leaves duplicate
   lockfile state or drops prior integrity information when APM must keep a file
   for a later retry. (#2283)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   @sergio-sisternes-epam. (#2294)
 - Narrowing active targets now removes shared-root skill copies owned only by a
   dropped target while preserving user edits and surviving ownership. (#2299)
+- Repeated `apm install` runs with unchanged self-defined MCP dependencies and
+  explicit target mappings now preserve `generated_at`, deployment ownership,
+  and `mcp_target_servers`, leaving `apm.lock.yaml` byte-identical instead of
+  rewriting it. (#2306)
+- `apm audit --ci` now surfaces the safe remediation when a lockfile's source
+  identity is tampered. A rewritten dependency `host`/`repo_url` trips both the
+  external `ref-consistency` check (remedy `apm install --update`, which
+  re-resolves from the trusted manifest) and the internal
+  `deployment-ledger-owners` check (remedy `apm prune`, which would reconcile
+  ownership toward the tampered lockfile). Under the default fail-fast the
+  runner now reports `ref-consistency` first, so operators get the
+  manifest-driven fix instead of the attacker-entrenching one. Genuine
+  departed-owner detection is unchanged. (#2300)
+- Project-scope installs for Gemini, Codex, OpenCode, and experimental Hermes now prompt users to run `apm compile` when dependency instructions need root context compilation, instead of silently leaving those instructions unapplied -- by @sergio-sisternes-epam (closes #2057; supersedes #2115) (#2293).
+- Removing a dependency and running `apm prune` now fully cleans its deployment
+  ownership records while preserving shared deployments and user-edited files.
+  `apm audit` now catches leftover ownership instead of reporting a clean bill
+  of health; run `apm prune`, then rerun `apm audit` to repair it.
 - Installing packages that share `.agents/skills` no longer leaves duplicate
   lockfile state or drops prior integrity information when APM must keep a file
   for a later retry. (#2283)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rewriting it. (#2306)
 - Repeated `apm install` runs with unchanged MCP dependencies no longer create
   spurious lockfile diffs. `apm.lock.yaml` stays byte-identical, preserving
-  `generated_at`, deployment ownership, and `mcp_target_servers`. (#2306)
+  `generated_at`, deployment records, and `mcp_target_servers`. (#2306)
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview
   now excludes the synthesized lockfile self-entry, matching the real install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   explicit target mappings now preserve `generated_at`, deployment ownership,
   and `mcp_target_servers`, leaving `apm.lock.yaml` byte-identical instead of
   rewriting it. (#2306)
+- Repeated `apm install` runs with unchanged MCP dependencies no longer create
+  spurious lockfile diffs. `apm.lock.yaml` stays byte-identical, preserving
+  `generated_at`, deployment ownership, and `mcp_target_servers`. (#2306)
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview
   now excludes the synthesized lockfile self-entry, matching the real install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,21 +109,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Repeated `apm install` runs with unchanged self-defined MCP dependencies and
   explicit target mappings now preserve `generated_at`, deployment ownership,
   and `mcp_target_servers`, leaving `apm.lock.yaml` byte-identical instead of
-  rewriting it. (#2306)
-- `apm audit --ci` now surfaces the safe remediation when a lockfile's source
-  identity is tampered. A rewritten dependency `host`/`repo_url` trips both the
-  external `ref-consistency` check (remedy `apm install --update`, which
-  re-resolves from the trusted manifest) and the internal
-  `deployment-ledger-owners` check (remedy `apm prune`, which would reconcile
-  ownership toward the tampered lockfile). Under the default fail-fast the
-  runner now reports `ref-consistency` first, so operators get the
-  manifest-driven fix instead of the attacker-entrenching one. Genuine
-  departed-owner detection is unchanged. (#2300)
-- Project-scope installs for Gemini, Codex, OpenCode, and experimental Hermes now prompt users to run `apm compile` when dependency instructions need root context compilation, instead of silently leaving those instructions unapplied -- by @sergio-sisternes-epam (closes #2057; supersedes #2115) (#2293).
-- Removing a dependency and running `apm prune` now fully cleans its deployment
-  ownership records while preserving shared deployments and user-edited files.
-  `apm audit` now catches leftover ownership instead of reporting a clean bill
-  of health; run `apm prune`, then rerun `apm audit` to repair it.
+  rewriting it. One bounded hermetic regression joins the PR-time lifecycle
+  gate. (#2306)
 - Installing packages that share `.agents/skills` no longer leaves duplicate
   lockfile state or drops prior integrity information when APM must keep a file
   for a later retry. (#2283)

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -2783,7 +2783,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:ff22fbee2c9194c14ef2de92cc67ff19cfcb092a109fae033022c0751acde5be
+  content_hash: sha256:183a410882333a8e60822adbe779420968041fb1fe54d324ff04b106855d03b1
 - kind: project-relative
   target: copilot
   value: .github/instructions/changelog.instructions.md
@@ -3290,7 +3290,7 @@ local_deployed_file_hashes:
   .github/agents/spec-tag-architect.agent.md: sha256:82907265c5e7cf1ac61ad96866fa7c5683b69c8f09b7a4c5f3cc241acc9568ca
   .github/agents/supply-chain-security-expert.agent.md: sha256:8fb8cc426d6af17ba084a28b3f026c2b475b62e3ca63ed2f88b83bd823f877af
   .github/agents/test-coverage-expert.agent.md: sha256:48c2172d1f18a394fa83ef9dc2be0b9b921a4e51e976498165250fed66369711
-  .github/instructions/architecture.instructions.md: sha256:ff22fbee2c9194c14ef2de92cc67ff19cfcb092a109fae033022c0751acde5be
+  .github/instructions/architecture.instructions.md: sha256:183a410882333a8e60822adbe779420968041fb1fe54d324ff04b106855d03b1
   .github/instructions/changelog.instructions.md: sha256:1e51ec4c74e847967962bd279dc4c6e582c5d3578490b3c28d5f3acd3e05f73e
   .github/instructions/cicd.instructions.md: sha256:08d87b7d635761cb41deb8fc71d5d83f54678de463db484afb16d2d4f8713ecb
   .github/instructions/cli.instructions.md: sha256:8e39e8d5047ce88575cb02f87c2bcede584dfef258bd86f7466c7badf136541a

--- a/docs/src/content/docs/contributing/integration-testing.md
+++ b/docs/src/content/docs/contributing/integration-testing.md
@@ -43,6 +43,7 @@ APM uses a tiered approach to integration testing:
 - **Selection mechanism**: `pytest --strict-markers -m 'lifecycle_smoke and not lifecycle_merge_group' tests/integration` -- declarative, not a file/node-id list. No central count or membership list is maintained.
 - **Full-coverage path**: merge-group workflow `ci-integration.yml`, job `integration-tests-shard`, step `Run integration tests (sharded + parallelized)`, calls `uv run ./scripts/test-integration.sh`; that script runs unfiltered `pytest tests/integration/`, so the complete lifecycle family remains exercised.
 - **Drift guard**: `tests/quality/test_ci_topology.py` independently collects the full, merge-group-only, and required selections; verifies their set partition; and preserves the required expression, full-integration execution path, step-level `APM_E2E_TESTS: "1"` binding, network/credential prohibitions, and required-check membership.
+- **Fixture controls**: lifecycle helpers set `APM_TEST_LOOPBACK_PORTS` for a port-scoped local registry and `APM_TEST_FAIL_LOCK_REPLACE=1` for atomic-write fault injection. These are internal test controls, not user-facing APM settings.
 - **Run it locally** (the exact command CI runs):
   ```bash
   APM_E2E_TESTS=1 uv run --extra dev pytest -p no:cacheprovider -q --strict-markers \

--- a/scripts/check_deployment_state_mutations.py
+++ b/scripts/check_deployment_state_mutations.py
@@ -17,6 +17,9 @@ _OWNED_FIELDS = frozenset(
     }
 )
 _MUTATORS = frozenset({"append", "remove", "pop", "extend", "clear", "update", "insert"})
+# This bounded AST guard intentionally does not perform alias dataflow analysis.
+# A pattern such as ``view = lock.mcp_target_servers; view.clear()`` requires a
+# heavier analyzer and remains covered by review plus the behavioral trap.
 _ALLOWED = frozenset(
     {
         Path("core/deployment_state.py"),

--- a/scripts/check_deployment_state_mutations.py
+++ b/scripts/check_deployment_state_mutations.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Reject deployment-state mutation outside its canonical codec owners."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from pathlib import Path
+
+_OWNED_FIELDS = frozenset(
+    {
+        "deployed_files",
+        "deployed_file_hashes",
+        "local_deployed_files",
+        "local_deployed_file_hashes",
+        "mcp_target_servers",
+    }
+)
+_MUTATORS = frozenset({"append", "remove", "pop", "extend", "clear", "update", "insert"})
+_ALLOWED = frozenset(
+    {
+        Path("core/deployment_state.py"),
+        Path("core/deployment_ledger.py"),
+        Path("deps/lockfile.py"),
+    }
+)
+
+
+def _owned_attribute(node: ast.AST) -> bool:
+    """Return whether one AST node references codec-owned state."""
+    return isinstance(node, ast.Attribute) and node.attr in _OWNED_FIELDS
+
+
+def mutation_lines(source: str) -> list[int]:
+    """Return direct mutation lines for codec-owned state in Python source."""
+    tree = ast.parse(source)
+    violations: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Assign, ast.AugAssign)):
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for target in targets:
+                if _owned_attribute(target) or (
+                    isinstance(target, ast.Subscript) and _owned_attribute(target.value)
+                ):
+                    violations.add(node.lineno)
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in _MUTATORS
+            and _owned_attribute(node.func.value)
+        ):
+            violations.add(node.lineno)
+    return sorted(violations)
+
+
+def analyze_tree(root: Path) -> list[str]:
+    """Return repository-relative violations below one apm_cli source root."""
+    violations: list[str] = []
+    for source in sorted(root.rglob("*.py")):
+        relative = source.relative_to(root)
+        if relative in _ALLOWED:
+            continue
+        for line_number in mutation_lines(source.read_text(encoding="utf-8")):
+            violations.append(f"{relative.as_posix()}:{line_number}")
+    return violations
+
+
+def main() -> int:
+    """Run the deployment-state mutation boundary check."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("root", type=Path)
+    args = parser.parse_args()
+    violations = analyze_tree(args.root)
+    if violations:
+        print("\n".join(violations))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -761,6 +761,15 @@ if ! grep -q '^_LEGACY_USER_TARGET_PREFIXES = {' src/apm_cli/core/deployment_led
     violations=$((violations + 1))
 fi
 
+deployment_state_output=$(python3 scripts/check_deployment_state_mutations.py \
+    src/apm_cli 2>&1)
+deployment_state_status=$?
+if [ "$deployment_state_status" -ne 0 ]; then
+    echo "[x] Deployment compatibility state must mutate only through canonical owners"
+    echo "$deployment_state_output"
+    violations=$((violations + 1))
+fi
+
 echo "[*] AC19: git-subprocess auth-header injection authority"
 # #2368: build_authorization_header_git_env / build_ado_bearer_git_env return
 # an overlay with a hardcoded GIT_CONFIG_COUNT="1". Dict-merging that overlay

--- a/src/apm_cli/deps/lockfile.py
+++ b/src/apm_cli/deps/lockfile.py
@@ -97,9 +97,11 @@ def _validate_lockfile_container(data: object) -> dict[str, Any]:
             raise LockfileFormatError("Lockfile mcp_target_servers entries must be strings")
     for server, provenance in (data.get("mcp_config_provenance") or {}).items():
         if not isinstance(server, str) or not (
-            isinstance(provenance, str)
+            (isinstance(provenance, str) and bool(provenance))
             or (
-                isinstance(provenance, list) and all(isinstance(owner, str) for owner in provenance)
+                isinstance(provenance, list)
+                and bool(provenance)
+                and all(isinstance(owner, str) and bool(owner) for owner in provenance)
             )
         ):
             raise LockfileFormatError(

--- a/src/apm_cli/deps/lockfile.py
+++ b/src/apm_cli/deps/lockfile.py
@@ -89,11 +89,11 @@ def _validate_lockfile_container(data: object) -> dict[str, Any]:
         if not isinstance(dependency, dict):
             raise LockfileFormatError(f"Lockfile dependency at index {index} must be a mapping")
     for target, servers in (data.get("mcp_target_servers") or {}).items():
-        if not isinstance(target, str) or not isinstance(servers, list):
+        if not isinstance(target, str) or not target or not isinstance(servers, list):
             raise LockfileFormatError(
                 "Lockfile mcp_target_servers values must be string-to-list mappings"
             )
-        if not all(isinstance(server, str) for server in servers):
+        if not all(isinstance(server, str) and bool(server) for server in servers):
             raise LockfileFormatError("Lockfile mcp_target_servers entries must be strings")
     for server, provenance in (data.get("mcp_config_provenance") or {}).items():
         if not isinstance(server, str) or not (

--- a/src/apm_cli/deps/lockfile.py
+++ b/src/apm_cli/deps/lockfile.py
@@ -93,6 +93,18 @@ def _validate_lockfile_container(data: object) -> dict[str, Any]:
             raise LockfileFormatError(
                 "Lockfile mcp_target_servers values must be string-to-list mappings"
             )
+        if not all(isinstance(server, str) for server in servers):
+            raise LockfileFormatError("Lockfile mcp_target_servers entries must be strings")
+    for server, provenance in (data.get("mcp_config_provenance") or {}).items():
+        if not isinstance(server, str) or not (
+            isinstance(provenance, str)
+            or (
+                isinstance(provenance, list) and all(isinstance(owner, str) for owner in provenance)
+            )
+        ):
+            raise LockfileFormatError(
+                "Lockfile mcp_config_provenance values must be strings or string lists"
+            )
     if "deployments" in data:
         from ..core.deployment_ledger import DeploymentLedgerCodec
 
@@ -101,6 +113,16 @@ def _validate_lockfile_container(data: object) -> dict[str, Any]:
         except ValueError as exc:
             raise LockfileFormatError(str(exc)) from exc
     return data
+
+
+def _normalized_mcp_provenance(
+    provenance: dict[str, str | list[str]],
+) -> dict[str, str | list[str]]:
+    """Return deterministic MCP provenance with list-valued owners sorted."""
+    return {
+        server: sorted(owners) if isinstance(owners, list) else owners
+        for server, owners in sorted(provenance.items())
+    }
 
 
 def _normalize_lockfile_host_type(raw: Any) -> str | None:
@@ -652,7 +674,7 @@ class LockFile:
     # ``resolved_by is None`` convention). Kept OUT of ``mcp_configs`` values so
     # it never pollutes config comparisons. Consistency diagnostics use this as
     # ownership context only; provenance never exempts a lock-only server.
-    mcp_config_provenance: dict[str, str] = field(default_factory=dict)
+    mcp_config_provenance: dict[str, str | list[str]] = field(default_factory=dict)
     lsp_servers: list[str] = field(default_factory=list)
     lsp_configs: dict[str, dict] = field(default_factory=dict)
     local_deployed_files: list[str] = field(default_factory=list)
@@ -760,7 +782,9 @@ class LockFile:
                     for target, servers in sorted(self.mcp_target_servers.items())
                 }
             if self.mcp_config_provenance:
-                data["mcp_config_provenance"] = dict(sorted(self.mcp_config_provenance.items()))
+                data["mcp_config_provenance"] = _normalized_mcp_provenance(
+                    self.mcp_config_provenance
+                )
             if self.lsp_servers:
                 data["lsp_servers"] = sorted(self.lsp_servers)
             if self.lsp_configs:
@@ -975,7 +999,9 @@ class LockFile:
             self.deployment_ledger.records
         ) != dict(other.deployment_ledger.records):
             return False
-        if self.mcp_config_provenance != other.mcp_config_provenance:
+        if _normalized_mcp_provenance(self.mcp_config_provenance) != _normalized_mcp_provenance(
+            other.mcp_config_provenance
+        ):
             return False
         if sorted(self.lsp_servers) != sorted(other.lsp_servers):
             return False

--- a/src/apm_cli/install/phases/lockfile.py
+++ b/src/apm_cli/install/phases/lockfile.py
@@ -463,7 +463,7 @@ class LockfileBuilder:
                 if target_servers:
                     mapping_count = len(target_servers)
                     mapping_noun = "mapping" if mapping_count == 1 else "mappings"
-                    detail += f", {mapping_count} target {mapping_noun}"
+                    detail += f", {mapping_count} runtime {mapping_noun}"
                 self.ctx.logger.verbose_detail(detail)
 
     def _preserve_existing_lsp_state(self, lockfile: LockFile) -> None:

--- a/src/apm_cli/install/phases/lockfile.py
+++ b/src/apm_cli/install/phases/lockfile.py
@@ -451,13 +451,19 @@ class LockfileBuilder:
                     copy.deepcopy(target_servers),
                 )
             if self.ctx.logger:
+                server_count = len(lockfile.mcp_servers)
+                config_count = len(lockfile.mcp_configs)
+                server_noun = "server" if server_count == 1 else "servers"
+                config_noun = "config" if config_count == 1 else "configs"
                 detail = (
                     "MCP state unchanged -- carrying forward "
-                    f"{len(lockfile.mcp_servers)} server(s), "
-                    f"{len(lockfile.mcp_configs)} config(s)"
+                    f"{server_count} {server_noun}, "
+                    f"{config_count} {config_noun}"
                 )
                 if target_servers:
-                    detail += f", {len(target_servers)} target mapping(s)"
+                    mapping_count = len(target_servers)
+                    mapping_noun = "mapping" if mapping_count == 1 else "mappings"
+                    detail += f", {mapping_count} target {mapping_noun}"
                 self.ctx.logger.verbose_detail(detail)
 
     def _preserve_existing_lsp_state(self, lockfile: LockFile) -> None:

--- a/src/apm_cli/install/phases/lockfile.py
+++ b/src/apm_cli/install/phases/lockfile.py
@@ -155,9 +155,11 @@ class LockfileBuilder:
             # merge new entries into the existing lockfile instead of
             # overwriting it -- otherwise the uninstalled packages disappear.
             lockfile = self._maybe_merge_partial(lockfile, lockfile_path, _LF)
+            # Restore local compatibility state first so the canonical ledger is
+            # complete when MCP target rows are projected into it.
+            self._preserve_existing_local_state(lockfile)
             self._preserve_existing_mcp_state(lockfile)
             self._preserve_existing_lsp_state(lockfile)
-            self._preserve_existing_local_state(lockfile)
             self._preserve_existing_revision_pin_tags(lockfile)
 
             # Only write when the semantic content has actually changed
@@ -437,27 +439,26 @@ class LockfileBuilder:
             lockfile.mcp_config_provenance = copy.deepcopy(
                 self.ctx.existing_lockfile.mcp_config_provenance
             )
-            # Also carry forward mcp_target_servers (and its ledger rows) via
-            # the same codec path MCPIntegrator itself uses. Without this, the
-            # freshly-built lockfile always starts with mcp_target_servers={},
-            # which reads as a real change against the on-disk file and forces
-            # an extra write here -- MCPIntegrator then has to correct it
-            # with a second write of its own, churning generated_at twice per
-            # install even when nothing changed (issue #2297).
-            if self.ctx.existing_lockfile.mcp_target_servers:
+            target_servers = self.ctx.existing_lockfile.mcp_target_servers
+            # The codec rebuild is linear in deployment rows and also marks the
+            # compatibility view present, so skip it when there is no target
+            # state to preserve.
+            if target_servers:
                 from apm_cli.core.deployment_ledger import DeploymentLedgerCodec
 
                 DeploymentLedgerCodec.replace_mcp_target_servers(
                     lockfile,
-                    copy.deepcopy(self.ctx.existing_lockfile.mcp_target_servers),
+                    copy.deepcopy(target_servers),
                 )
             if self.ctx.logger:
-                self.ctx.logger.verbose_detail(
+                detail = (
                     "MCP state unchanged -- carrying forward "
                     f"{len(lockfile.mcp_servers)} server(s), "
-                    f"{len(lockfile.mcp_configs)} config(s), "
-                    f"{len(lockfile.mcp_target_servers)} target mapping(s)"
+                    f"{len(lockfile.mcp_configs)} config(s)"
                 )
+                if target_servers:
+                    detail += f", {len(target_servers)} target mapping(s)"
+                self.ctx.logger.verbose_detail(detail)
 
     def _preserve_existing_lsp_state(self, lockfile: LockFile) -> None:
         """Keep LSP fields until LSP integration reconciles them later in install."""

--- a/src/apm_cli/install/phases/lockfile.py
+++ b/src/apm_cli/install/phases/lockfile.py
@@ -455,7 +455,8 @@ class LockfileBuilder:
                 self.ctx.logger.verbose_detail(
                     "MCP state unchanged -- carrying forward "
                     f"{len(lockfile.mcp_servers)} server(s), "
-                    f"{len(lockfile.mcp_configs)} config(s)"
+                    f"{len(lockfile.mcp_configs)} config(s), "
+                    f"{len(lockfile.mcp_target_servers)} target mapping(s)"
                 )
 
     def _preserve_existing_lsp_state(self, lockfile: LockFile) -> None:

--- a/src/apm_cli/install/phases/lockfile.py
+++ b/src/apm_cli/install/phases/lockfile.py
@@ -463,7 +463,7 @@ class LockfileBuilder:
                 if target_servers:
                     mapping_count = len(target_servers)
                     mapping_noun = "mapping" if mapping_count == 1 else "mappings"
-                    detail += f", {mapping_count} runtime {mapping_noun}"
+                    detail += f", {mapping_count} target {mapping_noun}"
                 self.ctx.logger.verbose_detail(detail)
 
     def _preserve_existing_lsp_state(self, lockfile: LockFile) -> None:

--- a/src/apm_cli/install/phases/lockfile.py
+++ b/src/apm_cli/install/phases/lockfile.py
@@ -437,6 +437,20 @@ class LockfileBuilder:
             lockfile.mcp_config_provenance = copy.deepcopy(
                 self.ctx.existing_lockfile.mcp_config_provenance
             )
+            # Also carry forward mcp_target_servers (and its ledger rows) via
+            # the same codec path MCPIntegrator itself uses. Without this, the
+            # freshly-built lockfile always starts with mcp_target_servers={},
+            # which reads as a real change against the on-disk file and forces
+            # an extra write here -- MCPIntegrator then has to correct it
+            # with a second write of its own, churning generated_at twice per
+            # install even when nothing changed (issue #2297).
+            if self.ctx.existing_lockfile.mcp_target_servers:
+                from apm_cli.core.deployment_ledger import DeploymentLedgerCodec
+
+                DeploymentLedgerCodec.replace_mcp_target_servers(
+                    lockfile,
+                    copy.deepcopy(self.ctx.existing_lockfile.mcp_target_servers),
+                )
             if self.ctx.logger:
                 self.ctx.logger.verbose_detail(
                     "MCP state unchanged -- carrying forward "

--- a/src/apm_cli/integration/mcp_integrator.py
+++ b/src/apm_cli/integration/mcp_integrator.py
@@ -833,7 +833,8 @@ class MCPIntegrator:
             lockfile.save(lock_path)
         except Exception:
             _log.debug(
-                "MCP lockfile persistence failed",
+                "MCP lockfile persistence failed at %s",
+                lock_path,
                 exc_info=True,
             )
             if creating:

--- a/src/apm_cli/integration/mcp_integrator.py
+++ b/src/apm_cli/integration/mcp_integrator.py
@@ -833,8 +833,7 @@ class MCPIntegrator:
             lockfile.save(lock_path)
         except Exception:
             _log.debug(
-                "Failed to update MCP servers in lockfile at %s",
-                lock_path,
+                "MCP lockfile persistence failed",
                 exc_info=True,
             )
             if creating:

--- a/src/apm_cli/integration/mcp_integrator.py
+++ b/src/apm_cli/integration/mcp_integrator.py
@@ -770,6 +770,10 @@ class MCPIntegrator:
                          transitively-contributed servers). Passed in lockstep
                          with ``mcp_configs`` so the two never diverge (#2081).
                          ``None`` leaves the existing value untouched.
+
+        Raises:
+            LockfileFormatError: If the existing lockfile is malformed.
+            OSError: If the atomic lockfile write fails.
         """
         if lock_path is None:
             lock_path = get_lockfile_path(Path.cwd())
@@ -846,7 +850,7 @@ class MCPIntegrator:
                     logger.warning(message)
                 else:
                     _rich_warning(message, symbol="warning")
-                raise
+            raise
 
     # ------------------------------------------------------------------
     # Runtime detection

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -342,6 +342,35 @@ def test_legacy_user_deployment_scope_has_single_owner() -> None:
     assert DeploymentLedgerCodec.legacy_scope(".github/hooks/demo.json") == "project"
 
 
+def test_deployment_compatibility_state_has_single_owner() -> None:
+    """Legacy deployment views must mutate only inside canonical owners."""
+    root = Path(__file__).parents[2]
+    guard = (root / "scripts/lint-architecture-boundaries.sh").read_text()
+    checker = _load_deployment_state_mutation_checker(root)
+
+    assert checker.analyze_tree(root / "src/apm_cli") == []
+    assert "scripts/check_deployment_state_mutations.py" in guard
+    assert "Deployment compatibility state must mutate only through canonical owners" in guard
+
+
+def test_deployment_state_guard_rejects_direct_mcp_target_assignment() -> None:
+    """A consumer cannot bypass DeploymentLedgerCodec for target mappings."""
+    root = Path(__file__).parents[2]
+    checker = _load_deployment_state_mutation_checker(root)
+    source = (root / "src/apm_cli/install/phases/lockfile.py").read_text(encoding="utf-8")
+    mutated = source.replace(
+        "DeploymentLedgerCodec.replace_mcp_target_servers(\n"
+        "                    lockfile,\n"
+        "                    copy.deepcopy(target_servers),\n"
+        "                )",
+        "lockfile.mcp_target_servers = copy.deepcopy(target_servers)",
+        1,
+    )
+    assert mutated != source
+    assert checker.mutation_lines(mutated)
+    assert checker.mutation_lines(mutated)
+
+
 def test_shared_target_contraction_has_single_reconciler_owner() -> None:
     """Generic shared-root supersession must remain inside DeploymentReconciler."""
     root = Path(__file__).parents[2]
@@ -603,6 +632,19 @@ def _load_cleanup_claim_owner_checker(root: Path) -> ModuleType:
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_deployment_state_mutation_checker(root: Path) -> ModuleType:
+    path = root / "scripts/check_deployment_state_mutations.py"
+    spec = importlib.util.spec_from_file_location(
+        "check_deployment_state_mutations",
+        path,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
 

--- a/tests/integration/test_install_mcp_lockfile_determinism.py
+++ b/tests/integration/test_install_mcp_lockfile_determinism.py
@@ -1,0 +1,112 @@
+"""Lifecycle regression for unchanged local-package MCP installs."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+from click.testing import CliRunner, Result
+
+from apm_cli.cli import cli
+from apm_cli.deps.lockfile import LockFile
+
+_INSTALL_ARGS = [
+    "install",
+    "--target",
+    "copilot,codex",
+    "--trust-transitive-mcp",
+    "--no-policy",
+]
+_TARGET_SERVERS = {
+    "codex": ["local-lifecycle-server"],
+    "vscode": ["local-lifecycle-server"],
+}
+
+
+def _write_local_mcp_project(project_root: Path) -> None:
+    """Create a consumer and local package with one self-defined MCP server."""
+    package_root = project_root / "packages" / "local-mcp"
+    package_root.mkdir(parents=True)
+    (package_root / "apm.yml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "local-mcp",
+                "version": "1.0.0",
+                "targets": ["copilot", "codex"],
+                "dependencies": {
+                    "mcp": [
+                        {
+                            "name": "local-lifecycle-server",
+                            "registry": False,
+                            "transport": "stdio",
+                            "command": "python",
+                            "args": ["-m", "local_lifecycle_server"],
+                        }
+                    ]
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    (project_root / "apm.yml").write_text(
+        yaml.safe_dump(
+            {
+                "name": "mcp-lockfile-determinism",
+                "version": "1.0.0",
+                "targets": ["copilot", "codex"],
+                "dependencies": {"apm": ["./packages/local-mcp"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    github_dir = project_root / ".github"
+    github_dir.mkdir()
+    (github_dir / "copilot-instructions.md").write_text("# Test project\n", encoding="utf-8")
+
+
+def _run_install(runner: CliRunner) -> Result:
+    """Run the hermetic CLI install with update checks disabled."""
+    with patch("apm_cli.commands._helpers.check_for_updates", return_value=None):
+        return runner.invoke(cli, _INSTALL_ARGS, catch_exceptions=False)
+
+
+@pytest.mark.lifecycle_smoke
+def test_unchanged_local_mcp_install_keeps_lockfile_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A repeated local MCP install preserves all lockfile state byte-for-byte."""
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    _write_local_mcp_project(project_root)
+    monkeypatch.chdir(project_root)
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    runner = CliRunner()
+
+    first_result = _run_install(runner)
+    assert first_result.exit_code == 0, first_result.output
+
+    lock_path = project_root / "apm.lock.yaml"
+    first_bytes = lock_path.read_bytes()
+    first_data = yaml.safe_load(first_bytes)
+    first_lock = LockFile.read(lock_path)
+    assert first_lock is not None
+    assert first_data["generated_at"] == first_lock.generated_at
+    assert first_data["deployments"]
+    assert first_data["mcp_target_servers"] == _TARGET_SERVERS
+    assert first_lock.mcp_target_servers == _TARGET_SERVERS
+
+    second_result = _run_install(runner)
+    assert second_result.exit_code == 0, second_result.output
+
+    second_bytes = lock_path.read_bytes()
+    second_data = yaml.safe_load(second_bytes)
+    second_lock = LockFile.read(lock_path)
+    assert second_lock is not None
+    assert second_data["generated_at"] == first_data["generated_at"]
+    assert second_data["deployments"] == first_data["deployments"]
+    assert second_data["mcp_target_servers"] == first_data["mcp_target_servers"]
+    assert second_lock.generated_at == first_lock.generated_at
+    assert second_lock.deployment_ledger == first_lock.deployment_ledger
+    assert second_lock.mcp_target_servers == first_lock.mcp_target_servers
+    assert second_bytes == first_bytes

--- a/tests/integration/test_install_mcp_lockfile_determinism.py
+++ b/tests/integration/test_install_mcp_lockfile_determinism.py
@@ -1,112 +1,405 @@
-"""Lifecycle regression for unchanged local-package MCP installs."""
+"""Installed-CLI lifecycle proofs for MCP lockfile determinism."""
 
-from pathlib import Path
-from unittest.mock import patch
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from urllib.parse import urlparse
 
 import pytest
-import yaml
-from click.testing import CliRunner, Result
+import tomlkit
 
-from apm_cli.cli import cli
 from apm_cli.deps.lockfile import LockFile
+from tests.utils.apm_lifecycle_runner import ApmLifecycleRunner, CommandResult
+from tests.utils.isolated_apm_environment import IsolatedApmEnvironment
+from tests.utils.lifecycle_state import LifecycleStateSnapshot
+from tests.utils.local_mcp_registry import LocalMcpRegistryFactory
+from tests.utils.local_package import LocalPackage, LocalPackageFactory
 
-_INSTALL_ARGS = [
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.e2e,
+    pytest.mark.requires_apm_binary,
+    pytest.mark.requires_e2e_mode,
+]
+
+_SERVER_NAME = "local-lifecycle-server"
+_REGISTRY_SERVER = "com.example/registry-lifecycle"
+_INSTALL_BOTH = (
     "install",
     "--target",
     "copilot,codex",
     "--trust-transitive-mcp",
     "--no-policy",
-]
+    "--parallel-downloads",
+    "0",
+)
+_INSTALL_COPILOT = (
+    "install",
+    "--target",
+    "copilot",
+    "--trust-transitive-mcp",
+    "--no-policy",
+    "--parallel-downloads",
+    "0",
+)
+_FROZEN_BOTH = (*_INSTALL_BOTH, "--frozen")
+_UPDATE_BOTH = (
+    "update",
+    "--yes",
+    "--target",
+    "copilot,codex",
+    "--parallel-downloads",
+    "0",
+)
+_AUDIT = ("audit", "--ci", "--no-policy", "--format", "json")
 _TARGET_SERVERS = {
-    "codex": ["local-lifecycle-server"],
-    "vscode": ["local-lifecycle-server"],
+    "codex": [_SERVER_NAME],
+    "vscode": [_SERVER_NAME],
 }
+_CONFIG_PATHS = (
+    PurePosixPath(".vscode/mcp.json"),
+    PurePosixPath(".codex/config.toml"),
+    PurePosixPath(".agents/skills/local-lifecycle/SKILL.md"),
+)
 
 
-def _write_local_mcp_project(project_root: Path) -> None:
-    """Create a consumer and local package with one self-defined MCP server."""
-    package_root = project_root / "packages" / "local-mcp"
-    package_root.mkdir(parents=True)
-    (package_root / "apm.yml").write_text(
-        yaml.safe_dump(
-            {
-                "name": "local-mcp",
-                "version": "1.0.0",
-                "targets": ["copilot", "codex"],
-                "dependencies": {
-                    "mcp": [
-                        {
-                            "name": "local-lifecycle-server",
-                            "registry": False,
-                            "transport": "stdio",
-                            "command": "python",
-                            "args": ["-m", "local_lifecycle_server"],
-                        }
-                    ]
-                },
-            }
+@dataclass(frozen=True)
+class _Scenario:
+    """One isolated installed-binary project with a local MCP package."""
+
+    isolated: IsolatedApmEnvironment
+    packages: LocalPackageFactory
+    project: LocalPackage
+    runner: ApmLifecycleRunner
+    environment: dict[str, str]
+
+
+def _self_defined_server(name: str = _SERVER_NAME) -> dict[str, object]:
+    """Return one deterministic self-defined stdio MCP declaration."""
+    return {
+        "name": name,
+        "registry": False,
+        "transport": "stdio",
+        "command": "python",
+        "args": ["-m", "local_lifecycle_server"],
+    }
+
+
+def _new_scenario(root: Path, apm_binary_path: Path) -> _Scenario:
+    """Create a mixed local-package project with user-authored MCP config."""
+    isolated = IsolatedApmEnvironment.create(root, base_env=dict(os.environ))
+    packages = LocalPackageFactory(isolated.work_root)
+    project = packages.create(
+        "mcp-lock-consumer",
+        targets=("copilot", "codex"),
+    )
+    dependency_factory = LocalPackageFactory(project.root / "packages")
+    dependency = dependency_factory.create(
+        "local-mcp",
+        mcp_dependencies=(_self_defined_server(),),
+    )
+    dependency_factory.add_skill(
+        dependency,
+        "local-lifecycle",
+        (
+            "---\n"
+            "name: local-lifecycle\n"
+            "description: Mixed non-MCP lifecycle fixture\n"
+            "---\n"
+            "# Local lifecycle\n"
         ),
+    )
+    packages.replace_apm_dependencies(
+        project,
+        ({"path": "./packages/local-mcp", "alias": dependency.name},),
+    )
+    _write_user_configs(project.root)
+    return _Scenario(
+        isolated=isolated,
+        packages=packages,
+        project=project,
+        runner=ApmLifecycleRunner(
+            (str(apm_binary_path),),
+            timeout_seconds=90,
+            scenario_timeout_seconds=360,
+        ),
+        environment=isolated.subprocess_env(),
+    )
+
+
+def _write_user_configs(project_root: Path) -> None:
+    """Seed native target configs with entries APM must preserve."""
+    vscode_config = project_root / ".vscode" / "mcp.json"
+    vscode_config.parent.mkdir(parents=True)
+    vscode_config.write_text(
+        json.dumps(
+            {
+                "servers": {
+                    "user-authored": {
+                        "type": "http",
+                        "url": "https://user.example.invalid/mcp",
+                    }
+                }
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
         encoding="utf-8",
     )
-    (project_root / "apm.yml").write_text(
-        yaml.safe_dump(
-            {
-                "name": "mcp-lockfile-determinism",
-                "version": "1.0.0",
-                "targets": ["copilot", "codex"],
-                "dependencies": {"apm": ["./packages/local-mcp"]},
-            }
-        ),
+    codex_config = project_root / ".codex" / "config.toml"
+    codex_config.parent.mkdir(parents=True)
+    codex_config.write_text(
+        r"[projects.'c:\src\project']"
+        "\n"
+        'trust_level = "trusted"\n'
+        "\n"
+        "[mcp_servers.user-authored]\n"
+        'command = "user-command"\n',
         encoding="utf-8",
     )
-    github_dir = project_root / ".github"
-    github_dir.mkdir()
-    (github_dir / "copilot-instructions.md").write_text("# Test project\n", encoding="utf-8")
 
 
-def _run_install(runner: CliRunner) -> Result:
-    """Run the hermetic CLI install with update checks disabled."""
-    with patch("apm_cli.commands._helpers.check_for_updates", return_value=None):
-        return runner.invoke(cli, _INSTALL_ARGS, catch_exceptions=False)
+def _run_ok(
+    scenario: _Scenario,
+    args: tuple[str, ...],
+    scenario_id: str,
+    *,
+    cwd: Path | None = None,
+    environment: dict[str, str] | None = None,
+) -> CommandResult:
+    """Run one installed command and retain complete failure evidence."""
+    result = scenario.runner.run(
+        args,
+        scenario_id=scenario_id,
+        cwd=cwd or scenario.project.root,
+        env=environment or scenario.environment,
+    )
+    assert result.returncode == 0, (
+        f"command={result.command!r}\n"
+        f"cwd={result.cwd!s}\n"
+        f"stdout={result.stdout!r}\n"
+        f"stderr={result.stderr!r}"
+    )
+    return result
+
+
+def _snapshot(project_root: Path) -> LifecycleStateSnapshot:
+    """Capture exact lock, MCP, deployment, and native-config state."""
+    return LifecycleStateSnapshot.capture(
+        project_root,
+        targets=("copilot", "codex"),
+        config_paths=_CONFIG_PATHS,
+    )
+
+
+def _assert_exact_state(
+    expected: LifecycleStateSnapshot,
+    actual: LifecycleStateSnapshot,
+) -> None:
+    """Assert every durable lifecycle surface remains byte-identical."""
+    assert actual.lockfile_bytes == expected.lockfile_bytes
+    assert actual.deployment_records == expected.deployment_records
+    assert actual.mcp_state_bytes == expected.mcp_state_bytes
+    assert actual.files == expected.files
+    assert actual.semantic_bytes == expected.semantic_bytes
+
+
+def _lock(project_root: Path) -> LockFile:
+    lock = LockFile.read(project_root / "apm.lock.yaml")
+    assert lock is not None
+    return lock
+
+
+def _file_identity(path: Path) -> tuple[int, int, int]:
+    """Return metadata that changes when atomic replacement occurs."""
+    metadata = path.stat()
+    return metadata.st_mtime_ns, metadata.st_size, metadata.st_ino
+
+
+def _assert_user_configs(project_root: Path) -> None:
+    """Verify APM-managed transitions never remove user-authored config."""
+    vscode = json.loads((project_root / ".vscode" / "mcp.json").read_text(encoding="utf-8"))
+    user_url = urlparse(vscode["servers"]["user-authored"]["url"])
+    assert (user_url.scheme, user_url.hostname, user_url.path) == (
+        "https",
+        "user.example.invalid",
+        "/mcp",
+    )
+    codex = tomlkit.parse((project_root / ".codex" / "config.toml").read_text(encoding="utf-8"))
+    assert codex["mcp_servers"]["user-authored"]["command"] == "user-command"
+    assert codex["projects"][r"c:\src\project"]["trust_level"] == "trusted"
 
 
 @pytest.mark.lifecycle_smoke
-def test_unchanged_local_mcp_install_keeps_lockfile_bytes(
+def test_installed_mcp_lifecycle_is_no_write_until_real_target_change(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
+    apm_binary_path: Path,
 ) -> None:
-    """A repeated local MCP install preserves all lockfile state byte-for-byte."""
-    project_root = tmp_path / "project"
-    project_root.mkdir()
-    _write_local_mcp_project(project_root)
-    monkeypatch.chdir(project_root)
-    monkeypatch.setenv("HOME", str(tmp_path / "home"))
-    runner = CliRunner()
-
-    first_result = _run_install(runner)
-    assert first_result.exit_code == 0, first_result.output
-
+    """Install, update, frozen, and audit converge; one target change writes."""
+    scenario = _new_scenario(tmp_path / "installed-lifecycle", apm_binary_path)
+    project_root = scenario.project.root
     lock_path = project_root / "apm.lock.yaml"
-    first_bytes = lock_path.read_bytes()
-    first_data = yaml.safe_load(first_bytes)
-    first_lock = LockFile.read(lock_path)
-    assert first_lock is not None
-    assert first_data["generated_at"] == first_lock.generated_at
-    assert first_data["deployments"]
-    assert first_data["mcp_target_servers"] == _TARGET_SERVERS
-    assert first_lock.mcp_target_servers == _TARGET_SERVERS
 
-    second_result = _run_install(runner)
-    assert second_result.exit_code == 0, second_result.output
+    _run_ok(scenario, _INSTALL_BOTH, "mcp-lock-install-first")
+    baseline = _snapshot(project_root)
+    baseline_lock = _lock(project_root)
+    baseline_identity = _file_identity(lock_path)
+    assert baseline_lock.mcp_target_servers == _TARGET_SERVERS
+    assert baseline_lock.mcp_config_provenance == {_SERVER_NAME: "local-mcp"}
+    assert baseline_lock.mcp_configs[_SERVER_NAME]["registry"] is False
+    assert baseline_lock.deployment_ledger.records
+    assert baseline.file(".agents/skills/local-lifecycle/SKILL.md").kind == "file"
+    _assert_user_configs(project_root)
 
-    second_bytes = lock_path.read_bytes()
-    second_data = yaml.safe_load(second_bytes)
-    second_lock = LockFile.read(lock_path)
-    assert second_lock is not None
-    assert second_data["generated_at"] == first_data["generated_at"]
-    assert second_data["deployments"] == first_data["deployments"]
-    assert second_data["mcp_target_servers"] == first_data["mcp_target_servers"]
-    assert second_lock.generated_at == first_lock.generated_at
-    assert second_lock.deployment_ledger == first_lock.deployment_ledger
-    assert second_lock.mcp_target_servers == first_lock.mcp_target_servers
-    assert second_bytes == first_bytes
+    time.sleep(0.02)
+    _run_ok(scenario, _INSTALL_BOTH, "mcp-lock-install-unchanged")
+    repeated = _snapshot(project_root)
+    _assert_exact_state(baseline, repeated)
+    assert _file_identity(lock_path) == baseline_identity
+
+    _run_ok(scenario, _UPDATE_BOTH, "mcp-lock-update-unchanged")
+    updated = _snapshot(project_root)
+    _assert_exact_state(baseline, updated)
+    assert _file_identity(lock_path) == baseline_identity
+
+    _run_ok(scenario, _FROZEN_BOTH, "mcp-lock-frozen-unchanged")
+    frozen = _snapshot(project_root)
+    _assert_exact_state(baseline, frozen)
+    assert _file_identity(lock_path) == baseline_identity
+
+    audit = _run_ok(scenario, _AUDIT, "mcp-lock-audit-unchanged")
+    audit_payload = json.loads(audit.stdout)
+    assert audit_payload["passed"] is True
+    audited = _snapshot(project_root)
+    _assert_exact_state(baseline, audited)
+    assert _file_identity(lock_path) == baseline_identity
+
+    scenario.packages.set_targets(scenario.project, ("copilot",))
+    time.sleep(0.02)
+    _run_ok(scenario, _INSTALL_COPILOT, "mcp-lock-target-change")
+    changed = _snapshot(project_root)
+    changed_lock = _lock(project_root)
+    changed_identity = _file_identity(lock_path)
+    assert changed.lockfile_bytes != baseline.lockfile_bytes
+    assert changed_lock.generated_at != baseline_lock.generated_at
+    assert changed_lock.mcp_target_servers == {"copilot": [_SERVER_NAME]}
+    assert changed_identity != baseline_identity
+    assert {
+        record.locator.runtime
+        for record in changed.deployment_records
+        if record.locator.target == "mcp"
+    } == {"copilot"}
+    _assert_user_configs(project_root)
+
+    time.sleep(0.02)
+    _run_ok(scenario, _INSTALL_COPILOT, "mcp-lock-target-converged")
+    converged = _snapshot(project_root)
+    _assert_exact_state(changed, converged)
+    assert _file_identity(lock_path) == changed_identity
+
+
+def test_redirected_root_registry_install_converges_without_rewrite(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """A local registry install under --root preserves exact lock bytes."""
+    isolated = IsolatedApmEnvironment.create(
+        tmp_path / "redirected-registry",
+        base_env=dict(os.environ),
+    )
+    registry_factory = LocalMcpRegistryFactory(isolated.root / "mcp-registries")
+    server_document = {
+        "name": _REGISTRY_SERVER,
+        "description": "Redirected-root registry fixture",
+        "version": "1.0.0",
+        "remotes": [
+            {
+                "transport_type": "http",
+                "url": "https://mcp.example.invalid/registry-lifecycle",
+            }
+        ],
+    }
+    with registry_factory.start(server_document) as registry:
+        project_factory = LocalPackageFactory(isolated.work_root)
+        project = project_factory.create(
+            "registry-source",
+            mcp_dependencies=({"name": _REGISTRY_SERVER, "registry": registry.url},),
+            targets=("copilot", "codex"),
+        )
+        dependency_factory = LocalPackageFactory(project.root / "packages")
+        regular_dependency = dependency_factory.create("regular-package")
+        dependency_factory.add_skill(
+            regular_dependency,
+            "redirected-regular",
+            (
+                "---\n"
+                "name: redirected-regular\n"
+                "description: Redirected mixed-dependency fixture\n"
+                "---\n"
+                "# Redirected regular package\n"
+            ),
+        )
+        project_factory.replace_apm_dependencies(
+            project,
+            ({"path": "./packages/regular-package", "alias": regular_dependency.name},),
+        )
+        output_root = isolated.root / "redirected-output"
+        output_root.mkdir()
+        environment = isolated.subprocess_env(
+            overrides={"MCP_REGISTRY_ALLOW_HTTP": "1"},
+        )
+        # This scenario intentionally permits only its process-local registry.
+        # The registry document points at an invalid remote that is never called.
+        environment.pop("PYTHONPATH", None)
+        scenario = _Scenario(
+            isolated=isolated,
+            packages=LocalPackageFactory(isolated.package_root),
+            project=project,
+            runner=ApmLifecycleRunner((str(apm_binary_path),), timeout_seconds=90),
+            environment=environment,
+        )
+        args = (
+            "install",
+            "--root",
+            str(output_root),
+            "--target",
+            "copilot,codex",
+            "--no-policy",
+            "--parallel-downloads",
+            "0",
+        )
+        source_manifest = project.manifest_path.read_bytes()
+
+        _run_ok(scenario, args, "redirected-registry-first")
+        first = LifecycleStateSnapshot.capture(
+            output_root,
+            config_paths=(
+                PurePosixPath(".vscode/mcp.json"),
+                PurePosixPath(".codex/config.toml"),
+            ),
+        )
+        lock_path = output_root / "apm.lock.yaml"
+        first_identity = _file_identity(lock_path)
+
+        time.sleep(0.02)
+        _run_ok(scenario, args, "redirected-registry-unchanged")
+        second = LifecycleStateSnapshot.capture(
+            output_root,
+            config_paths=(
+                PurePosixPath(".vscode/mcp.json"),
+                PurePosixPath(".codex/config.toml"),
+            ),
+        )
+
+        _assert_exact_state(first, second)
+        assert _file_identity(lock_path) == first_identity
+        assert project.manifest_path.read_bytes() == source_manifest
+        parsed_registry = urlparse(registry.url)
+        assert parsed_registry.hostname == "127.0.0.1"
+        assert parsed_registry.port is not None
+        assert registry.request_paths

--- a/tests/integration/test_install_mcp_lockfile_determinism.py
+++ b/tests/integration/test_install_mcp_lockfile_determinism.py
@@ -354,9 +354,10 @@ def test_redirected_root_registry_install_converges_without_rewrite(
         environment = isolated.subprocess_env(
             overrides={"MCP_REGISTRY_ALLOW_HTTP": "1"},
         )
-        # This scenario intentionally permits only its process-local registry.
-        # The registry document points at an invalid remote that is never called.
-        environment.pop("PYTHONPATH", None)
+        parsed_registry = urlparse(registry.url)
+        assert parsed_registry.hostname == "127.0.0.1"
+        assert parsed_registry.port is not None
+        environment["APM_TEST_LOOPBACK_PORTS"] = str(parsed_registry.port)
         scenario = _Scenario(
             isolated=isolated,
             packages=LocalPackageFactory(isolated.package_root),
@@ -400,7 +401,4 @@ def test_redirected_root_registry_install_converges_without_rewrite(
         _assert_exact_state(first, second)
         assert _file_identity(lock_path) == first_identity
         assert project.manifest_path.read_bytes() == source_manifest
-        parsed_registry = urlparse(registry.url)
-        assert parsed_registry.hostname == "127.0.0.1"
-        assert parsed_registry.port is not None
         assert registry.request_paths

--- a/tests/integration/test_install_mcp_lockfile_determinism.py
+++ b/tests/integration/test_install_mcp_lockfile_determinism.py
@@ -402,3 +402,29 @@ def test_redirected_root_registry_install_converges_without_rewrite(
         assert _file_identity(lock_path) == first_identity
         assert project.manifest_path.read_bytes() == source_manifest
         assert registry.request_paths
+
+
+def test_installed_mcp_write_failure_exits_nonzero_without_partial_lock(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """A real MCP persistence failure is explicit and leaves the lock intact."""
+    scenario = _new_scenario(tmp_path / "installed-write-failure", apm_binary_path)
+    project_root = scenario.project.root
+    lock_path = project_root / "apm.lock.yaml"
+    _run_ok(scenario, _INSTALL_BOTH, "mcp-write-failure-baseline")
+    baseline_bytes = lock_path.read_bytes()
+
+    scenario.packages.set_targets(scenario.project, ("copilot",))
+    failing_environment = dict(scenario.environment)
+    failing_environment["APM_TEST_FAIL_LOCK_REPLACE"] = "1"
+    result = scenario.runner.run(
+        _INSTALL_COPILOT,
+        scenario_id="mcp-write-failure-injected",
+        cwd=project_root,
+        env=failing_environment,
+    )
+
+    assert result.returncode != 0
+    assert lock_path.read_bytes() == baseline_bytes
+    assert list(project_root.glob("apm-atomic-*")) == []

--- a/tests/integration/test_install_mcp_lockfile_determinism.py
+++ b/tests/integration/test_install_mcp_lockfile_determinism.py
@@ -303,6 +303,7 @@ def test_installed_mcp_lifecycle_is_no_write_until_real_target_change(
     assert _file_identity(lock_path) == changed_identity
 
 
+@pytest.mark.lifecycle_smoke
 def test_redirected_root_registry_install_converges_without_rewrite(
     tmp_path: Path,
     apm_binary_path: Path,

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -514,6 +514,11 @@ class TestLockFileSemanticEquivalence:
         b = self._make_lock(mcp_config_provenance={"s": "package-b"})
         assert not a.is_semantically_equivalent(b)
 
+    def test_mcp_config_provenance_list_order_irrelevant(self):
+        a = self._make_lock(mcp_config_provenance={"s": ["package-b", "package-a"]})
+        b = self._make_lock(mcp_config_provenance={"s": ["package-a", "package-b"]})
+        assert a.is_semantically_equivalent(b)
+
     def test_changed_lsp_servers_not_equivalent(self):
         a = self._make_lock(lsp_servers=["server-a"])
         b = self._make_lock(lsp_servers=["server-b"])

--- a/tests/unit/core/test_deployment_owner_invariant.py
+++ b/tests/unit/core/test_deployment_owner_invariant.py
@@ -60,6 +60,7 @@ def _mutation_lines(source: str) -> list[int]:
         "lock.local_deployed_files.clear()",
         "lock.local_deployed_file_hashes.update({'path': 'hash'})",
         "lock.local_deployed_files.insert(0, 'path')",
+        "lock.mcp_target_servers = {'vscode': ['server']}",
     ],
 )
 def test_mutation_detector_catches_negative_controls(source: str) -> None:

--- a/tests/unit/core/test_deployment_owner_invariant.py
+++ b/tests/unit/core/test_deployment_owner_invariant.py
@@ -1,50 +1,22 @@
 """Source invariant for canonical deployment-state mutation."""
 
-import ast
+import importlib.util
+import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
-_OWNED_FIELDS = frozenset(
-    {
-        "deployed_files",
-        "deployed_file_hashes",
-        "local_deployed_files",
-        "local_deployed_file_hashes",
-        "mcp_target_servers",
-    }
-)
-_MUTATORS = frozenset({"append", "remove", "pop", "extend", "clear", "update", "insert"})
-_ALLOWED = {
-    Path("core/deployment_state.py"),
-    Path("core/deployment_ledger.py"),
-    Path("deps/lockfile.py"),
-}
 
-
-def _owned_attribute(node: ast.AST) -> bool:
-    return isinstance(node, ast.Attribute) and node.attr in _OWNED_FIELDS
-
-
-def _mutation_lines(source: str) -> list[int]:
-    tree = ast.parse(source)
-    violations: set[int] = set()
-    for node in ast.walk(tree):
-        if isinstance(node, (ast.Assign, ast.AugAssign)):
-            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
-            for target in targets:
-                if _owned_attribute(target) or (
-                    isinstance(target, ast.Subscript) and _owned_attribute(target.value)
-                ):
-                    violations.add(node.lineno)
-        elif (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and node.func.attr in _MUTATORS
-            and _owned_attribute(node.func.value)
-        ):
-            violations.add(node.lineno)
-    return sorted(violations)
+def _load_checker() -> ModuleType:
+    root = Path(__file__).resolve().parents[3]
+    path = root / "scripts/check_deployment_state_mutations.py"
+    spec = importlib.util.spec_from_file_location("check_deployment_state_mutations", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 @pytest.mark.parametrize(
@@ -64,7 +36,7 @@ def _mutation_lines(source: str) -> list[int]:
     ],
 )
 def test_mutation_detector_catches_negative_controls(source: str) -> None:
-    assert _mutation_lines(source) == [1]
+    assert _load_checker().mutation_lines(source) == [1]
 
 
 @pytest.mark.parametrize(
@@ -76,16 +48,9 @@ def test_mutation_detector_catches_negative_controls(source: str) -> None:
     ],
 )
 def test_mutation_detector_allows_owned_field_reads(source: str) -> None:
-    assert _mutation_lines(source) == []
+    assert _load_checker().mutation_lines(source) == []
 
 
 def test_only_canonical_owner_mutates_legacy_deployment_fields() -> None:
     root = Path(__file__).resolve().parents[3] / "src" / "apm_cli"
-    violations: list[str] = []
-    for source in root.rglob("*.py"):
-        relative = source.relative_to(root)
-        if relative in _ALLOWED:
-            continue
-        for line_number in _mutation_lines(source.read_text(encoding="utf-8")):
-            violations.append(f"{relative.as_posix()}:{line_number}")
-    assert violations == []
+    assert _load_checker().analyze_tree(root) == []

--- a/tests/unit/install/test_mcp_lockfile_determinism.py
+++ b/tests/unit/install/test_mcp_lockfile_determinism.py
@@ -109,6 +109,8 @@ def _run_lockfile_phase_and_mcp_persist(
     project_root: Path,
     package: APMPackage,
     instant: datetime,
+    *,
+    mcp_target_servers: dict[str, list[str]] | None = None,
 ) -> None:
     lock_path = get_lockfile_path(project_root)
     dep_ref = package.get_apm_dependencies()[0]
@@ -138,6 +140,7 @@ def _run_lockfile_phase_and_mcp_persist(
             MCPIntegrator.get_server_names(mcp_deps),
             lock_path,
             mcp_configs=MCPIntegrator.get_server_configs(mcp_deps),
+            mcp_target_servers=mcp_target_servers,
         )
 
 
@@ -262,6 +265,35 @@ def test_unchanged_mcp_dependencies_do_not_rewrite_lockfile(tmp_path: Path) -> N
     assert second_lock is not None
 
     assert second_lock.generated_at == first_lock.generated_at
+    assert second_bytes == first_bytes
+
+
+def test_unchanged_mcp_target_servers_do_not_rewrite_lockfile(tmp_path: Path) -> None:
+    """Regression for #2297: a populated mcp_target_servers must not churn generated_at."""
+    package = _write_manifest_with_mcp(tmp_path)
+    first_instant = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    second_instant = datetime(2026, 1, 1, 0, 1, 0, tzinfo=timezone.utc)
+    target_servers = {"claude": ["atlassian"]}
+
+    _run_lockfile_phase_and_mcp_persist(
+        tmp_path, package, first_instant, mcp_target_servers=target_servers
+    )
+    lock_path = get_lockfile_path(tmp_path)
+    first_bytes = lock_path.read_bytes()
+    first_lock = LockFile.read(lock_path)
+    assert first_lock is not None
+    assert first_lock.generated_at == first_instant.isoformat()
+    assert first_lock.mcp_target_servers == target_servers
+
+    _run_lockfile_phase_and_mcp_persist(
+        tmp_path, package, second_instant, mcp_target_servers=target_servers
+    )
+    second_bytes = lock_path.read_bytes()
+    second_lock = LockFile.read(lock_path)
+    assert second_lock is not None
+
+    assert second_lock.generated_at == first_lock.generated_at
+    assert second_lock.mcp_target_servers == target_servers
     assert second_bytes == first_bytes
 
 

--- a/tests/unit/install/test_mcp_lockfile_determinism.py
+++ b/tests/unit/install/test_mcp_lockfile_determinism.py
@@ -6,15 +6,19 @@ from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from apm_cli.core.deployment_ledger import DeploymentLedgerCodec
 from apm_cli.core.scope import InstallScope
 from apm_cli.deps.installed_package import InstalledPackage
-from apm_cli.deps.lockfile import LockFile, get_lockfile_path
+from apm_cli.deps.lockfile import LockFile, LockfileFormatError, get_lockfile_path
 from apm_cli.install.context import InstallContext
 from apm_cli.install.phases import post_deps_local
 from apm_cli.install.phases.lockfile import LockfileBuilder
 from apm_cli.integration.lsp_integrator import LSPIntegrator
 from apm_cli.integration.mcp_integrator import MCPIntegrator
 from apm_cli.models.apm_package import APMPackage, DependencyReference, clear_apm_yml_cache
+from apm_cli.utils.yaml_io import dump_yaml, load_yaml
 
 
 class _FixedDatetime:
@@ -111,7 +115,8 @@ def _run_lockfile_phase_and_mcp_persist(
     instant: datetime,
     *,
     mcp_target_servers: dict[str, list[str]] | None = None,
-) -> None:
+    package_type: str = "apm_package",
+) -> InstallContext:
     lock_path = get_lockfile_path(project_root)
     dep_ref = package.get_apm_dependencies()[0]
     ctx = InstallContext(
@@ -127,7 +132,7 @@ def _run_lockfile_phase_and_mcp_persist(
     ]
     dep_key = dep_ref.get_unique_key()
     ctx.package_deployed_files = {dep_key: [".github/instructions/dep.instructions.md"]}
-    ctx.package_types = {dep_key: "apm_package"}
+    ctx.package_types = {dep_key: package_type}
 
     _FixedDatetime.instant = instant
     with (
@@ -142,6 +147,7 @@ def _run_lockfile_phase_and_mcp_persist(
             mcp_configs=MCPIntegrator.get_server_configs(mcp_deps),
             mcp_target_servers=mcp_target_servers,
         )
+    return ctx
 
 
 def _run_lockfile_phase_and_lsp_persist(
@@ -285,7 +291,7 @@ def test_unchanged_mcp_target_servers_do_not_rewrite_lockfile(tmp_path: Path) ->
     assert first_lock.generated_at == first_instant.isoformat()
     assert first_lock.mcp_target_servers == target_servers
 
-    _run_lockfile_phase_and_mcp_persist(
+    second_context = _run_lockfile_phase_and_mcp_persist(
         tmp_path, package, second_instant, mcp_target_servers=target_servers
     )
     second_bytes = lock_path.read_bytes()
@@ -295,6 +301,279 @@ def test_unchanged_mcp_target_servers_do_not_rewrite_lockfile(tmp_path: Path) ->
     assert second_lock.generated_at == first_lock.generated_at
     assert second_lock.mcp_target_servers == target_servers
     assert second_bytes == first_bytes
+    second_context.logger.verbose_detail.assert_any_call(
+        "MCP state unchanged -- carrying forward 1 server(s), 1 config(s), 1 target mapping(s)"
+    )
+
+
+def test_real_mcp_target_change_writes_once_then_converges(tmp_path: Path) -> None:
+    """A meaningful target transition writes once; its next run writes zero times."""
+    package = _write_manifest_with_mcp(tmp_path)
+    first_instant = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    second_instant = datetime(2026, 1, 1, 0, 1, 0, tzinfo=timezone.utc)
+    third_instant = datetime(2026, 1, 1, 0, 2, 0, tzinfo=timezone.utc)
+    first_targets = {"claude": ["atlassian"]}
+    changed_targets = {"codex": ["atlassian"]}
+
+    _run_lockfile_phase_and_mcp_persist(
+        tmp_path,
+        package,
+        first_instant,
+        mcp_target_servers=first_targets,
+    )
+    lock_path = get_lockfile_path(tmp_path)
+    real_save = LockFile.save
+    changed_writes: list[Path] = []
+
+    def track_changed_write(lockfile: LockFile, path: Path) -> None:
+        changed_writes.append(path)
+        real_save(lockfile, path)
+
+    with patch.object(LockFile, "save", track_changed_write):
+        _run_lockfile_phase_and_mcp_persist(
+            tmp_path,
+            package,
+            second_instant,
+            mcp_target_servers=changed_targets,
+        )
+    changed_bytes = lock_path.read_bytes()
+    changed_lock = LockFile.read(lock_path)
+    assert changed_lock is not None
+    assert changed_writes == [lock_path]
+    assert changed_lock.generated_at == second_instant.isoformat()
+    assert changed_lock.mcp_target_servers == changed_targets
+
+    converged_writes: list[Path] = []
+
+    def track_converged_write(lockfile: LockFile, path: Path) -> None:
+        converged_writes.append(path)
+        real_save(lockfile, path)
+
+    with patch.object(LockFile, "save", track_converged_write):
+        _run_lockfile_phase_and_mcp_persist(
+            tmp_path,
+            package,
+            third_instant,
+            mcp_target_servers=changed_targets,
+        )
+    assert converged_writes == []
+    assert lock_path.read_bytes() == changed_bytes
+
+
+@pytest.mark.parametrize(
+    "provenance",
+    [
+        "packages/local-mcp",
+        ["packages/local-mcp", "legacy-alias"],
+    ],
+)
+def test_legacy_lock_preserves_scalar_or_list_provenance_without_write(
+    tmp_path: Path,
+    provenance: str | list[str],
+) -> None:
+    """Legacy locks without canonical rows remain byte-identical on a no-op."""
+    package = _write_manifest_with_mcp(tmp_path)
+    first_instant = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    second_instant = datetime(2026, 1, 1, 0, 1, 0, tzinfo=timezone.utc)
+    targets = {"claude": ["atlassian"]}
+    _run_lockfile_phase_and_mcp_persist(
+        tmp_path,
+        package,
+        first_instant,
+        mcp_target_servers=targets,
+    )
+    lock_path = get_lockfile_path(tmp_path)
+    legacy = load_yaml(lock_path)
+    legacy.pop("deployments")
+    legacy["mcp_config_provenance"] = {"atlassian": provenance}
+    dump_yaml(legacy, lock_path)
+    legacy_bytes = lock_path.read_bytes()
+    writes: list[Path] = []
+    real_save = LockFile.save
+
+    def track_write(lockfile: LockFile, path: Path) -> None:
+        writes.append(path)
+        real_save(lockfile, path)
+
+    with patch.object(LockFile, "save", track_write):
+        _run_lockfile_phase_and_mcp_persist(
+            tmp_path,
+            package,
+            second_instant,
+            mcp_target_servers=targets,
+        )
+
+    preserved = LockFile.read(lock_path)
+    assert preserved is not None
+    assert writes == []
+    assert lock_path.read_bytes() == legacy_bytes
+    assert preserved.mcp_config_provenance == {"atlassian": provenance}
+
+
+def test_stale_partial_provenance_repairs_once_then_converges(tmp_path: Path) -> None:
+    """A stale list-valued owner is pruned once without an earlier builder write."""
+    package = _write_manifest_with_mcp(tmp_path)
+    first_instant = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    second_instant = datetime(2026, 1, 1, 0, 1, 0, tzinfo=timezone.utc)
+    third_instant = datetime(2026, 1, 1, 0, 2, 0, tzinfo=timezone.utc)
+    targets = {"claude": ["atlassian"]}
+    _run_lockfile_phase_and_mcp_persist(
+        tmp_path,
+        package,
+        first_instant,
+        mcp_target_servers=targets,
+    )
+    lock_path = get_lockfile_path(tmp_path)
+    stale = load_yaml(lock_path)
+    stale["mcp_config_provenance"] = {"departed-server": ["departed-package"]}
+    dump_yaml(stale, lock_path)
+    real_save = LockFile.save
+    repair_writes: list[Path] = []
+
+    def track_repair(lockfile: LockFile, path: Path) -> None:
+        repair_writes.append(path)
+        real_save(lockfile, path)
+
+    with patch.object(LockFile, "save", track_repair):
+        _run_lockfile_phase_and_mcp_persist(
+            tmp_path,
+            package,
+            second_instant,
+            mcp_target_servers=targets,
+        )
+    repaired = LockFile.read(lock_path)
+    assert repaired is not None
+    assert repair_writes == [lock_path]
+    assert repaired.generated_at == second_instant.isoformat()
+    assert repaired.mcp_config_provenance == {}
+    repaired_bytes = lock_path.read_bytes()
+
+    converged_writes: list[Path] = []
+
+    def track_converged(lockfile: LockFile, path: Path) -> None:
+        converged_writes.append(path)
+        real_save(lockfile, path)
+
+    with patch.object(LockFile, "save", track_converged):
+        _run_lockfile_phase_and_mcp_persist(
+            tmp_path,
+            package,
+            third_instant,
+            mcp_target_servers=targets,
+        )
+    assert converged_writes == []
+    assert lock_path.read_bytes() == repaired_bytes
+
+
+def test_lockfile_write_failure_preserves_original_and_reports_error(tmp_path: Path) -> None:
+    """A failed atomic replacement leaves no partial lockfile behind."""
+    package = _write_manifest_with_mcp(tmp_path)
+    first_instant = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    second_instant = datetime(2026, 1, 1, 0, 1, 0, tzinfo=timezone.utc)
+    targets = {"claude": ["atlassian"]}
+    _run_lockfile_phase_and_mcp_persist(
+        tmp_path,
+        package,
+        first_instant,
+        mcp_target_servers=targets,
+    )
+    lock_path = get_lockfile_path(tmp_path)
+    original_bytes = lock_path.read_bytes()
+
+    with patch("apm_cli.utils.atomic_io.os.replace", side_effect=OSError("replace blocked")):
+        context = _run_lockfile_phase_and_mcp_persist(
+            tmp_path,
+            package,
+            second_instant,
+            mcp_target_servers=targets,
+            package_type="skill_bundle",
+        )
+
+    context.diagnostics.error.assert_called_once()
+    context.logger.error.assert_called_once()
+    assert lock_path.read_bytes() == original_bytes
+    assert list(tmp_path.glob("apm-atomic-*")) == []
+
+
+def test_mcp_persistence_write_failure_is_not_hidden(tmp_path: Path) -> None:
+    """The MCP persistence layer must propagate an atomic-write failure."""
+    lock_path = tmp_path / "apm.lock.yaml"
+    lockfile = LockFile(generated_at="2026-01-01T00:00:00+00:00")
+    lockfile.mcp_servers = ["atlassian"]
+    lockfile.mcp_configs = {"atlassian": {"name": "atlassian"}}
+    lockfile.save(lock_path)
+    original_bytes = lock_path.read_bytes()
+
+    with (
+        patch.object(LockFile, "save", side_effect=OSError("replace blocked")),
+        pytest.raises(OSError, match="replace blocked"),
+    ):
+        MCPIntegrator.update_lockfile(
+            {"atlassian"},
+            lock_path,
+            mcp_configs={"atlassian": {"name": "atlassian"}},
+            mcp_target_servers={"codex": ["atlassian"]},
+        )
+
+    assert lock_path.read_bytes() == original_bytes
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        {
+            "lockfile_version": "1",
+            "generated_at": "2026-01-01T00:00:00+00:00",
+            "dependencies": [],
+            "mcp_target_servers": {"codex": "atlassian"},
+        },
+        {
+            "lockfile_version": "1",
+            "generated_at": "2026-01-01T00:00:00+00:00",
+            "dependencies": [],
+            "mcp_config_provenance": {"atlassian": {"owner": "package"}},
+        },
+    ],
+)
+def test_malformed_mcp_lock_state_fails_explicitly(
+    tmp_path: Path,
+    document: dict[str, object],
+) -> None:
+    """Malformed target or provenance state never becomes an empty fallback."""
+    lock_path = tmp_path / "apm.lock.yaml"
+    dump_yaml(document, lock_path)
+
+    with pytest.raises(LockfileFormatError):
+        LockFile.read(lock_path)
+
+
+def test_mcp_serialization_is_deterministic_across_input_order() -> None:
+    """Target, server, and provenance ordering is platform-independent."""
+    first = LockFile(generated_at="2026-01-01T00:00:00+00:00")
+    second = LockFile(generated_at=first.generated_at)
+    first.mcp_servers = ["zeta", "alpha"]
+    second.mcp_servers = ["alpha", "zeta"]
+    first.mcp_configs = {
+        "zeta": {"name": "zeta"},
+        "alpha": {"name": "alpha"},
+    }
+    second.mcp_configs = dict(reversed(list(first.mcp_configs.items())))
+    first.mcp_config_provenance = {
+        "zeta": ["packages/zeta", r"packages\zeta"],
+        "alpha": "packages/alpha",
+    }
+    second.mcp_config_provenance = dict(reversed(list(first.mcp_config_provenance.items())))
+    second.mcp_config_provenance["zeta"] = list(reversed(second.mcp_config_provenance["zeta"]))
+    DeploymentLedgerCodec.replace_mcp_target_servers(
+        first,
+        {"vscode": ["zeta", "alpha"], "codex": ["zeta", "alpha"]},
+    )
+    DeploymentLedgerCodec.replace_mcp_target_servers(
+        second,
+        {"codex": ["alpha", "zeta"], "vscode": ["alpha", "zeta"]},
+    )
+
+    assert first.to_yaml() == second.to_yaml()
 
 
 def test_changed_mcp_dependencies_update_lockfile(tmp_path: Path) -> None:

--- a/tests/unit/install/test_mcp_lockfile_determinism.py
+++ b/tests/unit/install/test_mcp_lockfile_determinism.py
@@ -312,7 +312,7 @@ def test_unchanged_mcp_target_servers_do_not_rewrite_lockfile(tmp_path: Path) ->
         ".github/instructions/dep.instructions.md",
     ) in deployment_rows
     second_context.logger.verbose_detail.assert_any_call(
-        "MCP state unchanged -- carrying forward 1 server, 1 config, 1 runtime mapping"
+        "MCP state unchanged -- carrying forward 1 server, 1 config, 1 target mapping"
     )
 
 
@@ -555,6 +555,12 @@ def test_mcp_persistence_write_failure_is_not_hidden(tmp_path: Path) -> None:
             "generated_at": "2026-01-01T00:00:00+00:00",
             "dependencies": [],
             "mcp_config_provenance": {"atlassian": []},
+        },
+        {
+            "lockfile_version": "1",
+            "generated_at": "2026-01-01T00:00:00+00:00",
+            "dependencies": [],
+            "mcp_config_provenance": {"atlassian": [123]},
         },
     ],
 )

--- a/tests/unit/install/test_mcp_lockfile_determinism.py
+++ b/tests/unit/install/test_mcp_lockfile_determinism.py
@@ -548,6 +548,18 @@ def test_mcp_persistence_write_failure_is_not_hidden(tmp_path: Path) -> None:
             "lockfile_version": "1",
             "generated_at": "2026-01-01T00:00:00+00:00",
             "dependencies": [],
+            "mcp_target_servers": {"": ["atlassian"]},
+        },
+        {
+            "lockfile_version": "1",
+            "generated_at": "2026-01-01T00:00:00+00:00",
+            "dependencies": [],
+            "mcp_target_servers": {"codex": [""]},
+        },
+        {
+            "lockfile_version": "1",
+            "generated_at": "2026-01-01T00:00:00+00:00",
+            "dependencies": [],
             "mcp_config_provenance": {"atlassian": {"owner": "package"}},
         },
         {

--- a/tests/unit/install/test_mcp_lockfile_determinism.py
+++ b/tests/unit/install/test_mcp_lockfile_determinism.py
@@ -301,8 +301,18 @@ def test_unchanged_mcp_target_servers_do_not_rewrite_lockfile(tmp_path: Path) ->
     assert second_lock.generated_at == first_lock.generated_at
     assert second_lock.mcp_target_servers == target_servers
     assert second_bytes == first_bytes
+    deployment_rows = {
+        (record.locator.target, record.locator.runtime, record.locator.value)
+        for record in second_lock.deployment_ledger.records.values()
+    }
+    assert ("mcp", "claude", "atlassian") in deployment_rows
+    assert (
+        "copilot",
+        None,
+        ".github/instructions/dep.instructions.md",
+    ) in deployment_rows
     second_context.logger.verbose_detail.assert_any_call(
-        "MCP state unchanged -- carrying forward 1 server, 1 config, 1 target mapping"
+        "MCP state unchanged -- carrying forward 1 server, 1 config, 1 runtime mapping"
     )
 
 
@@ -489,8 +499,9 @@ def test_lockfile_write_failure_preserves_original_and_reports_error(tmp_path: P
             package_type="skill_bundle",
         )
 
-    context.diagnostics.error.assert_called_once()
-    context.logger.error.assert_called_once()
+    expected_error = "Could not generate apm.lock.yaml: replace blocked"
+    context.diagnostics.error.assert_called_once_with(expected_error)
+    context.logger.error.assert_called_once_with(expected_error)
     assert lock_path.read_bytes() == original_bytes
     assert list(tmp_path.glob("apm-atomic-*")) == []
 
@@ -526,6 +537,12 @@ def test_mcp_persistence_write_failure_is_not_hidden(tmp_path: Path) -> None:
             "generated_at": "2026-01-01T00:00:00+00:00",
             "dependencies": [],
             "mcp_target_servers": {"codex": "atlassian"},
+        },
+        {
+            "lockfile_version": "1",
+            "generated_at": "2026-01-01T00:00:00+00:00",
+            "dependencies": [],
+            "mcp_target_servers": {"codex": [123]},
         },
         {
             "lockfile_version": "1",

--- a/tests/unit/install/test_mcp_lockfile_determinism.py
+++ b/tests/unit/install/test_mcp_lockfile_determinism.py
@@ -302,7 +302,7 @@ def test_unchanged_mcp_target_servers_do_not_rewrite_lockfile(tmp_path: Path) ->
     assert second_lock.mcp_target_servers == target_servers
     assert second_bytes == first_bytes
     second_context.logger.verbose_detail.assert_any_call(
-        "MCP state unchanged -- carrying forward 1 server(s), 1 config(s), 1 target mapping(s)"
+        "MCP state unchanged -- carrying forward 1 server, 1 config, 1 target mapping"
     )
 
 
@@ -532,6 +532,12 @@ def test_mcp_persistence_write_failure_is_not_hidden(tmp_path: Path) -> None:
             "generated_at": "2026-01-01T00:00:00+00:00",
             "dependencies": [],
             "mcp_config_provenance": {"atlassian": {"owner": "package"}},
+        },
+        {
+            "lockfile_version": "1",
+            "generated_at": "2026-01-01T00:00:00+00:00",
+            "dependencies": [],
+            "mcp_config_provenance": {"atlassian": []},
         },
     ],
 )

--- a/tests/utils/isolated_apm_environment.py
+++ b/tests/utils/isolated_apm_environment.py
@@ -29,11 +29,19 @@ _ALLOWED_LOOPBACK_PORTS = {
 }
 
 
+def _normalized_port(port):
+    if isinstance(port, int):
+        return port
+    if isinstance(port, str) and port.isdigit():
+        return int(port)
+    return None
+
+
 def _is_allowed_loopback(address):
     if not isinstance(address, tuple) or len(address) < 2:
         return False
     host, port = address[:2]
-    return host in ("127.0.0.1", "::1") and port in _ALLOWED_LOOPBACK_PORTS
+    return host in ("127.0.0.1", "::1") and _normalized_port(port) in _ALLOWED_LOOPBACK_PORTS
 
 
 class _GuardedSocketOperations:
@@ -89,7 +97,10 @@ def _deny_network(*args, **kwargs):
 
 
 def _guarded_getaddrinfo(host, port, *args, **kwargs):
-    if host not in ("127.0.0.1", "::1") or port not in _ALLOWED_LOOPBACK_PORTS:
+    if (
+        host not in ("127.0.0.1", "::1")
+        or _normalized_port(port) not in _ALLOWED_LOOPBACK_PORTS
+    ):
         raise OSError(_MESSAGE)
     return _REAL_GETADDRINFO(host, port, *args, **kwargs)
 
@@ -137,6 +148,18 @@ socket.gethostbyname_ex = _deny_network
 socket.getnameinfo = _deny_network
 builtins.__import__ = _guarded_import
 importlib.import_module = _guarded_import_module
+
+if os.environ.get("APM_TEST_FAIL_LOCK_REPLACE") == "1":
+    import apm_cli.utils.atomic_io as _atomic_io
+
+    _real_replace = _atomic_io.os.replace
+
+    def _fail_lock_replace(source, destination):
+        if os.path.basename(os.fspath(destination)) == "apm.lock.yaml":
+            raise OSError("lockfile replace blocked by test")
+        return _real_replace(source, destination)
+
+    _atomic_io.os.replace = _fail_lock_replace
 """
 
 _APM_AUTH_ENV_NAMES = frozenset(
@@ -181,6 +204,7 @@ _APM_REMOTE_CONTROL_ENV_NAMES = frozenset(
         "APM_GITLAB_HOSTS",
         "APM_NO_CACHE",
         "APM_POLICY_DISABLE",
+        "APM_TEST_FAIL_LOCK_REPLACE",
         "APM_TEST_LOOPBACK_PORTS",
         "GITHUB_HOST",
         "GITHUB_URL",

--- a/tests/utils/isolated_apm_environment.py
+++ b/tests/utils/isolated_apm_environment.py
@@ -11,6 +11,7 @@ _NETWORK_GUARD = """\
 import _socket
 import builtins
 import importlib
+import os
 import socket
 import sys
 
@@ -19,6 +20,20 @@ _REAL_SOCKET = socket.socket
 _REAL_RAW_SOCKET = _socket.socket
 _REAL_IMPORT = builtins.__import__
 _REAL_IMPORT_MODULE = importlib.import_module
+_REAL_CREATE_CONNECTION = socket.create_connection
+_REAL_GETADDRINFO = _socket.getaddrinfo
+_ALLOWED_LOOPBACK_PORTS = {
+    int(value)
+    for value in os.environ.get("APM_TEST_LOOPBACK_PORTS", "").split(",")
+    if value.isdigit()
+}
+
+
+def _is_allowed_loopback(address):
+    if not isinstance(address, tuple) or len(address) < 2:
+        return False
+    host, port = address[:2]
+    return host in ("127.0.0.1", "::1") and port in _ALLOWED_LOOPBACK_PORTS
 
 
 class _GuardedSocketOperations:
@@ -33,12 +48,12 @@ class _GuardedSocketOperations:
         return super().bind(address)
 
     def connect(self, address):
-        if self.family in (socket.AF_INET, socket.AF_INET6):
+        if self.family in (socket.AF_INET, socket.AF_INET6) and not _is_allowed_loopback(address):
             raise OSError(_MESSAGE)
         return super().connect(address)
 
     def connect_ex(self, address):
-        if self.family in (socket.AF_INET, socket.AF_INET6):
+        if self.family in (socket.AF_INET, socket.AF_INET6) and not _is_allowed_loopback(address):
             raise OSError(_MESSAGE)
         return super().connect_ex(address)
 
@@ -73,10 +88,22 @@ def _deny_network(*args, **kwargs):
     raise OSError(_MESSAGE)
 
 
+def _guarded_getaddrinfo(host, port, *args, **kwargs):
+    if host not in ("127.0.0.1", "::1") or port not in _ALLOWED_LOOPBACK_PORTS:
+        raise OSError(_MESSAGE)
+    return _REAL_GETADDRINFO(host, port, *args, **kwargs)
+
+
+def _guarded_create_connection(address, *args, **kwargs):
+    if not _is_allowed_loopback(address):
+        raise OSError(_MESSAGE)
+    return _REAL_CREATE_CONNECTION(address, *args, **kwargs)
+
+
 def _guard_raw_socket_module(module):
     module.socket = _GuardedRawSocket
     module.SocketType = _GuardedRawSocket
-    module.getaddrinfo = _deny_network
+    module.getaddrinfo = _guarded_getaddrinfo
     module.gethostbyaddr = _deny_network
     module.gethostbyname = _deny_network
     module.gethostbyname_ex = _deny_network
@@ -102,8 +129,8 @@ def _guarded_import_module(name, package=None):
 socket.socket = _GuardedSocket
 socket.SocketType = _GuardedSocket
 _guard_raw_socket_module(_socket)
-socket.create_connection = _deny_network
-socket.getaddrinfo = _deny_network
+socket.create_connection = _guarded_create_connection
+socket.getaddrinfo = _guarded_getaddrinfo
 socket.gethostbyaddr = _deny_network
 socket.gethostbyname = _deny_network
 socket.gethostbyname_ex = _deny_network
@@ -154,6 +181,7 @@ _APM_REMOTE_CONTROL_ENV_NAMES = frozenset(
         "APM_GITLAB_HOSTS",
         "APM_NO_CACHE",
         "APM_POLICY_DISABLE",
+        "APM_TEST_LOOPBACK_PORTS",
         "GITHUB_HOST",
         "GITHUB_URL",
         "GITLAB_HOST",

--- a/tests/utils/local_mcp_registry.py
+++ b/tests/utils/local_mcp_registry.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import threading
+from collections import deque
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -20,7 +21,7 @@ class _RegistryServer(ThreadingHTTPServer):
     def __init__(
         self,
         server_document: Mapping[str, Any],
-        request_paths: list[str],
+        request_paths: deque[str],
     ) -> None:
         self.server_document = dict(server_document)
         self.request_paths = request_paths
@@ -79,7 +80,7 @@ class LocalMcpRegistry:
 
     _server: _RegistryServer
     _thread: threading.Thread
-    request_paths: list[str] = field(default_factory=list)
+    request_paths: deque[str] = field(default_factory=deque)
 
     @property
     def url(self) -> str:
@@ -116,7 +117,7 @@ class LocalMcpRegistryFactory:
         """Start a registry endpoint for one immutable server document."""
         if not isinstance(server_document.get("name"), str):
             raise ValueError("server_document.name must be a string")
-        request_paths: list[str] = []
+        request_paths: deque[str] = deque()
         server = _RegistryServer(server_document, request_paths)
         thread = threading.Thread(
             target=server.serve_forever,

--- a/tests/utils/local_mcp_registry.py
+++ b/tests/utils/local_mcp_registry.py
@@ -1,0 +1,134 @@
+"""Local MCP Registry v0.1 fixtures for real-binary lifecycle tests."""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+
+class _RegistryServer(ThreadingHTTPServer):
+    """HTTP server carrying one immutable MCP Registry server document."""
+
+    daemon_threads = True
+
+    def __init__(
+        self,
+        server_document: Mapping[str, Any],
+        request_paths: list[str],
+    ) -> None:
+        self.server_document = dict(server_document)
+        self.request_paths = request_paths
+        super().__init__(("127.0.0.1", 0), _RegistryRequestHandler)
+
+
+class _RegistryRequestHandler(BaseHTTPRequestHandler):
+    """Serve the search and detail routes used by ``SimpleRegistryClient``."""
+
+    server: _RegistryServer
+
+    def do_GET(self) -> None:
+        """Return one v0.1 search or detail response."""
+        parsed = urlparse(self.path)
+        self.server.request_paths.append(self.path)
+        if parsed.path == "/v0.1/servers":
+            payload = {
+                "servers": [
+                    {
+                        "server": {
+                            "name": self.server.server_document["name"],
+                            "description": self.server.server_document.get("description", ""),
+                        }
+                    }
+                ],
+                "metadata": {},
+            }
+            self._write_json(200, payload)
+            return
+
+        prefix = "/v0.1/servers/"
+        suffix = "/versions/latest"
+        if parsed.path.startswith(prefix) and parsed.path.endswith(suffix):
+            encoded_name = parsed.path[len(prefix) : -len(suffix)]
+            if unquote(encoded_name) == self.server.server_document["name"]:
+                self._write_json(200, {"server": self.server.server_document})
+                return
+        self._write_json(404, {"error": "not found"})
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        """Keep lifecycle output deterministic and quiet."""
+
+    def _write_json(self, status: int, payload: Mapping[str, Any]) -> None:
+        """Write one compact JSON response."""
+        body = json.dumps(payload, sort_keys=True).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+@dataclass
+class LocalMcpRegistry:
+    """One bounded in-process MCP Registry v0.1 endpoint."""
+
+    _server: _RegistryServer
+    _thread: threading.Thread
+    request_paths: list[str] = field(default_factory=list)
+
+    @property
+    def url(self) -> str:
+        """Return the loopback endpoint accepted by ``registry``."""
+        host, port = self._server.server_address
+        return f"http://{host}:{port}"
+
+    def close(self) -> None:
+        """Stop the endpoint and wait for its serving thread."""
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+        if self._thread.is_alive():
+            raise RuntimeError("local MCP registry thread did not stop")
+
+    def __enter__(self) -> LocalMcpRegistry:
+        """Return the running registry."""
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        """Stop the registry."""
+        self.close()
+
+
+class LocalMcpRegistryFactory:
+    """Create isolated registry endpoints from authored v0.1 documents."""
+
+    def __init__(self, root: Path) -> None:
+        """Reserve a scenario-owned root for registry fixture state."""
+        root.mkdir(parents=True, exist_ok=False)
+        self._root = root
+
+    def start(self, server_document: Mapping[str, Any]) -> LocalMcpRegistry:
+        """Start a registry endpoint for one immutable server document."""
+        if not isinstance(server_document.get("name"), str):
+            raise ValueError("server_document.name must be a string")
+        request_paths: list[str] = []
+        server = _RegistryServer(server_document, request_paths)
+        thread = threading.Thread(
+            target=server.serve_forever,
+            name=f"mcp-registry-{self._root.name}",
+            daemon=True,
+        )
+        thread.start()
+        if not thread.is_alive():
+            server.server_close()
+            raise RuntimeError("local MCP registry thread did not start")
+        return LocalMcpRegistry(
+            _server=server,
+            _thread=thread,
+            request_paths=request_paths,
+        )

--- a/tests/utils/local_mcp_registry.py
+++ b/tests/utils/local_mcp_registry.py
@@ -91,7 +91,7 @@ class LocalMcpRegistry:
         """Stop the endpoint and wait for its serving thread."""
         self._server.shutdown()
         self._server.server_close()
-        self._thread.join(timeout=5)
+        self._thread.join(timeout=10)
         if self._thread.is_alive():
             raise RuntimeError("local MCP registry thread did not stop")
 
@@ -123,7 +123,11 @@ class LocalMcpRegistryFactory:
             name=f"mcp-registry-{self._root.name}",
             daemon=True,
         )
-        thread.start()
+        try:
+            thread.start()
+        except Exception:
+            server.server_close()
+            raise
         if not thread.is_alive():
             server.server_close()
             raise RuntimeError("local MCP registry thread did not start")


### PR DESCRIPTION
# fix(install): preserve MCP target mappings before no-change writes

## TL;DR

This supersedes #2301 while preserving @rrazvd's authorship. It carries MCP target and deployment state through `DeploymentLedgerCodec` before `LockfileBuilder` decides whether to write, so unchanged install, update, frozen, and audit lifecycles leave `apm.lock.yaml` byte-identical. Real target changes still produce one meaningful timestamp/state transition and then converge.

> [!NOTE]
> Supersedes #2301 and closes #2297. It does not absorb #2298/#2307 target-selection semantics.

## Problem (WHY)

- [x] Repeating `apm install` with unchanged explicit MCP targets rewrote `apm.lock.yaml` and advanced `generated_at`.
- [x] `LockfileBuilder` dropped `mcp_target_servers` before its earliest semantic comparison, while `MCPIntegrator` repaired the content only after a needless write.
- [x] Byte equality alone could hide an unnecessary same-bytes atomic replacement.
- [!] Legacy locks, list-valued provenance, redirected roots, frozen/audit paths, and write failures lacked one installed-binary convergence proof.
- [!] Direct target-state mutation outside `DeploymentLedgerCodec` had no executable repository-wide boundary check.

Why this matters: lockfile determinism serves **Governed by policy**, while quiet repeat installs serve **DevX**. The evidence is tool-grounded because PROSE says ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)

## Approach (WHAT)

| # | Fix |
|---|---|
| 1 | Restore local compatibility state first, then carry MCP target mappings through `DeploymentLedgerCodec.replace_mcp_target_servers()` before `_write_if_changed()`. |
| 2 | Normalize scalar/list MCP provenance deterministically and reject malformed or empty target/provenance identifiers. |
| 3 | Re-raise MCP lock persistence failures so install exits non-zero instead of returning success-shaped output. |
| 4 | Add an AST boundary guard for direct deployment compatibility-state mutation and wire it into architecture lint. |
| 5 | Exercise installed binaries through isolated local package and MCP registry fixtures, exact snapshots, mtime/inode checks, update/frozen/audit, target contraction, and fault injection. |
| 6 | Adopt the marker-derived lifecycle topology from #2307/#2390: module-level markers, dynamic set invariants, AC22, and the three-minute bound remain canonical. |

## Implementation (HOW)

| Files | Intent |
|---|---|
| `src/apm_cli/install/phases/lockfile.py` | Preserves complete local/MCP state before the earliest write decision and reports exact verbose counts. |
| `src/apm_cli/deps/lockfile.py` | Validates scalar/list provenance and target mappings, normalizes owner-list ordering for serialization and semantic equality. |
| `src/apm_cli/integration/mcp_integrator.py` | Keeps no-op reconciliation silent and propagates malformed-lock/atomic-write failures. |
| `scripts/check_deployment_state_mutations.py`, `scripts/lint-architecture-boundaries.sh` | Make codec ownership an executable CI boundary. |
| `tests/unit/core/test_deployment_owner_invariant.py`, `tests/integration/test_architecture_authorities.py` | Share the checker and prove a direct assignment is rejected. |
| `tests/unit/install/test_mcp_lockfile_determinism.py`, `tests/test_lockfile.py` | Prove zero writes, one-write convergence, legacy/list provenance, malformed input, deterministic ordering, and atomic failure behavior. |
| `tests/integration/test_install_mcp_lockfile_determinism.py` | Runs real installed CLI lifecycles for local packages, redirected roots, a port-scoped local registry, user-authored configs, frozen/audit no-write, and injected write failure. |
| `tests/utils/isolated_apm_environment.py`, `tests/utils/local_mcp_registry.py` | Provide isolated roots, external-network denial with one port-scoped loopback exception, and deterministic local registry state. |
| `tests/quality/test_ci_topology.py`, `.github/workflows/ci.yml` | Preserve collection-derived lifecycle set invariants and the three-minute runtime budget without central counts or membership lists. |
| `docs/src/content/docs/contributing/integration-testing.md`, `CHANGELOG.md` | Keep contributor contracts and the user-visible no-spurious-diff fix current. |
| `.apm/instructions/architecture.instructions.md`, `.github/instructions/architecture.instructions.md` | Document the bounded AST guard's alias-dataflow limitation. |

## Diagrams

Legend: the highlighted exchange is the new pre-comparison carry-forward; the write branch remains meaningful-change-only.

```mermaid
sequenceDiagram
    participant Install as apm install
    participant Builder as LockfileBuilder
    participant Codec as DeploymentLedgerCodec
    participant Lock as apm.lock.yaml
    participant MCP as MCPIntegrator

    Install->>Builder: rebuild from current manifest
    Builder->>Codec: restore local compatibility state
    rect rgb(255, 247, 200)
        Note over Builder,Codec: NEW: preserve target mappings before comparison
        Builder->>Codec: replace_mcp_target_servers
        Codec-->>Builder: synchronized mappings and deployment rows
    end
    Builder->>Lock: semantic comparison
    alt unchanged
        Builder-->>Install: skip write
    else meaningful change
        Builder->>Lock: atomic write
    end
    Install->>MCP: reconcile current MCP view
    MCP-->>Install: skip or one meaningful write
```

## Trade-offs

- **Preserve before comparison, not after.** Chose the builder's earliest decision point; rejected a second corrective write because final-byte equality does not prove no write occurred.
- **Reuse the codec owner.** Chose `DeploymentLedgerCodec`; rejected direct assignment because target mappings and canonical rows must move together.
- **Fail closed on persistence errors.** Chose a non-zero install result; rejected debug-only swallowing that can leave stale lock state looking successful.
- **Bound local network narrowly.** Chose one OS-assigned loopback port for the registry fixture while denying external sockets; rejected disabling the test network guard wholesale.
- **Keep target selection out of scope.** This PR tests explicit target transitions but does not change precedence/discovery semantics owned by #2307.

## Benefits

1. Unchanged install, update, frozen, and audit flows perform zero lockfile replacements and preserve exact bytes.
2. A real target change produces exactly one lock write/timestamp transition; the next run performs zero writes.
3. Legacy locks and scalar/list provenance converge without migration churn; malformed state fails explicitly.
4. User-authored Copilot/Codex configs survive no-op and target-contraction lifecycles.
5. CI rejects direct `mcp_target_servers` mutation outside canonical owners.

## Validation

`APM_E2E_TESTS=1 uv run --frozen --extra dev pytest -q tests/integration/test_install_mcp_lockfile_determinism.py tests/unit/install/test_mcp_lockfile_determinism.py tests/unit/core/test_deployment_owner_invariant.py tests/integration/test_architecture_authorities.py::test_deployment_compatibility_state_has_single_owner tests/integration/test_architecture_authorities.py::test_deployment_state_guard_rejects_direct_mcp_target_assignment tests/integration/test_architecture_authorities.py::test_legacy_user_deployment_scope_has_single_owner tests/quality/test_test_taxonomy.py::test_tm002_marker_only_taxonomy_is_non_empty_and_uniform tests/quality/test_ci_topology.py::test_lifecycle_smoke_is_required_and_hermetic`:

```text
..........................................                               [100%]
42 passed in 262.51s (0:04:22)
```

<details><summary>Full required lint mirror and hosted CI</summary>

```text
All checks passed!
1564 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
[+] architecture boundary lint clean (AC1-AC24, including AC22)
FINAL_QUICK_LINT_MIRROR=PASS
```

Hosted run `30626075053` evaluated exact head `4cd5f0f0d9e2d32170a8fb28f0af02b3374d1a5e`; every required check passed. Lifecycle Smoke completed in 1m51s under the canonical three-minute budget.

</details>

<details><summary>Mutation-break evidence</summary>

Removing the codec carry-forward produced three expected failures: installed bytes changed, `generated_at` advanced, and the real-change run performed two writes instead of one.

```text
3 failed in 2.40s
EXACT_HEAD_CARRY_MUTATION_FAILURE=1
```

Replacing the codec call with direct assignment failed both the static checker and matching architecture tests.

```text
install/phases/lockfile.py:447
2 failed in 2.24s
EXACT_HEAD_CODEC_BYPASS_FAILURE checker=1 tests=1
```

</details>

### Lifecycle gate impact

| Measurement | Evidence |
|---|---|
| Classification | Module-level `pytestmark = pytest.mark.e2e` plus function-level `lifecycle_smoke` markers |
| Membership authority | Collection-derived sets; no central count or membership list |
| Required relationship | `required == full - merge_group`, disjoint, non-empty, duplicate-free |
| Runtime bound | Three minutes; hosted exact-head lifecycle completed in 1m51s |
| Static authority | AC22 rejects parallel taxonomy manifests and hard-coded lifecycle membership |

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|---|---|---|---|
| 1 | Repeating unchanged install/update/frozen/audit leaves the MCP lockfile byte-identical and does not replace it. | Governed by policy, DevX | `tests/integration/test_install_mcp_lockfile_determinism.py::test_installed_mcp_lifecycle_is_no_write_until_real_target_change` (regression-trap for #2297)<br/>`tests/unit/install/test_mcp_lockfile_determinism.py::test_unchanged_mcp_target_servers_do_not_rewrite_lockfile` | e2e + unit |
| 2 | One explicit target change writes once, updates timestamp/state, then converges on the next run. | Governed by policy, DevX | `tests/integration/test_install_mcp_lockfile_determinism.py::test_installed_mcp_lifecycle_is_no_write_until_real_target_change`<br/>`tests/unit/install/test_mcp_lockfile_determinism.py::test_real_mcp_target_change_writes_once_then_converges` | e2e + unit |
| 3 | A redirected project root using a local MCP registry converges without rewrite or source-manifest mutation. | Portability by manifest, Multi-harness support | `tests/integration/test_install_mcp_lockfile_determinism.py::test_redirected_root_registry_install_converges_without_rewrite` | e2e |
| 4 | Legacy scalar/list provenance is preserved; stale provenance repairs once; malformed state fails closed. | Secure by default, Governed by policy | `tests/unit/install/test_mcp_lockfile_determinism.py::test_legacy_lock_preserves_scalar_or_list_provenance_without_write`<br/>`::test_stale_partial_provenance_repairs_once_then_converges`<br/>`::test_malformed_mcp_lock_state_fails_explicitly` | unit |
| 5 | An atomic MCP lock write failure exits non-zero and leaves no partial lockfile. | Secure by default, DevX | `tests/integration/test_install_mcp_lockfile_determinism.py::test_installed_mcp_write_failure_exits_nonzero_without_partial_lock`<br/>`tests/unit/install/test_mcp_lockfile_determinism.py::test_mcp_persistence_write_failure_is_not_hidden` | e2e + unit |
| 6 | A direct target-state assignment outside the codec is rejected in CI. | Governed by policy | `tests/integration/test_architecture_authorities.py::test_deployment_state_guard_rejects_direct_mcp_target_assignment` | integration |

## How to test

- [ ] Run the targeted command above; expect 42 passing tests.
- [ ] Run the marker-derived lifecycle check; expect dynamic set invariants to pass within three minutes.
- [ ] Repeat unchanged install/update/frozen/audit; expect identical lock bytes and unchanged mtime/inode.
- [ ] Change explicit targets once; expect one write and then zero writes on the next run.
- [ ] Run both architecture guards; expect direct target-state assignment to fail.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
