### PR TITLE
test(tls): make override oracle state-independent

### DIFF
--- a/tests/integration/test_tls_frozen_hook.py
+++ b/tests/integration/test_tls_frozen_hook.py
@@ -21,6 +21,7 @@ import subprocess
 import sys
 import types
 from pathlib import Path
+from unittest.mock import Mock
 
 import certifi
 import pytest
@@ -151,16 +152,24 @@ def test_frozen_hook_ssl_cert_file_does_not_disable_injection():
     assert "truststore" in ssl.SSLContext.__module__
 
 
-def test_user_override_still_wins_under_frozen_hook():
+@_requires_truststore
+def test_user_override_still_wins_under_frozen_hook(monkeypatch):
     # A user-pinned REQUESTS_CA_BUNDLE makes the hook leave SSL_CERT_FILE unset,
     # and we must honour that bundle rather than inject the OS store.
+    import truststore
+
+    truststore.inject_into_ssl()
+    assert "truststore" in ssl.SSLContext.__module__
+    inject = Mock()
+    monkeypatch.setattr(truststore, "inject_into_ssl", inject)
+
     os.environ["REQUESTS_CA_BUNDLE"] = certifi.where()
     sys.frozen = True
     _run_runtime_hook()
 
     assert os.environ.get("SSL_CERT_FILE") is None
     assert configure_tls_trust() is False
-    assert "truststore" not in ssl.SSLContext.__module__
+    inject.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# fix(tls): make the frozen override oracle state-independent

## TL;DR

