### PR TITLE
fix(integration): hermeticize stale packaged G0 release-blocker tests

### DIFF
--- a/tests/integration/test_cache_lockfile_parity.py
+++ b/tests/integration/test_cache_lockfile_parity.py
@@ -17,52 +17,41 @@ of cache state. This test asserts it across three regimes:
   Run C: APM_NO_CACHE=1 (cache layer disabled entirely)
 
 A.lock == B.lock == C.lock is the parity invariant.
+The suite uses an owned local Git origin exposed as
+``microsoft/apm-sample-package`` so the cache/lockfile contract stays
+hermetic while preserving GitHub-shaped lockfile provenance.
 """
 
 from __future__ import annotations
 
 import hashlib
-import os
 import shutil
-import subprocess
+from collections.abc import Mapping
 from pathlib import Path
 
 import pytest
 
-pytestmark = pytest.mark.requires_github_token
+from tests.utils.hermetic_packaged_sample import HermeticPackagedSample
+
+pytestmark = [
+    pytest.mark.requires_apm_binary,
+]
 
 
-@pytest.fixture
-def project_with_apm(tmp_path: Path) -> Path:
-    """Minimal APM project with one stable APM dep for parity checks."""
-    project = tmp_path / "parity-test"
-    project.mkdir()
-    (project / ".github").mkdir()
-    (project / "apm.yml").write_text(
-        """\
-name: parity-test
-version: 0.1.0
-target: copilot
-dependencies:
-  apm:
-    - microsoft/apm-sample-package
-""",
-        encoding="utf-8",
-    )
-    return project
-
-
-def _run_install(apm: str, project: Path, *, env_overrides: dict[str, str]) -> None:
-    env = os.environ.copy()
+def _run_install(
+    packaged_sample: HermeticPackagedSample,
+    project: Path,
+    *,
+    scenario_id: str,
+    env_overrides: Mapping[str, str],
+) -> None:
+    env = dict(packaged_sample.environment)
     env.update(env_overrides)
-    # Quiet output keeps the test fast and avoids parsing fragility.
-    result = subprocess.run(
-        [apm, "install"],
-        cwd=str(project),
+    result = packaged_sample.runner.run(
+        ("install",),
+        scenario_id=scenario_id,
+        cwd=project,
         env=env,
-        capture_output=True,
-        text=True,
-        timeout=240,
     )
     assert result.returncode == 0, (
         f"apm install failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
@@ -103,8 +92,7 @@ def _clone_project(template: Path, dest: Path) -> Path:
 
 
 def test_lockfile_byte_identical_across_cache_regimes(
-    apm_binary_path: str,
-    project_with_apm: Path,
+    hermetic_packaged_sample: HermeticPackagedSample,
     tmp_path: Path,
 ) -> None:
     """A, B, C must produce content-identical apm.lock.yaml (modulo `generated_at`).
