### PR TITLE
chore: release v0.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.1] - 2026-08-01
+
+### Fixed
+
+- Installation now preserves caller Git configuration during credential-free
+  probes, projects `targets: [copilot]` to `.vscode/mcp.json`, retains usage
+  errors for malformed manifests, and serializes conflicting local dependency
+  materialization. This repairs the failed v0.27.0 release gate without adding
+  new user-facing surface. (#2417)
+
 ## [0.27.0] - 2026-07-31
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "apm-cli"
-version = "0.27.0"
+version = "0.27.1"
 description = "MCP configuration tool"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -203,7 +203,7 @@ wheels = [
 
 [[package]]
 name = "apm-cli"
-version = "0.27.0"
+version = "0.27.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
# ship(release): prepare the v0.27.1 recovery patch

## TL;DR

Cut v0.27.1 from repaired `main` after the unpublished v0.27.0 release gate
failed. This patch records the user-facing repairs from #2417 and synchronizes
the package version in `pyproject.toml` and `uv.lock`; it does not add a new
feature or tag the release.

> [!IMPORTANT]
> After this PR merges, a maintainer must tag `v0.27.1` to trigger publishing.

## Problem (WHY)

- [x] The v0.27.0 release run failed before publication with deterministic
  integration regressions ([run 30656328024](https://github.com/microsoft/apm/actions/runs/30656328024)).
- [x] PR #2417 repaired the auth, target projection, CLI exit-code, and local
  dependency materialization contracts, but those fixes are not represented by
  a published package version
  ([repair PR](https://github.com/microsoft/apm/pull/2417)).
- [!] Reusing v0.27.0 would make the failed and repaired release candidates
  indistinguishable; a patch version keeps the published artifact traceable to
  the repaired commit.

The release metadata is kept small and deterministic because
["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)

## Approach (WHAT)

| # | Fix | Principle | Source |
|---:|---|---|---|
| 1 | Add one v0.27.1 changelog entry for the repaired user contracts. | ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) | [PR #2417](https://github.com/microsoft/apm/pull/2417) |
| 2 | Bump both package-version authorities from 0.27.0 to 0.27.1. | ["agents pattern-match well against concrete structures"](https://agentskills.io/skill-creation/best-practices) | `pyproject.toml`, `uv.lock` |
| 3 | Leave tagging outside this PR as the explicit publication gate. | ["Context arrives just-in-time, not just-in-case."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) | `.github/workflows/build-release.yml` |

## Implementation (HOW)

- **`CHANGELOG.md`** -- Keeps `[Unreleased]` empty and adds
  `[0.27.1] - 2026-08-01` with one concise Fixed entry backed by #2417.
- **`pyproject.toml`** -- Changes the project version from `0.27.0` to
  `0.27.1`.
- **`uv.lock`** -- Refreshes the editable `apm-cli` package entry to the same
  `0.27.1` version; no dependency resolution changed.

## Diagrams

Legend: the repaired merge is converted into synchronized release metadata;
publication remains behind the post-merge human tag.

```mermaid
flowchart LR
    subgraph Repair[Repaired main]
        R[PR 2417]
        C[CI run 30698937627]
    end
    subgraph Prep[Release PR]
        H[CHANGELOG 0.27.1]
        P[pyproject 0.27.1]
        L[uv.lock 0.27.1]
    end
    subgraph Publish[Post-merge gate]
        T[tag v0.27.1]
        W[release workflow]
    end
    R --> C
    C --> H
    C --> P
    C --> L
    H --> T
    P --> T
    L --> T
    T --> W
    classDef new stroke-dasharray: 5 5;
    class H,P,L new;
```

## Trade-offs

- **Patch instead of minor.** Chose v0.27.1 because #2417 only repairs existing
  behavior; rejected v0.28.0 because no new command, feature flag, schema,
  contract, resolution mode, or supported target was added.
- **No tag in this PR.** Chose an explicit post-merge tag gate; rejected
  pre-merge tagging because it could publish an unreviewed release commit.
- **Scenario Evidence omitted.** This is release metadata only: a pure
  asset/version bump with no runtime behavior change, so the rubric's
  asset-bump skip clause applies.

## Benefits

1. Publishes a version distinguishable from the failed v0.27.0 candidate.
2. Keeps all three release metadata files aligned on `0.27.1`.
3. Produces one changelog entry for the only user-facing PR since `v0.27.0`.

## Validation

PR #2417 merged as `7bd5a83720d204d35fb3be666525e298077c43d1`;
[CI/CD run 30698937627](https://github.com/microsoft/apm/actions/runs/30698937627)
completed successfully for that commit.

<details><summary>Local lint mirror</summary>

`.agents/skills/cut-release/scripts/verify-lint-mirror.sh`:

```text
=== verify-lint-mirror summary ===
  ruff check                     PASS
  ruff format --check            PASS
  pylint R0801 duplication       PASS
  auth-signals boundary          PASS
[+] all lint-mirror checks PASSED
```

Remaining CI guards:

```text
[+] YAML I/O, file length, and portable path guards passed
```

</details>

Version synchronization:

```text
pyproject.toml:7:version = "0.27.1"
uv.lock:206:version = "0.27.1"
```

### Scenario Evidence

Not applicable under the pure asset/version-bump skip clause: this PR changes
release metadata only and introduces no executable behavior.

## How to test

- [ ] Confirm `CHANGELOG.md` has an empty `[Unreleased]` block followed by the
  dated `0.27.1` Fixed entry for #2417.
- [ ] Confirm `pyproject.toml` and the editable `apm-cli` entry in `uv.lock`
  both report `0.27.1`.
- [ ] Run `.agents/skills/cut-release/scripts/verify-lint-mirror.sh` and observe
  all four checks pass.
- [ ] After merge only, tag `v0.27.1` and observe the release workflow start:

```bash
git tag v0.27.1
git push origin v0.27.1
```

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
