### PR TITLE
fix(hooks): normalize Copilot lifecycle event aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Package-declared targets now restrict dependency primitive deployment without expanding project or consumer authorization, preventing Claude-only hooks from leaking into Cursor and repairing stale owned entries on update; the contract is cited in `docs/src/content/docs/specs/openapm-v0.1.md`. By @sergio-sisternes-epam (#2362)
 - Package-declared targets now restrict deployment without expanding project authorization -- a Claude-only hook package can no longer leak into Cursor (`req-tg-008`). By @sergio-sisternes-epam (#2362)
 - Copilot hooks now normalize session lifecycle aliases to documented `sessionStart` and `agentStop` keys while preserving Claude's `SessionStart` and `Stop` output -- by @SaulMoro (#2405)
+- Copilot hooks now normalize session lifecycle aliases to documented `sessionStart` and `agentStop` keys while preserving Claude's `SessionStart` and `Stop` output (reported by @SaulMoro, closes #2337, #2405)
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview
   now excludes the synthesized lockfile self-entry, matching the real install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rewriting it. (#2306)
 
 - Package-declared targets now restrict dependency primitive deployment without expanding project or consumer authorization, preventing Claude-only hooks from leaking into Cursor and repairing stale owned entries on update; the contract is cited in `docs/src/content/docs/specs/openapm-v0.1.md`. By @sergio-sisternes-epam (#2362)
+- Package-declared targets now restrict deployment without expanding project authorization -- a Claude-only hook package can no longer leak into Cursor (`req-tg-008`). By @sergio-sisternes-epam (#2362)
+- Copilot hooks now normalize session lifecycle aliases to documented `sessionStart` and `agentStop` keys while preserving Claude's `SessionStart` and `Stop` output -- by @SaulMoro (#2405)
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview
   now excludes the synthesized lockfile self-entry, matching the real install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Package-declared targets now restrict dependency primitive deployment without expanding project or consumer authorization, preventing Claude-only hooks from leaking into Cursor and repairing stale owned entries on update; the contract is cited in `docs/src/content/docs/specs/openapm-v0.1.md`. By @sergio-sisternes-epam (#2362)
 - Package-declared targets now restrict deployment without expanding project authorization -- a Claude-only hook package can no longer leak into Cursor (`req-tg-008`). By @sergio-sisternes-epam (#2362)
-- Copilot hooks now normalize session lifecycle aliases to documented `sessionStart` and `agentStop` keys while preserving Claude's `SessionStart` and `Stop` output -- by @SaulMoro (#2405)
 - Copilot hooks now normalize session lifecycle aliases to documented `sessionStart` and `agentStop` keys while preserving Claude's `SessionStart` and `Stop` output (reported by @SaulMoro, closes #2337, #2405)
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview

--- a/docs/src/content/docs/producer/author-primitives/hooks-and-commands.md
+++ b/docs/src/content/docs/producer/author-primitives/hooks-and-commands.md
@@ -41,11 +41,18 @@ your-package/
 Each file is a JSON document keyed by lifecycle event. APM accepts the
 Claude (`PreToolUse`, `PostToolUse`) and Copilot (`preToolUse`,
 `postToolUse`) shapes; events are renamed per target during merge.
-For session lifecycle events, `SessionStart` and `sessionStart` become
-Copilot's `sessionStart` or Claude's `SessionStart`. `Stop`, `AgentStop`,
-and `agentStop` become Copilot's `agentStop` or Claude's `Stop`. These are
-native mappings documented by the target runtimes; APM does not invent a
-replacement for unknown event names.
+
+For Copilot and Claude session lifecycle events:
+
+| Source aliases | Copilot native key | Claude native key |
+|----------------|---------------------|-------------------|
+| `SessionStart`, `sessionStart` | `sessionStart` | `SessionStart` |
+| `Stop`, `AgentStop`, `agentStop` | `agentStop` | `Stop` |
+
+Event names absent from this table are preserved unchanged. The existing
+diagnostic warns only when an unmapped camelCase or PascalCase name conflicts
+with the target convention. All-lowercase names such as `stop` have no
+detectable casing and pass through without a warning.
 
 ```json
 {
@@ -257,9 +264,9 @@ agent a procedure" fits a skill -- and reaches every harness.
 
 ## Pitfalls
 
-- **Hook event names.** Author in Claude or Copilot conventions only.
-  The integrator renames documented aliases; arbitrary event names are
-  preserved and a casing mismatch emits an install warning.
+- **Hook event names.** Use the documented aliases in the table above.
+  Unknown names are preserved; only an unmapped, detectable casing mismatch
+  emits an install warning.
 - **Cursor command frontmatter loss.** Cursor reuses the Claude
   command transformer today, so any prompt-only metadata is dropped
   with a diagnostic. Keep Cursor commands to the preserved key set.

--- a/docs/src/content/docs/producer/author-primitives/hooks-and-commands.md
+++ b/docs/src/content/docs/producer/author-primitives/hooks-and-commands.md
@@ -51,7 +51,8 @@ Claude (`PreToolUse`, `PostToolUse`) and Copilot (`preToolUse`,
 
 Event names absent from this table are preserved unchanged. Only an unmapped
 camelCase or PascalCase name that conflicts with the target convention emits
-an install warning; all-lowercase names such as `stop` pass through silently.
+an install warning. All-lowercase names such as `stop` pass through silently;
+`stop` is not a native Copilot or Claude event and will not fire.
 
 ```json
 {
@@ -263,9 +264,11 @@ agent a procedure" fits a skill -- and reaches every harness.
 
 ## Pitfalls
 
-- **Hook event names.** Use the documented aliases in the table above.
-  Unknown names are preserved; only an unmapped, detectable casing mismatch
-  emits an install warning.
+- **Hook event names.** Use the documented
+  [session lifecycle aliases](#session-lifecycle-event-aliases). Unknown names
+  are preserved. An install warning appears only when an unmapped name starts
+  with a capital letter or starts lowercase and contains a later capital
+  letter, and that casing conflicts with the target convention.
 - **Cursor command frontmatter loss.** Cursor reuses the Claude
   command transformer today, so any prompt-only metadata is dropped
   with a diagnostic. Keep Cursor commands to the preserved key set.

--- a/docs/src/content/docs/producer/author-primitives/hooks-and-commands.md
+++ b/docs/src/content/docs/producer/author-primitives/hooks-and-commands.md
@@ -41,6 +41,11 @@ your-package/
 Each file is a JSON document keyed by lifecycle event. APM accepts the
 Claude (`PreToolUse`, `PostToolUse`) and Copilot (`preToolUse`,
 `postToolUse`) shapes; events are renamed per target during merge.
+For session lifecycle events, `SessionStart` and `sessionStart` become
+Copilot's `sessionStart` or Claude's `SessionStart`. `Stop`, `AgentStop`,
+and `agentStop` become Copilot's `agentStop` or Claude's `Stop`. These are
+native mappings documented by the target runtimes; APM does not invent a
+replacement for unknown event names.
 
 ```json
 {
@@ -253,7 +258,8 @@ agent a procedure" fits a skill -- and reaches every harness.
 ## Pitfalls
 
 - **Hook event names.** Author in Claude or Copilot conventions only.
-  The integrator renames; arbitrary event names will not be mapped.
+  The integrator renames documented aliases; arbitrary event names are
+  preserved and a casing mismatch emits an install warning.
 - **Cursor command frontmatter loss.** Cursor reuses the Claude
   command transformer today, so any prompt-only metadata is dropped
   with a diagnostic. Keep Cursor commands to the preserved key set.

--- a/docs/src/content/docs/producer/author-primitives/hooks-and-commands.md
+++ b/docs/src/content/docs/producer/author-primitives/hooks-and-commands.md
@@ -42,17 +42,16 @@ Each file is a JSON document keyed by lifecycle event. APM accepts the
 Claude (`PreToolUse`, `PostToolUse`) and Copilot (`preToolUse`,
 `postToolUse`) shapes; events are renamed per target during merge.
 
-For Copilot and Claude session lifecycle events:
+### Session lifecycle event aliases
 
 | Source aliases | Copilot native key | Claude native key |
 |----------------|---------------------|-------------------|
 | `SessionStart`, `sessionStart` | `sessionStart` | `SessionStart` |
 | `Stop`, `AgentStop`, `agentStop` | `agentStop` | `Stop` |
 
-Event names absent from this table are preserved unchanged. The existing
-diagnostic warns only when an unmapped camelCase or PascalCase name conflicts
-with the target convention. All-lowercase names such as `stop` have no
-detectable casing and pass through without a warning.
+Event names absent from this table are preserved unchanged. Only an unmapped
+camelCase or PascalCase name that conflicts with the target convention emits
+an install warning; all-lowercase names such as `stop` pass through silently.
 
 ```json
 {

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -158,10 +158,15 @@ becomes `PostToolUse` in Claude) and rewrites path variables
 (`${PLUGIN_ROOT}`, `${CURSOR_PLUGIN_ROOT}`, `${CLAUDE_PLUGIN_ROOT}`) to
 the correct target-specific form. Kiro materializes one JSON document per
 hook action under `.kiro/hooks/`.
-For session lifecycle hooks, `SessionStart`/`sessionStart` normalize to
-Copilot `sessionStart` and Claude `SessionStart`; `Stop`/`AgentStop`/`agentStop`
-normalize to Copilot `agentStop` and Claude `Stop`. Unknown event names are
-not assigned invented native names.
+
+| Source aliases | Copilot native key | Claude native key |
+|----------------|---------------------|-------------------|
+| `SessionStart`, `sessionStart` | `sessionStart` | `SessionStart` |
+| `Stop`, `AgentStop`, `agentStop` | `agentStop` | `Stop` |
+
+Event names absent from this table are preserved unchanged. Only an unmapped
+camelCase or PascalCase name that conflicts with the target convention emits
+an install warning; all-lowercase names such as `stop` pass through silently.
 
 When a hook command references a script inside `hooks/` or `.apm/hooks/`,
 APM deploys that hook source bundle so sibling helper files resolve at

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -158,6 +158,10 @@ becomes `PostToolUse` in Claude) and rewrites path variables
 (`${PLUGIN_ROOT}`, `${CURSOR_PLUGIN_ROOT}`, `${CLAUDE_PLUGIN_ROOT}`) to
 the correct target-specific form. Kiro materializes one JSON document per
 hook action under `.kiro/hooks/`.
+For session lifecycle hooks, `SessionStart`/`sessionStart` normalize to
+Copilot `sessionStart` and Claude `SessionStart`; `Stop`/`AgentStop`/`agentStop`
+normalize to Copilot `agentStop` and Claude `Stop`. Unknown event names are
+not assigned invented native names.
 
 When a hook command references a script inside `hooks/` or `.apm/hooks/`,
 APM deploys that hook source bundle so sibling helper files resolve at

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -159,6 +159,8 @@ becomes `PostToolUse` in Claude) and rewrites path variables
 the correct target-specific form. Kiro materializes one JSON document per
 hook action under `.kiro/hooks/`.
 
+### Session lifecycle event aliases
+
 | Source aliases | Copilot native key | Claude native key |
 |----------------|---------------------|-------------------|
 | `SessionStart`, `sessionStart` | `sessionStart` | `SessionStart` |

--- a/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/package-authoring.md
@@ -159,6 +159,8 @@ becomes `PostToolUse` in Claude) and rewrites path variables
 the correct target-specific form. Kiro materializes one JSON document per
 hook action under `.kiro/hooks/`.
 
+<!-- Keep this table synchronized with docs/src/content/docs/producer/author-primitives/hooks-and-commands.md. -->
+
 ### Session lifecycle event aliases
 
 | Source aliases | Copilot native key | Claude native key |
@@ -168,7 +170,8 @@ hook action under `.kiro/hooks/`.
 
 Event names absent from this table are preserved unchanged. Only an unmapped
 camelCase or PascalCase name that conflicts with the target convention emits
-an install warning; all-lowercase names such as `stop` pass through silently.
+an install warning. All-lowercase names such as `stop` pass through silently;
+`stop` is not a native Copilot or Claude event and will not fire.
 
 When a hook command references a script inside `hooks/` or `.apm/hooks/`,
 APM deploys that hook source bundle so sibling helper files resolve at

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -93,6 +93,21 @@ if [ "$hook_scope_owner_count" -ne 1 ] \
     [ -n "$hook_scope_duplicate_hits" ] && echo "$hook_scope_duplicate_hits"
     violations=$((violations + 1))
 fi
+hook_event_map_owner_count=$(grep -Ec \
+    '^_HOOK_EVENT_MAP[[:space:]]*:' "$hook_file" || true)
+hook_event_map_duplicate_hits=$(
+    grep -REn --include='*.py' \
+        '^_HOOK_EVENT_MAP[[:space:]]*:' \
+        src/apm_cli \
+        | grep -v "^${hook_file}:" \
+        || true
+)
+if [ "$hook_event_map_owner_count" -ne 1 ] \
+    || [ -n "$hook_event_map_duplicate_hits" ]; then
+    echo "[x] Native hook event mapping must have one HookIntegrator owner"
+    [ -n "$hook_event_map_duplicate_hits" ] && echo "$hook_event_map_duplicate_hits"
+    violations=$((violations + 1))
+fi
 check_pattern \
     "Lockfile supported-version authority belongs in deps/lockfile.py" \
     'SUPPORTED_LOCKFILE_VERSIONS|lockfile_version[[:space:]]+(==|!=|in)' \

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -94,10 +94,10 @@ if [ "$hook_scope_owner_count" -ne 1 ] \
     violations=$((violations + 1))
 fi
 hook_event_map_owner_count=$(grep -Ec \
-    '^_HOOK_EVENT_MAP[[:space:]]*:' "$hook_file" || true)
+    '^_HOOK_EVENT_MAP[[:space:]]*[:=]' "$hook_file" || true)
 hook_event_map_duplicate_hits=$(
     grep -REn --include='*.py' \
-        '^_HOOK_EVENT_MAP[[:space:]]*:' \
+        '^_HOOK_EVENT_MAP[[:space:]]*[:=]' \
         src/apm_cli \
         | grep -v "^${hook_file}:" \
         || true

--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -168,7 +168,7 @@ _HOOK_EVENT_MAP: dict[str, dict[str, str]] = {
         "postTaskExecution": "postTaskExecution",
     },
     "claude": {
-        # Copilot camelCase -> Claude PascalCase
+        # Copilot camelCase and portable lifecycle aliases -> Claude PascalCase
         "preToolUse": "PreToolUse",
         "postToolUse": "PostToolUse",
         **dict.fromkeys(("SessionStart", "sessionStart"), "SessionStart"),

--- a/src/apm_cli/integration/hook_integrator.py
+++ b/src/apm_cli/integration/hook_integrator.py
@@ -160,10 +160,8 @@ _HOOK_EVENT_MAP: dict[str, dict[str, str]] = {
         "postToolUse": "postToolUse",
         "UserPromptSubmit": "userPromptSubmit",
         "userPromptSubmit": "userPromptSubmit",
-        "Stop": "stop",
-        "stop": "stop",
-        "AgentStop": "agentStop",
-        "agentStop": "agentStop",
+        **dict.fromkeys(("SessionStart", "sessionStart"), "sessionStart"),
+        **dict.fromkeys(("Stop", "AgentStop", "agentStop"), "agentStop"),
         "PreTaskExecution": "preTaskExecution",
         "preTaskExecution": "preTaskExecution",
         "PostTaskExecution": "postTaskExecution",
@@ -173,6 +171,8 @@ _HOOK_EVENT_MAP: dict[str, dict[str, str]] = {
         # Copilot camelCase -> Claude PascalCase
         "preToolUse": "PreToolUse",
         "postToolUse": "PostToolUse",
+        **dict.fromkeys(("SessionStart", "sessionStart"), "SessionStart"),
+        **dict.fromkeys(("Stop", "AgentStop", "agentStop"), "Stop"),
     },
     "gemini": {
         # Copilot / Claude -> Gemini

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -134,6 +134,57 @@ def test_hook_rewrite_scope_has_single_owner() -> None:
     assert "Hook rewrite scope must route through HookIntegrator" in guard
 
 
+def test_native_hook_event_map_has_single_owner() -> None:
+    """Target-native event names must come from HookIntegrator's map."""
+    root = Path(__file__).parents[2]
+    owner = (root / "src/apm_cli/integration/hook_integrator.py").read_text()
+    kiro = (root / "src/apm_cli/integration/kiro_hook_integrator.py").read_text()
+    guard = (root / "scripts/lint-architecture-boundaries.sh").read_text()
+
+    assert owner.count("_HOOK_EVENT_MAP:") == 1
+    assert "from apm_cli.integration.hook_integrator import" in kiro
+    assert "_HOOK_EVENT_MAP," in kiro
+    assert '_KIRO_EVENT_MAP = _HOOK_EVENT_MAP["kiro"]' in kiro
+    assert "Native hook event mapping must have one HookIntegrator owner" in guard
+
+
+def test_native_hook_event_map_guard_rejects_parallel_owner(tmp_path: Path) -> None:
+    """The boundary lint must reject a second native event map."""
+    root = Path(__file__).parents[2]
+    sandbox = tmp_path / "repo"
+    shutil.copytree(
+        root,
+        sandbox,
+        ignore=shutil.ignore_patterns(
+            ".git",
+            ".venv",
+            ".pytest_cache",
+            "__pycache__",
+            "build",
+            "dist",
+            "node_modules",
+        ),
+    )
+    duplicate = sandbox / "src/apm_cli/integration/hook_bundle.py"
+    duplicate.write_text(
+        duplicate.read_text(encoding="utf-8")
+        + "\n_HOOK_EVENT_MAP: dict[str, dict[str, str]] = {}\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ("bash", "scripts/lint-architecture-boundaries.sh"),
+        cwd=sandbox,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+
+    assert result.returncode == 1
+    assert "Native hook event mapping must have one HookIntegrator owner" in result.stdout
+
+
 def test_hook_rewrite_scope_guard_rejects_parallel_decision(tmp_path: Path) -> None:
     """The boundary lint must reject scope decisions outside HookIntegrator."""
     root = Path(__file__).parents[2]

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -167,8 +167,7 @@ def test_native_hook_event_map_guard_rejects_parallel_owner(tmp_path: Path) -> N
     )
     duplicate = sandbox / "src/apm_cli/integration/hook_bundle.py"
     duplicate.write_text(
-        duplicate.read_text(encoding="utf-8")
-        + "\n_HOOK_EVENT_MAP: dict[str, dict[str, str]] = {}\n",
+        duplicate.read_text(encoding="utf-8") + "\n_HOOK_EVENT_MAP = {}\n",
         encoding="utf-8",
     )
 

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -142,6 +142,7 @@ def test_native_hook_event_map_has_single_owner() -> None:
     guard = (root / "scripts/lint-architecture-boundaries.sh").read_text()
 
     assert owner.count("_HOOK_EVENT_MAP:") == 1
+    assert "\n_HOOK_EVENT_MAP =" not in owner
     assert "from apm_cli.integration.hook_integrator import" in kiro
     assert "_HOOK_EVENT_MAP," in kiro
     assert '_KIRO_EVENT_MAP = _HOOK_EVENT_MAP["kiro"]' in kiro

--- a/tests/integration/test_hook_event_native_lifecycle.py
+++ b/tests/integration/test_hook_event_native_lifecycle.py
@@ -1,0 +1,404 @@
+"""Installed-CLI lifecycle proof for native hook event normalization."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+import pytest
+
+from apm_cli.utils.yaml_io import dump_yaml
+from tests.utils.apm_lifecycle_runner import ApmLifecycleRunner, CommandResult
+from tests.utils.isolated_apm_environment import IsolatedApmEnvironment
+from tests.utils.lifecycle_state import LifecycleStateRoot, LifecycleStateSnapshot
+from tests.utils.local_git_repository import LocalGitRepositoryFactory
+from tests.utils.local_package import LocalPackage, LocalPackageFactory
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.lifecycle_smoke,
+    pytest.mark.requires_apm_binary,
+]
+
+_INSTALL_ARGS = ("install", "--no-policy", "--parallel-downloads", "0")
+_PACKAGE_NAME = "native-hook-kit"
+_COPILOT_GENERATED = f".github/hooks/{_PACKAGE_NAME}-events.json"
+_COPILOT_USER = ".github/hooks/user-hooks.json"
+_CLAUDE_SETTINGS = ".claude/settings.json"
+_CLAUDE_SIDECAR = ".claude/apm-hooks.json"
+
+
+def _entry(command: str) -> dict[str, Any]:
+    return {"hooks": [{"type": "command", "command": command}]}
+
+
+def _initial_document() -> dict[str, object]:
+    return {
+        "hooks": {
+            "SessionStart": [_entry("echo start-pascal-v1")],
+            "sessionStart": [_entry("echo start-camel-v1")],
+            "Stop": [_entry("echo stop-v1")],
+            "AgentStop": [_entry("echo agent-pascal-v1")],
+            "agentStop": [_entry("echo agent-camel-v1")],
+        }
+    }
+
+
+def _updated_document() -> dict[str, object]:
+    return {
+        "hooks": {
+            "sessionStart": [_entry("echo start-v2")],
+            "agentStop": [_entry("echo stop-v2")],
+        }
+    }
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> bytes:
+    content = (json.dumps(payload, indent=2) + "\n").encode()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return content
+
+
+def _read_hooks(path: Path) -> dict[str, list[dict[str, Any]]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    hooks = payload["hooks"]
+    assert isinstance(hooks, dict)
+    return hooks
+
+
+def _commands(entries: list[dict[str, Any]]) -> list[str]:
+    return [entry["hooks"][0]["command"] for entry in entries]
+
+
+def _run_success(
+    runner: ApmLifecycleRunner,
+    args: tuple[str, ...],
+    *,
+    scenario_id: str,
+    cwd: Path,
+    environment: dict[str, str],
+) -> CommandResult:
+    result = runner.run(
+        args,
+        scenario_id=scenario_id,
+        cwd=cwd,
+        env=environment,
+    )
+    assert result.returncode == 0, (
+        f"command={result.command!r}\nstdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    return result
+
+
+def _assert_project_native_hooks(
+    project_root: Path,
+    *,
+    expected_agent_commands: list[str],
+    expected_session_commands: list[str],
+    expected_user_bytes: bytes,
+) -> None:
+    copilot = _read_hooks(project_root / _COPILOT_GENERATED)
+    assert list(copilot) == ["agentStop", "sessionStart"]
+    assert _commands(copilot["agentStop"]) == expected_agent_commands
+    assert _commands(copilot["sessionStart"]) == expected_session_commands
+    assert (project_root / _COPILOT_USER).read_bytes() == expected_user_bytes
+
+    claude = _read_hooks(project_root / _CLAUDE_SETTINGS)
+    assert list(claude) == ["stop", "Stop", "SessionStart"]
+    assert _commands(claude["stop"]) == ["echo user-stop"]
+    assert _commands(claude["Stop"]) == expected_agent_commands
+    assert _commands(claude["SessionStart"]) == expected_session_commands
+    assert (project_root / _CLAUDE_SIDECAR).is_file()
+
+
+def _project_snapshot(project_root: Path) -> LifecycleStateSnapshot:
+    return LifecycleStateSnapshot.capture(
+        project_root,
+        targets=("copilot", "claude"),
+        config_paths=(
+            PurePosixPath(_COPILOT_GENERATED),
+            PurePosixPath(_COPILOT_USER),
+            PurePosixPath(_CLAUDE_SETTINGS),
+            PurePosixPath(_CLAUDE_SIDECAR),
+        ),
+    )
+
+
+def _author_source(
+    source_factory: LocalPackageFactory,
+    *,
+    name: str,
+    document: dict[str, object],
+) -> LocalPackage:
+    package = source_factory.create(name)
+    source_factory.add_hook(package, "events", document)
+    return package
+
+
+def test_project_hook_events_converge_update_and_contract(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    isolated = IsolatedApmEnvironment.create(
+        tmp_path / "project-hook-events",
+        base_env=dict(os.environ),
+    )
+    environment = isolated.subprocess_env()
+    sources = LocalPackageFactory(isolated.package_root)
+    consumers = LocalPackageFactory(isolated.work_root)
+    source = _author_source(
+        sources,
+        name=_PACKAGE_NAME,
+        document=_initial_document(),
+    )
+    consumer = consumers.create(
+        "hook-event-consumer",
+        dependencies=({"path": str(source.root)},),
+        targets=("copilot", "claude"),
+    )
+    runner = ApmLifecycleRunner(
+        (str(apm_binary_path),),
+        timeout_seconds=60,
+        scenario_timeout_seconds=120,
+    )
+    user_copilot = {
+        "version": 1,
+        "hooks": {"stop": [{"type": "command", "command": "echo user-stop"}]},
+    }
+    user_claude = {"hooks": {"stop": [_entry("echo user-stop")]}}
+    user_copilot_bytes = _write_json(consumer.root / _COPILOT_USER, user_copilot)
+    _write_json(consumer.root / _CLAUDE_SETTINGS, user_claude)
+
+    first_result = _run_success(
+        runner,
+        _INSTALL_ARGS,
+        scenario_id="hook-events-project-install-first",
+        cwd=consumer.root,
+        environment=environment,
+    )
+    assert "may not be recognized" not in first_result.stdout + first_result.stderr
+    initial_agent_commands = [
+        "echo agent-pascal-v1",
+        "echo stop-v1",
+        "echo agent-camel-v1",
+    ]
+    initial_session_commands = [
+        "echo start-pascal-v1",
+        "echo start-camel-v1",
+    ]
+    _assert_project_native_hooks(
+        consumer.root,
+        expected_agent_commands=initial_agent_commands,
+        expected_session_commands=initial_session_commands,
+        expected_user_bytes=user_copilot_bytes,
+    )
+    first = _project_snapshot(consumer.root)
+
+    _run_success(
+        runner,
+        _INSTALL_ARGS,
+        scenario_id="hook-events-project-install-idempotent",
+        cwd=consumer.root,
+        environment=environment,
+    )
+    second = _project_snapshot(consumer.root)
+    assert second.semantic_bytes == first.semantic_bytes
+    assert second.file(_COPILOT_GENERATED).content == first.file(_COPILOT_GENERATED).content
+    assert second.file(_CLAUDE_SETTINGS).content == first.file(_CLAUDE_SETTINGS).content
+
+    generated = consumer.root / _COPILOT_GENERATED
+    stale = json.loads(generated.read_text(encoding="utf-8"))
+    stale["hooks"]["stop"] = stale["hooks"].pop("agentStop")
+    _write_json(generated, stale)
+    sources.add_hook(source, "events", _updated_document())
+
+    update_result = _run_success(
+        runner,
+        _INSTALL_ARGS,
+        scenario_id="hook-events-project-update-aliases",
+        cwd=consumer.root,
+        environment=environment,
+    )
+    assert "may not be recognized" not in update_result.stdout + update_result.stderr
+    _assert_project_native_hooks(
+        consumer.root,
+        expected_agent_commands=["echo stop-v2"],
+        expected_session_commands=["echo start-v2"],
+        expected_user_bytes=user_copilot_bytes,
+    )
+    assert "stop" not in _read_hooks(generated)
+
+    consumers.set_targets(consumer, ("copilot",))
+    _run_success(
+        runner,
+        _INSTALL_ARGS,
+        scenario_id="hook-events-project-contract-claude",
+        cwd=consumer.root,
+        environment=environment,
+    )
+    assert _commands(_read_hooks(consumer.root / _CLAUDE_SETTINGS)["stop"]) == ["echo user-stop"]
+    assert not (consumer.root / _CLAUDE_SIDECAR).exists()
+    assert (consumer.root / _COPILOT_USER).read_bytes() == user_copilot_bytes
+    assert set(_read_hooks(generated)) == {"agentStop", "sessionStart"}
+
+    uninstall_result = _run_success(
+        runner,
+        ("uninstall", str(source.root)),
+        scenario_id="hook-events-project-uninstall",
+        cwd=consumer.root,
+        environment=environment,
+    )
+    assert not generated.exists(), uninstall_result.stdout + uninstall_result.stderr
+    assert (consumer.root / _COPILOT_USER).read_bytes() == user_copilot_bytes
+    assert _commands(_read_hooks(consumer.root / _CLAUDE_SETTINGS)["stop"]) == ["echo user-stop"]
+    final = _project_snapshot(consumer.root)
+    assert not final.deployment_records
+
+
+def test_global_hook_events_preserve_user_state(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    isolated = IsolatedApmEnvironment.create(
+        tmp_path / "global-hook-events",
+        base_env=dict(os.environ),
+    )
+    claude_root = isolated.home / ".claude"
+    environment = isolated.subprocess_env(overrides={"CLAUDE_CONFIG_DIR": str(claude_root)})
+    sources = LocalPackageFactory(isolated.package_root)
+    source = _author_source(
+        sources,
+        name="global-native-hook-kit",
+        document={
+            "hooks": {
+                "SessionStart": [_entry("echo global-start")],
+                "AgentStop": [_entry("echo global-stop")],
+            }
+        },
+    )
+    repositories = LocalGitRepositoryFactory(
+        isolated.repository_root,
+        env=environment,
+    )
+    repository = repositories.create(source.name, source_tree=source.root)
+    commit = repositories.commit(repository, message="seed global native hook package")
+    remote = f"https://github.com/apm-fixture/{source.name}"
+    environment = repositories.url_rewrite_subprocess_env(repository, remote)
+    dump_yaml(
+        {
+            "name": "global-hook-consumer",
+            "version": "0.1.0",
+            "dependencies": {
+                "apm": [
+                    {
+                        "git": remote,
+                        "ref": commit.sha,
+                        "alias": source.name,
+                    }
+                ]
+            },
+            "targets": ["copilot", "claude"],
+        },
+        isolated.config_root / "apm.yml",
+    )
+    workdir = isolated.work_root / "consumer"
+    workdir.mkdir()
+    copilot_root = isolated.home / ".copilot"
+    generated_relative = "hooks/global-native-hook-kit-events.json"
+    user_relative = "hooks/user-hooks.json"
+    user_copilot = {
+        "version": 1,
+        "hooks": {"stop": [{"type": "command", "command": "echo global-user-stop"}]},
+    }
+    user_copilot_bytes = _write_json(copilot_root / user_relative, user_copilot)
+    _write_json(
+        claude_root / "settings.json",
+        {"hooks": {"stop": [_entry("echo global-user-stop")]}},
+    )
+    runner = ApmLifecycleRunner(
+        (str(apm_binary_path),),
+        timeout_seconds=60,
+        scenario_timeout_seconds=120,
+    )
+    install = (
+        "install",
+        "--global",
+        "--target",
+        "copilot,claude",
+        "--no-policy",
+        "--parallel-downloads",
+        "0",
+    )
+
+    first_result = _run_success(
+        runner,
+        install,
+        scenario_id="hook-events-global-install-first",
+        cwd=workdir,
+        environment=environment,
+    )
+    assert "may not be recognized" not in first_result.stdout + first_result.stderr
+    copilot = _read_hooks(copilot_root / generated_relative)
+    assert list(copilot) == ["agentStop", "sessionStart"]
+    assert _commands(copilot["agentStop"]) == ["echo global-stop"]
+    assert _commands(copilot["sessionStart"]) == ["echo global-start"]
+    claude = _read_hooks(claude_root / "settings.json")
+    assert list(claude) == ["stop", "Stop", "SessionStart"]
+    assert _commands(claude["stop"]) == ["echo global-user-stop"]
+    assert _commands(claude["Stop"]) == ["echo global-stop"]
+    assert _commands(claude["SessionStart"]) == ["echo global-start"]
+
+    external_roots = (
+        LifecycleStateRoot(
+            root_id="copilot-user",
+            target="copilot",
+            scope="user",
+            path=copilot_root,
+            config_paths=(
+                PurePosixPath(generated_relative),
+                PurePosixPath(user_relative),
+            ),
+        ),
+        LifecycleStateRoot(
+            root_id="claude-user",
+            target="claude",
+            scope="user",
+            path=claude_root,
+            config_paths=(
+                PurePosixPath("settings.json"),
+                PurePosixPath("apm-hooks.json"),
+            ),
+        ),
+    )
+    first = LifecycleStateSnapshot.capture(
+        isolated.config_root,
+        external_roots=external_roots,
+    )
+    _run_success(
+        runner,
+        (
+            "install",
+            "--global",
+            "--target",
+            "copilot,claude",
+            "--no-policy",
+            "--parallel-downloads",
+            "0",
+        ),
+        scenario_id="hook-events-global-install-idempotent",
+        cwd=workdir,
+        environment=environment,
+    )
+    second = LifecycleStateSnapshot.capture(
+        isolated.config_root,
+        external_roots=external_roots,
+    )
+    assert second.semantic_bytes == first.semantic_bytes
+    assert (copilot_root / user_relative).read_bytes() == user_copilot_bytes
+    assert _commands(_read_hooks(claude_root / "settings.json")["stop"]) == [
+        "echo global-user-stop"
+    ]
+    assert (claude_root / "apm-hooks.json").is_file()

--- a/tests/integration/test_hook_integrator_copilot_casing_e2e.py
+++ b/tests/integration/test_hook_integrator_copilot_casing_e2e.py
@@ -103,6 +103,7 @@ def test_copilot_install_writes_only_camel_case_hook_events(tmp_path: Path) -> N
             "PreToolUse": [_hook_entry("echo pre")],
             "PostToolUse": [_hook_entry("echo post")],
             "UserPromptSubmit": [_hook_entry("echo prompt")],
+            "SessionStart": [_hook_entry("echo start")],
             "Stop": [_hook_entry("echo stop")],
         },
     )
@@ -112,8 +113,21 @@ def test_copilot_install_writes_only_camel_case_hook_events(tmp_path: Path) -> N
     assert result["hooks"] == 1
     config = _read_copilot_hooks_config(project_root, package_info.package.name)
     hooks = config["hooks"]
-    assert set(hooks) == {"preToolUse", "postToolUse", "userPromptSubmit", "stop"}
-    assert {"PreToolUse", "PostToolUse", "UserPromptSubmit", "Stop"}.isdisjoint(hooks)
+    assert set(hooks) == {
+        "preToolUse",
+        "postToolUse",
+        "userPromptSubmit",
+        "sessionStart",
+        "agentStop",
+    }
+    assert {
+        "PreToolUse",
+        "PostToolUse",
+        "UserPromptSubmit",
+        "SessionStart",
+        "Stop",
+        "stop",
+    }.isdisjoint(hooks)
 
 
 def test_copilot_install_merges_duplicate_event_aliases(tmp_path: Path) -> None:

--- a/tests/unit/integration/test_hook_diagnostics.py
+++ b/tests/unit/integration/test_hook_diagnostics.py
@@ -131,11 +131,10 @@ class TestEmitHookEventDiagnosticsMismatch:
     """Convention-mismatch events without a known mapping trigger user warning."""
 
     def test_warns_camel_event_on_pascal_target(self, capsys):
-        # "sessionStart" is camelCase but claude expects PascalCase;
-        # no mapping exists so it may not be recognized.
-        _emit_hook_event_diagnostics(["sessionStart"], "claude", {})
+        # An unknown camelCase event has no native Claude mapping.
+        _emit_hook_event_diagnostics(["mysteryEvent"], "claude", {})
         captured = capsys.readouterr()
-        assert "sessionStart" in captured.out
+        assert "mysteryEvent" in captured.out
 
     def test_warns_pascal_event_on_camel_target(self, capsys):
         # "PreToolUse" is PascalCase but copilot expects camelCase;
@@ -256,13 +255,12 @@ class TestMultiTargetHookDiagnostics:
         assert "copilot" in targets_logged, "No INFO log for copilot target"
         assert "claude" in targets_logged, "No INFO log for claude target"
 
-    def test_camel_event_on_claude_target_emits_warning(self, temp_project, capsys):
-        """camelCase event deployed to claude (PascalCase target) produces warning."""
+    def test_session_start_alias_on_claude_target_emits_no_warning(self, temp_project, capsys):
+        """Claude recognizes the portable camelCase session-start alias."""
         pkg_info = self._make_package_with_hooks(
             temp_project,
             {
                 "hooks": {
-                    # sessionStart is camelCase but has NO mapping for claude
                     "sessionStart": [{"type": "command", "bash": "echo start"}],
                 }
             },
@@ -273,7 +271,7 @@ class TestMultiTargetHookDiagnostics:
         integrator.integrate_hooks_for_target(claude, pkg_info, temp_project)
 
         captured = capsys.readouterr()
-        assert "sessionStart" in captured.out
+        assert "may not be recognized" not in captured.out
 
     def test_collision_suppresses_diagnostics(self, temp_project, caplog, capsys):
         """No diagnostics are emitted for a hook file skipped due to collision.

--- a/tests/unit/integration/test_hook_event_normalization.py
+++ b/tests/unit/integration/test_hook_event_normalization.py
@@ -1,0 +1,208 @@
+"""Regression coverage for native hook event normalization."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from apm_cli.integration.hook_integrator import (
+    _HOOK_EVENT_MAP,
+    HookIntegrator,
+    _emit_hook_event_diagnostics,
+)
+from apm_cli.integration.targets import KNOWN_TARGETS
+from apm_cli.models.apm_package import APMPackage, PackageInfo
+
+
+def _entry(command: str) -> dict[str, Any]:
+    return {"hooks": [{"type": "command", "command": command}]}
+
+
+def _package(
+    tmp_path: Path,
+    hooks: dict[str, list[dict[str, Any]]],
+    *,
+    name: str = "native-event-kit",
+) -> PackageInfo:
+    package_root = tmp_path / "packages" / name
+    hooks_dir = package_root / ".apm" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (hooks_dir / "events.json").write_text(
+        json.dumps({"hooks": hooks}, indent=2),
+        encoding="utf-8",
+    )
+    return PackageInfo(
+        package=APMPackage(name=name, version="1.0.0"),
+        install_path=package_root,
+    )
+
+
+def _commands(entries: list[dict[str, Any]]) -> list[str]:
+    return [entry["hooks"][0]["command"] for entry in entries]
+
+
+@pytest.mark.parametrize(
+    ("target", "source_event", "native_event"),
+    [
+        ("copilot", "SessionStart", "sessionStart"),
+        ("copilot", "sessionStart", "sessionStart"),
+        ("copilot", "Stop", "agentStop"),
+        ("copilot", "AgentStop", "agentStop"),
+        ("copilot", "agentStop", "agentStop"),
+        ("claude", "SessionStart", "SessionStart"),
+        ("claude", "sessionStart", "SessionStart"),
+        ("claude", "Stop", "Stop"),
+        ("claude", "AgentStop", "Stop"),
+        ("claude", "agentStop", "Stop"),
+    ],
+)
+def test_supported_aliases_map_to_documented_native_events(
+    target: str,
+    source_event: str,
+    native_event: str,
+) -> None:
+    assert _HOOK_EVENT_MAP[target][source_event] == native_event
+
+
+def test_unsupported_lowercase_stop_is_not_declared_as_native_alias() -> None:
+    assert "stop" not in _HOOK_EVENT_MAP["copilot"]
+    assert "stop" not in _HOOK_EVENT_MAP["claude"]
+
+
+def test_copilot_alias_collisions_merge_in_source_order(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    package = _package(
+        tmp_path,
+        {
+            "SessionStart": [_entry("echo start-pascal")],
+            "sessionStart": [_entry("echo start-camel")],
+            "Stop": [_entry("echo stop")],
+            "AgentStop": [_entry("echo agent-pascal")],
+            "agentStop": [_entry("echo agent-camel")],
+        },
+    )
+
+    HookIntegrator().integrate_hooks_for_target(
+        KNOWN_TARGETS["copilot"],
+        package,
+        project,
+    )
+
+    target = project / ".github" / "hooks" / "native-event-kit-events.json"
+    hooks = json.loads(target.read_text(encoding="utf-8"))["hooks"]
+    assert list(hooks) == ["sessionStart", "agentStop"]
+    assert _commands(hooks["sessionStart"]) == [
+        "echo start-pascal",
+        "echo start-camel",
+    ]
+    assert _commands(hooks["agentStop"]) == [
+        "echo stop",
+        "echo agent-pascal",
+        "echo agent-camel",
+    ]
+
+
+def test_claude_alias_collisions_merge_in_source_order(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    package = _package(
+        tmp_path,
+        {
+            "sessionStart": [_entry("echo start-camel")],
+            "SessionStart": [_entry("echo start-pascal")],
+            "agentStop": [_entry("echo agent-camel")],
+            "AgentStop": [_entry("echo agent-pascal")],
+            "Stop": [_entry("echo stop")],
+        },
+    )
+
+    HookIntegrator().integrate_hooks_for_target(
+        KNOWN_TARGETS["claude"],
+        package,
+        project,
+    )
+
+    hooks = json.loads((project / ".claude" / "settings.json").read_text(encoding="utf-8"))["hooks"]
+    assert list(hooks) == ["SessionStart", "Stop"]
+    assert _commands(hooks["SessionStart"]) == [
+        "echo start-camel",
+        "echo start-pascal",
+    ]
+    assert _commands(hooks["Stop"]) == [
+        "echo agent-camel",
+        "echo agent-pascal",
+        "echo stop",
+    ]
+
+
+def test_unknown_event_warns_and_is_not_renamed(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    project = tmp_path / "project"
+    package = _package(
+        tmp_path,
+        {"UnsupportedEvent": [_entry("echo unsupported")]},
+    )
+
+    HookIntegrator().integrate_hooks_for_target(
+        KNOWN_TARGETS["copilot"],
+        package,
+        project,
+    )
+
+    warning = capsys.readouterr().out
+    assert "UnsupportedEvent" in warning
+    assert "may not be recognized" in warning
+    target = project / ".github" / "hooks" / "native-event-kit-events.json"
+    hooks = json.loads(target.read_text(encoding="utf-8"))["hooks"]
+    assert list(hooks) == ["UnsupportedEvent"]
+
+
+def test_supported_alias_diagnostics_do_not_warn(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    aliases = ["SessionStart", "sessionStart", "Stop", "AgentStop", "agentStop"]
+
+    for target in ("copilot", "claude"):
+        _emit_hook_event_diagnostics(aliases, target, _HOOK_EVENT_MAP[target])
+
+    assert "may not be recognized" not in capsys.readouterr().out
+
+
+def test_reinstall_repairs_owned_stop_without_touching_user_hook(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    package = _package(
+        tmp_path,
+        {
+            "SessionStart": [_entry("echo start")],
+            "Stop": [_entry("echo managed-stop")],
+        },
+    )
+    integrator = HookIntegrator()
+    target = project / ".github" / "hooks" / "native-event-kit-events.json"
+    user_target = project / ".github" / "hooks" / "user-hooks.json"
+    user_payload = {
+        "version": 1,
+        "hooks": {"stop": [{"type": "command", "command": "echo user-stop"}]},
+    }
+
+    integrator.integrate_hooks_for_target(KNOWN_TARGETS["copilot"], package, project)
+    stale = json.loads(target.read_text(encoding="utf-8"))
+    stale["hooks"]["stop"] = stale["hooks"].pop("agentStop")
+    target.write_text(json.dumps(stale, indent=2) + "\n", encoding="utf-8")
+    user_target.write_text(json.dumps(user_payload, indent=2) + "\n", encoding="utf-8")
+
+    integrator.integrate_hooks_for_target(
+        KNOWN_TARGETS["copilot"],
+        package,
+        project,
+        managed_files={".github/hooks/native-event-kit-events.json"},
+    )
+
+    repaired = json.loads(target.read_text(encoding="utf-8"))
+    assert set(repaired["hooks"]) == {"sessionStart", "agentStop"}
+    assert "stop" not in repaired["hooks"]
+    assert json.loads(user_target.read_text(encoding="utf-8")) == user_payload

--- a/tests/unit/integration/test_hook_event_normalization.py
+++ b/tests/unit/integration/test_hook_event_normalization.py
@@ -156,6 +156,8 @@ def test_unknown_event_warns_and_is_not_renamed(
     warning = capsys.readouterr().out
     assert "UnsupportedEvent" in warning
     assert "may not be recognized" in warning
+    assert "Rename events" in warning
+    assert "then reinstall" in warning
     target = project / ".github" / "hooks" / "native-event-kit-events.json"
     hooks = json.loads(target.read_text(encoding="utf-8"))["hooks"]
     assert list(hooks) == ["UnsupportedEvent"]

--- a/tests/unit/integration/test_hook_integrator.py
+++ b/tests/unit/integration/test_hook_integrator.py
@@ -332,7 +332,7 @@ class TestVSCodeIntegration:
         # Verify rewritten paths
         target_json = temp_project / ".github" / "hooks" / "learning-output-style-hooks.json"
         data = json.loads(target_json.read_text())
-        cmd = data["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+        cmd = data["hooks"]["sessionStart"][0]["hooks"][0]["command"]
         assert "${CLAUDE_PLUGIN_ROOT}" not in cmd
         assert "learning-output-style" in cmd
         assert "session-start.sh" in cmd
@@ -367,7 +367,7 @@ class TestVSCodeIntegration:
 
         target_json = temp_project / ".github" / "hooks" / "ralph-loop-hooks.json"
         data = json.loads(target_json.read_text())
-        cmd = data["hooks"]["stop"][0]["hooks"][0]["command"]
+        cmd = data["hooks"]["agentStop"][0]["hooks"][0]["command"]
         assert "ralph-loop" in cmd
         assert "stop-hook.sh" in cmd
 


### PR DESCRIPTION
# fix(hooks): normalize Copilot lifecycle event aliases

## TL;DR

Copilot hook output now maps portable session lifecycle aliases to the documented `sessionStart` and `agentStop` keys, while Claude continues to receive `SessionStart` and `Stop`. Alias collisions retain every command in source order, diagnostics stop warning on supported names, and lifecycle tests cover reinstall, update, target contraction, uninstall, and user scope.

> [!NOTE]
> Closes #2337. Reported by @SaulMoro. Rebased onto latest main `a1c9786bf2787553c1cf4db737df76296db05d5c`, which contains merged #2362, #2387, and #2363; this remains a bounded native-compatibility repair and does not attempt #2111.

## Problem (WHY)

- [x] `SessionStart` was left unchanged in Copilot output and triggered a false casing warning, even though GitHub documents that event as ["A new or resumed session begins."](https://docs.github.com/en/copilot/reference/hooks-reference#hook-events)
- [x] `Stop` became unsupported lowercase `stop`, while GitHub documents `agentStop` for when ["The main agent finishes a turn."](https://docs.github.com/en/copilot/reference/hooks-reference#hook-events)
- [!] Multiple source aliases can collapse onto one native key, so a repair must preserve command order and must not discard entries during normalization.
- [!] Reinstall and cleanup must distinguish APM-owned generated state from user-authored hooks, including a user-owned lowercase `stop` key.

These failures regress [P5: "A primitive authored once must execute across every supported harness without modification."](https://github.com/microsoft/apm/blob/f0955d0aa7f6a5091884ca958e9ed1caaa861f32/PRINCIPLES.md#L72-L76) The repair follows P6 by keeping the transformation named, tested, and routed through the existing hook owner.

## Approach (WHAT)

| # | Fix | Contract |
|---:|---|---|
| 1 | Extend the sole `_HOOK_EVENT_MAP` with the documented Copilot and reverse Claude lifecycle aliases. | Existing native hook owner; no second mapping table. |
| 2 | Reuse the current deterministic merge and provenance paths. | Preserve sidecar/native behavior and avoid #2111 scope. |
| 3 | Add unit, installed-CLI lifecycle, mutation-break, and static-owner coverage. | P6: predictable, auditable behavior. |
| 4 | Update hook authoring docs and the packaged APM usage guide. | Authors see the exact accepted aliases and native outputs. |

## Implementation (HOW)

| Files | Intent |
|---|---|
| `src/apm_cli/integration/hook_integrator.py` | Maps `SessionStart`/`sessionStart` to Copilot `sessionStart`; maps `Stop`/`AgentStop`/`agentStop` to Copilot `agentStop`; adds the reverse Claude mappings; removes lowercase `stop` as a declared alias. |
| `tests/unit/integration/test_hook_event_normalization.py` | Covers every alias direction, deterministic collision merge order, supported and unknown diagnostics, stale owned output repair, and user-hook preservation. |
| `tests/unit/integration/test_hook_diagnostics.py` | Replaces stale expectations that treated Claude `sessionStart` as unsupported. |
| `tests/unit/integration/test_hook_integrator.py` | Updates established Copilot fixtures to assert `sessionStart` and `agentStop`. |
| `tests/integration/test_hook_integrator_copilot_casing_e2e.py` | Extends in-process install coverage to the repaired lifecycle keys. |
| `tests/integration/test_hook_event_native_lifecycle.py` | Uses the installed binary, `ApmLifecycleRunner`, `IsolatedApmEnvironment`, local package/repository factories, and lifecycle snapshots across project/global scope. Module-level `e2e` + `lifecycle_smoke` markers preserve #2390's marker-derived topology without a central manifest/count edit. |
| `scripts/lint-architecture-boundaries.sh` | Rejects a second `_HOOK_EVENT_MAP` definition outside `HookIntegrator`. |
| `tests/integration/test_architecture_authorities.py` | Proves the owner guard accepts the canonical map and rejects a parallel map. |
| `docs/src/content/docs/producer/author-primitives/hooks-and-commands.md` | Documents accepted lifecycle aliases, native outputs, and unknown-event behavior. |
| `packages/apm-guide/.apm/skills/apm-usage/package-authoring.md` | Mirrors the primitive-format guidance for agents consuming the bundled guide. |
| `CHANGELOG.md` | Credits reporter @SaulMoro and records the user-visible compatibility repair under Unreleased. |

## Diagrams

Legend: portable aliases converge at the existing canonical map, then fan out to each target's documented native keys.

```mermaid
flowchart LR
    subgraph Source[Portable source aliases]
        S1["SessionStart or sessionStart"]
        S2["Stop, AgentStop, or agentStop"]
    end
    subgraph Owner[Canonical native mapping]
        M["HookIntegrator _HOOK_EVENT_MAP"]
    end
    subgraph Output[Serialized native keys]
        C["Copilot sessionStart and agentStop"]
        A["Claude SessionStart and Stop"]
    end
    S1 --> M
    S2 --> M
    M --> C
    M --> A
    classDef new stroke-dasharray: 5 5;
    class M new;
```

## Trade-offs

- **Extend the current map, not the neutral IR.** Chose a bounded owner extension; rejected a semantic-model redesign because #2111 owns that larger decision.
- **Keep unknown-event behavior.** Chose explicit pass-through plus the existing casing diagnostic; rejected inventing native names or broad new validation in this bug fix.
- **Retain existing ownership mechanics.** Chose file-level Copilot ownership and Claude sidecar provenance; rejected changing native schemas or cleanup architecture, minimizing overlap with #2362/#2363.
- **Promote two real-binary scenarios.** Chose project and global lifecycle smoke coverage despite added runtime because unit-only assertions cannot prove persisted native state.

## Benefits

1. Five accepted source spellings serialize to exactly two documented Copilot keys and two Claude keys.
2. Alias collisions preserve all five fixture commands in deterministic source order.
3. Reinstall is byte/semantic-idempotent; update repairs stale APM-owned `stop` output.
4. Target contraction and uninstall remove APM-owned state while both Copilot and Claude user hooks survive.
5. A static CI guard rejects a second native hook-event map.

## Validation

`uv run --frozen apm audit --ci`:

```text
[+] No drift detected
[*] All 10 check(s) passed
```

`uv run --frozen --extra dev ruff check src/ tests/` and `ruff format --check`:

```text
All checks passed!
1573 files already formatted
```

<details><summary>Regression, lifecycle, quality, and mutation evidence</summary>

Certified installed lifecycle, owner, and topology evidence at `2c25ae6cc19e711c1ea2ca820eab215900984576` (not rerun for the final main-authority rebase, per maintainer):

```text
4 installed alias/cleanup lifecycle tests passed in 50.10s
26 alias + parent target/hook owner sanity tests passed in 4.08s
3 marker-derived taxonomy/topology tests passed in 89.82s
```

Child spec impact relative to latest main `a1c9786bf2787553c1cf4db737df76296db05d5c`:

```text
none -- no OpenAPM spec, schema, conformance, or fixture path is changed by the child delta
```

Certified mutation-break (not rerun during the parent rebase):

```text
Stop -> stop: installed lifecycle failed on unexpected serialized key 'stop'.
SessionStart mappings removed: installed lifecycle and diagnostics tests both failed on the false warning.
Mappings restored: selected lifecycle and diagnostics tests passed (2 passed).
```

Architecture/auth/duplication gates:

```text
Your code has been rated at 10.00/10
[+] auth-signal lint clean
[+] architecture boundary lint clean
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | Install one hook package for Copilot and Claude; every alias becomes the documented native key and every command remains. | Portability by manifest, Multi-harness support | [`test_project_hook_events_converge_update_and_contract` lines 141-232](https://github.com/microsoft/apm/blob/f0955d0aa7f6a5091884ca958e9ed1caaa861f32/tests/integration/test_hook_event_native_lifecycle.py#L141-L232) (regression-trap for #2337) | e2e |
| 2 | Supported lifecycle aliases do not emit false warnings; unknown events keep the existing explicit diagnostic. | DevX, OSS / community-driven | `tests/unit/integration/test_hook_event_normalization.py::test_supported_alias_diagnostics_do_not_warn`<br/>`tests/unit/integration/test_hook_event_normalization.py::test_unknown_event_warns_and_is_not_renamed` | unit |
| 3 | Reinstall, alias update, stale-output repair, contraction, and uninstall preserve user-authored hooks. | DevX, Portability by manifest | [`test_project_hook_events_converge_update_and_contract` assertions lines 200-258](https://github.com/microsoft/apm/blob/f0955d0aa7f6a5091884ca958e9ed1caaa861f32/tests/integration/test_hook_event_native_lifecycle.py#L200-L258) | e2e |
| 4 | Global Copilot and Claude installs serialize the same native event contract and remain idempotent. | Multi-harness support, DevX | `tests/integration/test_hook_event_native_lifecycle.py::test_global_hook_events_preserve_user_state` | e2e |
| 5 | Native event mappings continue to have one canonical owner. | OSS / community-driven | `tests/integration/test_architecture_authorities.py::test_native_hook_event_map_guard_rejects_parallel_owner` | integration |

## How to test

- [ ] Run `uv run --extra dev pytest -q tests/unit/integration/test_hook_event_normalization.py`; expect all alias, collision, diagnostic, and stale-repair cases to pass.
- [ ] Set `APM_BINARY_PATH="$PWD/.venv/bin/apm"` and run the new lifecycle module; expect both project and global scenarios to pass.
- [ ] Inspect the generated fixture state in a debug run; Copilot must contain only `sessionStart`/`agentStop`, while Claude contains `SessionStart`/`Stop` plus the user-owned `stop` fixture.
- [ ] Run `bash scripts/lint-architecture-boundaries.sh`; expect `[+] architecture boundary lint clean`.
- [ ] Run the full lint mirror; expect ruff, file-length, duplication, auth, and architecture gates to pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


