### PR TITLE
fix(mcp): render a docker launcher for v0.1 oci container packages

### DIFF
--- a/.apm/instructions/architecture.instructions.md
+++ b/.apm/instructions/architecture.instructions.md
@@ -58,6 +58,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | GitHub API throttle classification | deps/github_rate_limit.py | `src/apm_cli/deps/github_rate_limit.py` |
 | Git ref freshness and cache eligibility | deps/tiered_ref_resolver.py (RefFreshnessPolicy) | `src/apm_cli/deps/tiered_ref_resolver.py` |
 | Root vs dependency MCP declaration scope | integration/mcp_config_view.py (CurrentMcpConfigView) | `src/apm_cli/integration/mcp_config_view.py` |
+| MCP container launcher selection and Docker argv shape | adapters/client/base.py (MCPClientAdapter) | `src/apm_cli/adapters/client/base.py` |
 <!-- /canonical-owner-table -->
 
 Host + credential resolution includes public github.com anonymous-first ordering.

--- a/.github/instructions/architecture.instructions.md
+++ b/.github/instructions/architecture.instructions.md
@@ -58,6 +58,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | GitHub API throttle classification | deps/github_rate_limit.py | `src/apm_cli/deps/github_rate_limit.py` |
 | Git ref freshness and cache eligibility | deps/tiered_ref_resolver.py (RefFreshnessPolicy) | `src/apm_cli/deps/tiered_ref_resolver.py` |
 | Root vs dependency MCP declaration scope | integration/mcp_config_view.py (CurrentMcpConfigView) | `src/apm_cli/integration/mcp_config_view.py` |
