### PR TITLE
fix(release): bound macOS Intel integration coverage

### DIFF
--- a/.apm/instructions/cicd.instructions.md
+++ b/.apm/instructions/cicd.instructions.md
@@ -42,8 +42,8 @@ integration suite runs only at merge time via GitHub Merge Queue
      to `.github/workflows/**`.
 4. **`build-release.yml`** - `push` to main, tags, schedule, `workflow_dispatch`
    - **Linux + Windows** run combined `build-and-test` (unit tests + binary build in one job). Unit tests run on every push for platform-regression signal; **smoke tests are gated to tag/schedule/dispatch only** (promotion boundaries) to avoid duplicating `ci-integration.yml`'s merge-time smoke and to cut redundant codex-binary downloads.
-   - **macOS Intel** uses `build-and-validate-macos-intel` (root node, runs own unit tests - no dependency on `build-and-test`). Builds the binary on every push for early regression feedback; integration + release-validation phases conditional on tag/schedule/dispatch.
-   - **macOS ARM** uses `build-and-validate-macos-arm` (root node, tag/schedule/dispatch only - ARM runners are extremely scarce with 2-4h+ queue waits). Only requested when the binary is actually needed for a release.
+   - **macOS Intel** uses `build-and-validate-macos-intel` (root node, runs own unit tests - no dependency on `build-and-test`). Builds the binary on every push for early regression feedback; tag/schedule/dispatch promotion runs add marker-bounded `lifecycle_smoke` integration coverage and isolated release validation.
+   - **macOS ARM** uses `build-and-validate-macos-arm` (root node, tag/schedule/dispatch only - ARM runners are extremely scarce with 2-4h+ queue waits). Promotion runs retain the unfiltered integration corpus and isolated release validation.
    - Secrets always available. Full 5-platform binary output (linux x86_64/arm64, darwin x86_64/arm64, windows x86_64).
 5. **`ci-runtime.yml`** - nightly schedule, manual dispatch, path-filtered push
    - **Linux x86_64 only**. Live inference smoke tests (`apm run`) isolated from release pipeline.
@@ -82,8 +82,8 @@ integration suite runs only at merge time via GitHub Merge Queue
 - **Merge queue workflow**: ci.yml (Tier 1 against tentative merge ref) + ci-integration.yml (Tier 2: build -> smoke-test -> integration-tests -> release-validation). Queue auto-merges on success; ejects on failure.
 - **Push/Release workflow (Linux + Windows)**: build-and-test -> integration-tests -> release-validation -> create-release -> publish-pypi (gh-aw-compat runs in parallel, informational)
 - **Homebrew distribution**: `microsoft/homebrew-apm` polls the latest public APM release and updates its formula with its own `GITHUB_TOKEN`; this workflow must not send a cross-repository dispatch or hold a tap credential.
-- **Push/Release workflow (macOS Intel)**: build-and-validate-macos-intel (root node: unit tests + build always + conditional integration/release-validation) -> create-release
-- **Push/Release workflow (macOS ARM)**: build-and-validate-macos-arm (root node, tag/schedule/dispatch only; all phases run) -> create-release
+- **Push/Release workflow (macOS Intel)**: build-and-validate-macos-intel (root node: unit tests + build always + conditional `lifecycle_smoke` integration/release-validation) -> create-release
+- **Push/Release workflow (macOS ARM)**: build-and-validate-macos-arm (root node, tag/schedule/dispatch only; full integration corpus and all phases run) -> create-release
 - **Tag Triggers**: Only `v*.*.*` tags trigger full release pipeline
 - **Artifact Retention**: 30 days for debugging failed releases
 - **Cross-workflow artifacts**: ci-integration.yml builds the binary inline (no cross-workflow artifact transfer); build-release.yml jobs share artifacts within the same workflow run.
