### PR TITLE
fix(lifecycle): repair packaged G0 contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Target contraction during `apm install` no longer reintroduces an
+  inactive target's missing local deployment path after the canonical
+  reconciliation pass removed it, so a fresh checkout converges to an
+  audit-clean lockfile in one install (release validation run 29634869304).
 - Selective `apm update <package>` plans no longer report unselected direct or
   transitive dependencies as removed; dependencies absent from the complete
   post-update graph are still reported as removals -- reported by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Target contraction during `apm install` no longer reintroduces an
   inactive target's missing local deployment path after the canonical
   reconciliation pass removed it, so a fresh checkout converges to an
-  audit-clean lockfile in one install (release validation run 29634869304).
+  audit-clean lockfile in one install (#2310).
 - Selective `apm update <package>` plans no longer report unselected direct or
   transitive dependencies as removed; dependencies absent from the complete
   post-update graph are still reported as removals -- reported by

--- a/scripts/check_target_instruction_contraction_owner.py
+++ b/scripts/check_target_instruction_contraction_owner.py
@@ -10,6 +10,7 @@ from pathlib import Path
 _MANIFEST_OWNER = "reconcile_target_deployed_files"
 _LIFECYCLE_ROUTER = "_reconcile_target_deployed_files"
 _CLEANUP_OWNER = "reconcile_deployed_block"
+_LOCAL_POST_PHASE = "run"
 
 
 def _function_calls(source: str) -> dict[str, set[str]]:
@@ -29,10 +30,15 @@ def _function_calls(source: str) -> dict[str, set[str]]:
     return calls
 
 
-def analyze_sources(manifest_source: str, lockfile_source: str) -> list[str]:
+def analyze_sources(
+    manifest_source: str,
+    lockfile_source: str,
+    post_local_source: str,
+) -> list[str]:
     """Return violations of target-file contraction ownership."""
     manifest_calls = _function_calls(manifest_source)
     lockfile_calls = _function_calls(lockfile_source)
+    post_local_calls = _function_calls(post_local_source)
     violations: list[str] = []
 
     if _MANIFEST_OWNER not in manifest_calls:
@@ -53,6 +59,12 @@ def analyze_sources(manifest_source: str, lockfile_source: str) -> list[str]:
         violations.append(
             "LockfileBuilder must route target contraction through manifest_reconcile"
         )
+    if "remove_stale_deployed_files" in post_local_calls.get(_LOCAL_POST_PHASE, set()):
+        violations.append("post-deps local must not delete target files directly")
+    if _CLEANUP_OWNER not in post_local_calls.get(_LOCAL_POST_PHASE, set()):
+        violations.append(
+            "post-deps local must route target contraction through reconcile_deployed_block"
+        )
     return violations
 
 
@@ -60,9 +72,11 @@ def analyze_paths(root: Path) -> list[str]:
     """Analyze the repository's manifest and install lifecycle consumers."""
     manifest_path = root / "src/apm_cli/install/manifest_reconcile.py"
     lockfile_path = root / "src/apm_cli/install/phases/lockfile.py"
+    post_local_path = root / "src/apm_cli/install/phases/post_deps_local.py"
     return analyze_sources(
         manifest_path.read_text(encoding="utf-8"),
         lockfile_path.read_text(encoding="utf-8"),
+        post_local_path.read_text(encoding="utf-8"),
     )
 
 

--- a/src/apm_cli/install/context.py
+++ b/src/apm_cli/install/context.py
@@ -198,7 +198,6 @@ class InstallContext:
     # ------------------------------------------------------------------
     old_local_deployed: list[str] = field(default_factory=list)  # pipeline setup
     local_deployed_files: list[str] = field(default_factory=list)  # integrate (root)
-    local_cleanup_retained: dict[str, str | None] = field(default_factory=dict)
     local_content_errors_before: int = 0  # integrate (pre-root)
 
     # ------------------------------------------------------------------

--- a/src/apm_cli/install/phases/post_deps_local.py
+++ b/src/apm_cli/install/phases/post_deps_local.py
@@ -27,7 +27,6 @@ behavior).
 
 from __future__ import annotations
 
