### PR TITLE
refactor(auth): centralize indexed Git config cleanup

### DIFF
--- a/.apm/instructions/architecture.instructions.md
+++ b/.apm/instructions/architecture.instructions.md
@@ -38,6 +38,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 |---|---|---|
 | Accepted target vocabulary | core/target_catalog.py | `src/apm_cli/core/target_catalog.py` |
 | Host + credential resolution | core/auth.py (AuthResolver), core/host_providers.py | `src/apm_cli/core/auth.py`; `src/apm_cli/core/host_providers.py` |
+| Indexed Git auth-config retain/reindex policy | utils/git_env.py (strip_git_auth_config_entries) | `src/apm_cli/utils/git_env.py` |
 | Runtime descriptors | runtime/registry.py | `src/apm_cli/runtime/registry.py` |
 | User-facing output / diagnostics | CommandLogger / console owner | `src/apm_cli/core/command_logger.py`; `src/apm_cli/utils/console.py` |
 | Compiled-output writes (atomic) | CompiledOutputWriter | `src/apm_cli/compilation/output_writer.py` |

--- a/.github/instructions/architecture.instructions.md
+++ b/.github/instructions/architecture.instructions.md
@@ -38,6 +38,7 @@ semicolon-delimited, and specific to the file(s) that own the fact.
 |---|---|---|
 | Accepted target vocabulary | core/target_catalog.py | `src/apm_cli/core/target_catalog.py` |
 | Host + credential resolution | core/auth.py (AuthResolver), core/host_providers.py | `src/apm_cli/core/auth.py`; `src/apm_cli/core/host_providers.py` |