@@ -110,8 +110,8 @@ integration suite runs only at merge time via GitHub Merge Queue
 - **macOS as root nodes**: macOS consolidated jobs run their own unit tests and start immediately - no dependency on Linux/Windows test completion.
 - **Native uv caching**: `setup-uv` action with `enable-cache: true` replaces manual `actions/cache@v3` blocks.
 - **Targeted setup-node usage**: Node.js is only installed in `ci-runtime.yml`, macOS consolidated jobs, and integration-tests/release-validation phases (for `apm runtime setup copilot` -> npm install).
-- **macOS runner consolidation**: Each macOS arch has a single consolidated job (build + integration + release-validation). Intel (`build-and-validate-macos-intel`) runs on every push since Intel runners are plentiful. ARM (`build-and-validate-macos-arm`) is gated to tag/schedule/dispatch only since ARM runners are extremely scarce (2-4h+ queue waits). This avoids serial re-queuing of runners across multiple jobs.
-- **Unit tests skip macOS**: Python unit tests are platform-agnostic; Linux + Windows coverage is sufficient. macOS-specific validation (binary build, integration tests, release validation) still runs via the consolidated job.
+- **macOS runner consolidation**: Each macOS arch has a single consolidated job (build + integration + release-validation). Intel (`build-and-validate-macos-intel`) runs on every push since Intel runners are plentiful and uses marker-bounded lifecycle integration coverage for promotions. ARM (`build-and-validate-macos-arm`) is gated to tag/schedule/dispatch only since ARM runners are extremely scarce (2-4h+ queue waits) and remains the full-corpus macOS authority. This avoids serial re-queuing of runners across multiple jobs and redundant full-corpus replay on Intel.
+- **Unit tests skip macOS**: Python unit tests are platform-agnostic; Linux + Windows coverage is sufficient. macOS-specific validation (binary build, focused Intel integration, full ARM integration, and release validation) still runs via the consolidated jobs.
 - **Tier 2 runs once per merged PR**, not per WIP push, since it triggers on `merge_group` only. Saves the bulk of integration minutes that the previous per-push flow burned.
 - UPX compression when available (reduces binary size ~50%)
 - Python optimization level 2 in PyInstaller

--- a/.github/instructions/cicd.instructions.md
+++ b/.github/instructions/cicd.instructions.md
@@ -42,8 +42,8 @@ integration suite runs only at merge time via GitHub Merge Queue
      to `.github/workflows/**`.
 4. **`build-release.yml`** - `push` to main, tags, schedule, `workflow_dispatch`
    - **Linux + Windows** run combined `build-and-test` (unit tests + binary build in one job). Unit tests run on every push for platform-regression signal; **smoke tests are gated to tag/schedule/dispatch only** (promotion boundaries) to avoid duplicating `ci-integration.yml`'s merge-time smoke and to cut redundant codex-binary downloads.
-   - **macOS Intel** uses `build-and-validate-macos-intel` (root node, runs own unit tests - no dependency on `build-and-test`). Builds the binary on every push for early regression feedback; integration + release-validation phases conditional on tag/schedule/dispatch.
-   - **macOS ARM** uses `build-and-validate-macos-arm` (root node, tag/schedule/dispatch only - ARM runners are extremely scarce with 2-4h+ queue waits). Only requested when the binary is actually needed for a release.
+   - **macOS Intel** uses `build-and-validate-macos-intel` (root node, runs own unit tests - no dependency on `build-and-test`). Builds the binary on every push for early regression feedback; tag/schedule/dispatch promotion runs add marker-bounded `lifecycle_smoke` integration coverage and isolated release validation.
+   - **macOS ARM** uses `build-and-validate-macos-arm` (root node, tag/schedule/dispatch only - ARM runners are extremely scarce with 2-4h+ queue waits). Promotion runs retain the unfiltered integration corpus and isolated release validation.
    - Secrets always available. Full 5-platform binary output (linux x86_64/arm64, darwin x86_64/arm64, windows x86_64).
 5. **`ci-runtime.yml`** - nightly schedule, manual dispatch, path-filtered push
    - **Linux x86_64 only**. Live inference smoke tests (`apm run`) isolated from release pipeline.
