### PR TITLE
fix(release): preserve Git isolation across auth fallback

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -226,10 +226,9 @@ jobs:
           # slower Intel runner overruns the step timeout, so parallelise
           # in-process with xdist. --dist loadgroup is required: it is the
           # only scheduler that honors pytest.mark.xdist_group, which keeps
-          # the HOME-mutating tests serialized on a single worker. Kept at
-          # -n 2 (matching ci-integration's per-shard width) to bound the
-          # shared-PAT API concurrency these E2E tests generate.
-          PYTEST_EXTRA_ARGS: "-n 2 --dist loadgroup"
+          # the HOME-mutating tests serialized on a single worker. Four
+          # workers remain below the merge gate's aggregate concurrency.
+          PYTEST_EXTRA_ARGS: "-n 4 --dist loadgroup"
         run: |
           chmod +x scripts/test-integration.sh
           uv run ./scripts/test-integration.sh
@@ -345,7 +344,7 @@ jobs:
           # the full suite onto one runner, so parallelise in-process with
           # xdist. --dist loadgroup honors the home_env xdist_group markers
           # that keep HOME-mutating tests serialized on a single worker.
-          PYTEST_EXTRA_ARGS: "-n 2 --dist loadgroup"
+          PYTEST_EXTRA_ARGS: "-n 4 --dist loadgroup"
         run: |
           chmod +x scripts/test-integration.sh
           uv run ./scripts/test-integration.sh
@@ -439,6 +438,10 @@ jobs:
           APM_E2E_TESTS: "1"
           GITHUB_APM_PAT: ${{ secrets.GH_CLI_PAT }}    # Primary: APM module access
           ADO_APM_PAT: ${{ secrets.ADO_APM_PAT }}      # Azure DevOps module access
+          # The tag gate runs the full corpus on one runner. Four workers stay
+          # below the merge gate's aggregate width while loadgroup preserves
+          # xdist_group serialization for HOME-mutating tests.
+          PYTEST_EXTRA_ARGS: "-n 4 --dist loadgroup"
         run: |
           chmod +x scripts/test-integration.sh
           uv run ./scripts/test-integration.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Public `github.com` dependency installs now preserve caller-owned Git URL
