### PR TITLE
fix(yaml): separate literal and alias expansion budgets

### DIFF
--- a/src/apm_cli/utils/yaml_io.py
+++ b/src/apm_cli/utils/yaml_io.py
@@ -69,6 +69,8 @@ class _BoundedSafeLoader(yaml.SafeLoader):
     _MAX_MERGE_ENTRIES = 100_000
     _MAX_FLATTEN_DEPTH = 200
     _MAX_EXPANSION_WEIGHT = 5_000_000
+    _MAX_LITERAL_WEIGHT = 50_000_000
+    _LITERAL_WEIGHT_PER_SOURCE_CHAR = 4
     _EXPANSION_INPROGRESS = -1
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -76,17 +78,55 @@ class _BoundedSafeLoader(yaml.SafeLoader):
         self._merge_entries = 0
         self._flatten_depth = 0
 
-    def _raise_expansion(self, node: Any) -> None:
+    def _raise_expansion(self, node: Any, *, literal: bool = False) -> NoReturn:
+        if literal:
+            problem = (
+                "YAML document exceeded the safe literal-size budget "
+                "(possible resource-exhaustion input)"
+            )
+        else:
+            problem = (
+                "YAML alias/anchor expansion exceeded the safe budget "
+                "(possible billion-laughs expansion bomb)"
+            )
         raise yaml.constructor.ConstructorError(
             "while constructing a node",
             getattr(node, "start_mark", None),
-            "YAML alias/anchor expansion exceeded the safe budget "
-            "(possible billion-laughs expansion bomb)",
+            problem,
             getattr(node, "start_mark", None),
         )
 
+    @staticmethod
+    def _has_shared_nodes(root: Any) -> bool:
+        """Return whether aliases or cycles share a node in the composed graph."""
+        seen: set[int] = set()
+        pending = [root]
+        while pending:
+            node = pending.pop()
+            node_id = id(node)
+            if node_id in seen:
+                return True
+            seen.add(node_id)
+            if isinstance(node, yaml.nodes.MappingNode):
+                for key_node, value_node in node.value:
+                    pending.extend((key_node, value_node))
+            elif isinstance(node, yaml.nodes.SequenceNode):
+                pending.extend(node.value)
+        return False
+
+    @classmethod
+    def _literal_budget(cls, root: Any) -> int:
+        """Bound anchor-free documents from their source size, with a hard cap."""
+        start = getattr(getattr(root, "start_mark", None), "index", 0)
+        end = getattr(getattr(root, "end_mark", None), "index", start)
+        source_chars = max(1, end - start)
+        return min(
+            cls._MAX_LITERAL_WEIGHT,
+            max(cls._MAX_EXPANSION_WEIGHT, source_chars * cls._LITERAL_WEIGHT_PER_SOURCE_CHAR),
+        )
+
     def _guard_expansion(self, root: Any) -> None:
-        # Bound the LOGICAL (alias-expanded) size of the composed node graph
+        # Bound the LOGICAL (alias-expanded) size of shared composed graphs
         # BEFORE construction. PyYAML shares one node object across every
         # ``*alias`` reference, so a pure-alias billion-laughs graph
         # (``lN: &lN [*l(N-1), *l(N-1)]``) is only O(N) objects yet expands
@@ -100,8 +140,9 @@ class _BoundedSafeLoader(yaml.SafeLoader):
         # closed as a ``yaml.YAMLError`` the instant the running total crosses
         # the budget. A self-referential anchor (``a: &a [*a]``) is a cycle in
         # the node graph; the in-progress sentinel detects it and fails closed
-        # rather than recursing forever. The budget is orders of magnitude
-        # above any legitimate config, so real anchors/aliases still resolve.
+        # rather than recursing forever. Anchor-free documents use a separate
+        # source-proportional literal budget so large generated lockfiles do
+        # not look like alias bombs, while shared graphs keep the strict limit.
         #
         # Leaf weight is BYTE-AWARE, not a flat 1: PyYAML's representer reports
         # ``ignore_aliases() == True`` for ``str`` / ``int`` / ``float`` /
