### PR TITLE
fix(auth): try public GitHub anonymously before resolving credentials

### DIFF
--- a/.apm/instructions/architecture.instructions.md
+++ b/.apm/instructions/architecture.instructions.md
@@ -54,6 +54,9 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | GitHub API throttle classification | deps/github_rate_limit.py | `src/apm_cli/deps/github_rate_limit.py` |
 <!-- /canonical-owner-table -->
 
+Host + credential resolution includes public github.com anonymous-first ordering.
+Consumers must ask `AuthResolver` rather than reclassifying that host locally.
+
 If you are about to compute one of these locally, stop and call the
 owner. If the owner is missing a case you need, EXTEND the owner --
 never fork it.

--- a/.github/instructions/architecture.instructions.md
+++ b/.github/instructions/architecture.instructions.md
@@ -54,6 +54,9 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | GitHub API throttle classification | deps/github_rate_limit.py | `src/apm_cli/deps/github_rate_limit.py` |
 <!-- /canonical-owner-table -->
 
+Host + credential resolution includes public github.com anonymous-first ordering.
+Consumers must ask `AuthResolver` rather than reclassifying that host locally.
+
 If you are about to compute one of these locally, stop and call the
 owner. If the owner is missing a case you need, EXTEND the owner --
 never fork it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Public `github.com` dependencies now try anonymous HTTPS before resolving