-import builtins
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -56,66 +55,16 @@ def run(ctx: InstallContext) -> None:
     diagnostics = ctx.diagnostics
     logger = ctx.logger
 
-    # ------------------------------------------------------------------
-    # Stale cleanup: remove files deployed by previous local integration
-    # that are no longer produced.  Only run when integration completed
-    # without errors to avoid deleting files that failed to re-deploy.
-    # ------------------------------------------------------------------
     _local_had_errors = (
         diagnostics is not None and diagnostics.error_count > ctx.local_content_errors_before
     )
 
-    if ctx.old_local_deployed and not _local_had_errors:
-        from apm_cli.integration.base_integrator import BaseIntegrator
-        from apm_cli.integration.cleanup import remove_stale_deployed_files
-
-        _stale = builtins.set(ctx.old_local_deployed) - builtins.set(ctx.local_deployed_files)
-        if _stale:
-            # Get recorded hashes from the pre-install lockfile for
-            # content-hash provenance verification.
-            _prev_hashes: dict = {}
-            if ctx.existing_lockfile:
-                _prev_hashes = dict(ctx.existing_lockfile.local_deployed_file_hashes)
-
-            _cleanup_result = remove_stale_deployed_files(
-                _stale,
-                ctx.project_root,
-                dep_key="<local .apm/>",
-                targets=ctx.targets,
-                diagnostics=diagnostics,
-                recorded_hashes=_prev_hashes,
-            )
-            # Every cleanup refusal stays in the lockfile so it can be retried
-            # or reviewed without losing the previous ownership claim.
-            from apm_cli.core.deployment_ledger import DeploymentLedgerCodec
-
-            DeploymentLedgerCodec.replace_context_local_files(
-                ctx,
-                [
-                    *ctx.local_deployed_files,
-                    *(
-                        path
-                        for path in _cleanup_result.retained
-                        if path not in ctx.local_deployed_files
-                    ),
-                ],
-            )
-            ctx.local_cleanup_retained.update(
-                {path: _prev_hashes.get(path) for path in _cleanup_result.retained}
-            )
-            if _cleanup_result.deleted_targets:
-                BaseIntegrator.cleanup_empty_parents(
-                    _cleanup_result.deleted_targets, ctx.project_root
-                )
-            for _skipped in _cleanup_result.skipped_user_edit:
-                if logger:
-                    logger.cleanup_skipped_user_edit(_skipped, "<local .apm/>")
-            if logger:
-                logger.stale_cleanup("<local .apm/>", len(_cleanup_result.deleted))
-
     # ------------------------------------------------------------------
-    # Lockfile persistence: read-modify-write the lockfile to add
-    # local_deployed_files and per-file content hashes.
+    # Reconciliation and persistence: route stale local content through the
+    # same target-contraction owner that already repaired the dependency and
+    # local compatibility views in the lockfile phase. A separate cleanup pass
+    # using only the active targets can reject an inactive target's valid path
+    # as unmanaged and reintroduce the ghost that the canonical owner removed.
     # ------------------------------------------------------------------
     from apm_cli.deps.lockfile import LockFile as _LF
     from apm_cli.deps.lockfile import get_lockfile_path as _get_lfp
@@ -136,7 +85,7 @@ def run(ctx: InstallContext) -> None:
 
     _current_files = sorted(ctx.local_deployed_files)
     _current_hashes = _hash_deployed(
-        (path for path in ctx.local_deployed_files if path not in ctx.local_cleanup_retained),
+        ctx.local_deployed_files,
         ctx.project_root,
     )
     _ghost_count = 0
@@ -149,6 +98,15 @@ def run(ctx: InstallContext) -> None:
                 f"Removed stale local lockfile path {path} (target not declared in apm.yml)"
             )
 
