### PR TITLE
fix(deps): preserve mixed-case materialization paths

### DIFF
--- a/.apm/instructions/architecture.instructions.md
+++ b/.apm/instructions/architecture.instructions.md
@@ -55,6 +55,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | Windows stable executable path | install.ps1 ($currentDir / $currentExe) | `install.ps1` |
 | Git repository cache-key normalization | cache/url_normalize.py (normalize_repo_url / cache_shard_key) | `src/apm_cli/cache/url_normalize.py` |
 | Self-update release -> installer ref + VERSION | commands/self_update.py (_ResolvedSelfUpdateRelease) | `src/apm_cli/commands/self_update.py` |
+| Dependency comparison identity vs display-cased materialization path | models/dependency/identity.py + materialization.py + DependencyReference | `src/apm_cli/models/dependency/identity.py`; `src/apm_cli/models/dependency/materialization.py`; `src/apm_cli/models/dependency/reference.py` |
 | Cached policy shape | policy/discovery.py (_policy_to_dict via _serialize_policy) | `src/apm_cli/policy/discovery.py` |
 | Post-uninstall dependency reachability | deps/reachability.py (compute_forward_reachable_keys) | `src/apm_cli/deps/reachability.py` |
 | CI audit scratch materialization | install/audit_replay.py (prepare_ci_audit_replay) | `src/apm_cli/install/audit_replay.py` |

--- a/.github/instructions/architecture.instructions.md
+++ b/.github/instructions/architecture.instructions.md
@@ -55,6 +55,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 | Windows stable executable path | install.ps1 ($currentDir / $currentExe) | `install.ps1` |
 | Git repository cache-key normalization | cache/url_normalize.py (normalize_repo_url / cache_shard_key) | `src/apm_cli/cache/url_normalize.py` |
 | Self-update release -> installer ref + VERSION | commands/self_update.py (_ResolvedSelfUpdateRelease) | `src/apm_cli/commands/self_update.py` |