@@ -116,6 +157,8 @@ class _BoundedSafeLoader(yaml.SafeLoader):
         # real dump-amplification cost, so the bomb fails closed at parse while
         # a single large scalar (referenced a handful of times) still resolves.
         weights: dict[int, int] = {}
+        has_shared_nodes = self._has_shared_nodes(root)
+        budget = self._MAX_EXPANSION_WEIGHT if has_shared_nodes else self._literal_budget(root)
 
         def weight(node: Any) -> int:
             nid = id(node)
@@ -129,18 +172,18 @@ class _BoundedSafeLoader(yaml.SafeLoader):
                 total = 1
                 for key_node, value_node in node.value:
                     total += weight(key_node) + weight(value_node)
-                    if total > self._MAX_EXPANSION_WEIGHT:
-                        self._raise_expansion(node)
+                    if total > budget:
+                        self._raise_expansion(node, literal=not has_shared_nodes)
             elif isinstance(node, yaml.nodes.SequenceNode):
                 total = 1
                 for child in node.value:
                     total += weight(child)
-                    if total > self._MAX_EXPANSION_WEIGHT:
-                        self._raise_expansion(node)
+                    if total > budget:
+                        self._raise_expansion(node, literal=not has_shared_nodes)
             else:
                 total = self._leaf_byte_cost(node)
-                if total > self._MAX_EXPANSION_WEIGHT:
-                    self._raise_expansion(node)
+                if total > budget:
+                    self._raise_expansion(node, literal=not has_shared_nodes)
             weights[nid] = total
             return total
 

--- a/tests/unit/test_yaml_io.py
+++ b/tests/unit/test_yaml_io.py
@@ -213,6 +213,14 @@ class TestLoadYamlStr:
         assert data["use1"] == {"x": 1}
         assert data["use2"] == {"x": 1}
 
+    def test_large_anchor_free_document_uses_literal_budget(self):
+        """Large generated literals are not mistaken for alias expansion bombs."""
+        text = "value: " + ("x" * 5_000_001) + "\n"
+
+        data = load_yaml_str(text)
+
+        assert data["value"] == "x" * 5_000_001
+
 
 class TestLoadYamlRoundtrip:
     """Tests for comment-preserving YAML round-trip helpers."""


### PR DESCRIPTION
fix(yaml): separate literal and alias expansion budgets

## TL;DR

Closes #2389. The bounded YAML loader now distinguishes ordinary anchor-free
document size from shared-node alias expansion. Large APM-generated lockfiles
can load within a source-proportional, capped literal budget, while alias and
merge-bomb protections remain strict and covered by regression tests.

## Problem (WHY)

- [!] APM-generated lockfiles with no anchors or aliases can exceed the single
  5,000,000 expansion-weight threshold and fail to load.