This repairs the sole release blocker from exact-main packaged G0 run
[29638252321](https://github.com/microsoft/apm/actions/runs/29638252321).
The failure is classified as a **stale test oracle**, not a product bug:
`REQUESTS_CA_BUNDLE` already won, but the test inferred this invocation's
behavior from process-wide `ssl.SSLContext` state. The corrected test proves
that this invocation does not call truststore injection, even when truststore
was already injected earlier in the process.

> [!IMPORTANT]
> Human merge only. This PR does not dispatch or rerun G0 and must not be
> auto-merged.

## Problem (WHY)

- [x] Exact main `287959b4720b568b1438a5518f039675df40d5a8` passed every
  G0 cell except macOS arm64 integration job
  [88064257136](https://github.com/microsoft/apm/actions/runs/29638252321/job/88064257136).
- [x] `configure_tls_trust()` returned `False` and logged
  `TLS: explicit CA bundle in use: .../certifi/cacert.pem`, but the test still
  failed because ambient `ssl.SSLContext.__module__` was
  `truststore._api`.
- [!] Full-suite collection imports `apm_cli.cli`, whose startup path injects
  truststore process-wide. xdist worker assignment can therefore expose
  pre-existing global state that the exact node does not see in isolation.

The old assertion inspected ambient implementation state instead of the
mechanism owned by this invocation. The replacement follows
["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)
by observing the injection call directly.

## Approach (WHAT)

1. Establish the previously failing precondition deliberately by injecting
   truststore before the override path runs.
2. Replace `truststore.inject_into_ssl` with an invocation-scoped `Mock`, then
   execute the real frozen runtime hook and `configure_tls_trust()`.
3. Assert the user override outcome (`SSL_CERT_FILE` remains unset and the
   function returns `False`) plus the mechanism contract (the injection mock
   is not called).
4. Leave production TLS code unchanged; the same module's private-CA test
   continues to prove that a genuine user CA bundle succeeds end to end.

## Implementation (HOW)

- **[`tests/integration/test_tls_frozen_hook.py`](https://github.com/microsoft/apm/blob/2e620c8704de75c33f69e7d127a57f02399aff69/tests/integration/test_tls_frozen_hook.py#L152-L175)**
  now seeds real ambient truststore state, spies on the injection entry point,
  and asserts no injection by the override invocation. The existing autouse
  fixture still extracts truststore, restores `ssl.SSLContext`, restores
  `sys.frozen`, and restores every trust-related environment variable.

No production source, runtime hook, workflow, docs, README, changelog, or
deferred PR is changed.

## Diagrams

Legend: the highlighted block is the corrected test oracle; it distinguishes
pre-existing process state from calls made by the override invocation.

```mermaid
sequenceDiagram
    participant Prior as Earlier CLI import
    participant SSL as ssl module
    participant Test as Frozen hook regression
    participant TLS as configure_tls_trust
    participant Inject as truststore inject

    Prior->>TLS: configure process trust
    TLS->>Inject: inject
    Inject-->>SSL: wrap SSLContext
    rect rgb(255, 247, 200)
        Test->>Inject: replace with Mock
        Test->>TLS: run with REQUESTS_CA_BUNDLE
        TLS-->>Test: return False
        Note over TLS,Inject: No injection call for this invocation
        Test->>Test: assert Mock not called
    end
```

## Trade-offs

- **Invocation spy over final class ownership.** Chose a direct call assertion;
  rejected `SSLContext.__module__` because it cannot identify which invocation
  created global state.
- **Test-only repair over production churn.** Chose to preserve
  `tls_trust.py` and the runtime hook; rejected a product change because the
  explicit override branch already returns before truststore import/injection.
- **No docs or changelog entry.** This changes no user-visible product
  behavior. README remains untouched, and changelog noise would misclassify a
  release-gate test repair as a product fix.

## Benefits

1. The exact release-blocking node passes under both clean and deliberately
   pre-injected truststore state.
2. The test kills a return-value-preserving mutation that calls
   `inject_into_ssl()` under `REQUESTS_CA_BUNDLE`.
3. The six frozen-hook tests pass in five consecutive file-order repetitions
   without leaking trust state.
4. The full local Darwin arm64 integration suite passes against a packaged
   binary: 8,138 passed, 256 skipped, 2 xfailed.

## Validation

Pre-repair, exact node in a clean process:

```text
1 passed in 1.39s
```

Pre-repair, source suite collection with a CLI-importing module and hosted
xdist settings:

```text
1 failed, 9 passed in 3.86s
AssertionError: assert 'truststore' not in 'truststore._api'
```

Post-repair, the same source suite-order reproduction:

```text
10 passed in 4.46s
```

Post-repair, focused TLS neighborhood:

```text
96 passed in 22.78s
```

Post-repair, packaged Darwin arm64 full integration suite:

```text
8138 passed, 256 skipped, 2 xfailed in 471.64s (0:07:51)
```

Mutation proof after removing the explicit-override early return:

```text
FAILED tests/integration/test_tls_frozen_hook.py::test_user_override_still_wins_under_frozen_hook
E       assert True is False
mutation killed with pytest exit 1
```

<details><summary>Quality and repository gate receipts</summary>

`uv run --frozen --extra dev ruff check src/ tests/`:

```text
All checks passed!
```

`uv run --frozen --extra dev ruff format --check src/ tests/`:

```text
1548 files already formatted
```

`python -m pylint ... --enable=R0801`:

```text
Your code has been rated at 10.00/10
```

`bash scripts/lint-auth-signals.sh` and
`bash scripts/lint-architecture-boundaries.sh`:

```text
[+] auth-signal lint clean
[+] architecture boundary lint clean
```

`uv run --frozen python scripts/check_test_assertions.py`,
`scripts/check_exact_test_duplicates.py`, and `pytest tests/quality`:

```text
[+] assertion-quality ratchet clean: AQ001=4, AQ002=12
[+] exact test duplicate ratchet clean: 1061 files, 0 allowed duplicate group(s)
45 passed in 65.15s (0:01:05)
```

</details>

> [!NOTE]
> The local full unit matrix reached 19,019 passed, 2 skipped, 21 xfailed,
> and 88 subtests passed, with one unrelated real-system runtime enumeration
> failure that passes alone. The exact-main G0 macOS arm64 unit step passed;
> this PR does not touch that surface.

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|-------------------------|--------------|--------------------|------|
| 1 | A genuine user CA bundle remains authoritative even if truststore was already injected earlier in the process | Secure by default, Portability by manifest | `tests/integration/test_tls_frozen_hook.py::test_user_override_still_wins_under_frozen_hook` (mechanism regression trap for G0 run 29638252321)<br/>`tests/integration/test_tls_frozen_hook.py::test_genuine_user_override_still_honored` (private-CA outcome) | integration |
| 2 | A frozen binary's bundled default is not mistaken for user intent, and injection failure restores certifi rather than leaving zero trust | Secure by default | `tests/integration/test_tls_frozen_hook.py::test_bundled_default_marker_gates_ssl_cert_file_pop`<br/>`tests/integration/test_tls_frozen_hook.py::test_injection_failure_restores_bundled_certifi` | integration |

Security invariants preserved:

- `REQUESTS_CA_BUNDLE` and `CURL_CA_BUNDLE` win without injection.
- The runtime hook's bundled-default marker remains distinct from user intent.
- Injection failures retain the designed certifi fallback.
- Test cleanup restores global SSL and environment state.

## How to test

- [ ] Run the exact node; expect `1 passed`.
- [ ] Run `test_cli_docs_contract.py` with `test_tls_frozen_hook.py` under
  `-n 2 --dist loadgroup`; expect `10 passed`.
- [ ] Run the focused TLS neighborhood; expect `96 passed`.
- [ ] Temporarily remove the explicit-override early return; expect the
  regression node to fail, then restore production unchanged.
- [ ] Confirm the diff contains only `tests/integration/test_tls_frozen_hook.py`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