+| Dependency comparison identity vs display-cased materialization path | models/dependency/identity.py + materialization.py + DependencyReference | `src/apm_cli/models/dependency/identity.py`; `src/apm_cli/models/dependency/materialization.py`; `src/apm_cli/models/dependency/reference.py` |
 | Cached policy shape | policy/discovery.py (_policy_to_dict via _serialize_policy) | `src/apm_cli/policy/discovery.py` |
 | Post-uninstall dependency reachability | deps/reachability.py (compute_forward_reachable_keys) | `src/apm_cli/deps/reachability.py` |
 | CI audit scratch materialization | install/audit_replay.py (prepare_ci_audit_replay) | `src/apm_cli/install/audit_replay.py` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   service writes exit non-zero instead of skipping with success.
   (by @ryodocx, closes #2345)
 
+- Mixed-case GitHub dependency paths now retain source casing in
+  `apm_modules/` and generated links while lockfile and deduplication identity
+  stays canonical; reinstall migrates stale case-only paths safely. Reported
+  by @rcollette. (closes #2347)
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview
   now excludes the synthesized lockfile self-entry, matching the real install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mixed-case GitHub dependency paths now retain source casing in
   `apm_modules/` and generated links while lockfile and deduplication identity
   stays canonical; reinstall migrates stale case-only paths safely. Reported
-  by @rcollette. (closes #2347)
+  by @rcollette. (closes #2347, #2409)
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview
   now excludes the synthesized lockfile self-entry, matching the real install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,8 +116,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Mixed-case GitHub dependency paths now retain source casing in
   `apm_modules/` and generated links while lockfile and deduplication identity
-  stays canonical; reinstall migrates stale case-only paths safely. Reported
-  by @rcollette. (closes #2347, #2409)
+  stays canonical; reinstall migrates stale case-only paths safely.
+  `docs/src/content/docs/specs/openapm-v0.1.md` now defines this split in
+  `req-lk-022`. Reported by @rcollette. (closes #2347, #2409)
 - `apm install --dry-run` no longer lists the project's own `includes: auto`
   self-managed files under "Files that would be removed"; the orphan preview
   now excludes the synthesized lockfile self-entry, matching the real install

--- a/CONFORMANCE.json
+++ b/CONFORMANCE.json
@@ -291,6 +291,20 @@
       ]
     },
     {
+      "conformance_class": "consumer",
+      "id": "req-lk-022",
+      "keyword": "MUST",
+      "section": "5.2",
+      "status": "active",
+      "test_count": 4,
+      "tests": [
+        "tests/spec_conformance/test_lockfile_reqs.py::test_lockfile_materialization_spelling_is_non_identity_metadata",
+        "tests/spec_conformance/test_lockfile_reqs.py::test_materialization_spelling_collision_fails_without_deleting_candidates",
+        "tests/spec_conformance/test_lockfile_reqs.py::test_materialization_spelling_does_not_change_lockfile_sort_order",
+        "tests/spec_conformance/test_lockfile_reqs.py::test_materialization_spelling_migrates_one_case_variant_transactionally"
+      ]
+    },
+    {
       "conformance_class": "producer",
       "id": "req-mf-001",
       "keyword": "MUST",
@@ -1210,7 +1224,7 @@
   "spec_version": "v0.1.1",
   "summary_by_class": {
     "consumer": {
-      "active": 76,
+      "active": 77,
       "skipped": 1,
       "unbound": 0,
       "xfail": 0
@@ -1234,5 +1248,5 @@
       "xfail": 0
     }
   },
-  "total_requirements": 106
+  "total_requirements": 107
 }

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -19,7 +19,7 @@ All four conformance classes (Producer, Consumer, Registry, Governance) carry ac
 | Class | Active | Skipped | Xfail | Unbound |
 |-------|-------:|--------:|------:|--------:|
 | Producer | 12 | 0 | 0 | 0 |
-| Consumer | 76 | 1 | 0 | 0 |
+| Consumer | 77 | 1 | 0 | 0 |
 | Registry | 1 | 0 | 0 | 0 |
 | Governance | 16 | 0 | 0 | 0 |
 
@@ -52,6 +52,7 @@ All four conformance classes (Producer, Consumer, Registry, Governance) carry ac
 | [req-lk-019](docs/src/content/docs/specs/openapm-v0.1.md#req-lk-019) | MUST | 5.2 | consumer | active | 1 |
 | [req-lk-020](docs/src/content/docs/specs/openapm-v0.1.md#req-lk-020) | MUST | 5.2 | consumer | active | 2 |
 | [req-lk-021](docs/src/content/docs/specs/openapm-v0.1.md#req-lk-021) | MUST | 5.2 | consumer | active | 1 |
+| [req-lk-022](docs/src/content/docs/specs/openapm-v0.1.md#req-lk-022) | MUST | 5.2 | consumer | active | 4 |
 | [req-mf-001](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-001) | MUST | 4.1 | producer | active | 1 |
 | [req-mf-002](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-002) | MUST | 4.1 | producer | active | 1 |
 | [req-mf-003](docs/src/content/docs/specs/openapm-v0.1.md#req-mf-003) | MUST | 4.1 | producer | active | 1 |

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -2783,7 +2783,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:6baeb73b4acf037915c23a813947c21e01b99c36bc68d032568863dd842f5b92
+  content_hash: sha256:dfc192b55bc69389c960951e981e30a53240fbf83640fa5634545f5a21e12b5d
 - kind: project-relative
   target: copilot
   value: .github/instructions/changelog.instructions.md
@@ -3290,7 +3290,7 @@ local_deployed_file_hashes:
   .github/agents/spec-tag-architect.agent.md: sha256:82907265c5e7cf1ac61ad96866fa7c5683b69c8f09b7a4c5f3cc241acc9568ca
   .github/agents/supply-chain-security-expert.agent.md: sha256:8fb8cc426d6af17ba084a28b3f026c2b475b62e3ca63ed2f88b83bd823f877af
   .github/agents/test-coverage-expert.agent.md: sha256:48c2172d1f18a394fa83ef9dc2be0b9b921a4e51e976498165250fed66369711
-  .github/instructions/architecture.instructions.md: sha256:6baeb73b4acf037915c23a813947c21e01b99c36bc68d032568863dd842f5b92
+  .github/instructions/architecture.instructions.md: sha256:dfc192b55bc69389c960951e981e30a53240fbf83640fa5634545f5a21e12b5d
   .github/instructions/changelog.instructions.md: sha256:1e51ec4c74e847967962bd279dc4c6e582c5d3578490b3c28d5f3acd3e05f73e
   .github/instructions/cicd.instructions.md: sha256:08d87b7d635761cb41deb8fc71d5d83f54678de463db484afb16d2d4f8713ecb
   .github/instructions/cli.instructions.md: sha256:8e39e8d5047ce88575cb02f87c2bcede584dfef258bd86f7466c7badf136541a

--- a/docs/public/specs/manifests/openapm-v0.1.requirements.yml
+++ b/docs/public/specs/manifests/openapm-v0.1.requirements.yml
@@ -208,6 +208,11 @@ requirements:
     section: "5.2"
     conformance_class: consumer
     notes: "extends req-lk-020's preserve/remove decision to merge-based hook configuration and its ownership record"
+  - id: req-lk-022
+    keyword: MUST
+    section: "5.2"
+    conformance_class: consumer
+    notes: "source-cased materialization_repo_url remains non-identity metadata and drives rollback-safe, collision-closed materialization/link spelling"
   - id: req-pl-001
     keyword: MUST
     section: "6.1"

--- a/docs/public/specs/schemas/lockfile-v0.1.schema.json
+++ b/docs/public/specs/schemas/lockfile-v0.1.schema.json
@@ -35,7 +35,13 @@
     "entry": {
       "type": "object",
       "properties": {
-        "repo_url": { "type": "string" },
+        "repo_url": { "type": "string", "minLength": 1 },
+        "materialization_repo_url": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Source-cased repository identifier for materialization; non-identity metadata per req-lk-022.",
+          "$comment": "MUST map to the same canonical identity as repo_url under req-rs-016."
+        },
         "host": { "type": "string" },
         "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
         "registry_prefix": { "type": "string" },

--- a/docs/src/content/docs/concepts/package-anatomy.md
+++ b/docs/src/content/docs/concepts/package-anatomy.md
@@ -210,28 +210,13 @@ Top-level fields:
 | `local_deployed_files`         | Files this package wrote to deployed dirs.     |
 | `local_deployed_file_hashes`   | SHA-256 of each local-deployed file.           |
 
-Per-dependency fields:
-
-| Field                  | Notes                                          |
-|------------------------|------------------------------------------------|
-| `repo_url`             | Canonical clone URL.                           |
-| `host`, `port`         | For non-github.com or non-standard ports.      |
-| `registry_prefix`      | Artifactory-style prefix.                      |
-| `resolved_commit`      | Full SHA. The thing that makes installs reproducible. |
-| `resolved_ref`         | Original tag/branch the SHA was resolved from. |
-| `version`              | SemVer, if the dep is versioned.               |
-| `virtual_path`         | Subpath for single-primitive imports.          |
-| `is_virtual`           | True for primitive-form deps.                  |
-| `depth`                | 1 = direct dependency; >1 = transitive.        |
-| `package_type`         | `apm_package`, `claude_skill`, `hook_package`, `hybrid`, `marketplace_plugin`, `skill_bundle`. |
-| `deployed_files`       | Files this dep wrote to your tree.             |
-| `deployed_file_hashes` | SHA-256 of each deployed file.                 |
-| `source`, `local_path` | Set for `local_path:` deps.                    |
-| `content_hash`         | SHA-256 of the package file tree.              |
-| `is_dev`               | True for `devDependencies` entries.            |
-
-See the [lockfile specification](../../reference/lockfile-spec/#per-entry-fields)
-for package-type-specific `name` and `version` semantics.
+Each dependency stores canonical identity and resolution data. For
+case-insensitive providers, `repo_url` is the canonical comparison value while
+the optional `materialization_repo_url` retains the repository display spelling
+used under `apm_modules/` and in generated links. The
+[lockfile specification](../../reference/lockfile-spec/#per-entry-fields) is the
+single field reference, including package-type-specific `name` and `version`
+semantics.
 
 `apm audit` rehashes everything in `deployed_file_hashes` and
 `local_deployed_file_hashes` to detect hand-edits before they ship.

--- a/docs/src/content/docs/consumer/manage-dependencies.md
+++ b/docs/src/content/docs/consumer/manage-dependencies.md
@@ -68,10 +68,12 @@ parser. The supported forms:
 | Registry object form | `{ id: owner/repo, version: ^2.0.0 }` | Explicit registry dep. `registry:` optional when a default registry is configured. Requires `registries` experimental flag. |
 
 GitHub and package-registry owner/repository identifiers are normalized to
-lowercase before APM derives lock keys, cache identity, canonical strings, or
-`apm_modules/` paths. For example, `Owner/Repo` and `owner/repo` install as one
-package at `apm_modules/owner/repo`. Repository path casing is preserved for
-unknown git hosts because a self-hosted backend may be case-sensitive.
+lowercase only for comparison, lock keys, and cache identity. Materialization
+and generated links retain the source spelling: `Owner/Repo` installs at
+`apm_modules/Owner/Repo`, while `owner/repo` still compares as the same package.
+A reinstall migrates stale APM-created case variants before rewriting managed
+links. Repository path casing also remains identity-significant for unknown git
+hosts because a self-hosted backend may be case-sensitive.
 
 Object form in YAML — three mutually exclusive keys select the variant
 (`git`, `path`, or `marketplace`):

--- a/docs/src/content/docs/consumer/manage-dependencies.md
+++ b/docs/src/content/docs/consumer/manage-dependencies.md
@@ -68,12 +68,16 @@ parser. The supported forms:
 | Registry object form | `{ id: owner/repo, version: ^2.0.0 }` | Explicit registry dep. `registry:` optional when a default registry is configured. Requires `registries` experimental flag. |
 
 GitHub and package-registry owner/repository identifiers are normalized to
-lowercase only for comparison, lock keys, and cache identity. Materialization
-and generated links retain the source spelling: `Owner/Repo` installs at
+lowercase only for comparison, lock keys, and cache identity. APM retains the
+**repository display spelling** selected by the first declaration in `apm.yml`,
+`apm_modules/`, and generated links: `Owner/Repo` installs at
 `apm_modules/Owner/Repo`, while `owner/repo` still compares as the same package.
-A reinstall migrates stale APM-created case variants before rewriting managed
-links. Repository path casing also remains identity-significant for unknown git
-hosts because a self-hosted backend may be case-sensitive.
+A reinstall migrates one stale APM-created case variant before rewriting managed
+links. If multiple case-equivalent package directories exist, install stops for
+manual inspection; follow the
+[migration recovery steps](../../troubleshooting/migration/#mixed-case-github-package-paths).
+Repository path casing remains identity-significant for unknown git hosts
+because a self-hosted backend may be case-sensitive.
 
 Object form in YAML — three mutually exclusive keys select the variant
 (`git`, `path`, or `marketplace`):

--- a/docs/src/content/docs/producer/package-relative-links.md
+++ b/docs/src/content/docs/producer/package-relative-links.md
@@ -42,6 +42,12 @@ See [design patterns](../../apm_modules/<owner>/my-pkg/references/patterns.md).
 The package itself stays intact under `apm_modules/`; the deployed
 primitive points back into it.
 
+The `<owner>/<repo>` spelling matches the dependency source, including case.
+APM lowercases GitHub coordinates only for identity comparison; it never uses
+that comparison key in the generated relative link. Reinstall also repairs
+stale APM-managed links and case-only materialization paths without replacing
+user-authored files.
+
 ## What APM rewrites
 
 A markdown link with text `[text]` and target `(path)` is rewritten only

--- a/docs/src/content/docs/producer/package-relative-links.md
+++ b/docs/src/content/docs/producer/package-relative-links.md
@@ -42,11 +42,13 @@ See [design patterns](../../apm_modules/<owner>/my-pkg/references/patterns.md).
 The package itself stays intact under `apm_modules/`; the deployed
 primitive points back into it.
 
-The `<owner>/<repo>` spelling matches the dependency source, including case.
-APM lowercases GitHub coordinates only for identity comparison; it never uses
-that comparison key in the generated relative link. Reinstall also repairs
-stale APM-managed links and case-only materialization paths without replacing
-user-authored files.
+The `<owner>/<repo>` spelling matches the repository display spelling retained
+in `apm.yml`, including case. APM lowercases GitHub coordinates only for
+identity comparison; it never uses that comparison key in the generated
+relative link. Reinstall also repairs stale APM-managed links and one case-only
+materialization path without replacing user-authored files. For collision
+recovery, see
+[Mixed-case GitHub package paths](../../troubleshooting/migration/#mixed-case-github-package-paths).
 
 ## What APM rewrites
 

--- a/docs/src/content/docs/reference/lockfile-spec.md
+++ b/docs/src/content/docs/reference/lockfile-spec.md
@@ -188,6 +188,7 @@ Each item in `dependencies` describes one resolved package.
 | Field | Type | Required | Notes |
 |---|---|---|---|
 | `repo_url` | string | yes | Canonical repository path or URL. Entry identity is derived from `repo_url`, `host`, and virtual/local markers; see [lockfile identity keys](#lockfile-identity-keys). |
+| `materialization_repo_url` | string | no | Source-cased repository path used only for `apm_modules/` materialization and generated links. Omitted when it equals `repo_url`; it must normalize to the same identity and cannot redirect a lock entry. |
 | `host` | string | no | FQDN when not inferable from `repo_url` (e.g. for registry proxies or non-GitHub hosts). |
 | `host_type` | string | no | Explicit host-kind hint, currently `gitlab`, copied from object-form `type: gitlab`. |
 | `port` | int | no | Non-standard SSH/HTTPS port. Validated to `1..65535` on read. |
@@ -244,8 +245,11 @@ logical key because the proxy host is transport, not package identity.
 
 GitHub and package-registry owner/repository paths are lowercased before APM
 derives the key. Older mixed-case GitHub entries therefore serialize with the
-same key as new lowercase references. Repository path casing remains unchanged
-for unknown git hosts because those backends may be case-sensitive.
+same key as new lowercase references. Their source spelling is retained
+separately in `materialization_repo_url`, so filesystem paths and relative links
+do not reuse the lowercase comparison key. Repository path casing remains
+identity-significant for unknown git hosts because those backends may be
+case-sensitive.
 
 ## Self entry
 

--- a/docs/src/content/docs/reference/lockfile-spec.md
+++ b/docs/src/content/docs/reference/lockfile-spec.md
@@ -188,7 +188,7 @@ Each item in `dependencies` describes one resolved package.
 | Field | Type | Required | Notes |
 |---|---|---|---|
 | `repo_url` | string | yes | Canonical repository path or URL. Entry identity is derived from `repo_url`, `host`, and virtual/local markers; see [lockfile identity keys](#lockfile-identity-keys). |
-| `materialization_repo_url` | string | no | Source-cased repository path used only for `apm_modules/` materialization and generated links. Omitted when it equals `repo_url`; it must normalize to the same identity and cannot redirect a lock entry. |
+| `materialization_repo_url` | string | no | Source-cased path that preserves repository display spelling when APM reconstructs the dependency, including for `apm_modules/` materialization and generated links. Omitted when it equals `repo_url`; it must normalize to the same identity and cannot redirect a lock entry. |
 | `host` | string | no | FQDN when not inferable from `repo_url` (e.g. for registry proxies or non-GitHub hosts). |
 | `host_type` | string | no | Explicit host-kind hint, currently `gitlab`, copied from object-form `type: gitlab`. |
 | `port` | int | no | Non-standard SSH/HTTPS port. Validated to `1..65535` on read. |

--- a/docs/src/content/docs/specs/openapm-v0.1.md
+++ b/docs/src/content/docs/specs/openapm-v0.1.md
@@ -136,7 +136,7 @@ between the companion corpus and the implementation.
 
 ### 1.3 Document conventions
 
-- OpenAPM v0.1 carries **106 normative statements** indexed in
+- OpenAPM v0.1 carries **107 normative statements** indexed in
   [Appendix C](#appendix-c-index-of-normative-statements).
 - All on-disk files defined by this specification are **YAML 1.2**
   parsed under the safe subset defined in
@@ -808,6 +808,7 @@ unknown fields on round-trip. Field availability is **monotonic** in
 | Field                     | Notes                                                                           |
 |---------------------------|---------------------------------------------------------------------------------|
 | `repo_url`                | Canonical repo identity. REQUIRED for git-sourced entries. Cache isolation additionally follows [req-rs-016](#req-rs-016). |
+| `materialization_repo_url` | Optional source-cased repository identifier, with the same structure as `repo_url`, used to reconstruct materialization and generated-link paths. See [req-lk-022](#req-lk-022). |
 | `host`                    | FQDN when not inferable from `repo_url`.                                        |
 | `port`                    | Non-standard port. Validated to `1..65535` on read.                             |
 | `registry_prefix`         | Path prefix when resolved via registry proxy.                                   |
@@ -909,6 +910,41 @@ the recorded `resolved_hash` required by [req-lk-013](#req-lk-013).
 The presence of `name` or dependency-`apm.yml`-derived `version` is
 additive and MUST NOT change `lockfile_version` (both are valid in
 `"1"` and `"2"`).
+
+<a id="req-lk-022"></a>
+**[req-lk-022]** A conforming **consumer** implementation that
+case-folds any component of a repository identifier (authority or
+path) for identity comparison and retains a different source spelling
+MUST record that spelling in the optional
+`materialization_repo_url` field. The consumer MUST validate that
+`materialization_repo_url`, under the same host-specific repository
+normalization rule defined by [req-rs-016](#req-rs-016), identifies
+the same package as `repo_url`; a mismatch MUST fail closed. It MUST
+NOT use `materialization_repo_url` as an identity, deduplication,
+cache, sort, or trust key, and its presence MUST NOT change
+`lockfile_version`.
+
+When reconstructing a dependency, materializing it under
+`apm_modules/`, or generating a relative link back to that
+materialization, the consumer MUST prefer the retained source
+spelling. Case-folding applies only to repository-identity path
+components; an in-repository `virtual_path` and virtual-file leaf
+remain case-sensitive. If exactly one existing package path differs
+only in case-foldable repository components, the consumer MUST either
+migrate it transactionally to the retained spelling or fail without
+creating a duplicate. If multiple physical paths match one identity,
+the consumer MUST fail closed without deleting any candidate path.
+
+For this requirement, a transactional migration completes every
+case-only rename before the retained path is used, journals each
+completed rename, and restores the original spelling before returning
+from any caught failure. A consumer MAY use a temporary sibling path
+when its filesystem cannot apply a case-only rename directly; the
+temporary path MUST remain inside the materialization root and MUST
+NOT be treated as an installed package. This rollback contract does
+not claim process-crash atomicity; an interrupted temporary path is
+recovery state that a consumer MUST preserve for inspection rather
+than delete without verification.
 
 <a id="req-lk-020"></a>
 **[req-lk-020]** When an install that is not frozen under
@@ -1216,7 +1252,7 @@ This section's normative statements are:
   [req-lk-014](#req-lk-014), [req-lk-015](#req-lk-015),
   [req-lk-016](#req-lk-016), [req-lk-017](#req-lk-017),
   [req-lk-019](#req-lk-019), [req-lk-020](#req-lk-020),
-  [req-lk-021](#req-lk-021).
+  [req-lk-021](#req-lk-021), [req-lk-022](#req-lk-022).
 - Consumer (SHOULD): [req-lk-007](#req-lk-007),
   [req-lk-018](#req-lk-018).
 
@@ -2719,6 +2755,7 @@ every stored hash, foreclosing algorithm-ambiguity attacks.
 | 15| Cross-repository cache substitution                  | [req-rs-016](#req-rs-016)                                         | Consumer-default  |
 | 16| Silent capability-scope widening via lossy target conversion | [req-tg-006](#req-tg-006); default-visible conversion diagnostic | Consumer-default  |
 | 17| Cross-target primitive deployment                    | [req-tg-008](#req-tg-008), [req-lk-021](#req-lk-021)               | Consumer-default  |
+| 18| Case-collision materialization confusion             | [req-lk-022](#req-lk-022), [req-rs-016](#req-rs-016)               | Consumer-default  |
 
 ### 10.12 Publisher provenance and attestations (reserved for v0.2)
 
@@ -2881,7 +2918,7 @@ conformance statement identifying:
 [req-lk-015](#req-lk-015), [req-lk-016](#req-lk-016),
 [req-lk-017](#req-lk-017), [req-lk-018](#req-lk-018) (SHOULD),
 [req-lk-019](#req-lk-019), [req-lk-020](#req-lk-020),
-[req-lk-021](#req-lk-021),
+[req-lk-021](#req-lk-021), [req-lk-022](#req-lk-022),
 [req-rs-001](#req-rs-001), [req-rs-002](#req-rs-002),
 [req-rs-003](#req-rs-003), [req-rs-004](#req-rs-004),
 [req-rs-005](#req-rs-005), [req-rs-006](#req-rs-006),
@@ -3094,6 +3131,7 @@ tests/fixtures/spec-conformance/
     invalid-no-source-key.yml
     x-extension-roundtrip.yml
   lockfile/
+    materialization-sort-exclusion.yml
     v1-git-only.yml
     v2-with-registry.yml
     round-trip-unknown-fields.yml
@@ -3108,6 +3146,12 @@ Conformance-suite expansion (additional fixtures for archive
 path-traversal, merge-table cases, etc.) tracks here in subsequent
 revisions; the seed set above is the v0.1 minimum that
 implementations can run against immediately.
+
+The lockfile fixture `materialization-sort-exclusion.yml` exercises
+`materialization_repo_url` sort-exclusion while
+`v1-git-only.yml` exercises transactional spelling migration and
+collision refusal through the [req-lk-022](#req-lk-022) conformance
+oracles.
 
 ### 12.5 Round-trip conformance (normative)
 
@@ -3271,6 +3315,7 @@ renumbering of conformance classes.
 | [req-lk-019](#req-lk-019)                | MUST    | 5.2     | consumer    |
 | [req-lk-020](#req-lk-020)                | MUST    | 5.2     | consumer    |
 | [req-lk-021](#req-lk-021)                | MUST    | 5.2     | consumer    |
+| [req-lk-022](#req-lk-022)                | MUST    | 5.2     | consumer    |
 | [req-pl-001](#req-pl-001)                | MUST    | 6.1     | governance  |
 | [req-pl-002](#req-pl-002)                | MUST    | 6.2     | governance  |
 | [req-pl-003](#req-pl-003)                | MUST    | 6.4     | governance  |
@@ -3333,7 +3378,7 @@ renumbering of conformance classes.
 | [req-cf-001](#req-cf-001)                | MUST    | 12.5    | consumer    |
 | [req-cf-002](#req-cf-002)                | MUST    | 12.3    | consumer    |
 
-**Total normative statements: 106** (101 MUST, 5 SHOULD).
+**Total normative statements: 107** (102 MUST, 5 SHOULD).
 
 ---
 
@@ -3365,6 +3410,7 @@ renumbering of conformance classes.
 | 0.1.20  | 2026-07-30 | Defensive amendment of [req-lk-006] (no new normative statement; count remains 104 (99 MUST, 5 SHOULD)): frozen validation now covers direct MCP server names and configurations as well as package pins, runs before lockfile, target-config, deployment, or cache mutation, and rejects manifest dependency mutation. |
 | 0.1.21  | 2026-07-31 | Spec-citation fold for package-declared target restrictions (closes #2321 Mode-B silent-extension gate). Added [req-tg-008] (Section 8.5.3, consumer MUST): a consumer MUST treat a package's declared `target:`/`targets:` field as a restriction-only filter on all target-scoped primitive integration; if the field resolves to a non-empty set that does not contain `all`, the consumer MUST NOT deliver that package's primitives to any active integration target not in the declared set; the filter composes by intersection with the consumer-side per-dependency `targets:` filter and can only narrow, never expand. Section 8.7, Section 11.3.2 Consumer enumeration, and Appendix C updated. Statement count: 104 -> 105 (100 MUST, 5 SHOULD). |
 | 0.1.22  | 2026-07-31 | Spec-citation fold for deterministic configured-host credential isolation (closes #2338). Added [req-sc-013] (Section 10.3, consumer MUST): a consumer selects one effective host class before credential resolution, applies documented deterministic precedence when configuration signals overlap, exposes only credentials belonging to the selected class to requests and child processes, and preserves an explicit non-default port in both transport and credential scope. Clarified [req-sc-005] so this configured override is not prohibited by its default host-class collapse rule. Section 1.3, Section 10.11, Section 11.3.2 Consumer enumeration, and Appendix C updated. Statement count: 105 -> 106 (101 MUST, 5 SHOULD). |
+| 0.1.23  | 2026-07-31 | Spec-citation fold for case-preserving dependency materialization (closes #2347). Added [req-lk-022] (Section 5.2, consumer MUST): a consumer that case-folds repository identity but retains different source spelling records `materialization_repo_url`, validates it maps to the same canonical identity, excludes it from identity/cache/sort/trust decisions, preserves exact virtual-path casing, and either transactionally migrates one stale case variant or fails closed without deleting colliding paths. Defined rollback semantics for case-only rename and preserved interrupted recovery state. Added the field to the lockfile schema and conformance fixture, plus migration and collision conformance oracles. Section 5.7, Section 10.11, Section 11.3.2, and Appendix C updated. Statement count: 106 -> 107 (102 MUST, 5 SHOULD). |
 
 Errata (none at publication).
 

--- a/docs/src/content/docs/specs/openapm-v0.1.md
+++ b/docs/src/content/docs/specs/openapm-v0.1.md
@@ -808,7 +808,7 @@ unknown fields on round-trip. Field availability is **monotonic** in
 | Field                     | Notes                                                                           |
 |---------------------------|---------------------------------------------------------------------------------|
 | `repo_url`                | Canonical repo identity. REQUIRED for git-sourced entries. Cache isolation additionally follows [req-rs-016](#req-rs-016). |
-| `materialization_repo_url` | Optional source-cased repository identifier, with the same structure as `repo_url`, used to reconstruct materialization and generated-link paths. See [req-lk-022](#req-lk-022). |
+| `materialization_repo_url` | Optional source-cased repository identifier following the same host/owner/repo-path grammar as `repo_url`, used to reconstruct materialization and generated-link paths. See [req-lk-022](#req-lk-022). |
 | `host`                    | FQDN when not inferable from `repo_url`.                                        |
 | `port`                    | Non-standard port. Validated to `1..65535` on read.                             |
 | `registry_prefix`         | Path prefix when resolved via registry proxy.                                   |
@@ -923,6 +923,10 @@ the same package as `repo_url`; a mismatch MUST fail closed. It MUST
 NOT use `materialization_repo_url` as an identity, deduplication,
 cache, sort, or trust key, and its presence MUST NOT change
 `lockfile_version`.
+
+> **Note:** When `materialization_repo_url` is absent the consumer
+> derives materialization paths from `repo_url` directly;
+> absence is not an error.
 
 When reconstructing a dependency, materializing it under
 `apm_modules/`, or generating a relative link back to that
@@ -3410,7 +3414,7 @@ renumbering of conformance classes.
 | 0.1.20  | 2026-07-30 | Defensive amendment of [req-lk-006] (no new normative statement; count remains 104 (99 MUST, 5 SHOULD)): frozen validation now covers direct MCP server names and configurations as well as package pins, runs before lockfile, target-config, deployment, or cache mutation, and rejects manifest dependency mutation. |
 | 0.1.21  | 2026-07-31 | Spec-citation fold for package-declared target restrictions (closes #2321 Mode-B silent-extension gate). Added [req-tg-008] (Section 8.5.3, consumer MUST): a consumer MUST treat a package's declared `target:`/`targets:` field as a restriction-only filter on all target-scoped primitive integration; if the field resolves to a non-empty set that does not contain `all`, the consumer MUST NOT deliver that package's primitives to any active integration target not in the declared set; the filter composes by intersection with the consumer-side per-dependency `targets:` filter and can only narrow, never expand. Section 8.7, Section 11.3.2 Consumer enumeration, and Appendix C updated. Statement count: 104 -> 105 (100 MUST, 5 SHOULD). |
 | 0.1.22  | 2026-07-31 | Spec-citation fold for deterministic configured-host credential isolation (closes #2338). Added [req-sc-013] (Section 10.3, consumer MUST): a consumer selects one effective host class before credential resolution, applies documented deterministic precedence when configuration signals overlap, exposes only credentials belonging to the selected class to requests and child processes, and preserves an explicit non-default port in both transport and credential scope. Clarified [req-sc-005] so this configured override is not prohibited by its default host-class collapse rule. Section 1.3, Section 10.11, Section 11.3.2 Consumer enumeration, and Appendix C updated. Statement count: 105 -> 106 (101 MUST, 5 SHOULD). |
-| 0.1.23  | 2026-07-31 | Spec-citation fold for case-preserving dependency materialization (closes #2347). Added [req-lk-022] (Section 5.2, consumer MUST): a consumer that case-folds repository identity but retains different source spelling records `materialization_repo_url`, validates it maps to the same canonical identity, excludes it from identity/cache/sort/trust decisions, preserves exact virtual-path casing, and either transactionally migrates one stale case variant or fails closed without deleting colliding paths. Defined rollback semantics for case-only rename and preserved interrupted recovery state. Added the field to the lockfile schema and conformance fixture, plus migration and collision conformance oracles. Section 5.7, Section 10.11, Section 11.3.2, and Appendix C updated. Statement count: 106 -> 107 (102 MUST, 5 SHOULD). |
+| 0.1.23  | 2026-07-31 | Spec-citation fold for case-preserving dependency materialization (closes #2347). Added [req-lk-022] (Section 5.2, consumer MUST): a consumer that case-folds repository identity but retains different source spelling records `materialization_repo_url`, validates it maps to the same canonical identity, excludes it from identity/cache/sort/trust decisions, preserves exact virtual-path casing, and either transactionally migrates one stale case variant or fails closed without deleting colliding paths. Defined rollback semantics for case-only rename and preserved interrupted recovery state. Added the field to the lockfile schema and conformance fixture, plus migration and collision conformance oracles. Hardened lockfile schema: `repo_url` now carries `minLength: 1` to match the prose requirement that git-sourced entries provide a non-empty canonical identifier ([req-lk-003](#req-lk-003)). Section 5.7, Section 10.11, Section 11.3.2, and Appendix C updated. Statement count: 106 -> 107 (102 MUST, 5 SHOULD). |
 
 Errata (none at publication).
 

--- a/docs/src/content/docs/troubleshooting/migration.md
+++ b/docs/src/content/docs/troubleshooting/migration.md
@@ -77,6 +77,34 @@ Decision matrix:
 
 Schema details: [Lockfile spec](../../reference/lockfile-spec/).
 
+### Mixed-case GitHub package paths
+
+APM keeps GitHub lock and deduplication identity lowercase, but preserves the
+repository display spelling from `apm.yml` in `apm_modules/` and generated
+links. After upgrading, run:
+
+```bash
+apm install --verbose
+apm audit --ci
+```
+
+One stale case-only package directory is renamed transactionally and appears in
+verbose output. APM-managed links are rewritten; files you authored remain
+untouched.
+
+If install reports multiple package directories for one dependency:
+
+1. Stop and back up every named directory.
+2. Compare the directories and the matching `apm.yml` / `apm.lock.yaml` entry.
+3. Keep the directory whose spelling matches `apm.yml`. Remove another only
+   after confirming it is a duplicate and contains no unique edits.
+4. Run `apm install --verbose`, then `apm audit --ci`.
+
+An interrupted case-only rename can leave a hidden
+`.apm-case-migration-<id>` entry beside the package directory. Inspect its
+contents before renaming it back or removing it; APM does not delete an
+unverified recovery entry automatically.
+
 ## 4. Compile strategy migration
 
 The compile step writes per-target output (e.g. `.github/copilot-instructions.md`, `.claude/`, `.cursor/rules/`). Some targets support both a single-file (monolithic) layout and a per-primitive (distributed) layout.

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -44,11 +44,13 @@ dependencies:
 ```
 
 GitHub and package-registry owner/repository identifiers are normalized to
-lowercase only for comparison, lock keys, and cache identity. `Owner/Repo` and
-`owner/repo` therefore identify one package, but materialization and generated
-relative links retain the declared spelling. Reinstall migrates stale
-APM-created case variants. Repository path casing remains identity-significant
-for unknown git hosts because a self-hosted backend may be case-sensitive.
+lowercase only for comparison, lock keys, and cache identity. The first
+declaration selects the repository display spelling retained in `apm.yml`,
+`apm_modules/`, and generated relative links. Reinstall migrates one stale
+APM-created case variant; multiple case-equivalent package directories stop
+install for manual inspection. Repository path casing remains
+identity-significant for unknown git hosts because a self-hosted backend may be
+case-sensitive.
 
 **Local-path anchor rule:** a `local_path` declared INSIDE another local
 package is resolved relative to THAT package's own directory (npm/pip/cargo

--- a/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/dependencies.md
@@ -44,10 +44,11 @@ dependencies:
 ```
 
 GitHub and package-registry owner/repository identifiers are normalized to
-lowercase before APM derives lock keys, cache identity, canonical strings, or
-`apm_modules/` paths. `Owner/Repo` and `owner/repo` therefore identify one
-package. Repository path casing is preserved for unknown git hosts because a
-self-hosted backend may be case-sensitive.
+lowercase only for comparison, lock keys, and cache identity. `Owner/Repo` and
+`owner/repo` therefore identify one package, but materialization and generated
+relative links retain the declared spelling. Reinstall migrates stale
+APM-created case variants. Repository path casing remains identity-significant
+for unknown git hosts because a self-hosted backend may be case-sensitive.
 
 **Local-path anchor rule:** a `local_path` declared INSIDE another local
 package is resolved relative to THAT package's own directory (npm/pip/cargo

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -1317,6 +1317,40 @@ if ! grep -q '^def validate_tag_pattern(' "$tag_pattern_owner" \
     [ -n "$tag_pattern_parallel_hits" ] && echo "$tag_pattern_parallel_hits"
     violations=$((violations + 1))
 fi
+
+echo "[*] AC29: dependency identity and materialization path authority"
+identity_owner="src/apm_cli/models/dependency/identity.py"
+materialization_owner="src/apm_cli/models/dependency/materialization.py"
+reference_owner="src/apm_cli/models/dependency/reference.py"
+unique_key_body=$(awk '
+    /^def build_dependency_unique_key\(/ {flag=1}
+    flag && /^def / && !/^def build_dependency_unique_key\(/ {exit}
+    flag {print}
+' "$identity_owner")
+install_path_body=$(awk '
+    /^    def get_install_path\(/ {flag=1}
+    flag && /^    def / && !/^    def get_install_path\(/ {exit}
+    flag {print}
+' "$reference_owner")
+materialization_path_body=$(awk '
+    /^def build_materialization_path\(/ {flag=1}
+    flag && /^def / && !/^def build_materialization_path\(/ {exit}
+    flag {print}
+' "$materialization_owner")
+if ! printf '%s\n' "$unique_key_body" | grep -q 'normalize_package_repo_url(' \
+    || ! grep -q '^def prepare_materialization_path(' "$materialization_owner" \
+    || ! grep -q 'prepare_materialization_path(' src/apm_cli/install/phases/resolve.py \
+    || ! printf '%s\n' "$install_path_body" \
+        | grep -q 'return build_materialization_path(self, apm_modules_dir)' \
+    || ! printf '%s\n' "$materialization_path_body" \
+        | grep -q 'repo_parts = dependency.repo_url.split("/")' \
+    || printf '%s\n' "$materialization_path_body" \
+        | grep -Eq 'canonical_repo_url|normalize_package_repo_url|\.lower\(\)|\.casefold\(\)' \
+    || grep -q 'self\.repo_url = normalize_package_repo_url' "$reference_owner"; then
+    echo "[x] Dependency identity may casefold only in identity.py; materialization must preserve source casing"
+    violations=$((violations + 1))
+fi
+
 if [ "$violations" -gt 0 ]; then
     echo "[x] $violations architecture boundary rule(s) failed"
     exit 1

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -423,10 +423,7 @@ def _resolve_package_references(
                 logger=logger,
             )
             if marketplace_dep_ref is not None or direct_virtual_resolved:
-                _apm_yml_entries.setdefault(
-                    canonical,
-                    dependency_reference_to_yaml_entry(dep_ref),
-                )
+                _apm_yml_entries.setdefault(canonical, dependency_reference_to_yaml_entry(dep_ref))
         except ValueError as e:
             reason = str(e)
             invalid_outcomes.append((package, reason))

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -310,6 +310,7 @@ def _resolve_package_references(
     _apm_yml_entries = {}  # canonical -> apm.yml entry (str or dict for HTTP deps)
     validated_packages = []
     dependencies_changed = False
+    manifest_identities = builtins.set(existing_identities)
 
     if logger:
         logger.validation_start(len(packages))
@@ -412,6 +413,7 @@ def _resolve_package_references(
             )
             canonical = dep_ref.to_canonical()
             identity = dep_ref.get_identity()
+            _apm_yml_entries.setdefault(canonical, dep_ref.to_apm_yml_entry())
             apply_cli_skill_pin(
                 dep_ref,
                 skill_subset,
@@ -422,7 +424,10 @@ def _resolve_package_references(
                 logger=logger,
             )
             if marketplace_dep_ref is not None or direct_virtual_resolved:
-                _apm_yml_entries[canonical] = dependency_reference_to_yaml_entry(dep_ref)
+                _apm_yml_entries.setdefault(
+                    canonical,
+                    dependency_reference_to_yaml_entry(dep_ref),
+                )
         except ValueError as e:
             reason = str(e)
             invalid_outcomes.append((package, reason))
@@ -482,7 +487,7 @@ def _resolve_package_references(
         if package_accessible:
             updates_existing_entry = update_existing_dependency_entry_if_needed(
                 current_deps,
-                already_in_deps=already_in_deps,
+                already_in_deps=identity in manifest_identities,
                 apm_yml_entries=_apm_yml_entries,
                 canonical=canonical,
                 dep_ref=dep_ref,

--- a/src/apm_cli/commands/install.py
+++ b/src/apm_cli/commands/install.py
@@ -413,7 +413,6 @@ def _resolve_package_references(
             )
             canonical = dep_ref.to_canonical()
             identity = dep_ref.get_identity()
-            _apm_yml_entries.setdefault(canonical, dep_ref.to_apm_yml_entry())
             apply_cli_skill_pin(
                 dep_ref,
                 skill_subset,
@@ -463,6 +462,7 @@ def _resolve_package_references(
         # plain canonical string without this).
         if skill_subset and canonical not in _apm_yml_entries:
             _apm_yml_entries[canonical] = dep_ref.to_apm_yml_entry()
+        _apm_yml_entries.setdefault(canonical, dep_ref.to_apm_yml_entry())
 
         # Check if package is already in dependencies (by identity)
         already_in_deps = identity in existing_identities

--- a/src/apm_cli/compilation/link_resolver.py
+++ b/src/apm_cli/compilation/link_resolver.py
@@ -312,10 +312,7 @@ class UnifiedLinkResolver:
 
         # Calculate relative path from target location to actual source file
         # The shared helper owns ../ handling and cross-drive refusal.
-        try:
-            return portable_link_relpath(actual_file, ctx.target_location)
-        except Exception:
-            return None
+        return portable_link_relpath(actual_file, ctx.target_location)
 
     def _resolve_to_actual_file(self, link_path: str, source_file: Path) -> Path | None:
         """Resolve a link path to the actual file on disk.

--- a/src/apm_cli/compilation/link_resolver.py
+++ b/src/apm_cli/compilation/link_resolver.py
@@ -311,7 +311,7 @@ class UnifiedLinkResolver:
             return None
 
         # Calculate relative path from target location to actual source file
-        # Use os.path.relpath to support ../ for paths outside target directory
+        # The shared helper owns ../ handling and cross-drive refusal.
         try:
             return portable_link_relpath(actual_file, ctx.target_location)
         except Exception:

--- a/src/apm_cli/compilation/link_resolver.py
+++ b/src/apm_cli/compilation/link_resolver.py
@@ -9,13 +9,13 @@ Following KISS principle - simple, pragmatic implementation.
 """
 
 import builtins
-import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlparse
 
 from apm_cli.utils.path_security import PathTraversalError, ensure_path_within
+from apm_cli.utils.paths import portable_link_relpath
 
 # CRITICAL: Shadow Click commands to prevent namespace collision
 set = builtins.set
@@ -313,9 +313,7 @@ class UnifiedLinkResolver:
         # Calculate relative path from target location to actual source file
         # Use os.path.relpath to support ../ for paths outside target directory
         try:
-            relative_path = os.path.relpath(actual_file, ctx.target_location)
-            # Normalize to forward slashes for markdown link compatibility
-            return relative_path.replace(os.sep, "/")
+            return portable_link_relpath(actual_file, ctx.target_location)
         except Exception:
             return None
 
@@ -539,12 +537,14 @@ class UnifiedLinkResolver:
                 return None
 
         try:
-            relative_path = os.path.relpath(candidate_in_deployment, ctx.target_location)
+            relative_path = portable_link_relpath(
+                candidate_in_deployment,
+                ctx.target_location,
+            )
         except (OSError, ValueError):
             return None
 
-        rewritten = relative_path.replace(os.sep, "/")
-        return f"{rewritten}{suffix}"
+        return f"{relative_path}{suffix}" if relative_path is not None else None
 
 
 # Legacy functions for backward compatibility

--- a/src/apm_cli/deps/dependency_graph.py
+++ b/src/apm_cli/deps/dependency_graph.py
@@ -90,12 +90,11 @@ class DependencyTree:
         node_id = node.get_id()
         unique_key = node.dependency_ref.get_unique_key()
         is_new = node_id not in self.nodes
+        if not is_new:
+            return
         self.nodes[node_id] = node
-        if is_new:
-            self._nodes_by_unique_key.setdefault(unique_key, node)
-            self._nodes_by_depth[node.depth].append(node)
-        else:
-            self._nodes_by_unique_key[unique_key] = node
+        self._nodes_by_unique_key.setdefault(unique_key, node)
+        self._nodes_by_depth[node.depth].append(node)
         if node.dependency_ref.repo_url:
             self._repo_url_index.add(node.dependency_ref.repo_url)
         self.max_depth = max(self.max_depth, node.depth)

--- a/src/apm_cli/deps/dependency_graph.py
+++ b/src/apm_cli/deps/dependency_graph.py
@@ -96,12 +96,8 @@ class DependencyTree:
         self._nodes_by_unique_key.setdefault(unique_key, node)
         self._nodes_by_depth[node.depth].append(node)
         if node.dependency_ref.repo_url:
-            self._repo_lookup_index.update(
-                {
-                    node.dependency_ref.repo_url,
-                    node.dependency_ref.canonical_repo_url,
-                }
-            )
+            self._repo_lookup_index.add(node.dependency_ref.repo_url)
+            self._repo_lookup_index.add(node.dependency_ref.canonical_repo_url)
         self.max_depth = max(self.max_depth, node.depth)
 
     def get_node(self, unique_key: str) -> DependencyNode | None:

--- a/src/apm_cli/deps/dependency_graph.py
+++ b/src/apm_cli/deps/dependency_graph.py
@@ -81,7 +81,7 @@ class DependencyTree:
         default_factory=lambda: defaultdict(list)
     )
     _nodes_by_unique_key: dict[str, DependencyNode] = field(default_factory=dict)
-    _repo_url_index: set[str] = field(default_factory=set)
+    _repo_lookup_index: set[str] = field(default_factory=set)
     max_depth: int = 0
     resolution_errors: list[str] = field(default_factory=list)
 
@@ -96,7 +96,12 @@ class DependencyTree:
         self._nodes_by_unique_key.setdefault(unique_key, node)
         self._nodes_by_depth[node.depth].append(node)
         if node.dependency_ref.repo_url:
-            self._repo_url_index.add(node.dependency_ref.repo_url)
+            self._repo_lookup_index.update(
+                {
+                    node.dependency_ref.repo_url,
+                    node.dependency_ref.canonical_repo_url,
+                }
+            )
         self.max_depth = max(self.max_depth, node.depth)
 
     def get_node(self, unique_key: str) -> DependencyNode | None:
@@ -114,8 +119,8 @@ class DependencyTree:
         return list(self._nodes_by_depth.get(depth, []))
 
     def has_dependency(self, repo_url: str) -> bool:
-        """Check if a dependency exists in the tree (O(1) via index)."""
-        return repo_url in self._repo_url_index
+        """Check source or canonical GitHub repository spelling in O(1)."""
+        return repo_url in self._repo_lookup_index
 
 
 @dataclass

--- a/src/apm_cli/deps/lockfile.py
+++ b/src/apm_cli/deps/lockfile.py
@@ -167,6 +167,7 @@ class LockedDependency:
     """A resolved dependency with exact commit/version information."""
 
     repo_url: str
+    materialization_repo_url: str | None = None
     host: str | None = None
     host_type: str | None = None
     port: int | None = None  # Non-standard SSH/HTTPS port (e.g. 7999 for Bitbucket DC)
@@ -242,12 +243,26 @@ class LockedDependency:
     _unknown_fields: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        """Normalize case-insensitive package identity when loading or creating locks."""
-        self.repo_url = normalize_package_repo_url(
+        """Separate canonical lock identity from materialization spelling."""
+        original_repo_url = self.repo_url
+        canonical_repo_url = normalize_package_repo_url(
             self.repo_url,
             host=self.host,
             source=self.source,
             registry_prefix=self.registry_prefix,
+        )
+        materialization_repo_url = self.materialization_repo_url or original_repo_url
+        materialization_identity = normalize_package_repo_url(
+            materialization_repo_url,
+            host=self.host,
+            source=self.source,
+            registry_prefix=self.registry_prefix,
+        )
+        if materialization_identity != canonical_repo_url:
+            raise ValueError("materialization_repo_url must identify the same package as repo_url")
+        self.repo_url = canonical_repo_url
+        self.materialization_repo_url = (
+            materialization_repo_url if materialization_repo_url != canonical_repo_url else None
         )
 
     def get_unique_key(self) -> str:
@@ -283,6 +298,8 @@ class LockedDependency:
     def to_dict(self) -> dict[str, Any]:
         """Serialize to dict for YAML output."""
         result: dict[str, Any] = {"repo_url": self.repo_url}
+        if self.materialization_repo_url:
+            result["materialization_repo_url"] = self.materialization_repo_url
         if self.name is not None:
             result["name"] = self.name
         if self.host:
@@ -398,6 +415,7 @@ class LockedDependency:
         # the explicit legacy key handled above; do NOT consider it unknown.
         _known_keys = {
             "repo_url",
+            "materialization_repo_url",
             "host",
             "host_type",
             "port",
@@ -445,6 +463,7 @@ class LockedDependency:
 
         return cls(
             repo_url=data["repo_url"],
+            materialization_repo_url=data.get("materialization_repo_url"),
             host=data.get("host"),
             host_type=host_type,
             port=port,
@@ -580,8 +599,19 @@ class LockedDependency:
         else:
             version_value = None
 
+        canonical_repo_url = normalize_package_repo_url(
+            dep_ref.repo_url,
+            host=dep_ref.host,
+            source="local" if dep_ref.is_local else dep_ref.source,
+            registry_prefix=dep_ref.artifactory_prefix,
+            is_local=dep_ref.is_local,
+            is_marketplace=dep_ref.is_marketplace,
+        )
         return cls(
-            repo_url=dep_ref.repo_url,
+            repo_url=canonical_repo_url,
+            materialization_repo_url=(
+                dep_ref.repo_url if dep_ref.repo_url != canonical_repo_url else None
+            ),
             host=host,
             host_type=dep_ref.host_type,
             port=dep_ref.port,
@@ -639,7 +669,7 @@ class LockedDependency:
         is_registry = self.source == "registry"
         ref = self.version if (is_registry and self.version) else self.resolved_ref
         return DependencyReference(
-            repo_url=self.repo_url,
+            repo_url=self.materialization_repo_url or self.repo_url,
             host=self.host,
             host_type=self.host_type,
             port=self.port,

--- a/src/apm_cli/deps/lockfile.py
+++ b/src/apm_cli/deps/lockfile.py
@@ -259,7 +259,10 @@ class LockedDependency:
             registry_prefix=self.registry_prefix,
         )
         if materialization_identity != canonical_repo_url:
-            raise ValueError("materialization_repo_url must identify the same package as repo_url")
+            raise ValueError(
+                f"materialization_repo_url {materialization_repo_url!r} does not "
+                f"identify the same package as repo_url {self.repo_url!r}"
+            )
         self.repo_url = canonical_repo_url
         self.materialization_repo_url = (
             materialization_repo_url if materialization_repo_url != canonical_repo_url else None

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -20,8 +20,9 @@ from __future__ import annotations
 
 import builtins
 import logging
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from apm_cli.install.helpers.ref_reuse import (
     annotate_update_plan_refs,
@@ -32,7 +33,11 @@ from apm_cli.install.helpers.ref_reuse import (
 from apm_cli.install.helpers.ref_seed import seed_ref_resolver_from_lockfile
 from apm_cli.install.transaction import resolution_for_context
 from apm_cli.models.apm_package import GitReferenceType, ResolvedReference
-from apm_cli.models.dependency.materialization import prepare_materialization_path
+from apm_cli.models.dependency.materialization import (
+    CachedMaterializationPathReader,
+    MaterializationPathReader,
+    prepare_materialization_path,
+)
 from apm_cli.utils.short_sha import format_short_sha
 
 if TYPE_CHECKING:
@@ -129,6 +134,7 @@ def _purge_cached_semver_paths_for_update(
 def _prepare_existing_materialization_paths(
     ctx: InstallContext,
     staging_session: ResolutionStagingSession,
+    materialization_reader: MaterializationPathReader,
 ) -> None:
     """Migrate case-only legacy paths before resolver cache checks can bypass callbacks."""
     dependencies = list(ctx.all_apm_deps)
@@ -142,11 +148,52 @@ def _prepare_existing_materialization_paths(
             dependencies.append(dependency)
             seen_keys.add(key)
 
+    on_migrate = _materialization_migration_logger(ctx.logger, ctx.apm_modules_dir)
     for dependency in dependencies:
         prepare_materialization_path(
             dependency,
             ctx.apm_modules_dir,
             staging_session,
+            reader=materialization_reader,
+            on_migrate=on_migrate,
+        )
+
+
+def _materialization_migration_logger(
+    logger,
+    apm_modules_dir: Path,
+) -> Callable[[Path, Path], None] | None:
+    """Build a verbose-only callback for case migration diagnostics."""
+    if logger is None:
+        return None
+    modules = apm_modules_dir.absolute()
+
+    def report(source: Path, destination: Path) -> None:
+        source_rel = source.absolute().relative_to(modules).as_posix()
+        destination_rel = destination.absolute().relative_to(modules).as_posix()
+        logger.verbose_detail(
+            f"    Migrated package directory casing: {source_rel} -> {destination_rel}"
+        )
+
+    return report
+
+
+def _prepare_callback_materialization_path(
+    dependency: Any,
+    modules_dir: Path,
+    staging_session: ResolutionStagingSession,
+    materialization_reader: MaterializationPathReader,
+    callback_lock: Any,
+    logger: Any,
+) -> Path:
+    """Serialize transitive casing lookup and migration across resolver workers."""
+    with callback_lock:
+        return prepare_materialization_path(
+            dependency,
+            modules_dir,
+            staging_session,
+            reader=materialization_reader,
+            on_migrate=_materialization_migration_logger(logger, modules_dir),
         )
 
 
@@ -336,7 +383,11 @@ def _build_dependency_graph(ctx: InstallContext, resolver):
     return dependency_graph
 
 
-def _resolve_dependencies(ctx: InstallContext, staging_session: ResolutionStagingSession) -> None:
+def _resolve_dependencies(
+    ctx: InstallContext,
+    staging_session: ResolutionStagingSession,
+    materialization_reader: MaterializationPathReader,
+) -> None:
     """Resolve dependencies and populate the resolution fields on ``ctx``."""
     import threading as _threading
 
@@ -437,10 +488,13 @@ def _resolve_dependencies(ctx: InstallContext, staging_session: ResolutionStagin
                 transitive ``../sibling`` resolves against the declaring
                 package's directory rather than the root consumer (#857).
         """
-        install_path = prepare_materialization_path(
+        install_path = _prepare_callback_materialization_path(
             dep_ref,
             modules_dir,
             staging_session,
+            materialization_reader,
+            callback_lock,
+            logger,
         )
         # Cache reuse stays behind the canonical ref-drift owner.
         if install_path.exists():
@@ -959,10 +1013,19 @@ def run(ctx: InstallContext) -> None:
     _load_lockfile(ctx)
     _ensure_modules_dir(ctx)
     staging_session = resolution_for_context(ctx)
-    _prepare_existing_materialization_paths(ctx, staging_session)
+    materialization_reader = CachedMaterializationPathReader()
+    _prepare_existing_materialization_paths(
+        ctx,
+        staging_session,
+        materialization_reader,
+    )
     _setup_downloader(ctx)
     seed_ref_resolver_from_lockfile(ctx)
-    _resolve_dependencies(ctx, staging_session)
+    _resolve_dependencies(
+        ctx,
+        staging_session,
+        materialization_reader,
+    )
     _record_update_plan_complete_dep_keys(ctx)
     if ctx.only_packages:
         _apply_only_filter(ctx)

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -137,10 +137,14 @@ def _prepare_existing_materialization_paths(
     materialization_reader: MaterializationPathReader,
 ) -> None:
     """Migrate case-only legacy paths before resolver cache checks can bypass callbacks."""
-    dependencies = list(ctx.all_apm_deps)
+    apm_modules_dir = getattr(ctx, "apm_modules_dir", None)
+    if apm_modules_dir is None:
+        return
+    dependencies = list(getattr(ctx, "all_apm_deps", ()))
     seen_keys = {dependency.get_unique_key() for dependency in dependencies}
-    if ctx.existing_lockfile is not None:
-        for locked in ctx.existing_lockfile.get_package_dependencies():
+    existing_lockfile = getattr(ctx, "existing_lockfile", None)
+    if existing_lockfile is not None:
+        for locked in existing_lockfile.get_package_dependencies():
             dependency = locked.to_dependency_ref()
             key = dependency.get_unique_key()
             if key in seen_keys:
@@ -148,11 +152,14 @@ def _prepare_existing_materialization_paths(
             dependencies.append(dependency)
             seen_keys.add(key)
 
-    on_migrate = _materialization_migration_logger(ctx.logger, ctx.apm_modules_dir)
+    on_migrate = _materialization_migration_logger(
+        getattr(ctx, "logger", None),
+        apm_modules_dir,
+    )
     for dependency in dependencies:
         prepare_materialization_path(
             dependency,
-            ctx.apm_modules_dir,
+            apm_modules_dir,
             staging_session,
             reader=materialization_reader,
             on_migrate=on_migrate,

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -1,9 +1,6 @@
 """Dependency resolution phase.
 
-Reads ``ctx.apm_package``, ``ctx.update_refs``, ``ctx.scope``, etc.;
-populates ``ctx.deps_to_install``, ``ctx.intended_dep_keys``,
-``ctx.dependency_graph``, ``ctx.existing_lockfile``, and several ancillary
-fields consumed by later phases (download, integrate, cleanup, lockfile).
+Loads inputs and populates resolution state consumed by later phases.
 
 This is the first phase of the install pipeline.  It covers:
 
@@ -30,11 +27,7 @@ from apm_cli.install.helpers.ref_reuse import (
 from apm_cli.install.helpers.ref_seed import seed_ref_resolver_from_lockfile
 from apm_cli.install.transaction import resolution_for_context
 from apm_cli.models.apm_package import GitReferenceType, ResolvedReference
-from apm_cli.models.dependency.materialization import (
-    CachedMaterializationPathReader,
-    MaterializationPathReader,
-    prepare_materialization_path,
-)
+from apm_cli.models.dependency import materialization as _materialization
 from apm_cli.utils.short_sha import format_short_sha
 
 if TYPE_CHECKING:
@@ -131,7 +124,7 @@ def _purge_cached_semver_paths_for_update(
 def _prepare_existing_materialization_paths(
     ctx: InstallContext,
     staging_session: ResolutionStagingSession,
-    materialization_reader: MaterializationPathReader,
+    materialization_reader: _materialization.MaterializationPathReader,
 ) -> None:
     """Migrate case-only legacy paths before resolver cache checks can bypass callbacks."""
     apm_modules_dir = getattr(ctx, "apm_modules_dir", None)
@@ -151,7 +144,7 @@ def _prepare_existing_materialization_paths(
 
     on_migrate = _materialization_migration_logger(getattr(ctx, "logger", None), apm_modules_dir)
     for dependency in dependencies:
-        prepare_materialization_path(
+        _materialization.prepare_materialization_path(
             dependency,
             apm_modules_dir,
             staging_session,
@@ -183,13 +176,13 @@ def _prepare_callback_materialization_path(
     dependency: Any,
     modules_dir: Path,
     staging_session: ResolutionStagingSession,
-    materialization_reader: MaterializationPathReader,
+    materialization_reader: _materialization.MaterializationPathReader,
     callback_lock: Any,
     logger: Any,
 ) -> Path:
     """Serialize transitive casing lookup and migration across resolver workers."""
     with callback_lock:
-        return prepare_materialization_path(
+        return _materialization.prepare_materialization_path(
             dependency,
             modules_dir,
             staging_session,
@@ -387,7 +380,7 @@ def _build_dependency_graph(ctx: InstallContext, resolver):
 def _resolve_dependencies(
     ctx: InstallContext,
     staging_session: ResolutionStagingSession,
-    materialization_reader: MaterializationPathReader,
+    materialization_reader: _materialization.MaterializationPathReader,
 ) -> None:
     """Resolve dependencies and populate the resolution fields on ``ctx``."""
     import threading as _threading
@@ -1014,19 +1007,11 @@ def run(ctx: InstallContext) -> None:
     _load_lockfile(ctx)
     _ensure_modules_dir(ctx)
     staging_session = resolution_for_context(ctx)
-    materialization_reader = CachedMaterializationPathReader()
-    _prepare_existing_materialization_paths(
-        ctx,
-        staging_session,
-        materialization_reader,
-    )
+    materialization_reader = _materialization.CachedMaterializationPathReader()
+    _prepare_existing_materialization_paths(ctx, staging_session, materialization_reader)
     _setup_downloader(ctx)
     seed_ref_resolver_from_lockfile(ctx)
-    _resolve_dependencies(
-        ctx,
-        staging_session,
-        materialization_reader,
-    )
+    _resolve_dependencies(ctx, staging_session, materialization_reader)
     _record_update_plan_complete_dep_keys(ctx)
     if ctx.only_packages:
         _apply_only_filter(ctx)

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -10,10 +10,7 @@ This is the first phase of the install pipeline.  It covers:
 1. Lockfile loading (``apm.lock.yaml``)
 2. ``apm_modules/`` directory creation
 3. Auth resolver defaulting + downloader construction
-4. Transitive dependency resolution via ``APMDependencyResolver``
-5. ``--only`` filtering (restrict to named packages + their subtrees)
-6. ``intended_dep_keys`` computation (the manifest-intent set used by
-   orphan cleanup in a later phase)
+4. Dependency resolution, ``--only`` filtering, and intended-key computation
 """
 
 from __future__ import annotations
@@ -152,10 +149,7 @@ def _prepare_existing_materialization_paths(
             dependencies.append(dependency)
             seen_keys.add(key)
 
-    on_migrate = _materialization_migration_logger(
-        getattr(ctx, "logger", None),
-        apm_modules_dir,
-    )
+    on_migrate = _materialization_migration_logger(getattr(ctx, "logger", None), apm_modules_dir)
     for dependency in dependencies:
         prepare_materialization_path(
             dependency,

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -32,6 +32,7 @@ from apm_cli.install.helpers.ref_reuse import (
 from apm_cli.install.helpers.ref_seed import seed_ref_resolver_from_lockfile
 from apm_cli.install.transaction import resolution_for_context
 from apm_cli.models.apm_package import GitReferenceType, ResolvedReference
+from apm_cli.models.dependency.materialization import prepare_materialization_path
 from apm_cli.utils.short_sha import format_short_sha
 
 if TYPE_CHECKING:
@@ -123,6 +124,30 @@ def _purge_cached_semver_paths_for_update(
                     f"[*] --update: cleared cached install path for "
                     f"{_dep.get_unique_key()} to force semver re-resolution"
                 )
+
+
+def _prepare_existing_materialization_paths(
+    ctx: InstallContext,
+    staging_session: ResolutionStagingSession,
+) -> None:
+    """Migrate case-only legacy paths before resolver cache checks can bypass callbacks."""
+    dependencies = list(ctx.all_apm_deps)
+    seen_keys = {dependency.get_unique_key() for dependency in dependencies}
+    if ctx.existing_lockfile is not None:
+        for locked in ctx.existing_lockfile.get_package_dependencies():
+            dependency = locked.to_dependency_ref()
+            key = dependency.get_unique_key()
+            if key in seen_keys:
+                continue
+            dependencies.append(dependency)
+            seen_keys.add(key)
+
+    for dependency in dependencies:
+        prepare_materialization_path(
+            dependency,
+            ctx.apm_modules_dir,
+            staging_session,
+        )
 
 
 def _load_lockfile(ctx: InstallContext) -> None:
@@ -412,7 +437,11 @@ def _resolve_dependencies(ctx: InstallContext, staging_session: ResolutionStagin
                 transitive ``../sibling`` resolves against the declaring
                 package's directory rather than the root consumer (#857).
         """
-        install_path = dep_ref.get_install_path(modules_dir)
+        install_path = prepare_materialization_path(
+            dep_ref,
+            modules_dir,
+            staging_session,
+        )
         # Cache reuse stays behind the canonical ref-drift owner.
         if install_path.exists():
             _locked_for_recheck = (
@@ -929,9 +958,11 @@ def run(ctx: InstallContext) -> None:
     """
     _load_lockfile(ctx)
     _ensure_modules_dir(ctx)
+    staging_session = resolution_for_context(ctx)
+    _prepare_existing_materialization_paths(ctx, staging_session)
     _setup_downloader(ctx)
     seed_ref_resolver_from_lockfile(ctx)
-    _resolve_dependencies(ctx, resolution_for_context(ctx))
+    _resolve_dependencies(ctx, staging_session)
     _record_update_plan_complete_dep_keys(ctx)
     if ctx.only_packages:
         _apply_only_filter(ctx)

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -1,6 +1,9 @@
 """Dependency resolution phase.
 
-Loads inputs and populates resolution state consumed by later phases:
+Loads inputs and populates resolution state consumed by later phases.
+
+This is the first phase of the install pipeline.  It covers:
+
 1. Lockfile loading (``apm.lock.yaml``)
 2. ``apm_modules/`` directory creation
 3. Auth resolver defaulting + downloader construction
@@ -106,8 +109,6 @@ def _prepare_existing_materialization_paths(
     """Migrate case-only legacy paths before resolver cache checks can bypass callbacks."""
     apm_modules_dir = getattr(ctx, "apm_modules_dir", None)
     if apm_modules_dir is None:
-        return
-    if not any(materialization_reader.iterdir(apm_modules_dir)):
         return
     dependencies = list(getattr(ctx, "all_apm_deps", ()))
     seen_keys = {dependency.get_unique_key() for dependency in dependencies}

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -1,9 +1,6 @@
 """Dependency resolution phase.
 
-Loads inputs and populates resolution state consumed by later phases.
-
-This is the first phase of the install pipeline.  It covers:
-
+Loads inputs and populates resolution state consumed by later phases:
 1. Lockfile loading (``apm.lock.yaml``)
 2. ``apm_modules/`` directory creation
 3. Auth resolver defaulting + downloader construction
@@ -109,6 +106,8 @@ def _prepare_existing_materialization_paths(
     """Migrate case-only legacy paths before resolver cache checks can bypass callbacks."""
     apm_modules_dir = getattr(ctx, "apm_modules_dir", None)
     if apm_modules_dir is None:
+        return
+    if not any(materialization_reader.iterdir(apm_modules_dir)):
         return
     dependencies = list(getattr(ctx, "all_apm_deps", ()))
     seen_keys = {dependency.get_unique_key() for dependency in dependencies}

--- a/src/apm_cli/install/phases/resolve.py
+++ b/src/apm_cli/install/phases/resolve.py
@@ -43,15 +43,7 @@ _logger = logging.getLogger(__name__)
 
 
 def _lockfile_has_registry_deps(existing_lockfile) -> bool:
-    """True when the on-disk lockfile records at least one registry-sourced dep.
-
-    Used to construct the registry resolver even when apm.yml's
-    ``registries:`` block has been removed but locked deps still need to
-    re-install. A user clones a repo, the apm.yml has no registries: block
-    but the lockfile says some deps are ``source: registry`` — we still
-    want them to install (they'll fail at auth lookup if the URL doesn't
-    match anything configured, with a clear remediation per §6.2).
-    """
+    """Return whether the lockfile contains a registry-sourced dependency."""
     if not existing_lockfile:
         return False
     return any(
@@ -77,21 +69,9 @@ def _purge_cached_semver_paths_for_update(
     logger,
     staging_session: ResolutionStagingSession,
 ) -> None:
-    """Pre-purge on-disk install paths for direct git-source and registry semver deps
-    when ``--update`` / ``--refresh`` is set.
+    """Clear direct semver install paths for update/refresh re-resolution.
 
-    Bug 1 fix (#1496): the BFS resolver short-circuits at
-    ``install_path.exists()`` and never invokes ``download_callback``,
-    which is where ``_maybe_resolve_git_semver`` lives. For git-source
-    semver direct deps we therefore pre-purge the install path so the
-    resolver is forced through the callback, re-runs ``git ls-remote``,
-    and rewrites the lockfile with the latest matching tag. Matches
-    npm / cargo / bundler: ``--update`` is the explicit re-resolve
-    trigger and must not be swallowed by the on-disk cache. Scoped to
-    direct deps -- a transitive dep's own range is covered separately by
-    ``APMDependencyResolver._should_force_recheck``. Local and proxy deps
-    are excluded (different resolver path). Registry semver deps are
-    included: their callback also gates on install_path.exists().
+    Transitives use resolver recheck; local and proxy dependencies are excluded.
     """
     from contextlib import suppress
 
@@ -144,6 +124,8 @@ def _prepare_existing_materialization_paths(
 
     on_migrate = _materialization_migration_logger(getattr(ctx, "logger", None), apm_modules_dir)
     for dependency in dependencies:
+        if dependency.is_marketplace:
+            continue
         _materialization.prepare_materialization_path(
             dependency,
             apm_modules_dir,

--- a/src/apm_cli/install/pipeline.py
+++ b/src/apm_cli/install/pipeline.py
@@ -46,6 +46,7 @@ import time
 from functools import wraps
 from typing import TYPE_CHECKING
 
+from ..models.dependency.materialization import MaterializationPathCollisionError
 from ..models.results import InstallDisposition, InstallResult
 from ..utils.console import _rich_error
 from ..utils.diagnostics import DiagnosticCollector
@@ -985,9 +986,9 @@ def run_install_pipeline(  # noqa: C901, PLR0913, RUF100
         raise
     except InstallFailureAlreadyRendered:
         raise
-    except PathTraversalError:
-        # Path-safety violation in SKILL_BUNDLE or other nested
-        # resolution -- surface as-is for actionable user guidance.
+    except (PathTraversalError, MaterializationPathCollisionError):
+        # Path-safety and package-directory collision errors already include
+        # actionable guidance; preserve them instead of adding generic wrappers.
         raise
     except Exception as e:
         raise RuntimeError(f"Failed to resolve APM dependencies: {e}")  # noqa: B904

--- a/src/apm_cli/install/resolution_staging.py
+++ b/src/apm_cli/install/resolution_staging.py
@@ -41,7 +41,7 @@ class ResolutionStagingSession:
         ensure_path_within(source, self._modules_dir)
         ensure_path_within(destination, self._modules_dir)
         with self._lock:
-            if source == destination:
+            if source.parts == destination.parts:
                 return
             if source.is_symlink():
                 raise ValueError(
@@ -105,7 +105,8 @@ class ResolutionStagingSession:
         """Rename an entry through a sibling so case-insensitive filesystems update spelling."""
         try:
             source.replace(destination)
-            return
+            if any(child.name == destination.name for child in destination.parent.iterdir()):
+                return
         except OSError:
             if not source.exists() and destination.exists():
                 return

--- a/src/apm_cli/install/resolution_staging.py
+++ b/src/apm_cli/install/resolution_staging.py
@@ -43,11 +43,22 @@ class ResolutionStagingSession:
         with self._lock:
             if source == destination:
                 return
-            if source.is_symlink() or not source.exists():
-                raise ValueError(f"Materialization migration source is invalid: {source}")
+            if source.is_symlink():
+                raise ValueError(
+                    f"Refusing to migrate symlinked package directory: {source}. "
+                    "Replace the symlink with the installed package and retry."
+                )
+            if not source.exists():
+                raise FileNotFoundError(
+                    f"Package directory disappeared before casing migration: {source}. "
+                    "Run 'apm install' again."
+                )
             if destination.exists():
                 if not os.path.samefile(source, destination):
-                    raise FileExistsError(f"Materialization migration target exists: {destination}")
+                    raise FileExistsError(
+                        f"Package directory already exists at {destination}. "
+                        "Inspect both case variants and remove the duplicate before retrying."
+                    )
                 self._replace_case_only(source, destination)
                 self._relocations.append((source, destination))
                 return
@@ -84,6 +95,7 @@ class ResolutionStagingSession:
 
     def _remove_empty_parents(self, path: Path) -> None:
         """Remove empty migration-created parents below ``apm_modules``."""
+        ensure_path_within(path, self._modules_dir)
         while path != self._modules_dir and path.exists() and not any(path.iterdir()):
             path.rmdir()
             path = path.parent
@@ -91,6 +103,12 @@ class ResolutionStagingSession:
     @staticmethod
     def _replace_case_only(source: Path, destination: Path) -> None:
         """Rename an entry through a sibling so case-insensitive filesystems update spelling."""
+        try:
+            source.replace(destination)
+            return
+        except OSError:
+            if not source.exists() and destination.exists():
+                return
         temporary = source.with_name(f".apm-case-migration-{uuid.uuid4().hex}")
         source.replace(temporary)
         try:

--- a/src/apm_cli/install/resolution_staging.py
+++ b/src/apm_cli/install/resolution_staging.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import threading
 import uuid
 from pathlib import Path
@@ -17,6 +18,7 @@ class ResolutionStagingSession:
         self._modules_dir = apm_modules_dir
         self._staging_root = apm_modules_dir / ".apm-resolution-staging" / uuid.uuid4().hex
         self._backups: dict[Path, Path | None] = {}
+        self._relocations: list[tuple[Path, Path]] = []
         self._lock = threading.Lock()
 
     def prepare_path(self, path: Path) -> None:
@@ -34,10 +36,30 @@ class ResolutionStagingSession:
                 resolved.replace(backup)
             self._backups[resolved] = backup
 
+    def relocate_path(self, source: Path, destination: Path) -> None:
+        """Move one existing package path and journal the rename for rollback."""
+        ensure_path_within(source, self._modules_dir)
+        ensure_path_within(destination, self._modules_dir)
+        with self._lock:
+            if source == destination:
+                return
+            if source.is_symlink() or not source.exists():
+                raise ValueError(f"Materialization migration source is invalid: {source}")
+            if destination.exists():
+                if not os.path.samefile(source, destination):
+                    raise FileExistsError(f"Materialization migration target exists: {destination}")
+                self._replace_case_only(source, destination)
+                self._relocations.append((source, destination))
+                return
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            source.replace(destination)
+            self._relocations.append((source, destination))
+
     def commit(self) -> None:
         """Discard preserved pre-resolution contents after successful validation."""
         self._remove_staging_root()
         self._backups.clear()
+        self._relocations.clear()
 
     def rollback(self) -> None:
         """Remove session-created paths and restore every replaced path."""
@@ -48,8 +70,34 @@ class ResolutionStagingSession:
                 if backup is not None and backup.exists():
                     path.parent.mkdir(parents=True, exist_ok=True)
                     backup.replace(path)
+            for source, destination in reversed(self._relocations):
+                if destination.exists():
+                    source.parent.mkdir(parents=True, exist_ok=True)
+                    if source.exists() and os.path.samefile(source, destination):
+                        self._replace_case_only(destination, source)
+                    else:
+                        destination.replace(source)
+                self._remove_empty_parents(destination.parent)
             self._remove_staging_root()
             self._backups.clear()
+            self._relocations.clear()
+
+    def _remove_empty_parents(self, path: Path) -> None:
+        """Remove empty migration-created parents below ``apm_modules``."""
+        while path != self._modules_dir and path.exists() and not any(path.iterdir()):
+            path.rmdir()
+            path = path.parent
+
+    @staticmethod
+    def _replace_case_only(source: Path, destination: Path) -> None:
+        """Rename an entry through a sibling so case-insensitive filesystems update spelling."""
+        temporary = source.with_name(f".apm-case-migration-{uuid.uuid4().hex}")
+        source.replace(temporary)
+        try:
+            temporary.replace(destination)
+        except BaseException:
+            temporary.replace(source)
+            raise
 
     def _remove_staging_root(self) -> None:
         if self._staging_root.exists():

--- a/src/apm_cli/models/dependency/identity.py
+++ b/src/apm_cli/models/dependency/identity.py
@@ -62,13 +62,12 @@ def normalize_package_repo_url(
     hosts retain their path casing because their repository semantics may be
     case-sensitive.
     """
-    if is_case_insensitive_package_identity(
-        host=host,
-        source=source,
-        registry_prefix=registry_prefix,
-        is_local=is_local,
-        is_marketplace=is_marketplace,
-    ):
+    if is_local or source == "local" or is_marketplace:
+        return repo_url
+    if source == "registry" or registry_prefix:
+        return repo_url.lower()
+    effective_host = host or default_host()
+    if is_github_hostname(effective_host):
         return repo_url.lower()
     return repo_url
 

--- a/src/apm_cli/models/dependency/identity.py
+++ b/src/apm_cli/models/dependency/identity.py
@@ -7,7 +7,7 @@ file-length guardrail. These are pure, stateless helpers with no dependency on
 without collapsing their distinct local-detection semantics.
 
 ``normalize_package_repo_url`` is the single casing-normalization boundary for
-package identity. Callers must not lowercase repository paths independently.
+comparison identity. It must never be used as a display or filesystem path.
 """
 
 import re
@@ -74,6 +74,26 @@ def normalize_package_repo_url(
     return repo_url
 
 
+def is_case_insensitive_package_identity(
+    *,
+    host: str | None = None,
+    source: str | None = None,
+    registry_prefix: str | None = None,
+    is_local: bool = False,
+    is_marketplace: bool = False,
+) -> bool:
+    """Return whether repository casing is excluded from package identity."""
+    if is_local or source == "local" or is_marketplace:
+        return False
+    if source == "registry" or registry_prefix:
+        return True
+    configured_default_host = default_host()
+    effective_host = host or configured_default_host
+    return effective_host.lower() == configured_default_host.lower() or is_github_hostname(
+        effective_host
+    )
+
+
 def build_dependency_unique_key(
     repo_url: str,
     *,
@@ -85,6 +105,7 @@ def build_dependency_unique_key(
     registry_prefix: str | None = None,
     declaring_parent: str | None = None,
     anchored_local_path: str | None = None,
+    is_marketplace: bool = False,
 ) -> str:
     """Return the lockfile/dedup key for a dependency identity.
 
@@ -106,7 +127,14 @@ def build_dependency_unique_key(
             return f"local:{anchored_local_path}"
         return local_path
 
-    key = repo_url
+    key = normalize_package_repo_url(
+        repo_url,
+        host=host,
+        source=source,
+        registry_prefix=registry_prefix,
+        is_local=source == "local",
+        is_marketplace=is_marketplace,
+    )
     if is_virtual and virtual_path:
         key = f"{key}/{virtual_path}"
 

--- a/src/apm_cli/models/dependency/identity.py
+++ b/src/apm_cli/models/dependency/identity.py
@@ -62,14 +62,13 @@ def normalize_package_repo_url(
     hosts retain their path casing because their repository semantics may be
     case-sensitive.
     """
-    if is_local or source == "local" or is_marketplace:
-        return repo_url
-
-    if source == "registry" or registry_prefix:
-        return repo_url.lower()
-
-    effective_host = host or default_host()
-    if is_github_hostname(effective_host):
+    if is_case_insensitive_package_identity(
+        host=host,
+        source=source,
+        registry_prefix=registry_prefix,
+        is_local=is_local,
+        is_marketplace=is_marketplace,
+    ):
         return repo_url.lower()
     return repo_url
 
@@ -87,11 +86,8 @@ def is_case_insensitive_package_identity(
         return False
     if source == "registry" or registry_prefix:
         return True
-    configured_default_host = default_host()
-    effective_host = host or configured_default_host
-    return effective_host.lower() == configured_default_host.lower() or is_github_hostname(
-        effective_host
-    )
+    effective_host = host or default_host()
+    return is_github_hostname(effective_host)
 
 
 def build_dependency_unique_key(

--- a/src/apm_cli/models/dependency/materialization.py
+++ b/src/apm_cli/models/dependency/materialization.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import hashlib
 import os
-from collections.abc import Iterable, Sequence
+import threading
+from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Protocol
 
@@ -34,6 +35,9 @@ class MaterializationPathReader(Protocol):
     def samefile(self, left: Path, right: Path) -> bool:
         """Return whether two spellings address the same entry."""
 
+    def invalidate(self, *paths: Path) -> None:
+        """Discard cached directory listings affected by a rename."""
+
 
 class _NativeMaterializationPathReader:
     def exists(self, path: Path) -> bool:
@@ -48,8 +52,45 @@ class _NativeMaterializationPathReader:
     def samefile(self, left: Path, right: Path) -> bool:
         return os.path.samefile(left, right)
 
+    def invalidate(self, *paths: Path) -> None:
+        return None
+
 
 _NATIVE_READER = _NativeMaterializationPathReader()
+
+
+class CachedMaterializationPathReader:
+    """Thread-safe directory-listing cache for one resolution attempt."""
+
+    def __init__(
+        self,
+        delegate: MaterializationPathReader = _NATIVE_READER,
+    ) -> None:
+        self._delegate = delegate
+        self._children: dict[Path, tuple[Path, ...]] = {}
+        self._lock = threading.RLock()
+
+    def exists(self, path: Path) -> bool:
+        return self._delegate.exists(path)
+
+    def is_dir(self, path: Path) -> bool:
+        return self._delegate.is_dir(path)
+
+    def iterdir(self, path: Path) -> Iterable[Path]:
+        key = path.absolute()
+        with self._lock:
+            if key not in self._children:
+                self._children[key] = tuple(self._delegate.iterdir(path))
+            return self._children[key]
+
+    def samefile(self, left: Path, right: Path) -> bool:
+        return self._delegate.samefile(left, right)
+
+    def invalidate(self, *paths: Path) -> None:
+        with self._lock:
+            for path in paths:
+                self._children.pop(path.absolute(), None)
+        self._delegate.invalidate(*paths)
 
 
 def build_materialization_path(
@@ -123,7 +164,7 @@ def _relative_parts(desired: Path, apm_modules_dir: Path) -> tuple[str, ...]:
         relative = desired.absolute().relative_to(apm_modules_dir.absolute())
     except ValueError as exc:
         raise MaterializationPathCollisionError(
-            f"Materialization path escapes apm_modules: {desired}"
+            f"Package directory escapes apm_modules/: {desired}"
         ) from exc
     return relative.parts
 
@@ -158,7 +199,9 @@ def find_case_equivalent_materialization_path(
         if len(matches) > 1:
             rendered = ", ".join(match.as_posix() for match in matches)
             raise MaterializationPathCollisionError(
-                f"Found multiple materialization paths for one package identity: {rendered}"
+                "Found multiple package directories for one dependency: "
+                f"{rendered}. Inspect the duplicates under apm_modules/, "
+                "keep the intended package, and run 'apm install' again."
             )
         return apm_modules_dir.joinpath(*matches[0].parts) if matches else None
 
@@ -177,7 +220,9 @@ def find_case_equivalent_materialization_path(
         if len(matches) > 1:
             rendered = ", ".join(str(match) for match in matches)
             raise MaterializationPathCollisionError(
-                f"Found multiple materialization paths for one package identity: {rendered}"
+                "Found multiple package directories for one dependency: "
+                f"{rendered}. Inspect the duplicates under apm_modules/, "
+                "keep the intended package, and run 'apm install' again."
             )
         if not matches:
             return None
@@ -203,9 +248,12 @@ def _relocate_case_components(
             if reader.exists(target):
                 if not reader.samefile(source, target):
                     raise MaterializationPathCollisionError(
-                        f"Materialization path collision between {source} and {target}"
+                        "Package directory casing collides between "
+                        f"{source} and {target}. Inspect both directories, "
+                        "keep the intended package, and run 'apm install' again."
                     )
             staging_session.relocate_path(source, target)
+            reader.invalidate(current_parent)
         current_parent = target
 
 
@@ -215,6 +263,7 @@ def prepare_materialization_path(
     staging_session: ResolutionStagingSession,
     *,
     reader: MaterializationPathReader = _NATIVE_READER,
+    on_migrate: Callable[[Path, Path], None] | None = None,
 ) -> Path:
     """Return the display-cased path, transactionally migrating stale casing."""
     desired = dependency.get_install_path(apm_modules_dir)
@@ -235,4 +284,6 @@ def prepare_materialization_path(
         staging_session,
         reader,
     )
+    if on_migrate is not None:
+        on_migrate(existing, desired)
     return desired

--- a/src/apm_cli/models/dependency/materialization.py
+++ b/src/apm_cli/models/dependency/materialization.py
@@ -1,0 +1,238 @@
+"""Case-preserving dependency materialization path migration."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from collections.abc import Iterable, Sequence
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING, Protocol
+
+from ...utils.path_security import ensure_path_within, validate_path_segments
+
+if TYPE_CHECKING:
+    from ...install.resolution_staging import ResolutionStagingSession
+    from .reference import DependencyReference
+
+
+class MaterializationPathCollisionError(ValueError):
+    """Raised when one canonical identity has multiple physical paths."""
+
+
+class MaterializationPathReader(Protocol):
+    """Filesystem read seam for platform-neutral casing tests."""
+
+    def exists(self, path: Path) -> bool:
+        """Return whether *path* exists."""
+
+    def is_dir(self, path: Path) -> bool:
+        """Return whether *path* is a directory."""
+
+    def iterdir(self, path: Path) -> Iterable[Path]:
+        """Yield children of *path*."""
+
+    def samefile(self, left: Path, right: Path) -> bool:
+        """Return whether two spellings address the same entry."""
+
+
+class _NativeMaterializationPathReader:
+    def exists(self, path: Path) -> bool:
+        return path.exists()
+
+    def is_dir(self, path: Path) -> bool:
+        return path.is_dir()
+
+    def iterdir(self, path: Path) -> Iterable[Path]:
+        return path.iterdir()
+
+    def samefile(self, left: Path, right: Path) -> bool:
+        return os.path.samefile(left, right)
+
+
+_NATIVE_READER = _NativeMaterializationPathReader()
+
+
+def build_materialization_path(
+    dependency: DependencyReference,
+    apm_modules_dir: Path,
+) -> Path:
+    """Build the source-cased path for one dependency below ``apm_modules``."""
+    if dependency.is_marketplace:
+        raise ValueError(
+            "Cannot compute install path for unresolved marketplace dependency "
+            f"'{dependency.marketplace_plugin_name}@{dependency.marketplace_name}'"
+        )
+
+    if dependency.is_local and dependency.local_path:
+        pkg_dir_name = Path(dependency.local_path).name
+        validate_path_segments(
+            pkg_dir_name,
+            context="local package path",
+            reject_empty=True,
+        )
+        if dependency.declaring_parent:
+            identity = dependency.anchored_local_path or dependency.local_path
+            parent_slot = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:12]
+            result = apm_modules_dir / "_local" / parent_slot / pkg_dir_name
+        else:
+            result = apm_modules_dir / "_local" / pkg_dir_name
+        ensure_path_within(result, apm_modules_dir)
+        return result
+
+    repo_parts = dependency.repo_url.split("/")
+    validate_path_segments(dependency.repo_url, context="repo_url")
+    if dependency.virtual_path:
+        validate_path_segments(dependency.virtual_path, context="virtual_path")
+
+    result: Path | None = None
+    if dependency.is_virtual:
+        if dependency.is_virtual_subdirectory():
+            if dependency.is_azure_devops() and len(repo_parts) >= 3:
+                result = apm_modules_dir.joinpath(
+                    repo_parts[0],
+                    repo_parts[1],
+                    repo_parts[2],
+                    dependency.virtual_path,
+                )
+            elif len(repo_parts) >= 2:
+                result = apm_modules_dir.joinpath(
+                    *repo_parts,
+                    dependency.virtual_path,
+                )
+        else:
+            package_name = dependency.get_virtual_package_name()
+            if dependency.is_azure_devops() and len(repo_parts) >= 3:
+                result = apm_modules_dir / repo_parts[0] / repo_parts[1] / package_name
+            elif len(repo_parts) >= 2:
+                result = apm_modules_dir / repo_parts[0] / package_name
+    elif dependency.is_azure_devops() and len(repo_parts) >= 3:
+        result = apm_modules_dir / repo_parts[0] / repo_parts[1] / repo_parts[2]
+    elif len(repo_parts) >= 2:
+        result = apm_modules_dir.joinpath(*repo_parts)
+
+    if result is None:
+        result = apm_modules_dir.joinpath(*repo_parts)
+    ensure_path_within(result, apm_modules_dir)
+    return result
+
+
+def _relative_parts(desired: Path, apm_modules_dir: Path) -> tuple[str, ...]:
+    """Validate and return *desired* components below ``apm_modules``."""
+    ensure_path_within(desired, apm_modules_dir)
+    try:
+        relative = desired.absolute().relative_to(apm_modules_dir.absolute())
+    except ValueError as exc:
+        raise MaterializationPathCollisionError(
+            f"Materialization path escapes apm_modules: {desired}"
+        ) from exc
+    return relative.parts
+
+
+def _candidate_matches(
+    desired_parts: Sequence[str],
+    candidate_relatives: Iterable[PurePosixPath],
+) -> list[PurePosixPath]:
+    """Return candidates with the same component-wise casefolded identity."""
+    expected = tuple(part.casefold() for part in desired_parts)
+    return sorted(
+        (
+            candidate
+            for candidate in candidate_relatives
+            if tuple(part.casefold() for part in candidate.parts) == expected
+        ),
+        key=lambda value: value.as_posix(),
+    )
+
+
+def find_case_equivalent_materialization_path(
+    desired: Path,
+    apm_modules_dir: Path,
+    *,
+    reader: MaterializationPathReader = _NATIVE_READER,
+    candidate_relatives: Iterable[PurePosixPath] | None = None,
+) -> Path | None:
+    """Find the sole existing path whose components differ only by casing."""
+    desired_parts = _relative_parts(desired, apm_modules_dir)
+    if candidate_relatives is not None:
+        matches = _candidate_matches(desired_parts, candidate_relatives)
+        if len(matches) > 1:
+            rendered = ", ".join(match.as_posix() for match in matches)
+            raise MaterializationPathCollisionError(
+                f"Found multiple materialization paths for one package identity: {rendered}"
+            )
+        return apm_modules_dir.joinpath(*matches[0].parts) if matches else None
+
+    current = apm_modules_dir
+    for desired_part in desired_parts:
+        if not reader.is_dir(current):
+            return None
+        matches = sorted(
+            (
+                child
+                for child in reader.iterdir(current)
+                if child.name.casefold() == desired_part.casefold()
+            ),
+            key=lambda child: child.name,
+        )
+        if len(matches) > 1:
+            rendered = ", ".join(str(match) for match in matches)
+            raise MaterializationPathCollisionError(
+                f"Found multiple materialization paths for one package identity: {rendered}"
+            )
+        if not matches:
+            return None
+        current = matches[0]
+    return current
+
+
+def _relocate_case_components(
+    existing: Path,
+    desired: Path,
+    apm_modules_dir: Path,
+    staging_session: ResolutionStagingSession,
+    reader: MaterializationPathReader,
+) -> None:
+    """Rename case-different components top-down through the transaction."""
+    existing_parts = _relative_parts(existing, apm_modules_dir)
+    desired_parts = _relative_parts(desired, apm_modules_dir)
+    current_parent = apm_modules_dir
+    for existing_part, desired_part in zip(existing_parts, desired_parts, strict=True):
+        source = current_parent / existing_part
+        target = current_parent / desired_part
+        if existing_part != desired_part:
+            if reader.exists(target):
+                if not reader.samefile(source, target):
+                    raise MaterializationPathCollisionError(
+                        f"Materialization path collision between {source} and {target}"
+                    )
+            staging_session.relocate_path(source, target)
+        current_parent = target
+
+
+def prepare_materialization_path(
+    dependency: DependencyReference,
+    apm_modules_dir: Path,
+    staging_session: ResolutionStagingSession,
+    *,
+    reader: MaterializationPathReader = _NATIVE_READER,
+) -> Path:
+    """Return the display-cased path, transactionally migrating stale casing."""
+    desired = dependency.get_install_path(apm_modules_dir)
+    if not dependency.has_case_insensitive_repo_identity:
+        return desired
+
+    existing = find_case_equivalent_materialization_path(
+        desired,
+        apm_modules_dir,
+        reader=reader,
+    )
+    if existing is None or existing == desired:
+        return desired
+    _relocate_case_components(
+        existing,
+        desired,
+        apm_modules_dir,
+        staging_session,
+        reader,
+    )
+    return desired

--- a/src/apm_cli/models/dependency/materialization.py
+++ b/src/apm_cli/models/dependency/materialization.py
@@ -6,6 +6,7 @@ import hashlib
 import os
 import threading
 from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Protocol
 
@@ -57,6 +58,14 @@ class _NativeMaterializationPathReader:
 
 
 _NATIVE_READER = _NativeMaterializationPathReader()
+
+
+@dataclass(frozen=True)
+class _MaterializationCasePolicy:
+    """Component-level casing rules for one materialized dependency path."""
+
+    casefold_parts: frozenset[int]
+    partial_repo_part: tuple[int, str, str] | None = None
 
 
 class CachedMaterializationPathReader:
@@ -172,16 +181,66 @@ def _relative_parts(desired: Path, apm_modules_dir: Path) -> tuple[str, ...]:
 def _candidate_matches(
     desired_parts: Sequence[str],
     candidate_relatives: Iterable[PurePosixPath],
+    policy: _MaterializationCasePolicy,
 ) -> list[PurePosixPath]:
-    """Return candidates with the same component-wise casefolded identity."""
-    expected = tuple(part.casefold() for part in desired_parts)
+    """Return candidates matching the dependency's component casing contract."""
     return sorted(
         (
             candidate
             for candidate in candidate_relatives
-            if tuple(part.casefold() for part in candidate.parts) == expected
+            if _parts_match(desired_parts, candidate.parts, policy)
         ),
         key=lambda value: value.as_posix(),
+    )
+
+
+def _parts_match(
+    desired_parts: Sequence[str],
+    candidate_parts: Sequence[str],
+    policy: _MaterializationCasePolicy,
+) -> bool:
+    """Compare path parts without casefolding in-repository virtual paths."""
+    if len(desired_parts) != len(candidate_parts):
+        return False
+    for index, (desired, candidate) in enumerate(zip(desired_parts, candidate_parts, strict=True)):
+        if not _component_matches(index, desired, candidate, policy):
+            return False
+    return True
+
+
+def _component_matches(
+    index: int,
+    desired: str,
+    candidate: str,
+    policy: _MaterializationCasePolicy,
+) -> bool:
+    """Compare one materialized path component under the identity contract."""
+    if index in policy.casefold_parts:
+        return desired.casefold() == candidate.casefold()
+    partial = policy.partial_repo_part
+    if partial is not None and index == partial[0]:
+        repo_name, suffix = partial[1:]
+        if not candidate.endswith(suffix):
+            return False
+        candidate_repo = candidate[: -len(suffix)] if suffix else candidate
+        return candidate_repo.casefold() == repo_name.casefold()
+    return desired == candidate
+
+
+def _case_policy(dependency: DependencyReference) -> _MaterializationCasePolicy:
+    """Return case-insensitive repository components and exact virtual components."""
+    repo_parts = dependency.repo_url.split("/")
+    if not dependency.is_virtual or dependency.is_virtual_subdirectory():
+        return _MaterializationCasePolicy(
+            casefold_parts=frozenset(range(len(repo_parts))),
+        )
+
+    package_name = dependency.get_virtual_package_name()
+    repo_name = repo_parts[-1]
+    suffix = package_name[len(repo_name) :]
+    return _MaterializationCasePolicy(
+        casefold_parts=frozenset({0}),
+        partial_repo_part=(1, repo_name, suffix),
     )
 
 
@@ -189,13 +248,15 @@ def find_case_equivalent_materialization_path(
     desired: Path,
     apm_modules_dir: Path,
     *,
+    dependency: DependencyReference,
     reader: MaterializationPathReader = _NATIVE_READER,
     candidate_relatives: Iterable[PurePosixPath] | None = None,
 ) -> Path | None:
     """Find the sole existing path whose components differ only by casing."""
     desired_parts = _relative_parts(desired, apm_modules_dir)
+    policy = _case_policy(dependency)
     if candidate_relatives is not None:
-        matches = _candidate_matches(desired_parts, candidate_relatives)
+        matches = _candidate_matches(desired_parts, candidate_relatives, policy)
         if len(matches) > 1:
             rendered = ", ".join(match.as_posix() for match in matches)
             raise MaterializationPathCollisionError(
@@ -206,14 +267,14 @@ def find_case_equivalent_materialization_path(
         return apm_modules_dir.joinpath(*matches[0].parts) if matches else None
 
     current = apm_modules_dir
-    for desired_part in desired_parts:
+    for index, desired_part in enumerate(desired_parts):
         if not reader.is_dir(current):
             return None
         matches = sorted(
             (
                 child
                 for child in reader.iterdir(current)
-                if child.name.casefold() == desired_part.casefold()
+                if _component_matches(index, desired_part, child.name, policy)
             ),
             key=lambda child: child.name,
         )
@@ -273,6 +334,7 @@ def prepare_materialization_path(
     existing = find_case_equivalent_materialization_path(
         desired,
         apm_modules_dir,
+        dependency=dependency,
         reader=reader,
     )
     if existing is None or existing == desired:

--- a/src/apm_cli/models/dependency/materialization.py
+++ b/src/apm_cli/models/dependency/materialization.py
@@ -337,7 +337,7 @@ def prepare_materialization_path(
         dependency=dependency,
         reader=reader,
     )
-    if existing is None or existing == desired:
+    if existing is None or existing.parts == desired.parts:
         return desired
     _relocate_case_components(
         existing,

--- a/src/apm_cli/models/dependency/reference.py
+++ b/src/apm_cli/models/dependency/reference.py
@@ -22,7 +22,6 @@ from ...utils.github_host import (
 )
 from ...utils.path_security import (
     PathTraversalError,
-    ensure_path_within,
     validate_path_segments,
 )
 from ..validation import InvalidVirtualPackageExtensionError
@@ -36,8 +35,10 @@ from .identity import (
     _split_shorthand_host_port,
     build_canonical_dependency_string,
     build_dependency_unique_key,
+    is_case_insensitive_package_identity,
     normalize_package_repo_url,
 )
+from .materialization import build_materialization_path
 from .object_fields import (
     apply_optional_dependency_fields,
     local_path_apm_yml_entry,
@@ -118,10 +119,22 @@ class DependencyReference(ProviderCoordinateMixin):
     marketplace_plugin_name: str | None = None
     marketplace_version_spec: str | None = None
 
-    def __post_init__(self) -> None:
-        """Normalize case-insensitive package identity at the model boundary."""
-        self.repo_url = normalize_package_repo_url(
+    @property
+    def canonical_repo_url(self) -> str:
+        """Return the comparison-only repository identity."""
+        return normalize_package_repo_url(
             self.repo_url,
+            host=self.host,
+            source=self.source,
+            registry_prefix=self.artifactory_prefix,
+            is_local=self.is_local,
+            is_marketplace=self.is_marketplace,
+        )
+
+    @property
+    def has_case_insensitive_repo_identity(self) -> bool:
+        """Return whether repository casing is presentation-only."""
+        return is_case_insensitive_package_identity(
             host=self.host,
             source=self.source,
             registry_prefix=self.artifactory_prefix,
@@ -329,6 +342,7 @@ class DependencyReference(ProviderCoordinateMixin):
             registry_prefix=self.artifactory_prefix,
             declaring_parent=self.declaring_parent,
             anchored_local_path=self.anchored_local_path,
+            is_marketplace=self.is_marketplace,
         )
 
     def get_resolution_key(self) -> str:
@@ -342,6 +356,28 @@ class DependencyReference(ProviderCoordinateMixin):
         if self.is_local and self.anchored_local_path:
             return f"local:{self.anchored_local_path}"
         return self.get_unique_key()
+
+    def _format_reference(self, repo_url: str) -> str:
+        """Format one scheme-free reference from the supplied repository path."""
+        if self.is_local and self.local_path:
+            return self.local_path
+
+        host = self.host or default_host()
+        is_default = host.lower() == default_host().lower()
+        host_label = f"{host}:{self.port}" if self.port else host
+
+        if is_default and not self.port and not self.artifactory_prefix:
+            result = repo_url
+        elif self.artifactory_prefix:
+            result = f"{host_label}/{self.artifactory_prefix}/{repo_url}"
+        else:
+            result = f"{host_label}/{repo_url}"
+
+        if self.is_virtual and self.virtual_path:
+            result = f"{result}/{self.virtual_path}"
+        if self.reference:
+            result = f"{result}#{self.reference}"
+        return result
 
     def to_canonical(self) -> str:
         """Return the canonical scheme-free identity string for this dependency.
@@ -360,32 +396,11 @@ class DependencyReference(ProviderCoordinateMixin):
         Returns:
             str: Canonical dependency string
         """
-        if self.is_local and self.local_path:
-            return self.local_path
+        return self._format_reference(self.canonical_repo_url)
 
-        host = self.host or default_host()
-
-        is_default = host.lower() == default_host().lower()
-        # Custom port is part of the transport and must travel with the host label.
-        host_label = f"{host}:{self.port}" if self.port else host
-
-        # Start with optional host prefix
-        if is_default and not self.port and not self.artifactory_prefix:
-            result = self.repo_url
-        elif self.artifactory_prefix:
-            result = f"{host_label}/{self.artifactory_prefix}/{self.repo_url}"
-        else:
-            result = f"{host_label}/{self.repo_url}"
-
-        # Append virtual path for virtual packages
-        if self.is_virtual and self.virtual_path:
-            result = f"{result}/{self.virtual_path}"
-
-        # Append reference (branch, tag, commit)
-        if self.reference:
-            result = f"{result}#{self.reference}"
-
-        return result
+    def to_display_reference(self) -> str:
+        """Return a portable reference retaining source repository casing."""
+        return self._format_reference(self.repo_url)
 
     def get_identity(self) -> str:
         """Return the identity of this dependency (canonical form without ref/alias).
@@ -401,14 +416,16 @@ class DependencyReference(ProviderCoordinateMixin):
 
         host = self.host or default_host()
         is_default = host.lower() == default_host().lower()
-        host_label = f"{host}:{self.port}" if self.port else host
+        normalized_host = host.lower()
+        host_label = f"{normalized_host}:{self.port}" if self.port else normalized_host
+        repo_url = self.canonical_repo_url
 
         if is_default and not self.port and not self.artifactory_prefix:
-            result = self.repo_url
+            result = repo_url
         elif self.artifactory_prefix:
-            result = f"{host_label}/{self.artifactory_prefix}/{self.repo_url}"
+            result = f"{host_label}/{self.artifactory_prefix}/{repo_url}"
         else:
-            result = f"{host_label}/{self.repo_url}"
+            result = f"{host_label}/{repo_url}"
 
         if self.is_virtual and self.virtual_path:
             result = f"{result}/{self.virtual_path}"
@@ -443,7 +460,7 @@ class DependencyReference(ProviderCoordinateMixin):
             str: Host-blind canonical string (e.g., "owner/repo")
         """
         return build_canonical_dependency_string(
-            self.repo_url,
+            self.canonical_repo_url,
             is_local=self.is_local,
             local_path=self.local_path,
             is_virtual=self.is_virtual,
@@ -464,80 +481,7 @@ class DependencyReference(ProviderCoordinateMixin):
         Returns:
             Path: Absolute path to the package installation directory
         """
-        if self.is_marketplace:
-            raise ValueError(
-                f"Cannot compute install path for unresolved marketplace dependency "
-                f"'{self.marketplace_plugin_name}@{self.marketplace_name}'"
-            )
-
-        if self.is_local and self.local_path:
-            pkg_dir_name = Path(self.local_path).name
-            validate_path_segments(
-                pkg_dir_name,
-                context="local package path",
-                reject_empty=True,
-            )
-            if self.declaring_parent:
-                import hashlib
-
-                identity = self.anchored_local_path or self.local_path
-                parent_slot = hashlib.sha256(identity.encode("utf-8")).hexdigest()[:12]
-                result = apm_modules_dir / "_local" / parent_slot / pkg_dir_name
-            else:
-                result = apm_modules_dir / "_local" / pkg_dir_name
-            ensure_path_within(result, apm_modules_dir)
-            return result
-
-        repo_parts = self.repo_url.split("/")
-
-        # Security: reject traversal in repo_url segments (catches lockfile injection)
-        validate_path_segments(self.repo_url, context="repo_url")
-
-        # Security: reject traversal in virtual_path (catches lockfile injection)
-        if self.virtual_path:
-            validate_path_segments(self.virtual_path, context="virtual_path")
-        result: Path | None = None
-
-        if self.is_virtual:
-            # Subdirectory packages (like Claude Skills) should use natural path structure
-            if self.is_virtual_subdirectory():
-                # Use repo path + subdirectory path
-                if self.is_azure_devops() and len(repo_parts) >= 3:
-                    # ADO: org/project/repo/subdir
-                    result = (
-                        apm_modules_dir
-                        / repo_parts[0]
-                        / repo_parts[1]
-                        / repo_parts[2]
-                        / self.virtual_path
-                    )
-                elif len(repo_parts) >= 2:
-                    # owner/repo/subdir or group/subgroup/repo/subdir
-                    result = apm_modules_dir.joinpath(*repo_parts, self.virtual_path)
-            else:
-                # Virtual file/collection: use sanitized package name (flattened)
-                package_name = self.get_virtual_package_name()
-                if self.is_azure_devops() and len(repo_parts) >= 3:
-                    # ADO: org/project/virtual-pkg-name
-                    result = apm_modules_dir / repo_parts[0] / repo_parts[1] / package_name
-                elif len(repo_parts) >= 2:
-                    # owner/virtual-pkg-name (use first segment as namespace)
-                    result = apm_modules_dir / repo_parts[0] / package_name
-        # Regular package: use full repo path
-        elif self.is_azure_devops() and len(repo_parts) >= 3:
-            # ADO: org/project/repo
-            result = apm_modules_dir / repo_parts[0] / repo_parts[1] / repo_parts[2]
-        elif len(repo_parts) >= 2:
-            # owner/repo or group/subgroup/repo (generic hosts)
-            result = apm_modules_dir.joinpath(*repo_parts)
-
-        if result is None:
-            # Fallback: join all parts
-            result = apm_modules_dir.joinpath(*repo_parts)
-
-        # Security: ensure the computed path stays within apm_modules/
-        ensure_path_within(result, apm_modules_dir)
-        return result
+        return build_materialization_path(self, apm_modules_dir)
 
     @staticmethod
     def _reject_shorthand_alias(dependency_str: str) -> None:
@@ -1992,7 +1936,7 @@ class DependencyReference(ProviderCoordinateMixin):
         - HTTP (insecure) git deps: returns a dict with 'git' and 'allow_insecure' keys.
         - Git deps with skill_subset or target_subset: returns a dict with 'git' plus
           the applicable optional keys.
-        - All other deps: returns the canonical string (same as to_canonical()).
+        - All other deps: returns a scheme-free string retaining repository casing.
 
         Returns:
             str or dict: String for simple deps; dict for local-with-subsets, HTTP, or
@@ -2014,7 +1958,7 @@ class DependencyReference(ProviderCoordinateMixin):
                     self.skill_subset,
                     self.target_subset,
                 )
-            return self.to_canonical()
+            return self.to_display_reference()
         if self.is_insecure:
             host = self.host or default_host()
             netloc = f"{host}:{self.port}" if self.port else host
@@ -2030,7 +1974,7 @@ class DependencyReference(ProviderCoordinateMixin):
                 entry["targets"] = sorted(self.target_subset)
             return entry
         if self.skill_subset or self.target_subset:
-            entry = {"git": self.get_identity()}
+            entry = {"git": self._format_reference(self.repo_url).split("#", 1)[0]}
             if self.reference:
                 entry["ref"] = self.reference
             if self.alias:
@@ -2040,7 +1984,7 @@ class DependencyReference(ProviderCoordinateMixin):
             if self.target_subset:
                 entry["targets"] = sorted(self.target_subset)
             return entry
-        return self.to_canonical()
+        return self.to_display_reference()
 
     def to_github_url(self) -> str:
         """Convert to the canonical repository URL, or return a local path."""

--- a/src/apm_cli/utils/paths.py
+++ b/src/apm_cli/utils/paths.py
@@ -6,6 +6,8 @@ call site gets Windows-safe, forward-slash relative paths by default.
 
 from __future__ import annotations
 
+import os
+from collections.abc import Callable
 from pathlib import Path
 
 
@@ -25,6 +27,20 @@ def portable_relpath(path: Path, base: Path) -> str:
             return path.resolve().as_posix()
         except (OSError, RuntimeError):
             return path.as_posix()
+
+
+def portable_link_relpath(
+    path: str | Path,
+    base: str | Path,
+    *,
+    relpath: Callable[[str, str], str] = os.path.relpath,
+) -> str | None:
+    """Return a relative Markdown path, or ``None`` across incompatible drives."""
+    try:
+        relative = relpath(str(path), str(base))
+    except (OSError, ValueError):
+        return None
+    return relative.replace("\\", "/")
 
 
 def resolve_base_and_source_dirs(

--- a/tests/benchmarks/test_lookup_and_cache_benchmarks.py
+++ b/tests/benchmarks/test_lookup_and_cache_benchmarks.py
@@ -1,7 +1,7 @@
 """Performance benchmarks for optimised lookup and cache paths.
 
 Covers the fixes from the performance audit:
-- has_dependency() O(1) index lookup (was O(n) linear scan)
+- has_dependency() O(1) lookup index (was O(n) linear scan)
 - HttpCache._enforce_size_cap() fast-path (was unconditional full scan)
 - github_host env-var helper consolidation (was repeated parsing)
 
@@ -51,7 +51,7 @@ def _build_tree(n: int) -> DependencyTree:
 
 
 # ---------------------------------------------------------------------------
-# 1. has_dependency() -- O(1) via _repo_url_index
+# 1. has_dependency() -- O(1) via _repo_lookup_index
 # ---------------------------------------------------------------------------
 
 
@@ -94,7 +94,7 @@ class TestHasDependencyScaling:
         assert t < 1e-4, f"Negative lookup took {t:.6f}s"
 
     def test_index_consistency(self):
-        """_repo_url_index matches brute-force scan."""
+        """The repository lookup index matches brute-force scan."""
         tree = _build_tree(200)
         for node in tree.nodes.values():
             url = node.dependency_ref.repo_url

--- a/tests/fixtures/spec-conformance/lockfile/materialization-sort-exclusion.yml
+++ b/tests/fixtures/spec-conformance/lockfile/materialization-sort-exclusion.yml
@@ -1,0 +1,10 @@
+# Exercises: req-lk-005, req-lk-022
+# Canonical repo_url order is alpha, beta. Display spelling would sort beta first.
+lockfile_version: "1"
+dependencies:
+  - repo_url: github.com/contoso/alpha
+    materialization_repo_url: github.com/Contoso/alpha
+    resolved_commit: "1111111111111111111111111111111111111111"
+  - repo_url: github.com/contoso/beta
+    materialization_repo_url: GitHub.com/Contoso/Beta
+    resolved_commit: "2222222222222222222222222222222222222222"

--- a/tests/fixtures/spec-conformance/lockfile/v1-git-only.yml
+++ b/tests/fixtures/spec-conformance/lockfile/v1-git-only.yml
@@ -1,10 +1,11 @@
-# Exercises: req-lk-001, req-lk-002, req-lk-003, req-lk-014, req-lk-015
+# Exercises: req-lk-001, req-lk-002, req-lk-003, req-lk-014, req-lk-015, req-lk-022
 # Valid v1 lockfile: no registry-sourced entries, git-only with tree_sha256.
 lockfile_version: "1"
 generated_at: "2026-05-10T20:14:00+00:00"
 apm_version: "0.7.0"
 dependencies:
   - repo_url: github.com/contoso/example
+    materialization_repo_url: GitHub.com/Contoso/Example
     resolved_commit: "7f3c9a4d2e1b8c7f0a9e6d5c4b3a2918f7e6d5c4"
     resolved_ref: v1.2.0
     tree_sha256: "sha256:a1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff00"

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -2306,7 +2306,7 @@ def test_git_auth_header_injection_has_single_owner() -> None:
 
 
 def test_dependency_identity_and_materialization_path_have_separate_owners() -> None:
-    """AC27 keeps canonical comparison casing out of filesystem path construction."""
+    """AC28 keeps canonical comparison casing out of filesystem path construction."""
     root = Path(__file__).parents[2]
     identity = (root / "src/apm_cli/models/dependency/identity.py").read_text(encoding="utf-8")
     materialization = (root / "src/apm_cli/models/dependency/materialization.py").read_text(
@@ -2330,7 +2330,7 @@ def test_dependency_identity_and_materialization_path_have_separate_owners() -> 
     owner_row = "| Dependency comparison identity vs display-cased materialization path |"
     assert owner_row in canonical_owners
     assert owner_row in owner_mirror
-    assert "AC27: dependency identity and materialization path authority" in guard
+    assert "AC28: dependency identity and materialization path authority" in guard
     assert (
         "Dependency identity may casefold only in identity.py; "
         "materialization must preserve source casing" in guard
@@ -2340,7 +2340,7 @@ def test_dependency_identity_and_materialization_path_have_separate_owners() -> 
 def test_dependency_materialization_owner_guard_rejects_canonical_path_reuse(
     tmp_path: Path,
 ) -> None:
-    """AC27 rejects routing the filesystem path back through lowercase identity."""
+    """AC28 rejects routing the filesystem path back through lowercase identity."""
     root = Path(__file__).parents[2]
     sandbox = tmp_path / "repo"
     shutil.copytree(

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -2306,7 +2306,7 @@ def test_git_auth_header_injection_has_single_owner() -> None:
 
 
 def test_dependency_identity_and_materialization_path_have_separate_owners() -> None:
-    """AC20 keeps canonical comparison casing out of filesystem path construction."""
+    """AC25 keeps canonical comparison casing out of filesystem path construction."""
     root = Path(__file__).parents[2]
     identity = (root / "src/apm_cli/models/dependency/identity.py").read_text(encoding="utf-8")
     materialization = (root / "src/apm_cli/models/dependency/materialization.py").read_text(
@@ -2330,7 +2330,7 @@ def test_dependency_identity_and_materialization_path_have_separate_owners() -> 
     owner_row = "| Dependency comparison identity vs display-cased materialization path |"
     assert owner_row in canonical_owners
     assert owner_row in owner_mirror
-    assert "AC20: dependency identity and materialization path authority" in guard
+    assert "AC25: dependency identity and materialization path authority" in guard
     assert (
         "Dependency identity may casefold only in identity.py; "
         "materialization must preserve source casing" in guard
@@ -2340,7 +2340,7 @@ def test_dependency_identity_and_materialization_path_have_separate_owners() -> 
 def test_dependency_materialization_owner_guard_rejects_canonical_path_reuse(
     tmp_path: Path,
 ) -> None:
-    """AC20 rejects routing the filesystem path back through lowercase identity."""
+    """AC25 rejects routing the filesystem path back through lowercase identity."""
     root = Path(__file__).parents[2]
     sandbox = tmp_path / "repo"
     shutil.copytree(

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -2306,7 +2306,7 @@ def test_git_auth_header_injection_has_single_owner() -> None:
 
 
 def test_dependency_identity_and_materialization_path_have_separate_owners() -> None:
-    """AC28 keeps canonical comparison casing out of filesystem path construction."""
+    """AC29 keeps canonical comparison casing out of filesystem path construction."""
     root = Path(__file__).parents[2]
     identity = (root / "src/apm_cli/models/dependency/identity.py").read_text(encoding="utf-8")
     materialization = (root / "src/apm_cli/models/dependency/materialization.py").read_text(
@@ -2330,7 +2330,7 @@ def test_dependency_identity_and_materialization_path_have_separate_owners() -> 
     owner_row = "| Dependency comparison identity vs display-cased materialization path |"
     assert owner_row in canonical_owners
     assert owner_row in owner_mirror
-    assert "AC28: dependency identity and materialization path authority" in guard
+    assert "AC29: dependency identity and materialization path authority" in guard
     assert (
         "Dependency identity may casefold only in identity.py; "
         "materialization must preserve source casing" in guard
@@ -2340,7 +2340,7 @@ def test_dependency_identity_and_materialization_path_have_separate_owners() -> 
 def test_dependency_materialization_owner_guard_rejects_canonical_path_reuse(
     tmp_path: Path,
 ) -> None:
-    """AC28 rejects routing the filesystem path back through lowercase identity."""
+    """AC29 rejects routing the filesystem path back through lowercase identity."""
     root = Path(__file__).parents[2]
     sandbox = tmp_path / "repo"
     shutil.copytree(

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -2306,7 +2306,7 @@ def test_git_auth_header_injection_has_single_owner() -> None:
 
 
 def test_dependency_identity_and_materialization_path_have_separate_owners() -> None:
-    """AC26 keeps canonical comparison casing out of filesystem path construction."""
+    """AC27 keeps canonical comparison casing out of filesystem path construction."""
     root = Path(__file__).parents[2]
     identity = (root / "src/apm_cli/models/dependency/identity.py").read_text(encoding="utf-8")
     materialization = (root / "src/apm_cli/models/dependency/materialization.py").read_text(
@@ -2330,7 +2330,7 @@ def test_dependency_identity_and_materialization_path_have_separate_owners() -> 
     owner_row = "| Dependency comparison identity vs display-cased materialization path |"
     assert owner_row in canonical_owners
     assert owner_row in owner_mirror
-    assert "AC26: dependency identity and materialization path authority" in guard
+    assert "AC27: dependency identity and materialization path authority" in guard
     assert (
         "Dependency identity may casefold only in identity.py; "
         "materialization must preserve source casing" in guard
@@ -2340,7 +2340,7 @@ def test_dependency_identity_and_materialization_path_have_separate_owners() -> 
 def test_dependency_materialization_owner_guard_rejects_canonical_path_reuse(
     tmp_path: Path,
 ) -> None:
-    """AC26 rejects routing the filesystem path back through lowercase identity."""
+    """AC27 rejects routing the filesystem path back through lowercase identity."""
     root = Path(__file__).parents[2]
     sandbox = tmp_path / "repo"
     shutil.copytree(

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -1469,7 +1469,6 @@ def test_target_instruction_contraction_uses_manifest_reconciliation() -> None:
     architecture = (root / ".apm/instructions/architecture.instructions.md").read_text(
         encoding="utf-8"
     )
-
     assert checker.analyze_paths(root) == []
     assert "AC15a: target-specific instruction contraction authority" in guard
     assert (
@@ -2315,6 +2314,12 @@ def test_dependency_identity_and_materialization_path_have_separate_owners() -> 
     )
     reference = (root / "src/apm_cli/models/dependency/reference.py").read_text(encoding="utf-8")
     guard = (root / "scripts/lint-architecture-boundaries.sh").read_text(encoding="utf-8")
+    canonical_owners = (root / ".apm/instructions/architecture.instructions.md").read_text(
+        encoding="utf-8"
+    )
+    owner_mirror = (root / ".github/instructions/architecture.instructions.md").read_text(
+        encoding="utf-8"
+    )
 
     assert "def build_dependency_unique_key(" in identity
     assert "key = normalize_package_repo_url(" in identity
@@ -2322,6 +2327,9 @@ def test_dependency_identity_and_materialization_path_have_separate_owners() -> 
     assert 'repo_parts = dependency.repo_url.split("/")' in materialization
     assert "def prepare_materialization_path(" in materialization
     assert "return build_materialization_path(self, apm_modules_dir)" in reference
+    owner_row = "| Dependency comparison identity vs display-cased materialization path |"
+    assert owner_row in canonical_owners
+    assert owner_row in owner_mirror
     assert "AC20: dependency identity and materialization path authority" in guard
     assert (
         "Dependency identity may casefold only in identity.py; "

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -2306,6 +2306,75 @@ def test_git_auth_header_injection_has_single_owner() -> None:
     )
 
 
+def test_dependency_identity_and_materialization_path_have_separate_owners() -> None:
+    """AC20 keeps canonical comparison casing out of filesystem path construction."""
+    root = Path(__file__).parents[2]
+    identity = (root / "src/apm_cli/models/dependency/identity.py").read_text(encoding="utf-8")
+    materialization = (root / "src/apm_cli/models/dependency/materialization.py").read_text(
+        encoding="utf-8"
+    )
+    reference = (root / "src/apm_cli/models/dependency/reference.py").read_text(encoding="utf-8")
+    guard = (root / "scripts/lint-architecture-boundaries.sh").read_text(encoding="utf-8")
+
+    assert "def build_dependency_unique_key(" in identity
+    assert "key = normalize_package_repo_url(" in identity
+    assert "def build_materialization_path(" in materialization
+    assert 'repo_parts = dependency.repo_url.split("/")' in materialization
+    assert "def prepare_materialization_path(" in materialization
+    assert "return build_materialization_path(self, apm_modules_dir)" in reference
+    assert "AC20: dependency identity and materialization path authority" in guard
+    assert (
+        "Dependency identity may casefold only in identity.py; "
+        "materialization must preserve source casing" in guard
+    )
+
+
+def test_dependency_materialization_owner_guard_rejects_canonical_path_reuse(
+    tmp_path: Path,
+) -> None:
+    """AC20 rejects routing the filesystem path back through lowercase identity."""
+    root = Path(__file__).parents[2]
+    sandbox = tmp_path / "repo"
+    shutil.copytree(
+        root,
+        sandbox,
+        ignore=shutil.ignore_patterns(
+            ".git",
+            ".venv",
+            ".pytest_cache",
+            "__pycache__",
+            "build",
+            "dist",
+            "node_modules",
+        ),
+    )
+    owner_path = sandbox / "src/apm_cli/models/dependency/materialization.py"
+    source = owner_path.read_text(encoding="utf-8")
+    owner_path.write_text(
+        source.replace(
+            'repo_parts = dependency.repo_url.split("/")',
+            'repo_parts = dependency.canonical_repo_url.split("/")',
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ("bash", "scripts/lint-architecture-boundaries.sh"),
+        cwd=sandbox,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+
+    assert result.returncode == 1
+    assert (
+        "Dependency identity may casefold only in identity.py; "
+        "materialization must preserve source casing" in result.stdout
+    )
+
+
 def test_git_auth_header_owner_guard_rejects_dictmerge_reintroduction(tmp_path: Path) -> None:
     """AC19 must reject a re-introduced dict-merge of the build_* overlay
     onto a populated env -- the exact #2368 clobber pattern.

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -2306,7 +2306,7 @@ def test_git_auth_header_injection_has_single_owner() -> None:
 
 
 def test_dependency_identity_and_materialization_path_have_separate_owners() -> None:
-    """AC25 keeps canonical comparison casing out of filesystem path construction."""
+    """AC26 keeps canonical comparison casing out of filesystem path construction."""
     root = Path(__file__).parents[2]
     identity = (root / "src/apm_cli/models/dependency/identity.py").read_text(encoding="utf-8")
     materialization = (root / "src/apm_cli/models/dependency/materialization.py").read_text(
@@ -2330,7 +2330,7 @@ def test_dependency_identity_and_materialization_path_have_separate_owners() -> 
     owner_row = "| Dependency comparison identity vs display-cased materialization path |"
     assert owner_row in canonical_owners
     assert owner_row in owner_mirror
-    assert "AC25: dependency identity and materialization path authority" in guard
+    assert "AC26: dependency identity and materialization path authority" in guard
     assert (
         "Dependency identity may casefold only in identity.py; "
         "materialization must preserve source casing" in guard
@@ -2340,7 +2340,7 @@ def test_dependency_identity_and_materialization_path_have_separate_owners() -> 
 def test_dependency_materialization_owner_guard_rejects_canonical_path_reuse(
     tmp_path: Path,
 ) -> None:
-    """AC25 rejects routing the filesystem path back through lowercase identity."""
+    """AC26 rejects routing the filesystem path back through lowercase identity."""
     root = Path(__file__).parents[2]
     sandbox = tmp_path / "repo"
     shutil.copytree(

--- a/tests/integration/test_marketplace_tag_pattern_lifecycle.py
+++ b/tests/integration/test_marketplace_tag_pattern_lifecycle.py
@@ -25,6 +25,7 @@ pytestmark = [
     pytest.mark.integration,
     pytest.mark.e2e,
     pytest.mark.lifecycle_smoke,
+    pytest.mark.lifecycle_merge_group,
     pytest.mark.requires_apm_binary,
     pytest.mark.requires_e2e_mode,
 ]

--- a/tests/integration/test_mixed_case_materialization_lifecycle.py
+++ b/tests/integration/test_mixed_case_materialization_lifecycle.py
@@ -20,7 +20,6 @@ pytestmark = [
     pytest.mark.integration,
     pytest.mark.e2e,
     pytest.mark.lifecycle_smoke,
-    pytest.mark.lifecycle_merge_group,
     pytest.mark.requires_apm_binary,
     pytest.mark.requires_e2e_mode,
 ]

--- a/tests/integration/test_mixed_case_materialization_lifecycle.py
+++ b/tests/integration/test_mixed_case_materialization_lifecycle.py
@@ -241,7 +241,7 @@ def test_mixed_case_links_survive_install_update_audit_and_uninstall(
     _run(
         runner,
         consumer,
-        _INSTALL,
+        (*_INSTALL, "--verbose"),
         environment=child_env,
         scenario_id="mixed-case-repeat",
     )

--- a/tests/integration/test_mixed_case_materialization_lifecycle.py
+++ b/tests/integration/test_mixed_case_materialization_lifecycle.py
@@ -20,6 +20,7 @@ pytestmark = [
     pytest.mark.integration,
     pytest.mark.e2e,
     pytest.mark.lifecycle_smoke,
+    pytest.mark.lifecycle_merge_group,
     pytest.mark.requires_apm_binary,
     pytest.mark.requires_e2e_mode,
 ]

--- a/tests/integration/test_mixed_case_materialization_lifecycle.py
+++ b/tests/integration/test_mixed_case_materialization_lifecycle.py
@@ -1,0 +1,334 @@
+"""Installed-binary lifecycle coverage for mixed-case GitHub paths."""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+from apm_cli.deps.lockfile import LockFile
+from apm_cli.utils.yaml_io import dump_yaml, load_yaml
+from tests.utils.apm_lifecycle_runner import ApmLifecycleRunner, CommandResult
+from tests.utils.isolated_apm_environment import IsolatedApmEnvironment
+from tests.utils.lifecycle_state import LifecycleStateSnapshot
+from tests.utils.local_git_repository import LocalGitRepositoryFactory
+from tests.utils.local_package import LocalPackage, LocalPackageFactory
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.e2e,
+    pytest.mark.lifecycle_smoke,
+    pytest.mark.requires_apm_binary,
+    pytest.mark.requires_e2e_mode,
+]
+
+_OWNER = "MixedOrg"
+_PARENT_REPO = "MixedParent"
+_CHILD_REPO = "MixedChild"
+_PARENT_REMOTE = f"https://github.com/{_OWNER}/{_PARENT_REPO}"
+_CHILD_REMOTE = f"https://github.com/{_OWNER}/{_CHILD_REPO}"
+_INSTALL = (
+    "install",
+    "--target",
+    "copilot,cursor",
+    "--no-policy",
+    "--parallel-downloads",
+    "0",
+)
+_MARKDOWN_LINK = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
+
+
+def _instruction(marker: str) -> str:
+    return (
+        "---\n"
+        "applyTo: '**'\n"
+        f"description: Mixed-case lifecycle instruction {marker}\n"
+        "---\n"
+        f"# {marker}\n\n"
+        "[nested guide](../../skills/linked/references/NestedGuide.md)\n"
+    )
+
+
+def _agent(marker: str) -> str:
+    return (
+        "---\n"
+        f"description: Mixed-case lifecycle agent {marker}\n"
+        "---\n"
+        f"# {marker}\n\n"
+        "[nested guide](../../skills/linked/references/NestedGuide.md)\n"
+    )
+
+
+def _prompt(marker: str) -> str:
+    return (
+        "---\n"
+        f"description: Mixed-case lifecycle prompt {marker}\n"
+        "---\n"
+        f"# {marker}\n\n"
+        "[nested guide](../../skills/linked/references/NestedGuide.md)\n"
+    )
+
+
+def _run(
+    runner: ApmLifecycleRunner,
+    project: LocalPackage,
+    args: tuple[str, ...],
+    *,
+    environment: dict[str, str],
+    scenario_id: str,
+) -> CommandResult:
+    result = runner.run(
+        args,
+        scenario_id=scenario_id,
+        cwd=project.root,
+        env=environment,
+    )
+    assert result.returncode == 0, (
+        f"{scenario_id} failed\nstdout={result.stdout!r}\nstderr={result.stderr!r}"
+    )
+    return result
+
+
+def _locked_dependencies(project: LocalPackage) -> list:
+    lock = LockFile.read(project.root / "apm.lock.yaml")
+    assert lock is not None
+    return lock.get_package_dependencies()
+
+
+def _managed_markdown_with_links(project: LocalPackage) -> tuple[Path, ...]:
+    paths: set[Path] = set()
+    for dependency in _locked_dependencies(project):
+        for relative in dependency.deployed_files:
+            candidate = project.root / relative
+            if (
+                not candidate.is_file()
+                or candidate.suffix != ".md"
+                or not candidate.name.startswith("child")
+            ):
+                continue
+            if _MARKDOWN_LINK.search(candidate.read_text(encoding="utf-8")):
+                paths.add(candidate)
+    return tuple(sorted(paths))
+
+
+def _assert_all_managed_links_resolve(project: LocalPackage) -> tuple[Path, ...]:
+    linked_files = _managed_markdown_with_links(project)
+    assert linked_files
+    for generated in linked_files:
+        content = generated.read_text(encoding="utf-8")
+        for raw_target in _MARKDOWN_LINK.findall(content):
+            path_text = raw_target.split("#", 1)[0].split("?", 1)[0]
+            assert path_text
+            assert "\\" not in path_text
+            target = Path(path_text)
+            assert not target.is_absolute()
+            resolved = (generated.parent / target).resolve()
+            assert resolved.is_file(), f"{generated}: broken link {raw_target!r}"
+            relative = resolved.relative_to(project.root.resolve())
+            parts = relative.parts
+            assert parts[:3] == ("apm_modules", _OWNER, _CHILD_REPO)
+    return linked_files
+
+
+def _rename_case_only(path: Path, new_name: str) -> Path:
+    """Force an on-disk case change through a same-directory intermediate."""
+    intermediate = path.with_name(f".case-stage-{new_name.casefold()}")
+    destination = path.with_name(new_name)
+    path.replace(intermediate)
+    intermediate.replace(destination)
+    return destination
+
+
+def _author_packages(
+    packages: LocalPackageFactory,
+) -> tuple[LocalPackage, LocalPackage]:
+    child = packages.create(_CHILD_REPO, targets=("copilot", "cursor"))
+    packages.add_instruction(child, "child", _instruction("child-v1"))
+    packages.add_agent(child, "child", _agent("child-v1"))
+    packages.add_prompt(child, "child", _prompt("child-v1"))
+    packages.add_skill(
+        child,
+        "linked",
+        "---\nname: linked\ndescription: Mixed-case linked skill\n---\n# Linked\n",
+    )
+    packages.add_relative_link(
+        child,
+        PurePosixPath("skills/linked/references/NestedGuide.md"),
+        PurePosixPath("../SKILL.md"),
+        label="skill source",
+    )
+
+    parent = packages.create(
+        _PARENT_REPO,
+        dependencies=({"git": _CHILD_REMOTE, "ref": "main"},),
+        targets=("copilot", "cursor"),
+    )
+    return parent, child
+
+
+def test_mixed_case_links_survive_install_update_audit_and_uninstall(
+    tmp_path: Path,
+    apm_binary_path: Path,
+) -> None:
+    """Canonical dedupe and display-cased links remain closed over the lifecycle."""
+    isolated = IsolatedApmEnvironment.create(
+        tmp_path / "mixed-case-lifecycle",
+        base_env=dict(os.environ),
+    )
+    environment = isolated.subprocess_env()
+    packages = LocalPackageFactory(isolated.package_root)
+    parent, child = _author_packages(packages)
+
+    repositories = LocalGitRepositoryFactory(
+        isolated.repository_root,
+        env=environment,
+    )
+    child_repository = repositories.create(_CHILD_REPO, source_tree=child.root)
+    child_v1 = repositories.commit(child_repository, message="seed mixed child")
+    parent_repository = repositories.create(_PARENT_REPO, source_tree=parent.root)
+    repositories.commit(parent_repository, message="seed mixed parent")
+    child_env = repositories.url_rewrite_subprocess_env_many(
+        (
+            (parent_repository, _PARENT_REMOTE),
+            (child_repository, _CHILD_REMOTE),
+        )
+    )
+
+    consumer = LocalPackageFactory(isolated.work_root).create(
+        "mixed-case-consumer",
+        dependencies=({"git": _PARENT_REMOTE, "ref": "main"},),
+        targets=("copilot", "cursor"),
+    )
+    runner = ApmLifecycleRunner(
+        (str(apm_binary_path),),
+        timeout_seconds=120,
+        scenario_timeout_seconds=360,
+    )
+
+    _run(
+        runner,
+        consumer,
+        _INSTALL,
+        environment=child_env,
+        scenario_id="mixed-case-install",
+    )
+    first_links = _assert_all_managed_links_resolve(consumer)
+    first_state = LifecycleStateSnapshot.capture(
+        consumer.root,
+        targets=("copilot", "cursor"),
+    )
+    locked = _locked_dependencies(consumer)
+    assert len(locked) == 2
+    assert {dependency.repo_url for dependency in locked} == {
+        "mixedorg/mixedparent",
+        "mixedorg/mixedchild",
+    }
+    assert {dependency.materialization_repo_url for dependency in locked} == {
+        f"{_OWNER}/{_PARENT_REPO}",
+        f"{_OWNER}/{_CHILD_REPO}",
+    }
+    assert (consumer.root / "apm_modules" / _OWNER / _PARENT_REPO).is_dir()
+    assert (consumer.root / "apm_modules" / _OWNER / _CHILD_REPO).is_dir()
+    assert child_v1.sha in (consumer.root / "apm.lock.yaml").read_text(encoding="utf-8")
+
+    owner_path = consumer.root / "apm_modules" / _OWNER
+    _rename_case_only(owner_path / _PARENT_REPO, _PARENT_REPO.casefold())
+    _rename_case_only(owner_path / _CHILD_REPO, _CHILD_REPO.casefold())
+    _rename_case_only(owner_path, _OWNER.casefold())
+
+    _run(
+        runner,
+        consumer,
+        _INSTALL,
+        environment=child_env,
+        scenario_id="mixed-case-repeat",
+    )
+    repeated_state = LifecycleStateSnapshot.capture(
+        consumer.root,
+        targets=("copilot", "cursor"),
+    )
+    assert repeated_state.semantic_bytes == first_state.semantic_bytes
+    migrated_owner = consumer.root / "apm_modules" / _OWNER
+    assert sorted(path.name for path in migrated_owner.iterdir() if path.is_dir()) == [
+        _CHILD_REPO,
+        _PARENT_REPO,
+    ]
+    _assert_all_managed_links_resolve(consumer)
+
+    stale_managed = first_links[0]
+    stale_managed.write_text(
+        stale_managed.read_text(encoding="utf-8").replace(
+            f"{_OWNER}/{_CHILD_REPO}",
+            "mixedorg/mixedchild",
+        ),
+        encoding="utf-8",
+    )
+    user_file = consumer.root / ".github" / "instructions" / "user-owned.instructions.md"
+    user_file.write_text(
+        "# User-owned\n\n[user link](../../apm_modules/mixedorg/mixedchild/user.md)\n",
+        encoding="utf-8",
+    )
+    user_bytes = user_file.read_bytes()
+
+    _run(
+        runner,
+        consumer,
+        _INSTALL,
+        environment=child_env,
+        scenario_id="mixed-case-repair-stale-link",
+    )
+    assert f"{_OWNER}/{_CHILD_REPO}" in stale_managed.read_text(encoding="utf-8")
+    assert user_file.read_bytes() == user_bytes
+    _assert_all_managed_links_resolve(consumer)
+
+    child_instruction = (
+        child_repository.worktree / ".apm" / "instructions" / "child.instructions.md"
+    )
+    child_instruction.write_text(_instruction("child-v2"), encoding="utf-8")
+    child_v2 = repositories.commit(child_repository, message="advance mixed child")
+    assert child_v2.sha != child_v1.sha
+    parent_manifest = parent_repository.worktree / "apm.yml"
+    parent_document = load_yaml(parent_manifest)
+    parent_document["dependencies"]["apm"][0]["ref"] = child_v2.sha
+    dump_yaml(parent_document, parent_manifest)
+    parent_v2 = repositories.commit(parent_repository, message="pin advanced mixed child")
+    consumer_document = load_yaml(consumer.manifest_path)
+    consumer_document["dependencies"]["apm"][0]["ref"] = parent_v2.sha
+    dump_yaml(consumer_document, consumer.manifest_path)
+
+    _run(
+        runner,
+        consumer,
+        _INSTALL,
+        environment=child_env,
+        scenario_id="mixed-case-update",
+    )
+    assert parent_v2.sha in (consumer.root / "apm.lock.yaml").read_text(encoding="utf-8")
+    assert child_v2.sha in (consumer.root / "apm.lock.yaml").read_text(encoding="utf-8")
+    assert any(
+        "child-v2" in path.read_text(encoding="utf-8")
+        for path in _assert_all_managed_links_resolve(consumer)
+    )
+    assert user_file.read_bytes() == user_bytes
+
+    audit = _run(
+        runner,
+        consumer,
+        ("audit", "--ci", "--no-policy", "--format", "json"),
+        environment=child_env,
+        scenario_id="mixed-case-audit",
+    )
+    assert '"passed": true' in audit.stdout.lower()
+
+    _run(
+        runner,
+        consumer,
+        ("uninstall", f"{_OWNER}/{_PARENT_REPO}"),
+        environment=child_env,
+        scenario_id="mixed-case-uninstall",
+    )
+    assert user_file.read_bytes() == user_bytes
+    assert not (consumer.root / "apm_modules" / _OWNER / _PARENT_REPO).exists()
+    assert not (consumer.root / "apm_modules" / _OWNER / _CHILD_REPO).exists()

--- a/tests/integration/test_package_identity_case_install.py
+++ b/tests/integration/test_package_identity_case_install.py
@@ -1,4 +1,4 @@
-"""Integration coverage for case-insensitive GitHub package identity."""
+"""Integration coverage for canonical GitHub identity and display casing."""
 
 from pathlib import Path
 from unittest.mock import patch
@@ -11,11 +11,11 @@ from apm_cli.deps.lockfile import LockedDependency, LockFile
 from apm_cli.models.apm_package import APMPackage, clear_apm_yml_cache
 
 
-def test_mixed_case_install_resolves_once_without_collision(
+def test_mixed_case_install_keeps_first_display_path_without_duplicate_identity(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
-    """Mixed-case install inputs converge before manifest and graph deduplication."""
+    """Mixed-case inputs dedupe while the first spelling owns materialization."""
     monkeypatch.chdir(tmp_path)
     (tmp_path / "apm.yml").write_text(
         yaml.safe_dump(
@@ -30,7 +30,10 @@ def test_mixed_case_install_resolves_once_without_collision(
 
     with patch("apm_cli.commands.install._validate_package_exists", return_value=True):
         installed, _outcome = _validate_and_add_packages_to_apm_yml(
-            ["Owner/Example-Package", "owner/example-package"]
+            [
+                "https://GitHub.com/Owner/Example-Package.git",
+                "git@github.com:owner/example-package.git",
+            ]
         )
 
     clear_apm_yml_cache()
@@ -51,13 +54,17 @@ def test_mixed_case_install_resolves_once_without_collision(
     reloaded_lockfile = LockFile.read(lock_path)
 
     assert installed == ["owner/example-package"]
-    assert [dependency.repo_url for dependency in dependencies] == ["owner/example-package"]
+    assert [dependency.repo_url for dependency in dependencies] == ["Owner/Example-Package"]
     assert [dependency.get_unique_key() for dependency in resolved] == ["owner/example-package"]
     assert resolved[0].get_install_path(tmp_path / "apm_modules") == (
-        tmp_path / "apm_modules" / "owner" / "example-package"
+        tmp_path / "apm_modules" / "Owner" / "Example-Package"
     )
     assert graph.flattened_dependencies.conflicts == []
     assert list(reloaded_lockfile.dependencies) == ["owner/example-package"]
     assert reloaded_lockfile.dependencies["owner/example-package"].repo_url == (
         "owner/example-package"
+    )
+    assert (
+        reloaded_lockfile.dependencies["owner/example-package"].materialization_repo_url
+        == "Owner/Example-Package"
     )

--- a/tests/spec_conformance/test_lockfile_reqs.py
+++ b/tests/spec_conformance/test_lockfile_reqs.py
@@ -1,11 +1,13 @@
 """Lockfile (apm.lock.yaml) conformance tests -- sec.5.
 
-Covers req-lk-001..021. The integrity sub-cluster (req-lk-012..017)
+Covers req-lk-001..022. The integrity sub-cluster (req-lk-012..017)
 now drives REAL fail-closed oracles against the committed binary
 fixture pair under `integrity/`.
 """
 
 from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
 
 import jsonschema
 import pytest
@@ -23,6 +25,7 @@ from tests.spec_conformance._helpers import (
 V1 = ("lockfile", "v1-git-only.yml")
 V2 = ("lockfile", "v2-with-registry.yml")
 RT = ("lockfile", "round-trip-unknown-fields.yml")
+MATERIALIZATION_SORT = ("lockfile", "materialization-sort-exclusion.yml")
 
 TRUST_ARCHIVE = ("integrity", "security-baseline-2.3.1.tar.gz")
 TRUST_LOCKFILE = ("integrity", "security-baseline-2.3.1.frozen.yaml")
@@ -339,6 +342,101 @@ def test_lockfile_inventory_metadata_is_non_trust_anchor():
         "registry-resolved `version` MAY remain the exact\nregistry selection",
         "MUST NOT change `lockfile_version`",
     )
+
+
+@pytest.mark.req("req-lk-022")
+def test_lockfile_materialization_spelling_is_non_identity_metadata():
+    from apm_cli.deps.lockfile import LockedDependency
+
+    schema = load_schema("lockfile-v0.1.schema.json")
+    entry_props = schema["$defs"]["entry"]["properties"]
+    assert entry_props["materialization_repo_url"]["type"] == "string"
+    validate_against("lockfile-v0.1.schema.json", load_yaml_fixture(*V1))
+
+    dependency = LockedDependency(
+        repo_url="contoso/example",
+        host="github.com",
+        materialization_repo_url="Contoso/Example",
+    )
+    assert dependency.get_unique_key() == "contoso/example"
+    assert dependency.to_dependency_ref().repo_url == "Contoso/Example"
+
+    with pytest.raises(ValueError, match="does not identify the same package"):
+        LockedDependency(
+            repo_url="contoso/example",
+            host="github.com",
+            materialization_repo_url="other/example",
+        )
+
+    assert_spec_contains(
+        "**[req-lk-022]**",
+        "It MUST\nNOT use `materialization_repo_url` as an identity",
+        "an in-repository `virtual_path` and virtual-file leaf\nremain case-sensitive",
+        "MUST fail closed without deleting any candidate path",
+    )
+
+
+@pytest.mark.req("req-lk-022")
+def test_materialization_spelling_migrates_one_case_variant_transactionally(
+    tmp_path: Path,
+):
+    from apm_cli.install.resolution_staging import ResolutionStagingSession
+    from apm_cli.models.dependency import DependencyReference
+    from apm_cli.models.dependency.materialization import prepare_materialization_path
+
+    modules = tmp_path / "apm_modules"
+    stale = modules / "contoso" / "example"
+    stale.mkdir(parents=True)
+    (stale / "marker").write_text("owned", encoding="utf-8")
+    dependency = DependencyReference.parse("Contoso/Example")
+    staging = ResolutionStagingSession(modules)
+
+    selected = prepare_materialization_path(dependency, modules, staging)
+
+    assert selected == modules / "Contoso" / "Example"
+    assert (selected / "marker").read_text(encoding="utf-8") == "owned"
+    staging.rollback()
+    assert (stale / "marker").read_text(encoding="utf-8") == "owned"
+
+
+@pytest.mark.req("req-lk-022")
+def test_materialization_spelling_collision_fails_without_deleting_candidates(
+    tmp_path: Path,
+):
+    from apm_cli.models.dependency import DependencyReference
+    from apm_cli.models.dependency.materialization import (
+        MaterializationPathCollisionError,
+        find_case_equivalent_materialization_path,
+    )
+
+    modules = tmp_path / "apm_modules"
+    modules.mkdir()
+    dependency = DependencyReference.parse("Contoso/Example")
+    candidates = (
+        PurePosixPath("Contoso/Example"),
+        PurePosixPath("contoso/example"),
+    )
+
+    with pytest.raises(MaterializationPathCollisionError, match="multiple"):
+        find_case_equivalent_materialization_path(
+            dependency.get_install_path(modules),
+            modules,
+            dependency=dependency,
+            candidate_relatives=candidates,
+        )
+
+    assert list(modules.iterdir()) == []
+
+
+@pytest.mark.req("req-lk-022")
+def test_materialization_spelling_does_not_change_lockfile_sort_order():
+    document = load_yaml_fixture(*MATERIALIZATION_SORT)
+    dependencies = document["dependencies"]
+    canonical = [entry["repo_url"] for entry in dependencies]
+    display = [entry["materialization_repo_url"] for entry in dependencies]
+
+    assert canonical == sorted(canonical)
+    assert display != sorted(display)
 
 
 @pytest.mark.req("req-lk-020")

--- a/tests/test_apm_package_models.py
+++ b/tests/test_apm_package_models.py
@@ -39,7 +39,7 @@ class TestDependencyReference:
         mixed = DependencyReference.parse("Owner/Example-Package#v1.0.0")
         lower = DependencyReference.parse("owner/example-package#v1.0.0")
 
-        assert mixed.repo_url == "owner/example-package"
+        assert mixed.repo_url == "Owner/Example-Package"
         assert mixed.get_identity() == lower.get_identity()
         assert mixed.to_canonical() == lower.to_canonical()
 
@@ -50,14 +50,15 @@ class TestDependencyReference:
 
         assert mixed.get_unique_key() == lower.get_unique_key() == "owner/example-package"
 
-    def test_github_owner_repo_casing_has_one_install_path(self):
-        """GitHub owner/repo casing must not create distinct install directories."""
+    def test_github_owner_repo_casing_preserves_materialization_spelling(self):
+        """GitHub identity deduplication must not choose the display path."""
         mixed = DependencyReference.parse("Owner/Example-Package")
         lower = DependencyReference.parse("owner/example-package")
         modules = Path("apm_modules")
 
-        assert mixed.get_install_path(modules) == lower.get_install_path(modules)
-        assert mixed.get_install_path(modules) == modules / "owner" / "example-package"
+        assert mixed.get_unique_key() == lower.get_unique_key()
+        assert mixed.get_install_path(modules) == modules / "Owner" / "Example-Package"
+        assert lower.get_install_path(modules) == modules / "owner" / "example-package"
 
     def test_generic_git_host_preserves_case_sensitive_repo_path(self):
         """Unknown git hosts retain path casing because their semantics are unknown."""

--- a/tests/unit/deps/test_lockfile_consumer_contract.py
+++ b/tests/unit/deps/test_lockfile_consumer_contract.py
@@ -16,6 +16,7 @@ pytestmark = pytest.mark.unit
 
 _LOCKED_DEPENDENCY_VALUES = {
     "repo_url": "apm-org/apm-project/consume-contract",
+    "materialization_repo_url": None,
     "host": "dev.azure.com",
     "host_type": "gitlab",
     "port": 2222,
@@ -59,6 +60,7 @@ _LOCKED_DEPENDENCY_VALUES = {
 
 _RECONSTRUCTED_LOCK_FIELDS = {
     "repo_url",
+    "materialization_repo_url",
     "host",
     "host_type",
     "port",

--- a/tests/unit/deps/test_lockfile_field_properties.py
+++ b/tests/unit/deps/test_lockfile_field_properties.py
@@ -100,6 +100,7 @@ def locked_dependency_kwargs(draw: st.DrawFn) -> dict[str, Any]:
         return draw(st.one_of(st.just(default), value))
 
     kwargs: dict[str, Any] = {"repo_url": _repo_url(draw)}
+    kwargs["materialization_repo_url"] = None
     kwargs["host"] = maybe(None, st.sampled_from(["gitlab.example.invalid", "git.example.invalid"]))
     kwargs["host_type"] = maybe(None, st.just("gitlab"))
     kwargs["port"] = maybe(None, st.integers(min_value=1, max_value=65535))

--- a/tests/unit/install/phases/test_resolve_selective_update_plan.py
+++ b/tests/unit/install/phases/test_resolve_selective_update_plan.py
@@ -32,7 +32,7 @@ def test_run_records_complete_keys_before_only_filter(monkeypatch):
     monkeypatch.setattr(
         resolve,
         "_resolve_dependencies",
-        lambda target_ctx, _staging: setattr(
+        lambda target_ctx, _staging, _reader: setattr(
             target_ctx,
             "deps_to_install",
             [selected, unselected],

--- a/tests/unit/install/test_pipeline_preflight.py
+++ b/tests/unit/install/test_pipeline_preflight.py
@@ -426,3 +426,34 @@ class TestRunInstallPipelineExceptionContracts:
 
             with pytest.raises(RuntimeError, match="Failed to resolve APM dependencies"):
                 run_install_pipeline(pkg, target="claude")
+
+    def test_materialization_collision_is_not_double_wrapped(self) -> None:
+        """Actionable package-directory collisions propagate unchanged."""
+        from apm_cli.install.pipeline import run_install_pipeline
+        from apm_cli.models.dependency.materialization import (
+            MaterializationPathCollisionError,
+        )
+
+        pkg = self._make_pkg_with_deps()
+        collision = MaterializationPathCollisionError(
+            "Found multiple package directories; inspect duplicates."
+        )
+
+        with (
+            patch("apm_cli.deps.lockfile.LockFile") as mock_lf_cls,
+            patch("apm_cli.deps.lockfile.get_lockfile_path", return_value=None),
+            patch("apm_cli.core.scope.get_deploy_root", return_value=MagicMock()),
+            patch("apm_cli.core.scope.get_apm_dir", return_value=None),
+            patch(
+                "apm_cli.install.phases.local_content._project_has_root_primitives",
+                return_value=False,
+            ),
+            patch("apm_cli.install.pipeline._run_phase", side_effect=collision),
+            patch("apm_cli.utils.install_tui.InstallTui"),
+        ):
+            mock_lf_cls.read.return_value = None
+            with pytest.raises(MaterializationPathCollisionError) as raised:
+            with pytest.raises(MaterializationPathCollisionError) as raised:
+                run_install_pipeline(pkg, target="claude")
+        assert raised.value is collision
+        assert raised.value is collision

--- a/tests/unit/install/test_pipeline_preflight.py
+++ b/tests/unit/install/test_pipeline_preflight.py
@@ -453,7 +453,5 @@ class TestRunInstallPipelineExceptionContracts:
         ):
             mock_lf_cls.read.return_value = None
             with pytest.raises(MaterializationPathCollisionError) as raised:
-            with pytest.raises(MaterializationPathCollisionError) as raised:
                 run_install_pipeline(pkg, target="claude")
-        assert raised.value is collision
         assert raised.value is collision

--- a/tests/unit/install/test_resolution_staging_relocate.py
+++ b/tests/unit/install/test_resolution_staging_relocate.py
@@ -1,0 +1,71 @@
+"""Direct regression tests for resolution-staging path relocations."""
+
+from pathlib import Path
+
+import pytest
+
+from apm_cli.install.resolution_staging import ResolutionStagingSession
+
+
+def test_relocate_path_rejects_symlinked_package_directory(tmp_path: Path) -> None:
+    """Migration never follows a package-directory symlink."""
+    modules = tmp_path / "apm_modules"
+    real_package = modules / "real"
+    real_package.mkdir(parents=True)
+    linked_package = modules / "linked"
+    linked_package.symlink_to(real_package, target_is_directory=True)
+    staging = ResolutionStagingSession(modules)
+
+    with pytest.raises(ValueError, match="symlinked package directory"):
+        staging.relocate_path(linked_package, modules / "Linked")
+
+    assert linked_package.is_symlink()
+    assert real_package.is_dir()
+
+
+def test_relocate_path_reports_disappeared_source(tmp_path: Path) -> None:
+    """A concurrent source removal produces an actionable retry error."""
+    modules = tmp_path / "apm_modules"
+    modules.mkdir()
+    staging = ResolutionStagingSession(modules)
+
+    with pytest.raises(FileNotFoundError, match="Run 'apm install' again"):
+        staging.relocate_path(modules / "missing", modules / "Missing")
+
+
+def test_relocation_rollback_reverses_nested_case_changes(tmp_path: Path) -> None:
+    """Nested owner/repository renames roll back in reverse order."""
+    modules = tmp_path / "apm_modules"
+    original_owner = modules / "mixedorg"
+    original_repo = original_owner / "mixedrepo"
+    original_repo.mkdir(parents=True)
+    (original_repo / "marker.txt").write_text("owned", encoding="utf-8")
+    staging = ResolutionStagingSession(modules)
+
+    display_owner = modules / "MixedOrg"
+    staging.relocate_path(original_owner, display_owner)
+    display_repo = display_owner / "MixedRepo"
+    staging.relocate_path(display_owner / "mixedrepo", display_repo)
+
+    assert (display_repo / "marker.txt").read_text(encoding="utf-8") == "owned"
+
+    staging.rollback()
+
+    assert (original_repo / "marker.txt").read_text(encoding="utf-8") == "owned"
+    assert [path.name for path in modules.iterdir()] == ["mixedorg"]
+
+
+@pytest.mark.windows_compat
+def test_case_only_relocation_updates_spelling_and_rolls_back(tmp_path: Path) -> None:
+    """Case-only rename behavior is identical on sensitive and insensitive filesystems."""
+    modules = tmp_path / "apm_modules"
+    source = modules / "mixedorg"
+    source.mkdir(parents=True)
+    staging = ResolutionStagingSession(modules)
+
+    destination = modules / "MixedOrg"
+    staging.relocate_path(source, destination)
+    assert [path.name for path in modules.iterdir()] == ["MixedOrg"]
+
+    staging.rollback()
+    assert [path.name for path in modules.iterdir()] == ["mixedorg"]

--- a/tests/unit/install/test_resolve_phase3w5.py
+++ b/tests/unit/install/test_resolve_phase3w5.py
@@ -79,6 +79,27 @@ def _make_mock_graph(*, circular=None, deps=None):
     return mock_graph
 
 
+def test_materialization_migration_logger_reports_relative_case_change(
+    tmp_path: Path,
+) -> None:
+    """Verbose diagnostics name the old and new package directory spelling."""
+    from apm_cli.install.phases.resolve import _materialization_migration_logger
+
+    logger = MagicMock()
+    modules = tmp_path / "apm_modules"
+    report = _materialization_migration_logger(logger, modules)
+
+    assert report is not None
+    report(
+        modules / "mixedorg" / "mixedchild",
+        modules / "MixedOrg" / "MixedChild",
+    )
+
+    logger.verbose_detail.assert_called_once_with(
+        "    Migrated package directory casing: mixedorg/mixedchild -> MixedOrg/MixedChild"
+    )
+
+
 def _run_ctx(ctx, tmp_path, *, graph=None, extra_env=None, mock_resolver=None):
     mods_dir = tmp_path / "apm_modules"
     env = {"APM_NO_CACHE": "1", **(extra_env or {})}

--- a/tests/unit/models/test_dependency_materialization.py
+++ b/tests/unit/models/test_dependency_materialization.py
@@ -218,11 +218,13 @@ def test_cached_reader_reuses_directory_listings(tmp_path: Path) -> None:
     reader = CachedMaterializationPathReader(delegate)
 
     for repo in ("RepoA", "RepoB"):
+        dependency = DependencyReference.parse(f"MixedOrg/{repo}")
         desired = modules / "MixedOrg" / repo
         assert (
             find_case_equivalent_materialization_path(
                 desired,
                 modules,
+                dependency=dependency,
                 reader=reader,
             )
             == desired
@@ -242,10 +244,57 @@ def test_case_variant_lookup_fails_closed_on_distinct_collisions(tmp_path: Path)
         PurePosixPath("MixedOrg/MixedRepo"),
         PurePosixPath("mixedorg/mixedrepo"),
     )
+    dependency = DependencyReference.parse("MixedOrg/MixedRepo")
 
     with pytest.raises(MaterializationPathCollisionError, match="multiple"):
         find_case_equivalent_materialization_path(
             desired,
             modules,
+            dependency=dependency,
             candidate_relatives=candidates,
         )
+
+
+def test_virtual_subpath_casing_remains_identity_significant(tmp_path: Path) -> None:
+    """Casefolding stops at the repository boundary for nested packages."""
+    modules = tmp_path / "apm_modules"
+    dependency = DependencyReference.parse_from_dict(
+        {
+            "git": "https://github.com/MixedOrg/MixedRepo.git",
+            "path": "Nested/Rules",
+        }
+    )
+    desired = dependency.get_install_path(modules)
+
+    assert (
+        find_case_equivalent_materialization_path(
+            desired,
+            modules,
+            dependency=dependency,
+            candidate_relatives=(PurePosixPath("mixedorg/mixedrepo/Nested/rules"),),
+        )
+        is None
+    )
+
+
+def test_virtual_file_leaf_casing_remains_identity_significant(tmp_path: Path) -> None:
+    """Flattened virtual-file names fold only their repository-name prefix."""
+    modules = tmp_path / "apm_modules"
+    dependency = DependencyReference.parse_from_dict(
+        {
+            "git": "https://github.com/MixedOrg/MixedRepo.git",
+            "path": "Prompts/Review.prompt.md",
+        }
+    )
+    desired = dependency.get_install_path(modules)
+    correct = PurePosixPath("mixedorg/mixedrepo-Review")
+
+    assert find_case_equivalent_materialization_path(
+        desired,
+        modules,
+        dependency=dependency,
+        candidate_relatives=(
+            PurePosixPath("mixedorg/mixedrepo-review"),
+            correct,
+        ),
+    ) == modules.joinpath(*correct.parts)

--- a/tests/unit/models/test_dependency_materialization.py
+++ b/tests/unit/models/test_dependency_materialization.py
@@ -1,0 +1,178 @@
+"""Dependency identity and materialization casing contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path, PurePosixPath
+
+import pytest
+
+from apm_cli.deps.dependency_graph import FlatDependencyMap
+from apm_cli.deps.lockfile import LockedDependency
+from apm_cli.install.resolution_staging import ResolutionStagingSession
+from apm_cli.models.dependency.materialization import (
+    MaterializationPathCollisionError,
+    find_case_equivalent_materialization_path,
+    prepare_materialization_path,
+)
+from apm_cli.models.dependency.reference import DependencyReference
+
+
+@pytest.mark.parametrize(
+    "raw",
+    (
+        "https://github.com/MixedOrg/MixedRepo.git",
+        "git@github.com:MixedOrg/MixedRepo.git",
+        "ssh://git@github.com/MixedOrg/MixedRepo.git",
+    ),
+)
+def test_github_url_spellings_separate_identity_from_materialization(
+    raw: str,
+    tmp_path: Path,
+) -> None:
+    """HTTPS and SSH spellings share identity without lowering disk paths."""
+    reference = DependencyReference.parse(raw)
+
+    assert reference.repo_url == "MixedOrg/MixedRepo"
+    assert reference.canonical_repo_url == "mixedorg/mixedrepo"
+    assert reference.get_unique_key() == "mixedorg/mixedrepo"
+    assert reference.get_identity() == "mixedorg/mixedrepo"
+    assert reference.get_install_path(tmp_path / "apm_modules") == (
+        tmp_path / "apm_modules" / "MixedOrg" / "MixedRepo"
+    )
+
+
+def test_nested_virtual_path_preserves_every_source_path_segment(tmp_path: Path) -> None:
+    """Repository and in-repository path casing survive materialization."""
+    reference = DependencyReference.parse_from_dict(
+        {
+            "git": "https://github.com/MixedOrg/MixedRepo.git",
+            "path": "Nested/Rules/Review",
+        }
+    )
+
+    assert reference.get_unique_key() == "mixedorg/mixedrepo/Nested/Rules/Review"
+    assert reference.get_install_path(tmp_path / "apm_modules") == (
+        tmp_path / "apm_modules" / "MixedOrg" / "MixedRepo" / "Nested" / "Rules" / "Review"
+    )
+
+
+def test_host_case_and_repo_case_dedupe_without_replacing_first_display_spelling() -> None:
+    """Host-case variants have one key while first source casing remains visible."""
+    first = DependencyReference(
+        repo_url="MixedOrg/MixedRepo",
+        host="GitHub.COM",
+    )
+    duplicate = DependencyReference(
+        repo_url="mixedorg/mixedrepo",
+        host="github.com",
+    )
+
+    assert first.get_unique_key() == duplicate.get_unique_key() == "mixedorg/mixedrepo"
+    assert first.repo_url == "MixedOrg/MixedRepo"
+    assert duplicate.repo_url == "mixedorg/mixedrepo"
+
+
+def test_flat_dependency_map_dedupes_case_variants_by_canonical_key() -> None:
+    """Graph flattening cannot create two packages from presentation casing."""
+    dependencies = FlatDependencyMap()
+    first = DependencyReference(repo_url="MixedOrg/MixedRepo", host="GitHub.COM")
+    duplicate = DependencyReference(repo_url="mixedorg/mixedrepo", host="github.com")
+
+    dependencies.add_dependency(first)
+    dependencies.add_dependency(duplicate)
+
+    assert dependencies.total_dependencies() == 1
+    assert dependencies.get_installation_list() == [first]
+
+
+def test_lockfile_keeps_canonical_identity_and_materialization_spelling() -> None:
+    """Lock serialization can replay both identity and the actual disk path."""
+    reference = DependencyReference.parse("https://github.com/MixedOrg/MixedRepo.git")
+    locked = LockedDependency.from_dependency_ref(
+        reference,
+        resolved_commit="a" * 40,
+        depth=1,
+        resolved_by=None,
+    )
+    payload = locked.to_dict()
+    restored = LockedDependency.from_dict(payload)
+
+    assert payload["repo_url"] == "mixedorg/mixedrepo"
+    assert payload["materialization_repo_url"] == "MixedOrg/MixedRepo"
+    assert restored.get_unique_key() == "mixedorg/mixedrepo"
+    assert restored.to_dependency_ref().repo_url == "MixedOrg/MixedRepo"
+
+
+def test_legacy_mixed_case_lock_entry_migrates_without_losing_display_spelling() -> None:
+    """Pre-0.25 mixed-case lock rows gain a separate materialization spelling."""
+    restored = LockedDependency.from_dict(
+        {
+            "repo_url": "MixedOrg/MixedRepo",
+            "host": "github.com",
+            "resolved_commit": "b" * 40,
+        }
+    )
+
+    assert restored.repo_url == "mixedorg/mixedrepo"
+    assert restored.materialization_repo_url == "MixedOrg/MixedRepo"
+    assert restored.get_unique_key() == "mixedorg/mixedrepo"
+
+
+def test_lock_rejects_materialization_spelling_for_a_different_identity() -> None:
+    """A tampered display path cannot redirect a canonical lock identity."""
+    with pytest.raises(ValueError, match="materialization_repo_url"):
+        LockedDependency(
+            repo_url="mixedorg/mixedrepo",
+            host="github.com",
+            materialization_repo_url="OtherOrg/OtherRepo",
+        )
+
+
+def test_stale_lowercase_materialization_moves_transactionally(tmp_path: Path) -> None:
+    """A stale generated path is reused once and rolls back with the install."""
+    modules = tmp_path / "apm_modules"
+    stale = modules / "mixedorg" / "mixedrepo"
+    stale.mkdir(parents=True)
+    (stale / "marker.txt").write_text("owned", encoding="utf-8")
+    reference = DependencyReference.parse("MixedOrg/MixedRepo")
+    staging = ResolutionStagingSession(modules)
+
+    selected = prepare_materialization_path(reference, modules, staging)
+
+    assert selected == modules / "MixedOrg" / "MixedRepo"
+    assert (selected / "marker.txt").read_text(encoding="utf-8") == "owned"
+    owner_entries = [path for path in modules.iterdir() if path.name.casefold() == "mixedorg"]
+    assert [path.name for path in owner_entries] == ["MixedOrg"]
+    package_entries = [
+        path for path in owner_entries[0].iterdir() if path.name.casefold() == "mixedrepo"
+    ]
+    assert [path.name for path in package_entries] == ["MixedRepo"]
+    matches = [
+        path
+        for owner in modules.iterdir()
+        if owner.is_dir() and owner.name.casefold() == "mixedorg"
+        for path in owner.iterdir()
+        if path.is_dir() and path.name.casefold() == "mixedrepo"
+    ]
+    assert len(matches) == 1
+
+    staging.rollback()
+    assert (stale / "marker.txt").read_text(encoding="utf-8") == "owned"
+    assert [path.name for path in modules.iterdir()] == ["mixedorg"]
+
+
+def test_case_variant_lookup_fails_closed_on_distinct_collisions(tmp_path: Path) -> None:
+    """Case-sensitive filesystems reject two physical paths for one identity."""
+    modules = tmp_path / "apm_modules"
+    desired = modules / "MixedOrg" / "MixedRepo"
+    candidates = (
+        PurePosixPath("MixedOrg/MixedRepo"),
+        PurePosixPath("mixedorg/mixedrepo"),
+    )
+
+    with pytest.raises(MaterializationPathCollisionError, match="multiple"):
+        find_case_equivalent_materialization_path(
+            desired,
+            modules,
+            candidate_relatives=candidates,
+        )

--- a/tests/unit/models/test_dependency_materialization.py
+++ b/tests/unit/models/test_dependency_materialization.py
@@ -10,6 +10,7 @@ from apm_cli.deps.dependency_graph import FlatDependencyMap
 from apm_cli.deps.lockfile import LockedDependency
 from apm_cli.install.resolution_staging import ResolutionStagingSession
 from apm_cli.models.dependency.materialization import (
+    CachedMaterializationPathReader,
     MaterializationPathCollisionError,
     find_case_equivalent_materialization_path,
     prepare_materialization_path,
@@ -85,6 +86,20 @@ def test_flat_dependency_map_dedupes_case_variants_by_canonical_key() -> None:
     assert dependencies.get_installation_list() == [first]
 
 
+def test_dependency_tree_lookup_accepts_source_and_canonical_spelling() -> None:
+    """Legacy O(1) lookup remains useful after repo_url becomes source-cased."""
+    from unittest.mock import Mock
+
+    from apm_cli.deps.dependency_graph import DependencyNode, DependencyTree
+
+    reference = DependencyReference(repo_url="MixedOrg/MixedRepo", host="github.com")
+    tree = DependencyTree(root_package=Mock())
+    tree.add_node(DependencyNode(package=Mock(), dependency_ref=reference))
+
+    assert tree.has_dependency("MixedOrg/MixedRepo")
+    assert tree.has_dependency("mixedorg/mixedrepo")
+
+
 def test_lockfile_keeps_canonical_identity_and_materialization_spelling() -> None:
     """Lock serialization can replay both identity and the actual disk path."""
     reference = DependencyReference.parse("https://github.com/MixedOrg/MixedRepo.git")
@@ -128,6 +143,7 @@ def test_lock_rejects_materialization_spelling_for_a_different_identity() -> Non
         )
 
 
+@pytest.mark.windows_compat
 def test_stale_lowercase_materialization_moves_transactionally(tmp_path: Path) -> None:
     """A stale generated path is reused once and rolls back with the install."""
     modules = tmp_path / "apm_modules"
@@ -136,10 +152,17 @@ def test_stale_lowercase_materialization_moves_transactionally(tmp_path: Path) -
     (stale / "marker.txt").write_text("owned", encoding="utf-8")
     reference = DependencyReference.parse("MixedOrg/MixedRepo")
     staging = ResolutionStagingSession(modules)
+    migrations: list[tuple[Path, Path]] = []
 
-    selected = prepare_materialization_path(reference, modules, staging)
+    selected = prepare_materialization_path(
+        reference,
+        modules,
+        staging,
+        on_migrate=lambda source, destination: migrations.append((source, destination)),
+    )
 
     assert selected == modules / "MixedOrg" / "MixedRepo"
+    assert migrations == [(stale, selected)]
     assert (selected / "marker.txt").read_text(encoding="utf-8") == "owned"
     owner_entries = [path for path in modules.iterdir() if path.name.casefold() == "mixedorg"]
     assert [path.name for path in owner_entries] == ["MixedOrg"]
@@ -159,6 +182,56 @@ def test_stale_lowercase_materialization_moves_transactionally(tmp_path: Path) -
     staging.rollback()
     assert (stale / "marker.txt").read_text(encoding="utf-8") == "owned"
     assert [path.name for path in modules.iterdir()] == ["mixedorg"]
+
+
+def test_cached_reader_reuses_directory_listings(tmp_path: Path) -> None:
+    """One resolution attempt does not rescan the same owner for every dep."""
+
+    class CountingReader:
+        def __init__(self) -> None:
+            self.scans: dict[Path, int] = {}
+
+        @staticmethod
+        def exists(path: Path) -> bool:
+            return path.exists()
+
+        @staticmethod
+        def is_dir(path: Path) -> bool:
+            return path.is_dir()
+
+        def iterdir(self, path: Path):
+            key = path.absolute()
+            self.scans[key] = self.scans.get(key, 0) + 1
+            return path.iterdir()
+
+        @staticmethod
+        def samefile(left: Path, right: Path) -> bool:
+            return left.samefile(right)
+
+        def invalidate(self, *paths: Path) -> None:
+            return None
+
+    modules = tmp_path / "apm_modules"
+    (modules / "MixedOrg" / "RepoA").mkdir(parents=True)
+    (modules / "MixedOrg" / "RepoB").mkdir()
+    delegate = CountingReader()
+    reader = CachedMaterializationPathReader(delegate)
+
+    for repo in ("RepoA", "RepoB"):
+        desired = modules / "MixedOrg" / repo
+        assert (
+            find_case_equivalent_materialization_path(
+                desired,
+                modules,
+                reader=reader,
+            )
+            == desired
+        )
+
+    assert delegate.scans == {
+        modules.absolute(): 1,
+        (modules / "MixedOrg").absolute(): 1,
+    }
 
 
 def test_case_variant_lookup_fails_closed_on_distinct_collisions(tmp_path: Path) -> None:

--- a/tests/unit/utils/test_paths.py
+++ b/tests/unit/utils/test_paths.py
@@ -1,4 +1,4 @@
-"""Unit tests for apm_cli.utils.paths.portable_relpath().
+"""Unit tests for portable path helpers.
 
 Covers:
 - Normal case: path under base returns relative POSIX path
@@ -11,12 +11,34 @@ Covers:
 
 from __future__ import annotations
 
-from pathlib import Path
+import ntpath
+from pathlib import Path, PureWindowsPath
 from unittest.mock import patch
 
 import pytest
 
-from apm_cli.utils.paths import portable_relpath
+from apm_cli.utils.paths import portable_link_relpath, portable_relpath
+
+
+@pytest.mark.windows_compat
+def test_portable_link_relpath_uses_forward_slashes_on_windows() -> None:
+    """Generated Markdown paths stay relative and POSIX-like on Windows."""
+    target = PureWindowsPath(r"C:\repo\apm_modules\MixedOrg\MixedRepo\Guide.md")
+    base = PureWindowsPath(r"C:\repo\.github\instructions")
+
+    assert portable_link_relpath(target, base, relpath=ntpath.relpath) == (
+        "../../apm_modules/MixedOrg/MixedRepo/Guide.md"
+    )
+
+
+@pytest.mark.windows_compat
+def test_portable_link_relpath_refuses_cross_drive_absolute_fallback() -> None:
+    """Different Windows drives never leak an absolute path into Markdown."""
+    target = PureWindowsPath(r"D:\modules\MixedOrg\MixedRepo\Guide.md")
+    base = PureWindowsPath(r"C:\repo\.github\instructions")
+
+    assert portable_link_relpath(target, base, relpath=ntpath.relpath) is None
+
 
 # Entire module: this is the canonical owner of platform-independent
 # relative-path formatting (microsoft/apm#2233's backslash-on-Windows

--- a/tests/utils/local_git_repository.py
+++ b/tests/utils/local_git_repository.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import shutil
 import subprocess
 import time
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlsplit
@@ -227,14 +227,32 @@ class LocalGitRepositoryFactory:
         append an adjacent remote suffix onto a sibling fixture repository
         path (same containment as :meth:`install_url_rewrite`).
         """
-        repository = self._owned_repository(repository)
-        remote_forms = self._remote_url_forms(remote_url)
+        return self.url_rewrite_subprocess_env_many(((repository, remote_url),))
+
+    def url_rewrite_subprocess_env_many(
+        self,
+        rewrites: Sequence[tuple[LocalGitRepository, str]],
+    ) -> dict[str, str]:
+        """Return one child env routing multiple remotes to owned repositories."""
+        if not rewrites:
+            raise ValueError("At least one repository rewrite is required")
         self._reject_preexisting_process_git_config(self._env)
-        rewrite_base = f"{repository.file_url}/"
-        key = f"url.{rewrite_base}.insteadOf"
+        slots: list[tuple[str, str]] = []
+        remote_owners: dict[str, Path] = {}
+        for repository, remote_url in rewrites:
+            repository = self._owned_repository(repository)
+            rewrite_base = f"{repository.file_url}/"
+            key = f"url.{rewrite_base}.insteadOf"
+            for remote_form in self._remote_url_forms(remote_url):
+                prior = remote_owners.setdefault(remote_form, repository.origin)
+                if prior != repository.origin:
+                    raise ValueError(
+                        f"Remote URL is assigned to multiple fixture repositories: {remote_form}"
+                    )
+                slots.append((key, remote_form))
         env = dict(self._env)
-        env["GIT_CONFIG_COUNT"] = str(len(remote_forms))
-        for index, remote_form in enumerate(remote_forms):
+        env["GIT_CONFIG_COUNT"] = str(len(slots))
+        for index, (key, remote_form) in enumerate(slots):
             env[f"GIT_CONFIG_KEY_{index}"] = key
             env[f"GIT_CONFIG_VALUE_{index}"] = remote_form
         return env


### PR DESCRIPTION
# fix(deps): preserve mixed-case materialization paths

## TL;DR

GitHub dependency identity remains case-insensitive for lock keys and deduplication, while `apm_modules/` paths and generated relative links now retain the source spelling. Reinstall transactionally migrates stale case-only materializations, repairs APM-managed links, and preserves user-authored files. The regression is covered through the installed binary across direct and transitive install, repeat, ref update, audit, and uninstall.

> [!IMPORTANT]
> Closes #2347. Reported by @rcollette.

## Problem (WHY)

- [x] Since the identity normalization added in #2098, `DependencyReference.repo_url` was lowercased before both comparison and filesystem path construction. An existing `apm_modules/MixedOrg/MixedRepo` could therefore be paired with a generated `apm_modules/mixedorg/mixedrepo` link.
- [x] On case-sensitive filesystems, the lowercase path could become a second materialization or miss the package that already existed. On case-insensitive filesystems, cache checks could reuse the old directory without correcting its spelling.
- [x] `repo_url` served two incompatible contracts: canonical package identity and presentation/materialization. The architecture rule requires one owner for each durable decision because ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/).
- [!] Fixing only the Copilot instruction writer would leave prompts, agents, commands, skills, lock replay, audit, and uninstall coupled to the same bad model value. The shared fix follows ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/).

## Approach (WHAT)

| # | Fix | Principle | Source |
|---:|---|---|---|
| 1 | Keep source casing on `DependencyReference.repo_url`; derive lowercase comparison identity only through `identity.py`. | "Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action." | [PROSE](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |
| 2 | Route filesystem paths and stale-path migration through one materialization owner. | "Favor small, chainable primitives over monolithic frameworks." | [PROSE](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |
| 3 | Persist source spelling separately while retaining canonical lock keys. | "Add what the agent lacks, omit what it knows" | [Agent Skills](https://agentskills.io/skill-creation/best-practices) |
| 4 | Prove lifecycle and architecture promises with installed-binary and static mutation guards. | "do the work, run a validator (a script, a reference checklist, or a self-check), fix any issues, and repeat until validation passes." | [Agent Skills](https://agentskills.io/skill-creation/best-practices) |

## Implementation (HOW)

| Files | Change |
|---|---|
| `src/apm_cli/models/dependency/identity.py`, `reference.py` | Separate canonical comparison identity from source-cased display data. Canonical keys still casefold GitHub/registry owner and repo; virtual subpaths retain their own case. |
| `src/apm_cli/models/dependency/materialization.py` | Add the canonical path builder, cached case-equivalent lookup seam, repository-prefix-only case policy, collision refusal, and transactional migration preparation. |
| `src/apm_cli/deps/lockfile.py`, `dependency_graph.py` | Keep `repo_url` canonical, persist optional `materialization_repo_url`, validate both identify the same package, and retain first-wins display casing during graph dedupe. |
| `src/apm_cli/install/phases/resolve.py`, `resolution_staging.py`, `pipeline.py` | Migrate direct and locked transitive paths before cache checks; serialize callback scans, journal renames for rollback, and preserve actionable collision errors. |
| `src/apm_cli/commands/install.py` | Preserve the first requested spelling in `apm.yml` without weakening duplicate detection or accidentally appending the same batch entry twice. |
| `src/apm_cli/compilation/link_resolver.py`, `utils/paths.py` | Emit relative POSIX-style Markdown paths and refuse cross-drive absolute fallback on Windows. All target integrators continue through the shared resolver. |
| `scripts/lint-architecture-boundaries.sh`, `.apm/instructions/architecture.instructions.md`, `.github/instructions/architecture.instructions.md` | Register the split identity/materialization authority and reject future reuse of canonical lowercase identity in filesystem path construction. |
| `tests/integration/test_mixed_case_materialization_lifecycle.py`, `test_package_identity_case_install.py` | Exercise real local Git remotes through the installed binary, including transitive dependencies, multiple targets, stale paths/links, repeat, ref update, audit, and uninstall. |
| `tests/unit/models/test_dependency_materialization.py`, `tests/unit/install/test_resolution_staging_relocate.py`, `tests/test_apm_package_models.py`, `tests/unit/utils/test_paths.py` | Cover URL spellings, exact virtual paths, lock tampering, collisions, rollback order, symlinks, dedupe, and Windows drive/separator behavior. |
| `tests/utils/local_git_repository.py` | Extend the hermetic Git fixture to provide one process-scoped environment for multiple rewritten local remotes. |
| `tests/integration/test_architecture_authorities.py` | Add behavioral/static owner evidence and a static mutation that rejects canonical-path recoupling. |
| `docs/src/content/docs/{consumer,producer,concepts,troubleshooting,reference}/**`, `packages/apm-guide/.apm/skills/apm-usage/dependencies.md`, `CHANGELOG.md` | Document display spelling, collision recovery, canonical lock fields, link behavior, and reporter credit. |
| `docs/src/content/docs/specs/openapm-v0.1.md`, `docs/public/specs/**`, `tests/spec_conformance/**`, `CONFORMANCE.{json,md}` | Add normative `req-lk-022`, schema/manifest entries, migration/collision/sort oracles, and consistent 105-statement conformance indexes. |

## Diagrams

Legend: solid nodes are existing lifecycle stages; dashed nodes are the new casing-preserving authority and migration path.

```mermaid
flowchart LR
    subgraph Parse[Parse]
        P1[Source-cased repo_url]
    end
    subgraph Identity[Canonical identity]
        I1[normalize_package_repo_url]
        I2[Lock and dedupe key]
    end
    subgraph Materialize[Materialization]
        M1[build_materialization_path]
        M2[Case-equivalent lookup]
        M3[Transactional rename]
    end
    subgraph Deploy[Target integration]
        D1[UnifiedLinkResolver]
        D2[Relative generated link]
    end
    P1 --> I1
    I1 --> I2
    P1 --> M1
    M1 --> M2
    M2 --> M3
    M3 --> D1
    D1 --> D2
    classDef new stroke-dasharray: 5 5;
    class M1,M2,M3 new;
```

## Trade-offs

- **Add one optional lock field instead of restoring mixed-case `repo_url`.** `repo_url` remains the stable canonical identity; `materialization_repo_url` carries presentation only and is rejected if it normalizes to another package.
- **Rename transactionally instead of deleting and downloading again.** Existing verified bytes are reused, while rollback restores every component if resolution later fails.
- **Fail on distinct case collisions instead of choosing by timestamp or content.** Guessing could delete user data or combine unrelated trees; an explicit collision is deterministic and recoverable.
- **Use a link-specific relative-path helper instead of `portable_relpath()`.** The general helper may return an absolute fallback; generated Markdown links must never do so, especially across Windows drives.
- **Fix the shared root rather than target-specific writers.** Copilot, Cursor, and other affected integrators keep their existing behavior and consume the same source-cased package root.

## Benefits

1. `MixedOrg/MixedRepo` produces one canonical key (`mixedorg/mixedrepo`) and one source-cased materialization.
2. Every managed link emitted by the installed-binary lifecycle resolves to the actual `apm_modules/MixedOrg/...` object and remains relative.
3. A repeat install, explicit ref update, audit, and uninstall complete without duplicate package trees or deleted user-authored files.
4. Legacy mixed-case lock rows migrate to canonical identity while retaining replayable source casing.
5. Static architecture lint rejects any future path builder that reads `canonical_repo_url`.

## Validation

`uv run --frozen --extra dev pytest ...` (exact-head installed-binary lifecycle contracts):

```text
............................................                             [100%]
44 passed in 28.30s
```

`uv run --frozen --extra dev pytest ...` (exact-head spec and regression contracts):

```text
........................................................................ [ 25%]
........................................................................ [ 50%]
........................................................................ [ 75%]
.......................................................................  [100%]
285 passed, 2 skipped in 23.50s
```

<details><summary>CI lint mirror</summary>

```text
All checks passed!
1560 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
[+] architecture boundary lint clean
```

The YAML I/O, 2,100-line source limit, and raw `str(path.relative_to(...))` guards also passed.

</details>

<details><summary>Mutation-break evidence</summary>

1. Replacing the materialization path's `dependency.repo_url` with `dependency.canonical_repo_url`, rebuilding the binary, and running the lifecycle test failed on `apm_modules/mixedorg/mixedchild` versus `apm_modules/MixedOrg/MixedChild`.
2. Replacing canonical key derivation with `key = repo_url` made `test_flat_dependency_map_dedupes_case_variants_by_canonical_key` fail with two dependencies instead of one.

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | Install mixed-case direct and transitive GitHub packages for Copilot and Cursor; every generated link resolves through repeat, ref update, audit, and uninstall. | Portability by manifest, Multi-harness support, DevX | `tests/integration/test_mixed_case_materialization_lifecycle.py::test_mixed_case_links_survive_install_update_audit_and_uninstall` (regression-trap for #2347) | e2e |
| 2 | HTTPS, SCP-style SSH, and `ssh://` spellings retain source casing but dedupe to one GitHub identity. | Vendor-neutral, Governed by policy | `tests/unit/models/test_dependency_materialization.py::test_github_url_spellings_separate_identity_from_materialization`<br/>`tests/integration/test_package_identity_case_install.py::test_mixed_case_install_keeps_first_display_path_without_duplicate_identity` | unit + integration |
| 3 | Reinstall migrates a stale lowercase package tree without duplicating it, and rollback restores the prior tree. | DevX, Governed by policy | `tests/unit/models/test_dependency_materialization.py::test_stale_lowercase_materialization_moves_transactionally` | unit |
| 4 | A lockfile cannot use presentation casing to redirect canonical identity, and real case collisions fail closed. | Secure by default, Governed by policy | `tests/unit/models/test_dependency_materialization.py::test_lock_rejects_materialization_spelling_for_a_different_identity`<br/>`::test_case_variant_lookup_fails_closed_on_distinct_collisions` | unit |
| 5 | Generated links use forward slashes on Windows and never become absolute across drives. | Portability by manifest | `tests/unit/utils/test_paths.py::test_portable_link_relpath_uses_forward_slashes_on_windows`<br/>`::test_portable_link_relpath_refuses_cross_drive_absolute_fallback` | unit |
| 6 | Future code cannot route materialization back through lowercase canonical identity. | Governed by policy | `tests/integration/test_architecture_authorities.py::test_dependency_materialization_owner_guard_rejects_canonical_path_reuse` | integration |
| 7 | Another consumer can validate source-cased lock metadata, migrate one stale path, refuse collisions without deletion, and keep canonical sort order. | Governed by policy, Vendor-neutral | `tests/spec_conformance/test_lockfile_reqs.py` (`req-lk-022`) | integration |

## How to test

- [ ] Build the local binary with `bash scripts/build-binary.sh`; expect the binary smoke check to pass.
- [ ] Run `APM_E2E_TESTS=1 APM_BINARY_PATH=<binary> uv run --frozen --extra dev pytest -q tests/integration/test_mixed_case_materialization_lifecycle.py`; expect one passing lifecycle.
- [ ] Run `uv run --frozen --extra dev pytest -q tests/unit/models/test_dependency_materialization.py tests/integration/test_package_identity_case_install.py`; expect all casing and dedupe scenarios to pass.
- [ ] Run `uv run --frozen --extra dev pytest -q tests/spec_conformance`; expect `req-lk-022` and all existing requirements to pass.
- [ ] Run the CI lint mirror; expect Ruff, duplication, auth, and architecture guards to exit 0.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
