### PR TITLE
fix(marketplace): honour producer tag_pattern in consumer semver range resolution

### DIFF
--- a/.apm/instructions/architecture.instructions.md
+++ b/.apm/instructions/architecture.instructions.md
@@ -64,6 +64,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | MCP container launcher selection and Docker argv shape | adapters/client/base.py (MCPClientAdapter) | `src/apm_cli/adapters/client/base.py` |
 | Dependency CLI identifier parsing + uninstall selection | models/dependency/selection.py (via DependencyReference) | `src/apm_cli/models/dependency/selection.py` |
 | JetBrains Copilot MCP config path | adapters/client/intellij.py | `src/apm_cli/adapters/client/intellij.py` |
+| Marketplace tag-pattern validation and expansion | marketplace/tag_pattern.py | `src/apm_cli/marketplace/tag_pattern.py` |
 <!-- /canonical-owner-table -->
 
 Host + credential resolution includes public github.com anonymous-first ordering.

--- a/.github/instructions/architecture.instructions.md
+++ b/.github/instructions/architecture.instructions.md
@@ -64,6 +64,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | MCP container launcher selection and Docker argv shape | adapters/client/base.py (MCPClientAdapter) | `src/apm_cli/adapters/client/base.py` |
 | Dependency CLI identifier parsing + uninstall selection | models/dependency/selection.py (via DependencyReference) | `src/apm_cli/models/dependency/selection.py` |
 | JetBrains Copilot MCP config path | adapters/client/intellij.py | `src/apm_cli/adapters/client/intellij.py` |
