### PR TITLE
Fix SSH passphrase hang: add BatchMode=yes to GIT_SSH_COMMAND

### DIFF
--- a/src/apm_cli/deps/bare_cache.py
+++ b/src/apm_cli/deps/bare_cache.py
@@ -749,6 +749,10 @@ def _is_ssh_key_auth_failure(error_text: str, last_attempt_scheme: str | None) -
         "bad passphrase",
         "read_passphrase",
         "permission denied (publickey)",
+        # OpenSSH BatchMode=yes output when all keys are skipped (e.g. an
+        # encrypted key with no ssh-agent loaded).
+        "no supported authentication methods remain",
+        "no more authentication methods to try",
     )
     return any(marker in text for marker in markers)
 

--- a/src/apm_cli/deps/git_auth_env.py
+++ b/src/apm_cli/deps/git_auth_env.py
@@ -5,7 +5,7 @@ Centralizes the three flavours of git env the downloader needs:
 1. ``setup_environment`` -- the auth-bearing env used for the
    downloader's primary git ops (clone, fetch, ls-remote with token).
    Sets up GIT_TERMINAL_PROMPT, GIT_ASKPASS, GIT_CONFIG_NOSYSTEM,
-   GIT_SSH_COMMAND (with ConnectTimeout), and GIT_CONFIG_GLOBAL
+   GIT_SSH_COMMAND (with ConnectTimeout and BatchMode), and GIT_CONFIG_GLOBAL
    to a sentinel empty file.
 
 2. ``noninteractive_env`` -- a non-auth env for fallback attempts
@@ -50,17 +50,30 @@ class GitAuthEnvBuilder:
         env["GIT_ASKPASS"] = "echo"
         env["GIT_CONFIG_NOSYSTEM"] = "1"
 
-        # Ensure SSH connections fail fast instead of hanging indefinitely
-        # when a firewall silently drops packets.
-        ssh_timeout = "-o ConnectTimeout=30"
+        # Ensure SSH connections fail fast instead of hanging indefinitely.
+        # ConnectTimeout=30 guards the TCP connection phase.
+        # BatchMode=yes prevents SSH from issuing an interactive passphrase
+        # prompt when the key is encrypted and no ssh-agent is running --
+        # without it, git hangs until the server closes the connection
+        # (LoginGraceTime, typically 120 s), which looks like a network
+        # timeout rather than an auth failure.  Users with a passphrase-
+        # protected key should load it into ssh-agent before running APM
+        # (e.g. 'ssh-add <key-file>'); BatchMode=yes converts the
+        # confusing timeout into an immediate, diagnosable failure.
         existing_ssh_cmd = os.environ.get("GIT_SSH_COMMAND", "").strip()
         if existing_ssh_cmd:
+            base_cmd = existing_ssh_cmd
+            extra_opts: list[str] = []
             if "connecttimeout" not in existing_ssh_cmd.lower():
-                env["GIT_SSH_COMMAND"] = f"{existing_ssh_cmd} {ssh_timeout}"
+                extra_opts.append("-o ConnectTimeout=30")
+            if "batchmode" not in existing_ssh_cmd.lower():
+                extra_opts.append("-o BatchMode=yes")
+            if extra_opts:
+                env["GIT_SSH_COMMAND"] = f"{base_cmd} {' '.join(extra_opts)}"
             else:
-                env["GIT_SSH_COMMAND"] = existing_ssh_cmd
+                env["GIT_SSH_COMMAND"] = base_cmd
         else:
-            env["GIT_SSH_COMMAND"] = f"ssh {ssh_timeout}"
+            env["GIT_SSH_COMMAND"] = "ssh -o ConnectTimeout=30 -o BatchMode=yes"
 
         env.setdefault("GIT_CONFIG_GLOBAL", self.isolated_global_config_path())
 

--- a/tests/unit/deps/test_bare_cache_clone_failure.py
+++ b/tests/unit/deps/test_bare_cache_clone_failure.py
@@ -96,6 +96,34 @@ def test_clone_failure_message_explains_explicit_ssh_publickey_failure() -> None
     assert "token-backed HTTPS" in message
 
 