+  credentials, so all-public installs no longer open repeated credential or
+  Git Credential Manager prompts. Reported by @RuiRomano. (#2406, closes #2400)
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview
   now excludes the synthesized lockfile self-entry, matching the real install

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -2783,7 +2783,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:7c1a9541c841175cf6b75bcb6d789c8a9736d48575bfc58bc963910581914075
+  content_hash: sha256:20587bba4a65a62cb96bc91d9ef55ccd9e8b938c170d92f95d9099714f1ba831
 - kind: project-relative
   target: copilot
   value: .github/instructions/changelog.instructions.md
@@ -3290,7 +3290,7 @@ local_deployed_file_hashes:
   .github/agents/spec-tag-architect.agent.md: sha256:82907265c5e7cf1ac61ad96866fa7c5683b69c8f09b7a4c5f3cc241acc9568ca
   .github/agents/supply-chain-security-expert.agent.md: sha256:8fb8cc426d6af17ba084a28b3f026c2b475b62e3ca63ed2f88b83bd823f877af
   .github/agents/test-coverage-expert.agent.md: sha256:48c2172d1f18a394fa83ef9dc2be0b9b921a4e51e976498165250fed66369711
-  .github/instructions/architecture.instructions.md: sha256:7c1a9541c841175cf6b75bcb6d789c8a9736d48575bfc58bc963910581914075
+  .github/instructions/architecture.instructions.md: sha256:20587bba4a65a62cb96bc91d9ef55ccd9e8b938c170d92f95d9099714f1ba831
   .github/instructions/changelog.instructions.md: sha256:1e51ec4c74e847967962bd279dc4c6e582c5d3578490b3c28d5f3acd3e05f73e
   .github/instructions/cicd.instructions.md: sha256:08d87b7d635761cb41deb8fc71d5d83f54678de463db484afb16d2d4f8713ecb
   .github/instructions/cli.instructions.md: sha256:8e39e8d5047ce88575cb02f87c2bcede584dfef258bd86f7466c7badf136541a

--- a/docs/src/content/docs/getting-started/authentication.md
+++ b/docs/src/content/docs/getting-started/authentication.md
@@ -12,7 +12,7 @@ Public `github.com` packages need no token configuration. APM tries HTTPS reposi
 
 The first attempt has no authorization header, GitHub token environment variable, or active Git credential helper. A 401, 403, 404, or equivalent Git authentication failure unlocks the credential chain below; DNS, TLS, timeout, and GitHub throttle failures do not.
 
-APM resolves tokens per `(host, port, org)` pair. For private `github.com` fallback and other hosts, it walks a **host-class-specific** chain until it finds a token:
+APM resolves ordinary tokens per `(host, port, org)` scope. When a private `github.com` fallback asks the credential helper for a repository path, that path also scopes the cache entry. APM then walks a **host-class-specific** chain until it finds a token:
 
 1. **GitHub-class hosts** (`github.com`, `*.ghe.com`, GHES via `GITHUB_HOST`): **Per-org env var** `GITHUB_APM_PAT_{ORG}` (when an org slug applies), then **global** `GITHUB_APM_PAT` -> `GITHUB_TOKEN` -> `GH_TOKEN`, then **GitHub CLI active account** (`gh auth token --hostname <host>`, silently skipped if `gh` is not installed or not logged in for the host), then host-specific **git credential helper**.
 2. **GitLab-class hosts** (`gitlab.com`, or FQDNs listed via `GITLAB_HOST` / `APM_GITLAB_HOSTS`): **only** `GITLAB_APM_PAT` -> `GITLAB_TOKEN`, then host-specific **git credential helper**. GitHub token env vars are **not** used for GitLab (including `GITHUB_APM_PAT`, `GITHUB_TOKEN`, and `GH_TOKEN`, and `GITHUB_APM_PAT_{ORG}` for group/namespace paths).
@@ -21,7 +21,7 @@ APM resolves tokens per `(host, port, org)` pair. For private `github.com` fallb
 Azure DevOps uses its own chain (`ADO_APM_PAT` -> Azure CLI bearer). See [Azure DevOps](#azure-devops).
 If the resolved token fails for the target host, APM retries with git credential helpers on paths that support it. If nothing matches, APM attempts unauthenticated access where the host exposes public repos (not *ghe.com* Data Residency). Before an anonymous `github.com` attempt, APM also disables credential helpers and global/system Git config while preserving non-auth process-scoped Git settings such as CA paths, URL rewrites, and `credential.interactive=never`.
 
-Results are cached per-process for each `(host, port, org)` key, so validation and later fetch phases reuse one private-repository fallback instead of prompting repeatedly. All token-bearing requests use HTTPS.
+Results are cached per-process. Validation and later fetch phases for the same private repository reuse one path-scoped fallback instead of prompting repeatedly, while another repository can resolve its own credential. All token-bearing requests use HTTPS.
 
 ## Token lookup
 ### GitHub-class hosts (`github.com`, `*.ghe.com`, GHES via `GITHUB_HOST`)

--- a/docs/src/content/docs/getting-started/authentication.md
+++ b/docs/src/content/docs/getting-started/authentication.md
@@ -8,9 +8,11 @@ APM works without tokens for public packages on github.com. Authentication is ne
 
 ## How APM resolves authentication
 
-APM resolves tokens per `(host, port, org)` pair. Public `github.com` HTTPS repository operations are a deliberate exception to eager token lookup: APM first tries the repository anonymously. That first attempt has no authorization header, GitHub token environment variable, or active Git credential helper. A 401, 403, 404, or equivalent Git authentication failure then unlocks the credential chain below. DNS, TLS, timeout, and GitHub throttle failures do not trigger credential lookup.
+Public `github.com` packages need no token configuration. APM tries HTTPS repository operations anonymously before resolving credentials.
 
-For private `github.com` fallback and other hosts, APM walks a **host-class-specific** chain until it finds a token:
+The first attempt has no authorization header, GitHub token environment variable, or active Git credential helper. A 401, 403, 404, or equivalent Git authentication failure unlocks the credential chain below; DNS, TLS, timeout, and GitHub throttle failures do not.
+
+APM resolves tokens per `(host, port, org)` pair. For private `github.com` fallback and other hosts, it walks a **host-class-specific** chain until it finds a token:
 
 1. **GitHub-class hosts** (`github.com`, `*.ghe.com`, GHES via `GITHUB_HOST`): **Per-org env var** `GITHUB_APM_PAT_{ORG}` (when an org slug applies), then **global** `GITHUB_APM_PAT` -> `GITHUB_TOKEN` -> `GH_TOKEN`, then **GitHub CLI active account** (`gh auth token --hostname <host>`, silently skipped if `gh` is not installed or not logged in for the host), then host-specific **git credential helper**.
 2. **GitLab-class hosts** (`gitlab.com`, or FQDNs listed via `GITLAB_HOST` / `APM_GITLAB_HOSTS`): **only** `GITLAB_APM_PAT` -> `GITLAB_TOKEN`, then host-specific **git credential helper**. GitHub token env vars are **not** used for GitLab (including `GITHUB_APM_PAT`, `GITHUB_TOKEN`, and `GH_TOKEN`, and `GITHUB_APM_PAT_{ORG}` for group/namespace paths).

--- a/docs/src/content/docs/getting-started/authentication.md
+++ b/docs/src/content/docs/getting-started/authentication.md
@@ -8,16 +8,18 @@ APM works without tokens for public packages on github.com. Authentication is ne
 
 ## How APM resolves authentication
 
-APM resolves tokens per `(host, port, org)` pair. For each dependency, it walks a **host-class-specific** chain until it finds a token:
+APM resolves tokens per `(host, port, org)` pair. Public `github.com` HTTPS repository operations are a deliberate exception to eager token lookup: APM first tries the repository anonymously. That first attempt has no authorization header, GitHub token environment variable, or active Git credential helper. A 401, 403, 404, or equivalent Git authentication failure then unlocks the credential chain below. DNS, TLS, timeout, and GitHub throttle failures do not trigger credential lookup.
+
+For private `github.com` fallback and other hosts, APM walks a **host-class-specific** chain until it finds a token:
 
 1. **GitHub-class hosts** (`github.com`, `*.ghe.com`, GHES via `GITHUB_HOST`): **Per-org env var** `GITHUB_APM_PAT_{ORG}` (when an org slug applies), then **global** `GITHUB_APM_PAT` -> `GITHUB_TOKEN` -> `GH_TOKEN`, then **GitHub CLI active account** (`gh auth token --hostname <host>`, silently skipped if `gh` is not installed or not logged in for the host), then host-specific **git credential helper**.
 2. **GitLab-class hosts** (`gitlab.com`, or FQDNs listed via `GITLAB_HOST` / `APM_GITLAB_HOSTS`): **only** `GITLAB_APM_PAT` -> `GITLAB_TOKEN`, then host-specific **git credential helper**. GitHub token env vars are **not** used for GitLab (including `GITHUB_APM_PAT`, `GITHUB_TOKEN`, and `GH_TOKEN`, and `GITHUB_APM_PAT_{ORG}` for group/namespace paths).
 3. **Generic hosts** (other FQDNs such as Bitbucket): host-specific **git credential helper** or unauthenticated/public access -- **no** GitHub or GitLab platform env vars.
 
 Azure DevOps uses its own chain (`ADO_APM_PAT` -> Azure CLI bearer). See [Azure DevOps](#azure-devops).
-If the resolved token fails for the target host, APM retries with git credential helpers on paths that support it. If nothing matches, APM attempts unauthenticated access where the host exposes public repos (not *ghe.com* Data Residency). Before an unauthenticated attempt, APM removes inherited Git token and authorization-header environment settings.
+If the resolved token fails for the target host, APM retries with git credential helpers on paths that support it. If nothing matches, APM attempts unauthenticated access where the host exposes public repos (not *ghe.com* Data Residency). Before an anonymous `github.com` attempt, APM also disables credential helpers and global/system Git config while preserving non-auth process-scoped Git settings such as CA paths, URL rewrites, and `credential.interactive=never`.
 
-Results are cached per-process for each `(host, port, org)` key. All token-bearing requests use HTTPS.
+Results are cached per-process for each `(host, port, org)` key, so validation and later fetch phases reuse one private-repository fallback instead of prompting repeatedly. All token-bearing requests use HTTPS.
 
 ## Token lookup
 ### GitHub-class hosts (`github.com`, `*.ghe.com`, GHES via `GITHUB_HOST`)
@@ -416,7 +418,12 @@ The full resolution and fallback flow (simplified):
 flowchart TD
     A[Dependency Reference] --> HC{Host class?}
 
-    HC -->|GitHub / GHE Cloud / GHES| B{Per-org env var?}
+    HC -->|github.com HTTPS| ANON[Anonymous attempt<br/>tokens and helpers fenced]
+    ANON -->|Success| L[Success]
+    ANON -->|401 / 403 / 404<br/>or Git auth failure| B{Per-org env var?}
+    ANON -->|DNS / TLS / timeout<br/>or rate limit| Q[Surface non-auth failure]
+
+    HC -->|GHE Cloud / GHES| B
     B -->|GITHUB_APM_PAT_ORG| C[Use per-org token]
     B -->|Not set| D{Global env var?}
     D -->|GITHUB_APM_PAT / GITHUB_TOKEN / GH_TOKEN| E[Use global token]
@@ -438,11 +445,12 @@ flowchart TD
     G --> I
     H --> I
 
-    I -->|Token works| L[Success]
+    I -->|Token works| L
     I -->|Token fails| M{Fallback credentials}
     M -->|gh or git credential found| L
     M -->|No credential| N{Host has public repos?}
-    N -->|Yes| O[Try unauthenticated]
+    N -->|Other public host| O[Try unauthenticated]
+    N -->|github.com already tried| P
     N -->|No| P[Auth error with actionable message]
 ```
 

--- a/packages/apm-guide/.apm/skills/apm-usage/authentication.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/authentication.md
@@ -2,7 +2,11 @@
 
 ## Token precedence chain
 
-APM checks these sources in order, using the first valid token found:
+For public `github.com` HTTPS repositories, APM makes one anonymous attempt before checking any token source. The attempt removes GitHub token variables and authorization headers, and disables Git credential helpers plus global/system Git config. It preserves non-auth process-scoped Git config such as CA settings, URL rewrites, and `credential.interactive=never`.
+
+Only HTTP 401, 403, 404, or an equivalent Git authentication failure unlocks the fallback chain below. DNS, TLS, timeout, and GitHub throttle failures do not prompt for credentials. Private-repository fallback is cached per `(host, port, org)` for the process, so later validation and fetch phases reuse it.
+
+When fallback is required, APM checks these sources in order:
 
 | Priority | Variable | Scope | Notes |
 |----------|----------|-------|-------|
@@ -12,12 +16,13 @@ APM checks these sources in order, using the first valid token found:
 | 4 | `GH_TOKEN` | Global | Set by `gh auth login` |
 | 5 | `gh auth token --hostname <host>` | GitHub-like hosts | Active `gh auth login` account |
 | 6 | `git credential fill` | Per-host | System credential manager. APM forwards `path=<owner>/<repo>` so Git Credential Manager users with `credential.useHttpPath = true` get per-URL account selection (no account-picker prompt). |
-| -- | None | -- | Unauthenticated (public GitHub repos only) |
+| -- | None | -- | No credential was available after an auth-shaped anonymous failure |
 
 APM checks the active `gh` CLI account before invoking OS credential helpers. This reduces ambiguous multi-account prompts on hosts like github.com. If the `gh` CLI is not installed or no account is active, APM skips this step silently and continues to `git credential fill`.
 
-Unauthenticated public-repository retries use a fresh Git environment with
-inherited token and authorization-header settings removed.
+This anonymous-first rule is exact to `github.com` HTTPS. GHE Cloud, GHES, ADO,
+GitLab, SSH, local paths, and generic hosts keep their existing authentication
+and transport behavior.
 
 For multi-account Git Credential Manager setups, see the [Multi-account Git Credential Manager](https://microsoft.github.io/apm/getting-started/authentication/#multi-account-git-credential-manager) section in the main authentication guide.
 

--- a/packages/apm-guide/.apm/skills/apm-usage/authentication.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/authentication.md
@@ -4,7 +4,7 @@
 
 For public `github.com` HTTPS repositories, APM makes one anonymous attempt before checking any token source. The attempt removes GitHub token variables and authorization headers, and disables Git credential helpers plus global/system Git config. It preserves non-auth process-scoped Git config such as CA settings, URL rewrites, and `credential.interactive=never`.
 
-Only HTTP 401, 403, 404, or an equivalent Git authentication failure unlocks the fallback chain below. DNS, TLS, timeout, and GitHub throttle failures do not prompt for credentials. Private-repository fallback is cached per `(host, port, org)` for the process, so later validation and fetch phases reuse it.
+Only HTTP 401, 403, 404, or an equivalent Git authentication failure unlocks the fallback chain below. DNS, TLS, timeout, and GitHub throttle failures do not prompt for credentials. Private-repository fallback is cached per repository path for the process, so later phases reuse it without applying that credential to a different repository.
 
 When fallback is required, APM checks these sources in order:
 

--- a/packages/apm-guide/.apm/skills/apm-usage/authentication.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/authentication.md
@@ -20,7 +20,7 @@ When fallback is required, APM checks these sources in order:
 
 APM checks the active `gh` CLI account before invoking OS credential helpers. This reduces ambiguous multi-account prompts on hosts like github.com. If the `gh` CLI is not installed or no account is active, APM skips this step silently and continues to `git credential fill`.
 
-This anonymous-first rule is exact to `github.com` HTTPS. GHE Cloud, GHES, ADO,
+This anonymous-first rule applies only to `github.com` HTTPS. GHE Cloud, GHES, ADO,
 GitLab, SSH, local paths, and generic hosts keep their existing authentication
 and transport behavior.
 

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -719,6 +719,42 @@ if [ -n "$auth_header_dictmerge_hits" ]; then
     violations=$((violations + 1))
 fi
 
+echo "[*] AC20: public github.com anonymous-first auth authority"
+public_github_auth_owner="src/apm_cli/core/auth.py"
+public_github_auth_duplicate_defs=$(
+    grep -rEn --include='*.py' \
+        '^[[:space:]]*def uses_public_github_anonymous_first\(' \
+        src/apm_cli \
+        | grep -v "^${public_github_auth_owner}:" \
+        | grep -v 'architecture-authority-exempt:' \
+        || true
+)
+public_github_auth_consumers="
+src/apm_cli/deps/clone_engine.py
+src/apm_cli/deps/download_strategies.py
+src/apm_cli/deps/git_reference_resolver.py
+src/apm_cli/deps/github_downloader.py
+src/apm_cli/deps/github_downloader_validation.py
+"
+public_github_auth_missing_consumers=""
+for consumer in $public_github_auth_consumers; do
+    if ! grep -q 'uses_public_github_anonymous_first(' "$consumer"; then
+        public_github_auth_missing_consumers="${public_github_auth_missing_consumers}
+${consumer}"
+    fi
+done
+if ! grep -q '^    def uses_public_github_anonymous_first(' "$public_github_auth_owner" \
+    || ! grep -q '^    def build_public_github_anonymous_git_env(' "$public_github_auth_owner" \
+    || ! grep -q 'lazy_public_github' "$public_github_auth_owner" \
+    || [ -n "$public_github_auth_duplicate_defs" ] \
+    || [ -n "$public_github_auth_missing_consumers" ]; then
+    echo "[x] Public github.com anonymous-first auth ordering must stay owned by AuthResolver"
+    [ -n "$public_github_auth_duplicate_defs" ] && echo "$public_github_auth_duplicate_defs"
+    [ -n "$public_github_auth_missing_consumers" ] \
+        && echo "Missing owner routing:${public_github_auth_missing_consumers}"
+    violations=$((violations + 1))
+fi
+
 if [ "$violations" -gt 0 ]; then
     echo "[x] $violations architecture boundary rule(s) failed"
     exit 1

--- a/src/apm_cli/core/auth.py
+++ b/src/apm_cli/core/auth.py
@@ -485,6 +485,7 @@ class AuthResolver:
             signal in text
             for signal in (
                 "rate limit",
+                "throttle",
                 "too many requests",
                 "could not resolve host",
                 "connection refused",
@@ -548,6 +549,9 @@ class AuthResolver:
             ``git credential fill`` request so helpers configured with
             ``credential.useHttpPath = true`` can disambiguate per-URL
             (notably Git Credential Manager for multi-account users).
+            Primary auth-first resolution stays host-scoped; the path is
+            applied when public github.com anonymous-first fallback proves
+            credentials may be required.
         unauth_first:
             If *True*, try unauthenticated first (saves rate limits, EMU-safe).
         verbose_callback:

--- a/src/apm_cli/core/auth.py
+++ b/src/apm_cli/core/auth.py
@@ -245,6 +245,24 @@ class AuthResolver:
         with self._lock:
             self._cache.clear()
 
+    def has_cached_resolution(
+        self,
+        host: str,
+        org: str | None = None,
+        *,
+        port: int | None = None,
+        host_type: str | None = None,
+    ) -> bool:
+        """Return whether credential resolution already ran for this scope."""
+        key = AuthCacheKey(
+            host.lower() if host else host,
+            port,
+            self._cache_host_type(host, host_type),
+            org.lower() if org else "",
+        )
+        with self._lock:
+            return key in self._cache
+
     # -- host classification ------------------------------------------------
 
     @staticmethod
@@ -343,6 +361,7 @@ class AuthResolver:
         *,
         port: int | None = None,
         host_type: str | None = None,
+        path: str | None = None,
     ) -> AuthContext:
         """Resolve auth for *(host, port, org)*.  Cached & thread-safe.
 
@@ -370,7 +389,14 @@ class AuthResolver:
             # Bounded by APM_GIT_CREDENTIAL_TIMEOUT (default 60s). No deadlock
             # risk: single lock, never nested.
             host_info = self.classify_host(host, port=port, host_type=host_type)
-            token, source, scheme = self._resolve_token(host_info, org)
+            if path is None:
+                token, source, scheme = self._resolve_token(host_info, org)
+            else:
+                token, source, scheme = self._resolve_token(
+                    host_info,
+                    org,
+                    path=path,
+                )
             token_type = self.detect_token_type(token) if token else "unknown"
             git_env = self._build_git_env(token, scheme=scheme, host_kind=host_info.kind)
 
@@ -402,6 +428,96 @@ class AuthResolver:
             org,
             port=dep_ref.port,
             host_type=dep_ref.host_type,
+        )
+
+    def uses_public_github_anonymous_first(
+        self,
+        host: str,
+        *,
+        port: int | None = None,
+        host_type: str | None = None,
+    ) -> bool:
+        """Return whether HTTPS repository access must start anonymously.
+
+        This exact-host decision is owned here so validation, ref resolution,
+        cache fetches, and clone execution cannot drift into separate host
+        checks. GitHub Enterprise, ADO, GitLab, and generic hosts retain their
+        existing authentication order.
+        """
+        return (
+            self.classify_host(
+                host,
+                port=port,
+                host_type=host_type,
+            ).kind
+            == "github"
+        )
+
+    @staticmethod
+    def is_public_github_auth_failure(exc: BaseException) -> bool:
+        """Return whether an anonymous github.com failure may require auth.
+
+        HTTP 401, 403, and 404 are deliberately eligible because GitHub hides
+        private repositories behind 404. Git and libcurl equivalents are
+        matched narrowly. Connectivity, TLS, timeout, and throttle failures
+        are not auth signals and must surface without credential resolution.
+        """
+        from ..deps.github_rate_limit import GitHubThrottleError
+
+        if isinstance(exc, GitHubThrottleError):
+            return False
+        response = getattr(exc, "response", None)
+        status_code = getattr(exc, "status_code", None)
+        if status_code is None and response is not None:
+            status_code = getattr(response, "status_code", None)
+        if isinstance(status_code, int):
+            return status_code in {401, 403, 404}
+
+        parts = [str(exc)]
+        for name in ("stderr", "stdout"):
+            value = getattr(exc, name, None)
+            if isinstance(value, bytes):
+                value = value.decode("utf-8", errors="replace")
+            if value:
+                parts.append(str(value))
+        text = " ".join(parts).lower()
+        if any(
+            signal in text
+            for signal in (
+                "rate limit",
+                "too many requests",
+                "could not resolve host",
+                "connection refused",
+                "connection timed out",
+                "network is unreachable",
+                "certificate verify failed",
+                "certificate_verify_failed",
+                "ssl certificate problem",
+                "tls verification failed",
+            )
+        ):
+            return False
+        if any(
+            signal in text
+            for signal in (
+                "authentication failed",
+                "authorization failed",
+                "unauthorized",
+                "could not read username",
+                "invalid username or password",
+                "repository not found",
+                "terminal prompts disabled",
+                "unable to get password from user",
+            )
+        ):
+            return True
+        return (
+            re.search(
+                r"(?:http(?: error)?|returned error:|status(?: code)?[=: ]+)"
+                r"\s*(?:401|403|404)\b",
+                text,
+            )
+            is not None
         )
 
     # -- fallback strategy --------------------------------------------------
@@ -442,16 +558,37 @@ class AuthResolver:
         retries with ``gh auth token`` and then ``git credential fill``
         before giving up.
         """
-        auth_ctx = self.resolve(host, org, port=port)
-        host_info = auth_ctx.host_info
-        git_env = auth_ctx.git_env
-        unauth_env = self._build_git_env(None, host_kind=host_info.kind)
+        host_info = self.classify_host(host, port=port)
+        lazy_public_github = unauth_first and self.uses_public_github_anonymous_first(
+            host,
+            port=port,
+        )
+        auth_ctx: AuthContext | None = None
+        if not lazy_public_github:
+            auth_ctx = self.resolve(host, org, port=port)
+            host_info = auth_ctx.host_info
+        unauth_env = (
+            self.build_public_github_anonymous_git_env()
+            if lazy_public_github
+            else self._build_git_env(None, host_kind=host_info.kind)
+        )
+
+        def _auth_context() -> AuthContext:
+            nonlocal auth_ctx
+            if auth_ctx is None:
+                auth_ctx = self.resolve(
+                    host,
+                    org,
+                    port=port,
+                    path=path if lazy_public_github else None,
+                )
+            return auth_ctx
 
         def _log(msg: str) -> None:
             if verbose_callback:
                 verbose_callback(msg)
 
-        def _try_credential_fallback(exc: Exception) -> T:
+        def _try_credential_fallback(exc: Exception, ctx: AuthContext) -> T:
             """Retry the operation when the originally-resolved token fails.
 
             Walks the secondary chain in order: gh CLI (GitHub-like hosts;
@@ -462,13 +599,13 @@ class AuthResolver:
             ``git-credential-fill``, ``none``) skip retry to avoid
             double-invocation.
             """
-            if auth_ctx.source in ("gh-auth-token", "git-credential-fill", "none"):
+            if ctx.source in ("gh-auth-token", "git-credential-fill", "none"):
                 raise exc
             # ADO uses ADO_APM_PAT + AAD bearer fallback; credential fill is out of scope.
             if host_info.kind == "ado":
                 raise exc
             _log(
-                f"Token from {auth_ctx.source} failed for {host_info.display_name}; "
+                f"Token from {ctx.source} failed for {host_info.display_name}; "
                 "trying secondary credential sources"
             )
             _log(f"trying gh auth token for {host_info.display_name}")
@@ -493,8 +630,10 @@ class AuthResolver:
             raise exc
 
         # ADO bearer fallback machinery (PAT was tried first; bearer is the safety net)
-        ado_bearer_fallback_available = (
-            auth_ctx.host_info.kind == "ado" and auth_ctx.source == "ADO_APM_PAT"
+        ado_bearer_fallback_available = bool(
+            auth_ctx is not None
+            and auth_ctx.host_info.kind == "ado"
+            and auth_ctx.source == "ADO_APM_PAT"
         )
 
         def _try_ado_bearer_fallback(exc: Exception) -> T:
@@ -541,9 +680,10 @@ class AuthResolver:
 
         # Hosts that never have public repos -> auth-only
         if host_info.kind == "ghe_cloud":
+            ctx = _auth_context()
             _log(f"Auth-only attempt for {host_info.kind} host {host_info.display_name}")
             try:
-                return operation(auth_ctx.token, git_env)
+                return operation(ctx.token, ctx.git_env)
             except Exception as exc:
                 # operation is caller-provided; broad catch required -- cannot narrow
                 # without restricting the caller API.  Use %r so the type is visible.
@@ -552,13 +692,14 @@ class AuthResolver:
                     host_info.display_name,
                     exc,
                 )
-                return _try_credential_fallback(exc)
+                return _try_credential_fallback(exc, ctx)
 
         # ADO: auth-first with bearer fallback when PAT fails
         if host_info.kind == "ado":
+            ctx = _auth_context()
             _log(f"Auth-only attempt for {host_info.kind} host {host_info.display_name}")
             try:
-                return operation(auth_ctx.token, git_env)
+                return operation(ctx.token, ctx.git_env)
             except Exception as exc:
                 # operation is caller-provided; broad catch required -- cannot narrow
                 # without restricting the caller API.  Use %r so the type is visible.
@@ -582,10 +723,17 @@ class AuthResolver:
                     host_info.display_name,
                     exc,
                 )
-                if auth_ctx.token:
-                    _log(f"Unauthenticated failed, retrying with token (source: {auth_ctx.source})")
+                if (
+                    lazy_public_github
+                    and path is not None
+                    and not self.is_public_github_auth_failure(exc)
+                ):
+                    raise
+                ctx = _auth_context()
+                if ctx.token:
+                    _log(f"Unauthenticated failed, retrying with token (source: {ctx.source})")
                     try:
-                        return operation(auth_ctx.token, git_env)
+                        return operation(ctx.token, ctx.git_env)
                     except Exception as retry_exc:
                         # operation is caller-provided; broad catch required.
                         logger.debug(
@@ -593,16 +741,17 @@ class AuthResolver:
                             host_info.display_name,
                             retry_exc,
                         )
-                        return _try_credential_fallback(retry_exc)
+                        return _try_credential_fallback(retry_exc, ctx)
                 raise
         # Download path: auth-first for higher rate limits
-        elif auth_ctx.token:
+        ctx = _auth_context()
+        if ctx.token:
             try:
                 _log(
                     f"Trying authenticated access to {host_info.display_name} "
-                    f"(source: {auth_ctx.source})"
+                    f"(source: {ctx.source})"
                 )
-                return operation(auth_ctx.token, git_env)
+                return operation(ctx.token, ctx.git_env)
             except Exception as exc:
                 # operation is caller-provided; broad catch required -- cannot narrow
                 # without restricting the caller API.  Use %r so the type is visible.
@@ -622,11 +771,10 @@ class AuthResolver:
                             host_info.display_name,
                             unauth_exc,
                         )
-                        return _try_credential_fallback(exc)
-                return _try_credential_fallback(exc)
-        else:
-            _log(f"No token available, trying unauthenticated access to {host_info.display_name}")
-            return operation(None, unauth_env)
+                        return _try_credential_fallback(exc, ctx)
+                return _try_credential_fallback(exc, ctx)
+        _log(f"No token available, trying unauthenticated access to {host_info.display_name}")
+        return operation(None, unauth_env)
 
     # -- error context ------------------------------------------------------
 
@@ -829,7 +977,13 @@ class AuthResolver:
 
     # -- internals ----------------------------------------------------------
 
-    def _resolve_token(self, host_info: HostInfo, org: str | None) -> tuple[str | None, str, str]:
+    def _resolve_token(
+        self,
+        host_info: HostInfo,
+        org: str | None,
+        *,
+        path: str | None = None,
+    ) -> tuple[str | None, str, str]:
         """Walk the token resolution chain.  Returns (token, source, scheme).
 
         Resolution order (GitHub-class: ``github``, ``ghe_cloud``, ``ghes``):
@@ -899,18 +1053,21 @@ class AuthResolver:
 
         # 4. Git credential helper (not for ADO)
         if host_info.kind not in ("ado",):
-            # Note: path= is intentionally omitted here. _resolve_token is the
-            # primary credential-resolution leg invoked once per host; it has
-            # no per-call repository context. The fallback leg in
-            # _try_credential_fallback re-invokes resolve_credential_from_git
-            # WITH path= when the primary credential is rejected, so GCM
-            # multi-account users still get per-URL disambiguation -- they
-            # just pay one extra round-trip on the first miss. Adding path=
-            # here would require threading repo context through every
-            # resolve() call site, which is disproportionate to the benefit.
-            credential = self._token_manager.resolve_credential_from_git(
-                host_info.host, port=host_info.port
-            )
+            # Most primary resolution calls remain host-scoped. The public
+            # github.com anonymous-first fallback supplies path= after a
+            # private-repo-shaped failure so GCM can choose the correct
+            # account without an unscoped prompt.
+            if path is None:
+                credential = self._token_manager.resolve_credential_from_git(
+                    host_info.host,
+                    port=host_info.port,
+                )
+            else:
+                credential = self._token_manager.resolve_credential_from_git(
+                    host_info.host,
+                    port=host_info.port,
+                    path=path,
+                )
             if credential:
                 return credential, "git-credential-fill", "basic"
 
@@ -959,6 +1116,33 @@ class AuthResolver:
             env["GIT_TOKEN"] = token
         return env
 
+    @classmethod
+    def build_public_github_anonymous_git_env(cls) -> dict[str, str]:
+        """Build a credential-free Git env for public github.com attempts."""
+        env = cls._build_git_env(None, host_kind="github")
+        for name in tuple(env):
+            if name in {"GH_TOKEN", "GITHUB_APM_PAT", "GITHUB_TOKEN"} or name.startswith(
+                "GITHUB_APM_PAT_"
+            ):
+                env.pop(name, None)
+        from ..deps.git_auth_env import GitAuthEnvBuilder
+
+        env["GIT_CONFIG_NOSYSTEM"] = "1"
+        env["GIT_CONFIG_GLOBAL"] = GitAuthEnvBuilder.isolated_global_config_path()
+        cls._append_git_config(env, "credential.helper", "")
+        return env
+
+    @staticmethod
+    def _append_git_config(env: dict[str, str], key: str, value: str) -> None:
+        """Append one process-scoped Git config entry without clobbering peers."""
+        try:
+            count = max(0, int(env.get("GIT_CONFIG_COUNT", "0") or "0"))
+        except ValueError:
+            count = 0
+        env["GIT_CONFIG_COUNT"] = str(count + 1)
+        env[f"GIT_CONFIG_KEY_{count}"] = key
+        env[f"GIT_CONFIG_VALUE_{count}"] = value
+
     @staticmethod
     def _clear_git_auth_env(env: dict) -> None:
         """Remove inherited Git authorization channels before an attempt."""
@@ -974,7 +1158,7 @@ class AuthResolver:
             key = env.pop(f"GIT_CONFIG_KEY_{index}", "")
             value = env.pop(f"GIT_CONFIG_VALUE_{index}", "")
             normalized = key.lower()
-            if "extraheader" in normalized or "authorization" in value.lower():
+            if "extraheader" in normalized or value.strip().lower().startswith("authorization:"):
                 continue
             if key:
                 retained.append((key, value))

--- a/src/apm_cli/core/auth.py
+++ b/src/apm_cli/core/auth.py
@@ -199,13 +199,15 @@ class AuthCacheKey(NamedTuple):
     port: int | None
     host_type: str  # Empty string represents an absent or canonical host_type.
     org: str
+    path: str  # Empty unless credential resolution is repository-scoped.
 
 
 class AuthResolver:
     """Single source of truth for auth resolution.
 
     Every APM operation that touches a remote host MUST use this class.
-    Resolution is per-(host, org) pair, thread-safe, cached per-process.
+    Resolution is per-(host, port, host_type, org, optional path), thread-safe,
+    and cached per-process.
     """
 
     def __init__(
@@ -252,6 +254,7 @@ class AuthResolver:
         *,
         port: int | None = None,
         host_type: str | None = None,
+        path: str | None = None,
     ) -> bool:
         """Return whether credential resolution already ran for this scope."""
         key = AuthCacheKey(
@@ -259,6 +262,7 @@ class AuthResolver:
             port,
             self._cache_host_type(host, host_type),
             org.lower() if org else "",
+            path or "",
         )
         with self._lock:
             return key in self._cache
@@ -363,7 +367,7 @@ class AuthResolver:
         host_type: str | None = None,
         path: str | None = None,
     ) -> AuthContext:
-        """Resolve auth for *(host, port, org)*.  Cached & thread-safe.
+        """Resolve auth for a host/org and optional repository path.
 
         ``port`` discriminates the cache key so that the same hostname on
         different ports (e.g. Bitbucket Datacenter with SSH on 7999 and a
@@ -376,6 +380,7 @@ class AuthResolver:
             port,
             self._cache_host_type(host, host_type),
             org.lower() if org else "",
+            path or "",
         )
         with self._lock:
             cached = self._cache.get(key)
@@ -384,7 +389,7 @@ class AuthResolver:
 
             # Hold lock during entire credential resolution to prevent duplicate
             # credential-helper popups when parallel downloads resolve the same
-            # (host, port, org) concurrently.  The first caller fills the cache;
+            # (host, port, org, path) concurrently. The first caller fills the cache;
             # all subsequent callers for the same key become O(1) cache hits.
             # Bounded by APM_GIT_CREDENTIAL_TIMEOUT (default 60s). No deadlock
             # risk: single lock, never nested.
@@ -531,6 +536,7 @@ class AuthResolver:
         org: str | None = None,
         port: int | None = None,
         path: str | None = None,
+        host_type: str | None = None,
         unauth_first: bool = False,
         verbose_callback: Callable[[str], None] | None = None,
     ) -> T:
@@ -552,6 +558,9 @@ class AuthResolver:
             Primary auth-first resolution stays host-scoped; the path is
             applied when public github.com anonymous-first fallback proves
             credentials may be required.
+        host_type:
+            Optional manifest provider hint. Forwarded through classification
+            and credential resolution so the inner owner matches its caller.
         unauth_first:
             If *True*, try unauthenticated first (saves rate limits, EMU-safe).
         verbose_callback:
@@ -562,14 +571,24 @@ class AuthResolver:
         retries with ``gh auth token`` and then ``git credential fill``
         before giving up.
         """
-        host_info = self.classify_host(host, port=port)
+        host_info = self.classify_host(
+            host,
+            port=port,
+            host_type=host_type,
+        )
         lazy_public_github = unauth_first and self.uses_public_github_anonymous_first(
             host,
             port=port,
+            host_type=host_type,
         )
         auth_ctx: AuthContext | None = None
         if not lazy_public_github:
-            auth_ctx = self.resolve(host, org, port=port)
+            auth_ctx = self.resolve(
+                host,
+                org,
+                port=port,
+                host_type=host_type,
+            )
             host_info = auth_ctx.host_info
         unauth_env = (
             self.build_public_github_anonymous_git_env()
@@ -584,6 +603,7 @@ class AuthResolver:
                     host,
                     org,
                     port=port,
+                    host_type=host_type,
                     path=path if lazy_public_github else None,
                 )
             return auth_ctx
@@ -802,7 +822,8 @@ class AuthResolver:
         context. Callers MUST only set this when the bearer attempt
         actually ran (see :class:`BearerFallbackOutcome.bearer_attempted`).
         """
-        auth_ctx = self.resolve(host, org, port=port)
+        path = dep_url if self.uses_public_github_anonymous_first(host, port=port) is True else None
+        auth_ctx = self.resolve(host, org, port=port, path=path)
         host_info = auth_ctx.host_info
         display = host_info.display_name
 

--- a/src/apm_cli/deps/bare_cache.py
+++ b/src/apm_cli/deps/bare_cache.py
@@ -788,6 +788,7 @@ def build_clone_failure_message(
     last_error: Exception | None,
     last_attempt_scheme: str | None,
     sanitize_git_error: Callable[[str], str],
+    public_github_non_auth_failure: bool = False,
 ) -> str:
     """Build the aggregate ``RuntimeError`` message for a failed transport plan.
 
@@ -838,6 +839,13 @@ def build_clone_failure_message(
             f"(without a hostname) resolve against that host. "
             f"If this package lives on a different server (e.g., github.com), "
             f"use the full hostname in apm.yml: {suggested}"
+        )
+    elif public_github_non_auth_failure:
+        error_msg += (
+            f"Could not connect to {dep_host or default_host_fn()} "
+            "(network error, not an auth failure). "
+            "Check your internet connection and proxy settings. "
+            "Run with --verbose for details."
         )
     elif not has_token:
         host = dep_host or default_host_fn()

--- a/src/apm_cli/deps/clone_engine.py
+++ b/src/apm_cli/deps/clone_engine.py
@@ -413,6 +413,11 @@ class CloneEngine:
             last_error=last_error,
             last_attempt_scheme=prev_scheme,
             sanitize_git_error=host._sanitize_git_error,
+            public_github_non_auth_failure=bool(
+                public_github_https_first
+                and last_error is not None
+                and not host.auth_resolver.is_public_github_auth_failure(last_error)
+            ),
         )
 
         raise RuntimeError(error_msg)

--- a/src/apm_cli/deps/clone_engine.py
+++ b/src/apm_cli/deps/clone_engine.py
@@ -285,6 +285,7 @@ class CloneEngine:
                 org=org,
                 port=dep_ref.port,
                 path=dep_ref.repo_url,
+                host_type=dep_ref.host_type,
                 unauth_first=True,
                 verbose_callback=verbose_callback,
             )

--- a/src/apm_cli/deps/clone_engine.py
+++ b/src/apm_cli/deps/clone_engine.py
@@ -154,11 +154,35 @@ class CloneEngine:
         is_github = is_github_hostname(dep_host) if dep_host else True
         is_generic = not is_ado and not is_github
 
-        dep_token = host._resolve_dep_token(dep_ref)
-        has_token = dep_token is not None
+        anonymous_plan = self._transport_selector.select(
+            dep_ref=dep_ref,
+            cli_pref=self._protocol_pref,
+            allow_fallback=self._allow_fallback,
+            has_token=False,
+        )
+        public_github_https_first = bool(
+            dep_ref is not None
+            and not dep_ref.is_insecure
+            and anonymous_plan.attempts
+            and anonymous_plan.attempts[0].scheme == "https"
+            and host.auth_resolver.uses_public_github_anonymous_first(
+                dep_host or default_host(),
+                port=dep_ref.port,
+                host_type=dep_ref.host_type,
+            )
+            is True
+        )
 
-        dep_auth_ctx = host._resolve_dep_auth_ctx(dep_ref)
-        dep_auth_scheme = dep_auth_ctx.auth_scheme if dep_auth_ctx else "basic"
+        if public_github_https_first:
+            dep_token = None
+            has_token = False
+            dep_auth_ctx = None
+            dep_auth_scheme = "basic"
+        else:
+            dep_token = host._resolve_dep_token(dep_ref)
+            has_token = dep_token is not None
+            dep_auth_ctx = host._resolve_dep_auth_ctx(dep_ref)
+            dep_auth_scheme = dep_auth_ctx.auth_scheme if dep_auth_ctx else "basic"
 
         _debug(
             f"_clone_with_fallback: repo={repo_url_base}, is_ado={is_ado}, "
@@ -180,11 +204,15 @@ class CloneEngine:
                 )
             return host._build_noninteractive_git_env()
 
-        plan: TransportPlan = self._transport_selector.select(
-            dep_ref=dep_ref,
-            cli_pref=self._protocol_pref,
-            allow_fallback=self._allow_fallback,
-            has_token=has_token,
+        plan: TransportPlan = (
+            anonymous_plan
+            if public_github_https_first
+            else self._transport_selector.select(
+                dep_ref=dep_ref,
+                cli_pref=self._protocol_pref,
+                allow_fallback=self._allow_fallback,
+                has_token=has_token,
+            )
         )
         _debug(
             "transport plan: "
@@ -229,24 +257,66 @@ class CloneEngine:
                     symbol="warning",
                 )
 
+        def _run_public_github_attempt() -> tuple[str, bool]:
+            if dep_ref is None:
+                raise RuntimeError("Public GitHub attempt requires a dependency reference")
+            winning_url = ""
+            winning_token = False
+
+            def _clone_public_github(
+                token: str | None,
+                git_env: dict[str, str],
+            ) -> None:
+                nonlocal winning_token, winning_url
+                winning_token = token is not None
+                winning_url = host._build_repo_url(
+                    repo_url_base,
+                    use_ssh=False,
+                    dep_ref=dep_ref,
+                    token=token or "",
+                    auth_scheme="basic",
+                )
+                clone_action(winning_url, git_env, target_path)
+
+            org = repo_url_base.split("/", 1)[0] if "/" in repo_url_base else None
+            host.auth_resolver.try_with_fallback(
+                dep_host or default_host(),
+                _clone_public_github,
+                org=org,
+                port=dep_ref.port,
+                path=dep_ref.repo_url,
+                unauth_first=True,
+                verbose_callback=verbose_callback,
+            )
+            return winning_url, winning_token
+
         prev_label: str | None = None
         prev_scheme: str | None = None
+        authenticated_fallback_used = False
         for attempt in plan.attempts:
             if attempt.use_token and not has_token:
                 continue
 
             use_ssh = attempt.scheme == "ssh"
-            try:
-                url = host._build_repo_url(
-                    repo_url_base,
-                    use_ssh=use_ssh,
-                    dep_ref=dep_ref,
-                    token=dep_token if attempt.use_token else "",
-                    auth_scheme=dep_auth_scheme if attempt.use_token else "basic",
-                )
-            except Exception as e:
-                last_error = e
-                continue
+            lazy_public_attempt = (
+                public_github_https_first
+                and attempt.scheme == "https"
+                and not attempt.use_token
+                and dep_ref is not None
+            )
+            url = ""
+            if not lazy_public_attempt:
+                try:
+                    url = host._build_repo_url(
+                        repo_url_base,
+                        use_ssh=use_ssh,
+                        dep_ref=dep_ref,
+                        token=dep_token if attempt.use_token else "",
+                        auth_scheme=dep_auth_scheme if attempt.use_token else "basic",
+                    )
+                except Exception as e:
+                    last_error = e
+                    continue
 
             if not plan.strict and prev_label and prev_scheme and prev_scheme != attempt.scheme:
                 _rich_warning(
@@ -257,9 +327,16 @@ class CloneEngine:
 
             try:
                 _debug(f"Attempting clone with {attempt.label} (URL sanitized)")
-                clone_action(url, _env_for(attempt), target_path)
+                if lazy_public_attempt:
+                    url, authenticated_fallback_used = _run_public_github_attempt()
+                else:
+                    clone_action(url, _env_for(attempt), target_path)
                 if verbose_callback:
-                    display = host._sanitize_git_error(url) if attempt.use_token else url
+                    display = (
+                        host._sanitize_git_error(url)
+                        if attempt.use_token or authenticated_fallback_used
+                        else url
+                    )
                     verbose_callback(f"Cloned from: {display}")
                 return
             except (GitCommandError, subprocess.CalledProcessError) as e:
@@ -329,7 +406,7 @@ class CloneEngine:
             is_ado=bool(is_ado),
             is_generic=is_generic,
             has_ado_token=host.has_ado_token,
-            has_token=has_token,
+            has_token=has_token or authenticated_fallback_used,
             auth_resolver=host.auth_resolver,
             configured_github_host=os.environ.get("GITHUB_HOST", ""),
             default_host_fn=default_host,

--- a/src/apm_cli/deps/download_strategies.py
+++ b/src/apm_cli/deps/download_strategies.py
@@ -746,6 +746,62 @@ class DownloadDelegate:
     ) -> GitFileFetchResult:
         """Fetch a throttled GitHub virtual file through one sparse Git transport."""
         key = self._git_file_transport_key(dep_ref, ref)
+        host = dep_ref.host or default_host()
+        if (
+            self._host.auth_resolver.uses_public_github_anonymous_first(
+                host,
+                port=dep_ref.port,
+                host_type=dep_ref.host_type,
+            )
+            is True
+        ):
+
+            def _fetch(
+                token: str | None,
+                git_env: dict[str, str],
+            ) -> GitFileFetchResult:
+                attempt_env = dict(git_env)
+                if token:
+                    set_authorization_header_git_env(
+                        attempt_env,
+                        "Bearer",
+                        token,
+                    )
+                    attempt_env.pop("GIT_TOKEN", None)
+
+                def _tokenless_repo_url(
+                    repo_ref: str,
+                    *,
+                    dep_ref: DependencyReference,
+                ) -> str:
+                    return self.build_repo_url(
+                        repo_ref,
+                        dep_ref=dep_ref,
+                        token="",
+                        auth_scheme="basic",
+                    )
+
+                transport_factory = self._git_file_transport_factory or GitSparseFileTransport
+                transport = transport_factory(
+                    dep_ref,
+                    ref,
+                    build_repo_url_fn=_tokenless_repo_url,
+                    git_env=attempt_env,
+                )
+                try:
+                    return transport.fetch_file_with_commit(file_path)
+                finally:
+                    transport.close()
+
+            return self._host.auth_resolver.try_with_fallback(
+                host,
+                _fetch,
+                org=dep_ref.repo_url.split("/", 1)[0],
+                port=dep_ref.port,
+                path=dep_ref.repo_url,
+                unauth_first=True,
+            )
+
         auth_ctx = self._host.auth_resolver.resolve_for_dep(dep_ref)
         if auth_ctx.token:
             # AuthResolver owns credential resolution. Convert its resolved
@@ -933,6 +989,127 @@ class DownloadDelegate:
     # GitHub file download
     # ------------------------------------------------------------------
 
+    def _download_public_github_file_anonymous_first(
+        self,
+        dep_ref: DependencyReference,
+        file_path: str,
+        ref: str,
+        verbose_callback=None,
+    ) -> bytes:
+        """Fetch one github.com file anonymously, resolving auth only on 4xx."""
+        host = dep_ref.host or default_host()
+        owner, repo = dep_ref.repo_url.split("/", 1)
+        refs = [ref]
+        if ref in ("main", "master"):
+            refs.append("master" if ref == "main" else "main")
+
+        for candidate_ref in refs:
+            content = self.try_raw_download(owner, repo, candidate_ref, file_path)
+            if content is not None:
+                if verbose_callback:
+                    verbose_callback(f"Downloaded file: {host}/{dep_ref.repo_url}/{file_path}")
+                return content
+
+        def _contents_request(
+            token: str | None,
+            _git_env: dict[str, str],
+        ) -> bytes:
+            headers: dict[str, str] = {
+                "Accept": "application/vnd.github.v3.raw",
+            }
+            if token:
+                headers["Authorization"] = f"token {token}"
+            last_response = None
+            for candidate_ref in refs:
+                api_url = self._build_contents_api_urls(
+                    host,
+                    owner,
+                    repo,
+                    file_path,
+                    candidate_ref,
+                    is_github_host=True,
+                )[0]
+                response = self._host._resilient_get(
+                    api_url,
+                    headers=headers,
+                    timeout=30,
+                    retry_throttles=False,
+                )
+                if response.status_code == 200:
+                    if verbose_callback:
+                        verbose_callback(f"Downloaded file: {host}/{dep_ref.repo_url}/{file_path}")
+                    return self._extract_contents_api_payload(
+                        response,
+                        is_github_host=True,
+                    )
+                throttle = github_throttle_error(response, host)
+                if throttle is not None:
+                    raise throttle
+                last_response = response
+                if response.status_code != 404:
+                    response.raise_for_status()
+            if last_response is not None:
+                last_response.raise_for_status()
+            raise RuntimeError(f"No GitHub Contents API response for {file_path}")
+
+        try:
+            return self._host.auth_resolver.try_with_fallback(
+                host,
+                _contents_request,
+                org=owner,
+                port=dep_ref.port,
+                path=dep_ref.repo_url,
+                unauth_first=True,
+                verbose_callback=verbose_callback,
+            )
+        except GitHubThrottleError:
+            raise
+        except requests.exceptions.HTTPError as exc:
+            status = exc.response.status_code if exc.response is not None else "unknown"
+            if status in (401, 403):
+                raise RuntimeError(
+                    f"Authentication failed for {dep_ref.repo_url} "
+                    f"(file: {file_path}, ref: {ref}). "
+                    "The repository may be private or the resolved credential "
+                    "may lack access."
+                ) from exc
+            if status == 404:
+                raise RuntimeError(
+                    self._build_unsupported_or_missing_error(
+                        host,
+                        dep_ref.repo_url,
+                        file_path,
+                        ref,
+                        self._build_contents_api_urls(
+                            host,
+                            owner,
+                            repo,
+                            file_path,
+                            ref,
+                            is_github_host=True,
+                        ),
+                        is_github_host=True,
+                        fallback_ref=refs[-1] if len(refs) > 1 else None,
+                    )
+                ) from exc
+            raise RuntimeError(
+                self._build_download_http_error(
+                    host,
+                    file_path,
+                    status,
+                    "Contents API",
+                )
+            ) from exc
+        except requests.exceptions.RequestException as exc:
+            raise RuntimeError(
+                self._build_download_network_error(
+                    host,
+                    file_path,
+                    "Contents API",
+                    exc,
+                )
+            ) from exc
+
     def download_github_file(
         self,
         dep_ref: DependencyReference,
@@ -957,6 +1134,21 @@ class DownloadDelegate:
             bytes: File content
         """
         host = dep_ref.host or default_host()
+
+        if (
+            self._host.auth_resolver.uses_public_github_anonymous_first(
+                host,
+                port=dep_ref.port,
+                host_type=dep_ref.host_type,
+            )
+            is True
+        ):
+            return self._download_public_github_file_anonymous_first(
+                dep_ref,
+                file_path,
+                ref,
+                verbose_callback,
+            )
 
         # Parse owner/repo from repo_url
         owner, repo = dep_ref.repo_url.split("/", 1)

--- a/src/apm_cli/deps/download_strategies.py
+++ b/src/apm_cli/deps/download_strategies.py
@@ -802,6 +802,7 @@ class DownloadDelegate:
                 org=dep_ref.repo_url.split("/", 1)[0],
                 port=dep_ref.port,
                 path=dep_ref.repo_url,
+                host_type=dep_ref.host_type,
                 unauth_first=True,
             )
 
@@ -1062,6 +1063,7 @@ class DownloadDelegate:
                 org=owner,
                 port=dep_ref.port,
                 path=dep_ref.repo_url,
+                host_type=dep_ref.host_type,
                 unauth_first=True,
                 verbose_callback=verbose_callback,
             )

--- a/src/apm_cli/deps/download_strategies.py
+++ b/src/apm_cli/deps/download_strategies.py
@@ -541,6 +541,9 @@ class DownloadDelegate:
     def try_raw_download(self, owner: str, repo: str, ref: str, file_path: str) -> bytes | None:
         """Attempt to fetch a file via raw.githubusercontent.com (CDN).
 
+        This pre-auth helper must remain token-free: it runs before
+        ``AuthResolver`` has established that credentials may be required.
+
         Returns the raw bytes on success, or ``None`` if the file was not found
         (HTTP 404) or the request failed for any reason.  This is intentionally
         best-effort: callers fall back to the Contents API when ``None`` is

--- a/src/apm_cli/deps/git_auth_env.py
+++ b/src/apm_cli/deps/git_auth_env.py
@@ -76,7 +76,7 @@ class GitAuthEnvBuilder:
 
             temp_base = get_apm_temp_dir() or tempfile.gettempdir()
             empty_cfg = os.path.join(temp_base, ".apm_empty_gitconfig")
-            with open(empty_cfg, "w") as f:  # noqa: F841
+            with open(empty_cfg, "w", encoding="ascii"):
                 pass
             return empty_cfg
         return os.devnull

--- a/src/apm_cli/deps/git_auth_env.py
+++ b/src/apm_cli/deps/git_auth_env.py
@@ -62,6 +62,13 @@ class GitAuthEnvBuilder:
         else:
             env["GIT_SSH_COMMAND"] = f"ssh {ssh_timeout}"
 
+        env["GIT_CONFIG_GLOBAL"] = self.isolated_global_config_path()
+
+        return env
+
+    @staticmethod
+    def isolated_global_config_path() -> str:
+        """Return a cross-platform empty Git config path."""
         if sys.platform == "win32":
             import tempfile
 
@@ -71,11 +78,8 @@ class GitAuthEnvBuilder:
             empty_cfg = os.path.join(temp_base, ".apm_empty_gitconfig")
             with open(empty_cfg, "w") as f:  # noqa: F841
                 pass
-            env["GIT_CONFIG_GLOBAL"] = empty_cfg
-        else:
-            env["GIT_CONFIG_GLOBAL"] = "/dev/null"
-
-        return env
+            return empty_cfg
+        return os.devnull
 
     # -- noninteractive (fallback) env ----------------------------------
 

--- a/src/apm_cli/deps/git_reference_resolver.py
+++ b/src/apm_cli/deps/git_reference_resolver.py
@@ -273,6 +273,7 @@ class GitReferenceResolver:
                     org=org,
                     port=dep_ref.port,
                     path=dep_ref.repo_url,
+                    host_type=dep_ref.host_type,
                     unauth_first=True,
                 )
             except (GitCommandError, OSError) as exc:
@@ -405,6 +406,7 @@ class GitReferenceResolver:
                     org=org,
                     port=dep_ref.port,
                     path=dep_ref.repo_url,
+                    host_type=dep_ref.host_type,
                     unauth_first=True,
                 )
             file_ctx = host.auth_resolver.resolve(

--- a/src/apm_cli/deps/git_reference_resolver.py
+++ b/src/apm_cli/deps/git_reference_resolver.py
@@ -42,6 +42,7 @@ from ..utils.github_host import (
     is_ado_auth_failure_signal,
     is_github_hostname,
 )
+from .github_rate_limit import raise_for_github_throttle
 
 if TYPE_CHECKING:
     import requests
@@ -139,21 +140,47 @@ class GitReferenceResolver:
             return []
 
         is_ado = dep_ref.is_azure_devops()
-        dep_token = host._resolve_dep_token(dep_ref)
-        dep_auth_ctx = host._resolve_dep_auth_ctx(dep_ref)
-        dep_auth_scheme = dep_auth_ctx.auth_scheme if dep_auth_ctx else "basic"
-
         repo_url_base = dep_ref.repo_url
-        transport_plan = host._transport_selector.select(
+        anonymous_plan = host._transport_selector.select(
             dep_ref=dep_ref,
             cli_pref=host._protocol_pref,
             allow_fallback=False,
-            has_token=bool(dep_token),
+            has_token=False,
         )
+        dep_host = dep_ref.host or default_host()
+        public_github_https_first = bool(
+            not dep_ref.is_insecure
+            and anonymous_plan.attempts
+            and anonymous_plan.attempts[0].scheme == "https"
+            and host.auth_resolver.uses_public_github_anonymous_first(
+                dep_host,
+                port=dep_ref.port,
+                host_type=dep_ref.host_type,
+            )
+            is True
+        )
+        if public_github_https_first:
+            dep_token = None
+            dep_auth_ctx = None
+            dep_auth_scheme = "basic"
+            transport_plan = anonymous_plan
+        else:
+            dep_token = host._resolve_dep_token(dep_ref)
+            dep_auth_ctx = host._resolve_dep_auth_ctx(dep_ref)
+            dep_auth_scheme = dep_auth_ctx.auth_scheme if dep_auth_ctx else "basic"
+            transport_plan = host._transport_selector.select(
+                dep_ref=dep_ref,
+                cli_pref=host._protocol_pref,
+                allow_fallback=False,
+                has_token=bool(dep_token),
+            )
         transport_attempt = transport_plan.attempts[0]
         use_ssh = transport_attempt.scheme == "ssh"
 
-        if use_ssh:
+        if public_github_https_first:
+            ls_env: dict[str, str] = {}
+            remote_url = ""
+        elif use_ssh:
             ls_env = host._build_noninteractive_git_env()
             from ..core.auth import AuthResolver
 
@@ -170,13 +197,14 @@ class GitReferenceResolver:
                 suppress_credential_helpers=bool(getattr(dep_ref, "is_insecure", False)),
             )
 
-        remote_url = host._build_repo_url(
-            repo_url_base,
-            use_ssh=use_ssh,
-            dep_ref=dep_ref,
-            token=None if use_ssh else (dep_token if transport_attempt.use_token else None),
-            auth_scheme=dep_auth_scheme if transport_attempt.use_token else "basic",
-        )
+        if not public_github_https_first:
+            remote_url = host._build_repo_url(
+                repo_url_base,
+                use_ssh=use_ssh,
+                dep_ref=dep_ref,
+                token=None if use_ssh else (dep_token if transport_attempt.use_token else None),
+                auth_scheme=dep_auth_scheme if transport_attempt.use_token else "basic",
+            )
 
         # Route through the github_downloader module so that test patches
         # of ``apm_cli.deps.github_downloader.git.cmd.Git`` intercept here.
@@ -222,7 +250,35 @@ class GitReferenceResolver:
             and dep_token is not None
         )
 
-        if ado_eligible:
+        if public_github_https_first:
+
+            def _public_github_op(
+                token: str | None,
+                git_env: dict[str, str],
+            ) -> tuple[str, str]:
+                public_url = host._build_repo_url(
+                    repo_url_base,
+                    use_ssh=False,
+                    dep_ref=dep_ref,
+                    token=token or "",
+                    auth_scheme="basic",
+                )
+                return ("ok", g.ls_remote(*ls_args, public_url, env=git_env))
+
+            org = repo_url_base.split("/", 1)[0] if "/" in repo_url_base else None
+            try:
+                outcome = host.auth_resolver.try_with_fallback(
+                    dep_host,
+                    _public_github_op,
+                    org=org,
+                    port=dep_ref.port,
+                    path=dep_ref.repo_url,
+                    unauth_first=True,
+                )
+            except (GitCommandError, OSError) as exc:
+                outcome = ("err", exc)
+            ado_bearer_also_failed = False
+        elif ado_eligible:
             fb = host.auth_resolver.execute_with_bearer_fallback(
                 dep_ref, _primary_op, _bearer_op, _is_auth_failure
             )
@@ -247,6 +303,13 @@ class GitReferenceResolver:
             if dep_host:
                 host_info = host.auth_resolver.classify_host(dep_host, port=dep_ref.port)
                 host_name = host_info.display_name
+            elif public_github_https_first and not host.auth_resolver.is_public_github_auth_failure(
+                e
+            ):
+                error_msg += (
+                    f"Unable to reach {dep_host or default_host()} without credentials. "
+                    "Check DNS, TLS, proxy, and network connectivity."
+                )
             else:
                 host_name = "the target host"
             error_msg += (
@@ -308,25 +371,48 @@ class GitReferenceResolver:
         parts = dep_ref.repo_url.split("/")
         if parts:
             org = parts[0]
-        try:
-            file_ctx = host.auth_resolver.resolve(target_host, org, port=dep_ref.port)
-            token = file_ctx.token
-        except Exception:
-            token = None
 
-        headers: dict[str, str] = {"Accept": "application/vnd.github.sha"}
-        if token:
-            headers["Authorization"] = f"token {token}"
-
-        try:
-            # L2/L3 own fallback, so this optional metadata tier gets one total attempt.
-            response = host._resilient_get(api_url, headers=headers, timeout=10, max_retries=1)
+        def _request(token: str | None, _git_env: dict[str, str]) -> str | None:
+            headers: dict[str, str] = {"Accept": "application/vnd.github.sha"}
+            if token:
+                headers["Authorization"] = f"token {token}"
+            response = host._resilient_get(
+                api_url,
+                headers=headers,
+                timeout=10,
+                max_retries=1,
+            )
             if response.status_code != 200:
-                return None
+                raise_for_github_throttle(response, target_host)
+                error = RuntimeError(f"GitHub commits API returned HTTP {response.status_code}")
+                error.status_code = response.status_code
+                raise error
             body = (response.text or "").strip()
-            if re.match(r"^[a-f0-9]{40}$", body.lower()):
-                return body.lower()
-            return None
+            return body.lower() if re.match(r"^[a-f0-9]{40}$", body.lower()) else None
+
+        try:
+            if (
+                host.auth_resolver.uses_public_github_anonymous_first(
+                    target_host,
+                    port=dep_ref.port,
+                    host_type=dep_ref.host_type,
+                )
+                is True
+            ):
+                return host.auth_resolver.try_with_fallback(
+                    target_host,
+                    _request,
+                    org=org,
+                    port=dep_ref.port,
+                    path=dep_ref.repo_url,
+                    unauth_first=True,
+                )
+            file_ctx = host.auth_resolver.resolve(
+                target_host,
+                org,
+                port=dep_ref.port,
+            )
+            return _request(file_ctx.token, file_ctx.git_env)
         except Exception:
             return None
 

--- a/src/apm_cli/deps/git_reference_resolver.py
+++ b/src/apm_cli/deps/git_reference_resolver.py
@@ -413,6 +413,7 @@ class GitReferenceResolver:
                 target_host,
                 org,
                 port=dep_ref.port,
+                host_type=dep_ref.host_type,
             )
             return _request(file_ctx.token, file_ctx.git_env)
         except Exception:

--- a/src/apm_cli/deps/git_reference_resolver.py
+++ b/src/apm_cli/deps/git_reference_resolver.py
@@ -299,17 +299,17 @@ class GitReferenceResolver:
 
         ref_kind = "remote refs" if include_heads else "remote tags"
         error_msg = f"Failed to list {ref_kind} for {repo_url_base}. "
-        if is_generic:
+        if public_github_https_first and not host.auth_resolver.is_public_github_auth_failure(e):
+            error_msg += (
+                f"Could not connect to {dep_host or default_host()} "
+                "(network error, not an auth failure). "
+                "Check your internet connection and proxy settings. "
+                "Run with --verbose for details."
+            )
+        elif is_generic:
             if dep_host:
                 host_info = host.auth_resolver.classify_host(dep_host, port=dep_ref.port)
                 host_name = host_info.display_name
-            elif public_github_https_first and not host.auth_resolver.is_public_github_auth_failure(
-                e
-            ):
-                error_msg += (
-                    f"Unable to reach {dep_host or default_host()} without credentials. "
-                    "Check DNS, TLS, proxy, and network connectivity."
-                )
             else:
                 host_name = "the target host"
             error_msg += (

--- a/src/apm_cli/deps/github_downloader.py
+++ b/src/apm_cli/deps/github_downloader.py
@@ -293,6 +293,17 @@ class GitHubPackageDownloader:
         """
         from .git_auth_env import GitAuthEnvBuilder
 
+        if (
+            self.auth_resolver.uses_public_github_anonymous_first(
+                dep_ref.host or default_host(),
+                port=dep_ref.port,
+                host_type=dep_ref.host_type,
+            )
+            is True
+            and not dep_ref.is_insecure
+        ):
+            return self.auth_resolver.build_public_github_anonymous_git_env()
+
         git_env = GitAuthEnvBuilder.subprocess_env_dict(self.git_env)
         if dep_ref.is_insecure:
             git_env = GitAuthEnvBuilder.noninteractive_env(
@@ -1089,6 +1100,103 @@ class GitHubPackageDownloader:
 
         try:
             temp_clone_path.mkdir(parents=True, exist_ok=True)
+
+            public_github_anonymous_first = (
+                not dep_ref.is_insecure
+                and self.auth_resolver.uses_public_github_anonymous_first(
+                    dep_ref.host or default_host(),
+                    port=dep_ref.port,
+                    host_type=dep_ref.host_type,
+                )
+                is True
+            )
+            if public_github_anonymous_first:
+                anonymous_url = self._build_repo_url(
+                    dep_ref.repo_url,
+                    use_ssh=False,
+                    dep_ref=dep_ref,
+                    token="",
+                )
+                setup_env = self.auth_resolver.build_public_github_anonymous_git_env()
+                setup_cmds = [
+                    ["git", "init"],
+                    ["git", "remote", "add", "origin", anonymous_url],
+                    ["git", "sparse-checkout", "init", "--cone"],
+                    ["git", "sparse-checkout", "set", subdir_path],
+                ]
+                for cmd in setup_cmds:
+                    result = subprocess.run(
+                        cmd,
+                        cwd=str(temp_clone_path),
+                        env=setup_env,
+                        capture_output=True,
+                        text=True,
+                        encoding="utf-8",
+                        timeout=120,
+                    )
+                    if result.returncode != 0:
+                        return False
+
+                def _fetch(token: str | None, git_env: dict[str, str]) -> None:
+                    if token is not None:
+                        authenticated_url = self._build_repo_url(
+                            dep_ref.repo_url,
+                            use_ssh=False,
+                            dep_ref=dep_ref,
+                            token=token or "",
+                        )
+                        remote_result = subprocess.run(
+                            ["git", "remote", "set-url", "origin", authenticated_url],
+                            cwd=str(temp_clone_path),
+                            env=git_env,
+                            capture_output=True,
+                            text=True,
+                            encoding="utf-8",
+                            timeout=120,
+                        )
+                        if remote_result.returncode != 0:
+                            raise subprocess.CalledProcessError(
+                                remote_result.returncode,
+                                remote_result.args,
+                                output=remote_result.stdout,
+                                stderr=remote_result.stderr,
+                            )
+                    fetch_result = subprocess.run(
+                        ["git", "fetch", "origin", ref or "HEAD", "--depth=1"],
+                        cwd=str(temp_clone_path),
+                        env=git_env,
+                        capture_output=True,
+                        text=True,
+                        encoding="utf-8",
+                        timeout=120,
+                    )
+                    if fetch_result.returncode != 0:
+                        raise subprocess.CalledProcessError(
+                            fetch_result.returncode,
+                            fetch_result.args,
+                            output=fetch_result.stdout,
+                            stderr=fetch_result.stderr,
+                        )
+
+                org = dep_ref.repo_url.split("/", 1)[0]
+                self.auth_resolver.try_with_fallback(
+                    dep_ref.host or default_host(),
+                    _fetch,
+                    org=org,
+                    port=dep_ref.port,
+                    path=dep_ref.repo_url,
+                    unauth_first=True,
+                )
+                checkout_result = subprocess.run(
+                    ["git", "checkout", "FETCH_HEAD"],
+                    cwd=str(temp_clone_path),
+                    env=setup_env,
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    timeout=120,
+                )
+                return checkout_result.returncode == 0
 
             # Resolve per-dependency auth via AuthResolver.
             dep_auth_ctx = self._resolve_dep_auth_ctx(dep_ref)

--- a/src/apm_cli/deps/github_downloader.py
+++ b/src/apm_cli/deps/github_downloader.py
@@ -1185,6 +1185,7 @@ class GitHubPackageDownloader:
                     org=org,
                     port=dep_ref.port,
                     path=dep_ref.repo_url,
+                    host_type=dep_ref.host_type,
                     unauth_first=True,
                 )
                 checkout_result = subprocess.run(

--- a/src/apm_cli/deps/github_downloader_validation.py
+++ b/src/apm_cli/deps/github_downloader_validation.py
@@ -541,6 +541,7 @@ def _ref_exists_via_ls_remote(
                 org=org,
                 port=dep_ref.port,
                 path=dep_ref.repo_url,
+                host_type=dep_ref.host_type,
                 unauth_first=True,
             )
             if is_sha:

--- a/src/apm_cli/deps/github_downloader_validation.py
+++ b/src/apm_cli/deps/github_downloader_validation.py
@@ -253,7 +253,6 @@ def _directory_exists_at_ref(
         log(f"  [x] repo_url '{dep_ref.repo_url}' missing owner/repo split")
         return False
     owner, repo = parts
-    token = downloader.auth_resolver.resolve_for_dep(dep_ref).token
 
     from urllib.parse import quote
 
@@ -274,11 +273,10 @@ def _directory_exists_at_ref(
             f"https://{host}/api/v3/repos/{owner}/{repo}/contents/{encoded_path}?ref={encoded_ref}"
         )
 
-    headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
-    if token:
-        headers["Authorization"] = f"token {token}"
-
-    try:
+    def _request(token: str | None, _git_env: dict[str, str]) -> bool:
+        headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
+        if token:
+            headers["Authorization"] = f"token {token}"
         response = downloader._resilient_get(
             api_url,
             headers=headers,
@@ -289,16 +287,37 @@ def _directory_exists_at_ref(
         if response.status_code == 200:
             log(f"  [+] {path}@{ref} (directory)")
             return True
-        # 404 is the expected "not present at this ref" outcome -- the
-        # marker-file fallback path treats this as informational, not
-        # an error.  Reserve [x] for unexpected HTTP statuses.
-        if response.status_code == 404:
-            log(f"  [i] {path}@{ref} (HTTP 404)")
-        else:
-            log(f"  [x] {path}@{ref} (HTTP {response.status_code})")
+        response.raise_for_status()
         return False
+
+    try:
+        if (
+            downloader.auth_resolver.uses_public_github_anonymous_first(
+                host,
+                port=dep_ref.port,
+                host_type=dep_ref.host_type,
+            )
+            is True
+        ):
+            return downloader.auth_resolver.try_with_fallback(
+                host,
+                _request,
+                org=owner,
+                port=dep_ref.port,
+                path=dep_ref.repo_url,
+                unauth_first=True,
+            )
+        auth_ctx = downloader.auth_resolver.resolve_for_dep(dep_ref)
+        return _request(auth_ctx.token, auth_ctx.git_env)
     except GitHubThrottleError:
         raise
+    except requests.exceptions.HTTPError as exc:
+        status = exc.response.status_code if exc.response is not None else "unknown"
+        if status == 404:
+            log(f"  [i] {path}@{ref} (HTTP 404)")
+        else:
+            log(f"  [x] {path}@{ref} (HTTP {status})")
+        return False
     except (requests.exceptions.RequestException, RuntimeError) as exc:
         log(f"  [x] {path}@{ref} ({exc})")
         return False
@@ -339,9 +358,6 @@ def _build_validation_attempts(
     if dep_ref.is_artifactory():
         return []
 
-    dep_token: str | None = downloader._resolve_dep_token(dep_ref)
-    dep_auth_ctx = downloader._resolve_dep_auth_ctx(dep_ref)
-    dep_auth_scheme: str = dep_auth_ctx.auth_scheme if dep_auth_ctx else "basic"
     is_insecure: bool = bool(getattr(dep_ref, "is_insecure", False))
     is_ado: bool = dep_ref.is_azure_devops()
     host_info = (
@@ -354,6 +370,24 @@ def _build_validation_attempts(
         else None
     )
     is_gitlab = host_info is not None and host_info.kind == "gitlab"
+    public_github_anonymous_first = bool(
+        host_info is not None
+        and not is_insecure
+        and downloader.auth_resolver.uses_public_github_anonymous_first(
+            host_info.host,
+            port=dep_ref.port,
+            host_type=dep_ref.host_type,
+        )
+        is True
+    )
+    if public_github_anonymous_first:
+        dep_token = None
+        dep_auth_ctx = None
+        dep_auth_scheme = "basic"
+    else:
+        dep_token = downloader._resolve_dep_token(dep_ref)
+        dep_auth_ctx = downloader._resolve_dep_auth_ctx(dep_ref)
+        dep_auth_scheme = dep_auth_ctx.auth_scheme if dep_auth_ctx else "basic"
 
     attempts: list[AttemptSpec] = []
 
@@ -390,9 +424,13 @@ def _build_validation_attempts(
         attempts.append(AttemptSpec(label, token_url, token_env))
 
     # Attempt 2: plain HTTPS w/ credential helper (no token, no header).
-    plain_env = downloader._build_noninteractive_git_env(
-        preserve_config_isolation=is_insecure,
-        suppress_credential_helpers=is_insecure,
+    plain_env = (
+        downloader.auth_resolver.build_public_github_anonymous_git_env()
+        if public_github_anonymous_first
+        else downloader._build_noninteractive_git_env(
+            preserve_config_isolation=is_insecure,
+            suppress_credential_helpers=is_insecure,
+        )
     )
     plain_url = downloader._build_repo_url(
         dep_ref.repo_url,
@@ -400,7 +438,12 @@ def _build_validation_attempts(
         dep_ref=dep_ref,
         token="",
     )
-    attempts.append(AttemptSpec("plain HTTPS w/ credential helper", plain_url, plain_env))
+    plain_label = (
+        "anonymous GitHub HTTPS"
+        if public_github_anonymous_first
+        else "plain HTTPS w/ credential helper"
+    )
+    attempts.append(AttemptSpec(plain_label, plain_url, plain_env))
 
     # Attempt 3 (SSH): only when allowed. StrictHostKeyChecking is
     # intentionally inherited from the user's ssh config; do NOT add
@@ -447,13 +490,85 @@ def _ref_exists_via_ls_remote(
         if ls-remote succeeded via SSH but the follow-up probe used the
         rejected PAT, the fallback would silently false-reject).
     """
+    is_sha = _is_sha_pin(ref)
+    ref_lc = ref.lower()
+    g = git.cmd.Git()
+    host = dep_ref.host or default_host()
+    if (
+        not dep_ref.is_insecure
+        and downloader.auth_resolver.uses_public_github_anonymous_first(
+            host,
+            port=dep_ref.port,
+            host_type=dep_ref.host_type,
+        )
+        is True
+    ):
+
+        def _public_github_ref_probe(
+            token: str | None,
+            git_env: dict[str, str],
+        ) -> tuple[str, AttemptSpec]:
+            probe_env = dict(git_env)
+            label = "anonymous GitHub HTTPS"
+            if token:
+                set_authorization_header_git_env(probe_env, "Bearer", token)
+                probe_env.pop("GIT_TOKEN", None)
+                label = "authenticated GitHub HTTPS"
+            url = downloader._build_repo_url(
+                dep_ref.repo_url,
+                use_ssh=False,
+                dep_ref=dep_ref,
+                token="",
+            )
+            if is_sha:
+                output = g.ls_remote(url, env=probe_env)
+            else:
+                output = g.ls_remote(
+                    "--heads",
+                    "--tags",
+                    url,
+                    ref,
+                    env=probe_env,
+                )
+            return output, AttemptSpec(label, url, probe_env)
+
+        org = dep_ref.repo_url.split("/", 1)[0]
+        try:
+            output, attempt = downloader.auth_resolver.try_with_fallback(
+                host,
+                _public_github_ref_probe,
+                org=org,
+                port=dep_ref.port,
+                path=dep_ref.repo_url,
+                unauth_first=True,
+            )
+            if is_sha:
+                matched = bool(
+                    output
+                    and any(
+                        line.split("\t", 1)[0].lower().startswith(ref_lc)
+                        for line in output.splitlines()
+                        if line
+                    )
+                )
+            else:
+                matched = bool(output and output.strip())
+            if matched:
+                log(f"  [+] ls-remote ok via {attempt.label}")
+                return True, attempt
+            log(f"  [!] ls-remote returned no matching refs via {attempt.label}")
+            return False, None
+        except (GitCommandError, OSError) as exc:
+            log(
+                "  [x] ls-remote failed via anonymous-first GitHub HTTPS: "
+                f"{downloader._sanitize_git_error(str(exc))}"
+            )
+            return False, None
+
     attempts = _build_validation_attempts(downloader, dep_ref, log)
     if not attempts:
         return False, None
 
-    is_sha = _is_sha_pin(ref)
-    ref_lc = ref.lower()
-    g = git.cmd.Git()
     for attempt in attempts:
         label, url, env = attempt
         try:

--- a/src/apm_cli/deps/github_downloader_validation.py
+++ b/src/apm_cli/deps/github_downloader_validation.py
@@ -305,6 +305,7 @@ def _directory_exists_at_ref(
                 org=owner,
                 port=dep_ref.port,
                 path=dep_ref.repo_url,
+                host_type=dep_ref.host_type,
                 unauth_first=True,
             )
         auth_ctx = downloader.auth_resolver.resolve_for_dep(dep_ref)

--- a/src/apm_cli/install/validation.py
+++ b/src/apm_cli/install/validation.py
@@ -344,6 +344,7 @@ def _validate_virtual_package(
         org,
         port=dep_ref.port,
         host_type=dep_ref.host_type,
+        path=dep_ref.repo_url,
     )
     if not result and verbose_log and (public_github is not True or auth_was_resolved):
         try:
@@ -727,6 +728,7 @@ def _validate_github_package(
             # DependencyReference invariant); forwarded as path= so GCM
             # multi-account users get per-URL credential matching.
             path=dep_ref.repo_url,
+            host_type=dep_ref.host_type,
             unauth_first=True,
             verbose_callback=verbose_log,
         )

--- a/src/apm_cli/install/validation.py
+++ b/src/apm_cli/install/validation.py
@@ -281,13 +281,25 @@ def _validate_virtual_package(
             )
         return True
 
-    ctx = auth_resolver.resolve_for_dep(dep_ref)
     host = dep_ref.host or default_host()
     org = dep_ref.repo_url.split("/")[0] if dep_ref.repo_url and "/" in dep_ref.repo_url else None
     if verbose_log:
-        verbose_log(
-            f"Auth resolved: host={host}, org={org}, source={ctx.source}, type={ctx.token_type}"
-        )
+        if (
+            auth_resolver.uses_public_github_anonymous_first(
+                host,
+                port=dep_ref.port,
+                host_type=dep_ref.host_type,
+            )
+            is True
+        ):
+            verbose_log(
+                f"Auth deferred: host={host}, org={org}, public github.com probes run anonymously"
+            )
+        else:
+            ctx = auth_resolver.resolve_for_dep(dep_ref)
+            verbose_log(
+                f"Auth resolved: host={host}, org={org}, source={ctx.source}, type={ctx.token_type}"
+            )
     virtual_downloader = GitHubPackageDownloader(auth_resolver=auth_resolver)
 
     def _warn(msg: str) -> None:
@@ -321,7 +333,18 @@ def _validate_virtual_package(
         verbose_callback=verbose_log,
         warn_callback=_warn,
     )
-    if not result and verbose_log:
+    public_github = auth_resolver.uses_public_github_anonymous_first(
+        host,
+        port=dep_ref.port,
+        host_type=dep_ref.host_type,
+    )
+    auth_was_resolved = auth_resolver.has_cached_resolution(
+        host,
+        org,
+        port=dep_ref.port,
+        host_type=dep_ref.host_type,
+    )
+    if not result and verbose_log and (public_github is not True or auth_was_resolved):
         try:
             err_ctx = auth_resolver.build_error_context(
                 host,
@@ -654,11 +677,17 @@ def _validate_github_package(
         return True
 
     if verbose_log:
-        ctx = auth_resolver.resolve(host, org=org, port=port)
-        verbose_log(
-            f"Auth resolved: host={host_info.display_name}, org={org}, "
-            f"source={ctx.source}, type={ctx.token_type}"
-        )
+        if auth_resolver.uses_public_github_anonymous_first(host, port=port) is True:
+            verbose_log(
+                f"Auth deferred: host={host_info.display_name}, org={org}, "
+                "anonymous probe runs before credential resolution"
+            )
+        else:
+            ctx = auth_resolver.resolve(host, org=org, port=port)
+            verbose_log(
+                f"Auth resolved: host={host_info.display_name}, org={org}, "
+                f"source={ctx.source}, type={ctx.token_type}"
+            )
 
     def _check_repo(token, git_env) -> bool:
         """Check repo accessibility via GitHub API."""

--- a/src/apm_cli/install/validation.py
+++ b/src/apm_cli/install/validation.py
@@ -293,7 +293,8 @@ def _validate_virtual_package(
             is True
         ):
             verbose_log(
-                f"Auth deferred: host={host}, org={org}, public github.com probes run anonymously"
+                f"Auth deferred: host={host}, org={org} -- "
+                "anonymous probe before credential resolution"
             )
         else:
             ctx = auth_resolver.resolve_for_dep(dep_ref)
@@ -679,8 +680,8 @@ def _validate_github_package(
     if verbose_log:
         if auth_resolver.uses_public_github_anonymous_first(host, port=port) is True:
             verbose_log(
-                f"Auth deferred: host={host_info.display_name}, org={org}, "
-                "anonymous probe runs before credential resolution"
+                f"Auth deferred: host={host_info.display_name}, org={org} -- "
+                "anonymous probe before credential resolution"
             )
         else:
             ctx = auth_resolver.resolve(host, org=org, port=port)

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -1431,3 +1431,64 @@ def test_git_auth_header_owner_guard_rejects_dictmerge_reintroduction(tmp_path: 
         "Git-subprocess Authorization-header injection must use "
         "set_authorization_header_git_env / set_ado_bearer_git_env" in result.stdout
     )
+
+
+def test_public_github_anonymous_first_has_single_auth_owner() -> None:
+    """Public GitHub auth ordering belongs to AuthResolver and its consumers."""
+    root = Path(__file__).parents[2]
+    owner = (root / "src/apm_cli/core/auth.py").read_text(encoding="utf-8")
+    guard = (root / "scripts/lint-architecture-boundaries.sh").read_text(encoding="utf-8")
+    architecture_doc = (root / ".apm/instructions/architecture.instructions.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "def uses_public_github_anonymous_first(" in owner
+    assert "def build_public_github_anonymous_git_env(" in owner
+    assert "AC20: public github.com anonymous-first auth authority" in guard
+    assert (
+        "Public github.com anonymous-first auth ordering must stay owned by AuthResolver" in guard
+    )
+    assert "public github.com anonymous-first ordering" in architecture_doc
+
+
+def test_public_github_auth_owner_guard_rejects_duplicate_owner(
+    tmp_path: Path,
+) -> None:
+    """AC20 rejects a second host-ordering implementation outside auth.py."""
+    root = Path(__file__).parents[2]
+    sandbox = tmp_path / "repo"
+    shutil.copytree(
+        root,
+        sandbox,
+        ignore=shutil.ignore_patterns(
+            ".git",
+            ".venv",
+            ".pytest_cache",
+            "__pycache__",
+            "build",
+            "dist",
+            "node_modules",
+        ),
+    )
+    consumer = sandbox / "src/apm_cli/deps/clone_engine.py"
+    consumer.write_text(
+        consumer.read_text(encoding="utf-8")
+        + "\n\ndef uses_public_github_anonymous_first(host):\n"
+        + '    return host.lower() == "github.com"\n',
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ("bash", "scripts/lint-architecture-boundaries.sh"),
+        cwd=sandbox,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+
+    assert result.returncode == 1
+    assert (
+        "Public github.com anonymous-first auth ordering must stay owned by "
+        "AuthResolver" in result.stdout
+    )

--- a/tests/integration/test_audit_cold_cache_ci_e2e.py
+++ b/tests/integration/test_audit_cold_cache_ci_e2e.py
@@ -134,29 +134,14 @@ def _seed_consumer(
     dependency_repo = repositories.create("remote-dependency", source_tree=dependency.root)
     dependency_commit = repositories.commit(dependency_repo, message="seed dependency")
     remote_url = "https://github.com/test/remote-dependency.git"
-    git_sources = (
-        "git@github.com:test/remote-dependency.git",
+    environment = repositories.url_rewrite_subprocess_env(
+        dependency_repo,
         remote_url,
     )
-    user_git_environment = dict(environment)
-    user_git_environment.pop("GIT_CONFIG_GLOBAL", None)
-    for git_environment in (environment, user_git_environment):
-        for source in git_sources:
-            subprocess.run(
-                (
-                    "git",
-                    "config",
-                    "--global",
-                    "--add",
-                    f"url.{dependency_repo.file_url}.insteadOf",
-                    source,
-                ),
-                env=git_environment,
-                capture_output=True,
-                text=True,
-                check=True,
-                timeout=30,
-            )
+    rewrite_index = int(environment["GIT_CONFIG_COUNT"])
+    environment["GIT_CONFIG_COUNT"] = str(rewrite_index + 1)
+    environment[f"GIT_CONFIG_KEY_{rewrite_index}"] = f"url.{dependency_repo.file_url}/.insteadOf"
+    environment[f"GIT_CONFIG_VALUE_{rewrite_index}"] = "git@github.com:test/remote-dependency.git"
 
     consumer = packages.create(
         "consumer",

--- a/tests/integration/test_public_github_anonymous_lifecycle_e2e.py
+++ b/tests/integration/test_public_github_anonymous_lifecycle_e2e.py
@@ -1,0 +1,343 @@
+"""Installed-CLI lifecycle coverage for public GitHub anonymous-first auth."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+from tests.utils.apm_lifecycle_runner import ApmLifecycleRunner
+from tests.utils.git_credential_shim import (
+    GitCredentialShim,
+    GitCredentialShimFactory,
+)
+from tests.utils.isolated_apm_environment import IsolatedApmEnvironment
+from tests.utils.local_git_http_server import LocalGitHttpServerFactory
+from tests.utils.local_git_repository import (
+    LocalGitRepository,
+    LocalGitRepositoryFactory,
+)
+from tests.utils.local_package import LocalPackageFactory
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.e2e,
+    pytest.mark.requires_e2e_mode,
+]
+
+_PUBLIC_OWNER = "fixture-public"
+_PRIVATE_OWNER = "fixture-private"
+_PRIVATE_TOKEN = "fixture-private-token"
+_INSTALL_ARGS = (
+    "install",
+    "--target",
+    "copilot",
+    "--no-policy",
+    "--parallel-downloads",
+    "0",
+)
+_AUDIT_ARGS = (
+    "audit",
+    "--ci",
+    "--no-policy",
+    "--format",
+    "json",
+    "--output",
+    "reports/audit.json",
+)
+
+
+def _real_git() -> Path:
+    executable = shutil.which("git")
+    if executable is None:
+        pytest.skip("git executable not available")
+    return Path(executable).resolve()
+
+
+def _skill_source(name: str) -> str:
+    return f"---\nname: {name}\ndescription: Anonymous-first lifecycle fixture\n---\n# {name}\n"
+
+
+def _child_environment(
+    isolated: IsolatedApmEnvironment,
+    shim: GitCredentialShim,
+    *,
+    proxy_url: str,
+) -> dict[str, str]:
+    """Route HTTPS probes into the rejecting loopback proxy for hermeticity."""
+    environment = dict(shim.environment)
+    for name in (
+        "ALL_PROXY",
+        "HTTP_PROXY",
+        "NO_PROXY",
+        "all_proxy",
+        "http_proxy",
+        "no_proxy",
+    ):
+        environment.pop(name, None)
+    environment["HTTPS_PROXY"] = proxy_url
+    environment["https_proxy"] = proxy_url
+    environment["NO_PROXY"] = "127.0.0.1,localhost"
+    environment["no_proxy"] = "127.0.0.1,localhost"
+    environment["GIT_ALLOW_PROTOCOL"] = "file:http:https"
+    environment["GIT_CONFIG_COUNT"] = "1"
+    environment["GIT_CONFIG_KEY_0"] = "credential.interactive"
+    environment["GIT_CONFIG_VALUE_0"] = "never"
+    assert environment["HOME"] == str(isolated.home)
+    return environment
+
+
+def _remote_events(shim: GitCredentialShim) -> list[dict[str, object]]:
+    return [
+        event for event in shim.events() if event.get("event") == "git" and event.get("remotes")
+    ]
+
+
+def _assert_anonymous_remote_event(event: dict[str, object]) -> None:
+    assert event["github_token_env"] == []
+    assert event["git_token_present"] is False
+    assert event["auth_config_present"] is False
+    assert event["credential_helpers"] == [""]
+    assert event["credential_interactive"] in ([], ["never"])
+    remotes = event["remotes"]
+    assert isinstance(remotes, list)
+    assert remotes
+    assert all(remote["authenticated_url"] is False for remote in remotes)
+
+
+def _create_public_graph(
+    isolated: IsolatedApmEnvironment,
+    *,
+    environment: dict[str, str],
+) -> tuple[
+    LocalGitRepositoryFactory,
+    tuple[LocalGitRepository, ...],
+    Path,
+]:
+    packages = LocalPackageFactory(isolated.package_root)
+    repositories = LocalGitRepositoryFactory(
+        isolated.repository_root,
+        env=environment,
+    )
+
+    leaf = packages.create("public-leaf", targets=("copilot",))
+    packages.add_skill(leaf, "public-leaf", _skill_source("public-leaf"))
+    leaf_repository = repositories.create("public-leaf", source_tree=leaf.root)
+    repositories.commit(leaf_repository, message="seed public leaf")
+
+    parent = packages.create(
+        "public-parent",
+        dependencies=(f"{_PUBLIC_OWNER}/public-leaf#main",),
+        targets=("copilot",),
+    )
+    packages.add_skill(parent, "public-parent", _skill_source("public-parent"))
+    parent_repository = repositories.create("public-parent", source_tree=parent.root)
+    repositories.commit(parent_repository, message="seed public parent")
+
+    virtuals = packages.create("public-virtuals", targets=("copilot",))
+    packages.add_skill(virtuals, "virtual-alpha", _skill_source("virtual-alpha"))
+    packages.add_skill(virtuals, "virtual-beta", _skill_source("virtual-beta"))
+    virtuals_repository = repositories.create(
+        "public-virtuals",
+        source_tree=virtuals.root,
+    )
+    repositories.commit(virtuals_repository, message="seed public virtuals")
+
+    consumer = LocalPackageFactory(isolated.work_root).create(
+        "public-consumer",
+        dependencies=(
+            f"{_PUBLIC_OWNER}/public-parent#main",
+            f"{_PUBLIC_OWNER}/public-virtuals/skills/virtual-alpha#main",
+            f"{_PUBLIC_OWNER}/public-virtuals/skills/virtual-beta#main",
+        ),
+        targets=("copilot",),
+    )
+    return (
+        repositories,
+        (leaf_repository, parent_repository, virtuals_repository),
+        consumer.root,
+    )
+
+
+def test_all_public_graph_lifecycle_never_resolves_or_leaks_credentials(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Install, repeat, update, and audit remain credential-free."""
+    isolated = IsolatedApmEnvironment.create(
+        tmp_path / "public-scenario",
+        base_env={
+            **os.environ,
+            "GITHUB_APM_PAT": "ambient-pat-must-be-stripped",
+            "GITHUB_TOKEN": "ambient-actions-token-must-be-stripped",
+            "GIT_CONFIG_COUNT": "2",
+            "GIT_CONFIG_KEY_0": "http.extraHeader",
+            "GIT_CONFIG_VALUE_0": "Authorization: Bearer ambient-header",
+            "GIT_CONFIG_KEY_1": "credential.interactive",
+            "GIT_CONFIG_VALUE_1": "never",
+        },
+    )
+    base_environment = isolated.subprocess_env()
+    _repositories, graph, project_root = _create_public_graph(
+        isolated,
+        environment=base_environment,
+    )
+    server_factory = LocalGitHttpServerFactory(
+        isolated.repository_root,
+        real_git=_real_git(),
+        env=base_environment,
+    )
+
+    with server_factory.start(graph, password=_PRIVATE_TOKEN) as server:
+        remote_map = {
+            f"{_PUBLIC_OWNER}/{repository.origin.stem}": server.remote_url(repository)
+            for repository in graph
+        }
+        shim = GitCredentialShimFactory(isolated.root / "shims").create(
+            base_env=base_environment,
+            real_git=_real_git(),
+            remote_map=remote_map,
+            credential=_PRIVATE_TOKEN,
+        )
+        environment = _child_environment(
+            isolated,
+            shim,
+            proxy_url=server.proxy_url,
+        )
+        results = ApmLifecycleRunner(
+            (str(apm_binary_path),),
+            scenario_timeout_seconds=360,
+        ).run_sequence(
+            (
+                _INSTALL_ARGS,
+                _INSTALL_ARGS,
+                ("update", "--yes", "--target", "copilot"),
+                _AUDIT_ARGS,
+            ),
+            expected_returncodes=(0, 0, 0, 0),
+            scenario_id="public-github-anonymous-lifecycle",
+            cwd=project_root,
+            env=environment,
+        )
+
+        assert len(results) == 4
+        assert (project_root / ".agents/skills/public-parent/SKILL.md").is_file()
+        assert (project_root / ".agents/skills/public-leaf/SKILL.md").is_file()
+        assert (project_root / ".agents/skills/virtual-alpha/SKILL.md").is_file()
+        assert (project_root / ".agents/skills/virtual-beta/SKILL.md").is_file()
+        assert (project_root / "reports/audit.json").is_file()
+
+        events = shim.events()
+        assert [event for event in events if event.get("event") == "credential-fill"] == []
+        assert [event for event in events if event.get("event") == "gh"] == []
+        remote_events = _remote_events(shim)
+        assert remote_events
+        for event in remote_events:
+            _assert_anonymous_remote_event(event)
+
+        repository_requests = [
+            observation
+            for observation in server.observations
+            if any(repository.origin.name in observation.path for repository in graph)
+        ]
+        assert repository_requests
+        assert all(not observation.authorization_present for observation in repository_requests)
+
+
+def test_private_github_fallback_resolves_once_and_completes_lifecycle(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """One private dependency uses one path-scoped credential fallback."""
+    isolated = IsolatedApmEnvironment.create(
+        tmp_path / "private-scenario",
+        base_env=dict(os.environ),
+    )
+    base_environment = isolated.subprocess_env()
+    packages = LocalPackageFactory(isolated.package_root)
+    source = packages.create("private-package", targets=("copilot",))
+    packages.add_skill(source, "private-package", _skill_source("private-package"))
+    repositories = LocalGitRepositoryFactory(
+        isolated.repository_root,
+        env=base_environment,
+    )
+    repository = repositories.create("private-package", source_tree=source.root)
+    repositories.commit(repository, message="seed private package")
+    project = LocalPackageFactory(isolated.work_root).create(
+        "private-consumer",
+        dependencies=(f"{_PRIVATE_OWNER}/private-package#main",),
+        targets=("copilot",),
+    )
+
+    server_factory = LocalGitHttpServerFactory(
+        isolated.repository_root,
+        real_git=_real_git(),
+        env=base_environment,
+    )
+    with server_factory.start(
+        (repository,),
+        private_repositories=(repository,),
+        password=_PRIVATE_TOKEN,
+    ) as server:
+        shim = GitCredentialShimFactory(isolated.root / "shims").create(
+            base_env=base_environment,
+            real_git=_real_git(),
+            remote_map={
+                f"{_PRIVATE_OWNER}/private-package": server.remote_url(repository),
+            },
+            credential=_PRIVATE_TOKEN,
+        )
+        environment = _child_environment(
+            isolated,
+            shim,
+            proxy_url=server.proxy_url,
+        )
+        result = ApmLifecycleRunner((str(apm_binary_path),)).run(
+            (*_INSTALL_ARGS, "--verbose"),
+            scenario_id="private-github-scoped-fallback",
+            cwd=project.root,
+            env=environment,
+        )
+
+        assert result.returncode == 0, (
+            f"stdout={result.stdout!r}\nstderr={result.stderr!r}\n"
+            f"shim_events={shim.events()!r}\n"
+            f"http_observations={server.observations!r}"
+        )
+        assert (project.root / ".agents/skills/private-package/SKILL.md").is_file()
+
+        credential_events = [
+            event for event in shim.events() if event.get("event") == "credential-fill"
+        ]
+        assert credential_events == [
+            {
+                "credential_interactive": ["never"],
+                "event": "credential-fill",
+                "host": "github.com",
+                "path": f"{_PRIVATE_OWNER}/private-package",
+                "protocol": "https",
+            }
+        ]
+
+        remote_events = _remote_events(shim)
+        assert remote_events
+        remote_attempts = [remote for event in remote_events for remote in event["remotes"]]
+        assert remote_attempts[0]["authenticated_url"] is False
+        assert any(remote["authenticated_url"] is True for remote in remote_attempts)
+        for event in remote_events:
+            remotes = event["remotes"]
+            if all(remote["authenticated_url"] is False for remote in remotes):
+                _assert_anonymous_remote_event(event)
+
+        private_requests = [
+            observation
+            for observation in server.observations
+            if repository.origin.name in observation.path
+        ]
+        assert any(not observation.accepted for observation in private_requests)
+        assert any(
+            observation.accepted and observation.authorization_present
+            for observation in private_requests
+        )

--- a/tests/quality/critical_suite.toml
+++ b/tests/quality/critical_suite.toml
@@ -114,3 +114,7 @@ marker = "e2e"
 [[modules]]
 path = "tests/integration/test_virtual_skill_audit_e2e.py"
 marker = "e2e"
+
+[[modules]]
+path = "tests/integration/test_public_github_anonymous_lifecycle_e2e.py"
+marker = "e2e"

--- a/tests/quality/test_test_taxonomy.py
+++ b/tests/quality/test_test_taxonomy.py
@@ -137,7 +137,7 @@ def test_tm001_behavioral_marker_definitions_match_spec() -> None:
 
 def test_tm002_manifest_is_finite_unique_and_existing() -> None:
     modules = _manifest_modules()
-    assert len(modules) == 29
+    assert len(modules) == 30
     paths = [entry["path"] for entry in modules]
     assert len(paths) == len(set(paths))
     assert {entry["marker"] for entry in modules} == BEHAVIORAL_MARKERS

--- a/tests/unit/core/test_public_github_anonymous_first.py
+++ b/tests/unit/core/test_public_github_anonymous_first.py
@@ -228,6 +228,65 @@ def test_public_github_connectivity_and_throttle_failures_never_resolve(
     resolve.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    ("failure", "expected"),
+    (
+        (_HttpStatusError(401), True),
+        (_HttpStatusError(403), True),
+        (_HttpStatusError(404), True),
+        (RuntimeError("Authentication failed"), True),
+        (RuntimeError("Authorization failed"), True),
+        (RuntimeError("Unauthorized"), True),
+        (RuntimeError("could not read Username"), True),
+        (RuntimeError("invalid username or password"), True),
+        (RuntimeError("remote: Repository not found"), True),
+        (RuntimeError("terminal prompts disabled"), True),
+        (RuntimeError("unable to get password from user"), True),
+        (RuntimeError("The requested URL returned error: 404"), True),
+        (RuntimeError("HTTP error 403"), True),
+        (RuntimeError("status code=401"), True),
+        (RuntimeError("GitHub API throttle for github.com (HTTP 403)"), False),
+        (RuntimeError("too many requests: HTTP 403"), False),
+        (RuntimeError("could not resolve host: github.com"), False),
+        (RuntimeError("connection refused"), False),
+        (RuntimeError("connection timed out"), False),
+        (RuntimeError("network is unreachable"), False),
+        (RuntimeError("certificate verify failed"), False),
+        (RuntimeError("CERTIFICATE_VERIFY_FAILED"), False),
+        (RuntimeError("SSL certificate problem"), False),
+        (RuntimeError("TLS verification failed"), False),
+    ),
+)
+def test_public_github_auth_failure_classifier_signal_vocabulary(
+    failure: Exception,
+    expected: bool,
+) -> None:
+    """Every documented auth and non-auth signal stays in its intended bucket."""
+    assert AuthResolver.is_public_github_auth_failure(failure) is expected
+
+
+def test_clear_git_auth_env_only_removes_real_auth_channels() -> None:
+    """Authorization-like path text survives while real headers are stripped."""
+    env = {
+        "GIT_CONFIG_COUNT": "4",
+        "GIT_CONFIG_KEY_0": "http.sslCAInfo",
+        "GIT_CONFIG_VALUE_0": "/authorization/corporate-ca.pem",
+        "GIT_CONFIG_KEY_1": "custom.policy",
+        "GIT_CONFIG_VALUE_1": "X-Custom: authorization=reviewed",
+        "GIT_CONFIG_KEY_2": "custom.header",
+        "GIT_CONFIG_VALUE_2": "Authorization: Bearer secret",
+        "GIT_CONFIG_KEY_3": "http.extraHeader",
+        "GIT_CONFIG_VALUE_3": "X-Harmless: value",
+    }
+
+    AuthResolver._clear_git_auth_env(env)
+
+    assert _indexed_git_config(env) == [
+        ("http.sslCAInfo", "/authorization/corporate-ca.pem"),
+        ("custom.policy", "X-Custom: authorization=reviewed"),
+    ]
+
+
 def _public_downloader(resolver: AuthResolver) -> GitHubPackageDownloader:
     """Build a deterministic HTTPS-only downloader for clone-engine tests."""
     return GitHubPackageDownloader(
@@ -268,6 +327,46 @@ def test_public_github_clone_is_anonymous_before_inherited_pat() -> None:
     assert parsed.username is None
     assert parsed.password is None
     _assert_anonymous_attempt_env(calls[0][1])
+    manager.get_token_for_purpose.assert_not_called()
+    manager.resolve_credential_from_gh_cli.assert_not_called()
+    manager.resolve_credential_from_git.assert_not_called()
+
+
+def test_public_github_clone_connectivity_failure_does_not_resolve() -> None:
+    """Clone error rendering preserves a network failure without auth lookup."""
+    manager = MagicMock(spec=GitHubTokenManager)
+    manager.setup_environment.side_effect = lambda: dict(os.environ)
+    manager.get_token_for_purpose.return_value = None
+    manager.resolve_credential_from_gh_cli.return_value = None
+    manager.resolve_credential_from_git.return_value = None
+    resolver = AuthResolver(token_manager=manager)
+    dep_ref = DependencyReference.parse("https://github.com/acme/widgets.git#main")
+
+    def clone_action(
+        _url: str,
+        _env: dict[str, str],
+        _target: Path,
+    ) -> None:
+        raise subprocess.CalledProcessError(
+            128,
+            ("git", "clone"),
+            stderr="fatal: could not resolve host: github.com",
+        )
+
+    with patch.dict(os.environ, {}, clear=True):
+        downloader = _public_downloader(resolver)
+        manager.reset_mock()
+        with pytest.raises(
+            RuntimeError,
+            match="network error, not an auth failure",
+        ):
+            downloader._execute_transport_plan(
+                dep_ref.repo_url,
+                Path("unused-target"),
+                dep_ref=dep_ref,
+                clone_action=clone_action,
+            )
+
     manager.get_token_for_purpose.assert_not_called()
     manager.resolve_credential_from_gh_cli.assert_not_called()
     manager.resolve_credential_from_git.assert_not_called()

--- a/tests/unit/core/test_public_github_anonymous_first.py
+++ b/tests/unit/core/test_public_github_anonymous_first.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import subprocess
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 from urllib.parse import urlparse
 
 import pytest
@@ -181,6 +181,7 @@ def test_public_github_auth_status_resolves_once_then_retries(status_code: int) 
         "github.com",
         "acme",
         port=None,
+        host_type=None,
         path="acme/private",
     )
 
@@ -417,6 +418,76 @@ def test_private_github_clone_resolves_one_path_scoped_fallback() -> None:
         port=None,
         path="acme/private",
     )
+
+
+def test_path_scoped_resolution_caches_per_repository() -> None:
+    """The same repo reuses auth while another repo gets its own credential."""
+    manager = MagicMock(spec=GitHubTokenManager)
+    manager.get_token_for_purpose.return_value = None
+    manager.resolve_credential_from_gh_cli.return_value = None
+    manager.resolve_credential_from_git.side_effect = lambda _host, *, port, path: (
+        f"token-for-{path}"
+    )
+    resolver = AuthResolver(token_manager=manager)
+
+    first = resolver.resolve(
+        "github.com",
+        "acme",
+        path="acme/private-a",
+    )
+    repeated = resolver.resolve(
+        "github.com",
+        "acme",
+        path="acme/private-a",
+    )
+    second = resolver.resolve(
+        "github.com",
+        "acme",
+        path="acme/private-b",
+    )
+
+    assert repeated is first
+    assert first.token == "token-for-acme/private-a"
+    assert second.token == "token-for-acme/private-b"
+    assert manager.resolve_credential_from_git.call_args_list == [
+        call("github.com", port=None, path="acme/private-a"),
+        call("github.com", port=None, path="acme/private-b"),
+    ]
+    assert resolver.has_cached_resolution(
+        "github.com",
+        "acme",
+        path="acme/private-a",
+    )
+    assert resolver.has_cached_resolution(
+        "github.com",
+        "acme",
+        path="acme/private-b",
+    )
+    assert not resolver.has_cached_resolution(
+        "github.com",
+        "acme",
+        path="acme/private-c",
+    )
+    assert not resolver.has_cached_resolution("github.com", "acme")
+
+
+def test_try_with_fallback_preserves_host_type_conflict_checks() -> None:
+    """The inner owner sees the same manifest host hint as its caller."""
+    resolver = AuthResolver()
+    operation = MagicMock()
+
+    with pytest.raises(
+        ValueError,
+        match="conflicts with recognized 'github' host",
+    ):
+        resolver.try_with_fallback(
+            "github.com",
+            operation,
+            host_type="gitlab",
+            unauth_first=True,
+        )
+
+    operation.assert_not_called()
 
 
 def _response(status_code: int, content: bytes = b"") -> requests.Response:

--- a/tests/unit/core/test_public_github_anonymous_first.py
+++ b/tests/unit/core/test_public_github_anonymous_first.py
@@ -1,0 +1,427 @@
+"""Regression contracts for public github.com anonymous-first auth."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
+
+import pytest
+import requests
+
+from apm_cli.core.auth import AuthResolver
+from apm_cli.core.token_manager import GitHubTokenManager
+from apm_cli.deps.github_downloader import GitHubPackageDownloader
+from apm_cli.deps.github_rate_limit import GitHubThrottle, GitHubThrottleError
+from apm_cli.deps.transport_selection import (
+    NoOpInsteadOfResolver,
+    ProtocolPreference,
+    TransportSelector,
+)
+from apm_cli.models.dependency.reference import DependencyReference
+
+_GITHUB_TOKEN_ENV_NAMES = {
+    "GH_TOKEN",
+    "GITHUB_APM_PAT",
+    "GITHUB_TOKEN",
+}
+
+
+class _HttpStatusError(RuntimeError):
+    """Minimal HTTP-shaped failure consumed by AuthResolver."""
+
+    def __init__(self, status_code: int) -> None:
+        self.status_code = status_code
+        super().__init__(f"HTTP {status_code}")
+
+
+def _indexed_git_config(env: dict[str, str]) -> list[tuple[str, str]]:
+    """Return process-scoped Git config entries in declared order."""
+    count = int(env.get("GIT_CONFIG_COUNT", "0"))
+    return [
+        (
+            env.get(f"GIT_CONFIG_KEY_{index}", ""),
+            env.get(f"GIT_CONFIG_VALUE_{index}", ""),
+        )
+        for index in range(count)
+    ]
+
+
+def _git_auth_entries(env: dict[str, str]) -> list[tuple[str, str]]:
+    """Return only config entries that can carry an Authorization header."""
+    return [
+        (key, value)
+        for key, value in _indexed_git_config(env)
+        if "extraheader" in key.lower() or value.strip().lower().startswith("authorization:")
+    ]
+
+
+def _poisoned_environment() -> dict[str, str]:
+    """Return inherited auth state plus harmless Git policy entries."""
+    return {
+        "GH_TOKEN": "gh-token-must-not-leak",
+        "GITHUB_APM_PAT": "apm-pat-must-not-leak",
+        "GITHUB_APM_PAT_ACME": "org-pat-private-fallback",
+        "GITHUB_TOKEN": "actions-token-must-not-leak",
+        "GIT_HTTP_EXTRAHEADER": "Authorization: Bearer inherited-header",
+        "GIT_TOKEN": "git-token-must-not-leak",
+        "GIT_CONFIG_COUNT": "4",
+        "GIT_CONFIG_KEY_0": "http.extraHeader",
+        "GIT_CONFIG_VALUE_0": "Authorization: Basic inherited-header",
+        "GIT_CONFIG_KEY_1": "url.file:///fixture.git/.insteadOf",
+        "GIT_CONFIG_VALUE_1": "https://github.com/acme/widgets",
+        "GIT_CONFIG_KEY_2": "credential.interactive",
+        "GIT_CONFIG_VALUE_2": "never",
+        "GIT_CONFIG_KEY_3": "http.sslCAInfo",
+        "GIT_CONFIG_VALUE_3": "/authorization/corporate-ca.pem",
+    }
+
+
+def _assert_anonymous_attempt_env(env: dict[str, str]) -> None:
+    """Assert the complete credential-free anonymous Git call shape."""
+    assert env["GIT_TERMINAL_PROMPT"] == "0"
+    assert env["GIT_ASKPASS"] == "echo"
+    assert env["GIT_CONFIG_NOSYSTEM"] == "1"
+    if os.name == "nt":
+        assert Path(env["GIT_CONFIG_GLOBAL"]).is_file()
+    else:
+        assert env["GIT_CONFIG_GLOBAL"] == os.devnull
+    assert "GIT_TOKEN" not in env
+    assert "GIT_HTTP_EXTRAHEADER" not in env
+    assert "GIT_CONFIG_PARAMETERS" not in env
+    assert not (_GITHUB_TOKEN_ENV_NAMES & env.keys())
+    assert not any(name.startswith("GITHUB_APM_PAT_") for name in env)
+    assert _git_auth_entries(env) == []
+
+    config = dict(_indexed_git_config(env))
+    assert config["credential.helper"] == ""
+    assert config["credential.interactive"] == "never"
+    assert config["url.file:///fixture.git/.insteadOf"] == ("https://github.com/acme/widgets")
+    assert config["http.sslCAInfo"] == "/authorization/corporate-ca.pem"
+
+
+@pytest.mark.windows_compat
+def test_public_github_success_never_resolves_or_leaks_credentials() -> None:
+    """A successful public request runs before every credential source."""
+    manager = MagicMock(spec=GitHubTokenManager)
+    manager.get_token_for_purpose.return_value = "eager-token"
+    resolver = AuthResolver(token_manager=manager)
+    attempts: list[tuple[str | None, dict[str, str]]] = []
+
+    def operation(token: str | None, env: dict[str, str]) -> str:
+        attempts.append((token, env))
+        return "public-ok"
+
+    with (
+        patch.dict(os.environ, _poisoned_environment(), clear=True),
+        patch.object(resolver, "resolve", wraps=resolver.resolve) as resolve,
+    ):
+        result = resolver.try_with_fallback(
+            "github.com",
+            operation,
+            org="acme",
+            path="acme/widgets",
+            unauth_first=True,
+        )
+
+    assert result == "public-ok"
+    assert len(attempts) == 1
+    assert attempts[0][0] is None
+    _assert_anonymous_attempt_env(attempts[0][1])
+    resolve.assert_not_called()
+    manager.get_token_for_purpose.assert_not_called()
+    manager.resolve_credential_from_gh_cli.assert_not_called()
+    manager.resolve_credential_from_git.assert_not_called()
+
+
+@pytest.mark.parametrize("status_code", (401, 403, 404))
+def test_public_github_auth_status_resolves_once_then_retries(status_code: int) -> None:
+    """Only an auth-shaped anonymous response unlocks credential resolution."""
+    resolver = AuthResolver()
+    attempts: list[tuple[str | None, dict[str, str]]] = []
+
+    def operation(token: str | None, env: dict[str, str]) -> str:
+        attempts.append((token, env))
+        if token is None:
+            raise _HttpStatusError(status_code)
+        return "private-ok"
+
+    with (
+        patch.dict(
+            os.environ,
+            {**_poisoned_environment(), "GITHUB_APM_PAT": "private-token"},
+            clear=True,
+        ),
+        patch.object(resolver, "resolve", wraps=resolver.resolve) as resolve,
+        patch.object(
+            GitHubTokenManager,
+            "resolve_credential_from_gh_cli",
+            side_effect=AssertionError("env token must short-circuit gh"),
+        ),
+        patch.object(
+            GitHubTokenManager,
+            "resolve_credential_from_git",
+            side_effect=AssertionError("env token must short-circuit credential fill"),
+        ),
+    ):
+        result = resolver.try_with_fallback(
+            "github.com",
+            operation,
+            org="acme",
+            path="acme/private",
+            unauth_first=True,
+        )
+
+    assert result == "private-ok"
+    assert [token for token, _env in attempts] == [None, "org-pat-private-fallback"]
+    _assert_anonymous_attempt_env(attempts[0][1])
+    resolve.assert_called_once_with(
+        "github.com",
+        "acme",
+        port=None,
+        path="acme/private",
+    )
+
+
+@pytest.mark.parametrize(
+    "failure",
+    (
+        requests.exceptions.ConnectionError("DNS unavailable"),
+        requests.exceptions.SSLError("certificate verify failed"),
+        requests.exceptions.Timeout("request timed out"),
+        _HttpStatusError(429),
+        RuntimeError("GitHub secondary rate limit"),
+        GitHubThrottleError(
+            GitHubThrottle(403, "remaining-zero"),
+            "github.com",
+        ),
+    ),
+)
+def test_public_github_connectivity_and_throttle_failures_never_resolve(
+    failure: Exception,
+) -> None:
+    """Connectivity and throttle failures surface without an auth prompt."""
+    resolver = AuthResolver()
+
+    def operation(_token: str | None, _env: dict[str, str]) -> str:
+        raise failure
+
+    with (
+        patch.dict(os.environ, _poisoned_environment(), clear=True),
+        patch.object(
+            resolver,
+            "resolve",
+            side_effect=AssertionError("non-auth failure must not resolve credentials"),
+        ) as resolve,
+    ):
+        with pytest.raises(type(failure)):
+            resolver.try_with_fallback(
+                "github.com",
+                operation,
+                org="acme",
+                path="acme/widgets",
+                unauth_first=True,
+            )
+
+    resolve.assert_not_called()
+
+
+def _public_downloader(resolver: AuthResolver) -> GitHubPackageDownloader:
+    """Build a deterministic HTTPS-only downloader for clone-engine tests."""
+    return GitHubPackageDownloader(
+        auth_resolver=resolver,
+        transport_selector=TransportSelector(NoOpInsteadOfResolver()),
+        protocol_pref=ProtocolPreference.HTTPS,
+        allow_fallback=False,
+    )
+
+
+@pytest.mark.windows_compat
+def test_public_github_clone_is_anonymous_before_inherited_pat() -> None:
+    """The download transport does not resolve or present an inherited PAT."""
+    manager = MagicMock(spec=GitHubTokenManager)
+    manager.setup_environment.side_effect = lambda: dict(os.environ)
+    manager.get_token_for_purpose.return_value = "eager-token"
+    resolver = AuthResolver(token_manager=manager)
+    dep_ref = DependencyReference.parse("https://github.com/acme/widgets.git#main")
+    calls: list[tuple[str, dict[str, str]]] = []
+
+    def clone_action(url: str, env: dict[str, str], _target: Path) -> None:
+        calls.append((url, env))
+
+    with patch.dict(os.environ, _poisoned_environment(), clear=True):
+        downloader = _public_downloader(resolver)
+        manager.reset_mock()
+        downloader._execute_transport_plan(
+            dep_ref.repo_url,
+            Path("unused-target"),
+            dep_ref=dep_ref,
+            clone_action=clone_action,
+        )
+
+    assert len(calls) == 1
+    parsed = urlparse(calls[0][0])
+    assert parsed.scheme == "https"
+    assert parsed.hostname == "github.com"
+    assert parsed.username is None
+    assert parsed.password is None
+    _assert_anonymous_attempt_env(calls[0][1])
+    manager.get_token_for_purpose.assert_not_called()
+    manager.resolve_credential_from_gh_cli.assert_not_called()
+    manager.resolve_credential_from_git.assert_not_called()
+
+
+def test_private_github_clone_resolves_one_path_scoped_fallback() -> None:
+    """A private-repo-shaped failure retries through one scoped credential fill."""
+    manager = MagicMock(spec=GitHubTokenManager)
+    manager.setup_environment.side_effect = lambda: dict(os.environ)
+    manager.get_token_for_purpose.return_value = None
+    manager.resolve_credential_from_gh_cli.return_value = None
+    manager.resolve_credential_from_git.return_value = "private-token"
+    resolver = AuthResolver(token_manager=manager)
+    dep_ref = DependencyReference.parse("https://github.com/acme/private.git#main")
+    calls: list[tuple[str, dict[str, str]]] = []
+
+    def clone_action(url: str, env: dict[str, str], _target: Path) -> None:
+        calls.append((url, env))
+        if urlparse(url).username is None:
+            raise subprocess.CalledProcessError(
+                128,
+                ("git", "clone"),
+                stderr="remote: Repository not found\nfatal: HTTP 404",
+            )
+
+    inherited = _poisoned_environment()
+    for name in tuple(inherited):
+        if name in _GITHUB_TOKEN_ENV_NAMES or name.startswith("GITHUB_APM_PAT_"):
+            inherited.pop(name)
+    with patch.dict(os.environ, inherited, clear=True):
+        downloader = _public_downloader(resolver)
+        downloader._execute_transport_plan(
+            dep_ref.repo_url,
+            Path("unused-target"),
+            dep_ref=dep_ref,
+            clone_action=clone_action,
+        )
+
+    assert len(calls) == 2
+    anonymous_url = urlparse(calls[0][0])
+    authenticated_url = urlparse(calls[1][0])
+    assert anonymous_url.hostname == authenticated_url.hostname == "github.com"
+    assert anonymous_url.username is None
+    assert authenticated_url.username is not None
+    _assert_anonymous_attempt_env(calls[0][1])
+    manager.resolve_credential_from_git.assert_called_once_with(
+        "github.com",
+        port=None,
+        path="acme/private",
+    )
+
+
+def _response(status_code: int, content: bytes = b"") -> requests.Response:
+    """Build a concrete requests response for file-fetch fallback tests."""
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = content
+    response.url = "https://api.github.com/repos/acme/widgets/contents/SKILL.md"
+    return response
+
+
+def test_public_github_file_fetch_sends_no_auth_or_resolver_call() -> None:
+    """The Contents API public success remains fully anonymous."""
+    manager = MagicMock(spec=GitHubTokenManager)
+    manager.setup_environment.side_effect = lambda: dict(os.environ)
+    manager.get_token_for_purpose.return_value = "eager-token"
+    resolver = AuthResolver(token_manager=manager)
+    dep_ref = DependencyReference.parse("https://github.com/acme/widgets.git#main")
+
+    with patch.dict(os.environ, _poisoned_environment(), clear=True):
+        downloader = _public_downloader(resolver)
+        manager.reset_mock()
+        downloader._strategies.try_raw_download = MagicMock(return_value=None)
+        downloader._resilient_get = MagicMock(
+            return_value=_response(200, b"public-file"),
+        )
+        content = downloader._strategies.download_github_file(
+            dep_ref,
+            "SKILL.md",
+            "main",
+        )
+
+    assert content == b"public-file"
+    calls = downloader._resilient_get.call_args_list
+    assert len(calls) == 1
+    assert "Authorization" not in calls[0].kwargs["headers"]
+    manager.get_token_for_purpose.assert_not_called()
+    manager.resolve_credential_from_gh_cli.assert_not_called()
+    manager.resolve_credential_from_git.assert_not_called()
+
+
+def test_private_github_file_fetch_uses_one_scoped_fallback() -> None:
+    """Anonymous 404s unlock one credential resolution and authenticated retry."""
+    manager = MagicMock(spec=GitHubTokenManager)
+    manager.setup_environment.side_effect = lambda: dict(os.environ)
+    manager.get_token_for_purpose.return_value = None
+    manager.resolve_credential_from_gh_cli.return_value = None
+    manager.resolve_credential_from_git.return_value = "private-token"
+    resolver = AuthResolver(token_manager=manager)
+    dep_ref = DependencyReference.parse("https://github.com/acme/private.git#main")
+    inherited = _poisoned_environment()
+    for name in tuple(inherited):
+        if name in _GITHUB_TOKEN_ENV_NAMES or name.startswith("GITHUB_APM_PAT_"):
+            inherited.pop(name)
+
+    with patch.dict(os.environ, inherited, clear=True):
+        downloader = _public_downloader(resolver)
+        downloader._strategies.try_raw_download = MagicMock(return_value=None)
+        downloader._resilient_get = MagicMock(
+            side_effect=(
+                _response(404),
+                _response(404),
+                _response(200, b"private-file"),
+            )
+        )
+        content = downloader._strategies.download_github_file(
+            dep_ref,
+            "SKILL.md",
+            "main",
+        )
+
+    assert content == b"private-file"
+    calls = downloader._resilient_get.call_args_list
+    assert len(calls) == 3
+    assert "Authorization" not in calls[0].kwargs["headers"]
+    assert "Authorization" not in calls[1].kwargs["headers"]
+    assert calls[2].kwargs["headers"]["Authorization"] == "token private-token"
+    manager.resolve_credential_from_git.assert_called_once_with(
+        "github.com",
+        port=None,
+        path="acme/private",
+    )
+
+
+def test_ghe_cloud_https_keeps_existing_auth_first_behavior() -> None:
+    """The anonymous-first rule is exact to github.com, not GHE Cloud."""
+    manager = MagicMock(spec=GitHubTokenManager)
+    manager.setup_environment.side_effect = lambda: dict(os.environ)
+    manager.get_token_for_purpose.return_value = "ghe-token"
+    resolver = AuthResolver(token_manager=manager)
+    dep_ref = DependencyReference.parse("https://contoso.ghe.com/acme/widgets.git#main")
+    calls: list[str] = []
+
+    with patch.dict(os.environ, {}, clear=True):
+        downloader = _public_downloader(resolver)
+        downloader._execute_transport_plan(
+            dep_ref.repo_url,
+            Path("unused-target"),
+            dep_ref=dep_ref,
+            clone_action=lambda url, _env, _target: calls.append(url),
+        )
+
+    assert len(calls) == 1
+    parsed = urlparse(calls[0])
+    assert parsed.hostname == "contoso.ghe.com"
+    assert parsed.username is not None
+    manager.get_token_for_purpose.assert_called()

--- a/tests/unit/deps/test_git_reference_resolver.py
+++ b/tests/unit/deps/test_git_reference_resolver.py
@@ -306,6 +306,33 @@ class TestListRemoteRefs:
             with pytest.raises(RuntimeError, match=r"Failed to list remote refs"):
                 resolver.list_remote_refs(_dep(host="github.com"))
 
+    def test_public_github_connectivity_error_does_not_render_auth_context(self):
+        """A non-auth ref failure stays a network diagnostic."""
+        host = _ctx()
+        host.auth_resolver.uses_public_github_anonymous_first.return_value = True
+        host.auth_resolver.try_with_fallback.side_effect = lambda _host, operation, **_kwargs: (
+            operation(
+                None,
+                {"GIT_CONFIG_KEY_0": "credential.helper"},
+            )
+        )
+        host.auth_resolver.is_public_github_auth_failure.return_value = False
+        host._build_repo_url.return_value = "https://github.com/owner/repo.git"
+        with patch("apm_cli.deps.github_downloader.git.cmd.Git") as MockGit:
+            MockGit.return_value.ls_remote.side_effect = GitCommandError(
+                "ls-remote",
+                128,
+                b"fatal: could not resolve host: github.com",
+            )
+            resolver = GitReferenceResolver(host)
+            with pytest.raises(
+                RuntimeError,
+                match="network error, not an auth failure",
+            ):
+                resolver.list_remote_refs(_dep(host="github.com"))
+
+        host.auth_resolver.build_error_context.assert_not_called()
+
     def test_ado_basic_with_token_uses_bearer_fallback(self):
         host = _ctx(token="ado_pat", auth_scheme="basic")
         # Wire bearer fallback to be invoked: primary fails with auth signal,

--- a/tests/unit/deps/test_git_reference_resolver.py
+++ b/tests/unit/deps/test_git_reference_resolver.py
@@ -318,6 +318,8 @@ class TestListRemoteRefs:
         )
         host.auth_resolver.is_public_github_auth_failure.return_value = False
         host._build_repo_url.return_value = "https://github.com/owner/repo.git"
+        dep = _dep(host="github.com")
+        dep.host_type = "gitlab"
         with patch("apm_cli.deps.github_downloader.git.cmd.Git") as MockGit:
             MockGit.return_value.ls_remote.side_effect = GitCommandError(
                 "ls-remote",
@@ -329,9 +331,10 @@ class TestListRemoteRefs:
                 RuntimeError,
                 match="network error, not an auth failure",
             ):
-                resolver.list_remote_refs(_dep(host="github.com"))
+                resolver.list_remote_refs(dep)
 
         host.auth_resolver.build_error_context.assert_not_called()
+        assert host.auth_resolver.try_with_fallback.call_args.kwargs["host_type"] == "gitlab"
 
     def test_ado_basic_with_token_uses_bearer_fallback(self):
         host = _ctx(token="ado_pat", auth_scheme="basic")

--- a/tests/unit/deps/test_github_downloader_validation.py
+++ b/tests/unit/deps/test_github_downloader_validation.py
@@ -480,6 +480,33 @@ class TestRound3NonAdoTokenNotInProcessArgv:
         assert _git_config_value(attempts[0].env, "credential.helper") == ""
 
 
+def test_public_ref_probe_threads_host_type_to_fallback() -> None:
+    """Virtual ref validation keeps the manifest host hint in the auth owner."""
+    downloader = GitHubPackageDownloader()
+    dep_ref = _make_subdir_dep(host="github.com", ref="main")
+    dep_ref.host_type = "gitlab"
+    auth_resolver = MagicMock()
+    auth_resolver.uses_public_github_anonymous_first.return_value = True
+    winning = gdv.AttemptSpec(
+        "anonymous GitHub HTTPS",
+        "https://github.com/owner/repo.git",
+        {},
+    )
+    auth_resolver.try_with_fallback.return_value = (
+        f"{'a' * 40}\trefs/heads/main\n",
+        winning,
+    )
+    downloader.auth_resolver = auth_resolver
+
+    assert gdv._ref_exists_via_ls_remote(
+        downloader,
+        dep_ref,
+        "main",
+        lambda _message: None,
+    ) == (True, winning)
+    assert auth_resolver.try_with_fallback.call_args.kwargs["host_type"] == "gitlab"
+
+
 class TestRound3SafeRmtreeNotRobustRmtreeDirect:
     """Round-3: cleanup MUST go through safe_rmtree (containment gate)."""
 

--- a/tests/unit/deps/test_github_downloader_validation.py
+++ b/tests/unit/deps/test_github_downloader_validation.py
@@ -24,6 +24,18 @@ from apm_cli.deps.github_downloader import GitHubPackageDownloader
 from apm_cli.models.apm_package import DependencyReference
 
 
+def _git_config_value(env: dict[str, str], expected_key: str) -> str:
+    """Return one indexed Git config value by its exact key."""
+    count = int(env.get("GIT_CONFIG_COUNT", "0"))
+    matches = [
+        env.get(f"GIT_CONFIG_VALUE_{index}", "")
+        for index in range(count)
+        if env.get(f"GIT_CONFIG_KEY_{index}", "").lower() == expected_key.lower()
+    ]
+    assert len(matches) == 1
+    return matches[0]
+
+
 def _make_subdir_dep(
     repo_url: str = "owner/repo",
     vpath: str = "skills/my-skill",
@@ -235,8 +247,7 @@ class TestAdoBearerHeaderInjection:
 
         assert secret not in url, "ADO PAT must not appear in the URL"
         # The env must carry the Basic header.
-        assert env.get("GIT_CONFIG_KEY_0") == "http.extraheader"
-        header_value = env.get("GIT_CONFIG_VALUE_0", "")
+        header_value = _git_config_value(env, "http.extraheader")
         assert header_value.startswith("Authorization: Basic "), header_value
         # base64(":<PAT>") must contain the expected encoded form.
         import base64
@@ -277,7 +288,7 @@ class TestAdoBearerHeaderInjection:
         assert len(ado_attempts) == 1
         _label, url, env = ado_attempts[0]
         assert secret not in url
-        header_value = env.get("GIT_CONFIG_VALUE_0", "")
+        header_value = _git_config_value(env, "http.extraheader")
         assert header_value == f"Authorization: Bearer {secret}"
 
     def test_non_ado_token_uses_header_not_url(self) -> None:
@@ -317,17 +328,10 @@ class TestAdoBearerHeaderInjection:
             "Round-3 security: non-ADO token must not be embedded in the URL"
         )
 
-        labels = [a.label for a in attempts]
-        # Header label, no longer the bare 'authenticated HTTPS'.
-        assert any(lbl == "authenticated HTTPS (header)" for lbl in labels), labels
-
-        auth_attempts = [a for a in attempts if a.label == "authenticated HTTPS (header)"]
-        assert len(auth_attempts) == 1
-        _label, url, env = auth_attempts[0]
+        assert [attempt.label for attempt in attempts] == ["anonymous GitHub HTTPS"]
+        _label, url, env = attempts[0]
         assert secret not in url
-        # Header carries the token.
-        header_value = env.get("GIT_CONFIG_VALUE_0", "")
-        assert header_value == f"Authorization: Bearer {secret}"
+        assert _git_config_value(env, "credential.helper") == ""
 
     def test_gitlab_pat_injected_as_oauth2_basic_header_not_url(self) -> None:
         """GitLab validation matches oauth2 PAT clone semantics without URL userinfo."""
@@ -357,7 +361,7 @@ class TestAdoBearerHeaderInjection:
         assert len(gitlab_attempts) == 1
         _label, url, env = gitlab_attempts[0]
         assert secret not in url
-        header_value = env.get("GIT_CONFIG_VALUE_0", "")
+        header_value = _git_config_value(env, "http.extraheader")
         assert header_value.startswith("Authorization: Basic "), header_value
 
         import base64
@@ -472,10 +476,8 @@ class TestRound3NonAdoTokenNotInProcessArgv:
 
         for attempt in attempts:
             assert secret not in attempt.url, f"Token leaked into URL for attempt '{attempt.label}'"
-        # Header injection: the auth attempt env must contain a Bearer header.
-        auth_attempt = next(a for a in attempts if "header" in a.label)
-        assert auth_attempt.env.get("GIT_CONFIG_KEY_0") == "http.extraheader"
-        assert auth_attempt.env["GIT_CONFIG_VALUE_0"] == f"Authorization: Bearer {secret}"
+        assert [attempt.label for attempt in attempts] == ["anonymous GitHub HTTPS"]
+        assert _git_config_value(attempts[0].env, "credential.helper") == ""
 
 
 class TestRound3SafeRmtreeNotRobustRmtreeDirect:

--- a/tests/unit/install/phases/test_resolve_ref_resolver_reuse.py
+++ b/tests/unit/install/phases/test_resolve_ref_resolver_reuse.py
@@ -21,6 +21,16 @@ from apm_cli.install.phases.resolve import _maybe_resolve_git_semver
 from apm_cli.models.dependency.reference import DependencyReference
 
 
+def _authorization_config_values(env: dict[str, str]) -> set[str]:
+    """Return only indexed Git config values whose key is an auth header."""
+    count = int(env.get("GIT_CONFIG_COUNT", "0"))
+    return {
+        env.get(f"GIT_CONFIG_VALUE_{index}", "")
+        for index in range(count)
+        if "extraheader" in env.get(f"GIT_CONFIG_KEY_{index}", "").lower()
+    }
+
+
 def _semver_dep(repo_url: str, virtual_path: str) -> DependencyReference:
     """A git-source semver-range dep (ref_kind == 'semver')."""
     return DependencyReference(
@@ -360,9 +370,7 @@ def test_semver_resolution_preserves_bearer_and_basic_auth_schemes():
     assert {resolver._auth_scheme for resolver in cache.values()} == {"basic", "bearer"}
     ado_args, ado_kwargs = calls[0]
     github_args, github_kwargs = calls[1]
-    ado_auth_values = {
-        value for key, value in ado_kwargs["env"].items() if key.startswith("GIT_CONFIG_VALUE_")
-    }
+    ado_auth_values = _authorization_config_values(ado_kwargs["env"])
     assert ado_auth_values == {f"Authorization: Bearer {bearer_token}"}
     assert urlparse(ado_args[-1]).username is None
     assert urlparse(github_args[-1]).password == basic_token
@@ -437,9 +445,7 @@ def test_semver_ref_resolution_retries_rejected_ado_pat_with_bearer():
 
     def _run(args, **kwargs):
         calls.append((args, kwargs))
-        auth_values = {
-            value for key, value in kwargs["env"].items() if key.startswith("GIT_CONFIG_VALUE_")
-        }
+        auth_values = _authorization_config_values(kwargs["env"])
         if any("Bearer " in value for value in auth_values):
             return SimpleNamespace(
                 returncode=0,
@@ -465,8 +471,7 @@ def test_semver_ref_resolution_retries_rejected_ado_pat_with_bearer():
     assert resolution.resolved_tag == "v1.2.0"
     assert len(calls) == 2
     auth_headers = [
-        {value for key, value in call_kwargs["env"].items() if key.startswith("GIT_CONFIG_VALUE_")}
-        for _call_args, call_kwargs in calls
+        _authorization_config_values(call_kwargs["env"]) for _call_args, call_kwargs in calls
     ]
     assert len(auth_headers[0]) == 1
     assert next(iter(auth_headers[0])).startswith("Authorization: Basic ")

--- a/tests/unit/install/test_validation_transient_probe.py
+++ b/tests/unit/install/test_validation_transient_probe.py
@@ -69,7 +69,12 @@ def _run_probe(
         patch("apm_cli.deps.registry_proxy.is_enforce_only", return_value=False),
     ):
         if probe_path == "primary":
-            dep_ref = SimpleNamespace(host="github.com", port=None, repo_url="owner/repo")
+            dep_ref = SimpleNamespace(
+                host="github.com",
+                port=None,
+                repo_url="owner/repo",
+                host_type=None,
+            )
             result = validation._validate_github_package(
                 dep_ref,
                 resolver,

--- a/tests/unit/test_auth_scoping.py
+++ b/tests/unit/test_auth_scoping.py
@@ -269,7 +269,7 @@ class TestCloneWithFallbackEnv:
             assert cfg_path == "/dev/null"
 
     def test_github_host_no_token_allows_credential_helpers(self):
-        """For GitHub hosts WITHOUT a token, env is relaxed so credential helpers work."""
+        """GitHub anonymous-first blocks credential helpers before the request."""
         dl = _make_downloader(github_token=None)
         dep = _dep("https://github.com/owner/repo.git")
 
@@ -277,9 +277,10 @@ class TestCloneWithFallbackEnv:
         assert len(calls) >= 1
 
         env_used = calls[0][1].get("env", calls[0].kwargs.get("env"))
-        assert "GIT_ASKPASS" not in env_used
-        assert "GIT_CONFIG_GLOBAL" not in env_used
-        assert "GIT_CONFIG_NOSYSTEM" not in env_used
+        assert env_used.get("GIT_ASKPASS") == "echo"
+        assert env_used.get("GIT_CONFIG_NOSYSTEM") == "1"
+        assert env_used.get("GIT_CONFIG_KEY_0") == "credential.helper"
+        assert env_used.get("GIT_CONFIG_VALUE_0") == ""
         assert env_used.get("GIT_TERMINAL_PROMPT") == "0"
 
     def test_generic_host_explicit_https_strict_no_ssh_fallback(self):
@@ -314,13 +315,13 @@ class TestCloneWithFallbackEnv:
         )
 
     def test_github_host_with_token_tries_method1_first(self):
-        """GitHub with a token → Method 1 (auth HTTPS) is tried first."""
+        """GitHub with a token still tries anonymous HTTPS first."""
         dl = _make_downloader(github_token="ghp_TESTTOKEN")
         dep = _dep("https://github.com/owner/repo.git")
 
         calls = self._run_clone(dl, dep, succeed_on=1)
         first_url = calls[0][0][0]
-        assert "ghp_TESTTOKEN" in first_url
+        assert "ghp_TESTTOKEN" not in first_url
         assert _url_host(first_url) == "github.com"
 
     def test_insecure_http_dep_is_strict_by_default(self):
@@ -459,14 +460,10 @@ class TestCloneWithFallbackEnv:
         assert "ConnectTimeout" in relaxed["GIT_SSH_COMMAND"]
 
     def test_allow_fallback_env_is_per_attempt_not_per_dep(self):
-        """In a mixed allow_fallback plan, only token-bearing attempts get the
-        locked-down env; SSH and plain-HTTPS attempts get the relaxed env so
-        user credential helpers (gh auth, Keychain, ssh-agent) keep working.
+        """A non-auth HTTPS failure stays anonymous before SSH fallback.
 
-        Regression for the Wave 2 panel finding: previously the env was decided
-        once per dependency from `has_token`, so SSH attempts in a token-having
-        dep ran with `GIT_ASKPASS=echo` and `GIT_CONFIG_GLOBAL=/dev/null`,
-        breaking encrypted-key prompts and credential helpers.
+        The arbitrary ``GitCommandError("failed")`` is not an authentication
+        signal, so the configured PAT must not be resolved or presented.
         """
         dl = _make_downloader(github_token="ghp_TESTTOKEN")
         dl._allow_fallback = True
@@ -497,9 +494,7 @@ class TestCloneWithFallbackEnv:
                 shutil.rmtree(target, ignore_errors=True)
             calls = MockRepo.clone_from.call_args_list
 
-        # Map URL -> env used. Token-bearing attempts must get locked-down env;
-        # SSH attempts and plain-HTTPS must get the relaxed env. Plain-HTTPS
-        # must NOT embed the token in the URL.
+        # Plain HTTPS is credential-fenced; SSH retains its existing relaxed env.
         assert len(calls) >= 2, f"expected mixed chain, got {len(calls)} attempts"
         seen_auth_https = False
         seen_plain_https = False
@@ -519,17 +514,14 @@ class TestCloneWithFallbackEnv:
                     f"token URL must run with locked-down env; got env={env_used}"
                 )
             else:
-                # Plain HTTPS attempt: must NOT embed the token, and must run
-                # with relaxed env so credential helpers (gh auth, Keychain)
-                # can supply credentials.
+                # Public GitHub HTTPS is anonymous and credential-fenced.
                 seen_plain_https = True
                 assert url.startswith("https://"), url
-                assert "GIT_ASKPASS" not in env_used, (
-                    f"plain HTTPS must run with relaxed env; got env={env_used}"
+                assert env_used.get("GIT_ASKPASS") == "echo", (
+                    f"plain HTTPS must run with a helper fence; got env={env_used}"
                 )
-        assert seen_auth_https and seen_ssh and seen_plain_https, (
-            "expected at least one of each attempt kind in the mixed chain"
-        )
+        assert not seen_auth_https
+        assert seen_ssh and seen_plain_https
 
 
 # ===========================================================================
@@ -1239,10 +1231,10 @@ class TestIsGitHubClassification:
 
 
 class TestSparseCheckoutTokenResolution:
-    """Verify _try_sparse_checkout uses resolve_for_dep() for per-dep tokens."""
+    """Verify sparse checkout follows public GitHub anonymous-first auth."""
 
-    def test_sparse_checkout_uses_per_org_token(self, tmp_path):
-        """Sparse checkout should use per-org token, not the global instance token."""
+    def test_sparse_checkout_starts_anonymous_before_per_org_token(self, tmp_path):
+        """Sparse checkout does not present either configured token initially."""
         org_token = "ghp_ORG_SPECIFIC"
         global_token = "ghp_GLOBAL"
 
@@ -1278,8 +1270,5 @@ class TestSparseCheckoutTokenResolution:
                 dl._try_sparse_checkout(dep, tmp_path / "sparse", "subdir", ref="main")
 
             assert len(captured_urls) == 1, f"Expected 1 URL capture, got {captured_urls}"
-            # The per-org token should be in the URL, not the global one
-            assert org_token in captured_urls[0], (
-                f"Expected org-specific token in sparse checkout URL, got: {captured_urls[0]}"
-            )
+            assert org_token not in captured_urls[0]
             assert global_token not in captured_urls[0]

--- a/tests/unit/test_install_command.py
+++ b/tests/unit/test_install_command.py
@@ -550,11 +550,8 @@ class TestValidationFailureReasonMessages:
         ):
             result = _validate_package_exists("owner/repo/skills/my-skill", verbose=True)
             assert result is False
-            mock_resolve.assert_called_once()
-            mock_build_ctx.assert_called_once()
-            call_args = mock_build_ctx.call_args
-            assert call_args[0][0] == "github.com"  # host
-            assert "owner/repo/skills/my-skill" in call_args[0][1]  # operation
+            mock_resolve.assert_not_called()
+            mock_build_ctx.assert_not_called()
 
     def test_virtual_package_validation_reuses_auth_resolver(self):
         """Virtual package validation should pass its AuthResolver to the downloader."""

--- a/tests/utils/git_credential_shim.py
+++ b/tests/utils/git_credential_shim.py
@@ -1,0 +1,294 @@
+"""Cross-platform Git and gh shims for installed-binary auth tests."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_GIT_SHIM = r"""#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import base64
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+
+def _config_entries():
+    try:
+        count = max(0, int(os.environ.get("GIT_CONFIG_COUNT", "0")))
+    except ValueError:
+        count = 0
+    return [
+        (
+            os.environ.get(f"GIT_CONFIG_KEY_{index}", ""),
+            os.environ.get(f"GIT_CONFIG_VALUE_{index}", ""),
+        )
+        for index in range(count)
+    ]
+
+
+def _append_event(event):
+    path = Path(os.environ["APM_TEST_GIT_SHIM_LOG"])
+    with path.open("a", encoding="utf-8", newline="\n") as handle:
+        handle.write(json.dumps(event, sort_keys=True) + "\n")
+
+
+def _credential_request():
+    body = sys.stdin.read()
+    fields = {}
+    for line in body.splitlines():
+        if "=" in line:
+            key, value = line.split("=", 1)
+            fields[key] = value
+    entries = _config_entries()
+    _append_event(
+        {
+            "event": "credential-fill",
+            "host": fields.get("host"),
+            "path": fields.get("path"),
+            "protocol": fields.get("protocol"),
+            "credential_interactive": [
+                value for key, value in entries if key.lower() == "credential.interactive"
+            ],
+        }
+    )
+    token = os.environ["APM_TEST_GIT_CREDENTIAL"]
+    sys.stdout.write(
+        "protocol=https\n"
+        f"host={fields.get('host', '')}\n"
+        "username=x-access-token\n"
+        f"password={token}\n\n"
+    )
+    return 0
+
+
+def _rewrite_url(value):
+    parsed = urlsplit(value)
+    if parsed.hostname != "github.com":
+        return value, None, None
+    repository_path = parsed.path.lstrip("/").removesuffix(".git")
+    mapping = json.loads(os.environ["APM_TEST_GIT_REMOTE_MAP"])
+    target = mapping.get(repository_path)
+    if target is None:
+        return value, None, None
+    local = urlsplit(target)
+    rewritten = urlunsplit(
+        (
+            local.scheme,
+            local.netloc,
+            local.path,
+            local.query,
+            local.fragment,
+        )
+    )
+    authorization = None
+    if parsed.username is not None:
+        raw = f"{parsed.username}:{parsed.password or ''}".encode("utf-8")
+        authorization = "Authorization: Basic " + base64.b64encode(raw).decode("ascii")
+    return rewritten, {
+        "host": parsed.hostname,
+        "path": repository_path,
+        "authenticated_url": parsed.username is not None,
+    }, authorization
+
+
+def _strip_dumb_http_incompatible_options(args):
+    stripped = []
+    skip_next = False
+    for value in args:
+        if skip_next:
+            skip_next = False
+            continue
+        if value in {"--depth", "--filter", "--shallow-since", "--shallow-exclude"}:
+            skip_next = True
+            continue
+        if value.startswith(
+            ("--depth=", "--filter=", "--shallow-since=", "--shallow-exclude=")
+        ):
+            continue
+        stripped.append(value)
+    return stripped
+
+
+def main():
+    args = sys.argv[1:]
+    if args[:2] == ["credential", "fill"]:
+        return _credential_request()
+
+    rewritten_args = []
+    remotes = []
+    authorizations = []
+    for value in args:
+        rewritten, remote, authorization = _rewrite_url(value)
+        rewritten_args.append(rewritten)
+        if remote is not None:
+            remotes.append(remote)
+        if authorization is not None:
+            authorizations.append(authorization)
+    rewritten_args = _strip_dumb_http_incompatible_options(rewritten_args)
+    for authorization in reversed(authorizations):
+        rewritten_args[:0] = ["-c", f"http.extraHeader={authorization}"]
+
+    entries = _config_entries()
+    _append_event(
+        {
+            "event": "git",
+            "command": args[0] if args else "",
+            "remotes": remotes,
+            "github_token_env": sorted(
+                name
+                for name in os.environ
+                if name in {"GH_TOKEN", "GITHUB_APM_PAT", "GITHUB_TOKEN"}
+                or name.startswith("GITHUB_APM_PAT_")
+            ),
+            "git_token_present": "GIT_TOKEN" in os.environ,
+            "auth_config_present": any(
+                "extraheader" in key.lower()
+                or value.strip().lower().startswith("authorization:")
+                for key, value in entries
+            ),
+            "credential_helpers": [
+                value for key, value in entries if key.lower() == "credential.helper"
+            ],
+            "credential_interactive": [
+                value for key, value in entries if key.lower() == "credential.interactive"
+            ],
+        }
+    )
+    completed = subprocess.run(
+        [os.environ["APM_TEST_REAL_GIT"], *rewritten_args],
+        env=os.environ,
+        check=False,
+    )
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+"""
+
+_GH_SHIM = r"""#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+path = Path(os.environ["APM_TEST_GIT_SHIM_LOG"])
+with path.open("a", encoding="utf-8", newline="\n") as handle:
+    handle.write(
+        json.dumps(
+            {
+                "event": "gh",
+                "command": sys.argv[1:],
+            },
+            sort_keys=True,
+        )
+        + "\n"
+    )
+raise SystemExit(1)
+"""
+
+
+@dataclass(frozen=True)
+class GitCredentialShim:
+    """Paths and child environment for one credential-recording shim."""
+
+    root: Path
+    log_path: Path
+    environment: dict[str, str]
+
+    def events(self) -> tuple[dict[str, object], ...]:
+        """Read all recorded shim events."""
+        if not self.log_path.exists():
+            return ()
+        return tuple(
+            json.loads(line)
+            for line in self.log_path.read_text(encoding="utf-8").splitlines()
+            if line
+        )
+
+
+class GitCredentialShimFactory:
+    """Create a PATH-prepended Git/gh shim without replacing real Git."""
+
+    def __init__(self, root: Path) -> None:
+        self._root = root
+
+    def create(
+        self,
+        *,
+        base_env: dict[str, str],
+        real_git: Path,
+        remote_map: dict[str, str],
+        credential: str = "fixture-private-token",
+    ) -> GitCredentialShim:
+        """Write shims and return their complete subprocess environment."""
+        self._root.mkdir(parents=True, exist_ok=False)
+        log_path = self._root / "events.jsonl"
+        git_script = self._root / "git-shim.py"
+        gh_script = self._root / "gh-shim.py"
+        git_script.write_text(_GIT_SHIM, encoding="ascii", newline="\n")
+        gh_script.write_text(_GH_SHIM, encoding="ascii", newline="\n")
+        git_script.chmod(git_script.stat().st_mode | stat.S_IXUSR)
+        gh_script.chmod(gh_script.stat().st_mode | stat.S_IXUSR)
+
+        if os.name == "nt":
+            self._write_windows_launcher("git", git_script)
+            self._write_windows_launcher("gh", gh_script)
+        else:
+            self._write_posix_launcher("git", git_script)
+            self._write_posix_launcher("gh", gh_script)
+
+        environment = dict(base_env)
+        environment["PATH"] = os.pathsep.join((str(self._root), environment.get("PATH", "")))
+        environment["APM_TEST_REAL_GIT"] = str(real_git)
+        environment["APM_TEST_GIT_REMOTE_MAP"] = json.dumps(
+            remote_map,
+            sort_keys=True,
+        )
+        environment["APM_TEST_GIT_CREDENTIAL"] = credential
+        environment["APM_TEST_GIT_SHIM_LOG"] = str(log_path)
+        git_exec_path = subprocess.run(
+            (str(real_git), "--exec-path"),
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=10,
+        ).stdout.strip()
+        if git_exec_path:
+            environment["GIT_EXEC_PATH"] = git_exec_path
+        return GitCredentialShim(
+            root=self._root,
+            log_path=log_path,
+            environment=environment,
+        )
+
+    def _write_posix_launcher(self, name: str, script: Path) -> None:
+        launcher = self._root / name
+        launcher.write_text(
+            f"#!{sys.executable}\n"
+            "import runpy\n"
+            f"runpy.run_path({str(script)!r}, run_name='__main__')\n",
+            encoding="ascii",
+            newline="\n",
+        )
+        launcher.chmod(launcher.stat().st_mode | stat.S_IXUSR)
+
+    def _write_windows_launcher(self, name: str, script: Path) -> None:
+        launcher = self._root / f"{name}.cmd"
+        launcher.write_text(
+            f'@"{sys.executable}" "{script}" %*\r\n',
+            encoding="ascii",
+            newline="",
+        )

--- a/tests/utils/local_git_http_server.py
+++ b/tests/utils/local_git_http_server.py
@@ -1,0 +1,191 @@
+"""Loopback dumb-HTTP Git repository fixtures."""
+
+from __future__ import annotations
+
+import base64
+import functools
+import subprocess
+import threading
+from dataclasses import dataclass
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+from apm_cli.utils.path_security import ensure_path_within
+from tests.utils.local_git_repository import LocalGitRepository
+
+
+@dataclass(frozen=True)
+class GitHttpObservation:
+    """One request observed by the local Git HTTP fixture."""
+
+    method: str
+    path: str
+    authorization_present: bool
+    accepted: bool
+
+
+class _GitHttpServer(ThreadingHTTPServer):
+    """HTTP server state shared with request handlers."""
+
+    daemon_threads = True
+    fixture_root: Path
+    private_repositories: frozenset[str]
+    expected_authorization: str
+    observations: list[GitHttpObservation]
+    observations_lock: threading.Lock
+
+
+class _GitHttpHandler(SimpleHTTPRequestHandler):
+    """Serve dumb-HTTP Git data and hide private repositories anonymously."""
+
+    server: _GitHttpServer
+
+    def do_CONNECT(self) -> None:
+        """Reject HTTPS proxy tunnelling without contacting the target host."""
+        self._record(accepted=False)
+        self.send_error(502, "Hermetic fixture does not proxy external hosts")
+
+    def do_GET(self) -> None:
+        """Serve a file after enforcing the fixture repository policy."""
+        if not self._authorize_request():
+            return
+        super().do_GET()
+
+    def do_HEAD(self) -> None:
+        """Serve metadata after enforcing the fixture repository policy."""
+        if not self._authorize_request():
+            return
+        super().do_HEAD()
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        """Keep hermetic test output silent."""
+
+    def _authorize_request(self) -> bool:
+        repository = self._repository_name()
+        authorization = self.headers.get("Authorization")
+        accepted = (
+            repository not in self.server.private_repositories
+            or authorization == self.server.expected_authorization
+        )
+        self._record(accepted=accepted)
+        if not accepted:
+            self.send_response(401)
+            self.send_header("WWW-Authenticate", 'Basic realm="fixture-private"')
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+        return accepted
+
+    def _repository_name(self) -> str:
+        path = unquote(urlparse(self.path).path).lstrip("/")
+        return path.split("/", 1)[0]
+
+    def _record(self, *, accepted: bool) -> None:
+        observation = GitHttpObservation(
+            method=self.command,
+            path=urlparse(self.path).path,
+            authorization_present=self.headers.get("Authorization") is not None,
+            accepted=accepted,
+        )
+        with self.server.observations_lock:
+            self.server.observations.append(observation)
+
+
+class LocalGitHttpServer:
+    """Running loopback server for one or more bare Git repositories."""
+
+    def __init__(self, server: _GitHttpServer, thread: threading.Thread) -> None:
+        self._server = server
+        self._thread = thread
+
+    @property
+    def proxy_url(self) -> str:
+        """Return a loopback URL suitable for HTTPS_PROXY."""
+        return f"http://127.0.0.1:{self._server.server_port}"
+
+    @property
+    def observations(self) -> tuple[GitHttpObservation, ...]:
+        """Return a stable snapshot of observed HTTP requests."""
+        with self._server.observations_lock:
+            return tuple(self._server.observations)
+
+    def remote_url(self, repository: LocalGitRepository) -> str:
+        """Return the local dumb-HTTP URL for *repository*."""
+        return f"{self.proxy_url}/{repository.origin.name}"
+
+    def close(self) -> None:
+        """Stop the server and release its loopback socket."""
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=10)
+        if self._thread.is_alive():
+            raise RuntimeError("Local Git HTTP server did not stop")
+
+    def __enter__(self) -> LocalGitHttpServer:
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        self.close()
+
+
+class LocalGitHttpServerFactory:
+    """Publish owned bare repositories through one loopback HTTP server."""
+
+    def __init__(
+        self,
+        root: Path,
+        *,
+        real_git: Path,
+        env: dict[str, str],
+    ) -> None:
+        self._root = root.resolve()
+        self._real_git = real_git.resolve()
+        self._env = dict(env)
+
+    def start(
+        self,
+        repositories: tuple[LocalGitRepository, ...],
+        *,
+        password: str,
+        private_repositories: tuple[LocalGitRepository, ...] = (),
+        username: str = "x-access-token",
+    ) -> LocalGitHttpServer:
+        """Prepare and serve repositories with optional Basic-auth policy."""
+        if not repositories:
+            raise ValueError("At least one repository is required")
+        private_names = {repository.origin.name for repository in private_repositories}
+        repository_names = {repository.origin.name for repository in repositories}
+        if not private_names <= repository_names:
+            raise ValueError("Private repositories must be included in repositories")
+
+        for repository in repositories:
+            ensure_path_within(repository.origin, self._root)
+            subprocess.run(
+                (
+                    str(self._real_git),
+                    "--git-dir",
+                    str(repository.origin),
+                    "update-server-info",
+                ),
+                env=self._env,
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=30,
+            )
+
+        credentials = base64.b64encode(f"{username}:{password}".encode("ascii")).decode("ascii")
+        handler = functools.partial(_GitHttpHandler, directory=str(self._root))
+        server = _GitHttpServer(("127.0.0.1", 0), handler)
+        server.fixture_root = self._root
+        server.private_repositories = frozenset(private_names)
+        server.expected_authorization = f"Basic {credentials}"
+        server.observations = []
+        server.observations_lock = threading.Lock()
+        thread = threading.Thread(
+            target=server.serve_forever,
+            name="local-git-http",
+            daemon=True,
+        )
+        thread.start()
+        return LocalGitHttpServer(server, thread)


### PR DESCRIPTION
# fix(auth): try public GitHub anonymously before resolving credentials

## TL;DR

`apm install --target copilot` now makes the first HTTPS validation and fetch attempt for public `github.com` dependencies anonymously, even when a PAT or credential manager is available. Credentials are resolved once, with the repository path, only after a 401, 403, 404, or equivalent Git auth failure; connectivity and throttle failures do not prompt. GHE, GHES, ADO, SSH, local paths, GitLab, and generic hosts keep their existing behavior.

> [!NOTE]
> Reported by @RuiRomano in #2400. Closes #2400.

## Problem (WHY)

- [x] An all-public, multi-dependency graph triggered repeated Git Credential Manager dialogs on Windows before APM proved credentials were needed ([#2400](https://github.com/microsoft/apm/issues/2400)).
- [x] `AuthResolver.try_with_fallback(unauth_first=True)` still called `resolve()` before the anonymous request, so its name did not match its observable behavior.
- [x] Clone, sparse-checkout, ref, cache, and virtual-file paths could resolve credentials independently, multiplying prompts across phases and dependencies.
- [x] The prior anonymous Git environment removed headers but still allowed native credential helpers to activate.
- [!] Broad failure fallback risked treating DNS, TLS, timeout, or GitHub throttle failures as requests for authentication.

The fix keeps behavior grounded in executable evidence because ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/).

## Approach (WHAT)

| # | Fix | Principle | Source |
|---:|---|---|---|
| 1 | Extend `AuthResolver` as the single owner of the exact `github.com` decision, anonymous environment, and auth-failure classifier. | "Favor small, chainable primitives over monolithic frameworks." | [PROSE](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |
| 2 | Route every GitHub HTTPS consumer through that owner instead of repeating hostname or credential policy. | "agents pattern-match well against concrete structures" | [Agent Skills](https://agentskills.io/skill-creation/best-practices) |
| 3 | Lock the behavior with poisoned-env unit tests, installed-CLI lifecycles, mutation breaks, and AC20 architecture enforcement. | "do the work, run a validator (a script, a reference checklist, or a self-check), fix any issues, and repeat until validation passes." | [Agent Skills](https://agentskills.io/skill-creation/best-practices) |

## Implementation (HOW)

| Area | Files | Change |
|---|---|---|
| Canonical auth owner | `src/apm_cli/core/auth.py` | Adds exact-host anonymous-first selection, a credential-free Git environment, narrow auth-failure classification, path-scoped fallback, and cache-state inspection. |
| Git environment | `src/apm_cli/deps/git_auth_env.py` | Reuses one cross-platform empty-global-config path; Windows receives a real empty file and `GIT_ASKPASS=echo`. |
| Git consumers | `clone_engine.py`, `git_reference_resolver.py`, `github_downloader.py`, `github_downloader_validation.py` | Starts GitHub HTTPS clone, ref, cache, sparse, and validation operations anonymously; an auth-shaped failure re-enters the existing authenticated path. |
| HTTP consumers | `download_strategies.py`, `install/validation.py` | Sends no Authorization header on the first API/raw request and keeps throttle/connectivity failures out of credential resolution. |
| Architecture boundary | `.apm/instructions/architecture.instructions.md`, `.github/instructions/architecture.instructions.md`, `scripts/lint-architecture-boundaries.sh`, `test_architecture_authorities.py` | Extends the existing host-and-credential owner and adds AC20 plus a duplicate-owner mutation test. |
| Hermetic lifecycle | `test_public_github_anonymous_lifecycle_e2e.py`, `git_credential_shim.py`, `local_git_http_server.py` | Uses the installed CLI, local bare repos, dumb HTTP, a rejecting HTTPS proxy, and credential shims to prove public and private flows without external network access. |
| Call-shape coverage | `test_public_github_anonymous_first.py` and updated auth/downloader tests | Verifies no PAT/header/helper leakage, exact fallback scope, GHE/ADO compatibility, rate-limit handling, and non-auth Git config preservation. |
| Test taxonomy | `critical_suite.toml`, `test_test_taxonomy.py` | Classifies the installed lifecycle as E2E and advances the finite manifest count. |
| User docs | `docs/.../authentication.md`, `packages/apm-guide/.../authentication.md` | Documents the anonymous-first exception, private fallback, cache reuse, and unchanged host classes; updates the canonical Mermaid flow. |
| Release and self-integrity | `CHANGELOG.md`, `apm.lock.yaml` | Credits the reporter, records the user-visible fix, and refreshes the mirrored architecture-instruction hash. |

> [!IMPORTANT]
> Suggested review order:
> 1. `AuthResolver.try_with_fallback` for lazy resolution and failure classification.
> 2. `CloneEngine.execute` for the anonymous-to-authenticated transition.
> 3. The installed lifecycle test for observable prompt and leakage evidence.
> 4. AC20 for the long-term single-owner boundary.

The remaining files adapt existing consumers and proofs to that owner.

## Diagrams

Legend: the highlighted block shows the new network ordering and the only branch that may activate `AuthResolver`.

```mermaid
sequenceDiagram
    participant CLI as apm install
    participant GH as github.com
    participant AR as AuthResolver

    rect rgb(255, 247, 200)
        Note over CLI,AR: NEW: no credential resolution before first HTTPS attempt
        CLI->>GH: Anonymous validation or fetch
        alt Public repository succeeds
            GH-->>CLI: 2xx or Git success
        else Private-repository-shaped failure
            GH-->>CLI: 401, 403, 404, or Git auth failure
            CLI->>AR: Resolve host, org, and path once
            AR-->>CLI: Scoped credential
            CLI->>GH: Authenticated retry
            GH-->>CLI: Success or auth error
        else Connectivity or throttle failure
            GH-->>CLI: DNS, TLS, timeout, or throttle
            CLI-->>CLI: Surface without resolving credentials
        end
    end
```

## Trade-offs

- **Anonymous-first instead of token-first on `github.com`.** This avoids prompts and EMU-token interference for public repos; the cost is one failed anonymous round trip before a private repo uses its cached credential.
- **Exact host classification instead of `has_public_repos`.** Only public GitHub Cloud changes. GHES, GHE Cloud, ADO, GitLab, and generic hosts retain their established contracts.
- **Process-scoped config preservation instead of user config inheritance.** Harmless injected settings such as CA paths, URL rewrites, and `credential.interactive=never` survive, while global/system config and helpers are fenced for the anonymous attempt.
- **One shared fixture stack instead of mocked lifecycle calls.** The test support is larger, but it crosses the installed CLI, Git subprocess, HTTP server, and credential protocol boundaries without secrets or internet access.
- **No README edit.** The README does not describe this ordering; the canonical authentication guide and shipped `apm-usage` resource are the directly related surfaces.
- **No OpenAPM artifact change.** `apm-spec-waiver: Internal authentication retry ordering only; no OpenAPM artifact contract change.`

## Benefits

1. Public install, repeat install, update, and audit produce zero `gh auth token` or `git credential fill` calls in the installed-CLI lifecycle.
2. One private dependency produces exactly one `path=owner/repo` credential-fill call, then reuses the cached context across later phases.
3. Anonymous Git attempts contain zero GitHub token variables, zero Authorization headers, and an empty `credential.helper`.
4. 401/403/404 and Git auth failures retry; DNS, TLS, timeout, HTTP 429, and typed 403 throttles do not.
5. AC20 rejects a second implementation of the public-GitHub ordering outside `AuthResolver`.

## Validation

`uv run --frozen --extra dev pytest -q tests/unit tests/test_console.py tests/red_team -n 2 --dist worksteal`:

```text
19373 passed, 2 skipped, 21 xfailed, 19 warnings, 88 subtests passed
```

`APM_E2E_TESTS=1 APM_BINARY_PATH=.venv/bin/apm uv run --frozen --extra dev pytest -p no:cacheprovider -q --strict-markers tests/integration/test_public_github_anonymous_lifecycle_e2e.py`:

```text
2 passed
```

<details><summary>Additional exact-head gates</summary>

```text
Auth owner tests: 43 passed
Test quality: 45 passed
Ruff check: clean
Ruff format: 1554 files already formatted
Pylint R0801: 10.00/10
Auth-signal lint: clean
Architecture boundary lint AC1-AC20: clean
Assertion-quality ratchet: clean
Exact-duplicate ratchet: clean
```

Mutation-break evidence:

```text
Eager AuthResolver before public clone -> public lifecycle failed on credential-fill count.
Private fallback removed -> private lifecycle failed to install.
AC20 removed -> duplicate-owner architecture test failed.
All guards restored -> unit, lifecycle, and architecture tests passed.
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | Install an all-public multi-dependency GitHub graph without any auth dialog or token leakage. | Secure by default, DevX | `tests/integration/test_public_github_anonymous_lifecycle_e2e.py::test_all_public_graph_lifecycle_never_resolves_or_leaks_credentials` (regression-trap for #2400) | e2e |
| 2 | Install one private GitHub dependency with one scoped credential lookup and a successful retry. | Secure by default, DevX | `tests/integration/test_public_github_anonymous_lifecycle_e2e.py::test_private_github_fallback_resolves_once_and_completes_lifecycle` | e2e |
| 3 | Keep GHE Cloud auth-first and do not reinterpret connectivity or throttling as authentication. | Vendor-neutral, Secure by default | `tests/unit/core/test_public_github_anonymous_first.py::test_ghe_cloud_https_keeps_existing_auth_first_behavior`<br/>`::test_public_github_connectivity_and_throttle_failures_never_resolve` | unit |
| 4 | Preserve Windows non-interactive Git policy without treating every config value as an auth header. | Portability by manifest, Secure by default | `tests/unit/core/test_public_github_anonymous_first.py::test_public_github_success_never_resolves_or_leaks_credentials` | unit |

## How to test

- [ ] Run the two lifecycle tests with `APM_E2E_TESTS=1`; expect `2 passed`.
- [ ] Run `tests/unit/core/test_public_github_anonymous_first.py`; expect `43 passed`.
- [ ] Run `bash scripts/lint-architecture-boundaries.sh`; expect AC20 and a clean exit.
- [ ] Optionally run the full unit command above; expect the recorded 19,373-pass result.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>