### PR TITLE
fix(yaml): allow large anchor-free documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Large anchor-free `apm.lock.yaml` files no longer fail with a false
-  alias-bomb warning; shared alias graphs still receive bounded expansion
-  accounting. (by @tomatotomata, closes #2389)
+- Anchor-free `apm.lock.yaml` files up to 8 MiB no longer fail with a false
+  alias-bomb warning; larger raw YAML inputs are rejected and shared alias
+  graphs still receive bounded expansion accounting. (by @tomatotomata, closes #2389)
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview
   now excludes the synthesized lockfile self-entry, matching the real install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Large anchor-free `apm.lock.yaml` files no longer fail with a false
   alias-bomb warning; shared alias graphs still receive bounded expansion
-  accounting. (by @tomatotomata, closes #2389, #2401)
+  accounting. (by @tomatotomata, closes #2389)
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview
   now excludes the synthesized lockfile self-entry, matching the real install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Large anchor-free `apm.lock.yaml` files no longer fail with a false
+  alias-bomb warning; shared alias graphs still receive bounded expansion
+  accounting. (by @tomatotomata, closes #2389, #2401)
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview
   now excludes the synthesized lockfile self-entry, matching the real install

--- a/docs/src/content/docs/troubleshooting/common-errors.md
+++ b/docs/src/content/docs/troubleshooting/common-errors.md
@@ -7,7 +7,7 @@ sidebar:
 
 Found a confusing error? Search this page first. Each entry shows the error string APM prints, the underlying cause, and the shortest fix. Deeper guides are linked under "See also".
 
-Errors are grouped by the surface that produces them: install, compile, audit, run, and auth/network.
+Errors are grouped by the surface that produces them: configuration, install, compile, audit, run, and auth/network.
 
 ## Configuration
 
@@ -19,7 +19,7 @@ YAML file apm.lock.yaml exceeds 8388608-byte (8 MiB) safe limit (... bytes); red
 
 Cause: APM rejects YAML sources larger than 8 MiB before parsing them. This includes project manifests and lockfiles.
 
-Fix: reduce the source file. For a generated `apm.lock.yaml`, reduce its inputs, then run `apm install` to regenerate it. Files exactly 8 MiB are accepted.
+Fix: reduce the source file. For a generated `apm.lock.yaml`, reduce its inputs, then remove the oversized generated lockfile and run `apm install` to create a replacement. Files exactly 8 MiB are accepted.
 
 See also: [Manifest schema](../../reference/manifest-schema/), [Lockfile specification](../../reference/lockfile-spec/)
 

--- a/docs/src/content/docs/troubleshooting/common-errors.md
+++ b/docs/src/content/docs/troubleshooting/common-errors.md
@@ -9,6 +9,20 @@ Found a confusing error? Search this page first. Each entry shows the error stri
 
 Errors are grouped by the surface that produces them: install, compile, audit, run, and auth/network.
 
+## Configuration
+
+### `YAML file ... exceeds 8388608-byte (8 MiB) safe limit`
+
+```
+YAML file apm.lock.yaml exceeds 8388608-byte (8 MiB) safe limit (... bytes); reduce or regenerate the YAML file before retrying
+```
+
+Cause: APM rejects YAML sources larger than 8 MiB before parsing them. This includes project manifests and lockfiles.
+
+Fix: reduce the source file. For a generated `apm.lock.yaml`, reduce its inputs, then run `apm install` to regenerate it. Files exactly 8 MiB are accepted.
+
+See also: [Manifest schema](../../reference/manifest-schema/), [Lockfile specification](../../reference/lockfile-spec/)
+
 ## Install
 
 ### `apm.yml not found. Run 'apm init' first.`

--- a/docs/src/content/docs/troubleshooting/common-errors.md
+++ b/docs/src/content/docs/troubleshooting/common-errors.md
@@ -14,7 +14,7 @@ Errors are grouped by the surface that produces them: configuration, install, co
 ### `YAML file ... exceeds 8388608-byte (8 MiB) safe limit`
 
 ```
-YAML file apm.lock.yaml exceeds 8388608-byte (8 MiB) safe limit (... bytes); reduce or regenerate the YAML file before retrying
+YAML file apm.lock.yaml exceeds 8388608-byte (8 MiB) safe limit (at least 8388609 bytes); reduce or regenerate the YAML file before retrying
 ```
 
 Cause: APM rejects YAML sources larger than 8 MiB before parsing them. This includes project manifests and lockfiles.
@@ -22,6 +22,12 @@ Cause: APM rejects YAML sources larger than 8 MiB before parsing them. This incl
 Fix: reduce the source file. For a generated `apm.lock.yaml`, reduce its inputs, then remove the oversized generated lockfile and run `apm install` to create a replacement. Files exactly 8 MiB are accepted.
 
 See also: [Manifest schema](../../reference/manifest-schema/), [Lockfile specification](../../reference/lockfile-spec/)
+
+### `YAML frontmatter exceeds 8388608-byte (8 MiB) safe limit`
+
+Cause: the YAML metadata between a Markdown document's opening `---` fences is larger than 8 MiB.
+
+Fix: reduce the frontmatter header, or update the package that supplies the document.
 
 ## Install
 

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -97,6 +97,12 @@ check_pattern \
     "Lockfile supported-version authority belongs in deps/lockfile.py" \
     'SUPPORTED_LOCKFILE_VERSIONS|lockfile_version[[:space:]]+(==|!=|in)' \
     $(find src/apm_cli -name '*.py' ! -path 'src/apm_cli/deps/lockfile.py')
+lock_export_file="src/apm_cli/commands/lock.py"
+if ! grep -q 'lockfile = LockFile.read(lockfile_path)' "$lock_export_file" \
+    || grep -q 'LockFile.from_yaml(lockfile_path.read_text' "$lock_export_file"; then
+    echo "[x] Lock export must read lockfiles through LockFile.read"
+    violations=$((violations + 1))
+fi
 
 echo "[*] AC3: outcome and policy enforcement authorities"
 check_pattern \

--- a/src/apm_cli/bundle/local_bundle.py
+++ b/src/apm_cli/bundle/local_bundle.py
@@ -47,7 +47,7 @@ from ..utils.path_security import (
     ensure_path_within,
     validate_path_segments,
 )
-from ..utils.yaml_io import load_yaml_str
+from ..utils.yaml_io import load_yaml
 
 _MAX_ZIP_ENTRIES = MAX_ZIP_ENTRIES
 _MAX_ZIP_UNCOMPRESSED = MAX_ZIP_UNCOMPRESSED
@@ -110,7 +110,7 @@ def _read_bundle_lockfile(bundle_dir: Path) -> dict[str, Any] | None:
     if not lf_path.is_file():
         return None
     try:
-        data = load_yaml_str(lf_path.read_text(encoding="utf-8"))
+        data = load_yaml(lf_path)
     except (yaml.YAMLError, OSError):
         return None
     return data if isinstance(data, dict) else None

--- a/src/apm_cli/commands/lock.py
+++ b/src/apm_cli/commands/lock.py
@@ -288,7 +288,7 @@ def lock_export(fmt: str, output: str | None, global_: bool, timestamp: str | No
     re-resolves, re-hashes, or touches the network.
     """
     from apm_cli.core.scope import InstallScope, get_apm_dir
-    from apm_cli.deps.lockfile import LockFile, get_lockfile_path
+    from apm_cli.deps.lockfile import LockFile, LockfileFormatError, get_lockfile_path
     from apm_cli.export.sbom import export_sbom
 
     if global_:
@@ -302,7 +302,14 @@ def lock_export(fmt: str, output: str | None, global_: bool, timestamp: str | No
         _rich_error(f"No lockfile found at {lockfile_path}. Run 'apm lock' to generate one first.")
         sys.exit(1)
 
-    lockfile = LockFile.from_yaml(lockfile_path.read_text(encoding="utf-8"))
+    try:
+        lockfile = LockFile.read(lockfile_path)
+    except LockfileFormatError as exc:
+        _rich_error(str(exc))
+        sys.exit(1)
+    if lockfile is None:
+        _rich_error(f"No lockfile found at {lockfile_path}. Run 'apm lock' to generate one first.")
+        sys.exit(1)
     resolved_timestamp = _resolve_export_timestamp(timestamp, lockfile.generated_at)
 
     document = export_sbom(lockfile, fmt, timestamp=resolved_timestamp)

--- a/src/apm_cli/deps/lockfile.py
+++ b/src/apm_cli/deps/lockfile.py
@@ -838,7 +838,9 @@ class LockFile:
         if not path.exists():
             return None
         try:
-            return cls.from_yaml(path.read_text(encoding="utf-8"))
+            from ..utils.yaml_io import _read_yaml_text
+
+            return cls.from_yaml(_read_yaml_text(path))
         except (LockfileFormatError, UnsupportedLockfileVersionError):
             raise
         except (yaml.YAMLError, ValueError, KeyError, TypeError) as exc:

--- a/src/apm_cli/deps/lockfile.py
+++ b/src/apm_cli/deps/lockfile.py
@@ -844,7 +844,12 @@ class LockFile:
         except (LockfileFormatError, UnsupportedLockfileVersionError):
             raise
         except (yaml.YAMLError, ValueError, KeyError, TypeError) as exc:
-            raise LockfileFormatError(f"Invalid lockfile at {path}: {exc}") from exc
+            recovery = ""
+            if "safe limit" in str(exc):
+                recovery = (
+                    " Remove the oversized lockfile, then run 'apm install' to regenerate it."
+                )
+            raise LockfileFormatError(f"Invalid lockfile at {path}: {exc}{recovery}") from exc
 
     @classmethod
     def load_or_create(cls, path: Path) -> LockFile:

--- a/src/apm_cli/utils/yaml_io.py
+++ b/src/apm_cli/utils/yaml_io.py
@@ -120,25 +120,25 @@ class _BoundedSafeLoader(yaml.SafeLoader):
         # would only reject legitimate large lockfiles. Aliases are the only
         # way the composed graph gains shared nodes (or cycles), and therefore
         # the only way its logical materialization can exceed its source size.
-        # Detect sharing first without recursively revisiting a seen node; this
-        # stays linear in the composed graph even for an exponential alias bomb.
+        # Detect sharing first with an explicit worklist. This stays linear in
+        # the composed graph even for an exponential alias bomb, and never adds
+        # Python call-stack pressure for a deeply nested but otherwise valid
+        # document.
         seen: set[int] = set()
-
-        def has_shared_node(node: Any) -> bool:
+        worklist = [root]
+        while worklist:
+            node = worklist.pop()
             nid = id(node)
             if nid in seen:
-                return True
+                break
             seen.add(nid)
             if isinstance(node, yaml.nodes.MappingNode):
-                return any(
-                    has_shared_node(key_node) or has_shared_node(value_node)
-                    for key_node, value_node in node.value
-                )
-            if isinstance(node, yaml.nodes.SequenceNode):
-                return any(has_shared_node(child) for child in node.value)
-            return False
-
-        if not has_shared_node(root):
+                for key_node, value_node in node.value:
+                    worklist.append(value_node)
+                    worklist.append(key_node)
+            elif isinstance(node, yaml.nodes.SequenceNode):
+                worklist.extend(node.value)
+        else:
             return
 
         weights: dict[int, int] = {}

--- a/src/apm_cli/utils/yaml_io.py
+++ b/src/apm_cli/utils/yaml_io.py
@@ -269,7 +269,7 @@ def _ensure_yaml_input_size(text: str) -> None:
     size = len(text.encode("utf-8"))
     if size > _MAX_YAML_INPUT_BYTES:
         raise yaml.YAMLError(
-            f"YAML input exceeds {_MAX_YAML_INPUT_BYTES}-byte safe limit ({size} bytes); "
+            f"YAML input exceeds {_MAX_YAML_INPUT_BYTES}-byte (8 MiB) safe limit ({size} bytes); "
             "reduce or regenerate the YAML file before retrying"
         )
 
@@ -277,13 +277,14 @@ def _ensure_yaml_input_size(text: str) -> None:
 def _read_yaml_text(path: str | Path) -> str:
     """Read a regular YAML file through a bounded single descriptor."""
     yaml_path = Path(path)
-    with yaml_path.open("rb") as stream:
+    descriptor = os.open(yaml_path, os.O_RDONLY | getattr(os, "O_NONBLOCK", 0))
+    with os.fdopen(descriptor, "rb") as stream:
         if not stat.S_ISREG(os.fstat(stream.fileno()).st_mode):
             raise yaml.YAMLError(f"YAML source {yaml_path} must be a regular file")
         raw = stream.read(_MAX_YAML_INPUT_BYTES + 1)
     if len(raw) > _MAX_YAML_INPUT_BYTES:
         raise yaml.YAMLError(
-            f"YAML file {yaml_path} exceeds {_MAX_YAML_INPUT_BYTES}-byte safe limit "
+            f"YAML file {yaml_path} exceeds {_MAX_YAML_INPUT_BYTES}-byte (8 MiB) safe limit "
             f"({len(raw)} bytes); reduce or regenerate the YAML file before retrying"
         )
     return raw.decode("utf-8")
@@ -293,11 +294,12 @@ def _read_frontmatter_text(fd: Any, encoding: str) -> str:
     """Read frontmatter input under the raw YAML cap."""
     if isinstance(fd, (str, os.PathLike)):
         return _read_yaml_text(fd)
-    raw = fd.read(_MAX_YAML_INPUT_BYTES + 1)
+    stream = getattr(fd, "buffer", fd)
+    raw = stream.read(_MAX_YAML_INPUT_BYTES + 1)
     if isinstance(raw, bytes):
         if len(raw) > _MAX_YAML_INPUT_BYTES:
             raise yaml.YAMLError(
-                f"YAML input exceeds {_MAX_YAML_INPUT_BYTES}-byte safe limit ({len(raw)} bytes); "
+                f"YAML input exceeds {_MAX_YAML_INPUT_BYTES}-byte (8 MiB) safe limit ({len(raw)} bytes); "
                 "reduce or regenerate the YAML file before retrying"
             )
         return raw.decode(encoding)

--- a/src/apm_cli/utils/yaml_io.py
+++ b/src/apm_cli/utils/yaml_io.py
@@ -264,12 +264,12 @@ class _BoundedSafeLoader(yaml.SafeLoader):
             self._flatten_depth -= 1
 
 
-def _ensure_yaml_input_size(text: str) -> None:
+def _ensure_yaml_input_size(text: str, *, source: str = "YAML input") -> None:
     """Reject YAML text that exceeds the raw input cap before parsing."""
     size = len(text.encode("utf-8"))
     if size > _MAX_YAML_INPUT_BYTES:
         raise yaml.YAMLError(
-            f"YAML input exceeds {_MAX_YAML_INPUT_BYTES}-byte (8 MiB) safe limit ({size} bytes); "
+            f"{source} exceeds {_MAX_YAML_INPUT_BYTES}-byte (8 MiB) safe limit ({size} bytes); "
             "reduce or regenerate the YAML file before retrying"
         )
 
@@ -291,19 +291,18 @@ def _read_yaml_text(path: str | Path) -> str:
 
 
 def _read_frontmatter_text(fd: Any, encoding: str) -> str:
-    """Read frontmatter input under the raw YAML cap."""
+    """Read a regular Markdown source for the bounded frontmatter handler."""
     if isinstance(fd, (str, os.PathLike)):
-        return _read_yaml_text(fd)
-    stream = getattr(fd, "buffer", fd)
-    raw = stream.read(_MAX_YAML_INPUT_BYTES + 1)
+        markdown_path = Path(fd)
+        descriptor = os.open(markdown_path, os.O_RDONLY | getattr(os, "O_NONBLOCK", 0))
+        with os.fdopen(descriptor, "rb") as stream:
+            if not stat.S_ISREG(os.fstat(stream.fileno()).st_mode):
+                raise yaml.YAMLError(f"Markdown source {markdown_path} must be a regular file")
+            raw = stream.read()
+    else:
+        raw = fd.read()
     if isinstance(raw, bytes):
-        if len(raw) > _MAX_YAML_INPUT_BYTES:
-            raise yaml.YAMLError(
-                f"YAML input exceeds {_MAX_YAML_INPUT_BYTES}-byte (8 MiB) safe limit ({len(raw)} bytes); "
-                "reduce or regenerate the YAML file before retrying"
-            )
         return raw.decode(encoding)
-    _ensure_yaml_input_size(raw)
     return raw
 
 
@@ -445,7 +444,7 @@ class _BoundedYAMLHandler(_FrontmatterYAMLHandler):
     def load(self, fm: str, **kwargs: Any) -> Any:
         kwargs["Loader"] = _BoundedSafeLoader
         try:
-            _ensure_yaml_input_size(fm)
+            _ensure_yaml_input_size(fm, source="YAML frontmatter")
             return yaml.load(fm, **kwargs)  # noqa: S506 - SafeLoader subclass
         except yaml.YAMLError:
             raise

--- a/src/apm_cli/utils/yaml_io.py
+++ b/src/apm_cli/utils/yaml_io.py
@@ -264,13 +264,18 @@ class _BoundedSafeLoader(yaml.SafeLoader):
             self._flatten_depth -= 1
 
 
-def _ensure_yaml_input_size(text: str, *, source: str = "YAML input") -> None:
+def _ensure_yaml_input_size(
+    text: str,
+    *,
+    source: str = "YAML input",
+    recovery: str = "reduce or regenerate the YAML file before retrying",
+) -> None:
     """Reject YAML text that exceeds the raw input cap before parsing."""
     size = len(text.encode("utf-8"))
     if size > _MAX_YAML_INPUT_BYTES:
         raise yaml.YAMLError(
             f"{source} exceeds {_MAX_YAML_INPUT_BYTES}-byte (8 MiB) safe limit ({size} bytes); "
-            "reduce or regenerate the YAML file before retrying"
+            f"{recovery}"
         )
 
 
@@ -285,7 +290,7 @@ def _read_yaml_text(path: str | Path) -> str:
     if len(raw) > _MAX_YAML_INPUT_BYTES:
         raise yaml.YAMLError(
             f"YAML file {yaml_path} exceeds {_MAX_YAML_INPUT_BYTES}-byte (8 MiB) safe limit "
-            f"({len(raw)} bytes); reduce or regenerate the YAML file before retrying"
+            f"(at least {len(raw)} bytes); reduce or regenerate the YAML file before retrying"
         )
     return raw.decode("utf-8")
 
@@ -444,7 +449,11 @@ class _BoundedYAMLHandler(_FrontmatterYAMLHandler):
     def load(self, fm: str, **kwargs: Any) -> Any:
         kwargs["Loader"] = _BoundedSafeLoader
         try:
-            _ensure_yaml_input_size(fm, source="YAML frontmatter")
+            _ensure_yaml_input_size(
+                fm,
+                source="YAML frontmatter",
+                recovery="reduce the frontmatter header or update the source package before retrying",
+            )
             return yaml.load(fm, **kwargs)  # noqa: S506 - SafeLoader subclass
         except yaml.YAMLError:
             raise

--- a/src/apm_cli/utils/yaml_io.py
+++ b/src/apm_cli/utils/yaml_io.py
@@ -16,6 +16,7 @@ Public API::
 
 import os
 import secrets
+import stat
 from contextlib import suppress
 from io import StringIO
 from pathlib import Path
@@ -268,19 +269,40 @@ def _ensure_yaml_input_size(text: str) -> None:
     size = len(text.encode("utf-8"))
     if size > _MAX_YAML_INPUT_BYTES:
         raise yaml.YAMLError(
-            f"YAML input exceeds {_MAX_YAML_INPUT_BYTES}-byte safe limit ({size} bytes)"
+            f"YAML input exceeds {_MAX_YAML_INPUT_BYTES}-byte safe limit ({size} bytes); "
+            "reduce or regenerate the YAML file before retrying"
         )
 
 
 def _read_yaml_text(path: str | Path) -> str:
-    """Read a YAML file only after checking its raw byte size."""
+    """Read a regular YAML file through a bounded single descriptor."""
     yaml_path = Path(path)
-    size = yaml_path.stat().st_size
-    if size > _MAX_YAML_INPUT_BYTES:
+    with yaml_path.open("rb") as stream:
+        if not stat.S_ISREG(os.fstat(stream.fileno()).st_mode):
+            raise yaml.YAMLError(f"YAML source {yaml_path} must be a regular file")
+        raw = stream.read(_MAX_YAML_INPUT_BYTES + 1)
+    if len(raw) > _MAX_YAML_INPUT_BYTES:
         raise yaml.YAMLError(
-            f"YAML file {yaml_path} exceeds {_MAX_YAML_INPUT_BYTES}-byte safe limit ({size} bytes)"
+            f"YAML file {yaml_path} exceeds {_MAX_YAML_INPUT_BYTES}-byte safe limit "
+            f"({len(raw)} bytes); reduce or regenerate the YAML file before retrying"
         )
-    return yaml_path.read_text(encoding="utf-8")
+    return raw.decode("utf-8")
+
+
+def _read_frontmatter_text(fd: Any, encoding: str) -> str:
+    """Read frontmatter input under the raw YAML cap."""
+    if isinstance(fd, (str, os.PathLike)):
+        return _read_yaml_text(fd)
+    raw = fd.read(_MAX_YAML_INPUT_BYTES + 1)
+    if isinstance(raw, bytes):
+        if len(raw) > _MAX_YAML_INPUT_BYTES:
+            raise yaml.YAMLError(
+                f"YAML input exceeds {_MAX_YAML_INPUT_BYTES}-byte safe limit ({len(raw)} bytes); "
+                "reduce or regenerate the YAML file before retrying"
+            )
+        return raw.decode(encoding)
+    _ensure_yaml_input_size(raw)
+    return raw
 
 
 def _bounded_load(text: str) -> Any:
@@ -448,7 +470,10 @@ def load_frontmatter(fd: Any, encoding: str = "utf-8") -> Any:
     """
     import frontmatter
 
-    return frontmatter.load(fd, encoding=encoding, handler=_BOUNDED_FRONTMATTER_HANDLER)
+    return frontmatter.loads(
+        _read_frontmatter_text(fd, encoding),
+        handler=_BOUNDED_FRONTMATTER_HANDLER,
+    )
 
 
 def dump_yaml(

--- a/src/apm_cli/utils/yaml_io.py
+++ b/src/apm_cli/utils/yaml_io.py
@@ -115,6 +115,32 @@ class _BoundedSafeLoader(yaml.SafeLoader):
         # scalar occurrence its emitted byte length makes the budget model the
         # real dump-amplification cost, so the bomb fails closed at parse while
         # a single large scalar (referenced a handful of times) still resolves.
+        # A composed YAML document without aliases is a tree: its logical
+        # expansion is exactly its input structure, so a fixed expansion cap
+        # would only reject legitimate large lockfiles. Aliases are the only
+        # way the composed graph gains shared nodes (or cycles), and therefore
+        # the only way its logical materialization can exceed its source size.
+        # Detect sharing first without recursively revisiting a seen node; this
+        # stays linear in the composed graph even for an exponential alias bomb.
+        seen: set[int] = set()
+
+        def has_shared_node(node: Any) -> bool:
+            nid = id(node)
+            if nid in seen:
+                return True
+            seen.add(nid)
+            if isinstance(node, yaml.nodes.MappingNode):
+                return any(
+                    has_shared_node(key_node) or has_shared_node(value_node)
+                    for key_node, value_node in node.value
+                )
+            if isinstance(node, yaml.nodes.SequenceNode):
+                return any(has_shared_node(child) for child in node.value)
+            return False
+
+        if not has_shared_node(root):
+            return
+
         weights: dict[int, int] = {}
 
         def weight(node: Any) -> int:

--- a/src/apm_cli/utils/yaml_io.py
+++ b/src/apm_cli/utils/yaml_io.py
@@ -30,6 +30,7 @@ _DUMP_DEFAULTS: dict[str, Any] = dict(
     sort_keys=False,
     allow_unicode=True,
 )
+_MAX_YAML_INPUT_BYTES = 8 * 1024 * 1024
 
 
 class _BoundedSafeLoader(yaml.SafeLoader):
@@ -124,21 +125,7 @@ class _BoundedSafeLoader(yaml.SafeLoader):
         # the composed graph even for an exponential alias bomb, and never adds
         # Python call-stack pressure for a deeply nested but otherwise valid
         # document.
-        seen: set[int] = set()
-        worklist = [root]
-        while worklist:
-            node = worklist.pop()
-            nid = id(node)
-            if nid in seen:
-                break
-            seen.add(nid)
-            if isinstance(node, yaml.nodes.MappingNode):
-                for key_node, value_node in node.value:
-                    worklist.append(value_node)
-                    worklist.append(key_node)
-            elif isinstance(node, yaml.nodes.SequenceNode):
-                worklist.extend(node.value)
-        else:
+        if not self._has_shared_nodes(root):
             return
 
         weights: dict[int, int] = {}
@@ -171,6 +158,25 @@ class _BoundedSafeLoader(yaml.SafeLoader):
             return total
 
         weight(root)
+
+    @staticmethod
+    def _has_shared_nodes(root: Any) -> bool:
+        """Return whether a composed YAML graph has aliases or a cycle."""
+        seen: set[int] = set()
+        worklist = [root]
+        while worklist:
+            node = worklist.pop()
+            nid = id(node)
+            if nid in seen:
+                return True
+            seen.add(nid)
+            if isinstance(node, yaml.nodes.MappingNode):
+                for key_node, value_node in node.value:
+                    worklist.append(value_node)
+                    worklist.append(key_node)
+            elif isinstance(node, yaml.nodes.SequenceNode):
+                worklist.extend(node.value)
+        return False
 
     @staticmethod
     def _leaf_byte_cost(node: Any) -> int:
@@ -257,7 +263,27 @@ class _BoundedSafeLoader(yaml.SafeLoader):
             self._flatten_depth -= 1
 
 
-def _bounded_load(stream: Any) -> Any:
+def _ensure_yaml_input_size(text: str) -> None:
+    """Reject YAML text that exceeds the raw input cap before parsing."""
+    size = len(text.encode("utf-8"))
+    if size > _MAX_YAML_INPUT_BYTES:
+        raise yaml.YAMLError(
+            f"YAML input exceeds {_MAX_YAML_INPUT_BYTES}-byte safe limit ({size} bytes)"
+        )
+
+
+def _read_yaml_text(path: str | Path) -> str:
+    """Read a YAML file only after checking its raw byte size."""
+    yaml_path = Path(path)
+    size = yaml_path.stat().st_size
+    if size > _MAX_YAML_INPUT_BYTES:
+        raise yaml.YAMLError(
+            f"YAML file {yaml_path} exceeds {_MAX_YAML_INPUT_BYTES}-byte safe limit ({size} bytes)"
+        )
+    return yaml_path.read_text(encoding="utf-8")
+
+
+def _bounded_load(text: str) -> Any:
     """Parse *stream* with the merge-bounded SafeLoader, failing closed.
 
     Centralizes the round-16 bounded-loader entrypoint AND normalizes the
@@ -274,10 +300,11 @@ def _bounded_load(stream: Any) -> Any:
     ``.prompt.md`` -> whole-run DoS) instead of the intended per-file skip.
     """
     try:
-        return yaml.load(stream, Loader=_BoundedSafeLoader)  # noqa: S506 - SafeLoader subclass
+        _ensure_yaml_input_size(text)
+        return yaml.load(text, Loader=_BoundedSafeLoader)  # noqa: S506 - SafeLoader subclass
     except yaml.YAMLError:
         raise
-    except (ValueError, RecursionError) as exc:
+    except (MemoryError, ValueError, RecursionError) as exc:
         raise yaml.YAMLError(f"bounded YAML parse failed: {type(exc).__name__}: {exc}") from exc
 
 
@@ -292,8 +319,7 @@ def load_yaml(path: str | Path) -> dict[str, Any] | None:
     the bomb -- and a huge-int / deep-nest scalar -- fails closed as a
     ``yaml.YAMLError`` (see ``_bounded_load``) instead of hanging or escaping.
     """
-    with open(path, encoding="utf-8") as fh:
-        return _bounded_load(fh)
+    return _bounded_load(_read_yaml_text(path))
 
 
 def load_yaml_str(text: str) -> dict[str, Any] | None:
@@ -354,7 +380,7 @@ def load_yaml_roundtrip(path: str | Path) -> Any:
     round-trip mode so callers can mutate the returned object and write it back
     without stripping comments.
     """
-    text = Path(path).read_text(encoding="utf-8")
+    text = _read_yaml_text(path)
     _bounded_load(text)
     try:
         return _roundtrip_yaml().load(text)
@@ -395,10 +421,11 @@ class _BoundedYAMLHandler(_FrontmatterYAMLHandler):
     def load(self, fm: str, **kwargs: Any) -> Any:
         kwargs["Loader"] = _BoundedSafeLoader
         try:
+            _ensure_yaml_input_size(fm)
             return yaml.load(fm, **kwargs)  # noqa: S506 - SafeLoader subclass
         except yaml.YAMLError:
             raise
-        except (ValueError, RecursionError) as exc:
+        except (MemoryError, ValueError, RecursionError) as exc:
             raise yaml.YAMLError(
                 f"bounded frontmatter parse failed: {type(exc).__name__}: {exc}"
             ) from exc

--- a/tests/integration/test_architecture_mutation_guards.py
+++ b/tests/integration/test_architecture_mutation_guards.py
@@ -8,6 +8,14 @@ from pathlib import Path
 import pytest
 
 
+def test_lock_export_routes_filesystem_input_through_lockfile_reader() -> None:
+    """Lock export must not bypass LockFile.read's bounded source policy."""
+    source = Path("src/apm_cli/commands/lock.py").read_text(encoding="utf-8")
+
+    assert "lockfile = LockFile.read(lockfile_path)" in source
+    assert "LockFile.from_yaml(lockfile_path.read_text" not in source
+
+
 def test_compiled_output_batch_scans_once_before_writing(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/integration/test_command_integrator_hermetic.py
+++ b/tests/integration/test_command_integrator_hermetic.py
@@ -231,6 +231,23 @@ class TestTransformPromptToCommand:
         assert warnings == []
         assert dropped == []
 
+    def test_large_body_with_small_frontmatter_integrates(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A small fenced header does not cap an otherwise large prompt body."""
+        from apm_cli.utils import yaml_io
+
+        monkeypatch.setattr(yaml_io, "_MAX_YAML_INPUT_BYTES", 8)
+        body = "body\n" * 4
+        prompt = _write_prompt(tmp_path / "large.prompt.md", "---\na: ok\n---\n" + body)
+
+        _, post, warnings, dropped = CommandIntegrator()._transform_prompt_to_command(prompt)
+
+        assert post.metadata == {}
+        assert post.content == body.rstrip()
+        assert warnings == []
+        assert dropped == ["a"]
+
     def test_falls_back_to_stem_for_non_prompt_suffix(self, tmp_path: Path) -> None:
         prompt = _write_prompt(
             tmp_path / "feature.md",

--- a/tests/integration/test_yaml_guard_lifecycle_e2e.py
+++ b/tests/integration/test_yaml_guard_lifecycle_e2e.py
@@ -123,6 +123,6 @@ def test_oversize_literal_lockfile_fails_audit_without_writes(
 
     combined_output = f"{result.stdout}\n{result.stderr}"
     assert result.returncode != 0
-    assert "YAML input exceeds" in combined_output
+    assert "YAML file" in combined_output
     assert "reduce or regenerate the YAML file before retrying" in combined_output
     assert_unchanged(before, ArtifactSnapshot.capture(project))

--- a/tests/integration/test_yaml_guard_lifecycle_e2e.py
+++ b/tests/integration/test_yaml_guard_lifecycle_e2e.py
@@ -25,6 +25,7 @@ pytestmark = [
 ]
 
 _AUDIT_ARGS = ("audit", "--ci", "--no-policy", "--no-drift", "--format", "json")
+_LOCK_EXPORT_ARGS = ("lock", "export", "--output", "sbom.json")
 
 
 def _project(root: Path) -> tuple[Path, dict[str, str]]:
@@ -125,4 +126,31 @@ def test_oversize_literal_lockfile_fails_audit_without_writes(
     assert result.returncode != 0
     assert "YAML file" in combined_output
     assert "reduce or regenerate the YAML file before retrying" in combined_output
+    assert_unchanged(before, ArtifactSnapshot.capture(project))
+
+
+def test_oversize_literal_lockfile_export_fails_without_writes(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """The installed lock export rejects an oversized input before writing output."""
+    project, environment = _project(tmp_path / "oversize-export")
+    lockfile = project / "apm.lock.yaml"
+    lockfile.write_text(
+        large_anchor_free_lockfile(_MAX_YAML_INPUT_BYTES),
+        encoding="utf-8",
+    )
+    before = ArtifactSnapshot.capture(project)
+
+    result = _runner(apm_binary_path).run(
+        _LOCK_EXPORT_ARGS,
+        scenario_id="oversize-literal-lockfile-export",
+        cwd=project,
+        env=environment,
+    )
+
+    combined_output = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode != 0
+    assert "safe limit" in combined_output
+    assert "apm install" in combined_output
     assert_unchanged(before, ArtifactSnapshot.capture(project))

--- a/tests/integration/test_yaml_guard_lifecycle_e2e.py
+++ b/tests/integration/test_yaml_guard_lifecycle_e2e.py
@@ -1,0 +1,102 @@
+"""Installed-CLI lifecycle coverage for bounded YAML graph accounting."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from apm_cli.utils.yaml_io import _BoundedSafeLoader
+from tests.utils.apm_lifecycle_runner import ApmLifecycleRunner
+from tests.utils.artifact_snapshot import ArtifactSnapshot, assert_unchanged
+from tests.utils.isolated_apm_environment import IsolatedApmEnvironment
+from tests.utils.yaml_guard_fixtures import (
+    PRIVATE_LOCKFILE_MARKER,
+    compact_alias_bomb_lockfile,
+    large_anchor_free_lockfile,
+)
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.requires_e2e_mode,
+    pytest.mark.requires_apm_binary,
+]
+
+_AUDIT_ARGS = ("audit", "--ci", "--no-policy", "--no-drift", "--format", "json")
+
+
+def _project(root: Path) -> tuple[Path, dict[str, str]]:
+    """Create one hermetic dependency-free project and child environment."""
+    isolated = IsolatedApmEnvironment.create(root, base_env=os.environ)
+    project = isolated.work_root / "project"
+    project.mkdir()
+    (project / "apm.yml").write_text(
+        "name: yaml-guard-lifecycle\nversion: 0.1.0\ntarget: copilot\ndependencies:\n  apm: []\n",
+        encoding="utf-8",
+    )
+    return project, isolated.subprocess_env(overrides={"APM_DISABLE_UPDATE_CHECK": "1"})
+
+
+def _runner(apm_binary_path: Path) -> ApmLifecycleRunner:
+    """Return the bounded installed-binary runner for this lifecycle."""
+    return ApmLifecycleRunner(
+        (str(apm_binary_path),),
+        timeout_seconds=30,
+        scenario_timeout_seconds=60,
+    )
+
+
+def test_large_anchor_free_lockfile_audits_without_rewrite(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """The installed audit accepts a large literal lockfile byte-for-byte."""
+    project, environment = _project(tmp_path / "large-valid")
+    lockfile = project / "apm.lock.yaml"
+    content = large_anchor_free_lockfile(_BoundedSafeLoader._MAX_EXPANSION_WEIGHT)
+    assert len(content.encode("utf-8")) < 8_000_000
+    lockfile.write_text(content, encoding="utf-8")
+    before_bytes = lockfile.read_bytes()
+    before_stat = lockfile.stat()
+
+    result = _runner(apm_binary_path).run(
+        _AUDIT_ARGS,
+        scenario_id="large-anchor-free-lockfile",
+        cwd=project,
+        env=environment,
+    )
+
+    assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    assert json.loads(result.stdout)["passed"] is True
+    after_stat = lockfile.stat()
+    assert lockfile.read_bytes() == before_bytes
+    assert after_stat.st_mtime_ns == before_stat.st_mtime_ns
+    assert after_stat.st_ino == before_stat.st_ino
+
+
+def test_alias_bomb_lockfile_fails_audit_without_writes(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """The installed audit rejects a compact alias graph without side effects."""
+    project, environment = _project(tmp_path / "alias-bomb")
+    lockfile = project / "apm.lock.yaml"
+    content = compact_alias_bomb_lockfile()
+    assert len(content.encode("utf-8")) < 4096
+    lockfile.write_text(content, encoding="utf-8")
+    before = ArtifactSnapshot.capture(project)
+
+    result = _runner(apm_binary_path).run(
+        _AUDIT_ARGS,
+        scenario_id="alias-bomb-lockfile",
+        cwd=project,
+        env=environment,
+    )
+
+    combined_output = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode != 0
+    assert "YAML alias/anchor expansion exceeded the safe budget" in combined_output
+    assert PRIVATE_LOCKFILE_MARKER not in combined_output
+    assert_unchanged(before, ArtifactSnapshot.capture(project))

--- a/tests/integration/test_yaml_guard_lifecycle_e2e.py
+++ b/tests/integration/test_yaml_guard_lifecycle_e2e.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from apm_cli.utils.yaml_io import _BoundedSafeLoader
+from apm_cli.utils.yaml_io import _MAX_YAML_INPUT_BYTES, _BoundedSafeLoader
 from tests.utils.apm_lifecycle_runner import ApmLifecycleRunner
 from tests.utils.artifact_snapshot import ArtifactSnapshot, assert_unchanged
 from tests.utils.isolated_apm_environment import IsolatedApmEnvironment
@@ -99,4 +99,30 @@ def test_alias_bomb_lockfile_fails_audit_without_writes(
     assert result.returncode != 0
     assert "YAML alias/anchor expansion exceeded the safe budget" in combined_output
     assert PRIVATE_LOCKFILE_MARKER not in combined_output
+    assert_unchanged(before, ArtifactSnapshot.capture(project))
+
+
+def test_oversize_literal_lockfile_fails_audit_without_writes(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """An oversized literal lockfile fails safely with a recovery action."""
+    project, environment = _project(tmp_path / "oversize-literal")
+    lockfile = project / "apm.lock.yaml"
+    content = large_anchor_free_lockfile(_MAX_YAML_INPUT_BYTES)
+    assert len(content.encode("utf-8")) > _MAX_YAML_INPUT_BYTES
+    lockfile.write_text(content, encoding="utf-8")
+    before = ArtifactSnapshot.capture(project)
+
+    result = _runner(apm_binary_path).run(
+        _AUDIT_ARGS,
+        scenario_id="oversize-literal-lockfile",
+        cwd=project,
+        env=environment,
+    )
+
+    combined_output = f"{result.stdout}\n{result.stderr}"
+    assert result.returncode != 0
+    assert "YAML input exceeds" in combined_output
+    assert "reduce or regenerate the YAML file before retrying" in combined_output
     assert_unchanged(before, ArtifactSnapshot.capture(project))

--- a/tests/quality/critical_suite.toml
+++ b/tests/quality/critical_suite.toml
@@ -106,3 +106,7 @@ marker = "e2e"
 [[modules]]
 path = "tests/integration/test_required_lifecycle_state_machine.py"
 marker = "e2e"
+
+[[modules]]
+path = "tests/integration/test_yaml_guard_lifecycle_e2e.py"
+marker = "e2e"

--- a/tests/quality/test_test_taxonomy.py
+++ b/tests/quality/test_test_taxonomy.py
@@ -137,7 +137,7 @@ def test_tm001_behavioral_marker_definitions_match_spec() -> None:
 
 def test_tm002_manifest_is_finite_unique_and_existing() -> None:
     modules = _manifest_modules()
-    assert len(modules) == 27
+    assert len(modules) == 28
     paths = [entry["path"] for entry in modules]
     assert len(paths) == len(set(paths))
     assert {entry["marker"] for entry in modules} == BEHAVIORAL_MARKERS

--- a/tests/red_team/parser/test_yaml_bomb.py
+++ b/tests/red_team/parser/test_yaml_bomb.py
@@ -144,20 +144,45 @@ def test_shallow_alias_doc_still_parses_under_budget(tmp_path: Path, levels: int
     assert isinstance(result, dict)
 
 
-def test_large_anchor_free_scalar_is_not_treated_as_an_alias_bomb(tmp_path: Path):
-    """A literal document above the expansion budget remains loadable.
+def test_large_anchor_free_lockfile_is_not_treated_as_an_alias_bomb(tmp_path: Path):
+    """A tree-shaped lockfile above the expansion budget remains loadable.
 
     The expansion budget defends against shared alias nodes whose logical size
-    can grow exponentially. A single unaliased scalar is linear in the input
-    size, so rejecting it as an alias bomb prevents APM from reading its own
-    large generated lockfiles without adding protection.
+    can grow exponentially. A large mapping of literal provenance values is
+    linear in the input size, so rejecting it as an alias bomb prevents APM
+    from reading its own generated lockfiles without adding protection.
     """
     from apm_cli.utils.yaml_io import _BoundedSafeLoader, load_yaml
+    from tests.utils.yaml_guard_fixtures import (
+        LARGE_LOCKFILE_PROVENANCE_ROWS,
+        large_anchor_free_lockfile,
+    )
 
-    literal = "x" * (_BoundedSafeLoader._MAX_EXPANSION_WEIGHT + 1)
+    content = large_anchor_free_lockfile(_BoundedSafeLoader._MAX_EXPANSION_WEIGHT)
     doc = tmp_path / "apm.lock.yaml"
-    doc.write_text(f"payload: {literal}\n", encoding="utf-8")
+    doc.write_text(content, encoding="utf-8")
 
     result = load_yaml(doc)
 
-    assert result == {"payload": literal}
+    assert "&" not in content
+    assert "*" not in content
+    assert len(result["mcp_config_provenance"]) == LARGE_LOCKFILE_PROVENANCE_ROWS
+
+
+def test_anchor_without_alias_uses_actual_graph_semantics(monkeypatch: pytest.MonkeyPatch):
+    """An anchor declaration alone does not make the composed graph shared."""
+    from apm_cli.utils.yaml_io import _BoundedSafeLoader, load_yaml_str
+
+    monkeypatch.setattr(_BoundedSafeLoader, "_MAX_EXPANSION_WEIGHT", 8)
+
+    assert load_yaml_str("payload: &declared literal-value\n") == {"payload": "literal-value"}
+
+
+def test_self_referential_alias_fails_closed():
+    """A cyclic alias graph is rejected without recursive work."""
+    import yaml
+
+    from apm_cli.utils.yaml_io import load_yaml_str
+
+    with pytest.raises(yaml.YAMLError, match="alias/anchor expansion exceeded"):
+        load_yaml_str("cycle: &cycle [*cycle]\n")

--- a/tests/red_team/parser/test_yaml_bomb.py
+++ b/tests/red_team/parser/test_yaml_bomb.py
@@ -142,3 +142,22 @@ def test_shallow_alias_doc_still_parses_under_budget(tmp_path: Path, levels: int
     assert finished, f"depth={levels}: load did not finish"
     assert exc is None, f"depth={levels}: shallow doc wrongly rejected: {exc!r}"
     assert isinstance(result, dict)
+
+
+def test_large_anchor_free_scalar_is_not_treated_as_an_alias_bomb(tmp_path: Path):
+    """A literal document above the expansion budget remains loadable.
+
+    The expansion budget defends against shared alias nodes whose logical size
+    can grow exponentially. A single unaliased scalar is linear in the input
+    size, so rejecting it as an alias bomb prevents APM from reading its own
+    large generated lockfiles without adding protection.
+    """
+    from apm_cli.utils.yaml_io import _BoundedSafeLoader, load_yaml
+
+    literal = "x" * (_BoundedSafeLoader._MAX_EXPANSION_WEIGHT + 1)
+    doc = tmp_path / "apm.lock.yaml"
+    doc.write_text(f"payload: {literal}\n", encoding="utf-8")
+
+    result = load_yaml(doc)
+
+    assert result == {"payload": literal}

--- a/tests/test_lockfile.py
+++ b/tests/test_lockfile.py
@@ -9,6 +9,7 @@ import yaml
 from apm_cli.deps.lockfile import (
     LockedDependency,
     LockFile,
+    LockfileFormatError,
     get_lockfile_path,
     migrate_lockfile_if_needed,
 )
@@ -250,6 +251,17 @@ class TestLockFile:
         loaded = LockFile.read(lock_path)
         assert loaded is not None
         assert loaded.has_dependency("owner/repo")
+
+    def test_read_rejects_oversized_lockfile_before_parsing(self, tmp_path, monkeypatch):
+        """Lockfile reads use the canonical bounded YAML file reader."""
+        from apm_cli.utils import yaml_io
+
+        lock_path = tmp_path / "apm.lock.yaml"
+        lock_path.write_text("x: 123456789\n", encoding="utf-8")
+        monkeypatch.setattr(yaml_io, "_MAX_YAML_INPUT_BYTES", 8)
+
+        with pytest.raises(LockfileFormatError, match=r"YAML file .* safe limit"):
+            LockFile.read(lock_path)
 
     def test_mcp_servers_round_trip(self, tmp_path):
         """mcp_servers must survive a write → read cycle."""

--- a/tests/unit/bundle/test_local_bundle.py
+++ b/tests/unit/bundle/test_local_bundle.py
@@ -25,6 +25,7 @@ try:
     from apm_cli.bundle.local_bundle import (
         LocalBundleInfo,
         _looks_like_legacy_apm_bundle,
+        _read_bundle_lockfile,
         check_target_mismatch,
         detect_local_bundle,
         read_bundle_plugin_json,
@@ -193,6 +194,16 @@ class TestDetectLocalBundle:
         assert result is not None
         assert "copilot" in result.pack_targets
         assert "claude" in result.pack_targets
+
+    def test_oversized_bundle_lockfile_fails_closed(self, tmp_path: Path, monkeypatch) -> None:
+        """Bundle metadata cannot bypass the canonical bounded YAML reader."""
+        from apm_cli.utils import yaml_io
+
+        bundle = _make_plugin_bundle(tmp_path)
+        (bundle / "apm.lock.yaml").write_text("x: 123456789\n", encoding="utf-8")
+        monkeypatch.setattr(yaml_io, "_MAX_YAML_INPUT_BYTES", 8)
+
+        assert _read_bundle_lockfile(bundle) is None
 
     def test_detect_cleans_temp_dir_on_malicious_archive(self, tmp_path: Path) -> None:
         """Reject paths must not leak temp dirs (review #1099 finding)."""

--- a/tests/unit/commands/test_lock_export_command.py
+++ b/tests/unit/commands/test_lock_export_command.py
@@ -114,6 +114,21 @@ def test_export_missing_lockfile_errors(runner, tmp_path):
         assert "No lockfile" in result.stderr
 
 
+def test_export_rejects_oversized_lockfile_before_reading_it(runner, tmp_path, monkeypatch):
+    """Export routes lockfile input through the bounded canonical reader."""
+    from apm_cli.utils import yaml_io
+
+    monkeypatch.setattr(yaml_io, "_MAX_YAML_INPUT_BYTES", 8)
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        (Path.cwd() / "apm.yml").write_text("name: test\nversion: 1.0.0\n")
+        (Path.cwd() / "apm.lock.yaml").write_text("x: 123456789\n")
+
+        result = runner.invoke(cli, ["lock", "export"])
+
+        assert result.exit_code != 0
+        assert "safe limit" in result.output
+
+
 def test_export_does_not_resolve(runner, tmp_path, monkeypatch):
     # export must read the lockfile only -- never invoke the resolve pipeline.
     import apm_cli.commands.install as install_mod

--- a/tests/unit/test_yaml_io.py
+++ b/tests/unit/test_yaml_io.py
@@ -1,6 +1,8 @@
 """Tests for apm_cli.utils.yaml_io -- cross-platform UTF-8 YAML I/O."""
 
 import io
+import os
+from pathlib import Path
 
 import pytest
 import yaml
@@ -72,6 +74,27 @@ class TestLoadYaml:
         p = tmp_path / "large.yml"
         p.write_text("key: value\n", encoding="utf-8")
         monkeypatch.setattr(yaml_io, "_MAX_YAML_INPUT_BYTES", 1)
+
+        with pytest.raises(yaml.YAMLError, match=r"YAML file .* safe limit"):
+            load_yaml(p)
+
+    @pytest.mark.skipif(os.name == "nt", reason="os.mkfifo is unavailable on Windows")
+    def test_named_pipe_fails_closed_without_blocking(self, tmp_path):
+        """A FIFO source is rejected before a writer can block the loader."""
+        fifo = tmp_path / "hostile.yml"
+        os.mkfifo(fifo)
+
+        with pytest.raises(yaml.YAMLError, match="must be a regular file"):
+            load_yaml(fifo)
+
+    def test_file_cap_does_not_trust_path_metadata(self, tmp_path, monkeypatch):
+        """The opened descriptor, not stale path metadata, controls the cap."""
+        from apm_cli.utils import yaml_io
+
+        p = tmp_path / "large.yml"
+        p.write_text("key: value\n", encoding="utf-8")
+        monkeypatch.setattr(yaml_io, "_MAX_YAML_INPUT_BYTES", 1)
+        monkeypatch.setattr(Path, "stat", lambda _path: pytest.fail("path stat must not run"))
 
         with pytest.raises(yaml.YAMLError, match=r"YAML file .* safe limit"):
             load_yaml(p)
@@ -224,7 +247,7 @@ class TestLoadYamlStr:
 
         monkeypatch.setattr(yaml_io, "_MAX_YAML_INPUT_BYTES", 8)
 
-        with pytest.raises(yaml.YAMLError, match="YAML input exceeds 8-byte safe limit"):
+        with pytest.raises(yaml.YAMLError, match="YAML input exceeds 8-byte"):
             load_yaml_str("key: 1234\n")
 
     def test_benign_reused_anchor_dag_still_parses(self):
@@ -308,7 +331,7 @@ class TestLoadFrontmatter:
 
         monkeypatch.setattr(yaml_io, "_MAX_YAML_INPUT_BYTES", 8)
 
-        with pytest.raises(yaml.YAMLError, match="YAML input exceeds 8-byte safe limit"):
+        with pytest.raises(yaml.YAMLError, match="YAML input exceeds 8-byte"):
             load_frontmatter(io.StringIO("---\nkey: 1234\n---\nbody\n"))
 
     def test_frontmatter_reads_at_most_the_input_cap(self, monkeypatch):
@@ -330,6 +353,18 @@ class TestLoadFrontmatter:
 
         assert post.metadata == {}
         assert reader.limit == 9
+
+    def test_text_frontmatter_reads_bytes_from_its_buffer(self, monkeypatch):
+        """A text file object uses its byte buffer for the raw cap."""
+        from apm_cli.utils import yaml_io
+
+        monkeypatch.setattr(yaml_io, "_MAX_YAML_INPUT_BYTES", 8)
+        reader = io.TextIOWrapper(io.BytesIO(b"x: 1\n"), encoding="utf-8")
+
+        post = load_frontmatter(reader)
+
+        assert post.metadata == {}
+        assert reader.buffer.tell() == 5
 
 
 class TestSharedNodeScan:

--- a/tests/unit/test_yaml_io.py
+++ b/tests/unit/test_yaml_io.py
@@ -331,40 +331,20 @@ class TestLoadFrontmatter:
 
         monkeypatch.setattr(yaml_io, "_MAX_YAML_INPUT_BYTES", 8)
 
-        with pytest.raises(yaml.YAMLError, match="YAML input exceeds 8-byte"):
+        with pytest.raises(yaml.YAMLError, match="YAML frontmatter exceeds 8-byte"):
             load_frontmatter(io.StringIO("---\nkey: 1234\n---\nbody\n"))
 
-    def test_frontmatter_reads_at_most_the_input_cap(self, monkeypatch):
-        """Untrusted frontmatter reads no more than the configured bound."""
-        from apm_cli.utils import yaml_io
-
-        class BoundedReader:
-            def __init__(self) -> None:
-                self.limit: int | None = None
-
-            def read(self, limit: int) -> str:
-                self.limit = limit
-                return "x: 1\n"
-
-        monkeypatch.setattr(yaml_io, "_MAX_YAML_INPUT_BYTES", 8)
-        reader = BoundedReader()
-
-        post = load_frontmatter(reader)
-
-        assert post.metadata == {}
-        assert reader.limit == 9
-
-    def test_text_frontmatter_reads_bytes_from_its_buffer(self, monkeypatch):
-        """A text file object uses its byte buffer for the raw cap."""
+    def test_large_markdown_body_with_small_frontmatter_is_accepted(self, monkeypatch):
+        """Only the fenced YAML header, not the Markdown body, has the cap."""
         from apm_cli.utils import yaml_io
 
         monkeypatch.setattr(yaml_io, "_MAX_YAML_INPUT_BYTES", 8)
-        reader = io.TextIOWrapper(io.BytesIO(b"x: 1\n"), encoding="utf-8")
+        reader = io.StringIO("---\na: ok\n---\n" + ("body\n" * 4))
 
         post = load_frontmatter(reader)
 
-        assert post.metadata == {}
-        assert reader.buffer.tell() == 5
+        assert post.metadata == {"a": "ok"}
+        assert post.content.count("body") == 4
 
 
 class TestSharedNodeScan:

--- a/tests/unit/test_yaml_io.py
+++ b/tests/unit/test_yaml_io.py
@@ -66,7 +66,7 @@ class TestLoadYaml:
             load_yaml(p)
 
     def test_oversize_file_fails_before_reading(self, tmp_path, monkeypatch):
-        """An oversized YAML file fails closed before its content is read."""
+        """An oversized YAML file fails closed through a bounded read."""
         from apm_cli.utils import yaml_io
 
         p = tmp_path / "large.yml"
@@ -310,6 +310,26 @@ class TestLoadFrontmatter:
 
         with pytest.raises(yaml.YAMLError, match="YAML input exceeds 8-byte safe limit"):
             load_frontmatter(io.StringIO("---\nkey: 1234\n---\nbody\n"))
+
+    def test_frontmatter_reads_at_most_the_input_cap(self, monkeypatch):
+        """Untrusted frontmatter reads no more than the configured bound."""
+        from apm_cli.utils import yaml_io
+
+        class BoundedReader:
+            def __init__(self) -> None:
+                self.limit: int | None = None
+
+            def read(self, limit: int) -> str:
+                self.limit = limit
+                return "x: 1\n"
+
+        monkeypatch.setattr(yaml_io, "_MAX_YAML_INPUT_BYTES", 8)
+        reader = BoundedReader()
+
+        post = load_frontmatter(reader)
+
+        assert post.metadata == {}
+        assert reader.limit == 9
 
 
 class TestSharedNodeScan:

--- a/tests/unit/test_yaml_io.py
+++ b/tests/unit/test_yaml_io.py
@@ -5,6 +5,7 @@ import io
 import pytest
 import yaml
 from ruamel.yaml import YAMLError as RuamelYAMLError
+from yaml.nodes import MappingNode, ScalarNode
 
 from apm_cli.utils.yaml_io import (
     _roundtrip_yaml,
@@ -62,6 +63,17 @@ class TestLoadYaml:
         p = tmp_path / "bad.yml"
         p.write_text(":\n  - :\n  bad: [unmatched", encoding="utf-8")
         with pytest.raises(yaml.YAMLError):
+            load_yaml(p)
+
+    def test_oversize_file_fails_before_reading(self, tmp_path, monkeypatch):
+        """An oversized YAML file fails closed before its content is read."""
+        from apm_cli.utils import yaml_io
+
+        p = tmp_path / "large.yml"
+        p.write_text("key: value\n", encoding="utf-8")
+        monkeypatch.setattr(yaml_io, "_MAX_YAML_INPUT_BYTES", 1)
+
+        with pytest.raises(yaml.YAMLError, match=r"YAML file .* safe limit"):
             load_yaml(p)
 
 
@@ -206,6 +218,15 @@ class TestLoadYamlStr:
         with pytest.raises(yaml.YAMLError):
             load_yaml_str(bomb)
 
+    def test_oversize_string_fails_closed(self, monkeypatch):
+        """An oversized in-memory YAML string fails before construction."""
+        from apm_cli.utils import yaml_io
+
+        monkeypatch.setattr(yaml_io, "_MAX_YAML_INPUT_BYTES", 8)
+
+        with pytest.raises(yaml.YAMLError, match="YAML input exceeds 8-byte safe limit"):
+            load_yaml_str("key: 1234\n")
+
     def test_benign_reused_anchor_dag_still_parses(self):
         """A benign reused-anchor DAG (shared refs, no expansion) still parses."""
         doc = "base: &b {x: 1}\nuse1: *b\nuse2: *b\n"
@@ -280,6 +301,53 @@ class TestLoadFrontmatter:
         bomb = "---\n" + "\n".join(lines) + "\n---\nbody\n"
         with pytest.raises(yaml.YAMLError):
             load_frontmatter(io.StringIO(bomb))
+
+    def test_oversize_frontmatter_fails_closed(self, monkeypatch):
+        """Oversized untrusted frontmatter cannot reach YAML construction."""
+        from apm_cli.utils import yaml_io
+
+        monkeypatch.setattr(yaml_io, "_MAX_YAML_INPUT_BYTES", 8)
+
+        with pytest.raises(yaml.YAMLError, match="YAML input exceeds 8-byte safe limit"):
+            load_frontmatter(io.StringIO("---\nkey: 1234\n---\nbody\n"))
+
+
+class TestSharedNodeScan:
+    """Deterministic complexity checks for the tree fast path."""
+
+    def test_tree_scan_visits_children_once_at_n_and_ten_n(self):
+        """The identity worklist scales linearly without repeated traversal."""
+        from apm_cli.utils.yaml_io import _BoundedSafeLoader
+
+        class CountingPairs(list[tuple[ScalarNode, ScalarNode]]):
+            def __init__(self, pairs: list[tuple[ScalarNode, ScalarNode]]) -> None:
+                super().__init__(pairs)
+                self.yields = 0
+
+            def __iter__(self):
+                for item in super().__iter__():
+                    self.yields += 1
+                    yield item
+
+        def tree(entries: int) -> tuple[MappingNode, CountingPairs]:
+            pairs = CountingPairs(
+                [
+                    (
+                        ScalarNode("tag:yaml.org,2002:str", f"key-{index}"),
+                        ScalarNode("tag:yaml.org,2002:str", "value"),
+                    )
+                    for index in range(entries)
+                ]
+            )
+            return MappingNode("tag:yaml.org,2002:map", pairs), pairs
+
+        small_root, small_pairs = tree(100)
+        large_root, large_pairs = tree(1_000)
+
+        assert _BoundedSafeLoader._has_shared_nodes(small_root) is False
+        assert _BoundedSafeLoader._has_shared_nodes(large_root) is False
+        assert small_pairs.yields == 100
+        assert large_pairs.yields == 1_000
 
 
 class TestBoundedMergeHappyPath:

--- a/tests/utils/yaml_guard_fixtures.py
+++ b/tests/utils/yaml_guard_fixtures.py
@@ -1,0 +1,44 @@
+"""Bounded YAML fixtures shared by parser and installed-CLI tests."""
+
+from __future__ import annotations
+
+LARGE_LOCKFILE_PROVENANCE_ROWS = 10_000
+PRIVATE_LOCKFILE_MARKER = "DO_NOT_LEAK_LOCK_CONTENT"
+
+
+def large_anchor_free_lockfile(expansion_weight: int) -> str:
+    """Return a realistic tree-shaped lockfile just beyond the old budget."""
+    value = "x" * (expansion_weight // LARGE_LOCKFILE_PROVENANCE_ROWS + 1)
+    provenance = "".join(
+        f"  server-{index:05d}: {value}\n" for index in range(LARGE_LOCKFILE_PROVENANCE_ROWS)
+    )
+    return (
+        'lockfile_version: "1"\n'
+        'generated_at: "2026-07-31T00:00:00Z"\n'
+        'apm_version: "0.26.0"\n'
+        "dependencies: []\n"
+        "deployments: []\n"
+        "mcp_servers: []\n"
+        "mcp_config_provenance:\n"
+        f"{provenance}"
+    )
+
+
+def compact_alias_bomb_lockfile(*, levels: int = 8, fanout: int = 9) -> str:
+    """Return a sub-kilobyte lockfile whose aliases expand past the budget."""
+    lines = [
+        'lockfile_version: "1"',
+        'generated_at: "2026-07-31T00:00:00Z"',
+        "dependencies: []",
+        "deployments: []",
+        "mcp_config_provenance:",
+        f"  private-note: {PRIVATE_LOCKFILE_MARKER}",
+        "  level0: &level0 [x]",
+    ]
+    previous = "level0"
+    for level in range(1, levels + 1):
+        anchor = f"level{level}"
+        aliases = ", ".join([f"*{previous}"] * fanout)
+        lines.append(f"  {anchor}: &{anchor} [{aliases}]")
+        previous = anchor
+    return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary

Fixes #2389 by distinguishing ordinary, anchor-free YAML from shared alias graphs before applying the logical expansion budget.

## Root cause

`_guard_expansion` charged every composed document against the alias-expansion budget. Large literal lockfiles are tree-shaped and grow linearly with their input, but were rejected with an alias-bomb error once their scalar weight exceeded 5,000,000.

## Approach

- Perform a linear shared-node scan before expansion accounting.
- Return early for tree-shaped YAML with no aliases.
- Retain the existing expansion accounting for alias graphs and cycles, as well as the separate merge-key budget.
- Add a regression for an anchor-free document just above the former cap.

## Validation

- `uv run pytest tests/red_team/parser/test_yaml_bomb.py tests/unit/test_yaml_io.py -q` (49 passed)
- `uv run pytest tests/red_team/parser -q` (103 passed; four existing Windows thread-cleanup warnings)
- `uv run --extra dev ruff check src/ tests/`
- `uv run --extra dev ruff format --check src/ tests/`
- The prescribed broad unit gate was attempted: `uv run pytest tests/unit tests/test_console.py -x`; it stops at an unrelated Windows-only Hermes permissions assertion (`expected 0o600, got 0o666`) before reaching the YAML tests.

## Scenario Evidence

| Scenario | Evidence | Principles |
|---|---|---|
| A large literal `apm.lock.yaml` audits successfully without a rewrite. | `tests/integration/test_yaml_guard_lifecycle_e2e.py::test_large_anchor_free_lockfile_audits_without_rewrite` | DevX; Secure by default |
| A compact alias bomb fails without leaking its private marker or writing files. | `tests/integration/test_yaml_guard_lifecycle_e2e.py::test_alias_bomb_lockfile_fails_audit_without_writes` | Secure by default |