@@ -82,8 +82,8 @@ integration suite runs only at merge time via GitHub Merge Queue
 - **Merge queue workflow**: ci.yml (Tier 1 against tentative merge ref) + ci-integration.yml (Tier 2: build -> smoke-test -> integration-tests -> release-validation). Queue auto-merges on success; ejects on failure.
 - **Push/Release workflow (Linux + Windows)**: build-and-test -> integration-tests -> release-validation -> create-release -> publish-pypi (gh-aw-compat runs in parallel, informational)
 - **Homebrew distribution**: `microsoft/homebrew-apm` polls the latest public APM release and updates its formula with its own `GITHUB_TOKEN`; this workflow must not send a cross-repository dispatch or hold a tap credential.
-- **Push/Release workflow (macOS Intel)**: build-and-validate-macos-intel (root node: unit tests + build always + conditional integration/release-validation) -> create-release
-- **Push/Release workflow (macOS ARM)**: build-and-validate-macos-arm (root node, tag/schedule/dispatch only; all phases run) -> create-release
+- **Push/Release workflow (macOS Intel)**: build-and-validate-macos-intel (root node: unit tests + build always + conditional `lifecycle_smoke` integration/release-validation) -> create-release
+- **Push/Release workflow (macOS ARM)**: build-and-validate-macos-arm (root node, tag/schedule/dispatch only; full integration corpus and all phases run) -> create-release
 - **Tag Triggers**: Only `v*.*.*` tags trigger full release pipeline
 - **Artifact Retention**: 30 days for debugging failed releases
 - **Cross-workflow artifacts**: ci-integration.yml builds the binary inline (no cross-workflow artifact transfer); build-release.yml jobs share artifacts within the same workflow run.
@@ -110,8 +110,8 @@ integration suite runs only at merge time via GitHub Merge Queue
 - **macOS as root nodes**: macOS consolidated jobs run their own unit tests and start immediately - no dependency on Linux/Windows test completion.
 - **Native uv caching**: `setup-uv` action with `enable-cache: true` replaces manual `actions/cache@v3` blocks.
 - **Targeted setup-node usage**: Node.js is only installed in `ci-runtime.yml`, macOS consolidated jobs, and integration-tests/release-validation phases (for `apm runtime setup copilot` -> npm install).
-- **macOS runner consolidation**: Each macOS arch has a single consolidated job (build + integration + release-validation). Intel (`build-and-validate-macos-intel`) runs on every push since Intel runners are plentiful. ARM (`build-and-validate-macos-arm`) is gated to tag/schedule/dispatch only since ARM runners are extremely scarce (2-4h+ queue waits). This avoids serial re-queuing of runners across multiple jobs.
-- **Unit tests skip macOS**: Python unit tests are platform-agnostic; Linux + Windows coverage is sufficient. macOS-specific validation (binary build, integration tests, release validation) still runs via the consolidated job.
+- **macOS runner consolidation**: Each macOS arch has a single consolidated job (build + integration + release-validation). Intel (`build-and-validate-macos-intel`) runs on every push since Intel runners are plentiful and uses marker-bounded lifecycle integration coverage for promotions. ARM (`build-and-validate-macos-arm`) is gated to tag/schedule/dispatch only since ARM runners are extremely scarce (2-4h+ queue waits) and remains the full-corpus macOS authority. This avoids serial re-queuing of runners across multiple jobs and redundant full-corpus replay on Intel.
+- **Unit tests skip macOS**: Python unit tests are platform-agnostic; Linux + Windows coverage is sufficient. macOS-specific validation (binary build, focused Intel integration, full ARM integration, and release validation) still runs via the consolidated jobs.
 - **Tier 2 runs once per merged PR**, not per WIP push, since it triggers on `merge_group` only. Saves the bulk of integration minutes that the previous per-push flow burned.
 - UPX compression when available (reduces binary size ~50%)
 - Python optimization level 2 in PyInstaller

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -213,22 +213,17 @@ jobs:
           retention-days: 30
           if-no-files-found: error
 
