### PR TITLE
fix(install): defer transient GitHub validation failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Transient GitHub REST pre-flight failures no longer reject an otherwise
+  downloadable package; connection failures, timeouts, HTTP 408, throttles,
+  and 5xx responses now defer to the authoritative download while TLS,
+  authentication, permission, and not-found failures remain closed. (#TBD)
 - Target contraction during `apm install` no longer reintroduces an
   inactive target's missing local deployment path after the canonical
   reconciliation pass removed it, so a fresh checkout converges to an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Transient GitHub REST pre-flight failures no longer reject an otherwise
   downloadable package; connection failures, timeouts, HTTP 408, throttles,
   and 5xx responses now defer to the authoritative download while TLS,
-  authentication, permission, and not-found failures remain closed. (#TBD)
+  authentication, permission, and not-found failures remain closed. (#2313)
 - Target contraction during `apm install` no longer reintroduces an
   inactive target's missing local deployment path after the canonical
   reconciliation pass removed it, so a fresh checkout converges to an

--- a/src/apm_cli/install/validation.py
+++ b/src/apm_cli/install/validation.py
@@ -52,6 +52,15 @@ from .errors import AuthenticationError
 _TLS_ERROR_PREFIX = "TLS verification failed"
 
 
+class _GitHubRestStatusError(RuntimeError):
+    """Preserve a failed GitHub REST response status across auth fallback."""
+
+    def __init__(self, status_code: int, reason: str) -> None:
+        self.status_code = status_code
+        self.reason = reason
+        super().__init__(f"GitHub API returned HTTP {status_code}: {reason}")
+
+
 def _is_tls_failure(exc: BaseException) -> bool:
     """Return True if exc (or any cause in its chain) is a TLS verification failure."""
     cur: BaseException | None = exc
@@ -65,6 +74,38 @@ def _is_tls_failure(exc: BaseException) -> bool:
         cur = cur.__cause__ or cur.__context__
         seen += 1
     return False
+
+
+def _inconclusive_github_probe_detail(exc: BaseException) -> str | None:
+    """Describe failures that leave repository accessibility unproven."""
+    if _is_tls_failure(exc):
+        return None
+    if isinstance(exc, _GitHubRestStatusError):
+        if exc.status_code in (408, 429) or 500 <= exc.status_code < 600:
+            return f"HTTP {exc.status_code}"
+        return None
+    if isinstance(exc, requests.exceptions.Timeout):
+        return "request timeout"
+    if isinstance(exc, requests.exceptions.ConnectionError):
+        return "connection failure"
+    return None
+
+
+def _allow_download_after_inconclusive_github_probe(
+    exc: BaseException,
+    host_display: str,
+    verbose_log,
+) -> bool:
+    """Let the downloader decide only when the REST probe was inconclusive."""
+    detail = _inconclusive_github_probe_detail(exc)
+    if detail is None:
+        return False
+    if verbose_log:
+        verbose_log(
+            f"GitHub API pre-flight for {host_display} was inconclusive ({detail}); "
+            "continuing because the download step will verify repository access"
+        )
+    return True
 
 
 def _log_rate_limit_allow(host_display: str, verbose_log, logger) -> None:
@@ -643,11 +684,8 @@ def _validate_github_package(
             verbose_log(f"API {api_url} -> {resp.status_code}")
         if resp.ok:
             return True
-        if resp.status_code == 404 and token:
-            # 404 with token could mean no access -- raise to trigger fallback
-            raise RuntimeError(f"API returned {resp.status_code}")
         raise_for_github_throttle(resp, host_info.display_name)
-        raise RuntimeError(f"API returned {resp.status_code}: {resp.reason}")
+        raise _GitHubRestStatusError(resp.status_code, resp.reason)
 
     try:
         return auth_resolver.try_with_fallback(
@@ -669,6 +707,10 @@ def _validate_github_package(
         if _is_tls_failure(exc):
             _log_tls_failure(host_info.display_name, exc, verbose_log, logger)
             return False
+        if _allow_download_after_inconclusive_github_probe(
+            exc, host_info.display_name, verbose_log
+        ):
+            return True
         if verbose_log:
             try:
                 ctx = auth_resolver.build_error_context(
@@ -745,7 +787,7 @@ def _validate_parse_failure_fallback(
         if verbose_log:
             verbose_log(f"API fallback -> {resp.status_code} {resp.reason}")
         raise_for_github_throttle(resp, host_info.display_name)
-        raise RuntimeError(f"API returned {resp.status_code}")
+        raise _GitHubRestStatusError(resp.status_code, resp.reason)
 
     try:
         return auth_resolver.try_with_fallback(
@@ -764,6 +806,8 @@ def _validate_parse_failure_fallback(
             # See note above: logged once here, skip auth context render.
             _log_tls_failure(host, exc, verbose_log, logger)
             return False
+        if _allow_download_after_inconclusive_github_probe(exc, host, verbose_log):
+            return True
         if verbose_log:
             try:
                 ctx = auth_resolver.build_error_context(

--- a/src/apm_cli/install/validation.py
+++ b/src/apm_cli/install/validation.py
@@ -81,7 +81,7 @@ def _inconclusive_github_probe_detail(exc: BaseException) -> str | None:
     if _is_tls_failure(exc):
         return None
     if isinstance(exc, _GitHubRestStatusError):
-        if exc.status_code in (408, 429) or 500 <= exc.status_code < 600:
+        if exc.status_code == 408 or 500 <= exc.status_code < 600:
             return f"HTTP {exc.status_code}"
         return None
     if isinstance(exc, requests.exceptions.Timeout):

--- a/tests/unit/install/test_validation_transient_probe.py
+++ b/tests/unit/install/test_validation_transient_probe.py
@@ -115,7 +115,7 @@ def test_transport_failure_defers_to_authoritative_download(
 
 
 @pytest.mark.parametrize("probe_path", PROBE_PATHS)
-@pytest.mark.parametrize("status_code", [408, 429, 500, 502, 503, 504])
+@pytest.mark.parametrize("status_code", [408, 500, 502, 503, 504])
 def test_transient_http_status_defers_to_authoritative_download(
     probe_path: str,
     status_code: int,

--- a/tests/unit/install/test_validation_transient_probe.py
+++ b/tests/unit/install/test_validation_transient_probe.py
@@ -1,0 +1,207 @@
+"""Regression tests for inconclusive GitHub validation probes."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from apm_cli.install import validation
+
+PROBE_PATHS = ("primary", "parse-fallback")
+
+
+def _response(status_code: int, headers: dict[str, str] | None = None) -> SimpleNamespace:
+    return SimpleNamespace(
+        ok=False,
+        status_code=status_code,
+        reason="test response",
+        headers=headers or {},
+    )
+
+
+def _resolver() -> MagicMock:
+    resolver = MagicMock()
+    resolver.classify_host.return_value = SimpleNamespace(
+        api_base="https://api.github.com",
+        display_name="github.com",
+        kind="github",
+        has_public_repos=True,
+    )
+    resolver.resolve.return_value = SimpleNamespace(
+        source="test",
+        token_type="pat",
+        token="test-token",
+    )
+    resolver.build_error_context.return_value = "auth diagnostics"
+
+    def _retry_after_unauthenticated_failure(host, operation, **kwargs):
+        try:
+            return operation(None, {})
+        except Exception:
+            return operation("test-token", {})
+
+    resolver.try_with_fallback.side_effect = _retry_after_unauthenticated_failure
+    return resolver
+
+
+def _run_probe(
+    probe_path: str,
+    request_result: object | list[object],
+    *,
+    verbose: bool = False,
+) -> tuple[bool, MagicMock, MagicMock]:
+    resolver = _resolver()
+    logger = MagicMock()
+    logger.verbose = verbose
+    verbose_log = logger.verbose_detail if verbose else None
+    request_results = (
+        request_result if isinstance(request_result, list) else [request_result, request_result]
+    )
+
+    with (
+        patch(
+            "apm_cli.install.validation.requests.get",
+            side_effect=request_results,
+        ),
+        patch("apm_cli.deps.registry_proxy.is_enforce_only", return_value=False),
+    ):
+        if probe_path == "primary":
+            dep_ref = SimpleNamespace(host="github.com", port=None, repo_url="owner/repo")
+            result = validation._validate_github_package(
+                dep_ref,
+                resolver,
+                verbose,
+                verbose_log,
+                "owner/repo",
+                logger,
+            )
+        else:
+            result = validation._validate_parse_failure_fallback(
+                "owner/repo",
+                resolver,
+                verbose_log,
+                logger,
+            )
+
+    return result, resolver, logger
+
+
+@pytest.mark.parametrize("probe_path", PROBE_PATHS)
+@pytest.mark.parametrize(
+    "transport_error",
+    [
+        requests.exceptions.ConnectionError("connection failed"),
+        requests.exceptions.Timeout("request timed out"),
+    ],
+    ids=["connection-error", "timeout"],
+)
+def test_transport_failure_defers_to_authoritative_download(
+    probe_path: str,
+    transport_error: requests.exceptions.RequestException,
+) -> None:
+    result, _resolver_mock, logger = _run_probe(probe_path, transport_error, verbose=True)
+
+    assert result is True
+    assert any(
+        "download" in call.args[0] and "inconclusive" in call.args[0]
+        for call in logger.verbose_detail.call_args_list
+    )
+    assert all("test-token" not in call.args[0] for call in logger.verbose_detail.call_args_list)
+    logger.warning.assert_not_called()
+    logger.info.assert_not_called()
+
+
+@pytest.mark.parametrize("probe_path", PROBE_PATHS)
+@pytest.mark.parametrize("status_code", [408, 429, 500, 502, 503, 504])
+def test_transient_http_status_defers_to_authoritative_download(
+    probe_path: str,
+    status_code: int,
+) -> None:
+    result, _resolver_mock, _logger = _run_probe(probe_path, _response(status_code))
+
+    assert result is True
+
+
+@pytest.mark.parametrize("probe_path", PROBE_PATHS)
+@pytest.mark.parametrize("status_code", [401, 403, 404])
+def test_non_transient_http_status_fails_closed(
+    probe_path: str,
+    status_code: int,
+) -> None:
+    result, resolver, _logger = _run_probe(
+        probe_path,
+        _response(status_code, {"X-RateLimit-Remaining": "10"}),
+    )
+
+    assert result is False
+    resolver.build_error_context.assert_not_called()
+
+
+@pytest.mark.parametrize("probe_path", PROBE_PATHS)
+def test_final_status_after_auth_fallback_controls_classification(probe_path: str) -> None:
+    transient_result, _resolver_mock, _logger = _run_probe(
+        probe_path,
+        [_response(404), _response(503)],
+    )
+    closed_result, _resolver_mock, _logger = _run_probe(
+        probe_path,
+        [_response(503), _response(404)],
+    )
+
+    assert transient_result is True
+    assert closed_result is False
+
+
+@pytest.mark.parametrize("probe_path", PROBE_PATHS)
+def test_closed_status_keeps_verbose_auth_diagnostics(probe_path: str) -> None:
+    result, resolver, logger = _run_probe(probe_path, _response(401), verbose=True)
+
+    assert result is False
+    resolver.build_error_context.assert_called_once()
+    assert any(call.args[0] == "auth diagnostics" for call in logger.verbose_detail.call_args_list)
+
+
+@pytest.mark.parametrize("probe_path", PROBE_PATHS)
+def test_tls_failure_fails_closed(probe_path: str) -> None:
+    result, resolver, logger = _run_probe(
+        probe_path,
+        requests.exceptions.SSLError("certificate validation failed"),
+    )
+
+    assert result is False
+    resolver.build_error_context.assert_not_called()
+    logger.warning.assert_called_once()
+
+
+@pytest.mark.parametrize("probe_path", PROBE_PATHS)
+def test_confirmed_throttle_keeps_existing_download_defer(probe_path: str) -> None:
+    result, _resolver_mock, logger = _run_probe(
+        probe_path,
+        _response(403, {"X-RateLimit-Remaining": "0"}),
+    )
+
+    assert result is True
+    logger.info.assert_called_once()
+
+
+@pytest.mark.parametrize("probe_path", PROBE_PATHS)
+def test_unknown_failure_fails_closed(probe_path: str) -> None:
+    result, _resolver_mock, _logger = _run_probe(
+        probe_path,
+        ValueError("unexpected response handling failure"),
+    )
+
+    assert result is False
+
+
+@pytest.mark.parametrize("probe_path", PROBE_PATHS)
+def test_transient_detail_is_verbose_only(probe_path: str) -> None:
+    result, _resolver_mock, logger = _run_probe(probe_path, _response(503))
+
+    assert result is True
+    logger.verbose_detail.assert_not_called()
+    logger.warning.assert_not_called()
+    logger.info.assert_not_called()


### PR DESCRIPTION
# fix(install): defer transient GitHub validation failures to download

## TL;DR

GitHub package validation now treats exhausted connection failures, timeouts,
HTTP 408, and 5xx responses as inconclusive instead of declaring the package
inaccessible. Confirmed throttles continue through the existing canonical
throttle path; TLS, authentication, permission, not-found, and unknown failures
still fail closed while the downloader remains the authoritative fetch and
integrity boundary.

> [!IMPORTANT]
> This is the minimal human-merge-only blocker fix for packaged G0 run
> `29641255055`; it does not add retries, change credentials, or alter release
> workflow ordering.

## Problem (WHY)

- [x] In packaged G0 run `29641255055`, macOS arm64 passed 19,020 unit tests,
  binary startup, artifact upload, and integration before one direct
  `apm install microsoft/apm-sample-package` pre-flight failed generically.
- [x] Seconds later, the same repository installed through the
  manifest/dependency path, and the exact arm64 artifact passed isolated
  release validation locally. The REST probe therefore produced a false
  negative rather than evidence that the repository was absent.
- [!] `_validate_github_package` and `_validate_parse_failure_fallback`
  previously collapsed every non-throttle exception to `False`, erasing the
  final HTTP status after `AuthResolver` exhausted its fallback chain.

The fix classifies deterministic exception types and status codes rather than
matching exception text, following the PROSE principle that
["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/).

## Approach (WHAT)

| # | Fix | Principle |
|---:|---|---|
| 1 | Preserve failed REST status in a private typed exception after each API response. | Keep status data intact across the existing `AuthResolver` fallback. |
| 2 | Route both GitHub validation paths through one inconclusive-failure classifier. | One owner decides whether download may remain authoritative. |
| 3 | Allow only connection errors, timeouts, HTTP 408, and 5xx; retain closed behavior for every other failure. | Narrow fail-open scope without re-deriving the canonical throttle decision. |

## Implementation (HOW)

| File | Change |
|---|---|
| `src/apm_cli/install/validation.py` | Adds `_GitHubRestStatusError` and one shared classifier used by both REST probe paths. Transient detail is emitted only through the existing verbose callback. `AuthResolver`, token sources, downloader behavior, and throttle ownership are unchanged. |
| `tests/unit/install/test_validation_transient_probe.py` | Adds deterministic two-attempt fallback coverage for both primary and parse-fallback paths, including transport errors, transient and closed statuses, TLS, confirmed throttling, unknown failures, diagnostics, and token-free verbose output. |
| `CHANGELOG.md` | Records the release-blocker behavior change under Unreleased / Fixed. |

## Diagrams

Legend: the dashed nodes are the new status-preserving and classification
steps; the terminal branches show exactly which component remains authoritative.

```mermaid
flowchart LR
    subgraph Probe["GitHub REST pre-flight"]
        A["AuthResolver fallback"] --> B["Final probe failure"]
    end
    subgraph Classify["Shared validation owner"]
        B --> T["raise_for_github_throttle"]
        T -->|"Not a throttle"| C["_GitHubRestStatusError"]:::new
        C --> D{"Failure classification"}:::new
    end
    T -->|"Confirmed throttle"| E["Return True"]
    D -->|"Connection, timeout, HTTP 408/5xx"| E
    D -->|"TLS, HTTP 401/403/404, unknown"| F["Return False"]
    E --> G["Downloader performs authoritative fetch"]
    F --> H["Existing auth or TLS diagnostics"]
    classDef new stroke-dasharray: 5 5;
    class C,D new;
```

## Trade-offs

- **Defer to download; reject validator retries.** The downloader already owns
  the authoritative network fetch, so this avoids sleeps and duplicate retry
  policy in the pre-flight.
- **Enumerate transient categories; reject broad `RequestException`
  allow-through.** Invalid requests and unknown failures remain closed even
  though this may preserve some conservative false negatives.
- **Keep the type private to validation; reject `AuthResolver` changes.**
  Credential ordering and token handling are unrelated to this incident and
  stay untouched.
- **No docs corpus edit.** This changes an internal pre-flight decision, not a
  documented CLI, authentication, manifest, or policy contract.

## Benefits

1. Both GitHub REST validation paths now defer the same four transient classes:
   connection failure, timeout, HTTP 408, and the 5xx range.
2. HTTP 401, non-throttle 403, HTTP 404, TLS, and unknown exceptions continue
   to return `False`.
3. HTTP 429 and confirmed 403 throttles remain owned by
   `deps/github_rate_limit.py`.
4. The transient explanation appears only under verbose output and contains no
   credential value; the unchanged downloader continues to enforce authoritative
   repository access, provenance, and integrity.

## Validation

<details open><summary>Focused and related tests</summary>

`uv run --extra dev pytest -q tests/unit/install/test_validation_transient_probe.py`:

```text
................................                                         [100%]
32 passed in 0.99s
```

</details>

<details><summary>RED / mutation-break evidence</summary>

Before implementation, the focused suite produced `16 failed, 14 passed`.
After GREEN, changing the shared allow-through decision from `True` to `False`
caused the targeted HTTP 503 regression test to fail:

```text
E       assert False is True
1 failed in 0.49s
```

The exact implementation bytes were then restored; SHA-256 returned to
`bd5e8b245eabd5962e3377d0ee14652503f9b244edbd7b9a953a9f737025e58c`,
and the focused tests passed again.

</details>

<details><summary>Canonical lint mirror</summary>

```text
All checks passed!
1549 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
[+] architecture boundary lint clean
```

The YAML I/O, 2,100-line source limit, and raw `str(relative_to(...))`
guards also passed; `validation.py` is 902 lines.

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | A direct GitHub install survives a temporary REST timeout or service response and lets the real download decide. | DevX, Vendor-neutral | `tests/unit/install/test_validation_transient_probe.py::test_transport_failure_defers_to_authoritative_download`<br/>`::test_transient_http_status_defers_to_authoritative_download` (regression-trap for G0 run `29641255055`) | unit |
| 2 | Missing, unauthorized, forbidden, or TLS-invalid repositories are not waved through by the pre-flight. | Secure by default | `tests/unit/install/test_validation_transient_probe.py::test_non_transient_http_status_fails_closed`<br/>`::test_tls_failure_fails_closed`<br/>`::test_unknown_failure_fails_closed` | unit |
| 3 | Diagnostic detail for a transient probe appears only with verbose output and never reveals the token. | Secure by default, DevX | `tests/unit/install/test_validation_transient_probe.py::test_transient_detail_is_verbose_only`<br/>`::test_transport_failure_defers_to_authoritative_download` | unit |

## How to test

- [ ] Run the focused test file and observe all 32 cases pass.
- [ ] Review the two exception handlers and confirm both call the same
  `_allow_download_after_inconclusive_github_probe` helper after TLS handling.
- [ ] Confirm the PR remains non-draft with auto-merge disabled for human merge.

apm-spec-waiver: GitHub REST pre-flight resilience is implementation-specific, not a new OpenAPM contract.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