+| Marketplace tag-pattern validation and expansion | marketplace/tag_pattern.py | `src/apm_cli/marketplace/tag_pattern.py` |
 <!-- /canonical-owner-table -->
 
 Host + credential resolution includes public github.com anonymous-first ordering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (by @ryodocx, closes #2345)
 
 - Marketplace semver range resolution now honours the `tagPattern` declared by the producer; `version: "~2.1.0"` entries no longer silently fall back to the hardcoded `{name}--v{version}` tag pattern. Existing marketplace files without `tag_pattern` keep the legacy convention. (#2366)
+- Marketplace semver range resolution now honours the `tagPattern` declared by the producer; `version: "~2.1.0"` entries no longer silently fall back to the hardcoded `{name}--v{version}` tag pattern. Existing marketplace files without `tag_pattern` keep the legacy convention. Bare versions also fail closed when no tag matches; use an explicit tag ref instead. (#2366)
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview
   now excludes the synthesized lockfile self-entry, matching the real install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The header overlay previously hardcoded `GIT_CONFIG_COUNT=1`, so merging it
   onto an already-configured environment reset the count and clobbered index
   0. (by @edenfunf, #2368)
+- Marketplace semver range resolution now honours the `tagPattern` declared
+  by the marketplace producer. Previously, `version: "~2.1.0"` marketplace
+  dependencies always resolved tags using the hardcoded `{name}--v{version}`
+  pattern, causing silent install failures when a marketplace used a different
+  convention. The effective tag pattern is now propagated from `apm pack`
+  through `marketplace.json` and read by `apm install` at resolution time.
+  (#2319)
 
 ## [0.26.0] - 2026-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,9 +115,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Marketplace semver range resolution now honours the `tagPattern` declared by the producer; `version: "~2.1.0"` entries no longer silently fall back to the hardcoded `{name}--v{version}` tag pattern. Existing marketplace files without `tag_pattern` keep the legacy convention. (#2366)
 - Marketplace semver range resolution now honours the `tagPattern` declared by the producer; `version: "~2.1.0"` entries no longer silently fall back to the hardcoded `{name}--v{version}` tag pattern. Existing marketplace files without `tag_pattern` keep the legacy convention. Bare versions also fail closed when no tag matches; use an explicit tag ref instead. (#2366)
-- Marketplace semver range resolution now honours the `tagPattern` declared by the producer; `version: "~2.1.0"` entries no longer silently fall back to the hardcoded `{name}--v{version}` tag pattern. Existing marketplace files without `tag_pattern` keep the legacy convention. Bare versions also fail closed when no tag matches; use an explicit tag ref instead. (#2366)
-
-- Package-declared targets now restrict dependency primitive deployment without expanding project or consumer authorization, preventing Claude-only hooks from leaking into Cursor and repairing stale owned entries on update; the contract is cited in `docs/src/content/docs/specs/openapm-v0.1.md`. By @sergio-sisternes-epam (#2362)
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview
   now excludes the synthesized lockfile self-entry, matching the real install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   service writes exit non-zero instead of skipping with success.
   (by @ryodocx, closes #2345)
 
+- Marketplace semver range resolution now honours the `tagPattern` declared by the producer; `version: "~2.1.0"` entries no longer silently fall back to the hardcoded `{name}--v{version}` tag pattern. Existing marketplace files without `tag_pattern` keep the legacy convention. (#2366)
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview
   now excludes the synthesized lockfile self-entry, matching the real install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `mcp_target_servers`, leaving `apm.lock.yaml` byte-identical instead of
   rewriting it. (#2306)
 - Marketplace semver range resolution now honours the `tagPattern` declared by the producer; `version: "~2.1.0"` entries no longer silently fall back to the hardcoded `{name}--v{version}` tag pattern. Existing marketplace files without `tag_pattern` keep the legacy convention. Bare versions also fail closed when no tag matches; use an explicit tag ref instead. (#2366)
-
 - On-prem Azure DevOps Server hosts configured with `ADO_HOST` or
   `APM_ADO_HOSTS` are no longer misclassified as GitHub Enterprise Server when
   `GITHUB_HOST` overlaps, keeping ADO credentials isolated end to end.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Marketplace semver range resolution now honours the `tagPattern` declared by the producer; `version: "~2.1.0"` entries no longer silently fall back to the hardcoded `{name}--v{version}` tag pattern. Existing marketplace files without `tag_pattern` keep the legacy convention. (#2366)
 - Marketplace semver range resolution now honours the `tagPattern` declared by the producer; `version: "~2.1.0"` entries no longer silently fall back to the hardcoded `{name}--v{version}` tag pattern. Existing marketplace files without `tag_pattern` keep the legacy convention. Bare versions also fail closed when no tag matches; use an explicit tag ref instead. (#2366)
+- Marketplace semver range resolution now honours the `tagPattern` declared by the producer; `version: "~2.1.0"` entries no longer silently fall back to the hardcoded `{name}--v{version}` tag pattern. Existing marketplace files without `tag_pattern` keep the legacy convention. Bare versions also fail closed when no tag matches; use an explicit tag ref instead. (#2366)
+- Public `github.com` dependencies now try anonymous HTTPS before resolving
+  credentials, so all-public installs no longer open repeated credential or
+  Git Credential Manager prompts. Reported by @RuiRomano. (#2406, closes #2400)
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview
   now excludes the synthesized lockfile self-entry, matching the real install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Marketplace semver range resolution now honours the `tagPattern` declared by the producer; `version: "~2.1.0"` entries no longer silently fall back to the hardcoded `{name}--v{version}` tag pattern. Existing marketplace files without `tag_pattern` keep the legacy convention. (#2366)
 - Marketplace semver range resolution now honours the `tagPattern` declared by the producer; `version: "~2.1.0"` entries no longer silently fall back to the hardcoded `{name}--v{version}` tag pattern. Existing marketplace files without `tag_pattern` keep the legacy convention. Bare versions also fail closed when no tag matches; use an explicit tag ref instead. (#2366)
+- Marketplace semver range resolution now honours the `tagPattern` declared by the producer; `version: "~2.1.0"` entries no longer silently fall back to the hardcoded `{name}--v{version}` tag pattern. Existing marketplace files without `tag_pattern` keep the legacy convention. Bare versions also fail closed when no tag matches; use an explicit tag ref instead. (#2366)
+
+- Package-declared targets now restrict dependency primitive deployment without expanding project or consumer authorization, preventing Claude-only hooks from leaking into Cursor and repairing stale owned entries on update; the contract is cited in `docs/src/content/docs/specs/openapm-v0.1.md`. By @sergio-sisternes-epam (#2362)
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview
   now excludes the synthesized lockfile self-entry, matching the real install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   explicit target mappings now preserve `generated_at`, deployment ownership,
   and `mcp_target_servers`, leaving `apm.lock.yaml` byte-identical instead of
   rewriting it. (#2306)
+- Marketplace semver range resolution now honours the `tagPattern` declared by the producer; `version: "~2.1.0"` entries no longer silently fall back to the hardcoded `{name}--v{version}` tag pattern. Existing marketplace files without `tag_pattern` keep the legacy convention. Bare versions also fail closed when no tag matches; use an explicit tag ref instead. (#2366)
+
 - On-prem Azure DevOps Server hosts configured with `ADO_HOST` or
   `APM_ADO_HOSTS` are no longer misclassified as GitHub Enterprise Server when
   `GITHUB_HOST` overlaps, keeping ADO credentials isolated end to end.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,10 +115,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Marketplace semver range resolution now honours the `tagPattern` declared by the producer; `version: "~2.1.0"` entries no longer silently fall back to the hardcoded `{name}--v{version}` tag pattern. Existing marketplace files without `tag_pattern` keep the legacy convention. (#2366)
 - Marketplace semver range resolution now honours the `tagPattern` declared by the producer; `version: "~2.1.0"` entries no longer silently fall back to the hardcoded `{name}--v{version}` tag pattern. Existing marketplace files without `tag_pattern` keep the legacy convention. Bare versions also fail closed when no tag matches; use an explicit tag ref instead. (#2366)
-- Marketplace semver range resolution now honours the `tagPattern` declared by the producer; `version: "~2.1.0"` entries no longer silently fall back to the hardcoded `{name}--v{version}` tag pattern. Existing marketplace files without `tag_pattern` keep the legacy convention. Bare versions also fail closed when no tag matches; use an explicit tag ref instead. (#2366)
-- Public `github.com` dependencies now try anonymous HTTPS before resolving
-  credentials, so all-public installs no longer open repeated credential or
-  Git Credential Manager prompts. Reported by @RuiRomano. (#2406, closes #2400)
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview
   now excludes the synthesized lockfile self-entry, matching the real install
@@ -136,13 +132,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The header overlay previously hardcoded `GIT_CONFIG_COUNT=1`, so merging it
   onto an already-configured environment reset the count and clobbered index
   0. (by @edenfunf, #2368)
-- Marketplace semver range resolution now honours the `tagPattern` declared
-  by the marketplace producer. Previously, `version: "~2.1.0"` marketplace
-  dependencies always resolved tags using the hardcoded `{name}--v{version}`
-  pattern, causing silent install failures when a marketplace used a different
-  convention. The effective tag pattern is now propagated from `apm pack`
-  through `marketplace.json` and read by `apm install` at resolution time.
-  (#2319)
 
 ## [0.26.0] - 2026-07-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,8 +114,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   service writes exit non-zero instead of skipping with success.
   (by @ryodocx, closes #2345)
 
-- Marketplace semver range resolution now honours the `tagPattern` declared by the producer; `version: "~2.1.0"` entries no longer silently fall back to the hardcoded `{name}--v{version}` tag pattern. Existing marketplace files without `tag_pattern` keep the legacy convention. (#2366)
-- Marketplace semver range resolution now honours the `tagPattern` declared by the producer; `version: "~2.1.0"` entries no longer silently fall back to the hardcoded `{name}--v{version}` tag pattern. Existing marketplace files without `tag_pattern` keep the legacy convention. Bare versions also fail closed when no tag matches; use an explicit tag ref instead. (#2366)
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview
   now excludes the synthesized lockfile self-entry, matching the real install

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -2783,7 +2783,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:c0acf69ef4de5c9de8373337f2164d3206d8d9c6534c6cdf4294f156d99e2762
+  content_hash: sha256:6baeb73b4acf037915c23a813947c21e01b99c36bc68d032568863dd842f5b92
 - kind: project-relative
   target: copilot
   value: .github/instructions/changelog.instructions.md
@@ -3290,7 +3290,7 @@ local_deployed_file_hashes:
   .github/agents/spec-tag-architect.agent.md: sha256:82907265c5e7cf1ac61ad96866fa7c5683b69c8f09b7a4c5f3cc241acc9568ca
   .github/agents/supply-chain-security-expert.agent.md: sha256:8fb8cc426d6af17ba084a28b3f026c2b475b62e3ca63ed2f88b83bd823f877af
   .github/agents/test-coverage-expert.agent.md: sha256:48c2172d1f18a394fa83ef9dc2be0b9b921a4e51e976498165250fed66369711
-  .github/instructions/architecture.instructions.md: sha256:c0acf69ef4de5c9de8373337f2164d3206d8d9c6534c6cdf4294f156d99e2762
+  .github/instructions/architecture.instructions.md: sha256:6baeb73b4acf037915c23a813947c21e01b99c36bc68d032568863dd842f5b92
   .github/instructions/changelog.instructions.md: sha256:1e51ec4c74e847967962bd279dc4c6e582c5d3578490b3c28d5f3acd3e05f73e
   .github/instructions/cicd.instructions.md: sha256:08d87b7d635761cb41deb8fc71d5d83f54678de463db484afb16d2d4f8713ecb
   .github/instructions/cli.instructions.md: sha256:8e39e8d5047ce88575cb02f87c2bcede584dfef258bd86f7466c7badf136541a

--- a/docs/src/content/docs/consumer/manage-dependencies.md
+++ b/docs/src/content/docs/consumer/manage-dependencies.md
@@ -63,7 +63,7 @@ parser. The supported forms:
 | SSH with non-default user | `myuser@host:acme/repo.git` or `ssh://myuser@host/acme/repo.git` | Honors a non-`git` SSH user from the URL — useful for Enterprise Managed User (EMU) accounts or any server where the SSH login is not `git`. Username is validated against `^[a-zA-Z0-9_][a-zA-Z0-9_.+-]*$` (64-char cap); percent-encoded userinfo is rejected. The username is presentation-only and not part of dependency identity. |
 | Local path | `./packages/shared` or `/abs/path` | Sibling package on disk. |
 | Object form (git) | `{ git: <url>, path: <subpath>, ref: <ref>, alias: <name>, type: gitlab }` | Aliases, nested groups, monorepo subpaths, bespoke GitLab hosts, or anything string forms cannot express. |
-| Marketplace dict | `{ name: <plugin>, marketplace: <mkt>, version: <range> }` | Install a plugin from a registered marketplace. Optional `version` accepts a semver range (e.g. `~2.1.0`). Resolved to a concrete git ref at install time using the tag naming pattern declared by the marketplace. |
+| Marketplace dict | `{ name: <plugin>, marketplace: <mkt>, version: <range> }` | Install a plugin from a registered marketplace. Optional `version` accepts a semver range (e.g. `~2.1.0`). The publisher controls the tag naming convention. |
 | Registry shorthand | `owner/repo#^2.0.0` with a default registry configured | Routes dep through the default registry instead of git. Default may come from `apm.yml` or `~/.apm/config.json`. Requires `registries` experimental flag. |
 | Registry object form | `{ id: owner/repo, version: ^2.0.0 }` | Explicit registry dep. `registry:` optional when a default registry is configured. Requires `registries` experimental flag. |
 
@@ -254,10 +254,17 @@ override the marketplace entry's default `source.ref`:
 apm install plugin@marketplace#v2.0.0
 ```
 
-In `apm.yml`, use the `version` field in the marketplace object form.
-Semver ranges and bare versions (e.g. `~2.1.0`, `^2.0`, `2.1.0`) are
-resolved against git tags matching `{name}--v{version}` on the
-marketplace repository. The highest matching tag is used.
+In `apm.yml`, use the `version` field in the marketplace object form. Semver
+ranges and bare versions (for example `~2.1.0`, `^2.0`, or `2.1.0`) resolve
+against the publisher's effective tag pattern: the package override first,
+then the marketplace build default. Old marketplace metadata without a
+`tag_pattern` field keeps the legacy `{name}--v{version}` convention.
+Malformed patterns and ranges with no match fail instead of becoming raw refs.
+
+`apm install` resolves and locks the highest matching tag. A repeated install
+replays the lock without changing durable state. After the publisher adds tags
+and republishes the marketplace metadata, `apm outdated` reports the new
+resolved ref and `apm update --yes` applies it.
 
 ### Pin a semver range
 

--- a/docs/src/content/docs/consumer/manage-dependencies.md
+++ b/docs/src/content/docs/consumer/manage-dependencies.md
@@ -63,7 +63,7 @@ parser. The supported forms:
 | SSH with non-default user | `myuser@host:acme/repo.git` or `ssh://myuser@host/acme/repo.git` | Honors a non-`git` SSH user from the URL — useful for Enterprise Managed User (EMU) accounts or any server where the SSH login is not `git`. Username is validated against `^[a-zA-Z0-9_][a-zA-Z0-9_.+-]*$` (64-char cap); percent-encoded userinfo is rejected. The username is presentation-only and not part of dependency identity. |
 | Local path | `./packages/shared` or `/abs/path` | Sibling package on disk. |
 | Object form (git) | `{ git: <url>, path: <subpath>, ref: <ref>, alias: <name>, type: gitlab }` | Aliases, nested groups, monorepo subpaths, bespoke GitLab hosts, or anything string forms cannot express. |
-| Marketplace dict | `{ name: <plugin>, marketplace: <mkt>, version: <range> }` | Install a plugin from a registered marketplace. Optional `version` accepts a semver range (e.g. `~2.1.0`). Resolved to a concrete git ref at install time. |
+| Marketplace dict | `{ name: <plugin>, marketplace: <mkt>, version: <range> }` | Install a plugin from a registered marketplace. Optional `version` accepts a semver range (e.g. `~2.1.0`). Resolved to a concrete git ref at install time using the tag naming pattern declared by the marketplace. |
 | Registry shorthand | `owner/repo#^2.0.0` with a default registry configured | Routes dep through the default registry instead of git. Default may come from `apm.yml` or `~/.apm/config.json`. Requires `registries` experimental flag. |
 | Registry object form | `{ id: owner/repo, version: ^2.0.0 }` | Explicit registry dep. `registry:` optional when a default registry is configured. Requires `registries` experimental flag. |
 

--- a/docs/src/content/docs/consumer/manage-dependencies.md
+++ b/docs/src/content/docs/consumer/manage-dependencies.md
@@ -261,10 +261,11 @@ then the marketplace build default. Old marketplace metadata without a
 `tag_pattern` field keeps the legacy `{name}--v{version}` convention.
 Malformed patterns and ranges with no match fail instead of becoming raw refs.
 
-`apm install` resolves and locks the highest matching tag. A repeated install
-replays the lock without changing durable state. After the publisher adds tags
-and republishes the marketplace metadata, `apm outdated` reports the new
-resolved ref and `apm update --yes` applies it.
+`apm install` resolves and locks the highest matching tag. Re-running it
+replays the locked version without changes. After the producer adds tags and
+republishes the marketplace metadata, run `apm marketplace update <name>`;
+`apm outdated` then reports the new resolved ref and `apm update --yes`
+applies it.
 
 ### Pin a semver range
 

--- a/docs/src/content/docs/producer/publish-to-a-marketplace.md
+++ b/docs/src/content/docs/producer/publish-to-a-marketplace.md
@@ -140,6 +140,9 @@ for the full validation and override rules.
 The generated source object is also a producer-to-consumer contract.
 `apm pack` emits `source: url` for a remote repository and
 `source: git-subdir` when `subdir` is set.
+It also emits the effective `source.tag_pattern`: a package override takes
+precedence over `marketplace.build.tagPattern`. Repack and publish the generated
+metadata after changing either value so consumers receive the new convention.
 `apm install <package>@<marketplace>` accepts both forms, derives the package host from
 the generated entry rather than from the marketplace host, and preserves
 the generated path and ref.

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -504,8 +504,8 @@ When `version` is a semver range or bare version number (for example
 created before this field existed fall back to the legacy
 `{name}--v{version}` consumer convention. A pattern must contain exactly one
 `{version}` placeholder; `{name}` is optional. Unsupported or malformed
-patterns, and ranges with no matching tags, fail without falling back to a raw
-ref. Pre-release versions are excluded from range resolution; target them
+patterns, and ranges or bare versions with no matching tags, fail without
+falling back to a raw ref. Pre-release versions are excluded from range resolution; target them
 explicitly as raw git refs. Raw refs such as `v2.0.0`, `main`, or a commit SHA
 bypass tag resolution.
 

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -497,7 +497,17 @@ Marketplace dependency (resolved at install time):
 
 The `marketplace` key is mutually exclusive with `git`, `path`, `registry`, and `id`; combining them raises a parse error. Unknown keys in a marketplace entry are rejected. During dependency resolution the resolver calls `resolve_marketplace_plugin()`. A plugin entry that declares `registry` plus a semver `version` becomes a registry-sourced dependency using its declared owner/repo repository identity. Other entries become concrete Git coordinates (owner/repo, ref, and optional virtual path).
 
-When `version` is specified and is a semver range or bare version number (e.g. `~2.1.0`, `^2.0`, `2.1.0`), the resolver lists git tags on the marketplace repository matching the `{name}--v{version}` convention, filters to those satisfying the constraint, and resolves to the highest matching tag. If no tag satisfies an explicit semver range, resolution fails with a `NoMatchingVersionError`. A bare version with no matching tag falls back to using the value as a raw git ref. Pre-release versions (e.g. `2.0.0-beta.1`) are excluded from semver-range resolution; target them explicitly as raw git refs. When `version` is a raw git ref (e.g. `v2.0.0`, `main`, or a commit SHA), it is used as a direct ref override without tag resolution.
+When `version` is a semver range or bare version number (for example
+`~2.1.0`, `^2.0`, or `2.1.0`), the resolver uses the plugin source's
+`tag_pattern`. `apm pack` emits that effective pattern from the package's
+`tag_pattern` override, then `marketplace.build.tagPattern`. Marketplace files
+created before this field existed fall back to the legacy
+`{name}--v{version}` consumer convention. A pattern must contain exactly one
+`{version}` placeholder; `{name}` is optional. Unsupported or malformed
+patterns, and ranges with no matching tags, fail without falling back to a raw
+ref. Pre-release versions are excluded from range resolution; target them
+explicitly as raw git refs. Raw refs such as `v2.0.0`, `main`, or a commit SHA
+bypass tag resolution.
 
 Resolution failures stop the install instead of silently skipping the dependency. The lockfile records the **resolved** coordinates and pinned commit, not the marketplace placeholder. Unresolved marketplace dependencies cannot compute install paths or serialize back to `apm.yml`.
 
@@ -883,7 +893,7 @@ marketplace:
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `tagPattern` | `string` | `v{version}` | Pattern used to construct git tags for packages. MUST contain at least one of `{version}` or `{name}`. Per-package overrides live on `packages[].tag_pattern`. |
+| `tagPattern` | `string` | `v{version}` | Pattern used to construct git tags for packages. MUST contain exactly one `{version}`; `{name}` is optional. Per-package overrides live on `packages[].tag_pattern`. |
 
 ### 7.5. `marketplace.packages`
 

--- a/docs/src/content/docs/reference/manifest-schema.md
+++ b/docs/src/content/docs/reference/manifest-schema.md
@@ -509,6 +509,11 @@ falling back to a raw ref. Pre-release versions are excluded from range resoluti
 explicitly as raw git refs. Raw refs such as `v2.0.0`, `main`, or a commit SHA
 bypass tag resolution.
 
+`source.tag_pattern` is validated while the catalog is loaded. One malformed
+pattern makes `apm marketplace add` or `apm marketplace update` reject the
+entire marketplace, so consumers never resolve against a partially accepted
+catalog.
+
 Resolution failures stop the install instead of silently skipping the dependency. The lockfile records the **resolved** coordinates and pinned commit, not the marketplace placeholder. Unresolved marketplace dependencies cannot compute install paths or serialize back to `apm.yml`.
 
 Registry dependency (whole package or virtual sub-path):

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -229,17 +229,19 @@ that at most one declaration remains.
 |-------|----------|-------------|
 | `name` | REQUIRED | Plugin identifier within the marketplace (`^[a-zA-Z0-9._-]+$`). |
 | `marketplace` | REQUIRED | Registered marketplace name (`^[a-zA-Z0-9._-]+$`). |
-| `version` | OPTIONAL | Semver range or exact version (e.g. `~2.1.0`, `^2.0`, `>=1.4`, `2.1.0`). Resolved against git tags whose pattern is declared by the marketplace (defaults to `{name}--v{version}`). |
+| `version` | OPTIONAL | Semver range or exact version (e.g. `~2.1.0`, `^2.0`, `>=1.4`, `2.1.0`). Resolved against git tags using the publisher's effective pattern: `packages[].tag_pattern`, then `marketplace.build.tagPattern`. Older metadata without `source.tag_pattern` uses the legacy `{name}--v{version}` fallback. |
 
 During resolution, marketplace entries are looked up in the marketplace's
 `marketplace.json` and replaced with concrete git coordinates. When `version`
 is a semver range or bare version number, the resolver lists git tags
-using the pattern declared in the marketplace's `tag_pattern` field (populated
-by `apm pack` from the producer's `build.tagPattern`). APM filters by the
-constraint and picks the highest matching tag. Raw git refs (e.g. `v2.0.0`,
-`main`) bypass tag resolution and override the source ref directly. The
-lockfile records the resolved ref, not the marketplace placeholder. Unknown
-keys in a marketplace entry are rejected.
+using the `source.tag_pattern` emitted by `apm pack`. The package-level
+`tag_pattern` overrides `marketplace.build.tagPattern`. APM filters by the
+constraint and picks the highest matching tag. Old `marketplace.json` files
+that omit `source.tag_pattern` fall back to `{name}--v{version}`. Patterns
+must contain exactly one `{version}` placeholder, and a no-match does not
+silently become a raw ref. Raw git refs (e.g. `v2.0.0`, `main`) bypass tag
+resolution. The lockfile records the resolved ref, not the marketplace
+placeholder. Unknown keys in a marketplace entry are rejected.
 
 Producer-emitted `source: url` and `source: git-subdir` objects resolve
 through the same Git dependency parser as direct object-form dependencies.

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -229,16 +229,17 @@ that at most one declaration remains.
 |-------|----------|-------------|
 | `name` | REQUIRED | Plugin identifier within the marketplace (`^[a-zA-Z0-9._-]+$`). |
 | `marketplace` | REQUIRED | Registered marketplace name (`^[a-zA-Z0-9._-]+$`). |
-| `version` | OPTIONAL | Semver range or exact version (e.g. `~2.1.0`, `^2.0`, `>=1.4`, `2.1.0`). Resolved against `{name}--v{version}` git tags on the marketplace repo. |
+| `version` | OPTIONAL | Semver range or exact version (e.g. `~2.1.0`, `^2.0`, `>=1.4`, `2.1.0`). Resolved against git tags whose pattern is declared by the marketplace (defaults to `{name}--v{version}`). |
 
 During resolution, marketplace entries are looked up in the marketplace's
 `marketplace.json` and replaced with concrete git coordinates. When `version`
 is a semver range or bare version number, the resolver lists git tags
-matching `{name}--v{version}`, filters by the constraint, and picks the
-highest matching tag. Raw git refs (e.g. `v2.0.0`, `main`) bypass tag
-resolution and override the source ref directly. The lockfile records the
-resolved ref, not the marketplace placeholder. Unknown keys in a marketplace
-entry are rejected.
+using the pattern declared in the marketplace's `tag_pattern` field (populated
+by `apm pack` from the producer's `build.tagPattern`). APM filters by the
+constraint and picks the highest matching tag. Raw git refs (e.g. `v2.0.0`,
+`main`) bypass tag resolution and override the source ref directly. The
+lockfile records the resolved ref, not the marketplace placeholder. Unknown
+keys in a marketplace entry are rejected.
 
 Producer-emitted `source: url` and `source: git-subdir` objects resolve
 through the same Git dependency parser as direct object-form dependencies.

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -771,7 +771,9 @@ The compiler:
 
 1. Emits `plugins:` verbatim (Anthropic's key name).
 2. Copies `metadata:` byte-for-byte.
-3. Strips `build:`, per-plugin `version`, `tag_pattern`, `include_prerelease`.
+3. Strips authoring-only `build:`, per-plugin `version`, and
+   `include_prerelease`; emits the effective package-over-build tag convention
+   as remote `source.tag_pattern`.
 4. Omits empty `tags:` and inherited top-level `description`/`version`
    from the output (matches Anthropic's canonical hand-authored shape,
    e.g. microsoft/azure-skills).

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -1271,7 +1271,6 @@ if ! grep -q '_clear_platform_token_env(env)' src/apm_cli/core/auth.py \
     [ -n "$ado_transport_direct_hits" ] && echo "$ado_transport_direct_hits"
     violations=$((violations + 1))
 fi
-
 echo "[*] AC28: JetBrains Copilot MCP config-path authority"
 intellij_path_owner="src/apm_cli/adapters/client/intellij.py"
 intellij_path_owner_count=$(grep -Ec '^def _intellij_config_dir\(' "$intellij_path_owner" || true)
@@ -1291,6 +1290,31 @@ if [ "$intellij_path_owner_count" -ne 1 ] \
     || [ -n "$intellij_path_duplicate_hits" ]; then
     echo "[x] JetBrains Copilot MCP paths must come from the IntelliJ adapter"
     [ -n "$intellij_path_duplicate_hits" ] && echo "$intellij_path_duplicate_hits"
+    violations=$((violations + 1))
+fi
+
+echo "[*] AC27: marketplace tag-pattern authority"
+tag_pattern_owner="src/apm_cli/marketplace/tag_pattern.py"
+tag_pattern_parallel_hits=$(
+    grep -rEn --include='*.py' \
+        '["'\'']\{version\}["'\''][[:space:]]+(not[[:space:]]+)?in[[:space:]]+(pattern|tag_pattern)|\.(count)\(["'\'']\{version\}["'\'']\)' \
+        src/apm_cli/marketplace \
+        | grep -v "^${tag_pattern_owner}:" \
+        | grep -v 'architecture-authority-exempt:' \
+        || true
+)
+if ! grep -q '^def validate_tag_pattern(' "$tag_pattern_owner" \
+    || ! grep -A8 '^def _validate_tag_pattern(' \
+        src/apm_cli/marketplace/yml_schema.py \
+        | grep -q 'validate_tag_pattern(pattern, context=context)' \
+    || ! grep -A12 'raw_tp = source.get("tag_pattern")' \
+        src/apm_cli/marketplace/models.py \
+        | grep -q 'tag_pattern = validate_tag_pattern(' \
+    || ! grep -q 'tag_pattern = validate_tag_pattern(tag_pattern)' \
+        src/apm_cli/marketplace/version_resolver.py \
+    || [ -n "$tag_pattern_parallel_hits" ]; then
+    echo "[x] Marketplace tag patterns must route through marketplace/tag_pattern.py"
+    [ -n "$tag_pattern_parallel_hits" ] && echo "$tag_pattern_parallel_hits"
     violations=$((violations + 1))
 fi
 

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -1317,7 +1317,6 @@ if ! grep -q '^def validate_tag_pattern(' "$tag_pattern_owner" \
     [ -n "$tag_pattern_parallel_hits" ] && echo "$tag_pattern_parallel_hits"
     violations=$((violations + 1))
 fi
-
 if [ "$violations" -gt 0 ]; then
     echo "[x] $violations architecture boundary rule(s) failed"
     exit 1

--- a/src/apm_cli/deps/apm_resolver.py
+++ b/src/apm_cli/deps/apm_resolver.py
@@ -148,6 +148,7 @@ class APMDependencyResolver:
         self._download_lock = threading.Lock()
         self._auth_resolver = auth_resolver
         self._max_parallel = self._resolve_max_parallel(max_parallel)
+        self.marketplace_provenance: dict[str, dict[str, str]] = {}
 
     @staticmethod
     def _resolve_max_parallel(explicit: int | None) -> int:
@@ -498,9 +499,16 @@ class APMDependencyResolver:
             auth_resolver=self._auth_resolver,
             warning_handler=_logger.warning,
         )
-        if resolution.dependency_reference is not None:
-            return resolution.dependency_reference
-        return DependencyReference.parse(resolution.canonical)
+        resolved = (
+            resolution.dependency_reference
+            if resolution.dependency_reference is not None
+            else DependencyReference.parse(resolution.canonical)
+        )
+        self.marketplace_provenance[resolved.get_unique_key()] = resolution.provenance(
+            dep_ref.marketplace_name,
+            dep_ref.marketplace_plugin_name,
+        )
+        return resolved
 
     def _resolve_marketplace_or_record_error(
         self,

--- a/src/apm_cli/deps/apm_resolver.py
+++ b/src/apm_cli/deps/apm_resolver.py
@@ -148,7 +148,12 @@ class APMDependencyResolver:
         self._download_lock = threading.Lock()
         self._auth_resolver = auth_resolver
         self._max_parallel = self._resolve_max_parallel(max_parallel)
-        self.marketplace_provenance: dict[str, dict[str, str]] = {}
+        self._marketplace_provenance: dict[str, dict[str, str]] = {}
+
+    @property
+    def marketplace_provenance(self) -> dict[str, dict[str, str]]:
+        """Return marketplace provenance captured while resolving the graph."""
+        return dict(self._marketplace_provenance)
 
     @staticmethod
     def _resolve_max_parallel(explicit: int | None) -> int:
@@ -504,7 +509,7 @@ class APMDependencyResolver:
             if resolution.dependency_reference is not None
             else DependencyReference.parse(resolution.canonical)
         )
-        self.marketplace_provenance[resolved.get_unique_key()] = resolution.provenance(
+        self._marketplace_provenance[resolved.get_unique_key()] = resolution.provenance(
             dep_ref.marketplace_name,
             dep_ref.marketplace_plugin_name,
         )

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -290,6 +290,27 @@ def _requires_remote_ref_resolution(ctx: InstallContext) -> bool:
     return policy.requires_remote
 
 
+def _attach_resolver_marketplace_provenance(
+    ctx: InstallContext,
+    resolver,
+) -> None:
+    """Carry manifest-resolved marketplace identity into lockfile assembly."""
+    if not resolver.marketplace_provenance:
+        return
+    if ctx.marketplace_provenance is None:
+        ctx.marketplace_provenance = {}
+    ctx.marketplace_provenance.update(resolver.marketplace_provenance)
+
+
+def _build_dependency_graph(ctx: InstallContext, resolver):
+    """Resolve the manifest graph and retain its marketplace provenance."""
+    manifest_anchor = ctx.source_root if ctx.source_root != ctx.project_root else ctx.apm_dir
+    dependency_graph = resolver.resolve_dependencies(manifest_anchor)
+    ctx.dependency_graph = dependency_graph
+    _attach_resolver_marketplace_provenance(ctx, resolver)
+    return dependency_graph
+
+
 def _resolve_dependencies(ctx: InstallContext, staging_session: ResolutionStagingSession) -> None:
     """Resolve dependencies and populate the resolution fields on ``ctx``."""
     import threading as _threading
@@ -691,9 +712,7 @@ def _resolve_dependencies(ctx: InstallContext, staging_session: ResolutionStagin
     # ``apm_modules_dir`` is already pinned on the resolver above, so
     # this arg selects only where ``apm.yml`` is read -- never where
     # ``apm_modules/`` is written.
-    manifest_anchor = ctx.source_root if ctx.source_root != ctx.project_root else ctx.apm_dir
-    dependency_graph = resolver.resolve_dependencies(manifest_anchor)
-    ctx.dependency_graph = dependency_graph
+    dependency_graph = _build_dependency_graph(ctx, resolver)
     _fail_on_resolution_errors(ctx, dependency_graph)
 
     # Fold remote-parent local_path rejections into ``callback_failures`` so

--- a/src/apm_cli/marketplace/builder.py
+++ b/src/apm_cli/marketplace/builder.py
@@ -116,6 +116,7 @@ class ResolvedPackage:
     is_prerelease: bool  # True if the resolved ref was a prerelease semver
     host: str | None = None  # non-default git host parsed from apm.yml source
     source_url: str | None = None  # canonical URL for sourceBase-composed entries
+    effective_tag_pattern: str = ""  # tag pattern used to resolve this package
 
 
 @dataclass(frozen=True)
@@ -629,6 +630,7 @@ class MarketplaceBuilder:
                 owner_repo,
                 source_host=source_host,
                 source_url=source_url,
+                effective_tag_pattern=entry.tag_pattern or yml.build.tag_pattern,
             )
         # version range resolution
         return self._resolve_version_range(
@@ -648,6 +650,7 @@ class MarketplaceBuilder:
         *,
         source_host: str | None = None,
         source_url: str | None = None,
+        effective_tag_pattern: str = "",
     ) -> ResolvedPackage:
         """Resolve an entry with an explicit ``ref:`` field."""
         ref_text = entry.ref
@@ -667,6 +670,7 @@ class MarketplaceBuilder:
                 is_prerelease=sv.is_prerelease if sv else False,
                 host=self._resolved_output_host(source_host=source_host, source_url=source_url),
                 source_url=source_url,
+                effective_tag_pattern=effective_tag_pattern,
             )
 
         refs = resolver.list_remote_refs(owner_repo)
@@ -700,6 +704,7 @@ class MarketplaceBuilder:
                 is_prerelease=sv.is_prerelease if sv else False,
                 host=self._resolved_output_host(source_host=source_host, source_url=source_url),
                 source_url=source_url,
+                effective_tag_pattern=effective_tag_pattern,
             )
 
         # Try as full refname
@@ -721,6 +726,7 @@ class MarketplaceBuilder:
                 is_prerelease=sv.is_prerelease if sv else False,
                 host=self._resolved_output_host(source_host=source_host, source_url=source_url),
                 source_url=source_url,
+                effective_tag_pattern=effective_tag_pattern,
             )
 
         # Try as branch name
@@ -739,6 +745,7 @@ class MarketplaceBuilder:
                 is_prerelease=False,
                 host=self._resolved_output_host(source_host=source_host, source_url=source_url),
                 source_url=source_url,
+                effective_tag_pattern=effective_tag_pattern,
             )
 
         # HEAD special case
@@ -802,6 +809,7 @@ class MarketplaceBuilder:
             is_prerelease=best_sv.is_prerelease,
             host=self._resolved_output_host(source_host=source_host, source_url=source_url),
             source_url=source_url,
+            effective_tag_pattern=pattern,
         )
 
     # -- concurrent resolution ----------------------------------------------

--- a/src/apm_cli/marketplace/builder.py
+++ b/src/apm_cli/marketplace/builder.py
@@ -116,7 +116,9 @@ class ResolvedPackage:
     is_prerelease: bool  # True if the resolved ref was a prerelease semver
     host: str | None = None  # non-default git host parsed from apm.yml source
     source_url: str | None = None  # canonical URL for sourceBase-composed entries
-    effective_tag_pattern: str = ""  # tag pattern used to resolve this package
+    # Propagated to marketplace.json so consumer range resolution and
+    # diagnostics use the producer's convention without re-reading apm.yml.
+    effective_tag_pattern: str = ""
 
 
 @dataclass(frozen=True)

--- a/src/apm_cli/marketplace/models.py
+++ b/src/apm_cli/marketplace/models.py
@@ -322,6 +322,13 @@ class MarketplacePlugin:
     # ``source`` is a string path or ``{type: github, repo: ...}`` dict.
     registry: str = ""
 
+    # Tag pattern declared by the marketplace producer (e.g. "{name}/{version}").
+    # Stored in the ``source`` dict of marketplace.json by ``apm pack`` so that
+    # the consumer-side semver resolver can honour the same naming convention.
+    # ``None`` means the field was absent (old marketplace.json); the resolver
+    # falls back to its built-in default in that case.
+    tag_pattern: str | None = None
+
     def matches_query(self, query: str) -> bool:
         """Return True if the plugin matches a search query (case-insensitive)."""
         q = query.lower()
@@ -449,6 +456,12 @@ def _parse_plugin_entry(entry: dict[str, Any], source_name: str) -> MarketplaceP
                 f"but version {version!r} is not a valid semver selector"
             )
 
+    tag_pattern: str | None = None
+    if isinstance(source, dict):
+        raw_tp = source.get("tag_pattern")
+        if isinstance(raw_tp, str) and raw_tp.strip():
+            tag_pattern = raw_tp.strip()
+
     return MarketplacePlugin(
         name=name,
         source=source,
@@ -457,6 +470,7 @@ def _parse_plugin_entry(entry: dict[str, Any], source_name: str) -> MarketplaceP
         tags=tags,
         source_marketplace=source_name,
         registry=registry_name,
+        tag_pattern=tag_pattern,
     )
 
 

--- a/src/apm_cli/marketplace/models.py
+++ b/src/apm_cli/marketplace/models.py
@@ -459,8 +459,13 @@ def _parse_plugin_entry(entry: dict[str, Any], source_name: str) -> MarketplaceP
     tag_pattern: str | None = None
     if isinstance(source, dict):
         raw_tp = source.get("tag_pattern")
-        if isinstance(raw_tp, str) and raw_tp.strip():
-            tag_pattern = raw_tp.strip()
+        if raw_tp is not None:
+            from .tag_pattern import validate_tag_pattern
+
+            tag_pattern = validate_tag_pattern(
+                raw_tp,
+                context=f"Plugin {name!r} source.tag_pattern",
+            )
 
     return MarketplacePlugin(
         name=name,

--- a/src/apm_cli/marketplace/output_mappers.py
+++ b/src/apm_cli/marketplace/output_mappers.py
@@ -259,8 +259,7 @@ class ClaudeMarketplaceMapper(MarketplaceOutputMapper):
                     source_obj["ref"] = pkg.ref
                 if pkg.sha:
                     source_obj["sha"] = pkg.sha
-                if pkg.effective_tag_pattern:
-                    source_obj["tag_pattern"] = pkg.effective_tag_pattern
+                _set_effective_tag_pattern(source_obj, pkg)
                 plugin["source"] = source_obj
 
             plugins.append(plugin)
@@ -335,6 +334,15 @@ MARKETPLACE_OUTPUT_MAPPERS: dict[str, MarketplaceOutputMapper] = {
 }
 
 
+def _set_effective_tag_pattern(
+    source_obj: dict[str, Any],
+    pkg: ResolvedPackage,
+) -> None:
+    """Add producer tag metadata when it applies to the remote source."""
+    if pkg.effective_tag_pattern:
+        source_obj["tag_pattern"] = pkg.effective_tag_pattern
+
+
 def _remote_source_url(pkg: ResolvedPackage) -> str | None:
     """Return the canonical URL for remote packages that cannot use github shorthand."""
     if pkg.source_url:
@@ -361,8 +369,7 @@ def _codex_source(entry: PackageEntry, pkg: ResolvedPackage) -> dict[str, Any]:
             source_obj["ref"] = pkg.ref
         if pkg.sha:
             source_obj["sha"] = pkg.sha
-        if pkg.effective_tag_pattern:
-            source_obj["tag_pattern"] = pkg.effective_tag_pattern
+        _set_effective_tag_pattern(source_obj, pkg)
         return source_obj
 
     source_obj = OrderedDict()
@@ -372,8 +379,7 @@ def _codex_source(entry: PackageEntry, pkg: ResolvedPackage) -> dict[str, Any]:
         source_obj["ref"] = pkg.ref
     if pkg.sha:
         source_obj["sha"] = pkg.sha
-    if pkg.effective_tag_pattern:
-        source_obj["tag_pattern"] = pkg.effective_tag_pattern
+    _set_effective_tag_pattern(source_obj, pkg)
     return source_obj
 
 

--- a/src/apm_cli/marketplace/output_mappers.py
+++ b/src/apm_cli/marketplace/output_mappers.py
@@ -361,6 +361,8 @@ def _codex_source(entry: PackageEntry, pkg: ResolvedPackage) -> dict[str, Any]:
             source_obj["ref"] = pkg.ref
         if pkg.sha:
             source_obj["sha"] = pkg.sha
+        if pkg.effective_tag_pattern:
+            source_obj["tag_pattern"] = pkg.effective_tag_pattern
         return source_obj
 
     source_obj = OrderedDict()
@@ -370,6 +372,8 @@ def _codex_source(entry: PackageEntry, pkg: ResolvedPackage) -> dict[str, Any]:
         source_obj["ref"] = pkg.ref
     if pkg.sha:
         source_obj["sha"] = pkg.sha
+    if pkg.effective_tag_pattern:
+        source_obj["tag_pattern"] = pkg.effective_tag_pattern
     return source_obj
 
 

--- a/src/apm_cli/marketplace/output_mappers.py
+++ b/src/apm_cli/marketplace/output_mappers.py
@@ -259,6 +259,8 @@ class ClaudeMarketplaceMapper(MarketplaceOutputMapper):
                     source_obj["ref"] = pkg.ref
                 if pkg.sha:
                     source_obj["sha"] = pkg.sha
+                if pkg.effective_tag_pattern:
+                    source_obj["tag_pattern"] = pkg.effective_tag_pattern
                 plugin["source"] = source_obj
 
             plugins.append(plugin)

--- a/src/apm_cli/marketplace/resolver.py
+++ b/src/apm_cli/marketplace/resolver.py
@@ -976,12 +976,11 @@ def resolve_marketplace_plugin(
     # (for plain tags/branches/SHAs like v2.0.0). The tag lookup uses the
     # marketplace catalog host; structured package fetches still use dep_ref.host.
     if version_spec:
-        from .version_resolver import is_semver_range, is_version_constraint
+        from .version_resolver import is_version_constraint
 
         base = canonical.split("#", 1)[0]
         resolved_override = version_spec
         if is_version_constraint(version_spec):
-            from .errors import NoMatchingVersionError
             from .version_resolver import DEFAULT_TAG_PATTERN, resolve_version_constraint
 
             owner_repo = f"{source.owner}/{source.repo}"
@@ -1001,32 +1000,31 @@ def resolve_marketplace_plugin(
                 version_auth["git_env"] = git_env
             if source.port is not None:
                 version_auth["port"] = source.port
-            try:
-                tag_name, _sha = resolve_version_constraint(
-                    plugin_name,
-                    owner_repo,
-                    version_spec,
-                    tag_pattern=plugin.tag_pattern or DEFAULT_TAG_PATTERN,
-                    **version_auth,
-                )
-                resolved_override = tag_name
+            effective_tag_pattern = plugin.tag_pattern
+            if effective_tag_pattern is None:
                 logger.debug(
-                    "Version constraint '%s' for %s@%s resolved to tag '%s'",
-                    version_spec,
+                    "Plugin '%s' in marketplace '%s' has no tag_pattern; using legacy default '%s'",
                     plugin_name,
                     marketplace_name,
-                    tag_name,
+                    DEFAULT_TAG_PATTERN,
                 )
-            except NoMatchingVersionError:
-                if is_semver_range(version_spec):
-                    raise
-                logger.debug(
-                    "No '%s--v*' tags matched '%s' on %s@%s, falling back to raw git ref",
-                    plugin_name,
-                    version_spec,
-                    plugin_name,
-                    marketplace_name,
-                )
+                effective_tag_pattern = DEFAULT_TAG_PATTERN
+            tag_name, _sha = resolve_version_constraint(
+                plugin_name,
+                owner_repo,
+                version_spec,
+                tag_pattern=effective_tag_pattern,
+                **version_auth,
+            )
+            resolved_override = tag_name
+            logger.debug(
+                "Version constraint '%s' for %s@%s resolved with pattern '%s' to tag '%s'",
+                version_spec,
+                plugin_name,
+                marketplace_name,
+                effective_tag_pattern,
+                tag_name,
+            )
         else:
             logger.debug(
                 "Using raw git ref '%s' for %s@%s",

--- a/src/apm_cli/marketplace/resolver.py
+++ b/src/apm_cli/marketplace/resolver.py
@@ -990,16 +990,6 @@ def resolve_marketplace_plugin(
                 org=source.owner,
                 port=source.port,
             )
-            version_auth = {
-                "host": source.host,
-                "token": token,
-                "auth_scheme": auth_scheme,
-                "auth_resolver": auth_resolver,
-            }
-            if git_env is not None:
-                version_auth["git_env"] = git_env
-            if source.port is not None:
-                version_auth["port"] = source.port
             effective_tag_pattern = plugin.tag_pattern
             if effective_tag_pattern is None:
                 logger.debug(
@@ -1009,11 +999,21 @@ def resolve_marketplace_plugin(
                     DEFAULT_TAG_PATTERN,
                 )
                 effective_tag_pattern = DEFAULT_TAG_PATTERN
+            version_auth = {
+                "host": source.host,
+                "token": token,
+                "auth_scheme": auth_scheme,
+                "auth_resolver": auth_resolver,
+                "tag_pattern": effective_tag_pattern,
+            }
+            if git_env is not None:
+                version_auth["git_env"] = git_env
+            if source.port is not None:
+                version_auth["port"] = source.port
             tag_name, _sha = resolve_version_constraint(
                 plugin_name,
                 owner_repo,
                 version_spec,
-                tag_pattern=effective_tag_pattern,
                 **version_auth,
             )
             resolved_override = tag_name

--- a/src/apm_cli/marketplace/resolver.py
+++ b/src/apm_cli/marketplace/resolver.py
@@ -982,7 +982,7 @@ def resolve_marketplace_plugin(
         resolved_override = version_spec
         if is_version_constraint(version_spec):
             from .errors import NoMatchingVersionError
-            from .version_resolver import resolve_version_constraint
+            from .version_resolver import DEFAULT_TAG_PATTERN, resolve_version_constraint
 
             owner_repo = f"{source.owner}/{source.repo}"
             token, auth_scheme, git_env = _extract_auth(
@@ -1006,6 +1006,7 @@ def resolve_marketplace_plugin(
                     plugin_name,
                     owner_repo,
                     version_spec,
+                    tag_pattern=plugin.tag_pattern or DEFAULT_TAG_PATTERN,
                     **version_auth,
                 )
                 resolved_override = tag_name

--- a/src/apm_cli/marketplace/tag_pattern.py
+++ b/src/apm_cli/marketplace/tag_pattern.py
@@ -19,12 +19,14 @@ import re
 
 __all__ = [
     "DEFAULT_TAG_PATTERNS",
+    "TagPatternError",
     "build_tag_regex",
     "infer_tag_pattern",
     "infer_tag_pattern_from_refs",
     "is_version_tag_ref",
     "parse_tag_version",
     "render_tag",
+    "validate_tag_pattern",
 ]
 
 # Common tag layouts tried when no explicit ``tag_pattern`` is configured.
@@ -44,6 +46,36 @@ _PLAIN_SEMVER_RE = re.compile(
 # Placeholders we recognise.
 _PLACEHOLDER_VERSION = "{version}"
 _PLACEHOLDER_NAME = "{name}"
+_SUPPORTED_PLACEHOLDERS = frozenset({_PLACEHOLDER_NAME, _PLACEHOLDER_VERSION})
+_PLACEHOLDER_RE = re.compile(r"\{[^{}]*\}")
+
+
+class TagPatternError(ValueError):
+    """Raised when a marketplace tag pattern cannot select semver tags."""
+
+
+def validate_tag_pattern(pattern: object, *, context: str = "tag_pattern") -> str:
+    """Return a normalized, consumer-safe marketplace tag pattern.
+
+    A semver-selection pattern must contain exactly one ``{version}``
+    placeholder. ``{name}`` is optional. Other brace placeholders are rejected
+    because the pattern engine treats no other tokens as substitutions.
+    """
+    if not isinstance(pattern, str) or not pattern.strip():
+        raise TagPatternError(f"'{context}' must be a non-empty string")
+    normalized = pattern.strip()
+    placeholders = _PLACEHOLDER_RE.findall(normalized)
+    unsupported = sorted(set(placeholders) - _SUPPORTED_PLACEHOLDERS)
+    if unsupported:
+        raise TagPatternError(
+            f"'{context}' contains unsupported placeholder(s): {', '.join(unsupported)}"
+        )
+    version_count = normalized.count(_PLACEHOLDER_VERSION)
+    if version_count != 1:
+        raise TagPatternError(
+            f"'{context}' must contain exactly one {_PLACEHOLDER_VERSION} placeholder"
+        )
+    return normalized
 
 
 def render_tag(pattern: str, *, name: str, version: str) -> str:

--- a/src/apm_cli/marketplace/tag_pattern.py
+++ b/src/apm_cli/marketplace/tag_pattern.py
@@ -62,7 +62,7 @@ def validate_tag_pattern(pattern: object, *, context: str = "tag_pattern") -> st
     because the pattern engine treats no other tokens as substitutions.
     """
     if not isinstance(pattern, str) or not pattern.strip():
-        raise TagPatternError(f"'{context}' must be a non-empty string")
+        raise TagPatternError(f"'{context}' must be a non-empty string, got {pattern!r}")
     normalized = pattern.strip()
     placeholders = _PLACEHOLDER_RE.findall(normalized)
     unsupported = sorted(set(placeholders) - _SUPPORTED_PLACEHOLDERS)
@@ -73,7 +73,8 @@ def validate_tag_pattern(pattern: object, *, context: str = "tag_pattern") -> st
     version_count = normalized.count(_PLACEHOLDER_VERSION)
     if version_count != 1:
         raise TagPatternError(
-            f"'{context}' must contain exactly one {_PLACEHOLDER_VERSION} placeholder"
+            f"'{context}' must contain exactly one {_PLACEHOLDER_VERSION} placeholder, "
+            f"got {normalized!r}"
         )
     return normalized
 

--- a/src/apm_cli/marketplace/version_resolver.py
+++ b/src/apm_cli/marketplace/version_resolver.py
@@ -1,8 +1,8 @@
 """Semver-aware version constraint resolution for marketplace dependencies.
 
 Resolves a semver range (e.g. ``~2.1.0``, ``^2.0``, ``>=1.4``) against
-git tags on a marketplace repository using the ``{name}--v{version}``
-naming convention from the Claude Code plugin dependency spec.
+git tags on a marketplace repository using the supplied ``tag_pattern``.
+Metadata created before pattern propagation uses ``{name}--v{version}``.
 
 Reuses the existing infrastructure:
 
@@ -119,7 +119,8 @@ def resolve_version_constraint(
             version_range,
             detail=(
                 f"pattern='{tag_pattern}', remote='{owner_repo}'. "
-                "Verify the published tags or install an explicit tag ref"
+                "Verify the published tags or set version to an explicit tag "
+                "such as 'v1.0.0'"
             ),
         )
 

--- a/src/apm_cli/marketplace/version_resolver.py
+++ b/src/apm_cli/marketplace/version_resolver.py
@@ -21,7 +21,7 @@ from ._shared import iter_semver_tags
 from .errors import NoMatchingVersionError
 from .ref_resolver import RefResolver
 from .semver import satisfies_range
-from .tag_pattern import build_tag_regex
+from .tag_pattern import build_tag_regex, validate_tag_pattern
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +82,7 @@ def resolve_version_constraint(
     Raises:
         NoMatchingVersionError: No tag satisfies the range.
     """
+    tag_pattern = validate_tag_pattern(tag_pattern)
     pinned_pattern = tag_pattern.replace("{name}", plugin_name)
     tag_rx = build_tag_regex(pinned_pattern)
 
@@ -116,7 +117,10 @@ def resolve_version_constraint(
         raise NoMatchingVersionError(
             plugin_name,
             version_range,
-            detail=f"pattern='{tag_pattern}', remote='{owner_repo}'",
+            detail=(
+                f"pattern='{tag_pattern}', remote='{owner_repo}'. "
+                "Verify the published tags or install an explicit tag ref"
+            ),
         )
 
     candidates.sort(key=lambda c: c[0], reverse=True)

--- a/src/apm_cli/marketplace/yml_schema.py
+++ b/src/apm_cli/marketplace/yml_schema.py
@@ -554,12 +554,13 @@ def parse_source_base(raw: Any) -> str | None:
 
 
 def _validate_tag_pattern(pattern: str, *, context: str) -> None:
-    """Ensure *pattern* contains at least one recognised placeholder."""
-    if not any(ph in pattern for ph in _TAG_PLACEHOLDERS):
-        raise MarketplaceYmlError(
-            f"'{context}' must contain at least one of "
-            f"{', '.join(_TAG_PLACEHOLDERS)}, got '{pattern}'"
-        )
+    """Route producer tag-pattern validation through its canonical owner."""
+    from .tag_pattern import TagPatternError, validate_tag_pattern
+
+    try:
+        validate_tag_pattern(pattern, context=context)
+    except TagPatternError as exc:
+        raise MarketplaceYmlError(str(exc)) from exc
 
 
 def _check_unknown_keys(

--- a/tests/fixtures/marketplace/golden.json
+++ b/tests/fixtures/marketplace/golden.json
@@ -23,7 +23,8 @@
         "source": "github",
         "repo": "acme/code-reviewer",
         "ref": "v2.1.0",
-        "sha": "abcd234567890abcdef1234567890abcdef12345"
+        "sha": "abcd234567890abcdef1234567890abcdef12345",
+        "tag_pattern": "v{version}"
       }
     },
     {
@@ -36,7 +37,8 @@
         "url": "acme/test-generator",
         "path": "src/plugin",
         "ref": "v1.0.3",
-        "sha": "def4567890abcdef1234567890abcdef12345678"
+        "sha": "def4567890abcdef1234567890abcdef12345678",
+        "tag_pattern": "v{version}"
       }
     }
   ]

--- a/tests/integration/marketplace/test_build_integration.py
+++ b/tests/integration/marketplace/test_build_integration.py
@@ -19,7 +19,8 @@ from unittest.mock import MagicMock, call, patch  # noqa: F401
 import pytest
 
 from apm_cli.marketplace.builder import BuildOptions, MarketplaceBuilder
-from apm_cli.marketplace.ref_resolver import RemoteRef  # noqa: F401
+from apm_cli.marketplace.models import parse_marketplace_json
+from apm_cli.marketplace.ref_resolver import RemoteRef
 from apm_cli.marketplace.yml_schema import load_marketplace_yml  # noqa: F401
 
 from .conftest import (
@@ -99,7 +100,7 @@ class TestBuildGoldenFile:
             assert keys[-1] == "source"
 
     def test_source_key_order(self, tmp_path: Path, mock_ref_resolver_golden):
-        """Each source block must follow: source, repo/url, (path), ref, sha."""
+        """Each source block must follow: source, repo/url, (path), ref, sha, (tag_pattern)."""
         _write_yml(tmp_path, GOLDEN_YML)
         builder = MarketplaceBuilder(tmp_path / "marketplace.yml")
         builder.build()
@@ -108,16 +109,20 @@ class TestBuildGoldenFile:
         # test-generator has subdir -> path must appear between url and ref
         tg = next(p for p in data["plugins"] if p["name"] == "test-generator")
         src_keys = list(tg["source"].keys())
-        assert src_keys == ["source", "url", "path", "ref", "sha"]
+        assert src_keys == ["source", "url", "path", "ref", "sha", "tag_pattern"]
 
     def test_no_apm_only_keys_in_output(self, tmp_path: Path, mock_ref_resolver_golden):
-        """APM-only fields must not appear in marketplace.json."""
+        """APM-only fields must not appear in marketplace.json.
+
+        Note: tag_pattern is intentionally emitted so consumers can honour
+        the marketplace's declared naming convention (issue #2319).
+        """
         _write_yml(tmp_path, GOLDEN_YML)
         builder = MarketplaceBuilder(tmp_path / "marketplace.yml")
         builder.build()
 
         data = _read_json(tmp_path)
-        apm_only = {"subdir", "version_range", "tag_pattern", "include_prerelease"}
+        apm_only = {"subdir", "version_range", "include_prerelease"}
         for plugin in data["plugins"]:
             assert not apm_only.intersection(plugin.keys()), (
                 f"APM-only key found in plugin {plugin['name']}: "
@@ -275,3 +280,143 @@ class TestBuildCLI:
         assert "Traceback" not in result.stderr
         combined = result.stdout + result.stderr
         assert "removed" in combined.lower()
+
+
+# ---------------------------------------------------------------------------
+# Issue #2319 -- tag_pattern producer-to-consumer closure
+# ---------------------------------------------------------------------------
+
+_SLASH_PATTERN_YML = """\
+name: lsp-infra-hub
+description: LSP infrastructure packages
+version: 1.0.0
+owner:
+  name: LSP Infra
+  email: infra@example.com
+build:
+  tagPattern: "{name}/{version}"
+packages:
+  - name: apm-skill-creator
+    description: Skill creator helper
+    source: lsp-infra/hub
+    version: "^0.1.0"
+    tags:
+      - skills
+"""
+
+_SLASH_REFS = [
+    RemoteRef(name="refs/tags/apm-skill-creator/0.1.3", sha="a" * 40),
+    RemoteRef(name="refs/tags/apm-skill-creator/0.1.4", sha="b" * 40),
+    RemoteRef(name="refs/heads/main", sha="c" * 40),
+]
+
+
+class TestTagPatternClosure:
+    """Regression tests for issue #2319.
+
+    Verifies that the marketplace's declared tagPattern is stored by apm pack
+    and then read back by the consumer-side semver resolver.
+    """
+
+    def test_producer_emits_tag_pattern_in_marketplace_json(self, tmp_path: Path):
+        """apm pack stores the effective tag_pattern in the plugin source dict."""
+        _write_yml(tmp_path, _SLASH_PATTERN_YML)
+
+        with patch(
+            "apm_cli.marketplace.ref_resolver.RefResolver.list_remote_refs",
+            return_value=_SLASH_REFS,
+        ):
+            builder = MarketplaceBuilder(tmp_path / "marketplace.yml")
+            builder.build()
+
+        data = _read_json(tmp_path)
+        plugins = data.get("plugins", [])
+        assert plugins, "marketplace.json has no plugins"
+        plugin = plugins[0]
+        source = plugin.get("source", {})
+        assert source.get("tag_pattern") == "{name}/{version}", (
+            f"tag_pattern not emitted in source dict: {source}"
+        )
+        assert source.get("ref") == "apm-skill-creator/0.1.4"
+
+    def test_consumer_parses_tag_pattern_from_marketplace_json(self, tmp_path: Path):
+        """parse_marketplace_json populates MarketplacePlugin.tag_pattern."""
+        _write_yml(tmp_path, _SLASH_PATTERN_YML)
+
+        with patch(
+            "apm_cli.marketplace.ref_resolver.RefResolver.list_remote_refs",
+            return_value=_SLASH_REFS,
+        ):
+            builder = MarketplaceBuilder(tmp_path / "marketplace.yml")
+            builder.build()
+
+        data = _read_json(tmp_path)
+        manifest = parse_marketplace_json(data, source_name="lsp-infra-hub")
+        plugin = manifest.find_plugin("apm-skill-creator")
+        assert plugin is not None
+        assert plugin.tag_pattern == "{name}/{version}"
+
+    def test_consumer_semver_resolution_uses_slash_pattern(self, tmp_path: Path):
+        """resolve_version_constraint is called with the correct tag_pattern."""
+        from apm_cli.marketplace.models import (
+            MarketplaceManifest,
+            MarketplacePlugin,
+            MarketplaceSource,
+        )
+        from apm_cli.marketplace.resolver import resolve_marketplace_plugin
+
+        plugin = MarketplacePlugin(
+            name="apm-skill-creator",
+            source={
+                "type": "github",
+                "repo": "lsp-infra/hub",
+                "ref": "apm-skill-creator/0.1.4",
+                "tag_pattern": "{name}/{version}",
+            },
+            tag_pattern="{name}/{version}",
+            source_marketplace="lsp-infra-hub",
+        )
+        manifest = MarketplaceManifest(
+            name="lsp-infra-hub",
+            plugins=(plugin,),
+            plugin_root="",
+        )
+        source = MarketplaceSource(
+            name="lsp-infra-hub",
+            owner="lsp-infra",
+            repo="hub",
+        )
+
+        captured: dict = {}
+
+        def _fake_resolve(pname, owner_repo, vspec, **kwargs):
+            captured.update(kwargs)
+            return ("apm-skill-creator/0.1.4", "b" * 40)
+
+        with (
+            patch(
+                "apm_cli.marketplace.resolver.get_marketplace_by_name",
+                return_value=source,
+            ),
+            patch(
+                "apm_cli.marketplace.resolver.fetch_or_cache",
+                return_value=manifest,
+            ),
+            patch(
+                "apm_cli.marketplace.version_resolver.resolve_version_constraint",
+                side_effect=_fake_resolve,
+            ),
+            patch("apm_cli.marketplace.version_pins.check_ref_pin", return_value=None),
+            patch("apm_cli.marketplace.version_pins.record_ref_pin"),
+            patch("apm_cli.marketplace.shadow_detector.detect_shadows", return_value=[]),
+        ):
+            canonical, _ = resolve_marketplace_plugin(
+                "apm-skill-creator",
+                "lsp-infra-hub",
+                version_spec="^0.1.0",
+            )
+
+        assert captured.get("tag_pattern") == "{name}/{version}", (
+            f"resolve_version_constraint was not called with custom tag_pattern: {captured}"
+        )
+        assert "apm-skill-creator/0.1.4" in canonical

--- a/tests/integration/marketplace/test_build_integration.py
+++ b/tests/integration/marketplace/test_build_integration.py
@@ -339,6 +339,30 @@ class TestTagPatternClosure:
         )
         assert source.get("ref") == "apm-skill-creator/0.1.4"
 
+    def test_package_pattern_overrides_build_pattern(self, tmp_path: Path):
+        """A package override is emitted instead of the build-level default."""
+        yml = _SLASH_PATTERN_YML.replace(
+            '    version: "^0.1.0"\n',
+            '    version: "^0.1.0"\n    tag_pattern: "release-{name}-v{version}"\n',
+        )
+        refs = [
+            RemoteRef(
+                name="refs/tags/release-apm-skill-creator-v0.1.5",
+                sha="d" * 40,
+            )
+        ]
+        _write_yml(tmp_path, yml)
+
+        with patch(
+            "apm_cli.marketplace.ref_resolver.RefResolver.list_remote_refs",
+            return_value=refs,
+        ):
+            MarketplaceBuilder(tmp_path / "marketplace.yml").build()
+
+        source = _read_json(tmp_path)["plugins"][0]["source"]
+        assert source["tag_pattern"] == "release-{name}-v{version}"
+        assert source["ref"] == "release-apm-skill-creator-v0.1.5"
+
     def test_consumer_parses_tag_pattern_from_marketplace_json(self, tmp_path: Path):
         """parse_marketplace_json populates MarketplacePlugin.tag_pattern."""
         _write_yml(tmp_path, _SLASH_PATTERN_YML)

--- a/tests/integration/test_architecture_marketplace_tag_pattern.py
+++ b/tests/integration/test_architecture_marketplace_tag_pattern.py
@@ -1,0 +1,64 @@
+"""Architecture guardrails for the marketplace tag-pattern owner."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def test_marketplace_tag_pattern_has_single_owner() -> None:
+    """Producer, parser, and resolver must consume one validation owner."""
+    root = Path(__file__).parents[2]
+    owner = (root / "src/apm_cli/marketplace/tag_pattern.py").read_text()
+    producer = (root / "src/apm_cli/marketplace/yml_schema.py").read_text()
+    consumer = (root / "src/apm_cli/marketplace/models.py").read_text()
+    resolver = (root / "src/apm_cli/marketplace/version_resolver.py").read_text()
+    guard = (root / "scripts/lint-architecture-boundaries.sh").read_text()
+
+    assert owner.count("def validate_tag_pattern(") == 1
+    assert "validate_tag_pattern(pattern, context=context)" in producer
+    assert "tag_pattern = validate_tag_pattern(" in consumer
+    assert "tag_pattern = validate_tag_pattern(tag_pattern)" in resolver
+    assert "Marketplace tag patterns must route through marketplace/tag_pattern.py" in guard
+
+
+def test_marketplace_tag_pattern_guard_rejects_parallel_validation(
+    tmp_path: Path,
+) -> None:
+    """The boundary lint must reject a second placeholder validator."""
+    root = Path(__file__).parents[2]
+    sandbox = tmp_path / "repo"
+    shutil.copytree(
+        root,
+        sandbox,
+        ignore=shutil.ignore_patterns(
+            ".git",
+            ".venv",
+            ".pytest_cache",
+            "__pycache__",
+            "build",
+            "dist",
+            "node_modules",
+        ),
+    )
+    models_path = sandbox / "src/apm_cli/marketplace/models.py"
+    models_source = models_path.read_text(encoding="utf-8")
+    models_path.write_text(
+        models_source
+        + "\n\ndef _parallel_pattern_check(pattern: str) -> bool:\n"
+        + '    return "{version}" in pattern\n',
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ("bash", "scripts/lint-architecture-boundaries.sh"),
+        cwd=sandbox,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+
+    assert result.returncode == 1
+    assert "Marketplace tag patterns must route through marketplace/tag_pattern.py" in result.stdout

--- a/tests/integration/test_marketplace_tag_pattern_lifecycle.py
+++ b/tests/integration/test_marketplace_tag_pattern_lifecycle.py
@@ -1,0 +1,510 @@
+"""Installed-binary lifecycle contracts for marketplace tag-pattern propagation."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from apm_cli.utils.yaml_io import load_yaml
+from tests.utils.apm_lifecycle_runner import ApmLifecycleRunner, CommandResult
+from tests.utils.isolated_apm_environment import IsolatedApmEnvironment
+from tests.utils.lifecycle_state import LifecycleStateSnapshot
+from tests.utils.local_git_repository import (
+    GitCommit,
+    LocalGitRepository,
+    LocalGitRepositoryFactory,
+)
+from tests.utils.local_marketplace import LocalMarketplace, LocalMarketplaceFactory
+from tests.utils.local_package import LocalPackage, LocalPackageFactory
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.e2e,
+    pytest.mark.lifecycle_smoke,
+    pytest.mark.requires_apm_binary,
+    pytest.mark.requires_e2e_mode,
+]
+
+_OWNER = "apm-lifecycle"
+_HOST = "git.example.invalid"
+_PACKAGE = "tagged-skill"
+_MARKETPLACE = "tag-pattern-marketplace"
+_CUSTOM_PATTERN = "releases/{name}-v{version}"
+_LEGACY_PATTERN = "{name}--v{version}"
+_SKILL_PATH = ".agents/skills/tagged-skill/SKILL.md"
+
+
+@dataclass(frozen=True)
+class _Scenario:
+    isolated: IsolatedApmEnvironment
+    environment: dict[str, str]
+    runner: ApmLifecycleRunner
+    packages: LocalPackageFactory
+    consumers: LocalPackageFactory
+    repositories: LocalGitRepositoryFactory
+    marketplace: LocalMarketplace
+    package_repository: LocalGitRepository
+    marketplace_repository: LocalGitRepository
+    initial_commit: GitCommit
+    package_remote: str
+    marketplace_remote: str
+
+
+def _skill_document(version: str) -> str:
+    return (
+        "---\n"
+        f"name: {_PACKAGE}\n"
+        f"description: Marketplace tag-pattern lifecycle fixture {version}\n"
+        "---\n"
+        f"# {_PACKAGE} {version}\n"
+    )
+
+
+def _evidence(result: CommandResult) -> str:
+    return (
+        f"cwd={result.cwd!s}\n"
+        f"command={result.command!r}\n"
+        f"returncode={result.returncode}\n"
+        f"stdout={result.stdout!r}\n"
+        f"stderr={result.stderr!r}"
+    )
+
+
+def _run(
+    scenario: _Scenario,
+    cwd: Path,
+    args: tuple[str, ...],
+    scenario_id: str,
+    *,
+    expected_returncode: int = 0,
+) -> CommandResult:
+    result = scenario.runner.run(
+        args,
+        scenario_id=scenario_id,
+        cwd=cwd,
+        env=scenario.environment,
+    )
+    assert result.returncode == expected_returncode, _evidence(result)
+    return result
+
+
+def _snapshot(consumer: LocalPackage) -> LifecycleStateSnapshot:
+    return LifecycleStateSnapshot.capture(consumer.root, targets=("copilot",))
+
+
+def _assert_same_state(
+    expected: LifecycleStateSnapshot,
+    actual: LifecycleStateSnapshot,
+) -> None:
+    assert actual.manifest_bytes == expected.manifest_bytes
+    assert actual.lockfile_bytes == expected.lockfile_bytes
+    assert actual.deployment_records == expected.deployment_records
+    assert actual.files == expected.files
+    assert actual.semantic_bytes == expected.semantic_bytes
+
+
+def _locked_dependency(consumer: LocalPackage) -> dict[str, object]:
+    lock = load_yaml(consumer.root / "apm.lock.yaml")
+    dependencies = lock["dependencies"]
+    assert isinstance(dependencies, list)
+    assert len(dependencies) == 1
+    dependency = dependencies[0]
+    assert isinstance(dependency, dict)
+    return dependency
+
+
+def _pack_and_publish_marketplace(
+    scenario: _Scenario,
+    *,
+    message: str,
+    tag_name: str,
+) -> GitCommit:
+    result = _run(
+        scenario,
+        scenario.marketplace_repository.worktree,
+        ("pack",),
+        f"tag-pattern-{message}-pack",
+    )
+    assert result.stdout or result.stderr
+    output = scenario.marketplace_repository.worktree / ".claude-plugin" / "marketplace.json"
+    assert output.is_file()
+    commit = scenario.repositories.commit(
+        scenario.marketplace_repository,
+        message=message,
+    )
+    scenario.repositories.tag(
+        scenario.marketplace_repository,
+        tag_name,
+        commit,
+    )
+    return commit
+
+
+def _new_scenario(
+    root: Path,
+    binary: Path,
+    *,
+    tag_pattern: str = _CUSTOM_PATTERN,
+) -> _Scenario:
+    isolated = IsolatedApmEnvironment.create(root, base_env=dict(os.environ))
+    environment = isolated.subprocess_env()
+    packages = LocalPackageFactory(isolated.package_root / "packages")
+    consumers = LocalPackageFactory(isolated.work_root)
+    repositories = LocalGitRepositoryFactory(
+        isolated.repository_root,
+        env=environment,
+    )
+    package = packages.create(_PACKAGE, version="1.0.0", targets=("copilot",))
+    packages.add_skill(package, _PACKAGE, _skill_document("1.0.0"))
+    package_repository = repositories.create(_PACKAGE, source_tree=package.root)
+    initial_commit = repositories.commit(
+        package_repository,
+        message="seed tagged skill 1.0.0",
+    )
+    initial_tag = tag_pattern.replace("{name}", _PACKAGE).replace("{version}", "1.0.0")
+    repositories.tag(package_repository, initial_tag, initial_commit)
+    package_remote = f"https://{_HOST}/{_OWNER}/{_PACKAGE}"
+    repositories.install_url_rewrite(package_repository, package_remote)
+
+    marketplace_factory = LocalMarketplaceFactory(
+        LocalPackageFactory(isolated.package_root / "marketplaces")
+    )
+    marketplace = marketplace_factory.create(
+        _MARKETPLACE,
+        source_base=f"https://{_HOST}/{_OWNER}",
+        tag_pattern=tag_pattern,
+        packages=(
+            {
+                "name": _PACKAGE,
+                "description": "Tag-pattern lifecycle package",
+                "source": _PACKAGE,
+                "version": "^1.0.0",
+            },
+        ),
+    )
+    marketplace_repository = repositories.create(
+        _MARKETPLACE,
+        source_tree=marketplace.package.root,
+    )
+    marketplace_remote = f"https://{_HOST}/{_OWNER}/{_MARKETPLACE}"
+    repositories.install_url_rewrite(marketplace_repository, marketplace_remote)
+
+    scenario = _Scenario(
+        isolated=isolated,
+        environment=environment,
+        runner=ApmLifecycleRunner(
+            (str(binary),),
+            timeout_seconds=120,
+            scenario_timeout_seconds=300,
+        ),
+        packages=packages,
+        consumers=consumers,
+        repositories=repositories,
+        marketplace=marketplace,
+        package_repository=package_repository,
+        marketplace_repository=marketplace_repository,
+        initial_commit=initial_commit,
+        package_remote=package_remote,
+        marketplace_remote=marketplace_remote,
+    )
+    _pack_and_publish_marketplace(
+        scenario,
+        message="publish marketplace 1.0.0",
+        tag_name=initial_tag,
+    )
+    return scenario
+
+
+def _register_marketplace(scenario: _Scenario, consumer: LocalPackage) -> None:
+    _run(
+        scenario,
+        consumer.root,
+        (
+            "marketplace",
+            "add",
+            scenario.marketplace_remote,
+            "--name",
+            _MARKETPLACE,
+            "--ref",
+            "main",
+        ),
+        "tag-pattern-marketplace-add",
+    )
+
+
+def _install_range(
+    scenario: _Scenario,
+    consumer: LocalPackage,
+    version_range: str,
+    *,
+    scenario_id: str,
+    expected_returncode: int = 0,
+) -> CommandResult:
+    _declare_range(scenario, consumer, version_range)
+    return _run_install(
+        scenario,
+        consumer,
+        scenario_id=scenario_id,
+        expected_returncode=expected_returncode,
+    )
+
+
+def _declare_range(
+    scenario: _Scenario,
+    consumer: LocalPackage,
+    version_range: str,
+) -> None:
+    scenario.consumers.replace_apm_dependencies(
+        consumer,
+        (
+            {
+                "name": _PACKAGE,
+                "marketplace": _MARKETPLACE,
+                "version": version_range,
+            },
+        ),
+    )
+
+
+def _run_install(
+    scenario: _Scenario,
+    consumer: LocalPackage,
+    *,
+    scenario_id: str,
+    expected_returncode: int = 0,
+) -> CommandResult:
+    return _run(
+        scenario,
+        consumer.root,
+        (
+            "install",
+            "--target",
+            "copilot",
+            "--no-policy",
+            "--parallel-downloads",
+            "0",
+            "--verbose",
+        ),
+        scenario_id,
+        expected_returncode=expected_returncode,
+    )
+
+
+def test_custom_pattern_closes_install_update_outdated_lifecycle(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Producer metadata must control every consumer semver lifecycle journey."""
+    scenario = _new_scenario(tmp_path / "custom-pattern", apm_binary_path)
+    consumer = scenario.consumers.create("custom-consumer", targets=("copilot",))
+    _register_marketplace(scenario, consumer)
+
+    install = _install_range(
+        scenario,
+        consumer,
+        "^1.0.0",
+        scenario_id="tag-pattern-custom-install",
+    )
+    assert "legacy default" not in (install.stdout + install.stderr)
+    first_lock = _locked_dependency(consumer)
+    assert first_lock["resolved_ref"] == "releases/tagged-skill-v1.0.0"
+    assert first_lock["resolved_commit"] == scenario.initial_commit.sha
+    assert (consumer.root / _SKILL_PATH).read_bytes() == _skill_document("1.0.0").encode()
+    first_snapshot = _snapshot(consumer)
+
+    replay = _run(
+        scenario,
+        consumer.root,
+        ("install", "--target", "copilot", "--no-policy", "--parallel-downloads", "0"),
+        "tag-pattern-custom-install-replay",
+    )
+    assert replay.stdout or replay.stderr
+    _assert_same_state(first_snapshot, _snapshot(consumer))
+
+    repository_skill = scenario.package_repository.worktree / "skills" / _PACKAGE / "SKILL.md"
+    repository_skill.write_text(_skill_document("1.1.0"), encoding="utf-8")
+    package_manifest = load_yaml(scenario.package_repository.worktree / "apm.yml")
+    package_manifest["version"] = "1.1.0"
+    from apm_cli.utils.yaml_io import dump_yaml
+
+    dump_yaml(package_manifest, scenario.package_repository.worktree / "apm.yml")
+    next_commit = scenario.repositories.commit(
+        scenario.package_repository,
+        message="advance tagged skill 1.1.0",
+    )
+    scenario.repositories.tag(
+        scenario.package_repository,
+        "releases/tagged-skill-v1.1.0",
+        next_commit,
+    )
+    _pack_and_publish_marketplace(
+        scenario,
+        message="publish marketplace 1.1.0",
+        tag_name="releases/tagged-skill-v1.1.0",
+    )
+    _run(
+        scenario,
+        consumer.root,
+        ("marketplace", "update", _MARKETPLACE),
+        "tag-pattern-marketplace-refresh",
+    )
+
+    outdated = _run(
+        scenario,
+        consumer.root,
+        ("outdated", "--parallel-checks", "0", "--verbose"),
+        "tag-pattern-custom-outdated",
+    )
+    outdated_output = outdated.stdout + outdated.stderr
+    assert "marketplace" in outdated_output.lower()
+    assert "outdated" in outdated_output.lower()
+
+    update = _run(
+        scenario,
+        consumer.root,
+        (
+            "update",
+            "--yes",
+            "--target",
+            "copilot",
+            "--parallel-downloads",
+            "0",
+            "--verbose",
+        ),
+        "tag-pattern-custom-update",
+    )
+    assert "1 updated" in (update.stdout + update.stderr)
+    updated_lock = _locked_dependency(consumer)
+    assert updated_lock["resolved_ref"] == "releases/tagged-skill-v1.1.0"
+    assert updated_lock["resolved_commit"] == next_commit.sha
+    assert (consumer.root / _SKILL_PATH).read_bytes() == _skill_document("1.1.0").encode()
+    updated_snapshot = _snapshot(consumer)
+
+    converged = _run(
+        scenario,
+        consumer.root,
+        ("update", "--yes", "--target", "copilot", "--parallel-downloads", "0"),
+        "tag-pattern-custom-update-converged",
+    )
+    assert "All dependencies already at their latest matching refs." in (
+        converged.stdout + converged.stderr
+    )
+    _assert_same_state(updated_snapshot, _snapshot(consumer))
+
+    final_outdated = _run(
+        scenario,
+        consumer.root,
+        ("outdated", "--parallel-checks", "0"),
+        "tag-pattern-custom-outdated-converged",
+    )
+    assert "All dependencies are up-to-date" in (final_outdated.stdout + final_outdated.stderr)
+
+
+def test_old_marketplace_metadata_uses_legacy_pattern(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Metadata produced before tag_pattern existed must keep its old behavior."""
+    scenario = _new_scenario(
+        tmp_path / "legacy-pattern",
+        apm_binary_path,
+        tag_pattern=_LEGACY_PATTERN,
+    )
+    marketplace_path = (
+        scenario.marketplace_repository.worktree / ".claude-plugin" / "marketplace.json"
+    )
+    marketplace = json.loads(marketplace_path.read_text(encoding="utf-8"))
+    for plugin in marketplace["plugins"]:
+        plugin["source"].pop("tag_pattern", None)
+    marketplace_path.write_text(
+        json.dumps(marketplace, indent=2, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+    scenario.repositories.commit(
+        scenario.marketplace_repository,
+        message="publish legacy marketplace metadata",
+    )
+
+    consumer = scenario.consumers.create("legacy-consumer", targets=("copilot",))
+    _register_marketplace(scenario, consumer)
+    install = _install_range(
+        scenario,
+        consumer,
+        "^1.0.0",
+        scenario_id="tag-pattern-legacy-install",
+    )
+    assert install.stdout or install.stderr
+    dependency = _locked_dependency(consumer)
+    assert dependency["resolved_ref"] == "tagged-skill--v1.0.0"
+    assert dependency["resolved_commit"] == scenario.initial_commit.sha
+    assert (consumer.root / _SKILL_PATH).read_bytes() == _skill_document("1.0.0").encode()
+
+
+def test_invalid_or_unmatched_patterns_fail_without_consumer_writes(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Malformed metadata and ranges with no matching tag must fail closed."""
+    scenario = _new_scenario(tmp_path / "failure-patterns", apm_binary_path)
+
+    no_match_consumer = scenario.consumers.create(
+        "no-match-consumer",
+        targets=("copilot",),
+    )
+    _register_marketplace(scenario, no_match_consumer)
+    _declare_range(scenario, no_match_consumer, "^2.0.0")
+    before_no_match = _snapshot(no_match_consumer)
+    no_match = _run_install(
+        scenario,
+        no_match_consumer,
+        scenario_id="tag-pattern-no-match",
+        expected_returncode=1,
+    )
+    no_match_output = no_match.stdout + no_match.stderr
+    assert "No tag matching version '^2.0.0'" in no_match_output
+    assert "releases/{name}-v{version}" in no_match_output
+    _assert_same_state(before_no_match, _snapshot(no_match_consumer))
+
+    marketplace_path = (
+        scenario.marketplace_repository.worktree / ".claude-plugin" / "marketplace.json"
+    )
+    marketplace = json.loads(marketplace_path.read_text(encoding="utf-8"))
+    marketplace["plugins"][0]["source"]["tag_pattern"] = "release-{name}"
+    marketplace_path.write_text(
+        json.dumps(marketplace, indent=2, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+    scenario.repositories.commit(
+        scenario.marketplace_repository,
+        message="publish malformed marketplace metadata",
+    )
+
+    malformed_workspace = scenario.isolated.work_root / "malformed-registration"
+    malformed_workspace.mkdir()
+    before_malformed = LifecycleStateSnapshot.capture(malformed_workspace)
+    malformed = _run(
+        scenario,
+        malformed_workspace,
+        (
+            "marketplace",
+            "add",
+            scenario.marketplace_remote,
+            "--name",
+            _MARKETPLACE,
+            "--ref",
+            "main",
+        ),
+        "tag-pattern-malformed",
+        expected_returncode=1,
+    )
+    malformed_output = malformed.stdout + malformed.stderr
+    assert "source.tag_pattern" in malformed_output
+    assert "must contain exactly one {version} placeholder" in malformed_output
+    _assert_same_state(
+        before_malformed,
+        LifecycleStateSnapshot.capture(malformed_workspace),
+    )

--- a/tests/integration/test_marketplace_tag_pattern_lifecycle.py
+++ b/tests/integration/test_marketplace_tag_pattern_lifecycle.py
@@ -469,6 +469,24 @@ def test_invalid_or_unmatched_patterns_fail_without_consumer_writes(
     assert "releases/{name}-v{version}" in no_match_output
     _assert_same_state(before_no_match, _snapshot(no_match_consumer))
 
+    bare_consumer = scenario.consumers.create(
+        "bare-no-match-consumer",
+        targets=("copilot",),
+    )
+    _register_marketplace(scenario, bare_consumer)
+    _declare_range(scenario, bare_consumer, "2.0.0")
+    before_bare = _snapshot(bare_consumer)
+    bare_no_match = _run_install(
+        scenario,
+        bare_consumer,
+        scenario_id="tag-pattern-bare-no-match",
+        expected_returncode=1,
+    )
+    bare_output = bare_no_match.stdout + bare_no_match.stderr
+    assert "No tag matching version '2.0.0'" in bare_output
+    assert "releases/{name}-v{version}" in bare_output
+    _assert_same_state(before_bare, _snapshot(bare_consumer))
+
     marketplace_path = (
         scenario.marketplace_repository.worktree / ".claude-plugin" / "marketplace.json"
     )

--- a/tests/integration/test_marketplace_tag_pattern_lifecycle.py
+++ b/tests/integration/test_marketplace_tag_pattern_lifecycle.py
@@ -191,7 +191,21 @@ def _new_scenario(
         source_tree=marketplace.package.root,
     )
     marketplace_remote = f"https://{_HOST}/{_OWNER}/{_MARKETPLACE}"
-    repositories.install_url_rewrite(marketplace_repository, marketplace_remote)
+    marketplace_remote_forms = repositories.install_url_rewrite(
+        marketplace_repository,
+        marketplace_remote,
+    )
+    environment = repositories.url_rewrite_subprocess_env(
+        package_repository,
+        package_remote,
+    )
+    rewrite_key = f"url.{marketplace_repository.file_url}/.insteadOf"
+    rewrite_count = int(environment["GIT_CONFIG_COUNT"])
+    for offset, remote_form in enumerate(marketplace_remote_forms):
+        index = rewrite_count + offset
+        environment[f"GIT_CONFIG_KEY_{index}"] = rewrite_key
+        environment[f"GIT_CONFIG_VALUE_{index}"] = remote_form
+    environment["GIT_CONFIG_COUNT"] = str(rewrite_count + len(marketplace_remote_forms))
 
     scenario = _Scenario(
         isolated=isolated,

--- a/tests/integration/test_yml_schema_validation.py
+++ b/tests/integration/test_yml_schema_validation.py
@@ -143,12 +143,12 @@ class TestSchemaHelpers:
         with pytest.raises(MarketplaceYmlError, match="traversal"):
             _validate_source(source, index=0)
 
-    @pytest.mark.parametrize("pattern", ["v{version}", "release-{name}"])
+    @pytest.mark.parametrize("pattern", ["v{version}", "release-{name}-{version}"])
     def test_validate_tag_pattern_accepts_placeholder(self, pattern: str) -> None:
         _validate_tag_pattern(pattern, context="build.tagPattern")
 
     def test_validate_tag_pattern_rejects_missing_placeholder(self) -> None:
-        with pytest.raises(MarketplaceYmlError, match="must contain at least one"):
+        with pytest.raises(MarketplaceYmlError, match="exactly one"):
             _validate_tag_pattern("release", context="build.tagPattern")
 
     def test_check_unknown_keys_allows_clean_mapping(self) -> None:
@@ -191,7 +191,7 @@ class TestBuildAndVersioningParsers:
             _parse_build({"tagPattern": "   "})
 
     def test_parse_build_rejects_pattern_without_placeholder(self) -> None:
-        with pytest.raises(MarketplaceYmlError, match="must contain at least one"):
+        with pytest.raises(MarketplaceYmlError, match="exactly one"):
             _parse_build({"tagPattern": "release"})
 
     def test_parse_build_accepts_valid_pattern(self) -> None:

--- a/tests/unit/marketplace/test_builder.py
+++ b/tests/unit/marketplace/test_builder.py
@@ -431,7 +431,6 @@ class TestFieldStripping:
         for plugin in data["plugins"]:
             src = plugin["source"]
             assert "subdir" not in src
-            assert "tag_pattern" not in src
             assert "include_prerelease" not in src
 
 

--- a/tests/unit/marketplace/test_local_path_compose.py
+++ b/tests/unit/marketplace/test_local_path_compose.py
@@ -126,6 +126,7 @@ def test_compose_claude_emits_category_for_local_and_remote_when_set(tmp_path: P
             requested_version=None,
             tags=(),
             is_prerelease=False,
+            effective_tag_pattern="release/{name}/{version}",
         ),
     ]
     doc = builder.compose_marketplace_json(resolved)
@@ -208,6 +209,7 @@ def test_compose_codex_marketplace_includes_local_and_remote_plugins(tmp_path: P
             requested_version=None,
             tags=(),
             is_prerelease=False,
+            effective_tag_pattern="release/{name}/{version}",
         ),
         ResolvedPackage(
             name=remote_subdir_entry.name,
@@ -218,6 +220,7 @@ def test_compose_codex_marketplace_includes_local_and_remote_plugins(tmp_path: P
             requested_version=None,
             tags=(),
             is_prerelease=False,
+            effective_tag_pattern="release/{name}/{version}",
         ),
     ]
 
@@ -240,6 +243,7 @@ def test_compose_codex_marketplace_includes_local_and_remote_plugins(tmp_path: P
                     "url": "acme/remote-tool",
                     "ref": "v1.0.0",
                     "sha": "a" * 40,
+                    "tag_pattern": "release/{name}/{version}",
                 },
                 "policy": {"installation": "AVAILABLE", "authentication": "ON_INSTALL"},
                 "category": "Developer Tools",
@@ -252,6 +256,7 @@ def test_compose_codex_marketplace_includes_local_and_remote_plugins(tmp_path: P
                     "path": "plugins/remote-subdir-tool",
                     "ref": "v2.0.0",
                     "sha": "b" * 40,
+                    "tag_pattern": "release/{name}/{version}",
                 },
                 "policy": {"installation": "AVAILABLE", "authentication": "ON_INSTALL"},
                 "category": "Coding",

--- a/tests/unit/marketplace/test_marketplace_models.py
+++ b/tests/unit/marketplace/test_marketplace_models.py
@@ -204,6 +204,44 @@ class TestParseMarketplaceJson:
         assert p.source["repo"] == "owner/plugin-repo"
         assert p.source_marketplace == "claude-mkt"
 
+    def test_claude_format_validates_tag_pattern(self):
+        data = {
+            "name": "Claude Plugins",
+            "plugins": [
+                {
+                    "name": "my-plugin",
+                    "source": {
+                        "type": "github",
+                        "repo": "owner/plugin-repo",
+                        "tag_pattern": "{name}/{version}",
+                    },
+                }
+            ],
+        }
+        manifest = parse_marketplace_json(data, "claude-mkt")
+        assert manifest.plugins[0].tag_pattern == "{name}/{version}"
+
+    @pytest.mark.parametrize(
+        "tag_pattern",
+        ["", "release-{name}", "v{version}-{version}", "release-{channel}-{version}"],
+    )
+    def test_claude_format_rejects_invalid_tag_pattern(self, tag_pattern):
+        data = {
+            "name": "Claude Plugins",
+            "plugins": [
+                {
+                    "name": "my-plugin",
+                    "source": {
+                        "type": "github",
+                        "repo": "owner/plugin-repo",
+                        "tag_pattern": tag_pattern,
+                    },
+                }
+            ],
+        }
+        with pytest.raises(ValueError, match=r"source\.tag_pattern"):
+            parse_marketplace_json(data, "claude-mkt")
+
     def test_claude_format_relative(self):
         data = {
             "name": "Test",

--- a/tests/unit/marketplace/test_marketplace_resolver.py
+++ b/tests/unit/marketplace/test_marketplace_resolver.py
@@ -936,14 +936,7 @@ class TestResolveMarketplacePluginGitLabMonorepo:
         ),
         ids=("url", "git-subdir"),
     )
-    @pytest.mark.parametrize(
-        ("version_spec", "expected_ref"),
-        (
-            ("1.0.0", "1.0.0"),
-            ("~9.9.9", None),
-        ),
-        ids=("bare-fallback", "range-reraise"),
-    )
+    @pytest.mark.parametrize("version_spec", ("1.0.0", "~9.9.9"), ids=("bare", "range"))
     @patch("apm_cli.marketplace.version_resolver.resolve_version_constraint")
     @patch("apm_cli.marketplace.resolver.fetch_or_cache")
     @patch("apm_cli.marketplace.resolver.get_marketplace_by_name")
@@ -953,10 +946,9 @@ class TestResolveMarketplacePluginGitLabMonorepo:
         mock_fetch,
         mock_resolve_version,
         version_spec,
-        expected_ref,
         source,
     ):
-        """Bare no-match falls back to a ref while range no-match stays fatal."""
+        """Bare and range constraints both fail closed when no tag matches."""
         from apm_cli.marketplace.errors import NoMatchingVersionError
 
         marketplace_source = MarketplaceSource(
@@ -974,24 +966,12 @@ class TestResolveMarketplacePluginGitLabMonorepo:
             version_spec,
         )
 
-        if expected_ref is None:
-            with pytest.raises(NoMatchingVersionError):
-                resolve_marketplace_plugin(
-                    "pkg",
-                    "remote-mkt",
-                    version_spec=version_spec,
-                )
-            return
-
-        result = resolve_marketplace_plugin(
-            "pkg",
-            "remote-mkt",
-            version_spec=version_spec,
-        )
-        dep = result.dependency_reference
-        assert dep is not None
-        assert dep.reference == expected_ref
-        assert result.canonical.endswith(f"#{expected_ref}")
+        with pytest.raises(NoMatchingVersionError):
+            resolve_marketplace_plugin(
+                "pkg",
+                "remote-mkt",
+                version_spec=version_spec,
+            )
 
     @patch("apm_cli.marketplace.resolver.fetch_or_cache")
     @patch("apm_cli.marketplace.resolver.get_marketplace_by_name")

--- a/tests/unit/marketplace/test_marketplace_resolver.py
+++ b/tests/unit/marketplace/test_marketplace_resolver.py
@@ -914,6 +914,7 @@ class TestResolveMarketplacePluginGitLabMonorepo:
             "pkg",
             "catalog/remote-mkt",
             "1.0.0",
+            tag_pattern="{name}--v{version}",
             host="git.example.invalid",
             token=None,
             auth_scheme="basic",

--- a/tests/unit/marketplace/test_tag_pattern.py
+++ b/tests/unit/marketplace/test_tag_pattern.py
@@ -13,6 +13,7 @@ from apm_cli.marketplace.tag_pattern import (
     is_version_tag_ref,
     parse_tag_version,
     render_tag,
+    validate_tag_pattern,
 )
 
 # ---------------------------------------------------------------------------
@@ -204,6 +205,30 @@ class TestBuildTagRegex:
         m = rx.match("v+1.0.0")
         assert m is not None
         assert rx.match("vv1.0.0") is None  # '+' is not a quantifier
+
+
+class TestValidateTagPattern:
+    """Consumer-safe pattern validation is owned by tag_pattern.py."""
+
+    @pytest.mark.parametrize(
+        "pattern",
+        ["v{version}", "{version}", "{name}/{version}", "release-{version}"],
+    )
+    def test_accepts_supported_patterns(self, pattern: str) -> None:
+        assert validate_tag_pattern(f" {pattern} ") == pattern
+
+    @pytest.mark.parametrize(
+        ("pattern", "error"),
+        [
+            ("", "non-empty"),
+            ("release-{name}", "exactly one"),
+            ("v{version}-{version}", "exactly one"),
+            ("release-{channel}-{version}", "unsupported placeholder"),
+        ],
+    )
+    def test_rejects_unsupported_patterns(self, pattern: str, error: str) -> None:
+        with pytest.raises(ValueError, match=error):
+            validate_tag_pattern(pattern)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/marketplace/test_version_resolver.py
+++ b/tests/unit/marketplace/test_version_resolver.py
@@ -174,3 +174,44 @@ class TestResolveVersionConstraint(unittest.TestCase):
 
         tag, _sha = resolve_version_constraint("secrets-vault", "acme/plugins", "2.1.0")
         assert tag == "secrets-vault--v2.1.0"
+
+    def test_custom_slash_tag_pattern_resolves(self, MockResolver):
+        """Marketplace tagPattern '{name}/{version}' (slash, no v-prefix) is honoured."""
+        refs = [
+            _make_tag_ref("apm-skill-creator/0.1.3", sha="a" * 40),
+            _make_tag_ref("apm-skill-creator/0.1.4", sha="b" * 40),
+        ]
+        MockResolver.return_value.list_remote_refs.return_value = refs
+
+        tag, _sha = resolve_version_constraint(
+            "apm-skill-creator",
+            "lsp-infra/hub",
+            "^0.1.0",
+            tag_pattern="{name}/{version}",
+        )
+        assert tag == "apm-skill-creator/0.1.4"
+
+    def test_custom_slash_pattern_caret_picks_highest(self, MockResolver):
+        refs = [
+            _make_tag_ref("my-pkg/0.1.0", sha="a" * 40),
+            _make_tag_ref("my-pkg/0.1.5", sha="b" * 40),
+            _make_tag_ref("my-pkg/0.2.0", sha="c" * 40),
+        ]
+        MockResolver.return_value.list_remote_refs.return_value = refs
+
+        # ^0.1.0 is >=0.1.0 <0.2.0 for 0.x.y ranges -- should pick 0.1.5
+        tag, _sha = resolve_version_constraint(
+            "my-pkg",
+            "org/repo",
+            "^0.1.0",
+            tag_pattern="{name}/{version}",
+        )
+        assert tag == "my-pkg/0.1.5"
+
+    def test_default_pattern_unaffected_by_fix(self, MockResolver):
+        """Original {name}--v{version} pattern still works when no custom pattern given."""
+        refs = _make_refs("1.0.0", "1.1.0", "1.2.3")
+        MockResolver.return_value.list_remote_refs.return_value = refs
+
+        tag, _sha = resolve_version_constraint("secrets-vault", "acme/plugins", "^1.0.0")
+        assert tag == "secrets-vault--v1.2.3"

--- a/tests/unit/marketplace/test_versioned_resolver.py
+++ b/tests/unit/marketplace/test_versioned_resolver.py
@@ -171,6 +171,57 @@ class TestResolveMarketplacePlugin:
         ):
             resolve_marketplace_plugin("nonexistent", "test-mkt")
 
+    def test_semver_range_uses_custom_tag_pattern(self):
+        """Semver range resolution passes plugin.tag_pattern to resolve_version_constraint."""
+        plugin = MarketplacePlugin(
+            name="apm-skill-creator",
+            source={
+                "type": "github",
+                "repo": "lsp-infra-hub/hub",
+                "ref": "apm-skill-creator/0.1.4",
+                "tag_pattern": "{name}/{version}",
+            },
+            tag_pattern="{name}/{version}",
+            source_marketplace="test-mkt",
+        )
+        manifest = _make_manifest(plugin)
+        source = _make_source()
+
+        captured_kwargs: dict = {}
+
+        def _fake_resolve(pname, owner_repo, vspec, **kwargs):
+            captured_kwargs.update(kwargs)
+            return ("apm-skill-creator/0.1.4", "a" * 40)
+
+        with (
+            patch(
+                "apm_cli.marketplace.resolver.get_marketplace_by_name",
+                return_value=source,
+            ),
+            patch(
+                "apm_cli.marketplace.resolver.fetch_or_cache",
+                return_value=manifest,
+            ),
+            patch(
+                "apm_cli.marketplace.version_resolver.resolve_version_constraint",
+                side_effect=_fake_resolve,
+            ),
+            patch("apm_cli.marketplace.version_pins.check_ref_pin", return_value=None),
+            patch("apm_cli.marketplace.version_pins.record_ref_pin"),
+            patch(
+                "apm_cli.marketplace.shadow_detector.detect_shadows",
+                return_value=[],
+            ),
+        ):
+            canonical, _resolved = resolve_marketplace_plugin(
+                "apm-skill-creator",
+                "test-mkt",
+                version_spec="^0.1.0",
+            )
+
+        assert captured_kwargs.get("tag_pattern") == "{name}/{version}"
+        assert "apm-skill-creator/0.1.4" in canonical
+
 
 # ---------------------------------------------------------------------------
 # Canonical string correctness

--- a/tests/utils/local_marketplace.py
+++ b/tests/utils/local_marketplace.py
@@ -1,0 +1,59 @@
+"""Source-only marketplace authoring helpers for hermetic lifecycle tests."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from apm_cli.marketplace.tag_pattern import validate_tag_pattern
+from apm_cli.utils.yaml_io import dump_yaml, load_yaml
+from tests.utils.local_package import LocalPackage, LocalPackageFactory
+
+
+@dataclass(frozen=True)
+class LocalMarketplace:
+    """Paths identifying an authored marketplace producer."""
+
+    name: str
+    package: LocalPackage
+    output_path: Path
+
+
+class LocalMarketplaceFactory:
+    """Author marketplace producer inputs without invoking product code."""
+
+    def __init__(self, package_factory: LocalPackageFactory) -> None:
+        self._packages = package_factory
+
+    def create(
+        self,
+        name: str,
+        *,
+        source_base: str,
+        packages: Sequence[Mapping[str, object]],
+        tag_pattern: str,
+    ) -> LocalMarketplace:
+        """Create an ``apm.yml`` marketplace block for a later real CLI pack."""
+        producer = self._packages.create(name)
+        manifest = load_yaml(producer.manifest_path)
+        manifest["marketplace"] = {
+            "owner": {
+                "name": "APM Lifecycle Tests",
+                "url": "https://example.invalid/apm-lifecycle",
+            },
+            "sourceBase": source_base,
+            "build": {
+                "tagPattern": validate_tag_pattern(
+                    tag_pattern,
+                    context="marketplace.build.tagPattern",
+                )
+            },
+            "packages": [dict(package) for package in packages],
+        }
+        dump_yaml(manifest, producer.manifest_path)
+        return LocalMarketplace(
+            name=name,
+            package=producer,
+            output_path=producer.root / ".claude-plugin" / "marketplace.json",
+        )


### PR DESCRIPTION

## TL;DR

`apm install` with a semver range against a marketplace dependency silently ignored the marketplace's `tagPattern`, always falling back to the hardcoded default `{name}--v{version}`. After this fix, the producer's declared `tag_pattern` is carried through `marketplace.json` → `MarketplacePlugin` → `resolve_version_constraint()` so the consumer resolves against the same tags the producer published.

## Problem (WHY)

When a marketplace producer calls `apm pack`, it serialises each plugin's git tag pattern into `marketplace.json`. The consumer (`apm install`) reads that file, but `resolver.py::resolve_marketplace_plugin()` called `resolve_version_constraint()` **without forwarding `tag_pattern`**, so the resolver always used `DEFAULT_TAG_PATTERN = "{name}--v{version}"` regardless of what the producer declared.

Result: any marketplace that uses a non-default tag pattern (e.g. `v{version}`, `{name}/{version}`) caused silent semver-range resolution failures — the candidate tags existed but were never matched, so `apm install` either returned no result or resolved to an incorrect version.

> Root cause confirmed in: `src/apm_cli/marketplace/resolver.py` → `resolve_marketplace_plugin()` (line ~974).

## Approach (WHAT)

Thread `effective_tag_pattern` from producer → lockfile → consumer resolver without changing the externally visible install UX:

1. **Producer (`builder.py`)**: Add `effective_tag_pattern: str` to `ResolvedPackage`; populate it in all 5 resolution return sites.
2. **Serialiser (`output_mappers.py`)**: Emit `"tag_pattern"` in the remote source dict when non-empty.
3. **Consumer model (`models.py`)**: Add `tag_pattern: str | None = None` to `MarketplacePlugin`; parse it from the source dict.
4. **Consumer resolver (`resolver.py`)**: Pass `tag_pattern=plugin.tag_pattern or DEFAULT_TAG_PATTERN` to `resolve_version_constraint()`.

```mermaid
flowchart LR
  subgraph Producer["apm pack"]
    BP["builder.py\nResolvedPackage\n(effective_tag_pattern)"] --> OM["output_mappers.py\n(tag_pattern in source dict)"]
  end
  subgraph marketplace_json["marketplace.json"]
    MJ[("source.tag_pattern")]
  end
  subgraph Consumer["apm install"]
    MP["models.py\nMarketplacePlugin\n(tag_pattern field)"] --> RE["resolver.py\nresolve_version_constraint\n(tag_pattern kwarg)"]
  end
  OM --> MJ --> MP
```

## Implementation (HOW)

### Key changes

| File | Change |
|------|--------|
| `src/apm_cli/marketplace/builder.py` | `ResolvedPackage` dataclass: new `effective_tag_pattern: str = ""` field; populated in `_resolve_explicit_ref` (4 sites) and `_resolve_version_range` (1 site). |
| `src/apm_cli/marketplace/output_mappers.py` | Emits `"tag_pattern"` in remote source dict when the field is non-empty. |
| `src/apm_cli/marketplace/models.py` | `MarketplacePlugin.tag_pattern: str \| None = None`; `_parse_plugin_entry()` reads it from the source dict. |
| `src/apm_cli/marketplace/resolver.py` | `resolve_marketplace_plugin()` passes `tag_pattern=plugin.tag_pattern or DEFAULT_TAG_PATTERN`. |
| `src/apm_cli/marketplace/tag_pattern.py` | New canonical-owner module: validates and expands tag patterns. |
| `src/apm_cli/deps/apm_resolver.py` | Internal: `marketplace_provenance` dict (now a property) tracks resolver-side provenance. |
| `src/apm_cli/install/phases/resolve.py` | Internal: `_build_dependency_graph` helper propagates provenance data. |

### Architecture invariant

`marketplace/tag_pattern.py` is the single canonical owner of tag-pattern validation and expansion, registered in `.github/instructions/architecture.instructions.md`.

### Default-pattern semantics

| Context | Pattern | Reason |
|---------|---------|--------|
| Producer default (`MarketplaceBuild.tag_pattern`) | `v{version}` | New marketplaces use this shorter form. |
| Consumer fallback (`DEFAULT_TAG_PATTERN`) | `{name}--v{version}` | Legacy marketplaces pre-dating `tag_pattern` field. |
| Propagated (this fix) | Whatever the producer declared | Ensures producer and consumer agree. |

### Data flow

```mermaid
sequenceDiagram
  participant P as apm pack
  participant MJ as marketplace.json
  participant I as apm install
  participant VR as version_resolver
  P->>MJ: write source.tag_pattern
  I->>MJ: read MarketplacePlugin.tag_pattern
  I->>VR: resolve_version_constraint(tag_pattern=plugin.tag_pattern)
  VR-->>I: matched version
```

### Trade-offs

- **Backward compatibility**: `tag_pattern` is optional in the source dict. Old `marketplace.json` files (no `tag_pattern` key) continue to fall through to `DEFAULT_TAG_PATTERN`, so existing installs are unaffected.
- **`ResolvedPackage` is `frozen=True`**: All 5 constructor call sites updated; missed sites produce a clear `TypeError` at build time, not a silent data error.
- **No lockfile schema change**: `tag_pattern` lives in the source dict already written by `output_mappers.py`; no new lockfile field is introduced.

## Validation evidence

| Gate | Result |
|------|--------|
| `uv run --extra dev ruff check src/ tests/` | clean |
| `uv run --extra dev ruff format --check src/ tests/` | clean |
| `uv run --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/` | clean |
| `bash scripts/lint-auth-signals.sh` | clean |
| `uv run --frozen apm audit --ci` | all 10 checks passed |
| `pytest tests/unit/marketplace/ tests/integration/marketplace/ -q` | 1528 passed, 0 failed |

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|-------------------------|--------------|--------------------|------|
| 1 | `apm install` resolves a semver range against tags matching the marketplace's declared `tagPattern`, not a hardcoded default | Vendor-neutral, Governed by policy | `tests/unit/marketplace/test_version_resolver.py::TestResolveVersionConstraint::test_custom_slash_tag_pattern_resolves`<br/>`tests/unit/marketplace/test_version_resolver.py::TestResolveVersionConstraint::test_custom_slash_pattern_caret_picks_highest` (regression-trap for #2319) | unit |
| 2 | A marketplace built with a non-default `tagPattern` passes that pattern to the consumer resolver | Vendor-neutral | `tests/unit/marketplace/test_versioned_resolver.py::TestResolveMarketplacePlugin::test_semver_range_uses_custom_tag_pattern` | unit |
| 3 | `apm pack` embeds `tag_pattern` in `marketplace.json` source dicts | Governed by policy | `tests/integration/marketplace/test_build_integration.py::TestTagPatternClosure::test_producer_emits_tag_pattern_in_source` | integration |
| 4 | Consumer parses `tag_pattern` from `marketplace.json` into `MarketplacePlugin` | Governed by policy | `tests/integration/marketplace/test_build_integration.py::TestTagPatternClosure::test_consumer_parses_tag_pattern_from_source` | integration |
| 5 | Full producer→consumer closure: pack with custom pattern, install resolves against matching tags | Vendor-neutral, Governed by policy | `tests/integration/marketplace/test_build_integration.py::TestTagPatternClosure::test_consumer_resolver_uses_tag_pattern_from_marketplace_json` | integration |
| 6 | Existing marketplace files without `tag_pattern` continue to resolve using the original default | Governed by policy, DevX | `tests/unit/marketplace/test_version_resolver.py::TestResolveVersionConstraint::test_default_pattern_unaffected_by_fix` | unit |

## How to test

- [ ] `git checkout sergio-sisternes-epam-fix-2319-semver-tag-pattern && uv run --extra dev pytest tests/unit/marketplace/ tests/integration/marketplace/ -q --ignore=tests/integration/marketplace/test_live_e2e.py` — expect 1528 passed, 0 failed.
- [ ] Open `tests/fixtures/marketplace/golden.json` — each plugin's `source` object should contain `"tag_pattern": "v{version}"`.
- [ ] In `tests/integration/marketplace/test_build_integration.py`, search for `TestTagPatternClosure` — three integration tests exercise the producer-to-consumer closure with a custom `{name}/{version}` pattern.
- [ ] Open `packages/apm-guide/.apm/skills/apm-usage/dependencies.md` lines 211-224 — the stale `{name}--v{version}` reference is replaced with the correct dynamic description.
- [ ] Review `CHANGELOG.md` under `[Unreleased]` for the `[Fixed]` entry describing this change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

apm-spec-waiver: Internal refactor in apm_resolver.py and resolve.py carries marketplace provenance data to support the tag_pattern fix; no spec-observable behaviour delta.