-      # ── PHASE 2: INTEGRATION TESTS (tag/schedule/dispatch only) ──
-      - name: Run integration tests
+      # ── PHASE 2: FOCUSED INTEGRATION TESTS (tag/schedule/dispatch only) ──
+      - name: Run focused Intel integration tests
         if: github.ref_type == 'tag' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         env:
           APM_E2E_TESTS: "1"
           GITHUB_APM_PAT: ${{ secrets.GH_CLI_PAT }}
           ADO_APM_PAT: ${{ secrets.ADO_APM_PAT }}
-          # macOS runners are scarce, so this consolidated job runs the
-          # whole integration suite on one runner instead of sharding it
-          # across four like ci-integration.yml. Run it serially and the
-          # slower Intel runner overruns the step timeout, so parallelise
-          # in-process with xdist. --dist loadgroup is required: it is the
-          # only scheduler that honors pytest.mark.xdist_group, which keeps
-          # the HOME-mutating tests serialized on a single worker. Four
-          # workers remain below the merge gate's aggregate concurrency.
-          PYTEST_EXTRA_ARGS: "-n 4 --dist loadgroup"
+          # Intel validates the promoted lifecycle subset against its native
+          # binary. ARM and Linux retain the unfiltered integration corpus.
+          # loadgroup preserves HOME-mutating test serialization.
+          PYTEST_EXTRA_ARGS: "-m=lifecycle_smoke -n 4 --dist loadgroup"
         run: |
           chmod +x scripts/test-integration.sh
           uv run ./scripts/test-integration.sh
@@ -340,10 +335,10 @@ jobs:
           APM_E2E_TESTS: "1"
           GITHUB_APM_PAT: ${{ secrets.GH_CLI_PAT }}
           ADO_APM_PAT: ${{ secrets.ADO_APM_PAT }}
-          # See the Intel job for the rationale: scarce macOS runners force
-          # the full suite onto one runner, so parallelise in-process with
-          # xdist. --dist loadgroup honors the home_env xdist_group markers
-          # that keep HOME-mutating tests serialized on a single worker.
+          # Scarce ARM runners force the full suite onto one runner, so
+          # parallelise in-process with xdist. --dist loadgroup honors the
+          # home_env xdist_group markers that keep HOME-mutating tests
+          # serialized on a single worker.
           PYTEST_EXTRA_ARGS: "-n 4 --dist loadgroup"
         run: |
           chmod +x scripts/test-integration.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Release promotions now run marker-bounded lifecycle integration on macOS Intel