+  rewrites and transport policy across anonymous and authenticated retries.
+  (#2422)
+
 ## [0.27.0] - 2026-07-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Public `github.com` dependency installs now preserve caller-owned Git URL
-  rewrites and transport policy across anonymous and authenticated retries.
-  (#2422)
+  rewrites and transport policy across anonymous and authenticated retries;
+  policy cache metadata and diagnostics also omit credentials embedded in
+  direct policy URLs. (#2422)
 
 ## [0.27.0] - 2026-07-31
 

--- a/docs/src/content/docs/reference/cli/policy.md
+++ b/docs/src/content/docs/reference/cli/policy.md
@@ -54,6 +54,9 @@ apm policy status [OPTIONS]
 | `--json` | Emit JSON. Alias of `-o json`. |
 | `--check` | Exit `1` when no usable policy is resolved (any `outcome` other than `found`). Default exit is always `0`. |
 
+Direct policy URLs should not embed credentials. Cache metadata and command
+output omit URL userinfo, query strings, and fragments.
+
 #### Output fields
 
 The table and JSON renderers expose the same fields:

--- a/docs/src/content/docs/reference/policy-schema.md
+++ b/docs/src/content/docs/reference/policy-schema.md
@@ -47,6 +47,11 @@ The `<ref>` accepts:
 - `<owner>/<repo>` shorthand (defaults to `github.com`).
 - `<host>/<owner>/<repo>` for GHES or other hosts.
 
+Do not embed credentials in direct policy URLs. APM strips URL userinfo,
+query strings, and fragments from policy cache metadata and diagnostics; use
+the repository forms above with the normal host authentication chain when
+possible.
+
 ## Top-level fields
 
 | Field              | Type                | Default          | Required | Notes                                                                             |

--- a/packages/apm-guide/.apm/skills/apm-usage/governance.md
+++ b/packages/apm-guide/.apm/skills/apm-usage/governance.md
@@ -10,6 +10,10 @@ CHANGELOG when using policy features.
 - **Repo-level:** `apm-policy.yml` in the repository root
 - **Local override:** `--policy ./path/to/apm-policy.yml`
 
+Do not embed credentials in direct policy URLs. APM omits URL userinfo, query
+strings, and fragments from policy cache metadata and diagnostics; prefer
+repository references with the normal host authentication chain.
+
 ## User config trust boundary
 
 `~/.apm/config.json` is user-scoped state, not org policy. Keep durable config

--- a/scripts/lint-architecture-boundaries.sh
+++ b/scripts/lint-architecture-boundaries.sh
@@ -591,6 +591,12 @@ if ! grep -q '_clear_git_auth_env(env)' src/apm_cli/core/auth.py; then
     echo "[x] AuthResolver must scrub inherited Git authorization state"
     violations=$((violations + 1))
 fi
+if ! grep -q '"repo_ref": _redact_policy_ref(repo_ref)' src/apm_cli/policy/discovery.py \
+    || ! grep -q '"chain_refs": \[_redact_policy_ref(ref) for ref in persisted_chain_refs\]' \
+        src/apm_cli/policy/discovery.py; then
+    echo "[x] Policy cache metadata must redact URL credentials at its canonical writer"
+    violations=$((violations + 1))
+fi
 check_pattern \
     "TLS trust injection belongs to canonical owners" \
     'truststore\.inject_into_ssl\(' \

--- a/src/apm_cli/commands/policy.py
+++ b/src/apm_cli/commands/policy.py
@@ -25,6 +25,7 @@ from ..policy.discovery import (
     MAX_STALE_TTL,
     PolicyFetchResult,
     _read_cache_entry,
+    _redact_policy_ref,
     discover_policy_with_chain,
 )
 from ..policy.schema import ApmPolicy
@@ -134,13 +135,18 @@ def _resolve_chain_refs(result: PolicyFetchResult, project_root: Path) -> list[s
         return []
 
     # Try cache lookup first (org / URL paths populate chain_refs in meta).
-    repo_ref = _strip_source_prefix(result.source)
+    repo_ref = result.cache_ref or _strip_source_prefix(result.source)
     if repo_ref and not result.source.startswith("file:"):
         try:
             entry = _read_cache_entry(repo_ref, project_root, ttl=MAX_STALE_TTL)
             if entry is not None and entry.chain_refs:
                 # Drop the leaf itself from the visible chain.
-                tail = [r for r in entry.chain_refs if r != repo_ref]
+                safe_repo_ref = _redact_policy_ref(repo_ref)
+                tail = [
+                    _redact_policy_ref(ref)
+                    for ref in entry.chain_refs
+                    if _redact_policy_ref(ref) != safe_repo_ref
+                ]
                 if tail:
                     return tail
         except Exception:
@@ -148,7 +154,7 @@ def _resolve_chain_refs(result: PolicyFetchResult, project_root: Path) -> list[s
 
     # Fallback: declared extends on the merged/leaf policy.
     if result.policy.extends:
-        return [result.policy.extends]
+        return [_redact_policy_ref(result.policy.extends)]
     return []
 
 
@@ -184,7 +190,7 @@ def _build_report(
     counts: dict[str, int],
 ) -> dict[str, Any]:
     """Assemble the structured report consumed by both renderers."""
-    source_label = result.source if result.source else "n/a"
+    source_label = _redact_policy_ref(result.source) if result.source else "n/a"
     if result.outcome in ("absent", "no_git_remote", "disabled"):
         source_label = source_label or "n/a"
 

--- a/src/apm_cli/core/auth.py
+++ b/src/apm_cli/core/auth.py
@@ -557,6 +557,7 @@ class AuthResolver:
         host_type: str | None = None,
         unauth_first: bool = False,
         verbose_callback: Callable[[str], None] | None = None,
+        base_env: dict[str, str] | None = None,
     ) -> T:
         """Execute *operation* with automatic auth/unauth fallback.
 
@@ -583,6 +584,9 @@ class AuthResolver:
             If *True*, try unauthenticated first (saves rate limits, EMU-safe).
         verbose_callback:
             Called with a human-readable step description at each attempt.
+        base_env:
+            Optional caller-owned Git environment. When provided, isolated
+            config and transport policy are retained across every attempt.
 
         When the resolved token comes from a global env var and fails
         (e.g. a github.com PAT tried on ``*.ghe.com``), the method
@@ -609,9 +613,13 @@ class AuthResolver:
             )
             host_info = auth_ctx.host_info
         unauth_env = (
-            self.build_public_github_anonymous_git_env()
+            self.build_public_github_anonymous_git_env(base_env=base_env)
             if lazy_public_github
-            else self._build_git_env(None, host_kind=host_info.kind)
+            else self._build_git_env(
+                None,
+                host_kind=host_info.kind,
+                base_env=base_env,
+            )
         )
 
         def _auth_context() -> AuthContext:
@@ -625,6 +633,11 @@ class AuthResolver:
                     path=path if lazy_public_github else None,
                 )
             return auth_ctx
+
+        def _git_env_for_context(ctx: AuthContext) -> dict[str, str]:
+            if base_env is None:
+                return ctx.git_env
+            return self.git_env_for_context(ctx, base_env=base_env)
 
         def _log(msg: str) -> None:
             if verbose_callback:
@@ -656,7 +669,12 @@ class AuthResolver:
                 _log(f"gh auth token resolved a credential for {host_info.display_name}")
                 return operation(
                     gh_token,
-                    self._build_git_env(gh_token, scheme="basic", host_kind=host_info.kind),
+                    self._build_git_env(
+                        gh_token,
+                        scheme="basic",
+                        host_kind=host_info.kind,
+                        base_env=base_env,
+                    ),
                 )
             path_suffix = f" (path={path})" if path else ""
             _log(f"trying git credential fill for {host_info.display_name}{path_suffix}")
@@ -667,7 +685,12 @@ class AuthResolver:
                 _log(f"git credential fill resolved a credential for {host_info.display_name}")
                 return operation(
                     cred,
-                    self._build_git_env(cred, scheme="basic", host_kind=host_info.kind),
+                    self._build_git_env(
+                        cred,
+                        scheme="basic",
+                        host_kind=host_info.kind,
+                        base_env=base_env,
+                    ),
                 )
             raise exc
 
@@ -694,7 +717,12 @@ class AuthResolver:
                 raise exc
             try:
                 bearer = provider.get_bearer_token()
-                bearer_env = self._build_git_env(bearer, scheme="bearer", host_kind="ado")
+                bearer_env = self._build_git_env(
+                    bearer,
+                    scheme="bearer",
+                    host_kind="ado",
+                    base_env=base_env,
+                )
                 result = operation(bearer, bearer_env)
                 # Success on fallback -- emit deferred diagnostic warning
                 self.emit_stale_pat_diagnostic(auth_ctx.host_info.display_name)
@@ -726,7 +754,7 @@ class AuthResolver:
             ctx = _auth_context()
             _log(f"Auth-only attempt for {host_info.kind} host {host_info.display_name}")
             try:
-                return operation(ctx.token, ctx.git_env)
+                return operation(ctx.token, _git_env_for_context(ctx))
             except Exception as exc:
                 # operation is caller-provided; broad catch required -- cannot narrow
                 # without restricting the caller API.  Use %r so the type is visible.
@@ -742,7 +770,7 @@ class AuthResolver:
             ctx = _auth_context()
             _log(f"Auth-only attempt for {host_info.kind} host {host_info.display_name}")
             try:
-                return operation(ctx.token, ctx.git_env)
+                return operation(ctx.token, _git_env_for_context(ctx))
             except Exception as exc:
                 # operation is caller-provided; broad catch required -- cannot narrow
                 # without restricting the caller API.  Use %r so the type is visible.
@@ -776,7 +804,7 @@ class AuthResolver:
                 if ctx.token:
                     _log(f"Unauthenticated failed, retrying with token (source: {ctx.source})")
                     try:
-                        return operation(ctx.token, ctx.git_env)
+                        return operation(ctx.token, _git_env_for_context(ctx))
                     except Exception as retry_exc:
                         # operation is caller-provided; broad catch required.
                         logger.debug(
@@ -794,7 +822,7 @@ class AuthResolver:
                     f"Trying authenticated access to {host_info.display_name} "
                     f"(source: {ctx.source})"
                 )
-                return operation(ctx.token, ctx.git_env)
+                return operation(ctx.token, _git_env_for_context(ctx))
             except Exception as exc:
                 # operation is caller-provided; broad catch required -- cannot narrow
                 # without restricting the caller API.  Use %r so the type is visible.

--- a/src/apm_cli/deps/clone_engine.py
+++ b/src/apm_cli/deps/clone_engine.py
@@ -296,6 +296,7 @@ class CloneEngine:
                 path=dep_ref.repo_url,
                 host_type=dep_ref.host_type,
                 unauth_first=True,
+                base_env=host.git_env,
                 verbose_callback=verbose_callback,
             )
             return winning_url, winning_token

--- a/src/apm_cli/deps/download_strategies.py
+++ b/src/apm_cli/deps/download_strategies.py
@@ -840,6 +840,7 @@ class DownloadDelegate:
                 path=dep_ref.repo_url,
                 host_type=dep_ref.host_type,
                 unauth_first=True,
+                base_env=self._host.git_env,
             )
 
         auth_ctx = self._host.auth_resolver.resolve_for_dep(dep_ref)

--- a/src/apm_cli/deps/git_reference_resolver.py
+++ b/src/apm_cli/deps/git_reference_resolver.py
@@ -290,6 +290,7 @@ class GitReferenceResolver:
                     path=dep_ref.repo_url,
                     host_type=dep_ref.host_type,
                     unauth_first=True,
+                    base_env=host.git_env,
                 )
             except (GitCommandError, OSError) as exc:
                 outcome = ("err", exc)

--- a/src/apm_cli/deps/github_downloader.py
+++ b/src/apm_cli/deps/github_downloader.py
@@ -302,7 +302,9 @@ class GitHubPackageDownloader:
             is True
             and not dep_ref.is_insecure
         ):
-            return self.auth_resolver.build_public_github_anonymous_git_env()
+            return self.auth_resolver.build_public_github_anonymous_git_env(
+                base_env=self.git_env,
+            )
 
         auth_ctx = self._resolve_dep_auth_ctx(dep_ref)
         base_env = (
@@ -1124,7 +1126,9 @@ class GitHubPackageDownloader:
                     dep_ref=dep_ref,
                     token="",
                 )
-                setup_env = self.auth_resolver.build_public_github_anonymous_git_env()
+                setup_env = self.auth_resolver.build_public_github_anonymous_git_env(
+                    base_env=self.git_env,
+                )
                 setup_cmds = [
                     ["git", "init"],
                     ["git", "remote", "add", "origin", anonymous_url],
@@ -1194,6 +1198,7 @@ class GitHubPackageDownloader:
                     path=dep_ref.repo_url,
                     host_type=dep_ref.host_type,
                     unauth_first=True,
+                    base_env=self.git_env,
                 )
                 checkout_result = subprocess.run(
                     ["git", "checkout", "FETCH_HEAD"],

--- a/src/apm_cli/deps/github_downloader_validation.py
+++ b/src/apm_cli/deps/github_downloader_validation.py
@@ -433,7 +433,9 @@ def _build_validation_attempts(
 
     # Attempt 2: plain HTTPS w/ credential helper (no token, no header).
     plain_env = (
-        downloader.auth_resolver.build_public_github_anonymous_git_env()
+        downloader.auth_resolver.build_public_github_anonymous_git_env(
+            base_env=downloader.git_env,
+        )
         if public_github_anonymous_first
         else (
             downloader.auth_resolver.build_noninteractive_git_env(
@@ -558,6 +560,7 @@ def _ref_exists_via_ls_remote(
                 path=dep_ref.repo_url,
                 host_type=dep_ref.host_type,
                 unauth_first=True,
+                base_env=downloader.git_env,
             )
             if is_sha:
                 matched = bool(

--- a/src/apm_cli/policy/discovery.py
+++ b/src/apm_cli/policy/discovery.py
@@ -36,7 +36,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlsplit, urlunsplit
 
 import requests
 import yaml
@@ -198,7 +198,7 @@ def _verify_hash_pin(
 POLICY_CACHE_DIR = ".policy-cache"
 DEFAULT_CACHE_TTL = 3600  # 1 hour
 MAX_STALE_TTL = 7 * 24 * 3600  # 7 days -- stale cache usable on refresh failure
-CACHE_SCHEMA_VERSION = "5"  # Bump when cache format changes to auto-invalidate
+CACHE_SCHEMA_VERSION = "6"  # Bump when cache format changes to auto-invalidate
 
 
 @dataclass
@@ -223,6 +223,7 @@ class PolicyFetchResult:
 
     policy: ApmPolicy | None = None
     source: str = ""  # "org:contoso/.github", "file:/path", "url:https://..."
+    cache_ref: str | None = field(default=None, repr=False)
     cached: bool = False  # True if served from cache
     error: str | None = None  # Error message if fetch failed
 
@@ -346,6 +347,29 @@ def discover_policy_with_chain(
 def _strip_source_prefix(src: str) -> str:
     """Strip 'org:' / 'url:' / 'file:' prefix from a PolicyFetchResult.source."""
     return src.removeprefix("org:").removeprefix("url:").removeprefix("file:")
+
+
+def _redact_policy_ref(ref: str) -> str:
+    """Return a credential-free policy reference for persistence and output."""
+    prefix = "url:" if ref.startswith("url:") else ""
+    bare_ref = ref.removeprefix(prefix)
+    if not bare_ref.startswith(("http://", "https://")):
+        return ref
+
+    try:
+        parts = urlsplit(bare_ref)
+        host = parts.hostname or ""
+        port = parts.port
+    except (TypeError, ValueError):
+        return f"{prefix}<redacted-url>"
+
+    if not host:
+        return f"{prefix}<redacted-url>"
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    netloc = f"{host}:{port}" if port is not None else host
+    safe_url = urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+    return f"{prefix}{safe_url}"
 
 
 def _derive_leaf_host(source: str, project_root: Path) -> str | None:
@@ -578,6 +602,7 @@ def _resolve_and_persist_chain(
 
     leaf_policy = fetch_result.policy
     leaf_source = fetch_result.source
+    leaf_cache_ref = fetch_result.cache_ref or _strip_source_prefix(leaf_source)
 
     # Host pin: extends: refs may only resolve against the leaf's origin
     # host. Prevents credential leakage to attacker-controlled hosts via
@@ -592,7 +617,7 @@ def _resolve_and_persist_chain(
     # Track normalized refs we've already followed to break cycles.
     # We seed with the leaf's source so an extends pointing back at the
     # leaf is also detected.
-    visited: list[str] = [_strip_source_prefix(leaf_source)] if leaf_source else []
+    visited: list[str] = [leaf_cache_ref] if leaf_source else []
 
     current = leaf_policy
     incomplete_chain: tuple[str, int, int] | None = None
@@ -606,18 +631,23 @@ def _resolve_and_persist_chain(
         _validate_extends_host(leaf_host, next_ref)
 
         if _inheritance_mod.detect_cycle(visited, next_ref):
+            safe_visited = [_redact_policy_ref(ref) for ref in visited]
+            safe_next_ref = _redact_policy_ref(next_ref)
             raise _inheritance_mod.PolicyInheritanceError(
-                f"Cycle detected in policy extends chain: {' -> '.join(visited)} -> {next_ref}"
+                f"Cycle detected in policy extends chain: "
+                f"{' -> '.join(safe_visited)} -> {safe_next_ref}"
             )
 
         # Depth check: chain_policies already has len() entries; next fetch
         # would push us to len()+1.  resolve_policy_chain enforces this
         # afterwards, but failing here gives a clearer error.
         if len(chain_policies) + 1 > _inheritance_mod.MAX_CHAIN_DEPTH:
+            safe_visited = [_redact_policy_ref(ref) for ref in visited]
+            safe_next_ref = _redact_policy_ref(next_ref)
             raise _inheritance_mod.PolicyInheritanceError(
                 f"Policy chain depth exceeds maximum of "
                 f"{_inheritance_mod.MAX_CHAIN_DEPTH} "
-                f"(chain: {' -> '.join(visited)} -> {next_ref})"
+                f"(chain: {' -> '.join(safe_visited)} -> {safe_next_ref})"
             )
 
         parent_result = _fetch_chain_parent(
@@ -654,7 +684,7 @@ def _resolve_and_persist_chain(
             ref, resolved, attempted = incomplete_chain
             fetch_result.outcome = "incomplete_chain"
             fetch_result.error = (
-                f"Policy chain incomplete: {ref} unreachable "
+                f"Policy chain incomplete: {_redact_policy_ref(ref)} unreachable "
                 f"({resolved} of {attempted} policies resolved)"
             )
             fetch_result.policy = None
@@ -673,7 +703,7 @@ def _resolve_and_persist_chain(
 
     chain_refs: list[str] = [_strip_source_prefix(src) for src in ordered_sources if src]
 
-    cache_key = _strip_source_prefix(leaf_source) if leaf_source else ""
+    cache_key = leaf_cache_ref if leaf_source else ""
     if cache_key and incomplete_chain is None and stale_ancestor is None:
         _write_cache(
             cache_key,
@@ -688,7 +718,7 @@ def _resolve_and_persist_chain(
         ref, resolved, attempted = incomplete_chain
         fetch_result.outcome = "incomplete_chain"
         fetch_result.error = (
-            f"Policy chain incomplete: {ref} unreachable "
+            f"Policy chain incomplete: {_redact_policy_ref(ref)} unreachable "
             f"({resolved} of {attempted} policies resolved)"
         )
         fetch_result.policy = None
@@ -1030,7 +1060,8 @@ def _fetch_from_url(
     cache_only: bool = False,
 ) -> PolicyFetchResult:
     """Fetch policy YAML from a direct URL."""
-    source_label = f"url:{url}"
+    safe_url = _redact_policy_ref(url)
+    source_label = f"url:{safe_url}"
     cache_entry: _CacheEntry | None = None
     cache_entry_persisted = _cache_entry_files_exist(url, project_root)
 
@@ -1042,6 +1073,7 @@ def _fetch_from_url(
             return PolicyFetchResult(
                 policy=cache_entry.policy,
                 source=cache_entry.source,
+                cache_ref=url,
                 cached=True,
                 cache_age_seconds=cache_entry.age_seconds,
                 outcome=outcome,
@@ -1051,12 +1083,14 @@ def _fetch_from_url(
             )
 
     if cache_only:
-        return _cache_only_policy_result(
+        result = _cache_only_policy_result(
             cache_entry,
             source_label=source_label,
             expected_hash=expected_hash,
             cache_entry_persisted=cache_entry_persisted,
         )
+        result.cache_ref = url
+        return result
 
     fetch_error: str | None = None
     content: str | None = None
@@ -1066,6 +1100,7 @@ def _fetch_from_url(
         if resp.status_code == 404:
             return PolicyFetchResult(
                 source=source_label,
+                cache_ref=url,
                 error="404: Policy file not found",
                 outcome="absent",
             )
@@ -1073,27 +1108,32 @@ def _fetch_from_url(
             # Redirects are refused: a malicious or compromised origin
             # could otherwise bounce us to an attacker-controlled host
             # (SSRF / Referer leakage). Treat as fetch failure.
-            location = resp.headers.get("Location", "<no Location header>")
-            fetch_error = f"Refusing HTTP redirect ({resp.status_code}) from {url} to {location}"
+            location = _redact_policy_ref(resp.headers.get("Location", "<no Location header>"))
+            fetch_error = (
+                f"Refusing HTTP redirect ({resp.status_code}) from {safe_url} to {location}"
+            )
         elif resp.status_code != 200:
-            fetch_error = f"HTTP {resp.status_code} fetching {url}"
+            fetch_error = f"HTTP {resp.status_code} fetching {safe_url}"
         else:
             content = resp.text
     except requests.exceptions.Timeout:
-        fetch_error = f"Timeout fetching {url}"
+        fetch_error = f"Timeout fetching {safe_url}"
     except requests.exceptions.ConnectionError:
-        fetch_error = f"Connection error fetching {url}"
+        fetch_error = f"Connection error fetching {safe_url}"
     except Exception as e:
-        fetch_error = f"Error fetching {url}: {e}"
+        fetch_error = f"Error fetching {safe_url}: {type(e).__name__}"
 
     if fetch_error:
-        return _stale_fallback_or_error(
+        result = _stale_fallback_or_error(
             cache_entry, fetch_error, source_label, "cache_miss_fetch_fail"
         )
+        result.cache_ref = url
+        return result
 
     # Garbage-response detection: body must be valid YAML mapping
-    garbage_result = _detect_garbage(content, url, source_label, cache_entry)
+    garbage_result = _detect_garbage(content, safe_url, source_label, cache_entry)
     if garbage_result is not None:
+        garbage_result.cache_ref = url
         return garbage_result
 
     # Hash pin verification (#827) -- BEFORE parse, on raw bytes off wire.
@@ -1102,14 +1142,16 @@ def _fetch_from_url(
     # exactly the compromise this pin is designed to catch.
     mismatch = _verify_hash_pin(content, expected_hash, source_label)
     if mismatch is not None:
+        mismatch.cache_ref = url
         return mismatch
 
     try:
         policy, warnings = load_policy(content)
     except PolicyValidationError as e:
         return PolicyFetchResult(
-            error=f"Invalid policy from {url}: {e}",
+            error=f"Invalid policy from {safe_url}: {e}",
             source=source_label,
+            cache_ref=url,
             outcome="malformed",
             warnings=e.warnings,
         )
@@ -1129,6 +1171,7 @@ def _fetch_from_url(
     return PolicyFetchResult(
         policy=policy,
         source=source_label,
+        cache_ref=url,
         outcome=outcome,
         raw_bytes_hash=actual_hash,
         expected_hash=expected_hash,
@@ -1905,6 +1948,7 @@ def _read_cache_entry(
 
         # Schema version check -- auto-invalidate on format change
         if meta.get("schema_version") != CACHE_SCHEMA_VERSION:
+            meta_file.unlink(missing_ok=True)
             return None
 
         cached_at = meta.get("cached_at", 0)
@@ -1940,7 +1984,7 @@ def _read_cache_entry(
 
         # Determine source label
         if repo_ref.startswith("http://") or repo_ref.startswith("https://"):
-            source = f"url:{repo_ref}"
+            source = f"url:{_redact_policy_ref(repo_ref)}"
         else:
             source = f"org:{repo_ref}"
 
@@ -1949,7 +1993,7 @@ def _read_cache_entry(
             source=source,
             age_seconds=age,
             stale=age > effective_ttl,
-            chain_refs=meta.get("chain_refs", [repo_ref]),
+            chain_refs=[_redact_policy_ref(str(ref)) for ref in meta.get("chain_refs", [repo_ref])],
             warnings=cached_warnings,
             fingerprint=meta.get("fingerprint", ""),
             raw_bytes_hash=raw_bytes_hash,
@@ -2030,10 +2074,11 @@ def _write_cache(
         return
 
     # Atomic write: metadata sidecar
+    persisted_chain_refs = chain_refs if chain_refs is not None else [repo_ref]
     meta = {
-        "repo_ref": repo_ref,
+        "repo_ref": _redact_policy_ref(repo_ref),
         "cached_at": time.time(),
-        "chain_refs": chain_refs if chain_refs is not None else [repo_ref],
+        "chain_refs": [_redact_policy_ref(ref) for ref in persisted_chain_refs],
         "warnings": warnings or [],
         "schema_version": CACHE_SCHEMA_VERSION,
         "fingerprint": fingerprint,

--- a/tests/integration/test_architecture_authorities.py
+++ b/tests/integration/test_architecture_authorities.py
@@ -14,6 +14,18 @@ from types import ModuleType
 import pytest
 
 
+def test_policy_cache_metadata_redaction_has_single_owner() -> None:
+    """Policy cache refs must be sanitized by the canonical writer."""
+    root = Path(__file__).parents[2]
+    owner = (root / "src/apm_cli/policy/discovery.py").read_text(encoding="utf-8")
+    guard = (root / "scripts/lint-architecture-boundaries.sh").read_text(encoding="utf-8")
+
+    assert owner.count("def _redact_policy_ref(") == 1
+    assert '"repo_ref": _redact_policy_ref(repo_ref)' in owner
+    assert '"chain_refs": [_redact_policy_ref(ref) for ref in persisted_chain_refs]' in owner
+    assert "Policy cache metadata must redact URL credentials at its canonical writer" in guard
+
+
 def test_intellij_mcp_config_path_has_single_owner() -> None:
     """JetBrains Copilot path selection must stay in its client adapter."""
     root = Path(__file__).parents[2]

--- a/tests/unit/commands/test_policy_status.py
+++ b/tests/unit/commands/test_policy_status.py
@@ -5,20 +5,23 @@ from __future__ import annotations
 import json
 import textwrap
 import unicodedata
-from pathlib import Path  # noqa: F401
+from pathlib import Path
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 import pytest
 from click.testing import CliRunner
 
 from apm_cli.commands.policy import (
+    _build_report,
     _count_rules,
     _format_age,
+    _resolve_chain_refs,
 )
 from apm_cli.commands.policy import (
     policy as policy_group,
 )
-from apm_cli.policy.discovery import PolicyFetchResult
+from apm_cli.policy.discovery import PolicyFetchResult, _CacheEntry
 from apm_cli.policy.parser import load_policy
 from apm_cli.policy.schema import ApmPolicy
 
@@ -273,6 +276,49 @@ class TestStatusJsonOutput:
             result = runner.invoke(policy_group, ["status", "-o", "json"])
         assert result.exit_code == 0, result.output
         json.loads(result.output)  # must parse
+
+
+class TestStatusCredentialRedaction:
+    def test_legacy_cache_refs_and_source_are_redacted(self, tmp_path: Path) -> None:
+        raw_leaf = "https://alice:s3cr3t@policy.example.com/apm-policy.yml?sig=private-signature"
+        raw_parent = "https://bob:parent-secret@policy.example.com/base.yml"
+        policy = _rich_policy()
+        result = PolicyFetchResult(
+            policy=policy,
+            source=f"url:{raw_leaf}",
+            outcome="found",
+        )
+        legacy_entry = _CacheEntry(
+            policy=policy,
+            source=f"url:{raw_leaf}",
+            age_seconds=10,
+            stale=False,
+            chain_refs=[raw_parent, raw_leaf],
+        )
+
+        with patch(
+            "apm_cli.commands.policy._read_cache_entry",
+            return_value=legacy_entry,
+        ):
+            chain = _resolve_chain_refs(result, tmp_path)
+        report = _build_report(result, chain, _count_rules(policy))
+
+        source = urlparse(report["source"].removeprefix("url:"))
+        assert source.username is None
+        assert source.password is None
+        assert source.query == ""
+        assert source.hostname == "policy.example.com"
+        assert source.path == "/apm-policy.yml"
+
+        assert len(report["extends_chain"]) == 1
+        parent = urlparse(report["extends_chain"][0])
+        assert parent.username is None
+        assert parent.password is None
+        assert parent.query == ""
+        assert parent.hostname == "policy.example.com"
+        assert parent.path == "/base.yml"
+        assert "s3cr3t" not in json.dumps(report)
+        assert "parent-secret" not in json.dumps(report)
 
 
 class TestStatusNoCache:

--- a/tests/unit/core/test_public_github_anonymous_first.py
+++ b/tests/unit/core/test_public_github_anonymous_first.py
@@ -292,10 +292,10 @@ def test_ado_bearer_fallback_preserves_caller_git_config(tmp_path: Path) -> None
 
     with (
         patch.dict(os.environ, {"ADO_APM_PAT": "stale-pat"}, clear=True),
-        patch("apm_cli.core.azure_cli.AzureCliBearerProvider") as provider_class,
+        patch("apm_cli.core.azure_cli.get_bearer_provider") as get_provider,
     ):
-        provider_class.return_value.is_available.return_value = True
-        provider_class.return_value.get_bearer_token.return_value = "bearer-token"
+        get_provider.return_value.is_available.return_value = True
+        get_provider.return_value.get_bearer_token.return_value = "bearer-token"
         result = resolver.try_with_fallback(
             "dev.azure.com",
             operation,

--- a/tests/unit/core/test_public_github_anonymous_first.py
+++ b/tests/unit/core/test_public_github_anonymous_first.py
@@ -159,6 +159,158 @@ def test_public_github_preserves_caller_git_config_isolation(tmp_path: Path) -> 
     assert dict(_indexed_git_config(env))["credential.helper"] == ""
 
 
+def test_public_github_fallback_preserves_caller_git_config_isolation(tmp_path: Path) -> None:
+    """Anonymous and authenticated retries retain downloader-owned rewrites."""
+    git_config = tmp_path / "gitconfig"
+    git_config.write_text(
+        '[url "file:///fixture.git/"]\n\tinsteadOf = https://github.com/acme/widgets\n',
+        encoding="ascii",
+    )
+    base_env = {
+        "GIT_CONFIG_GLOBAL": str(git_config),
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_ALLOW_PROTOCOL": "file",
+    }
+    resolver = AuthResolver()
+    attempts: list[tuple[str | None, dict[str, str]]] = []
+
+    def operation(token: str | None, env: dict[str, str]) -> str:
+        attempts.append((token, env))
+        if token is None:
+            raise _HttpStatusError(404)
+        return "private-ok"
+
+    with patch.dict(
+        os.environ,
+        {"GITHUB_APM_PAT_ACME": "private-token"},
+        clear=True,
+    ):
+        result = resolver.try_with_fallback(
+            "github.com",
+            operation,
+            org="acme",
+            path="acme/widgets",
+            unauth_first=True,
+            base_env=base_env,
+        )
+
+    assert result == "private-ok"
+    assert [token for token, _env in attempts] == [None, "private-token"]
+    for _token, env in attempts:
+        assert env["GIT_CONFIG_GLOBAL"] == str(git_config)
+        assert env["GIT_CONFIG_NOSYSTEM"] == "1"
+        assert env["GIT_ALLOW_PROTOCOL"] == "file"
+        assert "GITHUB_APM_PAT_ACME" not in env
+
+
+@pytest.mark.parametrize("secondary_source", ("gh", "git"))
+def test_public_github_secondary_fallback_preserves_caller_git_config(
+    tmp_path: Path,
+    secondary_source: str,
+) -> None:
+    """Secondary credential retries retain isolated Git transport policy."""
+    git_config = tmp_path / "gitconfig"
+    git_config.write_text(
+        '[url "file:///fixture.git/"]\n\tinsteadOf = https://github.com/acme/widgets\n',
+        encoding="ascii",
+    )
+    base_env = {
+        "GIT_CONFIG_GLOBAL": str(git_config),
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_ALLOW_PROTOCOL": "file",
+    }
+    resolver = AuthResolver()
+    attempts: list[tuple[str | None, dict[str, str]]] = []
+
+    def operation(token: str | None, env: dict[str, str]) -> str:
+        attempts.append((token, env))
+        if token != "secondary-token":
+            raise _HttpStatusError(404)
+        return "private-ok"
+
+    gh_token = "secondary-token" if secondary_source == "gh" else None
+    git_token = "secondary-token" if secondary_source == "git" else None
+    with (
+        patch.dict(
+            os.environ,
+            {"GITHUB_APM_PAT_ACME": "primary-token"},
+            clear=True,
+        ),
+        patch.object(
+            resolver._token_manager,
+            "resolve_credential_from_gh_cli",
+            return_value=gh_token,
+        ),
+        patch.object(
+            resolver._token_manager,
+            "resolve_credential_from_git",
+            return_value=git_token,
+        ),
+    ):
+        result = resolver.try_with_fallback(
+            "github.com",
+            operation,
+            org="acme",
+            path="acme/widgets",
+            unauth_first=True,
+            base_env=base_env,
+        )
+
+    assert result == "private-ok"
+    assert [token for token, _env in attempts] == [
+        None,
+        "primary-token",
+        "secondary-token",
+    ]
+    for _token, env in attempts:
+        assert env["GIT_CONFIG_GLOBAL"] == str(git_config)
+        assert env["GIT_CONFIG_NOSYSTEM"] == "1"
+        assert env["GIT_ALLOW_PROTOCOL"] == "file"
+        assert "GITHUB_APM_PAT_ACME" not in env
+
+
+def test_ado_bearer_fallback_preserves_caller_git_config(tmp_path: Path) -> None:
+    """ADO PAT and bearer attempts retain caller-owned Git isolation."""
+    git_config = tmp_path / "gitconfig"
+    git_config.write_text(
+        '[url "file:///fixture.git/"]\n\tinsteadOf = https://dev.azure.com/acme/project/_git/repo\n',
+        encoding="ascii",
+    )
+    base_env = {
+        "GIT_CONFIG_GLOBAL": str(git_config),
+        "GIT_CONFIG_NOSYSTEM": "1",
+        "GIT_ALLOW_PROTOCOL": "file",
+    }
+    resolver = AuthResolver()
+    attempts: list[tuple[str | None, dict[str, str]]] = []
+
+    def operation(token: str | None, env: dict[str, str]) -> str:
+        attempts.append((token, env))
+        if token == "stale-pat":
+            raise RuntimeError("401 unauthorized")
+        return "bearer-ok"
+
+    with (
+        patch.dict(os.environ, {"ADO_APM_PAT": "stale-pat"}, clear=True),
+        patch("apm_cli.core.azure_cli.AzureCliBearerProvider") as provider_class,
+    ):
+        provider_class.return_value.is_available.return_value = True
+        provider_class.return_value.get_bearer_token.return_value = "bearer-token"
+        result = resolver.try_with_fallback(
+            "dev.azure.com",
+            operation,
+            base_env=base_env,
+        )
+
+    assert result == "bearer-ok"
+    assert [token for token, _env in attempts] == ["stale-pat", "bearer-token"]
+    for _token, env in attempts:
+        assert env["GIT_CONFIG_GLOBAL"] == str(git_config)
+        assert env["GIT_CONFIG_NOSYSTEM"] == "1"
+        assert env["GIT_ALLOW_PROTOCOL"] == "file"
+        assert env.get("ADO_APM_PAT") in {None, ""}
+
+
 def test_public_github_ignores_ambient_git_config_isolation(tmp_path: Path) -> None:
     ambient_config = tmp_path / "ambient-gitconfig"
     ambient_config.write_text(

--- a/tests/unit/policy/test_cache_atomicity.py
+++ b/tests/unit/policy/test_cache_atomicity.py
@@ -7,15 +7,16 @@ and metadata sidecar.  No torn writes, no truncated JSON, no partial YAML.
 
 from __future__ import annotations
 
-import json  # noqa: F401
+import json
 import tempfile
 import unittest
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
+from urllib.parse import urlparse
 
 from apm_cli.policy.discovery import (
     CACHE_SCHEMA_VERSION,  # noqa: F401
-    _cache_key,  # noqa: F401
+    _cache_key,
     _get_cache_dir,
     _read_cache,
     _read_cache_entry,
@@ -145,6 +146,46 @@ class TestCacheAtomicity(unittest.TestCase):
                 [],
                 f"Leftover .tmp files: {[f.name for f in tmp_files]}",
             )
+
+    def test_cache_metadata_redacts_url_credentials_without_changing_identity(self):
+        """Persisted refs are safe while lookups retain the original cache key."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            repo_ref = (
+                "https://alice:s3cr3t@policy.example.com/apm-policy.yml"
+                "?sig=private-signature#private-fragment"
+            )
+            parent_ref = "https://bob:parent-secret@policy.example.com/base.yml"
+
+            _write_cache(
+                repo_ref,
+                _make_policy(1),
+                root,
+                chain_refs=[parent_ref, repo_ref],
+            )
+
+            meta_path = _get_cache_dir(root) / f"{_cache_key(repo_ref)}.meta.json"
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            persisted_refs = [meta["repo_ref"], *meta["chain_refs"]]
+            parsed_refs = [urlparse(ref) for ref in persisted_refs]
+
+            self.assertTrue(all(parsed.username is None for parsed in parsed_refs))
+            self.assertTrue(all(parsed.password is None for parsed in parsed_refs))
+            self.assertTrue(all(parsed.query == "" for parsed in parsed_refs))
+            self.assertTrue(all(parsed.fragment == "" for parsed in parsed_refs))
+            self.assertEqual(
+                {(parsed.hostname, parsed.path) for parsed in parsed_refs},
+                {
+                    ("policy.example.com", "/apm-policy.yml"),
+                    ("policy.example.com", "/base.yml"),
+                },
+            )
+            self.assertNotIn("s3cr3t", json.dumps(meta))
+            self.assertNotIn("private-signature", json.dumps(meta))
+
+            entry = _read_cache_entry(repo_ref, root)
+            self.assertIsNotNone(entry)
+            self.assertEqual(entry.policy.name, "writer-1")
 
 
 if __name__ == "__main__":

--- a/tests/unit/policy/test_cache_merged_effective.py
+++ b/tests/unit/policy/test_cache_merged_effective.py
@@ -250,13 +250,18 @@ class TestCacheInvalidation(unittest.TestCase):
     """Cache entries are invalidated on schema or chain mismatch."""
 
     def test_schema_version_mismatch_invalidates(self):
-        """Old cache with wrong schema_version returns None."""
+        """Old cache metadata is removed so legacy secrets do not remain."""
         policy = ApmPolicy(name="old-format")
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            _setup_cache("test/.github", root, policy, schema_version="1")
-            entry = _read_cache_entry("test/.github", root)
+            repo_ref = "test/.github"
+            _setup_cache(repo_ref, root, policy, schema_version="5")
+            meta_file = _get_cache_dir(root) / f"{_cache_key(repo_ref)}.meta.json"
+
+            entry = _read_cache_entry(repo_ref, root)
+
             self.assertIsNone(entry, "Stale schema_version should invalidate cache")
+            self.assertFalse(meta_file.exists(), "Legacy metadata sidecar was not scrubbed")
 
     def test_current_schema_version_accepted(self):
         """Cache with correct schema_version is accepted."""

--- a/tests/unit/policy/test_chain_discovery_shared.py
+++ b/tests/unit/policy/test_chain_discovery_shared.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from unittest.mock import MagicMock, call, patch
+from urllib.parse import urlparse
 
 import pytest
 
@@ -223,6 +224,44 @@ class TestChainResolution:
         mock_discover.side_effect = [leaf_fetch, parent_fetch]
         discover_policy_with_chain(Path("/fake"))
         assert mock_write_cache.call_args.kwargs["raw_bytes_hash"] == "sha256:" + ("a" * 64)
+
+    @patch(_PATCH_WRITE_CACHE)
+    @patch(_PATCH_DISCOVER)
+    def test_url_chain_keeps_raw_cache_identity_but_redacts_chain_refs(
+        self,
+        mock_discover: MagicMock,
+        mock_write_cache: MagicMock,
+    ) -> None:
+        raw_leaf = "https://alice:s3cr3t@policy.example.com/apm-policy.yml?sig=private-signature"
+        safe_leaf = "https://policy.example.com/apm-policy.yml"
+        raw_parent = "https://bob:parent-secret@policy.example.com/base.yml"
+        safe_parent = "https://policy.example.com/base.yml"
+        leaf = _make_policy(extends=raw_parent)
+        leaf_fetch = _make_fetch(
+            policy=leaf,
+            source=f"url:{safe_leaf}",
+            cached=False,
+        )
+        leaf_fetch.cache_ref = raw_leaf
+        parent_fetch = _make_fetch(
+            policy=_make_policy(enforcement="block"),
+            source=f"url:{safe_parent}",
+        )
+        parent_fetch.cache_ref = raw_parent
+        mock_discover.side_effect = [leaf_fetch, parent_fetch]
+
+        discover_policy_with_chain(Path("/fake"))
+
+        assert mock_write_cache.call_args.args[0] == raw_leaf
+        chain_refs = mock_write_cache.call_args.kwargs["chain_refs"]
+        parsed_refs = [urlparse(ref) for ref in chain_refs]
+        assert [(parsed.hostname, parsed.path) for parsed in parsed_refs] == [
+            ("policy.example.com", "/base.yml"),
+            ("policy.example.com", "/apm-policy.yml"),
+        ]
+        assert all(parsed.username is None for parsed in parsed_refs)
+        assert all(parsed.password is None for parsed in parsed_refs)
+        assert all(parsed.query == "" for parsed in parsed_refs)
 
 
 # ======================================================================

--- a/tests/unit/policy/test_discovery_policy_resolution.py
+++ b/tests/unit/policy/test_discovery_policy_resolution.py
@@ -27,6 +27,7 @@ import hashlib
 import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
 
 import pytest
 import requests
@@ -515,6 +516,34 @@ class TestFetchFromUrl:
         with patch("requests.get", return_value=mock_resp):
             result = _fetch_from_url("https://example.com/p.yml", tmp_path, no_cache=True)
         assert result.error is not None or result.fetch_error is not None
+
+    def test_authenticated_url_is_dispatched_raw_but_never_persisted_or_reported(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        raw_url = "https://alice:s3cr3t@policy.example.com/apm-policy.yml?sig=private-signature"
+        mock_resp = MagicMock(status_code=200, text=VALID_POLICY_YAML)
+
+        with patch("requests.get", return_value=mock_resp) as mock_get:
+            result = _fetch_from_url(raw_url, tmp_path, no_cache=True)
+
+        dispatched = urlparse(mock_get.call_args.args[0])
+        assert dispatched.username == "alice"
+        assert dispatched.password == "s3cr3t"
+        assert dispatched.query == "sig=private-signature"
+
+        reported = urlparse(result.source.removeprefix("url:"))
+        assert reported.username is None
+        assert reported.password is None
+        assert reported.query == ""
+        assert reported.hostname == "policy.example.com"
+        assert reported.path == "/apm-policy.yml"
+        assert "s3cr3t" not in result.source
+        assert "private-signature" not in result.source
+
+        entry = _read_cache_entry(raw_url, tmp_path)
+        assert entry is not None
+        assert entry.policy.name == "test-policy"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_platform_contract_workflow.py
+++ b/tests/unit/test_platform_contract_workflow.py
@@ -43,6 +43,12 @@ MACOS_STARTUP_CONTRACTS = (
         "github.event_name == 'workflow_dispatch'",
     ),
 )
+RELEASE_UNIX_INTEGRATION_STEPS = (
+    ("integration-tests", "Run integration tests (Unix)"),
+    ("build-and-validate-macos-intel", "Run integration tests"),
+    ("build-and-validate-macos-arm", "Run integration tests"),
+)
+RELEASE_UNIX_PYTEST_ARGS = "-n 4 --dist loadgroup"
 
 
 def _workflow() -> dict:
@@ -113,6 +119,13 @@ def _assert_standalone_integration_timeouts(workflow: dict) -> None:
     assert windows_step.get("timeout-minutes") == 20
 
 
+def _assert_release_unix_integration_parallelism(workflow: dict) -> None:
+    for job_id, step_name in RELEASE_UNIX_INTEGRATION_STEPS:
+        step = workflow_step(workflow_job(workflow, job_id), step_name)
+        assert step["env"].get("PYTEST_EXTRA_ARGS") == RELEASE_UNIX_PYTEST_ARGS
+        assert step.get("timeout-minutes") == 30
+
+
 def test_macos_jobs_run_non_shell_binary_startup_after_build() -> None:
     """Both macOS jobs execute the exact generated artifact before upload."""
     _assert_macos_startup_steps(_workflow())
@@ -126,6 +139,39 @@ def test_windows_installer_contract_is_windows_only_and_tokenless() -> None:
 def test_standalone_integration_timeouts_are_platform_specific() -> None:
     """Standalone Unix has headroom while Windows retains its proven bound."""
     _assert_standalone_integration_timeouts(_workflow())
+
+
+def test_release_unix_integration_uses_bounded_grouped_parallelism() -> None:
+    """Every full-corpus Unix release node uses the same bounded scheduler."""
+    _assert_release_unix_integration_parallelism(_workflow())
+
+
+@pytest.mark.parametrize(("job_id", "step_name"), RELEASE_UNIX_INTEGRATION_STEPS)
+def test_release_unix_serial_integration_mutation_is_rejected(
+    job_id: str,
+    step_name: str,
+) -> None:
+    """No release node can silently regress to the 30-minute serial path."""
+    workflow = deepcopy(_workflow())
+    step = workflow_step(workflow_job(workflow, job_id), step_name)
+    del step["env"]["PYTEST_EXTRA_ARGS"]
+
+    with pytest.raises(AssertionError):
+        _assert_release_unix_integration_parallelism(workflow)
+
+
+@pytest.mark.parametrize(("job_id", "step_name"), RELEASE_UNIX_INTEGRATION_STEPS)
+def test_release_unix_timeout_mutation_is_rejected(
+    job_id: str,
+    step_name: str,
+) -> None:
+    """Every full-corpus Unix release node remains bounded to 30 minutes."""
+    workflow = deepcopy(_workflow())
+    step = workflow_step(workflow_job(workflow, job_id), step_name)
+    step["timeout-minutes"] = 31
+
+    with pytest.raises(AssertionError):
+        _assert_release_unix_integration_parallelism(workflow)
 
 
 def test_unix_integration_twenty_minute_timeout_mutation_is_rejected() -> None:


### PR DESCRIPTION
# fix(release): preserve Git isolation across auth fallback

## TL;DR

Public `github.com` Git operations now retain the downloader's isolated Git configuration through anonymous, token, `gh`, credential-helper, and ADO bearer attempts. This repairs the four functional failures in the blocked v0.27.0 tag run and changes every Unix release integration node to four grouped workers, keeping the existing 30-minute deadline. The follow-up also closes CodeQL alert 190 by keeping credential-bearing policy URLs in memory while persisting and displaying only redacted references. The complete arm64 release corpus finishes locally in 11:54 with the built binary.

> [!IMPORTANT]
> Release publication remains blocked until the repaired Linux and macOS nodes are green.

## Problem (WHY)

- [x] [Tag run 30699590291](https://github.com/microsoft/apm/actions/runs/30699590291) lost `apm.lock.yaml` in the full-SHA and warm-cache scenarios on macOS arm64 and Linux arm64.
- [x] The macOS arm64 prune and HTTPS-control semver scenarios attempted the original GitHub URL instead of their isolated fixture rewrite, ending with `fatal: transport 'https' not allowed`.
- [x] `AuthResolver.try_with_fallback()` created attempt environments from ambient process state, discarding caller-owned `GIT_CONFIG_GLOBAL`, indexed `GIT_CONFIG_*` rewrites, and `GIT_ALLOW_PROTOCOL`.
- [x] CodeQL alert 190 found that direct policy URLs containing userinfo, signed query parameters, or fragments could be persisted in `.policy-cache/*.meta.json` and resurfaced by `apm policy status`.
- [!] macOS x86_64 reached only 3% before the 30-minute integration deadline; Linux x86_64 reached 35% while running the same full corpus serially.

These failures crossed the release boundary with insufficient deterministic grounding. The repair follows PROSE's principle that ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) It keeps the fix small because Agent Skills recommends ["Add what the agent lacks, omit what it knows"](https://agentskills.io/skill-creation/best-practices).

## Approach (WHAT)

| # | Fix | Principle |
|---:|---|---|
| 1 | Thread an optional caller Git environment through the canonical auth fallback owner and rebuild every credentialed attempt on that base. | ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |
| 2 | Pass each downloader's hardened environment from clone, ref-resolution, sparse-file, cache, and validation Git paths. | ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |
| 3 | Run all Unix release integration nodes with four `loadgroup` workers while preserving their 30-minute bounds. | ["agents pattern-match well against concrete structures"](https://agentskills.io/skill-creation/best-practices) |
| 4 | Separate raw in-memory policy fetch/cache identity from credential-free persisted and displayed references, then invalidate legacy metadata. | ["Favor small, chainable primitives over monolithic frameworks."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/) |

## Implementation (HOW)

| File | Surgical change |
|---|---|
| `CHANGELOG.md` | Records the restored public GitHub install behavior under Unreleased. |
| `.github/workflows/build-release.yml` | Uses `-n 4 --dist loadgroup` for Linux, macOS Intel, and macOS arm64 integration without increasing any timeout. |
| `src/apm_cli/core/auth.py` | Adds `base_env` to `try_with_fallback()` and reapplies resolved credentials to that base for primary, `gh`, credential-fill, and ADO bearer attempts. |
| `src/apm_cli/deps/clone_engine.py` | Supplies the downloader Git environment to public GitHub clone fallback. |
| `src/apm_cli/deps/download_strategies.py` | Preserves the environment for sparse Git file transport. |
| `src/apm_cli/deps/git_reference_resolver.py` | Preserves fixture and policy rewrites during `ls-remote`. |
| `src/apm_cli/deps/github_downloader.py` | Reuses the hardened base for cache and sparse-checkout setup/fetch. |
| `src/apm_cli/deps/github_downloader_validation.py` | Reuses the hardened base for validation attempts and ref probes. |
| `tests/unit/core/test_public_github_anonymous_first.py` | Traps environment loss across anonymous, PAT, `gh`, credential-fill, and ADO bearer retries. |
| `tests/unit/test_platform_contract_workflow.py` | Pins four grouped workers and the unchanged 30-minute bound on every Unix release node. |
| `src/apm_cli/policy/discovery.py` | Keeps raw policy URLs only for request dispatch and cache hashing, redacts persisted/diagnostic references, bumps metadata to schema v6, and deletes legacy sidecars on mismatch. |
| `src/apm_cli/commands/policy.py` | Uses raw cache identity only for lookup and sanitizes cached source/chain references before table or JSON rendering. |
| `tests/unit/policy/*` and `tests/unit/commands/test_policy_status.py` | Cover raw dispatch, stable cache identity, sanitized metadata/results/inheritance, legacy cleanup, and pre-fix status output. |
| `scripts/lint-architecture-boundaries.sh` and `tests/integration/test_architecture_authorities.py` | Pin the canonical redaction owner and reject future raw policy metadata persistence. |
| `docs/src/content/docs/reference/{policy-schema.md,cli/policy.md}` and `packages/apm-guide/.apm/skills/apm-usage/governance.md` | Document that policy URL credentials, query values, and fragments are omitted from cache metadata and diagnostics. |

## Diagrams

Legend: the highlighted interaction is new -- caller-owned Git policy now survives the complete auth retry chain.

```mermaid
sequenceDiagram
    participant D as Git downloader
    participant A as AuthResolver
    participant G as Git subprocess

    D->>A: try_with_fallback(base_env)
    rect rgb(255, 247, 200)
        Note over A,G: NEW: rebuild every attempt from caller base_env
        A->>G: anonymous env plus isolated rewrites
        G-->>A: private-repo auth signal
        A->>G: PAT env plus isolated rewrites
        G-->>A: rejected credential
        A->>G: gh or credential-helper env plus isolated rewrites
    end
    G-->>D: clone, ref, cache, or sparse-file result
```

Legend: all full-corpus Unix release nodes use the same bounded scheduler and retain the original deadline.

```mermaid
flowchart LR
    subgraph Nodes[Release integration nodes]
        L[Linux matrix]
        MI[macOS Intel]
        MA[macOS arm64]
    end
    subgraph Scheduler[Bounded pytest scheduler]
        X["4 xdist workers"]
        G["--dist loadgroup"]
    end
    subgraph Gate[Release bound]
        T["30-minute timeout"]
    end
    L --> X
    MI --> X
    MA --> X
    X --> G
    G --> T
    classDef new stroke-dasharray: 5 5;
    class X,G new;
```

Legend: credential-bearing policy URLs remain available only for network dispatch and cache identity; every durable or user-visible edge receives a sanitized reference.

```mermaid
flowchart LR
    subgraph Input[Policy input]
        U["Raw URL with credentials"]
    end
    subgraph Runtime[In-memory runtime]
        F[HTTP fetch]
        H[Cache hash]
    end
    subgraph Safe[Credential-free outputs]
        M["Schema v6 metadata"]
        S["policy status"]
        E["Errors and chain labels"]
    end
    U --> F
    U --> H
    U --> R[Redaction owner]
    R --> M
    R --> S
    R --> E
    classDef new stroke-dasharray: 5 5;
    class R,M,S,E new;
```

## Trade-offs

- **Propagate an explicit base instead of mutating process state.** This keeps auth ownership in `AuthResolver`; global environment mutation was rejected because concurrent downloads could observe unrelated policy.
- **Increase bounded parallelism instead of the timeout.** Four workers were chosen over a deadline increase because the complete arm64 corpus finishes in 11:54 and remains below the merge gate's aggregate concurrency.
- **Keep `loadgroup` instead of raw work stealing.** This preserves `xdist_group` serialization for HOME-mutating tests, trading some perfect balancing for isolation.
- **Leave HTTP-only callers unchanged.** `base_env` is optional, so REST and marketplace operations retain their existing behavior.
- **Preserve raw URL identity only in memory.** Redacting before dispatch or hashing was rejected because it would break authenticated requests and cache hits; persistence and rendering are sanitized at their owners instead.
- **Invalidate legacy metadata instead of migrating it.** Schema v6 deletes stale sidecars on first access so previously persisted secrets are not copied into a replacement file.

`apm-spec-waiver: repairs auth propagation and credential persistence without extending OpenAPM behavior`

## Benefits

1. All four previously failing release scenarios pass against the rebuilt macOS arm64 binary.
2. The full integration corpus completes with 8,385 passes in 714.59 seconds under the unchanged 30-minute gate.
3. Unit contracts prove isolated Git policy survives five credential paths: anonymous, PAT, `gh`, credential fill, and ADO bearer.
4. Workflow contracts reject serial execution, worker-count drift, and timeout drift for all three Unix release paths.
5. CodeQL reports no clear-text sensitive-data alert on the repaired head, and 359 policy tests pin credential-free persistence and output.

## Validation

<details open><summary>Release regression and full-corpus evidence</summary>

Exact failed nodes:

```text
============================== 4 passed in 11.29s ==============================
```

Full release integration command with `PYTEST_EXTRA_ARGS='-n 4 --dist loadgroup'`:

```text
=========== 8385 passed, 153 skipped, 2 xfailed in 714.59s (0:11:54) ===========
✅ Integration test suite passed (collected and ran via pytest discovery)
✅ All integration tests completed successfully!
```

</details>

Related auth, downloader, ref-resolution, and workflow suites:

```text
936 passed in 5.96s
```

Final focused regression contracts:

```text
77 passed in 1.00s
```

Expanded policy security suite:

```text
359 passed
```

CI lint mirror and architecture boundaries:

```text
All checks passed!
1592 files already formatted
Your code has been rated at 10.00/10
[+] auth-signal lint clean
[+] architecture boundary lint clean
```

Hosted CodeQL analysis:

```text
Analyze (python)  success
CodeQL            success
```

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---:|---|---|---|---|
| 1 | Installing a public GitHub dependency pinned to a full SHA writes a lockfile and converges. | Governed by policy, DevX | `tests/integration/test_consume_source_ref_cache_matrix.py::test_immutable_source_ref_rows_resolve_deploy_audit_and_converge[github-https-full-sha]` (regression-trap for release run 30699590291) | integration |
| 2 | Auditing a warm cached GitHub dependency succeeds after its origin becomes unavailable. | Governed by policy, DevX | `tests/integration/test_consume_source_ref_cache_matrix.py::test_warm_cache_only_audit_replays_after_origin_becomes_unavailable` (regression-trap for release run 30699590291) | integration |
| 3 | Pruning deployed dependency state through an isolated local Git fixture leaves no audit ghost. | Secure by default, Governed by policy | `tests/integration/test_prune_deployment_ledger_e2e.py::test_prune_cascades_dependency_state_and_audit_sees_no_ghost` (regression-trap for release run 30699590291) | e2e |
| 4 | HTTPS semver resolution honors the configured transport rewrite and installs successfully. | Vendor-neutral, DevX | `tests/integration/test_ssh_semver_transport_contract.py::test_git_semver_resolution_honors_consume_transport_contract[https-control]` (regression-trap for release run 30699590291) | integration |
| 5 | Private-repository retries retain caller Git policy without leaking ambient credentials. | Secure by default, Vendor-neutral | `tests/unit/core/test_public_github_anonymous_first.py::test_public_github_fallback_preserves_caller_git_config_isolation`<br/>`tests/unit/core/test_public_github_anonymous_first.py::test_public_github_secondary_fallback_preserves_caller_git_config`<br/>`tests/unit/core/test_public_github_anonymous_first.py::test_ado_bearer_fallback_preserves_caller_git_config` | unit |
| 6 | Every Unix release node runs the full corpus with grouped parallelism inside a fixed deadline. | Governed by policy | `tests/unit/test_platform_contract_workflow.py::test_release_unix_integration_uses_bounded_grouped_parallelism`<br/>`tests/unit/test_platform_contract_workflow.py::test_release_unix_timeout_mutation_is_rejected` | unit |
| 7 | Fetching a policy from a credential-bearing URL succeeds without writing or displaying the secret-bearing reference. | Secure by default, Governed by policy | `tests/unit/policy/test_discovery_policy_resolution.py`<br/>`tests/unit/policy/test_cache_atomicity.py`<br/>`tests/unit/commands/test_policy_status.py` | unit |

## How to test

- [ ] Build the native artifact with `uv run ./scripts/build-binary.sh`; expect `Binary test successful`.
- [ ] Run the four scenario node IDs listed above with `APM_E2E_TESTS=1` and `APM_BINARY_PATH` set to the built binary; expect four passes.
- [ ] Run `scripts/test-integration.sh` with `PYTEST_EXTRA_ARGS='-n 4 --dist loadgroup'`; expect the complete corpus to finish inside 30 minutes.
- [ ] Run the related auth/downloader, workflow, and policy security unit suites; expect all tests to pass and no credential-bearing reference in cache metadata or status output.
- [ ] Run the CI lint mirror plus auth and architecture boundary scripts; expect no diagnostics.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