- [!] The issue reports that the current error calls an ordinary generated
  lockfile a possible expansion bomb: “The expansion guard is a legitimate and
  necessary security control; it must not be weakened in ways that allow actual
  alias-bomb files.” ([#2389](https://github.com/microsoft/apm/issues/2389))
- [x] The accepted triage direction is a separate literal-document budget plus
  the existing strict alias-expansion budget.

## Approach (WHAT)

| # | Fix | Principle | Source |
|---:|---|---|---|
| 1 | Detect shared nodes before calculating logical expansion weight. | “Add what the agent lacks, omit what it knows” | [Agent Skills](https://agentskills.io/skill-creation/best-practices) |
| 2 | Bound anchor-free documents from source size with a hard cap. | “Favor small, chainable primitives over monolithic frameworks.” | [PROSE](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |
| 3 | Keep the existing strict budget for aliases and cycles. | “Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action.” | [PROSE](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |

## Implementation (HOW)

- `src/apm_cli/utils/yaml_io.py` adds shared-node detection and a capped
  source-proportional literal budget. Shared graphs continue to use the
  5,000,000 logical expansion limit; literal-size failures now have a distinct
  actionable error.
- `tests/unit/test_yaml_io.py` adds a regression test for a 5,000,001-character
  anchor-free scalar. Existing merge and alias bomb tests remain unchanged and
  continue to exercise the strict security path.

## Data-flow

The loader selects the budget from the composed YAML graph before constructing
Python objects.

```mermaid
flowchart LR
    subgraph Compose[Compose]
        C1[Parsed YAML node graph]
    end
    subgraph Classify[Classify]
        C2{Shared node or cycle?}
    end
    subgraph Guard[Guard]
        G1[Strict alias budget]
        G2[Source-proportional literal budget]
    end
    subgraph Construct[Construct]
        O1[Python object]
    end
    C1 --> C2
    C2 -->|yes| G1
    C2 -->|no| G2
    G1 --> O1
    G2 --> O1
    classDef new stroke-dasharray: 5 5;
    class C2,G2 new;
```

## Trade-offs

- A source-proportional budget is chosen over removing the guard entirely, so
  very large anchor-free inputs still fail closed at a hard 50,000,000 weight.
- A preliminary graph walk is chosen over inferring aliases from scalar text;
  this matches PyYAML's composed-node representation and catches cycles.
- The implementation keeps the existing alias/merge budgets and error path
  rather than changing security-sensitive thresholds for shared graphs.

## Benefits

1. Anchor-free documents just over the old 5,000,000 threshold now parse when
   their source size remains within the bounded literal budget.
2. Pure-alias and self-referential graphs still fail before construction.
3. Merge-key expansion remains governed by the existing merge-entry and depth
   limits.
4. The regression test covers the false-positive path without adding a large
   fixture to the repository.

## Validation

Focused parser and security tests:

```text
python -m pytest tests/unit/test_yaml_io.py tests/red_team/parser/test_yaml_bomb.py -q
.................................................                        [100%]
49 passed in 2.56s
```

Lint and formatting:

```text
python -m ruff check src/apm_cli/utils/yaml_io.py tests/unit/test_yaml_io.py
All checks passed!

python -m ruff format --check src/apm_cli/utils/yaml_io.py tests/unit/test_yaml_io.py
2 files already formatted
```

`git diff --check` also passes. A broader `tests/unit` invocation was stopped
after several minutes with no output or CPU progress; no failure from that run
was observed, so the focused evidence above is the local completed proof and
the repository CI remains the authority for the full suite.

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test proving it | Type |
|---:|---|---|---|---|
| 1 | A large APM-generated lockfile without aliases loads successfully. | Correctness, fail-closed security | `tests/unit/test_yaml_io.py::TestLoadYamlStr::test_large_anchor_free_document_uses_literal_budget` | Regression |
| 2 | Alias-expansion bombs are rejected before object construction. | Fail-closed security | `tests/unit/test_yaml_io.py::TestLoadYamlStr::test_benign_reused_anchor_dag_still_parses`; `tests/unit/test_yaml_io.py::TestLoadYamlRoundtrip::test_alias_expansion_bomb_fails_closed`; `tests/red_team/parser/test_yaml_bomb.py` | Security |
| 3 | Merge-key bombs remain bounded. | Fail-closed security | `tests/unit/test_yaml_io.py::TestLoadYamlStr::test_merge_key_bomb_fails_closed`; `tests/unit/test_yaml_io.py::TestLoadFrontmatter::test_merge_bomb_frontmatter_fails_closed` | Security |

## How to test

- [ ] Install the development dependencies with the repository's documented
  `uv sync --extra dev` flow.
- [ ] Run `uv run pytest tests/unit/test_yaml_io.py tests/red_team/parser/test_yaml_bomb.py -q` and observe 49 passing tests.
- [ ] Run `uv run --extra dev ruff check src/ tests/` and observe no diagnostics.
- [ ] Run `uv run --extra dev ruff format --check src/ tests/` and observe no formatting changes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