@@ -117,29 +105,32 @@ def test_lockfile_byte_identical_across_cache_regimes(
     cache_dir.mkdir()
 
     # Run A: cold cache
-    project_a = _clone_project(project_with_apm, tmp_path / "run-a")
+    project_a = _clone_project(hermetic_packaged_sample.project.root, tmp_path / "run-a")
     _run_install(
-        apm_binary_path,
+        hermetic_packaged_sample,
         project_a,
-        env_overrides={"APM_CACHE_DIR": str(cache_dir), "CI": "1"},
+        scenario_id="cache-lockfile-parity-cold",
+        env_overrides={"APM_CACHE_DIR": str(cache_dir)},
     )
     sha_a = _lockfile_sha(project_a)
 
     # Run B: warm cache (same APM_CACHE_DIR retained, fresh project tree)
-    project_b = _clone_project(project_with_apm, tmp_path / "run-b")
+    project_b = _clone_project(hermetic_packaged_sample.project.root, tmp_path / "run-b")
     _run_install(
-        apm_binary_path,
+        hermetic_packaged_sample,
         project_b,
-        env_overrides={"APM_CACHE_DIR": str(cache_dir), "CI": "1"},
+        scenario_id="cache-lockfile-parity-warm",
+        env_overrides={"APM_CACHE_DIR": str(cache_dir)},
     )
     sha_b = _lockfile_sha(project_b)
 
     # Run C: cache disabled (fresh project tree)
-    project_c = _clone_project(project_with_apm, tmp_path / "run-c")
+    project_c = _clone_project(hermetic_packaged_sample.project.root, tmp_path / "run-c")
     _run_install(
-        apm_binary_path,
+        hermetic_packaged_sample,
         project_c,
-        env_overrides={"APM_NO_CACHE": "1", "CI": "1"},
+        scenario_id="cache-lockfile-parity-no-cache",
+        env_overrides={"APM_NO_CACHE": "1"},
     )
     sha_c = _lockfile_sha(project_c)
 

--- a/tests/integration/test_global_install_e2e.py
+++ b/tests/integration/test_global_install_e2e.py
@@ -203,9 +203,10 @@ class TestGlobalInstallDeploysRealPackage:
 
         # Manifest should no longer list the package.
         manifest_after = yaml.safe_load((apm_dir / "apm.yml").read_text(encoding="utf-8"))
+        assert isinstance(manifest_after, dict)
         apm_deps = manifest_after.get("dependencies", {}).get("apm", []) or []
-        assert SAMPLE_PKG not in apm_deps, (
-            f"{SAMPLE_PKG} still in ~/.apm/apm.yml after uninstall: {apm_deps}"
+        assert apm_deps == [], (
+            f"~/.apm/apm.yml should have no apm dependencies after uninstall: {apm_deps}"
         )
 
         # Previously deployed primitive files must be gone.

--- a/tests/integration/test_global_install_e2e.py
+++ b/tests/integration/test_global_install_e2e.py
@@ -1,4 +1,4 @@
-"""End-to-end integration tests for `apm install -g` / `apm uninstall -g`.
+"""End-to-end integration tests for ``apm install -g`` / ``apm uninstall -g``.
 
 Covers gaps that existing scope tests do not exercise:
 - G1: real package install under user scope deploys primitive files to ~/.apm/
@@ -6,88 +6,104 @@ Covers gaps that existing scope tests do not exercise:
 - Cross-scope coexistence: a global install and a project install of the same
   package live side by side without colliding.
 
-Uses the public `microsoft/apm-sample-package` repo (ref `main`) as the real
-fixture, the same canonical sample referenced by other e2e suites.
-
-Requires network access and GITHUB_TOKEN/GITHUB_APM_PAT for GitHub API.
+Uses an owned local Git origin exposed as ``microsoft/apm-sample-package`` so
+the user-scope lifecycle stays hermetic while preserving GitHub-shaped
+lockfile provenance.
 """
 
-import os
-import subprocess
-import sys
+from __future__ import annotations
+
+from pathlib import Path
 
 import pytest
 import yaml
 
-pytestmark = pytest.mark.requires_github_token
+from apm_cli.utils.yaml_io import dump_yaml
+from tests.utils.apm_lifecycle_runner import CommandResult
+from tests.utils.hermetic_packaged_sample import DEPENDENCY, HermeticPackagedSample
+
+pytestmark = [
+    pytest.mark.requires_apm_binary,
+]
 
 
-SAMPLE_PKG = "microsoft/apm-sample-package"
+SAMPLE_PKG = DEPENDENCY
+SAMPLE_REMOTE_URL = f"https://github.com/{SAMPLE_PKG}"
 
 
-@pytest.fixture
-def fake_home(tmp_path):
-    """Isolated HOME directory so user-scope installs never touch the real home."""
-    home_dir = tmp_path / "fakehome"
-    home_dir.mkdir()
-    return home_dir
+def _home(packaged_sample: HermeticPackagedSample) -> Path:
+    return Path(packaged_sample.environment["HOME"])
 
 
-def _env_with_home(fake_home):
-    env = os.environ.copy()
-    env["HOME"] = str(fake_home)
-    if sys.platform == "win32":
-        env["USERPROFILE"] = str(fake_home)
-    return env
+def _apm_home(packaged_sample: HermeticPackagedSample) -> Path:
+    return Path(packaged_sample.environment["APM_HOME"])
 
 
-def _run_apm(apm_binary_path, args, cwd, fake_home, timeout=180):
-    return subprocess.run(
-        [apm_binary_path] + args,  # noqa: RUF005
+def _run_apm(
+    packaged_sample: HermeticPackagedSample,
+    args: tuple[str, ...],
+    *,
+    cwd: Path,
+    scenario_id: str,
+) -> CommandResult:
+    return packaged_sample.runner.run(
+        args,
+        scenario_id=scenario_id,
         cwd=cwd,
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-        env=_env_with_home(fake_home),
+        env=packaged_sample.environment,
     )
 
 
-def _write_user_manifest(fake_home, packages):
+def _ensure_home_target_signal(packaged_sample: HermeticPackagedSample) -> None:
+    home_dir = _home(packaged_sample)
+    github_dir = home_dir / ".github"
+    github_dir.mkdir(exist_ok=True)
+    (github_dir / "copilot-instructions.md").write_text("# test\n", encoding="utf-8")
+
+
+def _write_user_manifest(packaged_sample: HermeticPackagedSample, packages: list[object]) -> None:
     """Seed ~/.apm/apm.yml with the given APM dependency list."""
-    apm_dir = fake_home / ".apm"
+    _ensure_home_target_signal(packaged_sample)
+    apm_dir = _apm_home(packaged_sample)
     apm_dir.mkdir(parents=True, exist_ok=True)
-    (apm_dir / "apm.yml").write_text(
-        yaml.dump(
-            {
-                "name": "global-project",
-                "version": "1.0.0",
-                "dependencies": {"apm": packages, "mcp": []},
-            },
-            default_flow_style=False,
-        ),
-        encoding="utf-8",
+    dump_yaml(
+        {
+            "name": "global-project",
+            "version": "1.0.0",
+            "dependencies": {"apm": packages, "mcp": []},
+        },
+        apm_dir / "apm.yml",
     )
 
 
-def _read_lockfile(directory):
+def _read_lockfile(directory: Path) -> dict[str, object] | None:
     lock_path = directory / "apm.lock.yaml"
     if not lock_path.exists():
         return None
-    return yaml.safe_load(lock_path.read_text(encoding="utf-8"))
+    lockfile = yaml.safe_load(lock_path.read_text(encoding="utf-8"))
+    assert lockfile is None or isinstance(lockfile, dict)
+    return lockfile
 
 
-def _get_locked_dep(lockfile, repo_url):
+def _get_locked_dep(
+    lockfile: dict[str, object] | None,
+    repo_url: str,
+) -> dict[str, object] | None:
     if not lockfile or "dependencies" not in lockfile:
         return None
     deps = lockfile["dependencies"]
     if isinstance(deps, list):
         for entry in deps:
+            assert isinstance(entry, dict)
             if entry.get("repo_url") == repo_url:
                 return entry
     return None
 
 
-def _existing_deployed_files(deploy_root, dep_entry):
+def _existing_deployed_files(
+    deploy_root: Path,
+    dep_entry: dict[str, object] | None,
+) -> list[str]:
     """Return deployed_files entries that exist on disk under *deploy_root*.
 
     User-scope deploy_root is ``~/`` (Path.home()), not ``~/.apm/``: integrators
@@ -99,28 +115,39 @@ def _existing_deployed_files(deploy_root, dep_entry):
     return [f for f in dep_entry["deployed_files"] if (deploy_root / f).exists()]
 
 
+def _make_workdir(packaged_sample: HermeticPackagedSample, name: str) -> Path:
+    work_dir = packaged_sample.project.root.parent / name
+    work_dir.mkdir()
+    return work_dir
+
+
 class TestGlobalInstallDeploysRealPackage:
     """Verify `apm install -g` actually deploys primitive files under ~/.apm/."""
 
     def test_install_global_deploys_real_package_to_user_scope(
-        self, apm_binary_path, fake_home, tmp_path
-    ):
-        _write_user_manifest(fake_home, [SAMPLE_PKG])
-        work_dir = tmp_path / "workdir"
-        work_dir.mkdir()
+        self,
+        hermetic_packaged_sample: HermeticPackagedSample,
+    ) -> None:
+        _write_user_manifest(hermetic_packaged_sample, [{"git": SAMPLE_REMOTE_URL}])
+        work_dir = _make_workdir(hermetic_packaged_sample, "global-install-workdir")
 
-        result = _run_apm(apm_binary_path, ["install", "-g"], work_dir, fake_home)
+        result = _run_apm(
+            hermetic_packaged_sample,
+            ("install", "-g"),
+            cwd=work_dir,
+            scenario_id="global-install-user-scope",
+        )
         assert result.returncode == 0, (
             f"global install failed:\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}"
         )
 
-        apm_dir = fake_home / ".apm"
+        apm_dir = _apm_home(hermetic_packaged_sample)
         lockfile = _read_lockfile(apm_dir)
         assert lockfile is not None, "~/.apm/apm.lock.yaml was not created"
         dep = _get_locked_dep(lockfile, SAMPLE_PKG)
         assert dep is not None, f"{SAMPLE_PKG} not present in user-scope lockfile: {lockfile}"
 
-        deployed = _existing_deployed_files(fake_home, dep)
+        deployed = _existing_deployed_files(_home(hermetic_packaged_sample), dep)
         assert len(deployed) > 0, (
             f"No primitive files deployed under user-scope deploy root. "
             f"deployed_files={dep.get('deployed_files')}\n"
@@ -132,29 +159,35 @@ class TestGlobalInstallDeploysRealPackage:
         assert not (work_dir / "apm.lock.yaml").exists(), "lockfile leaked into cwd"
         assert not (work_dir / "apm_modules").exists(), "apm_modules leaked into cwd"
 
-    def test_uninstall_global_removes_deployed_files(self, apm_binary_path, fake_home, tmp_path):
-        _write_user_manifest(fake_home, [SAMPLE_PKG])
-        work_dir = tmp_path / "workdir"
-        work_dir.mkdir()
+    def test_uninstall_global_removes_deployed_files(
+        self,
+        hermetic_packaged_sample: HermeticPackagedSample,
+    ) -> None:
+        _write_user_manifest(hermetic_packaged_sample, [{"git": SAMPLE_REMOTE_URL}])
+        work_dir = _make_workdir(hermetic_packaged_sample, "global-uninstall-workdir")
 
-        install_result = _run_apm(apm_binary_path, ["install", "-g"], work_dir, fake_home)
+        install_result = _run_apm(
+            hermetic_packaged_sample,
+            ("install", "-g"),
+            cwd=work_dir,
+            scenario_id="global-install-before-uninstall",
+        )
         assert install_result.returncode == 0, (
             f"setup install failed:\nSTDOUT: {install_result.stdout}\n"
             f"STDERR: {install_result.stderr}"
         )
 
-        apm_dir = fake_home / ".apm"
+        apm_dir = _apm_home(hermetic_packaged_sample)
         dep_before = _get_locked_dep(_read_lockfile(apm_dir), SAMPLE_PKG)
         assert dep_before is not None, "Package missing from lockfile after install"
-        deployed_before = _existing_deployed_files(fake_home, dep_before)
-        if not deployed_before:
-            pytest.skip("Sample package deployed no files; nothing to verify removal of")
+        deployed_before = _existing_deployed_files(_home(hermetic_packaged_sample), dep_before)
+        assert deployed_before, "Fixture package must deploy user-scope files before uninstall"
 
         uninstall_result = _run_apm(
-            apm_binary_path,
-            ["uninstall", SAMPLE_PKG, "-g"],
-            work_dir,
-            fake_home,
+            hermetic_packaged_sample,
+            ("uninstall", SAMPLE_PKG, "-g"),
+            cwd=work_dir,
+            scenario_id="global-uninstall-user-scope",
         )
         assert uninstall_result.returncode == 0, (
             f"global uninstall failed:\nSTDOUT: {uninstall_result.stdout}\n"
@@ -177,45 +210,39 @@ class TestGlobalInstallDeploysRealPackage:
 
         # Previously deployed primitive files must be gone.
         for rel_path in deployed_before:
-            assert not (fake_home / rel_path).exists(), (
+            assert not (_home(hermetic_packaged_sample) / rel_path).exists(), (
                 f"Deployed file {rel_path} not removed by uninstall -g"
             )
 
     def test_install_global_then_project_install_does_not_collide(
-        self, apm_binary_path, fake_home, tmp_path
-    ):
+        self,
+        hermetic_packaged_sample: HermeticPackagedSample,
+    ) -> None:
         # Install globally first.
-        _write_user_manifest(fake_home, [SAMPLE_PKG])
-        global_workdir = tmp_path / "global-workdir"
-        global_workdir.mkdir()
-        global_result = _run_apm(apm_binary_path, ["install", "-g"], global_workdir, fake_home)
+        _write_user_manifest(hermetic_packaged_sample, [{"git": SAMPLE_REMOTE_URL}])
+        global_workdir = _make_workdir(hermetic_packaged_sample, "global-coexistence-workdir")
+        global_result = _run_apm(
+            hermetic_packaged_sample,
+            ("install", "-g"),
+            cwd=global_workdir,
+            scenario_id="global-install-before-project",
+        )
         assert global_result.returncode == 0, (
             f"global install failed:\nSTDOUT: {global_result.stdout}\n"
             f"STDERR: {global_result.stderr}"
         )
 
-        apm_dir = fake_home / ".apm"
+        apm_dir = _apm_home(hermetic_packaged_sample)
         global_dep = _get_locked_dep(_read_lockfile(apm_dir), SAMPLE_PKG)
         assert global_dep is not None, "Global lockfile missing the package"
 
-        # Now create a separate project and install the same package locally.
-        project_dir = tmp_path / "project"
-        project_dir.mkdir()
-        (project_dir / ".github").mkdir()
-        (project_dir / ".github" / "copilot-instructions.md").write_text("# test\n")
-        (project_dir / "apm.yml").write_text(
-            yaml.dump(
-                {
-                    "name": "local-project",
-                    "version": "1.0.0",
-                    "dependencies": {"apm": [SAMPLE_PKG], "mcp": []},
-                },
-                default_flow_style=False,
-            ),
-            encoding="utf-8",
+        project_dir = hermetic_packaged_sample.project.root
+        local_result = _run_apm(
+            hermetic_packaged_sample,
+            ("install",),
+            cwd=project_dir,
+            scenario_id="project-install-after-global",
         )
-
-        local_result = _run_apm(apm_binary_path, ["install"], project_dir, fake_home)
         assert local_result.returncode == 0, (
             f"project install failed:\nSTDOUT: {local_result.stdout}\nSTDERR: {local_result.stderr}"
         )


### PR DESCRIPTION
# fix(integration): hermeticize stale packaged G0 release-blocker tests

## TL;DR

Exact-main packaged G0 run `29643782978` only went red in two macOS x86_64 full-integration nodes, and both failures were stale test topology rather than product behavior. This PR removes the last live-GitHub dependency from those two modules by routing them through the owned `hermetic_packaged_sample` fixture and its process-scoped Git rewrite while keeping their lockfile and user-scope assertions intact. Product code, binaries, docs, changelog, and workflows are unchanged; the diff is exactly two test files.

> [!IMPORTANT]
> STALE TEST TOPOLOGY only. Human merge only. The coordinator replayed the exact failed run `29643782978` packaged binary (`dist/apm-darwin-x86_64/apm`) with `APM_BINARY_PATH=$bin uv run --extra dev pytest tests/integration/test_cache_lockfile_parity.py tests/integration/test_global_install_e2e.py -q -n 2 --dist loadgroup` and got `4 passed in 10.57s`.

## Problem (WHY)

- [x] Exact-main packaged G0 run `29643782978` failed in only two macOS x86_64 full-integration nodes while every other build/test cell, macOS arm64 integration cell, Linux/Windows integration cell, and Release Validation job stayed green.
- [x] `tests/integration/test_cache_lockfile_parity.py::test_lockfile_byte_identical_across_cache_regimes` still depended on a live `project_with_apm` / ambient-token path, so a runner DNS outage surfaced as `git clone` stderr `Could not resolve host: github.com` instead of as lockfile drift.
- [x] `tests/integration/test_global_install_e2e.py::TestGlobalInstallDeploysRealPackage::test_install_global_deploys_real_package_to_user_scope` still depended on live GitHub reachability, so the same outage consumed the 180s timeout before the test could exercise user-scope deployment.
- [!] A deterministic local poison against the source-backed CLI contract did not reproduce the packaged-binary DNS outage, so the stale-topology classification must anchor to the exact G0 record plus a post-fix mutation break on the owned rewrite boundary.

Why these matter: per PROSE, ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) These two modules were still letting GitHub availability decide whether package-manager contracts could even run. The fix also follows Agent Skills guidance to ["Add what the agent lacks, omit what it knows"](https://agentskills.io/skill-creation/best-practices): reuse the existing fixture owner instead of inventing another test-only authority.

## Approach (WHAT)

- Replace the bespoke parity-test manifest fixture with `hermetic_packaged_sample`, then let `_run_install` start from the fixture's full isolated environment and change only the cache knobs that define the cold, warm, and no-cache regimes.
- Seed `~/.apm/apm.yml` inside the same fixture-owned HOME for the global-install suite, but express the dependency as the owned GitHub-shaped HTTPS identity so the established `url_rewrite_subprocess_env` owner continues to intercept clones without changing the lockfile's `microsoft/apm-sample-package` identity.
- Keep scope surgical: no product code, fixture-owner code, docs, changelog, workflow, deferred PRs, or panel invocations changed.

## Implementation (HOW)

- **`tests/integration/test_cache_lockfile_parity.py`** -- swapped the token-gated `project_with_apm` path for `HermeticPackagedSample`, cloned the fixture consumer into three pristine per-regime worktrees, and ran each install from the fixture's isolated env plus only `APM_CACHE_DIR` / `APM_NO_CACHE` overrides. The parity assertions and all three regimes stayed intact. https://github.com/microsoft/apm/blob/4004699dcb8e1204d44d8a6b0a0efc93aeef8243/tests/integration/test_cache_lockfile_parity.py#L20-L145
- **`tests/integration/test_global_install_e2e.py`** -- replaced ad hoc `HOME` rewriting plus `requires_github_token` gating with fixture-owned HOME/APM_HOME helpers, seeded the user-scope manifest through the owned HTTPS identity, ran install/uninstall/coexistence through the same hermetic runner, and tightened uninstall to require an exactly empty `dependencies.apm` list instead of a vacuous string-membership check against dict-form entries. https://github.com/microsoft/apm/blob/4004699dcb8e1204d44d8a6b0a0efc93aeef8243/tests/integration/test_global_install_e2e.py#L9-L262

## Diagrams

Legend: both repaired modules now send the real CLI through the same fixture-owned rewrite boundary, but each still asserts its original contract at the lockfile or user-scope layer.

```mermaid
sequenceDiagram
    participant CacheTest as test_cache_lockfile_parity.py
    participant GlobalTest as test_global_install_e2e.py
    participant Fixture as hermetic_packaged_sample
    participant APM as apm binary
    participant Origin as local bare origin

    CacheTest->>Fixture: clone consumer for cold/warm/no-cache runs
    GlobalTest->>Fixture: seed ~/.apm/apm.yml in isolated HOME
    rect rgb(255, 247, 200)
        Note over Fixture,Origin: NEW: both modules reuse the same process-scoped Git rewrite
        Fixture->>APM: env with GIT_ALLOW_PROTOCOL=file + GIT_CONFIG_* rewrite
        APM->>Origin: clone https://github.com/microsoft/apm-sample-package
        Origin-->>APM: file:// bare repo contents
    end
    APM-->>CacheTest: parity lockfile across cache regimes
    APM-->>GlobalTest: user-scope deploy, uninstall, coexistence assertions
```

## Trade-offs

- **Reused the existing fixture owner instead of adding a new helper.** Chose `hermetic_packaged_sample` plus `url_rewrite_subprocess_env`; rejected a new global-install fixture because the repo already owns the GitHub-shaped local-origin authority.
- **Used HTTPS object-form input for the user-scope manifest while keeping `SAMPLE_PKG` as the asserted lockfile identity.** Rejected the old shortform manifest because it fell into the SSH auth path and bypassed the existing HTTPS rewrite owner.
- **Validated locally on the source-backed CLI contract and separately on the exact packaged artifact.** The coordinator replayed the exact failed run `29643782978` packaged binary (`dist/apm-darwin-x86_64/apm`) against these two modules under `-n 2 --dist loadgroup` and got `4 passed in 10.57s`.
- **Did not broaden scope into product code or fixture-owner code.** The failing signal was stale topology, so the fix stops at the two consumer tests.

## Benefits

1. The two exact release-blocker modules no longer depend on live GitHub DNS or token state to reach their actual assertions.
2. Cache-parity coverage still exercises all three regimes (`cold`, `warm`, `APM_NO_CACHE=1`) and now does so from the same isolated env the packaged fixture already proves.
3. User-scope install, uninstall, and project/global coexistence now run in an owned HOME with the same GitHub-shaped package identity the lockfile asserts.
4. The mutation break is now load-bearing: removing the process-scoped rewrite fails immediately with `fatal: transport 'https' not allowed`, which proves the repaired tests are actually using the owned fixture boundary.

## Validation

The commands below ran through `uv run --extra dev pytest`, which resolved `apm_binary_path` to `.venv/bin/apm`. Separately, the coordinator replayed the exact failed run `29643782978` packaged binary (`dist/apm-darwin-x86_64/apm`) with `APM_BINARY_PATH=$bin uv run --extra dev pytest tests/integration/test_cache_lockfile_parity.py tests/integration/test_global_install_e2e.py -q -n 2 --dist loadgroup` and got `4 passed in 10.57s`.

`uv run --extra dev ruff check tests/integration/test_cache_lockfile_parity.py tests/integration/test_global_install_e2e.py`

```text
All checks passed!
```

`uv run --extra dev ruff format --check tests/integration/test_cache_lockfile_parity.py tests/integration/test_global_install_e2e.py`

```text
2 files already formatted
```

<details><summary>Focused pytest and quality evidence</summary>

```text
$ uv run --extra dev pytest -p xdist.plugin tests/integration/test_url_rewrite_subprocess_env_install_e2e.py -q -n 2 --dist loadgroup
bringing up nodes...
bringing up nodes...

.                                                                        [100%]
1 passed in 2.34s

$ uv run --extra dev pytest tests/integration/test_local_git_repository_factory_contract.py -q -k url_rewrite_subprocess_env
.......                                                                  [100%]
7 passed, 12 deselected in 2.80s

$ for i in 1 2 3 4 5; do uv run --extra dev pytest -p xdist.plugin tests/integration/test_cache_lockfile_parity.py tests/integration/test_global_install_e2e.py -q -n 2 --dist loadgroup; done
REPEAT 1
....                                                                     [100%]
4 passed in 5.97s
REPEAT 2
....                                                                     [100%]
4 passed in 5.99s
REPEAT 3
....                                                                     [100%]
4 passed in 6.61s
REPEAT 4
....                                                                     [100%]
4 passed in 5.64s
REPEAT 5
....                                                                     [100%]
4 passed in 5.55s

$ uv run --extra dev pytest -p no:cacheprovider -q tests/quality/test_quality_baselines.py tests/quality/test_test_taxonomy.py
...............                                                          [100%]
15 passed in 23.72s

$ uv run --frozen python scripts/check_test_assertions.py
[+] assertion-quality ratchet clean: AQ001=4, AQ002=12

$ uv run --frozen python scripts/check_exact_test_duplicates.py
[+] exact test duplicate ratchet clean: 1062 files, 0 allowed duplicate group(s)
```

</details>

<details><summary>Mutation break: strip the process-scoped Git rewrite from the parity helper</summary>

```text
$ uv run --extra dev pytest tests/integration/test_cache_lockfile_parity.py::test_lockfile_byte_identical_across_cache_regimes -q -s
F
...
E       AssertionError: apm install failed:
E         STDOUT:
E         [>] Installing dependencies from apm.yml...
E         [>] Resolving microsoft/apm-sample-package...
E           [x] 1 package failed:
E             +- microsoft/apm-sample-package -- Failed to download dependency
E         microsoft/apm-sample-package: Failed to clone repository
E         microsoft/apm-sample-package via plain HTTPS.
E         ...
E         fatal: transport 'https' not allowed

$ shasum -a 256 tests/integration/test_cache_lockfile_parity.py
c4e61fa2131ed26f2fcf8690bd4230b54179c6bdaa9affd01e9aa385d20793e1

$ uv run --extra dev pytest -p xdist.plugin tests/integration/test_cache_lockfile_parity.py tests/integration/test_global_install_e2e.py -q -n 2 --dist loadgroup
....                                                                     [100%]
4 passed in 5.59s
```

</details>

<details><summary>Follow-up red proof: the old uninstall assertion was vacuous for dict-form deps</summary>

```text
$ python3 - <<'PY'
SAMPLE_PKG = 'microsoft/apm-sample-package'
SAMPLE_REMOTE_URL = f'https://github.com/{SAMPLE_PKG}'
apm_deps = [{'git': SAMPLE_REMOTE_URL}]
print(f'old_assertion={SAMPLE_PKG not in apm_deps}')
print(f'new_assertion={apm_deps == []}')
PY
old_assertion=True
new_assertion=False

$ uv run --extra dev pytest tests/integration/test_global_install_e2e.py::TestGlobalInstallDeploysRealPackage::test_uninstall_global_removes_deployed_files -q -s
F
...
E       AssertionError: ~/.apm/apm.yml should have no apm dependencies after uninstall: [{'git': 'https://github.com/microsoft/apm-sample-package'}]
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|------------------------|--------------|--------------------|------|
| 1 | Run `apm install` from the same manifest with a cold cache, a warm cache, or `APM_NO_CACHE=1` and get the same lockfile bytes every time | Governed by policy, DevX (pragmatic as npm) | `tests/integration/test_cache_lockfile_parity.py::test_lockfile_byte_identical_across_cache_regimes` (regression-trap for G0 run `29643782978` node 1) | integration |
| 2 | Run `apm install -g` in an isolated HOME and get a user-scope lockfile plus deployed files without leaking project files into the working directory | Multi-harness support, DevX (pragmatic as npm) | `tests/integration/test_global_install_e2e.py::TestGlobalInstallDeploysRealPackage::test_install_global_deploys_real_package_to_user_scope` (regression-trap for G0 run `29643782978` node 2) | integration |
| 3 | Run `apm uninstall microsoft/apm-sample-package -g` and remove the user-scope manifest entry, lockfile entry, and previously deployed files | Governed by policy, DevX (pragmatic as npm) | `tests/integration/test_global_install_e2e.py::TestGlobalInstallDeploysRealPackage::test_uninstall_global_removes_deployed_files` | integration |
| 4 | Install the same package globally and in a project without either scope losing its own lockfile or `apm_modules` tree | Portability by manifest, DevX (pragmatic as npm) | `tests/integration/test_global_install_e2e.py::TestGlobalInstallDeploysRealPackage::test_install_global_then_project_install_does_not_collide` | integration |

## How to test

- [ ] Run `uv run --extra dev pytest -p xdist.plugin tests/integration/test_cache_lockfile_parity.py tests/integration/test_global_install_e2e.py -q -n 2 --dist loadgroup` and see `4 passed`.
- [ ] Run `uv run --extra dev pytest tests/integration/test_url_rewrite_subprocess_env_install_e2e.py -q -n 2 --dist loadgroup` and see the rewrite owner stay green.
- [ ] Run `uv run --extra dev pytest tests/integration/test_local_git_repository_factory_contract.py -q -k url_rewrite_subprocess_env` and see the process-scoped rewrite contract stay green.
- [ ] Temporarily strip the `GIT_CONFIG_*` rewrite from `tests/integration/test_cache_lockfile_parity.py::_run_install`, rerun the parity node, and see `fatal: transport 'https' not allowed`; restore the file and rerun the four-node xdist command above.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
