### PR TITLE
fix(deps): preserve inherited git config when injecting auth headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Injecting an HTTP `Authorization` header into a git subprocess no longer
+  discards inherited `GIT_CONFIG_*` entries. The header overlay hardcoded
+  `GIT_CONFIG_COUNT=1`, so merging it dropped retained hardening such as
+  `safe.bareRepository=explicit` and a corporate `http.sslCAInfo` pin on every
+  clone, download, and marketplace `ls-remote`. (by @edenfunf, #2368)
+
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview
   now excludes the synthesized lockfile self-entry, matching the real install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Injecting an HTTP `Authorization` header into a git subprocess no longer
-  discards inherited `GIT_CONFIG_*` entries. The header overlay hardcoded
-  `GIT_CONFIG_COUNT=1`, so merging it dropped retained hardening such as
-  `safe.bareRepository=explicit` and a corporate `http.sslCAInfo` pin on every
-  clone, download, and marketplace `ls-remote`. (by @edenfunf, #2368)
-
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview
   now excludes the synthesized lockfile self-entry, matching the real install
   which never removes them. (by @mia106dev, #2069)
+
+### Security
+
+- Corporate git security settings -- SSL CA pins (`http.sslCAInfo`), bare-repo
+  protection (`safe.bareRepository=explicit`), and other inherited `GIT_CONFIG_*`
+  hardening -- are no longer silently dropped when apm injects an
+  `Authorization` header for a clone, download, or marketplace `ls-remote`.
+  The header overlay previously hardcoded `GIT_CONFIG_COUNT=1`, so merging it
+  onto an already-configured environment reset the count and clobbered index
+  0. (by @edenfunf, #2368)
 
 ## [0.26.0] - 2026-07-18
 

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -678,6 +678,30 @@ if [ "$deployment_owner_status" -ne 0 ]; then
     violations=$((violations + 1))
 fi
 
+echo "[*] AC19: git-subprocess auth-header injection authority"
+# #2368: build_authorization_header_git_env / build_ado_bearer_git_env return
+# an overlay with a hardcoded GIT_CONFIG_COUNT="1". Dict-merging that overlay
+# onto an env that already carries indexed GIT_CONFIG_* entries resets the
+# count and clobbers index 0, silently dropping inherited git hardening
+# (safe.bareRepository, http.sslCAInfo, credential.interactive). The single
+# owner for injecting an Authorization header into a git-subprocess env is
+# set_authorization_header_git_env / set_ado_bearer_git_env (in-place
+# rewrite); dict-merging the build_* overlay onto a populated env is the
+# exact defect those setters exist to prevent from recurring.
+auth_header_dictmerge_hits=$(
+    grep -rEn --include='*.py' \
+        '\.update\(\s*build_(authorization_header_git_env|ado_bearer_git_env)\(|\{\*\*[A-Za-z_][A-Za-z0-9_.]*,\s*\*\*build_(authorization_header_git_env|ado_bearer_git_env)\(' \
+        src/apm_cli \
+        | grep -vE ':[0-9]+:[[:space:]]*#' \
+        | grep -v 'architecture-authority-exempt:' \
+        || true
+)
+if [ -n "$auth_header_dictmerge_hits" ]; then
+    echo "[x] Git-subprocess Authorization-header injection must use set_authorization_header_git_env / set_ado_bearer_git_env (in-place); dict-merging the build_* overlay onto a populated env re-introduces the #2368 clobber bug"
+    echo "$auth_header_dictmerge_hits"
+    violations=$((violations + 1))
+fi
+
 if [ "$violations" -gt 0 ]; then
     echo "[x] $violations architecture boundary rule(s) failed"
     exit 1

--- a/src/apm_cli/core/auth.py
+++ b/src/apm_cli/core/auth.py
@@ -937,7 +937,7 @@ class AuthResolver:
         """Pre-built env dict for subprocess git calls.
 
         For ADO bearer tokens (scheme='bearer'), injects an Authorization header
-        via GIT_CONFIG_COUNT/KEY/VALUE env vars (see github_host.build_ado_bearer_git_env).
+        via GIT_CONFIG_COUNT/KEY/VALUE env vars (see github_host.set_ado_bearer_git_env).
         For all other cases, behavior is unchanged.
         """
         env = os.environ.copy()
@@ -946,12 +946,15 @@ class AuthResolver:
         env["GIT_ASKPASS"] = "echo"
         if scheme == "bearer" and token and host_kind == "ado":
             # B2 #852: skip GIT_TOKEN for bearer scheme -- the JWT is injected via
-            # GIT_CONFIG_VALUE_0 only; GIT_TOKEN here would leak it into every
-            # child-process env (visible in /proc/<pid>/environ, ps eww).
+            # a GIT_CONFIG_VALUE_N header only; GIT_TOKEN here would leak it into
+            # every child-process env (visible in /proc/<pid>/environ, ps eww).
             #
-            from apm_cli.utils.github_host import build_ado_bearer_git_env
+            # #2368: set (append-after-retained) rather than dict-merge, so the
+            # non-auth entries _clear_git_auth_env just retained (e.g.
+            # http.sslCAInfo) are not clobbered by a hardcoded COUNT=1 overlay.
+            from apm_cli.utils.github_host import set_ado_bearer_git_env
 
-            env.update(build_ado_bearer_git_env(token))
+            set_ado_bearer_git_env(env, token)
         elif token:
             env["GIT_TOKEN"] = token
         return env

--- a/src/apm_cli/deps/clone_engine.py
+++ b/src/apm_cli/deps/clone_engine.py
@@ -283,7 +283,7 @@ class CloneEngine:
                             AzureCliBearerError,
                             get_bearer_provider,
                         )
-                        from apm_cli.utils.github_host import build_ado_bearer_git_env
+                        from apm_cli.utils.github_host import append_ado_bearer_git_env
 
                         provider = get_bearer_provider()
                         if provider.is_available():
@@ -296,10 +296,8 @@ class CloneEngine:
                                     token=None,
                                     auth_scheme="bearer",
                                 )
-                                bearer_env = {
-                                    **host.git_env,
-                                    **build_ado_bearer_git_env(bearer),
-                                }
+                                bearer_env = dict(host.git_env)
+                                append_ado_bearer_git_env(bearer_env, bearer)
                                 clone_action(bearer_url, bearer_env, target_path)
                                 host.auth_resolver.emit_stale_pat_diagnostic(
                                     dep_host or "dev.azure.com"

--- a/src/apm_cli/deps/clone_engine.py
+++ b/src/apm_cli/deps/clone_engine.py
@@ -283,7 +283,7 @@ class CloneEngine:
                             AzureCliBearerError,
                             get_bearer_provider,
                         )
-                        from apm_cli.utils.github_host import append_ado_bearer_git_env
+                        from apm_cli.utils.github_host import set_ado_bearer_git_env
 
                         provider = get_bearer_provider()
                         if provider.is_available():
@@ -297,7 +297,7 @@ class CloneEngine:
                                     auth_scheme="bearer",
                                 )
                                 bearer_env = dict(host.git_env)
-                                append_ado_bearer_git_env(bearer_env, bearer)
+                                set_ado_bearer_git_env(bearer_env, bearer)
                                 clone_action(bearer_url, bearer_env, target_path)
                                 host.auth_resolver.emit_stale_pat_diagnostic(
                                     dep_host or "dev.azure.com"

--- a/src/apm_cli/deps/download_strategies.py
+++ b/src/apm_cli/deps/download_strategies.py
@@ -26,9 +26,9 @@ from ..core.auth import AuthResolver, HostInfo
 from ..models.apm_package import DependencyReference
 from ..utils.archive import ArchiveError, safe_extract_zip
 from ..utils.github_host import (
+    append_authorization_header_git_env,
     build_ado_api_url,
     build_artifactory_archive_url,
-    build_authorization_header_git_env,
     build_https_clone_url,
     build_raw_content_url,
     build_ssh_url,
@@ -751,10 +751,8 @@ class DownloadDelegate:
             # AuthResolver owns credential resolution. Convert its resolved
             # GitHub credential into Git's header channel so the token remains
             # out of the remote URL and is actually consumed by git.
-            git_env = {
-                **auth_ctx.git_env,
-                **build_authorization_header_git_env("Bearer", auth_ctx.token),
-            }
+            git_env = dict(auth_ctx.git_env)
+            append_authorization_header_git_env(git_env, "Bearer", auth_ctx.token)
             git_env.pop("GIT_TOKEN", None)
             auth_scheme = "basic"
         else:

--- a/src/apm_cli/deps/download_strategies.py
+++ b/src/apm_cli/deps/download_strategies.py
@@ -26,7 +26,6 @@ from ..core.auth import AuthResolver, HostInfo
 from ..models.apm_package import DependencyReference
 from ..utils.archive import ArchiveError, safe_extract_zip
 from ..utils.github_host import (
-    append_authorization_header_git_env,
     build_ado_api_url,
     build_artifactory_archive_url,
     build_https_clone_url,
@@ -34,6 +33,7 @@ from ..utils.github_host import (
     build_ssh_url,
     default_host,
     is_github_hostname,
+    set_authorization_header_git_env,
 )
 from ..utils.path_security import PathTraversalError
 from .git_file_transport import (
@@ -752,7 +752,7 @@ class DownloadDelegate:
             # GitHub credential into Git's header channel so the token remains
             # out of the remote URL and is actually consumed by git.
             git_env = dict(auth_ctx.git_env)
-            append_authorization_header_git_env(git_env, "Bearer", auth_ctx.token)
+            set_authorization_header_git_env(git_env, "Bearer", auth_ctx.token)
             git_env.pop("GIT_TOKEN", None)
             auth_scheme = "basic"
         else:

--- a/src/apm_cli/deps/github_downloader_validation.py
+++ b/src/apm_cli/deps/github_downloader_validation.py
@@ -24,7 +24,7 @@ Security gates (round-2 panel findings)
   shallow-fetch + ``ls-tree`` to confirm ``vpath`` resolves at that ref
   before returning ``True``.
 * For Azure DevOps, credentials (PAT or AAD bearer) are injected via
-  ``http.extraheader`` (see ``build_authorization_header_git_env``) and
+  ``http.extraheader`` (see ``set_authorization_header_git_env``) and
   never embedded in the clone URL.  This keeps tokens out of the OS
   process table, git's own logs, and any downstream debug output.
 """
@@ -45,9 +45,9 @@ from git.exc import GitCommandError
 
 from ..config import get_apm_temp_dir
 from ..utils.github_host import (
-    build_authorization_header_git_env,
     default_host,
     is_github_hostname,
+    set_authorization_header_git_env,
 )
 from ..utils.path_security import (
     PathTraversalError,
@@ -363,22 +363,23 @@ def _build_validation_attempts(
             # ADO PAT requires HTTP Basic with base64(":PAT"). A raw
             # Bearer header would 401 every ADO PAT user.
             encoded = base64.b64encode(f":{dep_token}".encode()).decode("ascii")
-            auth_env = build_authorization_header_git_env("Basic", encoded)
+            auth_header = ("Basic", encoded)
             label = "ADO authenticated HTTPS (basic header)"
         elif is_ado:  # bearer (AAD JWT)
-            auth_env = build_authorization_header_git_env("Bearer", dep_token)
+            auth_header = ("Bearer", dep_token)
             label = "ADO authenticated HTTPS (bearer header)"
         elif is_gitlab:
             encoded = base64.b64encode(f"oauth2:{dep_token}".encode()).decode("ascii")
-            auth_env = build_authorization_header_git_env("Basic", encoded)
+            auth_header = ("Basic", encoded)
             label = "GitLab authenticated HTTPS (basic header)"
         else:
             # Non-ADO: header injection rather than URL embedding so the
             # token never appears in argv or temp .git/config.
-            auth_env = build_authorization_header_git_env("Bearer", dep_token)
+            auth_header = ("Bearer", dep_token)
             label = "authenticated HTTPS (header)"
 
-        token_env = {**downloader.git_env, **auth_env}
+        token_env = dict(downloader.git_env)
+        set_authorization_header_git_env(token_env, *auth_header)
         token_url = downloader._build_repo_url(
             dep_ref.repo_url,
             use_ssh=False,

--- a/src/apm_cli/marketplace/client.py
+++ b/src/apm_cli/marketplace/client.py
@@ -631,8 +631,10 @@ def _ado_auth_header(token: str | None, git_env: dict | None) -> dict[str, str]:
 
     ``AuthResolver.try_with_fallback`` hands the operation a ``(token, git_env)``
     pair but not the auth scheme. Bearer contexts carry the full
-    ``Authorization: Bearer <jwt>`` header in ``GIT_CONFIG_VALUE_0`` (see
-    ``AuthResolver._build_git_env``); detect that and emit the Bearer scheme.
+    ``Authorization: Bearer <jwt>`` header in a ``GIT_CONFIG_VALUE_<i>`` slot
+    (see ``AuthResolver._build_git_env``); detect that and emit the Bearer
+    scheme. The slot index is not fixed: since #2368 the header is appended
+    after retained non-auth entries, so every value slot must be scanned.
     Otherwise treat the token as an ADO PAT and use HTTP Basic with
     ``base64(":" + PAT)`` per ADO's convention (empty username, PAT as
     password). Returns an empty dict for an anonymous request.
@@ -641,9 +643,11 @@ def _ado_auth_header(token: str | None, git_env: dict | None) -> dict[str, str]:
     """
     if not token:
         return {}
-    extra_header = (git_env or {}).get("GIT_CONFIG_VALUE_0", "").strip()
-    if extra_header.lower().startswith("authorization: bearer "):
-        return {"Authorization": f"Bearer {token}"}
+    for key, value in (git_env or {}).items():
+        if not key.startswith("GIT_CONFIG_VALUE_"):
+            continue
+        if str(value).strip().lower().startswith("authorization: bearer "):
+            return {"Authorization": f"Bearer {token}"}
     encoded = base64.b64encode(f":{token}".encode()).decode("ascii")
     return {"Authorization": f"Basic {encoded}"}
 

--- a/src/apm_cli/marketplace/client.py
+++ b/src/apm_cli/marketplace/client.py
@@ -633,8 +633,14 @@ def _ado_auth_header(token: str | None, git_env: dict | None) -> dict[str, str]:
     pair but not the auth scheme. Bearer contexts carry the full
     ``Authorization: Bearer <jwt>`` header in a ``GIT_CONFIG_VALUE_<i>`` slot
     (see ``AuthResolver._build_git_env``); detect that and emit the Bearer
-    scheme. The slot index is not fixed: since #2368 the header is appended
-    after retained non-auth entries, so every value slot must be scanned.
+    scheme. The slot index is not fixed -- since #2368 the header is appended
+    after any retained non-auth entries -- so the whole indexed set is scanned.
+
+    Only indices below ``GIT_CONFIG_COUNT`` are read, because that is all git
+    itself reads. A slot above the count is either a leftover from an env this
+    process did not build or an injected one, and honouring it would send an
+    ADO PAT under the Bearer scheme, which the server rejects.
+
     Otherwise treat the token as an ADO PAT and use HTTP Basic with
     ``base64(":" + PAT)`` per ADO's convention (empty username, PAT as
     password). Returns an empty dict for an anonymous request.
@@ -643,10 +649,14 @@ def _ado_auth_header(token: str | None, git_env: dict | None) -> dict[str, str]:
     """
     if not token:
         return {}
-    for key, value in (git_env or {}).items():
-        if not key.startswith("GIT_CONFIG_VALUE_"):
-            continue
-        if str(value).strip().lower().startswith("authorization: bearer "):
+    env = git_env or {}
+    try:
+        count = max(0, int(env.get("GIT_CONFIG_COUNT", "0") or "0"))
+    except (TypeError, ValueError):
+        count = 0
+    for index in range(count):
+        value = str(env.get(f"GIT_CONFIG_VALUE_{index}", ""))
+        if value.strip().lower().startswith("authorization: bearer "):
             return {"Authorization": f"Bearer {token}"}
     encoded = base64.b64encode(f":{token}".encode()).decode("ascii")
     return {"Authorization": f"Basic {encoded}"}

--- a/src/apm_cli/marketplace/ref_resolver.py
+++ b/src/apm_cli/marketplace/ref_resolver.py
@@ -25,14 +25,14 @@ import urllib.parse
 from dataclasses import dataclass
 
 from ..utils.github_host import (
-    build_ado_bearer_git_env,
     build_ado_ssh_url,
-    build_authorization_header_git_env,
     build_https_clone_url,
     build_ssh_url,
     default_host,
     is_ado_auth_failure_signal,
     is_azure_devops_hostname,
+    set_ado_bearer_git_env,
+    set_authorization_header_git_env,
 )
 from ._git_utils import redact_token as _redact_token
 from .errors import GitLsRemoteError, OfflineMissError
@@ -341,10 +341,10 @@ class RefResolver:
             env["GIT_ASKPASS"] = "echo"
         if bearer and self._token:
             env.pop("GIT_TOKEN", None)
-            env.update(build_ado_bearer_git_env(self._token))
+            set_ado_bearer_git_env(env, self._token)
         elif ado_host and url_token:
             credential = base64.b64encode(f":{url_token}".encode()).decode()
-            env.update(build_authorization_header_git_env("Basic", credential))
+            set_authorization_header_git_env(env, "Basic", credential)
         return url, env
 
     def list_remote_refs(
@@ -472,7 +472,7 @@ class RefResolver:
                 dict(self._git_env) if self._git_env is not None else AuthResolver._build_git_env()
             )
             AuthResolver._clear_git_auth_env(bearer_env)
-            bearer_env.update(build_ado_bearer_git_env(bearer))
+            set_ado_bearer_git_env(bearer_env, bearer)
             bearer_env["GIT_TERMINAL_PROMPT"] = "0"
             bearer_env["GIT_ASKPASS"] = "echo"
             resolver = RefResolver(

--- a/src/apm_cli/utils/github_host.py
+++ b/src/apm_cli/utils/github_host.py
@@ -507,23 +507,44 @@ def set_authorization_header_git_env(env: dict[str, str], scheme: str, credentia
     ``safe.bareRepository=explicit`` or ``http.sslCAInfo`` (#2368).
 
     This helper instead rewrites the indexed set in place: existing
-    auth-channel entries (any ``*extraheader*`` key, or a value containing
-    ``authorization`` -- the same policy as
+    auth-channel entries (any ``*extraheader*`` key, or a value that IS an
+    ``Authorization:`` header -- the same policy as
     ``AuthResolver._clear_git_auth_env``) are removed so layered callers
     cannot stack duplicate Authorization headers, every other entry is
     preserved, and the new header is appended at the end.  Orphaned
     ``GIT_CONFIG_KEY_/VALUE_`` entries at or beyond the count are also
     dropped so no stale credential lingers in the child-process env table.
 
+    Note:
+        The retain/reindex predicate below intentionally mirrors
+        ``AuthResolver._clear_git_auth_env`` (``core/auth.py``) rather than
+        delegating to a shared primitive.  Extracting a single owner (e.g.
+        ``utils/git_env.py``) is the right end state -- see PR discussion on
+        #2368 and follow-up #2398 -- but doing so means editing
+        ``_clear_git_auth_env``, a security-critical function this bug does
+        not otherwise touch, which deserves its own focused security review
+        rather than riding along in this fix.
+        TODO(#2398): extract a shared ``_is_auth_channel_entry`` /
+        retain-reindex helper into ``utils/git_env.py``, and delegate both
+        this function and ``AuthResolver._clear_git_auth_env`` to it.
+
     Args:
         env: The subprocess env dict to mutate (base env already merged in).
         scheme: HTTP auth scheme, e.g. ``"Bearer"`` or ``"Basic"``.
         credential: The credential value (token or base64-encoded user:pass).
 
+    Raises:
+        ValueError: If *scheme* or *credential* contains a carriage-return
+            or newline, which would let the appended git-config value smuggle
+            a second config entry or header (defense-in-depth; no known
+            caller in this codebase can trigger this today).
+
     Note:
         Callers MUST NOT log *env* afterwards.  The appended
         ``GIT_CONFIG_VALUE_N`` contains the credential.
     """
+    if "\r" in scheme or "\n" in scheme or "\r" in credential or "\n" in credential:
+        raise ValueError("scheme and credential must not contain CR or LF")
     try:
         count = max(0, int(env.get("GIT_CONFIG_COUNT", "0") or "0"))
     except ValueError:
@@ -532,7 +553,7 @@ def set_authorization_header_git_env(env: dict[str, str], scheme: str, credentia
     for index in range(count):
         key = env.get(f"GIT_CONFIG_KEY_{index}", "")
         value = env.get(f"GIT_CONFIG_VALUE_{index}", "")
-        if "extraheader" in key.lower() or "authorization" in value.lower():
+        if "extraheader" in key.lower() or value.strip().lower().startswith("authorization:"):
             continue
         if key:
             retained.append((key, value))

--- a/src/apm_cli/utils/github_host.py
+++ b/src/apm_cli/utils/github_host.py
@@ -496,7 +496,7 @@ def build_ado_bearer_git_env(bearer_token: str) -> dict:
     return build_authorization_header_git_env("Bearer", bearer_token)
 
 
-def set_authorization_header_git_env(env: dict, scheme: str, credential: str) -> None:
+def set_authorization_header_git_env(env: dict[str, str], scheme: str, credential: str) -> None:
     """Make ``Authorization: <scheme> <credential>`` the sole auth header in *env*.
 
     :func:`build_authorization_header_git_env` returns an overlay whose
@@ -546,7 +546,7 @@ def set_authorization_header_git_env(env: dict, scheme: str, credential: str) ->
         env[f"GIT_CONFIG_VALUE_{index}"] = value
 
 
-def set_ado_bearer_git_env(env: dict, bearer_token: str) -> None:
+def set_ado_bearer_git_env(env: dict[str, str], bearer_token: str) -> None:
     """Set an ADO AAD bearer Authorization header on *env* in place.
 
     In-place variant of :func:`build_ado_bearer_git_env`; see

--- a/src/apm_cli/utils/github_host.py
+++ b/src/apm_cli/utils/github_host.py
@@ -490,6 +490,46 @@ def build_ado_bearer_git_env(bearer_token: str) -> dict:
     return build_authorization_header_git_env("Bearer", bearer_token)
 
 
+def append_authorization_header_git_env(env: dict, scheme: str, credential: str) -> None:
+    """Append an Authorization ``http.extraheader`` entry to *env* in place.
+
+    :func:`build_authorization_header_git_env` returns an overlay whose
+    ``GIT_CONFIG_COUNT`` is hardcoded to ``"1"``.  Dict-merging that overlay
+    onto a base env that already carries indexed git config entries
+    (``GIT_CONFIG_COUNT=N`` with keys ``0..N-1``) resets the count and
+    overwrites index 0, silently dropping retained entries such as
+    ``safe.bareRepository=explicit`` or ``credential.interactive=never``
+    (#2368).  This variant appends the header at the next free index so
+    the existing config set survives.
+
+    Args:
+        env: The subprocess env dict to mutate (base env already merged in).
+        scheme: HTTP auth scheme, e.g. ``"Bearer"`` or ``"Basic"``.
+        credential: The credential value (token or base64-encoded user:pass).
+
+    Note:
+        Callers MUST NOT log *env* afterwards.  The appended
+        ``GIT_CONFIG_VALUE_N`` contains the credential.
+    """
+    try:
+        count = max(0, int(env.get("GIT_CONFIG_COUNT", "0") or "0"))
+    except ValueError:
+        count = 0
+    env["GIT_CONFIG_COUNT"] = str(count + 1)
+    env[f"GIT_CONFIG_KEY_{count}"] = "http.extraheader"
+    env[f"GIT_CONFIG_VALUE_{count}"] = f"Authorization: {scheme} {credential}"
+
+
+def append_ado_bearer_git_env(env: dict, bearer_token: str) -> None:
+    """Append an ADO AAD bearer Authorization header to *env* in place.
+
+    Append-variant of :func:`build_ado_bearer_git_env`; see
+    :func:`append_authorization_header_git_env` for why appending (rather
+    than replacing) the ``GIT_CONFIG_*`` set matters.
+    """
+    append_authorization_header_git_env(env, "Bearer", bearer_token)
+
+
 # Single source of truth for the ADO auth-failure signal set.
 #
 # Historically these signal strings were open-coded across 3+ call sites

--- a/src/apm_cli/utils/github_host.py
+++ b/src/apm_cli/utils/github_host.py
@@ -464,6 +464,12 @@ def build_authorization_header_git_env(scheme: str, credential: str) -> dict:
     Note:
         Callers MUST NOT log the returned dict.  ``GIT_CONFIG_VALUE_0``
         contains the credential.
+
+    Warning:
+        Do NOT dict-merge this overlay onto an env that may already carry
+        indexed ``GIT_CONFIG_*`` entries -- the hardcoded count resets the
+        set and clobbers index 0 (#2368).  Use
+        :func:`set_authorization_header_git_env` for that case.
     """
     return {
         "GIT_CONFIG_COUNT": "1",
@@ -490,17 +496,24 @@ def build_ado_bearer_git_env(bearer_token: str) -> dict:
     return build_authorization_header_git_env("Bearer", bearer_token)
 
 
-def append_authorization_header_git_env(env: dict, scheme: str, credential: str) -> None:
-    """Append an Authorization ``http.extraheader`` entry to *env* in place.
+def set_authorization_header_git_env(env: dict, scheme: str, credential: str) -> None:
+    """Make ``Authorization: <scheme> <credential>`` the sole auth header in *env*.
 
     :func:`build_authorization_header_git_env` returns an overlay whose
     ``GIT_CONFIG_COUNT`` is hardcoded to ``"1"``.  Dict-merging that overlay
     onto a base env that already carries indexed git config entries
     (``GIT_CONFIG_COUNT=N`` with keys ``0..N-1``) resets the count and
-    overwrites index 0, silently dropping retained entries such as
-    ``safe.bareRepository=explicit`` or ``credential.interactive=never``
-    (#2368).  This variant appends the header at the next free index so
-    the existing config set survives.
+    overwrites index 0, silently dropping non-auth entries such as
+    ``safe.bareRepository=explicit`` or ``http.sslCAInfo`` (#2368).
+
+    This helper instead rewrites the indexed set in place: existing
+    auth-channel entries (any ``*extraheader*`` key, or a value containing
+    ``authorization`` -- the same policy as
+    ``AuthResolver._clear_git_auth_env``) are removed so layered callers
+    cannot stack duplicate Authorization headers, every other entry is
+    preserved, and the new header is appended at the end.  Orphaned
+    ``GIT_CONFIG_KEY_/VALUE_`` entries at or beyond the count are also
+    dropped so no stale credential lingers in the child-process env table.
 
     Args:
         env: The subprocess env dict to mutate (base env already merged in).
@@ -515,19 +528,32 @@ def append_authorization_header_git_env(env: dict, scheme: str, credential: str)
         count = max(0, int(env.get("GIT_CONFIG_COUNT", "0") or "0"))
     except ValueError:
         count = 0
-    env["GIT_CONFIG_COUNT"] = str(count + 1)
-    env[f"GIT_CONFIG_KEY_{count}"] = "http.extraheader"
-    env[f"GIT_CONFIG_VALUE_{count}"] = f"Authorization: {scheme} {credential}"
+    retained: list[tuple[str, str]] = []
+    for index in range(count):
+        key = env.get(f"GIT_CONFIG_KEY_{index}", "")
+        value = env.get(f"GIT_CONFIG_VALUE_{index}", "")
+        if "extraheader" in key.lower() or "authorization" in value.lower():
+            continue
+        if key:
+            retained.append((key, value))
+    for key in tuple(env):
+        if key.startswith(("GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_")):
+            env.pop(key, None)
+    retained.append(("http.extraheader", f"Authorization: {scheme} {credential}"))
+    env["GIT_CONFIG_COUNT"] = str(len(retained))
+    for index, (key, value) in enumerate(retained):
+        env[f"GIT_CONFIG_KEY_{index}"] = key
+        env[f"GIT_CONFIG_VALUE_{index}"] = value
 
 
-def append_ado_bearer_git_env(env: dict, bearer_token: str) -> None:
-    """Append an ADO AAD bearer Authorization header to *env* in place.
+def set_ado_bearer_git_env(env: dict, bearer_token: str) -> None:
+    """Set an ADO AAD bearer Authorization header on *env* in place.
 
-    Append-variant of :func:`build_ado_bearer_git_env`; see
-    :func:`append_authorization_header_git_env` for why appending (rather
-    than replacing) the ``GIT_CONFIG_*`` set matters.
+    In-place variant of :func:`build_ado_bearer_git_env`; see
+    :func:`set_authorization_header_git_env` for why rewriting (rather
+    than dict-merging) the ``GIT_CONFIG_*`` set matters.
     """
-    append_authorization_header_git_env(env, "Bearer", bearer_token)
+    set_authorization_header_git_env(env, "Bearer", bearer_token)
 
 
 # Single source of truth for the ADO auth-failure signal set.

--- a/tests/integration/test_ado_marketplace_check_auth.py
+++ b/tests/integration/test_ado_marketplace_check_auth.py
@@ -50,9 +50,14 @@ marketplace:
         assert parsed.path == "/contoso/platform/_git/my-package"
         assert parsed.username is None
         env = kwargs["env"]
-        assert env["GIT_CONFIG_COUNT"] == "1"
-        assert env["GIT_CONFIG_KEY_0"] == "http.extraheader"
-        assert env["GIT_CONFIG_VALUE_0"] == f"Authorization: Bearer {bearer}"
+        # Header index is not fixed (#2368: appended after retained entries),
+        # so locate it instead of assuming slot 0.
+        headers = [
+            (env[f"GIT_CONFIG_KEY_{i}"], v)
+            for i in range(int(env["GIT_CONFIG_COUNT"]))
+            if "Authorization" in (v := env[f"GIT_CONFIG_VALUE_{i}"])
+        ]
+        assert headers == [("http.extraheader", f"Authorization: Bearer {bearer}")]
         return subprocess.CompletedProcess(
             command,
             0,

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -1347,3 +1347,68 @@ def test_github_throttle_owner_guard_rejects_parallel_header_parsing(tmp_path: P
     assert "GitHub throttle signals must be classified only by deps/github_rate_limit.py" in (
         result.stdout
     )
+
+
+def test_git_auth_header_injection_has_single_owner() -> None:
+    """#2368: injecting an Authorization header into a git-subprocess env
+    must have exactly one owner (set_authorization_header_git_env /
+    set_ado_bearer_git_env, in-place). Dict-merging the build_* overlay
+    (hardcoded GIT_CONFIG_COUNT="1") onto a populated env is the split
+    that silently clobbered inherited git hardening across 5 call sites.
+    """
+    root = Path(__file__).parents[2]
+    owner = (root / "src/apm_cli/utils/github_host.py").read_text(encoding="utf-8")
+    guard = (root / "scripts/lint-architecture-boundaries.sh").read_text(encoding="utf-8")
+
+    assert "def set_authorization_header_git_env(" in owner
+    assert "def set_ado_bearer_git_env(" in owner
+    assert "AC19: git-subprocess auth-header injection authority" in guard
+    assert (
+        "Git-subprocess Authorization-header injection must use "
+        "set_authorization_header_git_env / set_ado_bearer_git_env" in guard
+    )
+
+
+def test_git_auth_header_owner_guard_rejects_dictmerge_reintroduction(tmp_path: Path) -> None:
+    """AC19 must reject a re-introduced dict-merge of the build_* overlay
+    onto a populated env -- the exact #2368 clobber pattern.
+    """
+    root = Path(__file__).parents[2]
+    sandbox = tmp_path / "repo"
+    shutil.copytree(
+        root,
+        sandbox,
+        ignore=shutil.ignore_patterns(
+            ".git",
+            ".venv",
+            ".pytest_cache",
+            "__pycache__",
+            "build",
+            "dist",
+            "node_modules",
+        ),
+    )
+    consumer = sandbox / "src/apm_cli/deps/download_strategies.py"
+    consumer.write_text(
+        consumer.read_text(encoding="utf-8")
+        + "\n\n"
+        + "def _reintroduced_clobber_site(base_env, token):\n"
+        + "    from .utils.github_host import build_authorization_header_git_env\n"
+        + '    return {**base_env, **build_authorization_header_git_env("Bearer", token)}\n',
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ("bash", "scripts/lint-architecture-boundaries.sh"),
+        cwd=sandbox,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+
+    assert result.returncode == 1
+    assert (
+        "Git-subprocess Authorization-header injection must use "
+        "set_authorization_header_git_env / set_ado_bearer_git_env" in result.stdout
+    )

--- a/tests/unit/deps/test_clone_engine_bearer_env.py
+++ b/tests/unit/deps/test_clone_engine_bearer_env.py
@@ -1,0 +1,82 @@
+"""Focused contracts for CloneEngine's ADO bearer-retry env construction (#2368)."""
+
+from __future__ import annotations
+
+import subprocess as sp
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from apm_cli.deps.clone_engine import CloneEngine
+from apm_cli.deps.transport_selection import TransportAttempt, TransportPlan
+from apm_cli.models.dependency.reference import DependencyReference
+
+
+def _ado_host(git_env: dict) -> MagicMock:
+    """Build the downloader-context slice CloneEngine.execute needs."""
+    host = MagicMock()
+    host.git_env = git_env
+    host._allow_fallback = False
+    host._fallback_port_warned = set()
+    host._transport_selector.select.return_value = TransportPlan(
+        attempts=[TransportAttempt(scheme="https", label="https-token", use_token=True)],
+        strict=False,
+    )
+    host._resolve_dep_token.return_value = "pat-token"
+    ctx = MagicMock()
+    ctx.auth_scheme = "basic"
+    ctx.git_env = {}
+    host._resolve_dep_auth_ctx.return_value = ctx
+    host._build_repo_url = MagicMock(
+        side_effect=lambda *a, **kw: (
+            "https://bearer-url/o/r" if kw.get("auth_scheme") == "bearer" else "https://pat-url/o/r"
+        )
+    )
+    host._sanitize_git_error = MagicMock(side_effect=lambda s: s)
+    return host
+
+
+def test_bearer_retry_appends_header_preserving_retained_git_config(tmp_path: Path) -> None:
+    """#2368: the bearer retry env must append the Authorization header at the
+    next free GIT_CONFIG index instead of resetting the count and clobbering
+    retained hardening entries (safe.bareRepository etc.) from the base env."""
+    host = _ado_host(
+        {
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_KEY_0": "safe.bareRepository",
+            "GIT_CONFIG_VALUE_0": "explicit",
+        }
+    )
+    dep = DependencyReference.parse("dev.azure.com/org/proj/_git/repo/skills/X#main")
+    assert dep.is_azure_devops(), "fixture sanity: dep must be ADO"
+
+    envs_seen: list[dict] = []
+
+    def clone_action(url: str, env: dict, target: Path) -> None:
+        envs_seen.append(dict(env))
+        if "pat-url" in url:
+            raise sp.CalledProcessError(128, ["git"], stderr=b"Authentication failed")
+
+    bearer_provider = MagicMock()
+    bearer_provider.is_available.return_value = True
+    bearer_provider.get_bearer_token.return_value = "fake-bearer-token"
+
+    with patch(
+        "apm_cli.core.azure_cli.get_bearer_provider",
+        return_value=bearer_provider,
+    ):
+        CloneEngine(host).execute(
+            "org/proj/_git/repo",
+            tmp_path / "dst",
+            dep_ref=dep,
+            clone_action=clone_action,
+        )
+
+    assert len(envs_seen) == 2, "expected PAT attempt then bearer retry"
+    bearer_env = envs_seen[-1]
+    assert bearer_env["GIT_CONFIG_COUNT"] == "2"
+    assert bearer_env["GIT_CONFIG_KEY_0"] == "safe.bareRepository"
+    assert bearer_env["GIT_CONFIG_VALUE_0"] == "explicit"
+    assert bearer_env["GIT_CONFIG_KEY_1"] == "http.extraheader"
+    assert bearer_env["GIT_CONFIG_VALUE_1"] == "Authorization: Bearer fake-bearer-token"
+    # The retry must not mutate the host's shared base env.
+    assert host.git_env["GIT_CONFIG_COUNT"] == "1"

--- a/tests/unit/deps/test_clone_engine_bearer_env.py
+++ b/tests/unit/deps/test_clone_engine_bearer_env.py
@@ -1,4 +1,4 @@
-"""Focused contracts for CloneEngine's ADO bearer-retry env construction (#2368)."""
+﻿"""Focused contracts for CloneEngine's ADO bearer-retry env construction (#2368)."""
 
 from __future__ import annotations
 
@@ -35,7 +35,7 @@ def _ado_host(git_env: dict) -> MagicMock:
     return host
 
 
-def test_bearer_retry_appends_header_preserving_retained_git_config(tmp_path: Path) -> None:
+def test_bearer_retry_sets_header_preserving_retained_git_config(tmp_path: Path) -> None:
     """#2368: the bearer retry env must append the Authorization header at the
     next free GIT_CONFIG index instead of resetting the count and clobbering
     retained hardening entries (safe.bareRepository etc.) from the base env."""

--- a/tests/unit/deps/test_clone_engine_bearer_env.py
+++ b/tests/unit/deps/test_clone_engine_bearer_env.py
@@ -1,4 +1,4 @@
-﻿"""Focused contracts for CloneEngine's ADO bearer-retry env construction (#2368)."""
+"""Focused contracts for CloneEngine's ADO bearer-retry env construction (#2368)."""
 
 from __future__ import annotations
 

--- a/tests/unit/deps/test_github_downloader_input_validation.py
+++ b/tests/unit/deps/test_github_downloader_input_validation.py
@@ -420,6 +420,30 @@ class TestBuildValidationAttempts:
         header_values = [v for v in env_values if isinstance(v, str) and ("Bearer" in v)]
         assert any("Bearer" in v for v in header_values)
 
+    def test_token_attempt_preserves_retained_git_config(self) -> None:
+        """#2368: the auth header must not clobber indexed entries in git_env."""
+        dl = _make_downloader(token="ghp_token")
+        dl.auth_resolver.resolve_for_dep.return_value.token = "ghp_token"
+        dl.auth_resolver.resolve_for_dep.return_value.auth_scheme = "basic"
+        dl.git_env = {
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_KEY_0": "safe.bareRepository",
+            "GIT_CONFIG_VALUE_0": "explicit",
+        }
+        dep = self._make_dep()
+        dep.is_azure_devops.return_value = False
+        dl.auth_resolver.classify_host.return_value = MagicMock(kind="github")
+
+        attempts = _build_validation_attempts(dl, dep, lambda m: None)
+        token_env = attempts[0].env
+        assert token_env["GIT_CONFIG_COUNT"] == "2"
+        assert token_env["GIT_CONFIG_KEY_0"] == "safe.bareRepository"
+        assert token_env["GIT_CONFIG_VALUE_0"] == "explicit"
+        assert token_env["GIT_CONFIG_KEY_1"] == "http.extraheader"
+        assert token_env["GIT_CONFIG_VALUE_1"] == "Authorization: Bearer ghp_token"
+        # The downloader's shared base env must not be mutated.
+        assert dl.git_env["GIT_CONFIG_COUNT"] == "1"
+
 
 # ---------------------------------------------------------------------------
 # _ref_exists_via_ls_remote

--- a/tests/unit/deps/test_github_throttle_fallback.py
+++ b/tests/unit/deps/test_github_throttle_fallback.py
@@ -177,6 +177,42 @@ def test_private_fallback_uses_only_auth_resolver_git_environment() -> None:
     assert url.call_args.kwargs["token"] == ""
 
 
+def test_private_fallback_appends_header_after_retained_git_config() -> None:
+    """#2368: the auth header must not clobber retained GIT_CONFIG entries."""
+    host = _host(token="private-token")
+    host.auth_resolver.resolve_for_dep.return_value.git_env = {
+        "GIT_TOKEN": "private-token",
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "safe.bareRepository",
+        "GIT_CONFIG_VALUE_0": "explicit",
+    }
+    delegate = DownloadDelegate(host)
+    transport = MagicMock()
+    transport.fetch_file_with_commit.return_value = GitFileFetchResult(b"content", _SHA)
+
+    with (
+        patch(
+            "apm_cli.deps.download_strategies.GitSparseFileTransport",
+            return_value=transport,
+        ) as transport_factory,
+        patch.object(delegate, "build_repo_url", return_value="https://github.com/owner/repo.git"),
+    ):
+        delegate.download_github_file_via_throttle_fallback(
+            _dep(),
+            "instructions/example.instructions.md",
+            "main",
+            GitHubThrottleError(GitHubThrottle(429, "http-429"), "github.com"),
+        )
+
+    git_env = transport_factory.call_args.kwargs["git_env"]
+    assert git_env["GIT_CONFIG_COUNT"] == "2"
+    assert git_env["GIT_CONFIG_KEY_0"] == "safe.bareRepository"
+    assert git_env["GIT_CONFIG_VALUE_0"] == "explicit"
+    assert git_env["GIT_CONFIG_KEY_1"] == "http.extraheader"
+    assert git_env["GIT_CONFIG_VALUE_1"] == "Authorization: Bearer private-token"
+    assert "GIT_TOKEN" not in git_env
+
+
 def test_public_fallback_uses_normal_git_environment() -> None:
     """Public fallback excludes downloader auth state and uses normal Git."""
     host = _host(token=None)

--- a/tests/unit/deps/test_github_throttle_fallback.py
+++ b/tests/unit/deps/test_github_throttle_fallback.py
@@ -1,4 +1,4 @@
-"""Focused contracts for the virtual-file GitHub throttle fallback."""
+﻿"""Focused contracts for the virtual-file GitHub throttle fallback."""
 
 from __future__ import annotations
 
@@ -177,7 +177,7 @@ def test_private_fallback_uses_only_auth_resolver_git_environment() -> None:
     assert url.call_args.kwargs["token"] == ""
 
 
-def test_private_fallback_appends_header_after_retained_git_config() -> None:
+def test_private_fallback_sets_header_after_retained_git_config() -> None:
     """#2368: the auth header must not clobber retained GIT_CONFIG entries."""
     host = _host(token="private-token")
     host.auth_resolver.resolve_for_dep.return_value.git_env = {

--- a/tests/unit/deps/test_github_throttle_fallback.py
+++ b/tests/unit/deps/test_github_throttle_fallback.py
@@ -1,4 +1,4 @@
-﻿"""Focused contracts for the virtual-file GitHub throttle fallback."""
+"""Focused contracts for the virtual-file GitHub throttle fallback."""
 
 from __future__ import annotations
 

--- a/tests/unit/deps/test_shared_clone_cache.py
+++ b/tests/unit/deps/test_shared_clone_cache.py
@@ -1250,10 +1250,6 @@ class TestAdoBareBearerRetry:
                 "apm_cli.core.azure_cli.get_bearer_provider",
                 return_value=bearer_provider,
             ),
-            patch(
-                "apm_cli.utils.github_host.build_ado_bearer_git_env",
-                return_value={"GIT_CONFIG_COUNT": "1"},
-            ),
         ):
             d._bare_clone_with_fallback(
                 "https://pat-url/o/r",

--- a/tests/unit/marketplace/test_client_ado.py
+++ b/tests/unit/marketplace/test_client_ado.py
@@ -117,6 +117,19 @@ def test_ado_auth_header_bearer_detected_from_git_env() -> None:
     assert _ado_auth_header("jwt-xyz", git_env) == {"Authorization": "Bearer jwt-xyz"}
 
 
+def test_ado_auth_header_bearer_detected_at_any_config_index() -> None:
+    """#2368: the bearer header is appended after retained entries, so the
+    scheme sniff must scan every GIT_CONFIG_VALUE_ slot, not just index 0."""
+    git_env = {
+        "GIT_CONFIG_COUNT": "2",
+        "GIT_CONFIG_KEY_0": "http.sslCAInfo",
+        "GIT_CONFIG_VALUE_0": "/corporate/ca.pem",
+        "GIT_CONFIG_KEY_1": "http.extraheader",
+        "GIT_CONFIG_VALUE_1": "Authorization: Bearer jwt-xyz",
+    }
+    assert _ado_auth_header("jwt-xyz", git_env) == {"Authorization": "Bearer jwt-xyz"}
+
+
 # ---------------------------------------------------------------------------
 # _fetch_ado -- REST fast path
 # ---------------------------------------------------------------------------

--- a/tests/unit/marketplace/test_client_ado.py
+++ b/tests/unit/marketplace/test_client_ado.py
@@ -113,7 +113,13 @@ def test_ado_auth_header_pat_uses_basic() -> None:
 
 
 def test_ado_auth_header_bearer_detected_from_git_env() -> None:
-    git_env = {"GIT_CONFIG_VALUE_0": "Authorization: Bearer jwt-xyz"}
+    # GIT_CONFIG_COUNT accompanies the slot in every env APM builds; git reads
+    # nothing without it, and the sniff now honours the same bound.
+    git_env = {
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "http.extraheader",
+        "GIT_CONFIG_VALUE_0": "Authorization: Bearer jwt-xyz",
+    }
     assert _ado_auth_header("jwt-xyz", git_env) == {"Authorization": "Bearer jwt-xyz"}
 
 
@@ -128,6 +134,30 @@ def test_ado_auth_header_bearer_detected_at_any_config_index() -> None:
         "GIT_CONFIG_VALUE_1": "Authorization: Bearer jwt-xyz",
     }
     assert _ado_auth_header("jwt-xyz", git_env) == {"Authorization": "Bearer jwt-xyz"}
+
+
+def test_ado_auth_header_ignores_slots_beyond_the_configured_count() -> None:
+    """Only what git reads counts.
+
+    A slot above ``GIT_CONFIG_COUNT`` is a leftover or an injected entry; git
+    never applies it, so honouring it here would send the PAT under the Bearer
+    scheme and get it rejected.
+    """
+    git_env = {
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "http.sslCAInfo",
+        "GIT_CONFIG_VALUE_0": "/corporate/ca.pem",
+        "GIT_CONFIG_KEY_5": "http.extraheader",
+        "GIT_CONFIG_VALUE_5": "Authorization: Bearer not-ours",
+    }
+    expected = base64.b64encode(b":pat-123").decode("ascii")
+    assert _ado_auth_header("pat-123", git_env) == {"Authorization": f"Basic {expected}"}
+
+
+def test_ado_auth_header_tolerates_a_malformed_count() -> None:
+    git_env = {"GIT_CONFIG_COUNT": "not-a-number", "GIT_CONFIG_VALUE_0": "Authorization: Bearer x"}
+    expected = base64.b64encode(b":pat-123").decode("ascii")
+    assert _ado_auth_header("pat-123", git_env) == {"Authorization": f"Basic {expected}"}
 
 
 # ---------------------------------------------------------------------------
@@ -178,7 +208,11 @@ def test_fetch_ado_bearer_context_sends_bearer_header() -> None:
 
     resolver = _FakeResolver(
         token="jwt-xyz",
-        git_env={"GIT_CONFIG_VALUE_0": "Authorization: Bearer jwt-xyz"},
+        git_env={
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_KEY_0": "http.extraheader",
+            "GIT_CONFIG_VALUE_0": "Authorization: Bearer jwt-xyz",
+        },
     )
     with patch("apm_cli.marketplace.client._http_get", side_effect=fake_get):
         result = _fetch_ado(

--- a/tests/unit/marketplace/test_ref_resolver.py
+++ b/tests/unit/marketplace/test_ref_resolver.py
@@ -792,9 +792,15 @@ class TestRefResolverTokenInjection:
         assert parsed.hostname == "dev.azure.com"
         assert parsed.username is None
         env = mock_run.call_args.kwargs["env"]
-        assert env["GIT_CONFIG_KEY_0"] == "http.extraheader"
+        # Header index is not fixed (#2368: appended after retained entries),
+        # so locate it instead of assuming slot 0.
         expected = base64.b64encode(b":ado_pat").decode()
-        assert env["GIT_CONFIG_VALUE_0"] == f"Authorization: Basic {expected}"
+        headers = [
+            (env[f"GIT_CONFIG_KEY_{i}"], v)
+            for i in range(int(env["GIT_CONFIG_COUNT"]))
+            if "Authorization" in (v := env[f"GIT_CONFIG_VALUE_{i}"])
+        ]
+        assert headers == [("http.extraheader", f"Authorization: Basic {expected}")]
 
     def test_ado_ssh_transport_skips_bearer_retry(self) -> None:
         """SSH transport never retries an ADO PAT as an HTTP bearer flow."""

--- a/tests/unit/marketplace/test_ref_resolver.py
+++ b/tests/unit/marketplace/test_ref_resolver.py
@@ -818,3 +818,75 @@ class TestRefResolverTokenInjection:
                 resolver.list_remote_refs("contoso/platform/repo")
 
         auth_resolver.execute_with_bearer_fallback.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# #2368: auth header injection must preserve retained GIT_CONFIG entries
+# ---------------------------------------------------------------------------
+
+
+class TestGitUrlAndEnvPreservesRetainedGitConfig:
+    """The env returned by _git_url_and_env must keep non-auth git config."""
+
+    @staticmethod
+    def _retained() -> dict[str, str]:
+        return {
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_KEY_0": "http.sslCAInfo",
+            "GIT_CONFIG_VALUE_0": "/corporate/ca.pem",
+        }
+
+    def test_ado_bearer_appends_after_retained_entries(self) -> None:
+        resolver = RefResolver(
+            host="dev.azure.com",
+            token="aad-jwt",
+            auth_scheme="bearer",
+            git_env=self._retained(),
+        )
+        _url, env = resolver._git_url_and_env("contoso/platform/repo")
+        assert env["GIT_CONFIG_COUNT"] == "2"
+        assert env["GIT_CONFIG_KEY_0"] == "http.sslCAInfo"
+        assert env["GIT_CONFIG_VALUE_0"] == "/corporate/ca.pem"
+        assert env["GIT_CONFIG_KEY_1"] == "http.extraheader"
+        assert env["GIT_CONFIG_VALUE_1"] == "Authorization: Bearer aad-jwt"
+        resolver.close()
+
+    def test_ado_basic_appends_after_retained_entries(self) -> None:
+        resolver = RefResolver(
+            host="dev.azure.com",
+            token="ado_pat",
+            auth_scheme="basic",
+            git_env=self._retained(),
+        )
+        _url, env = resolver._git_url_and_env("contoso/platform/repo")
+        expected = base64.b64encode(b":ado_pat").decode()
+        assert env["GIT_CONFIG_COUNT"] == "2"
+        assert env["GIT_CONFIG_KEY_0"] == "http.sslCAInfo"
+        assert env["GIT_CONFIG_KEY_1"] == "http.extraheader"
+        assert env["GIT_CONFIG_VALUE_1"] == f"Authorization: Basic {expected}"
+        resolver.close()
+
+    def test_ado_bearer_replaces_stale_header_instead_of_stacking(self) -> None:
+        stale = {
+            "GIT_CONFIG_COUNT": "2",
+            "GIT_CONFIG_KEY_0": "http.extraheader",
+            "GIT_CONFIG_VALUE_0": "Authorization: Bearer stale-jwt",
+            "GIT_CONFIG_KEY_1": "http.sslCAInfo",
+            "GIT_CONFIG_VALUE_1": "/corporate/ca.pem",
+        }
+        resolver = RefResolver(
+            host="dev.azure.com",
+            token="fresh-jwt",
+            auth_scheme="bearer",
+            git_env=stale,
+        )
+        _url, env = resolver._git_url_and_env("contoso/platform/repo")
+        headers = [
+            v
+            for k, v in env.items()
+            if k.startswith("GIT_CONFIG_VALUE_") and "Authorization" in str(v)
+        ]
+        assert headers == ["Authorization: Bearer fresh-jwt"]
+        assert env["GIT_CONFIG_COUNT"] == "2"
+        assert env["GIT_CONFIG_KEY_0"] == "http.sslCAInfo"
+        resolver.close()

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1072,6 +1072,30 @@ class TestBuildGitEnvBearerIsolation:
             env = AuthResolver._build_git_env("a-pat", scheme="basic", host_kind="github")
         assert env.get("GIT_TOKEN") == "a-pat"
 
+    def test_bearer_env_preserves_retained_git_config_entries(self):
+        """#2368: the bearer header must not clobber entries _clear_git_auth_env retained.
+
+        ``_clear_git_auth_env`` deliberately keeps inherited non-auth git
+        config (e.g. a corporate CA pin) re-indexed from 0. The bearer
+        header must be appended after those entries, not merged in with a
+        hardcoded ``GIT_CONFIG_COUNT=1`` overlay that overwrites index 0.
+        """
+        inherited = {
+            "GIT_CONFIG_COUNT": "2",
+            "GIT_CONFIG_KEY_0": "http.extraHeader",
+            "GIT_CONFIG_VALUE_0": "Authorization: inherited-secret",
+            "GIT_CONFIG_KEY_1": "http.sslCAInfo",
+            "GIT_CONFIG_VALUE_1": "/corporate/ca.pem",
+        }
+        with patch.dict(os.environ, inherited, clear=False):
+            env = AuthResolver._build_git_env("fresh-jwt", scheme="bearer", host_kind="ado")
+        assert env["GIT_CONFIG_COUNT"] == "2"
+        assert env["GIT_CONFIG_KEY_0"] == "http.sslCAInfo"
+        assert env["GIT_CONFIG_VALUE_0"] == "/corporate/ca.pem"
+        assert env["GIT_CONFIG_KEY_1"] == "http.extraheader"
+        assert env["GIT_CONFIG_VALUE_1"] == "Authorization: Bearer fresh-jwt"
+        assert not any("inherited-secret" in str(v) for v in env.values())
+
 
 # ---------------------------------------------------------------------------
 # TestHostInfoPort -- port field + display_name property

--- a/tests/unit/test_github_host.py
+++ b/tests/unit/test_github_host.py
@@ -542,6 +542,41 @@ def test_set_ado_bearer_git_env_delegates_with_bearer_scheme():
     assert env["GIT_CONFIG_VALUE_1"] == "Authorization: Bearer aad-jwt"
 
 
+@pytest.mark.parametrize(
+    ("scheme", "credential"),
+    [
+        ("Bearer", "tok\r\nGIT_CONFIG_KEY_9: injected"),
+        ("Bearer\r\nEvil", "tok"),
+        ("Bearer", "tok\ninjected"),
+    ],
+)
+def test_set_authorization_header_rejects_crlf_in_scheme_or_credential(scheme, credential):
+    """Defense-in-depth: a CR/LF in scheme or credential could smuggle a second
+    git-config entry into the appended value; reject it before it is written.
+    """
+    env = {"GIT_CONFIG_COUNT": "0"}
+    with pytest.raises(ValueError, match="CR or LF"):
+        github_host.set_authorization_header_git_env(env, scheme, credential)
+    # Reject-before-mutate: no partial write on the rejected call.
+    assert env == {"GIT_CONFIG_COUNT": "0"}
+
+
+def test_set_authorization_header_does_not_false_positive_on_substring_authorization():
+    """A retained non-auth value that merely CONTAINS 'authorization' as a
+    substring (not an actual Authorization: header) must survive the filter.
+    """
+    env = {
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "http.proxy",
+        "GIT_CONFIG_VALUE_0": "http://authorization-proxy.corp.example:3128",
+    }
+    github_host.set_authorization_header_git_env(env, "Bearer", "tok")
+    assert env["GIT_CONFIG_COUNT"] == "2"
+    assert env["GIT_CONFIG_KEY_0"] == "http.proxy"
+    assert env["GIT_CONFIG_VALUE_0"] == "http://authorization-proxy.corp.example:3128"
+    assert env["GIT_CONFIG_KEY_1"] == "http.extraheader"
+
+
 def test_unsupported_host_error_with_context():
     """Test that context message is included when provided."""
     error_msg = github_host.unsupported_host_error(

--- a/tests/unit/test_github_host.py
+++ b/tests/unit/test_github_host.py
@@ -437,6 +437,58 @@ def test_build_ado_bearer_git_env_does_not_url_encode():
     assert env["GIT_CONFIG_VALUE_0"] == f"Authorization: Bearer {token}"
 
 
+def test_append_authorization_header_preserves_existing_git_config_entries():
+    """#2368: appending must not reset GIT_CONFIG_COUNT or clobber index 0."""
+    env = {
+        "GIT_CONFIG_COUNT": "2",
+        "GIT_CONFIG_KEY_0": "safe.bareRepository",
+        "GIT_CONFIG_VALUE_0": "explicit",
+        "GIT_CONFIG_KEY_1": "credential.interactive",
+        "GIT_CONFIG_VALUE_1": "never",
+    }
+    github_host.append_authorization_header_git_env(env, "Bearer", "tok")
+    assert env["GIT_CONFIG_COUNT"] == "3"
+    assert env["GIT_CONFIG_KEY_0"] == "safe.bareRepository"
+    assert env["GIT_CONFIG_VALUE_0"] == "explicit"
+    assert env["GIT_CONFIG_KEY_1"] == "credential.interactive"
+    assert env["GIT_CONFIG_VALUE_1"] == "never"
+    assert env["GIT_CONFIG_KEY_2"] == "http.extraheader"
+    assert env["GIT_CONFIG_VALUE_2"] == "Authorization: Bearer tok"
+
+
+def test_append_authorization_header_on_empty_base_matches_build_helper():
+    """Without prior entries, append degenerates to the build overlay."""
+    env = {"OTHER": "1"}
+    github_host.append_authorization_header_git_env(env, "Basic", "dXNlcjpwYXNz")
+    assert env["GIT_CONFIG_COUNT"] == "1"
+    assert env["GIT_CONFIG_KEY_0"] == "http.extraheader"
+    assert env["GIT_CONFIG_VALUE_0"] == "Authorization: Basic dXNlcjpwYXNz"
+    assert env["OTHER"] == "1"
+
+
+def test_append_authorization_header_tolerates_blank_or_invalid_count():
+    """Empty or non-numeric GIT_CONFIG_COUNT is treated as zero entries."""
+    for bad_count in ("", "not-a-number", "-3"):
+        env = {"GIT_CONFIG_COUNT": bad_count}
+        github_host.append_authorization_header_git_env(env, "Bearer", "tok")
+        assert env["GIT_CONFIG_COUNT"] == "1"
+        assert env["GIT_CONFIG_KEY_0"] == "http.extraheader"
+
+
+def test_append_ado_bearer_git_env_delegates_with_bearer_scheme():
+    """ADO append wrapper mirrors build_ado_bearer_git_env semantics."""
+    env = {
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "safe.bareRepository",
+        "GIT_CONFIG_VALUE_0": "explicit",
+    }
+    github_host.append_ado_bearer_git_env(env, "aad-jwt")
+    assert env["GIT_CONFIG_COUNT"] == "2"
+    assert env["GIT_CONFIG_KEY_0"] == "safe.bareRepository"
+    assert env["GIT_CONFIG_KEY_1"] == "http.extraheader"
+    assert env["GIT_CONFIG_VALUE_1"] == "Authorization: Bearer aad-jwt"
+
+
 def test_unsupported_host_error_with_context():
     """Test that context message is included when provided."""
     error_msg = github_host.unsupported_host_error(

--- a/tests/unit/test_github_host.py
+++ b/tests/unit/test_github_host.py
@@ -437,8 +437,8 @@ def test_build_ado_bearer_git_env_does_not_url_encode():
     assert env["GIT_CONFIG_VALUE_0"] == f"Authorization: Bearer {token}"
 
 
-def test_append_authorization_header_preserves_existing_git_config_entries():
-    """#2368: appending must not reset GIT_CONFIG_COUNT or clobber index 0."""
+def test_set_authorization_header_preserves_existing_git_config_entries():
+    """#2368: setting the header must not reset GIT_CONFIG_COUNT or clobber index 0."""
     env = {
         "GIT_CONFIG_COUNT": "2",
         "GIT_CONFIG_KEY_0": "safe.bareRepository",
@@ -446,7 +446,7 @@ def test_append_authorization_header_preserves_existing_git_config_entries():
         "GIT_CONFIG_KEY_1": "credential.interactive",
         "GIT_CONFIG_VALUE_1": "never",
     }
-    github_host.append_authorization_header_git_env(env, "Bearer", "tok")
+    github_host.set_authorization_header_git_env(env, "Bearer", "tok")
     assert env["GIT_CONFIG_COUNT"] == "3"
     assert env["GIT_CONFIG_KEY_0"] == "safe.bareRepository"
     assert env["GIT_CONFIG_VALUE_0"] == "explicit"
@@ -456,33 +456,86 @@ def test_append_authorization_header_preserves_existing_git_config_entries():
     assert env["GIT_CONFIG_VALUE_2"] == "Authorization: Bearer tok"
 
 
-def test_append_authorization_header_on_empty_base_matches_build_helper():
-    """Without prior entries, append degenerates to the build overlay."""
+def test_set_authorization_header_on_empty_base_matches_build_helper():
+    """Without prior entries, the in-place set degenerates to the build overlay."""
     env = {"OTHER": "1"}
-    github_host.append_authorization_header_git_env(env, "Basic", "dXNlcjpwYXNz")
+    github_host.set_authorization_header_git_env(env, "Basic", "dXNlcjpwYXNz")
     assert env["GIT_CONFIG_COUNT"] == "1"
     assert env["GIT_CONFIG_KEY_0"] == "http.extraheader"
     assert env["GIT_CONFIG_VALUE_0"] == "Authorization: Basic dXNlcjpwYXNz"
     assert env["OTHER"] == "1"
 
 
-def test_append_authorization_header_tolerates_blank_or_invalid_count():
+def test_set_authorization_header_tolerates_blank_or_invalid_count():
     """Empty or non-numeric GIT_CONFIG_COUNT is treated as zero entries."""
     for bad_count in ("", "not-a-number", "-3"):
         env = {"GIT_CONFIG_COUNT": bad_count}
-        github_host.append_authorization_header_git_env(env, "Bearer", "tok")
+        github_host.set_authorization_header_git_env(env, "Bearer", "tok")
         assert env["GIT_CONFIG_COUNT"] == "1"
         assert env["GIT_CONFIG_KEY_0"] == "http.extraheader"
 
 
-def test_append_ado_bearer_git_env_delegates_with_bearer_scheme():
-    """ADO append wrapper mirrors build_ado_bearer_git_env semantics."""
+def test_set_authorization_header_replaces_inherited_auth_header():
+    """An inherited Authorization entry is replaced, never duplicated.
+
+    Sending two Authorization headers (stale + fresh) breaks auth; the
+    helper applies the same auth-channel policy as _clear_git_auth_env.
+    """
+    env = {
+        "GIT_CONFIG_COUNT": "2",
+        "GIT_CONFIG_KEY_0": "http.extraHeader",
+        "GIT_CONFIG_VALUE_0": "Authorization: Bearer stale",
+        "GIT_CONFIG_KEY_1": "http.sslCAInfo",
+        "GIT_CONFIG_VALUE_1": "/corporate/ca.pem",
+    }
+    github_host.set_authorization_header_git_env(env, "Bearer", "fresh")
+    assert env["GIT_CONFIG_COUNT"] == "2"
+    assert env["GIT_CONFIG_KEY_0"] == "http.sslCAInfo"
+    assert env["GIT_CONFIG_VALUE_0"] == "/corporate/ca.pem"
+    assert env["GIT_CONFIG_KEY_1"] == "http.extraheader"
+    assert env["GIT_CONFIG_VALUE_1"] == "Authorization: Bearer fresh"
+    assert not any("stale" in v for v in env.values())
+
+
+def test_set_authorization_header_is_idempotent_under_layering():
+    """Two layered calls (e.g. _build_git_env then a retry wrapper) keep one header."""
     env = {
         "GIT_CONFIG_COUNT": "1",
         "GIT_CONFIG_KEY_0": "safe.bareRepository",
         "GIT_CONFIG_VALUE_0": "explicit",
     }
-    github_host.append_ado_bearer_git_env(env, "aad-jwt")
+    github_host.set_authorization_header_git_env(env, "Bearer", "jwt")
+    github_host.set_authorization_header_git_env(env, "Bearer", "jwt")
+    assert env["GIT_CONFIG_COUNT"] == "2"
+    assert env["GIT_CONFIG_KEY_0"] == "safe.bareRepository"
+    assert env["GIT_CONFIG_KEY_1"] == "http.extraheader"
+    assert "GIT_CONFIG_KEY_2" not in env
+
+
+def test_set_authorization_header_drops_orphaned_indexed_entries():
+    """Stale KEY_/VALUE_ orphans beyond the count must not linger in the env."""
+    env = {
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "safe.bareRepository",
+        "GIT_CONFIG_VALUE_0": "explicit",
+        "GIT_CONFIG_KEY_5": "http.extraheader",
+        "GIT_CONFIG_VALUE_5": "Authorization: Bearer orphaned-secret",
+    }
+    github_host.set_authorization_header_git_env(env, "Bearer", "fresh")
+    assert env["GIT_CONFIG_COUNT"] == "2"
+    assert "GIT_CONFIG_KEY_5" not in env
+    assert "GIT_CONFIG_VALUE_5" not in env
+    assert not any("orphaned-secret" in v for v in env.values())
+
+
+def test_set_ado_bearer_git_env_delegates_with_bearer_scheme():
+    """ADO in-place wrapper mirrors build_ado_bearer_git_env semantics."""
+    env = {
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "safe.bareRepository",
+        "GIT_CONFIG_VALUE_0": "explicit",
+    }
+    github_host.set_ado_bearer_git_env(env, "aad-jwt")
     assert env["GIT_CONFIG_COUNT"] == "2"
     assert env["GIT_CONFIG_KEY_0"] == "safe.bareRepository"
     assert env["GIT_CONFIG_KEY_1"] == "http.extraheader"


### PR DESCRIPTION
## Description

`build_authorization_header_git_env()` / `build_ado_bearer_git_env()` return an overlay whose `GIT_CONFIG_COUNT` is hardcoded to `"1"`. Dict-merging that onto a base env that already carries indexed git config entries (`GIT_CONFIG_COUNT=N`, keys `0..N-1`) resets the count and overwrites index 0, silently dropping inherited hardening such as `safe.bareRepository=explicit`, `credential.interactive=never`, or a corporate `http.sslCAInfo` pin.

The issue names two call sites and says the same defect was already fixed elsewhere via an append helper. That helper is not in the tree or in history — the other sites still dict-merge the overlay. An audit of every consumer of the overlay found five:

- `deps/clone_engine.py` — ADO bearer in-attempt retry (named in the issue)
- `deps/download_strategies.py` — GitHub sparse-git file fetch (named in the issue)
- `core/auth.py` `_build_git_env` — the bearer branch overwrote the very entries `_clear_git_auth_env` had just retained and re-indexed
- `marketplace/ref_resolver.py` — `_git_url_and_env` (bearer + ADO basic) and the ls-remote bearer retry
- `deps/github_downloader_validation.py` — validation attempt env construction

Fixes #2368

## Approach

`set_authorization_header_git_env` / `set_ado_bearer_git_env` rewrite the indexed set in place: existing auth-channel entries are removed so layered callers cannot stack duplicate `Authorization` headers, every other entry is preserved and re-indexed, orphaned `GIT_CONFIG_KEY_/VALUE_` entries at or beyond the count are dropped so no stale credential lingers in the child-process env table, and the new header is appended last.

Because the header no longer sits at a fixed index, `marketplace/client.py`'s `_ado_auth_header` — which sniffed `GIT_CONFIG_VALUE_0` to tell an AAD bearer from a PAT — now scans the indexed set, bounded by `GIT_CONFIG_COUNT` because that is all git itself reads. Two tests that hardcoded the header at index 0 locate it instead; they previously passed only in environments without ambient `GIT_CONFIG_*` entries.

The `build_*` helpers remain for fresh-overlay construction, with a docstring warning against dict-merging them onto a populated env.

## Considered and not done here

The retain/re-index policy in the new setter mirrors `AuthResolver._clear_git_auth_env`. Extracting it into a shared primitive (`utils/git_env.py` would be the right home) is the better end state, but it means editing a security-critical function this bug does not otherwise touch, inside a fix that needs to stay reviewable. The two are cross-referenced in the docstrings; happy to do the extraction as a follow-up if preferred.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

Helper unit tests cover preservation, replacement of an inherited stale header, layering idempotence, orphan cleanup, and blank/invalid counts. Per-site regression tests cover all five call sites plus the `_ado_auth_header` sniff, and each was verified to fail against the pre-fix code.

The touched suites also pass with `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=safe.bareRepository GIT_CONFIG_VALUE_0=explicit` exported in the shell — the environment this fix is about.

## Spec conformance (OpenAPM v0.1)

- [x] N/A -- this PR does not change OpenAPM-observable behaviour.