+| Indexed Git auth-config retain/reindex policy | utils/git_env.py (strip_git_auth_config_entries) | `src/apm_cli/utils/git_env.py` |
 | Runtime descriptors | runtime/registry.py | `src/apm_cli/runtime/registry.py` |
 | User-facing output / diagnostics | CommandLogger / console owner | `src/apm_cli/core/command_logger.py`; `src/apm_cli/utils/console.py` |
 | Compiled-output writes (atomic) | CompiledOutputWriter | `src/apm_cli/compilation/output_writer.py` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Indexed Git authentication cleanup now strips actual `Authorization` headers, including multiline values, while preserving unrelated proxy, TLS, CA, and hardening entries — by @Pybsama (#2411)
 - Corporate git security settings -- SSL CA pins (`http.sslCAInfo`), bare-repo
   protection (`safe.bareRepository=explicit`), and other inherited `GIT_CONFIG_*`
   hardening -- are no longer silently dropped when apm injects an

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -2783,7 +2783,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:c8cd4b941415ffae010102fa6936c0654e3fe55a80b114af2ba7076e2c5e572e
+  content_hash: sha256:e859b2db5e892a9e97be74366238a68d9f0be0437e0ce9f820d49cb5542214e7
 - kind: project-relative
   target: copilot
   value: .github/instructions/changelog.instructions.md
@@ -3290,7 +3290,7 @@ local_deployed_file_hashes:
   .github/agents/spec-tag-architect.agent.md: sha256:82907265c5e7cf1ac61ad96866fa7c5683b69c8f09b7a4c5f3cc241acc9568ca
   .github/agents/supply-chain-security-expert.agent.md: sha256:8fb8cc426d6af17ba084a28b3f026c2b475b62e3ca63ed2f88b83bd823f877af
   .github/agents/test-coverage-expert.agent.md: sha256:48c2172d1f18a394fa83ef9dc2be0b9b921a4e51e976498165250fed66369711
-  .github/instructions/architecture.instructions.md: sha256:c8cd4b941415ffae010102fa6936c0654e3fe55a80b114af2ba7076e2c5e572e
+  .github/instructions/architecture.instructions.md: sha256:e859b2db5e892a9e97be74366238a68d9f0be0437e0ce9f820d49cb5542214e7
   .github/instructions/changelog.instructions.md: sha256:1e51ec4c74e847967962bd279dc4c6e582c5d3578490b3c28d5f3acd3e05f73e
   .github/instructions/cicd.instructions.md: sha256:08d87b7d635761cb41deb8fc71d5d83f54678de463db484afb16d2d4f8713ecb
   .github/instructions/cli.instructions.md: sha256:8e39e8d5047ce88575cb02f87c2bcede584dfef258bd86f7466c7badf136541a

--- a/scripts/check_git_auth_config_owner.py
+++ b/scripts/check_git_auth_config_owner.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Enforce one owner for indexed Git auth-config retain/reindex policy."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from pathlib import Path
+
+OWNER_MODULE = "apm_cli.utils.git_env"
+OWNER_SYMBOL = "strip_git_auth_config_entries"
+OWNER_PATH = Path("src/apm_cli/utils/git_env.py")
+CONSUMERS = {
+    Path("src/apm_cli/core/auth.py"): "AuthResolver._clear_git_auth_env",
+    Path("src/apm_cli/utils/github_host.py"): "set_authorization_header_git_env",
+}
+EXEMPT_MARKER = "architecture-authority-exempt:"
+
+
+def _qualnamed_functions(tree: ast.Module) -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Return all functions keyed by class-qualified name."""
+    functions: dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
+
+    def visit(node: ast.AST, prefix: tuple[str, ...]) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.ClassDef):
+                visit(child, (*prefix, child.name))
+            elif isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                qualname = ".".join((*prefix, child.name))
+                functions[qualname] = child
+                visit(child, (*prefix, child.name))
+            else:
+                visit(child, prefix)
+
+    visit(tree, ())
+    return functions
+
+
+def _imports_owner(tree: ast.Module) -> bool:
+    """Return whether a module imports the canonical helper directly."""
+    return any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == OWNER_MODULE
+        and any(alias.name == OWNER_SYMBOL and alias.asname is None for alias in node.names)
+        for node in tree.body
+    )
+
+
+def _owner_call_count(node: ast.AST) -> int:
+    """Count direct calls to the canonical helper."""
+    return sum(
+        1
+        for child in ast.walk(node)
+        if isinstance(child, ast.Call)
+        and isinstance(child.func, ast.Name)
+        and child.func.id == OWNER_SYMBOL
+    )
+
+
+def _inline_predicate_lines(tree: ast.AST) -> list[int]:
+    """Find exact auth-classifier literals used by comparison/search syntax."""
+    classifier_literals = {"extraheader", "authorization", "authorization:"}
+    lines: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Compare):
+            operands = [node.left, *node.comparators]
+            if any(
+                isinstance(operand, ast.Constant)
+                and isinstance(operand.value, str)
+                and operand.value.casefold() in classifier_literals
+                for operand in operands
+            ):
+                lines.add(node.lineno)
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr
+            in {"__contains__", "count", "endswith", "find", "index", "startswith"}
+            and any(
+                isinstance(argument, ast.Constant)
+                and isinstance(argument.value, str)
+                and argument.value.casefold() in classifier_literals
+                for argument in node.args
+            )
+        ):
+            lines.add(node.lineno)
+    return sorted(lines)
+
+
+def _references_indexed_git_config(node: ast.AST) -> bool:
+    """Return whether a function touches the indexed GIT_CONFIG_* contract."""
+    prefixes = ("GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_")
+    return any(
+        isinstance(child, ast.Constant)
+        and isinstance(child.value, str)
+        and child.value.startswith(prefixes)
+        for child in ast.walk(node)
+    )
+
+
+def analyze(root: Path) -> list[str]:
+    """Return architecture violations under *root*."""
+    violations: list[str] = []
+    owner = root / OWNER_PATH
+    owner_tree = ast.parse(owner.read_text(encoding="utf-8"), filename=str(owner))
+    owner_definitions = [
+        node
+        for node in owner_tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == OWNER_SYMBOL
+    ]
+    if len(owner_definitions) != 1:
+        violations.append(f"{OWNER_PATH}: expected exactly one top-level {OWNER_SYMBOL} definition")
+
+    for relative_path, function_name in CONSUMERS.items():
+        path = root / relative_path
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        functions = _qualnamed_functions(tree)
+        function = functions.get(function_name)
+        if not _imports_owner(tree):
+            violations.append(f"{relative_path}: must import {OWNER_SYMBOL} from {OWNER_MODULE}")
+        if function is None:
+            violations.append(f"{relative_path}: required consumer {function_name} is missing")
+        elif _owner_call_count(function) != 1:
+            violations.append(
+                f"{relative_path}: {function_name} must call {OWNER_SYMBOL} exactly once"
+            )
+
+    source_root = root / "src/apm_cli"
+    for path in source_root.rglob("*.py"):
+        relative_path = path.relative_to(root)
+        if relative_path == OWNER_PATH:
+            continue
+        source = path.read_text(encoding="utf-8")
+        source_lines = source.splitlines()
+        tree = ast.parse(source, filename=str(path))
+        duplicate_lines = {
+            line
+            for function in _qualnamed_functions(tree).values()
+            if _references_indexed_git_config(function)
+            for line in _inline_predicate_lines(function)
+            if EXEMPT_MARKER not in source_lines[line - 1]
+        }
+        for line in sorted(duplicate_lines):
+            violations.append(
+                f"{relative_path}:{line}: indexed Git auth-config classification "
+                f"must route through {OWNER_SYMBOL}"
+            )
+    return violations
+
+
+def main() -> int:
+    """Run the owner-boundary checker."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    args = parser.parse_args()
+    violations = analyze(args.root.resolve())
+    if violations:
+        print("\n".join(violations))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -702,6 +702,16 @@ if [ -n "$auth_header_dictmerge_hits" ]; then
     violations=$((violations + 1))
 fi
 
+echo "[*] AC20: indexed Git auth-config retain/reindex authority"
+git_auth_config_owner_output=$(python3 scripts/check_git_auth_config_owner.py \
+    --root "$ROOT" 2>&1)
+git_auth_config_owner_status=$?
+if [ "$git_auth_config_owner_status" -ne 0 ]; then
+    echo "[x] Indexed Git auth-config retain/reindex must route through utils/git_env.py"
+    echo "$git_auth_config_owner_output"
+    violations=$((violations + 1))
+fi
+
 if [ "$violations" -gt 0 ]; then
     echo "[x] $violations architecture boundary rule(s) failed"
     exit 1

--- a/src/apm_cli/core/auth.py
+++ b/src/apm_cli/core/auth.py
@@ -43,6 +43,7 @@ from apm_cli.core.host_providers import (
     classify_host_provider,
 )
 from apm_cli.core.token_manager import GitHubTokenManager
+from apm_cli.utils.git_env import strip_git_auth_config_entries
 from apm_cli.utils.github_host import (
     default_host,
     is_azure_devops_hostname,
@@ -965,27 +966,7 @@ class AuthResolver:
         env.pop("GIT_TOKEN", None)
         env.pop("GIT_HTTP_EXTRAHEADER", None)
         env.pop("GIT_CONFIG_PARAMETERS", None)
-        try:
-            count = int(env.pop("GIT_CONFIG_COUNT", "0"))
-        except ValueError:
-            count = 0
-        retained: list[tuple[str, str]] = []
-        for index in range(max(0, count)):
-            key = env.pop(f"GIT_CONFIG_KEY_{index}", "")
-            value = env.pop(f"GIT_CONFIG_VALUE_{index}", "")
-            normalized = key.lower()
-            if "extraheader" in normalized or "authorization" in value.lower():
-                continue
-            if key:
-                retained.append((key, value))
-        for key in tuple(env):
-            if key.startswith(("GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_")):
-                env.pop(key, None)
-        if retained:
-            env["GIT_CONFIG_COUNT"] = str(len(retained))
-            for index, (key, value) in enumerate(retained):
-                env[f"GIT_CONFIG_KEY_{index}"] = key
-                env[f"GIT_CONFIG_VALUE_{index}"] = value
+        strip_git_auth_config_entries(env)
 
     def emit_stale_pat_diagnostic(self, host_display: str) -> None:
         """Emit a [!] warning when PAT was rejected but bearer succeeded.

--- a/src/apm_cli/utils/git_env.py
+++ b/src/apm_cli/utils/git_env.py
@@ -50,6 +50,85 @@ _STRIP_GIT_VARS: frozenset[str] = frozenset(
 )
 
 
+def _is_git_auth_config_entry(key: str, value: str) -> bool:
+    """Return whether an indexed Git config entry carries an auth header."""
+    if "extraheader" in key.casefold():
+        return True
+
+    normalized_value = value.replace("\r\n", "\n").replace("\r", "\n")
+    for line in normalized_value.split("\n"):
+        field_name, separator, _field_value = line.lstrip(" \t").partition(":")
+        if separator and field_name.rstrip(" \t").casefold() == "authorization":
+            return True
+    return False
+
+
+def strip_git_auth_config_entries(env: dict[str, str]) -> int:
+    """Remove auth entries from the indexed Git config environment.
+
+    ``GIT_CONFIG_COUNT`` is untrusted process input. Blank, invalid, and
+    negative values are treated as zero. Only canonical ``KEY_N`` slots below
+    that count are considered, so work is bounded by the actual environment
+    size rather than by an arbitrarily large declared count.
+
+    Non-auth entries are preserved in their original index order and compacted
+    to contiguous indexes. Every indexed key/value slot, including malformed
+    and out-of-range orphans, is removed before the retained set is rebuilt.
+
+    Args:
+        env: The subprocess environment mapping to rewrite in place.
+
+    Returns:
+        The number of retained entries, which is also the next free index.
+    """
+    try:
+        count = max(0, int(env.get("GIT_CONFIG_COUNT", "0") or "0"))
+    except (TypeError, ValueError):
+        count = 0
+
+    present_indexes: list[int] = []
+    key_prefix = "GIT_CONFIG_KEY_"
+    value_prefix = "GIT_CONFIG_VALUE_"
+    for name in env:
+        if not name.startswith(key_prefix):
+            continue
+        suffix = name.removeprefix(key_prefix)
+        if not suffix or not suffix.isascii() or not suffix.isdigit():
+            continue
+        if suffix != "0" and suffix.startswith("0"):
+            continue
+        try:
+            index = int(suffix)
+        except ValueError:
+            continue
+        if index < count:
+            present_indexes.append(index)
+
+    retained: list[tuple[str, str]] = []
+    for index in sorted(present_indexes):
+        key = env[f"{key_prefix}{index}"]
+        value = env.get(f"{value_prefix}{index}", "")
+        if key and not _is_git_auth_config_entry(key, value):
+            retained.append((key, value))
+
+    rewritten = {
+        key: value
+        for key, value in env.items()
+        if key != "GIT_CONFIG_COUNT"
+        and not key.startswith(key_prefix)
+        and not key.startswith(value_prefix)
+    }
+    if retained:
+        rewritten["GIT_CONFIG_COUNT"] = str(len(retained))
+        for index, (key, value) in enumerate(retained):
+            rewritten[f"{key_prefix}{index}"] = key
+            rewritten[f"{value_prefix}{index}"] = value
+
+    env.clear()
+    env.update(rewritten)
+    return len(retained)
+
+
 def get_git_executable() -> str:
     """Return the path to the git executable (cached after a successful lookup).
 

--- a/src/apm_cli/utils/github_host.py
+++ b/src/apm_cli/utils/github_host.py
@@ -4,6 +4,8 @@ import os
 import re
 import urllib.parse
 
+from apm_cli.utils.git_env import strip_git_auth_config_entries
+
 
 def _get_ghes_host() -> str:
     """Return the normalised GITHUB_HOST env value."""
@@ -497,7 +499,7 @@ def build_ado_bearer_git_env(bearer_token: str) -> dict:
 
 
 def set_authorization_header_git_env(env: dict[str, str], scheme: str, credential: str) -> None:
-    """Make ``Authorization: <scheme> <credential>`` the sole auth header in *env*.
+    """Make a new header the sole indexed Git auth header in *env*.
 
     :func:`build_authorization_header_git_env` returns an overlay whose
     ``GIT_CONFIG_COUNT`` is hardcoded to ``"1"``.  Dict-merging that overlay
@@ -506,27 +508,11 @@ def set_authorization_header_git_env(env: dict[str, str], scheme: str, credentia
     overwrites index 0, silently dropping non-auth entries such as
     ``safe.bareRepository=explicit`` or ``http.sslCAInfo`` (#2368).
 
-    This helper instead rewrites the indexed set in place: existing
-    auth-channel entries (any ``*extraheader*`` key, or a value that IS an
-    ``Authorization:`` header -- the same policy as
-    ``AuthResolver._clear_git_auth_env``) are removed so layered callers
-    cannot stack duplicate Authorization headers, every other entry is
-    preserved, and the new header is appended at the end.  Orphaned
-    ``GIT_CONFIG_KEY_/VALUE_`` entries at or beyond the count are also
-    dropped so no stale credential lingers in the child-process env table.
-
-    Note:
-        The retain/reindex predicate below intentionally mirrors
-        ``AuthResolver._clear_git_auth_env`` (``core/auth.py``) rather than
-        delegating to a shared primitive.  Extracting a single owner (e.g.
-        ``utils/git_env.py``) is the right end state -- see PR discussion on
-        #2368 and follow-up #2398 -- but doing so means editing
-        ``_clear_git_auth_env``, a security-critical function this bug does
-        not otherwise touch, which deserves its own focused security review
-        rather than riding along in this fix.
-        TODO(#2398): extract a shared ``_is_auth_channel_entry`` /
-        retain-reindex helper into ``utils/git_env.py``, and delegate both
-        this function and ``AuthResolver._clear_git_auth_env`` to it.
+    This helper delegates indexed retain/reindex policy to
+    :func:`apm_cli.utils.git_env.strip_git_auth_config_entries`, then appends
+    the new header after every retained non-auth entry. Layered callers cannot
+    stack indexed Authorization headers, and orphaned indexed slots cannot
+    retain stale credentials in the child-process environment.
 
     Args:
         env: The subprocess env dict to mutate (base env already merged in).
@@ -545,26 +531,10 @@ def set_authorization_header_git_env(env: dict[str, str], scheme: str, credentia
     """
     if "\r" in scheme or "\n" in scheme or "\r" in credential or "\n" in credential:
         raise ValueError("scheme and credential must not contain CR or LF")
-    try:
-        count = max(0, int(env.get("GIT_CONFIG_COUNT", "0") or "0"))
-    except ValueError:
-        count = 0
-    retained: list[tuple[str, str]] = []
-    for index in range(count):
-        key = env.get(f"GIT_CONFIG_KEY_{index}", "")
-        value = env.get(f"GIT_CONFIG_VALUE_{index}", "")
-        if "extraheader" in key.lower() or value.strip().lower().startswith("authorization:"):
-            continue
-        if key:
-            retained.append((key, value))
-    for key in tuple(env):
-        if key.startswith(("GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_")):
-            env.pop(key, None)
-    retained.append(("http.extraheader", f"Authorization: {scheme} {credential}"))
-    env["GIT_CONFIG_COUNT"] = str(len(retained))
-    for index, (key, value) in enumerate(retained):
-        env[f"GIT_CONFIG_KEY_{index}"] = key
-        env[f"GIT_CONFIG_VALUE_{index}"] = value
+    next_index = strip_git_auth_config_entries(env)
+    env["GIT_CONFIG_COUNT"] = str(next_index + 1)
+    env[f"GIT_CONFIG_KEY_{next_index}"] = "http.extraheader"
+    env[f"GIT_CONFIG_VALUE_{next_index}"] = f"Authorization: {scheme} {credential}"
 
 
 def set_ado_bearer_git_env(env: dict[str, str], bearer_token: str) -> None:

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -1412,3 +1412,82 @@ def test_git_auth_header_owner_guard_rejects_dictmerge_reintroduction(tmp_path: 
         "Git-subprocess Authorization-header injection must use "
         "set_authorization_header_git_env / set_ado_bearer_git_env" in result.stdout
     )
+
+
+def test_indexed_git_auth_config_retain_reindex_has_single_owner() -> None:
+    """#2398: both consumers delegate indexed cleanup to utils/git_env.py."""
+    root = Path(__file__).parents[2]
+    owner = (root / "src/apm_cli/utils/git_env.py").read_text(encoding="utf-8")
+    core_consumer = (root / "src/apm_cli/core/auth.py").read_text(encoding="utf-8")
+    setter_consumer = (root / "src/apm_cli/utils/github_host.py").read_text(encoding="utf-8")
+    guard = (root / "scripts/lint-architecture-boundaries.sh").read_text(encoding="utf-8")
+    source_doc = (root / ".apm/instructions/architecture.instructions.md").read_text(
+        encoding="utf-8"
+    )
+    deployed_doc = (root / ".github/instructions/architecture.instructions.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "def strip_git_auth_config_entries(" in owner
+    assert core_consumer.count("strip_git_auth_config_entries(env)") == 1
+    assert setter_consumer.count("strip_git_auth_config_entries(env)") == 1
+    assert "AC20: indexed Git auth-config retain/reindex authority" in guard
+    assert "Indexed Git auth-config retain/reindex policy" in source_doc
+    assert "`src/apm_cli/utils/git_env.py`" in source_doc
+    assert deployed_doc == source_doc
+
+
+def test_git_auth_config_owner_guard_rejects_inline_predicate(tmp_path: Path) -> None:
+    """AC20 must reject a second indexed auth-entry classifier."""
+    root = Path(__file__).parents[2]
+    sandbox = tmp_path / "repo"
+    shutil.copytree(
+        root,
+        sandbox,
+        ignore=shutil.ignore_patterns(
+            ".git",
+            ".venv",
+            ".pytest_cache",
+            "__pycache__",
+            "build",
+            "dist",
+            "node_modules",
+        ),
+    )
+    consumer = sandbox / "src/apm_cli/core/auth.py"
+    original = consumer.read_text(encoding="utf-8")
+    inline_reimplementation = (
+        '        count = int(env.pop("GIT_CONFIG_COUNT", "0") or "0")\n'
+        "        retained = []\n"
+        "        for index in range(max(0, count)):\n"
+        '            key = env.pop(f"GIT_CONFIG_KEY_{index}", "")\n'
+        '            value = env.pop(f"GIT_CONFIG_VALUE_{index}", "")\n'
+        '            if key.lower().find("extraheader") >= 0 '
+        'or value.lower().find("authorization") >= 0:\n'
+        "                continue\n"
+        "            if key:\n"
+        "                retained.append((key, value))\n"
+        "        if retained:\n"
+        '            env["GIT_CONFIG_COUNT"] = str(len(retained))\n'
+    )
+    mutated = original.replace(
+        "        strip_git_auth_config_entries(env)\n",
+        inline_reimplementation,
+        1,
+    )
+    assert mutated != original
+    consumer.write_text(mutated, encoding="utf-8")
+
+    result = subprocess.run(
+        ("bash", "scripts/lint-architecture-boundaries.sh"),
+        cwd=sandbox,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+
+    assert result.returncode == 1
+    assert "Indexed Git auth-config retain/reindex must route through utils/git_env.py" in (
+        result.stdout
+    )

--- a/tests/unit/cache/test_git_env.py
+++ b/tests/unit/cache/test_git_env.py
@@ -11,6 +11,7 @@ from apm_cli.utils.git_env import (
     get_git_executable,
     git_subprocess_env,
     reset_git_cache,
+    strip_git_auth_config_entries,
 )
 
 # Entire module: this is the canonical owner of resolved,
@@ -143,3 +144,118 @@ class TestGitSubprocessEnv:
         with patch.dict(os.environ, {"LD_LIBRARY_PATH": "/custom/lib"}, clear=True):
             env = git_subprocess_env()
             assert env["LD_LIBRARY_PATH"] == "/custom/lib"
+
+
+class TestStripGitAuthConfigEntries:
+    """Canonical indexed GIT_CONFIG_* retain/reindex policy."""
+
+    def test_strips_auth_entries_and_reindexes_safe_entries_stably(self) -> None:
+        env = {
+            "OTHER": "preserved",
+            "GIT_CONFIG_COUNT": "4",
+            "GIT_CONFIG_KEY_0": "safe.bareRepository",
+            "GIT_CONFIG_VALUE_0": "explicit",
+            "GIT_CONFIG_KEY_1": "http.ExtraHeader",
+            "GIT_CONFIG_VALUE_1": "X-Trace: inherited",
+            "GIT_CONFIG_KEY_2": "credential.helper",
+            "GIT_CONFIG_VALUE_2": "note\r\n\tAUTHORIZATION : Bearer stale-secret",
+            "GIT_CONFIG_KEY_3": "http.sslCAInfo",
+            "GIT_CONFIG_VALUE_3": "/corporate/ca.pem",
+            "GIT_CONFIG_KEY_9": "http.extraheader",
+            "GIT_CONFIG_VALUE_9": "Authorization: Bearer orphan-secret",
+        }
+
+        retained_count = strip_git_auth_config_entries(env)
+
+        assert retained_count == 2
+        assert env == {
+            "OTHER": "preserved",
+            "GIT_CONFIG_COUNT": "2",
+            "GIT_CONFIG_KEY_0": "safe.bareRepository",
+            "GIT_CONFIG_VALUE_0": "explicit",
+            "GIT_CONFIG_KEY_1": "http.sslCAInfo",
+            "GIT_CONFIG_VALUE_1": "/corporate/ca.pem",
+        }
+        assert not any("secret" in value for value in env.values())
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "Authorization: Bearer stale",
+            "  authorization:\tBasic stale",
+            "note\nAuthorization: Bearer stale",
+            "note\rAuthorization: Bearer stale",
+            "note\r\n\tAuthorization : Bearer stale",
+        ],
+    )
+    def test_strips_exact_authorization_header_lines(self, value: str) -> None:
+        env = {
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_KEY_0": "credential.helper",
+            "GIT_CONFIG_VALUE_0": value,
+        }
+
+        assert strip_git_auth_config_entries(env) == 0
+        assert env == {}
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "http://authorization-proxy.corp.example:3128",
+            "authorization is required",
+            "x=Authorization: example",
+            "X-Authorization: example",
+        ],
+    )
+    def test_preserves_non_header_authorization_text(self, value: str) -> None:
+        env = {
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_KEY_0": "http.proxy",
+            "GIT_CONFIG_VALUE_0": value,
+        }
+
+        assert strip_git_auth_config_entries(env) == 1
+        assert env["GIT_CONFIG_VALUE_0"] == value
+
+    @pytest.mark.parametrize("count", [None, "", " ", "invalid", "-3"])
+    def test_invalid_or_non_positive_count_discards_all_slots(self, count: str | None) -> None:
+        env: dict[str, str] = {
+            "GIT_CONFIG_COUNT": count,  # type: ignore[dict-item]
+            "GIT_CONFIG_KEY_0": "safe.bareRepository",
+            "GIT_CONFIG_VALUE_0": "explicit",
+        }
+
+        assert strip_git_auth_config_entries(env) == 0
+        assert env == {}
+
+    def test_runtime_is_bounded_by_present_slots_not_declared_count(self) -> None:
+        env = {
+            "GIT_CONFIG_COUNT": "999999999999999999999999999999999999",
+            "GIT_CONFIG_KEY_7": "safe.bareRepository",
+            "GIT_CONFIG_VALUE_7": "explicit",
+        }
+
+        assert strip_git_auth_config_entries(env) == 1
+        assert env == {
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_KEY_0": "safe.bareRepository",
+            "GIT_CONFIG_VALUE_0": "explicit",
+        }
+
+    def test_missing_values_and_noncanonical_slots_are_cleaned(self) -> None:
+        env = {
+            "GIT_CONFIG_COUNT": "4",
+            "GIT_CONFIG_VALUE_0": "value-without-key",
+            "GIT_CONFIG_KEY_1": "credential.interactive",
+            "GIT_CONFIG_KEY_00": "http.extraheader",
+            "GIT_CONFIG_VALUE_00": "Authorization: Bearer stale",
+            "GIT_CONFIG_KEY_bad": "http.extraheader",
+            "GIT_CONFIG_VALUE_bad": "Authorization: Bearer stale",
+        }
+
+        assert strip_git_auth_config_entries(env) == 1
+        assert env == {
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_KEY_0": "credential.interactive",
+            "GIT_CONFIG_VALUE_0": "",
+        }

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1096,6 +1096,22 @@ class TestBuildGitEnvBearerIsolation:
         assert env["GIT_CONFIG_VALUE_1"] == "Authorization: Bearer fresh-jwt"
         assert not any("inherited-secret" in str(v) for v in env.values())
 
+    def test_clear_git_auth_env_preserves_authorization_substring_value(self):
+        """#2398: ordinary values containing ``authorization`` are not headers."""
+        env = {
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_KEY_0": "http.proxy",
+            "GIT_CONFIG_VALUE_0": "http://authorization-proxy.corp.example:3128",
+        }
+
+        AuthResolver._clear_git_auth_env(env)
+
+        assert env == {
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_KEY_0": "http.proxy",
+            "GIT_CONFIG_VALUE_0": "http://authorization-proxy.corp.example:3128",
+        }
+
 
 # ---------------------------------------------------------------------------
 # TestHostInfoPort -- port field + display_name property

--- a/tests/unit/test_github_host.py
+++ b/tests/unit/test_github_host.py
@@ -497,6 +497,24 @@ def test_set_authorization_header_replaces_inherited_auth_header():
     assert not any("stale" in v for v in env.values())
 
 
+def test_set_authorization_header_replaces_multiline_inherited_auth_header():
+    """An inherited header cannot hide behind an earlier non-header line."""
+    env = {
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "credential.helper",
+        "GIT_CONFIG_VALUE_0": "note\r\nAuthorization: Bearer stale-secret",
+    }
+
+    github_host.set_authorization_header_git_env(env, "Bearer", "fresh")
+
+    assert env == {
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "http.extraheader",
+        "GIT_CONFIG_VALUE_0": "Authorization: Bearer fresh",
+    }
+    assert not any("stale-secret" in value for value in env.values())
+
+
 def test_set_authorization_header_is_idempotent_under_layering():
     """Two layered calls (e.g. _build_git_env then a retry wrapper) keep one header."""
     env = {


### PR DESCRIPTION
refactor(auth): centralize indexed Git config cleanup

## TL;DR

Centralize ownership of indexed `GIT_CONFIG_*` authentication-header cleanup in
`apm_cli.utils.git_env`.

This removes two subtly different cleanup implementations from the authentication
resolver and the GitHub-host helper.

The shared owner now:

- identifies only `http.*.extraheader` entries whose value contains an actual
  `Authorization:` header field;
- preserves proxy, TLS, CA, and other unrelated Git configuration;
- handles LF, CRLF, and CR-separated header values;
- compacts retained entries into a stable contiguous sequence;
- removes orphaned indexed keys left by stale or malformed counts.

Fixes #2398.

## Problem

APM has two consumers that need to remove stale Git authentication headers before
constructing a child-process environment:

- `AuthResolver._clear_git_auth_env`;
- `set_authorization_header_git_env`.

Each consumer previously implemented its own scan, filtering, and reindexing.

The two implementations did not agree on what counted as an authentication entry.
One checked whether the entire value started with `authorization:` while the other
removed any value containing the substring `authorization`.

That split ownership created two concrete risks:

1. a multiline `extraheader` value could retain a stale credential when its
   Authorization field was not first;
2. an unrelated value containing text such as `x-authorization-mode` could be
   discarded even though it was not an Authorization header.

Because the environment is inherited by Git subprocesses, both false negatives and
false positives matter: stale credentials are a security boundary, while removed
proxy or TLS configuration can make a valid clone fail.

## Approach

Introduce one canonical helper that owns the indexed representation and make both
call sites delegate to it.

| Concern | Decision |
| --- | --- |
| Header recognition | Parse line boundaries and match the exact `Authorization` field name |
| Line endings | Accept LF, CRLF, and CR |
| Whitespace | Allow optional horizontal whitespace around the field name and colon |
| Key scope | Restrict removal to `http.*.extraheader` entries |
| Retention | Preserve every non-authentication entry without modifying its value |
| Reindexing | Rewrite retained pairs from index zero in their original order |
| Stale metadata | Remove indexed keys that are not represented by a trustworthy count |
| Consumer behavior | Keep direct credential channels local to the resolver |

The helper stages the new indexed state before mutating the environment. This
avoids leaving a partially rewritten sequence if the input contains malformed
count metadata.

## Implementation

### Canonical owner

[`src/apm_cli/utils/git_env.py`](https://github.com/microsoft/apm/blob/3e97d647fda69aa97cfc1e22aea456b55c2a88ba/src/apm_cli/utils/git_env.py#L53-L129)
now provides:

- `_is_git_auth_config_entry(key, value)` for exact field recognition;
- `strip_git_auth_config_entries(env)` for filtering, cleanup, and stable
  compaction.

The function returns the next free index so a caller that needs to append a new
header can do so without recomputing the sequence.

It treats a missing, negative, non-integer, or otherwise stale count defensively
and still inspects actual indexed key slots present in the environment.

### Consumers

[`AuthResolver._clear_git_auth_env`](https://github.com/microsoft/apm/blob/3e97d647fda69aa97cfc1e22aea456b55c2a88ba/src/apm_cli/core/auth.py#L963-L969)
delegates indexed cleanup to the shared helper,
then continues to clear the resolver-owned direct credential channels.

[`set_authorization_header_git_env`](https://github.com/microsoft/apm/blob/3e97d647fda69aa97cfc1e22aea456b55c2a88ba/src/apm_cli/utils/github_host.py#L501-L537)
rejects CR/LF in the new token, delegates stale
indexed cleanup, and appends exactly one fresh Authorization header at the returned
index.

Its contract now explicitly describes that sole indexed Git authentication header.

### Ownership guard

[`scripts/check_git_auth_config_owner.py`](https://github.com/microsoft/apm/blob/3e97d647fda69aa97cfc1e22aea456b55c2a88ba/scripts/check_git_auth_config_owner.py#L1-L164)
establishes the helper as the only
production owner of indexed Git authentication cleanup.

The architecture lint invokes this checker as AC20.

The checker understands relevant syntax rather than relying on a broad text search,
so comments, fixtures, and approved helper implementation details do not create
false positives.

The owner declaration is mirrored in `.apm`, `.github`, and the lock file so the
published and repository-local architecture guidance remain aligned.

### Tests

The change adds focused tests for:

- exact header-field matching;
- LF, CRLF, and CR multiline values;
- optional horizontal whitespace;
- safe values that merely contain authorization-related text;
- malformed and stale count metadata;
- orphan-key cleanup;
- stable reindexing and return values;
- resolver delegation and direct-channel cleanup;
- setter replacement and injection rejection;
- the architecture owner boundary.

## Diagrams

```mermaid
flowchart LR
    subgraph Consumers["Consumers"]
        C1["AuthResolver._clear_git_auth_env"]
        C2["set_authorization_header_git_env"]
    end

    subgraph Owner["Canonical owner"]
        O1["strip_git_auth_config_entries"]:::new
        O2["_is_git_auth_config_entry"]:::new
    end

    subgraph Result["Indexed environment"]
        R1["Stable retained entries"]
        R2["Fresh header appended by setter"]
    end

    C1 --> O1
    C2 --> O1
    O1 --> O2
    O1 --> R1
    O1 --> C2
    C2 --> R2

    classDef new stroke-dasharray: 5 5
```

The dashed nodes are introduced by this change. Existing consumers now share the
same filtering and compaction path before continuing with their own responsibilities.

## Trade-offs

- Exact header-field matching is deliberately narrower than a substring search.
  This preserves vendor-neutral configuration while still rejecting a real
  Authorization field anywhere in a multiline value.
- The helper scans the indexed slots actually present in the environment in
  addition to a valid declared range. This makes stale metadata recoverable without
  trusting an arbitrarily large count.
- Direct credential variables remain resolver-owned. Moving those channels into
  the indexed-config utility would broaden its contract beyond issue #2398.
- The architecture checker adds a small maintenance cost, but turns an otherwise
  informal ownership rule into an executable boundary.

## Benefits

- One implementation defines the security-sensitive cleanup behavior.
- Both credential paths preserve unrelated proxy, TLS, CA, and hardening settings.
- Multiline stale Authorization fields cannot bypass cleanup.
- Safe values containing authorization-related words are no longer over-filtered.
- Future duplicate cleanup loops fail the architecture check before review.
- Focused regression tests describe the retained and removed cases independently.

## Validation

### Automated checks

- Focused Git-auth test selection:
  `119 passed in 0.40s`
- Full unit suite:
  `19098 passed, 2 skipped, 21 xfailed, 19 warnings, 87 subtests passed in 162.63s`
- Ruff check:
  `All checks passed!`
- Ruff format:
  `1550 files already formatted`
- Pylint:
  `Your code has been rated at 10.00/10`
- Authentication-signal lint:
  `[+] auth-signal lint clean`
- Architecture lint AC1-AC20:
  `[+] architecture boundary lint clean`
- Package build:
  source distribution and wheel both built successfully with `uv build`
- Patch hygiene:
  `git diff --check` completed with no output

### Mutation evidence

| Deliberate regression | Detection |
| --- | --- |
| Replace exact field matching with broad substring matching | 5 focused tests fail |
| Change extraheader key scope from OR to AND | 6 focused tests fail |
| Reintroduce a consumer-owned cleanup loop | AC20 fails |

All mutations were temporary and the correct implementation was restored before
the full validation run.

### Scenario Evidence

| Scenario | Principle demonstrated | Test level | Regression trap |
| --- | --- | --- | --- |
| A bearer retry inherits corporate proxy and CA entries while stale auth is removed | Secure by default; vendor-neutral behavior | Unit | Resolver preservation test for #2398 |
| The setter replaces an old indexed header and retains hardening entries | Secure by default; predictable developer experience | Unit | Setter replacement and ordering tests |
| An Authorization field follows another field in one multiline value | Secure by default | Unit | LF, CRLF, and CR multiline tests |
| A second production consumer attempts to own indexed cleanup | Community-maintainable architecture | Integration lint | AC20 mutation test |

## How to test

From the repository root:

1. Run the focused regression set:
   `uv run pytest tests/unit/test_git_env.py tests/unit/test_auth.py tests/unit/test_github_host.py -q`.
2. Run the full suite:
   `uv run pytest tests/unit -q`.
3. Run formatting and lint checks:
   `uv run ruff check .` and `uv run ruff format --check .`.
4. Run the repository authentication and architecture lint scripts.
5. Build both package artifacts with `uv build`.

## Repository checklist

- [x] Maintenance/refactor change
- [x] Tested locally
- [x] Existing tests pass
- [x] New regression tests added
- [x] OpenAPM specification change: N/A
- [x] Architecture ownership metadata synchronized
- [x] Changelog entry references #2411
- [x] No new runtime dependency

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
