### PR TITLE
Fix dep devDependencies.mcp leaking into consumer MCP config (#2340)

### DIFF
--- a/.apm/instructions/architecture.instructions.md
+++ b/.apm/instructions/architecture.instructions.md
@@ -56,6 +56,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | Post-uninstall dependency reachability | deps/reachability.py (compute_forward_reachable_keys) | `src/apm_cli/deps/reachability.py` |
 | CI audit scratch materialization | install/audit_replay.py (prepare_ci_audit_replay) | `src/apm_cli/install/audit_replay.py` |
 | GitHub API throttle classification | deps/github_rate_limit.py | `src/apm_cli/deps/github_rate_limit.py` |
+| Root vs dependency MCP declaration scope | integration/mcp_config_view.py (CurrentMcpConfigView) | `src/apm_cli/integration/mcp_config_view.py` |
 <!-- /canonical-owner-table -->
 
 Host + credential resolution includes public github.com anonymous-first ordering.

--- a/.github/instructions/architecture.instructions.md
+++ b/.github/instructions/architecture.instructions.md
@@ -56,6 +56,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | Post-uninstall dependency reachability | deps/reachability.py (compute_forward_reachable_keys) | `src/apm_cli/deps/reachability.py` |
 | CI audit scratch materialization | install/audit_replay.py (prepare_ci_audit_replay) | `src/apm_cli/install/audit_replay.py` |
 | GitHub API throttle classification | deps/github_rate_limit.py | `src/apm_cli/deps/github_rate_limit.py` |
+| Root vs dependency MCP declaration scope | integration/mcp_config_view.py (CurrentMcpConfigView) | `src/apm_cli/integration/mcp_config_view.py` |
 <!-- /canonical-owner-table -->
 
 Host + credential resolution includes public github.com anonymous-first ordering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `dependencies.mcp` from transitive packages propagate downstream,
   matching how `devDependencies.apm` is already handled and the documented
   dev/prod contract. Root-project `devDependencies.mcp` behavior is
+- Consuming projects no longer inherit a dependency author's development-only
+  MCP servers: `devDependencies.mcp` from direct and transitive dependency
+  packages is now excluded from the consumer's MCP config and provenance, just
+  as `devDependencies.apm` already is. Only `dependencies.mcp` from packages
+  propagates downstream. Root-project `devDependencies.mcp` behavior is
   unchanged. (#2340)
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,11 +49,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   matching how `devDependencies.apm` is already handled and the documented
   dev/prod contract. Root-project `devDependencies.mcp` behavior is
 - Consuming projects no longer inherit a dependency author's development-only
-  MCP servers: `devDependencies.mcp` from direct and transitive dependency
-  packages is now excluded from the consumer's MCP config and provenance, just
-  as `devDependencies.apm` already is. Only `dependencies.mcp` from packages
-  propagates downstream. Root-project `devDependencies.mcp` behavior is
-  unchanged. (#2340)
+  MCP servers. Only `dependencies.mcp` from direct and transitive packages
+  propagates; the root project's `dependencies.mcp` and `devDependencies.mcp`
+  remain active for its authoring environment.
+  (by @sergio-sisternes-epam, #2340)
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview
   now excludes the synthesized lockfile self-entry, matching the real install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stale. The matching `openapm-v0.1.md` frozen-install requirement now covers
   MCP state and all durable writes. (by @edenfunf, #2390; fixes #2373)
 
+- `devDependencies.mcp` servers declared by a dependency are no longer
+  installed into the consuming project's MCP config. Only
+  `dependencies.mcp` from transitive packages propagate downstream,
+  matching how `devDependencies.apm` is already handled and the documented
+  dev/prod contract. Root-project `devDependencies.mcp` behavior is
+  unchanged. (#2340)
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview
   now excludes the synthesized lockfile self-entry, matching the real install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,11 +40,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stale. The matching `openapm-v0.1.md` frozen-install requirement now covers
   MCP state and all durable writes. (by @edenfunf, #2390; fixes #2373)
 
-- `devDependencies.mcp` servers declared by a dependency are no longer
-  installed into the consuming project's MCP config. Only
-  `dependencies.mcp` from transitive packages propagate downstream,
-  matching how `devDependencies.apm` is already handled and the documented
-  dev/prod contract. Root-project `devDependencies.mcp` behavior is
 - Consuming projects no longer inherit a dependency author's development-only
   MCP servers. Only `dependencies.mcp` from direct and transitive packages
   propagates; the root project's `dependencies.mcp` and `devDependencies.mcp`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Public `github.com` dependencies now try anonymous HTTPS before resolving
   credentials, so all-public installs no longer open repeated credential or
   Git Credential Manager prompts. Reported by @RuiRomano. (#2406, closes #2400)
-- `apm self-update` now downloads the installer script from the exact selected
-  release tag and passes that same normalized version to the installer, avoiding
-  drift between installer bytes and stable or prerelease selection. (by
 - `apm self-update` now downloads GitHub and GHES installer scripts from the
   exact selected release tag and passes that same normalized version to the
   installer, while configured installer mirrors remain authoritative. (by

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -2783,7 +2783,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:ff22fbee2c9194c14ef2de92cc67ff19cfcb092a109fae033022c0751acde5be
+  content_hash: sha256:5054539ccfe9df5365b53dd5d2679ceb8806121b99856e2fa185166d7d7d8cee
 - kind: project-relative
   target: copilot
   value: .github/instructions/changelog.instructions.md
@@ -3290,7 +3290,7 @@ local_deployed_file_hashes:
   .github/agents/spec-tag-architect.agent.md: sha256:82907265c5e7cf1ac61ad96866fa7c5683b69c8f09b7a4c5f3cc241acc9568ca
   .github/agents/supply-chain-security-expert.agent.md: sha256:8fb8cc426d6af17ba084a28b3f026c2b475b62e3ca63ed2f88b83bd823f877af
   .github/agents/test-coverage-expert.agent.md: sha256:48c2172d1f18a394fa83ef9dc2be0b9b921a4e51e976498165250fed66369711
-  .github/instructions/architecture.instructions.md: sha256:ff22fbee2c9194c14ef2de92cc67ff19cfcb092a109fae033022c0751acde5be
+  .github/instructions/architecture.instructions.md: sha256:5054539ccfe9df5365b53dd5d2679ceb8806121b99856e2fa185166d7d7d8cee
   .github/instructions/changelog.instructions.md: sha256:1e51ec4c74e847967962bd279dc4c6e582c5d3578490b3c28d5f3acd3e05f73e
   .github/instructions/cicd.instructions.md: sha256:08d87b7d635761cb41deb8fc71d5d83f54678de463db484afb16d2d4f8713ecb
   .github/instructions/cli.instructions.md: sha256:8e39e8d5047ce88575cb02f87c2bcede584dfef258bd86f7466c7badf136541a

--- a/docs/src/content/docs/consumer/install-mcp-servers.md
+++ b/docs/src/content/docs/consumer/install-mcp-servers.md
@@ -24,6 +24,12 @@ MCP servers live under `dependencies.mcp:` (or
 `devDependencies.mcp:`). Three forms are valid -- pick the one that
 matches the source you have:
 
+The two sections have different propagation rules. In the root project,
+`apm install` activates both sections for the author's environment. A
+direct or transitive dependency package contributes only
+`dependencies.mcp`; its `devDependencies.mcp` entries never enter the
+consumer's target config, lockfile provenance, or audit baseline.
+
 ```yaml
 dependencies:
   mcp:

--- a/docs/src/content/docs/consumer/install-mcp-servers.md
+++ b/docs/src/content/docs/consumer/install-mcp-servers.md
@@ -20,15 +20,16 @@ adapter prerequisites.
 
 ## The `mcp:` section in apm.yml
 
-MCP servers live under `dependencies.mcp:` (or
-`devDependencies.mcp:`). Three forms are valid -- pick the one that
-matches the source you have:
-
 The two sections have different propagation rules. In the root project,
 `apm install` activates both sections for the author's environment. A
 direct or transitive dependency package contributes only
 `dependencies.mcp`; its `devDependencies.mcp` entries never enter the
 consumer's target config, lockfile provenance, or audit baseline.
+This keeps package-author debug servers out of consumer tool lists.
+
+MCP servers live under `dependencies.mcp:` (or
+`devDependencies.mcp:`). Three forms are valid -- pick the one that
+matches the source you have:
 
 ```yaml
 dependencies:

--- a/docs/src/content/docs/enterprise/security.md
+++ b/docs/src/content/docs/enterprise/security.md
@@ -358,6 +358,7 @@ APM separates production and development dependencies:
 
 - **Production dependencies** (`dependencies.apm`) are included in plugin bundles and shared packages.
 - **Development dependencies** (`devDependencies.apm`, installed via `apm install --dev`) are resolved and cached locally but **excluded** from `apm pack` output (both plugin format -- the default -- and `--format apm`).
+- **Development MCP servers** in the root project's `devDependencies.mcp` are active for authoring, but the same section in a direct or transitive dependency package never propagates into the consumer's target config or provenance.
 
 This prevents transitive inclusion of development-only packages (test fixtures, linting rules, internal helpers) in distributed artifacts. The lockfile marks dev dependencies with `is_dev: true` for explicit tracking. See the [Lock File Specification](../../reference/lockfile-spec/#42-dependency-entries) for field details.
 

--- a/docs/src/content/docs/integrations/ide-tool-integration.md
+++ b/docs/src/content/docs/integrations/ide-tool-integration.md
@@ -100,7 +100,10 @@ apm install --target agent-skills
 
 ## MCP server integration
 
-MCP servers declared in `apm.yml` (under `dependencies.mcp:` or `devDependencies.mcp:`) are wired into each target's MCP config on install:
+MCP servers declared by the root project under `dependencies.mcp:` or
+`devDependencies.mcp:` are wired into each target's MCP config on install.
+Dependency packages contribute only `dependencies.mcp`; their
+`devDependencies.mcp` entries stay in the package author's environment.
 
 - `.mcp.json` at the repo root when `.claude/` exists (Claude Code project scope)
 - `.cursor/mcp.json` (Cursor)

--- a/docs/src/content/docs/reference/baseline-checks.md
+++ b/docs/src/content/docs/reference/baseline-checks.md
@@ -124,7 +124,7 @@ the [policy schema](../policy-schema/).
 
 ### `config-consistency`
 
-- **What it verifies.** That MCP server configs derived from the root `dependencies.mcp` and `devDependencies.mcp`, plus every current local or installed-remote package manifest bounded by the lockfile, match the `mcp_configs` baseline.
+- **What it verifies.** That MCP server configs derived from the root `dependencies.mcp` and `devDependencies.mcp`, plus `dependencies.mcp` from every current local or installed-remote package manifest bounded by the lockfile, match the `mcp_configs` baseline. Dependency-package `devDependencies.mcp` is author-only and is excluded from the consumer baseline.
 - **Fails when.** A server's resolved config differs from the lockfile, a server exists on only one side, or a locked package manifest is unreadable. In `apm audit --ci`, when `apm_modules/` is absent but the lockfile is present, APM first self-hydrates a lock-pinned scratch install and derives the current MCP truth from that isolated modules tree; if the scratch replay itself fails, `config-consistency` fails closed with the replay error. A missing manifest also fails unless the lockfile records a skill bundle, or declares a virtual subdirectory whose lock metadata and materialized shape both identify it as a Claude skill. `mcp_config_provenance` identifies the package in lock-only diagnostics but never exempts a removed declaration.
 - **Remediation.** Run `apm install` to reconcile the MCP configuration or restore an unreadable package source.
 

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -392,7 +392,7 @@ lives in `docs/src/content/docs/reference/manifest-schema.md` section
 
 ## MCP dependency formats
 
-See also: [MCP Servers guide](../../../../../docs/src/content/docs/guides/mcp-servers.md) for the CLI-first `apm install --mcp` workflow.
+See also: [MCP Servers guide](../../../../../docs/src/content/docs/consumer/install-mcp-servers.md) for the CLI-first `apm install --mcp` workflow.
 
 ```yaml
 dependencies:
@@ -452,6 +452,26 @@ dependencies:
         clientId: "<pre-registered-client-id>"
         callbackPort: 3118
 ```
+
+### Development MCP scope
+
+Use `dependencies.mcp` for servers that a consuming project should
+receive. Use `devDependencies.mcp` for author-only servers such as local
+mocks or debug bridges:
+
+```yaml
+devDependencies:
+  mcp:
+    - name: author-debug
+      registry: false
+      transport: stdio
+      command: ./scripts/author-debug
+```
+
+The root project activates both sections during `apm install`. Direct
+and transitive dependency packages contribute only `dependencies.mcp`;
+their development MCP entries do not enter the consumer's target config
+or `mcp_config_provenance`.
 
 At user scope, Claude MCP entries are written to
 `$CLAUDE_CONFIG_DIR/.claude.json` when `CLAUDE_CONFIG_DIR` is set to a

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -92,6 +92,15 @@ Per-primitive scan paths for `apm install`:
 every primitive. This is the only layout that is symmetric between
 `apm pack` and `apm install`.
 
+## Development MCP scope
+
+Put consumer-facing MCP servers in `dependencies.mcp`. Put local mocks,
+debug bridges, and other author-only servers in
+`devDependencies.mcp`. The root package receives both sections in its
+authoring environment; consumers of that package receive only
+`dependencies.mcp`, including when the package is nested transitively.
+See [MCP dependency formats](dependencies.md#mcp-dependency-formats).
+
 ## Hook files
 
 Packages can ship hooks (pre/post tool-use scripts) by placing JSON

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -1004,6 +1004,35 @@ if ! grep -q '^    def enforce_frozen(' "$frozen_owner" \
     violations=$((violations + 1))
 fi
 
+echo "[*] AC25: root vs dependency MCP declaration-scope authority"
+mcp_scope_owner="src/apm_cli/integration/mcp_config_view.py"
+mcp_root_scope_body=$(awk '
+    /^    def derive\(/ {flag=1}
+    flag && /^    def / && !/^    def derive\(/ {exit}
+    flag {print}
+' "$mcp_scope_owner")
+mcp_locked_scope_body=$(awk '
+    /^def _collect_locked_dependencies\(/ {flag=1}
+    flag && /^def / && !/^def _collect_locked_dependencies\(/ {exit}
+    flag {print}
+' "$mcp_scope_owner")
+mcp_unlocked_scope_body=$(awk '
+    /^def _collect_unlocked_compat\(/ {flag=1}
+    flag && /^def / && !/^def _collect_unlocked_compat\(/ {exit}
+    flag {print}
+' "$mcp_scope_owner")
+if [ "$(printf '%s\n' "$mcp_root_scope_body" \
+        | grep -c 'root\.get_all_mcp_dependencies()')" -ne 1 ] \
+    || printf '%s\n%s\n' "$mcp_locked_scope_body" "$mcp_unlocked_scope_body" \
+        | grep -q 'get_all_mcp_dependencies()' \
+    || [ "$(printf '%s\n' "$mcp_locked_scope_body" \
+        | grep -c 'package\.get_mcp_dependencies()')" -ne 1 ] \
+    || [ "$(printf '%s\n' "$mcp_unlocked_scope_body" \
+        | grep -c 'package\.get_mcp_dependencies()')" -ne 1 ]; then
+    echo "[x] Transitive MCP dependency scope must use production-only collection"
+    violations=$((violations + 1))
+fi
+
 
 
 

--- a/src/apm_cli/commands/update.py
+++ b/src/apm_cli/commands/update.py
@@ -251,6 +251,11 @@ def _run_mcp_lsp_integration(
         old_mcp_configs = dict(existing_lock.mcp_configs)
         old_mcp_provenance = dict(existing_lock.mcp_config_provenance)
         old_mcp_target_servers = dict(existing_lock.mcp_target_servers)
+    trusted_transitive_configs = {
+        name: config
+        for name, config in old_mcp_configs.items()
+        if name in old_mcp_provenance and config.get("registry") is False
+    }
 
     apm_modules_path = get_modules_dir(scope)
     user_scope = scope is InstallScope.USER
@@ -265,6 +270,7 @@ def _run_mcp_lsp_integration(
             old_mcp_configs=old_mcp_configs,
             old_mcp_provenance=old_mcp_provenance,
             old_mcp_target_servers=old_mcp_target_servers,
+            trusted_transitive_configs=trusted_transitive_configs,
             project_root=project_root,
             user_scope=user_scope,
             should_install=True,
@@ -730,6 +736,7 @@ def _run_dep_update(
                 _rich_error(f"Failed to record revision-pin tags in apm.lock.yaml: {e}")
                 sys.exit(1)
 
+    if plan_state.proceeded or reconcile_noop:
         try:
             _run_mcp_lsp_integration(
                 scope=scope,
@@ -747,6 +754,7 @@ def _run_dep_update(
                 _rich_info("Run with --verbose for detailed diagnostics.")
             sys.exit(1)
 
+    if plan_state.proceeded:
         # Report the number of dependencies that actually changed (per the
         # plan), not the total tree re-materialized (result.installed_count).
         # The latter counts unchanged deps that were re-integrated, which

--- a/src/apm_cli/commands/update.py
+++ b/src/apm_cli/commands/update.py
@@ -252,7 +252,7 @@ def _run_mcp_lsp_integration(
         old_mcp_provenance = dict(existing_lock.mcp_config_provenance)
         old_mcp_target_servers = dict(existing_lock.mcp_target_servers)
     trusted_transitive_configs = {
-        name: config
+        name: (old_mcp_provenance[name], config)
         for name, config in old_mcp_configs.items()
         if name in old_mcp_provenance and config.get("registry") is False
     }

--- a/src/apm_cli/install/mcp/integration.py
+++ b/src/apm_cli/install/mcp/integration.py
@@ -35,6 +35,7 @@ def run_mcp_integration(  # noqa: PLR0913
     verbose: bool = False,
     explicit_target: str | list[str] | None = None,
     scope=None,
+    trusted_transitive_configs: builtins.dict | None = None,
 ) -> tuple[int, dict]:
     """Run MCP server integration after APM package installation.
 
@@ -69,6 +70,8 @@ def run_mcp_integration(  # noqa: PLR0913
         no_policy: Skip policy enforcement for the merged MCP set.
         verbose: Show detailed installation information.
         explicit_target: Explicit target selected by CLI or manifest.
+        trusted_transitive_configs: Exact previously trusted self-defined
+            transitive configs that a no-op update may preserve.
         scope: Optional InstallScope for user/project filtering.
 
     Returns:
@@ -96,6 +99,8 @@ def run_mcp_integration(  # noqa: PLR0913
             apm_modules_path,
             trust_transitive_self_defined=trust_transitive_mcp,
             diagnostics=diagnostics,
+            logger=logger,
+            trusted_transitive_configs=trusted_transitive_configs,
         )
         root_count = len(apm_package.get_all_mcp_dependencies())
         transitive_count = max(0, len(current_view.dependencies) - root_count)

--- a/src/apm_cli/install/mcp/integration.py
+++ b/src/apm_cli/install/mcp/integration.py
@@ -5,8 +5,9 @@ with runtime-neutral target selection.
 """
 
 import builtins
+from collections.abc import Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from apm_cli.models.apm_package import APMPackage
@@ -35,7 +36,7 @@ def run_mcp_integration(  # noqa: PLR0913
     verbose: bool = False,
     explicit_target: str | list[str] | None = None,
     scope=None,
-    trusted_transitive_configs: builtins.dict | None = None,
+    trusted_transitive_configs: (Mapping[str, tuple[str, Mapping[str, Any]]] | None) = None,
 ) -> tuple[int, dict]:
     """Run MCP server integration after APM package installation.
 
@@ -70,8 +71,8 @@ def run_mcp_integration(  # noqa: PLR0913
         no_policy: Skip policy enforcement for the merged MCP set.
         verbose: Show detailed installation information.
         explicit_target: Explicit target selected by CLI or manifest.
-        trusted_transitive_configs: Exact previously trusted self-defined
-            transitive configs that a no-op update may preserve.
+        trusted_transitive_configs: Exact declaring-package/config pairs for
+            previously trusted self-defined servers that a no-op update may preserve.
         scope: Optional InstallScope for user/project filtering.
 
     Returns:

--- a/src/apm_cli/integration/mcp_config_view.py
+++ b/src/apm_cli/integration/mcp_config_view.py
@@ -62,7 +62,8 @@ class CurrentMcpConfigView:
         )
         # Root is the authoring project: both prod and dev MCP are intentionally
         # included here (behaviour introduced in #1780). Transitive package deps
-        # are collected prod-only (see _collect_locked_dependencies).
+        # are collected prod-only (see _collect_locked_dependencies and
+        # _collect_unlocked_compat).
         dependencies = tuple(_deduplicate(root.get_all_mcp_dependencies() + package_deps))
         return cls(
             dependencies=dependencies,
@@ -314,7 +315,7 @@ def _collect_unlocked_compat(
         except (OSError, ValueError, UnicodeError):
             continue
         declarer = package.name or manifest_path.parent.name
-        # Only collect prod MCP from packages; devDependencies.mcp scoped to
+        # Only collect prod MCP from packages; devDependencies.mcp are scoped to
         # the package author's own environment (#2340).
         for dependency in package.get_mcp_dependencies():
             if dependency.is_self_defined and not trust_transitive_self_defined:

--- a/src/apm_cli/integration/mcp_config_view.py
+++ b/src/apm_cli/integration/mcp_config_view.py
@@ -50,6 +50,8 @@ class CurrentMcpConfigView:
         *,
         trust_transitive_self_defined: bool,
         diagnostics: DiagnosticCollector | None = None,
+        logger: Any | None = None,
+        trusted_transitive_configs: Mapping[str, Mapping[str, Any]] | None = None,
     ) -> CurrentMcpConfigView:
         """Derive current MCP truth without mutating manifests or the lockfile."""
         project_root = root.package_path or Path.cwd()
@@ -59,6 +61,8 @@ class CurrentMcpConfigView:
             project_root,
             trust_transitive_self_defined=trust_transitive_self_defined,
             diagnostics=diagnostics,
+            logger=logger,
+            trusted_transitive_configs=trusted_transitive_configs,
         )
         # Root is the authoring project: both prod and dev MCP are intentionally
         # included here (behaviour introduced in #1780). Transitive package deps
@@ -133,6 +137,31 @@ def _get_server_provenance(dependencies: list[Any] | tuple[Any, ...]) -> dict[st
     return provenance
 
 
+def _log_skipped_dev_mcp(
+    package: APMPackage,
+    declarer: str,
+    logger: Any | None,
+) -> None:
+    """Explain a dependency-scope exclusion without logging server names."""
+    skipped_count = len(package.get_dev_mcp_dependencies())
+    if skipped_count and logger is not None:
+        logger.verbose_detail(
+            f"Skipping {skipped_count} development MCP dependency(ies) from "
+            f"'{declarer}'; dependency devDependencies.mcp do not propagate"
+        )
+
+
+def _matches_trusted_transitive_config(
+    dependency: MCPDependency,
+    trusted_configs: Mapping[str, Mapping[str, Any]] | None,
+) -> bool:
+    """Return whether an unchanged self-defined config was trusted before."""
+    if trusted_configs is None:
+        return False
+    stored = trusted_configs.get(dependency.name)
+    return stored is not None and dependency.to_dict() == stored
+
+
 def _fallback_manifest_path(
     dependency: LockedDependency,
     modules_root: Path,
@@ -198,6 +227,7 @@ def _collect_locked_dependencies(
     trust_transitive_self_defined: bool,
     diagnostics: DiagnosticCollector | None,
     logger: Any | None = None,
+    trusted_transitive_configs: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> tuple[list[MCPDependency], list[McpSourceProblem]]:
     """Collect MCP declarations from only package manifests named by the lockfile."""
     if lockfile is None:
@@ -269,6 +299,7 @@ def _collect_locked_dependencies(
             continue
 
         declarer = package.name or dependency.name or manifest_path.parent.name
+        _log_skipped_dev_mcp(package, declarer, logger)
         # Only collect prod MCP from transitive packages; devDependencies.mcp
         # are scoped to the package author's own environment (#2340).
         for mcp_dependency in package.get_mcp_dependencies():
@@ -284,6 +315,15 @@ def _collect_locked_dependencies(
                         logger.progress(
                             f"Trusting self-defined MCP server '{mcp_dependency.name}' "
                             f"from transitive package '{declarer}' (--trust-transitive-mcp)"
+                        )
+                elif _matches_trusted_transitive_config(
+                    mcp_dependency,
+                    trusted_transitive_configs,
+                ):
+                    if logger is not None:
+                        logger.verbose_detail(
+                            f"Preserving unchanged trusted MCP server "
+                            f"'{mcp_dependency.name}' from '{declarer}'"
                         )
                 else:
                     message = (
@@ -315,6 +355,7 @@ def _collect_unlocked_compat(
         except (OSError, ValueError, UnicodeError):
             continue
         declarer = package.name or manifest_path.parent.name
+        _log_skipped_dev_mcp(package, declarer, logger)
         # Only collect prod MCP from packages; devDependencies.mcp are scoped to
         # the package author's own environment (#2340).
         for dependency in package.get_mcp_dependencies():

--- a/src/apm_cli/integration/mcp_config_view.py
+++ b/src/apm_cli/integration/mcp_config_view.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 from apm_cli.deps.path_anchoring import LocalResolutionError, resolve_local_dep_dir
 from apm_cli.integration._shared import deduplicate_deps
@@ -21,6 +21,19 @@ from apm_cli.models.validation import PackageType, detect_package_type
 if TYPE_CHECKING:
     from apm_cli.deps.lockfile import LockedDependency, LockFile
     from apm_cli.utils.diagnostics import DiagnosticCollector
+
+
+class _McpViewLogger(Protocol):
+    """Output methods used while deriving the current MCP view."""
+
+    def progress(self, message: str) -> None:
+        """Report an install-time trust decision."""
+
+    def warning(self, message: str) -> None:
+        """Report a trust decision that needs user attention."""
+
+    def verbose_detail(self, message: str) -> None:
+        """Report a non-actionable derivation detail in verbose mode."""
 
 
 @dataclass(frozen=True)
@@ -50,8 +63,8 @@ class CurrentMcpConfigView:
         *,
         trust_transitive_self_defined: bool,
         diagnostics: DiagnosticCollector | None = None,
-        logger: Any | None = None,
-        trusted_transitive_configs: Mapping[str, Mapping[str, Any]] | None = None,
+        logger: _McpViewLogger | None = None,
+        trusted_transitive_configs: (Mapping[str, tuple[str, Mapping[str, Any]]] | None) = None,
     ) -> CurrentMcpConfigView:
         """Derive current MCP truth without mutating manifests or the lockfile."""
         project_root = root.package_path or Path.cwd()
@@ -140,26 +153,30 @@ def _get_server_provenance(dependencies: list[Any] | tuple[Any, ...]) -> dict[st
 def _log_skipped_dev_mcp(
     package: APMPackage,
     declarer: str,
-    logger: Any | None,
+    logger: _McpViewLogger | None,
 ) -> None:
     """Explain a dependency-scope exclusion without logging server names."""
     skipped_count = len(package.get_dev_mcp_dependencies())
     if skipped_count and logger is not None:
         logger.verbose_detail(
-            f"Skipping {skipped_count} development MCP dependency(ies) from "
-            f"'{declarer}'; dependency devDependencies.mcp do not propagate"
+            f"Skipping {skipped_count} author-only MCP server(s) from "
+            f"'{declarer}'; transitive devDependencies.mcp do not propagate"
         )
 
 
 def _matches_trusted_transitive_config(
     dependency: MCPDependency,
-    trusted_configs: Mapping[str, Mapping[str, Any]] | None,
+    declarer: str,
+    trusted_configs: Mapping[str, tuple[str, Mapping[str, Any]]] | None,
 ) -> bool:
-    """Return whether an unchanged self-defined config was trusted before."""
+    """Return whether this package's unchanged config was trusted before."""
     if trusted_configs is None:
         return False
-    stored = trusted_configs.get(dependency.name)
-    return stored is not None and dependency.to_dict() == stored
+    trusted = trusted_configs.get(dependency.name)
+    if trusted is None:
+        return False
+    stored_declarer, stored_config = trusted
+    return stored_declarer == declarer and dependency.to_dict() == stored_config
 
 
 def _fallback_manifest_path(
@@ -226,8 +243,8 @@ def _collect_locked_dependencies(
     *,
     trust_transitive_self_defined: bool,
     diagnostics: DiagnosticCollector | None,
-    logger: Any | None = None,
-    trusted_transitive_configs: Mapping[str, Mapping[str, Any]] | None = None,
+    logger: _McpViewLogger | None = None,
+    trusted_transitive_configs: (Mapping[str, tuple[str, Mapping[str, Any]]] | None) = None,
 ) -> tuple[list[MCPDependency], list[McpSourceProblem]]:
     """Collect MCP declarations from only package manifests named by the lockfile."""
     if lockfile is None:
@@ -318,6 +335,7 @@ def _collect_locked_dependencies(
                         )
                 elif _matches_trusted_transitive_config(
                     mcp_dependency,
+                    declarer,
                     trusted_transitive_configs,
                 ):
                     if logger is not None:
@@ -345,7 +363,7 @@ def _collect_unlocked_compat(
     *,
     trust_transitive_self_defined: bool,
     diagnostics: DiagnosticCollector | None,
-    logger: Any | None,
+    logger: _McpViewLogger | None,
 ) -> list[MCPDependency]:
     """Preserve the legacy no-lock fallback for the compatibility wrapper only."""
     collected: list[MCPDependency] = []
@@ -379,7 +397,7 @@ def _collect_transitive_compat(
     lock_path: Path | None,
     trust_private: bool,
     *,
-    logger: Any | None,
+    logger: _McpViewLogger | None,
     diagnostics: DiagnosticCollector | None,
 ) -> list[MCPDependency]:
     """Implement the legacy MCPIntegrator traversal through this owner."""

--- a/src/apm_cli/integration/mcp_config_view.py
+++ b/src/apm_cli/integration/mcp_config_view.py
@@ -60,6 +60,9 @@ class CurrentMcpConfigView:
             trust_transitive_self_defined=trust_transitive_self_defined,
             diagnostics=diagnostics,
         )
+        # Root is the authoring project: both prod and dev MCP are intentionally
+        # included here (behaviour introduced in #1780). Transitive package deps
+        # are collected prod-only (see _collect_locked_dependencies).
         dependencies = tuple(_deduplicate(root.get_all_mcp_dependencies() + package_deps))
         return cls(
             dependencies=dependencies,
@@ -265,7 +268,9 @@ def _collect_locked_dependencies(
             continue
 
         declarer = package.name or dependency.name or manifest_path.parent.name
-        for mcp_dependency in package.get_all_mcp_dependencies():
+        # Only collect prod MCP from transitive packages; devDependencies.mcp
+        # are scoped to the package author's own environment (#2340).
+        for mcp_dependency in package.get_mcp_dependencies():
             if mcp_dependency.is_self_defined:
                 if dependency.depth == 1:
                     if logger is not None:
@@ -309,7 +314,9 @@ def _collect_unlocked_compat(
         except (OSError, ValueError, UnicodeError):
             continue
         declarer = package.name or manifest_path.parent.name
-        for dependency in package.get_all_mcp_dependencies():
+        # Only collect prod MCP from packages; devDependencies.mcp scoped to
+        # the package author's own environment (#2340).
+        for dependency in package.get_mcp_dependencies():
             if dependency.is_self_defined and not trust_transitive_self_defined:
                 message = (
                     f"Transitive package '{declarer}' declares self-defined MCP server "

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -175,6 +175,63 @@ def test_hook_rewrite_scope_guard_rejects_parallel_decision(tmp_path: Path) -> N
     assert "Hook rewrite scope must route through HookIntegrator" in result.stdout
 
 
+def test_mcp_dependency_scope_has_single_owner() -> None:
+    """Root and dependency MCP declarations must route through one view."""
+    root = Path(__file__).parents[2]
+    owner = (root / "src/apm_cli/integration/mcp_config_view.py").read_text()
+    owner_table = (root / ".apm/instructions/architecture.instructions.md").read_text()
+    guard = (root / "scripts/lint-architecture-boundaries.sh").read_text()
+
+    assert owner.count("root.get_all_mcp_dependencies()") == 1
+    assert owner.count("package.get_mcp_dependencies()") == 2
+    assert "package.get_all_mcp_dependencies()" not in owner
+    assert "| Root vs dependency MCP declaration scope |" in owner_table
+    assert "Transitive MCP dependency scope must use production-only collection" in guard
+
+
+def test_mcp_dependency_scope_guard_rejects_all_dependency_collection(
+    tmp_path: Path,
+) -> None:
+    """The boundary lint must reject restoring dev MCP propagation."""
+    root = Path(__file__).parents[2]
+    sandbox = tmp_path / "repo"
+    shutil.copytree(
+        root,
+        sandbox,
+        ignore=shutil.ignore_patterns(
+            ".git",
+            ".venv",
+            ".pytest_cache",
+            "__pycache__",
+            "build",
+            "dist",
+            "node_modules",
+        ),
+    )
+    owner_path = sandbox / "src/apm_cli/integration/mcp_config_view.py"
+    owner_source = owner_path.read_text(encoding="utf-8")
+    owner_path.write_text(
+        owner_source.replace(
+            "for mcp_dependency in package.get_mcp_dependencies():",
+            "for mcp_dependency in package.get_all_mcp_dependencies():",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ("bash", "scripts/lint-architecture-boundaries.sh"),
+        cwd=sandbox,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+
+    assert result.returncode == 1
+    assert "Transitive MCP dependency scope must use production-only collection" in result.stdout
+
+
 def test_policy_resolution_failure_outcomes_have_single_owner() -> None:
     """Approval fallback outcomes must come from policy outcome routing."""
     from apm_cli.policy.outcome_routing import POLICY_RESOLUTION_FAILURE_OUTCOMES

--- a/tests/integration/test_local_package_factory_contract.py
+++ b/tests/integration/test_local_package_factory_contract.py
@@ -132,6 +132,56 @@ def test_create_authors_manifest_and_primitives_only(tmp_path: Path) -> None:
     assert not (tmp_path / "packages/invalid-target").exists()
 
 
+def test_create_authors_production_and_development_mcp_blocks(tmp_path: Path) -> None:
+    """Fixture packages preserve the package-authoring MCP scope boundary."""
+    package = LocalPackageFactory(tmp_path / "packages").create(
+        "mcp-package",
+        mcp_dependencies=(
+            {
+                "name": "prod-server",
+                "registry": False,
+                "transport": "stdio",
+                "command": "prod-command",
+            },
+        ),
+        dev_mcp_dependencies=(
+            {
+                "name": "dev-server",
+                "registry": False,
+                "transport": "stdio",
+                "command": "dev-command",
+            },
+        ),
+    )
+
+    assert load_yaml(package.manifest_path) == {
+        "name": "mcp-package",
+        "version": "0.1.0",
+        "description": "Hermetic test package mcp-package",
+        "author": "APM Test",
+        "dependencies": {
+            "mcp": [
+                {
+                    "name": "prod-server",
+                    "registry": False,
+                    "transport": "stdio",
+                    "command": "prod-command",
+                }
+            ]
+        },
+        "devDependencies": {
+            "mcp": [
+                {
+                    "name": "dev-server",
+                    "registry": False,
+                    "transport": "stdio",
+                    "command": "dev-command",
+                }
+            ]
+        },
+    }
+
+
 def test_relative_dependency_uses_portable_manifest_path(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/integration/test_mcp_dev_dependency_lifecycle.py
+++ b/tests/integration/test_mcp_dev_dependency_lifecycle.py
@@ -444,7 +444,7 @@ def test_stale_dependency_dev_mcp_repair_and_frozen_no_write(
     tmp_path: Path,
     apm_binary_path: Path,
 ) -> None:
-    """Frozen dry-run is non-mutating; install and update prune stale state."""
+    """Frozen dry-run rejects without writes; install and update repair stale state."""
     case = _TARGET_CASES[0]
     with ExitStack() as stack:
         scenario = _create_scenario(tmp_path / "repair", case, stack)
@@ -454,13 +454,16 @@ def test_stale_dependency_dev_mcp_repair_and_frozen_no_write(
 
         _plant_stale_dependency_dev_state(scenario)
         stale = _snapshot(scenario)
-        frozen = _run_ok(
-            runner,
-            scenario,
+        frozen = runner.run(
             (*install_args, "--frozen", "--dry-run"),
-            "repair-frozen-dry-run",
+            scenario_id="repair-frozen-dry-run",
+            cwd=scenario.project,
+            env=scenario.environment,
         )
-        assert "dry" in f"{frozen.stdout}\n{frozen.stderr}".lower()
+        assert frozen.returncode == 1
+        frozen_output = f"{frozen.stdout}\n{frozen.stderr}"
+        assert "--frozen" in frozen_output
+        assert _DEP_DEV in frozen_output
         assert _snapshot(scenario) == stale
 
         _run_ok(runner, scenario, install_args, "repair-normal-install")

--- a/tests/integration/test_mcp_dev_dependency_lifecycle.py
+++ b/tests/integration/test_mcp_dev_dependency_lifecycle.py
@@ -1,0 +1,489 @@
+"""Installed-CLI lifecycle contract for dependency development MCP isolation."""
+
+from __future__ import annotations
+
+import json
+import os
+from contextlib import ExitStack
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+import pytest
+import tomlkit
+
+from apm_cli.utils.yaml_io import dump_yaml, load_yaml
+from tests.utils.apm_lifecycle_runner import ApmLifecycleRunner, CommandResult
+from tests.utils.isolated_apm_environment import IsolatedApmEnvironment
+from tests.utils.lifecycle_state import LifecycleStateSnapshot
+from tests.utils.local_git_repository import LocalGitRepositoryFactory
+from tests.utils.local_mcp_registry import LocalMcpRegistry, LocalMcpRegistryFactory
+from tests.utils.local_package import LocalPackageFactory
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.e2e,
+    pytest.mark.lifecycle_smoke,
+    pytest.mark.requires_apm_binary,
+    pytest.mark.requires_e2e_mode,
+]
+
+_ROOT_PROD = "com.example/root-prod"
+_ROOT_DEV = "com.example/root-dev"
+_DEP_PROD = "dep-prod"
+_DEP_DEV = "dep-dev"
+_EXPECTED_NAMES = (_ROOT_PROD, _ROOT_DEV, _DEP_PROD)
+_REMOTE_URLS = {
+    _ROOT_PROD: "https://mcp.example.invalid/root-prod",
+    _ROOT_DEV: "https://mcp.example.invalid/root-dev",
+    _DEP_PROD: "https://mcp.example.invalid/dep-prod",
+    _DEP_DEV: "https://mcp.example.invalid/dep-dev",
+}
+
+
+@dataclass(frozen=True)
+class _TargetCase:
+    """One native MCP target projection of the shared current view."""
+
+    runtime: str
+    manifest_target: str
+    state_target: str
+    config_path: PurePosixPath
+    config_section: str
+    signal_directory: PurePosixPath
+    trailing_newline: bool
+
+
+_TARGET_CASES = (
+    _TargetCase(
+        runtime="claude",
+        manifest_target="claude",
+        state_target="claude",
+        config_path=PurePosixPath(".mcp.json"),
+        config_section="mcpServers",
+        signal_directory=PurePosixPath(".claude"),
+        trailing_newline=True,
+    ),
+    _TargetCase(
+        runtime="codex",
+        manifest_target="codex",
+        state_target="codex",
+        config_path=PurePosixPath(".codex/config.toml"),
+        config_section="mcp_servers",
+        signal_directory=PurePosixPath(".codex"),
+        trailing_newline=True,
+    ),
+)
+
+
+@dataclass(frozen=True)
+class _Scenario:
+    """One isolated nested-package consumer and its local registries."""
+
+    isolated: IsolatedApmEnvironment
+    project: Path
+    environment: dict[str, str]
+    registries: dict[str, LocalMcpRegistry]
+    case: _TargetCase
+
+
+def _server_document(name: str) -> dict[str, object]:
+    """Return one deterministic remote-only MCP Registry v0.1 document."""
+    return {
+        "name": name,
+        "description": f"Lifecycle fixture for {name}",
+        "version": "1.0.0",
+        "remotes": [
+            {
+                "transport_type": "http",
+                "url": _REMOTE_URLS[name],
+            }
+        ],
+    }
+
+
+def _registry_entry(name: str, registry: LocalMcpRegistry) -> dict[str, object]:
+    """Return a manifest entry pinned to one scenario-local registry."""
+    return {"name": name, "registry": registry.url}
+
+
+def _dependency_entry(name: str) -> dict[str, object]:
+    """Return one self-defined dependency-package server."""
+    return {
+        "name": name,
+        "registry": False,
+        "transport": "http",
+        "url": _REMOTE_URLS[name],
+    }
+
+
+def _native_key(case: _TargetCase, name: str) -> str:
+    """Return the adapter key derived from a registry reference."""
+    return name.rsplit("/", maxsplit=1)[-1]
+
+
+def _start_registries(
+    isolated: IsolatedApmEnvironment,
+    stack: ExitStack,
+) -> dict[str, LocalMcpRegistry]:
+    """Start one isolated endpoint per declared server."""
+    factory = LocalMcpRegistryFactory(isolated.root / "mcp-registries")
+    return {
+        name: stack.enter_context(factory.start(_server_document(name)))
+        for name in (_ROOT_PROD, _ROOT_DEV)
+    }
+
+
+def _create_scenario(
+    root: Path,
+    case: _TargetCase,
+    stack: ExitStack,
+) -> _Scenario:
+    """Create root -> Git aggregator -> local nested dependency."""
+    isolated = IsolatedApmEnvironment.create(root, base_env=dict(os.environ))
+    registries = _start_registries(isolated, stack)
+
+    source_factory = LocalPackageFactory(isolated.package_root)
+    aggregator = source_factory.create("aggregator")
+    dependency = LocalPackageFactory(aggregator.root / "packages").create(
+        "dep",
+        mcp_dependencies=(_dependency_entry(_DEP_PROD),),
+        dev_mcp_dependencies=(_dependency_entry(_DEP_DEV),),
+    )
+    source_factory.replace_apm_dependencies(
+        aggregator,
+        ({"path": "./packages/dep", "alias": dependency.name},),
+    )
+
+    base_environment = isolated.subprocess_env()
+    repositories = LocalGitRepositoryFactory(
+        isolated.repository_root,
+        env=base_environment,
+    )
+    repository = repositories.create("aggregator", source_tree=aggregator.root)
+    repositories.commit(repository, message="seed nested MCP dependency")
+    source_url = "https://gitlab.example.invalid/contracts/aggregator.git"
+    environment = repositories.url_rewrite_subprocess_env(repository, source_url)
+    environment["MCP_REGISTRY_ALLOW_HTTP"] = "1"
+    environment.pop("PYTHONPATH", None)
+
+    project = LocalPackageFactory(isolated.work_root).create(
+        f"{case.runtime}-consumer",
+        dependencies=(
+            {
+                "git": source_url,
+                "type": "gitlab",
+                "ref": "main",
+                "alias": "aggregator",
+            },
+        ),
+        mcp_dependencies=(_registry_entry(_ROOT_PROD, registries[_ROOT_PROD]),),
+        dev_mcp_dependencies=(_registry_entry(_ROOT_DEV, registries[_ROOT_DEV]),),
+        targets=(case.manifest_target,),
+    )
+    project.root.joinpath(*case.signal_directory.parts).mkdir(parents=True)
+    return _Scenario(
+        isolated=isolated,
+        project=project.root,
+        environment=environment,
+        registries=registries,
+        case=case,
+    )
+
+
+def _runner(apm_binary_path: Path) -> ApmLifecycleRunner:
+    """Return a bounded installed-binary runner."""
+    return ApmLifecycleRunner(
+        (str(apm_binary_path),),
+        timeout_seconds=120,
+        scenario_timeout_seconds=480,
+    )
+
+
+def _install_args(case: _TargetCase) -> tuple[str, ...]:
+    """Return the normal install command for one target."""
+    return (
+        "install",
+        "--runtime",
+        case.runtime,
+        "--target",
+        case.manifest_target,
+        "--trust-transitive-mcp",
+        "--no-policy",
+        "--verbose",
+    )
+
+
+def _run_ok(
+    runner: ApmLifecycleRunner,
+    scenario: _Scenario,
+    args: tuple[str, ...],
+    scenario_id: str,
+) -> CommandResult:
+    """Run one command and retain complete failure evidence."""
+    result = runner.run(
+        args,
+        scenario_id=scenario_id,
+        cwd=scenario.project,
+        env=scenario.environment,
+    )
+    assert result.returncode == 0, (
+        f"command={result.command!r}\nstdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    return result
+
+
+def _snapshot(scenario: _Scenario) -> LifecycleStateSnapshot:
+    """Capture exact lock-derived MCP state and native config bytes."""
+    return LifecycleStateSnapshot.capture(
+        scenario.project,
+        config_paths=(scenario.case.config_path,),
+    )
+
+
+def _native_document(
+    case: _TargetCase,
+    include_user_entry: bool = False,
+) -> dict[str, object]:
+    """Return the exact managed native server mapping."""
+    servers: dict[str, object] = {}
+    for name in _EXPECTED_NAMES:
+        if case.runtime == "codex":
+            config = {"url": _REMOTE_URLS[name], "id": ""}
+        else:
+            config = {"type": "http", "url": _REMOTE_URLS[name]}
+        servers[_native_key(case, name)] = config
+    if include_user_entry:
+        servers["user-authored"] = {
+            "type": "http",
+            "url": "https://user.example.invalid/mcp",
+        }
+    return servers
+
+
+def _expected_native_bytes(
+    case: _TargetCase,
+    *,
+    include_user_entry: bool = False,
+) -> bytes:
+    """Serialize the exact target-native bytes in adapter write order."""
+    document: dict[str, object] = {
+        case.config_section: _native_document(case, include_user_entry),
+    }
+    if case.runtime == "codex":
+        return tomlkit.dumps(document).encode("ascii")
+    suffix = "\n" if case.trailing_newline else ""
+    return f"{json.dumps(document, indent=2)}{suffix}".encode("ascii")
+
+
+def _expected_mcp_state_bytes(scenario: _Scenario) -> bytes:
+    """Return the exact canonical lock-derived MCP state."""
+    state = {
+        "servers": sorted(_EXPECTED_NAMES),
+        "configs": {
+            name: (
+                {
+                    "name": name,
+                    "registry": scenario.registries[name].url,
+                }
+                if name in scenario.registries
+                else _dependency_entry(name)
+            )
+            for name in sorted(_EXPECTED_NAMES)
+        },
+        "target_servers": {
+            scenario.case.state_target: sorted(_EXPECTED_NAMES),
+        },
+        "provenance": {
+            _DEP_PROD: "dep",
+        },
+    }
+    return json.dumps(
+        state,
+        sort_keys=True,
+        ensure_ascii=True,
+        separators=(",", ":"),
+    ).encode("ascii")
+
+
+def _assert_current_state(
+    scenario: _Scenario,
+    snapshot: LifecycleStateSnapshot,
+    *,
+    include_user_entry: bool = False,
+) -> None:
+    """Assert exact native bytes, provenance, and lock-derived server state."""
+    config = snapshot.file(scenario.case.config_path.as_posix())
+    assert config.content == _expected_native_bytes(
+        scenario.case,
+        include_user_entry=include_user_entry,
+    )
+    assert snapshot.mcp_state_bytes == _expected_mcp_state_bytes(scenario)
+    assert _native_key(scenario.case, _DEP_DEV).encode("ascii") not in config.content
+    assert _DEP_DEV.encode("ascii") not in snapshot.mcp_state_bytes
+    assert snapshot.lockfile_bytes is not None
+    assert _DEP_DEV.encode("ascii") not in snapshot.lockfile_bytes
+
+
+def _assert_byte_idempotent(
+    expected: LifecycleStateSnapshot,
+    actual: LifecycleStateSnapshot,
+    config_path: PurePosixPath,
+) -> None:
+    """Compare exact config/provenance bytes and timestamp-neutral durable state."""
+    assert (
+        actual.file(config_path.as_posix()).content == expected.file(config_path.as_posix()).content
+    )
+    assert actual.mcp_state_bytes == expected.mcp_state_bytes
+    assert actual.semantic_bytes == expected.semantic_bytes
+
+
+def _assert_nested_lock(project: Path) -> None:
+    """Prove the MCP declarer came from a depth-two package."""
+    lock = load_yaml(project / "apm.lock.yaml")
+    assert isinstance(lock, dict)
+    dependencies = lock["dependencies"]
+    assert isinstance(dependencies, list)
+    rows = {
+        row["name"]: row
+        for row in dependencies
+        if isinstance(row, dict) and isinstance(row.get("name"), str)
+    }
+    assert rows["aggregator"].get("depth", 1) == 1
+    assert rows["dep"]["depth"] == 2
+    assert lock["mcp_config_provenance"] == {_DEP_PROD: "dep"}
+
+
+def _assert_no_dev_log(*results: CommandResult) -> None:
+    """Prove fresh lifecycle output never names an excluded dev server."""
+    for result in results:
+        assert _DEP_DEV not in f"{result.stdout}\n{result.stderr}"
+
+
+@pytest.mark.parametrize("case", _TARGET_CASES, ids=lambda case: case.runtime)
+def test_dependency_dev_mcp_isolated_across_installed_lifecycle(
+    case: _TargetCase,
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Fresh install, repeat, update, reinstall, and audit stay isolated."""
+    with ExitStack() as stack:
+        scenario = _create_scenario(tmp_path / case.runtime, case, stack)
+        runner = _runner(apm_binary_path)
+        install_args = _install_args(case)
+
+        installed = _run_ok(runner, scenario, install_args, f"{case.runtime}-install")
+        first = _snapshot(scenario)
+        _assert_current_state(scenario, first)
+        _assert_nested_lock(scenario.project)
+
+        repeated = _run_ok(runner, scenario, install_args, f"{case.runtime}-repeat")
+        repeat_state = _snapshot(scenario)
+        _assert_current_state(scenario, repeat_state)
+        _assert_byte_idempotent(first, repeat_state, case.config_path)
+
+        updated = _run_ok(
+            runner,
+            scenario,
+            ("update", "--yes", "--target", case.manifest_target),
+            f"{case.runtime}-update",
+        )
+        update_state = _snapshot(scenario)
+        _assert_current_state(scenario, update_state)
+        _assert_byte_idempotent(first, update_state, case.config_path)
+
+        reinstalled = _run_ok(
+            runner,
+            scenario,
+            install_args,
+            f"{case.runtime}-reinstall",
+        )
+        reinstall_state = _snapshot(scenario)
+        _assert_current_state(scenario, reinstall_state)
+        _assert_byte_idempotent(first, reinstall_state, case.config_path)
+
+        before_audit = _snapshot(scenario)
+        audited = _run_ok(
+            runner,
+            scenario,
+            ("audit", "--ci", "--no-policy", "--format", "json"),
+            f"{case.runtime}-audit",
+        )
+        assert json.loads(audited.stdout)["passed"] is True
+        assert _snapshot(scenario) == before_audit
+        _assert_no_dev_log(installed, repeated, updated, reinstalled, audited)
+        assert scenario.registries[_ROOT_PROD].request_paths
+        assert scenario.registries[_ROOT_DEV].request_paths
+
+
+def _plant_stale_dependency_dev_state(scenario: _Scenario) -> None:
+    """Mimic the pre-fix config and provenance written by a normal install."""
+    config_path = scenario.project.joinpath(*scenario.case.config_path.parts)
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    servers = config[scenario.case.config_section]
+    servers["user-authored"] = _native_document(
+        scenario.case,
+        include_user_entry=True,
+    )["user-authored"]
+    servers[_native_key(scenario.case, _DEP_DEV)] = {
+        "type": "http",
+        "url": _REMOTE_URLS[_DEP_DEV],
+    }
+    config_path.write_text(f"{json.dumps(config, indent=2)}\n", encoding="utf-8")
+
+    lock_path = scenario.project / "apm.lock.yaml"
+    lock = load_yaml(lock_path)
+    assert isinstance(lock, dict)
+    lock["mcp_servers"].append(_DEP_DEV)
+    lock["mcp_configs"][_DEP_DEV] = _dependency_entry(_DEP_DEV)
+    lock["mcp_target_servers"][scenario.case.state_target].append(_DEP_DEV)
+    lock["mcp_config_provenance"][_DEP_DEV] = "dep"
+    dump_yaml(lock, lock_path)
+
+
+def test_stale_dependency_dev_mcp_repair_and_frozen_no_write(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Frozen dry-run is non-mutating; install and update prune stale state."""
+    case = _TARGET_CASES[0]
+    with ExitStack() as stack:
+        scenario = _create_scenario(tmp_path / "repair", case, stack)
+        runner = _runner(apm_binary_path)
+        install_args = _install_args(case)
+        _run_ok(runner, scenario, install_args, "repair-seed-install")
+
+        _plant_stale_dependency_dev_state(scenario)
+        stale = _snapshot(scenario)
+        frozen = _run_ok(
+            runner,
+            scenario,
+            (*install_args, "--frozen", "--dry-run"),
+            "repair-frozen-dry-run",
+        )
+        assert "dry" in f"{frozen.stdout}\n{frozen.stderr}".lower()
+        assert _snapshot(scenario) == stale
+
+        _run_ok(runner, scenario, install_args, "repair-normal-install")
+        repaired = _snapshot(scenario)
+        _assert_current_state(scenario, repaired, include_user_entry=True)
+
+        _plant_stale_dependency_dev_state(scenario)
+        _run_ok(
+            runner,
+            scenario,
+            ("update", "--yes", "--target", case.manifest_target),
+            "repair-normal-update",
+        )
+        updated = _snapshot(scenario)
+        _assert_current_state(scenario, updated, include_user_entry=True)
+        _assert_byte_idempotent(repaired, updated, case.config_path)
+
+        before_audit = _snapshot(scenario)
+        audit = _run_ok(
+            runner,
+            scenario,
+            ("audit", "--ci", "--no-policy", "--format", "json"),
+            "repair-audit",
+        )
+        assert json.loads(audit.stdout)["passed"] is True
+        assert _snapshot(scenario) == before_audit

--- a/tests/unit/integration/test_mcp_config_view.py
+++ b/tests/unit/integration/test_mcp_config_view.py
@@ -537,3 +537,48 @@ def test_dependency_dev_mcp_is_excluded_from_consumer(tmp_path: Path) -> None:
     names = [dep.name for dep in view.dependencies]
     assert "prod-server" in names, "prod MCP from dependency must be included"
     assert "dev-server" not in names, "dev MCP from dependency must NOT be included"
+
+
+def test_unlocked_compat_excludes_dep_dev_mcp(tmp_path: Path) -> None:
+    """Regression #2340: no-lock compat path also excludes dependency dev MCP.
+
+    _collect_unlocked_compat is the legacy path when no lockfile exists;
+    it must enforce the same prod-only rule as _collect_locked_dependencies.
+    """
+    from apm_cli.integration.mcp_config_view import _collect_transitive_compat
+
+    modules_root = tmp_path / "apm_modules"
+    dep_dir = modules_root / "dep-pkg"
+    _write_manifest(
+        dep_dir,
+        name="dep-pkg",
+        mcp=[
+            {
+                "name": "prod-server",
+                "registry": False,
+                "transport": "http",
+                "url": "https://example.com/prod",
+            }
+        ],
+        dev_mcp=[
+            {
+                "name": "dev-server",
+                "registry": False,
+                "transport": "http",
+                "url": "https://example.com/dev",
+            }
+        ],
+    )
+
+    # No lock_path -- forces the _collect_unlocked_compat branch.
+    result = _collect_transitive_compat(
+        modules_root,
+        lock_path=None,
+        trust_private=True,
+        logger=None,
+        diagnostics=None,
+    )
+
+    names = [dep.name for dep in result]
+    assert "prod-server" in names, "prod MCP must be collected by no-lock compat path"
+    assert "dev-server" not in names, "dev MCP must NOT be collected by no-lock compat path"

--- a/tests/unit/integration/test_mcp_config_view.py
+++ b/tests/unit/integration/test_mcp_config_view.py
@@ -7,7 +7,11 @@ from pathlib import Path
 import yaml
 
 from apm_cli.deps.lockfile import LockedDependency, LockFile
-from apm_cli.integration.mcp_config_view import CurrentMcpConfigView, McpConfigDiff
+from apm_cli.integration.mcp_config_view import (
+    CurrentMcpConfigView,
+    McpConfigDiff,
+    _collect_transitive_compat,
+)
 from apm_cli.models.apm_package import APMPackage, clear_apm_yml_cache
 from apm_cli.models.dependency.mcp import MCPDependency
 
@@ -57,6 +61,17 @@ def _derive(
         modules_root,
         trust_transitive_self_defined=True,
     )
+
+
+class _RecordingLogger:
+    """Capture compatibility-path verbose diagnostics."""
+
+    def __init__(self) -> None:
+        self.details: list[str] = []
+
+    def verbose_detail(self, message: str) -> None:
+        """Record one verbose diagnostic."""
+        self.details.append(message)
 
 
 def test_root_dev_mcp_included_dep_dev_mcp_excluded(tmp_path: Path) -> None:
@@ -492,6 +507,49 @@ def test_transitive_self_defined_trust_matches_install_behavior(tmp_path: Path) 
     assert [dep.name for dep in trusted.dependencies] == ["direct-server", "deep-server"]
 
 
+def test_only_unchanged_previously_trusted_transitive_config_is_preserved(
+    tmp_path: Path,
+) -> None:
+    """A no-op update preserves prior trust without trusting changed code."""
+    root = _write_manifest(tmp_path, name="root")
+    deep_dir = tmp_path / "packages" / "deep"
+    package = _write_manifest(
+        deep_dir,
+        name="deep",
+        mcp=[_self_defined("deep-server", "trusted-command")],
+    )
+    deep = LockedDependency(
+        repo_url="_local/deep",
+        source="local",
+        local_path="./packages/deep",
+        depth=2,
+    )
+    stored_config = package.get_mcp_dependencies()[0].to_dict()
+
+    preserved = CurrentMcpConfigView.derive(
+        root,
+        _lock(deep),
+        tmp_path / "apm_modules",
+        trust_transitive_self_defined=False,
+        trusted_transitive_configs={"deep-server": stored_config},
+    )
+    changed = CurrentMcpConfigView.derive(
+        root,
+        _lock(deep),
+        tmp_path / "apm_modules",
+        trust_transitive_self_defined=False,
+        trusted_transitive_configs={
+            "deep-server": {
+                **stored_config,
+                "command": "different-command",
+            }
+        },
+    )
+
+    assert [dependency.name for dependency in preserved.dependencies] == ["deep-server"]
+    assert changed.dependencies == ()
+
+
 def test_view_dependencies_are_mcp_dependency_objects(tmp_path: Path) -> None:
     """The public dependencies tuple remains strongly typed."""
     root = _write_manifest(tmp_path, name="root", mcp=["server"])
@@ -545,8 +603,6 @@ def test_unlocked_compat_excludes_dep_dev_mcp(tmp_path: Path) -> None:
     _collect_unlocked_compat is the legacy path when no lockfile exists;
     it must enforce the same prod-only rule as _collect_locked_dependencies.
     """
-    from apm_cli.integration.mcp_config_view import _collect_transitive_compat
-
     modules_root = tmp_path / "apm_modules"
     dep_dir = modules_root / "dep-pkg"
     _write_manifest(
@@ -569,16 +625,22 @@ def test_unlocked_compat_excludes_dep_dev_mcp(tmp_path: Path) -> None:
             }
         ],
     )
+    logger = _RecordingLogger()
 
     # No lock_path -- forces the _collect_unlocked_compat branch.
     result = _collect_transitive_compat(
         modules_root,
         lock_path=None,
         trust_private=True,
-        logger=None,
+        logger=logger,
         diagnostics=None,
     )
 
-    names = [dep.name for dep in result]
-    assert "prod-server" in names, "prod MCP must be collected by no-lock compat path"
-    assert "dev-server" not in names, "dev MCP must NOT be collected by no-lock compat path"
+    assert [(dependency.name, dependency.resolved_by) for dependency in result] == [
+        ("prod-server", "dep-pkg")
+    ]
+    assert logger.details == [
+        "Skipping 1 development MCP dependency(ies) from 'dep-pkg'; "
+        "dependency devDependencies.mcp do not propagate"
+    ]
+    assert all("dev-server" not in detail for detail in logger.details)

--- a/tests/unit/integration/test_mcp_config_view.py
+++ b/tests/unit/integration/test_mcp_config_view.py
@@ -531,7 +531,7 @@ def test_only_unchanged_previously_trusted_transitive_config_is_preserved(
         _lock(deep),
         tmp_path / "apm_modules",
         trust_transitive_self_defined=False,
-        trusted_transitive_configs={"deep-server": stored_config},
+        trusted_transitive_configs={"deep-server": ("deep", stored_config)},
     )
     changed = CurrentMcpConfigView.derive(
         root,
@@ -539,15 +539,26 @@ def test_only_unchanged_previously_trusted_transitive_config_is_preserved(
         tmp_path / "apm_modules",
         trust_transitive_self_defined=False,
         trusted_transitive_configs={
-            "deep-server": {
-                **stored_config,
-                "command": "different-command",
-            }
+            "deep-server": (
+                "deep",
+                {
+                    **stored_config,
+                    "command": "different-command",
+                },
+            )
         },
+    )
+    wrong_declarer = CurrentMcpConfigView.derive(
+        root,
+        _lock(deep),
+        tmp_path / "apm_modules",
+        trust_transitive_self_defined=False,
+        trusted_transitive_configs={"deep-server": ("other-package", stored_config)},
     )
 
     assert [dependency.name for dependency in preserved.dependencies] == ["deep-server"]
     assert changed.dependencies == ()
+    assert wrong_declarer.dependencies == ()
 
 
 def test_view_dependencies_are_mcp_dependency_objects(tmp_path: Path) -> None:
@@ -640,7 +651,7 @@ def test_unlocked_compat_excludes_dep_dev_mcp(tmp_path: Path) -> None:
         ("prod-server", "dep-pkg")
     ]
     assert logger.details == [
-        "Skipping 1 development MCP dependency(ies) from 'dep-pkg'; "
-        "dependency devDependencies.mcp do not propagate"
+        "Skipping 1 author-only MCP server(s) from 'dep-pkg'; "
+        "transitive devDependencies.mcp do not propagate"
     ]
     assert all("dev-server" not in detail for detail in logger.details)

--- a/tests/unit/integration/test_mcp_config_view.py
+++ b/tests/unit/integration/test_mcp_config_view.py
@@ -60,7 +60,7 @@ def _derive(
 
 
 def test_derives_root_and_package_production_and_dev_mcp(tmp_path: Path) -> None:
-    """Root and locked package prod/dev declarations share manifest order."""
+    """Root dev MCP is included; locked package dev MCP is excluded (#2340)."""
     root = _write_manifest(
         tmp_path,
         name="root",
@@ -83,15 +83,14 @@ def test_derives_root_and_package_production_and_dev_mcp(tmp_path: Path) -> None
 
     view = _derive(root, _lock(locked), tmp_path / "apm_modules")
 
+    # Root dev MCP is included (authoring project); dep dev MCP is NOT (#2340).
     assert [dep.name for dep in view.dependencies] == [
         "root-prod",
         "root-dev",
         "package-prod",
-        "package-dev",
     ]
     assert view.provenance == {
         "package-prod": "tools",
-        "package-dev": "tools",
     }
 
 
@@ -500,3 +499,41 @@ def test_view_dependencies_are_mcp_dependency_objects(tmp_path: Path) -> None:
     view = _derive(root, None, tmp_path / "apm_modules")
 
     assert all(isinstance(dep, MCPDependency) for dep in view.dependencies)
+
+
+def test_dependency_dev_mcp_is_excluded_from_consumer(tmp_path: Path) -> None:
+    """Regression #2340: dep devDependencies.mcp must not reach the consumer."""
+    root = _write_manifest(tmp_path, name="root")
+    dep_dir = tmp_path / "packages" / "dep"
+    _write_manifest(
+        dep_dir,
+        name="dep",
+        mcp=[
+            {
+                "name": "prod-server",
+                "registry": False,
+                "transport": "http",
+                "url": "https://example.com/prod",
+            }
+        ],
+        dev_mcp=[
+            {
+                "name": "dev-server",
+                "registry": False,
+                "transport": "http",
+                "url": "https://example.com/dev",
+            }
+        ],
+    )
+    locked = LockedDependency(
+        repo_url="_local/dep",
+        source="local",
+        local_path="./packages/dep",
+        depth=1,
+    )
+
+    view = _derive(root, _lock(locked), tmp_path / "apm_modules")
+
+    names = [dep.name for dep in view.dependencies]
+    assert "prod-server" in names, "prod MCP from dependency must be included"
+    assert "dev-server" not in names, "dev MCP from dependency must NOT be included"

--- a/tests/unit/integration/test_mcp_config_view.py
+++ b/tests/unit/integration/test_mcp_config_view.py
@@ -68,6 +68,16 @@ class _RecordingLogger:
 
     def __init__(self) -> None:
         self.details: list[str] = []
+        self.progress_messages: list[str] = []
+        self.warning_messages: list[str] = []
+
+    def progress(self, message: str) -> None:
+        """Record one progress diagnostic."""
+        self.progress_messages.append(message)
+
+    def warning(self, message: str) -> None:
+        """Record one warning diagnostic."""
+        self.warning_messages.append(message)
 
     def verbose_detail(self, message: str) -> None:
         """Record one verbose diagnostic."""

--- a/tests/unit/integration/test_mcp_config_view.py
+++ b/tests/unit/integration/test_mcp_config_view.py
@@ -59,7 +59,7 @@ def _derive(
     )
 
 
-def test_derives_root_and_package_production_and_dev_mcp(tmp_path: Path) -> None:
+def test_root_dev_mcp_included_dep_dev_mcp_excluded(tmp_path: Path) -> None:
     """Root dev MCP is included; locked package dev MCP is excluded (#2340)."""
     root = _write_manifest(
         tmp_path,

--- a/tests/utils/local_mcp_registry.py
+++ b/tests/utils/local_mcp_registry.py
@@ -1,0 +1,134 @@
+"""Local MCP Registry v0.1 fixtures for real-binary lifecycle tests."""
+
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+
+class _RegistryServer(ThreadingHTTPServer):
+    """HTTP server carrying one immutable MCP Registry server document."""
+
+    daemon_threads = True
+
+    def __init__(
+        self,
+        server_document: Mapping[str, Any],
+        request_paths: list[str],
+    ) -> None:
+        self.server_document = dict(server_document)
+        self.request_paths = request_paths
+        super().__init__(("127.0.0.1", 0), _RegistryRequestHandler)
+
+
+class _RegistryRequestHandler(BaseHTTPRequestHandler):
+    """Serve the search and detail routes used by ``SimpleRegistryClient``."""
+
+    server: _RegistryServer
+
+    def do_GET(self) -> None:
+        """Return one v0.1 search or detail response."""
+        parsed = urlparse(self.path)
+        self.server.request_paths.append(self.path)
+        if parsed.path == "/v0.1/servers":
+            payload = {
+                "servers": [
+                    {
+                        "server": {
+                            "name": self.server.server_document["name"],
+                            "description": self.server.server_document.get("description", ""),
+                        }
+                    }
+                ],
+                "metadata": {},
+            }
+            self._write_json(200, payload)
+            return
+
+        prefix = "/v0.1/servers/"
+        suffix = "/versions/latest"
+        if parsed.path.startswith(prefix) and parsed.path.endswith(suffix):
+            encoded_name = parsed.path[len(prefix) : -len(suffix)]
+            if unquote(encoded_name) == self.server.server_document["name"]:
+                self._write_json(200, {"server": self.server.server_document})
+                return
+        self._write_json(404, {"error": "not found"})
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        """Keep lifecycle output deterministic and quiet."""
+
+    def _write_json(self, status: int, payload: Mapping[str, Any]) -> None:
+        """Write one compact JSON response."""
+        body = json.dumps(payload, sort_keys=True).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+@dataclass
+class LocalMcpRegistry:
+    """One bounded in-process MCP Registry v0.1 endpoint."""
+
+    _server: _RegistryServer
+    _thread: threading.Thread
+    request_paths: list[str] = field(default_factory=list)
+
+    @property
+    def url(self) -> str:
+        """Return the loopback endpoint accepted by ``registry``."""
+        host, port = self._server.server_address
+        return f"http://{host}:{port}"
+
+    def close(self) -> None:
+        """Stop the endpoint and wait for its serving thread."""
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=5)
+        if self._thread.is_alive():
+            raise RuntimeError("local MCP registry thread did not stop")
+
+    def __enter__(self) -> LocalMcpRegistry:
+        """Return the running registry."""
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        """Stop the registry."""
+        self.close()
+
+
+class LocalMcpRegistryFactory:
+    """Create isolated registry endpoints from authored v0.1 documents."""
+
+    def __init__(self, root: Path) -> None:
+        """Reserve a scenario-owned root for registry fixture state."""
+        root.mkdir(parents=True, exist_ok=False)
+        self._root = root
+
+    def start(self, server_document: Mapping[str, Any]) -> LocalMcpRegistry:
+        """Start a registry endpoint for one immutable server document."""
+        if not isinstance(server_document.get("name"), str):
+            raise ValueError("server_document.name must be a string")
+        request_paths: list[str] = []
+        server = _RegistryServer(server_document, request_paths)
+        thread = threading.Thread(
+            target=server.serve_forever,
+            name=f"mcp-registry-{self._root.name}",
+            daemon=True,
+        )
+        thread.start()
+        if not thread.is_alive():
+            server.server_close()
+            raise RuntimeError("local MCP registry thread did not start")
+        return LocalMcpRegistry(
+            _server=server,
+            _thread=thread,
+            request_paths=request_paths,
+        )

--- a/tests/utils/local_package.py
+++ b/tests/utils/local_package.py
@@ -59,6 +59,7 @@ class LocalPackageFactory:
         version: str = "0.1.0",
         dependencies: Sequence[DependencyInput] = (),
         mcp_dependencies: Sequence[DependencyInput] = (),
+        dev_mcp_dependencies: Sequence[DependencyInput] = (),
         lsp_dependencies: Sequence[DependencyInput] = (),
         targets: Sequence[str] = (),
     ) -> LocalPackage:
@@ -70,6 +71,10 @@ class LocalPackageFactory:
         validated_dependencies = self._validate_dependencies(dependencies)
         validated_mcp = self._validate_config_dependencies(
             mcp_dependencies,
+            kind="MCP",
+        )
+        validated_dev_mcp = self._validate_config_dependencies(
+            dev_mcp_dependencies,
             kind="MCP",
         )
         validated_lsp = self._validate_config_dependencies(
@@ -98,6 +103,8 @@ class LocalPackageFactory:
             dependency_block["lsp"] = validated_lsp
         if dependency_block:
             manifest["dependencies"] = dependency_block
+        if validated_dev_mcp:
+            manifest["devDependencies"] = {"mcp": validated_dev_mcp}
         if validated_targets:
             manifest["targets"] = validated_targets
         dump_yaml(manifest, manifest_path)


### PR DESCRIPTION
## TL;DR

`devDependencies.mcp` servers declared by a dependency were silently installed into the consuming project's MCP config alongside the dependency's prod servers. This PR fixes the root cause with a two-line change and adds a regression test.

---

## Problem (WHY)

Issue #2340 reports that after `apm install`, a dependency's `devDependencies.mcp` servers appear in the consumer's `.mcp.json` and `mcp_config_provenance`. The package-authoring contract says `devDependencies` are scoped to the author's own dev environment -- matching how `devDependencies.apm` is already handled correctly.

Root cause: both `_collect_locked_dependencies` and `_collect_unlocked_compat` in `src/apm_cli/integration/mcp_config_view.py` called `package.get_all_mcp_dependencies()` (prod + dev) for transitive package manifests. The fix for #1780 made dev MCP work for the *authoring project* (root), which is correct, but the same all-deps collection inadvertently applied to dependency packages too.

---

## Approach (WHAT)

Switch the two transitive-package collection sites from `get_all_mcp_dependencies()` to `get_mcp_dependencies()` (prod-only). The root project's call in `derive()` keeps `get_all_mcp_dependencies()` intentionally -- the root IS the authoring project and its dev MCP should still be installed (#1780 behavior preserved).

```
Root project   -> get_all_mcp_dependencies()  [prod + dev -- authoring context]
Locked package -> get_mcp_dependencies()      [prod only  -- consumer context]
```

---

## Implementation (HOW)

### `src/apm_cli/integration/mcp_config_view.py`

- `_collect_locked_dependencies` -- changed `get_all_mcp_dependencies()` to `get_mcp_dependencies()` with a comment referencing #2340.
- `_collect_unlocked_compat` -- same change in the legacy no-lock fallback.
- Added a comment on the `derive()` root call explaining why it intentionally keeps `get_all_mcp_dependencies()`.

### `tests/unit/integration/test_mcp_config_view.py`

- Updated `test_derives_root_and_package_production_and_dev_mcp`: was asserting that `package-dev` from a locked dependency appeared in the view (i.e. asserting the bug). Now asserts root dev MCP is still included and dep dev MCP is excluded.
- Added `test_dependency_dev_mcp_is_excluded_from_consumer`: direct regression test for the issue report scenario -- dep with both prod and dev MCP; consumer view must contain only the prod server.

### `CHANGELOG.md`

- Added bug-fix entry under `[Unreleased]`.

---

## Trade-offs

The change is intentionally minimal to avoid touching other install paths. The `get_all_mcp_dependencies()` / `get_mcp_dependencies()` split is already established in the model; this PR just applies it at the right call sites.

---

## Validation evidence

```
uv run --extra dev pytest tests/unit/integration/test_mcp_config_view.py -v
# 18 passed in 1.93s

uv run --extra dev ruff check src/ tests/
# All checks passed!

uv run --extra dev ruff format --check src/ tests/
# 1549 files already formatted

uv run --extra dev python -m pylint --disable=all --enable=R0801 \
  --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/
# Your code has been rated at 10.00/10

bash scripts/lint-auth-signals.sh
# [+] auth-signal lint clean
```

---

## How to test

1. Author a package `owner/dep` with `dependencies.mcp: [prod-server]` and `devDependencies.mcp: [dev-server]`.
2. In a consumer, add `owner/dep` to `dependencies.apm` and run `apm install --target claude`.
3. Inspect `.mcp.json`: only `prod-server` appears. `dev-server` is absent.
4. Run the regression test: `uv run --extra dev pytest tests/unit/integration/test_mcp_config_view.py::test_dependency_dev_mcp_is_excluded_from_consumer`.

Closes #2340


apm-spec-waiver: Restores the existing documented dev-dependency isolation contract; no new OpenAPM requirement.