+def test_clone_failure_message_explains_batchmode_no_auth_methods() -> None:
+    """BatchMode=yes 'no supported authentication methods remain' should surface ssh-add hint.
+
+    When APM sets -o BatchMode=yes and the user's SSH key is passphrase-protected
+    but no ssh-agent has the decrypted key cached, OpenSSH skips the encrypted key
+    and may emit this message before failing with 'Permission denied (publickey)'.
+    """
+    message = _clone_failure_message(
+        stderr=b"no supported authentication methods remain\nfatal: Could not read from remote repository.\n",
+        attempt_scheme="ssh",
+    )
+
+    assert "SSH key authentication failed" in message
+    assert "ssh-add <key-file>" in message
+    assert "token-backed HTTPS" in message
+
+
+def test_clone_failure_message_explains_batchmode_no_more_auth_methods() -> None:
+    """Alternative OpenSSH BatchMode=yes output variant triggers ssh-add hint."""
+    message = _clone_failure_message(
+        stderr=b"no more authentication methods to try\nPermission denied.\n",
+        attempt_scheme="ssh",
+    )
+
+    assert "SSH key authentication failed" in message
+    assert "ssh-add <key-file>" in message
+
+
 def test_clone_failure_message_does_not_echo_captured_ssh_stderr() -> None:
     """Classification input must not become user-visible output."""
     message = _clone_failure_message(

--- a/tests/unit/deps/test_git_auth_env.py
+++ b/tests/unit/deps/test_git_auth_env.py
@@ -57,8 +57,9 @@ class TestSetupEnvironment:
         assert env["GIT_CONFIG_NOSYSTEM"] == "1"
         # Token-manager-provided keys preserved.
         assert env["GITHUB_TOKEN"] == "ghp_xxx"
-        # ConnectTimeout always added.
+        # ConnectTimeout and BatchMode always added.
         assert "ConnectTimeout=30" in env["GIT_SSH_COMMAND"]
+        assert "BatchMode=yes" in env["GIT_SSH_COMMAND"]
 
     def test_bearer_path_preserves_token_manager_env(self):
         # ADO bearer flow: token_manager publishes Authorization-style
@@ -81,13 +82,25 @@ class TestSetupEnvironment:
         assert env["GIT_ASKPASS"] == "echo"
         assert env["GIT_CONFIG_NOSYSTEM"] == "1"
         assert "GIT_CONFIG_GLOBAL" in env
+        assert "BatchMode=yes" in env["GIT_SSH_COMMAND"]
 
     def test_existing_ssh_command_preserves_existing_connecttimeout(self):
         tm = _FakeTokenManager()
         with patch.dict(os.environ, {"GIT_SSH_COMMAND": "ssh -o ConnectTimeout=5"}, clear=False):
             env = GitAuthEnvBuilder(tm).setup_environment()
-        # Existing ConnectTimeout NOT overridden (case-insensitive check).
-        assert env["GIT_SSH_COMMAND"] == "ssh -o ConnectTimeout=5"
+        # Existing ConnectTimeout NOT overridden (case-insensitive check),
+        # but BatchMode=yes is still appended since it was absent.
+        assert "ConnectTimeout=5" in env["GIT_SSH_COMMAND"]
+        assert "ConnectTimeout=30" not in env["GIT_SSH_COMMAND"]
+        assert "BatchMode=yes" in env["GIT_SSH_COMMAND"]
+
+    def test_existing_ssh_command_preserves_existing_batchmode(self):
+        tm = _FakeTokenManager()
+        with patch.dict(os.environ, {"GIT_SSH_COMMAND": "ssh -o BatchMode=yes"}, clear=False):
+            env = GitAuthEnvBuilder(tm).setup_environment()
+        # User-set BatchMode preserved; ConnectTimeout appended; no duplicate BatchMode.
+        assert env["GIT_SSH_COMMAND"].count("BatchMode") == 1
+        assert "ConnectTimeout=30" in env["GIT_SSH_COMMAND"]
 
     def test_existing_ssh_command_appends_connecttimeout(self):
         tm = _FakeTokenManager()
@@ -97,6 +110,7 @@ class TestSetupEnvironment:
             env = GitAuthEnvBuilder(tm).setup_environment()
         assert "StrictHostKeyChecking=no" in env["GIT_SSH_COMMAND"]
         assert "ConnectTimeout=30" in env["GIT_SSH_COMMAND"]
+        assert "BatchMode=yes" in env["GIT_SSH_COMMAND"]
 
     def test_git_config_global_set_to_devnull_on_unix(self):
         if sys.platform == "win32":

--- a/tests/unit/deps/test_git_auth_env.py
+++ b/tests/unit/deps/test_git_auth_env.py
@@ -99,7 +99,8 @@ class TestSetupEnvironment:
         with patch.dict(os.environ, {"GIT_SSH_COMMAND": "ssh -o BatchMode=yes"}, clear=False):
             env = GitAuthEnvBuilder(tm).setup_environment()
         # User-set BatchMode preserved; ConnectTimeout appended; no duplicate BatchMode.
-        assert env["GIT_SSH_COMMAND"].count("BatchMode") == 1
+        # Use case-insensitive count to match the production idempotency contract.
+        assert env["GIT_SSH_COMMAND"].lower().count("batchmode") == 1
         assert "ConnectTimeout=30" in env["GIT_SSH_COMMAND"]
 
     def test_existing_ssh_command_appends_connecttimeout(self):


### PR DESCRIPTION
## TL;DR

Add `-o BatchMode=yes` to the SSH command APM injects via `GIT_SSH_COMMAND`, so a missing passphrase causes an immediate, diagnosable failure instead of a silent hang that surfaces as "Connection timed out" after ~120 seconds.

Fixes #1976.

---

## Problem (WHY)

When a user's SSH key is passphrase-protected and `ssh-agent` is not running (or does not have the key loaded), OpenSSH cannot obtain the passphrase non-interactively. Without `BatchMode=yes`, SSH silently waits for a TTY passphrase prompt that never arrives. The SSH server eventually closes the idle connection after its `LoginGraceTime` (default 120 s), and git reports:

```
ssh: connect to host org.ghe.com port 22: Connection timed out
fatal: Could not read from remote repository.
```

This is indistinguishable from a network/firewall problem. The user has no indication that running `ssh-add <key-file>` before `apm install` would fix everything.

---

## Approach (WHAT)

`-o BatchMode=yes` tells OpenSSH to **never issue interactive prompts**. When an encrypted key has no agent entry, SSH skips the key and fails immediately with `Permission denied (publickey)` instead of hanging. APM's existing `_is_ssh_key_auth_failure()` detection already catches this string and surfaces the `ssh-add` diagnostic. The fix converts a confusing 30-120 second timeout into an instant, actionable error message.

Key properties:
- **Safe for ssh-agent users** -- the agent serves the passphrase without any interactive prompt; `BatchMode=yes` does not interfere.
- **Safe for unencrypted keys** -- they are usable in BatchMode without an agent.
- **Idempotent** -- if the user sets `GIT_SSH_COMMAND` with their own `BatchMode` option, it is preserved and not duplicated.

---

## Implementation (HOW)

### `src/apm_cli/deps/git_auth_env.py`

`setup_environment()` now builds `GIT_SSH_COMMAND` with both options, applying the same case-insensitive idempotency checks:

```python
# Before
env["GIT_SSH_COMMAND"] = f"ssh {ssh_timeout}"

# After
env["GIT_SSH_COMMAND"] = "ssh -o ConnectTimeout=30 -o BatchMode=yes"
```

When the user already has `GIT_SSH_COMMAND` set, each option is appended only if absent (case-insensitive match).

### `src/apm_cli/deps/bare_cache.py`

`_is_ssh_key_auth_failure()` gains two additional OpenSSH BatchMode-era failure strings:

```python
"no supported authentication methods remain",
"no more authentication methods to try",
```

These are emitted when BatchMode=yes causes SSH to skip all encrypted keys with no agent entry.

### Tests

- `tests/unit/deps/test_git_auth_env.py` -- assert `BatchMode=yes` present in the default env; new test for user-set BatchMode not being duplicated; existing ConnectTimeout override test updated.
- `tests/unit/deps/test_bare_cache_clone_failure.py` -- two new tests assert the BatchMode failure strings trigger the `ssh-add` diagnostic.

---

## Architecture diagram

```mermaid
sequenceDiagram
    participant User
    participant APM
    participant Git
    participant SSH
    participant Server

    Note over APM: GIT_SSH_COMMAND includes BatchMode=yes

    User->>APM: apm install
    APM->>Git: clone (GIT_SSH_COMMAND set)
    Git->>SSH: authenticate with key
    alt ssh-agent has key cached
        SSH->>Server: key exchange succeeds
        Server-->>APM: clone OK
    else no agent / passphrase needed
        SSH-->>Git: Permission denied (publickey) [immediate]
        Git-->>APM: GitCommandError
        APM-->>User: "run ssh-add <key-file> before apm install"
    end
```

---

## Trade-offs

| Option | Chosen | Reason |
|--------|--------|--------|
| `BatchMode=yes` global | Yes | Correct for all non-interactive use; safe with ssh-agent |
| Per-attempt opt-in (SSH only) | No | `GIT_SSH_COMMAND` already applies only to SSH; no extra branching needed |
| Surface passphrase prompt interactively | No | Requires ConPTY/pty which has CI measurement failures (#2242); BatchMode is the standard non-interactive pattern |

---

## Validation evidence

- All 26 targeted unit tests pass: `pytest tests/unit/deps/test_git_auth_env.py tests/unit/deps/test_bare_cache_clone_failure.py`
- Full lint mirror clean: `ruff check`, `ruff format --check`, `pylint R0801`, `bash scripts/lint-auth-signals.sh` -- all exit 0

## How to test

1. Generate an encrypted SSH key: `ssh-keygen -t ed25519 -f /tmp/test_key` (enter a passphrase)
2. Add the public key to a test repo
3. Configure APM to use SSH for that repo; do NOT load the key into ssh-agent
4. Run `apm install` -- **before**: hangs ~120 s then "Connection timed out"; **after**: fails immediately with the ssh-add diagnostic
5. Run `ssh-add /tmp/test_key` (enter passphrase once)
6. Run `apm install` again -- succeeds without prompting