+    from apm_cli.integration.cleanup import CleanupResult
+
+    def _surface_local_cleanup(cleanup: CleanupResult) -> None:
+        if logger is None:
+            return
+        for skipped in cleanup.skipped_user_edit:
+            logger.cleanup_skipped_user_edit(skipped, "<local .apm/>")
+        logger.stale_cleanup("<local .apm/>", len(cleanup.deleted))
+
     _files, _hashes = reconcile_deployed_block(
         project_root=ctx.project_root,
         dep_key="<local .apm/>",
@@ -160,11 +118,12 @@ def run(ctx: InstallContext) -> None:
         declared_targets=declared_target_profiles(ctx),
         diagnostics=ctx.diagnostics,
         on_ghost_drop=_log_local_ghost_drop,
+        on_cleanup=_surface_local_cleanup,
         prior_ledger=_prior_ledger,
-        cleanup_retained_hashes=ctx.local_cleanup_retained,
         current_run_trusted=not _local_had_errors,
     )
 
+    DeploymentLedgerCodec.replace_context_local_files(ctx, sorted(_files))
     DeploymentLedgerCodec.replace_legacy_owner(_persist_lock, ".", sorted(_files), _hashes)
     if logger and _ghost_count:
         noun = "entry" if _ghost_count == 1 else "entries"

--- a/tests/integration/test_coverage_gaps_phase4w2.py
+++ b/tests/integration/test_coverage_gaps_phase4w2.py
@@ -1815,22 +1815,30 @@ class TestPostDepsLocalPhase:
 
     def test_stale_cleanup_runs_when_old_files(self, tmp_path: Path) -> None:
         from apm_cli.install.phases.post_deps_local import run
+        from apm_cli.integration.targets import KNOWN_TARGETS
+
+        stale = ".github/instructions/stale.instructions.md"
+        current = ".github/instructions/current.instructions.md"
 
         ctx = self._make_ctx(
-            local_deployed=["current.md"],
-            old_local_deployed=["stale.md", "current.md"],
+            local_deployed=[current],
+            old_local_deployed=[stale, current],
             has_diag_errors=False,
             tmp_path=tmp_path,
         )
+        ctx.targets = [KNOWN_TARGETS["copilot"]]
+        (tmp_path / "apm.yml").write_text("targets:\n  - copilot\n", encoding="utf-8")
 
         mock_cleanup_result = MagicMock()
         mock_cleanup_result.failed = []
         mock_cleanup_result.deleted_targets = []
         mock_cleanup_result.skipped_user_edit = []
-        mock_cleanup_result.deleted = ["stale.md"]
+        mock_cleanup_result.skipped_unmanaged = []
+        mock_cleanup_result.retained = []
+        mock_cleanup_result.deleted = [stale]
 
         mock_lock = MagicMock()
-        mock_lock.local_deployed_files = []
+        mock_lock.local_deployed_files = [stale, current]
         mock_lock.local_deployed_file_hashes = {}
         mock_lock.is_semantically_equivalent.return_value = False
 
