### PR TITLE
docs(getting-started): remove additional scoop bucket

### DIFF
--- a/docs/src/content/docs/getting-started/installation.md
+++ b/docs/src/content/docs/getting-started/installation.md
@@ -217,7 +217,6 @@ brew install microsoft/apm/apm
 **Scoop (Windows):**
 
 ```powershell
-scoop bucket add apm https://github.com/microsoft/scoop-apm
 scoop install apm
 ```
 


### PR DESCRIPTION
APM is now supported on main scoop bucket

## Description

Documentation about installation using scoop specifies an extra bucket.
This is does not exist anymore : https://github.com/microsoft/scoop-apm

Scoop has APM configured in the main bucket : https://github.com/ScoopInstaller/Main/blob/master/bucket/apm.json

Fixes # (issue)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Maintenance / refactor