+  while retaining the full corpus on macOS ARM and Linux, preventing Intel
+  runner capacity timeouts. (#2423)
 - Public `github.com` dependency installs now preserve caller-owned Git URL
   rewrites and transport policy across anonymous and authenticated retries;
   policy cache metadata and diagnostics also omit credentials embedded in

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -2801,7 +2801,7 @@ deployments:
   owners:
   - .
   active_owner: .
-  content_hash: sha256:08d87b7d635761cb41deb8fc71d5d83f54678de463db484afb16d2d4f8713ecb
+  content_hash: sha256:60466b074de6bcc8a682ddb8ba938d8f76eb3dd76013812ad6e1bd3c729c5152
 - kind: project-relative
   target: copilot
   value: .github/instructions/cli.instructions.md
@@ -3292,7 +3292,7 @@ local_deployed_file_hashes:
   .github/agents/test-coverage-expert.agent.md: sha256:48c2172d1f18a394fa83ef9dc2be0b9b921a4e51e976498165250fed66369711
   .github/instructions/architecture.instructions.md: sha256:18bbdeaf073d7e15a6bdc836d1079ad5c199b4f05aa1db8ac6f724ae8fc08260
   .github/instructions/changelog.instructions.md: sha256:1e51ec4c74e847967962bd279dc4c6e582c5d3578490b3c28d5f3acd3e05f73e
-  .github/instructions/cicd.instructions.md: sha256:08d87b7d635761cb41deb8fc71d5d83f54678de463db484afb16d2d4f8713ecb
+  .github/instructions/cicd.instructions.md: sha256:60466b074de6bcc8a682ddb8ba938d8f76eb3dd76013812ad6e1bd3c729c5152
   .github/instructions/cli.instructions.md: sha256:8e39e8d5047ce88575cb02f87c2bcede584dfef258bd86f7466c7badf136541a
   .github/instructions/doc-sync.instructions.md: sha256:bb3816254f8df6bffc6faacd556871f36903e9d7f348982f1e2de0339384c696
   .github/instructions/encoding.instructions.md: sha256:93db7377dc896f6efecf2c5d8c5d89255a555562f468d034d64c42edd5cf46d5

--- a/docs/src/content/docs/contributing/integration-testing.md
+++ b/docs/src/content/docs/contributing/integration-testing.md
@@ -318,7 +318,7 @@ environment end-to-end; for local iteration prefer the direct
 **On version tag releases:**
 1. Unit tests + Smoke tests
 2. Build binaries (cross-platform)
-3. **E2E golden scenario tests** (using built binaries)
+3. **E2E golden scenario tests** (using built binaries). Linux and macOS Apple Silicon retain the full integration corpus; macOS Intel runs the marker-bounded `lifecycle_smoke` subset plus native startup and isolated release validation.
 4. Create GitHub Release
 5. Publish to PyPI 
 
@@ -360,8 +360,8 @@ The [`microsoft/homebrew-apm`](https://github.com/microsoft/homebrew-apm) tap up
 Promotion integration tests run on:
 - **Linux**: ubuntu-24.04 (x86_64), ubuntu-24.04-arm (arm64)
 - **Windows**: windows-latest (x86_64)
-- **macOS Intel**: macos-15-intel (x86_64)
-- **macOS Apple Silicon**: macos-latest (arm64)
+- **macOS Intel**: macos-15-intel (x86_64), with marker-bounded `lifecycle_smoke` integration coverage, native binary startup, and isolated release validation
+- **macOS Apple Silicon**: macos-latest (arm64), with the full integration corpus
 
 **Python Version**: 3.12 (standardized across all environments)
 **Package Manager**: uv (for fast dependency management and virtual environments)

--- a/tests/unit/test_platform_contract_workflow.py
+++ b/tests/unit/test_platform_contract_workflow.py
@@ -43,12 +43,13 @@ MACOS_STARTUP_CONTRACTS = (
         "github.event_name == 'workflow_dispatch'",
     ),
 )
-RELEASE_UNIX_INTEGRATION_STEPS = (
+FULL_CORPUS_UNIX_INTEGRATION_STEPS = (
     ("integration-tests", "Run integration tests (Unix)"),
-    ("build-and-validate-macos-intel", "Run integration tests"),
     ("build-and-validate-macos-arm", "Run integration tests"),
 )
-RELEASE_UNIX_PYTEST_ARGS = "-n 4 --dist loadgroup"
+FULL_CORPUS_UNIX_PYTEST_ARGS = "-n 4 --dist loadgroup"
+INTEL_FOCUSED_INTEGRATION_STEP = "Run focused Intel integration tests"
+INTEL_FOCUSED_PYTEST_ARGS = "-m=lifecycle_smoke -n 4 --dist loadgroup"
 
 
 def _workflow() -> dict:
@@ -119,11 +120,27 @@ def _assert_standalone_integration_timeouts(workflow: dict) -> None:
     assert windows_step.get("timeout-minutes") == 20
 
 
-def _assert_release_unix_integration_parallelism(workflow: dict) -> None:
-    for job_id, step_name in RELEASE_UNIX_INTEGRATION_STEPS:
+def _assert_full_corpus_unix_integration_parallelism(workflow: dict) -> None:
+    for job_id, step_name in FULL_CORPUS_UNIX_INTEGRATION_STEPS:
         step = workflow_step(workflow_job(workflow, job_id), step_name)
-        assert step["env"].get("PYTEST_EXTRA_ARGS") == RELEASE_UNIX_PYTEST_ARGS
+        assert step["env"].get("PYTEST_EXTRA_ARGS") == FULL_CORPUS_UNIX_PYTEST_ARGS
         assert step.get("timeout-minutes") == 30
+
+
+def _assert_intel_focused_integration(workflow: dict) -> None:
+    job = workflow_job(workflow, "build-and-validate-macos-intel")
+    step = workflow_step(job, INTEL_FOCUSED_INTEGRATION_STEP)
+    assert step.get("if") == (
+        "github.ref_type == 'tag' || github.event_name == 'schedule' || "
+        "github.event_name == 'workflow_dispatch'"
+    )
+    assert step["env"].get("PYTEST_EXTRA_ARGS") == INTEL_FOCUSED_PYTEST_ARGS
+    assert step.get("timeout-minutes") == 30
+    assert_exact_command(
+        shell_commands(step),
+        ["uv", "run", "./scripts/test-integration.sh"],
+        label="macOS Intel focused integration step",
+    )
 
 
 def test_macos_jobs_run_non_shell_binary_startup_after_build() -> None:
@@ -141,27 +158,38 @@ def test_standalone_integration_timeouts_are_platform_specific() -> None:
     _assert_standalone_integration_timeouts(_workflow())
 
 
-def test_release_unix_integration_uses_bounded_grouped_parallelism() -> None:
-    """Every full-corpus Unix release node uses the same bounded scheduler."""
-    _assert_release_unix_integration_parallelism(_workflow())
+def test_linux_and_arm_retain_full_corpus_grouped_parallelism() -> None:
+    """Linux and macOS ARM keep the unfiltered, bounded integration corpus."""
+    _assert_full_corpus_unix_integration_parallelism(_workflow())
 
 
-@pytest.mark.parametrize(("job_id", "step_name"), RELEASE_UNIX_INTEGRATION_STEPS)
-def test_release_unix_serial_integration_mutation_is_rejected(
+def test_intel_integration_is_marker_scoped_and_bounded() -> None:
+    """Intel keeps focused native coverage without replaying the full corpus."""
+    _assert_intel_focused_integration(_workflow())
+
+
+@pytest.mark.parametrize(
+    ("job_id", "step_name"),
+    FULL_CORPUS_UNIX_INTEGRATION_STEPS,
+)
+def test_full_corpus_unix_serial_integration_mutation_is_rejected(
     job_id: str,
     step_name: str,
 ) -> None:
-    """No release node can silently regress to the 30-minute serial path."""
+    """No full-corpus release node can silently regress to the serial path."""
     workflow = deepcopy(_workflow())
     step = workflow_step(workflow_job(workflow, job_id), step_name)
     del step["env"]["PYTEST_EXTRA_ARGS"]
 
     with pytest.raises(AssertionError):
-        _assert_release_unix_integration_parallelism(workflow)
+        _assert_full_corpus_unix_integration_parallelism(workflow)
 
 
-@pytest.mark.parametrize(("job_id", "step_name"), RELEASE_UNIX_INTEGRATION_STEPS)
-def test_release_unix_timeout_mutation_is_rejected(
+@pytest.mark.parametrize(
+    ("job_id", "step_name"),
+    FULL_CORPUS_UNIX_INTEGRATION_STEPS,
+)
+def test_full_corpus_unix_timeout_mutation_is_rejected(
     job_id: str,
     step_name: str,
 ) -> None:
@@ -171,7 +199,33 @@ def test_release_unix_timeout_mutation_is_rejected(
     step["timeout-minutes"] = 31
 
     with pytest.raises(AssertionError):
-        _assert_release_unix_integration_parallelism(workflow)
+        _assert_full_corpus_unix_integration_parallelism(workflow)
+
+
+def test_intel_full_corpus_mutation_is_rejected() -> None:
+    """Intel cannot silently regain the redundant unfiltered corpus."""
+    workflow = deepcopy(_workflow())
+    step = workflow_step(
+        workflow_job(workflow, "build-and-validate-macos-intel"),
+        INTEL_FOCUSED_INTEGRATION_STEP,
+    )
+    step["env"]["PYTEST_EXTRA_ARGS"] = FULL_CORPUS_UNIX_PYTEST_ARGS
+
+    with pytest.raises(AssertionError):
+        _assert_intel_focused_integration(workflow)
+
+
+def test_arm_focused_subset_mutation_is_rejected() -> None:
+    """ARM remains a full-corpus macOS release authority."""
+    workflow = deepcopy(_workflow())
+    step = workflow_step(
+        workflow_job(workflow, "build-and-validate-macos-arm"),
+        "Run integration tests",
+    )
+    step["env"]["PYTEST_EXTRA_ARGS"] = INTEL_FOCUSED_PYTEST_ARGS
+
+    with pytest.raises(AssertionError):
+        _assert_full_corpus_unix_integration_parallelism(workflow)
 
 
 def test_unix_integration_twenty_minute_timeout_mutation_is_rejected() -> None:


### PR DESCRIPTION
# fix(release): bound macOS Intel integration coverage

## TL;DR

The v0.27.0 promotion replayed all 8,558 integration nodes on macOS Intel and hit the 30-minute step limit while still making healthy progress. This change gives Intel a marker-bounded `lifecycle_smoke` integration pass while preserving native binary startup and isolated release validation. macOS ARM and Linux remain the full-corpus authorities.

> [!NOTE]
> The failed Intel job had 1,151 passing completions across all four xdist workers and reached 13% immediately before GitHub Actions enforced the timeout.

## Problem (WHY)

- [x] [Run 30712176510, job 91401431001](https://github.com/microsoft/apm/actions/runs/30712176510/job/91401431001) ended with `The action 'Run integration tests' has timed out after 30 minutes` at 13%, not with a stalled worker or a test failure.
- [x] The same run completed the macOS ARM job and both Linux integration jobs, so replaying the complete cross-platform corpus on Intel added a redundant release-critical capacity gate.
- [!] Raising the timeout would retain the structural duplication and increase release latency without adding a distinct platform contract.

The fix follows the evidence rather than inferring a deadlock: ["Grounding outputs in deterministic tool execution transforms probabilistic generation into verifiable action."](https://danielmeppiel.github.io/awesome-ai-native/docs/prose/)

## Approach (WHAT)

- Select the existing `lifecycle_smoke` marker on macOS Intel and retain four-worker `loadgroup` scheduling plus the existing 30-minute ceiling.
- Leave macOS Intel's native startup checks and isolated release-validation phase intact.
- Keep the unfiltered integration corpus unchanged on macOS ARM and Linux.
- Add semantic workflow contracts that reject either Intel full-corpus regression or ARM focused-subset regression.

## Implementation (HOW)

| File | Change |
|---|---|
| `.github/workflows/build-release.yml` | Renames the Intel phase to focused integration and sets `PYTEST_EXTRA_ARGS` to `-m=lifecycle_smoke -n 4 --dist loadgroup`; ARM remains unfiltered. |
| `tests/unit/test_platform_contract_workflow.py` | Separates focused-Intel and full-corpus Unix contracts, including mutation tests for both sides of the partition. |
| `.apm/instructions/cicd.instructions.md` | Records Intel as marker-bounded and ARM as the full-corpus macOS authority. |
| `.github/instructions/cicd.instructions.md`, `apm.lock.yaml` | Rematerializes the Copilot instruction mirror and its integrity hash through `apm install --target copilot`. |
| `docs/src/content/docs/contributing/integration-testing.md` | Documents the release-platform coverage split. |
| `CHANGELOG.md` | Records the release-gate repair under `[Unreleased]`. |

## Diagrams

Legend: promotion validation now divides platform-specific Intel evidence from the full corpus retained on ARM and Linux.

```mermaid
sequenceDiagram
    participant W as Release workflow
    participant I as macOS Intel
    participant A as macOS ARM
    participant L as Linux
    participant R as Create release

    W->>I: build native x86_64 binary
    I->>I: run version and rich-table startup
    rect rgb(255, 247, 200)
        Note over I: NEW: bounded promoted lifecycle subset
        I->>I: run lifecycle_smoke with 4 loadgroup workers
    end
    I->>I: run isolated release validation
    W->>A: run full integration corpus
    W->>L: run full integration corpus
    I-->>R: Intel validation passed
    A-->>R: ARM validation passed
    L-->>R: Linux validation passed
```

## Trade-offs

- **Marker selection over file enumeration.** Chose the existing declarative `lifecycle_smoke` contract; rejected a hand-maintained node list because it would drift as tests move.
- **Structural reduction over a larger timeout.** Chose fewer redundant executions; rejected a timeout increase because it would hide capacity growth.
- **Full corpus retained on ARM and Linux.** Chose Intel for distinct native evidence and ARM/Linux for complete coverage; rejected removing a full macOS corpus because that would weaken platform validation.

## Benefits

1. Intel executes 76 selected integration nodes instead of replaying all 8,558, a 99.1% reduction in executed corpus.
2. Intel still runs two explicit native startup nodes, the promoted lifecycle subset, and isolated shipped-binary validation.
3. ARM and Linux keep the exact unfiltered `-n 4 --dist loadgroup` integration contract.
4. Four mutation tests prevent either side of the platform partition from silently drifting.

## Validation

`tests/unit/test_platform_contract_workflow.py`:

```text
.............................                                            [100%]
29 passed in 0.81s
```

Focused Intel selection:

```text
76/8558 tests collected (8482 deselected) in 3.39s
```

<details><summary>Lint and integrity gates</summary>

`uv run --frozen --extra dev ruff check src/ tests/`:

```text
All checks passed!
```

`uv run --frozen --extra dev ruff format --check src/ tests/`:

```text
1592 files already formatted
```

`uv run --frozen --extra dev python -m pylint --disable=all --enable=R0801 --min-similarity-lines=10 --fail-on=R0801 src/apm_cli/`:

```text
--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```

`bash scripts/lint-auth-signals.sh`:

```text
[*] Rule A: get_bearer_provider boundary (any reference)
[*] Rule B: git ls-remote auth-delegated annotation
[+] auth-signal lint clean
```

`bash scripts/lint-architecture-boundaries.sh`:

```text
[+] architecture boundary lint clean
```

`uv run --frozen apm audit --ci`:

```text
[>] Replaying install (cache-only)...
[+] Replayed 7 package(s)
[>] Diffing scratch vs working tree...
[+] No drift detected
[*] All 10 check(s) passed
```

</details>

### Scenario Evidence

| # | Scenario (user promise) | Principle(s) | Test(s) proving it | Type |
|---|---|---|---|---|
| 1 | A release validates the macOS Intel binary without replaying the entire cross-platform integration corpus | DevX, OSS / community-driven | `tests/unit/test_platform_contract_workflow.py::test_intel_integration_is_marker_scoped_and_bounded`<br/>`tests/unit/test_platform_contract_workflow.py::test_intel_full_corpus_mutation_is_rejected` (regression-trap for run 30712176510) | unit |
| 2 | macOS ARM and Linux still execute the full release integration corpus | Portability by manifest, OSS / community-driven | `tests/unit/test_platform_contract_workflow.py::test_linux_and_arm_retain_full_corpus_grouped_parallelism`<br/>`tests/unit/test_platform_contract_workflow.py::test_arm_focused_subset_mutation_is_rejected` | unit |
| 3 | Both macOS release artifacts still execute natively before upload | Portability by manifest | `tests/integration/test_core_smoke.py::TestBinaryStartup::test_apm_version_runs`<br/>`tests/integration/test_core_smoke.py::TestBinaryStartup::test_apm_rich_table_runs`<br/>`tests/unit/test_platform_contract_workflow.py::test_macos_jobs_run_non_shell_binary_startup_after_build` | e2e |

## How to test

- [ ] Run `uv run --extra dev pytest -q tests/unit/test_platform_contract_workflow.py` and observe 29 passing contracts.
- [ ] Run `uv run --extra dev pytest tests/integration --collect-only -q -m lifecycle_smoke` and observe 76 selected nodes.
- [ ] Inspect `build-and-validate-macos-intel` and confirm startup, focused integration, and release validation remain ordered.
- [ ] Inspect `build-and-validate-macos-arm` and `integration-tests` and confirm neither has a marker filter.
- [ ] Run `uv run --frozen apm audit --ci` and observe all 10 checks pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
