### PR TITLE
fix(vscode): build container run args from v0.1 registry arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   state; frozen install fails without writing when that state is missing or
   stale. The matching `openapm-v0.1.md` frozen-install requirement now covers
   MCP state and all durable writes. (by @edenfunf, #2390; fixes #2373)
+- `apm install --target vscode` no longer drops a container server's
+  registry-supplied run options, including bind mounts whose values APM had
+  just prompted for. The VS Code argument reader recognised only the legacy
+  `value_hint` spelling, so every MCP Registry v0.1 argument was skipped and
+  the launcher fell back to a bare `run -i --rm <image>`. (by @edenfunf, #2377)
+
 - MCP servers whose registry entry uses the MCP Registry v0.1 container type
   `oci` now render a `docker` launcher. They previously matched no launcher
   branch and fell through to the generic `npx` default, which handed the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   just prompted for. The VS Code argument reader recognised only the legacy
   `value_hint` spelling, so every MCP Registry v0.1 argument was skipped and
   the launcher fell back to a bare `run -i --rm <image>`. (by @edenfunf, #2377)
+- `apm install --target vscode` now launches container servers with their full
+  registry-supplied run options, including bind mounts whose values APM just
+  collected. VS Code previously read only the legacy `value_hint` spelling, so
+  MCP Registry v0.1 arguments were skipped and the launcher fell back to a bare
+  `run -i --rm <image>`. (by @edenfunf, #2377)
 
 - MCP servers whose registry entry uses the MCP Registry v0.1 container type
   `oci` now render a `docker` launcher. They previously matched no launcher

--- a/src/apm_cli/adapters/client/base.py
+++ b/src/apm_cli/adapters/client/base.py
@@ -44,15 +44,30 @@ _DOCKER_RUN_OPTIONS_WITH_VALUES = frozenset(
         "--add-host",
         "--annotation",
         "--attach",
+        "--blkio-weight",
+        "--blkio-weight-device",
         "--cap-add",
         "--cap-drop",
         "--cgroup-parent",
         "--cgroupns",
         "--cidfile",
+        "--cpu-count",
+        "--cpu-percent",
+        "--cpu-period",
+        "--cpu-quota",
+        "--cpu-rt-period",
+        "--cpu-rt-runtime",
+        "--cpu-shares",
         "--cpus",
         "--cpuset-cpus",
         "--cpuset-mems",
+        "--detach-keys",
         "--device",
+        "--device-cgroup-rule",
+        "--device-read-bps",
+        "--device-read-iops",
+        "--device-write-bps",
+        "--device-write-iops",
         "--dns",
         "--dns-option",
         "--dns-search",
@@ -64,23 +79,40 @@ _DOCKER_RUN_OPTIONS_WITH_VALUES = frozenset(
         "--gpus",
         "--group-add",
         "--health-cmd",
+        "--health-interval",
+        "--health-retries",
+        "--health-start-interval",
+        "--health-start-period",
+        "--health-timeout",
         "--hostname",
+        "--io-maxbandwidth",
+        "--io-maxiops",
+        "--ip",
+        "--ip6",
         "--ipc",
         "--isolation",
+        "--kernel-memory",
         "--label",
         "--label-file",
         "--link",
+        "--link-local-ip",
         "--log-driver",
         "--log-opt",
         "--mac-address",
         "--memory",
+        "--memory-reservation",
+        "--memory-swap",
+        "--memory-swappiness",
         "--mount",
         "--name",
         "--network",
         "--network-alias",
+        "--oom-score-adj",
         "--pid",
+        "--pids-limit",
         "--platform",
         "--publish",
+        "--pull",
         "--restart",
         "--runtime",
         "--security-opt",
@@ -437,7 +469,55 @@ class MCPClientAdapter(ABC):
         return ""
 
     @staticmethod
-    def _ensure_docker_image_arg(runtime_args, image):
+    def _docker_image_references_match(left: Any, right: Any) -> bool:
+        """Return whether two strings name the same image repository."""
+        return (
+            isinstance(left, str)
+            and isinstance(right, str)
+            and _docker_image_repository(left) == _docker_image_repository(right)
+        )
+
+    @classmethod
+    def _docker_image_arg_index(
+        cls,
+        runtime_args: list[Any],
+        image: str | None,
+    ) -> int | None:
+        """Return the matching Docker image operand index, or None."""
+        if not image or not runtime_args or runtime_args[0] != "run":
+            return None
+        index = 1
+        while index < len(runtime_args):
+            argument = runtime_args[index]
+            if argument == "--":
+                index += 1
+                break
+            if isinstance(argument, str) and argument.startswith("--"):
+                option = argument.split("=", 1)[0]
+                index += (
+                    2 if "=" not in argument and option in _DOCKER_RUN_OPTIONS_WITH_VALUES else 1
+                )
+                continue
+            if isinstance(argument, str) and argument.startswith("-") and argument != "-":
+                option = argument[:2]
+                index += (
+                    2 if len(argument) == 2 and option in _DOCKER_RUN_OPTIONS_WITH_VALUES else 1
+                )
+                continue
+            break
+        if index >= len(runtime_args):
+            return None
+        candidate = runtime_args[index]
+        if cls._docker_image_references_match(candidate, image):
+            return index
+        return None
+
+    @classmethod
+    def _ensure_docker_image_arg(
+        cls,
+        runtime_args: list[Any],
+        image: str | None,
+    ) -> list[Any]:
         """Return *runtime_args* with the container image operand present.
 
         ``docker run [OPTIONS] IMAGE`` needs the image after the run options.
@@ -464,22 +544,7 @@ class MCPClientAdapter(ABC):
         runtime_args = list(runtime_args)
         if not image:
             return runtime_args
-        # Only the trailing entry can be the image: everything before it is a
-        # run option or an option's value. Scanning the whole list instead lets
-        # a value like `--name mcp-server` masquerade as the image and suppress
-        # the append, rendering the very image-less `docker run` this guards.
-        tail = runtime_args[-1] if runtime_args else None
-        previous = runtime_args[-2] if len(runtime_args) > 1 else None
-        tail_is_option_value = (
-            isinstance(previous, str)
-            and "=" not in previous
-            and previous in _DOCKER_RUN_OPTIONS_WITH_VALUES
-        )
-        if (
-            not tail_is_option_value
-            and isinstance(tail, str)
-            and _docker_image_repository(tail) == _docker_image_repository(image)
-        ):
+        if cls._docker_image_arg_index(runtime_args, image) is not None:
             return runtime_args
         runtime_args.append(image)
         return runtime_args

--- a/src/apm_cli/adapters/client/base.py
+++ b/src/apm_cli/adapters/client/base.py
@@ -69,6 +69,7 @@ _DOCKER_RUN_OPTIONS_WITH_VALUES = frozenset(
         "--device-write-bps",
         "--device-write-iops",
         "--dns",
+        "--dns-opt",
         "--dns-option",
         "--dns-search",
         "--domainname",
@@ -105,6 +106,8 @@ _DOCKER_RUN_OPTIONS_WITH_VALUES = frozenset(
         "--memory-swappiness",
         "--mount",
         "--name",
+        "--net",
+        "--net-alias",
         "--network",
         "--network-alias",
         "--oom-score-adj",
@@ -511,12 +514,16 @@ class MCPClientAdapter(ABC):
                 break
             if isinstance(argument, str) and argument.startswith("--"):
                 option = argument.split("=", 1)[0]
-                index += (
-                    2 if "=" not in argument and option in _DOCKER_RUN_OPTIONS_WITH_VALUES else 1
-                )
+                consumes_next = "=" not in argument and option in _DOCKER_RUN_OPTIONS_WITH_VALUES
+                if consumes_next and index + 1 >= len(runtime_args):
+                    raise ValueError(f"Docker run option '{option}' requires a value")
+                index += 2 if consumes_next else 1
                 continue
             if isinstance(argument, str) and argument.startswith("-") and argument != "-":
-                index += 2 if cls._docker_option_requires_value(argument) else 1
+                consumes_next = cls._docker_option_requires_value(argument)
+                if consumes_next and index + 1 >= len(runtime_args):
+                    raise ValueError(f"Docker run option '{argument}' requires a value")
+                index += 2 if consumes_next else 1
                 continue
             break
         if index >= len(runtime_args):

--- a/src/apm_cli/adapters/client/base.py
+++ b/src/apm_cli/adapters/client/base.py
@@ -39,6 +39,77 @@ _LEGACY_ANGLE_VAR_RE = re.compile(r"<([A-Z_][A-Z0-9_]*)>")
 # (#2376). Keyed on the lowercased registry type; unlisted values pass through
 # untouched.
 _REGISTRY_TYPE_ALIASES = {"oci": "docker"}
+_DOCKER_RUN_OPTIONS_WITH_VALUES = frozenset(
+    {
+        "--add-host",
+        "--annotation",
+        "--attach",
+        "--cap-add",
+        "--cap-drop",
+        "--cgroup-parent",
+        "--cgroupns",
+        "--cidfile",
+        "--cpus",
+        "--cpuset-cpus",
+        "--cpuset-mems",
+        "--device",
+        "--dns",
+        "--dns-option",
+        "--dns-search",
+        "--domainname",
+        "--entrypoint",
+        "--env",
+        "--env-file",
+        "--expose",
+        "--gpus",
+        "--group-add",
+        "--health-cmd",
+        "--hostname",
+        "--ipc",
+        "--isolation",
+        "--label",
+        "--label-file",
+        "--link",
+        "--log-driver",
+        "--log-opt",
+        "--mac-address",
+        "--memory",
+        "--mount",
+        "--name",
+        "--network",
+        "--network-alias",
+        "--pid",
+        "--platform",
+        "--publish",
+        "--restart",
+        "--runtime",
+        "--security-opt",
+        "--shm-size",
+        "--stop-signal",
+        "--stop-timeout",
+        "--storage-opt",
+        "--sysctl",
+        "--tmpfs",
+        "--ulimit",
+        "--user",
+        "--userns",
+        "--uts",
+        "--volume",
+        "--volume-driver",
+        "--volumes-from",
+        "--workdir",
+        "-a",
+        "-c",
+        "-e",
+        "-h",
+        "-l",
+        "-m",
+        "-p",
+        "-u",
+        "-v",
+        "-w",
+    }
+)
 
 
 def _docker_image_repository(reference: str) -> str:
@@ -398,8 +469,16 @@ class MCPClientAdapter(ABC):
         # a value like `--name mcp-server` masquerade as the image and suppress
         # the append, rendering the very image-less `docker run` this guards.
         tail = runtime_args[-1] if runtime_args else None
-        if isinstance(tail, str) and _docker_image_repository(tail) == _docker_image_repository(
-            image
+        previous = runtime_args[-2] if len(runtime_args) > 1 else None
+        tail_is_option_value = (
+            isinstance(previous, str)
+            and "=" not in previous
+            and previous in _DOCKER_RUN_OPTIONS_WITH_VALUES
+        )
+        if (
+            not tail_is_option_value
+            and isinstance(tail, str)
+            and _docker_image_repository(tail) == _docker_image_repository(image)
         ):
             return runtime_args
         runtime_args.append(image)

--- a/src/apm_cli/adapters/client/base.py
+++ b/src/apm_cli/adapters/client/base.py
@@ -433,12 +433,14 @@ class MCPClientAdapter(ABC):
             return ""
 
         explicit = package.get("registry_name", "")
-        if explicit:
+        if not isinstance(explicit, str):
             # Registry payloads are untrusted. A malformed explicit value must
             # fail closed rather than miss every launcher branch and reach the
             # generic npx fallback with an untrusted package name.
-            if not isinstance(explicit, str):
-                raise ValueError("MCP package registry_name must be a string")
+            raise ValueError("MCP package registry_name must be a string")
+        if explicit and not explicit.strip():
+            raise ValueError("MCP package registry_name must not be whitespace")
+        if explicit:
             canonical = explicit.strip().lower()
             return _REGISTRY_TYPE_ALIASES.get(canonical, canonical)
 
@@ -477,6 +479,21 @@ class MCPClientAdapter(ABC):
             and _docker_image_repository(left) == _docker_image_repository(right)
         )
 
+    @staticmethod
+    def _docker_option_requires_value(argument: Any) -> bool:
+        """Return whether a Docker run option needs a separate value."""
+        if not isinstance(argument, str) or "=" in argument:
+            return False
+        if argument.startswith("--"):
+            return argument in _DOCKER_RUN_OPTIONS_WITH_VALUES
+        if not argument.startswith("-") or argument == "-":
+            return False
+        short_options = argument[1:]
+        for index, short_name in enumerate(short_options):
+            if f"-{short_name}" in _DOCKER_RUN_OPTIONS_WITH_VALUES:
+                return index == len(short_options) - 1
+        return False
+
     @classmethod
     def _docker_image_arg_index(
         cls,
@@ -499,10 +516,7 @@ class MCPClientAdapter(ABC):
                 )
                 continue
             if isinstance(argument, str) and argument.startswith("-") and argument != "-":
-                option = argument[:2]
-                index += (
-                    2 if len(argument) == 2 and option in _DOCKER_RUN_OPTIONS_WITH_VALUES else 1
-                )
+                index += 2 if cls._docker_option_requires_value(argument) else 1
                 continue
             break
         if index >= len(runtime_args):

--- a/src/apm_cli/adapters/client/codex.py
+++ b/src/apm_cli/adapters/client/codex.py
@@ -425,16 +425,20 @@ class CodexClientAdapter(MCPClientAdapter):
                         )
                         processed.append(processed_value)
                 elif arg_type == "named":
-                    # For named arguments, the flag name is in the "value" field
-                    flag_name = arg.get("value", "")
+                    name = arg.get("name", "")
+                    value = arg.get("value", arg.get("default", ""))
+                    if isinstance(name, str) and name.startswith("-"):
+                        flag_name = name
+                        additional_value = value
+                    else:
+                        flag_name = value
+                        additional_value = name
                     if flag_name:
                         processed.append(flag_name)
-                        # Some named arguments might have additional values (rare)
-                        additional_value = arg.get("name", "")
                         if (
                             additional_value
                             and additional_value != flag_name
-                            and not additional_value.startswith("-")
+                            and not str(additional_value).startswith("-")
                         ):
                             processed_value = self._resolve_variable_placeholders(
                                 str(additional_value), resolved_env, runtime_vars

--- a/src/apm_cli/adapters/client/codex.py
+++ b/src/apm_cli/adapters/client/codex.py
@@ -354,6 +354,7 @@ class CodexClientAdapter(MCPClientAdapter):
                         config["env"] = resolved_env
                 elif registry_name == "docker":
                     config["command"] = "docker"
+                    runtime_args = processed_runtime_args or ["run", "-i", "--rm"]
 
                     # For Docker packages in Codex TOML format:
                     # - Ensure all environment variables from resolved_env are represented as -e flags in args
@@ -368,7 +369,7 @@ class CodexClientAdapter(MCPClientAdapter):
                     # container argv, where docker never applies them.
                     config["args"] = (
                         self._ensure_docker_env_flags(
-                            self._ensure_docker_image_arg(processed_runtime_args, package_name),
+                            self._ensure_docker_image_arg(runtime_args, package_name),
                             resolved_env,
                         )
                         + processed_package_args

--- a/src/apm_cli/adapters/client/copilot.py
+++ b/src/apm_cli/adapters/client/copilot.py
@@ -12,7 +12,6 @@ from typing import ClassVar
 
 import click
 
-from ...core.docker_args import DockerArgsProcessor
 from ...core.token_manager import GitHubTokenManager
 from ...registry.client import SimpleRegistryClient
 from ...registry.integration import RegistryIntegration
@@ -559,16 +558,12 @@ class CopilotClientAdapter(MCPClientAdapter):
                 config["env"] = resolved_env
         elif registry_name == "docker":
             config["command"] = "docker"
-            if processed_runtime_args:
-                docker_args = self._inject_env_vars_into_docker_args(
-                    self._ensure_docker_image_arg(processed_runtime_args, package_name),
-                    resolved_env,
-                )
-                config["args"] = docker_args + processed_package_args
-            else:
-                config["args"] = DockerArgsProcessor.process_docker_args(
-                    ["run", "-i", "--rm", package_name], resolved_env
-                )
+            runtime_args = processed_runtime_args or ["run", "-i", "--rm"]
+            docker_args = self._inject_env_vars_into_docker_args(
+                self._ensure_docker_image_arg(runtime_args, package_name),
+                resolved_env,
+            )
+            config["args"] = docker_args + processed_package_args
         else:
             self._apply_pypi_homebrew_generic_config(
                 config,

--- a/src/apm_cli/adapters/client/gemini.py
+++ b/src/apm_cli/adapters/client/gemini.py
@@ -31,7 +31,6 @@ import logging
 import os
 from pathlib import Path
 
-from ...core.docker_args import DockerArgsProcessor
 from ...utils.console import _rich_error, _rich_success
 from .copilot import CopilotClientAdapter
 
@@ -235,15 +234,11 @@ class GeminiClientAdapter(CopilotClientAdapter):
             config["args"] = ["-y", package_name] + processed_rt + processed_pkg  # noqa: RUF005
         elif registry_name == "docker":
             config["command"] = "docker"
-            if processed_rt:
-                docker_args = self._inject_env_vars_into_docker_args(
-                    self._ensure_docker_image_arg(processed_rt, package_name), resolved_env
-                )
-                config["args"] = docker_args + processed_pkg
-            else:
-                config["args"] = DockerArgsProcessor.process_docker_args(
-                    ["run", "-i", "--rm", package_name], resolved_env
-                )
+            runtime_args = processed_rt or ["run", "-i", "--rm"]
+            docker_args = self._inject_env_vars_into_docker_args(
+                self._ensure_docker_image_arg(runtime_args, package_name), resolved_env
+            )
+            config["args"] = docker_args + processed_pkg
         elif registry_name == "pypi":
             config["command"] = runtime_hint or "uvx"
             config["args"] = [package_name] + processed_rt + processed_pkg  # noqa: RUF005

--- a/src/apm_cli/adapters/client/vscode.py
+++ b/src/apm_cli/adapters/client/vscode.py
@@ -311,23 +311,12 @@ class VSCodeClientAdapter(MCPClientAdapter):
 
             # Handle docker packages
             elif is_docker:
-                runtime_args = self._extract_package_args(
-                    {"runtime_arguments": package.get("runtime_arguments") or []},
-                    runtime_vars=runtime_vars,
-                )
-                package_args = (
-                    self._extract_package_args(
-                        {"package_arguments": package["package_arguments"]},
-                        runtime_vars=runtime_vars,
+                args = self._docker_run_args(package, runtime_vars) or (
+                    self._ensure_docker_image_arg(
+                        ["run", "-i", "--rm"],
+                        package.get("name"),
                     )
-                    if package.get("package_arguments")
-                    else []
                 )
-                args = self._ensure_docker_image_arg(
-                    runtime_args or ["run", "-i", "--rm"],
-                    package.get("name"),
-                )
-                args += package_args
 
                 server_config = {"type": "stdio", "command": "docker", "args": args}
 
@@ -677,6 +666,94 @@ class VSCodeClientAdapter(MCPClientAdapter):
                 return args
 
         return []
+
+    @classmethod
+    def _docker_run_args(cls, package, runtime_vars=None):
+        """Build ``docker run`` arguments from a container package's metadata.
+
+        ``_extract_package_args`` cannot serve this path: the npm, pypi, and
+        generic branches read an empty extraction as "synthesize the command
+        from the package name", so teaching it the MCP Registry v0.1 argument
+        shape would strip the package name out of those launchers. Container
+        packages instead need the registry's run options assembled into a
+        launchable command, which is what this builds.
+
+        Handles both argument spellings -- v0.1 ``value`` (beside a ``type``)
+        and the legacy ``value_hint`` -- because reading only the latter
+        dropped every option a v0.1 registry supplied, including mounts whose
+        values APM had just collected from the user (#2377). ``named`` entries
+        contribute their flag as well as its value, matching
+        ``CopilotClientAdapter._process_arguments``.
+
+        Returns ``None`` -- leaving the caller on its previous synthesized
+        launcher -- when the registry arguments cannot form a usable command:
+        no ``run`` verb, or a placeholder this install could not resolve.
+        Emitting a half-substituted mount path would be worse than the
+        image-only command that shipped before.
+
+        Args:
+            package (dict): A single package entry from the registry.
+            runtime_vars (dict, optional): Collected runtime variable values.
+
+        Returns:
+            list[str] | None: Ordered ``docker`` arguments, or None to decline.
+        """
+        args: list[str] = []
+        for arg in package.get("runtime_arguments") or []:
+            if not isinstance(arg, dict):
+                continue
+            # v0.1 marks optional entries with ``isRequired``; only package-level
+            # keys get camelCase-normalized, so accept either spelling here.
+            required = arg.get("is_required", arg.get("isRequired", True))
+            template = arg.get("value_hint")
+            if template is None:
+                template = arg.get("value")
+            if template is None or template == "":
+                continue
+            template = str(template)
+            variables = arg.get("variables")
+            if isinstance(variables, dict) and variables:
+                template = cls._substitute_runtime_variables(template, variables, runtime_vars)
+                if template is None:
+                    return None
+            elif not required:
+                continue
+            if arg.get("type") == "named" and arg.get("name"):
+                args.append(str(arg["name"]))
+            args.append(template)
+
+        # Without the subcommand there is nothing to normalize flags around and
+        # the rendered entry would not be a `docker run` invocation at all.
+        if "run" not in args:
+            return None
+
+        # Reuse the shared normalizer so a registry template that omits -i/--rm
+        # still yields an interactive, self-cleaning container.
+        from ...core.docker_args import DockerArgsProcessor
+
+        args = DockerArgsProcessor.process_docker_args(args, {})
+        return cls._ensure_docker_image_arg(args, package.get("name"))
+
+    @staticmethod
+    def _substitute_runtime_variables(template, variables, runtime_vars):
+        """Substitute ``{var}`` placeholders, or return None if unresolvable.
+
+        ``workspaceFolder`` resolves to VS Code's own ``${workspaceFolder}``
+        token, which the editor expands at server start. Any other name that
+        this install did not collect a value for has no such fallback, so the
+        caller is told to decline rather than write a literal ``${name}`` into
+        a mount path.
+        """
+        for var_name in variables:
+            supplied = (runtime_vars or {}).get(var_name)
+            if supplied:
+                replacement = str(supplied)
+            elif var_name == "workspaceFolder":
+                replacement = "${workspaceFolder}"
+            else:
+                return None
+            template = template.replace(f"{{{var_name}}}", replacement)
+        return template
 
     @staticmethod
     def _select_remote_with_url(remotes):

--- a/src/apm_cli/adapters/client/vscode.py
+++ b/src/apm_cli/adapters/client/vscode.py
@@ -747,7 +747,10 @@ class VSCodeClientAdapter(MCPClientAdapter):
         # Reuse the shared normalizer so a registry template that omits -i/--rm
         # still yields an interactive, self-cleaning container.
         args: list[str] = DockerArgsProcessor.process_docker_args(run_options, {})
-        with_image: list[str] = cls._ensure_docker_image_arg(args, image)
+        try:
+            with_image: list[str] = cls._ensure_docker_image_arg(args, image)
+        except ValueError:
+            return None
         return with_image + package_args
 
     @classmethod

--- a/src/apm_cli/adapters/client/vscode.py
+++ b/src/apm_cli/adapters/client/vscode.py
@@ -714,12 +714,19 @@ class VSCodeClientAdapter(MCPClientAdapter):
         if not package:
             return None
         run_options = cls._docker_arg_values(package.get("runtime_arguments"), runtime_vars)
+        if run_options is None:
+            return None
         package_args = cls._docker_arg_values(package.get("package_arguments"), runtime_vars)
         if package_args is None:
             return None
         if not run_options and package_args and package_args[0] == "run":
-            run_options = package_args
-            package_args = []
+            image_index = cls._docker_image_arg_index(package_args, package.get("name"))
+            if image_index is None:
+                run_options = package_args
+                package_args = []
+            else:
+                run_options = package_args[: image_index + 1]
+                package_args = package_args[image_index + 1 :]
         # The subcommand has to lead: `docker -v … run` is not a run invocation,
         # and there would be nothing for the flag normalizer to anchor on.
         if not run_options or run_options[0] != "run":
@@ -730,7 +737,9 @@ class VSCodeClientAdapter(MCPClientAdapter):
         # instead of describing the container's own arguments. Appending that
         # after the image would hand docker a second `run …` as the container
         # command, so treat it as a duplicate of what runtime_arguments said.
-        if (package_args and package_args[0] == "run") or (image and image in package_args):
+        if (package_args and package_args[0] == "run") or any(
+            cls._docker_image_references_match(argument, image) for argument in package_args
+        ):
             package_args = []
 
         # Reuse the shared normalizer so a registry template that omits -i/--rm

--- a/src/apm_cli/adapters/client/vscode.py
+++ b/src/apm_cli/adapters/client/vscode.py
@@ -317,7 +317,9 @@ class VSCodeClientAdapter(MCPClientAdapter):
                     if package.get("runtime_arguments") or package.get("package_arguments"):
                         _rich_warning(
                             "Could not resolve container run options for "
-                            f"'{package.get('name', '')}'; using the default launcher."
+                            f"'{package.get('name', '')}'; using the default launcher. "
+                            "Set the required registry runtime variables and rerun "
+                            "'apm install'."
                         )
                     args = self._ensure_docker_image_arg(
                         ["run", "-i", "--rm"],

--- a/src/apm_cli/adapters/client/vscode.py
+++ b/src/apm_cli/adapters/client/vscode.py
@@ -685,6 +685,9 @@ class VSCodeClientAdapter(MCPClientAdapter):
         contribute their flag as well as its value, matching
         ``CopilotClientAdapter._process_arguments``.
 
+        ``package_arguments`` are the container's own argv and follow the image
+        per ``docker run [OPTIONS] IMAGE [ARG...]``.
+
         Returns ``None`` -- leaving the caller on its previous synthesized
         launcher -- when the registry arguments cannot form a usable command:
         no ``run`` verb, or a placeholder this install could not resolve.
@@ -698,8 +701,31 @@ class VSCodeClientAdapter(MCPClientAdapter):
         Returns:
             list[str] | None: Ordered ``docker`` arguments, or None to decline.
         """
+        run_options = cls._docker_arg_values(package.get("runtime_arguments"), runtime_vars)
+        # Without the subcommand there is nothing to normalize flags around and
+        # the rendered entry would not be a `docker run` invocation at all.
+        if run_options is None or "run" not in run_options:
+            return None
+        container_args = cls._docker_arg_values(package.get("package_arguments"), runtime_vars)
+        if container_args is None:
+            return None
+
+        # Reuse the shared normalizer so a registry template that omits -i/--rm
+        # still yields an interactive, self-cleaning container.
+        from ...core.docker_args import DockerArgsProcessor
+
+        args = DockerArgsProcessor.process_docker_args(run_options, {})
+        return cls._ensure_docker_image_arg(args, package.get("name")) + container_args
+
+    @classmethod
+    def _docker_arg_values(cls, entries, runtime_vars):
+        """Resolve one registry argument list into CLI argument strings.
+
+        Returns ``None`` when an entry carries a placeholder this install has
+        no value for, so the caller can decline the whole command.
+        """
         args: list[str] = []
-        for arg in package.get("runtime_arguments") or []:
+        for arg in entries or []:
             if not isinstance(arg, dict):
                 continue
             # v0.1 marks optional entries with ``isRequired``; only package-level
@@ -721,18 +747,7 @@ class VSCodeClientAdapter(MCPClientAdapter):
             if arg.get("type") == "named" and arg.get("name"):
                 args.append(str(arg["name"]))
             args.append(template)
-
-        # Without the subcommand there is nothing to normalize flags around and
-        # the rendered entry would not be a `docker run` invocation at all.
-        if "run" not in args:
-            return None
-
-        # Reuse the shared normalizer so a registry template that omits -i/--rm
-        # still yields an interactive, self-cleaning container.
-        from ...core.docker_args import DockerArgsProcessor
-
-        args = DockerArgsProcessor.process_docker_args(args, {})
-        return cls._ensure_docker_image_arg(args, package.get("name"))
+        return args
 
     @staticmethod
     def _substitute_runtime_variables(template, variables, runtime_vars):

--- a/src/apm_cli/adapters/client/vscode.py
+++ b/src/apm_cli/adapters/client/vscode.py
@@ -668,7 +668,7 @@ class VSCodeClientAdapter(MCPClientAdapter):
         return []
 
     @classmethod
-    def _docker_run_args(cls, package, runtime_vars=None):
+    def _docker_run_args(cls, package: dict, runtime_vars: dict | None = None) -> list[str] | None:
         """Build ``docker run`` arguments from a container package's metadata.
 
         ``_extract_package_args`` cannot serve this path: the npm, pypi, and
@@ -690,9 +690,13 @@ class VSCodeClientAdapter(MCPClientAdapter):
 
         Returns ``None`` -- leaving the caller on its previous synthesized
         launcher -- when the registry arguments cannot form a usable command:
-        no ``run`` verb, or a placeholder this install could not resolve.
-        Emitting a half-substituted mount path would be worse than the
-        image-only command that shipped before.
+        no ``run`` verb, or a placeholder in a required entry that this
+        install could not resolve. Emitting a half-substituted mount path
+        would be worse than the image-only command that shipped before. An
+        *optional* entry whose placeholder is unresolved is dropped on its
+        own instead -- declining a whole working command over a mount the
+        registry itself marked optional would throw away every required
+        argument with it.
 
         Args:
             package (dict): A single package entry from the registry.
@@ -714,15 +718,25 @@ class VSCodeClientAdapter(MCPClientAdapter):
         # still yields an interactive, self-cleaning container.
         from ...core.docker_args import DockerArgsProcessor
 
-        args = DockerArgsProcessor.process_docker_args(run_options, {})
-        return cls._ensure_docker_image_arg(args, package.get("name")) + container_args
+        args: list[str] = DockerArgsProcessor.process_docker_args(run_options, {})
+        args = cls._ensure_docker_image_arg(args, package.get("name"))
+        return args + container_args
 
     @classmethod
-    def _docker_arg_values(cls, entries, runtime_vars):
+    def _docker_arg_values(
+        cls, entries: list | None, runtime_vars: dict | None
+    ) -> list[str] | None:
         """Resolve one registry argument list into CLI argument strings.
 
-        Returns ``None`` when an entry carries a placeholder this install has
-        no value for, so the caller can decline the whole command.
+        Returns ``None`` when a *required* entry carries a placeholder this
+        install has no value for, so the caller can decline the whole command.
+        An optional entry in the same situation is skipped by itself.
+
+        An optional entry whose placeholder DID resolve is kept: its value was
+        explicitly collected from the user, and discarding user-supplied
+        configuration is the failure mode #2377 exists to prevent. (This also
+        matches the legacy ``value_hint`` walk in ``_extract_package_args``,
+        which never gated variables-bearing entries on ``is_required``.)
         """
         args: list[str] = []
         for arg in entries or []:
@@ -739,9 +753,12 @@ class VSCodeClientAdapter(MCPClientAdapter):
             template = str(template)
             variables = arg.get("variables")
             if isinstance(variables, dict) and variables:
-                template = cls._substitute_runtime_variables(template, variables, runtime_vars)
-                if template is None:
-                    return None
+                substituted = cls._substitute_runtime_variables(template, variables, runtime_vars)
+                if substituted is None:
+                    if required:
+                        return None
+                    continue
+                template = substituted
             elif not required:
                 continue
             if arg.get("type") == "named" and arg.get("name"):
@@ -750,7 +767,9 @@ class VSCodeClientAdapter(MCPClientAdapter):
         return args
 
     @staticmethod
-    def _substitute_runtime_variables(template, variables, runtime_vars):
+    def _substitute_runtime_variables(
+        template: str, variables: dict, runtime_vars: dict | None
+    ) -> str | None:
         """Substitute ``{var}`` placeholders, or return None if unresolvable.
 
         ``workspaceFolder`` resolves to VS Code's own ``${workspaceFolder}``

--- a/src/apm_cli/adapters/client/vscode.py
+++ b/src/apm_cli/adapters/client/vscode.py
@@ -9,6 +9,7 @@ import json
 import re
 from pathlib import Path
 
+from ...core.docker_args import DockerArgsProcessor
 from ...registry.client import SimpleRegistryClient
 from ...registry.integration import RegistryIntegration
 from ...utils.console import _rich_warning
@@ -705,22 +706,30 @@ class VSCodeClientAdapter(MCPClientAdapter):
         Returns:
             list[str] | None: Ordered ``docker`` arguments, or None to decline.
         """
+        if not package:
+            return None
         run_options = cls._docker_arg_values(package.get("runtime_arguments"), runtime_vars)
-        # Without the subcommand there is nothing to normalize flags around and
-        # the rendered entry would not be a `docker run` invocation at all.
-        if run_options is None or "run" not in run_options:
+        # The subcommand has to lead: `docker -v … run` is not a run invocation,
+        # and there would be nothing for the flag normalizer to anchor on.
+        if not run_options or run_options[0] != "run":
             return None
         container_args = cls._docker_arg_values(package.get("package_arguments"), runtime_vars)
         if container_args is None:
             return None
 
+        image = package.get("name")
+        # Some registry data repeats the whole docker argv in package_arguments
+        # instead of describing the container's own arguments. Appending that
+        # after the image would hand docker a second `run …` as the container
+        # command, so treat it as a duplicate of what runtime_arguments said.
+        if "run" in container_args or (image and image in container_args):
+            container_args = []
+
         # Reuse the shared normalizer so a registry template that omits -i/--rm
         # still yields an interactive, self-cleaning container.
-        from ...core.docker_args import DockerArgsProcessor
-
         args: list[str] = DockerArgsProcessor.process_docker_args(run_options, {})
-        args = cls._ensure_docker_image_arg(args, package.get("name"))
-        return args + container_args
+        with_image: list[str] = cls._ensure_docker_image_arg(args, image)
+        return with_image + container_args
 
     @classmethod
     def _docker_arg_values(
@@ -742,15 +751,34 @@ class VSCodeClientAdapter(MCPClientAdapter):
         for arg in entries or []:
             if not isinstance(arg, dict):
                 continue
+            arg_type = arg.get("type")
             # v0.1 marks optional entries with ``isRequired``; only package-level
-            # keys get camelCase-normalized, so accept either spelling here.
-            required = arg.get("is_required", arg.get("isRequired", True))
-            template = arg.get("value_hint")
-            if template is None:
-                template = arg.get("value")
-            if template is None or template == "":
+            # keys get camelCase-normalized, so accept either spelling here. An
+            # explicit null means "unspecified", not "optional".
+            required = arg.get("is_required", arg.get("isRequired"))
+            required = True if required is None else bool(required)
+            if not required and "variables" not in arg:
                 continue
-            template = str(template)
+
+            # A typed entry carries its payload in ``value`` -- ``value_hint`` is
+            # the schema's *display* hint for it, and emitting that renders
+            # placeholder words like "env_var_name" as CLI arguments. Untyped
+            # legacy entries have only the hint. This mirrors
+            # ``CopilotClientAdapter._process_arguments``.
+            if arg_type in ("positional", "named"):
+                raw = arg.get("value", arg.get("default"))
+            else:
+                raw = arg.get("value_hint", arg.get("value", arg.get("default")))
+
+            # A named entry contributes its flag even with no value: dropping a
+            # valueless ``--read-only`` / ``--user`` silently weakens the
+            # container's security posture.
+            if arg_type == "named" and arg.get("name"):
+                args.append(str(arg["name"]))
+            if raw is None or raw == "":
+                continue
+
+            template = str(raw)
             variables = arg.get("variables")
             if isinstance(variables, dict) and variables:
                 substituted = cls._substitute_runtime_variables(template, variables, runtime_vars)
@@ -759,10 +787,6 @@ class VSCodeClientAdapter(MCPClientAdapter):
                         return None
                     continue
                 template = substituted
-            elif not required:
-                continue
-            if arg.get("type") == "named" and arg.get("name"):
-                args.append(str(arg["name"]))
             args.append(template)
         return args
 
@@ -779,14 +803,19 @@ class VSCodeClientAdapter(MCPClientAdapter):
         a mount path.
         """
         for var_name in variables:
+            placeholder = f"{{{var_name}}}"
+            # A descriptor the template never references cannot make it
+            # unresolvable; declining on one would drop a usable argument.
+            if placeholder not in template:
+                continue
             supplied = (runtime_vars or {}).get(var_name)
-            if supplied:
+            if supplied is not None and str(supplied) != "":
                 replacement = str(supplied)
             elif var_name == "workspaceFolder":
                 replacement = "${workspaceFolder}"
             else:
                 return None
-            template = template.replace(f"{{{var_name}}}", replacement)
+            template = template.replace(placeholder, replacement)
         return template
 
     @staticmethod

--- a/src/apm_cli/adapters/client/vscode.py
+++ b/src/apm_cli/adapters/client/vscode.py
@@ -714,12 +714,15 @@ class VSCodeClientAdapter(MCPClientAdapter):
         if not package:
             return None
         run_options = cls._docker_arg_values(package.get("runtime_arguments"), runtime_vars)
+        package_args = cls._docker_arg_values(package.get("package_arguments"), runtime_vars)
+        if package_args is None:
+            return None
+        if not run_options and package_args and package_args[0] == "run":
+            run_options = package_args
+            package_args = []
         # The subcommand has to lead: `docker -v … run` is not a run invocation,
         # and there would be nothing for the flag normalizer to anchor on.
         if not run_options or run_options[0] != "run":
-            return None
-        container_args = cls._docker_arg_values(package.get("package_arguments"), runtime_vars)
-        if container_args is None:
             return None
 
         image = package.get("name")
@@ -727,14 +730,14 @@ class VSCodeClientAdapter(MCPClientAdapter):
         # instead of describing the container's own arguments. Appending that
         # after the image would hand docker a second `run …` as the container
         # command, so treat it as a duplicate of what runtime_arguments said.
-        if "run" in container_args or (image and image in container_args):
-            container_args = []
+        if (package_args and package_args[0] == "run") or (image and image in package_args):
+            package_args = []
 
         # Reuse the shared normalizer so a registry template that omits -i/--rm
         # still yields an interactive, self-cleaning container.
         args: list[str] = DockerArgsProcessor.process_docker_args(run_options, {})
         with_image: list[str] = cls._ensure_docker_image_arg(args, image)
-        return with_image + container_args
+        return with_image + package_args
 
     @classmethod
     def _docker_arg_values(
@@ -775,12 +778,11 @@ class VSCodeClientAdapter(MCPClientAdapter):
             else:
                 raw = arg.get("value_hint", arg.get("value", arg.get("default")))
 
-            # A named entry contributes its flag even with no value: dropping a
-            # valueless ``--read-only`` / ``--user`` silently weakens the
-            # container's security posture.
-            if arg_type == "named" and arg.get("name"):
-                args.append(str(arg["name"]))
             if raw is None or raw == "":
+                # A named entry contributes its flag even with no value:
+                # dropping ``--read-only`` silently weakens the container.
+                if arg_type == "named" and arg.get("name"):
+                    args.append(str(arg["name"]))
                 continue
 
             template = str(raw)
@@ -792,6 +794,8 @@ class VSCodeClientAdapter(MCPClientAdapter):
                         return None
                     continue
                 template = substituted
+            if arg_type == "named" and arg.get("name"):
+                args.append(str(arg["name"]))
             args.append(template)
         return args
 

--- a/src/apm_cli/adapters/client/vscode.py
+++ b/src/apm_cli/adapters/client/vscode.py
@@ -312,12 +312,17 @@ class VSCodeClientAdapter(MCPClientAdapter):
 
             # Handle docker packages
             elif is_docker:
-                args = self._docker_run_args(package, runtime_vars) or (
-                    self._ensure_docker_image_arg(
+                args = self._docker_run_args(package, runtime_vars)
+                if args is None:
+                    if package.get("runtime_arguments") or package.get("package_arguments"):
+                        _rich_warning(
+                            "Could not resolve container run options for "
+                            f"'{package.get('name', '')}'; using the default launcher."
+                        )
+                    args = self._ensure_docker_image_arg(
                         ["run", "-i", "--rm"],
                         package.get("name"),
                     )
-                )
 
                 server_config = {"type": "stdio", "command": "docker", "args": args}
 
@@ -661,8 +666,6 @@ class VSCodeClientAdapter(MCPClientAdapter):
                     elif "value_hint" in arg and arg["value_hint"] and "is_required" not in arg:
                         # v0.1 format: plain value_hint entries without is_required
                         args.append(arg["value_hint"])
-                    elif arg.get("value"):
-                        args.append(arg["value"])
             if args:
                 return args
 

--- a/src/apm_cli/adapters/client/vscode.py
+++ b/src/apm_cli/adapters/client/vscode.py
@@ -727,6 +727,8 @@ class VSCodeClientAdapter(MCPClientAdapter):
             else:
                 run_options = package_args[: image_index + 1]
                 package_args = package_args[image_index + 1 :]
+        elif not run_options and package_args:
+            run_options = ["run", "-i", "--rm"]
         # The subcommand has to lead: `docker -v … run` is not a run invocation,
         # and there would be nothing for the flag normalizer to anchor on.
         if not run_options or run_options[0] != "run":
@@ -791,7 +793,12 @@ class VSCodeClientAdapter(MCPClientAdapter):
                 # A named entry contributes its flag even with no value:
                 # dropping ``--read-only`` silently weakens the container.
                 if arg_type == "named" and arg.get("name"):
-                    args.append(str(arg["name"]))
+                    name = str(arg["name"])
+                    if cls._docker_option_requires_value(name):
+                        if required:
+                            return None
+                        continue
+                    args.append(name)
                 continue
 
             template = str(raw)

--- a/src/apm_cli/registry/operations.py
+++ b/src/apm_cli/registry/operations.py
@@ -280,20 +280,25 @@ class MCPServerOperations:
                 if not server_info:
                     continue
 
-                # Extract runtime variables from runtime_arguments
+                # Extract runtime variables from both Docker argument phases.
                 packages = server_info.get("packages", [])
                 for package in packages:
                     if isinstance(package, dict):
-                        runtime_arguments = package.get("runtime_arguments", [])
-                        for arg in runtime_arguments:
-                            if isinstance(arg, dict) and "variables" in arg:
-                                variables = arg.get("variables", {})
-                                for var_name, var_info in variables.items():
-                                    if isinstance(var_info, dict):
-                                        collected_runtime_vars[var_name] = {
-                                            "description": var_info.get("description", ""),
-                                            "required": var_info.get("is_required", True),
-                                        }
+                        for field_name in ("runtime_arguments", "package_arguments"):
+                            for arg in package.get(field_name, []):
+                                if isinstance(arg, dict) and "variables" in arg:
+                                    variables = arg.get("variables", {})
+                                    if not isinstance(variables, dict):
+                                        continue
+                                    for var_name, var_info in variables.items():
+                                        if isinstance(var_info, dict):
+                                            collected_runtime_vars[var_name] = {
+                                                "description": var_info.get("description", ""),
+                                                "required": var_info.get(
+                                                    "is_required",
+                                                    var_info.get("isRequired", True),
+                                                ),
+                                            }
 
             except Exception:  # noqa: S112
                 # Skip servers we can't analyze

--- a/tests/integration/test_oci_mcp_lifecycle_contract.py
+++ b/tests/integration/test_oci_mcp_lifecycle_contract.py
@@ -35,6 +35,8 @@ _VALUE_SERVER_NAME = "com.example.lifecycle/vscode-value-server"
 _VALUE_SERVER_IMAGE = "registry.example.invalid/team/vscode-value-server:2.0.0"
 _WORKDIR_VARIABLE = "MCP_TEST_WORKDIR"
 _WORKDIR_VALUE = "/fixture/workdir"
+_CONFIG_VARIABLE = "MCP_TEST_CONFIG"
+_CONFIG_VALUE = "/fixture/config.json"
 
 
 @dataclass(frozen=True)
@@ -157,7 +159,18 @@ def _vscode_value_server_document() -> dict[str, object]:
                         "type": "named",
                         "name": "--transport",
                         "value": "stdio",
-                    }
+                    },
+                    {
+                        "type": "named",
+                        "name": "--config",
+                        "value": f"{{{_CONFIG_VARIABLE}}}",
+                        "variables": {
+                            _CONFIG_VARIABLE: {
+                                "description": "Container config path",
+                                "isRequired": True,
+                            }
+                        },
+                    },
                 ],
             }
         ],
@@ -352,7 +365,11 @@ def test_vscode_typed_value_mount_survives_install_update_and_offline_audit(
         timeout_seconds=120,
         scenario_timeout_seconds=300,
     )
-    install_env = isolated.subprocess_env(overrides={_WORKDIR_VARIABLE: _WORKDIR_VALUE})
+    runtime_values = {
+        _WORKDIR_VARIABLE: _WORKDIR_VALUE,
+        _CONFIG_VARIABLE: _CONFIG_VALUE,
+    }
+    install_env = isolated.subprocess_env(overrides=runtime_values)
     install_env.pop("PYTHONPATH")
     install_env["MCP_REGISTRY_ALLOW_HTTP"] = "1"
     reinstall = (
@@ -377,6 +394,8 @@ def test_vscode_typed_value_mount_survives_install_update_and_offline_audit(
         _VALUE_SERVER_IMAGE,
         "--transport",
         "stdio",
+        "--config",
+        _CONFIG_VALUE,
     ]
 
     with registry_factory.start(_vscode_value_server_document()) as registry:
@@ -431,7 +450,7 @@ def test_vscode_typed_value_mount_survives_install_update_and_offline_audit(
         assert any(path.startswith("/v0.1/servers?") for path in registry.request_paths)
         assert any(path.endswith("/versions/latest") for path in registry.request_paths)
 
-    audit_env = isolated.subprocess_env(overrides={_WORKDIR_VARIABLE: _WORKDIR_VALUE})
+    audit_env = isolated.subprocess_env(overrides=runtime_values)
     before_audit = LifecycleStateSnapshot.capture(project, config_paths=(config_path,))
     audit = runner.run(
         ("audit", "--ci", "--no-policy", "--format", "json"),

--- a/tests/integration/test_oci_mcp_lifecycle_contract.py
+++ b/tests/integration/test_oci_mcp_lifecycle_contract.py
@@ -381,7 +381,7 @@ def test_vscode_typed_value_mount_survives_install_update_and_offline_audit(
         "--trust-transitive-mcp",
         "--no-policy",
     )
-    update = ("update", "--yes", "--target", "copilot")
+    update = ("update", "--yes", "--target", "vscode")
     expected_args = [
         "run",
         "-i",

--- a/tests/integration/test_oci_mcp_lifecycle_contract.py
+++ b/tests/integration/test_oci_mcp_lifecycle_contract.py
@@ -31,6 +31,10 @@ _ENV_NAME = "OCI_TEST_ENV"
 _ENV_VALUE = "lifecycle-value"
 _RUNTIME_ARGS = ["run", "--rm", "-i", "--label", "apm.lifecycle=true", "-e"]
 _PACKAGE_ARGS = ["--transport", "stdio"]
+_VALUE_SERVER_NAME = "com.example.lifecycle/vscode-value-server"
+_VALUE_SERVER_IMAGE = "registry.example.invalid/team/vscode-value-server:2.0.0"
+_WORKDIR_VARIABLE = "MCP_TEST_WORKDIR"
+_WORKDIR_VALUE = "/fixture/workdir"
 
 
 @dataclass(frozen=True)
@@ -104,6 +108,55 @@ def _server_document() -> dict[str, object]:
                         "name": _ENV_NAME,
                         "description": "Lifecycle fixture environment value",
                         "isRequired": True,
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def _vscode_value_server_document() -> dict[str, object]:
+    """Return a v0.1 container package with typed and variable-backed arguments."""
+    return {
+        "name": _VALUE_SERVER_NAME,
+        "description": "Lifecycle fixture for VS Code typed container arguments",
+        "version": "2.0.0",
+        "packages": [
+            {
+                "registryType": "oci",
+                "identifier": _VALUE_SERVER_IMAGE,
+                "runtimeHint": "docker",
+                "transport": {"type": "stdio"},
+                "runtimeArguments": [
+                    {
+                        "type": "positional",
+                        "value": "run",
+                        "valueHint": "docker_subcommand",
+                    },
+                    {"type": "named", "name": "--read-only"},
+                    {
+                        "type": "named",
+                        "name": "--mount",
+                        "value": f"type=bind,src={{{_WORKDIR_VARIABLE}}},dst=/workspace",
+                        "valueHint": "mount_spec",
+                        "variables": {
+                            _WORKDIR_VARIABLE: {
+                                "description": "Workspace path mounted into the container",
+                                "isRequired": True,
+                            }
+                        },
+                    },
+                    {
+                        "type": "named",
+                        "name": "--workdir",
+                        "default": "/workspace",
+                    },
+                ],
+                "packageArguments": [
+                    {
+                        "type": "named",
+                        "name": "--transport",
+                        "value": "stdio",
                     }
                 ],
             }
@@ -272,3 +325,121 @@ def test_oci_mcp_install_lifecycle_is_cross_adapter_and_idempotent(
     assert audit.returncode == 0, f"stdout={audit.stdout!r}\nstderr={audit.stderr!r}"
     audit_payload = json.loads(audit.stdout)
     assert audit_payload["passed"] is True
+
+
+def test_vscode_typed_value_mount_survives_install_update_and_offline_audit(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Render collected v0.1 values through the installed CLI and keep state exact."""
+    isolated = IsolatedApmEnvironment.create(
+        tmp_path / "vscode-value-runtime-args",
+        base_env=dict(os.environ),
+    )
+    project = (
+        LocalPackageFactory(isolated.work_root)
+        .create(
+            "vscode-value-consumer",
+            targets=("copilot",),
+        )
+        .root
+    )
+    config_path = PurePosixPath(".vscode/mcp.json")
+    (project / config_path.parent).mkdir(parents=True, exist_ok=True)
+    registry_factory = LocalMcpRegistryFactory(isolated.root / "registries")
+    runner = ApmLifecycleRunner(
+        (str(apm_binary_path),),
+        timeout_seconds=120,
+        scenario_timeout_seconds=300,
+    )
+    install_env = isolated.subprocess_env(overrides={_WORKDIR_VARIABLE: _WORKDIR_VALUE})
+    install_env.pop("PYTHONPATH")
+    install_env["MCP_REGISTRY_ALLOW_HTTP"] = "1"
+    reinstall = (
+        "install",
+        "--runtime",
+        "vscode",
+        "--target",
+        "copilot",
+        "--trust-transitive-mcp",
+        "--no-policy",
+    )
+    update = ("update", "--yes", "--target", "copilot")
+    expected_args = [
+        "run",
+        "-i",
+        "--rm",
+        "--read-only",
+        "--mount",
+        f"type=bind,src={_WORKDIR_VALUE},dst=/workspace",
+        "--workdir",
+        "/workspace",
+        _VALUE_SERVER_IMAGE,
+        "--transport",
+        "stdio",
+    ]
+
+    with registry_factory.start(_vscode_value_server_document()) as registry:
+        source = LocalPackageFactory(isolated.package_root).create(
+            "vscode-value-source",
+            mcp_dependencies=(
+                {
+                    "name": _VALUE_SERVER_NAME,
+                    "registry": registry.url,
+                },
+            ),
+        )
+        initial_install = (
+            "install",
+            str(source.root),
+            "--runtime",
+            "vscode",
+            "--target",
+            "copilot",
+            "--trust-transitive-mcp",
+            "--no-policy",
+        )
+        runner.run_sequence(
+            (initial_install,),
+            expected_returncodes=(0,),
+            scenario_id="vscode-value-initial-install",
+            cwd=project,
+            env=install_env,
+        )
+        first = LifecycleStateSnapshot.capture(project, config_paths=(config_path,))
+        document = json.loads((project / config_path).read_text(encoding="utf-8"))
+        assert document == {
+            "servers": {
+                _VALUE_SERVER_NAME: {
+                    "type": "stdio",
+                    "command": "docker",
+                    "args": expected_args,
+                }
+            },
+            "inputs": [],
+        }
+
+        runner.run_sequence(
+            (reinstall, update),
+            expected_returncodes=(0, 0),
+            scenario_id="vscode-value-reinstall-update",
+            cwd=project,
+            env=install_env,
+        )
+        converged = LifecycleStateSnapshot.capture(project, config_paths=(config_path,))
+        _assert_idempotent_state(first, converged)
+        assert any(path.startswith("/v0.1/servers?") for path in registry.request_paths)
+        assert any(path.endswith("/versions/latest") for path in registry.request_paths)
+
+    audit_env = isolated.subprocess_env(overrides={_WORKDIR_VARIABLE: _WORKDIR_VALUE})
+    before_audit = LifecycleStateSnapshot.capture(project, config_paths=(config_path,))
+    audit = runner.run(
+        ("audit", "--ci", "--no-policy", "--format", "json"),
+        scenario_id="vscode-value-offline-audit",
+        cwd=project,
+        env=audit_env,
+    )
+    assert audit.returncode == 0, f"stdout={audit.stdout!r}\nstderr={audit.stderr!r}"
+    assert json.loads(audit.stdout)["passed"] is True
+    after_audit = LifecycleStateSnapshot.capture(project, config_paths=(config_path,))
+    assert after_audit == before_audit

--- a/tests/unit/adapters/test_oci_docker_launcher.py
+++ b/tests/unit/adapters/test_oci_docker_launcher.py
@@ -279,6 +279,10 @@ class TestEnsureDockerImageArg(unittest.TestCase):
             ["run", "-itp", "8080:80", "docker.io/library/8080:latest"],
         )
 
+    def test_missing_value_for_docker_option_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "Docker run option '--user' requires a value"):
+            MCPClientAdapter._ensure_docker_image_arg(["run", "--user"], OCI_IMAGE)
+
     def test_docker_hub_short_form_matches_the_qualified_identifier(self):
         """Registries qualify the identifier while their run args stay implicit."""
         base = ["run", "-i", "--rm", "mcp/github"]
@@ -355,6 +359,20 @@ class TestOciLauncherAcrossTargets(unittest.TestCase):
         config = _make_codex()._format_server_config(SERVER_INFO, runtime_vars=RUNTIME_VARS)
         self.assertEqual(config.get("command"), "docker")
         self.assertEqual(config.get("args"), EXPECTED_ARGS)
+
+    def test_codex_named_runtime_argument_emits_name_then_value(self):
+        package = dict(OCI_PACKAGE)
+        package["runtime_arguments"] = [
+            {"type": "positional", "value": "run"},
+            {"type": "named", "name": "--network", "value": "none"},
+        ]
+        config = _make_codex()._format_server_config(
+            {"id": "s", "name": "s", "packages": [package]}
+        )
+        self.assertEqual(
+            config.get("args"),
+            ["run", "--network", "none", OCI_IMAGE],
+        )
 
     def test_existing_docker_package_gains_no_duplicate_image(self):
         """Regression guard for packages that already worked before #2376.

--- a/tests/unit/adapters/test_oci_docker_launcher.py
+++ b/tests/unit/adapters/test_oci_docker_launcher.py
@@ -227,6 +227,12 @@ class TestEnsureDockerImageArg(unittest.TestCase):
         )
         self.assertEqual(args[-1], "mcp-server:1.0")
 
+    def test_a_trailing_option_value_does_not_stand_in_for_the_image(self):
+        args = MCPClientAdapter._ensure_docker_image_arg(
+            ["run", "--rm", "--name", "mcp-server"], "mcp-server:1.0"
+        )
+        self.assertEqual(args, ["run", "--rm", "--name", "mcp-server", "mcp-server:1.0"])
+
     def test_docker_hub_short_form_matches_the_qualified_identifier(self):
         """Registries qualify the identifier while their run args stay implicit."""
         base = ["run", "-i", "--rm", "mcp/github"]

--- a/tests/unit/adapters/test_oci_docker_launcher.py
+++ b/tests/unit/adapters/test_oci_docker_launcher.py
@@ -233,6 +233,19 @@ class TestEnsureDockerImageArg(unittest.TestCase):
         )
         self.assertEqual(args, ["run", "--rm", "--name", "mcp-server", "mcp-server:1.0"])
 
+    def test_pull_policy_value_does_not_stand_in_for_the_image(self):
+        args = MCPClientAdapter._ensure_docker_image_arg(
+            ["run", "--pull", "always"], "docker.io/library/always:latest"
+        )
+        self.assertEqual(
+            args,
+            ["run", "--pull", "always", "docker.io/library/always:latest"],
+        )
+
+    def test_image_before_container_argv_is_not_duplicated(self):
+        base = ["run", "--rm", OCI_IMAGE, "--transport", "stdio"]
+        self.assertEqual(MCPClientAdapter._ensure_docker_image_arg(base, OCI_IMAGE), base)
+
     def test_docker_hub_short_form_matches_the_qualified_identifier(self):
         """Registries qualify the identifier while their run args stay implicit."""
         base = ["run", "-i", "--rm", "mcp/github"]

--- a/tests/unit/adapters/test_oci_docker_launcher.py
+++ b/tests/unit/adapters/test_oci_docker_launcher.py
@@ -158,10 +158,34 @@ class TestInferRegistryNameOci(unittest.TestCase):
 
     def test_non_string_registry_type_fails_closed_before_launcher_dispatch(self):
         """Malformed explicit types must never reach the generic npx fallback."""
-        with self.assertRaisesRegex(ValueError, "registry_name must be a string"):
+        for malformed in (0, 5, [], {}):
+            with self.subTest(malformed=malformed):
+                with self.assertRaisesRegex(ValueError, "registry_name must be a string"):
+                    MCPClientAdapter._infer_registry_name(
+                        {
+                            "name": "p",
+                            "registry_name": malformed,
+                            "runtime_hint": "docker",
+                        }
+                    )
+
+    def test_whitespace_registry_type_fails_closed_before_launcher_dispatch(self):
+        with self.assertRaisesRegex(ValueError, "registry_name must not be whitespace"):
             MCPClientAdapter._infer_registry_name(
-                {"name": "p", "registry_name": 5, "runtime_hint": "docker"}
+                {
+                    "name": "registry.example.invalid/team/server:1",
+                    "registry_name": " ",
+                    "runtime_hint": "docker",
+                }
             )
+
+    def test_empty_registry_type_still_uses_safe_runtime_inference(self):
+        self.assertEqual(
+            MCPClientAdapter._infer_registry_name(
+                {"name": "p", "registry_name": "", "runtime_hint": "docker"}
+            ),
+            "docker",
+        )
 
     def test_oci_package_wins_container_selection_priority(self):
         """_select_best_package ranks containers above pypi; oci must qualify."""
@@ -245,6 +269,15 @@ class TestEnsureDockerImageArg(unittest.TestCase):
     def test_image_before_container_argv_is_not_duplicated(self):
         base = ["run", "--rm", OCI_IMAGE, "--transport", "stdio"]
         self.assertEqual(MCPClientAdapter._ensure_docker_image_arg(base, OCI_IMAGE), base)
+
+    def test_clustered_short_value_option_does_not_hide_the_image(self):
+        args = MCPClientAdapter._ensure_docker_image_arg(
+            ["run", "-itp", "8080:80"], "docker.io/library/8080:latest"
+        )
+        self.assertEqual(
+            args,
+            ["run", "-itp", "8080:80", "docker.io/library/8080:latest"],
+        )
 
     def test_docker_hub_short_form_matches_the_qualified_identifier(self):
         """Registries qualify the identifier while their run args stay implicit."""
@@ -406,6 +439,33 @@ class TestOciLauncherAcrossTargets(unittest.TestCase):
                 image_at = args.index(OCI_IMAGE)
                 self.assertEqual(args.count(OCI_IMAGE), 1)
                 self.assertEqual(args[image_at + 1 :], ["--transport", "stdio"])
+
+    def test_package_only_arguments_follow_synthesized_image_across_adapters(self):
+        package = {
+            "name": OCI_IMAGE,
+            "registry_name": "oci",
+            "runtime_hint": "docker",
+            "runtime_arguments": [],
+            "package_arguments": [
+                {"value": "--transport", "type": "positional"},
+                {"value": "stdio", "type": "positional"},
+            ],
+        }
+        for name, make_adapter in (
+            ("copilot", _make_copilot),
+            ("codex", _make_codex),
+            ("gemini", _make_gemini),
+            ("vscode", _make_vscode),
+        ):
+            with self.subTest(adapter=name):
+                rendered = make_adapter()._format_server_config(
+                    {"id": "s", "name": "s", "packages": [package]}
+                )
+                config = rendered[0] if isinstance(rendered, tuple) else rendered
+                self.assertEqual(
+                    config["args"],
+                    ["run", "-i", "--rm", OCI_IMAGE, "--transport", "stdio"],
+                )
 
     def test_vscode_still_renders_a_docker_launcher_for_an_oci_package(self):
         """Guard: VS Code already keyed off runtime_hint, and must stay that way.

--- a/tests/unit/adapters/test_vscode_docker_runtime_args.py
+++ b/tests/unit/adapters/test_vscode_docker_runtime_args.py
@@ -222,17 +222,15 @@ class TestFormatServerConfigDockerVariables(unittest.TestCase):
         self.assertLess(rm_idx, v_idx)
 
     def test_format_server_config_threads_runtime_vars(self):
-        """Verify runtime_vars passed to _format_server_config reaches _extract_package_args."""
+        """Verify runtime_vars passed to _format_server_config reaches the Docker builder."""
         runtime_vars = {"workspaceFolder": "/some/path"}
         with patch.object(
             VSCodeClientAdapter,
-            "_extract_package_args",
-            wraps=VSCodeClientAdapter._extract_package_args,
-        ) as mock_extract:
+            "_docker_run_args",
+            wraps=VSCodeClientAdapter._docker_run_args,
+        ) as mock_builder:
             self.adapter._format_server_config(self.server_info, runtime_vars=runtime_vars)
-            mock_extract.assert_called_once()
-            _, kwargs = mock_extract.call_args
-            self.assertEqual(kwargs.get("runtime_vars"), runtime_vars)
+            mock_builder.assert_called_once_with(V01_DOCKER_PACKAGE, runtime_vars)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/adapters/test_vscode_v01_value_runtime_args.py
+++ b/tests/unit/adapters/test_vscode_v01_value_runtime_args.py
@@ -275,6 +275,22 @@ class TestDockerRunArgs(unittest.TestCase):
             ["run", "-i", "--rm", "-w", WORKDIR, IMAGE],
         )
 
+    def test_optional_named_entry_drops_its_flag_with_unresolved_value(self):
+        package = _docker_package(
+            {"value": "run", "type": "positional"},
+            {
+                "name": "--mount",
+                "value": "type=bind,src={cacheDir},dst=/cache",
+                "type": "named",
+                "is_required": False,
+                "variables": {"cacheDir": {"description": "cache"}},
+            },
+        )
+        self.assertEqual(
+            VSCodeClientAdapter._docker_run_args(package),
+            ["run", "-i", "--rm", IMAGE],
+        )
+
     def test_optional_entry_is_skipped_in_either_spelling(self):
         """Argument-level keys are not camelCase-normalized, so accept both."""
         for key in ("is_required", "isRequired"):
@@ -465,11 +481,12 @@ class TestRenderedDockerLauncher(unittest.TestCase):
                     {"value": "run", "type": "positional"},
                     {"value": "-i", "type": "positional"},
                     {"value": "--rm", "type": "positional"},
+                    {"value": "--read-only", "type": "positional"},
                     {"value": IMAGE, "type": "positional"},
                 ],
             }
         )
-        self.assertEqual(config.get("args"), FALLBACK_ARGS)
+        self.assertEqual(config.get("args"), ["run", "-i", "--rm", "--read-only", IMAGE])
 
 
 if __name__ == "__main__":

--- a/tests/unit/adapters/test_vscode_v01_value_runtime_args.py
+++ b/tests/unit/adapters/test_vscode_v01_value_runtime_args.py
@@ -442,7 +442,8 @@ class TestRenderedDockerLauncher(unittest.TestCase):
         self.assertEqual(config.get("args"), FALLBACK_ARGS)
         warning.assert_called_once_with(
             "Could not resolve container run options for "
-            f"'{IMAGE}'; using the default launcher."
+            f"'{IMAGE}'; using the default launcher. "
+            "Set the required registry runtime variables and rerun 'apm install'."
         )
 
     def test_package_without_runtime_args_keeps_the_synthesized_launcher(self):

--- a/tests/unit/adapters/test_vscode_v01_value_runtime_args.py
+++ b/tests/unit/adapters/test_vscode_v01_value_runtime_args.py
@@ -410,9 +410,7 @@ class TestDockerRunArgs(unittest.TestCase):
             {"value": "run", "type": "positional"},
             {"value": "-v", "variables": None, "type": "positional"},
         )
-        self.assertEqual(
-            VSCodeClientAdapter._docker_run_args(package), ["run", "-i", "--rm", "-v", IMAGE]
-        )
+        self.assertIsNone(VSCodeClientAdapter._docker_run_args(package))
 
     def test_non_string_values_are_coerced_rather_than_dropped(self):
         package = _docker_package(

--- a/tests/unit/adapters/test_vscode_v01_value_runtime_args.py
+++ b/tests/unit/adapters/test_vscode_v01_value_runtime_args.py
@@ -22,7 +22,11 @@ from __future__ import annotations
 import unittest
 from unittest.mock import patch
 
+import pytest
+
 from apm_cli.adapters.client.vscode import VSCodeClientAdapter
+
+pytestmark = pytest.mark.unit
 
 IMAGE = "myregistry.example.com/team/mcp-server:1.4.0"
 WORKDIR = "/home/dev/project"
@@ -433,12 +437,19 @@ class TestRenderedDockerLauncher(unittest.TestCase):
         self.assertNotEqual(config.get("args"), FALLBACK_ARGS)
 
     def test_unresolvable_package_keeps_the_previous_launcher(self):
-        config = _config(V01_VALUE_PACKAGE)
+        with patch("apm_cli.adapters.client.vscode._rich_warning") as warning:
+            config = _config(V01_VALUE_PACKAGE)
         self.assertEqual(config.get("args"), FALLBACK_ARGS)
+        warning.assert_called_once_with(
+            "Could not resolve container run options for "
+            f"'{IMAGE}'; using the default launcher."
+        )
 
     def test_package_without_runtime_args_keeps_the_synthesized_launcher(self):
-        config = _config({"name": IMAGE, "registry_name": "oci", "runtime_hint": "docker"})
+        with patch("apm_cli.adapters.client.vscode._rich_warning") as warning:
+            config = _config({"name": IMAGE, "registry_name": "oci", "runtime_hint": "docker"})
         self.assertEqual(config.get("args"), FALLBACK_ARGS)
+        warning.assert_not_called()
 
     def test_legacy_full_argv_in_package_arguments_stays_verbatim(self):
         """Some registry data authors the complete docker argv in

--- a/tests/unit/adapters/test_vscode_v01_value_runtime_args.py
+++ b/tests/unit/adapters/test_vscode_v01_value_runtime_args.py
@@ -98,6 +98,87 @@ class TestDockerRunArgs(unittest.TestCase):
         args = VSCodeClientAdapter._docker_run_args(V01_VALUE_PACKAGE, RUNTIME_VARS)
         self.assertIn(f"{WORKDIR}:{WORKDIR}", args)
 
+    def test_typed_entries_read_value_not_the_display_hint(self):
+        """`value_hint` is the schema's display hint for a typed argument.
+
+        Real registry data carries both keys -- see the GitHub MCP fixture in
+        tests/test_codex_docker_args_fix.py -- so preferring the hint renders
+        placeholder words like `env_var_name` as CLI arguments.
+        """
+        package = _docker_package(
+            {"type": "positional", "value": "run", "value_hint": "docker_cmd"},
+            {"type": "positional", "value": "-i", "value_hint": "interactive_flag"},
+            {"type": "named", "name": "-e", "value": "GITHUB_TOKEN", "value_hint": "env_var_name"},
+        )
+        self.assertEqual(
+            VSCodeClientAdapter._docker_run_args(package),
+            ["run", "--rm", "-i", "-e", "GITHUB_TOKEN", IMAGE],
+        )
+
+    def test_valueless_named_flags_survive(self):
+        """Dropping a bare `--read-only` weakens the container's posture."""
+        package = _docker_package(
+            {"type": "positional", "value": "run"},
+            {"type": "named", "name": "--read-only"},
+            {"type": "named", "name": "--network", "value": "none"},
+        )
+        self.assertEqual(
+            VSCodeClientAdapter._docker_run_args(package),
+            ["run", "-i", "--rm", "--read-only", "--network", "none", IMAGE],
+        )
+
+    def test_default_is_used_when_value_is_absent(self):
+        package = _docker_package(
+            {"type": "positional", "value": "run"},
+            {"type": "positional", "default": "--fromdefault"},
+        )
+        self.assertIn("--fromdefault", VSCodeClientAdapter._docker_run_args(package))
+
+    def test_declines_when_the_run_verb_is_not_first(self):
+        """`docker -v run …` is not a run invocation."""
+        package = _docker_package(
+            {"type": "positional", "value": "-v"},
+            {"type": "positional", "value": "run"},
+        )
+        self.assertIsNone(VSCodeClientAdapter._docker_run_args(package))
+
+    def test_placeholder_absent_from_the_template_does_not_decline(self):
+        package = _docker_package(
+            {"type": "positional", "value": "run"},
+            {
+                "type": "positional",
+                "value": "--flag",
+                "variables": {"unused": {"description": "x"}},
+            },
+        )
+        self.assertEqual(
+            VSCodeClientAdapter._docker_run_args(package), ["run", "-i", "--rm", "--flag", IMAGE]
+        )
+
+    def test_a_collected_zero_resolves_rather_than_declining(self):
+        """`0` is a supplied value; only an unset or empty one is unresolved."""
+        package = _docker_package(
+            {"type": "positional", "value": "run"},
+            {"type": "positional", "value": "--port={port}", "variables": {"port": {}}},
+        )
+        self.assertIn("--port=0", VSCodeClientAdapter._docker_run_args(package, {"port": 0}))
+
+    def test_legacy_full_argv_in_package_arguments_is_not_appended_twice(self):
+        """Registry data that repeats the docker argv there is a duplicate, not
+        container arguments -- appending it hands docker a second `run`."""
+        package = _docker_package(
+            {"type": "positional", "value": "run"},
+            {"type": "named", "name": "-e", "value": "TOK"},
+        )
+        package["package_arguments"] = [
+            {"type": "positional", "value": "run"},
+            {"type": "positional", "value": IMAGE},
+        ]
+        self.assertEqual(
+            VSCodeClientAdapter._docker_run_args(package),
+            ["run", "-i", "--rm", "-e", "TOK", IMAGE],
+        )
+
     def test_named_entries_keep_their_flag(self):
         """A named argument contributes the flag as well as its value."""
         package = _docker_package(

--- a/tests/unit/adapters/test_vscode_v01_value_runtime_args.py
+++ b/tests/unit/adapters/test_vscode_v01_value_runtime_args.py
@@ -131,6 +131,28 @@ class TestDockerRunArgs(unittest.TestCase):
             ["run", "-i", "--rm", "--read-only", "--network", "none", IMAGE],
         )
 
+    def test_required_value_taking_option_without_value_declines(self):
+        package = _docker_package(
+            {"type": "positional", "value": "run"},
+            {"type": "named", "name": "--user"},
+        )
+        self.assertIsNone(VSCodeClientAdapter._docker_run_args(package))
+
+    def test_optional_value_taking_option_without_value_is_dropped(self):
+        package = _docker_package(
+            {"type": "positional", "value": "run"},
+            {
+                "type": "named",
+                "name": "--network",
+                "is_required": False,
+                "variables": {},
+            },
+        )
+        self.assertEqual(
+            VSCodeClientAdapter._docker_run_args(package),
+            ["run", "-i", "--rm", IMAGE],
+        )
+
     def test_default_is_used_when_value_is_absent(self):
         package = _docker_package(
             {"type": "positional", "value": "run"},

--- a/tests/unit/adapters/test_vscode_v01_value_runtime_args.py
+++ b/tests/unit/adapters/test_vscode_v01_value_runtime_args.py
@@ -183,6 +183,16 @@ class TestDockerRunArgs(unittest.TestCase):
             ["run", "-i", "--rm", "-e", "TOK", IMAGE],
         )
 
+    def test_pinned_image_in_package_arguments_is_not_appended_as_container_argv(self):
+        package = _docker_package({"type": "positional", "value": "run"})
+        package["package_arguments"] = [
+            {"type": "positional", "value": "myregistry.example.com/team/mcp-server:latest"}
+        ]
+        self.assertEqual(
+            VSCodeClientAdapter._docker_run_args(package),
+            ["run", "-i", "--rm", IMAGE],
+        )
+
     def test_named_entries_keep_their_flag(self):
         """A named argument contributes the flag as well as its value."""
         package = _docker_package(
@@ -336,6 +346,21 @@ class TestDockerRunArgs(unittest.TestCase):
         ]
         self.assertIsNone(VSCodeClientAdapter._docker_run_args(package))
 
+    def test_required_runtime_argument_cannot_be_replaced_by_legacy_package_argv(self):
+        package = _docker_package(
+            {"value": "run", "type": "positional"},
+            {
+                "value": "--mount={requiredPath}",
+                "type": "positional",
+                "variables": {"requiredPath": {"description": "required"}},
+            },
+        )
+        package["package_arguments"] = [
+            {"value": "run", "type": "positional"},
+            {"value": IMAGE, "type": "positional"},
+        ]
+        self.assertIsNone(VSCodeClientAdapter._docker_run_args(package))
+
     # -- declining cases: the caller keeps its previous launcher --------------
 
     def test_declines_when_the_run_verb_is_absent(self):
@@ -479,14 +504,27 @@ class TestRenderedDockerLauncher(unittest.TestCase):
                 "runtime_hint": "docker",
                 "package_arguments": [
                     {"value": "run", "type": "positional"},
-                    {"value": "-i", "type": "positional"},
-                    {"value": "--rm", "type": "positional"},
                     {"value": "--read-only", "type": "positional"},
                     {"value": IMAGE, "type": "positional"},
+                    {"value": "--rm", "type": "positional"},
+                    {"value": "--transport", "type": "positional"},
+                    {"value": "stdio", "type": "positional"},
                 ],
             }
         )
-        self.assertEqual(config.get("args"), ["run", "-i", "--rm", "--read-only", IMAGE])
+        self.assertEqual(
+            config.get("args"),
+            [
+                "run",
+                "-i",
+                "--rm",
+                "--read-only",
+                IMAGE,
+                "--rm",
+                "--transport",
+                "stdio",
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/adapters/test_vscode_v01_value_runtime_args.py
+++ b/tests/unit/adapters/test_vscode_v01_value_runtime_args.py
@@ -153,6 +153,43 @@ class TestDockerRunArgs(unittest.TestCase):
             "${workspaceFolder}:/workspace", VSCodeClientAdapter._docker_run_args(package)
         )
 
+    def test_optional_entry_with_a_collected_value_is_kept(self):
+        """An optional mount whose variable the user filled in must survive --
+        discarding user-supplied configuration is the #2377 failure mode."""
+        package = _docker_package(
+            {"value": "run", "type": "positional"},
+            {"value": "-v", "type": "positional"},
+            {
+                "value": "{cacheDir}:/cache",
+                "type": "positional",
+                "is_required": False,
+                "variables": {"cacheDir": {"description": "cache"}},
+            },
+        )
+        self.assertEqual(
+            VSCodeClientAdapter._docker_run_args(package, {"cacheDir": "/home/dev/.cache"}),
+            ["run", "-i", "--rm", "-v", "/home/dev/.cache:/cache", IMAGE],
+        )
+
+    def test_optional_entry_with_an_unresolved_variable_is_dropped_alone(self):
+        """A registry-declared optional mount must not take the whole command
+        down with it -- only the unresolvable entry is skipped."""
+        package = _docker_package(
+            {"value": "run", "type": "positional"},
+            {"value": "-w", "type": "positional"},
+            {"value": "{workdir}", "type": "positional", "variables": _WORKDIR_VAR},
+            {
+                "value": "{cacheDir}:/cache",
+                "type": "positional",
+                "is_required": False,
+                "variables": {"cacheDir": {"description": "cache"}},
+            },
+        )
+        self.assertEqual(
+            VSCodeClientAdapter._docker_run_args(package, {"workdir": WORKDIR}),
+            ["run", "-i", "--rm", "-w", WORKDIR, IMAGE],
+        )
+
     def test_optional_entry_is_skipped_in_either_spelling(self):
         """Argument-level keys are not camelCase-normalized, so accept both."""
         for key in ("is_required", "isRequired"):

--- a/tests/unit/adapters/test_vscode_v01_value_runtime_args.py
+++ b/tests/unit/adapters/test_vscode_v01_value_runtime_args.py
@@ -1,0 +1,304 @@
+"""Regression tests for VS Code and MCP Registry v0.1 container run arguments.
+
+Issue #2377: ``apm install --target vscode`` prompted for a Docker server's
+``workdir`` variable, reported success, and then wrote a ``.vscode/mcp.json``
+launcher with every registry-supplied run option missing -- including the bind
+mount the user had just filled in.
+
+``_extract_package_args`` walked ``runtime_arguments`` looking only at
+``value_hint``. The v0.1 spec spells the payload ``value`` (beside a ``type``),
+so every entry was skipped and the docker branch fell back to a synthesized
+``run -i --rm <image>``.
+
+That extractor is shared with the npm, pypi, and generic branches, which read
+an empty extraction as "synthesize the command from the package name" -- so it
+cannot simply learn the v0.1 shape without stripping the package name out of
+those launchers. Container arguments are assembled by ``_docker_run_args``
+instead, and the tests below pin both halves of that contract.
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from apm_cli.adapters.client.vscode import VSCodeClientAdapter
+
+IMAGE = "myregistry.example.com/team/mcp-server:1.4.0"
+WORKDIR = "/home/dev/project"
+RUNTIME_VARS = {"workdir": WORKDIR}
+
+_WORKDIR_VAR = {
+    "workdir": {
+        "description": "Working directory to mount into the container.",
+        "isRequired": True,
+        "format": "filepath",
+    }
+}
+
+# The reporting registry's shape: `value` + `type`, image only in `name`.
+V01_VALUE_PACKAGE = {
+    "name": IMAGE,
+    "registry_name": "oci",
+    "runtime_hint": "docker",
+    "runtime_arguments": [
+        {"value": "run", "type": "positional"},
+        {"value": "--rm", "type": "positional"},
+        {"value": "-i", "type": "positional"},
+        {"value": "-v", "type": "positional"},
+        {"value": "{workdir}:{workdir}", "type": "positional", "variables": _WORKDIR_VAR},
+        {"value": "-w", "type": "positional"},
+        {"value": "{workdir}", "type": "positional", "variables": _WORKDIR_VAR},
+    ],
+}
+
+EXPECTED_ARGS = ["run", "--rm", "-i", "-v", f"{WORKDIR}:{WORKDIR}", "-w", WORKDIR, IMAGE]
+
+FALLBACK_ARGS = ["run", "-i", "--rm", IMAGE]
+
+
+def _make_vscode() -> VSCodeClientAdapter:
+    with (
+        patch("apm_cli.adapters.client.vscode.SimpleRegistryClient"),
+        patch("apm_cli.adapters.client.vscode.RegistryIntegration"),
+    ):
+        return VSCodeClientAdapter(project_root="/tmp/workspace")
+
+
+def _docker_package(*runtime_arguments, name=IMAGE):
+    return {
+        "name": name,
+        "registry_name": "docker",
+        "runtime_hint": "docker",
+        "runtime_arguments": list(runtime_arguments),
+    }
+
+
+def _config(package, **kwargs):
+    config, _inputs = _make_vscode()._format_server_config(
+        {"id": "team/mcp-server", "name": "team/mcp-server", "packages": [package]}, **kwargs
+    )
+    return config
+
+
+# ---------------------------------------------------------------------------
+# _docker_run_args
+# ---------------------------------------------------------------------------
+
+
+class TestDockerRunArgs(unittest.TestCase):
+    """v0.1 ``value`` entries become run options; the image is always named."""
+
+    def test_value_entries_become_run_options(self):
+        args = VSCodeClientAdapter._docker_run_args(V01_VALUE_PACKAGE, RUNTIME_VARS)
+        self.assertEqual(args, EXPECTED_ARGS)
+
+    def test_collected_variable_reaches_the_mount_argument(self):
+        """The value APM prompted for must not be silently discarded (#2377)."""
+        args = VSCodeClientAdapter._docker_run_args(V01_VALUE_PACKAGE, RUNTIME_VARS)
+        self.assertIn(f"{WORKDIR}:{WORKDIR}", args)
+
+    def test_named_entries_keep_their_flag(self):
+        """A named argument contributes the flag as well as its value."""
+        package = _docker_package(
+            {"type": "positional", "value": "run"},
+            {"type": "named", "name": "-e", "value": "GITHUB_TOKEN"},
+            {"type": "named", "name": "--mount", "value": "type=bind,src=/w,dst=/w"},
+        )
+        self.assertEqual(
+            VSCodeClientAdapter._docker_run_args(package),
+            [
+                "run",
+                "-i",
+                "--rm",
+                "-e",
+                "GITHUB_TOKEN",
+                "--mount",
+                "type=bind,src=/w,dst=/w",
+                IMAGE,
+            ],
+        )
+
+    def test_required_flags_are_normalized_in(self):
+        """A template omitting -i/--rm still yields an interactive container."""
+        package = _docker_package(
+            {"value": "run", "type": "positional"},
+            {"value": "-v", "type": "positional"},
+            {"value": "/w:/w", "type": "positional"},
+        )
+        self.assertEqual(
+            VSCodeClientAdapter._docker_run_args(package),
+            ["run", "-i", "--rm", "-v", "/w:/w", IMAGE],
+        )
+
+    def test_image_already_in_runtime_args_is_not_duplicated(self):
+        package = _docker_package(
+            {"value": "run", "type": "positional"},
+            {"value": "-i", "type": "positional"},
+            {"value": "--rm", "type": "positional"},
+            {"value": IMAGE, "type": "positional"},
+        )
+        self.assertEqual(VSCodeClientAdapter._docker_run_args(package).count(IMAGE), 1)
+
+    def test_workspace_folder_uses_the_vscode_native_token(self):
+        package = _docker_package(
+            {"value": "run", "type": "positional"},
+            {
+                "value": "{workspaceFolder}:/workspace",
+                "type": "positional",
+                "variables": {"workspaceFolder": {"description": "ws"}},
+            },
+        )
+        self.assertIn(
+            "${workspaceFolder}:/workspace", VSCodeClientAdapter._docker_run_args(package)
+        )
+
+    def test_optional_entry_is_skipped_in_either_spelling(self):
+        """Argument-level keys are not camelCase-normalized, so accept both."""
+        for key in ("is_required", "isRequired"):
+            package = _docker_package(
+                {"value": "run", "type": "positional"},
+                {"value": "--verbose", "type": "positional", key: False},
+            )
+            self.assertEqual(
+                VSCodeClientAdapter._docker_run_args(package),
+                ["run", "-i", "--rm", IMAGE],
+                f"{key}: False must not become a CLI argument",
+            )
+
+    def test_legacy_value_hint_entries_still_supported(self):
+        package = _docker_package(
+            {"value_hint": "run"},
+            {"value_hint": "-i"},
+            {"value_hint": "--rm"},
+            {"value_hint": IMAGE},
+        )
+        self.assertEqual(VSCodeClientAdapter._docker_run_args(package), FALLBACK_ARGS)
+
+    # -- declining cases: the caller keeps its previous launcher --------------
+
+    def test_declines_when_the_run_verb_is_absent(self):
+        package = _docker_package(
+            {"value": "-v", "type": "positional"},
+            {"value": "/w:/w", "type": "positional"},
+        )
+        self.assertIsNone(VSCodeClientAdapter._docker_run_args(package))
+
+    def test_declines_when_a_variable_has_no_collected_value(self):
+        """Writing a literal ${workdir} into a mount path would be worse."""
+        self.assertIsNone(VSCodeClientAdapter._docker_run_args(V01_VALUE_PACKAGE))
+
+    def test_declines_when_a_variable_resolves_to_an_empty_string(self):
+        """Non-interactive installs surface empty values; ':' is not a mount."""
+        self.assertIsNone(VSCodeClientAdapter._docker_run_args(V01_VALUE_PACKAGE, {"workdir": ""}))
+
+    def test_declines_for_a_package_without_runtime_arguments(self):
+        self.assertIsNone(VSCodeClientAdapter._docker_run_args({"name": IMAGE}))
+
+    # -- malformed registry payloads must not abort the install --------------
+
+    def test_non_dict_variables_do_not_raise(self):
+        package = _docker_package(
+            {"value": "run", "type": "positional"},
+            {"value": "-v", "variables": None, "type": "positional"},
+        )
+        self.assertEqual(
+            VSCodeClientAdapter._docker_run_args(package), ["run", "-i", "--rm", "-v", IMAGE]
+        )
+
+    def test_non_string_values_are_coerced_rather_than_dropped(self):
+        package = _docker_package(
+            {"value": "run", "type": "positional"},
+            {"value": "-p", "type": "positional"},
+            {"value": 8080, "type": "positional"},
+        )
+        self.assertEqual(
+            VSCodeClientAdapter._docker_run_args(package),
+            ["run", "-i", "--rm", "-p", "8080", IMAGE],
+        )
+
+    def test_non_dict_entries_are_ignored(self):
+        package = _docker_package({"value": "run", "type": "positional"}, "not-a-dict")
+        self.assertEqual(VSCodeClientAdapter._docker_run_args(package), FALLBACK_ARGS)
+
+
+# ---------------------------------------------------------------------------
+# The shared extractor must stay untouched
+# ---------------------------------------------------------------------------
+
+
+class TestSharedExtractorUnaffected(unittest.TestCase):
+    """Other registry branches read an empty extraction as "use the name"."""
+
+    def test_extractor_still_ignores_value_shaped_runtime_args(self):
+        self.assertEqual(
+            VSCodeClientAdapter._extract_package_args(V01_VALUE_PACKAGE, runtime_vars=RUNTIME_VARS),
+            [],
+        )
+
+    def test_pypi_launcher_keeps_the_package_name(self):
+        config = _config(
+            {
+                "name": "mcp-server-fetch",
+                "registry_name": "pypi",
+                "runtime_hint": "uvx",
+                "runtime_arguments": [
+                    {"value": "--python", "type": "named"},
+                    {"value": "3.12", "type": "positional"},
+                ],
+            }
+        )
+        self.assertEqual(config.get("command"), "uvx")
+        self.assertEqual(config.get("args"), ["mcp-server-fetch"])
+
+    def test_generic_runtime_launcher_keeps_the_package_name(self):
+        config = _config(
+            {
+                "name": "Azure.Mcp",
+                "registry_name": "nuget",
+                "runtime_hint": "dnx",
+                "runtime_arguments": [{"value": "--yes"}],
+            }
+        )
+        self.assertEqual(config.get("command"), "dnx")
+        self.assertEqual(config.get("args"), ["Azure.Mcp"])
+
+    def test_npm_launcher_keeps_the_package_name(self):
+        config = _config(
+            {
+                "name": "@scope/mcp",
+                "registry_name": "npm",
+                "runtime_hint": "npx",
+                "runtime_arguments": [{"value": "-y"}, {"value": "@scope/mcp"}],
+            }
+        )
+        self.assertEqual(config.get("command"), "npx")
+        self.assertEqual(config.get("args"), ["-y", "@scope/mcp"])
+
+
+# ---------------------------------------------------------------------------
+# Rendered .vscode/mcp.json entry
+# ---------------------------------------------------------------------------
+
+
+class TestRenderedDockerLauncher(unittest.TestCase):
+    def test_launcher_carries_the_run_options_and_the_image(self):
+        config = _config(V01_VALUE_PACKAGE, runtime_vars=RUNTIME_VARS)
+        self.assertEqual(config.get("command"), "docker")
+        self.assertEqual(config.get("args"), EXPECTED_ARGS)
+
+    def test_launcher_is_no_longer_the_bare_fallback(self):
+        config = _config(V01_VALUE_PACKAGE, runtime_vars=RUNTIME_VARS)
+        self.assertNotEqual(config.get("args"), FALLBACK_ARGS)
+
+    def test_unresolvable_package_keeps_the_previous_launcher(self):
+        config = _config(V01_VALUE_PACKAGE)
+        self.assertEqual(config.get("args"), FALLBACK_ARGS)
+
+    def test_package_without_runtime_args_keeps_the_synthesized_launcher(self):
+        config = _config({"name": IMAGE, "registry_name": "oci", "runtime_hint": "docker"})
+        self.assertEqual(config.get("args"), FALLBACK_ARGS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/adapters/test_vscode_v01_value_runtime_args.py
+++ b/tests/unit/adapters/test_vscode_v01_value_runtime_args.py
@@ -175,6 +175,29 @@ class TestDockerRunArgs(unittest.TestCase):
         )
         self.assertEqual(VSCodeClientAdapter._docker_run_args(package), FALLBACK_ARGS)
 
+    def test_package_arguments_follow_the_image_as_container_argv(self):
+        """docker run [OPTIONS] IMAGE [ARG...] -- container args come last."""
+        package = _docker_package({"value": "run", "type": "positional"})
+        package["package_arguments"] = [
+            {"value": "--transport", "type": "named"},
+            {"value": "stdio", "type": "positional"},
+        ]
+        self.assertEqual(
+            VSCodeClientAdapter._docker_run_args(package),
+            ["run", "-i", "--rm", IMAGE, "--transport", "stdio"],
+        )
+
+    def test_unresolvable_package_argument_also_declines(self):
+        package = _docker_package({"value": "run", "type": "positional"})
+        package["package_arguments"] = [
+            {
+                "value": "{configPath}",
+                "type": "positional",
+                "variables": {"configPath": {"description": "cfg"}},
+            }
+        ]
+        self.assertIsNone(VSCodeClientAdapter._docker_run_args(package))
+
     # -- declining cases: the caller keeps its previous launcher --------------
 
     def test_declines_when_the_run_verb_is_absent(self):
@@ -297,6 +320,25 @@ class TestRenderedDockerLauncher(unittest.TestCase):
 
     def test_package_without_runtime_args_keeps_the_synthesized_launcher(self):
         config = _config({"name": IMAGE, "registry_name": "oci", "runtime_hint": "docker"})
+        self.assertEqual(config.get("args"), FALLBACK_ARGS)
+
+    def test_legacy_full_argv_in_package_arguments_stays_verbatim(self):
+        """Some registry data authors the complete docker argv in
+        package_arguments; without a run verb in runtime_arguments the builder
+        declines and the pre-change verbatim path still applies."""
+        config = _config(
+            {
+                "name": IMAGE,
+                "registry_name": "docker",
+                "runtime_hint": "docker",
+                "package_arguments": [
+                    {"value": "run", "type": "positional"},
+                    {"value": "-i", "type": "positional"},
+                    {"value": "--rm", "type": "positional"},
+                    {"value": IMAGE, "type": "positional"},
+                ],
+            }
+        )
         self.assertEqual(config.get("args"), FALLBACK_ARGS)
 
 

--- a/tests/unit/test_registry_operations_state.py
+++ b/tests/unit/test_registry_operations_state.py
@@ -345,6 +345,33 @@ class TestCollectRuntimeVariables:
         result = ops.collect_runtime_variables(["server-a"], server_info_cache=cache)
         assert "MY_VAR" in result
 
+    def test_collects_variables_from_package_arguments(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("APM_E2E_TESTS", "1")
+        monkeypatch.setenv("PACKAGE_CONFIG", "/config/settings.json")
+        ops = _make_ops()
+        cache = {
+            "server-a": {
+                "packages": [
+                    {
+                        "package_arguments": [
+                            {
+                                "variables": {
+                                    "PACKAGE_CONFIG": {
+                                        "description": "package config",
+                                        "is_required": True,
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+        result = ops.collect_runtime_variables(["server-a"], server_info_cache=cache)
+        assert result == {"PACKAGE_CONFIG": "/config/settings.json"}
+
     def test_uses_batch_fetch_when_no_cache(self) -> None:
         ops = _make_ops()
         ops.batch_fetch_server_info = MagicMock(return_value={"server-a": None})

--- a/tests/unit/test_runtime_args.py
+++ b/tests/unit/test_runtime_args.py
@@ -148,7 +148,7 @@ class TestRuntimeArguments(unittest.TestCase):
         # Validate the args array includes all required runtime arguments
         self.assertEqual(server_config["type"], "stdio")
         self.assertEqual(server_config["command"], "docker")
-        self.assertEqual(server_config["args"], ["run", "--rm", "test-image", "8080"])
+        self.assertEqual(server_config["args"], ["run", "-i", "--rm", "test-image", "8080"])
 
     def test_python_runtime_args_handling(self):
         """Test that python runtime arguments are correctly added to the args list."""


### PR DESCRIPTION
## Description

> **Stacked on #2385.** Retargeting the base is not possible across forks, so the diff below `main` also carries #2385's five commits. This PR's own work is the four commits titled `fix(vscode): …` plus its changelog entry, touching only `src/apm_cli/adapters/client/vscode.py` and one new test file. The branch rebases cleanly once #2385 merges.

`VSCodeClientAdapter._extract_package_args` walks `runtime_arguments` reading only `value_hint`. MCP Registry v0.1 spells the payload `value`, beside a `"type"`:

```json
{ "value": "{workdir}:{workdir}", "type": "positional", "variables": { "workdir": { … } } }
```

Every entry therefore failed all three branch conditions, the extraction came back empty, and the container branch fell through to its synthesized `["run", "-i", "--rm", <image>]` — the config in the report. The mount the user had just been prompted for was collected, then dropped.

That extractor cannot simply learn the v0.1 shape. It is shared with the npm, pypi and generic branches, each of which reads an *empty* extraction as "synthesize the command from the package name":

```python
args = pkg_args if pkg_args else [package.get("name", "")]
```

Teaching it makes those branches use the registry arguments instead and the package name disappears — a pypi package with `runtime_arguments: [--python, 3.12]` renders `uvx --python 3.12`, no package at all. So it is left untouched and container arguments are assembled by a dedicated `_docker_run_args`.

Fixes #2377

## What `_docker_run_args` does

- Reads a typed entry's payload from `value` (then `default`), and an untyped legacy entry's from `value_hint`, matching `CopilotClientAdapter._process_arguments`. `value_hint` is the schema's *display* hint for a typed argument; reading it first renders placeholder words such as `env_var_name` as CLI arguments on real registry data.
- Emits a `named` entry's flag whether or not a value follows, so a bare `--read-only`, `--user` or `--cap-drop` is not dropped along with its empty value.
- Honours `is_required` in either spelling — `_normalize_v0_1_package` camelCases only *package*-level keys, so argument-level entries arrive as the registry sent them.
- Normalizes `-i`/`--rm` through the existing `DockerArgsProcessor`, and names the image the registry exposes only as the package identifier.
- Places `package_arguments` after the image as the container's argv, unless they repeat the run verb or the image — registry data that does so is a duplicate of `runtime_arguments`, and appending it hands docker a second `run`.

It declines, leaving the caller on the previous synthesized launcher, when the arguments cannot form a usable command: no leading `run` verb, or a placeholder this install could not resolve. A half-substituted mount path is worse than the image-only command that shipped before, and non-interactive installs surface empty strings for uncollected variables. `workspaceFolder` is exempt — VS Code expands `${workspaceFolder}` itself.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Maintenance / refactor

## Testing

- [x] Tested locally
- [x] All existing tests pass
- [x] Added tests for new functionality (if applicable)

`tests/unit/adapters/test_vscode_v01_value_runtime_args.py`; 28 of its 35 tests fail against the pre-change source.

Beyond the reported payload they pin the shapes this is easy to get wrong on: typed entries carrying both a value and a display hint, valueless named flags, `default`, both `is_required` spellings, a run verb that is not first, unresolved and empty-string variables, a `variables` descriptor the template never references, a collected `0`, `variables: null`, non-string values, and legacy full argv in `package_arguments`. A separate class asserts the shared extractor still returns `[]` for v0.1 arguments and that the npm, pypi and generic launchers keep their package name — the regression this design exists to avoid.

## Not addressed here

The npm, pypi and generic branches still drop v0.1 `value`-shaped arguments. Fixing them requires deciding whether VS Code's verbatim-argv semantics should align with Copilot's always-prepend-the-name semantics, which changes behaviour for existing `value_hint` data. Filed as #2388 with the evidence.

## Spec conformance (OpenAPM v0.1)

- [x] N/A -- this PR does not change OpenAPM-observable behaviour.