+| MCP container launcher selection and Docker argv shape | adapters/client/base.py (MCPClientAdapter) | `src/apm_cli/adapters/client/base.py` |
 <!-- /canonical-owner-table -->
 
 Host + credential resolution includes public github.com anonymous-first ordering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   state; frozen install fails without writing when that state is missing or
   stale. The matching `openapm-v0.1.md` frozen-install requirement now covers
   MCP state and all durable writes. (by @edenfunf, #2390; fixes #2373)
+- MCP servers whose registry entry uses the MCP Registry v0.1 container type
+  `oci` now render a `docker` launcher. They previously matched no launcher
+  branch and fell through to the generic `npx` default, which handed the
+  container image reference to npm as a package name. (by @edenfunf, #2376)
+
+### Changed
+
+- A server publishing both a container and a pypi package now resolves to the
+  container on Copilot, Codex, Gemini and the adapters inheriting them,
+  following the documented `npm, docker, pypi` selection order. Such a server
+  previously fell through to `uvx` and now requires a Docker daemon. VS Code
+  keeps its own `npm, pypi, docker` order. (by @edenfunf, #2376)
 
 - Consuming projects no longer inherit a dependency author's development-only
   MCP servers. Only `dependencies.mcp` from direct and transitive packages

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,6 +1,6 @@
 lockfile_version: '1'
-generated_at: '2026-07-16T10:55:54.310339+00:00'
-apm_version: 0.25.0
+generated_at: '2026-07-31T12:14:04.210842+00:00'
+apm_version: 0.26.0
 dependencies:
 - repo_url: _local/apm-issue-autopilot
   name: apm-issue-autopilot
@@ -275,384 +275,6 @@ dependencies:
 deployments:
 - kind: project-relative
   target: agents
-  value: .agents/skills/apm-issue-autopilot
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:9872bd7ada9903073c663a5b1d1bfaa15743d4bcb2f450631a4da610b1fd0a6e
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/assets/acceptance-observer.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:e4ddab439f62bb372f5ad608775294dd44653ef475eeca8ef5517af7f5e42699
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/assets/autopilot-triage-schema.json
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:35d672ce4584fb576b3c16ce4dffbe29de6b3f6711725855b3c6eb0f338d464d
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/assets/confidence-gate-rubric.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:2d6eff739cd4ac1eb4533868cbdcf0c44d469ae247447f29595d05858b2d8a97
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/assets/final-report-template.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:8088fe8f5bb9fd1ec93fbe806971465bb7f6850019af5be1a329e252d4818df2
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/assets/ground-truth-table.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:00dd5a35ef0b39ba299e5fcd7f9ca682fc322792ec20440f7861edd39997d40e
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/assets/ideate-prompt.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:abab1a5e2a765229d1cdd215b90c57036cdb4b2764866b68399eb81a51362ddc
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/assets/implement-bug.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:4c74c8dfa0f98987ab5beede16d3e8c0e8113fac60955826d2ed61949624bcc5
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/assets/implement-docs.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:81f2f9b617587df4a6f422838b05c63a5e05e0c8afd6d80952a9aa5cdad88b5a
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/assets/implement-feature.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:394b25a0b0b41b0f99b250590af782968c0f25673c156d0b87d4f1f9b205de75
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/assets/implement-refactor.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:5175ea7edefdaaf787d1701ba6f7fce8433d04134718d9a6445ca524ececa3bc
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/assets/model-routing.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:4d1ffaf63fab75a7a7de265ff77d457c0636939d36a373dc9ce485ba76275209
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/assets/plan-panel-prompt.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:422daafc8fcdf26f1096787075b2e8c15722df6b51e1d1784ea3b1435809b09f
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/assets/plan-schema.json
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:f766382fbac2a2b99c0dad1d0327659103c4482cc155854ea7ef2e3c82fce8f2
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/assets/solution-pipeline-prompt.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:812487116b89e66414562312992204dfb3132cc5e9265392b718d78e33cd9973
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/assets/task-implement-prompt.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:397ab60c270f0312a3ddaac0fbc03e853fa16552a962f6b2ebca5ed27bab2818
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/assets/triage-digest-template.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:78c2e7be93543122e485eb494a2b50ecac6e18d7e077a9e8edde12b478242ca9
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/assets/triage-prompt.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:5136ab42be575b58730a8d8a1614394813014ca74e2d6df3e56948e94c419470
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/assets/wave-gate-rubric.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:a8bf5270c8d63c1d9ffcf0b3f18ba22d591b062e7b969982320150986ab211cd
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/evals/.gitignore
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:f370ad043ec0c98a166fd98646c3b94280ed78bc996223b6cca2ba936f7c6781
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/evals/README.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:79bb6636a89edce40fc24bde9576e351de57a0f828181def37c423a284cd1ef8
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/evals/content/gate-escalate-doubtful.json
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:20bcabed2b58be8552421f68e9522cea3a1206a1796c26d2f77e65a3982d438f
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/evals/content/gate-proceed-clean-accept.json
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:f304138fe9aafe48989710bd2c68238342b32e643281f9747c0678b7cb1ae244
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/evals/content/mixed-types-one-review.json
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:df2b1b66e1ec64743cc8d66e465e5cca931de6fb51974cc51c81908efad58eb5
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/evals/evals.json
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:a94ed339f171e7ca557df3e7ed10c8e55f9a14befcba940b7263c9d7fe4d8ca1
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/evals/real-task-refinement.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:183d6d7270dc5f865a02d42643ba0afbae9046509f0e3b2481559fc9c1dcb64a
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/evals/triggers.json
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:59bbb6e937d6de8db69aee4478989fccff561c77e86cc6894e7994eb841defd0
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-issue-autopilot/scripts/run_evals.py
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/apm-issue-autopilot
-  active_owner: ./packages/apm-issue-autopilot
-  content_hash: sha256:8f4580cb2bdb88e7e570e4feb60cbf244d7fbe3e8217a8eadfd9dff2c763b615
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-review-panel
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/apm-review-panel
-  active_owner: local:packages/apm-review-panel
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-review-panel/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/apm-review-panel
-  active_owner: local:packages/apm-review-panel
-  content_hash: sha256:c9fee6c311b23b6ea72b06a424c8ba21c5d88bcc833e65259b7e0212aa73abbb
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-review-panel/apm.yml
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/apm-review-panel
-  active_owner: local:packages/apm-review-panel
-  content_hash: sha256:80c403c4d3c59a91bb27b85650e21a466e9cd0cbc28e92bf0f3e53c6ea71cb2c
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-review-panel/assets/ceo-return-schema.json
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/apm-review-panel
-  active_owner: local:packages/apm-review-panel
-  content_hash: sha256:d8707211968efb0471d083f880d5353d66a0eda84635e803a930f60c91837468
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-review-panel/assets/panelist-return-schema.json
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/apm-review-panel
-  active_owner: local:packages/apm-review-panel
-  content_hash: sha256:e3cf2ae17e93dd934f2659ed77d2640ea9601fbe8698f63ba800edf046691f99
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-review-panel/assets/recommendation-template.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/apm-review-panel
-  active_owner: local:packages/apm-review-panel
-  content_hash: sha256:ed973263897671ea04c980cb54c76b33aaa9bb7d1b5b24082df89b388d4329b8
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-review-panel/evals/README.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/apm-review-panel
-  active_owner: local:packages/apm-review-panel
-  content_hash: sha256:40e7abb1fa15403a71505797e23dde8433f31ca70546657886c3f9760974bfb8
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-review-panel/evals/fixtures/01-ship-now-pr1084-shape.json
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/apm-review-panel
-  active_owner: local:packages/apm-review-panel
-  content_hash: sha256:108fc261680f17bdade3e2bdf8e64fc908d16a37ec9c29c53169b394530bdd67
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-review-panel/evals/fixtures/01-ship-now-pr1084-shape.rendered.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/apm-review-panel
-  active_owner: local:packages/apm-review-panel
-  content_hash: sha256:ca1fdd3cd24e0fd8ec15b37690c597921ebf1c872270166edb2727d54ee155d8
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-review-panel/evals/fixtures/02-needs-rework-shape.json
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/apm-review-panel
-  active_owner: local:packages/apm-review-panel
-  content_hash: sha256:faa41c6c83c4a7955447bcb8fc0ad5a3b8afb4235db257462f649ba0a901913e
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-review-panel/evals/fixtures/02-needs-rework-shape.rendered.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/apm-review-panel
-  active_owner: local:packages/apm-review-panel
-  content_hash: sha256:b69cd113a428b61d8bbb9381a85261b3ee3acd3f101c08d06419e26aab03bba8
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-review-panel/evals/render_eval.py
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/apm-review-panel
-  active_owner: local:packages/apm-review-panel
-  content_hash: sha256:690baf6267775077ad011b98839eda1001e207bbae78a7a8454c4d39bb8a2864
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-review-panel/evals/trigger-evals.json
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/apm-review-panel
-  active_owner: local:packages/apm-review-panel
-  content_hash: sha256:c715ba52cd2131f294c1cf685a10995a08e4ee6971f97cf5d36e09df28d3af91
-- kind: project-relative
-  target: agents
   value: .agents/skills/apm-spec-guardian
   runtime: null
   scope: project
@@ -725,42 +347,6 @@ deployments:
   content_hash: sha256:6c7fbc821fef930ab76764c7b33d55bd181f31cdd406cff5ce7cf14d1071c2ef
 - kind: project-relative
   target: agents
-  value: .agents/skills/apm-triage-panel
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/apm-triage-panel
-  active_owner: local:packages/apm-triage-panel
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-triage-panel/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/apm-triage-panel
-  active_owner: local:packages/apm-triage-panel
-  content_hash: sha256:2ef70329aefd0cbec1302aad3975f6caa0a27654d58005bba622ef1021267d1e
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-triage-panel/apm.yml
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/apm-triage-panel
-  active_owner: local:packages/apm-triage-panel
-  content_hash: sha256:e8b7946f433abdc8342241483963bac2895182916ea66f5aa39497d00c7930a4
-- kind: project-relative
-  target: agents
-  value: .agents/skills/apm-triage-panel/assets/triage-template.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/apm-triage-panel
-  active_owner: local:packages/apm-triage-panel
-  content_hash: sha256:69a027959eaec5335668e087c86babd814ba20cf21662ed524cf285b178e21d1
-- kind: project-relative
-  target: agents
   value: .agents/skills/auth
   runtime: null
   scope: project
@@ -777,204 +363,6 @@ deployments:
   - .
   active_owner: .
   content_hash: sha256:bf1039cb63dbb968d50dbf4a9e4ceec9a4c30e40e8dd666d404f1c39eda55bc0
-- kind: project-relative
-  target: agents
-  value: .agents/skills/batch-bug-shepherd
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/batch-bug-shepherd
-  active_owner: ./packages/batch-bug-shepherd
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/batch-bug-shepherd/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/batch-bug-shepherd
-  active_owner: ./packages/batch-bug-shepherd
-  content_hash: sha256:c5b0f8752e726d123f61491c959681134882dfddbc9f5d15ac5c47e55931375f
-- kind: project-relative
-  target: agents
-  value: .agents/skills/batch-bug-shepherd/assets/final-report-template.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/batch-bug-shepherd
-  active_owner: ./packages/batch-bug-shepherd
-  content_hash: sha256:ea280a4d1e15a9b56ba8d3ef5f0e931754cc44ae29d5615da58da8d445f455c2
-- kind: project-relative
-  target: agents
-  value: .agents/skills/batch-bug-shepherd/assets/fix-prompt.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/batch-bug-shepherd
-  active_owner: ./packages/batch-bug-shepherd
-  content_hash: sha256:ea4fde3d619f12fc7e05f27d6b440b48f3ef66cb9509b2efb85aed66439438f9
-- kind: project-relative
-  target: agents
-  value: .agents/skills/batch-bug-shepherd/assets/ground-truth-table.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/batch-bug-shepherd
-  active_owner: ./packages/batch-bug-shepherd
-  content_hash: sha256:981ebeee98596beb6a00db6edb35a8e871acdd52a938faa8d8915edfd01ba15b
-- kind: project-relative
-  target: agents
-  value: .agents/skills/batch-bug-shepherd/assets/progress-diagram.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/batch-bug-shepherd
-  active_owner: ./packages/batch-bug-shepherd
-  content_hash: sha256:72c4606899f50b0761a7683f6ab17878472bc45b18fe03869aae65e3bd6a7bb2
-- kind: project-relative
-  target: agents
-  value: .agents/skills/batch-bug-shepherd/assets/strategic-alignment-prompt.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/batch-bug-shepherd
-  active_owner: ./packages/batch-bug-shepherd
-  content_hash: sha256:67db0bb51d6cbdafad4ea8224ab2012f02e6341b2fd4eb7a09b2a24cc9cb4d7e
-- kind: project-relative
-  target: agents
-  value: .agents/skills/batch-bug-shepherd/assets/triage-prompt.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/batch-bug-shepherd
-  active_owner: ./packages/batch-bug-shepherd
-  content_hash: sha256:51bab548ac85044400b77858c6a1554f59bda197c388d9a8546076d87380b060
-- kind: project-relative
-  target: agents
-  value: .agents/skills/batch-bug-shepherd/assets/verdict-schema.json
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/batch-bug-shepherd
-  active_owner: ./packages/batch-bug-shepherd
-  content_hash: sha256:d82b7ed0791b89617be965097fce1ace9ec6f6b5a33d9a1567cdf4b3651cd83a
-- kind: project-relative
-  target: agents
-  value: .agents/skills/batch-bug-shepherd/evals/.gitignore
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/batch-bug-shepherd
-  active_owner: ./packages/batch-bug-shepherd
-  content_hash: sha256:f370ad043ec0c98a166fd98646c3b94280ed78bc996223b6cca2ba936f7c6781
-- kind: project-relative
-  target: agents
-  value: .agents/skills/batch-bug-shepherd/evals/README.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/batch-bug-shepherd
-  active_owner: ./packages/batch-bug-shepherd
-  content_hash: sha256:7d0a5c983612953289a8e34c0b95995ccad7273653c4ab145c3f10b9adafa905
-- kind: project-relative
-  target: agents
-  value: .agents/skills/batch-bug-shepherd/evals/content/sweep-bug-queue.json
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/batch-bug-shepherd
-  active_owner: ./packages/batch-bug-shepherd
-  content_hash: sha256:f865943bbe523d22555d6e69834f47364237ce27388cb7732795a6887f6820ee
-- kind: project-relative
-  target: agents
-  value: .agents/skills/batch-bug-shepherd/evals/content/three-issues-mixed.json
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/batch-bug-shepherd
-  active_owner: ./packages/batch-bug-shepherd
-  content_hash: sha256:9c2b0f108e958fc7d779cb9222339b12310307f7a2a2c87d83c715d0d0c3460b
-- kind: project-relative
-  target: agents
-  value: .agents/skills/batch-bug-shepherd/evals/evals.json
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/batch-bug-shepherd
-  active_owner: ./packages/batch-bug-shepherd
-  content_hash: sha256:0b47a8ea4c49c375a575d0f44d488b65c0d797bff5022ebb79746808495dab26
-- kind: project-relative
-  target: agents
-  value: .agents/skills/batch-bug-shepherd/evals/fixtures/sweep-bug-queue.with_skill.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/batch-bug-shepherd
-  active_owner: ./packages/batch-bug-shepherd
-  content_hash: sha256:0dbfab6bc74cb2b92bbf25d08196b1405669a3e6841be41915f00a1ea54ff950
-- kind: project-relative
-  target: agents
-  value: .agents/skills/batch-bug-shepherd/evals/fixtures/sweep-bug-queue.without_skill.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/batch-bug-shepherd
-  active_owner: ./packages/batch-bug-shepherd
-  content_hash: sha256:83a2a11ac6dc2a188bb95a92f24dc7f94568f8af30ec4979ae85f52bd3102ee6
-- kind: project-relative
-  target: agents
-  value: .agents/skills/batch-bug-shepherd/evals/fixtures/three-issues-mixed.with_skill.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/batch-bug-shepherd
-  active_owner: ./packages/batch-bug-shepherd
-  content_hash: sha256:ab8707f0842af611fe135029a7002356a0bececfbb3abbe442dbc196d48be7ed
-- kind: project-relative
-  target: agents
-  value: .agents/skills/batch-bug-shepherd/evals/fixtures/three-issues-mixed.without_skill.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/batch-bug-shepherd
-  active_owner: ./packages/batch-bug-shepherd
-  content_hash: sha256:8bf17d4cdc3c10beb54bcb1348efb4a111846d49d9548ca714e4354b4eccff22
-- kind: project-relative
-  target: agents
-  value: .agents/skills/batch-bug-shepherd/evals/triggers.json
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/batch-bug-shepherd
-  active_owner: ./packages/batch-bug-shepherd
-  content_hash: sha256:f195dc4b80b66f23a5fd9cfc6c60cf3fa1bba5b09b97f044d31f8dae27445470
-- kind: project-relative
-  target: agents
-  value: .agents/skills/batch-bug-shepherd/references/invariants.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/batch-bug-shepherd
-  active_owner: ./packages/batch-bug-shepherd
-  content_hash: sha256:3af10723afea02e7d4c4cb7ae08cb60eee621da3a3d0ffb1f041b70fb29fb6cd
-- kind: project-relative
-  target: agents
-  value: .agents/skills/batch-bug-shepherd/references/strategic-alignment-gate.md
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/batch-bug-shepherd
-  active_owner: ./packages/batch-bug-shepherd
-  content_hash: sha256:66613a8344411a2f9d5147b4acea798887bed20132ffd27bac9b3f5ba6bb65ed
-- kind: project-relative
-  target: agents
-  value: .agents/skills/batch-bug-shepherd/scripts/run_evals.py
-  runtime: null
-  scope: project
-  owners:
-  - ./packages/batch-bug-shepherd
-  active_owner: ./packages/batch-bug-shepherd
-  content_hash: sha256:ecc003164e65cb002f301a7cdff9c0a2e39eddc35a81ede63da8934519e483c9
 - kind: project-relative
   target: agents
   value: .agents/skills/cli-logging-ux
@@ -2228,204 +1616,6 @@ deployments:
   content_hash: sha256:90b5d0369032de850f2255910f4cf5caafb7d60f07bda8a2146d394bfa459918
 - kind: project-relative
   target: agents
-  value: .agents/skills/pr-description-skill
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/pr-description-skill
-  active_owner: local:packages/pr-description-skill
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/pr-description-skill/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/pr-description-skill
-  active_owner: local:packages/pr-description-skill
-  content_hash: sha256:d07254e9d0b95ea52d1a81d3262ca42da8c4c51d801eac4f11b6bc454cfb01a0
-- kind: project-relative
-  target: agents
-  value: .agents/skills/pr-description-skill/apm.yml
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/pr-description-skill
-  active_owner: local:packages/pr-description-skill
-  content_hash: sha256:ee9bb48581e62279708a9a12dc57174c9f5f7d347a384e4ca6b99c050c63879d
-- kind: project-relative
-  target: agents
-  value: .agents/skills/pr-description-skill/assets/mermaid-conventions.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/pr-description-skill
-  active_owner: local:packages/pr-description-skill
-  content_hash: sha256:3d9c7adf95d40db00833ec087d699a7d04b3d799e9b9d07271cf2ae7d51524ca
-- kind: project-relative
-  target: agents
-  value: .agents/skills/pr-description-skill/assets/pr-body-template.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/pr-description-skill
-  active_owner: local:packages/pr-description-skill
-  content_hash: sha256:aaeb885fbfa87364724f575eb150c9c39dc3cb60ab0459972e76185df9c98f97
-- kind: project-relative
-  target: agents
-  value: .agents/skills/pr-description-skill/assets/scenario-evidence-rubric.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/pr-description-skill
-  active_owner: local:packages/pr-description-skill
-  content_hash: sha256:bbb386b6f48974bbb78a380fd4674ed7a3a81810a6c2136e30c80158153596ae
-- kind: project-relative
-  target: agents
-  value: .agents/skills/pr-description-skill/assets/section-rubric.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/pr-description-skill
-  active_owner: local:packages/pr-description-skill
-  content_hash: sha256:f07fbbc5c741c4fd30f32edec985d8301d20e3deebb1761dd92b04da51c5e42d
-- kind: project-relative
-  target: agents
-  value: .agents/skills/pr-description-skill/evals/.gitignore
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/pr-description-skill
-  active_owner: local:packages/pr-description-skill
-  content_hash: sha256:dc810cf3561d22d2d47b89fd0697de46aff0068819b3514577842cb2a2a1c332
-- kind: project-relative
-  target: agents
-  value: .agents/skills/pr-description-skill/evals/README.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/pr-description-skill
-  active_owner: local:packages/pr-description-skill
-  content_hash: sha256:92b4529515917d25cbf5e597d1d46751e602dd4eb80be20a97ac81597f410cd0
-- kind: project-relative
-  target: agents
-  value: .agents/skills/pr-description-skill/evals/content/auth-refactor.json
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/pr-description-skill
-  active_owner: local:packages/pr-description-skill
-  content_hash: sha256:86791ada2f4983fde709237eaae9ef9c5a0f87a28f14e8b0f26b4b7e5b0e73c9
-- kind: project-relative
-  target: agents
-  value: .agents/skills/pr-description-skill/evals/content/dep-bump.json
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/pr-description-skill
-  active_owner: local:packages/pr-description-skill
-  content_hash: sha256:5136278ecf83a6c3a618176810ef62634cc988527dcdb8bd343ae83278f9e1d7
-- kind: project-relative
-  target: agents
-  value: .agents/skills/pr-description-skill/evals/content/docs-only.json
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/pr-description-skill
-  active_owner: local:packages/pr-description-skill
-  content_hash: sha256:78a6f98f939b1b8e0efa1b67a57a4b9008ddffd3b4f02fbde4f9843c4f29b39a
-- kind: project-relative
-  target: agents
-  value: .agents/skills/pr-description-skill/evals/evals.json
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/pr-description-skill
-  active_owner: local:packages/pr-description-skill
-  content_hash: sha256:1d137370f60955469a089a7ef085371aa14bbb74a80675957f4d6e0a694252cc
-- kind: project-relative
-  target: agents
-  value: .agents/skills/pr-description-skill/evals/fixtures/auth-refactor__with_skill.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/pr-description-skill
-  active_owner: local:packages/pr-description-skill
-  content_hash: sha256:b5ebacb04c4ace19e0d634e9b9104ef70b72330afb9f29ac0de07a03f1e78628
-- kind: project-relative
-  target: agents
-  value: .agents/skills/pr-description-skill/evals/fixtures/auth-refactor__without_skill.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/pr-description-skill
-  active_owner: local:packages/pr-description-skill
-  content_hash: sha256:81c42403d4f1406ba2689106bb6e1cdf0a74f1921681f6e096cefac0c46efd46
-- kind: project-relative
-  target: agents
-  value: .agents/skills/pr-description-skill/evals/fixtures/dep-bump__with_skill.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/pr-description-skill
-  active_owner: local:packages/pr-description-skill
-  content_hash: sha256:60df233958541ed42b94c1751a3d2d99324ec83f263fa0becc3abcb4a682ee91
-- kind: project-relative
-  target: agents
-  value: .agents/skills/pr-description-skill/evals/fixtures/dep-bump__without_skill.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/pr-description-skill
-  active_owner: local:packages/pr-description-skill
-  content_hash: sha256:1410a89d81b6745d14242181197d2d05ec5aba5078f1ad3ae702e3341a3fc798
-- kind: project-relative
-  target: agents
-  value: .agents/skills/pr-description-skill/evals/fixtures/docs-only__with_skill.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/pr-description-skill
-  active_owner: local:packages/pr-description-skill
-  content_hash: sha256:e4ca53c7dc8c8a65f4945e2e4e4cc878b433c5662d13c5b613d957d6d505029c
-- kind: project-relative
-  target: agents
-  value: .agents/skills/pr-description-skill/evals/fixtures/docs-only__without_skill.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/pr-description-skill
-  active_owner: local:packages/pr-description-skill
-  content_hash: sha256:7e790d6711b8a33702c6bf0f7486e1928c58c60b4dad0a998c570a07d6a05fec
-- kind: project-relative
-  target: agents
-  value: .agents/skills/pr-description-skill/evals/results/.gitkeep
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/pr-description-skill
-  active_owner: local:packages/pr-description-skill
-  content_hash: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-- kind: project-relative
-  target: agents
-  value: .agents/skills/pr-description-skill/evals/triggers.json
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/pr-description-skill
-  active_owner: local:packages/pr-description-skill
-  content_hash: sha256:6762c7f071195491700cc59ce5329ff185b0493682c93efdcf01db8fb522bbe4
-- kind: project-relative
-  target: agents
-  value: .agents/skills/pr-description-skill/scripts/run_evals.py
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/pr-description-skill
-  active_owner: local:packages/pr-description-skill
-  content_hash: sha256:a1792f8cb95b4fb37a4133af079908e2a3b5643c1a81d97e4dcda399bac069a2
-- kind: project-relative
-  target: agents
   value: .agents/skills/python-architecture
   runtime: null
   scope: project
@@ -2442,114 +1632,6 @@ deployments:
   - .
   active_owner: .
   content_hash: sha256:f06e50b8c40d7e5a732a5405a603efd80da58de2b6f6b293f0f6b58f28eefe7b
-- kind: project-relative
-  target: agents
-  value: .agents/skills/shepherd-driver
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/shepherd-driver
-  active_owner: local:packages/shepherd-driver
-  content_hash: null
-- kind: project-relative
-  target: agents
-  value: .agents/skills/shepherd-driver/SKILL.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/shepherd-driver
-  active_owner: local:packages/shepherd-driver
-  content_hash: sha256:71773e1ad047d7f12e9d4f416606e961a35dc7dc1cc92cb02ce4c10d1a33e32d
-- kind: project-relative
-  target: agents
-  value: .agents/skills/shepherd-driver/apm.yml
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/shepherd-driver
-  active_owner: local:packages/shepherd-driver
-  content_hash: sha256:d53355a3862fee76c099f99eeb49ed6fd9ce1c24d648451ce9a2efdced9fda4b
-- kind: project-relative
-  target: agents
-  value: .agents/skills/shepherd-driver/assets/ci-recovery-checklist.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/shepherd-driver
-  active_owner: local:packages/shepherd-driver
-  content_hash: sha256:21801867a8459d9713e45efe68e612c4d22a2cb577c23eceab55cd855bbd23ef
-- kind: project-relative
-  target: agents
-  value: .agents/skills/shepherd-driver/assets/completion-schema.json
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/shepherd-driver
-  active_owner: local:packages/shepherd-driver
-  content_hash: sha256:11dd97df9308cd868ddb3c7c7c398f59f3b07d571d790d2a1ec8537f2feba4ca
-- kind: project-relative
-  target: agents
-  value: .agents/skills/shepherd-driver/assets/conflict-resolution-prompt.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/shepherd-driver
-  active_owner: local:packages/shepherd-driver
-  content_hash: sha256:453237e56043e4008c37c5a89d9da5e77a1fa46b028ea172321dcc39a737c679
-- kind: project-relative
-  target: agents
-  value: .agents/skills/shepherd-driver/assets/copilot-classification-prompt.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/shepherd-driver
-  active_owner: local:packages/shepherd-driver
-  content_hash: sha256:71c0ad6c5d2c422dcc7fc0c44e13d8b3b049b37c04418ade7daf9722fe115c1f
-- kind: project-relative
-  target: agents
-  value: .agents/skills/shepherd-driver/assets/fold-vs-defer-rubric.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/shepherd-driver
-  active_owner: local:packages/shepherd-driver
-  content_hash: sha256:50ece018b83c70508ca3fc4b3d267e39df2de4497938ce4aa56d3b49c594f75f
-- kind: project-relative
-  target: agents
-  value: .agents/skills/shepherd-driver/assets/pr-comment-templates.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/shepherd-driver
-  active_owner: local:packages/shepherd-driver
-  content_hash: sha256:24fe0ec64286c7b39037a5e93acfa607a43dbb4763d653f3955a1c4d65d68882
-- kind: project-relative
-  target: agents
-  value: .agents/skills/shepherd-driver/assets/shepherd-driver-prompt.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/shepherd-driver
-  active_owner: local:packages/shepherd-driver
-  content_hash: sha256:48f5f9276f92984480dba4f0d54ecc5b612b6c72f313fd5222962dffd75ed0ed
-- kind: project-relative
-  target: agents
-  value: .agents/skills/shepherd-driver/references/mergeability-gate.md
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/shepherd-driver
-  active_owner: local:packages/shepherd-driver
-  content_hash: sha256:90bf5cd838d1025dd0fa223a0843be926cd509c85c91ef683cc9bfc98b5e8785
-- kind: project-relative
-  target: agents
-  value: .agents/skills/shepherd-driver/scripts/owner_touch_gate.py
-  runtime: null
-  scope: project
-  owners:
-  - local:packages/shepherd-driver
-  active_owner: local:packages/shepherd-driver
-  content_hash: sha256:f78a10e6a972046d212720372a1bf6971fd8cbadd0eb78c06c1a48f333fcd5b5
 - kind: project-relative
   target: agents
   value: .agents/skills/supply-chain-security
@@ -2586,6 +1668,924 @@ deployments:
   - ./packages/batch-bug-shepherd
   active_owner: ./packages/batch-bug-shepherd
   content_hash: null
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: null
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:9872bd7ada9903073c663a5b1d1bfaa15743d4bcb2f450631a4da610b1fd0a6e
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/assets/acceptance-observer.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:e4ddab439f62bb372f5ad608775294dd44653ef475eeca8ef5517af7f5e42699
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/assets/autopilot-triage-schema.json
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:35d672ce4584fb576b3c16ce4dffbe29de6b3f6711725855b3c6eb0f338d464d
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/assets/confidence-gate-rubric.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:2d6eff739cd4ac1eb4533868cbdcf0c44d469ae247447f29595d05858b2d8a97
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/assets/final-report-template.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:8088fe8f5bb9fd1ec93fbe806971465bb7f6850019af5be1a329e252d4818df2
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/assets/ground-truth-table.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:00dd5a35ef0b39ba299e5fcd7f9ca682fc322792ec20440f7861edd39997d40e
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/assets/ideate-prompt.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:abab1a5e2a765229d1cdd215b90c57036cdb4b2764866b68399eb81a51362ddc
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/assets/implement-bug.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:4c74c8dfa0f98987ab5beede16d3e8c0e8113fac60955826d2ed61949624bcc5
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/assets/implement-docs.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:81f2f9b617587df4a6f422838b05c63a5e05e0c8afd6d80952a9aa5cdad88b5a
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/assets/implement-feature.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:394b25a0b0b41b0f99b250590af782968c0f25673c156d0b87d4f1f9b205de75
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/assets/implement-refactor.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:5175ea7edefdaaf787d1701ba6f7fce8433d04134718d9a6445ca524ececa3bc
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/assets/model-routing.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:4d1ffaf63fab75a7a7de265ff77d457c0636939d36a373dc9ce485ba76275209
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/assets/plan-panel-prompt.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:422daafc8fcdf26f1096787075b2e8c15722df6b51e1d1784ea3b1435809b09f
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/assets/plan-schema.json
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:f766382fbac2a2b99c0dad1d0327659103c4482cc155854ea7ef2e3c82fce8f2
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/assets/solution-pipeline-prompt.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:812487116b89e66414562312992204dfb3132cc5e9265392b718d78e33cd9973
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/assets/task-implement-prompt.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:397ab60c270f0312a3ddaac0fbc03e853fa16552a962f6b2ebca5ed27bab2818
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/assets/triage-digest-template.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:78c2e7be93543122e485eb494a2b50ecac6e18d7e077a9e8edde12b478242ca9
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/assets/triage-prompt.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:5136ab42be575b58730a8d8a1614394813014ca74e2d6df3e56948e94c419470
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/assets/wave-gate-rubric.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:a8bf5270c8d63c1d9ffcf0b3f18ba22d591b062e7b969982320150986ab211cd
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/evals/.gitignore
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:f370ad043ec0c98a166fd98646c3b94280ed78bc996223b6cca2ba936f7c6781
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/evals/README.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:79bb6636a89edce40fc24bde9576e351de57a0f828181def37c423a284cd1ef8
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/evals/content/gate-escalate-doubtful.json
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:20bcabed2b58be8552421f68e9522cea3a1206a1796c26d2f77e65a3982d438f
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/evals/content/gate-proceed-clean-accept.json
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:f304138fe9aafe48989710bd2c68238342b32e643281f9747c0678b7cb1ae244
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/evals/content/mixed-types-one-review.json
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:df2b1b66e1ec64743cc8d66e465e5cca931de6fb51974cc51c81908efad58eb5
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/evals/evals.json
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:a94ed339f171e7ca557df3e7ed10c8e55f9a14befcba940b7263c9d7fe4d8ca1
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/evals/real-task-refinement.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:183d6d7270dc5f865a02d42643ba0afbae9046509f0e3b2481559fc9c1dcb64a
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/evals/triggers.json
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:59bbb6e937d6de8db69aee4478989fccff561c77e86cc6894e7994eb841defd0
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-issue-autopilot/scripts/run_evals.py
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/apm-issue-autopilot
+  active_owner: ./packages/apm-issue-autopilot
+  content_hash: sha256:8f4580cb2bdb88e7e570e4feb60cbf244d7fbe3e8217a8eadfd9dff2c763b615
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-review-panel
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/apm-review-panel
+  active_owner: local:packages/apm-review-panel
+  content_hash: null
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-review-panel/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/apm-review-panel
+  active_owner: local:packages/apm-review-panel
+  content_hash: sha256:c9fee6c311b23b6ea72b06a424c8ba21c5d88bcc833e65259b7e0212aa73abbb
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-review-panel/apm.yml
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/apm-review-panel
+  active_owner: local:packages/apm-review-panel
+  content_hash: sha256:80c403c4d3c59a91bb27b85650e21a466e9cd0cbc28e92bf0f3e53c6ea71cb2c
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-review-panel/assets/ceo-return-schema.json
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/apm-review-panel
+  active_owner: local:packages/apm-review-panel
+  content_hash: sha256:d8707211968efb0471d083f880d5353d66a0eda84635e803a930f60c91837468
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-review-panel/assets/panelist-return-schema.json
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/apm-review-panel
+  active_owner: local:packages/apm-review-panel
+  content_hash: sha256:e3cf2ae17e93dd934f2659ed77d2640ea9601fbe8698f63ba800edf046691f99
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-review-panel/assets/recommendation-template.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/apm-review-panel
+  active_owner: local:packages/apm-review-panel
+  content_hash: sha256:ed973263897671ea04c980cb54c76b33aaa9bb7d1b5b24082df89b388d4329b8
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-review-panel/evals/README.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/apm-review-panel
+  active_owner: local:packages/apm-review-panel
+  content_hash: sha256:40e7abb1fa15403a71505797e23dde8433f31ca70546657886c3f9760974bfb8
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-review-panel/evals/fixtures/01-ship-now-pr1084-shape.json
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/apm-review-panel
+  active_owner: local:packages/apm-review-panel
+  content_hash: sha256:108fc261680f17bdade3e2bdf8e64fc908d16a37ec9c29c53169b394530bdd67
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-review-panel/evals/fixtures/01-ship-now-pr1084-shape.rendered.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/apm-review-panel
+  active_owner: local:packages/apm-review-panel
+  content_hash: sha256:ca1fdd3cd24e0fd8ec15b37690c597921ebf1c872270166edb2727d54ee155d8
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-review-panel/evals/fixtures/02-needs-rework-shape.json
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/apm-review-panel
+  active_owner: local:packages/apm-review-panel
+  content_hash: sha256:faa41c6c83c4a7955447bcb8fc0ad5a3b8afb4235db257462f649ba0a901913e
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-review-panel/evals/fixtures/02-needs-rework-shape.rendered.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/apm-review-panel
+  active_owner: local:packages/apm-review-panel
+  content_hash: sha256:b69cd113a428b61d8bbb9381a85261b3ee3acd3f101c08d06419e26aab03bba8
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-review-panel/evals/render_eval.py
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/apm-review-panel
+  active_owner: local:packages/apm-review-panel
+  content_hash: sha256:690baf6267775077ad011b98839eda1001e207bbae78a7a8454c4d39bb8a2864
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-review-panel/evals/trigger-evals.json
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/apm-review-panel
+  active_owner: local:packages/apm-review-panel
+  content_hash: sha256:c715ba52cd2131f294c1cf685a10995a08e4ee6971f97cf5d36e09df28d3af91
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-triage-panel
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/apm-triage-panel
+  active_owner: local:packages/apm-triage-panel
+  content_hash: null
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-triage-panel/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/apm-triage-panel
+  active_owner: local:packages/apm-triage-panel
+  content_hash: sha256:2ef70329aefd0cbec1302aad3975f6caa0a27654d58005bba622ef1021267d1e
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-triage-panel/apm.yml
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/apm-triage-panel
+  active_owner: local:packages/apm-triage-panel
+  content_hash: sha256:e8b7946f433abdc8342241483963bac2895182916ea66f5aa39497d00c7930a4
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/apm-triage-panel/assets/triage-template.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/apm-triage-panel
+  active_owner: local:packages/apm-triage-panel
+  content_hash: sha256:69a027959eaec5335668e087c86babd814ba20cf21662ed524cf285b178e21d1
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/batch-bug-shepherd
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/batch-bug-shepherd
+  active_owner: ./packages/batch-bug-shepherd
+  content_hash: null
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/batch-bug-shepherd/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/batch-bug-shepherd
+  active_owner: ./packages/batch-bug-shepherd
+  content_hash: sha256:c5b0f8752e726d123f61491c959681134882dfddbc9f5d15ac5c47e55931375f
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/batch-bug-shepherd/assets/final-report-template.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/batch-bug-shepherd
+  active_owner: ./packages/batch-bug-shepherd
+  content_hash: sha256:ea280a4d1e15a9b56ba8d3ef5f0e931754cc44ae29d5615da58da8d445f455c2
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/batch-bug-shepherd/assets/fix-prompt.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/batch-bug-shepherd
+  active_owner: ./packages/batch-bug-shepherd
+  content_hash: sha256:ea4fde3d619f12fc7e05f27d6b440b48f3ef66cb9509b2efb85aed66439438f9
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/batch-bug-shepherd/assets/ground-truth-table.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/batch-bug-shepherd
+  active_owner: ./packages/batch-bug-shepherd
+  content_hash: sha256:981ebeee98596beb6a00db6edb35a8e871acdd52a938faa8d8915edfd01ba15b
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/batch-bug-shepherd/assets/progress-diagram.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/batch-bug-shepherd
+  active_owner: ./packages/batch-bug-shepherd
+  content_hash: sha256:72c4606899f50b0761a7683f6ab17878472bc45b18fe03869aae65e3bd6a7bb2
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/batch-bug-shepherd/assets/strategic-alignment-prompt.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/batch-bug-shepherd
+  active_owner: ./packages/batch-bug-shepherd
+  content_hash: sha256:67db0bb51d6cbdafad4ea8224ab2012f02e6341b2fd4eb7a09b2a24cc9cb4d7e
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/batch-bug-shepherd/assets/triage-prompt.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/batch-bug-shepherd
+  active_owner: ./packages/batch-bug-shepherd
+  content_hash: sha256:51bab548ac85044400b77858c6a1554f59bda197c388d9a8546076d87380b060
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/batch-bug-shepherd/assets/verdict-schema.json
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/batch-bug-shepherd
+  active_owner: ./packages/batch-bug-shepherd
+  content_hash: sha256:d82b7ed0791b89617be965097fce1ace9ec6f6b5a33d9a1567cdf4b3651cd83a
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/batch-bug-shepherd/evals/.gitignore
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/batch-bug-shepherd
+  active_owner: ./packages/batch-bug-shepherd
+  content_hash: sha256:f370ad043ec0c98a166fd98646c3b94280ed78bc996223b6cca2ba936f7c6781
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/batch-bug-shepherd/evals/README.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/batch-bug-shepherd
+  active_owner: ./packages/batch-bug-shepherd
+  content_hash: sha256:7d0a5c983612953289a8e34c0b95995ccad7273653c4ab145c3f10b9adafa905
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/batch-bug-shepherd/evals/content/sweep-bug-queue.json
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/batch-bug-shepherd
+  active_owner: ./packages/batch-bug-shepherd
+  content_hash: sha256:f865943bbe523d22555d6e69834f47364237ce27388cb7732795a6887f6820ee
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/batch-bug-shepherd/evals/content/three-issues-mixed.json
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/batch-bug-shepherd
+  active_owner: ./packages/batch-bug-shepherd
+  content_hash: sha256:9c2b0f108e958fc7d779cb9222339b12310307f7a2a2c87d83c715d0d0c3460b
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/batch-bug-shepherd/evals/evals.json
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/batch-bug-shepherd
+  active_owner: ./packages/batch-bug-shepherd
+  content_hash: sha256:0b47a8ea4c49c375a575d0f44d488b65c0d797bff5022ebb79746808495dab26
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/batch-bug-shepherd/evals/fixtures/sweep-bug-queue.with_skill.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/batch-bug-shepherd
+  active_owner: ./packages/batch-bug-shepherd
+  content_hash: sha256:0dbfab6bc74cb2b92bbf25d08196b1405669a3e6841be41915f00a1ea54ff950
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/batch-bug-shepherd/evals/fixtures/sweep-bug-queue.without_skill.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/batch-bug-shepherd
+  active_owner: ./packages/batch-bug-shepherd
+  content_hash: sha256:83a2a11ac6dc2a188bb95a92f24dc7f94568f8af30ec4979ae85f52bd3102ee6
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/batch-bug-shepherd/evals/fixtures/three-issues-mixed.with_skill.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/batch-bug-shepherd
+  active_owner: ./packages/batch-bug-shepherd
+  content_hash: sha256:ab8707f0842af611fe135029a7002356a0bececfbb3abbe442dbc196d48be7ed
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/batch-bug-shepherd/evals/fixtures/three-issues-mixed.without_skill.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/batch-bug-shepherd
+  active_owner: ./packages/batch-bug-shepherd
+  content_hash: sha256:8bf17d4cdc3c10beb54bcb1348efb4a111846d49d9548ca714e4354b4eccff22
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/batch-bug-shepherd/evals/triggers.json
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/batch-bug-shepherd
+  active_owner: ./packages/batch-bug-shepherd
+  content_hash: sha256:f195dc4b80b66f23a5fd9cfc6c60cf3fa1bba5b09b97f044d31f8dae27445470
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/batch-bug-shepherd/references/invariants.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/batch-bug-shepherd
+  active_owner: ./packages/batch-bug-shepherd
+  content_hash: sha256:3af10723afea02e7d4c4cb7ae08cb60eee621da3a3d0ffb1f041b70fb29fb6cd
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/batch-bug-shepherd/references/strategic-alignment-gate.md
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/batch-bug-shepherd
+  active_owner: ./packages/batch-bug-shepherd
+  content_hash: sha256:66613a8344411a2f9d5147b4acea798887bed20132ffd27bac9b3f5ba6bb65ed
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/batch-bug-shepherd/scripts/run_evals.py
+  runtime: null
+  scope: project
+  owners:
+  - ./packages/batch-bug-shepherd
+  active_owner: ./packages/batch-bug-shepherd
+  content_hash: sha256:ecc003164e65cb002f301a7cdff9c0a2e39eddc35a81ede63da8934519e483c9
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/pr-description-skill
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/pr-description-skill
+  active_owner: local:packages/pr-description-skill
+  content_hash: null
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/pr-description-skill/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/pr-description-skill
+  active_owner: local:packages/pr-description-skill
+  content_hash: sha256:d07254e9d0b95ea52d1a81d3262ca42da8c4c51d801eac4f11b6bc454cfb01a0
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/pr-description-skill/apm.yml
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/pr-description-skill
+  active_owner: local:packages/pr-description-skill
+  content_hash: sha256:ee9bb48581e62279708a9a12dc57174c9f5f7d347a384e4ca6b99c050c63879d
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/pr-description-skill/assets/mermaid-conventions.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/pr-description-skill
+  active_owner: local:packages/pr-description-skill
+  content_hash: sha256:3d9c7adf95d40db00833ec087d699a7d04b3d799e9b9d07271cf2ae7d51524ca
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/pr-description-skill/assets/pr-body-template.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/pr-description-skill
+  active_owner: local:packages/pr-description-skill
+  content_hash: sha256:aaeb885fbfa87364724f575eb150c9c39dc3cb60ab0459972e76185df9c98f97
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/pr-description-skill/assets/scenario-evidence-rubric.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/pr-description-skill
+  active_owner: local:packages/pr-description-skill
+  content_hash: sha256:bbb386b6f48974bbb78a380fd4674ed7a3a81810a6c2136e30c80158153596ae
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/pr-description-skill/assets/section-rubric.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/pr-description-skill
+  active_owner: local:packages/pr-description-skill
+  content_hash: sha256:f07fbbc5c741c4fd30f32edec985d8301d20e3deebb1761dd92b04da51c5e42d
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/pr-description-skill/evals/.gitignore
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/pr-description-skill
+  active_owner: local:packages/pr-description-skill
+  content_hash: sha256:dc810cf3561d22d2d47b89fd0697de46aff0068819b3514577842cb2a2a1c332
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/pr-description-skill/evals/README.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/pr-description-skill
+  active_owner: local:packages/pr-description-skill
+  content_hash: sha256:92b4529515917d25cbf5e597d1d46751e602dd4eb80be20a97ac81597f410cd0
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/pr-description-skill/evals/content/auth-refactor.json
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/pr-description-skill
+  active_owner: local:packages/pr-description-skill
+  content_hash: sha256:86791ada2f4983fde709237eaae9ef9c5a0f87a28f14e8b0f26b4b7e5b0e73c9
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/pr-description-skill/evals/content/dep-bump.json
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/pr-description-skill
+  active_owner: local:packages/pr-description-skill
+  content_hash: sha256:5136278ecf83a6c3a618176810ef62634cc988527dcdb8bd343ae83278f9e1d7
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/pr-description-skill/evals/content/docs-only.json
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/pr-description-skill
+  active_owner: local:packages/pr-description-skill
+  content_hash: sha256:78a6f98f939b1b8e0efa1b67a57a4b9008ddffd3b4f02fbde4f9843c4f29b39a
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/pr-description-skill/evals/evals.json
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/pr-description-skill
+  active_owner: local:packages/pr-description-skill
+  content_hash: sha256:1d137370f60955469a089a7ef085371aa14bbb74a80675957f4d6e0a694252cc
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/pr-description-skill/evals/fixtures/auth-refactor__with_skill.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/pr-description-skill
+  active_owner: local:packages/pr-description-skill
+  content_hash: sha256:b5ebacb04c4ace19e0d634e9b9104ef70b72330afb9f29ac0de07a03f1e78628
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/pr-description-skill/evals/fixtures/auth-refactor__without_skill.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/pr-description-skill
+  active_owner: local:packages/pr-description-skill
+  content_hash: sha256:81c42403d4f1406ba2689106bb6e1cdf0a74f1921681f6e096cefac0c46efd46
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/pr-description-skill/evals/fixtures/dep-bump__with_skill.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/pr-description-skill
+  active_owner: local:packages/pr-description-skill
+  content_hash: sha256:60df233958541ed42b94c1751a3d2d99324ec83f263fa0becc3abcb4a682ee91
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/pr-description-skill/evals/fixtures/dep-bump__without_skill.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/pr-description-skill
+  active_owner: local:packages/pr-description-skill
+  content_hash: sha256:1410a89d81b6745d14242181197d2d05ec5aba5078f1ad3ae702e3341a3fc798
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/pr-description-skill/evals/fixtures/docs-only__with_skill.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/pr-description-skill
+  active_owner: local:packages/pr-description-skill
+  content_hash: sha256:e4ca53c7dc8c8a65f4945e2e4e4cc878b433c5662d13c5b613d957d6d505029c
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/pr-description-skill/evals/fixtures/docs-only__without_skill.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/pr-description-skill
+  active_owner: local:packages/pr-description-skill
+  content_hash: sha256:7e790d6711b8a33702c6bf0f7486e1928c58c60b4dad0a998c570a07d6a05fec
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/pr-description-skill/evals/results/.gitkeep
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/pr-description-skill
+  active_owner: local:packages/pr-description-skill
+  content_hash: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/pr-description-skill/evals/triggers.json
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/pr-description-skill
+  active_owner: local:packages/pr-description-skill
+  content_hash: sha256:6762c7f071195491700cc59ce5329ff185b0493682c93efdcf01db8fb522bbe4
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/pr-description-skill/scripts/run_evals.py
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/pr-description-skill
+  active_owner: local:packages/pr-description-skill
+  content_hash: sha256:a1792f8cb95b4fb37a4133af079908e2a3b5643c1a81d97e4dcda399bac069a2
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/shepherd-driver
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/shepherd-driver
+  active_owner: local:packages/shepherd-driver
+  content_hash: null
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/shepherd-driver/SKILL.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/shepherd-driver
+  active_owner: local:packages/shepherd-driver
+  content_hash: sha256:71773e1ad047d7f12e9d4f416606e961a35dc7dc1cc92cb02ce4c10d1a33e32d
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/shepherd-driver/apm.yml
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/shepherd-driver
+  active_owner: local:packages/shepherd-driver
+  content_hash: sha256:d53355a3862fee76c099f99eeb49ed6fd9ce1c24d648451ce9a2efdced9fda4b
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/shepherd-driver/assets/ci-recovery-checklist.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/shepherd-driver
+  active_owner: local:packages/shepherd-driver
+  content_hash: sha256:21801867a8459d9713e45efe68e612c4d22a2cb577c23eceab55cd855bbd23ef
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/shepherd-driver/assets/completion-schema.json
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/shepherd-driver
+  active_owner: local:packages/shepherd-driver
+  content_hash: sha256:11dd97df9308cd868ddb3c7c7c398f59f3b07d571d790d2a1ec8537f2feba4ca
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/shepherd-driver/assets/conflict-resolution-prompt.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/shepherd-driver
+  active_owner: local:packages/shepherd-driver
+  content_hash: sha256:453237e56043e4008c37c5a89d9da5e77a1fa46b028ea172321dcc39a737c679
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/shepherd-driver/assets/copilot-classification-prompt.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/shepherd-driver
+  active_owner: local:packages/shepherd-driver
+  content_hash: sha256:71c0ad6c5d2c422dcc7fc0c44e13d8b3b049b37c04418ade7daf9722fe115c1f
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/shepherd-driver/assets/fold-vs-defer-rubric.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/shepherd-driver
+  active_owner: local:packages/shepherd-driver
+  content_hash: sha256:50ece018b83c70508ca3fc4b3d267e39df2de4497938ce4aa56d3b49c594f75f
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/shepherd-driver/assets/pr-comment-templates.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/shepherd-driver
+  active_owner: local:packages/shepherd-driver
+  content_hash: sha256:24fe0ec64286c7b39037a5e93acfa607a43dbb4763d653f3955a1c4d65d68882
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/shepherd-driver/assets/shepherd-driver-prompt.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/shepherd-driver
+  active_owner: local:packages/shepherd-driver
+  content_hash: sha256:48f5f9276f92984480dba4f0d54ecc5b612b6c72f313fd5222962dffd75ed0ed
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/shepherd-driver/references/mergeability-gate.md
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/shepherd-driver
+  active_owner: local:packages/shepherd-driver
+  content_hash: sha256:90bf5cd838d1025dd0fa223a0843be926cd509c85c91ef683cc9bfc98b5e8785
+- kind: project-relative
+  target: copilot
+  value: .agents/skills/shepherd-driver/scripts/owner_touch_gate.py
+  runtime: null
+  scope: project
+  owners:
+  - local:packages/shepherd-driver
+  active_owner: local:packages/shepherd-driver
+  content_hash: sha256:f78a10e6a972046d212720372a1bf6971fd8cbadd0eb78c06c1a48f333fcd5b5
 - kind: project-relative
   target: copilot
   value: .github/agents/agentic-workflows.agent.md
@@ -2783,7 +2783,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:e032386ad2898bddde644f840cc9a460d320484b2c41a2403c055f868f6e7c84
+  content_hash: sha256:12b44916b1235c8c1f258fb943739f3bb9fab178c37a0562d488ed30b8c2085f
 - kind: project-relative
   target: copilot
   value: .github/instructions/changelog.instructions.md
@@ -3290,7 +3290,7 @@ local_deployed_file_hashes:
   .github/agents/spec-tag-architect.agent.md: sha256:82907265c5e7cf1ac61ad96866fa7c5683b69c8f09b7a4c5f3cc241acc9568ca
   .github/agents/supply-chain-security-expert.agent.md: sha256:8fb8cc426d6af17ba084a28b3f026c2b475b62e3ca63ed2f88b83bd823f877af
   .github/agents/test-coverage-expert.agent.md: sha256:48c2172d1f18a394fa83ef9dc2be0b9b921a4e51e976498165250fed66369711
-  .github/instructions/architecture.instructions.md: sha256:8743aaf262f1dbc78a64beb932c3bddd9358e8841a3f25e4d7953206b7b4f483
+  .github/instructions/architecture.instructions.md: sha256:12b44916b1235c8c1f258fb943739f3bb9fab178c37a0562d488ed30b8c2085f
   .github/instructions/changelog.instructions.md: sha256:1e51ec4c74e847967962bd279dc4c6e582c5d3578490b3c28d5f3acd3e05f73e
   .github/instructions/cicd.instructions.md: sha256:08d87b7d635761cb41deb8fc71d5d83f54678de463db484afb16d2d4f8713ecb
   .github/instructions/cli.instructions.md: sha256:8e39e8d5047ce88575cb02f87c2bcede584dfef258bd86f7466c7badf136541a

--- a/docs/src/content/docs/consumer/install-mcp-servers.md
+++ b/docs/src/content/docs/consumer/install-mcp-servers.md
@@ -106,6 +106,14 @@ prompts until you choose to configure one. See the
 [manifest schema reference](../../reference/manifest-schema/#424-variable-references-in-headers-and-env)
 for the full required-vs-optional runtime config rule.
 
+MCP Registry v0.1 container packages use `registryType: oci`. APM
+selects Docker automatically, keeps Docker run options before the image,
+and places package arguments after the image. Copilot, Codex, Gemini,
+and related adapters prefer packages in `npm`, OCI, then PyPI order.
+VS Code prefers `npm`, PyPI, then OCI. OCI packages require Docker to be
+available when the harness starts the server; no per-target launcher
+configuration is needed.
+
 | Harness | File | Scope | Format |
 |---|---|---|---|
 | GitHub Copilot CLI | `~/.copilot/mcp-config.json` | global | JSON `mcpServers` |

--- a/packages/apm-guide/.apm/skills/apm-usage/commands.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/commands.md
@@ -231,6 +231,11 @@ Self-defined stdio MCP entries declared in `apm.yml` (`env:` / `args:`) have the
 
 Set `MCP_REGISTRY_URL` (default `https://api.mcp.github.com`) to point all `apm mcp` commands and `apm install --mcp` at a custom MCP registry. The URL is validated at startup and must use `https://`; set `MCP_REGISTRY_ALLOW_HTTP=1` to opt in to plaintext `http://` for development. The registry must implement the [MCP Registry v0.1 spec](https://github.com/modelcontextprotocol/registry) (apm calls `/v0.1/servers/...`); legacy `/v0/`-only registries will return 404. When the override is set and the registry is unreachable during install pre-flight, APM fails closed.
 
+For a v0.1 package with `registryType: oci`, install generates a `docker`
+launcher automatically. Docker run options stay before the image and
+package arguments stay after it. Docker must be available when the
+harness starts the server; no manual launcher override is required.
+
 ## Runtime management (experimental)
 
 | Command | Purpose | Key flags |

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -453,6 +453,14 @@ dependencies:
         callbackPort: 3118
 ```
 
+MCP Registry v0.1 uses `registryType: oci` for container packages. APM
+maps that type to the Docker launcher automatically, preserves Docker
+run options before the image, and appends package arguments after the
+image. Copilot, Codex, Gemini, and related adapters select `npm`, OCI,
+then PyPI; VS Code selects `npm`, PyPI, then OCI. Docker must be
+available when the harness starts an OCI server. Do not add per-target
+launcher overrides.
+
 ### Development MCP scope
 
 Use `dependencies.mcp` for servers that a consuming project should

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -1071,9 +1071,26 @@ if [ "$(printf '%s\n' "$mcp_root_scope_body" \
     violations=$((violations + 1))
 fi
 
-
-
-
+echo "[*] AC26: MCP container launcher authority"
+mcp_container_owner="src/apm_cli/adapters/client/base.py"
+mcp_container_consumers=(
+    src/apm_cli/adapters/client/copilot.py
+    src/apm_cli/adapters/client/codex.py
+    src/apm_cli/adapters/client/gemini.py
+    src/apm_cli/adapters/client/vscode.py
+)
+mcp_image_owner_defs=$(grep -rEc \
+    '^[[:space:]]*def _ensure_docker_image_arg\(' \
+    src/apm_cli/adapters/client --include='*.py' \
+    | awk -F: '{sum += $2} END {print sum + 0}')
+mcp_container_missing_consumers=$(grep -L \
+    '_ensure_docker_image_arg(' "${mcp_container_consumers[@]}" || true)
+if ! grep -q '_REGISTRY_TYPE_ALIASES = {"oci": "docker"}' "$mcp_container_owner" \
+    || [ "$mcp_image_owner_defs" -ne 1 ] \
+    || [ -n "$mcp_container_missing_consumers" ]; then
+    echo "[x] MCP container launcher decisions must route through MCPClientAdapter"
+    violations=$((violations + 1))
+fi
 
 if [ "$violations" -gt 0 ]; then
     echo "[x] $violations architecture boundary rule(s) failed"

--- a/src/apm_cli/adapters/client/base.py
+++ b/src/apm_cli/adapters/client/base.py
@@ -323,21 +323,21 @@ class MCPClientAdapter(ABC):
             str: Inferred registry name (e.g. "npm", "pypi", "docker") or "".
             Spec spellings that name the same registry as an APM launcher
             branch are canonicalized via ``_REGISTRY_TYPE_ALIASES`` (v0.1
-            ``oci`` -> ``docker``); every other value is returned verbatim.
+            ``oci`` -> ``docker``). Malformed explicit values are ignored so
+            runtime and image-name inference can select a safe launcher.
         """
         if not package:
             return ""
 
         explicit = package.get("registry_name", "")
         if explicit:
-            # Registry payloads are untrusted: a non-string here must not abort
-            # the install, and the branches below all compare lowercase, so a
-            # sloppy "DOCKER" should reach them rather than fall through to the
-            # generic npx default.
-            if not isinstance(explicit, str):
-                return explicit
-            canonical = explicit.strip().lower()
-            return _REGISTRY_TYPE_ALIASES.get(canonical, canonical)
+            # Registry payloads are untrusted. Ignore malformed explicit values
+            # and continue through the runtime/name inference below rather than
+            # returning an opaque value that misses every launcher branch and
+            # reaches the generic npx fallback.
+            if isinstance(explicit, str):
+                canonical = explicit.strip().lower()
+                return _REGISTRY_TYPE_ALIASES.get(canonical, canonical)
 
         name = package.get("name", "")
         runtime_hint = package.get("runtime_hint", "")

--- a/src/apm_cli/adapters/client/base.py
+++ b/src/apm_cli/adapters/client/base.py
@@ -323,21 +323,21 @@ class MCPClientAdapter(ABC):
             str: Inferred registry name (e.g. "npm", "pypi", "docker") or "".
             Spec spellings that name the same registry as an APM launcher
             branch are canonicalized via ``_REGISTRY_TYPE_ALIASES`` (v0.1
-            ``oci`` -> ``docker``). Malformed explicit values are ignored so
-            runtime and image-name inference can select a safe launcher.
+            ``oci`` -> ``docker``). Malformed explicit values fail closed
+            before any package-manager launcher is selected.
         """
         if not package:
             return ""
 
         explicit = package.get("registry_name", "")
         if explicit:
-            # Registry payloads are untrusted. Ignore malformed explicit values
-            # and continue through the runtime/name inference below rather than
-            # returning an opaque value that misses every launcher branch and
-            # reaches the generic npx fallback.
-            if isinstance(explicit, str):
-                canonical = explicit.strip().lower()
-                return _REGISTRY_TYPE_ALIASES.get(canonical, canonical)
+            # Registry payloads are untrusted. A malformed explicit value must
+            # fail closed rather than miss every launcher branch and reach the
+            # generic npx fallback with an untrusted package name.
+            if not isinstance(explicit, str):
+                raise ValueError("MCP package registry_name must be a string")
+            canonical = explicit.strip().lower()
+            return _REGISTRY_TYPE_ALIASES.get(canonical, canonical)
 
         name = package.get("name", "")
         runtime_hint = package.get("runtime_hint", "")

--- a/src/apm_cli/adapters/client/base.py
+++ b/src/apm_cli/adapters/client/base.py
@@ -48,12 +48,25 @@ def _docker_image_repository(reference: str) -> str:
     references to the same repository compare equal regardless of how each
     side is pinned. A ``host:port/`` prefix is preserved, since a tag can
     only appear in the final path segment.
+
+    Docker Hub is also folded to its short form: a registry commonly
+    publishes a fully qualified ``identifier`` while the run arguments it
+    ships use the implicit spelling, and treating those as different
+    repositories would append a second image operand.
     """
     repository = reference.split("@", 1)[0]
     last_segment = repository.rsplit("/", 1)[-1]
     tag_at = last_segment.find(":")
     if tag_at != -1:
         repository = repository[: len(repository) - len(last_segment) + tag_at]
+    for default_registry in ("docker.io/", "index.docker.io/"):
+        if repository.startswith(default_registry):
+            repository = repository[len(default_registry) :]
+            break
+    # Only meaningful once the implicit registry is stripped: ``library/`` is
+    # where Docker Hub keeps official images, so ``library/redis`` is ``redis``.
+    if repository.startswith("library/"):
+        repository = repository[len("library/") :]
     return repository
 
 

--- a/src/apm_cli/adapters/client/base.py
+++ b/src/apm_cli/adapters/client/base.py
@@ -330,7 +330,14 @@ class MCPClientAdapter(ABC):
 
         explicit = package.get("registry_name", "")
         if explicit:
-            return _REGISTRY_TYPE_ALIASES.get(explicit.strip().lower(), explicit)
+            # Registry payloads are untrusted: a non-string here must not abort
+            # the install, and the branches below all compare lowercase, so a
+            # sloppy "DOCKER" should reach them rather than fall through to the
+            # generic npx default.
+            if not isinstance(explicit, str):
+                return explicit
+            canonical = explicit.strip().lower()
+            return _REGISTRY_TYPE_ALIASES.get(canonical, canonical)
 
         name = package.get("name", "")
         runtime_hint = package.get("runtime_hint", "")
@@ -386,10 +393,15 @@ class MCPClientAdapter(ABC):
         runtime_args = list(runtime_args)
         if not image:
             return runtime_args
-        repository = _docker_image_repository(image)
-        for arg in runtime_args:
-            if isinstance(arg, str) and _docker_image_repository(arg) == repository:
-                return runtime_args
+        # Only the trailing entry can be the image: everything before it is a
+        # run option or an option's value. Scanning the whole list instead lets
+        # a value like `--name mcp-server` masquerade as the image and suppress
+        # the append, rendering the very image-less `docker run` this guards.
+        tail = runtime_args[-1] if runtime_args else None
+        if isinstance(tail, str) and _docker_image_repository(tail) == _docker_image_repository(
+            image
+        ):
+            return runtime_args
         runtime_args.append(image)
         return runtime_args
 

--- a/src/apm_cli/adapters/client/base.py
+++ b/src/apm_cli/adapters/client/base.py
@@ -29,6 +29,34 @@ _ENV_PLACEHOLDER_RE = re.compile(r"<([A-Z_][A-Z0-9_]*)>|" + _ENV_VAR_RE.pattern)
 # deprecation warnings across all servers in a single install run.
 _LEGACY_ANGLE_VAR_RE = re.compile(r"<([A-Z_][A-Z0-9_]*)>")
 
+# MCP Registry v0.1 names the container registry type ``oci``; the adapters
+# below key their launcher dispatch on ``docker`` (the vocabulary the legacy
+# registry shape used, and what ``_infer_registry_name`` derives from a
+# ``docker`` runtime hint or an image-shaped package name). Without this
+# mapping an ``oci`` package matches no launcher branch and falls through to
+# the generic ``npx`` default, which hands the image reference to npm as a
+# package name -- a dependency-confusion exposure, not just a broken config
+# (#2376). Keyed on the lowercased registry type; unlisted values pass through
+# untouched.
+_REGISTRY_TYPE_ALIASES = {"oci": "docker"}
+
+
+def _docker_image_repository(reference: str) -> str:
+    """Return the repository component of a container image reference.
+
+    Drops an ``@sha256:...`` digest and a trailing ``:tag`` so that two
+    references to the same repository compare equal regardless of how each
+    side is pinned. A ``host:port/`` prefix is preserved, since a tag can
+    only appear in the final path segment.
+    """
+    repository = reference.split("@", 1)[0]
+    last_segment = repository.rsplit("/", 1)[-1]
+    tag_at = last_segment.find(":")
+    if tag_at != -1:
+        repository = repository[: len(repository) - len(last_segment) + tag_at]
+    return repository
+
+
 # Config keys that ``_extra`` passthrough must NEVER set on a rendered harness
 # config. Covers the modeled MCP fields (imported single-source from the model)
 # plus harness-specific aliases that mirror a modeled field under a different
@@ -280,13 +308,16 @@ class MCPClientAdapter(ABC):
 
         Returns:
             str: Inferred registry name (e.g. "npm", "pypi", "docker") or "".
+            Spec spellings that name the same registry as an APM launcher
+            branch are canonicalized via ``_REGISTRY_TYPE_ALIASES`` (v0.1
+            ``oci`` -> ``docker``); every other value is returned verbatim.
         """
         if not package:
             return ""
 
         explicit = package.get("registry_name", "")
         if explicit:
-            return explicit
+            return _REGISTRY_TYPE_ALIASES.get(explicit.strip().lower(), explicit)
 
         name = package.get("name", "")
         runtime_hint = package.get("runtime_hint", "")
@@ -313,6 +344,41 @@ class MCPClientAdapter(ABC):
             return "nuget"
 
         return ""
+
+    @staticmethod
+    def _ensure_docker_image_arg(runtime_args, image):
+        """Return *runtime_args* with the container image operand present.
+
+        ``docker run [OPTIONS] IMAGE`` needs the image after the run options.
+        Registries that list it as the last ``runtime_arguments`` entry already
+        satisfy that; registries that expose it only as the package
+        ``identifier`` leave the resolved args ending at the last option, which
+        would render an image-less ``docker run`` that fails on invocation
+        (#2376).
+
+        The image is appended only when no argument already references the same
+        repository. Comparison is on the repository component, so a digest- or
+        tag-pinned identifier still matches a differently-pinned argument
+        instead of being appended a second time -- a duplicate operand would be
+        parsed by Docker as the container command and break a launcher that
+        previously worked.
+
+        Args:
+            runtime_args (list): Resolved registry runtime arguments.
+            image (str): Container image reference from the package entry.
+
+        Returns:
+            list: A new list of ``docker run`` arguments.
+        """
+        runtime_args = list(runtime_args)
+        if not image:
+            return runtime_args
+        repository = _docker_image_repository(image)
+        for arg in runtime_args:
+            if isinstance(arg, str) and _docker_image_repository(arg) == repository:
+                return runtime_args
+        runtime_args.append(image)
+        return runtime_args
 
     @classmethod
     def _select_best_package(cls, packages):

--- a/src/apm_cli/adapters/client/codex.py
+++ b/src/apm_cli/adapters/client/codex.py
@@ -358,10 +358,20 @@ class CodexClientAdapter(MCPClientAdapter):
                     # For Docker packages in Codex TOML format:
                     # - Ensure all environment variables from resolved_env are represented as -e flags in args
                     # - Put actual environment variable values in separate [env] section
-                    config["args"] = self._ensure_docker_env_flags(
-                        self._ensure_docker_image_arg(processed_runtime_args, package_name)
-                        + processed_package_args,
-                        resolved_env,
+                    # _ensure_docker_env_flags inserts -e flags immediately
+                    # before the trailing operand on the assumption that it is
+                    # the image, so it must run while the image IS trailing.
+                    # Package arguments are the container's own argv and are
+                    # appended afterwards, keeping them behind the image per
+                    # `docker run [OPTIONS] IMAGE [ARG...]`; folding them in
+                    # first pushed the env flags past the image into the
+                    # container argv, where docker never applies them.
+                    config["args"] = (
+                        self._ensure_docker_env_flags(
+                            self._ensure_docker_image_arg(processed_runtime_args, package_name),
+                            resolved_env,
+                        )
+                        + processed_package_args
                     )
 
                     # Environment variables go in separate env section for Codex TOML format

--- a/src/apm_cli/adapters/client/codex.py
+++ b/src/apm_cli/adapters/client/codex.py
@@ -359,7 +359,9 @@ class CodexClientAdapter(MCPClientAdapter):
                     # - Ensure all environment variables from resolved_env are represented as -e flags in args
                     # - Put actual environment variable values in separate [env] section
                     config["args"] = self._ensure_docker_env_flags(
-                        processed_runtime_args + processed_package_args, resolved_env
+                        self._ensure_docker_image_arg(processed_runtime_args, package_name)
+                        + processed_package_args,
+                        resolved_env,
                     )
 
                     # Environment variables go in separate env section for Codex TOML format

--- a/src/apm_cli/adapters/client/copilot.py
+++ b/src/apm_cli/adapters/client/copilot.py
@@ -560,10 +560,11 @@ class CopilotClientAdapter(MCPClientAdapter):
         elif registry_name == "docker":
             config["command"] = "docker"
             if processed_runtime_args:
-                config["args"] = self._inject_env_vars_into_docker_args(
+                docker_args = self._inject_env_vars_into_docker_args(
                     self._ensure_docker_image_arg(processed_runtime_args, package_name),
                     resolved_env,
                 )
+                config["args"] = docker_args + processed_package_args
             else:
                 config["args"] = DockerArgsProcessor.process_docker_args(
                     ["run", "-i", "--rm", package_name], resolved_env

--- a/src/apm_cli/adapters/client/copilot.py
+++ b/src/apm_cli/adapters/client/copilot.py
@@ -561,7 +561,8 @@ class CopilotClientAdapter(MCPClientAdapter):
             config["command"] = "docker"
             if processed_runtime_args:
                 config["args"] = self._inject_env_vars_into_docker_args(
-                    processed_runtime_args, resolved_env
+                    self._ensure_docker_image_arg(processed_runtime_args, package_name),
+                    resolved_env,
                 )
             else:
                 config["args"] = DockerArgsProcessor.process_docker_args(

--- a/src/apm_cli/adapters/client/gemini.py
+++ b/src/apm_cli/adapters/client/gemini.py
@@ -236,7 +236,9 @@ class GeminiClientAdapter(CopilotClientAdapter):
         elif registry_name == "docker":
             config["command"] = "docker"
             if processed_rt:
-                config["args"] = self._inject_env_vars_into_docker_args(processed_rt, resolved_env)
+                config["args"] = self._inject_env_vars_into_docker_args(
+                    self._ensure_docker_image_arg(processed_rt, package_name), resolved_env
+                )
             else:
                 config["args"] = DockerArgsProcessor.process_docker_args(
                     ["run", "-i", "--rm", package_name], resolved_env

--- a/src/apm_cli/adapters/client/gemini.py
+++ b/src/apm_cli/adapters/client/gemini.py
@@ -236,9 +236,10 @@ class GeminiClientAdapter(CopilotClientAdapter):
         elif registry_name == "docker":
             config["command"] = "docker"
             if processed_rt:
-                config["args"] = self._inject_env_vars_into_docker_args(
+                docker_args = self._inject_env_vars_into_docker_args(
                     self._ensure_docker_image_arg(processed_rt, package_name), resolved_env
                 )
+                config["args"] = docker_args + processed_pkg
             else:
                 config["args"] = DockerArgsProcessor.process_docker_args(
                     ["run", "-i", "--rm", package_name], resolved_env

--- a/src/apm_cli/adapters/client/vscode.py
+++ b/src/apm_cli/adapters/client/vscode.py
@@ -308,7 +308,19 @@ class VSCodeClientAdapter(MCPClientAdapter):
 
             # Handle docker packages
             elif runtime_hint == "docker" or registry_name == "docker":
-                args = pkg_args if pkg_args else ["run", "-i", "--rm", package.get("name")]
+                runtime_args = self._extract_package_args(
+                    {"runtime_arguments": package.get("runtime_arguments") or []},
+                    runtime_vars=runtime_vars,
+                )
+                package_args = self._extract_package_args(
+                    {"package_arguments": package.get("package_arguments") or []},
+                    runtime_vars=runtime_vars,
+                )
+                args = self._ensure_docker_image_arg(
+                    runtime_args or ["run", "-i", "--rm"],
+                    package.get("name"),
+                )
+                args += package_args
 
                 server_config = {"type": "stdio", "command": "docker", "args": args}
 
@@ -652,6 +664,8 @@ class VSCodeClientAdapter(MCPClientAdapter):
                     elif "value_hint" in arg and arg["value_hint"] and "is_required" not in arg:
                         # v0.1 format: plain value_hint entries without is_required
                         args.append(arg["value_hint"])
+                    elif arg.get("value"):
+                        args.append(arg["value"])
             if args:
                 return args
 

--- a/src/apm_cli/adapters/client/vscode.py
+++ b/src/apm_cli/adapters/client/vscode.py
@@ -289,8 +289,11 @@ class VSCodeClientAdapter(MCPClientAdapter):
             package = self._select_best_package(server_info["packages"])
             runtime_hint = package.get("runtime_hint", "") if package else ""
             registry_name = self._infer_registry_name(package) if package else ""
+            is_docker = runtime_hint == "docker" or registry_name == "docker"
             pkg_args = (
-                self._extract_package_args(package, runtime_vars=runtime_vars) if package else []
+                (self._extract_package_args(package, runtime_vars=runtime_vars) if package else [])
+                if not is_docker
+                else []
             )
 
             # Handle npm packages
@@ -307,14 +310,18 @@ class VSCodeClientAdapter(MCPClientAdapter):
                 }
 
             # Handle docker packages
-            elif runtime_hint == "docker" or registry_name == "docker":
+            elif is_docker:
                 runtime_args = self._extract_package_args(
                     {"runtime_arguments": package.get("runtime_arguments") or []},
                     runtime_vars=runtime_vars,
                 )
-                package_args = self._extract_package_args(
-                    {"package_arguments": package.get("package_arguments") or []},
-                    runtime_vars=runtime_vars,
+                package_args = (
+                    self._extract_package_args(
+                        {"package_arguments": package["package_arguments"]},
+                        runtime_vars=runtime_vars,
+                    )
+                    if package.get("package_arguments")
+                    else []
                 )
                 args = self._ensure_docker_image_arg(
                     runtime_args or ["run", "-i", "--rm"],

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ast
+import ast
 import importlib.util
 import shutil
 import subprocess
@@ -1958,3 +1959,31 @@ def test_public_github_auth_owner_guard_rejects_duplicate_owner(
         "Public github.com anonymous-first auth ordering must stay owned by "
         "AuthResolver" in result.stdout
     )
+
+
+def test_mcp_container_launcher_has_one_canonical_owner() -> None:
+    """OCI selection and image placement must stay shared across adapters."""
+    root = Path(__file__).parents[2]
+    owner = root / "src/apm_cli/adapters/client/base.py"
+    consumers = (
+        root / "src/apm_cli/adapters/client/copilot.py",
+        root / "src/apm_cli/adapters/client/codex.py",
+        root / "src/apm_cli/adapters/client/gemini.py",
+        root / "src/apm_cli/adapters/client/vscode.py",
+    )
+    owner_source = owner.read_text(encoding="utf-8")
+    definitions = [
+        node
+        for path in (owner, *consumers)
+        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8")))
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "_ensure_docker_image_arg"
+    ]
+
+    assert '_REGISTRY_TYPE_ALIASES = {"oci": "docker"}' in owner_source
+    assert len(definitions) == 1
+    for consumer in consumers:
+        assert "_ensure_docker_image_arg(" in consumer.read_text(encoding="utf-8")
+
+    guard = (root / "scripts/lint-architecture-boundaries.sh").read_text(encoding="utf-8")
+    assert "MCP container launcher decisions must route through MCPClientAdapter" in guard

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import ast
-import ast
 import importlib.util
 import shutil
 import subprocess

--- a/tests/integration/test_oci_mcp_lifecycle_contract.py
+++ b/tests/integration/test_oci_mcp_lifecycle_contract.py
@@ -1,0 +1,274 @@
+"""Installed-binary lifecycle contract for MCP Registry v0.1 OCI packages."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+import pytest
+import tomllib
+
+from tests.utils.apm_lifecycle_runner import ApmLifecycleRunner
+from tests.utils.isolated_apm_environment import IsolatedApmEnvironment
+from tests.utils.lifecycle_state import LifecycleStateRoot, LifecycleStateSnapshot
+from tests.utils.local_mcp_registry import LocalMcpRegistryFactory
+from tests.utils.local_package import LocalPackageFactory
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.e2e,
+    pytest.mark.lifecycle_smoke,
+    pytest.mark.requires_apm_binary,
+    pytest.mark.requires_e2e_mode,
+]
+
+_SERVER_NAME = "com.example.lifecycle/oci-server"
+_SERVER_KEY = "oci-server"
+_IMAGE = "registry.example.invalid/team/oci-server:1.4.0"
+_ENV_NAME = "OCI_TEST_ENV"
+_ENV_VALUE = "lifecycle-value"
+_RUNTIME_ARGS = ["run", "--rm", "-i", "--label", "apm.lifecycle=true", "-e"]
+_PACKAGE_ARGS = ["--transport", "stdio"]
+
+
+@dataclass(frozen=True)
+class _TargetCase:
+    """One native MCP config surface exercised through the installed binary."""
+
+    runtime: str
+    manifest_target: str
+    config_path: PurePosixPath
+    config_section: str
+    env_operand: str
+    server_key: str = _SERVER_KEY
+    external_config_root: bool = False
+
+
+_CASES = (
+    _TargetCase(
+        runtime="copilot",
+        manifest_target="copilot",
+        config_path=PurePosixPath("mcp-config.json"),
+        config_section="mcpServers",
+        env_operand=f"{_ENV_NAME}=${{{_ENV_NAME}}}",
+        external_config_root=True,
+    ),
+    _TargetCase(
+        runtime="codex",
+        manifest_target="codex",
+        config_path=PurePosixPath(".codex/config.toml"),
+        config_section="mcp_servers",
+        env_operand=_ENV_NAME,
+    ),
+    _TargetCase(
+        runtime="gemini",
+        manifest_target="gemini",
+        config_path=PurePosixPath(".gemini/settings.json"),
+        config_section="mcpServers",
+        env_operand=f"{_ENV_NAME}={_ENV_VALUE}",
+    ),
+    _TargetCase(
+        runtime="vscode",
+        manifest_target="copilot",
+        config_path=PurePosixPath(".vscode/mcp.json"),
+        config_section="servers",
+        env_operand=_ENV_NAME,
+        server_key=_SERVER_NAME,
+    ),
+)
+
+
+def _server_document() -> dict[str, object]:
+    """Return the reported v0.1 package shape with no image runtime argument."""
+    return {
+        "name": _SERVER_NAME,
+        "description": "Lifecycle fixture for OCI launcher canonicalization",
+        "version": "1.4.0",
+        "packages": [
+            {
+                "registryType": "oci",
+                "identifier": _IMAGE,
+                "runtimeHint": "docker",
+                "transport": {"type": "stdio"},
+                "runtimeArguments": [
+                    *({"value": value, "type": "positional"} for value in _RUNTIME_ARGS),
+                    {"value": _ENV_NAME, "type": "positional"},
+                ],
+                "packageArguments": [
+                    {"value": value, "type": "positional"} for value in _PACKAGE_ARGS
+                ],
+                "environmentVariables": [
+                    {
+                        "name": _ENV_NAME,
+                        "description": "Lifecycle fixture environment value",
+                        "isRequired": True,
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def _config_root(case: _TargetCase, isolated: IsolatedApmEnvironment, project: Path) -> Path:
+    """Return the root containing the target's native config."""
+    if case.external_config_root:
+        return isolated.home / ".copilot"
+    return project
+
+
+def _snapshot(
+    case: _TargetCase,
+    isolated: IsolatedApmEnvironment,
+    project: Path,
+) -> LifecycleStateSnapshot:
+    """Capture the manifest, lock, and exact native config bytes."""
+    if case.external_config_root:
+        return LifecycleStateSnapshot.capture(
+            project,
+            external_roots=(
+                LifecycleStateRoot(
+                    root_id="copilot-config",
+                    target="copilot",
+                    scope="project",
+                    path=_config_root(case, isolated, project),
+                    config_paths=(case.config_path,),
+                ),
+            ),
+        )
+    return LifecycleStateSnapshot.capture(project, config_paths=(case.config_path,))
+
+
+def _native_server_config(
+    case: _TargetCase,
+    isolated: IsolatedApmEnvironment,
+    project: Path,
+) -> dict[str, object]:
+    """Read the target's generated native server mapping."""
+    config_root = _config_root(case, isolated, project)
+    path = config_root / case.config_path
+    if path.suffix == ".toml":
+        document = tomllib.loads(path.read_text(encoding="utf-8"))
+    else:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    section = document[case.config_section]
+    assert isinstance(section, dict)
+    server = section[case.server_key]
+    assert isinstance(server, dict)
+    return server
+
+
+def _assert_idempotent_state(
+    first: LifecycleStateSnapshot,
+    second: LifecycleStateSnapshot,
+) -> None:
+    """Assert every durable field except the lock generation timestamp is exact."""
+    assert second.manifest_bytes == first.manifest_bytes
+    assert second.deployment_records == first.deployment_records
+    assert second.mcp_state_bytes == first.mcp_state_bytes
+    assert second.lsp_state_bytes == first.lsp_state_bytes
+    assert second.files == first.files
+    assert second.semantic_bytes == first.semantic_bytes
+
+
+@pytest.mark.parametrize("case", _CASES, ids=lambda case: case.runtime)
+def test_oci_mcp_install_lifecycle_is_cross_adapter_and_idempotent(
+    case: _TargetCase,
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Install, reinstall, and audit one OCI package without Docker execution."""
+    isolated = IsolatedApmEnvironment.create(
+        tmp_path / f"oci-{case.runtime}",
+        base_env=dict(os.environ),
+    )
+    project_factory = LocalPackageFactory(isolated.work_root)
+    project = project_factory.create(
+        f"oci-{case.runtime}-consumer",
+        targets=(case.manifest_target,),
+    ).root
+    if not case.external_config_root:
+        (project / case.config_path.parent).mkdir(parents=True, exist_ok=True)
+    registry_factory = LocalMcpRegistryFactory(isolated.root / "registries")
+    runner = ApmLifecycleRunner(
+        (str(apm_binary_path),),
+        timeout_seconds=120,
+        scenario_timeout_seconds=300,
+    )
+    install_env = isolated.subprocess_env(overrides={_ENV_NAME: _ENV_VALUE})
+    install_env.pop("PYTHONPATH")
+    install_env["MCP_REGISTRY_ALLOW_HTTP"] = "1"
+    reinstall_args = (
+        "install",
+        "--runtime",
+        case.runtime,
+        "--target",
+        case.manifest_target,
+        "--trust-transitive-mcp",
+        "--no-policy",
+    )
+
+    with registry_factory.start(_server_document()) as registry:
+        source = LocalPackageFactory(isolated.package_root).create(
+            f"oci-{case.runtime}-source",
+            mcp_dependencies=(
+                {
+                    "name": _SERVER_NAME,
+                    "registry": registry.url,
+                },
+            ),
+        )
+        first_command = (
+            "install",
+            str(source.root),
+            "--runtime",
+            case.runtime,
+            "--target",
+            case.manifest_target,
+            "--trust-transitive-mcp",
+            "--no-policy",
+        )
+        runner.run_sequence(
+            (first_command,),
+            expected_returncodes=(0,),
+            scenario_id=f"oci-{case.runtime}-install",
+            cwd=project,
+            env=install_env,
+        )
+        first = _snapshot(case, isolated, project)
+        server = _native_server_config(case, isolated, project)
+        assert server["command"] == "docker"
+        expected_args = [
+            *_RUNTIME_ARGS,
+            case.env_operand,
+            _IMAGE,
+            *_PACKAGE_ARGS,
+        ]
+        assert server["args"] == expected_args
+        assert expected_args.count(_IMAGE) == 1
+        assert expected_args.count("-e") == 1
+        assert "-y" not in expected_args
+
+        runner.run_sequence(
+            (reinstall_args,),
+            expected_returncodes=(0,),
+            scenario_id=f"oci-{case.runtime}-reinstall",
+            cwd=project,
+            env=install_env,
+        )
+        second = _snapshot(case, isolated, project)
+        _assert_idempotent_state(first, second)
+        assert any(path.startswith("/v0.1/servers?") for path in registry.request_paths)
+        assert any(path.endswith("/versions/latest") for path in registry.request_paths)
+
+    audit_env = isolated.subprocess_env(overrides={_ENV_NAME: _ENV_VALUE})
+    audit = runner.run(
+        ("audit", "--ci", "--no-policy", "--format", "json"),
+        scenario_id=f"oci-{case.runtime}-offline-audit",
+        cwd=project,
+        env=audit_env,
+    )
+    assert audit.returncode == 0, f"stdout={audit.stdout!r}\nstderr={audit.stderr!r}"
+    audit_payload = json.loads(audit.stdout)
+    assert audit_payload["passed"] is True

--- a/tests/test_codex_docker_args_fix.py
+++ b/tests/test_codex_docker_args_fix.py
@@ -339,17 +339,21 @@ class TestCodexDockerArgsFix:
             config = codex_adapter.get_current_config()
             server_config = config["mcp_servers"]["test-docker-server"]
 
-            # Check that both runtime_arguments and package_arguments are combined
-            # Plus -e flags for environment variables (inserted before image name)
+            # docker run [OPTIONS] IMAGE [ARG...]: the -e flag is a run option
+            # and must precede the image, while package_arguments are the
+            # container's own argv and follow it. The previous expectation had
+            # the -e landing inside the container argv (after the image,
+            # splitting --config from its value), where docker never applies
+            # it -- the TEST_TOKEN env var silently did not reach the server.
             expected_args = [
                 "run",
                 "-i",
                 "--rm",
+                "-e",
+                "TEST_TOKEN",
                 "example/test-server",
                 "--verbose",
                 "--config",
-                "-e",
-                "TEST_TOKEN",
                 "/app/config.json",
             ]
             assert server_config["args"] == expected_args

--- a/tests/test_codex_docker_args_fix.py
+++ b/tests/test_codex_docker_args_fix.py
@@ -389,6 +389,8 @@ class TestCodexDockerArgsFix:
                 "-e",
                 "GITHUB_DYNAMIC_TOOLSETS",
                 "-e",
+                "GITHUB_HOST",
+                "-e",
                 "GITHUB_READ_ONLY",
                 "-e",
                 "GITHUB_TOOLSETS",
@@ -401,9 +403,7 @@ class TestCodexDockerArgsFix:
             assert args.count("run") == 1
             assert args.count("-i") == 1
             assert args.count("--rm") == 1
-            assert (
-                args.count("-e") == 4
-            )  # One for each environment variable (including GITHUB_DYNAMIC_TOOLSETS default)
+            assert args.count("-e") == 5
             assert args.count("GITHUB_PERSONAL_ACCESS_TOKEN") == 1
             assert args.count("ghcr.io/github/github-mcp-server") == 1
 
@@ -497,6 +497,8 @@ class TestCodexDockerArgsFix:
                 "GITHUB_PERSONAL_ACCESS_TOKEN",
                 "-e",
                 "GITHUB_DYNAMIC_TOOLSETS",
+                "-e",
+                "GITHUB_HOST",
                 "-e",
                 "GITHUB_READ_ONLY",
                 "-e",

--- a/tests/unit/adapters/test_oci_docker_launcher.py
+++ b/tests/unit/adapters/test_oci_docker_launcher.py
@@ -17,11 +17,15 @@ import tempfile
 import unittest
 from unittest.mock import patch
 
+import pytest
+
 from apm_cli.adapters.client.base import MCPClientAdapter
 from apm_cli.adapters.client.codex import CodexClientAdapter
 from apm_cli.adapters.client.copilot import CopilotClientAdapter
 from apm_cli.adapters.client.gemini import GeminiClientAdapter
 from apm_cli.adapters.client.vscode import VSCodeClientAdapter
+
+pytestmark = pytest.mark.unit
 
 # ---------------------------------------------------------------------------
 # Fixtures -- the reporting registry's shape, after the registry client maps
@@ -153,9 +157,12 @@ class TestInferRegistryNameOci(unittest.TestCase):
         )
 
     def test_non_string_registry_type_does_not_raise(self):
-        """Registry payloads are untrusted; a numeric type must not abort install."""
+        """Malformed explicit types continue through safe runtime inference."""
         self.assertEqual(
-            MCPClientAdapter._infer_registry_name({"name": "p", "registry_name": 5}), 5
+            MCPClientAdapter._infer_registry_name(
+                {"name": "p", "registry_name": 5, "runtime_hint": "docker"}
+            ),
+            "docker",
         )
 
     def test_oci_package_wins_container_selection_priority(self):
@@ -359,6 +366,29 @@ class TestOciLauncherAcrossTargets(unittest.TestCase):
         self.assertLess(args.index("-e"), image_at, "env flags must precede the image")
         self.assertGreater(args.index("--transport"), image_at, "container argv must follow it")
         self.assertEqual(args[-2:], ["--transport", "stdio"])
+
+    def test_package_arguments_follow_image_across_adapters(self):
+        package = dict(OCI_PACKAGE)
+        package["package_arguments"] = [
+            {"value": "--transport", "type": "positional"},
+            {"value": "stdio", "type": "positional"},
+        ]
+        for name, make_adapter in (
+            ("copilot", _make_copilot),
+            ("codex", _make_codex),
+            ("gemini", _make_gemini),
+            ("vscode", _make_vscode),
+        ):
+            with self.subTest(adapter=name):
+                rendered = make_adapter()._format_server_config(
+                    {"id": "s", "name": "s", "packages": [package]},
+                    runtime_vars=RUNTIME_VARS,
+                )
+                config = rendered[0] if isinstance(rendered, tuple) else rendered
+                args = config["args"]
+                image_at = args.index(OCI_IMAGE)
+                self.assertEqual(args.count(OCI_IMAGE), 1)
+                self.assertEqual(args[image_at + 1 :], ["--transport", "stdio"])
 
     def test_vscode_still_renders_a_docker_launcher_for_an_oci_package(self):
         """Guard: VS Code already keyed off runtime_hint, and must stay that way.

--- a/tests/unit/adapters/test_oci_docker_launcher.py
+++ b/tests/unit/adapters/test_oci_docker_launcher.py
@@ -192,6 +192,24 @@ class TestEnsureDockerImageArg(unittest.TestCase):
         )
         self.assertEqual(args, ["run", "--rm", "myreg.example.com:5000/team/img"])
 
+    def test_docker_hub_short_form_matches_the_qualified_identifier(self):
+        """Registries qualify the identifier while their run args stay implicit."""
+        base = ["run", "-i", "--rm", "mcp/github"]
+        args = MCPClientAdapter._ensure_docker_image_arg(base, "docker.io/mcp/github")
+        self.assertEqual(args, base)
+
+    def test_official_image_library_prefix_is_folded(self):
+        base = ["run", "redis"]
+        args = MCPClientAdapter._ensure_docker_image_arg(base, "docker.io/library/redis:7")
+        self.assertEqual(args, base)
+
+    def test_non_docker_hub_library_path_is_not_folded(self):
+        """`library/` is only implicit on Docker Hub; elsewhere it is a real path."""
+        args = MCPClientAdapter._ensure_docker_image_arg(
+            ["run", "redis"], "ghcr.io/library/redis:7"
+        )
+        self.assertEqual(args, ["run", "redis", "ghcr.io/library/redis:7"])
+
     def test_distinct_image_repositories_are_not_conflated(self):
         args = MCPClientAdapter._ensure_docker_image_arg(
             ["run", "ghcr.io/other/img:1.0"], "ghcr.io/example/img:1.0"

--- a/tests/unit/adapters/test_oci_docker_launcher.py
+++ b/tests/unit/adapters/test_oci_docker_launcher.py
@@ -156,14 +156,12 @@ class TestInferRegistryNameOci(unittest.TestCase):
             "docker",
         )
 
-    def test_non_string_registry_type_does_not_raise(self):
-        """Malformed explicit types continue through safe runtime inference."""
-        self.assertEqual(
+    def test_non_string_registry_type_fails_closed_before_launcher_dispatch(self):
+        """Malformed explicit types must never reach the generic npx fallback."""
+        with self.assertRaisesRegex(ValueError, "registry_name must be a string"):
             MCPClientAdapter._infer_registry_name(
                 {"name": "p", "registry_name": 5, "runtime_hint": "docker"}
-            ),
-            "docker",
-        )
+            )
 
     def test_oci_package_wins_container_selection_priority(self):
         """_select_best_package ranks containers above pypi; oci must qualify."""

--- a/tests/unit/adapters/test_oci_docker_launcher.py
+++ b/tests/unit/adapters/test_oci_docker_launcher.py
@@ -309,6 +309,27 @@ class TestOciLauncherAcrossTargets(unittest.TestCase):
         self.assertIn("-e", args)
         self.assertLess(args.index("-e"), args.index(OCI_IMAGE), "env flags must precede the image")
 
+    def test_codex_container_argv_follows_the_image(self):
+        """package_arguments are the container's argv: after the image, with
+        the -e run option still ahead of it -- the composition that previously
+        pushed -e into the argv left the env var unset in the container."""
+        package = dict(OCI_PACKAGE)
+        package["environment_variables"] = [{"name": "API_KEY", "is_required": True}]
+        package["package_arguments"] = [
+            {"value": "--transport", "type": "named"},
+            {"value": "stdio", "type": "positional"},
+        ]
+        config = _make_codex()._format_server_config(
+            {"id": "s", "name": "s", "packages": [package]},
+            env_overrides={"API_KEY": "secret"},
+            runtime_vars=RUNTIME_VARS,
+        )
+        args = config.get("args", [])
+        image_at = args.index(OCI_IMAGE)
+        self.assertLess(args.index("-e"), image_at, "env flags must precede the image")
+        self.assertGreater(args.index("--transport"), image_at, "container argv must follow it")
+        self.assertEqual(args[-2:], ["--transport", "stdio"])
+
     def test_vscode_still_renders_a_docker_launcher_for_an_oci_package(self):
         """Guard: VS Code already keyed off runtime_hint, and must stay that way.
 

--- a/tests/unit/adapters/test_oci_docker_launcher.py
+++ b/tests/unit/adapters/test_oci_docker_launcher.py
@@ -141,6 +141,23 @@ class TestInferRegistryNameOci(unittest.TestCase):
                 registry_type,
             )
 
+    def test_uppercase_registry_types_reach_their_launcher_branch(self):
+        """Dispatch compares lowercase; returning the raw value would send a
+        sloppily-cased type to the generic npx default."""
+        self.assertEqual(
+            MCPClientAdapter._infer_registry_name({"name": "pkg", "registry_name": "NPM"}), "npm"
+        )
+        self.assertEqual(
+            MCPClientAdapter._infer_registry_name({"name": "pkg", "registry_name": "Docker"}),
+            "docker",
+        )
+
+    def test_non_string_registry_type_does_not_raise(self):
+        """Registry payloads are untrusted; a numeric type must not abort install."""
+        self.assertEqual(
+            MCPClientAdapter._infer_registry_name({"name": "p", "registry_name": 5}), 5
+        )
+
     def test_oci_package_wins_container_selection_priority(self):
         """_select_best_package ranks containers above pypi; oci must qualify."""
         pypi_package = {"name": "some-server", "registry_name": "pypi"}
@@ -191,6 +208,19 @@ class TestEnsureDockerImageArg(unittest.TestCase):
             ["run", "--rm"], "myreg.example.com:5000/team/img"
         )
         self.assertEqual(args, ["run", "--rm", "myreg.example.com:5000/team/img"])
+
+    def test_an_option_value_mid_list_does_not_stand_in_for_the_image(self):
+        """`--name <image-basename>` is a common template.
+
+        Only the trailing entry can be the image -- everything before it is a
+        run option or an option's value -- so matching anywhere in the list let
+        `--name mcp-server` suppress the append and render the image-less
+        `docker run` this guard exists to prevent.
+        """
+        args = MCPClientAdapter._ensure_docker_image_arg(
+            ["run", "--rm", "--name", "mcp-server", "-v", "/w:/w"], "mcp-server:1.0"
+        )
+        self.assertEqual(args[-1], "mcp-server:1.0")
 
     def test_docker_hub_short_form_matches_the_qualified_identifier(self):
         """Registries qualify the identifier while their run args stay implicit."""

--- a/tests/unit/adapters/test_oci_docker_launcher.py
+++ b/tests/unit/adapters/test_oci_docker_launcher.py
@@ -1,0 +1,323 @@
+"""Regression tests for MCP Registry v0.1 ``oci`` container packages.
+
+Issue #2376: a package whose ``registryType`` is the v0.1 spelling ``oci``
+matched no launcher branch (the adapters key on ``docker``) and fell through
+to the generic ``npx`` default, so the container image reference was handed
+to npm as a package name -- a dependency-confusion exposure, not merely a
+broken config.
+
+The same registry exposes the image only as the package ``identifier``, never
+inside ``runtimeArguments``, so the resolved args must also gain the image or
+the generated ``docker run`` names no image at all.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from apm_cli.adapters.client.base import MCPClientAdapter
+from apm_cli.adapters.client.codex import CodexClientAdapter
+from apm_cli.adapters.client.copilot import CopilotClientAdapter
+from apm_cli.adapters.client.gemini import GeminiClientAdapter
+from apm_cli.adapters.client.vscode import VSCodeClientAdapter
+
+# ---------------------------------------------------------------------------
+# Fixtures -- the reporting registry's shape, after the registry client maps
+# v0.1 camelCase onto the legacy snake_case keys adapters consume.
+# ---------------------------------------------------------------------------
+
+OCI_IMAGE = "myregistry.example.com/team/mcp-server:1.4.0"
+
+_WORKDIR_VAR = {
+    "workdir": {
+        "description": "Working directory to mount into the container.",
+        "isRequired": True,
+        "format": "filepath",
+    }
+}
+
+# Note: no runtime argument carries the image -- it exists only as `name`
+# (v0.1 `identifier`). This is what makes the image-append path load-bearing.
+OCI_PACKAGE = {
+    "name": OCI_IMAGE,
+    "registry_name": "oci",
+    "runtime_hint": "docker",
+    "transport": {"type": "stdio"},
+    "runtime_arguments": [
+        {"value": "run", "type": "positional"},
+        {"value": "--rm", "type": "positional"},
+        {"value": "-i", "type": "positional"},
+        {"value": "-v", "type": "positional"},
+        {"value": "{workdir}:{workdir}", "type": "positional", "variables": _WORKDIR_VAR},
+        {"value": "-w", "type": "positional"},
+        {"value": "{workdir}", "type": "positional", "variables": _WORKDIR_VAR},
+    ],
+}
+
+SERVER_INFO = {"id": "team/mcp-server", "name": "team/mcp-server", "packages": [OCI_PACKAGE]}
+
+RUNTIME_VARS = {"workdir": "/home/dev/project"}
+
+EXPECTED_ARGS = [
+    "run",
+    "--rm",
+    "-i",
+    "-v",
+    "/home/dev/project:/home/dev/project",
+    "-w",
+    "/home/dev/project",
+    OCI_IMAGE,
+]
+
+
+def _make_copilot() -> CopilotClientAdapter:
+    with (
+        patch("apm_cli.adapters.client.copilot.SimpleRegistryClient"),
+        patch("apm_cli.adapters.client.copilot.RegistryIntegration"),
+    ):
+        return CopilotClientAdapter()
+
+
+def _make_codex() -> CodexClientAdapter:
+    # Pin project_root to a scratch dir: the adapter resolves config paths
+    # relative to it, and the default (cwd) would litter the repo.
+    with (
+        patch("apm_cli.adapters.client.codex.SimpleRegistryClient"),
+        patch("apm_cli.adapters.client.codex.RegistryIntegration"),
+    ):
+        return CodexClientAdapter(project_root=tempfile.mkdtemp())
+
+
+def _make_gemini() -> GeminiClientAdapter:
+    # Gemini inherits Copilot's __init__; its own module exposes no registry
+    # symbols to patch, so intercept them where they are resolved.
+    with (
+        patch("apm_cli.adapters.client.copilot.SimpleRegistryClient"),
+        patch("apm_cli.adapters.client.copilot.RegistryIntegration"),
+    ):
+        return GeminiClientAdapter()
+
+
+def _make_vscode() -> VSCodeClientAdapter:
+    with (
+        patch("apm_cli.adapters.client.vscode.SimpleRegistryClient"),
+        patch("apm_cli.adapters.client.vscode.RegistryIntegration"),
+    ):
+        return VSCodeClientAdapter(project_root="/tmp/workspace")
+
+
+# ---------------------------------------------------------------------------
+# _infer_registry_name
+# ---------------------------------------------------------------------------
+
+
+class TestInferRegistryNameOci(unittest.TestCase):
+    """The v0.1 ``oci`` registry type selects APM's container launcher."""
+
+    def test_oci_maps_to_docker(self):
+        self.assertEqual(
+            MCPClientAdapter._infer_registry_name({"name": OCI_IMAGE, "registry_name": "oci"}),
+            "docker",
+        )
+
+    def test_oci_mapping_is_case_and_space_insensitive(self):
+        for spelling in ("OCI", " oci ", "Oci"):
+            self.assertEqual(
+                MCPClientAdapter._infer_registry_name(
+                    {"name": OCI_IMAGE, "registry_name": spelling}
+                ),
+                "docker",
+                f"registry type {spelling!r} must select the container launcher",
+            )
+
+    def test_other_explicit_registry_types_pass_through_untouched(self):
+        for registry_type in ("npm", "pypi", "nuget", "mcpb", "homebrew", "docker"):
+            self.assertEqual(
+                MCPClientAdapter._infer_registry_name(
+                    {"name": "pkg", "registry_name": registry_type}
+                ),
+                registry_type,
+            )
+
+    def test_oci_package_wins_container_selection_priority(self):
+        """_select_best_package ranks containers above pypi; oci must qualify."""
+        pypi_package = {"name": "some-server", "registry_name": "pypi"}
+        selected = MCPClientAdapter._select_best_package([pypi_package, OCI_PACKAGE])
+        self.assertIs(selected, OCI_PACKAGE)
+
+
+# ---------------------------------------------------------------------------
+# _ensure_docker_image_arg
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureDockerImageArg(unittest.TestCase):
+    """The image operand is present exactly once, after the run options."""
+
+    def test_image_appended_when_runtime_args_omit_it(self):
+        args = MCPClientAdapter._ensure_docker_image_arg(["run", "--rm", "-i"], OCI_IMAGE)
+        self.assertEqual(args, ["run", "--rm", "-i", OCI_IMAGE])
+
+    def test_image_not_duplicated_when_already_present(self):
+        base = ["run", "-i", "--rm", OCI_IMAGE]
+        self.assertEqual(MCPClientAdapter._ensure_docker_image_arg(base, OCI_IMAGE), base)
+
+    def test_pinned_runtime_arg_matches_unpinned_identifier(self):
+        base = ["run", "ghcr.io/example/img:2.0.0"]
+        args = MCPClientAdapter._ensure_docker_image_arg(base, "ghcr.io/example/img")
+        self.assertEqual(args, base)
+
+    def test_unpinned_runtime_arg_matches_pinned_identifier(self):
+        base = ["run", "ghcr.io/example/img"]
+        args = MCPClientAdapter._ensure_docker_image_arg(base, "ghcr.io/example/img:2.0.0")
+        self.assertEqual(args, base)
+
+    def test_digest_pinned_identifier_matches_plain_runtime_arg(self):
+        """A duplicate operand would be parsed by Docker as the container command."""
+        base = ["run", "--rm", "mcp/everything"]
+        args = MCPClientAdapter._ensure_docker_image_arg(base, "mcp/everything@sha256:" + "d" * 64)
+        self.assertEqual(args, base)
+
+    def test_differently_tagged_runtime_arg_is_still_the_same_image(self):
+        base = ["run", "ghcr.io/example/img:latest"]
+        args = MCPClientAdapter._ensure_docker_image_arg(base, "ghcr.io/example/img:1.2.3")
+        self.assertEqual(args, base)
+
+    def test_registry_port_is_not_mistaken_for_a_tag(self):
+        """`host:port/path` has no tag; the image must still be appended."""
+        args = MCPClientAdapter._ensure_docker_image_arg(
+            ["run", "--rm"], "myreg.example.com:5000/team/img"
+        )
+        self.assertEqual(args, ["run", "--rm", "myreg.example.com:5000/team/img"])
+
+    def test_distinct_image_repositories_are_not_conflated(self):
+        args = MCPClientAdapter._ensure_docker_image_arg(
+            ["run", "ghcr.io/other/img:1.0"], "ghcr.io/example/img:1.0"
+        )
+        self.assertEqual(args, ["run", "ghcr.io/other/img:1.0", "ghcr.io/example/img:1.0"])
+
+    def test_bind_mount_value_is_not_mistaken_for_the_image(self):
+        args = MCPClientAdapter._ensure_docker_image_arg(
+            ["run", "-v", "/home/dev/project:/home/dev/project"], OCI_IMAGE
+        )
+        self.assertEqual(args[-1], OCI_IMAGE)
+
+    def test_non_string_arguments_do_not_raise(self):
+        """Registry payloads are untrusted; a numeric arg must not abort install."""
+        args = MCPClientAdapter._ensure_docker_image_arg(["run", 8080], OCI_IMAGE)
+        self.assertEqual(args, ["run", 8080, OCI_IMAGE])
+
+    def test_empty_image_leaves_args_untouched(self):
+        self.assertEqual(
+            MCPClientAdapter._ensure_docker_image_arg(["run", "--rm"], ""), ["run", "--rm"]
+        )
+
+    def test_inputs_are_not_mutated(self):
+        runtime_args = ["run", "--rm"]
+        MCPClientAdapter._ensure_docker_image_arg(runtime_args, OCI_IMAGE)
+        self.assertEqual(runtime_args, ["run", "--rm"])
+
+
+# ---------------------------------------------------------------------------
+# End-to-end launcher generation per target
+# ---------------------------------------------------------------------------
+
+
+class TestOciLauncherAcrossTargets(unittest.TestCase):
+    """Every target renders a runnable docker launcher, never an npx one."""
+
+    def test_copilot_generates_docker_launcher_with_image(self):
+        config = _make_copilot()._format_server_config(SERVER_INFO, runtime_vars=RUNTIME_VARS)
+        self.assertEqual(config.get("command"), "docker")
+        self.assertEqual(config.get("args"), EXPECTED_ARGS)
+
+    def test_copilot_never_routes_a_container_package_through_npm(self):
+        """The #2376 dependency-confusion trap: npx would resolve `run` on npm."""
+        config = _make_copilot()._format_server_config(SERVER_INFO, runtime_vars=RUNTIME_VARS)
+        args = config.get("args", [])
+        self.assertNotEqual(config.get("command"), "npx")
+        self.assertNotIn("-y", args)
+        self.assertEqual(args[-1], OCI_IMAGE, "image must be the final docker run operand")
+
+    def test_gemini_generates_docker_launcher_with_image(self):
+        config = _make_gemini()._format_server_config(SERVER_INFO, runtime_vars=RUNTIME_VARS)
+        self.assertEqual(config.get("command"), "docker")
+        self.assertEqual(config.get("args"), EXPECTED_ARGS)
+
+    def test_codex_generates_docker_launcher_with_image(self):
+        config = _make_codex()._format_server_config(SERVER_INFO, runtime_vars=RUNTIME_VARS)
+        self.assertEqual(config.get("command"), "docker")
+        self.assertEqual(config.get("args"), EXPECTED_ARGS)
+
+    def test_existing_docker_package_gains_no_duplicate_image(self):
+        """Regression guard for packages that already worked before #2376.
+
+        The identifier may be digest-pinned while the runtime argument names
+        the bare repository; appending a second operand would be read by
+        Docker as the container command and break a working launcher.
+        """
+        package = {
+            "name": "mcp/everything@sha256:" + "d" * 64,
+            "registry_name": "docker",
+            "runtime_hint": "docker",
+            "runtime_arguments": [
+                {"value": "run", "type": "positional"},
+                {"value": "--rm", "type": "positional"},
+                {"value": "-i", "type": "positional"},
+                {"value": "mcp/everything", "type": "positional"},
+            ],
+        }
+        config = _make_copilot()._format_server_config(
+            {"id": "everything", "name": "everything", "packages": [package]}
+        )
+        self.assertEqual(config.get("args"), ["run", "--rm", "-i", "mcp/everything"])
+
+    def test_codex_keeps_env_flags_ahead_of_the_appended_image(self):
+        """``-e`` flags are ``docker run`` options, so they precede the image.
+
+        ``_ensure_docker_env_flags`` inserts them before the trailing operand,
+        which only lands correctly once that operand is the image.
+        """
+        package = dict(OCI_PACKAGE)
+        package["environment_variables"] = [{"name": "API_KEY", "is_required": True}]
+        config = _make_codex()._format_server_config(
+            {"id": "s", "name": "s", "packages": [package]},
+            env_overrides={"API_KEY": "secret"},
+            runtime_vars=RUNTIME_VARS,
+        )
+        args = config.get("args", [])
+        self.assertIn("-e", args)
+        self.assertLess(args.index("-e"), args.index(OCI_IMAGE), "env flags must precede the image")
+
+    def test_vscode_still_renders_a_docker_launcher_for_an_oci_package(self):
+        """Guard: VS Code already keyed off runtime_hint, and must stay that way.
+
+        VS Code's own ``value``-shaped argument handling is tracked separately
+        (#2377); this only pins that the registry-type change does not divert
+        an ``oci`` package away from its container branch.
+        """
+        package = {
+            "name": "ghcr.io/example/playwright-mcp:1.2.3",
+            "registry_name": "oci",
+            "runtime_hint": "docker",
+            "runtime_arguments": [
+                {"value_hint": "run"},
+                {"value_hint": "-i"},
+                {"value_hint": "--rm"},
+                {"value_hint": "ghcr.io/example/playwright-mcp:1.2.3"},
+            ],
+        }
+        config, _inputs = _make_vscode()._format_server_config(
+            {"id": "playwright-mcp", "name": "playwright-mcp", "packages": [package]}
+        )
+        self.assertEqual(config.get("command"), "docker")
+        self.assertEqual(
+            config.get("args"),
+            ["run", "-i", "--rm", "ghcr.io/example/playwright-mcp:1.2.3"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_runtime_args.py
+++ b/tests/unit/test_runtime_args.py
@@ -134,14 +134,10 @@ class TestRuntimeArguments(unittest.TestCase):
                     "registry_name": "docker",
                     "runtime_hint": "docker",
                     "runtime_arguments": [
-                        {"is_required": True, "value": "test-image", "value_hint": "test-image"},
-                        {
-                            "is_required": True,
-                            "value": "<PORT>",
-                            "value_hint": "8080",
-                            "description": "Port to expose",
-                        },
+                        {"is_required": True, "value": "run", "value_hint": "run"},
+                        {"is_required": True, "value": "--rm", "value_hint": "--rm"},
                     ],
+                    "package_arguments": [{"type": "positional", "value": "8080"}],
                 }
             ],
         }
@@ -152,11 +148,7 @@ class TestRuntimeArguments(unittest.TestCase):
         # Validate the args array includes all required runtime arguments
         self.assertEqual(server_config["type"], "stdio")
         self.assertEqual(server_config["command"], "docker")
-        self.assertEqual(
-            len(server_config["args"]), 2
-        )  # All arguments should come directly from runtime_arguments
-        self.assertEqual(server_config["args"][0], "test-image")
-        self.assertEqual(server_config["args"][1], "8080")
+        self.assertEqual(server_config["args"], ["run", "--rm", "test-image", "8080"])
 
     def test_python_runtime_args_handling(self):
         """Test that python runtime arguments are correctly added to the args list."""


### PR DESCRIPTION
## Description

MCP Registry v0.1 names the container registry type `oci`. Every client adapter keys its launcher dispatch on `docker`, and `_infer_registry_name` returns an explicit `registry_name` before reaching its own `runtime_hint == "docker"` inference — so an `oci` package matched no branch and fell through to `_apply_pypi_homebrew_generic_config`'s generic default:

```python
config["command"] = "npx"
config["args"] = processed_runtime_args + ["-y", package_name] + processed_package_args
```

That reproduces the reported config exactly, and hands both the container image reference and the literal `run` argument to npm as package names.

The triage note attributes this to a server-level `runtimeHint` not reaching the per-package entry. It does reach it — `registryType` and `runtimeHint` are mapped by the same table in `registry/client.py` — and the fallback that would have used it is unreachable while `registry_name` is truthy.

A registry-type alias table canonicalizes the v0.1 spelling in `_infer_registry_name`, which covers Copilot/Cursor/Codex/Gemini dispatch (and the adapters inheriting them) plus `_select_best_package`, where a container package previously failed to match the `"docker"` priority slot.

The reporting registry exposes the image only as the package `identifier`, never inside `runtimeArguments`, so routing to the container branch alone still rendered an image-less `docker run`. `_ensure_docker_image_arg` appends it when the trailing argument does not already name the same repository — compared on the repository component, so a digest- or tag-pinned identifier matches a differently-pinned argument instead of emitting a second operand that Docker would read as the container command.

Fixes #2376

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

`tests/unit/adapters/test_oci_docker_launcher.py` builds the reporting registry's package shape and asserts the rendered launcher per target; 26 of its 30 tests fail against `main`. The four that pass are deliberate no-regression guards — other registry types pass through unchanged, VS Code still renders a container launcher, and an existing docker package gains no duplicate image operand.

Helper coverage includes digest/tag mismatches, `host:port` registries, Docker Hub short forms, bind-mount values that resemble an image, an option value that must not stand in for it, and non-string payloads.

## Behaviour change worth flagging

A server publishing both a pypi and a container package now resolves to the container on Copilot/Codex/Gemini, following the documented `npm, docker, pypi` order. Such a server previously fell through to `uvx` and now requires a Docker daemon. VS Code keeps its own `npm, pypi, docker` order, so the two can differ per target. Recorded in `CHANGELOG.md` under `Changed`.

## Review follow-ups included here

- Codex fed the env-flag pass runtime args, image and package arguments in one list. `_ensure_docker_env_flags` inserts `-e` before the trailing operand on the assumption that it is the image, so with package arguments present the flags landed in the container's argv and docker never applied them. `test_docker_server_with_package_arguments` asserted that corrupted order; its expectation now follows the `docker run [OPTIONS] IMAGE [ARG...]` contract.
- `_docker_image_repository` folds the Docker Hub short form, so a fully qualified `docker.io/mcp/github` identifier matches the implicit `mcp/github` a registry ships in its run arguments rather than appending a second operand.
- `_infer_registry_name` no longer calls `.strip()` on a non-string registry type, and returns the canonical lowercase form so a sloppily-cased value still reaches its launcher branch.

## Spec conformance (OpenAPM v0.1)

- [x] N/A -- this PR does not change OpenAPM-observable behaviour.