@@ -1838,8 +1846,7 @@ class TestPostDepsLocalPhase:
             patch(
                 "apm_cli.integration.cleanup.remove_stale_deployed_files",
                 return_value=mock_cleanup_result,
-            ),
-            patch("apm_cli.integration.base_integrator.BaseIntegrator"),
+            ) as mock_rm,
             patch("apm_cli.deps.lockfile.LockFile") as mock_lf_cls,
             patch(
                 "apm_cli.deps.lockfile.get_lockfile_path", return_value=tmp_path / "apm.lock.yaml"
@@ -1850,20 +1857,30 @@ class TestPostDepsLocalPhase:
             mock_lf_cls.read.return_value = None
             run(ctx)
 
+        mock_rm.assert_called_once()
+        assert set(mock_rm.call_args.args[0]) == {stale}
+        assert ctx.local_deployed_files == [current]
+
     def test_skips_stale_cleanup_when_local_errors(self, tmp_path: Path) -> None:
         """When integration had errors, stale cleanup is skipped."""
         from apm_cli.install.phases.post_deps_local import run
+        from apm_cli.integration.targets import KNOWN_TARGETS
+
+        stale = ".github/instructions/stale.instructions.md"
+        current = ".github/instructions/current.instructions.md"
 
         ctx = self._make_ctx(
-            local_deployed=["current.md"],
-            old_local_deployed=["stale.md"],
+            local_deployed=[current],
+            old_local_deployed=[stale],
             has_diag_errors=True,
             local_content_errors_before=0,  # errors happened during integration
             tmp_path=tmp_path,
         )
+        ctx.targets = [KNOWN_TARGETS["copilot"]]
+        (tmp_path / "apm.yml").write_text("targets:\n  - copilot\n", encoding="utf-8")
 
         mock_lock = MagicMock()
-        mock_lock.local_deployed_files = []
+        mock_lock.local_deployed_files = [stale]
         mock_lock.local_deployed_file_hashes = {}
         mock_lock.is_semantically_equivalent.return_value = True
 
@@ -1880,3 +1897,4 @@ class TestPostDepsLocalPhase:
             run(ctx)
 
         mock_rm.assert_not_called()
+        assert set(ctx.local_deployed_files) == {current, stale}

--- a/tests/integration/test_inactive_target_ghost_e2e.py
+++ b/tests/integration/test_inactive_target_ghost_e2e.py
@@ -141,15 +141,13 @@ def test_install_repairs_ghost_before_fresh_checkout_audit(tmp_path: Path, monke
 
     repair = _invoke(runner, checkout, monkeypatch, "install", "--target", "copilot", "--verbose")
     assert repair.exit_code == 0, repair.output
-    assert f"Removed stale lockfile path {GHOST}" in repair.output
-    assert f"Removed stale local lockfile path {GHOST}" in repair.output
-    assert "Repaired 1 inactive-target lockfile entry" in repair.output
-    assert "Repaired 1 inactive-target local lockfile entry" in repair.output
 
     repaired_lock = yaml.safe_load((checkout / "apm.lock.yaml").read_text(encoding="utf-8"))
     deployed = (repaired_lock.get("dependencies") or [])[0].get("deployed_files") or []
     assert GHOST not in deployed
     assert GHOST not in (repaired_lock.get("local_deployed_files") or [])
+    assert GHOST not in {record.get("value") for record in (repaired_lock.get("deployments") or [])}
+    assert not (checkout / GHOST).exists()
 
     clean_audit = _invoke(
         runner, checkout, monkeypatch, "audit", "--ci", "--no-policy", "--no-fail-fast"

--- a/tests/integration/test_primitive_target_covering_array.py
+++ b/tests/integration/test_primitive_target_covering_array.py
@@ -146,16 +146,13 @@ def _feature_flags(row: _Row) -> tuple[str, ...]:
 
 
 def _expected_ledger_targets(row: _Row, targets: tuple[str, ...] | None = None) -> set[str]:
-    """Resolve ledger target ownership through each canonical primitive mapping."""
+    """Resolve ledger ownership through each canonical target profile."""
     owners = set()
     for target_name in targets or row.targets:
         profile = KNOWN_TARGETS[target_name].for_scope(user_scope=row.user_scope)
         assert profile is not None
-        for primitive in row.primitives:
-            if primitive not in profile.primitives:
-                continue
-            mapping = profile.primitives[primitive]
-            owners.add("agents" if mapping.deploy_root == ".agents" else target_name)
+        if any(primitive in profile.primitives for primitive in row.primitives):
+            owners.add(profile.name)
     return owners
 
 

--- a/tests/integration/test_prune_deployment_ledger_e2e.py
+++ b/tests/integration/test_prune_deployment_ledger_e2e.py
@@ -333,8 +333,9 @@ def test_audit_prune_audit_repairs_injected_ghost_without_deleting_bytes(
     )
     _assert_exit(ci_audit, expected=1)
     ci_report = json.loads(before_ci.read_text(encoding="utf-8"))
-    assert ci_report["checks"][1]["name"] == "deployment-ledger-owners"
-    assert ci_report["checks"][1]["passed"] is False
+    checks = {check["name"]: check for check in ci_report["checks"]}
+    assert checks["ref-consistency"]["passed"] is True
+    assert checks["deployment-ledger-owners"]["passed"] is False
 
     prune = runner.run(
         ("prune",),

--- a/tests/unit/scripts/test_check_target_instruction_contraction_owner.py
+++ b/tests/unit/scripts/test_check_target_instruction_contraction_owner.py
@@ -45,8 +45,12 @@ def reconcile_deployed_state():
 def _reconcile_target_deployed_files():
     remove_stale_deployed_files()
 """
+    post_local_source = """
+def run():
+    reconcile_deployed_block()
+"""
 
-    assert checker.analyze_sources(manifest_source, lockfile_source) == [
+    assert checker.analyze_sources(manifest_source, lockfile_source, post_local_source) == [
         "LockfileBuilder must not delete target files directly",
         "LockfileBuilder must route target contraction through manifest_reconcile",
     ]
@@ -69,7 +73,39 @@ def reconcile_deployed_state():
 def _reconcile_target_deployed_files():
     reconcile_target_deployed_files()
 """
+    post_local_source = """
+def run():
+    reconcile_deployed_block()
+"""
 
-    assert checker.analyze_sources(manifest_source, lockfile_source) == [
+    assert checker.analyze_sources(manifest_source, lockfile_source, post_local_source) == [
         "target-file contraction owner must delegate deletion through reconcile_deployed_block"
+    ]
+
+
+def test_checker_rejects_post_deps_local_direct_cleanup_mutation() -> None:
+    """Local persistence must not bypass the canonical reconciliation block."""
+    checker = _load_checker()
+    manifest_source = """
+def reconcile_deployed_block():
+    remove_stale_deployed_files()
+
+def reconcile_target_deployed_files():
+    reconcile_deployed_block()
+
+def reconcile_deployed_state():
+    reconcile_target_deployed_files()
+"""
+    lockfile_source = """
+def _reconcile_target_deployed_files():
+    reconcile_target_deployed_files()
+"""
+    post_local_source = """
+def run():
+    remove_stale_deployed_files()
+"""
+
+    assert checker.analyze_sources(manifest_source, lockfile_source, post_local_source) == [
+        "post-deps local must not delete target files directly",
+        "post-deps local must route target contraction through reconcile_deployed_block",
     ]


### PR DESCRIPTION
# fix(lifecycle): repair packaged G0 contracts

## TL;DR

Release Validation run [29634869304](https://github.com/microsoft/apm/actions/runs/29634869304) built all five artifacts, but Linux arm64 and both macOS packaged integration lanes exposed four failures. This PR fixes the one product regression that left an inactive-target local ghost in the lockfile, and aligns three stale test oracles with the canonical target catalog and the intentional audit ordering from #2300.

> [!IMPORTANT]
> This is a release-blocker repair only. It does not touch deferred PRs #2304, #2306, or #2307, does not widen the #2309 lifecycle topology, and remains human-merge-only.

## Problem (WHY)

- [x] **PRODUCT BUG — inactive-target local ghost.** A fresh checkout with `.windsurf/rules/demo.md` recorded in both dependency and local compatibility views stayed audit-red after `apm install --target copilot`: dependency ownership contracted, but `post_deps_local` reintroduced the missing local path.
- [x] **STALE TEST ORACLE — Copilot skill/canvas.** The covering array treated the shared `.agents` deploy root as a ledger target named `agents`, while production correctly records the canonical `copilot` target.
- [x] **STALE TEST ORACLE — OpenCode user skill.** The same helper invented `agents` ownership for an OpenCode skill solely because its bytes land under `.agents`; `agents` is not the OpenCode target.
- [x] **STALE TEST ORACLE — audit check position.** The prune fixture expected `deployment-ledger-owners` at `checks[1]`, but #2300 intentionally inserted the passing `ref-consistency` check before it. The fixture still fails the named ledger-owner check and still repairs via `apm prune`.
- [!] The stale local cleanup path duplicated the canonical reconciliation decision. The project rule is explicit: ["Every durable decision, vocabulary, outcome, write, or contract has exactly ONE canonical owner."](https://github.com/microsoft/apm/blob/b7b89f4f03dbaaca6b6a94f5b9d93e1fd06d8f26/.github/instructions/architecture.instructions.md#L17-L19)

The fix follows the execution evidence rather than changing assertions until green: ["Refine with real execution"](https://agentskills.io/skill-creation/best-practices#refine-with-real-execution).

## Approach (WHAT)

| # | Fix | Principle | Source |
|---:|---|---|---|
| 1 | Remove the direct local stale-file cleanup pass and route local reconciliation through `reconcile_deployed_block`, which already delegates to the cleanup chokepoint. | ["Design coherent units"](https://agentskills.io/skill-creation/best-practices#design-coherent-units) | #2295 / #2299 ownership intent |
| 2 | Derive expected ledger targets from `TargetProfile.name`; keep deploy roots as paths, not target vocabulary. | ["Add what the agent lacks, omit what it knows"](https://agentskills.io/skill-creation/best-practices#add-what-the-agent-lacks-omit-what-it-knows) | `target_catalog.py` + `KNOWN_TARGETS` |
| 3 | Assert audit results by check name and outcome, preserving #2300’s external-before-internal order. | ["Match specificity to fragility"](https://agentskills.io/skill-creation/best-practices#match-specificity-to-fragility) | #2300 |
| 4 | Extend the architecture ratchet so `post_deps_local` cannot regain a direct cleanup route. | ["Checklists for multi-step workflows"](https://agentskills.io/skill-creation/best-practices#checklists-for-multi-step-workflows) | existing contraction-owner checker |

## Implementation (HOW)

| File | Change |
|---|---|
| `src/apm_cli/install/phases/post_deps_local.py` | Deletes the active-target-only cleanup pass that reclassified an inactive Windsurf path as unmanaged. The phase now reconciles and persists once through `reconcile_deployed_block`, retains user-edited/failed paths, and preserves logger callbacks. |
| `src/apm_cli/install/context.py` | Removes the now-dead `local_cleanup_retained` staging field; retained hashes are owned inside canonical reconciliation via prior lockfile hashes. |
| `scripts/check_target_instruction_contraction_owner.py` | Requires `post_deps_local.run` to call `reconcile_deployed_block` and rejects direct `remove_stale_deployed_files` calls. |
| `tests/integration/test_inactive_target_ghost_e2e.py` | Replaces obsolete verbose-copy assertions with durable lockfile, ledger, disk, and audit convergence assertions. |
| `tests/integration/test_primitive_target_covering_array.py` | Uses canonical profile names for expected ledger ownership; `.agents` remains a deployment root only. |
| `tests/integration/test_prune_deployment_ledger_e2e.py` | Looks up named audit checks, proves `ref-consistency` passes, and proves `deployment-ledger-owners` fails before prune. |
| `tests/integration/test_coverage_gaps_phase4w2.py` | Makes the local cleanup/trust tests exercise real Copilot-governed paths and assert both cleanup and fail-closed retention. |
| `tests/unit/scripts/test_check_target_instruction_contraction_owner.py` | Adds a mutation trap for reintroducing direct post-deps cleanup. |
| `CHANGELOG.md` | Records the real user-visible convergence fix; the three oracle repairs add no release-note noise. |

## Diagrams

Legend: the dashed nodes are the changed route; reviewers should verify that local state reaches the same reconciliation chokepoint as dependency state.

```mermaid
flowchart LR
    subgraph Lockfile[Lockfile phase]
        L1[reconcile_target_deployed_files]
    end
    subgraph Local[Post-deps local phase]
        P1[post_deps_local.run]
        P2[reconcile_deployed_block]
    end
    subgraph Cleanup[Canonical cleanup]
        C1[remove_stale_deployed_files]
        C2[lockfile and ledger persistence]
    end
    L1 --> P1
    P1 --> P2
    P2 --> C1
    C1 --> C2
    classDef new stroke-dasharray: 5 5;
    class P1,P2 new;
```

## Trade-offs

- **Route once instead of filtering twice.** Chose the existing `reconcile_deployed_block` authority; rejected patching the direct cleanup pass with a larger target set because that would preserve split ownership.
- **Assert durable state instead of verbose copy.** Chose lockfile, ledger, disk, and final audit outcomes; rejected restoring old “Removed stale…” lines because the earlier canonical phase may already have completed the repair.
- **Keep native target identity separate from shared paths.** Chose `TargetProfile.name`; rejected deriving target vocabulary from `deploy_root`, which conflates ownership with filesystem layout.
- **No lifecycle topology expansion.** The existing #2309 matrix already executes these tests in packaged G0; this PR repairs behavior and oracles without adding markers or jobs.

## Benefits

1. One ordinary install now removes the injected inactive-target local ghost and leaves the fresh checkout audit-clean.
2. Both failing covering-array rows now validate the actual canonical owners: `copilot` and `opencode`.
3. The prune fixture proves the #2300 ordering and the genuine ledger-owner failure without depending on array position.
4. A static CI ratchet rejects any future direct local cleanup path outside `reconcile_deployed_block`.

## Validation

### Original run and artifact reproduction

The downloaded `apm-darwin-arm64` artifact from run 29634869304 identified the exact source head and checksum:

```text
Agent Package Manager (APM) CLI version 0.25.0 (b7b89f4)
07059b966c30f268c10fc715d0c48060f0eacc532a95d02c330f88d4199055fc
```

It reproduced the three binary-backed failures. Source mode independently reproduced the inactive-target failure and proved the durable defect: `ghost_in_local=True` and `after_exit=1`.

### Exact-head packaged receipt

`APM_BINARY_PATH=dist/apm-darwin-arm64/apm uv run --extra dev pytest <four exact nodes>`:

```text
Agent Package Manager (APM) CLI version 0.25.0 (334245724b)
2b78fa8346c0f03333b45d4260eade3603ca1e91b11fde0e3c1b71fbdc917eee
collected 4 items
test_install_repairs_ghost_before_fresh_checkout_audit PASSED
test_primitive_target_covering_array[copilot-skill-canvas-project] PASSED
test_primitive_target_covering_array[opencode-skill-user] PASSED
test_audit_prune_audit_repairs_injected_ghost_without_deleting_bytes PASSED
4 passed in 6.15s
```

<details><summary>Focused, lint, quality, and full-unit evidence</summary>

```text
142 passed in 2.27s
All checks passed!
1548 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
[+] architecture boundary lint clean
45 passed in 224.58s
[+] assertion-quality ratchet clean: AQ001=4, AQ002=12
[+] exact test duplicate ratchet clean: 1061 files, 0 allowed duplicate group(s)
19020 passed, 2 skipped, 21 xfailed, 19 warnings, 86 subtests passed in 151.02s
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | After dropping Windsurf, one normal Copilot install makes a fresh checkout audit-clean without leaving bytes or provenance behind. | Governed by policy, DevX | `tests/integration/test_inactive_target_ghost_e2e.py::test_install_repairs_ghost_before_fresh_checkout_audit` (regression trap for run 29634869304) | integration |
| 2 | A shared `.agents` path remains owned by the native harness that deployed it. | Portability by manifest, Multi-harness support | `tests/integration/test_primitive_target_covering_array.py::test_primitive_target_covering_array` | e2e |
| 3 | A genuine departed ledger owner surfaces after the passing external identity check and is safely repaired without deleting untrusted bytes. | Secure by default, Governed by policy | `tests/integration/test_prune_deployment_ledger_e2e.py::test_audit_prune_audit_repairs_injected_ghost_without_deleting_bytes` | e2e |
| 4 | Local cleanup refuses destructive contraction when integration produced errors. | Secure by default | `tests/integration/test_coverage_gaps_phase4w2.py::TestPostDepsLocalPhase::test_skips_stale_cleanup_when_local_errors` | integration |

## How to test

- [ ] Build with `uv run --extra build --extra dev ./scripts/build-binary.sh`; observe version head `334245724b`.
- [ ] Set `APM_E2E_TESTS=1` and `APM_BINARY_PATH=dist/apm-darwin-arm64/apm`.
- [ ] Run the four exact nodes listed above; observe `4 passed`.
- [ ] Run the canonical lint and architecture chains; observe no diagnostics.
- [ ] Run the full clean-environment unit lane; observe `19020 passed`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
